### PR TITLE
Reduce macOS test runner pressure

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -24,6 +24,10 @@ on:
       - '.github/workflows/deploy-website.yml'
       - '.gitignore'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   DOTNET_VERSION: |
     8.0.418
@@ -245,106 +249,17 @@ jobs:
           echo "Ubuntu test matrix passed."
 
   test-macos-matrix:
-    name: 'macOS ${{ matrix.framework }} ${{ matrix.slice }}'
+    name: 'macOS platform smoke'
     runs-on: macos-latest
-    # Hosted macOS runners run the large solution test suite much slower than
-    # Linux/Windows, and macOS concurrency is limited. Keep the legs split by
-    # workload so no single PDF-heavy family owns the whole timeout.
-    timeout-minutes: 60
+    # Linux covers the full net8.0/net10.0 solution test contract. Hosted macOS
+    # runners are scarce for the organization, so keep this lane to one focused
+    # platform smoke that proves macOS restore/build/test execution still works.
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
         include:
           - framework: net8.0
-            slice: pdf-core
-            project: OfficeIMO.Tests/OfficeIMO.Tests.csproj
-            filter: FullyQualifiedName~OfficeIMO.Tests.Pdf
-            extraArgs: ''
-          - framework: net8.0
-            slice: save-as-pdf-word
-            project: OfficeIMO.Tests/OfficeIMO.Tests.csproj
-            filter: FullyQualifiedName~SaveAsPdf&FullyQualifiedName~OfficeIMO.Tests.Word&FullyQualifiedName!~OfficeIMO.Tests.Pdf
-            extraArgs: ''
-          - framework: net8.0
-            slice: save-as-pdf-markdown-more
-            project: OfficeIMO.Tests/OfficeIMO.Tests.csproj
-            filter: FullyQualifiedName~SaveAsPdf&FullyQualifiedName~MarkdownMoreCasesTests&FullyQualifiedName!~OfficeIMO.Tests.Pdf
-            extraArgs: ''
-          - framework: net8.0
-            slice: save-as-pdf-markdown-roundtrip
-            project: OfficeIMO.Tests/OfficeIMO.Tests.csproj
-            filter: FullyQualifiedName~SaveAsPdf&FullyQualifiedName~MarkdownRoundTripTests&FullyQualifiedName!~OfficeIMO.Tests.Pdf
-            extraArgs: ''
-          - framework: net8.0
-            slice: save-as-pdf-other
-            project: OfficeIMO.Tests/OfficeIMO.Tests.csproj
-            filter: FullyQualifiedName~SaveAsPdf&FullyQualifiedName!~OfficeIMO.Tests.Pdf&FullyQualifiedName!~OfficeIMO.Tests.Word&FullyQualifiedName!~MarkdownMoreCasesTests&FullyQualifiedName!~MarkdownRoundTripTests
-            extraArgs: ''
-          - framework: net8.0
-            slice: markdown
-            project: OfficeIMO.Tests/OfficeIMO.Tests.csproj
-            filter: FullyQualifiedName~Markdown&FullyQualifiedName!~OfficeIMO.Tests.Pdf&FullyQualifiedName!~SaveAsPdf
-            extraArgs: ''
-          - framework: net8.0
-            slice: core-non-pdf
-            project: OfficeIMO.Tests/OfficeIMO.Tests.csproj
-            filter: FullyQualifiedName!~PerformanceReview&FullyQualifiedName!~OfficeIMO.Tests.Pdf&FullyQualifiedName!~SaveAsPdf&FullyQualifiedName!~Markdown
-            extraArgs: ''
-          - framework: net8.0
-            slice: supporting-projects
-            project: ''
-            filter: ''
-            extraArgs: ''
-          - framework: net8.0
-            slice: excel-performance
-            project: OfficeIMO.Tests/OfficeIMO.Tests.csproj
-            filter: FullyQualifiedName~PerformanceReview
-            extraArgs: '-- xUnit.ParallelizeTestCollections=false'
-          - framework: net10.0
-            slice: pdf-core
-            project: OfficeIMO.Tests/OfficeIMO.Tests.csproj
-            filter: FullyQualifiedName~OfficeIMO.Tests.Pdf
-            extraArgs: ''
-          - framework: net10.0
-            slice: save-as-pdf-word
-            project: OfficeIMO.Tests/OfficeIMO.Tests.csproj
-            filter: FullyQualifiedName~SaveAsPdf&FullyQualifiedName~OfficeIMO.Tests.Word&FullyQualifiedName!~OfficeIMO.Tests.Pdf
-            extraArgs: ''
-          - framework: net10.0
-            slice: save-as-pdf-markdown-more
-            project: OfficeIMO.Tests/OfficeIMO.Tests.csproj
-            filter: FullyQualifiedName~SaveAsPdf&FullyQualifiedName~MarkdownMoreCasesTests&FullyQualifiedName!~OfficeIMO.Tests.Pdf
-            extraArgs: ''
-          - framework: net10.0
-            slice: save-as-pdf-markdown-roundtrip
-            project: OfficeIMO.Tests/OfficeIMO.Tests.csproj
-            filter: FullyQualifiedName~SaveAsPdf&FullyQualifiedName~MarkdownRoundTripTests&FullyQualifiedName!~OfficeIMO.Tests.Pdf
-            extraArgs: ''
-          - framework: net10.0
-            slice: save-as-pdf-other
-            project: OfficeIMO.Tests/OfficeIMO.Tests.csproj
-            filter: FullyQualifiedName~SaveAsPdf&FullyQualifiedName!~OfficeIMO.Tests.Pdf&FullyQualifiedName!~OfficeIMO.Tests.Word&FullyQualifiedName!~MarkdownMoreCasesTests&FullyQualifiedName!~MarkdownRoundTripTests
-            extraArgs: ''
-          - framework: net10.0
-            slice: markdown
-            project: OfficeIMO.Tests/OfficeIMO.Tests.csproj
-            filter: FullyQualifiedName~Markdown&FullyQualifiedName!~OfficeIMO.Tests.Pdf&FullyQualifiedName!~SaveAsPdf
-            extraArgs: ''
-          - framework: net10.0
-            slice: core-non-pdf
-            project: OfficeIMO.Tests/OfficeIMO.Tests.csproj
-            filter: FullyQualifiedName!~PerformanceReview&FullyQualifiedName!~OfficeIMO.Tests.Pdf&FullyQualifiedName!~SaveAsPdf&FullyQualifiedName!~Markdown
-            extraArgs: ''
-          - framework: net10.0
-            slice: supporting-projects
-            project: ''
-            filter: ''
-            extraArgs: ''
-          - framework: net10.0
-            slice: excel-performance
-            project: OfficeIMO.Tests/OfficeIMO.Tests.csproj
-            filter: FullyQualifiedName~PerformanceReview
-            extraArgs: '-- xUnit.ParallelizeTestCollections=false'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -370,13 +285,9 @@ jobs:
 
       - name: Run tests
         run: |
-          if [ "${{ matrix.slice }}" = "supporting-projects" ]; then
-            dotnet test OfficeIMO.CSV.Tests/OfficeIMO.CSV.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity ${{ env.TEST_VERBOSITY }} --framework ${{ matrix.framework }} --filter "FullyQualifiedName~OfficeIMO.CSV.Tests" --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx
-            dotnet test OfficeIMO.VerifyTests/OfficeIMO.VerifyTests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity ${{ env.TEST_VERBOSITY }} --framework ${{ matrix.framework }} --filter "FullyQualifiedName~OfficeIMO.VerifyTests" --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx
-            dotnet test OfficeIMO.MarkdownRenderer.Wpf.Tests/OfficeIMO.MarkdownRenderer.Wpf.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity ${{ env.TEST_VERBOSITY }} --framework ${{ matrix.framework }} --filter "FullyQualifiedName~OfficeIMO.MarkdownRenderer.Wpf.Tests" --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx
-          else
-            dotnet test ${{ matrix.project }} --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity ${{ env.TEST_VERBOSITY }} --framework ${{ matrix.framework }} --filter "${{ matrix.filter }}" --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx ${{ matrix.extraArgs }}
-          fi
+          dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity ${{ env.TEST_VERBOSITY }} --framework ${{ matrix.framework }} --filter "FullyQualifiedName=OfficeIMO.Tests.Word.Test_WordDocument_SaveAsPdf|FullyQualifiedName~OfficeIMO.Tests.Pdf.PdfReadStreamTests|FullyQualifiedName~OfficeIMO.Tests.HtmlCoreTests|FullyQualifiedName~OfficeIMO.Tests.Markdown.Test_SaveAsMarkdown_FileAndRead" --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx
+          dotnet test OfficeIMO.CSV.Tests/OfficeIMO.CSV.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity ${{ env.TEST_VERBOSITY }} --framework ${{ matrix.framework }} --filter "FullyQualifiedName~OfficeIMO.CSV.Tests" --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx
+          dotnet test OfficeIMO.VerifyTests/OfficeIMO.VerifyTests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity ${{ env.TEST_VERBOSITY }} --framework ${{ matrix.framework }} --filter "FullyQualifiedName~OfficeIMO.VerifyTests" --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx
 
       - name: Summarize failing tests
         if: failure() && env.SUMMARIZE_FAILURES == 'true'
@@ -416,7 +327,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: test-results-macos-${{ matrix.framework }}-${{ matrix.slice }}
+          name: test-results-macos-${{ matrix.framework }}
           path: '**/*.trx'
 
   test-macos:


### PR DESCRIPTION
## Summary
- add branch/PR concurrency for the .NET test workflow so superseded runs cancel automatically
- shrink the hosted macOS lane from an 18-job duplicated matrix to one focused `net8.0` platform smoke
- keep full `net8.0`/`net10.0` solution test coverage on Ubuntu and unique `net472` coverage on Windows

## Evidence
- recent `Test .NET Libraries` runs showed many cancelled macOS matrix jobs queued for 15-45 minutes, with only the Linux/Windows lanes completing normally
- local YAML parse confirms the macOS matrix now has 1 include entry and the aggregate `macOS` check still depends on it
- local no-build smoke equivalent passed: OfficeIMO.Tests 85/85, OfficeIMO.CSV.Tests 25/25, OfficeIMO.VerifyTests 28/28

## Notes
- CodeQL still contains a conditional macOS runner expression, but its current matrix only includes `csharp`, so it resolves to Ubuntu
- `actionlint` was not available locally through `npx`; YAML structure and the dotnet smoke commands were validated locally