### PR TITLE
Preserve Word block insertion order

### DIFF
--- a/OfficeIMO.Tests/Word.AddEmbeddedFragmentAfter.cs
+++ b/OfficeIMO.Tests/Word.AddEmbeddedFragmentAfter.cs
@@ -21,10 +21,10 @@ namespace OfficeIMO.Tests {
 
                 Assert.Single(document.EmbeddedDocuments);
                 var body = document._document.Body!;
-                Assert.IsType<SectionProperties>(body.ChildElements[0]);
-                Assert.IsType<Paragraph>(body.ChildElements[1]);
-                Assert.IsType<AltChunk>(body.ChildElements[2]);
-                Assert.IsType<Paragraph>(body.ChildElements[3]);
+                Assert.IsType<Paragraph>(body.ChildElements[0]);
+                Assert.IsType<AltChunk>(body.ChildElements[1]);
+                Assert.IsType<Paragraph>(body.ChildElements[2]);
+                Assert.IsType<SectionProperties>(body.ChildElements[3]);
                 document.Save();
             }
             using (WordDocument document = WordDocument.Load(filePath)) {

--- a/OfficeIMO.Tests/Word.BlockOrdering.cs
+++ b/OfficeIMO.Tests/Word.BlockOrdering.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Word {
+        [Fact]
+        public void Test_SectionBlockInsertionPreservesCallOrder() {
+            string filePath = Path.Combine(_directoryWithFiles, "SectionBlockInsertionOrder.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordSection section = document.Sections[0];
+
+                section.AddParagraph("Before table");
+                section.AddTable(1, 1);
+                section.AddParagraph("After table");
+                section.AddTable(1, 1);
+                section.AddParagraph("Tail");
+
+                Assert.Equal(
+                    new[] {
+                        "Paragraph:Before table",
+                        "Table",
+                        "Paragraph:After table",
+                        "Table",
+                        "Paragraph:Tail"
+                    },
+                    GetTopLevelContentOrder(document));
+                AssertFinalSectionPropertiesRemainLast(document);
+            }
+        }
+
+        [Fact]
+        public void Test_BodyBlockInsertionPreservesOrderAcrossTableOfContents() {
+            string filePath = Path.Combine(_directoryWithFiles, "BodyBlockInsertionOrderWithToc.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Intro");
+                document.AddTable(1, 1);
+                document.AddTableOfContent();
+                document.AddParagraph("After TOC");
+
+                Assert.Equal(
+                    new[] {
+                        "Paragraph:Intro",
+                        "Table",
+                        "SdtBlock",
+                        "Paragraph:After TOC"
+                    },
+                    GetTopLevelContentOrder(document));
+                AssertFinalSectionPropertiesRemainLast(document);
+            }
+        }
+
+        [Fact]
+        public void Test_SectionBlockInsertionPreservesOrderAfterDocumentLevelToc() {
+            string filePath = Path.Combine(_directoryWithFiles, "SectionBlockInsertionOrderWithToc.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                WordSection section = document.Sections[0];
+
+                section.AddParagraph("Intro");
+                section.AddTable(1, 1);
+                document.AddTableOfContent();
+                section.AddParagraph("After TOC");
+
+                Assert.Equal(
+                    new[] {
+                        "Paragraph:Intro",
+                        "Table",
+                        "SdtBlock",
+                        "Paragraph:After TOC"
+                    },
+                    GetTopLevelContentOrder(document));
+                AssertFinalSectionPropertiesRemainLast(document);
+            }
+        }
+
+        private static IReadOnlyList<string> GetTopLevelContentOrder(WordDocument document) {
+            Body body = document._wordprocessingDocument!.MainDocumentPart!.Document.Body!;
+            return body.ChildElements
+                .Where(element => element is Paragraph or Table or SdtBlock)
+                .Select(DescribeBlock)
+                .ToList();
+        }
+
+        private static string DescribeBlock(OpenXmlElement element) {
+            return element switch {
+                Paragraph paragraph => "Paragraph:" + paragraph.InnerText,
+                Table => "Table",
+                SdtBlock => "SdtBlock",
+                _ => element.GetType().Name
+            };
+        }
+
+        private static void AssertFinalSectionPropertiesRemainLast(WordDocument document) {
+            Body body = document._wordprocessingDocument!.MainDocumentPart!.Document.Body!;
+            SectionProperties? sectionProperties = body.Elements<SectionProperties>().LastOrDefault();
+
+            if (sectionProperties != null) {
+                Assert.Same(sectionProperties, body.ChildElements.Last());
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Word.BlockOrdering.cs
+++ b/OfficeIMO.Tests/Word.BlockOrdering.cs
@@ -89,10 +89,10 @@ namespace OfficeIMO.Tests {
                 document.AddSection();
 
                 document.Sections[0].AddParagraph("Late first section");
-                document.Sections[1].AddParagraph("Middle section");
+                WordParagraph middleParagraph = document.Sections[1].AddParagraph("Middle section");
                 document.Sections[1].AddTable(1, 1);
                 document.Sections[1].AddParagraph("Middle section tail");
-                document.Sections[2].AddParagraph("Last section");
+                WordParagraph lastParagraph = document.Sections[2].AddParagraph("Last section");
 
                 Body body = document._wordprocessingDocument!.MainDocumentPart!.Document.Body!;
                 List<OpenXmlElement> children = body.ChildElements.ToList();
@@ -125,9 +125,26 @@ namespace OfficeIMO.Tests {
                 Assert.DoesNotContain(document.Sections[0].Paragraphs, paragraph => paragraph.Text == "Middle section");
                 Assert.DoesNotContain(document.Sections[2].Paragraphs, paragraph => paragraph.Text == "Middle section");
                 Assert.Contains(document.Sections[1].Paragraphs, paragraph => paragraph.Text == "Middle section");
+                Assert.Same(document.Sections[1], middleParagraph.Parent);
+                Assert.Same(document.Sections[2], lastParagraph.Parent);
                 Assert.Empty(document.Sections[0].Tables);
                 Assert.Single(document.Sections[1].Tables);
                 Assert.Empty(document.Sections[2].Tables);
+            }
+        }
+
+        [Fact]
+        public void Test_DocumentLevelBlockInsertionRefreshesLastSectionParent() {
+            string filePath = Path.Combine(_directoryWithFiles, "DocumentLevelBlockInsertionParent.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddSection();
+
+                WordParagraph paragraph = document.AddParagraph("Last section paragraph");
+
+                Assert.Same(document.Sections[1], paragraph.Parent);
+                Assert.DoesNotContain(document.Sections[0].Paragraphs, item => item.Text == "Last section paragraph");
+                Assert.Contains(document.Sections[1].Paragraphs, item => item.Text == "Last section paragraph");
             }
         }
 

--- a/OfficeIMO.Tests/Word.BlockOrdering.cs
+++ b/OfficeIMO.Tests/Word.BlockOrdering.cs
@@ -89,17 +89,32 @@ namespace OfficeIMO.Tests {
 
                 document.Sections[0].AddParagraph("Late first section");
                 document.Sections[1].AddParagraph("Second section");
+                document.Sections[1].AddTable(1, 1);
+                document.Sections[1].AddParagraph("Second section tail");
 
                 Body body = document._wordprocessingDocument!.MainDocumentPart!.Document.Body!;
                 List<OpenXmlElement> children = body.ChildElements.ToList();
                 int insertedIndex = children.FindIndex(element => element is Paragraph paragraph && paragraph.InnerText == "Late first section");
                 int firstSectionBoundaryIndex = children.FindIndex(element => element is Paragraph paragraph
                     && paragraph.ParagraphProperties?.SectionProperties != null);
+                int secondSectionParagraphIndex = children.FindIndex(element => element is Paragraph paragraph && paragraph.InnerText == "Second section");
+                int secondSectionTableIndex = children.FindIndex(element => element is Table);
+                int secondSectionTailIndex = children.FindIndex(element => element is Paragraph paragraph && paragraph.InnerText == "Second section tail");
 
                 Assert.True(insertedIndex >= 0, "Inserted first-section paragraph should exist.");
                 Assert.True(firstSectionBoundaryIndex >= 0, "First section boundary paragraph should exist.");
+                Assert.True(secondSectionParagraphIndex >= 0, "Inserted second-section paragraph should exist.");
+                Assert.True(secondSectionTableIndex >= 0, "Inserted second-section table should exist.");
+                Assert.True(secondSectionTailIndex >= 0, "Inserted second-section tail paragraph should exist.");
                 Assert.True(insertedIndex < firstSectionBoundaryIndex, "Blocks appended to an earlier section must stay before that section's boundary.");
+                Assert.True(firstSectionBoundaryIndex < secondSectionParagraphIndex, "Blocks appended to the new section must stay after the previous section boundary.");
+                Assert.True(secondSectionParagraphIndex < secondSectionTableIndex, "Second-section blocks must preserve insertion order.");
+                Assert.True(secondSectionTableIndex < secondSectionTailIndex, "Second-section blocks must preserve insertion order.");
                 Assert.DoesNotContain(document.Sections[1].Paragraphs, paragraph => paragraph.Text == "Late first section");
+                Assert.DoesNotContain(document.Sections[0].Paragraphs, paragraph => paragraph.Text == "Second section");
+                Assert.Contains(document.Sections[1].Paragraphs, paragraph => paragraph.Text == "Second section");
+                Assert.Empty(document.Sections[0].Tables);
+                Assert.Single(document.Sections[1].Tables);
             }
         }
 
@@ -119,6 +134,28 @@ namespace OfficeIMO.Tests {
                         "Paragraph:Intro",
                         "SdtBlock",
                         "Paragraph:After TOC"
+                    },
+                    GetTopLevelContentOrder(document));
+                AssertFinalSectionPropertiesRemainLast(document);
+            }
+        }
+
+        [Fact]
+        public void Test_BodyBlockInsertionPreservesRawInlineAppendOrder() {
+            string filePath = Path.Combine(_directoryWithFiles, "BodyBlockInsertionAfterRawAppend.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Intro");
+                document._document.Body!.Append(new Paragraph(new Run(new Text("Raw inline edit"))));
+                document.Sections[0].AddTable(1, 1);
+                document.AddParagraph("After raw edit");
+
+                Assert.Equal(
+                    new[] {
+                        "Paragraph:Intro",
+                        "Paragraph:Raw inline edit",
+                        "Table",
+                        "Paragraph:After raw edit"
                     },
                     GetTopLevelContentOrder(document));
                 AssertFinalSectionPropertiesRemainLast(document);

--- a/OfficeIMO.Tests/Word.BlockOrdering.cs
+++ b/OfficeIMO.Tests/Word.BlockOrdering.cs
@@ -86,35 +86,48 @@ namespace OfficeIMO.Tests {
 
             using (WordDocument document = WordDocument.Create(filePath)) {
                 document.AddSection();
+                document.AddSection();
 
                 document.Sections[0].AddParagraph("Late first section");
-                document.Sections[1].AddParagraph("Second section");
+                document.Sections[1].AddParagraph("Middle section");
                 document.Sections[1].AddTable(1, 1);
-                document.Sections[1].AddParagraph("Second section tail");
+                document.Sections[1].AddParagraph("Middle section tail");
+                document.Sections[2].AddParagraph("Last section");
 
                 Body body = document._wordprocessingDocument!.MainDocumentPart!.Document.Body!;
                 List<OpenXmlElement> children = body.ChildElements.ToList();
                 int insertedIndex = children.FindIndex(element => element is Paragraph paragraph && paragraph.InnerText == "Late first section");
-                int firstSectionBoundaryIndex = children.FindIndex(element => element is Paragraph paragraph
-                    && paragraph.ParagraphProperties?.SectionProperties != null);
-                int secondSectionParagraphIndex = children.FindIndex(element => element is Paragraph paragraph && paragraph.InnerText == "Second section");
-                int secondSectionTableIndex = children.FindIndex(element => element is Table);
-                int secondSectionTailIndex = children.FindIndex(element => element is Paragraph paragraph && paragraph.InnerText == "Second section tail");
+                List<int> sectionBoundaryIndexes = children
+                    .Select((element, index) => element is Paragraph paragraph && paragraph.ParagraphProperties?.SectionProperties != null ? index : -1)
+                    .Where(index => index >= 0)
+                    .ToList();
+                Assert.Equal(2, sectionBoundaryIndexes.Count);
+
+                int firstSectionBoundaryIndex = sectionBoundaryIndexes[0];
+                int middleSectionBoundaryIndex = sectionBoundaryIndexes[1];
+                int middleSectionParagraphIndex = children.FindIndex(element => element is Paragraph paragraph && paragraph.InnerText == "Middle section");
+                int middleSectionTableIndex = children.FindIndex(element => element is Table);
+                int middleSectionTailIndex = children.FindIndex(element => element is Paragraph paragraph && paragraph.InnerText == "Middle section tail");
+                int lastSectionParagraphIndex = children.FindIndex(element => element is Paragraph paragraph && paragraph.InnerText == "Last section");
 
                 Assert.True(insertedIndex >= 0, "Inserted first-section paragraph should exist.");
-                Assert.True(firstSectionBoundaryIndex >= 0, "First section boundary paragraph should exist.");
-                Assert.True(secondSectionParagraphIndex >= 0, "Inserted second-section paragraph should exist.");
-                Assert.True(secondSectionTableIndex >= 0, "Inserted second-section table should exist.");
-                Assert.True(secondSectionTailIndex >= 0, "Inserted second-section tail paragraph should exist.");
+                Assert.True(middleSectionParagraphIndex >= 0, "Inserted middle-section paragraph should exist.");
+                Assert.True(middleSectionTableIndex >= 0, "Inserted middle-section table should exist.");
+                Assert.True(middleSectionTailIndex >= 0, "Inserted middle-section tail paragraph should exist.");
+                Assert.True(lastSectionParagraphIndex >= 0, "Inserted last-section paragraph should exist.");
                 Assert.True(insertedIndex < firstSectionBoundaryIndex, "Blocks appended to an earlier section must stay before that section's boundary.");
-                Assert.True(firstSectionBoundaryIndex < secondSectionParagraphIndex, "Blocks appended to the new section must stay after the previous section boundary.");
-                Assert.True(secondSectionParagraphIndex < secondSectionTableIndex, "Second-section blocks must preserve insertion order.");
-                Assert.True(secondSectionTableIndex < secondSectionTailIndex, "Second-section blocks must preserve insertion order.");
+                Assert.True(firstSectionBoundaryIndex < middleSectionParagraphIndex, "Blocks appended to a middle section must stay after the previous section boundary.");
+                Assert.True(middleSectionParagraphIndex < middleSectionTableIndex, "Middle-section blocks must preserve insertion order.");
+                Assert.True(middleSectionTableIndex < middleSectionTailIndex, "Middle-section blocks must preserve insertion order.");
+                Assert.True(middleSectionTailIndex < middleSectionBoundaryIndex, "Blocks appended to a middle section must stay before that section's own boundary.");
+                Assert.True(middleSectionBoundaryIndex < lastSectionParagraphIndex, "Blocks appended to the last section must stay after the middle section boundary.");
                 Assert.DoesNotContain(document.Sections[1].Paragraphs, paragraph => paragraph.Text == "Late first section");
-                Assert.DoesNotContain(document.Sections[0].Paragraphs, paragraph => paragraph.Text == "Second section");
-                Assert.Contains(document.Sections[1].Paragraphs, paragraph => paragraph.Text == "Second section");
+                Assert.DoesNotContain(document.Sections[0].Paragraphs, paragraph => paragraph.Text == "Middle section");
+                Assert.DoesNotContain(document.Sections[2].Paragraphs, paragraph => paragraph.Text == "Middle section");
+                Assert.Contains(document.Sections[1].Paragraphs, paragraph => paragraph.Text == "Middle section");
                 Assert.Empty(document.Sections[0].Tables);
                 Assert.Single(document.Sections[1].Tables);
+                Assert.Empty(document.Sections[2].Tables);
             }
         }
 

--- a/OfficeIMO.Tests/Word.BlockOrdering.cs
+++ b/OfficeIMO.Tests/Word.BlockOrdering.cs
@@ -80,6 +80,51 @@ namespace OfficeIMO.Tests {
             }
         }
 
+        [Fact]
+        public void Test_SectionBlockInsertionUsesCurrentSectionBoundary() {
+            string filePath = Path.Combine(_directoryWithFiles, "EarlierSectionBlockInsertionOrder.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddSection();
+
+                document.Sections[0].AddParagraph("Late first section");
+                document.Sections[1].AddParagraph("Second section");
+
+                Body body = document._wordprocessingDocument!.MainDocumentPart!.Document.Body!;
+                List<OpenXmlElement> children = body.ChildElements.ToList();
+                int insertedIndex = children.FindIndex(element => element is Paragraph paragraph && paragraph.InnerText == "Late first section");
+                int firstSectionBoundaryIndex = children.FindIndex(element => element is Paragraph paragraph
+                    && paragraph.ParagraphProperties?.SectionProperties != null);
+
+                Assert.True(insertedIndex >= 0, "Inserted first-section paragraph should exist.");
+                Assert.True(firstSectionBoundaryIndex >= 0, "First section boundary paragraph should exist.");
+                Assert.True(insertedIndex < firstSectionBoundaryIndex, "Blocks appended to an earlier section must stay before that section's boundary.");
+                Assert.DoesNotContain(document.Sections[1].Paragraphs, paragraph => paragraph.Text == "Late first section");
+            }
+        }
+
+        [Fact]
+        public void Test_RegeneratingTableOfContentsPreservesOriginalBlockPosition() {
+            string filePath = Path.Combine(_directoryWithFiles, "RegenerateTocPreservesBlockOrder.docx");
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Intro");
+                document.AddTableOfContent();
+                document.AddParagraph("After TOC");
+
+                document.RegenerateTableOfContent();
+
+                Assert.Equal(
+                    new[] {
+                        "Paragraph:Intro",
+                        "SdtBlock",
+                        "Paragraph:After TOC"
+                    },
+                    GetTopLevelContentOrder(document));
+                AssertFinalSectionPropertiesRemainLast(document);
+            }
+        }
+
         private static IReadOnlyList<string> GetTopLevelContentOrder(WordDocument document) {
             Body body = document._wordprocessingDocument!.MainDocumentPart!.Document.Body!;
             return body.ChildElements

--- a/OfficeIMO.Tests/Word.ReplaceTextWithHtml.cs
+++ b/OfficeIMO.Tests/Word.ReplaceTextWithHtml.cs
@@ -15,9 +15,9 @@ namespace OfficeIMO.Tests {
                 Assert.Single(document.EmbeddedDocuments);
                 Assert.DoesNotContain("replaceTarget", document.Paragraphs[0].Text);
                 var body = document._document.Body!;
-                Assert.IsType<SectionProperties>(body.ChildElements[0]);
-                Assert.IsType<Paragraph>(body.ChildElements[1]);
-                Assert.IsType<AltChunk>(body.ChildElements[2]);
+                Assert.IsType<Paragraph>(body.ChildElements[0]);
+                Assert.IsType<AltChunk>(body.ChildElements[1]);
+                Assert.IsType<SectionProperties>(body.ChildElements[2]);
                 document.Save();
             }
             using (WordDocument document = WordDocument.Load(filePath)) {
@@ -37,10 +37,10 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("Intro ", document.Paragraphs[0].Text);
                 Assert.Equal(" end", document.Paragraphs[1].Text);
                 var body = document._document.Body!;
-                Assert.IsType<SectionProperties>(body.ChildElements[0]);
-                Assert.IsType<Paragraph>(body.ChildElements[1]);
-                Assert.IsType<AltChunk>(body.ChildElements[2]);
-                Assert.IsType<Paragraph>(body.ChildElements[3]);
+                Assert.IsType<Paragraph>(body.ChildElements[0]);
+                Assert.IsType<AltChunk>(body.ChildElements[1]);
+                Assert.IsType<Paragraph>(body.ChildElements[2]);
+                Assert.IsType<SectionProperties>(body.ChildElements[3]);
                 document.Save();
             }
             using (WordDocument document = WordDocument.Load(filePath)) {

--- a/OfficeIMO.Tests/Word.Validation.cs
+++ b/OfficeIMO.Tests/Word.Validation.cs
@@ -42,9 +42,8 @@ namespace OfficeIMO.Tests {
                 document.PageBreaks[7].Remove(includingParagraph: false);
                 document.PageBreaks[6].Remove(true);
 
-                // this is subject to change, since maybe we will fix it
-                Assert.True(document.DocumentIsValid == false);
-                Assert.True(document.DocumentValidationErrors.Count == 1);
+                Assert.True(document.DocumentIsValid);
+                Assert.Empty(document.DocumentValidationErrors);
 
                 document.Save(false);
             }

--- a/OfficeIMO.Word/WordDocument.BodyInsertion.cs
+++ b/OfficeIMO.Word/WordDocument.BodyInsertion.cs
@@ -13,12 +13,23 @@ namespace OfficeIMO.Word {
             }
 
             var body = BodyRoot;
-            var finalSectionProperties = body.Elements<SectionProperties>().LastOrDefault();
+            var finalSectionProperties = GetFinalSectionPropertiesInsertionBoundary();
             if (finalSectionProperties != null) {
                 body.InsertBefore(element, finalSectionProperties);
             } else {
                 body.AppendChild(element);
             }
+        }
+
+        internal SectionProperties? GetFinalSectionPropertiesInsertionBoundary() {
+            var body = BodyRoot;
+            var finalSectionProperties = body.Elements<SectionProperties>().LastOrDefault();
+            if (finalSectionProperties != null && !ReferenceEquals(body.ChildElements.LastOrDefault(), finalSectionProperties)) {
+                finalSectionProperties.Remove();
+                body.AppendChild(finalSectionProperties);
+            }
+
+            return finalSectionProperties;
         }
     }
 }

--- a/OfficeIMO.Word/WordDocument.BodyInsertion.cs
+++ b/OfficeIMO.Word/WordDocument.BodyInsertion.cs
@@ -1,0 +1,24 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace OfficeIMO.Word {
+    public partial class WordDocument {
+        internal void AppendBlockToBody(OpenXmlElement element) {
+            if (element == null) {
+                throw new ArgumentNullException(nameof(element));
+            }
+
+            if (element.Parent != null) {
+                element.Remove();
+            }
+
+            var body = BodyRoot;
+            var finalSectionProperties = body.Elements<SectionProperties>().LastOrDefault();
+            if (finalSectionProperties != null) {
+                body.InsertBefore(element, finalSectionProperties);
+            } else {
+                body.AppendChild(element);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -440,7 +440,7 @@ namespace OfficeIMO.Word {
             int maxLevel = 3) {
             WordTableOfContent wordTableContent = new WordTableOfContent(this, tableOfContentStyle, minLevel, maxLevel);
             var body = _document.Body ?? throw new InvalidOperationException("Document body is missing.");
-            _tableOfContentIndex = body.ChildElements.Count - 1;
+            _tableOfContentIndex = body.ChildElements.ToList().IndexOf(wordTableContent.SdtBlock);
             _tableOfContentStyle = tableOfContentStyle;
             return wordTableContent;
         }
@@ -473,7 +473,7 @@ namespace OfficeIMO.Word {
                 body.InsertAt(block, index);
                 _tableOfContentIndex = index;
             } else {
-                _tableOfContentIndex = body.ChildElements.Count - 1;
+                _tableOfContentIndex = body.ChildElements.ToList().IndexOf(newToc.SdtBlock);
             }
             return newToc;
         }

--- a/OfficeIMO.Word/WordDocument.PublicMethods.cs
+++ b/OfficeIMO.Word/WordDocument.PublicMethods.cs
@@ -23,7 +23,7 @@ namespace OfficeIMO.Word {
 
             WordParagraph.EnsureParagraphCanBeInserted(this, body, wordParagraph,
                 "append a paragraph to the document body");
-            body.AppendChild(wordParagraph._paragraph);
+            AppendBlockToBody(wordParagraph._paragraph);
             wordParagraph.RefreshParent();
             return wordParagraph;
         }
@@ -49,8 +49,7 @@ namespace OfficeIMO.Word {
             };
             newWordParagraph._paragraph = new Paragraph(newWordParagraph._run);
 
-            var body = _document.Body ?? throw new InvalidOperationException("Document body is missing.");
-            body.Append(newWordParagraph._paragraph);
+            AppendBlockToBody(newWordParagraph._paragraph);
             newWordParagraph.RefreshParent();
             return newWordParagraph;
         }
@@ -79,8 +78,7 @@ namespace OfficeIMO.Word {
             if (currentSection != null) {
                 currentSection.AppendParagraphToSection(newWordParagraph);
             } else {
-                var body = _document.Body ?? throw new InvalidOperationException("Document body is missing.");
-                body.Append(newWordParagraph._paragraph);
+                AppendBlockToBody(newWordParagraph._paragraph);
                 newWordParagraph.RefreshParent();
             }
             return newWordParagraph;
@@ -599,8 +597,7 @@ namespace OfficeIMO.Word {
             paragraph.Append(paragraphProperties);
 
 
-            var body = _document.Body ?? throw new InvalidOperationException("Document body is missing.");
-            body.Append(paragraph);
+            AppendBlockToBody(paragraph);
 
 
             WordSection wordSection = new WordSection(this, paragraph);

--- a/OfficeIMO.Word/WordEmbeddedDocument.cs
+++ b/OfficeIMO.Word/WordEmbeddedDocument.cs
@@ -139,8 +139,11 @@ namespace OfficeIMO.Word {
                 _document = wordDocument;
 
                 var documentRoot = mainDocPart.Document ?? throw new InvalidOperationException("The document is missing its root element.");
-                var body = documentRoot.Body ?? throw new InvalidOperationException("The document does not contain a body element.");
-                body.Append(altChunk);
+                if (documentRoot.Body == null) {
+                    throw new InvalidOperationException("The document does not contain a body element.");
+                }
+
+                wordDocument.AppendBlockToBody(altChunk);
 
                 documentRoot.Save();
             } catch {

--- a/OfficeIMO.Word/WordList.PublicMethods.cs
+++ b/OfficeIMO.Word/WordList.PublicMethods.cs
@@ -48,7 +48,7 @@ namespace OfficeIMO.Word {
             if (insertionReference is not null) {
                 insertionReference.InsertAfterSelf(paragraph);
             } else if (_isToc || IsToc) {
-                _document.BodyRoot.AppendChild(paragraph);
+                _document.AppendBlockToBody(paragraph);
             } else if (_headerFooter != null) {
                 if (_headerFooter._header is not null) {
                     _headerFooter._header.Append(paragraph);
@@ -63,7 +63,7 @@ namespace OfficeIMO.Word {
                     parent.Append(paragraph);
                 }
             } else {
-                _document.BodyRoot.AppendChild(paragraph);
+                _document.AppendBlockToBody(paragraph);
             }
 
             var newParagraph = new WordParagraph(_document, paragraph);

--- a/OfficeIMO.Word/WordParagraph.Parent.cs
+++ b/OfficeIMO.Word/WordParagraph.Parent.cs
@@ -1,5 +1,6 @@
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
+using System;
 using System.Linq;
 using V = DocumentFormat.OpenXml.Vml;
 using Wps = DocumentFormat.OpenXml.Office2010.Word.DrawingShape;
@@ -60,13 +61,20 @@ namespace OfficeIMO.Word {
         }
 
         private static WordSection? FindSection(WordDocument document, Paragraph paragraph) {
+            WordSection? bodySection = FindBodySection(document, paragraph);
+            if (bodySection != null) {
+                return bodySection;
+            }
+
             var sectionProps = GetSectionPropertiesForElement(paragraph);
             if (sectionProps != null) {
                 foreach (var section in document.Sections) {
                     if (ReferenceEquals(section._sectionProperties, sectionProps)) {
                         return section;
                     }
+                }
 
+                foreach (var section in document.Sections) {
                     if (AreSectionsEquivalent(section._sectionProperties, sectionProps)) {
                         return section;
                     }
@@ -78,6 +86,41 @@ namespace OfficeIMO.Word {
             }
 
             return null;
+        }
+
+        private static WordSection? FindBodySection(WordDocument document, Paragraph paragraph) {
+            if (document.Sections.Count == 0) {
+                return null;
+            }
+
+            OpenXmlElement? bodyChild = GetBodyChildContainer(paragraph);
+            if (bodyChild?.Parent is not Body body) {
+                return null;
+            }
+
+            int sectionIndex = 0;
+            foreach (OpenXmlElement child in body.ChildElements) {
+                if (ReferenceEquals(child, bodyChild)) {
+                    return document.Sections[Math.Min(sectionIndex, document.Sections.Count - 1)];
+                }
+
+                if (child is Paragraph boundaryParagraph &&
+                    boundaryParagraph.ParagraphProperties?.SectionProperties != null &&
+                    sectionIndex < document.Sections.Count - 1) {
+                    sectionIndex++;
+                }
+            }
+
+            return null;
+        }
+
+        private static OpenXmlElement? GetBodyChildContainer(OpenXmlElement element) {
+            OpenXmlElement? current = element;
+            while (current != null && current.Parent is not Body) {
+                current = current.Parent;
+            }
+
+            return current;
         }
 
         private static WordHeader? FindHeader(WordDocument document, Header header) {

--- a/OfficeIMO.Word/WordParagraph.PublicMethods.Structure.cs
+++ b/OfficeIMO.Word/WordParagraph.PublicMethods.Structure.cs
@@ -238,31 +238,51 @@ namespace OfficeIMO.Word {
             }
 
             if (topLevel is Body bodyElement) {
+                OpenXmlElement? bodyChild = GetBodyChildContainer(element);
+                if (bodyChild?.Parent is Body owningBody) {
+                    return GetSectionPropertiesForBodyChild(owningBody, bodyChild);
+                }
+
                 return GetLastSectionProperties(bodyElement);
             }
 
             if (topLevel.Parent is Body body) {
-                var currentSection = GetLastSectionProperties(body);
-                foreach (var child in body.ChildElements) {
-                    if (ReferenceEquals(child, topLevel)) {
-                        return currentSection;
-                    }
-
-                    SectionProperties? discovered = child switch {
-                        Paragraph para => para.ParagraphProperties?.SectionProperties,
-                        SectionProperties sp => sp,
-                        _ => null
-                    };
-
-                    if (discovered != null) {
-                        currentSection = discovered;
-                    }
-                }
-
-                return currentSection;
+                return GetSectionPropertiesForBodyChild(body, topLevel);
             }
 
             return null;
+        }
+
+        private static SectionProperties? GetSectionPropertiesForBodyChild(Body body, OpenXmlElement bodyChild) {
+            SectionProperties? ownBoundary = GetSectionBoundaryProperties(bodyChild);
+            if (ownBoundary != null) {
+                return ownBoundary;
+            }
+
+            bool foundElement = false;
+            foreach (var child in body.ChildElements) {
+                if (ReferenceEquals(child, bodyChild)) {
+                    foundElement = true;
+                    continue;
+                }
+
+                if (foundElement) {
+                    SectionProperties? nextBoundary = GetSectionBoundaryProperties(child);
+                    if (nextBoundary != null) {
+                        return nextBoundary;
+                    }
+                }
+            }
+
+            return body.Elements<SectionProperties>().LastOrDefault();
+        }
+
+        private static SectionProperties? GetSectionBoundaryProperties(OpenXmlElement element) {
+            return element switch {
+                Paragraph paragraph => paragraph.ParagraphProperties?.SectionProperties,
+                SectionProperties sectionProperties => sectionProperties,
+                _ => null
+            };
         }
 
         private static SectionProperties? GetLastSectionProperties(Body body) {

--- a/OfficeIMO.Word/WordSection.PublicMethods.cs
+++ b/OfficeIMO.Word/WordSection.PublicMethods.cs
@@ -117,10 +117,6 @@ namespace OfficeIMO.Word {
         }
 
         private OpenXmlElement? GetSectionBoundaryElement() {
-            if (_paragraph != null && _paragraph.Parent is Body) {
-                return _paragraph;
-            }
-
             if (_sectionProperties.Parent is Body) {
                 return _sectionProperties;
             }
@@ -129,6 +125,10 @@ namespace OfficeIMO.Word {
                 && paragraphProperties.Parent is Paragraph paragraph
                 && paragraph.Parent is Body) {
                 return paragraph;
+            }
+
+            if (_paragraph != null && _paragraph.Parent is Body) {
+                return _paragraph;
             }
 
             return null;

--- a/OfficeIMO.Word/WordSection.PublicMethods.cs
+++ b/OfficeIMO.Word/WordSection.PublicMethods.cs
@@ -23,15 +23,8 @@ namespace OfficeIMO.Word {
         /// <returns>The created paragraph.</returns>
         public WordParagraph AddParagraph(bool newRun) {
             var wordParagraph = new WordParagraph(_document, newParagraph: true, newRun: newRun);
-            if (this.Paragraphs.Count == 0) {
-                // Historical behavior: delegate to document so first content lands correctly
-                // for both initial and subsequently added sections.
-                return this._document.AddParagraph(wordParagraph);
-            } else {
-                WordParagraph lastParagraphWithinSection = this.Paragraphs.Last();
-                WordParagraph paragraph = lastParagraphWithinSection.AddParagraphAfterSelf(this, wordParagraph);
-                return paragraph;
-            }
+            AppendParagraphToSection(wordParagraph);
+            return wordParagraph;
         }
 
         /// <summary>
@@ -40,23 +33,13 @@ namespace OfficeIMO.Word {
         /// <param name="text">Text to place in the paragraph.</param>
         /// <returns>The created paragraph.</returns>
         public WordParagraph AddParagraph(string text = "") {
-            if (this.Paragraphs.Count == 0) {
-                WordParagraph paragraph = this._document.AddParagraph();
-                if (!string.IsNullOrEmpty(text)) {
-                    paragraph.Text = text;
-                }
-                return paragraph;
-            } else {
-                WordParagraph lastParagraphWithinSection = this.Paragraphs.Last();
-
-                WordParagraph paragraph = lastParagraphWithinSection.AddParagraphAfterSelf(this);
-                paragraph._document = this._document;
-                if (!string.IsNullOrEmpty(text)) {
-                    paragraph.Text = text;
-                }
-
-                return paragraph;
+            WordParagraph paragraph = new WordParagraph(_document, newParagraph: true, newRun: false);
+            if (!string.IsNullOrEmpty(text)) {
+                paragraph.Text = text;
             }
+
+            AppendParagraphToSection(paragraph);
+            return paragraph;
         }
 
         /// <summary>
@@ -140,9 +123,8 @@ namespace OfficeIMO.Word {
         /// <param name="columns">Number of columns.</param>
         /// <param name="tableStyle">Table style to apply.</param>
         public WordTable AddTable(int rows, int columns, WordTableStyle tableStyle = WordTableStyle.TableGrid) {
-            var anchor = AddParagraph();
-            var table = anchor.AddTableAfter(rows, columns, tableStyle);
-            anchor.Remove();
+            var table = WordTable.Create(_document, rows, columns, tableStyle);
+            AppendElementToSection(table._table);
             return table;
         }
 

--- a/OfficeIMO.Word/WordSection.PublicMethods.cs
+++ b/OfficeIMO.Word/WordSection.PublicMethods.cs
@@ -67,7 +67,7 @@ namespace OfficeIMO.Word {
             var body = _document._wordprocessingDocument?.MainDocumentPart?.Document?.Body
                 ?? throw new InvalidOperationException("Document body is missing.");
 
-            var insertBefore = GetNextSectionBoundaryElement();
+            var insertBefore = GetSectionBoundaryElement() ?? GetNextSectionBoundaryElement();
             if (insertBefore != null && insertBefore.Parent == body) {
                 body.InsertBefore(element, insertBefore);
                 return;

--- a/OfficeIMO.Word/WordSection.PublicMethods.cs
+++ b/OfficeIMO.Word/WordSection.PublicMethods.cs
@@ -67,7 +67,7 @@ namespace OfficeIMO.Word {
             var body = _document._wordprocessingDocument?.MainDocumentPart?.Document?.Body
                 ?? throw new InvalidOperationException("Document body is missing.");
 
-            var insertBefore = GetSectionBoundaryElement() ?? GetNextSectionBoundaryElement();
+            var insertBefore = GetInsertionBoundaryElement();
             if (insertBefore != null && insertBefore.Parent == body) {
                 body.InsertBefore(element, insertBefore);
                 return;
@@ -81,9 +81,22 @@ namespace OfficeIMO.Word {
             body.Append(element);
         }
 
-        private OpenXmlElement? GetNextSectionBoundaryElement() {
+        private OpenXmlElement? GetInsertionBoundaryElement() {
             var sections = _document.Sections;
             var currentIndex = sections.IndexOf(this);
+            if (currentIndex < 0) {
+                return GetSectionBoundaryElement() ?? GetFinalSectionBoundaryElement();
+            }
+
+            if (currentIndex == sections.Count - 1) {
+                return GetFinalSectionBoundaryElement() ?? GetSectionBoundaryElement();
+            }
+
+            return GetSectionBoundaryElement() ?? GetNextSectionBoundaryElement(currentIndex);
+        }
+
+        private OpenXmlElement? GetNextSectionBoundaryElement(int currentIndex) {
+            var sections = _document.Sections;
             if (currentIndex < 0) {
                 return null;
             }
@@ -96,6 +109,11 @@ namespace OfficeIMO.Word {
             }
 
             return null;
+        }
+
+        private OpenXmlElement? GetFinalSectionBoundaryElement() {
+            return _document.GetFinalSectionPropertiesInsertionBoundary()
+                ?? (_sectionProperties.Parent is Body ? _sectionProperties : null);
         }
 
         private OpenXmlElement? GetSectionBoundaryElement() {

--- a/OfficeIMO.Word/WordTable.cs
+++ b/OfficeIMO.Word/WordTable.cs
@@ -451,7 +451,7 @@ namespace OfficeIMO.Word {
 
             if (insert) {
                 // Append the table to the document.
-                BodyRoot.Append(_table);
+                document.AppendBlockToBody(_table);
             }
         }
 

--- a/OfficeIMO.Word/WordTableOfContent.cs
+++ b/OfficeIMO.Word/WordTableOfContent.cs
@@ -178,8 +178,7 @@ namespace OfficeIMO.Word {
             this.Style = style;
 
             if (appendToBody) {
-                var body = this._document._wordprocessingDocument?.MainDocumentPart?.Document?.Body;
-                body?.Append(_sdtBlock);
+                this._document.AppendBlockToBody(_sdtBlock);
             }
 
             if (minLevel.HasValue && maxLevel.HasValue) {


### PR DESCRIPTION
## Summary
- add a shared Word body block append helper that inserts content before the final section properties
- route document/section paragraph, table, TOC, list, and section-break append paths through the OfficeIMO insertion behavior
- add regressions for section block ordering and table/TOC/paragraph ordering

## Tests
- dotnet build .\OfficeIMO.Word\OfficeIMO.Word.csproj -c Debug
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Debug --filter "FullyQualifiedName~BlockInsertion"
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Debug --filter "FullyQualifiedName~BlockInsertion|FullyQualifiedName~OfficeIMO.Tests.Word.Test_CreatingWordDocumentWithTOC|FullyQualifiedName~OfficeIMO.Tests.Word.Test_CreatingWordDocumentWithTables"