### PR TITLE
Prevent quadratic DoS in chart number-format bracket parsing

### DIFF
--- a/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Text.cs
+++ b/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Text.cs
@@ -596,6 +596,7 @@ public static partial class OfficeChartDrawingRenderer {
         var builder = new System.Text.StringBuilder(value.Length);
         bool inQuotedLiteral = false;
         bool escaped = false;
+        int nextClosingBracket = value.IndexOf(']');
         for (int i = 0; i < value.Length; i++) {
             char c = value[i];
             if (escaped) {
@@ -615,9 +616,13 @@ public static partial class OfficeChartDrawingRenderer {
             }
 
             if (!inQuotedLiteral && c == '[') {
-                int close = value.IndexOf(']', i + 1);
-                if (close > i) {
-                    i = close;
+                while (nextClosingBracket >= 0 && nextClosingBracket < i) {
+                    nextClosingBracket = value.IndexOf(']', nextClosingBracket + 1);
+                }
+
+                if (nextClosingBracket > i) {
+                    i = nextClosingBracket;
+                    nextClosingBracket = value.IndexOf(']', nextClosingBracket + 1);
                     continue;
                 }
             }

--- a/OfficeIMO.Tests/Pdf/PdfDocumentChartDrawingTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentChartDrawingTests.cs
@@ -409,6 +409,17 @@ public class PdfDocumentChartDrawingTests {
     }
 
     [Fact]
+    public void FlowDrawing_IgnoresBracketDirectivesInDataLabelNumberFormatsLinearly() {
+        MethodInfo method = typeof(OfficeChartDrawingRenderer).GetMethod("FormatDataLabelValue", BindingFlags.NonPublic | BindingFlags.Static)!;
+        string unmatchedPrefixFormat = new string('[', 4096) + "0";
+        string directivePrefix = (string)method.Invoke(null, new object?[] { 123D, "[Red]$0" })!;
+        string unmatchedPrefix = (string)method.Invoke(null, new object?[] { 123D, unmatchedPrefixFormat })!;
+
+        Assert.Equal("$123", directivePrefix);
+        Assert.Equal(new string('[', 4096) + "123", unmatchedPrefix);
+    }
+
+    [Fact]
     public void FlowDrawing_AppliesNumberFormatsToPercentDataLabels() {
         OfficeDrawing drawing = OfficeChartDrawingRenderer.Render(new OfficeChartSnapshot(
             "Percent labels",


### PR DESCRIPTION
### Motivation
- Chart number-format literals read from OpenXML can be attacker-controlled and the previous normalization logic called `IndexOf(']')` from every unmatched `'['`, producing O(n^2) CPU for long malicious inputs. 
- The goal is to remove the repeated suffix scans while preserving existing behavior for matched bracket directives and literal output for unmatched brackets.

### Description
- Replace per-`'['` forward `IndexOf` scans with a single-pass tracker (`nextClosingBracket`) so the literal is walked once and closing brackets are advanced linearly; the change is in `OfficeIMO.Drawing/OfficeChartDrawingRenderer.Text.cs` in `NormalizeDataLabelFormatLiteral`.
- Add a regression unit test `FlowDrawing_IgnoresBracketDirectivesInDataLabelNumberFormatsLinearly` that verifies matched directives are stripped (e.g. `"[Red]$0"`) and that very long unmatched `'['` prefixes are preserved as literals without quadratic cost in `OfficeIMO.Tests/Pdf/PdfDocumentChartDrawingTests.cs`.
- No project target frameworks or packaging settings were changed and `net472` / `net8.0` / other existing targets were preserved.

### Testing
- Repository static checks were run and no whitespace or obvious diff issues were reported. 
- The new unit test was added but could not be executed in this environment because `dotnet` is not available; the test is included and should be run in CI or a local environment with the repository test matrix (for example: run `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj` for the relevant target frameworks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fdf9039bc832e80caa0a4f7307c91)