### PR TITLE
Limit native VML image reads to prevent memory exhaustion

### DIFF
--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.StructuredBlocks.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.StructuredBlocks.cs
@@ -2443,4 +2443,74 @@ public partial class Word {
 
     private static byte[] CreateNativeMinimalRgbPng() =>
         Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADUlEQVR42mP8z8BQDwAFgwJ/l2hYtQAAAABJRU5ErkJggg==");
+
+    [Fact]
+    public void SaveAsPdf_OfficeIMOEngine_NativeVmlImageReader_Rejects_Images_Above_Limit() {
+        using var stream = new NativeVmlGeneratedStream(WordPdfConverterExtensions.NativeVmlImageMaxBytes + 1L);
+
+        bool result = WordPdfConverterExtensions.TryReadNativeVmlImageBytes(stream, WordPdfConverterExtensions.NativeVmlImageMaxBytes, out byte[]? imageBytes);
+
+        Assert.False(result);
+        Assert.Null(imageBytes);
+        Assert.True(stream.BytesRead <= WordPdfConverterExtensions.NativeVmlImageMaxBytes + 81920L);
+    }
+
+    [Fact]
+    public void SaveAsPdf_OfficeIMOEngine_NativeVmlImageReader_Reads_Images_Within_Limit() {
+        byte[] source = { 1, 2, 3, 4 };
+        using var stream = new MemoryStream(source);
+
+        bool result = WordPdfConverterExtensions.TryReadNativeVmlImageBytes(stream, WordPdfConverterExtensions.NativeVmlImageMaxBytes, out byte[]? imageBytes);
+
+        Assert.True(result);
+        Assert.Equal(source, imageBytes);
+    }
+
+    private sealed class NativeVmlGeneratedStream : Stream {
+        private long _remaining;
+
+        public NativeVmlGeneratedStream(long length) {
+            _remaining = length;
+        }
+
+        public long BytesRead { get; private set; }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position {
+            get => BytesRead;
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) {
+            if (_remaining == 0L) {
+                return 0;
+            }
+
+            int bytesToRead = (int)Math.Min(count, _remaining);
+            for (int i = offset; i < offset + bytesToRead; i++) {
+                buffer[i] = 1;
+            }
+
+            _remaining -= bytesToRead;
+            BytesRead += bytesToRead;
+            return bytesToRead;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
 }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.CoverPages.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.CoverPages.cs
@@ -10,6 +10,8 @@ using PdfCore = OfficeIMO.Pdf;
 
 namespace OfficeIMO.Word.Pdf {
     public static partial class WordPdfConverterExtensions {
+        internal const long NativeVmlImageMaxBytes = 32L * 1024L * 1024L;
+
         private static bool TryRenderNativeCoverPageCanvas(INativePdfFlow pdf, WordDocument document, W.SdtBlock? sdtBlock, WordSection section, PdfSaveOptions? options) {
             W.SdtContentBlock? content = sdtBlock?.SdtContentBlock;
             if (content == null || !HasNativeVmlCoverDrawing(content)) {
@@ -234,10 +236,42 @@ namespace OfficeIMO.Word.Pdf {
             }
 
             using Stream stream = imagePart.GetStream(FileMode.Open, FileAccess.Read);
-            using var memory = new MemoryStream();
-            stream.CopyTo(memory);
+            return TryReadNativeVmlImageBytes(stream, NativeVmlImageMaxBytes, out imageBytes);
+        }
+
+        internal static bool TryReadNativeVmlImageBytes(Stream stream, long maxBytes, out byte[]? imageBytes) {
+            imageBytes = null;
+            if (stream == null || maxBytes <= 0L) {
+                return false;
+            }
+
+            if (stream.CanSeek && stream.Length > maxBytes) {
+                return false;
+            }
+
+            using var memory = new MemoryStream(stream.CanSeek && stream.Length > 0L && stream.Length <= int.MaxValue ? (int)stream.Length : 0);
+            byte[] buffer = new byte[81920];
+            long totalRead = 0L;
+            while (true) {
+                int bytesRead = stream.Read(buffer, 0, buffer.Length);
+                if (bytesRead == 0) {
+                    break;
+                }
+
+                totalRead += bytesRead;
+                if (totalRead > maxBytes) {
+                    return false;
+                }
+
+                memory.Write(buffer, 0, bytesRead);
+            }
+
+            if (memory.Length == 0L) {
+                return false;
+            }
+
             imageBytes = memory.ToArray();
-            return imageBytes.Length > 0;
+            return true;
         }
 
         private static bool TryGetNativeVmlImagePart(WordDocument document, OpenXmlElement element, string relationshipId, out ImagePart? imagePart) {


### PR DESCRIPTION
### Motivation
- Prevent unbounded allocation when reading attacker-controlled VML ImagePart data referenced from cover-page VML shapes, which can exhaust process memory during Word-to-PDF conversion.
- Add a small, conservative safeguard that enforces a per-image byte cap and streaming read logic before any expensive format validation occurs.

### Description
- Introduce `NativeVmlImageMaxBytes = 32L * 1024L * 1024L` and replace the previous unbounded `CopyTo`/`ToArray` with a bounded reader that reads in chunks and rejects streams that exceed the limit. 
- Add `TryReadNativeVmlImageBytes(Stream, long, out byte[]?)` implementing chunked reads, early rejection for seekable oversized parts, and immediate abort when the running total exceeds the configured limit. 
- Update `TryGetNativeVmlImageBytes` to call the new bounded reader instead of materializing the entire part unconditionally. 
- Add two regression unit tests that validate oversized streams are rejected and small streams are accepted, using a custom non-seekable test stream to exercise the streaming path.

### Testing
- Ran the focused unit tests with `PATH=/tmp/dotnet:$PATH dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --framework net8.0 --filter "NativeVmlImageReader"` and the matching tests passed. 
- Built the modified package with `PATH=/tmp/dotnet:$PATH dotnet build OfficeIMO.Word.Pdf/OfficeIMO.Word.Pdf.csproj --no-restore` and the project built successfully. 
- Performed a quick repository hygiene check with `git diff --check` (no whitespace/format issues introduced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fe08f49f0832e824f9ab368eb362e)