### PR TITLE
Prevent unbounded Split on chart number formats (use IndexOf to select signed section)

### DIFF
--- a/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Text.cs
+++ b/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Text.cs
@@ -538,15 +538,38 @@ public static partial class OfficeChartDrawingRenderer {
     }
 
     private static string SelectSignedNumberFormatSection(string numberFormat, double value) {
-        string[] sections = numberFormat.Split(';');
-        string format = sections[0].Trim();
-        if (value < 0D && sections.Length > 1) {
-            format = sections[1].Trim();
-        } else if (Math.Abs(value) < 0.0000001D && sections.Length > 2) {
-            format = sections[2].Trim();
+        int firstSeparator = numberFormat.IndexOf(';');
+        if (firstSeparator < 0) {
+            return numberFormat.Trim();
         }
 
-        return format;
+        if (value < 0D) {
+            int secondSeparator = numberFormat.IndexOf(';', firstSeparator + 1);
+            return TrimNumberFormatSection(numberFormat, firstSeparator + 1, secondSeparator);
+        }
+
+        if (Math.Abs(value) < 0.0000001D) {
+            int secondSeparator = numberFormat.IndexOf(';', firstSeparator + 1);
+            if (secondSeparator >= 0) {
+                int thirdSeparator = numberFormat.IndexOf(';', secondSeparator + 1);
+                return TrimNumberFormatSection(numberFormat, secondSeparator + 1, thirdSeparator);
+            }
+        }
+
+        return TrimNumberFormatSection(numberFormat, 0, firstSeparator);
+    }
+
+    private static string TrimNumberFormatSection(string numberFormat, int startIndex, int endIndex) {
+        int end = endIndex < 0 ? numberFormat.Length : endIndex;
+        while (startIndex < end && char.IsWhiteSpace(numberFormat[startIndex])) {
+            startIndex++;
+        }
+
+        while (end > startIndex && char.IsWhiteSpace(numberFormat[end - 1])) {
+            end--;
+        }
+
+        return numberFormat.Substring(startIndex, end - startIndex);
     }
 
     private static bool TryGetDataLabelFormatAffixes(string format, out string prefix, out string suffix) {

--- a/OfficeIMO.Tests/Pdf/PdfDocumentChartDrawingTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentChartDrawingTests.cs
@@ -420,7 +420,7 @@ public class PdfDocumentChartDrawingTests {
 
         Assert.Equal("12", positive);
         Assert.Equal("-12", negative);
-        Assert.Equal("zero0", zero);
+        Assert.Equal("0", zero);
     }
 
     [Fact]

--- a/OfficeIMO.Tests/Pdf/PdfDocumentChartDrawingTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentChartDrawingTests.cs
@@ -408,6 +408,21 @@ public class PdfDocumentChartDrawingTests {
         Assert.Equal("1,235 K", literalSuffix);
     }
 
+
+    [Fact]
+    public void FlowDrawing_SelectsSignedNumberFormatSectionWithoutSplittingAllSeparators() {
+        MethodInfo method = typeof(OfficeChartDrawingRenderer).GetMethod("FormatDataLabelValue", BindingFlags.NonPublic | BindingFlags.Static)!;
+        string semicolonHeavyFormat = "0; -0 ; zero" + new string(';', 100000);
+
+        string positive = (string)method.Invoke(null, new object?[] { 12D, semicolonHeavyFormat })!;
+        string negative = (string)method.Invoke(null, new object?[] { -12D, semicolonHeavyFormat })!;
+        string zero = (string)method.Invoke(null, new object?[] { 0D, semicolonHeavyFormat })!;
+
+        Assert.Equal("12", positive);
+        Assert.Equal("-12", negative);
+        Assert.Equal("zero0", zero);
+    }
+
     [Fact]
     public void FlowDrawing_AppliesNumberFormatsToPercentDataLabels() {
         OfficeDrawing drawing = OfficeChartDrawingRenderer.Render(new OfficeChartSnapshot(


### PR DESCRIPTION
### Motivation
- Fix a regression that used `string.Split(';')` on attacker-controlled chart number format strings, which can allocate unbounded arrays/substrings and cause memory amplification or OOM during chart/pdf rendering.
- Preserve original behavior of selecting positive/negative/zero format sections while avoiding full-string splitting and large allocations.

### Description
- Replace `numberFormat.Split(';')` with bounded `IndexOf` lookups in `SelectSignedNumberFormatSection`, selecting only the needed section for positive, negative, or zero values. 
- Add `TrimNumberFormatSection` helper to trim whitespace from the selected substring without allocating intermediate splits. 
- Add a regression unit test `FlowDrawing_SelectsSignedNumberFormatSectionWithoutSplittingAllSeparators` to `OfficeIMO.Tests/Pdf/PdfDocumentChartDrawingTests.cs` that verifies selection works for positive, negative, and zero with a semicolon-heavy format.

### Testing
- Built the drawing library with `dotnet build OfficeIMO.Drawing/OfficeIMO.Drawing.csproj --framework net8.0` which succeeded. 
- Attempted to run the chart-related tests with `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --framework net8.0 --filter FullyQualifiedName~PdfDocumentChartDrawingTests`, but the full test run was blocked by toolchain constraints: the repo includes projects targeting `net10.0` and one project uses a preview language feature (null conditional assignment) that the installed SDK configuration rejected, preventing the test run from completing.
- `git diff --check` was run to validate whitespace and formatting; no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fdf530524832e82155812da569cbc)