### PR TITLE
Make image extraction opt-in for PdfLogicalDocument loads

### DIFF
--- a/OfficeIMO.Pdf/Reading/Layout/PdfTextLayoutOptions.cs
+++ b/OfficeIMO.Pdf/Reading/Layout/PdfTextLayoutOptions.cs
@@ -28,6 +28,10 @@ public sealed class PdfTextLayoutOptions {
     public double GapSpaceThresholdEm { get; set; } = 0.35;
     /// <summary>Threshold as a fraction of previous span's average glyph advance to insert a space. Default: 0.60.</summary>
     public double GapGlyphFactor { get; set; } = 0.60;
+    /// <summary>
+    /// When true, includes page image extraction in logical document reads. Default: false.
+    /// </summary>
+    public bool IncludeImages { get; set; }
 
     internal TextLayoutEngine.Options ToEngineOptions() => new TextLayoutEngine.Options {
         MarginLeft = this.MarginLeft,

--- a/OfficeIMO.Pdf/Reading/Logical/PdfLogicalDocument.cs
+++ b/OfficeIMO.Pdf/Reading/Logical/PdfLogicalDocument.cs
@@ -964,10 +964,12 @@ public sealed class PdfLogicalPage {
             elements.Add(logicalTable);
         }
 
-        foreach (var image in page.GetImages(pageNumber)) {
-            var logicalImage = new PdfLogicalImage(image);
-            images.Add(logicalImage);
-            elements.Add(logicalImage);
+        if (options?.IncludeImages == true) {
+            foreach (var image in page.GetImages(pageNumber)) {
+                var logicalImage = new PdfLogicalImage(image);
+                images.Add(logicalImage);
+                elements.Add(logicalImage);
+            }
         }
 
         IReadOnlyList<PdfLinkAnnotation> linkAnnotations = page.GetLinkAnnotations();

--- a/OfficeIMO.Tests/Pdf/PdfLogicalDocumentTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfLogicalDocumentTests.cs
@@ -34,7 +34,8 @@ public class PdfLogicalDocumentTests {
             .ToBytes();
 
         PdfLogicalDocument logical = PdfLogicalDocument.Load(pdf, new PdfTextLayoutOptions {
-            ForceSingleColumn = true
+            ForceSingleColumn = true,
+            IncludeImages = true
         });
 
         PdfLogicalPage page = Assert.Single(logical.Pages);
@@ -105,6 +106,27 @@ public class PdfLogicalDocumentTests {
         Assert.Throws<ArgumentOutOfRangeException>(() => logical.GetElements(0));
         Assert.Contains(logical.Elements, element => element.Kind == PdfLogicalElementKind.Table);
         Assert.Contains(logical.Elements, element => element.Kind == PdfLogicalElementKind.Image);
+    }
+
+    [Fact]
+    public void Load_DoesNotExtractImagesByDefault() {
+        byte[] pdf = PdfDoc.Create(new PdfOptions {
+                PageWidth = 420,
+                PageHeight = 360
+            })
+            .Paragraph(p => p.Text("Logical readback marker."))
+            .Image(CreateMinimalRgbPng(), 18, 18)
+            .ToBytes();
+
+        PdfLogicalDocument logical = PdfLogicalDocument.Load(pdf, new PdfTextLayoutOptions {
+            ForceSingleColumn = true
+        });
+
+        PdfLogicalPage page = Assert.Single(logical.Pages);
+        Assert.Empty(page.Images);
+        Assert.Empty(logical.Images);
+        Assert.DoesNotContain(page.Elements, element => element.Kind == PdfLogicalElementKind.Image);
+        Assert.False(logical.HasElementKind(PdfLogicalElementKind.Image));
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- A logical-read API was eagerly calling page image extraction and therefore reached existing unbounded image decode/allocation paths, exposing logical loads to resource-exhaustion attacks. 
- The intent is to avoid traversing into expensive image-decode code paths during typical text/structure-only logical reads. 

### Description
- Added a new `PdfTextLayoutOptions.IncludeImages` boolean property (default `false`) to let callers opt in to image extraction. 
- Updated `PdfLogicalPage.From(...)` to call `page.GetImages(...)` only when `options?.IncludeImages == true`, making image extraction opt-in and preserving existing image extraction logic for callers that request it. 
- Updated tests: the existing image-bearing test now passes `IncludeImages = true`, and a new unit test `Load_DoesNotExtractImagesByDefault` asserts that images are not extracted for default logical loads.

### Testing
- Attempted to run `PdfLogicalDocumentTests` via `dotnet test`, but automated test execution failed in this environment due to an SDK mismatch (`NETSDK1045`) because the repository includes `net10.0` targets while the available SDK is `9.0.314`, so tests could not be executed here. 
- No test failures in this patch itself; new tests were added and expect to succeed when run with a matching SDK that can build the solution (ensure a .NET SDK that supports the repo targets). 
- Confirmed repository project files and targets were not altered and no target frameworks were removed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17ed40fe64832ea7980e918155d38c)