### PR TITLE
Prevent DoS by avoiding preallocation from untrusted cellXfs count

### DIFF
--- a/OfficeIMO.Excel/Read/Helpers/StylesCache.cs
+++ b/OfficeIMO.Excel/Read/Helpers/StylesCache.cs
@@ -61,13 +61,6 @@ namespace OfficeIMO.Excel {
 
             var xfs = sp.Stylesheet.CellFormats;
             if (xfs != null) {
-                int expectedCount = xfs.Count?.Value is uint declaredCount && declaredCount <= int.MaxValue
-                    ? (int)declaredCount
-                    : 0;
-                if (expectedCount > 0) {
-                    cache._dateStyleIndexes = new bool[expectedCount];
-                }
-
                 int idx = 0;
                 foreach (var cf in xfs.Elements<CellFormat>()) {
                     if (idx == cache._dateStyleIndexes.Length) {
@@ -146,11 +139,6 @@ namespace OfficeIMO.Excel {
         }
 
         private static void ReadCellFormatsXml(XmlReader reader, StylesCache cache, Dictionary<uint, string>? numberingFormats) {
-            int expectedCount = TryParseIntAttribute(reader.GetAttribute("count"), out int parsedCount) ? parsedCount : 0;
-            if (expectedCount > 0) {
-                cache._dateStyleIndexes = new bool[expectedCount];
-            }
-
             if (reader.IsEmptyElement) {
                 cache._dateStyleIndexes = EmptyDateStyleIndexes;
                 cache.HasDateStyles = false;
@@ -234,15 +222,5 @@ namespace OfficeIMO.Excel {
             return true;
         }
 
-        private static bool TryParseIntAttribute(string? value, out int result) {
-            result = 0;
-            if (!TryParseUIntAttribute(value, out uint parsed) || parsed > int.MaxValue) {
-                return false;
-            }
-
-            result = (int)parsed;
-            return true;
-        }
     }
 }
-

--- a/OfficeIMO.Tests/Excel.Reader.cs
+++ b/OfficeIMO.Tests/Excel.Reader.cs
@@ -1800,6 +1800,34 @@ namespace OfficeIMO.Tests {
             }
         }
 
+        [Fact]
+        public void Reader_Open_IgnoresDeclaredCellFormatCountWhenItExceedsActualFormats() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderStylesDeclaredCountTooLarge.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, new DateTime(2024, 1, 1));
+                    document.Save();
+                }
+
+                using (var spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                    var stylesheet = spreadsheet.WorkbookPart!.WorkbookStylesPart!.Stylesheet!;
+                    stylesheet.CellFormats!.Count = uint.MaxValue;
+                    stylesheet.Save();
+                }
+
+                using var reader = ExcelDocumentReader.Open(filePath);
+                var values = reader.GetSheet("Data").ReadRange("A1:A1");
+
+                Assert.NotNull(values[0, 0]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
         private sealed class ReaderDecisionRecord {
             public int Id { get; set; }
 


### PR DESCRIPTION
### Motivation
- The XLSX `styles.xml` `cellXfs@count` attribute is attacker-controlled and could advertise an extremely large count, causing a large `bool[]` allocation and potential OutOfMemory / DoS when date-style parsing is enabled. 
- The code previously preallocated `StylesCache._dateStyleIndexes` from the declared `count` in both the DOM and XML fast paths, which is unsafe when the attribute is untrusted.
- The intent is to preserve existing date-detection behavior while removing any allocation that trusts the declared `count` attribute.

### Description
- Removed preallocation based on the `cellXfs@count` attribute in the DOM path of `StylesCache.Build` and in the XML fast path `ReadCellFormatsXml`, so the cache grows only as actual `<xf>` elements are enumerated. 
- Kept the dynamic growth strategy using `Array.Resize` when actual formats are encountered, and preserved `HasDateStyles` and `IsDateLike` semantics. 
- Removed the now-unused integer parse helper that existed only to support the removed preallocation logic. 
- Added a regression test `Reader_Open_IgnoresDeclaredCellFormatCountWhenItExceedsActualFormats` in `OfficeIMO.Tests/Excel.Reader.cs` that sets `Stylesheet.CellFormats.Count = uint.MaxValue` while leaving actual formats small and verifies the reader can still open and read the cell.
- Files changed: `OfficeIMO.Excel/Read/Helpers/StylesCache.cs` and `OfficeIMO.Tests/Excel.Reader.cs`.

### Testing
- Added a targeted unit test `Reader_Open_IgnoresDeclaredCellFormatCountWhenItExceedsActualFormats` in the test project and committed it to the branch. 
- Attempted to run the single test with `dotnet test OfficeIMO.Tests/OfficeIMO.Tests.csproj --filter "Reader_Open_IgnoresDeclaredCellFormatCountWhenItExceedsActualFormats"` but the `dotnet` SDK is not available in this environment (`dotnet: command not found`), so automated test execution could not be performed here. 
- No other automated test runs were executed in this environment due to the missing SDK, but the change is intentionally minimal and limited to allocation behavior to preserve existing API and runtime targets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1306fb5928832ea31b38f43f826de4)