### PR TITLE
Respect PDF default table styles in converters

### DIFF
--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.TableStyles.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.TableStyles.cs
@@ -6,15 +6,9 @@ namespace OfficeIMO.Excel.Pdf {
         private static PdfCore.PdfTableStyle CreateTableStyle(ExcelPdfSaveOptions options, ExcelSheetPageSetup? pageSetup, IReadOnlyList<int> rowIndexes, int headerRowCount, ExcelCellStyleSnapshot?[,]? styles, ConditionalFillData? conditionalFills, ColumnLayoutData? columnWidths, RowLayoutData? rowHeights, int columnOffset = 0, int exportedColumns = 0) {
             int exportedRows = rowIndexes.Count;
             int headerRows = Math.Min(headerRowCount, exportedRows);
-            var tableStyle = new PdfCore.PdfTableStyle {
-                HeaderRowCount = headerRows,
-                RepeatHeaderRowCount = headerRows == 0 ? null : headerRows,
-                CellPaddingX = 4,
-                CellPaddingY = 3,
-                HeaderFill = PdfCore.PdfColor.FromRgb(230, 238, 247),
-                HeaderTextColor = PdfCore.PdfColor.FromRgb(31, 78, 121),
-                RowStripeFill = PdfCore.PdfColor.FromRgb(248, 250, 252)
-            };
+            PdfCore.PdfTableStyle tableStyle = CreateBaseTableStyle(options);
+            tableStyle.HeaderRowCount = headerRows;
+            tableStyle.RepeatHeaderRowCount = headerRows == 0 ? null : headerRows;
 
             if (columnWidths != null) {
                 List<double> widthWeights = columnWidths.WidthWeights.Skip(columnOffset).Take(exportedColumns).ToList();
@@ -64,6 +58,30 @@ namespace OfficeIMO.Excel.Pdf {
                 tableStyle.CellBorders = cellBorders;
             }
 
+            return tableStyle;
+        }
+
+        private static PdfCore.PdfTableStyle CreateBaseTableStyle(ExcelPdfSaveOptions options) {
+            PdfCore.PdfTableStyle? configuredStyle = options.PdfOptions?.HasExplicitDefaultTableStyle == true
+                ? options.PdfOptions.DefaultTableStyle
+                : null;
+            if (configuredStyle != null) {
+                return configuredStyle.Clone();
+            }
+
+            return new PdfCore.PdfTableStyle {
+                CellPaddingX = 4,
+                CellPaddingY = 3,
+                HeaderFill = PdfCore.PdfColor.FromRgb(230, 238, 247),
+                HeaderTextColor = PdfCore.PdfColor.FromRgb(31, 78, 121),
+                RowStripeFill = PdfCore.PdfColor.FromRgb(248, 250, 252)
+            };
+        }
+
+        private static PdfCore.PdfTableStyle CreateEmptyWorkbookTableStyle(ExcelPdfSaveOptions options) {
+            PdfCore.PdfTableStyle tableStyle = CreateBaseTableStyle(options);
+            tableStyle.HeaderRowCount = 0;
+            tableStyle.RepeatHeaderRowCount = null;
             return tableStyle;
         }
 

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.cs
@@ -70,7 +70,7 @@ namespace OfficeIMO.Excel.Pdf {
 
             if (exportPlans.Count == 0) {
                 pdf.H1("Workbook");
-                pdf.Table(new[] { new[] { "No worksheet data found." } }, style: new PdfCore.PdfTableStyle { HeaderRowCount = 0 });
+                pdf.Table(new[] { new[] { "No worksheet data found." } }, style: CreateEmptyWorkbookTableStyle(options));
             }
 
             return pdf;

--- a/OfficeIMO.Pdf/Options/PdfOptions.Clone.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.Clone.cs
@@ -78,7 +78,6 @@ public sealed partial class PdfOptions {
             PageNumberStyle = PageNumberStyle,
             DefaultTextColor = DefaultTextColor,
             DefaultParagraphStyle = _defaultParagraphStyle?.Clone(),
-            DefaultTableStyle = _defaultTableStyle?.Clone(),
             DefaultHeadingStyles = _defaultHeadingStyles?.Clone(),
             DefaultListStyle = _defaultListStyle?.Clone(),
             DefaultPanelStyle = _defaultPanelStyle?.Clone(),
@@ -133,6 +132,8 @@ public sealed partial class PdfOptions {
             _firstPageFooterShapes = CloneHeaderFooterShapes(_firstPageFooterShapes),
             _evenPageFooterShapes = CloneHeaderFooterShapes(_evenPageFooterShapes)
         };
+        clone._defaultTableStyle = _defaultTableStyle?.Clone();
+        clone._hasExplicitDefaultTableStyle = _hasExplicitDefaultTableStyle;
         clone._pageNumberStart = _pageNumberStart;
         clone._hasExplicitPageNumberStart = _hasExplicitPageNumberStart;
         return clone;

--- a/OfficeIMO.Pdf/Options/PdfOptions.Styles.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.Styles.cs
@@ -21,8 +21,13 @@ public sealed partial class PdfOptions {
     /// <summary>Default table style applied when none is provided.</summary>
     public PdfTableStyle? DefaultTableStyle {
         get => _defaultTableStyle?.Clone();
-        set => _defaultTableStyle = value?.Clone();
+        set {
+            _defaultTableStyle = value?.Clone();
+            _hasExplicitDefaultTableStyle = value != null;
+        }
     }
+    /// <summary>Gets whether <see cref="DefaultTableStyle"/> was explicitly supplied by the caller or a theme.</summary>
+    public bool HasExplicitDefaultTableStyle => _hasExplicitDefaultTableStyle;
     /// <summary>Default heading styles applied when H1/H2/H3 blocks do not specify their own style.</summary>
     public PdfHeadingStyles? DefaultHeadingStyles {
         get => _defaultHeadingStyles?.Clone();
@@ -87,6 +92,7 @@ public sealed partial class PdfOptions {
     }
     internal PdfParagraphStyle? DefaultParagraphStyleSnapshot => _defaultParagraphStyle;
     internal PdfTableStyle? DefaultTableStyleSnapshot => _defaultTableStyle;
+    internal bool HasExplicitDefaultTableStyleSnapshot => _hasExplicitDefaultTableStyle;
     internal PdfHeadingStyles? DefaultHeadingStylesSnapshot => _defaultHeadingStyles;
     internal PdfListStyle? DefaultListStyleSnapshot => _defaultListStyle;
     internal PanelStyle? DefaultPanelStyleSnapshot => _defaultPanelStyle;

--- a/OfficeIMO.Pdf/Options/PdfOptions.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.cs
@@ -52,6 +52,7 @@ public sealed partial class PdfOptions {
     private System.Collections.Generic.List<PdfPageLabelRange>? _pageLabelRanges;
     private PdfParagraphStyle? _defaultParagraphStyle;
     private PdfTableStyle? _defaultTableStyle = TableStyles.Light();
+    private bool _hasExplicitDefaultTableStyle;
     private PdfHeadingStyles? _defaultHeadingStyles;
     private PdfListStyle? _defaultListStyle;
     private PanelStyle? _defaultPanelStyle;

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Tables.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Tables.cs
@@ -29,7 +29,7 @@ public static partial class PowerPointPdfConverterExtensions {
             rows.Add(pdfCells.ToArray());
         }
 
-        PdfCore.PdfTableStyle style = CreateTableStyle(table);
+        PdfCore.PdfTableStyle style = CreateTableStyle(table, options);
         bool reportedCellOverflow = false;
         try {
             canvas.Table(rows, x, y, width, height, style, table.Rotation ?? 0D, diagnostic => {
@@ -128,19 +128,62 @@ public static partial class PowerPointPdfConverterExtensions {
             font: MapFont(cell.FontName));
     }
 
-    private static PdfCore.PdfTableStyle CreateTableStyle(PptCore.PowerPointTable table) {
-        var style = PdfCore.TableStyles.Light().Clone();
+    private static PdfCore.PdfTableStyle CreateTableStyle(PptCore.PowerPointTable table, PowerPointPdfSaveOptions options) {
+        PdfCore.PdfTableStyle style = CreateBaseTableStyle(options);
         style.HeaderRowCount = table.FirstRow ? 1 : 0;
+        style.RepeatHeaderRowCount = style.HeaderRowCount == 0 ? 0 : style.HeaderRowCount;
         style.FooterRowCount = table.LastRow ? 1 : 0;
         style.RowStripeFill = table.BandedRows ? style.RowStripeFill : null;
         style.ColumnWidthPoints = CreateColumnWidths(table, table.WidthPoints);
         style.RowMinHeights = CreateRowHeights(table, table.HeightPoints);
-        style.CellFills = CreateTableCellFills(table);
-        style.CellPaddings = CreateTableCellPaddings(table);
-        style.CellAlignments = CreateTableCellAlignments(table);
-        style.CellVerticalAlignments = CreateTableCellVerticalAlignments(table);
-        style.CellBorders = CreateTableCellBorders(table);
+        Dictionary<(int Row, int Column), PdfCore.PdfColor>? cellFills = CreateTableCellFills(table);
+        if (cellFills != null) {
+            style.CellFills = MergeTableCellMap(style.CellFills, cellFills);
+        }
+
+        Dictionary<(int Row, int Column), PdfCore.PdfCellPadding>? cellPaddings = CreateTableCellPaddings(table);
+        if (cellPaddings != null) {
+            style.CellPaddings = MergeTableCellMap(style.CellPaddings, cellPaddings);
+        }
+
+        Dictionary<(int Row, int Column), PdfCore.PdfColumnAlign>? cellAlignments = CreateTableCellAlignments(table);
+        if (cellAlignments != null) {
+            style.CellAlignments = MergeTableCellMap(style.CellAlignments, cellAlignments);
+        }
+
+        Dictionary<(int Row, int Column), PdfCore.PdfCellVerticalAlign>? cellVerticalAlignments = CreateTableCellVerticalAlignments(table);
+        if (cellVerticalAlignments != null) {
+            style.CellVerticalAlignments = MergeTableCellMap(style.CellVerticalAlignments, cellVerticalAlignments);
+        }
+
+        Dictionary<(int Row, int Column), PdfCore.PdfCellBorder>? cellBorders = CreateTableCellBorders(table);
+        if (cellBorders != null) {
+            style.CellBorders = MergeTableCellMap(style.CellBorders, cellBorders);
+        }
+
         return style;
+    }
+
+    private static PdfCore.PdfTableStyle CreateBaseTableStyle(PowerPointPdfSaveOptions options) {
+        PdfCore.PdfTableStyle? configuredStyle = options.PdfOptions?.HasExplicitDefaultTableStyle == true
+            ? options.PdfOptions.DefaultTableStyle
+            : null;
+        if (configuredStyle != null) {
+            return configuredStyle.Clone();
+        }
+
+        return PdfCore.TableStyles.Light().Clone();
+    }
+
+    private static Dictionary<(int Row, int Column), T> MergeTableCellMap<T>(Dictionary<(int Row, int Column), T>? baseline, Dictionary<(int Row, int Column), T> overlay) {
+        var merged = baseline == null
+            ? new Dictionary<(int Row, int Column), T>()
+            : new Dictionary<(int Row, int Column), T>(baseline);
+        foreach (KeyValuePair<(int Row, int Column), T> item in overlay) {
+            merged[item.Key] = item.Value;
+        }
+
+        return merged;
     }
 
     private static List<double?> CreateColumnWidths(PptCore.PowerPointTable table, double tableWidth) {

--- a/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.BasicSheetTests.cs
+++ b/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.BasicSheetTests.cs
@@ -63,6 +63,93 @@ public partial class Excel {
     }
 
     [Fact]
+    public void ToPdfDocument_ExcelWorkbook_Uses_Configured_Default_Table_Style() {
+        string workbookPath = Path.Combine(_directoryWithFiles, "ExcelPdfConfiguredDefaultTableStyle.xlsx");
+        var configuredStyle = new PdfCore.PdfTableStyle {
+            HeaderRowCount = 0,
+            RepeatHeaderRowCount = 0,
+            CellPaddingX = 9,
+            CellPaddingY = 7,
+            BorderColor = null,
+            HeaderFill = PdfCore.PdfColor.FromRgb(10, 20, 30),
+            HeaderTextColor = PdfCore.PdfColor.FromRgb(240, 245, 250),
+            RowStripeFill = null,
+            FontSize = 10.5D,
+            SpacingAfter = 12D
+        };
+
+        PdfCore.PdfDocument pdfDocument;
+        using (ExcelDocument document = ExcelDocument.Create(workbookPath, "Styled")) {
+            ExcelSheet sheet = document.Sheets[0];
+            sheet.Cell(1, 1, "Product");
+            sheet.Cell(1, 2, "Amount");
+            sheet.Cell(2, 1, "Licenses");
+            sheet.Cell(2, 2, 1250.5);
+            document.Save(false);
+
+            pdfDocument = document.ToPdfDocument(new ExcelPdfSaveOptions {
+                IncludeSheetHeadings = false,
+                HeaderRowCount = 1,
+                PdfOptions = new PdfCore.PdfOptions {
+                    DefaultTableStyle = configuredStyle
+                }
+            });
+        }
+
+        PdfCore.PageBlock page = Assert.IsType<PdfCore.PageBlock>(Assert.Single(pdfDocument.Blocks));
+        PdfCore.TableBlock table = Assert.Single(page.Blocks.OfType<PdfCore.TableBlock>());
+        Assert.NotNull(table.Style);
+        PdfCore.PdfTableStyle style = table.Style!;
+
+        Assert.Equal(1, style.HeaderRowCount);
+        Assert.Equal(1, style.RepeatHeaderRowCount);
+        Assert.Equal(9, style.CellPaddingX);
+        Assert.Equal(7, style.CellPaddingY);
+        Assert.Null(style.BorderColor);
+        Assert.Equal(PdfCore.PdfColor.FromRgb(10, 20, 30), style.HeaderFill);
+        Assert.Equal(PdfCore.PdfColor.FromRgb(240, 245, 250), style.HeaderTextColor);
+        Assert.Null(style.RowStripeFill);
+        Assert.Equal(10.5D, style.FontSize);
+        Assert.Equal(12D, style.SpacingAfter);
+
+        Assert.Equal(0, configuredStyle.HeaderRowCount);
+        Assert.Equal(0, configuredStyle.RepeatHeaderRowCount);
+        Assert.Null(configuredStyle.CellFills);
+        Assert.Null(configuredStyle.ColumnWidthWeights);
+    }
+
+    [Fact]
+    public void ToPdfDocument_ExcelWorkbook_Keeps_Excel_Default_Table_Style_For_Unrelated_PdfOptions() {
+        string workbookPath = Path.Combine(_directoryWithFiles, "ExcelPdfUnrelatedPdfOptions.xlsx");
+
+        PdfCore.PdfDocument pdfDocument;
+        using (ExcelDocument document = ExcelDocument.Create(workbookPath, "Styled")) {
+            ExcelSheet sheet = document.Sheets[0];
+            sheet.Cell(1, 1, "Product");
+            sheet.Cell(2, 1, "Licenses");
+            document.Save(false);
+
+            pdfDocument = document.ToPdfDocument(new ExcelPdfSaveOptions {
+                IncludeSheetHeadings = false,
+                HeaderRowCount = 1,
+                PdfOptions = new PdfCore.PdfOptions {
+                    DefaultFontSize = 9D
+                }
+            });
+        }
+
+        PdfCore.PageBlock page = Assert.IsType<PdfCore.PageBlock>(Assert.Single(pdfDocument.Blocks));
+        PdfCore.TableBlock table = Assert.Single(page.Blocks.OfType<PdfCore.TableBlock>());
+        PdfCore.PdfTableStyle style = table.Style!;
+
+        Assert.Equal(4D, style.CellPaddingX);
+        Assert.Equal(3D, style.CellPaddingY);
+        Assert.Equal(PdfCore.PdfColor.FromRgb(230, 238, 247), style.HeaderFill);
+        Assert.Equal(PdfCore.PdfColor.FromRgb(31, 78, 121), style.HeaderTextColor);
+        Assert.Equal(PdfCore.PdfColor.FromRgb(248, 250, 252), style.RowStripeFill);
+    }
+
+    [Fact]
     public void SaveAsPdf_ExcelWorkbook_Respects_Selected_Sheets() {
         string workbookPath = Path.Combine(_directoryWithFiles, "ExcelPdfSelectedSheets.xlsx");
 

--- a/OfficeIMO.Tests/Pdf/PdfDocumentVisualQualityDefaultStyleTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentVisualQualityDefaultStyleTests.cs
@@ -99,6 +99,7 @@ public partial class PdfDocumentVisualQualityTests {
 
         PdfOptions clone = options.Clone();
 
+        Assert.True(options.HasExplicitDefaultTableStyle);
         Assert.Equal(0.8, options.DefaultTableStyle!.BorderWidth);
         Assert.Equal(12, options.DefaultTableStyle.CellPaddingX);
         Assert.Equal(new PdfColor(0.11, 0.22, 0.33), options.DefaultTableStyle.RowSeparatorColor);
@@ -116,6 +117,9 @@ public partial class PdfDocumentVisualQualityTests {
         Assert.Equal(180, clone.DefaultTableStyle.MaxWidth);
         Assert.Equal(24, clone.DefaultTableStyle.LeftIndent);
         Assert.True(clone.DefaultTableStyle.KeepWithNext);
+        Assert.True(clone.HasExplicitDefaultTableStyle);
+        Assert.False(new PdfOptions().HasExplicitDefaultTableStyle);
+        Assert.False(new PdfOptions().Clone().HasExplicitDefaultTableStyle);
     }
 
     [Fact]

--- a/OfficeIMO.Tests/Pdf/PowerPoint.SaveAsPdf.cs
+++ b/OfficeIMO.Tests/Pdf/PowerPoint.SaveAsPdf.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -1001,6 +1002,91 @@ public class PowerPointSaveAsPdfTests {
         Assert.Contains("Metric", text, StringComparison.Ordinal);
         Assert.Contains("Quality", text, StringComparison.Ordinal);
         Assert.Contains("99", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ToPdfDocument_PowerPointPresentation_Uses_Configured_Default_Table_Style() {
+        using var stream = new MemoryStream();
+        using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
+        presentation.SlideSize.SetSizePoints(260, 180);
+        PowerPointTable table = presentation.Slides[0].AddTablePoints(2, 2, 30, 34, 150, 70);
+        table.FirstRow = true;
+        table.BandedRows = false;
+        table.SetColumnWidthsPoints(90, 60);
+        table.SetRowHeightsPoints(28, 42);
+        table.GetCell(0, 0).Text = "Metric";
+        table.GetCell(0, 1).Text = "Score";
+        table.GetCell(1, 0).Text = "Quality";
+        table.GetCell(1, 1).Text = "99";
+
+        var configuredStyle = new PdfCore.PdfTableStyle {
+            CellPaddingX = 8D,
+            CellPaddingY = 6D,
+            BorderColor = null,
+            HeaderFill = PdfCore.PdfColor.FromRgb(10, 20, 30),
+            HeaderTextColor = PdfCore.PdfColor.FromRgb(240, 245, 250),
+            RowStripeFill = PdfCore.PdfColor.FromRgb(220, 235, 250),
+            CellFills = new Dictionary<(int Row, int Column), PdfCore.PdfColor> {
+                [(1, 1)] = PdfCore.PdfColor.FromRgb(200, 210, 220)
+            },
+            FontSize = 12.5D,
+            SpacingAfter = 11D
+        };
+
+        PdfCore.PdfDocument pdfDocument = presentation.ToPdfDocument(new PowerPointPdfSaveOptions {
+            PdfOptions = new PdfCore.PdfOptions {
+                DefaultTableStyle = configuredStyle
+            }
+        });
+
+        var canvas = Assert.IsType<PdfCore.PdfCanvasBlock>(Assert.Single(pdfDocument.Blocks));
+        PdfCore.PdfCanvasTableItem tableItem = Assert.Single(canvas.Items.OfType<PdfCore.PdfCanvasTableItem>());
+        Assert.NotNull(tableItem.Block.Style);
+        PdfCore.PdfTableStyle style = tableItem.Block.Style!;
+
+        Assert.Equal(1, style.HeaderRowCount);
+        Assert.Equal(8D, style.CellPaddingX);
+        Assert.Equal(6D, style.CellPaddingY);
+        Assert.Null(style.BorderColor);
+        Assert.Equal(PdfCore.PdfColor.FromRgb(10, 20, 30), style.HeaderFill);
+        Assert.Equal(PdfCore.PdfColor.FromRgb(240, 245, 250), style.HeaderTextColor);
+        Assert.Null(style.RowStripeFill);
+        Assert.Equal(12.5D, style.FontSize);
+        Assert.Equal(11D, style.SpacingAfter);
+        Assert.Equal(new double?[] { 90D, 60D }, style.ColumnWidthPoints);
+        Assert.Equal(new double?[] { 28D, 42D }, style.RowMinHeights);
+
+        Assert.Equal(PdfCore.PdfColor.FromRgb(220, 235, 250), configuredStyle.RowStripeFill);
+        Assert.Null(configuredStyle.ColumnWidthPoints);
+        Assert.Null(configuredStyle.RowMinHeights);
+        Assert.NotNull(style.CellFills);
+        Assert.Equal(PdfCore.PdfColor.FromRgb(200, 210, 220), style.CellFills![(1, 1)]);
+        Assert.Equal(PdfCore.PdfColor.FromRgb(200, 210, 220), configuredStyle.CellFills![(1, 1)]);
+    }
+
+    [Fact]
+    public void ToPdfDocument_PowerPointPresentation_Resets_Repeating_Header_Count_From_Slide_Table() {
+        using var stream = new MemoryStream();
+        using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
+        presentation.SlideSize.SetSizePoints(260, 180);
+        PowerPointTable table = presentation.Slides[0].AddTablePoints(1, 1, 30, 34, 150, 40);
+        table.FirstRow = false;
+        table.GetCell(0, 0).Text = "Value";
+
+        PdfCore.PdfDocument pdfDocument = presentation.ToPdfDocument(new PowerPointPdfSaveOptions {
+            PdfOptions = new PdfCore.PdfOptions {
+                DefaultTableStyle = new PdfCore.PdfTableStyle {
+                    HeaderRowCount = 2,
+                    RepeatHeaderRowCount = 2
+                }
+            }
+        });
+
+        var canvas = Assert.IsType<PdfCore.PdfCanvasBlock>(Assert.Single(pdfDocument.Blocks));
+        PdfCore.PdfTableStyle style = Assert.Single(canvas.Items.OfType<PdfCore.PdfCanvasTableItem>()).Block.Style!;
+
+        Assert.Equal(0, style.HeaderRowCount);
+        Assert.Equal(0, style.RepeatHeaderRowCount);
     }
 
     [Fact]

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.TableStyleMapping.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.TableStyleMapping.cs
@@ -43,6 +43,148 @@ public partial class Word {
     }
 
     [Fact]
+    public void SaveAsPdf_OfficeIMOEngine_Uses_Configured_Default_Table_Style_For_Unstyled_Native_Table() {
+        using WordDocument document = WordDocument.Create(Path.Combine(_directoryWithFiles, "PdfNativeDefaultTableStyle.docx"));
+        WordTable table = document.AddTable(2, 2);
+        table._tableProperties!.TableStyle?.Remove();
+        table.Rows[0].RepeatHeaderRowAtTheTopOfEachPage = true;
+
+        var configuredStyle = new PdfCore.PdfTableStyle {
+            CellPaddingX = 8D,
+            CellPaddingY = 6D,
+            BorderColor = null,
+            HeaderFill = PdfCore.PdfColor.FromRgb(10, 20, 30),
+            HeaderTextColor = PdfCore.PdfColor.FromRgb(240, 245, 250),
+            RowStripeFill = null,
+            FontSize = 12.5D,
+            LineHeight = 1.4D,
+            SpacingAfter = 11D
+        };
+
+        PdfCore.PdfTableStyle style = CreateNativeTableStyleForTest(table, new PdfSaveOptions {
+            PdfOptions = new PdfCore.PdfOptions {
+                DefaultTableStyle = configuredStyle
+            }
+        });
+
+        Assert.Equal(1, style.HeaderRowCount);
+        Assert.Equal(1, style.RepeatHeaderRowCount);
+        Assert.Equal(8D, style.CellPaddingX);
+        Assert.Equal(6D, style.CellPaddingY);
+        Assert.Null(style.BorderColor);
+        Assert.Equal(PdfCore.PdfColor.FromRgb(10, 20, 30), style.HeaderFill);
+        Assert.Equal(PdfCore.PdfColor.FromRgb(240, 245, 250), style.HeaderTextColor);
+        Assert.Null(style.RowStripeFill);
+        Assert.Equal(12.5D, style.FontSize);
+        Assert.Equal(1.4D, style.LineHeight);
+        Assert.Equal(11D, style.SpacingAfter);
+
+        Assert.Null(table.Style);
+        Assert.Null(configuredStyle.CellBorders);
+        Assert.Null(configuredStyle.MaxWidth);
+    }
+
+    [Fact]
+    public void SaveAsPdf_OfficeIMOEngine_Clones_Configured_Default_Table_Style_For_Native_Table() {
+        using WordDocument document = WordDocument.Create(Path.Combine(_directoryWithFiles, "PdfNativeDefaultTableStyleClone.docx"));
+        WordTable table = document.AddTable(1, 1);
+        table._tableProperties!.TableStyle?.Remove();
+        table.WidthType = TableWidthUnitValues.Dxa;
+        table.Width = 1440;
+        table._tableProperties.TableCellSpacing = new TableCellSpacing { Width = "120", Type = TableWidthUnitValues.Dxa };
+
+        var configuredStyle = new PdfCore.PdfTableStyle {
+            HeaderRowCount = 0,
+            RepeatHeaderRowCount = 0,
+            CellPaddingX = 8D,
+            CellPaddingY = 6D,
+            FontSize = null,
+            LineHeight = null,
+            BorderColor = null
+        };
+
+        PdfCore.PdfTableStyle style = CreateNativeTableStyleForTest(table, new PdfSaveOptions {
+            PdfOptions = new PdfCore.PdfOptions {
+                DefaultTableStyle = configuredStyle
+            }
+        });
+
+        Assert.Equal(72D, style.MaxWidth);
+        Assert.Equal(6D, style.CellSpacing);
+        Assert.Null(style.FontSize);
+        Assert.Null(style.LineHeight);
+
+        Assert.Equal(0, configuredStyle.HeaderRowCount);
+        Assert.Equal(0, configuredStyle.RepeatHeaderRowCount);
+        Assert.Equal(0D, configuredStyle.CellSpacing);
+        Assert.Null(configuredStyle.MaxWidth);
+        Assert.Null(configuredStyle.FontSize);
+        Assert.Null(configuredStyle.LineHeight);
+    }
+
+    [Fact]
+    public void SaveAsPdf_OfficeIMOEngine_Preserves_Explicit_TableGrid_When_Default_Table_Style_Is_Configured() {
+        using WordDocument document = WordDocument.Create(Path.Combine(_directoryWithFiles, "PdfNativeExplicitTableGrid.docx"));
+        WordTable table = document.AddTable(1, 1, WordTableStyle.TableGrid);
+
+        PdfCore.PdfTableStyle style = CreateNativeTableStyleForTest(table, new PdfSaveOptions {
+            PdfOptions = new PdfCore.PdfOptions {
+                DefaultTableStyle = new PdfCore.PdfTableStyle {
+                    BorderColor = null,
+                    HeaderFill = PdfCore.PdfColor.FromRgb(10, 20, 30),
+                    FontSize = null,
+                    LineHeight = null
+                }
+            }
+        });
+
+        Assert.Equal(PdfCore.PdfColor.Black, style.BorderColor);
+        Assert.Null(style.HeaderFill);
+        Assert.Equal(10D, style.FontSize);
+        Assert.Equal(1.15D, style.LineHeight);
+    }
+
+    [Fact]
+    public void SaveAsPdf_OfficeIMOEngine_Applies_Native_Font_And_Padding_Fallbacks_To_Explicit_Word_Styles() {
+        using WordDocument document = WordDocument.Create(Path.Combine(_directoryWithFiles, "PdfNativeExplicitStyleFallbacks.docx"));
+        WordTable table = document.AddTable(1, 1, WordTableStyle.GridTable1Light);
+
+        PdfCore.PdfTableStyle style = CreateNativeTableStyleForTest(table, new PdfSaveOptions {
+            PdfOptions = new PdfCore.PdfOptions {
+                DefaultTableStyle = new PdfCore.PdfTableStyle {
+                    CellPaddingTop = 12D,
+                    CellPaddingBottom = 13D,
+                    FontSize = null,
+                    LineHeight = null
+                }
+            }
+        });
+
+        Assert.Equal(10D, style.FontSize);
+        Assert.Equal(1.15D, style.LineHeight);
+        Assert.Equal(3D, style.CellPaddingTop);
+        Assert.Equal(3D, style.CellPaddingBottom);
+    }
+
+    [Fact]
+    public void SaveAsPdf_OfficeIMOEngine_Preserves_TableNormal_Mapping_For_Unrelated_PdfOptions() {
+        using WordDocument document = WordDocument.Create(Path.Combine(_directoryWithFiles, "PdfNativeTableNormalUnrelatedOptions.docx"));
+        WordTable table = document.AddTable(1, 1, WordTableStyle.TableNormal);
+
+        PdfCore.PdfTableStyle style = CreateNativeTableStyleForTest(table, new PdfSaveOptions {
+            PdfOptions = new PdfCore.PdfOptions {
+                DefaultFontSize = 9D
+            }
+        });
+
+        Assert.Null(style.BorderColor);
+        Assert.Equal(10D, style.FontSize);
+        Assert.Equal(1.15D, style.LineHeight);
+        Assert.Equal(3D, style.CellPaddingTop);
+        Assert.Equal(3D, style.CellPaddingBottom);
+    }
+
+    [Fact]
     public void SaveAsPdf_OfficeIMOEngine_Maps_Table_Row_Break_Policies() {
         using WordDocument document = WordDocument.Create(Path.Combine(_directoryWithFiles, "PdfNativeTableRowBreakPolicies.docx"));
         WordTable table = document.AddTable(2, 1);

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.TableStyles.Support.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.TableStyles.Support.cs
@@ -42,7 +42,11 @@ public partial class Word {
     }
 
     private static PdfCore.PdfTableStyle CreateNativeTableStyleForTest(WordTable table) {
+        return CreateNativeTableStyleForTest(table, null);
+    }
+
+    private static PdfCore.PdfTableStyle CreateNativeTableStyleForTest(WordTable table, PdfSaveOptions? options) {
         MethodInfo method = typeof(WordPdfConverterExtensions).GetMethod("CreateNativeTableStyle", BindingFlags.NonPublic | BindingFlags.Static)!;
-        return Assert.IsType<PdfCore.PdfTableStyle>(method.Invoke(null, new object?[] { table, table.Rows.Count, null }));
+        return Assert.IsType<PdfCore.PdfTableStyle>(method.Invoke(null, new object?[] { table, table.Rows.Count, options }));
     }
 }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Tables.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Tables.cs
@@ -142,11 +142,14 @@ namespace OfficeIMO.Word.Pdf {
         }
 
         private static PdfCore.PdfTableStyle CreateNativeTableStyle(WordTable table, int rowCount, PdfSaveOptions? options) {
-            PdfCore.PdfTableStyle style = ResolveNativeWordTableStyle(table) ?? new PdfCore.PdfTableStyle {
-                RowStripeFill = null
-            };
-            style.FontSize ??= 10D;
-            style.LineHeight ??= 1.15D;
+            bool hasExplicitDefaultTableStyle = options?.PdfOptions?.HasExplicitDefaultTableStyle == true;
+            PdfCore.PdfTableStyle? wordStyle = ResolveNativeWordTableStyle(table, hasExplicitDefaultTableStyle);
+            bool usesConfiguredDefaultStyle = wordStyle == null && hasExplicitDefaultTableStyle;
+            PdfCore.PdfTableStyle style = wordStyle ?? CreateNativeDefaultTableStyle(options);
+            if (!usesConfiguredDefaultStyle) {
+                style.FontSize ??= 10D;
+                style.LineHeight ??= 1.15D;
+            }
 
             int repeatedHeaderRowCount = GetNativeTableRepeatedHeaderRowCount(table, rowCount);
             style.HeaderRowCount = GetNativeTableVisualHeaderRowCount(table, rowCount, repeatedHeaderRowCount);
@@ -156,10 +159,23 @@ namespace OfficeIMO.Word.Pdf {
             }
 
             ApplyNativeTableBorders(table, style);
-            ApplyNativeTableDefaultCellMargins(table, style);
+            ApplyNativeTableDefaultCellMargins(table, style, usesConfiguredDefaultStyle);
             ApplyNativeTableLayoutOptions(table, style);
             ApplyNativeTableRowOptions(table, style);
             return style;
+        }
+
+        private static PdfCore.PdfTableStyle CreateNativeDefaultTableStyle(PdfSaveOptions? options) {
+            PdfCore.PdfTableStyle? configuredStyle = options?.PdfOptions?.HasExplicitDefaultTableStyle == true
+                ? options.PdfOptions.DefaultTableStyle
+                : null;
+            if (configuredStyle != null) {
+                return configuredStyle.Clone();
+            }
+
+            return new PdfCore.PdfTableStyle {
+                RowStripeFill = null
+            };
         }
 
         private static void ApplyNativeTableLayoutOptions(WordTable table, PdfCore.PdfTableStyle style) {
@@ -258,11 +274,14 @@ namespace OfficeIMO.Word.Pdf {
             return (ParseNativeColor(color) ?? PdfCore.PdfColor.Black, size / 8D);
         }
 
-        private static void ApplyNativeTableDefaultCellMargins(WordTable table, PdfCore.PdfTableStyle style) {
+        private static void ApplyNativeTableDefaultCellMargins(WordTable table, PdfCore.PdfTableStyle style, bool preserveConfiguredFallbackPadding) {
             W.TableCellMarginDefault? margins = table._tableProperties?.TableCellMarginDefault;
             if (margins == null) {
-                style.CellPaddingTop = 3D;
-                style.CellPaddingBottom = 3D;
+                if (!preserveConfiguredFallbackPadding) {
+                    style.CellPaddingTop = 3D;
+                    style.CellPaddingBottom = 3D;
+                }
+
                 return;
             }
 
@@ -275,8 +294,17 @@ namespace OfficeIMO.Word.Pdf {
                 ? null
                 : ConvertNativeTwipsToPoints(margins.TableCellRightMargin.Width.Value);
 
-            style.CellPaddingTop = top ?? 3D;
-            style.CellPaddingBottom = bottom ?? 3D;
+            if (top.HasValue) {
+                style.CellPaddingTop = top.Value;
+            } else if (!preserveConfiguredFallbackPadding) {
+                style.CellPaddingTop = 3D;
+            }
+
+            if (bottom.HasValue) {
+                style.CellPaddingBottom = bottom.Value;
+            } else if (!preserveConfiguredFallbackPadding) {
+                style.CellPaddingBottom = 3D;
+            }
 
             if (left.HasValue) {
                 style.CellPaddingLeft = left.Value;
@@ -392,9 +420,13 @@ namespace OfficeIMO.Word.Pdf {
             return height;
         }
 
-        private static PdfCore.PdfTableStyle? ResolveNativeWordTableStyle(WordTable table) {
+        private static PdfCore.PdfTableStyle? ResolveNativeWordTableStyle(WordTable table, bool preferConfiguredDefaultStyle) {
             WordTableStyle? wordStyle = table.Style;
             if (!wordStyle.HasValue) {
+                return null;
+            }
+
+            if (preferConfiguredDefaultStyle && IsNativeFallbackTableStyle(wordStyle.Value)) {
                 return null;
             }
 
@@ -402,6 +434,9 @@ namespace OfficeIMO.Word.Pdf {
                 ? style
                 : null;
         }
+
+        private static bool IsNativeFallbackTableStyle(WordTableStyle style) =>
+            style == WordTableStyle.TableNormal;
 
         private static int GetNativeTableVisualHeaderRowCount(WordTable table, int rowCount, int repeatedHeaderRowCount) {
             if (rowCount == 0) {


### PR DESCRIPTION
## Summary
- Respect `PdfOptions.DefaultTableStyle` during Excel-to-PDF table conversion, including empty workbook fallback tables.
- Extend the same default-table-style behavior to PowerPoint slide tables and Word native table fallback styles.
- Add regression coverage for Excel, PowerPoint, and Word PDF conversion table style options.

## Root Cause
Excel and sibling converters created explicit `PdfTableStyle` instances with converter-owned defaults before rendering tables, so caller-supplied `PdfOptions.DefaultTableStyle` values such as `RowStripeFill = null` could be ignored.

## Validation
- `dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore --filter "FullyQualifiedName~Excel.SaveAsPdf|FullyQualifiedName~Word.SaveAsPdf.TableStyleMapping|FullyQualifiedName~PowerPointSaveAsPdfTests" -v minimal /p:WarningLevel=0`
  - net8.0: 130/130 passed
  - net10.0: 130/130 passed
  - net472: 130/130 passed
- `git diff --check HEAD`

Closes #1922
