### PR TITLE
Harden document parsing security defaults

### DIFF
--- a/OfficeIMO.Drawing/OfficeImageReader.cs
+++ b/OfficeIMO.Drawing/OfficeImageReader.cs
@@ -133,7 +133,8 @@ public static class OfficeImageReader {
         int offset = 8;
         while (offset + 12 <= data.Length) {
             int length = ReadInt32BigEndian(data, offset);
-            if (length < 0 || offset + 12 + length > data.Length) {
+            long chunkEnd = (long)offset + 12L + length;
+            if (length < 0 || chunkEnd > data.Length) {
                 break;
             }
 
@@ -150,7 +151,7 @@ public static class OfficeImageReader {
                 break;
             }
 
-            offset += 12 + length;
+            offset = (int)chunkEnd;
         }
 
         info = new OfficeImageInfo(OfficeImageFormat.Png, width, height, dpiX, dpiY);

--- a/OfficeIMO.Html.Pdf/HtmlPdfResourcePolicySummary.cs
+++ b/OfficeIMO.Html.Pdf/HtmlPdfResourcePolicySummary.cs
@@ -74,7 +74,7 @@ public sealed class HtmlPdfResourcePolicySummary {
             return summary;
         }
 
-        WordHtml.HtmlToWordOptions wordOptions = options.WordHtmlOptions ?? WordHtml.HtmlToWordOptions.CreateOfficeIMOProfile();
+        WordHtml.HtmlToWordOptions wordOptions = options.WordHtmlOptions ?? new WordHtml.HtmlToWordOptions();
         summary.UsesWordHtmlPolicy = true;
         summary.AllowDocumentStylesheetLinks = wordOptions.AllowDocumentStylesheetLinks;
         summary.AllowedStylesheetUriSchemes = CopySorted(wordOptions.AllowedStylesheetUriSchemes);

--- a/OfficeIMO.Html/Rtf/Internal/RtfHtmlReader.Fields.cs
+++ b/OfficeIMO.Html/Rtf/Internal/RtfHtmlReader.Fields.cs
@@ -13,6 +13,10 @@ internal static partial class RtfHtmlReader {
                 return false;
             }
 
+            if (!IsHyperlinkFieldAllowed(token, instruction)) {
+                return false;
+            }
+
             RtfField field = EnsureInlineParagraph().AddField(instruction ?? string.Empty);
             ReadHyperlinkFieldData(token, field);
             ReadFormFieldData(token, field);
@@ -50,6 +54,50 @@ internal static partial class RtfHtmlReader {
                    string.Equals(marker, "start", StringComparison.OrdinalIgnoreCase);
         }
 
+        private bool IsHyperlinkFieldAllowed(IElement token, string? instruction) {
+            if (string.IsNullOrWhiteSpace(instruction)) {
+                return AreHyperlinkFieldTargetsAllowed(token, null);
+            }
+
+            var field = new RtfField(instruction!);
+            return AreHyperlinkFieldTargetsAllowed(token, field.HyperlinkField?.Target?.ToString());
+        }
+
+        private bool AreHyperlinkFieldTargetsAllowed(IElement token, string? instructionTarget) {
+            string? explicitTarget = GetAttribute(token, "data-officeimo-rtf-field-hyperlink");
+            string? href = GetAttribute(token, "href");
+            if (!IsHyperlinkFieldTargetAllowed(instructionTarget, "data-officeimo-rtf-field-instruction")) {
+                return false;
+            }
+
+            if (!IsHyperlinkFieldTargetAllowed(explicitTarget, "data-officeimo-rtf-field-hyperlink")) {
+                return false;
+            }
+
+            if (!IsFragmentHref(href) && !IsHyperlinkFieldTargetAllowed(href, "href")) {
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool IsHyperlinkFieldTargetAllowed(string? target, string source) {
+            if (string.IsNullOrWhiteSpace(target)) {
+                return true;
+            }
+
+            string resolved = HtmlUrlPolicyEvaluator.ResolveUrl(target, _baseUri, _options.UrlPolicy);
+            if (!string.IsNullOrWhiteSpace(resolved)) {
+                return true;
+            }
+
+            _options.AddDiagnostic(
+                "RtfHtmlFieldHyperlinkRejected",
+                "RTF hyperlink field target was rejected by the configured URL policy.",
+                source);
+            return false;
+        }
+
         private void ReadFormFieldData(IElement token, RtfField field) {
             if (!HasFormFieldData(token)) {
                 return;
@@ -80,11 +128,12 @@ internal static partial class RtfHtmlReader {
                    GetAttribute(token, "data-officeimo-rtf-form-dropdown-items") != null;
         }
 
-        private static void ReadHyperlinkFieldData(IElement token, RtfField field) {
+        private void ReadHyperlinkFieldData(IElement token, RtfField field) {
             string? explicitTarget = GetAttribute(token, "data-officeimo-rtf-field-hyperlink");
             string? href = GetAttribute(token, "href");
             string? target = explicitTarget ?? (IsFragmentHref(href) ? null : href);
-            if (!string.IsNullOrWhiteSpace(target) && Uri.TryCreate(target, UriKind.RelativeOrAbsolute, out Uri? uri)) {
+            Uri? uri = ReadUriValue(target);
+            if (uri != null) {
                 field.Hyperlink = uri;
             }
 

--- a/OfficeIMO.Html/Rtf/Internal/RtfHtmlReader.Fields.cs
+++ b/OfficeIMO.Html/Rtf/Internal/RtfHtmlReader.Fields.cs
@@ -59,8 +59,98 @@ internal static partial class RtfHtmlReader {
                 return AreHyperlinkFieldTargetsAllowed(token, null);
             }
 
+            if (!TryReadHyperlinkInstructionTargets(instruction!, out IReadOnlyList<string> instructionTargets)) {
+                return false;
+            }
+
             var field = new RtfField(instruction!);
-            return AreHyperlinkFieldTargetsAllowed(token, field.HyperlinkField?.Target?.ToString());
+            string? instructionTarget = instructionTargets.Count == 0
+                ? field.HyperlinkField?.Target?.ToString()
+                : instructionTargets[0];
+            return AreHyperlinkFieldTargetsAllowed(token, instructionTarget);
+        }
+
+        private bool TryReadHyperlinkInstructionTargets(string instruction, out IReadOnlyList<string> targets) {
+            targets = Array.Empty<string>();
+            IReadOnlyList<string> tokens = TokenizeRtfFieldInstruction(instruction);
+            if (tokens.Count == 0 || !string.Equals(tokens[0], "HYPERLINK", StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+
+            var values = new List<string>();
+            for (int index = 1; index < tokens.Count; index++) {
+                string token = tokens[index];
+                if (token.Length == 0) {
+                    continue;
+                }
+
+                if (token[0] == '\\') {
+                    if (RtfHyperlinkSwitchConsumesValue(token) && index + 1 < tokens.Count) {
+                        index++;
+                    }
+
+                    continue;
+                }
+
+                values.Add(token);
+            }
+
+            if (values.Count > 1) {
+                _options.AddDiagnostic(
+                    "RtfHtmlFieldHyperlinkRejected",
+                    "RTF hyperlink field instruction contains multiple targets.",
+                    "data-officeimo-rtf-field-instruction");
+                return false;
+            }
+
+            targets = values;
+            return true;
+        }
+
+        private static bool RtfHyperlinkSwitchConsumesValue(string token) =>
+            string.Equals(token, "\\l", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(token, "\\m", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(token, "\\n", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(token, "\\o", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(token, "\\t", StringComparison.OrdinalIgnoreCase);
+
+        private static IReadOnlyList<string> TokenizeRtfFieldInstruction(string instruction) {
+            var tokens = new List<string>();
+            int index = 0;
+            while (index < instruction.Length) {
+                while (index < instruction.Length && char.IsWhiteSpace(instruction[index])) {
+                    index++;
+                }
+
+                if (index >= instruction.Length) {
+                    break;
+                }
+
+                if (instruction[index] == '"') {
+                    index++;
+                    var quoted = new System.Text.StringBuilder();
+                    while (index < instruction.Length) {
+                        char c = instruction[index++];
+                        if (c == '"') {
+                            break;
+                        }
+
+                        quoted.Append(c);
+                    }
+
+                    tokens.Add(quoted.ToString());
+                    continue;
+                }
+
+                int start = index;
+                while (index < instruction.Length && !char.IsWhiteSpace(instruction[index])) {
+                    index++;
+                }
+
+                tokens.Add(instruction.Substring(start, index - start));
+            }
+
+            return tokens;
         }
 
         private bool AreHyperlinkFieldTargetsAllowed(IElement token, string? instructionTarget) {

--- a/OfficeIMO.Html/Rtf/Internal/RtfHtmlReader.cs
+++ b/OfficeIMO.Html/Rtf/Internal/RtfHtmlReader.cs
@@ -500,7 +500,10 @@ internal static partial class RtfHtmlReader {
         }
 
         private Uri? ReadUri(IElement token, string name) {
-            string? value = GetAttribute(token, name);
+            return ReadUriValue(GetAttribute(token, name));
+        }
+
+        private Uri? ReadUriValue(string? value) {
             if (string.IsNullOrWhiteSpace(value)) {
                 return null;
             }

--- a/OfficeIMO.Markdown.Pdf/MarkdownPdfConverterExtensions.Images.cs
+++ b/OfficeIMO.Markdown.Pdf/MarkdownPdfConverterExtensions.Images.cs
@@ -9,11 +9,6 @@ namespace OfficeIMO.Markdown.Pdf;
 /// </summary>
 public static partial class MarkdownPdfConverterExtensions {
     private static void RenderImageBlock(PdfCore.PdfDocument pdf, ImageBlock image, MarkdownPdfSaveOptions options) {
-        if (!options.IncludeLocalImages) {
-            RenderImagePlaceholder(pdf, image);
-            return;
-        }
-
         if (!TryReadImageBytes(image.Path, options, out byte[] bytes, out string sourceName, out string warningCode, out string warningMessage)) {
             AddWarning(options, warningCode, image.Path, warningMessage);
             RenderImagePlaceholder(pdf, image);
@@ -59,6 +54,12 @@ public static partial class MarkdownPdfConverterExtensions {
 
         if (TryCreateRemoteImageUri(path, out Uri? remoteUri)) {
             return TryReadRemoteImageBytes(remoteUri!, options, out bytes, out sourceName, out warningCode, out warningMessage);
+        }
+
+        if (!options.IncludeLocalImages) {
+            warningCode = "LocalImageDisabled";
+            warningMessage = "Local Markdown images are disabled by default. Set MarkdownPdfSaveOptions.IncludeLocalImages to true for trusted documents.";
+            return false;
         }
 
         string? resolvedPath = ResolveImagePath(path, options.BaseDirectory);

--- a/OfficeIMO.Markdown.Pdf/MarkdownPdfSaveOptions.cs
+++ b/OfficeIMO.Markdown.Pdf/MarkdownPdfSaveOptions.cs
@@ -64,8 +64,8 @@ public sealed class MarkdownPdfSaveOptions {
     /// <summary>Base directory used to resolve relative local image paths.</summary>
     public string? BaseDirectory { get; set; }
 
-    /// <summary>When true, supported local image files are embedded as PDF images.</summary>
-    public bool IncludeLocalImages { get; set; } = true;
+    /// <summary>When true, supported local image files are embedded as PDF images. Defaults to false for untrusted Markdown.</summary>
+    public bool IncludeLocalImages { get; set; }
 
     /// <summary>When true, supported base64 data URI images are embedded as PDF images.</summary>
     public bool IncludeDataUriImages { get; set; } = true;

--- a/OfficeIMO.Pdf/Core/PdfDocument.Blocks.ImageValidation.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocument.Blocks.ImageValidation.cs
@@ -3,6 +3,9 @@ using OfficeIMO.Drawing;
 namespace OfficeIMO.Pdf;
 
 public sealed partial class PdfDocument {
+    private const string SupportedImageMessage =
+        "PdfDocument.Image currently supports JPEG and grayscale/grayscale-alpha/indexed-color/RGB/RGBA PNG image bytes only, including Adam7-interlaced PNGs and supported 16-bit grayscale/grayscale-alpha/RGB/RGBA PNG payloads.";
+
     /// <summary>
     /// Checks whether image bytes can be embedded by the first-party PDF writer.
     /// </summary>
@@ -33,13 +36,20 @@ public sealed partial class PdfDocument {
                     return info;
                 }
 
-                throw new NotSupportedException(
-                    "PdfDocument.Image currently supports JPEG and grayscale/grayscale-alpha/indexed-color/RGB/RGBA PNG image bytes only, including Adam7-interlaced PNGs and supported 16-bit grayscale/grayscale-alpha/RGB/RGBA PNG payloads. " +
-                    unsupportedReason);
+                throw new NotSupportedException(SupportedImageMessage + " " + unsupportedReason);
             } else {
                 throw new NotSupportedException(
-                    $"PdfDocument.Image currently supports JPEG and grayscale/grayscale-alpha/indexed-color/RGB/RGBA PNG image bytes only, including Adam7-interlaced PNGs and supported 16-bit grayscale/grayscale-alpha/RGB/RGBA PNG payloads. Detected {info.Format} ({info.MimeType}).");
+                    $"{SupportedImageMessage} Detected {info.Format} ({info.MimeType}).");
             }
+        }
+
+        if (LooksLikePng(data)) {
+            string? unsupportedReason;
+            if (PdfWriter.TryGetPngImageData(data, out var image, out unsupportedReason)) {
+                return new OfficeImageInfo(OfficeImageFormat.Png, image.PixelWidth, image.PixelHeight);
+            }
+
+            throw new NotSupportedException(SupportedImageMessage + " " + unsupportedReason);
         }
 
         if (!LooksLikeJpeg(data)) {
@@ -48,6 +58,17 @@ public sealed partial class PdfDocument {
 
         return new OfficeImageInfo(OfficeImageFormat.Unknown, 0, 0);
     }
+
+    private static bool LooksLikePng(byte[] data) =>
+        data.Length >= 8 &&
+        data[0] == 137 &&
+        data[1] == 80 &&
+        data[2] == 78 &&
+        data[3] == 71 &&
+        data[4] == 13 &&
+        data[5] == 10 &&
+        data[6] == 26 &&
+        data[7] == 10;
 
     private static bool LooksLikeJpeg(byte[] data) {
         if (data.Length < 4)

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.XmpMetadata.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.XmpMetadata.cs
@@ -25,15 +25,16 @@ public sealed partial class PdfReadDocument {
             return null;
         }
 
-        byte[] decoded = StreamDecoder.Decode(stream.Dictionary, stream.Data, _objects);
-        string? rawXml = decoded.Length <= MaxXmpMetadataBytes ? DecodeMetadataText(decoded) : null;
+        bool decodedWithinLimit = StreamDecoder.TryDecode(stream.Dictionary, stream.Data, MaxXmpMetadataBytes, out byte[] decoded, _objects);
+        string? rawXml = decodedWithinLimit ? DecodeMetadataText(decoded) : null;
+        int decodedSizeBytes = decodedWithinLimit ? decoded.Length : MaxXmpMetadataBytes + 1;
         XDocument? document = rawXml is null ? null : TryParseXml(rawXml);
         return new PdfXmpMetadataInfo(
             objectNumber,
             TryReadName(stream.Dictionary, "Subtype"),
             TryReadStreamFilter(stream),
             stream.Data.Length,
-            decoded.Length,
+            decodedSizeBytes,
             StreamDecoder.GetUnsupportedFilters(stream.Dictionary, _objects).AsReadOnly(),
             rawXml,
             document is not null,

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.XmpMetadata.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.XmpMetadata.cs
@@ -1,3 +1,4 @@
+using System.Xml;
 using System.Xml.Linq;
 using OfficeIMO.Pdf.Filters;
 
@@ -6,6 +7,8 @@ namespace OfficeIMO.Pdf;
 public sealed partial class PdfReadDocument {
     private const string DublinCoreNamespaceUri = "http://purl.org/dc/elements/1.1/";
     private const string PdfAIdentificationNamespaceUri = "http://www.aiim.org/pdfa/ns/id/";
+    /// <summary>Maximum decoded XMP metadata size parsed as XML.</summary>
+    public const int MaxXmpMetadataBytes = 4_000_000;
 
     /// <summary>Catalog XMP metadata stream discovered from /Metadata.</summary>
     public PdfXmpMetadataInfo? XmpMetadata { get; }
@@ -23,8 +26,8 @@ public sealed partial class PdfReadDocument {
         }
 
         byte[] decoded = StreamDecoder.Decode(stream.Dictionary, stream.Data, _objects);
-        string? rawXml = DecodeMetadataText(decoded);
-        XDocument? document = TryParseXml(rawXml);
+        string? rawXml = decoded.Length <= MaxXmpMetadataBytes ? DecodeMetadataText(decoded) : null;
+        XDocument? document = rawXml is null ? null : TryParseXml(rawXml);
         return new PdfXmpMetadataInfo(
             objectNumber,
             TryReadName(stream.Dictionary, "Subtype"),
@@ -82,7 +85,14 @@ public sealed partial class PdfReadDocument {
         }
 
         try {
-            return XDocument.Parse(rawXml!, LoadOptions.None);
+            var settings = new XmlReaderSettings {
+                DtdProcessing = DtdProcessing.Prohibit,
+                MaxCharactersInDocument = MaxXmpMetadataBytes,
+                XmlResolver = null
+            };
+            using var stringReader = new StringReader(rawXml!);
+            using XmlReader reader = XmlReader.Create(stringReader, settings);
+            return XDocument.Load(reader, LoadOptions.None);
         } catch (Exception ex) when (ex is System.Xml.XmlException || ex is InvalidOperationException) {
             return null;
         }

--- a/OfficeIMO.Pdf/Reading/Core/ResourceResolver.cs
+++ b/OfficeIMO.Pdf/Reading/Core/ResourceResolver.cs
@@ -1,6 +1,9 @@
 namespace OfficeIMO.Pdf;
 
 internal static class ResourceResolver {
+    private const int MaxCidWidthEntries = 65536;
+    private const int MaxCidWidthRangeEntries = 4096;
+
     public static Dictionary<string, PdfFontResource> GetFontsForPage(PdfDictionary page, Dictionary<int, PdfIndirectObject> objects) {
         var fonts = new Dictionary<string, PdfFontResource>(System.StringComparer.Ordinal);
         var dict = GetInheritedDictionary(page, "Resources", objects);
@@ -103,14 +106,24 @@ internal static class ResourceResolver {
                 if (i >= wArr.Items.Count) break;
                 var next = wArr.Items[i];
                 if (next is PdfArray list) {
-                    for (int j = 0; j < list.Items.Count; j++) {
+                    int count = System.Math.Min(list.Items.Count, MaxCidWidthEntries - dict.Count);
+                    for (int j = 0; j < count; j++) {
                         if (list.Items[j] is PdfNumber wn) dict[startCid + j] = wn.Value; else dict[startCid + j] = dw;
                     }
                 } else if (next is PdfNumber endCidNum) {
                     int endCid = (int)endCidNum.Value; i++;
                     if (i >= wArr.Items.Count) break;
                     var wNum = wArr.Items[i] as PdfNumber; double wv = wNum?.Value ?? dw;
-                    for (int cid = startCid; cid <= endCid; cid++) dict[cid] = wv;
+                    int rangeLength = endCid >= startCid ? endCid - startCid + 1 : 0;
+                    if (rangeLength <= 0) continue;
+
+                    int count = System.Math.Min(rangeLength, MaxCidWidthRangeEntries);
+                    count = System.Math.Min(count, MaxCidWidthEntries - dict.Count);
+                    for (int offset = 0; offset < count; offset++) dict[startCid + offset] = wv;
+                }
+
+                if (dict.Count >= MaxCidWidthEntries) {
+                    break;
                 }
             }
         }

--- a/OfficeIMO.Pdf/Reading/Filters/Ascii85Decoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/Ascii85Decoder.cs
@@ -57,6 +57,73 @@ internal static class Ascii85Decoder {
         return output.ToArray();
     }
 
+    public static bool TryDecode(byte[] data, int maxOutputBytes, out byte[] outputBytes) {
+        outputBytes = Array.Empty<byte>();
+        if (maxOutputBytes < 0) {
+            return false;
+        }
+
+        if (data == null || data.Length == 0) {
+            return true;
+        }
+
+        using var output = new MemoryStream();
+        uint value = 0;
+        int count = 0;
+
+        for (int i = 0; i < data.Length; i++) {
+            byte b = data[i];
+            if (IsWhitespace(b)) {
+                continue;
+            }
+
+            if (b == (byte)'~') {
+                break;
+            }
+
+            if (b == (byte)'z') {
+                if (count != 0) {
+                    throw new FormatException("Invalid 'z' inside partial ASCII85 group.");
+                }
+
+                if (!TryWriteTuple(output, 0, 4, maxOutputBytes)) {
+                    return false;
+                }
+
+                continue;
+            }
+
+            if (b < (byte)'!' || b > (byte)'u') {
+                throw new FormatException($"Invalid ASCII85 character '{(char)b}'.");
+            }
+
+            value = checked(value * 85 + (uint)(b - (byte)'!'));
+            count++;
+
+            if (count == 5) {
+                if (!TryWriteTuple(output, value, 4, maxOutputBytes)) {
+                    return false;
+                }
+
+                value = 0;
+                count = 0;
+            }
+        }
+
+        if (count > 1) {
+            for (int i = count; i < 5; i++) {
+                value = checked(value * 85 + 84);
+            }
+
+            if (!TryWriteTuple(output, value, count - 1, maxOutputBytes)) {
+                return false;
+            }
+        }
+
+        outputBytes = output.ToArray();
+        return true;
+    }
+
     private static bool IsWhitespace(byte value) =>
         value == (byte)' ' || value == (byte)'\t' || value == (byte)'\r' || value == (byte)'\n' || value == (byte)'\f' || value == 0;
 
@@ -67,5 +134,14 @@ internal static class Ascii85Decoder {
         tuple[2] = (byte)(value >> 8);
         tuple[3] = (byte)value;
         output.Write(tuple, 0, bytesToWrite);
+    }
+
+    private static bool TryWriteTuple(Stream output, uint value, int bytesToWrite, int maxOutputBytes) {
+        if (output.Length + bytesToWrite > maxOutputBytes) {
+            return false;
+        }
+
+        WriteTuple(output, value, bytesToWrite);
+        return true;
     }
 }

--- a/OfficeIMO.Pdf/Reading/Filters/AsciiHexDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/AsciiHexDecoder.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.IO;
 
 namespace OfficeIMO.Pdf.Filters;
 
@@ -38,6 +39,54 @@ internal static class AsciiHexDecoder {
         }
 
         return bytes;
+    }
+
+    public static bool TryDecode(byte[] data, int maxOutputBytes, out byte[] output) {
+        output = Array.Empty<byte>();
+        if (maxOutputBytes < 0) {
+            return false;
+        }
+
+        if (data == null || data.Length == 0) {
+            return true;
+        }
+
+        using var stream = new MemoryStream();
+        int? highNibble = null;
+        for (int i = 0; i < data.Length; i++) {
+            char ch = (char)data[i];
+            if (char.IsWhiteSpace(ch)) {
+                continue;
+            }
+
+            if (ch == '>') {
+                break;
+            }
+
+            int nibble = HexNibble(ch);
+            if (highNibble is null) {
+                highNibble = nibble;
+                continue;
+            }
+
+            if (stream.Length >= maxOutputBytes) {
+                return false;
+            }
+
+            stream.WriteByte((byte)((highNibble.Value << 4) | nibble));
+            highNibble = null;
+        }
+
+        if (highNibble is not null) {
+            if (stream.Length >= maxOutputBytes) {
+                return false;
+            }
+
+            stream.WriteByte((byte)(highNibble.Value << 4));
+        }
+
+        output = stream.ToArray();
+        return true;
     }
 
     private static int HexNibble(char c) {

--- a/OfficeIMO.Pdf/Reading/Filters/FlateDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/FlateDecoder.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using System.IO.Compression;
 
 namespace OfficeIMO.Pdf.Filters;
@@ -6,43 +8,91 @@ internal static class FlateDecoder {
     public static byte[] Decode(byte[] data) {
         // Try zlib (RFC1950) first when available in this target
 #if NET6_0_OR_GREATER
-        if (TryZlib(data, out var result)) return result!;
+        if (TryZlib(data, maxOutputBytes: null, out var result)) return result!;
 #endif
         // Try raw Deflate
-        if (TryInflate(data, out var result2)) return result2!;
+        if (TryInflate(data, maxOutputBytes: null, out var result2)) return result2!;
         // Try skip zlib header (2 bytes) with raw Deflate
         if (data.Length > 2 && IsLikelyZlib(data)) {
             var sliced = new byte[data.Length - 2];
             Buffer.BlockCopy(data, 2, sliced, 0, sliced.Length);
-            if (TryInflate(sliced, out var result3)) return result3!;
+            if (TryInflate(sliced, maxOutputBytes: null, out var result3)) return result3!;
         }
         // Fallback to original
         return data;
     }
 
-    private static bool TryInflate(byte[] input, out byte[]? output) {
+    public static bool TryDecode(byte[] data, int maxOutputBytes, out byte[] output) {
+        if (maxOutputBytes < 0) {
+            output = Array.Empty<byte>();
+            return false;
+        }
+
+#if NET6_0_OR_GREATER
+        if (TryZlib(data, maxOutputBytes, out var result)) {
+            output = result!;
+            return true;
+        }
+#endif
+
+        if (TryInflate(data, maxOutputBytes, out var result2)) {
+            output = result2!;
+            return true;
+        }
+
+        if (data.Length > 2 && IsLikelyZlib(data)) {
+            var sliced = new byte[data.Length - 2];
+            Buffer.BlockCopy(data, 2, sliced, 0, sliced.Length);
+            if (TryInflate(sliced, maxOutputBytes, out var result3)) {
+                output = result3!;
+                return true;
+            }
+        }
+
+        if (data.Length <= maxOutputBytes) {
+            output = data;
+            return true;
+        }
+
+        output = Array.Empty<byte>();
+        return false;
+    }
+
+    private static bool TryInflate(byte[] input, int? maxOutputBytes, out byte[]? output) {
         try {
             using var msIn = new MemoryStream(input);
             using var ds = new DeflateStream(msIn, CompressionMode.Decompress, leaveOpen: true);
-            using var msOut = new MemoryStream();
-            ds.CopyTo(msOut);
-            output = msOut.ToArray();
-            return true;
+            return TryCopyToByteArray(ds, maxOutputBytes, out output);
         } catch { output = null; return false; }
     }
 
 #if NET6_0_OR_GREATER
-    private static bool TryZlib(byte[] input, out byte[]? output) {
+    private static bool TryZlib(byte[] input, int? maxOutputBytes, out byte[]? output) {
         try {
             using var msIn = new MemoryStream(input);
             using var zs = new ZLibStream(msIn, CompressionMode.Decompress, leaveOpen: true);
-            using var msOut = new MemoryStream();
-            zs.CopyTo(msOut);
-            output = msOut.ToArray();
-            return true;
+            return TryCopyToByteArray(zs, maxOutputBytes, out output);
         } catch { output = null; return false; }
     }
 #endif
+
+    private static bool TryCopyToByteArray(Stream source, int? maxOutputBytes, out byte[]? output) {
+        using var msOut = new MemoryStream();
+        var buffer = new byte[81920];
+        int read;
+        while ((read = source.Read(buffer, 0, buffer.Length)) > 0) {
+            if (maxOutputBytes.HasValue && msOut.Length + read > maxOutputBytes.Value) {
+                output = null;
+                return false;
+            }
+
+            msOut.Write(buffer, 0, read);
+        }
+
+        output = msOut.ToArray();
+        return true;
+    }
+
 
     private static bool IsLikelyZlib(byte[] d) {
         // RFC1950: first byte CMF low 4 bits = 8 for deflate; checksum of first two bytes mod 31 == 0

--- a/OfficeIMO.Pdf/Reading/Filters/FlateDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/FlateDecoder.cs
@@ -8,15 +8,15 @@ internal static class FlateDecoder {
     public static byte[] Decode(byte[] data) {
         // Try zlib (RFC1950) first when available in this target
 #if NET6_0_OR_GREATER
-        if (TryZlib(data, maxOutputBytes: null, out var result)) return result!;
+        if (TryZlib(data, maxOutputBytes: null, out var result, out _)) return result!;
 #endif
         // Try raw Deflate
-        if (TryInflate(data, maxOutputBytes: null, out var result2)) return result2!;
+        if (TryInflate(data, maxOutputBytes: null, out var result2, out _)) return result2!;
         // Try skip zlib header (2 bytes) with raw Deflate
         if (data.Length > 2 && IsLikelyZlib(data)) {
             var sliced = new byte[data.Length - 2];
             Buffer.BlockCopy(data, 2, sliced, 0, sliced.Length);
-            if (TryInflate(sliced, maxOutputBytes: null, out var result3)) return result3!;
+            if (TryInflate(sliced, maxOutputBytes: null, out var result3, out _)) return result3!;
         }
         // Fallback to original
         return data;
@@ -29,23 +29,38 @@ internal static class FlateDecoder {
         }
 
 #if NET6_0_OR_GREATER
-        if (TryZlib(data, maxOutputBytes, out var result)) {
+        if (TryZlib(data, maxOutputBytes, out var result, out bool zlibLimitExceeded)) {
             output = result!;
             return true;
         }
+
+        if (zlibLimitExceeded) {
+            output = Array.Empty<byte>();
+            return false;
+        }
 #endif
 
-        if (TryInflate(data, maxOutputBytes, out var result2)) {
+        if (TryInflate(data, maxOutputBytes, out var result2, out bool inflateLimitExceeded)) {
             output = result2!;
             return true;
+        }
+
+        if (inflateLimitExceeded) {
+            output = Array.Empty<byte>();
+            return false;
         }
 
         if (data.Length > 2 && IsLikelyZlib(data)) {
             var sliced = new byte[data.Length - 2];
             Buffer.BlockCopy(data, 2, sliced, 0, sliced.Length);
-            if (TryInflate(sliced, maxOutputBytes, out var result3)) {
+            if (TryInflate(sliced, maxOutputBytes, out var result3, out bool slicedLimitExceeded)) {
                 output = result3!;
                 return true;
+            }
+
+            if (slicedLimitExceeded) {
+                output = Array.Empty<byte>();
+                return false;
             }
         }
 
@@ -58,31 +73,41 @@ internal static class FlateDecoder {
         return false;
     }
 
-    private static bool TryInflate(byte[] input, int? maxOutputBytes, out byte[]? output) {
+    private static bool TryInflate(byte[] input, int? maxOutputBytes, out byte[]? output, out bool limitExceeded) {
         try {
             using var msIn = new MemoryStream(input);
             using var ds = new DeflateStream(msIn, CompressionMode.Decompress, leaveOpen: true);
-            return TryCopyToByteArray(ds, maxOutputBytes, out output);
-        } catch { output = null; return false; }
+            return TryCopyToByteArray(ds, maxOutputBytes, out output, out limitExceeded);
+        } catch {
+            output = null;
+            limitExceeded = false;
+            return false;
+        }
     }
 
 #if NET6_0_OR_GREATER
-    private static bool TryZlib(byte[] input, int? maxOutputBytes, out byte[]? output) {
+    private static bool TryZlib(byte[] input, int? maxOutputBytes, out byte[]? output, out bool limitExceeded) {
         try {
             using var msIn = new MemoryStream(input);
             using var zs = new ZLibStream(msIn, CompressionMode.Decompress, leaveOpen: true);
-            return TryCopyToByteArray(zs, maxOutputBytes, out output);
-        } catch { output = null; return false; }
+            return TryCopyToByteArray(zs, maxOutputBytes, out output, out limitExceeded);
+        } catch {
+            output = null;
+            limitExceeded = false;
+            return false;
+        }
     }
 #endif
 
-    private static bool TryCopyToByteArray(Stream source, int? maxOutputBytes, out byte[]? output) {
+    private static bool TryCopyToByteArray(Stream source, int? maxOutputBytes, out byte[]? output, out bool limitExceeded) {
+        limitExceeded = false;
         using var msOut = new MemoryStream();
         var buffer = new byte[81920];
         int read;
         while ((read = source.Read(buffer, 0, buffer.Length)) > 0) {
             if (maxOutputBytes.HasValue && msOut.Length + read > maxOutputBytes.Value) {
                 output = null;
+                limitExceeded = true;
                 return false;
             }
 

--- a/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
@@ -53,6 +53,76 @@ internal static class StreamDecoder {
         return current;
     }
 
+    public static bool TryDecode(PdfDictionary dict, byte[] data, int maxOutputBytes, out byte[] decoded, Dictionary<int, PdfIndirectObject>? objects = null) {
+        decoded = Array.Empty<byte>();
+        if (maxOutputBytes < 0) {
+            return false;
+        }
+
+        if (data == null || data.Length == 0 || !dict.Items.TryGetValue("Filter", out var filterObj)) {
+            return TryUseOriginal(data ?? Array.Empty<byte>(), maxOutputBytes, out decoded);
+        }
+
+        byte[] original = data;
+        byte[] current = data;
+        int filterIndex = 0;
+        foreach (string filterName in EnumerateFilters(filterObj, objects)) {
+            try {
+                switch (GetFilterKind(filterName)) {
+                    case DecodeFilterKind.Flate:
+                        if (!FlateDecoder.TryDecode(current, maxOutputBytes, out current)) {
+                            return false;
+                        }
+
+                        current = ApplyDecodeParms(dict, filterIndex, current, objects);
+                        if (!IsWithinLimit(current, maxOutputBytes)) {
+                            return false;
+                        }
+
+                        break;
+                    case DecodeFilterKind.AsciiHex:
+                        current = AsciiHexDecoder.Decode(current);
+                        if (!IsWithinLimit(current, maxOutputBytes)) {
+                            return false;
+                        }
+
+                        break;
+                    case DecodeFilterKind.Ascii85:
+                        current = Ascii85Decoder.Decode(current);
+                        if (!IsWithinLimit(current, maxOutputBytes)) {
+                            return false;
+                        }
+
+                        break;
+                    case DecodeFilterKind.RunLength:
+                        current = RunLengthDecoder.Decode(current);
+                        if (!IsWithinLimit(current, maxOutputBytes)) {
+                            return false;
+                        }
+
+                        break;
+                    case DecodeFilterKind.Lzw:
+                        current = LzwDecoder.Decode(current, GetEarlyChange(dict, filterIndex, objects));
+                        current = ApplyDecodeParms(dict, filterIndex, current, objects);
+                        if (!IsWithinLimit(current, maxOutputBytes)) {
+                            return false;
+                        }
+
+                        break;
+                    default:
+                        return TryUseOriginal(original, maxOutputBytes, out decoded);
+                }
+            } catch {
+                return TryUseOriginal(original, maxOutputBytes, out decoded);
+            }
+
+            filterIndex++;
+        }
+
+        decoded = current;
+        return true;
+    }
+
     internal static List<string> GetUnsupportedFilters(PdfDictionary dict, Dictionary<int, PdfIndirectObject>? objects = null) {
         if (!dict.Items.TryGetValue("Filter", out var filterObj)) {
             return new List<string>(0);
@@ -102,6 +172,20 @@ internal static class StreamDecoder {
         }
 
         return false;
+    }
+
+    private static bool TryUseOriginal(byte[] data, int maxOutputBytes, out byte[] decoded) {
+        if (!IsWithinLimit(data, maxOutputBytes)) {
+            decoded = Array.Empty<byte>();
+            return false;
+        }
+
+        decoded = data;
+        return true;
+    }
+
+    private static bool IsWithinLimit(byte[] data, int maxOutputBytes) {
+        return data.LongLength <= maxOutputBytes;
     }
 
     private static byte[] ApplyDecodeParms(PdfDictionary dict, int filterIndex, byte[] data, Dictionary<int, PdfIndirectObject>? objects) {

--- a/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
@@ -79,7 +79,25 @@ internal static class StreamDecoder {
 
                         break;
                     case DecodeFilterKind.AsciiHex:
+                        if (HasActiveDecodeParms(dict, filterIndex, objects)) {
+                            return false;
+                        }
+
+                        if (!AsciiHexDecoder.TryDecode(current, maxOutputBytes, out current)) {
+                            return false;
+                        }
+
+                        break;
                     case DecodeFilterKind.Ascii85:
+                        if (HasActiveDecodeParms(dict, filterIndex, objects)) {
+                            return false;
+                        }
+
+                        if (!Ascii85Decoder.TryDecode(current, maxOutputBytes, out current)) {
+                            return false;
+                        }
+
+                        break;
                     case DecodeFilterKind.RunLength:
                     case DecodeFilterKind.Lzw:
                         return false;

--- a/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
+++ b/OfficeIMO.Pdf/Reading/Filters/StreamDecoder.cs
@@ -63,57 +63,31 @@ internal static class StreamDecoder {
             return TryUseOriginal(data ?? Array.Empty<byte>(), maxOutputBytes, out decoded);
         }
 
-        byte[] original = data;
         byte[] current = data;
         int filterIndex = 0;
         foreach (string filterName in EnumerateFilters(filterObj, objects)) {
             try {
                 switch (GetFilterKind(filterName)) {
                     case DecodeFilterKind.Flate:
-                        if (!FlateDecoder.TryDecode(current, maxOutputBytes, out current)) {
+                        if (HasActiveDecodeParms(dict, filterIndex, objects)) {
                             return false;
                         }
 
-                        current = ApplyDecodeParms(dict, filterIndex, current, objects);
-                        if (!IsWithinLimit(current, maxOutputBytes)) {
+                        if (!FlateDecoder.TryDecode(current, maxOutputBytes, out current)) {
                             return false;
                         }
 
                         break;
                     case DecodeFilterKind.AsciiHex:
-                        current = AsciiHexDecoder.Decode(current);
-                        if (!IsWithinLimit(current, maxOutputBytes)) {
-                            return false;
-                        }
-
-                        break;
                     case DecodeFilterKind.Ascii85:
-                        current = Ascii85Decoder.Decode(current);
-                        if (!IsWithinLimit(current, maxOutputBytes)) {
-                            return false;
-                        }
-
-                        break;
                     case DecodeFilterKind.RunLength:
-                        current = RunLengthDecoder.Decode(current);
-                        if (!IsWithinLimit(current, maxOutputBytes)) {
-                            return false;
-                        }
-
-                        break;
                     case DecodeFilterKind.Lzw:
-                        current = LzwDecoder.Decode(current, GetEarlyChange(dict, filterIndex, objects));
-                        current = ApplyDecodeParms(dict, filterIndex, current, objects);
-                        if (!IsWithinLimit(current, maxOutputBytes)) {
-                            return false;
-                        }
-
-                        break;
+                        return false;
                     default:
-                        return TryUseOriginal(original, maxOutputBytes, out decoded);
+                        return false;
                 }
             } catch {
-                return TryUseOriginal(original, maxOutputBytes, out decoded);
+                return false;
             }
 
             filterIndex++;
@@ -186,6 +160,16 @@ internal static class StreamDecoder {
 
     private static bool IsWithinLimit(byte[] data, int maxOutputBytes) {
         return data.LongLength <= maxOutputBytes;
+    }
+
+    private static bool HasActiveDecodeParms(PdfDictionary dict, int filterIndex, Dictionary<int, PdfIndirectObject>? objects) {
+        var decodeParms = GetDecodeParms(dict, filterIndex, objects);
+        if (decodeParms is null) {
+            return false;
+        }
+
+        int predictor = (int)(decodeParms.Get<PdfNumber>("Predictor")?.Value ?? 1);
+        return predictor > 1;
     }
 
     private static byte[] ApplyDecodeParms(PdfDictionary dict, int filterIndex, byte[] data, Dictionary<int, PdfIndirectObject>? objects) {

--- a/OfficeIMO.Pdf/Reading/Font/ToUnicodeCMap.cs
+++ b/OfficeIMO.Pdf/Reading/Font/ToUnicodeCMap.cs
@@ -10,6 +10,7 @@ internal sealed class ToUnicodeCMap {
     private readonly Dictionary<string, string> _reverseMap = new(StringComparer.Ordinal);
     private int _maxKeyBytes = 1;
     private int _maxReverseTextLength = 1;
+    private int _processedMappings;
 
     public static bool TryParse(byte[] data, out ToUnicodeCMap? cmap) {
         try {
@@ -25,20 +26,36 @@ internal sealed class ToUnicodeCMap {
         var bfchar = new Regex(@"<(?<src>[0-9A-Fa-f]+)>\s+<(?<dst>[0-9A-Fa-f]+)>");
         foreach (Match section in Regex.Matches(s, @"beginbfchar([\s\S]*?)endbfchar", RegexOptions.IgnoreCase)) {
             foreach (Match m in bfchar.Matches(section.Groups[1].Value)) {
+                if (HasReachedMappingLimit()) {
+                    break;
+                }
+
                 AddMap(m.Groups["src"].Value, m.Groups["dst"].Value);
+            }
+
+            if (HasReachedMappingLimit()) {
+                break;
             }
         }
         // Handle beginbfrange / endbfrange, sequential mapping
         var bfrangeLine = new Regex(@"<(?<from>[0-9A-Fa-f]+)>\s+<(?<to>[0-9A-Fa-f]+)>\s+<(?<dst>[0-9A-Fa-f]+)>");
         foreach (Match section in Regex.Matches(s, @"beginbfrange([\s\S]*?)endbfrange", RegexOptions.IgnoreCase)) {
+            if (HasReachedMappingLimit()) {
+                break;
+            }
+
             string body = section.Groups[1].Value;
             string sequentialBody = Regex.Replace(body, @"<(?<from>[0-9A-Fa-f]+)>\s+<(?<to>[0-9A-Fa-f]+)>\s+\[(?<dsts>[\s\S]*?)\]", string.Empty, RegexOptions.IgnoreCase);
             foreach (Match m in bfrangeLine.Matches(sequentialBody)) {
+                if (HasReachedMappingLimit()) {
+                    break;
+                }
+
                 int from = Convert.ToInt32(m.Groups["from"].Value, 16);
                 int to = Convert.ToInt32(m.Groups["to"].Value, 16);
                 int dst = Convert.ToInt32(m.Groups["dst"].Value, 16);
                 int rangeLength = to >= from ? to - from + 1 : 0;
-                if (rangeLength <= 0 || rangeLength > MaxRangeMappings || _map.Count + rangeLength > MaxMappings) {
+                if (rangeLength <= 0 || rangeLength > MaxRangeMappings || _processedMappings + rangeLength > MaxMappings) {
                     continue;
                 }
 
@@ -51,6 +68,10 @@ internal sealed class ToUnicodeCMap {
             }
 
             foreach (Match m in Regex.Matches(body, @"<(?<from>[0-9A-Fa-f]+)>\s+<(?<to>[0-9A-Fa-f]+)>\s+\[(?<dsts>[\s\S]*?)\]", RegexOptions.IgnoreCase)) {
+                if (HasReachedMappingLimit()) {
+                    break;
+                }
+
                 int from = Convert.ToInt32(m.Groups["from"].Value, 16);
                 int to = Convert.ToInt32(m.Groups["to"].Value, 16);
                 int keyBytes = m.Groups["from"].Value.Length / 2;
@@ -60,7 +81,7 @@ internal sealed class ToUnicodeCMap {
                         break;
                     }
 
-                    if (_map.Count >= MaxMappings || code - from >= MaxRangeMappings) {
+                    if (HasReachedMappingLimit() || code - from >= MaxRangeMappings) {
                         break;
                     }
 
@@ -73,10 +94,11 @@ internal sealed class ToUnicodeCMap {
     }
 
     private void AddMap(string srcHex, string dstHex) {
-        if (_map.Count >= MaxMappings) {
+        if (HasReachedMappingLimit()) {
             return;
         }
 
+        _processedMappings++;
         srcHex = RemoveHexWhitespace(srcHex);
         dstHex = RemoveHexWhitespace(dstHex);
         if (srcHex.Length % 2 != 0) srcHex = "0" + srcHex;
@@ -93,6 +115,8 @@ internal sealed class ToUnicodeCMap {
             _reverseMap[s] = key;
         }
     }
+
+    private bool HasReachedMappingLimit() => _processedMappings >= MaxMappings;
 
     private static string RemoveHexWhitespace(string value) {
         bool hasWhitespace = false;

--- a/OfficeIMO.Pdf/Reading/Font/ToUnicodeCMap.cs
+++ b/OfficeIMO.Pdf/Reading/Font/ToUnicodeCMap.cs
@@ -3,6 +3,9 @@ using System.Text.RegularExpressions;
 namespace OfficeIMO.Pdf;
 
 internal sealed class ToUnicodeCMap {
+    private const int MaxMappings = 65536;
+    private const int MaxRangeMappings = 4096;
+
     private readonly Dictionary<string, string> _map = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, string> _reverseMap = new(StringComparer.Ordinal);
     private int _maxKeyBytes = 1;
@@ -34,6 +37,11 @@ internal sealed class ToUnicodeCMap {
                 int from = Convert.ToInt32(m.Groups["from"].Value, 16);
                 int to = Convert.ToInt32(m.Groups["to"].Value, 16);
                 int dst = Convert.ToInt32(m.Groups["dst"].Value, 16);
+                int rangeLength = to >= from ? to - from + 1 : 0;
+                if (rangeLength <= 0 || rangeLength > MaxRangeMappings || _map.Count + rangeLength > MaxMappings) {
+                    continue;
+                }
+
                 int keyBytes = m.Groups["from"].Value.Length / 2; // bytes per code
                 for (int code = from, u = dst; code <= to; code++, u++) {
                     string srcHex = code.ToString("X", System.Globalization.CultureInfo.InvariantCulture).PadLeft(keyBytes * 2, '0');
@@ -52,6 +60,10 @@ internal sealed class ToUnicodeCMap {
                         break;
                     }
 
+                    if (_map.Count >= MaxMappings || code - from >= MaxRangeMappings) {
+                        break;
+                    }
+
                     string srcHex = code.ToString("X", System.Globalization.CultureInfo.InvariantCulture).PadLeft(keyBytes * 2, '0');
                     AddMap(srcHex, destination);
                     code++;
@@ -61,6 +73,10 @@ internal sealed class ToUnicodeCMap {
     }
 
     private void AddMap(string srcHex, string dstHex) {
+        if (_map.Count >= MaxMappings) {
+            return;
+        }
+
         srcHex = RemoveHexWhitespace(srcHex);
         dstHex = RemoveHexWhitespace(dstHex);
         if (srcHex.Length % 2 != 0) srcHex = "0" + srcHex;

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Images.Interlace.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Images.Interlace.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using OfficeIMO.Pdf.Filters;
 
 namespace OfficeIMO.Pdf;
@@ -20,9 +22,14 @@ internal static partial class PdfWriter {
         }
 
         int bitsPerPixel = channels * bitDepth;
-        int fullRowBytes = GetPngRowByteCount(width, bitsPerPixel);
-        var fullRows = new byte[fullRowBytes * height];
-        byte[] decoded = FlateDecoder.Decode(compressedData);
+        if (!TryGetPngRowByteCount(width, bitsPerPixel, out int fullRowBytes) ||
+            !TryGetPngCheckedLength(fullRowBytes, height, 1, includeFilterByte: false, out int fullRowsLength) ||
+            !TryDecodePngData(compressedData, out byte[] decoded, out unsupportedReason)) {
+            unsupportedReason ??= "PNG dimensions exceed supported limits.";
+            return false;
+        }
+
+        var fullRows = new byte[fullRowsLength];
         int offset = 0;
 
         for (int pass = 0; pass < Adam7Passes.Length; pass++) {
@@ -33,8 +40,11 @@ internal static partial class PdfWriter {
                 continue;
             }
 
-            int passRowBytes = GetPngRowByteCount(passWidth, bitsPerPixel);
-            int passScanlineBytes = (passRowBytes + 1) * passHeight;
+            if (!TryGetPngRowByteCount(passWidth, bitsPerPixel, out int passRowBytes) ||
+                !TryGetPngScanlineLength(passRowBytes, passHeight, out int passScanlineBytes)) {
+                unsupportedReason = "PNG dimensions exceed supported limits.";
+                return false;
+            }
             if (offset + passScanlineBytes > decoded.Length) {
                 unsupportedReason = "PNG image data ended before all interlaced scanlines were decoded.";
                 return false;
@@ -54,7 +64,12 @@ internal static partial class PdfWriter {
             CopyAdam7PassPixels(passPixels, fullRows, width, bitDepth, bitsPerPixel, passWidth, passHeight, adam7Pass);
         }
 
-        var normalizedRows = new byte[(fullRowBytes + 1) * height];
+        if (!TryGetPngScanlineLength(fullRowBytes, height, out int normalizedRowsLength)) {
+            unsupportedReason = "PNG dimensions exceed supported limits.";
+            return false;
+        }
+
+        var normalizedRows = new byte[normalizedRowsLength];
         for (int row = 0; row < height; row++) {
             int sourceRow = row * fullRowBytes;
             int targetRow = row * (fullRowBytes + 1);
@@ -75,8 +90,10 @@ internal static partial class PdfWriter {
         int passWidth,
         int passHeight,
         Adam7Pass pass) {
-        int passRowBytes = GetPngRowByteCount(passWidth, bitsPerPixel);
-        int fullRowBytes = GetPngRowByteCount(width, bitsPerPixel);
+        if (!TryGetPngRowByteCount(passWidth, bitsPerPixel, out int passRowBytes) ||
+            !TryGetPngRowByteCount(width, bitsPerPixel, out int fullRowBytes)) {
+            return;
+        }
         if (bitDepth < 8) {
             for (int y = 0; y < passHeight; y++) {
                 int targetY = pass.YStart + y * pass.YStep;
@@ -132,8 +149,17 @@ internal static partial class PdfWriter {
         return ((length - start - 1) / step) + 1;
     }
 
-    private static int GetPngRowByteCount(int pixelCount, int bitsPerPixel) =>
-        (pixelCount * bitsPerPixel + 7) / 8;
+    private static bool TryGetPngRowByteCount(int pixelCount, int bitsPerPixel, out int rowBytes) {
+        rowBytes = 0;
+        long bits = (long)pixelCount * bitsPerPixel;
+        long bytes = (bits + 7L) / 8L;
+        if (bytes > int.MaxValue || bytes > MaxPngExpandedBytes) {
+            return false;
+        }
+
+        rowBytes = (int)bytes;
+        return true;
+    }
 
     private static void WritePackedPngSample(byte[] packedRows, int rowStart, int pixelIndex, int bitDepth, int sample) {
         int samplesPerByte = 8 / bitDepth;

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Images.Png16.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Images.Png16.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using OfficeIMO.Pdf.Filters;
 
 namespace OfficeIMO.Pdf;
@@ -51,10 +53,17 @@ internal static partial class PdfWriter {
             transparentBlue = colorType == 2 ? ReadUInt16BigEndian(transparency, 4) : -1;
         }
 
-        byte[] decoded = FlateDecoder.Decode(compressedData);
+        if (!TryDecodePngData(compressedData, out byte[] decoded, out unsupportedReason)) {
+            return false;
+        }
+
         int sourceBytesPerPixel = sourceChannels * 2;
-        int expectedRowLength = 1 + width * sourceBytesPerPixel;
-        if (decoded.Length < expectedRowLength * height) {
+        if (!TryGetPngCheckedLength(width, height, sourceBytesPerPixel, includeFilterByte: true, out int expectedLength)) {
+            unsupportedReason = "PNG dimensions exceed supported limits.";
+            return false;
+        }
+
+        if (decoded.Length < expectedLength) {
             unsupportedReason = "PNG image data ended before all 16-bit scanlines were decoded.";
             return false;
         }
@@ -63,8 +72,14 @@ internal static partial class PdfWriter {
             return false;
         }
 
-        byte[] baseRows = new byte[(1 + width * baseChannels) * height];
-        byte[]? alphaRows = hasIntrinsicAlpha || transparency != null ? new byte[(1 + width) * height] : null;
+        if (!TryGetPngCheckedLength(width, height, baseChannels, includeFilterByte: true, out int baseRowsLength) ||
+            !TryGetPngCheckedLength(width, height, 1, includeFilterByte: true, out int alphaRowsLength)) {
+            unsupportedReason = "PNG dimensions exceed supported limits.";
+            return false;
+        }
+
+        byte[] baseRows = new byte[baseRowsLength];
+        byte[]? alphaRows = hasIntrinsicAlpha || transparency != null ? new byte[alphaRowsLength] : null;
 
         for (int row = 0; row < height; row++) {
             int baseRowStart = row * (1 + width * baseChannels);

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Images.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Images.cs
@@ -1,3 +1,7 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Linq;
 using System.Globalization;
 using OfficeIMO.Drawing;
 using OfficeIMO.Pdf.Filters;
@@ -5,6 +9,10 @@ using OfficeIMO.Pdf.Filters;
 namespace OfficeIMO.Pdf;
 
 internal static partial class PdfWriter {
+    private const long MaxPngPixelCount = 100_000_000L;
+    private const long MaxPngExpandedBytes = 256L * 1024L * 1024L;
+    private const int MaxPngDecodedBytes = 256 * 1024 * 1024;
+
     internal sealed class PdfImageStream {
         public byte[] Data { get; set; } = Array.Empty<byte>();
         public string DictionarySuffix { get; set; } = string.Empty;
@@ -43,6 +51,11 @@ internal static partial class PdfWriter {
 
             string type = Encoding.ASCII.GetString(data, offset + 4, 4);
             int chunkData = offset + 8;
+            if (!IsPngChunkCrcValid(data, offset, length)) {
+                unsupportedReason = "PNG chunk CRC is invalid.";
+                return false;
+            }
+
             if (type == "IHDR") {
                 if (length < 13) {
                     unsupportedReason = "PNG IHDR chunk is invalid.";
@@ -113,6 +126,10 @@ internal static partial class PdfWriter {
 
         if (transparency != null && (colorType == 4 || colorType == 6)) {
             unsupportedReason = "PNG transparency chunks are not valid for grayscale-alpha or RGBA PNG images.";
+            return false;
+        }
+
+        if (!TryValidatePngResourceLimits(width, height, bitDepth, colorType, out unsupportedReason)) {
             return false;
         }
 
@@ -198,8 +215,16 @@ internal static partial class PdfWriter {
             return false;
         }
 
-        byte[] decoded = FlateDecoder.Decode(compressedData);
-        if (decoded.Length < (1 + width * sourceChannels) * height) {
+        if (!TryDecodePngData(compressedData, out byte[] decoded, out unsupportedReason)) {
+            return false;
+        }
+
+        if (!TryGetPngCheckedLength(width, height, sourceChannels, includeFilterByte: true, out int expectedLength)) {
+            unsupportedReason = "PNG dimensions exceed supported limits.";
+            return false;
+        }
+
+        if (decoded.Length < expectedLength) {
             unsupportedReason = "PNG image data ended before all transparency scanlines were decoded.";
             return false;
         }
@@ -208,8 +233,14 @@ internal static partial class PdfWriter {
             return false;
         }
 
-        byte[] baseRows = new byte[(1 + width * sourceChannels) * height];
-        byte[] alphaRows = new byte[(1 + width) * height];
+        if (!TryGetPngCheckedLength(width, height, sourceChannels, includeFilterByte: true, out int baseRowsLength) ||
+            !TryGetPngCheckedLength(width, height, 1, includeFilterByte: true, out int alphaRowsLength)) {
+            unsupportedReason = "PNG dimensions exceed supported limits.";
+            return false;
+        }
+
+        byte[] baseRows = new byte[baseRowsLength];
+        byte[] alphaRows = new byte[alphaRowsLength];
         int transparentGray = ReadUInt16BigEndian(transparency, 0);
         int transparentRed = colorType == 2 ? ReadUInt16BigEndian(transparency, 0) : -1;
         int transparentGreen = colorType == 2 ? ReadUInt16BigEndian(transparency, 2) : -1;
@@ -271,9 +302,17 @@ internal static partial class PdfWriter {
             }
         }
 
-        byte[] decoded = FlateDecoder.Decode(compressedData);
-        int packedRowBytes = ((width * bitDepth) + 7) / 8;
-        if (decoded.Length < (packedRowBytes + 1) * height) {
+        if (!TryDecodePngData(compressedData, out byte[] decoded, out unsupportedReason)) {
+            return false;
+        }
+
+        if (!TryGetPngRowByteCount(width, bitDepth, out int packedRowBytes) ||
+            !TryGetPngScanlineLength(packedRowBytes, height, out int expectedLength)) {
+            unsupportedReason = "PNG dimensions exceed supported limits.";
+            return false;
+        }
+
+        if (decoded.Length < expectedLength) {
             unsupportedReason = "PNG image data ended before all grayscale scanlines were decoded.";
             return false;
         }
@@ -282,8 +321,13 @@ internal static partial class PdfWriter {
             return false;
         }
 
-        byte[] baseRows = new byte[(1 + width) * height];
-        byte[]? alphaRows = transparency != null ? new byte[(1 + width) * height] : null;
+        if (!TryGetPngCheckedLength(width, height, 1, includeFilterByte: true, out int grayscaleRowsLength)) {
+            unsupportedReason = "PNG dimensions exceed supported limits.";
+            return false;
+        }
+
+        byte[] baseRows = new byte[grayscaleRowsLength];
+        byte[]? alphaRows = transparency != null ? new byte[grayscaleRowsLength] : null;
         for (int row = 0; row < height; row++) {
             int baseRowStart = row * (1 + width);
             int alphaRowStart = row * (1 + width);
@@ -336,9 +380,17 @@ internal static partial class PdfWriter {
             return false;
         }
 
-        byte[] decoded = FlateDecoder.Decode(compressedData);
-        int packedRowBytes = ((width * bitDepth) + 7) / 8;
-        if (decoded.Length < (packedRowBytes + 1) * height) {
+        if (!TryDecodePngData(compressedData, out byte[] decoded, out unsupportedReason)) {
+            return false;
+        }
+
+        if (!TryGetPngRowByteCount(width, bitDepth, out int packedRowBytes) ||
+            !TryGetPngScanlineLength(packedRowBytes, height, out int expectedLength)) {
+            unsupportedReason = "PNG dimensions exceed supported limits.";
+            return false;
+        }
+
+        if (decoded.Length < expectedLength) {
             unsupportedReason = "PNG image data ended before all indexed-color scanlines were decoded.";
             return false;
         }
@@ -347,8 +399,14 @@ internal static partial class PdfWriter {
             return false;
         }
 
-        byte[] baseRows = new byte[(1 + width * 3) * height];
-        byte[]? alphaRows = HasPaletteTransparency(paletteAlpha) ? new byte[(1 + width) * height] : null;
+        if (!TryGetPngCheckedLength(width, height, 3, includeFilterByte: true, out int rgbRowsLength) ||
+            !TryGetPngCheckedLength(width, height, 1, includeFilterByte: true, out int indexedAlphaRowsLength)) {
+            unsupportedReason = "PNG dimensions exceed supported limits.";
+            return false;
+        }
+
+        byte[] baseRows = new byte[rgbRowsLength];
+        byte[]? alphaRows = HasPaletteTransparency(paletteAlpha) ? new byte[indexedAlphaRowsLength] : null;
         for (int row = 0; row < height; row++) {
             int baseRowStart = row * (1 + width * 3);
             int alphaRowStart = row * (1 + width);
@@ -425,9 +483,15 @@ internal static partial class PdfWriter {
 
         int sourceChannels = colorType == 4 ? 2 : 4;
         int baseChannels = colorType == 4 ? 1 : 3;
-        byte[] decoded = FlateDecoder.Decode(compressedData);
-        int expectedRowLength = 1 + width * sourceChannels;
-        int expectedLength = expectedRowLength * height;
+        if (!TryDecodePngData(compressedData, out byte[] decoded, out unsupportedReason)) {
+            return false;
+        }
+
+        if (!TryGetPngCheckedLength(width, height, sourceChannels, includeFilterByte: true, out int expectedLength)) {
+            unsupportedReason = "PNG dimensions exceed supported limits.";
+            return false;
+        }
+
         if (decoded.Length < expectedLength) {
             unsupportedReason = "PNG image data ended before all alpha scanlines were decoded.";
             return false;
@@ -437,8 +501,14 @@ internal static partial class PdfWriter {
             return false;
         }
 
-        byte[] baseRows = new byte[(1 + width * baseChannels) * height];
-        byte[] alphaRows = new byte[(1 + width) * height];
+        if (!TryGetPngCheckedLength(width, height, baseChannels, includeFilterByte: true, out int alphaBaseRowsLength) ||
+            !TryGetPngCheckedLength(width, height, 1, includeFilterByte: true, out int splitAlphaRowsLength)) {
+            unsupportedReason = "PNG dimensions exceed supported limits.";
+            return false;
+        }
+
+        byte[] baseRows = new byte[alphaBaseRowsLength];
+        byte[] alphaRows = new byte[splitAlphaRowsLength];
         for (int row = 0; row < height; row++) {
             int baseRowStart = row * (1 + width * baseChannels);
             int alphaRowStart = row * (1 + width);
@@ -487,14 +557,20 @@ internal static partial class PdfWriter {
         rawPixels = Array.Empty<byte>();
         unsupportedReason = null;
 
-        int stride = width * bytesPerPixel;
-        int sourceRowLength = stride + 1;
-        if (decoded.Length < sourceRowLength * height) {
+        if (!TryGetPngCheckedLength(width, height, bytesPerPixel, includeFilterByte: false, out int rawLength) ||
+            !TryGetPngCheckedLength(width, height, bytesPerPixel, includeFilterByte: true, out int expectedLength)) {
+            unsupportedReason = "PNG dimensions exceed supported limits.";
+            return false;
+        }
+
+        int stride = rawLength / height;
+        int sourceRowLength = expectedLength / height;
+        if (decoded.Length < expectedLength) {
             unsupportedReason = "PNG scanline data is incomplete.";
             return false;
         }
 
-        rawPixels = new byte[stride * height];
+        rawPixels = new byte[rawLength];
         byte[] previous = new byte[stride];
         byte[] current = new byte[stride];
 
@@ -533,6 +609,67 @@ internal static partial class PdfWriter {
             Buffer.BlockCopy(current, 0, previous, 0, stride);
         }
 
+        return true;
+    }
+
+    private static bool TryDecodePngData(byte[] compressedData, out byte[] decoded, out string? unsupportedReason) {
+        if (!FlateDecoder.TryDecode(compressedData, MaxPngDecodedBytes, out decoded)) {
+            unsupportedReason = "PNG image data exceeds the supported decompressed size limit.";
+            return false;
+        }
+
+        unsupportedReason = null;
+        return true;
+    }
+
+    private static bool TryValidatePngResourceLimits(int width, int height, int bitDepth, int colorType, out string? unsupportedReason) {
+        unsupportedReason = null;
+        long pixels = (long)width * height;
+        if (pixels > MaxPngPixelCount) {
+            unsupportedReason = "PNG dimensions exceed the supported pixel count limit.";
+            return false;
+        }
+
+        if (!TryGetPngChannelCount(colorType, out int channels) ||
+            !TryGetPngRowByteCount(width, channels * bitDepth, out int rowBytes) ||
+            !TryGetPngScanlineLength(rowBytes, height, out int _)) {
+            unsupportedReason = "PNG dimensions exceed supported limits.";
+            return false;
+        }
+
+        int expandedChannels = colorType == 3 || colorType == 6 ? 4 : Math.Max(channels, 1);
+        if (colorType == 4) {
+            expandedChannels = 2;
+        }
+
+        if (!TryGetPngCheckedLength(width, height, expandedChannels, includeFilterByte: true, out int _)) {
+            unsupportedReason = "PNG dimensions exceed supported limits.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryGetPngCheckedLength(int width, int height, int channels, bool includeFilterByte, out int length) {
+        length = 0;
+        long rowLength = ((long)width * channels) + (includeFilterByte ? 1 : 0);
+        long totalLength = rowLength * height;
+        if (rowLength > int.MaxValue || totalLength > int.MaxValue || totalLength > MaxPngExpandedBytes) {
+            return false;
+        }
+
+        length = (int)totalLength;
+        return true;
+    }
+
+    private static bool TryGetPngScanlineLength(int rowBytes, int height, out int length) {
+        length = 0;
+        long totalLength = ((long)rowBytes + 1L) * height;
+        if (totalLength > int.MaxValue || totalLength > MaxPngExpandedBytes) {
+            return false;
+        }
+
+        length = (int)totalLength;
         return true;
     }
 
@@ -651,6 +788,34 @@ internal static partial class PdfWriter {
     internal static PdfStream BuildImageXObject(PdfImageStream image, int? softMaskObjectNumber = null) {
         return PdfImageXObjectDictionaryBuilder.BuildStreamObject(image, softMaskObjectNumber);
     }
+
+    private static bool IsPngChunkCrcValid(byte[] data, int chunkOffset, int chunkLength) {
+        int crcOffset = chunkOffset + 8 + chunkLength;
+        if (crcOffset + 4 > data.Length) {
+            return false;
+        }
+
+        uint expectedCrc = ReadUInt32BigEndian(data, crcOffset);
+        uint actualCrc = Crc32(data, chunkOffset + 4, chunkLength + 4);
+        return expectedCrc == actualCrc;
+    }
+
+    private static uint Crc32(byte[] data, int offset, int length) {
+        uint crc = 0xFFFFFFFF;
+        for (int i = 0; i < length; i++) {
+            crc ^= data[offset + i];
+            for (int bit = 0; bit < 8; bit++) {
+                crc = (crc & 1) == 1 ? (crc >> 1) ^ 0xEDB88320U : crc >> 1;
+            }
+        }
+
+        return ~crc;
+    }
+
+    private static uint ReadUInt32BigEndian(byte[] data, int offset) =>
+        offset + 4 <= data.Length
+            ? ((uint)data[offset] << 24) | ((uint)data[offset + 1] << 16) | ((uint)data[offset + 2] << 8) | data[offset + 3]
+            : 0;
 
     private static bool IsPng(byte[] data) =>
         data.Length >= 8 &&

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Images.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Images.cs
@@ -189,6 +189,10 @@ internal static partial class PdfWriter {
             return false;
         }
 
+        if (!TryValidatePngPassThroughData(streamData, width, height, colors, out unsupportedReason)) {
+            return false;
+        }
+
         image = new PdfImageStream {
             Data = streamData,
             PixelWidth = width,
@@ -200,6 +204,24 @@ internal static partial class PdfWriter {
                                width.ToString(CultureInfo.InvariantCulture) +
                                " >>"
         };
+        return true;
+    }
+
+    private static bool TryValidatePngPassThroughData(byte[] compressedData, int width, int height, int colors, out string? unsupportedReason) {
+        if (!TryDecodePngData(compressedData, out byte[] decoded, out unsupportedReason)) {
+            return false;
+        }
+
+        if (!TryGetPngCheckedLength(width, height, colors, includeFilterByte: true, out int expectedLength)) {
+            unsupportedReason = "PNG dimensions exceed supported limits.";
+            return false;
+        }
+
+        if (decoded.Length != expectedLength) {
+            unsupportedReason = "PNG image data length does not match the expected scanline size.";
+            return false;
+        }
+
         return true;
     }
 

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Images.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Images.cs
@@ -44,7 +44,8 @@ internal static partial class PdfWriter {
 
         while (offset + 12 <= data.Length) {
             int length = ReadInt32BigEndian(data, offset);
-            if (length < 0 || offset + 12 + length > data.Length) {
+            long chunkEnd = (long)offset + 12L + length;
+            if (length < 0 || chunkEnd > data.Length) {
                 unsupportedReason = "PNG chunk length is invalid.";
                 return false;
             }
@@ -86,7 +87,7 @@ internal static partial class PdfWriter {
                 break;
             }
 
-            offset += 12 + length;
+            offset = (int)chunkEnd;
         }
 
         if (width <= 0 || height <= 0) {
@@ -790,11 +791,12 @@ internal static partial class PdfWriter {
     }
 
     private static bool IsPngChunkCrcValid(byte[] data, int chunkOffset, int chunkLength) {
-        int crcOffset = chunkOffset + 8 + chunkLength;
-        if (crcOffset + 4 > data.Length) {
+        long crcOffsetLong = (long)chunkOffset + 8L + chunkLength;
+        if (crcOffsetLong < 0 || crcOffsetLong + 4L > data.Length) {
             return false;
         }
 
+        int crcOffset = (int)crcOffsetLong;
         uint expectedCrc = ReadUInt32BigEndian(data, crcOffset);
         uint actualCrc = Crc32(data, chunkOffset + 4, chunkLength + 4);
         return expectedCrc == actualCrc;

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Fonts.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Fonts.cs
@@ -50,18 +50,18 @@ public static partial class PowerPointPdfConverterExtensions {
             }
 
             int slideNumber = slideIndex + 1;
-            RegisterPresentationShapesFonts(slide.GetInheritedShapesForExport(), slideNumber, pageWidth, pageHeight, pdfOptions, registeredFamilies, registeredFontSlots, options);
-            RegisterPresentationShapesFonts(slide.Shapes, slideNumber, pageWidth, pageHeight, pdfOptions, registeredFamilies, registeredFontSlots, options);
+            RegisterPresentationShapesFonts(slide.GetInheritedShapesForExport(), slideNumber, pageWidth, pageHeight, pdfOptions, registeredFamilies, registeredFontSlots, options, groupDepth: 0);
+            RegisterPresentationShapesFonts(slide.Shapes, slideNumber, pageWidth, pageHeight, pdfOptions, registeredFamilies, registeredFontSlots, options, groupDepth: 0);
         }
     }
 
-    private static void RegisterPresentationShapesFonts(IReadOnlyList<PptCore.PowerPointShape> shapes, int slideNumber, double pageWidth, double pageHeight, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, PowerPointPdfSaveOptions options) {
+    private static void RegisterPresentationShapesFonts(IReadOnlyList<PptCore.PowerPointShape> shapes, int slideNumber, double pageWidth, double pageHeight, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, PowerPointPdfSaveOptions options, int groupDepth) {
         foreach (PptCore.PowerPointShape shape in shapes) {
-            RegisterPresentationShapeFonts(shape, slideNumber, pageWidth, pageHeight, pdfOptions, registeredFamilies, registeredFontSlots, options);
+            RegisterPresentationShapeFonts(shape, slideNumber, pageWidth, pageHeight, pdfOptions, registeredFamilies, registeredFontSlots, options, groupDepth);
         }
     }
 
-    private static void RegisterPresentationShapeFonts(PptCore.PowerPointShape shape, int slideNumber, double pageWidth, double pageHeight, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, PowerPointPdfSaveOptions options) {
+    private static void RegisterPresentationShapeFonts(PptCore.PowerPointShape shape, int slideNumber, double pageWidth, double pageHeight, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, PowerPointPdfSaveOptions options, int groupDepth) {
         if (shape.Hidden) {
             return;
         }
@@ -85,7 +85,9 @@ public static partial class PowerPointPdfConverterExtensions {
         }
 
         if (shape is PptCore.PowerPointGroupShape groupShape && groupShape.OwnerSlide != null) {
-            RegisterPresentationShapesFonts(groupShape.OwnerSlide.GetGroupChildren(groupShape), slideNumber, pageWidth, pageHeight, pdfOptions, registeredFamilies, registeredFontSlots, options);
+            if (options.MaxGroupShapeDepth < 0 || groupDepth < options.MaxGroupShapeDepth) {
+                RegisterPresentationShapesFonts(groupShape.OwnerSlide.GetGroupChildren(groupShape), slideNumber, pageWidth, pageHeight, pdfOptions, registeredFamilies, registeredFontSlots, options, groupDepth + 1);
+            }
         }
     }
 

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.cs
@@ -96,12 +96,12 @@ public static partial class PowerPointPdfConverterExtensions {
         pdf.Canvas(canvas => {
             RenderSlideBackground(canvas, slide, slideNumber, pageWidth, pageHeight, options);
 
-            RenderShapes(canvas, slide.GetInheritedShapesForExport(), slideNumber, pageWidth, pageHeight, options, warnInvalidBounds: false);
-            RenderShapes(canvas, slide.Shapes, slideNumber, pageWidth, pageHeight, options, warnInvalidBounds: true);
+            RenderShapes(canvas, slide.GetInheritedShapesForExport(), slideNumber, pageWidth, pageHeight, options, warnInvalidBounds: false, groupDepth: 0);
+            RenderShapes(canvas, slide.Shapes, slideNumber, pageWidth, pageHeight, options, warnInvalidBounds: true, groupDepth: 0);
         });
     }
 
-    private static void RenderShapes(PdfCore.PdfPageCanvas canvas, IReadOnlyList<PptCore.PowerPointShape> shapes, int slideNumber, double pageWidth, double pageHeight, PowerPointPdfSaveOptions options, bool warnInvalidBounds) {
+    private static void RenderShapes(PdfCore.PdfPageCanvas canvas, IReadOnlyList<PptCore.PowerPointShape> shapes, int slideNumber, double pageWidth, double pageHeight, PowerPointPdfSaveOptions options, bool warnInvalidBounds, int groupDepth) {
         foreach (PptCore.PowerPointShape shape in shapes) {
             if (shape.Hidden) {
                 continue;
@@ -111,7 +111,7 @@ public static partial class PowerPointPdfConverterExtensions {
                 continue;
             }
 
-            Action<PdfCore.PdfPageCanvas> render = target => RenderShapeContent(target, shape, x, y, width, height, slideNumber, pageWidth, pageHeight, options, warnInvalidBounds);
+            Action<PdfCore.PdfPageCanvas> render = target => RenderShapeContent(target, shape, x, y, width, height, slideNumber, pageWidth, pageHeight, options, warnInvalidBounds, groupDepth);
             if (TryGetVisibleSlideBox(x, y, width, height, pageWidth, pageHeight, out double clipX, out double clipY, out double clipWidth, out double clipHeight) &&
                 NeedsSlideClip(x, y, width, height, pageWidth, pageHeight)) {
                 canvas.Clip(clipX, clipY, clipWidth, clipHeight, render);
@@ -121,7 +121,7 @@ public static partial class PowerPointPdfConverterExtensions {
         }
     }
 
-    private static void RenderShapeContent(PdfCore.PdfPageCanvas canvas, PptCore.PowerPointShape shape, double x, double y, double width, double height, int slideNumber, double pageWidth, double pageHeight, PowerPointPdfSaveOptions options, bool warnInvalidBounds) {
+    private static void RenderShapeContent(PdfCore.PdfPageCanvas canvas, PptCore.PowerPointShape shape, double x, double y, double width, double height, int slideNumber, double pageWidth, double pageHeight, PowerPointPdfSaveOptions options, bool warnInvalidBounds, int groupDepth) {
         if (shape is PptCore.PowerPointTextBox textBox) {
             bool renderedGeometry = options.IncludeAutoShapes && RenderTextBoxGeometry(canvas, textBox, x, y, width, height);
             if (options.IncludeTextBoxes) {
@@ -160,7 +160,7 @@ public static partial class PowerPointPdfConverterExtensions {
 
         if (shape is PptCore.PowerPointGroupShape groupShape) {
             if (shape.OwnerSlide != null) {
-                RenderGroupShape(canvas, groupShape, slideNumber, pageWidth, pageHeight, options, warnInvalidBounds);
+                RenderGroupShape(canvas, groupShape, slideNumber, pageWidth, pageHeight, options, warnInvalidBounds, groupDepth);
             } else {
                 AddWarning(options, slideNumber, "unsupported-shape", "Skipped a PowerPoint group shape because its owning slide context could not be resolved.");
             }
@@ -170,7 +170,12 @@ public static partial class PowerPointPdfConverterExtensions {
         AddWarning(options, slideNumber, "unsupported-shape", "Skipped unsupported PowerPoint shape content type '" + shape.ShapeContentType + "'.");
     }
 
-    private static void RenderGroupShape(PdfCore.PdfPageCanvas canvas, PptCore.PowerPointGroupShape groupShape, int slideNumber, double pageWidth, double pageHeight, PowerPointPdfSaveOptions options, bool warnInvalidBounds) {
+    private static void RenderGroupShape(PdfCore.PdfPageCanvas canvas, PptCore.PowerPointGroupShape groupShape, int slideNumber, double pageWidth, double pageHeight, PowerPointPdfSaveOptions options, bool warnInvalidBounds, int groupDepth) {
+        if (options.MaxGroupShapeDepth >= 0 && groupDepth >= options.MaxGroupShapeDepth) {
+            AddWarning(options, slideNumber, "group-depth-limit", "Skipped nested PowerPoint group shape content because MaxGroupShapeDepth was reached.");
+            return;
+        }
+
         IReadOnlyList<PptCore.PowerPointShape> children = groupShape.OwnerSlide!.GetGroupChildren(groupShape);
         foreach (PptCore.PowerPointShape child in children) {
             if (child.Hidden) {
@@ -182,7 +187,7 @@ public static partial class PowerPointPdfConverterExtensions {
             }
 
             MapGroupChildBox(groupShape, ref x, ref y, ref width, ref height);
-            Action<PdfCore.PdfPageCanvas> render = target => RenderShapeContent(target, child, x, y, width, height, slideNumber, pageWidth, pageHeight, options, warnInvalidBounds);
+            Action<PdfCore.PdfPageCanvas> render = target => RenderShapeContent(target, child, x, y, width, height, slideNumber, pageWidth, pageHeight, options, warnInvalidBounds, groupDepth + 1);
             if (TryGetVisibleSlideBox(x, y, width, height, pageWidth, pageHeight, out double clipX, out double clipY, out double clipWidth, out double clipHeight) &&
                 NeedsSlideClip(x, y, width, height, pageWidth, pageHeight)) {
                 canvas.Clip(clipX, clipY, clipWidth, clipHeight, render);

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfSaveOptions.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfSaveOptions.cs
@@ -34,6 +34,9 @@ public sealed class PowerPointPdfSaveOptions {
     /// <summary>When true, slides marked hidden in PowerPoint are exported. Defaults to false.</summary>
     public bool IncludeHiddenSlides { get; set; }
 
+    /// <summary>Maximum nested group-shape depth rendered during PDF export. Defaults to 32.</summary>
+    public int MaxGroupShapeDepth { get; set; } = 32;
+
     private DrawingCore.OfficeImageFit _pictureFit = DrawingCore.OfficeImageFit.Stretch;
 
     /// <summary>

--- a/OfficeIMO.Reader.Yaml/DocumentReaderYamlExtensions.cs
+++ b/OfficeIMO.Reader.Yaml/DocumentReaderYamlExtensions.cs
@@ -47,14 +47,25 @@ public static class DocumentReaderYamlExtensions {
             cancellationToken,
             out var ownsParseStream);
         UpdateSourceMetadataFromSeekableStream(source, parseStream, effectiveReaderOptions.ComputeHashes);
+        long parseStartPosition = parseStream.CanSeek ? parseStream.Position : 0;
 
         YamlStream? yaml = null;
         string? parseError = null;
         try {
             try {
-                using var reader = new StreamReader(parseStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 4096, leaveOpen: true);
-                yaml = new YamlStream();
-                yaml.Load(reader);
+                parseStream.Position = parseStartPosition;
+                using (var preflightReader = new StreamReader(parseStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 4096, leaveOpen: true)) {
+                    if (!TryPreflightYaml(preflightReader, options, out var limitError)) {
+                        parseError = limitError;
+                    }
+                }
+
+                if (parseError == null) {
+                    parseStream.Position = parseStartPosition;
+                    using var reader = new StreamReader(parseStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 4096, leaveOpen: true);
+                    yaml = new YamlStream();
+                    yaml.Load(reader);
+                }
             } catch (Exception ex) when (ex is not OperationCanceledException) {
                 parseError = "YAML parse error: " + ex.GetType().Name + ".";
             }
@@ -99,6 +110,28 @@ public static class DocumentReaderYamlExtensions {
                 parseStream.Dispose();
             }
         }
+    }
+
+    private static bool TryPreflightYaml(TextReader reader, YamlReadOptions options, out string? limitError) {
+        limitError = null;
+        var parser = new Parser(reader);
+        int events = 0;
+        while (parser.MoveNext()) {
+            events++;
+            if (events > options.MaxParseEvents) {
+                limitError = "YAML parse limit exceeded: maximum parse event count reached.";
+                return false;
+            }
+
+            if (parser.Current is Scalar scalar &&
+                scalar.Value != null &&
+                scalar.Value.Length > options.MaxScalarLength) {
+                limitError = "YAML parse limit exceeded: scalar length exceeds maximum.";
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static IEnumerable<ReaderChunk> BuildStructuredChunks(
@@ -737,12 +770,16 @@ public static class DocumentReaderYamlExtensions {
             ChunkRows = source.ChunkRows,
             MaxDepth = source.MaxDepth,
             MaxNodes = source.MaxNodes,
+            MaxParseEvents = source.MaxParseEvents,
+            MaxScalarLength = source.MaxScalarLength,
             IncludeMarkdown = source.IncludeMarkdown
         };
 
         if (normalized.ChunkRows < 1) normalized.ChunkRows = 1;
         if (normalized.MaxDepth < 1) normalized.MaxDepth = 1;
         if (normalized.MaxNodes < 1) normalized.MaxNodes = 1;
+        if (normalized.MaxParseEvents < 1) normalized.MaxParseEvents = 1;
+        if (normalized.MaxScalarLength < 1) normalized.MaxScalarLength = 1;
 
         return normalized;
     }

--- a/OfficeIMO.Reader.Yaml/DocumentReaderYamlRegistrationExtensions.cs
+++ b/OfficeIMO.Reader.Yaml/DocumentReaderYamlRegistrationExtensions.cs
@@ -61,6 +61,8 @@ public static class DocumentReaderYamlRegistrationExtensions {
             ChunkRows = options.ChunkRows,
             MaxDepth = options.MaxDepth,
             MaxNodes = options.MaxNodes,
+            MaxParseEvents = options.MaxParseEvents,
+            MaxScalarLength = options.MaxScalarLength,
             IncludeMarkdown = options.IncludeMarkdown
         };
     }

--- a/OfficeIMO.Reader.Yaml/YamlReadOptions.cs
+++ b/OfficeIMO.Reader.Yaml/YamlReadOptions.cs
@@ -20,6 +20,16 @@ public sealed class YamlReadOptions {
     public int MaxNodes { get; set; } = 20_000;
 
     /// <summary>
+    /// Maximum number of YAML parse events accepted before the representation model is loaded.
+    /// </summary>
+    public int MaxParseEvents { get; set; } = 100_000;
+
+    /// <summary>
+    /// Maximum scalar value length accepted before the representation model is loaded.
+    /// </summary>
+    public int MaxScalarLength { get; set; } = 1_048_576;
+
+    /// <summary>
     /// Include markdown table previews in emitted chunks.
     /// </summary>
     public bool IncludeMarkdown { get; set; } = true;

--- a/OfficeIMO.Tests/ConversionOptions.cs
+++ b/OfficeIMO.Tests/ConversionOptions.cs
@@ -31,6 +31,7 @@ public class ConversionOptionsTests {
         Assert.Equal(8192, options.MaxCssBytes);
         Assert.Equal(16384, options.MaxTotalCssBytes);
         Assert.Equal(10000, options.MaxTableCells);
+        Assert.Equal(ImageProcessingMode.EmbedDataUriOnly, options.ImageProcessing);
         Assert.False(options.AllowDocumentStylesheetLinks);
         Assert.True(options.ValidateImageContentTypes);
         Assert.Contains("image/png", options.AllowedImageContentTypes);
@@ -51,6 +52,7 @@ public class ConversionOptionsTests {
         var options = new HtmlToWordOptions();
 
         Assert.Equal(50000, options.MaxTableCells);
+        Assert.Equal(ImageProcessingMode.EmbedDataUriOnly, options.ImageProcessing);
     }
 
     [Fact]

--- a/OfficeIMO.Tests/ConversionOptions.cs
+++ b/OfficeIMO.Tests/ConversionOptions.cs
@@ -35,6 +35,7 @@ public class ConversionOptionsTests {
         Assert.True(options.ValidateImageContentTypes);
         Assert.Contains("image/png", options.AllowedImageContentTypes);
         Assert.Contains("https", options.AllowedImageUriSchemes);
+        Assert.DoesNotContain("file", options.AllowedImageUriSchemes);
         Assert.Empty(options.AllowedImageHosts);
         Assert.True(options.ValidateStylesheetContentTypes);
         Assert.Contains("text/css", options.AllowedStylesheetContentTypes);
@@ -58,6 +59,7 @@ public class ConversionOptionsTests {
         Assert.False(defaultProfile.AllowDocumentStylesheetLinks);
         Assert.Equal(ImageProcessingMode.Embed, defaultProfile.ImageProcessing);
         Assert.Contains("https", defaultProfile.AllowedImageUriSchemes);
+        Assert.Contains("file", defaultProfile.AllowedImageUriSchemes);
         Assert.Contains("https", defaultProfile.AllowedStylesheetUriSchemes);
         Assert.True(defaultProfile.HyperlinkUrlPolicy.DisallowScriptUrls);
         Assert.True(defaultProfile.HyperlinkUrlPolicy.DisallowFileUrls);
@@ -81,6 +83,7 @@ public class ConversionOptionsTests {
         var trustedProfile = HtmlToWordOptions.CreateTrustedDocumentProfile();
         Assert.True(trustedProfile.AllowDocumentStylesheetLinks);
         Assert.Equal(ImageProcessingMode.Embed, trustedProfile.ImageProcessing);
+        Assert.Contains("file", trustedProfile.AllowedImageUriSchemes);
         Assert.True(trustedProfile.ValidateImageContentTypes);
         Assert.True(trustedProfile.ValidateStylesheetContentTypes);
     }

--- a/OfficeIMO.Tests/ConversionOptions.cs
+++ b/OfficeIMO.Tests/ConversionOptions.cs
@@ -41,7 +41,15 @@ public class ConversionOptionsTests {
         Assert.Contains("https", options.AllowedStylesheetUriSchemes);
         Assert.Contains("file", options.AllowedStylesheetUriSchemes);
         Assert.Empty(options.AllowedStylesheetHosts);
+        Assert.Equal(10000, options.MaxTableCells);
         Assert.True(options.EnableAccessibilityDiagnostics);
+    }
+
+    [Fact]
+    public void HtmlToWordOptions_DefaultsBoundTableExpansion() {
+        var options = new HtmlToWordOptions();
+
+        Assert.Equal(50000, options.MaxTableCells);
     }
 
     [Fact]
@@ -55,6 +63,7 @@ public class ConversionOptionsTests {
         Assert.True(defaultProfile.HyperlinkUrlPolicy.DisallowFileUrls);
         Assert.False(defaultProfile.HyperlinkUrlPolicy.AllowDataUrls);
         Assert.Null(defaultProfile.MaxHtmlNodes);
+        Assert.Null(defaultProfile.MaxTableCells);
 
         var untrustedProfile = HtmlToWordOptions.CreateUntrustedHtmlProfile();
         Assert.False(untrustedProfile.AllowDocumentStylesheetLinks);

--- a/OfficeIMO.Tests/Html.HtmlConverter.cs
+++ b/OfficeIMO.Tests/Html.HtmlConverter.cs
@@ -128,7 +128,7 @@ public partial class Html {
         string uri = new Uri(assetPath).AbsoluteUri;
         string html = $"<p><img src=\"{uri}\" /></p>";
         
-        var doc = html.LoadFromHtml(new HtmlToWordOptions());
+        var doc = html.LoadFromHtml(HtmlToWordOptions.CreateTrustedDocumentProfile());
         string roundTrip = doc.ToHtml(new WordToHtmlOptions());
 
         Assert.Contains("<img", roundTrip, StringComparison.OrdinalIgnoreCase);
@@ -342,7 +342,7 @@ public partial class Html {
         string uri = new Uri(assetPath).AbsoluteUri;
         string html = $"<p><img src=\"{uri}\" /></p>";
 
-        var doc = html.LoadFromHtml(new HtmlToWordOptions());
+        var doc = html.LoadFromHtml(HtmlToWordOptions.CreateTrustedDocumentProfile());
 
         Assert.Single(doc.Images);
     }

--- a/OfficeIMO.Tests/Html.Images.cs
+++ b/OfficeIMO.Tests/Html.Images.cs
@@ -88,11 +88,11 @@ namespace OfficeIMO.Tests {
             Assert.Single(doc.Paragraphs);
             Assert.Equal("Missing", doc.Paragraphs[0].Text);
             var diagnostic = Assert.Single(options.Diagnostics);
-            Assert.Equal("ImageLoadFailed", diagnostic.Code);
+            Assert.Equal("ImageSkippedByPolicy", diagnostic.Code);
             Assert.Equal(HtmlConversionDiagnosticSeverity.Warning, diagnostic.Severity);
             Assert.Equal("http://localhost:1/missing.png", diagnostic.Source);
-            Assert.Contains("image", diagnostic.Message, StringComparison.OrdinalIgnoreCase);
-            Assert.NotNull(diagnostic.Detail);
+            Assert.Contains("data URI", diagnostic.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Null(diagnostic.Detail);
             Assert.Same(diagnostic, Assert.Single(callbackDiagnostics));
         }
 
@@ -106,7 +106,7 @@ namespace OfficeIMO.Tests {
             Assert.Empty(doc.Images);
             Assert.Empty(doc.Paragraphs);
             var diagnostic = Assert.Single(options.Diagnostics);
-            Assert.Equal("ImageLoadFailed", diagnostic.Code);
+            Assert.Equal("ImageSkippedByPolicy", diagnostic.Code);
             Assert.Equal("http://localhost:1/missing.png", diagnostic.Source);
         }
 
@@ -115,9 +115,10 @@ namespace OfficeIMO.Tests {
             using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(_ =>
                 Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
                     Content = new ByteArrayContent(new byte[16])
-                })));
+            })));
             var options = new HtmlToWordOptions {
                 HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed,
                 MaxImageBytes = 4
             };
             string html = "<img src=\"https://example.test/large.png\" alt=\"Too large\" />";
@@ -143,7 +144,8 @@ namespace OfficeIMO.Tests {
                 return Task.FromResult(response);
             }));
             var options = new HtmlToWordOptions {
-                HttpClient = httpClient
+                HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed
             };
             string html = "<img src=\"https://example.test/not-image.png\" alt=\"Not image\" />";
 
@@ -166,7 +168,8 @@ namespace OfficeIMO.Tests {
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
             }));
             var options = new HtmlToWordOptions {
-                HttpClient = httpClient
+                HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed
             };
             options.AllowedImageUriSchemes.Remove(Uri.UriSchemeHttps);
             string html = "<img src=\"https://example.test/scheme.png\" alt=\"Blocked scheme\" />";
@@ -213,7 +216,8 @@ namespace OfficeIMO.Tests {
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
             }));
             var options = new HtmlToWordOptions {
-                HttpClient = httpClient
+                HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed
             };
             options.AllowedImageHosts.Add("images.example.test");
             string html = "<img src=\"https://other.example.test/host.png\" alt=\"Blocked host\" />";
@@ -245,7 +249,8 @@ namespace OfficeIMO.Tests {
                 });
             }));
             var options = new HtmlToWordOptions {
-                HttpClient = httpClient
+                HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed
             };
             options.AllowedImageHosts.Add("images.example.test");
             string html = """
@@ -279,7 +284,8 @@ namespace OfficeIMO.Tests {
                 });
             }));
             var options = new HtmlToWordOptions {
-                HttpClient = httpClient
+                HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed
             };
             options.AllowedImageHosts.Add("images.example.test");
             string html = """
@@ -313,7 +319,8 @@ namespace OfficeIMO.Tests {
                 });
             }));
             var options = new HtmlToWordOptions {
-                HttpClient = httpClient
+                HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed
             };
             options.AllowedImageHosts.Add("images.example.test");
             string html = """<img src="https://images.example.test/fallback.png" srcset="https://images.example.test/hero.png 1x" alt="Responsive image" />""";
@@ -337,7 +344,8 @@ namespace OfficeIMO.Tests {
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
             }));
             var options = new HtmlToWordOptions {
-                HttpClient = httpClient
+                HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed
             };
             string html = $"<img srcset=\"https://cdn.example.test/one.png 1x, https://cdn.example.test/two.png 2x, https://cdn.example.test/three.png 3x\" src=\"data:image/png;base64,{base64}\" alt=\"Logo\" />";
 
@@ -368,6 +376,7 @@ namespace OfficeIMO.Tests {
             }));
             var options = new HtmlToWordOptions {
                 HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed,
                 MaxRemoteImageCandidateProbes = null
             };
             string html = """<img srcset="https://cdn.example.test/one.png 1x, https://cdn.example.test/two.png 2x" alt="Logo" />""";
@@ -387,6 +396,7 @@ namespace OfficeIMO.Tests {
                 })));
             var options = new HtmlToWordOptions {
                 HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed,
                 MaxTotalImageBytes = 4
             };
             string html = "<img src=\"https://example.test/budget.png\" alt=\"Budget\" />";
@@ -415,6 +425,7 @@ namespace OfficeIMO.Tests {
             string html = $"<img src=\"data:image/png;base64,{validPng}\" alt=\"Valid\" /><img src=\"https://example.test/too-large.png\" alt=\"Too large\" />";
             var options = new HtmlToWordOptions {
                 HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed,
                 MaxTotalImageBytes = 80
             };
 
@@ -491,6 +502,7 @@ namespace OfficeIMO.Tests {
             string html = $"<img src=\"https://example.test/broken.png\" alt=\"Broken\" /><img src=\"data:image/png;base64,{validPng}\" alt=\"Valid\" />";
             var options = new HtmlToWordOptions {
                 HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed,
                 MaxTotalImageBytes = 70
             };
 
@@ -570,6 +582,7 @@ namespace OfficeIMO.Tests {
             string html = $"<img src=\"https://example.test/broken.svg\" alt=\"Broken svg\" /><img src=\"data:image/png;base64,{validPng}\" alt=\"Valid\" />";
             var options = new HtmlToWordOptions {
                 HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed,
                 MaxTotalImageBytes = 100
             };
 
@@ -1034,7 +1047,8 @@ namespace OfficeIMO.Tests {
             string base64 = Convert.ToBase64String(File.ReadAllBytes(path));
             string html = $"<img srcset=\"//cdn.example.test/missing.png 1x\" src=\"data:image/png;base64,{base64}\" alt=\"Logo\" />";
             var options = new HtmlToWordOptions {
-                HttpClient = httpClient
+                HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed
             };
 
             var doc = html.LoadFromHtml(options);
@@ -1069,7 +1083,7 @@ namespace OfficeIMO.Tests {
             Assert.Single(doc.Paragraphs);
             Assert.Equal("Missing", doc.Paragraphs[0].Text);
             var diagnostic = Assert.Single(options.Diagnostics);
-            Assert.Equal("ImageLoadFailed", diagnostic.Code);
+            Assert.Equal("ImageSkippedByPolicy", diagnostic.Code);
             Assert.Equal("missing.png", diagnostic.Source);
         }
 
@@ -1083,7 +1097,8 @@ namespace OfficeIMO.Tests {
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
             }));
             var options = new HtmlToWordOptions {
-                HttpClient = httpClient
+                HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed
             };
             string html = $"<img srcset=\"https://cdn.example.test/missing.png 1x\" src=\"data:image/png;base64,{base64}\" alt=\"Logo\" />";
 
@@ -1102,7 +1117,8 @@ namespace OfficeIMO.Tests {
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
             }));
             var options = new HtmlToWordOptions {
-                HttpClient = httpClient
+                HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed
             };
             string html = """<img src="https://cdn.example.test/missing.png" alt="Missing" />""";
 
@@ -1125,6 +1141,7 @@ namespace OfficeIMO.Tests {
             }));
             var options = new HtmlToWordOptions {
                 HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed,
                 ResourceTimeout = TimeSpan.FromMilliseconds(1)
             };
             string html = $"<img data-src=\"https://cdn.example.test/slow.png\" src=\"data:image/png;base64,{base64}\" alt=\"Logo\" />";
@@ -1231,6 +1248,7 @@ namespace OfficeIMO.Tests {
             }));
             var options = new HtmlToWordOptions {
                 HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed,
                 MaxTotalImageBytes = bytes.LongLength
             };
             string html = """
@@ -1267,7 +1285,8 @@ namespace OfficeIMO.Tests {
 <img data-src="https://cdn.example.test/bad-two.png" src="data:image/png;base64,{validPng}" alt="Two" />
 """;
             var options = new HtmlToWordOptions {
-                HttpClient = httpClient
+                HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed
             };
             var converter = new HtmlToWordConverter();
 
@@ -1301,7 +1320,8 @@ namespace OfficeIMO.Tests {
                 });
             }));
             var options = new HtmlToWordOptions {
-                HttpClient = httpClient
+                HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed
             };
             string html = """
 <img src="https://cdn.example.test/Logo.png" alt="Missing" />

--- a/OfficeIMO.Tests/Html.Images.cs
+++ b/OfficeIMO.Tests/Html.Images.cs
@@ -26,7 +26,7 @@ namespace OfficeIMO.Tests {
                 var baseHref = new Uri(new Uri(Path.Combine(dir, "dummy"), UriKind.Absolute), ".").AbsoluteUri;
                 Assert.EndsWith("/", baseHref);
                 string html = $"<base href=\"{baseHref}\"><img src=\"logo.png\" alt=\"Logo\" />";
-                var doc = html.LoadFromHtml(new HtmlToWordOptions());
+                var doc = html.LoadFromHtml(HtmlToWordOptions.CreateTrustedDocumentProfile());
                 Assert.Single(doc.Images);
                 Assert.Equal("Logo", doc.Images[0].Description);
             } finally {
@@ -44,7 +44,8 @@ namespace OfficeIMO.Tests {
             File.Copy(source, dest);
             try {
                 string html = "<img src=\"logo.png\" alt=\"Logo\" />";
-                var options = new HtmlToWordOptions { BasePath = dir };
+                var options = HtmlToWordOptions.CreateTrustedDocumentProfile();
+                options.BasePath = dir;
                 var doc = html.LoadFromHtml(options);
                 Assert.Single(doc.Images);
                 Assert.Equal("Logo", doc.Images[0].Description);
@@ -59,7 +60,7 @@ namespace OfficeIMO.Tests {
             var path = Path.Combine(AppContext.BaseDirectory, "Images", "EvotecLogo.png");
             string html = $"<img src=\"{path}\" alt=\"Company logo\" title=\"Quarterly report logo\" width=\"32\" height=\"32\" />";
 
-            using var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            using var doc = html.LoadFromHtml(HtmlToWordOptions.CreateTrustedDocumentProfile());
 
             var image = Assert.Single(doc.Images);
             Assert.Equal("Company logo", image.Description);
@@ -507,9 +508,8 @@ namespace OfficeIMO.Tests {
             File.WriteAllText(path, "not an image");
             try {
                 string html = $"<img src=\"{path}\" alt=\"Broken\" /><img src=\"data:image/png;base64,{validPng}\" alt=\"Valid\" />";
-                var options = new HtmlToWordOptions {
-                    MaxTotalImageBytes = 70
-                };
+                var options = HtmlToWordOptions.CreateTrustedDocumentProfile();
+                options.MaxTotalImageBytes = 70;
 
                 var doc = html.LoadFromHtml(options);
 
@@ -544,9 +544,8 @@ namespace OfficeIMO.Tests {
             File.WriteAllText(path, "<svg xmlns=\"http://www.w3.org/2000/svg\"><path></svg>");
             try {
                 string html = $"<img src=\"{path}\" alt=\"Broken svg\" /><img src=\"data:image/png;base64,{validPng}\" alt=\"Valid\" />";
-                var options = new HtmlToWordOptions {
-                    MaxTotalImageBytes = 100
-                };
+                var options = HtmlToWordOptions.CreateTrustedDocumentProfile();
+                options.MaxTotalImageBytes = 100;
 
                 var doc = html.LoadFromHtml(options);
 
@@ -709,7 +708,7 @@ namespace OfficeIMO.Tests {
         public void DuplicateImageFileSrcSharesPart() {
             var path = Path.Combine(AppContext.BaseDirectory, "Images", "EvotecLogo.png");
             string html = $"<p><img src=\"{path}\"/><img src=\"{path}\"/></p>";
-            var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            var doc = html.LoadFromHtml(HtmlToWordOptions.CreateTrustedDocumentProfile());
             Assert.Equal(2, doc.Images.Count);
             Assert.Equal(doc.Images[0].RelationshipId, doc.Images[1].RelationshipId);
             var wordDoc = doc._wordprocessingDocument;
@@ -783,7 +782,7 @@ namespace OfficeIMO.Tests {
             var path = Path.Combine(AppContext.BaseDirectory, "Images", "EvotecLogo.png");
             string html = $"<img src=\"{path}\" width=\"64\" height=\"32\" alt=\"Logo\" />";
 
-            using var doc = html.LoadFromHtml(new HtmlToWordOptions());
+            using var doc = html.LoadFromHtml(HtmlToWordOptions.CreateTrustedDocumentProfile());
 
             var img = Assert.Single(doc.Images);
             Assert.Equal(64D, Math.Round(img.Width!.Value));
@@ -805,7 +804,8 @@ namespace OfficeIMO.Tests {
             var path = Path.Combine(AppContext.BaseDirectory, "Images", "EvotecLogo.png");
             var uri = new Uri(path).AbsoluteUri;
             string html = $"<img src=\"{uri}\" width=\"64\" height=\"64\" alt=\"Logo\" />";
-            var options = new HtmlToWordOptions { ImageProcessing = ImageProcessingMode.LinkExternal };
+            var options = HtmlToWordOptions.CreateTrustedDocumentProfile();
+            options.ImageProcessing = ImageProcessingMode.LinkExternal;
             var doc = html.LoadFromHtml(options);
             var img = Assert.Single(doc.Images);
             Assert.True(img.IsExternal);
@@ -1144,7 +1144,7 @@ namespace OfficeIMO.Tests {
                 var path = Path.Combine(AppContext.BaseDirectory, "Images", "EvotecLogo.png");
                 string base64 = Convert.ToBase64String(File.ReadAllBytes(path));
                 string html = $"<img data-src=\"{new Uri(badPath).AbsoluteUri}\" src=\"data:image/png;base64,{base64}\" alt=\"Logo\" />";
-                var options = new HtmlToWordOptions();
+                var options = HtmlToWordOptions.CreateTrustedDocumentProfile();
 
                 var doc = html.LoadFromHtml(options);
 
@@ -1164,9 +1164,8 @@ namespace OfficeIMO.Tests {
             try {
                 string base64 = Convert.ToBase64String(imageBytes);
                 string html = $"<img data-src=\"{new Uri(oversizedPath).AbsoluteUri}\" src=\"data:image/png;base64,{base64}\" alt=\"Logo\" />";
-                var options = new HtmlToWordOptions {
-                    MaxImageBytes = imageBytes.LongLength
-                };
+                var options = HtmlToWordOptions.CreateTrustedDocumentProfile();
+                options.MaxImageBytes = imageBytes.LongLength;
 
                 var doc = html.LoadFromHtml(options);
 
@@ -1174,6 +1173,25 @@ namespace OfficeIMO.Tests {
                 Assert.Empty(options.Diagnostics);
             } finally {
                 File.Delete(oversizedPath);
+            }
+        }
+
+        [Fact]
+        public void HtmlToWord_ImageSelection_SkipsLocalFileCandidateByDefault() {
+            string localPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".png");
+            File.WriteAllText(localPath, "not an image");
+            try {
+                var path = Path.Combine(AppContext.BaseDirectory, "Images", "EvotecLogo.png");
+                string base64 = Convert.ToBase64String(File.ReadAllBytes(path));
+                string html = $"<img data-src=\"{new Uri(localPath).AbsoluteUri}\" src=\"data:image/png;base64,{base64}\" alt=\"Logo\" />";
+                var options = new HtmlToWordOptions();
+
+                var doc = html.LoadFromHtml(options);
+
+                Assert.Single(doc.Images);
+                Assert.Empty(options.Diagnostics);
+            } finally {
+                File.Delete(localPath);
             }
         }
 

--- a/OfficeIMO.Tests/Html.Limits.cs
+++ b/OfficeIMO.Tests/Html.Limits.cs
@@ -81,5 +81,31 @@ namespace OfficeIMO.Tests {
             var diagnostic = Assert.Single(options.Diagnostics);
             Assert.Equal("TableSizeLimitExceeded", diagnostic.Code);
         }
+
+        [Fact]
+        public void HtmlToWord_DefaultMaxTableCells_StopsHostileColumnSpan() {
+            var options = new HtmlToWordOptions();
+            string html = "<table><tr><td colspan=\"50001\">Wide</td></tr></table>";
+
+            var exception = Assert.Throws<HtmlConversionLimitException>(() => html.LoadFromHtml(options));
+
+            Assert.Equal("TableSizeLimitExceeded", exception.Code);
+            Assert.Equal("MaxTableCells", exception.LimitSource);
+            Assert.Equal(50000, exception.Limit);
+            Assert.True(exception.Actual > exception.Limit);
+            var diagnostic = Assert.Single(options.Diagnostics);
+            Assert.Equal("TableSizeLimitExceeded", diagnostic.Code);
+        }
+
+        [Fact]
+        public void HtmlToWord_ColumnGroupSpan_DoesNotExpandBeyondResolvedColumns() {
+            var options = new HtmlToWordOptions();
+            string html = "<table><colgroup><col span=\"1000000\" style=\"width:10px\"></colgroup><tr><td>Cell</td></tr></table>";
+
+            using var document = html.LoadFromHtml(options);
+
+            Assert.Single(document.Tables);
+            Assert.Empty(options.Diagnostics);
+        }
     }
 }

--- a/OfficeIMO.Tests/Html.Pdf.cs
+++ b/OfficeIMO.Tests/Html.Pdf.cs
@@ -381,7 +381,7 @@ public sealed class HtmlPdfTests {
         Assert.True(policy.UsesWordHtmlPolicy);
         Assert.False(policy.AllowDocumentStylesheetLinks);
         Assert.Contains("data", policy.AllowedImageUriSchemes);
-        Assert.Equal("Embed", policy.ImageProcessing);
+        Assert.Equal("EmbedDataUriOnly", policy.ImageProcessing);
         Assert.Null(options.WordHtmlOptions);
     }
 

--- a/OfficeIMO.Tests/Markdown.Pdf.cs
+++ b/OfficeIMO.Tests/Markdown.Pdf.cs
@@ -133,6 +133,34 @@ Console.WriteLine("OfficeIMO");
     }
 
     [Fact]
+    public void Markdown_SaveAsPdf_BlocksLocalImagesByDefault() {
+        string directory = Path.Combine(Path.GetTempPath(), "OfficeIMO.Markdown.Pdf.LocalImages", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try {
+            string imagePath = Path.Combine(directory, "pixel.png");
+            File.WriteAllBytes(imagePath, Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="));
+
+            var options = new MarkdownPdfSaveOptions {
+                BaseDirectory = directory
+            };
+            string markdown = "![Local pixel](pixel.png){width=24 height=24}";
+
+            byte[] pdf = markdown.SaveAsPdf(options);
+            string text = PdfCore.PdfReadDocument.Load(pdf).ExtractText();
+            IReadOnlyList<PdfCore.PdfExtractedImage> images = PdfCore.PdfImageExtractor.ExtractImages(pdf);
+
+            MarkdownPdfExportWarning warning = Assert.Single(options.Warnings);
+            Assert.Equal("LocalImageDisabled", warning.Code);
+            Assert.Contains("[Image:", text, StringComparison.Ordinal);
+            Assert.Empty(images);
+        } finally {
+            if (Directory.Exists(directory)) {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public void Markdown_SaveAsPdf_EmbedsRemoteImagesThroughExplicitResolver() {
         Uri? requestedUri = null;
         var options = new MarkdownPdfSaveOptions {
@@ -197,7 +225,9 @@ Console.WriteLine("OfficeIMO");
 _Figure 1. Embedded from a relative Markdown path._
 """);
 
-            var options = new MarkdownPdfSaveOptions();
+            var options = new MarkdownPdfSaveOptions {
+                IncludeLocalImages = true
+            };
             MarkdownPdfConverter.SaveFileAsPdf(markdownPath, pdfPath, options);
 
             byte[] pdf = File.ReadAllBytes(pdfPath);
@@ -230,6 +260,7 @@ _Figure 1. Embedded from a relative Markdown path._
             var options = new MarkdownPdfSaveOptions {
                 ApplyWordLikeTheme = false,
                 BaseDirectory = directory,
+                IncludeLocalImages = true,
                 PdfOptions = new PdfCore.PdfOptions {
                     PageWidth = 220,
                     PageHeight = 180,

--- a/OfficeIMO.Tests/Markdown.Pdf.cs
+++ b/OfficeIMO.Tests/Markdown.Pdf.cs
@@ -1,5 +1,6 @@
 using OfficeIMO.Markdown;
 using OfficeIMO.Markdown.Pdf;
+using OfficeIMO.Tests.Pdf;
 using PdfCore = OfficeIMO.Pdf;
 using PdfPigDocument = UglyToad.PdfPig.PdfDocument;
 using Xunit;
@@ -7,6 +8,11 @@ using Xunit;
 namespace OfficeIMO.Tests;
 
 public partial class MarkdownPdfTests {
+    private static byte[] CreateMinimalRgbPng() => PdfPngTestImages.CreateRgbPng(1, 1);
+
+    private static string CreateMinimalRgbPngDataUri() =>
+        "data:image/png;base64," + Convert.ToBase64String(CreateMinimalRgbPng());
+
     [Fact]
     public void Markdown_SaveAsPdf_ExportsCoreDocumentStructure() {
         var options = new MarkdownPdfSaveOptions();
@@ -138,7 +144,7 @@ Console.WriteLine("OfficeIMO");
         Directory.CreateDirectory(directory);
         try {
             string imagePath = Path.Combine(directory, "pixel.png");
-            File.WriteAllBytes(imagePath, Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="));
+            File.WriteAllBytes(imagePath, CreateMinimalRgbPng());
 
             var options = new MarkdownPdfSaveOptions {
                 BaseDirectory = directory
@@ -166,7 +172,7 @@ Console.WriteLine("OfficeIMO");
         var options = new MarkdownPdfSaveOptions {
             RemoteImageResolver = uri => {
                 requestedUri = uri;
-                return Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=");
+                return CreateMinimalRgbPng();
             }
         };
         string markdown = """
@@ -217,7 +223,7 @@ Console.WriteLine("OfficeIMO");
             string pdfPath = Path.Combine(directory, "README.pdf");
             string imagePath = Path.Combine(directory, "pixel.png");
 
-            File.WriteAllBytes(imagePath, Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="));
+            File.WriteAllBytes(imagePath, CreateMinimalRgbPng());
             File.WriteAllText(markdownPath, """
 # Asset Report
 
@@ -255,7 +261,7 @@ _Figure 1. Embedded from a relative Markdown path._
         Directory.CreateDirectory(directory);
         try {
             string imagePath = Path.Combine(directory, "pixel.png");
-            File.WriteAllBytes(imagePath, Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="));
+            File.WriteAllBytes(imagePath, CreateMinimalRgbPng());
 
             var options = new MarkdownPdfSaveOptions {
                 ApplyWordLikeTheme = false,
@@ -327,11 +333,9 @@ _Figure 1. Embedded from a relative Markdown path._
     [Fact]
     public void Markdown_SaveAsPdf_EmbedsDataUriImages() {
         var options = new MarkdownPdfSaveOptions();
-        string markdown = """
-# Inline Asset
-
-![Inline pixel](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=){width=24 height=24}
-""";
+        string markdown =
+            "# Inline Asset\n\n" +
+            "![Inline pixel](" + CreateMinimalRgbPngDataUri() + "){width=24 height=24}\n";
 
         byte[] pdf = markdown.SaveAsPdf(options);
         string text = PdfCore.PdfReadDocument.Load(pdf).ExtractText();

--- a/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.Support.cs
+++ b/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.Support.cs
@@ -61,24 +61,7 @@ public partial class Excel {
         return x;
     }
 
-    private static byte[] CreateMinimalRgbPng() {
-        return new byte[] {
-            137, 80, 78, 71, 13, 10, 26, 10,
-            0, 0, 0, 13,
-            73, 72, 68, 82,
-            0, 0, 0, 1,
-            0, 0, 0, 1,
-            8, 2, 0, 0, 0,
-            0, 0, 0, 0,
-            0, 0, 0, 12,
-            73, 68, 65, 84,
-            0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-            73, 69, 78, 68,
-            0, 0, 0, 0
-        };
-    }
+    private static byte[] CreateMinimalRgbPng() => Pdf.PdfPngTestImages.CreateRgbPng(255, 0, 0);
 
     private static string NormalizePdfTextSpaces(string text) =>
         text.Replace('\u00A0', ' ').Replace('\u202F', ' ');

--- a/OfficeIMO.Tests/Pdf/PdfComplianceGateTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfComplianceGateTests.cs
@@ -329,7 +329,7 @@ public class PdfComplianceGateTests {
     }
 
     private static byte[] CreateOnePixelPng() {
-        return Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=");
+        return PdfPngTestImages.CreateRgbPng(1, 1);
     }
 
     private static void WriteProfileProofContract() {

--- a/OfficeIMO.Tests/Pdf/PdfComposePageOptionsSupport.cs
+++ b/OfficeIMO.Tests/Pdf/PdfComposePageOptionsSupport.cs
@@ -54,23 +54,6 @@ namespace OfficeIMO.Tests.Pdf {
             throw new InvalidOperationException("Could not find word '" + word + "' in rendered PDF text.");
         }
 
-        private static byte[] CreateMinimalRgbPng() {
-            return new byte[] {
-                137, 80, 78, 71, 13, 10, 26, 10,
-                0, 0, 0, 13,
-                73, 72, 68, 82,
-                0, 0, 0, 1,
-                0, 0, 0, 1,
-                8, 2, 0, 0, 0,
-                0, 0, 0, 0,
-                0, 0, 0, 12,
-                73, 68, 65, 84,
-                0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00,
-                0, 0, 0, 0,
-                0, 0, 0, 0,
-                73, 69, 78, 68,
-                0, 0, 0, 0
-            };
-        }
+        private static byte[] CreateMinimalRgbPng() => PdfPngTestImages.CreateRgbPng(255, 0, 0);
     }
 }

--- a/OfficeIMO.Tests/Pdf/PdfDocumentCanvasTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentCanvasTests.cs
@@ -986,22 +986,5 @@ public class PdfDocumentCanvasTests {
     private static void AssertClose(double expected, double actual) =>
         Assert.InRange(Math.Abs(expected - actual), 0D, 0.01D);
 
-    private static byte[] CreateMinimalRgbPng() {
-        return new byte[] {
-            137, 80, 78, 71, 13, 10, 26, 10,
-            0, 0, 0, 13,
-            73, 72, 68, 82,
-            0, 0, 0, 1,
-            0, 0, 0, 1,
-            8, 2, 0, 0, 0,
-            0, 0, 0, 0,
-            0, 0, 0, 12,
-            73, 68, 65, 84,
-            0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-            73, 69, 78, 68,
-            0, 0, 0, 0
-        };
-    }
+    private static byte[] CreateMinimalRgbPng() => PdfPngTestImages.CreateRgbPng(255, 0, 0);
 }

--- a/OfficeIMO.Tests/Pdf/PdfDocumentChartDrawingTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentChartDrawingTests.cs
@@ -116,6 +116,52 @@ public class PdfDocumentChartDrawingTests {
     }
 
     [Fact]
+    public void WordChartNumberExtraction_RejectsSparsePointIndexesBeyondLimit() {
+        var values = new Values(
+            new NumberReference(
+                new NumberingCache(
+                    new PointCount { Val = 1U },
+                    new NumericPoint(new NumericValue("1")) { Index = 100_000U })));
+        MethodInfo method = typeof(WordPdfConverterExtensions).GetMethod("ExtractNativeWordChartNumberValues", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        TargetInvocationException exception = Assert.Throws<TargetInvocationException>(() => method.Invoke(null, new object?[] { values }));
+
+        Assert.Contains("point index", exception.InnerException?.Message);
+    }
+
+    [Fact]
+    public void WordChartNumberExtraction_RejectsExcessivePointCounts() {
+        var cache = new NumberingCache(new PointCount { Val = 4097U });
+        for (int index = 0; index < 4097; index++) {
+            cache.Append(new NumericPoint(new NumericValue("1")));
+        }
+
+        var values = new Values(new NumberReference(cache));
+        MethodInfo method = typeof(WordPdfConverterExtensions).GetMethod("ExtractNativeWordChartNumberValues", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        TargetInvocationException exception = Assert.Throws<TargetInvocationException>(() => method.Invoke(null, new object?[] { values }));
+
+        Assert.Contains("maximum supported point count", exception.InnerException?.Message);
+    }
+
+    [Fact]
+    public void WordChartLayout_RejectsOversizedDataLabelPointIndexes() {
+        var chartElement = new BarChart(
+            new BarDirection { Val = BarDirectionValues.Column },
+            CreateBarSeries(0U, new[] { "Q1" }, new[] { 1D }, new DataLabels(
+                new DataLabel(
+                    new DocumentFormat.OpenXml.Drawing.Charts.Index { Val = 100_000U },
+                    new ShowValue { Val = true }))));
+        var plotArea = new PlotArea(chartElement);
+        var chart = new Chart(plotArea);
+        MethodInfo method = typeof(WordPdfConverterExtensions).GetMethod("CreateNativeWordChartLayout", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        TargetInvocationException exception = Assert.Throws<TargetInvocationException>(() => method.Invoke(null, new object[] { chart, chartElement, plotArea, OfficeChartKind.ColumnClustered, 1 }));
+
+        Assert.Contains("point index", exception.InnerException?.Message);
+    }
+
+    [Fact]
     public void WordChartSeriesExtraction_ExtendsCategoriesAcrossAllSeries() {
         var chart = new BarChart(
             new BarDirection { Val = BarDirectionValues.Column },

--- a/OfficeIMO.Tests/Pdf/PdfDocumentChartDrawingTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentChartDrawingTests.cs
@@ -179,6 +179,23 @@ public class PdfDocumentChartDrawingTests {
     }
 
     [Fact]
+    public void WordChartSeriesExtraction_RejectsTooManySeriesBeforeOrdering() {
+        var chart = new BarChart(
+            new BarDirection { Val = BarDirectionValues.Column },
+            new BarGrouping { Val = BarGroupingValues.Clustered });
+        for (uint index = 0; index < 257; index++) {
+            chart.Append(CreateBarSeries(index, new[] { "Q1" }, new[] { 1D }));
+        }
+
+        MethodInfo method = typeof(WordPdfConverterExtensions).GetMethod("ExtractNativeWordChartSeries", BindingFlags.NonPublic | BindingFlags.Static)!;
+        object?[] args = { new Chart(), chart, OfficeChartKind.ColumnClustered, new Dictionary<A.SchemeColorValues, OfficeColor>(), null };
+
+        TargetInvocationException exception = Assert.Throws<TargetInvocationException>(() => method.Invoke(null, args));
+
+        Assert.Contains("maximum supported series count", exception.InnerException?.Message);
+    }
+
+    [Fact]
     public void WordChartSeriesExtraction_PreservesNonPiePointFillColors() {
         OfficeColor highlight = OfficeColor.ParseHex("#F76707");
         BarChartSeries barSeries = CreateBarSeries(0U, new[] { "Q1", "Q2" }, new[] { 1D, 2D });

--- a/OfficeIMO.Tests/Pdf/PdfDocumentComplianceAssessmentSupport.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentComplianceAssessmentSupport.cs
@@ -48,24 +48,7 @@ public partial class PdfDocumentComplianceAssessmentTests {
         return requirement;
     }
 
-    private static byte[] CreateMinimalRgbPng() {
-        return new byte[] {
-            137, 80, 78, 71, 13, 10, 26, 10,
-            0, 0, 0, 13,
-            73, 72, 68, 82,
-            0, 0, 0, 1,
-            0, 0, 0, 1,
-            8, 2, 0, 0, 0,
-            0, 0, 0, 0,
-            0, 0, 0, 12,
-            73, 68, 65, 84,
-            0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-            73, 69, 78, 68,
-            0, 0, 0, 0
-        };
-    }
+    private static byte[] CreateMinimalRgbPng() => PdfPngTestImages.CreateRgbPng(255, 0, 0);
 
     private static int CountOccurrences(string text, string value) {
         int count = 0;

--- a/OfficeIMO.Tests/Pdf/PdfDocumentImageValidationTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentImageValidationTests.cs
@@ -1027,42 +1027,34 @@ public class PdfDocumentImageValidationTests {
         text.Split(new[] { value }, StringSplitOptions.None).Length - 1;
 
     private static byte[] CreateMinimalRgbPng() {
-        return new byte[] {
-            137, 80, 78, 71, 13, 10, 26, 10,
-            0, 0, 0, 13,
-            73, 72, 68, 82,
+        using var ms = new MemoryStream();
+        byte[] signature = new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 };
+        ms.Write(signature, 0, signature.Length);
+        WritePngChunk(ms, "IHDR", new byte[] {
             0, 0, 0, 1,
             0, 0, 0, 1,
-            8, 2, 0, 0, 0,
-            0, 0, 0, 0,
-            0, 0, 0, 12,
-            73, 68, 65, 84,
-            0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-            73, 69, 78, 68,
-            0, 0, 0, 0
-        };
+            8, 2, 0, 0, 0
+        });
+        WritePngChunk(ms, "IDAT", new byte[] { 0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00 });
+        WritePngChunk(ms, "IEND", Array.Empty<byte>());
+        return ms.ToArray();
     }
 
     private static byte[] CreateMinimalRgbaPng() {
-        return new byte[] {
-            137, 80, 78, 71, 13, 10, 26, 10,
-            0, 0, 0, 13,
-            73, 72, 68, 82,
+        using var ms = new MemoryStream();
+        byte[] signature = new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 };
+        ms.Write(signature, 0, signature.Length);
+        WritePngChunk(ms, "IHDR", new byte[] {
             0, 0, 0, 1,
             0, 0, 0, 1,
-            8, 6, 0, 0, 0,
-            0, 0, 0, 0,
-            0, 0, 0, 16,
-            73, 68, 65, 84,
+            8, 6, 0, 0, 0
+        });
+        WritePngChunk(ms, "IDAT", new byte[] {
             0x78, 0x01, 0x01, 0x05, 0x00, 0xFA, 0xFF, 0x00,
-            0xFF, 0x00, 0x00, 0x80, 0x04, 0x81, 0x01, 0x80,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-            73, 69, 78, 68,
-            0, 0, 0, 0
-        };
+            0xFF, 0x00, 0x00, 0x80, 0x04, 0x81, 0x01, 0x80
+        });
+        WritePngChunk(ms, "IEND", Array.Empty<byte>());
+        return ms.ToArray();
     }
 
     private static byte[] CreateMinimalRgbTransparencyPng() {
@@ -1204,7 +1196,11 @@ public class PdfDocumentImageValidationTests {
         byte[] typeBytes = System.Text.Encoding.ASCII.GetBytes(type);
         stream.Write(typeBytes, 0, typeBytes.Length);
         stream.Write(data, 0, data.Length);
-        stream.Write(new byte[] { 0, 0, 0, 0 }, 0, 4);
+        uint crc = ComputeCrc32(typeBytes, data);
+        stream.WriteByte((byte)((crc >> 24) & 0xFF));
+        stream.WriteByte((byte)((crc >> 16) & 0xFF));
+        stream.WriteByte((byte)((crc >> 8) & 0xFF));
+        stream.WriteByte((byte)(crc & 0xFF));
     }
 
     private static byte[] CreateMinimalGif() {
@@ -1230,4 +1226,27 @@ public class PdfDocumentImageValidationTests {
             0xFF, 0xD9
         };
     }
+
+    private static uint ComputeCrc32(byte[] typeBytes, byte[] data) {
+        uint crc = 0xFFFFFFFF;
+        for (int i = 0; i < typeBytes.Length; i++) {
+            crc = UpdateCrc32(crc, typeBytes[i]);
+        }
+
+        for (int i = 0; i < data.Length; i++) {
+            crc = UpdateCrc32(crc, data[i]);
+        }
+
+        return crc ^ 0xFFFFFFFF;
+    }
+
+    private static uint UpdateCrc32(uint crc, byte value) {
+        crc ^= value;
+        for (int bit = 0; bit < 8; bit++) {
+            crc = (crc & 1) != 0 ? (crc >> 1) ^ 0xEDB88320 : crc >> 1;
+        }
+
+        return crc;
+    }
+
 }

--- a/OfficeIMO.Tests/Pdf/PdfDocumentPngImageTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentPngImageTests.cs
@@ -168,6 +168,26 @@ public class PdfDocumentPngImageTests {
     }
 
     [Fact]
+    public void Image_WithOversizedInterlacedPng_RejectsImageBytesWithoutExpanding() {
+        Assert.False(PdfDocument.TryValidateImageBytes(
+            PdfPngTestImages.CreateOversizedInterlacedGrayscalePng(),
+            out OfficeImageInfo? imageInfo,
+            out string? unsupportedReason));
+        Assert.Null(imageInfo);
+        Assert.Contains("PNG dimensions exceed", unsupportedReason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Image_WithInvalidPngCrc_RejectsImageBytes() {
+        Assert.False(PdfDocument.TryValidateImageBytes(
+            PdfPngTestImages.CreatePngWithInvalidCrc(),
+            out OfficeImageInfo? imageInfo,
+            out string? unsupportedReason));
+        Assert.Null(imageInfo);
+        Assert.Contains("PNG chunk CRC is invalid.", unsupportedReason, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Image_With16BitRgbTransparency_WritesSoftMaskImageObject() {
         byte[] bytes = PdfDocument.Create()
             .Image(PdfPngTestImages.Create16BitRgbPng(includeTransparency: true), 24, 24)

--- a/OfficeIMO.Tests/Pdf/PdfDocumentPngImageTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentPngImageTests.cs
@@ -188,6 +188,16 @@ public class PdfDocumentPngImageTests {
     }
 
     [Fact]
+    public void Image_WithOverflowingPngChunkLength_RejectsPdfGenerationWithoutThrowingParserErrors() {
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(() =>
+            PdfDocument.Create()
+                .Image(PdfPngTestImages.CreatePngWithOverflowingChunkLength(), 24, 24)
+                .ToBytes());
+
+        Assert.Contains("PNG chunk length is invalid.", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Image_With16BitRgbTransparency_WritesSoftMaskImageObject() {
         byte[] bytes = PdfDocument.Create()
             .Image(PdfPngTestImages.Create16BitRgbPng(includeTransparency: true), 24, 24)

--- a/OfficeIMO.Tests/Pdf/PdfDocumentPngImageTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentPngImageTests.cs
@@ -188,6 +188,16 @@ public class PdfDocumentPngImageTests {
     }
 
     [Fact]
+    public void Image_WithExtraDecodedPngScanlines_RejectsPassThroughImageBytes() {
+        Assert.False(PdfDocument.TryValidateImageBytes(
+            PdfPngTestImages.CreateRgbPngWithExtraDecodedScanlines(),
+            out OfficeImageInfo? imageInfo,
+            out string? unsupportedReason));
+        Assert.Null(imageInfo);
+        Assert.Contains("PNG image data length does not match the expected scanline size.", unsupportedReason, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Image_WithOverflowingPngChunkLength_RejectsPdfGenerationWithoutThrowingParserErrors() {
         NotSupportedException exception = Assert.Throws<NotSupportedException>(() =>
             PdfDocument.Create()

--- a/OfficeIMO.Tests/Pdf/PdfDocumentRasterVisualBaselineNativeScenarios.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentRasterVisualBaselineNativeScenarios.cs
@@ -389,7 +389,8 @@ MarkdownPdfConverter.SaveFileAsPdf("README.md", "README.pdf");
 
             var options = new MarkdownPdfSaveOptions {
                 DefaultImageWidth = 104,
-                DefaultImageHeight = 36
+                DefaultImageHeight = 36,
+                IncludeLocalImages = true
             };
 
             byte[] pdf = MarkdownPdfConverter.SaveFileAsPdf(markdownPath, options);

--- a/OfficeIMO.Tests/Pdf/PdfDocumentRasterVisualBaselineReportScenarios.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentRasterVisualBaselineReportScenarios.cs
@@ -458,42 +458,7 @@ public partial class PdfDocumentRasterVisualBaselineTests {
         };
     }
 
-    private static byte[] CreateFallbackLogo() {
-        return new byte[] {
-            137, 80, 78, 71, 13, 10, 26, 10,
-            0, 0, 0, 13,
-            73, 72, 68, 82,
-            0, 0, 0, 1,
-            0, 0, 0, 1,
-            8, 2, 0, 0, 0,
-            0, 0, 0, 0,
-            0, 0, 0, 12,
-            73, 68, 65, 84,
-            0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-            73, 69, 78, 68,
-            0, 0, 0, 0
-        };
-    }
+    private static byte[] CreateFallbackLogo() => PdfPngTestImages.CreateRgbPng(255, 0, 0);
 
-    private static byte[] CreateTransparentBadgePng() {
-        return new byte[] {
-            137, 80, 78, 71, 13, 10, 26, 10,
-            0, 0, 0, 13,
-            73, 72, 68, 82,
-            0, 0, 0, 1,
-            0, 0, 0, 1,
-            8, 6, 0, 0, 0,
-            0, 0, 0, 0,
-            0, 0, 0, 16,
-            73, 68, 65, 84,
-            0x78, 0x01, 0x01, 0x05, 0x00, 0xFA, 0xFF, 0x00,
-            0x2A, 0x84, 0x52, 0xA0, 0x03, 0x7D, 0x01, 0xA1,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-            73, 69, 78, 68,
-            0, 0, 0, 0
-        };
-    }
+    private static byte[] CreateTransparentBadgePng() => PdfPngTestImages.CreateRgbaPng(0x2A, 0x84, 0x52, 0xA0);
 }

--- a/OfficeIMO.Tests/Pdf/PdfDocumentVisualBaselineTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentVisualBaselineTests.cs
@@ -410,25 +410,7 @@ public class PdfDocumentVisualBaselineTests {
         };
     }
 
-    private static byte[] CreateTransparentBadgePng() {
-        return new byte[] {
-            137, 80, 78, 71, 13, 10, 26, 10,
-            0, 0, 0, 13,
-            73, 72, 68, 82,
-            0, 0, 0, 1,
-            0, 0, 0, 1,
-            8, 6, 0, 0, 0,
-            0, 0, 0, 0,
-            0, 0, 0, 16,
-            73, 68, 65, 84,
-            0x78, 0x01, 0x01, 0x05, 0x00, 0xFA, 0xFF, 0x00,
-            0x2A, 0x84, 0x52, 0xA0, 0x03, 0x7D, 0x01, 0xA1,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-            73, 69, 78, 68,
-            0, 0, 0, 0
-        };
-    }
+    private static byte[] CreateTransparentBadgePng() => PdfPngTestImages.CreateRgbaPng(0x2A, 0x84, 0x52, 0xA0);
 
     private readonly struct VisualLine {
         internal VisualLine(double y, double x1, double x2, double pointSize, string text) {

--- a/OfficeIMO.Tests/Pdf/PdfDocumentVisualQualitySupport.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentVisualQualitySupport.cs
@@ -474,24 +474,7 @@ public partial class PdfDocumentVisualQualityTests {
             .AddShape(shape, 0, 0);
     }
 
-    private static byte[] CreateMinimalRgbPng() {
-        return new byte[] {
-            137, 80, 78, 71, 13, 10, 26, 10,
-            0, 0, 0, 13,
-            73, 72, 68, 82,
-            0, 0, 0, 1,
-            0, 0, 0, 1,
-            8, 2, 0, 0, 0,
-            0, 0, 0, 0,
-            0, 0, 0, 12,
-            73, 68, 65, 84,
-            0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-            73, 69, 78, 68,
-            0, 0, 0, 0
-        };
-    }
+    private static byte[] CreateMinimalRgbPng() => PdfPngTestImages.CreateRgbPng(255, 0, 0);
 
     private static double FindWordStartX(UglyToad.PdfPig.Content.Page page, string word) {
         var lines = page.Letters

--- a/OfficeIMO.Tests/Pdf/PdfFontSecurityTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfFontSecurityTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Text;
 using OfficeIMO.Pdf;
 using Xunit;
@@ -23,6 +24,24 @@ endbfrange
 
         Assert.Equal("A", cmap!.MapBytes(new byte[] { 0x00, 0x01 }));
         Assert.NotEqual("B", cmap.MapBytes(new byte[] { 0x10, 0x00 }));
+    }
+
+    [Fact]
+    public void ToUnicodeCMap_CapsDuplicateSourceEntriesByProcessedCount() {
+        var builder = new StringBuilder();
+        builder.AppendLine("beginbfchar");
+        for (int index = 0; index < 70000; index++) {
+            builder.AppendLine("<01> <0041>");
+        }
+
+        builder.AppendLine("endbfchar");
+
+        Assert.True(ToUnicodeCMap.TryParse(Encoding.ASCII.GetBytes(builder.ToString()), out ToUnicodeCMap? cmap));
+        Assert.NotNull(cmap);
+
+        FieldInfo field = typeof(ToUnicodeCMap).GetField("_processedMappings", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        Assert.Equal(65536, (int)field.GetValue(cmap!)!);
+        Assert.Equal("A", cmap!.MapBytes(new byte[] { 0x01 }));
     }
 
     [Fact]

--- a/OfficeIMO.Tests/Pdf/PdfFontSecurityTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfFontSecurityTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using OfficeIMO.Pdf;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf;
+
+public class PdfFontSecurityTests {
+    [Fact]
+    public void ToUnicodeCMap_SkipsOversizedSequentialRanges() {
+        byte[] cmapBytes = Encoding.ASCII.GetBytes("""
+beginbfchar
+<0001> <0041>
+endbfchar
+beginbfrange
+<1000> <FFFF> <0042>
+endbfrange
+""");
+
+        Assert.True(ToUnicodeCMap.TryParse(cmapBytes, out ToUnicodeCMap? cmap));
+        Assert.NotNull(cmap);
+
+        Assert.Equal("A", cmap!.MapBytes(new byte[] { 0x00, 0x01 }));
+        Assert.NotEqual("B", cmap.MapBytes(new byte[] { 0x10, 0x00 }));
+    }
+
+    [Fact]
+    public void ResourceResolver_CapsCidWidthRangeExpansion() {
+        var page = new PdfDictionary();
+        var resources = new PdfDictionary();
+        var fontDictionary = new PdfDictionary();
+        var type0Font = new PdfDictionary();
+        var descendant = new PdfDictionary();
+        var descendantFonts = new PdfArray();
+        var widths = new PdfArray();
+
+        widths.Items.Add(new PdfNumber(0));
+        widths.Items.Add(new PdfNumber(100000));
+        widths.Items.Add(new PdfNumber(250));
+        descendant.Items["DW"] = new PdfNumber(1000);
+        descendant.Items["W"] = widths;
+        descendantFonts.Items.Add(descendant);
+        type0Font.Items["Subtype"] = new PdfName("Type0");
+        type0Font.Items["DescendantFonts"] = descendantFonts;
+        fontDictionary.Items["F1"] = type0Font;
+        resources.Items["Font"] = fontDictionary;
+        page.Items["Resources"] = resources;
+
+        Dictionary<string, Func<byte[], double>> providers = ResourceResolver.GetFontWidthProviders(page, new Dictionary<int, PdfIndirectObject>());
+
+        Func<byte[], double> provider = Assert.Contains("F1", providers);
+        Assert.Equal(250, provider(new byte[] { 0x00, 0x01 }));
+        Assert.Equal(1000, provider(new byte[] { 0x13, 0x87 }));
+    }
+}

--- a/OfficeIMO.Tests/Pdf/PdfImageExtractorTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfImageExtractorTests.cs
@@ -523,44 +523,9 @@ public class PdfImageExtractorTests {
         }
     }
 
-    private static byte[] CreateMinimalRgbPng() {
-        return new byte[] {
-            137, 80, 78, 71, 13, 10, 26, 10,
-            0, 0, 0, 13,
-            73, 72, 68, 82,
-            0, 0, 0, 1,
-            0, 0, 0, 1,
-            8, 2, 0, 0, 0,
-            0, 0, 0, 0,
-            0, 0, 0, 12,
-            73, 68, 65, 84,
-            0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-            73, 69, 78, 68,
-            0, 0, 0, 0
-        };
-    }
+    private static byte[] CreateMinimalRgbPng() => PdfPngTestImages.CreateRgbPng(255, 0, 0);
 
-    private static byte[] CreateMinimalRgbaPng() {
-        return new byte[] {
-            137, 80, 78, 71, 13, 10, 26, 10,
-            0, 0, 0, 13,
-            73, 72, 68, 82,
-            0, 0, 0, 1,
-            0, 0, 0, 1,
-            8, 6, 0, 0, 0,
-            0, 0, 0, 0,
-            0, 0, 0, 16,
-            73, 68, 65, 84,
-            0x78, 0x01, 0x01, 0x05, 0x00, 0xFA, 0xFF, 0x00,
-            0xFF, 0x00, 0x00, 0x80, 0x04, 0x81, 0x01, 0x80,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-            73, 69, 78, 68,
-            0, 0, 0, 0
-        };
-    }
+    private static byte[] CreateMinimalRgbaPng() => PdfPngTestImages.CreateRgbaPng(255, 0, 0, 128);
 
     private static byte[] CreateMinimalRgbTransparencyPng() {
         using var ms = new MemoryStream();

--- a/OfficeIMO.Tests/Pdf/PdfInspectorSupport.MetadataFixtures.cs
+++ b/OfficeIMO.Tests/Pdf/PdfInspectorSupport.MetadataFixtures.cs
@@ -157,24 +157,7 @@ public partial class PdfInspectorTests {
         return System.Text.Encoding.ASCII.GetBytes(pdf);
     }
 
-    private static byte[] CreateMinimalRgbPng() {
-        return new byte[] {
-            137, 80, 78, 71, 13, 10, 26, 10,
-            0, 0, 0, 13,
-            73, 72, 68, 82,
-            0, 0, 0, 1,
-            0, 0, 0, 1,
-            8, 2, 0, 0, 0,
-            0, 0, 0, 0,
-            0, 0, 0, 12,
-            73, 68, 65, 84,
-            0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-            73, 69, 78, 68,
-            0, 0, 0, 0
-        };
-    }
+    private static byte[] CreateMinimalRgbPng() => PdfPngTestImages.CreateRgbPng(255, 0, 0);
 
 
 }

--- a/OfficeIMO.Tests/Pdf/PdfInspectorViewerMetadataPreflightTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfInspectorViewerMetadataPreflightTests.cs
@@ -224,6 +224,34 @@ public partial class PdfInspectorTests {
     }
 
     [Fact]
+    public void Inspect_XmpMetadataRejectsDtdEntityExpansion() {
+        const string xmp = "<!DOCTYPE xmp [<!ENTITY boom \"expanded\">]><xmp>&boom;</xmp>";
+
+        PdfDocumentInfo info = PdfInspector.Inspect(BuildXmpMetadataPdfWithPayload(xmp));
+
+        Assert.True(info.HasXmpMetadata);
+        PdfXmpMetadataInfo metadata = Assert.IsType<PdfXmpMetadataInfo>(info.XmpMetadata);
+        Assert.Equal(xmp.Length, metadata.DecodedSizeBytes);
+        Assert.Contains("<!DOCTYPE", metadata.RawXml, StringComparison.Ordinal);
+        Assert.False(metadata.IsWellFormedXml);
+        Assert.Null(metadata.Title);
+        Assert.Empty(metadata.Subjects);
+    }
+
+    [Fact]
+    public void Inspect_XmpMetadataOverLimitKeepsSizeButDoesNotMaterializeRawXml() {
+        string xmp = new('x', PdfReadDocument.MaxXmpMetadataBytes + 1);
+
+        PdfDocumentInfo info = PdfInspector.Inspect(BuildXmpMetadataPdfWithPayload(xmp));
+
+        Assert.True(info.HasXmpMetadata);
+        PdfXmpMetadataInfo metadata = Assert.IsType<PdfXmpMetadataInfo>(info.XmpMetadata);
+        Assert.Equal(PdfReadDocument.MaxXmpMetadataBytes + 1, metadata.DecodedSizeBytes);
+        Assert.Null(metadata.RawXml);
+        Assert.False(metadata.IsWellFormedXml);
+    }
+
+    [Fact]
     public void Preflight_AllowsSimpleCatalogUriPdfReadAndRewrite() {
         PdfDocumentPreflight report = PdfInspector.Preflight(BuildCatalogUriPdf());
 
@@ -363,5 +391,36 @@ public partial class PdfInspectorTests {
         Assert.True(outputIntent.DestinationOutputProfileHasIccSignature);
     }
 
+    private static byte[] BuildXmpMetadataPdfWithPayload(string xmp) {
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R /Metadata 5 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>",
+            "endobj",
+            "4 0 obj",
+            "<< /Length 0 >>",
+            "stream",
+            "",
+            "endstream",
+            "endobj",
+            "5 0 obj",
+            "<< /Type /Metadata /Subtype /XML /Length " + System.Text.Encoding.UTF8.GetByteCount(xmp).ToString(System.Globalization.CultureInfo.InvariantCulture) + " >>",
+            "stream",
+            xmp,
+            "endstream",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R /Size 6 >>",
+            "%%EOF"
+        });
+
+        return System.Text.Encoding.UTF8.GetBytes(pdf);
+    }
 
 }

--- a/OfficeIMO.Tests/Pdf/PdfInspectorViewerMetadataPreflightTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfInspectorViewerMetadataPreflightTests.cs
@@ -266,6 +266,36 @@ public partial class PdfInspectorTests {
     }
 
     [Fact]
+    public void Inspect_XmpMetadataRejectsLzwBeforeUnboundedDecode() {
+        byte[] payload = System.Text.Encoding.UTF8.GetBytes("<x:xmpmeta/>");
+
+        PdfDocumentInfo info = PdfInspector.Inspect(BuildFilteredXmpMetadataPdf(payload, "/Filter /LZWDecode"));
+
+        Assert.True(info.HasXmpMetadata);
+        PdfXmpMetadataInfo metadata = Assert.IsType<PdfXmpMetadataInfo>(info.XmpMetadata);
+        Assert.Equal(payload.Length, metadata.StreamSizeBytes);
+        Assert.Equal(PdfReadDocument.MaxXmpMetadataBytes + 1, metadata.DecodedSizeBytes);
+        Assert.Null(metadata.RawXml);
+        Assert.False(metadata.IsWellFormedXml);
+    }
+
+    [Fact]
+    public void Inspect_XmpMetadataRejectsPredictorDecodeParmsBeforeExpansion() {
+        byte[] compressed = Compress(System.Text.Encoding.UTF8.GetBytes("<x:xmpmeta/>"));
+
+        PdfDocumentInfo info = PdfInspector.Inspect(BuildFilteredXmpMetadataPdf(
+            compressed,
+            "/Filter /FlateDecode /DecodeParms << /Predictor 12 /Columns 100000000 >>"));
+
+        Assert.True(info.HasXmpMetadata);
+        PdfXmpMetadataInfo metadata = Assert.IsType<PdfXmpMetadataInfo>(info.XmpMetadata);
+        Assert.Equal(compressed.Length, metadata.StreamSizeBytes);
+        Assert.Equal(PdfReadDocument.MaxXmpMetadataBytes + 1, metadata.DecodedSizeBytes);
+        Assert.Null(metadata.RawXml);
+        Assert.False(metadata.IsWellFormedXml);
+    }
+
+    [Fact]
     public void Preflight_AllowsSimpleCatalogUriPdfReadAndRewrite() {
         PdfDocumentPreflight report = PdfInspector.Preflight(BuildCatalogUriPdf());
 
@@ -439,6 +469,10 @@ public partial class PdfInspectorTests {
 
     private static byte[] BuildCompressedXmpMetadataPdfWithPayload(string xmp) {
         byte[] compressed = Compress(System.Text.Encoding.UTF8.GetBytes(xmp));
+        return BuildFilteredXmpMetadataPdf(compressed, "/Filter /FlateDecode");
+    }
+
+    private static byte[] BuildFilteredXmpMetadataPdf(byte[] streamData, string dictionarySuffix) {
         using var output = new MemoryStream();
         WriteAscii(output, string.Join("\n", new[] {
             "%PDF-1.4",
@@ -458,10 +492,10 @@ public partial class PdfInspectorTests {
             "endstream",
             "endobj",
             "5 0 obj",
-            "<< /Type /Metadata /Subtype /XML /Length " + compressed.Length.ToString(System.Globalization.CultureInfo.InvariantCulture) + " /Filter /FlateDecode >>",
+            "<< /Type /Metadata /Subtype /XML /Length " + streamData.Length.ToString(System.Globalization.CultureInfo.InvariantCulture) + " " + dictionarySuffix + " >>",
             "stream"
         }) + "\n");
-        output.Write(compressed, 0, compressed.Length);
+        output.Write(streamData, 0, streamData.Length);
         WriteAscii(output, "\n" + string.Join("\n", new[] {
             "endstream",
             "endobj",

--- a/OfficeIMO.Tests/Pdf/PdfInspectorViewerMetadataPreflightTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfInspectorViewerMetadataPreflightTests.cs
@@ -266,6 +266,36 @@ public partial class PdfInspectorTests {
     }
 
     [Fact]
+    public void Inspect_AsciiHexXmpMetadataDecodesWithinLimit() {
+        const string xmp = "<x:xmpmeta xmlns:x=\"adobe:ns:meta/\"/>";
+        byte[] encoded = System.Text.Encoding.ASCII.GetBytes(ToHex(System.Text.Encoding.UTF8.GetBytes(xmp)) + ">");
+
+        PdfDocumentInfo info = PdfInspector.Inspect(BuildFilteredXmpMetadataPdf(encoded, "/Filter /ASCIIHexDecode"));
+
+        Assert.True(info.HasXmpMetadata);
+        PdfXmpMetadataInfo metadata = Assert.IsType<PdfXmpMetadataInfo>(info.XmpMetadata);
+        Assert.Equal(xmp.Length, metadata.DecodedSizeBytes);
+        Assert.Equal(xmp, metadata.RawXml);
+        Assert.True(metadata.IsWellFormedXml);
+        Assert.Empty(metadata.UnsupportedFilters);
+    }
+
+    [Fact]
+    public void Inspect_Ascii85XmpMetadataDecodesWithinLimit() {
+        const string xmp = "<x:xmpmeta xmlns:x=\"adobe:ns:meta/\"/>";
+        byte[] encoded = System.Text.Encoding.ASCII.GetBytes(EncodeAscii85ForXmp(System.Text.Encoding.UTF8.GetBytes(xmp)));
+
+        PdfDocumentInfo info = PdfInspector.Inspect(BuildFilteredXmpMetadataPdf(encoded, "/Filter /ASCII85Decode"));
+
+        Assert.True(info.HasXmpMetadata);
+        PdfXmpMetadataInfo metadata = Assert.IsType<PdfXmpMetadataInfo>(info.XmpMetadata);
+        Assert.Equal(xmp.Length, metadata.DecodedSizeBytes);
+        Assert.Equal(xmp, metadata.RawXml);
+        Assert.True(metadata.IsWellFormedXml);
+        Assert.Empty(metadata.UnsupportedFilters);
+    }
+
+    [Fact]
     public void Inspect_XmpMetadataRejectsLzwBeforeUnboundedDecode() {
         byte[] payload = System.Text.Encoding.UTF8.GetBytes("<x:xmpmeta/>");
 
@@ -509,6 +539,52 @@ public partial class PdfInspectorTests {
     private static void WriteAscii(Stream stream, string value) {
         byte[] bytes = System.Text.Encoding.ASCII.GetBytes(value);
         stream.Write(bytes, 0, bytes.Length);
+    }
+
+    private static string EncodeAscii85ForXmp(byte[] input) {
+        var builder = new System.Text.StringBuilder();
+        int offset = 0;
+        while (offset + 4 <= input.Length) {
+            uint value = ((uint)input[offset] << 24) |
+                         ((uint)input[offset + 1] << 16) |
+                         ((uint)input[offset + 2] << 8) |
+                         input[offset + 3];
+            if (value == 0) {
+                builder.Append('z');
+            } else {
+                char[] tuple = new char[5];
+                for (int i = 4; i >= 0; i--) {
+                    tuple[i] = (char)((value % 85) + 33);
+                    value /= 85;
+                }
+
+                builder.Append(tuple);
+            }
+
+            offset += 4;
+        }
+
+        int remaining = input.Length - offset;
+        if (remaining > 0) {
+            uint value = 0;
+            for (int i = 0; i < 4; i++) {
+                value <<= 8;
+                if (i < remaining) {
+                    value |= input[offset + i];
+                }
+            }
+
+            char[] tuple = new char[5];
+            for (int i = 4; i >= 0; i--) {
+                tuple[i] = (char)((value % 85) + 33);
+                value /= 85;
+            }
+
+            builder.Append(tuple, 0, remaining + 1);
+        }
+
+        builder.Append("~>");
+        return builder.ToString();
     }
 
 }

--- a/OfficeIMO.Tests/Pdf/PdfInspectorViewerMetadataPreflightTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfInspectorViewerMetadataPreflightTests.cs
@@ -252,6 +252,20 @@ public partial class PdfInspectorTests {
     }
 
     [Fact]
+    public void Inspect_CompressedXmpMetadataOverLimitDoesNotMaterializeDecodedXml() {
+        string xmp = new('x', PdfReadDocument.MaxXmpMetadataBytes + 1);
+
+        PdfDocumentInfo info = PdfInspector.Inspect(BuildCompressedXmpMetadataPdfWithPayload(xmp));
+
+        Assert.True(info.HasXmpMetadata);
+        PdfXmpMetadataInfo metadata = Assert.IsType<PdfXmpMetadataInfo>(info.XmpMetadata);
+        Assert.True(metadata.StreamSizeBytes < PdfReadDocument.MaxXmpMetadataBytes);
+        Assert.Equal(PdfReadDocument.MaxXmpMetadataBytes + 1, metadata.DecodedSizeBytes);
+        Assert.Null(metadata.RawXml);
+        Assert.False(metadata.IsWellFormedXml);
+    }
+
+    [Fact]
     public void Preflight_AllowsSimpleCatalogUriPdfReadAndRewrite() {
         PdfDocumentPreflight report = PdfInspector.Preflight(BuildCatalogUriPdf());
 
@@ -421,6 +435,46 @@ public partial class PdfInspectorTests {
         });
 
         return System.Text.Encoding.UTF8.GetBytes(pdf);
+    }
+
+    private static byte[] BuildCompressedXmpMetadataPdfWithPayload(string xmp) {
+        byte[] compressed = Compress(System.Text.Encoding.UTF8.GetBytes(xmp));
+        using var output = new MemoryStream();
+        WriteAscii(output, string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R /Metadata 5 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>",
+            "endobj",
+            "4 0 obj",
+            "<< /Length 0 >>",
+            "stream",
+            "",
+            "endstream",
+            "endobj",
+            "5 0 obj",
+            "<< /Type /Metadata /Subtype /XML /Length " + compressed.Length.ToString(System.Globalization.CultureInfo.InvariantCulture) + " /Filter /FlateDecode >>",
+            "stream"
+        }) + "\n");
+        output.Write(compressed, 0, compressed.Length);
+        WriteAscii(output, "\n" + string.Join("\n", new[] {
+            "endstream",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R /Size 6 >>",
+            "%%EOF"
+        }));
+        return output.ToArray();
+    }
+
+    private static void WriteAscii(Stream stream, string value) {
+        byte[] bytes = System.Text.Encoding.ASCII.GetBytes(value);
+        stream.Write(bytes, 0, bytes.Length);
     }
 
 }

--- a/OfficeIMO.Tests/Pdf/PdfLogicalDocumentSupport.cs
+++ b/OfficeIMO.Tests/Pdf/PdfLogicalDocumentSupport.cs
@@ -585,22 +585,5 @@ public partial class PdfLogicalDocumentTests {
         return Encoding.ASCII.GetBytes(pdf);
     }
 
-    private static byte[] CreateMinimalRgbPng() {
-        return new byte[] {
-            137, 80, 78, 71, 13, 10, 26, 10,
-            0, 0, 0, 13,
-            73, 72, 68, 82,
-            0, 0, 0, 1,
-            0, 0, 0, 1,
-            8, 2, 0, 0, 0,
-            0, 0, 0, 0,
-            0, 0, 0, 12,
-            73, 68, 65, 84,
-            0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-            73, 69, 78, 68,
-            0, 0, 0, 0
-        };
-    }
+    private static byte[] CreateMinimalRgbPng() => PdfPngTestImages.CreateRgbPng(255, 0, 0);
 }

--- a/OfficeIMO.Tests/Pdf/PdfMergerTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfMergerTests.cs
@@ -59,7 +59,8 @@ public class PdfMergerTests {
         string pdfText = Encoding.ASCII.GetString(merged);
         Assert.Contains("/Subtype /Image", pdfText);
         Assert.Contains("/Filter /FlateDecode", pdfText);
-        Assert.Contains("/Length 12", pdfText);
+        Assert.Contains("/Width 1", pdfText);
+        Assert.Contains("/Height 1", pdfText);
 
         string text = NormalizeExtractedText(PdfReadDocument.Load(merged).ExtractText());
         AssertContainsInOrder(text, "Imagesourcepage", "Textonlypage");

--- a/OfficeIMO.Tests/Pdf/PdfMergerTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfMergerTests.cs
@@ -408,22 +408,5 @@ public class PdfMergerTests {
         public override bool CanWrite => false;
     }
 
-    private static byte[] CreateMinimalRgbPng() {
-        return new byte[] {
-            137, 80, 78, 71, 13, 10, 26, 10,
-            0, 0, 0, 13,
-            73, 72, 68, 82,
-            0, 0, 0, 1,
-            0, 0, 0, 1,
-            8, 2, 0, 0, 0,
-            0, 0, 0, 0,
-            0, 0, 0, 12,
-            73, 68, 65, 84,
-            0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-            73, 69, 78, 68,
-            0, 0, 0, 0
-        };
-    }
+    private static byte[] CreateMinimalRgbPng() => PdfPngTestImages.CreateRgbPng(255, 0, 0);
 }

--- a/OfficeIMO.Tests/Pdf/PdfPageExtractorPreservationTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfPageExtractorPreservationTests.cs
@@ -26,7 +26,8 @@ public partial class PdfPageExtractorTests {
         string pdfText = Encoding.ASCII.GetString(extracted);
         Assert.Contains("/Subtype /Image", pdfText);
         Assert.Contains("/Filter /FlateDecode", pdfText);
-        Assert.Contains("/Length 12", pdfText);
+        Assert.Contains("/Width 1", pdfText);
+        Assert.Contains("/Height 1", pdfText);
         string extractedText = NormalizeExtractedText(PdfReadDocument.Load(extracted).ExtractText());
         Assert.Contains("Imagepagemarker", extractedText);
         Assert.DoesNotContain("Coverpage", extractedText);

--- a/OfficeIMO.Tests/Pdf/PdfPageExtractorSupport.cs
+++ b/OfficeIMO.Tests/Pdf/PdfPageExtractorSupport.cs
@@ -141,24 +141,7 @@ public partial class PdfPageExtractorTests {
         return expectedCells.All(expected => row.Any(cell => NormalizeExtractedText(cell).Contains(expected, StringComparison.Ordinal)));
     }
 
-    private static byte[] CreateMinimalRgbPng() {
-        return new byte[] {
-            137, 80, 78, 71, 13, 10, 26, 10,
-            0, 0, 0, 13,
-            73, 72, 68, 82,
-            0, 0, 0, 1,
-            0, 0, 0, 1,
-            8, 2, 0, 0, 0,
-            0, 0, 0, 0,
-            0, 0, 0, 12,
-            73, 68, 65, 84,
-            0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-            73, 69, 78, 68,
-            0, 0, 0, 0
-        };
-    }
+    private static byte[] CreateMinimalRgbPng() => PdfPngTestImages.CreateRgbPng(255, 0, 0);
 
     private sealed class WriteOnlyStream : MemoryStream {
         public override bool CanRead => false;

--- a/OfficeIMO.Tests/Pdf/PdfPngTestImages.cs
+++ b/OfficeIMO.Tests/Pdf/PdfPngTestImages.cs
@@ -161,6 +161,24 @@ internal static class PdfPngTestImages {
         return ms.ToArray();
     }
 
+    internal static byte[] CreateOversizedInterlacedGrayscalePng() {
+        using var ms = CreatePng();
+        WritePngChunk(ms, "IHDR", new byte[] {
+            0x00, 0x01, 0x86, 0xA0,
+            0x00, 0x00, 0x75, 0x30,
+            8, 0, 0, 0, 1
+        });
+        WritePngChunk(ms, "IDAT", BuildStoredZlib(Array.Empty<byte>()));
+        WritePngChunk(ms, "IEND", Array.Empty<byte>());
+        return ms.ToArray();
+    }
+
+    internal static byte[] CreatePngWithInvalidCrc() {
+        byte[] png = Create16BitRgbPng();
+        png[png.Length - 1] ^= 0xFF;
+        return png;
+    }
+
     internal static byte[] CreateInterlacedRgbExpectedScanlines() {
         return CreateExpectedScanlines(3, WriteRgbPixel);
     }

--- a/OfficeIMO.Tests/Pdf/PdfPngTestImages.cs
+++ b/OfficeIMO.Tests/Pdf/PdfPngTestImages.cs
@@ -130,6 +130,41 @@ internal static class PdfPngTestImages {
         return ms.ToArray();
     }
 
+    internal static byte[] CreateRgbPng(byte red, byte green, byte blue) {
+        using var ms = CreatePng();
+        WritePngChunk(ms, "IHDR", new byte[] {
+            0, 0, 0, 1,
+            0, 0, 0, 1,
+            8, 2, 0, 0, 0
+        });
+        WritePngChunk(ms, "IDAT", BuildStoredZlib(new byte[] {
+            0,
+            red,
+            green,
+            blue
+        }));
+        WritePngChunk(ms, "IEND", Array.Empty<byte>());
+        return ms.ToArray();
+    }
+
+    internal static byte[] CreateRgbaPng(byte red, byte green, byte blue, byte alpha) {
+        using var ms = CreatePng();
+        WritePngChunk(ms, "IHDR", new byte[] {
+            0, 0, 0, 1,
+            0, 0, 0, 1,
+            8, 6, 0, 0, 0
+        });
+        WritePngChunk(ms, "IDAT", BuildStoredZlib(new byte[] {
+            0,
+            red,
+            green,
+            blue,
+            alpha
+        }));
+        WritePngChunk(ms, "IEND", Array.Empty<byte>());
+        return ms.ToArray();
+    }
+
     internal static byte[] CreateInterlacedRgbaPng() {
         using var ms = CreatePng();
         WritePngChunk(ms, "IHDR", new byte[] {
@@ -177,6 +212,23 @@ internal static class PdfPngTestImages {
         byte[] png = Create16BitRgbPng();
         png[png.Length - 1] ^= 0xFF;
         return png;
+    }
+
+    internal static byte[] CreatePngWithOverflowingChunkLength() {
+        using var ms = CreatePng();
+        WritePngChunk(ms, "IHDR", new byte[] {
+            0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x01,
+            8, 2, 0, 0, 0
+        });
+        ms.WriteByte(0x7F);
+        ms.WriteByte(0xFF);
+        ms.WriteByte(0xFF);
+        ms.WriteByte(0xFF);
+        byte[] type = Encoding.ASCII.GetBytes("tEXt");
+        ms.Write(type, 0, type.Length);
+        ms.Write(new byte[4], 0, 4);
+        return ms.ToArray();
     }
 
     internal static byte[] CreateInterlacedRgbExpectedScanlines() {

--- a/OfficeIMO.Tests/Pdf/PdfPngTestImages.cs
+++ b/OfficeIMO.Tests/Pdf/PdfPngTestImages.cs
@@ -214,6 +214,27 @@ internal static class PdfPngTestImages {
         return png;
     }
 
+    internal static byte[] CreateRgbPngWithExtraDecodedScanlines() {
+        using var ms = CreatePng();
+        WritePngChunk(ms, "IHDR", new byte[] {
+            0, 0, 0, 1,
+            0, 0, 0, 1,
+            8, 2, 0, 0, 0
+        });
+        WritePngChunk(ms, "IDAT", BuildStoredZlib(new byte[] {
+            0,
+            0xFF,
+            0x00,
+            0x00,
+            0,
+            0x00,
+            0xFF,
+            0x00
+        }));
+        WritePngChunk(ms, "IEND", Array.Empty<byte>());
+        return ms.ToArray();
+    }
+
     internal static byte[] CreatePngWithOverflowingChunkLength() {
         using var ms = CreatePng();
         WritePngChunk(ms, "IHDR", new byte[] {

--- a/OfficeIMO.Tests/Pdf/PdfStamperSupport.cs
+++ b/OfficeIMO.Tests/Pdf/PdfStamperSupport.cs
@@ -166,44 +166,9 @@ public partial class PdfStamperTests {
         public override bool CanWrite => false;
     }
 
-    private static byte[] CreateMinimalRgbPng() {
-        return new byte[] {
-            137, 80, 78, 71, 13, 10, 26, 10,
-            0, 0, 0, 13,
-            73, 72, 68, 82,
-            0, 0, 0, 1,
-            0, 0, 0, 1,
-            8, 2, 0, 0, 0,
-            0, 0, 0, 0,
-            0, 0, 0, 12,
-            73, 68, 65, 84,
-            0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-            73, 69, 78, 68,
-            0, 0, 0, 0
-        };
-    }
+    private static byte[] CreateMinimalRgbPng() => PdfPngTestImages.CreateRgbPng(255, 0, 0);
 
-    private static byte[] CreateMinimalRgbaPng() {
-        return new byte[] {
-            137, 80, 78, 71, 13, 10, 26, 10,
-            0, 0, 0, 13,
-            73, 72, 68, 82,
-            0, 0, 0, 1,
-            0, 0, 0, 1,
-            8, 6, 0, 0, 0,
-            0, 0, 0, 0,
-            0, 0, 0, 16,
-            73, 68, 65, 84,
-            0x78, 0x01, 0x01, 0x05, 0x00, 0xFA, 0xFF, 0x00,
-            0xFF, 0x00, 0x00, 0x80, 0x04, 0x81, 0x01, 0x80,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-            73, 69, 78, 68,
-            0, 0, 0, 0
-        };
-    }
+    private static byte[] CreateMinimalRgbaPng() => PdfPngTestImages.CreateRgbaPng(255, 0, 0, 128);
 
     private static byte[] CreateMinimalIndexedColorPng() {
         using var ms = new MemoryStream();

--- a/OfficeIMO.Tests/Pdf/PdfStamperSupport.cs
+++ b/OfficeIMO.Tests/Pdf/PdfStamperSupport.cs
@@ -287,7 +287,33 @@ public partial class PdfStamperTests {
         byte[] typeBytes = Encoding.ASCII.GetBytes(type);
         stream.Write(typeBytes, 0, typeBytes.Length);
         stream.Write(data, 0, data.Length);
-        byte[] crc = new byte[] { 0, 0, 0, 0 };
-        stream.Write(crc, 0, crc.Length);
+        uint crc = ComputeCrc32(typeBytes, data);
+        stream.WriteByte((byte)((crc >> 24) & 0xFF));
+        stream.WriteByte((byte)((crc >> 16) & 0xFF));
+        stream.WriteByte((byte)((crc >> 8) & 0xFF));
+        stream.WriteByte((byte)(crc & 0xFF));
     }
+
+    private static uint ComputeCrc32(byte[] typeBytes, byte[] data) {
+        uint crc = 0xFFFFFFFF;
+        for (int i = 0; i < typeBytes.Length; i++) {
+            crc = UpdateCrc32(crc, typeBytes[i]);
+        }
+
+        for (int i = 0; i < data.Length; i++) {
+            crc = UpdateCrc32(crc, data[i]);
+        }
+
+        return crc ^ 0xFFFFFFFF;
+    }
+
+    private static uint UpdateCrc32(uint crc, byte value) {
+        crc ^= value;
+        for (int bit = 0; bit < 8; bit++) {
+            crc = (crc & 1) != 0 ? (crc >> 1) ^ 0xEDB88320 : crc >> 1;
+        }
+
+        return crc;
+    }
+
 }

--- a/OfficeIMO.Tests/Pdf/PowerPoint.SaveAsPdf.SecurityTests.cs
+++ b/OfficeIMO.Tests/Pdf/PowerPoint.SaveAsPdf.SecurityTests.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using OfficeIMO.PowerPoint;
+using OfficeIMO.PowerPoint.Pdf;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf;
+
+public class PowerPointSaveAsPdfSecurityTests {
+    [Fact]
+    public void SaveAsPdf_PowerPointPresentation_StopsAtConfiguredGroupDepth() {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".pptx");
+        try {
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(path);
+            PowerPointSlide slide = presentation.AddSlide();
+            PowerPointTextBox textBox = slide.AddTextBoxPoints("Nested text", 72, 72, 144, 36);
+            PowerPointTextBox secondTextBox = slide.AddTextBoxPoints("Nested sibling", 72, 120, 144, 36);
+            slide.GroupShapes(new PowerPointShape[] { textBox, secondTextBox }, "Outer");
+
+            var options = new PowerPointPdfSaveOptions {
+                MaxGroupShapeDepth = 0
+            };
+
+            _ = presentation.ToPdfDocument(options);
+
+            PowerPointPdfExportWarning warning = Assert.Single(options.Warnings, item => item.Code == "group-depth-limit");
+            Assert.Equal(1, warning.SlideNumber);
+            Assert.Contains("MaxGroupShapeDepth", warning.Message, StringComparison.Ordinal);
+        } finally {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Pdf/PowerPoint.SaveAsPdf.cs
+++ b/OfficeIMO.Tests/Pdf/PowerPoint.SaveAsPdf.cs
@@ -1700,24 +1700,7 @@ public class PowerPointSaveAsPdfTests {
         Assert.Contains("Dense Slide Chart", pdf.GetPage(1).Text, StringComparison.Ordinal);
     }
 
-    private static byte[] CreateMinimalRgbPng() {
-        return new byte[] {
-            137, 80, 78, 71, 13, 10, 26, 10,
-            0, 0, 0, 13,
-            73, 72, 68, 82,
-            0, 0, 0, 1,
-            0, 0, 0, 1,
-            8, 2, 0, 0, 0,
-            0, 0, 0, 0,
-            0, 0, 0, 12,
-            73, 68, 65, 84,
-            0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-            73, 69, 78, 68,
-            0, 0, 0, 0
-        };
-    }
+    private static byte[] CreateMinimalRgbPng() => PdfPngTestImages.CreateRgbPng(255, 0, 0);
 
     private static void SetBarChartShape(PowerPointChart chart, C.BarDirectionValues direction, C.BarGroupingValues grouping) {
         ChartPart chartPart = GetChartPart(chart);

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.StructuredBlocks.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.StructuredBlocks.cs
@@ -4,6 +4,7 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Drawing;
 using OfficeIMO.Pdf;
+using OfficeIMO.Tests.Pdf;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Pdf;
 using System;
@@ -2441,8 +2442,7 @@ public partial class Word {
         return Assert.IsType<double>(value);
     }
 
-    private static byte[] CreateNativeMinimalRgbPng() =>
-        Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADUlEQVR42mP8z8BQDwAFgwJ/l2hYtQAAAABJRU5ErkJggg==");
+    private static byte[] CreateNativeMinimalRgbPng() => PdfPngTestImages.CreateRgbPng(1, 1);
 
     [Fact]
     public void SaveAsPdf_OfficeIMOEngine_NativeVmlImageReader_Rejects_Images_Above_Limit() {

--- a/OfficeIMO.Tests/Reader.Pdf.Modular.cs
+++ b/OfficeIMO.Tests/Reader.Pdf.Modular.cs
@@ -1477,24 +1477,7 @@ public sealed class ReaderPdfModularTests {
             .ToBytes();
     }
 
-    private static byte[] CreateMinimalRgbPng() {
-        return new byte[] {
-            137, 80, 78, 71, 13, 10, 26, 10,
-            0, 0, 0, 13,
-            73, 72, 68, 82,
-            0, 0, 0, 1,
-            0, 0, 0, 1,
-            8, 2, 0, 0, 0,
-            0, 0, 0, 0,
-            0, 0, 0, 12,
-            73, 68, 65, 84,
-            0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0x00, 0x00, 0x03, 0x01, 0x01, 0x00,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-            73, 69, 78, 68,
-            0, 0, 0, 0
-        };
-    }
+    private static byte[] CreateMinimalRgbPng() => PdfPngTestImages.CreateRgbPng(1, 1);
 
     private static byte[] CreateLinkAnnotationPdf(string uri) {
         string escapedUri = uri.Replace("\\", "\\\\").Replace("(", "\\(").Replace(")", "\\)");

--- a/OfficeIMO.Tests/Reader.Yaml.Modular.cs
+++ b/OfficeIMO.Tests/Reader.Yaml.Modular.cs
@@ -268,6 +268,44 @@ public sealed class ReaderYamlModularTests {
     }
 
     [Fact]
+    public void DocumentReaderYaml_ReadYamlStream_EnforcesParseEventLimitBeforeModelLoad() {
+        const string yaml =
+            "root:\n" +
+            "  - one\n" +
+            "  - two\n" +
+            "  - three\n";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(yaml), writable: false);
+
+        var chunk = Assert.Single(DocumentReaderYamlExtensions.ReadYaml(
+            stream,
+            sourceName: "parse-limited.yaml",
+            yamlOptions: new YamlReadOptions {
+                MaxParseEvents = 3,
+                IncludeMarkdown = false
+            }));
+
+        Assert.Contains("YAML parse limit exceeded", chunk.Text ?? string.Empty, StringComparison.Ordinal);
+        Assert.Contains("maximum parse event count reached", chunk.Text ?? string.Empty, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DocumentReaderYaml_ReadYamlStream_EnforcesScalarLengthBeforeModelLoad() {
+        string yaml = "value: " + new string('a', 32) + "\n";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(yaml), writable: false);
+
+        var chunk = Assert.Single(DocumentReaderYamlExtensions.ReadYaml(
+            stream,
+            sourceName: "scalar-limited.yaml",
+            yamlOptions: new YamlReadOptions {
+                MaxScalarLength = 8,
+                IncludeMarkdown = false
+            }));
+
+        Assert.Contains("YAML parse limit exceeded", chunk.Text ?? string.Empty, StringComparison.Ordinal);
+        Assert.Contains("scalar length exceeds maximum", chunk.Text ?? string.Empty, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void DocumentReaderYaml_ReadYamlStream_CountsDepthLimitedChildrenAgainstNodeLimit() {
         const string yaml =
             "root:\n" +

--- a/OfficeIMO.Tests/Rtf/RtfHtmlFieldTests.cs
+++ b/OfficeIMO.Tests/Rtf/RtfHtmlFieldTests.cs
@@ -89,6 +89,40 @@ public class RtfHtmlFieldTests {
     }
 
     [Fact]
+    public void Html_ToRtfDocument_Rejects_Unsafe_Hyperlink_Field_Instruction_Target() {
+        const string html = "<p><span data-officeimo-rtf-field=\"true\" data-officeimo-rtf-field-instruction=\"HYPERLINK &quot;file:///C:/secret.txt&quot;\">Secret</span></p>";
+        var options = new HtmlToRtfOptions {
+            UrlPolicy = HtmlUrlPolicy.CreateWebOnlyProfile()
+        };
+
+        RtfDocument document = html.ToRtfDocument(options);
+        RtfParagraph paragraph = Assert.Single(document.Paragraphs);
+
+        Assert.Empty(paragraph.Inlines.OfType<RtfField>());
+        Assert.Equal("Secret", paragraph.ToPlainText());
+        HtmlRtfConversionDiagnostic diagnostic = Assert.Single(options.Diagnostics);
+        Assert.Equal("RtfHtmlFieldHyperlinkRejected", diagnostic.Code);
+        Assert.Equal("data-officeimo-rtf-field-instruction", diagnostic.Source);
+    }
+
+    [Fact]
+    public void Html_ToRtfDocument_Rejects_Unsafe_Hyperlink_Field_Metadata_Target() {
+        const string html = "<p><a href=\"https://example.test/\" data-officeimo-rtf-field=\"true\" data-officeimo-rtf-field-instruction=\"HYPERLINK &quot;https://example.test/&quot;\" data-officeimo-rtf-field-hyperlink=\"javascript:alert(1)\">Link</a></p>";
+        var options = new HtmlToRtfOptions {
+            UrlPolicy = HtmlUrlPolicy.CreateWebOnlyProfile()
+        };
+
+        RtfDocument document = html.ToRtfDocument(options);
+        RtfParagraph paragraph = Assert.Single(document.Paragraphs);
+
+        Assert.Empty(paragraph.Inlines.OfType<RtfField>());
+        Assert.Equal("Link", paragraph.ToPlainText());
+        HtmlRtfConversionDiagnostic diagnostic = Assert.Single(options.Diagnostics);
+        Assert.Equal("RtfHtmlFieldHyperlinkRejected", diagnostic.Code);
+        Assert.Equal("data-officeimo-rtf-field-hyperlink", diagnostic.Source);
+    }
+
+    [Fact]
     public void RtfDocument_ToHtml_Escapes_Field_Instruction_Attribute() {
         RtfDocument document = RtfDocument.Create();
         RtfField field = document.AddParagraph().AddField("MERGEFIELD Patient<Name>");

--- a/OfficeIMO.Tests/Rtf/RtfHtmlFieldTests.cs
+++ b/OfficeIMO.Tests/Rtf/RtfHtmlFieldTests.cs
@@ -106,6 +106,25 @@ public class RtfHtmlFieldTests {
     }
 
     [Fact]
+    public void Html_ToRtfDocument_Rejects_Hyperlink_Field_Instruction_With_Extra_Target() {
+        const string html = "<p><a href=\"https://example.test/\" data-officeimo-rtf-field=\"true\" data-officeimo-rtf-field-instruction=\"HYPERLINK &quot;file:///C:/secret.txt&quot; &quot;https://example.test/&quot;\">Link</a></p>";
+        var options = new HtmlToRtfOptions {
+            UrlPolicy = HtmlUrlPolicy.CreateWebOnlyProfile()
+        };
+
+        RtfDocument document = html.ToRtfDocument(options);
+        RtfParagraph paragraph = Assert.Single(document.Paragraphs);
+        string rtf = document.ToRtf();
+
+        Assert.Empty(paragraph.Inlines.OfType<RtfField>());
+        Assert.Equal("Link", paragraph.ToPlainText());
+        Assert.DoesNotContain("file:///C:/secret.txt", rtf, StringComparison.OrdinalIgnoreCase);
+        HtmlRtfConversionDiagnostic diagnostic = Assert.Single(options.Diagnostics);
+        Assert.Equal("RtfHtmlFieldHyperlinkRejected", diagnostic.Code);
+        Assert.Equal("data-officeimo-rtf-field-instruction", diagnostic.Source);
+    }
+
+    [Fact]
     public void Html_ToRtfDocument_Rejects_Unsafe_Hyperlink_Field_Metadata_Target() {
         const string html = "<p><a href=\"https://example.test/\" data-officeimo-rtf-field=\"true\" data-officeimo-rtf-field-instruction=\"HYPERLINK &quot;https://example.test/&quot;\" data-officeimo-rtf-field-hyperlink=\"javascript:alert(1)\">Link</a></p>";
         var options = new HtmlToRtfOptions {

--- a/OfficeIMO.Tests/Visio.Comments.cs
+++ b/OfficeIMO.Tests/Visio.Comments.cs
@@ -229,6 +229,43 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void SaveRejectsOversizedNativeCommentTextWithoutTruncatingExistingTarget() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+            VisioDocument valid = VisioDocument.Create(filePath);
+            valid.AddPage("Original", 11, 8.5).AddComment("Keep this file", "Operations", "OP");
+            valid.Save();
+            byte[] originalBytes = File.ReadAllBytes(filePath);
+
+            VisioDocument invalid = VisioDocument.Create(filePath);
+            invalid.AddPage("Review", 11, 8.5)
+                .AddComment(new string('x', VisioDocument.MaxCommentTextCharacters + 1), "Operations", "OP");
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() => invalid.Save());
+
+            Assert.Contains(VisioDocument.MaxCommentTextCharacters.ToString(), exception.Message);
+            Assert.Equal(originalBytes, File.ReadAllBytes(filePath));
+        }
+
+        [Fact]
+        public void SaveRejectsDuplicatePageIdsWithoutTruncatingExistingTarget() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+            VisioDocument valid = VisioDocument.Create(filePath);
+            valid.AddPage("Original", 11, 8.5).Shapes.Add(new VisioShape("original", 1, 1, 1, 1, "Original"));
+            valid.Save();
+            byte[] originalBytes = File.ReadAllBytes(filePath);
+
+            VisioDocument invalid = VisioDocument.Create(filePath);
+            VisioPage page = invalid.AddPage("Broken", 11, 8.5);
+            page.Shapes.Add(new VisioShape("duplicate", 1, 1, 1, 1, "One"));
+            page.Shapes.Add(new VisioShape("duplicate", 3, 1, 1, 1, "Two"));
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => invalid.Save());
+
+            Assert.Contains("Duplicate", exception.Message);
+            Assert.Equal(originalBytes, File.ReadAllBytes(filePath));
+        }
+
+        [Fact]
         public void SaveRejectsCommentsPartThatExceedsUtf8ByteLimit() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
             VisioDocument document = VisioDocument.Create(filePath);

--- a/OfficeIMO.Tests/Visio.Stencils.cs
+++ b/OfficeIMO.Tests/Visio.Stencils.cs
@@ -974,6 +974,19 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ImportStencilMastersRejectsOversizedEmbeddedMasterRelationship() {
+            string packagePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vssx");
+            byte[] oversizedMedia = new byte[checked((int)VisioAssets.MaxMasterRelationshipBytes + 1)];
+            CreatePackageWithRawGroupMaster(packagePath, "FancyCloud", "Fancy Cloud", "png", oversizedMedia);
+            VisioDocument document = VisioDocument.Create(Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx"));
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                document.ImportStencilMastersAndGet(packagePath, new[] { "fancy-cloud" }));
+
+            Assert.Contains(VisioAssets.MaxMasterRelationshipBytes.ToString(), exception.Message);
+        }
+
+        [Fact]
         public void ReplaceMasterImportsPackageMasterWhenNameUAlreadyRegistered() {
             string packagePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vssx");
             CreatePackageWithRawGroupMaster(packagePath, "Rectangle", "Package Rectangle");

--- a/OfficeIMO.Tests/Visio.Validation.cs
+++ b/OfficeIMO.Tests/Visio.Validation.cs
@@ -132,6 +132,41 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ValidatorRejectsVisioPagesXmlDtdWithoutThrowing() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+
+            VisioDocument document = VisioDocument.Create(filePath);
+            VisioPage page = document.AddPage("Page-1");
+            page.Shapes.Add(new VisioShape("1", 1, 1, 2, 1, "Start"));
+            document.Save();
+
+            using (FileStream stream = new(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            using (ZipArchive archive = new(stream, ZipArchiveMode.Update)) {
+                ZipArchiveEntry? entry = archive.GetEntry("visio/pages/pages.xml");
+                Assert.NotNull(entry);
+                entry!.Delete();
+
+                ZipArchiveEntry replacement = archive.CreateEntry("visio/pages/pages.xml");
+                using StreamWriter writer = new(replacement.Open());
+                writer.Write("""
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE Pages [<!ENTITY local "expanded">]>
+<Pages xmlns="http://schemas.microsoft.com/office/visio/2012/main">
+  <Page ID="0" NameU="&local;" />
+</Pages>
+""");
+            }
+
+            IReadOnlyList<string> issues = Array.Empty<string>();
+            Exception? exception = Record.Exception(() => issues = VisioValidator.Validate(filePath));
+
+            Assert.Null(exception);
+            Assert.Contains(issues, issue =>
+                issue.Contains("pages.xml", StringComparison.OrdinalIgnoreCase) &&
+                issue.Contains("not valid XML", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
         public void ValidatorReportsMissingPagesRelationshipsWithoutThrowing() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
 

--- a/OfficeIMO.Visio/VisioAssets.cs
+++ b/OfficeIMO.Visio/VisioAssets.cs
@@ -13,6 +13,14 @@ namespace OfficeIMO.Visio {
         private const string V = "http://schemas.microsoft.com/office/visio/2012/main";
         private const string REL_PKG = "http://schemas.openxmlformats.org/package/2006/relationships";
         private const string REL_ODC = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+        /// <summary>Maximum uncompressed size accepted for a Visio master-related XML part.</summary>
+        public const long MaxMasterXmlPartBytes = 12_000_000;
+        /// <summary>Maximum uncompressed size accepted for a single embedded master relationship payload.</summary>
+        public const long MaxMasterRelationshipBytes = 16_000_000;
+        /// <summary>Maximum cumulative uncompressed size accepted for embedded master relationship payloads.</summary>
+        public const long MaxTotalMasterRelationshipBytes = 64_000_000;
+        /// <summary>Maximum number of master relationships copied from one Visio package import.</summary>
+        public const int MaxMasterRelationships = 4096;
 
         /// <summary>
         /// Lightweight info about a master available inside a Visio package.
@@ -83,6 +91,7 @@ namespace OfficeIMO.Visio {
             using ZipArchive zip = ZipFile.OpenRead(vsdxPath);
             var mastersEntry = zip.GetEntry("visio/masters/masters.xml");
             if (mastersEntry == null) return Array.Empty<MasterInfo>();
+            EnsureZipEntryWithinLimit(mastersEntry, MaxMasterXmlPartBytes, "masters XML part");
             using var s = mastersEntry.Open();
             XDocument doc = XDocument.Load(s);
             XNamespace v = V;
@@ -102,6 +111,7 @@ namespace OfficeIMO.Visio {
             using ZipArchive zip = ZipFile.OpenRead(vsdxPath);
             var mastersEntry = zip.GetEntry("visio/masters/masters.xml");
             if (mastersEntry == null) return Array.Empty<MasterContent>();
+            EnsureZipEntryWithinLimit(mastersEntry, MaxMasterXmlPartBytes, "masters XML part");
             using var mStream = mastersEntry.Open();
             XDocument mastersDoc = XDocument.Load(mStream);
             XNamespace v = V;
@@ -110,6 +120,7 @@ namespace OfficeIMO.Visio {
             var relsEntry = zip.GetEntry("visio/masters/_rels/masters.xml.rels");
             var relMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             if (relsEntry != null) {
+                EnsureZipEntryWithinLimit(relsEntry, MaxMasterXmlPartBytes, "masters relationship part");
                 using var relsStream = relsEntry.Open();
                 var relsDoc = XDocument.Load(relsStream);
                 XNamespace pr = REL_PKG;
@@ -120,6 +131,8 @@ namespace OfficeIMO.Visio {
                 }
             }
             List<MasterContent> result = new();
+            long totalRelationshipBytes = 0;
+            int totalRelationships = 0;
             foreach (var m in mastersDoc.Root!.Elements(v + "Master")) {
                 string id = (string?)m.Attribute("ID") ?? string.Empty;
                 string nameU = (string?)m.Attribute("NameU") ?? string.Empty;
@@ -131,10 +144,11 @@ namespace OfficeIMO.Visio {
                 string partPath = "visio/masters/" + target.Replace("\\", "/");
                 var part = zip.GetEntry(partPath);
                 if (part == null) continue;
+                EnsureZipEntryWithinLimit(part, MaxMasterXmlPartBytes, "master XML part");
                 using var pStream = part.Open();
                 XDocument masterXml = XDocument.Load(pStream);
                 MasterContent content = new() { Id = id, NameU = nameU, MasterXml = masterXml, MasterElement = new XElement(m) };
-                foreach (MasterRelationshipContent relationship in LoadMasterRelationships(zip, partPath)) {
+                foreach (MasterRelationshipContent relationship in LoadMasterRelationships(zip, partPath, ref totalRelationshipBytes, ref totalRelationships)) {
                     content.Relationships.Add(relationship);
                 }
 
@@ -151,12 +165,14 @@ namespace OfficeIMO.Visio {
             PackageVisualContext context = new();
             ZipArchiveEntry? documentEntry = zip.GetEntry("visio/document.xml");
             if (documentEntry != null) {
+                EnsureZipEntryWithinLimit(documentEntry, MaxMasterXmlPartBytes, "document XML part");
                 using Stream stream = documentEntry.Open();
                 context.DocumentXml = XDocument.Load(stream);
             }
 
             ZipArchiveEntry? themeEntry = zip.GetEntry("visio/theme/theme1.xml");
             if (themeEntry != null) {
+                EnsureZipEntryWithinLimit(themeEntry, MaxMasterXmlPartBytes, "theme XML part");
                 using Stream stream = themeEntry.Open();
                 context.ThemeXml = XDocument.Load(stream);
             }
@@ -177,7 +193,7 @@ namespace OfficeIMO.Visio {
             }
         }
 
-        private static IEnumerable<MasterRelationshipContent> LoadMasterRelationships(ZipArchive zip, string masterPartPath) {
+        private static IEnumerable<MasterRelationshipContent> LoadMasterRelationships(ZipArchive zip, string masterPartPath, ref long totalRelationshipBytes, ref int totalRelationships) {
             string fileName = Path.GetFileName(masterPartPath.Replace('\\', '/'));
             string relsPath = "visio/masters/_rels/" + fileName + ".rels";
             ZipArchiveEntry? relsEntry = zip.GetEntry(relsPath);
@@ -185,6 +201,7 @@ namespace OfficeIMO.Visio {
                 return Array.Empty<MasterRelationshipContent>();
             }
 
+            EnsureZipEntryWithinLimit(relsEntry, MaxMasterXmlPartBytes, "master relationship XML part");
             using Stream relsStream = relsEntry.Open();
             XDocument relsDoc = XDocument.Load(relsStream);
             XNamespace pr = REL_PKG;
@@ -196,6 +213,11 @@ namespace OfficeIMO.Visio {
                 bool external = string.Equals((string?)rel.Attribute("TargetMode"), "External", StringComparison.OrdinalIgnoreCase);
                 if (string.IsNullOrWhiteSpace(id) || string.IsNullOrWhiteSpace(type) || string.IsNullOrWhiteSpace(target)) {
                     continue;
+                }
+
+                totalRelationships++;
+                if (totalRelationships > MaxMasterRelationships) {
+                    throw new InvalidDataException($"Visio package master relationships exceed {MaxMasterRelationships} entries.");
                 }
 
                 MasterRelationshipContent relationship = new() {
@@ -213,10 +235,7 @@ namespace OfficeIMO.Visio {
                         continue;
                     }
 
-                    using Stream targetStream = targetEntry.Open();
-                    using MemoryStream buffer = new();
-                    targetStream.CopyTo(buffer);
-                    relationship.Data = buffer.ToArray();
+                    relationship.Data = ReadMasterRelationshipBytes(targetEntry, ref totalRelationshipBytes);
                     relationship.Extension = Path.GetExtension(targetPath);
                     relationship.ContentType = GuessContentType(relationship.Extension);
                 }
@@ -225,6 +244,45 @@ namespace OfficeIMO.Visio {
             }
 
             return relationships;
+        }
+
+        private static byte[] ReadMasterRelationshipBytes(ZipArchiveEntry entry, ref long totalRelationshipBytes) {
+            EnsureZipEntryWithinLimit(entry, MaxMasterRelationshipBytes, "master relationship target");
+            if (totalRelationshipBytes > MaxTotalMasterRelationshipBytes - entry.Length) {
+                throw new InvalidDataException($"Visio package master relationship targets exceed {MaxTotalMasterRelationshipBytes} total bytes.");
+            }
+
+            using Stream source = entry.Open();
+            using MemoryStream buffer = entry.Length > 0 && entry.Length <= int.MaxValue
+                ? new MemoryStream((int)entry.Length)
+                : new MemoryStream();
+            CopyToWithLimit(source, buffer, MaxMasterRelationshipBytes, entry.FullName);
+            if (totalRelationshipBytes > MaxTotalMasterRelationshipBytes - buffer.Length) {
+                throw new InvalidDataException($"Visio package master relationship targets exceed {MaxTotalMasterRelationshipBytes} total bytes.");
+            }
+
+            totalRelationshipBytes += buffer.Length;
+            return buffer.ToArray();
+        }
+
+        private static void EnsureZipEntryWithinLimit(ZipArchiveEntry entry, long maxBytes, string description) {
+            if (entry.Length > maxBytes) {
+                throw new InvalidDataException($"Visio package {description} '{entry.FullName}' exceeds {maxBytes} bytes.");
+            }
+        }
+
+        private static void CopyToWithLimit(Stream source, Stream destination, long maxBytes, string entryName) {
+            byte[] buffer = new byte[81920];
+            long copied = 0;
+            int read;
+            while ((read = source.Read(buffer, 0, buffer.Length)) > 0) {
+                copied += read;
+                if (copied > maxBytes) {
+                    throw new InvalidDataException($"Visio package master relationship target '{entryName}' exceeds {maxBytes} bytes.");
+                }
+
+                destination.Write(buffer, 0, read);
+            }
         }
 
         private static string ResolveZipPath(string basePath, string target) {

--- a/OfficeIMO.Visio/VisioDocument.SaveCore.Comments.cs
+++ b/OfficeIMO.Visio/VisioDocument.SaveCore.Comments.cs
@@ -43,6 +43,22 @@ namespace OfficeIMO.Visio {
             PackagePart commentsPart,
             IReadOnlyList<VisioPage> pages,
             IReadOnlyDictionary<VisioPage, Dictionary<string, VisioMaster>> effectivePageMasters) {
+            string serializedComments = BuildCommentsXmlForSave(pages, effectivePageMasters);
+
+            using Stream stream = commentsPart.GetStream(FileMode.Create, FileAccess.Write);
+            using StreamWriter writer = new(stream, new UTF8Encoding(false));
+            writer.Write(serializedComments);
+        }
+
+        private static void ValidateCommentsForSave(
+            IReadOnlyList<VisioPage> pages,
+            IReadOnlyDictionary<VisioPage, Dictionary<string, VisioMaster>> effectivePageMasters) {
+            _ = BuildCommentsXmlForSave(pages, effectivePageMasters);
+        }
+
+        private static string BuildCommentsXmlForSave(
+            IReadOnlyList<VisioPage> pages,
+            IReadOnlyDictionary<VisioPage, Dictionary<string, VisioMaster>> effectivePageMasters) {
             XNamespace ns = VisioNamespace;
             Dictionary<CommentAuthorKey, int> authorIds = new();
             List<(VisioPage Page, VisioComment Comment, int AuthorId)> comments = new();
@@ -110,10 +126,7 @@ namespace OfficeIMO.Visio {
 
             string serializedComments = commentsXml.Declaration + Environment.NewLine + commentsXml.ToString(SaveOptions.DisableFormatting);
             ValidateCommentsXmlForSave(serializedComments);
-
-            using Stream stream = commentsPart.GetStream(FileMode.Create, FileAccess.Write);
-            using StreamWriter writer = new(stream, new UTF8Encoding(false));
-            writer.Write(serializedComments);
+            return serializedComments;
         }
 
         private static void ValidateCommentForSave(VisioComment comment) {

--- a/OfficeIMO.Visio/VisioDocument.SaveCore.Masters.cs
+++ b/OfficeIMO.Visio/VisioDocument.SaveCore.Masters.cs
@@ -33,6 +33,15 @@ namespace OfficeIMO.Visio {
             return map;
         }
 
+        private Dictionary<VisioPage, Dictionary<string, VisioMaster>> BuildEffectivePageMastersForSave(IReadOnlyList<VisioPage> pages) {
+            Dictionary<VisioPage, Dictionary<string, VisioMaster>> effectivePageMasters = new();
+            foreach (VisioPage page in pages) {
+                effectivePageMasters[page] = BuildEffectiveShapeMasterMap(page);
+            }
+
+            return effectivePageMasters;
+        }
+
         private static void AddMastersInShapeOrder(IEnumerable<VisioShape> shapes, IReadOnlyDictionary<string, VisioMaster> pageMasters, IList<VisioMaster> masterCandidates) {
             foreach (VisioShape shape in shapes) {
                 if (pageMasters.TryGetValue(shape.Id, out VisioMaster? master)) {

--- a/OfficeIMO.Visio/VisioDocument.SaveCore.cs
+++ b/OfficeIMO.Visio/VisioDocument.SaveCore.cs
@@ -23,6 +23,11 @@ namespace OfficeIMO.Visio {
             List<VisioPage> pagesToSave = _pages.Count > 0 ? _pages : new List<VisioPage> { new VisioPage("Page-1") { Id = 0 } };
             bool includeComments = pagesToSave.Any(page => page.Comments.Count > 0);
             PrepareTextFontFaceNames(pagesToSave);
+            ValidatePagesForSave(pagesToSave);
+            if (includeComments) {
+                ValidateCommentsForSave(pagesToSave, BuildEffectivePageMastersForSave(pagesToSave));
+            }
+
             int pageCount = pagesToSave.Count;
             List<string> pagePartNames = new();
             int masterCount;
@@ -43,6 +48,11 @@ namespace OfficeIMO.Visio {
             List<VisioPage> pagesToSave = _pages.Count > 0 ? _pages : new List<VisioPage> { new VisioPage("Page-1") { Id = 0 } };
             bool includeComments = pagesToSave.Any(page => page.Comments.Count > 0);
             PrepareTextFontFaceNames(pagesToSave);
+            ValidatePagesForSave(pagesToSave);
+            if (includeComments) {
+                ValidateCommentsForSave(pagesToSave, BuildEffectivePageMastersForSave(pagesToSave));
+            }
+
             int pageCount = pagesToSave.Count;
             List<string> pagePartNames = new();
             int masterCount;
@@ -211,8 +221,6 @@ namespace OfficeIMO.Visio {
                     using StreamWriter sw = new(s, new UTF8Encoding(false));
                     sw.Write(winXml.Declaration + Environment.NewLine + winXml.ToString(SaveOptions.DisableFormatting));
                 }
-
-                ValidatePagesForSave(pagesToSave);
 
                 Dictionary<VisioPage, Dictionary<string, VisioMaster>> effectivePageMasters = new();
                 List<VisioMaster> masterCandidates = new();

--- a/OfficeIMO.Visio/VisioValidator.cs
+++ b/OfficeIMO.Visio/VisioValidator.cs
@@ -5,6 +5,7 @@ using System.IO.Packaging;
 using System.IO.Compression;
 using System.Linq;
 using System.Xml.Linq;
+using System.Xml;
 
 namespace OfficeIMO.Visio {
     /// <summary>
@@ -23,6 +24,14 @@ namespace OfficeIMO.Visio {
         private const string CT_Document = "application/vnd.ms-visio.drawing.main+xml";
         private const string CT_Pages = "application/vnd.ms-visio.pages+xml";
         private const string CT_Page = "application/vnd.ms-visio.page+xml";
+        private const long MaxXmlCharactersInDocument = 10_000_000;
+
+        private static readonly XmlReaderSettings SecureXmlReaderSettings = new() {
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null,
+            MaxCharactersInDocument = MaxXmlCharactersInDocument,
+            MaxCharactersFromEntities = 0
+        };
 
         /// <summary>
         /// Validates the specified Visio package.
@@ -177,7 +186,8 @@ namespace OfficeIMO.Visio {
                 }
 
                 using Stream stream = entry.Open();
-                document = XDocument.Load(stream);
+                using XmlReader reader = XmlReader.Create(stream, SecureXmlReaderSettings);
+                document = XDocument.Load(reader);
                 return true;
             } catch (InvalidDataException ex) {
                 issues.Add($"Cannot read Visio package '{packagePath}' as a zip archive: {ex.Message}");
@@ -198,7 +208,8 @@ namespace OfficeIMO.Visio {
 
             try {
                 using Stream stream = pkg.GetPart(partUri).GetStream();
-                document = XDocument.Load(stream);
+                using XmlReader reader = XmlReader.Create(stream, SecureXmlReaderSettings);
+                document = XDocument.Load(reader);
                 return true;
             } catch (System.Xml.XmlException ex) {
                 issues.Add($"Visio {partKind} part '{partName}' is not valid XML: {ex.Message}");

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Tables.cs
@@ -327,7 +327,13 @@ namespace OfficeIMO.Word.Html {
                     return; // mixed width types not supported
                 }
 
-                for (int i = 0; i < span; i++) {
+                int remainingColumns = cols - widths.Count;
+                if (remainingColumns <= 0) {
+                    return;
+                }
+
+                int widthsToAdd = Math.Min(span, remainingColumns);
+                for (int i = 0; i < widthsToAdd; i++) {
                     widths.Add(size);
                 }
             }

--- a/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
+++ b/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
@@ -13,6 +13,7 @@ namespace OfficeIMO.Word.Html {
         /// <returns>A new <see cref="HtmlToWordOptions"/> instance with the default compatibility-oriented settings.</returns>
         public static HtmlToWordOptions CreateOfficeIMOProfile() {
             var options = new HtmlToWordOptions {
+                ImageProcessing = ImageProcessingMode.Embed,
                 MaxTableCells = null
             };
             options.AllowedImageUriSchemes.Add(Uri.UriSchemeFile);
@@ -62,6 +63,7 @@ namespace OfficeIMO.Word.Html {
         /// <returns>A new <see cref="HtmlToWordOptions"/> instance configured for trusted document links.</returns>
         public static HtmlToWordOptions CreateTrustedDocumentProfile() {
             var options = new HtmlToWordOptions {
+                ImageProcessing = ImageProcessingMode.Embed,
                 AllowDocumentStylesheetLinks = true
             };
             options.AllowedImageUriSchemes.Add(Uri.UriSchemeFile);
@@ -137,7 +139,7 @@ namespace OfficeIMO.Word.Html {
         /// <summary>
         /// Controls how images are processed during conversion.
         /// </summary>
-        public ImageProcessingMode ImageProcessing { get; set; } = ImageProcessingMode.Embed;
+        public ImageProcessingMode ImageProcessing { get; set; } = ImageProcessingMode.EmbedDataUriOnly;
 
         /// <summary>
         /// Optional <see cref="HttpClient"/> used to download remote resources (images, SVG).
@@ -192,6 +194,8 @@ namespace OfficeIMO.Word.Html {
 
         /// <summary>
         /// Image URI schemes allowed during import. Defaults allow HTTP, HTTPS, and data URI images.
+        /// Remote image embedding still requires <see cref="ImageProcessingMode.Embed"/> through an explicit option
+        /// or compatibility profile.
         /// Add <see cref="Uri.UriSchemeFile"/> or use <see cref="CreateTrustedDocumentProfile"/> for trusted local-file images.
         /// Remove entries to reject matching image sources before they are loaded or linked.
         /// </summary>

--- a/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
+++ b/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
@@ -11,7 +11,9 @@ namespace OfficeIMO.Word.Html {
         /// Creates the default OfficeIMO HTML import profile.
         /// </summary>
         /// <returns>A new <see cref="HtmlToWordOptions"/> instance with the default compatibility-oriented settings.</returns>
-        public static HtmlToWordOptions CreateOfficeIMOProfile() => new HtmlToWordOptions();
+        public static HtmlToWordOptions CreateOfficeIMOProfile() => new HtmlToWordOptions {
+            MaxTableCells = null
+        };
 
         /// <summary>
         /// Creates a bounded offline profile for untrusted HTML ingestion.
@@ -250,10 +252,10 @@ namespace OfficeIMO.Word.Html {
 
         /// <summary>
         /// Optional maximum number of Word table cells allowed for a single imported HTML table.
-        /// Spans are resolved before the limit is checked. When exceeded, conversion stops with
+        /// Defaults to 50,000 cells. Spans are resolved before the limit is checked. When exceeded, conversion stops with
         /// <see cref="HtmlConversionLimitException"/> and an error diagnostic.
         /// </summary>
-        public long? MaxTableCells { get; set; }
+        public long? MaxTableCells { get; set; } = 50000;
 
         /// <summary>
         /// Diagnostics produced while converting HTML. The converter appends warnings here when

--- a/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
+++ b/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
@@ -11,9 +11,13 @@ namespace OfficeIMO.Word.Html {
         /// Creates the default OfficeIMO HTML import profile.
         /// </summary>
         /// <returns>A new <see cref="HtmlToWordOptions"/> instance with the default compatibility-oriented settings.</returns>
-        public static HtmlToWordOptions CreateOfficeIMOProfile() => new HtmlToWordOptions {
-            MaxTableCells = null
-        };
+        public static HtmlToWordOptions CreateOfficeIMOProfile() {
+            var options = new HtmlToWordOptions {
+                MaxTableCells = null
+            };
+            options.AllowedImageUriSchemes.Add(Uri.UriSchemeFile);
+            return options;
+        }
 
         /// <summary>
         /// Creates a bounded offline profile for untrusted HTML ingestion.
@@ -56,9 +60,13 @@ namespace OfficeIMO.Word.Html {
         /// or byte limits when trusted documents can reference broad network locations.
         /// </remarks>
         /// <returns>A new <see cref="HtmlToWordOptions"/> instance configured for trusted document links.</returns>
-        public static HtmlToWordOptions CreateTrustedDocumentProfile() => new HtmlToWordOptions {
-            AllowDocumentStylesheetLinks = true
-        };
+        public static HtmlToWordOptions CreateTrustedDocumentProfile() {
+            var options = new HtmlToWordOptions {
+                AllowDocumentStylesheetLinks = true
+            };
+            options.AllowedImageUriSchemes.Add(Uri.UriSchemeFile);
+            return options;
+        }
 
         /// <summary>
         /// Optional font family applied to created runs during conversion.
@@ -183,13 +191,13 @@ namespace OfficeIMO.Word.Html {
         };
 
         /// <summary>
-        /// Image URI schemes allowed during import. Defaults allow HTTP, HTTPS, file, and data URI images.
+        /// Image URI schemes allowed during import. Defaults allow HTTP, HTTPS, and data URI images.
+        /// Add <see cref="Uri.UriSchemeFile"/> or use <see cref="CreateTrustedDocumentProfile"/> for trusted local-file images.
         /// Remove entries to reject matching image sources before they are loaded or linked.
         /// </summary>
         public HashSet<string> AllowedImageUriSchemes { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
             Uri.UriSchemeHttp,
             Uri.UriSchemeHttps,
-            Uri.UriSchemeFile,
             "data"
         };
 

--- a/OfficeIMO.Word.Html/README.md
+++ b/OfficeIMO.Word.Html/README.md
@@ -50,6 +50,7 @@ WordDocument safeDocument = html.LoadFromHtml(safeOptions);
 - `CreateOfficeIMOProfile()` keeps the compatibility-oriented defaults.
 - `CreateUntrustedHtmlProfile()` keeps external document resources offline by default and enables bounded conversion.
 - `CreateTrustedDocumentProfile()` enables document-provided stylesheet links for known-good HTML while keeping resource validation.
+- Local file images are not loaded by `new HtmlToWordOptions()` by default; use a trusted/compatibility profile or add `Uri.UriSchemeFile` to `AllowedImageUriSchemes` for trusted local files.
 
 ## Boundaries
 

--- a/OfficeIMO.Word.Html/README.md
+++ b/OfficeIMO.Word.Html/README.md
@@ -50,7 +50,8 @@ WordDocument safeDocument = html.LoadFromHtml(safeOptions);
 - `CreateOfficeIMOProfile()` keeps the compatibility-oriented defaults.
 - `CreateUntrustedHtmlProfile()` keeps external document resources offline by default and enables bounded conversion.
 - `CreateTrustedDocumentProfile()` enables document-provided stylesheet links for known-good HTML while keeping resource validation.
-- Local file images are not loaded by `new HtmlToWordOptions()` by default; use a trusted/compatibility profile or add `Uri.UriSchemeFile` to `AllowedImageUriSchemes` for trusted local files.
+- `new HtmlToWordOptions()` embeds data URI images only; use a trusted/compatibility profile or set `ImageProcessing = ImageProcessingMode.Embed` for trusted remote image fetching.
+- Local file images are not loaded by default; use a trusted/compatibility profile or add `Uri.UriSchemeFile` to `AllowedImageUriSchemes` for trusted local files.
 
 ## Boundaries
 

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Charts.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Charts.cs
@@ -439,13 +439,23 @@ namespace OfficeIMO.Word.Pdf {
             return false;
         }
 
-        private static IEnumerable<(OpenXmlElement SeriesElement, int OriginalSeriesIndex)> GetNativeWordOrderedSeriesElements(OpenXmlElement chartElement) {
-            return chartElement.ChildElements
-                .Where(element => element.LocalName == "ser")
-                .Select((element, index) => (SeriesElement: element, OriginalSeriesIndex: index, Order: GetNativeWordChartSeriesOrder(element, index)))
+        private static IReadOnlyList<(OpenXmlElement SeriesElement, int OriginalSeriesIndex)> GetNativeWordOrderedSeriesElements(OpenXmlElement chartElement) {
+            var series = new List<(OpenXmlElement SeriesElement, int OriginalSeriesIndex, int Order)>();
+            int index = 0;
+            foreach (OpenXmlElement element in chartElement.ChildElements.Where(element => element.LocalName == "ser")) {
+                if (series.Count >= MaxNativeWordChartSeries) {
+                    throw new NativeWordChartLimitException("Word chart cache exceeds the maximum supported series count.");
+                }
+
+                series.Add((element, index, GetNativeWordChartSeriesOrder(element, index)));
+                index++;
+            }
+
+            return series
                 .OrderBy(item => item.Order)
                 .ThenBy(item => item.OriginalSeriesIndex)
-                .Select(item => (item.SeriesElement, item.OriginalSeriesIndex));
+                .Select(item => (item.SeriesElement, item.OriginalSeriesIndex))
+                .ToArray();
         }
 
         private static int GetNativeWordChartSeriesOrder(OpenXmlElement seriesElement, int fallback) {

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Charts.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Charts.cs
@@ -12,6 +12,10 @@ using PdfCore = OfficeIMO.Pdf;
 namespace OfficeIMO.Word.Pdf {
     public static partial class WordPdfConverterExtensions {
         private const double NativeEmusPerPoint = 12700D;
+        private const int MaxNativeWordChartSeries = 256;
+        private const int MaxNativeWordChartPoints = 4096;
+        private const double MaxNativeWordChartWidthPoints = 1440D;
+        private const double MaxNativeWordChartHeightPoints = 1080D;
 
         private static bool RenderNativeChart(INativePdfFlow pdf, WordChart? chart, PdfCore.PdfAlign align, PdfSaveOptions? options, string source) {
             if (chart == null) {
@@ -82,27 +86,33 @@ namespace OfficeIMO.Word.Pdf {
                 return false;
             }
 
-            IReadOnlyDictionary<A.SchemeColorValues, OfficeColor> themeColors = GetNativeDrawingThemeColors(chartPart);
-            IReadOnlyList<OfficeChartSeries> series = ExtractNativeWordChartSeries(openXmlChart!, chartElement, chartKind, themeColors, out IReadOnlyList<string> categories);
-            if (categories.Count == 0 || series.Count == 0) {
-                warning = "Word chart does not contain cached categories and values that can be rendered without Office.";
+            try {
+                IReadOnlyDictionary<A.SchemeColorValues, OfficeColor> themeColors = GetNativeDrawingThemeColors(chartPart);
+                IReadOnlyList<OfficeChartSeries> series = ExtractNativeWordChartSeries(openXmlChart!, chartElement, chartKind, themeColors, out IReadOnlyList<string> categories);
+                if (categories.Count == 0 || series.Count == 0) {
+                    warning = "Word chart does not contain cached categories and values that can be rendered without Office.";
+                    return false;
+                }
+
+                (double width, double height) = GetNativeWordChartSizePoints(chart);
+                string? title = GetNativeWordChartTitle(openXmlChart!);
+                string name = GetNativeWordChartName(chart, chartPart, title);
+                OfficeChartStyle? style = CreateNativeWordChartStyle(openXmlChart!, chartElement, plotArea, chartKind, categories.Count, series.Count, themeColors);
+                OfficeChartLayout? layout = CreateNativeWordChartLayout(openXmlChart!, chartElement, plotArea, chartKind, categories.Count);
+                snapshot = new OfficeChartSnapshot(
+                    name,
+                    title,
+                    chartKind,
+                    new OfficeChartData(categories, series),
+                    width,
+                    height,
+                    style: style,
+                    layout: layout);
+            } catch (NativeWordChartLimitException ex) {
+                warning = ex.Message;
                 return false;
             }
 
-            (double width, double height) = GetNativeWordChartSizePoints(chart);
-            string? title = GetNativeWordChartTitle(openXmlChart!);
-            string name = GetNativeWordChartName(chart, chartPart, title);
-            OfficeChartStyle? style = CreateNativeWordChartStyle(openXmlChart!, chartElement, plotArea, chartKind, categories.Count, series.Count, themeColors);
-            OfficeChartLayout? layout = CreateNativeWordChartLayout(openXmlChart!, chartElement, plotArea, chartKind, categories.Count);
-            snapshot = new OfficeChartSnapshot(
-                name,
-                title,
-                chartKind,
-                new OfficeChartData(categories, series),
-                width,
-                height,
-                style: style,
-                layout: layout);
             return true;
         }
 
@@ -192,6 +202,10 @@ namespace OfficeIMO.Word.Pdf {
 
             int seriesIndex = 0;
             foreach ((OpenXmlElement seriesElement, int originalSeriesIndex) in GetNativeWordOrderedSeriesElements(chartElement)) {
+                if (seriesIndex >= MaxNativeWordChartSeries) {
+                    throw new NativeWordChartLimitException("Word chart cache exceeds the maximum supported series count.");
+                }
+
                 IReadOnlyList<double> values;
                 IReadOnlyList<double>? xValues = null;
                 IReadOnlyList<string> currentCategories;
@@ -256,6 +270,7 @@ namespace OfficeIMO.Word.Pdf {
         }
 
         private static IReadOnlyList<string> ExtractNativeWordChartCategories(OpenXmlElement? categoryAxisData, int valueCount) {
+            EnsureNativeWordChartPointCount(valueCount);
             List<string> categories = ExtractNativeWordChartStringValues(categoryAxisData).ToList();
             if (categories.Count == 0) {
                 categories.AddRange(ExtractNativeWordChartNumberValues(categoryAxisData).Select(value => value.ToString("0.####", CultureInfo.InvariantCulture)));
@@ -273,6 +288,7 @@ namespace OfficeIMO.Word.Pdf {
         }
 
         private static IReadOnlyList<string> CreateNativeWordChartDefaultCategories(int count) {
+            EnsureNativeWordChartPointCount(count);
             var categories = new List<string>();
             for (int i = 0; i < count; i++) {
                 categories.Add("Category " + (i + 1).ToString(CultureInfo.InvariantCulture));
@@ -325,7 +341,12 @@ namespace OfficeIMO.Word.Pdf {
             uint maxIndex = 0;
             bool hasPoint = false;
             foreach (StringPoint point in container.Descendants<StringPoint>()) {
+                if (fallbackIndex >= MaxNativeWordChartPoints) {
+                    throw new NativeWordChartLimitException("Word chart cache exceeds the maximum supported point count.");
+                }
+
                 uint index = point.Index?.Value ?? fallbackIndex;
+                EnsureNativeWordChartPointIndex(index);
                 hasPoint = true;
                 if (index > maxIndex) {
                     maxIndex = index;
@@ -361,7 +382,12 @@ namespace OfficeIMO.Word.Pdf {
             uint maxIndex = 0;
             bool hasPoint = false;
             foreach (NumericPoint point in container.Descendants<NumericPoint>()) {
+                if (fallbackIndex >= MaxNativeWordChartPoints) {
+                    throw new NativeWordChartLimitException("Word chart cache exceeds the maximum supported point count.");
+                }
+
                 uint index = point.Index?.Value ?? fallbackIndex;
+                EnsureNativeWordChartPointIndex(index);
                 hasPoint = true;
                 if (index > maxIndex) {
                     maxIndex = index;
@@ -389,6 +415,7 @@ namespace OfficeIMO.Word.Pdf {
         }
 
         private static IReadOnlyList<double> NormalizeNativeWordChartNumberValues(IReadOnlyList<double> values, int count, bool useIndexDefaults) {
+            EnsureNativeWordChartPointCount(count);
             var result = new List<double>(count);
             for (int index = 0; index < count; index++) {
                 if (index < values.Count) {
@@ -472,10 +499,17 @@ namespace OfficeIMO.Word.Pdf {
             long? cy = chart.Drawing?.Inline?.Extent?.Cy?.Value ?? chart.Drawing?.Anchor?.Extent?.Cy?.Value;
             double width = cx.HasValue && cx.Value > 0 ? cx.Value / NativeEmusPerPoint : 360D;
             double height = cy.HasValue && cy.Value > 0 ? cy.Value / NativeEmusPerPoint : 216D;
+            width = Math.Min(MaxNativeWordChartWidthPoints, width);
+            height = Math.Min(MaxNativeWordChartHeightPoints, height);
             return (width, height);
         }
 
         private static OfficeChartStyle? CreateNativeWordChartStyle(Chart chart, OpenXmlElement chartElement, PlotArea plotArea, OfficeChartKind chartKind, int categoryCount, int seriesCount, IReadOnlyDictionary<A.SchemeColorValues, OfficeColor> themeColors) {
+            EnsureNativeWordChartPointCount(categoryCount);
+            if (seriesCount > MaxNativeWordChartSeries) {
+                throw new NativeWordChartLimitException("Word chart cache exceeds the maximum supported series count.");
+            }
+
             int paletteCount = IsNativeWordPieLikeChart(chartKind) ? categoryCount : seriesCount;
             if (paletteCount <= 0) {
                 return null;
@@ -1329,6 +1363,10 @@ namespace OfficeIMO.Word.Pdf {
             int seriesIndex = 0;
             foreach (OpenXmlElement seriesElement in chartElement.ChildElements.Where(element => element.LocalName == "ser")) {
                 if (IsNativeWordChartSeriesRenderable(seriesElement, chartKind)) {
+                    if (seriesIndex >= MaxNativeWordChartSeries) {
+                        throw new NativeWordChartLimitException("Word chart cache exceeds the maximum supported series count.");
+                    }
+
                     indexes.Add(seriesIndex);
                     seriesIndex++;
                 }
@@ -1354,6 +1392,7 @@ namespace OfficeIMO.Word.Pdf {
                     continue;
                 }
 
+                EnsureNativeWordChartPointIndex(index.Value);
                 bool isDeleted = IsNativeWordChartBooleanOn(label.GetFirstChild<Delete>());
                 if (deleted == isDeleted && (deleted || HasNativeWordChartDataLabelFlags(label))) {
                     pointIndexes.Add((int)index.Value);
@@ -1393,5 +1432,22 @@ namespace OfficeIMO.Word.Pdf {
 
         private static bool IsNativeWordChartBooleanOn(BooleanType? value) =>
             value != null && (value.Val == null || value.Val.Value);
+
+        private static void EnsureNativeWordChartPointIndex(uint index) {
+            if (index >= MaxNativeWordChartPoints) {
+                throw new NativeWordChartLimitException("Word chart cache contains a point index beyond the maximum supported point count.");
+            }
+        }
+
+        private static void EnsureNativeWordChartPointCount(int count) {
+            if (count > MaxNativeWordChartPoints) {
+                throw new NativeWordChartLimitException("Word chart cache exceeds the maximum supported point count.");
+            }
+        }
+
+        private sealed class NativeWordChartLimitException : Exception {
+            public NativeWordChartLimitException(string message) : base(message) {
+            }
+        }
     }
 }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.FootnotesImages.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.FootnotesImages.cs
@@ -216,7 +216,10 @@ namespace OfficeIMO.Word.Pdf {
                 return;
             }
 
-            byte[] bytes = ImageEmbedder.GetImageBytes(image);
+            if (!TryGetNativeBodyImageBytes(image, options, source, out byte[] bytes)) {
+                return;
+            }
+
             if (!IsNativePdfSupportedImageBytes(bytes, out string? unsupportedReason)) {
                 if (options != null) {
                     AddNativeExportWarning(
@@ -232,6 +235,24 @@ namespace OfficeIMO.Word.Pdf {
             double width = image.Width.HasValue ? image.Width.Value * 72D / 96D : 144D;
             double height = image.Height.HasValue ? image.Height.Value * 72D / 96D : 144D;
             pdf.Image(bytes, width, height, align);
+        }
+
+        private static bool TryGetNativeBodyImageBytes(WordImage image, PdfSaveOptions? options, string source, out byte[] bytes) {
+            try {
+                bytes = ImageEmbedder.GetImageBytes(image);
+                return true;
+            } catch (InvalidOperationException ex) {
+                bytes = System.Array.Empty<byte>();
+                if (options != null) {
+                    AddNativeExportWarning(
+                        options,
+                        "NativeBodyImageUnavailable",
+                        source,
+                        "Word image was not exported because the image bytes could not be extracted. " + ex.Message);
+                }
+
+                return false;
+            }
         }
 
         private static bool IsNativePdfSupportedImageBytes(byte[] bytes, out string? unsupportedReason) {


### PR DESCRIPTION
## Summary
- make Markdown-to-PDF local image embedding opt-in by default so untrusted Markdown cannot read local files unless callers explicitly allow it
- cap PDF CMap and CID width range expansion to prevent attacker-controlled font metadata from creating unbounded dictionaries
- cap recursive PowerPoint group-shape rendering during PDF export and secure Visio XML validation readers against DTD/entity expansion
- bound HTML-to-Word table span expansion by default and clamp colgroup width expansion to resolved table columns
- add focused regression coverage for Markdown local images, PDF font expansion, PowerPoint group depth, Visio DTD handling, and HTML table span limits

## Validation
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore --filter "FullyQualifiedName~MarkdownPdfTests|FullyQualifiedName~PdfFontSecurityTests|FullyQualifiedName~PowerPointSaveAsPdfSecurityTests|FullyQualifiedName~VisioValidation|FullyQualifiedName~ConversionOptionsTests|FullyQualifiedName~Html.HtmlToWord_MaxTableCells|FullyQualifiedName~Html.HtmlToWord_DefaultMaxTableCells|FullyQualifiedName~Html.HtmlToWord_ColumnGroupSpan"

## Notes
- This is a broader first hardening pass from the Codex security overview. It does not replace the PNG-specific work already opened in #1933.