### PR TITLE
Harden Visio SVG gallery previews

### DIFF
--- a/OfficeIMO.Tests/Visio.ShowcaseSummary.cs
+++ b/OfficeIMO.Tests/Visio.ShowcaseSummary.cs
@@ -435,6 +435,30 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ShowcaseGalleryLinksSvgPreviewsWithoutInliningThem() {
+            string folderPath = Path.Combine(Path.GetTempPath(), "OfficeIMO-Visio-Showcase-Svg-" + Guid.NewGuid());
+            string nativePreviewPath = Path.Combine(folderPath, "Native Preview");
+            Directory.CreateDirectory(nativePreviewPath);
+            string packagePath = Path.Combine(folderPath, "sample.vsdx");
+            string pngPreviewPath = Path.Combine(nativePreviewPath, "sample-page1.native.png");
+            string svgPreviewPath = Path.Combine(nativePreviewPath, "sample-page1.native.svg");
+            File.WriteAllBytes(packagePath, new byte[] { 1, 2, 3 });
+            File.WriteAllBytes(pngPreviewPath, new byte[] { 4, 5, 6, 7 });
+            File.WriteAllText(svgPreviewPath, "<svg xmlns=\"http://www.w3.org/2000/svg\"><script>alert(1)</script><rect width=\"10\" height=\"10\"/></svg>", new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+            VisioShowcaseSummary summary = VisioShowcaseSummary.Create(
+                folderPath,
+                new[] { packagePath },
+                new[] { pngPreviewPath, svgPreviewPath });
+            summary.SaveArtifacts();
+
+            string html = File.ReadAllText(Path.Combine(folderPath, VisioShowcaseSummary.HtmlFileName));
+            Assert.Contains("src=\"Native%20Preview/sample-page1.native.png\"", html);
+            Assert.Contains("href=\"Native%20Preview/sample-page1.native.svg\"", html);
+            Assert.DoesNotContain("src=\"Native%20Preview/sample-page1.native.svg\"", html, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
         public void ShowcaseSummaryValidationDetectsModifiedArtifactBytes() {
             string folderPath = Path.Combine(Path.GetTempPath(), "OfficeIMO-Visio-Showcase-Validation-" + Guid.NewGuid());
             string nativePreviewPath = Path.Combine(folderPath, "Native Preview");

--- a/OfficeIMO.Tests/Visio.Stencils.cs
+++ b/OfficeIMO.Tests/Visio.Stencils.cs
@@ -922,6 +922,41 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void PackageStencilPreviewGalleryLinksSvgPreviewsWithoutInliningThem() {
+            string packagePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vssx");
+            byte[] svg = Encoding.UTF8.GetBytes("<svg xmlns=\"http://www.w3.org/2000/svg\"><script>alert(1)</script><rect width=\"10\" height=\"10\"/></svg>");
+            CreatePackageWithRawGroupMaster(packagePath, "FancyCloud", "Fancy Cloud", "svg", svg);
+            string outputDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+            VisioStencilPreviewGallery gallery = VisioStencilPackageCatalog.CreatePreviewGallery(
+                packagePath,
+                outputDirectory,
+                new VisioStencilPackageLoadOptions {
+                    IncludeUnsupportedMasters = true
+                },
+                new VisioStencilPreviewGalleryOptions {
+                    Title = "SVG Preview Review",
+                    PreviewDirectoryName = "assets",
+                    ThumbnailDirectoryName = "thumbs"
+                });
+
+            VisioStencilPreviewGalleryEntry entry = Assert.Single(gallery.Entries);
+            Assert.False(entry.IsBrowserRenderable);
+            Assert.False(entry.HasThumbnail);
+            Assert.Equal(0, gallery.BrowserRenderableCount);
+            Assert.Equal(0, gallery.ThumbnailCount);
+            Assert.Equal("assets/42-FancyCloud.svg", entry.RelativePath);
+            Assert.True(File.Exists(entry.FilePath));
+            Assert.Equal(svg, File.ReadAllBytes(entry.FilePath));
+
+            string html = File.ReadAllText(gallery.IndexPath!);
+            Assert.Contains("assets/42-FancyCloud.svg", html);
+            Assert.Contains("<div class=\"fallback\">svg</div>", html);
+            Assert.DoesNotContain("<img src=\"assets/42-FancyCloud.svg\"", html, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(".thumbnail.svg", html, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
         public void ImportedStencilMastersPreserveExternalMasterArtwork() {
             string packagePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vssx");
             CreatePackageWithRawGroupMaster(packagePath, "FancyCloud", "Fancy Cloud");

--- a/OfficeIMO.Visio/Gallery/VisioShowcaseHtmlRenderer.cs
+++ b/OfficeIMO.Visio/Gallery/VisioShowcaseHtmlRenderer.cs
@@ -553,7 +553,11 @@ namespace OfficeIMO.Visio {
 
         private static bool IsEmbeddablePreview(VisioShowcaseArtifact artifact) {
             return string.Equals(artifact.Format, "png", StringComparison.OrdinalIgnoreCase) ||
-                   string.Equals(artifact.Format, "svg", StringComparison.OrdinalIgnoreCase);
+                   string.Equals(artifact.Format, "jpg", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(artifact.Format, "jpeg", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(artifact.Format, "gif", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(artifact.Format, "bmp", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(artifact.Format, "webp", StringComparison.OrdinalIgnoreCase);
         }
 
         private static int PreviewSortKey(VisioShowcaseArtifact artifact) {

--- a/OfficeIMO.Visio/Stencils/VisioStencilPreviewGallery.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilPreviewGallery.cs
@@ -83,7 +83,7 @@ namespace OfficeIMO.Visio.Stencils {
         /// <summary>Extracted preview entries.</summary>
         public IReadOnlyList<VisioStencilPreviewGalleryEntry> Entries { get; }
 
-        /// <summary>Number of preview payloads that common browsers can render directly.</summary>
+        /// <summary>Number of preview payloads that the generated gallery renders inline.</summary>
         public int BrowserRenderableCount => Entries.Count(entry => entry.IsBrowserRenderable);
 
         /// <summary>Number of generated thumbnail artifacts.</summary>
@@ -120,7 +120,7 @@ namespace OfficeIMO.Visio.Stencils {
         /// <summary>Whether this entry has a generated SVG thumbnail artifact.</summary>
         public bool HasThumbnail => !string.IsNullOrWhiteSpace(ThumbnailFilePath);
 
-        /// <summary>Whether the payload extension is usually directly renderable in a browser.</summary>
+        /// <summary>Whether the generated gallery can safely render the payload inline.</summary>
         public bool IsBrowserRenderable => IsBrowserRenderableExtension(Image.PreviewImage.Extension);
 
         internal static bool IsBrowserRenderableExtension(string? extension) {
@@ -130,7 +130,7 @@ namespace OfficeIMO.Visio.Stencils {
 
             string normalized = extension!.TrimStart('.').ToLowerInvariant();
             return normalized switch {
-                "png" or "jpg" or "jpeg" or "gif" or "svg" or "bmp" or "webp" => true,
+                "png" or "jpg" or "jpeg" or "gif" or "bmp" or "webp" => true,
                 _ => false
             };
         }


### PR DESCRIPTION
## Summary
- stop generated Visio showcase galleries from embedding SVG preview artifacts inline
- keep SVG previews exported and linked while continuing inline rendering for raster formats
- prevent stencil preview galleries from generating thumbnails for SVG payloads
- add regression coverage for SVG previews containing script content

## Validation
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~VisioStencilPreviewGallery|FullyQualifiedName~ShowcaseGalleryLinksSvgPreviewsWithoutInliningThem"
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~PackageStencilPreviewGallery" --no-restore
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net10.0 --filter "FullyQualifiedName~PackageStencilPreviewGallery|FullyQualifiedName~ShowcaseGalleryLinksSvgPreviewsWithoutInliningThem" --no-restore
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net472 --filter "FullyQualifiedName~PackageStencilPreviewGallery|FullyQualifiedName~ShowcaseGalleryLinksSvgPreviewsWithoutInliningThem" --no-restore
- dotnet build OfficeIMO.Visio\OfficeIMO.Visio.csproj --framework netstandard2.0 --no-restore
- dotnet build OfficeIMO.Visio\OfficeIMO.Visio.csproj --framework net472 --no-restore
- git diff --check