### PR TITLE
Harden Excel clear range pending values

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.ObjectModel.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ObjectModel.cs
@@ -114,12 +114,16 @@ namespace OfficeIMO.Excel {
                 return;
             }
 
+            bool clearCellFields = options.HasFlag(ExcelClearOptions.Values)
+                || options.HasFlag(ExcelClearOptions.Formulas)
+                || options.HasFlag(ExcelClearOptions.Styles);
+            if (clearCellFields) {
+                MaterializeDeferredDataSetImportIfNeeded();
+            }
+
             WriteLock(() => {
                 var ws = WorksheetRoot;
                 bool worksheetChanged = false;
-                bool clearCellFields = options.HasFlag(ExcelClearOptions.Values)
-                    || options.HasFlag(ExcelClearOptions.Formulas)
-                    || options.HasFlag(ExcelClearOptions.Styles);
 
                 if (clearCellFields) {
                     worksheetChanged |= ClearExistingCellFieldsInRange((r1, c1, r2, c2), options);

--- a/OfficeIMO.Tests/Excel.CellAndRange.cs
+++ b/OfficeIMO.Tests/Excel.CellAndRange.cs
@@ -76,6 +76,35 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ClearRangeRemovesPendingDirectCellValuesBeforeSave() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                for (int row = 1; row <= 160; row++) {
+                    sheet.CellAt(row, 1).SetValue("secret-" + row.ToString(CultureInfo.InvariantCulture));
+                }
+
+                sheet.ClearRange("A1:A160", ExcelClearOptions.Values);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorkbookPart workbookPart = spreadsheet.WorkbookPart!;
+                WorksheetPart worksheetPart = workbookPart.WorksheetParts.Single();
+                string worksheetXml = worksheetPart.Worksheet.OuterXml;
+
+                Assert.DoesNotContain("secret-", worksheetXml, StringComparison.Ordinal);
+                SharedStringTable? sharedStrings = workbookPart.SharedStringTablePart?.SharedStringTable;
+                if (sharedStrings != null) {
+                    Assert.DoesNotContain(sharedStrings.InnerText, "secret-", StringComparison.Ordinal);
+                }
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
         public void RangeEnforces1BasedIndexing() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             using (ExcelDocument document = ExcelDocument.Create(filePath)) {


### PR DESCRIPTION
## Summary
- materialize pending direct-cell values before ClearRange removes values, formulas, or styles
- prevent pending Excel cell buffers from restoring cleared sensitive values during save
- add a regression that writes 160 pending values, clears the range, saves, and verifies secrets are absent from worksheet XML and shared strings

## Tests
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore --filter "FullyQualifiedName~ExcelCellAndRangeTests" -f net8.0 --verbosity minimal
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore --filter "FullyQualifiedName~ExcelCellAndRangeTests.ClearRangeRemovesPendingDirectCellValuesBeforeSave" -f net472 --verbosity minimal