### PR TITLE
Add Excel HTTP load host allowlist

### DIFF
--- a/OfficeIMO.Excel/ExcelHttpLoadOptions.cs
+++ b/OfficeIMO.Excel/ExcelHttpLoadOptions.cs
@@ -34,6 +34,12 @@ namespace OfficeIMO.Excel {
         public IDictionary<string, string> Headers { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
+        /// Gets allowed remote workbook host names. When empty, any host is allowed.
+        /// Entries are host names only; schemes, paths, and ports are not accepted.
+        /// </summary>
+        public ISet<string> AllowedHosts { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
         /// Gets or sets whether the downloaded workbook must look like a ZIP/OpenXML package.
         /// </summary>
         public bool ValidateZipHeader { get; set; } = true;

--- a/OfficeIMO.Excel/ExcelHttpWorkbookLoader.cs
+++ b/OfficeIMO.Excel/ExcelHttpWorkbookLoader.cs
@@ -20,6 +20,7 @@ namespace OfficeIMO.Excel {
 
             var snapshot = ExcelHttpLoadOptionsSnapshot.Create(options);
             ValidateScheme(uri, snapshot.SchemePolicy);
+            ValidateHost(uri, snapshot);
             ValidateLimits(snapshot);
 
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -95,6 +96,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 ValidateScheme(nextUri, options.SchemePolicy);
+                ValidateHost(nextUri, options);
                 if (!IsSameOrigin(currentUri, nextUri)) {
                     includeCustomHeaders = false;
                 }
@@ -147,6 +149,19 @@ namespace OfficeIMO.Excel {
             }
 
             throw new NotSupportedException("Remote Excel loads require HTTPS unless ExcelHttpLoadOptions.SchemePolicy allows HTTP.");
+        }
+
+        private static void ValidateHost(Uri uri, ExcelHttpLoadOptionsSnapshot options) {
+            if (options.AllowedHosts.Count == 0) {
+                return;
+            }
+
+            string host = NormalizeUriHost(uri);
+            if (options.AllowedHosts.Contains(host)) {
+                return;
+            }
+
+            throw new NotSupportedException($"Remote Excel load host '{uri.Host}' is not allowed by ExcelHttpLoadOptions.AllowedHosts.");
         }
 
         private static void ValidateLimits(ExcelHttpLoadOptionsSnapshot options) {
@@ -216,6 +231,46 @@ namespace OfficeIMO.Excel {
             return bytes.Length >= 2 && bytes[0] == (byte)'P' && bytes[1] == (byte)'K';
         }
 
+        private static HashSet<string> NormalizeAllowedHosts(ISet<string> hosts) {
+            var normalizedHosts = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (string host in hosts) {
+                normalizedHosts.Add(NormalizeConfiguredHost(host));
+            }
+
+            return normalizedHosts;
+        }
+
+        private static string NormalizeConfiguredHost(string host) {
+            if (string.IsNullOrWhiteSpace(host)) {
+                throw new ArgumentException("AllowedHosts entries must be non-empty host names.", nameof(ExcelHttpLoadOptions.AllowedHosts));
+            }
+
+            string candidate = host.Trim();
+            if (candidate.Length > 1 && candidate[0] == '[' && candidate[candidate.Length - 1] == ']') {
+                candidate = candidate.Substring(1, candidate.Length - 2);
+            }
+
+            UriHostNameType hostNameType = Uri.CheckHostName(candidate);
+            if (hostNameType == UriHostNameType.Unknown) {
+                throw new ArgumentException("AllowedHosts entries must be host names only; schemes, paths, and ports are not accepted.", nameof(ExcelHttpLoadOptions.AllowedHosts));
+            }
+
+            if (hostNameType == UriHostNameType.IPv6) {
+                return candidate.ToLowerInvariant();
+            }
+
+            return new Uri("https://" + candidate).IdnHost.TrimEnd('.').ToLowerInvariant();
+        }
+
+        private static string NormalizeUriHost(Uri uri) {
+            string host = uri.IdnHost;
+            if (Uri.CheckHostName(host) == UriHostNameType.IPv6) {
+                return host.Trim('[', ']').ToLowerInvariant();
+            }
+
+            return host.TrimEnd('.').ToLowerInvariant();
+        }
+
         private sealed class ExcelHttpLoadOptionsSnapshot {
             private ExcelHttpLoadOptionsSnapshot(
                 ExcelUriSchemePolicy schemePolicy,
@@ -223,6 +278,7 @@ namespace OfficeIMO.Excel {
                 TimeSpan timeout,
                 string? userAgent,
                 Dictionary<string, string> headers,
+                HashSet<string> allowedHosts,
                 bool validateZipHeader,
                 bool validateContentTypeWhenPresent,
                 HashSet<string> allowedContentTypes,
@@ -233,6 +289,7 @@ namespace OfficeIMO.Excel {
                 Timeout = timeout;
                 UserAgent = userAgent;
                 Headers = headers;
+                AllowedHosts = allowedHosts;
                 ValidateZipHeader = validateZipHeader;
                 ValidateContentTypeWhenPresent = validateContentTypeWhenPresent;
                 AllowedContentTypes = allowedContentTypes;
@@ -245,6 +302,7 @@ namespace OfficeIMO.Excel {
             internal TimeSpan Timeout { get; }
             internal string? UserAgent { get; }
             internal Dictionary<string, string> Headers { get; }
+            internal HashSet<string> AllowedHosts { get; }
             internal bool ValidateZipHeader { get; }
             internal bool ValidateContentTypeWhenPresent { get; }
             internal HashSet<string> AllowedContentTypes { get; }
@@ -260,6 +318,7 @@ namespace OfficeIMO.Excel {
                     options.Timeout,
                     options.UserAgent,
                     new Dictionary<string, string>(options.Headers, StringComparer.OrdinalIgnoreCase),
+                    NormalizeAllowedHosts(options.AllowedHosts),
                     options.ValidateZipHeader,
                     options.ValidateContentTypeWhenPresent,
                     new HashSet<string>(options.AllowedContentTypes, StringComparer.OrdinalIgnoreCase),

--- a/OfficeIMO.Tests/Excel.HttpLoading.cs
+++ b/OfficeIMO.Tests/Excel.HttpLoading.cs
@@ -193,6 +193,87 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public async Task ExcelHttpLoadRejectsInitialHostOutsideAllowListBeforeFetch() {
+            int requestCount = 0;
+            using var handler = new FakeWorkbookHttpMessageHandler((_, _) => {
+                requestCount++;
+                return Task.FromResult(CreateWorkbookResponse(CreateRemoteWorkbookBytes()));
+            });
+
+            var options = new ExcelHttpLoadOptions {
+                HttpMessageHandler = handler
+            };
+            options.AllowedHosts.Add("allowed.example.test");
+
+            var ex = await Assert.ThrowsAsync<NotSupportedException>(() =>
+                ExcelDocumentReader.OpenAsync(
+                    new Uri("https://blocked.example.test/workbook.xlsx"),
+                    httpOptions: options));
+
+            Assert.Contains("AllowedHosts", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(0, requestCount);
+        }
+
+        [Fact]
+        public async Task ExcelHttpLoadRejectsRedirectHostOutsideAllowListBeforeFetch() {
+            var requests = new List<HttpRequestMessage>();
+            using var handler = new FakeWorkbookHttpMessageHandler((request, _) => {
+                requests.Add(CloneRequestHeaders(request));
+                if (requests.Count == 1) {
+                    var redirect = new HttpResponseMessage(HttpStatusCode.Redirect);
+                    redirect.Headers.Location = new Uri("https://blocked.example.test/workbook.xlsx");
+                    return Task.FromResult(redirect);
+                }
+
+                return Task.FromResult(CreateWorkbookResponse(CreateRemoteWorkbookBytes()));
+            });
+
+            var options = new ExcelHttpLoadOptions {
+                HttpMessageHandler = handler
+            };
+            options.AllowedHosts.Add("example.test");
+
+            var ex = await Assert.ThrowsAsync<NotSupportedException>(() =>
+                ExcelDocumentReader.OpenAsync(
+                    new Uri("https://example.test/workbook.xlsx"),
+                    httpOptions: options));
+
+            Assert.Contains("AllowedHosts", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Single(requests);
+            Assert.Equal("example.test", requests[0].RequestUri!.Host);
+        }
+
+        [Fact]
+        public async Task ExcelHttpLoadAllowsRedirectHostInsideAllowList() {
+            byte[] workbookBytes = CreateRemoteWorkbookBytes();
+            var requests = new List<HttpRequestMessage>();
+            using var handler = new FakeWorkbookHttpMessageHandler((request, _) => {
+                requests.Add(CloneRequestHeaders(request));
+                if (requests.Count == 1) {
+                    var redirect = new HttpResponseMessage(HttpStatusCode.Redirect);
+                    redirect.Headers.Location = new Uri("https://cdn.example.test/workbook.xlsx");
+                    return Task.FromResult(redirect);
+                }
+
+                return Task.FromResult(CreateWorkbookResponse(workbookBytes));
+            });
+
+            var options = new ExcelHttpLoadOptions {
+                HttpMessageHandler = handler
+            };
+            options.AllowedHosts.Add("example.test");
+            options.AllowedHosts.Add("cdn.example.test");
+
+            using var reader = await ExcelDocumentReader.OpenAsync(
+                new Uri("https://example.test/workbook.xlsx"),
+                httpOptions: options);
+
+            Assert.Equal(new[] { "Remote" }, reader.GetSheetNames());
+            Assert.Equal(2, requests.Count);
+            Assert.Equal("cdn.example.test", requests[1].RequestUri!.Host);
+        }
+
+        [Fact]
         public async Task ExcelHttpLoadDoesNotForwardCustomHeadersAcrossRedirectedHosts() {
             byte[] workbookBytes = CreateRemoteWorkbookBytes();
             var requests = new List<HttpRequestMessage>();


### PR DESCRIPTION
## Summary
- add optional ExcelHttpLoadOptions.AllowedHosts for remote workbook loads
- enforce the host allowlist before the initial request and after each redirect target is resolved
- keep existing behavior unchanged when the allowlist is empty
- add regressions for initial-host rejection, redirected-host rejection before fetch, and allowed redirected hosts

## Tests
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --filter "FullyQualifiedName~ExcelHttpLoad" -f net8.0 --verbosity minimal
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore --filter "FullyQualifiedName~ExcelHttpLoad" -f net472 --verbosity minimal