### PR TITLE
Harden Word form picture path values

### DIFF
--- a/OfficeIMO.Tests/Word.ContentControlForm.cs
+++ b/OfficeIMO.Tests/Word.ContentControlForm.cs
@@ -135,6 +135,40 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ContentControlFormPictureValuesDoNotReadRawStringPaths() {
+            string filePath = Path.Combine(_directoryWithFiles, "DocumentWithRawPathPictureFormValue.docx");
+            string originalImagePath = Path.Combine(_directoryWithImages, "Kulek.jpg");
+            string replacementImagePath = Path.Combine(_directoryWithImages, "EvotecLogo.png");
+            byte[] originalBytes;
+
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Logo:").AddPictureControl(originalImagePath, 24, 24, "Logo Alias", "Logo");
+                originalBytes = document.GetPictureControlByTag("Logo")!.Image!.GetBytes();
+
+                WordContentControlFormValidationResult validation = document.ValidateContentControlValues(new Dictionary<string, object?> {
+                    ["Logo"] = replacementImagePath
+                });
+
+                Assert.False(validation.IsValid);
+                Assert.Contains(validation.Issues, issue => issue.Kind == WordContentControlFormIssueKind.InvalidImage && issue.Key == "Logo");
+
+                int updated = document.FillContentControlValues(new Dictionary<string, object?> {
+                    ["Logo"] = replacementImagePath
+                });
+
+                Assert.Equal(0, updated);
+                Assert.Equal(originalBytes, document.GetPictureControlByTag("Logo")!.Image!.GetBytes());
+
+                int trustedUpdated = document.FillContentControlValues(new Dictionary<string, object?> {
+                    ["Logo"] = WordContentControlPictureValue.FromFile(replacementImagePath)
+                });
+
+                Assert.Equal(1, trustedUpdated);
+                Assert.Equal(File.ReadAllBytes(replacementImagePath), document.GetPictureControlByTag("Logo")!.Image!.GetBytes());
+            }
+        }
+
+        [Fact]
         public void Test_ContentControlFormValidationReportsAmbiguousTagAliasKeys() {
             string filePath = Path.Combine(_directoryWithFiles, "DocumentWithAmbiguousContentControlFormKeys.docx");
 

--- a/OfficeIMO.Word/WordContentControlForm.cs
+++ b/OfficeIMO.Word/WordContentControlForm.cs
@@ -673,14 +673,6 @@ namespace OfficeIMO.Word {
         }
 
         private static bool IsValidPictureFormValue(object? value) {
-            if (value is string filePath) {
-                return File.Exists(filePath);
-            }
-
-            if (value is FileInfo fileInfo) {
-                return fileInfo.Exists;
-            }
-
             if (value is WordContentControlPictureValue pictureValue) {
                 if (!string.IsNullOrWhiteSpace(pictureValue.FilePath)) {
                     return File.Exists(pictureValue.FilePath);
@@ -696,16 +688,6 @@ namespace OfficeIMO.Word {
         }
 
         private static bool TryApplyPictureFormValue(WordPictureControl pictureControl, object? value) {
-            if (value is string filePath && File.Exists(filePath)) {
-                pictureControl.SetImage(filePath);
-                return true;
-            }
-
-            if (value is FileInfo fileInfo && fileInfo.Exists) {
-                pictureControl.SetImage(fileInfo.FullName);
-                return true;
-            }
-
             if (value is WordContentControlPictureValue pictureValue) {
                 string? pictureFilePath = pictureValue.FilePath;
                 if (!string.IsNullOrWhiteSpace(pictureFilePath) && File.Exists(pictureFilePath)) {


### PR DESCRIPTION
## Summary
- stop treating raw string and FileInfo form-map values as picture-control file paths
- keep explicit trusted file replacement through WordContentControlPictureValue.FromFile and byte-backed replacements
- add a regression proving raw string paths validate as invalid and do not replace/read picture content, while explicit FromFile still works

## Tests
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --filter "FullyQualifiedName~ContentControlForm" -f net8.0 --verbosity minimal
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore --filter "FullyQualifiedName~ContentControlForm" -f net472 --verbosity minimal