### PR TITLE
Harden markup image path boundaries

### DIFF
--- a/OfficeIMO.Markup.PowerPoint/OfficeMarkupPowerPointExportOptions.cs
+++ b/OfficeIMO.Markup.PowerPoint/OfficeMarkupPowerPointExportOptions.cs
@@ -6,6 +6,7 @@ public sealed class OfficeMarkupPowerPointExportOptions {
     public double SlideWidthInches { get; set; } = 10.0;
     public double SlideHeightInches { get; set; } = 5.625;
     public bool IncludeUnsupportedBlocksAsText { get; set; } = true;
+    public bool AllowExternalImagePaths { get; set; }
     public bool RenderMermaidDiagrams { get; set; } = true;
     public string? MermaidRendererPath { get; set; }
     public string? TemporaryDirectory { get; set; }

--- a/OfficeIMO.Markup.PowerPoint/OfficeMarkupPowerPointExporter.Background.cs
+++ b/OfficeIMO.Markup.PowerPoint/OfficeMarkupPowerPointExporter.Background.cs
@@ -56,8 +56,7 @@ public sealed partial class OfficeMarkupPowerPointExporter {
         string? resolvedImage = null;
         if (!string.IsNullOrWhiteSpace(image)) {
             var candidate = image!.Trim().Trim('"', '\'');
-            var resolved = ResolvePath(options, candidate);
-            if (File.Exists(resolved)) {
+            if (TryResolveFilePath(options, candidate, out var resolved) && File.Exists(resolved)) {
                 resolvedImage = resolved;
             }
         }
@@ -77,14 +76,6 @@ public sealed partial class OfficeMarkupPowerPointExporter {
         }
 
         return spec;
-    }
-
-    private static string ResolvePath(OfficeMarkupPowerPointExportOptions? options, string source) {
-        if (Path.IsPathRooted(source) || options == null || string.IsNullOrWhiteSpace(options.BaseDirectory)) {
-            return source;
-        }
-
-        return Path.Combine(options.BaseDirectory!, source);
     }
 
     private static string? TryExtractFunctionArgument(string value, string functionName) {

--- a/OfficeIMO.Markup.PowerPoint/OfficeMarkupPowerPointExporter.Media.cs
+++ b/OfficeIMO.Markup.PowerPoint/OfficeMarkupPowerPointExporter.Media.cs
@@ -43,15 +43,36 @@ public sealed partial class OfficeMarkupPowerPointExporter {
 
             path = uri.LocalPath;
         } else {
-            path = ResolvePath(options, source);
+            path = source;
         }
 
         try {
-            path = Path.GetFullPath(path);
+            bool hasBaseDirectory = options != null && !string.IsNullOrWhiteSpace(options.BaseDirectory);
+            if (!hasBaseDirectory && Path.IsPathRooted(path) && !(options?.AllowExternalImagePaths ?? false)) {
+                return false;
+            }
+
+            string candidate = Path.IsPathRooted(path) || !hasBaseDirectory
+                ? path
+                : Path.Combine(options!.BaseDirectory!, path);
+            path = Path.GetFullPath(candidate);
+            if (hasBaseDirectory
+                && !(options?.AllowExternalImagePaths ?? false)
+                && !IsPathWithinDirectory(path, Path.GetFullPath(options!.BaseDirectory!))) {
+                return false;
+            }
+
             return true;
         } catch (Exception) when (!Debugger.IsAttached) {
             return false;
         }
+    }
+
+    private static bool IsPathWithinDirectory(string path, string directory) {
+        string normalizedDirectory = directory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+        string normalizedPath = path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return normalizedPath.StartsWith(normalizedDirectory, StringComparison.OrdinalIgnoreCase);
     }
 
     private static void AddTable(PowerPointSlide slide, OfficeMarkupTableBlock table, LayoutCursor cursor) {

--- a/OfficeIMO.Markup.Word/OfficeMarkupWordExportOptions.cs
+++ b/OfficeIMO.Markup.Word/OfficeMarkupWordExportOptions.cs
@@ -3,6 +3,7 @@ namespace OfficeIMO.Markup.Word;
 public sealed class OfficeMarkupWordExportOptions {
     public string OutputPath { get; set; } = string.Empty;
     public string? BaseDirectory { get; set; }
+    public bool AllowExternalImagePaths { get; set; }
     public bool IncludeUnsupportedBlocksAsText { get; set; } = true;
     public int DefaultChartWidthPixels { get; set; } = 640;
     public int DefaultChartHeightPixels { get; set; } = 360;

--- a/OfficeIMO.Markup.Word/OfficeMarkupWordExporter.cs
+++ b/OfficeIMO.Markup.Word/OfficeMarkupWordExporter.cs
@@ -121,8 +121,7 @@ public sealed class OfficeMarkupWordExporter {
     }
 
     private static void AddImage(WordExportContext context, OfficeMarkupImageBlock image) {
-        var path = ResolvePath(context.Options, image.Source);
-        if (!File.Exists(path)) {
+        if (!TryResolveImagePath(context.Options, image.Source, out var path) || !File.Exists(path)) {
             if (context.Options.IncludeUnsupportedBlocksAsText) {
                 context.AddParagraph($"Image: {image.Source}");
             }
@@ -304,12 +303,56 @@ public sealed class OfficeMarkupWordExporter {
         return new ChartData(categories, series);
     }
 
-    private static string ResolvePath(OfficeMarkupWordExportOptions options, string source) {
-        if (Path.IsPathRooted(source) || string.IsNullOrWhiteSpace(options.BaseDirectory)) {
-            return source;
+    private static bool TryResolveImagePath(OfficeMarkupWordExportOptions options, string source, out string path) {
+        path = string.Empty;
+        if (string.IsNullOrWhiteSpace(source)) {
+            return false;
         }
 
-        return Path.Combine(options.BaseDirectory!, source);
+        string candidate = source;
+        if (Uri.TryCreate(source, UriKind.Absolute, out var uri)) {
+            if (!uri.IsFile) {
+                return false;
+            }
+
+            candidate = uri.LocalPath;
+        }
+
+        return TryResolveLocalPath(options.BaseDirectory, candidate, options.AllowExternalImagePaths, out path);
+    }
+
+    private static bool TryResolveLocalPath(string? baseDirectory, string source, bool allowExternalPaths, out string path) {
+        path = string.Empty;
+        try {
+            bool hasBaseDirectory = !string.IsNullOrWhiteSpace(baseDirectory);
+            if (!hasBaseDirectory && Path.IsPathRooted(source) && !allowExternalPaths) {
+                return false;
+            }
+
+            string candidate = Path.IsPathRooted(source) || !hasBaseDirectory
+                ? source
+                : Path.Combine(baseDirectory!, source);
+            string fullPath = Path.GetFullPath(candidate);
+            if (hasBaseDirectory && !allowExternalPaths && !IsPathWithinDirectory(fullPath, Path.GetFullPath(baseDirectory!))) {
+                return false;
+            }
+
+            path = fullPath;
+            return true;
+        } catch (ArgumentException) {
+            return false;
+        } catch (NotSupportedException) {
+            return false;
+        } catch (PathTooLongException) {
+            return false;
+        }
+    }
+
+    private static bool IsPathWithinDirectory(string path, string directory) {
+        string normalizedDirectory = directory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+        string normalizedPath = path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return normalizedPath.StartsWith(normalizedDirectory, StringComparison.OrdinalIgnoreCase);
     }
 
     private static int? GetInt(IDictionary<string, string> attributes, string name) {

--- a/OfficeIMO.Tests/Markup/OfficeMarkupParserTests.cs
+++ b/OfficeIMO.Tests/Markup/OfficeMarkupParserTests.cs
@@ -1415,6 +1415,89 @@ profile: presentation
     }
 
     [Fact]
+    public void PowerPointExporter_SkipsAbsoluteSlideImagesOutsideBaseDirectoryByDefault() {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+        var imageSource = new Uri(Path.Combine(AppContext.BaseDirectory, "Images", "EvotecLogo.png")).AbsoluteUri;
+
+        var markup = $$"""
+---
+profile: presentation
+---
+
+# Visual
+
+@slide {
+  layout: blank
+}
+
+![Logo]({{imageSource}})
+""";
+        var path = Path.Combine(tempDirectory, "external-image-slide.pptx");
+
+        try {
+            var result = OfficeMarkupParser.Parse(markup);
+
+            new OfficeMarkupPowerPointExporter().Export(result.Document, new OfficeMarkupPowerPointExportOptions {
+                OutputPath = path,
+                BaseDirectory = tempDirectory,
+                RenderMermaidDiagrams = false
+            });
+
+            using var package = PresentationDocument.Open(path, false);
+            var slidePart = Assert.Single(package.PresentationPart!.SlideParts);
+            Assert.Empty(slidePart.ImageParts);
+            Assert.Contains("Image:", slidePart.Slide.OuterXml, StringComparison.Ordinal);
+        } finally {
+            if (Directory.Exists(tempDirectory)) {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void PowerPointExporter_AllowsAbsoluteSlideImagesWhenOptedIn() {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+        var imageSource = new Uri(Path.Combine(AppContext.BaseDirectory, "Images", "EvotecLogo.png")).AbsoluteUri;
+
+        var markup = $$"""
+---
+profile: presentation
+---
+
+# Visual
+
+@slide {
+  layout: blank
+}
+
+![Logo]({{imageSource}})
+""";
+        var path = Path.Combine(tempDirectory, "trusted-external-image-slide.pptx");
+
+        try {
+            var result = OfficeMarkupParser.Parse(markup);
+
+            new OfficeMarkupPowerPointExporter().Export(result.Document, new OfficeMarkupPowerPointExportOptions {
+                OutputPath = path,
+                BaseDirectory = tempDirectory,
+                RenderMermaidDiagrams = false,
+                AllowExternalImagePaths = true
+            });
+
+            using var package = PresentationDocument.Open(path, false);
+            var slidePart = Assert.Single(package.PresentationPart!.SlideParts);
+            Assert.NotEmpty(slidePart.ImageParts);
+            Assert.DoesNotContain("Image:", slidePart.Slide.OuterXml, StringComparison.Ordinal);
+        } finally {
+            if (Directory.Exists(tempDirectory)) {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public void PowerPointExporter_PreservesJpegAspectRatioForContainedImages() {
         var tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempDirectory);
@@ -2215,6 +2298,77 @@ Q2,180
         } finally {
             if (File.Exists(path)) {
                 File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void WordExporter_SkipsAbsoluteImagesOutsideBaseDirectoryByDefault() {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+        var imageSource = new Uri(Path.Combine(AppContext.BaseDirectory, "Images", "EvotecLogo.png")).AbsoluteUri;
+
+        var markup = $"""
+---
+profile: document
+---
+
+# Visual
+
+![Logo]({imageSource})
+""";
+        var path = Path.Combine(tempDirectory, "external-image.docx");
+
+        try {
+            var result = OfficeMarkupParser.Parse(markup);
+
+            new OfficeMarkupWordExporter().Export(result.Document, new OfficeMarkupWordExportOptions {
+                OutputPath = path,
+                BaseDirectory = tempDirectory
+            });
+
+            using var package = WordprocessingDocument.Open(path, false);
+            Assert.Empty(package.MainDocumentPart!.ImageParts);
+            Assert.Contains("Image:", package.MainDocumentPart!.Document.Body!.InnerText, StringComparison.Ordinal);
+        } finally {
+            if (Directory.Exists(tempDirectory)) {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void WordExporter_AllowsAbsoluteImagesWhenOptedIn() {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+        var imageSource = new Uri(Path.Combine(AppContext.BaseDirectory, "Images", "EvotecLogo.png")).AbsoluteUri;
+
+        var markup = $"""
+---
+profile: document
+---
+
+# Visual
+
+![Logo]({imageSource})
+""";
+        var path = Path.Combine(tempDirectory, "trusted-external-image.docx");
+
+        try {
+            var result = OfficeMarkupParser.Parse(markup);
+
+            new OfficeMarkupWordExporter().Export(result.Document, new OfficeMarkupWordExportOptions {
+                OutputPath = path,
+                BaseDirectory = tempDirectory,
+                AllowExternalImagePaths = true
+            });
+
+            using var package = WordprocessingDocument.Open(path, false);
+            Assert.NotEmpty(package.MainDocumentPart!.ImageParts);
+            Assert.DoesNotContain("Image:", package.MainDocumentPart!.Document.Body!.InnerText, StringComparison.Ordinal);
+        } finally {
+            if (Directory.Exists(tempDirectory)) {
+                Directory.Delete(tempDirectory, recursive: true);
             }
         }
     }


### PR DESCRIPTION
## Summary
- block Word/PPT markup image exports from embedding absolute or file-URI image paths outside BaseDirectory by default
- add AllowExternalImagePaths opt-in for trusted markup exports that intentionally reference external local images
- cover default rejection and explicit opt-in with DOCX/PPTX artifact tests

## Tests
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore --filter "FullyQualifiedName~PowerPointExporter_|FullyQualifiedName~WordExporter_" -f net8.0 --verbosity minimal
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore --filter "FullyQualifiedName~PowerPointExporter_|FullyQualifiedName~WordExporter_" -f net472 --verbosity minimal