### PR TITLE
Harden Visio stencil manifest source paths

### DIFF
--- a/OfficeIMO.Tests/Visio.Stencils.cs
+++ b/OfficeIMO.Tests/Visio.Stencils.cs
@@ -530,6 +530,78 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void StencilCatalogManifestDropsSourcePackagePathsByDefault() {
+            VisioStencilCatalog source = VisioStencilCatalog.Create("Untrusted Catalog", builder => builder
+                .AddWithMetadata(
+                    "external.master",
+                    "External Master",
+                    "ExternalMaster",
+                    "External",
+                    1.8,
+                    0.9,
+                    keywords: null,
+                    aliases: null,
+                    tags: null,
+                    iconNameU: "ExternalMaster",
+                    defaultUnit: null,
+                    sourcePackagePath: Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vssx")));
+            using MemoryStream manifest = new();
+            source.Save(manifest);
+            manifest.Position = 0;
+
+            VisioStencilCatalog loaded = VisioStencilCatalog.Load(manifest);
+            VisioStencilShape stencil = loaded.Get("external.master");
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+            VisioDocument document = VisioDocument.Create(filePath);
+            VisioPage page = document.AddPage("Untrusted");
+            VisioShape shape = page.AddStencilShape(stencil, "shape", 2, 4);
+
+            Assert.Null(stencil.SourcePackagePath);
+            Assert.Null(shape.Master);
+        }
+
+        [Fact]
+        public void StencilCatalogManifestRequiresExternalSourcePackagePathOptIn() {
+            string baseDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(baseDirectory);
+            string externalPackagePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vssx");
+            string manifestPath = Path.Combine(baseDirectory, "catalog.xml");
+
+            try {
+                VisioStencilCatalog source = VisioStencilCatalog.Create("Untrusted Catalog", builder => builder
+                    .AddWithMetadata(
+                        "external.master",
+                        "External Master",
+                        "ExternalMaster",
+                        "External",
+                        1.8,
+                        0.9,
+                        keywords: null,
+                        aliases: null,
+                        tags: null,
+                        iconNameU: "ExternalMaster",
+                        defaultUnit: null,
+                        sourcePackagePath: externalPackagePath));
+                source.Save(manifestPath);
+
+                VisioStencilCatalog bounded = VisioStencilCatalog.Load(manifestPath, new VisioStencilCatalogManifestLoadOptions {
+                    AllowSourcePackagePaths = true
+                });
+                VisioStencilCatalog trustedExternal = VisioStencilCatalog.Load(manifestPath, new VisioStencilCatalogManifestLoadOptions {
+                    AllowSourcePackagePaths = true,
+                    AllowExternalSourcePackagePaths = true
+                });
+
+                Assert.Null(bounded.Get("external.master").SourcePackagePath);
+                Assert.Equal(Path.GetFullPath(externalPackagePath), trustedExternal.Get("external.master").SourcePackagePath);
+            } finally {
+                if (Directory.Exists(baseDirectory)) {
+                    Directory.Delete(baseDirectory, recursive: true);
+                }
+            }
+        }
+
+        [Fact]
         public void PackageStencilCatalogLoadsSupportedMastersFromVssxWithoutRuntimeTemplateDependency() {
             string packagePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vssx");
             CreatePackageWithMasters(packagePath, "Rectangle", "FancyCloud", "Decision");
@@ -1059,7 +1131,11 @@ namespace OfficeIMO.Tests {
             VisioStencilShape vaultStencil = catalog.Get("data-vault");
             string manifestPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xml");
             catalog.Save(manifestPath);
-            VisioStencilCatalog reloadedCatalog = VisioStencilCatalog.Load(manifestPath);
+            VisioStencilCatalog untrustedCatalog = VisioStencilCatalog.Load(manifestPath);
+            VisioStencilCatalog reloadedCatalog = VisioStencilCatalog.Load(manifestPath, new VisioStencilCatalogManifestLoadOptions {
+                AllowSourcePackagePaths = true
+            });
+            Assert.Null(untrustedCatalog.Get("fancy-cloud").SourcePackagePath);
             Assert.Equal(Path.GetFullPath(firstPackage), reloadedCatalog.Get("fancy-cloud").SourcePackagePath);
 
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");

--- a/OfficeIMO.Visio/Stencils/VisioStencilCatalog.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilCatalog.cs
@@ -63,10 +63,24 @@ namespace OfficeIMO.Visio.Stencils {
         }
 
         /// <summary>
+        /// Loads an OfficeIMO-native stencil catalog manifest with explicit source-package trust options.
+        /// </summary>
+        public static VisioStencilCatalog Load(string path, VisioStencilCatalogManifestLoadOptions? options) {
+            return VisioStencilCatalogManifest.Load(path, options);
+        }
+
+        /// <summary>
         /// Loads an OfficeIMO-native stencil catalog manifest.
         /// </summary>
         public static VisioStencilCatalog Load(Stream stream) {
             return VisioStencilCatalogManifest.Load(stream);
+        }
+
+        /// <summary>
+        /// Loads an OfficeIMO-native stencil catalog manifest with explicit source-package trust options.
+        /// </summary>
+        public static VisioStencilCatalog Load(Stream stream, VisioStencilCatalogManifestLoadOptions? options) {
+            return VisioStencilCatalogManifest.Load(stream, options);
         }
 
         /// <summary>

--- a/OfficeIMO.Visio/Stencils/VisioStencilCatalogManifest.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilCatalogManifest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Xml;
 using System.Xml.Linq;
 
@@ -46,20 +47,34 @@ namespace OfficeIMO.Visio.Stencils {
         /// Loads a stencil catalog manifest from a file.
         /// </summary>
         public static VisioStencilCatalog Load(string path) {
+            return Load(path, null);
+        }
+
+        /// <summary>
+        /// Loads a stencil catalog manifest from a file with explicit source-package trust options.
+        /// </summary>
+        public static VisioStencilCatalog Load(string path, VisioStencilCatalogManifestLoadOptions? options) {
             if (string.IsNullOrWhiteSpace(path)) throw new ArgumentException("Manifest path cannot be null or whitespace.", nameof(path));
             using FileStream stream = File.OpenRead(path);
-            return Load(stream);
+            return Load(stream, CreateOptionsForPath(path, options));
         }
 
         /// <summary>
         /// Loads a stencil catalog manifest from a stream.
         /// </summary>
         public static VisioStencilCatalog Load(Stream stream) {
+            return Load(stream, null);
+        }
+
+        /// <summary>
+        /// Loads a stencil catalog manifest from a stream with explicit source-package trust options.
+        /// </summary>
+        public static VisioStencilCatalog Load(Stream stream, VisioStencilCatalogManifestLoadOptions? options) {
             if (stream == null) throw new ArgumentNullException(nameof(stream));
             if (!stream.CanRead) throw new ArgumentException("Stream must be readable.", nameof(stream));
 
             XDocument document = XDocument.Load(stream);
-            return FromXml(document);
+            return FromXml(document, options);
         }
 
         /// <summary>
@@ -95,6 +110,13 @@ namespace OfficeIMO.Visio.Stencils {
         /// Converts an XML manifest document to a stencil catalog.
         /// </summary>
         public static VisioStencilCatalog FromXml(XDocument document) {
+            return FromXml(document, null);
+        }
+
+        /// <summary>
+        /// Converts an XML manifest document to a stencil catalog with explicit source-package trust options.
+        /// </summary>
+        public static VisioStencilCatalog FromXml(XDocument document, VisioStencilCatalogManifestLoadOptions? options) {
             if (document == null) throw new ArgumentNullException(nameof(document));
             XElement root = document.Root ?? throw new InvalidDataException("Stencil manifest does not contain a root element.");
             if (root.Name != Ns + "StencilCatalog") {
@@ -121,12 +143,89 @@ namespace OfficeIMO.Visio.Stencils {
                     ReadValues(shape, "Tags"),
                     (string?)shape.Attribute("IconNameU"),
                     ReadUnit(shape, "DefaultUnit"),
-                    (string?)shape.Attribute("SourcePackagePath"),
+                    ResolveSourcePackagePath((string?)shape.Attribute("SourcePackagePath"), options),
                     ReadPreviewImage(shape),
                     ReadConnectionPoints(shape));
             }
 
             return builder.Build();
+        }
+
+        private static VisioStencilCatalogManifestLoadOptions? CreateOptionsForPath(string path, VisioStencilCatalogManifestLoadOptions? options) {
+            string? directory = Path.GetDirectoryName(Path.GetFullPath(path));
+            if (string.IsNullOrWhiteSpace(directory)) {
+                return options;
+            }
+
+            if (options == null) {
+                return new VisioStencilCatalogManifestLoadOptions {
+                    BaseDirectory = directory
+                };
+            }
+
+            return new VisioStencilCatalogManifestLoadOptions {
+                AllowSourcePackagePaths = options.AllowSourcePackagePaths,
+                AllowExternalSourcePackagePaths = options.AllowExternalSourcePackagePaths,
+                BaseDirectory = string.IsNullOrWhiteSpace(options.BaseDirectory) ? directory : options.BaseDirectory
+            };
+        }
+
+        private static string? ResolveSourcePackagePath(string? sourcePackagePath, VisioStencilCatalogManifestLoadOptions? options) {
+            if (string.IsNullOrWhiteSpace(sourcePackagePath) ||
+                options?.AllowSourcePackagePaths != true) {
+                return null;
+            }
+
+            string candidate = sourcePackagePath!.Trim();
+            if (Uri.TryCreate(candidate, UriKind.Absolute, out Uri? uri)) {
+                if (!uri.IsFile) {
+                    return null;
+                }
+
+                candidate = uri.LocalPath;
+            }
+
+            try {
+                bool hasBaseDirectory = !string.IsNullOrWhiteSpace(options.BaseDirectory);
+                if (!Path.IsPathRooted(candidate) && !hasBaseDirectory) {
+                    return null;
+                }
+
+                if (!Path.IsPathRooted(candidate)) {
+                    candidate = Path.Combine(options.BaseDirectory!, candidate);
+                }
+
+                string fullPath = Path.GetFullPath(candidate);
+                if (hasBaseDirectory &&
+                    !options.AllowExternalSourcePackagePaths &&
+                    !IsPathWithinDirectory(fullPath, Path.GetFullPath(options.BaseDirectory!))) {
+                    return null;
+                }
+
+                if (!hasBaseDirectory &&
+                    Path.IsPathRooted(candidate) &&
+                    !options.AllowExternalSourcePackagePaths) {
+                    return null;
+                }
+
+                return fullPath;
+            } catch (ArgumentException) {
+                return null;
+            } catch (NotSupportedException) {
+                return null;
+            } catch (PathTooLongException) {
+                return null;
+            }
+        }
+
+        private static bool IsPathWithinDirectory(string path, string directory) {
+            string normalizedDirectory = directory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                + Path.DirectorySeparatorChar;
+            string normalizedPath = path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            StringComparison comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+            return normalizedPath.StartsWith(normalizedDirectory, comparison);
         }
 
         private static XElement Values(string name, IEnumerable<string> values) {

--- a/OfficeIMO.Visio/Stencils/VisioStencilCatalogManifestLoadOptions.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilCatalogManifestLoadOptions.cs
@@ -1,0 +1,24 @@
+namespace OfficeIMO.Visio.Stencils {
+    /// <summary>
+    /// Controls how source package paths from OfficeIMO-native stencil catalog manifests are trusted.
+    /// </summary>
+    public sealed class VisioStencilCatalogManifestLoadOptions {
+        /// <summary>
+        /// Gets or sets whether SourcePackagePath values from the manifest should be retained.
+        /// Defaults to false so untrusted manifests cannot trigger later local or UNC package reads.
+        /// </summary>
+        public bool AllowSourcePackagePaths { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether retained SourcePackagePath values may point outside <see cref="BaseDirectory"/>.
+        /// Defaults to false. Set this only for manifests and package paths from a trusted source.
+        /// </summary>
+        public bool AllowExternalSourcePackagePaths { get; set; }
+
+        /// <summary>
+        /// Gets or sets the directory used to resolve relative SourcePackagePath values.
+        /// When loading from a file path, this defaults to the manifest file directory.
+        /// </summary>
+        public string? BaseDirectory { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- stop trusting SourcePackagePath values from OfficeIMO-native Visio stencil catalog manifests by default
- add explicit manifest load options for retaining source package paths and allowing paths outside the manifest directory
- cover untrusted manifest loading and trusted opt-in behavior with focused Visio stencil tests

## Validation
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore --filter "FullyQualifiedName~VisioStencilsTests" -f net8.0 --logger "console;verbosity=minimal"
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore --filter "FullyQualifiedName~VisioStencilsTests" -f net472 --logger "console;verbosity=minimal"