### PR TITLE
Strip Word macros on package downgrade

### DIFF
--- a/OfficeIMO.Tests/Word.FeatureReport.cs
+++ b/OfficeIMO.Tests/Word.FeatureReport.cs
@@ -14,7 +14,7 @@ namespace OfficeIMO.Tests {
     public partial class Word {
         [Fact]
         public void Test_WordFeatureReport_DetectsEditableAndAdvancedFeatures() {
-            string filePath = Path.Combine(_directoryWithFiles, "WordFeatureReport.Advanced.docx");
+            string filePath = Path.Combine(_directoryWithFiles, "WordFeatureReport.Advanced.docm");
             File.Delete(filePath);
 
             using (WordDocument document = WordDocument.Create(filePath)) {

--- a/OfficeIMO.Tests/Word.Macros.cs
+++ b/OfficeIMO.Tests/Word.Macros.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Packaging;
 using OpenMcdf;
 using OfficeIMO.Word;
 using Xunit;
@@ -72,6 +74,69 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_SavingMacroDocumentAsDocxRemovesMacros() {
+            string macroPath = Path.Combine(_directoryDocuments, "vbaProject.bin");
+            string sourcePath = Path.Combine(_directoryWithFiles, "MacroDowngradeSource.docm");
+            string targetPath = Path.Combine(_directoryWithFiles, "MacroDowngradeTarget.docx");
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+
+            using (WordDocument document = WordDocument.Create(sourcePath)) {
+                document.AddMacro(macroPath);
+                Assert.True(document.HasMacros);
+                document.Save(targetPath);
+            }
+
+            AssertPackageHasNoVbaProject(targetPath);
+            using (WordDocument loaded = WordDocument.Load(targetPath)) {
+                Assert.False(loaded.HasMacros);
+            }
+        }
+
+        [Fact]
+        public void Test_SavingMacroDocumentAsDocmRetainsMacros() {
+            string macroPath = Path.Combine(_directoryDocuments, "vbaProject.bin");
+            string sourcePath = Path.Combine(_directoryWithFiles, "MacroRetainSource.docm");
+            string targetPath = Path.Combine(_directoryWithFiles, "MacroRetainTarget.docm");
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+
+            using (WordDocument document = WordDocument.Create(sourcePath)) {
+                document.AddMacro(macroPath);
+                Assert.True(document.HasMacros);
+                document.Save(targetPath);
+            }
+
+            using (WordprocessingDocument package = WordprocessingDocument.Open(targetPath, false)) {
+                Assert.NotNull(package.MainDocumentPart?.VbaProjectPart);
+            }
+
+            using (WordDocument loaded = WordDocument.Load(targetPath)) {
+                Assert.True(loaded.HasMacros);
+            }
+        }
+
+        [Fact]
+        public async Task Test_SaveAsyncMacroDocumentAsDocxRemovesMacros() {
+            string macroPath = Path.Combine(_directoryDocuments, "vbaProject.bin");
+            string sourcePath = Path.Combine(_directoryWithFiles, "MacroAsyncDowngradeSource.docm");
+            string targetPath = Path.Combine(_directoryWithFiles, "MacroAsyncDowngradeTarget.docx");
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+
+            using (WordDocument document = WordDocument.Create(sourcePath)) {
+                document.AddMacro(macroPath);
+                Assert.True(document.HasMacros);
+                await document.SaveAsync(targetPath);
+            }
+
+            AssertPackageHasNoVbaProject(targetPath);
+            using (WordDocument loaded = WordDocument.Load(targetPath)) {
+                Assert.False(loaded.HasMacros);
+            }
+        }
+
+        [Fact]
         public void Test_SavingAndRemovingMacros() {
             string macroPath = Path.Combine(_directoryDocuments, "vbaProject.bin");
             string filePath = Path.Combine(_directoryWithFiles, "DocumentWithMacro2.docm");
@@ -98,6 +163,11 @@ namespace OfficeIMO.Tests {
 
             File.Delete(filePath);
             File.Delete(extracted);
+        }
+
+        private static void AssertPackageHasNoVbaProject(string filePath) {
+            using WordprocessingDocument package = WordprocessingDocument.Open(filePath, false);
+            Assert.Null(package.MainDocumentPart?.VbaProjectPart);
         }
 
         [Fact]

--- a/OfficeIMO.Word/WordDocument.CreateLoad.cs
+++ b/OfficeIMO.Word/WordDocument.CreateLoad.cs
@@ -94,6 +94,22 @@ namespace OfficeIMO.Word {
             if (document.DocumentType != documentType) {
                 document.ChangeDocumentType(documentType);
             }
+
+            if (!IsMacroEnabledDocumentType(documentType)) {
+                RemoveVbaProjectPart(document);
+            }
+        }
+
+        private static bool IsMacroEnabledDocumentType(WordprocessingDocumentType documentType) {
+            return documentType == WordprocessingDocumentType.MacroEnabledDocument ||
+                   documentType == WordprocessingDocumentType.MacroEnabledTemplate;
+        }
+
+        private static void RemoveVbaProjectPart(WordprocessingDocument document) {
+            var mainPart = document.MainDocumentPart;
+            if (mainPart?.VbaProjectPart != null) {
+                mainPart.DeletePart(mainPart.VbaProjectPart);
+            }
         }
 
         private static WordDocument CreateInternal(string? filePath, Stream? stream, WordprocessingDocumentType documentType, bool autoSave) {

--- a/OfficeIMO.Word/WordDocument.Save.cs
+++ b/OfficeIMO.Word/WordDocument.Save.cs
@@ -335,6 +335,7 @@ namespace OfficeIMO.Word {
 
                     using (var fs = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite | FileShare.Delete, 4096, FileOptions.Asynchronous)) {
                         using (var clone = this._wordprocessingDocument.Clone(fs)) {
+                            AlignDocumentTypeWithFilePath(clone, filePath);
                             CopyPackageProperties(_wordprocessingDocument.PackageProperties, clone.PackageProperties);
                         }
                         fs.Seek(0, SeekOrigin.Begin);


### PR DESCRIPTION
## Summary
- strip `vbaProject.bin` when a macro-enabled Word package is saved to a non-macro extension such as `.docx` or `.dotx`
- keep macros when saving to macro-enabled targets such as `.docm` and `.dotm`
- route async file saves through the same package type alignment as sync file saves

## Validation
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-build --no-restore -f net8.0 --filter "FullyQualifiedName=OfficeIMO.Tests.Word.Test_SavingMacroDocumentAsDocxRemovesMacros" --verbosity minimal
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-build --no-restore -f net8.0 --filter "FullyQualifiedName=OfficeIMO.Tests.Word.Test_SavingMacroDocumentAsDocmRetainsMacros" --verbosity minimal
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-build --no-restore -f net8.0 --filter "FullyQualifiedName=OfficeIMO.Tests.Word.Test_SaveAsyncMacroDocumentAsDocxRemovesMacros" --verbosity minimal
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore -f net472 --filter "FullyQualifiedName~OfficeIMO.Tests.Word.Test_SavingMacroDocument" --verbosity minimal
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-build --no-restore -f net472 --filter "FullyQualifiedName=OfficeIMO.Tests.Word.Test_SaveAsyncMacroDocumentAsDocxRemovesMacros" --verbosity minimal
- git diff --check