### PR TITLE
Harden font parser resource limits

### DIFF
--- a/OfficeIMO.Drawing/OfficeTrueTypeFont.cs
+++ b/OfficeIMO.Drawing/OfficeTrueTypeFont.cs
@@ -14,6 +14,10 @@ namespace OfficeIMO.Drawing;
 /// cleanly when no suitable platform font file is available.
 /// </remarks>
 public sealed class OfficeTrueTypeFont {
+    private const uint MaxTrueTypeCollectionFonts = 256;
+    private const int MaxFontTableRecords = 512;
+    private const int MaxCmapSubtables = 64;
+    private const uint MaxFormat12Groups = 4096;
     private static readonly object FontCacheLock = new();
     private static readonly Dictionary<string, OfficeTrueTypeFont?> FontCache = new(StringComparer.OrdinalIgnoreCase);
     private readonly byte[] _data;
@@ -112,6 +116,8 @@ public sealed class OfficeTrueTypeFont {
             var scaler = ReadUInt32(data, 0);
             if (scaler == 0x74746366) {
                 var fontCount = ReadUInt32(data, 8);
+                if (fontCount == 0 || fontCount > MaxTrueTypeCollectionFonts) return null;
+                if (data.Length < 12 + fontCount * 4) return null;
                 if (collectionIndex.HasValue) {
                     if (collectionIndex.Value >= fontCount) return null;
                     var indexedFont = TryLoad(data, CheckedOffset(data, ReadUInt32(data, 12 + collectionIndex.Value * 4)), collectionIndex.Value);
@@ -142,6 +148,8 @@ public sealed class OfficeTrueTypeFont {
         var scaler = ReadUInt32(data, directoryOffset);
         if (scaler != 0x00010000 && scaler != 0x74727565) return null;
         var count = ReadUInt16(data, directoryOffset + 4);
+        if (count == 0 || count > MaxFontTableRecords) return null;
+        if (data.Length < directoryOffset + 12 + count * 16) return null;
         var tables = new Dictionary<string, int>(StringComparer.Ordinal);
         for (var i = 0; i < count; i++) {
             var record = directoryOffset + 12 + i * 16;
@@ -269,14 +277,17 @@ public sealed class OfficeTrueTypeFont {
 
     private ushort MapGlyph(char ch) {
         var cmapOffset = _cmap;
+        if (!InBounds(cmapOffset, 4)) return 0;
         var subtableCount = ReadUInt16(_data, cmapOffset + 2);
+        if (subtableCount == 0 || subtableCount > MaxCmapSubtables) return 0;
+        if (!InBounds(cmapOffset + 4, subtableCount * 8)) return 0;
         var best = 0;
         var bestScore = 0;
         for (var i = 0; i < subtableCount; i++) {
             var record = cmapOffset + 4 + i * 8;
             var platform = ReadUInt16(_data, record);
             var encoding = ReadUInt16(_data, record + 2);
-            var offset = CheckedOffset(_data, ReadUInt32(_data, record + 4));
+            if (!TryCheckedOffset(_data, ReadUInt32(_data, record + 4), out var offset)) continue;
             var absolute = cmapOffset + offset;
             if (absolute < 0 || absolute + 2 > _data.Length) continue;
             var format = ReadUInt16(_data, absolute);
@@ -293,12 +304,17 @@ public sealed class OfficeTrueTypeFont {
     }
 
     private ushort MapFormat4(int table, char ch) {
+        if (!InBounds(table, 16)) return 0;
+        var length = ReadUInt16(_data, table + 2);
+        if (length < 16 || !InBounds(table, length)) return 0;
         var code = ch;
         var segCount = ReadUInt16(_data, table + 6) / 2;
+        if (segCount == 0 || segCount > MaxCmapSubtables * 16) return 0;
         var endCodes = table + 14;
         var startCodes = endCodes + segCount * 2 + 2;
         var idDeltas = startCodes + segCount * 2;
         var idRangeOffsets = idDeltas + segCount * 2;
+        if (idRangeOffsets < table || idRangeOffsets + segCount * 2 > table + length) return 0;
 
         for (var i = 0; i < segCount; i++) {
             var end = ReadUInt16(_data, endCodes + i * 2);
@@ -318,8 +334,12 @@ public sealed class OfficeTrueTypeFont {
     }
 
     private ushort MapFormat12(int table, char ch) {
+        if (!InBounds(table, 16)) return 0;
+        var length = ReadUInt32(_data, table + 4);
+        if (length < 16 || length > int.MaxValue || !InBounds(table, (int)length)) return 0;
         var code = ch;
         var groups = ReadUInt32(_data, table + 12);
+        if (groups > MaxFormat12Groups || groups > (length - 16U) / 12U) return 0;
         var groupOffset = table + 16;
         for (var i = 0; i < groups; i++) {
             var start = ReadUInt32(_data, groupOffset + i * 12);
@@ -712,6 +732,16 @@ public sealed class OfficeTrueTypeFont {
     private static int CheckedOffset(byte[] data, uint offset) {
         if (offset > int.MaxValue || offset >= data.Length) throw new ArgumentOutOfRangeException(nameof(offset));
         return (int)offset;
+    }
+
+    private static bool TryCheckedOffset(byte[] data, uint offset, out int checkedOffset) {
+        if (offset > int.MaxValue || offset >= data.Length) {
+            checkedOffset = 0;
+            return false;
+        }
+
+        checkedOffset = (int)offset;
+        return true;
     }
 
     private static string? FullPathOrNull(string? path) {

--- a/OfficeIMO.Pdf/Model/PdfOpenTypeFontInspector.cs
+++ b/OfficeIMO.Pdf/Model/PdfOpenTypeFontInspector.cs
@@ -9,6 +9,7 @@ public static class PdfOpenTypeFontInspector {
     private const uint TrueTypeScalerType = 0x00010000;
     private const uint AppleTrueTypeScalerType = 0x74727565;
     private const uint OpenTypeCffScalerType = 0x4F54544F;
+    private const int MaxUnicodeCMapMappings = 131_072;
 
     /// <summary>
     /// Parses OpenType table metadata and Unicode coverage from a single font program.
@@ -239,6 +240,11 @@ public static class PdfOpenTypeFontInspector {
             groupOffset += 12;
             if (startCharCode > 0x10FFFF || endCharCode > 0x10FFFF || endCharCode < startCharCode) {
                 continue;
+            }
+
+            uint mappingCount = endCharCode - startCharCode + 1U;
+            if (mappingCount > MaxUnicodeCMapMappings || map.Count > MaxUnicodeCMapMappings - (int)mappingCount) {
+                throw new NotSupportedException("OpenType Unicode cmap mapping count exceeds supported limits.");
             }
 
             for (uint code = startCharCode; code <= endCharCode; code++) {

--- a/OfficeIMO.Tests/Drawing.Tests.cs
+++ b/OfficeIMO.Tests/Drawing.Tests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using OfficeIMO.Drawing;
 using Xunit;
 
@@ -600,6 +602,26 @@ public class DrawingTests {
     }
 
     [Fact]
+    public void OfficeTrueTypeFontRejectsOversizedTrueTypeCollections() {
+        byte[] collection = {
+            0x74, 0x74, 0x63, 0x66,
+            0x00, 0x01, 0x00, 0x00,
+            0x00, 0x00, 0x01, 0x01
+        };
+
+        Assert.Null(OfficeTrueTypeFont.TryLoad(collection));
+    }
+
+    [Fact]
+    public void OfficeTrueTypeFontTreatsMalformedFormat12CmapAsMissingGlyphs() {
+        byte[] fontData = CreateMinimalTrueTypeFont(CreateTruncatedFormat12Cmap());
+        OfficeTrueTypeFont? font = OfficeTrueTypeFont.TryLoad(fontData);
+
+        Assert.NotNull(font);
+        Assert.Equal(500D, font!.Measure("A", 1000D));
+    }
+
+    [Fact]
     public void OfficeTrueTypeFontReadsDefaultFontOutlinesWhenAvailable() {
         OfficeTrueTypeFont? font = OfficeTrueTypeFont.TryLoadDefault(out string? path);
         if (font == null) {
@@ -613,6 +635,85 @@ public class DrawingTests {
         List<List<OfficePoint>> contours = font.GetTextContours("OfficeIMO", 0, 0, 18);
         Assert.NotEmpty(contours);
         Assert.Contains(contours, contour => contour.Count >= 3);
+    }
+
+    private static byte[] CreateTruncatedFormat12Cmap() {
+        var data = new byte[28];
+        WriteUInt16(data, 2, 1);
+        WriteUInt16(data, 4, 3);
+        WriteUInt16(data, 6, 10);
+        WriteUInt32(data, 8, 12);
+        WriteUInt16(data, 12, 12);
+        WriteUInt32(data, 16, 16);
+        WriteUInt32(data, 24, 2);
+        return data;
+    }
+
+    private static byte[] CreateMinimalTrueTypeFont(byte[] cmap) {
+        var tables = new List<(string Tag, byte[] Data)> {
+            ("cmap", cmap),
+            ("glyf", new byte[4]),
+            ("head", CreateHeadTable()),
+            ("hhea", CreateHheaTable()),
+            ("hmtx", new byte[] { 0x01, 0xF4, 0x00, 0x00 }),
+            ("loca", new byte[4]),
+            ("maxp", new byte[] { 0x00, 0x01, 0x00, 0x00, 0x00, 0x02 })
+        };
+
+        int tableDirectoryLength = 12 + tables.Count * 16;
+        var offsets = new int[tables.Count];
+        int offset = tableDirectoryLength;
+        for (int index = 0; index < tables.Count; index++) {
+            offsets[index] = offset;
+            offset += Align4(tables[index].Data.Length);
+        }
+
+        var font = new byte[offset];
+        WriteUInt32(font, 0, 0x00010000);
+        WriteUInt16(font, 4, (ushort)tables.Count);
+        for (int index = 0; index < tables.Count; index++) {
+            int record = 12 + index * 16;
+            WriteTag(font, record, tables[index].Tag);
+            WriteUInt32(font, record + 8, (uint)offsets[index]);
+            WriteUInt32(font, record + 12, (uint)tables[index].Data.Length);
+            Array.Copy(tables[index].Data, 0, font, offsets[index], tables[index].Data.Length);
+        }
+
+        return font;
+    }
+
+    private static byte[] CreateHeadTable() {
+        var table = new byte[54];
+        WriteUInt16(table, 18, 1000);
+        return table;
+    }
+
+    private static byte[] CreateHheaTable() {
+        var table = new byte[36];
+        WriteUInt16(table, 4, 800);
+        WriteUInt16(table, 6, unchecked((ushort)-200));
+        WriteUInt16(table, 34, 1);
+        return table;
+    }
+
+    private static int Align4(int value) => (value + 3) & ~3;
+
+    private static void WriteTag(byte[] data, int offset, string tag) {
+        for (int index = 0; index < 4; index++) {
+            data[offset + index] = (byte)tag[index];
+        }
+    }
+
+    private static void WriteUInt16(byte[] data, int offset, int value) {
+        data[offset] = (byte)((value >> 8) & 0xFF);
+        data[offset + 1] = (byte)(value & 0xFF);
+    }
+
+    private static void WriteUInt32(byte[] data, int offset, uint value) {
+        data[offset] = (byte)((value >> 24) & 0xFF);
+        data[offset + 1] = (byte)((value >> 16) & 0xFF);
+        data[offset + 2] = (byte)((value >> 8) & 0xFF);
+        data[offset + 3] = (byte)(value & 0xFF);
     }
 
     [Theory]

--- a/OfficeIMO.Tests/Pdf/PdfFontSecurityTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfFontSecurityTests.cs
@@ -72,4 +72,85 @@ endbfrange
         Assert.Equal(250, provider(new byte[] { 0x00, 0x01 }));
         Assert.Equal(1000, provider(new byte[] { 0x13, 0x87 }));
     }
+
+    [Fact]
+    public void OpenTypeInspectorRejectsOversizedFormat12CmapExpansion() {
+        byte[] fontData = CreateMinimalTrueTypeFont(CreateLargeRangeFormat12Cmap());
+
+        Assert.False(PdfOpenTypeFontInspector.TryInspect(fontData, out PdfOpenTypeFontInfo? info, out string? error, "OfficeIMO Security Font"));
+        Assert.Null(info);
+        Assert.Contains("cmap mapping count exceeds supported limits", error, StringComparison.Ordinal);
+    }
+
+    private static byte[] CreateLargeRangeFormat12Cmap() {
+        var data = new byte[40];
+        WriteUInt16(data, 2, 1);
+        WriteUInt16(data, 4, 3);
+        WriteUInt16(data, 6, 10);
+        WriteUInt32(data, 8, 12);
+        WriteUInt16(data, 12, 12);
+        WriteUInt32(data, 16, 28);
+        WriteUInt32(data, 24, 1);
+        WriteUInt32(data, 28, 0);
+        WriteUInt32(data, 32, 0x10FFFF);
+        WriteUInt32(data, 36, 1);
+        return data;
+    }
+
+    private static byte[] CreateMinimalTrueTypeFont(byte[] cmap) {
+        var tables = new List<(string Tag, byte[] Data)> {
+            ("cmap", cmap),
+            ("glyf", new byte[4]),
+            ("head", CreateHeadTable()),
+            ("maxp", new byte[] { 0x00, 0x01, 0x00, 0x00, 0x00, 0x02 }),
+            ("name", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x06 })
+        };
+
+        int tableDirectoryLength = 12 + tables.Count * 16;
+        var offsets = new int[tables.Count];
+        int offset = tableDirectoryLength;
+        for (int index = 0; index < tables.Count; index++) {
+            offsets[index] = offset;
+            offset += Align4(tables[index].Data.Length);
+        }
+
+        var font = new byte[offset];
+        WriteUInt32(font, 0, 0x00010000);
+        WriteUInt16(font, 4, (ushort)tables.Count);
+        for (int index = 0; index < tables.Count; index++) {
+            int record = 12 + index * 16;
+            WriteTag(font, record, tables[index].Tag);
+            WriteUInt32(font, record + 8, (uint)offsets[index]);
+            WriteUInt32(font, record + 12, (uint)tables[index].Data.Length);
+            Array.Copy(tables[index].Data, 0, font, offsets[index], tables[index].Data.Length);
+        }
+
+        return font;
+    }
+
+    private static byte[] CreateHeadTable() {
+        var table = new byte[54];
+        WriteUInt16(table, 18, 1000);
+        return table;
+    }
+
+    private static int Align4(int value) => (value + 3) & ~3;
+
+    private static void WriteTag(byte[] data, int offset, string tag) {
+        for (int index = 0; index < 4; index++) {
+            data[offset + index] = (byte)tag[index];
+        }
+    }
+
+    private static void WriteUInt16(byte[] data, int offset, int value) {
+        data[offset] = (byte)((value >> 8) & 0xFF);
+        data[offset + 1] = (byte)(value & 0xFF);
+    }
+
+    private static void WriteUInt32(byte[] data, int offset, uint value) {
+        data[offset] = (byte)((value >> 24) & 0xFF);
+        data[offset + 1] = (byte)((value >> 16) & 0xFF);
+        data[offset + 2] = (byte)((value >> 8) & 0xFF);
+        data[offset + 3] = (byte)(value & 0xFF);
+    }
 }


### PR DESCRIPTION
## Summary
- cap TrueType collection, table-directory, cmap subtable, and format-12 group traversal in the managed drawing font reader
- cap PDF OpenType format-12 cmap expansion before building Unicode mapping dictionaries
- add generated-font regression tests for malformed/oversized TTC and cmap inputs

## Validation
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore -f net8.0 --filter "FullyQualifiedName~OfficeTrueTypeFont|FullyQualifiedName=OfficeIMO.Tests.Pdf.PdfFontSecurityTests.OpenTypeInspectorRejectsOversizedFormat12CmapExpansion" --verbosity minimal
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore -f net472 --filter "FullyQualifiedName~OfficeTrueTypeFont|FullyQualifiedName=OfficeIMO.Tests.Pdf.PdfFontSecurityTests.OpenTypeInspectorRejectsOversizedFormat12CmapExpansion" --verbosity minimal
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore -f net10.0 --filter "FullyQualifiedName~OfficeTrueTypeFont|FullyQualifiedName=OfficeIMO.Tests.Pdf.PdfFontSecurityTests.OpenTypeInspectorRejectsOversizedFormat12CmapExpansion" --verbosity minimal
- git diff --check