### PR TITLE
Harden Excel image URL redirects

### DIFF
--- a/OfficeIMO.Excel/Utilities/ImageDownloader.cs
+++ b/OfficeIMO.Excel/Utilities/ImageDownloader.cs
@@ -126,7 +126,18 @@ namespace OfficeIMO.Excel {
             if (!Uri.TryCreate(location, UriKind.RelativeOrAbsolute, out var parsed)) return null;
 
             var resolved = parsed.IsAbsoluteUri ? parsed : new Uri(currentUri, parsed);
-            return IsHttpUri(resolved) ? resolved : null;
+            return IsHttpUri(resolved) && IsSameOrigin(currentUri, resolved) ? resolved : null;
+        }
+
+        private static bool IsSameOrigin(Uri left, Uri right) {
+            return string.Equals(left.Scheme, right.Scheme, StringComparison.OrdinalIgnoreCase)
+                   && string.Equals(NormalizeHost(left), NormalizeHost(right), StringComparison.OrdinalIgnoreCase)
+                   && left.Port == right.Port;
+        }
+
+        private static string NormalizeHost(Uri uri) {
+            string host = string.IsNullOrEmpty(uri.IdnHost) ? uri.Host : uri.IdnHost;
+            return host.TrimEnd('.').ToLowerInvariant();
         }
 
 #if NETFRAMEWORK

--- a/OfficeIMO.Tests/Excel.HeadersFootersAndProperties.cs
+++ b/OfficeIMO.Tests/Excel.HeadersFootersAndProperties.cs
@@ -252,6 +252,54 @@ namespace OfficeIMO.Tests {
 
         [Fact]
         [Trait("Category","ExcelHeaderFooterImages")]
+        public async Task ImageDownloader_Rejects_CrossOrigin_Redirect_Before_Fetching_Target() {
+            OfficeIMO.Excel.ImageDownloader.ClearCache();
+
+            var redirectListener = new TcpListener(IPAddress.Loopback, 0);
+            var targetListener = new TcpListener(IPAddress.Loopback, 0);
+            redirectListener.Start();
+            targetListener.Start();
+            var redirectPort = ((IPEndPoint)redirectListener.LocalEndpoint).Port;
+            var targetPort = ((IPEndPoint)targetListener.LocalEndpoint).Port;
+            var url = $"http://127.0.0.1:{redirectPort}/redirect.png";
+            var targetUrl = $"http://127.0.0.1:{targetPort}/private.png";
+            var response = $"HTTP/1.1 302 Found\r\nLocation: {targetUrl}\r\nConnection: close\r\n\r\n";
+            var redirectTask = ServeSingleRawResponseAsync(redirectListener, Encoding.ASCII.GetBytes(response));
+            var targetRequestCount = 0;
+            var targetTask = Task.Run(async () =>
+            {
+                try
+                {
+                    using var client = await targetListener.AcceptTcpClientAsync();
+                    targetRequestCount++;
+                }
+                catch (SocketException)
+                {
+                    // Listener stopped before accepting a connection; ignore for test cleanup.
+                }
+                catch (ObjectDisposedException)
+                {
+                    // Listener disposed before accept completed; ignore for cleanup.
+                }
+            });
+
+            try {
+                Assert.False(OfficeIMO.Excel.ImageDownloader.TryFetch(url, 5, 2_000_000, out var bytes, out var contentType));
+                Assert.Null(bytes);
+                Assert.Null(contentType);
+                await Task.Delay(100);
+                Assert.Equal(0, targetRequestCount);
+            } finally {
+                redirectListener.Stop();
+                targetListener.Stop();
+                await redirectTask;
+                await targetTask;
+                OfficeIMO.Excel.ImageDownloader.ClearCache();
+            }
+        }
+
+        [Fact]
+        [Trait("Category","ExcelHeaderFooterImages")]
         public async Task ImageDownloader_Rejects_Response_When_Stream_Exceeds_Limit() {
             OfficeIMO.Excel.ImageDownloader.ClearCache();
 


### PR DESCRIPTION
## Summary
- require Excel image URL redirects to remain on the same origin before following them
- add a downloader regression test proving cross-origin redirects are rejected before the redirected endpoint is contacted

## Validation
- dotnet restore .\OfficeIMO.Tests\OfficeIMO.Tests.csproj
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore -f net8.0 --filter "Category=ExcelHeaderFooterImages" --verbosity minimal
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore -f net472 --filter "Category=ExcelHeaderFooterImages" --verbosity minimal
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore -f net10.0 --filter "Category=ExcelHeaderFooterImages" --verbosity minimal
- git diff --check