### PR TITLE
Harden Excel PDF number format parsing

### DIFF
--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.CellFormatting.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.CellFormatting.cs
@@ -172,12 +172,60 @@ namespace OfficeIMO.Excel.Pdf {
         }
 
         private static string GetNumberFormatSection(string formatCode, int sectionIndex) {
-            string[] sections = formatCode.Split(';');
-            if (sectionIndex >= 0 && sectionIndex < sections.Length) {
-                return sections[sectionIndex];
+            if (sectionIndex < 0) {
+                sectionIndex = 0;
             }
 
-            return sections.Length > 0 ? sections[0] : formatCode;
+            int currentSection = 0;
+            int sectionStart = 0;
+            bool inQuote = false;
+            for (int i = 0; i < formatCode.Length; i++) {
+                char ch = formatCode[i];
+                if (ch == '"') {
+                    inQuote = !inQuote;
+                    continue;
+                }
+
+                if (ch == '\\') {
+                    i++;
+                    continue;
+                }
+
+                if (ch != ';' || inQuote) {
+                    continue;
+                }
+
+                if (currentSection == sectionIndex) {
+                    return formatCode.Substring(sectionStart, i - sectionStart);
+                }
+
+                currentSection++;
+                sectionStart = i + 1;
+            }
+
+            if (currentSection == sectionIndex) {
+                return formatCode.Substring(sectionStart);
+            }
+
+            inQuote = false;
+            for (int i = 0; i < formatCode.Length; i++) {
+                char ch = formatCode[i];
+                if (ch == '"') {
+                    inQuote = !inQuote;
+                    continue;
+                }
+
+                if (ch == '\\') {
+                    i++;
+                    continue;
+                }
+
+                if (ch == ';' && !inQuote) {
+                    return formatCode.Substring(0, i);
+                }
+            }
+
+            return formatCode;
         }
 
         private static int GetNumberFormatSectionIndex(double number) {

--- a/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.CellStyleFormatTests.cs
+++ b/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.CellStyleFormatTests.cs
@@ -510,6 +510,39 @@ public partial class Excel {
     }
 
     [Fact]
+    public void SaveAsPdf_ExcelWorkbook_NumberFormatSections_DoNotExpandAllSemicolonSegments() {
+        string workbookPath = Path.Combine(_directoryWithFiles, "ExcelPdfHostileNumberFormatSections.xlsx");
+        string extraSections = string.Concat(Enumerable.Repeat(";[Red]0", 20000));
+
+        byte[] bytes;
+        using (ExcelDocument document = ExcelDocument.Create(workbookPath, "Formats")) {
+            ExcelSheet sheet = document.Sheets[0];
+            sheet.Cell(1, 1, "Kind");
+            sheet.Cell(1, 2, "Value");
+            sheet.Cell(2, 1, "ManySections");
+            sheet.CellAt(2, 2).SetValue(1234).SetNumberFormat("#,##0" + extraSections);
+            sheet.Cell(3, 1, "QuotedSectionSeparator");
+            sheet.CellAt(3, 2).SetValue(-12).SetNumberFormat("0;\"minus;literal\"0" + extraSections);
+
+            document.Save(false);
+
+            bytes = document.SaveAsPdf(new ExcelPdfSaveOptions {
+                IncludeSheetHeadings = false,
+                HeaderRowCount = 1,
+                PageSize = new PdfCore.PageSize(420, 220),
+                Margins = PdfCore.PageMargins.Uniform(24)
+            });
+        }
+
+        using PdfPigDocument pdf = PdfPigDocument.Open(new MemoryStream(bytes));
+        string text = string.Concat(Enumerable.Range(1, pdf.NumberOfPages).Select(page => pdf.GetPage(page).Text));
+        Assert.Contains("ManySections", text);
+        Assert.Contains("1,234", text);
+        Assert.Contains("QuotedSectionSeparator", text);
+        Assert.Contains("minus;literal-12", text);
+    }
+
+    [Fact]
     public void SaveAsPdf_ExcelWorkbook_Maps_Elapsed_Time_And_Quoted_Number_Literals() {
         string workbookPath = Path.Combine(_directoryWithFiles, "ExcelPdfElapsedAndQuotedFormats.xlsx");
 


### PR DESCRIPTION
## Summary
- scan Excel PDF number-format sections without splitting attacker-controlled format strings into unbounded arrays
- preserve quoted and escaped semicolon handling while keeping fallback behavior for missing sections
- add a regression test covering hostile section counts and quoted section separators

## Validation
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore -f net8.0 --filter "FullyQualifiedName~SaveAsPdf_ExcelWorkbook_NumberFormatSections_DoNotExpandAllSemicolonSegments" --verbosity quiet
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore -f net10.0 --filter "FullyQualifiedName~SaveAsPdf_ExcelWorkbook_NumberFormatSections_DoNotExpandAllSemicolonSegments" --verbosity quiet
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore -f net472 --filter "FullyQualifiedName~SaveAsPdf_ExcelWorkbook_NumberFormatSections_DoNotExpandAllSemicolonSegments" --verbosity quiet
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore -f net8.0 --filter "FullyQualifiedName~SaveAsPdf_ExcelWorkbook_Maps_Common_Number_Formats" --verbosity quiet
- git diff --check
