### PR TITLE
Harden chart legend filtering

### DIFF
--- a/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Text.cs
+++ b/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Text.cs
@@ -7,8 +7,12 @@ namespace OfficeIMO.Drawing;
 
 public static partial class OfficeChartDrawingRenderer {
     private static double GetSeriesLegendWidth(IReadOnlyList<OfficeChartSeries> series, double chartWidth, OfficeChartLayout layout) {
+        if (!ShouldRenderLegendSide(layout) || chartWidth < 180D) {
+            return 0D;
+        }
+
         List<int> legendIndexes = GetLegendSeriesIndexes(series);
-        if (!ShouldRenderLegendSide(layout) || legendIndexes.Count == 0 || chartWidth < 180D) {
+        if (legendIndexes.Count == 0) {
             return 0D;
         }
 
@@ -39,8 +43,12 @@ public static partial class OfficeChartDrawingRenderer {
     }
 
     private static double GetCategoryLegendWidth(IReadOnlyList<string> categories, double chartWidth, OfficeChartLayout layout) {
+        if (!ShouldRenderLegendSide(layout) || chartWidth < 180D) {
+            return 0D;
+        }
+
         List<int> legendIndexes = GetCategoryLegendIndexes(categories, layout);
-        if (!ShouldRenderLegendSide(layout) || legendIndexes.Count == 0 || chartWidth < 180D) {
+        if (legendIndexes.Count == 0) {
             return 0D;
         }
 
@@ -91,8 +99,12 @@ public static partial class OfficeChartDrawingRenderer {
     }
 
     private static void AddCategoryLegend(OfficeDrawing drawing, IReadOnlyList<string> categories, double x, double y, double width, double plotHeight, OfficeChartStyle style, OfficeChartLayout layout, IReadOnlyList<OfficeColor?>? pointColors = null) {
+        if (!layout.ShowLegend || width < 28D) {
+            return;
+        }
+
         List<int> legendIndexes = GetCategoryLegendIndexes(categories, layout);
-        if (!layout.ShowLegend || legendIndexes.Count == 0 || width < 28D) {
+        if (legendIndexes.Count == 0) {
             return;
         }
 
@@ -143,8 +155,12 @@ public static partial class OfficeChartDrawingRenderer {
     }
 
     private static double GetSeriesLegendBandHeight(IReadOnlyList<OfficeChartSeries> series, double chartWidth, OfficeChartLayout layout) {
+        if (!ShouldRenderLegendBand(layout) || chartWidth < 160D) {
+            return 0D;
+        }
+
         List<int> legendIndexes = GetLegendSeriesIndexes(series);
-        if (!ShouldRenderLegendBand(layout) || legendIndexes.Count == 0 || chartWidth < 160D) {
+        if (legendIndexes.Count == 0) {
             return 0D;
         }
 
@@ -152,8 +168,12 @@ public static partial class OfficeChartDrawingRenderer {
     }
 
     private static double GetCategoryLegendBandHeight(IReadOnlyList<string> categories, double chartWidth, OfficeChartLayout layout) {
+        if (!ShouldRenderLegendBand(layout) || chartWidth < 160D) {
+            return 0D;
+        }
+
         List<int> legendIndexes = GetCategoryLegendIndexes(categories, layout);
-        if (!ShouldRenderLegendBand(layout) || legendIndexes.Count == 0 || chartWidth < 160D) {
+        if (legendIndexes.Count == 0) {
             return 0D;
         }
 
@@ -161,8 +181,12 @@ public static partial class OfficeChartDrawingRenderer {
     }
 
     private static void AddSeriesLegendBand(OfficeDrawing drawing, IReadOnlyList<OfficeChartSeries> series, double x, double y, double width, OfficeChartStyle style, OfficeChartLayout layout) {
+        if (!ShouldRenderLegendBand(layout) || width < 48D) {
+            return;
+        }
+
         List<int> legendIndexes = GetLegendSeriesIndexes(series);
-        if (!ShouldRenderLegendBand(layout) || legendIndexes.Count == 0 || width < 48D) {
+        if (legendIndexes.Count == 0) {
             return;
         }
 
@@ -189,8 +213,12 @@ public static partial class OfficeChartDrawingRenderer {
     }
 
     private static void AddCategoryLegendBand(OfficeDrawing drawing, IReadOnlyList<string> categories, double x, double y, double width, OfficeChartStyle style, OfficeChartLayout layout, IReadOnlyList<OfficeColor?>? pointColors = null) {
+        if (!ShouldRenderLegendBand(layout) || width < 48D) {
+            return;
+        }
+
         List<int> legendIndexes = GetCategoryLegendIndexes(categories, layout);
-        if (!ShouldRenderLegendBand(layout) || legendIndexes.Count == 0 || width < 48D) {
+        if (legendIndexes.Count == 0) {
             return;
         }
 
@@ -207,8 +235,12 @@ public static partial class OfficeChartDrawingRenderer {
 
     private static List<int> GetCategoryLegendIndexes(IReadOnlyList<string> categories, OfficeChartLayout layout) {
         var indexes = new List<int>(categories.Count);
+        IReadOnlyCollection<int>? hiddenIndexes = layout.HiddenCategoryLegendIndexes;
+        HashSet<int>? hiddenIndexSet = hiddenIndexes == null || hiddenIndexes.Count == 0
+            ? null
+            : hiddenIndexes as HashSet<int> ?? new HashSet<int>(hiddenIndexes);
         for (int i = 0; i < categories.Count; i++) {
-            if (layout.HiddenCategoryLegendIndexes?.Contains(i) == true) {
+            if (hiddenIndexSet != null && hiddenIndexSet.Contains(i)) {
                 continue;
             }
 

--- a/OfficeIMO.Tests/Pdf/PdfDocumentChartDrawingTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentChartDrawingTests.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -926,6 +927,38 @@ public class PdfDocumentChartDrawingTests {
         Assert.Contains("Passed", labels);
         Assert.DoesNotContain("Failed", labels);
         Assert.Contains("Skipped", labels);
+    }
+
+    [Fact]
+    public void FlowDrawing_FiltersLargeHiddenPieCategoryLegendIndexesWithBoundedLookups() {
+        string[] categories = Enumerable.Range(0, 240)
+            .Select(index => "Slice " + index.ToString(System.Globalization.CultureInfo.InvariantCulture))
+            .ToArray();
+        double[] values = Enumerable.Repeat(1D, categories.Length).ToArray();
+        var hiddenIndexes = new CountingReadOnlyCollection<int>(Enumerable.Range(0, 220).ToArray());
+
+        OfficeDrawing drawing = OfficeChartDrawingRenderer.Render(new OfficeChartSnapshot(
+            "Pie hidden legend lookup",
+            "Pie Legend",
+            OfficeChartKind.Pie,
+            new OfficeChartData(
+                categories,
+                new[] {
+                    new OfficeChartSeries("Outcome", values)
+                }),
+            widthPoints: 300D,
+            heightPoints: 200D,
+            layout: new OfficeChartLayout(
+                showLegend: true,
+                legendPosition: OfficeChartLegendPosition.Top) {
+                HiddenCategoryLegendIndexes = hiddenIndexes
+            }));
+
+        IReadOnlyList<string> labels = drawing.Elements.OfType<OfficeDrawingText>().Select(text => text.Text).ToArray();
+
+        Assert.DoesNotContain("Slice 0", labels);
+        Assert.Contains("Slice 220", labels);
+        Assert.True(hiddenIndexes.EnumerationCount <= 4, "Hidden legend indexes should be materialized per legend pass, not searched once per category.");
     }
 
     [Fact]
@@ -2067,4 +2100,22 @@ public class PdfDocumentChartDrawingTests {
             shape.Shape.StrokeColor == highlight);
     }
 
+    private sealed class CountingReadOnlyCollection<T> : IReadOnlyCollection<T> {
+        private readonly IReadOnlyList<T> _values;
+
+        public CountingReadOnlyCollection(IReadOnlyList<T> values) {
+            _values = values;
+        }
+
+        public int Count => _values.Count;
+
+        public int EnumerationCount { get; private set; }
+
+        public IEnumerator<T> GetEnumerator() {
+            EnumerationCount++;
+            return _values.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
 }


### PR DESCRIPTION
## Summary
- materialize hidden pie/category legend indexes into a hash set before filtering categories
- skip legend-index construction when the requested legend surface cannot render
- add a regression test that proves hidden-index filtering uses bounded enumeration instead of per-category linear scans

## Validation
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -f net8.0 --filter "FullyQualifiedName~FlowDrawing_FiltersLargeHiddenPieCategoryLegendIndexesWithBoundedLookups|FullyQualifiedName~FlowDrawing_SuppressesHiddenPieCategoryLegendEntries|FullyQualifiedName~FlowDrawing_RendersTopPieLegendSwatchesWithSourceCategoryIndexes" --verbosity minimal
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore -f net10.0 --filter "FullyQualifiedName~FlowDrawing_FiltersLargeHiddenPieCategoryLegendIndexesWithBoundedLookups" --verbosity quiet
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --no-restore -f net472 --filter "FullyQualifiedName~FlowDrawing_FiltersLargeHiddenPieCategoryLegendIndexesWithBoundedLookups" --verbosity quiet
- git diff --check
