### PR TITLE
Harden native heading destination generation

### DIFF
--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.HeadingTocLinkTests.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.HeadingTocLinkTests.cs
@@ -154,6 +154,43 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void NativeHeadingDestinationNames_TrackSuffixes_ForRepeatedHeadings() {
+            MethodInfo method = typeof(WordPdfConverterExtensions).GetMethod("CreateNativeHeadingDestinationName", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var used = new HashSet<string>(StringComparer.Ordinal);
+            var nextSuffixByBaseName = new Dictionary<string, int>(StringComparer.Ordinal);
+            const string headingText = "Repeated native heading";
+            const string baseDestination = "officeimo-heading-repeated-native-heading";
+
+            for (int index = 1; index <= 256; index++) {
+                string destinationName = (string)method.Invoke(null, new object[] {
+                    headingText,
+                    index,
+                    used,
+                    nextSuffixByBaseName
+                })!;
+
+                string expectedName = index == 1
+                    ? baseDestination
+                    : baseDestination + "-" + index.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                Assert.Equal(expectedName, destinationName);
+                used.Add(destinationName);
+            }
+
+            Assert.Equal(257, nextSuffixByBaseName[baseDestination]);
+
+            used.Add(baseDestination + "-257");
+            string skippedCollision = (string)method.Invoke(null, new object[] {
+                headingText,
+                257,
+                used,
+                nextSuffixByBaseName
+            })!;
+
+            Assert.Equal(baseDestination + "-258", skippedCollision);
+            Assert.Equal(259, nextSuffixByBaseName[baseDestination]);
+        }
+
+        [Fact]
         public void SaveAsPdf_OfficeIMOEngine_TableOfContents_Accounts_For_Section_Page_Starts() {
             string docPath = Path.Combine(_directoryWithFiles, "PdfNativeTableOfContentsSections.docx");
             string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeTableOfContentsSections.pdf");

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
@@ -259,6 +259,7 @@ namespace OfficeIMO.Word.Pdf {
         private static Dictionary<W.Paragraph, string> BuildNativeHeadingDestinations(WordDocument document) {
             var destinations = new Dictionary<W.Paragraph, string>();
             var used = new HashSet<string>(StringComparer.Ordinal);
+            var nextSuffixByBaseName = new Dictionary<string, int>(StringComparer.Ordinal);
             int headingIndex = 0;
 
             foreach (WordSection section in document.Sections) {
@@ -277,7 +278,7 @@ namespace OfficeIMO.Word.Pdf {
                     string? bookmarkName = string.IsNullOrWhiteSpace(paragraph.Bookmark?.Name)
                         ? null
                         : paragraph.Bookmark!.Name;
-                    string destinationName = bookmarkName ?? CreateNativeHeadingDestinationName(headingText, ++headingIndex, used);
+                    string destinationName = bookmarkName ?? CreateNativeHeadingDestinationName(headingText, ++headingIndex, used, nextSuffixByBaseName);
                     destinations[paragraph._paragraph] = destinationName;
                     used.Add(destinationName);
                 }
@@ -286,7 +287,7 @@ namespace OfficeIMO.Word.Pdf {
             return destinations;
         }
 
-        private static string CreateNativeHeadingDestinationName(string text, int headingIndex, HashSet<string> used) {
+        private static string CreateNativeHeadingDestinationName(string text, int headingIndex, HashSet<string> used, Dictionary<string, int> nextSuffixByBaseName) {
             var builder = new StringBuilder("officeimo-heading-");
             foreach (char ch in text) {
                 if (char.IsLetterOrDigit(ch)) {
@@ -305,13 +306,19 @@ namespace OfficeIMO.Word.Pdf {
                 baseName = "officeimo-heading-" + headingIndex.ToString(CultureInfo.InvariantCulture);
             }
 
-            string name = baseName;
-            int suffix = 2;
-            while (used.Contains(name)) {
-                name = baseName + "-" + suffix.ToString(CultureInfo.InvariantCulture);
-                suffix++;
+            if (!used.Contains(baseName)) {
+                nextSuffixByBaseName[baseName] = 2;
+                return baseName;
             }
 
+            int suffix = nextSuffixByBaseName.TryGetValue(baseName, out int nextSuffix) ? nextSuffix : 2;
+            string name;
+            do {
+                name = baseName + "-" + suffix.ToString(CultureInfo.InvariantCulture);
+                suffix++;
+            } while (used.Contains(name));
+
+            nextSuffixByBaseName[baseName] = suffix;
             return name;
         }
 


### PR DESCRIPTION
## Summary
- track the next generated native Word PDF heading destination suffix per base name
- avoid restarting duplicate-heading collision scans from suffix 2 for every repeated heading
- keep existing destination naming behavior and skip occupied suffixes safely
- add a regression guard for repeated native heading destination generation

## Tests
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -f net8.0 --filter "FullyQualifiedName~NativeHeadingDestinationNames_TrackSuffixes_ForRepeatedHeadings|FullyQualifiedName~SaveAsPdf_OfficeIMOEngine_Renders_TableOfContents_With_Heading_Entries" --verbosity minimal
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -f net10.0 --no-restore --filter "FullyQualifiedName~NativeHeadingDestinationNames_TrackSuffixes_ForRepeatedHeadings" --verbosity minimal
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -f net472 --no-restore --filter "FullyQualifiedName~NativeHeadingDestinationNames_TrackSuffixes_ForRepeatedHeadings" --verbosity minimal
- git diff --check
