### PR TITLE
Constrain Markdown PDF local image paths

### DIFF
--- a/OfficeIMO.Markdown.Pdf/MarkdownPdfConverterExtensions.Images.cs
+++ b/OfficeIMO.Markdown.Pdf/MarkdownPdfConverterExtensions.Images.cs
@@ -62,8 +62,7 @@ public static partial class MarkdownPdfConverterExtensions {
             return false;
         }
 
-        string? resolvedPath = ResolveImagePath(path, options.BaseDirectory);
-        if (resolvedPath == null) {
+        if (!TryResolveImagePath(path, options, out string resolvedPath, out warningCode, out warningMessage)) {
             return false;
         }
 
@@ -72,20 +71,72 @@ public static partial class MarkdownPdfConverterExtensions {
         return true;
     }
 
-    private static string? ResolveImagePath(string path, string? baseDirectory) {
+    private static bool TryResolveImagePath(
+        string path,
+        MarkdownPdfSaveOptions options,
+        out string resolvedPath,
+        out string warningCode,
+        out string warningMessage) {
+        resolvedPath = string.Empty;
+        warningCode = "UnsupportedImage";
+        warningMessage = "Only resolvable local Markdown images or supported base64 data URI images are embedded in the Markdown PDF adapter.";
+
         if (string.IsNullOrWhiteSpace(path) || Uri.TryCreate(path, UriKind.Absolute, out Uri? uri) && !uri.IsFile) {
-            return null;
+            return false;
         }
 
         string candidate = path;
         if (Uri.TryCreate(path, UriKind.Absolute, out Uri? fileUri) && fileUri.IsFile) {
             candidate = fileUri.LocalPath;
-        } else if (!Path.IsPathRooted(candidate) && !string.IsNullOrWhiteSpace(baseDirectory)) {
-            candidate = Path.Combine(baseDirectory!, candidate);
+        } else if (!Path.IsPathRooted(candidate) && !string.IsNullOrWhiteSpace(options.BaseDirectory)) {
+            candidate = Path.Combine(options.BaseDirectory!, candidate);
         }
 
-        return File.Exists(candidate) ? Path.GetFullPath(candidate) : null;
+        string fullPath;
+        try {
+            fullPath = Path.GetFullPath(candidate);
+        } catch (Exception ex) when (ex is ArgumentException || ex is NotSupportedException || ex is PathTooLongException) {
+            return false;
+        }
+
+        if (options.RestrictLocalImagesToBaseDirectory &&
+            !string.IsNullOrWhiteSpace(options.BaseDirectory)) {
+            try {
+                if (!IsPathInsideDirectory(fullPath, options.BaseDirectory!)) {
+                    warningCode = "LocalImageOutsideBaseDirectory";
+                    warningMessage = "Local Markdown image paths must resolve inside MarkdownPdfSaveOptions.BaseDirectory.";
+                    return false;
+                }
+            } catch (Exception ex) when (ex is ArgumentException || ex is NotSupportedException || ex is PathTooLongException) {
+                return false;
+            }
+        }
+
+        if (!File.Exists(fullPath)) {
+            return false;
+        }
+
+        resolvedPath = fullPath;
+        return true;
     }
+
+    private static bool IsPathInsideDirectory(string fullPath, string baseDirectory) {
+        string normalizedBase = EnsureTrailingDirectorySeparator(Path.GetFullPath(baseDirectory));
+        string normalizedPath = Path.GetFullPath(fullPath);
+        return normalizedPath.StartsWith(normalizedBase, GetPathComparison());
+    }
+
+    private static string EnsureTrailingDirectorySeparator(string path) {
+        if (path.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal) ||
+            path.EndsWith(Path.AltDirectorySeparatorChar.ToString(), StringComparison.Ordinal)) {
+            return path;
+        }
+
+        return path + Path.DirectorySeparatorChar;
+    }
+
+    private static StringComparison GetPathComparison() =>
+        Path.DirectorySeparatorChar == '\\' ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
     private static bool TryReadRemoteImageBytes(Uri uri, MarkdownPdfSaveOptions options, out byte[] bytes, out string sourceName, out string warningCode, out string warningMessage) {
         bytes = Array.Empty<byte>();

--- a/OfficeIMO.Markdown.Pdf/MarkdownPdfSaveOptions.cs
+++ b/OfficeIMO.Markdown.Pdf/MarkdownPdfSaveOptions.cs
@@ -67,6 +67,9 @@ public sealed class MarkdownPdfSaveOptions {
     /// <summary>When true, supported local image files are embedded as PDF images. Defaults to false for untrusted Markdown.</summary>
     public bool IncludeLocalImages { get; set; }
 
+    /// <summary>When true and <see cref="BaseDirectory"/> is set, local image paths must resolve inside that directory.</summary>
+    public bool RestrictLocalImagesToBaseDirectory { get; set; } = true;
+
     /// <summary>When true, supported base64 data URI images are embedded as PDF images.</summary>
     public bool IncludeDataUriImages { get; set; } = true;
 

--- a/OfficeIMO.Tests/Markdown.Pdf.cs
+++ b/OfficeIMO.Tests/Markdown.Pdf.cs
@@ -256,6 +256,44 @@ _Figure 1. Embedded from a relative Markdown path._
     }
 
     [Fact]
+    public void MarkdownPdfConverter_SaveFileAsPdf_BlocksLocalImagesOutsideBaseDirectory() {
+        string directory = Path.Combine(Path.GetTempPath(), "OfficeIMO.Markdown.Pdf.BaseDirectory", Guid.NewGuid().ToString("N"));
+        string markdownDirectory = Path.Combine(directory, "docs");
+        Directory.CreateDirectory(markdownDirectory);
+        try {
+            string markdownPath = Path.Combine(markdownDirectory, "README.md");
+            string pdfPath = Path.Combine(markdownDirectory, "README.pdf");
+            string outsideImagePath = Path.Combine(directory, "secret.png");
+
+            File.WriteAllBytes(outsideImagePath, CreateMinimalRgbPng());
+            File.WriteAllText(markdownPath, """
+# Escaped Asset
+
+![Secret pixel](../secret.png){width=32 height=32}
+""");
+
+            var options = new MarkdownPdfSaveOptions {
+                IncludeLocalImages = true
+            };
+            MarkdownPdfConverter.SaveFileAsPdf(markdownPath, pdfPath, options);
+
+            byte[] pdf = File.ReadAllBytes(pdfPath);
+            string text = PdfCore.PdfReadDocument.Load(pdf).ExtractText();
+            IReadOnlyList<PdfCore.PdfExtractedImage> images = PdfCore.PdfImageExtractor.ExtractImages(pdf);
+
+            MarkdownPdfExportWarning warning = Assert.Single(options.Warnings);
+            Assert.Equal("LocalImageOutsideBaseDirectory", warning.Code);
+            Assert.Null(options.BaseDirectory);
+            Assert.Contains("[Image:", text, StringComparison.Ordinal);
+            Assert.Empty(images);
+        } finally {
+            if (Directory.Exists(directory)) {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public void Markdown_SaveAsPdf_ScalesOversizedLocalImagesIntoContentFrame() {
         string directory = Path.Combine(Path.GetTempPath(), "OfficeIMO.Markdown.Pdf.ScaleDown", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);


### PR DESCRIPTION
## Summary
- keep Markdown PDF local images disabled by default
- when trusted callers enable local images and a base directory is set, require local image paths to resolve inside that base directory
- emit a specific LocalImageOutsideBaseDirectory warning for path escapes
- add a regression for Markdown file conversion blocking ../ image traversal while preserving valid relative images

## Tests
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -f net8.0 --filter "FullyQualifiedName~MarkdownPdfConverter_SaveFileAsPdf_BlocksLocalImagesOutsideBaseDirectory|FullyQualifiedName~MarkdownPdfConverter_SaveFileAsPdf_ResolvesRelativeLocalImages|FullyQualifiedName~Markdown_SaveAsPdf_BlocksLocalImagesByDefault" --verbosity minimal
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -f net10.0 --no-restore --filter "FullyQualifiedName~MarkdownPdfConverter_SaveFileAsPdf_BlocksLocalImagesOutsideBaseDirectory" --verbosity minimal
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -f net472 --no-restore --filter "FullyQualifiedName~MarkdownPdfConverter_SaveFileAsPdf_BlocksLocalImagesOutsideBaseDirectory" --verbosity minimal
- git diff --check
