### PR TITLE
Harden Visio SVG preview rendering

### DIFF
--- a/OfficeIMO.Tests/Visio.SvgExport.cs
+++ b/OfficeIMO.Tests/Visio.SvgExport.cs
@@ -902,7 +902,7 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void SvgRendererSniffsPackageBackedSvgPreviewArtworkWithXmlPreamble() {
+        public void SvgRendererSkipsPackageBackedSvgPreviewArtworkWithXmlPreamble() {
             using MemoryStream packageStream = new();
             VisioDocument document = VisioDocument.Create(packageStream);
             VisioPage page = document.AddPage("Package SVG Preview").Size(3, 2);
@@ -923,10 +923,11 @@ namespace OfficeIMO.Tests {
             XNamespace ns = "http://www.w3.org/2000/svg";
             XElement shapeGroup = parsed.Root!.Descendants(ns + "g")
                 .Single(g => (string?)g.Attribute("data-visio-shape-id") == shape.Id);
-            XElement image = shapeGroup.Elements(ns + "image")
-                .Single(element => (string?)element.Attribute("data-officeimo-package-preview-artwork") == "true");
-            Assert.StartsWith("data:image/svg+xml;base64,", image.Attribute("href")!.Value, StringComparison.Ordinal);
-            Assert.DoesNotContain("data-officeimo-stencil-artwork=\"true\"", svg);
+            Assert.DoesNotContain(
+                shapeGroup.Elements(ns + "image"),
+                element => (string?)element.Attribute("data-officeimo-package-preview-artwork") == "true");
+            Assert.DoesNotContain("data:image/svg+xml;base64,", svg, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("data-officeimo-stencil-artwork=\"true\"", svg, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/OfficeIMO.Visio/VisioPackagePreviewArtwork.cs
+++ b/OfficeIMO.Visio/VisioPackagePreviewArtwork.cs
@@ -99,8 +99,7 @@ namespace OfficeIMO.Visio {
         private static bool IsBrowserRenderable(string contentType, string? extension) {
             if (string.Equals(contentType, "image/png", StringComparison.OrdinalIgnoreCase) ||
                 string.Equals(contentType, "image/jpeg", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(contentType, "image/gif", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(contentType, "image/svg+xml", StringComparison.OrdinalIgnoreCase)) {
+                string.Equals(contentType, "image/gif", StringComparison.OrdinalIgnoreCase)) {
                 return true;
             }
 


### PR DESCRIPTION
## Summary
- skip untrusted package-backed SVG preview images when exporting Visio pages to SVG
- keep PNG/JPEG/GIF package previews renderable while falling back to generated stencil artwork for SVG payloads
- update the SVG export regression to assert package SVG data URIs are not emitted

## Testing
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -f net8.0 --no-restore --filter "FullyQualifiedName~SvgRendererSkipsPackageBackedSvgPreviewArtworkWithXmlPreamble|FullyQualifiedName~SvgRendererProjectsPackageBackedPngPreviewArtwork|FullyQualifiedName~SvgRendererNormalizesPackagePreviewContentTypeParameters" --verbosity minimal
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -f net10.0 --no-restore --filter "FullyQualifiedName~SvgRendererSkipsPackageBackedSvgPreviewArtworkWithXmlPreamble" --verbosity minimal
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj -f net472 --no-restore --filter "FullyQualifiedName~SvgRendererSkipsPackageBackedSvgPreviewArtworkWithXmlPreamble" --verbosity minimal
- git diff --check