### PR TITLE
Add CSV formula injection escape policy

### DIFF
--- a/OfficeIMO.CSV.Tests/CsvDocumentBasicsTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvDocumentBasicsTests.cs
@@ -78,4 +78,55 @@ public class CsvDocumentBasicsTests
         Assert.Equal(new[] { "Name", "Age" }, parsed.Header);
         Assert.Empty(parsed.AsEnumerable());
     }
+
+    [Fact]
+    public void Formula_Injection_Policy_Preserves_Values_By_Default()
+    {
+        var doc = new CsvDocument()
+            .WithHeader("=Header");
+
+        doc.AddRow("=cmd");
+
+        var text = doc.ToString(new CsvSaveOptions { NewLine = "\n" });
+
+        Assert.Equal("=Header\n=cmd\n", text);
+    }
+
+    [Theory]
+    [InlineData("=cmd", "'=cmd")]
+    [InlineData("+cmd", "'+cmd")]
+    [InlineData("-cmd", "'-cmd")]
+    [InlineData("@cmd", "'@cmd")]
+    [InlineData("\tcmd", "'\tcmd")]
+    [InlineData("  =cmd", "'  =cmd")]
+    public void Formula_Injection_Policy_Escapes_Dangerous_Row_Values(string value, string expected)
+    {
+        var doc = new CsvDocument()
+            .WithHeader("Value");
+
+        doc.AddRow(value);
+
+        var text = doc.ToString(new CsvSaveOptions {
+            NewLine = "\n",
+            FormulaInjectionPolicy = CsvFormulaInjectionPolicy.Escape
+        });
+
+        Assert.Equal($"Value\n{expected}\n", text);
+    }
+
+    [Fact]
+    public void Formula_Injection_Policy_Escapes_Dangerous_Headers()
+    {
+        var doc = new CsvDocument()
+            .WithHeader("=Header");
+
+        doc.AddRow("safe");
+
+        var text = doc.ToString(new CsvSaveOptions {
+            NewLine = "\n",
+            FormulaInjectionPolicy = CsvFormulaInjectionPolicy.Escape
+        });
+
+        Assert.Equal("'=Header\nsafe\n", text);
+    }
 }

--- a/OfficeIMO.CSV/CsvFormulaInjectionPolicy.cs
+++ b/OfficeIMO.CSV/CsvFormulaInjectionPolicy.cs
@@ -1,0 +1,19 @@
+#nullable enable
+
+namespace OfficeIMO.CSV;
+
+/// <summary>
+/// Controls how CSV serialization treats values that spreadsheet applications may interpret as formulas.
+/// </summary>
+public enum CsvFormulaInjectionPolicy
+{
+    /// <summary>
+    /// Preserve values exactly as supplied.
+    /// </summary>
+    Preserve = 0,
+
+    /// <summary>
+    /// Prefix formula-like values with an apostrophe before writing them.
+    /// </summary>
+    Escape = 1
+}

--- a/OfficeIMO.CSV/CsvSaveOptions.cs
+++ b/OfficeIMO.CSV/CsvSaveOptions.cs
@@ -36,4 +36,9 @@ public sealed class CsvSaveOptions
     /// Gets or sets the text encoding used when writing to files. Defaults to UTF-8 without BOM when omitted.
     /// </summary>
     public Encoding? Encoding { get; set; }
+
+    /// <summary>
+    /// Gets or sets how formula-like values are handled before writing CSV output. Default preserves values exactly.
+    /// </summary>
+    public CsvFormulaInjectionPolicy FormulaInjectionPolicy { get; set; } = CsvFormulaInjectionPolicy.Preserve;
 }

--- a/OfficeIMO.CSV/CsvWriter.cs
+++ b/OfficeIMO.CSV/CsvWriter.cs
@@ -13,24 +13,26 @@ internal static class CsvWriter
         var culture = options.Culture;
         var includeHeader = options.IncludeHeader;
         var newLine = options.NewLine;
+        var formulaInjectionPolicy = options.FormulaInjectionPolicy;
 
         if (includeHeader && document.Header.Count > 0)
         {
-            WriteRecord(writer, document.Header, delimiter, newLine);
+            WriteRecord(writer, document.Header, delimiter, newLine, CultureInfo.InvariantCulture, formulaInjectionPolicy);
         }
 
         foreach (var row in document.AsEnumerable())
         {
-            WriteRecord(writer, row.Values, delimiter, newLine, culture);
+            WriteRecord(writer, row.Values, delimiter, newLine, culture, formulaInjectionPolicy);
         }
     }
 
-    private static void WriteRecord(TextWriter writer, IReadOnlyList<string> header, char delimiter, string newLine)
-    {
-        WriteRecord(writer, header.Cast<object?>(), delimiter, newLine, CultureInfo.InvariantCulture);
-    }
-
-    private static void WriteRecord(TextWriter writer, IEnumerable<object?> values, char delimiter, string newLine, CultureInfo culture)
+    private static void WriteRecord(
+        TextWriter writer,
+        IEnumerable<object?> values,
+        char delimiter,
+        string newLine,
+        CultureInfo culture,
+        CsvFormulaInjectionPolicy formulaInjectionPolicy)
     {
         var first = true;
         foreach (var value in values)
@@ -44,7 +46,7 @@ internal static class CsvWriter
                 first = false;
             }
 
-            var text = FormatValue(value, culture);
+            var text = ApplyFormulaInjectionPolicy(FormatValue(value, culture), formulaInjectionPolicy);
             WriteEscaped(writer, text, delimiter);
         }
 
@@ -64,6 +66,43 @@ internal static class CsvWriter
         }
 
         return value.ToString() ?? string.Empty;
+    }
+
+    private static string ApplyFormulaInjectionPolicy(string text, CsvFormulaInjectionPolicy policy)
+    {
+        if (policy != CsvFormulaInjectionPolicy.Escape || !StartsWithFormulaTrigger(text))
+        {
+            return text;
+        }
+
+        return "'" + text;
+    }
+
+    private static bool StartsWithFormulaTrigger(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return false;
+        }
+
+        var index = 0;
+        while (index < text.Length && text[index] == ' ')
+        {
+            index++;
+        }
+
+        if (index >= text.Length)
+        {
+            return false;
+        }
+
+        return text[index] == '='
+            || text[index] == '+'
+            || text[index] == '-'
+            || text[index] == '@'
+            || text[index] == '\t'
+            || text[index] == '\r'
+            || text[index] == '\n';
     }
 
     private static void WriteEscaped(TextWriter writer, string text, char delimiter)

--- a/OfficeIMO.CSV/README.md
+++ b/OfficeIMO.CSV/README.md
@@ -29,6 +29,7 @@ new CsvDocument()
     .Save("people.csv", new CsvSaveOptions {
         Delimiter = ';',
         IncludeHeader = true,
+        FormulaInjectionPolicy = CsvFormulaInjectionPolicy.Escape,
         NewLine = "\n"
     });
 ```
@@ -37,6 +38,7 @@ new CsvDocument()
 
 - Keeps headers and rows as a first-class document model instead of ad hoc string arrays.
 - Loads from files, streams, or text and saves through configurable delimiter, culture, encoding, and newline options.
+- Can escape formula-like values during save when producing CSV files that people will open in spreadsheet applications.
 - Supports `AddRow`, `AddColumn`, `RemoveColumn`, `SortBy`, `Filter`, and `Transform`.
 - Provides schema validation with required columns, typed columns, defaults, and custom rules.
 - Maps rows to typed objects with explicit no-reflection mapping.


### PR DESCRIPTION
## Summary
- add an explicit CSV save-time formula injection policy for spreadsheet-targeted exports
- escape formula-like header and row values with an apostrophe when the policy is enabled
- document the option and preserve existing CSV output by default

## Tests
- dotnet test OfficeIMO.CSV.Tests\OfficeIMO.CSV.Tests.csproj --framework net8.0
- dotnet test OfficeIMO.CSV.Tests\OfficeIMO.CSV.Tests.csproj --framework net472