### PR TITLE
Gate PowerPoint COM preview automation

### DIFF
--- a/OfficeIMO.PowerPoint/PowerPointPreviewExportOptions.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPreviewExportOptions.cs
@@ -1,0 +1,13 @@
+namespace OfficeIMO.PowerPoint {
+    /// <summary>
+    ///     Options for the optional Microsoft PowerPoint automation preview/export boundary.
+    /// </summary>
+    public sealed class PowerPointPreviewExportOptions {
+        /// <summary>
+        ///     Gets or sets whether the caller has classified the presentation as trusted for
+        ///     opening in installed Microsoft PowerPoint automation. Keep this disabled for
+        ///     user-supplied or otherwise untrusted presentation files.
+        /// </summary>
+        public bool TrustPresentationFile { get; set; }
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointPreviewExporter.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPreviewExporter.cs
@@ -28,6 +28,27 @@ namespace OfficeIMO.PowerPoint {
             PowerPointPreviewExportFormat format = PowerPointPreviewExportFormat.Png,
             int width = 0,
             int height = 0) {
+            return TryExportSlides(
+                presentationPath,
+                outputDirectory,
+                null,
+                out result,
+                format,
+                width,
+                height);
+        }
+
+        /// <summary>
+        ///     Attempts to export slides from a saved, trusted presentation to image files.
+        /// </summary>
+        public static bool TryExportSlides(
+            string presentationPath,
+            string outputDirectory,
+            PowerPointPreviewExportOptions? options,
+            out PowerPointPreviewExportResult result,
+            PowerPointPreviewExportFormat format = PowerPointPreviewExportFormat.Png,
+            int width = 0,
+            int height = 0) {
             if (presentationPath == null) {
                 throw new ArgumentNullException(nameof(presentationPath));
             }
@@ -42,6 +63,12 @@ namespace OfficeIMO.PowerPoint {
             }
             if (!File.Exists(presentationPath)) {
                 throw new FileNotFoundException("Presentation file not found.", presentationPath);
+            }
+
+            if (options?.TrustPresentationFile != true) {
+                result = new PowerPointPreviewExportResult(false, Array.Empty<string>(),
+                    "PowerPoint automation opens presentation files in installed Microsoft PowerPoint. Set TrustPresentationFile only for trusted presentation files.", null);
+                return false;
             }
 
             Type? powerPointType = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)

--- a/OfficeIMO.PowerPoint/README.md
+++ b/OfficeIMO.PowerPoint/README.md
@@ -40,6 +40,18 @@ presentation.Save();
 - Supports encrypted presentation save/open workflows.
 - Uses Open XML directly, making it suitable for services, build agents, desktop apps, and automation hosts.
 
+## Trusted preview export
+
+`PowerPointPreviewExporter` is an optional Windows-only boundary that uses installed Microsoft PowerPoint automation to render slide images. It does not open presentation files by default. Enable it only for presentations your application has already classified as trusted:
+
+```csharp
+PowerPointPreviewExporter.TryExportSlides(
+    "trusted-deck.pptx",
+    "preview",
+    new PowerPointPreviewExportOptions { TrustPresentationFile = true },
+    out PowerPointPreviewExportResult result);
+```
+
 ## Runnable samples
 
 ```powershell

--- a/OfficeIMO.Tests/PowerPoint.PreviewExport.cs
+++ b/OfficeIMO.Tests/PowerPoint.PreviewExport.cs
@@ -33,6 +33,32 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void PreviewExporterDoesNotOpenExistingPresentationWithoutTrustOptIn() {
+            string outputDirectory = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString());
+            string existingPresentation = System.IO.Path.Combine(outputDirectory, "existing.pptx");
+
+            try {
+                Directory.CreateDirectory(outputDirectory);
+                File.WriteAllBytes(existingPresentation, Array.Empty<byte>());
+
+                bool exported = PowerPointPreviewExporter.TryExportSlides(
+                    existingPresentation,
+                    outputDirectory,
+                    out PowerPointPreviewExportResult result);
+
+                Assert.False(exported);
+                Assert.False(result.Succeeded);
+                Assert.Empty(result.Files);
+                Assert.Null(result.Exception);
+                Assert.Contains("TrustPresentationFile", result.Message, StringComparison.Ordinal);
+            } finally {
+                if (Directory.Exists(outputDirectory)) {
+                    Directory.Delete(outputDirectory, recursive: true);
+                }
+            }
+        }
+
+        [Fact]
         public void PreviewExporterReportsAvailabilityWithoutThrowing() {
             bool available = PowerPointPreviewExporter.IsPowerPointAutomationAvailable();
             Assert.IsType<bool>(available);


### PR DESCRIPTION
## Summary
- require an explicit TrustPresentationFile opt-in before optional PowerPoint COM preview export opens a presentation in installed Microsoft PowerPoint
- preserve input validation before the trust gate so missing files and bad dimensions still fail deterministically
- document the trusted-preview boundary and add regression coverage that does not require PowerPoint automation

## Tests
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --filter "FullyQualifiedName~PowerPointPreviewExportTests" --framework net8.0
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --filter "FullyQualifiedName~PowerPointPreviewExportTests" --framework net472