### PR TITLE
Harden Word PDF system font embedding

### DIFF
--- a/OfficeIMO.Tests/Pdf/PdfConversionTypographyTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfConversionTypographyTests.cs
@@ -523,7 +523,8 @@ Zażółć gęślą jaźń
 
         return exception.Message.Contains("not covered by the embedded TrueType font", StringComparison.Ordinal) ||
                exception.Message.Contains("cannot be encoded with embedded TrueType font", StringComparison.Ordinal) ||
-               exception.Message.Contains("not covered by any embedded font fallback candidate", StringComparison.Ordinal);
+               exception.Message.Contains("not covered by any embedded font fallback candidate", StringComparison.Ordinal) ||
+               exception.Message.Contains("Embedded Unicode fonts are required for this text", StringComparison.Ordinal);
     }
 
     private static void WriteReviewArtifact(string fileName, byte[] bytes) {

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.RunStyleTests.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.RunStyleTests.cs
@@ -83,7 +83,29 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void SaveAsPdf_OfficeIMOEngine_Embeds_Document_Default_Font_When_Available() {
+        public void SaveAsPdf_OfficeIMOEngine_Does_Not_Embed_System_Fonts_By_Default() {
+            string docPath = Path.Combine(_directoryWithFiles, "PdfNativeDocumentDefaultFontNoEmbedding.docx");
+            string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeDocumentDefaultFontNoEmbedding.pdf");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                document.Settings.FontFamily = "Calibri";
+                document.AddParagraph("Document default font should not embed host fonts by default.");
+
+                document.Save();
+                document.SaveAsPdf(pdfPath, new PdfSaveOptions {
+                    IncludePageNumbers = false
+                });
+            }
+
+            byte[] bytes = File.ReadAllBytes(pdfPath);
+            string content = Encoding.ASCII.GetString(bytes);
+
+            Assert.DoesNotContain("/FontFile2", content, StringComparison.Ordinal);
+            Assert.DoesNotContain("/BaseFont /Calibri", content, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void SaveAsPdf_OfficeIMOEngine_Embeds_Document_Default_Font_When_Allowed_And_Available() {
             if (!PdfEmbeddedFontFamily.TryFromSystem("Calibri", out PdfEmbeddedFontFamily? _)) {
                 return;
             }
@@ -97,6 +119,7 @@ namespace OfficeIMO.Tests {
 
                 document.Save();
                 document.SaveAsPdf(pdfPath, new PdfSaveOptions {
+                    AllowSystemFontEmbedding = true,
                     IncludePageNumbers = false
                 });
             }

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.StructuredBlocks.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.StructuredBlocks.cs
@@ -1913,6 +1913,7 @@ public partial class Word {
 
             document.Save();
             document.SaveAsPdf(pdfPath, new PdfSaveOptions {
+                AllowSystemFontEmbedding = true,
                 IncludePageNumbers = false
             });
         }

--- a/OfficeIMO.Word.Pdf/PdfSaveOptions.cs
+++ b/OfficeIMO.Word.Pdf/PdfSaveOptions.cs
@@ -12,9 +12,16 @@ namespace OfficeIMO.Word.Pdf {
         public PdfCore.PdfOptions? PdfOptions { get; set; }
 
         /// <summary>
-        /// Optional Word-style font family used as the first-party PDF default font. Installed TrueType faces are embedded when available; otherwise the family maps to the nearest PDF standard font.
+        /// Optional Word-style font family used as the first-party PDF default font. By default, the family maps to the nearest PDF standard font without embedding installed host fonts.
         /// </summary>
         public string? FontFamily { get; set; }
+
+        /// <summary>
+        /// When true, first-party Word PDF export may load installed system fonts to embed them into the generated PDF.
+        /// Defaults to false so untrusted DOCX content cannot silently copy host font files into exported PDFs.
+        /// Explicit font data supplied through <see cref="PdfOptions"/> remains available regardless of this setting.
+        /// </summary>
+        public bool AllowSystemFontEmbedding { get; set; }
 
         /// <summary>
         /// Optional page size in PDF points. The supplied geometry is preserved unless <see cref="Orientation"/> is also set.

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
@@ -20,20 +20,21 @@ namespace OfficeIMO.Word.Pdf {
 
             pdfOptions.PageSize = firstSection == null ? PdfCore.PageSizes.A4 : GetNativePageSize(firstSection, options);
             pdfOptions.Margins = firstSection == null ? PdfCore.PageMargins.Uniform(72) : GetNativeMargins(firstSection, options);
-            bool preserveConfiguredFontSlots = ApplyNativeDefaultFont(document, options, pdfOptions) ||
+            bool allowSystemFontEmbedding = options?.AllowSystemFontEmbedding == true;
+            bool preserveConfiguredFontSlots = ApplyNativeDefaultFont(document, options, pdfOptions, allowSystemFontEmbedding) ||
                                                 options?.PdfOptions != null;
-            HashSet<PdfCore.PdfStandardFont> registeredFontSlots = RegisterNativeDocumentFonts(document, pdfOptions, preserveConfiguredFontSlots);
-            ApplyNativeFallbackFont(options, pdfOptions, preserveConfiguredFontSlots);
-            RegisterNativeEmbeddedTextFallbacks(pdfOptions, registeredFontSlots);
+            HashSet<PdfCore.PdfStandardFont> registeredFontSlots = RegisterNativeDocumentFonts(document, pdfOptions, preserveConfiguredFontSlots, allowSystemFontEmbedding);
+            ApplyNativeFallbackFont(options, pdfOptions, preserveConfiguredFontSlots, allowSystemFontEmbedding);
+            RegisterNativeEmbeddedTextFallbacks(pdfOptions, registeredFontSlots, allowSystemFontEmbedding);
             pdfOptions.BackgroundColor = ParseNativeColor(document.Background?.Color);
             pdfOptions.CreateOutlineFromHeadings = true;
             return pdfOptions;
         }
 
-        private static bool ApplyNativeDefaultFont(WordDocument document, PdfSaveOptions? options, PdfCore.PdfOptions pdfOptions) {
+        private static bool ApplyNativeDefaultFont(WordDocument document, PdfSaveOptions? options, PdfCore.PdfOptions pdfOptions, bool allowSystemFontEmbedding) {
             string? optionFontFamily = options?.FontFamily;
             if (!string.IsNullOrWhiteSpace(optionFontFamily) &&
-                TryApplyNativeDefaultFontCandidate(optionFontFamily, pdfOptions, embedSystemFont: true)) {
+                TryApplyNativeDefaultFontCandidate(optionFontFamily, pdfOptions, embedSystemFont: allowSystemFontEmbedding)) {
                 return true;
             }
 
@@ -43,7 +44,7 @@ namespace OfficeIMO.Word.Pdf {
                 document.Settings.FontFamilyEastAsia,
                 document.Settings.FontFamilyComplexScript
             }) {
-                if (TryApplyNativeDefaultFontCandidate(family, pdfOptions, embedSystemFont: true)) {
+                if (TryApplyNativeDefaultFontCandidate(family, pdfOptions, embedSystemFont: allowSystemFontEmbedding)) {
                     return true;
                 }
             }
@@ -51,8 +52,9 @@ namespace OfficeIMO.Word.Pdf {
             return false;
         }
 
-        private static void ApplyNativeFallbackFont(PdfSaveOptions? options, PdfCore.PdfOptions pdfOptions, bool preserveConfiguredFontSlots) {
+        private static void ApplyNativeFallbackFont(PdfSaveOptions? options, PdfCore.PdfOptions pdfOptions, bool preserveConfiguredFontSlots, bool allowSystemFontEmbedding) {
             if (options?.PdfOptions == null &&
+                allowSystemFontEmbedding &&
                 !preserveConfiguredFontSlots &&
                 !pdfOptions.HasEmbeddedStandardFontFamily(pdfOptions.DefaultFont)) {
                 pdfOptions.TryUseDefaultDocumentFontFallback(requireEmbeddedFont: true);
@@ -63,8 +65,9 @@ namespace OfficeIMO.Word.Pdf {
             return pdfOptions.TryUseOfficeFontFamily(familyName, embedSystemFont, requireEmbeddedFont);
         }
 
-        private static void RegisterNativeEmbeddedTextFallbacks(PdfCore.PdfOptions pdfOptions, IEnumerable<PdfCore.PdfStandardFont> reservedFontSlots) {
-            if (pdfOptions.EmbeddedFontFallbacks != null) {
+        private static void RegisterNativeEmbeddedTextFallbacks(PdfCore.PdfOptions pdfOptions, IEnumerable<PdfCore.PdfStandardFont> reservedFontSlots, bool allowSystemFontEmbedding) {
+            if (!allowSystemFontEmbedding ||
+                pdfOptions.EmbeddedFontFallbacks != null) {
                 return;
             }
 
@@ -121,14 +124,14 @@ namespace OfficeIMO.Word.Pdf {
             }
         }
 
-        private static HashSet<PdfCore.PdfStandardFont> RegisterNativeDocumentFonts(WordDocument document, PdfCore.PdfOptions pdfOptions, bool preserveConfiguredFontSlots) {
+        private static HashSet<PdfCore.PdfStandardFont> RegisterNativeDocumentFonts(WordDocument document, PdfCore.PdfOptions pdfOptions, bool preserveConfiguredFontSlots, bool allowSystemFontEmbedding) {
             var registeredFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             HashSet<PdfCore.PdfStandardFont> registeredFontSlots = CreateNativeRegisteredFontSlots(pdfOptions, preserveConfiguredFontSlots);
             foreach (WordSection section in document.Sections) {
                 foreach (WordElement element in CollapseNativeParagraphElements(section.Elements)) {
                     if (element is WordCoverPage coverPage) {
                         foreach (WordElement coverElement in GetNativeStructuredBlockElements(coverPage.Document, coverPage.SdtBlock)) {
-                            RegisterNativeElementFonts(coverElement, pdfOptions, registeredFamilies, registeredFontSlots);
+                            RegisterNativeElementFonts(coverElement, pdfOptions, registeredFamilies, registeredFontSlots, allowSystemFontEmbedding);
                         }
 
                         continue;
@@ -136,49 +139,49 @@ namespace OfficeIMO.Word.Pdf {
 
                     if (element is WordStructuredDocumentTag structuredDocumentTag) {
                         foreach (WordElement structuredElement in GetNativeStructuredBlockElements(structuredDocumentTag.Document, structuredDocumentTag.SdtBlock)) {
-                            RegisterNativeElementFonts(structuredElement, pdfOptions, registeredFamilies, registeredFontSlots);
+                            RegisterNativeElementFonts(structuredElement, pdfOptions, registeredFamilies, registeredFontSlots, allowSystemFontEmbedding);
                         }
 
                         continue;
                     }
 
-                    RegisterNativeElementFonts(element, pdfOptions, registeredFamilies, registeredFontSlots);
+                    RegisterNativeElementFonts(element, pdfOptions, registeredFamilies, registeredFontSlots, allowSystemFontEmbedding);
                 }
 
-                RegisterNativeHeaderFooterFonts(section.Header?.Default, pdfOptions, registeredFamilies, registeredFontSlots);
-                RegisterNativeHeaderFooterFonts(section.Header?.First, pdfOptions, registeredFamilies, registeredFontSlots);
-                RegisterNativeHeaderFooterFonts(section.Header?.Even, pdfOptions, registeredFamilies, registeredFontSlots);
-                RegisterNativeHeaderFooterFonts(section.Footer?.Default, pdfOptions, registeredFamilies, registeredFontSlots);
-                RegisterNativeHeaderFooterFonts(section.Footer?.First, pdfOptions, registeredFamilies, registeredFontSlots);
-                RegisterNativeHeaderFooterFonts(section.Footer?.Even, pdfOptions, registeredFamilies, registeredFontSlots);
+                RegisterNativeHeaderFooterFonts(section.Header?.Default, pdfOptions, registeredFamilies, registeredFontSlots, allowSystemFontEmbedding);
+                RegisterNativeHeaderFooterFonts(section.Header?.First, pdfOptions, registeredFamilies, registeredFontSlots, allowSystemFontEmbedding);
+                RegisterNativeHeaderFooterFonts(section.Header?.Even, pdfOptions, registeredFamilies, registeredFontSlots, allowSystemFontEmbedding);
+                RegisterNativeHeaderFooterFonts(section.Footer?.Default, pdfOptions, registeredFamilies, registeredFontSlots, allowSystemFontEmbedding);
+                RegisterNativeHeaderFooterFonts(section.Footer?.First, pdfOptions, registeredFamilies, registeredFontSlots, allowSystemFontEmbedding);
+                RegisterNativeHeaderFooterFonts(section.Footer?.Even, pdfOptions, registeredFamilies, registeredFontSlots, allowSystemFontEmbedding);
 
                 foreach (WordWatermark watermark in section.Watermarks) {
-                    RegisterNativeFontCandidate(watermark.FontFamily, pdfOptions, registeredFamilies, registeredFontSlots);
+                    RegisterNativeFontCandidate(watermark.FontFamily, pdfOptions, registeredFamilies, registeredFontSlots, allowSystemFontEmbedding);
                 }
             }
 
             return registeredFontSlots;
         }
 
-        private static void RegisterNativeHeaderFooterFonts(WordHeaderFooter? headerFooter, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots) {
+        private static void RegisterNativeHeaderFooterFonts(WordHeaderFooter? headerFooter, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, bool allowSystemFontEmbedding) {
             if (headerFooter == null) {
                 return;
             }
 
             foreach (WordElement element in CollapseNativeParagraphElements(headerFooter.Elements)) {
-                RegisterNativeElementFonts(element, pdfOptions, registeredFamilies, registeredFontSlots);
+                RegisterNativeElementFonts(element, pdfOptions, registeredFamilies, registeredFontSlots, allowSystemFontEmbedding);
             }
         }
 
-        private static void RegisterNativeElementFonts(WordElement element, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots) {
-                    if (element is WordParagraph paragraph) {
-                        RegisterNativeParagraphFonts(paragraph, pdfOptions, registeredFamilies, registeredFontSlots);
-                        foreach (WordParagraph run in GetNativeRuns(paragraph)) {
-                            RegisterNativeParagraphFonts(run, pdfOptions, registeredFamilies, registeredFontSlots);
-                        }
-                    } else if (element is WordTable table) {
-                        RegisterNativeTableFonts(table, pdfOptions, registeredFamilies, registeredFontSlots);
-                    }
+        private static void RegisterNativeElementFonts(WordElement element, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, bool allowSystemFontEmbedding) {
+            if (element is WordParagraph paragraph) {
+                RegisterNativeParagraphFonts(paragraph, pdfOptions, registeredFamilies, registeredFontSlots, allowSystemFontEmbedding);
+                foreach (WordParagraph run in GetNativeRuns(paragraph)) {
+                    RegisterNativeParagraphFonts(run, pdfOptions, registeredFamilies, registeredFontSlots, allowSystemFontEmbedding);
+                }
+            } else if (element is WordTable table) {
+                RegisterNativeTableFonts(table, pdfOptions, registeredFamilies, registeredFontSlots, allowSystemFontEmbedding);
+            }
         }
 
         private static HashSet<PdfCore.PdfStandardFont> CreateNativeRegisteredFontSlots(PdfCore.PdfOptions pdfOptions, bool preserveConfiguredFontSlots) {
@@ -200,31 +203,31 @@ namespace OfficeIMO.Word.Pdf {
             registeredFontSlots.Add(PdfCore.PdfStandardFontMapper.GetFontFamily(font));
         }
 
-        private static void RegisterNativeTableFonts(WordTable table, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots) {
+        private static void RegisterNativeTableFonts(WordTable table, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, bool allowSystemFontEmbedding) {
             foreach (WordTableRow row in table.Rows) {
                 foreach (WordTableCell cell in row.Cells) {
                     foreach (WordParagraph paragraph in cell.Paragraphs) {
-                        RegisterNativeParagraphFonts(paragraph, pdfOptions, registeredFamilies, registeredFontSlots);
+                        RegisterNativeParagraphFonts(paragraph, pdfOptions, registeredFamilies, registeredFontSlots, allowSystemFontEmbedding);
                         foreach (WordParagraph run in GetNativeRuns(paragraph)) {
-                            RegisterNativeParagraphFonts(run, pdfOptions, registeredFamilies, registeredFontSlots);
+                            RegisterNativeParagraphFonts(run, pdfOptions, registeredFamilies, registeredFontSlots, allowSystemFontEmbedding);
                         }
                     }
 
                     foreach (WordTable nestedTable in cell.NestedTables) {
-                        RegisterNativeTableFonts(nestedTable, pdfOptions, registeredFamilies, registeredFontSlots);
+                        RegisterNativeTableFonts(nestedTable, pdfOptions, registeredFamilies, registeredFontSlots, allowSystemFontEmbedding);
                     }
                 }
             }
         }
 
-        private static void RegisterNativeParagraphFonts(WordParagraph paragraph, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots) {
-            RegisterNativeFontCandidate(paragraph.FontFamily, pdfOptions, registeredFamilies, registeredFontSlots);
-            RegisterNativeFontCandidate(paragraph.FontFamilyHighAnsi, pdfOptions, registeredFamilies, registeredFontSlots);
-            RegisterNativeFontCandidate(paragraph.FontFamilyEastAsia, pdfOptions, registeredFamilies, registeredFontSlots);
-            RegisterNativeFontCandidate(paragraph.FontFamilyComplexScript, pdfOptions, registeredFamilies, registeredFontSlots);
+        private static void RegisterNativeParagraphFonts(WordParagraph paragraph, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, bool allowSystemFontEmbedding) {
+            RegisterNativeFontCandidate(paragraph.FontFamily, pdfOptions, registeredFamilies, registeredFontSlots, allowSystemFontEmbedding);
+            RegisterNativeFontCandidate(paragraph.FontFamilyHighAnsi, pdfOptions, registeredFamilies, registeredFontSlots, allowSystemFontEmbedding);
+            RegisterNativeFontCandidate(paragraph.FontFamilyEastAsia, pdfOptions, registeredFamilies, registeredFontSlots, allowSystemFontEmbedding);
+            RegisterNativeFontCandidate(paragraph.FontFamilyComplexScript, pdfOptions, registeredFamilies, registeredFontSlots, allowSystemFontEmbedding);
         }
 
-        private static void RegisterNativeFontCandidate(string? familyName, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots) {
+        private static void RegisterNativeFontCandidate(string? familyName, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, bool allowSystemFontEmbedding) {
             if (string.IsNullOrWhiteSpace(familyName)) {
                 return;
             }
@@ -237,7 +240,7 @@ namespace OfficeIMO.Word.Pdf {
             if (PdfCore.PdfStandardFontMapper.TryMapFontFamily(trimmedFamilyName, out PdfCore.PdfStandardFont standardFont)) {
                 PdfCore.PdfStandardFont fontFamily = PdfCore.PdfStandardFontMapper.GetFontFamily(standardFont);
                 if (registeredFontSlots.Add(fontFamily)) {
-                    pdfOptions.RegisterOfficeFontFamily(trimmedFamilyName, fontFamily);
+                    pdfOptions.RegisterOfficeFontFamily(trimmedFamilyName, fontFamily, embedSystemFont: allowSystemFontEmbedding);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- make Word PDF export refuse silent host system font embedding by default
- add PdfSaveOptions.AllowSystemFontEmbedding for callers that explicitly trust the host font boundary
- keep explicit low-level PdfOptions font data usable, and update Unicode fallback tests to opt in where system fonts are required

## Tests
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --filter "FullyQualifiedName~Word.SaveAsPdf_OfficeIMOEngine" --framework net8.0
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --filter "FullyQualifiedName~Word.SaveAsPdf_OfficeIMOEngine" --framework net472