### PR TITLE
Harden PDF outline traversal limits

### DIFF
--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Outlines.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Outlines.cs
@@ -1,6 +1,9 @@
 namespace OfficeIMO.Pdf;
 
 public sealed partial class PdfReadDocument {
+    private const int MaxReadOutlineDepth = 64;
+    private const int MaxReadOutlineItems = 2048;
+
     private IReadOnlyList<PdfOutlineItem> ExtractOutlines() {
         PdfDictionary? catalog = FindCatalog();
         if (catalog is null ||
@@ -11,26 +14,32 @@ public sealed partial class PdfReadDocument {
         }
 
         var visited = new HashSet<int>();
-        return ReadOutlineSiblings(firstObj, 1, visited).AsReadOnly();
+        int remainingItems = MaxReadOutlineItems;
+        return ReadOutlineSiblings(firstObj, 1, visited, ref remainingItems).AsReadOnly();
     }
 
-    private List<PdfOutlineItem> ReadOutlineSiblings(PdfObject firstObj, int level, HashSet<int> visited) {
+    private List<PdfOutlineItem> ReadOutlineSiblings(PdfObject firstObj, int level, HashSet<int> visited, ref int remainingItems) {
         var items = new List<PdfOutlineItem>();
+        if (level > MaxReadOutlineDepth || remainingItems <= 0) {
+            return items;
+        }
+
         PdfObject? currentObj = firstObj;
 
-        while (currentObj is not null && ResolveDict(currentObj) is PdfDictionary current) {
+        while (remainingItems > 0 && currentObj is not null && ResolveDict(currentObj) is PdfDictionary current) {
             int objectNumber = currentObj is PdfReference reference ? reference.ObjectNumber : FindObjectNumberFor(current);
             if (objectNumber > 0 && !visited.Add(objectNumber)) {
                 break;
             }
 
+            remainingItems--;
             string title = current.Get<PdfStringObj>("Title")?.Value ?? string.Empty;
             var (pageNumber, destinationTop, destinationMode, destinationLeft, destinationBottom, destinationRight) = GetOutlineDestination(current);
             bool isExpanded = !current.Items.TryGetValue("Count", out var countObject) ||
                 ResolveObject(countObject) is not PdfNumber countNumber ||
                 countNumber.Value >= 0D;
-            var children = current.Items.TryGetValue("First", out var childObj)
-                ? ReadOutlineSiblings(childObj, level + 1, visited)
+            var children = level < MaxReadOutlineDepth && current.Items.TryGetValue("First", out var childObj)
+                ? ReadOutlineSiblings(childObj, level + 1, visited, ref remainingItems)
                 : new List<PdfOutlineItem>();
 
             items.Add(new PdfOutlineItem(title, level, pageNumber, destinationTop, isExpanded, children.AsReadOnly(), destinationMode, destinationLeft, destinationBottom, destinationRight));

--- a/OfficeIMO.Tests/Pdf/PdfInspectorOutlinePreflightTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfInspectorOutlinePreflightTests.cs
@@ -59,5 +59,29 @@ public partial class PdfInspectorTests {
         AssertRewriteBlocker(report, PdfRewriteBlockerKind.Outlines, "PDF outlines are not supported for rewriting by OfficeIMO.Pdf yet.");
     }
 
+    [Fact]
+    public void ReadApis_LimitWideOutlineTraversal() {
+        PdfDocumentInfo info = PdfInspector.Inspect(BuildWideOutlinePdf(2_100));
+
+        Assert.Equal(2_048, info.Outlines.Count);
+        Assert.Equal("Item 0", info.Outlines[0].Title);
+        Assert.Equal("Item 2047", info.Outlines[2_047].Title);
+    }
+
+    [Fact]
+    public void ReadApis_LimitDeepOutlineTraversal() {
+        PdfDocumentInfo info = PdfInspector.Inspect(BuildDeepOutlinePdf(80));
+
+        PdfOutlineItem current = Assert.Single(info.Outlines);
+        int depth = 1;
+        while (current.Children.Count > 0) {
+            current = Assert.Single(current.Children);
+            depth++;
+        }
+
+        Assert.Equal(64, depth);
+        Assert.Equal("Depth 64", current.Title);
+    }
+
 
 }

--- a/OfficeIMO.Tests/Pdf/PdfInspectorSupport.LinksOutlines.cs
+++ b/OfficeIMO.Tests/Pdf/PdfInspectorSupport.LinksOutlines.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 using OfficeIMO.Drawing;
 using OfficeIMO.Pdf;
 using Xunit;
@@ -51,6 +52,90 @@ public partial class PdfInspectorTests {
         });
 
         return System.Text.Encoding.ASCII.GetBytes(pdf);
+    }
+
+    private static byte[] BuildWideOutlinePdf(int outlineItemCount) {
+        var pdf = new StringBuilder();
+        AppendMinimalOutlineDocumentHeader(pdf, outlineItemCount);
+
+        for (int i = 0; i < outlineItemCount; i++) {
+            int objectNumber = 6 + i;
+            pdf.AppendLine(objectNumber.ToString(System.Globalization.CultureInfo.InvariantCulture) + " 0 obj");
+            pdf.Append("<< /Title (Item ")
+                .Append(i.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                .Append(") /Parent 5 0 R /Dest [3 0 R /Fit]");
+            if (i + 1 < outlineItemCount) {
+                pdf.Append(" /Next ")
+                    .Append((objectNumber + 1).ToString(System.Globalization.CultureInfo.InvariantCulture))
+                    .Append(" 0 R");
+            }
+
+            pdf.AppendLine(" >>");
+            pdf.AppendLine("endobj");
+        }
+
+        pdf.AppendLine("trailer");
+        pdf.Append("<< /Root 1 0 R /Size ")
+            .Append((6 + outlineItemCount).ToString(System.Globalization.CultureInfo.InvariantCulture))
+            .AppendLine(" >>");
+        pdf.AppendLine("%%EOF");
+        return Encoding.ASCII.GetBytes(pdf.ToString());
+    }
+
+    private static byte[] BuildDeepOutlinePdf(int outlineDepth) {
+        var pdf = new StringBuilder();
+        AppendMinimalOutlineDocumentHeader(pdf, 1);
+
+        for (int i = 0; i < outlineDepth; i++) {
+            int objectNumber = 6 + i;
+            pdf.AppendLine(objectNumber.ToString(System.Globalization.CultureInfo.InvariantCulture) + " 0 obj");
+            pdf.Append("<< /Title (Depth ")
+                .Append((i + 1).ToString(System.Globalization.CultureInfo.InvariantCulture))
+                .Append(") /Parent ")
+                .Append(i == 0 ? "5" : (objectNumber - 1).ToString(System.Globalization.CultureInfo.InvariantCulture))
+                .Append(" 0 R /Dest [3 0 R /Fit]");
+            if (i + 1 < outlineDepth) {
+                pdf.Append(" /First ")
+                    .Append((objectNumber + 1).ToString(System.Globalization.CultureInfo.InvariantCulture))
+                    .Append(" 0 R");
+            }
+
+            pdf.AppendLine(" >>");
+            pdf.AppendLine("endobj");
+        }
+
+        pdf.AppendLine("trailer");
+        pdf.Append("<< /Root 1 0 R /Size ")
+            .Append((6 + outlineDepth).ToString(System.Globalization.CultureInfo.InvariantCulture))
+            .AppendLine(" >>");
+        pdf.AppendLine("%%EOF");
+        return Encoding.ASCII.GetBytes(pdf.ToString());
+    }
+
+    private static void AppendMinimalOutlineDocumentHeader(StringBuilder pdf, int outlineCount) {
+        pdf.AppendLine("%PDF-1.4");
+        pdf.AppendLine("1 0 obj");
+        pdf.AppendLine("<< /Type /Catalog /Pages 2 0 R /Outlines 5 0 R /PageMode /UseOutlines >>");
+        pdf.AppendLine("endobj");
+        pdf.AppendLine("2 0 obj");
+        pdf.AppendLine("<< /Type /Pages /Count 1 /Kids [3 0 R] >>");
+        pdf.AppendLine("endobj");
+        pdf.AppendLine("3 0 obj");
+        pdf.AppendLine("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>");
+        pdf.AppendLine("endobj");
+        pdf.AppendLine("4 0 obj");
+        pdf.AppendLine("<< /Length 0 >>");
+        pdf.AppendLine("stream");
+        pdf.AppendLine();
+        pdf.AppendLine("endstream");
+        pdf.AppendLine("endobj");
+        pdf.AppendLine("5 0 obj");
+        pdf.Append("<< /Type /Outlines /First 6 0 R /Last ")
+            .Append((5 + outlineCount).ToString(System.Globalization.CultureInfo.InvariantCulture))
+            .Append(" 0 R /Count ")
+            .Append(outlineCount.ToString(System.Globalization.CultureInfo.InvariantCulture))
+            .AppendLine(" >>");
+        pdf.AppendLine("endobj");
     }
 
 


### PR DESCRIPTION
## Summary
- bound PDF outline reader traversal by total item count and nesting depth
- keep existing cycle handling while returning the safely collected outline prefix
- add wide and deep malicious-outline regression fixtures

## Tests
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~ReadApis_LimitWideOutlineTraversal|FullyQualifiedName~ReadApis_LimitDeepOutlineTraversal|FullyQualifiedName~Preflight_BlocksCyclicGoToOutlineDestinationsWithoutRecursingForever|FullyQualifiedName~RewriteApis_PreserveSimpleOutlinePdfsForCopiedPages|FullyQualifiedName~RewriteApis_PreserveGoToActionOutlinePdfsForCopiedPages|FullyQualifiedName~RewriteApis_RejectComplexOutlinePdfsWithClearUnsupportedDiagnostic"
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net472 --filter "FullyQualifiedName~ReadApis_LimitWideOutlineTraversal|FullyQualifiedName~ReadApis_LimitDeepOutlineTraversal|FullyQualifiedName~Preflight_BlocksCyclicGoToOutlineDestinationsWithoutRecursingForever|FullyQualifiedName~RewriteApis_PreserveSimpleOutlinePdfsForCopiedPages|FullyQualifiedName~RewriteApis_PreserveGoToActionOutlinePdfsForCopiedPages|FullyQualifiedName~RewriteApis_RejectComplexOutlinePdfsWithClearUnsupportedDiagnostic"
