### PR TITLE
Limit TrueType format 12 cmap expansion

### DIFF
--- a/OfficeIMO.Pdf/Rendering/Writer/PdfTrueTypeFontProgram.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfTrueTypeFontProgram.cs
@@ -1,6 +1,8 @@
 namespace OfficeIMO.Pdf;
 
 internal sealed partial class PdfTrueTypeFontProgram {
+    private const int MaxUnicodeCMapMappings = 131_072;
+
     private readonly byte[] _data;
     private readonly ushort[] _advanceWidths;
     private readonly Dictionary<int, int> _cmap;
@@ -423,6 +425,11 @@ internal sealed partial class PdfTrueTypeFontProgram {
             groupOffset += 12;
             if (startCharCode > 0x10FFFF || endCharCode > 0x10FFFF || endCharCode < startCharCode) {
                 continue;
+            }
+
+            uint mappingCount = endCharCode - startCharCode + 1U;
+            if (mappingCount > MaxUnicodeCMapMappings || map.Count > MaxUnicodeCMapMappings - (int)mappingCount) {
+                throw new NotSupportedException("TrueType Unicode cmap mapping count exceeds supported limits.");
             }
 
             for (uint code = startCharCode; code <= endCharCode; code++) {

--- a/OfficeIMO.Tests/Pdf/PdfFontSecurityTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfFontSecurityTests.cs
@@ -82,6 +82,16 @@ endbfrange
         Assert.Contains("cmap mapping count exceeds supported limits", error, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void TrueTypeFontProgramRejectsOversizedFormat12CmapExpansion() {
+        byte[] fontData = CreateMinimalTrueTypeFont(CreateLargeRangeFormat12Cmap());
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(
+            () => PdfTrueTypeFontProgram.Parse(fontData, "OfficeIMO Security Font"));
+
+        Assert.Contains("cmap mapping count exceeds supported limits", exception.Message, StringComparison.Ordinal);
+    }
+
     private static byte[] CreateLargeRangeFormat12Cmap() {
         var data = new byte[40];
         WriteUInt16(data, 2, 1);
@@ -102,6 +112,8 @@ endbfrange
             ("cmap", cmap),
             ("glyf", new byte[4]),
             ("head", CreateHeadTable()),
+            ("hhea", CreateHheaTable()),
+            ("hmtx", CreateHmtxTable()),
             ("maxp", new byte[] { 0x00, 0x01, 0x00, 0x00, 0x00, 0x02 }),
             ("name", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x06 })
         };
@@ -131,6 +143,21 @@ endbfrange
     private static byte[] CreateHeadTable() {
         var table = new byte[54];
         WriteUInt16(table, 18, 1000);
+        return table;
+    }
+
+    private static byte[] CreateHheaTable() {
+        var table = new byte[36];
+        WriteUInt16(table, 4, 800);
+        WriteUInt16(table, 6, unchecked((ushort)-200));
+        WriteUInt16(table, 34, 2);
+        return table;
+    }
+
+    private static byte[] CreateHmtxTable() {
+        var table = new byte[8];
+        WriteUInt16(table, 0, 500);
+        WriteUInt16(table, 4, 500);
         return table;
     }
 


### PR DESCRIPTION
## Summary
- cap TrueType format 12 Unicode cmap expansion while parsing embedded fonts
- reject oversized sequential mapping ranges before they can consume CPU or memory
- extend the minimal TrueType fixture so the parser path is covered end to end

## Tests
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~PdfFontSecurityTests"
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net472 --filter "FullyQualifiedName~PdfFontSecurityTests"