### PR TITLE
Bound system font discovery

### DIFF
--- a/OfficeIMO.Pdf/Model/PdfEmbeddedFontFamily.System.TrueTypeCollection.cs
+++ b/OfficeIMO.Pdf/Model/PdfEmbeddedFontFamily.System.TrueTypeCollection.cs
@@ -1,6 +1,10 @@
 namespace OfficeIMO.Pdf;
 
 public sealed partial class PdfEmbeddedFontFamily {
+    internal const int MaxTrueTypeCollectionFontsToInspect = 256;
+    internal const int MaxExtractedTrueTypeCollectionFontBytes = 64 * 1024 * 1024;
+    internal const int MaxExtractedTrueTypeCollectionBytes = 128 * 1024 * 1024;
+
     private static System.Collections.Generic.List<byte[]> ExtractTrueTypeFontPrograms(byte[] data) {
         if (!IsTrueTypeCollection(data)) {
             return new System.Collections.Generic.List<byte[]> { data };
@@ -8,19 +12,26 @@ public sealed partial class PdfEmbeddedFontFamily {
 
         EnsureRange(data, 0, 12);
         uint fontCount = ReadUInt32(data, 8);
-        if (fontCount == 0 || fontCount > 4096) {
+        if (fontCount == 0 || fontCount > MaxTrueTypeCollectionFontsToInspect) {
             throw new System.NotSupportedException("TrueType collection font count is invalid.");
         }
 
         EnsureRange(data, 12, checked((int)fontCount * 4));
         var fonts = new System.Collections.Generic.List<byte[]>((int)fontCount);
+        int extractedBytes = 0;
         for (int i = 0; i < fontCount; i++) {
             uint offset = ReadUInt32(data, 12 + i * 4);
             if (offset > int.MaxValue) {
                 throw new System.NotSupportedException("TrueType collection font offset is too large.");
             }
 
-            fonts.Add(ExtractTrueTypeCollectionFont(data, (int)offset));
+            byte[] font = ExtractTrueTypeCollectionFont(data, (int)offset);
+            extractedBytes = checked(extractedBytes + font.Length);
+            if (extractedBytes > MaxExtractedTrueTypeCollectionBytes) {
+                throw new System.NotSupportedException("TrueType collection extracted font data exceeds supported limits.");
+            }
+
+            fonts.Add(font);
         }
 
         return fonts;
@@ -57,6 +68,10 @@ public sealed partial class PdfEmbeddedFontFamily {
             EnsureRange(collectionData, (int)sourceOffset, (int)length);
             tables.Add(new FontTableCopyRecord(tag, checksum, (int)sourceOffset, (int)length, outputOffset));
             outputOffset = Align4(checked(outputOffset + (int)length));
+        }
+
+        if (outputOffset > MaxExtractedTrueTypeCollectionFontBytes) {
+            throw new System.NotSupportedException("TrueType collection font data exceeds supported limits.");
         }
 
         byte[] fontData = new byte[outputOffset];

--- a/OfficeIMO.Pdf/Model/PdfEmbeddedFontFamily.System.cs
+++ b/OfficeIMO.Pdf/Model/PdfEmbeddedFontFamily.System.cs
@@ -1,6 +1,9 @@
 namespace OfficeIMO.Pdf;
 
 public sealed partial class PdfEmbeddedFontFamily {
+    internal const int MaxSystemFontFilesToInspect = 8192;
+    internal const long MaxSystemFontFileBytes = 128L * 1024L * 1024L;
+
     /// <summary>
     /// Loads an installed TrueType font family from common operating-system font folders.
     /// </summary>
@@ -44,7 +47,12 @@ public sealed partial class PdfEmbeddedFontFamily {
         SystemFontFaceCandidate? italicFace = null;
         SystemFontFaceCandidate? boldItalicFace = null;
 
+        int inspectedFiles = 0;
         foreach (string fontFile in fontFiles) {
+            if (inspectedFiles++ >= MaxSystemFontFilesToInspect) {
+                break;
+            }
+
             if (!TryReadSystemFontFaces(fontFile, normalizedFamily, acceptedFileNamePrefixes, out System.Collections.Generic.List<SystemFontFaceCandidate>? candidates) ||
                 candidates == null) {
                 continue;
@@ -90,6 +98,11 @@ public sealed partial class PdfEmbeddedFontFamily {
         }
 
         try {
+            var fileInfo = new System.IO.FileInfo(path);
+            if (!fileInfo.Exists || fileInfo.Length > MaxSystemFontFileBytes) {
+                return false;
+            }
+
             byte[] fileData = System.IO.File.ReadAllBytes(path);
             System.Collections.Generic.List<byte[]> fontPrograms = ExtractTrueTypeFontPrograms(fileData);
             var found = new System.Collections.Generic.List<SystemFontFaceCandidate>();

--- a/OfficeIMO.Tests/Pdf/PdfFontFamilyTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfFontFamilyTests.cs
@@ -237,6 +237,82 @@ public class PdfFontFamilyTests {
     }
 
     [Fact]
+    public void PdfEmbeddedFontFamily_TryFromSystemFontFilesStopsAfterScanBudget() {
+        if (!TryFindSingleInstalledRegularFontFace(out string familyName, out string fontPath)) {
+            return;
+        }
+
+        string[] missingFiles = Enumerable
+            .Range(0, PdfEmbeddedFontFamily.MaxSystemFontFilesToInspect)
+            .Select(index => Path.Combine(Path.GetTempPath(), "OfficeIMO.Missing." + index.ToString(CultureInfo.InvariantCulture) + ".ttf"))
+            .Concat(new[] { fontPath })
+            .ToArray();
+
+        bool found = PdfEmbeddedFontFamily.TryFromSystemFontFiles(
+            familyName,
+            missingFiles,
+            out PdfEmbeddedFontFamily? family);
+
+        Assert.False(found);
+        Assert.Null(family);
+    }
+
+    [Fact]
+    public void PdfEmbeddedFontFamily_TryFromSystemFontFilesSkipsOversizedFontFiles() {
+        if (!TryFindSingleInstalledRegularFontFace(out string familyName, out string fontPath)) {
+            return;
+        }
+
+        string tempDir = Path.Combine(Path.GetTempPath(), "OfficeIMO.Pdf.Fonts." + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try {
+            string oversizedPath = Path.Combine(tempDir, "OfficeIMO-Oversized.ttf");
+            using (FileStream stream = File.Create(oversizedPath)) {
+                stream.SetLength(PdfEmbeddedFontFamily.MaxSystemFontFileBytes + 1);
+            }
+
+            bool found = PdfEmbeddedFontFamily.TryFromSystemFontFiles(
+                familyName,
+                new[] { oversizedPath, fontPath },
+                out PdfEmbeddedFontFamily? family);
+
+            Assert.True(found);
+            Assert.NotNull(family);
+            Assert.NotEmpty(family!.Regular);
+        } finally {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void PdfEmbeddedFontFamily_TryFromSystemFontFilesRejectsOversizedTrueTypeCollectionFaceCounts() {
+        if (!TryFindSingleInstalledRegularFontFace(out string familyName, out string fontPath)) {
+            return;
+        }
+
+        string tempDir = Path.Combine(Path.GetTempPath(), "OfficeIMO.Pdf.Fonts." + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try {
+            string collectionPath = Path.Combine(tempDir, "officeimo-oversized-system-face.ttc");
+            File.WriteAllBytes(
+                collectionPath,
+                CreateRepeatedFaceTrueTypeCollection(
+                    File.ReadAllBytes(fontPath),
+                    PdfEmbeddedFontFamily.MaxTrueTypeCollectionFontsToInspect + 1));
+
+            bool found = PdfEmbeddedFontFamily.TryFromSystemFontFiles(
+                familyName,
+                new[] { collectionPath },
+                out PdfEmbeddedFontFamily? family);
+
+            Assert.False(found);
+            Assert.Null(family);
+        } finally {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public void PdfEmbeddedFontFamily_TryFromSystemFontFilesSkipsMalformedTrueTypeFiles() {
         string tempDir = Path.Combine(Path.GetTempPath(), "OfficeIMO.Pdf.Fonts." + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempDir);
@@ -2354,7 +2430,11 @@ public class PdfFontFamilyTests {
     }
 
     private static byte[] CreateSingleFaceTrueTypeCollection(byte[] fontData) {
-        int fontOffset = 16;
+        return CreateRepeatedFaceTrueTypeCollection(fontData, 1);
+    }
+
+    private static byte[] CreateRepeatedFaceTrueTypeCollection(byte[] fontData, int fontCount) {
+        int fontOffset = 12 + fontCount * 4;
         int tableCount = ReadUInt16(fontData, 4);
         int sourceDirectoryLength = 12 + tableCount * 16;
         int collectionLength = fontOffset + fontData.Length;
@@ -2365,8 +2445,11 @@ public class PdfFontFamilyTests {
         collection[2] = (byte)'c';
         collection[3] = (byte)'f';
         WriteUInt32(collection, 4, 0x00010000);
-        WriteUInt32(collection, 8, 1);
-        WriteUInt32(collection, 12, (uint)fontOffset);
+        WriteUInt32(collection, 8, (uint)fontCount);
+        for (int index = 0; index < fontCount; index++) {
+            WriteUInt32(collection, 12 + index * 4, (uint)fontOffset);
+        }
+
         Array.Copy(fontData, 0, collection, fontOffset, fontData.Length);
 
         for (int i = 0; i < tableCount; i++) {


### PR DESCRIPTION
## Summary
- bound installed font discovery by inspected file count and per-file byte size
- cap TrueType collection face expansion and total extracted TTC bytes
- add fixture-driven tests for scan budget, oversized font files, and oversized TTC face counts

## Tests
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~PdfEmbeddedFontFamily_TryFromSystemFontFiles"
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net472 --filter "FullyQualifiedName~PdfEmbeddedFontFamily_TryFromSystemFontFiles"