### PR TITLE
Harden PDF choice option lookup

### DIFF
--- a/OfficeIMO.Pdf/Manipulation/PdfFormFiller.Values.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfFormFiller.Values.cs
@@ -11,6 +11,80 @@ public static partial class PdfFormFiller {
         }
     }
 
+    private sealed class ChoiceOptionLookup {
+        private readonly Dictionary<string, ChoiceFillValue> _byExportValue;
+        private readonly Dictionary<string, ChoiceFillValue> _byDisplayValue;
+        private readonly Dictionary<string, string> _displayByExportValue;
+
+        private ChoiceOptionLookup(
+            Dictionary<string, ChoiceFillValue> byExportValue,
+            Dictionary<string, ChoiceFillValue> byDisplayValue,
+            Dictionary<string, string> displayByExportValue) {
+            _byExportValue = byExportValue;
+            _byDisplayValue = byDisplayValue;
+            _displayByExportValue = displayByExportValue;
+        }
+
+        public static ChoiceOptionLookup Create(Dictionary<int, PdfIndirectObject> objects, PdfArray options) {
+            var byExportValue = new Dictionary<string, ChoiceFillValue>(StringComparer.Ordinal);
+            var byDisplayValue = new Dictionary<string, ChoiceFillValue>(StringComparer.Ordinal);
+            var displayByExportValue = new Dictionary<string, string>(StringComparer.Ordinal);
+
+            for (int i = 0; i < options.Items.Count; i++) {
+                PdfObject? optionObject = ResolveObject(objects, options.Items[i]);
+                if (optionObject is PdfArray pair &&
+                    pair.Items.Count >= 2 &&
+                    TryReadOptionText(objects, pair.Items[0], out string? pairExportValue) &&
+                    pairExportValue is not null &&
+                    TryReadOptionText(objects, pair.Items[1], out string? pairDisplayText) &&
+                    pairDisplayText is not null) {
+                    var choice = new ChoiceFillValue(pairExportValue, pairDisplayText);
+                    AddIfMissing(byExportValue, pairExportValue, choice);
+                    AddIfMissing(displayByExportValue, pairExportValue, pairDisplayText);
+                    AddIfMissing(byDisplayValue, pairDisplayText, choice);
+                    continue;
+                }
+
+                if (optionObject is not null &&
+                    TryReadOptionText(objects, optionObject, out string? singleValue) &&
+                    singleValue is not null) {
+                    var choice = new ChoiceFillValue(singleValue, singleValue);
+                    AddIfMissing(byExportValue, singleValue, choice);
+                    AddIfMissing(displayByExportValue, singleValue, singleValue);
+                }
+            }
+
+            return new ChoiceOptionLookup(byExportValue, byDisplayValue, displayByExportValue);
+        }
+
+        public bool TryResolveFillValue(string value, out ChoiceFillValue fillValue) {
+            if (_byExportValue.TryGetValue(value, out fillValue)) {
+                return true;
+            }
+
+            return _byDisplayValue.TryGetValue(value, out fillValue);
+        }
+
+        public string? ResolveDisplayValue(string exportValue) =>
+            _displayByExportValue.TryGetValue(exportValue, out string? displayValue) ? displayValue : null;
+
+        private static void AddIfMissing(Dictionary<string, ChoiceFillValue> dictionary, string key, ChoiceFillValue value) {
+#pragma warning disable CA1864 // Dictionary.TryAdd is unavailable for the net472 target.
+            if (!dictionary.ContainsKey(key)) {
+                dictionary.Add(key, value);
+            }
+#pragma warning restore CA1864
+        }
+
+        private static void AddIfMissing(Dictionary<string, string> dictionary, string key, string value) {
+#pragma warning disable CA1864 // Dictionary.TryAdd is unavailable for the net472 target.
+            if (!dictionary.ContainsKey(key)) {
+                dictionary.Add(key, value);
+            }
+#pragma warning restore CA1864
+        }
+    }
+
     private static string? TryReadSimpleValue(Dictionary<int, PdfIndirectObject> objects, PdfDictionary dictionary, string key) {
         if (!dictionary.Items.TryGetValue(key, out var value)) {
             return null;
@@ -81,77 +155,32 @@ public static partial class PdfFormFiller {
         }
 
         var displayValues = new List<string>(exportValues.Count);
+        ChoiceOptionLookup optionLookup = ChoiceOptionLookup.Create(objects, options);
         for (int i = 0; i < exportValues.Count; i++) {
-            displayValues.Add(ResolveSingleChoiceDisplayValue(objects, options, exportValues[i]) ?? exportValues[i]);
+            displayValues.Add(optionLookup.ResolveDisplayValue(exportValues[i]) ?? exportValues[i]);
         }
 
         return displayValues.Count == 0 ? null : string.Join(", ", displayValues);
     }
 
-    private static string? ResolveSingleChoiceDisplayValue(Dictionary<int, PdfIndirectObject> objects, PdfArray options, string exportValue) {
-        for (int i = 0; i < options.Items.Count; i++) {
-            PdfObject? optionObject = ResolveObject(objects, options.Items[i]);
-            if (optionObject is PdfArray pair &&
-                pair.Items.Count >= 2 &&
-                TryReadOptionText(objects, pair.Items[0], out string? pairExportValue) &&
-                string.Equals(pairExportValue, exportValue, StringComparison.Ordinal) &&
-                TryReadOptionText(objects, pair.Items[1], out string? pairDisplayText)) {
-                return pairDisplayText;
-            }
-
-            if (optionObject is not null &&
-                TryReadOptionText(objects, optionObject, out string? singleValue) &&
-                string.Equals(singleValue, exportValue, StringComparison.Ordinal)) {
-                return singleValue;
-            }
-        }
-
-        return null;
-    }
-
     private static List<ChoiceFillValue> ResolveChoiceFillValues(Dictionary<int, PdfIndirectObject> objects, PdfArray? options, bool isEditableChoice, IReadOnlyList<string> values) {
         var resolved = new List<ChoiceFillValue>(values.Count);
+        ChoiceOptionLookup? optionLookup = options is null || options.Items.Count == 0
+            ? null
+            : ChoiceOptionLookup.Create(objects, options);
+
         for (int i = 0; i < values.Count; i++) {
-            resolved.Add(options is null || options.Items.Count == 0
+            resolved.Add(optionLookup is null
                 ? new ChoiceFillValue(values[i], values[i])
-                : ResolveSingleChoiceFillValue(objects, options, isEditableChoice, values[i]));
+                : ResolveChoiceFillValue(optionLookup, isEditableChoice, values[i]));
         }
 
         return resolved;
     }
 
-    private static ChoiceFillValue ResolveSingleChoiceFillValue(Dictionary<int, PdfIndirectObject> objects, PdfArray options, bool isEditableChoice, string value) {
-        for (int i = 0; i < options.Items.Count; i++) {
-            PdfObject? optionObject = ResolveObject(objects, options.Items[i]);
-            if (optionObject is PdfArray pair &&
-                pair.Items.Count >= 2 &&
-                TryReadOptionText(objects, pair.Items[0], out string? pairExportValue) &&
-                pairExportValue is not null &&
-                TryReadOptionText(objects, pair.Items[1], out string? pairDisplayText) &&
-                pairDisplayText is not null &&
-                string.Equals(pairExportValue, value, StringComparison.Ordinal)) {
-                return new ChoiceFillValue(pairExportValue, pairDisplayText);
-            }
-
-            if (optionObject is not null &&
-                TryReadOptionText(objects, optionObject, out string? singleValue) &&
-                singleValue is not null &&
-                string.Equals(singleValue, value, StringComparison.Ordinal)) {
-                return new ChoiceFillValue(singleValue, singleValue);
-            }
-        }
-
-        for (int i = 0; i < options.Items.Count; i++) {
-            PdfObject? optionObject = ResolveObject(objects, options.Items[i]);
-            if (optionObject is PdfArray pair &&
-                pair.Items.Count >= 2 &&
-                TryReadOptionText(objects, pair.Items[0], out string? pairExportValue) &&
-                pairExportValue is not null &&
-                TryReadOptionText(objects, pair.Items[1], out string? pairDisplayText) &&
-                pairDisplayText is not null &&
-                string.Equals(pairDisplayText, value, StringComparison.Ordinal)) {
-                return new ChoiceFillValue(pairExportValue, pairDisplayText);
-            }
+    private static ChoiceFillValue ResolveChoiceFillValue(ChoiceOptionLookup optionLookup, bool isEditableChoice, string value) {
+        if (optionLookup.TryResolveFillValue(value, out ChoiceFillValue fillValue)) {
+            return fillValue;
         }
 
         if (isEditableChoice) {

--- a/OfficeIMO.Tests/Pdf/PdfFormFillerChoiceSupport.cs
+++ b/OfficeIMO.Tests/Pdf/PdfFormFillerChoiceSupport.cs
@@ -1,0 +1,40 @@
+using System.Text;
+
+namespace OfficeIMO.Tests.Pdf;
+
+public partial class PdfFormFillerTests {
+    private static byte[] BuildDuplicateChoiceWidgetFormPdf() {
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.4",
+            "1 0 obj",
+            "<< /Type /Catalog /Pages 2 0 R /AcroForm 5 0 R >>",
+            "endobj",
+            "2 0 obj",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "endobj",
+            "3 0 obj",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 240 180] /Contents 4 0 R /Annots [8 0 R] >>",
+            "endobj",
+            "4 0 obj",
+            "<< /Length 0 >>",
+            "stream",
+            "",
+            "endstream",
+            "endobj",
+            "5 0 obj",
+            "<< /Fields [7 0 R] >>",
+            "endobj",
+            "7 0 obj",
+            "<< /FT /Ch /T (Choice) /V (A) /Opt [[(A) (Same)] [(B) (Same)] [(C) (First C)] [(C) (Second C)]] /Kids [8 0 R] >>",
+            "endobj",
+            "8 0 obj",
+            "<< /Type /Annot /Subtype /Widget /Parent 7 0 R /Rect [20 100 200 122] /F 4 >>",
+            "endobj",
+            "trailer",
+            "<< /Root 1 0 R /Size 9 >>",
+            "%%EOF"
+        });
+
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+}

--- a/OfficeIMO.Tests/Pdf/PdfFormFillerChoiceTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfFormFillerChoiceTests.cs
@@ -60,6 +60,31 @@ public partial class PdfFormFillerTests {
     }
 
     [Fact]
+    public void FillFields_ChoiceDisplayTextUsesFirstMatchingOption() {
+        byte[] filled = PdfFormFiller.FillFields(BuildDuplicateChoiceWidgetFormPdf(), new Dictionary<string, string> {
+            ["Choice"] = "Same"
+        });
+
+        PdfFormField filledField = Assert.Single(PdfInspector.Inspect(filled).FormFields);
+
+        Assert.Equal("A", filledField.Value);
+        Assert.Equal("Same", Assert.Single(filledField.SelectedOptions).DisplayText);
+    }
+
+    [Fact]
+    public void FillFields_ChoiceExportValueUsesFirstMatchingOption() {
+        byte[] filled = PdfFormFiller.FillFields(BuildDuplicateChoiceWidgetFormPdf(), new Dictionary<string, string> {
+            ["Choice"] = "C"
+        });
+
+        PdfFormField filledField = Assert.Single(PdfInspector.Inspect(filled).FormFields);
+
+        Assert.Equal("C", filledField.Value);
+        Assert.Equal(new[] { "First C", "Second C" }, filledField.SelectedOptions.Select(option => option.DisplayText).ToArray());
+        Assert.Contains("<46697273742043> Tj", Encoding.ASCII.GetString(filled), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void FillFields_ChoiceDisplayTextUsesInheritedOptions() {
         byte[] filled = PdfFormFiller.FillFields(BuildInheritedChoiceWidgetFormPdf(), new Dictionary<string, string> {
             ["Selection.Country"] = "United States"


### PR DESCRIPTION
## Summary
- build a per-field lookup for PDF choice `/Opt` entries instead of scanning all options for every submitted or flattened value
- preserve exact-export precedence, display-text fallback, editable unknown values, and first-match behavior for duplicate choices
- add focused PDF form filler regression coverage for duplicate display/export options

## Validation
- `dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net472 --filter "FullyQualifiedName~OfficeIMO.Tests.Pdf.PdfFormFillerTests" --no-restore`
- `dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~OfficeIMO.Tests.Pdf.PdfFormFillerTests" --no-restore`
- `dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net10.0 --filter "FullyQualifiedName~OfficeIMO.Tests.Pdf.PdfFormFillerTests" --no-restore`