### PR TITLE
Harden Visio page object ID allocation

### DIFF
--- a/OfficeIMO.Tests/Visio.BacklogP1.cs
+++ b/OfficeIMO.Tests/Visio.BacklogP1.cs
@@ -86,6 +86,41 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void PageRejectsDuplicateIdsBeforeSaveAcrossShapesAndConnectors() {
+            VisioPage page = new("Page-1");
+            VisioShape left = new("1", 1, 1, 1, 1, "Left");
+            VisioShape right = new("2", 3, 1, 1, 1, "Right");
+            page.Shapes.Add(left);
+            page.Shapes.Add(right);
+
+            InvalidOperationException connectorCollision = Assert.Throws<InvalidOperationException>(() =>
+                page.AddConnector("1", left, right, ConnectorKind.Dynamic));
+
+            Assert.Contains("already used", connectorCollision.Message);
+
+            page.AddConnector("3", left, right, ConnectorKind.Dynamic);
+
+            InvalidOperationException shapeCollision = Assert.Throws<InvalidOperationException>(() =>
+                page.Shapes.Add(new VisioShape("3", 5, 1, 1, 1, "Duplicate")));
+
+            Assert.Contains("already used", shapeCollision.Message);
+        }
+
+        [Fact]
+        public void GeneratedConnectorIdsSkipExistingShapeAndConnectorIds() {
+            VisioPage page = new("Page-1");
+            VisioShape left = new("1", 1, 1, 1, 1, "Left");
+            VisioShape right = new("2", 3, 1, 1, 1, "Right");
+            page.Shapes.Add(left);
+            page.Shapes.Add(right);
+            page.AddConnector("3", left, right, ConnectorKind.Dynamic);
+
+            VisioConnector generated = page.AddConnector(left, right);
+
+            Assert.Equal("4", generated.Id);
+        }
+
+        [Fact]
         public void MastersWithCollidingIdsAreRemappedAndRoundTrip() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
             VisioDocument document = VisioDocument.Create(filePath);

--- a/OfficeIMO.Tests/Visio.BacklogP1.cs
+++ b/OfficeIMO.Tests/Visio.BacklogP1.cs
@@ -79,7 +79,7 @@ namespace OfficeIMO.Tests {
             VisioPage page = document.AddPage("Page-1");
 
             page.Shapes.Add(new VisioShape("dup", 1, 1, 1, 1, "First"));
-            page.Shapes.Add(new VisioShape("dup", 3, 1, 1, 1, "Second"));
+            AddRawShape(page, new VisioShape("dup", 3, 1, 1, 1, "Second"));
 
             InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => document.Save());
             Assert.Contains("dup", exception.Message);
@@ -118,6 +118,13 @@ namespace OfficeIMO.Tests {
             VisioConnector generated = page.AddConnector(left, right);
 
             Assert.Equal("4", generated.Id);
+        }
+
+        private static void AddRawShape(VisioPage page, VisioShape shape) {
+            var shapes = Assert.IsType<System.Collections.Generic.List<VisioShape>>(typeof(VisioPage)
+                .GetField("_shapes", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+                .GetValue(page));
+            shapes.Add(shape);
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Visio.Comments.cs
+++ b/OfficeIMO.Tests/Visio.Comments.cs
@@ -257,7 +257,7 @@ namespace OfficeIMO.Tests {
             VisioDocument invalid = VisioDocument.Create(filePath);
             VisioPage page = invalid.AddPage("Broken", 11, 8.5);
             page.Shapes.Add(new VisioShape("duplicate", 1, 1, 1, 1, "One"));
-            page.Shapes.Add(new VisioShape("duplicate", 3, 1, 1, 1, "Two"));
+            AddRawShape(page, new VisioShape("duplicate", 3, 1, 1, 1, "Two"));
 
             InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => invalid.Save());
 
@@ -402,6 +402,13 @@ namespace OfficeIMO.Tests {
             ZipArchiveEntry entry = archive.GetEntry(entryName) ?? throw new InvalidOperationException("Missing " + entryName);
             using Stream stream = entry.Open();
             return XDocument.Load(stream);
+        }
+
+        private static void AddRawShape(VisioPage page, VisioShape shape) {
+            var shapes = Assert.IsType<List<VisioShape>>(typeof(VisioPage)
+                .GetField("_shapes", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+                .GetValue(page));
+            shapes.Add(shape);
         }
     }
 }

--- a/OfficeIMO.Tests/Visio.DocumentValidation.cs
+++ b/OfficeIMO.Tests/Visio.DocumentValidation.cs
@@ -24,12 +24,12 @@ namespace OfficeIMO.Tests {
 
             VisioShape shared = new("dup", 1, 1, 1, 1, "Shared");
             first.Shapes.Add(shared);
-            first.Shapes.Add(new VisioShape("dup", 3, 1, 1, 1, "Duplicate"));
+            AddRawShape(first, new VisioShape("dup", 3, 1, 1, 1, "Duplicate"));
 
             VisioShape external = new("outside", 1, 1, 1, 1, "Outside");
             second.Shapes.Add(external);
 
-            first.Connectors.Add(new VisioConnector("dup", shared, external));
+            AddRawConnector(first, new VisioConnector("dup", shared, external));
 
             string[] issues = document.Validate().ToArray();
 
@@ -76,7 +76,7 @@ namespace OfficeIMO.Tests {
             VisioShape shared = new("dup", 1, 1, 1, 1, "Shared");
             first.Shapes.Add(shared);
             second.Shapes.Add(new VisioShape("outside", 2, 2, 1, 1, "Outside"));
-            first.Connectors.Add(new VisioConnector("dup", shared, second.Shapes[0]));
+            AddRawConnector(first, new VisioConnector("dup", shared, second.Shapes[0]));
 
             InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => document.Save());
 
@@ -119,6 +119,20 @@ namespace OfficeIMO.Tests {
 
             Assert.Contains(issues, issue => issue.Contains("cyclic parent/child hierarchy"));
             Assert.Contains(issues, issue => issue.Contains("inconsistent parent reference"));
+        }
+
+        private static void AddRawShape(VisioPage page, VisioShape shape) {
+            var shapes = Assert.IsType<System.Collections.Generic.List<VisioShape>>(typeof(VisioPage)
+                .GetField("_shapes", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(page));
+            shapes.Add(shape);
+        }
+
+        private static void AddRawConnector(VisioPage page, VisioConnector connector) {
+            var connectors = Assert.IsType<System.Collections.Generic.List<VisioConnector>>(typeof(VisioPage)
+                .GetField("_connectors", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(page));
+            connectors.Add(connector);
         }
     }
 }

--- a/OfficeIMO.Visio/VisioPage.Collections.cs
+++ b/OfficeIMO.Visio/VisioPage.Collections.cs
@@ -19,7 +19,7 @@ namespace OfficeIMO.Visio {
                         return;
                     }
 
-                    _page.PrepareShapeForPage(value);
+                    _page.PrepareShapeForPage(value, _page._shapes[index]);
                     _page._shapes[index] = value;
                 }
             }

--- a/OfficeIMO.Visio/VisioPage.Shapes.cs
+++ b/OfficeIMO.Visio/VisioPage.Shapes.cs
@@ -53,14 +53,16 @@ namespace OfficeIMO.Visio {
             if (connector.HasAutomaticId) {
                 connector.Id = NextId(ignoredConnector);
             }
+
+            EnsurePageObjectIdAvailable(connector.Id, "Connector", ignoredConnector: ignoredConnector);
         }
 
-        private void PrepareShapeForPage(VisioShape shape) {
+        private void PrepareShapeForPage(VisioShape shape, VisioShape? ignoredShape = null) {
             if (shape == null) {
                 throw new ArgumentNullException(nameof(shape));
             }
 
-             if (_shapes.Contains(shape)) {
+            if (_shapes.Contains(shape) && !ReferenceEquals(shape, ignoredShape)) {
                 throw new InvalidOperationException("The shape is already part of this page.");
             }
 
@@ -68,8 +70,67 @@ namespace OfficeIMO.Visio {
                 throw new InvalidOperationException("A child shape must be removed from its parent before being added to a page.");
             }
 
+            EnsureShapeTreeIdsAvailable(shape, ignoredShape);
             shape.Parent = null;
             shape.NormalizeDescendantParentLinks();
+        }
+
+        private void EnsureShapeTreeIdsAvailable(VisioShape shape, VisioShape? ignoredShape) {
+            HashSet<string> newIds = new(StringComparer.Ordinal);
+
+            void Visit(VisioShape current) {
+                if (string.IsNullOrWhiteSpace(current.Id)) {
+                    throw new InvalidOperationException("Shape id cannot be null or whitespace.");
+                }
+
+                if (!newIds.Add(current.Id)) {
+                    throw new InvalidOperationException($"Duplicate shape id '{current.Id}' found in the shape tree being added to page '{Name}'.");
+                }
+
+                EnsurePageObjectIdAvailable(current.Id, "Shape", ignoredShape: ignoredShape);
+                foreach (VisioShape child in current.Children) {
+                    Visit(child);
+                }
+            }
+
+            Visit(shape);
+        }
+
+        private void EnsurePageObjectIdAvailable(string id, string kind, VisioShape? ignoredShape = null, VisioConnector? ignoredConnector = null) {
+            if (string.IsNullOrWhiteSpace(id)) {
+                throw new InvalidOperationException($"{kind} id cannot be null or whitespace on page '{Name}'.");
+            }
+
+            foreach (VisioShape shape in _shapes) {
+                if (ShapeTreeContainsId(shape, id, ignoredShape)) {
+                    throw new InvalidOperationException($"{kind} id '{id}' is already used by another page object on page '{Name}'.");
+                }
+            }
+
+            foreach (VisioConnector connector in _connectors) {
+                if (!ReferenceEquals(connector, ignoredConnector) &&
+                    string.Equals(connector.Id, id, StringComparison.Ordinal)) {
+                    throw new InvalidOperationException($"{kind} id '{id}' is already used by another page object on page '{Name}'.");
+                }
+            }
+        }
+
+        private static bool ShapeTreeContainsId(VisioShape shape, string id, VisioShape? ignoredShape) {
+            if (ReferenceEquals(shape, ignoredShape)) {
+                return false;
+            }
+
+            if (string.Equals(shape.Id, id, StringComparison.Ordinal)) {
+                return true;
+            }
+
+            foreach (VisioShape child in shape.Children) {
+                if (ShapeTreeContainsId(child, id, ignoredShape)) {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static void ApplyUnits(ref double x, ref double y, ref double w, ref double h, VisioMeasurementUnit unit) {


### PR DESCRIPTION
## Summary
- reject duplicate Visio page object IDs when shapes or connectors are added instead of waiting until save
- validate inserted shape subtrees against existing shape and connector IDs
- keep generated connector IDs collision-free across existing shapes and connectors

## Validation
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net472 --filter "FullyQualifiedName~OfficeIMO.Tests.VisioBacklogP1" --no-restore
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~OfficeIMO.Tests.VisioBacklogP1" --no-restore
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net10.0 --filter "FullyQualifiedName~OfficeIMO.Tests.VisioBacklogP1" --no-restore
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~OfficeIMO.Tests.Visio" --no-restore