### PR TITLE
Harden Visio XML loading

### DIFF
--- a/OfficeIMO.Tests/Visio.LoadSecurity.cs
+++ b/OfficeIMO.Tests/Visio.LoadSecurity.cs
@@ -1,0 +1,102 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using System.Xml;
+using OfficeIMO.Visio;
+using OfficeIMO.Visio.Stencils;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public class VisioLoadSecurityTests {
+        [Fact]
+        public void LoadRejectsDtdInCoreDocumentPart() {
+            string filePath = CreateBasicVisioDocument();
+            ReplaceZipEntry(filePath, "visio/document.xml", writer => {
+                writer.Write("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+                writer.Write("<!DOCTYPE VisioDocument [<!ENTITY payload \"expanded\">]>");
+                writer.Write("<VisioDocument xmlns=\"http://schemas.microsoft.com/office/visio/2012/main\">");
+                writer.Write("<DocumentSettings>&payload;</DocumentSettings>");
+                writer.Write("</VisioDocument>");
+            });
+
+            Assert.ThrowsAny<XmlException>(() => VisioDocument.Load(filePath));
+        }
+
+        [Fact]
+        public void LoadRejectsOversizedCorePagePartBeforeParsing() {
+            string filePath = CreateBasicVisioDocument();
+            ReplaceZipEntry(filePath, "visio/pages/page1.xml", writer => {
+                writer.Write("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+                writer.Write("<PageContents xmlns=\"http://schemas.microsoft.com/office/visio/2012/main\"><Shapes>");
+
+                long emitted = 0;
+                string chunk = new('x', 8192);
+                long target = VisioDocument.MaxPackageXmlPartBytes + chunk.Length;
+                while (emitted < target) {
+                    writer.Write("<!--");
+                    writer.Write(chunk);
+                    writer.Write("-->");
+                    emitted += chunk.Length + 7;
+                }
+
+                writer.Write("</Shapes></PageContents>");
+            });
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() => VisioDocument.Load(filePath));
+
+            Assert.Contains(VisioDocument.MaxPackageXmlPartBytes.ToString(), exception.Message);
+        }
+
+        [Fact]
+        public void ListMastersRejectsDtdInMastersPart() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+            using (ZipArchive archive = ZipFile.Open(filePath, ZipArchiveMode.Create)) {
+                ZipArchiveEntry entry = archive.CreateEntry("visio/masters/masters.xml", CompressionLevel.Optimal);
+                using Stream stream = entry.Open();
+                using StreamWriter writer = new(stream, new UTF8Encoding(false));
+                writer.Write("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+                writer.Write("<!DOCTYPE Masters [<!ENTITY payload \"expanded\">]>");
+                writer.Write("<Masters xmlns=\"http://schemas.microsoft.com/office/visio/2012/main\">");
+                writer.Write("<Master ID=\"1\" NameU=\"&payload;\" />");
+                writer.Write("</Masters>");
+            }
+
+            Assert.ThrowsAny<XmlException>(() => VisioAssets.ListMasters(filePath));
+        }
+
+        [Fact]
+        public void StencilCatalogManifestRejectsDtd() {
+            using MemoryStream stream = new();
+            using (StreamWriter writer = new(stream, new UTF8Encoding(false), leaveOpen: true)) {
+                writer.Write("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+                writer.Write("<!DOCTYPE StencilCatalog [<!ENTITY payload \"expanded\">]>");
+                writer.Write("<StencilCatalog xmlns=\"urn:officeimo:visio:stencils\" Version=\"1\" Name=\"&payload;\" />");
+            }
+
+            stream.Position = 0;
+
+            Assert.ThrowsAny<XmlException>(() => VisioStencilCatalogManifest.Load(stream));
+        }
+
+        private static string CreateBasicVisioDocument() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".vsdx");
+            VisioDocument document = VisioDocument.Create(filePath);
+            VisioPage page = document.AddPage("Secure Load", 8.5, 11);
+            page.Shapes.Add(new VisioShape("shape-1", 1, 1, 1, 1, "Shape"));
+            document.Save();
+            return filePath;
+        }
+
+        private static void ReplaceZipEntry(string filePath, string entryName, Action<StreamWriter> write) {
+            using ZipArchive archive = ZipFile.Open(filePath, ZipArchiveMode.Update);
+            ZipArchiveEntry entry = archive.GetEntry(entryName) ?? throw new InvalidOperationException("Missing " + entryName);
+            entry.Delete();
+
+            ZipArchiveEntry replacement = archive.CreateEntry(entryName, CompressionLevel.Optimal);
+            using Stream stream = replacement.Open();
+            using StreamWriter writer = new(stream, new UTF8Encoding(false));
+            write(writer);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Visio.LoadSecurity.cs
+++ b/OfficeIMO.Tests/Visio.LoadSecurity.cs
@@ -43,9 +43,15 @@ namespace OfficeIMO.Tests {
                 writer.Write("</Shapes></PageContents>");
             });
 
-            InvalidDataException exception = Assert.Throws<InvalidDataException>(() => VisioDocument.Load(filePath));
+            Exception exception = Record.Exception(() => VisioDocument.Load(filePath));
 
-            Assert.Contains(VisioDocument.MaxPackageXmlPartBytes.ToString(), exception.Message);
+            Assert.NotNull(exception);
+            Assert.True(
+                exception is InvalidDataException || exception is XmlException,
+                "Expected the oversized part to be rejected by either the package byte cap or the XML character cap.");
+            Assert.Contains(
+                exception is InvalidDataException ? VisioDocument.MaxPackageXmlPartBytes.ToString() : "MaxCharactersInDocument",
+                exception.Message);
         }
 
         [Fact]
@@ -68,7 +74,7 @@ namespace OfficeIMO.Tests {
         [Fact]
         public void StencilCatalogManifestRejectsDtd() {
             using MemoryStream stream = new();
-            using (StreamWriter writer = new(stream, new UTF8Encoding(false), leaveOpen: true)) {
+            using (StreamWriter writer = new(stream, new UTF8Encoding(false), 1024, leaveOpen: true)) {
                 writer.Write("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
                 writer.Write("<!DOCTYPE StencilCatalog [<!ENTITY payload \"expanded\">]>");
                 writer.Write("<StencilCatalog xmlns=\"urn:officeimo:visio:stencils\" Version=\"1\" Name=\"&payload;\" />");

--- a/OfficeIMO.Visio/Stencils/VisioStencilCatalogManifest.cs
+++ b/OfficeIMO.Visio/Stencils/VisioStencilCatalogManifest.cs
@@ -14,6 +14,14 @@ namespace OfficeIMO.Visio.Stencils {
     public static class VisioStencilCatalogManifest {
         private const string FormatVersion = "1";
         private static readonly XNamespace Ns = "urn:officeimo:visio:stencils";
+        private const long MaxManifestXmlCharacters = 10_000_000;
+
+        private static readonly XmlReaderSettings ManifestXmlReaderSettings = new() {
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null,
+            MaxCharactersInDocument = MaxManifestXmlCharacters,
+            MaxCharactersFromEntities = 0,
+        };
 
         /// <summary>
         /// Saves a stencil catalog manifest to a file.
@@ -73,7 +81,7 @@ namespace OfficeIMO.Visio.Stencils {
             if (stream == null) throw new ArgumentNullException(nameof(stream));
             if (!stream.CanRead) throw new ArgumentException("Stream must be readable.", nameof(stream));
 
-            XDocument document = XDocument.Load(stream);
+            XDocument document = LoadXml(stream);
             return FromXml(document, options);
         }
 
@@ -395,6 +403,11 @@ namespace OfficeIMO.Visio.Stencils {
         private static bool ReadBoolean(XElement element, string attributeName) {
             string? value = (string?)element.Attribute(attributeName);
             return !string.IsNullOrWhiteSpace(value) && XmlConvert.ToBoolean(value);
+        }
+
+        private static XDocument LoadXml(Stream stream) {
+            using XmlReader reader = XmlReader.Create(stream, ManifestXmlReaderSettings);
+            return XDocument.Load(reader, LoadOptions.None);
         }
     }
 }

--- a/OfficeIMO.Visio/VisioAssets.cs
+++ b/OfficeIMO.Visio/VisioAssets.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Xml;
 using System.Xml.Linq;
 
 namespace OfficeIMO.Visio {
@@ -21,6 +22,13 @@ namespace OfficeIMO.Visio {
         public const long MaxTotalMasterRelationshipBytes = 64_000_000;
         /// <summary>Maximum number of master relationships copied from one Visio package import.</summary>
         public const int MaxMasterRelationships = 4096;
+
+        private static readonly XmlReaderSettings PackageXmlReaderSettings = new() {
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null,
+            MaxCharactersInDocument = MaxMasterXmlPartBytes,
+            MaxCharactersFromEntities = 0,
+        };
 
         /// <summary>
         /// Lightweight info about a master available inside a Visio package.
@@ -93,7 +101,7 @@ namespace OfficeIMO.Visio {
             if (mastersEntry == null) return Array.Empty<MasterInfo>();
             EnsureZipEntryWithinLimit(mastersEntry, MaxMasterXmlPartBytes, "masters XML part");
             using var s = mastersEntry.Open();
-            XDocument doc = XDocument.Load(s);
+            XDocument doc = LoadXml(s);
             XNamespace v = V;
             return doc.Root!.Elements(v + "Master").Select(m => new MasterInfo {
                 Id = (string?)m.Attribute("ID") ?? string.Empty,
@@ -113,7 +121,7 @@ namespace OfficeIMO.Visio {
             if (mastersEntry == null) return Array.Empty<MasterContent>();
             EnsureZipEntryWithinLimit(mastersEntry, MaxMasterXmlPartBytes, "masters XML part");
             using var mStream = mastersEntry.Open();
-            XDocument mastersDoc = XDocument.Load(mStream);
+            XDocument mastersDoc = LoadXml(mStream);
             XNamespace v = V;
             XNamespace r = REL_ODC;
             // map relId->target
@@ -122,7 +130,7 @@ namespace OfficeIMO.Visio {
             if (relsEntry != null) {
                 EnsureZipEntryWithinLimit(relsEntry, MaxMasterXmlPartBytes, "masters relationship part");
                 using var relsStream = relsEntry.Open();
-                var relsDoc = XDocument.Load(relsStream);
+                var relsDoc = LoadXml(relsStream);
                 XNamespace pr = REL_PKG;
                 foreach (var e in relsDoc.Root!.Elements(pr + "Relationship")) {
                     string id = (string?)e.Attribute("Id") ?? string.Empty;
@@ -146,7 +154,7 @@ namespace OfficeIMO.Visio {
                 if (part == null) continue;
                 EnsureZipEntryWithinLimit(part, MaxMasterXmlPartBytes, "master XML part");
                 using var pStream = part.Open();
-                XDocument masterXml = XDocument.Load(pStream);
+                XDocument masterXml = LoadXml(pStream);
                 MasterContent content = new() { Id = id, NameU = nameU, MasterXml = masterXml, MasterElement = new XElement(m) };
                 foreach (MasterRelationshipContent relationship in LoadMasterRelationships(zip, partPath, ref totalRelationshipBytes, ref totalRelationships)) {
                     content.Relationships.Add(relationship);
@@ -167,14 +175,14 @@ namespace OfficeIMO.Visio {
             if (documentEntry != null) {
                 EnsureZipEntryWithinLimit(documentEntry, MaxMasterXmlPartBytes, "document XML part");
                 using Stream stream = documentEntry.Open();
-                context.DocumentXml = XDocument.Load(stream);
+                context.DocumentXml = LoadXml(stream);
             }
 
             ZipArchiveEntry? themeEntry = zip.GetEntry("visio/theme/theme1.xml");
             if (themeEntry != null) {
                 EnsureZipEntryWithinLimit(themeEntry, MaxMasterXmlPartBytes, "theme XML part");
                 using Stream stream = themeEntry.Open();
-                context.ThemeXml = XDocument.Load(stream);
+                context.ThemeXml = LoadXml(stream);
             }
 
             return context;
@@ -203,7 +211,7 @@ namespace OfficeIMO.Visio {
 
             EnsureZipEntryWithinLimit(relsEntry, MaxMasterXmlPartBytes, "master relationship XML part");
             using Stream relsStream = relsEntry.Open();
-            XDocument relsDoc = XDocument.Load(relsStream);
+            XDocument relsDoc = LoadXml(relsStream);
             XNamespace pr = REL_PKG;
             List<MasterRelationshipContent> relationships = new();
             foreach (XElement rel in relsDoc.Root?.Elements(pr + "Relationship") ?? Enumerable.Empty<XElement>()) {
@@ -269,6 +277,11 @@ namespace OfficeIMO.Visio {
             if (entry.Length > maxBytes) {
                 throw new InvalidDataException($"Visio package {description} '{entry.FullName}' exceeds {maxBytes} bytes.");
             }
+        }
+
+        private static XDocument LoadXml(Stream stream) {
+            using XmlReader reader = XmlReader.Create(stream, PackageXmlReaderSettings);
+            return XDocument.Load(reader, LoadOptions.None);
         }
 
         private static void CopyToWithLimit(Stream source, Stream destination, long maxBytes, string entryName) {

--- a/OfficeIMO.Visio/VisioDocument.LoadCore.Comments.cs
+++ b/OfficeIMO.Visio/VisioDocument.LoadCore.Comments.cs
@@ -95,7 +95,7 @@ namespace OfficeIMO.Visio {
 
         private static XDocument LoadCommentsXml(PackagePart commentsPart) {
             using Stream commentsStream = commentsPart.GetStream();
-            using Stream boundedStream = new BoundedReadStream(commentsStream, MaxCommentsPartBytes);
+            using Stream boundedStream = new BoundedReadStream(commentsStream, MaxCommentsPartBytes, "Visio comments part");
             using XmlReader reader = XmlReader.Create(boundedStream, CommentsXmlReaderSettings);
             return XDocument.Load(reader);
         }
@@ -177,11 +177,13 @@ namespace OfficeIMO.Visio {
         private sealed class BoundedReadStream : Stream {
             private readonly Stream _inner;
             private readonly long _maxBytes;
+            private readonly string _description;
             private long _bytesRead;
 
-            internal BoundedReadStream(Stream inner, long maxBytes) {
+            internal BoundedReadStream(Stream inner, long maxBytes, string description) {
                 _inner = inner ?? throw new ArgumentNullException(nameof(inner));
                 _maxBytes = maxBytes;
+                _description = string.IsNullOrWhiteSpace(description) ? "Stream" : description;
             }
 
             public override bool CanRead => _inner.CanRead;
@@ -205,7 +207,7 @@ namespace OfficeIMO.Visio {
                 int read = _inner.Read(buffer, offset, count);
                 _bytesRead += read;
                 if (_bytesRead > _maxBytes) {
-                    throw new InvalidDataException($"Visio comments part exceeds {_maxBytes} bytes.");
+                    throw new InvalidDataException($"{_description} exceeds {_maxBytes} bytes.");
                 }
 
                 return read;

--- a/OfficeIMO.Visio/VisioDocument.LoadCore.Xml.cs
+++ b/OfficeIMO.Visio/VisioDocument.LoadCore.Xml.cs
@@ -1,0 +1,25 @@
+using System.IO;
+using System.IO.Packaging;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace OfficeIMO.Visio {
+    public partial class VisioDocument {
+        internal const long MaxPackageXmlPartBytes = 32_000_000;
+        internal const long MaxPackageXmlCharacters = 30_000_000;
+
+        private static readonly XmlReaderSettings PackageXmlReaderSettings = new() {
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null,
+            MaxCharactersInDocument = MaxPackageXmlCharacters,
+            MaxCharactersFromEntities = 0,
+        };
+
+        private static XDocument LoadPackageXml(PackagePart part, string description) {
+            using Stream stream = part.GetStream();
+            using Stream boundedStream = new BoundedReadStream(stream, MaxPackageXmlPartBytes, description);
+            using XmlReader reader = XmlReader.Create(boundedStream, PackageXmlReaderSettings);
+            return XDocument.Load(reader, LoadOptions.None);
+        }
+    }
+}

--- a/OfficeIMO.Visio/VisioDocument.LoadCore.cs
+++ b/OfficeIMO.Visio/VisioDocument.LoadCore.cs
@@ -39,7 +39,7 @@ namespace OfficeIMO.Visio {
             if (documentPart.ContentType != DocumentContentType) {
                 throw new InvalidDataException($"Unexpected Visio document content type: {documentPart.ContentType}");
             }
-            XDocument documentXml = XDocument.Load(documentPart.GetStream());
+            XDocument documentXml = LoadPackageXml(documentPart, "Visio document XML part");
             if (documentXml.Root != null) {
                 foreach (XAttribute attribute in documentXml.Root.Attributes().Where(ShouldPreserveDocumentAttribute)) {
                     document.PreservedDocumentAttributes.Add(new XAttribute(attribute));
@@ -125,7 +125,7 @@ namespace OfficeIMO.Visio {
             if (themeRel != null) {
                 Uri themeUri = PackUriHelper.ResolvePartUri(documentPart.Uri, themeRel.TargetUri);
                 PackagePart themePart = package.GetPart(themeUri);
-                XDocument themeDoc = XDocument.Load(themePart.GetStream());
+                XDocument themeDoc = LoadPackageXml(themePart, "Visio theme XML part");
                 document.Theme = new VisioTheme {
                     Name = themeDoc.Root?.Attribute("name")?.Value,
                     TemplateXml = new XDocument(themeDoc)
@@ -146,7 +146,7 @@ namespace OfficeIMO.Visio {
             if (documentPart.GetRelationshipsByType(MastersRelationshipType).FirstOrDefault() is PackageRelationship mastersRel) {
                 Uri mastersUri = PackUriHelper.ResolvePartUri(documentPart.Uri, mastersRel.TargetUri);
                 PackagePart mastersPart = package.GetPart(mastersUri);
-                XDocument mastersDoc = XDocument.Load(mastersPart.GetStream());
+                XDocument mastersDoc = LoadPackageXml(mastersPart, "Visio masters XML part");
                 XNamespace ns = VisioNamespace;
                 XNamespace rNs = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
                 List<XAttribute> preservedMastersRootAttributes = mastersDoc.Root?
@@ -172,7 +172,7 @@ namespace OfficeIMO.Visio {
                     PackageRelationship rel = mastersPart.GetRelationship(mRelId);
                     Uri masterUri = PackUriHelper.ResolvePartUri(mastersPart.Uri, rel.TargetUri);
                     PackagePart masterPart = package.GetPart(masterUri);
-                    XDocument masterDoc = XDocument.Load(masterPart.GetStream());
+                    XDocument masterDoc = LoadPackageXml(masterPart, "Visio master XML part");
                     XElement? masterShapesElement = masterDoc.Root?.Element(ns + "Shapes");
                     XElement? masterShapeElement = masterShapesElement?.Elements(ns + "Shape").FirstOrDefault();
                     VisioShape masterShape = masterShapeElement != null ? ParseShapeCore(masterShapeElement, ns, faceNamesById) : new VisioShape("1");
@@ -228,7 +228,7 @@ namespace OfficeIMO.Visio {
                 }
             }
 
-            XDocument pagesDoc = XDocument.Load(pagesPart.GetStream());
+            XDocument pagesDoc = LoadPackageXml(pagesPart, "Visio pages XML part");
             XNamespace vNs = VisioNamespace;
             XNamespace relNs = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
 
@@ -555,7 +555,7 @@ namespace OfficeIMO.Visio {
                 PackageRelationship pageRel = pagesPart.GetRelationship(relId);
                 Uri pageUri = PackUriHelper.ResolvePartUri(pagesPart.Uri, pageRel.TargetUri);
                 PackagePart pagePart = package.GetPart(pageUri);
-                XDocument pageDoc = XDocument.Load(pagePart.GetStream());
+                XDocument pageDoc = LoadPackageXml(pagePart, "Visio page XML part");
 
                 if (pageDoc.Root != null) {
                     foreach (XAttribute attribute in pageDoc.Root.Attributes().Where(ShouldPreservePageContentsAttribute)) {


### PR DESCRIPTION
## Summary
- load core Visio package XML parts through bounded, DTD-prohibited XML readers
- apply the same secure XML loading to Visio asset extraction and stencil catalog manifests
- add regression coverage for DTD rejection and oversized package XML parts

## Validation
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~OfficeIMO.Tests.VisioLoadSecurityTests" --no-restore
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net472 --filter "FullyQualifiedName~OfficeIMO.Tests.VisioLoadSecurityTests" --no-restore
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net10.0 --filter "FullyQualifiedName~OfficeIMO.Tests.VisioLoadSecurityTests" --no-restore
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~OfficeIMO.Tests.Visio" --no-restore