### PR TITLE
Harden Excel VML XML loading

### DIFF
--- a/OfficeIMO.Excel/ExcelSheet.Comments.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Comments.cs
@@ -763,7 +763,7 @@ namespace OfficeIMO.Excel {
             try {
                 using var stream = part.GetStream();
                 if (stream.Length > 0) {
-                    return XDocument.Load(stream);
+                    return LoadVmlXDocument(stream);
                 }
             } catch (Exception ex) {
                 System.Diagnostics.Debug.WriteLine($"Failed to load VML drawing part stream: {ex}");

--- a/OfficeIMO.Excel/ExcelSheet.HeadersFooters.cs
+++ b/OfficeIMO.Excel/ExcelSheet.HeadersFooters.cs
@@ -190,7 +190,7 @@ namespace OfficeIMO.Excel {
             XDocument vmlDocument;
             try {
                 using Stream stream = vmlPart.GetStream(FileMode.Open, FileAccess.Read);
-                vmlDocument = XDocument.Load(stream);
+                vmlDocument = LoadVmlXDocument(stream);
             } catch {
                 return images;
             }

--- a/OfficeIMO.Excel/ExcelSheet.VmlXml.cs
+++ b/OfficeIMO.Excel/ExcelSheet.VmlXml.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelSheet {
+        internal const long MaxVmlXmlPartBytes = 12_000_000;
+        internal const long MaxVmlXmlCharacters = 10_000_000;
+
+        private static readonly XmlReaderSettings VmlXmlReaderSettings = new() {
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null,
+            MaxCharactersInDocument = MaxVmlXmlCharacters,
+            MaxCharactersFromEntities = 0,
+        };
+
+        /// <summary>
+        /// Loads workbook VML XML parts with external entities disabled and bounded document size.
+        /// </summary>
+        private static XDocument LoadVmlXDocument(Stream stream) {
+            if (stream.CanSeek && stream.Length > MaxVmlXmlPartBytes) {
+                throw new InvalidDataException($"Excel VML XML part exceeds {MaxVmlXmlPartBytes} bytes.");
+            }
+
+            using XmlReader reader = XmlReader.Create(stream, VmlXmlReaderSettings);
+            return XDocument.Load(reader, LoadOptions.None);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.VmlSecurity.cs
+++ b/OfficeIMO.Tests/Excel.VmlSecurity.cs
@@ -1,0 +1,94 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void HeaderFooterVmlRejectsDtdWhenReadingImages() {
+            string filePath = Path.Combine(_directoryWithFiles, "HeaderFooterVmlDtd.xlsx");
+            byte[] pngBytes = File.ReadAllBytes(Path.Combine(_directoryWithImages, "EvotecLogo.png"));
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Sheet1");
+                sheet.SetHeaderImage(HeaderFooterPosition.Center, pngBytes, "image/png");
+                document.Save(false);
+            }
+
+            string relationshipId = GetSingleVmlImageRelationshipId(filePath);
+            ReplaceFirstVmlPart(filePath, $$"""
+                <?xml version="1.0" encoding="utf-8"?>
+                <!DOCTYPE xml [<!ENTITY section "CH">]>
+                <xml xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+                  <v:shape id="&section;" type="#_x0000_t75" style="width:96pt;height:32pt">
+                    <v:imagedata r:id="{{relationshipId}}" o:relid="{{relationshipId}}" />
+                  </v:shape>
+                </xml>
+                """);
+
+            using ExcelDocument loaded = ExcelDocument.Load(filePath, readOnly: true);
+            ExcelSheet.HeaderFooterSnapshot snapshot = loaded.Sheets.Single().GetHeaderFooter();
+
+            Assert.True(snapshot.HeaderHasPicturePlaceholder);
+            Assert.Null(snapshot.HeaderCenterImage);
+        }
+
+        [Fact]
+        public void CommentVmlRejectsDtdBeforeUpdatingShapes() {
+            string filePath = Path.Combine(_directoryWithFiles, "CommentVmlDtd.xlsx");
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Sheet1");
+                sheet.SetComment(1, 1, "Original");
+                document.Save(false);
+            }
+
+            ReplaceFirstVmlPart(filePath, """
+                <?xml version="1.0" encoding="utf-8"?>
+                <!DOCTYPE xml [<!ENTITY shape "_x0000_s2048">]>
+                <xml xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:x="urn:schemas-microsoft-com:office:excel">
+                  <v:shape id="&shape;" type="#_x0000_t202">
+                    <x:ClientData ObjectType="Note">
+                      <x:Row>0</x:Row>
+                      <x:Column>0</x:Column>
+                    </x:ClientData>
+                  </v:shape>
+                </xml>
+                """);
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath)) {
+                document.Sheets.Single().SetComment(2, 1, "Updated");
+                document.Save(false);
+            }
+
+            string vml = ReadFirstVmlPartText(filePath);
+            Assert.DoesNotContain("<!DOCTYPE", vml, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("_x0000_s2049", vml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("_x0000_s1025", vml, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string GetSingleVmlImageRelationshipId(string filePath) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            VmlDrawingPart vmlPart = spreadsheet.WorkbookPart!.WorksheetParts.Single().VmlDrawingParts.Single();
+            return vmlPart.Parts.Single(part => part.OpenXmlPart is ImagePart).RelationshipId;
+        }
+
+        private static void ReplaceFirstVmlPart(string filePath, string xml) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true);
+            VmlDrawingPart vmlPart = spreadsheet.WorkbookPart!.WorksheetParts.Single().VmlDrawingParts.Single();
+            using Stream stream = vmlPart.GetStream(FileMode.Create, FileAccess.Write);
+            using StreamWriter writer = new(stream, new UTF8Encoding(false));
+            writer.Write(xml);
+        }
+
+        private static string ReadFirstVmlPartText(string filePath) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            VmlDrawingPart vmlPart = spreadsheet.WorkbookPart!.WorksheetParts.Single().VmlDrawingParts.Single();
+            using Stream stream = vmlPart.GetStream(FileMode.Open, FileAccess.Read);
+            using StreamReader reader = new(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+            return reader.ReadToEnd();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- load Excel VML XML parts through a DTD-prohibited, bounded XML reader
- apply the hardened loader to header/footer image VML and legacy comment VML updates
- add regression coverage for DTD-bearing VML in header/footer images and comment shape updates

## Validation
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~OfficeIMO.Tests.Excel.HeaderFooterVmlRejectsDtdWhenReadingImages|FullyQualifiedName~OfficeIMO.Tests.Excel.CommentVmlRejectsDtdBeforeUpdatingShapes" --no-restore
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net472 --filter "FullyQualifiedName~OfficeIMO.Tests.Excel.HeaderFooterVmlRejectsDtdWhenReadingImages|FullyQualifiedName~OfficeIMO.Tests.Excel.CommentVmlRejectsDtdBeforeUpdatingShapes" --no-restore
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net10.0 --filter "FullyQualifiedName~OfficeIMO.Tests.Excel.HeaderFooterVmlRejectsDtdWhenReadingImages|FullyQualifiedName~OfficeIMO.Tests.Excel.CommentVmlRejectsDtdBeforeUpdatingShapes" --no-restore
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "Category=ExcelHeaderFooterImages|FullyQualifiedName~OfficeIMO.Tests.Excel.HeaderFooterVmlRejectsDtdWhenReadingImages|FullyQualifiedName~OfficeIMO.Tests.Excel.CommentVmlRejectsDtdBeforeUpdatingShapes" --no-restore
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~OfficeIMO.Tests.Excel.Excel_Template|FullyQualifiedName~OfficeIMO.Tests.Excel.Comment" --no-restore