### PR TITLE
Harden VSIX marketplace publish gate

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -103,12 +103,10 @@ jobs:
           npm audit --omit=dev --audit-level ${{ env.NPM_AUDIT_LEVEL }}
 
       - name: Package extension
-        id: package_extension
         shell: pwsh
         env:
           IS_PRE_RELEASE: ${{ (github.event_name == 'release' && github.event.release.prerelease) || (github.event_name == 'workflow_dispatch' && inputs.pre_release) }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-          SHOULD_PUBLISH: ${{ github.event_name == 'release' || inputs.publish_marketplace }}
         run: |
           function Convert-OfficeIMOReleaseTagToExtensionVersion {
             param(
@@ -152,6 +150,116 @@ jobs:
             return $package
           }
 
+          if ('${{ github.event_name }}' -eq 'release') {
+            git fetch origin master
+            if ($LASTEXITCODE -ne 0) {
+              throw 'Failed to fetch origin/master for release source validation.'
+            }
+
+            git merge-base --is-ancestor HEAD origin/master
+            if ($LASTEXITCODE -ne 0) {
+              throw 'Release publishing is only allowed from commits contained in origin/master.'
+            }
+
+            $targetVersion = Convert-OfficeIMOReleaseTagToExtensionVersion -TagName $env:RELEASE_TAG
+            Set-ExtensionPackageVersion -Version $targetVersion | Out-Null
+            Write-Host "Stamped OfficeIMO Markup extension version $targetVersion from release tag $env:RELEASE_TAG." -ForegroundColor Cyan
+          }
+
+          $params = @{
+            OutputDirectory = 'dist'
+            SkipNpmCi = $true
+          }
+
+          if ($env:IS_PRE_RELEASE -eq 'true') {
+            $params.PreRelease = $true
+          }
+
+          ./OfficeIMO.Markup.VSCode/scripts/package-vsix.ps1 @params
+
+      - name: Upload VSIX
+        uses: actions/upload-artifact@v7
+        with:
+          name: officeimo-markup-vsix
+          path: OfficeIMO.Markup.VSCode/dist/*.vsix
+          if-no-files-found: error
+
+  publish-marketplace:
+    name: Publish VSIX Marketplace
+    if: ${{ (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'OfficeIMO-v')) || (github.event_name == 'workflow_dispatch' && github.ref_name == 'master' && inputs.publish_marketplace) }}
+    needs: package
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate release source
+        if: ${{ github.event_name == 'release' }}
+        shell: pwsh
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if ($env:RELEASE_TAG -notmatch '^OfficeIMO-v\d{14}$') {
+            throw "OfficeIMO VS Code Marketplace publishing only accepts normal OfficeIMO release tags named OfficeIMO-vYYYYMMDDHHMMSS. Current tag: $env:RELEASE_TAG. Example: OfficeIMO-v20260507115122"
+          }
+
+          git fetch origin master
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Failed to fetch origin/master for release source validation.'
+          }
+
+          git merge-base --is-ancestor HEAD origin/master
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Release publishing is only allowed from commits contained in origin/master.'
+          }
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: OfficeIMO.Markup.VSCode/package-lock.json
+
+      - name: Install publisher dependencies
+        working-directory: OfficeIMO.Markup.VSCode
+        run: npm ci --ignore-scripts
+
+      - name: Download VSIX
+        uses: actions/download-artifact@v7
+        with:
+          name: officeimo-markup-vsix
+          path: OfficeIMO.Markup.VSCode/dist
+
+      - name: Publish VSIX
+        shell: pwsh
+        env:
+          IS_PRE_RELEASE: ${{ (github.event_name == 'release' && github.event.release.prerelease) || (github.event_name == 'workflow_dispatch' && inputs.pre_release) }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          function Convert-OfficeIMOReleaseTagToExtensionVersion {
+            param(
+              [Parameter(Mandatory)]
+              [string] $TagName
+            )
+
+            if ($TagName -match '^OfficeIMO-v(?<stamp>\d{14})$') {
+              $stamp = $Matches.stamp
+              $year = [int] $stamp.Substring(0, 4)
+              $monthDay = [int] $stamp.Substring(4, 4)
+              $time = [int] $stamp.Substring(8, 6)
+              return "$year.$monthDay.$time"
+            }
+
+            throw "OfficeIMO VS Code Marketplace publishing only accepts normal OfficeIMO release tags named OfficeIMO-vYYYYMMDDHHMMSS. Current tag: $TagName. Example: OfficeIMO-v20260507115122"
+          }
+
           function Test-MarketplaceVersionExists {
             param(
               [Parameter(Mandatory)]
@@ -171,57 +279,24 @@ jobs:
             return @($listing.versions | Where-Object { $_.version -eq $Version }).Count -gt 0
           }
 
-          $shouldPublishMarketplace = $env:SHOULD_PUBLISH -eq 'true'
-
-          if ('${{ github.event_name }}' -eq 'release') {
-            git fetch origin master
-            if ($LASTEXITCODE -ne 0) {
-              throw 'Failed to fetch origin/master for release source validation.'
-            }
-
-            git merge-base --is-ancestor HEAD origin/master
-            if ($LASTEXITCODE -ne 0) {
-              throw 'Release publishing is only allowed from commits contained in origin/master.'
-            }
-
-            $targetVersion = Convert-OfficeIMOReleaseTagToExtensionVersion -TagName $env:RELEASE_TAG
-            $package = Set-ExtensionPackageVersion -Version $targetVersion
-            $extensionId = "$($package.publisher).$($package.name)"
-            Write-Host "Stamped OfficeIMO Markup extension version $targetVersion from release tag $env:RELEASE_TAG." -ForegroundColor Cyan
-
-            if (Test-MarketplaceVersionExists -ExtensionId $extensionId -Version $targetVersion) {
-              Write-Host "Marketplace version $extensionId@$targetVersion already exists. The VSIX will be packaged and attached to the GitHub Release, but Marketplace publishing will be skipped." -ForegroundColor Yellow
-              $shouldPublishMarketplace = $false
-            }
-          }
-
-          $params = @{
-            OutputDirectory = 'dist'
-            SkipNpmCi = $true
-          }
-
-          if ($env:IS_PRE_RELEASE -eq 'true') {
-            $params.PreRelease = $true
-          }
-
-          if ($shouldPublishMarketplace) {
-            if ('${{ github.event_name }}' -eq 'workflow_dispatch' -and '${{ github.ref_name }}' -ne 'master') {
-              throw 'Marketplace publishing is only allowed from the master branch.'
-            }
-          }
-
-          ./OfficeIMO.Markup.VSCode/scripts/package-vsix.ps1 @params
-          "should_publish_marketplace=$($shouldPublishMarketplace.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
-
-      - name: Publish VSIX
-        if: ${{ steps.package_extension.outputs.should_publish_marketplace == 'true' }}
-        shell: pwsh
-        env:
-          IS_PRE_RELEASE: ${{ (github.event_name == 'release' && github.event.release.prerelease) || (github.event_name == 'workflow_dispatch' && inputs.pre_release) }}
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        run: |
           if ([string]::IsNullOrWhiteSpace($env:VSCE_PAT)) {
             throw 'VSCE_PAT is required when publishing to the Visual Studio Marketplace.'
+          }
+
+          if ('${{ github.event_name }}' -eq 'workflow_dispatch' -and '${{ github.ref_name }}' -ne 'master') {
+            throw 'Marketplace publishing is only allowed from the master branch.'
+          }
+
+          $package = Get-Content -LiteralPath 'OfficeIMO.Markup.VSCode/package.json' -Raw | ConvertFrom-Json
+          $extensionVersion = $package.version
+          if ('${{ github.event_name }}' -eq 'release') {
+            $extensionVersion = Convert-OfficeIMOReleaseTagToExtensionVersion -TagName $env:RELEASE_TAG
+          }
+
+          $extensionId = "$($package.publisher).$($package.name)"
+          if (Test-MarketplaceVersionExists -ExtensionId $extensionId -Version $extensionVersion) {
+            Write-Host "Marketplace version $extensionId@$extensionVersion already exists. Marketplace publishing will be skipped." -ForegroundColor Yellow
+            return
           }
 
           $vsixFiles = @(Get-ChildItem -LiteralPath 'OfficeIMO.Markup.VSCode/dist' -Filter '*.vsix')
@@ -243,13 +318,6 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             throw "VSIX marketplace publishing failed with exit code $LASTEXITCODE."
           }
-
-      - name: Upload VSIX
-        uses: actions/upload-artifact@v7
-        with:
-          name: officeimo-markup-vsix
-          path: OfficeIMO.Markup.VSCode/dist/*.vsix
-          if-no-files-found: error
 
   attach-release-asset:
     if: ${{ github.event_name == 'release' }}


### PR DESCRIPTION
## Summary
- move Visual Studio Marketplace publishing into a separate job with a fresh checkout and downloaded VSIX artifact
- remove the package-step output gate that could be influenced after repository-controlled package/build code runs
- repeat trusted release/manual-master publish checks directly on the secret-bearing publish job
- reinstall publisher dependencies without lifecycle scripts before exposing VSCE_PAT only to the final publish step

## Validation
- Parsed `.github/workflows/vscode-extension.yml` with PyYAML
- Ran a structural check confirming `should_publish_marketplace` and `id: package_extension` are gone while the new publish job, artifact download, and VSCE_PAT publish step are present
- Ran `git diff --check`