### PR TITLE
Harden OpenXML image asset extraction

### DIFF
--- a/OfficeIMO.Reader/DocumentReader.OpenXmlAssets.cs
+++ b/OfficeIMO.Reader/DocumentReader.OpenXmlAssets.cs
@@ -37,28 +37,30 @@ public static partial class DocumentReader {
         }
 
         var assets = new List<OfficeDocumentAsset>();
+        var payloadCache = new Dictionary<Uri, OpenXmlImagePayload>();
+        long totalPayloadBytes = 0;
         OpenSettings? openSettings = CreateOpenSettings(opt);
         if (kind == ReaderInputKind.Word) {
             using WordprocessingDocument document = openSettings == null
                 ? WordprocessingDocument.Open(stream, false)
                 : WordprocessingDocument.Open(stream, false, openSettings);
-            CollectWordImageAssets(document, sourceName, opt, assets, cancellationToken);
+            CollectWordImageAssets(document, sourceName, opt, assets, payloadCache, ref totalPayloadBytes, cancellationToken);
         } else if (kind == ReaderInputKind.PowerPoint) {
             using PresentationDocument document = openSettings == null
                 ? PresentationDocument.Open(stream, false)
                 : PresentationDocument.Open(stream, false, openSettings);
-            CollectPowerPointImageAssets(document, sourceName, opt, assets, cancellationToken);
+            CollectPowerPointImageAssets(document, sourceName, opt, assets, payloadCache, ref totalPayloadBytes, cancellationToken);
         } else if (kind == ReaderInputKind.Excel) {
             using SpreadsheetDocument document = openSettings == null
                 ? SpreadsheetDocument.Open(stream, false)
                 : SpreadsheetDocument.Open(stream, false, openSettings);
-            CollectExcelImageAssets(document, sourceName, opt, assets, cancellationToken);
+            CollectExcelImageAssets(document, sourceName, opt, assets, payloadCache, ref totalPayloadBytes, cancellationToken);
         }
 
         return assets.Count == 0 ? Array.Empty<OfficeDocumentAsset>() : assets;
     }
 
-    private static void CollectWordImageAssets(WordprocessingDocument document, string sourceName, ReaderOptions opt, List<OfficeDocumentAsset> assets, CancellationToken cancellationToken) {
+    private static void CollectWordImageAssets(WordprocessingDocument document, string sourceName, ReaderOptions opt, List<OfficeDocumentAsset> assets, Dictionary<Uri, OpenXmlImagePayload> payloadCache, ref long totalPayloadBytes, CancellationToken cancellationToken) {
         if (document.MainDocumentPart == null) {
             return;
         }
@@ -77,11 +79,13 @@ public static partial class DocumentReader {
             seenImagePlacements,
             visitedParts,
             opt,
+            payloadCache,
+            ref totalPayloadBytes,
             ref assetIndex,
             cancellationToken);
     }
 
-    private static void CollectPowerPointImageAssets(PresentationDocument document, string sourceName, ReaderOptions opt, List<OfficeDocumentAsset> assets, CancellationToken cancellationToken) {
+    private static void CollectPowerPointImageAssets(PresentationDocument document, string sourceName, ReaderOptions opt, List<OfficeDocumentAsset> assets, Dictionary<Uri, OpenXmlImagePayload> payloadCache, ref long totalPayloadBytes, CancellationToken cancellationToken) {
         PresentationPart? presentationPart = document.PresentationPart;
         if (presentationPart?.Presentation?.SlideIdList == null) {
             return;
@@ -112,6 +116,8 @@ public static partial class DocumentReader {
                     seenImagePlacements,
                     visitedParts,
                     opt,
+                    payloadCache,
+                    ref totalPayloadBytes,
                     ref assetIndex,
                     cancellationToken);
             }
@@ -120,7 +126,7 @@ public static partial class DocumentReader {
         }
     }
 
-    private static void CollectExcelImageAssets(SpreadsheetDocument document, string sourceName, ReaderOptions opt, List<OfficeDocumentAsset> assets, CancellationToken cancellationToken) {
+    private static void CollectExcelImageAssets(SpreadsheetDocument document, string sourceName, ReaderOptions opt, List<OfficeDocumentAsset> assets, Dictionary<Uri, OpenXmlImagePayload> payloadCache, ref long totalPayloadBytes, CancellationToken cancellationToken) {
         WorkbookPart? workbookPart = document.WorkbookPart;
         if (workbookPart?.Workbook?.Sheets == null) {
             return;
@@ -162,6 +168,8 @@ public static partial class DocumentReader {
                     opt,
                     (container, imageRelationshipId) => ResolveExcelImageMetadata(container, worksheetPart.DrawingsPart, imageMetadata, imageRelationshipId),
                     metadata => IsExcelImageInSelectedRange(metadata, selectedRange),
+                    payloadCache,
+                    ref totalPayloadBytes,
                     ref assetIndex,
                     cancellationToken);
             }
@@ -181,9 +189,11 @@ public static partial class DocumentReader {
         HashSet<string> seenImagePlacements,
         HashSet<Uri> visitedParts,
         ReaderOptions opt,
+        Dictionary<Uri, OpenXmlImagePayload> payloadCache,
+        ref long totalPayloadBytes,
         ref int assetIndex,
         CancellationToken cancellationToken) {
-        CollectImageParts(container, sourceName, kind, slideNumber, sheetNumber, sheetName, assets, seenImagePlacements, visitedParts, opt, resolveMetadata: null, shouldIncludeMetadata: null, ref assetIndex, cancellationToken);
+        CollectImageParts(container, sourceName, kind, slideNumber, sheetNumber, sheetName, assets, seenImagePlacements, visitedParts, opt, resolveMetadata: null, shouldIncludeMetadata: null, payloadCache, ref totalPayloadBytes, ref assetIndex, cancellationToken);
     }
 
     private static void CollectImageParts(
@@ -199,6 +209,8 @@ public static partial class DocumentReader {
         ReaderOptions opt,
         Func<OpenXmlPartContainer, string, IReadOnlyList<OpenXmlImageAssetMetadata>?>? resolveMetadata,
         Func<OpenXmlImageAssetMetadata?, bool>? shouldIncludeMetadata,
+        Dictionary<Uri, OpenXmlImagePayload> payloadCache,
+        ref long totalPayloadBytes,
         ref int assetIndex,
         CancellationToken cancellationToken) {
         foreach (IdPartPair pair in container.Parts) {
@@ -207,8 +219,9 @@ public static partial class DocumentReader {
             OpenXmlPart part = pair.OpenXmlPart;
             if (part is ImagePart imagePart) {
                 IReadOnlyList<OpenXmlImageAssetMetadata>? metadataPlacements = resolveMetadata?.Invoke(container, pair.RelationshipId)
-                    ?? ResolveOpenXmlImageMetadataPlacements(container, pair.RelationshipId);
-                int placementCount = metadataPlacements?.Count ?? Math.Max(1, CountImageRelationshipPlacements(container, pair.RelationshipId));
+                    ?? ResolveOpenXmlImageMetadataPlacements(container, pair.RelationshipId, opt);
+                int placementCount = metadataPlacements?.Count ?? Math.Max(1, CountImageRelationshipPlacements(container, pair.RelationshipId, opt));
+                EnsureOpenXmlImagePlacementCount(opt, placementCount, pair.RelationshipId);
                 for (int placementIndex = 0; placementIndex < placementCount; placementIndex++) {
                     OpenXmlImageAssetMetadata? metadata = metadataPlacements != null && placementIndex < metadataPlacements.Count
                         ? metadataPlacements[placementIndex]
@@ -221,7 +234,9 @@ public static partial class DocumentReader {
                         continue;
                     }
 
-                    assets.Add(BuildOpenXmlImageAsset(imagePart, pair.RelationshipId, sourceName, kind, slideNumber, sheetNumber, sheetName, assetIndex, metadata));
+                    EnsureOpenXmlImageAssetCount(opt, assets.Count + 1);
+                    OpenXmlImagePayload payload = GetOpenXmlImagePayload(imagePart, opt, payloadCache, ref totalPayloadBytes);
+                    assets.Add(BuildOpenXmlImageAsset(imagePart, pair.RelationshipId, sourceName, kind, slideNumber, sheetNumber, sheetName, assetIndex, payload, metadata));
                     assetIndex++;
                 }
 
@@ -230,7 +245,7 @@ public static partial class DocumentReader {
 
             if (part is OpenXmlPartContainer childContainer) {
                 if (ShouldTraverseRelatedPart(kind, opt, part) && visitedParts.Add(part.Uri)) {
-                    CollectImageParts(childContainer, sourceName, kind, slideNumber, sheetNumber, sheetName, assets, seenImagePlacements, visitedParts, opt, resolveMetadata, shouldIncludeMetadata, ref assetIndex, cancellationToken);
+                    CollectImageParts(childContainer, sourceName, kind, slideNumber, sheetNumber, sheetName, assets, seenImagePlacements, visitedParts, opt, resolveMetadata, shouldIncludeMetadata, payloadCache, ref totalPayloadBytes, ref assetIndex, cancellationToken);
                 }
             }
         }
@@ -248,22 +263,8 @@ public static partial class DocumentReader {
             "|placement:", placementIndex.ToString(CultureInfo.InvariantCulture));
     }
 
-    private static OfficeDocumentAsset BuildOpenXmlImageAsset(ImagePart imagePart, string relationshipId, string sourceName, ReaderInputKind kind, int? slideNumber, int? sheetNumber, string? sheetName, int assetIndex, OpenXmlImageAssetMetadata? metadata = null) {
-        byte[] payload;
-        using (Stream imageStream = imagePart.GetStream(FileMode.Open, FileAccess.Read)) {
-            using var memory = new MemoryStream();
-            imageStream.CopyTo(memory);
-            payload = memory.ToArray();
-        }
-
+    private static OfficeDocumentAsset BuildOpenXmlImageAsset(ImagePart imagePart, string relationshipId, string sourceName, ReaderInputKind kind, int? slideNumber, int? sheetNumber, string? sheetName, int assetIndex, OpenXmlImagePayload payload, OpenXmlImageAssetMetadata? metadata = null) {
         string kindStem = kind.ToString().ToLowerInvariant();
-        int? width = null;
-        int? height = null;
-        if (OfficeDocumentImageDimensions.TryReadPixelDimensions(payload, imagePart.ContentType, out int detectedWidth, out int detectedHeight)) {
-            width = detectedWidth;
-            height = detectedHeight;
-        }
-
         string assetId;
         if (slideNumber.HasValue) {
             assetId = string.Concat(kindStem, "-slide-", slideNumber.Value.ToString("D4", CultureInfo.InvariantCulture), "-image-", assetIndex.ToString("D4", CultureInfo.InvariantCulture));
@@ -272,21 +273,20 @@ public static partial class DocumentReader {
         } else {
             assetId = string.Concat(kindStem, "-image-", assetIndex.ToString("D4", CultureInfo.InvariantCulture));
         }
-        string? extension = ResolveImageExtension(imagePart.ContentType, imagePart.Uri);
 
         return new OfficeDocumentAsset {
             Id = assetId,
             Kind = "image",
             MediaType = imagePart.ContentType,
-            Extension = extension,
-            FileName = OfficeDocumentAssetNaming.BuildFileName(assetId, extension),
+            Extension = payload.Extension,
+            FileName = OfficeDocumentAssetNaming.BuildFileName(assetId, payload.Extension),
             AltText = metadata?.AltText,
             Title = metadata?.Title,
-            Width = width,
-            Height = height,
-            LengthBytes = payload.Length,
-            PayloadHash = OfficeDocumentAssetHash.ComputeSha256Hex(payload),
-            PayloadBytes = payload,
+            Width = payload.Width,
+            Height = payload.Height,
+            LengthBytes = payload.Bytes.Length,
+            PayloadHash = payload.Hash,
+            PayloadBytes = payload.Bytes,
             SourceObjectId = relationshipId + "|" + imagePart.Uri,
             Location = new ReaderLocation {
                 Path = sourceName,
@@ -298,6 +298,84 @@ public static partial class DocumentReader {
         };
     }
 
+    private static OpenXmlImagePayload GetOpenXmlImagePayload(ImagePart imagePart, ReaderOptions opt, Dictionary<Uri, OpenXmlImagePayload> payloadCache, ref long totalPayloadBytes) {
+        if (payloadCache.TryGetValue(imagePart.Uri, out OpenXmlImagePayload? cached)) {
+            return cached;
+        }
+
+        byte[] payload;
+        using (Stream imageStream = imagePart.GetStream(FileMode.Open, FileAccess.Read)) {
+            payload = CopyOpenXmlImagePayload(imageStream, opt.MaxOpenXmlImageAssetBytes);
+        }
+
+        if (opt.MaxOpenXmlImageTotalAssetBytes.HasValue) {
+            long nextTotal = checked(totalPayloadBytes + payload.LongLength);
+            if (nextTotal > opt.MaxOpenXmlImageTotalAssetBytes.Value) {
+                throw new IOException($"OpenXML image asset extraction exceeds MaxOpenXmlImageTotalAssetBytes ({nextTotal.ToString(CultureInfo.InvariantCulture)} > {opt.MaxOpenXmlImageTotalAssetBytes.Value.ToString(CultureInfo.InvariantCulture)}).");
+            }
+
+            totalPayloadBytes = nextTotal;
+        } else {
+            totalPayloadBytes = checked(totalPayloadBytes + payload.LongLength);
+        }
+
+        int? width = null;
+        int? height = null;
+        if (OfficeDocumentImageDimensions.TryReadPixelDimensions(payload, imagePart.ContentType, out int detectedWidth, out int detectedHeight)) {
+            width = detectedWidth;
+            height = detectedHeight;
+        }
+
+        var value = new OpenXmlImagePayload(
+            payload,
+            OfficeDocumentAssetHash.ComputeSha256Hex(payload),
+            ResolveImageExtension(imagePart.ContentType, imagePart.Uri),
+            width,
+            height);
+        payloadCache.Add(imagePart.Uri, value);
+        return value;
+    }
+
+    private static byte[] CopyOpenXmlImagePayload(Stream imageStream, long? maxBytes) {
+        if (maxBytes.HasValue && imageStream.CanSeek) {
+            long remaining = imageStream.Length - imageStream.Position;
+            if (remaining > maxBytes.Value) {
+                throw new IOException($"OpenXML image asset exceeds MaxOpenXmlImageAssetBytes ({remaining.ToString(CultureInfo.InvariantCulture)} > {maxBytes.Value.ToString(CultureInfo.InvariantCulture)}).");
+            }
+        }
+
+        using var memory = new MemoryStream();
+        var buffer = new byte[81920];
+        long total = 0;
+        while (true) {
+            int read = imageStream.Read(buffer, 0, buffer.Length);
+            if (read == 0) {
+                break;
+            }
+
+            total += read;
+            if (maxBytes.HasValue && total > maxBytes.Value) {
+                throw new IOException($"OpenXML image asset exceeds MaxOpenXmlImageAssetBytes ({total.ToString(CultureInfo.InvariantCulture)} > {maxBytes.Value.ToString(CultureInfo.InvariantCulture)}).");
+            }
+
+            memory.Write(buffer, 0, read);
+        }
+
+        return memory.ToArray();
+    }
+
+    private static void EnsureOpenXmlImageAssetCount(ReaderOptions opt, int nextCount) {
+        if (opt.MaxOpenXmlImageAssets.HasValue && nextCount > opt.MaxOpenXmlImageAssets.Value) {
+            throw new IOException($"OpenXML image asset extraction exceeds MaxOpenXmlImageAssets ({nextCount.ToString(CultureInfo.InvariantCulture)} > {opt.MaxOpenXmlImageAssets.Value.ToString(CultureInfo.InvariantCulture)}).");
+        }
+    }
+
+    private static void EnsureOpenXmlImagePlacementCount(ReaderOptions opt, int count, string relationshipId) {
+        if (opt.MaxOpenXmlImagePlacementsPerRelationship.HasValue && count > opt.MaxOpenXmlImagePlacementsPerRelationship.Value) {
+            throw new IOException($"OpenXML image relationship '{relationshipId}' exceeds MaxOpenXmlImagePlacementsPerRelationship ({count.ToString(CultureInfo.InvariantCulture)} > {opt.MaxOpenXmlImagePlacementsPerRelationship.Value.ToString(CultureInfo.InvariantCulture)}).");
+        }
+    }
+
     private sealed class OpenXmlImageAssetMetadata {
         public string? AltText { get; set; }
 
@@ -306,6 +384,22 @@ public static partial class DocumentReader {
         public int? AnchorRow { get; set; }
 
         public int? AnchorColumn { get; set; }
+    }
+
+    private sealed class OpenXmlImagePayload {
+        public OpenXmlImagePayload(byte[] bytes, string hash, string? extension, int? width, int? height) {
+            Bytes = bytes;
+            Hash = hash;
+            Extension = extension;
+            Width = width;
+            Height = height;
+        }
+
+        public byte[] Bytes { get; }
+        public string Hash { get; }
+        public string? Extension { get; }
+        public int? Width { get; }
+        public int? Height { get; }
     }
 
     private static IReadOnlyDictionary<string, IReadOnlyList<OpenXmlImageAssetMetadata>> BuildExcelImageMetadata(DrawingsPart? drawingsPart) {
@@ -355,7 +449,7 @@ public static partial class DocumentReader {
         return metadata.TryGetValue(relationshipId, out IReadOnlyList<OpenXmlImageAssetMetadata>? value) ? value : null;
     }
 
-    private static IReadOnlyList<OpenXmlImageAssetMetadata>? ResolveOpenXmlImageMetadataPlacements(OpenXmlPartContainer container, string relationshipId) {
+    private static IReadOnlyList<OpenXmlImageAssetMetadata>? ResolveOpenXmlImageMetadataPlacements(OpenXmlPartContainer container, string relationshipId, ReaderOptions opt) {
         OpenXmlPartRootElement? root = (container as OpenXmlPart)?.RootElement;
         if (root == null) {
             return null;
@@ -369,6 +463,7 @@ public static partial class DocumentReader {
             }
 
             placements ??= new List<OpenXmlImageAssetMetadata>();
+            EnsureOpenXmlImagePlacementCount(opt, placements.Count + 1, relationshipId);
             placements.Add(ResolveOpenXmlImageMetadata(blip));
         }
 
@@ -405,7 +500,7 @@ public static partial class DocumentReader {
         return true;
     }
 
-    private static int CountImageRelationshipPlacements(OpenXmlPartContainer container, string relationshipId) {
+    private static int CountImageRelationshipPlacements(OpenXmlPartContainer container, string relationshipId, ReaderOptions opt) {
         OpenXmlPartRootElement? root = (container as OpenXmlPart)?.RootElement;
         if (root == null) {
             return 0;
@@ -416,6 +511,7 @@ public static partial class DocumentReader {
             if (string.Equals(blip.Embed?.Value, relationshipId, StringComparison.Ordinal) ||
                 string.Equals(blip.Link?.Value, relationshipId, StringComparison.Ordinal)) {
                 count++;
+                EnsureOpenXmlImagePlacementCount(opt, count, relationshipId);
             }
         }
 

--- a/OfficeIMO.Reader/DocumentReader.Registry.cs
+++ b/OfficeIMO.Reader/DocumentReader.Registry.cs
@@ -354,7 +354,11 @@ public static partial class DocumentReader {
         var o = options;
         var clone = new ReaderOptions {
             MaxInputBytes = o?.MaxInputBytes,
-            OpenXmlMaxCharactersInPart = o?.OpenXmlMaxCharactersInPart,
+            OpenXmlMaxCharactersInPart = o == null ? ReaderOptions.DefaultOpenXmlMaxCharactersInPart : o.OpenXmlMaxCharactersInPart,
+            MaxOpenXmlImageAssets = o == null ? ReaderOptions.DefaultMaxOpenXmlImageAssets : o.MaxOpenXmlImageAssets,
+            MaxOpenXmlImagePlacementsPerRelationship = o == null ? ReaderOptions.DefaultMaxOpenXmlImagePlacementsPerRelationship : o.MaxOpenXmlImagePlacementsPerRelationship,
+            MaxOpenXmlImageAssetBytes = o == null ? ReaderOptions.DefaultMaxOpenXmlImageAssetBytes : o.MaxOpenXmlImageAssetBytes,
+            MaxOpenXmlImageTotalAssetBytes = o == null ? ReaderOptions.DefaultMaxOpenXmlImageTotalAssetBytes : o.MaxOpenXmlImageTotalAssetBytes,
             MaxChars = o?.MaxChars ?? 8_000,
             MaxTableRows = o?.MaxTableRows ?? 200,
             IncludeWordFootnotes = o?.IncludeWordFootnotes ?? true,
@@ -372,6 +376,10 @@ public static partial class DocumentReader {
         if (clone.MaxTableRows < 1) clone.MaxTableRows = 1;
         if (clone.ExcelChunkRows < 1) clone.ExcelChunkRows = 1;
         if (clone.OpenXmlMaxCharactersInPart.HasValue && clone.OpenXmlMaxCharactersInPart.Value < 1) clone.OpenXmlMaxCharactersInPart = null;
+        if (clone.MaxOpenXmlImageAssets.HasValue && clone.MaxOpenXmlImageAssets.Value < 1) clone.MaxOpenXmlImageAssets = null;
+        if (clone.MaxOpenXmlImagePlacementsPerRelationship.HasValue && clone.MaxOpenXmlImagePlacementsPerRelationship.Value < 1) clone.MaxOpenXmlImagePlacementsPerRelationship = null;
+        if (clone.MaxOpenXmlImageAssetBytes.HasValue && clone.MaxOpenXmlImageAssetBytes.Value < 1) clone.MaxOpenXmlImageAssetBytes = null;
+        if (clone.MaxOpenXmlImageTotalAssetBytes.HasValue && clone.MaxOpenXmlImageTotalAssetBytes.Value < 1) clone.MaxOpenXmlImageTotalAssetBytes = null;
 
         return clone;
     }
@@ -381,6 +389,10 @@ public static partial class DocumentReader {
         return new ReaderOptions {
             MaxInputBytes = options.MaxInputBytes,
             OpenXmlMaxCharactersInPart = options.OpenXmlMaxCharactersInPart,
+            MaxOpenXmlImageAssets = options.MaxOpenXmlImageAssets,
+            MaxOpenXmlImagePlacementsPerRelationship = options.MaxOpenXmlImagePlacementsPerRelationship,
+            MaxOpenXmlImageAssetBytes = options.MaxOpenXmlImageAssetBytes,
+            MaxOpenXmlImageTotalAssetBytes = options.MaxOpenXmlImageTotalAssetBytes,
             MaxChars = options.MaxChars,
             MaxTableRows = options.MaxTableRows,
             IncludeWordFootnotes = options.IncludeWordFootnotes,

--- a/OfficeIMO.Reader/DocumentReader.Registry.cs
+++ b/OfficeIMO.Reader/DocumentReader.Registry.cs
@@ -553,18 +553,6 @@ public static partial class DocumentReader {
         }
     }
 
-    private static void EnforceStreamSize(Stream stream, long? maxBytes) {
-        if (!maxBytes.HasValue) return;
-        if (!stream.CanSeek) return;
-        try {
-            if (stream.Length > maxBytes.Value) {
-                throw new IOException($"Input exceeds MaxInputBytes ({stream.Length.ToString(CultureInfo.InvariantCulture)} > {maxBytes.Value.ToString(CultureInfo.InvariantCulture)}).");
-            }
-        } catch (NotSupportedException) {
-            // ignore
-        }
-    }
-
     private static string ReadAllText(Stream stream, CancellationToken ct, int? hardCapChars = 50_000_000) {
         ct.ThrowIfCancellationRequested();
         using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 16 * 1024, leaveOpen: true);

--- a/OfficeIMO.Reader/DocumentReader.Streams.cs
+++ b/OfficeIMO.Reader/DocumentReader.Streams.cs
@@ -35,35 +35,42 @@ public static partial class DocumentReader {
         if (!stream.CanRead) throw new ArgumentException("Stream must be readable.", nameof(stream));
 
         var opt = NormalizeOptions(options);
-        EnforceStreamSize(stream, opt.MaxInputBytes);
+        Stream readStream = ReaderInputLimits.EnsureSeekableReadStream(stream, opt.MaxInputBytes, cancellationToken, out bool ownsReadStream);
         string? logicalSourceName = null;
-        if (sourceName != null) {
-            var trimmedSourceName = sourceName.Trim();
-            if (trimmedSourceName.Length > 0) {
-                logicalSourceName = trimmedSourceName;
+        try {
+            if (sourceName != null) {
+                var trimmedSourceName = sourceName.Trim();
+                if (trimmedSourceName.Length > 0) {
+                    logicalSourceName = trimmedSourceName;
+                }
             }
-        }
-        var source = BuildSourceInfoFromStream(stream, logicalSourceName, opt.ComputeHashes);
 
-        IEnumerable<ReaderChunk> raw;
-        if (TryResolveCustomHandlerBySourceName(logicalSourceName, out var customStreamHandler) && customStreamHandler.ReadStream != null) {
-            raw = customStreamHandler.ReadStream(stream, logicalSourceName, opt, cancellationToken);
-        } else {
-            var kind = string.IsNullOrWhiteSpace(logicalSourceName) ? ReaderInputKind.Unknown : DetectKind(logicalSourceName!);
-            raw = kind switch {
-                ReaderInputKind.Word => ReadWord(stream, logicalSourceName, opt, cancellationToken),
-                ReaderInputKind.Excel => ReadExcel(stream, logicalSourceName, opt, cancellationToken),
-                ReaderInputKind.PowerPoint => ReadPowerPoint(stream, logicalSourceName, opt, cancellationToken),
-                ReaderInputKind.Markdown => ReadMarkdown(stream, logicalSourceName, opt, cancellationToken),
-                ReaderInputKind.Pdf => ReadPdf(stream, logicalSourceName, opt, cancellationToken),
-                ReaderInputKind.Text => ReadText(stream, logicalSourceName, opt, cancellationToken),
-                _ => ReadUnknown(stream, logicalSourceName, opt, cancellationToken)
-            };
-        }
+            var source = BuildSourceInfoFromStream(readStream, logicalSourceName, opt.ComputeHashes);
 
-        foreach (var chunk in raw) {
-            cancellationToken.ThrowIfCancellationRequested();
-            yield return EnrichChunk(chunk, source, opt.ComputeHashes);
+            IEnumerable<ReaderChunk> raw;
+            if (TryResolveCustomHandlerBySourceName(logicalSourceName, out var customStreamHandler) && customStreamHandler.ReadStream != null) {
+                raw = customStreamHandler.ReadStream(readStream, logicalSourceName, opt, cancellationToken);
+            } else {
+                var kind = string.IsNullOrWhiteSpace(logicalSourceName) ? ReaderInputKind.Unknown : DetectKind(logicalSourceName!);
+                raw = kind switch {
+                    ReaderInputKind.Word => ReadWord(readStream, logicalSourceName, opt, cancellationToken),
+                    ReaderInputKind.Excel => ReadExcel(readStream, logicalSourceName, opt, cancellationToken),
+                    ReaderInputKind.PowerPoint => ReadPowerPoint(readStream, logicalSourceName, opt, cancellationToken),
+                    ReaderInputKind.Markdown => ReadMarkdown(readStream, logicalSourceName, opt, cancellationToken),
+                    ReaderInputKind.Pdf => ReadPdf(readStream, logicalSourceName, opt, cancellationToken),
+                    ReaderInputKind.Text => ReadText(readStream, logicalSourceName, opt, cancellationToken),
+                    _ => ReadUnknown(readStream, logicalSourceName, opt, cancellationToken)
+                };
+            }
+
+            foreach (var chunk in raw) {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return EnrichChunk(chunk, source, opt.ComputeHashes);
+            }
+        } finally {
+            if (ownsReadStream) {
+                readStream.Dispose();
+            }
         }
     }
 

--- a/OfficeIMO.Reader/ReaderOptions.cs
+++ b/OfficeIMO.Reader/ReaderOptions.cs
@@ -10,6 +10,12 @@ namespace OfficeIMO.Reader;
 /// Options controlling extraction behavior for <see cref="DocumentReader"/>.
 /// </summary>
 public sealed class ReaderOptions {
+    internal const long DefaultOpenXmlMaxCharactersInPart = 10_000_000L;
+    internal const int DefaultMaxOpenXmlImageAssets = 512;
+    internal const int DefaultMaxOpenXmlImagePlacementsPerRelationship = 256;
+    internal const long DefaultMaxOpenXmlImageAssetBytes = 32L * 1024L * 1024L;
+    internal const long DefaultMaxOpenXmlImageTotalAssetBytes = 128L * 1024L * 1024L;
+
     /// <summary>
     /// Optional maximum input size in bytes enforced by <see cref="DocumentReader"/> when reading from a file or seekable stream.
     /// When null, no size limit is enforced.
@@ -20,7 +26,32 @@ public sealed class ReaderOptions {
     /// OpenXML security: maximum characters allowed per part when opening OpenXML packages (best-effort).
     /// When null, the OpenXML SDK default is used.
     /// </summary>
-    public long? OpenXmlMaxCharactersInPart { get; set; } = 10_000_000;
+    public long? OpenXmlMaxCharactersInPart { get; set; } = DefaultOpenXmlMaxCharactersInPart;
+
+    /// <summary>
+    /// OpenXML security: maximum image asset entries emitted from an Office package.
+    /// When null, no image asset entry limit is enforced.
+    /// </summary>
+    public int? MaxOpenXmlImageAssets { get; set; } = DefaultMaxOpenXmlImageAssets;
+
+    /// <summary>
+    /// OpenXML security: maximum placements emitted for one image relationship.
+    /// When null, no per-relationship placement limit is enforced.
+    /// </summary>
+    public int? MaxOpenXmlImagePlacementsPerRelationship { get; set; } = DefaultMaxOpenXmlImagePlacementsPerRelationship;
+
+    /// <summary>
+    /// OpenXML security: maximum bytes read from a single image part.
+    /// When null, no individual image payload limit is enforced.
+    /// </summary>
+    public long? MaxOpenXmlImageAssetBytes { get; set; } = DefaultMaxOpenXmlImageAssetBytes;
+
+    /// <summary>
+    /// OpenXML security: maximum unique image payload bytes retained while extracting assets.
+    /// Repeated placements of the same image part count once toward this limit.
+    /// When null, no total image payload limit is enforced.
+    /// </summary>
+    public long? MaxOpenXmlImageTotalAssetBytes { get; set; } = DefaultMaxOpenXmlImageTotalAssetBytes;
 
     /// <summary>
     /// Maximum characters per emitted chunk (best-effort).

--- a/OfficeIMO.Tests/Reader.DocumentReadResult.Assets.cs
+++ b/OfficeIMO.Tests/Reader.DocumentReadResult.Assets.cs
@@ -3,6 +3,7 @@ using OfficeIMO.Excel;
 using OfficeIMO.PowerPoint;
 using OfficeIMO.Reader;
 using OfficeIMO.Word;
+using System.Reflection;
 using System.Text.Json;
 using Xdr = DocumentFormat.OpenXml.Drawing.Spreadsheet;
 using Xunit;
@@ -280,6 +281,68 @@ public sealed class ReaderDocumentReadResultAssetTests {
         } finally {
             if (File.Exists(path)) File.Delete(path);
         }
+    }
+
+    [Fact]
+    public void DocumentReader_ReadDocument_SharesPayloadForDuplicateExcelRelationshipPlacements() {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+        byte[] png = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==");
+        try {
+            using (ExcelDocument document = ExcelDocument.Create(path)) {
+                ExcelSheet sheet = document.AddWorkSheet("Images");
+                sheet.AddImage(1, 1, png, "image/png", widthPixels: 12, heightPixels: 10, name: "First", altText: "First");
+                sheet.AddImage(3, 1, png, "image/png", widthPixels: 12, heightPixels: 10, name: "Second", altText: "Second");
+                document.Save();
+            }
+            PointSecondExcelPictureAtFirstImageRelationship(path);
+
+            OfficeDocumentReadResult result = DocumentReader.ReadDocument(path);
+
+            OfficeDocumentAsset[] duplicateRelationshipAssets = result.Assets
+                .GroupBy(asset => asset.SourceObjectId, StringComparer.Ordinal)
+                .Single(group => group.Count() == 2)
+                .ToArray();
+            Assert.Same(duplicateRelationshipAssets[0].PayloadBytes, duplicateRelationshipAssets[1].PayloadBytes);
+            Assert.All(duplicateRelationshipAssets, asset => Assert.True(asset.PayloadHashMatches(out _)));
+        } finally {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void DocumentReader_ReadDocument_RejectsDuplicateExcelRelationshipPlacementsAboveLimit() {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+        byte[] png = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==");
+        try {
+            using (ExcelDocument document = ExcelDocument.Create(path)) {
+                ExcelSheet sheet = document.AddWorkSheet("Images");
+                sheet.AddImage(1, 1, png, "image/png", widthPixels: 12, heightPixels: 10, name: "First", altText: "First");
+                sheet.AddImage(3, 1, png, "image/png", widthPixels: 12, heightPixels: 10, name: "Second", altText: "Second");
+                document.Save();
+            }
+            PointSecondExcelPictureAtFirstImageRelationship(path);
+
+            IOException exception = Assert.Throws<IOException>(() => DocumentReader.ReadDocument(
+                path,
+                new ReaderOptions { MaxOpenXmlImagePlacementsPerRelationship = 1 }));
+
+            Assert.Contains("MaxOpenXmlImagePlacementsPerRelationship", exception.Message, StringComparison.Ordinal);
+        } finally {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void DocumentReader_NormalizeOptions_AppliesOpenXmlSafetyDefaultsWhenOptionsAreNull() {
+        MethodInfo method = typeof(DocumentReader).GetMethod("NormalizeOptions", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var normalized = (ReaderOptions)method.Invoke(null, new object?[] { null })!;
+        var defaults = new ReaderOptions();
+
+        Assert.Equal(defaults.OpenXmlMaxCharactersInPart, normalized.OpenXmlMaxCharactersInPart);
+        Assert.Equal(defaults.MaxOpenXmlImageAssets, normalized.MaxOpenXmlImageAssets);
+        Assert.Equal(defaults.MaxOpenXmlImagePlacementsPerRelationship, normalized.MaxOpenXmlImagePlacementsPerRelationship);
+        Assert.Equal(defaults.MaxOpenXmlImageAssetBytes, normalized.MaxOpenXmlImageAssetBytes);
+        Assert.Equal(defaults.MaxOpenXmlImageTotalAssetBytes, normalized.MaxOpenXmlImageTotalAssetBytes);
     }
 
     [Fact]

--- a/OfficeIMO.Tests/Reader.DocumentReadResult.cs
+++ b/OfficeIMO.Tests/Reader.DocumentReadResult.cs
@@ -326,6 +326,26 @@ public sealed class ReaderDocumentReadResultTests {
     }
 
     [Fact]
+    public void DocumentReader_Read_NonSeekableStream_EnforcesMaxInputBytesBeforeSnapshot() {
+        using var package = new MemoryStream();
+        using (WordDocument document = WordDocument.Create(package)) {
+            document.AddParagraph("Large document");
+            document.Save();
+        }
+
+        using var stream = new NonSeekableReadStream(package.ToArray());
+
+        IOException ex = Assert.Throws<IOException>(() => {
+            foreach (ReaderChunk _ in DocumentReader.Read(
+                stream,
+                "large.docx",
+                new ReaderOptions { MaxInputBytes = 16 })) {
+            }
+        });
+        Assert.Contains("Input exceeds MaxInputBytes", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void DocumentReader_ReadDocument_EmitsChunkMetadataForWordDocument() {
         var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".docx");
         try {


### PR DESCRIPTION
## Summary
- add default OpenXML image asset count, placement, per-image byte, and total unique payload byte limits to ReaderOptions
- cache OpenXML image payloads per image part so duplicate placements do not retain duplicate byte arrays
- keep OpenXML safety defaults active for default ReadDocument calls and cover duplicate relationship placement regressions
- enforce MaxInputBytes at the public Read(Stream) boundary before non-seekable input can be snapshotted by hashes, custom stream handlers, or built-in readers

## Validation
- dotnet build .\OfficeIMO.Reader\OfficeIMO.Reader.csproj --framework net8.0
- dotnet build .\OfficeIMO.Reader\OfficeIMO.Reader.csproj --framework net472 --no-restore
- dotnet build .\OfficeIMO.Reader\OfficeIMO.Reader.csproj --framework net10.0 --no-restore
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "DocumentReader_Read_NonSeekableStream_EnforcesMaxInputBytesBeforeSnapshot|DocumentReader_ReadDocument_NonSeekableStream_EnforcesMaxInputBytesBeforeSnapshot|FullyQualifiedName~ReaderDocumentReadResultAssetTests" --no-restore --verbosity quiet
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net472 --filter "DocumentReader_Read_NonSeekableStream_EnforcesMaxInputBytesBeforeSnapshot|DocumentReader_ReadDocument_NonSeekableStream_EnforcesMaxInputBytesBeforeSnapshot|FullyQualifiedName~ReaderDocumentReadResultAssetTests" --no-restore --verbosity quiet
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net10.0 --filter "DocumentReader_Read_NonSeekableStream_EnforcesMaxInputBytesBeforeSnapshot|DocumentReader_ReadDocument_NonSeekableStream_EnforcesMaxInputBytesBeforeSnapshot|FullyQualifiedName~ReaderDocumentReadResultAssetTests" --no-restore --verbosity quiet