### PR TITLE
Harden Word PDF inline chart references

### DIFF
--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.StructuredBlocks.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.StructuredBlocks.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using A = DocumentFormat.OpenXml.Drawing;
+using DW = DocumentFormat.OpenXml.Drawing.Wordprocessing;
 using V = DocumentFormat.OpenXml.Vml;
 using PdfPigDocument = UglyToad.PdfPig.PdfDocument;
 using Xunit;
@@ -1269,6 +1270,37 @@ public partial class Word {
         Assert.Contains("0.184 0.435 0.243 rg", rawPdf, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SaveAsPdf_OfficeIMOEngine_Ignores_Malformed_Inline_Word_Chart_References(bool relationshipPointsToImagePart) {
+        string suffix = relationshipPointsToImagePart ? "WrongPart" : "MissingPart";
+        string docPath = Path.Combine(_directoryWithFiles, $"PdfNativeMalformedInlineWordChart{suffix}.docx");
+        string pdfPath = Path.Combine(_directoryWithFiles, $"PdfNativeMalformedInlineWordChart{suffix}.pdf");
+        const string relationshipId = "rIdMalformedInlineChart";
+        var options = new PdfSaveOptions {
+            IncludePageNumbers = false
+        };
+
+        using (WordDocument document = WordDocument.Create(docPath)) {
+            WordParagraph paragraph = document.AddParagraph("Before malformed inline chart");
+            if (relationshipPointsToImagePart) {
+                AddPngImagePart(document, relationshipId);
+            }
+
+            paragraph._paragraph!.Append(CreateMalformedInlineChartRun(relationshipId));
+            document.AddParagraph("After malformed inline chart");
+
+            document.Save();
+            document.SaveAsPdf(pdfPath, options);
+        }
+
+        Assert.Contains(options.Warnings, warning => warning.Code == "NativeBodyChartUnsupported");
+        string text = PdfTextExtractor.ExtractAllText(pdfPath);
+        Assert.Contains("Before malformed inline chart", text);
+        Assert.Contains("After malformed inline chart", text);
+    }
+
     [Fact]
     public void SaveAsPdf_OfficeIMOEngine_Renders_Word_Pie_DataLabels() {
         string docPath = Path.Combine(_directoryWithFiles, "PdfNativeWordPieDataLabels.docx");
@@ -1299,6 +1331,37 @@ public partial class Word {
         Assert.Contains("1; 100%", text);
         Assert.Contains("0; 0%", text);
         Assert.Contains("After pie labels", text);
+    }
+
+    private static Run CreateMalformedInlineChartRun(string relationshipId) {
+        var chartReference = new ChartReference {
+            Id = relationshipId
+        };
+        chartReference.AddNamespaceDeclaration("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
+        chartReference.AddNamespaceDeclaration("r", "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+
+        return new Run(
+            new Drawing(
+                new DW.Inline(
+                    new DW.Extent {
+                        Cx = 3048000L,
+                        Cy = 1714500L
+                    },
+                    new DW.DocProperties {
+                        Id = 1U,
+                        Name = "malformed chart"
+                    },
+                    new A.Graphic(
+                        new A.GraphicData(chartReference) {
+                            Uri = "http://schemas.openxmlformats.org/drawingml/2006/chart"
+                        }))));
+    }
+
+    private static void AddPngImagePart(WordDocument document, string relationshipId) {
+        ImagePart imagePart = document._wordprocessingDocument.MainDocumentPart!.AddImagePart(ImagePartType.Png, relationshipId);
+        byte[] png = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=");
+        using Stream stream = imagePart.GetStream(FileMode.Create, FileAccess.Write);
+        stream.Write(png, 0, png.Length);
     }
 
     [Fact]

--- a/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.StructuredBlocks.cs
+++ b/OfficeIMO.Tests/Pdf/Word.SaveAsPdf.StructuredBlocks.cs
@@ -1341,7 +1341,7 @@ public partial class Word {
         chartReference.AddNamespaceDeclaration("r", "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
 
         return new Run(
-            new Drawing(
+            new DocumentFormat.OpenXml.Wordprocessing.Drawing(
                 new DW.Inline(
                     new DW.Extent {
                         Cx = 3048000L,

--- a/OfficeIMO.Word/WordChart.Properties.cs
+++ b/OfficeIMO.Word/WordChart.Properties.cs
@@ -50,7 +50,7 @@ namespace OfficeIMO.Word {
                 }
 
                 try {
-                    return _document.MainDocumentPartRoot.GetPartById(id) as ChartPart;
+                    return _document.MainDocumentPartRoot.GetPartById(id!) as ChartPart;
                 } catch (System.ArgumentOutOfRangeException) {
                     return null;
                 } catch (System.InvalidOperationException) {

--- a/OfficeIMO.Word/WordChart.Properties.cs
+++ b/OfficeIMO.Word/WordChart.Properties.cs
@@ -42,9 +42,22 @@ namespace OfficeIMO.Word {
                 if (_drawing == null) {
                     return null;
                 }
+
                 var chartRef = _drawing.Inline?.Graphic?.GraphicData?.GetFirstChild<ChartReference>();
-                var id = chartRef?.Id?.Value;
-                return id != null ? (ChartPart?)_document.MainDocumentPartRoot.GetPartById(id) : null;
+                string? id = chartRef?.Id?.Value;
+                if (string.IsNullOrWhiteSpace(id)) {
+                    return null;
+                }
+
+                try {
+                    return _document.MainDocumentPartRoot.GetPartById(id) as ChartPart;
+                } catch (System.ArgumentOutOfRangeException) {
+                    return null;
+                } catch (System.InvalidOperationException) {
+                    return null;
+                } catch (OpenXmlPackageException) {
+                    return null;
+                }
             }
         }
         private WordDrawing? _drawing;


### PR DESCRIPTION
## Summary
- safely resolve Word chart relationships so malformed or wrong-type chart references are treated as unsupported charts instead of throwing during PDF conversion
- add DOCX/PDF regression coverage for inline chart references that point nowhere or to a non-chart image part

## Tests
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter FullyQualifiedName~SaveAsPdf_OfficeIMOEngine_Ignores_Malformed_Inline_Word_Chart_References --no-restore --verbosity quiet
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~SaveAsPdf_OfficeIMOEngine_Renders_Inline_Word_Charts_After_Text_Run|FullyQualifiedName~SaveAsPdf_OfficeIMOEngine_Renders_Word_Charts_Through_Shared_Renderer" --no-restore --verbosity quiet
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net472 --filter FullyQualifiedName~SaveAsPdf_OfficeIMOEngine_Ignores_Malformed_Inline_Word_Chart_References --no-restore --verbosity quiet
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net10.0 --filter FullyQualifiedName~SaveAsPdf_OfficeIMOEngine_Ignores_Malformed_Inline_Word_Chart_References --no-restore --verbosity quiet