### PR TITLE
Bound HTML image candidate expansion

### DIFF
--- a/OfficeIMO.Html/Images/HtmlImageSourceResolver.cs
+++ b/OfficeIMO.Html/Images/HtmlImageSourceResolver.cs
@@ -26,22 +26,30 @@ public static class HtmlImageSourceResolver {
     /// Resolves all image source candidates from an element in browser-like preference order.
     /// </summary>
     public static IReadOnlyList<string> ResolveImageSourceCandidates(IElement element, Uri? baseUri, HtmlUrlPolicy? policy, bool allowParentPictureFallback = true) {
-        var candidates = new List<string>();
+        return ResolveImageSourceCandidates(element, baseUri, policy, allowParentPictureFallback, null);
+    }
+
+    /// <summary>
+    /// Resolves image source candidates from an element in browser-like preference order, limiting responsive candidates from picture/source-set inputs.
+    /// </summary>
+    public static IReadOnlyList<string> ResolveImageSourceCandidates(IElement element, Uri? baseUri, HtmlUrlPolicy? policy, bool allowParentPictureFallback, int? maxResponsiveCandidates) {
+        var candidates = new CandidateAccumulator();
         if (element == null) {
-            return candidates;
+            return candidates.Items;
         }
 
+        int responsiveCandidateCount = 0;
         if (allowParentPictureFallback
             && element.ParentElement != null
             && element.ParentElement.TagName.Equals("PICTURE", StringComparison.OrdinalIgnoreCase)) {
-            AddRange(candidates, ResolvePictureSourceCandidates(element.ParentElement, baseUri, policy));
+            AddPictureSourceCandidates(candidates, element.ParentElement, baseUri, policy, maxResponsiveCandidates, ref responsiveCandidateCount);
         }
 
         AddResolvedUrlAttributes(candidates, element, baseUri, policy, LazySourceAttributes);
-        AddResolvedSrcSetAttributes(candidates, element, baseUri, policy, SrcSetAttributes);
+        AddResolvedSrcSetAttributes(candidates, element, baseUri, policy, maxResponsiveCandidates, ref responsiveCandidateCount, SrcSetAttributes);
         AddResolvedUrlAttributes(candidates, element, baseUri, policy, SourceAttributes);
 
-        return candidates;
+        return candidates.Items;
     }
 
     /// <summary>
@@ -59,21 +67,34 @@ public static class HtmlImageSourceResolver {
     /// Resolves all source candidates from a <c>picture</c> element.
     /// </summary>
     public static IReadOnlyList<string> ResolvePictureSourceCandidates(IElement pictureElement, Uri? baseUri, HtmlUrlPolicy? policy) {
-        var candidates = new List<string>();
+        return ResolvePictureSourceCandidates(pictureElement, baseUri, policy, null);
+    }
+
+    /// <summary>
+    /// Resolves source candidates from a <c>picture</c> element, stopping after the requested number of responsive candidates.
+    /// </summary>
+    public static IReadOnlyList<string> ResolvePictureSourceCandidates(IElement pictureElement, Uri? baseUri, HtmlUrlPolicy? policy, int? maxCandidates) {
+        var candidates = new CandidateAccumulator();
         if (pictureElement == null) {
-            return candidates;
+            return candidates.Items;
         }
 
+        int candidateCount = 0;
+        AddPictureSourceCandidates(candidates, pictureElement, baseUri, policy, maxCandidates, ref candidateCount);
+        return candidates.Items;
+    }
+
+    private static void AddPictureSourceCandidates(CandidateAccumulator candidates, IElement pictureElement, Uri? baseUri, HtmlUrlPolicy? policy, int? maxCandidates, ref int candidateCount) {
         foreach (var child in pictureElement.Children) {
             if (!child.TagName.Equals("SOURCE", StringComparison.OrdinalIgnoreCase)) {
                 continue;
             }
 
-            AddResolvedSrcSetAttributes(candidates, child, baseUri, policy, SrcSetAttributes);
-            AddResolvedUrlAttributes(candidates, child, baseUri, policy, PictureSourceAttributes);
+            if (!AddResolvedSrcSetAttributes(candidates, child, baseUri, policy, maxCandidates, ref candidateCount, SrcSetAttributes)
+                || !AddResolvedUrlAttributes(candidates, child, baseUri, policy, maxCandidates, ref candidateCount, PictureSourceAttributes)) {
+                return;
+            }
         }
-
-        return candidates;
     }
 
     /// <summary>
@@ -106,12 +127,19 @@ public static class HtmlImageSourceResolver {
     /// Resolves all allowed candidates from a <c>srcset</c> value.
     /// </summary>
     public static IReadOnlyList<HtmlSrcSetCandidate> ResolveSrcSetCandidates(string? rawSrcSet, Uri? baseUri, HtmlUrlPolicy? policy) {
+        return ResolveSrcSetCandidates(rawSrcSet, baseUri, policy, null);
+    }
+
+    /// <summary>
+    /// Resolves allowed candidates from a <c>srcset</c> value, stopping after the requested number of parsed candidates.
+    /// </summary>
+    public static IReadOnlyList<HtmlSrcSetCandidate> ResolveSrcSetCandidates(string? rawSrcSet, Uri? baseUri, HtmlUrlPolicy? policy, int? maxCandidates) {
         var candidates = new List<HtmlSrcSetCandidate>();
-        if (string.IsNullOrWhiteSpace(rawSrcSet)) {
+        if (string.IsNullOrWhiteSpace(rawSrcSet) || IsNonPositiveCandidateLimit(maxCandidates)) {
             return candidates;
         }
 
-        foreach (HtmlSrcSetCandidate candidate in HtmlSrcSetParser.Parse(rawSrcSet)) {
+        foreach (HtmlSrcSetCandidate candidate in HtmlSrcSetParser.Parse(rawSrcSet, maxCandidates)) {
             string resolved = HtmlUrlPolicyEvaluator.ResolveUrl(candidate.Url, baseUri, policy);
             if (!string.IsNullOrWhiteSpace(resolved)) {
                 candidates.Add(new HtmlSrcSetCandidate(resolved, candidate.Descriptor));
@@ -193,46 +221,90 @@ public static class HtmlImageSourceResolver {
         return new HtmlSrcSetCandidate(string.Empty, string.Empty);
     }
 
-    private static void AddResolvedSrcSetAttributes(List<string> candidates, IElement element, Uri? baseUri, HtmlUrlPolicy? policy, params string[] attributeNames) {
+    private static void AddResolvedSrcSetAttributes(CandidateAccumulator candidates, IElement element, Uri? baseUri, HtmlUrlPolicy? policy, params string[] attributeNames) {
+        int candidateCount = 0;
+        AddResolvedSrcSetAttributes(candidates, element, baseUri, policy, null, ref candidateCount, attributeNames);
+    }
+
+    private static bool AddResolvedSrcSetAttributes(CandidateAccumulator candidates, IElement element, Uri? baseUri, HtmlUrlPolicy? policy, int? maxCandidates, ref int candidateCount, params string[] attributeNames) {
         if (element == null || attributeNames == null || attributeNames.Length == 0) {
-            return;
+            return true;
         }
 
         for (int i = 0; i < attributeNames.Length; i++) {
-            foreach (HtmlSrcSetCandidate candidate in ResolveSrcSetCandidates(element.GetAttribute(attributeNames[i]), baseUri, policy)) {
+            int? remaining = GetRemainingCandidateCount(maxCandidates, candidateCount);
+            if (IsNonPositiveCandidateLimit(remaining)) {
+                return false;
+            }
+
+            foreach (HtmlSrcSetCandidate candidate in ResolveSrcSetCandidates(element.GetAttribute(attributeNames[i]), baseUri, policy, remaining)) {
+                candidateCount++;
                 AddCandidate(candidates, candidate.Url);
+                if (IsNonPositiveCandidateLimit(GetRemainingCandidateCount(maxCandidates, candidateCount))) {
+                    return false;
+                }
             }
         }
+
+        return true;
     }
 
-    private static void AddResolvedUrlAttributes(List<string> candidates, IElement element, Uri? baseUri, HtmlUrlPolicy? policy, params string[] attributeNames) {
+    private static void AddResolvedUrlAttributes(CandidateAccumulator candidates, IElement element, Uri? baseUri, HtmlUrlPolicy? policy, params string[] attributeNames) {
+        int candidateCount = 0;
+        AddResolvedUrlAttributes(candidates, element, baseUri, policy, null, ref candidateCount, attributeNames);
+    }
+
+    private static bool AddResolvedUrlAttributes(CandidateAccumulator candidates, IElement element, Uri? baseUri, HtmlUrlPolicy? policy, int? maxCandidates, ref int candidateCount, params string[] attributeNames) {
         if (element == null || attributeNames == null || attributeNames.Length == 0) {
-            return;
+            return true;
         }
 
         for (int i = 0; i < attributeNames.Length; i++) {
-            AddCandidate(candidates, HtmlUrlPolicyEvaluator.ResolveUrl(element.GetAttribute(attributeNames[i]), baseUri, policy));
+            if (IsNonPositiveCandidateLimit(GetRemainingCandidateCount(maxCandidates, candidateCount))) {
+                return false;
+            }
+
+            string resolved = HtmlUrlPolicyEvaluator.ResolveUrl(element.GetAttribute(attributeNames[i]), baseUri, policy);
+            if (!string.IsNullOrWhiteSpace(resolved)) {
+                candidateCount++;
+                AddCandidate(candidates, resolved);
+            }
         }
+
+        return true;
     }
 
-    private static void AddRange(List<string> candidates, IEnumerable<string> sourceItems) {
-        if (sourceItems == null) {
-            return;
+    private static int? GetRemainingCandidateCount(int? maxCandidates, int candidateCount) {
+        if (!maxCandidates.HasValue) {
+            return null;
         }
 
-        foreach (string source in sourceItems) {
-            AddCandidate(candidates, source);
-        }
+        return Math.Max(0, maxCandidates.Value - candidateCount);
     }
 
-    private static void AddCandidate(List<string> candidates, string? source) {
-        if (string.IsNullOrWhiteSpace(source)) {
-            return;
-        }
+    private static bool IsNonPositiveCandidateLimit(int? maxCandidates) {
+        return maxCandidates.HasValue && maxCandidates.Value <= 0;
+    }
 
-        string candidate = source!;
-        if (!candidates.Contains(candidate)) {
-            candidates.Add(candidate);
+    private static void AddCandidate(CandidateAccumulator candidates, string? source) {
+        candidates.Add(source);
+    }
+
+    private sealed class CandidateAccumulator {
+        private readonly List<string> _items = new List<string>();
+        private readonly HashSet<string> _seen = new HashSet<string>(StringComparer.Ordinal);
+
+        internal IReadOnlyList<string> Items => _items;
+
+        internal void Add(string? source) {
+            if (string.IsNullOrWhiteSpace(source)) {
+                return;
+            }
+
+            string candidate = source!;
+            if (_seen.Add(candidate)) {
+                _items.Add(candidate);
+            }
         }
     }
 }

--- a/OfficeIMO.Html/Images/HtmlImageSourceResolver.cs
+++ b/OfficeIMO.Html/Images/HtmlImageSourceResolver.cs
@@ -239,11 +239,8 @@ public static class HtmlImageSourceResolver {
 
             foreach (HtmlSrcSetCandidate candidate in HtmlSrcSetParser.Enumerate(element.GetAttribute(attributeNames[i]))) {
                 string resolved = HtmlUrlPolicyEvaluator.ResolveUrl(candidate.Url, baseUri, policy);
-                if (AddCandidate(candidates, resolved)) {
-                    candidateCount++;
-                } else if (string.IsNullOrWhiteSpace(resolved)) {
-                    candidateCount++;
-                }
+                AddCandidate(candidates, resolved);
+                candidateCount++;
 
                 if (IsNonPositiveCandidateLimit(GetRemainingCandidateCount(maxCandidates, candidateCount))) {
                     return false;
@@ -269,9 +266,19 @@ public static class HtmlImageSourceResolver {
                 return false;
             }
 
-            string resolved = HtmlUrlPolicyEvaluator.ResolveUrl(element.GetAttribute(attributeNames[i]), baseUri, policy);
-            if (AddCandidate(candidates, resolved)) {
+            string? rawValue = element.GetAttribute(attributeNames[i]);
+            if (string.IsNullOrWhiteSpace(rawValue)) {
+                continue;
+            }
+
+            string resolved = HtmlUrlPolicyEvaluator.ResolveUrl(rawValue, baseUri, policy);
+            AddCandidate(candidates, resolved);
+            if (!string.IsNullOrWhiteSpace(rawValue)) {
                 candidateCount++;
+            }
+
+            if (IsNonPositiveCandidateLimit(GetRemainingCandidateCount(maxCandidates, candidateCount))) {
+                return false;
             }
         }
 

--- a/OfficeIMO.Html/Images/HtmlImageSourceResolver.cs
+++ b/OfficeIMO.Html/Images/HtmlImageSourceResolver.cs
@@ -241,6 +241,8 @@ public static class HtmlImageSourceResolver {
                 string resolved = HtmlUrlPolicyEvaluator.ResolveUrl(candidate.Url, baseUri, policy);
                 if (AddCandidate(candidates, resolved)) {
                     candidateCount++;
+                } else if (string.IsNullOrWhiteSpace(resolved)) {
+                    candidateCount++;
                 }
 
                 if (IsNonPositiveCandidateLimit(GetRemainingCandidateCount(maxCandidates, candidateCount))) {

--- a/OfficeIMO.Html/Images/HtmlImageSourceResolver.cs
+++ b/OfficeIMO.Html/Images/HtmlImageSourceResolver.cs
@@ -237,9 +237,12 @@ public static class HtmlImageSourceResolver {
                 return false;
             }
 
-            foreach (HtmlSrcSetCandidate candidate in ResolveSrcSetCandidates(element.GetAttribute(attributeNames[i]), baseUri, policy, remaining)) {
-                candidateCount++;
-                AddCandidate(candidates, candidate.Url);
+            foreach (HtmlSrcSetCandidate candidate in HtmlSrcSetParser.Enumerate(element.GetAttribute(attributeNames[i]))) {
+                string resolved = HtmlUrlPolicyEvaluator.ResolveUrl(candidate.Url, baseUri, policy);
+                if (AddCandidate(candidates, resolved)) {
+                    candidateCount++;
+                }
+
                 if (IsNonPositiveCandidateLimit(GetRemainingCandidateCount(maxCandidates, candidateCount))) {
                     return false;
                 }
@@ -265,9 +268,8 @@ public static class HtmlImageSourceResolver {
             }
 
             string resolved = HtmlUrlPolicyEvaluator.ResolveUrl(element.GetAttribute(attributeNames[i]), baseUri, policy);
-            if (!string.IsNullOrWhiteSpace(resolved)) {
+            if (AddCandidate(candidates, resolved)) {
                 candidateCount++;
-                AddCandidate(candidates, resolved);
             }
         }
 
@@ -286,8 +288,8 @@ public static class HtmlImageSourceResolver {
         return maxCandidates.HasValue && maxCandidates.Value <= 0;
     }
 
-    private static void AddCandidate(CandidateAccumulator candidates, string? source) {
-        candidates.Add(source);
+    private static bool AddCandidate(CandidateAccumulator candidates, string? source) {
+        return candidates.Add(source);
     }
 
     private sealed class CandidateAccumulator {
@@ -296,15 +298,18 @@ public static class HtmlImageSourceResolver {
 
         internal IReadOnlyList<string> Items => _items;
 
-        internal void Add(string? source) {
+        internal bool Add(string? source) {
             if (string.IsNullOrWhiteSpace(source)) {
-                return;
+                return false;
             }
 
             string candidate = source!;
             if (_seen.Add(candidate)) {
                 _items.Add(candidate);
+                return true;
             }
+
+            return false;
         }
     }
 }

--- a/OfficeIMO.Html/Images/HtmlSrcSetParser.cs
+++ b/OfficeIMO.Html/Images/HtmlSrcSetParser.cs
@@ -16,12 +16,31 @@ public static class HtmlSrcSetParser {
     /// </summary>
     public static IReadOnlyList<HtmlSrcSetCandidate> Parse(string? srcSet, int? maxCandidates) {
         var candidates = new List<HtmlSrcSetCandidate>();
+        foreach (HtmlSrcSetCandidate candidate in Enumerate(srcSet, maxCandidates)) {
+            candidates.Add(candidate);
+        }
+
+        return candidates;
+    }
+
+    /// <summary>
+    /// Enumerates a <c>srcset</c> value while preserving candidate descriptors.
+    /// </summary>
+    public static IEnumerable<HtmlSrcSetCandidate> Enumerate(string? srcSet) {
+        return Enumerate(srcSet, null);
+    }
+
+    /// <summary>
+    /// Enumerates a <c>srcset</c> value while preserving candidate descriptors, stopping after the requested number of candidates.
+    /// </summary>
+    public static IEnumerable<HtmlSrcSetCandidate> Enumerate(string? srcSet, int? maxCandidates) {
         if (string.IsNullOrWhiteSpace(srcSet) || IsNonPositiveCandidateLimit(maxCandidates)) {
-            return candidates;
+            yield break;
         }
 
         string value = srcSet!;
         int index = 0;
+        int emittedCandidates = 0;
         while (index < value.Length) {
             SkipWhitespaceAndCommas(value, ref index);
             if (index >= value.Length) {
@@ -48,8 +67,9 @@ public static class HtmlSrcSetParser {
             }
 
             if (trailingCommaCount > 0) {
-                candidates.Add(new HtmlSrcSetCandidate(url, string.Empty));
-                if (HasReachedCandidateLimit(candidates.Count, maxCandidates)) {
+                yield return new HtmlSrcSetCandidate(url, string.Empty);
+                emittedCandidates++;
+                if (HasReachedCandidateLimit(emittedCandidates, maxCandidates)) {
                     break;
                 }
 
@@ -68,13 +88,12 @@ public static class HtmlSrcSetParser {
                 index++;
             }
 
-            candidates.Add(new HtmlSrcSetCandidate(url, descriptor));
-            if (HasReachedCandidateLimit(candidates.Count, maxCandidates)) {
+            yield return new HtmlSrcSetCandidate(url, descriptor);
+            emittedCandidates++;
+            if (HasReachedCandidateLimit(emittedCandidates, maxCandidates)) {
                 break;
             }
         }
-
-        return candidates;
     }
 
     private static bool HasReachedCandidateLimit(int count, int? maxCandidates) {

--- a/OfficeIMO.Html/Images/HtmlSrcSetParser.cs
+++ b/OfficeIMO.Html/Images/HtmlSrcSetParser.cs
@@ -8,8 +8,15 @@ public static class HtmlSrcSetParser {
     /// Parses a <c>srcset</c> value while preserving candidate descriptors.
     /// </summary>
     public static IReadOnlyList<HtmlSrcSetCandidate> Parse(string? srcSet) {
+        return Parse(srcSet, null);
+    }
+
+    /// <summary>
+    /// Parses a <c>srcset</c> value while preserving candidate descriptors, stopping after the requested number of candidates.
+    /// </summary>
+    public static IReadOnlyList<HtmlSrcSetCandidate> Parse(string? srcSet, int? maxCandidates) {
         var candidates = new List<HtmlSrcSetCandidate>();
-        if (string.IsNullOrWhiteSpace(srcSet)) {
+        if (string.IsNullOrWhiteSpace(srcSet) || IsNonPositiveCandidateLimit(maxCandidates)) {
             return candidates;
         }
 
@@ -42,6 +49,10 @@ public static class HtmlSrcSetParser {
 
             if (trailingCommaCount > 0) {
                 candidates.Add(new HtmlSrcSetCandidate(url, string.Empty));
+                if (HasReachedCandidateLimit(candidates.Count, maxCandidates)) {
+                    break;
+                }
+
                 continue;
             }
 
@@ -58,9 +69,20 @@ public static class HtmlSrcSetParser {
             }
 
             candidates.Add(new HtmlSrcSetCandidate(url, descriptor));
+            if (HasReachedCandidateLimit(candidates.Count, maxCandidates)) {
+                break;
+            }
         }
 
         return candidates;
+    }
+
+    private static bool HasReachedCandidateLimit(int count, int? maxCandidates) {
+        return maxCandidates.HasValue && count >= maxCandidates.Value;
+    }
+
+    private static bool IsNonPositiveCandidateLimit(int? maxCandidates) {
+        return maxCandidates.HasValue && maxCandidates.Value <= 0;
     }
 
     private static bool IsCandidateSeparator(string value, int urlStart, int index) {

--- a/OfficeIMO.Tests/ConversionOptions.cs
+++ b/OfficeIMO.Tests/ConversionOptions.cs
@@ -32,6 +32,7 @@ public class ConversionOptionsTests {
         Assert.Equal(16384, options.MaxTotalCssBytes);
         Assert.Equal(10000, options.MaxTableCells);
         Assert.Equal(ImageProcessingMode.EmbedDataUriOnly, options.ImageProcessing);
+        Assert.Equal(32, options.MaxImageSourceCandidates);
         Assert.False(options.AllowDocumentStylesheetLinks);
         Assert.True(options.ValidateImageContentTypes);
         Assert.Contains("image/png", options.AllowedImageContentTypes);
@@ -116,6 +117,7 @@ public class ConversionOptionsTests {
         options.MaxImageBytes = 11;
         options.MaxTotalImageBytes = 22;
         options.MaxRemoteImageCandidateProbes = null;
+        options.MaxImageSourceCandidates = 12;
         options.ValidateImageContentTypes = false;
         options.ValidateStylesheetContentTypes = false;
         options.MaxHtmlNodes = 33;
@@ -169,6 +171,7 @@ public class ConversionOptionsTests {
         Assert.Equal(options.MaxImageBytes, clone.MaxImageBytes);
         Assert.Equal(options.MaxTotalImageBytes, clone.MaxTotalImageBytes);
         Assert.Equal(options.MaxRemoteImageCandidateProbes, clone.MaxRemoteImageCandidateProbes);
+        Assert.Equal(options.MaxImageSourceCandidates, clone.MaxImageSourceCandidates);
         Assert.Equal(options.ValidateImageContentTypes, clone.ValidateImageContentTypes);
         Assert.Equal(options.ValidateStylesheetContentTypes, clone.ValidateStylesheetContentTypes);
         Assert.Equal(options.MaxHtmlNodes, clone.MaxHtmlNodes);

--- a/OfficeIMO.Tests/Html.Core.cs
+++ b/OfficeIMO.Tests/Html.Core.cs
@@ -115,7 +115,7 @@ public sealed class HtmlCoreTests {
     public void HtmlImageSourceResolver_LimitsResponsiveCandidatesAndKeepsImageFallback() {
         var document = HtmlDocumentParser.ParseDocument("""
 <picture>
-  <source srcset="media/one.webp 1x, media/two.webp 2x, media/three.webp 3x">
+  <source srcset="media/one.webp 1x, media/one.webp 2x, media/two.webp 3x, media/three.webp 4x">
   <img src="media/fallback.png" srcset="media/four.webp 4x" alt="Hero">
 </picture>
 """);

--- a/OfficeIMO.Tests/Html.Core.cs
+++ b/OfficeIMO.Tests/Html.Core.cs
@@ -136,6 +136,24 @@ public sealed class HtmlCoreTests {
     }
 
     [Fact]
+    public void HtmlImageSourceResolver_CountsRejectedSrcSetEntriesTowardExpansionLimit() {
+        var document = HtmlDocumentParser.ParseDocument("""
+<img srcset="javascript:alert(1) 1x, javascript:alert(2) 2x, media/good.webp 3x" src="media/fallback.png" alt="Hero">
+""");
+        var image = document.QuerySelector("img")!;
+
+        IReadOnlyList<string> candidates = HtmlImageSourceResolver.ResolveImageSourceCandidates(
+            image,
+            new Uri("https://example.test/gallery/"),
+            HtmlUrlPolicy.CreateOfficeIMOProfile(),
+            allowParentPictureFallback: true,
+            maxResponsiveCandidates: 2);
+
+        var source = Assert.Single(candidates);
+        Assert.Equal("https://example.test/gallery/media/fallback.png", source);
+    }
+
+    [Fact]
     public void HtmlSrcSetParser_CanLimitCandidateExpansion() {
         IReadOnlyList<HtmlSrcSetCandidate> candidates = HtmlSrcSetParser.Parse(
             "one.png 1x, two.png 2x, three.png 3x",

--- a/OfficeIMO.Tests/Html.Core.cs
+++ b/OfficeIMO.Tests/Html.Core.cs
@@ -112,6 +112,42 @@ public sealed class HtmlCoreTests {
     }
 
     [Fact]
+    public void HtmlImageSourceResolver_LimitsResponsiveCandidatesAndKeepsImageFallback() {
+        var document = HtmlDocumentParser.ParseDocument("""
+<picture>
+  <source srcset="media/one.webp 1x, media/two.webp 2x, media/three.webp 3x">
+  <img src="media/fallback.png" srcset="media/four.webp 4x" alt="Hero">
+</picture>
+""");
+        var image = document.QuerySelector("img")!;
+
+        IReadOnlyList<string> candidates = HtmlImageSourceResolver.ResolveImageSourceCandidates(
+            image,
+            new Uri("https://example.test/gallery/"),
+            HtmlUrlPolicy.CreateOfficeIMOProfile(),
+            allowParentPictureFallback: true,
+            maxResponsiveCandidates: 2);
+
+        Assert.Collection(
+            candidates,
+            source => Assert.Equal("https://example.test/gallery/media/one.webp", source),
+            source => Assert.Equal("https://example.test/gallery/media/two.webp", source),
+            source => Assert.Equal("https://example.test/gallery/media/fallback.png", source));
+    }
+
+    [Fact]
+    public void HtmlSrcSetParser_CanLimitCandidateExpansion() {
+        IReadOnlyList<HtmlSrcSetCandidate> candidates = HtmlSrcSetParser.Parse(
+            "one.png 1x, two.png 2x, three.png 3x",
+            maxCandidates: 2);
+
+        Assert.Collection(
+            candidates,
+            candidate => Assert.Equal("one.png", candidate.Url),
+            candidate => Assert.Equal("two.png", candidate.Url));
+    }
+
+    [Fact]
     public void HtmlSrcSetParser_SplitsCommaSeparatedCandidatesWithoutWhitespace() {
         IReadOnlyList<HtmlSrcSetCandidate> candidates = HtmlSrcSetParser.Parse("small.png,large.png 2x");
 

--- a/OfficeIMO.Tests/Html.Core.cs
+++ b/OfficeIMO.Tests/Html.Core.cs
@@ -131,7 +131,6 @@ public sealed class HtmlCoreTests {
         Assert.Collection(
             candidates,
             source => Assert.Equal("https://example.test/gallery/media/one.webp", source),
-            source => Assert.Equal("https://example.test/gallery/media/two.webp", source),
             source => Assert.Equal("https://example.test/gallery/media/fallback.png", source));
     }
 
@@ -148,6 +147,47 @@ public sealed class HtmlCoreTests {
             HtmlUrlPolicy.CreateOfficeIMOProfile(),
             allowParentPictureFallback: true,
             maxResponsiveCandidates: 2);
+
+        var source = Assert.Single(candidates);
+        Assert.Equal("https://example.test/gallery/media/fallback.png", source);
+    }
+
+    [Fact]
+    public void HtmlImageSourceResolver_CountsDuplicateSrcSetEntriesTowardExpansionLimit() {
+        var document = HtmlDocumentParser.ParseDocument("""
+<img srcset="media/one.webp 1x, media/one.webp 2x, media/two.webp 3x" src="media/fallback.png" alt="Hero">
+""");
+        var image = document.QuerySelector("img")!;
+
+        IReadOnlyList<string> candidates = HtmlImageSourceResolver.ResolveImageSourceCandidates(
+            image,
+            new Uri("https://example.test/gallery/"),
+            HtmlUrlPolicy.CreateOfficeIMOProfile(),
+            allowParentPictureFallback: true,
+            maxResponsiveCandidates: 2);
+
+        Assert.Collection(
+            candidates,
+            source => Assert.Equal("https://example.test/gallery/media/one.webp", source),
+            source => Assert.Equal("https://example.test/gallery/media/fallback.png", source));
+    }
+
+    [Fact]
+    public void HtmlImageSourceResolver_CountsRejectedPictureUrlAttributesTowardExpansionLimit() {
+        var document = HtmlDocumentParser.ParseDocument("""
+<picture>
+  <source src="javascript:alert(1)" data-lazy-src="media/good.webp">
+  <img src="media/fallback.png" alt="Hero">
+</picture>
+""");
+        var image = document.QuerySelector("img")!;
+
+        IReadOnlyList<string> candidates = HtmlImageSourceResolver.ResolveImageSourceCandidates(
+            image,
+            new Uri("https://example.test/gallery/"),
+            HtmlUrlPolicy.CreateOfficeIMOProfile(),
+            allowParentPictureFallback: true,
+            maxResponsiveCandidates: 1);
 
         var source = Assert.Single(candidates);
         Assert.Equal("https://example.test/gallery/media/fallback.png", source);

--- a/OfficeIMO.Tests/Html.Images.cs
+++ b/OfficeIMO.Tests/Html.Images.cs
@@ -381,6 +381,39 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void HtmlToWord_ImageSelection_DedupesResponsiveCandidatesBeforeApplyingLimit() {
+            var requested = new List<Uri>();
+            const string validPng = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+            using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(request => {
+                requested.Add(request.RequestUri!);
+                if (request.RequestUri!.AbsolutePath == "/good.png") {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                        Content = new ByteArrayContent(Convert.FromBase64String(validPng)) {
+                            Headers = {
+                                ContentType = new MediaTypeHeaderValue("image/png")
+                            }
+                        }
+                    });
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }));
+            var options = new HtmlToWordOptions {
+                HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed,
+                MaxRemoteImageCandidateProbes = null,
+                MaxImageSourceCandidates = 2
+            };
+            string html = """<img srcset="https://cdn.example.test/missing.png 1x, https://cdn.example.test/missing.png 2x, https://cdn.example.test/good.png 3x" alt="Logo" />""";
+
+            var doc = html.LoadFromHtml(options);
+
+            Assert.Single(doc.Images);
+            Assert.Equal(new[] { "/missing.png", "/good.png" }, requested.Select(uri => uri.AbsolutePath).ToArray());
+            Assert.Empty(options.Diagnostics);
+        }
+
+        [Fact]
         public void HtmlToWord_ImageSelection_AllowsTrustedCallersToProbeAllRemoteCandidates() {
             var requested = new List<Uri>();
             const string validPng = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";

--- a/OfficeIMO.Tests/Html.Images.cs
+++ b/OfficeIMO.Tests/Html.Images.cs
@@ -414,6 +414,71 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void HtmlToWord_ImageSelection_DedupesLazyAndResponsiveCandidatesBeforeProbing() {
+            var requested = new List<Uri>();
+            const string validPng = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+            using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(request => {
+                requested.Add(request.RequestUri!);
+                if (request.RequestUri!.AbsolutePath == "/good.png") {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                        Content = new ByteArrayContent(Convert.FromBase64String(validPng)) {
+                            Headers = {
+                                ContentType = new MediaTypeHeaderValue("image/png")
+                            }
+                        }
+                    });
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }));
+            var options = new HtmlToWordOptions {
+                HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed,
+                MaxRemoteImageCandidateProbes = 2,
+                MaxImageSourceCandidates = 2
+            };
+            string html = """<img data-src="https://cdn.example.test/missing.png" srcset="https://cdn.example.test/missing.png 1x, https://cdn.example.test/good.png 2x" alt="Logo" />""";
+
+            var doc = html.LoadFromHtml(options);
+
+            Assert.Single(doc.Images);
+            Assert.Equal(new[] { "/missing.png", "/good.png" }, requested.Select(uri => uri.AbsolutePath).ToArray());
+            Assert.Empty(options.Diagnostics);
+        }
+
+        [Fact]
+        public void HtmlToWord_ImageSelection_AppliesPolicyBeforeResponsiveCandidateLimit() {
+            var requested = new List<Uri>();
+            const string validPng = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+            using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(request => {
+                requested.Add(request.RequestUri!);
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new ByteArrayContent(Convert.FromBase64String(validPng)) {
+                        Headers = {
+                            ContentType = new MediaTypeHeaderValue("image/png")
+                        }
+                    }
+                });
+            }));
+            var options = new HtmlToWordOptions {
+                HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed,
+                MaxRemoteImageCandidateProbes = null,
+                MaxImageSourceCandidates = 2
+            };
+            options.AllowedImageHosts.Add("cdn.good.test");
+            string html = """<img srcset="https://bad.example.test/one.png 1x, https://bad.example.test/two.png 2x, https://cdn.good.test/good.png 3x" alt="Logo" />""";
+
+            var doc = html.LoadFromHtml(options);
+
+            Assert.Single(doc.Images);
+            var request = Assert.Single(requested);
+            Assert.Equal("cdn.good.test", request.Host);
+            Assert.Equal("/good.png", request.AbsolutePath);
+            Assert.Empty(options.Diagnostics);
+        }
+
+        [Fact]
         public void HtmlToWord_ImageSelection_AllowsTrustedCallersToProbeAllRemoteCandidates() {
             var requested = new List<Uri>();
             const string validPng = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";

--- a/OfficeIMO.Tests/Html.Images.cs
+++ b/OfficeIMO.Tests/Html.Images.cs
@@ -479,6 +479,96 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void HtmlToWord_ImageSelection_PreservesAltTextWhenResponsiveSourcesAreRejected() {
+            var options = new HtmlToWordOptions {
+                ImageProcessing = ImageProcessingMode.Embed
+            };
+            options.AllowedImageHosts.Add("cdn.good.test");
+            string html = """<img srcset="https://blocked.example.test/logo.png 1x" alt="Logo" />""";
+
+            var doc = html.LoadFromHtml(options);
+
+            Assert.Empty(doc.Images);
+            var paragraph = Assert.Single(doc.Paragraphs);
+            Assert.Equal("Logo", paragraph.Text);
+            var diagnostic = Assert.Single(options.Diagnostics);
+            Assert.Equal("ImageResourceRejectedByPolicy", diagnostic.Code);
+        }
+
+        [Fact]
+        public void HtmlToWord_ImageSelection_DoesNotCountAbsentPictureAttributesTowardScanLimit() {
+            var requested = new List<Uri>();
+            const string validPng = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+            using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(request => {
+                requested.Add(request.RequestUri!);
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = new ByteArrayContent(Convert.FromBase64String(validPng)) {
+                        Headers = {
+                            ContentType = new MediaTypeHeaderValue("image/png")
+                        }
+                    }
+                });
+            }));
+            var options = new HtmlToWordOptions {
+                HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed,
+                MaxRemoteImageCandidateProbes = null,
+                MaxImageSourceCandidates = 1
+            };
+            string html = """
+<picture>
+  <source data-lazy-src="https://cdn.example.test/good.png">
+  <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=" alt="Logo" />
+</picture>
+""";
+
+            var doc = html.LoadFromHtml(options);
+
+            Assert.Single(doc.Images);
+            var request = Assert.Single(requested);
+            Assert.Equal("/good.png", request.AbsolutePath);
+            Assert.Empty(options.Diagnostics);
+        }
+
+        [Fact]
+        public void HtmlToWord_ImageSelection_DoesNotLetOverLimitSrcSetSuppressSourceFallback() {
+            var requested = new List<Uri>();
+            const string validPng = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+            using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(request => {
+                requested.Add(request.RequestUri!);
+                if (request.RequestUri!.AbsolutePath == "/fallback.png") {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                        Content = new ByteArrayContent(Convert.FromBase64String(validPng)) {
+                            Headers = {
+                                ContentType = new MediaTypeHeaderValue("image/png")
+                            }
+                        }
+                    });
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }));
+            var options = new HtmlToWordOptions {
+                HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed,
+                MaxRemoteImageCandidateProbes = null,
+                MaxImageSourceCandidates = 1
+            };
+            string html = """
+<picture>
+  <source srcset="https://cdn.example.test/missing.png 1x">
+  <img srcset="https://cdn.example.test/fallback.png 1x" src="https://cdn.example.test/fallback.png" alt="Logo" />
+</picture>
+""";
+
+            var doc = html.LoadFromHtml(options);
+
+            Assert.Single(doc.Images);
+            Assert.Equal(new[] { "/missing.png", "/fallback.png" }, requested.Select(uri => uri.AbsolutePath).ToArray());
+            Assert.Empty(options.Diagnostics);
+        }
+
+        [Fact]
         public void HtmlToWord_ImageSelection_AllowsTrustedCallersToProbeAllRemoteCandidates() {
             var requested = new List<Uri>();
             const string validPng = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";

--- a/OfficeIMO.Tests/Html.Images.cs
+++ b/OfficeIMO.Tests/Html.Images.cs
@@ -357,6 +357,30 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void HtmlToWord_ImageSelection_LimitsResponsiveCandidatesAndUsesSourceFallback() {
+            var requested = new List<Uri>();
+            var path = Path.Combine(AppContext.BaseDirectory, "Images", "EvotecLogo.png");
+            string base64 = Convert.ToBase64String(File.ReadAllBytes(path));
+            using var httpClient = new HttpClient(new FakeHtmlHttpMessageHandler(request => {
+                requested.Add(request.RequestUri!);
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }));
+            var options = new HtmlToWordOptions {
+                HttpClient = httpClient,
+                ImageProcessing = ImageProcessingMode.Embed,
+                MaxRemoteImageCandidateProbes = null,
+                MaxImageSourceCandidates = 2
+            };
+            string html = $"<img srcset=\"https://cdn.example.test/one.png 1x, https://cdn.example.test/two.png 2x, https://cdn.example.test/three.png 3x\" src=\"data:image/png;base64,{base64}\" alt=\"Logo\" />";
+
+            var doc = html.LoadFromHtml(options);
+
+            Assert.Single(doc.Images);
+            Assert.Equal(new[] { "/one.png", "/two.png" }, requested.Select(uri => uri.AbsolutePath).ToArray());
+            Assert.Empty(options.Diagnostics);
+        }
+
+        [Fact]
         public void HtmlToWord_ImageSelection_AllowsTrustedCallersToProbeAllRemoteCandidates() {
             var requested = new List<Uri>();
             const string validPng = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
@@ -16,7 +16,15 @@ namespace OfficeIMO.Word.Html {
 
         private void ProcessImage(IHtmlImageElement img, WordDocument doc, HtmlToWordOptions options, WordParagraph? currentParagraph, WordHeaderFooter? headerFooter) {
             var src = ResolveWordImageSource(img, options);
-            if (string.IsNullOrEmpty(src)) return;
+            if (string.IsNullOrEmpty(src)) {
+                if (HasImageSourceCandidateAttribute(img)) {
+                    string altText = img.AlternativeText ?? string.Empty;
+                    AddDiagnostic(options, "ImageResourceRejectedByPolicy", "Image resource candidates were skipped because their URIs are not allowed by the current image policy.", "responsive image candidates");
+                    InsertAltText(currentParagraph, headerFooter, doc, altText);
+                }
+
+                return;
+            }
             var decl = _inlineParser.ParseDeclaration(img.GetAttribute("style") ?? string.Empty);
             var floatVal = decl.GetPropertyValue("float")?.Trim().ToLowerInvariant();
             var wrap = WrapTextImage.InLineWithText;
@@ -582,7 +590,12 @@ namespace OfficeIMO.Word.Html {
                     yield break;
                 }
 
-                string resolved = HtmlUrlPolicyEvaluator.ResolveUrl(sourceElement.GetAttribute(attributeName), baseUri, ImageSourceResolutionPolicy);
+                string? rawValue = sourceElement.GetAttribute(attributeName);
+                if (string.IsNullOrWhiteSpace(rawValue)) {
+                    continue;
+                }
+
+                string resolved = HtmlUrlPolicyEvaluator.ResolveUrl(rawValue, baseUri, ImageSourceResolutionPolicy);
                 if (!IsResolvedImageCandidateAllowedForEnumeration(resolved, img, options)) {
                     state.TrackRejectedResponsiveCandidate();
                     continue;
@@ -682,11 +695,7 @@ namespace OfficeIMO.Word.Html {
             internal bool TryTrackResponsiveCandidate(string? candidate, out string tracked) {
                 tracked = string.Empty;
                 _scanned++;
-                if (string.IsNullOrWhiteSpace(candidate) || !_seen.Add(candidate!)) {
-                    return false;
-                }
-
-                if (HasReachedLimit) {
+                if (string.IsNullOrWhiteSpace(candidate) || HasReachedLimit || !_seen.Add(candidate!)) {
                     return false;
                 }
 
@@ -708,6 +717,42 @@ namespace OfficeIMO.Word.Html {
             private static long GetResponsiveCandidateScanLimit(int maxCandidates) {
                 return Math.Max((long)maxCandidates, (long)maxCandidates * 4L);
             }
+        }
+
+        private static bool HasImageSourceCandidateAttribute(IHtmlImageElement img) {
+            if (HasAnyAttribute(img, WordImageLazySourceAttributes)
+                || HasAnyAttribute(img, WordImageSrcSetAttributes)
+                || HasAnyAttribute(img, WordImageSourceAttributes)) {
+                return true;
+            }
+
+            if (img.ParentElement == null
+                || !img.ParentElement.TagName.Equals("PICTURE", StringComparison.OrdinalIgnoreCase)) {
+                return false;
+            }
+
+            foreach (var child in img.ParentElement.Children) {
+                if (!child.TagName.Equals("SOURCE", StringComparison.OrdinalIgnoreCase)) {
+                    continue;
+                }
+
+                if (HasAnyAttribute(child, WordImageSrcSetAttributes)
+                    || HasAnyAttribute(child, WordPictureSourceAttributes)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool HasAnyAttribute(AngleSharp.Dom.IElement element, IEnumerable<string> attributeNames) {
+            foreach (string attributeName in attributeNames) {
+                if (!string.IsNullOrWhiteSpace(element.GetAttribute(attributeName))) {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static string ResolveImageSourcePath(string source, IHtmlImageElement img, HtmlToWordOptions options) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
@@ -11,6 +11,8 @@ namespace OfficeIMO.Word.Html {
         private static readonly HtmlUrlPolicy ImageSourceResolutionPolicy = CreateImageSourceResolutionPolicy();
         private static readonly string[] WordImageSrcSetAttributes = { "srcset", "data-srcset", "data-original-srcset", "data-lazy-srcset" };
         private static readonly string[] WordPictureSourceAttributes = { "src", "data-src", "data-original", "data-original-src", "data-lazy-src" };
+        private static readonly string[] WordImageLazySourceAttributes = { "data-src", "data-original", "data-original-src", "data-lazy-src" };
+        private static readonly string[] WordImageSourceAttributes = { "src" };
 
         private void ProcessImage(IHtmlImageElement img, WordDocument doc, HtmlToWordOptions options, WordParagraph? currentParagraph, WordHeaderFooter? headerFooter) {
             var src = ResolveWordImageSource(img, options);
@@ -506,6 +508,7 @@ namespace OfficeIMO.Word.Html {
 
         private static IEnumerable<string> EnumerateWordImageSourceCandidates(IHtmlImageElement img, HtmlToWordOptions options) {
             Uri? baseUri = ResolveImageBaseUri(img, options);
+            int responsiveCandidateCount = 0;
             if (img.ParentElement != null
                 && img.ParentElement.TagName.Equals("PICTURE", StringComparison.OrdinalIgnoreCase)) {
                 foreach (var child in img.ParentElement.Children) {
@@ -517,37 +520,110 @@ namespace OfficeIMO.Word.Html {
                         continue;
                     }
 
-                    foreach (string candidate in ResolveImageCandidatesFromSourceElement(child, baseUri)) {
+                    foreach (string candidate in ResolveImageCandidatesFromSourceElement(child, baseUri, GetRemainingImageSourceCandidateCount(options, responsiveCandidateCount))) {
                         yield return candidate;
+                        responsiveCandidateCount++;
+                        if (IsNonPositiveCandidateLimit(GetRemainingImageSourceCandidateCount(options, responsiveCandidateCount))) {
+                            break;
+                        }
+                    }
+
+                    if (IsNonPositiveCandidateLimit(GetRemainingImageSourceCandidateCount(options, responsiveCandidateCount))) {
+                        break;
                     }
                 }
             }
 
-            foreach (string candidate in HtmlImageSourceResolver.ResolveImageSourceCandidates(
-                         img,
-                         baseUri,
-                         ImageSourceResolutionPolicy,
-                         allowParentPictureFallback: false)) {
+            foreach (string candidate in ResolveImageUrlAttributeCandidates(img, baseUri, WordImageLazySourceAttributes)) {
+                yield return candidate;
+            }
+
+            foreach (string candidate in ResolveImageSrcSetCandidates(img, baseUri, GetRemainingImageSourceCandidateCount(options, responsiveCandidateCount))) {
+                yield return candidate;
+                responsiveCandidateCount++;
+                if (IsNonPositiveCandidateLimit(GetRemainingImageSourceCandidateCount(options, responsiveCandidateCount))) {
+                    break;
+                }
+            }
+
+            foreach (string candidate in ResolveImageUrlAttributeCandidates(img, baseUri, WordImageSourceAttributes)) {
                 yield return candidate;
             }
         }
 
-        private static IEnumerable<string> ResolveImageCandidatesFromSourceElement(AngleSharp.Dom.IElement sourceElement, Uri? baseUri) {
+        private static int? GetRemainingImageSourceCandidateCount(HtmlToWordOptions options, int candidateCount) {
+            if (!options.MaxImageSourceCandidates.HasValue) {
+                return null;
+            }
+
+            return Math.Max(0, options.MaxImageSourceCandidates.Value - candidateCount);
+        }
+
+        private static IEnumerable<string> ResolveImageCandidatesFromSourceElement(AngleSharp.Dom.IElement sourceElement, Uri? baseUri, int? maxCandidates) {
+            int candidateCount = 0;
             foreach (string attributeName in WordImageSrcSetAttributes) {
                 foreach (HtmlSrcSetCandidate candidate in HtmlImageSourceResolver.ResolveSrcSetCandidates(
                              sourceElement.GetAttribute(attributeName),
                              baseUri,
-                             ImageSourceResolutionPolicy)) {
+                             ImageSourceResolutionPolicy,
+                             GetRemainingCandidateCount(maxCandidates, candidateCount))) {
                     yield return candidate.Url;
+                    candidateCount++;
+                    if (IsNonPositiveCandidateLimit(GetRemainingCandidateCount(maxCandidates, candidateCount))) {
+                        yield break;
+                    }
                 }
             }
 
             foreach (string attributeName in WordPictureSourceAttributes) {
+                if (IsNonPositiveCandidateLimit(GetRemainingCandidateCount(maxCandidates, candidateCount))) {
+                    yield break;
+                }
+
                 string resolved = HtmlUrlPolicyEvaluator.ResolveUrl(sourceElement.GetAttribute(attributeName), baseUri, ImageSourceResolutionPolicy);
+                if (!string.IsNullOrWhiteSpace(resolved)) {
+                    yield return resolved;
+                    candidateCount++;
+                }
+            }
+        }
+
+        private static IEnumerable<string> ResolveImageSrcSetCandidates(IHtmlImageElement img, Uri? baseUri, int? maxCandidates) {
+            int candidateCount = 0;
+            foreach (string attributeName in WordImageSrcSetAttributes) {
+                foreach (HtmlSrcSetCandidate candidate in HtmlImageSourceResolver.ResolveSrcSetCandidates(
+                             img.GetAttribute(attributeName),
+                             baseUri,
+                             ImageSourceResolutionPolicy,
+                             GetRemainingCandidateCount(maxCandidates, candidateCount))) {
+                    yield return candidate.Url;
+                    candidateCount++;
+                    if (IsNonPositiveCandidateLimit(GetRemainingCandidateCount(maxCandidates, candidateCount))) {
+                        yield break;
+                    }
+                }
+            }
+        }
+
+        private static IEnumerable<string> ResolveImageUrlAttributeCandidates(IHtmlImageElement img, Uri? baseUri, IEnumerable<string> attributeNames) {
+            foreach (string attributeName in attributeNames) {
+                string resolved = HtmlUrlPolicyEvaluator.ResolveUrl(img.GetAttribute(attributeName), baseUri, ImageSourceResolutionPolicy);
                 if (!string.IsNullOrWhiteSpace(resolved)) {
                     yield return resolved;
                 }
             }
+        }
+
+        private static int? GetRemainingCandidateCount(int? maxCandidates, int candidateCount) {
+            if (!maxCandidates.HasValue) {
+                return null;
+            }
+
+            return Math.Max(0, maxCandidates.Value - candidateCount);
+        }
+
+        private static bool IsNonPositiveCandidateLimit(int? maxCandidates) {
+            return maxCandidates.HasValue && maxCandidates.Value <= 0;
         }
 
         private static string ResolveImageSourcePath(string source, IHtmlImageElement img, HtmlToWordOptions options) {

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
@@ -520,41 +520,50 @@ namespace OfficeIMO.Word.Html {
                         continue;
                     }
 
-                    foreach (string candidate in ResolveImageCandidatesFromSourceElement(child, baseUri, responsiveCandidateState)) {
+                    foreach (string candidate in ResolveImageCandidatesFromSourceElement(child, img, baseUri, options, responsiveCandidateState)) {
                         yield return candidate;
-                        if (responsiveCandidateState.HasReachedLimit) {
+                        if (responsiveCandidateState.HasReachedAnyLimit) {
                             break;
                         }
                     }
 
-                    if (responsiveCandidateState.HasReachedLimit) {
+                    if (responsiveCandidateState.HasReachedAnyLimit) {
                         break;
                     }
                 }
             }
 
-            foreach (string candidate in ResolveImageUrlAttributeCandidates(img, baseUri, WordImageLazySourceAttributes)) {
+            foreach (string candidate in ResolveImageUrlAttributeCandidates(img, baseUri, WordImageLazySourceAttributes, responsiveCandidateState)) {
                 yield return candidate;
             }
 
-            foreach (string candidate in ResolveImageSrcSetCandidates(img, baseUri, responsiveCandidateState)) {
+            foreach (string candidate in ResolveImageSrcSetCandidates(img, baseUri, options, responsiveCandidateState)) {
                 yield return candidate;
-                if (responsiveCandidateState.HasReachedLimit) {
+                if (responsiveCandidateState.HasReachedAnyLimit) {
                     break;
                 }
             }
 
-            foreach (string candidate in ResolveImageUrlAttributeCandidates(img, baseUri, WordImageSourceAttributes)) {
+            foreach (string candidate in ResolveImageUrlAttributeCandidates(img, baseUri, WordImageSourceAttributes, responsiveCandidateState)) {
                 yield return candidate;
             }
         }
 
-        private static IEnumerable<string> ResolveImageCandidatesFromSourceElement(AngleSharp.Dom.IElement sourceElement, Uri? baseUri, ResponsiveImageCandidateState state) {
+        private static IEnumerable<string> ResolveImageCandidatesFromSourceElement(AngleSharp.Dom.IElement sourceElement, IHtmlImageElement img, Uri? baseUri, HtmlToWordOptions options, ResponsiveImageCandidateState state) {
             foreach (string attributeName in WordImageSrcSetAttributes) {
                 foreach (HtmlSrcSetCandidate candidate in HtmlSrcSetParser.Enumerate(sourceElement.GetAttribute(attributeName))) {
                     string resolved = HtmlUrlPolicyEvaluator.ResolveUrl(candidate.Url, baseUri, ImageSourceResolutionPolicy);
-                    if (!state.TryTrack(resolved, out string tracked)) {
-                        if (state.HasReachedLimit) {
+                    if (!IsResolvedImageCandidateAllowedForEnumeration(resolved, img, options)) {
+                        state.TrackRejectedResponsiveCandidate();
+                        if (state.HasReachedScanLimit) {
+                            yield break;
+                        }
+
+                        continue;
+                    }
+
+                    if (!state.TryTrackResponsiveCandidate(resolved, out string tracked)) {
+                        if (state.HasReachedAnyLimit) {
                             yield break;
                         }
 
@@ -562,30 +571,44 @@ namespace OfficeIMO.Word.Html {
                     }
 
                     yield return tracked;
-                    if (state.HasReachedLimit) {
+                    if (state.HasReachedAnyLimit) {
                         yield break;
                     }
                 }
             }
 
             foreach (string attributeName in WordPictureSourceAttributes) {
-                if (state.HasReachedLimit) {
+                if (state.HasReachedAnyLimit) {
                     yield break;
                 }
 
                 string resolved = HtmlUrlPolicyEvaluator.ResolveUrl(sourceElement.GetAttribute(attributeName), baseUri, ImageSourceResolutionPolicy);
-                if (state.TryTrack(resolved, out string tracked)) {
+                if (!IsResolvedImageCandidateAllowedForEnumeration(resolved, img, options)) {
+                    state.TrackRejectedResponsiveCandidate();
+                    continue;
+                }
+
+                if (state.TryTrackResponsiveCandidate(resolved, out string tracked)) {
                     yield return tracked;
                 }
             }
         }
 
-        private static IEnumerable<string> ResolveImageSrcSetCandidates(IHtmlImageElement img, Uri? baseUri, ResponsiveImageCandidateState state) {
+        private static IEnumerable<string> ResolveImageSrcSetCandidates(IHtmlImageElement img, Uri? baseUri, HtmlToWordOptions options, ResponsiveImageCandidateState state) {
             foreach (string attributeName in WordImageSrcSetAttributes) {
                 foreach (HtmlSrcSetCandidate candidate in HtmlSrcSetParser.Enumerate(img.GetAttribute(attributeName))) {
                     string resolved = HtmlUrlPolicyEvaluator.ResolveUrl(candidate.Url, baseUri, ImageSourceResolutionPolicy);
-                    if (!state.TryTrack(resolved, out string tracked)) {
-                        if (state.HasReachedLimit) {
+                    if (!IsResolvedImageCandidateAllowedForEnumeration(resolved, img, options)) {
+                        state.TrackRejectedResponsiveCandidate();
+                        if (state.HasReachedScanLimit) {
+                            yield break;
+                        }
+
+                        continue;
+                    }
+
+                    if (!state.TryTrackResponsiveCandidate(resolved, out string tracked)) {
+                        if (state.HasReachedAnyLimit) {
                             yield break;
                         }
 
@@ -593,26 +616,52 @@ namespace OfficeIMO.Word.Html {
                     }
 
                     yield return tracked;
-                    if (state.HasReachedLimit) {
+                    if (state.HasReachedAnyLimit) {
                         yield break;
                     }
                 }
             }
         }
 
-        private static IEnumerable<string> ResolveImageUrlAttributeCandidates(IHtmlImageElement img, Uri? baseUri, IEnumerable<string> attributeNames) {
+        private static IEnumerable<string> ResolveImageUrlAttributeCandidates(IHtmlImageElement img, Uri? baseUri, IEnumerable<string> attributeNames, ResponsiveImageCandidateState state) {
             foreach (string attributeName in attributeNames) {
                 string resolved = HtmlUrlPolicyEvaluator.ResolveUrl(img.GetAttribute(attributeName), baseUri, ImageSourceResolutionPolicy);
-                if (!string.IsNullOrWhiteSpace(resolved)) {
-                    yield return resolved;
+                if (state.TryTrackFixedCandidate(resolved, out string tracked)) {
+                    yield return tracked;
                 }
             }
+        }
+
+        private static bool IsResolvedImageCandidateAllowedForEnumeration(string? resolved, IHtmlImageElement img, HtmlToWordOptions options) {
+            if (string.IsNullOrWhiteSpace(resolved)) {
+                return false;
+            }
+
+            string source = resolved!;
+            if (options.ImageProcessing == ImageProcessingMode.EmbedDataUriOnly
+                && !source.StartsWith("data:image", StringComparison.OrdinalIgnoreCase)) {
+                return false;
+            }
+
+            if (options.ImageProcessing == ImageProcessingMode.LinkExternal
+                && !source.StartsWith("data:image", StringComparison.OrdinalIgnoreCase)
+                && !HasExternalImageDimensionHints(img)) {
+                return false;
+            }
+
+            if (!IsImageSourceAllowed(source, options, out _)) {
+                return false;
+            }
+
+            return !source.StartsWith("data:", StringComparison.OrdinalIgnoreCase)
+                || source.StartsWith("data:image", StringComparison.OrdinalIgnoreCase);
         }
 
         private sealed class ResponsiveImageCandidateState {
             private readonly HtmlToWordOptions _options;
             private readonly HashSet<string> _seen = new HashSet<string>(StringComparer.Ordinal);
             private int _count;
+            private int _scanned;
 
             internal ResponsiveImageCandidateState(HtmlToWordOptions options) {
                 _options = options;
@@ -621,8 +670,18 @@ namespace OfficeIMO.Word.Html {
             internal bool HasReachedLimit => _options.MaxImageSourceCandidates.HasValue
                 && _count >= _options.MaxImageSourceCandidates.Value;
 
-            internal bool TryTrack(string? candidate, out string tracked) {
+            internal bool HasReachedScanLimit => _options.MaxImageSourceCandidates.HasValue
+                && _scanned >= GetResponsiveCandidateScanLimit(_options.MaxImageSourceCandidates.Value);
+
+            internal bool HasReachedAnyLimit => HasReachedLimit || HasReachedScanLimit;
+
+            internal void TrackRejectedResponsiveCandidate() {
+                _scanned++;
+            }
+
+            internal bool TryTrackResponsiveCandidate(string? candidate, out string tracked) {
                 tracked = string.Empty;
+                _scanned++;
                 if (string.IsNullOrWhiteSpace(candidate) || !_seen.Add(candidate!)) {
                     return false;
                 }
@@ -634,6 +693,20 @@ namespace OfficeIMO.Word.Html {
                 _count++;
                 tracked = candidate!;
                 return true;
+            }
+
+            internal bool TryTrackFixedCandidate(string? candidate, out string tracked) {
+                tracked = string.Empty;
+                if (string.IsNullOrWhiteSpace(candidate) || !_seen.Add(candidate!)) {
+                    return false;
+                }
+
+                tracked = candidate!;
+                return true;
+            }
+
+            private static long GetResponsiveCandidateScanLimit(int maxCandidates) {
+                return Math.Max((long)maxCandidates, (long)maxCandidates * 4L);
             }
         }
 

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Images.cs
@@ -508,7 +508,7 @@ namespace OfficeIMO.Word.Html {
 
         private static IEnumerable<string> EnumerateWordImageSourceCandidates(IHtmlImageElement img, HtmlToWordOptions options) {
             Uri? baseUri = ResolveImageBaseUri(img, options);
-            int responsiveCandidateCount = 0;
+            var responsiveCandidateState = new ResponsiveImageCandidateState(options);
             if (img.ParentElement != null
                 && img.ParentElement.TagName.Equals("PICTURE", StringComparison.OrdinalIgnoreCase)) {
                 foreach (var child in img.ParentElement.Children) {
@@ -520,15 +520,14 @@ namespace OfficeIMO.Word.Html {
                         continue;
                     }
 
-                    foreach (string candidate in ResolveImageCandidatesFromSourceElement(child, baseUri, GetRemainingImageSourceCandidateCount(options, responsiveCandidateCount))) {
+                    foreach (string candidate in ResolveImageCandidatesFromSourceElement(child, baseUri, responsiveCandidateState)) {
                         yield return candidate;
-                        responsiveCandidateCount++;
-                        if (IsNonPositiveCandidateLimit(GetRemainingImageSourceCandidateCount(options, responsiveCandidateCount))) {
+                        if (responsiveCandidateState.HasReachedLimit) {
                             break;
                         }
                     }
 
-                    if (IsNonPositiveCandidateLimit(GetRemainingImageSourceCandidateCount(options, responsiveCandidateCount))) {
+                    if (responsiveCandidateState.HasReachedLimit) {
                         break;
                     }
                 }
@@ -538,10 +537,9 @@ namespace OfficeIMO.Word.Html {
                 yield return candidate;
             }
 
-            foreach (string candidate in ResolveImageSrcSetCandidates(img, baseUri, GetRemainingImageSourceCandidateCount(options, responsiveCandidateCount))) {
+            foreach (string candidate in ResolveImageSrcSetCandidates(img, baseUri, responsiveCandidateState)) {
                 yield return candidate;
-                responsiveCandidateCount++;
-                if (IsNonPositiveCandidateLimit(GetRemainingImageSourceCandidateCount(options, responsiveCandidateCount))) {
+                if (responsiveCandidateState.HasReachedLimit) {
                     break;
                 }
             }
@@ -551,54 +549,51 @@ namespace OfficeIMO.Word.Html {
             }
         }
 
-        private static int? GetRemainingImageSourceCandidateCount(HtmlToWordOptions options, int candidateCount) {
-            if (!options.MaxImageSourceCandidates.HasValue) {
-                return null;
-            }
-
-            return Math.Max(0, options.MaxImageSourceCandidates.Value - candidateCount);
-        }
-
-        private static IEnumerable<string> ResolveImageCandidatesFromSourceElement(AngleSharp.Dom.IElement sourceElement, Uri? baseUri, int? maxCandidates) {
-            int candidateCount = 0;
+        private static IEnumerable<string> ResolveImageCandidatesFromSourceElement(AngleSharp.Dom.IElement sourceElement, Uri? baseUri, ResponsiveImageCandidateState state) {
             foreach (string attributeName in WordImageSrcSetAttributes) {
-                foreach (HtmlSrcSetCandidate candidate in HtmlImageSourceResolver.ResolveSrcSetCandidates(
-                             sourceElement.GetAttribute(attributeName),
-                             baseUri,
-                             ImageSourceResolutionPolicy,
-                             GetRemainingCandidateCount(maxCandidates, candidateCount))) {
-                    yield return candidate.Url;
-                    candidateCount++;
-                    if (IsNonPositiveCandidateLimit(GetRemainingCandidateCount(maxCandidates, candidateCount))) {
+                foreach (HtmlSrcSetCandidate candidate in HtmlSrcSetParser.Enumerate(sourceElement.GetAttribute(attributeName))) {
+                    string resolved = HtmlUrlPolicyEvaluator.ResolveUrl(candidate.Url, baseUri, ImageSourceResolutionPolicy);
+                    if (!state.TryTrack(resolved, out string tracked)) {
+                        if (state.HasReachedLimit) {
+                            yield break;
+                        }
+
+                        continue;
+                    }
+
+                    yield return tracked;
+                    if (state.HasReachedLimit) {
                         yield break;
                     }
                 }
             }
 
             foreach (string attributeName in WordPictureSourceAttributes) {
-                if (IsNonPositiveCandidateLimit(GetRemainingCandidateCount(maxCandidates, candidateCount))) {
+                if (state.HasReachedLimit) {
                     yield break;
                 }
 
                 string resolved = HtmlUrlPolicyEvaluator.ResolveUrl(sourceElement.GetAttribute(attributeName), baseUri, ImageSourceResolutionPolicy);
-                if (!string.IsNullOrWhiteSpace(resolved)) {
-                    yield return resolved;
-                    candidateCount++;
+                if (state.TryTrack(resolved, out string tracked)) {
+                    yield return tracked;
                 }
             }
         }
 
-        private static IEnumerable<string> ResolveImageSrcSetCandidates(IHtmlImageElement img, Uri? baseUri, int? maxCandidates) {
-            int candidateCount = 0;
+        private static IEnumerable<string> ResolveImageSrcSetCandidates(IHtmlImageElement img, Uri? baseUri, ResponsiveImageCandidateState state) {
             foreach (string attributeName in WordImageSrcSetAttributes) {
-                foreach (HtmlSrcSetCandidate candidate in HtmlImageSourceResolver.ResolveSrcSetCandidates(
-                             img.GetAttribute(attributeName),
-                             baseUri,
-                             ImageSourceResolutionPolicy,
-                             GetRemainingCandidateCount(maxCandidates, candidateCount))) {
-                    yield return candidate.Url;
-                    candidateCount++;
-                    if (IsNonPositiveCandidateLimit(GetRemainingCandidateCount(maxCandidates, candidateCount))) {
+                foreach (HtmlSrcSetCandidate candidate in HtmlSrcSetParser.Enumerate(img.GetAttribute(attributeName))) {
+                    string resolved = HtmlUrlPolicyEvaluator.ResolveUrl(candidate.Url, baseUri, ImageSourceResolutionPolicy);
+                    if (!state.TryTrack(resolved, out string tracked)) {
+                        if (state.HasReachedLimit) {
+                            yield break;
+                        }
+
+                        continue;
+                    }
+
+                    yield return tracked;
+                    if (state.HasReachedLimit) {
                         yield break;
                     }
                 }
@@ -614,16 +609,32 @@ namespace OfficeIMO.Word.Html {
             }
         }
 
-        private static int? GetRemainingCandidateCount(int? maxCandidates, int candidateCount) {
-            if (!maxCandidates.HasValue) {
-                return null;
+        private sealed class ResponsiveImageCandidateState {
+            private readonly HtmlToWordOptions _options;
+            private readonly HashSet<string> _seen = new HashSet<string>(StringComparer.Ordinal);
+            private int _count;
+
+            internal ResponsiveImageCandidateState(HtmlToWordOptions options) {
+                _options = options;
             }
 
-            return Math.Max(0, maxCandidates.Value - candidateCount);
-        }
+            internal bool HasReachedLimit => _options.MaxImageSourceCandidates.HasValue
+                && _count >= _options.MaxImageSourceCandidates.Value;
 
-        private static bool IsNonPositiveCandidateLimit(int? maxCandidates) {
-            return maxCandidates.HasValue && maxCandidates.Value <= 0;
+            internal bool TryTrack(string? candidate, out string tracked) {
+                tracked = string.Empty;
+                if (string.IsNullOrWhiteSpace(candidate) || !_seen.Add(candidate!)) {
+                    return false;
+                }
+
+                if (HasReachedLimit) {
+                    return false;
+                }
+
+                _count++;
+                tracked = candidate!;
+                return true;
+            }
         }
 
         private static string ResolveImageSourcePath(string source, IHtmlImageElement img, HtmlToWordOptions options) {

--- a/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
+++ b/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
@@ -172,6 +172,13 @@ namespace OfficeIMO.Word.Html {
         public int? MaxRemoteImageCandidateProbes { get; set; } = 1;
 
         /// <summary>
+        /// Optional maximum number of responsive image candidates considered from <c>picture</c> and <c>srcset</c> inputs per image element.
+        /// The direct <c>img src</c> fallback is still considered after this limit. Defaults to 32 candidates.
+        /// Set to <see langword="null"/> to restore unbounded candidate expansion for trusted HTML.
+        /// </summary>
+        public int? MaxImageSourceCandidates { get; set; } = 32;
+
+        /// <summary>
         /// When true, validates declared image content types for remote image resources and data URI images.
         /// Images with rejected content types are skipped, alt text is inserted when available, and a diagnostic is emitted.
         /// </summary>
@@ -371,6 +378,7 @@ namespace OfficeIMO.Word.Html {
                 MaxImageBytes = MaxImageBytes,
                 MaxTotalImageBytes = MaxTotalImageBytes,
                 MaxRemoteImageCandidateProbes = MaxRemoteImageCandidateProbes,
+                MaxImageSourceCandidates = MaxImageSourceCandidates,
                 ValidateImageContentTypes = ValidateImageContentTypes,
                 ValidateStylesheetContentTypes = ValidateStylesheetContentTypes,
                 MaxHtmlNodes = MaxHtmlNodes,


### PR DESCRIPTION
## Summary
- cap responsive HTML image candidates considered from picture/source-set inputs during Word HTML conversion
- add bounded shared srcset/image-source resolver overloads and set-backed candidate dedupe to avoid list-amplification work
- preserve direct img src fallback after responsive candidate limits so legitimate fallback images still import

## Validation
- dotnet restore .\OfficeIMO.Tests\OfficeIMO.Tests.csproj
- dotnet build .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --configuration Debug --framework net8.0 --no-restore
- dotnet vstest .\OfficeIMO.Tests\bin\Debug\net8.0\OfficeIMO.Tests.dll --TestCaseFilter:"FullyQualifiedName~OfficeIMO.Tests.HtmlCoreTests"
- dotnet vstest .\OfficeIMO.Tests\bin\Debug\net8.0\OfficeIMO.Tests.dll --TestCaseFilter:"FullyQualifiedName~HtmlToWord_ImageSelection"
- dotnet vstest .\OfficeIMO.Tests\bin\Debug\net8.0\OfficeIMO.Tests.dll --TestCaseFilter:"FullyQualifiedName~HtmlToWordOptions_"
- dotnet build .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --configuration Debug --framework net472 --no-restore
- dotnet vstest .\OfficeIMO.Tests\bin\Debug\net472\OfficeIMO.Tests.dll --TestCaseFilter:"FullyQualifiedName~HtmlImageSourceResolver_LimitsResponsiveCandidatesAndKeepsImageFallback|FullyQualifiedName~HtmlSrcSetParser_CanLimitCandidateExpansion"
- dotnet vstest .\OfficeIMO.Tests\bin\Debug\net472\OfficeIMO.Tests.dll --TestCaseFilter:"FullyQualifiedName~HtmlToWord_ImageSelection_LimitsResponsiveCandidatesAndUsesSourceFallback"