### PR TITLE
Bound chart number format parsing

### DIFF
--- a/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Text.cs
+++ b/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Text.cs
@@ -535,12 +535,13 @@ public static partial class OfficeChartDrawingRenderer {
         formatted = null;
         if (string.IsNullOrWhiteSpace(numberFormat) ||
             string.Equals(numberFormat, "General", StringComparison.OrdinalIgnoreCase) ||
+            numberFormat!.Length > OfficeChartLayout.MaxNumberFormatLength ||
             double.IsNaN(value) ||
             double.IsInfinity(value)) {
             return false;
         }
 
-        string format = SelectSignedNumberFormatSection(numberFormat!, value);
+        string format = SelectSignedNumberFormatSection(numberFormat, value);
 
         if (format.Length == 0) {
             return false;
@@ -552,7 +553,7 @@ public static partial class OfficeChartDrawingRenderer {
         int requiredDecimals = GetDataLabelRequiredDecimalPlaces(format);
         int scalingCommas = GetDataLabelScalingCommaCount(format);
         double displayValue = (percent ? value * 100D : value) / Math.Pow(1000D, scalingCommas);
-        bool useAbsoluteNegative = displayValue < 0D && numberFormat!.IndexOf(';') >= 0;
+        bool useAbsoluteNegative = displayValue < 0D && numberFormat.IndexOf(';') >= 0;
         string numericFormat = (grouped ? "N" : "F") + decimals.ToString(CultureInfo.InvariantCulture);
         formatted = (useAbsoluteNegative ? Math.Abs(displayValue) : displayValue).ToString(numericFormat, CultureInfo.InvariantCulture);
         formatted = TrimOptionalDataLabelDecimals(formatted, requiredDecimals);

--- a/OfficeIMO.Drawing/OfficeChartLayout.cs
+++ b/OfficeIMO.Drawing/OfficeChartLayout.cs
@@ -8,6 +8,8 @@ namespace OfficeIMO.Drawing;
 /// Reusable chart layout metadata shared by OfficeIMO chart renderers and format exporters.
 /// </summary>
 public sealed class OfficeChartLayout {
+    internal const int MaxNumberFormatLength = 1024;
+
     private static readonly OfficeChartLayout DefaultLayout = new OfficeChartLayout();
 
     /// <summary>
@@ -243,11 +245,11 @@ public sealed class OfficeChartLayout {
         DataLabelSeparator = string.IsNullOrEmpty(dataLabelSeparator) ? "; " : dataLabelSeparator!;
         DataLabelFontSize = ValidatePositiveFinite(dataLabelFontSize ?? 7D, nameof(dataLabelFontSize));
         DataLabelPosition = dataLabelPosition;
-        DataLabelNumberFormat = string.IsNullOrWhiteSpace(dataLabelNumberFormat) ? null : dataLabelNumberFormat;
+        DataLabelNumberFormat = NormalizeNumberFormat(dataLabelNumberFormat);
         ShowMarkers = showMarkers;
-        AxisNumberFormat = string.IsNullOrWhiteSpace(axisNumberFormat) ? null : axisNumberFormat;
-        HorizontalAxisNumberFormat = string.IsNullOrWhiteSpace(horizontalAxisNumberFormat) ? AxisNumberFormat : horizontalAxisNumberFormat;
-        VerticalAxisNumberFormat = string.IsNullOrWhiteSpace(verticalAxisNumberFormat) ? AxisNumberFormat : verticalAxisNumberFormat;
+        AxisNumberFormat = NormalizeNumberFormat(axisNumberFormat);
+        HorizontalAxisNumberFormat = string.IsNullOrWhiteSpace(horizontalAxisNumberFormat) ? AxisNumberFormat : NormalizeNumberFormat(horizontalAxisNumberFormat);
+        VerticalAxisNumberFormat = string.IsNullOrWhiteSpace(verticalAxisNumberFormat) ? AxisNumberFormat : NormalizeNumberFormat(verticalAxisNumberFormat);
         CategoryAxisTitle = string.IsNullOrWhiteSpace(categoryAxisTitle) ? null : categoryAxisTitle;
         ValueAxisTitle = string.IsNullOrWhiteSpace(valueAxisTitle) ? null : valueAxisTitle;
         ConnectScatterPoints = connectScatterPoints;
@@ -419,5 +421,14 @@ public sealed class OfficeChartLayout {
         }
 
         return value;
+    }
+
+    private static string? NormalizeNumberFormat(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        string normalized = value!.Trim();
+        return normalized.Length <= MaxNumberFormatLength ? normalized : null;
     }
 }

--- a/OfficeIMO.Tests/Pdf/PdfDocumentChartDrawingTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentChartDrawingTests.cs
@@ -490,12 +490,39 @@ public class PdfDocumentChartDrawingTests {
     [Fact]
     public void FlowDrawing_IgnoresBracketDirectivesInDataLabelNumberFormatsLinearly() {
         MethodInfo method = typeof(OfficeChartDrawingRenderer).GetMethod("FormatDataLabelValue", BindingFlags.NonPublic | BindingFlags.Static)!;
-        string unmatchedPrefixFormat = new string('[', 4096) + "0";
+        string unmatchedPrefixFormat = new string('[', 512) + "0";
         string directivePrefix = (string)method.Invoke(null, new object?[] { 123D, "[Red]$0" })!;
         string unmatchedPrefix = (string)method.Invoke(null, new object?[] { 123D, unmatchedPrefixFormat })!;
 
         Assert.Equal("$123", directivePrefix);
-        Assert.Equal(new string('[', 4096) + "123", unmatchedPrefix);
+        Assert.Equal(new string('[', 512) + "123", unmatchedPrefix);
+    }
+
+    [Fact]
+    public void FlowDrawing_DropsOversizedChartNumberFormatsFromLayout() {
+        string oversized = "\"" + new string('x', 2048) + "\"0";
+
+        var layout = new OfficeChartLayout(
+            dataLabelNumberFormat: oversized,
+            axisNumberFormat: oversized,
+            horizontalAxisNumberFormat: oversized,
+            verticalAxisNumberFormat: oversized);
+
+        Assert.Null(layout.DataLabelNumberFormat);
+        Assert.Null(layout.AxisNumberFormat);
+        Assert.Null(layout.HorizontalAxisNumberFormat);
+        Assert.Null(layout.VerticalAxisNumberFormat);
+    }
+
+    [Fact]
+    public void FlowDrawing_FallsBackForOversizedChartNumberFormatsBeforeParsingAffixes() {
+        MethodInfo method = typeof(OfficeChartDrawingRenderer).GetMethod("FormatDataLabelValue", BindingFlags.NonPublic | BindingFlags.Static)!;
+        string oversized = "\"" + new string('x', 2048) + "\"0";
+
+        string formatted = (string)method.Invoke(null, new object?[] { 123D, oversized })!;
+
+        Assert.Equal("123", formatted);
+        Assert.DoesNotContain("x", formatted);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- cap shared chart number-format strings before storing them in OfficeChartLayout
- make the shared chart formatter fall back before parsing oversized format affixes
- add regression coverage for bounded layout formats and oversized formatter fallback

## Validation
- dotnet restore .\OfficeIMO.Tests\OfficeIMO.Tests.csproj
- dotnet build .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --configuration Debug --framework net8.0 --no-restore -v minimal
- dotnet vstest .\OfficeIMO.Tests\bin\Debug\net8.0\OfficeIMO.Tests.dll --TestCaseFilter:"FullyQualifiedName~PdfDocumentChartDrawingTests"
- dotnet build .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --configuration Debug --framework net472 --no-restore -v minimal
- dotnet build .\OfficeIMO.Drawing\OfficeIMO.Drawing.csproj --configuration Release --framework netstandard2.0 --no-restore -v minimal
- dotnet vstest .\OfficeIMO.Tests\bin\Debug\net472\OfficeIMO.Tests.dll --TestCaseFilter:"FullyQualifiedName~PdfDocumentChartDrawingTests"