### PR TITLE
Harden Markdown native syntax indexing

### DIFF
--- a/OfficeIMO.Markdown/Reader/Syntax/MarkdownSyntaxNode.cs
+++ b/OfficeIMO.Markdown/Reader/Syntax/MarkdownSyntaxNode.cs
@@ -4,6 +4,8 @@ namespace OfficeIMO.Markdown;
 /// A lightweight syntax-tree node built from the parsed markdown document.
 /// </summary>
 public sealed class MarkdownSyntaxNode {
+    private int _indexInParent = -1;
+
     /// <summary>Node kind.</summary>
     public MarkdownSyntaxKind Kind { get; }
     /// <summary>Optional source span from the original markdown.</summary>
@@ -21,7 +23,7 @@ public sealed class MarkdownSyntaxNode {
     /// <summary>Whether this node behaves like a block/container boundary for navigation.</summary>
     public bool IsBlockLike => IsBlockLikeKind(Kind);
     /// <summary>Zero-based child index within <see cref="Parent"/> when available.</summary>
-    public int IndexInParent => Parent == null ? -1 : Parent.IndexOfChild(this);
+    public int IndexInParent => _indexInParent;
     /// <summary>Nearest previous sibling node when present.</summary>
     public MarkdownSyntaxNode? PreviousSibling => Parent == null ? null : Parent.GetChildOrNull(IndexInParent - 1);
     /// <summary>Nearest next sibling node when present.</summary>
@@ -44,7 +46,7 @@ public sealed class MarkdownSyntaxNode {
         AssociatedObject = associatedObject;
         Children = children ?? Array.Empty<MarkdownSyntaxNode>();
         for (int i = 0; i < Children.Count; i++) {
-            Children[i]?.AttachToParent(this);
+            Children[i]?.AttachToParent(this, i);
         }
     }
 
@@ -293,18 +295,9 @@ public sealed class MarkdownSyntaxNode {
         }
     }
 
-    private void AttachToParent(MarkdownSyntaxNode parent) {
+    private void AttachToParent(MarkdownSyntaxNode parent, int index) {
         Parent = parent;
-    }
-
-    private int IndexOfChild(MarkdownSyntaxNode child) {
-        for (int i = 0; i < Children.Count; i++) {
-            if (ReferenceEquals(Children[i], child)) {
-                return i;
-            }
-        }
-
-        return -1;
+        _indexInParent = index;
     }
 
     private MarkdownSyntaxNode? GetChildOrNull(int index) =>

--- a/OfficeIMO.Tests/Markdown/Markdown_Native_Document_Tests.cs
+++ b/OfficeIMO.Tests/Markdown/Markdown_Native_Document_Tests.cs
@@ -35,7 +35,7 @@ Inside details
         var reparsed = MarkdownNativeDocument.Parse(markdown);
 
         Assert.Equal(MarkdownNativeDocumentSourceKind.ReaderInput, native.SourceKind);
-        Assert.Equal(markdown, native.SourceMarkdown);
+        Assert.Equal(NormalizeLineEndings(markdown), native.SourceMarkdown);
         Assert.Equal(
             native.Blocks.Select(block => block.Id).ToArray(),
             reparsed.Blocks.Select(block => block.Id).ToArray());
@@ -305,6 +305,23 @@ Paragraph with `code` and ![Alt](img.png "Img").
     }
 
     [Fact]
+    public void SyntaxNode_IndexInParent_Does_Not_Rescan_Wide_Sibling_Lists() {
+        var childArray = Enumerable.Range(0, 2048)
+            .Select(_ => new MarkdownSyntaxNode(MarkdownSyntaxKind.InlineText, literal: "x"))
+            .ToArray();
+        var children = new CountingReadOnlyList<MarkdownSyntaxNode>(childArray);
+
+        _ = new MarkdownSyntaxNode(MarkdownSyntaxKind.Paragraph, children: children);
+        children.ResetIndexerReads();
+
+        for (var i = 0; i < childArray.Length; i++) {
+            Assert.Equal(i, childArray[i].IndexInParent);
+        }
+
+        Assert.Equal(0, children.IndexerReads);
+    }
+
+    [Fact]
     public void Parse_Exposes_Visual_Payload_Hints_Without_Json_Dependency() {
         var options = new MarkdownReaderOptions();
         options.DocumentTransforms.Add(new MarkdownJsonVisualCodeBlockTransform(MarkdownVisualFenceLanguageMode.IntelligenceXAliasFence));
@@ -479,6 +496,35 @@ ix:cached-tool-evidence:v1
             clone.Add(new ParagraphBlock(new InlineSequence().Text("Same")));
             clone.Add(new ParagraphBlock(new InlineSequence().Text("Same")));
             return clone;
+        }
+    }
+
+    private static string NormalizeLineEndings(string value) => value.Replace("\r\n", "\n");
+
+    private sealed class CountingReadOnlyList<T> : IReadOnlyList<T> {
+        private readonly IReadOnlyList<T> _items;
+
+        internal CountingReadOnlyList(IReadOnlyList<T> items) {
+            _items = items;
+        }
+
+        internal int IndexerReads { get; private set; }
+
+        public int Count => _items.Count;
+
+        public T this[int index] {
+            get {
+                IndexerReads++;
+                return _items[index];
+            }
+        }
+
+        public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        internal void ResetIndexerReads() {
+            IndexerReads = 0;
         }
     }
 }


### PR DESCRIPTION
## Summary
- cache Markdown syntax node child indexes when parent links are assigned
- avoid repeated sibling scans during native Markdown block/inline ID path construction
- make the native document source assertion line-ending independent for Windows validation

## Validation
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~Markdown_Native_Document_Tests"
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net472 --filter "FullyQualifiedName~Markdown_Native_Document_Tests"