### PR TITLE
Harden PowerPoint package XML loading

### DIFF
--- a/OfficeIMO.PowerPoint/PowerPointPresentation.Themes.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.Themes.cs
@@ -271,7 +271,7 @@ namespace OfficeIMO.PowerPoint {
         }
 
         private static void AddTableStylesFromStream(List<PowerPointTableStyleInfo> styles, ISet<string> seenStyleIds, Stream stream) {
-            XDocument document = XDocument.Load(stream);
+            XDocument document = PowerPointXmlReader.LoadPackagePartXml(stream);
             XElement? root = document.Root;
             if (root == null) {
                 return;

--- a/OfficeIMO.PowerPoint/PowerPointSmartArt.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSmartArt.cs
@@ -87,7 +87,7 @@ namespace OfficeIMO.PowerPoint {
 
         private static XDocument LoadDiagramXDocument(DiagramDataPart dataPart) {
             using Stream stream = dataPart.GetStream(FileMode.Open, FileAccess.Read);
-            return XDocument.Load(stream);
+            return PowerPointXmlReader.LoadPackagePartXml(stream);
         }
 
         private static void SaveDiagramData(DiagramDataPart dataPart, XDocument xdoc) {

--- a/OfficeIMO.PowerPoint/PowerPointTable.Styles.cs
+++ b/OfficeIMO.PowerPoint/PowerPointTable.Styles.cs
@@ -135,7 +135,7 @@ namespace OfficeIMO.PowerPoint {
         }
 
         private static string? ResolveStyleIdFromXml(string styleName, StringComparison comparison, Stream stream) {
-            XDocument document = XDocument.Load(stream);
+            XDocument document = PowerPointXmlReader.LoadPackagePartXml(stream);
             XElement? root = document.Root;
             if (root == null) {
                 return null;

--- a/OfficeIMO.PowerPoint/PowerPointXmlReader.cs
+++ b/OfficeIMO.PowerPoint/PowerPointXmlReader.cs
@@ -1,0 +1,19 @@
+using System.Xml;
+using System.Xml.Linq;
+
+namespace OfficeIMO.PowerPoint;
+
+internal static class PowerPointXmlReader {
+    internal const long MaximumPackageXmlCharacters = 16L * 1024L * 1024L;
+
+    private static readonly XmlReaderSettings PackageXmlReaderSettings = new() {
+        DtdProcessing = DtdProcessing.Prohibit,
+        XmlResolver = null,
+        MaxCharactersInDocument = MaximumPackageXmlCharacters
+    };
+
+    internal static XDocument LoadPackagePartXml(Stream stream, LoadOptions options = LoadOptions.None) {
+        using XmlReader reader = XmlReader.Create(stream, PackageXmlReaderSettings);
+        return XDocument.Load(reader, options);
+    }
+}

--- a/OfficeIMO.Tests/PowerPoint.Tables.cs
+++ b/OfficeIMO.Tests/PowerPoint.Tables.cs
@@ -4,6 +4,10 @@ using System.IO;
 
 using System.Linq;
 
+using System.Text;
+
+using System.Xml;
+
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Validation;
@@ -155,6 +159,22 @@ namespace OfficeIMO.Tests {
             }
 
             File.Delete(filePath);
+        }
+
+        [Fact]
+        public void PowerPointPackageXmlReader_RejectsDtdPackageXml() {
+            byte[] xml = Encoding.UTF8.GetBytes("""
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE a:tblStyleLst [
+  <!ENTITY expand "blocked">
+]>
+<a:tblStyleLst xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" def="{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}">
+  <a:tblStyle styleId="{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}" styleName="&expand;" />
+</a:tblStyleLst>
+""");
+            using var stream = new MemoryStream(xml);
+
+            Assert.Throws<XmlException>(() => PowerPointXmlReader.LoadPackagePartXml(stream));
         }
 
         [Fact]


### PR DESCRIPTION
This hardens PowerPoint package XML reads by routing table-style and SmartArt XML through a shared secure XML reader.

Changes:
- Adds an internal PowerPoint package XML loader with DTD processing prohibited, no XML resolver, and a 16 MB document character cap.
- Uses the loader for table style enumeration, table style lookup, and SmartArt diagram data reads.
- Adds a regression test proving DTD/entity-bearing package XML is rejected before interpretation.

Validation:
- `dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~PowerPointTables"`
- `dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net472 --filter "FullyQualifiedName~PowerPointTables"`