### PR TITLE
Improve Excel preflight and report evidence

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -11,9 +11,9 @@
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <!-- Examples are executable documentation. Keep samples focused on API usage rather than nullable ceremony. -->
+  <!-- Examples are executable documentation. Keep nullable enabled so annotated samples do not emit CS8632 noise. -->
   <PropertyGroup Condition="'$(MSBuildProjectName)' == 'OfficeIMO.Examples'">
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <Nullable>disable</Nullable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>

--- a/Docs/officeimo.excel.large-workbook-guidance.md
+++ b/Docs/officeimo.excel.large-workbook-guidance.md
@@ -43,6 +43,20 @@ formulas.EnsureAllHaveCachedResults();
 
 Use `EnsureNoAdvancedFeatures()` only for workflows that must avoid preserve-only package content such as custom XML, macros, slicers, timelines, embedded packages, or external workbook relationships.
 
+For workflow routing, prefer the capability preflight API over ad hoc feature-name checks:
+
+```csharp
+ExcelFeatureReport features = document.InspectFeatures();
+
+features.EnsureCan(ExcelPreflightCapability.EditCellValues);
+
+if (!features.Can(ExcelPreflightCapability.ExportPdfReport)) {
+    File.WriteAllText("excel-preflight.md", features.ToMarkdown());
+}
+```
+
+`ExcelPreflightCapability` covers readback, cell-value edits, structure-changing edits, cached formula reads, OfficeIMO formula calculation, template binding, and first-party PDF report export. This is intentionally separate from benchmark guidance and does not require benchmark runs in CI.
+
 ## Measuring A Change
 
 Use the benchmark harness for repeatable local evidence:

--- a/OfficeIMO.Drawing/OfficeImagePdfCompatibility.cs
+++ b/OfficeIMO.Drawing/OfficeImagePdfCompatibility.cs
@@ -1,0 +1,150 @@
+namespace OfficeIMO.Drawing {
+    /// <summary>
+    /// Validates image bytes against the lightweight image constraints used by first-party PDF export preflight checks.
+    /// </summary>
+    public static class OfficeImagePdfCompatibility {
+        private static readonly byte[] PngSignature = { 137, 80, 78, 71, 13, 10, 26, 10 };
+
+        /// <summary>
+        /// Returns true when the image bytes are JPEG or structurally valid PNG bytes suitable for first-party PDF export.
+        /// </summary>
+        public static bool TryValidate(byte[] bytes, out OfficeImageInfo? imageInfo, out string? unsupportedReason) {
+            imageInfo = null;
+            unsupportedReason = null;
+            if (bytes == null || bytes.Length == 0) {
+                unsupportedReason = "Image bytes are empty.";
+                return false;
+            }
+
+            if (!OfficeImageReader.TryIdentify(bytes, null, out OfficeImageInfo detected)) {
+                unsupportedReason = "Image bytes do not contain a supported image header.";
+                return false;
+            }
+
+            imageInfo = detected;
+            switch (detected.Format) {
+                case OfficeImageFormat.Jpeg:
+                    return true;
+                case OfficeImageFormat.Png:
+                    return TryValidatePngContainer(bytes, out unsupportedReason);
+                default:
+                    unsupportedReason = $"Detected {detected.Format} ({detected.MimeType}); first-party PDF export supports JPEG and PNG image bytes.";
+                    return false;
+            }
+        }
+
+        private static bool TryValidatePngContainer(byte[] bytes, out string? unsupportedReason) {
+            unsupportedReason = null;
+            if (bytes.Length < 33 || !StartsWith(bytes, PngSignature)) {
+                unsupportedReason = "PNG bytes are missing the PNG signature or required chunks.";
+                return false;
+            }
+
+            int offset = 8;
+            bool seenIhdr = false;
+            bool seenIdat = false;
+            while (offset + 12 <= bytes.Length) {
+                int length = ReadInt32BigEndian(bytes, offset);
+                long chunkEnd = (long)offset + 12L + length;
+                if (length < 0 || chunkEnd > bytes.Length) {
+                    unsupportedReason = "PNG chunk length exceeds the available image bytes.";
+                    return false;
+                }
+
+                string type = GetAscii(bytes, offset + 4, 4);
+                uint expectedCrc = ReadUInt32BigEndian(bytes, offset + 8 + length);
+                uint actualCrc = ComputePngCrc(bytes, offset + 4, 4 + length);
+                if (actualCrc != expectedCrc) {
+                    unsupportedReason = $"PNG chunk '{type}' has an invalid CRC.";
+                    return false;
+                }
+
+                if (!seenIhdr) {
+                    if (type != "IHDR" || length != 13) {
+                        unsupportedReason = "PNG bytes must start with an IHDR chunk.";
+                        return false;
+                    }
+
+                    seenIhdr = true;
+                } else if (type == "IHDR") {
+                    unsupportedReason = "PNG bytes contain more than one IHDR chunk.";
+                    return false;
+                }
+
+                if (type == "IDAT") {
+                    seenIdat = true;
+                }
+
+                offset = (int)chunkEnd;
+                if (type == "IEND") {
+                    if (!seenIdat) {
+                        unsupportedReason = "PNG bytes do not contain image data.";
+                        return false;
+                    }
+
+                    return offset == bytes.Length;
+                }
+            }
+
+            unsupportedReason = "PNG bytes do not contain a complete IEND chunk.";
+            return false;
+        }
+
+        private static bool StartsWith(byte[] data, byte[] prefix) {
+            if (data.Length < prefix.Length) {
+                return false;
+            }
+
+            for (int i = 0; i < prefix.Length; i++) {
+                if (data[i] != prefix[i]) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static int ReadInt32BigEndian(byte[] data, int offset) {
+            return (data[offset] << 24)
+                   | (data[offset + 1] << 16)
+                   | (data[offset + 2] << 8)
+                   | data[offset + 3];
+        }
+
+        private static uint ReadUInt32BigEndian(byte[] data, int offset) {
+            return ((uint)data[offset] << 24)
+                   | ((uint)data[offset + 1] << 16)
+                   | ((uint)data[offset + 2] << 8)
+                   | data[offset + 3];
+        }
+
+        private static string GetAscii(byte[] data, int offset, int count) {
+            char[] chars = new char[count];
+            for (int i = 0; i < count; i++) {
+                chars[i] = (char)data[offset + i];
+            }
+
+            return new string(chars);
+        }
+
+        private static uint ComputePngCrc(byte[] bytes, int offset, int count) {
+            uint crc = 0xFFFFFFFFU;
+            for (int i = 0; i < count; i++) {
+                crc = UpdateCrc(crc, bytes[offset + i]);
+            }
+
+            return crc ^ 0xFFFFFFFFU;
+        }
+
+        private static uint UpdateCrc(uint crc, byte value) {
+            crc ^= value;
+            for (int i = 0; i < 8; i++) {
+                crc = (crc & 1U) != 0
+                    ? 0xEDB88320U ^ (crc >> 1)
+                    : crc >> 1;
+            }
+
+            return crc;
+        }
+    }
+}

--- a/OfficeIMO.Examples/Excel/FeaturePreflight.cs
+++ b/OfficeIMO.Examples/Excel/FeaturePreflight.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using OfficeIMO.Excel;
+
+namespace OfficeIMO.Examples.Excel {
+    /// <summary>
+    /// Demonstrates workflow-level feature preflight before read, edit, template, or PDF operations.
+    /// </summary>
+    public static class FeaturePreflight {
+        public static void Example(string folderPath, bool openExcel) {
+            Console.WriteLine("[*] Excel - Feature preflight");
+            string filePath = Path.Combine(folderPath, "FeaturePreflight.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Report");
+                sheet.CellValue(1, 1, "Name");
+                sheet.CellValue(1, 2, "Score");
+                sheet.CellValue(2, 1, "Alpha");
+                sheet.CellValue(2, 2, 10d);
+                sheet.CellValue(3, 1, "Beta");
+                sheet.CellValue(3, 2, 20d);
+                sheet.CellFormula(4, 2, "SUM(B2:B3)");
+                document.Calculate();
+                document.Save(openExcel);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                foreach (ExcelPreflightCapability capability in Enum.GetValues(typeof(ExcelPreflightCapability))) {
+                    Console.WriteLine($"{capability}: {(report.Can(capability) ? "ready" : "blocked")}");
+                    foreach (string diagnostic in report.GetCapabilityDiagnostics(capability)) {
+                        Console.WriteLine("  - " + diagnostic);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/Excel/ReportWorkflow.cs
+++ b/OfficeIMO.Examples/Excel/ReportWorkflow.cs
@@ -1,0 +1,71 @@
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.Pdf;
+using PdfCore = OfficeIMO.Pdf;
+
+namespace OfficeIMO.Examples.Excel {
+    /// <summary>
+    /// Demonstrates a template-to-report workflow with formulas, charts, pivots, preflight, and PDF export.
+    /// </summary>
+    public static class ReportWorkflow {
+        public static void Example(string folderPath, bool openExcel) {
+            Console.WriteLine("[*] Excel - Report workflow");
+            string workbookPath = Path.Combine(folderPath, "ExcelReportWorkflow.xlsx");
+            string pdfPath = Path.Combine(folderPath, "ExcelReportWorkflow.pdf");
+
+            using (ExcelDocument document = ExcelDocument.Create(workbookPath, "Report")) {
+                ExcelSheet sheet = document.Sheets[0];
+                sheet.Cell(1, 1, "{{ReportTitle}}");
+                sheet.Cell(2, 1, "Region");
+                sheet.Cell(2, 2, "Revenue");
+                sheet.Cell(2, 3, "Cost");
+                sheet.Cell(2, 4, "Margin");
+                sheet.Cell(3, 1, "East");
+                sheet.Cell(3, 2, 120);
+                sheet.Cell(3, 3, 50);
+                sheet.CellFormula(3, 4, "B3-C3");
+                sheet.Cell(4, 1, "West");
+                sheet.Cell(4, 2, 90);
+                sheet.Cell(4, 3, 40);
+                sheet.CellFormula(4, 4, "B4-C4");
+
+                document.ApplyTemplate(new {
+                    ReportTitle = "Executive revenue report"
+                });
+                document.Calculate();
+
+                sheet.AddTable("A2:D4", hasHeader: true, name: "RevenueData", style: OfficeIMO.Excel.TableStyle.TableStyleMedium4);
+                sheet.AddChartFromRange("A2:D4", row: 6, column: 1, widthPixels: 420, heightPixels: 240,
+                    type: ExcelChartType.ColumnClustered, title: "Revenue and Margin");
+                sheet.AddPivotTable(
+                    sourceRange: "A2:D4",
+                    destinationCell: "F2",
+                    name: "RevenuePivot",
+                    rowFields: new[] { "Region" },
+                    dataFields: new[] { new ExcelPivotDataField("Revenue", DataConsolidateFunctionValues.Sum, "Total Revenue") },
+                    pivotStyleName: "PivotStyleMedium9");
+
+                ExcelFeatureReport report = document.InspectFeatures();
+                if (!report.Can(ExcelPreflightCapability.ExportPdfReport)) {
+                    Console.WriteLine("[!] Excel-to-PDF export is blocked:");
+                    foreach (string diagnostic in report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport)) {
+                        Console.WriteLine("  - " + diagnostic);
+                    }
+                    return;
+                }
+
+                document.Save(false);
+                document.SaveAsPdf(pdfPath, new ExcelPdfSaveOptions {
+                    IncludeSheetHeadings = false,
+                    HeaderRowCount = 1,
+                    PageSize = new PdfCore.PageSize(560, 520),
+                    Margins = PdfCore.PageMargins.Uniform(24)
+                });
+
+                if (openExcel) {
+                    document.Open(workbookPath, true);
+                }
+            }
+        }
+    }
+}

--- a/OfficeIMO.Examples/OfficeIMO.Examples.csproj
+++ b/OfficeIMO.Examples/OfficeIMO.Examples.csproj
@@ -11,6 +11,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\\OfficeIMO.Excel\\OfficeIMO.Excel.csproj" />
+        <ProjectReference Include="..\\OfficeIMO.Excel.Pdf\\OfficeIMO.Excel.Pdf.csproj" />
         <ProjectReference Include="..\\OfficeIMO.Excel.GoogleSheets\\OfficeIMO.Excel.GoogleSheets.csproj" />
         <ProjectReference Include="..\\OfficeIMO.GoogleWorkspace\\OfficeIMO.GoogleWorkspace.csproj" />
         <ProjectReference Include="..\\OfficeIMO.Pdf\\OfficeIMO.Pdf.csproj" />

--- a/OfficeIMO.Examples/Program.cs
+++ b/OfficeIMO.Examples/Program.cs
@@ -319,6 +319,10 @@ namespace OfficeIMO.Examples {
             // Excel.ReadPresetsAndHelpers.Example(folderPath, false);
             // // Excel/Read for PowerShell consumption (emits JSON rows)
             // Excel.ReadForPowerShell.Example(folderPath, false);
+            // // Excel/Feature preflight for read/edit/template/PDF workflow routing
+            // Excel.FeaturePreflight.Example(folderPath, false);
+            // // Excel/Report workflow with template, formulas, chart, pivot, preflight, and PDF
+            // Excel.ReportWorkflow.Example(folderPath, false);
             // // Excel/PowerShell-style round trip: write → read → modify → write → JSON
             // Excel.PowerShellRoundTrip.Example(folderPath, false);
             // // Excel/Headers + Footers + Properties

--- a/OfficeIMO.Excel/ExcelDocument.CalculationAndProtection.cs
+++ b/OfficeIMO.Excel/ExcelDocument.CalculationAndProtection.cs
@@ -1,4 +1,5 @@
 using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 
 namespace OfficeIMO.Excel {
@@ -128,7 +129,17 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public ExcelFormulaInspection InspectFormulas() {
             var formulas = new List<ExcelFormulaCellInfo>();
-            foreach (var sheet in Sheets) {
+            var workbookPart = WorkbookPartRoot;
+            foreach (Sheet sheetElement in WorkbookRoot.Sheets?.Elements<Sheet>() ?? Enumerable.Empty<Sheet>()) {
+                if (string.IsNullOrWhiteSpace(sheetElement.Id?.Value)) {
+                    continue;
+                }
+
+                if (workbookPart.GetPartById(sheetElement.Id!.Value!) is not WorksheetPart) {
+                    continue;
+                }
+
+                var sheet = new ExcelSheet(this, _spreadSheetDocument!, sheetElement);
                 formulas.AddRange(sheet.GetFormulaCells());
             }
 

--- a/OfficeIMO.Excel/ExcelFeatureReport.PdfPreflight.Formulas.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.PdfPreflight.Formulas.cs
@@ -1,0 +1,96 @@
+namespace OfficeIMO.Excel {
+    public partial class ExcelDocument {
+        private static bool IsDefaultPdfExportedFormulaCell(
+            ExcelFormulaCellInfo formula,
+            IReadOnlyDictionary<string, ExcelSheet> exportedSheetsByName) {
+            if (!exportedSheetsByName.TryGetValue(formula.SheetName, out ExcelSheet? sheet)) {
+                return false;
+            }
+
+            if (!A1.TryParseCellReferenceFast(formula.CellReference, out int row, out int column)) {
+                return true;
+            }
+
+            if (IsPdfHiddenRow(sheet, row) || IsPdfHiddenColumn(sheet, column)) {
+                return false;
+            }
+
+            if (!TryGetDefaultPdfBodyRange(sheet, out int firstRow, out int firstColumn, out int lastRow, out int lastColumn)) {
+                return true;
+            }
+
+            ExcelPrintTitles titles = sheet.GetPrintTitles();
+            if (titles.HasRows
+                && row >= titles.FirstRow!.Value
+                && row <= titles.LastRow!.Value
+                && column >= firstColumn
+                && column <= lastColumn) {
+                return true;
+            }
+
+            return row >= firstRow
+                   && row <= lastRow
+                   && column >= firstColumn
+                   && column <= lastColumn;
+        }
+
+        private static bool TryGetDefaultPdfBodyRange(ExcelSheet sheet, out int firstRow, out int firstColumn, out int lastRow, out int lastColumn) {
+            firstRow = 0;
+            firstColumn = 0;
+            lastRow = 0;
+            lastColumn = 0;
+
+            string? printArea = sheet.GetPrintArea();
+            if (string.IsNullOrWhiteSpace(printArea)) {
+                return false;
+            }
+
+            if (ContainsMultiplePrintAreas(printArea!)) {
+                return false;
+            }
+
+            string range = StripSheetPrefix(printArea!).Replace("$", string.Empty);
+            if (A1.TryParseRange(range, out firstRow, out firstColumn, out lastRow, out lastColumn)) {
+                return true;
+            }
+
+            if (!A1.TryParseCellReferenceFast(range, out firstRow, out firstColumn)) {
+                return false;
+            }
+
+            lastRow = firstRow;
+            lastColumn = firstColumn;
+            return true;
+        }
+
+        private static string StripSheetPrefix(string reference) {
+            int separator = reference.LastIndexOf('!');
+            return separator >= 0 && separator + 1 < reference.Length
+                ? reference.Substring(separator + 1)
+                : reference;
+        }
+
+        private static bool IsPdfHiddenRow(ExcelSheet sheet, int rowIndex) {
+            IReadOnlyList<ExcelRowSnapshot> definitions = sheet.GetRowDefinitions();
+            for (int i = definitions.Count - 1; i >= 0; i--) {
+                if (definitions[i].Index == rowIndex) {
+                    return definitions[i].Hidden;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsPdfHiddenColumn(ExcelSheet sheet, int columnIndex) {
+            IReadOnlyList<ExcelColumnSnapshot> definitions = sheet.GetColumnDefinitions();
+            for (int i = definitions.Count - 1; i >= 0; i--) {
+                ExcelColumnSnapshot definition = definitions[i];
+                if (columnIndex >= definition.StartIndex && columnIndex <= definition.EndIndex) {
+                    return definition.Hidden;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelFeatureReport.PdfPreflight.HeaderFooter.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.PdfPreflight.HeaderFooter.cs
@@ -1,0 +1,330 @@
+namespace OfficeIMO.Excel {
+    public partial class ExcelDocument {
+        private static void AddUnsupportedHeaderFooterFormatting(ExcelSheet.HeaderFooterSnapshot headerFooter, string sheetName, ref int count, List<string> details) {
+            var sections = EnumerateHeaderFooterSections(headerFooter).ToArray();
+            var stylesByLocation = new Dictionary<string, string?>(StringComparer.Ordinal);
+            var hasTextByLocation = new Dictionary<string, bool>(StringComparer.Ordinal);
+            foreach (var section in sections) {
+                if (!TryGetHeaderFooterFormatting(section.Text, out string? styleSignature, out string reason)) {
+                    continue;
+                }
+
+                hasTextByLocation[section.Location] = !string.IsNullOrWhiteSpace(section.Text);
+                stylesByLocation[section.Location] = styleSignature;
+                if (string.IsNullOrWhiteSpace(reason)) {
+                    continue;
+                }
+
+                count++;
+                details.Add($"{sheetName} {section.Location}: {reason} is simplified by the first-party PDF header/footer writer.");
+            }
+
+            AddMixedHeaderFooterStyle("header", new[] { "header left", "header center", "header right" }, stylesByLocation, hasTextByLocation, sheetName, ref count, details);
+            AddMixedHeaderFooterStyle("footer", new[] { "footer left", "footer center", "footer right" }, stylesByLocation, hasTextByLocation, sheetName, ref count, details);
+            AddMixedHeaderFooterStyle("first header", new[] { "first header left", "first header center", "first header right" }, stylesByLocation, hasTextByLocation, sheetName, ref count, details);
+            AddMixedHeaderFooterStyle("first footer", new[] { "first footer left", "first footer center", "first footer right" }, stylesByLocation, hasTextByLocation, sheetName, ref count, details);
+            AddMixedHeaderFooterStyle("even header", new[] { "even header left", "even header center", "even header right" }, stylesByLocation, hasTextByLocation, sheetName, ref count, details);
+            AddMixedHeaderFooterStyle("even footer", new[] { "even footer left", "even footer center", "even footer right" }, stylesByLocation, hasTextByLocation, sheetName, ref count, details);
+        }
+
+        private static IEnumerable<(string Location, string Text)> EnumerateHeaderFooterSections(ExcelSheet.HeaderFooterSnapshot headerFooter) {
+            yield return ("header left", headerFooter.HeaderLeft);
+            yield return ("header center", headerFooter.HeaderCenter);
+            yield return ("header right", headerFooter.HeaderRight);
+            yield return ("footer left", headerFooter.FooterLeft);
+            yield return ("footer center", headerFooter.FooterCenter);
+            yield return ("footer right", headerFooter.FooterRight);
+            yield return ("first header left", headerFooter.FirstHeaderLeft);
+            yield return ("first header center", headerFooter.FirstHeaderCenter);
+            yield return ("first header right", headerFooter.FirstHeaderRight);
+            yield return ("first footer left", headerFooter.FirstFooterLeft);
+            yield return ("first footer center", headerFooter.FirstFooterCenter);
+            yield return ("first footer right", headerFooter.FirstFooterRight);
+            yield return ("even header left", headerFooter.EvenHeaderLeft);
+            yield return ("even header center", headerFooter.EvenHeaderCenter);
+            yield return ("even header right", headerFooter.EvenHeaderRight);
+            yield return ("even footer left", headerFooter.EvenFooterLeft);
+            yield return ("even footer center", headerFooter.EvenFooterCenter);
+            yield return ("even footer right", headerFooter.EvenFooterRight);
+        }
+
+        private static void AddMixedHeaderFooterStyle(
+            string scope,
+            IReadOnlyList<string> locations,
+            IReadOnlyDictionary<string, string?> stylesByLocation,
+            IReadOnlyDictionary<string, bool> hasTextByLocation,
+            string sheetName,
+            ref int count,
+            List<string> details) {
+            string? sharedStyle = null;
+            bool hasStyle = false;
+            bool hasUnstyledText = false;
+            foreach (string location in locations) {
+                if (!hasTextByLocation.TryGetValue(location, out bool hasText) || !hasText) {
+                    continue;
+                }
+
+                string? style = stylesByLocation.TryGetValue(location, out string? value) ? value : null;
+                if (string.IsNullOrWhiteSpace(style)) {
+                    hasUnstyledText = true;
+                    continue;
+                }
+
+                if (!hasStyle) {
+                    sharedStyle = style;
+                    hasStyle = true;
+                    continue;
+                }
+
+                if (!string.Equals(sharedStyle, style, StringComparison.Ordinal)) {
+                    count++;
+                    details.Add($"{sheetName} {scope}: mixed header/footer formatting is simplified by the first-party PDF header/footer writer.");
+                    return;
+                }
+            }
+
+            if (hasStyle && hasUnstyledText) {
+                count++;
+                details.Add($"{sheetName} {scope}: mixed header/footer formatting is simplified by the first-party PDF header/footer writer.");
+            }
+        }
+
+        private static bool TryGetHeaderFooterFormatting(string text, out string? styleSignature, out string reason) {
+            styleSignature = null;
+            reason = string.Empty;
+            if (string.IsNullOrEmpty(text)) {
+                return true;
+            }
+
+            bool hasVisibleContent = false;
+            bool hasStyle = false;
+            bool bold = false;
+            bool italic = false;
+            string? color = null;
+            string? fontFamily = null;
+            double? fontSize = null;
+            for (int i = 0; i < text.Length; i++) {
+                char current = text[i];
+                if (current != '&') {
+                    hasVisibleContent = true;
+                    continue;
+                }
+
+                if (i + 1 >= text.Length) {
+                    hasVisibleContent = true;
+                    continue;
+                }
+
+                char token = text[++i];
+                switch (char.ToUpperInvariant(token)) {
+                    case '&':
+                        hasVisibleContent = true;
+                        break;
+                    case 'P':
+                    case 'N':
+                    case 'D':
+                    case 'T':
+                    case 'A':
+                    case 'F':
+                    case 'Z':
+                    case 'G':
+                        hasVisibleContent = true;
+                        break;
+                    case 'U':
+                        reason = "underline formatting";
+                        return true;
+                    case 'S':
+                        reason = "strikethrough formatting";
+                        return true;
+                    case 'B':
+                    case 'I':
+                        if (hasVisibleContent) {
+                            reason = token == 'B' ? "partial bold formatting" : "partial italic formatting";
+                            return true;
+                        }
+
+                        hasStyle = true;
+                        if (token == 'B') {
+                            bold = !bold;
+                        } else {
+                            italic = !italic;
+                        }
+                        break;
+                    case 'K':
+                        if (!TryReadHeaderFooterColorToken(text, ref i, out color)) {
+                            reason = "malformed color formatting";
+                            return true;
+                        }
+
+                        if (hasVisibleContent) {
+                            reason = "partial color formatting";
+                            return true;
+                        }
+
+                        hasStyle = true;
+                        break;
+                    case '"':
+                        if (!TryReadHeaderFooterFontToken(text, ref i, out string quotedToken)) {
+                            reason = "malformed font formatting";
+                            return true;
+                        }
+
+                        if (!TryMapSupportedPdfFontToken(quotedToken, out fontFamily, out bool tokenBold, out bool tokenItalic)) {
+                            reason = "unsupported font formatting";
+                            return true;
+                        }
+
+                        if (hasVisibleContent) {
+                            reason = "partial font formatting";
+                            return true;
+                        }
+
+                        hasStyle = true;
+                        bold = tokenBold;
+                        italic = tokenItalic;
+                        break;
+                    case 'L':
+                    case 'C':
+                    case 'R':
+                        break;
+                    default:
+                        if (char.IsDigit(token)) {
+                            if (!TryReadHeaderFooterFontSizeToken(text, token, ref i, out double parsedFontSize)) {
+                                reason = "malformed font-size formatting";
+                                return true;
+                            }
+
+                            if (hasVisibleContent) {
+                                reason = "partial font-size formatting";
+                                return true;
+                            }
+
+                            hasStyle = true;
+                            fontSize = parsedFontSize;
+                        } else {
+                            hasVisibleContent = true;
+                        }
+
+                        break;
+                }
+            }
+
+            if (hasStyle) {
+                styleSignature = $"B={bold};I={italic};C={color ?? string.Empty};F={fontFamily ?? string.Empty};S={fontSize?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty}";
+            }
+
+            return true;
+        }
+
+        private static bool TryReadHeaderFooterColorToken(string text, ref int index, out string color) {
+            color = string.Empty;
+            int start = index + 1;
+            int length = 0;
+            while (start + length < text.Length && length < 6 && IsHeaderFooterHexDigit(text[start + length])) {
+                length++;
+            }
+
+            if (length != 6) {
+                return false;
+            }
+
+            color = text.Substring(start, length).ToUpperInvariant();
+            index = start + length - 1;
+            return true;
+        }
+
+        private static bool TryReadHeaderFooterFontToken(string text, ref int index, out string token) {
+            token = string.Empty;
+            int closingQuote = text.IndexOf('"', index + 1);
+            if (closingQuote < 0) {
+                return false;
+            }
+
+            token = text.Substring(index + 1, closingQuote - index - 1);
+            index = closingQuote;
+            return true;
+        }
+
+        private static bool TryReadHeaderFooterFontSizeToken(string text, char firstDigit, ref int index, out double fontSize) {
+            var builder = new System.Text.StringBuilder();
+            builder.Append(firstDigit);
+            while (index + 1 < text.Length && char.IsDigit(text[index + 1])) {
+                index++;
+                builder.Append(text[index]);
+            }
+
+            return double.TryParse(builder.ToString(), System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out fontSize)
+                   && fontSize > 0D;
+        }
+
+        private static bool TryMapSupportedPdfFontToken(string token, out string fontFamily, out bool bold, out bool italic) {
+            fontFamily = string.Empty;
+            bold = false;
+            italic = false;
+            if (string.IsNullOrWhiteSpace(token)) {
+                return false;
+            }
+
+            string[] parts = token.Split(new[] { ',' }, 2);
+            fontFamily = NormalizePdfFontFamily(parts[0]);
+            if (!IsSupportedPdfFontFamily(fontFamily)) {
+                return false;
+            }
+
+            if (parts.Length > 1) {
+                string fontStyle = parts[1];
+                bold = fontStyle.IndexOf("bold", StringComparison.OrdinalIgnoreCase) >= 0;
+                italic = fontStyle.IndexOf("italic", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                         fontStyle.IndexOf("oblique", StringComparison.OrdinalIgnoreCase) >= 0;
+            }
+
+            return true;
+        }
+
+        private static string NormalizePdfFontFamily(string fontFamily) {
+            var builder = new System.Text.StringBuilder(fontFamily.Length);
+            foreach (char ch in fontFamily.Trim(' ', '\t', '"', '\'')) {
+                if (char.IsLetterOrDigit(ch)) {
+                    builder.Append(char.ToLowerInvariant(ch));
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        private static bool IsSupportedPdfFontFamily(string normalizedFamily) {
+            switch (normalizedFamily) {
+                case "timesnewroman":
+                case "times":
+                case "timesroman":
+                case "georgia":
+                case "cambria":
+                case "serif":
+                case "couriernew":
+                case "courier":
+                case "consolas":
+                case "lucidaconsole":
+                case "monospace":
+                case "monaco":
+                case "arial":
+                case "helvetica":
+                case "calibri":
+                case "aptos":
+                case "segoeui":
+                case "tahoma":
+                case "verdana":
+                case "sans":
+                case "sansserif":
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private static bool IsHeaderFooterHexDigit(char value) {
+            return (value >= '0' && value <= '9')
+                   || (value >= 'a' && value <= 'f')
+                   || (value >= 'A' && value <= 'F');
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelFeatureReport.PdfPreflight.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.PdfPreflight.cs
@@ -3,6 +3,79 @@ using OfficeIMO.Drawing;
 
 namespace OfficeIMO.Excel {
     public partial class ExcelDocument {
+        private static bool IsHiddenSheet(DocumentFormat.OpenXml.Spreadsheet.Sheet sheet) {
+            return sheet.State?.Value == DocumentFormat.OpenXml.Spreadsheet.SheetStateValues.Hidden
+                   || sheet.State?.Value == DocumentFormat.OpenXml.Spreadsheet.SheetStateValues.VeryHidden;
+        }
+
+        private static bool HasWorkbookRecalculationRequest(DocumentFormat.OpenXml.Spreadsheet.Workbook workbook) {
+            var properties = workbook.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.CalculationProperties>();
+            return properties?.ForceFullCalculation?.Value == true
+                   || properties?.FullCalculationOnLoad?.Value == true;
+        }
+
+        private static IEnumerable<string> DescribeWorkbookRecalculationRequest(DocumentFormat.OpenXml.Spreadsheet.Workbook workbook) {
+            var properties = workbook.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.CalculationProperties>();
+            if (properties?.ForceFullCalculation?.Value == true) {
+                yield return "Workbook calculation properties set forceFullCalc.";
+            }
+
+            if (properties?.FullCalculationOnLoad?.Value == true) {
+                yield return "Workbook calculation properties set fullCalcOnLoad.";
+            }
+        }
+
+        private static void AddUnsupportedHeaderFooterImages(ExcelSheet.HeaderFooterSnapshot headerFooter, string sheetName, ref int count, List<string> details) {
+            AddUnsupportedHeaderFooterImage(headerFooter.HeaderLeftImage, sheetName, "header left", ref count, details);
+            AddUnsupportedHeaderFooterImage(headerFooter.HeaderCenterImage, sheetName, "header center", ref count, details);
+            AddUnsupportedHeaderFooterImage(headerFooter.HeaderRightImage, sheetName, "header right", ref count, details);
+            AddUnsupportedHeaderFooterImage(headerFooter.FooterLeftImage, sheetName, "footer left", ref count, details);
+            AddUnsupportedHeaderFooterImage(headerFooter.FooterCenterImage, sheetName, "footer center", ref count, details);
+            AddUnsupportedHeaderFooterImage(headerFooter.FooterRightImage, sheetName, "footer right", ref count, details);
+        }
+
+        private static void AddUnsupportedHeaderFooterImage(ExcelSheet.HeaderFooterImageSnapshot? image, string sheetName, string location, ref int count, List<string> details) {
+            if (image == null || IsPdfSupportedHeaderFooterImage(image, out string reason)) {
+                return;
+            }
+
+            count++;
+            details.Add($"{sheetName} {location}: {reason}");
+        }
+
+        private static void AddUnrenderedDrawingShapes(WorksheetPart worksheetPart, string sheetName, ref int count, List<string> details) {
+            var shapes = worksheetPart.DrawingsPart?.WorksheetDrawing?
+                .Descendants<DocumentFormat.OpenXml.Drawing.Spreadsheet.Shape>()
+                .ToList();
+            if (shapes == null || shapes.Count == 0) {
+                return;
+            }
+
+            count += shapes.Count;
+            foreach (var shape in shapes) {
+                string name = shape.NonVisualShapeProperties?.NonVisualDrawingProperties?.Name?.Value ?? "unnamed shape";
+                details.Add($"{sheetName}: {name}");
+            }
+        }
+
+        private static void AddUnsupportedDrawingHyperlinks(WorksheetPart worksheetPart, string sheetName, ref int count, List<string> details) {
+            foreach (OpenXmlPart part in EnumeratePartAndChildren(worksheetPart, new HashSet<Uri>())) {
+                if (part == worksheetPart) {
+                    continue;
+                }
+
+                foreach (HyperlinkRelationship relationship in part.HyperlinkRelationships) {
+                    count++;
+                    details.Add($"{sheetName}: {part.Uri} {relationship.Id} -> {relationship.Uri}");
+                }
+
+                foreach (ExternalRelationship relationship in part.ExternalRelationships.Where(IsHyperlinkRelationship)) {
+                    count++;
+                    details.Add($"{sheetName}: {part.Uri} {relationship.Id} -> {relationship.Uri}");
+                }
+            }
+        }
+
         private static bool IsPdfSupportedChartType(ExcelChartType chartType) {
             switch (chartType) {
                 case ExcelChartType.ColumnClustered:
@@ -104,6 +177,45 @@ namespace OfficeIMO.Excel {
 
             reason = string.Empty;
             return true;
+        }
+
+        private static bool IsPdfSupportedHeaderFooterImage(ExcelSheet.HeaderFooterImageSnapshot image, out string reason) {
+            if (!IsPdfSupportedImageContentType(image.ContentType)) {
+                reason = $"content type '{image.ContentType}' is not supported by the first-party PDF image writer.";
+                return false;
+            }
+
+            if (image.WidthPoints <= 0 || image.HeightPoints <= 0) {
+                reason = "image has non-positive dimensions.";
+                return false;
+            }
+
+            if (image.Bytes.Length == 0) {
+                reason = "image has empty bytes.";
+                return false;
+            }
+
+            if (!OfficeImageReader.TryIdentify(image.Bytes, null, out OfficeImageInfo imageInfo)) {
+                reason = "image bytes do not contain a supported image header.";
+                return false;
+            }
+
+            if (IsPngContentType(image.ContentType) && imageInfo.Format != OfficeImageFormat.Png) {
+                reason = $"image bytes were declared as PNG but detected as {imageInfo.Format}.";
+                return false;
+            }
+
+            if (IsJpegContentType(image.ContentType) && imageInfo.Format != OfficeImageFormat.Jpeg) {
+                reason = $"image bytes were declared as JPEG but detected as {imageInfo.Format}.";
+                return false;
+            }
+
+            reason = string.Empty;
+            return true;
+        }
+
+        private static bool IsSupportedPdfExternalHyperlink(Uri uri) {
+            return uri.IsAbsoluteUri;
         }
 
         private static bool IsPdfSupportedImageContentType(string contentType) {

--- a/OfficeIMO.Excel/ExcelFeatureReport.PdfPreflight.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.PdfPreflight.cs
@@ -1,0 +1,126 @@
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Drawing;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelDocument {
+        private static bool IsPdfSupportedChartType(ExcelChartType chartType) {
+            switch (chartType) {
+                case ExcelChartType.ColumnClustered:
+                case ExcelChartType.Column3DClustered:
+                case ExcelChartType.ColumnStacked:
+                case ExcelChartType.Column3DStacked:
+                case ExcelChartType.ColumnStacked100:
+                case ExcelChartType.Column3DStacked100:
+                case ExcelChartType.BarClustered:
+                case ExcelChartType.Bar3DClustered:
+                case ExcelChartType.BarStacked:
+                case ExcelChartType.Bar3DStacked:
+                case ExcelChartType.BarStacked100:
+                case ExcelChartType.Bar3DStacked100:
+                case ExcelChartType.Line:
+                case ExcelChartType.Line3D:
+                case ExcelChartType.LineStacked:
+                case ExcelChartType.LineStacked100:
+                case ExcelChartType.Area:
+                case ExcelChartType.Area3D:
+                case ExcelChartType.AreaStacked:
+                case ExcelChartType.Area3DStacked:
+                case ExcelChartType.AreaStacked100:
+                case ExcelChartType.Area3DStacked100:
+                case ExcelChartType.Scatter:
+                case ExcelChartType.Radar:
+                case ExcelChartType.Pie:
+                case ExcelChartType.Pie3D:
+                case ExcelChartType.PieOfPie:
+                case ExcelChartType.BarOfPie:
+                case ExcelChartType.Doughnut:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private static bool HasRenderablePdfChartData(ExcelChartSnapshot snapshot) {
+            return snapshot.Data.Categories.Count > 0 && snapshot.Data.Series.Count > 0;
+        }
+
+        private static bool HasMixedPdfChartTypes(ExcelChartSnapshot snapshot) {
+            foreach (ExcelChartSeries series in snapshot.Data.Series) {
+                if (series.ChartType.HasValue && series.ChartType.Value != snapshot.ChartType) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static string GetChartDisplayName(ExcelChart chart) {
+            if (!string.IsNullOrWhiteSpace(chart.Title)) {
+                return chart.Title!;
+            }
+
+            return string.IsNullOrWhiteSpace(chart.Name) ? chart.ChartType.ToString() : chart.Name;
+        }
+
+        private static string GetChartDisplayName(ExcelChartSnapshot snapshot) {
+            if (!string.IsNullOrWhiteSpace(snapshot.Title)) {
+                return snapshot.Title!;
+            }
+
+            return string.IsNullOrWhiteSpace(snapshot.Name) ? snapshot.ChartType.ToString() : snapshot.Name;
+        }
+
+        private static bool IsPdfSupportedWorksheetImage(ExcelImage image, out string reason) {
+            if (!IsPdfSupportedImageContentType(image.ContentType)) {
+                reason = $"content type '{image.ContentType}' is not supported by the first-party PDF image writer.";
+                return false;
+            }
+
+            if (image.WidthPixels <= 0 || image.HeightPixels <= 0) {
+                reason = "image has non-positive dimensions.";
+                return false;
+            }
+
+            byte[] bytes = image.GetBytes();
+            if (bytes.Length == 0) {
+                reason = "image has empty bytes.";
+                return false;
+            }
+
+            if (!OfficeImageReader.TryIdentify(bytes, null, out OfficeImageInfo imageInfo)) {
+                reason = "image bytes do not contain a supported image header.";
+                return false;
+            }
+
+            if (IsPngContentType(image.ContentType) && imageInfo.Format != OfficeImageFormat.Png) {
+                reason = $"image bytes were declared as PNG but detected as {imageInfo.Format}.";
+                return false;
+            }
+
+            if (IsJpegContentType(image.ContentType) && imageInfo.Format != OfficeImageFormat.Jpeg) {
+                reason = $"image bytes were declared as JPEG but detected as {imageInfo.Format}.";
+                return false;
+            }
+
+            reason = string.Empty;
+            return true;
+        }
+
+        private static bool IsPdfSupportedImageContentType(string contentType) {
+            return IsPngContentType(contentType) || IsJpegContentType(contentType);
+        }
+
+        private static bool IsPngContentType(string contentType) {
+            return string.Equals(contentType, "image/png", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsJpegContentType(string contentType) {
+            return string.Equals(contentType, "image/jpeg", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(contentType, "image/jpg", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsHyperlinkRelationship(ExternalRelationship relationship) {
+            return relationship.RelationshipType.EndsWith("/hyperlink", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelFeatureReport.PdfPreflight.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.PdfPreflight.cs
@@ -1,4 +1,5 @@
 using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml;
 using OfficeIMO.Drawing;
 
 namespace OfficeIMO.Excel {
@@ -44,17 +45,86 @@ namespace OfficeIMO.Excel {
         }
 
         private static void AddUnrenderedDrawingShapes(WorksheetPart worksheetPart, string sheetName, ref int count, List<string> details) {
-            var shapes = worksheetPart.DrawingsPart?.WorksheetDrawing?
-                .Descendants<DocumentFormat.OpenXml.Drawing.Spreadsheet.Shape>()
+            var drawings = worksheetPart.DrawingsPart?.WorksheetDrawing?
+                .Descendants()
+                .Where(IsUnrenderedPdfDrawingElement)
                 .ToList();
-            if (shapes == null || shapes.Count == 0) {
+            if (drawings == null || drawings.Count == 0) {
                 return;
             }
 
-            count += shapes.Count;
-            foreach (var shape in shapes) {
-                string name = shape.NonVisualShapeProperties?.NonVisualDrawingProperties?.Name?.Value ?? "unnamed shape";
-                details.Add($"{sheetName}: {name}");
+            count += drawings.Count;
+            foreach (OpenXmlElement drawing in drawings) {
+                string name = drawing.Descendants<DocumentFormat.OpenXml.Drawing.Spreadsheet.NonVisualDrawingProperties>()
+                    .FirstOrDefault()?.Name?.Value ?? $"unnamed {GetDrawingElementDisplayName(drawing)}";
+                details.Add($"{sheetName}: {name} ({GetDrawingElementDisplayName(drawing)})");
+            }
+        }
+
+        private static bool IsUnrenderedPdfDrawingElement(OpenXmlElement element) {
+            if (!string.Equals(element.NamespaceUri, "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing", StringComparison.Ordinal)) {
+                return false;
+            }
+
+            switch (element.LocalName) {
+                case "sp":
+                case "cxnSp":
+                case "grpSp":
+                    return true;
+                case "graphicFrame":
+                    return !element.Descendants<DocumentFormat.OpenXml.Drawing.Charts.ChartReference>().Any();
+                default:
+                    return false;
+            }
+        }
+
+        private static string GetDrawingElementDisplayName(OpenXmlElement element) {
+            switch (element.LocalName) {
+                case "sp":
+                    return "shape";
+                case "cxnSp":
+                    return "connector";
+                case "grpSp":
+                    return "group shape";
+                case "graphicFrame":
+                    return "graphic frame";
+                default:
+                    return element.LocalName;
+            }
+        }
+
+        private static void AddUnsupportedWorksheetHyperlinks(
+            WorkbookPart workbookPart,
+            IReadOnlyList<DocumentFormat.OpenXml.Spreadsheet.Sheet> sheets,
+            WorksheetPart worksheetPart,
+            string sheetName,
+            ref int count,
+            List<string> details) {
+            var hyperlinks = worksheetPart.Worksheet?.Elements<DocumentFormat.OpenXml.Spreadsheet.Hyperlinks>().FirstOrDefault();
+            if (hyperlinks == null) {
+                return;
+            }
+
+            foreach (var hyperlink in hyperlinks.Elements<DocumentFormat.OpenXml.Spreadsheet.Hyperlink>()) {
+                if (hyperlink.Id != null) {
+                    continue;
+                }
+
+                string? location = hyperlink.Location?.Value;
+                if (string.IsNullOrWhiteSpace(location)) {
+                    continue;
+                }
+
+                if (!TryResolveInternalHyperlinkTarget(sheetName, location!, out string targetSheetName, out string targetCellReference)) {
+                    count++;
+                    details.Add($"{sheetName}: {hyperlink.Reference?.Value ?? "hyperlink"} -> {location} is not a worksheet cell target supported by the first-party PDF hyperlink writer.");
+                    continue;
+                }
+
+                if (!IsDefaultPdfExportedCell(workbookPart, sheets, targetSheetName, targetCellReference, out string reason)) {
+                    count++;
+                    details.Add($"{sheetName}: {hyperlink.Reference?.Value ?? "hyperlink"} -> {location} is skipped by the first-party PDF hyperlink writer because {reason}");
+                }
             }
         }
 
@@ -74,6 +144,102 @@ namespace OfficeIMO.Excel {
                     details.Add($"{sheetName}: {part.Uri} {relationship.Id} -> {relationship.Uri}");
                 }
             }
+        }
+
+        private static bool TryResolveInternalHyperlinkTarget(string currentSheetName, string location, out string sheetName, out string cellReference) {
+            sheetName = currentSheetName;
+            cellReference = string.Empty;
+
+            string targetReference = location;
+            if (SheetNameLookup.TryParseSheetQualifiedReference(location, out string parsedSheetName, out string parsedReference, allowExternalWorkbookReferences: false)) {
+                sheetName = parsedSheetName;
+                targetReference = parsedReference;
+            }
+
+            return TryGetTopLeftCellReference(targetReference, out cellReference);
+        }
+
+        private static bool IsDefaultPdfExportedCell(
+            WorkbookPart workbookPart,
+            IReadOnlyList<DocumentFormat.OpenXml.Spreadsheet.Sheet> sheets,
+            string sheetName,
+            string cellReference,
+            out string reason) {
+            var sheet = SheetNameLookup.FindByRequestedName(sheets, sheetName);
+            if (sheet == null || string.IsNullOrWhiteSpace(sheet.Id?.Value)) {
+                reason = $"target sheet '{sheetName}' was not found.";
+                return false;
+            }
+
+            if (IsHiddenSheet(sheet)) {
+                reason = $"target sheet '{sheetName}' is hidden and skipped by default PDF export.";
+                return false;
+            }
+
+            if (workbookPart.GetPartById(sheet.Id!.Value!) is not WorksheetPart worksheetPart) {
+                reason = $"target sheet '{sheetName}' is not a worksheet.";
+                return false;
+            }
+
+            if (!TryGetTopLeftCellReference(cellReference, out string normalizedCellReference)
+                || !A1.TryParseCellReferenceFast(normalizedCellReference, out int targetRow, out int targetColumn)) {
+                reason = $"target cell '{cellReference}' is not a supported A1 reference.";
+                return false;
+            }
+
+            if (!TryGetWorksheetUsedRange(worksheetPart, out int firstRow, out int firstColumn, out int lastRow, out int lastColumn)) {
+                reason = $"target sheet '{sheetName}' has no exported cells in the default PDF range.";
+                return false;
+            }
+
+            if (targetRow < firstRow || targetRow > lastRow || targetColumn < firstColumn || targetColumn > lastColumn) {
+                reason = $"target cell '{sheetName}!{normalizedCellReference}' is outside the default PDF exported range {A1.CellReference(firstRow, firstColumn)}:{A1.CellReference(lastRow, lastColumn)}.";
+                return false;
+            }
+
+            reason = string.Empty;
+            return true;
+        }
+
+        private static bool TryGetWorksheetUsedRange(WorksheetPart worksheetPart, out int firstRow, out int firstColumn, out int lastRow, out int lastColumn) {
+            firstRow = int.MaxValue;
+            firstColumn = int.MaxValue;
+            lastRow = 0;
+            lastColumn = 0;
+
+            foreach (var cell in worksheetPart.Worksheet?.Descendants<DocumentFormat.OpenXml.Spreadsheet.Cell>() ?? Enumerable.Empty<DocumentFormat.OpenXml.Spreadsheet.Cell>()) {
+                string? reference = cell.CellReference?.Value;
+                if (!A1.TryParseCellReferenceFast(reference, out int row, out int column)) {
+                    continue;
+                }
+
+                firstRow = Math.Min(firstRow, row);
+                firstColumn = Math.Min(firstColumn, column);
+                lastRow = Math.Max(lastRow, row);
+                lastColumn = Math.Max(lastColumn, column);
+            }
+
+            return lastRow > 0 && lastColumn > 0;
+        }
+
+        private static bool TryGetTopLeftCellReference(string referenceToken, out string cellReference) {
+            cellReference = string.Empty;
+            if (string.IsNullOrWhiteSpace(referenceToken)) {
+                return false;
+            }
+
+            string token = referenceToken.Trim().Replace("$", string.Empty);
+            if (A1.TryParseRange(token, out int firstRow, out int firstColumn, out _, out _)) {
+                cellReference = A1.CellReference(firstRow, firstColumn);
+                return true;
+            }
+
+            if (!A1.TryParseCellReferenceFast(token, out int row, out int column)) {
+                return false;
+            }
+
+            cellReference = A1.CellReference(row, column);
+            return true;
         }
 
         private static bool IsPdfSupportedChartType(ExcelChartType chartType) {

--- a/OfficeIMO.Excel/ExcelFeatureReport.PdfPreflight.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.PdfPreflight.cs
@@ -1,5 +1,5 @@
-using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
 using OfficeIMO.Drawing;
 
 namespace OfficeIMO.Excel {
@@ -42,6 +42,200 @@ namespace OfficeIMO.Excel {
 
             count++;
             details.Add($"{sheetName} {location}: {reason}");
+        }
+
+        private static void AddUnsupportedHeaderFooterFormatting(ExcelSheet.HeaderFooterSnapshot headerFooter, string sheetName, ref int count, List<string> details) {
+            foreach (var section in EnumerateHeaderFooterSections(headerFooter)) {
+                if (!TryGetUnsupportedHeaderFooterFormattingReason(section.Text, out string reason)) {
+                    continue;
+                }
+
+                count++;
+                details.Add($"{sheetName} {section.Location}: {reason} is simplified by the first-party PDF header/footer writer.");
+            }
+        }
+
+        private static IEnumerable<(string Location, string Text)> EnumerateHeaderFooterSections(ExcelSheet.HeaderFooterSnapshot headerFooter) {
+            yield return ("header left", headerFooter.HeaderLeft);
+            yield return ("header center", headerFooter.HeaderCenter);
+            yield return ("header right", headerFooter.HeaderRight);
+            yield return ("footer left", headerFooter.FooterLeft);
+            yield return ("footer center", headerFooter.FooterCenter);
+            yield return ("footer right", headerFooter.FooterRight);
+            yield return ("first header left", headerFooter.FirstHeaderLeft);
+            yield return ("first header center", headerFooter.FirstHeaderCenter);
+            yield return ("first header right", headerFooter.FirstHeaderRight);
+            yield return ("first footer left", headerFooter.FirstFooterLeft);
+            yield return ("first footer center", headerFooter.FirstFooterCenter);
+            yield return ("first footer right", headerFooter.FirstFooterRight);
+            yield return ("even header left", headerFooter.EvenHeaderLeft);
+            yield return ("even header center", headerFooter.EvenHeaderCenter);
+            yield return ("even header right", headerFooter.EvenHeaderRight);
+            yield return ("even footer left", headerFooter.EvenFooterLeft);
+            yield return ("even footer center", headerFooter.EvenFooterCenter);
+            yield return ("even footer right", headerFooter.EvenFooterRight);
+        }
+
+        private static bool TryGetUnsupportedHeaderFooterFormattingReason(string text, out string reason) {
+            reason = string.Empty;
+            if (string.IsNullOrEmpty(text)) {
+                return false;
+            }
+
+            bool hasVisibleContent = false;
+            for (int i = 0; i < text.Length; i++) {
+                char current = text[i];
+                if (current != '&') {
+                    hasVisibleContent = true;
+                    continue;
+                }
+
+                if (i + 1 >= text.Length) {
+                    hasVisibleContent = true;
+                    continue;
+                }
+
+                char token = text[++i];
+                switch (char.ToUpperInvariant(token)) {
+                    case '&':
+                        hasVisibleContent = true;
+                        break;
+                    case 'P':
+                    case 'N':
+                    case 'D':
+                    case 'T':
+                    case 'A':
+                    case 'F':
+                    case 'Z':
+                    case 'G':
+                        hasVisibleContent = true;
+                        break;
+                    case 'U':
+                        reason = "underline formatting";
+                        return true;
+                    case 'S':
+                        reason = "strikethrough formatting";
+                        return true;
+                    case 'B':
+                    case 'I':
+                        if (hasVisibleContent) {
+                            reason = token == 'B' ? "partial bold formatting" : "partial italic formatting";
+                            return true;
+                        }
+                        break;
+                    case 'K':
+                        if (!TrySkipHeaderFooterColorToken(text, ref i)) {
+                            reason = "malformed color formatting";
+                            return true;
+                        }
+
+                        if (hasVisibleContent) {
+                            reason = "partial color formatting";
+                            return true;
+                        }
+
+                        break;
+                    case '"':
+                        if (!TrySkipHeaderFooterFontToken(text, ref i)) {
+                            reason = "malformed font formatting";
+                            return true;
+                        }
+
+                        if (hasVisibleContent) {
+                            reason = "partial font formatting";
+                            return true;
+                        }
+
+                        break;
+                    case 'L':
+                    case 'C':
+                    case 'R':
+                        break;
+                    default:
+                        if (char.IsDigit(token)) {
+                            TrySkipHeaderFooterFontSizeToken(text, ref i);
+                            if (hasVisibleContent) {
+                                reason = "partial font-size formatting";
+                                return true;
+                            }
+                        } else {
+                            hasVisibleContent = true;
+                        }
+
+                        break;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool TrySkipHeaderFooterColorToken(string text, ref int index) {
+            int start = index + 1;
+            int length = 0;
+            while (start + length < text.Length && length < 6 && IsHexDigit(text[start + length])) {
+                length++;
+            }
+
+            if (length != 6) {
+                return false;
+            }
+
+            index = start + length - 1;
+            return true;
+        }
+
+        private static bool TrySkipHeaderFooterFontToken(string text, ref int index) {
+            int closingQuote = text.IndexOf('"', index + 1);
+            if (closingQuote < 0) {
+                return false;
+            }
+
+            index = closingQuote;
+            return true;
+        }
+
+        private static void TrySkipHeaderFooterFontSizeToken(string text, ref int index) {
+            while (index + 1 < text.Length && char.IsDigit(text[index + 1])) {
+                index++;
+            }
+        }
+
+        private static bool IsHexDigit(char value) {
+            return (value >= '0' && value <= '9')
+                   || (value >= 'a' && value <= 'f')
+                   || (value >= 'A' && value <= 'F');
+        }
+
+        private static void AddUnsupportedPrintArea(ExcelSheet sheet, string sheetName, ref int count, List<string> details) {
+            string? printArea = sheet.GetPrintArea();
+            if (string.IsNullOrWhiteSpace(printArea) || !ContainsMultiplePrintAreas(printArea!)) {
+                return;
+            }
+
+            count++;
+            details.Add($"{sheetName}: {printArea} uses multiple print areas; the first-party PDF path exports the worksheet used range instead.");
+        }
+
+        private static bool ContainsMultiplePrintAreas(string printArea) {
+            bool inQuotedSheetName = false;
+            for (int i = 0; i < printArea.Length; i++) {
+                char current = printArea[i];
+                if (current == '\'') {
+                    if (inQuotedSheetName && i + 1 < printArea.Length && printArea[i + 1] == '\'') {
+                        i++;
+                        continue;
+                    }
+
+                    inQuotedSheetName = !inQuotedSheetName;
+                    continue;
+                }
+
+                if (current == ',' && !inQuotedSheetName) {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static void AddUnrenderedDrawingShapes(WorksheetPart worksheetPart, string sheetName, ref int count, List<string> details) {
@@ -293,12 +487,25 @@ namespace OfficeIMO.Excel {
             return false;
         }
 
-        private static string GetChartDisplayName(ExcelChart chart) {
-            if (!string.IsNullOrWhiteSpace(chart.Title)) {
-                return chart.Title!;
+        private static string GetSafeChartDisplayName(ExcelChart chart) {
+            try {
+                if (!string.IsNullOrWhiteSpace(chart.Title)) {
+                    return chart.Title!;
+                }
+            } catch {
+                // Dangling chart relationships can make title lookup fail; fall back to frame metadata.
             }
 
-            return string.IsNullOrWhiteSpace(chart.Name) ? chart.ChartType.ToString() : chart.Name;
+            string name = chart.Name;
+            if (!string.IsNullOrWhiteSpace(name)) {
+                return name;
+            }
+
+            try {
+                return chart.ChartType.ToString();
+            } catch {
+                return "unnamed chart";
+            }
         }
 
         private static string GetChartDisplayName(ExcelChartSnapshot snapshot) {

--- a/OfficeIMO.Excel/ExcelFeatureReport.PdfPreflight.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.PdfPreflight.cs
@@ -44,168 +44,6 @@ namespace OfficeIMO.Excel {
             details.Add($"{sheetName} {location}: {reason}");
         }
 
-        private static void AddUnsupportedHeaderFooterFormatting(ExcelSheet.HeaderFooterSnapshot headerFooter, string sheetName, ref int count, List<string> details) {
-            foreach (var section in EnumerateHeaderFooterSections(headerFooter)) {
-                if (!TryGetUnsupportedHeaderFooterFormattingReason(section.Text, out string reason)) {
-                    continue;
-                }
-
-                count++;
-                details.Add($"{sheetName} {section.Location}: {reason} is simplified by the first-party PDF header/footer writer.");
-            }
-        }
-
-        private static IEnumerable<(string Location, string Text)> EnumerateHeaderFooterSections(ExcelSheet.HeaderFooterSnapshot headerFooter) {
-            yield return ("header left", headerFooter.HeaderLeft);
-            yield return ("header center", headerFooter.HeaderCenter);
-            yield return ("header right", headerFooter.HeaderRight);
-            yield return ("footer left", headerFooter.FooterLeft);
-            yield return ("footer center", headerFooter.FooterCenter);
-            yield return ("footer right", headerFooter.FooterRight);
-            yield return ("first header left", headerFooter.FirstHeaderLeft);
-            yield return ("first header center", headerFooter.FirstHeaderCenter);
-            yield return ("first header right", headerFooter.FirstHeaderRight);
-            yield return ("first footer left", headerFooter.FirstFooterLeft);
-            yield return ("first footer center", headerFooter.FirstFooterCenter);
-            yield return ("first footer right", headerFooter.FirstFooterRight);
-            yield return ("even header left", headerFooter.EvenHeaderLeft);
-            yield return ("even header center", headerFooter.EvenHeaderCenter);
-            yield return ("even header right", headerFooter.EvenHeaderRight);
-            yield return ("even footer left", headerFooter.EvenFooterLeft);
-            yield return ("even footer center", headerFooter.EvenFooterCenter);
-            yield return ("even footer right", headerFooter.EvenFooterRight);
-        }
-
-        private static bool TryGetUnsupportedHeaderFooterFormattingReason(string text, out string reason) {
-            reason = string.Empty;
-            if (string.IsNullOrEmpty(text)) {
-                return false;
-            }
-
-            bool hasVisibleContent = false;
-            for (int i = 0; i < text.Length; i++) {
-                char current = text[i];
-                if (current != '&') {
-                    hasVisibleContent = true;
-                    continue;
-                }
-
-                if (i + 1 >= text.Length) {
-                    hasVisibleContent = true;
-                    continue;
-                }
-
-                char token = text[++i];
-                switch (char.ToUpperInvariant(token)) {
-                    case '&':
-                        hasVisibleContent = true;
-                        break;
-                    case 'P':
-                    case 'N':
-                    case 'D':
-                    case 'T':
-                    case 'A':
-                    case 'F':
-                    case 'Z':
-                    case 'G':
-                        hasVisibleContent = true;
-                        break;
-                    case 'U':
-                        reason = "underline formatting";
-                        return true;
-                    case 'S':
-                        reason = "strikethrough formatting";
-                        return true;
-                    case 'B':
-                    case 'I':
-                        if (hasVisibleContent) {
-                            reason = token == 'B' ? "partial bold formatting" : "partial italic formatting";
-                            return true;
-                        }
-                        break;
-                    case 'K':
-                        if (!TrySkipHeaderFooterColorToken(text, ref i)) {
-                            reason = "malformed color formatting";
-                            return true;
-                        }
-
-                        if (hasVisibleContent) {
-                            reason = "partial color formatting";
-                            return true;
-                        }
-
-                        break;
-                    case '"':
-                        if (!TrySkipHeaderFooterFontToken(text, ref i)) {
-                            reason = "malformed font formatting";
-                            return true;
-                        }
-
-                        if (hasVisibleContent) {
-                            reason = "partial font formatting";
-                            return true;
-                        }
-
-                        break;
-                    case 'L':
-                    case 'C':
-                    case 'R':
-                        break;
-                    default:
-                        if (char.IsDigit(token)) {
-                            TrySkipHeaderFooterFontSizeToken(text, ref i);
-                            if (hasVisibleContent) {
-                                reason = "partial font-size formatting";
-                                return true;
-                            }
-                        } else {
-                            hasVisibleContent = true;
-                        }
-
-                        break;
-                }
-            }
-
-            return false;
-        }
-
-        private static bool TrySkipHeaderFooterColorToken(string text, ref int index) {
-            int start = index + 1;
-            int length = 0;
-            while (start + length < text.Length && length < 6 && IsHexDigit(text[start + length])) {
-                length++;
-            }
-
-            if (length != 6) {
-                return false;
-            }
-
-            index = start + length - 1;
-            return true;
-        }
-
-        private static bool TrySkipHeaderFooterFontToken(string text, ref int index) {
-            int closingQuote = text.IndexOf('"', index + 1);
-            if (closingQuote < 0) {
-                return false;
-            }
-
-            index = closingQuote;
-            return true;
-        }
-
-        private static void TrySkipHeaderFooterFontSizeToken(string text, ref int index) {
-            while (index + 1 < text.Length && char.IsDigit(text[index + 1])) {
-                index++;
-            }
-        }
-
-        private static bool IsHexDigit(char value) {
-            return (value >= '0' && value <= '9')
-                   || (value >= 'a' && value <= 'f')
-                   || (value >= 'A' && value <= 'F');
-        }
-
         private static void AddUnsupportedPrintArea(ExcelSheet sheet, string sheetName, ref int count, List<string> details) {
             string? printArea = sheet.GetPrintArea();
             if (string.IsNullOrWhiteSpace(printArea) || !ContainsMultiplePrintAreas(printArea!)) {
@@ -214,6 +52,16 @@ namespace OfficeIMO.Excel {
 
             count++;
             details.Add($"{sheetName}: {printArea} uses multiple print areas; the first-party PDF path exports the worksheet used range instead.");
+        }
+
+        private static void AddUnsupportedPrintTitles(ExcelSheet sheet, string sheetName, ref int count, List<string> details) {
+            ExcelPrintTitles titles = sheet.GetPrintTitles();
+            if (!titles.HasColumns) {
+                return;
+            }
+
+            count++;
+            details.Add($"{sheetName}: print-title columns {A1.ColumnIndexToLetters(titles.FirstColumn!.Value)}:{A1.ColumnIndexToLetters(titles.LastColumn!.Value)} are configured, but first-party PDF export repeats print-title rows only.");
         }
 
         private static bool ContainsMultiplePrintAreas(string printArea) {
@@ -533,17 +381,17 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            if (!OfficeImageReader.TryIdentify(bytes, null, out OfficeImageInfo imageInfo)) {
-                reason = "image bytes do not contain a supported image header.";
+            if (!OfficeImagePdfCompatibility.TryValidate(bytes, out OfficeImageInfo? imageInfo, out string? unsupportedReason)) {
+                reason = unsupportedReason ?? "image bytes are not supported by the first-party PDF image writer.";
                 return false;
             }
 
-            if (IsPngContentType(image.ContentType) && imageInfo.Format != OfficeImageFormat.Png) {
+            if (IsPngContentType(image.ContentType) && imageInfo!.Format != OfficeImageFormat.Png) {
                 reason = $"image bytes were declared as PNG but detected as {imageInfo.Format}.";
                 return false;
             }
 
-            if (IsJpegContentType(image.ContentType) && imageInfo.Format != OfficeImageFormat.Jpeg) {
+            if (IsJpegContentType(image.ContentType) && imageInfo!.Format != OfficeImageFormat.Jpeg) {
                 reason = $"image bytes were declared as JPEG but detected as {imageInfo.Format}.";
                 return false;
             }
@@ -568,17 +416,17 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            if (!OfficeImageReader.TryIdentify(image.Bytes, null, out OfficeImageInfo imageInfo)) {
-                reason = "image bytes do not contain a supported image header.";
+            if (!OfficeImagePdfCompatibility.TryValidate(image.Bytes, out OfficeImageInfo? imageInfo, out string? unsupportedReason)) {
+                reason = unsupportedReason ?? "image bytes are not supported by the first-party PDF image writer.";
                 return false;
             }
 
-            if (IsPngContentType(image.ContentType) && imageInfo.Format != OfficeImageFormat.Png) {
+            if (IsPngContentType(image.ContentType) && imageInfo!.Format != OfficeImageFormat.Png) {
                 reason = $"image bytes were declared as PNG but detected as {imageInfo.Format}.";
                 return false;
             }
 
-            if (IsJpegContentType(image.ContentType) && imageInfo.Format != OfficeImageFormat.Jpeg) {
+            if (IsJpegContentType(image.ContentType) && imageInfo!.Format != OfficeImageFormat.Jpeg) {
                 reason = $"image bytes were declared as JPEG but detected as {imageInfo.Format}.";
                 return false;
             }

--- a/OfficeIMO.Excel/ExcelFeatureReport.Preflight.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.Preflight.cs
@@ -29,7 +29,9 @@ namespace OfficeIMO.Excel {
         /// <summary>
         /// True when OfficeIMO can attempt read-oriented workbook data operations.
         /// </summary>
-        public bool CanReadWorkbookData => UnsupportedFeatures.Count == 0;
+        public bool CanReadWorkbookData =>
+            UnsupportedFeatures.Count == 0 &&
+            FindFeatureCount("Non-worksheet sheets") == 0;
 
         /// <summary>
         /// True when OfficeIMO can attempt cell-value edits without known unsupported package features.
@@ -69,6 +71,10 @@ namespace OfficeIMO.Excel {
             !HasPdfExportWorkbookBlockers() &&
             CanUseCachedFormulaValues &&
             FindFeatureCount("PDF-unsupported charts") == 0 &&
+            FindFeatureCount("PDF-unreadable charts") == 0 &&
+            FindFeatureCount("PDF-unsupported images") == 0 &&
+            FindFeatureCount("PDF-unrendered pivot tables") == 0 &&
+            FindFeatureCount("PDF-unrendered sparklines") == 0 &&
             FindFeatureCount("Non-worksheet sheets") == 0;
 
         /// <summary>
@@ -126,6 +132,7 @@ namespace OfficeIMO.Excel {
             switch (capability) {
                 case ExcelPreflightCapability.ReadWorkbookData:
                     AddUnsupportedDiagnostics(messages, "Workbook data reads are blocked by unsupported workbook features.");
+                    AddFeatureDiagnostics(messages, FindFeatures("Non-worksheet sheets"));
                     break;
                 case ExcelPreflightCapability.EditCellValues:
                     AddUnsupportedDiagnostics(messages, "Cell-value edits are blocked by unsupported workbook features.");
@@ -149,6 +156,10 @@ namespace OfficeIMO.Excel {
                     AddPdfExportWorkbookDiagnostics(messages);
                     AddFormulaDiagnostics(messages, requireCachedValues: true, requireSupportedFormulas: false);
                     AddFeatureDiagnostics(messages, FindFeatures("PDF-unsupported charts"));
+                    AddFeatureDiagnostics(messages, FindFeatures("PDF-unreadable charts"));
+                    AddFeatureDiagnostics(messages, FindFeatures("PDF-unsupported images"));
+                    AddFeatureDiagnostics(messages, FindFeatures("PDF-unrendered pivot tables"));
+                    AddFeatureDiagnostics(messages, FindFeatures("PDF-unrendered sparklines"));
                     AddFeatureDiagnostics(messages, FindFeatures("Non-worksheet sheets"));
                     break;
                 default:

--- a/OfficeIMO.Excel/ExcelFeatureReport.Preflight.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.Preflight.cs
@@ -69,12 +69,16 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public bool CanExportPdfReport =>
             !HasPdfExportWorkbookBlockers() &&
-            CanUseCachedFormulaValues &&
+            FindFeatureCount("PDF-missing formula caches") == 0 &&
+            FindFeatureCount("PDF-dirty formula caches") == 0 &&
+            FindFeatureCount("PDF-workbook recalculation requests") == 0 &&
             FindFeatureCount("PDF-unsupported charts") == 0 &&
             FindFeatureCount("PDF-unreadable charts") == 0 &&
             FindFeatureCount("PDF-unsupported images") == 0 &&
             FindFeatureCount("PDF-unsupported hyperlinks") == 0 &&
             FindFeatureCount("PDF-unrendered drawing shapes") == 0 &&
+            FindFeatureCount("PDF-unsupported print areas") == 0 &&
+            FindFeatureCount("PDF-unsupported header/footer formatting") == 0 &&
             FindFeatureCount("PDF-unrendered pivot tables") == 0 &&
             FindFeatureCount("PDF-unrendered sparklines") == 0 &&
             FindFeatureCount("Non-worksheet sheets") == 0;
@@ -156,12 +160,16 @@ namespace OfficeIMO.Excel {
                     break;
                 case ExcelPreflightCapability.ExportPdfReport:
                     AddPdfExportWorkbookDiagnostics(messages);
-                    AddFormulaDiagnostics(messages, requireCachedValues: true, requireSupportedFormulas: false);
+                    AddFeatureDiagnostics(messages, FindFeatures("PDF-missing formula caches"));
+                    AddFeatureDiagnostics(messages, FindFeatures("PDF-dirty formula caches"));
+                    AddFeatureDiagnostics(messages, FindFeatures("PDF-workbook recalculation requests"));
                     AddFeatureDiagnostics(messages, FindFeatures("PDF-unsupported charts"));
                     AddFeatureDiagnostics(messages, FindFeatures("PDF-unreadable charts"));
                     AddFeatureDiagnostics(messages, FindFeatures("PDF-unsupported images"));
                     AddFeatureDiagnostics(messages, FindFeatures("PDF-unsupported hyperlinks"));
                     AddFeatureDiagnostics(messages, FindFeatures("PDF-unrendered drawing shapes"));
+                    AddFeatureDiagnostics(messages, FindFeatures("PDF-unsupported print areas"));
+                    AddFeatureDiagnostics(messages, FindFeatures("PDF-unsupported header/footer formatting"));
                     AddFeatureDiagnostics(messages, FindFeatures("PDF-unrendered pivot tables"));
                     AddFeatureDiagnostics(messages, FindFeatures("PDF-unrendered sparklines"));
                     AddFeatureDiagnostics(messages, FindFeatures("Non-worksheet sheets"));
@@ -212,6 +220,9 @@ namespace OfficeIMO.Excel {
                 case "Missing formula caches":
                 case "Dirty formula caches":
                 case "Workbook recalculation requests":
+                case "PDF-missing formula caches":
+                case "PDF-dirty formula caches":
+                case "PDF-workbook recalculation requests":
                 case "Formula dependency issues":
                 case "Formula calculation blockers":
                     return true;

--- a/OfficeIMO.Excel/ExcelFeatureReport.Preflight.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.Preflight.cs
@@ -34,7 +34,9 @@ namespace OfficeIMO.Excel {
         /// <summary>
         /// True when OfficeIMO can attempt cell-value edits without known unsupported package features.
         /// </summary>
-        public bool CanEditCellValues => UnsupportedFeatures.Count == 0;
+        public bool CanEditCellValues =>
+            UnsupportedFeatures.Count == 0 &&
+            FindFeatureCount("Digital signatures") == 0;
 
         /// <summary>
         /// True when OfficeIMO can attempt structure-changing workbook edits without preserve-only or unsupported feature blockers.
@@ -46,14 +48,14 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public bool CanUseCachedFormulaValues =>
             FindFeatureCount("Missing formula caches") == 0 &&
+            FindFeatureCount("Dirty formula caches") == 0 &&
             FindFeatureCount("Formula dependency issues") == 0;
 
         /// <summary>
         /// True when OfficeIMO's lightweight evaluator can calculate all discovered formulas without known dependency issues.
         /// </summary>
         public bool CanCalculateFormulas =>
-            FindFeatureCount("Unsupported formulas") == 0 &&
-            FindFeatureCount("Formula dependency issues") == 0;
+            FindFeatureCount("Formula calculation blockers") == 0;
 
         /// <summary>
         /// True when template binding can be attempted without preserve-only or unsupported advanced package features.
@@ -65,7 +67,8 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public bool CanExportPdfReport =>
             !HasAdvancedFeatures &&
-            CanUseCachedFormulaValues;
+            CanUseCachedFormulaValues &&
+            FindFeatureCount("PDF-unsupported charts") == 0;
 
         /// <summary>
         /// Returns true when the requested workflow-level capability can be attempted for this workbook.
@@ -125,6 +128,7 @@ namespace OfficeIMO.Excel {
                     break;
                 case ExcelPreflightCapability.EditCellValues:
                     AddUnsupportedDiagnostics(messages, "Cell-value edits are blocked by unsupported workbook features.");
+                    AddFeatureDiagnostics(messages, FindFeatures("Digital signatures"));
                     break;
                 case ExcelPreflightCapability.EditWorkbookStructure:
                     AddUnsupportedDiagnostics(messages, "Structure-changing edits are blocked by unsupported workbook features.");
@@ -144,6 +148,7 @@ namespace OfficeIMO.Excel {
                     AddUnsupportedDiagnostics(messages, "Excel-to-PDF report export is blocked by unsupported workbook features.");
                     AddPreservedDiagnostics(messages, "Excel-to-PDF report export does not render preserve-only workbook features.");
                     AddFormulaDiagnostics(messages, requireCachedValues: true, requireSupportedFormulas: false);
+                    AddFeatureDiagnostics(messages, FindFeatures("PDF-unsupported charts"));
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(capability), capability, "Unsupported Excel preflight capability.");
@@ -176,14 +181,75 @@ namespace OfficeIMO.Excel {
 
         private void AddFormulaDiagnostics(List<string> messages, bool requireCachedValues, bool requireSupportedFormulas) {
             if (requireSupportedFormulas) {
-                AddFeatureDiagnostics(messages, FindFeatures("Unsupported formulas"));
+                AddFeatureDiagnostics(messages, FindFeatures("Formula calculation blockers"));
             }
 
             if (requireCachedValues) {
                 AddFeatureDiagnostics(messages, FindFeatures("Missing formula caches"));
+                AddFeatureDiagnostics(messages, FindFeatures("Dirty formula caches"));
+                AddFeatureDiagnostics(messages, FindFeatures("Formula dependency issues"));
+                return;
             }
 
-            AddFeatureDiagnostics(messages, FindFeatures("Formula dependency issues"));
+            AddFormulaDependencyDiagnostics(messages, includeMissingCachedDependencyIssues: false);
+        }
+
+        private void AddFormulaDependencyDiagnostics(List<string> messages, bool includeMissingCachedDependencyIssues) {
+            foreach (ExcelFeatureFinding finding in FindFeatures("Formula dependency issues")) {
+                IReadOnlyList<string> details = FilterFormulaDependencyIssueDetails(finding.Details, includeMissingCachedDependencyIssues);
+                if (details.Count == 0) {
+                    continue;
+                }
+
+                AddDistinct(messages, FormatCapabilityFinding(new ExcelFeatureFinding(
+                    finding.Category,
+                    finding.Name,
+                    finding.SupportLevel,
+                    details.Count,
+                    finding.Scope,
+                    finding.Note,
+                    details)));
+            }
+        }
+
+        private int CountFormulaDependencyIssues(bool includeMissingCachedDependencyIssues) {
+            int count = 0;
+            foreach (ExcelFeatureFinding finding in FindFeatures("Formula dependency issues")) {
+                count += includeMissingCachedDependencyIssues
+                    ? finding.Count
+                    : FilterFormulaDependencyIssueDetails(finding.Details, includeMissingCachedDependencyIssues).Count;
+            }
+
+            return count;
+        }
+
+        private static IReadOnlyList<string> FilterFormulaDependencyIssueDetails(IReadOnlyList<string> details, bool includeMissingCachedDependencyIssues) {
+            if (includeMissingCachedDependencyIssues) {
+                return details;
+            }
+
+            var filtered = new List<string>();
+            foreach (string detail in details) {
+                int separator = detail.IndexOf(": ", StringComparison.Ordinal);
+                if (separator < 0) {
+                    if (detail.IndexOf("without a cached result", StringComparison.OrdinalIgnoreCase) < 0) {
+                        filtered.Add(detail);
+                    }
+                    continue;
+                }
+
+                string prefix = detail.Substring(0, separator);
+                string[] issues = detail.Substring(separator + 2)
+                    .Split(new[] { "; " }, StringSplitOptions.RemoveEmptyEntries);
+                var calculationIssues = issues
+                    .Where(issue => issue.IndexOf("without a cached result", StringComparison.OrdinalIgnoreCase) < 0)
+                    .ToArray();
+                if (calculationIssues.Length > 0) {
+                    filtered.Add(prefix + ": " + string.Join("; ", calculationIssues));
+                }
+            }
+
+            return filtered;
         }
 
         private static void AddFeatureDiagnostics(List<string> messages, IEnumerable<ExcelFeatureFinding> findings) {

--- a/OfficeIMO.Excel/ExcelFeatureReport.Preflight.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.Preflight.cs
@@ -78,6 +78,7 @@ namespace OfficeIMO.Excel {
             FindFeatureCount("PDF-unsupported hyperlinks") == 0 &&
             FindFeatureCount("PDF-unrendered drawing shapes") == 0 &&
             FindFeatureCount("PDF-unsupported print areas") == 0 &&
+            FindFeatureCount("PDF-unsupported print titles") == 0 &&
             FindFeatureCount("PDF-unsupported header/footer formatting") == 0 &&
             FindFeatureCount("PDF-unrendered pivot tables") == 0 &&
             FindFeatureCount("PDF-unrendered sparklines") == 0 &&
@@ -169,6 +170,7 @@ namespace OfficeIMO.Excel {
                     AddFeatureDiagnostics(messages, FindFeatures("PDF-unsupported hyperlinks"));
                     AddFeatureDiagnostics(messages, FindFeatures("PDF-unrendered drawing shapes"));
                     AddFeatureDiagnostics(messages, FindFeatures("PDF-unsupported print areas"));
+                    AddFeatureDiagnostics(messages, FindFeatures("PDF-unsupported print titles"));
                     AddFeatureDiagnostics(messages, FindFeatures("PDF-unsupported header/footer formatting"));
                     AddFeatureDiagnostics(messages, FindFeatures("PDF-unrendered pivot tables"));
                     AddFeatureDiagnostics(messages, FindFeatures("PDF-unrendered sparklines"));

--- a/OfficeIMO.Excel/ExcelFeatureReport.Preflight.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.Preflight.cs
@@ -66,9 +66,10 @@ namespace OfficeIMO.Excel {
         /// True when the workbook is suitable for the first-party report-grade Excel-to-PDF export path.
         /// </summary>
         public bool CanExportPdfReport =>
-            !HasAdvancedFeatures &&
+            !HasPdfExportWorkbookBlockers() &&
             CanUseCachedFormulaValues &&
-            FindFeatureCount("PDF-unsupported charts") == 0;
+            FindFeatureCount("PDF-unsupported charts") == 0 &&
+            FindFeatureCount("Non-worksheet sheets") == 0;
 
         /// <summary>
         /// Returns true when the requested workflow-level capability can be attempted for this workbook.
@@ -145,10 +146,10 @@ namespace OfficeIMO.Excel {
                     AddPreservedDiagnostics(messages, "Template binding should not be attempted while preserve-only workbook features are present unless the workflow has explicit preservation coverage for those parts.");
                     break;
                 case ExcelPreflightCapability.ExportPdfReport:
-                    AddUnsupportedDiagnostics(messages, "Excel-to-PDF report export is blocked by unsupported workbook features.");
-                    AddPreservedDiagnostics(messages, "Excel-to-PDF report export does not render preserve-only workbook features.");
+                    AddPdfExportWorkbookDiagnostics(messages);
                     AddFormulaDiagnostics(messages, requireCachedValues: true, requireSupportedFormulas: false);
                     AddFeatureDiagnostics(messages, FindFeatures("PDF-unsupported charts"));
+                    AddFeatureDiagnostics(messages, FindFeatures("Non-worksheet sheets"));
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(capability), capability, "Unsupported Excel preflight capability.");
@@ -159,6 +160,48 @@ namespace OfficeIMO.Excel {
             }
 
             return messages.AsReadOnly();
+        }
+
+        private bool HasPdfExportWorkbookBlockers() {
+            if (UnsupportedFeatures.Count > 0) {
+                return true;
+            }
+
+            return PreservedFeatures.Any(IsPdfExportWorkbookBlocker);
+        }
+
+        private void AddPdfExportWorkbookDiagnostics(List<string> messages) {
+            AddUnsupportedDiagnostics(messages, "Excel-to-PDF report export is blocked by unsupported workbook features.");
+            var preservedBlockers = PreservedFeatures
+                .Where(IsPdfExportWorkbookBlocker)
+                .ToArray();
+            if (preservedBlockers.Length == 0) {
+                return;
+            }
+
+            AddDistinct(messages, "Excel-to-PDF report export does not render preserve-only workbook features.");
+            AddFeatureDiagnostics(messages, preservedBlockers);
+        }
+
+        private static bool IsPdfExportWorkbookBlocker(ExcelFeatureFinding finding) {
+            return !IsFormulaCachedValueFinding(finding);
+        }
+
+        private static bool IsFormulaCachedValueFinding(ExcelFeatureFinding finding) {
+            if (!string.Equals(finding.Category, "Calculation", StringComparison.Ordinal)) {
+                return false;
+            }
+
+            switch (finding.Name) {
+                case "Unsupported formulas":
+                case "Missing formula caches":
+                case "Dirty formula caches":
+                case "Formula dependency issues":
+                case "Formula calculation blockers":
+                    return true;
+                default:
+                    return false;
+            }
         }
 
         private void AddUnsupportedDiagnostics(List<string> messages, string fallbackMessage) {

--- a/OfficeIMO.Excel/ExcelFeatureReport.Preflight.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.Preflight.cs
@@ -1,0 +1,228 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Workflow-level OfficeIMO.Excel operation categories covered by feature preflight checks.
+    /// </summary>
+    public enum ExcelPreflightCapability {
+        /// <summary>Read worksheet data, tables, and typed rows from the workbook.</summary>
+        ReadWorkbookData,
+
+        /// <summary>Edit existing cell values while preserving package parts OfficeIMO does not fully author yet.</summary>
+        EditCellValues,
+
+        /// <summary>Perform structure-changing edits such as adding/removing sheets, tables, drawings, pivots, or relationships.</summary>
+        EditWorkbookStructure,
+
+        /// <summary>Use cached formula values for reads, export, or downstream reporting.</summary>
+        UseCachedFormulaValues,
+
+        /// <summary>Calculate workbook formulas through OfficeIMO's lightweight evaluator.</summary>
+        CalculateFormulas,
+
+        /// <summary>Bind data into an Excel template and save the generated workbook.</summary>
+        BindTemplate,
+
+        /// <summary>Export a report workbook through the first-party OfficeIMO Excel-to-PDF path.</summary>
+        ExportPdfReport
+    }
+
+    public sealed partial class ExcelFeatureReport {
+        /// <summary>
+        /// True when OfficeIMO can attempt read-oriented workbook data operations.
+        /// </summary>
+        public bool CanReadWorkbookData => UnsupportedFeatures.Count == 0;
+
+        /// <summary>
+        /// True when OfficeIMO can attempt cell-value edits without known unsupported package features.
+        /// </summary>
+        public bool CanEditCellValues => UnsupportedFeatures.Count == 0;
+
+        /// <summary>
+        /// True when OfficeIMO can attempt structure-changing workbook edits without preserve-only or unsupported feature blockers.
+        /// </summary>
+        public bool CanEditWorkbookStructure => !HasAdvancedFeatures;
+
+        /// <summary>
+        /// True when cached formula values can be trusted for read/export workflows.
+        /// </summary>
+        public bool CanUseCachedFormulaValues =>
+            FindFeatureCount("Missing formula caches") == 0 &&
+            FindFeatureCount("Formula dependency issues") == 0;
+
+        /// <summary>
+        /// True when OfficeIMO's lightweight evaluator can calculate all discovered formulas without known dependency issues.
+        /// </summary>
+        public bool CanCalculateFormulas =>
+            FindFeatureCount("Unsupported formulas") == 0 &&
+            FindFeatureCount("Formula dependency issues") == 0;
+
+        /// <summary>
+        /// True when template binding can be attempted without preserve-only or unsupported advanced package features.
+        /// </summary>
+        public bool CanBindTemplate => !HasAdvancedFeatures;
+
+        /// <summary>
+        /// True when the workbook is suitable for the first-party report-grade Excel-to-PDF export path.
+        /// </summary>
+        public bool CanExportPdfReport =>
+            !HasAdvancedFeatures &&
+            CanUseCachedFormulaValues;
+
+        /// <summary>
+        /// Returns true when the requested workflow-level capability can be attempted for this workbook.
+        /// </summary>
+        /// <param name="capability">The OfficeIMO.Excel workflow capability to check.</param>
+        public bool Can(ExcelPreflightCapability capability) {
+            switch (capability) {
+                case ExcelPreflightCapability.ReadWorkbookData:
+                    return CanReadWorkbookData;
+                case ExcelPreflightCapability.EditCellValues:
+                    return CanEditCellValues;
+                case ExcelPreflightCapability.EditWorkbookStructure:
+                    return CanEditWorkbookStructure;
+                case ExcelPreflightCapability.UseCachedFormulaValues:
+                    return CanUseCachedFormulaValues;
+                case ExcelPreflightCapability.CalculateFormulas:
+                    return CanCalculateFormulas;
+                case ExcelPreflightCapability.BindTemplate:
+                    return CanBindTemplate;
+                case ExcelPreflightCapability.ExportPdfReport:
+                    return CanExportPdfReport;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(capability), capability, "Unsupported Excel preflight capability.");
+            }
+        }
+
+        /// <summary>
+        /// Throws with workflow-specific diagnostics when the requested capability cannot be attempted for this workbook.
+        /// </summary>
+        /// <param name="capability">The OfficeIMO.Excel workflow capability that must be available.</param>
+        /// <returns>The current feature report for fluent guard usage.</returns>
+        public ExcelFeatureReport EnsureCan(ExcelPreflightCapability capability) {
+            if (Can(capability)) {
+                return this;
+            }
+
+            IReadOnlyList<string> diagnostics = GetCapabilityDiagnostics(capability);
+            string detail = diagnostics.Count == 0
+                ? "No additional diagnostics were reported."
+                : string.Join("; ", diagnostics);
+            throw new InvalidOperationException($"Excel preflight capability '{capability}' is not available: {detail}");
+        }
+
+        /// <summary>
+        /// Returns operation-specific diagnostics explaining why a workflow-level capability is blocked, or an empty list when it can be attempted.
+        /// </summary>
+        /// <param name="capability">The OfficeIMO.Excel workflow capability to explain.</param>
+        public IReadOnlyList<string> GetCapabilityDiagnostics(ExcelPreflightCapability capability) {
+            if (Can(capability)) {
+                return Array.Empty<string>();
+            }
+
+            var messages = new List<string>();
+            switch (capability) {
+                case ExcelPreflightCapability.ReadWorkbookData:
+                    AddUnsupportedDiagnostics(messages, "Workbook data reads are blocked by unsupported workbook features.");
+                    break;
+                case ExcelPreflightCapability.EditCellValues:
+                    AddUnsupportedDiagnostics(messages, "Cell-value edits are blocked by unsupported workbook features.");
+                    break;
+                case ExcelPreflightCapability.EditWorkbookStructure:
+                    AddUnsupportedDiagnostics(messages, "Structure-changing edits are blocked by unsupported workbook features.");
+                    AddPreservedDiagnostics(messages, "Structure-changing edits should not be attempted while preserve-only workbook features are present.");
+                    break;
+                case ExcelPreflightCapability.UseCachedFormulaValues:
+                    AddFormulaDiagnostics(messages, requireCachedValues: true, requireSupportedFormulas: false);
+                    break;
+                case ExcelPreflightCapability.CalculateFormulas:
+                    AddFormulaDiagnostics(messages, requireCachedValues: false, requireSupportedFormulas: true);
+                    break;
+                case ExcelPreflightCapability.BindTemplate:
+                    AddUnsupportedDiagnostics(messages, "Template binding is blocked by unsupported workbook features.");
+                    AddPreservedDiagnostics(messages, "Template binding should not be attempted while preserve-only workbook features are present unless the workflow has explicit preservation coverage for those parts.");
+                    break;
+                case ExcelPreflightCapability.ExportPdfReport:
+                    AddUnsupportedDiagnostics(messages, "Excel-to-PDF report export is blocked by unsupported workbook features.");
+                    AddPreservedDiagnostics(messages, "Excel-to-PDF report export does not render preserve-only workbook features.");
+                    AddFormulaDiagnostics(messages, requireCachedValues: true, requireSupportedFormulas: false);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(capability), capability, "Unsupported Excel preflight capability.");
+            }
+
+            if (messages.Count == 0) {
+                AddDistinct(messages, "The requested Excel workflow is not available for this workbook.");
+            }
+
+            return messages.AsReadOnly();
+        }
+
+        private void AddUnsupportedDiagnostics(List<string> messages, string fallbackMessage) {
+            if (UnsupportedFeatures.Count == 0) {
+                return;
+            }
+
+            AddDistinct(messages, fallbackMessage);
+            AddFeatureDiagnostics(messages, UnsupportedFeatures);
+        }
+
+        private void AddPreservedDiagnostics(List<string> messages, string fallbackMessage) {
+            if (PreservedFeatures.Count == 0) {
+                return;
+            }
+
+            AddDistinct(messages, fallbackMessage);
+            AddFeatureDiagnostics(messages, PreservedFeatures);
+        }
+
+        private void AddFormulaDiagnostics(List<string> messages, bool requireCachedValues, bool requireSupportedFormulas) {
+            if (requireSupportedFormulas) {
+                AddFeatureDiagnostics(messages, FindFeatures("Unsupported formulas"));
+            }
+
+            if (requireCachedValues) {
+                AddFeatureDiagnostics(messages, FindFeatures("Missing formula caches"));
+            }
+
+            AddFeatureDiagnostics(messages, FindFeatures("Formula dependency issues"));
+        }
+
+        private static void AddFeatureDiagnostics(List<string> messages, IEnumerable<ExcelFeatureFinding> findings) {
+            foreach (ExcelFeatureFinding finding in findings) {
+                AddDistinct(messages, FormatCapabilityFinding(finding));
+            }
+        }
+
+        private static string FormatCapabilityFinding(ExcelFeatureFinding finding) {
+            string message = $"{finding.Name} ({finding.Count}, {finding.SupportLevel}): {finding.Note}";
+            if (finding.Details.Count == 0) {
+                return message;
+            }
+
+            const int maxDetails = 3;
+            string details = string.Join("; ", finding.Details.Take(maxDetails));
+            if (finding.Details.Count > maxDetails) {
+                details += $"; +{finding.Details.Count - maxDetails} more";
+            }
+
+            return message + " [" + details + "]";
+        }
+
+        private int FindFeatureCount(string featureName) {
+            return FindFeatures(featureName).Sum(feature => feature.Count);
+        }
+
+        private static void AddDistinct(List<string> messages, string message) {
+            if (string.IsNullOrWhiteSpace(message)) {
+                return;
+            }
+
+            for (int i = 0; i < messages.Count; i++) {
+                if (string.Equals(messages[i], message, StringComparison.Ordinal)) {
+                    return;
+                }
+            }
+
+            messages.Add(message);
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelFeatureReport.Preflight.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.Preflight.cs
@@ -51,7 +51,7 @@ namespace OfficeIMO.Excel {
         public bool CanUseCachedFormulaValues =>
             FindFeatureCount("Missing formula caches") == 0 &&
             FindFeatureCount("Dirty formula caches") == 0 &&
-            FindFeatureCount("Formula dependency issues") == 0;
+            FindFeatureCount("Workbook recalculation requests") == 0;
 
         /// <summary>
         /// True when OfficeIMO's lightweight evaluator can calculate all discovered formulas without known dependency issues.
@@ -73,6 +73,8 @@ namespace OfficeIMO.Excel {
             FindFeatureCount("PDF-unsupported charts") == 0 &&
             FindFeatureCount("PDF-unreadable charts") == 0 &&
             FindFeatureCount("PDF-unsupported images") == 0 &&
+            FindFeatureCount("PDF-unsupported hyperlinks") == 0 &&
+            FindFeatureCount("PDF-unrendered drawing shapes") == 0 &&
             FindFeatureCount("PDF-unrendered pivot tables") == 0 &&
             FindFeatureCount("PDF-unrendered sparklines") == 0 &&
             FindFeatureCount("Non-worksheet sheets") == 0;
@@ -158,6 +160,8 @@ namespace OfficeIMO.Excel {
                     AddFeatureDiagnostics(messages, FindFeatures("PDF-unsupported charts"));
                     AddFeatureDiagnostics(messages, FindFeatures("PDF-unreadable charts"));
                     AddFeatureDiagnostics(messages, FindFeatures("PDF-unsupported images"));
+                    AddFeatureDiagnostics(messages, FindFeatures("PDF-unsupported hyperlinks"));
+                    AddFeatureDiagnostics(messages, FindFeatures("PDF-unrendered drawing shapes"));
                     AddFeatureDiagnostics(messages, FindFeatures("PDF-unrendered pivot tables"));
                     AddFeatureDiagnostics(messages, FindFeatures("PDF-unrendered sparklines"));
                     AddFeatureDiagnostics(messages, FindFeatures("Non-worksheet sheets"));
@@ -207,6 +211,7 @@ namespace OfficeIMO.Excel {
                 case "Unsupported formulas":
                 case "Missing formula caches":
                 case "Dirty formula caches":
+                case "Workbook recalculation requests":
                 case "Formula dependency issues":
                 case "Formula calculation blockers":
                     return true;
@@ -241,7 +246,7 @@ namespace OfficeIMO.Excel {
             if (requireCachedValues) {
                 AddFeatureDiagnostics(messages, FindFeatures("Missing formula caches"));
                 AddFeatureDiagnostics(messages, FindFeatures("Dirty formula caches"));
-                AddFeatureDiagnostics(messages, FindFeatures("Formula dependency issues"));
+                AddFeatureDiagnostics(messages, FindFeatures("Workbook recalculation requests"));
                 return;
             }
 

--- a/OfficeIMO.Excel/ExcelFeatureReport.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.cs
@@ -327,6 +327,8 @@ namespace OfficeIMO.Excel {
             int dataValidationCount = 0;
             int conditionalFormattingCount = 0;
             int sparklineCount = 0;
+            int pdfUnrenderedPivotCount = 0;
+            int pdfUnrenderedSparklineCount = 0;
             int legacyCommentCount = 0;
             int threadedCommentPartCount = 0;
             int imagePartCount = 0;
@@ -336,6 +338,8 @@ namespace OfficeIMO.Excel {
             int pdfUnsupportedChartCount = 0;
             int pdfUnreadableChartCount = 0;
             int pdfUnsupportedImageCount = 0;
+            int pdfUnsupportedHyperlinkCount = 0;
+            int pdfUnrenderedDrawingShapeCount = 0;
             var threadedCommentDetails = new List<string>();
             var oleObjectDetails = new List<string>();
             var formControlDetails = new List<string>();
@@ -343,8 +347,12 @@ namespace OfficeIMO.Excel {
             var pdfUnsupportedChartDetails = new List<string>();
             var pdfUnreadableChartDetails = new List<string>();
             var pdfUnsupportedImageDetails = new List<string>();
+            var pdfUnsupportedHyperlinkDetails = new List<string>();
             var pivotDetails = new List<string>();
+            var pdfUnrenderedPivotDetails = new List<string>();
             var sparklineDetails = new List<string>();
+            var pdfUnrenderedSparklineDetails = new List<string>();
+            var pdfUnrenderedDrawingShapeDetails = new List<string>();
             var threadedCommentPeople = BuildThreadedCommentPersonMap(workbookPart);
 
             foreach (var sheet in sheetElements) {
@@ -361,6 +369,7 @@ namespace OfficeIMO.Excel {
 
                 var excelSheet = new ExcelSheet(this, _spreadSheetDocument!, sheet);
                 var worksheet = worksheetPart.Worksheet;
+                bool isVisibleForDefaultPdfExport = !IsHiddenSheet(sheet);
                 tableCount += worksheetPart.TableDefinitionParts.Count();
                 int sheetPivotCount = worksheetPart.PivotTableParts.Count();
                 pivotCount += sheetPivotCount;
@@ -370,6 +379,12 @@ namespace OfficeIMO.Excel {
                 sparklineCount += sheetSparklineCount;
                 if (sheetPivotCount > 0) pivotDetails.Add($"{sheet.Name}: {sheetPivotCount} pivot table(s)");
                 if (sheetSparklineCount > 0) sparklineDetails.Add($"{sheet.Name}: {sheetSparklineCount} sparkline(s)");
+                if (isVisibleForDefaultPdfExport) {
+                    pdfUnrenderedPivotCount += sheetPivotCount;
+                    pdfUnrenderedSparklineCount += sheetSparklineCount;
+                    if (sheetPivotCount > 0) pdfUnrenderedPivotDetails.Add($"{sheet.Name}: {sheetPivotCount} pivot table(s)");
+                    if (sheetSparklineCount > 0) pdfUnrenderedSparklineDetails.Add($"{sheet.Name}: {sheetSparklineCount} sparkline(s)");
+                }
                 legacyCommentCount += worksheetPart.WorksheetCommentsPart?.Comments?.CommentList?.Elements<DocumentFormat.OpenXml.Spreadsheet.Comment>().Count() ?? 0;
                 var threadedComments = BuildThreadedCommentMap(worksheetPart, threadedCommentPeople)
                     .Values
@@ -384,7 +399,7 @@ namespace OfficeIMO.Excel {
                 var images = excelSheet.Images.ToList();
                 imagePartCount += images.Count;
                 foreach (ExcelImage image in images) {
-                    if (!IsPdfSupportedWorksheetImage(image, out string reason)) {
+                    if (isVisibleForDefaultPdfExport && !IsPdfSupportedWorksheetImage(image, out string reason)) {
                         pdfUnsupportedImageCount++;
                         pdfUnsupportedImageDetails.Add($"{sheet.Name}!{A1.CellReference(image.RowIndex, image.ColumnIndex)}: {reason}");
                     }
@@ -392,7 +407,7 @@ namespace OfficeIMO.Excel {
 
                 var charts = excelSheet.Charts.ToList();
                 chartCount += charts.Count;
-                foreach (ExcelChart chart in charts) {
+                foreach (ExcelChart chart in charts.Where(_ => isVisibleForDefaultPdfExport)) {
                     if (!chart.TryGetSnapshot(out ExcelChartSnapshot snapshot)) {
                         pdfUnreadableChartCount++;
                         pdfUnreadableChartDetails.Add($"{sheet.Name}: {GetChartDisplayName(chart)} data could not be read into a PDF snapshot.");
@@ -410,6 +425,11 @@ namespace OfficeIMO.Excel {
                         pdfUnsupportedChartDetails.Add($"{sheet.Name}: {snapshot.ChartType} ({GetChartDisplayName(snapshot)})");
                     }
                 }
+                if (isVisibleForDefaultPdfExport) {
+                    AddUnsupportedHeaderFooterImages(excelSheet.GetHeaderFooter(), sheet.Name?.Value ?? string.Empty, ref pdfUnsupportedImageCount, pdfUnsupportedImageDetails);
+                    AddUnrenderedDrawingShapes(worksheetPart, sheet.Name?.Value ?? string.Empty, ref pdfUnrenderedDrawingShapeCount, pdfUnrenderedDrawingShapeDetails);
+                    AddUnsupportedDrawingHyperlinks(worksheetPart, sheet.Name?.Value ?? string.Empty, ref pdfUnsupportedHyperlinkCount, pdfUnsupportedHyperlinkDetails);
+                }
                 int sheetOleObjects = CountDescendantsByLocalName(worksheet, "oleObject");
                 int sheetFormControls = CountDescendantsByLocalName(worksheet, "control") + CountDescendantsByLocalName(worksheet, "formControl");
                 oleObjectCount += sheetOleObjects;
@@ -419,6 +439,10 @@ namespace OfficeIMO.Excel {
                 if (sheetFormControls > 0) formControlDetails.Add($"{sheet.Name}: {sheetFormControls} form control marker(s)");
                 foreach (var relationship in worksheetPart.HyperlinkRelationships) {
                     externalHyperlinkDetails.Add($"{sheet.Name}: {relationship.Id} -> {relationship.Uri}");
+                    if (isVisibleForDefaultPdfExport && !IsSupportedPdfExternalHyperlink(relationship.Uri)) {
+                        pdfUnsupportedHyperlinkCount++;
+                        pdfUnsupportedHyperlinkDetails.Add($"{sheet.Name}: {relationship.Id} -> {relationship.Uri} is not an absolute URI supported by the first-party PDF hyperlink writer.");
+                    }
                 }
             }
 
@@ -438,14 +462,14 @@ namespace OfficeIMO.Excel {
                 pdfUnreadableChartDetails);
             Add(features, "Visualization", "Pivot tables", ExcelFeatureSupportLevel.PartiallyEditable, pivotCount, null,
                 "Source-range pivot creation and inspection are supported, including composable fluent field sort/subtotal/layout/display/number-format helpers with built-in/custom id/code readback, field item/page filters with fluent helpers plus hidden, visible, and selected-item readback, common label/value filters, negated filter variants, fixed and dynamic date filters, top/bottom count/percent/sum filters, formula-backed calculated fields with number-format id/code readback, date/number grouping metadata, generated multi-level date hierarchy fields with base/parent relationships, and explicit grouped-cache item metadata; slicers, deeper Excel interoperability checks, and advanced filters remain partial.");
-            Add(features, "Visualization", "PDF-unrendered pivot tables", ExcelFeatureSupportLevel.PartiallyEditable, pivotCount, null,
+            Add(features, "Visualization", "PDF-unrendered pivot tables", ExcelFeatureSupportLevel.PartiallyEditable, pdfUnrenderedPivotCount, null,
                 "Pivot table metadata is not rendered by the first-party Excel-to-PDF path unless the pivot output is already materialized as ordinary worksheet cells.",
-                pivotDetails);
+                pdfUnrenderedPivotDetails);
             Add(features, "Visualization", "Sparklines", ExcelFeatureSupportLevel.Editable, sparklineCount, null,
                 "Line, column, and win/loss sparklines can be authored.");
-            Add(features, "Visualization", "PDF-unrendered sparklines", ExcelFeatureSupportLevel.PartiallyEditable, sparklineCount, null,
+            Add(features, "Visualization", "PDF-unrendered sparklines", ExcelFeatureSupportLevel.PartiallyEditable, pdfUnrenderedSparklineCount, null,
                 "Sparkline metadata is authored and preserved in worksheets, but the first-party Excel-to-PDF path does not render sparkline visuals.",
-                sparklineDetails);
+                pdfUnrenderedSparklineDetails);
             Add(features, "Collaboration", "Legacy comments", ExcelFeatureSupportLevel.PartiallyEditable, legacyCommentCount, null,
                 "Legacy comments can be authored and inspected, including rich-text runs for authored comments; threaded comment workflows remain preserve-only.");
             Add(features, "Collaboration", "Threaded comments", ExcelFeatureSupportLevel.Preserved, threadedCommentPartCount, null,
@@ -456,6 +480,9 @@ namespace OfficeIMO.Excel {
             Add(features, "Media", "PDF-unsupported images", ExcelFeatureSupportLevel.PartiallyEditable, pdfUnsupportedImageCount, null,
                 "Worksheet images are present but are skipped by the first-party Excel-to-PDF image writer because only valid PNG and JPEG images are rendered.",
                 pdfUnsupportedImageDetails);
+            Add(features, "Media", "PDF-unrendered drawing shapes", ExcelFeatureSupportLevel.PartiallyEditable, pdfUnrenderedDrawingShapeCount, null,
+                "Worksheet drawing shapes and text boxes are present but are skipped by the first-party Excel-to-PDF path.",
+                pdfUnrenderedDrawingShapeDetails);
             Add(features, "Compatibility", "OLE objects", ExcelFeatureSupportLevel.Preserved, oleObjectCount, null,
                 "Embedded OLE objects are advanced package content and should be treated as preserve-only.", oleObjectDetails);
             Add(features, "Compatibility", "Form controls", ExcelFeatureSupportLevel.Preserved, formControlCount, null,
@@ -463,6 +490,9 @@ namespace OfficeIMO.Excel {
             Add(features, "Compatibility", "External hyperlinks", ExcelFeatureSupportLevel.PartiallyEditable, externalHyperlinkCount, null,
                 "Worksheet external hyperlinks can be authored and are rendered by PDF export when they target absolute URIs.",
                 externalHyperlinkDetails);
+            Add(features, "Compatibility", "PDF-unsupported hyperlinks", ExcelFeatureSupportLevel.PartiallyEditable, pdfUnsupportedHyperlinkCount, null,
+                "These external hyperlinks are present but are skipped by the first-party Excel-to-PDF hyperlink writer.",
+                pdfUnsupportedHyperlinkDetails);
             Add(features, "Compatibility", "Non-worksheet sheets", ExcelFeatureSupportLevel.Preserved, nonWorksheetSheetCount, null,
                 "Chartsheets and other non-worksheet sheet parts are preserve-only and cannot be materialized by worksheet-only workflows.",
                 nonWorksheetSheetDetails);
@@ -480,6 +510,9 @@ namespace OfficeIMO.Excel {
                     .Where(formula => formula.IsDirty)
                     .Select(formula => $"{formula.SheetName}!{formula.CellReference}")
                     .ToArray());
+            Add(features, "Calculation", "Workbook recalculation requests", ExcelFeatureSupportLevel.Preserved, HasWorkbookRecalculationRequest(workbook) ? 1 : 0, null,
+                "The workbook requests full recalculation on open, so cached formula values should be refreshed before cached-value reads are trusted.",
+                DescribeWorkbookRecalculationRequest(workbook).ToArray());
             var formulaCalculationBlockers = formulas.Formulas
                 .SelectMany(GetFormulaCalculationBlockers)
                 .ToArray();
@@ -487,7 +520,7 @@ namespace OfficeIMO.Excel {
                 "These formula cells need Excel recalculation or broader evaluator support before OfficeIMO can calculate the workbook.",
                 formulaCalculationBlockers);
             Add(features, "Calculation", "Formula dependency issues", ExcelFeatureSupportLevel.Preserved, formulas.DependencyIssueCount, null,
-                "Formula dependencies need review before cached-value reads, calculation, or report export can be trusted.",
+                "Formula dependencies need review before OfficeIMO calculation can be trusted; clean cached values remain usable when every formula cache is present and current.",
                 formulas.Formulas
                     .Where(formula => formula.DependencyIssues.Count > 0)
                     .Select(formula => $"{formula.SheetName}!{formula.CellReference}: {string.Join("; ", formula.DependencyIssues)}")

--- a/OfficeIMO.Excel/ExcelFeatureReport.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.cs
@@ -428,6 +428,7 @@ namespace OfficeIMO.Excel {
                 if (isVisibleForDefaultPdfExport) {
                     AddUnsupportedHeaderFooterImages(excelSheet.GetHeaderFooter(), sheet.Name?.Value ?? string.Empty, ref pdfUnsupportedImageCount, pdfUnsupportedImageDetails);
                     AddUnrenderedDrawingShapes(worksheetPart, sheet.Name?.Value ?? string.Empty, ref pdfUnrenderedDrawingShapeCount, pdfUnrenderedDrawingShapeDetails);
+                    AddUnsupportedWorksheetHyperlinks(workbookPart, sheetElements, worksheetPart, sheet.Name?.Value ?? string.Empty, ref pdfUnsupportedHyperlinkCount, pdfUnsupportedHyperlinkDetails);
                     AddUnsupportedDrawingHyperlinks(worksheetPart, sheet.Name?.Value ?? string.Empty, ref pdfUnsupportedHyperlinkCount, pdfUnsupportedHyperlinkDetails);
                 }
                 int sheetOleObjects = CountDescendantsByLocalName(worksheet, "oleObject");
@@ -498,6 +499,7 @@ namespace OfficeIMO.Excel {
                 nonWorksheetSheetDetails);
 
             var formulas = InspectFormulas();
+            bool hasWorkbookRecalculationRequest = formulas.Formulas.Count > 0 && HasWorkbookRecalculationRequest(workbook);
             Add(features, "Calculation", "Supported formulas", ExcelFeatureSupportLevel.PartiallyEditable, formulas.SupportedFormulas, null,
                 "Simple supported formulas can be recalculated by OfficeIMO.");
             Add(features, "Calculation", "Unsupported formulas", ExcelFeatureSupportLevel.Preserved, formulas.UnsupportedFormulas, null,
@@ -510,9 +512,9 @@ namespace OfficeIMO.Excel {
                     .Where(formula => formula.IsDirty)
                     .Select(formula => $"{formula.SheetName}!{formula.CellReference}")
                     .ToArray());
-            Add(features, "Calculation", "Workbook recalculation requests", ExcelFeatureSupportLevel.Preserved, HasWorkbookRecalculationRequest(workbook) ? 1 : 0, null,
+            Add(features, "Calculation", "Workbook recalculation requests", ExcelFeatureSupportLevel.Preserved, hasWorkbookRecalculationRequest ? 1 : 0, null,
                 "The workbook requests full recalculation on open, so cached formula values should be refreshed before cached-value reads are trusted.",
-                DescribeWorkbookRecalculationRequest(workbook).ToArray());
+                hasWorkbookRecalculationRequest ? DescribeWorkbookRecalculationRequest(workbook).ToArray() : Array.Empty<string>());
             var formulaCalculationBlockers = formulas.Formulas
                 .SelectMany(GetFormulaCalculationBlockers)
                 .ToArray();

--- a/OfficeIMO.Excel/ExcelFeatureReport.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.cs
@@ -1,6 +1,5 @@
 using DocumentFormat.OpenXml.Packaging;
 using System.Text;
-using C = DocumentFormat.OpenXml.Drawing.Charts;
 
 namespace OfficeIMO.Excel {
     /// <summary>
@@ -335,11 +334,17 @@ namespace OfficeIMO.Excel {
             int formControlCount = 0;
             int externalHyperlinkCount = 0;
             int pdfUnsupportedChartCount = 0;
+            int pdfUnreadableChartCount = 0;
+            int pdfUnsupportedImageCount = 0;
             var threadedCommentDetails = new List<string>();
             var oleObjectDetails = new List<string>();
             var formControlDetails = new List<string>();
             var externalHyperlinkDetails = new List<string>();
             var pdfUnsupportedChartDetails = new List<string>();
+            var pdfUnreadableChartDetails = new List<string>();
+            var pdfUnsupportedImageDetails = new List<string>();
+            var pivotDetails = new List<string>();
+            var sparklineDetails = new List<string>();
             var threadedCommentPeople = BuildThreadedCommentPersonMap(workbookPart);
 
             foreach (var sheet in sheetElements) {
@@ -354,12 +359,17 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
+                var excelSheet = new ExcelSheet(this, _spreadSheetDocument!, sheet);
                 var worksheet = worksheetPart.Worksheet;
                 tableCount += worksheetPart.TableDefinitionParts.Count();
-                pivotCount += worksheetPart.PivotTableParts.Count();
+                int sheetPivotCount = worksheetPart.PivotTableParts.Count();
+                pivotCount += sheetPivotCount;
                 dataValidationCount += worksheet?.Descendants<DocumentFormat.OpenXml.Spreadsheet.DataValidation>().Count() ?? 0;
                 conditionalFormattingCount += worksheet?.Elements<DocumentFormat.OpenXml.Spreadsheet.ConditionalFormatting>().Count() ?? 0;
-                sparklineCount += CountDescendantsByLocalName(worksheet, "sparkline");
+                int sheetSparklineCount = CountDescendantsByLocalName(worksheet, "sparkline");
+                sparklineCount += sheetSparklineCount;
+                if (sheetPivotCount > 0) pivotDetails.Add($"{sheet.Name}: {sheetPivotCount} pivot table(s)");
+                if (sheetSparklineCount > 0) sparklineDetails.Add($"{sheet.Name}: {sheetSparklineCount} sparkline(s)");
                 legacyCommentCount += worksheetPart.WorksheetCommentsPart?.Comments?.CommentList?.Elements<DocumentFormat.OpenXml.Spreadsheet.Comment>().Count() ?? 0;
                 var threadedComments = BuildThreadedCommentMap(worksheetPart, threadedCommentPeople)
                     .Values
@@ -370,22 +380,34 @@ namespace OfficeIMO.Excel {
                     string author = string.IsNullOrWhiteSpace(threadedComment.Author) ? threadedComment.PersonId ?? "unknown author" : threadedComment.Author!;
                     threadedCommentDetails.Add($"{sheet.Name}: {threadedComment.CellReference} by {author}");
                 }
-                imagePartCount += worksheetPart.DrawingsPart?.ImageParts.Count() ?? 0;
-                var chartParts = worksheetPart.DrawingsPart?.ChartParts.ToList() ?? new List<ChartPart>();
-                chartCount += chartParts.Count;
-                foreach (ChartPart chartPart in chartParts) {
-                    C.PlotArea? plotArea = chartPart.ChartSpace?.GetFirstChild<C.Chart>()?.GetFirstChild<C.PlotArea>();
-                    if (plotArea == null) {
+
+                var images = excelSheet.Images.ToList();
+                imagePartCount += images.Count;
+                foreach (ExcelImage image in images) {
+                    if (!IsPdfSupportedWorksheetImage(image, out string reason)) {
+                        pdfUnsupportedImageCount++;
+                        pdfUnsupportedImageDetails.Add($"{sheet.Name}!{A1.CellReference(image.RowIndex, image.ColumnIndex)}: {reason}");
+                    }
+                }
+
+                var charts = excelSheet.Charts.ToList();
+                chartCount += charts.Count;
+                foreach (ExcelChart chart in charts) {
+                    if (!chart.TryGetSnapshot(out ExcelChartSnapshot snapshot)) {
+                        pdfUnreadableChartCount++;
+                        pdfUnreadableChartDetails.Add($"{sheet.Name}: {GetChartDisplayName(chart)} data could not be read into a PDF snapshot.");
                         continue;
                     }
 
-                    ExcelChartType chartType = ExcelChartUtils.InferChartType(plotArea);
-                    if (HasMixedPdfChartTypes(plotArea)) {
+                    if (!HasRenderablePdfChartData(snapshot)) {
+                        pdfUnreadableChartCount++;
+                        pdfUnreadableChartDetails.Add($"{sheet.Name}: {GetChartDisplayName(snapshot)} does not contain renderable chart categories and series.");
+                    } else if (HasMixedPdfChartTypes(snapshot)) {
                         pdfUnsupportedChartCount++;
-                        pdfUnsupportedChartDetails.Add($"{sheet.Name}: mixed per-series chart types ({chartPart.Uri})");
-                    } else if (!IsPdfSupportedChartType(chartType)) {
+                        pdfUnsupportedChartDetails.Add($"{sheet.Name}: mixed per-series chart types ({GetChartDisplayName(snapshot)})");
+                    } else if (!IsPdfSupportedChartType(snapshot.ChartType)) {
                         pdfUnsupportedChartCount++;
-                        pdfUnsupportedChartDetails.Add($"{sheet.Name}: {chartType} ({chartPart.Uri})");
+                        pdfUnsupportedChartDetails.Add($"{sheet.Name}: {snapshot.ChartType} ({GetChartDisplayName(snapshot)})");
                     }
                 }
                 int sheetOleObjects = CountDescendantsByLocalName(worksheet, "oleObject");
@@ -411,10 +433,19 @@ namespace OfficeIMO.Excel {
             Add(features, "Visualization", "PDF-unsupported charts", ExcelFeatureSupportLevel.PartiallyEditable, pdfUnsupportedChartCount, null,
                 "These charts can be authored or preserved in the workbook but are skipped by the first-party Excel-to-PDF chart snapshot renderer.",
                 pdfUnsupportedChartDetails);
+            Add(features, "Visualization", "PDF-unreadable charts", ExcelFeatureSupportLevel.PartiallyEditable, pdfUnreadableChartCount, null,
+                "These charts are present in the workbook but cannot be read into the first-party Excel-to-PDF chart snapshot model.",
+                pdfUnreadableChartDetails);
             Add(features, "Visualization", "Pivot tables", ExcelFeatureSupportLevel.PartiallyEditable, pivotCount, null,
                 "Source-range pivot creation and inspection are supported, including composable fluent field sort/subtotal/layout/display/number-format helpers with built-in/custom id/code readback, field item/page filters with fluent helpers plus hidden, visible, and selected-item readback, common label/value filters, negated filter variants, fixed and dynamic date filters, top/bottom count/percent/sum filters, formula-backed calculated fields with number-format id/code readback, date/number grouping metadata, generated multi-level date hierarchy fields with base/parent relationships, and explicit grouped-cache item metadata; slicers, deeper Excel interoperability checks, and advanced filters remain partial.");
+            Add(features, "Visualization", "PDF-unrendered pivot tables", ExcelFeatureSupportLevel.PartiallyEditable, pivotCount, null,
+                "Pivot table metadata is not rendered by the first-party Excel-to-PDF path unless the pivot output is already materialized as ordinary worksheet cells.",
+                pivotDetails);
             Add(features, "Visualization", "Sparklines", ExcelFeatureSupportLevel.Editable, sparklineCount, null,
                 "Line, column, and win/loss sparklines can be authored.");
+            Add(features, "Visualization", "PDF-unrendered sparklines", ExcelFeatureSupportLevel.PartiallyEditable, sparklineCount, null,
+                "Sparkline metadata is authored and preserved in worksheets, but the first-party Excel-to-PDF path does not render sparkline visuals.",
+                sparklineDetails);
             Add(features, "Collaboration", "Legacy comments", ExcelFeatureSupportLevel.PartiallyEditable, legacyCommentCount, null,
                 "Legacy comments can be authored and inspected, including rich-text runs for authored comments; threaded comment workflows remain preserve-only.");
             Add(features, "Collaboration", "Threaded comments", ExcelFeatureSupportLevel.Preserved, threadedCommentPartCount, null,
@@ -422,10 +453,16 @@ namespace OfficeIMO.Excel {
                 threadedCommentDetails);
             Add(features, "Media", "Images", ExcelFeatureSupportLevel.PartiallyEditable, imagePartCount, null,
                 "Images can be inserted in common worksheet/header/footer scenarios; advanced drawing behaviors remain partial.");
+            Add(features, "Media", "PDF-unsupported images", ExcelFeatureSupportLevel.PartiallyEditable, pdfUnsupportedImageCount, null,
+                "Worksheet images are present but are skipped by the first-party Excel-to-PDF image writer because only valid PNG and JPEG images are rendered.",
+                pdfUnsupportedImageDetails);
             Add(features, "Compatibility", "OLE objects", ExcelFeatureSupportLevel.Preserved, oleObjectCount, null,
                 "Embedded OLE objects are advanced package content and should be treated as preserve-only.", oleObjectDetails);
             Add(features, "Compatibility", "Form controls", ExcelFeatureSupportLevel.Preserved, formControlCount, null,
                 "Form controls are preserve-only worksheet metadata.", formControlDetails);
+            Add(features, "Compatibility", "External hyperlinks", ExcelFeatureSupportLevel.PartiallyEditable, externalHyperlinkCount, null,
+                "Worksheet external hyperlinks can be authored and are rendered by PDF export when they target absolute URIs.",
+                externalHyperlinkDetails);
             Add(features, "Compatibility", "Non-worksheet sheets", ExcelFeatureSupportLevel.Preserved, nonWorksheetSheetCount, null,
                 "Chartsheets and other non-worksheet sheet parts are preserve-only and cannot be materialized by worksheet-only workflows.",
                 nonWorksheetSheetDetails);
@@ -474,8 +511,7 @@ namespace OfficeIMO.Excel {
             if (_spreadSheetDocument.ExtendedFilePropertiesPart?.Properties?.DigitalSignature != null) {
                 signatureDetails.Add("Extended application properties contain digital signature metadata.");
             }
-            var externalRelationshipDetails = DescribeExternalRelationships(allParts)
-                .Concat(externalHyperlinkDetails)
+            var externalRelationshipDetails = DescribeExternalRelationships(allParts, includeHyperlinks: false)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
@@ -486,7 +522,7 @@ namespace OfficeIMO.Excel {
             Add(features, "Compatibility", "Timelines", ExcelFeatureSupportLevel.Preserved, timelineDetails.Count, null,
                 "Timeline metadata is preserve-only; authoring timelines remains a roadmap item.", timelineDetails);
             Add(features, "Compatibility", "External workbook links", ExcelFeatureSupportLevel.Preserved, externalLinkDetails.Count + externalRelationshipDetails.Count, null,
-                "External relationships, external hyperlinks, and workbook-link parts should be treated carefully during round trips.",
+                "External relationships and workbook-link parts should be treated carefully during round trips.",
                 externalLinkDetails.Concat(externalRelationshipDetails).ToArray());
             Add(features, "Compatibility", "Connections and query tables", ExcelFeatureSupportLevel.Preserved, connectionDetails.Count, null,
                 "Connections and query-table metadata are preserve-only.", connectionDetails);
@@ -569,94 +605,14 @@ namespace OfficeIMO.Excel {
                 .ToList();
         }
 
-        private static List<string> DescribeExternalRelationships(IEnumerable<OpenXmlPart> parts) {
+        private static List<string> DescribeExternalRelationships(IEnumerable<OpenXmlPart> parts, bool includeHyperlinks = true) {
             return parts
-                .SelectMany(part => part.ExternalRelationships.Select(relationship =>
-                    $"{part.Uri}: {relationship.Id} -> {relationship.Uri}"))
+                .SelectMany(part => part.ExternalRelationships
+                    .Where(relationship => includeHyperlinks || !IsHyperlinkRelationship(relationship))
+                    .Select(relationship => $"{part.Uri}: {relationship.Id} -> {relationship.Uri}"))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .OrderBy(detail => detail, StringComparer.OrdinalIgnoreCase)
                 .ToList();
-        }
-
-        private static bool IsPdfSupportedChartType(ExcelChartType chartType) {
-            switch (chartType) {
-                case ExcelChartType.ColumnClustered:
-                case ExcelChartType.Column3DClustered:
-                case ExcelChartType.ColumnStacked:
-                case ExcelChartType.Column3DStacked:
-                case ExcelChartType.ColumnStacked100:
-                case ExcelChartType.Column3DStacked100:
-                case ExcelChartType.BarClustered:
-                case ExcelChartType.Bar3DClustered:
-                case ExcelChartType.BarStacked:
-                case ExcelChartType.Bar3DStacked:
-                case ExcelChartType.BarStacked100:
-                case ExcelChartType.Bar3DStacked100:
-                case ExcelChartType.Line:
-                case ExcelChartType.Line3D:
-                case ExcelChartType.LineStacked:
-                case ExcelChartType.LineStacked100:
-                case ExcelChartType.Area:
-                case ExcelChartType.Area3D:
-                case ExcelChartType.AreaStacked:
-                case ExcelChartType.Area3DStacked:
-                case ExcelChartType.AreaStacked100:
-                case ExcelChartType.Area3DStacked100:
-                case ExcelChartType.Scatter:
-                case ExcelChartType.Radar:
-                case ExcelChartType.Pie:
-                case ExcelChartType.Pie3D:
-                case ExcelChartType.PieOfPie:
-                case ExcelChartType.BarOfPie:
-                case ExcelChartType.Doughnut:
-                    return true;
-                default:
-                    return false;
-            }
-        }
-
-        private static bool HasMixedPdfChartTypes(C.PlotArea plotArea) {
-            string? firstFamily = null;
-            foreach (var chartElement in plotArea.ChildElements) {
-                string? family = GetPdfChartFamily(chartElement);
-                if (family == null) {
-                    continue;
-                }
-
-                if (firstFamily == null) {
-                    firstFamily = family;
-                    continue;
-                }
-
-                if (!string.Equals(firstFamily, family, StringComparison.Ordinal)) {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private static string? GetPdfChartFamily(DocumentFormat.OpenXml.OpenXmlElement chartElement) {
-            switch (chartElement) {
-                case C.BarChart:
-                    return "Bar";
-                case C.LineChart:
-                    return "Line";
-                case C.AreaChart:
-                    return "Area";
-                case C.ScatterChart:
-                    return "Scatter";
-                case C.RadarChart:
-                    return "Radar";
-                case C.PieChart:
-                case C.Pie3DChart:
-                case C.OfPieChart:
-                    return "Pie";
-                case C.DoughnutChart:
-                    return "Doughnut";
-                default:
-                    return null;
-            }
         }
 
         private static IEnumerable<string> GetFormulaCalculationBlockers(ExcelFormulaCellInfo formula) {

--- a/OfficeIMO.Excel/ExcelFeatureReport.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.cs
@@ -340,6 +340,8 @@ namespace OfficeIMO.Excel {
             int pdfUnsupportedImageCount = 0;
             int pdfUnsupportedHyperlinkCount = 0;
             int pdfUnrenderedDrawingShapeCount = 0;
+            int pdfUnsupportedPrintAreaCount = 0;
+            int pdfUnsupportedHeaderFooterFormattingCount = 0;
             var threadedCommentDetails = new List<string>();
             var oleObjectDetails = new List<string>();
             var formControlDetails = new List<string>();
@@ -348,12 +350,15 @@ namespace OfficeIMO.Excel {
             var pdfUnreadableChartDetails = new List<string>();
             var pdfUnsupportedImageDetails = new List<string>();
             var pdfUnsupportedHyperlinkDetails = new List<string>();
+            var pdfUnsupportedPrintAreaDetails = new List<string>();
+            var pdfUnsupportedHeaderFooterFormattingDetails = new List<string>();
             var pivotDetails = new List<string>();
             var pdfUnrenderedPivotDetails = new List<string>();
             var sparklineDetails = new List<string>();
             var pdfUnrenderedSparklineDetails = new List<string>();
             var pdfUnrenderedDrawingShapeDetails = new List<string>();
             var threadedCommentPeople = BuildThreadedCommentPersonMap(workbookPart);
+            var defaultPdfExportSheetNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var sheet in sheetElements) {
                 if (string.IsNullOrWhiteSpace(sheet.Id?.Value)) {
@@ -370,6 +375,10 @@ namespace OfficeIMO.Excel {
                 var excelSheet = new ExcelSheet(this, _spreadSheetDocument!, sheet);
                 var worksheet = worksheetPart.Worksheet;
                 bool isVisibleForDefaultPdfExport = !IsHiddenSheet(sheet);
+                string sheetName = sheet.Name?.Value ?? string.Empty;
+                if (isVisibleForDefaultPdfExport && !string.IsNullOrWhiteSpace(sheetName)) {
+                    defaultPdfExportSheetNames.Add(sheetName);
+                }
                 tableCount += worksheetPart.TableDefinitionParts.Count();
                 int sheetPivotCount = worksheetPart.PivotTableParts.Count();
                 pivotCount += sheetPivotCount;
@@ -410,7 +419,7 @@ namespace OfficeIMO.Excel {
                 foreach (ExcelChart chart in charts.Where(_ => isVisibleForDefaultPdfExport)) {
                     if (!chart.TryGetSnapshot(out ExcelChartSnapshot snapshot)) {
                         pdfUnreadableChartCount++;
-                        pdfUnreadableChartDetails.Add($"{sheet.Name}: {GetChartDisplayName(chart)} data could not be read into a PDF snapshot.");
+                        pdfUnreadableChartDetails.Add($"{sheet.Name}: {GetSafeChartDisplayName(chart)} data could not be read into a PDF snapshot.");
                         continue;
                     }
 
@@ -426,10 +435,13 @@ namespace OfficeIMO.Excel {
                     }
                 }
                 if (isVisibleForDefaultPdfExport) {
-                    AddUnsupportedHeaderFooterImages(excelSheet.GetHeaderFooter(), sheet.Name?.Value ?? string.Empty, ref pdfUnsupportedImageCount, pdfUnsupportedImageDetails);
-                    AddUnrenderedDrawingShapes(worksheetPart, sheet.Name?.Value ?? string.Empty, ref pdfUnrenderedDrawingShapeCount, pdfUnrenderedDrawingShapeDetails);
-                    AddUnsupportedWorksheetHyperlinks(workbookPart, sheetElements, worksheetPart, sheet.Name?.Value ?? string.Empty, ref pdfUnsupportedHyperlinkCount, pdfUnsupportedHyperlinkDetails);
-                    AddUnsupportedDrawingHyperlinks(worksheetPart, sheet.Name?.Value ?? string.Empty, ref pdfUnsupportedHyperlinkCount, pdfUnsupportedHyperlinkDetails);
+                    ExcelSheet.HeaderFooterSnapshot headerFooter = excelSheet.GetHeaderFooter();
+                    AddUnsupportedHeaderFooterImages(headerFooter, sheetName, ref pdfUnsupportedImageCount, pdfUnsupportedImageDetails);
+                    AddUnsupportedHeaderFooterFormatting(headerFooter, sheetName, ref pdfUnsupportedHeaderFooterFormattingCount, pdfUnsupportedHeaderFooterFormattingDetails);
+                    AddUnsupportedPrintArea(excelSheet, sheetName, ref pdfUnsupportedPrintAreaCount, pdfUnsupportedPrintAreaDetails);
+                    AddUnrenderedDrawingShapes(worksheetPart, sheetName, ref pdfUnrenderedDrawingShapeCount, pdfUnrenderedDrawingShapeDetails);
+                    AddUnsupportedWorksheetHyperlinks(workbookPart, sheetElements, worksheetPart, sheetName, ref pdfUnsupportedHyperlinkCount, pdfUnsupportedHyperlinkDetails);
+                    AddUnsupportedDrawingHyperlinks(worksheetPart, sheetName, ref pdfUnsupportedHyperlinkCount, pdfUnsupportedHyperlinkDetails);
                 }
                 int sheetOleObjects = CountDescendantsByLocalName(worksheet, "oleObject");
                 int sheetFormControls = CountDescendantsByLocalName(worksheet, "control") + CountDescendantsByLocalName(worksheet, "formControl");
@@ -484,6 +496,12 @@ namespace OfficeIMO.Excel {
             Add(features, "Media", "PDF-unrendered drawing shapes", ExcelFeatureSupportLevel.PartiallyEditable, pdfUnrenderedDrawingShapeCount, null,
                 "Worksheet drawing shapes and text boxes are present but are skipped by the first-party Excel-to-PDF path.",
                 pdfUnrenderedDrawingShapeDetails);
+            Add(features, "Layout", "PDF-unsupported print areas", ExcelFeatureSupportLevel.PartiallyEditable, pdfUnsupportedPrintAreaCount, null,
+                "Worksheet print-area settings are present but the first-party Excel-to-PDF path falls back to the worksheet used range for multi-area print areas.",
+                pdfUnsupportedPrintAreaDetails);
+            Add(features, "Layout", "PDF-unsupported header/footer formatting", ExcelFeatureSupportLevel.PartiallyEditable, pdfUnsupportedHeaderFooterFormattingCount, null,
+                "Header or footer text uses formatting that is simplified by the first-party Excel-to-PDF path.",
+                pdfUnsupportedHeaderFooterFormattingDetails);
             Add(features, "Compatibility", "OLE objects", ExcelFeatureSupportLevel.Preserved, oleObjectCount, null,
                 "Embedded OLE objects are advanced package content and should be treated as preserve-only.", oleObjectDetails);
             Add(features, "Compatibility", "Form controls", ExcelFeatureSupportLevel.Preserved, formControlCount, null,
@@ -499,7 +517,11 @@ namespace OfficeIMO.Excel {
                 nonWorksheetSheetDetails);
 
             var formulas = InspectFormulas();
+            var pdfExportFormulas = formulas.Formulas
+                .Where(formula => defaultPdfExportSheetNames.Contains(formula.SheetName))
+                .ToArray();
             bool hasWorkbookRecalculationRequest = formulas.Formulas.Count > 0 && HasWorkbookRecalculationRequest(workbook);
+            bool hasPdfWorkbookRecalculationRequest = pdfExportFormulas.Length > 0 && HasWorkbookRecalculationRequest(workbook);
             Add(features, "Calculation", "Supported formulas", ExcelFeatureSupportLevel.PartiallyEditable, formulas.SupportedFormulas, null,
                 "Simple supported formulas can be recalculated by OfficeIMO.");
             Add(features, "Calculation", "Unsupported formulas", ExcelFeatureSupportLevel.Preserved, formulas.UnsupportedFormulas, null,
@@ -515,6 +537,21 @@ namespace OfficeIMO.Excel {
             Add(features, "Calculation", "Workbook recalculation requests", ExcelFeatureSupportLevel.Preserved, hasWorkbookRecalculationRequest ? 1 : 0, null,
                 "The workbook requests full recalculation on open, so cached formula values should be refreshed before cached-value reads are trusted.",
                 hasWorkbookRecalculationRequest ? DescribeWorkbookRecalculationRequest(workbook).ToArray() : Array.Empty<string>());
+            Add(features, "Calculation", "PDF-missing formula caches", ExcelFeatureSupportLevel.Preserved, pdfExportFormulas.Count(formula => !formula.HasCachedValue), null,
+                "Visible worksheet formulas without cached results need OfficeIMO calculation support or Excel recalculation before PDF export can trust cached values.",
+                pdfExportFormulas
+                    .Where(formula => !formula.HasCachedValue)
+                    .Select(formula => $"{formula.SheetName}!{formula.CellReference}")
+                    .ToArray());
+            Add(features, "Calculation", "PDF-dirty formula caches", ExcelFeatureSupportLevel.PartiallyEditable, pdfExportFormulas.Count(formula => formula.IsDirty), null,
+                "Visible worksheet formulas with dirty cached results need recalculation before PDF export can trust cached values.",
+                pdfExportFormulas
+                    .Where(formula => formula.IsDirty)
+                    .Select(formula => $"{formula.SheetName}!{formula.CellReference}")
+                    .ToArray());
+            Add(features, "Calculation", "PDF-workbook recalculation requests", ExcelFeatureSupportLevel.Preserved, hasPdfWorkbookRecalculationRequest ? 1 : 0, null,
+                "The workbook requests full recalculation on open while visible worksheet formulas are exported to PDF, so cached values should be refreshed first.",
+                hasPdfWorkbookRecalculationRequest ? DescribeWorkbookRecalculationRequest(workbook).ToArray() : Array.Empty<string>());
             var formulaCalculationBlockers = formulas.Formulas
                 .SelectMany(GetFormulaCalculationBlockers)
                 .ToArray();

--- a/OfficeIMO.Excel/ExcelFeatureReport.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.cs
@@ -22,7 +22,7 @@ namespace OfficeIMO.Excel {
     /// <summary>
     /// Workbook-level feature and compatibility report.
     /// </summary>
-    public sealed class ExcelFeatureReport {
+    public sealed partial class ExcelFeatureReport {
         private readonly List<ExcelFeatureFinding> _features = new List<ExcelFeatureFinding>();
 
         internal ExcelFeatureReport(IReadOnlyList<ExcelFeatureFinding> features) {
@@ -172,6 +172,21 @@ namespace OfficeIMO.Excel {
             builder.AppendLine($"Partially editable features: {PartiallyEditableFeatures.Count}");
             builder.AppendLine($"Preserved features: {PreservedFeatures.Count}");
             builder.AppendLine($"Unsupported features: {UnsupportedFeatures.Count}");
+            builder.AppendLine();
+            builder.AppendLine("## Capability Preflight");
+            builder.AppendLine();
+            builder.AppendLine("| Capability | Can attempt | Diagnostics |");
+            builder.AppendLine("| --- | --- | --- |");
+            foreach (ExcelPreflightCapability capability in Enum.GetValues(typeof(ExcelPreflightCapability))) {
+                builder.Append("| ");
+                builder.Append(capability);
+                builder.Append(" | ");
+                builder.Append(Can(capability) ? "yes" : "no");
+                builder.Append(" | ");
+                builder.Append(EscapeMarkdownCell(string.Join("; ", GetCapabilityDiagnostics(capability))));
+                builder.AppendLine(" |");
+            }
+
             builder.AppendLine();
             builder.AppendLine("| Category | Feature | Count | Support | Scope | Note | Details |");
             builder.AppendLine("| --- | --- | --- | --- | --- | --- | --- |");
@@ -392,6 +407,12 @@ namespace OfficeIMO.Excel {
                 "Unsupported formulas are preserved and should be recalculated by Excel or read from cached values.");
             Add(features, "Calculation", "Missing formula caches", ExcelFeatureSupportLevel.Preserved, formulas.MissingCachedResults, null,
                 "Formulas without cached results need OfficeIMO calculation support or Excel recalculation before cached-value reads are reliable.");
+            Add(features, "Calculation", "Formula dependency issues", ExcelFeatureSupportLevel.Preserved, formulas.DependencyIssueCount, null,
+                "Formula dependencies need review before cached-value reads, calculation, or report export can be trusted.",
+                formulas.Formulas
+                    .Where(formula => formula.DependencyIssues.Count > 0)
+                    .Select(formula => $"{formula.SheetName}!{formula.CellReference}: {string.Join("; ", formula.DependencyIssues)}")
+                    .ToArray());
 
             var allParts = EnumeratePackageParts(_spreadSheetDocument).ToList();
             var vbaDetails = DescribePartsByUriOrContentType(allParts, "vbaProject");

--- a/OfficeIMO.Excel/ExcelFeatureReport.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.cs
@@ -341,6 +341,7 @@ namespace OfficeIMO.Excel {
             int pdfUnsupportedHyperlinkCount = 0;
             int pdfUnrenderedDrawingShapeCount = 0;
             int pdfUnsupportedPrintAreaCount = 0;
+            int pdfUnsupportedPrintTitleCount = 0;
             int pdfUnsupportedHeaderFooterFormattingCount = 0;
             var threadedCommentDetails = new List<string>();
             var oleObjectDetails = new List<string>();
@@ -351,6 +352,7 @@ namespace OfficeIMO.Excel {
             var pdfUnsupportedImageDetails = new List<string>();
             var pdfUnsupportedHyperlinkDetails = new List<string>();
             var pdfUnsupportedPrintAreaDetails = new List<string>();
+            var pdfUnsupportedPrintTitleDetails = new List<string>();
             var pdfUnsupportedHeaderFooterFormattingDetails = new List<string>();
             var pivotDetails = new List<string>();
             var pdfUnrenderedPivotDetails = new List<string>();
@@ -358,7 +360,7 @@ namespace OfficeIMO.Excel {
             var pdfUnrenderedSparklineDetails = new List<string>();
             var pdfUnrenderedDrawingShapeDetails = new List<string>();
             var threadedCommentPeople = BuildThreadedCommentPersonMap(workbookPart);
-            var defaultPdfExportSheetNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var defaultPdfExportSheetsByName = new Dictionary<string, ExcelSheet>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var sheet in sheetElements) {
                 if (string.IsNullOrWhiteSpace(sheet.Id?.Value)) {
@@ -377,7 +379,7 @@ namespace OfficeIMO.Excel {
                 bool isVisibleForDefaultPdfExport = !IsHiddenSheet(sheet);
                 string sheetName = sheet.Name?.Value ?? string.Empty;
                 if (isVisibleForDefaultPdfExport && !string.IsNullOrWhiteSpace(sheetName)) {
-                    defaultPdfExportSheetNames.Add(sheetName);
+                    defaultPdfExportSheetsByName[sheetName] = excelSheet;
                 }
                 tableCount += worksheetPart.TableDefinitionParts.Count();
                 int sheetPivotCount = worksheetPart.PivotTableParts.Count();
@@ -439,6 +441,7 @@ namespace OfficeIMO.Excel {
                     AddUnsupportedHeaderFooterImages(headerFooter, sheetName, ref pdfUnsupportedImageCount, pdfUnsupportedImageDetails);
                     AddUnsupportedHeaderFooterFormatting(headerFooter, sheetName, ref pdfUnsupportedHeaderFooterFormattingCount, pdfUnsupportedHeaderFooterFormattingDetails);
                     AddUnsupportedPrintArea(excelSheet, sheetName, ref pdfUnsupportedPrintAreaCount, pdfUnsupportedPrintAreaDetails);
+                    AddUnsupportedPrintTitles(excelSheet, sheetName, ref pdfUnsupportedPrintTitleCount, pdfUnsupportedPrintTitleDetails);
                     AddUnrenderedDrawingShapes(worksheetPart, sheetName, ref pdfUnrenderedDrawingShapeCount, pdfUnrenderedDrawingShapeDetails);
                     AddUnsupportedWorksheetHyperlinks(workbookPart, sheetElements, worksheetPart, sheetName, ref pdfUnsupportedHyperlinkCount, pdfUnsupportedHyperlinkDetails);
                     AddUnsupportedDrawingHyperlinks(worksheetPart, sheetName, ref pdfUnsupportedHyperlinkCount, pdfUnsupportedHyperlinkDetails);
@@ -499,6 +502,9 @@ namespace OfficeIMO.Excel {
             Add(features, "Layout", "PDF-unsupported print areas", ExcelFeatureSupportLevel.PartiallyEditable, pdfUnsupportedPrintAreaCount, null,
                 "Worksheet print-area settings are present but the first-party Excel-to-PDF path falls back to the worksheet used range for multi-area print areas.",
                 pdfUnsupportedPrintAreaDetails);
+            Add(features, "Layout", "PDF-unsupported print titles", ExcelFeatureSupportLevel.PartiallyEditable, pdfUnsupportedPrintTitleCount, null,
+                "Worksheet print-title columns are configured but the first-party Excel-to-PDF path currently repeats print-title rows only.",
+                pdfUnsupportedPrintTitleDetails);
             Add(features, "Layout", "PDF-unsupported header/footer formatting", ExcelFeatureSupportLevel.PartiallyEditable, pdfUnsupportedHeaderFooterFormattingCount, null,
                 "Header or footer text uses formatting that is simplified by the first-party Excel-to-PDF path.",
                 pdfUnsupportedHeaderFooterFormattingDetails);
@@ -518,7 +524,7 @@ namespace OfficeIMO.Excel {
 
             var formulas = InspectFormulas();
             var pdfExportFormulas = formulas.Formulas
-                .Where(formula => defaultPdfExportSheetNames.Contains(formula.SheetName))
+                .Where(formula => IsDefaultPdfExportedFormulaCell(formula, defaultPdfExportSheetsByName))
                 .ToArray();
             bool hasWorkbookRecalculationRequest = formulas.Formulas.Count > 0 && HasWorkbookRecalculationRequest(workbook);
             bool hasPdfWorkbookRecalculationRequest = pdfExportFormulas.Length > 0 && HasWorkbookRecalculationRequest(workbook);

--- a/OfficeIMO.Excel/ExcelFeatureReport.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.cs
@@ -1,5 +1,6 @@
 using DocumentFormat.OpenXml.Packaging;
 using System.Text;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
 
 namespace OfficeIMO.Excel {
     /// <summary>
@@ -331,10 +332,12 @@ namespace OfficeIMO.Excel {
             int oleObjectCount = 0;
             int formControlCount = 0;
             int externalHyperlinkCount = 0;
+            int pdfUnsupportedChartCount = 0;
             var threadedCommentDetails = new List<string>();
             var oleObjectDetails = new List<string>();
             var formControlDetails = new List<string>();
             var externalHyperlinkDetails = new List<string>();
+            var pdfUnsupportedChartDetails = new List<string>();
             var threadedCommentPeople = BuildThreadedCommentPersonMap(workbookPart);
 
             foreach (var sheet in sheetElements) {
@@ -363,7 +366,20 @@ namespace OfficeIMO.Excel {
                     threadedCommentDetails.Add($"{sheet.Name}: {threadedComment.CellReference} by {author}");
                 }
                 imagePartCount += worksheetPart.DrawingsPart?.ImageParts.Count() ?? 0;
-                chartCount += worksheetPart.DrawingsPart?.ChartParts.Count() ?? 0;
+                var chartParts = worksheetPart.DrawingsPart?.ChartParts.ToList() ?? new List<ChartPart>();
+                chartCount += chartParts.Count;
+                foreach (ChartPart chartPart in chartParts) {
+                    C.PlotArea? plotArea = chartPart.ChartSpace?.GetFirstChild<C.Chart>()?.GetFirstChild<C.PlotArea>();
+                    if (plotArea == null) {
+                        continue;
+                    }
+
+                    ExcelChartType chartType = ExcelChartUtils.InferChartType(plotArea);
+                    if (!IsPdfSupportedChartType(chartType)) {
+                        pdfUnsupportedChartCount++;
+                        pdfUnsupportedChartDetails.Add($"{sheet.Name}: {chartType} ({chartPart.Uri})");
+                    }
+                }
                 int sheetOleObjects = CountDescendantsByLocalName(worksheet, "oleObject");
                 int sheetFormControls = CountDescendantsByLocalName(worksheet, "control") + CountDescendantsByLocalName(worksheet, "formControl");
                 oleObjectCount += sheetOleObjects;
@@ -384,6 +400,9 @@ namespace OfficeIMO.Excel {
                 "Common rule types are editable; full Excel conditional-formatting parity remains a roadmap item.");
             Add(features, "Visualization", "Charts", ExcelFeatureSupportLevel.PartiallyEditable, chartCount, null,
                 "Common chart authoring and updates are supported, including stacked/100% stacked column/bar/line/area variants, 3-D area/line/column/bar/pie, pie-of-pie/bar-of-pie, radar, stock, and filled/wireframe/contour surface charts; advanced chart families remain partial.");
+            Add(features, "Visualization", "PDF-unsupported charts", ExcelFeatureSupportLevel.PartiallyEditable, pdfUnsupportedChartCount, null,
+                "These charts can be authored or preserved in the workbook but are skipped by the first-party Excel-to-PDF chart snapshot renderer.",
+                pdfUnsupportedChartDetails);
             Add(features, "Visualization", "Pivot tables", ExcelFeatureSupportLevel.PartiallyEditable, pivotCount, null,
                 "Source-range pivot creation and inspection are supported, including composable fluent field sort/subtotal/layout/display/number-format helpers with built-in/custom id/code readback, field item/page filters with fluent helpers plus hidden, visible, and selected-item readback, common label/value filters, negated filter variants, fixed and dynamic date filters, top/bottom count/percent/sum filters, formula-backed calculated fields with number-format id/code readback, date/number grouping metadata, generated multi-level date hierarchy fields with base/parent relationships, and explicit grouped-cache item metadata; slicers, deeper Excel interoperability checks, and advanced filters remain partial.");
             Add(features, "Visualization", "Sparklines", ExcelFeatureSupportLevel.Editable, sparklineCount, null,
@@ -407,6 +426,18 @@ namespace OfficeIMO.Excel {
                 "Unsupported formulas are preserved and should be recalculated by Excel or read from cached values.");
             Add(features, "Calculation", "Missing formula caches", ExcelFeatureSupportLevel.Preserved, formulas.MissingCachedResults, null,
                 "Formulas without cached results need OfficeIMO calculation support or Excel recalculation before cached-value reads are reliable.");
+            Add(features, "Calculation", "Dirty formula caches", ExcelFeatureSupportLevel.PartiallyEditable, formulas.DirtyFormulas, null,
+                "Dirty formulas have cached results that are explicitly awaiting recalculation before cached-value reads are reliable.",
+                formulas.Formulas
+                    .Where(formula => formula.IsDirty)
+                    .Select(formula => $"{formula.SheetName}!{formula.CellReference}")
+                    .ToArray());
+            var formulaCalculationBlockers = formulas.Formulas
+                .SelectMany(GetFormulaCalculationBlockers)
+                .ToArray();
+            Add(features, "Calculation", "Formula calculation blockers", ExcelFeatureSupportLevel.Preserved, formulaCalculationBlockers.Length, null,
+                "These formula cells need Excel recalculation or broader evaluator support before OfficeIMO can calculate the workbook.",
+                formulaCalculationBlockers);
             Add(features, "Calculation", "Formula dependency issues", ExcelFeatureSupportLevel.Preserved, formulas.DependencyIssueCount, null,
                 "Formula dependencies need review before cached-value reads, calculation, or report export can be trusted.",
                 formulas.Formulas
@@ -534,6 +565,67 @@ namespace OfficeIMO.Excel {
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .OrderBy(detail => detail, StringComparer.OrdinalIgnoreCase)
                 .ToList();
+        }
+
+        private static bool IsPdfSupportedChartType(ExcelChartType chartType) {
+            switch (chartType) {
+                case ExcelChartType.ColumnClustered:
+                case ExcelChartType.Column3DClustered:
+                case ExcelChartType.ColumnStacked:
+                case ExcelChartType.Column3DStacked:
+                case ExcelChartType.ColumnStacked100:
+                case ExcelChartType.Column3DStacked100:
+                case ExcelChartType.BarClustered:
+                case ExcelChartType.Bar3DClustered:
+                case ExcelChartType.BarStacked:
+                case ExcelChartType.Bar3DStacked:
+                case ExcelChartType.BarStacked100:
+                case ExcelChartType.Bar3DStacked100:
+                case ExcelChartType.Line:
+                case ExcelChartType.Line3D:
+                case ExcelChartType.LineStacked:
+                case ExcelChartType.LineStacked100:
+                case ExcelChartType.Area:
+                case ExcelChartType.Area3D:
+                case ExcelChartType.AreaStacked:
+                case ExcelChartType.Area3DStacked:
+                case ExcelChartType.AreaStacked100:
+                case ExcelChartType.Area3DStacked100:
+                case ExcelChartType.Scatter:
+                case ExcelChartType.Radar:
+                case ExcelChartType.Pie:
+                case ExcelChartType.Pie3D:
+                case ExcelChartType.PieOfPie:
+                case ExcelChartType.BarOfPie:
+                case ExcelChartType.Doughnut:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private static IEnumerable<string> GetFormulaCalculationBlockers(ExcelFormulaCellInfo formula) {
+            bool hasNonCacheDependencyIssue = false;
+            foreach (string issue in formula.DependencyIssues) {
+                if (issue.IndexOf("without a cached result", StringComparison.OrdinalIgnoreCase) >= 0) {
+                    continue;
+                }
+
+                hasNonCacheDependencyIssue = true;
+                yield return $"{formula.SheetName}!{formula.CellReference}: {issue}";
+            }
+
+            if (!formula.IsSupportedByOfficeIMO && (!HasOnlyMissingCachedFormulaDependencyIssues(formula) || hasNonCacheDependencyIssue)) {
+                string reason = string.IsNullOrWhiteSpace(formula.UnsupportedReason)
+                    ? "Formula is outside OfficeIMO's lightweight evaluator support."
+                    : formula.UnsupportedReason!;
+                yield return $"{formula.SheetName}!{formula.CellReference}: {reason}";
+            }
+        }
+
+        private static bool HasOnlyMissingCachedFormulaDependencyIssues(ExcelFormulaCellInfo formula) {
+            return formula.DependencyIssues.Count > 0
+                && formula.DependencyIssues.All(issue => issue.IndexOf("without a cached result", StringComparison.OrdinalIgnoreCase) >= 0);
         }
 
         private static string DescribePart(OpenXmlPart part) {

--- a/OfficeIMO.Excel/ExcelFeatureReport.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.cs
@@ -316,6 +316,8 @@ namespace OfficeIMO.Excel {
             Add(features, "Workbook", "Worksheets", ExcelFeatureSupportLevel.Editable, sheetElements.Count, null,
                 "Worksheets can be created, renamed, moved, hidden, inspected, copied, and removed.");
 
+            int nonWorksheetSheetCount = 0;
+            var nonWorksheetSheetDetails = new List<string>();
             int namedRangeCount = workbook.DefinedNames?.Elements<DocumentFormat.OpenXml.Spreadsheet.DefinedName>().Count() ?? 0;
             Add(features, "Workbook", "Named ranges", ExcelFeatureSupportLevel.Editable, namedRangeCount, null,
                 "Workbook and sheet-local named ranges are editable.");
@@ -345,7 +347,10 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                if (workbookPart.GetPartById(sheet.Id!.Value!) is not WorksheetPart worksheetPart) {
+                OpenXmlPart sheetPart = workbookPart.GetPartById(sheet.Id!.Value!);
+                if (sheetPart is not WorksheetPart worksheetPart) {
+                    nonWorksheetSheetCount++;
+                    nonWorksheetSheetDetails.Add($"{sheet.Name}: {sheetPart.GetType().Name} ({sheetPart.Uri})");
                     continue;
                 }
 
@@ -375,7 +380,10 @@ namespace OfficeIMO.Excel {
                     }
 
                     ExcelChartType chartType = ExcelChartUtils.InferChartType(plotArea);
-                    if (!IsPdfSupportedChartType(chartType)) {
+                    if (HasMixedPdfChartTypes(plotArea)) {
+                        pdfUnsupportedChartCount++;
+                        pdfUnsupportedChartDetails.Add($"{sheet.Name}: mixed per-series chart types ({chartPart.Uri})");
+                    } else if (!IsPdfSupportedChartType(chartType)) {
                         pdfUnsupportedChartCount++;
                         pdfUnsupportedChartDetails.Add($"{sheet.Name}: {chartType} ({chartPart.Uri})");
                     }
@@ -418,6 +426,9 @@ namespace OfficeIMO.Excel {
                 "Embedded OLE objects are advanced package content and should be treated as preserve-only.", oleObjectDetails);
             Add(features, "Compatibility", "Form controls", ExcelFeatureSupportLevel.Preserved, formControlCount, null,
                 "Form controls are preserve-only worksheet metadata.", formControlDetails);
+            Add(features, "Compatibility", "Non-worksheet sheets", ExcelFeatureSupportLevel.Preserved, nonWorksheetSheetCount, null,
+                "Chartsheets and other non-worksheet sheet parts are preserve-only and cannot be materialized by worksheet-only workflows.",
+                nonWorksheetSheetDetails);
 
             var formulas = InspectFormulas();
             Add(features, "Calculation", "Supported formulas", ExcelFeatureSupportLevel.PartiallyEditable, formulas.SupportedFormulas, null,
@@ -604,18 +615,60 @@ namespace OfficeIMO.Excel {
             }
         }
 
+        private static bool HasMixedPdfChartTypes(C.PlotArea plotArea) {
+            string? firstFamily = null;
+            foreach (var chartElement in plotArea.ChildElements) {
+                string? family = GetPdfChartFamily(chartElement);
+                if (family == null) {
+                    continue;
+                }
+
+                if (firstFamily == null) {
+                    firstFamily = family;
+                    continue;
+                }
+
+                if (!string.Equals(firstFamily, family, StringComparison.Ordinal)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static string? GetPdfChartFamily(DocumentFormat.OpenXml.OpenXmlElement chartElement) {
+            switch (chartElement) {
+                case C.BarChart:
+                    return "Bar";
+                case C.LineChart:
+                    return "Line";
+                case C.AreaChart:
+                    return "Area";
+                case C.ScatterChart:
+                    return "Scatter";
+                case C.RadarChart:
+                    return "Radar";
+                case C.PieChart:
+                case C.Pie3DChart:
+                case C.OfPieChart:
+                    return "Pie";
+                case C.DoughnutChart:
+                    return "Doughnut";
+                default:
+                    return null;
+            }
+        }
+
         private static IEnumerable<string> GetFormulaCalculationBlockers(ExcelFormulaCellInfo formula) {
-            bool hasNonCacheDependencyIssue = false;
             foreach (string issue in formula.DependencyIssues) {
                 if (issue.IndexOf("without a cached result", StringComparison.OrdinalIgnoreCase) >= 0) {
                     continue;
                 }
 
-                hasNonCacheDependencyIssue = true;
                 yield return $"{formula.SheetName}!{formula.CellReference}: {issue}";
             }
 
-            if (!formula.IsSupportedByOfficeIMO && (!HasOnlyMissingCachedFormulaDependencyIssues(formula) || hasNonCacheDependencyIssue)) {
+            if (!formula.IsSupportedByOfficeIMO && !IsMissingCacheOnlyFormulaCalculationGap(formula)) {
                 string reason = string.IsNullOrWhiteSpace(formula.UnsupportedReason)
                     ? "Formula is outside OfficeIMO's lightweight evaluator support."
                     : formula.UnsupportedReason!;
@@ -623,9 +676,16 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        private static bool HasOnlyMissingCachedFormulaDependencyIssues(ExcelFormulaCellInfo formula) {
-            return formula.DependencyIssues.Count > 0
-                && formula.DependencyIssues.All(issue => issue.IndexOf("without a cached result", StringComparison.OrdinalIgnoreCase) >= 0);
+        private static bool IsMissingCacheOnlyFormulaCalculationGap(ExcelFormulaCellInfo formula) {
+            if (formula.DependencyIssues.Count == 0
+                || formula.DependencyIssues.Any(issue => issue.IndexOf("without a cached result", StringComparison.OrdinalIgnoreCase) < 0)) {
+                return false;
+            }
+
+            string reason = formula.UnsupportedReason ?? string.Empty;
+            return reason.Length == 0
+                || reason.IndexOf("Formula is outside OfficeIMO's lightweight evaluator support", StringComparison.OrdinalIgnoreCase) >= 0
+                || reason.IndexOf("Formula uses supported function", StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         private static string DescribePart(OpenXmlPart part) {

--- a/OfficeIMO.Excel/README.md
+++ b/OfficeIMO.Excel/README.md
@@ -198,6 +198,26 @@ document.Save("report.xlsx", openExcel: false, options: new ExcelSaveOptions {
 });
 ```
 
+### Preflight a workbook before choosing a workflow
+
+```csharp
+using var document = ExcelDocument.Load("incoming.xlsx", readOnly: true);
+
+ExcelFeatureReport report = document.InspectFeatures();
+
+try {
+    report.EnsureCan(ExcelPreflightCapability.EditWorkbookStructure);
+} catch (InvalidOperationException ex) {
+    Console.WriteLine(ex.Message);
+}
+
+if (!report.Can(ExcelPreflightCapability.ExportPdfReport)) {
+    Console.WriteLine(report.ToMarkdown());
+}
+```
+
+Use workflow preflight when an application needs to decide whether a workbook is safe for readback, cell-value edits, structure-changing edits, cached-formula reads, OfficeIMO formula calculation, template binding, or first-party PDF report export. Preserve-only features such as macros, slicers, timelines, threaded comments, external links, custom XML, OLE objects, and form controls are reported with package details instead of being silently ignored.
+
 ### CSV and JSON exchange
 
 ```csharp

--- a/OfficeIMO.Tests/Excel.ClosedXmlGapFeatures.cs
+++ b/OfficeIMO.Tests/Excel.ClosedXmlGapFeatures.cs
@@ -935,7 +935,7 @@ namespace OfficeIMO.Tests {
             using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
                 ExcelFeatureReport report = document.InspectFeatures();
 
-                ExcelFeatureFinding externalLinks = Assert.Single(report.PreservedFeatures, feature => feature.Name == "External workbook links");
+                ExcelFeatureFinding externalLinks = Assert.Single(report.PartiallyEditableFeatures, feature => feature.Name == "External hyperlinks");
                 Assert.Equal(1, externalLinks.Count);
                 Assert.Contains(externalLinks.Details, detail => detail.Contains("https://example.org/spec", StringComparison.OrdinalIgnoreCase));
 
@@ -1310,19 +1310,19 @@ namespace OfficeIMO.Tests {
                 ExcelFeatureReport report = document.InspectFeatures();
 
                 Assert.Empty(report.FindFeatures("VBA macros"));
-                ExcelFeatureFinding externalLinks = Assert.Single(report.FindFeatures("External workbook links"));
-                Assert.Equal(ExcelFeatureSupportLevel.Preserved, externalLinks.SupportLevel);
+                ExcelFeatureFinding externalLinks = Assert.Single(report.FindFeatures("External hyperlinks"));
+                Assert.Equal(ExcelFeatureSupportLevel.PartiallyEditable, externalLinks.SupportLevel);
                 Assert.Same(report, report.EnsureNoFeatures("VBA macros"));
 
                 InvalidOperationException namedException = Assert.Throws<InvalidOperationException>(
-                    () => report.EnsureNoFeatures("External workbook links", "VBA macros"));
-                Assert.Contains("External workbook links", namedException.Message);
+                    () => report.EnsureNoFeatures("External hyperlinks", "VBA macros"));
+                Assert.Contains("External hyperlinks", namedException.Message);
                 Assert.Contains("https://example.org/spec", namedException.Message);
 
                 InvalidOperationException levelException = Assert.Throws<InvalidOperationException>(
-                    () => report.EnsureNoFeatures(ExcelFeatureSupportLevel.Preserved));
-                Assert.Contains("Preserved", levelException.Message);
-                Assert.Contains("External workbook links", levelException.Message);
+                    () => report.EnsureNoFeatures(ExcelFeatureSupportLevel.PartiallyEditable));
+                Assert.Contains("PartiallyEditable", levelException.Message);
+                Assert.Contains("External hyperlinks", levelException.Message);
             }
         }
 
@@ -1358,7 +1358,7 @@ namespace OfficeIMO.Tests {
 
             using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
                 ExcelFeatureReport report = document.InspectFeatures();
-                Assert.Contains(report.PreservedFeatures, feature => feature.Name == "External workbook links"
+                Assert.Contains(report.PartiallyEditableFeatures, feature => feature.Name == "External hyperlinks"
                     && feature.Details.Any(detail => detail.Contains("https://example.org/spec", StringComparison.OrdinalIgnoreCase)));
                 Assert.Contains(report.PreservedFeatures, feature => feature.Name == "Custom XML parts"
                     && feature.Details.Any(detail => detail.Contains("/customXml/", StringComparison.OrdinalIgnoreCase)));

--- a/OfficeIMO.Tests/Excel.CompatibilityCorpus.Preservation.cs
+++ b/OfficeIMO.Tests/Excel.CompatibilityCorpus.Preservation.cs
@@ -1,0 +1,219 @@
+using System.Text;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Compatibility_Corpus_PreserveOnlyMetadata_RoundTripsAndBlocksRiskyWorkflows() {
+            string filePath = Path.Combine(_directoryWithFiles, "CompatibilityCorpus.PreserveOnlyMetadata.xlsx");
+            byte[] customXmlBytes = Encoding.UTF8.GetBytes("<metadata><source>external-system</source><id>INV-2026-001</id></metadata>");
+            byte[] connectionBytes = Encoding.UTF8.GetBytes("<connections xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" count=\"1\"><connection id=\"1\" name=\"ExternalSales\" type=\"5\" refreshedVersion=\"7\"/></connections>");
+            byte[] queryTableBytes = Encoding.UTF8.GetBytes("<queryTable xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" name=\"ExternalSalesQuery\" connectionId=\"1\"/>");
+
+            try {
+                ExcelCompatibilityCorpusBuilder.CreateWorkbook(filePath, document => {
+                    var sheet = document.AddWorkSheet("Imported");
+                    sheet.CellValue(1, 1, "Resource");
+                    sheet.CellValue(1, 2, "Amount");
+                    sheet.SetHyperlink(2, 1, "https://example.org/external-system/invoice/INV-2026-001", display: "Invoice");
+                    sheet.CellValue(2, 2, 1250d);
+                });
+
+                AddPreserveOnlyPackageParts(filePath, customXmlBytes, connectionBytes, queryTableBytes);
+
+                using (ExcelDocument document = ExcelDocument.Load(filePath)) {
+                    document["Imported"].CellValue(3, 2, 1400d);
+                    document.Save(false);
+                }
+
+                AssertPreservedPackageParts(filePath, customXmlBytes, connectionBytes, queryTableBytes);
+
+                using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                    ExcelFeatureReport report = document.InspectFeatures();
+
+                    Assert.True(report.Can(ExcelPreflightCapability.ReadWorkbookData));
+                    Assert.True(report.Can(ExcelPreflightCapability.EditCellValues));
+                    Assert.False(report.Can(ExcelPreflightCapability.EditWorkbookStructure));
+                    Assert.False(report.Can(ExcelPreflightCapability.BindTemplate));
+                    Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+
+                    Assert.Contains(report.PreservedFeatures, feature => feature.Name == "External workbook links"
+                        && feature.Details.Any(detail => detail.Contains("INV-2026-001", StringComparison.OrdinalIgnoreCase)));
+                    Assert.Contains(report.PreservedFeatures, feature => feature.Name == "Custom XML parts");
+                    Assert.Contains(report.PreservedFeatures, feature => feature.Name == "Connections and query tables"
+                        && feature.Count == 2);
+
+                    string diagnostics = string.Join(Environment.NewLine,
+                        report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+                    Assert.Contains("External workbook links", diagnostics);
+                    Assert.Contains("Custom XML parts", diagnostics);
+                    Assert.Contains("Connections and query tables", diagnostics);
+                    Assert.Contains("Connections and query tables", Assert.Throws<InvalidOperationException>(() =>
+                        report.EnsureCan(ExcelPreflightCapability.ExportPdfReport)).Message);
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Compatibility_Corpus_MacroEmbeddedObjectsAndControls_RoundTripAndBlockRiskyWorkflows() {
+            string filePath = Path.Combine(_directoryWithFiles, "CompatibilityCorpus.MacroEmbeddedControls.xlsx");
+            byte[] vbaBytes = Encoding.ASCII.GetBytes("OfficeIMO macro project placeholder");
+            byte[] embeddedBytes = Encoding.ASCII.GetBytes("OfficeIMO embedded workbook placeholder");
+
+            try {
+                ExcelCompatibilityCorpusBuilder.CreateWorkbook(filePath, document => {
+                    var sheet = document.AddWorkSheet("Controls");
+                    sheet.CellValue(1, 1, "Status");
+                    sheet.CellValue(2, 1, "Before");
+                });
+
+                AddAdvancedPackageParts(filePath, vbaBytes, embeddedBytes);
+
+                using (ExcelDocument document = ExcelDocument.Load(filePath)) {
+                    document["Controls"].CellValue(3, 1, "After");
+                    document.Save(false);
+                }
+
+                AssertPreservedAdvancedPackageParts(filePath, vbaBytes, embeddedBytes);
+
+                using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                    ExcelFeatureReport report = document.InspectFeatures();
+
+                    Assert.True(report.Can(ExcelPreflightCapability.ReadWorkbookData));
+                    Assert.True(report.Can(ExcelPreflightCapability.EditCellValues));
+                    Assert.False(report.Can(ExcelPreflightCapability.EditWorkbookStructure));
+                    Assert.False(report.Can(ExcelPreflightCapability.BindTemplate));
+                    Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+
+                    Assert.Contains(report.PreservedFeatures, feature => feature.Name == "VBA macros"
+                        && feature.Details.Any(detail => detail.Contains("vbaProject", StringComparison.OrdinalIgnoreCase)));
+                    Assert.Contains(report.PreservedFeatures, feature => feature.Name == "Embedded packages"
+                        && feature.Details.Any(detail => detail.Contains("/embeddings/", StringComparison.OrdinalIgnoreCase)));
+                    Assert.Contains(report.PreservedFeatures, feature => feature.Name == "OLE objects"
+                        && feature.Details.Any(detail => detail.Contains("Controls", StringComparison.OrdinalIgnoreCase)));
+                    Assert.Contains(report.PreservedFeatures, feature => feature.Name == "Form controls"
+                        && feature.Details.Any(detail => detail.Contains("Controls", StringComparison.OrdinalIgnoreCase)));
+
+                    string diagnostics = string.Join(Environment.NewLine,
+                        report.GetCapabilityDiagnostics(ExcelPreflightCapability.BindTemplate));
+                    Assert.Contains("VBA macros", diagnostics);
+                    Assert.Contains("Embedded packages", diagnostics);
+                    Assert.Contains("OLE objects", diagnostics);
+                    Assert.Contains("Form controls", diagnostics);
+                    Assert.Contains("VBA macros", Assert.Throws<InvalidOperationException>(() =>
+                        report.EnsureCan(ExcelPreflightCapability.BindTemplate)).Message);
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        private static void AddPreserveOnlyPackageParts(
+            string filePath,
+            byte[] customXmlBytes,
+            byte[] connectionBytes,
+            byte[] queryTableBytes) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true);
+            WorkbookPart workbookPart = spreadsheet.WorkbookPart!;
+            WorksheetPart worksheetPart = workbookPart.WorksheetParts.Single();
+
+            CustomXmlPart customXmlPart = workbookPart.AddCustomXmlPart(CustomXmlPartType.CustomXml);
+            FeedPartData(customXmlPart, customXmlBytes);
+
+            ExtendedPart connectionPart = workbookPart.AddExtendedPart(
+                "http://schemas.openxmlformats.org/officeDocument/2006/relationships/connections",
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.connections+xml",
+                "xml");
+            FeedPartData(connectionPart, connectionBytes);
+
+            ExtendedPart queryTablePart = worksheetPart.AddExtendedPart(
+                "http://schemas.openxmlformats.org/officeDocument/2006/relationships/queryTable",
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.queryTable+xml",
+                "xml");
+            FeedPartData(queryTablePart, queryTableBytes);
+        }
+
+        private static void AddAdvancedPackageParts(
+            string filePath,
+            byte[] vbaBytes,
+            byte[] embeddedBytes) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true);
+            WorkbookPart workbookPart = spreadsheet.WorkbookPart!;
+            VbaProjectPart vbaProjectPart = workbookPart.AddNewPart<VbaProjectPart>();
+            FeedPartData(vbaProjectPart, vbaBytes);
+
+            WorksheetPart worksheetPart = workbookPart.WorksheetParts.Single();
+            EmbeddedPackagePart embeddedPackagePart = worksheetPart.AddEmbeddedPackagePart(EmbeddedPackagePartType.Xlsx);
+            FeedPartData(embeddedPackagePart, embeddedBytes);
+            worksheetPart.Worksheet.Append(new OleObjects(
+                "<x:oleObjects xmlns:x=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\"><x:oleObject progId=\"Package\" shapeId=\"1025\" r:id=\"rIdOlePackage\" /></x:oleObjects>"));
+            worksheetPart.Worksheet.Append(new Controls(
+                "<x:controls xmlns:x=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\"><x:control shapeId=\"1026\" name=\"ApproveButton\" r:id=\"rIdControl1\" /></x:controls>"));
+            worksheetPart.Worksheet.Save();
+        }
+
+        private static void AssertPreservedPackageParts(
+            string filePath,
+            byte[] customXmlBytes,
+            byte[] connectionBytes,
+            byte[] queryTableBytes) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            WorkbookPart workbookPart = spreadsheet.WorkbookPart!;
+            WorksheetPart worksheetPart = workbookPart.WorksheetParts.Single();
+            HyperlinkRelationship hyperlink = Assert.Single(worksheetPart.HyperlinkRelationships);
+            Assert.Equal(new Uri("https://example.org/external-system/invoice/INV-2026-001"), hyperlink.Uri);
+
+            CustomXmlPart customXmlPart = Assert.Single(workbookPart.CustomXmlParts);
+            Assert.Equal(customXmlBytes, ReadPartBytes(customXmlPart));
+
+            OpenXmlPart connectionPart = Assert.Single(workbookPart.Parts.Select(part => part.OpenXmlPart),
+                part => part.ContentType.IndexOf("connections", StringComparison.OrdinalIgnoreCase) >= 0);
+            Assert.Equal(connectionBytes, ReadPartBytes(connectionPart));
+
+            OpenXmlPart queryTablePart = Assert.Single(worksheetPart.Parts.Select(part => part.OpenXmlPart),
+                part => part.ContentType.IndexOf("queryTable", StringComparison.OrdinalIgnoreCase) >= 0);
+            Assert.Equal(queryTableBytes, ReadPartBytes(queryTablePart));
+        }
+
+        private static void AssertPreservedAdvancedPackageParts(
+            string filePath,
+            byte[] vbaBytes,
+            byte[] embeddedBytes) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            WorkbookPart workbookPart = spreadsheet.WorkbookPart!;
+            Assert.NotNull(workbookPart.VbaProjectPart);
+            Assert.Equal(vbaBytes, ReadPartBytes(workbookPart.VbaProjectPart!));
+
+            WorksheetPart worksheetPart = workbookPart.WorksheetParts.Single();
+            EmbeddedPackagePart embeddedPackagePart = Assert.Single(worksheetPart.EmbeddedPackageParts);
+            Assert.Equal(embeddedBytes, ReadPartBytes(embeddedPackagePart));
+
+            Worksheet worksheet = worksheetPart.Worksheet;
+            OleObjects oleObjects = Assert.Single(worksheet.Elements<OleObjects>());
+            Controls controls = Assert.Single(worksheet.Elements<Controls>());
+            Assert.Contains("rIdOlePackage", oleObjects.OuterXml);
+            Assert.Contains("ApproveButton", controls.OuterXml);
+        }
+
+        private static void FeedPartData(OpenXmlPart part, byte[] bytes) {
+            using var stream = new MemoryStream(bytes);
+            part.FeedData(stream);
+        }
+
+        private static byte[] ReadPartBytes(OpenXmlPart part) {
+            using Stream stream = part.GetStream(FileMode.Open, FileAccess.Read);
+            using var buffer = new MemoryStream();
+            stream.CopyTo(buffer);
+            return buffer.ToArray();
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.CompatibilityCorpus.Preservation.cs
+++ b/OfficeIMO.Tests/Excel.CompatibilityCorpus.Preservation.cs
@@ -40,7 +40,7 @@ namespace OfficeIMO.Tests {
                     Assert.False(report.Can(ExcelPreflightCapability.BindTemplate));
                     Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
 
-                    Assert.Contains(report.PreservedFeatures, feature => feature.Name == "External workbook links"
+                    Assert.Contains(report.PartiallyEditableFeatures, feature => feature.Name == "External hyperlinks"
                         && feature.Details.Any(detail => detail.Contains("INV-2026-001", StringComparison.OrdinalIgnoreCase)));
                     Assert.Contains(report.PreservedFeatures, feature => feature.Name == "Custom XML parts");
                     Assert.Contains(report.PreservedFeatures, feature => feature.Name == "Connections and query tables"
@@ -48,7 +48,6 @@ namespace OfficeIMO.Tests {
 
                     string diagnostics = string.Join(Environment.NewLine,
                         report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
-                    Assert.Contains("External workbook links", diagnostics);
                     Assert.Contains("Custom XML parts", diagnostics);
                     Assert.Contains("Connections and query tables", diagnostics);
                     Assert.Contains("Connections and query tables", Assert.Throws<InvalidOperationException>(() =>

--- a/OfficeIMO.Tests/Excel.CompatibilityCorpus.cs
+++ b/OfficeIMO.Tests/Excel.CompatibilityCorpus.cs
@@ -514,5 +514,6 @@ namespace OfficeIMO.Tests {
                 }
             }
         }
+
     }
 }

--- a/OfficeIMO.Tests/Excel.FeatureReport.PdfPreflightReview.cs
+++ b/OfficeIMO.Tests/Excel.FeatureReport.PdfPreflightReview.cs
@@ -1,0 +1,164 @@
+using System;
+using System.IO;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void FeatureReport_Preflight_BlocksPdfExportForPngBytesRejectedByPdfWriter() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.InvalidPngImage.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Images");
+                sheet.CellValue(1, 1, "Image");
+                sheet.AddImage(2, 1, CreatePngWithInvalidCrc(), "image/png", widthPixels: 12, heightPixels: 12, name: "InvalidPng");
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains("PDF-unsupported images", diagnostics);
+                Assert.Contains("invalid CRC", diagnostics);
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_BlocksPdfExportForMixedHeaderFooterStyles() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.MixedHeaderFormatting.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Headers");
+                sheet.CellValue(1, 1, "Report");
+                sheet.SetHeaderFooter(headerLeft: "&BTotal", headerCenter: "Page &P");
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains("PDF-unsupported header/footer formatting", diagnostics);
+                Assert.Contains("mixed header/footer formatting", diagnostics);
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_BlocksPdfExportForUnsupportedHeaderFooterFonts() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.UnsupportedHeaderFont.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Headers");
+                sheet.CellValue(1, 1, "Report");
+                sheet.SetHeaderFooter(headerCenter: "&\"UnmappedFont\"Report");
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains("PDF-unsupported header/footer formatting", diagnostics);
+                Assert.Contains("unsupported font formatting", diagnostics);
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_AllowsPdfExportWhenUnsafeFormulaCachesAreOutsidePrintArea() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.FormulaOutsidePrintArea.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Report");
+                sheet.CellValue(1, 1, "Name");
+                sheet.CellValue(1, 2, "Value");
+                sheet.CellValue(2, 1, "Alpha");
+                sheet.CellValue(2, 2, 10d);
+                sheet.CellFormula(5, 4, "B2+1");
+                document.SetPrintArea(sheet, "A1:B2", save: false);
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.UseCachedFormulaValues));
+                Assert.True(report.Can(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains(report.PreservedFeatures, feature => feature.Name == "Missing formula caches");
+                Assert.DoesNotContain(report.PreservedFeatures, feature => feature.Name == "PDF-missing formula caches");
+                Assert.Empty(report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_AllowsPdfExportWhenUnsafeFormulaCachesAreHiddenRows() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.HiddenRowFormulaCache.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Report");
+                sheet.CellValue(1, 1, "Ready");
+                sheet.CellFormula(5, 1, "A1+1");
+                sheet.SetRowHidden(5, true);
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.UseCachedFormulaValues));
+                Assert.True(report.Can(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains(report.PreservedFeatures, feature => feature.Name == "Missing formula caches");
+                Assert.DoesNotContain(report.PreservedFeatures, feature => feature.Name == "PDF-missing formula caches");
+                Assert.Empty(report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_BlocksPdfExportForPrintTitleColumns() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.PrintTitleColumns.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Report");
+                sheet.CellValue(1, 1, "Region");
+                sheet.CellValue(1, 2, "Value");
+                sheet.CellValue(2, 1, "North");
+                sheet.CellValue(2, 2, 10d);
+                document.SetPrintTitles(sheet, firstRow: null, lastRow: null, firstCol: 1, lastCol: 1, save: false);
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains("PDF-unsupported print titles", diagnostics);
+                Assert.Contains("print-title columns", diagnostics);
+            }
+        }
+
+        private static byte[] CreatePngWithInvalidCrc() {
+            return new byte[] {
+                137, 80, 78, 71, 13, 10, 26, 10,
+                0, 0, 0, 13,
+                73, 72, 68, 82,
+                0, 0, 0, 1,
+                0, 0, 0, 1,
+                8, 2, 0, 0, 0,
+                0, 0, 0, 0
+            };
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.FeatureReport.Preflight.cs
+++ b/OfficeIMO.Tests/Excel.FeatureReport.Preflight.cs
@@ -4,6 +4,7 @@ using System.Text;
 using DocumentFormat.OpenXml.Packaging;
 using OfficeIMO.Excel;
 using Xunit;
+using X = DocumentFormat.OpenXml.Spreadsheet;
 
 namespace OfficeIMO.Tests {
     public partial class Excel {
@@ -187,6 +188,56 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void FeatureReport_Preflight_BlocksUnsupportedFormulasEvenWhenDependenciesOnlyMissCaches() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.UnsupportedFormulaChain.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Calc");
+                sheet.CellValue(1, 1, 2d);
+                sheet.CellFormula(1, 2, "A1+1");
+                sheet.CellFormula(1, 3, "UNIQUE(B1:B1)");
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.UseCachedFormulaValues));
+                Assert.False(report.Can(ExcelPreflightCapability.CalculateFormulas));
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.CalculateFormulas));
+                Assert.Contains("Formula calculation blockers", diagnostics);
+                Assert.Contains("UNIQUE", diagnostics);
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_AllowsPdfExportForCleanCachedUnsupportedFormulas() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.CleanCachedUnsupportedFormula.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Calc");
+                sheet.CellValue(1, 1, 7d);
+                sheet.CellFormula(1, 2, "UNIQUE(A1:A1)");
+                document.Save(false);
+            }
+
+            AddCachedFormulaValue(filePath, "B1", "7");
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.True(report.Can(ExcelPreflightCapability.UseCachedFormulaValues));
+                Assert.False(report.Can(ExcelPreflightCapability.CalculateFormulas));
+                Assert.True(report.Can(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains(report.PreservedFeatures, feature => feature.Name == "Unsupported formulas");
+                Assert.Empty(report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+            }
+        }
+
+        [Fact]
         public void FeatureReport_Preflight_BlocksPdfExportForUnsupportedChartTypes() {
             string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.SurfaceChart.xlsx");
 
@@ -218,6 +269,92 @@ namespace OfficeIMO.Tests {
                 Assert.Contains("PDF-unsupported charts", diagnostics);
                 Assert.Contains("Surface", diagnostics);
             }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_BlocksPdfExportForMixedChartTypes() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.ComboChart.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Charts");
+                var data = new ExcelChartData(
+                    new[] { "Q1", "Q2", "Q3" },
+                    new[] {
+                        new ExcelChartSeries("Sales", new[] { 10d, 20d, 30d }, ExcelChartType.ColumnClustered, ExcelChartAxisGroup.Primary),
+                        new ExcelChartSeries("Trend", new[] { 12d, 18d, 28d }, ExcelChartType.Line, ExcelChartAxisGroup.Secondary)
+                    });
+                sheet.AddChart(data, row: 1, column: 5, widthPixels: 360, heightPixels: 220,
+                    type: ExcelChartType.ColumnClustered, title: "Combo Chart");
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains("PDF-unsupported charts", diagnostics);
+                Assert.Contains("mixed per-series chart types", diagnostics);
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_BlocksPdfExportForNonWorksheetSheets() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.ChartSheet.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Value");
+                sheet.CellValue(2, 1, 10d);
+                document.Save(false);
+            }
+
+            AddChartSheet(filePath);
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains(report.PreservedFeatures, feature => feature.Name == "Non-worksheet sheets");
+
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains("Non-worksheet sheets", diagnostics);
+                Assert.Contains("ChartOnly", diagnostics);
+            }
+        }
+
+        private static void AddCachedFormulaValue(string filePath, string cellReference, string value) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true);
+            WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+            X.Cell cell = worksheetPart.Worksheet!.Descendants<X.Cell>()
+                .First(item => string.Equals(item.CellReference?.Value, cellReference, StringComparison.OrdinalIgnoreCase));
+            cell.CellValue = new X.CellValue(value);
+            cell.DataType = X.CellValues.Number;
+            cell.CellFormula!.CalculateCell = false;
+            worksheetPart.Worksheet.Save();
+        }
+
+        private static void AddChartSheet(string filePath) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true);
+            WorkbookPart workbookPart = spreadsheet.WorkbookPart!;
+            ChartsheetPart chartsheetPart = workbookPart.AddNewPart<ChartsheetPart>();
+            chartsheetPart.Chartsheet = new X.Chartsheet();
+
+            X.Sheets sheets = workbookPart.Workbook.Sheets ?? workbookPart.Workbook.AppendChild(new X.Sheets());
+            uint nextSheetId = sheets.Elements<X.Sheet>()
+                .Select(sheet => sheet.SheetId?.Value ?? 0U)
+                .DefaultIfEmpty(0U)
+                .Max() + 1U;
+            sheets.Append(new X.Sheet {
+                Id = workbookPart.GetIdOfPart(chartsheetPart),
+                SheetId = nextSheetId,
+                Name = "ChartOnly"
+            });
+            chartsheetPart.Chartsheet.Save();
+            workbookPart.Workbook.Save();
         }
 
         private static void AddDigitalSignatureMetadata(string filePath) {

--- a/OfficeIMO.Tests/Excel.FeatureReport.Preflight.cs
+++ b/OfficeIMO.Tests/Excel.FeatureReport.Preflight.cs
@@ -247,6 +247,32 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void FeatureReport_Preflight_AllowsPdfExportWhenUnsafeFormulaCachesAreOnlyHidden() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.HiddenFormulaCaches.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet visible = document.AddWorkSheet("Report");
+                visible.CellValue(1, 1, "Ready");
+
+                ExcelSheet hidden = document.AddWorkSheet("Scratch");
+                hidden.CellValue(1, 1, 2d);
+                hidden.CellFormula(1, 2, "A1+1");
+                hidden.SetHidden(true);
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.UseCachedFormulaValues));
+                Assert.True(report.Can(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains(report.PreservedFeatures, feature => feature.Name == "Missing formula caches");
+                Assert.DoesNotContain(report.PreservedFeatures, feature => feature.Name == "PDF-missing formula caches");
+                Assert.Empty(report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+            }
+        }
+
+        [Fact]
         public void FeatureReport_Preflight_IgnoresWorkbookRecalculationRequestWhenNoFormulasExist() {
             string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.RecalcNoFormulas.xlsx");
 
@@ -517,6 +543,38 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void FeatureReport_Preflight_ReportsDanglingChartPartsWithoutThrowing() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.DanglingChart.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Charts");
+                sheet.CellValue(1, 1, "Zone");
+                sheet.CellValue(1, 2, "Value");
+                sheet.CellValue(2, 1, "North");
+                sheet.CellValue(2, 2, 10d);
+                sheet.CellValue(3, 1, "South");
+                sheet.CellValue(3, 2, 12d);
+                ExcelChart chart = sheet.AddChartFromRange("A1:B3", row: 1, column: 5, widthPixels: 320, heightPixels: 180,
+                    type: ExcelChartType.ColumnClustered, title: "Dangling Chart");
+                chart.Name = "Dangling chart frame";
+                document.Save(false);
+            }
+
+            RemoveFirstChartPart(filePath);
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains("PDF-unreadable charts", diagnostics);
+                Assert.Contains("Dangling chart frame", diagnostics);
+            }
+        }
+
+        [Fact]
         public void FeatureReport_Preflight_BlocksPdfExportForUnsupportedWorksheetImages() {
             string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.UnsupportedImage.xlsx");
 
@@ -562,6 +620,56 @@ namespace OfficeIMO.Tests {
                 Assert.Contains("PDF-unsupported images", diagnostics);
                 Assert.Contains("header center", diagnostics);
                 Assert.Contains("image/gif", diagnostics);
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_BlocksPdfExportForUnsupportedHeaderFooterFormatting() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.UnsupportedHeaderFormatting.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Headers");
+                sheet.CellValue(1, 1, "Report");
+                sheet.SetHeaderFooter(headerCenter: "&UConfidential");
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains("PDF-unsupported header/footer formatting", diagnostics);
+                Assert.Contains("underline formatting", diagnostics);
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_BlocksPdfExportForMultiAreaPrintAreas() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.MultiAreaPrintArea.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Report");
+                sheet.CellValue(1, 1, "Top");
+                sheet.CellValue(2, 2, "Area one");
+                sheet.CellValue(2, 4, "Area two");
+                sheet.CellValue(5, 5, "Bottom");
+                document.Save(false);
+            }
+
+            AddMultiAreaPrintArea(filePath);
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains("PDF-unsupported print areas", diagnostics);
+                Assert.Contains("multiple print areas", diagnostics);
             }
         }
 
@@ -823,6 +931,33 @@ namespace OfficeIMO.Tests {
             });
             chartsheetPart.Chartsheet.Save();
             workbookPart.Workbook.Save();
+        }
+
+        private static void AddMultiAreaPrintArea(string filePath) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true);
+            WorkbookPart workbookPart = spreadsheet.WorkbookPart!;
+            X.Workbook workbook = workbookPart.Workbook;
+            workbook.DefinedNames ??= new X.DefinedNames();
+            workbook.DefinedNames.Elements<X.DefinedName>()
+                .Where(name => string.Equals(name.Name?.Value, "_xlnm.Print_Area", StringComparison.OrdinalIgnoreCase))
+                .ToList()
+                .ForEach(name => name.Remove());
+            workbook.DefinedNames.Append(new X.DefinedName {
+                Name = "_xlnm.Print_Area",
+                LocalSheetId = 0U,
+                Text = "'Report'!$B$2:$B$2,'Report'!$D$2:$D$2"
+            });
+            workbook.Save();
+        }
+
+        private static void RemoveFirstChartPart(string filePath) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true);
+            DrawingsPart drawingsPart = spreadsheet.WorkbookPart!.WorksheetParts
+                .Select(part => part.DrawingsPart)
+                .First(part => part?.ChartParts.Any() == true)!;
+            ChartPart chartPart = drawingsPart.ChartParts.First();
+            drawingsPart.DeletePart(chartPart);
+            drawingsPart.WorksheetDrawing?.Save();
         }
 
         private static void RemoveChartRangeFormulas(string filePath) {

--- a/OfficeIMO.Tests/Excel.FeatureReport.Preflight.cs
+++ b/OfficeIMO.Tests/Excel.FeatureReport.Preflight.cs
@@ -128,6 +128,37 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void FeatureReport_Preflight_BlocksPdfExportForInternalHyperlinksToSkippedTargets() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.InternalHiddenHyperlink.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet summary = document.AddWorkSheet("Summary");
+                summary.CellValue(1, 1, "Resource");
+                summary.CellValue(2, 1, "Hidden target");
+
+                ExcelSheet hidden = document.AddWorkSheet("Hidden Details");
+                hidden.CellValue(1, 1, "Target");
+                hidden.SetHidden(true);
+                document.Save(false);
+            }
+
+            AddWorksheetInternalHyperlink(filePath, "A2", "'Hidden Details'!A1");
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains(report.PartiallyEditableFeatures, feature => feature.Name == "PDF-unsupported hyperlinks");
+
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains("PDF-unsupported hyperlinks", diagnostics);
+                Assert.Contains("Hidden Details", diagnostics);
+                Assert.Contains("hidden and skipped", diagnostics);
+            }
+        }
+
+        [Fact]
         public void FeatureReport_Preflight_BlocksFormulaCalculationAndCachedReadsWhenFormulaStateIsUnsafe() {
             string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.Formulas.xlsx");
 
@@ -212,6 +243,27 @@ namespace OfficeIMO.Tests {
                 string diagnostics = string.Join(Environment.NewLine,
                     report.GetCapabilityDiagnostics(ExcelPreflightCapability.UseCachedFormulaValues));
                 Assert.Contains("Workbook recalculation requests", diagnostics);
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_IgnoresWorkbookRecalculationRequestWhenNoFormulasExist() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.RecalcNoFormulas.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Ready");
+                document.ConfigureFullCalculationOnOpen();
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.True(report.Can(ExcelPreflightCapability.UseCachedFormulaValues));
+                Assert.True(report.Can(ExcelPreflightCapability.ExportPdfReport));
+                Assert.DoesNotContain(report.PreservedFeatures, feature => feature.Name == "Workbook recalculation requests");
+                Assert.Empty(report.GetCapabilityDiagnostics(ExcelPreflightCapability.UseCachedFormulaValues));
             }
         }
 
@@ -606,6 +658,7 @@ namespace OfficeIMO.Tests {
                     report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
                 Assert.Contains("PDF-unrendered drawing shapes", diagnostics);
                 Assert.Contains("Report callout", diagnostics);
+                Assert.Contains("Report connector", diagnostics);
                 Assert.Contains("PDF-unsupported hyperlinks", diagnostics);
                 Assert.Contains("https://example.org/callout", diagnostics);
             }
@@ -673,6 +726,18 @@ namespace OfficeIMO.Tests {
             worksheetPart.Worksheet.Save();
         }
 
+        private static void AddWorksheetInternalHyperlink(string filePath, string cellReference, string location) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true);
+            WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+            X.Hyperlinks hyperlinks = worksheetPart.Worksheet!.Elements<X.Hyperlinks>().FirstOrDefault()
+                ?? worksheetPart.Worksheet.AppendChild(new X.Hyperlinks());
+            hyperlinks.Append(new X.Hyperlink {
+                Reference = cellReference,
+                Location = location
+            });
+            worksheetPart.Worksheet.Save();
+        }
+
         private static void ClearWorkbookRecalculationRequest(string filePath) {
             using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true);
             X.CalculationProperties? properties = spreadsheet.WorkbookPart!.Workbook.GetFirstChild<X.CalculationProperties>();
@@ -717,6 +782,24 @@ namespace OfficeIMO.Tests {
                             new A.BodyProperties(),
                             new A.ListStyle(),
                             new A.Paragraph(new A.Run(new A.Text("Review"))))),
+                    new Xdr.ClientData()),
+                new Xdr.TwoCellAnchor(
+                    new Xdr.FromMarker(
+                        new Xdr.ColumnId("4"),
+                        new Xdr.ColumnOffset("0"),
+                        new Xdr.RowId("1"),
+                        new Xdr.RowOffset("0")),
+                    new Xdr.ToMarker(
+                        new Xdr.ColumnId("5"),
+                        new Xdr.ColumnOffset("0"),
+                        new Xdr.RowId("4"),
+                        new Xdr.RowOffset("0")),
+                    new Xdr.ConnectionShape(
+                        new Xdr.NonVisualConnectionShapeProperties(
+                            new Xdr.NonVisualDrawingProperties { Id = 3U, Name = "Report connector" },
+                            new Xdr.NonVisualConnectorShapeDrawingProperties()),
+                        new Xdr.ShapeProperties(
+                            new A.PresetGeometry { Preset = A.ShapeTypeValues.Line })),
                     new Xdr.ClientData()));
             drawingsPart.WorksheetDrawing.Save();
             worksheetPart.Worksheet.Save();

--- a/OfficeIMO.Tests/Excel.FeatureReport.Preflight.cs
+++ b/OfficeIMO.Tests/Excel.FeatureReport.Preflight.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Text;
+using DocumentFormat.OpenXml.Packaging;
 using OfficeIMO.Excel;
 using Xunit;
 
@@ -97,9 +99,9 @@ namespace OfficeIMO.Tests {
 
                 string calculationDiagnostics = string.Join(Environment.NewLine,
                     report.GetCapabilityDiagnostics(ExcelPreflightCapability.CalculateFormulas));
-                Assert.Contains("Unsupported formulas", calculationDiagnostics);
+                Assert.Contains("Formula calculation blockers", calculationDiagnostics);
                 Assert.Contains("Formula dependency issues", calculationDiagnostics);
-                Assert.Contains("Unsupported formulas", Assert.Throws<InvalidOperationException>(() =>
+                Assert.Contains("Formula calculation blockers", Assert.Throws<InvalidOperationException>(() =>
                     report.EnsureCan(ExcelPreflightCapability.CalculateFormulas)).Message);
 
                 string cachedValueDiagnostics = string.Join(Environment.NewLine,
@@ -107,6 +109,133 @@ namespace OfficeIMO.Tests {
                 Assert.Contains("Missing formula caches", cachedValueDiagnostics);
                 Assert.Contains("Formula dependency issues", cachedValueDiagnostics);
             }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_BlocksCellEditsForSignedWorkbooks() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.Signed.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Signed");
+                sheet.CellValue(1, 1, "Status");
+                sheet.CellValue(2, 1, "Ready");
+                document.Save(false);
+            }
+
+            AddDigitalSignatureMetadata(filePath);
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.True(report.Can(ExcelPreflightCapability.ReadWorkbookData));
+                Assert.False(report.Can(ExcelPreflightCapability.EditCellValues));
+                Assert.Contains(report.PreservedFeatures, feature => feature.Name == "Digital signatures");
+
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.EditCellValues));
+                Assert.Contains("Digital signatures", diagnostics);
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_BlocksCachedReadsWhenFormulaCachesAreDirty() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.DirtyFormulaCaches.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Calc");
+                sheet.CellValue(1, 1, 2d);
+                sheet.CellFormula(1, 2, "A1+1");
+                Assert.Equal(1, document.Calculate());
+                document.InvalidateFormulas();
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.True(report.Can(ExcelPreflightCapability.CalculateFormulas));
+                Assert.False(report.Can(ExcelPreflightCapability.UseCachedFormulaValues));
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains(report.Features, feature => feature.Name == "Dirty formula caches");
+
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.UseCachedFormulaValues));
+                Assert.Contains("Dirty formula caches", diagnostics);
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_AllowsSupportedFormulaChainsWithoutCachedResultsToCalculate() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.FormulaChain.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Calc");
+                sheet.CellValue(1, 1, 2d);
+                sheet.CellFormula(1, 2, "A1+1");
+                sheet.CellFormula(1, 3, "B1+1");
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.UseCachedFormulaValues));
+                Assert.True(report.Can(ExcelPreflightCapability.CalculateFormulas));
+                Assert.Contains(report.PreservedFeatures, feature => feature.Name == "Formula dependency issues");
+                Assert.Empty(report.GetCapabilityDiagnostics(ExcelPreflightCapability.CalculateFormulas));
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_BlocksPdfExportForUnsupportedChartTypes() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.SurfaceChart.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Charts");
+                sheet.CellValue(1, 1, "Zone");
+                sheet.CellValue(1, 2, "Low");
+                sheet.CellValue(1, 3, "High");
+                sheet.CellValue(2, 1, "North");
+                sheet.CellValue(2, 2, 10d);
+                sheet.CellValue(2, 3, 15d);
+                sheet.CellValue(3, 1, "South");
+                sheet.CellValue(3, 2, 12d);
+                sheet.CellValue(3, 3, 18d);
+                sheet.AddChartFromRange("A1:C3", row: 1, column: 5, widthPixels: 320, heightPixels: 180,
+                    type: ExcelChartType.Surface, title: "Surface Chart");
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.True(report.Can(ExcelPreflightCapability.ReadWorkbookData));
+                Assert.True(report.Can(ExcelPreflightCapability.EditCellValues));
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains("PDF-unsupported charts", diagnostics);
+                Assert.Contains("Surface", diagnostics);
+            }
+        }
+
+        private static void AddDigitalSignatureMetadata(string filePath) {
+            byte[] signatureBytes = Encoding.UTF8.GetBytes(
+                "<Signature xmlns=\"http://www.w3.org/2000/09/xmldsig#\"><SignedInfo /></Signature>");
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true);
+            spreadsheet.AddDigitalSignatureOriginPart();
+            DigitalSignatureOriginPart originPart = spreadsheet.DigitalSignatureOriginPart!;
+            XmlSignaturePart signaturePart = originPart.AddNewPart<XmlSignaturePart>();
+            using (var stream = new MemoryStream(signatureBytes)) {
+                signaturePart.FeedData(stream);
+            }
+
+            ExtendedFilePropertiesPart appPart = spreadsheet.ExtendedFilePropertiesPart ?? spreadsheet.AddExtendedFilePropertiesPart();
+            appPart.Properties ??= new DocumentFormat.OpenXml.ExtendedProperties.Properties();
+            appPart.Properties.DigitalSignature = new DocumentFormat.OpenXml.ExtendedProperties.DigitalSignature();
+            appPart.Properties.Save();
         }
     }
 }

--- a/OfficeIMO.Tests/Excel.FeatureReport.Preflight.cs
+++ b/OfficeIMO.Tests/Excel.FeatureReport.Preflight.cs
@@ -4,6 +4,7 @@ using System.Text;
 using DocumentFormat.OpenXml.Packaging;
 using OfficeIMO.Excel;
 using Xunit;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
 using X = DocumentFormat.OpenXml.Spreadsheet;
 
 namespace OfficeIMO.Tests {
@@ -50,11 +51,12 @@ namespace OfficeIMO.Tests {
             string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.PreserveOnly.xlsx");
 
             using (ExcelDocument document = ExcelDocument.Create(filePath)) {
-                ExcelSheet sheet = document.AddWorkSheet("Links");
+                ExcelSheet sheet = document.AddWorkSheet("Metadata");
                 sheet.CellValue(1, 1, "Resource");
-                sheet.SetHyperlink(2, 1, "https://example.org/spec", display: "Spec");
                 document.Save(false);
             }
+
+            AddCustomXmlPart(filePath);
 
             using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
                 ExcelFeatureReport report = document.InspectFeatures();
@@ -65,15 +67,37 @@ namespace OfficeIMO.Tests {
                 Assert.False(report.Can(ExcelPreflightCapability.BindTemplate));
                 Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
 
-                Assert.Contains("External workbook links", string.Join(Environment.NewLine,
+                Assert.Contains("Custom XML parts", string.Join(Environment.NewLine,
                     report.GetCapabilityDiagnostics(ExcelPreflightCapability.EditWorkbookStructure)));
-                Assert.Contains("https://example.org/spec", string.Join(Environment.NewLine,
+                Assert.Contains("Custom XML parts", string.Join(Environment.NewLine,
                     report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport)));
 
                 InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
                     report.EnsureCan(ExcelPreflightCapability.ExportPdfReport));
                 Assert.Contains("ExportPdfReport", exception.Message);
-                Assert.Contains("External workbook links", exception.Message);
+                Assert.Contains("Custom XML parts", exception.Message);
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_AllowsPdfExportForExternalHyperlinks() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.ExternalHyperlink.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Links");
+                sheet.CellValue(1, 1, "Resource");
+                sheet.SetHyperlink(2, 1, "https://example.org/spec", display: "Spec");
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.True(report.Can(ExcelPreflightCapability.ReadWorkbookData));
+                Assert.True(report.Can(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains(report.PartiallyEditableFeatures, feature => feature.Name == "External hyperlinks");
+                Assert.DoesNotContain(report.PreservedFeatures, feature => feature.Name == "External workbook links");
+                Assert.Empty(report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
             }
         }
 
@@ -301,6 +325,125 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void FeatureReport_Preflight_BlocksPdfExportForSameFamilyMixedChartTypes() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.SameFamilyComboChart.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Charts");
+                var data = new ExcelChartData(
+                    new[] { "Q1", "Q2", "Q3" },
+                    new[] {
+                        new ExcelChartSeries("Sales", new[] { 10d, 20d, 30d }, ExcelChartType.ColumnClustered),
+                        new ExcelChartSeries("Target", new[] { 12d, 18d, 28d }, ExcelChartType.ColumnStacked)
+                    });
+                sheet.AddChart(data, row: 1, column: 5, widthPixels: 360, heightPixels: 220,
+                    type: ExcelChartType.ColumnClustered, title: "Column Combo Chart");
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains("PDF-unsupported charts", diagnostics);
+                Assert.Contains("mixed per-series chart types", diagnostics);
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_BlocksPdfExportForUnreadableChartSnapshots() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.UnreadableChart.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Charts");
+                sheet.CellValue(1, 1, "Zone");
+                sheet.CellValue(1, 2, "Value");
+                sheet.CellValue(2, 1, "North");
+                sheet.CellValue(2, 2, 10d);
+                sheet.CellValue(3, 1, "South");
+                sheet.CellValue(3, 2, 12d);
+                sheet.AddChartFromRange("A1:B3", row: 1, column: 5, widthPixels: 320, heightPixels: 180,
+                    type: ExcelChartType.ColumnClustered, title: "Literal Chart");
+                document.Save(false);
+            }
+
+            RemoveChartRangeFormulas(filePath);
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains("PDF-unreadable charts", diagnostics);
+                Assert.Contains("Literal Chart", diagnostics);
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_BlocksPdfExportForUnsupportedWorksheetImages() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.UnsupportedImage.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Images");
+                sheet.CellValue(1, 1, "Image");
+                sheet.AddImage(2, 1, new byte[] { 0x47, 0x49, 0x46, 0x38, 0x39, 0x61 }, "image/gif",
+                    widthPixels: 12, heightPixels: 12, name: "GifLogo");
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains("PDF-unsupported images", diagnostics);
+                Assert.Contains("image/gif", diagnostics);
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_BlocksPdfExportForPivotTablesAndSparklines() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.PivotSparkline.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Region");
+                sheet.CellValue(1, 2, "Sales");
+                sheet.CellValue(2, 1, "North");
+                sheet.CellValue(2, 2, 10d);
+                sheet.CellValue(3, 1, "South");
+                sheet.CellValue(3, 2, 12d);
+                sheet.AddPivotTable(
+                    sourceRange: "A1:B3",
+                    destinationCell: "D1",
+                    name: "SalesPivot",
+                    rowFields: new[] { "Region" },
+                    dataFields: new[] { new ExcelPivotDataField("Sales", X.DataConsolidateFunctionValues.Sum, "Total Sales") },
+                    pivotStyleName: "PivotStyleMedium9");
+                sheet.AddSparklines("B2:B3", "C2:C3");
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains("PDF-unrendered pivot tables", diagnostics);
+                Assert.Contains("PDF-unrendered sparklines", diagnostics);
+            }
+        }
+
+        [Fact]
         public void FeatureReport_Preflight_BlocksPdfExportForNonWorksheetSheets() {
             string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.ChartSheet.xlsx");
 
@@ -316,14 +459,26 @@ namespace OfficeIMO.Tests {
             using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
                 ExcelFeatureReport report = document.InspectFeatures();
 
+                Assert.False(report.Can(ExcelPreflightCapability.ReadWorkbookData));
                 Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
                 Assert.Contains(report.PreservedFeatures, feature => feature.Name == "Non-worksheet sheets");
+
+                string readDiagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ReadWorkbookData));
+                Assert.Contains("Non-worksheet sheets", readDiagnostics);
 
                 string diagnostics = string.Join(Environment.NewLine,
                     report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
                 Assert.Contains("Non-worksheet sheets", diagnostics);
                 Assert.Contains("ChartOnly", diagnostics);
             }
+        }
+
+        private static void AddCustomXmlPart(string filePath) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true);
+            CustomXmlPart part = spreadsheet.WorkbookPart!.AddCustomXmlPart(CustomXmlPartType.CustomXml);
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes("<metadata><owner>OfficeIMO</owner></metadata>"));
+            part.FeedData(stream);
         }
 
         private static void AddCachedFormulaValue(string filePath, string cellReference, string value) {
@@ -355,6 +510,18 @@ namespace OfficeIMO.Tests {
             });
             chartsheetPart.Chartsheet.Save();
             workbookPart.Workbook.Save();
+        }
+
+        private static void RemoveChartRangeFormulas(string filePath) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true);
+            ChartPart chartPart = spreadsheet.WorkbookPart!.WorksheetParts
+                .SelectMany(part => part.DrawingsPart?.ChartParts ?? Enumerable.Empty<ChartPart>())
+                .First();
+            foreach (C.Formula formula in chartPart.ChartSpace!.Descendants<C.Formula>().ToList()) {
+                formula.Remove();
+            }
+
+            chartPart.ChartSpace.Save();
         }
 
         private static void AddDigitalSignatureMetadata(string filePath) {

--- a/OfficeIMO.Tests/Excel.FeatureReport.Preflight.cs
+++ b/OfficeIMO.Tests/Excel.FeatureReport.Preflight.cs
@@ -1,0 +1,112 @@
+using System;
+using System.IO;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void FeatureReport_Preflight_AllowsCleanReportWorkbookWorkflows() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.Clean.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Report");
+                sheet.CellValue(1, 1, "Name");
+                sheet.CellValue(1, 2, "Score");
+                sheet.CellValue(2, 1, "Alpha");
+                sheet.CellValue(2, 2, 10d);
+                sheet.CellValue(3, 1, "Beta");
+                sheet.CellValue(3, 2, 20d);
+                sheet.AddTable("A1:B3", hasHeader: true, name: "Scores", style: TableStyle.TableStyleMedium4);
+                sheet.CellFormula(4, 2, "SUM(B2:B3)");
+                Assert.Equal(1, document.Calculate());
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.True(report.Can(ExcelPreflightCapability.ReadWorkbookData));
+                Assert.True(report.Can(ExcelPreflightCapability.EditCellValues));
+                Assert.True(report.Can(ExcelPreflightCapability.EditWorkbookStructure));
+                Assert.True(report.Can(ExcelPreflightCapability.UseCachedFormulaValues));
+                Assert.True(report.Can(ExcelPreflightCapability.CalculateFormulas));
+                Assert.True(report.Can(ExcelPreflightCapability.BindTemplate));
+                Assert.True(report.Can(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Empty(report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Same(report, report.EnsureCan(ExcelPreflightCapability.ExportPdfReport));
+
+                string markdown = report.ToMarkdown();
+                Assert.Contains("## Capability Preflight", markdown);
+                Assert.Contains("ExportPdfReport", markdown);
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_BlocksStructureTemplateAndPdfWhenPreserveOnlyPartsExist() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.PreserveOnly.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Links");
+                sheet.CellValue(1, 1, "Resource");
+                sheet.SetHyperlink(2, 1, "https://example.org/spec", display: "Spec");
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.True(report.Can(ExcelPreflightCapability.ReadWorkbookData));
+                Assert.True(report.Can(ExcelPreflightCapability.EditCellValues));
+                Assert.False(report.Can(ExcelPreflightCapability.EditWorkbookStructure));
+                Assert.False(report.Can(ExcelPreflightCapability.BindTemplate));
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+
+                Assert.Contains("External workbook links", string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.EditWorkbookStructure)));
+                Assert.Contains("https://example.org/spec", string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport)));
+
+                InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+                    report.EnsureCan(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains("ExportPdfReport", exception.Message);
+                Assert.Contains("External workbook links", exception.Message);
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_BlocksFormulaCalculationAndCachedReadsWhenFormulaStateIsUnsafe() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.Formulas.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Calc");
+                sheet.CellValue(1, 1, "A");
+                sheet.CellValue(2, 1, "B");
+                sheet.CellFormula(1, 2, "UNIQUE(A1:A2)");
+                sheet.CellFormula(2, 2, "B1+1");
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.UseCachedFormulaValues));
+                Assert.False(report.Can(ExcelPreflightCapability.CalculateFormulas));
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains(report.PreservedFeatures, feature => feature.Name == "Formula dependency issues");
+
+                string calculationDiagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.CalculateFormulas));
+                Assert.Contains("Unsupported formulas", calculationDiagnostics);
+                Assert.Contains("Formula dependency issues", calculationDiagnostics);
+                Assert.Contains("Unsupported formulas", Assert.Throws<InvalidOperationException>(() =>
+                    report.EnsureCan(ExcelPreflightCapability.CalculateFormulas)).Message);
+
+                string cachedValueDiagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.UseCachedFormulaValues));
+                Assert.Contains("Missing formula caches", cachedValueDiagnostics);
+                Assert.Contains("Formula dependency issues", cachedValueDiagnostics);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.FeatureReport.Preflight.cs
+++ b/OfficeIMO.Tests/Excel.FeatureReport.Preflight.cs
@@ -4,7 +4,9 @@ using System.Text;
 using DocumentFormat.OpenXml.Packaging;
 using OfficeIMO.Excel;
 using Xunit;
+using A = DocumentFormat.OpenXml.Drawing;
 using C = DocumentFormat.OpenXml.Drawing.Charts;
+using Xdr = DocumentFormat.OpenXml.Drawing.Spreadsheet;
 using X = DocumentFormat.OpenXml.Spreadsheet;
 
 namespace OfficeIMO.Tests {
@@ -22,8 +24,6 @@ namespace OfficeIMO.Tests {
                 sheet.CellValue(3, 1, "Beta");
                 sheet.CellValue(3, 2, 20d);
                 sheet.AddTable("A1:B3", hasHeader: true, name: "Scores", style: TableStyle.TableStyleMedium4);
-                sheet.CellFormula(4, 2, "SUM(B2:B3)");
-                Assert.Equal(1, document.Calculate());
                 document.Save(false);
             }
 
@@ -102,6 +102,32 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void FeatureReport_Preflight_BlocksPdfExportForRelativeExternalHyperlinks() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.RelativeHyperlink.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Links");
+                sheet.CellValue(1, 1, "Resource");
+                sheet.CellValue(2, 1, "Spec");
+                document.Save(false);
+            }
+
+            AddWorksheetHyperlink(filePath, "A2", "../docs/spec.pdf", UriKind.Relative);
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains(report.PartiallyEditableFeatures, feature => feature.Name == "PDF-unsupported hyperlinks");
+
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains("PDF-unsupported hyperlinks", diagnostics);
+                Assert.Contains("../docs/spec.pdf", diagnostics);
+            }
+        }
+
+        [Fact]
         public void FeatureReport_Preflight_BlocksFormulaCalculationAndCachedReadsWhenFormulaStateIsUnsafe() {
             string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.Formulas.xlsx");
 
@@ -132,7 +158,60 @@ namespace OfficeIMO.Tests {
                 string cachedValueDiagnostics = string.Join(Environment.NewLine,
                     report.GetCapabilityDiagnostics(ExcelPreflightCapability.UseCachedFormulaValues));
                 Assert.Contains("Missing formula caches", cachedValueDiagnostics);
-                Assert.Contains("Formula dependency issues", cachedValueDiagnostics);
+                Assert.DoesNotContain("Formula dependency issues", cachedValueDiagnostics);
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_AllowsCachedReadsWhenUnsupportedDependenciesHaveCleanCaches() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.CleanCachedDependency.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Calc");
+                sheet.CellValue(1, 1, "A");
+                sheet.CellFormula(1, 2, "UNIQUE(A1:A1)");
+                sheet.CellFormula(1, 3, "B1+1");
+                document.Save(false);
+            }
+
+            AddCachedFormulaValue(filePath, "B1", "1");
+            AddCachedFormulaValue(filePath, "C1", "2");
+            ClearWorkbookRecalculationRequest(filePath);
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.True(report.Can(ExcelPreflightCapability.UseCachedFormulaValues));
+                Assert.False(report.Can(ExcelPreflightCapability.CalculateFormulas));
+                Assert.True(report.Can(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains(report.PreservedFeatures, feature => feature.Name == "Formula dependency issues");
+                Assert.Empty(report.GetCapabilityDiagnostics(ExcelPreflightCapability.UseCachedFormulaValues));
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_BlocksCachedReadsWhenWorkbookRequestsRecalculation() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.RecalcRequest.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Calc");
+                sheet.CellValue(1, 1, 2d);
+                sheet.CellFormula(1, 2, "A1+1");
+                Assert.Equal(1, document.Calculate());
+                document.ConfigureFullCalculationOnOpen();
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.UseCachedFormulaValues));
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains(report.PreservedFeatures, feature => feature.Name == "Workbook recalculation requests");
+
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.UseCachedFormulaValues));
+                Assert.Contains("Workbook recalculation requests", diagnostics);
             }
         }
 
@@ -249,6 +328,7 @@ namespace OfficeIMO.Tests {
             }
 
             AddCachedFormulaValue(filePath, "B1", "7");
+            ClearWorkbookRecalculationRequest(filePath);
 
             using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
                 ExcelFeatureReport report = document.InspectFeatures();
@@ -409,6 +489,31 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void FeatureReport_Preflight_BlocksPdfExportForUnsupportedHeaderFooterImages() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.UnsupportedHeaderImage.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Images");
+                sheet.CellValue(1, 1, "Image");
+                sheet.SetHeaderImage(HeaderFooterPosition.Center, new byte[] { 0x47, 0x49, 0x46, 0x38, 0x39, 0x61 }, "image/gif",
+                    widthPoints: 24, heightPoints: 24);
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains("PDF-unsupported images", diagnostics);
+                Assert.Contains("header center", diagnostics);
+                Assert.Contains("image/gif", diagnostics);
+            }
+        }
+
+        [Fact]
         public void FeatureReport_Preflight_BlocksPdfExportForPivotTablesAndSparklines() {
             string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.PivotSparkline.xlsx");
 
@@ -440,6 +545,69 @@ namespace OfficeIMO.Tests {
                     report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
                 Assert.Contains("PDF-unrendered pivot tables", diagnostics);
                 Assert.Contains("PDF-unrendered sparklines", diagnostics);
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_IgnoresHiddenSheetPdfOnlyBlockers() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.HiddenPivotSparkline.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet visible = document.AddWorkSheet("Report");
+                visible.CellValue(1, 1, "Ready");
+
+                ExcelSheet hidden = document.AddWorkSheet("Analysis");
+                hidden.CellValue(1, 1, "Region");
+                hidden.CellValue(1, 2, "Sales");
+                hidden.CellValue(2, 1, "North");
+                hidden.CellValue(2, 2, 10d);
+                hidden.CellValue(3, 1, "South");
+                hidden.CellValue(3, 2, 12d);
+                hidden.AddPivotTable(
+                    sourceRange: "A1:B3",
+                    destinationCell: "D1",
+                    name: "HiddenPivot",
+                    rowFields: new[] { "Region" },
+                    dataFields: new[] { new ExcelPivotDataField("Sales", X.DataConsolidateFunctionValues.Sum, "Total Sales") });
+                hidden.AddSparklines("B2:B3", "C2:C3");
+                hidden.SetHidden(true);
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.True(report.Can(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains(report.PartiallyEditableFeatures, feature => feature.Name == "Pivot tables");
+                Assert.Contains(report.EditableFeatures, feature => feature.Name == "Sparklines");
+                Assert.DoesNotContain(report.PartiallyEditableFeatures, feature => feature.Name == "PDF-unrendered pivot tables");
+                Assert.DoesNotContain(report.PartiallyEditableFeatures, feature => feature.Name == "PDF-unrendered sparklines");
+            }
+        }
+
+        [Fact]
+        public void FeatureReport_Preflight_BlocksPdfExportForDrawingShapesAndDrawingHyperlinks() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.DrawingShapeLink.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Shapes");
+                sheet.CellValue(1, 1, "Callout");
+                document.Save(false);
+            }
+
+            AddDrawingShapeAndHyperlink(filePath);
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+
+                string diagnostics = string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains("PDF-unrendered drawing shapes", diagnostics);
+                Assert.Contains("Report callout", diagnostics);
+                Assert.Contains("PDF-unsupported hyperlinks", diagnostics);
+                Assert.Contains("https://example.org/callout", diagnostics);
             }
         }
 
@@ -489,6 +657,68 @@ namespace OfficeIMO.Tests {
             cell.CellValue = new X.CellValue(value);
             cell.DataType = X.CellValues.Number;
             cell.CellFormula!.CalculateCell = false;
+            worksheetPart.Worksheet.Save();
+        }
+
+        private static void AddWorksheetHyperlink(string filePath, string cellReference, string target, UriKind uriKind) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true);
+            WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+            HyperlinkRelationship relationship = worksheetPart.AddHyperlinkRelationship(new Uri(target, uriKind), true);
+            X.Hyperlinks hyperlinks = worksheetPart.Worksheet!.Elements<X.Hyperlinks>().FirstOrDefault()
+                ?? worksheetPart.Worksheet.AppendChild(new X.Hyperlinks());
+            hyperlinks.Append(new X.Hyperlink {
+                Reference = cellReference,
+                Id = relationship.Id
+            });
+            worksheetPart.Worksheet.Save();
+        }
+
+        private static void ClearWorkbookRecalculationRequest(string filePath) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true);
+            X.CalculationProperties? properties = spreadsheet.WorkbookPart!.Workbook.GetFirstChild<X.CalculationProperties>();
+            if (properties == null) {
+                return;
+            }
+
+            properties.ForceFullCalculation = false;
+            properties.FullCalculationOnLoad = false;
+            spreadsheet.WorkbookPart.Workbook.Save();
+        }
+
+        private static void AddDrawingShapeAndHyperlink(string filePath) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true);
+            WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+            DrawingsPart drawingsPart = worksheetPart.DrawingsPart ?? worksheetPart.AddNewPart<DrawingsPart>();
+            if (worksheetPart.Worksheet!.Elements<X.Drawing>().FirstOrDefault() == null) {
+                worksheetPart.Worksheet.Append(new X.Drawing { Id = worksheetPart.GetIdOfPart(drawingsPart) });
+            }
+
+            drawingsPart.AddHyperlinkRelationship(new Uri("https://example.org/callout", UriKind.Absolute), true, "rIdCalloutLink");
+
+            drawingsPart.WorksheetDrawing = new Xdr.WorksheetDrawing(
+                new Xdr.TwoCellAnchor(
+                    new Xdr.FromMarker(
+                        new Xdr.ColumnId("1"),
+                        new Xdr.ColumnOffset("0"),
+                        new Xdr.RowId("1"),
+                        new Xdr.RowOffset("0")),
+                    new Xdr.ToMarker(
+                        new Xdr.ColumnId("3"),
+                        new Xdr.ColumnOffset("0"),
+                        new Xdr.RowId("4"),
+                        new Xdr.RowOffset("0")),
+                    new Xdr.Shape(
+                        new Xdr.NonVisualShapeProperties(
+                            new Xdr.NonVisualDrawingProperties { Id = 2U, Name = "Report callout" },
+                            new Xdr.NonVisualShapeDrawingProperties(new A.ShapeLocks { NoGrouping = true })),
+                        new Xdr.ShapeProperties(
+                            new A.PresetGeometry { Preset = A.ShapeTypeValues.RoundRectangle }),
+                        new Xdr.TextBody(
+                            new A.BodyProperties(),
+                            new A.ListStyle(),
+                            new A.Paragraph(new A.Run(new A.Text("Review"))))),
+                    new Xdr.ClientData()));
+            drawingsPart.WorksheetDrawing.Save();
             worksheetPart.Worksheet.Save();
         }
 

--- a/OfficeIMO.Tests/Pdf/Excel.ReportWorkflowTests.cs
+++ b/OfficeIMO.Tests/Pdf/Excel.ReportWorkflowTests.cs
@@ -1,0 +1,90 @@
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.Pdf;
+using PdfPigDocument = UglyToad.PdfPig.PdfDocument;
+using PdfCore = OfficeIMO.Pdf;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Excel {
+    [Fact]
+    public void ReportWorkflow_TemplateFormulaChartPivot_PreflightsAndExportsPdf() {
+        string workbookPath = Path.Combine(_directoryWithFiles, "ExcelReportWorkflow.xlsx");
+
+        try {
+            byte[] pdfBytes;
+            using (ExcelDocument document = ExcelDocument.Create(workbookPath, "Report")) {
+                ExcelSheet sheet = document.Sheets[0];
+                sheet.Cell(1, 1, "{{ReportTitle}}");
+                sheet.Cell(2, 1, "Region");
+                sheet.Cell(2, 2, "Revenue");
+                sheet.Cell(2, 3, "Cost");
+                sheet.Cell(2, 4, "Margin");
+                sheet.Cell(3, 1, "East");
+                sheet.Cell(3, 2, 120);
+                sheet.Cell(3, 3, 50);
+                sheet.CellFormula(3, 4, "B3-C3");
+                sheet.Cell(4, 1, "West");
+                sheet.Cell(4, 2, 90);
+                sheet.Cell(4, 3, 40);
+                sheet.CellFormula(4, 4, "B4-C4");
+
+                int replacements = document.ApplyTemplate(new Dictionary<string, object?> {
+                    ["ReportTitle"] = "Executive revenue report"
+                });
+                Assert.Equal(1, replacements);
+
+                Assert.Equal(2, document.RecalculateSupportedFormulas());
+                Assert.True(sheet.TryGetCachedFormulaValue(3, 4, out string? eastMargin));
+                Assert.Equal("70", eastMargin);
+
+                sheet.AddTable("A2:D4", hasHeader: true, name: "RevenueData", style: OfficeIMO.Excel.TableStyle.TableStyleMedium4);
+                sheet.AddChartFromRange("A2:D4", row: 6, column: 1, widthPixels: 420, heightPixels: 240,
+                    type: ExcelChartType.ColumnClustered, title: "Revenue and Margin");
+                sheet.AddPivotTable(
+                    sourceRange: "A2:D4",
+                    destinationCell: "F2",
+                    name: "RevenuePivot",
+                    rowFields: new[] { "Region" },
+                    dataFields: new[] { new ExcelPivotDataField("Revenue", DataConsolidateFunctionValues.Sum, "Total Revenue") },
+                    pivotStyleName: "PivotStyleMedium9");
+
+                ExcelFeatureReport report = document.InspectFeatures();
+                Assert.True(report.Can(ExcelPreflightCapability.BindTemplate));
+                Assert.True(report.Can(ExcelPreflightCapability.CalculateFormulas));
+                Assert.True(report.Can(ExcelPreflightCapability.UseCachedFormulaValues));
+                Assert.True(report.Can(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Empty(report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+
+                document.Save(false);
+                pdfBytes = document.SaveAsPdf(new ExcelPdfSaveOptions {
+                    IncludeSheetHeadings = false,
+                    HeaderRowCount = 1,
+                    PageSize = new PdfCore.PageSize(560, 520),
+                    Margins = PdfCore.PageMargins.Uniform(24)
+                });
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(workbookPath, false)) {
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts
+                    .Single(part => part.PivotTableParts.Any());
+                Assert.Single(worksheetPart.TableDefinitionParts);
+                Assert.Single(worksheetPart.PivotTableParts);
+                Assert.Single(worksheetPart.DrawingsPart!.ChartParts);
+            }
+
+            using PdfPigDocument pdf = PdfPigDocument.Open(new MemoryStream(pdfBytes));
+            string text = string.Concat(pdf.GetPages().Select(page => page.Text));
+            Assert.Contains("Executive revenue report", text);
+            Assert.Contains("Revenue and Margin", text);
+            Assert.Contains("East", text);
+            Assert.Contains("70", text);
+        } finally {
+            if (File.Exists(workbookPath)) {
+                File.Delete(workbookPath);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Pdf/Excel.ReportWorkflowTests.cs
+++ b/OfficeIMO.Tests/Pdf/Excel.ReportWorkflowTests.cs
@@ -55,8 +55,9 @@ public partial class Excel {
                 Assert.True(report.Can(ExcelPreflightCapability.BindTemplate));
                 Assert.True(report.Can(ExcelPreflightCapability.CalculateFormulas));
                 Assert.True(report.Can(ExcelPreflightCapability.UseCachedFormulaValues));
-                Assert.True(report.Can(ExcelPreflightCapability.ExportPdfReport));
-                Assert.Empty(report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
+                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Contains("PDF-unrendered pivot tables", string.Join(Environment.NewLine,
+                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport)));
 
                 document.Save(false);
                 pdfBytes = document.SaveAsPdf(new ExcelPdfSaveOptions {


### PR DESCRIPTION
## Summary
- add workflow-level Excel preflight capabilities with diagnostics and markdown output
- expand compatibility corpus evidence for preserve-only workbook content including external links, custom XML, connections, VBA, embedded packages, OLE objects, and form controls
- add integrated template/formula/chart/pivot/PDF workflow coverage plus job-oriented examples and docs
- reduce OfficeIMO.Examples nullable warning noise without adding benchmark or CI work

## Validation
- dotnet build .\OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Release --no-restore -v:minimal
- dotnet build .\OfficeIMO.Examples\OfficeIMO.Examples.csproj -c Release --no-restore -v:minimal
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~FeatureReport_Preflight|FullyQualifiedName~Compatibility_Corpus_PreserveOnlyMetadata_RoundTripsAndBlocksRiskyWorkflows|FullyQualifiedName~Compatibility_Corpus_MacroEmbeddedObjectsAndControls_RoundTripAndBlockRiskyWorkflows|FullyQualifiedName~ReportWorkflow_TemplateFormulaChartPivot_PreflightsAndExportsPdf" --no-build --logger "console;verbosity=minimal"
- dotnet test .\OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~Compatibility_Corpus" --no-restore --logger "console;verbosity=minimal"
