### PR TITLE
Add shared HTML diagnostics and gallery contracts

### DIFF
--- a/OfficeIMO.Html.Pdf/HtmlPdfConverterExtensions.cs
+++ b/OfficeIMO.Html.Pdf/HtmlPdfConverterExtensions.cs
@@ -119,6 +119,7 @@ public static class HtmlPdfConverterExtensions {
         options.WordPdfOptions = wordPdfOptions;
         options.WordHtmlOptions = wordHtmlOptions;
         wordHtmlOptions.Diagnostics.Clear();
+        wordHtmlOptions.ConversionReport.Clear();
         using WordDocument document = html.LoadFromHtml(wordHtmlOptions);
         PdfCore.PdfDocument pdf = document.ToPdfDocument(wordPdfOptions);
         options.ConversionReport.LinkReport(wordPdfOptions.ConversionReport);
@@ -156,14 +157,14 @@ public static class HtmlPdfConverterExtensions {
             return;
         }
 
-        foreach (HtmlConversionDiagnostic diagnostic in options.WordHtmlOptions.Diagnostics) {
+        foreach (HtmlDiagnostic diagnostic in options.WordHtmlOptions.ConversionReport.Diagnostics) {
             var details = string.IsNullOrWhiteSpace(diagnostic.Detail)
                 ? null
                 : new Dictionary<string, string> {
                     ["Detail"] = diagnostic.Detail!
                 };
             warnings.Add(new PdfCore.PdfConversionWarning(
-                "OfficeIMO.Word.Html",
+                diagnostic.Component,
                 diagnostic.Code,
                 diagnostic.Source ?? "html",
                 diagnostic.Message,
@@ -172,10 +173,10 @@ public static class HtmlPdfConverterExtensions {
         }
     }
 
-    private static PdfCore.PdfConversionWarningSeverity MapSeverity(HtmlConversionDiagnosticSeverity severity) {
+    private static PdfCore.PdfConversionWarningSeverity MapSeverity(HtmlDiagnosticSeverity severity) {
         return severity switch {
-            HtmlConversionDiagnosticSeverity.Info => PdfCore.PdfConversionWarningSeverity.Information,
-            HtmlConversionDiagnosticSeverity.Error => PdfCore.PdfConversionWarningSeverity.Error,
+            HtmlDiagnosticSeverity.Info => PdfCore.PdfConversionWarningSeverity.Information,
+            HtmlDiagnosticSeverity.Error => PdfCore.PdfConversionWarningSeverity.Error,
             _ => PdfCore.PdfConversionWarningSeverity.Warning
         };
     }

--- a/OfficeIMO.Html/Diagnostics/HtmlDiagnostic.cs
+++ b/OfficeIMO.Html/Diagnostics/HtmlDiagnostic.cs
@@ -1,0 +1,60 @@
+namespace OfficeIMO.Html;
+
+/// <summary>
+/// Shared diagnostic record for OfficeIMO HTML ingestion, conversion, and artifact workflows.
+/// </summary>
+public sealed class HtmlDiagnostic {
+    /// <summary>
+    /// Creates a shared HTML diagnostic.
+    /// </summary>
+    /// <param name="component">Component that emitted the diagnostic, such as <c>OfficeIMO.Word.Html</c>.</param>
+    /// <param name="code">Stable diagnostic code.</param>
+    /// <param name="message">Human-readable diagnostic message.</param>
+    /// <param name="severity">Diagnostic severity.</param>
+    /// <param name="source">Optional HTML, resource, or artifact source associated with the diagnostic.</param>
+    /// <param name="detail">Optional low-level detail, such as an exception type, status text, or limit data.</param>
+    public HtmlDiagnostic(string component, string code, string message, HtmlDiagnosticSeverity severity = HtmlDiagnosticSeverity.Warning, string? source = null, string? detail = null) {
+        Component = component ?? throw new ArgumentNullException(nameof(component));
+        Code = code ?? throw new ArgumentNullException(nameof(code));
+        Message = message ?? throw new ArgumentNullException(nameof(message));
+        Severity = severity;
+        Source = source;
+        Detail = detail;
+    }
+
+    /// <summary>
+    /// Component that emitted the diagnostic.
+    /// </summary>
+    public string Component { get; }
+
+    /// <summary>
+    /// Stable diagnostic code.
+    /// </summary>
+    public string Code { get; }
+
+    /// <summary>
+    /// Human-readable diagnostic message.
+    /// </summary>
+    public string Message { get; }
+
+    /// <summary>
+    /// Diagnostic severity.
+    /// </summary>
+    public HtmlDiagnosticSeverity Severity { get; }
+
+    /// <summary>
+    /// Optional HTML, resource, or artifact source associated with the diagnostic.
+    /// </summary>
+    public string? Source { get; }
+
+    /// <summary>
+    /// Optional low-level detail, such as an exception type, status text, or limit data.
+    /// </summary>
+    public string? Detail { get; }
+
+    /// <inheritdoc />
+    public override string ToString() {
+        string source = string.IsNullOrWhiteSpace(Source) ? string.Empty : $" [{Source}]";
+        return $"{Component}:{Code}:{Severity}{source} {Message}";
+    }
+}

--- a/OfficeIMO.Html/Diagnostics/HtmlDiagnosticReport.cs
+++ b/OfficeIMO.Html/Diagnostics/HtmlDiagnosticReport.cs
@@ -1,0 +1,79 @@
+namespace OfficeIMO.Html;
+
+/// <summary>
+/// Mutable report of diagnostics emitted by OfficeIMO HTML workflows.
+/// </summary>
+public sealed class HtmlDiagnosticReport {
+    private readonly List<HtmlDiagnostic> _diagnostics = new List<HtmlDiagnostic>();
+
+    /// <summary>
+    /// Diagnostics captured by the report in emission order.
+    /// </summary>
+    public IReadOnlyList<HtmlDiagnostic> Diagnostics => _diagnostics;
+
+    /// <summary>
+    /// Number of diagnostics currently captured.
+    /// </summary>
+    public int Count => _diagnostics.Count;
+
+    /// <summary>
+    /// Indicates whether any captured diagnostic has error severity.
+    /// </summary>
+    public bool HasErrors => _diagnostics.Any(diagnostic => diagnostic.Severity == HtmlDiagnosticSeverity.Error);
+
+    /// <summary>
+    /// Adds an existing diagnostic instance to the report.
+    /// </summary>
+    /// <param name="diagnostic">Diagnostic to add.</param>
+    public void Add(HtmlDiagnostic diagnostic) {
+        if (diagnostic == null) {
+            throw new ArgumentNullException(nameof(diagnostic));
+        }
+
+        _diagnostics.Add(diagnostic);
+    }
+
+    /// <summary>
+    /// Adds a diagnostic to the report.
+    /// </summary>
+    /// <param name="component">Component that emitted the diagnostic.</param>
+    /// <param name="code">Stable diagnostic code.</param>
+    /// <param name="message">Human-readable diagnostic message.</param>
+    /// <param name="severity">Diagnostic severity.</param>
+    /// <param name="source">Optional HTML, resource, or artifact source associated with the diagnostic.</param>
+    /// <param name="detail">Optional low-level detail.</param>
+    public void Add(string component, string code, string message, HtmlDiagnosticSeverity severity = HtmlDiagnosticSeverity.Warning, string? source = null, string? detail = null) {
+        Add(new HtmlDiagnostic(component, code, message, severity, source, detail));
+    }
+
+    /// <summary>
+    /// Adds diagnostics to the report in enumeration order.
+    /// </summary>
+    /// <param name="diagnostics">Diagnostics to add.</param>
+    public void AddRange(IEnumerable<HtmlDiagnostic> diagnostics) {
+        if (diagnostics == null) {
+            throw new ArgumentNullException(nameof(diagnostics));
+        }
+
+        foreach (HtmlDiagnostic diagnostic in diagnostics) {
+            Add(diagnostic);
+        }
+    }
+
+    /// <summary>
+    /// Removes all diagnostics from the report.
+    /// </summary>
+    public void Clear() {
+        _diagnostics.Clear();
+    }
+
+    /// <summary>
+    /// Creates an independent copy of the current diagnostic report.
+    /// </summary>
+    /// <returns>A report containing the same immutable diagnostics.</returns>
+    public HtmlDiagnosticReport Clone() {
+        var clone = new HtmlDiagnosticReport();
+        clone.AddRange(_diagnostics);
+        return clone;
+    }
+}

--- a/OfficeIMO.Html/Diagnostics/HtmlDiagnosticSeverity.cs
+++ b/OfficeIMO.Html/Diagnostics/HtmlDiagnosticSeverity.cs
@@ -1,0 +1,21 @@
+namespace OfficeIMO.Html;
+
+/// <summary>
+/// Severity for shared OfficeIMO HTML diagnostics.
+/// </summary>
+public enum HtmlDiagnosticSeverity {
+    /// <summary>
+    /// Informational diagnostic that does not indicate content loss.
+    /// </summary>
+    Info,
+
+    /// <summary>
+    /// Warning diagnostic for skipped, blocked, or degraded content.
+    /// </summary>
+    Warning,
+
+    /// <summary>
+    /// Error diagnostic for content that could not be processed as requested.
+    /// </summary>
+    Error
+}

--- a/OfficeIMO.Html/Gallery/HtmlCapabilityGalleryArtifact.cs
+++ b/OfficeIMO.Html/Gallery/HtmlCapabilityGalleryArtifact.cs
@@ -1,0 +1,85 @@
+using System.Security.Cryptography;
+
+namespace OfficeIMO.Html;
+
+/// <summary>
+/// Describes one artifact emitted by an HTML capability-gallery scenario.
+/// </summary>
+public sealed class HtmlCapabilityGalleryArtifact {
+    /// <summary>
+    /// Creates an artifact descriptor.
+    /// </summary>
+    /// <param name="id">Stable artifact identifier within the scenario.</param>
+    /// <param name="kind">Artifact kind, such as <c>input-html</c>, <c>docx</c>, or <c>roundtrip-html</c>.</param>
+    /// <param name="path">Artifact file path.</param>
+    /// <param name="mediaType">Artifact media type.</param>
+    /// <param name="length">Artifact length in bytes.</param>
+    /// <param name="sha256">Lowercase hexadecimal SHA-256 hash of the artifact bytes.</param>
+    public HtmlCapabilityGalleryArtifact(string id, string kind, string path, string mediaType, long length, string sha256) {
+        Id = id ?? throw new ArgumentNullException(nameof(id));
+        Kind = kind ?? throw new ArgumentNullException(nameof(kind));
+        Path = path ?? throw new ArgumentNullException(nameof(path));
+        MediaType = mediaType ?? throw new ArgumentNullException(nameof(mediaType));
+        Length = length;
+        Sha256 = sha256 ?? throw new ArgumentNullException(nameof(sha256));
+    }
+
+    /// <summary>
+    /// Creates an artifact descriptor from an existing file.
+    /// </summary>
+    /// <param name="id">Stable artifact identifier within the scenario.</param>
+    /// <param name="kind">Artifact kind, such as <c>input-html</c>, <c>docx</c>, or <c>roundtrip-html</c>.</param>
+    /// <param name="path">Artifact file path.</param>
+    /// <param name="mediaType">Artifact media type.</param>
+    /// <returns>A descriptor containing file length and SHA-256 hash.</returns>
+    public static HtmlCapabilityGalleryArtifact FromFile(string id, string kind, string path, string mediaType) {
+        if (path == null) {
+            throw new ArgumentNullException(nameof(path));
+        }
+
+        var info = new FileInfo(path);
+        using FileStream stream = File.OpenRead(path);
+        using SHA256 sha = SHA256.Create();
+        byte[] hash = sha.ComputeHash(stream);
+        return new HtmlCapabilityGalleryArtifact(id, kind, path, mediaType, info.Length, ToHex(hash));
+    }
+
+    /// <summary>
+    /// Stable artifact identifier within the scenario.
+    /// </summary>
+    public string Id { get; }
+
+    /// <summary>
+    /// Artifact kind, such as <c>input-html</c>, <c>docx</c>, or <c>roundtrip-html</c>.
+    /// </summary>
+    public string Kind { get; }
+
+    /// <summary>
+    /// Artifact file path.
+    /// </summary>
+    public string Path { get; }
+
+    /// <summary>
+    /// Artifact media type.
+    /// </summary>
+    public string MediaType { get; }
+
+    /// <summary>
+    /// Artifact length in bytes.
+    /// </summary>
+    public long Length { get; }
+
+    /// <summary>
+    /// Lowercase hexadecimal SHA-256 hash of the artifact bytes.
+    /// </summary>
+    public string Sha256 { get; }
+
+    private static string ToHex(byte[] bytes) {
+        var builder = new StringBuilder(bytes.Length * 2);
+        foreach (byte value in bytes) {
+            builder.Append(value.ToString("x2"));
+        }
+
+        return builder.ToString();
+    }
+}

--- a/OfficeIMO.Html/Gallery/HtmlCapabilityGalleryResult.cs
+++ b/OfficeIMO.Html/Gallery/HtmlCapabilityGalleryResult.cs
@@ -1,0 +1,43 @@
+namespace OfficeIMO.Html;
+
+/// <summary>
+/// Result manifest for one HTML capability-gallery scenario.
+/// </summary>
+public sealed class HtmlCapabilityGalleryResult {
+    private readonly List<HtmlCapabilityGalleryArtifact> _artifacts = new List<HtmlCapabilityGalleryArtifact>();
+
+    /// <summary>
+    /// Creates a capability-gallery result.
+    /// </summary>
+    /// <param name="scenario">Scenario proven by the result.</param>
+    public HtmlCapabilityGalleryResult(HtmlCapabilityGalleryScenario scenario) {
+        Scenario = scenario ?? throw new ArgumentNullException(nameof(scenario));
+    }
+
+    /// <summary>
+    /// Scenario proven by the result.
+    /// </summary>
+    public HtmlCapabilityGalleryScenario Scenario { get; }
+
+    /// <summary>
+    /// Artifacts emitted for the scenario.
+    /// </summary>
+    public IReadOnlyList<HtmlCapabilityGalleryArtifact> Artifacts => _artifacts;
+
+    /// <summary>
+    /// Shared diagnostics captured while generating the scenario artifacts.
+    /// </summary>
+    public HtmlDiagnosticReport Diagnostics { get; } = new HtmlDiagnosticReport();
+
+    /// <summary>
+    /// Adds an artifact to the result.
+    /// </summary>
+    /// <param name="artifact">Artifact descriptor to add.</param>
+    public void AddArtifact(HtmlCapabilityGalleryArtifact artifact) {
+        if (artifact == null) {
+            throw new ArgumentNullException(nameof(artifact));
+        }
+
+        _artifacts.Add(artifact);
+    }
+}

--- a/OfficeIMO.Html/Gallery/HtmlCapabilityGalleryScenario.cs
+++ b/OfficeIMO.Html/Gallery/HtmlCapabilityGalleryScenario.cs
@@ -1,0 +1,40 @@
+namespace OfficeIMO.Html;
+
+/// <summary>
+/// Describes one HTML capability-gallery scenario and its user-facing purpose.
+/// </summary>
+public sealed class HtmlCapabilityGalleryScenario {
+    /// <summary>
+    /// Creates a capability-gallery scenario.
+    /// </summary>
+    /// <param name="id">Stable scenario identifier used in artifact names and manifests.</param>
+    /// <param name="title">Human-readable scenario title.</param>
+    /// <param name="category">Scenario category, such as <c>Word HTML</c> or <c>HTML PDF</c>.</param>
+    /// <param name="description">Short explanation of the capability being proved.</param>
+    public HtmlCapabilityGalleryScenario(string id, string title, string category, string description) {
+        Id = id ?? throw new ArgumentNullException(nameof(id));
+        Title = title ?? throw new ArgumentNullException(nameof(title));
+        Category = category ?? throw new ArgumentNullException(nameof(category));
+        Description = description ?? throw new ArgumentNullException(nameof(description));
+    }
+
+    /// <summary>
+    /// Stable scenario identifier used in artifact names and manifests.
+    /// </summary>
+    public string Id { get; }
+
+    /// <summary>
+    /// Human-readable scenario title.
+    /// </summary>
+    public string Title { get; }
+
+    /// <summary>
+    /// Scenario category, such as <c>Word HTML</c> or <c>HTML PDF</c>.
+    /// </summary>
+    public string Category { get; }
+
+    /// <summary>
+    /// Short explanation of the capability being proved.
+    /// </summary>
+    public string Description { get; }
+}

--- a/OfficeIMO.Html/README.md
+++ b/OfficeIMO.Html/README.md
@@ -54,6 +54,21 @@ HtmlDomLimitTracker? tracker = HtmlDomLimitTracker.Create(
 
 Converter packages use these primitives to keep bounded HTML ingestion behavior consistent while still reporting converter-specific diagnostics.
 
+## Shared Diagnostics And Gallery Contracts
+
+```csharp
+var report = new HtmlDiagnosticReport();
+report.Add("OfficeIMO.Word.Html", "HtmlCommentSkipped", "Comment skipped");
+
+var scenario = new HtmlCapabilityGalleryScenario(
+    "quarterly-report",
+    "Quarterly Report",
+    "Word HTML",
+    "HTML import, DOCX validation, and round-trip export proof");
+```
+
+`HtmlDiagnosticReport` and the capability-gallery contracts provide a common shape for HTML converters, PDF bridges, readers, tests, and future documentation generators. Format-specific packages can keep their existing compatibility APIs while also publishing shared diagnostics and artifact metadata for market-facing proof galleries.
+
 ## Image Sources
 
 ```csharp

--- a/OfficeIMO.Tests/ConversionOptions.cs
+++ b/OfficeIMO.Tests/ConversionOptions.cs
@@ -148,6 +148,7 @@ public class ConversionOptionsTests {
         options.AllowedStylesheetContentTypes.Clear();
         options.AllowedStylesheetContentTypes.Add("text/css");
         options.Diagnostics.Add(new HtmlConversionDiagnostic("Existing", "Existing diagnostic"));
+        options.ConversionReport.Add("OfficeIMO.Word.Html", "Existing", "Existing diagnostic");
 
         var clone = options.Clone();
 
@@ -199,6 +200,7 @@ public class ConversionOptionsTests {
         Assert.Equal(options.AllowedStylesheetHosts, clone.AllowedStylesheetHosts);
         Assert.Equal(options.AllowedStylesheetContentTypes, clone.AllowedStylesheetContentTypes);
         Assert.Empty(clone.Diagnostics);
+        Assert.Empty(clone.ConversionReport.Diagnostics);
 
         clone.ClassStyles["lead"] = WordParagraphStyles.Heading3;
         clone.StylesheetPaths.Add("other.css");

--- a/OfficeIMO.Tests/Html.ArtifactGallery.cs
+++ b/OfficeIMO.Tests/Html.ArtifactGallery.cs
@@ -1,7 +1,9 @@
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Validation;
+using OfficeIMO.Html;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Html;
+using System.Text;
 using Xunit;
 
 namespace OfficeIMO.Tests;
@@ -54,9 +56,11 @@ public partial class Html {
         string inputPath = Path.Combine(artifactDirectory, "quarterly-report.input.html");
         string docxPath = Path.Combine(artifactDirectory, "quarterly-report.docx");
         string roundTripPath = Path.Combine(artifactDirectory, "quarterly-report.roundtrip.html");
+        string manifestPath = Path.Combine(artifactDirectory, "quarterly-report.manifest.md");
 
         var importOptions = HtmlToWordOptions.CreateTrustedDocumentProfile();
         importOptions.EnableAccessibilityDiagnostics = true;
+        importOptions.ConversionReport.Clear();
         using var document = html.LoadFromHtml(importOptions);
         using MemoryStream packageStream = document.SaveAsMemoryStream();
 
@@ -74,6 +78,18 @@ public partial class Html {
         });
         File.WriteAllText(roundTripPath, roundTripHtml);
 
+        var scenario = new HtmlCapabilityGalleryScenario(
+            "quarterly-report",
+            "Quarterly Report",
+            "Word HTML",
+            "Validates HTML import, DOCX package validity, round-trip HTML export, form controls, tables, and diagnostics.");
+        var result = new HtmlCapabilityGalleryResult(scenario);
+        result.AddArtifact(HtmlCapabilityGalleryArtifact.FromFile("source", "input-html", inputPath, "text/html"));
+        result.AddArtifact(HtmlCapabilityGalleryArtifact.FromFile("docx", "docx", docxPath, "application/vnd.openxmlformats-officedocument.wordprocessingml.document"));
+        result.AddArtifact(HtmlCapabilityGalleryArtifact.FromFile("roundtrip", "roundtrip-html", roundTripPath, "text/html"));
+        result.Diagnostics.AddRange(importOptions.ConversionReport.Diagnostics);
+        File.WriteAllText(manifestPath, BuildManifest(result));
+
         Assert.Contains("<h1>Quarterly Report</h1>", roundTripHtml, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("<thead>", roundTripHtml, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("<tfoot>", roundTripHtml, StringComparison.OrdinalIgnoreCase);
@@ -81,8 +97,38 @@ public partial class Html {
         Assert.Contains("<select", roundTripHtml, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("skipped comments are diagnostic evidence", roundTripHtml, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(importOptions.Diagnostics, diagnostic => string.Equals(diagnostic.Code, "HtmlCommentSkipped", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(importOptions.ConversionReport.Diagnostics, diagnostic => string.Equals(diagnostic.Code, "HtmlCommentSkipped", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal("quarterly-report", result.Scenario.Id);
+        Assert.Equal(3, result.Artifacts.Count);
+        Assert.Contains(result.Artifacts, artifact => artifact.Kind == "docx" && artifact.Length > 0 && artifact.Sha256.Length == 64);
+        Assert.Contains(result.Diagnostics.Diagnostics, diagnostic => diagnostic.Component == "OfficeIMO.Word.Html" && diagnostic.Code == "HtmlCommentSkipped");
         Assert.True(File.Exists(inputPath));
         Assert.True(File.Exists(docxPath));
         Assert.True(File.Exists(roundTripPath));
+        Assert.True(File.Exists(manifestPath));
+        Assert.Contains("HtmlCommentSkipped", File.ReadAllText(manifestPath), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string BuildManifest(HtmlCapabilityGalleryResult result) {
+        var builder = new StringBuilder();
+        builder.AppendLine("# HTML Capability Gallery Scenario");
+        builder.AppendLine();
+        builder.AppendLine($"Id: {result.Scenario.Id}");
+        builder.AppendLine($"Title: {result.Scenario.Title}");
+        builder.AppendLine($"Category: {result.Scenario.Category}");
+        builder.AppendLine($"Description: {result.Scenario.Description}");
+        builder.AppendLine();
+        builder.AppendLine("## Artifacts");
+        foreach (HtmlCapabilityGalleryArtifact artifact in result.Artifacts) {
+            builder.AppendLine($"- {artifact.Kind}: {Path.GetFileName(artifact.Path)} ({artifact.MediaType}, {artifact.Length} bytes, sha256={artifact.Sha256})");
+        }
+
+        builder.AppendLine();
+        builder.AppendLine("## Diagnostics");
+        foreach (HtmlDiagnostic diagnostic in result.Diagnostics.Diagnostics) {
+            builder.AppendLine($"- {diagnostic.Component}:{diagnostic.Code}:{diagnostic.Severity}: {diagnostic.Message}");
+        }
+
+        return builder.ToString();
     }
 }

--- a/OfficeIMO.Tests/Html.Pdf.cs
+++ b/OfficeIMO.Tests/Html.Pdf.cs
@@ -403,6 +403,7 @@ public sealed class HtmlPdfTests {
 
         Assert.True(pdf.Length > 0);
         Assert.Contains(options.WordHtmlOptions.Diagnostics, diagnostic => diagnostic.Code == "StylesheetResourceRejectedByPolicy");
+        Assert.Contains(options.WordHtmlOptions.ConversionReport.Diagnostics, diagnostic => diagnostic.Code == "StylesheetResourceRejectedByPolicy" && diagnostic.Component == "OfficeIMO.Word.Html");
         PdfCore.PdfConversionWarning warning = Assert.Single(options.ConversionReport.Warnings, item => item.Code == "StylesheetResourceRejectedByPolicy");
         Assert.Equal("OfficeIMO.Word.Html", warning.Converter);
         Assert.Equal(PdfCore.PdfConversionWarningSeverity.Warning, warning.Severity);
@@ -428,6 +429,7 @@ public sealed class HtmlPdfTests {
 
         Assert.NotNull(pdf);
         Assert.Contains(options.WordHtmlOptions.Diagnostics, diagnostic => diagnostic.Code == "StylesheetResourceRejectedByPolicy");
+        Assert.Contains(options.WordHtmlOptions.ConversionReport.Diagnostics, diagnostic => diagnostic.Code == "StylesheetResourceRejectedByPolicy" && diagnostic.Component == "OfficeIMO.Word.Html");
         PdfCore.PdfConversionWarning warning = Assert.Single(options.ConversionReport.Warnings, item => item.Code == "StylesheetResourceRejectedByPolicy");
         Assert.Equal("OfficeIMO.Word.Html", warning.Converter);
         Assert.Contains("blocked.example.test", warning.Source, StringComparison.Ordinal);
@@ -453,6 +455,7 @@ public sealed class HtmlPdfTests {
         Assert.NotNull(pdf);
         Assert.NotNull(options.WordHtmlOptions);
         Assert.Contains(options.WordHtmlOptions!.Diagnostics, diagnostic => diagnostic.Code == "HtmlStylesheetLinkSkipped");
+        Assert.Contains(options.WordHtmlOptions.ConversionReport.Diagnostics, diagnostic => diagnostic.Code == "HtmlStylesheetLinkSkipped" && diagnostic.Component == "OfficeIMO.Word.Html");
         PdfCore.PdfConversionWarning warning = Assert.Single(options.ConversionReport.Warnings, item => item.Code == "HtmlStylesheetLinkSkipped");
         Assert.Equal("OfficeIMO.Word.Html", warning.Converter);
         Assert.Contains("blocked.example.test", warning.Source, StringComparison.Ordinal);
@@ -485,6 +488,7 @@ public sealed class HtmlPdfTests {
         Assert.True(blockedPdf.Length > 0);
         Assert.True(cleanPdf.Length > 0);
         Assert.DoesNotContain(options.WordHtmlOptions!.Diagnostics, diagnostic => diagnostic.Code == "StylesheetResourceRejectedByPolicy");
+        Assert.DoesNotContain(options.WordHtmlOptions.ConversionReport.Diagnostics, diagnostic => diagnostic.Code == "StylesheetResourceRejectedByPolicy");
         Assert.DoesNotContain(options.ConversionReport.Warnings, warning => warning.Code == "StylesheetResourceRejectedByPolicy");
     }
 

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Diagnostics.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Diagnostics.cs
@@ -1,3 +1,5 @@
+using OfficeIMO.Html;
+
 namespace OfficeIMO.Word.Html {
     internal partial class HtmlToWordConverter {
         private static void AddDiagnostic(HtmlToWordOptions options, string code, string message, string? source = null, Exception? exception = null, HtmlConversionDiagnosticSeverity severity = HtmlConversionDiagnosticSeverity.Warning) {
@@ -8,7 +10,16 @@ namespace OfficeIMO.Word.Html {
                 : exception == null ? null : $"{exception.GetType().Name}: {exception.Message}";
             var diagnostic = new HtmlConversionDiagnostic(code, message, severity, source, detail);
             options.Diagnostics.Add(diagnostic);
+            options.ConversionReport.Add("OfficeIMO.Word.Html", code, message, MapSharedSeverity(severity), source, detail);
             options.DiagnosticHandler?.Invoke(diagnostic);
+        }
+
+        private static HtmlDiagnosticSeverity MapSharedSeverity(HtmlConversionDiagnosticSeverity severity) {
+            return severity switch {
+                HtmlConversionDiagnosticSeverity.Info => HtmlDiagnosticSeverity.Info,
+                HtmlConversionDiagnosticSeverity.Error => HtmlDiagnosticSeverity.Error,
+                _ => HtmlDiagnosticSeverity.Warning
+            };
         }
     }
 }

--- a/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
+++ b/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
@@ -283,6 +283,14 @@ namespace OfficeIMO.Word.Html {
         public List<HtmlConversionDiagnostic> Diagnostics { get; } = new List<HtmlConversionDiagnostic>();
 
         /// <summary>
+        /// Shared OfficeIMO HTML diagnostic report populated during conversion.
+        /// Prefer this report for cross-package tooling, gallery manifests, and adapters that aggregate
+        /// diagnostics from multiple OfficeIMO HTML workflows. The legacy <see cref="Diagnostics"/>
+        /// collection is still populated for existing callers.
+        /// </summary>
+        public HtmlDiagnosticReport ConversionReport { get; } = new HtmlDiagnosticReport();
+
+        /// <summary>
         /// Optional callback invoked whenever a conversion diagnostic is produced.
         /// </summary>
         public Action<HtmlConversionDiagnostic>? DiagnosticHandler { get; set; }
@@ -354,8 +362,8 @@ namespace OfficeIMO.Word.Html {
         /// </summary>
         /// <remarks>
         /// Configuration values, allow-lists, configured stylesheets, and the diagnostic callback are copied.
-        /// The runtime <see cref="Diagnostics"/> collection starts empty on the clone so diagnostics from one
-        /// conversion are not carried into the next.
+        /// Runtime diagnostic collections such as <see cref="Diagnostics"/> and <see cref="ConversionReport"/>
+        /// start empty on the clone so diagnostics from one conversion are not carried into the next.
         /// </remarks>
         /// <returns>A new <see cref="HtmlToWordOptions"/> with the same configuration values.</returns>
         public HtmlToWordOptions Clone() {


### PR DESCRIPTION
## Summary
- add shared `OfficeIMO.Html` diagnostic report types for cross-package HTML workflows
- add reusable capability-gallery scenario/result/artifact contracts with SHA-256 artifact metadata
- bridge Word HTML diagnostics into the shared report and have HTML PDF consume that shared report
- expand focused gallery, clone, and PDF diagnostic tests plus README usage notes

## Validation
- `dotnet build OfficeIMO.Html\OfficeIMO.Html.csproj -c Debug --framework net8.0 -m:1 -nr:false /clp:ErrorsOnly`
- `dotnet build OfficeIMO.Word.Html\OfficeIMO.Word.Html.csproj -c Debug --framework net8.0 -m:1 -nr:false /clp:ErrorsOnly`
- `dotnet build OfficeIMO.Html.Pdf\OfficeIMO.Html.Pdf.csproj -c Debug --framework net8.0 -m:1 -nr:false /clp:ErrorsOnly`
- `dotnet build OfficeIMO.Html\OfficeIMO.Html.csproj -c Debug --framework netstandard2.0 -m:1 -nr:false /clp:ErrorsOnly`
- `dotnet build OfficeIMO.Word.Html\OfficeIMO.Word.Html.csproj -c Debug --framework net472 -m:1 -nr:false /clp:ErrorsOnly`
- `dotnet build OfficeIMO.Html.Pdf\OfficeIMO.Html.Pdf.csproj -c Debug --framework net472 -m:1 -nr:false /clp:ErrorsOnly`
- `dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Debug --framework net8.0 --no-build --filter "Html_SaveAsPdf_DocumentProfile_ForwardsHtmlImportDiagnosticsToSharedReport|Html_ToPdfDocument_DocumentProfile_ForwardsHtmlImportDiagnosticsToSharedReport|Html_ToPdfDocument_DocumentProfileWithDefaultWordOptions_ForwardsHtmlImportDiagnostics|Html_SaveAsPdf_DocumentProfile_DoesNotReuseStaleHtmlImportDiagnostics|HtmlArtifactGallery_GeneratesValidDocxAndRoundTripHtml|HtmlToWordOptions_CloneCopiesConfigurationWithoutDiagnostics" --logger "console;verbosity=minimal"`
- `git diff --check`
