### PR TITLE
Improve Excel and PowerPoint PDF conversion fidelity

### DIFF
--- a/Docs/pdf-conversion-scenarios.json
+++ b/Docs/pdf-conversion-scenarios.json
@@ -429,6 +429,7 @@
         "theme-colors",
         "gradient-background",
         "text-boxes",
+        "preset-auto-shapes",
         "grouped-shapes",
         "group-transform"
       ],
@@ -448,6 +449,7 @@
         "logicalSignals": [
           "theme-color",
           "gradient-background",
+          "preset-auto-shape",
           "group-transform",
           "page-geometry"
         ],

--- a/OfficeIMO.Drawing/OfficeShapePresets.cs
+++ b/OfficeIMO.Drawing/OfficeShapePresets.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OfficeIMO.Drawing;
+
+/// <summary>
+/// Creates reusable <see cref="OfficeShape"/> descriptors for common DrawingML preset geometries.
+/// </summary>
+public static class OfficeShapePresets {
+    /// <summary>
+    /// Attempts to create a shared OfficeIMO shape for a DrawingML-style preset name.
+    /// </summary>
+    /// <param name="presetName">Preset name such as <c>rect</c>, <c>triangle</c>, or <c>rightArrow</c>.</param>
+    /// <param name="width">Requested shape width in the caller's layout unit.</param>
+    /// <param name="height">Requested shape height in the caller's layout unit.</param>
+    /// <param name="horizontalFlip">Whether the shape geometry should be mirrored horizontally.</param>
+    /// <param name="verticalFlip">Whether the shape geometry should be mirrored vertically.</param>
+    /// <param name="shape">Created shape when the preset is supported.</param>
+    /// <returns><c>true</c> when the preset could be mapped; otherwise <c>false</c>.</returns>
+    public static bool TryCreate(string? presetName, double width, double height, bool horizontalFlip, bool verticalFlip, out OfficeShape? shape) {
+        shape = null;
+        string normalized = NormalizePresetName(presetName);
+        if (normalized.Length == 0 || !IsFiniteNonNegative(width) || !IsFiniteNonNegative(height)) {
+            return false;
+        }
+
+        switch (normalized) {
+            case "rect":
+            case "rectangle":
+                if (!HasArea(width, height)) return false;
+                shape = OfficeShape.Rectangle(width, height);
+                return true;
+            case "roundrect":
+            case "roundrectangle":
+                if (!HasArea(width, height)) return false;
+                shape = OfficeShape.RoundedRectangle(width, height, Math.Min(width, height) * 0.18D);
+                return true;
+            case "ellipse":
+            case "oval":
+                if (!HasArea(width, height)) return false;
+                shape = OfficeShape.Ellipse(width, height);
+                return true;
+            case "line":
+            case "straightconnector1":
+                if (width == 0D && height == 0D) return false;
+                shape = OfficeShape.Line(
+                    horizontalFlip ? width : 0D,
+                    verticalFlip ? height : 0D,
+                    horizontalFlip ? 0D : width,
+                    verticalFlip ? 0D : height);
+                return true;
+            case "triangle":
+                shape = Polygon(width, height, horizontalFlip, verticalFlip, (0.5D, 0D), (1D, 1D), (0D, 1D));
+                return shape != null;
+            case "rttriangle":
+            case "righttriangle":
+                shape = Polygon(width, height, horizontalFlip, verticalFlip, (0D, 0D), (1D, 1D), (0D, 1D));
+                return shape != null;
+            case "diamond":
+                shape = Polygon(width, height, horizontalFlip, verticalFlip, (0.5D, 0D), (1D, 0.5D), (0.5D, 1D), (0D, 0.5D));
+                return shape != null;
+            case "parallelogram":
+                shape = Polygon(width, height, horizontalFlip, verticalFlip, (0.22D, 0D), (1D, 0D), (0.78D, 1D), (0D, 1D));
+                return shape != null;
+            case "trapezoid":
+                shape = Polygon(width, height, horizontalFlip, verticalFlip, (0.22D, 0D), (0.78D, 0D), (1D, 1D), (0D, 1D));
+                return shape != null;
+            case "pentagon":
+                shape = RegularPolygon(width, height, horizontalFlip, verticalFlip, 5, -90D);
+                return shape != null;
+            case "hexagon":
+                shape = RegularPolygon(width, height, horizontalFlip, verticalFlip, 6, 30D);
+                return shape != null;
+            case "octagon":
+                shape = RegularPolygon(width, height, horizontalFlip, verticalFlip, 8, 22.5D);
+                return shape != null;
+            case "plus":
+                shape = Polygon(width, height, horizontalFlip, verticalFlip,
+                    (0.38D, 0D), (0.62D, 0D), (0.62D, 0.38D), (1D, 0.38D),
+                    (1D, 0.62D), (0.62D, 0.62D), (0.62D, 1D), (0.38D, 1D),
+                    (0.38D, 0.62D), (0D, 0.62D), (0D, 0.38D), (0.38D, 0.38D));
+                return shape != null;
+            case "chevron":
+                shape = Polygon(width, height, horizontalFlip, verticalFlip, (0D, 0D), (0.72D, 0D), (1D, 0.5D), (0.72D, 1D), (0D, 1D), (0.28D, 0.5D));
+                return shape != null;
+            case "rightarrow":
+                shape = Polygon(width, height, horizontalFlip, verticalFlip, (0D, 0.25D), (0.62D, 0.25D), (0.62D, 0D), (1D, 0.5D), (0.62D, 1D), (0.62D, 0.75D), (0D, 0.75D));
+                return shape != null;
+            case "leftarrow":
+                shape = Polygon(width, height, horizontalFlip, verticalFlip, (1D, 0.25D), (0.38D, 0.25D), (0.38D, 0D), (0D, 0.5D), (0.38D, 1D), (0.38D, 0.75D), (1D, 0.75D));
+                return shape != null;
+            case "uparrow":
+                shape = Polygon(width, height, horizontalFlip, verticalFlip, (0.25D, 1D), (0.25D, 0.38D), (0D, 0.38D), (0.5D, 0D), (1D, 0.38D), (0.75D, 0.38D), (0.75D, 1D));
+                return shape != null;
+            case "downarrow":
+                shape = Polygon(width, height, horizontalFlip, verticalFlip, (0.25D, 0D), (0.25D, 0.62D), (0D, 0.62D), (0.5D, 1D), (1D, 0.62D), (0.75D, 0.62D), (0.75D, 0D));
+                return shape != null;
+            case "star5":
+                shape = Star(width, height, horizontalFlip, verticalFlip, 5);
+                return shape != null;
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to create a shared OfficeIMO shape for a DrawingML-style preset name.
+    /// </summary>
+    public static bool TryCreate(string? presetName, double width, double height, out OfficeShape? shape) =>
+        TryCreate(presetName, width, height, horizontalFlip: false, verticalFlip: false, out shape);
+
+    private static OfficeShape? Polygon(double width, double height, bool horizontalFlip, bool verticalFlip, params (double X, double Y)[] points) {
+        if (!HasArea(width, height)) {
+            return null;
+        }
+
+        return OfficeShape.Polygon(ToPoints(width, height, horizontalFlip, verticalFlip, points));
+    }
+
+    private static OfficeShape? RegularPolygon(double width, double height, bool horizontalFlip, bool verticalFlip, int sides, double rotationDegrees) {
+        if (!HasArea(width, height) || sides < 3) {
+            return null;
+        }
+
+        var points = new List<(double X, double Y)>(sides);
+        double rotation = Math.PI * rotationDegrees / 180D;
+        for (int i = 0; i < sides; i++) {
+            double angle = rotation + Math.PI * 2D * i / sides;
+            points.Add((0.5D + Math.Cos(angle) * 0.5D, 0.5D + Math.Sin(angle) * 0.5D));
+        }
+
+        return Polygon(width, height, horizontalFlip, verticalFlip, NormalizePoints(points).ToArray());
+    }
+
+    private static OfficeShape? Star(double width, double height, bool horizontalFlip, bool verticalFlip, int points) {
+        if (!HasArea(width, height) || points < 3) {
+            return null;
+        }
+
+        var coordinates = new List<(double X, double Y)>(points * 2);
+        for (int i = 0; i < points * 2; i++) {
+            double radius = i % 2 == 0 ? 0.5D : 0.22D;
+            double angle = -Math.PI / 2D + Math.PI * i / points;
+            coordinates.Add((0.5D + Math.Cos(angle) * radius, 0.5D + Math.Sin(angle) * radius));
+        }
+
+        return Polygon(width, height, horizontalFlip, verticalFlip, NormalizePoints(coordinates).ToArray());
+    }
+
+    private static IReadOnlyList<(double X, double Y)> NormalizePoints(IReadOnlyList<(double X, double Y)> points) {
+        double minX = double.MaxValue;
+        double minY = double.MaxValue;
+        double maxX = double.MinValue;
+        double maxY = double.MinValue;
+        for (int i = 0; i < points.Count; i++) {
+            minX = Math.Min(minX, points[i].X);
+            minY = Math.Min(minY, points[i].Y);
+            maxX = Math.Max(maxX, points[i].X);
+            maxY = Math.Max(maxY, points[i].Y);
+        }
+
+        double spanX = maxX - minX;
+        double spanY = maxY - minY;
+        if (spanX <= 0D || spanY <= 0D) {
+            return points;
+        }
+
+        var normalized = new List<(double X, double Y)>(points.Count);
+        for (int i = 0; i < points.Count; i++) {
+            normalized.Add(((points[i].X - minX) / spanX, (points[i].Y - minY) / spanY));
+        }
+
+        return normalized;
+    }
+
+    private static IReadOnlyList<OfficePoint> ToPoints(double width, double height, bool horizontalFlip, bool verticalFlip, IReadOnlyList<(double X, double Y)> points) {
+        var result = new List<OfficePoint>(points.Count);
+        for (int i = 0; i < points.Count; i++) {
+            double x = horizontalFlip ? 1D - points[i].X : points[i].X;
+            double y = verticalFlip ? 1D - points[i].Y : points[i].Y;
+            result.Add(new OfficePoint(x * width, y * height));
+        }
+
+        return result;
+    }
+
+    private static string NormalizePresetName(string? presetName) {
+        if (string.IsNullOrWhiteSpace(presetName)) {
+            return string.Empty;
+        }
+
+        var chars = new char[presetName!.Length];
+        int count = 0;
+        for (int i = 0; i < presetName.Length; i++) {
+            char value = presetName[i];
+            if (char.IsLetterOrDigit(value)) {
+                chars[count++] = char.ToLowerInvariant(value);
+            }
+        }
+
+        if (count == 0) {
+            return string.Empty;
+        }
+
+        string normalized = new string(chars, 0, count);
+        const string openXmlEnumPrefix = "shapetypevaluesinnertext";
+        if (normalized.StartsWith(openXmlEnumPrefix, StringComparison.Ordinal)) {
+            return normalized.Substring(openXmlEnumPrefix.Length);
+        }
+
+        return normalized;
+    }
+
+    private static bool HasArea(double width, double height) => width > 0D && height > 0D;
+
+    private static bool IsFiniteNonNegative(double value) => !double.IsNaN(value) && !double.IsInfinity(value) && value >= 0D;
+}

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.ChartRendering.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.ChartRendering.cs
@@ -13,9 +13,8 @@ namespace OfficeIMO.Excel.Pdf {
 
         private static void AddWorksheetChart(PdfCore.PdfItemCompose item, WorksheetChartExportData chart, string sheetName, ExcelPdfSaveOptions options) {
             ExcelChartSnapshot snapshot = chart.Snapshot;
-            string title = string.IsNullOrWhiteSpace(snapshot.Title) ? snapshot.Name : snapshot.Title!;
-            if (!string.IsNullOrWhiteSpace(title)) {
-                item.H2(title, PdfCore.PdfAlign.Left, PdfCore.PdfColor.FromRgb(31, 78, 121));
+            if (string.IsNullOrWhiteSpace(snapshot.Title) && !string.IsNullOrWhiteSpace(snapshot.Name)) {
+                item.H2(snapshot.Name, PdfCore.PdfAlign.Left, PdfCore.PdfColor.FromRgb(31, 78, 121));
             }
 
             OfficeChartRenderingResult rendering = OfficeChartDrawingRenderer.RenderWithQuality(CreateOfficeChartSnapshot(snapshot, options));

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.ChartRendering.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.ChartRendering.cs
@@ -65,7 +65,7 @@ namespace OfficeIMO.Excel.Pdf {
             var data = new OfficeChartData(snapshot.Data.Categories, series);
             return new OfficeChartSnapshot(
                 snapshot.Name,
-                title: null,
+                snapshot.Title,
                 chartKind,
                 data,
                 PixelsToPoints(snapshot.WidthPixels),

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.TableStyles.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.TableStyles.cs
@@ -27,6 +27,8 @@ namespace OfficeIMO.Excel.Pdf {
                     .ToList();
             }
 
+            ApplyFitToHeight(tableStyle, options, pageSetup, rowIndexes, rowHeights);
+
             Dictionary<(int Row, int Column), PdfCore.PdfColor>? cellFills = CreateCellFills(styles, conditionalFills, rowIndexes, columnOffset, exportedColumns);
             if (cellFills != null) {
                 tableStyle.CellFills = cellFills;
@@ -101,6 +103,77 @@ namespace OfficeIMO.Excel.Pdf {
 
         private static bool IsFitToWidth(ExcelSheetPageSetup? pageSetup) {
             return pageSetup?.FitToWidth is uint fitToWidth && fitToWidth > 0U;
+        }
+
+        private static void ApplyFitToHeight(PdfCore.PdfTableStyle tableStyle, ExcelPdfSaveOptions options, ExcelSheetPageSetup? pageSetup, IReadOnlyList<int> rowIndexes, RowLayoutData? rowHeights) {
+            if (!IsFitToHeight(pageSetup) || rowIndexes.Count == 0) {
+                return;
+            }
+
+            double targetHeight = CalculateFitToHeightMaxHeight(options, pageSetup);
+            List<double> currentHeights = CreateApproximateRowHeights(tableStyle, rowIndexes, rowHeights);
+            double currentHeight = currentHeights.Sum();
+            if (currentHeight <= targetHeight || currentHeight <= 0D) {
+                return;
+            }
+
+            double scale = Math.Max(0.05D, targetHeight / currentHeight);
+            tableStyle.FixedRowHeights = currentHeights
+                .Select(height => (double?)Math.Max(1D, height * scale))
+                .ToList();
+
+            tableStyle.CellPaddingY *= scale;
+            tableStyle.CellPaddingTop = ScaleOptional(tableStyle.CellPaddingTop, scale);
+            tableStyle.CellPaddingBottom = ScaleOptional(tableStyle.CellPaddingBottom, scale);
+            tableStyle.FontSize = ScaleFontSize(tableStyle.FontSize, scale);
+            tableStyle.HeaderFontSize = ScaleFontSize(tableStyle.HeaderFontSize, scale);
+            tableStyle.FooterFontSize = ScaleFontSize(tableStyle.FooterFontSize, scale);
+            tableStyle.MinRowHeight *= scale;
+            if (tableStyle.RowMinHeights != null) {
+                tableStyle.RowMinHeights = tableStyle.RowMinHeights
+                    .Select(height => height.HasValue ? (double?)Math.Max(1D, height.Value * scale) : null)
+                    .ToList();
+            }
+        }
+
+        private static bool IsFitToHeight(ExcelSheetPageSetup? pageSetup) {
+            return pageSetup?.FitToHeight is uint fitToHeight && fitToHeight > 0U;
+        }
+
+        private static double CalculateFitToHeightMaxHeight(ExcelPdfSaveOptions options, ExcelSheetPageSetup? pageSetup) {
+            PdfCore.PageSize pageSize = GetEffectivePageSize(options, pageSetup);
+            PdfCore.PageMargins margins = GetEffectiveMargins(options, pageSetup);
+            double pageContentHeight = Math.Max(24D, pageSize.Height - margins.Top - margins.Bottom);
+            uint fitToHeight = pageSetup?.FitToHeight ?? 1U;
+            return pageContentHeight * Math.Max(1U, fitToHeight);
+        }
+
+        private static List<double> CreateApproximateRowHeights(PdfCore.PdfTableStyle tableStyle, IReadOnlyList<int> rowIndexes, RowLayoutData? rowHeights) {
+            var heights = new List<double>(rowIndexes.Count);
+            double fallbackHeight = GetDefaultApproximateRowHeight(tableStyle);
+            for (int i = 0; i < rowIndexes.Count; i++) {
+                int row = rowIndexes[i];
+                double? configuredHeight = rowHeights != null && row >= 0 && row < rowHeights.MinHeights.Count
+                    ? rowHeights.MinHeights[row]
+                    : null;
+                heights.Add(Math.Max(1D, configuredHeight ?? fallbackHeight));
+            }
+
+            return heights;
+        }
+
+        private static double GetDefaultApproximateRowHeight(PdfCore.PdfTableStyle tableStyle) {
+            double fontSize = tableStyle.FontSize ?? 10D;
+            double lineHeight = tableStyle.LineHeight.HasValue ? fontSize * tableStyle.LineHeight.Value : fontSize * 1.4D;
+            return Math.Max(tableStyle.MinRowHeight, lineHeight + tableStyle.CellPaddingY * 2D);
+        }
+
+        private static double? ScaleOptional(double? value, double scale) {
+            return value.HasValue ? Math.Max(0D, value.Value * scale) : null;
+        }
+
+        private static double? ScaleFontSize(double? value, double scale) {
+            return value.HasValue ? Math.Max(0.1D, value.Value * scale) : value;
         }
 
         private static double CalculateFitToWidthMaxWidth(ExcelPdfSaveOptions options, ExcelSheetPageSetup? pageSetup) {

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.TableStyles.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.TableStyles.cs
@@ -111,7 +111,8 @@ namespace OfficeIMO.Excel.Pdf {
             }
 
             double targetHeight = CalculateFitToHeightMaxHeight(options, pageSetup);
-            List<double> currentHeights = CreateApproximateRowHeights(tableStyle, rowIndexes, rowHeights);
+            double defaultFontSize = GetDefaultTableFontSize(options);
+            List<double> currentHeights = CreateApproximateRowHeights(tableStyle, rowIndexes, rowHeights, defaultFontSize);
             double currentHeight = currentHeights.Sum();
             if (currentHeight <= targetHeight || currentHeight <= 0D) {
                 return;
@@ -125,9 +126,10 @@ namespace OfficeIMO.Excel.Pdf {
             tableStyle.CellPaddingY *= scale;
             tableStyle.CellPaddingTop = ScaleOptional(tableStyle.CellPaddingTop, scale);
             tableStyle.CellPaddingBottom = ScaleOptional(tableStyle.CellPaddingBottom, scale);
-            tableStyle.FontSize = ScaleFontSize(tableStyle.FontSize, scale);
-            tableStyle.HeaderFontSize = ScaleFontSize(tableStyle.HeaderFontSize, scale);
-            tableStyle.FooterFontSize = ScaleFontSize(tableStyle.FooterFontSize, scale);
+            double bodyFontSize = tableStyle.FontSize ?? defaultFontSize;
+            tableStyle.FontSize = ScaleFontSize(tableStyle.FontSize, defaultFontSize, scale);
+            tableStyle.HeaderFontSize = ScaleFontSize(tableStyle.HeaderFontSize, bodyFontSize, scale);
+            tableStyle.FooterFontSize = ScaleFontSize(tableStyle.FooterFontSize, bodyFontSize, scale);
             tableStyle.MinRowHeight *= scale;
             if (tableStyle.RowMinHeights != null) {
                 tableStyle.RowMinHeights = tableStyle.RowMinHeights
@@ -148,9 +150,9 @@ namespace OfficeIMO.Excel.Pdf {
             return pageContentHeight * Math.Max(1U, fitToHeight);
         }
 
-        private static List<double> CreateApproximateRowHeights(PdfCore.PdfTableStyle tableStyle, IReadOnlyList<int> rowIndexes, RowLayoutData? rowHeights) {
+        private static List<double> CreateApproximateRowHeights(PdfCore.PdfTableStyle tableStyle, IReadOnlyList<int> rowIndexes, RowLayoutData? rowHeights, double defaultFontSize) {
             var heights = new List<double>(rowIndexes.Count);
-            double fallbackHeight = GetDefaultApproximateRowHeight(tableStyle);
+            double fallbackHeight = GetDefaultApproximateRowHeight(tableStyle, defaultFontSize);
             for (int i = 0; i < rowIndexes.Count; i++) {
                 int row = rowIndexes[i];
                 double? configuredHeight = rowHeights != null && row >= 0 && row < rowHeights.MinHeights.Count
@@ -162,8 +164,8 @@ namespace OfficeIMO.Excel.Pdf {
             return heights;
         }
 
-        private static double GetDefaultApproximateRowHeight(PdfCore.PdfTableStyle tableStyle) {
-            double fontSize = tableStyle.FontSize ?? 10D;
+        private static double GetDefaultApproximateRowHeight(PdfCore.PdfTableStyle tableStyle, double defaultFontSize) {
+            double fontSize = tableStyle.FontSize ?? defaultFontSize;
             double lineHeight = tableStyle.LineHeight.HasValue ? fontSize * tableStyle.LineHeight.Value : fontSize * 1.4D;
             return Math.Max(tableStyle.MinRowHeight, lineHeight + tableStyle.CellPaddingY * 2D);
         }
@@ -172,8 +174,12 @@ namespace OfficeIMO.Excel.Pdf {
             return value.HasValue ? Math.Max(0D, value.Value * scale) : null;
         }
 
-        private static double? ScaleFontSize(double? value, double scale) {
-            return value.HasValue ? Math.Max(0.1D, value.Value * scale) : value;
+        private static double GetDefaultTableFontSize(ExcelPdfSaveOptions options) {
+            return options.PdfOptions?.DefaultFontSize ?? 11D;
+        }
+
+        private static double ScaleFontSize(double? value, double defaultFontSize, double scale) {
+            return Math.Max(0.1D, (value ?? defaultFontSize) * scale);
         }
 
         private static double CalculateFitToWidthMaxWidth(ExcelPdfSaveOptions options, ExcelSheetPageSetup? pageSetup) {

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.cs
@@ -798,7 +798,7 @@ public static partial class PowerPointPdfConverterExtensions {
             }
         }
 
-        bool isLineShape = shape is PptCore.PowerPointAutoShape autoShape && autoShape.ShapeType == ShapeTypeValues.Line;
+        bool isLineShape = IsLineShape(shape);
         bool hasRenderableSize = isLineShape
             ? width >= 0D && height >= 0D && (width > 0D || height > 0D)
             : width > 0D && height > 0D;
@@ -811,6 +811,11 @@ public static partial class PowerPointPdfConverterExtensions {
         }
 
         return false;
+    }
+
+    private static bool IsLineShape(PptCore.PowerPointShape shape) {
+        return shape is PptCore.PowerPointAutoShape autoShape &&
+               (autoShape.ShapeType == ShapeTypeValues.Line || autoShape.ShapeType == ShapeTypeValues.StraightConnector1);
     }
 
     private static bool IntersectsPage(double x, double y, double width, double height, double pageWidth, double pageHeight) =>

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.cs
@@ -708,7 +708,7 @@ public static partial class PowerPointPdfConverterExtensions {
     private static void RenderAutoShape(PdfCore.PdfPageCanvas canvas, PptCore.PowerPointAutoShape autoShape, double x, double y, double width, double height, int slideNumber, PowerPointPdfSaveOptions options) {
         OfficeShape? shape = CreateOfficeShape(autoShape.ShapeType, autoShape, width, height);
         if (shape == null) {
-            AddWarning(options, slideNumber, "unsupported-auto-shape", "Skipped unsupported PowerPoint auto-shape type '" + autoShape.ShapeType + "'.");
+            AddWarning(options, slideNumber, "unsupported-auto-shape", "Skipped unsupported PowerPoint auto-shape type '" + GetShapePresetName(autoShape.ShapeType) + "'.");
             return;
         }
 
@@ -733,27 +733,38 @@ public static partial class PowerPointPdfConverterExtensions {
     }
 
     private static OfficeShape? CreateOfficeShape(ShapeTypeValues? type, PptCore.PowerPointShape source, double width, double height) {
-        if (type == ShapeTypeValues.Rectangle) {
-            return OfficeShape.Rectangle(width, height);
+        return type.HasValue &&
+               OfficeShapePresets.TryCreate(GetShapePresetName(type), width, height, source.HorizontalFlip == true, source.VerticalFlip == true, out OfficeShape? shape)
+            ? shape
+            : null;
+    }
+
+    private static string? GetShapePresetName(ShapeTypeValues? type) {
+        if (!type.HasValue) {
+            return null;
         }
 
-        if (type == ShapeTypeValues.RoundRectangle) {
-            return OfficeShape.RoundedRectangle(width, height, Math.Min(width, height) * 0.18D);
-        }
-
-        if (type == ShapeTypeValues.Ellipse) {
-            return OfficeShape.Ellipse(width, height);
-        }
-
-        if (type == ShapeTypeValues.Line) {
-            double startX = source.HorizontalFlip == true ? width : 0D;
-            double endX = source.HorizontalFlip == true ? 0D : width;
-            double startY = source.VerticalFlip == true ? height : 0D;
-            double endY = source.VerticalFlip == true ? 0D : height;
-            return OfficeShape.Line(startX, startY, endX, endY);
-        }
-
-        return null;
+        ShapeTypeValues value = type.Value;
+        if (value == ShapeTypeValues.Rectangle) return "rect";
+        if (value == ShapeTypeValues.RoundRectangle) return "roundRect";
+        if (value == ShapeTypeValues.Ellipse) return "ellipse";
+        if (value == ShapeTypeValues.Line || value == ShapeTypeValues.StraightConnector1) return "line";
+        if (value == ShapeTypeValues.Triangle) return "triangle";
+        if (value == ShapeTypeValues.RightTriangle) return "rtTriangle";
+        if (value == ShapeTypeValues.Diamond) return "diamond";
+        if (value == ShapeTypeValues.Parallelogram) return "parallelogram";
+        if (value == ShapeTypeValues.Trapezoid) return "trapezoid";
+        if (value == ShapeTypeValues.Pentagon) return "pentagon";
+        if (value == ShapeTypeValues.Hexagon) return "hexagon";
+        if (value == ShapeTypeValues.Octagon) return "octagon";
+        if (value == ShapeTypeValues.Plus) return "plus";
+        if (value == ShapeTypeValues.Chevron) return "chevron";
+        if (value == ShapeTypeValues.RightArrow) return "rightArrow";
+        if (value == ShapeTypeValues.LeftArrow) return "leftArrow";
+        if (value == ShapeTypeValues.UpArrow) return "upArrow";
+        if (value == ShapeTypeValues.DownArrow) return "downArrow";
+        if (value == ShapeTypeValues.Star5) return "star5";
+        return value.ToString();
     }
 
     private static void ApplyShapeStyle(PptCore.PowerPointShape source, OfficeShape target) {

--- a/OfficeIMO.Tests/Drawing.Tests.cs
+++ b/OfficeIMO.Tests/Drawing.Tests.cs
@@ -485,6 +485,45 @@ public class DrawingTests {
     }
 
     [Fact]
+    public void OfficeShapePresetsCreateReusableDrawingMlGeometry() {
+        Assert.True(OfficeShapePresets.TryCreate("triangle", 120, 80, out OfficeShape? triangle));
+        Assert.NotNull(triangle);
+        Assert.Equal(OfficeShapeKind.Polygon, triangle!.Kind);
+        Assert.Equal(120, triangle.Width);
+        Assert.Equal(80, triangle.Height);
+        Assert.Equal(new OfficePoint(60, 0), triangle.Points[0]);
+        Assert.Equal(new OfficePoint(120, 80), triangle.Points[1]);
+        Assert.Equal(new OfficePoint(0, 80), triangle.Points[2]);
+
+        Assert.True(OfficeShapePresets.TryCreate("parallelogram", 100, 40, horizontalFlip: true, verticalFlip: false, out OfficeShape? flipped));
+        Assert.NotNull(flipped);
+        Assert.Equal(new OfficePoint(78, 0), flipped!.Points[0]);
+        Assert.Equal(new OfficePoint(0, 0), flipped.Points[1]);
+
+        Assert.True(OfficeShapePresets.TryCreate("rightArrow", 140, 50, out OfficeShape? arrow));
+        Assert.NotNull(arrow);
+        Assert.Equal(OfficeShapeKind.Polygon, arrow!.Kind);
+        Assert.Equal(7, arrow.Points.Count);
+
+        Assert.True(OfficeShapePresets.TryCreate("ShapeTypeValues { InnerText = triangle }", 60, 40, out OfficeShape? openXmlDiagnostic));
+        Assert.NotNull(openXmlDiagnostic);
+        Assert.Equal(60, openXmlDiagnostic!.Width);
+
+        Assert.True(OfficeShapePresets.TryCreate("hexagon", 120, 80, out OfficeShape? hexagon));
+        Assert.NotNull(hexagon);
+        Assert.Equal(120, hexagon!.Width);
+        Assert.Equal(80, hexagon.Height);
+
+        Assert.True(OfficeShapePresets.TryCreate("star5", 90, 90, out OfficeShape? star));
+        Assert.NotNull(star);
+        Assert.Equal(90, star!.Width);
+        Assert.Equal(90, star.Height);
+
+        Assert.False(OfficeShapePresets.TryCreate("cloud", 100, 60, out OfficeShape? unsupported));
+        Assert.Null(unsupported);
+    }
+
+    [Fact]
     public void OfficeShapeRejectsEmptyLineDrawingIntent() {
         Assert.Throws<ArgumentException>(() => OfficeShape.Line(10, 20, 10, 20));
     }

--- a/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.ChartTests.cs
+++ b/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.ChartTests.cs
@@ -68,6 +68,7 @@ public partial class Excel {
         using PdfPigDocument pdf = PdfPigDocument.Open(new MemoryStream(bytes));
         string text = pdf.GetPage(1).Text;
         Assert.Contains("Revenue Chart", text);
+        Assert.Single(Regex.Matches(text, "Revenue Chart").Cast<Match>());
         Assert.Contains("Actual", text);
         Assert.Contains("Target", text);
 

--- a/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.ChartTests.cs
+++ b/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.ChartTests.cs
@@ -43,6 +43,9 @@ public partial class Excel {
             Assert.Equal(ExcelChartType.ColumnClustered, snapshot.ChartType);
             Assert.Equal(3, snapshot.Data.Categories.Count);
             Assert.Equal(2, snapshot.Data.Series.Count);
+            MethodInfo createSnapshot = typeof(ExcelPdfConverterExtensions).GetMethod("CreateOfficeChartSnapshot", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var sharedSnapshot = Assert.IsType<OfficeChartSnapshot>(createSnapshot.Invoke(null, new object[] { snapshot, new ExcelPdfSaveOptions() }));
+            Assert.Equal("Revenue Chart", sharedSnapshot.Title);
 
             document.Save(false);
 

--- a/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.PageSetupPrintAreaTests.cs
+++ b/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.PageSetupPrintAreaTests.cs
@@ -197,6 +197,46 @@ public partial class Excel {
     }
 
     [Fact]
+    public void ToPdfDocument_ExcelWorkbook_Maps_Worksheet_FitToHeight_To_Table_Scaling() {
+        string workbookPath = Path.Combine(_directoryWithFiles, "ExcelPdfWorksheetFitToHeight.xlsx");
+
+        PdfCore.PdfDocument pdfDocument;
+        using (ExcelDocument document = ExcelDocument.Create(workbookPath, "PageSetup")) {
+            ExcelSheet sheet = document.Sheets[0];
+            sheet.Cell(1, 1, "Name");
+            sheet.Cell(1, 2, "Value");
+            for (int row = 2; row <= 10; row++) {
+                sheet.Cell(row, 1, "Row " + row.ToString(CultureInfo.InvariantCulture));
+                sheet.Cell(row, 2, row);
+            }
+
+            for (int row = 1; row <= 10; row++) {
+                sheet.SetRowHeight(row, 36D);
+            }
+
+            sheet.SetPageSetup(fitToWidth: 1U, fitToHeight: 1U);
+            document.Save(false);
+
+            pdfDocument = document.ToPdfDocument(new ExcelPdfSaveOptions {
+                IncludeSheetHeadings = false,
+                HeaderRowCount = 1,
+                PageSize = new PdfCore.PageSize(220, 144),
+                Margins = PdfCore.PageMargins.Uniform(18)
+            });
+        }
+
+        PdfCore.PageBlock page = Assert.IsType<PdfCore.PageBlock>(Assert.Single(pdfDocument.Blocks));
+        PdfCore.TableBlock table = Assert.Single(page.Blocks.OfType<PdfCore.TableBlock>());
+        Assert.NotNull(table.Style);
+        PdfCore.PdfTableStyle style = table.Style!;
+        Assert.Equal(1, style.HeaderRowCount);
+        Assert.NotNull(style.FixedRowHeights);
+        Assert.Equal(10, style.FixedRowHeights!.Count);
+        Assert.InRange(style.FixedRowHeights.Sum(height => height ?? 0D), 107D, 108.1D);
+        Assert.True(style.CellPaddingY < 3D, "Fit-to-height scaling should shrink default vertical padding along with row heights.");
+    }
+
+    [Fact]
     public void SaveAsPdf_ExcelWorkbook_Uses_Print_Title_Rows_As_Repeating_Table_Header() {
         string workbookPath = Path.Combine(_directoryWithFiles, "ExcelPdfPrintTitles.xlsx");
 

--- a/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.PageSetupPrintAreaTests.cs
+++ b/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.PageSetupPrintAreaTests.cs
@@ -234,6 +234,12 @@ public partial class Excel {
         Assert.Equal(10, style.FixedRowHeights!.Count);
         Assert.InRange(style.FixedRowHeights.Sum(height => height ?? 0D), 107D, 108.1D);
         Assert.True(style.CellPaddingY < 3D, "Fit-to-height scaling should shrink default vertical padding along with row heights.");
+        Assert.NotNull(style.FontSize);
+        Assert.NotNull(style.HeaderFontSize);
+        Assert.NotNull(style.FooterFontSize);
+        Assert.InRange(style.FontSize!.Value, 3.2D, 3.4D);
+        Assert.Equal(style.FontSize.Value, style.HeaderFontSize!.Value);
+        Assert.Equal(style.FontSize.Value, style.FooterFontSize!.Value);
     }
 
     [Fact]

--- a/OfficeIMO.Tests/Pdf/PdfConversionScenarioManifestTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfConversionScenarioManifestTests.cs
@@ -224,6 +224,7 @@ public sealed class PdfConversionScenarioManifestTests {
         Assert.Contains("Grouped transform marker", text, StringComparison.Ordinal);
         Assert.Contains("20 100 60 40 re", raw, StringComparison.Ordinal);
         Assert.Contains("100 100 60 40 re", raw, StringComparison.Ordinal);
+        Assert.Contains("0.122 0.306 0.475 rg", raw, StringComparison.Ordinal);
 
         WriteReviewArtifact("powerpoint-layout-theme-groups.pdf", pdf);
     }
@@ -937,6 +938,9 @@ public sealed class PdfConversionScenarioManifestTests {
         PowerPointTextBox marker = slide.AddTextBoxPoints("Grouped transform marker", 20, 58, 150, 20);
         marker.FontSize = 9;
         marker.Color = "0F172A";
+        PowerPointAutoShape preset = slide.AddShapePoints(DocumentFormat.OpenXml.Drawing.ShapeTypeValues.Triangle, 176, 44, 36, 36);
+        preset.FillColor = "1F4E79";
+        preset.OutlineColor = "1F4E79";
         PowerPointAutoShape first = slide.AddRectanglePoints(20, 20, 30, 20);
         first.FillColor = "FF0000";
         PowerPointAutoShape second = slide.AddRectanglePoints(60, 20, 30, 20);

--- a/OfficeIMO.Tests/Pdf/PowerPoint.SaveAsPdf.cs
+++ b/OfficeIMO.Tests/Pdf/PowerPoint.SaveAsPdf.cs
@@ -172,7 +172,7 @@ public class PowerPointSaveAsPdfTests {
     public void ToPdfDocument_PowerPointPresentation_WarnsForUnsupportedShapes() {
         using var stream = new MemoryStream();
         using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
-        presentation.Slides[0].AddShape(ShapeTypeValues.Triangle, PowerPointUnits.FromPoints(20), PowerPointUnits.FromPoints(20), PowerPointUnits.FromPoints(50), PowerPointUnits.FromPoints(40));
+        presentation.Slides[0].AddShape(ShapeTypeValues.Cloud, PowerPointUnits.FromPoints(20), PowerPointUnits.FromPoints(20), PowerPointUnits.FromPoints(50), PowerPointUnits.FromPoints(40));
         var options = new PowerPointPdfSaveOptions();
 
         presentation.ToPdfDocument(options).ToBytes();
@@ -180,6 +180,26 @@ public class PowerPointSaveAsPdfTests {
         PowerPointPdfExportWarning warning = Assert.Single(options.Warnings);
         Assert.Equal(1, warning.SlideNumber);
         Assert.Equal("unsupported-auto-shape", warning.Code);
+    }
+
+    [Fact]
+    public void SaveAsPdf_PowerPointPresentation_RendersCommonPresetAutoShapes() {
+        using var stream = new MemoryStream();
+        using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
+        presentation.SlideSize.SetSizePoints(260, 160);
+        PowerPointSlide slide = presentation.Slides[0];
+        slide.AddShapePoints(ShapeTypeValues.Triangle, 20, 24, 58, 44).Fill("1F4E79").Stroke("1F4E79", 1D);
+        slide.AddShapePoints(ShapeTypeValues.Parallelogram, 96, 24, 74, 44).Fill("1976D2").Stroke("1976D2", 1D);
+        slide.AddShapePoints(ShapeTypeValues.RightArrow, 36, 94, 112, 34).Fill("16A34A").Stroke("16A34A", 1D);
+        var options = new PowerPointPdfSaveOptions();
+
+        byte[] bytes = presentation.SaveAsPdf(options);
+
+        Assert.Empty(options.Warnings);
+        string raw = Encoding.ASCII.GetString(bytes);
+        Assert.Contains("0.122 0.306 0.475 rg", raw, StringComparison.Ordinal);
+        Assert.Contains("0.098 0.463 0.824 rg", raw, StringComparison.Ordinal);
+        Assert.Contains("0.086 0.639 0.29 rg", raw, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -596,6 +616,35 @@ public class PowerPointSaveAsPdfTests {
         PdfCore.PdfDocumentInfo info = PdfCore.PdfInspector.Inspect(bytes);
 
         Assert.Equal(new[] { "https://officeimo.net/layout" }, info.LinkUris);
+    }
+
+    [Fact]
+    public void SaveAsPdf_PowerPointPresentation_RendersInheritedLayoutPresetAutoShapes() {
+        using var stream = new MemoryStream();
+        using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
+        presentation.SlideSize.SetSizePoints(240, 160);
+        PowerPointSlide slide = presentation.Slides[0];
+        SlideLayoutPart layoutPart = slide.SlidePart.SlideLayoutPart!;
+        ShapeTree tree = layoutPart.SlideLayout.CommonSlideData!.ShapeTree!;
+        tree.AppendChild(new DocumentFormat.OpenXml.Presentation.Shape(
+            new DocumentFormat.OpenXml.Presentation.NonVisualShapeProperties(
+                new DocumentFormat.OpenXml.Presentation.NonVisualDrawingProperties { Id = 702U, Name = "Layout Triangle" },
+                new DocumentFormat.OpenXml.Presentation.NonVisualShapeDrawingProperties(),
+                new ApplicationNonVisualDrawingProperties()),
+            new DocumentFormat.OpenXml.Presentation.ShapeProperties(
+                new Transform2D(
+                    new Offset { X = PowerPointUnits.FromPoints(30), Y = PowerPointUnits.FromPoints(44) },
+                    new Extents { Cx = PowerPointUnits.FromPoints(72), Cy = PowerPointUnits.FromPoints(48) }),
+                new PresetGeometry(new AdjustValueList()) { Preset = ShapeTypeValues.Triangle },
+                new SolidFill(new RgbColorModelHex { Val = "1F4E79" }))));
+        layoutPart.SlideLayout.Save();
+        var options = new PowerPointPdfSaveOptions();
+
+        byte[] bytes = presentation.SaveAsPdf(options);
+
+        Assert.Empty(options.Warnings);
+        string raw = Encoding.ASCII.GetString(bytes);
+        Assert.Contains("0.122 0.306 0.475 rg", raw, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/OfficeIMO.Tests/Pdf/PowerPoint.SaveAsPdf.cs
+++ b/OfficeIMO.Tests/Pdf/PowerPoint.SaveAsPdf.cs
@@ -1578,6 +1578,26 @@ public class PowerPointSaveAsPdfTests {
     }
 
     [Fact]
+    public void SaveAsPdf_PowerPointPresentation_RendersZeroThicknessStraightConnectors() {
+        using var stream = new MemoryStream();
+        using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
+        presentation.SlideSize.SetSizePoints(240, 160);
+        PowerPointSlide slide = presentation.Slides[0];
+        slide.AddShapePoints(ShapeTypeValues.StraightConnector1, 20, 40, 100, 0).Stroke("1E5A96", 1.5D);
+        slide.AddShapePoints(ShapeTypeValues.StraightConnector1, 140, 30, 0, 80).Stroke("C00000", 1.5D);
+        var options = new PowerPointPdfSaveOptions();
+
+        byte[] bytes = presentation.SaveAsPdf(options);
+
+        Assert.Empty(options.Warnings);
+        string raw = Encoding.ASCII.GetString(bytes);
+        Assert.Contains("20 120 m", raw, StringComparison.Ordinal);
+        Assert.Contains("120 120 l", raw, StringComparison.Ordinal);
+        Assert.Contains("140 130 m", raw, StringComparison.Ordinal);
+        Assert.Contains("140 50 l", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void SaveAsPdf_PowerPointPresentation_PreservesFlippedLineAutoShapes() {
         using var stream = new MemoryStream();
         using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);


### PR DESCRIPTION
## Summary
- Add reusable DrawingML preset geometry so PowerPoint PDF rendering handles common auto-shapes consistently across direct slides and inherited layouts.
- Carry Excel chart titles into the shared chart snapshot path and respect FitToHeight print scaling in the Excel PDF table layout planner.
- Extend conversion scenario coverage and PDF visual-proof tests for PowerPoint layout/theme/group output and Excel/PowerPoint fidelity cases.

## Tests
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Debug -f net8.0 --no-restore --filter "FullyQualifiedName~OfficeShapePresetsCreateReusableDrawingMlGeometry|FullyQualifiedName~SaveAsPdf_PowerPointPresentation_RendersCommonPresetAutoShapes|FullyQualifiedName~ToPdfDocument_ExcelWorkbook_Maps_Worksheet_FitToHeight_To_Table_Scaling|FullyQualifiedName~SaveAsPdf_ExcelWorkbook_Exports_Worksheet_Chart_Snapshots|FullyQualifiedName~SaveAsPdf_PowerPointPresentation_RendersInheritedLayoutPresetAutoShapes|FullyQualifiedName~PowerPointLayoutThemeGroups_ProducesManifestedReviewProof|FullyQualifiedName~PdfConversionManifest_CoversEverySupportedConversionPathWithObservableProof"
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Debug -f net8.0 --no-build --filter "FullyQualifiedName~Excel.SaveAsPdf.ChartTests|FullyQualifiedName~Excel.SaveAsPdf.PageSetupPrintAreaTests|FullyQualifiedName~PowerPointSaveAsPdfTests"
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Debug -f net472 --no-restore --filter "FullyQualifiedName~OfficeShapePresetsCreateReusableDrawingMlGeometry|FullyQualifiedName~SaveAsPdf_PowerPointPresentation_RendersCommonPresetAutoShapes|FullyQualifiedName~ToPdfDocument_ExcelWorkbook_Maps_Worksheet_FitToHeight_To_Table_Scaling|FullyQualifiedName~SaveAsPdf_ExcelWorkbook_Exports_Worksheet_Chart_Snapshots|FullyQualifiedName~SaveAsPdf_PowerPointPresentation_RendersInheritedLayoutPresetAutoShapes|FullyQualifiedName~PowerPointLayoutThemeGroups_ProducesManifestedReviewProof|FullyQualifiedName~PdfConversionManifest_CoversEverySupportedConversionPathWithObservableProof"
- git diff --check