### PR TITLE
Expand Excel workflow engine coverage

### DIFF
--- a/OfficeIMO.Excel/CoerceValueHelper.cs
+++ b/OfficeIMO.Excel/CoerceValueHelper.cs
@@ -26,6 +26,7 @@ internal static class CoerceValueHelper {
     /// calculating the Excel serial number. When omitted, <see cref="DateTimeOffset.LocalDateTime"/> is used. The provided
     /// strategy only influences the numeric serial value that is written; cell formatting must still be applied separately.
     /// </param>
+    /// <param name="dateSystem">Workbook date system used when serializing <see cref="DateTime"/> and <see cref="DateTimeOffset"/> values.</param>
     /// <returns>The OpenXML representation of the supplied value.</returns>
     /// <remarks>
     /// Integer values with an absolute magnitude above ±9,007,199,254,740,992 are written using their string form to prevent
@@ -35,7 +36,8 @@ internal static class CoerceValueHelper {
     internal static (CellValue cellValue, CellValues type) Coerce(
         object? value,
         Func<string, CellValue> sharedStringHandler,
-        Func<DateTimeOffset, DateTime>? dateTimeOffsetStrategy = null) {
+        Func<DateTimeOffset, DateTime>? dateTimeOffsetStrategy = null,
+        ExcelDateSystem dateSystem = ExcelDateSystem.NineteenHundred) {
         if (sharedStringHandler is null) {
             throw new ArgumentNullException(nameof(sharedStringHandler));
         }
@@ -51,10 +53,10 @@ internal static class CoerceValueHelper {
             decimal dec => HandleDecimal(dec),
             int i => HandleSignedInteger(i),
             long l => HandleSignedInteger(l),
-            DateTime dt => HandleNumber(dt.ToOADate()),
-            DateTimeOffset dto => HandleDateTimeOffset(dto, sharedStringHandler, dateTimeOffsetStrategy, nameof(value)),
+            DateTime dt => HandleNumber(ExcelDateSystemConverter.ToSerial(dt, dateSystem)),
+            DateTimeOffset dto => HandleDateTimeOffset(dto, sharedStringHandler, dateTimeOffsetStrategy, dateSystem, nameof(value)),
 #if NET6_0_OR_GREATER
-            DateOnly dateOnly => HandleNumber(dateOnly.ToDateTime(TimeOnly.MinValue).ToOADate()),
+            DateOnly dateOnly => HandleNumber(ExcelDateSystemConverter.ToSerial(dateOnly.ToDateTime(TimeOnly.MinValue), dateSystem)),
             TimeOnly timeOnly => HandleNumber(timeOnly.ToTimeSpan().TotalDays),
 #endif
             TimeSpan ts => HandleNumber(ts.TotalDays),
@@ -89,6 +91,7 @@ internal static class CoerceValueHelper {
         DateTimeOffset value,
         Func<string, CellValue> sharedStringHandler,
         Func<DateTimeOffset, DateTime> dateTimeOffsetStrategy,
+        ExcelDateSystem dateSystem,
         string? paramName) {
         if (sharedStringHandler is null) {
             throw new ArgumentNullException(nameof(sharedStringHandler));
@@ -113,7 +116,7 @@ internal static class CoerceValueHelper {
                 return HandleDateTimeOffsetFallback(value, sharedStringHandler, paramName);
             }
 
-            double serial = converted.ToOADate();
+            double serial = ExcelDateSystemConverter.ToSerial(converted, dateSystem);
             return HandleNumber(serial);
         } catch (ArgumentException) {
             return HandleDateTimeOffsetFallback(value, sharedStringHandler, paramName);

--- a/OfficeIMO.Excel/ExcelCell.cs
+++ b/OfficeIMO.Excel/ExcelCell.cs
@@ -150,6 +150,14 @@ namespace OfficeIMO.Excel {
         }
 
         /// <summary>
+        /// Sets a two-color linear gradient fill using hex color values.
+        /// </summary>
+        public ExcelCell SetGradientFill(string fromHexColor, string toHexColor, double degree = 0) {
+            Sheet.CellGradientBackground(Row, Column, fromHexColor, toHexColor, degree);
+            return this;
+        }
+
+        /// <summary>
         /// Applies a border style to the cell.
         /// </summary>
         public ExcelCell SetBorder(BorderStyleValues style, string? hexColor = null) {
@@ -348,6 +356,14 @@ namespace OfficeIMO.Excel {
         }
 
         /// <summary>
+        /// Applies a two-color linear gradient fill to every cell in the range.
+        /// </summary>
+        public ExcelRange SetGradientFill(string fromHexColor, string toHexColor, double degree = 0) {
+            Sheet.FillRangeGradient(Address, fromHexColor, toHexColor, degree);
+            return this;
+        }
+
+        /// <summary>
         /// Applies a font color to every cell in the range.
         /// </summary>
         public ExcelRange SetFontColor(string hexColor) {
@@ -508,6 +524,14 @@ namespace OfficeIMO.Excel {
         public ExcelTable SortByColumn(int columnOffset, bool ascending = true) {
             AsRange().SortByColumn(columnOffset, ascending, hasHeader: true);
             return this;
+        }
+
+        /// <summary>
+        /// Resolves a data-column range in this table by its header text.
+        /// </summary>
+        public ExcelRange Column(string headerName, bool includeHeader = false, bool normalizeHeader = true) {
+            string range = Sheet.GetColumnRangeByHeader(headerName, NameOrRange, headerRow: 0, includeHeader, normalizeHeader);
+            return Sheet.Range(range);
         }
     }
 

--- a/OfficeIMO.Excel/ExcelChart.DataPoints.cs
+++ b/OfficeIMO.Excel/ExcelChart.DataPoints.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Linq;
+using DocumentFormat.OpenXml;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Represents a chart on a worksheet.
+    /// </summary>
+    public sealed partial class ExcelChart {
+        /// <summary>
+        /// Sets the fill color for a single chart data point by series index and zero-based point index.
+        /// </summary>
+        public ExcelChart SetDataPointFillColor(int seriesIndex, uint pointIndex, string color) {
+            if (string.IsNullOrWhiteSpace(color)) {
+                throw new ArgumentException("Data point fill color cannot be null or empty.", nameof(color));
+            }
+
+            return SetDataPointColor(seriesIndex, pointIndex, fillColor: color);
+        }
+
+        /// <summary>
+        /// Sets the fill color for a single chart data point by series name and zero-based point index.
+        /// </summary>
+        public ExcelChart SetDataPointFillColor(string seriesName, uint pointIndex, string color, bool ignoreCase = true) {
+            if (string.IsNullOrWhiteSpace(color)) {
+                throw new ArgumentException("Data point fill color cannot be null or empty.", nameof(color));
+            }
+
+            return SetDataPointColor(seriesName, pointIndex, fillColor: color, ignoreCase: ignoreCase);
+        }
+
+        /// <summary>
+        /// Sets the outline color and optional outline width for a single chart data point by series index and zero-based point index.
+        /// </summary>
+        public ExcelChart SetDataPointLineColor(int seriesIndex, uint pointIndex, string color, double? widthPoints = null) {
+            if (string.IsNullOrWhiteSpace(color)) {
+                throw new ArgumentException("Data point line color cannot be null or empty.", nameof(color));
+            }
+
+            return SetDataPointColor(seriesIndex, pointIndex, lineColor: color, lineWidthPoints: widthPoints);
+        }
+
+        /// <summary>
+        /// Sets the outline color and optional outline width for a single chart data point by series name and zero-based point index.
+        /// </summary>
+        public ExcelChart SetDataPointLineColor(string seriesName, uint pointIndex, string color, double? widthPoints = null, bool ignoreCase = true) {
+            if (string.IsNullOrWhiteSpace(color)) {
+                throw new ArgumentException("Data point line color cannot be null or empty.", nameof(color));
+            }
+
+            return SetDataPointColor(seriesName, pointIndex, lineColor: color, lineWidthPoints: widthPoints, ignoreCase: ignoreCase);
+        }
+
+        /// <summary>
+        /// Sets fill and/or outline styling for a single chart data point by series index and zero-based point index.
+        /// </summary>
+        public ExcelChart SetDataPointColor(int seriesIndex, uint pointIndex, string? fillColor = null, string? lineColor = null, double? lineWidthPoints = null) {
+            if (seriesIndex < 0) {
+                throw new ArgumentOutOfRangeException(nameof(seriesIndex));
+            }
+
+            ValidateDataPointStyle(fillColor, lineColor, lineWidthPoints);
+
+            bool applied = ApplySeriesByIndex(seriesIndex, series => {
+                C.DataPoint point = EnsureDataPoint(series, pointIndex);
+                ApplyDataPointStyle(point, fillColor, lineColor, lineWidthPoints);
+            });
+
+            if (!applied) {
+                throw new InvalidOperationException($"Series index {seriesIndex} was not found.");
+            }
+
+            Save();
+            return this;
+        }
+
+        /// <summary>
+        /// Sets fill and/or outline styling for a single chart data point by series name and zero-based point index.
+        /// </summary>
+        public ExcelChart SetDataPointColor(string seriesName, uint pointIndex, string? fillColor = null, string? lineColor = null, double? lineWidthPoints = null, bool ignoreCase = true) {
+            if (seriesName == null) {
+                throw new ArgumentNullException(nameof(seriesName));
+            }
+
+            ValidateDataPointStyle(fillColor, lineColor, lineWidthPoints);
+
+            bool applied = ApplySeriesByName(seriesName, ignoreCase, series => {
+                C.DataPoint point = EnsureDataPoint(series, pointIndex);
+                ApplyDataPointStyle(point, fillColor, lineColor, lineWidthPoints);
+            });
+
+            if (!applied) {
+                throw new InvalidOperationException($"Series '{seriesName}' was not found.");
+            }
+
+            Save();
+            return this;
+        }
+
+        private static void ValidateDataPointStyle(string? fillColor, string? lineColor, double? lineWidthPoints) {
+            if (fillColor != null && string.IsNullOrWhiteSpace(fillColor)) {
+                throw new ArgumentException("Data point fill color cannot be empty.", nameof(fillColor));
+            }
+            if (lineColor != null && string.IsNullOrWhiteSpace(lineColor)) {
+                throw new ArgumentException("Data point line color cannot be empty.", nameof(lineColor));
+            }
+            if (fillColor == null && lineColor == null && lineWidthPoints == null) {
+                throw new ArgumentException("Specify a fill color, line color, or line width to style the data point.");
+            }
+        }
+
+        private static C.DataPoint EnsureDataPoint(OpenXmlCompositeElement series, uint pointIndex) {
+            C.DataPoint? point = series.Elements<C.DataPoint>()
+                .FirstOrDefault(dataPoint => dataPoint.GetFirstChild<C.Index>()?.Val?.Value == pointIndex);
+
+            if (point == null) {
+                point = new C.DataPoint(new C.Index { Val = pointIndex });
+                InsertDataPoint(series, point);
+            }
+
+            return point;
+        }
+
+        private static void ApplyDataPointStyle(C.DataPoint point, string? fillColor, string? lineColor, double? lineWidthPoints) {
+            C.ChartShapeProperties props = point.GetFirstChild<C.ChartShapeProperties>() ?? new C.ChartShapeProperties();
+            if (fillColor != null) {
+                ApplySolidFill(props, NormalizeHexColor(fillColor));
+            }
+            if (lineColor != null) {
+                ApplyLine(props, NormalizeHexColor(lineColor), lineWidthPoints);
+            } else if (lineWidthPoints != null) {
+                ApplyOptionalLine(props, null, lineWidthPoints);
+            }
+
+            if (props.Parent == null) {
+                OpenXmlElement? insertBefore = point.GetFirstChild<C.PictureOptions>();
+                insertBefore ??= point.GetFirstChild<C.ExtensionList>();
+                if (insertBefore != null) {
+                    point.InsertBefore(props, insertBefore);
+                } else {
+                    point.Append(props);
+                }
+            }
+        }
+
+        private static void InsertDataPoint(OpenXmlCompositeElement series, C.DataPoint point) {
+            OpenXmlElement? insertBefore = series.GetFirstChild<C.DataLabels>();
+            insertBefore ??= series.GetFirstChild<C.Trendline>();
+            insertBefore ??= series.GetFirstChild<C.ErrorBars>();
+            insertBefore ??= series.GetFirstChild<C.CategoryAxisData>();
+            insertBefore ??= series.GetFirstChild<C.Values>();
+            insertBefore ??= series.GetFirstChild<C.XValues>();
+            insertBefore ??= series.GetFirstChild<C.YValues>();
+            insertBefore ??= series.GetFirstChild<C.BubbleSize>();
+            insertBefore ??= series.GetFirstChild<C.Smooth>();
+            insertBefore ??= series.GetFirstChild<C.ExtensionList>();
+
+            if (insertBefore != null) {
+                series.InsertBefore(point, insertBefore);
+            } else {
+                series.Append(point);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelChart.cs
+++ b/OfficeIMO.Excel/ExcelChart.cs
@@ -449,6 +449,7 @@ namespace OfficeIMO.Excel {
         private void Save() {
             ChartPart chartPart = GetChartPart();
             chartPart.ChartSpace?.Save();
+            _document.MarkPackageDirty();
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelCustomDocumentPropertyCollection.cs
+++ b/OfficeIMO.Excel/ExcelCustomDocumentPropertyCollection.cs
@@ -20,9 +20,12 @@ namespace OfficeIMO.Excel {
         internal void ReplaceWith(IEnumerable<KeyValuePair<string, ExcelCustomProperty>> properties) {
             _suppressChangeTracking = true;
             try {
+                DetachAll();
                 _properties.Clear();
                 foreach (var property in properties) {
-                    _properties[property.Key] = property.Value;
+                    ExcelCustomProperty value = property.Value ?? throw new ArgumentNullException(nameof(properties));
+                    Attach(value);
+                    _properties[property.Key] = value;
                 }
             } finally {
                 _suppressChangeTracking = false;
@@ -33,7 +36,12 @@ namespace OfficeIMO.Excel {
         public ExcelCustomProperty this[string key] {
             get => _properties[key];
             set {
-                _properties[key] = value ?? throw new ArgumentNullException(nameof(value));
+                if (_properties.TryGetValue(key, out ExcelCustomProperty? previous)) {
+                    Detach(previous);
+                }
+
+                Attach(value ?? throw new ArgumentNullException(nameof(value)));
+                _properties[key] = value;
                 MarkChanged();
             }
         }
@@ -56,6 +64,7 @@ namespace OfficeIMO.Excel {
 
         /// <inheritdoc />
         public void Add(string key, ExcelCustomProperty value) {
+            Attach(value ?? throw new ArgumentNullException(nameof(value)));
             _properties.Add(key, value);
             MarkChanged();
         }
@@ -67,8 +76,13 @@ namespace OfficeIMO.Excel {
 
         /// <inheritdoc />
         public bool Remove(string key) {
+            if (!_properties.TryGetValue(key, out ExcelCustomProperty? property)) {
+                return false;
+            }
+
             bool removed = _properties.Remove(key);
             if (removed) {
+                Detach(property);
                 MarkChanged();
             }
 
@@ -91,6 +105,7 @@ namespace OfficeIMO.Excel {
                 return;
             }
 
+            DetachAll();
             _properties.Clear();
             MarkChanged();
         }
@@ -109,6 +124,7 @@ namespace OfficeIMO.Excel {
         public bool Remove(KeyValuePair<string, ExcelCustomProperty> item) {
             bool removed = ((ICollection<KeyValuePair<string, ExcelCustomProperty>>)_properties).Remove(item);
             if (removed) {
+                Detach(item.Value);
                 MarkChanged();
             }
 
@@ -127,6 +143,20 @@ namespace OfficeIMO.Excel {
         private void MarkChanged() {
             if (!_suppressChangeTracking) {
                 _changed?.Invoke();
+            }
+        }
+
+        private void Attach(ExcelCustomProperty property) {
+            property.SetChangeHandler(MarkChanged);
+        }
+
+        private static void Detach(ExcelCustomProperty property) {
+            property.SetChangeHandler(null);
+        }
+
+        private void DetachAll() {
+            foreach (ExcelCustomProperty property in _properties.Values) {
+                Detach(property);
             }
         }
     }

--- a/OfficeIMO.Excel/ExcelCustomDocumentPropertyCollection.cs
+++ b/OfficeIMO.Excel/ExcelCustomDocumentPropertyCollection.cs
@@ -1,0 +1,133 @@
+using System.Collections;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Tracks workbook custom document properties and marks the owning document dirty when callers mutate the collection directly.
+    /// </summary>
+    public sealed class ExcelCustomDocumentPropertyCollection : IDictionary<string, ExcelCustomProperty>, IReadOnlyDictionary<string, ExcelCustomProperty> {
+        private readonly Dictionary<string, ExcelCustomProperty> _properties;
+        private Action? _changed;
+        private bool _suppressChangeTracking;
+
+        internal ExcelCustomDocumentPropertyCollection() {
+            _properties = new Dictionary<string, ExcelCustomProperty>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        internal void SetChangeHandler(Action changed) {
+            _changed = changed ?? throw new ArgumentNullException(nameof(changed));
+        }
+
+        internal void ReplaceWith(IEnumerable<KeyValuePair<string, ExcelCustomProperty>> properties) {
+            _suppressChangeTracking = true;
+            try {
+                _properties.Clear();
+                foreach (var property in properties) {
+                    _properties[property.Key] = property.Value;
+                }
+            } finally {
+                _suppressChangeTracking = false;
+            }
+        }
+
+        /// <inheritdoc />
+        public ExcelCustomProperty this[string key] {
+            get => _properties[key];
+            set {
+                _properties[key] = value ?? throw new ArgumentNullException(nameof(value));
+                MarkChanged();
+            }
+        }
+
+        /// <inheritdoc />
+        public ICollection<string> Keys => _properties.Keys;
+
+        /// <inheritdoc />
+        public ICollection<ExcelCustomProperty> Values => _properties.Values;
+
+        IEnumerable<string> IReadOnlyDictionary<string, ExcelCustomProperty>.Keys => _properties.Keys;
+
+        IEnumerable<ExcelCustomProperty> IReadOnlyDictionary<string, ExcelCustomProperty>.Values => _properties.Values;
+
+        /// <inheritdoc />
+        public int Count => _properties.Count;
+
+        /// <inheritdoc />
+        public bool IsReadOnly => false;
+
+        /// <inheritdoc />
+        public void Add(string key, ExcelCustomProperty value) {
+            _properties.Add(key, value);
+            MarkChanged();
+        }
+
+        /// <inheritdoc />
+        public bool ContainsKey(string key) {
+            return _properties.ContainsKey(key);
+        }
+
+        /// <inheritdoc />
+        public bool Remove(string key) {
+            bool removed = _properties.Remove(key);
+            if (removed) {
+                MarkChanged();
+            }
+
+            return removed;
+        }
+
+        /// <inheritdoc />
+        public bool TryGetValue(string key, out ExcelCustomProperty value) {
+            return _properties.TryGetValue(key, out value!);
+        }
+
+        /// <inheritdoc />
+        public void Add(KeyValuePair<string, ExcelCustomProperty> item) {
+            Add(item.Key, item.Value);
+        }
+
+        /// <inheritdoc />
+        public void Clear() {
+            if (_properties.Count == 0) {
+                return;
+            }
+
+            _properties.Clear();
+            MarkChanged();
+        }
+
+        /// <inheritdoc />
+        public bool Contains(KeyValuePair<string, ExcelCustomProperty> item) {
+            return ((ICollection<KeyValuePair<string, ExcelCustomProperty>>)_properties).Contains(item);
+        }
+
+        /// <inheritdoc />
+        public void CopyTo(KeyValuePair<string, ExcelCustomProperty>[] array, int arrayIndex) {
+            ((ICollection<KeyValuePair<string, ExcelCustomProperty>>)_properties).CopyTo(array, arrayIndex);
+        }
+
+        /// <inheritdoc />
+        public bool Remove(KeyValuePair<string, ExcelCustomProperty> item) {
+            bool removed = ((ICollection<KeyValuePair<string, ExcelCustomProperty>>)_properties).Remove(item);
+            if (removed) {
+                MarkChanged();
+            }
+
+            return removed;
+        }
+
+        /// <inheritdoc />
+        public IEnumerator<KeyValuePair<string, ExcelCustomProperty>> GetEnumerator() {
+            return _properties.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() {
+            return GetEnumerator();
+        }
+
+        private void MarkChanged() {
+            if (!_suppressChangeTracking) {
+                _changed?.Invoke();
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelCustomDocumentPropertyCollection.cs
+++ b/OfficeIMO.Excel/ExcelCustomDocumentPropertyCollection.cs
@@ -23,9 +23,10 @@ namespace OfficeIMO.Excel {
                 DetachAll();
                 _properties.Clear();
                 foreach (var property in properties) {
+                    string key = NormalizeKey(property.Key);
                     ExcelCustomProperty value = property.Value ?? throw new ArgumentNullException(nameof(properties));
                     Attach(value);
-                    _properties[property.Key] = value;
+                    _properties[key] = value;
                 }
             } finally {
                 _suppressChangeTracking = false;
@@ -34,14 +35,15 @@ namespace OfficeIMO.Excel {
 
         /// <inheritdoc />
         public ExcelCustomProperty this[string key] {
-            get => _properties[key];
+            get => _properties[NormalizeKey(key)];
             set {
-                if (_properties.TryGetValue(key, out ExcelCustomProperty? previous)) {
+                string normalizedKey = NormalizeKey(key);
+                if (_properties.TryGetValue(normalizedKey, out ExcelCustomProperty? previous)) {
                     Detach(previous);
                 }
 
                 Attach(value ?? throw new ArgumentNullException(nameof(value)));
-                _properties[key] = value;
+                _properties[normalizedKey] = value;
                 MarkChanged();
             }
         }
@@ -64,23 +66,25 @@ namespace OfficeIMO.Excel {
 
         /// <inheritdoc />
         public void Add(string key, ExcelCustomProperty value) {
+            string normalizedKey = NormalizeKey(key);
             Attach(value ?? throw new ArgumentNullException(nameof(value)));
-            _properties.Add(key, value);
+            _properties.Add(normalizedKey, value);
             MarkChanged();
         }
 
         /// <inheritdoc />
         public bool ContainsKey(string key) {
-            return _properties.ContainsKey(key);
+            return _properties.ContainsKey(NormalizeKey(key));
         }
 
         /// <inheritdoc />
         public bool Remove(string key) {
-            if (!_properties.TryGetValue(key, out ExcelCustomProperty? property)) {
+            string normalizedKey = NormalizeKey(key);
+            if (!_properties.TryGetValue(normalizedKey, out ExcelCustomProperty? property)) {
                 return false;
             }
 
-            bool removed = _properties.Remove(key);
+            bool removed = _properties.Remove(normalizedKey);
             if (removed) {
                 Detach(property);
                 MarkChanged();
@@ -91,7 +95,7 @@ namespace OfficeIMO.Excel {
 
         /// <inheritdoc />
         public bool TryGetValue(string key, out ExcelCustomProperty value) {
-            return _properties.TryGetValue(key, out value!);
+            return _properties.TryGetValue(NormalizeKey(key), out value!);
         }
 
         /// <inheritdoc />
@@ -112,7 +116,8 @@ namespace OfficeIMO.Excel {
 
         /// <inheritdoc />
         public bool Contains(KeyValuePair<string, ExcelCustomProperty> item) {
-            return ((ICollection<KeyValuePair<string, ExcelCustomProperty>>)_properties).Contains(item);
+            return ((ICollection<KeyValuePair<string, ExcelCustomProperty>>)_properties)
+                .Contains(new KeyValuePair<string, ExcelCustomProperty>(NormalizeKey(item.Key), item.Value));
         }
 
         /// <inheritdoc />
@@ -122,7 +127,8 @@ namespace OfficeIMO.Excel {
 
         /// <inheritdoc />
         public bool Remove(KeyValuePair<string, ExcelCustomProperty> item) {
-            bool removed = ((ICollection<KeyValuePair<string, ExcelCustomProperty>>)_properties).Remove(item);
+            bool removed = ((ICollection<KeyValuePair<string, ExcelCustomProperty>>)_properties)
+                .Remove(new KeyValuePair<string, ExcelCustomProperty>(NormalizeKey(item.Key), item.Value));
             if (removed) {
                 Detach(item.Value);
                 MarkChanged();
@@ -138,6 +144,14 @@ namespace OfficeIMO.Excel {
 
         IEnumerator IEnumerable.GetEnumerator() {
             return GetEnumerator();
+        }
+
+        private static string NormalizeKey(string key) {
+            if (string.IsNullOrWhiteSpace(key)) {
+                throw new ArgumentException("Custom property name is required.", nameof(key));
+            }
+
+            return key.Trim();
         }
 
         private void MarkChanged() {

--- a/OfficeIMO.Excel/ExcelCustomProperty.cs
+++ b/OfficeIMO.Excel/ExcelCustomProperty.cs
@@ -107,7 +107,7 @@ namespace OfficeIMO.Excel {
                 Value = property.VTLPWSTR.Text;
                 PropertyType = ExcelCustomPropertyType.Text;
             } else if (property.VTBool != null) {
-                Value = bool.Parse(property.VTBool.Text);
+                Value = ParseBooleanProperty(property.VTBool.Text);
                 PropertyType = ExcelCustomPropertyType.YesNo;
             } else {
                 Value = string.Empty;
@@ -126,10 +126,15 @@ namespace OfficeIMO.Excel {
                     property.VTFileTime = new VTFileTime(string.Format(CultureInfo.InvariantCulture, "{0:s}Z", Convert.ToDateTime(Value, CultureInfo.InvariantCulture).ToUniversalTime()));
                     break;
                 case ExcelCustomPropertyType.NumberInteger:
-                    property.VTInt32 = new VTInt32(Convert.ToInt32(Value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture));
+                    long integer = Convert.ToInt64(Value, CultureInfo.InvariantCulture);
+                    if (integer >= int.MinValue && integer <= int.MaxValue) {
+                        property.VTInt32 = new VTInt32(integer.ToString(CultureInfo.InvariantCulture));
+                    } else {
+                        property.VTInt64 = new VTInt64(integer.ToString(CultureInfo.InvariantCulture));
+                    }
                     break;
                 case ExcelCustomPropertyType.NumberDouble:
-                    property.VTFloat = new VTFloat(Convert.ToDouble(Value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture));
+                    property.VTDouble = new VTDouble(Convert.ToDouble(Value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture));
                     break;
                 case ExcelCustomPropertyType.YesNo:
                     property.VTBool = new VTBool(Convert.ToBoolean(Value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture).ToLowerInvariant());
@@ -140,6 +145,18 @@ namespace OfficeIMO.Excel {
             }
 
             return property;
+        }
+
+        private static bool ParseBooleanProperty(string text) {
+            if (bool.TryParse(text, out bool result)) {
+                return result;
+            }
+
+            if (int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out int numeric) && (numeric == 0 || numeric == 1)) {
+                return numeric == 1;
+            }
+
+            throw new FormatException($"The custom property boolean value '{text}' is not valid.");
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelCustomProperty.cs
+++ b/OfficeIMO.Excel/ExcelCustomProperty.cs
@@ -1,0 +1,145 @@
+using DocumentFormat.OpenXml.CustomProperties;
+using DocumentFormat.OpenXml.VariantTypes;
+using System.Globalization;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Represents a custom workbook property value.
+    /// </summary>
+    public sealed class ExcelCustomProperty {
+        /// <summary>
+        /// Gets or sets the raw value of the custom property.
+        /// </summary>
+        public object? Value { get; set; }
+
+        /// <summary>
+        /// Gets the custom property value type.
+        /// </summary>
+        public ExcelCustomPropertyType PropertyType { get; set; }
+
+        /// <summary>
+        /// Gets the value as a date/time when the property type is a date.
+        /// </summary>
+        public DateTime? Date => Value is DateTime value ? value : null;
+
+        /// <summary>
+        /// Gets the value as an integer when the property type is an integer.
+        /// </summary>
+        public int? NumberInteger => Value is int value ? value : null;
+
+        /// <summary>
+        /// Gets the value as a double when the property type is a floating point number.
+        /// </summary>
+        public double? NumberDouble => Value is double value ? value : null;
+
+        /// <summary>
+        /// Gets the value as text when the property type is textual.
+        /// </summary>
+        public string? Text => Value is string value ? value : null;
+
+        /// <summary>
+        /// Gets the value as a boolean when the property type is YesNo.
+        /// </summary>
+        public bool? Bool => Value is bool value ? value : null;
+
+        /// <summary>
+        /// Creates an empty custom property.
+        /// </summary>
+        public ExcelCustomProperty() {
+            Value = string.Empty;
+            PropertyType = ExcelCustomPropertyType.Text;
+        }
+
+        /// <summary>
+        /// Creates a custom property with the specified value and type.
+        /// </summary>
+        public ExcelCustomProperty(object? value, ExcelCustomPropertyType propertyType) {
+            Value = value;
+            PropertyType = propertyType;
+        }
+
+        /// <summary>
+        /// Creates a string custom property.
+        /// </summary>
+        public ExcelCustomProperty(string value) : this(value, ExcelCustomPropertyType.Text) { }
+
+        /// <summary>
+        /// Creates a boolean custom property.
+        /// </summary>
+        public ExcelCustomProperty(bool value) : this(value, ExcelCustomPropertyType.YesNo) { }
+
+        /// <summary>
+        /// Creates a date/time custom property.
+        /// </summary>
+        public ExcelCustomProperty(DateTime value) : this(value, ExcelCustomPropertyType.DateTime) { }
+
+        /// <summary>
+        /// Creates an integer custom property.
+        /// </summary>
+        public ExcelCustomProperty(int value) : this(value, ExcelCustomPropertyType.NumberInteger) { }
+
+        /// <summary>
+        /// Creates a floating point custom property.
+        /// </summary>
+        public ExcelCustomProperty(double value) : this(value, ExcelCustomPropertyType.NumberDouble) { }
+
+        internal ExcelCustomProperty(CustomDocumentProperty property) {
+            if (property.VTInt32 != null) {
+                Value = int.Parse(property.VTInt32.Text, CultureInfo.InvariantCulture);
+                PropertyType = ExcelCustomPropertyType.NumberInteger;
+            } else if (property.VTInt64 != null) {
+                long value = long.Parse(property.VTInt64.Text, CultureInfo.InvariantCulture);
+                Value = value >= int.MinValue && value <= int.MaxValue ? (int)value : value;
+                PropertyType = ExcelCustomPropertyType.NumberInteger;
+            } else if (property.VTFileTime != null) {
+                Value = DateTime.Parse(property.VTFileTime.Text, CultureInfo.InvariantCulture).ToUniversalTime();
+                PropertyType = ExcelCustomPropertyType.DateTime;
+            } else if (property.VTDate != null) {
+                Value = DateTime.Parse(property.VTDate.Text, CultureInfo.InvariantCulture).ToUniversalTime();
+                PropertyType = ExcelCustomPropertyType.DateTime;
+            } else if (property.VTFloat != null) {
+                Value = double.Parse(property.VTFloat.Text, CultureInfo.InvariantCulture);
+                PropertyType = ExcelCustomPropertyType.NumberDouble;
+            } else if (property.VTDouble != null) {
+                Value = double.Parse(property.VTDouble.Text, CultureInfo.InvariantCulture);
+                PropertyType = ExcelCustomPropertyType.NumberDouble;
+            } else if (property.VTLPWSTR != null) {
+                Value = property.VTLPWSTR.Text;
+                PropertyType = ExcelCustomPropertyType.Text;
+            } else if (property.VTBool != null) {
+                Value = bool.Parse(property.VTBool.Text);
+                PropertyType = ExcelCustomPropertyType.YesNo;
+            } else {
+                Value = string.Empty;
+                PropertyType = ExcelCustomPropertyType.Text;
+            }
+        }
+
+        internal CustomDocumentProperty ToOpenXml(string name) {
+            var property = new CustomDocumentProperty {
+                FormatId = "{D5CDD505-2E9C-101B-9397-08002B2CF9AE}",
+                Name = name
+            };
+
+            switch (PropertyType) {
+                case ExcelCustomPropertyType.DateTime:
+                    property.VTFileTime = new VTFileTime(string.Format(CultureInfo.InvariantCulture, "{0:s}Z", Convert.ToDateTime(Value, CultureInfo.InvariantCulture).ToUniversalTime()));
+                    break;
+                case ExcelCustomPropertyType.NumberInteger:
+                    property.VTInt32 = new VTInt32(Convert.ToInt32(Value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture));
+                    break;
+                case ExcelCustomPropertyType.NumberDouble:
+                    property.VTFloat = new VTFloat(Convert.ToDouble(Value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture));
+                    break;
+                case ExcelCustomPropertyType.YesNo:
+                    property.VTBool = new VTBool(Convert.ToBoolean(Value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture).ToLowerInvariant());
+                    break;
+                default:
+                    property.VTLPWSTR = new VTLPWSTR(Convert.ToString(Value, CultureInfo.InvariantCulture) ?? string.Empty);
+                    break;
+            }
+
+            return property;
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelCustomProperty.cs
+++ b/OfficeIMO.Excel/ExcelCustomProperty.cs
@@ -7,15 +7,35 @@ namespace OfficeIMO.Excel {
     /// Represents a custom workbook property value.
     /// </summary>
     public sealed class ExcelCustomProperty {
+        private object? _value;
+        private ExcelCustomPropertyType _propertyType;
+        private Action? _changed;
+
         /// <summary>
         /// Gets or sets the raw value of the custom property.
         /// </summary>
-        public object? Value { get; set; }
+        public object? Value {
+            get => _value;
+            set {
+                if (!Equals(_value, value)) {
+                    _value = value;
+                    MarkChanged();
+                }
+            }
+        }
 
         /// <summary>
         /// Gets the custom property value type.
         /// </summary>
-        public ExcelCustomPropertyType PropertyType { get; set; }
+        public ExcelCustomPropertyType PropertyType {
+            get => _propertyType;
+            set {
+                if (_propertyType != value) {
+                    _propertyType = value;
+                    MarkChanged();
+                }
+            }
+        }
 
         /// <summary>
         /// Gets the value as a date/time when the property type is a date.
@@ -46,16 +66,16 @@ namespace OfficeIMO.Excel {
         /// Creates an empty custom property.
         /// </summary>
         public ExcelCustomProperty() {
-            Value = string.Empty;
-            PropertyType = ExcelCustomPropertyType.Text;
+            _value = string.Empty;
+            _propertyType = ExcelCustomPropertyType.Text;
         }
 
         /// <summary>
         /// Creates a custom property with the specified value and type.
         /// </summary>
         public ExcelCustomProperty(object? value, ExcelCustomPropertyType propertyType) {
-            Value = value;
-            PropertyType = propertyType;
+            _value = value;
+            _propertyType = propertyType;
         }
 
         /// <summary>
@@ -85,49 +105,53 @@ namespace OfficeIMO.Excel {
 
         internal ExcelCustomProperty(CustomDocumentProperty property) {
             if (property.VTInt32 != null) {
-                Value = int.Parse(property.VTInt32.Text, CultureInfo.InvariantCulture);
-                PropertyType = ExcelCustomPropertyType.NumberInteger;
+                _value = int.Parse(property.VTInt32.Text, CultureInfo.InvariantCulture);
+                _propertyType = ExcelCustomPropertyType.NumberInteger;
             } else if (property.VTInt64 != null) {
                 long value = long.Parse(property.VTInt64.Text, CultureInfo.InvariantCulture);
-                Value = value >= int.MinValue && value <= int.MaxValue ? (int)value : value;
-                PropertyType = ExcelCustomPropertyType.NumberInteger;
+                _value = value >= int.MinValue && value <= int.MaxValue ? (int)value : value;
+                _propertyType = ExcelCustomPropertyType.NumberInteger;
             } else if (property.VTUnsignedByte != null) {
-                Value = byte.Parse(property.VTUnsignedByte.Text, CultureInfo.InvariantCulture);
-                PropertyType = ExcelCustomPropertyType.NumberInteger;
+                _value = byte.Parse(property.VTUnsignedByte.Text, CultureInfo.InvariantCulture);
+                _propertyType = ExcelCustomPropertyType.NumberInteger;
             } else if (property.VTUnsignedShort != null) {
-                Value = ushort.Parse(property.VTUnsignedShort.Text, CultureInfo.InvariantCulture);
-                PropertyType = ExcelCustomPropertyType.NumberInteger;
+                _value = ushort.Parse(property.VTUnsignedShort.Text, CultureInfo.InvariantCulture);
+                _propertyType = ExcelCustomPropertyType.NumberInteger;
             } else if (property.VTUnsignedInt32 != null) {
-                Value = uint.Parse(property.VTUnsignedInt32.Text, CultureInfo.InvariantCulture);
-                PropertyType = ExcelCustomPropertyType.NumberInteger;
+                _value = uint.Parse(property.VTUnsignedInt32.Text, CultureInfo.InvariantCulture);
+                _propertyType = ExcelCustomPropertyType.NumberInteger;
             } else if (property.VTUnsignedInteger != null) {
-                Value = ulong.Parse(property.VTUnsignedInteger.Text, CultureInfo.InvariantCulture);
-                PropertyType = ExcelCustomPropertyType.NumberInteger;
+                _value = ulong.Parse(property.VTUnsignedInteger.Text, CultureInfo.InvariantCulture);
+                _propertyType = ExcelCustomPropertyType.NumberInteger;
             } else if (property.VTUnsignedInt64 != null) {
-                Value = ulong.Parse(property.VTUnsignedInt64.Text, CultureInfo.InvariantCulture);
-                PropertyType = ExcelCustomPropertyType.NumberInteger;
+                _value = ulong.Parse(property.VTUnsignedInt64.Text, CultureInfo.InvariantCulture);
+                _propertyType = ExcelCustomPropertyType.NumberInteger;
             } else if (property.VTFileTime != null) {
-                Value = DateTime.Parse(property.VTFileTime.Text, CultureInfo.InvariantCulture).ToUniversalTime();
-                PropertyType = ExcelCustomPropertyType.DateTime;
+                _value = DateTime.Parse(property.VTFileTime.Text, CultureInfo.InvariantCulture).ToUniversalTime();
+                _propertyType = ExcelCustomPropertyType.DateTime;
             } else if (property.VTDate != null) {
-                Value = DateTime.Parse(property.VTDate.Text, CultureInfo.InvariantCulture).ToUniversalTime();
-                PropertyType = ExcelCustomPropertyType.DateTime;
+                _value = DateTime.Parse(property.VTDate.Text, CultureInfo.InvariantCulture).ToUniversalTime();
+                _propertyType = ExcelCustomPropertyType.DateTime;
             } else if (property.VTFloat != null) {
-                Value = double.Parse(property.VTFloat.Text, CultureInfo.InvariantCulture);
-                PropertyType = ExcelCustomPropertyType.NumberDouble;
+                _value = double.Parse(property.VTFloat.Text, CultureInfo.InvariantCulture);
+                _propertyType = ExcelCustomPropertyType.NumberDouble;
             } else if (property.VTDouble != null) {
-                Value = double.Parse(property.VTDouble.Text, CultureInfo.InvariantCulture);
-                PropertyType = ExcelCustomPropertyType.NumberDouble;
+                _value = double.Parse(property.VTDouble.Text, CultureInfo.InvariantCulture);
+                _propertyType = ExcelCustomPropertyType.NumberDouble;
             } else if (property.VTLPWSTR != null) {
-                Value = property.VTLPWSTR.Text;
-                PropertyType = ExcelCustomPropertyType.Text;
+                _value = property.VTLPWSTR.Text;
+                _propertyType = ExcelCustomPropertyType.Text;
             } else if (property.VTBool != null) {
-                Value = ParseBooleanProperty(property.VTBool.Text);
-                PropertyType = ExcelCustomPropertyType.YesNo;
+                _value = ParseBooleanProperty(property.VTBool.Text);
+                _propertyType = ExcelCustomPropertyType.YesNo;
             } else {
-                Value = string.Empty;
-                PropertyType = ExcelCustomPropertyType.Text;
+                _value = string.Empty;
+                _propertyType = ExcelCustomPropertyType.Text;
             }
+        }
+
+        internal void SetChangeHandler(Action? changed) {
+            _changed = changed;
         }
 
         internal CustomDocumentProperty ToOpenXml(string name) {
@@ -178,6 +202,10 @@ namespace OfficeIMO.Excel {
             }
 
             throw new FormatException($"The custom property boolean value '{text}' is not valid.");
+        }
+
+        private void MarkChanged() {
+            _changed?.Invoke();
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelCustomProperty.cs
+++ b/OfficeIMO.Excel/ExcelCustomProperty.cs
@@ -91,6 +91,21 @@ namespace OfficeIMO.Excel {
                 long value = long.Parse(property.VTInt64.Text, CultureInfo.InvariantCulture);
                 Value = value >= int.MinValue && value <= int.MaxValue ? (int)value : value;
                 PropertyType = ExcelCustomPropertyType.NumberInteger;
+            } else if (property.VTUnsignedByte != null) {
+                Value = byte.Parse(property.VTUnsignedByte.Text, CultureInfo.InvariantCulture);
+                PropertyType = ExcelCustomPropertyType.NumberInteger;
+            } else if (property.VTUnsignedShort != null) {
+                Value = ushort.Parse(property.VTUnsignedShort.Text, CultureInfo.InvariantCulture);
+                PropertyType = ExcelCustomPropertyType.NumberInteger;
+            } else if (property.VTUnsignedInt32 != null) {
+                Value = uint.Parse(property.VTUnsignedInt32.Text, CultureInfo.InvariantCulture);
+                PropertyType = ExcelCustomPropertyType.NumberInteger;
+            } else if (property.VTUnsignedInteger != null) {
+                Value = ulong.Parse(property.VTUnsignedInteger.Text, CultureInfo.InvariantCulture);
+                PropertyType = ExcelCustomPropertyType.NumberInteger;
+            } else if (property.VTUnsignedInt64 != null) {
+                Value = ulong.Parse(property.VTUnsignedInt64.Text, CultureInfo.InvariantCulture);
+                PropertyType = ExcelCustomPropertyType.NumberInteger;
             } else if (property.VTFileTime != null) {
                 Value = DateTime.Parse(property.VTFileTime.Text, CultureInfo.InvariantCulture).ToUniversalTime();
                 PropertyType = ExcelCustomPropertyType.DateTime;
@@ -126,11 +141,17 @@ namespace OfficeIMO.Excel {
                     property.VTFileTime = new VTFileTime(string.Format(CultureInfo.InvariantCulture, "{0:s}Z", Convert.ToDateTime(Value, CultureInfo.InvariantCulture).ToUniversalTime()));
                     break;
                 case ExcelCustomPropertyType.NumberInteger:
-                    long integer = Convert.ToInt64(Value, CultureInfo.InvariantCulture);
-                    if (integer >= int.MinValue && integer <= int.MaxValue) {
-                        property.VTInt32 = new VTInt32(integer.ToString(CultureInfo.InvariantCulture));
+                    if (Value is ulong unsignedLong) {
+                        property.VTUnsignedInt64 = new VTUnsignedInt64(unsignedLong.ToString(CultureInfo.InvariantCulture));
+                    } else if (Value is uint unsignedInteger) {
+                        property.VTUnsignedInt32 = new VTUnsignedInt32(unsignedInteger.ToString(CultureInfo.InvariantCulture));
                     } else {
-                        property.VTInt64 = new VTInt64(integer.ToString(CultureInfo.InvariantCulture));
+                        long integer = Convert.ToInt64(Value, CultureInfo.InvariantCulture);
+                        if (integer >= int.MinValue && integer <= int.MaxValue) {
+                            property.VTInt32 = new VTInt32(integer.ToString(CultureInfo.InvariantCulture));
+                        } else {
+                            property.VTInt64 = new VTInt64(integer.ToString(CultureInfo.InvariantCulture));
+                        }
                     }
                     break;
                 case ExcelCustomPropertyType.NumberDouble:

--- a/OfficeIMO.Excel/ExcelCustomPropertyType.cs
+++ b/OfficeIMO.Excel/ExcelCustomPropertyType.cs
@@ -1,0 +1,31 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Supported custom workbook property value types.
+    /// </summary>
+    public enum ExcelCustomPropertyType {
+        /// <summary>
+        /// Text value.
+        /// </summary>
+        Text,
+
+        /// <summary>
+        /// Integer value.
+        /// </summary>
+        NumberInteger,
+
+        /// <summary>
+        /// Floating point numeric value.
+        /// </summary>
+        NumberDouble,
+
+        /// <summary>
+        /// Boolean value.
+        /// </summary>
+        YesNo,
+
+        /// <summary>
+        /// Date/time value.
+        /// </summary>
+        DateTime
+    }
+}

--- a/OfficeIMO.Excel/ExcelDashboardOptions.cs
+++ b/OfficeIMO.Excel/ExcelDashboardOptions.cs
@@ -1,0 +1,45 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Options for building a dashboard table and chart from tabular data.
+    /// </summary>
+    public sealed class ExcelDashboardOptions {
+        /// <summary>Optional dashboard title.</summary>
+        public string? Title { get; set; }
+
+        /// <summary>Optional dashboard subtitle.</summary>
+        public string? Subtitle { get; set; }
+
+        /// <summary>Top-left row for the generated table.</summary>
+        public int TableRow { get; set; } = 3;
+
+        /// <summary>Top-left column for the generated table.</summary>
+        public int TableColumn { get; set; } = 1;
+
+        /// <summary>Optional table name.</summary>
+        public string? TableName { get; set; }
+
+        /// <summary>Built-in table style.</summary>
+        public TableStyle TableStyle { get; set; } = TableStyle.TableStyleMedium9;
+
+        /// <summary>Whether the table should include AutoFilter dropdowns.</summary>
+        public bool IncludeAutoFilter { get; set; } = true;
+
+        /// <summary>Whether table columns should be auto-fitted after insertion.</summary>
+        public bool AutoFit { get; set; } = true;
+
+        /// <summary>Whether to add a dashboard chart beside the table.</summary>
+        public bool AddChart { get; set; } = true;
+
+        /// <summary>Dashboard chart preset.</summary>
+        public ExcelDashboardChartPreset ChartPreset { get; set; } = ExcelDashboardChartPreset.Comparison;
+
+        /// <summary>Optional chart title. Defaults to <see cref="Title"/> when omitted.</summary>
+        public string? ChartTitle { get; set; }
+
+        /// <summary>Optional top-left chart row. Defaults to <see cref="TableRow"/>.</summary>
+        public int? ChartRow { get; set; }
+
+        /// <summary>Optional top-left chart column. Defaults to two columns after the table.</summary>
+        public int? ChartColumn { get; set; }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDashboardResult.cs
+++ b/OfficeIMO.Excel/ExcelDashboardResult.cs
@@ -1,0 +1,21 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Result of a dashboard build operation.
+    /// </summary>
+    public sealed class ExcelDashboardResult {
+        internal ExcelDashboardResult(string tableRange, string? tableName, ExcelChart? chart) {
+            TableRange = tableRange;
+            TableName = tableName;
+            Chart = chart;
+        }
+
+        /// <summary>A1 range occupied by the generated table.</summary>
+        public string TableRange { get; }
+
+        /// <summary>Name assigned to the generated table, when available.</summary>
+        public string? TableName { get; }
+
+        /// <summary>Generated chart, when requested.</summary>
+        public ExcelChart? Chart { get; }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDateSystem.cs
+++ b/OfficeIMO.Excel/ExcelDateSystem.cs
@@ -1,0 +1,16 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Excel workbook date system used for serial date values.
+    /// </summary>
+    public enum ExcelDateSystem {
+        /// <summary>
+        /// The default Excel 1900 date system.
+        /// </summary>
+        NineteenHundred = 1900,
+
+        /// <summary>
+        /// The Excel 1904 date system, commonly used by older Mac-originated workbooks.
+        /// </summary>
+        NineteenFour = 1904,
+    }
+}

--- a/OfficeIMO.Excel/ExcelDateSystemConverter.cs
+++ b/OfficeIMO.Excel/ExcelDateSystemConverter.cs
@@ -1,0 +1,15 @@
+namespace OfficeIMO.Excel {
+    internal static class ExcelDateSystemConverter {
+        internal const double Date1904OffsetDays = 1462d;
+
+        internal static double ToSerial(DateTime value, ExcelDateSystem dateSystem) {
+            double serial = value.ToOADate();
+            return dateSystem == ExcelDateSystem.NineteenFour ? serial - Date1904OffsetDays : serial;
+        }
+
+        internal static DateTime FromSerial(double serial, ExcelDateSystem dateSystem) {
+            double oa = dateSystem == ExcelDateSystem.NineteenFour ? serial + Date1904OffsetDays : serial;
+            return DateTime.FromOADate(oa);
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.ActiveWorksheet.cs
+++ b/OfficeIMO.Excel/ExcelDocument.ActiveWorksheet.cs
@@ -1,0 +1,120 @@
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using System.Globalization;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelDocument {
+        /// <summary>
+        /// Sets the worksheet that spreadsheet applications should show when the workbook opens.
+        /// </summary>
+        /// <param name="sheetName">Worksheet name.</param>
+        public void SetActiveWorksheet(string sheetName) {
+            SetActiveWorksheet(GetSheet(sheetName));
+        }
+
+        /// <summary>
+        /// Sets the worksheet that spreadsheet applications should show when the workbook opens.
+        /// </summary>
+        /// <param name="sheetIndex">Zero-based worksheet index.</param>
+        public void SetActiveWorksheet(int sheetIndex) {
+            var sheets = Sheets;
+            if (sheetIndex < 0 || sheetIndex >= sheets.Count) {
+                throw new ArgumentOutOfRangeException(nameof(sheetIndex), $"Index {sheetIndex.ToString(CultureInfo.InvariantCulture)} is out of range (0..{(sheets.Count - 1).ToString(CultureInfo.InvariantCulture)}).");
+            }
+
+            SetActiveWorksheet(sheets[sheetIndex]);
+        }
+
+        /// <summary>
+        /// Sets the worksheet that spreadsheet applications should show when the workbook opens.
+        /// </summary>
+        /// <param name="sheet">Worksheet to activate.</param>
+        public void SetActiveWorksheet(ExcelSheet sheet) {
+            if (sheet == null) {
+                throw new ArgumentNullException(nameof(sheet));
+            }
+
+            if (!ReferenceEquals(sheet.Document, this)) {
+                throw new ArgumentException("Worksheet must belong to this workbook.", nameof(sheet));
+            }
+
+            MaterializeDeferredDataSetImport();
+            Locking.ExecuteWrite(EnsureLock(), () => {
+                Sheets workbookSheets = WorkbookRoot.Sheets ?? throw new InvalidOperationException("Workbook sheets collection is missing.");
+                List<Sheet> orderedSheets = workbookSheets.Elements<Sheet>().ToList();
+                int activeIndex = orderedSheets.FindIndex(candidate => ReferenceEquals(candidate, sheet.SheetElement)
+                    || string.Equals(candidate.Name?.Value, sheet.Name, StringComparison.Ordinal));
+                if (activeIndex < 0) {
+                    throw new ArgumentException("Worksheet not found in workbook.", nameof(sheet));
+                }
+
+                Sheet activeSheet = orderedSheets[activeIndex];
+                if (activeSheet.State?.Value == SheetStateValues.Hidden || activeSheet.State?.Value == SheetStateValues.VeryHidden) {
+                    throw new InvalidOperationException("A hidden worksheet cannot be the active worksheet.");
+                }
+
+                WorkbookView workbookView = GetOrCreatePrimaryWorkbookViewForActiveWorksheet();
+                workbookView.ActiveTab = (uint)activeIndex;
+                workbookView.FirstSheet = (uint)activeIndex;
+
+                for (int index = 0; index < orderedSheets.Count; index++) {
+                    Sheet currentSheet = orderedSheets[index];
+                    if (currentSheet.Id?.Value == null || WorkbookPartRoot.GetPartById(currentSheet.Id.Value) is not WorksheetPart worksheetPart) {
+                        continue;
+                    }
+
+                    Worksheet worksheet = worksheetPart.Worksheet ?? throw new InvalidOperationException("Worksheet is missing.");
+                    SheetView sheetView = GetOrCreatePrimarySheetViewForActiveWorksheet(worksheet);
+                    sheetView.WorkbookViewId ??= 0U;
+                    sheetView.TabSelected = index == activeIndex;
+                    worksheet.Save();
+                }
+
+                WorkbookRoot.Save();
+                MarkPackageDirty();
+            });
+        }
+
+        private WorkbookView GetOrCreatePrimaryWorkbookViewForActiveWorksheet() {
+            BookViews? workbookViews = WorkbookRoot.GetFirstChild<BookViews>();
+            if (workbookViews == null) {
+                workbookViews = new BookViews();
+                var sheets = WorkbookRoot.GetFirstChild<Sheets>();
+                if (sheets != null) {
+                    WorkbookRoot.InsertBefore(workbookViews, sheets);
+                } else {
+                    WorkbookRoot.Append(workbookViews);
+                }
+            }
+
+            WorkbookView? workbookView = workbookViews.GetFirstChild<WorkbookView>();
+            if (workbookView == null) {
+                workbookView = new WorkbookView();
+                workbookViews.Append(workbookView);
+            }
+
+            return workbookView;
+        }
+
+        private static SheetView GetOrCreatePrimarySheetViewForActiveWorksheet(Worksheet worksheet) {
+            SheetViews? sheetViews = worksheet.GetFirstChild<SheetViews>();
+            if (sheetViews == null) {
+                sheetViews = new SheetViews();
+                var sheetData = worksheet.GetFirstChild<SheetData>();
+                if (sheetData != null) {
+                    worksheet.InsertBefore(sheetViews, sheetData);
+                } else {
+                    worksheet.Append(sheetViews);
+                }
+            }
+
+            SheetView? sheetView = sheetViews.GetFirstChild<SheetView>();
+            if (sheetView == null) {
+                sheetView = new SheetView { WorkbookViewId = 0U };
+                sheetViews.Append(sheetView);
+            }
+
+            return sheetView;
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.ConnectionMetadata.cs
+++ b/OfficeIMO.Excel/ExcelDocument.ConnectionMetadata.cs
@@ -24,9 +24,9 @@ namespace OfficeIMO.Excel {
             OpenXmlPart? existingPart = GetWorkbookConnectionPart();
             if (existingPart == null) {
                 return AddWorkbookMetadataPart(
-                WorkbookConnectionRelationshipType,
-                WorkbookConnectionContentType,
-                xml);
+                    WorkbookConnectionRelationshipType,
+                    WorkbookConnectionContentType,
+                    NormalizeWorkbookConnectionMetadata(xml));
             }
 
             string mergedXml = MergeWorkbookConnectionMetadata(ReadMetadataPart(existingPart), xml);
@@ -101,6 +101,10 @@ namespace OfficeIMO.Excel {
         /// <returns>The added package part.</returns>
         public ExtendedPart AddWorksheetMetadataPart(ExcelSheet sheet, string relationshipType, string contentType, string xml, string targetExtension = "xml") {
             if (sheet == null) throw new ArgumentNullException(nameof(sheet));
+            if (!ReferenceEquals(sheet.Document, this)) {
+                throw new ArgumentException("Worksheet metadata can only be added to a worksheet owned by this workbook.", nameof(sheet));
+            }
+
             return AddMetadataPart(sheet.WorksheetPart, relationshipType, contentType, xml, targetExtension);
         }
 
@@ -150,6 +154,22 @@ namespace OfficeIMO.Excel {
 
             existingDocument.Root.SetAttributeValue("count", existingDocument.Root.Elements().Count(element => element.Name.LocalName == "connection").ToString(System.Globalization.CultureInfo.InvariantCulture));
             return existingDocument.ToString(SaveOptions.DisableFormatting);
+        }
+
+        private static string NormalizeWorkbookConnectionMetadata(string xml) {
+            XDocument document = XDocument.Parse(xml);
+            if (document.Root == null) {
+                throw new InvalidDataException("Workbook connection metadata must have a document root.");
+            }
+
+            if (document.Root.Name.LocalName != "connection") {
+                return document.ToString(SaveOptions.DisableFormatting);
+            }
+
+            XNamespace ns = document.Root.Name.Namespace;
+            var connections = new XElement(ns + "connections", new XElement(document.Root));
+            connections.SetAttributeValue("count", "1");
+            return new XDocument(connections).ToString(SaveOptions.DisableFormatting);
         }
 
         private static string ReadMetadataPart(OpenXmlPart part) {

--- a/OfficeIMO.Excel/ExcelDocument.ConnectionMetadata.cs
+++ b/OfficeIMO.Excel/ExcelDocument.ConnectionMetadata.cs
@@ -174,6 +174,11 @@ namespace OfficeIMO.Excel {
             using Stream stream = part.GetStream(FileMode.Create, FileAccess.Write);
             byte[] bytes = Encoding.UTF8.GetBytes(xml);
             stream.Write(bytes, 0, bytes.Length);
+            if (part is ConnectionsPart connectionsPart) {
+                var connections = new Connections();
+                connections.Load(connectionsPart);
+                connectionsPart.Connections = connections;
+            }
         }
 
         private void MarkMetadataPartChanged() {

--- a/OfficeIMO.Excel/ExcelDocument.ConnectionMetadata.cs
+++ b/OfficeIMO.Excel/ExcelDocument.ConnectionMetadata.cs
@@ -1,5 +1,7 @@
+using System.Globalization;
 using System.Text;
 using System.Xml.Linq;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 
@@ -9,6 +11,8 @@ namespace OfficeIMO.Excel {
         private const string WorkbookConnectionContentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.connections+xml";
         private const string WorksheetQueryTableRelationshipType = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/queryTable";
         private const string WorksheetQueryTableContentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.queryTable+xml";
+        private const string SpreadsheetMainNamespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+        private const string OfficeDocumentRelationshipsNamespace = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
         private const string WorkbookSlicerCacheRelationshipType = "http://schemas.microsoft.com/office/2007/relationships/slicerCache";
         private const string WorkbookSlicerCacheContentType = "application/vnd.ms-excel.slicerCache+xml";
         private const string WorkbookTimelineCacheRelationshipType = "http://schemas.microsoft.com/office/2011/relationships/timelineCache";
@@ -45,11 +49,13 @@ namespace OfficeIMO.Excel {
         public ExtendedPart AddWorksheetQueryTableMetadata(string worksheetName, string xml) {
             if (string.IsNullOrWhiteSpace(worksheetName)) throw new ArgumentNullException(nameof(worksheetName));
             var sheet = this[worksheetName];
-            return AddWorksheetMetadataPart(
+            ExtendedPart part = AddWorksheetMetadataPart(
                 sheet,
                 WorksheetQueryTableRelationshipType,
                 WorksheetQueryTableContentType,
                 xml);
+            LinkWorksheetQueryTablePart(sheet.WorksheetPart, part);
+            return part;
         }
 
         /// <summary>
@@ -118,6 +124,54 @@ namespace OfficeIMO.Excel {
             WriteMetadataPart(part, xml);
             MarkMetadataPartChanged();
             return part;
+        }
+
+        private void LinkWorksheetQueryTablePart(WorksheetPart worksheetPart, OpenXmlPart queryTablePart) {
+            string relationshipId = worksheetPart.GetIdOfPart(queryTablePart);
+            Worksheet worksheet = worksheetPart.Worksheet ?? throw new InvalidDataException("Worksheet metadata cannot be linked because the worksheet part has no worksheet XML.");
+            OpenXmlElement? queryTableParts = worksheet.ChildElements.FirstOrDefault(IsQueryTablePartsElement);
+            if (queryTableParts == null) {
+                queryTableParts = new OpenXmlUnknownElement(string.Empty, "queryTableParts", SpreadsheetMainNamespace);
+                WorksheetExtensionList? extensionList = worksheet.GetFirstChild<WorksheetExtensionList>();
+                if (extensionList != null) {
+                    worksheet.InsertBefore(queryTableParts, extensionList);
+                } else {
+                    worksheet.Append(queryTableParts);
+                }
+            }
+
+            bool exists = queryTableParts.ChildElements
+                .Where(IsQueryTablePartElement)
+                .Any(part => string.Equals(GetRelationshipId(part), relationshipId, StringComparison.Ordinal));
+            if (!exists) {
+                var linkedPart = new OpenXmlUnknownElement(string.Empty, "queryTablePart", SpreadsheetMainNamespace);
+                linkedPart.SetAttribute(new OpenXmlAttribute("r", "id", OfficeDocumentRelationshipsNamespace, relationshipId));
+                queryTableParts.Append(linkedPart);
+            }
+
+            int count = queryTableParts.ChildElements.Count(IsQueryTablePartElement);
+            queryTableParts.SetAttribute(new OpenXmlAttribute("count", string.Empty, count.ToString(CultureInfo.InvariantCulture)));
+            worksheet.Save();
+            MarkMetadataPartChanged();
+        }
+
+        private static bool IsQueryTablePartsElement(OpenXmlElement element) {
+            return string.Equals(element.LocalName, "queryTableParts", StringComparison.Ordinal)
+                && string.Equals(element.NamespaceUri, SpreadsheetMainNamespace, StringComparison.Ordinal);
+        }
+
+        private static bool IsQueryTablePartElement(OpenXmlElement element) {
+            return string.Equals(element.LocalName, "queryTablePart", StringComparison.Ordinal)
+                && string.Equals(element.NamespaceUri, SpreadsheetMainNamespace, StringComparison.Ordinal);
+        }
+
+        private static string? GetRelationshipId(OpenXmlElement element) {
+            string? id = element.GetAttribute("id", OfficeDocumentRelationshipsNamespace).Value;
+            if (!string.IsNullOrWhiteSpace(id)) {
+                return id;
+            }
+
+            return element.GetAttribute("id", string.Empty).Value;
         }
 
         private OpenXmlPart? GetWorkbookConnectionPart() {

--- a/OfficeIMO.Excel/ExcelDocument.ConnectionMetadata.cs
+++ b/OfficeIMO.Excel/ExcelDocument.ConnectionMetadata.cs
@@ -1,0 +1,124 @@
+using System.Text;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelDocument {
+        private const string WorkbookConnectionRelationshipType = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/connections";
+        private const string WorkbookConnectionContentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.connections+xml";
+        private const string WorksheetQueryTableRelationshipType = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/queryTable";
+        private const string WorksheetQueryTableContentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.queryTable+xml";
+        private const string WorkbookSlicerCacheRelationshipType = "http://schemas.microsoft.com/office/2007/relationships/slicerCache";
+        private const string WorkbookSlicerCacheContentType = "application/vnd.ms-excel.slicerCache+xml";
+        private const string WorkbookTimelineCacheRelationshipType = "http://schemas.microsoft.com/office/2011/relationships/timelineCache";
+        private const string WorkbookTimelineCacheContentType = "application/vnd.ms-excel.timelineCache+xml";
+
+        /// <summary>
+        /// Adds caller-supplied workbook connection metadata XML as a workbook package part.
+        /// OfficeIMO preserves this metadata but does not execute or refresh external connections.
+        /// </summary>
+        /// <param name="xml">Connection metadata XML.</param>
+        /// <returns>The added package part.</returns>
+        public ExtendedPart AddWorkbookConnectionMetadata(string xml) {
+            return AddWorkbookMetadataPart(
+                WorkbookConnectionRelationshipType,
+                WorkbookConnectionContentType,
+                xml);
+        }
+
+        /// <summary>
+        /// Adds caller-supplied query-table metadata XML as a worksheet package part.
+        /// OfficeIMO preserves this metadata but does not execute or refresh external queries.
+        /// </summary>
+        /// <param name="worksheetName">Worksheet that owns the query-table metadata.</param>
+        /// <param name="xml">Query-table metadata XML.</param>
+        /// <returns>The added package part.</returns>
+        public ExtendedPart AddWorksheetQueryTableMetadata(string worksheetName, string xml) {
+            if (string.IsNullOrWhiteSpace(worksheetName)) throw new ArgumentNullException(nameof(worksheetName));
+            var sheet = this[worksheetName];
+            return AddWorksheetMetadataPart(
+                sheet,
+                WorksheetQueryTableRelationshipType,
+                WorksheetQueryTableContentType,
+                xml);
+        }
+
+        /// <summary>
+        /// Adds workbook-level slicer cache metadata. This authors package metadata for slicer workflows; Excel may still be required to materialize full UI slicer shapes and bindings.
+        /// </summary>
+        /// <param name="options">Slicer cache metadata options.</param>
+        /// <returns>The added package part.</returns>
+        public ExtendedPart AddWorkbookSlicerCache(ExcelSlicerCacheOptions options) {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            return AddWorkbookMetadataPart(
+                WorkbookSlicerCacheRelationshipType,
+                WorkbookSlicerCacheContentType,
+                options.ToXml());
+        }
+
+        /// <summary>
+        /// Adds workbook-level timeline cache metadata. This authors package metadata for timeline workflows; Excel may still be required to materialize full UI timeline shapes and bindings.
+        /// </summary>
+        /// <param name="options">Timeline cache metadata options.</param>
+        /// <returns>The added package part.</returns>
+        public ExtendedPart AddWorkbookTimelineCache(ExcelTimelineCacheOptions options) {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            return AddWorkbookMetadataPart(
+                WorkbookTimelineCacheRelationshipType,
+                WorkbookTimelineCacheContentType,
+                options.ToXml());
+        }
+
+        /// <summary>
+        /// Adds caller-supplied XML as a workbook package metadata part.
+        /// </summary>
+        /// <param name="relationshipType">Open XML relationship type.</param>
+        /// <param name="contentType">Package part content type.</param>
+        /// <param name="xml">Metadata XML.</param>
+        /// <param name="targetExtension">Target extension for the generated package part.</param>
+        /// <returns>The added package part.</returns>
+        public ExtendedPart AddWorkbookMetadataPart(string relationshipType, string contentType, string xml, string targetExtension = "xml") {
+            return AddMetadataPart(WorkbookPartRoot, relationshipType, contentType, xml, targetExtension);
+        }
+
+        /// <summary>
+        /// Adds caller-supplied XML as a worksheet package metadata part.
+        /// </summary>
+        /// <param name="sheet">Worksheet that owns the metadata part.</param>
+        /// <param name="relationshipType">Open XML relationship type.</param>
+        /// <param name="contentType">Package part content type.</param>
+        /// <param name="xml">Metadata XML.</param>
+        /// <param name="targetExtension">Target extension for the generated package part.</param>
+        /// <returns>The added package part.</returns>
+        public ExtendedPart AddWorksheetMetadataPart(ExcelSheet sheet, string relationshipType, string contentType, string xml, string targetExtension = "xml") {
+            if (sheet == null) throw new ArgumentNullException(nameof(sheet));
+            return AddMetadataPart(sheet.WorksheetPart, relationshipType, contentType, xml, targetExtension);
+        }
+
+        private ExtendedPart AddMetadataPart(OpenXmlPartContainer container, string relationshipType, string contentType, string xml, string targetExtension) {
+            if (container == null) throw new ArgumentNullException(nameof(container));
+            if (string.IsNullOrWhiteSpace(relationshipType)) throw new ArgumentNullException(nameof(relationshipType));
+            if (string.IsNullOrWhiteSpace(contentType)) throw new ArgumentNullException(nameof(contentType));
+            if (string.IsNullOrWhiteSpace(xml)) throw new ArgumentNullException(nameof(xml));
+
+            var part = container.AddExtendedPart(relationshipType, contentType, NormalizeMetadataPartExtension(targetExtension));
+            using (Stream stream = part.GetStream(FileMode.Create, FileAccess.Write)) {
+                byte[] bytes = Encoding.UTF8.GetBytes(xml);
+                stream.Write(bytes, 0, bytes.Length);
+            }
+
+            _packageDirty = true;
+            _packageContentTypesKnownNormalized = true;
+            _simplePackageContentKnown = false;
+            MarkRequiresSavePreflight();
+            return part;
+        }
+
+        private static string NormalizeMetadataPartExtension(string targetExtension) {
+            if (string.IsNullOrWhiteSpace(targetExtension)) {
+                return "xml";
+            }
+
+            return targetExtension.Trim().TrimStart('.');
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.ConnectionMetadata.cs
+++ b/OfficeIMO.Excel/ExcelDocument.ConnectionMetadata.cs
@@ -175,9 +175,7 @@ namespace OfficeIMO.Excel {
             byte[] bytes = Encoding.UTF8.GetBytes(xml);
             stream.Write(bytes, 0, bytes.Length);
             if (part is ConnectionsPart connectionsPart) {
-                var connections = new Connections();
-                connections.Load(connectionsPart);
-                connectionsPart.Connections = connections;
+                connectionsPart.Connections = new Connections(xml);
             }
         }
 

--- a/OfficeIMO.Excel/ExcelDocument.ConnectionMetadata.cs
+++ b/OfficeIMO.Excel/ExcelDocument.ConnectionMetadata.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Xml.Linq;
 using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
 
 namespace OfficeIMO.Excel {
     public partial class ExcelDocument {
@@ -122,6 +123,17 @@ namespace OfficeIMO.Excel {
                 .FirstOrDefault(part => string.Equals(part.ContentType, WorkbookConnectionContentType, StringComparison.OrdinalIgnoreCase));
         }
 
+        private IEnumerable<OpenXmlPart> EnumerateWorkbookConnectionParts() {
+            foreach (IdPartPair pair in WorkbookPartRoot.Parts) {
+                OpenXmlPart part = pair.OpenXmlPart;
+                if (part is ConnectionsPart
+                    || string.Equals(part.RelationshipType, WorkbookConnectionRelationshipType, StringComparison.Ordinal)
+                    || part.ContentType.IndexOf("connections", StringComparison.OrdinalIgnoreCase) >= 0) {
+                    yield return part;
+                }
+            }
+        }
+
         private static string MergeWorkbookConnectionMetadata(string existingXml, string newXml) {
             XDocument existingDocument = XDocument.Parse(existingXml);
             XDocument newDocument = XDocument.Parse(newXml);
@@ -142,12 +154,24 @@ namespace OfficeIMO.Excel {
         }
 
         private static string ReadMetadataPart(ExtendedPart part) {
+            return ReadOpenXmlPartText(part);
+        }
+
+        private static void WriteMetadataPart(ExtendedPart part, string xml) {
+            WriteOpenXmlPartText(part, xml);
+        }
+
+        private static string ReadOpenXmlPartText(OpenXmlPart part) {
+            if (part is ConnectionsPart connectionsPart && connectionsPart.Connections != null) {
+                return connectionsPart.Connections.OuterXml;
+            }
+
             using Stream stream = part.GetStream(FileMode.Open, FileAccess.Read);
             using var reader = new StreamReader(stream, Encoding.UTF8);
             return reader.ReadToEnd();
         }
 
-        private static void WriteMetadataPart(ExtendedPart part, string xml) {
+        private static void WriteOpenXmlPartText(OpenXmlPart part, string xml) {
             using Stream stream = part.GetStream(FileMode.Create, FileAccess.Write);
             byte[] bytes = Encoding.UTF8.GetBytes(xml);
             stream.Write(bytes, 0, bytes.Length);

--- a/OfficeIMO.Excel/ExcelDocument.ConnectionMetadata.cs
+++ b/OfficeIMO.Excel/ExcelDocument.ConnectionMetadata.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Xml.Linq;
 using DocumentFormat.OpenXml.Packaging;
 
 namespace OfficeIMO.Excel {
@@ -19,10 +20,18 @@ namespace OfficeIMO.Excel {
         /// <param name="xml">Connection metadata XML.</param>
         /// <returns>The added package part.</returns>
         public ExtendedPart AddWorkbookConnectionMetadata(string xml) {
-            return AddWorkbookMetadataPart(
+            ExtendedPart? existingPart = GetWorkbookConnectionPart();
+            if (existingPart == null) {
+                return AddWorkbookMetadataPart(
                 WorkbookConnectionRelationshipType,
                 WorkbookConnectionContentType,
                 xml);
+            }
+
+            string mergedXml = MergeWorkbookConnectionMetadata(ReadMetadataPart(existingPart), xml);
+            WriteMetadataPart(existingPart, mergedXml);
+            MarkMetadataPartChanged();
+            return existingPart;
         }
 
         /// <summary>
@@ -101,16 +110,54 @@ namespace OfficeIMO.Excel {
             if (string.IsNullOrWhiteSpace(xml)) throw new ArgumentNullException(nameof(xml));
 
             var part = container.AddExtendedPart(relationshipType, contentType, NormalizeMetadataPartExtension(targetExtension));
-            using (Stream stream = part.GetStream(FileMode.Create, FileAccess.Write)) {
-                byte[] bytes = Encoding.UTF8.GetBytes(xml);
-                stream.Write(bytes, 0, bytes.Length);
+            WriteMetadataPart(part, xml);
+            MarkMetadataPartChanged();
+            return part;
+        }
+
+        private ExtendedPart? GetWorkbookConnectionPart() {
+            return WorkbookPartRoot.Parts
+                .Select(pair => pair.OpenXmlPart)
+                .OfType<ExtendedPart>()
+                .FirstOrDefault(part => string.Equals(part.ContentType, WorkbookConnectionContentType, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static string MergeWorkbookConnectionMetadata(string existingXml, string newXml) {
+            XDocument existingDocument = XDocument.Parse(existingXml);
+            XDocument newDocument = XDocument.Parse(newXml);
+            if (existingDocument.Root == null || newDocument.Root == null) {
+                throw new InvalidDataException("Workbook connection metadata must have a document root.");
             }
 
+            IEnumerable<XElement> newConnections = newDocument.Root.Name.LocalName == "connection"
+                ? new[] { newDocument.Root }
+                : newDocument.Root.Elements().Where(element => element.Name.LocalName == "connection");
+
+            foreach (XElement connection in newConnections) {
+                existingDocument.Root.Add(new XElement(connection));
+            }
+
+            existingDocument.Root.SetAttributeValue("count", existingDocument.Root.Elements().Count(element => element.Name.LocalName == "connection").ToString(System.Globalization.CultureInfo.InvariantCulture));
+            return existingDocument.ToString(SaveOptions.DisableFormatting);
+        }
+
+        private static string ReadMetadataPart(ExtendedPart part) {
+            using Stream stream = part.GetStream(FileMode.Open, FileAccess.Read);
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+            return reader.ReadToEnd();
+        }
+
+        private static void WriteMetadataPart(ExtendedPart part, string xml) {
+            using Stream stream = part.GetStream(FileMode.Create, FileAccess.Write);
+            byte[] bytes = Encoding.UTF8.GetBytes(xml);
+            stream.Write(bytes, 0, bytes.Length);
+        }
+
+        private void MarkMetadataPartChanged() {
             _packageDirty = true;
             _packageContentTypesKnownNormalized = true;
             _simplePackageContentKnown = false;
             MarkRequiresSavePreflight();
-            return part;
         }
 
         private static string NormalizeMetadataPartExtension(string targetExtension) {

--- a/OfficeIMO.Excel/ExcelDocument.ConnectionMetadata.cs
+++ b/OfficeIMO.Excel/ExcelDocument.ConnectionMetadata.cs
@@ -19,9 +19,9 @@ namespace OfficeIMO.Excel {
         /// OfficeIMO preserves this metadata but does not execute or refresh external connections.
         /// </summary>
         /// <param name="xml">Connection metadata XML.</param>
-        /// <returns>The added package part.</returns>
-        public ExtendedPart AddWorkbookConnectionMetadata(string xml) {
-            ExtendedPart? existingPart = GetWorkbookConnectionPart();
+        /// <returns>The added or updated package part.</returns>
+        public OpenXmlPart AddWorkbookConnectionMetadata(string xml) {
+            OpenXmlPart? existingPart = GetWorkbookConnectionPart();
             if (existingPart == null) {
                 return AddWorkbookMetadataPart(
                 WorkbookConnectionRelationshipType,
@@ -116,11 +116,10 @@ namespace OfficeIMO.Excel {
             return part;
         }
 
-        private ExtendedPart? GetWorkbookConnectionPart() {
-            return WorkbookPartRoot.Parts
-                .Select(pair => pair.OpenXmlPart)
-                .OfType<ExtendedPart>()
-                .FirstOrDefault(part => string.Equals(part.ContentType, WorkbookConnectionContentType, StringComparison.OrdinalIgnoreCase));
+        private OpenXmlPart? GetWorkbookConnectionPart() {
+            return EnumerateWorkbookConnectionParts()
+                .FirstOrDefault(part => string.Equals(part.ContentType, WorkbookConnectionContentType, StringComparison.OrdinalIgnoreCase)
+                    || part is ConnectionsPart);
         }
 
         private IEnumerable<OpenXmlPart> EnumerateWorkbookConnectionParts() {
@@ -153,11 +152,11 @@ namespace OfficeIMO.Excel {
             return existingDocument.ToString(SaveOptions.DisableFormatting);
         }
 
-        private static string ReadMetadataPart(ExtendedPart part) {
+        private static string ReadMetadataPart(OpenXmlPart part) {
             return ReadOpenXmlPartText(part);
         }
 
-        private static void WriteMetadataPart(ExtendedPart part, string xml) {
+        private static void WriteMetadataPart(OpenXmlPart part, string xml) {
             WriteOpenXmlPartText(part, xml);
         }
 

--- a/OfficeIMO.Excel/ExcelDocument.CreateLoad.cs
+++ b/OfficeIMO.Excel/ExcelDocument.CreateLoad.cs
@@ -95,6 +95,7 @@ namespace OfficeIMO.Excel {
             // Initialize document property helpers
             document.BuiltinDocumentProperties = new BuiltinDocumentProperties(document);
             document.ApplicationProperties = new ApplicationProperties(document);
+            document.LoadCustomDocumentProperties();
 
             return document;
         }
@@ -130,6 +131,7 @@ namespace OfficeIMO.Excel {
 
             document.BuiltinDocumentProperties = new BuiltinDocumentProperties(document);
             document.ApplicationProperties = new ApplicationProperties(document);
+            document.LoadCustomDocumentProperties();
             ExcelChartAxisIdGenerator.Initialize(document._spreadSheetDocument);
             return document;
         }

--- a/OfficeIMO.Excel/ExcelDocument.CreateLoad.cs
+++ b/OfficeIMO.Excel/ExcelDocument.CreateLoad.cs
@@ -95,6 +95,7 @@ namespace OfficeIMO.Excel {
             // Initialize document property helpers
             document.BuiltinDocumentProperties = new BuiltinDocumentProperties(document);
             document.ApplicationProperties = new ApplicationProperties(document);
+            document.CustomDocumentProperties.SetChangeHandler(document.MarkCustomDocumentPropertiesChanged);
             document.LoadCustomDocumentProperties();
 
             return document;
@@ -131,6 +132,7 @@ namespace OfficeIMO.Excel {
 
             document.BuiltinDocumentProperties = new BuiltinDocumentProperties(document);
             document.ApplicationProperties = new ApplicationProperties(document);
+            document.CustomDocumentProperties.SetChangeHandler(document.MarkCustomDocumentPropertiesChanged);
             document.LoadCustomDocumentProperties();
             ExcelChartAxisIdGenerator.Initialize(document._spreadSheetDocument);
             return document;

--- a/OfficeIMO.Excel/ExcelDocument.CustomDocumentProperties.cs
+++ b/OfficeIMO.Excel/ExcelDocument.CustomDocumentProperties.cs
@@ -47,10 +47,11 @@ namespace OfficeIMO.Excel {
         }
 
         internal void LoadCustomDocumentProperties() {
-            CustomDocumentProperties.Clear();
+            var loadedProperties = new Dictionary<string, ExcelCustomProperty>(StringComparer.OrdinalIgnoreCase);
             _customDocumentPropertiesDirty = false;
             CustomFilePropertiesPart? customPart = _spreadSheetDocument.CustomFilePropertiesPart;
             if (customPart?.Properties == null) {
+                CustomDocumentProperties.ReplaceWith(loadedProperties);
                 return;
             }
 
@@ -59,8 +60,10 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                CustomDocumentProperties[property.Name!.Value!] = new ExcelCustomProperty(property);
+                loadedProperties[property.Name!.Value!] = new ExcelCustomProperty(property);
             }
+
+            CustomDocumentProperties.ReplaceWith(loadedProperties);
         }
 
         internal void SaveCustomDocumentProperties() {
@@ -162,6 +165,12 @@ namespace OfficeIMO.Excel {
             ClearDirectDataSetSaveCandidate();
             _materializedDirectDataSetFastSaveModel = null;
             _materializedDirectDataSetFastSaveModelHasMaterializedWorksheet = false;
+        }
+
+        private void MarkCustomDocumentPropertiesChanged() {
+            _customDocumentPropertiesDirty = true;
+            DisqualifyDirectDataSetFastSaveState();
+            MarkPackageDirty();
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelDocument.CustomDocumentProperties.cs
+++ b/OfficeIMO.Excel/ExcelDocument.CustomDocumentProperties.cs
@@ -1,0 +1,155 @@
+using DocumentFormat.OpenXml.CustomProperties;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelDocument {
+        /// <summary>
+        /// Sets or replaces a custom workbook property.
+        /// </summary>
+        public void SetCustomDocumentProperty(string name, ExcelCustomProperty property) {
+            if (string.IsNullOrWhiteSpace(name)) {
+                throw new ArgumentException("Custom property name is required.", nameof(name));
+            }
+
+            if (property == null) {
+                throw new ArgumentNullException(nameof(property));
+            }
+
+            CustomDocumentProperties[name.Trim()] = property;
+            _customDocumentPropertiesDirty = true;
+            MarkPackageDirty();
+        }
+
+        /// <summary>
+        /// Sets or replaces a custom workbook property, inferring the custom property type from the value.
+        /// </summary>
+        public void SetCustomDocumentProperty(string name, object? value) {
+            SetCustomDocumentProperty(name, CreateCustomProperty(value));
+        }
+
+        /// <summary>
+        /// Removes a custom workbook property.
+        /// </summary>
+        public bool RemoveCustomDocumentProperty(string name) {
+            if (string.IsNullOrWhiteSpace(name)) {
+                return false;
+            }
+
+            bool removed = CustomDocumentProperties.Remove(name.Trim());
+            if (removed) {
+                _customDocumentPropertiesDirty = true;
+                MarkPackageDirty();
+            }
+
+            return removed;
+        }
+
+        internal void LoadCustomDocumentProperties() {
+            CustomDocumentProperties.Clear();
+            _customDocumentPropertiesDirty = false;
+            CustomFilePropertiesPart? customPart = _spreadSheetDocument.CustomFilePropertiesPart;
+            if (customPart?.Properties == null) {
+                return;
+            }
+
+            foreach (CustomDocumentProperty property in customPart.Properties.Elements<CustomDocumentProperty>()) {
+                if (string.IsNullOrWhiteSpace(property.Name?.Value)) {
+                    continue;
+                }
+
+                CustomDocumentProperties[property.Name!.Value!] = new ExcelCustomProperty(property);
+            }
+        }
+
+        internal void SaveCustomDocumentProperties() {
+            CustomFilePropertiesPart? customPart = _spreadSheetDocument.CustomFilePropertiesPart;
+            if (CustomDocumentProperties.Count == 0) {
+                if (_customDocumentPropertiesDirty && customPart != null) {
+                    _spreadSheetDocument.DeletePart(customPart);
+                }
+
+                _customDocumentPropertiesDirty = false;
+                return;
+            }
+
+            if (customPart == null) {
+                customPart = _spreadSheetDocument.AddCustomFilePropertiesPart();
+            }
+
+            customPart.Properties = new Properties();
+            int propertyId = 2;
+            foreach (var pair in CustomDocumentProperties.OrderBy(property => property.Key, StringComparer.OrdinalIgnoreCase)) {
+                CustomDocumentProperty property = pair.Value.ToOpenXml(pair.Key);
+                property.PropertyId = propertyId++;
+                customPart.Properties.Append(property);
+            }
+
+            customPart.Properties.Save();
+            _customDocumentPropertiesDirty = false;
+        }
+
+        private static ExcelCustomProperty CreateCustomProperty(object? value) {
+            if (value == null) {
+                return new ExcelCustomProperty(string.Empty);
+            }
+
+            if (value is ExcelCustomProperty customProperty) {
+                return customProperty;
+            }
+
+            if (value is bool boolean) {
+                return new ExcelCustomProperty(boolean);
+            }
+
+            if (value is DateTime dateTime) {
+                return new ExcelCustomProperty(dateTime);
+            }
+
+            if (value is DateTimeOffset dateTimeOffset) {
+                return new ExcelCustomProperty(dateTimeOffset.UtcDateTime);
+            }
+
+            if (TryConvertToInt32(value, out int integer)) {
+                return new ExcelCustomProperty(integer);
+            }
+
+            if (value is float or double or decimal) {
+                return new ExcelCustomProperty(Convert.ToDouble(value, System.Globalization.CultureInfo.InvariantCulture));
+            }
+
+            return new ExcelCustomProperty(Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty);
+        }
+
+        private static bool TryConvertToInt32(object value, out int result) {
+            switch (value) {
+                case byte byteValue:
+                    result = byteValue;
+                    return true;
+                case sbyte sbyteValue:
+                    result = sbyteValue;
+                    return true;
+                case short shortValue:
+                    result = shortValue;
+                    return true;
+                case ushort ushortValue:
+                    result = ushortValue;
+                    return true;
+                case int intValue:
+                    result = intValue;
+                    return true;
+                case long longValue when longValue >= int.MinValue && longValue <= int.MaxValue:
+                    result = (int)longValue;
+                    return true;
+                case uint uintValue when uintValue <= int.MaxValue:
+                    result = (int)uintValue;
+                    return true;
+                case ulong ulongValue when ulongValue <= int.MaxValue:
+                    result = (int)ulongValue;
+                    return true;
+                default:
+                    result = default;
+                    return false;
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.CustomDocumentProperties.cs
+++ b/OfficeIMO.Excel/ExcelDocument.CustomDocumentProperties.cs
@@ -17,6 +17,7 @@ namespace OfficeIMO.Excel {
 
             CustomDocumentProperties[name.Trim()] = property;
             _customDocumentPropertiesDirty = true;
+            DisqualifyDirectDataSetFastSaveState();
             MarkPackageDirty();
         }
 
@@ -38,6 +39,7 @@ namespace OfficeIMO.Excel {
             bool removed = CustomDocumentProperties.Remove(name.Trim());
             if (removed) {
                 _customDocumentPropertiesDirty = true;
+                DisqualifyDirectDataSetFastSaveState();
                 MarkPackageDirty();
             }
 
@@ -113,6 +115,10 @@ namespace OfficeIMO.Excel {
                 return new ExcelCustomProperty(integer);
             }
 
+            if (value is long or uint or ulong) {
+                return new ExcelCustomProperty(value, ExcelCustomPropertyType.NumberInteger);
+            }
+
             if (value is float or double or decimal) {
                 return new ExcelCustomProperty(Convert.ToDouble(value, System.Globalization.CultureInfo.InvariantCulture));
             }
@@ -150,6 +156,12 @@ namespace OfficeIMO.Excel {
                     result = default;
                     return false;
             }
+        }
+
+        private void DisqualifyDirectDataSetFastSaveState() {
+            ClearDirectDataSetSaveCandidate();
+            _materializedDirectDataSetFastSaveModel = null;
+            _materializedDirectDataSetFastSaveModelHasMaterializedWorksheet = false;
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelDocument.DateSystem.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DateSystem.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 
 namespace OfficeIMO.Excel {
@@ -24,16 +26,70 @@ namespace OfficeIMO.Excel {
                     OpenXmlWorkbookElementOrder.InsertInOrder(workbook, properties);
                 }
 
-                bool use1904 = value == ExcelDateSystem.NineteenFour;
-                if (properties.Date1904?.Value == use1904) {
+                ExcelDateSystem current = properties.Date1904?.Value == true
+                    ? ExcelDateSystem.NineteenFour
+                    : ExcelDateSystem.NineteenHundred;
+                if (current == value) {
                     return;
                 }
 
+                ConvertExistingDateSerials(current, value);
+                bool use1904 = value == ExcelDateSystem.NineteenFour;
                 properties.Date1904 = use1904 ? true : null;
                 RefreshDeferredDirectDataSetDateSystem(value);
                 WorkbookRoot.Save();
                 MarkPackageDirty();
             }
+        }
+
+        private void ConvertExistingDateSerials(ExcelDateSystem current, ExcelDateSystem target) {
+            if (current == target || _spreadSheetDocument == null) {
+                return;
+            }
+
+            StylesCache styles = StylesCache.Build(_spreadSheetDocument);
+            if (!styles.HasDateStyles) {
+                return;
+            }
+
+            double offset = target == ExcelDateSystem.NineteenFour
+                ? -ExcelDateSystemConverter.Date1904OffsetDays
+                : ExcelDateSystemConverter.Date1904OffsetDays;
+
+            foreach (WorksheetPart worksheetPart in WorkbookPartRoot.WorksheetParts) {
+                Worksheet? worksheet = worksheetPart.Worksheet;
+                if (worksheet == null) {
+                    continue;
+                }
+
+                bool changed = false;
+                foreach (Cell cell in worksheet.Descendants<Cell>()) {
+                    if (cell.CellFormula != null || !IsNumericDateCell(cell, styles)) {
+                        continue;
+                    }
+
+                    string? text = cell.CellValue?.Text;
+                    if (!double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out double serial)) {
+                        continue;
+                    }
+
+                    cell.CellValue = new CellValue((serial + offset).ToString(CultureInfo.InvariantCulture));
+                    changed = true;
+                }
+
+                if (changed) {
+                    worksheet.Save();
+                }
+            }
+        }
+
+        private static bool IsNumericDateCell(Cell cell, StylesCache styles) {
+            if (cell.StyleIndex?.Value is not uint styleIndex || !styles.IsDateLike(styleIndex)) {
+                return false;
+            }
+
+            CellValues? dataType = cell.DataType?.Value;
+            return dataType == null || dataType == CellValues.Number;
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelDocument.DateSystem.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DateSystem.cs
@@ -30,6 +30,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 properties.Date1904 = use1904 ? true : null;
+                RefreshDeferredDirectDataSetDateSystem(value);
                 WorkbookRoot.Save();
                 MarkPackageDirty();
             }

--- a/OfficeIMO.Excel/ExcelDocument.DateSystem.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DateSystem.cs
@@ -1,0 +1,38 @@
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelDocument {
+        /// <summary>
+        /// Gets or sets the workbook date system used for serialized date values.
+        /// </summary>
+        public ExcelDateSystem DateSystem {
+            get {
+                WorkbookProperties? properties = WorkbookRoot.GetFirstChild<WorkbookProperties>();
+                return properties?.Date1904?.Value == true
+                    ? ExcelDateSystem.NineteenFour
+                    : ExcelDateSystem.NineteenHundred;
+            }
+            set {
+                if (value != ExcelDateSystem.NineteenHundred && value != ExcelDateSystem.NineteenFour) {
+                    throw new ArgumentOutOfRangeException(nameof(value), value, "Unsupported Excel date system.");
+                }
+
+                Workbook workbook = WorkbookRoot;
+                WorkbookProperties? properties = workbook.GetFirstChild<WorkbookProperties>();
+                if (properties == null) {
+                    properties = new WorkbookProperties();
+                    OpenXmlWorkbookElementOrder.InsertInOrder(workbook, properties);
+                }
+
+                bool use1904 = value == ExcelDateSystem.NineteenFour;
+                if (properties.Date1904?.Value == use1904) {
+                    return;
+                }
+
+                properties.Date1904 = use1904 ? true : null;
+                WorkbookRoot.Save();
+                MarkPackageDirty();
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Materialization.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Materialization.cs
@@ -33,7 +33,8 @@ namespace OfficeIMO.Excel {
                     autoFit,
                     _dateTimeOffsetWriteStrategy,
                     ct,
-                    snapshotTables: true);
+                    snapshotTables: true,
+                    dateSystem: DateSystem);
                 _directDataSetSaveCandidate = new DirectDataSetSaveCandidate(dataSet, model, MaterializeDeferredDataSetImport, isDeferred: true, subscribeToSourceChanges: false);
                 _directDataSetMetadataSourceSheet = null;
                 _packageDirty = true;
@@ -165,19 +166,29 @@ namespace OfficeIMO.Excel {
                 ResetWorksheetForDirectDataSetMaterialization(sheet.WorksheetPart);
                 using var noLock = sheet.BeginNoLock();
                 if (sheetModel.HasTable) {
-                    string materializedRange = sheet.InsertTabularRowSourceAsTableForDeferredMaterialization(
+                    string tableRange = sheet.InsertTabularRowSourceAsTableForDeferredMaterialization(
                         sheetModel.Table,
                         includeHeaders: sheetModel.IncludeHeaders,
                         tableName: sheetModel.TableName,
                         style: sheetModel.TableStyle,
                         includeAutoFilter: sheetModel.IncludeAutoFilter);
-                    if (materializedRange.Length == 0) {
-                        sheet.InsertDataTableAsTable(
+                    if (tableRange.Length == 0) {
+                        tableRange = sheet.InsertDataTableAsTable(
                             sheetModel.Table.ToDataTable(),
                             includeHeaders: sheetModel.IncludeHeaders,
                             tableName: sheetModel.TableName,
                             style: sheetModel.TableStyle,
                             includeAutoFilter: sheetModel.IncludeAutoFilter);
+                    }
+
+                    if (tableRange.Length > 0) {
+                        sheet.SetTableStyle(
+                            tableRange,
+                            sheetModel.TableStyle,
+                            sheetModel.ShowFirstColumn,
+                            sheetModel.ShowLastColumn,
+                            sheetModel.ShowRowStripes,
+                            sheetModel.ShowColumnStripes);
                     }
                 } else {
                     if (!sheet.TryInsertTabularRowSourceForDeferredMaterialization(
@@ -196,7 +207,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 ApplyDirectMaterializedColumnNumberFormats(sheet, sheetModel);
-                ApplyCapturedDirectWorksheetMetadata(sheet.WorksheetPart.Worksheet!, preservedMetadata);
+                ApplyCapturedDirectWorksheetMetadata(sheet.WorksheetPart.Worksheet!, preservedMetadata, DateSystem);
             }
         }
 
@@ -221,7 +232,7 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        private static void ApplyCapturedDirectWorksheetMetadata(Worksheet worksheet, DirectWorksheetMetadata? metadata) {
+        private static void ApplyCapturedDirectWorksheetMetadata(Worksheet worksheet, DirectWorksheetMetadata? metadata, ExcelDateSystem dateSystem) {
             if (metadata == null || metadata.IsEmpty) {
                 return;
             }
@@ -236,6 +247,10 @@ namespace OfficeIMO.Excel {
 
             if (!string.IsNullOrEmpty(metadata.SheetFormatPropertiesXml)) {
                 InsertWorksheetMetadataElement(worksheet, CreateElementWithAttributes<SheetFormatProperties>(metadata.SheetFormatPropertiesXml!), typeof(Columns), typeof(SheetData));
+            }
+
+            if (!string.IsNullOrEmpty(metadata.SheetProtectionXml)) {
+                InsertWorksheetMetadataElement(worksheet, CreateElementWithAttributes<SheetProtection>(metadata.SheetProtectionXml!), typeof(AutoFilter), typeof(DocumentFormat.OpenXml.Spreadsheet.ConditionalFormatting), typeof(DataValidations), typeof(TableParts));
             }
 
             if (!string.IsNullOrEmpty(metadata.AutoFilterXml)) {
@@ -261,10 +276,10 @@ namespace OfficeIMO.Excel {
                 InsertWorksheetMetadataElement(worksheet, CreateElementWithAttributes<DocumentFormat.OpenXml.Spreadsheet.Drawing>(metadata.DrawingXml!), typeof(TableParts));
             }
 
-            ApplyCapturedDirectOverlayCells(worksheet, metadata.OverlayCells);
+            ApplyCapturedDirectOverlayCells(worksheet, metadata.OverlayCells, dateSystem);
         }
 
-        private static void ApplyCapturedDirectOverlayCells(Worksheet worksheet, IReadOnlyList<DirectOverlayCell> overlayCells) {
+        private static void ApplyCapturedDirectOverlayCells(Worksheet worksheet, IReadOnlyList<DirectOverlayCell> overlayCells, ExcelDateSystem dateSystem) {
             if (overlayCells.Count == 0) {
                 return;
             }
@@ -278,7 +293,7 @@ namespace OfficeIMO.Excel {
                 Row row = GetOrCreateDirectOverlayRow(sheetData, overlayCell.Row);
                 Cell cell = GetOrCreateDirectOverlayCell(row, overlayCell.Row, overlayCell.Column);
                 cell.StyleIndex = overlayCell.StyleIndex.HasValue ? overlayCell.StyleIndex.Value : null;
-                ApplyCapturedDirectOverlayCellValue(cell, overlayCell.Value);
+                ApplyCapturedDirectOverlayCellValue(cell, overlayCell.Value, dateSystem);
             }
         }
 
@@ -348,7 +363,7 @@ namespace OfficeIMO.Excel {
             return created;
         }
 
-        private static void ApplyCapturedDirectOverlayCellValue(Cell cell, object? value) {
+        private static void ApplyCapturedDirectOverlayCellValue(Cell cell, object? value, ExcelDateSystem dateSystem) {
             cell.CellFormula = null;
             cell.InlineString = null;
 
@@ -410,7 +425,7 @@ namespace OfficeIMO.Excel {
                     ApplyCapturedDirectOverlayNumber(cell, number);
                     break;
                 case DateTime dateTime:
-                    ApplyCapturedDirectOverlayNumber(cell, dateTime.ToOADate());
+                    ApplyCapturedDirectOverlayNumber(cell, ExcelDateSystemConverter.ToSerial(dateTime, dateSystem));
                     break;
                 default:
                     cell.CellValue = new CellValue(Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty);

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Materialization.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Materialization.cs
@@ -150,6 +150,17 @@ namespace OfficeIMO.Excel {
 
         internal bool HasPendingDirectCellValues => _pendingDirectCellValueSheet != null;
 
+        internal void RefreshDeferredDirectDataSetDateSystem(ExcelDateSystem dateSystem) {
+            var candidate = _directDataSetSaveCandidate;
+            if (candidate == null || !candidate.IsDeferred || !candidate.IsValid) {
+                return;
+            }
+
+            var updated = candidate.WithModel(candidate.Model.WithDateSystem(dateSystem));
+            _directDataSetSaveCandidate = updated;
+            candidate.Dispose();
+        }
+
         private void MaterializeDirectDataSetModel(DirectDataSetWorkbookModel model) {
             foreach (var sheetModel in model.Sheets) {
                 ExcelSheet sheet = TryGetExistingSheet(sheetModel.SheetName)

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Metadata.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Metadata.cs
@@ -61,6 +61,51 @@ namespace OfficeIMO.Excel {
             return _directDataSetSaveCandidate != null && _directDataSetSaveCandidate.IsValid;
         }
 
+        internal bool TrySetDirectTableStyleMetadata(
+            ExcelSheet sheet,
+            string tableOrRange,
+            TableStyle tableStyle,
+            bool? showFirstColumn,
+            bool? showLastColumn,
+            bool? showRowStripes,
+            bool? showColumnStripes) {
+            if (sheet == null) throw new ArgumentNullException(nameof(sheet));
+            if (string.IsNullOrEmpty(tableOrRange)) throw new ArgumentNullException(nameof(tableOrRange));
+            if (!ReferenceEquals(sheet.Document, this)) {
+                return false;
+            }
+
+            var candidate = _directDataSetSaveCandidate;
+            if (candidate == null || !candidate.IsValid) {
+                return false;
+            }
+
+            if (!candidate.Model.TryWithTableStyle(
+                sheet.Name,
+                tableOrRange,
+                tableStyle,
+                showFirstColumn,
+                showLastColumn,
+                showRowStripes,
+                showColumnStripes,
+                out var model)) {
+                return false;
+            }
+
+            _directDataSetSaveCandidate = new DirectDataSetSaveCandidate(
+                candidate.Owner,
+                model,
+                candidate.InvalidateCallback,
+                candidate.IsDeferred,
+                candidate.SubscribesToSourceChanges);
+            _directDataSetMetadataSourceSheet = sheet;
+            candidate.Dispose();
+            _packageDirty = true;
+            _unchangedPackageBytes = null;
+            _requiresSavePreflight = false;
+            return _directDataSetSaveCandidate != null && _directDataSetSaveCandidate.IsValid;
+        }
+
         internal bool TryApplyDirectWorksheetFreezeMetadata(ExcelSheet sheet, int topRows, int leftCols) {
             if (sheet == null) throw new ArgumentNullException(nameof(sheet));
             if (topRows < 0) throw new ArgumentOutOfRangeException(nameof(topRows));
@@ -373,7 +418,8 @@ namespace OfficeIMO.Excel {
                     includeAutoFilter,
                     autoFit,
                     _dateTimeOffsetWriteStrategy,
-                    CancellationToken.None);
+                    CancellationToken.None,
+                    dateSystem: DateSystem);
                 _directDataSetSaveCandidate = new DirectDataSetSaveCandidate(DirectTabularSnapshotOwner, model, MaterializeDeferredDataSetImport, isDeferred: true, subscribeToSourceChanges: false);
                 _directDataSetMetadataSourceSheet = sheet;
                 _packageDirty = true;
@@ -426,7 +472,8 @@ namespace OfficeIMO.Excel {
                     includeAutoFilter,
                     autoFit,
                     _dateTimeOffsetWriteStrategy,
-                    CancellationToken.None);
+                    CancellationToken.None,
+                    dateSystem: DateSystem);
                 _directDataSetSaveCandidate = new DirectDataSetSaveCandidate(DirectTabularSnapshotOwner, model, MaterializeDeferredDataSetImport, isDeferred: true, subscribeToSourceChanges: false);
                 _directDataSetMetadataSourceSheet = sheet;
                 _packageDirty = true;
@@ -479,7 +526,8 @@ namespace OfficeIMO.Excel {
                     includeAutoFilter,
                     autoFit,
                     _dateTimeOffsetWriteStrategy,
-                    CancellationToken.None);
+                    CancellationToken.None,
+                    dateSystem: DateSystem);
                 _directDataSetSaveCandidate = new DirectDataSetSaveCandidate(DirectTabularSnapshotOwner, model, MaterializeDeferredDataSetImport, isDeferred: true, subscribeToSourceChanges: false);
                 _directDataSetMetadataSourceSheet = sheet;
                 _packageDirty = true;

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Models.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Models.cs
@@ -29,6 +29,12 @@ namespace OfficeIMO.Excel {
 
             internal ExcelDateSystem DateSystem { get; }
 
+            internal DirectDataSetWorkbookModel WithDateSystem(ExcelDateSystem dateSystem) {
+                return dateSystem == DateSystem
+                    ? this
+                    : new DirectDataSetWorkbookModel(Sheets, Results, DateTimeOffsetWriteStrategy, dateSystem);
+            }
+
             internal DirectDataSetWorkbookModel WithWorksheetMetadata(IReadOnlyList<DirectWorksheetMetadata?> metadata) {
                 if (metadata == null) throw new ArgumentNullException(nameof(metadata));
                 if (metadata.Count != Sheets.Count) {

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Models.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Models.cs
@@ -13,10 +13,12 @@ namespace OfficeIMO.Excel {
             private DirectDataSetWorkbookModel(
                 IReadOnlyList<DirectDataSetSheetModel> sheets,
                 IReadOnlyList<ExcelDataSetImportResult> results,
-                Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy) {
+                Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy,
+                ExcelDateSystem dateSystem = ExcelDateSystem.NineteenHundred) {
                 Sheets = sheets;
                 Results = results;
                 DateTimeOffsetWriteStrategy = dateTimeOffsetWriteStrategy;
+                DateSystem = dateSystem;
             }
 
             internal IReadOnlyList<DirectDataSetSheetModel> Sheets { get; }
@@ -24,6 +26,8 @@ namespace OfficeIMO.Excel {
             internal IReadOnlyList<ExcelDataSetImportResult> Results { get; }
 
             internal Func<DateTimeOffset, DateTime> DateTimeOffsetWriteStrategy { get; }
+
+            internal ExcelDateSystem DateSystem { get; }
 
             internal DirectDataSetWorkbookModel WithWorksheetMetadata(IReadOnlyList<DirectWorksheetMetadata?> metadata) {
                 if (metadata == null) throw new ArgumentNullException(nameof(metadata));
@@ -36,7 +40,7 @@ namespace OfficeIMO.Excel {
                     sheets[i] = Sheets[i].WithMetadata(metadata[i]);
                 }
 
-                return new DirectDataSetWorkbookModel(sheets, Results, DateTimeOffsetWriteStrategy);
+                return new DirectDataSetWorkbookModel(sheets, Results, DateTimeOffsetWriteStrategy, DateSystem);
             }
 
             internal DirectDataSetWorkbookModel WithAutoFitColumns(
@@ -72,10 +76,14 @@ namespace OfficeIMO.Excel {
                         columnWidths,
                         sheet.UseCellValueNumberFormats,
                         sheet.Metadata,
-                        sheet.ColumnNumberFormats);
+                        sheet.ColumnNumberFormats,
+                        sheet.ShowFirstColumn,
+                        sheet.ShowLastColumn,
+                        sheet.ShowRowStripes,
+                        sheet.ShowColumnStripes);
                 }
 
-                return new DirectDataSetWorkbookModel(sheets, Results, dateTimeOffsetWriteStrategy ?? DateTimeOffsetWriteStrategy);
+                return new DirectDataSetWorkbookModel(sheets, Results, dateTimeOffsetWriteStrategy ?? DateTimeOffsetWriteStrategy, DateSystem);
             }
 
             internal DirectDataSetWorkbookModel WithTableAutoFilter(string sheetName, bool includeAutoFilter) {
@@ -102,10 +110,43 @@ namespace OfficeIMO.Excel {
                         sheet.ColumnWidths,
                         sheet.UseCellValueNumberFormats,
                         sheet.Metadata,
-                        sheet.ColumnNumberFormats);
+                        sheet.ColumnNumberFormats,
+                        sheet.ShowFirstColumn,
+                        sheet.ShowLastColumn,
+                        sheet.ShowRowStripes,
+                        sheet.ShowColumnStripes);
                 }
 
-                return new DirectDataSetWorkbookModel(sheets, Results, DateTimeOffsetWriteStrategy);
+                return new DirectDataSetWorkbookModel(sheets, Results, DateTimeOffsetWriteStrategy, DateSystem);
+            }
+
+            internal bool TryWithTableStyle(
+                string sheetName,
+                string tableOrRange,
+                TableStyle tableStyle,
+                bool? showFirstColumn,
+                bool? showLastColumn,
+                bool? showRowStripes,
+                bool? showColumnStripes,
+                out DirectDataSetWorkbookModel model) {
+                var sheets = new DirectDataSetSheetModel[Sheets.Count];
+                bool matched = false;
+                for (int i = 0; i < Sheets.Count; i++) {
+                    var sheet = Sheets[i];
+                    if (!matched
+                        && sheet.HasTable
+                        && string.Equals(sheet.SheetName, sheetName, StringComparison.Ordinal)
+                        && (string.Equals(sheet.Range, tableOrRange, StringComparison.OrdinalIgnoreCase)
+                            || string.Equals(sheet.TableName, tableOrRange, StringComparison.OrdinalIgnoreCase))) {
+                        sheets[i] = sheet.WithTableStyle(tableStyle, showFirstColumn, showLastColumn, showRowStripes, showColumnStripes);
+                        matched = true;
+                    } else {
+                        sheets[i] = sheet;
+                    }
+                }
+
+                model = matched ? new DirectDataSetWorkbookModel(sheets, Results, DateTimeOffsetWriteStrategy, DateSystem) : this;
+                return matched;
             }
 
             internal DirectDataSetWorkbookModel WithAutoFitColumns(
@@ -155,10 +196,14 @@ namespace OfficeIMO.Excel {
                         columnWidths,
                         sheet.UseCellValueNumberFormats,
                         sheet.Metadata,
-                        sheet.ColumnNumberFormats);
+                        sheet.ColumnNumberFormats,
+                        sheet.ShowFirstColumn,
+                        sheet.ShowLastColumn,
+                        sheet.ShowRowStripes,
+                        sheet.ShowColumnStripes);
                 }
 
-                return new DirectDataSetWorkbookModel(sheets, Results, dateTimeOffsetWriteStrategy ?? DateTimeOffsetWriteStrategy);
+                return new DirectDataSetWorkbookModel(sheets, Results, dateTimeOffsetWriteStrategy ?? DateTimeOffsetWriteStrategy, DateSystem);
             }
 
             internal DirectDataSetWorkbookModel WithTable(
@@ -205,11 +250,15 @@ namespace OfficeIMO.Excel {
                         columnWidths,
                         sheet.UseCellValueNumberFormats,
                         sheet.Metadata,
-                        sheet.ColumnNumberFormats);
+                        sheet.ColumnNumberFormats,
+                        sheet.ShowFirstColumn,
+                        sheet.ShowLastColumn,
+                        sheet.ShowRowStripes,
+                        sheet.ShowColumnStripes);
                     results[i] = new ExcelDataSetImportResult(sheet.SheetName, tableName, sheet.Range, table.RowCount, table.ColumnCount);
                 }
 
-                return new DirectDataSetWorkbookModel(sheets, results, dateTimeOffsetWriteStrategy ?? DateTimeOffsetWriteStrategy);
+                return new DirectDataSetWorkbookModel(sheets, results, dateTimeOffsetWriteStrategy ?? DateTimeOffsetWriteStrategy, DateSystem);
             }
 
             internal DirectDataSetWorkbookModel WithColumnNumberFormat(string sheetName, int columnIndex, string numberFormat) {
@@ -221,7 +270,7 @@ namespace OfficeIMO.Excel {
                         : sheet;
                 }
 
-                return new DirectDataSetWorkbookModel(sheets, Results, DateTimeOffsetWriteStrategy);
+                return new DirectDataSetWorkbookModel(sheets, Results, DateTimeOffsetWriteStrategy, DateSystem);
             }
 
 
@@ -236,7 +285,8 @@ namespace OfficeIMO.Excel {
                 CancellationToken ct,
                 IReadOnlyList<ExcelDataSetImportResult>? importResults = null,
                 bool snapshotTables = false,
-                bool omitBlankCells = false) {
+                bool omitBlankCells = false,
+                ExcelDateSystem dateSystem = ExcelDateSystem.NineteenHundred) {
                 var sheets = new List<DirectDataSetSheetModel>();
                 var results = new List<ExcelDataSetImportResult>();
                 var usedSheetNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -277,7 +327,7 @@ namespace OfficeIMO.Excel {
                     index++;
                 }
 
-                return new DirectDataSetWorkbookModel(sheets, results, dateTimeOffsetWriteStrategy ?? DefaultDateTimeOffsetWriteStrategy);
+                return new DirectDataSetWorkbookModel(sheets, results, dateTimeOffsetWriteStrategy ?? DefaultDateTimeOffsetWriteStrategy, dateSystem);
             }
 
             internal static DirectDataSetWorkbookModel CreateSingle(
@@ -293,7 +343,8 @@ namespace OfficeIMO.Excel {
                 bool autoFit,
                 Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy,
                 CancellationToken ct,
-                bool useCellValueNumberFormats = false) {
+                bool useCellValueNumberFormats = false,
+                ExcelDateSystem dateSystem = ExcelDateSystem.NineteenHundred) {
                 int rowCount = tableModel.RowCount + (includeHeaders ? 1 : 0);
                 ValidateWorksheetBounds(tableModel, rowCount, requestedName);
                 bool hasTable = createTable && range.Length > 0;
@@ -305,7 +356,7 @@ namespace OfficeIMO.Excel {
                     : null;
                 var sheet = new DirectDataSetSheetModel(1, sheetName, resolvedTableName, range, tableModel, tableStyle, includeHeaders, includeAutoFilter, hasTable, autoFit, omitBlankCells: false, columnWidths: columnWidths, useCellValueNumberFormats: useCellValueNumberFormats);
                 var result = new ExcelDataSetImportResult(sheetName, resolvedTableName, range, tableModel.RowCount, tableModel.ColumnCount);
-                return new DirectDataSetWorkbookModel([sheet], [result], dateTimeOffsetWriteStrategy ?? DefaultDateTimeOffsetWriteStrategy);
+                return new DirectDataSetWorkbookModel([sheet], [result], dateTimeOffsetWriteStrategy ?? DefaultDateTimeOffsetWriteStrategy, dateSystem);
             }
 
             private static string GetUniqueSheetName(string baseName, HashSet<string> used) {
@@ -426,7 +477,11 @@ namespace OfficeIMO.Excel {
                 double[]? columnWidths,
                 bool useCellValueNumberFormats = false,
                 DirectWorksheetMetadata? metadata = null,
-                IReadOnlyList<string?>? columnNumberFormats = null) {
+                IReadOnlyList<string?>? columnNumberFormats = null,
+                bool showFirstColumn = false,
+                bool showLastColumn = false,
+                bool showRowStripes = true,
+                bool showColumnStripes = false) {
                 Index = index;
                 SheetName = sheetName;
                 TableName = tableName;
@@ -442,6 +497,10 @@ namespace OfficeIMO.Excel {
                 UseCellValueNumberFormats = useCellValueNumberFormats;
                 Metadata = metadata;
                 ColumnNumberFormats = columnNumberFormats;
+                ShowFirstColumn = showFirstColumn;
+                ShowLastColumn = showLastColumn;
+                ShowRowStripes = showRowStripes;
+                ShowColumnStripes = showColumnStripes;
             }
 
             internal DirectDataSetSheetModel WithMetadata(DirectWorksheetMetadata? metadata) {
@@ -464,7 +523,39 @@ namespace OfficeIMO.Excel {
                     ColumnWidths,
                     UseCellValueNumberFormats,
                     metadata,
-                    ColumnNumberFormats);
+                    ColumnNumberFormats,
+                    ShowFirstColumn,
+                    ShowLastColumn,
+                    ShowRowStripes,
+                    ShowColumnStripes);
+            }
+
+            internal DirectDataSetSheetModel WithTableStyle(
+                TableStyle tableStyle,
+                bool? showFirstColumn,
+                bool? showLastColumn,
+                bool? showRowStripes,
+                bool? showColumnStripes) {
+                return new DirectDataSetSheetModel(
+                    Index,
+                    SheetName,
+                    TableName,
+                    Range,
+                    Table,
+                    tableStyle,
+                    IncludeHeaders,
+                    IncludeAutoFilter,
+                    HasTable,
+                    AutoFitColumns,
+                    OmitBlankCells,
+                    ColumnWidths,
+                    UseCellValueNumberFormats,
+                    Metadata,
+                    ColumnNumberFormats,
+                    showFirstColumn ?? ShowFirstColumn,
+                    showLastColumn ?? ShowLastColumn,
+                    showRowStripes ?? ShowRowStripes,
+                    showColumnStripes ?? ShowColumnStripes);
             }
 
             internal DirectDataSetSheetModel WithColumnNumberFormat(int columnIndex, string numberFormat) {
@@ -498,7 +589,11 @@ namespace OfficeIMO.Excel {
                     ColumnWidths,
                     UseCellValueNumberFormats,
                     Metadata,
-                    formats);
+                    formats,
+                    ShowFirstColumn,
+                    ShowLastColumn,
+                    ShowRowStripes,
+                    ShowColumnStripes);
             }
 
             internal int Index { get; }
@@ -530,10 +625,19 @@ namespace OfficeIMO.Excel {
             internal DirectWorksheetMetadata? Metadata { get; }
 
             internal IReadOnlyList<string?>? ColumnNumberFormats { get; }
+
+            internal bool ShowFirstColumn { get; }
+
+            internal bool ShowLastColumn { get; }
+
+            internal bool ShowRowStripes { get; }
+
+            internal bool ShowColumnStripes { get; }
         }
 
         private sealed class DirectWorksheetMetadata {
             internal static readonly DirectWorksheetMetadata Empty = new(
+                null,
                 null,
                 null,
                 null,
@@ -548,6 +652,7 @@ namespace OfficeIMO.Excel {
                 string? sheetPropertiesXml,
                 string? sheetViewsXml,
                 string? sheetFormatPropertiesXml,
+                string? sheetProtectionXml,
                 string? autoFilterXml,
                 IReadOnlyList<string> conditionalFormattingXml,
                 string? dataValidationsXml,
@@ -557,6 +662,7 @@ namespace OfficeIMO.Excel {
                 SheetPropertiesXml = sheetPropertiesXml;
                 SheetViewsXml = sheetViewsXml;
                 SheetFormatPropertiesXml = sheetFormatPropertiesXml;
+                SheetProtectionXml = sheetProtectionXml;
                 AutoFilterXml = autoFilterXml;
                 ConditionalFormattingXml = conditionalFormattingXml ?? Array.Empty<string>();
                 DataValidationsXml = dataValidationsXml;
@@ -574,6 +680,7 @@ namespace OfficeIMO.Excel {
                     SheetPropertiesXml,
                     sheetViewsXml,
                     SheetFormatPropertiesXml,
+                    SheetProtectionXml,
                     AutoFilterXml,
                     ConditionalFormattingXml,
                     DataValidationsXml,
@@ -591,6 +698,7 @@ namespace OfficeIMO.Excel {
                     SheetPropertiesXml,
                     SheetViewsXml,
                     SheetFormatPropertiesXml,
+                    SheetProtectionXml,
                     autoFilterXml,
                     ConditionalFormattingXml,
                     DataValidationsXml,
@@ -604,6 +712,8 @@ namespace OfficeIMO.Excel {
             internal string? SheetViewsXml { get; }
 
             internal string? SheetFormatPropertiesXml { get; }
+
+            internal string? SheetProtectionXml { get; }
 
             internal string? AutoFilterXml { get; }
 
@@ -621,6 +731,7 @@ namespace OfficeIMO.Excel {
                 => SheetPropertiesXml == null
                    && SheetViewsXml == null
                    && SheetFormatPropertiesXml == null
+                   && SheetProtectionXml == null
                 && AutoFilterXml == null
                 && ConditionalFormattingXml.Count == 0
                 && DataValidationsXml == null

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Package.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Package.cs
@@ -212,6 +212,7 @@ namespace OfficeIMO.Excel {
                         existing.SheetPropertiesXml,
                         existing.SheetViewsXml,
                         existing.SheetFormatPropertiesXml,
+                        existing.SheetProtectionXml,
                         existing.AutoFilterXml,
                         existing.ConditionalFormattingXml,
                         existing.DataValidationsXml,
@@ -230,6 +231,7 @@ namespace OfficeIMO.Excel {
                 existing.SheetPropertiesXml ?? captured.SheetPropertiesXml,
                 existing.SheetViewsXml ?? captured.SheetViewsXml,
                 existing.SheetFormatPropertiesXml ?? captured.SheetFormatPropertiesXml,
+                existing.SheetProtectionXml ?? captured.SheetProtectionXml,
                 existing.AutoFilterXml ?? captured.AutoFilterXml,
                 CombineMetadataXmlLists(existing.ConditionalFormattingXml, captured.ConditionalFormattingXml),
                 existing.DataValidationsXml ?? captured.DataValidationsXml,
@@ -264,6 +266,7 @@ namespace OfficeIMO.Excel {
                         metadata.SheetPropertiesXml,
                         metadata.SheetViewsXml,
                         metadata.SheetFormatPropertiesXml,
+                        metadata.SheetProtectionXml,
                         metadata.AutoFilterXml,
                         metadata.ConditionalFormattingXml,
                         metadata.DataValidationsXml,
@@ -389,6 +392,7 @@ namespace OfficeIMO.Excel {
             string? sheetPropertiesXml = null;
             string? sheetViewsXml = null;
             string? sheetFormatPropertiesXml = null;
+            string? sheetProtectionXml = null;
             string? autoFilterXml = null;
             string? dataValidationsXml = null;
             string? drawingXml = null;
@@ -412,6 +416,9 @@ namespace OfficeIMO.Excel {
                         break;
                     case SheetFormatProperties sheetFormatProperties when sheetFormatPropertiesXml == null:
                         sheetFormatPropertiesXml = sheetFormatProperties.OuterXml;
+                        break;
+                    case SheetProtection sheetProtection when sheetProtectionXml == null:
+                        sheetProtectionXml = sheetProtection.OuterXml;
                         break;
                     case Columns when sheetModel.ColumnWidths is { Length: > 0 }:
                         break;
@@ -453,6 +460,7 @@ namespace OfficeIMO.Excel {
             if (sheetPropertiesXml == null
                 && sheetViewsXml == null
                 && sheetFormatPropertiesXml == null
+                && sheetProtectionXml == null
                 && autoFilterXml == null
                 && dataValidationsXml == null
                 && drawingXml == null
@@ -466,6 +474,7 @@ namespace OfficeIMO.Excel {
                 sheetPropertiesXml,
                 sheetViewsXml,
                 sheetFormatPropertiesXml,
+                sheetProtectionXml,
                 autoFilterXml,
                 conditionalFormattingXml?.ToArray() ?? Array.Empty<string>(),
                 dataValidationsXml,

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.SaveCandidate.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.SaveCandidate.cs
@@ -50,6 +50,10 @@ namespace OfficeIMO.Excel {
 
             internal bool IsValid { get; private set; } = true;
 
+            internal DirectDataSetSaveCandidate WithModel(DirectDataSetWorkbookModel model) {
+                return new DirectDataSetSaveCandidate(_dataSet, model, _invalidate, IsDeferred, _subscribed);
+            }
+
             private void Subscribe(DataSet dataSet) {
                 dataSet.Tables.CollectionChanged += OnCollectionChanged;
                 foreach (DataTable table in dataSet.Tables) {

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Writer.Cells.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Writer.Cells.cs
@@ -17,11 +17,12 @@ namespace OfficeIMO.Excel {
                 DirectCellValueKind cellValueKind,
                 bool useCellValueNumberFormats,
                 Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy,
+                ExcelDateSystem dateSystem,
                 DirectSharedStringTable? sharedStrings) {
                 if (valueStyleColumn) {
-                    WriteCell(writer, rowReference, cellReferencePrefix, value, styleAttribute, valueStyleColumn, cellValueKind, useCellValueNumberFormats, dateTimeOffsetWriteStrategy, sharedStrings);
+                    WriteCell(writer, rowReference, cellReferencePrefix, value, styleAttribute, valueStyleColumn, cellValueKind, useCellValueNumberFormats, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                 } else {
-                    WriteCell(writer, rowReference, cellReferencePrefix, value, styleAttribute, cellValueKind, dateTimeOffsetWriteStrategy, sharedStrings);
+                    WriteCell(writer, rowReference, cellReferencePrefix, value, styleAttribute, cellValueKind, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                 }
             }
 
@@ -43,7 +44,7 @@ namespace OfficeIMO.Excel {
                 }
             }
 
-            private static void WriteCell(TextWriter writer, string rowReference, string cellReferencePrefix, object? value, string? styleAttribute, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy, DirectSharedStringTable? sharedStrings) {
+            private static void WriteCell(TextWriter writer, string rowReference, string cellReferencePrefix, object? value, string? styleAttribute, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy, ExcelDateSystem dateSystem, DirectSharedStringTable? sharedStrings) {
                 writer.Write(cellReferencePrefix);
                 writer.Write(rowReference);
                 writer.Write('"');
@@ -51,10 +52,10 @@ namespace OfficeIMO.Excel {
                     writer.Write(styleAttribute);
                 }
 
-                WriteCellValue(writer, value, dateTimeOffsetWriteStrategy, sharedStrings);
+                WriteCellValue(writer, value, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
             }
 
-            private static void WriteCell(TextWriter writer, string rowReference, string cellReferencePrefix, object? value, string? styleAttribute, DirectCellValueKind cellValueKind, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy, DirectSharedStringTable? sharedStrings) {
+            private static void WriteCell(TextWriter writer, string rowReference, string cellReferencePrefix, object? value, string? styleAttribute, DirectCellValueKind cellValueKind, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy, ExcelDateSystem dateSystem, DirectSharedStringTable? sharedStrings) {
                 writer.Write(cellReferencePrefix);
                 writer.Write(rowReference);
                 writer.Write('"');
@@ -62,10 +63,10 @@ namespace OfficeIMO.Excel {
                     writer.Write(styleAttribute);
                 }
 
-                WriteCellValue(writer, value, cellValueKind, dateTimeOffsetWriteStrategy, sharedStrings);
+                WriteCellValue(writer, value, cellValueKind, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
             }
 
-            private static void WriteCell(TextWriter writer, string rowReference, string cellReferencePrefix, object? value, string? styleAttribute, bool useValueStyle, DirectCellValueKind cellValueKind, bool useCellValueNumberFormats, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy, DirectSharedStringTable? sharedStrings) {
+            private static void WriteCell(TextWriter writer, string rowReference, string cellReferencePrefix, object? value, string? styleAttribute, bool useValueStyle, DirectCellValueKind cellValueKind, bool useCellValueNumberFormats, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy, ExcelDateSystem dateSystem, DirectSharedStringTable? sharedStrings) {
                 writer.Write(cellReferencePrefix);
                 writer.Write(rowReference);
                 writer.Write('"');
@@ -75,13 +76,13 @@ namespace OfficeIMO.Excel {
                 }
 
                 if (useValueStyle) {
-                    WriteCellValue(writer, value, dateTimeOffsetWriteStrategy, sharedStrings);
+                    WriteCellValue(writer, value, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                 } else {
-                    WriteCellValue(writer, value, cellValueKind, dateTimeOffsetWriteStrategy, sharedStrings);
+                    WriteCellValue(writer, value, cellValueKind, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                 }
             }
 
-            private static void WriteCellValue(TextWriter writer, object? value, DirectCellValueKind cellValueKind, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy, DirectSharedStringTable? sharedStrings) {
+            private static void WriteCellValue(TextWriter writer, object? value, DirectCellValueKind cellValueKind, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy, ExcelDateSystem dateSystem, DirectSharedStringTable? sharedStrings) {
                 if (value == null || value == DBNull.Value) {
                     writer.Write(" t=\"str\"><v/></c>");
                     return;
@@ -118,14 +119,14 @@ namespace OfficeIMO.Excel {
                         break;
                     case DirectCellValueKind.DateTime:
                         if (value is DateTime dateTime) {
-                            WriteRawValueCell(writer, dateTime.ToOADate());
+                            WriteRawValueCell(writer, ExcelDateSystemConverter.ToSerial(dateTime, dateSystem));
                             return;
                         }
 
                         break;
                     case DirectCellValueKind.DateTimeOffset:
                         if (value is DateTimeOffset dateTimeOffset) {
-                            WriteDateTimeOffsetCellValue(writer, dateTimeOffset, dateTimeOffsetWriteStrategy);
+                            WriteDateTimeOffsetCellValue(writer, dateTimeOffset, dateTimeOffsetWriteStrategy, dateSystem);
                             return;
                         }
 
@@ -217,7 +218,7 @@ namespace OfficeIMO.Excel {
 #if NET6_0_OR_GREATER
                     case DirectCellValueKind.DateOnly:
                         if (value is DateOnly dateOnly) {
-                            WriteRawValueCell(writer, dateOnly.ToDateTime(TimeOnly.MinValue).ToOADate());
+                            WriteRawValueCell(writer, ExcelDateSystemConverter.ToSerial(dateOnly.ToDateTime(TimeOnly.MinValue), dateSystem));
                             return;
                         }
 
@@ -232,10 +233,10 @@ namespace OfficeIMO.Excel {
 #endif
                 }
 
-                WriteCellValue(writer, value, dateTimeOffsetWriteStrategy, sharedStrings);
+                WriteCellValue(writer, value, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
             }
 
-            private static void WriteCellValue(TextWriter writer, object? value, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy, DirectSharedStringTable? sharedStrings) {
+            private static void WriteCellValue(TextWriter writer, object? value, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy, ExcelDateSystem dateSystem, DirectSharedStringTable? sharedStrings) {
                 switch (value) {
                     case null:
                     case DBNull:
@@ -254,10 +255,10 @@ namespace OfficeIMO.Excel {
                         writer.Write(boolValue ? " t=\"b\"><v>1</v></c>" : " t=\"b\"><v>0</v></c>");
                         return;
                     case DateTime dateTime:
-                        WriteRawValueCell(writer, dateTime.ToOADate());
+                        WriteRawValueCell(writer, ExcelDateSystemConverter.ToSerial(dateTime, dateSystem));
                         return;
                     case DateTimeOffset dateTimeOffset:
-                        WriteDateTimeOffsetCellValue(writer, dateTimeOffset, dateTimeOffsetWriteStrategy);
+                        WriteDateTimeOffsetCellValue(writer, dateTimeOffset, dateTimeOffsetWriteStrategy, dateSystem);
                         return;
                     case TimeSpan timeSpan:
                         WriteRawValueCell(writer, timeSpan.TotalDays);
@@ -297,7 +298,7 @@ namespace OfficeIMO.Excel {
                         return;
 #if NET6_0_OR_GREATER
                     case DateOnly dateOnly:
-                        WriteRawValueCell(writer, dateOnly.ToDateTime(TimeOnly.MinValue).ToOADate());
+                        WriteRawValueCell(writer, ExcelDateSystemConverter.ToSerial(dateOnly.ToDateTime(TimeOnly.MinValue), dateSystem));
                         return;
                     case TimeOnly timeOnly:
                         WriteRawValueCell(writer, timeOnly.ToTimeSpan().TotalDays);
@@ -357,8 +358,8 @@ namespace OfficeIMO.Excel {
                 }
             }
 
-            private static void WriteDateTimeOffsetCellValue(TextWriter writer, DateTimeOffset value, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy) {
-                if (!TryGetDateTimeOffsetSerial(value, dateTimeOffsetWriteStrategy, out double dateTimeOffsetSerial)) {
+            private static void WriteDateTimeOffsetCellValue(TextWriter writer, DateTimeOffset value, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy, ExcelDateSystem dateSystem) {
+                if (!TryGetDateTimeOffsetSerial(value, dateTimeOffsetWriteStrategy, dateSystem, out double dateTimeOffsetSerial)) {
                     WriteStringCell(writer, value.ToString("o", CultureInfo.InvariantCulture), validateLength: true);
                     return;
                 }
@@ -366,14 +367,14 @@ namespace OfficeIMO.Excel {
                 WriteRawValueCell(writer, dateTimeOffsetSerial);
             }
 
-            private static bool TryGetDateTimeOffsetSerial(DateTimeOffset value, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy, out double serial) {
+            private static bool TryGetDateTimeOffsetSerial(DateTimeOffset value, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy, ExcelDateSystem dateSystem, out double serial) {
                 try {
                     if (value.UtcDateTime < ExcelMinimumSupportedDateTimeOffset) {
                         serial = 0D;
                         return false;
                     }
 
-                    serial = dateTimeOffsetWriteStrategy(value).ToOADate();
+                    serial = ExcelDateSystemConverter.ToSerial(dateTimeOffsetWriteStrategy(value), dateSystem);
                     return true;
                 } catch (ArgumentException) {
                     serial = 0D;

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Writer.Rows.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Writer.Rows.cs
@@ -34,31 +34,32 @@ namespace OfficeIMO.Excel {
                 bool[]? valueStyleColumns,
                 DirectStylePlan stylePlan,
                 Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy,
+                ExcelDateSystem dateSystem,
                 DirectSharedStringTable? sharedStrings,
                 CancellationToken ct,
                 IReadOnlyDictionary<int, IReadOnlyList<DirectOverlayCell>>? overlayCellsByRow = null) {
                 if (overlayCellsByRow != null) {
-                    WriteDirectValueRowsWithOverlayCells(writer, sheet, rowCount, columnCount, startRowIndex, cellReferencePrefixes, styleAttributes, cellValueKinds, valueStyleColumns, stylePlan, dateTimeOffsetWriteStrategy, sharedStrings, ct, overlayCellsByRow);
+                    WriteDirectValueRowsWithOverlayCells(writer, sheet, rowCount, columnCount, startRowIndex, cellReferencePrefixes, styleAttributes, cellValueKinds, valueStyleColumns, stylePlan, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings, ct, overlayCellsByRow);
                     return;
                 }
 
                 if (sheet.Table.TryGetExactDictionaryRows(out var exactDictionaryRows)) {
-                    WriteExactDictionaryValueRows(writer, exactDictionaryRows, sheet, rowCount, columnCount, startRowIndex, cellReferencePrefixes, sheet.Table.CreateColumnNameArray(), styleAttributes, cellValueKinds, valueStyleColumns, dateTimeOffsetWriteStrategy, sharedStrings, ct);
+                    WriteExactDictionaryValueRows(writer, exactDictionaryRows, sheet, rowCount, columnCount, startRowIndex, cellReferencePrefixes, sheet.Table.CreateColumnNameArray(), styleAttributes, cellValueKinds, valueStyleColumns, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings, ct);
                     return;
                 }
 
                 if (sheet.Table.TryGetDictionaryRows(out var dictionaryRows)) {
-                    WriteDictionaryValueRows(writer, dictionaryRows, sheet, rowCount, columnCount, startRowIndex, cellReferencePrefixes, sheet.Table.CreateColumnNameArray(), styleAttributes, cellValueKinds, valueStyleColumns, dateTimeOffsetWriteStrategy, sharedStrings, ct);
+                    WriteDictionaryValueRows(writer, dictionaryRows, sheet, rowCount, columnCount, startRowIndex, cellReferencePrefixes, sheet.Table.CreateColumnNameArray(), styleAttributes, cellValueKinds, valueStyleColumns, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings, ct);
                     return;
                 }
 
                 if (sheet.Table.TryGetLegacyDictionaryRows(out _)) {
-                    WriteLegacyDictionaryValueRows(writer, sheet, rowCount, columnCount, startRowIndex, cellReferencePrefixes, styleAttributes, cellValueKinds, valueStyleColumns, dateTimeOffsetWriteStrategy, sharedStrings, ct);
+                    WriteLegacyDictionaryValueRows(writer, sheet, rowCount, columnCount, startRowIndex, cellReferencePrefixes, styleAttributes, cellValueKinds, valueStyleColumns, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings, ct);
                     return;
                 }
 
                 if (sheet.Table.TryGetCellValueRows(out DirectCellValueRows cellValueRows)) {
-                    WriteDirectCellValueRows(writer, sheet, cellValueRows, rowCount, columnCount, startRowIndex, cellReferencePrefixes, styleAttributes, cellValueKinds, valueStyleColumns, dateTimeOffsetWriteStrategy, sharedStrings, ct);
+                    WriteDirectCellValueRows(writer, sheet, cellValueRows, rowCount, columnCount, startRowIndex, cellReferencePrefixes, styleAttributes, cellValueKinds, valueStyleColumns, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings, ct);
                     return;
                 }
 
@@ -85,7 +86,7 @@ namespace OfficeIMO.Excel {
                                 rowStarted = true;
                             }
 
-                            WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, sharedStrings);
+                            WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                         }
 
                         if (rowStarted) {
@@ -109,7 +110,7 @@ namespace OfficeIMO.Excel {
                     writer.Write("\">");
                     for (int c = 0; c < columnCount; c++) {
                         object? value = sheet.Table.GetValue(sourceRowIndex, c);
-                        WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, sharedStrings);
+                        WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                     }
 
                     writer.Write("</row>");
@@ -129,6 +130,7 @@ namespace OfficeIMO.Excel {
                 DirectCellValueKind[] cellValueKinds,
                 bool[]? valueStyleColumns,
                 Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy,
+                ExcelDateSystem dateSystem,
                 DirectSharedStringTable? sharedStrings,
                 CancellationToken ct) {
                 bool canCancel = ct.CanBeCanceled;
@@ -137,7 +139,7 @@ namespace OfficeIMO.Excel {
 
                 if (!sheet.OmitBlankCells && valueStyleColumns == null) {
                     if (columnCount == 4 && styleAttributes == null) {
-                        WriteDirectCellValueRowsFourColumns(writer, rows, rowCount, startRowIndex, cellReferencePrefixes, cellValueKinds, dateTimeOffsetWriteStrategy, sharedStrings, ct);
+                        WriteDirectCellValueRowsFourColumns(writer, rows, rowCount, startRowIndex, cellReferencePrefixes, cellValueKinds, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings, ct);
                         return;
                     }
 
@@ -152,7 +154,7 @@ namespace OfficeIMO.Excel {
                         writer.Write("\">");
                         int rowOffset = rows.GetRowOffset(sourceRowIndex);
                         for (int c = 0; c < columnCount; c++) {
-                            WriteCell(writer, rowReference, cellReferencePrefixes[c], values[rowOffset + c], styleAttributes?[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                            WriteCell(writer, rowReference, cellReferencePrefixes[c], values[rowOffset + c], styleAttributes?[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                         }
 
                         writer.Write("</row>");
@@ -184,7 +186,7 @@ namespace OfficeIMO.Excel {
                                 rowStarted = true;
                             }
 
-                            WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, sharedStrings);
+                            WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                         }
 
                         if (rowStarted) {
@@ -208,7 +210,7 @@ namespace OfficeIMO.Excel {
                     writer.Write("\">");
                     int rowOffset = rows.GetRowOffset(sourceRowIndex);
                     for (int c = 0; c < columnCount; c++) {
-                        WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], values[rowOffset + c], styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, sharedStrings);
+                        WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], values[rowOffset + c], styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                     }
 
                     writer.Write("</row>");
@@ -224,6 +226,7 @@ namespace OfficeIMO.Excel {
                 string[] cellReferencePrefixes,
                 DirectCellValueKind[] cellValueKinds,
                 Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy,
+                ExcelDateSystem dateSystem,
                 DirectSharedStringTable? sharedStrings,
                 CancellationToken ct) {
                 bool canCancel = ct.CanBeCanceled;
@@ -245,7 +248,7 @@ namespace OfficeIMO.Excel {
                     if (rows.ValuesMatchColumnTypes) {
                         WriteDirectCellValueRowsExactIntStringStringDouble(writer, values, rowCount, startRowIndex, prefix0, prefix1, prefix2, prefix3, sharedStrings, ct);
                     } else {
-                        WriteDirectCellValueRowsIntStringStringDouble(writer, values, rowCount, startRowIndex, prefix0, prefix1, prefix2, prefix3, dateTimeOffsetWriteStrategy, sharedStrings, ct);
+                        WriteDirectCellValueRowsIntStringStringDouble(writer, values, rowCount, startRowIndex, prefix0, prefix1, prefix2, prefix3, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings, ct);
                     }
 
                     return;
@@ -260,10 +263,10 @@ namespace OfficeIMO.Excel {
                     writer.Write("<row r=\"");
                     writer.Write(rowReference);
                     writer.Write("\">");
-                    WriteCell(writer, rowReference, prefix0, values[offset], null, kind0, dateTimeOffsetWriteStrategy, sharedStrings);
-                    WriteCell(writer, rowReference, prefix1, values[offset + 1], null, kind1, dateTimeOffsetWriteStrategy, sharedStrings);
-                    WriteCell(writer, rowReference, prefix2, values[offset + 2], null, kind2, dateTimeOffsetWriteStrategy, sharedStrings);
-                    WriteCell(writer, rowReference, prefix3, values[offset + 3], null, kind3, dateTimeOffsetWriteStrategy, sharedStrings);
+                    WriteCell(writer, rowReference, prefix0, values[offset], null, kind0, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
+                    WriteCell(writer, rowReference, prefix1, values[offset + 1], null, kind1, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
+                    WriteCell(writer, rowReference, prefix2, values[offset + 2], null, kind2, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
+                    WriteCell(writer, rowReference, prefix3, values[offset + 3], null, kind3, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                     writer.Write("</row>");
                     rowIndex++;
                 }
@@ -279,6 +282,7 @@ namespace OfficeIMO.Excel {
                 string prefix2,
                 string prefix3,
                 Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy,
+                ExcelDateSystem dateSystem,
                 DirectSharedStringTable? sharedStrings,
                 CancellationToken ct) {
                 bool canCancel = ct.CanBeCanceled;
@@ -299,7 +303,7 @@ namespace OfficeIMO.Excel {
                     if (values[offset] is int intValue) {
                         WriteRawValueCell(writer, intValue);
                     } else {
-                        WriteCellValue(writer, values[offset], DirectCellValueKind.Int32, dateTimeOffsetWriteStrategy, sharedStrings);
+                        WriteCellValue(writer, values[offset], DirectCellValueKind.Int32, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                     }
 
                     writer.Write(prefix1);
@@ -308,7 +312,7 @@ namespace OfficeIMO.Excel {
                     if (values[offset + 1] is string stringValue1) {
                         WriteStringCellValue(writer, stringValue1, sharedStrings);
                     } else {
-                        WriteCellValue(writer, values[offset + 1], DirectCellValueKind.String, dateTimeOffsetWriteStrategy, sharedStrings);
+                        WriteCellValue(writer, values[offset + 1], DirectCellValueKind.String, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                     }
 
                     writer.Write(prefix2);
@@ -317,7 +321,7 @@ namespace OfficeIMO.Excel {
                     if (values[offset + 2] is string stringValue2) {
                         WriteStringCellValue(writer, stringValue2, sharedStrings);
                     } else {
-                        WriteCellValue(writer, values[offset + 2], DirectCellValueKind.String, dateTimeOffsetWriteStrategy, sharedStrings);
+                        WriteCellValue(writer, values[offset + 2], DirectCellValueKind.String, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                     }
 
                     writer.Write(prefix3);
@@ -326,7 +330,7 @@ namespace OfficeIMO.Excel {
                     if (values[offset + 3] is double doubleValue) {
                         WriteRawValueCell(writer, doubleValue);
                     } else {
-                        WriteCellValue(writer, values[offset + 3], DirectCellValueKind.Double, dateTimeOffsetWriteStrategy, sharedStrings);
+                        WriteCellValue(writer, values[offset + 3], DirectCellValueKind.Double, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                     }
 
                     writer.Write("</row>");
@@ -394,6 +398,7 @@ namespace OfficeIMO.Excel {
                 bool[]? valueStyleColumns,
                 DirectStylePlan stylePlan,
                 Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy,
+                ExcelDateSystem dateSystem,
                 DirectSharedStringTable? sharedStrings,
                 CancellationToken ct,
                 IReadOnlyDictionary<int, IReadOnlyList<DirectOverlayCell>> overlayCellsByRow) {
@@ -420,7 +425,7 @@ namespace OfficeIMO.Excel {
                                 rowStarted = true;
                             }
 
-                            WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, sharedStrings);
+                            WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                         }
 
                         if (overlayCellsByRow.ContainsKey(rowIndex)) {
@@ -430,7 +435,7 @@ namespace OfficeIMO.Excel {
                                 writer.Write("\">");
                             }
 
-                            WriteOverlayCellsForRow(writer, overlayCellsByRow, rowIndex, stylePlan, dateTimeOffsetWriteStrategy, sharedStrings);
+                            WriteOverlayCellsForRow(writer, overlayCellsByRow, rowIndex, stylePlan, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                             rowStarted = true;
                         }
 
@@ -455,10 +460,10 @@ namespace OfficeIMO.Excel {
                     writer.Write("\">");
                     for (int c = 0; c < columnCount; c++) {
                         object? value = sheet.Table.GetValue(sourceRowIndex, c);
-                        WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, sharedStrings);
+                        WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                     }
 
-                    WriteOverlayCellsForRow(writer, overlayCellsByRow, rowIndex, stylePlan, dateTimeOffsetWriteStrategy, sharedStrings);
+                    WriteOverlayCellsForRow(writer, overlayCellsByRow, rowIndex, stylePlan, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                     writer.Write("</row>");
                     rowIndex++;
                 }
@@ -477,12 +482,13 @@ namespace OfficeIMO.Excel {
                 DirectCellValueKind[] cellValueKinds,
                 bool[]? valueStyleColumns,
                 Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy,
+                ExcelDateSystem dateSystem,
                 DirectSharedStringTable? sharedStrings,
                 CancellationToken ct) {
                 bool canCancel = ct.CanBeCanceled;
                 int rowIndex = startRowIndex;
                 if (!sheet.OmitBlankCells && valueStyleColumns == null) {
-                    WriteFixedKindExactDictionaryRows(writer, rows, rowCount, columnCount, rowIndex, cellReferencePrefixes, columnNames, styleAttributes, cellValueKinds, dateTimeOffsetWriteStrategy, sharedStrings, ct);
+                    WriteFixedKindExactDictionaryRows(writer, rows, rowCount, columnCount, rowIndex, cellReferencePrefixes, columnNames, styleAttributes, cellValueKinds, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings, ct);
                     return;
                 }
 
@@ -510,7 +516,7 @@ namespace OfficeIMO.Excel {
                                 rowStarted = true;
                             }
 
-                            WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, sharedStrings);
+                            WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                         }
 
                         if (rowStarted) {
@@ -537,7 +543,7 @@ namespace OfficeIMO.Excel {
                         object? value = row.TryGetValue(columnNames[c], out object? dictionaryValue)
                             ? dictionaryValue
                             : null;
-                        WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, sharedStrings);
+                        WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                     }
 
                     writer.Write("</row>");
@@ -556,6 +562,7 @@ namespace OfficeIMO.Excel {
                 string?[]? styleAttributes,
                 DirectCellValueKind[] cellValueKinds,
                 Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy,
+                ExcelDateSystem dateSystem,
                 DirectSharedStringTable? sharedStrings,
                 CancellationToken ct) {
                 bool canCancel = ct.CanBeCanceled;
@@ -578,7 +585,7 @@ namespace OfficeIMO.Excel {
                             object? value = row.TryGetValue(columnNames[c], out object? dictionaryValue)
                                 ? dictionaryValue
                                 : null;
-                            WriteCellValue(writer, value, cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                            WriteCellValue(writer, value, cellValueKinds[c], dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                         }
 
                         writer.Write("</row>");
@@ -610,7 +617,7 @@ namespace OfficeIMO.Excel {
                         object? value = row.TryGetValue(columnNames[c], out object? dictionaryValue)
                             ? dictionaryValue
                             : null;
-                        WriteCellValue(writer, value, cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                        WriteCellValue(writer, value, cellValueKinds[c], dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                     }
 
                     writer.Write("</row>");
@@ -631,12 +638,13 @@ namespace OfficeIMO.Excel {
                 DirectCellValueKind[] cellValueKinds,
                 bool[]? valueStyleColumns,
                 Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy,
+                ExcelDateSystem dateSystem,
                 DirectSharedStringTable? sharedStrings,
                 CancellationToken ct) {
                 bool canCancel = ct.CanBeCanceled;
                 int rowIndex = startRowIndex;
                 if (!sheet.OmitBlankCells && valueStyleColumns == null) {
-                    WriteFixedKindDictionaryRows(writer, rows, rowCount, columnCount, rowIndex, cellReferencePrefixes, columnNames, styleAttributes, cellValueKinds, dateTimeOffsetWriteStrategy, sharedStrings, ct);
+                    WriteFixedKindDictionaryRows(writer, rows, rowCount, columnCount, rowIndex, cellReferencePrefixes, columnNames, styleAttributes, cellValueKinds, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings, ct);
                     return;
                 }
 
@@ -664,7 +672,7 @@ namespace OfficeIMO.Excel {
                                 rowStarted = true;
                             }
 
-                            WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, sharedStrings);
+                            WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                         }
 
                         if (rowStarted) {
@@ -691,7 +699,7 @@ namespace OfficeIMO.Excel {
                         object? value = row.TryGetValue(columnNames[c], out object? dictionaryValue)
                             ? dictionaryValue
                             : null;
-                        WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, sharedStrings);
+                        WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                     }
 
                     writer.Write("</row>");
@@ -710,6 +718,7 @@ namespace OfficeIMO.Excel {
                 string?[]? styleAttributes,
                 DirectCellValueKind[] cellValueKinds,
                 Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy,
+                ExcelDateSystem dateSystem,
                 DirectSharedStringTable? sharedStrings,
                 CancellationToken ct) {
                 bool canCancel = ct.CanBeCanceled;
@@ -732,7 +741,7 @@ namespace OfficeIMO.Excel {
                             object? value = row.TryGetValue(columnNames[c], out object? dictionaryValue)
                                 ? dictionaryValue
                                 : null;
-                            WriteCellValue(writer, value, cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                            WriteCellValue(writer, value, cellValueKinds[c], dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                         }
 
                         writer.Write("</row>");
@@ -764,7 +773,7 @@ namespace OfficeIMO.Excel {
                         object? value = row.TryGetValue(columnNames[c], out object? dictionaryValue)
                             ? dictionaryValue
                             : null;
-                        WriteCellValue(writer, value, cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                        WriteCellValue(writer, value, cellValueKinds[c], dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                     }
 
                     writer.Write("</row>");
@@ -783,12 +792,13 @@ namespace OfficeIMO.Excel {
                 DirectCellValueKind[] cellValueKinds,
                 bool[]? valueStyleColumns,
                 Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy,
+                ExcelDateSystem dateSystem,
                 DirectSharedStringTable? sharedStrings,
                 CancellationToken ct) {
                 bool canCancel = ct.CanBeCanceled;
                 int rowIndex = startRowIndex;
                 if (!sheet.OmitBlankCells && valueStyleColumns == null) {
-                    WriteFixedKindLegacyDictionaryRows(writer, sheet, rowCount, columnCount, rowIndex, cellReferencePrefixes, styleAttributes, cellValueKinds, dateTimeOffsetWriteStrategy, sharedStrings, ct);
+                    WriteFixedKindLegacyDictionaryRows(writer, sheet, rowCount, columnCount, rowIndex, cellReferencePrefixes, styleAttributes, cellValueKinds, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings, ct);
                     return;
                 }
 
@@ -813,7 +823,7 @@ namespace OfficeIMO.Excel {
                                 rowStarted = true;
                             }
 
-                            WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, sharedStrings);
+                            WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                         }
 
                         if (rowStarted) {
@@ -837,7 +847,7 @@ namespace OfficeIMO.Excel {
                     writer.Write("\">");
                     for (int c = 0; c < columnCount; c++) {
                         object? value = sheet.Table.GetValue(sourceRowIndex, c);
-                        WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, sharedStrings);
+                        WriteDirectValueCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns?[c] ?? false, cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                     }
 
                     writer.Write("</row>");
@@ -855,6 +865,7 @@ namespace OfficeIMO.Excel {
                 string?[]? styleAttributes,
                 DirectCellValueKind[] cellValueKinds,
                 Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy,
+                ExcelDateSystem dateSystem,
                 DirectSharedStringTable? sharedStrings,
                 CancellationToken ct) {
                 bool canCancel = ct.CanBeCanceled;
@@ -874,7 +885,7 @@ namespace OfficeIMO.Excel {
                             writer.Write(rowReference);
                             writer.Write('"');
                             object? value = sheet.Table.GetValue(sourceRowIndex, c);
-                            WriteCellValue(writer, value, cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                            WriteCellValue(writer, value, cellValueKinds[c], dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                         }
 
                         writer.Write("</row>");
@@ -903,7 +914,7 @@ namespace OfficeIMO.Excel {
                         }
 
                         object? value = sheet.Table.GetValue(sourceRowIndex, c);
-                        WriteCellValue(writer, value, cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                        WriteCellValue(writer, value, cellValueKinds[c], dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                     }
 
                     writer.Write("</row>");

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Writer.Tables.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Writer.Tables.cs
@@ -50,7 +50,15 @@ namespace OfficeIMO.Excel {
 
                 builder.Append("</tableColumns><tableStyleInfo name=\"");
                 builder.Append(sheet.TableStyle.ToString());
-                builder.Append("\" showFirstColumn=\"0\" showLastColumn=\"0\" showRowStripes=\"1\" showColumnStripes=\"0\"/></table>");
+                builder.Append("\" showFirstColumn=\"");
+                builder.Append(sheet.ShowFirstColumn ? "1" : "0");
+                builder.Append("\" showLastColumn=\"");
+                builder.Append(sheet.ShowLastColumn ? "1" : "0");
+                builder.Append("\" showRowStripes=\"");
+                builder.Append(sheet.ShowRowStripes ? "1" : "0");
+                builder.Append("\" showColumnStripes=\"");
+                builder.Append(sheet.ShowColumnStripes ? "1" : "0");
+                builder.Append("\"/></table>");
                 WriteTextEntry(archive, "xl/tables/table" + sheetIndexText + ".xml", builder.ToString());
             }
 

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Writer.Worksheet.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Writer.Worksheet.cs
@@ -7,7 +7,7 @@ using System.Threading;
 namespace OfficeIMO.Excel {
     public partial class ExcelDocument {
         private static partial class DirectDataSetWorkbookWriter {
-            private static void WriteWorksheet(ZipArchive archive, DirectDataSetSheetModel sheet, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy, DirectSharedStringTable? sharedStrings, DirectStylePlan stylePlan, DirectColumnWritePlan columnWritePlan, CancellationToken ct, string? worksheetPath = null, string? tableRelationshipId = null) {
+            private static void WriteWorksheet(ZipArchive archive, DirectDataSetSheetModel sheet, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy, ExcelDateSystem dateSystem, DirectSharedStringTable? sharedStrings, DirectStylePlan stylePlan, DirectColumnWritePlan columnWritePlan, CancellationToken ct, string? worksheetPath = null, string? tableRelationshipId = null) {
                 var entry = archive.CreateEntry(worksheetPath ?? "xl/worksheets/sheet" + InvariantNumberText.Get(sheet.Index) + ".xml", CompressionLevel.Fastest);
                 using var stream = entry.Open();
                 using var writer = new StreamWriter(stream, Utf8NoBom, XmlWriterBufferSize);
@@ -48,10 +48,10 @@ namespace OfficeIMO.Excel {
                     const string headerRowReference = "1";
                     writer.Write("<row r=\"1\">");
                     for (int c = 0; c < columnCount; c++) {
-                        WriteCell(writer, headerRowReference, cellReferencePrefixes[c], sheet.Table.GetColumnName(c), null, dateTimeOffsetWriteStrategy, sharedStrings);
+                        WriteCell(writer, headerRowReference, cellReferencePrefixes[c], sheet.Table.GetColumnName(c), null, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                     }
 
-                    WriteOverlayCellsForRow(writer, overlayCellsByRow, 1, stylePlan, dateTimeOffsetWriteStrategy, sharedStrings);
+                    WriteOverlayCellsForRow(writer, overlayCellsByRow, 1, stylePlan, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                     writer.Write("</row>");
                     rowIndex++;
                 }
@@ -59,7 +59,7 @@ namespace OfficeIMO.Excel {
                 bool hasBufferedRows = sheet.Table.TryGetBufferedRows(out DirectBufferedRows bufferedRows);
                 bool hasCellValueRows = sheet.Table.TryGetCellValueRows(out DirectCellValueRows cellValueRows);
                 if (hasInlineOverlayCells) {
-                    WriteDirectValueRows(writer, sheet, rowCount, columnCount, rowIndex, cellReferencePrefixes, styleAttributes, cellValueKinds, valueStyleColumns, stylePlan, dateTimeOffsetWriteStrategy, sharedStrings, ct, overlayCellsByRow);
+                    WriteDirectValueRows(writer, sheet, rowCount, columnCount, rowIndex, cellReferencePrefixes, styleAttributes, cellValueKinds, valueStyleColumns, stylePlan, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings, ct, overlayCellsByRow);
                     rowIndex += rowCount;
                 } else if (hasBufferedRows
                     && !sheet.OmitBlankCells
@@ -71,12 +71,12 @@ namespace OfficeIMO.Excel {
                 } else if (hasBufferedRows
                     && !sheet.OmitBlankCells
                     && valueStyleColumns == null) {
-                    WriteFixedKindBufferedRows(writer, bufferedRows, rowCount, columnCount, rowIndex, cellReferencePrefixes, styleAttributes, cellValueKinds, dateTimeOffsetWriteStrategy, sharedStrings, ct);
+                    WriteFixedKindBufferedRows(writer, bufferedRows, rowCount, columnCount, rowIndex, cellReferencePrefixes, styleAttributes, cellValueKinds, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings, ct);
                     rowIndex += rowCount;
                 } else if (hasCellValueRows
                     && !sheet.OmitBlankCells
                     && valueStyleColumns == null) {
-                    WriteFixedKindCellValueRows(writer, cellValueRows, rowCount, columnCount, rowIndex, cellReferencePrefixes, styleAttributes, cellValueKinds, dateTimeOffsetWriteStrategy, sharedStrings, ct);
+                    WriteFixedKindCellValueRows(writer, cellValueRows, rowCount, columnCount, rowIndex, cellReferencePrefixes, styleAttributes, cellValueKinds, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings, ct);
                     rowIndex += rowCount;
                 } else if (valueStyleColumns == null) {
                     if (hasBufferedRows) {
@@ -102,7 +102,7 @@ namespace OfficeIMO.Excel {
                                         rowStarted = true;
                                     }
 
-                                    WriteCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                                    WriteCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                                 }
 
                                 if (rowStarted) {
@@ -123,7 +123,7 @@ namespace OfficeIMO.Excel {
                                 writer.Write(rowReference);
                                 writer.Write("\">");
                                 for (int c = 0; c < columnCount; c++) {
-                                    WriteCell(writer, rowReference, cellReferencePrefixes[c], bufferedRow[c], styleAttributes?[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                                    WriteCell(writer, rowReference, cellReferencePrefixes[c], bufferedRow[c], styleAttributes?[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                                 }
 
                                 writer.Write("</row>");
@@ -153,7 +153,7 @@ namespace OfficeIMO.Excel {
                                         rowStarted = true;
                                     }
 
-                                    WriteCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                                    WriteCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                                 }
 
                                 if (rowStarted) {
@@ -174,7 +174,7 @@ namespace OfficeIMO.Excel {
                                 writer.Write(rowReference);
                                 writer.Write("\">");
                                 for (int c = 0; c < columnCount; c++) {
-                                    WriteCell(writer, rowReference, cellReferencePrefixes[c], sourceRow[c], styleAttributes?[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                                    WriteCell(writer, rowReference, cellReferencePrefixes[c], sourceRow[c], styleAttributes?[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                                 }
 
                                 writer.Write("</row>");
@@ -182,7 +182,7 @@ namespace OfficeIMO.Excel {
                             }
                         }
                     } else {
-                        WriteDirectValueRows(writer, sheet, rowCount, columnCount, rowIndex, cellReferencePrefixes, styleAttributes, cellValueKinds, valueStyleColumns: null, stylePlan, dateTimeOffsetWriteStrategy, sharedStrings, ct);
+                        WriteDirectValueRows(writer, sheet, rowCount, columnCount, rowIndex, cellReferencePrefixes, styleAttributes, cellValueKinds, valueStyleColumns: null, stylePlan, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings, ct);
                         rowIndex += rowCount;
                     }
                 } else if (hasBufferedRows) {
@@ -208,7 +208,7 @@ namespace OfficeIMO.Excel {
                                     rowStarted = true;
                                 }
 
-                                WriteCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns[c], cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, sharedStrings);
+                                WriteCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns[c], cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                             }
 
                             if (rowStarted) {
@@ -229,7 +229,7 @@ namespace OfficeIMO.Excel {
                             writer.Write(rowReference);
                             writer.Write("\">");
                             for (int c = 0; c < columnCount; c++) {
-                                WriteCell(writer, rowReference, cellReferencePrefixes[c], bufferedRow[c], styleAttributes?[c], valueStyleColumns[c], cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, sharedStrings);
+                                WriteCell(writer, rowReference, cellReferencePrefixes[c], bufferedRow[c], styleAttributes?[c], valueStyleColumns[c], cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                             }
 
                             writer.Write("</row>");
@@ -259,7 +259,7 @@ namespace OfficeIMO.Excel {
                                     rowStarted = true;
                                 }
 
-                                WriteCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns[c], cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, sharedStrings);
+                                WriteCell(writer, rowReference, cellReferencePrefixes[c], value, styleAttributes?[c], valueStyleColumns[c], cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                             }
 
                             if (rowStarted) {
@@ -280,7 +280,7 @@ namespace OfficeIMO.Excel {
                             writer.Write(rowReference);
                             writer.Write("\">");
                             for (int c = 0; c < columnCount; c++) {
-                                WriteCell(writer, rowReference, cellReferencePrefixes[c], sourceRow[c], styleAttributes?[c], valueStyleColumns[c], cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, sharedStrings);
+                                WriteCell(writer, rowReference, cellReferencePrefixes[c], sourceRow[c], styleAttributes?[c], valueStyleColumns[c], cellValueKinds[c], sheet.UseCellValueNumberFormats, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                             }
 
                             writer.Write("</row>");
@@ -288,12 +288,16 @@ namespace OfficeIMO.Excel {
                         }
                     }
                 } else {
-                    WriteDirectValueRows(writer, sheet, rowCount, columnCount, rowIndex, cellReferencePrefixes, styleAttributes, cellValueKinds, valueStyleColumns, stylePlan, dateTimeOffsetWriteStrategy, sharedStrings, ct);
+                    WriteDirectValueRows(writer, sheet, rowCount, columnCount, rowIndex, cellReferencePrefixes, styleAttributes, cellValueKinds, valueStyleColumns, stylePlan, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings, ct);
                     rowIndex += rowCount;
                 }
 
-                WriteOverlayCells(writer, overlayCells, stylePlan, dateTimeOffsetWriteStrategy, sharedStrings, directLastRow);
+                WriteOverlayCells(writer, overlayCells, stylePlan, dateTimeOffsetWriteStrategy, dateSystem, sharedStrings, directLastRow);
                 writer.Write("</sheetData>");
+                if (!string.IsNullOrEmpty(metadata?.SheetProtectionXml)) {
+                    writer.Write(metadata!.SheetProtectionXml);
+                }
+
                 if (!string.IsNullOrEmpty(metadata?.AutoFilterXml)) {
                     writer.Write(metadata!.AutoFilterXml);
                 }
@@ -337,6 +341,7 @@ namespace OfficeIMO.Excel {
                 string?[]? styleAttributes,
                 DirectCellValueKind[] cellValueKinds,
                 Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy,
+                ExcelDateSystem dateSystem,
                 DirectSharedStringTable? sharedStrings,
                 CancellationToken ct) {
                 bool canCancel = ct.CanBeCanceled;
@@ -357,7 +362,7 @@ namespace OfficeIMO.Excel {
                             writer.Write(cellReferencePrefixes[c]);
                             writer.Write(rowReference);
                             writer.Write('"');
-                            WriteCellValue(writer, values[rowOffset + c], cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                            WriteCellValue(writer, values[rowOffset + c], cellValueKinds[c], dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                         }
 
                         writer.Write("</row>");
@@ -388,7 +393,7 @@ namespace OfficeIMO.Excel {
                             writer.Write(styleAttribute);
                         }
 
-                        WriteCellValue(writer, styledValues[styledRowOffset + c], cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                        WriteCellValue(writer, styledValues[styledRowOffset + c], cellValueKinds[c], dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                     }
 
                     writer.Write("</row>");
@@ -407,6 +412,7 @@ namespace OfficeIMO.Excel {
                 string?[]? styleAttributes,
                 DirectCellValueKind[] cellValueKinds,
                 Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy,
+                ExcelDateSystem dateSystem,
                 DirectSharedStringTable? sharedStrings,
                 CancellationToken ct) {
                 bool canCancel = ct.CanBeCanceled;
@@ -426,7 +432,7 @@ namespace OfficeIMO.Excel {
                             writer.Write(cellReferencePrefixes[c]);
                             writer.Write(rowReference);
                             writer.Write('"');
-                            WriteCellValue(writer, bufferedRow[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                            WriteCellValue(writer, bufferedRow[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                         }
 
                         writer.Write("</row>");
@@ -455,7 +461,7 @@ namespace OfficeIMO.Excel {
                             writer.Write(styleAttribute);
                         }
 
-                        WriteCellValue(writer, bufferedRow[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, sharedStrings);
+                        WriteCellValue(writer, bufferedRow[c], cellValueKinds[c], dateTimeOffsetWriteStrategy, dateSystem, sharedStrings);
                     }
 
                     writer.Write("</row>");
@@ -586,6 +592,7 @@ namespace OfficeIMO.Excel {
                 IReadOnlyList<DirectOverlayCell>? overlayCells,
                 DirectStylePlan stylePlan,
                 Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy,
+                ExcelDateSystem dateSystem,
                 DirectSharedStringTable? sharedStrings,
                 int skipRowsAtOrBefore = 0) {
                 if (overlayCells == null || overlayCells.Count == 0) {
@@ -617,6 +624,7 @@ namespace OfficeIMO.Excel {
                         cell.Value,
                         CreateOverlayStyleAttribute(cell, stylePlan),
                         dateTimeOffsetWriteStrategy,
+                        dateSystem,
                         sharedStrings);
                 }
 
@@ -658,6 +666,7 @@ namespace OfficeIMO.Excel {
                 int row,
                 DirectStylePlan stylePlan,
                 Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy,
+                ExcelDateSystem dateSystem,
                 DirectSharedStringTable? sharedStrings) {
                 if (overlayCellsByRow == null || !overlayCellsByRow.TryGetValue(row, out var rowOverlayCells)) {
                     return false;
@@ -677,6 +686,7 @@ namespace OfficeIMO.Excel {
                         cell.Value,
                         CreateOverlayStyleAttribute(cell, stylePlan),
                         dateTimeOffsetWriteStrategy,
+                        dateSystem,
                         sharedStrings);
                 }
 

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Writer.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Writer.cs
@@ -37,7 +37,7 @@ namespace OfficeIMO.Excel {
                     "</Relationships>");
                 WriteCoreProperties(archive);
                 WriteAppProperties(archive);
-                WriteWorkbook(archive, model.Sheets);
+                WriteWorkbook(archive, model);
                 WriteWorkbookRelationships(archive, model.Sheets.Count, sharedStrings != null);
                 WriteStyles(archive, stylePlan);
                 if (sharedStrings != null) {
@@ -51,7 +51,7 @@ namespace OfficeIMO.Excel {
                     }
 
                     var sheet = model.Sheets[i];
-                    WriteWorksheet(archive, sheet, model.DateTimeOffsetWriteStrategy, sharedStrings, stylePlan, columnWritePlans[i], ct);
+                    WriteWorksheet(archive, sheet, model.DateTimeOffsetWriteStrategy, model.DateSystem, sharedStrings, stylePlan, columnWritePlans[i], ct);
                     if (sheet.HasTable) {
                         string sheetIndexText = InvariantNumberText.Get(sheet.Index);
                         WriteTextEntry(archive, "xl/worksheets/_rels/sheet" + sheetIndexText + ".xml.rels",
@@ -96,7 +96,7 @@ namespace OfficeIMO.Excel {
                     throw new InvalidOperationException("The direct worksheet is not part of the extended direct write plan.");
                 }
 
-                WriteWorksheet(archive, sheet, plan.Model.DateTimeOffsetWriteStrategy, plan.SharedStrings, plan.StylePlan, plan.ColumnWritePlans[sheetIndex], ct, worksheetPath, tableRelationshipId);
+                WriteWorksheet(archive, sheet, plan.Model.DateTimeOffsetWriteStrategy, plan.Model.DateSystem, plan.SharedStrings, plan.StylePlan, plan.ColumnWritePlans[sheetIndex], ct, worksheetPath, tableRelationshipId);
             }
 
             private static void WriteContentTypes(ZipArchive archive, IReadOnlyList<DirectDataSetSheetModel> sheets, bool includeSharedStrings) {
@@ -129,10 +129,16 @@ namespace OfficeIMO.Excel {
                 WriteTextEntry(archive, "[Content_Types].xml", builder.ToString());
             }
 
-            private static void WriteWorkbook(ZipArchive archive, IReadOnlyList<DirectDataSetSheetModel> sheets) {
+            private static void WriteWorkbook(ZipArchive archive, DirectDataSetWorkbookModel model) {
+                IReadOnlyList<DirectDataSetSheetModel> sheets = model.Sheets;
                 var builder = new StringBuilder(256 + sheets.Count * 120);
                 builder.Append("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
-                builder.Append("<workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\"><sheets>");
+                builder.Append("<workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">");
+                if (model.DateSystem == ExcelDateSystem.NineteenFour) {
+                    builder.Append("<workbookPr date1904=\"1\"/>");
+                }
+
+                builder.Append("<sheets>");
                 foreach (var sheet in sheets) {
                     builder.Append("<sheet name=\"");
                     AppendEscaped(builder, sheet.SheetName);

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.cs
@@ -23,13 +23,14 @@ namespace OfficeIMO.Excel {
             TableStyle tableStyle = TableStyle.TableStyleMedium2,
             bool includeHeaders = true,
             bool includeAutoFilter = true,
-            CancellationToken ct = default) {
+            CancellationToken ct = default,
+            ExcelDateSystem dateSystem = ExcelDateSystem.NineteenHundred) {
             if (stream == null) throw new ArgumentNullException(nameof(stream));
             if (!stream.CanWrite) throw new ArgumentException("The destination stream must be writable.", nameof(stream));
             if (dataSet == null) throw new ArgumentNullException(nameof(dataSet));
             if (dataSet.Tables.Count == 0) throw new ArgumentException("The DataSet must contain at least one DataTable.", nameof(dataSet));
 
-            var model = DirectDataSetWorkbookModel.Create(dataSet, createTables: true, tableStyle, includeHeaders, includeAutoFilter, autoFit: false, DefaultDateTimeOffsetWriteStrategy, ct, omitBlankCells: true);
+            var model = DirectDataSetWorkbookModel.Create(dataSet, createTables: true, tableStyle, includeHeaders, includeAutoFilter, autoFit: false, DefaultDateTimeOffsetWriteStrategy, ct, omitBlankCells: true, dateSystem: dateSystem);
             if (stream.CanSeek) {
                 PrepareDestinationStreamForWrite(stream);
             }
@@ -62,7 +63,8 @@ namespace OfficeIMO.Excel {
                     autoFit,
                     _dateTimeOffsetWriteStrategy,
                     CancellationToken.None,
-                    results);
+                    results,
+                    dateSystem: DateSystem);
                 _directDataSetSaveCandidate = new DirectDataSetSaveCandidate(dataSet, model, ClearDirectDataSetSaveCandidate, isDeferred: false, subscribeToSourceChanges: true);
                 _directDataSetMetadataSourceSheet = null;
             } catch {
@@ -106,7 +108,8 @@ namespace OfficeIMO.Excel {
                         includeAutoFilter,
                         autoFit,
                         _dateTimeOffsetWriteStrategy,
-                        CancellationToken.None);
+                        CancellationToken.None,
+                        dateSystem: DateSystem);
                     _directDataSetSaveCandidate = new DirectDataSetSaveCandidate(DirectTabularSnapshotOwner, model, ClearDirectDataSetSaveCandidate, isDeferred: false, subscribeToSourceChanges: false);
                     _directDataSetMetadataSourceSheet = sheet;
                 } else {
@@ -130,7 +133,8 @@ namespace OfficeIMO.Excel {
                         autoFit,
                         _dateTimeOffsetWriteStrategy,
                         CancellationToken.None,
-                        results);
+                        results,
+                        dateSystem: DateSystem);
                     _directDataSetSaveCandidate = new DirectDataSetSaveCandidate(dataSet, model, ClearDirectDataSetSaveCandidate, isDeferred: false, subscribeToSourceChanges: false);
                     _directDataSetMetadataSourceSheet = null;
                 }
@@ -177,7 +181,8 @@ namespace OfficeIMO.Excel {
                     includeAutoFilter,
                     autoFit,
                     _dateTimeOffsetWriteStrategy,
-                    CancellationToken.None);
+                    CancellationToken.None,
+                    dateSystem: DateSystem);
                 _directDataSetSaveCandidate = new DirectDataSetSaveCandidate(DirectTabularSnapshotOwner, model, MaterializeDeferredDataSetImport, isDeferred: true, subscribeToSourceChanges: false);
                 _directDataSetMetadataSourceSheet = sheet;
                 _packageDirty = true;
@@ -233,7 +238,8 @@ namespace OfficeIMO.Excel {
                     autoFit,
                     _dateTimeOffsetWriteStrategy,
                     CancellationToken.None,
-                    useCellValueNumberFormats);
+                    useCellValueNumberFormats,
+                    DateSystem);
                 _directDataSetSaveCandidate = new DirectDataSetSaveCandidate(DirectTabularSnapshotOwner, model, MaterializeDeferredDataSetImport, isDeferred: true, subscribeToSourceChanges: false);
                 _directDataSetMetadataSourceSheet = sheet;
                 _packageDirty = true;
@@ -292,7 +298,8 @@ namespace OfficeIMO.Excel {
                     autoFit,
                     _dateTimeOffsetWriteStrategy,
                     CancellationToken.None,
-                    useCellValueNumberFormats);
+                    useCellValueNumberFormats,
+                    DateSystem);
                 _directDataSetSaveCandidate = new DirectDataSetSaveCandidate(DirectTabularSnapshotOwner, model, MaterializeDeferredDataSetImport, isDeferred: true, subscribeToSourceChanges: false);
                 _directDataSetMetadataSourceSheet = sheet;
                 _packageDirty = true;
@@ -343,7 +350,8 @@ namespace OfficeIMO.Excel {
                     includeAutoFilter,
                     autoFit,
                     _dateTimeOffsetWriteStrategy,
-                    CancellationToken.None);
+                    CancellationToken.None,
+                    dateSystem: DateSystem);
                 _directDataSetSaveCandidate = new DirectDataSetSaveCandidate(DirectTabularSnapshotOwner, model, ClearDirectDataSetSaveCandidate, isDeferred: false, subscribeToSourceChanges: false);
                 _directDataSetMetadataSourceSheet = sheet;
             } catch {
@@ -392,7 +400,8 @@ namespace OfficeIMO.Excel {
                     includeAutoFilter,
                     autoFit,
                     _dateTimeOffsetWriteStrategy,
-                    CancellationToken.None);
+                    CancellationToken.None,
+                    dateSystem: DateSystem);
                 _directDataSetSaveCandidate = new DirectDataSetSaveCandidate(DirectTabularSnapshotOwner, model, ClearDirectDataSetSaveCandidate, isDeferred: false, subscribeToSourceChanges: false);
                 _directDataSetMetadataSourceSheet = sheet;
             } catch {

--- a/OfficeIMO.Excel/ExcelDocument.DocumentProperties.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DocumentProperties.cs
@@ -31,6 +31,11 @@ namespace OfficeIMO.Excel {
         public ApplicationProperties ApplicationProperties = null!;
 
         /// <summary>
+        /// Custom workbook properties keyed by property name.
+        /// </summary>
+        public readonly Dictionary<string, ExcelCustomProperty> CustomDocumentProperties = new Dictionary<string, ExcelCustomProperty>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
         /// FileOpenAccess of the document
         /// </summary>
         public FileAccess FileOpenAccess => _spreadSheetDocument.FileOpenAccess;

--- a/OfficeIMO.Excel/ExcelDocument.DocumentProperties.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DocumentProperties.cs
@@ -33,7 +33,7 @@ namespace OfficeIMO.Excel {
         /// <summary>
         /// Custom workbook properties keyed by property name.
         /// </summary>
-        public readonly Dictionary<string, ExcelCustomProperty> CustomDocumentProperties = new Dictionary<string, ExcelCustomProperty>(StringComparer.OrdinalIgnoreCase);
+        public readonly ExcelCustomDocumentPropertyCollection CustomDocumentProperties = new ExcelCustomDocumentPropertyCollection();
 
         /// <summary>
         /// FileOpenAccess of the document

--- a/OfficeIMO.Excel/ExcelDocument.FastPackage.FastModels.cs
+++ b/OfficeIMO.Excel/ExcelDocument.FastPackage.FastModels.cs
@@ -14,17 +14,15 @@ namespace OfficeIMO.Excel {
             internal static void Write(Stream destination, FastWorkbookPackageModel model, CancellationToken ct) {
                 using (var archive = new ZipArchive(destination, ZipArchiveMode.Create, leaveOpen: true)) {
                     ct.ThrowIfCancellationRequested();
-                    WriteContentTypesEntry(archive, model.HasStyles, model.HasSharedStrings, model.Worksheets.Count, model.Tables.Count);
+                    WriteContentTypesEntry(archive, model.HasStyles, model.HasSharedStrings, model.HasCustomProperties, model.Worksheets.Count, model.Tables.Count);
                     ct.ThrowIfCancellationRequested();
-                    WriteTextEntry(archive, "_rels/.rels",
-                        "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
-                        "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">" +
-                        "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"xl/workbook.xml\"/>" +
-                        "<Relationship Id=\"rId2\" Type=\"http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties\" Target=\"docProps/core.xml\"/>" +
-                        "<Relationship Id=\"rId3\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties\" Target=\"docProps/app.xml\"/>" +
-                        "</Relationships>");
+                    WriteTextEntry(archive, "_rels/.rels", CreatePackageRelationshipsXml(model.HasCustomProperties));
                     WriteCorePropertiesEntry(archive);
                     WriteAppPropertiesEntry(archive);
+                    if (model.CustomProperties != null) {
+                        WriteOpenXmlElementEntry(archive, "docProps/custom.xml", model.CustomProperties);
+                    }
+
                     ct.ThrowIfCancellationRequested();
                     WriteWorkbookEntry(archive, model);
                     WriteWorkbookRelationshipsEntry(archive, model.Worksheets, model.HasStyles, model.HasSharedStrings);
@@ -53,6 +51,21 @@ namespace OfficeIMO.Excel {
                     }
                 }
             }
+
+            private static string CreatePackageRelationshipsXml(bool hasCustomProperties) {
+                var builder = new System.Text.StringBuilder(384);
+                builder.Append("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+                builder.Append("<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">");
+                builder.Append("<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"xl/workbook.xml\"/>");
+                builder.Append("<Relationship Id=\"rId2\" Type=\"http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties\" Target=\"docProps/core.xml\"/>");
+                builder.Append("<Relationship Id=\"rId3\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties\" Target=\"docProps/app.xml\"/>");
+                if (hasCustomProperties) {
+                    builder.Append("<Relationship Id=\"rId4\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/custom-properties\" Target=\"docProps/custom.xml\"/>");
+                }
+
+                builder.Append("</Relationships>");
+                return builder.ToString();
+            }
         }
 
         private sealed class FastWorkbookPackageModel {
@@ -67,7 +80,8 @@ namespace OfficeIMO.Excel {
                 WorkbookProtection? workbookProtection,
                 BookViews? bookViews,
                 DefinedNames? definedNames,
-                CalculationProperties? calculationProperties) {
+                CalculationProperties? calculationProperties,
+                DocumentFormat.OpenXml.CustomProperties.Properties? customProperties) {
                 Worksheets = worksheets;
                 Stylesheet = stylesheet;
                 SharedStrings = sharedStrings;
@@ -79,6 +93,7 @@ namespace OfficeIMO.Excel {
                 BookViews = bookViews;
                 DefinedNames = definedNames;
                 CalculationProperties = calculationProperties;
+                CustomProperties = customProperties;
             }
 
             internal IReadOnlyList<FastWorksheetPackageModel> Worksheets { get; }
@@ -106,6 +121,10 @@ namespace OfficeIMO.Excel {
             internal DefinedNames? DefinedNames { get; }
 
             internal CalculationProperties? CalculationProperties { get; }
+
+            internal DocumentFormat.OpenXml.CustomProperties.Properties? CustomProperties { get; }
+
+            internal bool HasCustomProperties => CustomProperties != null && CustomProperties.Elements<DocumentFormat.OpenXml.CustomProperties.CustomDocumentProperty>().Any();
 
             internal static bool TryCreate(SpreadsheetDocument document, out FastWorkbookPackageModel model, out string? skipReason) {
                 model = null!;
@@ -215,6 +234,13 @@ namespace OfficeIMO.Excel {
                     return false;
                 }
 
+                var customProperties = document.CustomFilePropertiesPart?.Properties;
+                if (customProperties != null
+                    && customProperties.Descendants<DocumentFormat.OpenXml.OpenXmlUnknownElement>().Any()) {
+                    skipReason = "Workbook custom properties contain unknown Open XML elements.";
+                    return false;
+                }
+
                 model = new FastWorkbookPackageModel(
                     worksheets,
                     workbookPart.WorkbookStylesPart?.Stylesheet,
@@ -226,7 +252,8 @@ namespace OfficeIMO.Excel {
                     workbookPart.Workbook.GetFirstChild<WorkbookProtection>(),
                     workbookPart.Workbook.GetFirstChild<BookViews>(),
                     definedNames,
-                    workbookPart.Workbook.GetFirstChild<CalculationProperties>());
+                    workbookPart.Workbook.GetFirstChild<CalculationProperties>(),
+                    customProperties);
                 return true;
             }
 

--- a/OfficeIMO.Excel/ExcelDocument.FastPackage.PackageEntries.cs
+++ b/OfficeIMO.Excel/ExcelDocument.FastPackage.PackageEntries.cs
@@ -10,7 +10,7 @@ using System.Xml;
 namespace OfficeIMO.Excel {
     public partial class ExcelDocument {
 
-        private static void WriteContentTypesEntry(ZipArchive archive, bool hasStyles, bool hasSharedStrings, int worksheetCount, int tableCount) {
+        private static void WriteContentTypesEntry(ZipArchive archive, bool hasStyles, bool hasSharedStrings, bool hasCustomProperties, int worksheetCount, int tableCount) {
             var builder = new System.Text.StringBuilder(512 + worksheetCount * 160 + tableCount * 160);
             builder.Append("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
             builder.Append("<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">");
@@ -18,6 +18,10 @@ namespace OfficeIMO.Excel {
             builder.Append("<Default Extension=\"xml\" ContentType=\"application/xml\"/>");
             builder.Append("<Override PartName=\"/docProps/core.xml\" ContentType=\"application/vnd.openxmlformats-package.core-properties+xml\"/>");
             builder.Append("<Override PartName=\"/docProps/app.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.extended-properties+xml\"/>");
+            if (hasCustomProperties) {
+                builder.Append("<Override PartName=\"/docProps/custom.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.custom-properties+xml\"/>");
+            }
+
             builder.Append("<Override PartName=\"/xl/workbook.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\"/>");
             for (int i = 1; i <= worksheetCount; i++) {
                 builder.Append("<Override PartName=\"/xl/worksheets/sheet");

--- a/OfficeIMO.Excel/ExcelDocument.Inspection.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Inspection.cs
@@ -16,6 +16,7 @@ namespace OfficeIMO.Excel {
 
             var snapshot = new ExcelWorkbookSnapshot {
                 FilePath = string.IsNullOrWhiteSpace(FilePath) ? null : FilePath,
+                DateSystem = DateSystem,
             };
 
             try {
@@ -27,8 +28,18 @@ namespace OfficeIMO.Excel {
             using (var reader = CreateReader(effectiveOptions)) {
                 var workbookPart = WorkbookPartRoot ?? throw new InvalidOperationException("WorkbookPart is missing.");
                 var workbook = workbookPart.Workbook ?? throw new InvalidOperationException("Workbook is missing.");
+                snapshot.SlicerPartCount = CountPackagePartsByContentType(workbookPart, "slicer");
+                snapshot.TimelinePartCount = CountPackagePartsByContentType(workbookPart, "timeline");
+                snapshot.ConnectionPartCount = CountPackagePartsByContentType(workbookPart, "connections");
+                snapshot.QueryTablePartCount = CountPackagePartsByContentType(workbookPart, "queryTable");
                 var styleContext = StyleInspectionContext.Create(workbookPart.WorkbookStylesPart?.Stylesheet);
                 var sheetElements = workbook.Sheets?.Elements<Sheet>().ToList() ?? new List<Sheet>();
+                int? activeWorksheetIndex = GetActiveWorksheetIndex(workbook, sheetElements.Count);
+                if (activeWorksheetIndex.HasValue) {
+                    snapshot.ActiveWorksheetIndex = activeWorksheetIndex.Value;
+                    snapshot.ActiveWorksheetName = sheetElements[activeWorksheetIndex.Value].Name?.Value;
+                }
+
                 var threadedCommentPeople = BuildThreadedCommentPersonMap(workbookPart);
 
                 for (int sheetIndex = 0; sheetIndex < sheetElements.Count; sheetIndex++) {
@@ -42,24 +53,28 @@ namespace OfficeIMO.Excel {
                     var commentMap = BuildCommentMap(worksheetPart);
                     var threadedCommentMap = BuildThreadedCommentMap(worksheetPart, threadedCommentPeople);
 
+                    var outlineProperties = worksheet.GetFirstChild<SheetProperties>()?.GetFirstChild<OutlineProperties>();
+                    var sheetView = worksheet
+                        .GetFirstChild<SheetViews>()?
+                        .Elements<SheetView>()
+                        .FirstOrDefault();
                     var worksheetSnapshot = new ExcelWorksheetSnapshot {
                         Name = sheetName,
                         Index = sheetIndex,
                         Hidden = sheet.State?.Value == SheetStateValues.Hidden || sheet.State?.Value == SheetStateValues.VeryHidden,
-                        RightToLeft = worksheet
-                            .GetFirstChild<SheetViews>()?
-                            .Elements<SheetView>()
-                            .FirstOrDefault()?
-                            .RightToLeft?.Value == true,
+                        IsActive = activeWorksheetIndex == sheetIndex,
+                        RightToLeft = sheetView?.RightToLeft?.Value == true,
+                        ShowGridlines = sheetView?.ShowGridLines?.Value ?? true,
+                        View = sheetView?.View?.InnerText,
+                        ZoomScale = sheetView?.ZoomScale?.Value,
+                        ZoomScaleNormal = sheetView?.ZoomScaleNormal?.Value,
                         TabColorArgb = GetColorArgb(worksheet.GetFirstChild<SheetProperties>()?.TabColor),
+                        OutlineSummaryBelow = outlineProperties?.SummaryBelow?.Value,
+                        OutlineSummaryRight = outlineProperties?.SummaryRight?.Value,
                         UsedRangeA1 = readerSheet.GetUsedRangeA1(),
                     };
 
-                    var pane = worksheet
-                        .GetFirstChild<SheetViews>()?
-                        .Elements<SheetView>()
-                        .FirstOrDefault()?
-                        .GetFirstChild<Pane>();
+                    var pane = sheetView?.GetFirstChild<Pane>();
 
                     if (pane != null && (pane.State?.Value == PaneStateValues.Frozen || pane.State?.Value == PaneStateValues.FrozenSplit)) {
                         worksheetSnapshot.FrozenRowCount = ConvertToInt(pane.VerticalSplit);
@@ -81,6 +96,8 @@ namespace OfficeIMO.Excel {
                                 Width = column.Width?.Value,
                                 Hidden = column.Hidden?.Value == true,
                                 CustomWidth = column.CustomWidth?.Value == true,
+                                OutlineLevel = column.OutlineLevel?.Value,
+                                Collapsed = column.Collapsed?.Value == true,
                             });
                         }
                     }
@@ -89,12 +106,19 @@ namespace OfficeIMO.Excel {
                     if (sheetData != null) {
                         foreach (var row in sheetData.Elements<Row>()) {
                             var rowIndex = checked((int)(row.RowIndex?.Value ?? 0U));
-                            if (rowIndex > 0 && (row.Hidden?.Value == true || row.CustomHeight?.Value == true || row.Height != null)) {
+                            if (rowIndex > 0
+                                && (row.Hidden?.Value == true
+                                    || row.CustomHeight?.Value == true
+                                    || row.Height != null
+                                    || row.OutlineLevel != null
+                                    || row.Collapsed?.Value == true)) {
                                 worksheetSnapshot.AddRow(new ExcelRowSnapshot {
                                     Index = rowIndex,
                                     Height = row.Height?.Value,
                                     Hidden = row.Hidden?.Value == true,
                                     CustomHeight = row.CustomHeight?.Value == true,
+                                    OutlineLevel = row.OutlineLevel?.Value,
+                                    Collapsed = row.Collapsed?.Value == true,
                                 });
                             }
 
@@ -194,6 +218,22 @@ namespace OfficeIMO.Excel {
             }
 
             return snapshot;
+        }
+
+        private static int CountPackagePartsByContentType(OpenXmlPartContainer container, string marker) {
+            if (string.IsNullOrWhiteSpace(marker)) return 0;
+
+            int count = 0;
+            foreach (var relationship in container.Parts) {
+                var part = relationship.OpenXmlPart;
+                if (part.ContentType.IndexOf(marker, StringComparison.OrdinalIgnoreCase) >= 0) {
+                    count++;
+                }
+
+                count += CountPackagePartsByContentType(part, marker);
+            }
+
+            return count;
         }
 
         private static ExcelWorksheetProtectionSnapshot? BuildWorksheetProtectionSnapshot(SheetProtection? protection) {
@@ -678,6 +718,23 @@ namespace OfficeIMO.Excel {
             }
 
             return rgb.Length == 8 ? rgb.ToUpperInvariant() : null;
+        }
+
+        private static int? GetActiveWorksheetIndex(Workbook workbook, int sheetCount) {
+            if (sheetCount <= 0) {
+                return null;
+            }
+
+            uint activeTab = workbook.GetFirstChild<BookViews>()?
+                .Elements<WorkbookView>()
+                .FirstOrDefault()?
+                .ActiveTab?.Value ?? 0U;
+
+            if (activeTab >= sheetCount) {
+                return sheetCount - 1;
+            }
+
+            return checked((int)activeTab);
         }
 
         private static Dictionary<long, object?> BuildTypedCellMap(ExcelSheetReader readerSheet) {

--- a/OfficeIMO.Excel/ExcelDocument.Inspection.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Inspection.cs
@@ -44,7 +44,10 @@ namespace OfficeIMO.Excel {
 
                 for (int sheetIndex = 0; sheetIndex < sheetElements.Count; sheetIndex++) {
                     var sheet = sheetElements[sheetIndex];
-                    var worksheetPart = (WorksheetPart)workbookPart.GetPartById(sheet.Id!);
+                    if (sheet.Id == null || workbookPart.GetPartById(sheet.Id!) is not WorksheetPart worksheetPart) {
+                        continue;
+                    }
+
                     var worksheet = worksheetPart.Worksheet ?? throw new InvalidOperationException("Worksheet is missing.");
                     var sheetName = sheet.Name?.Value ?? $"Sheet{sheetIndex + 1}";
                     var readerSheet = reader.GetSheet(sheetName);

--- a/OfficeIMO.Excel/ExcelDocument.Inspection.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Inspection.cs
@@ -54,7 +54,7 @@ namespace OfficeIMO.Excel {
                     var typedValues = BuildTypedCellMap(readerSheet);
                     var hyperlinkMap = BuildHyperlinkMap(worksheetPart);
                     var commentMap = BuildCommentMap(worksheetPart);
-                    var threadedCommentMap = BuildThreadedCommentMap(worksheetPart, threadedCommentPeople);
+                    var threadedCommentMap = BuildThreadedCommentMap(worksheetPart, threadedCommentPeople, sheetName);
 
                     var outlineProperties = worksheet.GetFirstChild<SheetProperties>()?.GetFirstChild<OutlineProperties>();
                     var sheetView = worksheet
@@ -150,6 +150,8 @@ namespace OfficeIMO.Excel {
                             }
                         }
                     }
+
+                    AddCommentOnlyCells(worksheetSnapshot, commentMap);
 
                     foreach (var threadedComments in threadedCommentMap.Values) {
                         foreach (var threadedComment in threadedComments) {
@@ -298,13 +300,28 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                map[reference!] = new ExcelHyperlinkSnapshot {
+                var snapshot = new ExcelHyperlinkSnapshot {
                     IsExternal = isExternal,
                     Target = target!,
                 };
+                AddSnapshotForReference(map, reference!, snapshot);
             }
 
             return map;
+        }
+
+        private static void AddSnapshotForReference<TSnapshot>(Dictionary<string, TSnapshot> map, string reference, TSnapshot snapshot) {
+            if (A1.TryParseRange(reference, out int rowStart, out int columnStart, out int rowEnd, out int columnEnd)) {
+                for (int row = rowStart; row <= rowEnd; row++) {
+                    for (int column = columnStart; column <= columnEnd; column++) {
+                        map[A1.CellReference(row, column)] = snapshot;
+                    }
+                }
+
+                return;
+            }
+
+            map[reference] = snapshot;
         }
 
         private static Dictionary<string, ExcelCommentSnapshot> BuildCommentMap(WorksheetPart worksheetPart) {
@@ -340,6 +357,33 @@ namespace OfficeIMO.Excel {
             }
 
             return map;
+        }
+
+        private static void AddCommentOnlyCells(ExcelWorksheetSnapshot worksheetSnapshot, IReadOnlyDictionary<string, ExcelCommentSnapshot> commentMap) {
+            if (commentMap.Count == 0) {
+                return;
+            }
+
+            var existingCells = new HashSet<string>(
+                worksheetSnapshot.Cells.Select(cell => A1.CellReference(cell.Row, cell.Column)),
+                StringComparer.OrdinalIgnoreCase);
+
+            foreach (var pair in commentMap) {
+                if (existingCells.Contains(pair.Key)) {
+                    continue;
+                }
+
+                var (row, column) = A1.ParseCellRef(pair.Key);
+                if (row <= 0 || column <= 0) {
+                    continue;
+                }
+
+                worksheetSnapshot.AddCell(new ExcelCellSnapshot {
+                    Row = row,
+                    Column = column,
+                    Comment = pair.Value,
+                });
+            }
         }
 
         private static string ExtractCommentText(CommentText? commentText) {
@@ -388,7 +432,8 @@ namespace OfficeIMO.Excel {
 
         private static Dictionary<string, List<ExcelThreadedCommentSnapshot>> BuildThreadedCommentMap(
             WorksheetPart worksheetPart,
-            IReadOnlyDictionary<string, string> people) {
+            IReadOnlyDictionary<string, string> people,
+            string sheetName) {
             var map = new Dictionary<string, List<ExcelThreadedCommentSnapshot>>(StringComparer.OrdinalIgnoreCase);
             foreach (var commentsPart in worksheetPart.WorksheetThreadedCommentsParts) {
                 var threadedComments = commentsPart.ThreadedComments;
@@ -409,6 +454,7 @@ namespace OfficeIMO.Excel {
                     }
 
                     var snapshot = new ExcelThreadedCommentSnapshot {
+                        SheetName = sheetName,
                         CellReference = reference!,
                         Id = NullIfWhiteSpace(comment.Id?.Value),
                         ParentId = NullIfWhiteSpace(comment.ParentId?.Value),

--- a/OfficeIMO.Excel/ExcelDocument.Inspection.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Inspection.cs
@@ -304,16 +304,21 @@ namespace OfficeIMO.Excel {
                     IsExternal = isExternal,
                     Target = target!,
                 };
-                AddSnapshotForReference(map, reference!, snapshot);
+                AddSnapshotForReference(map, worksheet, reference!, snapshot);
             }
 
             return map;
         }
 
-        private static void AddSnapshotForReference<TSnapshot>(Dictionary<string, TSnapshot> map, string reference, TSnapshot snapshot) {
+        private static void AddSnapshotForReference<TSnapshot>(Dictionary<string, TSnapshot> map, Worksheet worksheet, string reference, TSnapshot snapshot) {
             if (A1.TryParseRange(reference, out int rowStart, out int columnStart, out int rowEnd, out int columnEnd)) {
-                for (int row = rowStart; row <= rowEnd; row++) {
-                    for (int column = columnStart; column <= columnEnd; column++) {
+                foreach (var cell in worksheet.Descendants<Cell>()) {
+                    string? cellReference = cell.CellReference?.Value;
+                    if (!A1.TryParseCellReferenceFast(cellReference, out int row, out int column)) {
+                        continue;
+                    }
+
+                    if (row >= rowStart && row <= rowEnd && column >= columnStart && column <= columnEnd) {
                         map[A1.CellReference(row, column)] = snapshot;
                     }
                 }

--- a/OfficeIMO.Excel/ExcelDocument.NamedRanges.cs
+++ b/OfficeIMO.Excel/ExcelDocument.NamedRanges.cs
@@ -63,7 +63,7 @@ namespace OfficeIMO.Excel {
                 definedNames.Append(dnNew);
             }
             MarkPackageDirty();
-            if (save) Save();
+            if (save) WorkbookRoot.Save();
         }
 
         /// <summary>
@@ -179,7 +179,7 @@ namespace OfficeIMO.Excel {
             }
             MarkPackageDirty();
             if (save) {
-                Save();
+                WorkbookRoot.Save();
             }
             return true;
         }

--- a/OfficeIMO.Excel/ExcelDocument.NamedRanges.cs
+++ b/OfficeIMO.Excel/ExcelDocument.NamedRanges.cs
@@ -62,7 +62,8 @@ namespace OfficeIMO.Excel {
                 var dnNew = new DefinedName { Name = name, Text = localRef, LocalSheetId = sheetPos, Hidden = hidden ? true : (bool?)null };
                 definedNames.Append(dnNew);
             }
-            if (save) workbook.Save();
+            MarkPackageDirty();
+            if (save) Save();
         }
 
         /// <summary>
@@ -176,8 +177,9 @@ namespace OfficeIMO.Excel {
             if (!definedNames.Elements<DefinedName>().Any()) {
                 WorkbookRoot.DefinedNames = null;
             }
+            MarkPackageDirty();
             if (save) {
-                WorkbookRoot.Save();
+                Save();
             }
             return true;
         }

--- a/OfficeIMO.Excel/ExcelDocument.NamedRanges.cs
+++ b/OfficeIMO.Excel/ExcelDocument.NamedRanges.cs
@@ -47,18 +47,18 @@ namespace OfficeIMO.Excel {
             name = EnsureValidDefinedName(name, validationMode);
 
             if (scope == null) {
+                string reference = NormalizeRange(range, validationMode); // may already contain a sheet prefix
                 // Workbook-global name: remove any existing global with same name
                 foreach (var dn in definedNames.Elements<DefinedName>().Where(d => d.Name == name && d.LocalSheetId == null).ToList())
                     dn.Remove();
-                string reference = NormalizeRange(range, validationMode); // may already contain a sheet prefix
                 var dnNew = new DefinedName { Name = name, Text = reference, Hidden = hidden ? true : (bool?)null };
                 definedNames.Append(dnNew);
             } else {
                 // Sheet-local name: remove existing with same name for this sheet
                 ushort sheetPos = GetSheetPositionIndex(scope);
+                string localRef = NormalizeLocalNamedRange(scope, range, validationMode);
                 foreach (var dn in definedNames.Elements<DefinedName>().Where(d => d.Name == name && d.LocalSheetId != null && d.LocalSheetId.Value == sheetPos).ToList())
                     dn.Remove();
-                string localRef = NormalizeLocalNamedRange(scope, range, validationMode);
                 var dnNew = new DefinedName { Name = name, Text = localRef, LocalSheetId = sheetPos, Hidden = hidden ? true : (bool?)null };
                 definedNames.Append(dnNew);
             }

--- a/OfficeIMO.Excel/ExcelDocument.NamedRanges.cs
+++ b/OfficeIMO.Excel/ExcelDocument.NamedRanges.cs
@@ -63,7 +63,7 @@ namespace OfficeIMO.Excel {
                 definedNames.Append(dnNew);
             }
             MarkPackageDirty();
-            if (save) WorkbookRoot.Save();
+            SaveWorkbookScopedChange(save);
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace OfficeIMO.Excel {
             string normalized = NormalizeRange($"'{EscapeSheetName(sheet.Name)}'!{range}");
             var printArea = new DefinedName { Name = "_xlnm.Print_Area", LocalSheetId = sheetPos, Text = normalized };
             definedNames.Append(printArea);
-            if (save) workbook.Save();
+            SaveWorkbookScopedChange(save);
         }
 
         /// <summary>
@@ -178,9 +178,7 @@ namespace OfficeIMO.Excel {
                 WorkbookRoot.DefinedNames = null;
             }
             MarkPackageDirty();
-            if (save) {
-                WorkbookRoot.Save();
-            }
+            SaveWorkbookScopedChange(save);
             return true;
         }
 
@@ -233,7 +231,7 @@ namespace OfficeIMO.Excel {
             bool hasRows = firstRow.HasValue && lastRow.HasValue && firstRow.Value > 0 && lastRow.Value >= firstRow.Value;
             bool hasCols = firstCol.HasValue && lastCol.HasValue && firstCol.Value > 0 && lastCol.Value >= firstCol.Value;
             if (!hasRows && !hasCols) {
-                if (save) workbook.Save();
+                SaveWorkbookScopedChange(save);
                 return;
             }
 
@@ -250,7 +248,22 @@ namespace OfficeIMO.Excel {
             string text = hasRows && hasCols ? string.Concat(rowsPart, ",", colsPart) : (rowsPart ?? colsPart)!;
             var dnNew = new DefinedName { Name = "_xlnm.Print_Titles", LocalSheetId = sheetPos, Text = text };
             definedNames.Append(dnNew);
-            if (save) workbook.Save();
+            SaveWorkbookScopedChange(save);
+        }
+
+        private void SaveWorkbookScopedChange(bool save) {
+            if (!save) {
+                return;
+            }
+
+            WorkbookRoot.Save();
+            if (_packageContentTypesKnownNormalized
+                && !string.IsNullOrEmpty(FilePath)
+                && !_copyPackageToFilePathOnDispose
+                && !_copyPackageToSourceOnDispose
+                && _spreadSheetDocument.FileOpenAccess != System.IO.FileAccess.Read) {
+                Save(FilePath, openExcel: false);
+            }
         }
 
         /// <summary>

--- a/OfficeIMO.Excel/ExcelDocument.NamedRanges.cs
+++ b/OfficeIMO.Excel/ExcelDocument.NamedRanges.cs
@@ -381,6 +381,7 @@ namespace OfficeIMO.Excel {
                 sheetPrefix = NormalizeSheetPrefix(range.Substring(0, idx), validationMode);
                 a1 = range.Substring(idx + 1);
             }
+            a1 = a1.Replace("$", string.Empty);
 
             int r1, c1, r2, c2;
             if (!A1.TryParseRange(a1, out r1, out c1, out r2, out c2)) {

--- a/OfficeIMO.Excel/ExcelDocument.NamedRanges.cs
+++ b/OfficeIMO.Excel/ExcelDocument.NamedRanges.cs
@@ -86,6 +86,7 @@ namespace OfficeIMO.Excel {
             string normalized = NormalizeRange($"'{EscapeSheetName(sheet.Name)}'!{range}");
             var printArea = new DefinedName { Name = "_xlnm.Print_Area", LocalSheetId = sheetPos, Text = normalized };
             definedNames.Append(printArea);
+            MarkPackageDirty();
             SaveWorkbookScopedChange(save);
         }
 
@@ -223,8 +224,10 @@ namespace OfficeIMO.Excel {
             // Remove existing sheet-local Print_Titles for this sheet
             ushort sheetPos = GetSheetPositionIndex(sheet);
             foreach (var dn in definedNames.Elements<DefinedName>().Where(d => d.Name == "_xlnm.Print_Titles").ToList()) {
-                if (dn.LocalSheetId != null && dn.LocalSheetId.Value == sheetPos)
+                if (dn.LocalSheetId != null && dn.LocalSheetId.Value == sheetPos) {
                     dn.Remove();
+                    MarkPackageDirty();
+                }
             }
 
             // Nothing to set? stop here (clears existing titles)
@@ -248,6 +251,7 @@ namespace OfficeIMO.Excel {
             string text = hasRows && hasCols ? string.Concat(rowsPart, ",", colsPart) : (rowsPart ?? colsPart)!;
             var dnNew = new DefinedName { Name = "_xlnm.Print_Titles", LocalSheetId = sheetPos, Text = text };
             definedNames.Append(dnNew);
+            MarkPackageDirty();
             SaveWorkbookScopedChange(save);
         }
 

--- a/OfficeIMO.Excel/ExcelDocument.Refresh.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Refresh.cs
@@ -1,0 +1,83 @@
+using System.Text;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelDocument {
+        /// <summary>
+        /// Enables or disables workbook refresh-on-open metadata for supported workbook data features.
+        /// OfficeIMO writes the metadata request; Excel-compatible applications perform the actual refresh on open.
+        /// </summary>
+        /// <param name="enabled">Whether refresh-on-open should be enabled.</param>
+        /// <param name="pivotTables">Update pivot cache definitions.</param>
+        /// <param name="connections">Update workbook connection metadata parts.</param>
+        /// <param name="savePivotSourceData">Optional pivot cache source-data setting to apply together with the refresh request.</param>
+        /// <returns>Counts of metadata entries updated.</returns>
+        public ExcelRefreshOnOpenResult SetRefreshOnOpen(
+            bool enabled = true,
+            bool pivotTables = true,
+            bool connections = true,
+            bool? savePivotSourceData = null) {
+            int pivotCacheCount = 0;
+            int connectionCount = 0;
+
+            if (pivotTables) {
+                foreach (var cachePart in WorkbookPartRoot.GetPartsOfType<PivotTableCacheDefinitionPart>()) {
+                    var cacheDefinition = cachePart.PivotCacheDefinition;
+                    if (cacheDefinition == null) {
+                        continue;
+                    }
+
+                    cacheDefinition.RefreshOnLoad = enabled;
+                    if (savePivotSourceData.HasValue) {
+                        cacheDefinition.SaveData = savePivotSourceData.Value;
+                    }
+
+                    cacheDefinition.Save();
+                    pivotCacheCount++;
+                }
+            }
+
+            if (connections) {
+                foreach (var part in WorkbookPartRoot.Parts.Select(relationship => relationship.OpenXmlPart).OfType<ExtendedPart>()) {
+                    if (!string.Equals(part.RelationshipType, WorkbookConnectionRelationshipType, StringComparison.Ordinal)
+                        && part.ContentType.IndexOf("connections", StringComparison.OrdinalIgnoreCase) < 0) {
+                        continue;
+                    }
+
+                    connectionCount += SetConnectionPartRefreshOnOpen(part, enabled);
+                }
+            }
+
+            if (pivotCacheCount > 0 || connectionCount > 0) {
+                MarkPackageDirty();
+            }
+
+            return new ExcelRefreshOnOpenResult(enabled, pivotCacheCount, connectionCount);
+        }
+
+        private static int SetConnectionPartRefreshOnOpen(ExtendedPart part, bool enabled) {
+            XDocument document;
+            using (Stream stream = part.GetStream(FileMode.Open, FileAccess.Read)) {
+                document = XDocument.Load(stream, LoadOptions.PreserveWhitespace);
+            }
+
+            int count = 0;
+            foreach (XElement connection in document.Descendants().Where(element => element.Name.LocalName == "connection")) {
+                connection.SetAttributeValue("refreshOnLoad", enabled ? "1" : "0");
+                count++;
+            }
+
+            if (count == 0) {
+                return 0;
+            }
+
+            using (Stream stream = part.GetStream(FileMode.Create, FileAccess.Write)) {
+                using var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                document.Save(writer, SaveOptions.DisableFormatting);
+            }
+
+            return count;
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.Refresh.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Refresh.cs
@@ -39,12 +39,7 @@ namespace OfficeIMO.Excel {
             }
 
             if (connections) {
-                foreach (var part in WorkbookPartRoot.Parts.Select(relationship => relationship.OpenXmlPart).OfType<ExtendedPart>()) {
-                    if (!string.Equals(part.RelationshipType, WorkbookConnectionRelationshipType, StringComparison.Ordinal)
-                        && part.ContentType.IndexOf("connections", StringComparison.OrdinalIgnoreCase) < 0) {
-                        continue;
-                    }
-
+                foreach (OpenXmlPart part in EnumerateWorkbookConnectionParts()) {
                     connectionCount += SetConnectionPartRefreshOnOpen(part, enabled);
                 }
             }
@@ -56,11 +51,9 @@ namespace OfficeIMO.Excel {
             return new ExcelRefreshOnOpenResult(enabled, pivotCacheCount, connectionCount);
         }
 
-        private static int SetConnectionPartRefreshOnOpen(ExtendedPart part, bool enabled) {
+        private static int SetConnectionPartRefreshOnOpen(OpenXmlPart part, bool enabled) {
             XDocument document;
-            using (Stream stream = part.GetStream(FileMode.Open, FileAccess.Read)) {
-                document = XDocument.Load(stream, LoadOptions.PreserveWhitespace);
-            }
+            document = XDocument.Parse(ReadOpenXmlPartText(part), LoadOptions.PreserveWhitespace);
 
             int count = 0;
             foreach (XElement connection in document.Descendants().Where(element => element.Name.LocalName == "connection")) {
@@ -72,10 +65,7 @@ namespace OfficeIMO.Excel {
                 return 0;
             }
 
-            using (Stream stream = part.GetStream(FileMode.Create, FileAccess.Write)) {
-                using var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-                document.Save(writer, SaveOptions.DisableFormatting);
-            }
+            WriteOpenXmlPartText(part, document.ToString(SaveOptions.DisableFormatting));
 
             return count;
         }

--- a/OfficeIMO.Excel/ExcelDocument.Save.Package.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Save.Package.cs
@@ -73,6 +73,9 @@ namespace OfficeIMO.Excel {
             }
             ReportSaveTiming(stageWatch, "Save.PrepareWorkbook.SaveSharedStrings");
 
+            SaveCustomDocumentProperties();
+            ReportSaveTiming(stageWatch, "Save.PrepareWorkbook.SaveCustomDocumentProperties");
+
             WorkbookRoot.Save();
             ReportSaveTiming(stageWatch, "Save.PrepareWorkbook.SaveWorkbookRoot");
             try { _spreadSheetDocument.PackageProperties.Modified = DateTime.UtcNow; } catch { }

--- a/OfficeIMO.Excel/ExcelDocument.TemplateCreation.cs
+++ b/OfficeIMO.Excel/ExcelDocument.TemplateCreation.cs
@@ -67,6 +67,7 @@ namespace OfficeIMO.Excel {
                 throw new FileNotFoundException($"Workbook package '{resolvedSourcePath}' was not found.", resolvedSourcePath);
             }
 
+            EnsureMacroCompatibleCopy(resolvedSourcePath, resolvedDestinationPath);
             EnsureDestinationDirectory(resolvedDestinationPath);
             File.Copy(resolvedSourcePath, resolvedDestinationPath, overwrite);
             NormalizeTemplateWorkbookContentType(resolvedDestinationPath);
@@ -99,7 +100,13 @@ namespace OfficeIMO.Excel {
                 sourceStream.CopyTo(targetStream);
             }
 
-            NormalizeTemplateWorkbookContentType(targetPath);
+            try {
+                EnsureMacroCompatibleCopy(targetPath, targetPath);
+                NormalizeTemplateWorkbookContentType(targetPath);
+            } catch {
+                File.Delete(targetPath);
+                throw;
+            }
         }
 
         private static void EnsureDestinationDirectory(string filePath) {
@@ -145,6 +152,54 @@ namespace OfficeIMO.Excel {
             ZipArchiveEntry replacement = archive.CreateEntry("[Content_Types].xml", CompressionLevel.Optimal);
             using Stream replacementStream = replacement.Open();
             document.Save(replacementStream, SaveOptions.DisableFormatting);
+        }
+
+        private static void EnsureMacroCompatibleCopy(string sourcePath, string destinationPath) {
+            if (AllowsMacroWorkbookContent(destinationPath) || !ForcesMacroFreeWorkbookContent(destinationPath)) {
+                return;
+            }
+
+            if (PackageContainsMacroContent(sourcePath)) {
+                throw new InvalidOperationException("Macro-enabled workbook packages cannot be copied to a macro-free .xlsx or .xltx destination. Use .xlsm or .xltm to preserve macros.");
+            }
+        }
+
+        private static bool PackageContainsMacroContent(string filePath) {
+            using ZipArchive archive = ZipFile.OpenRead(filePath);
+            if (archive.GetEntry("xl/vbaProject.bin") != null) {
+                return true;
+            }
+
+            string? workbookContentType = ReadWorkbookOverrideContentType(archive);
+            return string.Equals(workbookContentType, MacroEnabledWorkbookContentType, StringComparison.Ordinal)
+                || string.Equals(workbookContentType, MacroEnabledTemplateWorkbookContentType, StringComparison.Ordinal);
+        }
+
+        private static string? ReadWorkbookOverrideContentType(ZipArchive archive) {
+            ZipArchiveEntry? contentTypesEntry = archive.GetEntry("[Content_Types].xml");
+            if (contentTypesEntry == null) {
+                return null;
+            }
+
+            using Stream stream = contentTypesEntry.Open();
+            XDocument document = XDocument.Load(stream);
+            XNamespace ns = "http://schemas.openxmlformats.org/package/2006/content-types";
+            return document
+                .Root?
+                .Elements(ns + "Override")
+                .FirstOrDefault(element => string.Equals((string?)element.Attribute("PartName"), "/xl/workbook.xml", StringComparison.OrdinalIgnoreCase))
+                ?.Attribute("ContentType")
+                ?.Value;
+        }
+
+        private static bool AllowsMacroWorkbookContent(string filePath) {
+            string extension = Path.GetExtension(filePath).ToLowerInvariant();
+            return extension is ".xlsm" or ".xltm";
+        }
+
+        private static bool ForcesMacroFreeWorkbookContent(string filePath) {
+            string extension = Path.GetExtension(filePath).ToLowerInvariant();
+            return extension is ".xlsx" or ".xltx";
         }
 
         private static string? ResolveWorkbookContentTypeForPath(string filePath) {

--- a/OfficeIMO.Excel/ExcelDocument.TemplateCreation.cs
+++ b/OfficeIMO.Excel/ExcelDocument.TemplateCreation.cs
@@ -1,0 +1,161 @@
+using System.IO.Compression;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelDocument {
+        private const string WorkbookContentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml";
+        private const string MacroEnabledWorkbookContentType = "application/vnd.ms-excel.sheet.macroEnabled.main+xml";
+        private const string TemplateWorkbookContentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.template.main+xml";
+        private const string MacroEnabledTemplateWorkbookContentType = "application/vnd.ms-excel.template.macroEnabled.main+xml";
+
+        /// <summary>
+        /// Creates an editable workbook by copying a template package to a destination path and loading the copy.
+        /// Package parts such as styles, themes, drawings, tables, named ranges, and worksheet metadata are preserved.
+        /// </summary>
+        /// <param name="templatePath">Path to the source workbook or template package.</param>
+        /// <param name="filePath">Destination workbook path.</param>
+        /// <param name="overwrite">When true, replaces an existing destination file.</param>
+        /// <param name="autoSave">When true, saves changes on dispose.</param>
+        /// <param name="openSettings">Optional Open XML load settings.</param>
+        /// <returns>The loaded destination workbook.</returns>
+        public static ExcelDocument CreateFromTemplate(
+            string templatePath,
+            string filePath,
+            bool overwrite = true,
+            bool autoSave = false,
+            OpenSettings? openSettings = null) {
+            CopyPackage(templatePath, filePath, overwrite);
+            string targetPath = Path.GetFullPath(filePath);
+            return Load(targetPath, readOnly: false, autoSave: autoSave, openSettings: openSettings);
+        }
+
+        /// <summary>
+        /// Creates an editable workbook by copying a template package stream to a destination path and loading the copy.
+        /// </summary>
+        /// <param name="templateStream">Readable template package stream.</param>
+        /// <param name="filePath">Destination workbook path.</param>
+        /// <param name="overwrite">When true, replaces an existing destination file.</param>
+        /// <param name="autoSave">When true, saves changes on dispose.</param>
+        /// <param name="openSettings">Optional Open XML load settings.</param>
+        /// <returns>The loaded destination workbook.</returns>
+        public static ExcelDocument CreateFromTemplate(
+            Stream templateStream,
+            string filePath,
+            bool overwrite = true,
+            bool autoSave = false,
+            OpenSettings? openSettings = null) {
+            CopyPackage(templateStream, filePath, overwrite);
+            string targetPath = Path.GetFullPath(filePath);
+            return Load(targetPath, readOnly: false, autoSave: autoSave, openSettings: openSettings);
+        }
+
+        /// <summary>
+        /// Copies an existing workbook or template package to a destination path while preserving package parts.
+        /// The workbook content type is normalized for the destination extension.
+        /// </summary>
+        /// <param name="sourcePath">Path to the source workbook or template package.</param>
+        /// <param name="destinationPath">Destination workbook path.</param>
+        /// <param name="overwrite">When true, replaces an existing destination file.</param>
+        public static void CopyPackage(string sourcePath, string destinationPath, bool overwrite = true) {
+            if (string.IsNullOrWhiteSpace(sourcePath)) throw new ArgumentNullException(nameof(sourcePath));
+            if (string.IsNullOrWhiteSpace(destinationPath)) throw new ArgumentNullException(nameof(destinationPath));
+
+            string resolvedSourcePath = Path.GetFullPath(sourcePath);
+            string resolvedDestinationPath = Path.GetFullPath(destinationPath);
+            if (!File.Exists(resolvedSourcePath)) {
+                throw new FileNotFoundException($"Workbook package '{resolvedSourcePath}' was not found.", resolvedSourcePath);
+            }
+
+            EnsureDestinationDirectory(resolvedDestinationPath);
+            File.Copy(resolvedSourcePath, resolvedDestinationPath, overwrite);
+            NormalizeTemplateWorkbookContentType(resolvedDestinationPath);
+        }
+
+        /// <summary>
+        /// Copies a workbook or template package stream to a destination path while preserving package parts.
+        /// The workbook content type is normalized for the destination extension.
+        /// </summary>
+        /// <param name="sourceStream">Readable workbook package stream.</param>
+        /// <param name="destinationPath">Destination workbook path.</param>
+        /// <param name="overwrite">When true, replaces an existing destination file.</param>
+        public static void CopyPackage(Stream sourceStream, string destinationPath, bool overwrite = true) {
+            if (sourceStream == null) throw new ArgumentNullException(nameof(sourceStream));
+            if (!sourceStream.CanRead) throw new ArgumentException("Workbook package stream must be readable.", nameof(sourceStream));
+            if (string.IsNullOrWhiteSpace(destinationPath)) throw new ArgumentNullException(nameof(destinationPath));
+
+            string targetPath = Path.GetFullPath(destinationPath);
+            if (File.Exists(targetPath)) {
+                if (!overwrite) {
+                    throw new IOException($"Destination workbook '{targetPath}' already exists.");
+                }
+
+                File.Delete(targetPath);
+            }
+
+            EnsureDestinationDirectory(targetPath);
+
+            using (var targetStream = new FileStream(targetPath, FileMode.Create, FileAccess.Write, FileShare.None)) {
+                sourceStream.CopyTo(targetStream);
+            }
+
+            NormalizeTemplateWorkbookContentType(targetPath);
+        }
+
+        private static void EnsureDestinationDirectory(string filePath) {
+            string? directory = Path.GetDirectoryName(filePath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory)) {
+                Directory.CreateDirectory(directory);
+            }
+        }
+
+        private static void NormalizeTemplateWorkbookContentType(string filePath) {
+            string? contentType = ResolveWorkbookContentTypeForPath(filePath);
+            if (contentType == null) {
+                return;
+            }
+
+            using ZipArchive archive = ZipFile.Open(filePath, ZipArchiveMode.Update);
+            ZipArchiveEntry? contentTypesEntry = archive.GetEntry("[Content_Types].xml");
+            if (contentTypesEntry == null) {
+                return;
+            }
+
+            XDocument document;
+            using (Stream stream = contentTypesEntry.Open()) {
+                document = XDocument.Load(stream, LoadOptions.PreserveWhitespace);
+            }
+
+            XNamespace ns = "http://schemas.openxmlformats.org/package/2006/content-types";
+            XElement? workbookOverride = document
+                .Root?
+                .Elements(ns + "Override")
+                .FirstOrDefault(element => string.Equals((string?)element.Attribute("PartName"), "/xl/workbook.xml", StringComparison.OrdinalIgnoreCase));
+            if (workbookOverride == null) {
+                return;
+            }
+
+            XAttribute? contentTypeAttribute = workbookOverride.Attribute("ContentType");
+            if (string.Equals(contentTypeAttribute?.Value, contentType, StringComparison.Ordinal)) {
+                return;
+            }
+
+            workbookOverride.SetAttributeValue("ContentType", contentType);
+            contentTypesEntry.Delete();
+            ZipArchiveEntry replacement = archive.CreateEntry("[Content_Types].xml", CompressionLevel.Optimal);
+            using Stream replacementStream = replacement.Open();
+            document.Save(replacementStream, SaveOptions.DisableFormatting);
+        }
+
+        private static string? ResolveWorkbookContentTypeForPath(string filePath) {
+            string extension = Path.GetExtension(filePath).ToLowerInvariant();
+            return extension switch {
+                ".xlsx" => WorkbookContentType,
+                ".xlsm" => MacroEnabledWorkbookContentType,
+                ".xltx" => TemplateWorkbookContentType,
+                ".xltm" => MacroEnabledTemplateWorkbookContentType,
+                _ => null
+            };
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.Theme.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Theme.cs
@@ -48,10 +48,13 @@ namespace OfficeIMO.Excel {
             ThemePart themePart = workbookPart.GetPartsOfType<ThemePart>().FirstOrDefault() ?? workbookPart.AddNewPart<ThemePart>();
             byte[] bytes = Encoding.UTF8.GetBytes(themeXml);
             using var stream = new MemoryStream(bytes);
+            MarkPackageDirty();
             themePart.FeedData(stream);
 
             EnsureWorkbookThemeAndStyles();
-            Save();
+            if (!string.IsNullOrEmpty(FilePath)) {
+                Save();
+            }
             return this;
         }
 

--- a/OfficeIMO.Excel/ExcelDocument.Theme.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Theme.cs
@@ -55,7 +55,7 @@ namespace OfficeIMO.Excel {
             themePart.FeedData(stream);
 
             EnsureWorkbookThemeAndStyles();
-            if (!string.IsNullOrEmpty(FilePath)) {
+            if (!string.IsNullOrEmpty(FilePath) && _spreadSheetDocument?.AutoSave == true) {
                 Save();
             }
             return this;

--- a/OfficeIMO.Excel/ExcelDocument.Theme.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Theme.cs
@@ -17,7 +17,10 @@ namespace OfficeIMO.Excel {
         /// Ensures the workbook contains the default Office theme and stylesheet parts.
         /// </summary>
         public ExcelDocument EnsureWorkbookTheme() {
-            EnsureWorkbookThemeAndStyles();
+            if (EnsureWorkbookThemeAndStyles()) {
+                MarkPackageDirty();
+            }
+
             return this;
         }
 

--- a/OfficeIMO.Excel/ExcelDocument.Theme.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Theme.cs
@@ -1,0 +1,118 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Represents an Excel document and provides methods for creating,
+    /// loading and saving spreadsheets.
+    /// </summary>
+    public partial class ExcelDocument {
+        private static readonly XNamespace DrawingNamespace = "http://schemas.openxmlformats.org/drawingml/2006/main";
+
+        /// <summary>
+        /// Ensures the workbook contains the default Office theme and stylesheet parts.
+        /// </summary>
+        public ExcelDocument EnsureWorkbookTheme() {
+            EnsureWorkbookThemeAndStyles();
+            return this;
+        }
+
+        /// <summary>
+        /// Replaces the workbook theme with the embedded default Office theme.
+        /// </summary>
+        public ExcelDocument ResetWorkbookTheme(string? name = null) {
+            string xml = Encoding.UTF8.GetString(DefaultThemeBytes.Value);
+            if (!string.IsNullOrWhiteSpace(name)) {
+                xml = RenameThemeXml(xml, name!);
+            }
+
+            SetWorkbookThemeXml(xml);
+            return this;
+        }
+
+        /// <summary>
+        /// Replaces or creates the workbook theme part with caller-supplied DrawingML theme XML.
+        /// </summary>
+        public ExcelDocument SetWorkbookThemeXml(string themeXml) {
+            if (string.IsNullOrWhiteSpace(themeXml)) {
+                throw new ArgumentException("Theme XML cannot be null or empty.", nameof(themeXml));
+            }
+
+            XDocument.Parse(themeXml);
+
+            var workbookPart = _spreadSheetDocument?.WorkbookPart ?? _workBookPart;
+            ThemePart themePart = workbookPart.GetPartsOfType<ThemePart>().FirstOrDefault() ?? workbookPart.AddNewPart<ThemePart>();
+            byte[] bytes = Encoding.UTF8.GetBytes(themeXml);
+            using var stream = new MemoryStream(bytes);
+            themePart.FeedData(stream);
+
+            EnsureWorkbookThemeAndStyles();
+            Save();
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the workbook theme name while preserving the rest of the theme XML.
+        /// </summary>
+        public ExcelDocument SetWorkbookThemeName(string name) {
+            if (string.IsNullOrWhiteSpace(name)) {
+                throw new ArgumentException("Theme name cannot be null or empty.", nameof(name));
+            }
+
+            string xml = GetWorkbookThemeXml() ?? Encoding.UTF8.GetString(DefaultThemeBytes.Value);
+            SetWorkbookThemeXml(RenameThemeXml(xml, name));
+            return this;
+        }
+
+        /// <summary>
+        /// Gets workbook theme metadata and optionally includes the raw theme XML.
+        /// </summary>
+        public ExcelWorkbookThemeInfo GetWorkbookTheme(bool includeXml = false) {
+            string? xml = GetWorkbookThemeXml();
+            if (xml == null) {
+                return new ExcelWorkbookThemeInfo(false, null, null);
+            }
+
+            return new ExcelWorkbookThemeInfo(true, TryGetThemeName(xml), includeXml ? xml : null);
+        }
+
+        /// <summary>
+        /// Gets the raw workbook theme XML when a theme part exists.
+        /// </summary>
+        public string? GetWorkbookThemeXml() {
+            var workbookPart = _spreadSheetDocument?.WorkbookPart ?? _workBookPart;
+            ThemePart? themePart = workbookPart.GetPartsOfType<ThemePart>().FirstOrDefault();
+            if (themePart == null) {
+                return null;
+            }
+
+            using Stream stream = themePart.GetStream(FileMode.Open, FileAccess.Read);
+            using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+            return reader.ReadToEnd();
+        }
+
+        private static string RenameThemeXml(string themeXml, string name) {
+            XDocument document = XDocument.Parse(themeXml);
+            XElement root = document.Root ?? throw new InvalidOperationException("Theme XML did not contain a root element.");
+            if (root.Name != DrawingNamespace + "theme") {
+                throw new InvalidOperationException("Theme XML root must be a DrawingML theme element.");
+            }
+
+            root.SetAttributeValue("name", name);
+            return document.ToString(SaveOptions.DisableFormatting);
+        }
+
+        private static string? TryGetThemeName(string themeXml) {
+            try {
+                XDocument document = XDocument.Parse(themeXml);
+                return document.Root?.Attribute("name")?.Value;
+            } catch {
+                return null;
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.WorkbookMerge.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorkbookMerge.cs
@@ -28,7 +28,7 @@ namespace OfficeIMO.Excel {
                 createdTargetNames.Add(targetSheet.Name);
             }
 
-            Save();
+            MarkPackageDirty();
             return new ExcelWorkbookMergeResult(importedSourceNames, createdTargetNames);
         }
 

--- a/OfficeIMO.Excel/ExcelDocument.WorkbookMerge.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorkbookMerge.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Represents an Excel document and provides methods for creating,
+    /// loading and saving spreadsheets.
+    /// </summary>
+    public partial class ExcelDocument {
+        /// <summary>
+        /// Imports selected or all worksheets from another workbook into this workbook.
+        /// </summary>
+        public ExcelWorkbookMergeResult MergeWorkbookFrom(ExcelDocument sourceDocument, ExcelWorkbookMergeOptions? options = null) {
+            if (sourceDocument == null) {
+                throw new ArgumentNullException(nameof(sourceDocument));
+            }
+
+            options ??= new ExcelWorkbookMergeOptions();
+            List<ExcelSheet> sourceSheets = ResolveWorkbookMergeSheets(sourceDocument, options).ToList();
+            var importedSourceNames = new List<string>(sourceSheets.Count);
+            var createdTargetNames = new List<string>(sourceSheets.Count);
+
+            foreach (ExcelSheet sourceSheet in sourceSheets) {
+                string requestedName = (options.SheetNamePrefix ?? string.Empty) + sourceSheet.Name;
+                ExcelSheet targetSheet = CopyWorkSheetFrom(sourceDocument, sourceSheet.Name, requestedName, options.SheetNameValidationMode);
+                importedSourceNames.Add(sourceSheet.Name);
+                createdTargetNames.Add(targetSheet.Name);
+            }
+
+            Save();
+            return new ExcelWorkbookMergeResult(importedSourceNames, createdTargetNames);
+        }
+
+        /// <summary>
+        /// Alias for <see cref="MergeWorkbookFrom(ExcelDocument, ExcelWorkbookMergeOptions?)"/>.
+        /// </summary>
+        public ExcelWorkbookMergeResult JoinWorkbookFrom(ExcelDocument sourceDocument, ExcelWorkbookMergeOptions? options = null)
+            => MergeWorkbookFrom(sourceDocument, options);
+
+        private static IEnumerable<ExcelSheet> ResolveWorkbookMergeSheets(ExcelDocument sourceDocument, ExcelWorkbookMergeOptions options) {
+            if (options.SheetNames == null || options.SheetNames.Count == 0) {
+                return sourceDocument.Sheets;
+            }
+
+            return options.SheetNames.Select(sourceDocument.GetSheet);
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -91,20 +91,30 @@ namespace OfficeIMO.Excel {
         internal ReaderWriterLockSlim EnsureLock()
             => _lock ??= new ReaderWriterLockSlim(); // default: NoRecursion
 
-        internal void EnsureWorkbookThemeAndStyles() {
+        internal bool EnsureWorkbookThemeAndStyles() {
             var workbookPart = _spreadSheetDocument?.WorkbookPart ?? _workBookPart;
+            bool changed = false;
 
             if (!workbookPart.GetPartsOfType<ThemePart>().Any()) {
                 ThemePart themePart = workbookPart.AddNewPart<ThemePart>();
                 using var themeStream = new MemoryStream(DefaultThemeBytes.Value);
                 themePart.FeedData(themeStream);
+                changed = true;
             }
 
-            var stylesPart = workbookPart.WorkbookStylesPart ?? workbookPart.AddNewPart<WorkbookStylesPart>();
+            var stylesPart = workbookPart.WorkbookStylesPart;
+            if (stylesPart == null) {
+                stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
+                changed = true;
+            }
+
             if (stylesPart.Stylesheet == null) {
                 stylesPart.Stylesheet = CreateDefaultStylesheet();
                 stylesPart.Stylesheet.Save();
+                changed = true;
             }
+
+            return changed;
         }
 
         private static Stylesheet CreateDefaultStylesheet() {

--- a/OfficeIMO.Excel/ExcelDocument.cs
+++ b/OfficeIMO.Excel/ExcelDocument.cs
@@ -37,6 +37,7 @@ namespace OfficeIMO.Excel {
         private System.Collections.Generic.IEqualityComparer<string> _tableNameComparer = System.StringComparer.OrdinalIgnoreCase;
         private List<ExcelSheet>? _cachedSheets;
         private bool _sheetCacheDirty = true;
+        private bool _customDocumentPropertiesDirty;
 
         /// <summary>
         /// Enables caching of <see cref="ExcelSheet"/> wrappers for faster repeat access at the cost of higher memory usage.

--- a/OfficeIMO.Excel/ExcelFeatureReport.RepairHints.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.RepairHints.cs
@@ -1,0 +1,177 @@
+namespace OfficeIMO.Excel {
+    public sealed partial class ExcelFeatureReport {
+        /// <summary>
+        /// Returns actionable repair or routing hints for a blocked preflight capability.
+        /// </summary>
+        /// <param name="capability">Capability to explain.</param>
+        public IReadOnlyList<ExcelPreflightRepairHint> GetRepairHints(ExcelPreflightCapability capability) {
+            if (Can(capability)) {
+                return Array.Empty<ExcelPreflightRepairHint>();
+            }
+
+            var hints = new List<ExcelPreflightRepairHint>();
+            foreach (ExcelFeatureFinding finding in GetCapabilityFindings(capability)) {
+                AddRepairHints(hints, capability, finding);
+            }
+
+            return hints
+                .GroupBy(hint => hint.FeatureName + "\u001f" + hint.Action + "\u001f" + (hint.Command ?? string.Empty), StringComparer.Ordinal)
+                .Select(group => group.First())
+                .ToArray();
+        }
+
+        private IEnumerable<ExcelFeatureFinding> GetCapabilityFindings(ExcelPreflightCapability capability) {
+            switch (capability) {
+                case ExcelPreflightCapability.ReadWorkbookData:
+                    return UnsupportedFeatures.Concat(FindFeatures("Non-worksheet sheets"));
+                case ExcelPreflightCapability.EditCellValues:
+                    return UnsupportedFeatures.Concat(FindFeatures("Digital signatures"));
+                case ExcelPreflightCapability.EditWorkbookStructure:
+                case ExcelPreflightCapability.BindTemplate:
+                    return UnsupportedFeatures.Concat(PreservedFeatures);
+                case ExcelPreflightCapability.UseCachedFormulaValues:
+                    return FindFeatures("Missing formula caches", "Dirty formula caches", "Workbook recalculation requests");
+                case ExcelPreflightCapability.CalculateFormulas:
+                    return FindFeatures("Formula calculation blockers", "Formula dependency issues");
+                case ExcelPreflightCapability.ExportPdfReport:
+                    return UnsupportedFeatures
+                        .Concat(PreservedFeatures.Where(IsPdfExportWorkbookBlocker))
+                        .Concat(FindFeatures(
+                            "PDF-missing formula caches",
+                            "PDF-dirty formula caches",
+                            "PDF-workbook recalculation requests",
+                            "PDF-unsupported charts",
+                            "PDF-unreadable charts",
+                            "PDF-unsupported images",
+                            "PDF-unsupported hyperlinks",
+                            "PDF-unrendered drawing shapes",
+                            "PDF-unsupported print areas",
+                            "PDF-unsupported print titles",
+                            "PDF-unsupported header/footer formatting",
+                            "PDF-unrendered pivot tables",
+                            "PDF-unrendered sparklines",
+                            "Non-worksheet sheets"));
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(capability), capability, "Unsupported Excel preflight capability.");
+            }
+        }
+
+        private static void AddRepairHints(List<ExcelPreflightRepairHint> hints, ExcelPreflightCapability capability, ExcelFeatureFinding finding) {
+            switch (finding.Name) {
+                case "Missing formula caches":
+                case "Dirty formula caches":
+                case "Workbook recalculation requests":
+                case "PDF-missing formula caches":
+                case "PDF-dirty formula caches":
+                case "PDF-workbook recalculation requests":
+                    hints.Add(new ExcelPreflightRepairHint(
+                        capability,
+                        finding.Name,
+                        "Refresh cached formula values before trusting reads or exports.",
+                        "Calculate(), InvalidateFormulas(), or save with ForceFullCalculationOnOpen",
+                        "Use OfficeIMO calculation when every formula is supported; otherwise open the workbook in Excel-compatible software and save after recalculation."));
+                    break;
+                case "Formula calculation blockers":
+                case "Formula dependency issues":
+                    hints.Add(new ExcelPreflightRepairHint(
+                        capability,
+                        finding.Name,
+                        "Route calculation to Excel-compatible software or simplify unsupported formulas before using OfficeIMO calculation.",
+                        "InspectFormulas()",
+                        "Clean cached values may still be usable for read/export workflows when caches are present and current."));
+                    break;
+                case "Digital signatures":
+                    hints.Add(new ExcelPreflightRepairHint(
+                        capability,
+                        finding.Name,
+                        "Work on an unsigned copy or avoid edits that would invalidate the signature.",
+                        null,
+                        "OfficeIMO preserves signature metadata but cannot keep a signature valid after package mutation."));
+                    break;
+                case "PDF-unrendered pivot tables":
+                    hints.Add(new ExcelPreflightRepairHint(
+                        capability,
+                        finding.Name,
+                        "Materialize the pivot output as ordinary worksheet cells before first-party PDF export.",
+                        "AddPivotTable(...), then refresh/open in Excel-compatible software and save",
+                        "OfficeIMO preserves and authors pivot metadata, but the first-party PDF path renders worksheet cells, not pivot UI metadata."));
+                    break;
+                case "PDF-unrendered sparklines":
+                    hints.Add(new ExcelPreflightRepairHint(
+                        capability,
+                        finding.Name,
+                        "Replace sparklines with rendered chart/image/table indicators for first-party PDF export.",
+                        "AddDashboardChart(...)",
+                        null));
+                    break;
+                case "PDF-unsupported images":
+                    hints.Add(new ExcelPreflightRepairHint(
+                        capability,
+                        finding.Name,
+                        "Convert worksheet/header/footer images to PNG or JPEG before PDF export.",
+                        null,
+                        "Unsupported or invalid image bytes are skipped by the first-party PDF image writer."));
+                    break;
+                case "PDF-unsupported hyperlinks":
+                    hints.Add(new ExcelPreflightRepairHint(
+                        capability,
+                        finding.Name,
+                        "Use absolute external hyperlinks or visible exported targets.",
+                        "SetHyperlink(...)",
+                        "Relative links and links to skipped targets are not emitted by the first-party PDF hyperlink writer."));
+                    break;
+                case "PDF-unsupported print areas":
+                    hints.Add(new ExcelPreflightRepairHint(
+                        capability,
+                        finding.Name,
+                        "Use a single contiguous print area or export sheets/ranges separately.",
+                        "SetPrintArea(...)",
+                        null));
+                    break;
+                case "PDF-unsupported print titles":
+                    hints.Add(new ExcelPreflightRepairHint(
+                        capability,
+                        finding.Name,
+                        "Use repeat-title rows only or pre-render repeated columns into the export range.",
+                        "SetPrintTitles(...)",
+                        null));
+                    break;
+                case "PDF-unsupported header/footer formatting":
+                    hints.Add(new ExcelPreflightRepairHint(
+                        capability,
+                        finding.Name,
+                        "Simplify header/footer formatting to supported text, font, and size tokens.",
+                        "SetHeaderFooter(...)",
+                        null));
+                    break;
+                case "PDF-unsupported charts":
+                case "PDF-unreadable charts":
+                    hints.Add(new ExcelPreflightRepairHint(
+                        capability,
+                        finding.Name,
+                        "Use supported chart types or export the chart through Excel-compatible software.",
+                        "AddDashboardChart(...)",
+                        null));
+                    break;
+                case "Non-worksheet sheets":
+                    hints.Add(new ExcelPreflightRepairHint(
+                        capability,
+                        finding.Name,
+                        "Move needed content to normal worksheets before worksheet-only read/export workflows.",
+                        null,
+                        "Chartsheets and similar sheet parts are preserve-only for worksheet workflows."));
+                    break;
+                default:
+                    if (finding.SupportLevel == ExcelFeatureSupportLevel.Preserved || finding.SupportLevel == ExcelFeatureSupportLevel.Unsupported) {
+                        hints.Add(new ExcelPreflightRepairHint(
+                            capability,
+                            finding.Name,
+                            "Use a preserve-only workflow, remove the feature, or route this workbook through Excel-compatible software.",
+                            "CopyPackage(...)",
+                            finding.Note));
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelFeatureReport.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.cs
@@ -418,7 +418,7 @@ namespace OfficeIMO.Excel {
                     if (sheetSparklineCount > 0) pdfUnrenderedSparklineDetails.Add($"{sheet.Name}: {sheetSparklineCount} sparkline(s)");
                 }
                 legacyCommentCount += worksheetPart.WorksheetCommentsPart?.Comments?.CommentList?.Elements<DocumentFormat.OpenXml.Spreadsheet.Comment>().Count() ?? 0;
-                var threadedComments = BuildThreadedCommentMap(worksheetPart, threadedCommentPeople)
+                var threadedComments = BuildThreadedCommentMap(worksheetPart, threadedCommentPeople, sheetName)
                     .Values
                     .SelectMany(comments => comments)
                     .ToList();

--- a/OfficeIMO.Excel/ExcelFeatureReport.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.cs
@@ -188,6 +188,27 @@ namespace OfficeIMO.Excel {
             }
 
             builder.AppendLine();
+            builder.AppendLine("## Repair Hints");
+            builder.AppendLine();
+            builder.AppendLine("| Capability | Feature | Action | Command | Details |");
+            builder.AppendLine("| --- | --- | --- | --- | --- |");
+            foreach (ExcelPreflightCapability capability in Enum.GetValues(typeof(ExcelPreflightCapability))) {
+                foreach (ExcelPreflightRepairHint hint in GetRepairHints(capability)) {
+                    builder.Append("| ");
+                    builder.Append(EscapeMarkdownCell(capability.ToString()));
+                    builder.Append(" | ");
+                    builder.Append(EscapeMarkdownCell(hint.FeatureName));
+                    builder.Append(" | ");
+                    builder.Append(EscapeMarkdownCell(hint.Action));
+                    builder.Append(" | ");
+                    builder.Append(EscapeMarkdownCell(hint.Command ?? string.Empty));
+                    builder.Append(" | ");
+                    builder.Append(EscapeMarkdownCell(hint.Details ?? string.Empty));
+                    builder.AppendLine(" |");
+                }
+            }
+
+            builder.AppendLine();
             builder.AppendLine("| Category | Feature | Count | Support | Scope | Note | Details |");
             builder.AppendLine("| --- | --- | --- | --- | --- | --- | --- |");
 
@@ -595,10 +616,10 @@ namespace OfficeIMO.Excel {
 
             Add(features, "Compatibility", "VBA macros", ExcelFeatureSupportLevel.Preserved, vbaDetails.Count, null,
                 "Macro projects are preserve-only; OfficeIMO.Excel does not author or edit VBA modules.", vbaDetails);
-            Add(features, "Compatibility", "Slicers", ExcelFeatureSupportLevel.Preserved, slicerDetails.Count, null,
-                "Slicer metadata is preserve-only; authoring slicers remains a roadmap item.", slicerDetails);
-            Add(features, "Compatibility", "Timelines", ExcelFeatureSupportLevel.Preserved, timelineDetails.Count, null,
-                "Timeline metadata is preserve-only; authoring timelines remains a roadmap item.", timelineDetails);
+            Add(features, "Compatibility", "Slicers", ExcelFeatureSupportLevel.PartiallyEditable, slicerDetails.Count, null,
+                "Slicer cache metadata can be authored and preserved; full Excel UI slicer shape/materialization remains partial.", slicerDetails);
+            Add(features, "Compatibility", "Timelines", ExcelFeatureSupportLevel.PartiallyEditable, timelineDetails.Count, null,
+                "Timeline cache metadata can be authored and preserved; full Excel UI timeline shape/materialization remains partial.", timelineDetails);
             Add(features, "Compatibility", "External workbook links", ExcelFeatureSupportLevel.Preserved, externalLinkDetails.Count + externalRelationshipDetails.Count, null,
                 "External relationships and workbook-link parts should be treated carefully during round trips.",
                 externalLinkDetails.Concat(externalRelationshipDetails).ToArray());

--- a/OfficeIMO.Excel/ExcelImage.cs
+++ b/OfficeIMO.Excel/ExcelImage.cs
@@ -1,5 +1,6 @@
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
+using System.Globalization;
 using A = DocumentFormat.OpenXml.Drawing;
 using Xdr = DocumentFormat.OpenXml.Drawing.Spreadsheet;
 
@@ -178,6 +179,31 @@ namespace OfficeIMO.Excel {
                 transformExtents.Cy = cy;
             }
 
+            Save();
+            return this;
+        }
+
+        /// <summary>
+        /// Moves the image to a one-cell anchor position and optionally applies pixel offsets.
+        /// </summary>
+        /// <param name="row">1-based target row.</param>
+        /// <param name="column">1-based target column.</param>
+        /// <param name="offsetXPixels">Horizontal offset from the cell edge, in pixels.</param>
+        /// <param name="offsetYPixels">Vertical offset from the cell edge, in pixels.</param>
+        public ExcelImage MoveTo(int row, int column, int offsetXPixels = 0, int offsetYPixels = 0) {
+            if (row <= 0) throw new ArgumentOutOfRangeException(nameof(row));
+            if (column <= 0) throw new ArgumentOutOfRangeException(nameof(column));
+
+            var marker = _anchor.GetFirstChild<Xdr.FromMarker>();
+            if (marker == null) {
+                marker = new Xdr.FromMarker();
+                _anchor.PrependChild(marker);
+            }
+
+            marker.ColumnId = new Xdr.ColumnId((column - 1).ToString(CultureInfo.InvariantCulture));
+            marker.ColumnOffset = new Xdr.ColumnOffset(PxToEmu(offsetXPixels).ToString(CultureInfo.InvariantCulture));
+            marker.RowId = new Xdr.RowId((row - 1).ToString(CultureInfo.InvariantCulture));
+            marker.RowOffset = new Xdr.RowOffset(PxToEmu(offsetYPixels).ToString(CultureInfo.InvariantCulture));
             Save();
             return this;
         }

--- a/OfficeIMO.Excel/ExcelImage.cs
+++ b/OfficeIMO.Excel/ExcelImage.cs
@@ -12,11 +12,13 @@ namespace OfficeIMO.Excel {
         private readonly Xdr.Picture _picture;
         private readonly OpenXmlElement _anchor;
         private readonly DrawingsPart _drawingsPart;
+        private readonly ExcelDocument _document;
 
-        internal ExcelImage(Xdr.Picture picture, OpenXmlElement anchor, DrawingsPart drawingsPart) {
+        internal ExcelImage(Xdr.Picture picture, OpenXmlElement anchor, DrawingsPart drawingsPart, ExcelDocument document) {
             _picture = picture ?? throw new ArgumentNullException(nameof(picture));
             _anchor = anchor ?? throw new ArgumentNullException(nameof(anchor));
             _drawingsPart = drawingsPart ?? throw new ArgumentNullException(nameof(drawingsPart));
+            _document = document ?? throw new ArgumentNullException(nameof(document));
         }
 
         /// <summary>
@@ -228,6 +230,7 @@ namespace OfficeIMO.Excel {
 
         private void Save() {
             _drawingsPart.WorksheetDrawing?.Save();
+            _document.MarkPackageDirty();
         }
 
         private static long PxToEmu(int px) => (long)Math.Round(px * 9525.0);

--- a/OfficeIMO.Excel/ExcelImage.cs
+++ b/OfficeIMO.Excel/ExcelImage.cs
@@ -198,8 +198,7 @@ namespace OfficeIMO.Excel {
 
             var marker = _anchor.GetFirstChild<Xdr.FromMarker>();
             if (marker == null) {
-                marker = new Xdr.FromMarker();
-                _anchor.PrependChild(marker);
+                throw new NotSupportedException("Only images anchored to worksheet cells can be moved. Absolute image anchors do not have a cell marker.");
             }
 
             marker.ColumnId = new Xdr.ColumnId((column - 1).ToString(CultureInfo.InvariantCulture));

--- a/OfficeIMO.Excel/ExcelImage.cs
+++ b/OfficeIMO.Excel/ExcelImage.cs
@@ -193,8 +193,8 @@ namespace OfficeIMO.Excel {
         /// <param name="offsetXPixels">Horizontal offset from the cell edge, in pixels.</param>
         /// <param name="offsetYPixels">Vertical offset from the cell edge, in pixels.</param>
         public ExcelImage MoveTo(int row, int column, int offsetXPixels = 0, int offsetYPixels = 0) {
-            if (row <= 0) throw new ArgumentOutOfRangeException(nameof(row));
-            if (column <= 0) throw new ArgumentOutOfRangeException(nameof(column));
+            if (row <= 0 || row > A1.MaxRows) throw new ArgumentOutOfRangeException(nameof(row), "Row must be between 1 and the Excel row limit.");
+            if (column <= 0 || column > A1.MaxColumns) throw new ArgumentOutOfRangeException(nameof(column), "Column must be between 1 and the Excel column limit.");
 
             var marker = _anchor.GetFirstChild<Xdr.FromMarker>();
             if (marker == null) {

--- a/OfficeIMO.Excel/ExcelImage.cs
+++ b/OfficeIMO.Excel/ExcelImage.cs
@@ -201,12 +201,49 @@ namespace OfficeIMO.Excel {
                 throw new NotSupportedException("Only images anchored to worksheet cells can be moved. Absolute image anchors do not have a cell marker.");
             }
 
+            int previousColumn = ParseMarkerIndex(marker.ColumnId?.Text);
+            int previousRow = ParseMarkerIndex(marker.RowId?.Text);
+            long previousColumnOffset = ParseMarkerOffset(marker.ColumnOffset?.Text);
+            long previousRowOffset = ParseMarkerOffset(marker.RowOffset?.Text);
+            int targetColumn = column - 1;
+            int targetRow = row - 1;
+            long targetColumnOffset = PxToEmu(offsetXPixels);
+            long targetRowOffset = PxToEmu(offsetYPixels);
+
+            MoveTwoCellEndMarkerIfNeeded(
+                targetColumn - previousColumn,
+                targetRow - previousRow,
+                targetColumnOffset - previousColumnOffset,
+                targetRowOffset - previousRowOffset);
+
             marker.ColumnId = new Xdr.ColumnId((column - 1).ToString(CultureInfo.InvariantCulture));
-            marker.ColumnOffset = new Xdr.ColumnOffset(PxToEmu(offsetXPixels).ToString(CultureInfo.InvariantCulture));
+            marker.ColumnOffset = new Xdr.ColumnOffset(targetColumnOffset.ToString(CultureInfo.InvariantCulture));
             marker.RowId = new Xdr.RowId((row - 1).ToString(CultureInfo.InvariantCulture));
-            marker.RowOffset = new Xdr.RowOffset(PxToEmu(offsetYPixels).ToString(CultureInfo.InvariantCulture));
+            marker.RowOffset = new Xdr.RowOffset(targetRowOffset.ToString(CultureInfo.InvariantCulture));
             Save();
             return this;
+        }
+
+        private void MoveTwoCellEndMarkerIfNeeded(int columnDelta, int rowDelta, long columnOffsetDelta, long rowOffsetDelta) {
+            Xdr.ToMarker? toMarker = _anchor.GetFirstChild<Xdr.ToMarker>();
+            if (toMarker == null) {
+                return;
+            }
+
+            int targetColumn = ParseMarkerIndex(toMarker.ColumnId?.Text) + columnDelta;
+            int targetRow = ParseMarkerIndex(toMarker.RowId?.Text) + rowDelta;
+            if (targetColumn < 0 || targetColumn >= A1.MaxColumns) {
+                throw new ArgumentOutOfRangeException("column", "Moving this two-cell image would place its end marker outside the Excel column limit.");
+            }
+
+            if (targetRow < 0 || targetRow >= A1.MaxRows) {
+                throw new ArgumentOutOfRangeException("row", "Moving this two-cell image would place its end marker outside the Excel row limit.");
+            }
+
+            toMarker.ColumnId = new Xdr.ColumnId(targetColumn.ToString(CultureInfo.InvariantCulture));
+            toMarker.ColumnOffset = new Xdr.ColumnOffset((ParseMarkerOffset(toMarker.ColumnOffset?.Text) + columnOffsetDelta).ToString(CultureInfo.InvariantCulture));
+            toMarker.RowId = new Xdr.RowId(targetRow.ToString(CultureInfo.InvariantCulture));
+            toMarker.RowOffset = new Xdr.RowOffset((ParseMarkerOffset(toMarker.RowOffset?.Text) + rowOffsetDelta).ToString(CultureInfo.InvariantCulture));
         }
 
         private Xdr.NonVisualDrawingProperties? DrawingProperties
@@ -233,6 +270,14 @@ namespace OfficeIMO.Excel {
         }
 
         private static long PxToEmu(int px) => (long)Math.Round(px * 9525.0);
+
+        private static int ParseMarkerIndex(string? text) {
+            return int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value) && value >= 0 ? value : 0;
+        }
+
+        private static long ParseMarkerOffset(string? text) {
+            return long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out long value) ? value : 0L;
+        }
 
         private static int EmuToPx(long emu) {
             if (emu <= 0) {

--- a/OfficeIMO.Excel/ExcelInspectionSnapshot.cs
+++ b/OfficeIMO.Excel/ExcelInspectionSnapshot.cs
@@ -445,6 +445,11 @@ namespace OfficeIMO.Excel {
     /// </summary>
     public sealed class ExcelThreadedCommentSnapshot {
         /// <summary>
+        /// Worksheet name that owns the threaded comment.
+        /// </summary>
+        public string SheetName { get; internal set; } = string.Empty;
+
+        /// <summary>
         /// Cell reference in A1 notation.
         /// </summary>
         public string CellReference { get; internal set; } = string.Empty;

--- a/OfficeIMO.Excel/ExcelInspectionSnapshot.cs
+++ b/OfficeIMO.Excel/ExcelInspectionSnapshot.cs
@@ -17,6 +17,21 @@ namespace OfficeIMO.Excel {
         public string? FilePath { get; internal set; }
 
         /// <summary>
+        /// Workbook date system used to interpret numeric date serials.
+        /// </summary>
+        public ExcelDateSystem DateSystem { get; internal set; } = ExcelDateSystem.NineteenHundred;
+
+        /// <summary>
+        /// Zero-based active worksheet index, when present.
+        /// </summary>
+        public int? ActiveWorksheetIndex { get; internal set; }
+
+        /// <summary>
+        /// Active worksheet name, when present.
+        /// </summary>
+        public string? ActiveWorksheetName { get; internal set; }
+
+        /// <summary>
         /// Worksheets in workbook order.
         /// </summary>
         public IReadOnlyList<ExcelWorksheetSnapshot> Worksheets => _worksheets;
@@ -25,6 +40,46 @@ namespace OfficeIMO.Excel {
         /// Workbook and sheet-local named ranges discovered during inspection.
         /// </summary>
         public IReadOnlyList<ExcelNamedRangeSnapshot> NamedRanges => _namedRanges;
+
+        /// <summary>
+        /// Number of package parts related to Excel slicers discovered during inspection.
+        /// </summary>
+        public int SlicerPartCount { get; internal set; }
+
+        /// <summary>
+        /// Number of package parts related to Excel timelines discovered during inspection.
+        /// </summary>
+        public int TimelinePartCount { get; internal set; }
+
+        /// <summary>
+        /// Number of package parts related to workbook connections discovered during inspection.
+        /// </summary>
+        public int ConnectionPartCount { get; internal set; }
+
+        /// <summary>
+        /// Number of package parts related to worksheet query tables discovered during inspection.
+        /// </summary>
+        public int QueryTablePartCount { get; internal set; }
+
+        /// <summary>
+        /// Whether slicer package parts were discovered.
+        /// </summary>
+        public bool HasSlicers => SlicerPartCount > 0;
+
+        /// <summary>
+        /// Whether timeline package parts were discovered.
+        /// </summary>
+        public bool HasTimelines => TimelinePartCount > 0;
+
+        /// <summary>
+        /// Whether workbook connection package parts were discovered.
+        /// </summary>
+        public bool HasConnections => ConnectionPartCount > 0;
+
+        /// <summary>
+        /// Whether worksheet query-table package parts were discovered.
+        /// </summary>
+        public bool HasQueryTables => QueryTablePartCount > 0;
 
         internal void AddWorksheet(ExcelWorksheetSnapshot worksheet) {
             if (worksheet == null) throw new ArgumentNullException(nameof(worksheet));
@@ -65,14 +120,49 @@ namespace OfficeIMO.Excel {
         public bool Hidden { get; internal set; }
 
         /// <summary>
+        /// Whether the worksheet is the workbook's active worksheet.
+        /// </summary>
+        public bool IsActive { get; internal set; }
+
+        /// <summary>
         /// Whether the worksheet is displayed right-to-left.
         /// </summary>
         public bool RightToLeft { get; internal set; }
 
         /// <summary>
+        /// Whether worksheet gridlines are visible.
+        /// </summary>
+        public bool ShowGridlines { get; internal set; } = true;
+
+        /// <summary>
+        /// Worksheet view mode, when present.
+        /// </summary>
+        public string? View { get; internal set; }
+
+        /// <summary>
+        /// Active worksheet zoom percentage, when present.
+        /// </summary>
+        public uint? ZoomScale { get; internal set; }
+
+        /// <summary>
+        /// Normal-view worksheet zoom percentage, when present.
+        /// </summary>
+        public uint? ZoomScaleNormal { get; internal set; }
+
+        /// <summary>
         /// Worksheet tab color in ARGB hexadecimal form, when present.
         /// </summary>
         public string? TabColorArgb { get; internal set; }
+
+        /// <summary>
+        /// Whether row summary controls appear below grouped rows, when specified.
+        /// </summary>
+        public bool? OutlineSummaryBelow { get; internal set; }
+
+        /// <summary>
+        /// Whether column summary controls appear to the right of grouped columns, when specified.
+        /// </summary>
+        public bool? OutlineSummaryRight { get; internal set; }
 
         /// <summary>
         /// Number of frozen rows detected on the worksheet.
@@ -453,6 +543,16 @@ namespace OfficeIMO.Excel {
         /// Whether the width was explicitly customized.
         /// </summary>
         public bool CustomWidth { get; internal set; }
+
+        /// <summary>
+        /// Excel outline level for grouped columns, when set.
+        /// </summary>
+        public byte? OutlineLevel { get; internal set; }
+
+        /// <summary>
+        /// Whether this column range carries Excel's collapsed outline marker.
+        /// </summary>
+        public bool Collapsed { get; internal set; }
     }
 
     /// <summary>
@@ -478,6 +578,16 @@ namespace OfficeIMO.Excel {
         /// Whether the height was explicitly customized.
         /// </summary>
         public bool CustomHeight { get; internal set; }
+
+        /// <summary>
+        /// Excel outline level for grouped rows, when set.
+        /// </summary>
+        public byte? OutlineLevel { get; internal set; }
+
+        /// <summary>
+        /// Whether this row carries Excel's collapsed outline marker.
+        /// </summary>
+        public bool Collapsed { get; internal set; }
     }
 
     /// <summary>

--- a/OfficeIMO.Excel/ExcelPivotFilter.cs
+++ b/OfficeIMO.Excel/ExcelPivotFilter.cs
@@ -17,7 +17,9 @@ namespace OfficeIMO.Excel {
             string? description,
             bool? isTop = null,
             bool? isPercent = null,
-            string? filterValue = null) {
+            string? filterValue = null,
+            DateTime? dateValue1 = null,
+            DateTime? dateValue2 = null) {
             FieldName = string.IsNullOrWhiteSpace(fieldName) ? throw new ArgumentNullException(nameof(fieldName)) : fieldName.Trim();
             Type = type;
             Value1 = string.IsNullOrWhiteSpace(value1) ? null : value1;
@@ -28,6 +30,8 @@ namespace OfficeIMO.Excel {
             IsTop = isTop;
             IsPercent = isPercent;
             FilterValue = string.IsNullOrWhiteSpace(filterValue) ? null : filterValue;
+            DateValue1 = dateValue1;
+            DateValue2 = dateValue2;
         }
 
         /// <summary>Gets the source field name to filter.</summary>
@@ -59,6 +63,10 @@ namespace OfficeIMO.Excel {
 
         /// <summary>Gets the optional calculated top/bottom filter value threshold.</summary>
         public string? FilterValue { get; }
+
+        internal DateTime? DateValue1 { get; }
+
+        internal DateTime? DateValue2 { get; }
 
         /// <summary>Creates a label-equals pivot filter.</summary>
         public static ExcelPivotFilter LabelEquals(string fieldName, string value, string? name = null, string? description = null)
@@ -318,7 +326,7 @@ namespace OfficeIMO.Excel {
 
             string first = FormatDateFilterValue(value1);
             string? second = value2.HasValue ? FormatDateFilterValue(value2.Value) : null;
-            return new ExcelPivotFilter(fieldName, type, first, second, null, name, description);
+            return new ExcelPivotFilter(fieldName, type, first, second, null, name, description, dateValue1: value1, dateValue2: value2);
         }
 
         /// <summary>Creates a dynamic date pivot filter using a supported Open XML pivot filter type.</summary>

--- a/OfficeIMO.Excel/ExcelPivotRangeTarget.cs
+++ b/OfficeIMO.Excel/ExcelPivotRangeTarget.cs
@@ -1,0 +1,16 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Specifies which part of a pivot table output range should be targeted.
+    /// </summary>
+    public enum ExcelPivotRangeTarget {
+        /// <summary>
+        /// Use the full pivot table output range.
+        /// </summary>
+        WholeTable,
+
+        /// <summary>
+        /// Use the data body approximation by excluding the first row and first column when possible.
+        /// </summary>
+        DataBody
+    }
+}

--- a/OfficeIMO.Excel/ExcelPivotTableInfo.cs
+++ b/OfficeIMO.Excel/ExcelPivotTableInfo.cs
@@ -112,7 +112,11 @@ namespace OfficeIMO.Excel {
             IReadOnlyList<ExcelPivotFieldInfo>? fields = null,
             IReadOnlyList<ExcelPivotFilterInfo>? filters = null,
             IReadOnlyList<ExcelPivotCalculatedFieldInfo>? calculatedFields = null,
-            IReadOnlyList<ExcelPivotGroupingInfo>? groupings = null) {
+            IReadOnlyList<ExcelPivotGroupingInfo>? groupings = null,
+            bool? refreshOnOpen = null,
+            bool? saveSourceData = null,
+            bool? preserveFormatting = null,
+            bool? enableDrill = null) {
             Name = name;
             CacheId = cacheId;
             Location = location;
@@ -148,6 +152,10 @@ namespace OfficeIMO.Excel {
             Filters = filters ?? Array.Empty<ExcelPivotFilterInfo>();
             CalculatedFields = calculatedFields ?? Array.Empty<ExcelPivotCalculatedFieldInfo>();
             Groupings = groupings ?? Array.Empty<ExcelPivotGroupingInfo>();
+            RefreshOnOpen = refreshOnOpen;
+            SaveSourceData = saveSourceData;
+            PreserveFormatting = preserveFormatting;
+            EnableDrill = enableDrill;
         }
 
         /// <summary>
@@ -284,6 +292,26 @@ namespace OfficeIMO.Excel {
         /// Gets whether custom-list sorting is enabled.
         /// </summary>
         public bool? CustomListSort { get; }
+
+        /// <summary>
+        /// Gets whether Excel should refresh the pivot cache when the workbook opens.
+        /// </summary>
+        public bool? RefreshOnOpen { get; }
+
+        /// <summary>
+        /// Gets whether source cache records are saved in the workbook package.
+        /// </summary>
+        public bool? SaveSourceData { get; }
+
+        /// <summary>
+        /// Gets whether pivot formatting is preserved during refreshes.
+        /// </summary>
+        public bool? PreserveFormatting { get; }
+
+        /// <summary>
+        /// Gets whether pivot detail drill interaction is enabled.
+        /// </summary>
+        public bool? EnableDrill { get; }
 
         /// <summary>
         /// Gets row field names.

--- a/OfficeIMO.Excel/ExcelPivotTableOptions.cs
+++ b/OfficeIMO.Excel/ExcelPivotTableOptions.cs
@@ -1,0 +1,26 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Workbook-interaction options for authored pivot tables.
+    /// </summary>
+    public sealed class ExcelPivotTableOptions {
+        /// <summary>
+        /// Gets or sets whether Excel should refresh the pivot cache when the workbook opens.
+        /// </summary>
+        public bool? RefreshOnOpen { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether source cache records should be saved in the workbook package.
+        /// </summary>
+        public bool? SaveSourceData { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether Excel should preserve pivot table formatting during refreshes.
+        /// </summary>
+        public bool? PreserveFormatting { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether drill-down interaction is enabled for pivot details.
+        /// </summary>
+        public bool? EnableDrill { get; set; }
+    }
+}

--- a/OfficeIMO.Excel/ExcelPreflightRepairHint.cs
+++ b/OfficeIMO.Excel/ExcelPreflightRepairHint.cs
@@ -1,0 +1,34 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Actionable guidance for resolving or routing around a failed Excel preflight capability.
+    /// </summary>
+    public sealed class ExcelPreflightRepairHint {
+        internal ExcelPreflightRepairHint(
+            ExcelPreflightCapability capability,
+            string featureName,
+            string action,
+            string? command = null,
+            string? details = null) {
+            Capability = capability;
+            FeatureName = featureName;
+            Action = action;
+            Command = command;
+            Details = details;
+        }
+
+        /// <summary>Capability the hint applies to.</summary>
+        public ExcelPreflightCapability Capability { get; }
+
+        /// <summary>Feature or blocker that triggered the hint.</summary>
+        public string FeatureName { get; }
+
+        /// <summary>Recommended action.</summary>
+        public string Action { get; }
+
+        /// <summary>Optional OfficeIMO API or command-shaped remediation.</summary>
+        public string? Command { get; }
+
+        /// <summary>Optional additional context.</summary>
+        public string? Details { get; }
+    }
+}

--- a/OfficeIMO.Excel/ExcelRangeConditionalFormattingBuilder.cs
+++ b/OfficeIMO.Excel/ExcelRangeConditionalFormattingBuilder.cs
@@ -58,6 +58,14 @@ namespace OfficeIMO.Excel {
         }
 
         /// <summary>
+        /// Applies a unique-values rule.
+        /// </summary>
+        public ExcelRange UniqueValues() {
+            _range.Sheet.AddConditionalUniqueValuesRule(_range.Address);
+            return _range;
+        }
+
+        /// <summary>
         /// Applies a top-values rule.
         /// </summary>
         public ExcelRange Top(uint rank, bool percent = false) {
@@ -70,6 +78,94 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public ExcelRange Bottom(uint rank, bool percent = false) {
             _range.Sheet.AddConditionalTopBottomRule(_range.Address, rank, bottom: true, percent: percent);
+            return _range;
+        }
+
+        /// <summary>
+        /// Applies an above-average rule.
+        /// </summary>
+        public ExcelRange AboveAverage(bool equalAverage = false, uint? standardDeviation = null) {
+            _range.Sheet.AddConditionalAboveAverageRule(_range.Address, aboveAverage: true, equalAverage: equalAverage, standardDeviation: standardDeviation);
+            return _range;
+        }
+
+        /// <summary>
+        /// Applies a below-average rule.
+        /// </summary>
+        public ExcelRange BelowAverage(bool equalAverage = false, uint? standardDeviation = null) {
+            _range.Sheet.AddConditionalAboveAverageRule(_range.Address, aboveAverage: false, equalAverage: equalAverage, standardDeviation: standardDeviation);
+            return _range;
+        }
+
+        /// <summary>
+        /// Applies a contains-text rule.
+        /// </summary>
+        public ExcelRange ContainsText(string text) {
+            _range.Sheet.AddConditionalTextRule(_range.Address, ConditionalFormatValues.ContainsText, text);
+            return _range;
+        }
+
+        /// <summary>
+        /// Applies a not-contains-text rule.
+        /// </summary>
+        public ExcelRange NotContainsText(string text) {
+            _range.Sheet.AddConditionalTextRule(_range.Address, ConditionalFormatValues.NotContainsText, text);
+            return _range;
+        }
+
+        /// <summary>
+        /// Applies a begins-with text rule.
+        /// </summary>
+        public ExcelRange BeginsWith(string text) {
+            _range.Sheet.AddConditionalTextRule(_range.Address, ConditionalFormatValues.BeginsWith, text);
+            return _range;
+        }
+
+        /// <summary>
+        /// Applies an ends-with text rule.
+        /// </summary>
+        public ExcelRange EndsWith(string text) {
+            _range.Sheet.AddConditionalTextRule(_range.Address, ConditionalFormatValues.EndsWith, text);
+            return _range;
+        }
+
+        /// <summary>
+        /// Applies a blanks rule.
+        /// </summary>
+        public ExcelRange Blanks() {
+            _range.Sheet.AddConditionalBlanksRule(_range.Address, containsBlanks: true);
+            return _range;
+        }
+
+        /// <summary>
+        /// Applies a non-blanks rule.
+        /// </summary>
+        public ExcelRange NonBlanks() {
+            _range.Sheet.AddConditionalBlanksRule(_range.Address, containsBlanks: false);
+            return _range;
+        }
+
+        /// <summary>
+        /// Applies an errors rule.
+        /// </summary>
+        public ExcelRange Errors() {
+            _range.Sheet.AddConditionalErrorsRule(_range.Address, containsErrors: true);
+            return _range;
+        }
+
+        /// <summary>
+        /// Applies a non-errors rule.
+        /// </summary>
+        public ExcelRange NonErrors() {
+            _range.Sheet.AddConditionalErrorsRule(_range.Address, containsErrors: false);
+            return _range;
+        }
+
+        /// <summary>
+        /// Applies a time-period rule.
+        /// </summary>
+        public ExcelRange TimePeriod(TimePeriodValues timePeriod) {
+            _range.Sheet.AddConditionalTimePeriodRule(_range.Address, timePeriod);
             return _range;
         }
 

--- a/OfficeIMO.Excel/ExcelRefreshOnOpenResult.cs
+++ b/OfficeIMO.Excel/ExcelRefreshOnOpenResult.cs
@@ -1,0 +1,21 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Summary of workbook refresh-on-open metadata updates.
+    /// </summary>
+    public sealed class ExcelRefreshOnOpenResult {
+        internal ExcelRefreshOnOpenResult(bool enabled, int pivotCacheCount, int connectionCount) {
+            Enabled = enabled;
+            PivotCacheCount = pivotCacheCount;
+            ConnectionCount = connectionCount;
+        }
+
+        /// <summary>Whether refresh-on-open was enabled or disabled.</summary>
+        public bool Enabled { get; }
+
+        /// <summary>Number of pivot cache definitions updated.</summary>
+        public int PivotCacheCount { get; }
+
+        /// <summary>Number of workbook connection entries updated.</summary>
+        public int ConnectionCount { get; }
+    }
+}

--- a/OfficeIMO.Excel/ExcelRowLayoutOptions.cs
+++ b/OfficeIMO.Excel/ExcelRowLayoutOptions.cs
@@ -1,0 +1,66 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Describes row-level layout and style changes that should be applied together.
+    /// </summary>
+    public sealed class ExcelRowLayoutOptions {
+        /// <summary>
+        /// Explicit row height in points. Use <see cref="ClearHeight"/> to remove a custom height.
+        /// </summary>
+        public double? Height { get; set; }
+
+        /// <summary>
+        /// Clears any custom row height before optional auto-fit is applied.
+        /// </summary>
+        public bool ClearHeight { get; set; }
+
+        /// <summary>
+        /// Auto-fits the row height after style changes are applied.
+        /// </summary>
+        public bool AutoFit { get; set; }
+
+        /// <summary>
+        /// Optional hidden state for the row.
+        /// </summary>
+        public bool? Hidden { get; set; }
+
+        /// <summary>
+        /// Optional bold font state applied to cells in the target column span.
+        /// </summary>
+        public bool? Bold { get; set; }
+
+        /// <summary>
+        /// Optional italic font state applied to cells in the target column span.
+        /// </summary>
+        public bool? Italic { get; set; }
+
+        /// <summary>
+        /// Optional underline font state applied to cells in the target column span.
+        /// </summary>
+        public bool? Underline { get; set; }
+
+        /// <summary>
+        /// Optional wrap-text state applied to cells in the target column span.
+        /// </summary>
+        public bool? WrapText { get; set; }
+
+        /// <summary>
+        /// Optional font family applied to cells in the target column span.
+        /// </summary>
+        public string? FontName { get; set; }
+
+        /// <summary>
+        /// Optional background color applied to cells in the target column span. Accepts RGB or ARGB hex text.
+        /// </summary>
+        public string? BackgroundColor { get; set; }
+
+        /// <summary>
+        /// First 1-based column affected by cell style options. Defaults to the worksheet used range.
+        /// </summary>
+        public int? FirstColumn { get; set; }
+
+        /// <summary>
+        /// Last 1-based column affected by cell style options. Defaults to the worksheet used range.
+        /// </summary>
+        public int? LastColumn { get; set; }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.AutoFitText.cs
+++ b/OfficeIMO.Excel/ExcelSheet.AutoFitText.cs
@@ -90,7 +90,7 @@ namespace OfficeIMO.Excel {
             }
 
             if (IsDateNumberFormat(numberFormatId, formatCode)) {
-                return FormatAutoFitDateValue(value, numberFormatId, formatCode!);
+                return FormatAutoFitDateValue(value, numberFormatId, formatCode!, _excelDocument.DateSystem);
             }
 
             return FormatAutoFitNumberValue(value, numberFormatId, formatCode!) ?? raw;
@@ -194,7 +194,7 @@ namespace OfficeIMO.Excel {
             => numberFormatId is 14 or 15 or 16 or 17 or 18 or 19 or 20 or 21 or 22 or 45 or 46 or 47
             || ExcelNumberFormatClassifier.LooksLikeDateFormat(formatCode);
 
-        private static string FormatAutoFitDateValue(double value, uint numberFormatId, string formatCode) {
+        private static string FormatAutoFitDateValue(double value, uint numberFormatId, string formatCode, ExcelDateSystem dateSystem) {
             if (numberFormatId == 46U || formatCode.IndexOf("[h]", StringComparison.OrdinalIgnoreCase) >= 0) {
                 TimeSpan duration = TimeSpan.FromDays(value);
                 int totalHours = (int)Math.Floor(duration.TotalHours);
@@ -203,7 +203,7 @@ namespace OfficeIMO.Excel {
 
             DateTime date;
             try {
-                date = DateTime.FromOADate(value);
+                date = ExcelDateSystemConverter.FromSerial(value, dateSystem);
             } catch {
                 return value.ToString(CultureInfo.InvariantCulture);
             }

--- a/OfficeIMO.Excel/ExcelSheet.CellValue.Core.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.Core.cs
@@ -212,7 +212,7 @@ namespace OfficeIMO.Excel {
         }
 
         private void CellDateTimeValueCore(int row, int column, DateTime value) {
-            double serial = value.ToOADate();
+            double serial = ExcelDateSystemConverter.ToSerial(value, _excelDocument.DateSystem);
             var cell = GetCell(row, column);
             uint baseStyleIndex = cell.StyleIndex?.Value ?? 0U;
             cell.CellValue = new CellValue(serial.ToString(CultureInfo.InvariantCulture));
@@ -236,7 +236,7 @@ namespace OfficeIMO.Excel {
 
             if (value.UtcDateTime >= CellValueExcelMinimumSupportedDate) {
                 try {
-                    double serial = converted.ToOADate();
+                    double serial = ExcelDateSystemConverter.ToSerial(converted, _excelDocument.DateSystem);
                     cell.CellValue = new CellValue(serial.ToString(CultureInfo.InvariantCulture));
                     cell.DataType = DocumentFormat.OpenXml.Spreadsheet.CellValues.Number;
 
@@ -264,7 +264,7 @@ namespace OfficeIMO.Excel {
         private void CellDateOnlyValueCore(int row, int column, DateOnly value) {
             var cell = GetCell(row, column);
             uint baseStyleIndex = cell.StyleIndex?.Value ?? 0U;
-            cell.CellValue = new CellValue(value.ToDateTime(TimeOnly.MinValue).ToOADate().ToString(CultureInfo.InvariantCulture));
+            cell.CellValue = new CellValue(ExcelDateSystemConverter.ToSerial(value.ToDateTime(TimeOnly.MinValue), _excelDocument.DateSystem).ToString(CultureInfo.InvariantCulture));
             cell.DataType = DocumentFormat.OpenXml.Spreadsheet.CellValues.Number;
             cell.StyleIndex = baseStyleIndex == 0U
                 ? (_cellValueDefaultDateStyleIndex ??= GetOrCreateBuiltInNumberFormatStyleIndex(0U, 14))
@@ -313,7 +313,8 @@ namespace OfficeIMO.Excel {
                     int idx = _excelDocument.GetSharedStringIndex(s);
                     return new CellValue(SharedStringIndexText.Get(idx));
                 },
-                dateTimeOffsetStrategy);
+                dateTimeOffsetStrategy,
+                _excelDocument.DateSystem);
             return (cellValue, new EnumValue<DocumentFormat.OpenXml.Spreadsheet.CellValues>(cellType));
         }
     }

--- a/OfficeIMO.Excel/ExcelSheet.CellValue.GradientFills.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.GradientFills.cs
@@ -1,0 +1,92 @@
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelSheet {
+        /// <summary>
+        /// Applies a two-color linear gradient background to a single cell. Accepts #RRGGBB or #AARRGGBB.
+        /// </summary>
+        /// <param name="row">The 1-based row index of the cell to fill.</param>
+        /// <param name="column">The 1-based column index of the cell to fill.</param>
+        /// <param name="fromHexColor">The gradient start color expressed as an ARGB or RGB hex string.</param>
+        /// <param name="toHexColor">The gradient end color expressed as an ARGB or RGB hex string.</param>
+        /// <param name="degree">The linear gradient angle in degrees.</param>
+        public void CellGradientBackground(int row, int column, string fromHexColor, string toHexColor, double degree = 0) {
+            if (string.IsNullOrWhiteSpace(fromHexColor) || string.IsNullOrWhiteSpace(toHexColor)) {
+                return;
+            }
+
+            WriteLockConditional(() => {
+                var cell = GetCell(row, column);
+                ApplyGradientBackground(cell, fromHexColor, toHexColor, degree);
+            });
+        }
+
+        /// <summary>
+        /// Applies a two-color linear gradient fill to every cell in the range.
+        /// </summary>
+        /// <param name="a1Range">The A1 range to fill.</param>
+        /// <param name="fromHexColor">The gradient start color expressed as an ARGB or RGB hex string.</param>
+        /// <param name="toHexColor">The gradient end color expressed as an ARGB or RGB hex string.</param>
+        /// <param name="degree">The linear gradient angle in degrees.</param>
+        public void FillRangeGradient(string a1Range, string fromHexColor, string toHexColor, double degree = 0) {
+            if (string.IsNullOrWhiteSpace(fromHexColor) || string.IsNullOrWhiteSpace(toHexColor)) {
+                return;
+            }
+
+            var (r1, c1, r2, c2) = A1.ParseRange(a1Range);
+
+            if (!_excelDocument.IsMaterializingDeferredDataSetImport) {
+                MaterializeDeferredDataSetImportIfNeeded();
+            }
+
+            WriteLock(() => FillRangeGradientCore(r1, c1, r2, c2, fromHexColor, toHexColor, degree));
+        }
+
+        private void ApplyGradientBackground(Cell cell, string fromHexColor, string toHexColor, double degree) {
+            var workbookPart = _excelDocument.WorkbookPartRoot ?? throw new InvalidOperationException("WorkbookPart is null");
+            var stylesPart = workbookPart.WorkbookStylesPart ?? workbookPart.AddNewPart<DocumentFormat.OpenXml.Packaging.WorkbookStylesPart>();
+            var stylesheet = stylesPart.Stylesheet ??= new Stylesheet();
+            EnsureDefaultStylePrimitives(stylesheet);
+
+            uint fillId = GetOrCreateFill(stylesheet, CreateGradientFill(fromHexColor, toHexColor, degree));
+            ApplyCellFormatOverride(stylesheet, cell, format => {
+                format.FillId = fillId;
+                format.ApplyFill = true;
+            });
+
+            stylesPart.Stylesheet.Save();
+        }
+
+        private void FillRangeGradientCore(int firstRow, int firstColumn, int lastRow, int lastColumn, string fromHexColor, string toHexColor, double degree) {
+            var workbookPart = _excelDocument.WorkbookPartRoot ?? throw new InvalidOperationException("WorkbookPart is null");
+            var stylesPart = workbookPart.WorkbookStylesPart ?? workbookPart.AddNewPart<DocumentFormat.OpenXml.Packaging.WorkbookStylesPart>();
+            var stylesheet = stylesPart.Stylesheet ??= new Stylesheet();
+            EnsureDefaultStylePrimitives(stylesheet);
+
+            uint fillId = GetOrCreateFill(stylesheet, CreateGradientFill(fromHexColor, toHexColor, degree));
+            var styleIndexes = new Dictionary<uint, uint>();
+
+            for (int row = firstRow; row <= lastRow; row++) {
+                for (int column = firstColumn; column <= lastColumn; column++) {
+                    Cell cell = GetCell(row, column);
+                    uint baseStyleIndex = cell.StyleIndex?.Value ?? 0U;
+                    cell.StyleIndex = GetOrAddCellFormatOverride(styleIndexes, stylesheet, baseStyleIndex, format => {
+                        format.FillId = fillId;
+                        format.ApplyFill = true;
+                    });
+                }
+            }
+
+            stylesPart.Stylesheet.Save();
+        }
+
+        private static Fill CreateGradientFill(string fromHexColor, string toHexColor, double degree) {
+            return new Fill(new GradientFill(
+                new GradientStop(new Color { Rgb = NormalizeHexColor(fromHexColor) }) { Position = 0D },
+                new GradientStop(new Color { Rgb = NormalizeHexColor(toHexColor) }) { Position = 1D }) {
+                Type = GradientValues.Linear,
+                Degree = degree
+            });
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.CellValue.Styles.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.Styles.cs
@@ -46,6 +46,33 @@ namespace OfficeIMO.Excel {
         }
 
         /// <summary>
+        /// Applies or clears wrap text on a single cell.
+        /// </summary>
+        /// <param name="row">The 1-based row index of the cell to modify.</param>
+        /// <param name="column">The 1-based column index of the cell to modify.</param>
+        /// <param name="wrapText">Whether text should wrap within the cell.</param>
+        public void CellWrapText(int row, int column, bool wrapText = true) {
+            WriteLockConditional(() => {
+                var cell = GetCell(row, column);
+                var workbookPart = _excelDocument.WorkbookPartRoot ?? throw new InvalidOperationException("WorkbookPart is null");
+                var stylesPart = workbookPart.WorkbookStylesPart ?? workbookPart.AddNewPart<WorkbookStylesPart>();
+                var stylesheet = stylesPart.Stylesheet ??= new Stylesheet();
+                EnsureDefaultStylePrimitives(stylesheet);
+
+                ApplyCellFormatOverride(stylesheet, cell, format => {
+                    var alignment = format.Alignment != null
+                        ? (Alignment)format.Alignment.CloneNode(true)
+                        : new Alignment();
+                    alignment.WrapText = wrapText ? true : null;
+                    format.Alignment = alignment;
+                    format.ApplyAlignment = true;
+                });
+
+                stylesPart.Stylesheet.Save();
+            });
+        }
+
+        /// <summary>
         /// Applies a font family name to a single cell.
         /// </summary>
         /// <param name="row">The 1-based row index of the cell to modify.</param>

--- a/OfficeIMO.Excel/ExcelSheet.CellValues.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValues.cs
@@ -135,7 +135,8 @@ namespace OfficeIMO.Excel {
                     var sanitized = planner.Note(s);
                     return new CellValue(sanitized);
                 },
-                dateTimeOffsetStrategy);
+                dateTimeOffsetStrategy,
+                _excelDocument.DateSystem);
             return (cellValue, GetCachedDataTableCellType(cellType));
         }
 

--- a/OfficeIMO.Excel/ExcelSheet.ColumnDefinitions.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ColumnDefinitions.cs
@@ -24,7 +24,9 @@ namespace OfficeIMO.Excel {
                     EndIndex = end,
                     Width = column.Width?.Value,
                     Hidden = column.Hidden?.Value == true,
-                    CustomWidth = column.CustomWidth?.Value == true
+                    CustomWidth = column.CustomWidth?.Value == true,
+                    OutlineLevel = column.OutlineLevel?.Value,
+                    Collapsed = column.Collapsed?.Value == true
                 });
             }
 

--- a/OfficeIMO.Excel/ExcelSheet.ColumnRanges.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ColumnRanges.cs
@@ -46,6 +46,10 @@ namespace OfficeIMO.Excel {
                 return TryGetTableColumnRangeByHeader(headerName, tableName!, includeHeader, normalizeHeader, out range);
             }
 
+            if (!_excelDocument.IsMaterializingDeferredDataSetImport) {
+                _excelDocument.MaterializeDeferredDataSetImport();
+            }
+
             string usedRange = GetUsedRangeA1();
             if (!A1.TryParseRange(usedRange, out int usedStartRow, out int usedStartColumn, out int usedEndRow, out int usedEndColumn)) {
                 return false;

--- a/OfficeIMO.Excel/ExcelSheet.ColumnRanges.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ColumnRanges.cs
@@ -1,0 +1,129 @@
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelSheet {
+        /// <summary>
+        /// Resolves the data range for a worksheet or table column by matching its header text.
+        /// </summary>
+        /// <param name="headerName">Header or table column name to match.</param>
+        /// <param name="tableName">Optional table name, display name, or range. When omitted, the worksheet header row is scanned.</param>
+        /// <param name="headerRow">Worksheet header row to scan when <paramref name="tableName"/> is omitted. Use 0 to scan the first row of the used range.</param>
+        /// <param name="includeHeader">Include the matched header cell in the returned range.</param>
+        /// <param name="normalizeHeader">Normalize repeated whitespace before comparing headers.</param>
+        /// <returns>A single-column A1 range for the matched column.</returns>
+        public string GetColumnRangeByHeader(
+            string headerName,
+            string? tableName = null,
+            int headerRow = 0,
+            bool includeHeader = false,
+            bool normalizeHeader = true) {
+            if (TryGetColumnRangeByHeader(headerName, tableName, headerRow, includeHeader, normalizeHeader, out string range)) {
+                return range;
+            }
+
+            string scope = string.IsNullOrWhiteSpace(tableName)
+                ? $"worksheet '{Name}'"
+                : $"table '{tableName}' on worksheet '{Name}'";
+            throw new InvalidOperationException($"Column header '{headerName}' was not found in {scope}.");
+        }
+
+        /// <summary>
+        /// Tries to resolve the data range for a worksheet or table column by matching its header text.
+        /// </summary>
+        public bool TryGetColumnRangeByHeader(
+            string headerName,
+            string? tableName,
+            int headerRow,
+            bool includeHeader,
+            bool normalizeHeader,
+            out string range) {
+            range = string.Empty;
+            if (string.IsNullOrWhiteSpace(headerName)) {
+                throw new ArgumentNullException(nameof(headerName));
+            }
+
+            if (!string.IsNullOrWhiteSpace(tableName)) {
+                return TryGetTableColumnRangeByHeader(headerName, tableName!, includeHeader, normalizeHeader, out range);
+            }
+
+            string usedRange = GetUsedRangeA1();
+            if (!A1.TryParseRange(usedRange, out int usedStartRow, out int usedStartColumn, out int usedEndRow, out int usedEndColumn)) {
+                return false;
+            }
+
+            int effectiveHeaderRow = headerRow > 0 ? headerRow : usedStartRow;
+            if (effectiveHeaderRow < usedStartRow || effectiveHeaderRow > usedEndRow) {
+                return false;
+            }
+
+            for (int column = usedStartColumn; column <= usedEndColumn; column++) {
+                if (!TryGetCellText(effectiveHeaderRow, column, out string text)) {
+                    continue;
+                }
+
+                if (!HeadersMatch(text, headerName, normalizeHeader)) {
+                    continue;
+                }
+
+                int startRow = includeHeader ? effectiveHeaderRow : effectiveHeaderRow + 1;
+                int endRow = Math.Max(startRow, usedEndRow);
+                range = BuildSingleColumnRange(startRow, column, endRow);
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool TryGetTableColumnRangeByHeader(
+            string headerName,
+            string tableName,
+            bool includeHeader,
+            bool normalizeHeader,
+            out string range) {
+            range = string.Empty;
+            if (!_excelDocument.IsMaterializingDeferredDataSetImport) {
+                _excelDocument.MaterializeDeferredDataSetImport();
+            }
+
+            Table? table = FindTableByRangeNameOrDisplayName(tableName);
+            if (table?.Reference?.Value == null || table.HeaderRowCount?.Value == 0) {
+                return false;
+            }
+
+            if (!A1.TryParseRange(table.Reference.Value, out int startRow, out int startColumn, out int endRow, out _)) {
+                return false;
+            }
+
+            int headerRows = (int)(table.HeaderRowCount?.Value ?? 1U);
+            int columnOffset = 0;
+            foreach (TableColumn tableColumn in table.TableColumns?.Elements<TableColumn>() ?? Enumerable.Empty<TableColumn>()) {
+                if (HeadersMatch(tableColumn.Name?.Value, headerName, normalizeHeader)) {
+                    int column = startColumn + columnOffset;
+                    int firstRow = includeHeader ? startRow : startRow + headerRows;
+                    int totalsRows = table.TotalsRowShown?.Value == true
+                        ? Math.Max(1, (int)(table.TotalsRowCount?.Value ?? 1U))
+                        : 0;
+                    int lastRow = Math.Max(firstRow, endRow - totalsRows);
+                    range = BuildSingleColumnRange(firstRow, column, lastRow);
+                    return true;
+                }
+
+                columnOffset++;
+            }
+
+            return false;
+        }
+
+        private static bool HeadersMatch(string? actual, string expected, bool normalizeHeader) {
+            string normalizedActual = ExcelHeaderNameHelper.NormalizeHeader(actual, normalizeHeader);
+            string normalizedExpected = ExcelHeaderNameHelper.NormalizeHeader(expected, normalizeHeader);
+            return string.Equals(normalizedActual, normalizedExpected, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string BuildSingleColumnRange(int startRow, int column, int endRow) {
+            string start = A1.CellReference(startRow, column);
+            string end = A1.CellReference(endRow, column);
+            return $"{start}:{end}";
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.Dashboard.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Dashboard.cs
@@ -14,6 +14,7 @@ namespace OfficeIMO.Excel {
             if (data.Columns.Count == 0) throw new ArgumentException("Dashboard data must contain at least one column.", nameof(data));
             if (opts.TableRow <= 0) throw new ArgumentOutOfRangeException(nameof(ExcelDashboardOptions.TableRow));
             if (opts.TableColumn <= 0) throw new ArgumentOutOfRangeException(nameof(ExcelDashboardOptions.TableColumn));
+            ValidateDashboardLayout(opts);
 
             WriteDashboardHeader(opts);
 
@@ -72,6 +73,21 @@ namespace OfficeIMO.Excel {
 
             if (!string.IsNullOrWhiteSpace(options.Subtitle)) {
                 CellValue(2, 1, options.Subtitle!);
+            }
+        }
+
+        private static void ValidateDashboardLayout(ExcelDashboardOptions options) {
+            int headerLastRow = 0;
+            if (!string.IsNullOrWhiteSpace(options.Title)) {
+                headerLastRow = 1;
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.Subtitle)) {
+                headerLastRow = 2;
+            }
+
+            if (headerLastRow > 0 && options.TableRow <= headerLastRow) {
+                throw new ArgumentException("Dashboard table row overlaps the configured title or subtitle rows.", nameof(options));
             }
         }
     }

--- a/OfficeIMO.Excel/ExcelSheet.Dashboard.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Dashboard.cs
@@ -28,6 +28,7 @@ namespace OfficeIMO.Excel {
                 tableName: tableName,
                 style: opts.TableStyle,
                 includeAutoFilter: opts.IncludeAutoFilter);
+            string? actualTableName = ResolveTableNameByRange(tableRange) ?? tableName;
 
             if (opts.AutoFit) {
                 AutoFitColumnsFor(Enumerable.Range(opts.TableColumn, data.Columns.Count));
@@ -47,7 +48,20 @@ namespace OfficeIMO.Excel {
                 });
             }
 
-            return new ExcelDashboardResult(tableRange, tableName, chart);
+            return new ExcelDashboardResult(tableRange, actualTableName, chart);
+        }
+
+        private string? ResolveTableNameByRange(string tableRange) {
+            if (string.IsNullOrWhiteSpace(tableRange)) {
+                return null;
+            }
+
+            return _worksheetPart.TableDefinitionParts
+                .Select(part => part.Table)
+                .FirstOrDefault(table => string.Equals(table?.Reference?.Value, tableRange, StringComparison.OrdinalIgnoreCase))
+                is { } table
+                    ? table.Name?.Value ?? table.DisplayName?.Value
+                    : null;
         }
 
         private void WriteDashboardHeader(ExcelDashboardOptions options) {

--- a/OfficeIMO.Excel/ExcelSheet.Dashboard.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Dashboard.cs
@@ -14,7 +14,7 @@ namespace OfficeIMO.Excel {
             if (data.Columns.Count == 0) throw new ArgumentException("Dashboard data must contain at least one column.", nameof(data));
             if (opts.TableRow <= 0) throw new ArgumentOutOfRangeException(nameof(ExcelDashboardOptions.TableRow));
             if (opts.TableColumn <= 0) throw new ArgumentOutOfRangeException(nameof(ExcelDashboardOptions.TableColumn));
-            ValidateDashboardLayout(opts);
+            ValidateDashboardLayout(opts, data);
 
             WriteDashboardHeader(opts);
 
@@ -76,7 +76,7 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        private static void ValidateDashboardLayout(ExcelDashboardOptions options) {
+        private static void ValidateDashboardLayout(ExcelDashboardOptions options, DataTable data) {
             int headerLastRow = 0;
             if (!string.IsNullOrWhiteSpace(options.Title)) {
                 headerLastRow = 1;
@@ -88,6 +88,20 @@ namespace OfficeIMO.Excel {
 
             if (headerLastRow > 0 && options.TableRow <= headerLastRow) {
                 throw new ArgumentException("Dashboard table row overlaps the configured title or subtitle rows.", nameof(options));
+            }
+
+            long tableLastRow = (long)options.TableRow + data.Rows.Count;
+            long tableLastColumn = (long)options.TableColumn + data.Columns.Count - 1L;
+            if (tableLastRow > A1.MaxRows || tableLastColumn > A1.MaxColumns) {
+                throw new ArgumentException("Dashboard table exceeds Excel worksheet bounds.", nameof(options));
+            }
+
+            if (options.AddChart) {
+                int chartRow = options.ChartRow ?? options.TableRow;
+                int chartColumn = options.ChartColumn ?? options.TableColumn + data.Columns.Count + 2;
+                if (chartRow <= 0 || chartRow > A1.MaxRows || chartColumn <= 0 || chartColumn > A1.MaxColumns) {
+                    throw new ArgumentOutOfRangeException(nameof(options), "Dashboard chart anchor exceeds Excel worksheet bounds.");
+                }
             }
         }
     }

--- a/OfficeIMO.Excel/ExcelSheet.Dashboard.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Dashboard.cs
@@ -1,0 +1,64 @@
+using System.Data;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelSheet {
+        /// <summary>
+        /// Builds a dashboard table and optional chart from a data table.
+        /// </summary>
+        /// <param name="data">Tabular data to write.</param>
+        /// <param name="options">Dashboard layout and styling options.</param>
+        /// <returns>Dashboard table range and generated chart metadata.</returns>
+        public ExcelDashboardResult AddDashboard(DataTable data, ExcelDashboardOptions? options = null) {
+            if (data == null) throw new ArgumentNullException(nameof(data));
+            var opts = options ?? new ExcelDashboardOptions();
+            if (data.Columns.Count == 0) throw new ArgumentException("Dashboard data must contain at least one column.", nameof(data));
+            if (opts.TableRow <= 0) throw new ArgumentOutOfRangeException(nameof(ExcelDashboardOptions.TableRow));
+            if (opts.TableColumn <= 0) throw new ArgumentOutOfRangeException(nameof(ExcelDashboardOptions.TableColumn));
+
+            WriteDashboardHeader(opts);
+
+            string? tableName = string.IsNullOrWhiteSpace(opts.TableName)
+                ? (string.IsNullOrWhiteSpace(data.TableName) ? null : data.TableName)
+                : opts.TableName;
+            string tableRange = InsertDataTableAsTable(
+                data,
+                startRow: opts.TableRow,
+                startColumn: opts.TableColumn,
+                includeHeaders: true,
+                tableName: tableName,
+                style: opts.TableStyle,
+                includeAutoFilter: opts.IncludeAutoFilter);
+
+            if (opts.AutoFit) {
+                AutoFitColumnsFor(Enumerable.Range(opts.TableColumn, data.Columns.Count));
+            }
+
+            ExcelChart? chart = null;
+            if (opts.AddChart) {
+                int chartRow = opts.ChartRow ?? opts.TableRow;
+                int chartColumn = opts.ChartColumn ?? opts.TableColumn + data.Columns.Count + 2;
+                chart = AddDashboardChart(new ExcelDashboardChartOptions {
+                    Preset = opts.ChartPreset,
+                    Range = tableRange,
+                    Row = chartRow,
+                    Column = chartColumn,
+                    Title = string.IsNullOrWhiteSpace(opts.ChartTitle) ? opts.Title : opts.ChartTitle,
+                    HasHeaders = true
+                });
+            }
+
+            return new ExcelDashboardResult(tableRange, tableName, chart);
+        }
+
+        private void WriteDashboardHeader(ExcelDashboardOptions options) {
+            if (!string.IsNullOrWhiteSpace(options.Title)) {
+                CellValue(1, 1, options.Title!);
+                CellBold(1, 1, true);
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.Subtitle)) {
+                CellValue(2, 1, options.Subtitle!);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.DashboardCharts.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DashboardCharts.cs
@@ -1,0 +1,215 @@
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Common dashboard chart workflows.
+    /// </summary>
+    public enum ExcelDashboardChartPreset {
+        /// <summary>Clustered column chart for comparing categories.</summary>
+        Comparison,
+        /// <summary>Line chart for trends over time or ordered categories.</summary>
+        Trend,
+        /// <summary>Pie chart for contribution/share views.</summary>
+        Contribution,
+        /// <summary>Compact clustered bar chart for dashboards with limited space.</summary>
+        CompactComparison
+    }
+
+    /// <summary>
+    /// Options for adding a dashboard-ready chart.
+    /// </summary>
+    public sealed class ExcelDashboardChartOptions {
+        /// <summary>Dashboard chart preset.</summary>
+        public ExcelDashboardChartPreset Preset { get; set; } = ExcelDashboardChartPreset.Comparison;
+
+        /// <summary>A1 range containing chart data.</summary>
+        public string? Range { get; set; }
+
+        /// <summary>Table name containing chart data.</summary>
+        public string? TableName { get; set; }
+
+        /// <summary>Top-left row for the chart.</summary>
+        public int Row { get; set; } = 1;
+
+        /// <summary>Top-left column for the chart.</summary>
+        public int Column { get; set; } = 1;
+
+        /// <summary>Optional chart type override.</summary>
+        public ExcelChartType? ChartType { get; set; }
+
+        /// <summary>Optional chart title.</summary>
+        public string? Title { get; set; }
+
+        /// <summary>Whether the source range has headers.</summary>
+        public bool HasHeaders { get; set; } = true;
+
+        /// <summary>Include cached data in the chart for portability.</summary>
+        public bool IncludeCachedData { get; set; } = true;
+
+        /// <summary>Optional width override in pixels.</summary>
+        public int? WidthPixels { get; set; }
+
+        /// <summary>Optional height override in pixels.</summary>
+        public int? HeightPixels { get; set; }
+
+        /// <summary>Optional chart style id override.</summary>
+        public int? StyleId { get; set; }
+
+        /// <summary>Optional chart color style id override.</summary>
+        public int? ColorStyleId { get; set; }
+    }
+
+    public partial class ExcelSheet {
+        /// <summary>
+        /// Adds a dashboard-ready chart from a range or table and applies preset styling.
+        /// </summary>
+        /// <param name="options">Dashboard chart options.</param>
+        /// <returns>The created chart.</returns>
+        public ExcelChart AddDashboardChart(ExcelDashboardChartOptions options) {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            if (options.Row <= 0) throw new ArgumentOutOfRangeException(nameof(options.Row));
+            if (options.Column <= 0) throw new ArgumentOutOfRangeException(nameof(options.Column));
+            if (string.IsNullOrWhiteSpace(options.Range) == string.IsNullOrWhiteSpace(options.TableName)) {
+                throw new ArgumentException("Provide either Range or TableName.", nameof(options));
+            }
+
+            var preset = ResolveDashboardChartPreset(options.Preset);
+            var chartType = options.ChartType ?? preset.ChartType;
+            int width = options.WidthPixels ?? preset.WidthPixels;
+            int height = options.HeightPixels ?? preset.HeightPixels;
+            int styleId = options.StyleId ?? preset.StyleId;
+            int colorStyleId = options.ColorStyleId ?? preset.ColorStyleId;
+
+            ExcelChart chart = !string.IsNullOrWhiteSpace(options.TableName)
+                ? AddChartFromTable(options.TableName!, options.Row, options.Column, width, height, chartType, options.Title, options.IncludeCachedData)
+                : AddChartFromRange(options.Range!, options.Row, options.Column, width, height, chartType, options.HasHeaders, options.Title, options.IncludeCachedData);
+
+            chart.ApplyStylePreset(styleId, colorStyleId);
+            if (preset.HideLegend) {
+                chart.HideLegend();
+            } else {
+                chart.SetLegend(preset.LegendPosition);
+            }
+
+            if (preset.ShowDataLabels) {
+                chart.SetDataLabels(
+                    showValue: preset.ShowDataLabelValues,
+                    showCategoryName: preset.ShowDataLabelCategories,
+                    showSeriesName: false,
+                    showLegendKey: false,
+                    showPercent: preset.ShowDataLabelPercent,
+                    position: preset.DataLabelPosition,
+                    numberFormat: null);
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.Title)) {
+                chart.SetTitleTextStyle(fontSizePoints: 12, bold: true);
+            }
+
+            return chart;
+        }
+
+        private static ResolvedDashboardChartPreset ResolveDashboardChartPreset(ExcelDashboardChartPreset preset) {
+            switch (preset) {
+                case ExcelDashboardChartPreset.Trend:
+                    return new ResolvedDashboardChartPreset(
+                        ExcelChartType.Line,
+                        widthPixels: 720,
+                        heightPixels: 320,
+                        styleId: 252,
+                        colorStyleId: 11,
+                        C.LegendPositionValues.Bottom,
+                        hideLegend: false,
+                        showDataLabels: false,
+                        showDataLabelValues: false,
+                        showDataLabelCategories: false,
+                        showDataLabelPercent: false,
+                        dataLabelPosition: null);
+                case ExcelDashboardChartPreset.Contribution:
+                    return new ResolvedDashboardChartPreset(
+                        ExcelChartType.Pie,
+                        widthPixels: 520,
+                        heightPixels: 360,
+                        styleId: 253,
+                        colorStyleId: 12,
+                        C.LegendPositionValues.Right,
+                        hideLegend: false,
+                        showDataLabels: true,
+                        showDataLabelValues: false,
+                        showDataLabelCategories: true,
+                        showDataLabelPercent: true,
+                        dataLabelPosition: C.DataLabelPositionValues.BestFit);
+                case ExcelDashboardChartPreset.CompactComparison:
+                    return new ResolvedDashboardChartPreset(
+                        ExcelChartType.BarClustered,
+                        widthPixels: 420,
+                        heightPixels: 260,
+                        styleId: 251,
+                        colorStyleId: 10,
+                        C.LegendPositionValues.Bottom,
+                        hideLegend: true,
+                        showDataLabels: true,
+                        showDataLabelValues: true,
+                        showDataLabelCategories: false,
+                        showDataLabelPercent: false,
+                        dataLabelPosition: C.DataLabelPositionValues.OutsideEnd);
+                default:
+                    return new ResolvedDashboardChartPreset(
+                        ExcelChartType.ColumnClustered,
+                        widthPixels: 640,
+                        heightPixels: 360,
+                        styleId: 251,
+                        colorStyleId: 10,
+                        C.LegendPositionValues.Bottom,
+                        hideLegend: false,
+                        showDataLabels: false,
+                        showDataLabelValues: false,
+                        showDataLabelCategories: false,
+                        showDataLabelPercent: false,
+                        dataLabelPosition: null);
+            }
+        }
+
+        private sealed class ResolvedDashboardChartPreset {
+            internal ResolvedDashboardChartPreset(
+                ExcelChartType chartType,
+                int widthPixels,
+                int heightPixels,
+                int styleId,
+                int colorStyleId,
+                C.LegendPositionValues legendPosition,
+                bool hideLegend,
+                bool showDataLabels,
+                bool showDataLabelValues,
+                bool showDataLabelCategories,
+                bool showDataLabelPercent,
+                C.DataLabelPositionValues? dataLabelPosition) {
+                ChartType = chartType;
+                WidthPixels = widthPixels;
+                HeightPixels = heightPixels;
+                StyleId = styleId;
+                ColorStyleId = colorStyleId;
+                LegendPosition = legendPosition;
+                HideLegend = hideLegend;
+                ShowDataLabels = showDataLabels;
+                ShowDataLabelValues = showDataLabelValues;
+                ShowDataLabelCategories = showDataLabelCategories;
+                ShowDataLabelPercent = showDataLabelPercent;
+                DataLabelPosition = dataLabelPosition;
+            }
+
+            internal ExcelChartType ChartType { get; }
+            internal int WidthPixels { get; }
+            internal int HeightPixels { get; }
+            internal int StyleId { get; }
+            internal int ColorStyleId { get; }
+            internal C.LegendPositionValues LegendPosition { get; }
+            internal bool HideLegend { get; }
+            internal bool ShowDataLabels { get; }
+            internal bool ShowDataLabelValues { get; }
+            internal bool ShowDataLabelCategories { get; }
+            internal bool ShowDataLabelPercent { get; }
+            internal C.DataLabelPositionValues? DataLabelPosition { get; }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.DashboardCharts.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DashboardCharts.cs
@@ -67,8 +67,10 @@ namespace OfficeIMO.Excel {
         /// <returns>The created chart.</returns>
         public ExcelChart AddDashboardChart(ExcelDashboardChartOptions options) {
             if (options == null) throw new ArgumentNullException(nameof(options));
-            if (options.Row <= 0) throw new ArgumentOutOfRangeException(nameof(options.Row));
-            if (options.Column <= 0) throw new ArgumentOutOfRangeException(nameof(options.Column));
+            if (options.Row <= 0 || options.Row > A1.MaxRows) throw new ArgumentOutOfRangeException(nameof(options.Row), "Chart row must be between 1 and the Excel row limit.");
+            if (options.Column <= 0 || options.Column > A1.MaxColumns) throw new ArgumentOutOfRangeException(nameof(options.Column), "Chart column must be between 1 and the Excel column limit.");
+            if (options.WidthPixels <= 0) throw new ArgumentOutOfRangeException(nameof(options.WidthPixels), "Chart width must be greater than zero.");
+            if (options.HeightPixels <= 0) throw new ArgumentOutOfRangeException(nameof(options.HeightPixels), "Chart height must be greater than zero.");
             if (string.IsNullOrWhiteSpace(options.Range) == string.IsNullOrWhiteSpace(options.TableName)) {
                 throw new ArgumentException("Provide either Range or TableName.", nameof(options));
             }

--- a/OfficeIMO.Excel/ExcelSheet.DataOperations.Validation.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataOperations.Validation.cs
@@ -98,8 +98,8 @@ namespace OfficeIMO.Excel {
         /// Applies a date validation to the specified A1 range.
         /// </summary>
         public void ValidationDate(string a1Range, DataValidationOperatorValues @operator, DateTime formula1, DateTime? formula2 = null, bool allowBlank = true, string? errorTitle = null, string? errorMessage = null) {
-            string f1 = formula1.ToOADate().ToString(System.Globalization.CultureInfo.InvariantCulture);
-            string? f2 = formula2?.ToOADate().ToString(System.Globalization.CultureInfo.InvariantCulture);
+            string f1 = ExcelDateSystemConverter.ToSerial(formula1, _excelDocument.DateSystem).ToString(System.Globalization.CultureInfo.InvariantCulture);
+            string? f2 = formula2.HasValue ? ExcelDateSystemConverter.ToSerial(formula2.Value, _excelDocument.DateSystem).ToString(System.Globalization.CultureInfo.InvariantCulture) : null;
             ValidationAdd(a1Range, DataValidationValues.Date, @operator, f1, f2, allowBlank, errorTitle, errorMessage);
         }
 

--- a/OfficeIMO.Excel/ExcelSheet.DataTable.AppendRows.Builders.cs
+++ b/OfficeIMO.Excel/ExcelSheet.DataTable.AppendRows.Builders.cs
@@ -321,13 +321,13 @@ namespace OfficeIMO.Excel {
                     if (value is bool boolValue) return CoerceValueHelper.HandleBoolean(boolValue);
                     break;
                 case TabularAppendColumnKind.DateTime:
-                    if (value is DateTime dateTimeValue) return CoerceValueHelper.HandleNumber(dateTimeValue.ToOADate());
+                    if (value is DateTime dateTimeValue) return CoerceValueHelper.HandleNumber(ExcelDateSystemConverter.ToSerial(dateTimeValue, _excelDocument.DateSystem));
                     break;
                 case TabularAppendColumnKind.DateTimeOffset:
                     break;
 #if NET6_0_OR_GREATER
                 case TabularAppendColumnKind.DateOnly:
-                    if (value is DateOnly dateOnlyValue) return CoerceValueHelper.HandleNumber(dateOnlyValue.ToDateTime(TimeOnly.MinValue).ToOADate());
+                    if (value is DateOnly dateOnlyValue) return CoerceValueHelper.HandleNumber(ExcelDateSystemConverter.ToSerial(dateOnlyValue.ToDateTime(TimeOnly.MinValue), _excelDocument.DateSystem));
                     break;
                 case TabularAppendColumnKind.TimeOnly:
                     if (value is TimeOnly timeOnlyValue) return CoerceValueHelper.HandleNumber(timeOnlyValue.ToTimeSpan().TotalDays);
@@ -364,7 +364,8 @@ namespace OfficeIMO.Excel {
             var (cellValue, cellType) = CoerceValueHelper.Coerce(
                 value,
                 HandleString,
-                _excelDocument.DateTimeOffsetWriteStrategy);
+                _excelDocument.DateTimeOffsetWriteStrategy,
+                _excelDocument.DateSystem);
             sharedStringIndexes = indexes;
 
             if (useDirectStringCells && cellType == DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString) {

--- a/OfficeIMO.Excel/ExcelSheet.Formulas.Criteria.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Formulas.Criteria.cs
@@ -438,20 +438,24 @@ namespace OfficeIMO.Excel {
                 && TryGetWholeNumber(value, out number);
         }
 
-        private static bool TryGetDateFromSerial(double value, out DateTime date) {
+        private double ToExcelDateSerial(DateTime value) {
+            return ExcelDateSystemConverter.ToSerial(value, _excelDocument.DateSystem);
+        }
+
+        private bool TryGetDateFromSerial(double value, out DateTime date) {
             date = default;
             try {
-                date = DateTime.FromOADate(value).Date;
+                date = ExcelDateSystemConverter.FromSerial(value, _excelDocument.DateSystem).Date;
                 return true;
             } catch (ArgumentException) {
                 return false;
             }
         }
 
-        private static bool TryGetDateTimeFromSerial(double value, out DateTime date) {
+        private bool TryGetDateTimeFromSerial(double value, out DateTime date) {
             date = default;
             try {
-                date = DateTime.FromOADate(value);
+                date = ExcelDateSystemConverter.FromSerial(value, _excelDocument.DateSystem);
                 return true;
             } catch (ArgumentException) {
                 return false;

--- a/OfficeIMO.Excel/ExcelSheet.Formulas.DateTime.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Formulas.DateTime.cs
@@ -15,7 +15,7 @@ namespace OfficeIMO.Excel {
                     return false;
                 }
 
-                result = DateTime.Today.ToOADate();
+                result = ToExcelDateSerial(DateTime.Today);
                 return true;
             }
 
@@ -24,7 +24,7 @@ namespace OfficeIMO.Excel {
                     return false;
                 }
 
-                result = DateTime.Now.ToOADate();
+                result = ToExcelDateSerial(DateTime.Now);
                 return true;
             }
 
@@ -69,7 +69,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 try {
-                    result = new DateTime(year, 1, 1).AddMonths(month - 1).AddDays(day - 1).ToOADate();
+                    result = ToExcelDateSerial(new DateTime(year, 1, 1).AddMonths(month - 1).AddDays(day - 1));
                 } catch (ArgumentOutOfRangeException) {
                     return false;
                 }
@@ -104,8 +104,8 @@ namespace OfficeIMO.Excel {
                 try {
                     DateTime shifted = startDate.AddMonths(months);
                     result = function == "EOMONTH"
-                        ? new DateTime(shifted.Year, shifted.Month, DateTime.DaysInMonth(shifted.Year, shifted.Month)).ToOADate()
-                        : shifted.ToOADate();
+                        ? ToExcelDateSerial(new DateTime(shifted.Year, shifted.Month, DateTime.DaysInMonth(shifted.Year, shifted.Month)))
+                        : ToExcelDateSerial(shifted);
                 } catch (ArgumentOutOfRangeException) {
                     return false;
                 }
@@ -201,7 +201,7 @@ namespace OfficeIMO.Excel {
 
             DateTime dateTime;
             try {
-                dateTime = DateTime.FromOADate(numbers[0]);
+                dateTime = ExcelDateSystemConverter.FromSerial(numbers[0], _excelDocument.DateSystem);
             } catch (ArgumentException) {
                 return false;
             }
@@ -570,7 +570,7 @@ namespace OfficeIMO.Excel {
             }
 
             if (days == 0) {
-                result = current.ToOADate();
+                result = ToExcelDateSerial(current);
                 return true;
             }
 
@@ -583,7 +583,7 @@ namespace OfficeIMO.Excel {
                 }
             }
 
-            result = current.ToOADate();
+            result = ToExcelDateSerial(current);
             return true;
         }
 
@@ -603,7 +603,7 @@ namespace OfficeIMO.Excel {
                     return false;
                 }
 
-                result = date.Date.ToOADate();
+                result = ToExcelDateSerial(date.Date);
                 return true;
             }
 

--- a/OfficeIMO.Excel/ExcelSheet.Formulas.Text.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Formulas.Text.cs
@@ -522,7 +522,7 @@ namespace OfficeIMO.Excel {
             return true;
         }
 
-        private static bool TryFormatTextFunctionValue(FormulaArgumentValue value, string format, out string formatted) {
+        private bool TryFormatTextFunctionValue(FormulaArgumentValue value, string format, out string formatted) {
             formatted = string.Empty;
             if (string.IsNullOrWhiteSpace(format)) {
                 return false;

--- a/OfficeIMO.Excel/ExcelSheet.Images.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Images.cs
@@ -21,7 +21,7 @@ namespace OfficeIMO.Excel {
                 return drawingPart.WorksheetDrawing
                     .ChildElements
                     .Where(IsSupportedImageAnchor)
-                    .SelectMany(anchor => anchor.Descendants<Xdr.Picture>().Select(picture => new ExcelImage(picture, anchor, drawingPart)))
+                    .SelectMany(anchor => anchor.Descendants<Xdr.Picture>().Select(picture => new ExcelImage(picture, anchor, drawingPart, _excelDocument)))
                     .ToList();
             }
         }
@@ -138,7 +138,8 @@ namespace OfficeIMO.Excel {
                 drawingPart.WorksheetDrawing.Append(anchor);
                 drawingPart.WorksheetDrawing.Save();
                 WorksheetRoot.Save();
-                image = new ExcelImage(anchor.GetFirstChild<Xdr.Picture>()!, anchor, drawingPart);
+                _excelDocument.MarkPackageDirty();
+                image = new ExcelImage(anchor.GetFirstChild<Xdr.Picture>()!, anchor, drawingPart, _excelDocument);
             });
 
             return image!;

--- a/OfficeIMO.Excel/ExcelSheet.ObjectInsertion.CellValuesParallel.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ObjectInsertion.CellValuesParallel.cs
@@ -46,7 +46,8 @@ namespace OfficeIMO.Excel {
             var (cellValue, dataType) = CoerceValueHelper.Coerce(
                 value,
                 s => new CellValue(s),
-                dateTimeOffsetStrategy);
+                dateTimeOffsetStrategy,
+                _excelDocument.DateSystem);
 
             bool isSharedString = dataType == DocumentFormat.OpenXml.Spreadsheet.CellValues.SharedString;
             return new CellUpdate(row, column, cellValue.Text ?? string.Empty, dataType, isSharedString);

--- a/OfficeIMO.Excel/ExcelSheet.Outline.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Outline.cs
@@ -1,0 +1,266 @@
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelSheet {
+        /// <summary>
+        /// Groups a contiguous range of worksheet rows by applying an Excel outline level.
+        /// </summary>
+        /// <param name="startRow">First 1-based row in the group.</param>
+        /// <param name="endRow">Last 1-based row in the group.</param>
+        /// <param name="outlineLevel">Excel outline level from 1 through 7.</param>
+        /// <param name="collapsed">Whether to hide the grouped rows and mark the summary row as collapsed.</param>
+        /// <param name="hidden">Whether to hide the grouped rows without marking the group as collapsed.</param>
+        public void GroupRows(int startRow, int endRow, byte outlineLevel = 1, bool collapsed = false, bool hidden = false) {
+            ValidateOutlineRange(startRow, endRow, nameof(startRow), nameof(endRow));
+            ValidateOutlineLevel(outlineLevel);
+
+            _excelDocument.MaterializeDeferredDataSetImport();
+            WriteLock(() => {
+                SheetData sheetData = GetOrCreateSheetData();
+                for (int rowIndex = startRow; rowIndex <= endRow; rowIndex++) {
+                    Row row = GetOrCreateRowElement(sheetData, rowIndex);
+                    row.OutlineLevel = outlineLevel;
+                    row.Hidden = collapsed || hidden ? true : null;
+                    row.Collapsed = null;
+                }
+
+                if (collapsed) {
+                    Row summaryRow = GetOrCreateRowElement(sheetData, endRow + 1);
+                    summaryRow.Collapsed = true;
+                }
+
+                WorksheetRoot.Save();
+            });
+        }
+
+        /// <summary>
+        /// Clears Excel outline grouping metadata from a contiguous range of worksheet rows.
+        /// </summary>
+        /// <param name="startRow">First 1-based row to clear.</param>
+        /// <param name="endRow">Last 1-based row to clear.</param>
+        /// <param name="unhide">Whether hidden rows in the cleared range should be shown.</param>
+        public void ClearRowGroup(int startRow, int endRow, bool unhide = true) {
+            ValidateOutlineRange(startRow, endRow, nameof(startRow), nameof(endRow));
+
+            _excelDocument.MaterializeDeferredDataSetImport();
+            WriteLock(() => {
+                SheetData? sheetData = WorksheetRoot.GetFirstChild<SheetData>();
+                if (sheetData == null) {
+                    return;
+                }
+
+                for (int rowIndex = startRow; rowIndex <= endRow; rowIndex++) {
+                    Row? row = sheetData.Elements<Row>()
+                        .FirstOrDefault(candidate => candidate.RowIndex?.Value == (uint)rowIndex);
+                    if (row == null) {
+                        continue;
+                    }
+
+                    row.OutlineLevel = null;
+                    row.Collapsed = null;
+                    if (unhide) {
+                        row.Hidden = null;
+                    }
+
+                    RemoveRowWhenEmpty(row);
+                }
+
+                Row? nextRow = sheetData.Elements<Row>()
+                    .FirstOrDefault(candidate => candidate.RowIndex?.Value == (uint)(endRow + 1));
+                if (nextRow != null && nextRow.Collapsed?.Value == true) {
+                    nextRow.Collapsed = null;
+                    RemoveRowWhenEmpty(nextRow);
+                }
+
+                WorksheetRoot.Save();
+            });
+        }
+
+        /// <summary>
+        /// Groups a contiguous range of worksheet columns by applying an Excel outline level.
+        /// </summary>
+        /// <param name="startColumn">First 1-based column in the group.</param>
+        /// <param name="endColumn">Last 1-based column in the group.</param>
+        /// <param name="outlineLevel">Excel outline level from 1 through 7.</param>
+        /// <param name="collapsed">Whether to hide the grouped columns and mark the summary column as collapsed.</param>
+        /// <param name="hidden">Whether to hide the grouped columns without marking the group as collapsed.</param>
+        public void GroupColumns(int startColumn, int endColumn, byte outlineLevel = 1, bool collapsed = false, bool hidden = false) {
+            ValidateOutlineRange(startColumn, endColumn, nameof(startColumn), nameof(endColumn));
+            ValidateOutlineLevel(outlineLevel);
+            if (endColumn >= A1.MaxColumns && collapsed) {
+                throw new ArgumentOutOfRangeException(nameof(endColumn), "Collapsed column groups require a following summary column.");
+            }
+
+            _excelDocument.MaterializeDeferredDataSetImport();
+            WriteLock(() => {
+                Columns columns = GetOrCreateColumns();
+                for (int columnIndex = startColumn; columnIndex <= endColumn; columnIndex++) {
+                    Column column = GetOrCreateSingleColumn(columns, columnIndex);
+                    column.OutlineLevel = outlineLevel;
+                    column.Hidden = collapsed || hidden ? true : null;
+                    column.Collapsed = null;
+                }
+
+                if (collapsed) {
+                    Column summaryColumn = GetOrCreateSingleColumn(columns, endColumn + 1);
+                    summaryColumn.Collapsed = true;
+                }
+
+                ReorderColumns(columns);
+                WorksheetRoot.Save();
+            });
+        }
+
+        /// <summary>
+        /// Clears Excel outline grouping metadata from a contiguous range of worksheet columns.
+        /// </summary>
+        /// <param name="startColumn">First 1-based column to clear.</param>
+        /// <param name="endColumn">Last 1-based column to clear.</param>
+        /// <param name="unhide">Whether hidden columns in the cleared range should be shown.</param>
+        public void ClearColumnGroup(int startColumn, int endColumn, bool unhide = true) {
+            ValidateOutlineRange(startColumn, endColumn, nameof(startColumn), nameof(endColumn));
+
+            _excelDocument.MaterializeDeferredDataSetImport();
+            WriteLock(() => {
+                Columns? columns = WorksheetRoot.GetFirstChild<Columns>();
+                if (columns == null) {
+                    return;
+                }
+
+                for (int columnIndex = startColumn; columnIndex <= endColumn; columnIndex++) {
+                    Column? column = columns.Elements<Column>()
+                        .FirstOrDefault(candidate => candidate.Min?.Value <= (uint)columnIndex && candidate.Max?.Value >= (uint)columnIndex);
+                    if (column == null) {
+                        continue;
+                    }
+
+                    column = SplitColumn(columns, column, (uint)columnIndex);
+                    column.OutlineLevel = null;
+                    column.Collapsed = null;
+                    if (unhide) {
+                        column.Hidden = null;
+                    }
+
+                    RemoveColumnWhenEmpty(column);
+                }
+
+                Column? nextColumn = columns.Elements<Column>()
+                    .FirstOrDefault(candidate => candidate.Min?.Value <= (uint)(endColumn + 1) && candidate.Max?.Value >= (uint)(endColumn + 1));
+                if (nextColumn != null && nextColumn.Collapsed?.Value == true) {
+                    nextColumn = SplitColumn(columns, nextColumn, (uint)(endColumn + 1));
+                    nextColumn.Collapsed = null;
+                    RemoveColumnWhenEmpty(nextColumn);
+                }
+
+                if (columns.Elements<Column>().Any()) {
+                    ReorderColumns(columns);
+                } else {
+                    columns.Remove();
+                }
+
+                WorksheetRoot.Save();
+            });
+        }
+
+        /// <summary>
+        /// Configures the worksheet outline summary positions shown by Excel.
+        /// </summary>
+        /// <param name="summaryBelow">Whether row summaries should appear below grouped rows.</param>
+        /// <param name="summaryRight">Whether column summaries should appear to the right of grouped columns.</param>
+        public void SetOutlineSummary(bool? summaryBelow = null, bool? summaryRight = null) {
+            _excelDocument.MaterializeDeferredDataSetImport();
+            WriteLock(() => {
+                SheetProperties sheetProperties = WorksheetRoot.GetFirstChild<SheetProperties>() ?? new SheetProperties();
+                if (sheetProperties.Parent == null) {
+                    WorksheetRoot.InsertAt(sheetProperties, 0);
+                }
+
+                OutlineProperties outlineProperties = sheetProperties.GetFirstChild<OutlineProperties>() ?? new OutlineProperties();
+                if (outlineProperties.Parent == null) {
+                    sheetProperties.Append(outlineProperties);
+                }
+
+                if (summaryBelow.HasValue) {
+                    outlineProperties.SummaryBelow = summaryBelow.Value;
+                }
+
+                if (summaryRight.HasValue) {
+                    outlineProperties.SummaryRight = summaryRight.Value;
+                }
+
+                WorksheetRoot.Save();
+            });
+        }
+
+        private Columns GetOrCreateColumns() {
+            Columns? columns = WorksheetRoot.GetFirstChild<Columns>();
+            if (columns != null) {
+                return columns;
+            }
+
+            SheetData? sheetData = WorksheetRoot.GetFirstChild<SheetData>();
+            columns = new Columns();
+            if (sheetData != null) {
+                WorksheetRoot.InsertBefore(columns, sheetData);
+            } else {
+                WorksheetRoot.Append(columns);
+            }
+
+            return columns;
+        }
+
+        private static Column GetOrCreateSingleColumn(Columns columns, int columnIndex) {
+            Column? column = columns.Elements<Column>()
+                .FirstOrDefault(candidate => candidate.Min?.Value <= (uint)columnIndex && candidate.Max?.Value >= (uint)columnIndex);
+            if (column != null) {
+                return SplitColumn(columns, column, (uint)columnIndex);
+            }
+
+            column = new Column {
+                Min = (uint)columnIndex,
+                Max = (uint)columnIndex
+            };
+            columns.Append(column);
+            return column;
+        }
+
+        private static void ValidateOutlineRange(int start, int end, string startParameter, string endParameter) {
+            if (start <= 0) {
+                throw new ArgumentOutOfRangeException(startParameter, "Outline range start must be 1 or greater.");
+            }
+
+            if (end < start) {
+                throw new ArgumentException("Outline range end must be greater than or equal to the start.", endParameter);
+            }
+        }
+
+        private static void ValidateOutlineLevel(byte outlineLevel) {
+            if (outlineLevel < 1 || outlineLevel > 7) {
+                throw new ArgumentOutOfRangeException(nameof(outlineLevel), "Excel outline level must be between 1 and 7.");
+            }
+        }
+
+        private static void RemoveRowWhenEmpty(Row row) {
+            if (!row.Elements<Cell>().Any()
+                && row.Height == null
+                && row.CustomHeight == null
+                && row.Hidden == null
+                && row.OutlineLevel == null
+                && row.Collapsed == null) {
+                row.Remove();
+            }
+        }
+
+        private static void RemoveColumnWhenEmpty(Column column) {
+            if (column.Width == null
+                && column.CustomWidth == null
+                && column.BestFit == null
+                && column.Hidden == null
+                && column.OutlineLevel == null
+                && column.Collapsed == null
+                && column.Style == null) {
+                column.Remove();
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.Outline.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Outline.cs
@@ -13,6 +13,9 @@ namespace OfficeIMO.Excel {
         public void GroupRows(int startRow, int endRow, byte outlineLevel = 1, bool collapsed = false, bool hidden = false) {
             ValidateOutlineRange(startRow, endRow, nameof(startRow), nameof(endRow));
             ValidateOutlineLevel(outlineLevel);
+            if (endRow >= A1.MaxRows && collapsed) {
+                throw new ArgumentOutOfRangeException(nameof(endRow), "Collapsed row groups require a following summary row.");
+            }
 
             _excelDocument.MaterializeDeferredDataSetImport();
             WriteLock(() => {

--- a/OfficeIMO.Excel/ExcelSheet.Outline.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Outline.cs
@@ -11,7 +11,7 @@ namespace OfficeIMO.Excel {
         /// <param name="collapsed">Whether to hide the grouped rows and mark the summary row as collapsed.</param>
         /// <param name="hidden">Whether to hide the grouped rows without marking the group as collapsed.</param>
         public void GroupRows(int startRow, int endRow, byte outlineLevel = 1, bool collapsed = false, bool hidden = false) {
-            ValidateOutlineRange(startRow, endRow, nameof(startRow), nameof(endRow));
+            ValidateOutlineRange(startRow, endRow, nameof(startRow), nameof(endRow), A1.MaxRows, "row");
             ValidateOutlineLevel(outlineLevel);
             if (endRow >= A1.MaxRows && collapsed) {
                 throw new ArgumentOutOfRangeException(nameof(endRow), "Collapsed row groups require a following summary row.");
@@ -43,7 +43,7 @@ namespace OfficeIMO.Excel {
         /// <param name="endRow">Last 1-based row to clear.</param>
         /// <param name="unhide">Whether hidden rows in the cleared range should be shown.</param>
         public void ClearRowGroup(int startRow, int endRow, bool unhide = true) {
-            ValidateOutlineRange(startRow, endRow, nameof(startRow), nameof(endRow));
+            ValidateOutlineRange(startRow, endRow, nameof(startRow), nameof(endRow), A1.MaxRows, "row");
 
             _excelDocument.MaterializeDeferredDataSetImport();
             WriteLock(() => {
@@ -88,7 +88,7 @@ namespace OfficeIMO.Excel {
         /// <param name="collapsed">Whether to hide the grouped columns and mark the summary column as collapsed.</param>
         /// <param name="hidden">Whether to hide the grouped columns without marking the group as collapsed.</param>
         public void GroupColumns(int startColumn, int endColumn, byte outlineLevel = 1, bool collapsed = false, bool hidden = false) {
-            ValidateOutlineRange(startColumn, endColumn, nameof(startColumn), nameof(endColumn));
+            ValidateOutlineRange(startColumn, endColumn, nameof(startColumn), nameof(endColumn), A1.MaxColumns, "column");
             ValidateOutlineLevel(outlineLevel);
             if (endColumn >= A1.MaxColumns && collapsed) {
                 throw new ArgumentOutOfRangeException(nameof(endColumn), "Collapsed column groups require a following summary column.");
@@ -121,7 +121,7 @@ namespace OfficeIMO.Excel {
         /// <param name="endColumn">Last 1-based column to clear.</param>
         /// <param name="unhide">Whether hidden columns in the cleared range should be shown.</param>
         public void ClearColumnGroup(int startColumn, int endColumn, bool unhide = true) {
-            ValidateOutlineRange(startColumn, endColumn, nameof(startColumn), nameof(endColumn));
+            ValidateOutlineRange(startColumn, endColumn, nameof(startColumn), nameof(endColumn), A1.MaxColumns, "column");
 
             _excelDocument.MaterializeDeferredDataSetImport();
             WriteLock(() => {
@@ -227,13 +227,17 @@ namespace OfficeIMO.Excel {
             return column;
         }
 
-        private static void ValidateOutlineRange(int start, int end, string startParameter, string endParameter) {
+        private static void ValidateOutlineRange(int start, int end, string startParameter, string endParameter, int max, string unitName) {
             if (start <= 0) {
                 throw new ArgumentOutOfRangeException(startParameter, "Outline range start must be 1 or greater.");
             }
 
             if (end < start) {
                 throw new ArgumentException("Outline range end must be greater than or equal to the start.", endParameter);
+            }
+
+            if (start > max || end > max) {
+                throw new ArgumentOutOfRangeException(endParameter, $"Outline {unitName} range must not exceed the Excel {unitName} limit.");
             }
         }
 

--- a/OfficeIMO.Excel/ExcelSheet.PivotTables.CacheRecords.cs
+++ b/OfficeIMO.Excel/ExcelSheet.PivotTables.CacheRecords.cs
@@ -525,7 +525,7 @@ namespace OfficeIMO.Excel {
             }
 
             try {
-                date = DateTime.FromOADate(serial);
+                date = ExcelDateSystemConverter.FromSerial(serial, _excelDocument.DateSystem);
                 return true;
             } catch (ArgumentException) {
                 date = default;
@@ -557,7 +557,7 @@ namespace OfficeIMO.Excel {
                 DateOnly dateOnly => PivotFieldValue.FromDate(dateOnly.ToDateTime(TimeOnly.MinValue)),
 #endif
                 string text => CreatePivotFieldTextValue(TrimPivotFieldText(text)),
-                _ => PivotFieldValue.FromText(FormatPivotFieldText(value, _excelDocument.DateTimeOffsetWriteStrategy))
+                _ => PivotFieldValue.FromText(FormatPivotFieldText(value, _excelDocument.DateTimeOffsetWriteStrategy, _excelDocument.DateSystem))
             };
         }
 
@@ -566,20 +566,20 @@ namespace OfficeIMO.Excel {
                 return string.Empty;
             }
 
-            return FormatPivotFieldText(value, _excelDocument.DateTimeOffsetWriteStrategy);
+            return FormatPivotFieldText(value, _excelDocument.DateTimeOffsetWriteStrategy, _excelDocument.DateSystem);
         }
 
         private static PivotFieldValue CreatePivotFieldTextValue(string text)
             => text.Length == 0 ? PivotFieldValue.Blank() : PivotFieldValue.FromText(text);
 
-        private static string FormatPivotFieldText(object value, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy) {
+        private static string FormatPivotFieldText(object value, Func<DateTimeOffset, DateTime> dateTimeOffsetWriteStrategy, ExcelDateSystem dateSystem) {
             return value switch {
                 string text => TrimPivotFieldText(text),
                 bool boolean => boolean ? "1" : "0",
-                DateTime dateTime => dateTime.ToOADate().ToString(CultureInfo.InvariantCulture),
-                DateTimeOffset dateTimeOffset => dateTimeOffsetWriteStrategy(dateTimeOffset).ToOADate().ToString(CultureInfo.InvariantCulture),
+                DateTime dateTime => ExcelDateSystemConverter.ToSerial(dateTime, dateSystem).ToString(CultureInfo.InvariantCulture),
+                DateTimeOffset dateTimeOffset => ExcelDateSystemConverter.ToSerial(dateTimeOffsetWriteStrategy(dateTimeOffset), dateSystem).ToString(CultureInfo.InvariantCulture),
 #if NET6_0_OR_GREATER
-                DateOnly dateOnly => dateOnly.ToDateTime(TimeOnly.MinValue).ToOADate().ToString(CultureInfo.InvariantCulture),
+                DateOnly dateOnly => ExcelDateSystemConverter.ToSerial(dateOnly.ToDateTime(TimeOnly.MinValue), dateSystem).ToString(CultureInfo.InvariantCulture),
 #endif
                 double number => FormatPivotDoubleText(number),
                 float number => FormatPivotDoubleText(number),
@@ -627,7 +627,7 @@ namespace OfficeIMO.Excel {
             var snapshot = GetCellValueSnapshot(row, column);
             if (snapshot.Value is double serial) {
                 try {
-                    date = DateTime.FromOADate(serial);
+                    date = ExcelDateSystemConverter.FromSerial(serial, _excelDocument.DateSystem);
                     return true;
                 } catch {
                     // Fall through to string parsing when a numeric value is not a valid Excel date.

--- a/OfficeIMO.Excel/ExcelSheet.PivotTables.ConditionalFormatting.cs
+++ b/OfficeIMO.Excel/ExcelSheet.PivotTables.ConditionalFormatting.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Linq;
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Represents an Excel worksheet.
+    /// </summary>
+    public partial class ExcelSheet {
+        /// <summary>
+        /// Resolves the output range for a pivot table on this worksheet.
+        /// </summary>
+        public string GetPivotTableRange(string pivotTableName, ExcelPivotRangeTarget target = ExcelPivotRangeTarget.WholeTable) {
+            if (string.IsNullOrWhiteSpace(pivotTableName)) {
+                throw new ArgumentException("Pivot table name cannot be null or empty.", nameof(pivotTableName));
+            }
+
+            ExcelPivotTableInfo? pivot = GetPivotTables()
+                .FirstOrDefault(item => string.Equals(item.Name, pivotTableName, StringComparison.OrdinalIgnoreCase));
+
+            if (pivot == null) {
+                throw new InvalidOperationException($"Pivot table '{pivotTableName}' was not found on worksheet '{Name}'.");
+            }
+            if (string.IsNullOrWhiteSpace(pivot.Location)) {
+                throw new InvalidOperationException($"Pivot table '{pivotTableName}' does not expose an output range.");
+            }
+
+            return target == ExcelPivotRangeTarget.DataBody
+                ? ResolvePivotDataBodyRange(pivot.Location!)
+                : pivot.Location!;
+        }
+
+        /// <summary>
+        /// Adds a cell-is conditional formatting rule to a pivot table output range.
+        /// </summary>
+        public void AddPivotConditionalRule(string pivotTableName, ConditionalFormattingOperatorValues @operator, string formula1, string? formula2 = null, ExcelPivotRangeTarget target = ExcelPivotRangeTarget.DataBody) {
+            AddConditionalRule(GetPivotTableRange(pivotTableName, target), @operator, formula1, formula2);
+        }
+
+        /// <summary>
+        /// Adds a color scale conditional format to a pivot table output range.
+        /// </summary>
+        public void AddPivotConditionalColorScale(string pivotTableName, string startColor, string endColor, ExcelPivotRangeTarget target = ExcelPivotRangeTarget.DataBody) {
+            AddConditionalColorScale(GetPivotTableRange(pivotTableName, target), startColor, endColor);
+        }
+
+        /// <summary>
+        /// Adds a data bar conditional format to a pivot table output range.
+        /// </summary>
+        public void AddPivotConditionalDataBar(string pivotTableName, string color, ExcelPivotRangeTarget target = ExcelPivotRangeTarget.DataBody) {
+            AddConditionalDataBar(GetPivotTableRange(pivotTableName, target), color);
+        }
+
+        /// <summary>
+        /// Adds an icon set conditional format to a pivot table output range.
+        /// </summary>
+        public void AddPivotConditionalIconSet(string pivotTableName, IconSetValues iconSet, bool showValue, bool reverseIconOrder, double[]? percentThresholds = null, double[]? numberThresholds = null, ExcelPivotRangeTarget target = ExcelPivotRangeTarget.DataBody) {
+            AddConditionalIconSet(GetPivotTableRange(pivotTableName, target), iconSet, showValue, reverseIconOrder, percentThresholds, numberThresholds);
+        }
+
+        private static string ResolvePivotDataBodyRange(string location) {
+            if (!A1.TryParseRange(location, out int r1, out int c1, out int r2, out int c2)) {
+                return location;
+            }
+
+            int firstRow = r1 < r2 ? r1 + 1 : r1;
+            int firstColumn = c1 < c2 ? c1 + 1 : c1;
+            return A1.CellReference(firstRow, firstColumn) + ":" + A1.CellReference(r2, c2);
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.PivotTables.Filters.cs
+++ b/OfficeIMO.Excel/ExcelSheet.PivotTables.Filters.cs
@@ -80,7 +80,8 @@ namespace OfficeIMO.Excel {
 
         private static PivotFilters? CreatePivotFilters(IReadOnlyList<ExcelPivotFilter> filters,
             IDictionary<string, int> headerIndex,
-            IReadOnlyList<ExcelPivotDataField> dataFields) {
+            IReadOnlyList<ExcelPivotDataField> dataFields,
+            ExcelDateSystem dateSystem) {
             if (filters.Count == 0) return null;
 
             var pivotFilters = new PivotFilters { Count = (uint)filters.Count };
@@ -94,22 +95,24 @@ namespace OfficeIMO.Excel {
                     Id = (uint)(i + 1)
                 };
 
-                if (!string.IsNullOrWhiteSpace(filter.Value1)) pivotFilter.StringValue1 = filter.Value1;
-                if (!string.IsNullOrWhiteSpace(filter.Value2)) pivotFilter.StringValue2 = filter.Value2;
+                string? value1 = GetPivotFilterValue1(filter, dateSystem);
+                string? value2 = GetPivotFilterValue2(filter, dateSystem);
+                if (!string.IsNullOrWhiteSpace(value1)) pivotFilter.StringValue1 = value1;
+                if (!string.IsNullOrWhiteSpace(value2)) pivotFilter.StringValue2 = value2;
                 if (!string.IsNullOrWhiteSpace(filter.Name)) pivotFilter.Name = filter.Name;
                 if (!string.IsNullOrWhiteSpace(filter.Description)) pivotFilter.Description = filter.Description;
                 if (!string.IsNullOrWhiteSpace(filter.DataFieldName)) {
                     pivotFilter.MeasureField = (uint)ResolvePivotDataFieldIndex(filter.DataFieldName!, dataFields);
                 }
 
-                pivotFilter.AutoFilter = CreatePivotFilterAutoFilter(filter);
+                pivotFilter.AutoFilter = CreatePivotFilterAutoFilter(filter, dateSystem);
                 pivotFilters.Append(pivotFilter);
             }
 
             return pivotFilters;
         }
 
-        private static AutoFilter CreatePivotFilterAutoFilter(ExcelPivotFilter filter) {
+        private static AutoFilter CreatePivotFilterAutoFilter(ExcelPivotFilter filter, ExcelDateSystem dateSystem) {
             var autoFilter = new AutoFilter { Reference = "A1" };
             var filterColumn = new FilterColumn { ColumnId = 0U };
 
@@ -128,28 +131,31 @@ namespace OfficeIMO.Excel {
             CustomFilters customFilters;
 
             if (TryResolveBetweenFilter(filter.Type, out var firstOperator, out var secondOperator, out bool matchAll)) {
-                if (filter.Value1 == null || filter.Value2 == null) {
+                string? value1 = GetPivotFilterValue1(filter, dateSystem);
+                string? value2 = GetPivotFilterValue2(filter, dateSystem);
+                if (value1 == null || value2 == null) {
                     throw new ArgumentException($"Pivot filter '{filter.Type}' requires two values.", nameof(filter));
                 }
 
                 customFilters = new CustomFilters { And = matchAll };
                 customFilters.Append(new CustomFilter {
                     Operator = firstOperator,
-                    Val = filter.Value1
+                    Val = value1
                 });
                 customFilters.Append(new CustomFilter {
                     Operator = secondOperator,
-                    Val = filter.Value2
+                    Val = value2
                 });
             } else {
-                if (filter.Value1 == null) {
+                string? value1 = GetPivotFilterValue1(filter, dateSystem);
+                if (value1 == null) {
                     throw new ArgumentException($"Pivot filter '{filter.Type}' requires a value.", nameof(filter));
                 }
 
                 customFilters = new CustomFilters();
                 customFilters.Append(new CustomFilter {
                     Operator = ResolveSingleFilterOperator(filter.Type),
-                    Val = NormalizePivotFilterAutoFilterValue(filter.Type, filter.Value1)
+                    Val = NormalizePivotFilterAutoFilterValue(filter.Type, value1)
                 });
             }
 
@@ -157,6 +163,16 @@ namespace OfficeIMO.Excel {
             autoFilter.Append(filterColumn);
             return autoFilter;
         }
+
+        private static string? GetPivotFilterValue1(ExcelPivotFilter filter, ExcelDateSystem dateSystem)
+            => filter.DateValue1.HasValue
+                ? ExcelDateSystemConverter.ToSerial(filter.DateValue1.Value, dateSystem).ToString("G17", CultureInfo.InvariantCulture)
+                : filter.Value1;
+
+        private static string? GetPivotFilterValue2(ExcelPivotFilter filter, ExcelDateSystem dateSystem)
+            => filter.DateValue2.HasValue
+                ? ExcelDateSystemConverter.ToSerial(filter.DateValue2.Value, dateSystem).ToString("G17", CultureInfo.InvariantCulture)
+                : filter.Value2;
 
         private static bool TryCreateTop10Filter(ExcelPivotFilter filter, out Top10 top10) {
             if (filter.Type != PivotFilterValues.Count && filter.Type != PivotFilterValues.Percent && filter.Type != PivotFilterValues.Sum) {

--- a/OfficeIMO.Excel/ExcelSheet.PivotTables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.PivotTables.cs
@@ -117,7 +117,11 @@ namespace OfficeIMO.Excel {
                         fields: fieldInfos,
                         filters: filterInfos,
                         calculatedFields: calculatedFieldInfos,
-                        groupings: groupingInfos));
+                        groupings: groupingInfos,
+                        refreshOnOpen: cacheDef?.RefreshOnLoad?.Value,
+                        saveSourceData: cacheDef?.SaveData?.Value,
+                        preserveFormatting: def.PreserveFormatting?.Value,
+                        enableDrill: def.EnableDrill?.Value));
                 }
 
                 return list;
@@ -191,7 +195,8 @@ namespace OfficeIMO.Excel {
                 customListSort: null,
                 pivotFilters: null,
                 calculatedFields: null,
-                groupings: null);
+                groupings: null,
+                options: null);
         }
 
         /// <summary>
@@ -228,6 +233,7 @@ namespace OfficeIMO.Excel {
         /// <param name="pivotFilters">Optional label and value filters.</param>
         /// <param name="calculatedFields">Optional formula-backed pivot cache fields.</param>
         /// <param name="groupings">Optional date or numeric grouping metadata.</param>
+        /// <param name="options">Optional pivot cache and workbook-interaction settings.</param>
         public void AddPivotTable(
             string sourceRange,
             string destinationCell,
@@ -259,7 +265,8 @@ namespace OfficeIMO.Excel {
             bool? customListSort = null,
             IEnumerable<ExcelPivotFilter>? pivotFilters = null,
             IEnumerable<ExcelPivotCalculatedField>? calculatedFields = null,
-            IEnumerable<ExcelPivotGrouping>? groupings = null) {
+            IEnumerable<ExcelPivotGrouping>? groupings = null,
+            ExcelPivotTableOptions? options = null) {
             if (string.IsNullOrWhiteSpace(sourceRange)) throw new ArgumentNullException(nameof(sourceRange));
             if (string.IsNullOrWhiteSpace(destinationCell)) throw new ArgumentNullException(nameof(destinationCell));
             if (!A1.TryParseRange(sourceRange, out int r1, out int c1, out int r2, out int c2)) {
@@ -400,6 +407,7 @@ namespace OfficeIMO.Excel {
                     calculatedFieldList,
                     pivotFilterList,
                     fieldOptionMap);
+                bool effectiveSavePivotCacheRecords = options?.SaveSourceData ?? savePivotCacheRecords;
                 var cacheDefPart = workbookPart.AddNewPart<PivotTableCacheDefinitionPart>();
                 var cacheDef = new PivotCacheDefinition {
                     CacheSource = new CacheSource {
@@ -411,8 +419,8 @@ namespace OfficeIMO.Excel {
                     },
                     CacheFields = new CacheFields { Count = (uint)allFields.Count },
                     RecordCount = (uint)sourceRecordCount,
-                    SaveData = savePivotCacheRecords,
-                    RefreshOnLoad = !savePivotCacheRecords
+                    SaveData = effectiveSavePivotCacheRecords,
+                    RefreshOnLoad = options?.RefreshOnOpen ?? !effectiveSavePivotCacheRecords
                 };
 
                 for (int i = 0; i < headers.Count; i++) {
@@ -457,7 +465,7 @@ namespace OfficeIMO.Excel {
                 cacheDefPart.PivotCacheDefinition = cacheDef;
                 ReportPivotTiming("AddPivotTable.SaveCacheDefinition");
                 var cacheRecordsPart = cacheDefPart.AddNewPart<PivotTableCacheRecordsPart>();
-                if (!savePivotCacheRecords) {
+                if (!effectiveSavePivotCacheRecords) {
                     cacheRecordsPart.PivotCacheRecords = new PivotCacheRecords { Count = 0U };
                 } else if (canUseDeferredPivotValues) {
                     WritePivotCacheRecords(
@@ -557,7 +565,7 @@ namespace OfficeIMO.Excel {
                     dataFieldsElement.Append(dataField);
                 }
 
-                PivotFilters? pivotFiltersElement = CreatePivotFilters(pivotFilterList, headerIndex, dataFieldList);
+                PivotFilters? pivotFiltersElement = CreatePivotFilters(pivotFilterList, headerIndex, dataFieldList, _excelDocument.DateSystem);
 
                 string pivotRef = BuildPivotLocationReference(destRow, destCol, rowFieldIndices.Count + columnFieldIndices.Count + dataFieldList.Count);
 
@@ -570,7 +578,7 @@ namespace OfficeIMO.Excel {
                     ApplyWidthHeightFormats = true,
                     ApplyPatternFormats = true,
                     UseAutoFormatting = true,
-                    PreserveFormatting = true,
+                    PreserveFormatting = options?.PreserveFormatting ?? true,
                     RowGrandTotals = showRowGrandTotals,
                     ColumnGrandTotals = showColumnGrandTotals,
                     MultipleFieldFilters = true,
@@ -622,6 +630,7 @@ namespace OfficeIMO.Excel {
                 if (showMemberPropertyTips.HasValue) pivotDefinition.ShowMemberPropertyTips = showMemberPropertyTips.Value;
                 if (fieldListSortAscending.HasValue) pivotDefinition.FieldListSortAscending = fieldListSortAscending.Value;
                 if (customListSort.HasValue) pivotDefinition.CustomListSort = customListSort.Value;
+                if (options?.EnableDrill.HasValue == true) pivotDefinition.EnableDrill = options.EnableDrill.Value;
 
                 pivotPart.PivotTableDefinition = pivotDefinition;
                 ReportPivotTiming("AddPivotTable.BuildAndSavePivotDefinition");

--- a/OfficeIMO.Excel/ExcelSheet.PrintLayout.cs
+++ b/OfficeIMO.Excel/ExcelSheet.PrintLayout.cs
@@ -94,7 +94,7 @@ namespace OfficeIMO.Excel {
 
             SetOrientation(orientation);
             SetMarginsPreset(margins);
-            SetPageSetup(fitToWidth, fitToHeight, scale, pageOrder);
+            SetPageSetupAndClearStaleFit(fitToWidth, fitToHeight, scale, pageOrder);
 
             if (!string.IsNullOrWhiteSpace(options.PrintArea)) {
                 _excelDocument.SetPrintArea(this, options.PrintArea!, save: false);

--- a/OfficeIMO.Excel/ExcelSheet.PrintLayout.cs
+++ b/OfficeIMO.Excel/ExcelSheet.PrintLayout.cs
@@ -100,15 +100,13 @@ namespace OfficeIMO.Excel {
                 _excelDocument.SetPrintArea(this, options.PrintArea!, save: false);
             }
 
-            if (repeatFirstRow.HasValue || repeatLastRow.HasValue || repeatFirstColumn.HasValue || repeatLastColumn.HasValue) {
-                _excelDocument.SetPrintTitles(
-                    this,
-                    repeatFirstRow,
-                    repeatLastRow,
-                    repeatFirstColumn,
-                    repeatLastColumn,
-                    save: false);
-            }
+            _excelDocument.SetPrintTitles(
+                this,
+                repeatFirstRow,
+                repeatLastRow,
+                repeatFirstColumn,
+                repeatLastColumn,
+                save: false);
 
             WorksheetRoot.Save();
             return this;

--- a/OfficeIMO.Excel/ExcelSheet.PrintLayout.cs
+++ b/OfficeIMO.Excel/ExcelSheet.PrintLayout.cs
@@ -1,0 +1,206 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Common print layout workflows for worksheets.
+    /// </summary>
+    public enum ExcelPrintLayoutPreset {
+        /// <summary>Portrait worksheet defaults with normal margins.</summary>
+        Worksheet,
+        /// <summary>Landscape report layout, one page wide, repeated first header row, narrow margins.</summary>
+        Report,
+        /// <summary>Landscape dashboard layout, fit to one page, narrow margins.</summary>
+        Dashboard,
+        /// <summary>Landscape data-table layout, one page wide, repeated first header row.</summary>
+        DataTable
+    }
+
+    /// <summary>
+    /// Options for applying a worksheet print layout preset.
+    /// Nullable values override the selected preset only when provided.
+    /// </summary>
+    public sealed class ExcelPrintLayoutOptions {
+        /// <summary>Preset to apply.</summary>
+        public ExcelPrintLayoutPreset Preset { get; set; } = ExcelPrintLayoutPreset.Report;
+
+        /// <summary>Optional print area in A1 notation.</summary>
+        public string? PrintArea { get; set; }
+
+        /// <summary>Optional orientation override.</summary>
+        public ExcelPageOrientation? Orientation { get; set; }
+
+        /// <summary>Optional margin preset override.</summary>
+        public ExcelMarginPreset? Margins { get; set; }
+
+        /// <summary>Optional pages-wide fit override.</summary>
+        public uint? FitToWidth { get; set; }
+
+        /// <summary>Optional pages-tall fit override. Use 0 for unlimited height.</summary>
+        public uint? FitToHeight { get; set; }
+
+        /// <summary>Optional manual scale percentage override.</summary>
+        public uint? Scale { get; set; }
+
+        /// <summary>Optional page order override.</summary>
+        public ExcelPageOrder? PageOrder { get; set; }
+
+        /// <summary>Optional first repeated print-title row.</summary>
+        public int? RepeatFirstRow { get; set; }
+
+        /// <summary>Optional last repeated print-title row.</summary>
+        public int? RepeatLastRow { get; set; }
+
+        /// <summary>Optional first repeated print-title column.</summary>
+        public int? RepeatFirstColumn { get; set; }
+
+        /// <summary>Optional last repeated print-title column.</summary>
+        public int? RepeatLastColumn { get; set; }
+
+        /// <summary>When true, preset default print-title rows are not applied.</summary>
+        public bool SuppressPresetPrintTitles { get; set; }
+    }
+
+    public partial class ExcelSheet {
+        /// <summary>
+        /// Applies a reusable worksheet print layout preset with optional overrides.
+        /// </summary>
+        /// <param name="preset">Preset to apply.</param>
+        /// <param name="printArea">Optional print area in A1 notation.</param>
+        /// <returns>The worksheet for fluent chaining.</returns>
+        public ExcelSheet ApplyPrintLayoutPreset(ExcelPrintLayoutPreset preset, string? printArea = null) {
+            return ApplyPrintLayout(new ExcelPrintLayoutOptions {
+                Preset = preset,
+                PrintArea = printArea,
+            });
+        }
+
+        /// <summary>
+        /// Applies reusable worksheet print layout settings.
+        /// </summary>
+        /// <param name="options">Print layout options.</param>
+        /// <returns>The worksheet for fluent chaining.</returns>
+        public ExcelSheet ApplyPrintLayout(ExcelPrintLayoutOptions options) {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+
+            var preset = ResolvePrintLayoutPreset(options.Preset);
+            var orientation = options.Orientation ?? preset.Orientation;
+            var margins = options.Margins ?? preset.Margins;
+            var fitToWidth = options.FitToWidth ?? preset.FitToWidth;
+            var fitToHeight = options.FitToHeight ?? preset.FitToHeight;
+            var scale = options.Scale ?? preset.Scale;
+            var pageOrder = options.PageOrder ?? preset.PageOrder;
+            var repeatFirstRow = options.RepeatFirstRow ?? (options.SuppressPresetPrintTitles ? null : preset.RepeatFirstRow);
+            var repeatLastRow = options.RepeatLastRow ?? (options.SuppressPresetPrintTitles ? null : preset.RepeatLastRow);
+            var repeatFirstColumn = options.RepeatFirstColumn ?? preset.RepeatFirstColumn;
+            var repeatLastColumn = options.RepeatLastColumn ?? preset.RepeatLastColumn;
+
+            SetOrientation(orientation);
+            SetMarginsPreset(margins);
+            SetPageSetup(fitToWidth, fitToHeight, scale, pageOrder);
+
+            if (!string.IsNullOrWhiteSpace(options.PrintArea)) {
+                _excelDocument.SetPrintArea(this, options.PrintArea!, save: false);
+            }
+
+            if (repeatFirstRow.HasValue || repeatLastRow.HasValue || repeatFirstColumn.HasValue || repeatLastColumn.HasValue) {
+                _excelDocument.SetPrintTitles(
+                    this,
+                    repeatFirstRow,
+                    repeatLastRow,
+                    repeatFirstColumn,
+                    repeatLastColumn,
+                    save: false);
+            }
+
+            WorksheetRoot.Save();
+            return this;
+        }
+
+        private static ResolvedPrintLayoutPreset ResolvePrintLayoutPreset(ExcelPrintLayoutPreset preset) {
+            switch (preset) {
+                case ExcelPrintLayoutPreset.Worksheet:
+                    return new ResolvedPrintLayoutPreset(
+                        ExcelPageOrientation.Portrait,
+                        ExcelMarginPreset.Normal,
+                        fitToWidth: null,
+                        fitToHeight: null,
+                        scale: 100,
+                        ExcelPageOrder.DownThenOver,
+                        repeatFirstRow: null,
+                        repeatLastRow: null,
+                        repeatFirstColumn: null,
+                        repeatLastColumn: null);
+                case ExcelPrintLayoutPreset.Dashboard:
+                    return new ResolvedPrintLayoutPreset(
+                        ExcelPageOrientation.Landscape,
+                        ExcelMarginPreset.Narrow,
+                        fitToWidth: 1,
+                        fitToHeight: 1,
+                        scale: null,
+                        ExcelPageOrder.OverThenDown,
+                        repeatFirstRow: null,
+                        repeatLastRow: null,
+                        repeatFirstColumn: null,
+                        repeatLastColumn: null);
+                case ExcelPrintLayoutPreset.DataTable:
+                    return new ResolvedPrintLayoutPreset(
+                        ExcelPageOrientation.Landscape,
+                        ExcelMarginPreset.Normal,
+                        fitToWidth: 1,
+                        fitToHeight: 0,
+                        scale: null,
+                        ExcelPageOrder.DownThenOver,
+                        repeatFirstRow: 1,
+                        repeatLastRow: 1,
+                        repeatFirstColumn: null,
+                        repeatLastColumn: null);
+                default:
+                    return new ResolvedPrintLayoutPreset(
+                        ExcelPageOrientation.Landscape,
+                        ExcelMarginPreset.Narrow,
+                        fitToWidth: 1,
+                        fitToHeight: 0,
+                        scale: null,
+                        ExcelPageOrder.DownThenOver,
+                        repeatFirstRow: 1,
+                        repeatLastRow: 1,
+                        repeatFirstColumn: null,
+                        repeatLastColumn: null);
+            }
+        }
+
+        private sealed class ResolvedPrintLayoutPreset {
+            internal ResolvedPrintLayoutPreset(
+                ExcelPageOrientation orientation,
+                ExcelMarginPreset margins,
+                uint? fitToWidth,
+                uint? fitToHeight,
+                uint? scale,
+                ExcelPageOrder pageOrder,
+                int? repeatFirstRow,
+                int? repeatLastRow,
+                int? repeatFirstColumn,
+                int? repeatLastColumn) {
+                Orientation = orientation;
+                Margins = margins;
+                FitToWidth = fitToWidth;
+                FitToHeight = fitToHeight;
+                Scale = scale;
+                PageOrder = pageOrder;
+                RepeatFirstRow = repeatFirstRow;
+                RepeatLastRow = repeatLastRow;
+                RepeatFirstColumn = repeatFirstColumn;
+                RepeatLastColumn = repeatLastColumn;
+            }
+
+            internal ExcelPageOrientation Orientation { get; }
+            internal ExcelMarginPreset Margins { get; }
+            internal uint? FitToWidth { get; }
+            internal uint? FitToHeight { get; }
+            internal uint? Scale { get; }
+            internal ExcelPageOrder PageOrder { get; }
+            internal int? RepeatFirstRow { get; }
+            internal int? RepeatLastRow { get; }
+            internal int? RepeatFirstColumn { get; }
+            internal int? RepeatLastColumn { get; }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.PrintLayout.cs
+++ b/OfficeIMO.Excel/ExcelSheet.PrintLayout.cs
@@ -91,6 +91,7 @@ namespace OfficeIMO.Excel {
             var repeatLastRow = options.RepeatLastRow ?? (options.SuppressPresetPrintTitles ? null : preset.RepeatLastRow);
             var repeatFirstColumn = options.RepeatFirstColumn ?? preset.RepeatFirstColumn;
             var repeatLastColumn = options.RepeatLastColumn ?? preset.RepeatLastColumn;
+            ValidatePrintLayoutScale(scale);
 
             SetOrientation(orientation);
             SetMarginsPreset(margins);
@@ -110,6 +111,12 @@ namespace OfficeIMO.Excel {
 
             WorksheetRoot.Save();
             return this;
+        }
+
+        private static void ValidatePrintLayoutScale(uint? scale) {
+            if (scale is < 10U or > 400U) {
+                throw new ArgumentOutOfRangeException(nameof(ExcelPrintLayoutOptions.Scale), "Manual print scale must be between 10 and 400 percent.");
+            }
         }
 
         private static ResolvedPrintLayoutPreset ResolvePrintLayoutPreset(ExcelPrintLayoutPreset preset) {

--- a/OfficeIMO.Excel/ExcelSheet.PrintSettings.cs
+++ b/OfficeIMO.Excel/ExcelSheet.PrintSettings.cs
@@ -375,7 +375,7 @@ namespace OfficeIMO.Excel {
         }
 
         private static void AddManualPageBreak(OpenXmlCompositeElement breaks, uint id, uint max) {
-            Break? existing = breaks.Elements<Break>().FirstOrDefault(item => item.Id?.Value == id && item.ManualPageBreak?.Value == true);
+            Break? existing = breaks.Elements<Break>().FirstOrDefault(item => item.Id?.Value == id);
             if (existing == null) {
                 breaks.Append(new Break {
                     Id = id,

--- a/OfficeIMO.Excel/ExcelSheet.PrintSettings.cs
+++ b/OfficeIMO.Excel/ExcelSheet.PrintSettings.cs
@@ -162,8 +162,8 @@ namespace OfficeIMO.Excel {
         /// Adds a manual worksheet row page break after the specified one-based row.
         /// </summary>
         public void AddManualRowPageBreak(int row, bool save = true) {
-            if (row <= 0) {
-                throw new ArgumentOutOfRangeException(nameof(row), "Row page break must be one-based and positive.");
+            if (row <= 0 || row > A1.MaxRows) {
+                throw new ArgumentOutOfRangeException(nameof(row), "Row page break must be between 1 and the Excel row limit.");
             }
 
             WriteLock(() => {
@@ -179,8 +179,8 @@ namespace OfficeIMO.Excel {
         /// Adds a manual worksheet column page break after the specified one-based column.
         /// </summary>
         public void AddManualColumnPageBreak(int column, bool save = true) {
-            if (column <= 0) {
-                throw new ArgumentOutOfRangeException(nameof(column), "Column page break must be one-based and positive.");
+            if (column <= 0 || column > A1.MaxColumns) {
+                throw new ArgumentOutOfRangeException(nameof(column), "Column page break must be between 1 and the Excel column limit.");
             }
 
             WriteLock(() => {
@@ -389,8 +389,7 @@ namespace OfficeIMO.Excel {
                 existing.ManualPageBreak = true;
             }
 
-            uint count = (uint)breaks.Elements<Break>().Count();
-            UpdateManualPageBreakCounts(breaks, count);
+            UpdatePageBreakCounts(breaks);
         }
 
         private static bool RemoveManualPageBreak(OpenXmlCompositeElement? breaks, uint id) {
@@ -408,7 +407,7 @@ namespace OfficeIMO.Excel {
             if (count == 0U) {
                 breaks.Remove();
             } else {
-                UpdateManualPageBreakCounts(breaks, count);
+                UpdatePageBreakCounts(breaks);
             }
 
             return true;
@@ -419,20 +418,38 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            bool changed = breaks.Elements<Break>().Any();
-            breaks.Remove();
-            return changed;
+            var manualBreaks = breaks.Elements<Break>()
+                .Where(item => item.ManualPageBreak?.Value == true)
+                .ToList();
+            if (manualBreaks.Count == 0) {
+                return false;
+            }
+
+            foreach (Break manualBreak in manualBreaks) {
+                manualBreak.Remove();
+            }
+
+            uint count = (uint)breaks.Elements<Break>().Count();
+            if (count == 0U) {
+                breaks.Remove();
+            } else {
+                UpdatePageBreakCounts(breaks);
+            }
+
+            return true;
         }
 
-        private static void UpdateManualPageBreakCounts(OpenXmlCompositeElement breaks, uint count) {
+        private static void UpdatePageBreakCounts(OpenXmlCompositeElement breaks) {
+            uint count = (uint)breaks.Elements<Break>().Count();
+            uint manualCount = (uint)breaks.Elements<Break>().Count(item => item.ManualPageBreak?.Value == true);
             switch (breaks) {
                 case RowBreaks rowBreaks:
                     rowBreaks.Count = count;
-                    rowBreaks.ManualBreakCount = count;
+                    rowBreaks.ManualBreakCount = manualCount;
                     break;
                 case ColumnBreaks columnBreaks:
                     columnBreaks.Count = count;
-                    columnBreaks.ManualBreakCount = count;
+                    columnBreaks.ManualBreakCount = manualCount;
                     break;
             }
         }

--- a/OfficeIMO.Excel/ExcelSheet.PrintSettings.cs
+++ b/OfficeIMO.Excel/ExcelSheet.PrintSettings.cs
@@ -206,6 +206,85 @@ namespace OfficeIMO.Excel {
             return GetManualPageBreaks(WorksheetRoot.GetFirstChild<ColumnBreaks>());
         }
 
+        /// <summary>
+        /// Removes a manual worksheet row page break.
+        /// </summary>
+        public bool RemoveManualRowPageBreak(int row, bool save = true) {
+            if (row <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(row), "Row page break must be one-based and positive.");
+            }
+
+            bool changed = false;
+            WriteLock(() => {
+                changed = RemoveManualPageBreak(WorksheetRoot.GetFirstChild<RowBreaks>(), (uint)row);
+                if (changed && save) {
+                    WorksheetRoot.Save();
+                }
+            });
+            return changed;
+        }
+
+        /// <summary>
+        /// Removes a manual worksheet column page break.
+        /// </summary>
+        public bool RemoveManualColumnPageBreak(int column, bool save = true) {
+            if (column <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(column), "Column page break must be one-based and positive.");
+            }
+
+            bool changed = false;
+            WriteLock(() => {
+                changed = RemoveManualPageBreak(WorksheetRoot.GetFirstChild<ColumnBreaks>(), (uint)column);
+                if (changed && save) {
+                    WorksheetRoot.Save();
+                }
+            });
+            return changed;
+        }
+
+        /// <summary>
+        /// Clears all manual worksheet row page breaks.
+        /// </summary>
+        public bool ClearManualRowPageBreaks(bool save = true) {
+            bool changed = false;
+            WriteLock(() => {
+                changed = ClearManualPageBreaks(WorksheetRoot.GetFirstChild<RowBreaks>());
+                if (changed && save) {
+                    WorksheetRoot.Save();
+                }
+            });
+            return changed;
+        }
+
+        /// <summary>
+        /// Clears all manual worksheet column page breaks.
+        /// </summary>
+        public bool ClearManualColumnPageBreaks(bool save = true) {
+            bool changed = false;
+            WriteLock(() => {
+                changed = ClearManualPageBreaks(WorksheetRoot.GetFirstChild<ColumnBreaks>());
+                if (changed && save) {
+                    WorksheetRoot.Save();
+                }
+            });
+            return changed;
+        }
+
+        /// <summary>
+        /// Clears all manual worksheet row and column page breaks.
+        /// </summary>
+        public bool ClearManualPageBreaks(bool save = true) {
+            bool changed = false;
+            WriteLock(() => {
+                changed = ClearManualPageBreaks(WorksheetRoot.GetFirstChild<RowBreaks>());
+                changed |= ClearManualPageBreaks(WorksheetRoot.GetFirstChild<ColumnBreaks>());
+                if (changed && save) {
+                    WorksheetRoot.Save();
+                }
+            });
+            return changed;
+        }
+
         private static IEnumerable<string> SplitDefinedNameParts(string text) {
             var parts = new List<string>();
             int start = 0;
@@ -311,6 +390,41 @@ namespace OfficeIMO.Excel {
             }
 
             uint count = (uint)breaks.Elements<Break>().Count();
+            UpdateManualPageBreakCounts(breaks, count);
+        }
+
+        private static bool RemoveManualPageBreak(OpenXmlCompositeElement? breaks, uint id) {
+            if (breaks == null) {
+                return false;
+            }
+
+            Break? existing = breaks.Elements<Break>().FirstOrDefault(item => item.Id?.Value == id);
+            if (existing == null) {
+                return false;
+            }
+
+            existing.Remove();
+            uint count = (uint)breaks.Elements<Break>().Count();
+            if (count == 0U) {
+                breaks.Remove();
+            } else {
+                UpdateManualPageBreakCounts(breaks, count);
+            }
+
+            return true;
+        }
+
+        private static bool ClearManualPageBreaks(OpenXmlCompositeElement? breaks) {
+            if (breaks == null) {
+                return false;
+            }
+
+            bool changed = breaks.Elements<Break>().Any();
+            breaks.Remove();
+            return changed;
+        }
+
+        private static void UpdateManualPageBreakCounts(OpenXmlCompositeElement breaks, uint count) {
             switch (breaks) {
                 case RowBreaks rowBreaks:
                     rowBreaks.Count = count;

--- a/OfficeIMO.Excel/ExcelSheet.PrintSettings.cs
+++ b/OfficeIMO.Excel/ExcelSheet.PrintSettings.cs
@@ -210,8 +210,8 @@ namespace OfficeIMO.Excel {
         /// Removes a manual worksheet row page break.
         /// </summary>
         public bool RemoveManualRowPageBreak(int row, bool save = true) {
-            if (row <= 0) {
-                throw new ArgumentOutOfRangeException(nameof(row), "Row page break must be one-based and positive.");
+            if (row <= 0 || row > A1.MaxRows) {
+                throw new ArgumentOutOfRangeException(nameof(row), "Row page break must be between 1 and the Excel row limit.");
             }
 
             bool changed = false;
@@ -228,8 +228,8 @@ namespace OfficeIMO.Excel {
         /// Removes a manual worksheet column page break.
         /// </summary>
         public bool RemoveManualColumnPageBreak(int column, bool save = true) {
-            if (column <= 0) {
-                throw new ArgumentOutOfRangeException(nameof(column), "Column page break must be one-based and positive.");
+            if (column <= 0 || column > A1.MaxColumns) {
+                throw new ArgumentOutOfRangeException(nameof(column), "Column page break must be between 1 and the Excel column limit.");
             }
 
             bool changed = false;
@@ -375,7 +375,7 @@ namespace OfficeIMO.Excel {
         }
 
         private static void AddManualPageBreak(OpenXmlCompositeElement breaks, uint id, uint max) {
-            Break? existing = breaks.Elements<Break>().FirstOrDefault(item => item.Id?.Value == id);
+            Break? existing = breaks.Elements<Break>().FirstOrDefault(item => item.Id?.Value == id && item.ManualPageBreak?.Value == true);
             if (existing == null) {
                 breaks.Append(new Break {
                     Id = id,
@@ -397,7 +397,7 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            Break? existing = breaks.Elements<Break>().FirstOrDefault(item => item.Id?.Value == id);
+            Break? existing = breaks.Elements<Break>().FirstOrDefault(item => item.Id?.Value == id && item.ManualPageBreak?.Value == true);
             if (existing == null) {
                 return false;
             }

--- a/OfficeIMO.Excel/ExcelSheet.Protection.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Protection.cs
@@ -56,6 +56,13 @@ namespace OfficeIMO.Excel {
         }
 
         /// <summary>
+        /// Applies worksheet protection with permissions for common Excel table editing workflows.
+        /// </summary>
+        public void ProtectTableEditing(string? password = null) {
+            Protect(ExcelSheetProtectionOptions.TableEditing(password));
+        }
+
+        /// <summary>
         /// Removes worksheet protection.
         /// </summary>
         public void Unprotect() {

--- a/OfficeIMO.Excel/ExcelSheet.RowDefinitions.cs
+++ b/OfficeIMO.Excel/ExcelSheet.RowDefinitions.cs
@@ -20,7 +20,7 @@ namespace OfficeIMO.Excel {
 
                 bool hidden = row.Hidden?.Value == true;
                 bool customHeight = row.CustomHeight?.Value == true;
-                if (!hidden && !customHeight && row.Height == null) {
+                if (!hidden && !customHeight && row.Height == null && row.OutlineLevel == null && row.Collapsed?.Value != true) {
                     continue;
                 }
 
@@ -28,7 +28,9 @@ namespace OfficeIMO.Excel {
                     Index = index,
                     Height = row.Height?.Value,
                     Hidden = hidden,
-                    CustomHeight = customHeight
+                    CustomHeight = customHeight,
+                    OutlineLevel = row.OutlineLevel?.Value,
+                    Collapsed = row.Collapsed?.Value == true
                 });
             }
 

--- a/OfficeIMO.Excel/ExcelSheet.RowLayout.cs
+++ b/OfficeIMO.Excel/ExcelSheet.RowLayout.cs
@@ -8,8 +8,8 @@ namespace OfficeIMO.Excel {
         /// <param name="rowIndex">The 1-based row index to update.</param>
         /// <param name="options">The layout options to apply.</param>
         public void SetRowLayout(int rowIndex, ExcelRowLayoutOptions options) {
-            if (rowIndex <= 0) {
-                throw new ArgumentOutOfRangeException(nameof(rowIndex), "Row index must be 1 or greater.");
+            if (rowIndex <= 0 || rowIndex > A1.MaxRows) {
+                throw new ArgumentOutOfRangeException(nameof(rowIndex), "Row index must be between 1 and the Excel row limit.");
             }
 
             if (options == null) {

--- a/OfficeIMO.Excel/ExcelSheet.RowLayout.cs
+++ b/OfficeIMO.Excel/ExcelSheet.RowLayout.cs
@@ -1,0 +1,123 @@
+using System;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelSheet {
+        /// <summary>
+        /// Applies reusable row layout and row-wide cell style options to one worksheet row.
+        /// </summary>
+        /// <param name="rowIndex">The 1-based row index to update.</param>
+        /// <param name="options">The layout options to apply.</param>
+        public void SetRowLayout(int rowIndex, ExcelRowLayoutOptions options) {
+            if (rowIndex <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(rowIndex), "Row index must be 1 or greater.");
+            }
+
+            if (options == null) {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            if (options.ClearHeight) {
+                SetRowHeight(rowIndex, 0);
+            }
+
+            if (options.Height.HasValue) {
+                SetRowHeight(rowIndex, options.Height.Value);
+            }
+
+            if (options.Hidden.HasValue) {
+                SetRowHidden(rowIndex, options.Hidden.Value);
+            }
+
+            if (HasRowCellStyleOptions(options)) {
+                var (firstColumn, lastColumn) = ResolveRowLayoutColumnBounds(options);
+                ApplyRowCellStyle(rowIndex, firstColumn, lastColumn, options);
+            }
+
+            if (options.AutoFit) {
+                AutoFitRow(rowIndex);
+            }
+        }
+
+        /// <summary>
+        /// Applies the same reusable row layout and row-wide cell style options to multiple worksheet rows.
+        /// </summary>
+        /// <param name="rowIndexes">The 1-based row indexes to update.</param>
+        /// <param name="options">The layout options to apply.</param>
+        public void SetRowsLayout(IEnumerable<int> rowIndexes, ExcelRowLayoutOptions options) {
+            if (rowIndexes == null) {
+                throw new ArgumentNullException(nameof(rowIndexes));
+            }
+
+            foreach (int rowIndex in rowIndexes) {
+                SetRowLayout(rowIndex, options);
+            }
+        }
+
+        private static bool HasRowCellStyleOptions(ExcelRowLayoutOptions options) {
+            return options.Bold.HasValue
+                || options.Italic.HasValue
+                || options.Underline.HasValue
+                || options.WrapText.HasValue
+                || !string.IsNullOrWhiteSpace(options.FontName)
+                || !string.IsNullOrWhiteSpace(options.BackgroundColor);
+        }
+
+        private (int FirstColumn, int LastColumn) ResolveRowLayoutColumnBounds(ExcelRowLayoutOptions options) {
+            int firstColumn;
+            int lastColumn;
+
+            if (options.FirstColumn.HasValue || options.LastColumn.HasValue) {
+                firstColumn = options.FirstColumn ?? options.LastColumn!.Value;
+                lastColumn = options.LastColumn ?? firstColumn;
+            } else if (A1.TryParseRange(GetUsedRangeA1(), out _, out int usedFirstColumn, out _, out int usedLastColumn)) {
+                firstColumn = usedFirstColumn;
+                lastColumn = usedLastColumn;
+            } else {
+                firstColumn = 1;
+                lastColumn = 1;
+            }
+
+            if (firstColumn <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(options), "FirstColumn must be 1 or greater.");
+            }
+
+            if (lastColumn < firstColumn) {
+                throw new ArgumentException("LastColumn must be greater than or equal to FirstColumn.", nameof(options));
+            }
+
+            if (lastColumn > A1.MaxColumns) {
+                throw new ArgumentOutOfRangeException(nameof(options), "LastColumn exceeds the maximum Excel column.");
+            }
+
+            return (firstColumn, lastColumn);
+        }
+
+        private void ApplyRowCellStyle(int rowIndex, int firstColumn, int lastColumn, ExcelRowLayoutOptions options) {
+            for (int columnIndex = firstColumn; columnIndex <= lastColumn; columnIndex++) {
+                if (options.Bold.HasValue) {
+                    CellBold(rowIndex, columnIndex, options.Bold.Value);
+                }
+
+                if (options.Italic.HasValue) {
+                    CellItalic(rowIndex, columnIndex, options.Italic.Value);
+                }
+
+                if (options.Underline.HasValue) {
+                    CellUnderline(rowIndex, columnIndex, options.Underline.Value);
+                }
+
+                if (options.WrapText.HasValue) {
+                    CellWrapText(rowIndex, columnIndex, options.WrapText.Value);
+                }
+
+                if (!string.IsNullOrWhiteSpace(options.FontName)) {
+                    CellFontName(rowIndex, columnIndex, options.FontName!);
+                }
+
+                if (!string.IsNullOrWhiteSpace(options.BackgroundColor)) {
+                    CellBackground(rowIndex, columnIndex, options.BackgroundColor!);
+                }
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.RuleManagement.cs
+++ b/OfficeIMO.Excel/ExcelSheet.RuleManagement.cs
@@ -240,9 +240,10 @@ namespace OfficeIMO.Excel {
         /// Adds a time-period conditional formatting rule.
         /// </summary>
         public void AddConditionalTimePeriodRule(string range, TimePeriodValues timePeriod, bool stopIfTrue = false) {
+            string firstCell = GetFirstCellReference(range);
             AddConditionalRuleCore(range, ConditionalFormatValues.TimePeriod, rule => {
                 rule.TimePeriod = timePeriod;
-            }, Array.Empty<string>(), stopIfTrue);
+            }, new[] { BuildTimePeriodFormula(firstCell, timePeriod) }, stopIfTrue);
         }
 
         /// <summary>
@@ -365,6 +366,22 @@ namespace OfficeIMO.Excel {
 
         private static string EscapeFormulaString(string value) {
             return value.Replace("\"", "\"\"");
+        }
+
+        private static string BuildTimePeriodFormula(string firstCell, TimePeriodValues timePeriod) {
+            string day = $"FLOOR({firstCell},1)";
+            if (timePeriod == TimePeriodValues.Yesterday) return $"{day}=TODAY()-1";
+            if (timePeriod == TimePeriodValues.Today) return $"{day}=TODAY()";
+            if (timePeriod == TimePeriodValues.Tomorrow) return $"{day}=TODAY()+1";
+            if (timePeriod == TimePeriodValues.Last7Days) return $"AND(TODAY()-FLOOR({firstCell},1)<=6,FLOOR({firstCell},1)<=TODAY())";
+            if (timePeriod == TimePeriodValues.LastWeek) return $"AND({day}>=TODAY()-WEEKDAY(TODAY(),2)-6,{day}<=TODAY()-WEEKDAY(TODAY(),2))";
+            if (timePeriod == TimePeriodValues.ThisWeek) return $"AND({day}>=TODAY()-WEEKDAY(TODAY(),2)+1,{day}<=TODAY()-WEEKDAY(TODAY(),2)+7)";
+            if (timePeriod == TimePeriodValues.NextWeek) return $"AND({day}>=TODAY()-WEEKDAY(TODAY(),2)+8,{day}<=TODAY()-WEEKDAY(TODAY(),2)+14)";
+            if (timePeriod == TimePeriodValues.LastMonth) return $"AND({day}>=DATE(YEAR(TODAY()),MONTH(TODAY())-1,1),{day}<DATE(YEAR(TODAY()),MONTH(TODAY()),1))";
+            if (timePeriod == TimePeriodValues.ThisMonth) return $"AND({day}>=DATE(YEAR(TODAY()),MONTH(TODAY()),1),{day}<DATE(YEAR(TODAY()),MONTH(TODAY())+1,1))";
+            if (timePeriod == TimePeriodValues.NextMonth) return $"AND({day}>=DATE(YEAR(TODAY()),MONTH(TODAY())+1,1),{day}<DATE(YEAR(TODAY()),MONTH(TODAY())+2,1))";
+
+            return $"{day}=TODAY()";
         }
 
         private void ClearConditionalFormattingCore(string? a1Range) {

--- a/OfficeIMO.Excel/ExcelSheet.RuleManagement.cs
+++ b/OfficeIMO.Excel/ExcelSheet.RuleManagement.cs
@@ -154,6 +154,13 @@ namespace OfficeIMO.Excel {
         }
 
         /// <summary>
+        /// Adds a unique-values conditional formatting rule.
+        /// </summary>
+        public void AddConditionalUniqueValuesRule(string range) {
+            AddConditionalRuleCore(range, ConditionalFormatValues.UniqueValues, null, Array.Empty<string>(), stopIfTrue: false);
+        }
+
+        /// <summary>
         /// Adds a top/bottom conditional formatting rule.
         /// </summary>
         public void AddConditionalTopBottomRule(string range, uint rank, bool bottom = false, bool percent = false) {
@@ -163,6 +170,79 @@ namespace OfficeIMO.Excel {
                 rule.Bottom = bottom;
                 rule.Percent = percent;
             }, Array.Empty<string>(), stopIfTrue: false);
+        }
+
+        /// <summary>
+        /// Adds an above/below-average conditional formatting rule.
+        /// </summary>
+        public void AddConditionalAboveAverageRule(string range, bool aboveAverage = true, bool equalAverage = false, uint? standardDeviation = null, bool stopIfTrue = false) {
+            AddConditionalRuleCore(range, ConditionalFormatValues.AboveAverage, rule => {
+                rule.AboveAverage = aboveAverage;
+                rule.EqualAverage = equalAverage;
+                if (standardDeviation.HasValue) {
+                    rule.StdDev = checked((int)standardDeviation.Value);
+                }
+            }, Array.Empty<string>(), stopIfTrue);
+        }
+
+        /// <summary>
+        /// Adds a text-matching conditional formatting rule.
+        /// </summary>
+        public void AddConditionalTextRule(string range, ConditionalFormatValues type, string text, bool stopIfTrue = false) {
+            if (string.IsNullOrEmpty(text)) throw new ArgumentNullException(nameof(text));
+            string firstCell = GetFirstCellReference(range);
+            string literal = EscapeFormulaString(text);
+            string formula;
+            ConditionalFormattingOperatorValues op;
+            if (type == ConditionalFormatValues.ContainsText) {
+                formula = $"NOT(ISERROR(SEARCH(\"{literal}\",{firstCell})))";
+                op = ConditionalFormattingOperatorValues.ContainsText;
+            } else if (type == ConditionalFormatValues.NotContainsText) {
+                formula = $"ISERROR(SEARCH(\"{literal}\",{firstCell}))";
+                op = ConditionalFormattingOperatorValues.NotContains;
+            } else if (type == ConditionalFormatValues.BeginsWith) {
+                formula = $"LEFT({firstCell},LEN(\"{literal}\"))=\"{literal}\"";
+                op = ConditionalFormattingOperatorValues.BeginsWith;
+            } else if (type == ConditionalFormatValues.EndsWith) {
+                formula = $"RIGHT({firstCell},LEN(\"{literal}\"))=\"{literal}\"";
+                op = ConditionalFormattingOperatorValues.EndsWith;
+            } else {
+                throw new ArgumentOutOfRangeException(nameof(type), "Text conditional formatting requires ContainsText, NotContainsText, BeginsWith, or EndsWith.");
+            }
+
+            AddConditionalRuleCore(range, type, rule => {
+                rule.Text = text;
+                rule.Operator = op;
+            }, new[] { formula }, stopIfTrue);
+        }
+
+        /// <summary>
+        /// Adds a blanks/non-blanks conditional formatting rule.
+        /// </summary>
+        public void AddConditionalBlanksRule(string range, bool containsBlanks = true, bool stopIfTrue = false) {
+            string firstCell = GetFirstCellReference(range);
+            ConditionalFormatValues type = containsBlanks ? ConditionalFormatValues.ContainsBlanks : ConditionalFormatValues.NotContainsBlanks;
+            string formula = containsBlanks ? $"LEN(TRIM({firstCell}))=0" : $"LEN(TRIM({firstCell}))>0";
+            AddConditionalRuleCore(range, type, null, new[] { formula }, stopIfTrue);
+        }
+
+        /// <summary>
+        /// Adds an errors/non-errors conditional formatting rule.
+        /// </summary>
+        public void AddConditionalErrorsRule(string range, bool containsErrors = true, bool stopIfTrue = false) {
+            string firstCell = GetFirstCellReference(range);
+            ConditionalFormatValues type = containsErrors ? ConditionalFormatValues.ContainsErrors : ConditionalFormatValues.NotContainsErrors;
+            string formula = containsErrors ? $"ISERROR({firstCell})" : $"NOT(ISERROR({firstCell}))";
+            AddConditionalRuleCore(range, type, null, new[] { formula }, stopIfTrue);
+        }
+
+        /// <summary>
+        /// Adds a time-period conditional formatting rule.
+        /// </summary>
+        public void AddConditionalTimePeriodRule(string range, TimePeriodValues timePeriod, bool stopIfTrue = false) {
+            AddConditionalRuleCore(range, ConditionalFormatValues.TimePeriod, rule => {
+                rule.TimePeriod = timePeriod;
+            }, Array.Empty<string>(), stopIfTrue);
         }
 
         /// <summary>
@@ -265,6 +345,26 @@ namespace OfficeIMO.Excel {
                 conditional.Append(rule);
                 InsertConditionalFormatting(conditional);
             });
+        }
+
+        private static string GetFirstCellReference(string range) {
+            if (string.IsNullOrWhiteSpace(range)) throw new ArgumentNullException(nameof(range));
+            string firstReference = range.Split(new[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries)[0];
+            int sheetSeparatorIndex = firstReference.LastIndexOf('!');
+            if (sheetSeparatorIndex >= 0 && sheetSeparatorIndex < firstReference.Length - 1) {
+                firstReference = firstReference.Substring(sheetSeparatorIndex + 1);
+            }
+
+            int rangeSeparatorIndex = firstReference.IndexOf(':');
+            if (rangeSeparatorIndex >= 0) {
+                firstReference = firstReference.Substring(0, rangeSeparatorIndex);
+            }
+
+            return firstReference.Replace("$", string.Empty);
+        }
+
+        private static string EscapeFormulaString(string value) {
+            return value.Replace("\"", "\"\"");
         }
 
         private void ClearConditionalFormattingCore(string? a1Range) {

--- a/OfficeIMO.Excel/ExcelSheet.Subtotals.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Subtotals.cs
@@ -1,0 +1,168 @@
+using System.Globalization;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelSheet {
+        /// <summary>
+        /// Creates a grouped subtotal summary block from a contiguous worksheet data range.
+        /// </summary>
+        /// <param name="options">Subtotal generation options.</param>
+        /// <returns>Information about the generated summary block.</returns>
+        public ExcelSubtotalResult AddSubtotalSummary(ExcelSubtotalOptions options) {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            ValidateSubtotalOptions(options);
+
+            _excelDocument.MaterializeDeferredDataSetImport();
+
+            var groups = GetContiguousSubtotalGroups(options).ToArray();
+            if (groups.Length == 0) {
+                throw new InvalidOperationException("No data rows were available for subtotal summary generation.");
+            }
+
+            int summaryStartRow = options.SummaryStartRow ?? checked(options.DataEndRow + 2);
+            int currentRow = summaryStartRow;
+            int firstSummaryColumn = Math.Min(options.GroupColumn, options.ValueColumns.Min());
+            int lastSummaryColumn = Math.Max(options.GroupColumn, options.ValueColumns.Max());
+            int subtotalCode = GetSubtotalFunctionCode(options.Function);
+            var results = new List<ExcelSubtotalGroupResult>(groups.Length);
+
+            if (options.IncludeHeader) {
+                WriteSubtotalHeaderRow(options, currentRow);
+                currentRow++;
+            }
+
+            foreach (var group in groups) {
+                WriteSubtotalGroupRow(options, currentRow, group, subtotalCode);
+                if (options.OutlineDetailRows) {
+                    GroupRows(group.StartRow, group.EndRow, options.OutlineLevel, collapsed: false, hidden: options.HideDetailRows);
+                }
+
+                results.Add(new ExcelSubtotalGroupResult(group.Key, group.StartRow, group.EndRow, currentRow));
+                currentRow++;
+            }
+
+            bool grandTotalWritten = false;
+            if (options.IncludeGrandTotal) {
+                WriteSubtotalGrandTotalRow(options, currentRow, subtotalCode);
+                grandTotalWritten = true;
+                currentRow++;
+            }
+
+            int summaryEndRow = currentRow - 1;
+            string summaryRange = $"{A1.CellReference(summaryStartRow, firstSummaryColumn)}:{A1.CellReference(summaryEndRow, lastSummaryColumn)}";
+            return new ExcelSubtotalResult(summaryRange, summaryStartRow, summaryEndRow, results, grandTotalWritten);
+        }
+
+        private void WriteSubtotalHeaderRow(ExcelSubtotalOptions options, int row) {
+            string groupHeader = TryGetCellText(options.HeaderRow, options.GroupColumn, out string headerText) && !string.IsNullOrWhiteSpace(headerText)
+                ? headerText
+                : "Group";
+            CellValue(row, options.GroupColumn, groupHeader);
+            CellBold(row, options.GroupColumn, true);
+
+            foreach (int column in options.ValueColumns) {
+                string valueHeader = TryGetCellText(options.HeaderRow, column, out string valueText) && !string.IsNullOrWhiteSpace(valueText)
+                    ? valueText
+                    : A1.ColumnIndexToLetters(column);
+                CellValue(row, column, valueHeader);
+                CellBold(row, column, true);
+            }
+        }
+
+        private void WriteSubtotalGroupRow(ExcelSubtotalOptions options, int row, SubtotalGroup group, int subtotalCode) {
+            string label = string.Concat(group.Key, options.LabelSuffix ?? string.Empty);
+            CellValue(row, options.GroupColumn, label);
+            CellBold(row, options.GroupColumn, true);
+
+            foreach (int column in options.ValueColumns) {
+                string columnName = A1.ColumnIndexToLetters(column);
+                CellFormula(row, column, string.Format(CultureInfo.InvariantCulture, "SUBTOTAL({0},{1}{2}:{1}{3})", subtotalCode, columnName, group.StartRow, group.EndRow));
+                CellBold(row, column, true);
+            }
+        }
+
+        private void WriteSubtotalGrandTotalRow(ExcelSubtotalOptions options, int row, int subtotalCode) {
+            CellValue(row, options.GroupColumn, options.GrandTotalLabel);
+            CellBold(row, options.GroupColumn, true);
+
+            foreach (int column in options.ValueColumns) {
+                string columnName = A1.ColumnIndexToLetters(column);
+                CellFormula(row, column, string.Format(CultureInfo.InvariantCulture, "SUBTOTAL({0},{1}{2}:{1}{3})", subtotalCode, columnName, options.DataStartRow, options.DataEndRow));
+                CellBold(row, column, true);
+            }
+        }
+
+        private IEnumerable<SubtotalGroup> GetContiguousSubtotalGroups(ExcelSubtotalOptions options) {
+            string? currentKey = null;
+            int currentStart = 0;
+
+            for (int row = options.DataStartRow; row <= options.DataEndRow; row++) {
+                string key = GetSubtotalGroupKey(options, row);
+                if (currentKey == null) {
+                    currentKey = key;
+                    currentStart = row;
+                    continue;
+                }
+
+                if (string.Equals(currentKey, key, StringComparison.Ordinal)) {
+                    continue;
+                }
+
+                yield return new SubtotalGroup(currentKey, currentStart, row - 1);
+                currentKey = key;
+                currentStart = row;
+            }
+
+            if (currentKey != null) {
+                yield return new SubtotalGroup(currentKey, currentStart, options.DataEndRow);
+            }
+        }
+
+        private string GetSubtotalGroupKey(ExcelSubtotalOptions options, int row) {
+            if (TryGetCellText(row, options.GroupColumn, out string text) && !string.IsNullOrWhiteSpace(text)) {
+                return text;
+            }
+
+            var value = GetCellValueSnapshot(row, options.GroupColumn).Value;
+            string? converted = Convert.ToString(value, CultureInfo.InvariantCulture);
+            return string.IsNullOrWhiteSpace(converted) ? options.BlankGroupLabel : converted!;
+        }
+
+        private static void ValidateSubtotalOptions(ExcelSubtotalOptions options) {
+            if (options.HeaderRow <= 0) throw new ArgumentOutOfRangeException(nameof(options.HeaderRow), "Header row must be 1 or greater.");
+            if (options.DataStartRow <= 0) throw new ArgumentOutOfRangeException(nameof(options.DataStartRow), "Data start row must be 1 or greater.");
+            if (options.DataEndRow < options.DataStartRow) throw new ArgumentOutOfRangeException(nameof(options.DataEndRow), "Data end row must be greater than or equal to the data start row.");
+            if (options.GroupColumn <= 0) throw new ArgumentOutOfRangeException(nameof(options.GroupColumn), "Group column must be 1 or greater.");
+            if (options.ValueColumns == null || options.ValueColumns.Count == 0) throw new ArgumentException("At least one value column is required.", nameof(options.ValueColumns));
+            if (options.ValueColumns.Any(column => column <= 0)) throw new ArgumentOutOfRangeException(nameof(options.ValueColumns), "Value columns must be 1 or greater.");
+            if (options.OutlineLevel < 1 || options.OutlineLevel > 7) throw new ArgumentOutOfRangeException(nameof(options.OutlineLevel), "Excel outline level must be between 1 and 7.");
+            int summaryStartRow = options.SummaryStartRow ?? checked(options.DataEndRow + 2);
+            if (summaryStartRow <= options.DataEndRow) throw new ArgumentOutOfRangeException(nameof(options.SummaryStartRow), "Summary start row must be below the source data range.");
+        }
+
+        private static int GetSubtotalFunctionCode(ExcelSubtotalFunction function) {
+            return function switch {
+                ExcelSubtotalFunction.Average => 1,
+                ExcelSubtotalFunction.Count => 2,
+                ExcelSubtotalFunction.CountNonBlank => 3,
+                ExcelSubtotalFunction.Max => 4,
+                ExcelSubtotalFunction.Min => 5,
+                ExcelSubtotalFunction.Sum => 9,
+                _ => throw new ArgumentOutOfRangeException(nameof(function), function, null)
+            };
+        }
+
+        private readonly struct SubtotalGroup {
+            internal SubtotalGroup(string key, int startRow, int endRow) {
+                Key = key;
+                StartRow = startRow;
+                EndRow = endRow;
+            }
+
+            internal string Key { get; }
+
+            internal int StartRow { get; }
+
+            internal int EndRow { get; }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.Subtotals.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Subtotals.cs
@@ -17,6 +17,7 @@ namespace OfficeIMO.Excel {
             if (groups.Length == 0) {
                 throw new InvalidOperationException("No data rows were available for subtotal summary generation.");
             }
+            ValidateSubtotalOutputBounds(options, groups.Length);
 
             int summaryStartRow = options.SummaryStartRow ?? checked(options.DataEndRow + 2);
             int currentRow = summaryStartRow;
@@ -132,11 +133,26 @@ namespace OfficeIMO.Excel {
             if (options.DataStartRow <= 0) throw new ArgumentOutOfRangeException(nameof(options.DataStartRow), "Data start row must be 1 or greater.");
             if (options.DataEndRow < options.DataStartRow) throw new ArgumentOutOfRangeException(nameof(options.DataEndRow), "Data end row must be greater than or equal to the data start row.");
             if (options.GroupColumn <= 0) throw new ArgumentOutOfRangeException(nameof(options.GroupColumn), "Group column must be 1 or greater.");
+            if (options.HeaderRow > A1.MaxRows || options.DataStartRow > A1.MaxRows || options.DataEndRow > A1.MaxRows) throw new ArgumentOutOfRangeException(nameof(options.DataEndRow), "Subtotal source rows must not exceed the Excel row limit.");
+            if (options.GroupColumn > A1.MaxColumns) throw new ArgumentOutOfRangeException(nameof(options.GroupColumn), "Group column must not exceed the Excel column limit.");
             if (options.ValueColumns == null || options.ValueColumns.Count == 0) throw new ArgumentException("At least one value column is required.", nameof(options.ValueColumns));
             if (options.ValueColumns.Any(column => column <= 0)) throw new ArgumentOutOfRangeException(nameof(options.ValueColumns), "Value columns must be 1 or greater.");
+            if (options.ValueColumns.Any(column => column > A1.MaxColumns)) throw new ArgumentOutOfRangeException(nameof(options.ValueColumns), "Value columns must not exceed the Excel column limit.");
             if (options.OutlineLevel < 1 || options.OutlineLevel > 7) throw new ArgumentOutOfRangeException(nameof(options.OutlineLevel), "Excel outline level must be between 1 and 7.");
             int summaryStartRow = options.SummaryStartRow ?? checked(options.DataEndRow + 2);
             if (summaryStartRow <= options.DataEndRow) throw new ArgumentOutOfRangeException(nameof(options.SummaryStartRow), "Summary start row must be below the source data range.");
+            if (summaryStartRow > A1.MaxRows) throw new ArgumentOutOfRangeException(nameof(options.SummaryStartRow), "Summary start row must not exceed the Excel row limit.");
+        }
+
+        private static void ValidateSubtotalOutputBounds(ExcelSubtotalOptions options, int groupCount) {
+            int summaryStartRow = options.SummaryStartRow ?? checked(options.DataEndRow + 2);
+            int rowCount = groupCount
+                + (options.IncludeHeader ? 1 : 0)
+                + (options.IncludeGrandTotal ? 1 : 0);
+            int summaryEndRow = checked(summaryStartRow + rowCount - 1);
+            if (summaryEndRow > A1.MaxRows) {
+                throw new ArgumentOutOfRangeException(nameof(options.SummaryStartRow), "Subtotal summary output must not exceed the Excel row limit.");
+            }
         }
 
         private static int GetSubtotalFunctionCode(ExcelSubtotalFunction function) {

--- a/OfficeIMO.Excel/ExcelSheet.TabColor.cs
+++ b/OfficeIMO.Excel/ExcelSheet.TabColor.cs
@@ -1,0 +1,50 @@
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Drawing;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelSheet {
+        /// <summary>
+        /// Sets the worksheet tab color shown by spreadsheet applications.
+        /// </summary>
+        /// <param name="color">Named color, RGB hex, or RGBA hex value.</param>
+        public void SetTabColor(string color) {
+            if (string.IsNullOrWhiteSpace(color)) {
+                throw new ArgumentException("Tab color is required.", nameof(color));
+            }
+
+            OfficeColor parsed = OfficeColor.Parse(color);
+            _excelDocument.MaterializeDeferredDataSetImport();
+            WriteLock(() => {
+                SheetProperties sheetProperties = WorksheetRoot.GetFirstChild<SheetProperties>() ?? new SheetProperties();
+                if (sheetProperties.Parent == null) {
+                    WorksheetRoot.InsertAt(sheetProperties, 0);
+                }
+
+                sheetProperties.TabColor = new TabColor {
+                    Rgb = parsed.ToArgbHex()
+                };
+                WorksheetRoot.Save();
+            });
+        }
+
+        /// <summary>
+        /// Clears the worksheet tab color.
+        /// </summary>
+        public void ClearTabColor() {
+            _excelDocument.MaterializeDeferredDataSetImport();
+            WriteLock(() => {
+                SheetProperties? sheetProperties = WorksheetRoot.GetFirstChild<SheetProperties>();
+                if (sheetProperties == null) {
+                    return;
+                }
+
+                sheetProperties.TabColor = null;
+                if (!sheetProperties.HasChildren && !sheetProperties.HasAttributes) {
+                    sheetProperties.Remove();
+                }
+
+                WorksheetRoot.Save();
+            });
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.Tables.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Tables.cs
@@ -76,8 +76,21 @@ namespace OfficeIMO.Excel {
             if (string.IsNullOrWhiteSpace(tableOrRange)) throw new System.ArgumentNullException(nameof(tableOrRange));
 
             WriteLock(() => {
+                bool updatedDirectMetadata = _excelDocument.TrySetDirectTableStyleMetadata(
+                    this,
+                    tableOrRange,
+                    style,
+                    showFirstColumn,
+                    showLastColumn,
+                    showRowStripes,
+                    showColumnStripes);
+
                 var table = FindTableByRangeNameOrDisplayName(tableOrRange);
                 if (table == null) {
+                    if (updatedDirectMetadata) {
+                        return;
+                    }
+
                     throw new InvalidOperationException($"Table '{tableOrRange}' was not found on worksheet '{Name}'.");
                 }
 

--- a/OfficeIMO.Excel/ExcelSheet.Template.Rows.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Template.Rows.cs
@@ -47,6 +47,9 @@ namespace OfficeIMO.Excel {
         private int ApplyTemplateRowsCore(int templateRow, IReadOnlyList<IReadOnlyDictionary<string, object?>> rowBindings, ExcelTemplateOptions options) {
             if (templateRow <= 0) throw new ArgumentOutOfRangeException(nameof(templateRow));
             if (rowBindings.Count == 0) return 0;
+            if ((long)templateRow + rowBindings.Count - 1L > A1.MaxRows) {
+                throw new ArgumentOutOfRangeException(nameof(rowBindings), "Template row expansion must fit inside Excel's worksheet row limit.");
+            }
 
             int replacements = 0;
             WriteLockConditional(() => {
@@ -78,6 +81,7 @@ namespace OfficeIMO.Excel {
         private int ApplyTemplateOptionalRowsCore(int firstRow, int rowCount, bool include, IReadOnlyDictionary<string, object?>? bindings, ExcelTemplateOptions options) {
             if (firstRow <= 0) throw new ArgumentOutOfRangeException(nameof(firstRow));
             if (rowCount <= 0) throw new ArgumentOutOfRangeException(nameof(rowCount));
+            if ((long)firstRow + rowCount - 1L > A1.MaxRows) throw new ArgumentOutOfRangeException(nameof(rowCount), "Template optional row block must fit inside Excel's worksheet row limit.");
 
             int replacements = 0;
             WriteLockConditional(() => {
@@ -220,6 +224,15 @@ namespace OfficeIMO.Excel {
             var sheetData = WorksheetRoot.GetFirstChild<SheetData>();
             if (sheetData == null) {
                 return;
+            }
+
+            uint maxShiftedRow = sheetData.Elements<Row>()
+                .Where(item => item.RowIndex?.Value >= (uint)firstRow)
+                .Select(item => item.RowIndex?.Value ?? 0U)
+                .DefaultIfEmpty(0U)
+                .Max();
+            if (maxShiftedRow > 0U && (long)maxShiftedRow + count > A1.MaxRows) {
+                throw new InvalidOperationException("Template row expansion would move worksheet rows beyond Excel's row limit.");
             }
 
             foreach (var row in sheetData.Elements<Row>()

--- a/OfficeIMO.Excel/ExcelSheet.ThreadedComments.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ThreadedComments.cs
@@ -1,0 +1,175 @@
+using DocumentFormat.OpenXml.Packaging;
+using Threaded = DocumentFormat.OpenXml.Office2019.Excel.ThreadedComments;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Options used when authoring a threaded comment.
+    /// </summary>
+    public sealed class ExcelThreadedCommentOptions {
+        /// <summary>Cell address in A1 notation.</summary>
+        public string Address { get; set; } = "A1";
+
+        /// <summary>Comment text.</summary>
+        public string Text { get; set; } = string.Empty;
+
+        /// <summary>Display author stored in workbook person metadata.</summary>
+        public string Author { get; set; } = "OfficeIMO";
+
+        /// <summary>Optional parent threaded-comment id when adding a reply.</summary>
+        public string? ParentId { get; set; }
+
+        /// <summary>Optional stable comment id. A new GUID is generated when omitted.</summary>
+        public string? Id { get; set; }
+
+        /// <summary>Optional timestamp. UTC now is used when omitted.</summary>
+        public DateTime? Date { get; set; }
+
+        /// <summary>Marks the threaded comment as resolved/done.</summary>
+        public bool Done { get; set; }
+    }
+
+    /// <summary>
+    /// Result returned after authoring a threaded comment.
+    /// </summary>
+    public sealed class ExcelThreadedCommentResult {
+        internal ExcelThreadedCommentResult(string sheetName, string cellReference, string id, string personId, string author, bool isReply, bool done) {
+            SheetName = sheetName;
+            CellReference = cellReference;
+            Id = id;
+            PersonId = personId;
+            Author = author;
+            IsReply = isReply;
+            Done = done;
+        }
+
+        /// <summary>Worksheet name.</summary>
+        public string SheetName { get; }
+
+        /// <summary>Cell address in A1 notation.</summary>
+        public string CellReference { get; }
+
+        /// <summary>Threaded comment id.</summary>
+        public string Id { get; }
+
+        /// <summary>Workbook person id used by the threaded comment.</summary>
+        public string PersonId { get; }
+
+        /// <summary>Resolved author display name.</summary>
+        public string Author { get; }
+
+        /// <summary>True when the comment references a parent threaded comment.</summary>
+        public bool IsReply { get; }
+
+        /// <summary>True when the comment is marked resolved/done.</summary>
+        public bool Done { get; }
+    }
+
+    public partial class ExcelSheet {
+        /// <summary>
+        /// Adds a threaded comment or threaded reply to the worksheet while maintaining workbook person metadata.
+        /// </summary>
+        /// <param name="options">Threaded comment options.</param>
+        public ExcelThreadedCommentResult AddThreadedComment(ExcelThreadedCommentOptions options) {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            if (string.IsNullOrWhiteSpace(options.Address)) throw new ArgumentException("Threaded comment address is required.", nameof(options));
+            if (string.IsNullOrWhiteSpace(options.Text)) throw new ArgumentException("Threaded comment text is required.", nameof(options));
+
+            var (row, column) = A1.ParseCellRef(options.Address);
+            if (row <= 0 || column <= 0) {
+                throw new ArgumentException($"Address '{options.Address}' is not a valid A1 reference.", nameof(options));
+            }
+
+            string cellReference = A1.CellReference(row, column);
+            string author = string.IsNullOrWhiteSpace(options.Author) ? "OfficeIMO" : options.Author.Trim();
+            string id = NormalizeThreadedId(options.Id);
+            string? parentId = string.IsNullOrWhiteSpace(options.ParentId) ? null : options.ParentId!.Trim();
+            DateTime timestamp = options.Date ?? DateTime.UtcNow;
+            string personId = string.Empty;
+
+            WriteLock(() => {
+                personId = EnsureWorkbookPerson(author);
+                WorksheetThreadedCommentsPart commentsPart = GetOrCreateThreadedCommentsPart();
+                commentsPart.ThreadedComments ??= new Threaded.ThreadedComments();
+                RemoveThreadedCommentById(commentsPart.ThreadedComments, id);
+
+                var comment = new Threaded.ThreadedComment {
+                    Ref = cellReference,
+                    PersonId = personId,
+                    Id = id,
+                    DT = timestamp
+                };
+                if (parentId != null) {
+                    comment.ParentId = parentId;
+                }
+                if (options.Done) {
+                    comment.Done = true;
+                }
+
+                comment.Append(new Threaded.ThreadedCommentText(options.Text));
+                commentsPart.ThreadedComments.Append(comment);
+                commentsPart.ThreadedComments.Save();
+            });
+
+            return new ExcelThreadedCommentResult(Name, cellReference, id, personId, author, parentId != null, options.Done);
+        }
+
+        /// <summary>
+        /// Adds a threaded comment or threaded reply to the worksheet.
+        /// </summary>
+        public ExcelThreadedCommentResult AddThreadedComment(string address, string text, string author = "OfficeIMO", string? parentId = null, bool done = false) {
+            return AddThreadedComment(new ExcelThreadedCommentOptions {
+                Address = address,
+                Text = text,
+                Author = author,
+                ParentId = parentId,
+                Done = done
+            });
+        }
+
+        private WorksheetThreadedCommentsPart GetOrCreateThreadedCommentsPart() {
+            return _worksheetPart.WorksheetThreadedCommentsParts.FirstOrDefault()
+                ?? _worksheetPart.AddNewPart<WorksheetThreadedCommentsPart>();
+        }
+
+        private string EnsureWorkbookPerson(string author) {
+            WorkbookPart workbookPart = _spreadSheetDocument.WorkbookPart ?? throw new InvalidOperationException("Workbook part is missing.");
+            foreach (WorkbookPersonPart part in workbookPart.WorkbookPersonParts) {
+                if (part.PersonList == null) {
+                    continue;
+                }
+
+                foreach (Threaded.Person person in part.PersonList.Elements<Threaded.Person>()) {
+                    if (string.Equals(person.DisplayName?.Value, author, StringComparison.OrdinalIgnoreCase)
+                        && !string.IsNullOrWhiteSpace(person.Id?.Value)) {
+                        return person.Id!.Value!;
+                    }
+                }
+            }
+
+            WorkbookPersonPart personPart = workbookPart.WorkbookPersonParts.FirstOrDefault()
+                ?? workbookPart.AddNewPart<WorkbookPersonPart>();
+            personPart.PersonList ??= new Threaded.PersonList();
+            string personId = BracedGuid();
+            personPart.PersonList.Append(new Threaded.Person {
+                Id = personId,
+                DisplayName = author
+            });
+            personPart.PersonList.Save();
+            return personId;
+        }
+
+        private static string NormalizeThreadedId(string? id) {
+            return string.IsNullOrWhiteSpace(id) ? BracedGuid() : id!.Trim();
+        }
+
+        private static string BracedGuid() {
+            return "{" + Guid.NewGuid().ToString().ToUpperInvariant() + "}";
+        }
+
+        private static void RemoveThreadedCommentById(Threaded.ThreadedComments comments, string id) {
+            Threaded.ThreadedComment? existing = comments.Elements<Threaded.ThreadedComment>()
+                .FirstOrDefault(comment => string.Equals(comment.Id?.Value, id, StringComparison.OrdinalIgnoreCase));
+            existing?.Remove();
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.ThreadedComments.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ThreadedComments.cs
@@ -75,7 +75,7 @@ namespace OfficeIMO.Excel {
             if (string.IsNullOrWhiteSpace(options.Text)) throw new ArgumentException("Threaded comment text is required.", nameof(options));
 
             var (row, column) = A1.ParseCellRef(options.Address);
-            if (row <= 0 || column <= 0) {
+            if (row <= 0 || column <= 0 || row > A1.MaxRows || column > A1.MaxColumns) {
                 throw new ArgumentException($"Address '{options.Address}' is not a valid A1 reference.", nameof(options));
             }
 

--- a/OfficeIMO.Excel/ExcelSheet.ViewInfo.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ViewInfo.cs
@@ -1,0 +1,42 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelSheet {
+        /// <summary>
+        /// Reads worksheet view metadata such as frozen panes, gridline visibility, zoom, and direction.
+        /// </summary>
+        public ExcelWorksheetViewInfo GetViewInfo() {
+            SheetView? sheetView = WorksheetRoot
+                .GetFirstChild<SheetViews>()?
+                .Elements<SheetView>()
+                .FirstOrDefault();
+            Pane? pane = sheetView?.GetFirstChild<Pane>();
+            bool frozen = pane != null && IsFrozenPaneState(pane.State?.Value);
+
+            return new ExcelWorksheetViewInfo {
+                HasPane = pane != null,
+                PaneState = pane?.State?.InnerText,
+                HorizontalSplit = pane?.HorizontalSplit?.Value,
+                VerticalSplit = pane?.VerticalSplit?.Value,
+                FrozenRowCount = frozen ? ConvertFrozenSplitToInt(pane?.VerticalSplit) : 0,
+                FrozenColumnCount = frozen ? ConvertFrozenSplitToInt(pane?.HorizontalSplit) : 0,
+                TopLeftCell = pane?.TopLeftCell?.Value,
+                ActivePane = pane?.ActivePane?.InnerText,
+                ShowGridlines = sheetView?.ShowGridLines?.Value ?? true,
+                RightToLeft = sheetView?.RightToLeft?.Value ?? false,
+                View = sheetView?.View?.InnerText,
+                ZoomScale = sheetView?.ZoomScale?.Value,
+                ZoomScaleNormal = sheetView?.ZoomScaleNormal?.Value
+            };
+        }
+
+        private static int ConvertFrozenSplitToInt(DoubleValue? split) {
+            if (split == null) {
+                return 0;
+            }
+
+            return checked((int)Math.Round(split.Value, MidpointRounding.AwayFromZero));
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.ViewOptions.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ViewOptions.cs
@@ -1,0 +1,101 @@
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelSheet {
+        /// <summary>
+        /// Applies worksheet view options such as gridlines, direction, zoom, and view mode.
+        /// </summary>
+        /// <param name="options">Options to apply. Null properties leave the existing worksheet setting unchanged.</param>
+        public void SetViewOptions(ExcelWorksheetViewOptions options) {
+            if (options == null) {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            ValidateZoom(options.ZoomScale, nameof(options.ZoomScale));
+            ValidateZoom(options.ZoomScaleNormal, nameof(options.ZoomScaleNormal));
+
+            _excelDocument.MaterializeDeferredDataSetImport();
+            WriteLock(() => {
+                SheetView sheetView = GetOrCreatePrimarySheetViewForViewOptions();
+
+                if (options.ShowGridlines.HasValue) {
+                    sheetView.ShowGridLines = options.ShowGridlines.Value;
+                }
+
+                if (options.RightToLeft.HasValue) {
+                    sheetView.RightToLeft = options.RightToLeft.Value;
+                }
+
+                if (options.ZoomScale.HasValue) {
+                    sheetView.ZoomScale = options.ZoomScale.Value;
+                }
+
+                if (options.ZoomScaleNormal.HasValue) {
+                    sheetView.ZoomScaleNormal = options.ZoomScaleNormal.Value;
+                }
+
+                if (options.View.HasValue) {
+                    sheetView.View = ToOpenXmlSheetView(options.View.Value);
+                }
+
+                WorksheetRoot.Save();
+            });
+        }
+
+        /// <summary>
+        /// Applies worksheet view options such as gridlines, direction, zoom, and view mode.
+        /// </summary>
+        public void SetViewOptions(bool? showGridlines = null, bool? rightToLeft = null, uint? zoomScale = null, uint? zoomScaleNormal = null, ExcelWorksheetViewKind? view = null) {
+            SetViewOptions(new ExcelWorksheetViewOptions {
+                ShowGridlines = showGridlines,
+                RightToLeft = rightToLeft,
+                ZoomScale = zoomScale,
+                ZoomScaleNormal = zoomScaleNormal,
+                View = view,
+            });
+        }
+
+        private SheetView GetOrCreatePrimarySheetViewForViewOptions() {
+            var worksheet = WorksheetRoot;
+            SheetViews? sheetViews = worksheet.GetFirstChild<SheetViews>();
+            if (sheetViews == null) {
+                sheetViews = new SheetViews();
+                var sheetData = worksheet.GetFirstChild<SheetData>();
+                if (sheetData != null) {
+                    worksheet.InsertBefore(sheetViews, sheetData);
+                } else {
+                    worksheet.Append(sheetViews);
+                }
+            }
+
+            SheetView? sheetView = sheetViews.GetFirstChild<SheetView>();
+            if (sheetView == null) {
+                sheetView = new SheetView { WorkbookViewId = 0U };
+                sheetViews.Append(sheetView);
+            } else if (sheetView.WorkbookViewId == null) {
+                sheetView.WorkbookViewId = 0U;
+            }
+
+            return sheetView;
+        }
+
+        private static SheetViewValues ToOpenXmlSheetView(ExcelWorksheetViewKind view) {
+            return view switch {
+                ExcelWorksheetViewKind.Normal => SheetViewValues.Normal,
+                ExcelWorksheetViewKind.PageBreakPreview => SheetViewValues.PageBreakPreview,
+                ExcelWorksheetViewKind.PageLayout => SheetViewValues.PageLayout,
+                _ => throw new ArgumentOutOfRangeException(nameof(view), view, "Unsupported worksheet view kind."),
+            };
+        }
+
+        private static void ValidateZoom(uint? zoom, string parameterName) {
+            if (!zoom.HasValue) {
+                return;
+            }
+
+            if (zoom.Value < 10U || zoom.Value > 400U) {
+                throw new ArgumentOutOfRangeException(parameterName, zoom.Value, "Worksheet zoom must be between 10 and 400.");
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.ViewOptions.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ViewOptions.cs
@@ -39,6 +39,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 WorksheetRoot.Save();
+                _excelDocument.MarkPackageDirty();
             });
         }
 

--- a/OfficeIMO.Excel/ExcelSheet.ViewSetup.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ViewSetup.cs
@@ -143,7 +143,8 @@ namespace OfficeIMO.Excel {
         /// <param name="fitToWidth">Number of pages to fit horizontally (1 = fit to one page).</param>
         /// <param name="fitToHeight">Number of pages to fit vertically (0 = unlimited).</param>
         /// <param name="scale">Manual scale (10-400). Ignored if FitToWidth/Height are specified.</param>
-        public void SetPageSetup(uint? fitToWidth = null, uint? fitToHeight = null, uint? scale = null) {
+        /// <param name="pageOrder">Optional multi-page print order.</param>
+        public void SetPageSetup(uint? fitToWidth = null, uint? fitToHeight = null, uint? scale = null, ExcelPageOrder? pageOrder = null) {
             WriteLock(() => {
                 var ws = WorksheetRoot;
                 var pageSetup = ws.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.PageSetup>();
@@ -157,6 +158,27 @@ namespace OfficeIMO.Excel {
                 if (fitToWidth != null) pageSetup.FitToWidth = fitToWidth.Value;
                 if (fitToHeight != null) pageSetup.FitToHeight = fitToHeight.Value;
                 if (scale != null) pageSetup.Scale = scale.Value;
+                if (pageOrder != null) {
+                    pageSetup.PageOrder = pageOrder == ExcelPageOrder.OverThenDown
+                        ? DocumentFormat.OpenXml.Spreadsheet.PageOrderValues.OverThenDown
+                        : DocumentFormat.OpenXml.Spreadsheet.PageOrderValues.DownThenOver;
+                }
+
+                if (fitToWidth != null || fitToHeight != null) {
+                    var sheetProperties = ws.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.SheetProperties>();
+                    if (sheetProperties == null) {
+                        sheetProperties = new DocumentFormat.OpenXml.Spreadsheet.SheetProperties();
+                        ws.InsertAt(sheetProperties, 0);
+                    }
+
+                    var pageSetupProperties = sheetProperties.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.PageSetupProperties>();
+                    if (pageSetupProperties == null) {
+                        pageSetupProperties = new DocumentFormat.OpenXml.Spreadsheet.PageSetupProperties();
+                        sheetProperties.Append(pageSetupProperties);
+                    }
+
+                    pageSetupProperties.FitToPage = true;
+                }
 
                 ws.Save();
             });

--- a/OfficeIMO.Excel/ExcelSheet.ViewSetup.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ViewSetup.cs
@@ -183,5 +183,62 @@ namespace OfficeIMO.Excel {
                 ws.Save();
             });
         }
+
+        internal void SetPageSetupAndClearStaleFit(uint? fitToWidth = null, uint? fitToHeight = null, uint? scale = null, ExcelPageOrder? pageOrder = null) {
+            WriteLock(() => {
+                var ws = WorksheetRoot;
+                var pageSetup = ws.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.PageSetup>();
+                if (pageSetup == null) {
+                    pageSetup = new DocumentFormat.OpenXml.Spreadsheet.PageSetup();
+                    var margins = ws.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.PageMargins>();
+                    if (margins != null) ws.InsertAfter(pageSetup, margins); else ws.Append(pageSetup);
+                }
+
+                if (fitToWidth != null) pageSetup.FitToWidth = fitToWidth.Value;
+                else {
+                    pageSetup.FitToWidth = null;
+                    pageSetup.RemoveAttribute("fitToWidth", string.Empty);
+                }
+
+                if (fitToHeight != null) pageSetup.FitToHeight = fitToHeight.Value;
+                else {
+                    pageSetup.FitToHeight = null;
+                    pageSetup.RemoveAttribute("fitToHeight", string.Empty);
+                }
+
+                if (scale != null) pageSetup.Scale = scale.Value;
+                else {
+                    pageSetup.Scale = null;
+                    pageSetup.RemoveAttribute("scale", string.Empty);
+                }
+
+                if (pageOrder != null) {
+                    pageSetup.PageOrder = pageOrder == ExcelPageOrder.OverThenDown
+                        ? DocumentFormat.OpenXml.Spreadsheet.PageOrderValues.OverThenDown
+                        : DocumentFormat.OpenXml.Spreadsheet.PageOrderValues.DownThenOver;
+                }
+
+                var sheetProperties = ws.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.SheetProperties>();
+                var pageSetupProperties = sheetProperties?.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.PageSetupProperties>();
+                if (fitToWidth != null || fitToHeight != null) {
+                    if (sheetProperties == null) {
+                        sheetProperties = new DocumentFormat.OpenXml.Spreadsheet.SheetProperties();
+                        ws.InsertAt(sheetProperties, 0);
+                    }
+
+                    if (pageSetupProperties == null) {
+                        pageSetupProperties = new DocumentFormat.OpenXml.Spreadsheet.PageSetupProperties();
+                        sheetProperties.Append(pageSetupProperties);
+                    }
+
+                    pageSetupProperties.FitToPage = true;
+                } else if (pageSetupProperties != null) {
+                    pageSetupProperties.FitToPage = null;
+                    pageSetupProperties.RemoveAttribute("fitToPage", string.Empty);
+                }
+
+                ws.Save();
+            });
+        }
     }
 }

--- a/OfficeIMO.Excel/ExcelSheet.ViewSetup.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ViewSetup.cs
@@ -145,6 +145,10 @@ namespace OfficeIMO.Excel {
         /// <param name="scale">Manual scale (10-400). Ignored if FitToWidth/Height are specified.</param>
         /// <param name="pageOrder">Optional multi-page print order.</param>
         public void SetPageSetup(uint? fitToWidth = null, uint? fitToHeight = null, uint? scale = null, ExcelPageOrder? pageOrder = null) {
+            if (scale is < 10U or > 400U) {
+                throw new ArgumentOutOfRangeException(nameof(scale), "Manual print scale must be between 10 and 400 percent.");
+            }
+
             WriteLock(() => {
                 var ws = WorksheetRoot;
                 var pageSetup = ws.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.PageSetup>();
@@ -185,6 +189,10 @@ namespace OfficeIMO.Excel {
         }
 
         internal void SetPageSetupAndClearStaleFit(uint? fitToWidth = null, uint? fitToHeight = null, uint? scale = null, ExcelPageOrder? pageOrder = null) {
+            if (scale is < 10U or > 400U) {
+                throw new ArgumentOutOfRangeException(nameof(scale), "Manual print scale must be between 10 and 400 percent.");
+            }
+
             WriteLock(() => {
                 var ws = WorksheetRoot;
                 var pageSetup = ws.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.PageSetup>();

--- a/OfficeIMO.Excel/ExcelSheetProtectionOptions.cs
+++ b/OfficeIMO.Excel/ExcelSheetProtectionOptions.cs
@@ -3,6 +3,20 @@ namespace OfficeIMO.Excel {
     /// Options controlling worksheet protection behavior.
     /// </summary>
     public sealed class ExcelSheetProtectionOptions {
+        /// <summary>
+        /// Creates protection options that keep the sheet protected while allowing common table editing workflows.
+        /// </summary>
+        public static ExcelSheetProtectionOptions TableEditing(string? password = null) {
+            return new ExcelSheetProtectionOptions {
+                AllowSelectLockedCells = true,
+                AllowSelectUnlockedCells = true,
+                AllowInsertRows = true,
+                AllowSort = true,
+                AllowAutoFilter = true,
+                Password = password
+            };
+        }
+
         /// <summary>Allow selecting locked cells.</summary>
         public bool AllowSelectLockedCells { get; set; } = true;
         /// <summary>Allow selecting unlocked cells.</summary>

--- a/OfficeIMO.Excel/ExcelSlicerTimelineOptions.cs
+++ b/OfficeIMO.Excel/ExcelSlicerTimelineOptions.cs
@@ -1,0 +1,71 @@
+using System.Security;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Options for authoring workbook-level slicer cache metadata.
+    /// </summary>
+    public sealed class ExcelSlicerCacheOptions {
+        /// <summary>Slicer cache name.</summary>
+        public string Name { get; set; } = "SlicerCache";
+
+        /// <summary>Source field, table column, or pivot field name.</summary>
+        public string? SourceName { get; set; }
+
+        /// <summary>Optional pivot table name the slicer is intended to filter.</summary>
+        public string? PivotTableName { get; set; }
+
+        /// <summary>Optional caller-supplied XML. When set, OfficeIMO writes it as-is.</summary>
+        public string? Xml { get; set; }
+
+        internal string ToXml() {
+            if (!string.IsNullOrWhiteSpace(Xml)) {
+                return Xml!;
+            }
+
+            return "<slicerCacheDefinition xmlns=\"http://schemas.microsoft.com/office/spreadsheetml/2009/9/main\"" +
+                $" name=\"{Escape(Name)}\"" +
+                OptionalAttribute("sourceName", SourceName) +
+                OptionalAttribute("pivotTableName", PivotTableName) +
+                "/>";
+        }
+
+        private static string OptionalAttribute(string name, string? value)
+            => string.IsNullOrWhiteSpace(value) ? string.Empty : $" {name}=\"{Escape(value!)}\"";
+
+        private static string Escape(string value) => SecurityElement.Escape(value) ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Options for authoring workbook-level timeline cache metadata.
+    /// </summary>
+    public sealed class ExcelTimelineCacheOptions {
+        /// <summary>Timeline cache name.</summary>
+        public string Name { get; set; } = "TimelineCache";
+
+        /// <summary>Source date field, table column, or pivot field name.</summary>
+        public string? SourceName { get; set; }
+
+        /// <summary>Optional pivot table name the timeline is intended to filter.</summary>
+        public string? PivotTableName { get; set; }
+
+        /// <summary>Optional caller-supplied XML. When set, OfficeIMO writes it as-is.</summary>
+        public string? Xml { get; set; }
+
+        internal string ToXml() {
+            if (!string.IsNullOrWhiteSpace(Xml)) {
+                return Xml!;
+            }
+
+            return "<timelineCacheDefinition xmlns=\"http://schemas.microsoft.com/office/spreadsheetml/2011/1/main\"" +
+                $" name=\"{Escape(Name)}\"" +
+                OptionalAttribute("sourceName", SourceName) +
+                OptionalAttribute("pivotTableName", PivotTableName) +
+                "/>";
+        }
+
+        private static string OptionalAttribute(string name, string? value)
+            => string.IsNullOrWhiteSpace(value) ? string.Empty : $" {name}=\"{Escape(value!)}\"";
+
+        private static string Escape(string value) => SecurityElement.Escape(value) ?? string.Empty;
+    }
+}

--- a/OfficeIMO.Excel/ExcelSubtotalFunction.cs
+++ b/OfficeIMO.Excel/ExcelSubtotalFunction.cs
@@ -1,0 +1,19 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Aggregation function used by worksheet subtotal summary rows.
+    /// </summary>
+    public enum ExcelSubtotalFunction {
+        /// <summary>Average visible numeric values.</summary>
+        Average,
+        /// <summary>Count visible numeric values.</summary>
+        Count,
+        /// <summary>Count visible non-blank values.</summary>
+        CountNonBlank,
+        /// <summary>Maximum visible numeric value.</summary>
+        Max,
+        /// <summary>Minimum visible numeric value.</summary>
+        Min,
+        /// <summary>Sum visible numeric values.</summary>
+        Sum
+    }
+}

--- a/OfficeIMO.Excel/ExcelSubtotalOptions.cs
+++ b/OfficeIMO.Excel/ExcelSubtotalOptions.cs
@@ -1,0 +1,51 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Options for creating a reusable subtotal summary block from worksheet rows.
+    /// </summary>
+    public sealed class ExcelSubtotalOptions {
+        /// <summary>Header row that contains source labels.</summary>
+        public int HeaderRow { get; set; } = 1;
+
+        /// <summary>First source data row.</summary>
+        public int DataStartRow { get; set; } = 2;
+
+        /// <summary>Last source data row.</summary>
+        public int DataEndRow { get; set; }
+
+        /// <summary>Column containing group keys.</summary>
+        public int GroupColumn { get; set; }
+
+        /// <summary>Columns to aggregate into subtotal formulas.</summary>
+        public IReadOnlyList<int> ValueColumns { get; set; } = Array.Empty<int>();
+
+        /// <summary>First row for the generated summary block. Defaults to two rows below <see cref="DataEndRow"/>.</summary>
+        public int? SummaryStartRow { get; set; }
+
+        /// <summary>Function used by generated SUBTOTAL formulas.</summary>
+        public ExcelSubtotalFunction Function { get; set; } = ExcelSubtotalFunction.Sum;
+
+        /// <summary>Whether to write a header row for the summary block.</summary>
+        public bool IncludeHeader { get; set; } = true;
+
+        /// <summary>Whether to add a grand total row after group subtotal rows.</summary>
+        public bool IncludeGrandTotal { get; set; } = true;
+
+        /// <summary>Whether to apply Excel row outline metadata to detail groups.</summary>
+        public bool OutlineDetailRows { get; set; } = true;
+
+        /// <summary>Hide detail rows when applying outline metadata.</summary>
+        public bool HideDetailRows { get; set; }
+
+        /// <summary>Outline level used for grouped detail rows.</summary>
+        public byte OutlineLevel { get; set; } = 1;
+
+        /// <summary>Text appended to each group key in the subtotal label cell.</summary>
+        public string LabelSuffix { get; set; } = " Total";
+
+        /// <summary>Label used when the group key cell is blank.</summary>
+        public string BlankGroupLabel { get; set; } = "(blank)";
+
+        /// <summary>Label used for the optional grand total row.</summary>
+        public string GrandTotalLabel { get; set; } = "Grand Total";
+    }
+}

--- a/OfficeIMO.Excel/ExcelSubtotalResult.cs
+++ b/OfficeIMO.Excel/ExcelSubtotalResult.cs
@@ -1,0 +1,61 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Describes a generated subtotal summary block.
+    /// </summary>
+    public sealed class ExcelSubtotalResult {
+        internal ExcelSubtotalResult(
+            string summaryRange,
+            int summaryStartRow,
+            int summaryEndRow,
+            IReadOnlyList<ExcelSubtotalGroupResult> groups,
+            bool grandTotalWritten) {
+            SummaryRange = summaryRange;
+            SummaryStartRow = summaryStartRow;
+            SummaryEndRow = summaryEndRow;
+            Groups = groups;
+            GrandTotalWritten = grandTotalWritten;
+        }
+
+        /// <summary>A1 range occupied by the generated summary block.</summary>
+        public string SummaryRange { get; }
+
+        /// <summary>First row occupied by the generated summary block.</summary>
+        public int SummaryStartRow { get; }
+
+        /// <summary>Last row occupied by the generated summary block.</summary>
+        public int SummaryEndRow { get; }
+
+        /// <summary>Generated subtotal groups.</summary>
+        public IReadOnlyList<ExcelSubtotalGroupResult> Groups { get; }
+
+        /// <summary>Number of generated subtotal groups.</summary>
+        public int GroupCount => Groups.Count;
+
+        /// <summary>Whether a grand total row was written.</summary>
+        public bool GrandTotalWritten { get; }
+    }
+
+    /// <summary>
+    /// Describes a single generated subtotal group.
+    /// </summary>
+    public sealed class ExcelSubtotalGroupResult {
+        internal ExcelSubtotalGroupResult(string key, int sourceStartRow, int sourceEndRow, int summaryRow) {
+            Key = key;
+            SourceStartRow = sourceStartRow;
+            SourceEndRow = sourceEndRow;
+            SummaryRow = summaryRow;
+        }
+
+        /// <summary>Group key read from the worksheet.</summary>
+        public string Key { get; }
+
+        /// <summary>First source data row included in the group.</summary>
+        public int SourceStartRow { get; }
+
+        /// <summary>Last source data row included in the group.</summary>
+        public int SourceEndRow { get; }
+
+        /// <summary>Generated summary row for the group.</summary>
+        public int SummaryRow { get; }
+    }
+}

--- a/OfficeIMO.Excel/ExcelWorkbookIntelligence.Advanced.cs
+++ b/OfficeIMO.Excel/ExcelWorkbookIntelligence.Advanced.cs
@@ -413,9 +413,6 @@ namespace OfficeIMO.Excel {
                 AddWorksheetQueryTableMetadata(options.WorksheetName!, BuildQueryTableMetadataXml(queryTableName, connectionId));
                 addedQueryTable = true;
             }
-            if (options.RefreshOnOpen) {
-                SetRefreshOnOpen(enabled: true, pivotTables: false, connections: true);
-            }
 
             return new ExcelPowerQueryMetadataResult(name, connectionId, queryTableName, addedWorkbookConnection: true, addedQueryTable, options.RefreshOnOpen);
         }

--- a/OfficeIMO.Excel/ExcelWorkbookIntelligence.Advanced.cs
+++ b/OfficeIMO.Excel/ExcelWorkbookIntelligence.Advanced.cs
@@ -376,10 +376,10 @@ namespace OfficeIMO.Excel {
             var threaded = CreateInspectionSnapshot().Worksheets.SelectMany(sheet => sheet.ThreadedComments).ToList();
             foreach (ExcelThreadedCommentSnapshot comment in threaded) {
                 if (string.IsNullOrWhiteSpace(comment.Author)) {
-                    issues.Add(new ExcelWorkbookDiagnosticIssue("ThreadedComment", ExcelFindingSeverity.Warning, "Threaded comment has no resolved author.", address: comment.CellReference));
+                    issues.Add(new ExcelWorkbookDiagnosticIssue("ThreadedComment", ExcelFindingSeverity.Warning, "Threaded comment has no resolved author.", comment.SheetName, comment.CellReference));
                 }
                 if (!string.IsNullOrWhiteSpace(comment.ParentId) && threaded.All(parent => !string.Equals(parent.Id, comment.ParentId, StringComparison.OrdinalIgnoreCase))) {
-                    issues.Add(new ExcelWorkbookDiagnosticIssue("ThreadedComment", ExcelFindingSeverity.Warning, "Threaded comment reply references a missing parent.", address: comment.CellReference));
+                    issues.Add(new ExcelWorkbookDiagnosticIssue("ThreadedComment", ExcelFindingSeverity.Warning, "Threaded comment reply references a missing parent.", comment.SheetName, comment.CellReference));
                 }
             }
 

--- a/OfficeIMO.Excel/ExcelWorkbookIntelligence.Advanced.cs
+++ b/OfficeIMO.Excel/ExcelWorkbookIntelligence.Advanced.cs
@@ -301,8 +301,11 @@ namespace OfficeIMO.Excel {
                 actions.Add(new ExcelWorkbookRepairAction("Workbook", "Normalized workbook views, styles, and shared strings."));
             }
 
-            if (options.Save && CanSaveToDefaultDestination()) {
-                Save(false);
+            if (actions.Count > 0) {
+                MarkPackageDirty();
+                if (options.Save && CanSaveToDefaultDestination()) {
+                    Save(false);
+                }
             }
 
             ExcelWorkbookDiagnosticReport after = RunWorkbookDoctor(new ExcelWorkbookDoctorOptions { ValidateOpenXml = false });

--- a/OfficeIMO.Excel/ExcelWorkbookIntelligence.Advanced.cs
+++ b/OfficeIMO.Excel/ExcelWorkbookIntelligence.Advanced.cs
@@ -301,7 +301,7 @@ namespace OfficeIMO.Excel {
                 actions.Add(new ExcelWorkbookRepairAction("Workbook", "Normalized workbook views, styles, and shared strings."));
             }
 
-            if (options.Save) {
+            if (options.Save && CanSaveToDefaultDestination()) {
                 Save(false);
             }
 
@@ -318,6 +318,9 @@ namespace OfficeIMO.Excel {
             int maxDifferences = Math.Max(1, options.MaxDifferences);
             var differences = new List<ExcelWorkbookDifference>();
             var otherSheets = other.Sheets.ToDictionary(sheet => sheet.Name, StringComparer.OrdinalIgnoreCase);
+            bool compareSnapshots = options.CompareTables || options.CompareWorksheetMetadata || options.CompareComments;
+            ExcelWorkbookSnapshot? leftSnapshot = compareSnapshots ? CreateInspectionSnapshot() : null;
+            ExcelWorkbookSnapshot? rightSnapshot = compareSnapshots ? other.CreateInspectionSnapshot() : null;
 
             foreach (ExcelSheet sheet in Sheets) {
                 if (!otherSheets.TryGetValue(sheet.Name, out ExcelSheet? otherSheet)) {
@@ -331,8 +334,8 @@ namespace OfficeIMO.Excel {
                 if (options.CompareCellStyles) {
                     CompareCellStyles(sheet, otherSheet, differences, maxDifferences);
                 }
-                if (options.CompareTables || options.CompareWorksheetMetadata || options.CompareComments) {
-                    CompareSheetSnapshots(CreateInspectionSnapshot(), other.CreateInspectionSnapshot(), sheet.Name, differences, maxDifferences, options);
+                if (compareSnapshots) {
+                    CompareSheetSnapshots(leftSnapshot!, rightSnapshot!, sheet.Name, differences, maxDifferences, options);
                 }
                 if (differences.Count >= maxDifferences) break;
             }
@@ -348,6 +351,9 @@ namespace OfficeIMO.Excel {
 
             return new ExcelWorkbookDiffReport(differences);
         }
+
+        private bool CanSaveToDefaultDestination()
+            => !string.IsNullOrEmpty(FilePath) || _sourceStream != null;
 
         /// <summary>
         /// Audits legacy notes and threaded comments across the workbook.
@@ -404,13 +410,18 @@ namespace OfficeIMO.Excel {
             if (options == null) throw new ArgumentNullException(nameof(options));
             string name = string.IsNullOrWhiteSpace(options.Name) ? "OfficeIMOQuery" : options.Name.Trim();
             string commandText = options.CommandText ?? string.Empty;
+            string? worksheetName = null;
+            if (!string.IsNullOrWhiteSpace(options.WorksheetName)) {
+                worksheetName = this[options.WorksheetName!].Name;
+            }
+
             uint connectionId = GetNextPowerQueryConnectionId();
             AddWorkbookConnectionMetadata(BuildConnectionMetadataXml(name, options.Description, commandText, options.RefreshOnOpen, connectionId));
             bool addedQueryTable = false;
             string? queryTableName = null;
-            if (!string.IsNullOrWhiteSpace(options.WorksheetName)) {
+            if (worksheetName != null) {
                 queryTableName = NormalizeQueryTableName(options.QueryTableName, name);
-                AddWorksheetQueryTableMetadata(options.WorksheetName!, BuildQueryTableMetadataXml(queryTableName, connectionId));
+                AddWorksheetQueryTableMetadata(worksheetName, BuildQueryTableMetadataXml(queryTableName, connectionId));
                 addedQueryTable = true;
             }
 

--- a/OfficeIMO.Excel/ExcelWorkbookIntelligence.Advanced.cs
+++ b/OfficeIMO.Excel/ExcelWorkbookIntelligence.Advanced.cs
@@ -1,0 +1,544 @@
+using System.Globalization;
+using System.Text;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Options that control safe workbook repair orchestration.
+    /// </summary>
+    public sealed class ExcelWorkbookRepairOptions {
+        /// <summary>Repair duplicate, invalid, and broken workbook defined names.</summary>
+        public bool DefinedNames { get; set; } = true;
+
+        /// <summary>Normalize worksheet table metadata, table relationships, and table column definitions.</summary>
+        public bool Tables { get; set; } = true;
+
+        /// <summary>Normalize worksheet view metadata such as frozen panes and selections.</summary>
+        public bool SheetViews { get; set; } = true;
+
+        /// <summary>Normalize print metadata such as page breaks, margins, and page scale.</summary>
+        public bool PrintSettings { get; set; } = true;
+
+        /// <summary>Normalize worksheet protection metadata and protected range declarations.</summary>
+        public bool Protection { get; set; } = true;
+
+        /// <summary>Normalize AutoFilter metadata when the worksheet exposes a stale or invalid filter range.</summary>
+        public bool AutoFilters { get; set; } = true;
+
+        /// <summary>Normalize drawing relationships and worksheet drawing anchors.</summary>
+        public bool Drawings { get; set; } = true;
+
+        /// <summary>Normalize hyperlinks and comment artifacts.</summary>
+        public bool LinksAndComments { get; set; } = true;
+
+        /// <summary>Remove stale calculation chains and force recalculation on open when formulas exist.</summary>
+        public bool Calculation { get; set; } = true;
+
+        /// <summary>Normalize workbook views, style, and shared-string artifacts.</summary>
+        public bool WorkbookArtifacts { get; set; } = true;
+
+        /// <summary>Save the workbook after repairs are applied.</summary>
+        public bool Save { get; set; } = true;
+    }
+
+    /// <summary>
+    /// One safe repair action applied to a workbook.
+    /// </summary>
+    public sealed class ExcelWorkbookRepairAction {
+        internal ExcelWorkbookRepairAction(string category, string message, string? sheetName = null) {
+            Category = category;
+            Message = message;
+            SheetName = sheetName;
+        }
+
+        /// <summary>Repair category such as DefinedName, Table, View, or Drawing.</summary>
+        public string Category { get; }
+
+        /// <summary>Human-readable repair action summary.</summary>
+        public string Message { get; }
+
+        /// <summary>Worksheet name when the repair was worksheet scoped.</summary>
+        public string? SheetName { get; }
+    }
+
+    /// <summary>
+    /// Report returned after safe workbook repair orchestration.
+    /// </summary>
+    public sealed class ExcelWorkbookRepairReport {
+        internal ExcelWorkbookRepairReport(IReadOnlyList<ExcelWorkbookRepairAction> actions, ExcelWorkbookDiagnosticReport before, ExcelWorkbookDiagnosticReport after) {
+            Actions = actions;
+            Before = before;
+            After = after;
+        }
+
+        /// <summary>Actions attempted by the repair pass.</summary>
+        public IReadOnlyList<ExcelWorkbookRepairAction> Actions { get; }
+
+        /// <summary>Diagnostic report captured before repairs.</summary>
+        public ExcelWorkbookDiagnosticReport Before { get; }
+
+        /// <summary>Diagnostic report captured after repairs.</summary>
+        public ExcelWorkbookDiagnosticReport After { get; }
+
+        /// <summary>Number of repair actions attempted.</summary>
+        public int ActionCount => Actions.Count;
+    }
+
+    /// <summary>
+    /// Options for workbook comparison depth.
+    /// </summary>
+    public sealed class ExcelWorkbookDiffOptions {
+        /// <summary>Maximum differences to report.</summary>
+        public int MaxDifferences { get; set; } = 200;
+
+        /// <summary>Compare visible cell values and formulas.</summary>
+        public bool CompareCells { get; set; } = true;
+
+        /// <summary>Compare cell style indexes in used cells.</summary>
+        public bool CompareCellStyles { get; set; } = true;
+
+        /// <summary>Compare workbook and sheet-scoped defined names.</summary>
+        public bool CompareNamedRanges { get; set; } = true;
+
+        /// <summary>Compare table names, ranges, and header-row state.</summary>
+        public bool CompareTables { get; set; } = true;
+
+        /// <summary>Compare worksheet validations and AutoFilter/view state.</summary>
+        public bool CompareWorksheetMetadata { get; set; } = true;
+
+        /// <summary>Compare legacy and threaded comments.</summary>
+        public bool CompareComments { get; set; } = true;
+    }
+
+    /// <summary>
+    /// Comment and threaded-comment awareness report.
+    /// </summary>
+    public sealed class ExcelWorkbookCommentReport {
+        internal ExcelWorkbookCommentReport(IReadOnlyList<ExcelCommentRecord> comments, IReadOnlyList<ExcelThreadedCommentSnapshot> threadedComments, IReadOnlyList<ExcelWorkbookDiagnosticIssue> issues) {
+            Comments = comments;
+            ThreadedComments = threadedComments;
+            Issues = issues;
+        }
+
+        /// <summary>Legacy worksheet notes across the workbook.</summary>
+        public IReadOnlyList<ExcelCommentRecord> Comments { get; }
+
+        /// <summary>Threaded comments preserved in the workbook package.</summary>
+        public IReadOnlyList<ExcelThreadedCommentSnapshot> ThreadedComments { get; }
+
+        /// <summary>Comment metadata issues, such as missing authors or empty comment text.</summary>
+        public IReadOnlyList<ExcelWorkbookDiagnosticIssue> Issues { get; }
+
+        /// <summary>Legacy comment count.</summary>
+        public int CommentCount => Comments.Count;
+
+        /// <summary>Threaded comment count.</summary>
+        public int ThreadedCommentCount => ThreadedComments.Count;
+
+        /// <summary>True when any comment or threaded comment exists.</summary>
+        public bool HasComments => CommentCount > 0 || ThreadedCommentCount > 0;
+    }
+
+    /// <summary>
+    /// Legacy worksheet note projected with workbook-level sheet context.
+    /// </summary>
+    public sealed class ExcelCommentRecord {
+        internal ExcelCommentRecord(string sheetName, string cellReference, string? author, string text) {
+            SheetName = sheetName;
+            CellReference = cellReference;
+            Author = author;
+            Text = text;
+        }
+
+        /// <summary>Worksheet name.</summary>
+        public string SheetName { get; }
+
+        /// <summary>A1 cell reference.</summary>
+        public string CellReference { get; }
+
+        /// <summary>Comment author display name, when available.</summary>
+        public string? Author { get; }
+
+        /// <summary>Comment text.</summary>
+        public string Text { get; }
+    }
+
+    /// <summary>
+    /// Template binding diagnostics for a workbook or sheet template.
+    /// </summary>
+    public sealed class ExcelTemplateBindingReport {
+        internal ExcelTemplateBindingReport(ExcelTemplateInspection inspection) {
+            Inspection = inspection;
+        }
+
+        /// <summary>Underlying marker inspection.</summary>
+        public ExcelTemplateInspection Inspection { get; }
+
+        /// <summary>Total marker occurrences.</summary>
+        public int TotalMarkers => Inspection.TotalMarkers;
+
+        /// <summary>Distinct missing marker names.</summary>
+        public IReadOnlyList<string> MissingMarkerNames => Inspection.MissingMarkerNames;
+
+        /// <summary>True when the supplied bindings satisfy all markers.</summary>
+        public bool Passed => Inspection.HasBindingInfo && Inspection.MissingMarkerNames.Count == 0;
+
+        /// <summary>Markdown table describing all discovered markers and binding state.</summary>
+        public string Markdown => Inspection.ToMarkdown();
+    }
+
+    /// <summary>
+    /// Safe metadata options for workbook connection and query-table package parts.
+    /// </summary>
+    public sealed class ExcelPowerQueryMetadataOptions {
+        /// <summary>Connection name shown by Excel-compatible applications.</summary>
+        public string Name { get; set; } = "OfficeIMOQuery";
+
+        /// <summary>Optional worksheet name that should own query-table metadata.</summary>
+        public string? WorksheetName { get; set; }
+
+        /// <summary>Optional query-table name. Defaults to the connection name with "Table" suffix.</summary>
+        public string? QueryTableName { get; set; }
+
+        /// <summary>Connection description stored in package metadata.</summary>
+        public string? Description { get; set; }
+
+        /// <summary>Power Query M expression stored as metadata for Excel to own and execute.</summary>
+        public string? CommandText { get; set; }
+
+        /// <summary>Request refresh-on-open metadata on the authored connection.</summary>
+        public bool RefreshOnOpen { get; set; }
+    }
+
+    /// <summary>
+    /// Result from authoring safe workbook query metadata.
+    /// </summary>
+    public sealed class ExcelPowerQueryMetadataResult {
+        internal ExcelPowerQueryMetadataResult(string connectionName, uint connectionId, string? queryTableName, bool addedWorkbookConnection, bool addedWorksheetQueryTable, bool refreshOnOpen) {
+            ConnectionName = connectionName;
+            ConnectionId = connectionId;
+            QueryTableName = queryTableName;
+            AddedWorkbookConnection = addedWorkbookConnection;
+            AddedWorksheetQueryTable = addedWorksheetQueryTable;
+            RefreshOnOpen = refreshOnOpen;
+        }
+
+        /// <summary>Connection name stored in metadata.</summary>
+        public string ConnectionName { get; }
+
+        /// <summary>Workbook connection id used by authored query-table metadata.</summary>
+        public uint ConnectionId { get; }
+
+        /// <summary>Query-table name stored in worksheet metadata, when requested.</summary>
+        public string? QueryTableName { get; }
+
+        /// <summary>True when workbook connection metadata was authored.</summary>
+        public bool AddedWorkbookConnection { get; }
+
+        /// <summary>True when worksheet query-table metadata was authored.</summary>
+        public bool AddedWorksheetQueryTable { get; }
+
+        /// <summary>True when refresh-on-open metadata was requested.</summary>
+        public bool RefreshOnOpen { get; }
+    }
+
+    public partial class ExcelDocument {
+        /// <summary>
+        /// Runs safe workbook repairs using OfficeIMO's existing cleanup engines, then returns before/after diagnostics.
+        /// </summary>
+        public ExcelWorkbookRepairReport RepairWorkbook(ExcelWorkbookRepairOptions? options = null) {
+            options ??= new ExcelWorkbookRepairOptions();
+            ExcelWorkbookDiagnosticReport before = RunWorkbookDoctor(new ExcelWorkbookDoctorOptions { ValidateOpenXml = false });
+            var actions = new List<ExcelWorkbookRepairAction>();
+
+            if (options.DefinedNames) {
+                RepairDefinedNames(save: false);
+                CleanupDefinedNameArtifacts(includeAggressiveRepairs: true, save: false);
+                actions.Add(new ExcelWorkbookRepairAction("DefinedName", "Normalized duplicate, hidden, and broken defined-name artifacts."));
+            }
+
+            foreach (ExcelSheet sheet in Sheets) {
+                if (options.Tables) {
+                    sheet.CleanupTableArtifacts();
+                    actions.Add(new ExcelWorkbookRepairAction("Table", "Normalized table relationships, identifiers, names, and columns.", sheet.Name));
+                }
+                if (options.SheetViews) {
+                    sheet.CleanupSheetViewArtifacts();
+                    actions.Add(new ExcelWorkbookRepairAction("View", "Normalized worksheet view, pane, and selection metadata.", sheet.Name));
+                }
+                if (options.PrintSettings) {
+                    sheet.CleanupPrintArtifacts();
+                    actions.Add(new ExcelWorkbookRepairAction("Print", "Normalized print settings, page breaks, margins, and scale.", sheet.Name));
+                }
+                if (options.Protection) {
+                    sheet.CleanupProtectionArtifacts();
+                    actions.Add(new ExcelWorkbookRepairAction("Protection", "Normalized worksheet protection and protected ranges.", sheet.Name));
+                }
+                if (options.AutoFilters) {
+                    sheet.CleanupAutoFilterArtifacts();
+                    actions.Add(new ExcelWorkbookRepairAction("AutoFilter", "Normalized worksheet AutoFilter artifacts.", sheet.Name));
+                }
+                if (options.Drawings) {
+                    sheet.CleanupWorksheetDrawingArtifacts();
+                    sheet.CleanupHeaderFooterPictureArtifacts();
+                    actions.Add(new ExcelWorkbookRepairAction("Drawing", "Normalized drawing, image, and header/footer picture artifacts.", sheet.Name));
+                }
+                if (options.LinksAndComments) {
+                    sheet.CleanupHyperlinkArtifacts();
+                    actions.Add(new ExcelWorkbookRepairAction("Link", "Normalized hyperlink artifacts.", sheet.Name));
+                }
+            }
+
+            if (options.Calculation) {
+                CleanupCalculationArtifacts(save: false);
+                actions.Add(new ExcelWorkbookRepairAction("Calculation", "Removed stale calculation chains and requested recalculation on open."));
+            }
+            if (options.WorkbookArtifacts) {
+                CleanupWorkbookViewArtifacts(save: false);
+                CleanupStyleAndSharedStringArtifacts(save: false);
+                actions.Add(new ExcelWorkbookRepairAction("Workbook", "Normalized workbook views, styles, and shared strings."));
+            }
+
+            if (options.Save) {
+                Save(false);
+            }
+
+            ExcelWorkbookDiagnosticReport after = RunWorkbookDoctor(new ExcelWorkbookDoctorOptions { ValidateOpenXml = false });
+            return new ExcelWorkbookRepairReport(actions, before, after);
+        }
+
+        /// <summary>
+        /// Compares this workbook with another workbook using configurable structural, value, style, table, comment, and metadata checks.
+        /// </summary>
+        public ExcelWorkbookDiffReport CompareWorkbook(ExcelDocument other, ExcelWorkbookDiffOptions options) {
+            if (other == null) throw new ArgumentNullException(nameof(other));
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            int maxDifferences = Math.Max(1, options.MaxDifferences);
+            var differences = new List<ExcelWorkbookDifference>();
+            var otherSheets = other.Sheets.ToDictionary(sheet => sheet.Name, StringComparer.OrdinalIgnoreCase);
+
+            foreach (ExcelSheet sheet in Sheets) {
+                if (!otherSheets.TryGetValue(sheet.Name, out ExcelSheet? otherSheet)) {
+                    AddDifference(differences, maxDifferences, new ExcelWorkbookDifference("Sheet", "Sheet exists only in left workbook.", sheet.Name));
+                    continue;
+                }
+
+                if (options.CompareCells) {
+                    CompareSheetValues(sheet, otherSheet, differences, maxDifferences);
+                }
+                if (options.CompareCellStyles) {
+                    CompareCellStyles(sheet, otherSheet, differences, maxDifferences);
+                }
+                if (options.CompareTables || options.CompareWorksheetMetadata || options.CompareComments) {
+                    CompareSheetSnapshots(CreateInspectionSnapshot(), other.CreateInspectionSnapshot(), sheet.Name, differences, maxDifferences, options);
+                }
+                if (differences.Count >= maxDifferences) break;
+            }
+
+            var leftNames = new HashSet<string>(Sheets.Select(sheet => sheet.Name), StringComparer.OrdinalIgnoreCase);
+            foreach (ExcelSheet sheet in other.Sheets.Where(sheet => !leftNames.Contains(sheet.Name))) {
+                AddDifference(differences, maxDifferences, new ExcelWorkbookDifference("Sheet", "Sheet exists only in right workbook.", sheet.Name));
+            }
+
+            if (options.CompareNamedRanges) {
+                CompareNamedRanges(other, differences, maxDifferences);
+            }
+
+            return new ExcelWorkbookDiffReport(differences);
+        }
+
+        /// <summary>
+        /// Audits legacy notes and threaded comments across the workbook.
+        /// </summary>
+        public ExcelWorkbookCommentReport InspectComments() {
+            var comments = new List<ExcelCommentRecord>();
+            var issues = new List<ExcelWorkbookDiagnosticIssue>();
+            foreach (ExcelSheet sheet in Sheets) {
+                foreach (ExcelCommentInfo comment in sheet.GetComments()) {
+                    comments.Add(new ExcelCommentRecord(sheet.Name, comment.CellReference, comment.Author, comment.Text));
+                    if (string.IsNullOrWhiteSpace(comment.Author)) {
+                        issues.Add(new ExcelWorkbookDiagnosticIssue("Comment", ExcelFindingSeverity.Warning, "Legacy comment has no author.", sheet.Name, comment.CellReference));
+                    }
+                    if (string.IsNullOrWhiteSpace(comment.Text)) {
+                        issues.Add(new ExcelWorkbookDiagnosticIssue("Comment", ExcelFindingSeverity.Warning, "Legacy comment has no text.", sheet.Name, comment.CellReference));
+                    }
+                }
+            }
+
+            var threaded = CreateInspectionSnapshot().Worksheets.SelectMany(sheet => sheet.ThreadedComments).ToList();
+            foreach (ExcelThreadedCommentSnapshot comment in threaded) {
+                if (string.IsNullOrWhiteSpace(comment.Author)) {
+                    issues.Add(new ExcelWorkbookDiagnosticIssue("ThreadedComment", ExcelFindingSeverity.Warning, "Threaded comment has no resolved author.", address: comment.CellReference));
+                }
+                if (!string.IsNullOrWhiteSpace(comment.ParentId) && threaded.All(parent => !string.Equals(parent.Id, comment.ParentId, StringComparison.OrdinalIgnoreCase))) {
+                    issues.Add(new ExcelWorkbookDiagnosticIssue("ThreadedComment", ExcelFindingSeverity.Warning, "Threaded comment reply references a missing parent.", address: comment.CellReference));
+                }
+            }
+
+            return new ExcelWorkbookCommentReport(comments, threaded, issues);
+        }
+
+        /// <summary>
+        /// Validates all workbook template markers against a dictionary of values before applying the template.
+        /// </summary>
+        public ExcelTemplateBindingReport ValidateTemplateBindings(IDictionary<string, object?> values) {
+            if (values == null) throw new ArgumentNullException(nameof(values));
+            return new ExcelTemplateBindingReport(InspectTemplate(values));
+        }
+
+        /// <summary>
+        /// Validates all workbook template markers against an object model before applying the template.
+        /// </summary>
+        public ExcelTemplateBindingReport ValidateTemplateBindings(object model) {
+            if (model == null) throw new ArgumentNullException(nameof(model));
+            return new ExcelTemplateBindingReport(InspectTemplate(model));
+        }
+
+        /// <summary>
+        /// Authors safe connection/query-table metadata for Excel-compatible applications to own and refresh.
+        /// OfficeIMO writes metadata only; it does not execute Power Query M or contact external systems.
+        /// </summary>
+        public ExcelPowerQueryMetadataResult AddPowerQueryMetadata(ExcelPowerQueryMetadataOptions options) {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            string name = string.IsNullOrWhiteSpace(options.Name) ? "OfficeIMOQuery" : options.Name.Trim();
+            string commandText = options.CommandText ?? string.Empty;
+            uint connectionId = GetNextPowerQueryConnectionId();
+            AddWorkbookConnectionMetadata(BuildConnectionMetadataXml(name, options.Description, commandText, options.RefreshOnOpen, connectionId));
+            bool addedQueryTable = false;
+            string? queryTableName = null;
+            if (!string.IsNullOrWhiteSpace(options.WorksheetName)) {
+                queryTableName = NormalizeQueryTableName(options.QueryTableName, name);
+                AddWorksheetQueryTableMetadata(options.WorksheetName!, BuildQueryTableMetadataXml(queryTableName, connectionId));
+                addedQueryTable = true;
+            }
+            if (options.RefreshOnOpen) {
+                SetRefreshOnOpen(enabled: true, pivotTables: false, connections: true);
+            }
+
+            return new ExcelPowerQueryMetadataResult(name, connectionId, queryTableName, addedWorkbookConnection: true, addedQueryTable, options.RefreshOnOpen);
+        }
+
+        private static void CompareCellStyles(ExcelSheet left, ExcelSheet right, ICollection<ExcelWorkbookDifference> differences, int maxDifferences) {
+            var rightCells = (right.WorksheetPart.Worksheet?.Descendants<Cell>() ?? Enumerable.Empty<Cell>())
+                .Where(cell => !string.IsNullOrWhiteSpace(cell.CellReference?.Value))
+                .ToDictionary(cell => cell.CellReference!.Value!, StringComparer.OrdinalIgnoreCase);
+            foreach (Cell leftCell in left.WorksheetPart.Worksheet?.Descendants<Cell>() ?? Enumerable.Empty<Cell>()) {
+                if (differences.Count >= maxDifferences) break;
+                string? address = leftCell.CellReference?.Value;
+                if (string.IsNullOrWhiteSpace(address)) continue;
+                rightCells.TryGetValue(address!, out Cell? rightCell);
+                string leftStyle = leftCell.StyleIndex?.Value.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
+                string rightStyle = rightCell?.StyleIndex?.Value.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
+                if (!string.Equals(leftStyle, rightStyle, StringComparison.Ordinal)) {
+                    AddDifference(differences, maxDifferences, new ExcelWorkbookDifference("CellStyle", "Cell style index differs.", left.Name, address, leftStyle, rightStyle));
+                }
+            }
+        }
+
+        private static void CompareSheetSnapshots(ExcelWorkbookSnapshot leftSnapshot, ExcelWorkbookSnapshot rightSnapshot, string sheetName, ICollection<ExcelWorkbookDifference> differences, int maxDifferences, ExcelWorkbookDiffOptions options) {
+            ExcelWorksheetSnapshot? left = leftSnapshot.Worksheets.FirstOrDefault(sheet => string.Equals(sheet.Name, sheetName, StringComparison.OrdinalIgnoreCase));
+            ExcelWorksheetSnapshot? right = rightSnapshot.Worksheets.FirstOrDefault(sheet => string.Equals(sheet.Name, sheetName, StringComparison.OrdinalIgnoreCase));
+            if (left == null || right == null) return;
+
+            if (options.CompareTables) {
+                CompareKeyed(left.Tables.Select(table => $"{table.Name}|{table.A1Range}|{table.HasHeaderRow}"), right.Tables.Select(table => $"{table.Name}|{table.A1Range}|{table.HasHeaderRow}"), "Table", sheetName, differences, maxDifferences);
+            }
+            if (options.CompareWorksheetMetadata) {
+                CompareScalar("WorksheetView", "Used range differs.", sheetName, left.UsedRangeA1, right.UsedRangeA1, differences, maxDifferences);
+                CompareScalar("WorksheetView", "Gridline state differs.", sheetName, left.ShowGridlines.ToString(), right.ShowGridlines.ToString(), differences, maxDifferences);
+                CompareScalar("WorksheetView", "Frozen pane state differs.", sheetName, $"{left.FrozenRowCount},{left.FrozenColumnCount}", $"{right.FrozenRowCount},{right.FrozenColumnCount}", differences, maxDifferences);
+                CompareKeyed(left.Validations.Select(validation => $"{validation.Type}|{validation.Operator}|{string.Join(",", validation.A1Ranges)}"), right.Validations.Select(validation => $"{validation.Type}|{validation.Operator}|{string.Join(",", validation.A1Ranges)}"), "DataValidation", sheetName, differences, maxDifferences);
+            }
+            if (options.CompareComments) {
+                CompareKeyed(left.Cells.Where(cell => cell.Comment != null).Select(cell => $"{A1.CellReference(cell.Row, cell.Column)}|{cell.Comment!.Author}|{cell.Comment.Text}"), right.Cells.Where(cell => cell.Comment != null).Select(cell => $"{A1.CellReference(cell.Row, cell.Column)}|{cell.Comment!.Author}|{cell.Comment.Text}"), "Comment", sheetName, differences, maxDifferences);
+                CompareKeyed(left.ThreadedComments.Select(comment => $"{comment.CellReference}|{comment.Author}|{comment.Text}|{comment.Done}"), right.ThreadedComments.Select(comment => $"{comment.CellReference}|{comment.Author}|{comment.Text}|{comment.Done}"), "ThreadedComment", sheetName, differences, maxDifferences);
+            }
+        }
+
+        private void CompareNamedRanges(ExcelDocument other, ICollection<ExcelWorkbookDifference> differences, int maxDifferences) {
+            var left = ListNamedRanges(includeBuiltIn: true, includeHidden: true).Select(name => $"{name.SheetName}|{name.Name}|{name.Reference}|{name.Hidden}").OrderBy(item => item, StringComparer.OrdinalIgnoreCase).ToArray();
+            var right = other.ListNamedRanges(includeBuiltIn: true, includeHidden: true).Select(name => $"{name.SheetName}|{name.Name}|{name.Reference}|{name.Hidden}").OrderBy(item => item, StringComparer.OrdinalIgnoreCase).ToArray();
+            CompareKeyed(left, right, "NamedRange", null, differences, maxDifferences);
+        }
+
+        private static void CompareKeyed(IEnumerable<string> leftItems, IEnumerable<string> rightItems, string category, string? sheetName, ICollection<ExcelWorkbookDifference> differences, int maxDifferences) {
+            var left = new HashSet<string>(leftItems, StringComparer.OrdinalIgnoreCase);
+            var right = new HashSet<string>(rightItems, StringComparer.OrdinalIgnoreCase);
+            foreach (string item in left.Where(item => !right.Contains(item))) {
+                AddDifference(differences, maxDifferences, new ExcelWorkbookDifference(category, $"{category} exists only in left workbook.", sheetName, leftValue: item));
+                if (differences.Count >= maxDifferences) return;
+            }
+            foreach (string item in right.Where(item => !left.Contains(item))) {
+                AddDifference(differences, maxDifferences, new ExcelWorkbookDifference(category, $"{category} exists only in right workbook.", sheetName, rightValue: item));
+                if (differences.Count >= maxDifferences) return;
+            }
+        }
+
+        private static void CompareScalar(string category, string message, string sheetName, string? leftValue, string? rightValue, ICollection<ExcelWorkbookDifference> differences, int maxDifferences) {
+            if (!string.Equals(leftValue ?? string.Empty, rightValue ?? string.Empty, StringComparison.Ordinal)) {
+                AddDifference(differences, maxDifferences, new ExcelWorkbookDifference(category, message, sheetName, leftValue: leftValue, rightValue: rightValue));
+            }
+        }
+
+        private uint GetNextPowerQueryConnectionId() {
+            uint maxId = 0;
+            foreach (ExtendedPart part in WorkbookPartRoot.Parts.Select(pair => pair.OpenXmlPart).OfType<ExtendedPart>()) {
+                try {
+                    using Stream stream = part.GetStream(FileMode.Open, FileAccess.Read);
+                    XDocument document = XDocument.Load(stream);
+                    foreach (XElement connection in document.Descendants().Where(element => element.Name.LocalName == "connection")) {
+                        if (uint.TryParse(connection.Attribute("id")?.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out uint id)) {
+                            maxId = Math.Max(maxId, id);
+                        }
+                    }
+                } catch {
+                    // Extended metadata can be caller-supplied and not all parts are XML connection parts.
+                }
+            }
+
+            maxId = Math.Max(maxId, (uint)InspectDataModel().ConnectionPartCount);
+            return maxId + 1U;
+        }
+
+        private static string BuildConnectionMetadataXml(string name, string? description, string commandText, bool refreshOnOpen, uint connectionId) {
+            XNamespace main = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+            var connection = new XElement(main + "connection",
+                new XAttribute("id", connectionId.ToString(CultureInfo.InvariantCulture)),
+                new XAttribute("name", name),
+                new XAttribute("type", "5"),
+                new XAttribute("refreshedVersion", "7"),
+                new XAttribute("refreshOnLoad", refreshOnOpen ? "1" : "0"));
+            if (!string.IsNullOrWhiteSpace(description)) {
+                connection.SetAttributeValue("description", description!.Trim());
+            }
+            if (!string.IsNullOrWhiteSpace(commandText)) {
+                connection.Add(new XElement(main + "dbPr",
+                    new XAttribute("connection", "Provider=Microsoft.Mashup.OleDb.1;Data Source=$Workbook$;Location=" + name + ";Extended Properties=\"\""),
+                    new XAttribute("command", commandText),
+                    new XAttribute("commandType", "8")));
+            }
+
+            return new XDocument(new XElement(main + "connections", new XAttribute("count", "1"), connection)).ToString(SaveOptions.DisableFormatting);
+        }
+
+        private static string NormalizeQueryTableName(string? queryTableName, string connectionName) {
+            return string.IsNullOrWhiteSpace(queryTableName) ? connectionName + "Table" : queryTableName!.Trim();
+        }
+
+        private static string BuildQueryTableMetadataXml(string queryTableName, uint connectionId) {
+            XNamespace main = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+            return new XDocument(new XElement(main + "queryTable",
+                new XAttribute("name", queryTableName),
+                new XAttribute("connectionId", connectionId.ToString(CultureInfo.InvariantCulture)),
+                new XAttribute("autoFormatId", "16"),
+                new XAttribute("applyNumberFormats", "0"),
+                new XAttribute("applyBorderFormats", "0"),
+                new XAttribute("applyFontFormats", "0"),
+                new XAttribute("applyPatternFormats", "0"),
+                new XAttribute("applyAlignmentFormats", "0"),
+                new XAttribute("applyWidthHeightFormats", "0"))).ToString(SaveOptions.DisableFormatting);
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelWorkbookIntelligence.Advanced.cs
+++ b/OfficeIMO.Excel/ExcelWorkbookIntelligence.Advanced.cs
@@ -426,10 +426,19 @@ namespace OfficeIMO.Excel {
                 string? address = leftCell.CellReference?.Value;
                 if (string.IsNullOrWhiteSpace(address)) continue;
                 rightCells.TryGetValue(address!, out Cell? rightCell);
+                rightCells.Remove(address!);
                 string leftStyle = leftCell.StyleIndex?.Value.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
                 string rightStyle = rightCell?.StyleIndex?.Value.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
                 if (!string.Equals(leftStyle, rightStyle, StringComparison.Ordinal)) {
                     AddDifference(differences, maxDifferences, new ExcelWorkbookDifference("CellStyle", "Cell style index differs.", left.Name, address, leftStyle, rightStyle));
+                }
+            }
+
+            foreach (KeyValuePair<string, Cell> rightOnly in rightCells) {
+                if (differences.Count >= maxDifferences) break;
+                string rightStyle = rightOnly.Value.StyleIndex?.Value.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
+                if (!string.IsNullOrEmpty(rightStyle)) {
+                    AddDifference(differences, maxDifferences, new ExcelWorkbookDifference("CellStyle", "Cell style index differs.", left.Name, rightOnly.Key, string.Empty, rightStyle));
                 }
             }
         }
@@ -481,10 +490,9 @@ namespace OfficeIMO.Excel {
 
         private uint GetNextPowerQueryConnectionId() {
             uint maxId = 0;
-            foreach (ExtendedPart part in WorkbookPartRoot.Parts.Select(pair => pair.OpenXmlPart).OfType<ExtendedPart>()) {
+            foreach (OpenXmlPart part in EnumerateWorkbookConnectionParts()) {
                 try {
-                    using Stream stream = part.GetStream(FileMode.Open, FileAccess.Read);
-                    XDocument document = XDocument.Load(stream);
+                    XDocument document = XDocument.Parse(ReadOpenXmlPartText(part));
                     foreach (XElement connection in document.Descendants().Where(element => element.Name.LocalName == "connection")) {
                         if (uint.TryParse(connection.Attribute("id")?.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out uint id)) {
                             maxId = Math.Max(maxId, id);

--- a/OfficeIMO.Excel/ExcelWorkbookIntelligence.cs
+++ b/OfficeIMO.Excel/ExcelWorkbookIntelligence.cs
@@ -574,9 +574,28 @@ namespace OfficeIMO.Excel {
             string firstLine = text.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None).FirstOrDefault() ?? string.Empty;
             var candidates = new[] { ',', ';', '\t', '|' };
             return candidates
-                .Select(candidate => new { Delimiter = candidate, Count = firstLine.Count(ch => ch == candidate) })
+                .Select(candidate => new { Delimiter = candidate, Count = CountUnquoted(firstLine, candidate) })
                 .OrderByDescending(item => item.Count)
                 .First().Delimiter;
+        }
+
+        private static int CountUnquoted(string text, char delimiter) {
+            int count = 0;
+            bool quoted = false;
+            for (int i = 0; i < text.Length; i++) {
+                char ch = text[i];
+                if (ch == '"') {
+                    if (quoted && i + 1 < text.Length && text[i + 1] == '"') {
+                        i++;
+                    } else {
+                        quoted = !quoted;
+                    }
+                } else if (ch == delimiter && !quoted) {
+                    count++;
+                }
+            }
+
+            return count;
         }
 
         private static DataTable ParseDelimitedText(string text, char delimiter, ExcelDelimitedImportOptions options, ICollection<string> warnings) {

--- a/OfficeIMO.Excel/ExcelWorkbookIntelligence.cs
+++ b/OfficeIMO.Excel/ExcelWorkbookIntelligence.cs
@@ -370,8 +370,13 @@ namespace OfficeIMO.Excel {
                 .FirstOrDefault(item => string.Equals(item.Name, oldName, StringComparison.OrdinalIgnoreCase)
                     && string.Equals(item.SheetName, scope?.Name, StringComparison.OrdinalIgnoreCase))?.Hidden ?? false;
 
+            string validatedName = EnsureValidDefinedName(newName, validationMode);
+            string validatedReference = scope == null
+                ? NormalizeRange(reference, validationMode)
+                : NormalizeLocalNamedRange(scope, reference, validationMode);
+
             RemoveNamedRange(oldName, scope, save: false);
-            SetNamedRange(newName, reference, scope, save: save, hidden: hidden, validationMode: validationMode);
+            SetNamedRange(validatedName, validatedReference, scope, save: save, hidden: hidden, validationMode: validationMode);
             return true;
         }
 

--- a/OfficeIMO.Excel/ExcelWorkbookIntelligence.cs
+++ b/OfficeIMO.Excel/ExcelWorkbookIntelligence.cs
@@ -388,8 +388,19 @@ namespace OfficeIMO.Excel {
 
             var dataSet = new DataSet();
             dataSet.Tables.Add(table);
-            IReadOnlyList<ExcelDataSetImportResult> results = InsertDataSet(dataSet, createTables: options.CreateTable, tableStyle: options.TableStyle, includeHeaders: true, includeAutoFilter: true, autoFit: false);
-            return new ExcelDelimitedImportResult(results[0], delimiter, "UTF-16 string", warnings);
+            IReadOnlyList<ExcelDataSetImportResult> results = InsertDataSet(dataSet, createTables: false, tableStyle: options.TableStyle, includeHeaders: true, includeAutoFilter: true, autoFit: false);
+            ExcelDataSetImportResult result = results[0];
+            if (options.CreateTable && !string.IsNullOrWhiteSpace(result.Range)) {
+                ExcelSheet sheet = this[result.SheetName];
+                string requestedTableName = string.IsNullOrWhiteSpace(options.TableName) ? result.SheetName : options.TableName!.Trim();
+                sheet.AddTable(result.Range, hasHeader: true, requestedTableName, options.TableStyle, includeAutoFilter: true);
+                string? actualTableName = sheet.WorksheetPart.TableDefinitionParts
+                    .Select(part => part.Table?.Name?.Value ?? part.Table?.DisplayName?.Value)
+                    .FirstOrDefault(name => !string.IsNullOrWhiteSpace(name));
+                result = new ExcelDataSetImportResult(result.SheetName, actualTableName, result.Range, result.RowCount, result.ColumnCount);
+            }
+
+            return new ExcelDelimitedImportResult(result, delimiter, "UTF-16 string", warnings);
         }
 
         /// <summary>
@@ -653,6 +664,9 @@ namespace OfficeIMO.Excel {
                 if (string.IsNullOrWhiteSpace(address)) continue;
 
                 rightCells.TryGetValue(address!, out Cell? rightCell);
+                if (rightCell != null) {
+                    rightCells.Remove(address!);
+                }
                 string leftValue = left.GetCellText(leftCell);
                 string rightValue = rightCell == null ? string.Empty : right.GetCellText(rightCell);
                 string? leftFormula = leftCell.CellFormula?.Text;
@@ -660,6 +674,13 @@ namespace OfficeIMO.Excel {
                 if (!string.Equals(leftValue, rightValue, StringComparison.Ordinal) || !string.Equals(leftFormula, rightFormula, StringComparison.Ordinal)) {
                     AddDifference(differences, maxDifferences, new ExcelWorkbookDifference("Cell", "Cell value or formula differs.", left.Name, address, leftFormula ?? leftValue, rightFormula ?? rightValue));
                 }
+            }
+
+            foreach (KeyValuePair<string, Cell> rightOnly in rightCells) {
+                if (differences.Count >= maxDifferences) break;
+                string rightValue = right.GetCellText(rightOnly.Value);
+                string? rightFormula = rightOnly.Value.CellFormula?.Text;
+                AddDifference(differences, maxDifferences, new ExcelWorkbookDifference("Cell", "Cell exists only in right workbook.", left.Name, rightOnly.Key, string.Empty, rightFormula ?? rightValue));
             }
         }
 

--- a/OfficeIMO.Excel/ExcelWorkbookIntelligence.cs
+++ b/OfficeIMO.Excel/ExcelWorkbookIntelligence.cs
@@ -1,0 +1,671 @@
+using System.Data;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using DocumentFormat.OpenXml.Validation;
+
+#pragma warning disable CS1591
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Severity assigned to workbook diagnostics and compliance findings.
+    /// </summary>
+    public enum ExcelFindingSeverity {
+        Info,
+        Warning,
+        Error
+    }
+
+    /// <summary>
+    /// A diagnostic issue discovered in an Excel workbook.
+    /// </summary>
+    public sealed class ExcelWorkbookDiagnosticIssue {
+        internal ExcelWorkbookDiagnosticIssue(string category, ExcelFindingSeverity severity, string message, string? sheetName = null, string? address = null, string? repairAction = null) {
+            Category = category;
+            Severity = severity;
+            Message = message;
+            SheetName = sheetName;
+            Address = address;
+            RepairAction = repairAction;
+        }
+
+        public string Category { get; }
+        public ExcelFindingSeverity Severity { get; }
+        public string Message { get; }
+        public string? SheetName { get; }
+        public string? Address { get; }
+        public string? RepairAction { get; }
+    }
+
+    /// <summary>
+    /// Diagnostic report produced by the workbook doctor.
+    /// </summary>
+    public sealed class ExcelWorkbookDiagnosticReport {
+        internal ExcelWorkbookDiagnosticReport(IReadOnlyList<ExcelWorkbookDiagnosticIssue> issues, int repairedIssueCount) {
+            Issues = issues;
+            RepairedIssueCount = repairedIssueCount;
+        }
+
+        public IReadOnlyList<ExcelWorkbookDiagnosticIssue> Issues { get; }
+        public int RepairedIssueCount { get; }
+        public bool HasErrors => Issues.Any(issue => issue.Severity == ExcelFindingSeverity.Error);
+        public bool HasWarnings => Issues.Any(issue => issue.Severity == ExcelFindingSeverity.Warning);
+    }
+
+    /// <summary>
+    /// Options for workbook diagnostic scans and safe repairs.
+    /// </summary>
+    public sealed class ExcelWorkbookDoctorOptions {
+        public bool ValidateOpenXml { get; set; } = true;
+        public bool CheckDefinedNames { get; set; } = true;
+        public bool CheckFormulas { get; set; } = true;
+        public bool CheckTables { get; set; } = true;
+        public bool CheckDrawings { get; set; } = true;
+        public bool CheckConnections { get; set; } = true;
+        public bool RepairDefinedNames { get; set; }
+    }
+
+    /// <summary>
+    /// Formula metadata discovered during workbook analysis.
+    /// </summary>
+    public sealed class ExcelFormulaInfo {
+        internal ExcelFormulaInfo(string sheetName, string address, string formula, IReadOnlyList<string> references, IReadOnlyList<string> functions, bool hasExternalReference, bool isVolatile) {
+            SheetName = sheetName;
+            Address = address;
+            Formula = formula;
+            References = references;
+            Functions = functions;
+            HasExternalReference = hasExternalReference;
+            IsVolatile = isVolatile;
+        }
+
+        public string SheetName { get; }
+        public string Address { get; }
+        public string Formula { get; }
+        public IReadOnlyList<string> References { get; }
+        public IReadOnlyList<string> Functions { get; }
+        public bool HasExternalReference { get; }
+        public bool IsVolatile { get; }
+    }
+
+    /// <summary>
+    /// Workbook formula intelligence report.
+    /// </summary>
+    public sealed class ExcelFormulaAnalysisReport {
+        internal ExcelFormulaAnalysisReport(IReadOnlyList<ExcelFormulaInfo> formulas) {
+            Formulas = formulas;
+        }
+
+        public IReadOnlyList<ExcelFormulaInfo> Formulas { get; }
+        public int FormulaCount => Formulas.Count;
+        public int VolatileFormulaCount => Formulas.Count(formula => formula.IsVolatile);
+        public int ExternalReferenceCount => Formulas.Count(formula => formula.HasExternalReference);
+    }
+
+    /// <summary>
+    /// Named range metadata with scope and hidden state.
+    /// </summary>
+    public sealed class ExcelNamedRangeInfo {
+        internal ExcelNamedRangeInfo(string name, string reference, string? sheetName, bool hidden, bool builtIn) {
+            Name = name;
+            Reference = reference;
+            SheetName = sheetName;
+            Hidden = hidden;
+            BuiltIn = builtIn;
+        }
+
+        public string Name { get; }
+        public string Reference { get; }
+        public string? SheetName { get; }
+        public bool Hidden { get; }
+        public bool BuiltIn { get; }
+    }
+
+    /// <summary>
+    /// Result of importing normalized delimited text.
+    /// </summary>
+    public sealed class ExcelDelimitedImportResult {
+        internal ExcelDelimitedImportResult(ExcelDataSetImportResult importResult, char delimiter, string encodingName, IReadOnlyList<string> warnings) {
+            ImportResult = importResult;
+            Delimiter = delimiter;
+            EncodingName = encodingName;
+            Warnings = warnings;
+        }
+
+        public ExcelDataSetImportResult ImportResult { get; }
+        public char Delimiter { get; }
+        public string EncodingName { get; }
+        public IReadOnlyList<string> Warnings { get; }
+    }
+
+    /// <summary>
+    /// Options for culture-aware CSV/TSV import normalization.
+    /// </summary>
+    public sealed class ExcelDelimitedImportOptions {
+        public char? Delimiter { get; set; }
+        public bool HeadersInFirstRow { get; set; } = true;
+        public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
+        public bool ConvertNumbersAndDates { get; set; } = true;
+        public bool CreateTable { get; set; } = true;
+        public string? SheetName { get; set; }
+        public string? TableName { get; set; }
+        public TableStyle TableStyle { get; set; } = TableStyle.TableStyleMedium2;
+    }
+
+    /// <summary>
+    /// One workbook difference discovered by a structural/value comparison.
+    /// </summary>
+    public sealed class ExcelWorkbookDifference {
+        internal ExcelWorkbookDifference(string category, string message, string? sheetName = null, string? address = null, string? leftValue = null, string? rightValue = null) {
+            Category = category;
+            Message = message;
+            SheetName = sheetName;
+            Address = address;
+            LeftValue = leftValue;
+            RightValue = rightValue;
+        }
+
+        public string Category { get; }
+        public string Message { get; }
+        public string? SheetName { get; }
+        public string? Address { get; }
+        public string? LeftValue { get; }
+        public string? RightValue { get; }
+    }
+
+    /// <summary>
+    /// Workbook comparison report.
+    /// </summary>
+    public sealed class ExcelWorkbookDiffReport {
+        internal ExcelWorkbookDiffReport(IReadOnlyList<ExcelWorkbookDifference> differences) {
+            Differences = differences;
+        }
+
+        public IReadOnlyList<ExcelWorkbookDifference> Differences { get; }
+        public bool AreEqual => Differences.Count == 0;
+    }
+
+    /// <summary>
+    /// Accessibility and compliance finding.
+    /// </summary>
+    public sealed class ExcelAccessibilityFinding {
+        internal ExcelAccessibilityFinding(string category, ExcelFindingSeverity severity, string message, string? sheetName = null, string? address = null) {
+            Category = category;
+            Severity = severity;
+            Message = message;
+            SheetName = sheetName;
+            Address = address;
+        }
+
+        public string Category { get; }
+        public ExcelFindingSeverity Severity { get; }
+        public string Message { get; }
+        public string? SheetName { get; }
+        public string? Address { get; }
+    }
+
+    /// <summary>
+    /// Workbook accessibility and compliance report.
+    /// </summary>
+    public sealed class ExcelAccessibilityReport {
+        internal ExcelAccessibilityReport(IReadOnlyList<ExcelAccessibilityFinding> findings) {
+            Findings = findings;
+        }
+
+        public IReadOnlyList<ExcelAccessibilityFinding> Findings { get; }
+        public bool HasWarnings => Findings.Any(finding => finding.Severity != ExcelFindingSeverity.Info);
+    }
+
+    /// <summary>
+    /// Explicit large-workbook streaming capability contract for the current workbook.
+    /// </summary>
+    public sealed class ExcelStreamingContractReport {
+        internal ExcelStreamingContractReport(int worksheetCount, int estimatedCellCount, bool hasDirectDataSetFastSaveState, bool hasDeferredDirectDataSetImport, string recommendation) {
+            WorksheetCount = worksheetCount;
+            EstimatedCellCount = estimatedCellCount;
+            HasDirectDataSetFastSaveState = hasDirectDataSetFastSaveState;
+            HasDeferredDirectDataSetImport = hasDeferredDirectDataSetImport;
+            Recommendation = recommendation;
+        }
+
+        public int WorksheetCount { get; }
+        public int EstimatedCellCount { get; }
+        public bool HasDirectDataSetFastSaveState { get; }
+        public bool HasDeferredDirectDataSetImport { get; }
+        public string Recommendation { get; }
+    }
+
+    /// <summary>
+    /// Data-model and external-query awareness report.
+    /// </summary>
+    public sealed class ExcelDataModelReport {
+        internal ExcelDataModelReport(int connectionPartCount, int queryTablePartCount, int modelPartCount, int externalLinkPartCount, IReadOnlyList<string> details) {
+            ConnectionPartCount = connectionPartCount;
+            QueryTablePartCount = queryTablePartCount;
+            ModelPartCount = modelPartCount;
+            ExternalLinkPartCount = externalLinkPartCount;
+            Details = details;
+        }
+
+        public int ConnectionPartCount { get; }
+        public int QueryTablePartCount { get; }
+        public int ModelPartCount { get; }
+        public int ExternalLinkPartCount { get; }
+        public IReadOnlyList<string> Details { get; }
+        public bool HasDataModelOrQueries => ConnectionPartCount > 0 || QueryTablePartCount > 0 || ModelPartCount > 0 || ExternalLinkPartCount > 0;
+    }
+
+    public partial class ExcelDocument {
+        private static readonly Regex FormulaReferenceRegex = new Regex(@"(?<![A-Za-z0-9_])(?:'[^']+'|[A-Za-z_][A-Za-z0-9_ ]*)?!?\$?[A-Z]{1,3}\$?\d+(?::\$?[A-Z]{1,3}\$?\d+)?", RegexOptions.Compiled);
+        private static readonly Regex FormulaFunctionRegex = new Regex(@"(?<![A-Za-z0-9_])([A-Za-z_][A-Za-z0-9_\.]*)\s*\(", RegexOptions.Compiled);
+        private static readonly HashSet<string> VolatileFormulaFunctions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
+            "NOW", "TODAY", "RAND", "RANDBETWEEN", "OFFSET", "INDIRECT", "INFO", "CELL"
+        };
+
+        /// <summary>
+        /// Runs workbook diagnostics and optional safe repairs for common automation hazards.
+        /// </summary>
+        public ExcelWorkbookDiagnosticReport RunWorkbookDoctor(ExcelWorkbookDoctorOptions? options = null) {
+            options ??= new ExcelWorkbookDoctorOptions();
+            int repaired = 0;
+            if (options.RepairDefinedNames) {
+                int before = WorkbookRoot.DefinedNames?.Elements<DefinedName>().Count() ?? 0;
+                RepairDefinedNames(save: true);
+                int after = WorkbookRoot.DefinedNames?.Elements<DefinedName>().Count() ?? 0;
+                repaired += Math.Max(0, before - after);
+            }
+
+            var issues = new List<ExcelWorkbookDiagnosticIssue>();
+            if (options.ValidateOpenXml) {
+                foreach (ValidationErrorInfo error in new OpenXmlValidator().Validate(_spreadSheetDocument).Take(50)) {
+                    issues.Add(new ExcelWorkbookDiagnosticIssue("OpenXml", ExcelFindingSeverity.Error, error.Description ?? "OpenXml validation error.", repairAction: "Inspect package XML or save with validation enabled."));
+                }
+            }
+
+            if (options.CheckDefinedNames) AddDefinedNameDiagnostics(issues);
+            if (options.CheckFormulas) AddFormulaDiagnostics(issues);
+            if (options.CheckTables) AddTableDiagnostics(issues);
+            if (options.CheckDrawings) AddDrawingDiagnostics(issues);
+            if (options.CheckConnections) AddConnectionDiagnostics(issues);
+
+            return new ExcelWorkbookDiagnosticReport(issues, repaired);
+        }
+
+        /// <summary>
+        /// Analyzes formulas for references, external links, and volatile functions.
+        /// </summary>
+        public ExcelFormulaAnalysisReport AnalyzeFormulas() {
+            var formulas = new List<ExcelFormulaInfo>();
+            foreach (var item in EnumerateWorksheetParts()) {
+                Worksheet? worksheet = item.WorksheetPart.Worksheet;
+                if (worksheet == null) continue;
+
+                foreach (Cell cell in worksheet.Descendants<Cell>()) {
+                    string? formulaText = cell.CellFormula?.Text;
+                    if (string.IsNullOrWhiteSpace(formulaText)) continue;
+
+                    string address = cell.CellReference?.Value ?? string.Empty;
+                    var references = FormulaReferenceRegex.Matches(formulaText!)
+                        .Cast<Match>()
+                        .Select(match => match.Value)
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToArray();
+                    var functions = FormulaFunctionRegex.Matches(formulaText!)
+                        .Cast<Match>()
+                        .Select(match => match.Groups[1].Value)
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToArray();
+
+                    formulas.Add(new ExcelFormulaInfo(
+                        item.SheetName,
+                        address,
+                        formulaText!,
+                        references,
+                        functions,
+                        formulaText!.IndexOf('[') >= 0,
+                        functions.Any(function => VolatileFormulaFunctions.Contains(function))));
+                }
+            }
+
+            return new ExcelFormulaAnalysisReport(formulas);
+        }
+
+        /// <summary>
+        /// Returns all workbook and sheet-scoped defined names with scope and hidden metadata.
+        /// </summary>
+        public IReadOnlyList<ExcelNamedRangeInfo> ListNamedRanges(bool includeBuiltIn = true, bool includeHidden = true) {
+            var definedNames = WorkbookRoot.DefinedNames;
+            if (definedNames == null) return Array.Empty<ExcelNamedRangeInfo>();
+
+            var sheets = WorkbookRoot.Sheets?.Elements<Sheet>().ToList() ?? new List<Sheet>();
+            var result = new List<ExcelNamedRangeInfo>();
+            foreach (DefinedName name in definedNames.Elements<DefinedName>()) {
+                string nameValue = name.Name?.Value ?? string.Empty;
+                bool builtIn = nameValue.StartsWith("_xlnm.", StringComparison.OrdinalIgnoreCase);
+                bool hidden = name.Hidden?.Value ?? false;
+                if ((!includeBuiltIn && builtIn) || (!includeHidden && hidden)) continue;
+
+                string? sheetName = null;
+                if (name.LocalSheetId?.Value is uint local && local < sheets.Count) {
+                    sheetName = sheets[(int)local].Name?.Value;
+                }
+
+                result.Add(new ExcelNamedRangeInfo(nameValue, name.Text ?? string.Empty, sheetName, hidden, builtIn));
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Renames an existing workbook or sheet-scoped defined name.
+        /// </summary>
+        public bool RenameNamedRange(string oldName, string newName, ExcelSheet? scope = null, NameValidationMode validationMode = NameValidationMode.Sanitize, bool save = true) {
+            if (string.IsNullOrWhiteSpace(oldName)) throw new ArgumentException("Old name is required.", nameof(oldName));
+            if (string.IsNullOrWhiteSpace(newName)) throw new ArgumentException("New name is required.", nameof(newName));
+
+            string? reference = GetNamedRange(oldName, scope);
+            if (reference == null) return false;
+
+            bool hidden = ListNamedRanges(includeBuiltIn: true, includeHidden: true)
+                .FirstOrDefault(item => string.Equals(item.Name, oldName, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(item.SheetName, scope?.Name, StringComparison.OrdinalIgnoreCase))?.Hidden ?? false;
+
+            RemoveNamedRange(oldName, scope, save: false);
+            SetNamedRange(newName, reference, scope, save: save, hidden: hidden, validationMode: validationMode);
+            return true;
+        }
+
+        /// <summary>
+        /// Imports normalized CSV/TSV content into a worksheet using OfficeIMO's tabular writer.
+        /// </summary>
+        public ExcelDelimitedImportResult ImportDelimitedText(string text, ExcelDelimitedImportOptions? options = null) {
+            if (text == null) throw new ArgumentNullException(nameof(text));
+            options ??= new ExcelDelimitedImportOptions();
+            char delimiter = options.Delimiter ?? DetectDelimiter(text);
+            var warnings = new List<string>();
+            DataTable table = ParseDelimitedText(text, delimiter, options, warnings);
+            table.TableName = string.IsNullOrWhiteSpace(options.SheetName) ? "Import" : options.SheetName!.Trim();
+
+            var dataSet = new DataSet();
+            dataSet.Tables.Add(table);
+            IReadOnlyList<ExcelDataSetImportResult> results = InsertDataSet(dataSet, createTables: options.CreateTable, tableStyle: options.TableStyle, includeHeaders: true, includeAutoFilter: true, autoFit: false);
+            return new ExcelDelimitedImportResult(results[0], delimiter, "UTF-16 string", warnings);
+        }
+
+        /// <summary>
+        /// Compares this workbook with another workbook by sheets, dimensions, formulas, and visible cell text.
+        /// </summary>
+        public ExcelWorkbookDiffReport CompareWorkbook(ExcelDocument other, int maxDifferences = 200) {
+            if (other == null) throw new ArgumentNullException(nameof(other));
+            var differences = new List<ExcelWorkbookDifference>();
+            var otherSheets = other.Sheets.ToDictionary(sheet => sheet.Name, StringComparer.OrdinalIgnoreCase);
+
+            foreach (ExcelSheet sheet in Sheets) {
+                if (!otherSheets.TryGetValue(sheet.Name, out ExcelSheet? otherSheet)) {
+                    AddDifference(differences, maxDifferences, new ExcelWorkbookDifference("Sheet", "Sheet exists only in left workbook.", sheet.Name));
+                    continue;
+                }
+
+                CompareSheetValues(sheet, otherSheet, differences, maxDifferences);
+                if (differences.Count >= maxDifferences) break;
+            }
+
+            var leftNames = new HashSet<string>(Sheets.Select(sheet => sheet.Name), StringComparer.OrdinalIgnoreCase);
+            foreach (ExcelSheet sheet in other.Sheets.Where(sheet => !leftNames.Contains(sheet.Name))) {
+                AddDifference(differences, maxDifferences, new ExcelWorkbookDifference("Sheet", "Sheet exists only in right workbook.", sheet.Name));
+            }
+
+            return new ExcelWorkbookDiffReport(differences);
+        }
+
+        /// <summary>
+        /// Reports workbook accessibility and compliance issues such as missing alt text, hidden sheets, merged cells, and missing table headers.
+        /// </summary>
+        public ExcelAccessibilityReport AnalyzeAccessibility() {
+            var findings = new List<ExcelAccessibilityFinding>();
+            foreach (ExcelSheet sheet in Sheets) {
+                foreach (ExcelImage image in sheet.Images) {
+                    if (string.IsNullOrWhiteSpace(image.Description) && string.IsNullOrWhiteSpace(image.Title)) {
+                        findings.Add(new ExcelAccessibilityFinding("ImageAltText", ExcelFindingSeverity.Warning, "Image has no title or alternative text.", sheet.Name, A1.CellReference(image.RowIndex, image.ColumnIndex)));
+                    }
+                }
+            }
+
+            ExcelWorkbookSnapshot snapshot = CreateInspectionSnapshot();
+            foreach (ExcelWorksheetSnapshot worksheet in snapshot.Worksheets) {
+                if (worksheet.Hidden) {
+                    findings.Add(new ExcelAccessibilityFinding("HiddenData", ExcelFindingSeverity.Info, "Worksheet is hidden and may contain data excluded from normal review.", worksheet.Name));
+                }
+
+                foreach (ExcelMergedRangeSnapshot merge in worksheet.MergedRanges) {
+                    findings.Add(new ExcelAccessibilityFinding("MergedCells", ExcelFindingSeverity.Warning, "Merged cells can make sorting, filtering, and screen-reader navigation harder.", worksheet.Name, merge.A1Range));
+                }
+
+                foreach (ExcelTableSnapshot table in worksheet.Tables.Where(table => !table.HasHeaderRow)) {
+                    findings.Add(new ExcelAccessibilityFinding("TableHeaders", ExcelFindingSeverity.Warning, $"Table '{table.Name}' has no header row.", worksheet.Name, table.A1Range));
+                }
+            }
+
+            return new ExcelAccessibilityReport(findings);
+        }
+
+        /// <summary>
+        /// Returns a streaming/read-write contract summary for large workbook workflows.
+        /// </summary>
+        public ExcelStreamingContractReport GetStreamingContract() {
+            ExcelWorkbookSnapshot snapshot = CreateInspectionSnapshot();
+            int estimatedCellCount = snapshot.Worksheets.Sum(sheet => sheet.Cells.Count);
+            string recommendation = HasDeferredDirectDataSetImport || HasDirectDataSetFastSaveState
+                ? "Workbook is currently using OfficeIMO direct tabular save state."
+                : estimatedCellCount > 500000
+                    ? "Use direct DataSet/DataTable writers or reader streaming APIs for this workbook size."
+                    : "Standard OfficeIMO workbook APIs are suitable for this workbook size.";
+            return new ExcelStreamingContractReport(snapshot.Worksheets.Count, estimatedCellCount, HasDirectDataSetFastSaveState, HasDeferredDirectDataSetImport, recommendation);
+        }
+
+        /// <summary>
+        /// Inspects data model, Power Query, connection, query table, and external link package parts.
+        /// </summary>
+        public ExcelDataModelReport InspectDataModel() {
+            var details = new List<string>();
+            int connection = 0;
+            int queryTable = 0;
+            int model = 0;
+            int external = 0;
+            foreach (OpenXmlPart part in EnumerateParts(WorkbookPartRoot)) {
+                string contentType = part.ContentType ?? string.Empty;
+                string uri = part.Uri.ToString();
+                if (contentType.IndexOf("connections", StringComparison.OrdinalIgnoreCase) >= 0) { connection++; details.Add(uri); }
+                if (contentType.IndexOf("queryTable", StringComparison.OrdinalIgnoreCase) >= 0) { queryTable++; details.Add(uri); }
+                if (contentType.IndexOf("model", StringComparison.OrdinalIgnoreCase) >= 0) { model++; details.Add(uri); }
+                if (contentType.IndexOf("externalLink", StringComparison.OrdinalIgnoreCase) >= 0) { external++; details.Add(uri); }
+            }
+
+            return new ExcelDataModelReport(connection, queryTable, model, external, details.Distinct(StringComparer.OrdinalIgnoreCase).ToArray());
+        }
+
+        private void AddDefinedNameDiagnostics(ICollection<ExcelWorkbookDiagnosticIssue> issues) {
+            var names = ListNamedRanges(includeBuiltIn: true, includeHidden: true);
+            foreach (var duplicate in names.GroupBy(name => (name.SheetName ?? string.Empty) + "|" + name.Name, StringComparer.OrdinalIgnoreCase).Where(group => group.Count() > 1)) {
+                issues.Add(new ExcelWorkbookDiagnosticIssue("DefinedName", ExcelFindingSeverity.Warning, $"Duplicate defined name '{duplicate.First().Name}' in the same scope.", duplicate.First().SheetName, repairAction: "Run workbook doctor with RepairDefinedNames enabled."));
+            }
+
+            foreach (ExcelNamedRangeInfo name in names.Where(name => name.Reference.IndexOf("#REF!", StringComparison.OrdinalIgnoreCase) >= 0)) {
+                issues.Add(new ExcelWorkbookDiagnosticIssue("DefinedName", ExcelFindingSeverity.Error, $"Defined name '{name.Name}' contains #REF!.", name.SheetName, repairAction: "Remove or recreate the defined name."));
+            }
+        }
+
+        private void AddFormulaDiagnostics(ICollection<ExcelWorkbookDiagnosticIssue> issues) {
+            foreach (ExcelFormulaInfo formula in AnalyzeFormulas().Formulas) {
+                if (formula.HasExternalReference) {
+                    issues.Add(new ExcelWorkbookDiagnosticIssue("Formula", ExcelFindingSeverity.Warning, "Formula references an external workbook.", formula.SheetName, formula.Address, "Review external links before automated refresh or distribution."));
+                }
+                if (formula.IsVolatile) {
+                    issues.Add(new ExcelWorkbookDiagnosticIssue("Formula", ExcelFindingSeverity.Info, "Formula uses a volatile function.", formula.SheetName, formula.Address));
+                }
+            }
+        }
+
+        private void AddTableDiagnostics(ICollection<ExcelWorkbookDiagnosticIssue> issues) {
+            var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var item in EnumerateWorksheetParts()) {
+                foreach (TableDefinitionPart tablePart in item.WorksheetPart.TableDefinitionParts) {
+                    string name = tablePart.Table?.Name?.Value ?? tablePart.Table?.DisplayName?.Value ?? string.Empty;
+                    if (!string.IsNullOrWhiteSpace(name) && !names.Add(name)) {
+                        issues.Add(new ExcelWorkbookDiagnosticIssue("Table", ExcelFindingSeverity.Error, $"Duplicate table name '{name}'.", item.SheetName, repairAction: "Rename one table before saving."));
+                    }
+                }
+            }
+        }
+
+        private void AddDrawingDiagnostics(ICollection<ExcelWorkbookDiagnosticIssue> issues) {
+            foreach (ExcelSheet sheet in Sheets) {
+                foreach (ExcelImage image in sheet.Images) {
+                    if (image.GetBytes().Length == 0) {
+                        issues.Add(new ExcelWorkbookDiagnosticIssue("Drawing", ExcelFindingSeverity.Warning, $"Image '{image.Name}' has no readable image bytes.", sheet.Name, A1.CellReference(image.RowIndex, image.ColumnIndex)));
+                    }
+                }
+            }
+        }
+
+        private void AddConnectionDiagnostics(ICollection<ExcelWorkbookDiagnosticIssue> issues) {
+            ExcelDataModelReport dataModel = InspectDataModel();
+            if (dataModel.HasDataModelOrQueries) {
+                issues.Add(new ExcelWorkbookDiagnosticIssue("DataModel", ExcelFindingSeverity.Info, "Workbook contains connection, query, data-model, or external-link parts that OfficeIMO preserves but does not execute.", repairAction: "Use refresh-on-open metadata or Excel to execute queries."));
+            }
+        }
+
+        private IEnumerable<(string SheetName, WorksheetPart WorksheetPart)> EnumerateWorksheetParts() {
+            WorkbookPart workbookPart = WorkbookPartRoot;
+            foreach (Sheet sheet in workbookPart.Workbook?.Sheets?.Elements<Sheet>() ?? Enumerable.Empty<Sheet>()) {
+                if (sheet.Id?.Value == null) continue;
+                if (workbookPart.GetPartById(sheet.Id.Value) is WorksheetPart worksheetPart) {
+                    yield return (sheet.Name?.Value ?? string.Empty, worksheetPart);
+                }
+            }
+        }
+
+        private static IEnumerable<OpenXmlPart> EnumerateParts(OpenXmlPartContainer container) {
+            foreach (IdPartPair pair in container.Parts) {
+                yield return pair.OpenXmlPart;
+                foreach (OpenXmlPart child in EnumerateParts(pair.OpenXmlPart)) {
+                    yield return child;
+                }
+            }
+        }
+
+        private static char DetectDelimiter(string text) {
+            string firstLine = text.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None).FirstOrDefault() ?? string.Empty;
+            var candidates = new[] { ',', ';', '\t', '|' };
+            return candidates
+                .Select(candidate => new { Delimiter = candidate, Count = firstLine.Count(ch => ch == candidate) })
+                .OrderByDescending(item => item.Count)
+                .First().Delimiter;
+        }
+
+        private static DataTable ParseDelimitedText(string text, char delimiter, ExcelDelimitedImportOptions options, ICollection<string> warnings) {
+            var rows = ParseDelimitedRows(text, delimiter).ToList();
+            var table = new DataTable { Locale = options.Culture };
+            if (rows.Count == 0) return table;
+
+            int columnCount = rows.Max(row => row.Count);
+            int dataStart = options.HeadersInFirstRow ? 1 : 0;
+            for (int i = 0; i < columnCount; i++) {
+                string name = options.HeadersInFirstRow && i < rows[0].Count && !string.IsNullOrWhiteSpace(rows[0][i])
+                    ? rows[0][i]
+                    : "Column" + (i + 1).ToString(CultureInfo.InvariantCulture);
+                if (table.Columns.Contains(name)) name += "_" + (i + 1).ToString(CultureInfo.InvariantCulture);
+                table.Columns.Add(name, typeof(object));
+            }
+
+            for (int rowIndex = dataStart; rowIndex < rows.Count; rowIndex++) {
+                DataRow row = table.NewRow();
+                for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+                    string value = columnIndex < rows[rowIndex].Count ? rows[rowIndex][columnIndex] : string.Empty;
+                    row[columnIndex] = ConvertDelimitedValue(value, options, warnings);
+                }
+                table.Rows.Add(row);
+            }
+
+            return table;
+        }
+
+        private static object ConvertDelimitedValue(string value, ExcelDelimitedImportOptions options, ICollection<string> warnings) {
+            if (value.Length == 0) return DBNull.Value;
+            if (!options.ConvertNumbersAndDates) return value;
+            if (decimal.TryParse(value, NumberStyles.Number, options.Culture, out decimal number)) return number;
+            if (DateTime.TryParse(value, options.Culture, DateTimeStyles.None, out DateTime date)) return date;
+            return value;
+        }
+
+        private static IEnumerable<List<string>> ParseDelimitedRows(string text, char delimiter) {
+            var row = new List<string>();
+            var field = new StringBuilder();
+            bool quoted = false;
+            for (int i = 0; i < text.Length; i++) {
+                char ch = text[i];
+                if (quoted) {
+                    if (ch == '"' && i + 1 < text.Length && text[i + 1] == '"') {
+                        field.Append('"');
+                        i++;
+                    } else if (ch == '"') {
+                        quoted = false;
+                    } else {
+                        field.Append(ch);
+                    }
+                    continue;
+                }
+
+                if (ch == '"') { quoted = true; continue; }
+                if (ch == delimiter) { row.Add(field.ToString()); field.Clear(); continue; }
+                if (ch == '\r') continue;
+                if (ch == '\n') {
+                    row.Add(field.ToString());
+                    field.Clear();
+                    yield return row;
+                    row = new List<string>();
+                    continue;
+                }
+
+                field.Append(ch);
+            }
+
+            row.Add(field.ToString());
+            if (row.Count > 1 || row[0].Length > 0) yield return row;
+        }
+
+        private static void CompareSheetValues(ExcelSheet left, ExcelSheet right, ICollection<ExcelWorkbookDifference> differences, int maxDifferences) {
+            Worksheet? leftWorksheet = left.WorksheetPart.Worksheet;
+            Worksheet? rightWorksheet = right.WorksheetPart.Worksheet;
+            string leftRange = leftWorksheet?.SheetDimension?.Reference?.Value ?? string.Empty;
+            string rightRange = rightWorksheet?.SheetDimension?.Reference?.Value ?? string.Empty;
+            if (!string.Equals(leftRange, rightRange, StringComparison.OrdinalIgnoreCase)) {
+                AddDifference(differences, maxDifferences, new ExcelWorkbookDifference("UsedRange", "Used ranges differ.", left.Name, leftValue: leftRange, rightValue: rightRange));
+            }
+
+            var rightCells = (rightWorksheet?.Descendants<Cell>() ?? Enumerable.Empty<Cell>())
+                .Where(cell => !string.IsNullOrWhiteSpace(cell.CellReference?.Value))
+                .ToDictionary(cell => cell.CellReference!.Value!, StringComparer.OrdinalIgnoreCase);
+
+            foreach (Cell leftCell in leftWorksheet?.Descendants<Cell>() ?? Enumerable.Empty<Cell>()) {
+                if (differences.Count >= maxDifferences) break;
+                string? address = leftCell.CellReference?.Value;
+                if (string.IsNullOrWhiteSpace(address)) continue;
+
+                rightCells.TryGetValue(address!, out Cell? rightCell);
+                string leftValue = left.GetCellText(leftCell);
+                string rightValue = rightCell == null ? string.Empty : right.GetCellText(rightCell);
+                string? leftFormula = leftCell.CellFormula?.Text;
+                string? rightFormula = rightCell?.CellFormula?.Text;
+                if (!string.Equals(leftValue, rightValue, StringComparison.Ordinal) || !string.Equals(leftFormula, rightFormula, StringComparison.Ordinal)) {
+                    AddDifference(differences, maxDifferences, new ExcelWorkbookDifference("Cell", "Cell value or formula differs.", left.Name, address, leftFormula ?? leftValue, rightFormula ?? rightValue));
+                }
+            }
+        }
+
+        private static void AddDifference(ICollection<ExcelWorkbookDifference> differences, int maxDifferences, ExcelWorkbookDifference difference) {
+            if (differences.Count < maxDifferences) differences.Add(difference);
+        }
+    }
+}
+#pragma warning restore CS1591

--- a/OfficeIMO.Excel/ExcelWorkbookMergeOptions.cs
+++ b/OfficeIMO.Excel/ExcelWorkbookMergeOptions.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Options for importing worksheets from one workbook into another.
+    /// </summary>
+    public sealed class ExcelWorkbookMergeOptions {
+        /// <summary>
+        /// Gets or sets source worksheet names to import. When empty, all source worksheets are imported.
+        /// </summary>
+        public IReadOnlyList<string>? SheetNames { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional prefix added to every imported worksheet name.
+        /// </summary>
+        public string? SheetNamePrefix { get; set; }
+
+        /// <summary>
+        /// Gets or sets sheet name validation behavior for imported worksheets.
+        /// </summary>
+        public SheetNameValidationMode SheetNameValidationMode { get; set; } = SheetNameValidationMode.Sanitize;
+    }
+}

--- a/OfficeIMO.Excel/ExcelWorkbookMergeResult.cs
+++ b/OfficeIMO.Excel/ExcelWorkbookMergeResult.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Result of importing worksheets from one workbook into another.
+    /// </summary>
+    public sealed class ExcelWorkbookMergeResult {
+        /// <summary>
+        /// Creates a workbook merge result.
+        /// </summary>
+        public ExcelWorkbookMergeResult(IReadOnlyList<string> sourceSheets, IReadOnlyList<string> targetSheets) {
+            SourceSheets = sourceSheets;
+            TargetSheets = targetSheets;
+        }
+
+        /// <summary>
+        /// Gets the imported source worksheet names.
+        /// </summary>
+        public IReadOnlyList<string> SourceSheets { get; }
+
+        /// <summary>
+        /// Gets the created target worksheet names.
+        /// </summary>
+        public IReadOnlyList<string> TargetSheets { get; }
+
+        /// <summary>
+        /// Gets the number of imported worksheets.
+        /// </summary>
+        public int SheetCount => TargetSheets.Count;
+    }
+}

--- a/OfficeIMO.Excel/ExcelWorkbookThemeInfo.cs
+++ b/OfficeIMO.Excel/ExcelWorkbookThemeInfo.cs
@@ -1,0 +1,30 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Describes the workbook theme package part.
+    /// </summary>
+    public sealed class ExcelWorkbookThemeInfo {
+        /// <summary>
+        /// Creates workbook theme information.
+        /// </summary>
+        public ExcelWorkbookThemeInfo(bool hasTheme, string? name, string? xml) {
+            HasTheme = hasTheme;
+            Name = name;
+            Xml = xml;
+        }
+
+        /// <summary>
+        /// Gets whether the workbook contains a theme part.
+        /// </summary>
+        public bool HasTheme { get; }
+
+        /// <summary>
+        /// Gets the theme name from the theme XML root when available.
+        /// </summary>
+        public string? Name { get; }
+
+        /// <summary>
+        /// Gets the theme XML when requested by callers.
+        /// </summary>
+        public string? Xml { get; }
+    }
+}

--- a/OfficeIMO.Excel/ExcelWorksheetViewInfo.cs
+++ b/OfficeIMO.Excel/ExcelWorksheetViewInfo.cs
@@ -1,0 +1,45 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Read-only worksheet view metadata such as frozen panes, gridlines, zoom, and direction.
+    /// </summary>
+    public sealed class ExcelWorksheetViewInfo {
+        /// <summary>Gets or sets whether the worksheet contains a pane definition.</summary>
+        public bool HasPane { get; internal set; }
+
+        /// <summary>Gets or sets the pane state, for example <c>frozen</c> or <c>split</c>.</summary>
+        public string? PaneState { get; internal set; }
+
+        /// <summary>Gets or sets the horizontal split value stored by Excel.</summary>
+        public double? HorizontalSplit { get; internal set; }
+
+        /// <summary>Gets or sets the vertical split value stored by Excel.</summary>
+        public double? VerticalSplit { get; internal set; }
+
+        /// <summary>Gets or sets the number of frozen rows, when the pane is frozen.</summary>
+        public int FrozenRowCount { get; internal set; }
+
+        /// <summary>Gets or sets the number of frozen columns, when the pane is frozen.</summary>
+        public int FrozenColumnCount { get; internal set; }
+
+        /// <summary>Gets or sets the top-left scrollable cell, when present.</summary>
+        public string? TopLeftCell { get; internal set; }
+
+        /// <summary>Gets or sets the active pane, when present.</summary>
+        public string? ActivePane { get; internal set; }
+
+        /// <summary>Gets or sets whether worksheet gridlines are visible.</summary>
+        public bool ShowGridlines { get; internal set; } = true;
+
+        /// <summary>Gets or sets whether the worksheet view is right-to-left.</summary>
+        public bool RightToLeft { get; internal set; }
+
+        /// <summary>Gets or sets the sheet view type, when present.</summary>
+        public string? View { get; internal set; }
+
+        /// <summary>Gets or sets the current zoom scale, when present.</summary>
+        public uint? ZoomScale { get; internal set; }
+
+        /// <summary>Gets or sets the normal-view zoom scale, when present.</summary>
+        public uint? ZoomScaleNormal { get; internal set; }
+    }
+}

--- a/OfficeIMO.Excel/ExcelWorksheetViewKind.cs
+++ b/OfficeIMO.Excel/ExcelWorksheetViewKind.cs
@@ -1,0 +1,15 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Worksheet view modes supported by spreadsheet applications.
+    /// </summary>
+    public enum ExcelWorksheetViewKind {
+        /// <summary>Normal editing view.</summary>
+        Normal,
+
+        /// <summary>Page break preview view.</summary>
+        PageBreakPreview,
+
+        /// <summary>Page layout view.</summary>
+        PageLayout,
+    }
+}

--- a/OfficeIMO.Excel/ExcelWorksheetViewOptions.cs
+++ b/OfficeIMO.Excel/ExcelWorksheetViewOptions.cs
@@ -1,0 +1,21 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Mutable worksheet view options such as zoom, gridlines, direction, and view mode.
+    /// </summary>
+    public sealed class ExcelWorksheetViewOptions {
+        /// <summary>Gets or sets whether gridlines are visible.</summary>
+        public bool? ShowGridlines { get; set; }
+
+        /// <summary>Gets or sets whether the worksheet is shown right-to-left.</summary>
+        public bool? RightToLeft { get; set; }
+
+        /// <summary>Gets or sets the active zoom percentage. Excel supports values from 10 to 400.</summary>
+        public uint? ZoomScale { get; set; }
+
+        /// <summary>Gets or sets the normal-view zoom percentage. Excel supports values from 10 to 400.</summary>
+        public uint? ZoomScaleNormal { get; set; }
+
+        /// <summary>Gets or sets the worksheet view mode.</summary>
+        public ExcelWorksheetViewKind? View { get; set; }
+    }
+}

--- a/OfficeIMO.Excel/Fluent/PivotTableBuilder.cs
+++ b/OfficeIMO.Excel/Fluent/PivotTableBuilder.cs
@@ -35,6 +35,10 @@ namespace OfficeIMO.Excel.Fluent {
         private bool? _showMemberPropertyTips;
         private bool? _fieldListSortAscending;
         private bool? _customListSort;
+        private bool? _refreshOnOpen;
+        private bool? _saveSourceData;
+        private bool? _preserveFormatting;
+        private bool? _enableDrill;
 
         internal PivotTableBuilder(ExcelSheet sheet, string sourceRange) {
             _sheet = sheet ?? throw new ArgumentNullException(nameof(sheet));
@@ -154,6 +158,19 @@ namespace OfficeIMO.Excel.Fluent {
             _showMemberPropertyTips = showMemberPropertyTips;
             _fieldListSortAscending = fieldListSortAscending;
             _customListSort = customListSort;
+            return this;
+        }
+
+        /// <summary>Controls pivot cache refresh and interactive workbook behavior.</summary>
+        public PivotTableBuilder Interaction(
+            bool? refreshOnOpen = null,
+            bool? saveSourceData = null,
+            bool? preserveFormatting = null,
+            bool? enableDrill = null) {
+            _refreshOnOpen = refreshOnOpen;
+            _saveSourceData = saveSourceData;
+            _preserveFormatting = preserveFormatting;
+            _enableDrill = enableDrill;
             return this;
         }
 
@@ -355,9 +372,26 @@ namespace OfficeIMO.Excel.Fluent {
                 customListSort: _customListSort,
                 pivotFilters: _pivotFilters.Count == 0 ? null : _pivotFilters,
                 calculatedFields: _calculatedFields.Count == 0 ? null : _calculatedFields,
-                groupings: _groupings.Count == 0 ? null : _groupings);
+                groupings: _groupings.Count == 0 ? null : _groupings,
+                options: CreateOptions());
 
             return _sheet;
+        }
+
+        private ExcelPivotTableOptions? CreateOptions() {
+            if (!_refreshOnOpen.HasValue
+                && !_saveSourceData.HasValue
+                && !_preserveFormatting.HasValue
+                && !_enableDrill.HasValue) {
+                return null;
+            }
+
+            return new ExcelPivotTableOptions {
+                RefreshOnOpen = _refreshOnOpen,
+                SaveSourceData = _saveSourceData,
+                PreserveFormatting = _preserveFormatting,
+                EnableDrill = _enableDrill
+            };
         }
 
         private static void AddFieldNames(List<string> target, string[] fieldNames, string parameterName) {

--- a/OfficeIMO.Excel/Fluent/SheetComposer.ColumnsLayout.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.ColumnsLayout.cs
@@ -199,6 +199,7 @@ namespace OfficeIMO.Excel.Fluent {
                 _sheet.AddTable(range, hasHeader: true, name: tableName, style: style, includeAutoFilter: autoFilter);
 
                 var viz = new TableVisualOptions(); visuals?.Invoke(viz);
+                _sheet.SetTableStyle(range, style, viz.ShowFirstColumn, viz.ShowLastColumn, viz.ShowRowStripes, viz.ShowColumnStripes);
                 try {
                     for (int i = 0; i < headersT.Count; i++) {
                         string hdr = headersT[i];

--- a/OfficeIMO.Excel/Fluent/SheetComposer.Table.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.Table.cs
@@ -88,6 +88,7 @@ namespace OfficeIMO.Excel.Fluent {
 
             var viz = new TableVisualOptions();
             viz.FreezeHeaderRow = freezeHeaderRow; visuals?.Invoke(viz);
+            Sheet.SetTableStyle(range, style, viz.ShowFirstColumn, viz.ShowLastColumn, viz.ShowRowStripes, viz.ShowColumnStripes);
             if (viz.FreezeHeaderRow) { try { Sheet.Freeze(topRows: headerRow, leftCols: 0); } catch { } }
 
             try {

--- a/OfficeIMO.Excel/Fluent/SheetComposer.cs
+++ b/OfficeIMO.Excel/Fluent/SheetComposer.cs
@@ -27,7 +27,7 @@ namespace OfficeIMO.Excel.Fluent {
             // Create a sheet-local top anchor so callers/tests can rely on a defined name at A1.
             // Keep it simple and safe: local to this sheet, absolute A1.
             // Use a simple A1 reference so the normalizer can expand to $A$1
-            try { _workbook.SetNamedRange($"top_{SanitizeName(_sheet.Name)}", "A1", _sheet, save: true, hidden: true); } catch { }
+            try { _workbook.SetNamedRange($"top_{SanitizeName(_sheet.Name)}", "A1", _sheet, save: false, hidden: true); } catch { }
         }
 
         /// <summary>The underlying sheet created by this composer.</summary>

--- a/OfficeIMO.Excel/Fluent/TableVisualOptions.cs
+++ b/OfficeIMO.Excel/Fluent/TableVisualOptions.cs
@@ -24,6 +24,18 @@ namespace OfficeIMO.Excel.Fluent {
         /// <summary>Freeze through the header row for easier scrolling.</summary>
         public bool FreezeHeaderRow { get; set; } = true;
 
+        /// <summary>Emphasize the first table column when the selected table style supports it.</summary>
+        public bool ShowFirstColumn { get; set; }
+
+        /// <summary>Emphasize the last table column when the selected table style supports it.</summary>
+        public bool ShowLastColumn { get; set; }
+
+        /// <summary>Show alternating row stripes for the table.</summary>
+        public bool ShowRowStripes { get; set; } = true;
+
+        /// <summary>Show alternating column stripes for the table.</summary>
+        public bool ShowColumnStripes { get; set; }
+
         /// <summary>
         /// Apply a numeric format with fixed decimals by header name.
         /// </summary>

--- a/OfficeIMO.Excel/OpenXmlWorkbookElementOrder.cs
+++ b/OfficeIMO.Excel/OpenXmlWorkbookElementOrder.cs
@@ -1,0 +1,25 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeIMO.Excel {
+    internal static class OpenXmlWorkbookElementOrder {
+        internal static void InsertInOrder(Workbook workbook, OpenXmlElement element) {
+            if (workbook == null) throw new ArgumentNullException(nameof(workbook));
+            if (element == null) throw new ArgumentNullException(nameof(element));
+
+            if (element is WorkbookProperties) {
+                OpenXmlElement? before = workbook.GetFirstChild<WorkbookProtection>();
+                before ??= workbook.GetFirstChild<BookViews>();
+                before ??= workbook.GetFirstChild<Sheets>();
+                if (before != null) {
+                    workbook.InsertBefore(element, before);
+                } else {
+                    workbook.Append(element);
+                }
+                return;
+            }
+
+            workbook.Append(element);
+        }
+    }
+}

--- a/OfficeIMO.Excel/Read/ExcelDocumentReader.Sheets.cs
+++ b/OfficeIMO.Excel/Read/ExcelDocumentReader.Sheets.cs
@@ -12,7 +12,7 @@ namespace OfficeIMO.Excel {
         public ExcelSheetReader GetSheet(int index) {
             if (index < 1) throw new ArgumentOutOfRangeException(nameof(index));
             if (TryGetSheetByIndexXmlFast(index, out string fastSheetName, out WorksheetPart fastWorksheetPart)) {
-                return new ExcelSheetReader(fastSheetName, fastWorksheetPart, _sst, _styles, _opt, _owns);
+                return new ExcelSheetReader(fastSheetName, fastWorksheetPart, _sst, _styles, _opt, _dateSystem, _owns);
             }
 
             var wb = WorkbookRoot;
@@ -28,7 +28,7 @@ namespace OfficeIMO.Excel {
 
             if (sheet is null) throw new ArgumentOutOfRangeException(nameof(index));
             var wsPart = (WorksheetPart)WorkbookPartRoot.GetPartById(sheet.Id!);
-            return new ExcelSheetReader(sheet.Name!, wsPart, _sst, _styles, _opt, _owns);
+            return new ExcelSheetReader(sheet.Name!, wsPart, _sst, _styles, _opt, _dateSystem, _owns);
         }
 
         /// <summary>

--- a/OfficeIMO.Excel/Read/ExcelDocumentReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelDocumentReader.cs
@@ -18,6 +18,7 @@ namespace OfficeIMO.Excel {
         private readonly SpreadsheetDocument _doc;
         private readonly bool _owns;
         private readonly ExcelReadOptions _opt;
+        private readonly ExcelDateSystem _dateSystem;
         private readonly SharedStringCache _sst;
         private readonly StylesCacheProvider _styles;
         private readonly Package? _ownedPackage;
@@ -29,6 +30,7 @@ namespace OfficeIMO.Excel {
             _opt = opt ?? new ExcelReadOptions();
             _ownedPackage = ownedPackage;
             _ownedStream = ownedStream;
+            _dateSystem = GetWorkbookDateSystem(doc);
             _sst = SharedStringCache.Build(doc, _opt);
             _styles = new StylesCacheProvider(doc);
         }
@@ -108,7 +110,7 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public ExcelSheetReader GetSheet(string name) {
             if (TryGetSheetByNameXmlFast(name, out string? fastSheetName, out WorksheetPart? fastWorksheetPart)) {
-                return new ExcelSheetReader(fastSheetName, fastWorksheetPart, _sst, _styles, _opt, _owns);
+                return new ExcelSheetReader(fastSheetName, fastWorksheetPart, _sst, _styles, _opt, _dateSystem, _owns);
             }
 
             var wb = WorkbookRoot;
@@ -122,7 +124,13 @@ namespace OfficeIMO.Excel {
 
             if (sheet is null) throw new KeyNotFoundException($"Sheet '{name}' not found.");
             var wsPart = (WorksheetPart)WorkbookPartRoot.GetPartById(sheet.Id!);
-            return new ExcelSheetReader(sheet.Name!, wsPart, _sst, _styles, _opt, _owns);
+            return new ExcelSheetReader(sheet.Name!, wsPart, _sst, _styles, _opt, _dateSystem, _owns);
+        }
+
+        private static ExcelDateSystem GetWorkbookDateSystem(SpreadsheetDocument document) {
+            return document.WorkbookPart?.Workbook?.GetFirstChild<WorkbookProperties>()?.Date1904?.Value == true
+                ? ExcelDateSystem.NineteenFour
+                : ExcelDateSystem.NineteenHundred;
         }
 
         private bool TryGetSheetByNameXmlFast(string name, out string sheetName, out WorksheetPart worksheetPart) {

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.Conversion.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.Conversion.cs
@@ -125,7 +125,7 @@ namespace OfficeIMO.Excel {
                 if (styleIndex is not null && Styles.IsDateLike(styleIndex.Value)) {
                     if ((TryParseInvariantDoubleFast(rawText, out var oa)
                             || double.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out oa))
-                        && ReturnBindingConversion(TryConvertDateTimeForBinding(DateTime.FromOADate(oa), binding, out converted), binding, converted)) {
+                        && ReturnBindingConversion(TryConvertDateTimeForBinding(FromExcelSerialDate(oa), binding, out converted), binding, converted)) {
                         return true;
                     }
 
@@ -228,7 +228,7 @@ namespace OfficeIMO.Excel {
                 && Styles.IsDateLike(raw.StyleIndex.Value)) {
                 if (TryParseInvariantDoubleFast(raw.RawText, out var oa)
                     || double.TryParse(raw.RawText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out oa)) {
-                    return TryConvertDateTimeForBinding(DateTime.FromOADate(oa), binding, out converted);
+                    return TryConvertDateTimeForBinding(FromExcelSerialDate(oa), binding, out converted);
                 }
 
                 return TryConvertStringForBinding(raw.RawText, binding, out converted);
@@ -370,7 +370,7 @@ namespace OfficeIMO.Excel {
                 && Styles.IsDateLike(raw.StyleIndex.Value)) {
                 if (TryParseInvariantDoubleFast(raw.RawText, out var oa)
                     || double.TryParse(raw.RawText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out oa)) {
-                    DateTime dateValue = DateTime.FromOADate(oa);
+                    DateTime dateValue = FromExcelSerialDate(oa);
                     if (binding.SetDateTime != null && binding.BindingKind == TypedBindingKind.DateTime) {
                         binding.SetDateTime(target, dateValue);
                         return true;

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.XmlRows.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Objects.XmlRows.cs
@@ -406,7 +406,7 @@ namespace OfficeIMO.Excel {
                 && Styles.IsDateLike(styleIndex.Value)) {
                 if (TryParseInvariantDoubleFast(rawText, out var oa)
                     || double.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out oa)) {
-                    DateTime dateValue = DateTime.FromOADate(oa);
+                    DateTime dateValue = FromExcelSerialDate(oa);
                     if (binding.SetDateTime != null && binding.BindingKind == TypedBindingKind.DateTime) {
                         binding.SetDateTime(target, dateValue);
                         return true;

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.XmlValues.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.XmlValues.cs
@@ -145,7 +145,7 @@ namespace OfficeIMO.Excel {
             if (useDateStyle
                 && (TryParseInvariantDoubleFast(rawText, out double oa)
                     || double.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out oa))) {
-                return DateTime.FromOADate(oa);
+                return FromExcelSerialDate(oa);
             }
 
             if (numericAsDecimal
@@ -192,7 +192,7 @@ namespace OfficeIMO.Excel {
                             if (useDateStyle
                                 && (TryParseInvariantDoubleFast(rawText, out double oa)
                                     || double.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out oa))) {
-                                return DateTime.FromOADate(oa);
+                                return FromExcelSerialDate(oa);
                             }
 
                             if (rawText == null) {
@@ -250,7 +250,7 @@ namespace OfficeIMO.Excel {
             if (useDateStyle
                 && (TryParseInvariantDoubleFast(rawText, out double oaValue)
                     || double.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out oaValue))) {
-                return DateTime.FromOADate(oaValue);
+                return FromExcelSerialDate(oaValue);
             }
 
             if (numericAsDecimal
@@ -298,7 +298,7 @@ namespace OfficeIMO.Excel {
             if (useDateStyle
                 && (TryParseInvariantDoubleFast(rawText, out double oa)
                     || double.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out oa))) {
-                value = DateTime.FromOADate(oa);
+                value = FromExcelSerialDate(oa);
                 return true;
             }
 

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.cs
@@ -17,6 +17,7 @@ namespace OfficeIMO.Excel {
         private readonly SharedStringCache _sst;
         private readonly StylesCacheProvider _styles;
         private readonly ExcelReadOptions _opt;
+        private readonly ExcelDateSystem _dateSystem;
         private readonly bool _canStreamWorksheetPart;
         private StylesCache? _stylesCache;
         private List<string>? _sharedStringItems;
@@ -26,14 +27,17 @@ namespace OfficeIMO.Excel {
         private bool _lastDateStyleAttributeResult;
         private static readonly XmlReaderSettings WorksheetXmlReaderSettings = CreateWorksheetXmlReaderSettings();
 
-        internal ExcelSheetReader(string sheetName, WorksheetPart wsPart, SharedStringCache sst, StylesCacheProvider styles, ExcelReadOptions opt, bool canStreamWorksheetPart) {
+        internal ExcelSheetReader(string sheetName, WorksheetPart wsPart, SharedStringCache sst, StylesCacheProvider styles, ExcelReadOptions opt, ExcelDateSystem dateSystem, bool canStreamWorksheetPart) {
             _sheetName = sheetName;
             _wsPart = wsPart;
             _sst = sst;
             _styles = styles;
             _opt = opt;
+            _dateSystem = dateSystem;
             _canStreamWorksheetPart = canStreamWorksheetPart;
         }
+
+        private DateTime FromExcelSerialDate(double serial) => ExcelDateSystemConverter.FromSerial(serial, _dateSystem);
 
         private StylesCache Styles => _stylesCache ??= _styles.Value;
 
@@ -503,7 +507,7 @@ namespace OfficeIMO.Excel {
             if (_opt.TreatDatesUsingNumberFormat && styleIndex is not null && Styles.IsDateLike(styleIndex.Value)) {
                 if (TryParseInvariantDoubleFast(rawText, out var oa)
                     || double.TryParse(rawText, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out oa)) {
-                    value = DateTime.FromOADate(oa);
+                    value = FromExcelSerialDate(oa);
                 } else {
                     value = rawText;
                 }
@@ -842,7 +846,7 @@ namespace OfficeIMO.Excel {
                 if (_opt.TreatDatesUsingNumberFormat && styleIndex is not null && Styles.IsDateLike(styleIndex.Value)) {
                     if (TryParseInvariantDoubleFast(rawText, out var oa)
                         || double.TryParse(rawText, System.Globalization.NumberStyles.Float | System.Globalization.NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out oa))
-                        return System.DateTime.FromOADate(oa);
+                        return FromExcelSerialDate(oa);
                 }
                 if (_opt.NumericAsDecimal) {
                     if (TryParseRawDecimal(rawText, out var dec))
@@ -873,7 +877,7 @@ namespace OfficeIMO.Excel {
                 if (_opt.TreatDatesUsingNumberFormat && styleIndex is not null && Styles.IsDateLike(styleIndex.Value)) {
                     if (TryParseInvariantDoubleFast(rawText, out var oa)
                         || double.TryParse(rawText, System.Globalization.NumberStyles.Float | System.Globalization.NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out oa))
-                        return System.DateTime.FromOADate(oa);
+                        return FromExcelSerialDate(oa);
                     return rawText;
                 }
 

--- a/OfficeIMO.Tests/Excel.AutoFit.cs
+++ b/OfficeIMO.Tests/Excel.AutoFit.cs
@@ -97,6 +97,80 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_SetRowLayout_AppliesHeightHiddenAndCellStyles() {
+            string filePath = Path.Combine(_directoryWithFiles, "RowLayout.Basic.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValues(new[] {
+                    (1, 1, (object)"Name"),
+                    (1, 2, (object)"Notes"),
+                    (2, 1, (object)"Alice"),
+                    (2, 2, (object)"Long line that should wrap")
+                });
+
+                sheet.SetRowLayout(2, new ExcelRowLayoutOptions {
+                    Height = 32,
+                    Hidden = true,
+                    Bold = true,
+                    WrapText = true,
+                    FirstColumn = 1,
+                    LastColumn = 2
+                });
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                Row row2 = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex != null && r.RowIndex.Value == 2);
+                Assert.True(row2.CustomHeight?.Value ?? false);
+                Assert.Equal(32D, row2.Height!.Value);
+                Assert.True(row2.Hidden?.Value ?? false);
+
+                var workbookPart = spreadsheet.WorkbookPart!;
+                var stylesheet = workbookPart.WorkbookStylesPart!.Stylesheet;
+                Cell cell = row2.Elements<Cell>().First(c => c.CellReference?.Value == "B2");
+                CellFormat format = stylesheet.CellFormats!.Elements<CellFormat>().ElementAt((int)cell.StyleIndex!.Value);
+                Font font = stylesheet.Fonts!.Elements<Font>().ElementAt((int)format.FontId!.Value);
+                Assert.NotNull(font.Bold);
+                Assert.True(format.Alignment?.WrapText?.Value ?? false);
+            }
+        }
+
+        [Fact]
+        public void Test_SetRowLayout_ClearsHeightAndWrapText() {
+            string filePath = Path.Combine(_directoryWithFiles, "RowLayout.Clear.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Line 1\nLine 2");
+                sheet.SetRowLayout(1, new ExcelRowLayoutOptions {
+                    Height = 28,
+                    WrapText = true,
+                    FirstColumn = 1,
+                    LastColumn = 1
+                });
+                sheet.SetRowLayout(1, new ExcelRowLayoutOptions {
+                    ClearHeight = true,
+                    WrapText = false,
+                    FirstColumn = 1,
+                    LastColumn = 1
+                });
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                Row row1 = wsPart.Worksheet.Descendants<Row>().First(r => r.RowIndex != null && r.RowIndex.Value == 1);
+                Assert.False(row1.CustomHeight?.Value ?? false);
+                Assert.False(row1.Height?.HasValue ?? false);
+
+                var stylesheet = spreadsheet.WorkbookPart!.WorkbookStylesPart!.Stylesheet;
+                Cell cell = row1.Elements<Cell>().First(c => c.CellReference?.Value == "A1");
+                CellFormat format = stylesheet.CellFormats!.Elements<CellFormat>().ElementAt((int)cell.StyleIndex!.Value);
+                Assert.False(format.Alignment?.WrapText?.Value ?? false);
+            }
+        }
+
+        [Fact]
         public void Test_AutoFitColumns_RemovesCustomWidthWhenCleared() {
             string filePath = Path.Combine(_directoryWithFiles, "AutoFit.ClearColumn.xlsx");
             using (var document = ExcelDocument.Create(filePath)) {

--- a/OfficeIMO.Tests/Excel.Charts.cs
+++ b/OfficeIMO.Tests/Excel.Charts.cs
@@ -116,6 +116,36 @@ namespace OfficeIMO.Tests {
             }
         }
 
+        [Fact]
+        public void Test_ExcelCharts_DataPointStyling_WritesPointOverride() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelCharts.DataPointStyle.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Summary");
+                var data = new ExcelChartData(
+                    new[] { "Q1", "Q2", "Q3" },
+                    new[] {
+                        new ExcelChartSeries("Sales", new[] { 10d, 20d, 15d })
+                    });
+
+                ExcelChart chart = sheet.AddChart(data, row: 1, column: 6, widthPixels: 480, heightPixels: 320,
+                    type: ExcelChartType.ColumnClustered, title: "Quarterly");
+
+                chart.SetDataPointColor("Sales", pointIndex: 1, fillColor: "#C00000", lineColor: "#7030A0", lineWidthPoints: 1.25);
+                document.Save();
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = GetWorksheetPartWithCharts(spreadsheet);
+                ChartPart chartPart = wsPart.DrawingsPart!.ChartParts.Single();
+                C.DataPoint point = chartPart.ChartSpace!.Descendants<C.DataPoint>().Single();
+                Assert.Equal(1U, point.GetFirstChild<C.Index>()!.Val!.Value);
+                Assert.Contains(point.Descendants<A.RgbColorModelHex>(), color => color.Val!.Value == "C00000");
+                Assert.Contains(point.Descendants<A.RgbColorModelHex>(), color => color.Val!.Value == "7030A0");
+                Assert.Equal(15875, point.Descendants<A.Outline>().Single().Width!.Value);
+            }
+        }
+
         private sealed class ChartProjectionRow {
             public ChartProjectionRow(string category, double value) {
                 Category = category;

--- a/OfficeIMO.Tests/Excel.ClosedXmlGapFeatures.cs
+++ b/OfficeIMO.Tests/Excel.ClosedXmlGapFeatures.cs
@@ -139,6 +139,89 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ClosedXmlGap_GradientFills_AreReusableCellAndRangeStyles() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.GradientFills.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.CellAt(1, 1).SetValue("Single").SetGradientFill("#FF0000", "#00FF00", 45);
+                sheet.Range("B1:C1").SetGradientFill("112233", "445566", 90);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorkbookStylesPart stylesPart = spreadsheet.WorkbookPart!.WorkbookStylesPart!;
+                Stylesheet stylesheet = stylesPart.Stylesheet!;
+                WorksheetPart worksheetPart = spreadsheet.WorkbookPart.WorksheetParts.First();
+                Dictionary<string, Cell> cells = worksheetPart.Worksheet.Descendants<Cell>()
+                    .Where(cell => cell.CellReference?.Value != null)
+                    .ToDictionary(cell => cell.CellReference!.Value!);
+
+                Fill singleFill = GetCellFill(stylesheet, cells["A1"]);
+                AssertGradientFill(singleFill, "FFFF0000", "FF00FF00", 45D);
+
+                uint rangeStyleIndex = cells["B1"].StyleIndex!.Value;
+                Assert.Equal(rangeStyleIndex, cells["C1"].StyleIndex!.Value);
+                Fill rangeFill = GetCellFill(stylesheet, cells["B1"]);
+                AssertGradientFill(rangeFill, "FF112233", "FF445566", 90D);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+
+            static Fill GetCellFill(Stylesheet stylesheet, Cell cell) {
+                CellFormat format = stylesheet.CellFormats!.Elements<CellFormat>().ElementAt((int)cell.StyleIndex!.Value);
+                Assert.True(format.ApplyFill?.Value);
+                return stylesheet.Fills!.Elements<Fill>().ElementAt((int)format.FillId!.Value);
+            }
+
+            static void AssertGradientFill(Fill fill, string expectedStart, string expectedEnd, double expectedDegree) {
+                GradientFill gradient = fill.GradientFill!;
+                Assert.NotNull(gradient);
+                Assert.Equal(GradientValues.Linear, gradient.Type!.Value);
+                Assert.Equal(expectedDegree, gradient.Degree!.Value);
+
+                List<GradientStop> stops = gradient.Elements<GradientStop>().ToList();
+                Assert.Equal(2, stops.Count);
+                Assert.Equal(0D, stops[0].Position!.Value);
+                Assert.Equal(expectedStart, stops[0].Color!.Rgb!.Value);
+                Assert.Equal(1D, stops[1].Position!.Value);
+                Assert.Equal(expectedEnd, stops[1].Color!.Rgb!.Value);
+            }
+        }
+
+        [Fact]
+        public void Test_ClosedXmlGap_HeaderColumnRanges_TargetWorksheetAndTableDataColumns() {
+            string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.HeaderColumnRanges.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Region");
+                sheet.CellValue(1, 2, "Sales Amount");
+                sheet.CellValue(2, 1, "NA");
+                sheet.CellValue(2, 2, 100);
+                sheet.CellValue(3, 1, "EMEA");
+                sheet.CellValue(3, 2, 200);
+                sheet.AddTable("A1:B3", hasHeader: true, name: "SalesTable", style: ExcelTableStyle.TableStyleMedium2);
+
+                Assert.Equal("B2:B3", sheet.GetColumnRangeByHeader("Sales Amount"));
+                Assert.Equal("B1:B3", sheet.GetColumnRangeByHeader("Sales Amount", includeHeader: true));
+                Assert.Equal("B2:B3", sheet.GetColumnRangeByHeader("Sales   Amount", tableName: "SalesTable"));
+
+                ExcelRange tableColumn = sheet.Table("SalesTable").Column("sales amount");
+                Assert.Equal("B2:B3", tableColumn.Address);
+
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+                Assert.Equal("B2:B3", document["Data"].GetColumnRangeByHeader("Sales Amount", tableName: "SalesTable"));
+            }
+        }
+
+        [Fact]
         public void Test_ClosedXmlGap_CalculationPolicy_EvaluatesSupportedFormulasBeforeSave() {
             string filePath = Path.Combine(_directoryWithFiles, "ClosedXmlGap.Calculation.xlsx");
 
@@ -984,18 +1067,17 @@ namespace OfficeIMO.Tests {
                 ExcelFeatureReport report = document.InspectFeatures();
 
                 ExcelFeatureFinding slicers = Assert.Single(report.FindFeatures("Slicers"));
-                Assert.Equal(ExcelFeatureSupportLevel.Preserved, slicers.SupportLevel);
+                Assert.Equal(ExcelFeatureSupportLevel.PartiallyEditable, slicers.SupportLevel);
                 Assert.Equal(1, slicers.Count);
                 Assert.Contains(slicers.Details, detail => detail.Contains("slicerCache", StringComparison.OrdinalIgnoreCase));
 
                 ExcelFeatureFinding timelines = Assert.Single(report.FindFeatures("Timelines"));
-                Assert.Equal(ExcelFeatureSupportLevel.Preserved, timelines.SupportLevel);
+                Assert.Equal(ExcelFeatureSupportLevel.PartiallyEditable, timelines.SupportLevel);
                 Assert.Equal(1, timelines.Count);
                 Assert.Contains(timelines.Details, detail => detail.Contains("timelineCache", StringComparison.OrdinalIgnoreCase));
 
-                InvalidOperationException advancedException = Assert.Throws<InvalidOperationException>(() => report.EnsureNoAdvancedFeatures());
-                Assert.Contains("Slicers", advancedException.Message);
-                Assert.Contains("Timelines", advancedException.Message);
+                Assert.Same(report, report.EnsureNoAdvancedFeatures());
+                Assert.Same(report, report.EnsureCan(ExcelPreflightCapability.EditWorkbookStructure));
             }
         }
 
@@ -1105,9 +1187,9 @@ namespace OfficeIMO.Tests {
 
             using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
                 ExcelFeatureReport report = document.InspectFeatures();
-                Assert.Contains(report.PreservedFeatures, feature => feature.Name == "Slicers"
+                Assert.Contains(report.PartiallyEditableFeatures, feature => feature.Name == "Slicers"
                     && feature.Details.Any(detail => detail.Contains("slicerCache", StringComparison.OrdinalIgnoreCase)));
-                Assert.Contains(report.PreservedFeatures, feature => feature.Name == "Timelines"
+                Assert.Contains(report.PartiallyEditableFeatures, feature => feature.Name == "Timelines"
                     && feature.Details.Any(detail => detail.Contains("timelineCache", StringComparison.OrdinalIgnoreCase)));
             }
         }

--- a/OfficeIMO.Tests/Excel.ConditionalFormatting.cs
+++ b/OfficeIMO.Tests/Excel.ConditionalFormatting.cs
@@ -82,6 +82,54 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_AdditionalConditionalFormattingRuleTypes() {
+            string filePath = Path.Combine(_directoryWithFiles, "ConditionalAdditionalRuleTypes.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Ready");
+                sheet.CellValue(2, 1, "Blocked");
+                sheet.CellValue(3, 1, "Ready");
+                sheet.CellValue(1, 2, 1d);
+                sheet.CellValue(2, 2, 2d);
+                sheet.CellValue(3, 2, 3d);
+                sheet.CellValue(1, 3, new System.DateTime(2026, 6, 22));
+                sheet.CellValue(2, 3, new System.DateTime(2026, 6, 21));
+
+                sheet.AddConditionalUniqueValuesRule("A1:A3");
+                sheet.AddConditionalTextRule("A1:A3", ConditionalFormatValues.ContainsText, "Ready");
+                sheet.AddConditionalBlanksRule("D1:D3");
+                sheet.AddConditionalErrorsRule("E1:E3", containsErrors: false);
+                sheet.AddConditionalAboveAverageRule("B1:B3", aboveAverage: false, equalAverage: true, standardDeviation: 1);
+                sheet.AddConditionalTimePeriodRule("C1:C3", TimePeriodValues.Today);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                var rules = wsPart.Worksheet.Elements<ConditionalFormatting>()
+                    .SelectMany(cf => cf.Elements<ConditionalFormattingRule>())
+                    .ToList();
+                Assert.Contains(rules, rule => rule.Type?.Value == ConditionalFormatValues.UniqueValues);
+                Assert.Contains(rules, rule => rule.Type?.Value == ConditionalFormatValues.ContainsText && rule.Text?.Value == "Ready");
+                Assert.Contains(rules, rule => rule.Type?.Value == ConditionalFormatValues.ContainsBlanks);
+                Assert.Contains(rules, rule => rule.Type?.Value == ConditionalFormatValues.NotContainsErrors);
+                Assert.Contains(rules, rule => rule.Type?.Value == ConditionalFormatValues.AboveAverage && rule.AboveAverage?.Value == false && rule.EqualAverage?.Value == true && rule.StdDev?.Value == 1);
+                Assert.Contains(rules, rule => rule.Type?.Value == ConditionalFormatValues.TimePeriod && rule.TimePeriod?.Value == TimePeriodValues.Today);
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                var rules = document.Sheets[0].GetConditionalFormattingRules();
+                Assert.Contains(rules, info => info.Type == "UniqueValues");
+                Assert.Contains(rules, info => info.Type == "ContainsText" && info.Formulas.Count == 1);
+                Assert.Contains(rules, info => info.Type == "ContainsBlanks");
+                Assert.Contains(rules, info => info.Type == "NotContainsErrors");
+                Assert.Contains(rules, info => info.Type == "AboveAverage");
+                Assert.Contains(rules, info => info.Type == "TimePeriod");
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
         public void Test_AddConditionalColorScale() {
             string filePath = Path.Combine(_directoryWithFiles, "ConditionalColorScale.xlsx");
             using (var document = ExcelDocument.Create(filePath)) {

--- a/OfficeIMO.Tests/Excel.CreateStream.cs
+++ b/OfficeIMO.Tests/Excel.CreateStream.cs
@@ -77,6 +77,34 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ThemeEdit_LoadedPathWithAutoSaveFalse_DoesNotWriteUntilSaved() {
+            string filePath = Path.Combine(_directoryWithFiles, "ThemeAutoSaveFalse.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Data");
+                document.SetWorkbookThemeName("Original Theme");
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath, autoSave: false)) {
+                document.SetWorkbookThemeName("Unsaved Theme");
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Equal("Original Theme", document.GetWorkbookTheme().Name);
+            }
+
+            using (var document = ExcelDocument.Load(filePath, autoSave: false)) {
+                document.SetWorkbookThemeName("Saved Theme");
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Equal("Saved Theme", document.GetWorkbookTheme().Name);
+            }
+        }
+
+        [Fact]
         public void Create_ToMemoryStream_WithTableAutoFitAndDate_WritesReadablePackage() {
             var rows = new[] {
                 new StreamSalesRow(1, "North", new DateTime(2024, 1, 2), 123.45d),

--- a/OfficeIMO.Tests/Excel.CreateStream.cs
+++ b/OfficeIMO.Tests/Excel.CreateStream.cs
@@ -62,6 +62,21 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Save_LoadedStreamAfterThemeEdit_WritesEditedTheme() {
+            byte[] originalBytes = CreateStreamSaveWorkbookBytes();
+
+            using var input = new MemoryStream(originalBytes, writable: false);
+            using var output = new MemoryStream();
+            using (var document = ExcelDocument.Load(input)) {
+                document.SetWorkbookThemeName("Stream Theme");
+                document.Save(output);
+            }
+
+            using var reloaded = ExcelDocument.Load(new MemoryStream(output.ToArray()), readOnly: true);
+            Assert.Equal("Stream Theme", reloaded.GetWorkbookTheme().Name);
+        }
+
+        [Fact]
         public void Create_ToMemoryStream_WithTableAutoFitAndDate_WritesReadablePackage() {
             var rows = new[] {
                 new StreamSalesRow(1, "North", new DateTime(2024, 1, 2), 123.45d),

--- a/OfficeIMO.Tests/Excel.CustomDocumentProperties.cs
+++ b/OfficeIMO.Tests/Excel.CustomDocumentProperties.cs
@@ -104,5 +104,26 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("Reviewed", document.CustomDocumentProperties["Workflow"].Text);
             }
         }
+
+        [Fact]
+        public void Test_ExcelCustomDocumentProperties_DirectValueEditsAreTracked() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelCustomDocumentProperties.DirectValueEdit.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Data").CellValue(1, 1, "Ready");
+                document.SetCustomDocumentProperty("Workflow", "Draft");
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                document.CustomDocumentProperties["Workflow"].Value = "Reviewed";
+                document.CustomDocumentProperties["Workflow"].PropertyType = ExcelCustomPropertyType.Text;
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Equal("Reviewed", document.CustomDocumentProperties["Workflow"].Text);
+            }
+        }
     }
 }

--- a/OfficeIMO.Tests/Excel.CustomDocumentProperties.cs
+++ b/OfficeIMO.Tests/Excel.CustomDocumentProperties.cs
@@ -47,9 +47,11 @@ namespace OfficeIMO.Tests {
         public void Test_ExcelCustomDocumentProperties_PreserveNumericCompatibilityTypes() {
             string filePath = Path.Combine(_directoryWithFiles, "ExcelCustomDocumentProperties.NumericCompatibility.xlsx");
             long largeTicket = (long)int.MaxValue + 42L;
+            ulong unsignedTicket = ulong.MaxValue;
 
             using (var document = ExcelDocument.Create(filePath)) {
                 document.SetCustomDocumentProperty("LargeTicket", largeTicket);
+                document.SetCustomDocumentProperty("UnsignedTicket", unsignedTicket);
                 document.SetCustomDocumentProperty("Score", 12345.6789012345D);
                 document.SetCustomDocumentProperty("Reviewed", true);
                 document.AddWorkSheet("Data").CellValue(1, 1, "Ready");
@@ -65,6 +67,7 @@ namespace OfficeIMO.Tests {
 
             using (var document = ExcelDocument.Load(filePath, readOnly: false)) {
                 Assert.Equal(largeTicket, document.CustomDocumentProperties["LargeTicket"].Value);
+                Assert.Equal(unsignedTicket, document.CustomDocumentProperties["UnsignedTicket"].Value);
                 Assert.True(document.CustomDocumentProperties["Reviewed"].Bool);
                 document.Save();
             }
@@ -72,9 +75,12 @@ namespace OfficeIMO.Tests {
             using (SpreadsheetDocument package = SpreadsheetDocument.Open(filePath, false)) {
                 CustomFilePropertiesPart customPart = package.CustomFilePropertiesPart!;
                 CustomDocumentProperty large = customPart.Properties!.Elements<CustomDocumentProperty>().First(property => property.Name == "LargeTicket");
+                CustomDocumentProperty unsigned = customPart.Properties!.Elements<CustomDocumentProperty>().First(property => property.Name == "UnsignedTicket");
                 CustomDocumentProperty score = customPart.Properties!.Elements<CustomDocumentProperty>().First(property => property.Name == "Score");
                 Assert.NotNull(large.VTInt64);
                 Assert.Equal(largeTicket.ToString(System.Globalization.CultureInfo.InvariantCulture), large.VTInt64!.Text);
+                Assert.NotNull(unsigned.VTUnsignedInt64);
+                Assert.Equal(unsignedTicket.ToString(System.Globalization.CultureInfo.InvariantCulture), unsigned.VTUnsignedInt64!.Text);
                 Assert.NotNull(score.VTDouble);
             }
         }

--- a/OfficeIMO.Tests/Excel.CustomDocumentProperties.cs
+++ b/OfficeIMO.Tests/Excel.CustomDocumentProperties.cs
@@ -125,5 +125,19 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("Reviewed", document.CustomDocumentProperties["Workflow"].Text);
             }
         }
+
+        [Fact]
+        public void Test_ExcelCustomDocumentProperties_DirectDictionaryAccessValidatesKeys() {
+            using var document = ExcelDocument.Create(new MemoryStream(), autoSave: false);
+
+            Assert.Throws<ArgumentException>(() => document.CustomDocumentProperties[" "] = new ExcelCustomProperty("Invalid"));
+            Assert.Throws<ArgumentException>(() => document.CustomDocumentProperties.Add("\t", new ExcelCustomProperty("Invalid")));
+
+            document.CustomDocumentProperties[" Workflow "] = new ExcelCustomProperty("Ready");
+
+            Assert.True(document.CustomDocumentProperties.ContainsKey("Workflow"));
+            Assert.True(document.CustomDocumentProperties.ContainsKey(" Workflow "));
+            Assert.Equal("Ready", document.CustomDocumentProperties["Workflow"].Text);
+        }
     }
 }

--- a/OfficeIMO.Tests/Excel.CustomDocumentProperties.cs
+++ b/OfficeIMO.Tests/Excel.CustomDocumentProperties.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Data;
 using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.CustomProperties;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.VariantTypes;
 using OfficeIMO.Excel;
 using Xunit;
 
@@ -35,6 +40,62 @@ namespace OfficeIMO.Tests {
             using (var document = ExcelDocument.Load(filePath)) {
                 Assert.Equal("Published", document.CustomDocumentProperties["ReleaseStatus"].Text);
                 Assert.False(document.CustomDocumentProperties.ContainsKey("Ticket"));
+            }
+        }
+
+        [Fact]
+        public void Test_ExcelCustomDocumentProperties_PreserveNumericCompatibilityTypes() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelCustomDocumentProperties.NumericCompatibility.xlsx");
+            long largeTicket = (long)int.MaxValue + 42L;
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.SetCustomDocumentProperty("LargeTicket", largeTicket);
+                document.SetCustomDocumentProperty("Score", 12345.6789012345D);
+                document.SetCustomDocumentProperty("Reviewed", true);
+                document.AddWorkSheet("Data").CellValue(1, 1, "Ready");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument package = SpreadsheetDocument.Open(filePath, true)) {
+                CustomFilePropertiesPart customPart = package.CustomFilePropertiesPart!;
+                CustomDocumentProperty reviewed = customPart.Properties!.Elements<CustomDocumentProperty>().First(property => property.Name == "Reviewed");
+                reviewed.VTBool = new VTBool("1");
+                customPart.Properties.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: false)) {
+                Assert.Equal(largeTicket, document.CustomDocumentProperties["LargeTicket"].Value);
+                Assert.True(document.CustomDocumentProperties["Reviewed"].Bool);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument package = SpreadsheetDocument.Open(filePath, false)) {
+                CustomFilePropertiesPart customPart = package.CustomFilePropertiesPart!;
+                CustomDocumentProperty large = customPart.Properties!.Elements<CustomDocumentProperty>().First(property => property.Name == "LargeTicket");
+                CustomDocumentProperty score = customPart.Properties!.Elements<CustomDocumentProperty>().First(property => property.Name == "Score");
+                Assert.NotNull(large.VTInt64);
+                Assert.Equal(largeTicket.ToString(System.Globalization.CultureInfo.InvariantCulture), large.VTInt64!.Text);
+                Assert.NotNull(score.VTDouble);
+            }
+        }
+
+        [Fact]
+        public void Test_ExcelCustomDocumentProperties_DisqualifyDirectDataSetFastSave() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelCustomDocumentProperties.DirectDataSet.xlsx");
+            var data = new DataTable("Data");
+            data.Columns.Add("Name", typeof(string));
+            data.Rows.Add("Alpha");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var dataSet = new DataSet();
+                dataSet.Tables.Add(data);
+                document.InsertDataSet(dataSet);
+                document.SetCustomDocumentProperty("Workflow", "Reviewed");
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Equal("Reviewed", document.CustomDocumentProperties["Workflow"].Text);
             }
         }
     }

--- a/OfficeIMO.Tests/Excel.CustomDocumentProperties.cs
+++ b/OfficeIMO.Tests/Excel.CustomDocumentProperties.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_ExcelCustomDocumentProperties_RoundTripTypedValues() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelCustomDocumentProperties.xlsx");
+            DateTime reviewedAt = new DateTime(2026, 6, 22, 8, 30, 0, DateTimeKind.Utc);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.SetCustomDocumentProperty("ReleaseStatus", "Approved");
+                document.SetCustomDocumentProperty("Ticket", 42);
+                document.SetCustomDocumentProperty("Score", 98.5D);
+                document.SetCustomDocumentProperty("Reviewed", true);
+                document.SetCustomDocumentProperty("ReviewedAt", reviewedAt);
+                document.AddWorkSheet("Data").CellValue(1, 1, "Ready");
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                Assert.Equal("Approved", document.CustomDocumentProperties["ReleaseStatus"].Text);
+                Assert.Equal(42, document.CustomDocumentProperties["Ticket"].NumberInteger);
+                Assert.Equal(98.5D, document.CustomDocumentProperties["Score"].NumberDouble);
+                Assert.True(document.CustomDocumentProperties["Reviewed"].Bool);
+                Assert.Equal(reviewedAt, document.CustomDocumentProperties["ReviewedAt"].Date);
+
+                document.SetCustomDocumentProperty("ReleaseStatus", "Published");
+                Assert.True(document.RemoveCustomDocumentProperty("Ticket"));
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                Assert.Equal("Published", document.CustomDocumentProperties["ReleaseStatus"].Text);
+                Assert.False(document.CustomDocumentProperties.ContainsKey("Ticket"));
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.DashboardCharts.cs
+++ b/OfficeIMO.Tests/Excel.DashboardCharts.cs
@@ -71,5 +71,25 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("Revenue", chart.Title);
             }
         }
+
+        [Fact]
+        public void Test_DashboardBuilder_ReturnsActualSanitizedTableName() {
+            string filePath = Path.Combine(_directoryWithFiles, "DashboardBuilderResolvedTableName.xlsx");
+            var data = new DataTable("Sales Data");
+            data.Columns.Add("Region", typeof(string));
+            data.Columns.Add("Revenue", typeof(int));
+            data.Rows.Add("EU", 100);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Dashboard");
+                ExcelDashboardResult result = sheet.AddDashboard(data, new ExcelDashboardOptions {
+                    TableName = "Sales Data",
+                    AddChart = false
+                });
+
+                Assert.Equal("Sales_Data", result.TableName);
+                Assert.Equal(result.TableRange, sheet.GetTableRange(result.TableName!));
+            }
+        }
     }
 }

--- a/OfficeIMO.Tests/Excel.DashboardCharts.cs
+++ b/OfficeIMO.Tests/Excel.DashboardCharts.cs
@@ -91,5 +91,27 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(result.TableRange, sheet.GetTableRange(result.TableName!));
             }
         }
+
+        [Fact]
+        public void Test_DashboardBuilder_RejectsWorksheetBoundsOverflow() {
+            string filePath = Path.Combine(_directoryWithFiles, "DashboardBuilder.Bounds.xlsx");
+            var data = new DataTable("Sales");
+            data.Columns.Add("Region", typeof(string));
+            data.Columns.Add("Revenue", typeof(int));
+            data.Rows.Add("EU", 100);
+
+            using var document = ExcelDocument.Create(filePath);
+            ExcelSheet sheet = document.AddWorkSheet("Dashboard");
+
+            Assert.Throws<ArgumentException>(() => sheet.AddDashboard(data, new ExcelDashboardOptions {
+                TableRow = A1.MaxRows,
+                AddChart = false
+            }));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => sheet.AddDashboard(data, new ExcelDashboardOptions {
+                TableRow = 3,
+                ChartColumn = A1.MaxColumns + 1
+            }));
+        }
     }
 }

--- a/OfficeIMO.Tests/Excel.DashboardCharts.cs
+++ b/OfficeIMO.Tests/Excel.DashboardCharts.cs
@@ -1,0 +1,75 @@
+using System.Data;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_DashboardChartPreset_CreatesStyledChartFromRange() {
+            string filePath = Path.Combine(_directoryWithFiles, "DashboardChartPreset.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Dashboard");
+                sheet.CellValue(1, 1, "Region");
+                sheet.CellValue(1, 2, "Revenue");
+                sheet.CellValue(2, 1, "EU");
+                sheet.CellValue(2, 2, 100);
+                sheet.CellValue(3, 1, "US");
+                sheet.CellValue(3, 2, 120);
+
+                ExcelChart chart = sheet.AddDashboardChart(new ExcelDashboardChartOptions {
+                    Preset = ExcelDashboardChartPreset.CompactComparison,
+                    Range = "A1:B3",
+                    Row = 1,
+                    Column = 4,
+                    Title = "Revenue"
+                });
+
+                Assert.Equal(ExcelChartType.BarClustered, chart.ChartType);
+                Assert.Equal("Revenue", chart.Title);
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelChart chart = Assert.Single(document["Dashboard"].Charts);
+                Assert.Equal(ExcelChartType.BarClustered, chart.ChartType);
+                Assert.Equal("Revenue", chart.Title);
+            }
+        }
+
+        [Fact]
+        public void Test_DashboardBuilder_CreatesTableAndChart() {
+            string filePath = Path.Combine(_directoryWithFiles, "DashboardBuilder.xlsx");
+            var data = new DataTable("Sales");
+            data.Columns.Add("Region", typeof(string));
+            data.Columns.Add("Revenue", typeof(int));
+            data.Rows.Add("EU", 100);
+            data.Rows.Add("US", 120);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Dashboard");
+                ExcelDashboardResult result = sheet.AddDashboard(data, new ExcelDashboardOptions {
+                    Title = "Sales Dashboard",
+                    Subtitle = "Monthly revenue",
+                    TableName = "SalesTable",
+                    ChartPreset = ExcelDashboardChartPreset.CompactComparison,
+                    ChartTitle = "Revenue"
+                });
+
+                Assert.Equal("A3:B5", result.TableRange);
+                Assert.Equal("SalesTable", result.TableName);
+                Assert.NotNull(result.Chart);
+                Assert.Equal(ExcelChartType.BarClustered, result.Chart!.ChartType);
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelSheet sheet = document["Dashboard"];
+                Assert.True(sheet.TryGetCellText(1, 1, out string? title));
+                Assert.Equal("Sales Dashboard", title);
+                ExcelChart chart = Assert.Single(sheet.Charts);
+                Assert.Equal("Revenue", chart.Title);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.DateSystem.cs
+++ b/OfficeIMO.Tests/Excel.DateSystem.cs
@@ -78,6 +78,41 @@ namespace OfficeIMO.Tests {
             Assert.Equal(Expected1904Serial(date), double.Parse(serialText, CultureInfo.InvariantCulture), 6);
         }
 
+        [Fact]
+        public void DateSystem_ChangingExistingWorkbook_ConvertsDateStyledSerials() {
+            string filePath = Path.Combine(_directoryWithFiles, "DateSystemChangeConvertsSerials.xlsx");
+            var date = new DateTime(2024, 3, 4);
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    ExcelSheet sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, date);
+                    document.Save();
+                }
+
+                using (var document = ExcelDocument.Load(filePath)) {
+                    document.DateSystem = ExcelDateSystem.NineteenFour;
+                    document.Save();
+                }
+
+                using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                    AssertWorkbookUses1904DateSystem(spreadsheet);
+                    WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                    string serialText = GetCellValueText(worksheetPart, "A1");
+                    Assert.Equal(Expected1904Serial(date), double.Parse(serialText, CultureInfo.InvariantCulture), 6);
+                }
+
+                using (var reader = ExcelDocumentReader.Open(filePath, new ExcelReadOptions { TreatDatesUsingNumberFormat = true })) {
+                    var cell = reader.GetSheet("Data").EnumerateCells().Single(item => item.Row == 1 && item.Column == 1);
+                    Assert.Equal(date, Assert.IsType<DateTime>(cell.Value));
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
         private static double Expected1904Serial(DateTime value)
             => value.ToOADate() - Excel1904DateOffsetDays;
 

--- a/OfficeIMO.Tests/Excel.DateSystem.cs
+++ b/OfficeIMO.Tests/Excel.DateSystem.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Data;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        private const double Excel1904DateOffsetDays = 1462d;
+
+        [Fact]
+        public void DateSystem_1904_WritesWorkbookFlagAndAdjustedSerials() {
+            string filePath = Path.Combine(_directoryWithFiles, "DateSystem1904.xlsx");
+            var date = new DateTime(2024, 1, 1);
+            var minimum = new DateTime(2024, 1, 1);
+            var maximum = new DateTime(2024, 12, 31);
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    document.DateSystem = ExcelDateSystem.NineteenFour;
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, date);
+                    sheet.ValidationDate("A1:A10", DataValidationOperatorValues.Between, minimum, maximum);
+                    document.Save();
+                }
+
+                using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                    AssertWorkbookUses1904DateSystem(spreadsheet);
+
+                    WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                    string serialText = GetCellValueText(worksheetPart, "A1");
+                    Assert.Equal(Expected1904Serial(date), double.Parse(serialText, CultureInfo.InvariantCulture), 6);
+
+                    DataValidation validation = Assert.Single(worksheetPart.Worksheet.Descendants<DataValidation>());
+                    Assert.Equal(Expected1904Serial(minimum), double.Parse(validation.GetFirstChild<Formula1>()!.Text, CultureInfo.InvariantCulture), 6);
+                    Assert.Equal(Expected1904Serial(maximum), double.Parse(validation.GetFirstChild<Formula2>()!.Text, CultureInfo.InvariantCulture), 6);
+                }
+
+                using (var reader = ExcelDocumentReader.Open(filePath, new ExcelReadOptions { TreatDatesUsingNumberFormat = true })) {
+                    var cell = reader.GetSheet("Data").EnumerateCells().Single(item => item.Row == 1 && item.Column == 1);
+                    DateTime readDate = Assert.IsType<DateTime>(cell.Value);
+                    Assert.Equal(date, readDate);
+                }
+
+                using (ExcelDocument loaded = ExcelDocument.Load(filePath, readOnly: true)) {
+                    Assert.Equal(ExcelDateSystem.NineteenFour, loaded.DateSystem);
+                    Assert.Equal(ExcelDateSystem.NineteenFour, loaded.CreateInspectionSnapshot().DateSystem);
+                }
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void DirectDataSet_1904_WritesWorkbookFlagAndAdjustedDateSerials() {
+            var date = new DateTime(2024, 2, 3);
+            using var stream = new MemoryStream();
+            var table = new DataTable("Data");
+            table.Columns.Add("When", typeof(DateTime));
+            table.Rows.Add(date);
+            var dataSet = new DataSet();
+            dataSet.Tables.Add(table);
+
+            ExcelDocument.WriteDataSet(stream, dataSet, dateSystem: ExcelDateSystem.NineteenFour);
+            stream.Position = 0;
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(stream, false);
+            AssertWorkbookUses1904DateSystem(spreadsheet);
+
+            WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+            string serialText = GetCellValueText(worksheetPart, "A2");
+            Assert.Equal(Expected1904Serial(date), double.Parse(serialText, CultureInfo.InvariantCulture), 6);
+        }
+
+        private static double Expected1904Serial(DateTime value)
+            => value.ToOADate() - Excel1904DateOffsetDays;
+
+        private static string GetCellValueText(WorksheetPart worksheetPart, string cellReference) {
+            Cell cell = worksheetPart.Worksheet.Descendants<Cell>().Single(item => item.CellReference == cellReference);
+            return cell.CellValue?.Text ?? string.Empty;
+        }
+
+        private static void AssertWorkbookUses1904DateSystem(SpreadsheetDocument spreadsheet) {
+            WorkbookProperties? properties = spreadsheet.WorkbookPart!.Workbook.GetFirstChild<WorkbookProperties>();
+            Assert.NotNull(properties);
+            Assert.True(properties!.Date1904?.Value);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.FeatureReport.Preflight.cs
+++ b/OfficeIMO.Tests/Excel.FeatureReport.Preflight.cs
@@ -247,6 +247,32 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void FeatureReport_Preflight_ReportsRepairHintsForBlockedCapabilities() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.RepairHints.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Calc");
+                sheet.CellValue(1, 1, 2d);
+                sheet.CellFormula(1, 2, "A1+1");
+                document.ConfigureFullCalculationOnOpen();
+                document.Save(false);
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelFeatureReport report = document.InspectFeatures();
+
+                var hints = report.GetRepairHints(ExcelPreflightCapability.UseCachedFormulaValues);
+                Assert.Contains(hints, hint => hint.FeatureName == "Missing formula caches");
+                Assert.Contains(hints, hint => hint.FeatureName == "Workbook recalculation requests");
+                Assert.Contains(hints, hint => hint.Action.Contains("Refresh cached formula values", StringComparison.Ordinal));
+
+                string markdown = report.ToMarkdown();
+                Assert.Contains("## Repair Hints", markdown);
+                Assert.Contains("Refresh cached formula values", markdown);
+            }
+        }
+
+        [Fact]
         public void FeatureReport_Preflight_AllowsPdfExportWhenUnsafeFormulaCachesAreOnlyHidden() {
             string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.HiddenFormulaCaches.xlsx");
 

--- a/OfficeIMO.Tests/Excel.NamedRanges.cs
+++ b/OfficeIMO.Tests/Excel.NamedRanges.cs
@@ -105,6 +105,20 @@ namespace OfficeIMO.Tests {
             }
             File.Delete(filePath);
         }
+
+        [Fact]
+        public void RenameNamedRange_StrictValidationFailureKeepsOriginalName() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Data");
+                document.SetNamedRange("OriginalName", "'Data'!A1:A2", save: false);
+
+                Assert.Throws<ArgumentException>(() => document.RenameNamedRange("OriginalName", "A1", validationMode: NameValidationMode.Strict, save: false));
+                Assert.Equal("'Data'!$A$1:$A$2", document.GetNamedRange("OriginalName"));
+                Assert.Null(document.GetNamedRange("A1"));
+            }
+            File.Delete(filePath);
+        }
     }
 }
 

--- a/OfficeIMO.Tests/Excel.PackageInteractions.cs
+++ b/OfficeIMO.Tests/Excel.PackageInteractions.cs
@@ -157,10 +157,11 @@ namespace OfficeIMO.Tests {
             stream.Write(bytes, 0, bytes.Length);
         }
 
-        private static string ReadSinglePackagePartText(OpenXmlPartContainer container, string contentTypeMarker) {
+        private static string ReadSinglePackagePartText(OpenXmlPartContainer container, string contentTypeMarker, bool skipTypedParts = false) {
             var part = Assert.Single(
                 container.Parts.Select(relationship => relationship.OpenXmlPart),
-                part => part.ContentType.IndexOf(contentTypeMarker, StringComparison.OrdinalIgnoreCase) >= 0);
+                part => (!skipTypedParts || part is ExtendedPart)
+                    && part.ContentType.IndexOf(contentTypeMarker, StringComparison.OrdinalIgnoreCase) >= 0);
 
             using Stream stream = part.GetStream(FileMode.Open, FileAccess.Read);
             using var reader = new StreamReader(stream, Encoding.UTF8);

--- a/OfficeIMO.Tests/Excel.PackageInteractions.cs
+++ b/OfficeIMO.Tests/Excel.PackageInteractions.cs
@@ -1,0 +1,186 @@
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_InspectionCountsSlicerAndTimelinePackageParts() {
+            string filePath = Path.Combine(_directoryWithFiles, "PackageInteractions.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Data").CellValue(1, 1, "Value");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                var workbookPart = spreadsheet.WorkbookPart!;
+                WriteExtendedPart(
+                    workbookPart.AddExtendedPart(
+                        "http://schemas.microsoft.com/office/2007/relationships/slicerCache",
+                        "application/vnd.ms-excel.slicerCache+xml",
+                        ".xml"),
+                    "<slicerCacheDefinition xmlns=\"http://schemas.microsoft.com/office/spreadsheetml/2009/9/main\"/>");
+                WriteExtendedPart(
+                    workbookPart.AddExtendedPart(
+                        "http://schemas.microsoft.com/office/2011/relationships/timelineCache",
+                        "application/vnd.ms-excel.timelineCache+xml",
+                        ".xml"),
+                    "<timelineCacheDefinition xmlns=\"http://schemas.microsoft.com/office/spreadsheetml/2011/1/timeline\"/>");
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelWorkbookSnapshot snapshot = document.CreateInspectionSnapshot();
+                Assert.Equal(1, snapshot.SlicerPartCount);
+                Assert.Equal(1, snapshot.TimelinePartCount);
+                Assert.True(snapshot.HasSlicers);
+                Assert.True(snapshot.HasTimelines);
+            }
+        }
+
+        [Fact]
+        public void Test_CopyPackage_PreservesPartsAndNormalizesWorkbookContentType() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "PackageClone.Source.xlsx");
+            string destinationPath = Path.Combine(_directoryWithFiles, "PackageClone.Target.xlsm");
+
+            using (var document = ExcelDocument.Create(sourcePath)) {
+                document.AddWorkSheet("Data").CellValue(1, 1, "Value");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(sourcePath, true)) {
+                var workbookPart = spreadsheet.WorkbookPart!;
+                WriteExtendedPart(
+                    workbookPart.AddExtendedPart(
+                        "http://schemas.microsoft.com/office/2007/relationships/slicerCache",
+                        "application/vnd.ms-excel.slicerCache+xml",
+                        "xml"),
+                    "<slicerCacheDefinition xmlns=\"http://schemas.microsoft.com/office/spreadsheetml/2009/9/main\"/>");
+                WriteExtendedPart(
+                    workbookPart.AddExtendedPart(
+                        "http://schemas.microsoft.com/office/2011/relationships/timelineCache",
+                        "application/vnd.ms-excel.timelineCache+xml",
+                        "xml"),
+                    "<timelineCacheDefinition xmlns=\"http://schemas.microsoft.com/office/spreadsheetml/2011/1/timeline\"/>");
+            }
+
+            ExcelDocument.CopyPackage(sourcePath, destinationPath);
+
+            Assert.Equal(
+                "application/vnd.ms-excel.sheet.macroEnabled.main+xml",
+                GetWorkbookOverrideContentType(destinationPath));
+
+            using (var document = ExcelDocument.Load(destinationPath, readOnly: true)) {
+                var worksheetPart = document._spreadSheetDocument.WorkbookPart!.WorksheetParts.Single();
+                Assert.Equal("Value", GetCellValue(document._spreadSheetDocument, worksheetPart, "A1"));
+
+                ExcelWorkbookSnapshot snapshot = document.CreateInspectionSnapshot();
+                Assert.Equal(1, snapshot.SlicerPartCount);
+                Assert.Equal(1, snapshot.TimelinePartCount);
+            }
+        }
+
+        [Fact]
+        public void Test_ConnectionAndQueryTableMetadataParts_AreAuthoredAndInspected() {
+            string filePath = Path.Combine(_directoryWithFiles, "PackageInteractions.ConnectionMetadata.xlsx");
+            const string connectionXml = "<connections xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" count=\"1\"><connection id=\"1\" name=\"SalesConnection\" type=\"5\" refreshedVersion=\"7\"/></connections>";
+            const string queryTableXml = "<queryTable xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" name=\"SalesQuery\" connectionId=\"1\"/>";
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Data").CellValue(1, 1, "Region");
+                document.AddWorkbookConnectionMetadata(connectionXml);
+                document.AddWorksheetQueryTableMetadata("Data", queryTableXml);
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelWorkbookSnapshot snapshot = document.CreateInspectionSnapshot();
+                Assert.Equal(1, snapshot.ConnectionPartCount);
+                Assert.Equal(1, snapshot.QueryTablePartCount);
+                Assert.True(snapshot.HasConnections);
+                Assert.True(snapshot.HasQueryTables);
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                var workbookPart = spreadsheet.WorkbookPart!;
+                Assert.Contains("SalesConnection", ReadSinglePackagePartText(workbookPart, "connections"));
+
+                var worksheetPart = workbookPart.WorksheetParts.Single();
+                Assert.Contains("SalesQuery", ReadSinglePackagePartText(worksheetPart, "queryTable"));
+            }
+        }
+
+        [Fact]
+        public void Test_SlicerAndTimelineMetadataParts_AreAuthoredAndInspected() {
+            string filePath = Path.Combine(_directoryWithFiles, "PackageInteractions.SlicerTimelineMetadata.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Data").CellValue(1, 1, "Region");
+                document.AddWorkbookSlicerCache(new ExcelSlicerCacheOptions {
+                    Name = "RegionSlicer",
+                    SourceName = "Region",
+                    PivotTableName = "SalesPivot"
+                });
+                document.AddWorkbookTimelineCache(new ExcelTimelineCacheOptions {
+                    Name = "OrderDateTimeline",
+                    SourceName = "OrderDate",
+                    PivotTableName = "SalesPivot"
+                });
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelWorkbookSnapshot snapshot = document.CreateInspectionSnapshot();
+                Assert.Equal(1, snapshot.SlicerPartCount);
+                Assert.Equal(1, snapshot.TimelinePartCount);
+                Assert.True(snapshot.HasSlicers);
+                Assert.True(snapshot.HasTimelines);
+
+                ExcelFeatureReport report = document.InspectFeatures();
+                Assert.Equal(ExcelFeatureSupportLevel.PartiallyEditable, report.FindFeatures("Slicers").Single().SupportLevel);
+                Assert.Equal(ExcelFeatureSupportLevel.PartiallyEditable, report.FindFeatures("Timelines").Single().SupportLevel);
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                var workbookPart = spreadsheet.WorkbookPart!;
+                Assert.Contains("RegionSlicer", ReadSinglePackagePartText(workbookPart, "slicerCache"));
+                Assert.Contains("OrderDateTimeline", ReadSinglePackagePartText(workbookPart, "timelineCache"));
+            }
+        }
+
+        private static void WriteExtendedPart(ExtendedPart part, string xml) {
+            using var stream = part.GetStream(FileMode.Create, FileAccess.Write);
+            byte[] bytes = Encoding.UTF8.GetBytes(xml);
+            stream.Write(bytes, 0, bytes.Length);
+        }
+
+        private static string ReadSinglePackagePartText(OpenXmlPartContainer container, string contentTypeMarker) {
+            var part = Assert.Single(
+                container.Parts.Select(relationship => relationship.OpenXmlPart),
+                part => part.ContentType.IndexOf(contentTypeMarker, StringComparison.OrdinalIgnoreCase) >= 0);
+
+            using Stream stream = part.GetStream(FileMode.Open, FileAccess.Read);
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+            return reader.ReadToEnd();
+        }
+
+        private static string? GetWorkbookOverrideContentType(string filePath) {
+            using ZipArchive archive = ZipFile.OpenRead(filePath);
+            ZipArchiveEntry entry = archive.GetEntry("[Content_Types].xml")
+                ?? throw new InvalidOperationException("Workbook package is missing [Content_Types].xml.");
+
+            using Stream stream = entry.Open();
+            XDocument document = XDocument.Load(stream);
+            XNamespace ns = "http://schemas.openxmlformats.org/package/2006/content-types";
+            return document
+                .Root?
+                .Elements(ns + "Override")
+                .FirstOrDefault(element => string.Equals((string?)element.Attribute("PartName"), "/xl/workbook.xml", StringComparison.OrdinalIgnoreCase))
+                ?.Attribute("ContentType")
+                ?.Value;
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.PackageInteractions.cs
+++ b/OfficeIMO.Tests/Excel.PackageInteractions.cs
@@ -3,6 +3,7 @@ using System.IO.Compression;
 using System.Text;
 using System.Xml.Linq;
 using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
 using OfficeIMO.Excel;
 using Xunit;
 
@@ -84,6 +85,58 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_InspectionSnapshot_SkipsNonWorksheetSheetParts() {
+            string filePath = Path.Combine(_directoryWithFiles, "PackageInteractions.ChartSheetInspection.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Data").CellValue(1, 1, "Value");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                var workbookPart = spreadsheet.WorkbookPart!;
+                ChartsheetPart chartsheetPart = workbookPart.AddNewPart<ChartsheetPart>();
+                chartsheetPart.Chartsheet = new Chartsheet(new SheetViews(new SheetView { WorkbookViewId = 0U }));
+                chartsheetPart.Chartsheet.Save();
+
+                Sheets sheets = workbookPart.Workbook.Sheets!;
+                uint nextSheetId = sheets.Elements<Sheet>().Select(sheet => sheet.SheetId?.Value ?? 0U).Max() + 1U;
+                sheets.Append(new Sheet {
+                    Id = workbookPart.GetIdOfPart(chartsheetPart),
+                    SheetId = nextSheetId,
+                    Name = "Chart View"
+                });
+                workbookPart.Workbook.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelWorkbookSnapshot snapshot = document.CreateInspectionSnapshot();
+                ExcelWorksheetSnapshot worksheet = Assert.Single(snapshot.Worksheets);
+                Assert.Equal("Data", worksheet.Name);
+            }
+        }
+
+
+        [Fact]
+        public void Test_CopyPackage_RejectsMacroEnabledSourceToMacroFreeDestination() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "PackageClone.MacroSource.xlsx");
+            string macroPath = Path.Combine(_directoryWithFiles, "PackageClone.MacroSource.xlsm");
+            string destinationPath = Path.Combine(_directoryWithFiles, "PackageClone.MacroBlocked.xlsx");
+
+            using (var document = ExcelDocument.Create(sourcePath)) {
+                document.AddWorkSheet("Data").CellValue(1, 1, "Value");
+                document.Save();
+            }
+
+            ExcelDocument.CopyPackage(sourcePath, macroPath);
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+                ExcelDocument.CopyPackage(macroPath, destinationPath));
+            Assert.Contains("Macro-enabled workbook packages", exception.Message);
+            Assert.False(File.Exists(destinationPath));
+        }
+
+        [Fact]
         public void Test_ConnectionAndQueryTableMetadataParts_AreAuthoredAndInspected() {
             string filePath = Path.Combine(_directoryWithFiles, "PackageInteractions.ConnectionMetadata.xlsx");
             const string connectionXml = "<connections xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" count=\"1\"><connection id=\"1\" name=\"SalesConnection\" type=\"5\" refreshedVersion=\"7\"/></connections>";
@@ -110,6 +163,38 @@ namespace OfficeIMO.Tests {
 
                 var worksheetPart = workbookPart.WorksheetParts.Single();
                 Assert.Contains("SalesQuery", ReadSinglePackagePartText(worksheetPart, "queryTable"));
+            }
+        }
+
+        [Fact]
+        public void Test_ConnectionMetadata_MergesIntoTypedWorkbookConnectionsPart() {
+            string filePath = Path.Combine(_directoryWithFiles, "PackageInteractions.TypedConnectionMetadata.xlsx");
+            const string connectionXml = "<connections xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" count=\"1\"><connection id=\"2\" name=\"Added\" type=\"5\" refreshedVersion=\"7\"/></connections>";
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Data");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                ConnectionsPart connectionsPart = spreadsheet.WorkbookPart!.AddNewPart<ConnectionsPart>();
+                connectionsPart.Connections = new Connections(
+                    new Connection { Id = 1U, Name = "Existing", Type = 5, RefreshedVersion = 7 });
+                connectionsPart.Connections.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                OpenXmlPart part = document.AddWorkbookConnectionMetadata(connectionXml);
+                Assert.IsType<ConnectionsPart>(part);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                var workbookPart = spreadsheet.WorkbookPart!;
+                ConnectionsPart connectionsPart = Assert.Single(workbookPart.GetPartsOfType<ConnectionsPart>());
+                Assert.Contains(connectionsPart.Connections!.Elements<Connection>(), connection => connection.Name?.Value == "Existing");
+                Assert.Contains(connectionsPart.Connections!.Elements<Connection>(), connection => connection.Name?.Value == "Added");
+                Assert.DoesNotContain(workbookPart.Parts.Select(pair => pair.OpenXmlPart), part => part is ExtendedPart && part.ContentType.IndexOf("connections", StringComparison.OrdinalIgnoreCase) >= 0);
             }
         }
 

--- a/OfficeIMO.Tests/Excel.PivotTables.cs
+++ b/OfficeIMO.Tests/Excel.PivotTables.cs
@@ -74,6 +74,47 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_PivotConditionalFormatting_TargetsPivotDataBody() {
+            var filePath = Path.Combine(_directoryWithFiles, "ExcelPivotTableConditionalFormatting.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+
+                sheet.CellValue(1, 1, "Region");
+                sheet.CellValue(1, 2, "Product");
+                sheet.CellValue(1, 3, "Sales");
+                sheet.CellValue(2, 1, "East");
+                sheet.CellValue(2, 2, "A");
+                sheet.CellValue(2, 3, 10);
+                sheet.CellValue(3, 1, "West");
+                sheet.CellValue(3, 2, "A");
+                sheet.CellValue(3, 3, 12);
+                sheet.CellValue(4, 1, "East");
+                sheet.CellValue(4, 2, "B");
+                sheet.CellValue(4, 3, 7);
+
+                sheet.AddPivotTable(
+                    sourceRange: "A1:C4",
+                    destinationCell: "E2",
+                    name: "SalesPivot",
+                    rowFields: new[] { "Region" },
+                    columnFields: new[] { "Product" },
+                    dataFields: new[] { new ExcelPivotDataField("Sales", DataConsolidateFunctionValues.Sum, "Total Sales") });
+
+                Assert.Equal("F3:G3", sheet.GetPivotTableRange("SalesPivot", ExcelPivotRangeTarget.DataBody));
+                sheet.AddPivotConditionalRule("SalesPivot", ConditionalFormattingOperatorValues.GreaterThan, "0");
+                document.Save(false);
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = GetWorksheetPartByName(spreadsheet, "Data");
+                ConditionalFormatting formatting = worksheetPart.Worksheet.Descendants<ConditionalFormatting>().Single();
+                Assert.Equal("F3:G3", formatting.SequenceOfReferences!.InnerText);
+                Assert.Equal(ConditionalFormatValues.CellIs, formatting.GetFirstChild<ConditionalFormattingRule>()!.Type!.Value);
+            }
+        }
+
+        [Fact]
         public void Test_FluentPivotBuilder_CreatesPivotTable() {
             var filePath = Path.Combine(_directoryWithFiles, "ExcelPivotTableFluent.xlsx");
 
@@ -133,6 +174,52 @@ namespace OfficeIMO.Tests {
 
             using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
                 Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_PivotTableInteractionOptions_AreWrittenAndReadBack() {
+            var filePath = Path.Combine(_directoryWithFiles, "ExcelPivotTableInteractionOptions.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+
+                sheet.CellValue(1, 1, "Region");
+                sheet.CellValue(1, 2, "Sales");
+                sheet.CellValue(2, 1, "East");
+                sheet.CellValue(2, 2, 10);
+                sheet.CellValue(3, 1, "West");
+                sheet.CellValue(3, 2, 12);
+
+                sheet.Pivot("A1:B3")
+                    .Rows("Region")
+                    .Sum("Sales", "Total Sales")
+                    .Interaction(
+                        refreshOnOpen: true,
+                        saveSourceData: false,
+                        preserveFormatting: false,
+                        enableDrill: false)
+                    .At("E2", "SalesPivot");
+
+                document.Save(false);
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                var pivotPart = spreadsheet.WorkbookPart!.WorksheetParts.SelectMany(part => part.PivotTableParts).Single();
+                var cachePart = spreadsheet.WorkbookPart!.PivotTableCacheDefinitionParts.Single();
+
+                Assert.True(cachePart.PivotCacheDefinition!.RefreshOnLoad!.Value);
+                Assert.False(cachePart.PivotCacheDefinition!.SaveData!.Value);
+                Assert.False(pivotPart.PivotTableDefinition!.PreserveFormatting!.Value);
+                Assert.False(pivotPart.PivotTableDefinition!.EnableDrill!.Value);
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                var pivot = document.GetPivotTables().Single();
+                Assert.True(pivot.RefreshOnOpen);
+                Assert.False(pivot.SaveSourceData);
+                Assert.False(pivot.PreserveFormatting);
+                Assert.False(pivot.EnableDrill);
             }
         }
 

--- a/OfficeIMO.Tests/Excel.PrintLayout.cs
+++ b/OfficeIMO.Tests/Excel.PrintLayout.cs
@@ -46,5 +46,29 @@ namespace OfficeIMO.Tests {
                 Assert.True(worksheet.GetFirstChild<SheetProperties>()?.GetFirstChild<PageSetupProperties>()?.FitToPage?.Value);
             }
         }
+
+        [Fact]
+        public void Test_PrintLayoutPreset_ClearsStaleFitToPageSettings() {
+            string filePath = Path.Combine(_directoryWithFiles, "PrintLayoutPreset.ClearFit.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Report");
+                sheet.CellValue(1, 1, "Region");
+                sheet.SetPageSetup(fitToWidth: 1U, fitToHeight: 0U);
+                sheet.ApplyPrintLayout(new ExcelPrintLayoutOptions {
+                    Preset = ExcelPrintLayoutPreset.Worksheet
+                });
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                Worksheet worksheet = spreadsheet.WorkbookPart!.WorksheetParts.Single().Worksheet;
+                PageSetup setup = worksheet.GetFirstChild<PageSetup>()!;
+                Assert.Null(setup.FitToWidth);
+                Assert.Null(setup.FitToHeight);
+                Assert.Equal(100U, setup.Scale!.Value);
+                Assert.Null(worksheet.GetFirstChild<SheetProperties>()?.GetFirstChild<PageSetupProperties>()?.FitToPage);
+            }
+        }
     }
 }

--- a/OfficeIMO.Tests/Excel.PrintLayout.cs
+++ b/OfficeIMO.Tests/Excel.PrintLayout.cs
@@ -1,0 +1,50 @@
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_PrintLayoutPreset_AppliesReportWorkflowSettings() {
+            string filePath = Path.Combine(_directoryWithFiles, "PrintLayoutPreset.Report.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Report");
+                sheet.CellValue(1, 1, "Region");
+                sheet.CellValue(2, 1, "EU");
+
+                sheet.ApplyPrintLayout(new ExcelPrintLayoutOptions {
+                    Preset = ExcelPrintLayoutPreset.Report,
+                    PrintArea = "A1:D25",
+                    RepeatFirstColumn = 1,
+                    RepeatLastColumn = 1
+                });
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelSheet sheet = document["Report"];
+                ExcelSheetPageSetup setup = sheet.GetPageSetup();
+                Assert.Equal(ExcelPageOrientation.Landscape, setup.Orientation);
+                Assert.Equal(1U, setup.FitToWidth);
+                Assert.Equal(0U, setup.FitToHeight);
+                Assert.Equal(ExcelPageOrder.DownThenOver, setup.PageOrder);
+                Assert.NotNull(setup.Margins);
+                Assert.Equal(0.25D, setup.Margins!.Left);
+                Assert.Equal("$A$1:$D$25", sheet.GetPrintArea());
+
+                ExcelPrintTitles titles = sheet.GetPrintTitles();
+                Assert.Equal(1, titles.FirstRow);
+                Assert.Equal(1, titles.LastRow);
+                Assert.Equal(1, titles.FirstColumn);
+                Assert.Equal(1, titles.LastColumn);
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                Worksheet worksheet = spreadsheet.WorkbookPart!.WorksheetParts.Single().Worksheet;
+                Assert.True(worksheet.GetFirstChild<SheetProperties>()?.GetFirstChild<PageSetupProperties>()?.FitToPage?.Value);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.Protection.cs
+++ b/OfficeIMO.Tests/Excel.Protection.cs
@@ -1,0 +1,63 @@
+using System.Data;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_ExcelSheetProtection_TableEditingPreset_AllowsTableWorkflows() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelProtection.TableEditing.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Region");
+                sheet.CellValue(1, 2, "Sales");
+                sheet.CellValue(2, 1, "NA");
+                sheet.CellValue(2, 2, 100);
+                sheet.AddTable("A1:B2", true, "Sales", OfficeIMO.Excel.TableStyle.TableStyleMedium2);
+                sheet.ProtectTableEditing();
+                document.Save();
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = GetWorksheetPartByName(spreadsheet, "Data");
+                SheetProtection protection = worksheetPart.Worksheet.Elements<SheetProtection>().Single();
+                Assert.True(protection.Sheet!.Value);
+                Assert.False(protection.InsertRows!.Value);
+                Assert.False(protection.Sort!.Value);
+                Assert.False(protection.AutoFilter!.Value);
+                Assert.False(protection.SelectUnlockedCells!.Value);
+            }
+        }
+
+        [Fact]
+        public void Test_ExcelSheetProtection_TableEditingPreset_PersistsThroughDirectTableSave() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelProtection.TableEditingDirectSave.xlsx");
+            var table = new DataTable("Sales");
+            table.Columns.Add("Region", typeof(string));
+            table.Columns.Add("Sales", typeof(int));
+            table.Rows.Add("NA", 100);
+            table.Rows.Add("EMEA", 200);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.InsertDataTableAsTable(table, includeHeaders: true, tableName: "Sales", style: OfficeIMO.Excel.TableStyle.TableStyleMedium2);
+                sheet.ProtectTableEditing();
+                document.Save();
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = GetWorksheetPartByName(spreadsheet, "Data");
+                SheetProtection protection = worksheetPart.Worksheet.Elements<SheetProtection>().Single();
+                Assert.True(protection.Sheet!.Value);
+                Assert.False(protection.InsertRows!.Value);
+                Assert.False(protection.Sort!.Value);
+                Assert.False(protection.AutoFilter!.Value);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.Refresh.cs
+++ b/OfficeIMO.Tests/Excel.Refresh.cs
@@ -1,0 +1,54 @@
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_ExcelRefreshOnOpen_UpdatesPivotCachesAndConnections() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelRefreshOnOpen.PivotConnections.xlsx");
+            const string connectionXml = "<connections xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" count=\"1\"><connection id=\"1\" name=\"SalesConnection\" type=\"5\" refreshedVersion=\"7\"/></connections>";
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Region");
+                sheet.CellValue(1, 2, "Sales");
+                sheet.CellValue(2, 1, "East");
+                sheet.CellValue(2, 2, 10);
+                sheet.CellValue(3, 1, "West");
+                sheet.CellValue(3, 2, 20);
+                sheet.AddPivotTable(
+                    sourceRange: "A1:B3",
+                    destinationCell: "E2",
+                    name: "SalesPivot",
+                    rowFields: new[] { "Region" },
+                    dataFields: new[] { new ExcelPivotDataField("Sales") },
+                    options: new ExcelPivotTableOptions {
+                        RefreshOnOpen = false,
+                        SaveSourceData = true
+                    });
+                document.AddWorkbookConnectionMetadata(connectionXml);
+
+                ExcelRefreshOnOpenResult result = document.SetRefreshOnOpen(savePivotSourceData: false);
+                Assert.True(result.Enabled);
+                Assert.Equal(1, result.PivotCacheCount);
+                Assert.Equal(1, result.ConnectionCount);
+                document.Save(false);
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                var cacheDefinition = spreadsheet.WorkbookPart!.PivotTableCacheDefinitionParts.Single().PivotCacheDefinition!;
+                Assert.True(cacheDefinition.RefreshOnLoad!.Value);
+                Assert.False(cacheDefinition.SaveData!.Value);
+
+                string connectionText = ReadSinglePackagePartText(spreadsheet.WorkbookPart!, "connections");
+                XDocument connections = XDocument.Parse(connectionText);
+                XElement connection = connections.Descendants().Single(element => element.Name.LocalName == "connection");
+                Assert.Equal("1", connection.Attribute("refreshOnLoad")?.Value);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.Refresh.cs
+++ b/OfficeIMO.Tests/Excel.Refresh.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
 using OfficeIMO.Excel;
 using Xunit;
 
@@ -48,6 +49,49 @@ namespace OfficeIMO.Tests {
                 XDocument connections = XDocument.Parse(connectionText);
                 XElement connection = connections.Descendants().Single(element => element.Name.LocalName == "connection");
                 Assert.Equal("1", connection.Attribute("refreshOnLoad")?.Value);
+            }
+        }
+
+        [Fact]
+        public void Test_ExcelRefreshOnOpen_UpdatesTypedConnectionsAndAllocatesNextConnectionId() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelRefreshOnOpen.TypedConnections.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Data");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                ConnectionsPart connectionsPart = spreadsheet.WorkbookPart!.AddNewPart<ConnectionsPart>();
+                connectionsPart.Connections = new Connections(
+                    new Connection { Id = 1U, Name = "ExistingOne", Type = 5, RefreshedVersion = 7 },
+                    new Connection { Id = 2U, Name = "ExistingTwo", Type = 5, RefreshedVersion = 7 });
+                connectionsPart.Connections.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                ExcelRefreshOnOpenResult refresh = document.SetRefreshOnOpen(pivotTables: false, connections: true);
+                Assert.Equal(2, refresh.ConnectionCount);
+
+                ExcelPowerQueryMetadataResult metadata = document.AddPowerQueryMetadata(new ExcelPowerQueryMetadataOptions {
+                    Name = "AddedQuery",
+                    WorksheetName = "Data",
+                    CommandText = "let Source = Excel.CurrentWorkbook() in Source"
+                });
+                Assert.Equal(3U, metadata.ConnectionId);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                ConnectionsPart connectionsPart = spreadsheet.WorkbookPart!.GetPartsOfType<ConnectionsPart>()
+                    .First(part => part.Connections?.Elements<Connection>().Any(connection => connection.Name?.Value == "ExistingOne") == true);
+                Assert.All(connectionsPart.Connections!.Elements<Connection>(), connection => Assert.True(connection.RefreshOnLoad!.Value));
+
+                XElement addedConnection = EnumerateWorkbookConnectionXml(spreadsheet.WorkbookPart!)
+                    .Select(XDocument.Parse)
+                    .SelectMany(document => document.Descendants().Where(element => element.Name.LocalName == "connection"))
+                    .Single(element => element.Attribute("name")?.Value == "AddedQuery");
+                Assert.Equal("3", addedConnection.Attribute("id")?.Value);
             }
         }
     }

--- a/OfficeIMO.Tests/Excel.Refresh.cs
+++ b/OfficeIMO.Tests/Excel.Refresh.cs
@@ -76,7 +76,8 @@ namespace OfficeIMO.Tests {
                 ExcelPowerQueryMetadataResult metadata = document.AddPowerQueryMetadata(new ExcelPowerQueryMetadataOptions {
                     Name = "AddedQuery",
                     WorksheetName = "Data",
-                    CommandText = "let Source = Excel.CurrentWorkbook() in Source"
+                    CommandText = "let Source = Excel.CurrentWorkbook() in Source",
+                    RefreshOnOpen = true
                 });
                 Assert.Equal(3U, metadata.ConnectionId);
                 document.Save();
@@ -86,6 +87,7 @@ namespace OfficeIMO.Tests {
                 ConnectionsPart connectionsPart = spreadsheet.WorkbookPart!.GetPartsOfType<ConnectionsPart>()
                     .First(part => part.Connections?.Elements<Connection>().Any(connection => connection.Name?.Value == "ExistingOne") == true);
                 Assert.All(connectionsPart.Connections!.Elements<Connection>(), connection => Assert.True(connection.RefreshOnLoad!.Value));
+                Assert.DoesNotContain(spreadsheet.WorkbookPart!.Parts.Select(pair => pair.OpenXmlPart), part => part is ExtendedPart && part.ContentType.IndexOf("connections", StringComparison.OrdinalIgnoreCase) >= 0);
 
                 XElement addedConnection = EnumerateWorkbookConnectionXml(spreadsheet.WorkbookPart!)
                     .Select(XDocument.Parse)

--- a/OfficeIMO.Tests/Excel.SheetComposer.Report.cs
+++ b/OfficeIMO.Tests/Excel.SheetComposer.Report.cs
@@ -178,6 +178,44 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Composer_TableFrom_AppliesTableVisualStyleFlags() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            var rows = new[] {
+                new ComposerTableRow("Alpha", 10),
+                new ComposerTableRow("Beta", 20)
+            };
+
+            using (var doc = ExcelDocument.Create(filePath)) {
+                doc.Compose("Report", c => {
+                    c.TableFrom(
+                        rows,
+                        title: "Scores",
+                        visuals: options => {
+                            options.ShowFirstColumn = true;
+                            options.ShowLastColumn = true;
+                            options.ShowRowStripes = false;
+                            options.ShowColumnStripes = true;
+                        });
+                    c.Finish(autoFitColumns: false);
+                });
+
+                doc.Save();
+            }
+
+            using (var ss = SpreadsheetDocument.Open(filePath, false)) {
+                var tablePart = Assert.Single(ss.WorkbookPart!.WorksheetParts.First().TableDefinitionParts);
+                Assert.NotNull(tablePart.Table);
+                var styleInfo = Assert.IsType<TableStyleInfo>(tablePart.Table!.TableStyleInfo);
+                Assert.True(styleInfo.ShowFirstColumn?.Value);
+                Assert.True(styleInfo.ShowLastColumn?.Value);
+                Assert.False(styleInfo.ShowRowStripes?.Value);
+                Assert.True(styleInfo.ShowColumnStripes?.Value);
+            }
+
+            File.Delete(filePath);
+        }
+
+        [Fact]
         public void Composer_ColumnTableFrom_SummarizeOverflowPreservesMoreColumn() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             var rows = new[] {

--- a/OfficeIMO.Tests/Excel.SheetNameValidationAndPreflight.cs
+++ b/OfficeIMO.Tests/Excel.SheetNameValidationAndPreflight.cs
@@ -1555,6 +1555,37 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ManualPageBreaks_CanBeRemovedAndCleared() {
+            string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            using (var doc = ExcelDocument.Create(path)) {
+                var sheet = doc.AddWorkSheet("Print");
+                sheet.CellValue(1, 1, "Value");
+
+                sheet.AddManualRowPageBreak(3, save: false);
+                sheet.AddManualRowPageBreak(6, save: false);
+                sheet.AddManualColumnPageBreak(2, save: false);
+                sheet.AddManualColumnPageBreak(4, save: false);
+
+                Assert.Equal(new[] { 3, 6 }, sheet.GetManualRowPageBreaks());
+                Assert.Equal(new[] { 2, 4 }, sheet.GetManualColumnPageBreaks());
+
+                Assert.True(sheet.RemoveManualRowPageBreak(3, save: false));
+                Assert.False(sheet.RemoveManualRowPageBreak(99, save: false));
+                Assert.Equal(new[] { 6 }, sheet.GetManualRowPageBreaks());
+
+                Assert.True(sheet.ClearManualColumnPageBreaks(save: false));
+                Assert.False(sheet.ClearManualColumnPageBreaks(save: false));
+                Assert.Empty(sheet.GetManualColumnPageBreaks());
+
+                Assert.True(sheet.ClearManualPageBreaks(save: false));
+                Assert.False(sheet.ClearManualPageBreaks(save: false));
+                Assert.Empty(sheet.GetManualRowPageBreaks());
+            }
+
+            File.Delete(path);
+        }
+
+        [Fact]
         public void Preflight_NormalizesPrintMarginsAndScaleBeforeSave() {
             string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             string savePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");

--- a/OfficeIMO.Tests/Excel.SheetNameValidationAndPreflight.cs
+++ b/OfficeIMO.Tests/Excel.SheetNameValidationAndPreflight.cs
@@ -1561,6 +1561,9 @@ namespace OfficeIMO.Tests {
                 var sheet = doc.AddWorkSheet("Print");
                 sheet.CellValue(1, 1, "Value");
 
+                Assert.Throws<ArgumentOutOfRangeException>(() => sheet.AddManualRowPageBreak(A1.MaxRows + 1, save: false));
+                Assert.Throws<ArgumentOutOfRangeException>(() => sheet.AddManualColumnPageBreak(A1.MaxColumns + 1, save: false));
+
                 sheet.AddManualRowPageBreak(3, save: false);
                 sheet.AddManualRowPageBreak(6, save: false);
                 sheet.AddManualColumnPageBreak(2, save: false);
@@ -1580,6 +1583,39 @@ namespace OfficeIMO.Tests {
                 Assert.True(sheet.ClearManualPageBreaks(save: false));
                 Assert.False(sheet.ClearManualPageBreaks(save: false));
                 Assert.Empty(sheet.GetManualRowPageBreaks());
+            }
+
+            File.Delete(path);
+        }
+
+        [Fact]
+        public void ManualPageBreaks_ClearOnlyManualBreaks() {
+            string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            using (var doc = ExcelDocument.Create(path)) {
+                var sheet = doc.AddWorkSheet("Print");
+                sheet.CellValue(1, 1, "Value");
+                sheet.AddManualRowPageBreak(3, save: false);
+
+                var wsPartField = typeof(ExcelSheet).GetField("_worksheetPart", BindingFlags.NonPublic | BindingFlags.Instance);
+                Assert.NotNull(wsPartField);
+                var wsPart = (WorksheetPart)wsPartField!.GetValue(sheet)!;
+                RowBreaks rowBreaks = wsPart.Worksheet.GetFirstChild<RowBreaks>()!;
+                rowBreaks.Append(new Break {
+                    Id = 10U,
+                    Min = 0U,
+                    Max = 16383U,
+                    ManualPageBreak = false
+                });
+                rowBreaks.Count = 2U;
+                rowBreaks.ManualBreakCount = 1U;
+
+                Assert.True(sheet.ClearManualRowPageBreaks(save: false));
+                RowBreaks remaining = wsPart.Worksheet.GetFirstChild<RowBreaks>()!;
+                Break automatic = Assert.Single(remaining.Elements<Break>());
+                Assert.Equal(10U, automatic.Id!.Value);
+                Assert.False(automatic.ManualPageBreak!.Value);
+                Assert.Equal(1U, remaining.Count!.Value);
+                Assert.Equal(0U, remaining.ManualBreakCount!.Value);
             }
 
             File.Delete(path);

--- a/OfficeIMO.Tests/Excel.SheetNameValidationAndPreflight.cs
+++ b/OfficeIMO.Tests/Excel.SheetNameValidationAndPreflight.cs
@@ -1569,8 +1569,18 @@ namespace OfficeIMO.Tests {
                 sheet.AddManualColumnPageBreak(2, save: false);
                 sheet.AddManualColumnPageBreak(4, save: false);
 
+                var wsPartField = typeof(ExcelSheet).GetField("_worksheetPart", BindingFlags.NonPublic | BindingFlags.Instance);
+                Assert.NotNull(wsPartField);
+                var wsPart = (WorksheetPart)wsPartField!.GetValue(sheet)!;
+                RowBreaks rowBreaks = wsPart.Worksheet.GetFirstChild<RowBreaks>()!;
+                rowBreaks.Append(new Break { Id = 9U, Min = 0U, Max = 16383U, ManualPageBreak = false });
+                rowBreaks.Count = 3U;
+                rowBreaks.ManualBreakCount = 2U;
+
                 Assert.Equal(new[] { 3, 6 }, sheet.GetManualRowPageBreaks());
                 Assert.Equal(new[] { 2, 4 }, sheet.GetManualColumnPageBreaks());
+                Assert.False(sheet.RemoveManualRowPageBreak(9, save: false));
+                Assert.Contains(rowBreaks.Elements<Break>(), pageBreak => pageBreak.Id?.Value == 9U && pageBreak.ManualPageBreak?.Value != true);
 
                 Assert.True(sheet.RemoveManualRowPageBreak(3, save: false));
                 Assert.False(sheet.RemoveManualRowPageBreak(99, save: false));
@@ -1583,6 +1593,7 @@ namespace OfficeIMO.Tests {
                 Assert.True(sheet.ClearManualPageBreaks(save: false));
                 Assert.False(sheet.ClearManualPageBreaks(save: false));
                 Assert.Empty(sheet.GetManualRowPageBreaks());
+                Assert.Contains(rowBreaks.Elements<Break>(), pageBreak => pageBreak.Id?.Value == 9U && pageBreak.ManualPageBreak?.Value != true);
             }
 
             File.Delete(path);

--- a/OfficeIMO.Tests/Excel.Subtotals.cs
+++ b/OfficeIMO.Tests/Excel.Subtotals.cs
@@ -61,5 +61,31 @@ namespace OfficeIMO.Tests {
                 Assert.Empty(document.ValidateOpenXml());
             }
         }
+
+        [Fact]
+        public void Test_SubtotalSummary_RejectsOutputBeyondWorksheetBounds() {
+            string filePath = Path.Combine(_directoryWithFiles, "SubtotalSummaryBounds.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Region");
+                sheet.CellValue(1, 2, "Sales");
+                sheet.CellValue(2, 1, "NA");
+                sheet.CellValue(2, 2, 100);
+
+                Assert.Throws<ArgumentOutOfRangeException>(() => sheet.AddSubtotalSummary(new ExcelSubtotalOptions {
+                    DataEndRow = 2,
+                    GroupColumn = 1,
+                    ValueColumns = new[] { 2 },
+                    SummaryStartRow = A1.MaxRows
+                }));
+
+                Assert.Throws<ArgumentOutOfRangeException>(() => sheet.AddSubtotalSummary(new ExcelSubtotalOptions {
+                    DataEndRow = 2,
+                    GroupColumn = A1.MaxColumns + 1,
+                    ValueColumns = new[] { 2 },
+                    SummaryStartRow = 5
+                }));
+            }
+        }
     }
 }

--- a/OfficeIMO.Tests/Excel.Subtotals.cs
+++ b/OfficeIMO.Tests/Excel.Subtotals.cs
@@ -1,0 +1,65 @@
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_SubtotalSummary_WritesFormulasAndOutlinesGroups() {
+            string filePath = Path.Combine(_directoryWithFiles, "SubtotalSummary.xlsx");
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Region");
+                sheet.CellValue(1, 2, "Sales");
+                sheet.CellValue(1, 3, "Units");
+                sheet.CellValue(2, 1, "NA");
+                sheet.CellValue(2, 2, 100);
+                sheet.CellValue(2, 3, 2);
+                sheet.CellValue(3, 1, "NA");
+                sheet.CellValue(3, 2, 150);
+                sheet.CellValue(3, 3, 3);
+                sheet.CellValue(4, 1, "EMEA");
+                sheet.CellValue(4, 2, 200);
+                sheet.CellValue(4, 3, 4);
+                sheet.CellValue(5, 1, "EMEA");
+                sheet.CellValue(5, 2, 50);
+                sheet.CellValue(5, 3, 1);
+
+                ExcelSubtotalResult result = sheet.AddSubtotalSummary(new ExcelSubtotalOptions {
+                    DataEndRow = 5,
+                    GroupColumn = 1,
+                    ValueColumns = new[] { 2, 3 },
+                    SummaryStartRow = 7
+                });
+
+                Assert.Equal("A7:C10", result.SummaryRange);
+                Assert.Equal(2, result.GroupCount);
+                Assert.True(result.GrandTotalWritten);
+                Assert.Equal("NA", result.Groups[0].Key);
+                Assert.Equal(8, result.Groups[0].SummaryRow);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                SheetData sheetData = wsPart.Worksheet.GetFirstChild<SheetData>()!;
+                Cell b8 = sheetData.Descendants<Cell>().First(cell => cell.CellReference?.Value == "B8");
+                Cell c10 = sheetData.Descendants<Cell>().First(cell => cell.CellReference?.Value == "C10");
+                Assert.Equal("SUBTOTAL(9,B2:B3)", b8.CellFormula?.Text);
+                Assert.Equal("SUBTOTAL(9,C2:C5)", c10.CellFormula?.Text);
+
+                Row row2 = sheetData.Elements<Row>().First(row => row.RowIndex?.Value == 2U);
+                Row row4 = sheetData.Elements<Row>().First(row => row.RowIndex?.Value == 4U);
+                Assert.Equal((byte)1, row2.OutlineLevel?.Value);
+                Assert.Equal((byte)1, row4.OutlineLevel?.Value);
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.Tables.cs
+++ b/OfficeIMO.Tests/Excel.Tables.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -32,6 +33,39 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("A1:B2", tablePart.Table.Reference!.Value);
                 Assert.Equal("MyTable", tablePart.Table.Name);
                 Assert.Equal("TableStyleMedium9", tablePart.Table.TableStyleInfo!.Name!.Value);
+            }
+        }
+
+        [Fact]
+        public void Test_InsertDataTableAsTableSetStylePersistsDirectTableVisualOptions() {
+            string filePath = Path.Combine(_directoryWithFiles, "Table.DirectVisualStyle.xlsx");
+            var table = new DataTable("Sales");
+            table.Columns.Add("Region", typeof(string));
+            table.Columns.Add("Sales", typeof(int));
+            table.Rows.Add("NA", 100);
+            table.Rows.Add("EMEA", 200);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.GetOrCreateSheet("Data", SheetNameValidationMode.Sanitize);
+                string range = sheet.InsertDataTableAsTable(table, tableName: "Sales", style: TableStyle.TableStyleMedium9);
+                sheet.SetTableStyle(
+                    range,
+                    TableStyle.TableStyleMedium9,
+                    showFirstColumn: true,
+                    showLastColumn: true,
+                    showRowStripes: false,
+                    showColumnStripes: true);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                TableDefinitionPart tablePart = wsPart.TableDefinitionParts.First();
+                TableStyleInfo styleInfo = tablePart.Table.TableStyleInfo!;
+                Assert.True(styleInfo.ShowFirstColumn!.Value);
+                Assert.True(styleInfo.ShowLastColumn!.Value);
+                Assert.False(styleInfo.ShowRowStripes!.Value);
+                Assert.True(styleInfo.ShowColumnStripes!.Value);
             }
         }
 

--- a/OfficeIMO.Tests/Excel.Template.cs
+++ b/OfficeIMO.Tests/Excel.Template.cs
@@ -47,6 +47,45 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ExcelTemplate_CreateFromTemplatePreservesStylesAndThemeParts() {
+            string templatePath = Path.Combine(_directoryWithFiles, "ExcelTemplate.SourceTemplate.xlsx");
+            string outputPath = Path.Combine(_directoryWithFiles, "ExcelTemplate.FromTemplate.xlsx");
+
+            using (var document = ExcelDocument.Create(templatePath)) {
+                var sheet = document.AddWorkSheet("Template");
+                sheet.CellAt(1, 1).SetValue("{{Name}}").SetBold().SetFillColor("FFF2CC");
+                sheet.CellAt(2, 1).SetValue("Footer");
+                var data = new ExcelChartData(
+                    new[] { "Q1", "Q2" },
+                    new[] { new ExcelChartSeries("Sales", new[] { 10d, 20d }) });
+                sheet.AddChart(data, row: 1, column: 4, widthPixels: 320, heightPixels: 200, type: ExcelChartType.ColumnClustered, title: "Template Chart");
+                document.Save(false);
+            }
+
+            using (var document = ExcelDocument.CreateFromTemplate(templatePath, outputPath)) {
+                int replacements = document.ApplyTemplate(new Dictionary<string, object?> {
+                    ["Name"] = "Adatum"
+                });
+
+                Assert.Equal(1, replacements);
+                document.Save(false);
+            }
+
+            using (var document = ExcelDocument.Load(outputPath, readOnly: true)) {
+                var sheet = document["Template"];
+                Assert.Equal("Adatum", sheet.CellAt(1, 1).GetValue<string>());
+                Assert.Equal("Footer", sheet.CellAt(2, 1).GetValue<string>());
+
+                var style = sheet.CellAt(1, 1).GetStyle();
+                Assert.True(style.Bold);
+                Assert.Equal("FFFFF2CC", style.FillColorArgb);
+
+                Assert.NotNull(document.WorkbookPartRoot.GetPartsOfType<ThemePart>().FirstOrDefault());
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
         public void Test_ExcelTemplate_CanThrowOnMissingMarker() {
             string filePath = Path.Combine(_directoryWithFiles, "ExcelTemplate.MissingMarker.xlsx");
 

--- a/OfficeIMO.Tests/Excel.Template.cs
+++ b/OfficeIMO.Tests/Excel.Template.cs
@@ -174,6 +174,22 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ExcelTemplate_RepeatingRowsRejectsExpansionBeyondWorksheetLimit() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelTemplate.RepeatingRowsBounds.xlsx");
+
+            using var document = ExcelDocument.Create(filePath);
+            var sheet = document.AddWorkSheet("Invoice");
+            sheet.CellAt(A1.MaxRows, 1).SetValue("{{Name}}");
+
+            ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                sheet.ApplyTemplateRows(A1.MaxRows, new[] {
+                    new Dictionary<string, object?> { ["Name"] = "One" },
+                    new Dictionary<string, object?> { ["Name"] = "Two" }
+                }));
+            Assert.Equal("rowBindings", exception.ParamName);
+        }
+
+        [Fact]
         public void Test_ExcelTemplate_RepeatingRowsRebasesFormulasAndShiftedMerges() {
             string filePath = Path.Combine(_directoryWithFiles, "ExcelTemplate.RepeatingRowsFormulas.xlsx");
 

--- a/OfficeIMO.Tests/Excel.Theme.cs
+++ b/OfficeIMO.Tests/Excel.Theme.cs
@@ -1,0 +1,32 @@
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_ExcelWorkbookTheme_CanResetRenameAndReadBack() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelWorkbookTheme.ResetRename.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Data");
+                document.ResetWorkbookTheme("Contoso Workbook Theme");
+                ExcelWorkbookThemeInfo info = document.GetWorkbookTheme(includeXml: true);
+
+                Assert.True(info.HasTheme);
+                Assert.Equal("Contoso Workbook Theme", info.Name);
+                Assert.Contains("Contoso Workbook Theme", info.Xml);
+                document.Save();
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                ThemePart themePart = spreadsheet.WorkbookPart!.GetPartsOfType<ThemePart>().Single();
+                using var reader = new StreamReader(themePart.GetStream(FileMode.Open, FileAccess.Read));
+                string xml = reader.ReadToEnd();
+                Assert.Contains("Contoso Workbook Theme", xml);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.WorkbookIntelligence.cs
+++ b/OfficeIMO.Tests/Excel.WorkbookIntelligence.cs
@@ -1,0 +1,221 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_ExcelWorkbookIntelligence_ReportsFormulasDoctorDiffAndCompliance() {
+            string leftPath = Path.Combine(_directoryWithFiles, "ExcelWorkbookIntelligence.Left.xlsx");
+            string rightPath = Path.Combine(_directoryWithFiles, "ExcelWorkbookIntelligence.Right.xlsx");
+
+            using (var document = ExcelDocument.Create(leftPath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, 10);
+                sheet.CellValue(1, 2, 20);
+                sheet.CellFormula(1, 3, "SUM(A1:B1)+NOW()");
+                sheet.MergeRange("A3:B3");
+                document.SetNamedRange("TotalValue", "'Data'!C1", save: false);
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Create(rightPath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, 11);
+                sheet.CellValue(1, 2, 20);
+                sheet.CellFormula(1, 3, "SUM(A1:B1)");
+                document.Save();
+            }
+
+            using (var left = ExcelDocument.Load(leftPath, readOnly: false))
+            using (var right = ExcelDocument.Load(rightPath, readOnly: true)) {
+                ExcelFormulaAnalysisReport formulas = left.AnalyzeFormulas();
+                Assert.Equal(1, formulas.FormulaCount);
+                Assert.Equal(1, formulas.VolatileFormulaCount);
+                Assert.Contains("SUM", formulas.Formulas[0].Functions);
+
+                Assert.Contains(left.ListNamedRanges(), name => name.Name == "TotalValue");
+                left.RenameNamedRange("TotalValue", "GrandTotal", save: false);
+                Assert.Contains(left.ListNamedRanges(), name => name.Name == "GrandTotal");
+
+                ExcelWorkbookDiagnosticReport doctor = left.RunWorkbookDoctor(new ExcelWorkbookDoctorOptions { ValidateOpenXml = false });
+                Assert.False(doctor.HasErrors);
+                Assert.DoesNotContain(doctor.Issues, issue => issue.Severity == ExcelFindingSeverity.Error);
+
+                ExcelWorkbookDiffReport diff = left.CompareWorkbook(right);
+                Assert.False(diff.AreEqual);
+                Assert.Contains(diff.Differences, item => item.Category == "Cell" && item.Address == "A1");
+
+                ExcelAccessibilityReport accessibility = left.AnalyzeAccessibility();
+                Assert.Contains(accessibility.Findings, finding => finding.Category == "MergedCells");
+
+                ExcelDataModelReport dataModel = left.InspectDataModel();
+                Assert.False(dataModel.HasDataModelOrQueries);
+
+                ExcelStreamingContractReport streaming = left.GetStreamingContract();
+                Assert.Equal(1, streaming.WorksheetCount);
+            }
+        }
+
+        [Fact]
+        public void Test_ExcelDelimitedImport_NormalizesCsvIntoTable() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelDelimitedImport.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                ExcelDelimitedImportResult result = document.ImportDelimitedText(
+                    "Name;Amount\r\nAlpha;10.5\r\nBeta;11.75",
+                    new ExcelDelimitedImportOptions { Delimiter = ';', SheetName = "Import" });
+
+                Assert.Equal(';', result.Delimiter);
+                Assert.Equal("A1:B3", result.ImportResult.Range);
+                Assert.Equal(2, result.ImportResult.RowCount);
+                Assert.Equal(2, result.ImportResult.ColumnCount);
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.True(document["Import"].TryGetCellText(2, 1, out string name));
+                Assert.Equal("Alpha", name);
+            }
+        }
+
+        [Fact]
+        public void Test_ExcelWorkbookIntelligence_AdvancedReportsRepairAndDiffDepth() {
+            string leftPath = Path.Combine(_directoryWithFiles, "ExcelWorkbookIntelligence.Advanced.Left.xlsx");
+            string rightPath = Path.Combine(_directoryWithFiles, "ExcelWorkbookIntelligence.Advanced.Right.xlsx");
+
+            using (var document = ExcelDocument.Create(leftPath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "{{CustomerName}}");
+                sheet.CellValue(1, 2, 10);
+                sheet.CellFormula(1, 3, "SUM(B1:B1)");
+                sheet.SetComment("A1", "Needs customer binding", author: "Reviewer", initials: "RV");
+                sheet.AddTable("A1:C1", hasHeader: true, name: "DataTable", TableStyle.TableStyleMedium2, includeAutoFilter: true);
+                document.SetNamedRange("CustomerCell", "'Data'!A1", save: false);
+                document.AddPowerQueryMetadata(new ExcelPowerQueryMetadataOptions {
+                    Name = "CustomerQuery",
+                    WorksheetName = "Data",
+                    CommandText = "let Source = Excel.CurrentWorkbook() in Source",
+                    RefreshOnOpen = true
+                });
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Create(rightPath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Northwind");
+                sheet.CellValue(1, 2, 10);
+                sheet.CellFormula(1, 3, "SUM(B1:B1)");
+                sheet.AddTable("A1:C1", hasHeader: true, name: "OtherTable", TableStyle.TableStyleMedium2, includeAutoFilter: true);
+                document.Save();
+            }
+
+            using (var left = ExcelDocument.Load(leftPath, readOnly: false))
+            using (var right = ExcelDocument.Load(rightPath, readOnly: true)) {
+                ExcelWorkbookCommentReport comments = left.InspectComments();
+                Assert.Equal(1, comments.CommentCount);
+                Assert.Empty(comments.Issues);
+
+                ExcelTemplateBindingReport missingTemplate = left.ValidateTemplateBindings(new Dictionary<string, object?>());
+                Assert.False(missingTemplate.Passed);
+                Assert.Contains("CustomerName", missingTemplate.MissingMarkerNames);
+                Assert.Contains("Excel Template Markers", missingTemplate.Markdown);
+
+                ExcelTemplateBindingReport boundTemplate = left.ValidateTemplateBindings(new Dictionary<string, object?> {
+                    ["CustomerName"] = "Northwind"
+                });
+                Assert.True(boundTemplate.Passed);
+
+                ExcelDataModelReport dataModel = left.InspectDataModel();
+                Assert.True(dataModel.HasDataModelOrQueries);
+                Assert.True(dataModel.ConnectionPartCount > 0);
+                Assert.True(dataModel.QueryTablePartCount > 0);
+
+                ExcelWorkbookDiffReport diff = left.CompareWorkbook(right, new ExcelWorkbookDiffOptions {
+                    CompareComments = true,
+                    CompareNamedRanges = true,
+                    CompareTables = true,
+                    CompareWorksheetMetadata = true,
+                    MaxDifferences = 20
+                });
+                Assert.False(diff.AreEqual);
+                Assert.Contains(diff.Differences, item => item.Category == "NamedRange");
+                Assert.Contains(diff.Differences, item => item.Category == "Table");
+                Assert.Contains(diff.Differences, item => item.Category == "Comment");
+
+                ExcelWorkbookRepairReport repair = left.RepairWorkbook(new ExcelWorkbookRepairOptions { Save = false });
+                Assert.True(repair.ActionCount > 0);
+                Assert.NotNull(repair.Before);
+                Assert.NotNull(repair.After);
+            }
+        }
+
+        [Fact]
+        public void Test_ExcelWorkbookIntelligence_ThreadedCommentsAndQueryMetadataContracts() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelWorkbookIntelligence.ThreadedAndQuery.xlsx");
+
+            string parentId;
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Review");
+                sheet.CellValue(1, 1, "Variance");
+                sheet.CellValue(1, 2, 123.45);
+
+                ExcelThreadedCommentResult parent = sheet.AddThreadedComment(new ExcelThreadedCommentOptions {
+                    Address = "B1",
+                    Text = "Please confirm the variance.",
+                    Author = "Finance Reviewer",
+                    Id = "{00000000-0000-0000-0000-000000000101}",
+                    Date = new DateTime(2026, 6, 22, 8, 0, 0, DateTimeKind.Utc)
+                });
+                parentId = parent.Id;
+
+                ExcelThreadedCommentResult reply = sheet.AddThreadedComment(new ExcelThreadedCommentOptions {
+                    Address = "B1",
+                    Text = "Confirmed against source data.",
+                    Author = "Report Owner",
+                    ParentId = parentId,
+                    Id = "{00000000-0000-0000-0000-000000000102}",
+                    Done = true
+                });
+
+                ExcelPowerQueryMetadataResult first = document.AddPowerQueryMetadata(new ExcelPowerQueryMetadataOptions {
+                    Name = "ReviewQuery",
+                    WorksheetName = "Review",
+                    QueryTableName = "ReviewQueryTable",
+                    CommandText = "let Source = Excel.CurrentWorkbook() in Source"
+                });
+                ExcelPowerQueryMetadataResult second = document.AddPowerQueryMetadata(new ExcelPowerQueryMetadataOptions {
+                    Name = "ReviewQueryRefresh",
+                    WorksheetName = "Review",
+                    CommandText = "let Source = Excel.CurrentWorkbook() in Source",
+                    RefreshOnOpen = true
+                });
+
+                Assert.Equal("B1", parent.CellReference);
+                Assert.False(parent.IsReply);
+                Assert.True(reply.IsReply);
+                Assert.True(reply.Done);
+                Assert.Equal(1U, first.ConnectionId);
+                Assert.Equal(2U, second.ConnectionId);
+                Assert.Equal("ReviewQueryTable", first.QueryTableName);
+                Assert.Equal("ReviewQueryRefreshTable", second.QueryTableName);
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelWorkbookCommentReport comments = document.InspectComments();
+                Assert.Equal(2, comments.ThreadedCommentCount);
+                Assert.Contains(comments.ThreadedComments, comment => comment.Id == parentId && comment.Author == "Finance Reviewer");
+                Assert.Contains(comments.ThreadedComments, comment => comment.ParentId == parentId && comment.Author == "Report Owner" && comment.Done);
+                Assert.Empty(comments.Issues);
+
+                ExcelDataModelReport dataModel = document.InspectDataModel();
+                Assert.True(dataModel.HasDataModelOrQueries);
+                Assert.Equal(2, dataModel.ConnectionPartCount);
+                Assert.Equal(2, dataModel.QueryTablePartCount);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.WorkbookIntelligence.cs
+++ b/OfficeIMO.Tests/Excel.WorkbookIntelligence.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
 using OfficeIMO.Excel;
 using Xunit;
 
@@ -66,10 +67,11 @@ namespace OfficeIMO.Tests {
             using (var document = ExcelDocument.Create(filePath)) {
                 ExcelDelimitedImportResult result = document.ImportDelimitedText(
                     "Name;Amount\r\nAlpha;10.5\r\nBeta;11.75",
-                    new ExcelDelimitedImportOptions { Delimiter = ';', SheetName = "Import" });
+                    new ExcelDelimitedImportOptions { Delimiter = ';', SheetName = "Import", TableName = "ImportData" });
 
                 Assert.Equal(';', result.Delimiter);
                 Assert.Equal("A1:B3", result.ImportResult.Range);
+                Assert.Equal("ImportData", result.ImportResult.TableName);
                 Assert.Equal(2, result.ImportResult.RowCount);
                 Assert.Equal(2, result.ImportResult.ColumnCount);
                 document.Save();
@@ -97,6 +99,12 @@ namespace OfficeIMO.Tests {
                 document.AddPowerQueryMetadata(new ExcelPowerQueryMetadataOptions {
                     Name = "CustomerQuery",
                     WorksheetName = "Data",
+                    CommandText = "let Source = Excel.CurrentWorkbook() in Source",
+                    RefreshOnOpen = true
+                });
+                document.AddWorkbookConnectionMetadata("<?xml version=\"1.0\" encoding=\"UTF-8\"?><connections xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"><connection id=\"77\" name=\"Existing\" refreshOnLoad=\"0\" type=\"1\"/></connections>");
+                document.AddPowerQueryMetadata(new ExcelPowerQueryMetadataOptions {
+                    Name = "IsolatedRefresh",
                     CommandText = "let Source = Excel.CurrentWorkbook() in Source",
                     RefreshOnOpen = true
                 });
@@ -132,6 +140,11 @@ namespace OfficeIMO.Tests {
                 Assert.True(dataModel.HasDataModelOrQueries);
                 Assert.True(dataModel.ConnectionPartCount > 0);
                 Assert.True(dataModel.QueryTablePartCount > 0);
+                using (SpreadsheetDocument package = SpreadsheetDocument.Open(leftPath, false)) {
+                    string existingConnection = EnumerateWorkbookConnectionXml(package.WorkbookPart!)
+                        .First(text => text.Contains("Existing", System.StringComparison.Ordinal));
+                    Assert.Contains("refreshOnLoad=\"0\"", existingConnection);
+                }
 
                 ExcelWorkbookDiffReport diff = left.CompareWorkbook(right, new ExcelWorkbookDiffOptions {
                     CompareComments = true,
@@ -149,6 +162,33 @@ namespace OfficeIMO.Tests {
                 Assert.True(repair.ActionCount > 0);
                 Assert.NotNull(repair.Before);
                 Assert.NotNull(repair.After);
+            }
+        }
+
+        [Fact]
+        public void Test_ExcelWorkbookDiff_ReportsRightOnlyCellsWithinSameDimension() {
+            string leftPath = Path.Combine(_directoryWithFiles, "ExcelWorkbookDiff.LeftSparse.xlsx");
+            string rightPath = Path.Combine(_directoryWithFiles, "ExcelWorkbookDiff.RightSparse.xlsx");
+
+            using (var document = ExcelDocument.Create(leftPath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "A");
+                sheet.CellValue(1, 3, "C");
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Create(rightPath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "A");
+                sheet.CellValue(1, 2, "B");
+                sheet.CellValue(1, 3, "C");
+                document.Save();
+            }
+
+            using (var left = ExcelDocument.Load(leftPath, readOnly: true))
+            using (var right = ExcelDocument.Load(rightPath, readOnly: true)) {
+                ExcelWorkbookDiffReport diff = left.CompareWorkbook(right);
+                Assert.Contains(diff.Differences, difference => difference.Category == "Cell" && difference.Address == "B1" && difference.RightValue == "B");
             }
         }
 
@@ -213,8 +253,29 @@ namespace OfficeIMO.Tests {
 
                 ExcelDataModelReport dataModel = document.InspectDataModel();
                 Assert.True(dataModel.HasDataModelOrQueries);
-                Assert.Equal(2, dataModel.ConnectionPartCount);
+                Assert.Equal(1, dataModel.ConnectionPartCount);
                 Assert.Equal(2, dataModel.QueryTablePartCount);
+            }
+        }
+
+        private static string ReadExtendedPartText(ExtendedPart part) {
+            using Stream stream = part.GetStream(FileMode.Open, FileAccess.Read);
+            using var reader = new StreamReader(stream);
+            return reader.ReadToEnd();
+        }
+
+        private static IEnumerable<string> EnumerateWorkbookConnectionXml(OpenXmlPartContainer container) {
+            foreach (IdPartPair pair in container.Parts) {
+                if (pair.OpenXmlPart is ConnectionsPart connectionsPart && connectionsPart.Connections != null) {
+                    yield return connectionsPart.Connections.OuterXml;
+                } else if (pair.OpenXmlPart is ExtendedPart extendedPart
+                    && extendedPart.ContentType.IndexOf("connections", System.StringComparison.OrdinalIgnoreCase) >= 0) {
+                    yield return ReadExtendedPartText(extendedPart);
+                }
+
+                foreach (string child in EnumerateWorkbookConnectionXml(pair.OpenXmlPart)) {
+                    yield return child;
+                }
             }
         }
     }

--- a/OfficeIMO.Tests/Excel.WorkbookIntelligence.cs
+++ b/OfficeIMO.Tests/Excel.WorkbookIntelligence.cs
@@ -166,6 +166,30 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ExcelWorkbookIntelligence_NamedRangeSavePersistsPackage() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelWorkbookIntelligence.NamedRangeSave.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Name");
+                sheet.CellValue(1, 2, "Value");
+                document.SetNamedRange("Totals", "'Data'!A1:B1", scope: sheet, save: true);
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                ExcelSheet sheet = document["Data"];
+                Assert.True(document.RenameNamedRange("Totals", "GrandTotal", sheet, save: true));
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelSheet sheet = document["Data"];
+                Assert.Null(document.GetNamedRange("Totals", sheet));
+                Assert.Equal("$A$1:$B$1", document.GetNamedRange("GrandTotal", sheet));
+            }
+        }
+
+
+        [Fact]
         public void Test_ExcelWorkbookDiff_ReportsRightOnlyCellsWithinSameDimension() {
             string leftPath = Path.Combine(_directoryWithFiles, "ExcelWorkbookDiff.LeftSparse.xlsx");
             string rightPath = Path.Combine(_directoryWithFiles, "ExcelWorkbookDiff.RightSparse.xlsx");
@@ -241,6 +265,7 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(2U, second.ConnectionId);
                 Assert.Equal("ReviewQueryTable", first.QueryTableName);
                 Assert.Equal("ReviewQueryRefreshTable", second.QueryTableName);
+                Assert.Throws<ArgumentException>(() => sheet.AddThreadedComment("XFE1", "Outside sheet"));
                 document.Save();
             }
 

--- a/OfficeIMO.Tests/Excel.WorkbookIntelligence.cs
+++ b/OfficeIMO.Tests/Excel.WorkbookIntelligence.cs
@@ -278,5 +278,42 @@ namespace OfficeIMO.Tests {
                 }
             }
         }
+
+        [Fact]
+        public void Test_ExcelWorkbookDiff_ReportsRightOnlyCellStyles() {
+            string leftPath = Path.Combine(_directoryWithFiles, "ExcelWorkbookDiff.LeftStyle.xlsx");
+            string rightPath = Path.Combine(_directoryWithFiles, "ExcelWorkbookDiff.RightStyle.xlsx");
+
+            using (var left = ExcelDocument.Create(leftPath)) {
+                left.AddWorkSheet("Data");
+                left.Save();
+            }
+
+            using (var right = ExcelDocument.Create(rightPath)) {
+                var sheet = right.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Styled");
+                sheet.CellBold(1, 1, true);
+                right.Save();
+            }
+
+            using (var left = ExcelDocument.Load(leftPath, readOnly: true))
+            using (var right = ExcelDocument.Load(rightPath, readOnly: true)) {
+                ExcelWorkbookDiffReport report = left.CompareWorkbook(right, new ExcelWorkbookDiffOptions {
+                    CompareCells = false,
+                    CompareCellStyles = true,
+                    CompareWorksheetMetadata = false,
+                    CompareTables = false,
+                    CompareNamedRanges = false,
+                    CompareComments = false
+                });
+
+                Assert.Contains(report.Differences, difference =>
+                    difference.Category == "CellStyle"
+                    && difference.SheetName == "Data"
+                    && difference.Address == "A1"
+                    && string.IsNullOrEmpty(difference.LeftValue)
+                    && !string.IsNullOrEmpty(difference.RightValue));
+            }
+        }
     }
 }

--- a/OfficeIMO.Tests/Excel.WorkbookIntelligence.cs
+++ b/OfficeIMO.Tests/Excel.WorkbookIntelligence.cs
@@ -103,11 +103,12 @@ namespace OfficeIMO.Tests {
                     RefreshOnOpen = true
                 });
                 document.AddWorkbookConnectionMetadata("<?xml version=\"1.0\" encoding=\"UTF-8\"?><connections xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"><connection id=\"77\" name=\"Existing\" refreshOnLoad=\"0\" type=\"1\"/></connections>");
-                document.AddPowerQueryMetadata(new ExcelPowerQueryMetadataOptions {
+                ExcelPowerQueryMetadataResult isolatedRefresh = document.AddPowerQueryMetadata(new ExcelPowerQueryMetadataOptions {
                     Name = "IsolatedRefresh",
                     CommandText = "let Source = Excel.CurrentWorkbook() in Source",
                     RefreshOnOpen = true
                 });
+                Assert.Equal(78U, isolatedRefresh.ConnectionId);
                 document.Save();
             }
 
@@ -185,6 +186,38 @@ namespace OfficeIMO.Tests {
                 ExcelSheet sheet = document["Data"];
                 Assert.Null(document.GetNamedRange("Totals", sheet));
                 Assert.Equal("$A$1:$B$1", document.GetNamedRange("GrandTotal", sheet));
+            }
+        }
+
+        [Fact]
+        public void Test_ExcelWorkbookIntelligence_RepairSaveSkipsMissingDefaultDestination() {
+            using var stream = new MemoryStream();
+            using (var document = ExcelDocument.Create(stream, autoSave: true)) {
+                document.AddWorkSheet("Data").CellValue(1, 1, "Ready");
+            }
+
+            stream.Position = 0;
+            using (var document = ExcelDocument.Load(stream, readOnly: false, autoSave: false)) {
+                ExcelWorkbookRepairReport repair = document.RepairWorkbook(new ExcelWorkbookRepairOptions { Save = true });
+                Assert.NotNull(repair.Before);
+                Assert.NotNull(repair.After);
+            }
+        }
+
+        [Fact]
+        public void Test_ExcelWorkbookIntelligence_PowerQueryRejectsMissingWorksheetBeforeConnectionMutation() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelWorkbookIntelligence.QueryMissingSheet.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Data");
+
+                Assert.Throws<ArgumentOutOfRangeException>(() => document.AddPowerQueryMetadata(new ExcelPowerQueryMetadataOptions {
+                    Name = "MissingSheetQuery",
+                    WorksheetName = "Missing",
+                    CommandText = "let Source = Excel.CurrentWorkbook() in Source"
+                }));
+
+                Assert.False(document.InspectDataModel().HasDataModelOrQueries);
             }
         }
 

--- a/OfficeIMO.Tests/Excel.WorkbookMerge.cs
+++ b/OfficeIMO.Tests/Excel.WorkbookMerge.cs
@@ -1,0 +1,40 @@
+using System.IO;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_ExcelWorkbookMerge_ImportsSelectedSheetsWithPrefix() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "ExcelWorkbookMerge.Source.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "ExcelWorkbookMerge.Target.xlsx");
+
+            using (var source = ExcelDocument.Create(sourcePath)) {
+                source.AddWorkSheet("North").CellValue(1, 1, "North value");
+                source.AddWorkSheet("South").CellValue(1, 1, "South value");
+                source.Save();
+            }
+
+            using (var target = ExcelDocument.Create(targetPath))
+            using (var source = ExcelDocument.Load(sourcePath, readOnly: true)) {
+                target.AddWorkSheet("Summary");
+                ExcelWorkbookMergeResult result = target.MergeWorkbookFrom(source, new ExcelWorkbookMergeOptions {
+                    SheetNames = new[] { "South" },
+                    SheetNamePrefix = "Imported "
+                });
+
+                Assert.Equal(1, result.SheetCount);
+                Assert.Equal(new[] { "South" }, result.SourceSheets);
+                Assert.Equal(new[] { "Imported South" }, result.TargetSheets);
+                Assert.True(target["Imported South"].TryGetCellText(1, 1, out var importedValue));
+                Assert.Equal("South value", importedValue);
+                target.Save();
+            }
+
+            using (var reloaded = ExcelDocument.Load(targetPath, readOnly: true)) {
+                Assert.True(reloaded["Imported South"].TryGetCellText(1, 1, out var importedValue));
+                Assert.Equal("South value", importedValue);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.WorkbookMerge.cs
+++ b/OfficeIMO.Tests/Excel.WorkbookMerge.cs
@@ -36,5 +36,34 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("South value", importedValue);
             }
         }
+
+        [Fact]
+        public void Test_ExcelWorkbookMerge_StreamBackedWorkbookDoesNotForceSave() {
+            using var targetStream = new MemoryStream();
+            using var sourceStream = new MemoryStream();
+
+            using (var source = ExcelDocument.Create(sourceStream, autoSave: false)) {
+                source.AddWorkSheet("Source").CellValue(1, 1, "Imported");
+                source.Save(sourceStream);
+            }
+
+            sourceStream.Position = 0;
+            using (var target = ExcelDocument.Create(targetStream, autoSave: false))
+            using (var source = ExcelDocument.Load(sourceStream, readOnly: true)) {
+                target.AddWorkSheet("Target");
+                ExcelWorkbookMergeResult result = target.MergeWorkbookFrom(source);
+
+                Assert.Equal(1, result.SheetCount);
+                Assert.True(target["Source"].TryGetCellText(1, 1, out var imported));
+                Assert.Equal("Imported", imported);
+                target.Save(targetStream);
+            }
+
+            targetStream.Position = 0;
+            using var reloaded = ExcelDocument.Load(targetStream, readOnly: true);
+            Assert.Equal(2, reloaded.Sheets.Count);
+            Assert.True(reloaded["Source"].TryGetCellText(1, 1, out var value));
+            Assert.Equal("Imported", value);
+        }
     }
 }

--- a/OfficeIMO.Tests/Excel.WorkflowReviewRegressions.cs
+++ b/OfficeIMO.Tests/Excel.WorkflowReviewRegressions.cs
@@ -1,0 +1,195 @@
+using System;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_NamedRange_DefaultSave_DoesNotForceStreamPackageSave() {
+            using var source = new MemoryStream();
+            using var destination = new MemoryStream();
+
+            using (var document = ExcelDocument.Create(source, autoSave: false)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Ready");
+
+                document.SetNamedRange("Anchor", "A1", sheet);
+                document.Save(destination);
+            }
+
+            destination.Position = 0;
+            using var loaded = ExcelDocument.Load(destination, readOnly: true);
+            Assert.Equal("$A$1", loaded.GetNamedRange("Anchor", loaded["Data"]));
+        }
+
+        [Fact]
+        public void Test_CustomDocumentProperties_DirectCollectionEditsAreTracked() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelCustomDocumentProperties.DirectCollection.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Data").CellValue(1, 1, "Ready");
+                document.CustomDocumentProperties["Direct"] = new ExcelCustomProperty("Tracked");
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                Assert.Equal("Tracked", document.CustomDocumentProperties["Direct"].Text);
+                document.CustomDocumentProperties.Clear();
+                document.Save();
+            }
+
+            using (SpreadsheetDocument package = SpreadsheetDocument.Open(filePath, false)) {
+                Assert.Null(package.CustomFilePropertiesPart);
+            }
+        }
+
+        [Fact]
+        public void Test_ManualPageBreak_ConvertsExistingAutomaticBreak() {
+            string filePath = Path.Combine(_directoryWithFiles, "PageBreaks.ConvertAutomatic.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Data").CellValue(1, 1, "Ready");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument package = SpreadsheetDocument.Open(filePath, true)) {
+                WorksheetPart worksheetPart = package.WorkbookPart!.WorksheetParts.Single();
+                worksheetPart.Worksheet.Append(new RowBreaks(
+                    new Break { Id = 3U, Min = 0U, Max = 16383U, ManualPageBreak = false }) {
+                    Count = 1U,
+                    ManualBreakCount = 0U
+                });
+                worksheetPart.Worksheet.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                document["Data"].AddManualRowPageBreak(3);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument package = SpreadsheetDocument.Open(filePath, false)) {
+                Break pageBreak = Assert.Single(package.WorkbookPart!.WorksheetParts.Single().Worksheet.GetFirstChild<RowBreaks>()!.Elements<Break>());
+                Assert.Equal(3U, pageBreak.Id!.Value);
+                Assert.True(pageBreak.ManualPageBreak!.Value);
+            }
+        }
+
+        [Fact]
+        public void Test_TimePeriodConditionalFormatting_EmitsFormula() {
+            string filePath = Path.Combine(_directoryWithFiles, "ConditionalTimePeriodFormula.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, new DateTime(2026, 6, 22));
+                sheet.AddConditionalTimePeriodRule("A1:A3", TimePeriodValues.Today);
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelConditionalFormattingInfo rule = Assert.Single(document["Data"].GetConditionalFormattingRules("A1"));
+                Assert.Equal("TimePeriod", rule.Type);
+                Assert.Single(rule.Formulas);
+                Assert.Contains("TODAY()", rule.Formulas[0], StringComparison.OrdinalIgnoreCase);
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_SetRowLayout_RejectsRowsBeyondWorksheetLimit() {
+            string filePath = Path.Combine(_directoryWithFiles, "RowLayout.Bounds.xlsx");
+
+            using var document = ExcelDocument.Create(filePath);
+            ExcelSheet sheet = document.AddWorkSheet("Data");
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => sheet.SetRowLayout(A1.MaxRows + 1, new ExcelRowLayoutOptions { Height = 20 }));
+        }
+
+        [Fact]
+        public void Test_DashboardBuilder_RejectsHeaderTableOverlap() {
+            string filePath = Path.Combine(_directoryWithFiles, "DashboardBuilder.Overlap.xlsx");
+            var data = new System.Data.DataTable("Sales");
+            data.Columns.Add("Region", typeof(string));
+            data.Rows.Add("EU");
+
+            using var document = ExcelDocument.Create(filePath);
+            ExcelSheet sheet = document.AddWorkSheet("Dashboard");
+
+            Assert.Throws<ArgumentException>(() => sheet.AddDashboard(data, new ExcelDashboardOptions {
+                Title = "Sales Dashboard",
+                TableRow = 1,
+                AddChart = false
+            }));
+        }
+
+        [Fact]
+        public void Test_InspectionSnapshot_ExpandsRangeHyperlinksToCells() {
+            string filePath = Path.Combine(_directoryWithFiles, "Inspection.RangeHyperlinks.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "One");
+                sheet.CellValue(2, 1, "Two");
+                sheet.CellValue(3, 1, "Three");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument package = SpreadsheetDocument.Open(filePath, true)) {
+                WorksheetPart worksheetPart = package.WorkbookPart!.WorksheetParts.Single();
+                worksheetPart.AddHyperlinkRelationship(new Uri("https://example.com/report", UriKind.Absolute), true, "rIdRangeHyperlink");
+                worksheetPart.Worksheet.Append(new Hyperlinks(new Hyperlink {
+                    Reference = "A1:A3",
+                    Id = "rIdRangeHyperlink"
+                }));
+                worksheetPart.Worksheet.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelWorksheetSnapshot sheet = Assert.Single(document.CreateInspectionSnapshot().Worksheets);
+                Assert.All(sheet.Cells.Where(cell => cell.Row >= 1 && cell.Row <= 3), cell => Assert.NotNull(cell.Hyperlink));
+            }
+        }
+
+        [Fact]
+        public void Test_CompareWorkbook_ReportsCommentOnlyCells() {
+            string leftPath = Path.Combine(_directoryWithFiles, "CompareComments.Left.xlsx");
+            string rightPath = Path.Combine(_directoryWithFiles, "CompareComments.Right.xlsx");
+
+            using (var document = ExcelDocument.Create(leftPath)) {
+                document.AddWorkSheet("Data");
+                document.Save();
+            }
+
+            File.Copy(leftPath, rightPath, overwrite: true);
+            using (SpreadsheetDocument package = SpreadsheetDocument.Open(rightPath, true)) {
+                WorksheetPart worksheetPart = package.WorkbookPart!.WorksheetParts.Single();
+                WorksheetCommentsPart commentsPart = worksheetPart.AddNewPart<WorksheetCommentsPart>();
+                commentsPart.Comments = new Comments(
+                    new Authors(new Author("Reviewer")),
+                    new CommentList(new Comment(
+                        new CommentText(new Run(new Text("Blank cell note")))) {
+                        Reference = "A1",
+                        AuthorId = 0U
+                    }));
+                commentsPart.Comments.Save();
+            }
+
+            using var left = ExcelDocument.Load(leftPath, readOnly: true);
+            using var right = ExcelDocument.Load(rightPath, readOnly: true);
+
+            ExcelWorkbookDiffReport diff = left.CompareWorkbook(right, new ExcelWorkbookDiffOptions {
+                CompareCells = false,
+                CompareCellStyles = false,
+                CompareTables = false,
+                CompareWorksheetMetadata = false,
+                CompareNamedRanges = false,
+                CompareComments = true
+            });
+
+            Assert.Contains(diff.Differences, difference => difference.Category == "Comment" && difference.RightValue?.Contains("Blank cell note", StringComparison.Ordinal) == true);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.WorkflowReviewRegressions.cs
+++ b/OfficeIMO.Tests/Excel.WorkflowReviewRegressions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Data;
 using System.IO;
 using System.Linq;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using OfficeIMO.Excel;
@@ -363,6 +364,104 @@ namespace OfficeIMO.Tests {
                 ExcelImage imageRecord = Assert.Single(document["Images"].Images);
                 Assert.Throws<NotSupportedException>(() => imageRecord.MoveTo(2, 2));
             }
+        }
+
+        [Fact]
+        public void Test_ImageMoveTo_RejectsOutOfBoundsCellAnchors() {
+            string filePath = Path.Combine(_directoryWithFiles, "ImageMove.Bounds.xlsx");
+            byte[] image = File.ReadAllBytes(Path.Combine(_directoryWithImages, "EvotecLogo.png"));
+
+            using var document = ExcelDocument.Create(filePath);
+            ExcelSheet sheet = document.AddWorkSheet("Images");
+            ExcelImage imageRecord = sheet.AddImage(1, 1, image, "image/png", widthPixels: 16, heightPixels: 16);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => imageRecord.MoveTo(A1.MaxRows + 1, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => imageRecord.MoveTo(1, A1.MaxColumns + 1));
+        }
+
+        [Fact]
+        public void Test_DashboardChart_RejectsOutOfBoundsAnchorsAndDimensions() {
+            using var document = ExcelDocument.Create(new MemoryStream(), autoSave: false);
+            ExcelSheet sheet = document.AddWorkSheet("Dashboard");
+            sheet.CellValue(1, 1, "Region");
+            sheet.CellValue(1, 2, "Sales");
+            sheet.CellValue(2, 1, "EU");
+            sheet.CellValue(2, 2, 10);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => sheet.AddDashboardChart(new ExcelDashboardChartOptions { Range = "A1:B2", Row = A1.MaxRows + 1, Column = 1 }));
+            Assert.Throws<ArgumentOutOfRangeException>(() => sheet.AddDashboardChart(new ExcelDashboardChartOptions { Range = "A1:B2", Row = 1, Column = A1.MaxColumns + 1 }));
+            Assert.Throws<ArgumentOutOfRangeException>(() => sheet.AddDashboardChart(new ExcelDashboardChartOptions { Range = "A1:B2", WidthPixels = 0 }));
+            Assert.Throws<ArgumentOutOfRangeException>(() => sheet.AddDashboardChart(new ExcelDashboardChartOptions { Range = "A1:B2", HeightPixels = -1 }));
+        }
+
+        [Fact]
+        public void Test_PrintAreaAndTitles_MarkStreamWorkbookDirty() {
+            using var source = new MemoryStream();
+            using (var document = ExcelDocument.Create(source, autoSave: false)) {
+                ExcelSheet sheet = document.AddWorkSheet("Report");
+                sheet.CellValue(1, 1, "Region");
+                document.Save(source);
+            }
+
+            source.Position = 0;
+            using var destination = new MemoryStream();
+            using (var document = ExcelDocument.Load(source)) {
+                ExcelSheet sheet = document["Report"];
+                document.SetPrintArea(sheet, "A1:B2", save: false);
+                document.SetPrintTitles(sheet, firstRow: 1, lastRow: 1, firstCol: 1, lastCol: 1, save: false);
+                document.Save(destination);
+            }
+
+            destination.Position = 0;
+            using var loaded = ExcelDocument.Load(destination, readOnly: true);
+            ExcelSheet loadedSheet = loaded["Report"];
+            Assert.Equal("$A$1:$B$2", loadedSheet.GetPrintArea());
+            ExcelPrintTitles titles = loadedSheet.GetPrintTitles();
+            Assert.Equal(1, titles.FirstRow);
+            Assert.Equal(1, titles.LastRow);
+            Assert.Equal(1, titles.FirstColumn);
+            Assert.Equal(1, titles.LastColumn);
+        }
+
+        [Fact]
+        public void Test_WorksheetQueryTableMetadata_LinksWorksheetRelationship() {
+            string filePath = Path.Combine(_directoryWithFiles, "QueryTableMetadata.Linked.xlsx");
+            const string queryTableXml = "<queryTable xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" name=\"SalesQuery\" connectionId=\"1\"/>";
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Data");
+                document.AddWorksheetQueryTableMetadata("Data", queryTableXml);
+                document.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.Single();
+            Worksheet worksheet = worksheetPart.Worksheet!;
+            OpenXmlElement queryTableParts = Assert.Single(worksheet.ChildElements,
+                element => element.LocalName == "queryTableParts" && element.NamespaceUri == "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+            OpenXmlElement queryTablePart = Assert.Single(queryTableParts.ChildElements,
+                element => element.LocalName == "queryTablePart" && element.NamespaceUri == "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+            Assert.Equal("1", queryTableParts.GetAttribute("count", string.Empty).Value);
+            string? relationshipId = queryTablePart.GetAttribute("id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships").Value;
+
+            Assert.False(string.IsNullOrWhiteSpace(relationshipId));
+            Assert.NotNull(worksheetPart.GetPartById(relationshipId!));
+            Assert.Contains("SalesQuery", ReadSinglePackagePartText(worksheetPart, "queryTable"));
+        }
+
+        [Fact]
+        public void Test_PrintLayout_RejectsScaleOutsideExcelBounds() {
+            using var document = ExcelDocument.Create(new MemoryStream(), autoSave: false);
+            ExcelSheet sheet = document.AddWorkSheet("Report");
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => sheet.ApplyPrintLayout(new ExcelPrintLayoutOptions {
+                Preset = ExcelPrintLayoutPreset.Worksheet,
+                Scale = 1U
+            }));
+            Assert.Throws<ArgumentOutOfRangeException>(() => sheet.ApplyPrintLayout(new ExcelPrintLayoutOptions {
+                Preset = ExcelPrintLayoutPreset.Worksheet,
+                Scale = 401U
+            }));
         }
     }
 }

--- a/OfficeIMO.Tests/Excel.WorkflowReviewRegressions.cs
+++ b/OfficeIMO.Tests/Excel.WorkflowReviewRegressions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Data;
 using System.IO;
 using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
@@ -142,6 +143,130 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_WorkbookConnectionMetadata_WrapsSingletonConnectionXml() {
+            string filePath = Path.Combine(_directoryWithFiles, "ConnectionMetadata.Singleton.xlsx");
+            const string connectionXml = "<connection xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" id=\"1\" name=\"SalesConnection\" type=\"5\" refreshedVersion=\"7\"/>";
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Data");
+                document.AddWorkbookConnectionMetadata(connectionXml);
+                document.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            string xml = ReadSinglePackagePartText(spreadsheet.WorkbookPart!, "connections");
+            Assert.Contains("<connections", xml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("count=\"1\"", xml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("SalesConnection", xml, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void Test_WorksheetMetadata_RejectsForeignWorksheet() {
+            using var left = ExcelDocument.Create(new MemoryStream(), autoSave: false);
+            using var right = ExcelDocument.Create(new MemoryStream(), autoSave: false);
+            ExcelSheet foreignSheet = left.AddWorkSheet("Foreign");
+
+            Assert.Throws<ArgumentException>(() => right.AddWorksheetMetadataPart(
+                foreignSheet,
+                "http://schemas.openxmlformats.org/officeDocument/2006/relationships/queryTable",
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.queryTable+xml",
+                "<queryTable xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" name=\"Foreign\"/>"));
+        }
+
+        [Fact]
+        public void Test_PrintLayoutWorksheetPreset_ClearsStalePrintTitles() {
+            string filePath = Path.Combine(_directoryWithFiles, "PrintLayoutPreset.ClearTitles.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Report");
+                sheet.CellValue(1, 1, "Region");
+                document.SetPrintTitles(sheet, firstRow: 1, lastRow: 1, firstCol: 1, lastCol: 1, save: false);
+
+                sheet.ApplyPrintLayout(new ExcelPrintLayoutOptions {
+                    Preset = ExcelPrintLayoutPreset.Worksheet
+                });
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Null(document.GetNamedRange("_xlnm.Print_Titles", document["Report"]));
+            }
+        }
+
+        [Fact]
+        public void Test_ColumnRangeByHeader_MaterializesDeferredWorksheetData() {
+            string filePath = Path.Combine(_directoryWithFiles, "ColumnRangeByHeader.Deferred.xlsx");
+            var dataSet = new DataSet("Export");
+            var table = new DataTable("Items");
+            table.Columns.Add("Name", typeof(string));
+            table.Columns.Add("Sales Amount", typeof(int));
+            table.Rows.Add("Alpha", 10);
+            table.Rows.Add("Beta", 20);
+            dataSet.Tables.Add(table);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.InsertDataSet(dataSet);
+
+                Assert.Equal("B2:B3", document["Items"].GetColumnRangeByHeader("Sales Amount"));
+                document.Save();
+            }
+        }
+
+        [Fact]
+        public void Test_DateSystemChange_UpdatesDeferredDataSetImport() {
+            string filePath = Path.Combine(_directoryWithFiles, "DateSystem.DeferredChange.xlsx");
+            var date = new DateTime(2024, 2, 3);
+            var dataSet = new DataSet("Export");
+            var table = new DataTable("Items");
+            table.Columns.Add("When", typeof(DateTime));
+            table.Rows.Add(date);
+            dataSet.Tables.Add(table);
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                document.InsertDataSet(dataSet);
+                document.DateSystem = ExcelDateSystem.NineteenFour;
+                document.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.Single();
+            string serialText = GetCellValueText(worksheetPart, "A2");
+            Assert.Equal(Expected1904Serial(date), double.Parse(serialText, System.Globalization.CultureInfo.InvariantCulture), 6);
+        }
+
+        [Fact]
+        public void Test_EnsureWorkbookTheme_SavesEnsuredPartsForStreamWorkbook() {
+            using var source = new MemoryStream();
+            using (var document = ExcelDocument.Create(source, autoSave: false)) {
+                document.AddWorkSheet("Data").CellValue(1, 1, "Ready");
+                document.Save(source);
+            }
+
+            source.Position = 0;
+            using (SpreadsheetDocument package = SpreadsheetDocument.Open(source, true)) {
+                foreach (ThemePart themePart in package.WorkbookPart!.GetPartsOfType<ThemePart>().ToList()) {
+                    package.WorkbookPart.DeletePart(themePart);
+                }
+
+                if (package.WorkbookPart.WorkbookStylesPart != null) {
+                    package.WorkbookPart.DeletePart(package.WorkbookPart.WorkbookStylesPart);
+                }
+            }
+
+            source.Position = 0;
+            using var destination = new MemoryStream();
+            using (var document = ExcelDocument.Load(source)) {
+                document.EnsureWorkbookTheme();
+                document.Save(destination);
+            }
+
+            destination.Position = 0;
+            using SpreadsheetDocument saved = SpreadsheetDocument.Open(destination, false);
+            Assert.Single(saved.WorkbookPart!.GetPartsOfType<ThemePart>());
+            Assert.NotNull(saved.WorkbookPart.WorkbookStylesPart);
+        }
+
+        [Fact]
         public void Test_InspectionSnapshot_ExpandsRangeHyperlinksToCells() {
             string filePath = Path.Combine(_directoryWithFiles, "Inspection.RangeHyperlinks.xlsx");
 
@@ -157,7 +282,7 @@ namespace OfficeIMO.Tests {
                 WorksheetPart worksheetPart = package.WorkbookPart!.WorksheetParts.Single();
                 worksheetPart.AddHyperlinkRelationship(new Uri("https://example.com/report", UriKind.Absolute), true, "rIdRangeHyperlink");
                 worksheetPart.Worksheet.Append(new Hyperlinks(new Hyperlink {
-                    Reference = "A1:A3",
+                    Reference = "A1:XFD1048576",
                     Id = "rIdRangeHyperlink"
                 }));
                 worksheetPart.Worksheet.Save();
@@ -166,6 +291,7 @@ namespace OfficeIMO.Tests {
             using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
                 ExcelWorksheetSnapshot sheet = Assert.Single(document.CreateInspectionSnapshot().Worksheets);
                 Assert.All(sheet.Cells.Where(cell => cell.Row >= 1 && cell.Row <= 3), cell => Assert.NotNull(cell.Hyperlink));
+                Assert.Equal(3, sheet.Cells.Count(cell => cell.Hyperlink != null));
             }
         }
 

--- a/OfficeIMO.Tests/Excel.WorkflowReviewRegressions.cs
+++ b/OfficeIMO.Tests/Excel.WorkflowReviewRegressions.cs
@@ -380,6 +380,60 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ImageMoveTo_PreservesTwoCellAnchorExtent() {
+            string filePath = Path.Combine(_directoryWithFiles, "ImageMove.TwoCellAnchor.xlsx");
+            byte[] image = File.ReadAllBytes(Path.Combine(_directoryWithImages, "EvotecLogo.png"));
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Images");
+                sheet.AddImage(1, 1, image, "image/png", widthPixels: 16, heightPixels: 16, name: "Resizable image");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument package = SpreadsheetDocument.Open(filePath, true)) {
+                WorksheetPart worksheetPart = package.WorkbookPart!.WorksheetParts.Single();
+                Xdr.WorksheetDrawing drawing = worksheetPart.DrawingsPart!.WorksheetDrawing!;
+                Xdr.OneCellAnchor oneCell = Assert.Single(drawing.Elements<Xdr.OneCellAnchor>());
+                Xdr.Picture picture = (Xdr.Picture)oneCell.Descendants<Xdr.Picture>().Single().CloneNode(true);
+                var twoCell = new Xdr.TwoCellAnchor(
+                    new Xdr.FromMarker(
+                        new Xdr.ColumnId("0"),
+                        new Xdr.ColumnOffset("0"),
+                        new Xdr.RowId("0"),
+                        new Xdr.RowOffset("0")),
+                    new Xdr.ToMarker(
+                        new Xdr.ColumnId("2"),
+                        new Xdr.ColumnOffset(PixelsToEmuText(1)),
+                        new Xdr.RowId("4"),
+                        new Xdr.RowOffset(PixelsToEmuText(2))),
+                    picture,
+                    new Xdr.ClientData());
+                oneCell.Remove();
+                drawing.Append(twoCell);
+                drawing.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                ExcelImage imageRecord = Assert.Single(document["Images"].Images);
+                imageRecord.MoveTo(3, 4, offsetXPixels: 5, offsetYPixels: 7);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument package = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart worksheetPart = package.WorkbookPart!.WorksheetParts.Single();
+                Xdr.TwoCellAnchor twoCell = Assert.Single(worksheetPart.DrawingsPart!.WorksheetDrawing!.Elements<Xdr.TwoCellAnchor>());
+                Assert.Equal("3", twoCell.FromMarker!.ColumnId!.Text);
+                Assert.Equal(PixelsToEmuText(5), twoCell.FromMarker.ColumnOffset!.Text);
+                Assert.Equal("2", twoCell.FromMarker.RowId!.Text);
+                Assert.Equal(PixelsToEmuText(7), twoCell.FromMarker.RowOffset!.Text);
+                Assert.Equal("5", twoCell.ToMarker!.ColumnId!.Text);
+                Assert.Equal(PixelsToEmuText(6), twoCell.ToMarker.ColumnOffset!.Text);
+                Assert.Equal("6", twoCell.ToMarker.RowId!.Text);
+                Assert.Equal(PixelsToEmuText(9), twoCell.ToMarker.RowOffset!.Text);
+            }
+        }
+
+        [Fact]
         public void Test_DashboardChart_RejectsOutOfBoundsAnchorsAndDimensions() {
             using var document = ExcelDocument.Create(new MemoryStream(), autoSave: false);
             ExcelSheet sheet = document.AddWorkSheet("Dashboard");
@@ -393,6 +447,9 @@ namespace OfficeIMO.Tests {
             Assert.Throws<ArgumentOutOfRangeException>(() => sheet.AddDashboardChart(new ExcelDashboardChartOptions { Range = "A1:B2", WidthPixels = 0 }));
             Assert.Throws<ArgumentOutOfRangeException>(() => sheet.AddDashboardChart(new ExcelDashboardChartOptions { Range = "A1:B2", HeightPixels = -1 }));
         }
+
+        private static string PixelsToEmuText(int pixels)
+            => ((long)Math.Round(pixels * 9525.0)).ToString(System.Globalization.CultureInfo.InvariantCulture);
 
         [Fact]
         public void Test_PrintAreaAndTitles_MarkStreamWorkbookDirty() {

--- a/OfficeIMO.Tests/Excel.WorkflowReviewRegressions.cs
+++ b/OfficeIMO.Tests/Excel.WorkflowReviewRegressions.cs
@@ -5,6 +5,7 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using OfficeIMO.Excel;
 using Xunit;
+using Xdr = DocumentFormat.OpenXml.Drawing.Spreadsheet;
 
 namespace OfficeIMO.Tests {
     public partial class Excel {
@@ -24,6 +25,21 @@ namespace OfficeIMO.Tests {
             destination.Position = 0;
             using var loaded = ExcelDocument.Load(destination, readOnly: true);
             Assert.Equal("$A$1", loaded.GetNamedRange("Anchor", loaded["Data"]));
+        }
+
+        [Fact]
+        public void Test_DelimitedImport_DetectsDelimiterIgnoringQuotedFields() {
+            using var document = ExcelDocument.Create(new MemoryStream(), autoSave: false);
+            ExcelDelimitedImportResult result = document.ImportDelimitedText("\"Name, with comma\";Value\r\nAlpha;42", new ExcelDelimitedImportOptions {
+                SheetName = "Import"
+            });
+
+            Assert.Equal(';', result.Delimiter);
+            ExcelSheet sheet = document["Import"];
+            Assert.True(sheet.TryGetCellText(2, 1, out string? name));
+            Assert.Equal("Alpha", name);
+            Assert.True(sheet.TryGetCellText(2, 2, out string? value));
+            Assert.Equal("42", value);
         }
 
         [Fact]
@@ -190,6 +206,37 @@ namespace OfficeIMO.Tests {
             });
 
             Assert.Contains(diff.Differences, difference => difference.Category == "Comment" && difference.RightValue?.Contains("Blank cell note", StringComparison.Ordinal) == true);
+        }
+
+        [Fact]
+        public void Test_ImageMoveTo_RejectsAbsoluteAnchors() {
+            string filePath = Path.Combine(_directoryWithFiles, "ImageMove.AbsoluteAnchor.xlsx");
+            byte[] image = File.ReadAllBytes(Path.Combine(_directoryWithImages, "EvotecLogo.png"));
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Images");
+                sheet.AddImage(1, 1, image, "image/png", widthPixels: 16, heightPixels: 16, name: "Absolute image");
+                document.Save();
+            }
+
+            using (SpreadsheetDocument package = SpreadsheetDocument.Open(filePath, true)) {
+                WorksheetPart worksheetPart = package.WorkbookPart!.WorksheetParts.Single();
+                Xdr.WorksheetDrawing drawing = worksheetPart.DrawingsPart!.WorksheetDrawing!;
+                Xdr.OneCellAnchor oneCell = Assert.Single(drawing.Elements<Xdr.OneCellAnchor>());
+                var absolute = new Xdr.AbsoluteAnchor(
+                    new Xdr.Position { X = 0L, Y = 0L },
+                    (Xdr.Extent)oneCell.Extent!.CloneNode(true),
+                    (Xdr.Picture)oneCell.Descendants<Xdr.Picture>().Single().CloneNode(true),
+                    new Xdr.ClientData());
+                oneCell.Remove();
+                drawing.Append(absolute);
+                drawing.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                ExcelImage imageRecord = Assert.Single(document["Images"].Images);
+                Assert.Throws<NotSupportedException>(() => imageRecord.MoveTo(2, 2));
+            }
         }
     }
 }

--- a/OfficeIMO.Tests/Excel.WorksheetFeatures.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetFeatures.cs
@@ -616,6 +616,23 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_WorksheetViewOptions_StreamBackedWorkbookPersistsOnDispose() {
+            using var stream = new MemoryStream();
+            using (var document = ExcelDocument.Create(stream)) {
+                var sheet = document.AddWorkSheet("View");
+                sheet.CellValue(1, 1, "Header");
+                sheet.SetViewOptions(showGridlines: false, rightToLeft: true);
+            }
+
+            stream.Position = 0;
+            using var spreadsheet = SpreadsheetDocument.Open(stream, false);
+            WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+            SheetView sheetView = wsPart.Worksheet.GetFirstChild<SheetViews>()!.GetFirstChild<SheetView>()!;
+            Assert.False(sheetView.ShowGridLines!.Value);
+            Assert.True(sheetView.RightToLeft!.Value);
+        }
+
+        [Fact]
         public void Test_WorkbookActiveWorksheetSetAndInspect() {
             var filePath = Path.Combine(_directoryWithFiles, "ExcelWorkbookActiveWorksheet.xlsx");
 

--- a/OfficeIMO.Tests/Excel.WorksheetFeatures.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetFeatures.cs
@@ -670,6 +670,8 @@ namespace OfficeIMO.Tests {
                 sheet.GroupRows(2, 3, outlineLevel: 1, collapsed: true);
                 sheet.GroupColumns(2, 3, outlineLevel: 1, collapsed: true);
                 Assert.Throws<ArgumentOutOfRangeException>(() => sheet.GroupRows(A1.MaxRows, A1.MaxRows, outlineLevel: 1, collapsed: true));
+                Assert.Throws<ArgumentOutOfRangeException>(() => sheet.GroupRows(A1.MaxRows + 1, A1.MaxRows + 1));
+                Assert.Throws<ArgumentOutOfRangeException>(() => sheet.GroupColumns(A1.MaxColumns + 1, A1.MaxColumns + 1));
                 document.Save(false);
             }
 

--- a/OfficeIMO.Tests/Excel.WorksheetFeatures.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetFeatures.cs
@@ -512,5 +512,209 @@ namespace OfficeIMO.Tests {
                 Assert.True(view!.ShowGridLines?.Value ?? true);
             }
         }
+
+        [Fact]
+        public void Test_WorksheetTabColorSetClearAndInspect() {
+            var filePath = Path.Combine(_directoryWithFiles, "ExcelWorksheetTabColor.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Colored");
+                sheet.CellValue(1, 1, "Header");
+                sheet.SetTabColor("#336699");
+                document.Save(false);
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                TabColor tabColor = wsPart.Worksheet.GetFirstChild<SheetProperties>()!.TabColor!;
+                Assert.Equal("FF336699", tabColor.Rgb!.Value);
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelWorksheetSnapshot worksheet = Assert.Single(document.CreateInspectionSnapshot().Worksheets);
+                Assert.Equal("FF336699", worksheet.TabColorArgb);
+            }
+
+            using (var document = ExcelDocument.Load(filePath)) {
+                ExcelSheet sheet = document.Sheets.First();
+                sheet.ClearTabColor();
+                document.Save(false);
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                Assert.Null(wsPart.Worksheet.GetFirstChild<SheetProperties>()?.TabColor);
+            }
+        }
+
+        [Fact]
+        public void Test_WorksheetViewInfoReadsFreezeAndGridlines() {
+            var filePath = Path.Combine(_directoryWithFiles, "ExcelWorksheetViewInfo.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("View");
+                sheet.CellValue(1, 1, "Header");
+                sheet.Freeze(2, 1);
+                sheet.SetGridlinesVisible(false);
+                document.Save(false);
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                var sheet = document.Sheets.First();
+                ExcelWorksheetViewInfo view = sheet.GetViewInfo();
+
+                Assert.True(view.HasPane);
+                Assert.Equal("frozen", view.PaneState);
+                Assert.Equal(2, view.FrozenRowCount);
+                Assert.Equal(1, view.FrozenColumnCount);
+                Assert.Equal(2D, view.VerticalSplit);
+                Assert.Equal(1D, view.HorizontalSplit);
+                Assert.Equal("B3", view.TopLeftCell);
+                Assert.Equal("bottomRight", view.ActivePane);
+                Assert.False(view.ShowGridlines);
+                Assert.False(view.RightToLeft);
+            }
+        }
+
+        [Fact]
+        public void Test_WorksheetViewOptionsSetZoomDirectionGridlinesAndMode() {
+            var filePath = Path.Combine(_directoryWithFiles, "ExcelWorksheetViewOptions.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("View");
+                sheet.CellValue(1, 1, "Header");
+                sheet.SetViewOptions(showGridlines: false, rightToLeft: true, zoomScale: 125, zoomScaleNormal: 100, view: ExcelWorksheetViewKind.PageLayout);
+                document.Save(false);
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                SheetView sheetView = wsPart.Worksheet.GetFirstChild<SheetViews>()!.GetFirstChild<SheetView>()!;
+                Assert.False(sheetView.ShowGridLines!.Value);
+                Assert.True(sheetView.RightToLeft!.Value);
+                Assert.Equal(125U, sheetView.ZoomScale!.Value);
+                Assert.Equal(100U, sheetView.ZoomScaleNormal!.Value);
+                Assert.Equal(SheetViewValues.PageLayout, sheetView.View!.Value);
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                var sheet = document.Sheets.First();
+                ExcelWorksheetViewInfo view = sheet.GetViewInfo();
+                Assert.False(view.ShowGridlines);
+                Assert.True(view.RightToLeft);
+                Assert.Equal(125U, view.ZoomScale);
+                Assert.Equal(100U, view.ZoomScaleNormal);
+                Assert.Equal("pageLayout", view.View);
+
+                ExcelWorksheetSnapshot worksheet = Assert.Single(document.CreateInspectionSnapshot().Worksheets);
+                Assert.False(worksheet.ShowGridlines);
+                Assert.True(worksheet.RightToLeft);
+                Assert.Equal(125U, worksheet.ZoomScale);
+                Assert.Equal(100U, worksheet.ZoomScaleNormal);
+                Assert.Equal("pageLayout", worksheet.View);
+            }
+        }
+
+        [Fact]
+        public void Test_WorkbookActiveWorksheetSetAndInspect() {
+            var filePath = Path.Combine(_directoryWithFiles, "ExcelWorkbookActiveWorksheet.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var summary = document.AddWorkSheet("Summary");
+                summary.CellValue(1, 1, "Summary");
+                var details = document.AddWorkSheet("Details");
+                details.CellValue(1, 1, "Details");
+                var archive = document.AddWorkSheet("Archive");
+                archive.CellValue(1, 1, "Archive");
+                document.SetActiveWorksheet(details);
+                document.Save(false);
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                Workbook workbook = spreadsheet.WorkbookPart!.Workbook;
+                WorkbookView workbookView = workbook.GetFirstChild<BookViews>()!.GetFirstChild<WorkbookView>()!;
+                Assert.Equal(1U, workbookView.ActiveTab!.Value);
+                Assert.Equal(1U, workbookView.FirstSheet!.Value);
+
+                var sheets = workbook.Sheets!.Elements<Sheet>().ToArray();
+                for (int index = 0; index < sheets.Length; index++) {
+                    var worksheetPart = (WorksheetPart)spreadsheet.WorkbookPart.GetPartById(sheets[index].Id!);
+                    SheetView sheetView = worksheetPart.Worksheet.GetFirstChild<SheetViews>()!.GetFirstChild<SheetView>()!;
+                    Assert.Equal(index == 1, sheetView.TabSelected!.Value);
+                }
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelWorkbookSnapshot snapshot = document.CreateInspectionSnapshot();
+                Assert.Equal(1, snapshot.ActiveWorksheetIndex);
+                Assert.Equal("Details", snapshot.ActiveWorksheetName);
+                Assert.False(snapshot.Worksheets[0].IsActive);
+                Assert.True(snapshot.Worksheets[1].IsActive);
+                Assert.False(snapshot.Worksheets[2].IsActive);
+            }
+        }
+
+        [Fact]
+        public void Test_WorksheetOutlineGroupsRowsAndColumnsWithSnapshotReadback() {
+            var filePath = Path.Combine(_directoryWithFiles, "ExcelWorksheetOutlineGroups.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                var sheet = document.AddWorkSheet("Outline");
+                sheet.CellValue(1, 1, "Region");
+                sheet.CellValue(2, 1, "North");
+                sheet.CellValue(3, 1, "South");
+                sheet.CellValue(1, 2, "Q1");
+                sheet.CellValue(1, 3, "Q2");
+
+                sheet.SetOutlineSummary(summaryBelow: true, summaryRight: true);
+                sheet.GroupRows(2, 3, outlineLevel: 1, collapsed: true);
+                sheet.GroupColumns(2, 3, outlineLevel: 1, collapsed: true);
+                document.Save(false);
+            }
+
+            using (var spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart wsPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                Worksheet worksheet = wsPart.Worksheet;
+                OutlineProperties outline = worksheet.GetFirstChild<SheetProperties>()!.GetFirstChild<OutlineProperties>()!;
+                Assert.True(outline.SummaryBelow!.Value);
+                Assert.True(outline.SummaryRight!.Value);
+
+                var rows = worksheet.GetFirstChild<SheetData>()!.Elements<Row>().ToDictionary(row => row.RowIndex!.Value);
+                Assert.Equal(1, rows[2].OutlineLevel!.Value);
+                Assert.Equal(1, rows[3].OutlineLevel!.Value);
+                Assert.True(rows[2].Hidden!.Value);
+                Assert.True(rows[3].Hidden!.Value);
+                Assert.True(rows[4].Collapsed!.Value);
+
+                var columns = worksheet.GetFirstChild<Columns>()!.Elements<Column>().ToList();
+                Column columnB = Assert.Single(columns, column => column.Min!.Value == 2 && column.Max!.Value == 2);
+                Column columnC = Assert.Single(columns, column => column.Min!.Value == 3 && column.Max!.Value == 3);
+                Column columnD = Assert.Single(columns, column => column.Min!.Value == 4 && column.Max!.Value == 4);
+                Assert.Equal(1, columnB.OutlineLevel!.Value);
+                Assert.Equal(1, columnC.OutlineLevel!.Value);
+                Assert.True(columnB.Hidden!.Value);
+                Assert.True(columnC.Hidden!.Value);
+                Assert.True(columnD.Collapsed!.Value);
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelWorksheetSnapshot worksheet = Assert.Single(document.CreateInspectionSnapshot().Worksheets);
+                Assert.True(worksheet.OutlineSummaryBelow);
+                Assert.True(worksheet.OutlineSummaryRight);
+
+                ExcelRowSnapshot row2 = Assert.Single(worksheet.Rows, row => row.Index == 2);
+                ExcelRowSnapshot row4 = Assert.Single(worksheet.Rows, row => row.Index == 4);
+                Assert.Equal((byte)1, row2.OutlineLevel.GetValueOrDefault());
+                Assert.True(row2.Hidden);
+                Assert.True(row4.Collapsed);
+
+                ExcelColumnSnapshot column2 = Assert.Single(worksheet.Columns, column => column.StartIndex == 2 && column.EndIndex == 2);
+                ExcelColumnSnapshot column4 = Assert.Single(worksheet.Columns, column => column.StartIndex == 4 && column.EndIndex == 4);
+                Assert.Equal((byte)1, column2.OutlineLevel.GetValueOrDefault());
+                Assert.True(column2.Hidden);
+                Assert.True(column4.Collapsed);
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
     }
 }

--- a/OfficeIMO.Tests/Excel.WorksheetFeatures.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetFeatures.cs
@@ -669,6 +669,7 @@ namespace OfficeIMO.Tests {
                 sheet.SetOutlineSummary(summaryBelow: true, summaryRight: true);
                 sheet.GroupRows(2, 3, outlineLevel: 1, collapsed: true);
                 sheet.GroupColumns(2, 3, outlineLevel: 1, collapsed: true);
+                Assert.Throws<ArgumentOutOfRangeException>(() => sheet.GroupRows(A1.MaxRows, A1.MaxRows, outlineLevel: 1, collapsed: true));
                 document.Save(false);
             }
 


### PR DESCRIPTION
## Summary
- add reusable Excel threaded comment authoring and richer workbook intelligence metadata
- preserve advanced workbook metadata and custom document properties during package save flows
- expand Excel workflow coverage for pivots, sparklines, threaded comments, and query metadata

## Validation
- dotnet build OfficeIMO.Excel\OfficeIMO.Excel.csproj -f net8.0 --no-restore /clp:ErrorsOnly
- dotnet build OfficeIMO.Excel\OfficeIMO.Excel.csproj -f net472 --no-restore /clp:ErrorsOnly
- dotnet build OfficeIMO.Tests\OfficeIMO.Tests.csproj -f net8.0 --no-restore /clp:ErrorsOnly
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj -f net8.0 --no-build --filter "FullyQualifiedName~WorkbookIntelligence|FullyQualifiedName~Pivot|FullyQualifiedName~Sparkline|FullyQualifiedName~ClosedXmlGapFeatures|FullyQualifiedName=OfficeIMO.Tests.Excel.PerformanceReview_InsertDataSet_ExtendedPackagePreservesSharedStringsStylesHyperlinksAndRootParts" --verbosity minimal
- dotnet pack OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Release -o .\artifacts\local-packages /clp:ErrorsOnly

## Notes
- SQL/OleDB/web-client, COM automation, HTML parsing, and range image rendering are intentionally out of scope for this branch.