### PR TITLE
Complete PSWritePDF PDF workflow coverage

### DIFF
--- a/OfficeIMO.Pdf/Core/PdfDocumentPages.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocumentPages.cs
@@ -37,7 +37,7 @@ public sealed class PdfDocumentPages {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryExtract(PdfPageSelection selection, PdfReadOptions? options = null) {
         Guard.NotNull(selection, nameof(selection));
-        return _document.TryOperation("Extract pages", PdfPreflightCapability.ManipulatePages, () => Extract(selection), options);
+        return TryPageExtractionOperation("Extract pages", () => Extract(selection), options);
     }
 
     /// <summary>
@@ -152,14 +152,14 @@ public sealed class PdfDocumentPages {
     /// Attempts to create one PDF per page, returning diagnostics when blocked or failed.
     /// </summary>
     public PdfOperationResult<IReadOnlyList<PdfDocument>> TrySplit(PdfReadOptions? options = null) {
-        return _document.TryOperation("Split pages", PdfPreflightCapability.ManipulatePages, Split, options);
+        return TryPageExtractionOperation("Split pages", Split, options);
     }
 
     /// <summary>
     /// Attempts to create PDFs containing consecutive groups of the requested page count.
     /// </summary>
     public PdfOperationResult<IReadOnlyList<PdfDocument>> TrySplit(int pagesPerDocument, PdfReadOptions? options = null) {
-        return _document.TryOperation("Split page groups", PdfPreflightCapability.ManipulatePages, () => Split(pagesPerDocument), options);
+        return TryPageExtractionOperation("Split page groups", () => Split(pagesPerDocument), options);
     }
 
     /// <summary>
@@ -167,16 +167,15 @@ public sealed class PdfDocumentPages {
     /// </summary>
     public PdfOperationResult<IReadOnlyList<PdfDocument>> TrySplit(IReadOnlyList<PdfPageSelection> selections, PdfReadOptions? options = null) {
         Guard.NotNull(selections, nameof(selections));
-        return _document.TryOperation("Split page selections", PdfPreflightCapability.ManipulatePages, () => Split(selections.ToArray()), options);
+        return TryPageExtractionOperation("Split page selections", () => Split(selections.ToArray()), options);
     }
 
     /// <summary>
     /// Attempts to create one PDF for each outline/bookmark-derived page range.
     /// </summary>
     public PdfOperationResult<IReadOnlyList<PdfDocument>> TrySplitByBookmarks(IReadOnlyList<string>? bookmarkTitles = null, PdfReadOptions? options = null) {
-        return _document.TryOperation(
+        return TryPageExtractionOperation(
             "Split bookmarks",
-            PdfPreflightCapability.ManipulatePages,
             () => SplitByBookmarks(bookmarkTitles is null ? Array.Empty<string>() : bookmarkTitles.ToArray()),
             options);
     }
@@ -416,5 +415,39 @@ public sealed class PdfDocumentPages {
                 FlattenOutlines(outline.Children, destination);
             }
         }
+    }
+
+    private PdfOperationResult<T> TryPageExtractionOperation<T>(
+        string operationName,
+        Func<T> operation,
+        PdfReadOptions? options) where T : class {
+        PdfReadOptions? effectiveOptions = options ?? _document.ReadOptions;
+        PdfDocumentPreflight preflight = _document.Preflight(effectiveOptions);
+        if (!preflight.Can(PdfPreflightCapability.ManipulatePages) &&
+            !CanAttemptEncryptedPageExtraction(preflight, effectiveOptions)) {
+            return PdfOperationResult<T>.Blocked(operationName, PdfPreflightCapability.ManipulatePages, preflight);
+        }
+
+        try {
+            return PdfOperationResult<T>.Success(operationName, PdfPreflightCapability.ManipulatePages, preflight, operation());
+        } catch (Exception ex) {
+            return PdfOperationResult<T>.Failed(operationName, PdfPreflightCapability.ManipulatePages, preflight, ex);
+        }
+    }
+
+    private static bool CanAttemptEncryptedPageExtraction(PdfDocumentPreflight preflight, PdfReadOptions? options) {
+        if (!preflight.CanRead ||
+            options?.Password is null ||
+            !preflight.Probe.HasEncryption) {
+            return false;
+        }
+
+        foreach (PdfRewriteBlocker blocker in preflight.RewriteBlockers) {
+            if (blocker.Kind != PdfRewriteBlockerKind.Encryption) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/OfficeIMO.Pdf/Core/PdfDocumentPages.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocumentPages.cs
@@ -211,6 +211,13 @@ public sealed class PdfDocumentPages {
     /// </summary>
     public PdfOperationResult<IReadOnlyList<PdfDocument>> TrySplit(IReadOnlyList<PdfPageSelection> selections, PdfReadOptions? options = null) {
         Guard.NotNull(selections, nameof(selections));
+        if (selections.Count == 0) {
+            return TryPageExtractionOperation<IReadOnlyList<PdfDocument>>(
+                "Split page selections",
+                _ => throw new ArgumentException("At least one page selection must be specified.", nameof(selections)),
+                options);
+        }
+
         return TryPageExtractionOperation<IReadOnlyList<PdfDocument>>("Split page selections", effectiveOptions => Split(selections.ToArray(), effectiveOptions), options);
     }
 

--- a/OfficeIMO.Pdf/Core/PdfDocumentPages.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocumentPages.cs
@@ -29,7 +29,12 @@ public sealed class PdfDocumentPages {
     /// </summary>
     public PdfDocument Extract(PdfPageSelection selection) {
         Guard.NotNull(selection, nameof(selection));
-        return PdfDocument.FromBytes(PdfPageExtractor.ExtractPageRanges(_document.Snapshot(), selection.ToRanges(), _document.ReadOptions));
+        return Extract(selection, _document.ReadOptions);
+    }
+
+    private PdfDocument Extract(PdfPageSelection selection, PdfReadOptions? options) {
+        Guard.NotNull(selection, nameof(selection));
+        return PdfDocument.FromBytes(PdfPageExtractor.ExtractPageRanges(_document.Snapshot(), selection.ToRanges(), options));
     }
 
     /// <summary>
@@ -37,7 +42,7 @@ public sealed class PdfDocumentPages {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryExtract(PdfPageSelection selection, PdfReadOptions? options = null) {
         Guard.NotNull(selection, nameof(selection));
-        return TryPageExtractionOperation("Extract pages", () => Extract(selection), options);
+        return TryPageExtractionOperation("Extract pages", effectiveOptions => Extract(selection, effectiveOptions), options);
     }
 
     /// <summary>
@@ -51,7 +56,11 @@ public sealed class PdfDocumentPages {
     /// Creates one PDF per page.
     /// </summary>
     public IReadOnlyList<PdfDocument> Split() {
-        return PdfPageExtractor.SplitPages(_document.Snapshot(), _document.ReadOptions)
+        return Split(_document.ReadOptions);
+    }
+
+    private PdfDocument[] Split(PdfReadOptions? options) {
+        return PdfPageExtractor.SplitPages(_document.Snapshot(), options)
             .Select(PdfDocument.FromBytes)
             .ToArray();
     }
@@ -64,7 +73,15 @@ public sealed class PdfDocumentPages {
             throw new ArgumentOutOfRangeException(nameof(pagesPerDocument), pagesPerDocument, "Pages per document must be greater than zero.");
         }
 
-        int pageCount = _document.Inspect().PageCount;
+        return Split(pagesPerDocument, _document.ReadOptions);
+    }
+
+    private PdfDocument[] Split(int pagesPerDocument, PdfReadOptions? options) {
+        if (pagesPerDocument <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(pagesPerDocument), pagesPerDocument, "Pages per document must be greater than zero.");
+        }
+
+        int pageCount = _document.Inspect(options).PageCount;
         if (pageCount == 0) {
             throw new InvalidOperationException("PDF does not contain any readable pages.");
         }
@@ -75,7 +92,7 @@ public sealed class PdfDocumentPages {
             ranges.Add(PdfPageRange.From(firstPage, lastPage));
         }
 
-        return Split(ranges);
+        return Split(ranges, options);
     }
 
     /// <summary>
@@ -87,10 +104,14 @@ public sealed class PdfDocumentPages {
             throw new ArgumentException("At least one page selection must be specified.", nameof(selections));
         }
 
+        return Split(selections, _document.ReadOptions);
+    }
+
+    private PdfDocument[] Split(PdfPageSelection[] selections, PdfReadOptions? options) {
         var documents = new PdfDocument[selections.Length];
         for (int i = 0; i < selections.Length; i++) {
             Guard.NotNull(selections[i], nameof(selections));
-            documents[i] = Extract(selections[i]);
+            documents[i] = Extract(selections[i], options);
         }
 
         return documents;
@@ -106,7 +127,17 @@ public sealed class PdfDocumentPages {
             throw new ArgumentException("At least one page range must be specified.", nameof(pageRanges));
         }
 
-        return PdfPageExtractor.SplitPageRanges(_document.Snapshot(), ranges, _document.ReadOptions)
+        return Split(ranges, _document.ReadOptions);
+    }
+
+    private PdfDocument[] Split(IEnumerable<PdfPageRange> pageRanges, PdfReadOptions? options) {
+        Guard.NotNull(pageRanges, nameof(pageRanges));
+        PdfPageRange[] ranges = pageRanges.ToArray();
+        if (ranges.Length == 0) {
+            throw new ArgumentException("At least one page range must be specified.", nameof(pageRanges));
+        }
+
+        return PdfPageExtractor.SplitPageRanges(_document.Snapshot(), ranges, options)
             .Select(PdfDocument.FromBytes)
             .ToArray();
     }
@@ -115,7 +146,11 @@ public sealed class PdfDocumentPages {
     /// Returns outline/bookmark-derived page ranges in document order.
     /// </summary>
     public IReadOnlyList<PdfBookmarkPageRange> BookmarkPageRanges(params string[] bookmarkTitles) {
-        PdfDocumentInfo info = _document.Inspect();
+        return BookmarkPageRanges(_document.ReadOptions, bookmarkTitles);
+    }
+
+    private IReadOnlyList<PdfBookmarkPageRange> BookmarkPageRanges(PdfReadOptions? options, params string[] bookmarkTitles) {
+        PdfDocumentInfo info = _document.Inspect(options);
         PdfBookmarkPageRange[] allRanges = BuildBookmarkPageRanges(info);
         if (bookmarkTitles is null || bookmarkTitles.Length == 0) {
             return allRanges;
@@ -148,18 +183,27 @@ public sealed class PdfDocumentPages {
         return Split(ranges.Select(range => range.PageRange));
     }
 
+    private PdfDocument[] SplitByBookmarks(PdfReadOptions? options, params string[] bookmarkTitles) {
+        IReadOnlyList<PdfBookmarkPageRange> ranges = BookmarkPageRanges(options, bookmarkTitles);
+        if (ranges.Count == 0) {
+            throw new InvalidOperationException("PDF does not contain any readable bookmarks with page destinations.");
+        }
+
+        return Split(ranges.Select(range => range.PageRange), options);
+    }
+
     /// <summary>
     /// Attempts to create one PDF per page, returning diagnostics when blocked or failed.
     /// </summary>
     public PdfOperationResult<IReadOnlyList<PdfDocument>> TrySplit(PdfReadOptions? options = null) {
-        return TryPageExtractionOperation("Split pages", Split, options);
+        return TryPageExtractionOperation<IReadOnlyList<PdfDocument>>("Split pages", effectiveOptions => Split(effectiveOptions), options);
     }
 
     /// <summary>
     /// Attempts to create PDFs containing consecutive groups of the requested page count.
     /// </summary>
     public PdfOperationResult<IReadOnlyList<PdfDocument>> TrySplit(int pagesPerDocument, PdfReadOptions? options = null) {
-        return TryPageExtractionOperation("Split page groups", () => Split(pagesPerDocument), options);
+        return TryPageExtractionOperation<IReadOnlyList<PdfDocument>>("Split page groups", effectiveOptions => Split(pagesPerDocument, effectiveOptions), options);
     }
 
     /// <summary>
@@ -167,16 +211,16 @@ public sealed class PdfDocumentPages {
     /// </summary>
     public PdfOperationResult<IReadOnlyList<PdfDocument>> TrySplit(IReadOnlyList<PdfPageSelection> selections, PdfReadOptions? options = null) {
         Guard.NotNull(selections, nameof(selections));
-        return TryPageExtractionOperation("Split page selections", () => Split(selections.ToArray()), options);
+        return TryPageExtractionOperation<IReadOnlyList<PdfDocument>>("Split page selections", effectiveOptions => Split(selections.ToArray(), effectiveOptions), options);
     }
 
     /// <summary>
     /// Attempts to create one PDF for each outline/bookmark-derived page range.
     /// </summary>
     public PdfOperationResult<IReadOnlyList<PdfDocument>> TrySplitByBookmarks(IReadOnlyList<string>? bookmarkTitles = null, PdfReadOptions? options = null) {
-        return TryPageExtractionOperation(
+        return TryPageExtractionOperation<IReadOnlyList<PdfDocument>>(
             "Split bookmarks",
-            () => SplitByBookmarks(bookmarkTitles is null ? Array.Empty<string>() : bookmarkTitles.ToArray()),
+            effectiveOptions => SplitByBookmarks(effectiveOptions, bookmarkTitles is null ? Array.Empty<string>() : bookmarkTitles.ToArray()),
             options);
     }
 
@@ -419,7 +463,7 @@ public sealed class PdfDocumentPages {
 
     private PdfOperationResult<T> TryPageExtractionOperation<T>(
         string operationName,
-        Func<T> operation,
+        Func<PdfReadOptions?, T> operation,
         PdfReadOptions? options) where T : class {
         PdfReadOptions? effectiveOptions = options ?? _document.ReadOptions;
         PdfDocumentPreflight preflight = _document.Preflight(effectiveOptions);
@@ -429,7 +473,7 @@ public sealed class PdfDocumentPages {
         }
 
         try {
-            return PdfOperationResult<T>.Success(operationName, PdfPreflightCapability.ManipulatePages, preflight, operation());
+            return PdfOperationResult<T>.Success(operationName, PdfPreflightCapability.ManipulatePages, preflight, operation(effectiveOptions));
         } catch (Exception ex) {
             return PdfOperationResult<T>.Failed(operationName, PdfPreflightCapability.ManipulatePages, preflight, ex);
         }

--- a/OfficeIMO.Pdf/Core/PdfDocumentPages.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocumentPages.cs
@@ -474,21 +474,31 @@ public sealed class PdfDocumentPages {
         PdfReadOptions? options) where T : class {
         PdfReadOptions? effectiveOptions = options ?? _document.ReadOptions;
         PdfDocumentPreflight preflight = _document.Preflight(effectiveOptions);
-        if (!preflight.Can(PdfPreflightCapability.ManipulatePages) &&
-            !CanAttemptEncryptedPageExtraction(preflight, effectiveOptions)) {
+        bool canAttempt = preflight.Can(PdfPreflightCapability.ManipulatePages);
+        bool canAttemptEncryptedExtraction = !canAttempt && CanAttemptEncryptedPageExtraction(preflight);
+        if (!canAttempt && !canAttemptEncryptedExtraction) {
             return PdfOperationResult<T>.Blocked(operationName, PdfPreflightCapability.ManipulatePages, preflight);
         }
 
         try {
-            return PdfOperationResult<T>.Success(operationName, PdfPreflightCapability.ManipulatePages, preflight, operation(effectiveOptions));
+            return PdfOperationResult<T>.Success(
+                operationName,
+                PdfPreflightCapability.ManipulatePages,
+                preflight,
+                operation(effectiveOptions),
+                canAttemptEncryptedExtraction ? true : null);
         } catch (Exception ex) {
-            return PdfOperationResult<T>.Failed(operationName, PdfPreflightCapability.ManipulatePages, preflight, ex);
+            return PdfOperationResult<T>.Failed(
+                operationName,
+                PdfPreflightCapability.ManipulatePages,
+                preflight,
+                ex,
+                canAttemptEncryptedExtraction ? true : null);
         }
     }
 
-    private static bool CanAttemptEncryptedPageExtraction(PdfDocumentPreflight preflight, PdfReadOptions? options) {
+    private static bool CanAttemptEncryptedPageExtraction(PdfDocumentPreflight preflight) {
         if (!preflight.CanRead ||
-            options?.Password is null ||
             !preflight.Probe.HasEncryption) {
             return false;
         }

--- a/OfficeIMO.Pdf/Core/PdfDocumentPages.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocumentPages.cs
@@ -14,14 +14,14 @@ public sealed class PdfDocumentPages {
     /// Creates a new PDF containing selected pages in caller order.
     /// </summary>
     public PdfDocument Extract(params int[] pageNumbers) {
-        return PdfDocument.FromBytes(PdfPageExtractor.ExtractPages(_document.Snapshot(), pageNumbers));
+        return PdfDocument.FromBytes(PdfPageExtractor.ExtractPages(_document.Snapshot(), _document.ReadOptions, pageNumbers));
     }
 
     /// <summary>
     /// Creates a new PDF containing one inclusive one-based page range.
     /// </summary>
     public PdfDocument Extract(PdfPageRange pageRange) {
-        return PdfDocument.FromBytes(PdfPageExtractor.ExtractPageRange(_document.Snapshot(), pageRange));
+        return PdfDocument.FromBytes(PdfPageExtractor.ExtractPages(_document.Snapshot(), pageRange.ToPageNumbers(), _document.ReadOptions));
     }
 
     /// <summary>
@@ -29,7 +29,7 @@ public sealed class PdfDocumentPages {
     /// </summary>
     public PdfDocument Extract(PdfPageSelection selection) {
         Guard.NotNull(selection, nameof(selection));
-        return PdfDocument.FromBytes(PdfPageExtractor.ExtractPageRanges(_document.Snapshot(), selection.ToRanges()));
+        return PdfDocument.FromBytes(PdfPageExtractor.ExtractPageRanges(_document.Snapshot(), selection.ToRanges(), _document.ReadOptions));
     }
 
     /// <summary>
@@ -51,7 +51,7 @@ public sealed class PdfDocumentPages {
     /// Creates one PDF per page.
     /// </summary>
     public IReadOnlyList<PdfDocument> Split() {
-        return PdfPageExtractor.SplitPages(_document.Snapshot())
+        return PdfPageExtractor.SplitPages(_document.Snapshot(), _document.ReadOptions)
             .Select(PdfDocument.FromBytes)
             .ToArray();
     }
@@ -106,7 +106,7 @@ public sealed class PdfDocumentPages {
             throw new ArgumentException("At least one page range must be specified.", nameof(pageRanges));
         }
 
-        return PdfPageExtractor.SplitPageRanges(_document.Snapshot(), ranges)
+        return PdfPageExtractor.SplitPageRanges(_document.Snapshot(), ranges, _document.ReadOptions)
             .Select(PdfDocument.FromBytes)
             .ToArray();
     }

--- a/OfficeIMO.Pdf/Core/PdfOperationResult.cs
+++ b/OfficeIMO.Pdf/Core/PdfOperationResult.cs
@@ -11,13 +11,15 @@ public sealed class PdfOperationResult<T> where T : class {
         PdfDocumentPreflight preflight,
         T? value,
         IReadOnlyList<string> diagnostics,
-        Exception? exception) {
+        Exception? exception,
+        bool? canAttemptOverride) {
         OperationName = operationName;
         Capability = capability;
         Preflight = preflight;
         Value = value;
         Diagnostics = diagnostics;
         Exception = exception;
+        CanAttemptOverride = canAttemptOverride;
     }
 
     /// <summary>Human-readable operation name.</summary>
@@ -30,7 +32,7 @@ public sealed class PdfOperationResult<T> where T : class {
     public PdfDocumentPreflight Preflight { get; }
 
     /// <summary>True when preflight allowed the operation to be attempted.</summary>
-    public bool CanAttempt => Preflight.Can(Capability);
+    public bool CanAttempt => CanAttemptOverride ?? Preflight.Can(Capability);
 
     /// <summary>True when the operation completed and produced a value.</summary>
     public bool Succeeded => Value is not null && Exception is null;
@@ -43,6 +45,8 @@ public sealed class PdfOperationResult<T> where T : class {
 
     /// <summary>Exception captured from an attempted operation, when available.</summary>
     public Exception? Exception { get; }
+
+    private bool? CanAttemptOverride { get; }
 
     /// <summary>Returns the operation value or throws with diagnostics when the operation failed.</summary>
     public T RequireValue() {
@@ -57,14 +61,22 @@ public sealed class PdfOperationResult<T> where T : class {
     }
 
     internal static PdfOperationResult<T> Success(string operationName, PdfPreflightCapability capability, PdfDocumentPreflight preflight, T value) {
-        return new PdfOperationResult<T>(operationName, capability, preflight, value, Array.Empty<string>(), null);
+        return Success(operationName, capability, preflight, value, canAttemptOverride: null);
+    }
+
+    internal static PdfOperationResult<T> Success(string operationName, PdfPreflightCapability capability, PdfDocumentPreflight preflight, T value, bool? canAttemptOverride) {
+        return new PdfOperationResult<T>(operationName, capability, preflight, value, Array.Empty<string>(), null, canAttemptOverride);
     }
 
     internal static PdfOperationResult<T> Blocked(string operationName, PdfPreflightCapability capability, PdfDocumentPreflight preflight) {
-        return new PdfOperationResult<T>(operationName, capability, preflight, null, preflight.GetCapabilityDiagnostics(capability), null);
+        return new PdfOperationResult<T>(operationName, capability, preflight, null, preflight.GetCapabilityDiagnostics(capability), null, canAttemptOverride: null);
     }
 
     internal static PdfOperationResult<T> Failed(string operationName, PdfPreflightCapability capability, PdfDocumentPreflight preflight, Exception exception) {
+        return Failed(operationName, capability, preflight, exception, canAttemptOverride: null);
+    }
+
+    internal static PdfOperationResult<T> Failed(string operationName, PdfPreflightCapability capability, PdfDocumentPreflight preflight, Exception exception, bool? canAttemptOverride) {
         var diagnostics = new List<string>();
         AddDistinct(diagnostics, exception.Message);
 
@@ -73,7 +85,7 @@ public sealed class PdfOperationResult<T> where T : class {
             AddDistinct(diagnostics, capabilityDiagnostics[i]);
         }
 
-        return new PdfOperationResult<T>(operationName, capability, preflight, null, diagnostics.AsReadOnly(), exception);
+        return new PdfOperationResult<T>(operationName, capability, preflight, null, diagnostics.AsReadOnly(), exception, canAttemptOverride);
     }
 
     private static void AddDistinct(List<string> diagnostics, string? diagnostic) {

--- a/OfficeIMO.Pdf/Manipulation/PdfMergeOptions.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMergeOptions.cs
@@ -9,4 +9,10 @@ public sealed class PdfMergeOptions {
     /// Link annotations, form fields, and unsupported annotation shapes remain unchanged unless another OfficeIMO.Pdf operation handles them.
     /// </summary>
     public bool FlattenVisualAnnotations { get; set; }
+
+    /// <summary>
+    /// Gets or sets page resize options applied to each input PDF before pages are merged.
+    /// Use this to normalize mixed source page sizes into a fixed output paper size.
+    /// </summary>
+    public PdfPageResizeOptions? ResizePages { get; set; }
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfMerger.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMerger.cs
@@ -238,6 +238,20 @@ public static class PdfMerger {
     }
 
     /// <summary>
+    /// Merges PDFs from file paths and writes the result to the output path, applying optional source preparation first.
+    /// </summary>
+    public static void MergeFiles(PdfMergeOptions options, IEnumerable<string> inputPaths, string outputPath) {
+        Guard.NotNull(options, nameof(options));
+        Guard.NotNull(outputPath, nameof(outputPath));
+
+        string fullOutputPath = ValidateOutputPath(outputPath);
+        var merged = MergeFilesToBytes(options, inputPaths);
+        var directory = Path.GetDirectoryName(fullOutputPath);
+        if (!string.IsNullOrEmpty(directory)) Directory.CreateDirectory(directory);
+        File.WriteAllBytes(fullOutputPath, merged);
+    }
+
+    /// <summary>
     /// Merges PDFs from file paths and writes the result to <paramref name="outputStream"/>.
     /// </summary>
     public static void MergeFiles(IEnumerable<string> inputPaths, Stream outputStream) {
@@ -315,9 +329,19 @@ public static class PdfMerger {
     }
 
     private static byte[] PrepareMergeSource(byte[] source, PdfMergeOptions? options) {
-        return options?.FlattenVisualAnnotations == true
-            ? PdfAnnotationFlattener.FlattenVisualAnnotations(source)
-            : source;
+        if (options is null) {
+            return source;
+        }
+
+        if (options.FlattenVisualAnnotations) {
+            source = PdfAnnotationFlattener.FlattenVisualAnnotations(source);
+        }
+
+        if (options.ResizePages is not null) {
+            source = PdfPageEditor.ResizePages(source, options.ResizePages);
+        }
+
+        return source;
     }
 
     private static void WriteOutput(Stream outputStream, byte[] bytes) {

--- a/OfficeIMO.Pdf/Manipulation/PdfMerger.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMerger.cs
@@ -412,6 +412,7 @@ public static class PdfMerger {
         collector.CollectObjectGraph(catalogState.Outlines);
         collector.CollectObjectGraph(catalogState.PageLabels);
         collector.CollectObjectGraph(catalogState.NamedDestinationNameTree);
+        collector.CollectObjectGraph(catalogState.OpenAction);
         collector.CollectObjectGraph(catalogState.XmpMetadata);
         collector.CollectObjectGraph(catalogState.CatalogUri);
         collector.CollectObjectGraph(catalogState.OutputIntents);

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Resize.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Resize.cs
@@ -36,6 +36,7 @@ public static partial class PdfPageEditor {
         var pageObjectNumbers = document.Pages.Select(static page => page.ObjectNumber).ToArray();
         var overrides = new Dictionary<int, Dictionary<string, PdfObject>>();
         var additionalObjects = new List<PdfPageExtractor.AdditionalObject>();
+        var transformsByPageObjectNumber = new Dictionary<int, PageResizeTransform>();
 
         for (int i = 0; i < document.Pages.Count; i++) {
             int pageNumber = i + 1;
@@ -57,15 +58,18 @@ public static partial class PdfPageEditor {
             double sourceHeight = sourceBox?.Height ?? document.Pages[i].GetPageSize().Height;
             ValidateSourcePageSize(sourceWidth, sourceHeight, pageNumber);
 
-            var transform = CalculateResizeTransform(sourceLeft, sourceBottom, sourceWidth, sourceHeight, options);
+            var transform = CalculateResizeTransform(pageObjectNumber, sourceLeft, sourceBottom, sourceWidth, sourceHeight, options);
+            transformsByPageObjectNumber[pageObjectNumber] = transform;
             int prefixPseudoObjectNumber = ResizeContentPrefixBasePseudoObjectNumber - i;
             int suffixPseudoObjectNumber = ResizeContentSuffixBasePseudoObjectNumber - i;
-            additionalObjects.Add(new PdfPageExtractor.AdditionalObject(prefixPseudoObjectNumber, BuildResizeContentStream(transform)));
+            additionalObjects.Add(new PdfPageExtractor.AdditionalObject(prefixPseudoObjectNumber, BuildResizeContentStream(transform, sourceLeft, sourceBottom, sourceWidth, sourceHeight)));
             additionalObjects.Add(new PdfPageExtractor.AdditionalObject(suffixPseudoObjectNumber, new PdfStream(new PdfDictionary(), PdfEncoding.Latin1GetBytes("\nQ\n"))));
 
             var pageOverrides = new Dictionary<string, PdfObject>(StringComparer.Ordinal) {
                 ["MediaBox"] = CreatePageBoxArray(0D, 0D, options.PageSize.Width, options.PageSize.Height),
                 ["CropBox"] = CreatePageBoxArray(0D, 0D, options.PageSize.Width, options.PageSize.Height),
+                ["UserUnit"] = new PdfNumber(1D),
+                ["Rotate"] = new PdfNumber(0D),
                 ["Contents"] = BuildResizedContentsArray(
                     objects,
                     pageDictionary.Items.TryGetValue("Contents", out var contents) ? contents : null,
@@ -82,13 +86,15 @@ public static partial class PdfPageEditor {
         }
 
         PdfFileVersion fileVersion = PdfFileAssembler.ParseHeaderVersionOrDefault(PdfSyntax.GetHeaderVersion(pdf));
+        PdfPageExtractor.CatalogRewriteState catalogState = PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw);
+        TransformCatalogDestinationsForResize(objects, catalogState, transformsByPageObjectNumber);
         return PdfPageExtractor.ExtractPages(
             objects,
             document.Metadata,
             pageObjectNumbers,
             overrides,
             additionalObjects,
-            PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw),
+            catalogState,
             fileVersion);
     }
 
@@ -206,13 +212,18 @@ public static partial class PdfPageEditor {
         target.Items.Add(contents);
     }
 
-    private static PdfStream BuildResizeContentStream(PageResizeTransform transform) {
+    private static PdfStream BuildResizeContentStream(PageResizeTransform transform, double sourceLeft, double sourceBottom, double sourceWidth, double sourceHeight) {
         string content =
             "q\n" +
             FormatResizeNumber(transform.ScaleX) + " 0 0 " +
             FormatResizeNumber(transform.ScaleY) + " " +
             FormatResizeNumber(transform.TranslateX) + " " +
-            FormatResizeNumber(transform.TranslateY) + " cm\n";
+            FormatResizeNumber(transform.TranslateY) + " cm\n" +
+            FormatResizeNumber(sourceLeft) + " " +
+            FormatResizeNumber(sourceBottom) + " " +
+            FormatResizeNumber(sourceWidth) + " " +
+            FormatResizeNumber(sourceHeight) + " re\n" +
+            "W n\n";
         return new PdfStream(new PdfDictionary(), PdfEncoding.Latin1GetBytes(content));
     }
 
@@ -257,6 +268,9 @@ public static partial class PdfPageEditor {
             if (resolved is PdfDictionary annotationDictionary) {
                 var clonedAnnotation = (PdfDictionary)ClonePdfObject(annotationDictionary);
                 TransformAnnotationRectangle(clonedAnnotation, transform);
+                TransformDestinationsInObject(objects, clonedAnnotation, new Dictionary<int, PageResizeTransform> {
+                    [transform.PageObjectNumber] = transform
+                }, new HashSet<int>(), new HashSet<PdfArray>());
                 transformedAnnotations.Items.Add(clonedAnnotation);
             } else {
                 transformedAnnotations.Items.Add(ClonePdfObject(annotationObject));
@@ -295,6 +309,106 @@ public static partial class PdfPageEditor {
     private static double TransformY(double value, PageResizeTransform transform) =>
         value * transform.ScaleY + transform.TranslateY;
 
+    private static void TransformCatalogDestinationsForResize(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfPageExtractor.CatalogRewriteState catalogState,
+        IReadOnlyDictionary<int, PageResizeTransform> transformsByPageObjectNumber) {
+        if (transformsByPageObjectNumber.Count == 0) {
+            return;
+        }
+
+        var visitedReferences = new HashSet<int>();
+        var transformedArrays = new HashSet<PdfArray>();
+        TransformDestinationsInObject(objects, catalogState.Outlines, transformsByPageObjectNumber, visitedReferences, transformedArrays);
+        TransformDestinationsInObject(objects, catalogState.NamedDestinations, transformsByPageObjectNumber, visitedReferences, transformedArrays);
+        TransformDestinationsInObject(objects, catalogState.NamedDestinationNameTree, transformsByPageObjectNumber, visitedReferences, transformedArrays);
+        TransformDestinationsInObject(objects, catalogState.OpenAction, transformsByPageObjectNumber, visitedReferences, transformedArrays);
+    }
+
+    private static void TransformDestinationsInObject(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfObject? value,
+        IReadOnlyDictionary<int, PageResizeTransform> transformsByPageObjectNumber,
+        HashSet<int> visitedReferences,
+        HashSet<PdfArray> transformedArrays) {
+        switch (value) {
+            case PdfReference reference:
+                if (!visitedReferences.Add(reference.ObjectNumber) ||
+                    !PdfObjectLookup.TryGet(objects, reference, out PdfIndirectObject? indirect) ||
+                    IsPageDictionary(indirect.Value)) {
+                    return;
+                }
+
+                TransformDestinationsInObject(objects, indirect.Value, transformsByPageObjectNumber, visitedReferences, transformedArrays);
+                return;
+            case PdfArray array:
+                TransformDestinationArray(array, transformsByPageObjectNumber, transformedArrays);
+                foreach (PdfObject item in array.Items) {
+                    TransformDestinationsInObject(objects, item, transformsByPageObjectNumber, visitedReferences, transformedArrays);
+                }
+
+                return;
+            case PdfDictionary dictionary:
+                foreach (PdfObject item in dictionary.Items.Values) {
+                    TransformDestinationsInObject(objects, item, transformsByPageObjectNumber, visitedReferences, transformedArrays);
+                }
+
+                return;
+            case PdfStream stream:
+                TransformDestinationsInObject(objects, stream.Dictionary, transformsByPageObjectNumber, visitedReferences, transformedArrays);
+                return;
+        }
+    }
+
+    private static bool IsPageDictionary(PdfObject value) =>
+        value is PdfDictionary dictionary &&
+        dictionary.Get<PdfName>("Type")?.Name == "Page";
+
+    private static void TransformDestinationArray(
+        PdfArray array,
+        IReadOnlyDictionary<int, PageResizeTransform> transformsByPageObjectNumber,
+        HashSet<PdfArray> transformedArrays) {
+        if (!transformedArrays.Add(array) ||
+            array.Items.Count < 2 ||
+            array.Items[0] is not PdfReference pageReference ||
+            !transformsByPageObjectNumber.TryGetValue(pageReference.ObjectNumber, out PageResizeTransform transform) ||
+            array.Items[1] is not PdfName destinationMode) {
+            return;
+        }
+
+        switch (destinationMode.Name) {
+            case "XYZ":
+                TransformDestinationCoordinate(array, 2, transform, isX: true);
+                TransformDestinationCoordinate(array, 3, transform, isX: false);
+                break;
+            case "FitH":
+            case "FitBH":
+                TransformDestinationCoordinate(array, 2, transform, isX: false);
+                break;
+            case "FitV":
+            case "FitBV":
+                TransformDestinationCoordinate(array, 2, transform, isX: true);
+                break;
+            case "FitR":
+                TransformDestinationCoordinate(array, 2, transform, isX: true);
+                TransformDestinationCoordinate(array, 3, transform, isX: false);
+                TransformDestinationCoordinate(array, 4, transform, isX: true);
+                TransformDestinationCoordinate(array, 5, transform, isX: false);
+                break;
+        }
+    }
+
+    private static void TransformDestinationCoordinate(PdfArray array, int index, PageResizeTransform transform, bool isX) {
+        if (index >= array.Items.Count ||
+            array.Items[index] is not PdfNumber coordinate) {
+            return;
+        }
+
+        array.Items[index] = new PdfNumber(isX
+            ? TransformX(coordinate.Value, transform)
+            : TransformY(coordinate.Value, transform));
+    }
+
     private static PdfObject ClonePdfObject(PdfObject value) {
         switch (value) {
             case PdfNumber number:
@@ -330,7 +444,7 @@ public static partial class PdfPageEditor {
         }
     }
 
-    private static PageResizeTransform CalculateResizeTransform(double sourceLeft, double sourceBottom, double sourceWidth, double sourceHeight, PdfPageResizeOptions options) {
+    private static PageResizeTransform CalculateResizeTransform(int pageObjectNumber, double sourceLeft, double sourceBottom, double sourceWidth, double sourceHeight, PdfPageResizeOptions options) {
         double margin = options.Margin;
         double availableWidth = options.PageSize.Width - margin * 2D;
         double availableHeight = options.PageSize.Height - margin * 2D;
@@ -354,7 +468,7 @@ public static partial class PdfPageEditor {
         double scaledHeight = sourceHeight * scaleY;
         double translateX = margin + (availableWidth - scaledWidth) / 2D - sourceLeft * scaleX;
         double translateY = margin + (availableHeight - scaledHeight) / 2D - sourceBottom * scaleY;
-        return new PageResizeTransform(scaleX, scaleY, translateX, translateY);
+        return new PageResizeTransform(scaleX, scaleY, translateX, translateY, pageObjectNumber);
     }
 
     private static void ValidateResizeOptions(PdfPageResizeOptions options) {
@@ -384,11 +498,12 @@ public static partial class PdfPageEditor {
     }
 
     private readonly struct PageResizeTransform {
-        public PageResizeTransform(double scaleX, double scaleY, double translateX, double translateY) {
+        public PageResizeTransform(double scaleX, double scaleY, double translateX, double translateY, int pageObjectNumber) {
             ScaleX = scaleX;
             ScaleY = scaleY;
             TranslateX = translateX;
             TranslateY = translateY;
+            PageObjectNumber = pageObjectNumber;
         }
 
         public double ScaleX { get; }
@@ -398,5 +513,7 @@ public static partial class PdfPageEditor {
         public double TranslateX { get; }
 
         public double TranslateY { get; }
+
+        public int PageObjectNumber { get; }
     }
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Resize.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Resize.cs
@@ -330,7 +330,7 @@ public static partial class PdfPageEditor {
             if (resolved is PdfDictionary annotationDictionary) {
                 var clonedAnnotation = (PdfDictionary)ClonePdfObject(annotationDictionary);
                 if (annotationGeometryTransform.HasValue) {
-                    TransformAnnotationRectangle(clonedAnnotation, annotationGeometryTransform.Value);
+                    TransformAnnotationRectangle(objects, clonedAnnotation, annotationGeometryTransform.Value);
                     TransformAnnotationCoordinateArrays(objects, clonedAnnotation, annotationGeometryTransform.Value);
                 }
 
@@ -352,14 +352,19 @@ public static partial class PdfPageEditor {
         return true;
     }
 
-    private static void TransformAnnotationRectangle(PdfDictionary annotation, PageResizeTransform transform) {
+    private static void TransformAnnotationRectangle(Dictionary<int, PdfIndirectObject> objects, PdfDictionary annotation, PageResizeTransform transform) {
         if (!annotation.Items.TryGetValue("Rect", out PdfObject? rectObject) ||
-            rectObject is not PdfArray rect ||
-            rect.Items.Count < 4 ||
-            rect.Items[0] is not PdfNumber x1 ||
-            rect.Items[1] is not PdfNumber y1 ||
-            rect.Items[2] is not PdfNumber x2 ||
-            rect.Items[3] is not PdfNumber y2) {
+            !TryGetMutableArray(objects, rectObject, out PdfArray? rect) ||
+            rect is null) {
+            return;
+        }
+
+        PdfArray mutableRect = rect;
+        if (mutableRect.Items.Count < 4 ||
+            mutableRect.Items[0] is not PdfNumber x1 ||
+            mutableRect.Items[1] is not PdfNumber y1 ||
+            mutableRect.Items[2] is not PdfNumber x2 ||
+            mutableRect.Items[3] is not PdfNumber y2) {
             return;
         }
 

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Resize.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Resize.cs
@@ -261,6 +261,8 @@ public static partial class PdfPageEditor {
             return;
         }
 
+        var visitedReferences = new HashSet<int>();
+        var transformedArrays = new HashSet<PdfArray>();
         for (int i = 0; i < document.Pages.Count; i++) {
             int pageNumber = i + 1;
             int pageObjectNumber = document.Pages[i].ObjectNumber;
@@ -272,7 +274,7 @@ public static partial class PdfPageEditor {
             PageResizeTransform? annotationGeometryTransform = selectedPages.Contains(pageNumber)
                 ? transformsByPageObjectNumber[pageObjectNumber]
                 : null;
-            if (TryBuildTransformedAnnotations(objects, pageDictionary, annotationGeometryTransform, transformsByPageObjectNumber, out PdfArray? transformedAnnotations)) {
+            if (TryBuildTransformedAnnotations(objects, pageDictionary, annotationGeometryTransform, transformsByPageObjectNumber, visitedReferences, transformedArrays, out PdfArray? transformedAnnotations)) {
                 if (!overrides.TryGetValue(pageObjectNumber, out Dictionary<string, PdfObject>? pageOverrides)) {
                     pageOverrides = new Dictionary<string, PdfObject>(StringComparer.Ordinal);
                     overrides[pageObjectNumber] = pageOverrides;
@@ -288,6 +290,8 @@ public static partial class PdfPageEditor {
         PdfDictionary pageDictionary,
         PageResizeTransform? annotationGeometryTransform,
         IReadOnlyDictionary<int, PageResizeTransform> transformsByPageObjectNumber,
+        HashSet<int> visitedReferences,
+        HashSet<PdfArray> transformedArrays,
         out PdfArray? transformedAnnotations) {
         transformedAnnotations = null;
         if (!pageDictionary.Items.TryGetValue("Annots", out PdfObject? annotationsObject) ||
@@ -305,7 +309,7 @@ public static partial class PdfPageEditor {
                     TransformAnnotationCoordinateArrays(clonedAnnotation, annotationGeometryTransform.Value);
                 }
 
-                TransformDestinationsInObject(objects, clonedAnnotation, transformsByPageObjectNumber, new HashSet<int>(), new HashSet<PdfArray>());
+                TransformDestinationsInObject(objects, clonedAnnotation, transformsByPageObjectNumber, visitedReferences, transformedArrays);
                 transformedAnnotations.Items.Add(clonedAnnotation);
             } else {
                 transformedAnnotations.Items.Add(ClonePdfObject(annotationObject));
@@ -463,16 +467,61 @@ public static partial class PdfPageEditor {
                 break;
             case "FitH":
             case "FitBH":
+                if (TransformRotatedFitHorizontalDestination(array, transform)) {
+                    break;
+                }
+
                 TransformDestinationCoordinate(array, 2, transform, isX: false);
                 break;
             case "FitV":
             case "FitBV":
+                if (TransformRotatedFitVerticalDestination(array, transform)) {
+                    break;
+                }
+
                 TransformDestinationCoordinate(array, 2, transform, isX: true);
                 break;
             case "FitR":
                 TransformDestinationRectangle(array, 2, 3, 4, 5, transform);
                 break;
         }
+    }
+
+    private static bool TransformRotatedFitHorizontalDestination(PdfArray array, PageResizeTransform transform) {
+        if (!transform.HasAxisSwap ||
+            array.Items.Count <= 2 ||
+            array.Items[2] is not PdfNumber top) {
+            return false;
+        }
+
+        double anchorX = transform.SourceLeft;
+        (double transformedX, double transformedY) = TransformPoint(anchorX, top.Value, transform);
+        ReplaceDestinationWithXyz(array, transformedX, transformedY);
+        return true;
+    }
+
+    private static bool TransformRotatedFitVerticalDestination(PdfArray array, PageResizeTransform transform) {
+        if (!transform.HasAxisSwap ||
+            array.Items.Count <= 2 ||
+            array.Items[2] is not PdfNumber left) {
+            return false;
+        }
+
+        double anchorY = transform.SourceBottom + transform.SourceHeight;
+        (double transformedX, double transformedY) = TransformPoint(left.Value, anchorY, transform);
+        ReplaceDestinationWithXyz(array, transformedX, transformedY);
+        return true;
+    }
+
+    private static void ReplaceDestinationWithXyz(PdfArray array, double left, double top) {
+        while (array.Items.Count > 2) {
+            array.Items.RemoveAt(array.Items.Count - 1);
+        }
+
+        array.Items[1] = new PdfName("XYZ");
+        array.Items.Add(new PdfNumber(left));
+        array.Items.Add(new PdfNumber(top));
+        array.Items.Add(PdfNull.Instance);
     }
 
     private static void TransformDestinationPoint(PdfArray array, int xIndex, int yIndex, PageResizeTransform transform) {
@@ -597,7 +646,12 @@ public static partial class PdfPageEditor {
                 0D,
                 visualTranslateX - sourceBottom * scaleX,
                 visualTranslateY + (sourceWidth + sourceLeft) * scaleY,
-                pageObjectNumber),
+                pageObjectNumber,
+                sourceLeft,
+                sourceBottom,
+                sourceWidth,
+                sourceHeight,
+                rotationDegrees),
             180 => new PageResizeTransform(
                 -scaleX,
                 0D,
@@ -605,7 +659,12 @@ public static partial class PdfPageEditor {
                 -scaleY,
                 visualTranslateX + (sourceWidth + sourceLeft) * scaleX,
                 visualTranslateY + (sourceHeight + sourceBottom) * scaleY,
-                pageObjectNumber),
+                pageObjectNumber,
+                sourceLeft,
+                sourceBottom,
+                sourceWidth,
+                sourceHeight,
+                rotationDegrees),
             270 => new PageResizeTransform(
                 0D,
                 scaleY,
@@ -613,7 +672,12 @@ public static partial class PdfPageEditor {
                 0D,
                 visualTranslateX + (sourceHeight + sourceBottom) * scaleX,
                 visualTranslateY - sourceLeft * scaleY,
-                pageObjectNumber),
+                pageObjectNumber,
+                sourceLeft,
+                sourceBottom,
+                sourceWidth,
+                sourceHeight,
+                rotationDegrees),
             _ => new PageResizeTransform(
                 scaleX,
                 0D,
@@ -621,7 +685,12 @@ public static partial class PdfPageEditor {
                 scaleY,
                 visualTranslateX - sourceLeft * scaleX,
                 visualTranslateY - sourceBottom * scaleY,
-                pageObjectNumber)
+                pageObjectNumber,
+                sourceLeft,
+                sourceBottom,
+                sourceWidth,
+                sourceHeight,
+                rotationDegrees)
         };
     }
 
@@ -661,7 +730,7 @@ public static partial class PdfPageEditor {
     }
 
     private readonly struct PageResizeTransform {
-        public PageResizeTransform(double a, double b, double c, double d, double e, double f, int pageObjectNumber) {
+        public PageResizeTransform(double a, double b, double c, double d, double e, double f, int pageObjectNumber, double sourceLeft, double sourceBottom, double sourceWidth, double sourceHeight, int rotationDegrees) {
             A = a;
             B = b;
             C = c;
@@ -669,6 +738,11 @@ public static partial class PdfPageEditor {
             E = e;
             F = f;
             PageObjectNumber = pageObjectNumber;
+            SourceLeft = sourceLeft;
+            SourceBottom = sourceBottom;
+            SourceWidth = sourceWidth;
+            SourceHeight = sourceHeight;
+            RotationDegrees = rotationDegrees;
         }
 
         public double A { get; }
@@ -684,5 +758,17 @@ public static partial class PdfPageEditor {
         public double F { get; }
 
         public int PageObjectNumber { get; }
+
+        public double SourceLeft { get; }
+
+        public double SourceBottom { get; }
+
+        public double SourceWidth { get; }
+
+        public double SourceHeight { get; }
+
+        public int RotationDegrees { get; }
+
+        public bool HasAxisSwap => RotationDegrees == 90 || RotationDegrees == 270;
     }
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Resize.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Resize.cs
@@ -58,7 +58,8 @@ public static partial class PdfPageEditor {
             double sourceHeight = sourceBox?.Height ?? document.Pages[i].GetPageSize().Height;
             ValidateSourcePageSize(sourceWidth, sourceHeight, pageNumber);
 
-            var transform = CalculateResizeTransform(pageObjectNumber, sourceLeft, sourceBottom, sourceWidth, sourceHeight, options);
+            int rotationDegrees = NormalizeResizeRotation(document.Pages[i].GetRotationDegrees());
+            var transform = CalculateResizeTransform(pageObjectNumber, sourceLeft, sourceBottom, sourceWidth, sourceHeight, rotationDegrees, options);
             transformsByPageObjectNumber[pageObjectNumber] = transform;
             int prefixPseudoObjectNumber = ResizeContentPrefixBasePseudoObjectNumber - i;
             int suffixPseudoObjectNumber = ResizeContentSuffixBasePseudoObjectNumber - i;
@@ -78,16 +79,13 @@ public static partial class PdfPageEditor {
             };
 
             AddNormalizedProductionBoxes(pageOverrides, geometry, options.PageSize);
-            if (TryBuildTransformedAnnotations(objects, pageDictionary, transform, out PdfArray? transformedAnnotations)) {
-                pageOverrides["Annots"] = transformedAnnotations!;
-            }
-
             overrides[pageObjectNumber] = pageOverrides;
         }
 
         PdfFileVersion fileVersion = PdfFileAssembler.ParseHeaderVersionOrDefault(PdfSyntax.GetHeaderVersion(pdf));
         PdfPageExtractor.CatalogRewriteState catalogState = PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw);
         TransformCatalogDestinationsForResize(objects, catalogState, transformsByPageObjectNumber);
+        TransformPageAnnotationsForResize(objects, document, selected, transformsByPageObjectNumber, overrides);
         return PdfPageExtractor.ExtractPages(
             objects,
             document.Metadata,
@@ -215,10 +213,12 @@ public static partial class PdfPageEditor {
     private static PdfStream BuildResizeContentStream(PageResizeTransform transform, double sourceLeft, double sourceBottom, double sourceWidth, double sourceHeight) {
         string content =
             "q\n" +
-            FormatResizeNumber(transform.ScaleX) + " 0 0 " +
-            FormatResizeNumber(transform.ScaleY) + " " +
-            FormatResizeNumber(transform.TranslateX) + " " +
-            FormatResizeNumber(transform.TranslateY) + " cm\n" +
+            FormatResizeNumber(transform.A) + " " +
+            FormatResizeNumber(transform.B) + " " +
+            FormatResizeNumber(transform.C) + " " +
+            FormatResizeNumber(transform.D) + " " +
+            FormatResizeNumber(transform.E) + " " +
+            FormatResizeNumber(transform.F) + " cm\n" +
             FormatResizeNumber(sourceLeft) + " " +
             FormatResizeNumber(sourceBottom) + " " +
             FormatResizeNumber(sourceWidth) + " " +
@@ -251,10 +251,43 @@ public static partial class PdfPageEditor {
         return clone;
     }
 
+    private static void TransformPageAnnotationsForResize(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfReadDocument document,
+        HashSet<int> selectedPages,
+        IReadOnlyDictionary<int, PageResizeTransform> transformsByPageObjectNumber,
+        Dictionary<int, Dictionary<string, PdfObject>> overrides) {
+        if (transformsByPageObjectNumber.Count == 0) {
+            return;
+        }
+
+        for (int i = 0; i < document.Pages.Count; i++) {
+            int pageNumber = i + 1;
+            int pageObjectNumber = document.Pages[i].ObjectNumber;
+            if (!objects.TryGetValue(pageObjectNumber, out PdfIndirectObject? indirect) ||
+                indirect.Value is not PdfDictionary pageDictionary) {
+                continue;
+            }
+
+            PageResizeTransform? annotationGeometryTransform = selectedPages.Contains(pageNumber)
+                ? transformsByPageObjectNumber[pageObjectNumber]
+                : null;
+            if (TryBuildTransformedAnnotations(objects, pageDictionary, annotationGeometryTransform, transformsByPageObjectNumber, out PdfArray? transformedAnnotations)) {
+                if (!overrides.TryGetValue(pageObjectNumber, out Dictionary<string, PdfObject>? pageOverrides)) {
+                    pageOverrides = new Dictionary<string, PdfObject>(StringComparer.Ordinal);
+                    overrides[pageObjectNumber] = pageOverrides;
+                }
+
+                pageOverrides["Annots"] = transformedAnnotations!;
+            }
+        }
+    }
+
     private static bool TryBuildTransformedAnnotations(
         Dictionary<int, PdfIndirectObject> objects,
         PdfDictionary pageDictionary,
-        PageResizeTransform transform,
+        PageResizeTransform? annotationGeometryTransform,
+        IReadOnlyDictionary<int, PageResizeTransform> transformsByPageObjectNumber,
         out PdfArray? transformedAnnotations) {
         transformedAnnotations = null;
         if (!pageDictionary.Items.TryGetValue("Annots", out PdfObject? annotationsObject) ||
@@ -267,11 +300,12 @@ public static partial class PdfPageEditor {
             PdfObject? resolved = PdfObjectLookup.Resolve(objects, annotationObject);
             if (resolved is PdfDictionary annotationDictionary) {
                 var clonedAnnotation = (PdfDictionary)ClonePdfObject(annotationDictionary);
-                TransformAnnotationRectangle(clonedAnnotation, transform);
-                TransformAnnotationCoordinateArrays(clonedAnnotation, transform);
-                TransformDestinationsInObject(objects, clonedAnnotation, new Dictionary<int, PageResizeTransform> {
-                    [transform.PageObjectNumber] = transform
-                }, new HashSet<int>(), new HashSet<PdfArray>());
+                if (annotationGeometryTransform.HasValue) {
+                    TransformAnnotationRectangle(clonedAnnotation, annotationGeometryTransform.Value);
+                    TransformAnnotationCoordinateArrays(clonedAnnotation, annotationGeometryTransform.Value);
+                }
+
+                TransformDestinationsInObject(objects, clonedAnnotation, transformsByPageObjectNumber, new HashSet<int>(), new HashSet<PdfArray>());
                 transformedAnnotations.Items.Add(clonedAnnotation);
             } else {
                 transformedAnnotations.Items.Add(ClonePdfObject(annotationObject));
@@ -292,15 +326,15 @@ public static partial class PdfPageEditor {
             return;
         }
 
-        double transformedX1 = TransformX(x1.Value, transform);
-        double transformedY1 = TransformY(y1.Value, transform);
-        double transformedX2 = TransformX(x2.Value, transform);
-        double transformedY2 = TransformY(y2.Value, transform);
+        (double transformedX1, double transformedY1) = TransformPoint(x1.Value, y1.Value, transform);
+        (double transformedX2, double transformedY2) = TransformPoint(x2.Value, y1.Value, transform);
+        (double transformedX3, double transformedY3) = TransformPoint(x1.Value, y2.Value, transform);
+        (double transformedX4, double transformedY4) = TransformPoint(x2.Value, y2.Value, transform);
         var transformedRect = new PdfArray();
-        transformedRect.Items.Add(new PdfNumber(Math.Min(transformedX1, transformedX2)));
-        transformedRect.Items.Add(new PdfNumber(Math.Min(transformedY1, transformedY2)));
-        transformedRect.Items.Add(new PdfNumber(Math.Max(transformedX1, transformedX2)));
-        transformedRect.Items.Add(new PdfNumber(Math.Max(transformedY1, transformedY2)));
+        transformedRect.Items.Add(new PdfNumber(Min(transformedX1, transformedX2, transformedX3, transformedX4)));
+        transformedRect.Items.Add(new PdfNumber(Min(transformedY1, transformedY2, transformedY3, transformedY4)));
+        transformedRect.Items.Add(new PdfNumber(Max(transformedX1, transformedX2, transformedX3, transformedX4)));
+        transformedRect.Items.Add(new PdfNumber(Max(transformedY1, transformedY2, transformedY3, transformedY4)));
         annotation.Items["Rect"] = transformedRect;
     }
 
@@ -334,17 +368,27 @@ public static partial class PdfPageEditor {
         for (int i = 0; i + 1 < array.Items.Count; i += 2) {
             if (array.Items[i] is PdfNumber x &&
                 array.Items[i + 1] is PdfNumber y) {
-                array.Items[i] = new PdfNumber(TransformX(x.Value, transform));
-                array.Items[i + 1] = new PdfNumber(TransformY(y.Value, transform));
+                (double transformedX, double transformedY) = TransformPoint(x.Value, y.Value, transform);
+                array.Items[i] = new PdfNumber(transformedX);
+                array.Items[i + 1] = new PdfNumber(transformedY);
             }
         }
     }
 
     private static double TransformX(double value, PageResizeTransform transform) =>
-        value * transform.ScaleX + transform.TranslateX;
+        value * transform.A + transform.E;
 
     private static double TransformY(double value, PageResizeTransform transform) =>
-        value * transform.ScaleY + transform.TranslateY;
+        value * transform.D + transform.F;
+
+    private static (double X, double Y) TransformPoint(double x, double y, PageResizeTransform transform) =>
+        (transform.A * x + transform.C * y + transform.E, transform.B * x + transform.D * y + transform.F);
+
+    private static double Min(double a, double b, double c, double d) =>
+        Math.Min(Math.Min(a, b), Math.Min(c, d));
+
+    private static double Max(double a, double b, double c, double d) =>
+        Math.Max(Math.Max(a, b), Math.Max(c, d));
 
     private static void TransformCatalogDestinationsForResize(
         Dictionary<int, PdfIndirectObject> objects,
@@ -415,8 +459,7 @@ public static partial class PdfPageEditor {
 
         switch (destinationMode.Name) {
             case "XYZ":
-                TransformDestinationCoordinate(array, 2, transform, isX: true);
-                TransformDestinationCoordinate(array, 3, transform, isX: false);
+                TransformDestinationPoint(array, 2, 3, transform);
                 break;
             case "FitH":
             case "FitBH":
@@ -427,12 +470,50 @@ public static partial class PdfPageEditor {
                 TransformDestinationCoordinate(array, 2, transform, isX: true);
                 break;
             case "FitR":
-                TransformDestinationCoordinate(array, 2, transform, isX: true);
-                TransformDestinationCoordinate(array, 3, transform, isX: false);
-                TransformDestinationCoordinate(array, 4, transform, isX: true);
-                TransformDestinationCoordinate(array, 5, transform, isX: false);
+                TransformDestinationRectangle(array, 2, 3, 4, 5, transform);
                 break;
         }
+    }
+
+    private static void TransformDestinationPoint(PdfArray array, int xIndex, int yIndex, PageResizeTransform transform) {
+        if (xIndex < array.Items.Count &&
+            yIndex < array.Items.Count &&
+            array.Items[xIndex] is PdfNumber x &&
+            array.Items[yIndex] is PdfNumber y) {
+            (double transformedX, double transformedY) = TransformPoint(x.Value, y.Value, transform);
+            array.Items[xIndex] = new PdfNumber(transformedX);
+            array.Items[yIndex] = new PdfNumber(transformedY);
+            return;
+        }
+
+        TransformDestinationCoordinate(array, xIndex, transform, isX: true);
+        TransformDestinationCoordinate(array, yIndex, transform, isX: false);
+    }
+
+    private static void TransformDestinationRectangle(PdfArray array, int leftIndex, int bottomIndex, int rightIndex, int topIndex, PageResizeTransform transform) {
+        if (leftIndex >= array.Items.Count ||
+            bottomIndex >= array.Items.Count ||
+            rightIndex >= array.Items.Count ||
+            topIndex >= array.Items.Count ||
+            array.Items[leftIndex] is not PdfNumber left ||
+            array.Items[bottomIndex] is not PdfNumber bottom ||
+            array.Items[rightIndex] is not PdfNumber right ||
+            array.Items[topIndex] is not PdfNumber top) {
+            TransformDestinationCoordinate(array, leftIndex, transform, isX: true);
+            TransformDestinationCoordinate(array, bottomIndex, transform, isX: false);
+            TransformDestinationCoordinate(array, rightIndex, transform, isX: true);
+            TransformDestinationCoordinate(array, topIndex, transform, isX: false);
+            return;
+        }
+
+        (double x1, double y1) = TransformPoint(left.Value, bottom.Value, transform);
+        (double x2, double y2) = TransformPoint(left.Value, top.Value, transform);
+        (double x3, double y3) = TransformPoint(right.Value, bottom.Value, transform);
+        (double x4, double y4) = TransformPoint(right.Value, top.Value, transform);
+        array.Items[leftIndex] = new PdfNumber(Min(x1, x2, x3, x4));
+        array.Items[bottomIndex] = new PdfNumber(Min(y1, y2, y3, y4));
+        array.Items[rightIndex] = new PdfNumber(Max(x1, x2, x3, x4));
+        array.Items[topIndex] = new PdfNumber(Max(y1, y2, y3, y4));
     }
 
     private static void TransformDestinationCoordinate(PdfArray array, int index, PageResizeTransform transform, bool isX) {
@@ -481,12 +562,14 @@ public static partial class PdfPageEditor {
         }
     }
 
-    private static PageResizeTransform CalculateResizeTransform(int pageObjectNumber, double sourceLeft, double sourceBottom, double sourceWidth, double sourceHeight, PdfPageResizeOptions options) {
+    private static PageResizeTransform CalculateResizeTransform(int pageObjectNumber, double sourceLeft, double sourceBottom, double sourceWidth, double sourceHeight, int rotationDegrees, PdfPageResizeOptions options) {
         double margin = options.Margin;
         double availableWidth = options.PageSize.Width - margin * 2D;
         double availableHeight = options.PageSize.Height - margin * 2D;
-        double scaleX = availableWidth / sourceWidth;
-        double scaleY = availableHeight / sourceHeight;
+        double visualSourceWidth = rotationDegrees == 90 || rotationDegrees == 270 ? sourceHeight : sourceWidth;
+        double visualSourceHeight = rotationDegrees == 90 || rotationDegrees == 270 ? sourceWidth : sourceHeight;
+        double scaleX = availableWidth / visualSourceWidth;
+        double scaleY = availableHeight / visualSourceHeight;
 
         switch (options.Mode) {
             case PdfPageResizeMode.Fit:
@@ -501,11 +584,54 @@ public static partial class PdfPageEditor {
                 throw new ArgumentOutOfRangeException(nameof(options), "Unsupported page resize mode.");
         }
 
-        double scaledWidth = sourceWidth * scaleX;
-        double scaledHeight = sourceHeight * scaleY;
-        double translateX = margin + (availableWidth - scaledWidth) / 2D - sourceLeft * scaleX;
-        double translateY = margin + (availableHeight - scaledHeight) / 2D - sourceBottom * scaleY;
-        return new PageResizeTransform(scaleX, scaleY, translateX, translateY, pageObjectNumber);
+        double scaledWidth = visualSourceWidth * scaleX;
+        double scaledHeight = visualSourceHeight * scaleY;
+        double visualTranslateX = margin + (availableWidth - scaledWidth) / 2D;
+        double visualTranslateY = margin + (availableHeight - scaledHeight) / 2D;
+
+        return rotationDegrees switch {
+            90 => new PageResizeTransform(
+                0D,
+                -scaleY,
+                scaleX,
+                0D,
+                visualTranslateX - sourceBottom * scaleX,
+                visualTranslateY + (sourceWidth + sourceLeft) * scaleY,
+                pageObjectNumber),
+            180 => new PageResizeTransform(
+                -scaleX,
+                0D,
+                0D,
+                -scaleY,
+                visualTranslateX + (sourceWidth + sourceLeft) * scaleX,
+                visualTranslateY + (sourceHeight + sourceBottom) * scaleY,
+                pageObjectNumber),
+            270 => new PageResizeTransform(
+                0D,
+                scaleY,
+                -scaleX,
+                0D,
+                visualTranslateX + (sourceHeight + sourceBottom) * scaleX,
+                visualTranslateY - sourceLeft * scaleY,
+                pageObjectNumber),
+            _ => new PageResizeTransform(
+                scaleX,
+                0D,
+                0D,
+                scaleY,
+                visualTranslateX - sourceLeft * scaleX,
+                visualTranslateY - sourceBottom * scaleY,
+                pageObjectNumber)
+        };
+    }
+
+    private static int NormalizeResizeRotation(int rotationDegrees) {
+        int normalized = rotationDegrees % 360;
+        if (normalized < 0) {
+            normalized += 360;
+        }
+
+        return normalized == 90 || normalized == 180 || normalized == 270 ? normalized : 0;
     }
 
     private static void ValidateResizeOptions(PdfPageResizeOptions options) {
@@ -535,21 +661,27 @@ public static partial class PdfPageEditor {
     }
 
     private readonly struct PageResizeTransform {
-        public PageResizeTransform(double scaleX, double scaleY, double translateX, double translateY, int pageObjectNumber) {
-            ScaleX = scaleX;
-            ScaleY = scaleY;
-            TranslateX = translateX;
-            TranslateY = translateY;
+        public PageResizeTransform(double a, double b, double c, double d, double e, double f, int pageObjectNumber) {
+            A = a;
+            B = b;
+            C = c;
+            D = d;
+            E = e;
+            F = f;
             PageObjectNumber = pageObjectNumber;
         }
 
-        public double ScaleX { get; }
+        public double A { get; }
 
-        public double ScaleY { get; }
+        public double B { get; }
 
-        public double TranslateX { get; }
+        public double C { get; }
 
-        public double TranslateY { get; }
+        public double D { get; }
+
+        public double E { get; }
+
+        public double F { get; }
 
         public int PageObjectNumber { get; }
     }

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Resize.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Resize.cs
@@ -1,0 +1,281 @@
+using System.Globalization;
+
+namespace OfficeIMO.Pdf;
+
+public static partial class PdfPageEditor {
+    private const int ResizeContentPrefixBasePseudoObjectNumber = -10000;
+    private const int ResizeContentSuffixBasePseudoObjectNumber = -20000;
+
+    /// <summary>
+    /// Creates a new PDF with selected pages scaled into the supplied target page size.
+    /// If no page numbers are supplied, all pages are resized.
+    /// </summary>
+    public static byte[] ResizePages(byte[] pdf, PageSize pageSize, params int[] pageNumbers) {
+        return ResizePages(pdf, new PdfPageResizeOptions(pageSize), pageNumbers);
+    }
+
+    /// <summary>
+    /// Creates a new PDF with selected pages scaled into the target page size described by <paramref name="options"/>.
+    /// If no page numbers are supplied, all pages are resized.
+    /// </summary>
+    public static byte[] ResizePages(byte[] pdf, PdfPageResizeOptions options, params int[] pageNumbers) {
+        Guard.NotNull(pdf, nameof(pdf));
+        Guard.NotNull(options, nameof(options));
+        Guard.NotNull(pageNumbers, nameof(pageNumbers));
+        ValidateResizeOptions(options);
+        PdfSyntax.ThrowIfUnsafeForRewrite(pdf);
+
+        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf);
+        var document = PdfReadDocument.Load(pdf);
+        var selectedPages = pageNumbers.Length == 0
+            ? Enumerable.Range(1, document.Pages.Count).ToArray()
+            : pageNumbers;
+        ValidatePageNumbers(selectedPages, document.Pages.Count, nameof(pageNumbers));
+
+        var selected = new HashSet<int>(selectedPages);
+        var pageObjectNumbers = document.Pages.Select(static page => page.ObjectNumber).ToArray();
+        var overrides = new Dictionary<int, Dictionary<string, PdfObject>>();
+        var additionalObjects = new List<PdfPageExtractor.AdditionalObject>();
+
+        for (int i = 0; i < document.Pages.Count; i++) {
+            int pageNumber = i + 1;
+            if (!selected.Contains(pageNumber)) {
+                continue;
+            }
+
+            int pageObjectNumber = document.Pages[i].ObjectNumber;
+            if (!objects.TryGetValue(pageObjectNumber, out var indirect) ||
+                indirect.Value is not PdfDictionary pageDictionary) {
+                throw new InvalidOperationException("PDF page object " + pageObjectNumber.ToString(CultureInfo.InvariantCulture) + " was not found.");
+            }
+
+            var geometry = document.Pages[i].GetGeometry();
+            var sourceBox = geometry.EffectiveBox;
+            double sourceLeft = sourceBox?.Left ?? 0D;
+            double sourceBottom = sourceBox?.Bottom ?? 0D;
+            double sourceWidth = sourceBox?.Width ?? document.Pages[i].GetPageSize().Width;
+            double sourceHeight = sourceBox?.Height ?? document.Pages[i].GetPageSize().Height;
+            ValidateSourcePageSize(sourceWidth, sourceHeight, pageNumber);
+
+            var transform = CalculateResizeTransform(sourceLeft, sourceBottom, sourceWidth, sourceHeight, options);
+            int prefixPseudoObjectNumber = ResizeContentPrefixBasePseudoObjectNumber - i;
+            int suffixPseudoObjectNumber = ResizeContentSuffixBasePseudoObjectNumber - i;
+            additionalObjects.Add(new PdfPageExtractor.AdditionalObject(prefixPseudoObjectNumber, BuildResizeContentStream(transform)));
+            additionalObjects.Add(new PdfPageExtractor.AdditionalObject(suffixPseudoObjectNumber, new PdfStream(new PdfDictionary(), PdfEncoding.Latin1GetBytes("\nQ\n"))));
+
+            overrides[pageObjectNumber] = new Dictionary<string, PdfObject>(StringComparer.Ordinal) {
+                ["MediaBox"] = CreatePageBoxArray(0D, 0D, options.PageSize.Width, options.PageSize.Height),
+                ["CropBox"] = CreatePageBoxArray(0D, 0D, options.PageSize.Width, options.PageSize.Height),
+                ["Contents"] = BuildResizedContentsArray(
+                    objects,
+                    pageDictionary.Items.TryGetValue("Contents", out var contents) ? contents : null,
+                    prefixPseudoObjectNumber,
+                    suffixPseudoObjectNumber)
+            };
+        }
+
+        PdfFileVersion fileVersion = PdfFileAssembler.ParseHeaderVersionOrDefault(PdfSyntax.GetHeaderVersion(pdf));
+        return PdfPageExtractor.ExtractPages(
+            objects,
+            document.Metadata,
+            pageObjectNumbers,
+            overrides,
+            additionalObjects,
+            PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw),
+            fileVersion);
+    }
+
+    /// <summary>Creates a new PDF with selected pages scaled into the supplied target page size from a readable stream.</summary>
+    public static byte[] ResizePages(Stream stream, PageSize pageSize, params int[] pageNumbers) {
+        return ResizePages(ReadStream(stream, nameof(stream)), pageSize, pageNumbers);
+    }
+
+    /// <summary>Creates a new PDF with selected pages scaled into the target page size described by <paramref name="options"/> from a readable stream.</summary>
+    public static byte[] ResizePages(Stream stream, PdfPageResizeOptions options, params int[] pageNumbers) {
+        return ResizePages(ReadStream(stream, nameof(stream)), options, pageNumbers);
+    }
+
+    /// <summary>Writes a new PDF with selected pages scaled into the supplied target page size.</summary>
+    public static void ResizePages(byte[] pdf, Stream outputStream, PageSize pageSize, params int[] pageNumbers) {
+        WriteOutput(outputStream, ResizePages(pdf, pageSize, pageNumbers));
+    }
+
+    /// <summary>Writes a new PDF with selected pages scaled into the target page size described by <paramref name="options"/>.</summary>
+    public static void ResizePages(byte[] pdf, Stream outputStream, PdfPageResizeOptions options, params int[] pageNumbers) {
+        WriteOutput(outputStream, ResizePages(pdf, options, pageNumbers));
+    }
+
+    /// <summary>Writes a new PDF with selected pages scaled into the supplied target page size from a readable stream.</summary>
+    public static void ResizePages(Stream inputStream, Stream outputStream, PageSize pageSize, params int[] pageNumbers) {
+        WriteOutput(outputStream, ResizePages(inputStream, pageSize, pageNumbers));
+    }
+
+    /// <summary>Writes a new PDF with selected pages scaled into the target page size described by <paramref name="options"/> from a readable stream.</summary>
+    public static void ResizePages(Stream inputStream, Stream outputStream, PdfPageResizeOptions options, params int[] pageNumbers) {
+        WriteOutput(outputStream, ResizePages(inputStream, options, pageNumbers));
+    }
+
+    /// <summary>Writes a new PDF file with selected pages scaled into the supplied target page size.</summary>
+    public static void ResizePages(string inputPath, string outputPath, PageSize pageSize, params int[] pageNumbers) {
+        Guard.NotNullOrWhiteSpace(inputPath, nameof(inputPath));
+        Guard.NotNull(outputPath, nameof(outputPath));
+
+        string fullOutputPath = ValidateOutputPath(outputPath);
+        WriteOutput(fullOutputPath, ResizePages(File.ReadAllBytes(inputPath), pageSize, pageNumbers));
+    }
+
+    /// <summary>Writes a new PDF file with selected pages scaled into the target page size described by <paramref name="options"/>.</summary>
+    public static void ResizePages(string inputPath, string outputPath, PdfPageResizeOptions options, params int[] pageNumbers) {
+        Guard.NotNullOrWhiteSpace(inputPath, nameof(inputPath));
+        Guard.NotNull(outputPath, nameof(outputPath));
+
+        string fullOutputPath = ValidateOutputPath(outputPath);
+        WriteOutput(fullOutputPath, ResizePages(File.ReadAllBytes(inputPath), options, pageNumbers));
+    }
+
+    /// <summary>Creates a new PDF with selected pages scaled into the supplied target page size from a file path.</summary>
+    public static byte[] ResizePages(string inputPath, PageSize pageSize, params int[] pageNumbers) {
+        Guard.NotNullOrWhiteSpace(inputPath, nameof(inputPath));
+        return ResizePages(File.ReadAllBytes(inputPath), pageSize, pageNumbers);
+    }
+
+    /// <summary>Creates a new PDF with selected pages scaled into the target page size described by <paramref name="options"/> from a file path.</summary>
+    public static byte[] ResizePages(string inputPath, PdfPageResizeOptions options, params int[] pageNumbers) {
+        Guard.NotNullOrWhiteSpace(inputPath, nameof(inputPath));
+        return ResizePages(File.ReadAllBytes(inputPath), options, pageNumbers);
+    }
+
+    /// <summary>Creates a new PDF with the inclusive one-based page range scaled into the supplied target page size.</summary>
+    public static byte[] ResizePageRange(byte[] pdf, PageSize pageSize, int firstPage, int lastPage) {
+        return ResizePages(pdf, pageSize, BuildInclusivePageRange(firstPage, lastPage, nameof(lastPage)));
+    }
+
+    /// <summary>Creates a new PDF with the inclusive one-based page range scaled into the target page size described by <paramref name="options"/>.</summary>
+    public static byte[] ResizePageRange(byte[] pdf, PdfPageResizeOptions options, int firstPage, int lastPage) {
+        return ResizePages(pdf, options, BuildInclusivePageRange(firstPage, lastPage, nameof(lastPage)));
+    }
+
+    /// <summary>Creates a new PDF with the supplied page ranges scaled into the supplied target page size.</summary>
+    public static byte[] ResizePageRanges(byte[] pdf, PageSize pageSize, params PdfPageRange[] pageRanges) {
+        return ResizePages(pdf, pageSize, ExpandPageRangesDistinct(pageRanges, nameof(pageRanges)));
+    }
+
+    /// <summary>Creates a new PDF with the supplied page ranges scaled into the target page size described by <paramref name="options"/>.</summary>
+    public static byte[] ResizePageRanges(byte[] pdf, PdfPageResizeOptions options, params PdfPageRange[] pageRanges) {
+        return ResizePages(pdf, options, ExpandPageRangesDistinct(pageRanges, nameof(pageRanges)));
+    }
+
+    private static PdfArray BuildResizedContentsArray(Dictionary<int, PdfIndirectObject> objects, PdfObject? existingContents, int prefixPseudoObjectNumber, int suffixPseudoObjectNumber) {
+        var result = new PdfArray();
+        result.Items.Add(new PdfReference(prefixPseudoObjectNumber, 0));
+        AppendContentEntries(objects, result, existingContents);
+        result.Items.Add(new PdfReference(suffixPseudoObjectNumber, 0));
+        return result;
+    }
+
+    private static void AppendContentEntries(Dictionary<int, PdfIndirectObject> objects, PdfArray target, PdfObject? contents) {
+        if (contents is null) {
+            return;
+        }
+
+        if (contents is PdfArray directArray) {
+            foreach (var item in directArray.Items) {
+                target.Items.Add(item);
+            }
+
+            return;
+        }
+
+        if (contents is PdfReference reference &&
+            PdfObjectLookup.TryGet(objects, reference, out var indirect) &&
+            indirect.Value is PdfArray referencedArray) {
+            foreach (var item in referencedArray.Items) {
+                target.Items.Add(item);
+            }
+
+            return;
+        }
+
+        target.Items.Add(contents);
+    }
+
+    private static PdfStream BuildResizeContentStream(PageResizeTransform transform) {
+        string content =
+            "q\n" +
+            FormatResizeNumber(transform.ScaleX) + " 0 0 " +
+            FormatResizeNumber(transform.ScaleY) + " " +
+            FormatResizeNumber(transform.TranslateX) + " " +
+            FormatResizeNumber(transform.TranslateY) + " cm\n";
+        return new PdfStream(new PdfDictionary(), PdfEncoding.Latin1GetBytes(content));
+    }
+
+    private static PageResizeTransform CalculateResizeTransform(double sourceLeft, double sourceBottom, double sourceWidth, double sourceHeight, PdfPageResizeOptions options) {
+        double margin = options.Margin;
+        double availableWidth = options.PageSize.Width - margin * 2D;
+        double availableHeight = options.PageSize.Height - margin * 2D;
+        double scaleX = availableWidth / sourceWidth;
+        double scaleY = availableHeight / sourceHeight;
+
+        switch (options.Mode) {
+            case PdfPageResizeMode.Fit:
+                scaleX = scaleY = Math.Min(scaleX, scaleY);
+                break;
+            case PdfPageResizeMode.Fill:
+                scaleX = scaleY = Math.Max(scaleX, scaleY);
+                break;
+            case PdfPageResizeMode.Stretch:
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(options), "Unsupported page resize mode.");
+        }
+
+        double scaledWidth = sourceWidth * scaleX;
+        double scaledHeight = sourceHeight * scaleY;
+        double translateX = margin + (availableWidth - scaledWidth) / 2D - sourceLeft * scaleX;
+        double translateY = margin + (availableHeight - scaledHeight) / 2D - sourceBottom * scaleY;
+        return new PageResizeTransform(scaleX, scaleY, translateX, translateY);
+    }
+
+    private static void ValidateResizeOptions(PdfPageResizeOptions options) {
+        Guard.Positive(options.PageSize.Width, nameof(options));
+        Guard.Positive(options.PageSize.Height, nameof(options));
+        if (!IsFinite(options.Margin) || options.Margin < 0D) {
+            throw new ArgumentOutOfRangeException(nameof(options), "Resize margin must be a finite non-negative number.");
+        }
+
+        if (options.Margin * 2D >= options.PageSize.Width || options.Margin * 2D >= options.PageSize.Height) {
+            throw new ArgumentOutOfRangeException(nameof(options), "Resize margin must leave a positive content area.");
+        }
+    }
+
+    private static void ValidateSourcePageSize(double width, double height, int pageNumber) {
+        if (!IsFinite(width) || !IsFinite(height) || width <= 0D || height <= 0D) {
+            throw new InvalidOperationException("PDF page " + pageNumber.ToString(CultureInfo.InvariantCulture) + " does not expose a valid source page size.");
+        }
+    }
+
+    private static string FormatResizeNumber(double value) {
+        if (Math.Abs(value % 1) < 0.0000001) {
+            return ((long)Math.Round(value)).ToString(CultureInfo.InvariantCulture);
+        }
+
+        return value.ToString("0.######", CultureInfo.InvariantCulture);
+    }
+
+    private readonly struct PageResizeTransform {
+        public PageResizeTransform(double scaleX, double scaleY, double translateX, double translateY) {
+            ScaleX = scaleX;
+            ScaleY = scaleY;
+            TranslateX = translateX;
+            TranslateY = translateY;
+        }
+
+        public double ScaleX { get; }
+
+        public double ScaleY { get; }
+
+        public double TranslateX { get; }
+
+        public double TranslateY { get; }
+    }
+}

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Resize.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Resize.cs
@@ -221,6 +221,11 @@ public static partial class PdfPageEditor {
     private static PdfStream BuildResizeContentStream(PageResizeTransform transform, double sourceLeft, double sourceBottom, double sourceWidth, double sourceHeight) {
         string content =
             "q\n" +
+            FormatResizeNumber(transform.TargetClipLeft) + " " +
+            FormatResizeNumber(transform.TargetClipBottom) + " " +
+            FormatResizeNumber(transform.TargetClipWidth) + " " +
+            FormatResizeNumber(transform.TargetClipHeight) + " re\n" +
+            "W n\n" +
             FormatResizeNumber(transform.A) + " " +
             FormatResizeNumber(transform.B) + " " +
             FormatResizeNumber(transform.C) + " " +
@@ -819,7 +824,11 @@ public static partial class PdfPageEditor {
                 sourceBottom,
                 sourceWidth,
                 sourceHeight,
-                rotationDegrees),
+                rotationDegrees,
+                margin,
+                margin,
+                availableWidth,
+                availableHeight),
             180 => new PageResizeTransform(
                 -scaleX,
                 0D,
@@ -832,7 +841,11 @@ public static partial class PdfPageEditor {
                 sourceBottom,
                 sourceWidth,
                 sourceHeight,
-                rotationDegrees),
+                rotationDegrees,
+                margin,
+                margin,
+                availableWidth,
+                availableHeight),
             270 => new PageResizeTransform(
                 0D,
                 scaleY,
@@ -845,7 +858,11 @@ public static partial class PdfPageEditor {
                 sourceBottom,
                 sourceWidth,
                 sourceHeight,
-                rotationDegrees),
+                rotationDegrees,
+                margin,
+                margin,
+                availableWidth,
+                availableHeight),
             _ => new PageResizeTransform(
                 scaleX,
                 0D,
@@ -858,7 +875,11 @@ public static partial class PdfPageEditor {
                 sourceBottom,
                 sourceWidth,
                 sourceHeight,
-                rotationDegrees)
+                rotationDegrees,
+                margin,
+                margin,
+                availableWidth,
+                availableHeight)
         };
     }
 
@@ -898,7 +919,7 @@ public static partial class PdfPageEditor {
     }
 
     private readonly struct PageResizeTransform {
-        public PageResizeTransform(double a, double b, double c, double d, double e, double f, int pageObjectNumber, double sourceLeft, double sourceBottom, double sourceWidth, double sourceHeight, int rotationDegrees) {
+        public PageResizeTransform(double a, double b, double c, double d, double e, double f, int pageObjectNumber, double sourceLeft, double sourceBottom, double sourceWidth, double sourceHeight, int rotationDegrees, double targetClipLeft, double targetClipBottom, double targetClipWidth, double targetClipHeight) {
             A = a;
             B = b;
             C = c;
@@ -911,6 +932,10 @@ public static partial class PdfPageEditor {
             SourceWidth = sourceWidth;
             SourceHeight = sourceHeight;
             RotationDegrees = rotationDegrees;
+            TargetClipLeft = targetClipLeft;
+            TargetClipBottom = targetClipBottom;
+            TargetClipWidth = targetClipWidth;
+            TargetClipHeight = targetClipHeight;
         }
 
         public double A { get; }
@@ -936,6 +961,14 @@ public static partial class PdfPageEditor {
         public double SourceHeight { get; }
 
         public int RotationDegrees { get; }
+
+        public double TargetClipLeft { get; }
+
+        public double TargetClipBottom { get; }
+
+        public double TargetClipWidth { get; }
+
+        public double TargetClipHeight { get; }
 
         public bool HasAxisSwap => RotationDegrees == 90 || RotationDegrees == 270;
     }

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Resize.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Resize.cs
@@ -316,47 +316,60 @@ public static partial class PdfPageEditor {
             return false;
         }
 
-        var annotationReferenceMap = new Dictionary<int, int>();
-        foreach (PdfObject annotationObject in annotations.Items) {
-            if (annotationObject is PdfReference reference &&
-                PdfObjectLookup.Resolve(objects, reference) is PdfDictionary) {
-                annotationReferenceMap[reference.ObjectNumber] = AllocateResizePseudoObjectNumber(ref nextPseudoObjectNumber);
-            }
-        }
-
-        transformedAnnotations = new PdfArray();
+        var transformedCandidates = new List<TransformedAnnotationCandidate>();
         foreach (PdfObject annotationObject in annotations.Items) {
             PdfObject? resolved = PdfObjectLookup.Resolve(objects, annotationObject);
             if (resolved is PdfDictionary annotationDictionary) {
                 var clonedAnnotation = (PdfDictionary)ClonePdfObject(annotationDictionary);
                 if (annotationGeometryTransform.HasValue) {
-                    TransformAnnotationRectangle(objects, clonedAnnotation, annotationGeometryTransform.Value);
+                    if (!TransformAnnotationRectangle(objects, clonedAnnotation, annotationGeometryTransform.Value)) {
+                        continue;
+                    }
+
                     TransformAnnotationCoordinateArrays(objects, clonedAnnotation, annotationGeometryTransform.Value);
                 }
 
+                int? originalObjectNumber = annotationObject is PdfReference reference ? reference.ObjectNumber : null;
+                transformedCandidates.Add(new TransformedAnnotationCandidate(clonedAnnotation, originalObjectNumber));
+            } else {
+                transformedCandidates.Add(new TransformedAnnotationCandidate(ClonePdfObject(annotationObject), null));
+            }
+        }
+
+        var annotationReferenceMap = new Dictionary<int, int>();
+        foreach (TransformedAnnotationCandidate candidate in transformedCandidates) {
+            if (candidate.OriginalObjectNumber.HasValue &&
+                candidate.Value is PdfDictionary) {
+                annotationReferenceMap[candidate.OriginalObjectNumber.Value] = AllocateResizePseudoObjectNumber(ref nextPseudoObjectNumber);
+            }
+        }
+
+        transformedAnnotations = new PdfArray();
+        foreach (TransformedAnnotationCandidate candidate in transformedCandidates) {
+            if (candidate.Value is PdfDictionary clonedAnnotation) {
                 RemapAnnotationReferences(clonedAnnotation, annotationReferenceMap);
                 InlineDestinationArrayReferences(objects, clonedAnnotation, transformsByPageObjectNumber, transformedArrays);
                 TransformDestinationsInObject(objects, clonedAnnotation, transformsByPageObjectNumber, visitedReferences, transformedArrays);
-                if (annotationObject is PdfReference annotationReference &&
-                    annotationReferenceMap.TryGetValue(annotationReference.ObjectNumber, out int clonedObjectNumber)) {
+                if (candidate.OriginalObjectNumber.HasValue &&
+                    annotationReferenceMap.TryGetValue(candidate.OriginalObjectNumber.Value, out int clonedObjectNumber)) {
                     additionalObjects.Add(new PdfPageExtractor.AdditionalObject(clonedObjectNumber, clonedAnnotation));
                     transformedAnnotations.Items.Add(new PdfReference(clonedObjectNumber, 0));
                 } else {
                     transformedAnnotations.Items.Add(clonedAnnotation);
                 }
             } else {
-                transformedAnnotations.Items.Add(ClonePdfObject(annotationObject));
+                transformedAnnotations.Items.Add(candidate.Value);
             }
         }
 
         return true;
     }
 
-    private static void TransformAnnotationRectangle(Dictionary<int, PdfIndirectObject> objects, PdfDictionary annotation, PageResizeTransform transform) {
+    private static bool TransformAnnotationRectangle(Dictionary<int, PdfIndirectObject> objects, PdfDictionary annotation, PageResizeTransform transform) {
         if (!annotation.Items.TryGetValue("Rect", out PdfObject? rectObject) ||
             !TryGetMutableArray(objects, rectObject, out PdfArray? rect) ||
             rect is null) {
-            return;
+            return true;
         }
 
         PdfArray mutableRect = rect;
@@ -365,19 +378,28 @@ public static partial class PdfPageEditor {
             mutableRect.Items[1] is not PdfNumber y1 ||
             mutableRect.Items[2] is not PdfNumber x2 ||
             mutableRect.Items[3] is not PdfNumber y2) {
-            return;
+            return true;
         }
 
         (double transformedX1, double transformedY1) = TransformPoint(x1.Value, y1.Value, transform);
         (double transformedX2, double transformedY2) = TransformPoint(x2.Value, y1.Value, transform);
         (double transformedX3, double transformedY3) = TransformPoint(x1.Value, y2.Value, transform);
         (double transformedX4, double transformedY4) = TransformPoint(x2.Value, y2.Value, transform);
+        double left = Math.Max(Min(transformedX1, transformedX2, transformedX3, transformedX4), transform.TargetClipLeft);
+        double bottom = Math.Max(Min(transformedY1, transformedY2, transformedY3, transformedY4), transform.TargetClipBottom);
+        double right = Math.Min(Max(transformedX1, transformedX2, transformedX3, transformedX4), transform.TargetClipLeft + transform.TargetClipWidth);
+        double top = Math.Min(Max(transformedY1, transformedY2, transformedY3, transformedY4), transform.TargetClipBottom + transform.TargetClipHeight);
+        if (right <= left + 0.001D || top <= bottom + 0.001D) {
+            return false;
+        }
+
         var transformedRect = new PdfArray();
-        transformedRect.Items.Add(new PdfNumber(Min(transformedX1, transformedX2, transformedX3, transformedX4)));
-        transformedRect.Items.Add(new PdfNumber(Min(transformedY1, transformedY2, transformedY3, transformedY4)));
-        transformedRect.Items.Add(new PdfNumber(Max(transformedX1, transformedX2, transformedX3, transformedX4)));
-        transformedRect.Items.Add(new PdfNumber(Max(transformedY1, transformedY2, transformedY3, transformedY4)));
+        transformedRect.Items.Add(new PdfNumber(left));
+        transformedRect.Items.Add(new PdfNumber(bottom));
+        transformedRect.Items.Add(new PdfNumber(right));
+        transformedRect.Items.Add(new PdfNumber(top));
         annotation.Items["Rect"] = transformedRect;
+        return true;
     }
 
     private static void TransformAnnotationCoordinateArrays(Dictionary<int, PdfIndirectObject> objects, PdfDictionary annotation, PageResizeTransform transform) {
@@ -921,6 +943,17 @@ public static partial class PdfPageEditor {
         }
 
         return value.ToString("0.######", CultureInfo.InvariantCulture);
+    }
+
+    private readonly struct TransformedAnnotationCandidate {
+        public TransformedAnnotationCandidate(PdfObject value, int? originalObjectNumber) {
+            Value = value;
+            OriginalObjectNumber = originalObjectNumber;
+        }
+
+        public PdfObject Value { get; }
+
+        public int? OriginalObjectNumber { get; }
     }
 
     private readonly struct PageResizeTransform {

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Resize.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Resize.cs
@@ -268,6 +268,7 @@ public static partial class PdfPageEditor {
             if (resolved is PdfDictionary annotationDictionary) {
                 var clonedAnnotation = (PdfDictionary)ClonePdfObject(annotationDictionary);
                 TransformAnnotationRectangle(clonedAnnotation, transform);
+                TransformAnnotationCoordinateArrays(clonedAnnotation, transform);
                 TransformDestinationsInObject(objects, clonedAnnotation, new Dictionary<int, PageResizeTransform> {
                     [transform.PageObjectNumber] = transform
                 }, new HashSet<int>(), new HashSet<PdfArray>());
@@ -301,6 +302,42 @@ public static partial class PdfPageEditor {
         transformedRect.Items.Add(new PdfNumber(Math.Max(transformedX1, transformedX2)));
         transformedRect.Items.Add(new PdfNumber(Math.Max(transformedY1, transformedY2)));
         annotation.Items["Rect"] = transformedRect;
+    }
+
+    private static void TransformAnnotationCoordinateArrays(PdfDictionary annotation, PageResizeTransform transform) {
+        TransformPairedNumberArray(annotation, "QuadPoints", transform);
+        TransformPairedNumberArray(annotation, "L", transform);
+        TransformPairedNumberArray(annotation, "Vertices", transform);
+
+        if (!annotation.Items.TryGetValue("InkList", out PdfObject? inkListObject) ||
+            inkListObject is not PdfArray inkList) {
+            return;
+        }
+
+        foreach (PdfObject strokeObject in inkList.Items) {
+            if (strokeObject is PdfArray stroke) {
+                TransformPairedNumberArray(stroke, transform);
+            }
+        }
+    }
+
+    private static void TransformPairedNumberArray(PdfDictionary dictionary, string key, PageResizeTransform transform) {
+        if (!dictionary.Items.TryGetValue(key, out PdfObject? value) ||
+            value is not PdfArray array) {
+            return;
+        }
+
+        TransformPairedNumberArray(array, transform);
+    }
+
+    private static void TransformPairedNumberArray(PdfArray array, PageResizeTransform transform) {
+        for (int i = 0; i + 1 < array.Items.Count; i += 2) {
+            if (array.Items[i] is PdfNumber x &&
+                array.Items[i + 1] is PdfNumber y) {
+                array.Items[i] = new PdfNumber(TransformX(x.Value, transform));
+                array.Items[i + 1] = new PdfNumber(TransformY(y.Value, transform));
+            }
+        }
     }
 
     private static double TransformX(double value, PageResizeTransform transform) =>

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Resize.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Resize.cs
@@ -63,7 +63,7 @@ public static partial class PdfPageEditor {
             additionalObjects.Add(new PdfPageExtractor.AdditionalObject(prefixPseudoObjectNumber, BuildResizeContentStream(transform)));
             additionalObjects.Add(new PdfPageExtractor.AdditionalObject(suffixPseudoObjectNumber, new PdfStream(new PdfDictionary(), PdfEncoding.Latin1GetBytes("\nQ\n"))));
 
-            overrides[pageObjectNumber] = new Dictionary<string, PdfObject>(StringComparer.Ordinal) {
+            var pageOverrides = new Dictionary<string, PdfObject>(StringComparer.Ordinal) {
                 ["MediaBox"] = CreatePageBoxArray(0D, 0D, options.PageSize.Width, options.PageSize.Height),
                 ["CropBox"] = CreatePageBoxArray(0D, 0D, options.PageSize.Width, options.PageSize.Height),
                 ["Contents"] = BuildResizedContentsArray(
@@ -72,6 +72,13 @@ public static partial class PdfPageEditor {
                     prefixPseudoObjectNumber,
                     suffixPseudoObjectNumber)
             };
+
+            AddNormalizedProductionBoxes(pageOverrides, geometry, options.PageSize);
+            if (TryBuildTransformedAnnotations(objects, pageDictionary, transform, out PdfArray? transformedAnnotations)) {
+                pageOverrides["Annots"] = transformedAnnotations!;
+            }
+
+            overrides[pageObjectNumber] = pageOverrides;
         }
 
         PdfFileVersion fileVersion = PdfFileAssembler.ParseHeaderVersionOrDefault(PdfSyntax.GetHeaderVersion(pdf));
@@ -207,6 +214,120 @@ public static partial class PdfPageEditor {
             FormatResizeNumber(transform.TranslateX) + " " +
             FormatResizeNumber(transform.TranslateY) + " cm\n";
         return new PdfStream(new PdfDictionary(), PdfEncoding.Latin1GetBytes(content));
+    }
+
+    private static void AddNormalizedProductionBoxes(Dictionary<string, PdfObject> pageOverrides, PdfPageGeometry geometry, PageSize pageSize) {
+        PdfArray targetBox = CreatePageBoxArray(0D, 0D, pageSize.Width, pageSize.Height);
+        if (geometry.BleedBox is not null) {
+            pageOverrides["BleedBox"] = ClonePageBoxArray(targetBox);
+        }
+
+        if (geometry.TrimBox is not null) {
+            pageOverrides["TrimBox"] = ClonePageBoxArray(targetBox);
+        }
+
+        if (geometry.ArtBox is not null) {
+            pageOverrides["ArtBox"] = ClonePageBoxArray(targetBox);
+        }
+    }
+
+    private static PdfArray ClonePageBoxArray(PdfArray source) {
+        var clone = new PdfArray();
+        foreach (PdfObject item in source.Items) {
+            clone.Items.Add(ClonePdfObject(item));
+        }
+
+        return clone;
+    }
+
+    private static bool TryBuildTransformedAnnotations(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfDictionary pageDictionary,
+        PageResizeTransform transform,
+        out PdfArray? transformedAnnotations) {
+        transformedAnnotations = null;
+        if (!pageDictionary.Items.TryGetValue("Annots", out PdfObject? annotationsObject) ||
+            PdfObjectLookup.Resolve(objects, annotationsObject) is not PdfArray annotations) {
+            return false;
+        }
+
+        transformedAnnotations = new PdfArray();
+        foreach (PdfObject annotationObject in annotations.Items) {
+            PdfObject? resolved = PdfObjectLookup.Resolve(objects, annotationObject);
+            if (resolved is PdfDictionary annotationDictionary) {
+                var clonedAnnotation = (PdfDictionary)ClonePdfObject(annotationDictionary);
+                TransformAnnotationRectangle(clonedAnnotation, transform);
+                transformedAnnotations.Items.Add(clonedAnnotation);
+            } else {
+                transformedAnnotations.Items.Add(ClonePdfObject(annotationObject));
+            }
+        }
+
+        return true;
+    }
+
+    private static void TransformAnnotationRectangle(PdfDictionary annotation, PageResizeTransform transform) {
+        if (!annotation.Items.TryGetValue("Rect", out PdfObject? rectObject) ||
+            rectObject is not PdfArray rect ||
+            rect.Items.Count < 4 ||
+            rect.Items[0] is not PdfNumber x1 ||
+            rect.Items[1] is not PdfNumber y1 ||
+            rect.Items[2] is not PdfNumber x2 ||
+            rect.Items[3] is not PdfNumber y2) {
+            return;
+        }
+
+        double transformedX1 = TransformX(x1.Value, transform);
+        double transformedY1 = TransformY(y1.Value, transform);
+        double transformedX2 = TransformX(x2.Value, transform);
+        double transformedY2 = TransformY(y2.Value, transform);
+        var transformedRect = new PdfArray();
+        transformedRect.Items.Add(new PdfNumber(Math.Min(transformedX1, transformedX2)));
+        transformedRect.Items.Add(new PdfNumber(Math.Min(transformedY1, transformedY2)));
+        transformedRect.Items.Add(new PdfNumber(Math.Max(transformedX1, transformedX2)));
+        transformedRect.Items.Add(new PdfNumber(Math.Max(transformedY1, transformedY2)));
+        annotation.Items["Rect"] = transformedRect;
+    }
+
+    private static double TransformX(double value, PageResizeTransform transform) =>
+        value * transform.ScaleX + transform.TranslateX;
+
+    private static double TransformY(double value, PageResizeTransform transform) =>
+        value * transform.ScaleY + transform.TranslateY;
+
+    private static PdfObject ClonePdfObject(PdfObject value) {
+        switch (value) {
+            case PdfNumber number:
+                return new PdfNumber(number.Value);
+            case PdfBoolean boolean:
+                return new PdfBoolean(boolean.Value);
+            case PdfName name:
+                return new PdfName(name.Name);
+            case PdfStringObj text:
+                return new PdfStringObj(text.RawBytes, text.UseTextStringEncoding);
+            case PdfArray array:
+                var clonedArray = new PdfArray();
+                foreach (PdfObject item in array.Items) {
+                    clonedArray.Items.Add(ClonePdfObject(item));
+                }
+
+                return clonedArray;
+            case PdfDictionary dictionary:
+                var clonedDictionary = new PdfDictionary();
+                foreach (var item in dictionary.Items) {
+                    clonedDictionary.Items[item.Key] = ClonePdfObject(item.Value);
+                }
+
+                return clonedDictionary;
+            case PdfReference reference:
+                return new PdfReference(reference.ObjectNumber, reference.Generation);
+            case PdfStream stream:
+                return new PdfStream((PdfDictionary)ClonePdfObject(stream.Dictionary), (byte[])stream.Data.Clone(), stream.DecodingFailed, stream.DecodingError);
+            case PdfNull:
+                return PdfNull.Instance;
+            default:
+                return value;
+        }
     }
 
     private static PageResizeTransform CalculateResizeTransform(double sourceLeft, double sourceBottom, double sourceWidth, double sourceHeight, PdfPageResizeOptions options) {

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Resize.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Resize.cs
@@ -3,9 +3,6 @@ using System.Globalization;
 namespace OfficeIMO.Pdf;
 
 public static partial class PdfPageEditor {
-    private const int ResizeContentPrefixBasePseudoObjectNumber = -10000;
-    private const int ResizeContentSuffixBasePseudoObjectNumber = -20000;
-
     /// <summary>
     /// Creates a new PDF with selected pages scaled into the supplied target page size.
     /// If no page numbers are supplied, all pages are resized.
@@ -37,6 +34,7 @@ public static partial class PdfPageEditor {
         var overrides = new Dictionary<int, Dictionary<string, PdfObject>>();
         var additionalObjects = new List<PdfPageExtractor.AdditionalObject>();
         var transformsByPageObjectNumber = new Dictionary<int, PageResizeTransform>();
+        int nextPseudoObjectNumber = -1;
 
         for (int i = 0; i < document.Pages.Count; i++) {
             int pageNumber = i + 1;
@@ -61,8 +59,8 @@ public static partial class PdfPageEditor {
             int rotationDegrees = NormalizeResizeRotation(document.Pages[i].GetRotationDegrees());
             var transform = CalculateResizeTransform(pageObjectNumber, sourceLeft, sourceBottom, sourceWidth, sourceHeight, rotationDegrees, options);
             transformsByPageObjectNumber[pageObjectNumber] = transform;
-            int prefixPseudoObjectNumber = ResizeContentPrefixBasePseudoObjectNumber - i;
-            int suffixPseudoObjectNumber = ResizeContentSuffixBasePseudoObjectNumber - i;
+            int prefixPseudoObjectNumber = AllocateResizePseudoObjectNumber(ref nextPseudoObjectNumber);
+            int suffixPseudoObjectNumber = AllocateResizePseudoObjectNumber(ref nextPseudoObjectNumber);
             additionalObjects.Add(new PdfPageExtractor.AdditionalObject(prefixPseudoObjectNumber, BuildResizeContentStream(transform, sourceLeft, sourceBottom, sourceWidth, sourceHeight)));
             additionalObjects.Add(new PdfPageExtractor.AdditionalObject(suffixPseudoObjectNumber, new PdfStream(new PdfDictionary(), PdfEncoding.Latin1GetBytes("\nQ\n"))));
 
@@ -84,8 +82,10 @@ public static partial class PdfPageEditor {
 
         PdfFileVersion fileVersion = PdfFileAssembler.ParseHeaderVersionOrDefault(PdfSyntax.GetHeaderVersion(pdf));
         PdfPageExtractor.CatalogRewriteState catalogState = PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw);
-        TransformCatalogDestinationsForResize(objects, catalogState, transformsByPageObjectNumber);
-        TransformPageAnnotationsForResize(objects, document, selected, transformsByPageObjectNumber, overrides);
+        var destinationVisitedReferences = new HashSet<int>();
+        var transformedDestinationArrays = new HashSet<PdfArray>();
+        TransformCatalogDestinationsForResize(objects, catalogState, transformsByPageObjectNumber, destinationVisitedReferences, transformedDestinationArrays);
+        TransformPageAnnotationsForResize(objects, document, selected, transformsByPageObjectNumber, overrides, additionalObjects, ref nextPseudoObjectNumber, destinationVisitedReferences, transformedDestinationArrays);
         return PdfPageExtractor.ExtractPages(
             objects,
             document.Metadata,
@@ -94,6 +94,14 @@ public static partial class PdfPageEditor {
             additionalObjects,
             catalogState,
             fileVersion);
+    }
+
+    private static int AllocateResizePseudoObjectNumber(ref int nextPseudoObjectNumber) {
+        if (nextPseudoObjectNumber == int.MinValue) {
+            throw new InvalidOperationException("PDF resize generated too many temporary rewrite objects.");
+        }
+
+        return nextPseudoObjectNumber--;
     }
 
     /// <summary>Creates a new PDF with selected pages scaled into the supplied target page size from a readable stream.</summary>
@@ -256,13 +264,15 @@ public static partial class PdfPageEditor {
         PdfReadDocument document,
         HashSet<int> selectedPages,
         IReadOnlyDictionary<int, PageResizeTransform> transformsByPageObjectNumber,
-        Dictionary<int, Dictionary<string, PdfObject>> overrides) {
+        Dictionary<int, Dictionary<string, PdfObject>> overrides,
+        List<PdfPageExtractor.AdditionalObject> additionalObjects,
+        ref int nextPseudoObjectNumber,
+        HashSet<int> visitedReferences,
+        HashSet<PdfArray> transformedArrays) {
         if (transformsByPageObjectNumber.Count == 0) {
             return;
         }
 
-        var visitedReferences = new HashSet<int>();
-        var transformedArrays = new HashSet<PdfArray>();
         for (int i = 0; i < document.Pages.Count; i++) {
             int pageNumber = i + 1;
             int pageObjectNumber = document.Pages[i].ObjectNumber;
@@ -274,7 +284,7 @@ public static partial class PdfPageEditor {
             PageResizeTransform? annotationGeometryTransform = selectedPages.Contains(pageNumber)
                 ? transformsByPageObjectNumber[pageObjectNumber]
                 : null;
-            if (TryBuildTransformedAnnotations(objects, pageDictionary, annotationGeometryTransform, transformsByPageObjectNumber, visitedReferences, transformedArrays, out PdfArray? transformedAnnotations)) {
+            if (TryBuildTransformedAnnotations(objects, pageDictionary, annotationGeometryTransform, transformsByPageObjectNumber, additionalObjects, ref nextPseudoObjectNumber, visitedReferences, transformedArrays, out PdfArray? transformedAnnotations)) {
                 if (!overrides.TryGetValue(pageObjectNumber, out Dictionary<string, PdfObject>? pageOverrides)) {
                     pageOverrides = new Dictionary<string, PdfObject>(StringComparer.Ordinal);
                     overrides[pageObjectNumber] = pageOverrides;
@@ -290,6 +300,8 @@ public static partial class PdfPageEditor {
         PdfDictionary pageDictionary,
         PageResizeTransform? annotationGeometryTransform,
         IReadOnlyDictionary<int, PageResizeTransform> transformsByPageObjectNumber,
+        List<PdfPageExtractor.AdditionalObject> additionalObjects,
+        ref int nextPseudoObjectNumber,
         HashSet<int> visitedReferences,
         HashSet<PdfArray> transformedArrays,
         out PdfArray? transformedAnnotations) {
@@ -299,6 +311,14 @@ public static partial class PdfPageEditor {
             return false;
         }
 
+        var annotationReferenceMap = new Dictionary<int, int>();
+        foreach (PdfObject annotationObject in annotations.Items) {
+            if (annotationObject is PdfReference reference &&
+                PdfObjectLookup.Resolve(objects, reference) is PdfDictionary) {
+                annotationReferenceMap[reference.ObjectNumber] = AllocateResizePseudoObjectNumber(ref nextPseudoObjectNumber);
+            }
+        }
+
         transformedAnnotations = new PdfArray();
         foreach (PdfObject annotationObject in annotations.Items) {
             PdfObject? resolved = PdfObjectLookup.Resolve(objects, annotationObject);
@@ -306,11 +326,19 @@ public static partial class PdfPageEditor {
                 var clonedAnnotation = (PdfDictionary)ClonePdfObject(annotationDictionary);
                 if (annotationGeometryTransform.HasValue) {
                     TransformAnnotationRectangle(clonedAnnotation, annotationGeometryTransform.Value);
-                    TransformAnnotationCoordinateArrays(clonedAnnotation, annotationGeometryTransform.Value);
+                    TransformAnnotationCoordinateArrays(objects, clonedAnnotation, annotationGeometryTransform.Value);
                 }
 
+                RemapAnnotationReferences(clonedAnnotation, annotationReferenceMap);
+                InlineDestinationArrayReferences(objects, clonedAnnotation, transformsByPageObjectNumber, transformedArrays);
                 TransformDestinationsInObject(objects, clonedAnnotation, transformsByPageObjectNumber, visitedReferences, transformedArrays);
-                transformedAnnotations.Items.Add(clonedAnnotation);
+                if (annotationObject is PdfReference annotationReference &&
+                    annotationReferenceMap.TryGetValue(annotationReference.ObjectNumber, out int clonedObjectNumber)) {
+                    additionalObjects.Add(new PdfPageExtractor.AdditionalObject(clonedObjectNumber, clonedAnnotation));
+                    transformedAnnotations.Items.Add(new PdfReference(clonedObjectNumber, 0));
+                } else {
+                    transformedAnnotations.Items.Add(clonedAnnotation);
+                }
             } else {
                 transformedAnnotations.Items.Add(ClonePdfObject(annotationObject));
             }
@@ -342,30 +370,53 @@ public static partial class PdfPageEditor {
         annotation.Items["Rect"] = transformedRect;
     }
 
-    private static void TransformAnnotationCoordinateArrays(PdfDictionary annotation, PageResizeTransform transform) {
-        TransformPairedNumberArray(annotation, "QuadPoints", transform);
-        TransformPairedNumberArray(annotation, "L", transform);
-        TransformPairedNumberArray(annotation, "Vertices", transform);
+    private static void TransformAnnotationCoordinateArrays(Dictionary<int, PdfIndirectObject> objects, PdfDictionary annotation, PageResizeTransform transform) {
+        TransformPairedNumberArray(objects, annotation, "QuadPoints", transform);
+        TransformPairedNumberArray(objects, annotation, "L", transform);
+        TransformPairedNumberArray(objects, annotation, "Vertices", transform);
 
         if (!annotation.Items.TryGetValue("InkList", out PdfObject? inkListObject) ||
-            inkListObject is not PdfArray inkList) {
+            !TryGetMutableArray(objects, inkListObject, out PdfArray? inkList)) {
             return;
         }
 
-        foreach (PdfObject strokeObject in inkList.Items) {
-            if (strokeObject is PdfArray stroke) {
-                TransformPairedNumberArray(stroke, transform);
+        PdfArray mutableInkList = inkList!;
+        for (int i = 0; i < mutableInkList.Items.Count; i++) {
+            if (TryGetMutableArray(objects, mutableInkList.Items[i], out PdfArray? stroke)) {
+                PdfArray mutableStroke = stroke!;
+                TransformPairedNumberArray(mutableStroke, transform);
+                mutableInkList.Items[i] = mutableStroke;
             }
         }
+
+        annotation.Items["InkList"] = mutableInkList;
     }
 
-    private static void TransformPairedNumberArray(PdfDictionary dictionary, string key, PageResizeTransform transform) {
+    private static void TransformPairedNumberArray(Dictionary<int, PdfIndirectObject> objects, PdfDictionary dictionary, string key, PageResizeTransform transform) {
         if (!dictionary.Items.TryGetValue(key, out PdfObject? value) ||
-            value is not PdfArray array) {
+            !TryGetMutableArray(objects, value, out PdfArray? array)) {
             return;
         }
 
-        TransformPairedNumberArray(array, transform);
+        PdfArray mutableArray = array!;
+        TransformPairedNumberArray(mutableArray, transform);
+        dictionary.Items[key] = mutableArray;
+    }
+
+    private static bool TryGetMutableArray(Dictionary<int, PdfIndirectObject> objects, PdfObject value, out PdfArray? array) {
+        if (value is PdfArray directArray) {
+            array = directArray;
+            return true;
+        }
+
+        if (value is PdfReference reference &&
+            PdfObjectLookup.Resolve(objects, reference) is PdfArray referencedArray) {
+            array = (PdfArray)ClonePdfObject(referencedArray);
+            return true;
+        }
+
+        array = null;
+        return false;
     }
 
     private static void TransformPairedNumberArray(PdfArray array, PageResizeTransform transform) {
@@ -397,13 +448,13 @@ public static partial class PdfPageEditor {
     private static void TransformCatalogDestinationsForResize(
         Dictionary<int, PdfIndirectObject> objects,
         PdfPageExtractor.CatalogRewriteState catalogState,
-        IReadOnlyDictionary<int, PageResizeTransform> transformsByPageObjectNumber) {
+        IReadOnlyDictionary<int, PageResizeTransform> transformsByPageObjectNumber,
+        HashSet<int> visitedReferences,
+        HashSet<PdfArray> transformedArrays) {
         if (transformsByPageObjectNumber.Count == 0) {
             return;
         }
 
-        var visitedReferences = new HashSet<int>();
-        var transformedArrays = new HashSet<PdfArray>();
         TransformDestinationsInObject(objects, catalogState.Outlines, transformsByPageObjectNumber, visitedReferences, transformedArrays);
         TransformDestinationsInObject(objects, catalogState.NamedDestinations, transformsByPageObjectNumber, visitedReferences, transformedArrays);
         TransformDestinationsInObject(objects, catalogState.NamedDestinationNameTree, transformsByPageObjectNumber, visitedReferences, transformedArrays);
@@ -463,6 +514,10 @@ public static partial class PdfPageEditor {
 
         switch (destinationMode.Name) {
             case "XYZ":
+                if (TransformRotatedPartialXyzDestination(array, transform)) {
+                    break;
+                }
+
                 TransformDestinationPoint(array, 2, 3, transform);
                 break;
             case "FitH":
@@ -485,6 +540,30 @@ public static partial class PdfPageEditor {
                 TransformDestinationRectangle(array, 2, 3, 4, 5, transform);
                 break;
         }
+    }
+
+    private static bool TransformRotatedPartialXyzDestination(PdfArray array, PageResizeTransform transform) {
+        if (!transform.HasAxisSwap ||
+            array.Items.Count <= 3) {
+            return false;
+        }
+
+        bool hasX = array.Items[2] is PdfNumber;
+        bool hasY = array.Items[3] is PdfNumber;
+        if (hasX == hasY) {
+            return false;
+        }
+
+        double x = hasX && array.Items[2] is PdfNumber left
+            ? left.Value
+            : transform.SourceLeft;
+        double y = hasY && array.Items[3] is PdfNumber top
+            ? top.Value
+            : transform.SourceBottom + transform.SourceHeight;
+        PdfObject? zoom = array.Items.Count > 4 ? ClonePdfObject(array.Items[4]) : PdfNull.Instance;
+        (double transformedX, double transformedY) = TransformPoint(x, y, transform);
+        ReplaceDestinationWithXyz(array, transformedX, transformedY, zoom);
+        return true;
     }
 
     private static bool TransformRotatedFitHorizontalDestination(PdfArray array, PageResizeTransform transform) {
@@ -513,7 +592,7 @@ public static partial class PdfPageEditor {
         return true;
     }
 
-    private static void ReplaceDestinationWithXyz(PdfArray array, double left, double top) {
+    private static void ReplaceDestinationWithXyz(PdfArray array, double left, double top, PdfObject? zoom = null) {
         while (array.Items.Count > 2) {
             array.Items.RemoveAt(array.Items.Count - 1);
         }
@@ -521,7 +600,7 @@ public static partial class PdfPageEditor {
         array.Items[1] = new PdfName("XYZ");
         array.Items.Add(new PdfNumber(left));
         array.Items.Add(new PdfNumber(top));
-        array.Items.Add(PdfNull.Instance);
+        array.Items.Add(zoom ?? PdfNull.Instance);
     }
 
     private static void TransformDestinationPoint(PdfArray array, int xIndex, int yIndex, PageResizeTransform transform) {
@@ -609,6 +688,95 @@ public static partial class PdfPageEditor {
             default:
                 return value;
         }
+    }
+
+    private static void RemapAnnotationReferences(PdfObject value, IReadOnlyDictionary<int, int> annotationReferenceMap) {
+        switch (value) {
+            case PdfArray array:
+                for (int i = 0; i < array.Items.Count; i++) {
+                    if (array.Items[i] is PdfReference itemReference &&
+                        annotationReferenceMap.TryGetValue(itemReference.ObjectNumber, out int mappedObjectNumber)) {
+                        array.Items[i] = new PdfReference(mappedObjectNumber, 0);
+                    } else {
+                        RemapAnnotationReferences(array.Items[i], annotationReferenceMap);
+                    }
+                }
+
+                break;
+            case PdfDictionary dictionary:
+                foreach (string key in dictionary.Items.Keys.ToArray()) {
+                    PdfObject item = dictionary.Items[key];
+                    if (item is PdfReference reference &&
+                        annotationReferenceMap.TryGetValue(reference.ObjectNumber, out int mappedObjectNumber)) {
+                        dictionary.Items[key] = new PdfReference(mappedObjectNumber, 0);
+                    } else {
+                        RemapAnnotationReferences(item, annotationReferenceMap);
+                    }
+                }
+
+                break;
+            case PdfStream stream:
+                RemapAnnotationReferences(stream.Dictionary, annotationReferenceMap);
+                break;
+        }
+    }
+
+    private static void InlineDestinationArrayReferences(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfObject value,
+        IReadOnlyDictionary<int, PageResizeTransform> transformsByPageObjectNumber,
+        HashSet<PdfArray> transformedArrays) {
+        switch (value) {
+            case PdfArray array:
+                for (int i = 0; i < array.Items.Count; i++) {
+                    if (TryCloneTransformedDestinationReference(objects, array.Items[i], transformsByPageObjectNumber, transformedArrays, out PdfArray? clonedDestination)) {
+                        array.Items[i] = clonedDestination!;
+                    } else {
+                        InlineDestinationArrayReferences(objects, array.Items[i], transformsByPageObjectNumber, transformedArrays);
+                    }
+                }
+
+                break;
+            case PdfDictionary dictionary:
+                foreach (string key in dictionary.Items.Keys.ToArray()) {
+                    PdfObject item = dictionary.Items[key];
+                    if (TryCloneTransformedDestinationReference(objects, item, transformsByPageObjectNumber, transformedArrays, out PdfArray? clonedDestination)) {
+                        dictionary.Items[key] = clonedDestination!;
+                    } else {
+                        InlineDestinationArrayReferences(objects, item, transformsByPageObjectNumber, transformedArrays);
+                    }
+                }
+
+                break;
+            case PdfStream stream:
+                InlineDestinationArrayReferences(objects, stream.Dictionary, transformsByPageObjectNumber, transformedArrays);
+                break;
+        }
+    }
+
+    private static bool TryCloneTransformedDestinationReference(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfObject value,
+        IReadOnlyDictionary<int, PageResizeTransform> transformsByPageObjectNumber,
+        HashSet<PdfArray> transformedArrays,
+        out PdfArray? clonedDestination) {
+        clonedDestination = null;
+        if (value is not PdfReference reference ||
+            PdfObjectLookup.Resolve(objects, reference) is not PdfArray destination ||
+            destination.Items.Count < 2 ||
+            destination.Items[0] is not PdfReference pageReference ||
+            !transformsByPageObjectNumber.ContainsKey(pageReference.ObjectNumber)) {
+            return false;
+        }
+
+        clonedDestination = (PdfArray)ClonePdfObject(destination);
+        if (transformedArrays.Contains(destination)) {
+            transformedArrays.Add(clonedDestination);
+        } else {
+            TransformDestinationArray(clonedDestination, transformsByPageObjectNumber, transformedArrays);
+        }
+
+        return true;
     }
 
     private static PageResizeTransform CalculateResizeTransform(int pageObjectNumber, double sourceLeft, double sourceBottom, double sourceWidth, double sourceHeight, int rotationDegrees, PdfPageResizeOptions options) {

--- a/OfficeIMO.Pdf/Manipulation/PdfPageExtractor.Core.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageExtractor.Core.cs
@@ -31,9 +31,12 @@ public static partial class PdfPageExtractor {
         collector.CollectObjectGraph(catalogState.EmbeddedFiles);
         collector.CollectObjectGraph(catalogState.AssociatedFiles);
         collector.CollectObjectGraph(catalogState.OptionalContent);
-    
-        var sourceIds = collector.ObjectIds;
         var extraObjects = additionalObjects?.ToArray() ?? Array.Empty<AdditionalObject>();
+        foreach (var extraObject in extraObjects) {
+            collector.CollectObjectGraph(extraObject.Value);
+        }
+
+        var sourceIds = collector.ObjectIds;
         var numberMap = new Dictionary<int, int>();
         for (int i = 0; i < sourceIds.Count; i++) {
             numberMap[sourceIds[i]] = i + 1;

--- a/OfficeIMO.Pdf/Manipulation/PdfPageExtractor.Core.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageExtractor.Core.cs
@@ -24,6 +24,7 @@ public static partial class PdfPageExtractor {
         collector.CollectObjectGraph(catalogState.Outlines);
         collector.CollectObjectGraph(catalogState.PageLabels);
         collector.CollectObjectGraph(catalogState.NamedDestinationNameTree);
+        collector.CollectObjectGraph(catalogState.OpenAction);
         collector.CollectObjectGraph(catalogState.XmpMetadata);
         collector.CollectObjectGraph(catalogState.CatalogUri);
         collector.CollectObjectGraph(catalogState.OutputIntents);

--- a/OfficeIMO.Pdf/Manipulation/PdfPageExtractor.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageExtractor.cs
@@ -24,17 +24,31 @@ public static partial class PdfPageExtractor {
     /// Creates a new PDF containing the selected one-based page numbers in the requested order.
     /// </summary>
     public static byte[] ExtractPages(byte[] pdf, IEnumerable<int> pageNumbers) {
+        return ExtractPages(pdf, pageNumbers, options: null);
+    }
+
+    /// <summary>
+    /// Creates a new PDF containing the selected one-based page numbers in the requested order, using read options for password-protected sources.
+    /// </summary>
+    public static byte[] ExtractPages(byte[] pdf, PdfReadOptions? options, params int[] pageNumbers) {
+        return ExtractPages(pdf, pageNumbers, options);
+    }
+
+    /// <summary>
+    /// Creates a new PDF containing the selected one-based page numbers in the requested order, using read options for password-protected sources.
+    /// </summary>
+    public static byte[] ExtractPages(byte[] pdf, IEnumerable<int> pageNumbers, PdfReadOptions? options) {
         Guard.NotNull(pdf, nameof(pdf));
         Guard.NotNull(pageNumbers, nameof(pageNumbers));
-        PdfSyntax.ThrowIfUnsafeForRewrite(pdf);
+        PdfSyntax.ThrowIfUnsafeForRewrite(pdf, allowEncryption: options?.Password is not null);
 
         var selected = pageNumbers.ToArray();
         if (selected.Length == 0) {
             throw new ArgumentException("At least one page number must be specified.", nameof(pageNumbers));
         }
 
-        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf);
-        var document = PdfReadDocument.Load(pdf);
+        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf, options);
+        var document = PdfReadDocument.Load(pdf, options);
         ValidatePageNumbers(selected, document.Pages.Count, nameof(pageNumbers));
 
         var pageObjectNumbers = selected.Select(pageNumber => document.Pages[pageNumber - 1].ObjectNumber).ToArray();
@@ -196,17 +210,31 @@ public static partial class PdfPageExtractor {
     /// Creates a new PDF containing the supplied inclusive one-based page ranges in caller order.
     /// </summary>
     public static byte[] ExtractPageRanges(byte[] pdf, IEnumerable<PdfPageRange> pageRanges) {
+        return ExtractPageRanges(pdf, pageRanges, options: null);
+    }
+
+    /// <summary>
+    /// Creates a new PDF containing the supplied inclusive one-based page ranges in caller order, using read options for password-protected sources.
+    /// </summary>
+    public static byte[] ExtractPageRanges(byte[] pdf, PdfReadOptions? options, params PdfPageRange[] pageRanges) {
+        return ExtractPageRanges(pdf, (IEnumerable<PdfPageRange>)pageRanges, options);
+    }
+
+    /// <summary>
+    /// Creates a new PDF containing the supplied inclusive one-based page ranges in caller order, using read options for password-protected sources.
+    /// </summary>
+    public static byte[] ExtractPageRanges(byte[] pdf, IEnumerable<PdfPageRange> pageRanges, PdfReadOptions? options) {
         Guard.NotNull(pdf, nameof(pdf));
         Guard.NotNull(pageRanges, nameof(pageRanges));
-        PdfSyntax.ThrowIfUnsafeForRewrite(pdf);
+        PdfSyntax.ThrowIfUnsafeForRewrite(pdf, allowEncryption: options?.Password is not null);
 
         var ranges = pageRanges.ToArray();
         if (ranges.Length == 0) {
             throw new ArgumentException("At least one page range must be specified.", nameof(pageRanges));
         }
 
-        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf);
-        var document = PdfReadDocument.Load(pdf);
+        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf, options);
+        var document = PdfReadDocument.Load(pdf, options);
         ValidatePageRanges(ranges, document.Pages.Count, nameof(pageRanges));
 
         var pageObjectNumbers = new List<int>(ranges.Sum(range => range.PageCount));
@@ -283,11 +311,18 @@ public static partial class PdfPageExtractor {
     /// Splits a PDF into one single-page PDF per source page.
     /// </summary>
     public static IReadOnlyList<byte[]> SplitPages(byte[] pdf) {
-        Guard.NotNull(pdf, nameof(pdf));
-        PdfSyntax.ThrowIfUnsafeForRewrite(pdf);
+        return SplitPages(pdf, options: null);
+    }
 
-        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf);
-        var document = PdfReadDocument.Load(pdf);
+    /// <summary>
+    /// Splits a PDF into one single-page PDF per source page, using read options for password-protected sources.
+    /// </summary>
+    public static IReadOnlyList<byte[]> SplitPages(byte[] pdf, PdfReadOptions? options) {
+        Guard.NotNull(pdf, nameof(pdf));
+        PdfSyntax.ThrowIfUnsafeForRewrite(pdf, allowEncryption: options?.Password is not null);
+
+        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf, options);
+        var document = PdfReadDocument.Load(pdf, options);
         var catalogState = ExtractCatalogRewriteState(objects, trailerRaw);
         var result = new List<byte[]>(document.Pages.Count);
 
@@ -316,17 +351,31 @@ public static partial class PdfPageExtractor {
     /// Splits a PDF into one output PDF per inclusive one-based page range.
     /// </summary>
     public static IReadOnlyList<byte[]> SplitPageRanges(byte[] pdf, IEnumerable<PdfPageRange> pageRanges) {
+        return SplitPageRanges(pdf, pageRanges, options: null);
+    }
+
+    /// <summary>
+    /// Splits a PDF into one output PDF per inclusive one-based page range, using read options for password-protected sources.
+    /// </summary>
+    public static IReadOnlyList<byte[]> SplitPageRanges(byte[] pdf, PdfReadOptions? options, params PdfPageRange[] pageRanges) {
+        return SplitPageRanges(pdf, (IEnumerable<PdfPageRange>)pageRanges, options);
+    }
+
+    /// <summary>
+    /// Splits a PDF into one output PDF per inclusive one-based page range, using read options for password-protected sources.
+    /// </summary>
+    public static IReadOnlyList<byte[]> SplitPageRanges(byte[] pdf, IEnumerable<PdfPageRange> pageRanges, PdfReadOptions? options) {
         Guard.NotNull(pdf, nameof(pdf));
         Guard.NotNull(pageRanges, nameof(pageRanges));
-        PdfSyntax.ThrowIfUnsafeForRewrite(pdf);
+        PdfSyntax.ThrowIfUnsafeForRewrite(pdf, allowEncryption: options?.Password is not null);
 
         var ranges = pageRanges.ToArray();
         if (ranges.Length == 0) {
             throw new ArgumentException("At least one page range must be specified.", nameof(pageRanges));
         }
 
-        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf);
-        var document = PdfReadDocument.Load(pdf);
+        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf, options);
+        var document = PdfReadDocument.Load(pdf, options);
         ValidatePageRanges(ranges, document.Pages.Count, nameof(pageRanges));
         var catalogState = ExtractCatalogRewriteState(objects, trailerRaw);
         var result = new List<byte[]>(ranges.Length);

--- a/OfficeIMO.Pdf/Manipulation/PdfPageExtractor.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageExtractor.cs
@@ -40,7 +40,7 @@ public static partial class PdfPageExtractor {
     public static byte[] ExtractPages(byte[] pdf, IEnumerable<int> pageNumbers, PdfReadOptions? options) {
         Guard.NotNull(pdf, nameof(pdf));
         Guard.NotNull(pageNumbers, nameof(pageNumbers));
-        PdfSyntax.ThrowIfUnsafeForRewrite(pdf, allowEncryption: options?.Password is not null);
+        PdfSyntax.ThrowIfUnsafeForRewrite(pdf, options);
 
         var selected = pageNumbers.ToArray();
         if (selected.Length == 0) {
@@ -226,7 +226,7 @@ public static partial class PdfPageExtractor {
     public static byte[] ExtractPageRanges(byte[] pdf, IEnumerable<PdfPageRange> pageRanges, PdfReadOptions? options) {
         Guard.NotNull(pdf, nameof(pdf));
         Guard.NotNull(pageRanges, nameof(pageRanges));
-        PdfSyntax.ThrowIfUnsafeForRewrite(pdf, allowEncryption: options?.Password is not null);
+        PdfSyntax.ThrowIfUnsafeForRewrite(pdf, options);
 
         var ranges = pageRanges.ToArray();
         if (ranges.Length == 0) {
@@ -319,7 +319,7 @@ public static partial class PdfPageExtractor {
     /// </summary>
     public static IReadOnlyList<byte[]> SplitPages(byte[] pdf, PdfReadOptions? options) {
         Guard.NotNull(pdf, nameof(pdf));
-        PdfSyntax.ThrowIfUnsafeForRewrite(pdf, allowEncryption: options?.Password is not null);
+        PdfSyntax.ThrowIfUnsafeForRewrite(pdf, options);
 
         var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf, options);
         var document = PdfReadDocument.Load(pdf, options);
@@ -367,7 +367,7 @@ public static partial class PdfPageExtractor {
     public static IReadOnlyList<byte[]> SplitPageRanges(byte[] pdf, IEnumerable<PdfPageRange> pageRanges, PdfReadOptions? options) {
         Guard.NotNull(pdf, nameof(pdf));
         Guard.NotNull(pageRanges, nameof(pageRanges));
-        PdfSyntax.ThrowIfUnsafeForRewrite(pdf, allowEncryption: options?.Password is not null);
+        PdfSyntax.ThrowIfUnsafeForRewrite(pdf, options);
 
         var ranges = pageRanges.ToArray();
         if (ranges.Length == 0) {

--- a/OfficeIMO.Pdf/Manipulation/PdfPageResizeMode.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageResizeMode.cs
@@ -1,0 +1,15 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>
+/// Controls how existing page content is scaled when a PDF page is resized.
+/// </summary>
+public enum PdfPageResizeMode {
+    /// <summary>Preserve the original aspect ratio and fit the full source page inside the target page.</summary>
+    Fit,
+
+    /// <summary>Preserve the original aspect ratio and fill the target page, allowing content to be clipped.</summary>
+    Fill,
+
+    /// <summary>Scale width and height independently so the source page exactly fills the target page.</summary>
+    Stretch
+}

--- a/OfficeIMO.Pdf/Manipulation/PdfPageResizeOptions.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageResizeOptions.cs
@@ -1,0 +1,25 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>
+/// Configures page size normalization for existing PDF pages.
+/// </summary>
+public sealed class PdfPageResizeOptions {
+    /// <summary>
+    /// Creates resize options for the supplied target page size.
+    /// </summary>
+    /// <param name="pageSize">Target page size in PDF points.</param>
+    public PdfPageResizeOptions(PageSize pageSize) {
+        Guard.Positive(pageSize.Width, nameof(pageSize));
+        Guard.Positive(pageSize.Height, nameof(pageSize));
+        PageSize = pageSize;
+    }
+
+    /// <summary>Target page size in PDF points.</summary>
+    public PageSize PageSize { get; set; }
+
+    /// <summary>Margin in PDF points kept around fitted content.</summary>
+    public double Margin { get; set; }
+
+    /// <summary>Scaling behavior used for the original page content.</summary>
+    public PdfPageResizeMode Mode { get; set; } = PdfPageResizeMode.Fit;
+}

--- a/OfficeIMO.Pdf/Model/PdfTableStyle.cs
+++ b/OfficeIMO.Pdf/Model/PdfTableStyle.cs
@@ -50,6 +50,7 @@ public class PdfTableStyle {
     private double? _lineHeight;
     private double? _headerFontSize;
     private double? _footerFontSize;
+    private double? _minimumShrinkFontSize;
 
     /// <summary>Color of the table borders and cell grid lines. Set to null to hide borders.</summary>
     public PdfColor? BorderColor { get; set; } = new PdfColor(0.8, 0.8, 0.8);
@@ -495,6 +496,16 @@ public class PdfTableStyle {
     }
     /// <summary>When true, the resolved table frame width is preserved even if measured columns would otherwise shrink to their content.</summary>
     public bool PreserveWidth { get; set; }
+    /// <summary>When true, table rows can reduce their font size to keep cell text within the resolved cell width.</summary>
+    public bool ShrinkTextToFit { get; set; }
+    /// <summary>Smallest font size, in points, used by <see cref="ShrinkTextToFit"/>. When null the writer uses 6 points.</summary>
+    public double? MinimumShrinkFontSize {
+        get => _minimumShrinkFontSize;
+        set {
+            ValidateOptionalPositiveFiniteValue(value, nameof(MinimumShrinkFontSize), "Table minimum shrink font size must be a positive finite value.");
+            _minimumShrinkFontSize = value;
+        }
+    }
     /// <summary>Optional left indentation before table placement, in points.</summary>
     public double LeftIndent {
         get => _leftIndent;
@@ -625,6 +636,8 @@ public class PdfTableStyle {
             RowBaselineOffset = RowBaselineOffset,
             MaxWidth = MaxWidth,
             PreserveWidth = PreserveWidth,
+            ShrinkTextToFit = ShrinkTextToFit,
+            MinimumShrinkFontSize = MinimumShrinkFontSize,
             LeftIndent = LeftIndent,
             AutoFitColumns = AutoFitColumns,
             RightAlignNumeric = RightAlignNumeric,

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Catalog.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Catalog.cs
@@ -474,11 +474,19 @@ internal static partial class PdfSyntax {
                     return true;
                 }
             }
-        } catch (Exception ex) when (ex is not PdfEncryptionException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
+        } catch (Exception ex) when (ShouldSuppressParsedPdfNameException(ex, options)) {
             return false;
         }
 
         return false;
+    }
+
+    private static bool ShouldSuppressParsedPdfNameException(Exception exception, PdfReadOptions? options) {
+        if (exception is OutOfMemoryException || exception is StackOverflowException) {
+            return false;
+        }
+
+        return options is null || exception is not PdfEncryptionException;
     }
 
     private static bool ContainsAnyParsedPdfName(PdfObject value, HashSet<string> names) {

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Catalog.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Catalog.cs
@@ -462,15 +462,19 @@ internal static partial class PdfSyntax {
     }
 
     private static bool ContainsAnyParsedPdfName(byte[] pdf, params string[] names) {
+        return ContainsAnyParsedPdfName(pdf, null, names);
+    }
+
+    private static bool ContainsAnyParsedPdfName(byte[] pdf, PdfReadOptions? options, params string[] names) {
         try {
-            var (map, _) = ParseObjects(pdf);
+            var (map, _) = ParseObjects(pdf, options);
             var nameSet = new HashSet<string>(names, StringComparer.Ordinal);
             foreach (PdfIndirectObject indirectObject in map.Values) {
                 if (ContainsAnyParsedPdfName(indirectObject.Value, nameSet)) {
                     return true;
                 }
             }
-        } catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException) {
+        } catch (Exception ex) when (ex is not PdfEncryptionException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
             return false;
         }
 

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Markers.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Markers.cs
@@ -12,7 +12,7 @@ internal static partial class PdfSyntax {
     }
 
     internal static void ThrowIfUnsafeForRewrite(byte[] pdf, PdfReadOptions? options) {
-        ThrowIfUnsafeForRewrite(pdf, allowEncryption: options?.Password is not null, options);
+        ThrowIfUnsafeForRewrite(pdf, allowEncryption: options?.Password is not null || CanOpenEncryptedPdfWithEmptyPassword(pdf), options);
     }
 
     internal static void ThrowIfUnsafeForRewrite(byte[] pdf, bool allowEncryption) {
@@ -82,6 +82,21 @@ internal static partial class PdfSyntax {
 
         if (HasActiveContentMarkers(pdf, options)) {
             throw new NotSupportedException("PDF active content is not supported for rewriting by OfficeIMO.Pdf yet.");
+        }
+    }
+
+    private static bool CanOpenEncryptedPdfWithEmptyPassword(byte[] pdf) {
+        if (!HasEncryptionMarkers(pdf)) {
+            return false;
+        }
+
+        try {
+            PdfReadDocument.Load(pdf, new PdfReadOptions { Password = string.Empty });
+            return true;
+        } catch (PdfEncryptionException) {
+            return false;
+        } catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException) {
+            return false;
         }
     }
 

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Markers.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Markers.cs
@@ -11,7 +11,15 @@ internal static partial class PdfSyntax {
         ThrowIfUnsafeForRewrite(pdf, allowEncryption: false);
     }
 
+    internal static void ThrowIfUnsafeForRewrite(byte[] pdf, PdfReadOptions? options) {
+        ThrowIfUnsafeForRewrite(pdf, allowEncryption: options?.Password is not null, options);
+    }
+
     internal static void ThrowIfUnsafeForRewrite(byte[] pdf, bool allowEncryption) {
+        ThrowIfUnsafeForRewrite(pdf, allowEncryption, options: null);
+    }
+
+    private static void ThrowIfUnsafeForRewrite(byte[] pdf, bool allowEncryption, PdfReadOptions? options) {
         if (!allowEncryption && HasEncryptionMarkers(pdf)) {
             throw new NotSupportedException("Encrypted PDF files are not supported for rewriting by OfficeIMO.Pdf yet.");
         }
@@ -24,27 +32,27 @@ internal static partial class PdfSyntax {
             throw new NotSupportedException("PDF form fields are not supported for rewriting by OfficeIMO.Pdf yet.");
         }
 
-        if (HasUnsupportedOutlineRewriteMarkers(pdf)) {
+        if (HasUnsupportedOutlineRewriteMarkers(pdf, options)) {
             throw new NotSupportedException("PDF outlines are not supported for rewriting by OfficeIMO.Pdf yet.");
         }
 
-        if (HasUnsupportedPageLabelRewriteMarkers(pdf)) {
+        if (HasUnsupportedPageLabelRewriteMarkers(pdf, options)) {
             throw new NotSupportedException("PDF page labels are not supported for rewriting by OfficeIMO.Pdf yet.");
         }
 
-        if (HasUnsupportedCatalogNameTreeRewriteMarkers(pdf)) {
+        if (HasUnsupportedCatalogNameTreeRewriteMarkers(pdf, options)) {
             throw new NotSupportedException("PDF catalog name trees are not supported for rewriting by OfficeIMO.Pdf yet.");
         }
 
-        if (HasUnsupportedNamedDestinationRewriteMarkers(pdf)) {
+        if (HasUnsupportedNamedDestinationRewriteMarkers(pdf, options)) {
             throw new NotSupportedException("PDF named destinations are not supported for rewriting by OfficeIMO.Pdf yet.");
         }
 
-        if (HasUnsupportedOpenActionRewriteMarkers(pdf)) {
+        if (HasUnsupportedOpenActionRewriteMarkers(pdf, options)) {
             throw new NotSupportedException("PDF open actions are not supported for rewriting by OfficeIMO.Pdf yet.");
         }
 
-        if (HasUnsupportedViewerPreferenceRewriteMarkers(pdf)) {
+        if (HasUnsupportedViewerPreferenceRewriteMarkers(pdf, options)) {
             throw new NotSupportedException("PDF viewer preferences are not supported for rewriting by OfficeIMO.Pdf yet.");
         }
 
@@ -52,23 +60,23 @@ internal static partial class PdfSyntax {
             throw new NotSupportedException("PDF tagged content structure is not supported for rewriting by OfficeIMO.Pdf yet.");
         }
 
-        if (HasUnsupportedXmpMetadataRewriteMarkers(pdf)) {
+        if (HasUnsupportedXmpMetadataRewriteMarkers(pdf, options)) {
             throw new NotSupportedException("PDF XMP metadata is not supported for rewriting by OfficeIMO.Pdf yet.");
         }
 
-        if (HasUnsupportedCatalogUriRewriteMarkers(pdf)) {
+        if (HasUnsupportedCatalogUriRewriteMarkers(pdf, options)) {
             throw new NotSupportedException("PDF catalog URI dictionaries are not supported for rewriting by OfficeIMO.Pdf yet.");
         }
 
-        if (HasUnsupportedOutputIntentRewriteMarkers(pdf)) {
+        if (HasUnsupportedOutputIntentRewriteMarkers(pdf, options)) {
             throw new NotSupportedException("PDF output intents are not supported for rewriting by OfficeIMO.Pdf yet.");
         }
 
-        if (HasUnsupportedEmbeddedFileRewriteMarkers(pdf)) {
+        if (HasUnsupportedEmbeddedFileRewriteMarkers(pdf, options)) {
             throw new NotSupportedException("PDF embedded files are not supported for rewriting by OfficeIMO.Pdf yet.");
         }
 
-        if (HasUnsupportedOptionalContentRewriteMarkers(pdf)) {
+        if (HasUnsupportedOptionalContentRewriteMarkers(pdf, options)) {
             throw new NotSupportedException("PDF optional content layers are not supported for rewriting by OfficeIMO.Pdf yet.");
         }
 
@@ -115,13 +123,13 @@ internal static partial class PdfSyntax {
             ContainsAnyParsedPdfName(pdf, "Outlines", "UseOutlines");
     }
 
-    internal static bool HasUnsupportedOutlineRewriteMarkers(byte[] pdf) {
-        if (!HasOutlineMarkers(pdf)) {
+    internal static bool HasUnsupportedOutlineRewriteMarkers(byte[] pdf, PdfReadOptions? options = null) {
+        if (options is null && !HasOutlineMarkers(pdf)) {
             return false;
         }
 
         try {
-            var (objects, trailerRaw) = ParseObjects(pdf);
+            var (objects, trailerRaw) = ParseObjects(pdf, options);
             PdfDictionary? catalog = FindCatalog(objects, trailerRaw);
             if (catalog is null ||
                 !catalog.Items.TryGetValue("Outlines", out var outlines)) {
@@ -150,13 +158,13 @@ internal static partial class PdfSyntax {
             ContainsAnyParsedPdfName(pdf, "PageLabels");
     }
 
-    internal static bool HasUnsupportedPageLabelRewriteMarkers(byte[] pdf) {
-        if (!HasPageLabelMarkers(pdf)) {
+    internal static bool HasUnsupportedPageLabelRewriteMarkers(byte[] pdf, PdfReadOptions? options = null) {
+        if (options is null && !HasPageLabelMarkers(pdf)) {
             return false;
         }
 
         try {
-            var (objects, trailerRaw) = ParseObjects(pdf);
+            var (objects, trailerRaw) = ParseObjects(pdf, options);
             PdfDictionary? catalog = FindCatalog(objects, trailerRaw);
             if (catalog is null ||
                 !catalog.Items.TryGetValue("PageLabels", out var pageLabels)) {
@@ -185,13 +193,13 @@ internal static partial class PdfSyntax {
             ContainsAnyParsedPdfName(pdf, "Names");
     }
 
-    internal static bool HasUnsupportedCatalogNameTreeRewriteMarkers(byte[] pdf) {
-        if (!HasCatalogNameTreeMarkers(pdf)) {
+    internal static bool HasUnsupportedCatalogNameTreeRewriteMarkers(byte[] pdf, PdfReadOptions? options = null) {
+        if (options is null && !HasCatalogNameTreeMarkers(pdf)) {
             return false;
         }
 
         try {
-            var (objects, trailerRaw) = ParseObjects(pdf);
+            var (objects, trailerRaw) = ParseObjects(pdf, options);
             PdfDictionary? catalog = FindCatalog(objects, trailerRaw);
             if (catalog is null ||
                 !catalog.Items.TryGetValue("Names", out var names)) {
@@ -219,13 +227,13 @@ internal static partial class PdfSyntax {
         }
     }
 
-    internal static bool HasUnsupportedNamedDestinationRewriteMarkers(byte[] pdf) {
-        if (!HasNamedDestinationMarkers(pdf)) {
+    internal static bool HasUnsupportedNamedDestinationRewriteMarkers(byte[] pdf, PdfReadOptions? options = null) {
+        if (options is null && !HasNamedDestinationMarkers(pdf)) {
             return false;
         }
 
         try {
-            var (objects, trailerRaw) = ParseObjects(pdf);
+            var (objects, trailerRaw) = ParseObjects(pdf, options);
             PdfDictionary? catalog = FindCatalog(objects, trailerRaw);
             if (catalog is null) {
                 return true;
@@ -261,13 +269,13 @@ internal static partial class PdfSyntax {
             ContainsAnyParsedPdfName(pdf, "OpenAction");
     }
 
-    internal static bool HasUnsupportedOpenActionRewriteMarkers(byte[] pdf) {
-        if (!HasOpenActionMarkers(pdf)) {
+    internal static bool HasUnsupportedOpenActionRewriteMarkers(byte[] pdf, PdfReadOptions? options = null) {
+        if (options is null && !HasOpenActionMarkers(pdf)) {
             return false;
         }
 
         try {
-            var (objects, trailerRaw) = ParseObjects(pdf);
+            var (objects, trailerRaw) = ParseObjects(pdf, options);
             PdfDictionary? catalog = FindCatalog(objects, trailerRaw);
             if (catalog is null ||
                 !catalog.Items.TryGetValue("OpenAction", out var openAction)) {
@@ -299,13 +307,13 @@ internal static partial class PdfSyntax {
             ContainsAnyParsedPdfName(pdf, "ViewerPreferences");
     }
 
-    internal static bool HasUnsupportedViewerPreferenceRewriteMarkers(byte[] pdf) {
-        if (!HasViewerPreferenceMarkers(pdf)) {
+    internal static bool HasUnsupportedViewerPreferenceRewriteMarkers(byte[] pdf, PdfReadOptions? options = null) {
+        if (options is null && !HasViewerPreferenceMarkers(pdf)) {
             return false;
         }
 
         try {
-            var (objects, trailerRaw) = ParseObjects(pdf);
+            var (objects, trailerRaw) = ParseObjects(pdf, options);
             PdfDictionary? catalog = FindCatalog(objects, trailerRaw);
             if (catalog is null ||
                 !catalog.Items.TryGetValue("ViewerPreferences", out var viewerPreferences)) {
@@ -340,13 +348,13 @@ internal static partial class PdfSyntax {
             ContainsAnyParsedPdfName(pdf, "Metadata");
     }
 
-    internal static bool HasUnsupportedXmpMetadataRewriteMarkers(byte[] pdf) {
-        if (!HasXmpMetadataMarkers(pdf)) {
+    internal static bool HasUnsupportedXmpMetadataRewriteMarkers(byte[] pdf, PdfReadOptions? options = null) {
+        if (options is null && !HasXmpMetadataMarkers(pdf)) {
             return false;
         }
 
         try {
-            var (objects, trailerRaw) = ParseObjects(pdf);
+            var (objects, trailerRaw) = ParseObjects(pdf, options);
             PdfDictionary? catalog = FindCatalog(objects, trailerRaw);
             if (catalog is null ||
                 !catalog.Items.TryGetValue("Metadata", out var xmpMetadata)) {
@@ -380,13 +388,13 @@ internal static partial class PdfSyntax {
         }
     }
 
-    internal static bool HasUnsupportedCatalogUriRewriteMarkers(byte[] pdf) {
-        if (!HasCatalogUriMarkers(pdf)) {
+    internal static bool HasUnsupportedCatalogUriRewriteMarkers(byte[] pdf, PdfReadOptions? options = null) {
+        if (options is null && !HasCatalogUriMarkers(pdf)) {
             return false;
         }
 
         try {
-            var (objects, trailerRaw) = ParseObjects(pdf);
+            var (objects, trailerRaw) = ParseObjects(pdf, options);
             PdfDictionary? catalog = FindCatalog(objects, trailerRaw);
             if (catalog is null ||
                 !catalog.Items.TryGetValue("URI", out var catalogUri)) {
@@ -413,13 +421,13 @@ internal static partial class PdfSyntax {
             ContainsPdfName(text, "OutputIntent");
     }
 
-    internal static bool HasUnsupportedOutputIntentRewriteMarkers(byte[] pdf) {
-        if (!HasOutputIntentMarkers(pdf)) {
+    internal static bool HasUnsupportedOutputIntentRewriteMarkers(byte[] pdf, PdfReadOptions? options = null) {
+        if (options is null && !HasOutputIntentMarkers(pdf)) {
             return false;
         }
 
         try {
-            var (objects, trailerRaw) = ParseObjects(pdf);
+            var (objects, trailerRaw) = ParseObjects(pdf, options);
             PdfDictionary? catalog = FindCatalog(objects, trailerRaw);
             if (catalog is null ||
                 !catalog.Items.TryGetValue("OutputIntents", out var outputIntents)) {
@@ -444,13 +452,13 @@ internal static partial class PdfSyntax {
             ContainsAnyParsedPdfName(pdf, "EmbeddedFiles", "Filespec", "EmbeddedFile", "AF");
     }
 
-    internal static bool HasUnsupportedEmbeddedFileRewriteMarkers(byte[] pdf) {
-        if (!HasEmbeddedFileMarkers(pdf)) {
+    internal static bool HasUnsupportedEmbeddedFileRewriteMarkers(byte[] pdf, PdfReadOptions? options = null) {
+        if (options is null && !HasEmbeddedFileMarkers(pdf)) {
             return false;
         }
 
         try {
-            var (objects, trailerRaw) = ParseObjects(pdf);
+            var (objects, trailerRaw) = ParseObjects(pdf, options);
             PdfDictionary? catalog = FindCatalog(objects, trailerRaw);
             if (catalog is null) {
                 return true;
@@ -490,13 +498,13 @@ internal static partial class PdfSyntax {
             ContainsAnyParsedPdfName(pdf, "OCProperties", "OCGs", "OCG", "OCMD");
     }
 
-    internal static bool HasUnsupportedOptionalContentRewriteMarkers(byte[] pdf) {
-        if (!HasOptionalContentMarkers(pdf)) {
+    internal static bool HasUnsupportedOptionalContentRewriteMarkers(byte[] pdf, PdfReadOptions? options = null) {
+        if (options is null && !HasOptionalContentMarkers(pdf)) {
             return false;
         }
 
         try {
-            var (objects, trailerRaw) = ParseObjects(pdf);
+            var (objects, trailerRaw) = ParseObjects(pdf, options);
             PdfDictionary? catalog = FindCatalog(objects, trailerRaw);
             if (catalog is null ||
                 !catalog.Items.TryGetValue("OCProperties", out var optionalContent)) {

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Markers.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Markers.cs
@@ -28,7 +28,7 @@ internal static partial class PdfSyntax {
             throw new NotSupportedException("Signed PDF files are not supported for rewriting by OfficeIMO.Pdf yet.");
         }
 
-        if (HasFormMarkers(pdf)) {
+        if (HasFormMarkers(pdf, options)) {
             throw new NotSupportedException("PDF form fields are not supported for rewriting by OfficeIMO.Pdf yet.");
         }
 
@@ -56,7 +56,7 @@ internal static partial class PdfSyntax {
             throw new NotSupportedException("PDF viewer preferences are not supported for rewriting by OfficeIMO.Pdf yet.");
         }
 
-        if (HasTaggedContentMarkers(pdf)) {
+        if (HasTaggedContentMarkers(pdf, options)) {
             throw new NotSupportedException("PDF tagged content structure is not supported for rewriting by OfficeIMO.Pdf yet.");
         }
 
@@ -80,7 +80,7 @@ internal static partial class PdfSyntax {
             throw new NotSupportedException("PDF optional content layers are not supported for rewriting by OfficeIMO.Pdf yet.");
         }
 
-        if (HasActiveContentMarkers(pdf)) {
+        if (HasActiveContentMarkers(pdf, options)) {
             throw new NotSupportedException("PDF active content is not supported for rewriting by OfficeIMO.Pdf yet.");
         }
     }
@@ -100,7 +100,15 @@ internal static partial class PdfSyntax {
     }
 
     internal static bool HasFormMarkers(byte[] pdf) {
+        return HasFormMarkers(pdf, null);
+    }
+
+    private static bool HasFormMarkers(byte[] pdf, PdfReadOptions? options) {
         Guard.NotNull(pdf, nameof(pdf));
+
+        if (options is not null) {
+            return ContainsAnyParsedPdfName(pdf, options, "AcroForm", "Fields", "FT");
+        }
 
         string text = PdfEncoding.Latin1GetString(pdf);
         return ContainsAnyPdfName(text, "AcroForm", "Fields", "FT") ||
@@ -137,7 +145,7 @@ internal static partial class PdfSyntax {
             }
 
             return !IsSupportedOutlineGraph(objects, outlines, new HashSet<int>());
-        } catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException) {
+        } catch (Exception ex) when (ex is not PdfEncryptionException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
             return true;
         }
     }
@@ -172,7 +180,7 @@ internal static partial class PdfSyntax {
             }
 
             return !IsSupportedPageLabelTree(objects, pageLabels);
-        } catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException) {
+        } catch (Exception ex) when (ex is not PdfEncryptionException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
             return true;
         }
     }
@@ -222,7 +230,7 @@ internal static partial class PdfSyntax {
             }
 
             return false;
-        } catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException) {
+        } catch (Exception ex) when (ex is not PdfEncryptionException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
             return true;
         }
     }
@@ -256,7 +264,7 @@ internal static partial class PdfSyntax {
             }
 
             return false;
-        } catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException) {
+        } catch (Exception ex) when (ex is not PdfEncryptionException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
             return true;
         }
     }
@@ -294,7 +302,7 @@ internal static partial class PdfSyntax {
             }
 
             return true;
-        } catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException) {
+        } catch (Exception ex) when (ex is not PdfEncryptionException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
             return true;
         }
     }
@@ -327,13 +335,21 @@ internal static partial class PdfSyntax {
             }
 
             return true;
-        } catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException) {
+        } catch (Exception ex) when (ex is not PdfEncryptionException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
             return true;
         }
     }
 
     internal static bool HasTaggedContentMarkers(byte[] pdf) {
+        return HasTaggedContentMarkers(pdf, null);
+    }
+
+    private static bool HasTaggedContentMarkers(byte[] pdf, PdfReadOptions? options) {
         Guard.NotNull(pdf, nameof(pdf));
+
+        if (options is not null) {
+            return ContainsAnyParsedPdfName(pdf, options, "MarkInfo", "StructTreeRoot", "ParentTree", "StructElem");
+        }
 
         string text = PdfEncoding.Latin1GetString(pdf);
         return ContainsAnyPdfName(text, "MarkInfo", "StructTreeRoot", "ParentTree", "StructElem") ||
@@ -366,7 +382,7 @@ internal static partial class PdfSyntax {
             }
 
             return true;
-        } catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException) {
+        } catch (Exception ex) when (ex is not PdfEncryptionException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
             return true;
         }
     }
@@ -383,7 +399,7 @@ internal static partial class PdfSyntax {
             var (objects, trailerRaw) = ParseObjects(pdf);
             PdfDictionary? catalog = FindCatalog(objects, trailerRaw);
             return catalog?.Items.ContainsKey("URI") == true;
-        } catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException) {
+        } catch (Exception ex) when (ex is not PdfEncryptionException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
             return true;
         }
     }
@@ -408,7 +424,7 @@ internal static partial class PdfSyntax {
             }
 
             return true;
-        } catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException) {
+        } catch (Exception ex) when (ex is not PdfEncryptionException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
             return true;
         }
     }
@@ -439,7 +455,7 @@ internal static partial class PdfSyntax {
             }
 
             return true;
-        } catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException) {
+        } catch (Exception ex) when (ex is not PdfEncryptionException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
             return true;
         }
     }
@@ -485,7 +501,7 @@ internal static partial class PdfSyntax {
             }
 
             return false;
-        } catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException) {
+        } catch (Exception ex) when (ex is not PdfEncryptionException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
             return true;
         }
     }
@@ -516,13 +532,21 @@ internal static partial class PdfSyntax {
             }
 
             return true;
-        } catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException) {
+        } catch (Exception ex) when (ex is not PdfEncryptionException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
             return true;
         }
     }
 
     internal static bool HasActiveContentMarkers(byte[] pdf) {
+        return HasActiveContentMarkers(pdf, null);
+    }
+
+    private static bool HasActiveContentMarkers(byte[] pdf, PdfReadOptions? options) {
         Guard.NotNull(pdf, nameof(pdf));
+
+        if (options is not null) {
+            return ContainsAnyParsedPdfName(pdf, options, "JavaScript", "JS", "AA", "Launch", "SubmitForm", "RichMedia");
+        }
 
         string text = PdfEncoding.Latin1GetString(pdf);
         return ContainsAnyPdfName(text, "JavaScript", "JS", "AA", "Launch", "SubmitForm", "RichMedia") ||

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Markers.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Markers.cs
@@ -8,7 +8,11 @@ internal static partial class PdfSyntax {
     }
 
     internal static void ThrowIfUnsafeForRewrite(byte[] pdf) {
-        if (HasEncryptionMarkers(pdf)) {
+        ThrowIfUnsafeForRewrite(pdf, allowEncryption: false);
+    }
+
+    internal static void ThrowIfUnsafeForRewrite(byte[] pdf, bool allowEncryption) {
+        if (!allowEncryption && HasEncryptionMarkers(pdf)) {
             throw new NotSupportedException("Encrypted PDF files are not supported for rewriting by OfficeIMO.Pdf yet.");
         }
 

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Canvas.Table.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Canvas.Table.cs
@@ -31,7 +31,7 @@ internal static partial class PdfWriter {
                 double originalRowFontSize = GetTableRowFontSize(style, rowIndex, headerRowCount, footerStart, currentOpts.DefaultFontSize);
                 double rowFontSize = ResolveTableRowShrinkFontSize(table, style, rowIndex, columns, columnWidths, columnGap, originalRowFontSize, rowUsesBold, currentOpts);
                 rowFontSizes[rowIndex] = rowFontSize;
-                rowFontSizeScales[rowIndex] = GetTableRunFontSizeScale(originalRowFontSize, rowFontSize);
+                rowFontSizeScales[rowIndex] = GetTableRunFontSizeScale(table, style, rowIndex, columns, columnWidths, columnGap, originalRowFontSize, rowFontSize, rowUsesBold, currentOpts);
                 rowLeadings[rowIndex] = GetTableLeading(style, rowFontSize);
             }
 

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Canvas.Table.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Canvas.Table.cs
@@ -24,12 +24,14 @@ internal static partial class PdfWriter {
             double[] columnWidths = ResolveCanvasTableColumnWidths(style, columns, item.Width, columnGap);
             double[] rowHeights = ResolveCanvasTableRowHeights(style, rows, item.Height, rowGap);
             var rowFontSizes = new double[rows];
+            var rowFontSizeScales = new double[rows];
             var rowLeadings = new double[rows];
             for (int rowIndex = 0; rowIndex < rows; rowIndex++) {
                 bool rowUsesBold = GetTableRowBold(style, rowIndex, headerRowCount, footerStart);
-                double rowFontSize = GetTableRowFontSize(style, rowIndex, headerRowCount, footerStart, currentOpts.DefaultFontSize);
-                rowFontSize = ResolveTableRowShrinkFontSize(table, style, rowIndex, columns, columnWidths, columnGap, rowFontSize, rowUsesBold, currentOpts);
+                double originalRowFontSize = GetTableRowFontSize(style, rowIndex, headerRowCount, footerStart, currentOpts.DefaultFontSize);
+                double rowFontSize = ResolveTableRowShrinkFontSize(table, style, rowIndex, columns, columnWidths, columnGap, originalRowFontSize, rowUsesBold, currentOpts);
                 rowFontSizes[rowIndex] = rowFontSize;
+                rowFontSizeScales[rowIndex] = GetTableRunFontSizeScale(originalRowFontSize, rowFontSize);
                 rowLeadings[rowIndex] = GetTableLeading(style, rowFontSize);
             }
 
@@ -65,7 +67,7 @@ internal static partial class PdfWriter {
                     bool rowUsesBold = GetTableRowBold(style, rowIndex, headerRowCount, footerStart);
 
                     DrawCanvasTableCellBackground(style, rowIndex, cell.Column, rowIsHeader, rowIsFooter, cellX, cellBottom, cellWidth, cellHeight);
-                    RenderCanvasTableCellText(item, style, cell, rowIndex, cell.Column, rowIsHeader, rowIsFooter, rowUsesBold, cellX, rowTop, cellBottom, cellWidth, cellHeight, rowFontSizes[rowIndex], rowLeadings[rowIndex], item.Y + GetTableRowsHeight(rowHeights, 0, rowIndex, rowGap));
+                    RenderCanvasTableCellText(item, style, cell, rowIndex, cell.Column, rowIsHeader, rowIsFooter, rowUsesBold, cellX, rowTop, cellBottom, cellWidth, cellHeight, rowFontSizes[rowIndex], rowLeadings[rowIndex], rowFontSizeScales[rowIndex], item.Y + GetTableRowsHeight(rowHeights, 0, rowIndex, rowGap));
                     DrawCanvasTableCellBorder(style, rowIndex, cell.Column, cellX, cellBottom, cellWidth, cellHeight);
                 }
             }
@@ -212,7 +214,7 @@ internal static partial class PdfWriter {
             }
         }
 
-        private void RenderCanvasTableCellText(PdfCanvasTableItem item, PdfTableStyle style, TableCellLayout cell, int rowIndex, int columnIndex, bool rowIsHeader, bool rowIsFooter, bool rowUsesBold, double cellX, double cellTop, double cellBottom, double cellWidth, double cellHeight, double fontSize, double leading, double cellYFromTop) {
+        private void RenderCanvasTableCellText(PdfCanvasTableItem item, PdfTableStyle style, TableCellLayout cell, int rowIndex, int columnIndex, bool rowIsHeader, bool rowIsFooter, bool rowUsesBold, double cellX, double cellTop, double cellBottom, double cellWidth, double cellHeight, double fontSize, double leading, double runFontSizeScale, double cellYFromTop) {
             PdfStandardFont cellFont = GetTableRowFont(currentOpts, rowUsesBold);
             double padLeft = GetTableCellPaddingLeft(style, rowIndex, columnIndex);
             double padRight = GetTableCellPaddingRight(style, rowIndex, columnIndex);
@@ -220,7 +222,7 @@ internal static partial class PdfWriter {
             double padBottom = GetTableCellPaddingBottom(style, rowIndex, columnIndex);
             double innerWidth = Math.Max(1D, cellWidth - padLeft - padRight);
             double availableHeight = Math.Max(0D, cellHeight - padTop - padBottom);
-            var lines = CreateTableCellTextLayout(cell, innerWidth, cellFont, fontSize, leading, currentOpts);
+            var lines = CreateTableCellTextLayout(cell, innerWidth, cellFont, fontSize, leading, currentOpts, runFontSizeScale);
             int lineCount = Math.Max(1, lines.LineCount);
             double contentHeight = MeasureTableCellContentHeight(cell, lines, 0, lineCount, leading, innerWidth);
             if (contentHeight > availableHeight + 0.01D) {

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Canvas.Table.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Canvas.Table.cs
@@ -19,16 +19,25 @@ internal static partial class PdfWriter {
             double cellSpacing = GetTableCellSpacing(style);
             double columnGap = cellSpacing;
             double rowGap = cellSpacing;
+            int headerRowCount = style.HeaderRowCount;
+            int footerStart = rows - style.FooterRowCount;
             double[] columnWidths = ResolveCanvasTableColumnWidths(style, columns, item.Width, columnGap);
             double[] rowHeights = ResolveCanvasTableRowHeights(style, rows, item.Height, rowGap);
+            var rowFontSizes = new double[rows];
+            var rowLeadings = new double[rows];
+            for (int rowIndex = 0; rowIndex < rows; rowIndex++) {
+                bool rowUsesBold = GetTableRowBold(style, rowIndex, headerRowCount, footerStart);
+                double rowFontSize = GetTableRowFontSize(style, rowIndex, headerRowCount, footerStart, currentOpts.DefaultFontSize);
+                rowFontSize = ResolveTableRowShrinkFontSize(table, style, rowIndex, columns, columnWidths, columnGap, rowFontSize, rowUsesBold, currentOpts);
+                rowFontSizes[rowIndex] = rowFontSize;
+                rowLeadings[rowIndex] = GetTableLeading(style, rowFontSize);
+            }
+
             double tableWidth = GetTableCellWidth(columnWidths, 0, columns, columnGap);
             double tableHeight = GetTableRowsHeight(rowHeights, 0, rows, rowGap);
             double xOrigin = item.X;
             double topY = currentOpts.PageHeight - item.Y;
             double bottomY = topY - item.Height;
-            double footerStartRowIndex = rows - style.FooterRowCount;
-            int headerRowCount = style.HeaderRowCount;
-            int footerStart = rows - style.FooterRowCount;
             int annotationStart = currentPage!.Annotations.Count;
             int imageStart = currentPage.Images.Count;
             int formFieldStart = currentPage.FormFields.Count;
@@ -53,9 +62,10 @@ internal static partial class PdfWriter {
                     double cellWidth = GetTableCellWidth(columnWidths, cell.Column, cell.ColumnSpan, columnGap);
                     double cellHeight = GetTableCellHeight(rowHeights, rowIndex, cell.RowSpan, rowGap);
                     double cellBottom = rowTop - cellHeight;
+                    bool rowUsesBold = GetTableRowBold(style, rowIndex, headerRowCount, footerStart);
 
                     DrawCanvasTableCellBackground(style, rowIndex, cell.Column, rowIsHeader, rowIsFooter, cellX, cellBottom, cellWidth, cellHeight);
-                    RenderCanvasTableCellText(item, style, cell, rowIndex, cell.Column, rowIsHeader, rowIsFooter, cellX, rowTop, cellBottom, cellWidth, cellHeight, headerRowCount, footerStart, item.Y + GetTableRowsHeight(rowHeights, 0, rowIndex, rowGap));
+                    RenderCanvasTableCellText(item, style, cell, rowIndex, cell.Column, rowIsHeader, rowIsFooter, rowUsesBold, cellX, rowTop, cellBottom, cellWidth, cellHeight, rowFontSizes[rowIndex], rowLeadings[rowIndex], item.Y + GetTableRowsHeight(rowHeights, 0, rowIndex, rowGap));
                     DrawCanvasTableCellBorder(style, rowIndex, cell.Column, cellX, cellBottom, cellWidth, cellHeight);
                 }
             }
@@ -202,10 +212,7 @@ internal static partial class PdfWriter {
             }
         }
 
-        private void RenderCanvasTableCellText(PdfCanvasTableItem item, PdfTableStyle style, TableCellLayout cell, int rowIndex, int columnIndex, bool rowIsHeader, bool rowIsFooter, double cellX, double cellTop, double cellBottom, double cellWidth, double cellHeight, int headerRowCount, int footerStart, double cellYFromTop) {
-            double fontSize = GetTableRowFontSize(style, rowIndex, headerRowCount, footerStart, currentOpts.DefaultFontSize);
-            double leading = GetTableLeading(style, fontSize);
-            bool rowUsesBold = GetTableRowBold(style, rowIndex, headerRowCount, footerStart);
+        private void RenderCanvasTableCellText(PdfCanvasTableItem item, PdfTableStyle style, TableCellLayout cell, int rowIndex, int columnIndex, bool rowIsHeader, bool rowIsFooter, bool rowUsesBold, double cellX, double cellTop, double cellBottom, double cellWidth, double cellHeight, double fontSize, double leading, double cellYFromTop) {
             PdfStandardFont cellFont = GetTableRowFont(currentOpts, rowUsesBold);
             double padLeft = GetTableCellPaddingLeft(style, rowIndex, columnIndex);
             double padRight = GetTableCellPaddingRight(style, rowIndex, columnIndex);

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Canvas.Table.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Canvas.Table.cs
@@ -222,7 +222,7 @@ internal static partial class PdfWriter {
             double padBottom = GetTableCellPaddingBottom(style, rowIndex, columnIndex);
             double innerWidth = Math.Max(1D, cellWidth - padLeft - padRight);
             double availableHeight = Math.Max(0D, cellHeight - padTop - padBottom);
-            var lines = CreateTableCellTextLayout(cell, innerWidth, cellFont, fontSize, leading, currentOpts, runFontSizeScale);
+            var lines = CreateTableCellTextLayout(cell, innerWidth, cellFont, fontSize, leading, currentOpts, runFontSizeScale, style.MinimumShrinkFontSize ?? 6D);
             int lineCount = Math.Max(1, lines.LineCount);
             double contentHeight = MeasureTableCellContentHeight(cell, lines, 0, lineCount, leading, innerWidth);
             if (contentHeight > availableHeight + 0.01D) {

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.FlowMetrics.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.FlowMetrics.cs
@@ -609,7 +609,7 @@ internal static partial class PdfWriter {
                 bool rowUsesBold = GetTableRowBold(style, rowIndex, headerRowCount, footerStartRowIndex);
                 double originalRowSize = GetTableRowFontSize(style, rowIndex, headerRowCount, footerStartRowIndex, fontSize);
                 double rowSize = ResolveTableRowShrinkFontSize(table, style, rowIndex, columns, columnLayout.Widths, columnGap, originalRowSize, rowUsesBold, currentOpts);
-                double runFontSizeScale = GetTableRunFontSizeScale(originalRowSize, rowSize);
+                double runFontSizeScale = GetTableRunFontSizeScale(table, style, rowIndex, columns, columnLayout.Widths, columnGap, originalRowSize, rowSize, rowUsesBold, currentOpts);
                 double rowLeading = GetTableLeading(style, rowSize);
                 rowLeadings[rowIndex] = rowLeading;
                 rowLines[rowIndex] = new TableCellTextLayout[columns];

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.FlowMetrics.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.FlowMetrics.cs
@@ -606,9 +606,11 @@ internal static partial class PdfWriter {
             var rowHeights = new double[table.Rows.Count];
             var rowLeadings = new double[table.Rows.Count];
             for (int rowIndex = 0; rowIndex < table.Rows.Count; rowIndex++) {
-                double rowSize = GetTableRowFontSize(style, rowIndex, headerRowCount, footerStartRowIndex, fontSize);
-                double rowLeading = GetTableLeading(style, rowSize);
                 bool rowUsesBold = GetTableRowBold(style, rowIndex, headerRowCount, footerStartRowIndex);
+                double originalRowSize = GetTableRowFontSize(style, rowIndex, headerRowCount, footerStartRowIndex, fontSize);
+                double rowSize = ResolveTableRowShrinkFontSize(table, style, rowIndex, columns, columnLayout.Widths, columnGap, originalRowSize, rowUsesBold, currentOpts);
+                double runFontSizeScale = GetTableRunFontSizeScale(originalRowSize, rowSize);
+                double rowLeading = GetTableLeading(style, rowSize);
                 rowLeadings[rowIndex] = rowLeading;
                 rowLines[rowIndex] = new TableCellTextLayout[columns];
                 double maxRequiredHeight = rowLeading + GetTableRowMaxPaddingTop(table, style, rowIndex, columns) + GetTableRowMaxPaddingBottom(table, style, rowIndex, columns);
@@ -622,7 +624,7 @@ internal static partial class PdfWriter {
                     PdfStandardFont cellFont = GetTableRowFont(currentOpts, rowUsesBold);
                     double cellWidth = GetTableCellWidth(columnLayout.Widths, cell.Column, cell.ColumnSpan, columnGap);
                     double innerWidth = Math.Max(1D, cellWidth - GetTableCellPaddingLeft(style, rowIndex, cell.Column) - GetTableCellPaddingRight(style, rowIndex, cell.Column));
-                    TableCellTextLayout lines = CreateTableCellTextLayout(cell, innerWidth, cellFont, rowSize, rowLeading, currentOpts);
+                    TableCellTextLayout lines = CreateTableCellTextLayout(cell, innerWidth, cellFont, rowSize, rowLeading, currentOpts, runFontSizeScale);
                     rowLines[rowIndex][cell.Column] = lines;
                     if (cell.RowSpan <= 1) {
                         maxRequiredHeight = Math.Max(maxRequiredHeight, MeasureTableCellContentHeight(cell, lines, 0, lines.LineCount, rowLeading, innerWidth) + GetTableCellPaddingTop(style, rowIndex, cell.Column) + GetTableCellPaddingBottom(style, rowIndex, cell.Column));

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.FlowMetrics.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.FlowMetrics.cs
@@ -624,7 +624,7 @@ internal static partial class PdfWriter {
                     PdfStandardFont cellFont = GetTableRowFont(currentOpts, rowUsesBold);
                     double cellWidth = GetTableCellWidth(columnLayout.Widths, cell.Column, cell.ColumnSpan, columnGap);
                     double innerWidth = Math.Max(1D, cellWidth - GetTableCellPaddingLeft(style, rowIndex, cell.Column) - GetTableCellPaddingRight(style, rowIndex, cell.Column));
-                    TableCellTextLayout lines = CreateTableCellTextLayout(cell, innerWidth, cellFont, rowSize, rowLeading, currentOpts, runFontSizeScale);
+                    TableCellTextLayout lines = CreateTableCellTextLayout(cell, innerWidth, cellFont, rowSize, rowLeading, currentOpts, runFontSizeScale, style.MinimumShrinkFontSize ?? 6D);
                     rowLines[rowIndex][cell.Column] = lines;
                     if (cell.RowSpan <= 1) {
                         maxRequiredHeight = Math.Max(maxRequiredHeight, MeasureTableCellContentHeight(cell, lines, 0, lines.LineCount, rowLeading, innerWidth) + GetTableCellPaddingTop(style, rowIndex, cell.Column) + GetTableCellPaddingBottom(style, rowIndex, cell.Column));

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Row.Items.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Row.Items.cs
@@ -236,7 +236,7 @@ internal static partial class PdfWriter {
                             var cellFont = GetTableRowFont(currentOpts, rowUsesBold);
                             double cellWidth = GetTableCellWidth(colPixel, cell.Column, cell.ColumnSpan, columnGap);
                             double innerWidth = Math.Max(1, cellWidth - GetTableCellPaddingLeft(style, ri, cell.Column) - GetTableCellPaddingRight(style, ri, cell.Column));
-                            TableCellTextLayout lines = CreateTableCellTextLayout(cell, innerWidth, cellFont, rowSize, rowLeading, currentOpts, runFontSizeScale);
+                            TableCellTextLayout lines = CreateTableCellTextLayout(cell, innerWidth, cellFont, rowSize, rowLeading, currentOpts, runFontSizeScale, style.MinimumShrinkFontSize ?? 6D);
                             rowLines[ri][cell.Column] = lines;
                             if (cell.RowSpan <= 1) {
                                 maxLines = Math.Max(maxLines, lines.LineCount);

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Row.Items.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Row.Items.cs
@@ -216,8 +216,9 @@ internal static partial class PdfWriter {
                     var rowBold = new bool[tb2.Rows.Count];
                     for (int ri = 0; ri < tb2.Rows.Count; ri++) {
                         bool rowUsesBold = GetTableRowBold(style, ri, headerRowCount, footerStartRowIndex);
-                        double rowSize = GetTableRowFontSize(style, ri, headerRowCount, footerStartRowIndex, currentOpts.DefaultFontSize);
-                        rowSize = ResolveTableRowShrinkFontSize(tb2, style, ri, cols, colPixel, columnGap, rowSize, rowUsesBold, currentOpts);
+                        double originalRowSize = GetTableRowFontSize(style, ri, headerRowCount, footerStartRowIndex, currentOpts.DefaultFontSize);
+                        double rowSize = ResolveTableRowShrinkFontSize(tb2, style, ri, cols, colPixel, columnGap, originalRowSize, rowUsesBold, currentOpts);
+                        double runFontSizeScale = GetTableRunFontSizeScale(originalRowSize, rowSize);
                         double rowLeading = GetTableLeading(style, rowSize);
                         rowSizes[ri] = rowSize;
                         rowLeadings[ri] = rowLeading;
@@ -235,7 +236,7 @@ internal static partial class PdfWriter {
                             var cellFont = GetTableRowFont(currentOpts, rowUsesBold);
                             double cellWidth = GetTableCellWidth(colPixel, cell.Column, cell.ColumnSpan, columnGap);
                             double innerWidth = Math.Max(1, cellWidth - GetTableCellPaddingLeft(style, ri, cell.Column) - GetTableCellPaddingRight(style, ri, cell.Column));
-                            TableCellTextLayout lines = CreateTableCellTextLayout(cell, innerWidth, cellFont, rowSize, rowLeading, currentOpts);
+                            TableCellTextLayout lines = CreateTableCellTextLayout(cell, innerWidth, cellFont, rowSize, rowLeading, currentOpts, runFontSizeScale);
                             rowLines[ri][cell.Column] = lines;
                             if (cell.RowSpan <= 1) {
                                 maxLines = Math.Max(maxLines, lines.LineCount);

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Row.Items.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Row.Items.cs
@@ -215,9 +215,10 @@ internal static partial class PdfWriter {
                     var rowSizes = new double[tb2.Rows.Count];
                     var rowBold = new bool[tb2.Rows.Count];
                     for (int ri = 0; ri < tb2.Rows.Count; ri++) {
-                        double rowSize = GetTableRowFontSize(style, ri, headerRowCount, footerStartRowIndex, currentOpts.DefaultFontSize);
-                        double rowLeading = GetTableLeading(style, rowSize);
                         bool rowUsesBold = GetTableRowBold(style, ri, headerRowCount, footerStartRowIndex);
+                        double rowSize = GetTableRowFontSize(style, ri, headerRowCount, footerStartRowIndex, currentOpts.DefaultFontSize);
+                        rowSize = ResolveTableRowShrinkFontSize(tb2, style, ri, cols, colPixel, columnGap, rowSize, rowUsesBold, currentOpts);
+                        double rowLeading = GetTableLeading(style, rowSize);
                         rowSizes[ri] = rowSize;
                         rowLeadings[ri] = rowLeading;
                         rowBold[ri] = rowUsesBold;

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Row.Items.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Row.Items.cs
@@ -218,7 +218,7 @@ internal static partial class PdfWriter {
                         bool rowUsesBold = GetTableRowBold(style, ri, headerRowCount, footerStartRowIndex);
                         double originalRowSize = GetTableRowFontSize(style, ri, headerRowCount, footerStartRowIndex, currentOpts.DefaultFontSize);
                         double rowSize = ResolveTableRowShrinkFontSize(tb2, style, ri, cols, colPixel, columnGap, originalRowSize, rowUsesBold, currentOpts);
-                        double runFontSizeScale = GetTableRunFontSizeScale(originalRowSize, rowSize);
+                        double runFontSizeScale = GetTableRunFontSizeScale(tb2, style, ri, cols, colPixel, columnGap, originalRowSize, rowSize, rowUsesBold, currentOpts);
                         double rowLeading = GetTableLeading(style, rowSize);
                         rowSizes[ri] = rowSize;
                         rowLeadings[ri] = rowLeading;

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Table.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Table.cs
@@ -156,7 +156,7 @@ internal static partial class PdfWriter {
                     var cellFont = GetTableRowFont(currentOpts, rowUsesBold);
                     double cellWidth = GetTableCellWidth(colPixel, cell.Column, cell.ColumnSpan, colGapPx);
                     double innerWidth = Math.Max(1, cellWidth - GetTableCellPaddingLeft(style, ri, cell.Column) - GetTableCellPaddingRight(style, ri, cell.Column));
-                    TableCellTextLayout lines = CreateTableCellTextLayout(cell, innerWidth, cellFont, rowSize, rowLeading, currentOpts, runFontSizeScale);
+                    TableCellTextLayout lines = CreateTableCellTextLayout(cell, innerWidth, cellFont, rowSize, rowLeading, currentOpts, runFontSizeScale, style.MinimumShrinkFontSize ?? 6D);
                     rowLines[ri][cell.Column] = lines;
                     if (cell.RowSpan <= 1) {
                         maxLines = Math.Max(maxLines, lines.LineCount);

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Table.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Table.cs
@@ -135,9 +135,10 @@ internal static partial class PdfWriter {
             var rowSizes = new double[tb.Rows.Count];
             var rowBold = new bool[tb.Rows.Count];
             for (int ri = 0; ri < tb.Rows.Count; ri++) {
-                double rowSize = GetTableRowFontSize(style, ri, headerRowCount, footerStartRowIndex, currentOpts.DefaultFontSize);
+                double originalRowSize = GetTableRowFontSize(style, ri, headerRowCount, footerStartRowIndex, currentOpts.DefaultFontSize);
                 bool rowUsesBold = GetTableRowBold(style, ri, headerRowCount, footerStartRowIndex);
-                rowSize = ResolveTableRowShrinkFontSize(tb, style, ri, cols, colPixel, colGapPx, rowSize, rowUsesBold, currentOpts);
+                double rowSize = ResolveTableRowShrinkFontSize(tb, style, ri, cols, colPixel, colGapPx, originalRowSize, rowUsesBold, currentOpts);
+                double runFontSizeScale = GetTableRunFontSizeScale(originalRowSize, rowSize);
                 double rowLeading = GetTableLeading(style, rowSize);
                 rowSizes[ri] = rowSize;
                 rowLeadings[ri] = rowLeading;
@@ -155,7 +156,7 @@ internal static partial class PdfWriter {
                     var cellFont = GetTableRowFont(currentOpts, rowUsesBold);
                     double cellWidth = GetTableCellWidth(colPixel, cell.Column, cell.ColumnSpan, colGapPx);
                     double innerWidth = Math.Max(1, cellWidth - GetTableCellPaddingLeft(style, ri, cell.Column) - GetTableCellPaddingRight(style, ri, cell.Column));
-                    TableCellTextLayout lines = CreateTableCellTextLayout(cell, innerWidth, cellFont, rowSize, rowLeading, currentOpts);
+                    TableCellTextLayout lines = CreateTableCellTextLayout(cell, innerWidth, cellFont, rowSize, rowLeading, currentOpts, runFontSizeScale);
                     rowLines[ri][cell.Column] = lines;
                     if (cell.RowSpan <= 1) {
                         maxLines = Math.Max(maxLines, lines.LineCount);

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Table.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Table.cs
@@ -74,6 +74,9 @@ internal static partial class PdfWriter {
             if (style.CaptionFontSize.HasValue && (style.CaptionFontSize.Value <= 0 || double.IsNaN(style.CaptionFontSize.Value) || double.IsInfinity(style.CaptionFontSize.Value))) {
                 throw new ArgumentException("Table caption font size must be a positive finite value.");
             }
+            if (style.MinimumShrinkFontSize.HasValue && (style.MinimumShrinkFontSize.Value <= 0 || double.IsNaN(style.MinimumShrinkFontSize.Value) || double.IsInfinity(style.MinimumShrinkFontSize.Value))) {
+                throw new ArgumentException("Table minimum shrink font size must be a positive finite value.");
+            }
             if (style.CaptionSpacingAfter < 0 || double.IsNaN(style.CaptionSpacingAfter) || double.IsInfinity(style.CaptionSpacingAfter)) {
                 throw new ArgumentException("Table caption spacing after must be a non-negative finite value.");
             }
@@ -133,8 +136,9 @@ internal static partial class PdfWriter {
             var rowBold = new bool[tb.Rows.Count];
             for (int ri = 0; ri < tb.Rows.Count; ri++) {
                 double rowSize = GetTableRowFontSize(style, ri, headerRowCount, footerStartRowIndex, currentOpts.DefaultFontSize);
-                double rowLeading = GetTableLeading(style, rowSize);
                 bool rowUsesBold = GetTableRowBold(style, ri, headerRowCount, footerStartRowIndex);
+                rowSize = ResolveTableRowShrinkFontSize(tb, style, ri, cols, colPixel, colGapPx, rowSize, rowUsesBold, currentOpts);
+                double rowLeading = GetTableLeading(style, rowSize);
                 rowSizes[ri] = rowSize;
                 rowLeadings[ri] = rowLeading;
                 rowBold[ri] = rowUsesBold;

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Table.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Table.cs
@@ -138,7 +138,7 @@ internal static partial class PdfWriter {
                 double originalRowSize = GetTableRowFontSize(style, ri, headerRowCount, footerStartRowIndex, currentOpts.DefaultFontSize);
                 bool rowUsesBold = GetTableRowBold(style, ri, headerRowCount, footerStartRowIndex);
                 double rowSize = ResolveTableRowShrinkFontSize(tb, style, ri, cols, colPixel, colGapPx, originalRowSize, rowUsesBold, currentOpts);
-                double runFontSizeScale = GetTableRunFontSizeScale(originalRowSize, rowSize);
+                double runFontSizeScale = GetTableRunFontSizeScale(tb, style, ri, cols, colPixel, colGapPx, originalRowSize, rowSize, rowUsesBold, currentOpts);
                 double rowLeading = GetTableLeading(style, rowSize);
                 rowSizes[ri] = rowSize;
                 rowLeadings[ri] = rowLeading;

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableCells.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableCells.cs
@@ -571,13 +571,13 @@ internal static partial class PdfWriter {
         return height;
     }
 
-    private static TableCellTextLayout CreateTableCellTextLayout(TableCellLayout cell, double innerWidth, PdfStandardFont baseFont, double fontSize, double leading, PdfOptions? options, double runFontSizeScale = 1D) {
+    private static TableCellTextLayout CreateTableCellTextLayout(TableCellLayout cell, double innerWidth, PdfStandardFont baseFont, double fontSize, double leading, PdfOptions? options, double runFontSizeScale = 1D, double minimumShrinkFontSize = 0D) {
         double wrapWidth = GetTableCellWrapWidth(innerWidth, cell.NoWrap);
         if (cell.Paragraphs.Count > 0) {
-            return CreateTableCellParagraphTextLayout(ScaleTableCellParagraphsForShrink(cell.Paragraphs, runFontSizeScale), wrapWidth, baseFont, fontSize, leading, options);
+            return CreateTableCellParagraphTextLayout(ScaleTableCellParagraphsForShrink(cell.Paragraphs, runFontSizeScale, minimumShrinkFontSize), wrapWidth, baseFont, fontSize, leading, options);
         }
 
-        var wrap = WrapRichRunsCore(ScaleTableRunsForShrink(cell.Runs, runFontSizeScale), wrapWidth, fontSize, baseFont, leading, null, DefaultParagraphTabStopWidth, options);
+        var wrap = WrapRichRunsCore(ScaleTableRunsForShrink(cell.Runs, runFontSizeScale, minimumShrinkFontSize), wrapWidth, fontSize, baseFont, leading, null, DefaultParagraphTabStopWidth, options);
         if (wrap.Lines.Count == 0) {
             wrap.Lines.Add(new System.Collections.Generic.List<RichSeg>());
         }
@@ -589,15 +589,16 @@ internal static partial class PdfWriter {
         return new TableCellTextLayout(wrap.Lines, wrap.LineHeights);
     }
 
-    private static System.Collections.Generic.IReadOnlyList<TextRun> ScaleTableRunsForShrink(System.Collections.Generic.IReadOnlyList<TextRun> runs, double runFontSizeScale) {
+    private static System.Collections.Generic.IReadOnlyList<TextRun> ScaleTableRunsForShrink(System.Collections.Generic.IReadOnlyList<TextRun> runs, double runFontSizeScale, double minimumShrinkFontSize) {
         if (runFontSizeScale >= 0.999D) {
             return runs;
         }
 
+        double minimumExplicitFontSize = minimumShrinkFontSize > 0D ? minimumShrinkFontSize : 0.001D;
         var scaledRuns = new System.Collections.Generic.List<TextRun>(runs.Count);
         foreach (TextRun run in runs) {
             double? scaledFontSize = run.FontSize.HasValue
-                ? System.Math.Max(0.001D, run.FontSize.Value * runFontSizeScale)
+                ? System.Math.Max(minimumExplicitFontSize, run.FontSize.Value * runFontSizeScale)
                 : null;
             scaledRuns.Add(new TextRun(
                 run.Text,
@@ -620,7 +621,7 @@ internal static partial class PdfWriter {
         return scaledRuns.AsReadOnly();
     }
 
-    private static System.Collections.Generic.IReadOnlyList<PdfTableCellParagraph> ScaleTableCellParagraphsForShrink(System.Collections.Generic.IReadOnlyList<PdfTableCellParagraph> paragraphs, double runFontSizeScale) {
+    private static System.Collections.Generic.IReadOnlyList<PdfTableCellParagraph> ScaleTableCellParagraphsForShrink(System.Collections.Generic.IReadOnlyList<PdfTableCellParagraph> paragraphs, double runFontSizeScale, double minimumShrinkFontSize) {
         if (runFontSizeScale >= 0.999D) {
             return paragraphs;
         }
@@ -628,7 +629,7 @@ internal static partial class PdfWriter {
         var scaledParagraphs = new System.Collections.Generic.List<PdfTableCellParagraph>(paragraphs.Count);
         foreach (PdfTableCellParagraph paragraph in paragraphs) {
             scaledParagraphs.Add(new PdfTableCellParagraph(
-                ScaleTableRunsForShrink(paragraph.Runs, runFontSizeScale),
+                ScaleTableRunsForShrink(paragraph.Runs, runFontSizeScale, minimumShrinkFontSize),
                 paragraph.SpacingAfter,
                 paragraph.Align,
                 paragraph.SpacingBefore,

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableCells.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableCells.cs
@@ -242,13 +242,13 @@ internal static partial class PdfWriter {
                 double candidate = (low + high) / 2D;
                 double candidateWidth = MeasureTableCellTextWidth(cell, rowFont, resolvedFontSize, options, candidate, minimumFontSize);
                 if (candidateWidth <= innerWidth + 0.001D) {
-                    high = candidate;
-                } else {
                     low = candidate;
+                } else {
+                    high = candidate;
                 }
             }
 
-            scale = Math.Min(scale, high);
+            scale = Math.Min(scale, low);
         }
 
         return scale;

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableCells.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableCells.cs
@@ -140,6 +140,39 @@ internal static partial class PdfWriter {
         return null;
     }
 
+    private static double ResolveTableRowShrinkFontSize(TableBlock table, PdfTableStyle style, int rowIndex, int columnCount, double[] columnWidths, double columnGap, double rowFontSize, bool rowUsesBold, PdfOptions? options) {
+        if (!style.ShrinkTextToFit || rowFontSize <= 0D) {
+            return rowFontSize;
+        }
+
+        double minimumFontSize = style.MinimumShrinkFontSize ?? 6D;
+        if (minimumFontSize >= rowFontSize) {
+            return rowFontSize;
+        }
+
+        PdfStandardFont rowFont = GetTableRowFont(options ?? new PdfOptions(), rowUsesBold);
+        double resolvedFontSize = rowFontSize;
+        var cells = GetTableCellLayouts(table, rowIndex, columnCount);
+        for (int cellIndex = 0; cellIndex < cells.Count; cellIndex++) {
+            TableCellLayout cell = cells[cellIndex];
+            if (string.IsNullOrEmpty(cell.Text)) {
+                continue;
+            }
+
+            double cellWidth = GetTableCellWidth(columnWidths, cell.Column, cell.ColumnSpan, columnGap);
+            double innerWidth = Math.Max(1D, cellWidth - GetTableCellPaddingLeft(style, rowIndex, cell.Column) - GetTableCellPaddingRight(style, rowIndex, cell.Column));
+            double textWidth = EstimateSimpleTextWidthForOptions(cell.Text, rowFont, rowFontSize, options);
+            if (textWidth <= innerWidth + 0.001D || textWidth <= 0.001D) {
+                continue;
+            }
+
+            double candidate = Math.Max(minimumFontSize, rowFontSize * innerWidth / textWidth);
+            resolvedFontSize = Math.Min(resolvedFontSize, candidate);
+        }
+
+        return resolvedFontSize;
+    }
+
     private static double ResolveTableRowHeight(PdfTableStyle style, int rowIndex, double requiredHeight) {
         double? fixedHeight = GetTableRowFixedHeight(style, rowIndex);
         return fixedHeight ?? System.Math.Max(requiredHeight, GetTableRowMinHeight(style, rowIndex));

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableCells.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableCells.cs
@@ -146,7 +146,7 @@ internal static partial class PdfWriter {
         }
 
         double minimumFontSize = style.MinimumShrinkFontSize ?? 6D;
-        if (minimumFontSize >= rowFontSize) {
+        if (minimumFontSize > rowFontSize) {
             return rowFontSize;
         }
 
@@ -204,6 +204,57 @@ internal static partial class PdfWriter {
         }
 
         return resolvedFontSize / originalFontSize;
+    }
+
+    private static double GetTableRunFontSizeScale(TableBlock table, PdfTableStyle style, int rowIndex, int columnCount, double[] columnWidths, double columnGap, double originalFontSize, double resolvedFontSize, bool rowUsesBold, PdfOptions? options) {
+        double scale = GetTableRunFontSizeScale(originalFontSize, resolvedFontSize);
+        if (!style.ShrinkTextToFit) {
+            return scale;
+        }
+
+        double minimumFontSize = style.MinimumShrinkFontSize ?? 6D;
+        PdfStandardFont rowFont = GetTableRowFont(options ?? new PdfOptions(), rowUsesBold);
+        var cells = GetTableCellLayouts(table, rowIndex, columnCount);
+        for (int cellIndex = 0; cellIndex < cells.Count; cellIndex++) {
+            TableCellLayout cell = cells[cellIndex];
+            double maxExplicitFontSize = GetMaxExplicitTableRunFontSize(cell);
+            if (maxExplicitFontSize <= resolvedFontSize + 0.001D) {
+                continue;
+            }
+
+            double cellWidth = GetTableCellWidth(columnWidths, cell.Column, cell.ColumnSpan, columnGap);
+            double innerWidth = Math.Max(1D, cellWidth - GetTableCellPaddingLeft(style, rowIndex, cell.Column) - GetTableCellPaddingRight(style, rowIndex, cell.Column));
+            double textWidth = MeasureTableCellTextWidth(cell, rowFont, resolvedFontSize, options);
+            if (textWidth <= innerWidth + 0.001D || textWidth <= 0.001D) {
+                continue;
+            }
+
+            double minimumScale = minimumFontSize > 0D ? minimumFontSize / maxExplicitFontSize : 0.001D;
+            double fitScale = innerWidth / textWidth;
+            scale = Math.Min(scale, Math.Max(minimumScale, fitScale));
+        }
+
+        return scale;
+    }
+
+    private static double GetMaxExplicitTableRunFontSize(TableCellLayout cell) {
+        double max = GetMaxExplicitRunFontSize(cell.Runs);
+        for (int i = 0; i < cell.Paragraphs.Count; i++) {
+            max = Math.Max(max, GetMaxExplicitRunFontSize(cell.Paragraphs[i].Runs));
+        }
+
+        return max;
+    }
+
+    private static double GetMaxExplicitRunFontSize(System.Collections.Generic.IReadOnlyList<TextRun> runs) {
+        double max = 0D;
+        foreach (TextRun run in runs) {
+            if (run.FontSize.HasValue) {
+                max = Math.Max(max, run.FontSize.Value);
+            }
+        }
+
+        return max;
     }
 
     private static double ResolveTableRowHeight(PdfTableStyle style, int rowIndex, double requiredHeight) {

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableCells.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableCells.cs
@@ -161,7 +161,7 @@ internal static partial class PdfWriter {
 
             double cellWidth = GetTableCellWidth(columnWidths, cell.Column, cell.ColumnSpan, columnGap);
             double innerWidth = Math.Max(1D, cellWidth - GetTableCellPaddingLeft(style, rowIndex, cell.Column) - GetTableCellPaddingRight(style, rowIndex, cell.Column));
-            double textWidth = EstimateSimpleTextWidthForOptions(cell.Text, rowFont, rowFontSize, options);
+            double textWidth = MeasureTableCellTextWidth(cell, rowFont, rowFontSize, options);
             if (textWidth <= innerWidth + 0.001D || textWidth <= 0.001D) {
                 continue;
             }
@@ -171,6 +171,39 @@ internal static partial class PdfWriter {
         }
 
         return resolvedFontSize;
+    }
+
+    private static double MeasureTableCellTextWidth(TableCellLayout cell, PdfStandardFont baseFont, double fontSize, PdfOptions? options) {
+        double width = 0D;
+        if (cell.Paragraphs.Count > 0) {
+            foreach (PdfTableCellParagraph paragraph in cell.Paragraphs) {
+                width = Math.Max(width, MeasureTableRunsTextWidth(paragraph.Runs, baseFont, fontSize, options));
+            }
+        } else {
+            width = MeasureTableRunsTextWidth(cell.Runs, baseFont, fontSize, options);
+        }
+
+        return width;
+    }
+
+    private static double MeasureTableRunsTextWidth(System.Collections.Generic.IReadOnlyList<TextRun> runs, PdfStandardFont baseFont, double fontSize, PdfOptions? options) {
+        PdfOptions effectiveOptions = options ?? new PdfOptions();
+        System.Collections.Generic.IReadOnlyList<TextRun> normalizedRuns = NormalizeFallbackRuns(runs, baseFont, effectiveOptions);
+        double width = 0D;
+        foreach (System.Collections.Generic.IReadOnlyList<TextRun> line in BuildPageTextLineRuns(normalizedRuns)) {
+            width = Math.Max(width, MeasurePageTextLineRuns(line, baseFont, fontSize, effectiveOptions));
+        }
+
+        return width;
+    }
+
+    private static double GetTableRunFontSizeScale(double originalFontSize, double resolvedFontSize) {
+        if (originalFontSize <= 0D ||
+            resolvedFontSize >= originalFontSize - 0.001D) {
+            return 1D;
+        }
+
+        return resolvedFontSize / originalFontSize;
     }
 
     private static double ResolveTableRowHeight(PdfTableStyle style, int rowIndex, double requiredHeight) {
@@ -538,13 +571,13 @@ internal static partial class PdfWriter {
         return height;
     }
 
-    private static TableCellTextLayout CreateTableCellTextLayout(TableCellLayout cell, double innerWidth, PdfStandardFont baseFont, double fontSize, double leading, PdfOptions? options) {
+    private static TableCellTextLayout CreateTableCellTextLayout(TableCellLayout cell, double innerWidth, PdfStandardFont baseFont, double fontSize, double leading, PdfOptions? options, double runFontSizeScale = 1D) {
         double wrapWidth = GetTableCellWrapWidth(innerWidth, cell.NoWrap);
         if (cell.Paragraphs.Count > 0) {
-            return CreateTableCellParagraphTextLayout(cell.Paragraphs, wrapWidth, baseFont, fontSize, leading, options);
+            return CreateTableCellParagraphTextLayout(ScaleTableCellParagraphsForShrink(cell.Paragraphs, runFontSizeScale), wrapWidth, baseFont, fontSize, leading, options);
         }
 
-        var wrap = WrapRichRunsCore(cell.Runs, wrapWidth, fontSize, baseFont, leading, null, DefaultParagraphTabStopWidth, options);
+        var wrap = WrapRichRunsCore(ScaleTableRunsForShrink(cell.Runs, runFontSizeScale), wrapWidth, fontSize, baseFont, leading, null, DefaultParagraphTabStopWidth, options);
         if (wrap.Lines.Count == 0) {
             wrap.Lines.Add(new System.Collections.Generic.List<RichSeg>());
         }
@@ -554,6 +587,60 @@ internal static partial class PdfWriter {
         }
 
         return new TableCellTextLayout(wrap.Lines, wrap.LineHeights);
+    }
+
+    private static System.Collections.Generic.IReadOnlyList<TextRun> ScaleTableRunsForShrink(System.Collections.Generic.IReadOnlyList<TextRun> runs, double runFontSizeScale) {
+        if (runFontSizeScale >= 0.999D) {
+            return runs;
+        }
+
+        var scaledRuns = new System.Collections.Generic.List<TextRun>(runs.Count);
+        foreach (TextRun run in runs) {
+            double? scaledFontSize = run.FontSize.HasValue
+                ? System.Math.Max(0.001D, run.FontSize.Value * runFontSizeScale)
+                : null;
+            scaledRuns.Add(new TextRun(
+                run.Text,
+                run.Bold,
+                run.Underline,
+                run.Color,
+                run.Italic,
+                run.Strike,
+                scaledFontSize,
+                run.Font,
+                run.LinkUri,
+                run.LinkContents,
+                run.Baseline,
+                run.LinkDestinationName,
+                run.TabLeader,
+                run.TabAlignment,
+                run.BackgroundColor));
+        }
+
+        return scaledRuns.AsReadOnly();
+    }
+
+    private static System.Collections.Generic.IReadOnlyList<PdfTableCellParagraph> ScaleTableCellParagraphsForShrink(System.Collections.Generic.IReadOnlyList<PdfTableCellParagraph> paragraphs, double runFontSizeScale) {
+        if (runFontSizeScale >= 0.999D) {
+            return paragraphs;
+        }
+
+        var scaledParagraphs = new System.Collections.Generic.List<PdfTableCellParagraph>(paragraphs.Count);
+        foreach (PdfTableCellParagraph paragraph in paragraphs) {
+            scaledParagraphs.Add(new PdfTableCellParagraph(
+                ScaleTableRunsForShrink(paragraph.Runs, runFontSizeScale),
+                paragraph.SpacingAfter,
+                paragraph.Align,
+                paragraph.SpacingBefore,
+                paragraph.LeftIndent,
+                paragraph.RightIndent,
+                paragraph.FirstLineIndent,
+                paragraph.LineHeight,
+                paragraph.DefaultTabStopWidth,
+                paragraph.TabStops));
+        }
+
+        return scaledParagraphs.AsReadOnly();
     }
 
     private static double GetTableCellWrapWidth(double innerWidth, bool noWrap) =>

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableCells.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableCells.cs
@@ -224,17 +224,51 @@ internal static partial class PdfWriter {
 
             double cellWidth = GetTableCellWidth(columnWidths, cell.Column, cell.ColumnSpan, columnGap);
             double innerWidth = Math.Max(1D, cellWidth - GetTableCellPaddingLeft(style, rowIndex, cell.Column) - GetTableCellPaddingRight(style, rowIndex, cell.Column));
-            double textWidth = MeasureTableCellTextWidth(cell, rowFont, resolvedFontSize, options);
+            double textWidth = MeasureTableCellTextWidth(cell, rowFont, resolvedFontSize, options, scale, minimumFontSize);
             if (textWidth <= innerWidth + 0.001D || textWidth <= 0.001D) {
                 continue;
             }
 
-            double minimumScale = minimumFontSize > 0D ? minimumFontSize / maxExplicitFontSize : 0.001D;
-            double fitScale = innerWidth / textWidth;
-            scale = Math.Min(scale, Math.Max(minimumScale, fitScale));
+            double minimumScale = 0.001D;
+            double minimumWidth = MeasureTableCellTextWidth(cell, rowFont, resolvedFontSize, options, minimumScale, minimumFontSize);
+            if (minimumWidth > innerWidth + 0.001D) {
+                scale = Math.Min(scale, minimumScale);
+                continue;
+            }
+
+            double low = minimumScale;
+            double high = scale;
+            for (int iteration = 0; iteration < 20; iteration++) {
+                double candidate = (low + high) / 2D;
+                double candidateWidth = MeasureTableCellTextWidth(cell, rowFont, resolvedFontSize, options, candidate, minimumFontSize);
+                if (candidateWidth <= innerWidth + 0.001D) {
+                    high = candidate;
+                } else {
+                    low = candidate;
+                }
+            }
+
+            scale = Math.Min(scale, high);
         }
 
         return scale;
+    }
+
+    private static double MeasureTableCellTextWidth(TableCellLayout cell, PdfStandardFont baseFont, double fontSize, PdfOptions? options, double runFontSizeScale, double minimumShrinkFontSize) {
+        if (runFontSizeScale >= 0.999D) {
+            return MeasureTableCellTextWidth(cell, baseFont, fontSize, options);
+        }
+
+        double width = 0D;
+        if (cell.Paragraphs.Count > 0) {
+            foreach (PdfTableCellParagraph paragraph in cell.Paragraphs) {
+                width = Math.Max(width, MeasureTableRunsTextWidth(ScaleTableRunsForShrink(paragraph.Runs, runFontSizeScale, minimumShrinkFontSize), baseFont, fontSize, options));
+            }
+        } else {
+            width = MeasureTableRunsTextWidth(ScaleTableRunsForShrink(cell.Runs, runFontSizeScale, minimumShrinkFontSize), baseFont, fontSize, options);
+        }
+
+        return width;
     }
 
     private static double GetMaxExplicitTableRunFontSize(TableCellLayout cell) {
@@ -648,9 +682,13 @@ internal static partial class PdfWriter {
         double minimumExplicitFontSize = minimumShrinkFontSize > 0D ? minimumShrinkFontSize : 0.001D;
         var scaledRuns = new System.Collections.Generic.List<TextRun>(runs.Count);
         foreach (TextRun run in runs) {
-            double? scaledFontSize = run.FontSize.HasValue
-                ? System.Math.Max(minimumExplicitFontSize, run.FontSize.Value * runFontSizeScale)
-                : null;
+            double? scaledFontSize = null;
+            if (run.FontSize.HasValue) {
+                scaledFontSize = run.FontSize.Value <= minimumExplicitFontSize
+                    ? run.FontSize.Value
+                    : System.Math.Max(minimumExplicitFontSize, run.FontSize.Value * runFontSizeScale);
+            }
+
             scaledRuns.Add(new TextRun(
                 run.Text,
                 run.Bold,

--- a/OfficeIMO.Tests/Pdf/PdfDocumentWorkflowTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentWorkflowTests.cs
@@ -136,9 +136,15 @@ public class PdfDocumentWorkflowTests {
             })
             .ToBytes();
 
-        IReadOnlyList<PdfLogicalTextBlock> blocks = PdfDocument.Open(bytes).Read.TextBlocks();
+        PdfDocument document = PdfDocument.Open(bytes);
+        IReadOnlyList<PdfLogicalTextBlock> blocks = document.Read.TextBlocks();
+        string compactText = document.Read.Text()
+            .Replace("\r", string.Empty)
+            .Replace("\n", string.Empty)
+            .Replace(" ", string.Empty);
 
-        Assert.Contains(blocks, block => block.Text.Contains(longValue, StringComparison.Ordinal) && block.FontSize >= 7D);
+        Assert.Contains(longValue, compactText, StringComparison.Ordinal);
+        Assert.Contains(blocks, block => Math.Abs(block.FontSize - 7D) < 0.001D);
     }
 
     [Fact]

--- a/OfficeIMO.Tests/Pdf/PdfDocumentWorkflowTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentWorkflowTests.cs
@@ -182,6 +182,71 @@ public class PdfDocumentWorkflowTests {
     }
 
     [Fact]
+    public void TableStyle_DoesNotEnlargeExplicitRichRunsBelowShrinkMinimum() {
+        const string tinyValue = "Tiny";
+        const string longValue = "ThisIdentifierShouldShrinkToFit";
+        byte[] bytes = PdfDocument.Create()
+            .Table(new[] {
+                new[] { new PdfTableCell("Name"), new PdfTableCell("Value") },
+                new[] {
+                    new PdfTableCell("Alpha"),
+                    PdfTableCell.RichTextCell(new[] {
+                        TextRun.Normal(tinyValue, fontSize: 4, font: PdfStandardFont.Courier),
+                        TextRun.Normal(longValue)
+                    })
+                }
+            }, style: new PdfTableStyle {
+                FontSize = 18,
+                HeaderFontSize = 18,
+                MinimumShrinkFontSize = 7,
+                ShrinkTextToFit = true,
+                ColumnWidthPoints = new List<double?> { 54, 108 },
+                HeaderRowCount = 1
+            })
+            .ToBytes();
+
+        string raw = PdfEncoding.Latin1GetString(bytes);
+
+        Assert.Matches(@"(?s)/F\d+\s+4\s+Tf.*<54696E79>\s+Tj", raw);
+    }
+
+    [Fact]
+    public void TableStyle_ScalesExplicitRichRunsAgainstRemainingCellWidth() {
+        const string prefix = "PrefixConsumesWidth";
+        const string largeValue = "WideValue";
+        byte[] bytes = PdfDocument.Create()
+            .Table(new[] {
+                new[] { new PdfTableCell("Name"), new PdfTableCell("Value") },
+                new[] {
+                    new PdfTableCell("Alpha"),
+                    PdfTableCell.RichTextCell(new[] {
+                        TextRun.Normal(prefix),
+                        TextRun.Normal(largeValue, fontSize: 30, font: PdfStandardFont.Courier)
+                    })
+                }
+            }, style: new PdfTableStyle {
+                FontSize = 8,
+                HeaderFontSize = 8,
+                MinimumShrinkFontSize = 8,
+                ShrinkTextToFit = true,
+                ColumnWidthPoints = new List<double?> { 54, 108 },
+                HeaderRowCount = 1
+            })
+            .ToBytes();
+
+        PdfDocument document = PdfDocument.Open(bytes);
+        IReadOnlyList<PdfLogicalTextBlock> blocks = document.Read.TextBlocks();
+        string compactText = document.Read.Text()
+            .Replace("\r", string.Empty)
+            .Replace("\n", string.Empty)
+            .Replace(" ", string.Empty);
+
+        Assert.Contains(prefix + largeValue, compactText, StringComparison.Ordinal);
+        Assert.Contains(blocks, block => block.Text.Contains(largeValue, StringComparison.Ordinal) && Math.Abs(block.FontSize - 8D) < 0.001D);
+        Assert.DoesNotContain(blocks, block => block.Text.Contains(largeValue, StringComparison.Ordinal) && block.FontSize > 8.001D);
+    }
+
+    [Fact]
     public void TableStyle_CanShrinkTextToFitInsideRowColumnLayout() {
         const string longValue = "ThisIdentifierShouldShrinkToFit";
         byte[] bytes = PdfDocument.Create(new PdfOptions {

--- a/OfficeIMO.Tests/Pdf/PdfDocumentWorkflowTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentWorkflowTests.cs
@@ -82,6 +82,69 @@ public class PdfDocumentWorkflowTests {
     }
 
     [Fact]
+    public void TableStyle_CanShrinkTextToFitInsideRowColumnLayout() {
+        const string longValue = "ThisIdentifierShouldShrinkToFit";
+        byte[] bytes = PdfDocument.Create(new PdfOptions {
+                PageWidth = 240,
+                PageHeight = 180
+            })
+            .Compose(document =>
+                document.Page(page =>
+                    page.Content(content =>
+                        content.Row(row =>
+                            row.Column(100, column =>
+                                column.Table(new[] {
+                                    new[] { "Name", "Value" },
+                                    new[] { "Alpha", longValue }
+                                }, style: new PdfTableStyle {
+                                    FontSize = 18,
+                                    HeaderFontSize = 18,
+                                    MinimumShrinkFontSize = 7,
+                                    ShrinkTextToFit = true,
+                                    ColumnWidthPoints = new List<double?> { 54, 108 },
+                                    HeaderRowCount = 1
+                                }))))))
+            .ToBytes();
+
+        PdfDocument document = PdfDocument.Open(bytes);
+        IReadOnlyList<PdfLogicalTextBlock> blocks = document.Read.TextBlocks();
+        string compactText = document.Read.Text()
+            .Replace("\r", string.Empty)
+            .Replace("\n", string.Empty)
+            .Replace(" ", string.Empty);
+
+        Assert.Contains(longValue, compactText, StringComparison.Ordinal);
+        Assert.Contains(blocks, block => block.FontSize < 18D && block.FontSize >= 7D);
+    }
+
+    [Fact]
+    public void TableStyle_CanShrinkTextToFitInsideCanvasTable() {
+        const string longValue = "ThisIdentifierShouldShrinkToFit";
+        byte[] bytes = PdfDocument.Create(new PdfOptions {
+                PageWidth = 240,
+                PageHeight = 180
+            })
+            .Canvas(canvas => canvas.Table(new[] {
+                new[] { "Name", "Value" },
+                new[] { "Alpha", longValue }
+            }, 20, 20, 162, 80, new PdfTableStyle {
+                FontSize = 18,
+                HeaderFontSize = 18,
+                MinimumShrinkFontSize = 7,
+                ShrinkTextToFit = true,
+                ColumnWidthPoints = new List<double?> { 54, 108 },
+                HeaderRowCount = 1
+            }))
+            .ToBytes();
+
+        IReadOnlyList<PdfLogicalTextBlock> blocks = PdfDocument.Open(bytes).Read.TextBlocks();
+        PdfLogicalTextBlock valueBlock = Assert.Single(blocks, block => block.Text.Contains(longValue, StringComparison.Ordinal));
+
+        Assert.True(valueBlock.FontSize < 18D);
+        Assert.True(valueBlock.FontSize >= 7D);
+    }
+
+    [Fact]
     public void PageSizes_ResolveExpandedStandardNames() {
         Assert.True(PageSizes.TryGet("a0", out PageSize a0));
         Assert.Equal(2384, a0.Width);

--- a/OfficeIMO.Tests/Pdf/PdfDocumentWorkflowTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentWorkflowTests.cs
@@ -82,6 +82,39 @@ public class PdfDocumentWorkflowTests {
     }
 
     [Fact]
+    public void TableStyle_ShrinksExplicitRichRunFontSizesToFitResolvedCellWidth() {
+        const string longValue = "ThisIdentifierShouldShrinkToFit";
+        byte[] bytes = PdfDocument.Create()
+            .Table(new[] {
+                new[] { new PdfTableCell("Name"), new PdfTableCell("Value") },
+                new[] {
+                    new PdfTableCell("Alpha"),
+                    PdfTableCell.RichTextCell(new[] {
+                        TextRun.Normal(longValue, fontSize: 30, font: PdfStandardFont.Courier)
+                    })
+                }
+            }, style: new PdfTableStyle {
+                FontSize = 18,
+                HeaderFontSize = 18,
+                MinimumShrinkFontSize = 7,
+                ShrinkTextToFit = true,
+                ColumnWidthPoints = new List<double?> { 54, 108 },
+                HeaderRowCount = 1
+            })
+            .ToBytes();
+
+        PdfDocument document = PdfDocument.Open(bytes);
+        IReadOnlyList<PdfLogicalTextBlock> blocks = document.Read.TextBlocks();
+        string compactText = document.Read.Text()
+            .Replace("\r", string.Empty)
+            .Replace("\n", string.Empty)
+            .Replace(" ", string.Empty);
+
+        Assert.Contains(longValue, compactText, StringComparison.Ordinal);
+        Assert.Contains(blocks, block => block.FontSize < 30D && block.FontSize >= 7D);
+    }
+
+    [Fact]
     public void TableStyle_CanShrinkTextToFitInsideRowColumnLayout() {
         const string longValue = "ThisIdentifierShouldShrinkToFit";
         byte[] bytes = PdfDocument.Create(new PdfOptions {

--- a/OfficeIMO.Tests/Pdf/PdfDocumentWorkflowTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentWorkflowTests.cs
@@ -148,6 +148,40 @@ public class PdfDocumentWorkflowTests {
     }
 
     [Fact]
+    public void TableStyle_ShrinksExplicitRichRunsWhenRowFontIsAtMinimum() {
+        const string longValue = "ThisIdentifierShouldShrinkToFit";
+        byte[] bytes = PdfDocument.Create()
+            .Table(new[] {
+                new[] { new PdfTableCell("Name"), new PdfTableCell("Value") },
+                new[] {
+                    new PdfTableCell("Alpha"),
+                    PdfTableCell.RichTextCell(new[] {
+                        TextRun.Normal(longValue, fontSize: 30, font: PdfStandardFont.Courier)
+                    })
+                }
+            }, style: new PdfTableStyle {
+                FontSize = 8,
+                HeaderFontSize = 8,
+                MinimumShrinkFontSize = 8,
+                ShrinkTextToFit = true,
+                ColumnWidthPoints = new List<double?> { 54, 108 },
+                HeaderRowCount = 1
+            })
+            .ToBytes();
+
+        PdfDocument document = PdfDocument.Open(bytes);
+        IReadOnlyList<PdfLogicalTextBlock> blocks = document.Read.TextBlocks();
+        string compactText = document.Read.Text()
+            .Replace("\r", string.Empty)
+            .Replace("\n", string.Empty)
+            .Replace(" ", string.Empty);
+
+        Assert.Contains(longValue, compactText, StringComparison.Ordinal);
+        Assert.Contains(blocks, block => Math.Abs(block.FontSize - 8D) < 0.001D);
+        Assert.DoesNotContain(blocks, block => block.FontSize > 8.001D && block.Text.Contains(longValue, StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void TableStyle_CanShrinkTextToFitInsideRowColumnLayout() {
         const string longValue = "ThisIdentifierShouldShrinkToFit";
         byte[] bytes = PdfDocument.Create(new PdfOptions {

--- a/OfficeIMO.Tests/Pdf/PdfDocumentWorkflowTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentWorkflowTests.cs
@@ -434,6 +434,11 @@ public class PdfDocumentWorkflowTests {
         Assert.True(split.Succeeded);
         Assert.Equal(3, split.RequireValue().Count);
 
+        PdfOperationResult<IReadOnlyList<PdfDocument>> emptySelectionSplit = PdfDocument.Open(source).Pages.TrySplit(Array.Empty<PdfPageSelection>());
+        Assert.False(emptySelectionSplit.Succeeded);
+        Assert.Null(emptySelectionSplit.Value);
+        Assert.Contains("At least one page selection", string.Join(" ", emptySelectionSplit.Diagnostics), StringComparison.Ordinal);
+
         PdfDocument invalid = PdfDocument.Open(Encoding.ASCII.GetBytes("not a pdf"));
         PdfOperationResult<PdfDocument> blocked = invalid.Pages.TryExtract(PdfPageSelection.From(1));
 

--- a/OfficeIMO.Tests/Pdf/PdfDocumentWorkflowTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentWorkflowTests.cs
@@ -58,6 +58,30 @@ public class PdfDocumentWorkflowTests {
     }
 
     [Fact]
+    public void TableStyle_CanShrinkTextToFitResolvedCellWidth() {
+        const string longValue = "ThisIdentifierShouldShrinkToFit";
+        byte[] bytes = PdfDocument.Create()
+            .Table(new[] {
+                new[] { "Name", "Value" },
+                new[] { "Alpha", longValue }
+            }, style: new PdfTableStyle {
+                FontSize = 18,
+                HeaderFontSize = 18,
+                MinimumShrinkFontSize = 7,
+                ShrinkTextToFit = true,
+                ColumnWidthPoints = new List<double?> { 54, 108 },
+                HeaderRowCount = 1
+            })
+            .ToBytes();
+
+        IReadOnlyList<PdfLogicalTextBlock> blocks = PdfDocument.Open(bytes).Read.TextBlocks();
+        PdfLogicalTextBlock valueBlock = Assert.Single(blocks, block => block.Text.Contains(longValue, StringComparison.Ordinal));
+
+        Assert.True(valueBlock.FontSize < 18D);
+        Assert.True(valueBlock.FontSize >= 7D);
+    }
+
+    [Fact]
     public void PageSizes_ResolveExpandedStandardNames() {
         Assert.True(PageSizes.TryGet("a0", out PageSize a0));
         Assert.Equal(2384, a0.Width);

--- a/OfficeIMO.Tests/Pdf/PdfDocumentWorkflowTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentWorkflowTests.cs
@@ -247,6 +247,35 @@ public class PdfDocumentWorkflowTests {
     }
 
     [Fact]
+    public void TableStyle_ChoosesLargestFittingExplicitRichRunScale() {
+        const string prefix = "Short";
+        const string largeValue = "WideValue";
+        byte[] bytes = PdfDocument.Create()
+            .Table(new[] {
+                new[] { new PdfTableCell("Name"), new PdfTableCell("Value") },
+                new[] {
+                    new PdfTableCell("Alpha"),
+                    PdfTableCell.RichTextCell(new[] {
+                        TextRun.Normal(prefix),
+                        TextRun.Normal(largeValue, fontSize: 20, font: PdfStandardFont.Courier)
+                    })
+                }
+            }, style: new PdfTableStyle {
+                FontSize = 10,
+                HeaderFontSize = 10,
+                MinimumShrinkFontSize = 6,
+                ShrinkTextToFit = true,
+                ColumnWidthPoints = new List<double?> { 54, 108 },
+                HeaderRowCount = 1
+            })
+            .ToBytes();
+
+        IReadOnlyList<PdfLogicalTextBlock> blocks = PdfDocument.Open(bytes).Read.TextBlocks();
+
+        Assert.Contains(blocks, block => block.Text.Contains(largeValue, StringComparison.Ordinal) && block.FontSize > 6.001D && block.FontSize < 20D);
+    }
+
+    [Fact]
     public void TableStyle_CanShrinkTextToFitInsideRowColumnLayout() {
         const string longValue = "ThisIdentifierShouldShrinkToFit";
         byte[] bytes = PdfDocument.Create(new PdfOptions {

--- a/OfficeIMO.Tests/Pdf/PdfDocumentWorkflowTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentWorkflowTests.cs
@@ -115,6 +115,33 @@ public class PdfDocumentWorkflowTests {
     }
 
     [Fact]
+    public void TableStyle_ClampsShrunkExplicitRichRunFontSizesToMinimum() {
+        const string longValue = "ThisIdentifierShouldShrinkToFit";
+        byte[] bytes = PdfDocument.Create()
+            .Table(new[] {
+                new[] { new PdfTableCell("Name"), new PdfTableCell("Value") },
+                new[] {
+                    new PdfTableCell("Alpha"),
+                    PdfTableCell.RichTextCell(new[] {
+                        TextRun.Normal(longValue, fontSize: 8, font: PdfStandardFont.Courier)
+                    })
+                }
+            }, style: new PdfTableStyle {
+                FontSize = 18,
+                HeaderFontSize = 18,
+                MinimumShrinkFontSize = 7,
+                ShrinkTextToFit = true,
+                ColumnWidthPoints = new List<double?> { 54, 108 },
+                HeaderRowCount = 1
+            })
+            .ToBytes();
+
+        IReadOnlyList<PdfLogicalTextBlock> blocks = PdfDocument.Open(bytes).Read.TextBlocks();
+
+        Assert.Contains(blocks, block => block.Text.Contains(longValue, StringComparison.Ordinal) && block.FontSize >= 7D);
+    }
+
+    [Fact]
     public void TableStyle_CanShrinkTextToFitInsideRowColumnLayout() {
         const string longValue = "ThisIdentifierShouldShrinkToFit";
         byte[] bytes = PdfDocument.Create(new PdfOptions {

--- a/OfficeIMO.Tests/Pdf/PdfEncryptedReadTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfEncryptedReadTests.cs
@@ -63,12 +63,19 @@ public class PdfEncryptedReadTests {
     }
 
     [Fact]
-    public void StandardEmptyUserPasswordEncryptedPdf_RemainsBlockedForRewrite() {
+    public void StandardEmptyUserPasswordEncryptedPdf_SplitsAndExtractsWithoutExplicitPassword() {
         byte[] pdf = EncryptedPdfFixture.CreateRevision2(string.Empty, "owner", "Empty user password text");
 
-        NotSupportedException exception = Assert.Throws<NotSupportedException>(() => PdfPageExtractor.ExtractPages(pdf, 1));
+        byte[] extracted = PdfPageExtractor.ExtractPages(pdf, 1);
+        IReadOnlyList<PdfDocument> splitPages = PdfDocument.Open(pdf).Pages.Split();
+        PdfOperationResult<IReadOnlyList<PdfDocument>> trySplit = PdfDocument.Open(pdf).Pages.TrySplit();
 
-        Assert.Contains("Encrypted PDF files are not supported for rewriting by OfficeIMO.Pdf yet.", exception.Message, StringComparison.Ordinal);
+        Assert.False(PdfInspector.Probe(extracted).HasEncryption);
+        Assert.Contains("Empty user password text", PdfTextExtractor.ExtractAllText(extracted), StringComparison.Ordinal);
+        PdfDocument splitPage = Assert.Single(splitPages);
+        Assert.Contains("Empty user password text", splitPage.Read.Text(), StringComparison.Ordinal);
+        Assert.True(trySplit.CanAttempt);
+        Assert.True(trySplit.Succeeded);
     }
 
     [Fact]
@@ -91,6 +98,7 @@ public class PdfEncryptedReadTests {
 
         PdfOperationResult<IReadOnlyList<PdfDocument>> result = PdfDocument.Open(pdf, new PdfReadOptions { Password = "open" }).Pages.TrySplit();
 
+        Assert.True(result.CanAttempt);
         Assert.True(result.Succeeded);
         PdfDocument page = Assert.Single(result.RequireValue());
         Assert.Contains("Secret PDF Text", page.Read.Text(), StringComparison.Ordinal);
@@ -102,6 +110,7 @@ public class PdfEncryptedReadTests {
 
         PdfOperationResult<IReadOnlyList<PdfDocument>> result = PdfDocument.Open(pdf).Pages.TrySplit(new PdfReadOptions { Password = "open" });
 
+        Assert.True(result.CanAttempt);
         Assert.True(result.Succeeded);
         PdfDocument page = Assert.Single(result.RequireValue());
         Assert.Contains("Secret PDF Text", page.Read.Text(), StringComparison.Ordinal);

--- a/OfficeIMO.Tests/Pdf/PdfEncryptedReadTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfEncryptedReadTests.cs
@@ -72,6 +72,20 @@ public class PdfEncryptedReadTests {
     }
 
     [Fact]
+    public void StandardPasswordEncryptedPdf_SplitsWithPasswordAsUnencryptedOutputs() {
+        byte[] pdf = EncryptedPdfFixture.CreateRevision2("open", "owner", "Secret PDF Text");
+        var options = new PdfReadOptions { Password = "open" };
+
+        IReadOnlyList<byte[]> pages = PdfDocument.Open(pdf, options).Pages.Split()
+            .Select(page => page.ToBytes())
+            .ToArray();
+
+        Assert.Single(pages);
+        Assert.False(PdfInspector.Probe(pages[0]).HasEncryption);
+        Assert.Contains("Secret PDF Text", PdfTextExtractor.ExtractAllText(pages[0]), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void StandardPasswordEncryptedFormPdf_BlocksFormFillEvenWithValidPassword() {
         byte[] pdf = EncryptedPdfFixture.CreateRevision2WithTextField("open", "owner", "Secret PDF Text");
 

--- a/OfficeIMO.Tests/Pdf/PdfEncryptedReadTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfEncryptedReadTests.cs
@@ -97,6 +97,17 @@ public class PdfEncryptedReadTests {
     }
 
     [Fact]
+    public void StandardPasswordEncryptedPdf_TrySplitUsesSuppliedPassword() {
+        byte[] pdf = EncryptedPdfFixture.CreateRevision2("open", "owner", "Secret PDF Text");
+
+        PdfOperationResult<IReadOnlyList<PdfDocument>> result = PdfDocument.Open(pdf).Pages.TrySplit(new PdfReadOptions { Password = "open" });
+
+        Assert.True(result.Succeeded);
+        PdfDocument page = Assert.Single(result.RequireValue());
+        Assert.Contains("Secret PDF Text", page.Read.Text(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void StandardPasswordEncryptedPdf_ExtractWithWrongPasswordReportsPasswordError() {
         byte[] pdf = EncryptedPdfFixture.CreateRevision2WithPageLabels("open", "owner", "Secret PDF Text");
 

--- a/OfficeIMO.Tests/Pdf/PdfEncryptedReadTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfEncryptedReadTests.cs
@@ -86,6 +86,18 @@ public class PdfEncryptedReadTests {
     }
 
     [Fact]
+    public void StandardPasswordEncryptedPdf_ExtractsWithSupportedPageLabelsWhenPasswordProvided() {
+        byte[] pdf = EncryptedPdfFixture.CreateRevision2WithPageLabels("open", "owner", "Secret PDF Text");
+        var options = new PdfReadOptions { Password = "open" };
+
+        byte[] page = PdfPageExtractor.ExtractPages(pdf, options, 1);
+
+        Assert.False(PdfInspector.Probe(page).HasEncryption);
+        Assert.Contains("Secret PDF Text", PdfTextExtractor.ExtractAllText(page), StringComparison.Ordinal);
+    }
+
+
+    [Fact]
     public void StandardPasswordEncryptedFormPdf_BlocksFormFillEvenWithValidPassword() {
         byte[] pdf = EncryptedPdfFixture.CreateRevision2WithTextField("open", "owner", "Secret PDF Text");
 
@@ -117,7 +129,11 @@ public class PdfEncryptedReadTests {
             return CreateRevision2Core(userPassword, ownerPassword, visibleText, includeSignature: true, encryptGeneration: 0);
         }
 
-        private static byte[] CreateRevision2Core(string userPassword, string ownerPassword, string visibleText, bool includeSignature, int encryptGeneration) {
+        public static byte[] CreateRevision2WithPageLabels(string userPassword, string ownerPassword, string visibleText) {
+            return CreateRevision2Core(userPassword, ownerPassword, visibleText, includeSignature: false, encryptGeneration: 0, includePageLabels: true);
+        }
+
+        private static byte[] CreateRevision2Core(string userPassword, string ownerPassword, string visibleText, bool includeSignature, int encryptGeneration, bool includePageLabels = false) {
             byte[] fileId = new byte[] {
                 0x10, 0x45, 0xA8, 0x7C, 0x22, 0x18, 0x4E, 0xC1,
                 0x91, 0x4A, 0xCF, 0x66, 0x31, 0xD2, 0x74, 0x03
@@ -131,9 +147,16 @@ public class PdfEncryptedReadTests {
             byte[] encryptedContent = Rc4(ComputeObjectKey(fileKey, 5, 0), Encoding.ASCII.GetBytes(content));
 
             var objects = new List<byte[]>();
-            objects.Add(Ascii(includeSignature
-                ? "<< /Type /Catalog /Pages 2 0 R /AcroForm 7 0 R >>"
-                : "<< /Type /Catalog /Pages 2 0 R >>"));
+            string catalog = "<< /Type /Catalog /Pages 2 0 R";
+            if (includeSignature) {
+                catalog += " /AcroForm 7 0 R";
+            }
+
+            if (includePageLabels) {
+                catalog += " /PageLabels << /Nums [0 << /S /D >>] >>";
+            }
+
+            objects.Add(Ascii(catalog + " >>"));
             objects.Add(Ascii("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"));
             objects.Add(Ascii(includeSignature
                 ? "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 200] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R /Annots [8 0 R] >>"

--- a/OfficeIMO.Tests/Pdf/PdfEncryptedReadTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfEncryptedReadTests.cs
@@ -86,6 +86,24 @@ public class PdfEncryptedReadTests {
     }
 
     [Fact]
+    public void StandardPasswordEncryptedPdf_TrySplitSucceedsWhenOpenedWithPassword() {
+        byte[] pdf = EncryptedPdfFixture.CreateRevision2("open", "owner", "Secret PDF Text");
+
+        PdfOperationResult<IReadOnlyList<PdfDocument>> result = PdfDocument.Open(pdf, new PdfReadOptions { Password = "open" }).Pages.TrySplit();
+
+        Assert.True(result.Succeeded);
+        PdfDocument page = Assert.Single(result.RequireValue());
+        Assert.Contains("Secret PDF Text", page.Read.Text(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StandardPasswordEncryptedPdf_ExtractWithWrongPasswordReportsPasswordError() {
+        byte[] pdf = EncryptedPdfFixture.CreateRevision2WithPageLabels("open", "owner", "Secret PDF Text");
+
+        Assert.Throws<PdfInvalidPasswordException>(() => PdfPageExtractor.ExtractPages(pdf, new PdfReadOptions { Password = "wrong" }, 1));
+    }
+
+    [Fact]
     public void StandardPasswordEncryptedPdf_ExtractsWithSupportedPageLabelsWhenPasswordProvided() {
         byte[] pdf = EncryptedPdfFixture.CreateRevision2WithPageLabels("open", "owner", "Secret PDF Text");
         var options = new PdfReadOptions { Password = "open" };
@@ -94,6 +112,15 @@ public class PdfEncryptedReadTests {
 
         Assert.False(PdfInspector.Probe(page).HasEncryption);
         Assert.Contains("Secret PDF Text", PdfTextExtractor.ExtractAllText(page), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StandardPasswordEncryptedFormPdf_ExtractBlocksDecryptedFormMarkers() {
+        byte[] pdf = EncryptedPdfFixture.CreateRevision2WithTextField("open", "owner", "Secret PDF Text");
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(() => PdfPageExtractor.ExtractPages(pdf, new PdfReadOptions { Password = "open" }, 1));
+
+        Assert.Contains("PDF form fields are not supported", exception.Message, StringComparison.Ordinal);
     }
 
 

--- a/OfficeIMO.Tests/Pdf/PdfITextInspiredCoverageTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfITextInspiredCoverageTests.cs
@@ -409,6 +409,22 @@ public class PdfITextInspiredCoverageTests {
     }
 
     [Fact]
+    public void PageEditor_ResizePagesConvertsRotatedPartialXyzDestinationsToConcretePoints() {
+        byte[] pdf = BuildResizableRotatedPartialXyzDestinationPdf();
+
+        byte[] resized = PdfPageEditor.ResizePages(pdf, new PdfPageResizeOptions(new PageSize(600, 600)) {
+            Mode = PdfPageResizeMode.Stretch
+        });
+
+        PdfDocumentInfo info = PdfInspector.Inspect(resized);
+
+        Assert.NotNull(info.OpenAction);
+        Assert.Equal(PdfOpenActionDestinationMode.Xyz, info.OpenAction!.DestinationMode);
+        Assert.Equal(420, info.OpenAction.DestinationLeft);
+        Assert.Equal(600, info.OpenAction.DestinationTop);
+    }
+
+    [Fact]
     public void PageEditor_ResizePagesTransformsSharedIndirectDestinationsOnce() {
         byte[] pdf = BuildResizableSharedDestinationPdf();
 
@@ -423,6 +439,39 @@ public class PdfITextInspiredCoverageTests {
             Assert.Equal(60, link.DestinationLeft);
             Assert.Equal(420, link.DestinationTop);
         });
+        Assert.NotNull(info.OpenAction);
+        Assert.Equal(60, info.OpenAction!.DestinationLeft);
+        Assert.Equal(420, info.OpenAction.DestinationTop);
+    }
+
+    [Fact]
+    public void PageEditor_ResizePagesTransformsIndirectAnnotationGeometryArrays() {
+        byte[] pdf = BuildResizableIndirectAnnotationGeometryPdf();
+
+        byte[] resized = PdfPageEditor.ResizePages(pdf, new PdfPageResizeOptions(new PageSize(600, 600)) {
+            Mode = PdfPageResizeMode.Stretch
+        });
+        string raw = PdfEncoding.Latin1GetString(resized);
+
+        Assert.Contains("/QuadPoints [ 60 420 180 420 60 360 180 360 ]", raw, StringComparison.Ordinal);
+        Assert.Contains("/InkList [ [ 60 420 180 360 ] ]", raw, StringComparison.Ordinal);
+        Assert.DoesNotContain("/QuadPoints 7 0 R", raw, StringComparison.Ordinal);
+        Assert.DoesNotContain("/InkList 8 0 R", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PageEditor_ResizePagesRemapsPopupAnnotationReferencesToTransformedClones() {
+        byte[] pdf = BuildResizablePopupAnnotationPdf();
+
+        byte[] resized = PdfPageEditor.ResizePages(pdf, new PdfPageResizeOptions(new PageSize(600, 600)) {
+            Mode = PdfPageResizeMode.Stretch
+        });
+        string raw = PdfEncoding.Latin1GetString(resized);
+
+        Assert.DoesNotContain("/Rect [ 50 50 150 120 ]", raw, StringComparison.Ordinal);
+        Assert.Contains("/Rect [ 240 240 840 660 ]", raw, StringComparison.Ordinal);
+        Assert.Contains("/Popup", raw, StringComparison.Ordinal);
+        Assert.Contains("/Parent", raw, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -779,9 +828,21 @@ public class PdfITextInspiredCoverageTests {
         return Encoding.ASCII.GetBytes(BuildPdf(objects));
     }
 
+    private static byte[] BuildResizableRotatedPartialXyzDestinationPdf() {
+        var objects = new List<string> {
+            "<< /Type /Catalog /Pages 2 0 R /OpenAction [3 0 R /XYZ null 80 1] >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /CropBox [10 10 110 110] /Rotate 90 /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+            BuildStream(Encoding.ASCII.GetBytes("BT /F1 12 Tf 20 20 Td (Partial XYZ target) Tj ET"))
+        };
+
+        return Encoding.ASCII.GetBytes(BuildPdf(objects));
+    }
+
     private static byte[] BuildResizableSharedDestinationPdf() {
         var objects = new List<string> {
-            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Catalog /Pages 2 0 R /OpenAction 8 0 R >>",
             "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
             "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /CropBox [10 10 110 110] /Resources << /Font << /F1 4 0 R >> >> /Annots [6 0 R 7 0 R] /Contents 5 0 R >>",
             "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
@@ -789,6 +850,35 @@ public class PdfITextInspiredCoverageTests {
             "<< /Type /Annot /Subtype /Link /Rect [20 30 40 50] /Dest 8 0 R >>",
             "<< /Type /Annot /Subtype /Link /Rect [60 30 80 50] /Dest 8 0 R >>",
             "[3 0 R /XYZ 20 80 1]"
+        };
+
+        return Encoding.ASCII.GetBytes(BuildPdf(objects));
+    }
+
+    private static byte[] BuildResizableIndirectAnnotationGeometryPdf() {
+        var objects = new List<string> {
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /CropBox [10 10 110 110] /Resources << /Font << /F1 4 0 R >> >> /Annots [6 0 R] /Contents 5 0 R >>",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+            BuildStream(Encoding.ASCII.GetBytes("BT /F1 12 Tf 20 20 Td (Indirect geometry) Tj ET")),
+            "<< /Type /Annot /Subtype /Link /Rect [20 30 40 50] /QuadPoints 7 0 R /InkList 8 0 R /Dest [3 0 R /XYZ 20 80 1] >>",
+            "[20 80 40 80 20 70 40 70]",
+            "[[20 80 40 70]]"
+        };
+
+        return Encoding.ASCII.GetBytes(BuildPdf(objects));
+    }
+
+    private static byte[] BuildResizablePopupAnnotationPdf() {
+        var objects = new List<string> {
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /CropBox [10 10 110 110] /Resources << /Font << /F1 4 0 R >> >> /Annots [6 0 R 7 0 R] /Contents 5 0 R >>",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+            BuildStream(Encoding.ASCII.GetBytes("BT /F1 12 Tf 20 20 Td (Popup geometry) Tj ET")),
+            "<< /Type /Annot /Subtype /Text /Rect [20 30 40 50] /Popup 7 0 R /Contents (Note) >>",
+            "<< /Type /Annot /Subtype /Popup /Rect [50 50 150 120] /Parent 6 0 R >>"
         };
 
         return Encoding.ASCII.GetBytes(BuildPdf(objects));

--- a/OfficeIMO.Tests/Pdf/PdfITextInspiredCoverageTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfITextInspiredCoverageTests.cs
@@ -425,6 +425,24 @@ public class PdfITextInspiredCoverageTests {
     }
 
     [Fact]
+    public void PageEditor_ResizePagesFillClipsToMarginBoxBeforeScaling() {
+        byte[] pdf = BuildResizableTallPagePdf();
+
+        byte[] resized = PdfPageEditor.ResizePages(pdf, new PdfPageResizeOptions(new PageSize(600, 600)) {
+            Mode = PdfPageResizeMode.Fill,
+            Margin = 50
+        });
+        string raw = PdfEncoding.Latin1GetString(resized);
+
+        int targetClip = raw.IndexOf("50 50 500 500 re\nW n\n", StringComparison.Ordinal);
+        int transform = raw.IndexOf("5 0 0 5 50 -450 cm\n", StringComparison.Ordinal);
+        int sourceClip = raw.IndexOf("0 0 100 300 re\nW n\n", StringComparison.Ordinal);
+        Assert.True(targetClip >= 0, "Expected resized content stream to clip to the target margin box.");
+        Assert.True(transform > targetClip, "Expected target-space margin clipping before the resize transform.");
+        Assert.True(sourceClip > transform, "Expected source-space clipping after the resize transform.");
+    }
+
+    [Fact]
     public void PageEditor_ResizePagesTransformsSharedIndirectDestinationsOnce() {
         byte[] pdf = BuildResizableSharedDestinationPdf();
 
@@ -835,6 +853,18 @@ public class PdfITextInspiredCoverageTests {
             "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /CropBox [10 10 110 110] /Rotate 90 /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
             "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
             BuildStream(Encoding.ASCII.GetBytes("BT /F1 12 Tf 20 20 Td (Partial XYZ target) Tj ET"))
+        };
+
+        return Encoding.ASCII.GetBytes(BuildPdf(objects));
+    }
+
+    private static byte[] BuildResizableTallPagePdf() {
+        var objects = new List<string> {
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 300] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+            BuildStream(Encoding.ASCII.GetBytes("BT /F1 12 Tf 10 280 Td (Fill should crop to margins) Tj ET"))
         };
 
         return Encoding.ASCII.GetBytes(BuildPdf(objects));

--- a/OfficeIMO.Tests/Pdf/PdfITextInspiredCoverageTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfITextInspiredCoverageTests.cs
@@ -443,6 +443,26 @@ public class PdfITextInspiredCoverageTests {
     }
 
     [Fact]
+    public void PageEditor_ResizePagesFillClipsAnnotationRectanglesToMarginBox() {
+        byte[] pdf = BuildResizableTallPageWithCroppedAnnotationsPdf();
+
+        byte[] resized = PdfPageEditor.ResizePages(pdf, new PdfPageResizeOptions(new PageSize(600, 600)) {
+            Mode = PdfPageResizeMode.Fill,
+            Margin = 50
+        });
+        PdfDocumentInfo info = PdfInspector.Inspect(resized);
+        string raw = PdfEncoding.Latin1GetString(resized);
+
+        PdfAnnotation annotation = Assert.Single(info.GetAnnotationsBySubtype("Link"));
+        Assert.Equal(100, annotation.X1);
+        Assert.Equal(50, annotation.Y1);
+        Assert.Equal(200, annotation.X2);
+        Assert.Equal(100, annotation.Y2);
+        Assert.Contains("/Rect [ 100 50 200 100 ]", raw, StringComparison.Ordinal);
+        Assert.DoesNotContain("https://example.com/clipped-away", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void PageEditor_ResizePagesTransformsSharedIndirectDestinationsOnce() {
         byte[] pdf = BuildResizableSharedDestinationPdf();
 
@@ -489,7 +509,7 @@ public class PdfITextInspiredCoverageTests {
         string raw = PdfEncoding.Latin1GetString(resized);
 
         Assert.DoesNotContain("/Rect [ 50 50 150 120 ]", raw, StringComparison.Ordinal);
-        Assert.Contains("/Rect [ 240 240 840 660 ]", raw, StringComparison.Ordinal);
+        Assert.Contains("/Rect [ 240 240 600 600 ]", raw, StringComparison.Ordinal);
         Assert.Contains("/Popup", raw, StringComparison.Ordinal);
         Assert.Contains("/Parent", raw, StringComparison.Ordinal);
     }
@@ -880,6 +900,20 @@ public class PdfITextInspiredCoverageTests {
             "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 300] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
             "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
             BuildStream(Encoding.ASCII.GetBytes("BT /F1 12 Tf 10 280 Td (Fill should crop to margins) Tj ET"))
+        };
+
+        return Encoding.ASCII.GetBytes(BuildPdf(objects));
+    }
+
+    private static byte[] BuildResizableTallPageWithCroppedAnnotationsPdf() {
+        var objects = new List<string> {
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 300] /Resources << /Font << /F1 4 0 R >> >> /Annots [6 0 R 7 0 R] /Contents 5 0 R >>",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+            BuildStream(Encoding.ASCII.GetBytes("BT /F1 12 Tf 10 280 Td (Fill annotations should crop to margins) Tj ET")),
+            "<< /Type /Annot /Subtype /Link /Rect [10 90 30 110] /A << /S /URI /URI (https://example.com/kept) >> >>",
+            "<< /Type /Annot /Subtype /Link /Rect [10 10 30 20] /A << /S /URI /URI (https://example.com/clipped-away) >> >>"
         };
 
         return Encoding.ASCII.GetBytes(BuildPdf(objects));

--- a/OfficeIMO.Tests/Pdf/PdfITextInspiredCoverageTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfITextInspiredCoverageTests.cs
@@ -471,10 +471,12 @@ public class PdfITextInspiredCoverageTests {
         });
         string raw = PdfEncoding.Latin1GetString(resized);
 
+        Assert.Contains("/Rect [ 60 120 180 240 ]", raw, StringComparison.Ordinal);
         Assert.Contains("/QuadPoints [ 60 420 180 420 60 360 180 360 ]", raw, StringComparison.Ordinal);
         Assert.Contains("/InkList [ [ 60 420 180 360 ] ]", raw, StringComparison.Ordinal);
-        Assert.DoesNotContain("/QuadPoints 7 0 R", raw, StringComparison.Ordinal);
-        Assert.DoesNotContain("/InkList 8 0 R", raw, StringComparison.Ordinal);
+        Assert.DoesNotContain("/Rect 7 0 R", raw, StringComparison.Ordinal);
+        Assert.DoesNotContain("/QuadPoints 8 0 R", raw, StringComparison.Ordinal);
+        Assert.DoesNotContain("/InkList 9 0 R", raw, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -905,7 +907,8 @@ public class PdfITextInspiredCoverageTests {
             "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /CropBox [10 10 110 110] /Resources << /Font << /F1 4 0 R >> >> /Annots [6 0 R] /Contents 5 0 R >>",
             "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
             BuildStream(Encoding.ASCII.GetBytes("BT /F1 12 Tf 20 20 Td (Indirect geometry) Tj ET")),
-            "<< /Type /Annot /Subtype /Link /Rect [20 30 40 50] /QuadPoints 7 0 R /InkList 8 0 R /Dest [3 0 R /XYZ 20 80 1] >>",
+            "<< /Type /Annot /Subtype /Link /Rect 7 0 R /QuadPoints 8 0 R /InkList 9 0 R /Dest [3 0 R /XYZ 20 80 1] >>",
+            "[20 30 40 50]",
             "[20 80 40 80 20 70 40 70]",
             "[[20 80 40 70]]"
         };

--- a/OfficeIMO.Tests/Pdf/PdfITextInspiredCoverageTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfITextInspiredCoverageTests.cs
@@ -334,6 +334,29 @@ public class PdfITextInspiredCoverageTests {
     }
 
     [Fact]
+    public void PageEditor_ResizePagesTransformsAnnotationsAndNormalizesProductionBoxes() {
+        byte[] pdf = BuildResizableAnnotatedPagePdf();
+
+        byte[] resized = PdfPageEditor.ResizePages(pdf, new PdfPageResizeOptions(new PageSize(600, 600)) {
+            Mode = PdfPageResizeMode.Stretch
+        });
+
+        PdfDocumentInfo info = PdfInspector.Inspect(resized);
+        PdfPageGeometry geometry = info.Pages[0].Geometry!;
+        PdfAnnotation annotation = Assert.Single(info.GetAnnotationsBySubtype("Link"));
+
+        Assert.Equal(600, geometry.MediaBox.Width);
+        Assert.Equal(600, geometry.CropBox!.Width);
+        Assert.Equal(600, geometry.TrimBox!.Width);
+        Assert.Equal(600, geometry.BleedBox!.Width);
+        Assert.Equal(600, geometry.ArtBox!.Width);
+        Assert.Equal(40, annotation.X1);
+        Assert.Equal(60, annotation.Y1);
+        Assert.Equal(80, annotation.X2);
+        Assert.Equal(100, annotation.Y2);
+    }
+
+    [Fact]
     public void SecurityInfo_ReportsObjectStreamRewriteReadiness() {
         byte[] pdf = Encoding.ASCII.GetBytes(string.Join("\n", new[] {
             "%PDF-1.7",
@@ -643,6 +666,19 @@ public class PdfITextInspiredCoverageTests {
         };
 
         return Encoding.ASCII.GetBytes(BuildPdf(objects).Replace("%PDF-1.7", "%PDF-" + version));
+    }
+
+    private static byte[] BuildResizableAnnotatedPagePdf() {
+        var objects = new List<string> {
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /CropBox [0 0 300 300] /BleedBox [5 5 295 295] /TrimBox [10 10 290 290] /ArtBox [20 20 280 280] /Resources << /Font << /F1 4 0 R >> >> /Annots [6 0 R] /Contents 5 0 R >>",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+            BuildStream(Encoding.ASCII.GetBytes("BT /F1 12 Tf 20 20 Td (Resize source) Tj ET")),
+            "<< /Type /Annot /Subtype /Link /Rect [20 30 40 50] /A << /S /URI /URI (https://example.com) >> >>"
+        };
+
+        return Encoding.ASCII.GetBytes(BuildPdf(objects));
     }
 
     private static string BuildStream(byte[] data) =>

--- a/OfficeIMO.Tests/Pdf/PdfITextInspiredCoverageTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfITextInspiredCoverageTests.cs
@@ -351,27 +351,45 @@ public class PdfITextInspiredCoverageTests {
         Assert.Equal(600, geometry.TrimBox!.Width);
         Assert.Equal(600, geometry.BleedBox!.Width);
         Assert.Equal(600, geometry.ArtBox!.Width);
-        Assert.Equal(60, annotation.X1);
-        Assert.Equal(120, annotation.Y1);
-        Assert.Equal(180, annotation.X2);
-        Assert.Equal(240, annotation.Y2);
+        Assert.Equal(120, annotation.X1);
+        Assert.Equal(420, annotation.Y1);
+        Assert.Equal(240, annotation.X2);
+        Assert.Equal(540, annotation.Y2);
         Assert.Contains("/UserUnit 1", raw, StringComparison.Ordinal);
         Assert.Contains("/Rotate 0", raw, StringComparison.Ordinal);
+        Assert.Contains("0 -6 6 0 -60 660 cm", raw, StringComparison.Ordinal);
         Assert.Contains("10 10 100 100 re\nW n", raw, StringComparison.Ordinal);
-        Assert.Contains("/QuadPoints [ 60 420 180 420 60 360 180 360 ]", raw, StringComparison.Ordinal);
-        Assert.Contains("/L [ 60 120 180 240 ]", raw, StringComparison.Ordinal);
-        Assert.Contains("/Vertices [ 60 120 180 240 ]", raw, StringComparison.Ordinal);
-        Assert.Contains("/InkList [ [ 60 120 180 240 ] ]", raw, StringComparison.Ordinal);
+        Assert.Contains("/QuadPoints [ 420 540 420 420 360 540 360 420 ]", raw, StringComparison.Ordinal);
+        Assert.Contains("/L [ 120 540 240 420 ]", raw, StringComparison.Ordinal);
+        Assert.Contains("/Vertices [ 120 540 240 420 ]", raw, StringComparison.Ordinal);
+        Assert.Contains("/InkList [ [ 120 540 240 420 ] ]", raw, StringComparison.Ordinal);
 
         Assert.NotNull(info.OpenAction);
-        Assert.Equal(60, info.OpenAction!.DestinationLeft);
-        Assert.Equal(420, info.OpenAction.DestinationTop);
+        Assert.Equal(420, info.OpenAction!.DestinationLeft);
+        Assert.Equal(540, info.OpenAction.DestinationTop);
         PdfNamedDestination namedDestination = Assert.Single(info.NamedDestinations, destination => destination.Name == "Target");
-        Assert.Equal(60, namedDestination.DestinationLeft);
-        Assert.Equal(420, namedDestination.DestinationTop);
+        Assert.Equal(420, namedDestination.DestinationLeft);
+        Assert.Equal(540, namedDestination.DestinationTop);
         PdfOutlineItem outline = Assert.Single(info.Outlines);
-        Assert.Equal(60, outline.DestinationLeft);
-        Assert.Equal(420, outline.DestinationTop);
+        Assert.Equal(420, outline.DestinationLeft);
+        Assert.Equal(540, outline.DestinationTop);
+    }
+
+    [Fact]
+    public void PageEditor_ResizePagesTransformsDestinationsFromUnresizedPages() {
+        byte[] pdf = BuildResizableTwoPageLinkPdf();
+
+        byte[] resized = PdfPageEditor.ResizePages(pdf, new PdfPageResizeOptions(new PageSize(600, 600)) {
+            Mode = PdfPageResizeMode.Stretch
+        }, 1);
+
+        PdfDocumentInfo info = PdfInspector.Inspect(resized);
+        PdfLinkAnnotation link = Assert.Single(info.Pages[1].LinkAnnotations);
+
+        Assert.Equal(60, link.DestinationLeft);
+        Assert.Equal(420, link.DestinationTop);
+        Assert.Equal(600, info.Pages[0].Geometry!.MediaBox.Width);
+        Assert.Equal(300, info.Pages[1].Geometry!.MediaBox.Width);
     }
 
     [Fact]
@@ -696,6 +714,21 @@ public class PdfITextInspiredCoverageTests {
             "<< /Type /Annot /Subtype /Link /Rect [20 30 40 50] /QuadPoints [20 80 40 80 20 70 40 70] /L [20 30 40 50] /Vertices [20 30 40 50] /InkList [[20 30 40 50]] /Dest [3 0 R /XYZ 20 80 1] >>",
             "<< /Type /Outlines /First 8 0 R /Last 8 0 R /Count 1 >>",
             "<< /Title (Target) /Parent 7 0 R /Dest [3 0 R /XYZ 20 80 1] >>"
+        };
+
+        return Encoding.ASCII.GetBytes(BuildPdf(objects));
+    }
+
+    private static byte[] BuildResizableTwoPageLinkPdf() {
+        var objects = new List<string> {
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Count 2 /Kids [3 0 R 7 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /CropBox [10 10 110 110] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+            BuildStream(Encoding.ASCII.GetBytes("BT /F1 12 Tf 20 20 Td (Resize target) Tj ET")),
+            BuildStream(Encoding.ASCII.GetBytes("BT /F1 12 Tf 20 20 Td (Link source) Tj ET")),
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Resources << /Font << /F1 4 0 R >> >> /Annots [8 0 R] /Contents 6 0 R >>",
+            "<< /Type /Annot /Subtype /Link /Rect [20 30 40 50] /Dest [3 0 R /XYZ 20 80 1] >>"
         };
 
         return Encoding.ASCII.GetBytes(BuildPdf(objects));

--- a/OfficeIMO.Tests/Pdf/PdfITextInspiredCoverageTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfITextInspiredCoverageTests.cs
@@ -344,16 +344,30 @@ public class PdfITextInspiredCoverageTests {
         PdfDocumentInfo info = PdfInspector.Inspect(resized);
         PdfPageGeometry geometry = info.Pages[0].Geometry!;
         PdfAnnotation annotation = Assert.Single(info.GetAnnotationsBySubtype("Link"));
+        string raw = Encoding.ASCII.GetString(resized);
 
         Assert.Equal(600, geometry.MediaBox.Width);
         Assert.Equal(600, geometry.CropBox!.Width);
         Assert.Equal(600, geometry.TrimBox!.Width);
         Assert.Equal(600, geometry.BleedBox!.Width);
         Assert.Equal(600, geometry.ArtBox!.Width);
-        Assert.Equal(40, annotation.X1);
-        Assert.Equal(60, annotation.Y1);
-        Assert.Equal(80, annotation.X2);
-        Assert.Equal(100, annotation.Y2);
+        Assert.Equal(60, annotation.X1);
+        Assert.Equal(120, annotation.Y1);
+        Assert.Equal(180, annotation.X2);
+        Assert.Equal(240, annotation.Y2);
+        Assert.Contains("/UserUnit 1", raw, StringComparison.Ordinal);
+        Assert.Contains("/Rotate 0", raw, StringComparison.Ordinal);
+        Assert.Contains("10 10 100 100 re\nW n", raw, StringComparison.Ordinal);
+
+        Assert.NotNull(info.OpenAction);
+        Assert.Equal(60, info.OpenAction!.DestinationLeft);
+        Assert.Equal(420, info.OpenAction.DestinationTop);
+        PdfNamedDestination namedDestination = Assert.Single(info.NamedDestinations, destination => destination.Name == "Target");
+        Assert.Equal(60, namedDestination.DestinationLeft);
+        Assert.Equal(420, namedDestination.DestinationTop);
+        PdfOutlineItem outline = Assert.Single(info.Outlines);
+        Assert.Equal(60, outline.DestinationLeft);
+        Assert.Equal(420, outline.DestinationTop);
     }
 
     [Fact]
@@ -670,12 +684,14 @@ public class PdfITextInspiredCoverageTests {
 
     private static byte[] BuildResizableAnnotatedPagePdf() {
         var objects = new List<string> {
-            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Catalog /Pages 2 0 R /OpenAction [3 0 R /XYZ 20 80 1] /Dests << /Target [3 0 R /XYZ 20 80 1] >> /Outlines 7 0 R >>",
             "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
-            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /CropBox [0 0 300 300] /BleedBox [5 5 295 295] /TrimBox [10 10 290 290] /ArtBox [20 20 280 280] /Resources << /Font << /F1 4 0 R >> >> /Annots [6 0 R] /Contents 5 0 R >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /CropBox [10 10 110 110] /BleedBox [5 5 295 295] /TrimBox [10 10 290 290] /ArtBox [20 20 280 280] /UserUnit 2 /Rotate 90 /Resources << /Font << /F1 4 0 R >> >> /Annots [6 0 R] /Contents 5 0 R >>",
             "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
             BuildStream(Encoding.ASCII.GetBytes("BT /F1 12 Tf 20 20 Td (Resize source) Tj ET")),
-            "<< /Type /Annot /Subtype /Link /Rect [20 30 40 50] /A << /S /URI /URI (https://example.com) >> >>"
+            "<< /Type /Annot /Subtype /Link /Rect [20 30 40 50] /Dest [3 0 R /XYZ 20 80 1] >>",
+            "<< /Type /Outlines /First 8 0 R /Last 8 0 R /Count 1 >>",
+            "<< /Title (Target) /Parent 7 0 R /Dest [3 0 R /XYZ 20 80 1] >>"
         };
 
         return Encoding.ASCII.GetBytes(BuildPdf(objects));

--- a/OfficeIMO.Tests/Pdf/PdfITextInspiredCoverageTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfITextInspiredCoverageTests.cs
@@ -358,6 +358,10 @@ public class PdfITextInspiredCoverageTests {
         Assert.Contains("/UserUnit 1", raw, StringComparison.Ordinal);
         Assert.Contains("/Rotate 0", raw, StringComparison.Ordinal);
         Assert.Contains("10 10 100 100 re\nW n", raw, StringComparison.Ordinal);
+        Assert.Contains("/QuadPoints [ 60 420 180 420 60 360 180 360 ]", raw, StringComparison.Ordinal);
+        Assert.Contains("/L [ 60 120 180 240 ]", raw, StringComparison.Ordinal);
+        Assert.Contains("/Vertices [ 60 120 180 240 ]", raw, StringComparison.Ordinal);
+        Assert.Contains("/InkList [ [ 60 120 180 240 ] ]", raw, StringComparison.Ordinal);
 
         Assert.NotNull(info.OpenAction);
         Assert.Equal(60, info.OpenAction!.DestinationLeft);
@@ -689,7 +693,7 @@ public class PdfITextInspiredCoverageTests {
             "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /CropBox [10 10 110 110] /BleedBox [5 5 295 295] /TrimBox [10 10 290 290] /ArtBox [20 20 280 280] /UserUnit 2 /Rotate 90 /Resources << /Font << /F1 4 0 R >> >> /Annots [6 0 R] /Contents 5 0 R >>",
             "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
             BuildStream(Encoding.ASCII.GetBytes("BT /F1 12 Tf 20 20 Td (Resize source) Tj ET")),
-            "<< /Type /Annot /Subtype /Link /Rect [20 30 40 50] /Dest [3 0 R /XYZ 20 80 1] >>",
+            "<< /Type /Annot /Subtype /Link /Rect [20 30 40 50] /QuadPoints [20 80 40 80 20 70 40 70] /L [20 30 40 50] /Vertices [20 30 40 50] /InkList [[20 30 40 50]] /Dest [3 0 R /XYZ 20 80 1] >>",
             "<< /Type /Outlines /First 8 0 R /Last 8 0 R /Count 1 >>",
             "<< /Title (Target) /Parent 7 0 R /Dest [3 0 R /XYZ 20 80 1] >>"
         };

--- a/OfficeIMO.Tests/Pdf/PdfITextInspiredCoverageTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfITextInspiredCoverageTests.cs
@@ -393,6 +393,39 @@ public class PdfITextInspiredCoverageTests {
     }
 
     [Fact]
+    public void PageEditor_ResizePagesConvertsRotatedFitDestinationsToConcretePoints() {
+        byte[] pdf = BuildResizableRotatedFitDestinationPdf();
+
+        byte[] resized = PdfPageEditor.ResizePages(pdf, new PdfPageResizeOptions(new PageSize(600, 600)) {
+            Mode = PdfPageResizeMode.Stretch
+        });
+
+        PdfDocumentInfo info = PdfInspector.Inspect(resized);
+
+        Assert.NotNull(info.OpenAction);
+        Assert.Equal(PdfOpenActionDestinationMode.Xyz, info.OpenAction!.DestinationMode);
+        Assert.Equal(420, info.OpenAction.DestinationLeft);
+        Assert.Equal(600, info.OpenAction.DestinationTop);
+    }
+
+    [Fact]
+    public void PageEditor_ResizePagesTransformsSharedIndirectDestinationsOnce() {
+        byte[] pdf = BuildResizableSharedDestinationPdf();
+
+        byte[] resized = PdfPageEditor.ResizePages(pdf, new PdfPageResizeOptions(new PageSize(600, 600)) {
+            Mode = PdfPageResizeMode.Stretch
+        });
+
+        PdfDocumentInfo info = PdfInspector.Inspect(resized);
+
+        Assert.Equal(2, info.Pages[0].LinkAnnotations.Count);
+        Assert.All(info.Pages[0].LinkAnnotations, link => {
+            Assert.Equal(60, link.DestinationLeft);
+            Assert.Equal(420, link.DestinationTop);
+        });
+    }
+
+    [Fact]
     public void SecurityInfo_ReportsObjectStreamRewriteReadiness() {
         byte[] pdf = Encoding.ASCII.GetBytes(string.Join("\n", new[] {
             "%PDF-1.7",
@@ -729,6 +762,33 @@ public class PdfITextInspiredCoverageTests {
             BuildStream(Encoding.ASCII.GetBytes("BT /F1 12 Tf 20 20 Td (Link source) Tj ET")),
             "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Resources << /Font << /F1 4 0 R >> >> /Annots [8 0 R] /Contents 6 0 R >>",
             "<< /Type /Annot /Subtype /Link /Rect [20 30 40 50] /Dest [3 0 R /XYZ 20 80 1] >>"
+        };
+
+        return Encoding.ASCII.GetBytes(BuildPdf(objects));
+    }
+
+    private static byte[] BuildResizableRotatedFitDestinationPdf() {
+        var objects = new List<string> {
+            "<< /Type /Catalog /Pages 2 0 R /OpenAction [3 0 R /FitH 80] >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /CropBox [10 10 110 110] /Rotate 90 /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+            BuildStream(Encoding.ASCII.GetBytes("BT /F1 12 Tf 20 20 Td (Fit target) Tj ET"))
+        };
+
+        return Encoding.ASCII.GetBytes(BuildPdf(objects));
+    }
+
+    private static byte[] BuildResizableSharedDestinationPdf() {
+        var objects = new List<string> {
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /CropBox [10 10 110 110] /Resources << /Font << /F1 4 0 R >> >> /Annots [6 0 R 7 0 R] /Contents 5 0 R >>",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+            BuildStream(Encoding.ASCII.GetBytes("BT /F1 12 Tf 20 20 Td (Shared target) Tj ET")),
+            "<< /Type /Annot /Subtype /Link /Rect [20 30 40 50] /Dest 8 0 R >>",
+            "<< /Type /Annot /Subtype /Link /Rect [60 30 80 50] /Dest 8 0 R >>",
+            "[3 0 R /XYZ 20 80 1]"
         };
 
         return Encoding.ASCII.GetBytes(BuildPdf(objects));

--- a/OfficeIMO.Tests/Pdf/PdfITextInspiredCoverageTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfITextInspiredCoverageTests.cs
@@ -493,6 +493,19 @@ public class PdfITextInspiredCoverageTests {
     }
 
     [Fact]
+    public void PageEditor_ResizePagesCollectsClonedAnnotationActionDependencies() {
+        byte[] pdf = BuildResizableAnnotationActionPdf();
+
+        byte[] resized = PdfPageEditor.ResizePages(pdf, new PdfPageResizeOptions(new PageSize(600, 600)) {
+            Mode = PdfPageResizeMode.Stretch
+        });
+        string raw = PdfEncoding.Latin1GetString(resized);
+
+        Assert.Contains("/A ", raw, StringComparison.Ordinal);
+        Assert.Contains("/URI (https://example.com/review)", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void SecurityInfo_ReportsObjectStreamRewriteReadiness() {
         byte[] pdf = Encoding.ASCII.GetBytes(string.Join("\n", new[] {
             "%PDF-1.7",
@@ -909,6 +922,20 @@ public class PdfITextInspiredCoverageTests {
             BuildStream(Encoding.ASCII.GetBytes("BT /F1 12 Tf 20 20 Td (Popup geometry) Tj ET")),
             "<< /Type /Annot /Subtype /Text /Rect [20 30 40 50] /Popup 7 0 R /Contents (Note) >>",
             "<< /Type /Annot /Subtype /Popup /Rect [50 50 150 120] /Parent 6 0 R >>"
+        };
+
+        return Encoding.ASCII.GetBytes(BuildPdf(objects));
+    }
+
+    private static byte[] BuildResizableAnnotationActionPdf() {
+        var objects = new List<string> {
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /CropBox [10 10 110 110] /Resources << /Font << /F1 4 0 R >> >> /Annots [6 0 R] /Contents 5 0 R >>",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+            BuildStream(Encoding.ASCII.GetBytes("BT /F1 12 Tf 20 20 Td (Action dependency) Tj ET")),
+            "<< /Type /Annot /Subtype /Link /Rect [20 30 40 50] /A 7 0 R >>",
+            "<< /S /URI /URI (https://example.com/review) >>"
         };
 
         return Encoding.ASCII.GetBytes(BuildPdf(objects));

--- a/OfficeIMO.Tests/Pdf/PdfMergerTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfMergerTests.cs
@@ -95,6 +95,40 @@ public class PdfMergerTests {
     }
 
     [Fact]
+    public void Merge_WithResizePagesOption_NormalizesMixedSourcePageSizes() {
+        byte[] first = BuildPdf(
+            "Mixed size first",
+            "Letter source page",
+            ("Small source page", new PageSize(300, 500)));
+        byte[] second = BuildPdf(
+            "Mixed size second",
+            "Landscape source page",
+            ("A4 source page", PageSizes.A4));
+
+        byte[] merged = PdfMerger.Merge(
+            new PdfMergeOptions {
+                ResizePages = new PdfPageResizeOptions(PageSizes.A4) {
+                    Margin = 12,
+                    Mode = PdfPageResizeMode.Fit
+                }
+            },
+            first,
+            second);
+
+        PdfDocumentInfo info = PdfInspector.Inspect(merged);
+        Assert.Equal(4, info.PageCount);
+        Assert.All(info.Pages, page => {
+            Assert.Equal(595, Math.Round(page.Width));
+            Assert.Equal(842, Math.Round(page.Height));
+        });
+
+        string pdf = Encoding.ASCII.GetString(merged);
+        Assert.Contains(" cm", pdf, StringComparison.Ordinal);
+        string text = NormalizeExtractedText(PdfReadDocument.Load(merged).ExtractText());
+        AssertContainsInOrder(text, "Lettersourcepage", "Smallsourcepage", "Landscapesourcepage", "A4sourcepage");
+    }
+
+    [Fact]
     public void Merge_ReadsStreamsFromCurrentPositions() {
         using var first = CreatePrefixedStream(BuildPdf("First stream", "First stream page"));
         using var second = CreatePrefixedStream(BuildPdf("Second stream", "Second stream page"));

--- a/OfficeIMO.Tests/Pdf/PdfPageEditorWrapperPipelineTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfPageEditorWrapperPipelineTests.cs
@@ -122,6 +122,15 @@ public partial class PdfPageEditorTests {
             Assert.Equal(270, rotatedRangesInfo.Pages[0].RotationDegrees);
             Assert.Equal(0, rotatedRangesInfo.Pages[1].RotationDegrees);
             Assert.Equal(270, rotatedRangesInfo.Pages[2].RotationDegrees);
+
+            byte[] resized = PdfPageEditor.ResizePages(inputPath, PageSizes.Letter, 3);
+            PdfDocumentInfo resizedInfo = PdfInspector.Inspect(resized);
+            Assert.Equal(3, resizedInfo.PageCount);
+            Assert.Equal(595, Math.Round(resizedInfo.Pages[0].Width));
+            Assert.Equal(842, Math.Round(resizedInfo.Pages[0].Height));
+            Assert.Equal(612, Math.Round(resizedInfo.Pages[2].Width));
+            Assert.Equal(792, Math.Round(resizedInfo.Pages[2].Height));
+            Assert.Contains("Thirdpagemarker", NormalizeExtractedText(PdfReadDocument.Load(resized).ExtractText()));
         } finally {
             if (Directory.Exists(directory)) {
                 Directory.Delete(directory, recursive: true);

--- a/OfficeIMO.Tests/Pdf/PdfPageExtractorValidationTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfPageExtractorValidationTests.cs
@@ -46,7 +46,7 @@ public partial class PdfPageExtractorTests {
         Assert.Throws<ArgumentNullException>(() => PdfPageExtractor.ExtractPageRanges((Stream)null!, PdfPageRange.From(1, 1)));
         Assert.Throws<ArgumentNullException>(() => PdfPageExtractor.ExtractPageRanges(new MemoryStream(source), (PdfPageRange[])null!));
         Assert.Throws<ArgumentException>(() => PdfPageExtractor.ExtractPageRanges(new WriteOnlyStream(), PdfPageRange.From(1, 1)));
-        Assert.Throws<ArgumentNullException>(() => PdfPageExtractor.ExtractPageRanges(source, null!, PdfPageRange.From(1, 1)));
+        Assert.Throws<ArgumentNullException>(() => PdfPageExtractor.ExtractPageRanges(source, (Stream)null!, PdfPageRange.From(1, 1)));
         Assert.Throws<ArgumentException>(() => PdfPageExtractor.ExtractPageRanges(source, new ReadOnlyStream(), PdfPageRange.From(1, 1)));
         Assert.Throws<ArgumentNullException>(() => PdfPageExtractor.ExtractPageRanges(new MemoryStream(source), null!, PdfPageRange.From(1, 1)));
         Assert.Throws<ArgumentException>(() => PdfPageExtractor.ExtractPageRanges(new MemoryStream(source), new ReadOnlyStream(), PdfPageRange.From(1, 1)));


### PR DESCRIPTION
## Summary
- add no-dependency PDF page resize support for existing pages and merge normalization
- add opt-in PDF table shrink-to-fit rendering for fixed-width cells
- add password-aware page extraction/splitting so encrypted PDFs can be split into clean outputs after a valid password

## Validation
- dotnet build OfficeIMO.Pdf\OfficeIMO.Pdf.csproj -c Release --no-restore -v minimal
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release -f net8.0 --no-build --filter "FullyQualifiedName~PdfEncryptedReadTests|FullyQualifiedName~PdfDocumentWorkflowTests|FullyQualifiedName~PdfMergerTests|FullyQualifiedName~PdfPageEditorWrapperPipelineTests" -v minimal
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release -f net10.0 --no-build --filter "FullyQualifiedName~PdfEncryptedReadTests|FullyQualifiedName~PdfDocumentWorkflowTests|FullyQualifiedName~PdfMergerTests|FullyQualifiedName~PdfPageEditorWrapperPipelineTests" -v minimal