### PR TITLE
Add Excel workflow diagnostics and safeguards

### DIFF
--- a/OfficeIMO.Excel/ExcelCalculationOptions.cs
+++ b/OfficeIMO.Excel/ExcelCalculationOptions.cs
@@ -1,5 +1,25 @@
 namespace OfficeIMO.Excel {
     /// <summary>
+    /// Controls how workbook calculation metadata is handled when stale calculation chains are removed.
+    /// </summary>
+    public enum ExcelCalculationCleanupPolicy {
+        /// <summary>
+        /// Removes stale calculation-chain parts while preserving existing workbook calculation properties.
+        /// </summary>
+        PreserveExistingCalculationProperties,
+
+        /// <summary>
+        /// Removes stale calculation-chain parts and clears automatic full-recalculation flags from existing workbook calculation properties.
+        /// </summary>
+        ClearAutomaticFullCalculationOnOpen,
+
+        /// <summary>
+        /// Removes stale calculation-chain parts and explicitly requests full recalculation when the workbook is opened.
+        /// </summary>
+        RequestFullCalculationOnOpen
+    }
+
+    /// <summary>
     /// Controls how formula cells are treated before a workbook is saved.
     /// </summary>
     public sealed class ExcelCalculationOptions {

--- a/OfficeIMO.Excel/ExcelChart.Axes.cs
+++ b/OfficeIMO.Excel/ExcelChart.Axes.cs
@@ -425,6 +425,43 @@ namespace OfficeIMO.Excel {
         }
 
         /// <summary>
+        /// Sets category axis scale parameters for line, bar, column, and area charts.
+        /// </summary>
+        /// <param name="minimum">Optional minimum category-axis value.</param>
+        /// <param name="maximum">Optional maximum category-axis value.</param>
+        /// <param name="majorUnit">Optional major unit spacing.</param>
+        /// <param name="minorUnit">Optional minor unit spacing.</param>
+        /// <param name="reverseOrder">Optional category order direction.</param>
+        /// <param name="axisGroup">Primary or secondary category axis.</param>
+        public ExcelChart SetCategoryAxisScale(double? minimum = null, double? maximum = null,
+            double? majorUnit = null, double? minorUnit = null, bool? reverseOrder = null,
+            ExcelChartAxisGroup axisGroup = ExcelChartAxisGroup.Primary) {
+            ValidateAxisScale(minimum, maximum, majorUnit, minorUnit, logScale: null, logBase: null);
+
+            C.Chart chart = GetChart();
+            C.PlotArea? plotArea = chart.GetFirstChild<C.PlotArea>();
+            if (plotArea == null) {
+                return this;
+            }
+
+            OpenXmlCompositeElement? axis = ResolveDateAxis(plotArea, axisGroup);
+            if (axis == null) {
+                C.CategoryAxis? categoryAxis = ResolveCategoryAxis(plotArea, axisGroup);
+                if (categoryAxis == null) {
+                    return this;
+                }
+
+                axis = minimum != null || maximum != null || majorUnit != null || minorUnit != null
+                    ? PromoteCategoryAxisToDateAxis(plotArea, categoryAxis)
+                    : categoryAxis;
+            }
+
+            ApplyAxisScale(axis, minimum, maximum, majorUnit, minorUnit, reverseOrder, logScale: null, logBase: null);
+            Save();
+            return this;
+        }
+
+        /// <summary>
         /// Sets scatter chart X-axis scale (value axis on the bottom).
         /// </summary>
         public ExcelChart SetScatterXAxisScale(double? minimum = null, double? maximum = null,
@@ -799,6 +836,63 @@ namespace OfficeIMO.Excel {
             return axisGroup == ExcelChartAxisGroup.Primary
                 ? axes.FirstOrDefault()
                 : axes.Skip(1).FirstOrDefault() ?? axes.LastOrDefault();
+        }
+
+        private static C.DateAxis? ResolveDateAxis(C.PlotArea plotArea, ExcelChartAxisGroup axisGroup) {
+            var axes = plotArea.Elements<C.DateAxis>().ToList();
+            if (axes.Count == 0) {
+                return null;
+            }
+
+            bool isBar = HasHorizontalBarChart(plotArea);
+            C.AxisPositionValues primaryPosition = isBar ? C.AxisPositionValues.Left : C.AxisPositionValues.Bottom;
+            C.AxisPositionValues secondaryPosition = isBar ? C.AxisPositionValues.Right : C.AxisPositionValues.Top;
+            C.AxisPositionValues desired = axisGroup == ExcelChartAxisGroup.Primary ? primaryPosition : secondaryPosition;
+
+            C.DateAxis? axis = axes.FirstOrDefault(ax => ax.AxisPosition?.Val?.Value == desired);
+            if (axis != null) {
+                return axis;
+            }
+
+            return axisGroup == ExcelChartAxisGroup.Primary
+                ? axes.FirstOrDefault()
+                : axes.Skip(1).FirstOrDefault() ?? axes.LastOrDefault();
+        }
+
+        private static C.DateAxis PromoteCategoryAxisToDateAxis(C.PlotArea plotArea, C.CategoryAxis categoryAxis) {
+            var dateAxis = new C.DateAxis();
+            AppendClone<C.AxisId>(dateAxis, categoryAxis);
+            AppendClone<C.Scaling>(dateAxis, categoryAxis);
+            AppendClone<C.Delete>(dateAxis, categoryAxis);
+            AppendClone<C.AxisPosition>(dateAxis, categoryAxis);
+            AppendClone<C.MajorGridlines>(dateAxis, categoryAxis);
+            AppendClone<C.MinorGridlines>(dateAxis, categoryAxis);
+            AppendClone<C.Title>(dateAxis, categoryAxis);
+            AppendClone<C.NumberingFormat>(dateAxis, categoryAxis);
+            AppendClone<C.MajorTickMark>(dateAxis, categoryAxis);
+            AppendClone<C.MinorTickMark>(dateAxis, categoryAxis);
+            AppendClone<C.TickLabelPosition>(dateAxis, categoryAxis);
+            AppendClone<C.ChartShapeProperties>(dateAxis, categoryAxis);
+            AppendClone<C.TextProperties>(dateAxis, categoryAxis);
+            AppendClone<C.CrossingAxis>(dateAxis, categoryAxis);
+            AppendClone<C.Crosses>(dateAxis, categoryAxis);
+            AppendClone<C.CrossesAt>(dateAxis, categoryAxis);
+            AppendClone<C.LabelOffset>(dateAxis, categoryAxis);
+
+            if (categoryAxis.Parent != null) {
+                plotArea.ReplaceChild(dateAxis, categoryAxis);
+            } else {
+                plotArea.Append(dateAxis);
+            }
+
+            return dateAxis;
+        }
+
+        private static void AppendClone<T>(OpenXmlCompositeElement destination, OpenXmlCompositeElement source) where T : OpenXmlElement {
+            T? child = source.GetFirstChild<T>();
+            if (child != null) {
+                destination.Append(child.CloneNode(true));
+            }
         }
 
         private static C.ValueAxis? ResolveValueAxis(C.PlotArea plotArea, ExcelChartAxisGroup axisGroup) {

--- a/OfficeIMO.Excel/ExcelDocument.CalculationCleanup.cs
+++ b/OfficeIMO.Excel/ExcelDocument.CalculationCleanup.cs
@@ -4,7 +4,7 @@ using DocumentFormat.OpenXml.Spreadsheet;
 
 namespace OfficeIMO.Excel {
     public partial class ExcelDocument {
-        internal void CleanupCalculationArtifacts(bool save = true) {
+        internal void CleanupCalculationArtifacts(bool save = true, ExcelCalculationCleanupPolicy policy = ExcelCalculationCleanupPolicy.PreserveExistingCalculationProperties) {
             var workbookPart = WorkbookPartRoot;
 
             foreach (var calculationChainPart in workbookPart.GetPartsOfType<CalculationChainPart>().ToList()) {
@@ -25,21 +25,19 @@ namespace OfficeIMO.Excel {
                 return;
             }
 
-            if (calculationProperties == null) {
-                calculationProperties = new CalculationProperties();
-                var extensionList = workbook.Elements<ExtensionList>().FirstOrDefault();
-                if (extensionList != null) {
-                    workbook.InsertBefore(calculationProperties, extensionList);
-                } else if (workbook.Elements<PivotCaches>().FirstOrDefault() is { } pivotCaches) {
-                    workbook.InsertBefore(calculationProperties, pivotCaches);
-                } else {
-                    workbook.Append(calculationProperties);
+            if (policy == ExcelCalculationCleanupPolicy.RequestFullCalculationOnOpen) {
+                if (calculationProperties == null) {
+                    calculationProperties = new CalculationProperties();
+                    InsertCalculationPropertiesInSchemaOrder(workbook, calculationProperties);
                 }
-            }
 
-            calculationProperties.SetAttribute(new OpenXmlAttribute("calcId", string.Empty, "191029"));
-            calculationProperties.SetAttribute(new OpenXmlAttribute("fullCalcOnLoad", string.Empty, "1"));
-            calculationProperties.SetAttribute(new OpenXmlAttribute("forceFullCalc", string.Empty, "1"));
+                calculationProperties.SetAttribute(new OpenXmlAttribute("calcId", string.Empty, "191029"));
+                calculationProperties.SetAttribute(new OpenXmlAttribute("fullCalcOnLoad", string.Empty, "1"));
+                calculationProperties.SetAttribute(new OpenXmlAttribute("forceFullCalc", string.Empty, "1"));
+            } else if (policy == ExcelCalculationCleanupPolicy.ClearAutomaticFullCalculationOnOpen && calculationProperties != null) {
+                calculationProperties.RemoveAttribute("fullCalcOnLoad", string.Empty);
+                calculationProperties.RemoveAttribute("forceFullCalc", string.Empty);
+            }
 
             if (save) {
                 workbook.Save();

--- a/OfficeIMO.Excel/ExcelRuntimePreflight.cs
+++ b/OfficeIMO.Excel/ExcelRuntimePreflight.cs
@@ -1,0 +1,85 @@
+using System.Globalization;
+using System.Runtime.InteropServices;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Runtime diagnostics that can affect Excel import/export behavior.
+    /// </summary>
+    public sealed class ExcelRuntimePreflightReport {
+        internal ExcelRuntimePreflightReport(
+            string frameworkDescription,
+            string osDescription,
+            string currentCultureName,
+            string currentUICultureName,
+            bool globalizationInvariantMode,
+            IReadOnlyList<string> warnings) {
+            FrameworkDescription = frameworkDescription;
+            OSDescription = osDescription;
+            CurrentCultureName = currentCultureName;
+            CurrentUICultureName = currentUICultureName;
+            GlobalizationInvariantMode = globalizationInvariantMode;
+            Warnings = warnings;
+        }
+
+        /// <summary>Gets the .NET framework description.</summary>
+        public string FrameworkDescription { get; }
+
+        /// <summary>Gets the operating system description.</summary>
+        public string OSDescription { get; }
+
+        /// <summary>Gets the current culture name.</summary>
+        public string CurrentCultureName { get; }
+
+        /// <summary>Gets the current UI culture name.</summary>
+        public string CurrentUICultureName { get; }
+
+        /// <summary>Gets a value indicating whether globalization-invariant mode appears to be enabled.</summary>
+        public bool GlobalizationInvariantMode { get; }
+
+        /// <summary>Gets runtime warnings relevant to Excel workflows.</summary>
+        public IReadOnlyList<string> Warnings { get; }
+
+        /// <summary>Gets a value indicating whether no runtime warnings were found.</summary>
+        public bool IsClean => Warnings.Count == 0;
+    }
+
+    /// <summary>
+    /// Inspects the current runtime for Excel workflow compatibility issues.
+    /// </summary>
+    public static class ExcelRuntimePreflight {
+        /// <summary>
+        /// Inspects the current process for culture/runtime settings that commonly affect spreadsheet workflows.
+        /// </summary>
+        public static ExcelRuntimePreflightReport InspectCurrent() {
+            var warnings = new List<string>();
+            bool invariantMode = IsGlobalizationInvariantMode();
+
+            if (invariantMode) {
+                warnings.Add("Globalization-invariant mode is enabled. Use explicit invariant formats or install ICU/globalization data before relying on culture-specific dates, numbers, or currency symbols.");
+            }
+
+            return new ExcelRuntimePreflightReport(
+                RuntimeInformation.FrameworkDescription,
+                RuntimeInformation.OSDescription,
+                CultureInfo.CurrentCulture.Name,
+                CultureInfo.CurrentUICulture.Name,
+                invariantMode,
+                warnings);
+        }
+
+        private static bool IsGlobalizationInvariantMode() {
+            if (AppContext.TryGetSwitch("System.Globalization.Invariant", out bool invariantSwitch) && invariantSwitch) {
+                return true;
+            }
+
+            string? environmentValue = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT");
+            if (string.Equals(environmentValue, "1", StringComparison.Ordinal)
+                || string.Equals(environmentValue, "true", StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+
+            return CultureInfo.CurrentCulture.Name.Length == 0
+                && CultureInfo.CurrentUICulture.Name.Length == 0;
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelTableStyleCompatibility.cs
+++ b/OfficeIMO.Excel/ExcelTableStyleCompatibility.cs
@@ -1,0 +1,140 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Compatibility profile used when selecting Excel table styles.
+    /// </summary>
+    public enum ExcelTableStyleCompatibilityProfile {
+        /// <summary>
+        /// Accept any built-in Excel table style.
+        /// </summary>
+        Desktop,
+
+        /// <summary>
+        /// Prefer table styles that are broadly stable across desktop, web, and spreadsheet viewers.
+        /// </summary>
+        CrossHost
+    }
+
+    /// <summary>
+    /// Describes how a table style fits a compatibility profile.
+    /// </summary>
+    public sealed class ExcelTableStyleCompatibilityInfo {
+        internal ExcelTableStyleCompatibilityInfo(
+            TableStyle style,
+            string name,
+            ExcelTableStyleCompatibilityProfile profile,
+            bool isBuiltIn,
+            bool isRecommended,
+            string? warning) {
+            Style = style;
+            Name = name;
+            Profile = profile;
+            IsBuiltIn = isBuiltIn;
+            IsRecommended = isRecommended;
+            Warning = warning;
+        }
+
+        /// <summary>Gets the table style enum value.</summary>
+        public TableStyle Style { get; }
+
+        /// <summary>Gets the workbook style name written to table XML.</summary>
+        public string Name { get; }
+
+        /// <summary>Gets the profile used for the compatibility check.</summary>
+        public ExcelTableStyleCompatibilityProfile Profile { get; }
+
+        /// <summary>Gets a value indicating whether the style is a known built-in Excel table style.</summary>
+        public bool IsBuiltIn { get; }
+
+        /// <summary>Gets a value indicating whether the style is recommended for the selected profile.</summary>
+        public bool IsRecommended { get; }
+
+        /// <summary>Gets a warning when the style is valid but not recommended for the selected profile.</summary>
+        public string? Warning { get; }
+    }
+
+    /// <summary>
+    /// Provides built-in Excel table style names and compatibility recommendations.
+    /// </summary>
+    public static class ExcelTableStyleCatalog {
+        private static readonly HashSet<TableStyle> CrossHostRecommendedStyles = new HashSet<TableStyle> {
+            TableStyle.TableStyleLight1,
+            TableStyle.TableStyleLight2,
+            TableStyle.TableStyleLight9,
+            TableStyle.TableStyleLight11,
+            TableStyle.TableStyleMedium2,
+            TableStyle.TableStyleMedium4,
+            TableStyle.TableStyleMedium9,
+            TableStyle.TableStyleMedium15,
+            TableStyle.TableStyleMedium21
+        };
+
+        /// <summary>
+        /// Returns all built-in Excel table style names.
+        /// </summary>
+        public static IReadOnlyList<string> GetNames() {
+            return Enum.GetNames(typeof(TableStyle));
+        }
+
+        /// <summary>
+        /// Returns table style names recommended for the given compatibility profile.
+        /// </summary>
+        public static IReadOnlyList<string> GetRecommendedNames(ExcelTableStyleCompatibilityProfile profile = ExcelTableStyleCompatibilityProfile.CrossHost) {
+            if (profile == ExcelTableStyleCompatibilityProfile.Desktop) {
+                return GetNames();
+            }
+
+            return CrossHostRecommendedStyles
+                .OrderBy(style => style.ToString(), StringComparer.Ordinal)
+                .Select(style => style.ToString())
+                .ToArray();
+        }
+
+        /// <summary>
+        /// Tries to parse a built-in table style name.
+        /// </summary>
+        public static bool TryParse(string? name, out TableStyle style) {
+            return Enum.TryParse(name, ignoreCase: true, out style)
+                && Enum.IsDefined(typeof(TableStyle), style);
+        }
+
+        /// <summary>
+        /// Gets compatibility information for a built-in table style.
+        /// </summary>
+        public static ExcelTableStyleCompatibilityInfo Analyze(
+            TableStyle style,
+            ExcelTableStyleCompatibilityProfile profile = ExcelTableStyleCompatibilityProfile.CrossHost) {
+            bool recommended = profile == ExcelTableStyleCompatibilityProfile.Desktop
+                || CrossHostRecommendedStyles.Contains(style);
+            string? warning = recommended
+                ? null
+                : "The table style is valid, but a simpler light or medium style is recommended for cross-host workbook compatibility.";
+
+            return new ExcelTableStyleCompatibilityInfo(
+                style,
+                style.ToString(),
+                profile,
+                isBuiltIn: true,
+                isRecommended: recommended,
+                warning);
+        }
+
+        /// <summary>
+        /// Gets compatibility information for a table style name.
+        /// </summary>
+        public static ExcelTableStyleCompatibilityInfo Analyze(
+            string name,
+            ExcelTableStyleCompatibilityProfile profile = ExcelTableStyleCompatibilityProfile.CrossHost) {
+            if (!TryParse(name, out TableStyle style)) {
+                return new ExcelTableStyleCompatibilityInfo(
+                    default,
+                    name,
+                    profile,
+                    isBuiltIn: false,
+                    isRecommended: false,
+                    "The table style name is not one of the built-in Excel table styles.");
+            }
+
+            return Analyze(style, profile);
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelWorkbookIntelligence.Advanced.cs
+++ b/OfficeIMO.Excel/ExcelWorkbookIntelligence.Advanced.cs
@@ -292,7 +292,7 @@ namespace OfficeIMO.Excel {
             }
 
             if (options.Calculation) {
-                CleanupCalculationArtifacts(save: false);
+                CleanupCalculationArtifacts(save: false, ExcelCalculationCleanupPolicy.RequestFullCalculationOnOpen);
                 actions.Add(new ExcelWorkbookRepairAction("Calculation", "Removed stale calculation chains and requested recalculation on open."));
             }
             if (options.WorkbookArtifacts) {

--- a/OfficeIMO.Excel/ExcelWorkbookWriteReservation.cs
+++ b/OfficeIMO.Excel/ExcelWorkbookWriteReservation.cs
@@ -1,0 +1,137 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Options for Excel write-reservation metadata. This is not package encryption and does not protect worksheet or workbook structure.
+    /// </summary>
+    public sealed class ExcelWorkbookWriteReservationOptions {
+        /// <summary>
+        /// Suggests opening the workbook as read-only.
+        /// </summary>
+        public bool ReadOnlyRecommended { get; set; }
+
+        /// <summary>
+        /// Optional user name displayed by Excel-compatible applications for the write reservation.
+        /// </summary>
+        public string? UserName { get; set; }
+
+        /// <summary>
+        /// Optional write-reservation password. This uses Excel's legacy reservation hash and is not encryption.
+        /// </summary>
+        public string? Password { get; set; }
+
+        /// <summary>
+        /// Optional precomputed legacy write-reservation hash. When set, this value is written as-is.
+        /// </summary>
+        public string? LegacyPasswordHash { get; set; }
+    }
+
+    /// <summary>
+    /// Snapshot of workbook write-reservation metadata.
+    /// </summary>
+    public sealed class ExcelWorkbookWriteReservationInfo {
+        internal ExcelWorkbookWriteReservationInfo(bool exists, bool readOnlyRecommended, string? userName, string? legacyPasswordHash) {
+            Exists = exists;
+            ReadOnlyRecommended = readOnlyRecommended;
+            UserName = userName;
+            LegacyPasswordHash = legacyPasswordHash;
+        }
+
+        /// <summary>Gets a value indicating whether the workbook contains a file-sharing/write-reservation node.</summary>
+        public bool Exists { get; }
+
+        /// <summary>Gets a value indicating whether Excel-compatible applications should recommend read-only opening.</summary>
+        public bool ReadOnlyRecommended { get; }
+
+        /// <summary>Gets the reservation user name when present.</summary>
+        public string? UserName { get; }
+
+        /// <summary>Gets the legacy reservation password hash when present.</summary>
+        public string? LegacyPasswordHash { get; }
+
+        /// <summary>Gets a value indicating whether a write-reservation password hash is present.</summary>
+        public bool HasPasswordHash => !string.IsNullOrWhiteSpace(LegacyPasswordHash);
+    }
+
+    public partial class ExcelDocument {
+        /// <summary>
+        /// Gets workbook write-reservation metadata. This is separate from workbook protection and package encryption.
+        /// </summary>
+        public ExcelWorkbookWriteReservationInfo GetWriteReservation() {
+            FileSharing? fileSharing = WorkbookRoot.GetFirstChild<FileSharing>();
+            if (fileSharing == null) {
+                return new ExcelWorkbookWriteReservationInfo(false, false, null, null);
+            }
+
+            return new ExcelWorkbookWriteReservationInfo(
+                exists: true,
+                readOnlyRecommended: fileSharing.ReadOnlyRecommended?.Value ?? false,
+                userName: fileSharing.UserName?.Value,
+                legacyPasswordHash: GetFileSharingReservationPassword(fileSharing));
+        }
+
+        /// <summary>
+        /// Writes workbook write-reservation metadata. This is not package encryption and does not protect worksheet or workbook structure.
+        /// </summary>
+        public void SetWriteReservation(ExcelWorkbookWriteReservationOptions? options = null) {
+            var opts = options ?? new ExcelWorkbookWriteReservationOptions { ReadOnlyRecommended = true };
+            FileSharing fileSharing = WorkbookRoot.GetFirstChild<FileSharing>() ?? new FileSharing();
+            if (fileSharing.Parent == null) {
+                InsertFileSharingInSchemaOrder(WorkbookRoot, fileSharing);
+            }
+
+            fileSharing.ReadOnlyRecommended = opts.ReadOnlyRecommended ? true : (bool?)null;
+            if (string.IsNullOrWhiteSpace(opts.UserName)) {
+                fileSharing.UserName = null;
+                fileSharing.RemoveAttribute("userName", string.Empty);
+            } else {
+                fileSharing.UserName = opts.UserName;
+            }
+
+            string? hash = ExcelProtectionHash.ResolveLegacyHash(opts.Password, opts.LegacyPasswordHash);
+            if (hash == null) {
+                fileSharing.RemoveAttribute("reservationPassword", string.Empty);
+            } else {
+                fileSharing.SetAttribute(new OpenXmlAttribute("reservationPassword", string.Empty, hash));
+            }
+
+            WorkbookRoot.Save();
+            MarkPackageDirty();
+        }
+
+        /// <summary>
+        /// Removes workbook write-reservation metadata.
+        /// </summary>
+        public void ClearWriteReservation() {
+            FileSharing? fileSharing = WorkbookRoot.GetFirstChild<FileSharing>();
+            if (fileSharing == null) {
+                return;
+            }
+
+            WorkbookRoot.RemoveChild(fileSharing);
+            WorkbookRoot.Save();
+            MarkPackageDirty();
+        }
+
+        private static string? GetFileSharingReservationPassword(FileSharing fileSharing) {
+            OpenXmlAttribute attribute = fileSharing.GetAttribute("reservationPassword", string.Empty);
+            return string.IsNullOrWhiteSpace(attribute.Value) ? null : attribute.Value;
+        }
+
+        private static void InsertFileSharingInSchemaOrder(Workbook workbook, FileSharing fileSharing) {
+            OpenXmlElement? before = workbook.GetFirstChild<WorkbookProperties>();
+            before ??= workbook.GetFirstChild<WorkbookProtection>();
+            before ??= workbook.GetFirstChild<BookViews>();
+            before ??= workbook.GetFirstChild<Sheets>();
+
+            if (before != null) {
+                workbook.InsertBefore(fileSharing, before);
+            } else if (workbook.GetFirstChild<FileVersion>() is FileVersion fileVersion) {
+                workbook.InsertAfter(fileSharing, fileVersion);
+            } else {
+                workbook.InsertAt(fileSharing, 0);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/ObjectDataTableBuilderOptions.cs
+++ b/OfficeIMO.Excel/ObjectDataTableBuilderOptions.cs
@@ -1,0 +1,16 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Controls how object values are projected into cells when building a <see cref="System.Data.DataTable"/>.
+    /// </summary>
+    public sealed class ObjectDataTableBuilderOptions {
+        /// <summary>
+        /// Gets or sets whether non-string enumerable property values are joined into one display string.
+        /// </summary>
+        public bool NormalizeCollectionValues { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the separator used when <see cref="NormalizeCollectionValues"/> joins collection values.
+        /// </summary>
+        public string CollectionSeparator { get; set; } = ", ";
+    }
+}

--- a/OfficeIMO.Excel/Utilities/ExcelNumberFormats.cs
+++ b/OfficeIMO.Excel/Utilities/ExcelNumberFormats.cs
@@ -6,6 +6,13 @@ namespace OfficeIMO.Excel {
     /// </summary>
     public static class ExcelNumberFormats {
         /// <summary>
+        /// Returns the names of supported number format presets.
+        /// </summary>
+        public static IReadOnlyList<string> GetPresetNames() {
+            return Enum.GetNames(typeof(ExcelNumberPreset));
+        }
+
+        /// <summary>
         /// Returns an Excel number format code for the given <paramref name="preset"/>,
         /// optionally controlling decimal places and currency culture.
         /// </summary>

--- a/OfficeIMO.Excel/Utilities/ObjectDataTableBuilder.cs
+++ b/OfficeIMO.Excel/Utilities/ObjectDataTableBuilder.cs
@@ -14,13 +14,15 @@ namespace OfficeIMO.Excel {
         /// </summary>
         /// <param name="items">Sequence of objects to convert into table rows.</param>
         /// <param name="tableName">Optional DataTable name.</param>
+        /// <param name="options">Optional value-normalization settings for projected cell values.</param>
         /// <returns>Populated DataTable.</returns>
         [RequiresUnreferencedCode("Uses reflection over arbitrary object graphs. For AOT-safe usage, map values explicitly or pre-flatten items.")]
-        public static DataTable FromObjects(IEnumerable<object?> items, string tableName = "Data") {
+        public static DataTable FromObjects(IEnumerable<object?> items, string tableName = "Data", ObjectDataTableBuilderOptions? options = null) {
             if (items == null) {
                 throw new ArgumentNullException(nameof(items));
             }
 
+            options ??= new ObjectDataTableBuilderOptions();
             IReadOnlyList<object?> rows = items as IReadOnlyList<object?> ?? items.ToList();
             if (rows.Count == 0) {
                 throw new ArgumentException("Provide at least one data row.", nameof(items));
@@ -41,7 +43,7 @@ namespace OfficeIMO.Excel {
                 table.Columns.Add(name, typeof(object));
             }
 
-            var projector = ObjectRowProjector.Create(first, columnNames);
+            var projector = ObjectRowProjector.Create(first, columnNames, options);
             table.MinimumCapacity = Math.Max(table.MinimumCapacity, rows.Count);
             var values = projector.CreateValuesBuffer();
             table.BeginLoadData();
@@ -71,36 +73,38 @@ namespace OfficeIMO.Excel {
             private readonly Dictionary<string, int>? _ignoreCaseColumnIndexes;
             private readonly ObjectValueGetter[]? _getters;
             private readonly Type? _sourceType;
+            private readonly ObjectDataTableBuilderOptions _options;
             private int[]? _sparseTouchedColumns;
             private byte[]? _sparseColumnStates;
             private int _sparseTouchedCount;
             private bool _valuesReadyForSparseProjection;
 
-            private ObjectRowProjector(string[] columns, ObjectValueGetter[]? getters, Type? sourceType, bool createOrdinalColumnIndexes) {
+            private ObjectRowProjector(string[] columns, ObjectValueGetter[]? getters, Type? sourceType, bool createOrdinalColumnIndexes, ObjectDataTableBuilderOptions options) {
                 _columns = columns;
                 _ordinalColumnIndexes = createOrdinalColumnIndexes ? CreateOrdinalColumnIndexes(columns) : null;
                 _ignoreCaseColumnIndexes = createOrdinalColumnIndexes ? CreateIgnoreCaseColumnIndexes(columns) : null;
                 _getters = getters;
                 _sourceType = sourceType;
+                _options = options;
             }
 
-            internal static ObjectRowProjector Create(object first, IReadOnlyList<string> columns) {
+            internal static ObjectRowProjector Create(object first, IReadOnlyList<string> columns, ObjectDataTableBuilderOptions options) {
                 var firstType = first.GetType();
                 if (IsDictionaryLike(first)) {
-                    return new ObjectRowProjector(columns.ToArray(), getters: null, sourceType: null, createOrdinalColumnIndexes: true);
+                    return new ObjectRowProjector(columns.ToArray(), getters: null, sourceType: null, createOrdinalColumnIndexes: true, options);
                 }
 
                 var cachedProjection = TypedProjectionCache.GetOrAdd(firstType, type => CreateCachedProjection(type, columns));
                 if (ColumnsMatch(cachedProjection.Columns, columns)) {
-                    return new ObjectRowProjector(cachedProjection.Columns, cachedProjection.Getters, firstType, createOrdinalColumnIndexes: false);
+                    return new ObjectRowProjector(cachedProjection.Columns, cachedProjection.Getters, firstType, createOrdinalColumnIndexes: false, options);
                 }
 
                 var getters = CreateGetters(firstType, columns);
                 if (getters == null) {
-                    return new ObjectRowProjector(columns.ToArray(), getters: null, sourceType: null, createOrdinalColumnIndexes: false);
+                    return new ObjectRowProjector(columns.ToArray(), getters: null, sourceType: null, createOrdinalColumnIndexes: false, options);
                 }
 
-                return new ObjectRowProjector(columns.ToArray(), getters, firstType, createOrdinalColumnIndexes: false);
+                return new ObjectRowProjector(columns.ToArray(), getters, firstType, createOrdinalColumnIndexes: false, options);
             }
 
             private static CachedObjectRowProjection CreateCachedProjection(Type firstType, IReadOnlyList<string> columns) {
@@ -146,7 +150,7 @@ namespace OfficeIMO.Excel {
 
                 if (_getters != null && item.GetType() == _sourceType) {
                     for (int i = 0; i < _getters.Length; i++) {
-                        values[i] = _getters[i](item) ?? DBNull.Value;
+                        values[i] = NormalizeCellValue(_getters[i](item), _options) ?? DBNull.Value;
                     }
 
                     _valuesReadyForSparseProjection = false;
@@ -154,7 +158,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 for (int i = 0; i < _columns.Length; i++) {
-                    values[i] = ObjectDataHelpers.GetValue(item, _columns[i]) ?? DBNull.Value;
+                    values[i] = NormalizeCellValue(ObjectDataHelpers.GetValue(item, _columns[i]), _options) ?? DBNull.Value;
                 }
 
                 _valuesReadyForSparseProjection = false;
@@ -184,7 +188,7 @@ namespace OfficeIMO.Excel {
                     }
 
                     for (int i = 0; i < _columns.Length; i++) {
-                        values[i] = exactDictionary.TryGetValue(_columns[i], out var value) ? value ?? DBNull.Value : DBNull.Value;
+                        values[i] = exactDictionary.TryGetValue(_columns[i], out var value) ? NormalizeCellValue(value, _options) ?? DBNull.Value : DBNull.Value;
                     }
 
                     _valuesReadyForSparseProjection = false;
@@ -193,7 +197,7 @@ namespace OfficeIMO.Excel {
 
                 if (item is IReadOnlyDictionary<string, object?> readOnlyDictionary) {
                     for (int i = 0; i < _columns.Length; i++) {
-                        values[i] = readOnlyDictionary.TryGetValue(_columns[i], out var value) ? value ?? DBNull.Value : DBNull.Value;
+                        values[i] = readOnlyDictionary.TryGetValue(_columns[i], out var value) ? NormalizeCellValue(value, _options) ?? DBNull.Value : DBNull.Value;
                     }
 
                     _valuesReadyForSparseProjection = false;
@@ -202,7 +206,7 @@ namespace OfficeIMO.Excel {
 
                 if (item is IDictionary<string, object?> dictionary) {
                     for (int i = 0; i < _columns.Length; i++) {
-                        values[i] = dictionary.TryGetValue(_columns[i], out var value) ? value ?? DBNull.Value : DBNull.Value;
+                        values[i] = dictionary.TryGetValue(_columns[i], out var value) ? NormalizeCellValue(value, _options) ?? DBNull.Value : DBNull.Value;
                     }
 
                     _valuesReadyForSparseProjection = false;
@@ -215,7 +219,7 @@ namespace OfficeIMO.Excel {
                     }
 
                     for (int i = 0; i < _columns.Length; i++) {
-                        values[i] = GetLegacyDictionaryValue(legacyDictionary, _columns[i]) ?? DBNull.Value;
+                        values[i] = NormalizeCellValue(GetLegacyDictionaryValue(legacyDictionary, _columns[i]), _options) ?? DBNull.Value;
                     }
 
                     _valuesReadyForSparseProjection = false;
@@ -237,7 +241,7 @@ namespace OfficeIMO.Excel {
 
                 foreach (var entry in dictionary) {
                     if (_ordinalColumnIndexes.TryGetValue(entry.Key, out int columnIndex)) {
-                        values[columnIndex] = entry.Value ?? DBNull.Value;
+                        values[columnIndex] = NormalizeCellValue(entry.Value, _options) ?? DBNull.Value;
                         TrackSparseTouchedColumn(columnIndex);
                     }
                 }
@@ -262,7 +266,7 @@ namespace OfficeIMO.Excel {
                     string key = entry.Key?.ToString() ?? string.Empty;
                     if (_ordinalColumnIndexes.TryGetValue(key, out int exactColumnIndex)) {
                         TrackSparseLegacyColumn(exactColumnIndex);
-                        values[exactColumnIndex] = entry.Value ?? DBNull.Value;
+                        values[exactColumnIndex] = NormalizeCellValue(entry.Value, _options) ?? DBNull.Value;
                         _sparseColumnStates[exactColumnIndex] = 2;
                         continue;
                     }
@@ -270,7 +274,7 @@ namespace OfficeIMO.Excel {
                     if (_ignoreCaseColumnIndexes.TryGetValue(key, out int ignoreCaseColumnIndex)
                         && _sparseColumnStates[ignoreCaseColumnIndex] == 0) {
                         TrackSparseLegacyColumn(ignoreCaseColumnIndex);
-                        values[ignoreCaseColumnIndex] = entry.Value ?? DBNull.Value;
+                        values[ignoreCaseColumnIndex] = NormalizeCellValue(entry.Value, _options) ?? DBNull.Value;
                         _sparseColumnStates[ignoreCaseColumnIndex] = 1;
                     }
                 }
@@ -342,6 +346,31 @@ namespace OfficeIMO.Excel {
                     || item is IReadOnlyDictionary<string, object?>
                     || item is IDictionary<string, object?>
                     || item is System.Collections.IDictionary;
+            }
+
+            private static object? NormalizeCellValue(object? value, ObjectDataTableBuilderOptions options) {
+                if (value == null || value == DBNull.Value || !options.NormalizeCollectionValues) {
+                    return value;
+                }
+
+                if (value is string || value is System.Collections.IDictionary) {
+                    return value;
+                }
+
+                if (value is IEnumerable enumerable) {
+                    return JoinCollection(enumerable, options.CollectionSeparator);
+                }
+
+                return value;
+            }
+
+            private static string JoinCollection(IEnumerable values, string separator) {
+                var parts = new List<string>();
+                foreach (var value in values) {
+                    parts.Add(value?.ToString() ?? string.Empty);
+                }
+
+                return string.Join(separator ?? string.Empty, parts);
             }
 
             private static ObjectValueGetter CreateObjectValueGetter(PropertyInfo property) {

--- a/OfficeIMO.Tests/Excel.BestOfBar.cs
+++ b/OfficeIMO.Tests/Excel.BestOfBar.cs
@@ -1,0 +1,206 @@
+using System.Data;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using DocumentFormat.OpenXml.Validation;
+using OfficeIMO.Excel;
+using Xunit;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+using ExcelTableStyle = OfficeIMO.Excel.TableStyle;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_ExcelBestOfBar_SafePreflight_DoesNotForceFullRecalculationForStructuredReferenceFormulas() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelBestOfBar.SafePreflightFormula.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Amount");
+                sheet.CellValue(2, 1, 10);
+                sheet.CellValue(3, 1, 20);
+                sheet.AddTable("A1:A3", hasHeader: true, name: "Sales", style: ExcelTableStyle.TableStyleMedium2);
+                sheet.CellFormula(2, 3, "SUM(Sales[Amount])");
+                document.Save(filePath, openExcel: false, options: new ExcelSaveOptions { SafePreflight = true });
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            CalculationProperties? calculationProperties = spreadsheet.WorkbookPart!.Workbook.GetFirstChild<CalculationProperties>();
+
+            Assert.Null(calculationProperties?.FullCalculationOnLoad);
+            Assert.Null(calculationProperties?.ForceFullCalculation);
+        }
+
+        [Fact]
+        public void Test_ExcelBestOfBar_ExplicitFullCalculationRequest_StillWritesCalculationProperties() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelBestOfBar.FullCalcExplicit.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, 10);
+                sheet.CellFormula(1, 2, "A1*2");
+                document.Save(filePath, openExcel: false, options: new ExcelSaveOptions { ForceFullCalculationOnOpen = true });
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            CalculationProperties calculationProperties = spreadsheet.WorkbookPart!.Workbook.GetFirstChild<CalculationProperties>()!;
+
+            Assert.True(calculationProperties.FullCalculationOnLoad!.Value);
+            Assert.True(calculationProperties.ForceFullCalculation!.Value);
+        }
+
+        [Fact]
+        public void Test_ExcelBestOfBar_CategoryAxisScale_WritesLineChartCategoryAxisUnits() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelBestOfBar.CategoryAxisScale.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Trend");
+                sheet.CellValue(1, 1, "Month");
+                sheet.CellValue(1, 2, "Value");
+                sheet.CellValue(2, 1, "Jan");
+                sheet.CellValue(2, 2, 10);
+                sheet.CellValue(3, 1, "Feb");
+                sheet.CellValue(3, 2, 12);
+                sheet.CellValue(4, 1, "Mar");
+                sheet.CellValue(4, 2, 18);
+
+                sheet.Chart("A1:B4")
+                    .Line()
+                    .Title("Trend")
+                    .At(1, 5)
+                    .SetCategoryAxisScale(majorUnit: 2, minorUnit: 1, reverseOrder: true);
+
+                document.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            WorksheetPart worksheetPart = GetWorksheetPartWithCharts(spreadsheet);
+            C.DateAxis categoryAxis = worksheetPart.DrawingsPart!.ChartParts
+                .Select(part => part.ChartSpace.GetFirstChild<C.Chart>()!.GetFirstChild<C.PlotArea>()!.GetFirstChild<C.DateAxis>())
+                .First(axis => axis != null)!;
+
+            Assert.Equal(2D, categoryAxis.GetFirstChild<C.MajorUnit>()!.Val!.Value);
+            Assert.Equal(1D, categoryAxis.GetFirstChild<C.MinorUnit>()!.Val!.Value);
+            Assert.Equal(C.OrientationValues.MaxMin, categoryAxis.GetFirstChild<C.Scaling>()!.GetFirstChild<C.Orientation>()!.Val!.Value);
+
+            OpenXmlValidator validator = new OpenXmlValidator();
+            var errors = validator.Validate(spreadsheet).ToList();
+            Assert.True(errors.Count == 0, FormatValidationErrors(errors));
+        }
+
+        [Fact]
+        public void Test_ExcelBestOfBar_TableStyleCatalog_FlagsCrossHostRecommendations() {
+            ExcelTableStyleCompatibilityInfo stable = ExcelTableStyleCatalog.Analyze(ExcelTableStyle.TableStyleMedium2);
+            ExcelTableStyleCompatibilityInfo heavier = ExcelTableStyleCatalog.Analyze(ExcelTableStyle.TableStyleDark11);
+            ExcelTableStyleCompatibilityInfo unknown = ExcelTableStyleCatalog.Analyze("CustomStyle");
+
+            Assert.True(stable.IsRecommended);
+            Assert.False(heavier.IsRecommended);
+            Assert.Contains("cross-host", heavier.Warning, StringComparison.OrdinalIgnoreCase);
+            Assert.False(unknown.IsBuiltIn);
+            Assert.Contains(nameof(ExcelTableStyle.TableStyleMedium2), ExcelTableStyleCatalog.GetRecommendedNames());
+        }
+
+        [Fact]
+        public void Test_ExcelBestOfBar_WriteReservation_RoundTripsSeparatelyFromWorkbookProtection() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelBestOfBar.WriteReservation.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                document.AddWorkSheet("Data");
+                document.SetWriteReservation(new ExcelWorkbookWriteReservationOptions {
+                    ReadOnlyRecommended = true,
+                    UserName = "Reviewer",
+                    LegacyPasswordHash = "CAFE"
+                });
+                document.ProtectWorkbook(new ExcelWorkbookProtectionOptions { LegacyPasswordHash = "BEEF" });
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                ExcelWorkbookWriteReservationInfo reservation = document.GetWriteReservation();
+
+                Assert.True(reservation.Exists);
+                Assert.True(reservation.ReadOnlyRecommended);
+                Assert.Equal("Reviewer", reservation.UserName);
+                Assert.Equal("CAFE", reservation.LegacyPasswordHash);
+                Assert.True(document.IsWorkbookProtected);
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            Workbook workbook = spreadsheet.WorkbookPart!.Workbook;
+            var children = workbook.ChildElements.ToList();
+            int fileSharingIndex = children.FindIndex(element => element is FileSharing);
+            int workbookPropertiesIndex = children.FindIndex(element => element is WorkbookProperties);
+            int workbookProtectionIndex = children.FindIndex(element => element is WorkbookProtection);
+
+            Assert.InRange(fileSharingIndex, 0, int.MaxValue);
+            Assert.InRange(workbookProtectionIndex, 0, int.MaxValue);
+            if (workbookPropertiesIndex >= 0) {
+                Assert.True(fileSharingIndex < workbookPropertiesIndex);
+            }
+            Assert.True(fileSharingIndex < workbookProtectionIndex);
+        }
+
+        [Fact]
+        public void Test_ExcelBestOfBar_RuntimePreflight_ReportsCurrentCultureAndWarnings() {
+            ExcelRuntimePreflightReport report = ExcelRuntimePreflight.InspectCurrent();
+
+            Assert.False(string.IsNullOrWhiteSpace(report.FrameworkDescription));
+            Assert.False(string.IsNullOrWhiteSpace(report.OSDescription));
+            Assert.NotNull(report.CurrentCultureName);
+            Assert.NotNull(report.CurrentUICultureName);
+            Assert.NotNull(report.Warnings);
+        }
+
+        [Fact]
+        public void Test_ExcelBestOfBar_RowHeight_DoesNotSpillIntoNeighborRows() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelBestOfBar.RowHeight.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Rows");
+                sheet.CellValue(3, 1, "Tall");
+                sheet.CellValue(4, 1, "Normal");
+                sheet.SetRowHeight(3, 42D);
+                document.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            Row row3 = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Row>().First(row => row.RowIndex!.Value == 3U);
+            Row row4 = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Row>().First(row => row.RowIndex!.Value == 4U);
+
+            Assert.Equal(42D, row3.Height!.Value);
+            Assert.True(row3.CustomHeight!.Value);
+            Assert.Null(row4.Height);
+            Assert.Null(row4.CustomHeight);
+        }
+
+        [Fact]
+        public void Test_ExcelBestOfBar_DirectDataSetLargeAppend_SaveRemainsReadableAndValid() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelBestOfBar.LargeDataSet.xlsx");
+            var dataSet = new DataSet("LargeAppend");
+            var table = new DataTable("Rows");
+            table.Columns.Add("Id", typeof(int));
+            table.Columns.Add("Name", typeof(string));
+            for (int i = 1; i <= 2500; i++) {
+                table.Rows.Add(i, "Item " + i.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            }
+            dataSet.Tables.Add(table);
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                document.InsertDataSet(dataSet, createTables: true, autoFit: false);
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.Equal("Id", document.Sheets[0].CellAt(1, 1).GetValue<string>());
+                Assert.Equal(2500D, document.Sheets[0].CellAt(2501, 1).GetValue<double>());
+                Assert.Empty(document.ValidateOpenXml());
+            }
+        }
+
+        [Fact]
+        public void Test_ExcelBestOfBar_NumberFormatCatalog_ExposesPresetNames() {
+            Assert.Contains(nameof(ExcelNumberPreset.Currency), ExcelNumberFormats.GetPresetNames());
+            Assert.Equal("0.00%", ExcelNumberFormats.Get(ExcelNumberPreset.Percent, decimals: 2));
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.ObjectDataTableBuilder.cs
+++ b/OfficeIMO.Tests/Excel.ObjectDataTableBuilder.cs
@@ -67,6 +67,25 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ObjectDataTableBuilder_JoinsCollectionValuesForCellDisplay() {
+            var items = new object?[] {
+                new Dictionary<string, object?> {
+                    ["Name"] = "A",
+                    ["Tags"] = new[] { "one", "two" }
+                },
+                new Dictionary<string, object?> {
+                    ["Name"] = "B",
+                    ["Tags"] = new List<int> { 1, 2, 3 }
+                }
+            };
+
+            var table = ObjectDataTableBuilder.FromObjects(items, "Data");
+
+            Assert.Equal("one, two", table.Rows[0]["Tags"]);
+            Assert.Equal("1, 2, 3", table.Rows[1]["Tags"]);
+        }
+
+        [Fact]
         public void Test_ObjectDataTableBuilder_FromSparseOrdinalDictionaries_PreservesBlanks() {
             var first = new Dictionary<string, object?>();
             for (int i = 0; i < 32; i++) {

--- a/OfficeIMO.Tests/Excel.SheetNameValidationAndPreflight.cs
+++ b/OfficeIMO.Tests/Excel.SheetNameValidationAndPreflight.cs
@@ -222,7 +222,7 @@ namespace OfficeIMO.Tests {
                 ws.Append(new LegacyDrawing { Id = wsPart.GetIdOfPart(vmlPart) });
                 ws.Save();
 
-                doc.Save(savePath, openExcel: false);
+                doc.Save(savePath, openExcel: false, new ExcelSaveOptions { ForceFullCalculationOnOpen = true });
             }
 
             using (var package = SpreadsheetDocument.Open(savePath, false)) {
@@ -1092,7 +1092,7 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void Preflight_RemovesCalculationChainAndMarksWorkbookForRecalcBeforeSave() {
+        public void Preflight_RemovesCalculationChainAndPreservesWorkbookCalculationPropertiesBeforeSave() {
             string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             string savePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
 
@@ -1121,9 +1121,9 @@ namespace OfficeIMO.Tests {
                 Assert.Empty(workbookPart.GetPartsOfType<CalculationChainPart>());
                 var calcProps = workbookPart.Workbook.Elements<CalculationProperties>().FirstOrDefault();
                 Assert.NotNull(calcProps);
-                Assert.Equal(191029U, calcProps!.CalculationId!.Value);
-                Assert.True(calcProps.ForceFullCalculation?.Value ?? false);
-                Assert.True(calcProps.FullCalculationOnLoad?.Value ?? false);
+                Assert.Equal(1U, calcProps!.CalculationId!.Value);
+                Assert.False(calcProps.ForceFullCalculation?.Value ?? false);
+                Assert.False(calcProps.FullCalculationOnLoad?.Value ?? false);
             }
 
             using (var reopened = ExcelDocument.Load(savePath, readOnly: true)) {


### PR DESCRIPTION
## Summary
- add safe calculation cleanup policy controls, category/date-axis scaling, table-style compatibility catalog, runtime preflight, write-reservation metadata, and number-format preset discovery
- keep repair flows explicit when workbook recalculation is requested
- add focused Excel regression coverage for calculation preflight, chart scale XML, table-style recommendations, write reservation, row height, large append readability, runtime preflight, and number-format presets

## Validation
- dotnet build OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Release
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release -f net8.0 --filter "FullyQualifiedName~ExcelBestOfBar" --logger "console;verbosity=minimal"