### PR TITLE
Add Excel column format plans

### DIFF
--- a/OfficeIMO.Excel.Benchmarks.LegacyEpPlus/Program.cs
+++ b/OfficeIMO.Excel.Benchmarks.LegacyEpPlus/Program.cs
@@ -84,6 +84,7 @@ AddScenario(scenarios, scenarioFilter, "write-cellformula", LibraryName, "EPPlus
 AddScenario(scenarios, scenarioFilter, "write-insertobjects-direct", LibraryName, "EPPlus 4.x import equivalent typed object data and save.", () => WriteDataTable(salesDataTable), warmupIterations, measuredIterations);
 AddScenario(scenarios, scenarioFilter, "write-fluent-rowsfrom-direct", LibraryName, "EPPlus 4.x import equivalent typed row data and save.", () => WriteDataTable(salesDataTable), warmupIterations, measuredIterations);
 AddScenario(scenarios, scenarioFilter, "append-plain-rows", LibraryName, "EPPlus 4.x append equivalent row/cell values.", () => AppendPlainRows(rows), warmupIterations, measuredIterations);
+AddScenario(scenarios, scenarioFilter, "copy-worksheet-package", LibraryName, "EPPlus 4.x copy one worksheet between workbooks with the library worksheet-copy API.", () => CopyWorksheet(workbookBytes), warmupIterations, measuredIterations);
 AddScenario(scenarios, scenarioFilter, "read-range", LibraryName, "EPPlus 4.x iterate used data cells from workbook.", () => ReadRange(workbookBytes), warmupIterations, measuredIterations);
 AddScenario(scenarios, scenarioFilter, "read-top-range", LibraryName, "EPPlus 4.x read the first 100 data rows from a larger sheet.", () => ReadRange(workbookBytes, topDataRows), warmupIterations, measuredIterations);
 AddScenario(scenarios, scenarioFilter, "read-datatable", LibraryName, "EPPlus 4.x manual DataTable materialization from worksheet rows.", () => ReadDataTable(workbookBytes), warmupIterations, measuredIterations);
@@ -284,6 +285,21 @@ static int AppendPlainRows(IReadOnlyList<SalesRecord> rows) {
     }
 
     return checked((int)stream.Length);
+}
+
+static int CopyWorksheet(byte[] workbookBytes) {
+    using var input = new MemoryStream(workbookBytes, writable: false);
+    using var sourcePackage = new ExcelPackage(input);
+    var sourceWorksheet = sourcePackage.Workbook.Worksheets["Data"]
+        ?? throw new InvalidOperationException("Source worksheet 'Data' was not found.");
+
+    using var output = new MemoryStream();
+    using (var targetPackage = new ExcelPackage(output)) {
+        targetPackage.Workbook.Worksheets.Add("CopiedData", sourceWorksheet);
+        targetPackage.Save();
+    }
+
+    return checked((int)output.Length);
 }
 
 static int ReadRange(byte[] workbookBytes, int maxDataRows = int.MaxValue) {

--- a/OfficeIMO.Excel.Benchmarks/ExcelLibraryComparisonRunner.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelLibraryComparisonRunner.cs
@@ -388,6 +388,13 @@ internal static partial class ExcelLibraryComparisonRunner {
             new LibraryComparisonCase("LargeXlsx", "Streaming export of equivalent four-column row/cell values.", () => LargeXlsxWriteSalesRows(rows, includeAllColumns: false))
         ]);
 
+        AddScenarioGroup(scenarios, scenarioFilter, "copy-worksheet-package", warmupIterations, measuredIterations, [
+            new LibraryComparisonCase("OfficeIMO.Excel", "Copy one worksheet between workbooks with package mode, avoiding row-object materialization.", () => OfficeImoCopyWorksheetFromPackage(officeImoWorkbookBytes.Value)),
+            new LibraryComparisonCase("OfficeIMO.Excel Values", "Copy one worksheet between workbooks through the reader/writer values fallback.", () => OfficeImoCopyWorksheetFromValues(officeImoWorkbookBytes.Value)),
+            new LibraryComparisonCase("ClosedXML", "Copy one worksheet between workbooks with the library worksheet-copy API.", () => ClosedXmlCopyWorksheet(closedXmlWorkbookBytes.Value)),
+            new LibraryComparisonCase("EPPlus", "Copy one worksheet between workbooks with the library worksheet-copy API.", () => EpPlusCopyWorksheet(epPlusWorkbookBytes.Value))
+        ]);
+
         AddScenarioGroup(scenarios, scenarioFilter, "read-range", warmupIterations, measuredIterations, [
             new LibraryComparisonCase("OfficeIMO.Excel", "Read A1 range with automatic execution policy.", () => OfficeImoReadRange(officeImoWorkbookBytes.Value, dataRange)),
             new LibraryComparisonCase("ClosedXML", "Iterate used data cells from the same workbook payload.", () => ClosedXmlReadRange(officeImoWorkbookBytes.Value)),
@@ -2124,6 +2131,64 @@ internal static partial class ExcelLibraryComparisonRunner {
         }
 
         return stream.ToArray();
+    }
+
+    private static int OfficeImoCopyWorksheetFromPackage(byte[] workbookBytes)
+        => ByteCount(OfficeImoCopyWorksheetFromBytes(workbookBytes, ExcelWorksheetCopyMode.Package));
+
+    private static int OfficeImoCopyWorksheetFromValues(byte[] workbookBytes)
+        => ByteCount(OfficeImoCopyWorksheetFromBytes(workbookBytes, ExcelWorksheetCopyMode.Values));
+
+    private static byte[] OfficeImoCopyWorksheetFromBytes(byte[] workbookBytes, ExcelWorksheetCopyMode copyMode) {
+        using var sourceStream = new MemoryStream(workbookBytes, writable: false);
+        using var sourceDocument = ExcelDocument.Load(sourceStream, readOnly: true);
+        using var targetStream = new MemoryStream();
+        using (var targetDocument = ExcelDocument.Create(targetStream, autoSave: false)) {
+            targetDocument.CopyWorksheetFrom(
+                sourceDocument,
+                "Data",
+                "DataCopy",
+                SheetNameValidationMode.Sanitize,
+                new ExcelWorksheetCopyOptions { CopyMode = copyMode });
+            targetDocument.Save(targetStream);
+        }
+
+        return targetStream.ToArray();
+    }
+
+    private static int ClosedXmlCopyWorksheet(byte[] workbookBytes)
+        => ByteCount(ClosedXmlCopyWorksheetBytes(workbookBytes));
+
+    private static byte[] ClosedXmlCopyWorksheetBytes(byte[] workbookBytes) {
+        using var sourceStream = new MemoryStream(workbookBytes, writable: false);
+        using var sourceWorkbook = new XLWorkbook(sourceStream);
+        using var targetStream = new MemoryStream();
+        using (var targetWorkbook = new XLWorkbook()) {
+            sourceWorkbook.Worksheet("Data").CopyTo(targetWorkbook, "DataCopy");
+            targetWorkbook.SaveAs(targetStream);
+        }
+
+        return targetStream.ToArray();
+    }
+
+    private static int EpPlusCopyWorksheet(byte[] workbookBytes)
+        => ByteCount(EpPlusCopyWorksheetBytes(workbookBytes));
+
+    private static byte[] EpPlusCopyWorksheetBytes(byte[] workbookBytes) {
+        using var sourceStream = new MemoryStream(workbookBytes, writable: false);
+        using var sourcePackage = new ExcelPackage(sourceStream);
+        using var targetStream = new MemoryStream();
+        using (var targetPackage = new ExcelPackage(targetStream)) {
+            var sourceWorksheet = sourcePackage.Workbook.Worksheets["Data"];
+            if (sourceWorksheet == null) {
+                throw new InvalidOperationException("Source worksheet 'Data' was not found.");
+            }
+
+            targetPackage.Workbook.Worksheets.Add("DataCopy", sourceWorksheet);
+            targetPackage.Save();
+        }
+
+        return targetStream.ToArray();
     }
 
     private static int ClosedXmlAppendPlainRows(IReadOnlyList<ExcelBenchmarkScenarioFactory.SalesRecord> rows)

--- a/OfficeIMO.Excel.Benchmarks/ExcelWorksheetCopyBenchmarks.cs
+++ b/OfficeIMO.Excel.Benchmarks/ExcelWorksheetCopyBenchmarks.cs
@@ -1,0 +1,44 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace OfficeIMO.Excel.Benchmarks;
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net80)]
+public class ExcelWorksheetCopyBenchmarks {
+    private byte[] _sourceWorkbookBytes = [];
+
+    [Params(100, 2500, 25000)]
+    public int RowCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup() {
+        var rows = ExcelBenchmarkScenarioFactory.CreateSalesRecords(RowCount);
+        _sourceWorkbookBytes = ExcelBenchmarkScenarioFactory.CreateWorkbookBytes(rows);
+    }
+
+    [Benchmark(Baseline = true)]
+    public int PackageCopy()
+        => CopyWorksheet(ExcelWorksheetCopyMode.Package);
+
+    [Benchmark]
+    public int ValuesCopy()
+        => CopyWorksheet(ExcelWorksheetCopyMode.Values);
+
+    private int CopyWorksheet(ExcelWorksheetCopyMode copyMode) {
+        using var sourceStream = new MemoryStream(_sourceWorkbookBytes, writable: false);
+        using var sourceDocument = ExcelDocument.Load(sourceStream, readOnly: true);
+        using var targetStream = new MemoryStream();
+        using (var targetDocument = ExcelDocument.Create(targetStream, autoSave: false)) {
+            targetDocument.CopyWorksheetFrom(
+                sourceDocument,
+                "Data",
+                "DataCopy",
+                SheetNameValidationMode.Sanitize,
+                new ExcelWorksheetCopyOptions { CopyMode = copyMode });
+            targetDocument.Save(targetStream);
+        }
+
+        return checked((int)targetStream.Length);
+    }
+}

--- a/OfficeIMO.Excel.Benchmarks/README.md
+++ b/OfficeIMO.Excel.Benchmarks/README.md
@@ -36,6 +36,15 @@ dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\
 
 The comparison harness includes only libraries whose public APIs map to a scenario. It uses separate handling for legacy EPPlus so incompatible package generations do not run in one process.
 
+### Competitor coverage
+
+The comparison suite is intentionally scenario-shaped rather than forcing every library into every workflow:
+
+- Workbook/package edit scenarios, such as `copy-worksheet-package`, compare `OfficeIMO.Excel`, `OfficeIMO.Excel Values`, `ClosedXML`, current `EPPlus`, and legacy `EPPlus 4.5.3.3`.
+- Streaming/table export scenarios compare `OfficeIMO.Excel` with `ClosedXML`, current `EPPlus`, legacy `EPPlus 4.5.3.3`, `MiniExcel`, `LargeXlsx`, and `Sylvan.Data.Excel` where those libraries expose a matching write path.
+- Read scenarios compare `OfficeIMO.Excel` with `ClosedXML`, current `EPPlus`, legacy `EPPlus 4.5.3.3`, `MiniExcel`, `ExcelDataReader`, and `Sylvan.Data.Excel` where the library exposes a matching read path.
+- Libraries that do not expose a natural worksheet-copy or workbook-edit API are omitted from that specific scenario instead of being represented by an artificial row-by-row workaround.
+
 For release-style evidence:
 
 ```powershell
@@ -46,6 +55,12 @@ Focus the package-copy workbook merge scenario:
 
 ```powershell
 dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- compare --rows 25000 --scenario copy-worksheet-package --warmup 1 --iterations 3
+```
+
+Use `--skip-legacy-epplus` only when you want a faster local pass without the isolated EPPlus 4.x subprocess:
+
+```powershell
+dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- compare --rows 25000 --scenario copy-worksheet-package --skip-legacy-epplus --warmup 1 --iterations 3
 ```
 
 ## Website data

--- a/OfficeIMO.Excel.Benchmarks/README.md
+++ b/OfficeIMO.Excel.Benchmarks/README.md
@@ -14,6 +14,12 @@ Filter a class:
 dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --filter *ExcelWriteBenchmarks*
 ```
 
+Measure worksheet copy fast paths:
+
+```powershell
+dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- --filter *ExcelWorksheetCopyBenchmarks*
+```
+
 ## Snapshot and profile artifacts
 
 ```powershell
@@ -34,6 +40,12 @@ For release-style evidence:
 
 ```powershell
 dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- comparison-suite --out-dir .\Docs\benchmarks\comparison-current --row-set 2500,25000 --warmup 1 --iterations 3
+```
+
+Focus the package-copy workbook merge scenario:
+
+```powershell
+dotnet run -c Release --framework net8.0 --project .\OfficeIMO.Excel.Benchmarks\OfficeIMO.Excel.Benchmarks.csproj -- compare --rows 25000 --scenario copy-worksheet-package --warmup 1 --iterations 3
 ```
 
 ## Website data

--- a/OfficeIMO.Excel/ExcelColumnFormatPlan.cs
+++ b/OfficeIMO.Excel/ExcelColumnFormatPlan.cs
@@ -1,0 +1,236 @@
+using System.Globalization;
+
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Describes reusable header-based column number formats for worksheet exports.
+    /// </summary>
+    public sealed class ExcelColumnFormatPlan {
+        private readonly List<ExcelColumnFormatRule> _rules = new();
+
+        /// <summary>
+        /// Gets the configured column format rules.
+        /// </summary>
+        public IReadOnlyList<ExcelColumnFormatRule> Rules => _rules;
+
+        /// <summary>
+        /// Gets the number of configured rules.
+        /// </summary>
+        public int Count => _rules.Count;
+
+        /// <summary>
+        /// Adds a preset number format for a column resolved by header text.
+        /// </summary>
+        public ExcelColumnFormatPlan Add(
+            string header,
+            ExcelNumberPreset preset,
+            int decimals = 2,
+            CultureInfo? culture = null,
+            bool includeHeader = false,
+            bool autoFit = false) {
+            _rules.Add(ExcelColumnFormatRule.FromPreset(header, preset, decimals, culture, includeHeader, autoFit));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a custom Excel number format for a column resolved by header text.
+        /// </summary>
+        public ExcelColumnFormatPlan AddFormat(string header, string numberFormat, bool includeHeader = false, bool autoFit = false) {
+            _rules.Add(ExcelColumnFormatRule.FromFormat(header, numberFormat, includeHeader, autoFit));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds text formatting for columns resolved by header text.
+        /// </summary>
+        public ExcelColumnFormatPlan Text(params string[] headers) => AddPreset(headers, ExcelNumberPreset.Text, 0);
+
+        /// <summary>
+        /// Adds decimal number formatting for columns resolved by header text.
+        /// </summary>
+        public ExcelColumnFormatPlan Number(params string[] headers) => AddPreset(headers, ExcelNumberPreset.Decimal, 2);
+
+        /// <summary>
+        /// Adds decimal number formatting with explicit precision for columns resolved by header text.
+        /// </summary>
+        public ExcelColumnFormatPlan Number(int decimals, params string[] headers) => AddPreset(headers, ExcelNumberPreset.Decimal, decimals);
+
+        /// <summary>
+        /// Adds integer formatting for columns resolved by header text.
+        /// </summary>
+        public ExcelColumnFormatPlan Integer(params string[] headers) => AddPreset(headers, ExcelNumberPreset.Integer, 0);
+
+        /// <summary>
+        /// Adds percent formatting for columns resolved by header text.
+        /// </summary>
+        public ExcelColumnFormatPlan Percent(params string[] headers) => AddPreset(headers, ExcelNumberPreset.Percent, 0);
+
+        /// <summary>
+        /// Adds percent formatting with explicit precision for columns resolved by header text.
+        /// </summary>
+        public ExcelColumnFormatPlan Percent(int decimals, params string[] headers) => AddPreset(headers, ExcelNumberPreset.Percent, decimals);
+
+        /// <summary>
+        /// Adds currency formatting for columns resolved by header text.
+        /// </summary>
+        public ExcelColumnFormatPlan Currency(params string[] headers) => Currency(2, null, headers);
+
+        /// <summary>
+        /// Adds culture-aware currency formatting for columns resolved by header text.
+        /// </summary>
+        public ExcelColumnFormatPlan Currency(CultureInfo? culture, params string[] headers) => Currency(2, culture, headers);
+
+        /// <summary>
+        /// Adds currency formatting with explicit precision for columns resolved by header text.
+        /// </summary>
+        public ExcelColumnFormatPlan Currency(int decimals, params string[] headers) => Currency(decimals, null, headers);
+
+        /// <summary>
+        /// Adds culture-aware currency formatting with explicit precision for columns resolved by header text.
+        /// </summary>
+        public ExcelColumnFormatPlan Currency(int decimals, CultureInfo? culture, params string[] headers) {
+            foreach (string header in NormalizeHeaders(headers)) {
+                Add(header, ExcelNumberPreset.Currency, decimals, culture);
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Adds date formatting for columns resolved by header text.
+        /// </summary>
+        public ExcelColumnFormatPlan Date(params string[] headers) => AddPreset(headers, ExcelNumberPreset.DateShort, 0);
+
+        /// <summary>
+        /// Adds date and time formatting for columns resolved by header text.
+        /// </summary>
+        public ExcelColumnFormatPlan DateTime(params string[] headers) => AddPreset(headers, ExcelNumberPreset.DateTime, 0);
+
+        private ExcelColumnFormatPlan AddPreset(IEnumerable<string> headers, ExcelNumberPreset preset, int decimals) {
+            foreach (string header in NormalizeHeaders(headers)) {
+                Add(header, preset, decimals);
+            }
+            return this;
+        }
+
+        private static IEnumerable<string> NormalizeHeaders(IEnumerable<string>? headers) {
+            if (headers == null) {
+                yield break;
+            }
+
+            foreach (string? header in headers) {
+                if (!string.IsNullOrWhiteSpace(header)) {
+                    yield return header.Trim();
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Describes one header-based column number format.
+    /// </summary>
+    public sealed class ExcelColumnFormatRule {
+        private ExcelColumnFormatRule(
+            string header,
+            ExcelNumberPreset? preset,
+            string? numberFormat,
+            int decimals,
+            CultureInfo? culture,
+            bool includeHeader,
+            bool autoFit) {
+            if (string.IsNullOrWhiteSpace(header)) {
+                throw new ArgumentException("Header cannot be empty.", nameof(header));
+            }
+
+            if (preset == null && string.IsNullOrWhiteSpace(numberFormat)) {
+                throw new ArgumentException("A preset or custom number format is required.", nameof(numberFormat));
+            }
+
+            if (decimals < 0) {
+                throw new ArgumentOutOfRangeException(nameof(decimals), "Decimals must be zero or greater.");
+            }
+
+            Header = header.Trim();
+            Preset = preset;
+            NumberFormat = string.IsNullOrWhiteSpace(numberFormat) ? null : numberFormat;
+            Decimals = decimals;
+            Culture = culture;
+            IncludeHeader = includeHeader;
+            AutoFit = autoFit;
+        }
+
+        /// <summary>Header caption used to resolve the column.</summary>
+        public string Header { get; }
+
+        /// <summary>Preset number format, when the rule was created from a preset.</summary>
+        public ExcelNumberPreset? Preset { get; }
+
+        /// <summary>Custom number format, when supplied directly.</summary>
+        public string? NumberFormat { get; }
+
+        /// <summary>Decimal places used by preset formats that support precision.</summary>
+        public int Decimals { get; }
+
+        /// <summary>Culture used for culture-aware preset formats such as currency.</summary>
+        public CultureInfo? Culture { get; }
+
+        /// <summary>Whether the header cell should also receive the format.</summary>
+        public bool IncludeHeader { get; }
+
+        /// <summary>Whether the resolved column should be auto-fit after formatting.</summary>
+        public bool AutoFit { get; }
+
+        /// <summary>
+        /// Creates a preset-based column format rule.
+        /// </summary>
+        public static ExcelColumnFormatRule FromPreset(
+            string header,
+            ExcelNumberPreset preset,
+            int decimals = 2,
+            CultureInfo? culture = null,
+            bool includeHeader = false,
+            bool autoFit = false) {
+            return new ExcelColumnFormatRule(header, preset, null, decimals, culture, includeHeader, autoFit);
+        }
+
+        /// <summary>
+        /// Creates a custom number-format rule.
+        /// </summary>
+        public static ExcelColumnFormatRule FromFormat(string header, string numberFormat, bool includeHeader = false, bool autoFit = false) {
+            return new ExcelColumnFormatRule(header, null, numberFormat, 0, null, includeHeader, autoFit);
+        }
+
+        /// <summary>
+        /// Resolves the Excel number format code for this rule.
+        /// </summary>
+        public string ResolveNumberFormat() {
+            return NumberFormat ?? ExcelNumberFormats.Get(Preset ?? ExcelNumberPreset.General, Decimals, Culture);
+        }
+    }
+
+    /// <summary>
+    /// Result for one applied or skipped column format rule.
+    /// </summary>
+    public sealed class ExcelColumnFormatResult {
+        internal ExcelColumnFormatResult(string header, int? columnIndex, bool applied, string numberFormat, string? warning) {
+            Header = header;
+            ColumnIndex = columnIndex;
+            Applied = applied;
+            NumberFormat = numberFormat;
+            Warning = warning;
+        }
+
+        /// <summary>Header requested by the format rule.</summary>
+        public string Header { get; }
+
+        /// <summary>One-based column index when the header was resolved.</summary>
+        public int? ColumnIndex { get; }
+
+        /// <summary>Whether the rule was applied.</summary>
+        public bool Applied { get; }
+
+        /// <summary>Number format code resolved for the rule.</summary>
+        public string NumberFormat { get; }
+
+        /// <summary>Warning for skipped rules, when any.</summary>
+        public string? Warning { get; }
+    }
+}

--- a/OfficeIMO.Excel/ExcelColumnFormatPlan.cs
+++ b/OfficeIMO.Excel/ExcelColumnFormatPlan.cs
@@ -118,7 +118,7 @@ namespace OfficeIMO.Excel {
 
             foreach (string? header in headers) {
                 if (!string.IsNullOrWhiteSpace(header)) {
-                    yield return header.Trim();
+                    yield return header;
                 }
             }
         }
@@ -148,7 +148,7 @@ namespace OfficeIMO.Excel {
                 throw new ArgumentOutOfRangeException(nameof(decimals), "Decimals must be zero or greater.");
             }
 
-            Header = header.Trim();
+            Header = header;
             Preset = preset;
             NumberFormat = string.IsNullOrWhiteSpace(numberFormat) ? null : numberFormat;
             Decimals = decimals;

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Metadata.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Metadata.cs
@@ -647,6 +647,17 @@ namespace OfficeIMO.Excel {
             }
         }
 
+        internal bool HasMaterializedDirectTabularFastSaveWorksheet(ExcelSheet sheet) {
+            if (sheet == null) throw new ArgumentNullException(nameof(sheet));
+            if (!ReferenceEquals(sheet.Document, this) || !_materializedDirectDataSetFastSaveModelHasMaterializedWorksheet) {
+                return false;
+            }
+
+            var model = _materializedDirectDataSetFastSaveModel;
+            return model != null
+                && model.Sheets.Any(item => string.Equals(item.SheetName, sheet.Name, StringComparison.Ordinal));
+        }
+
         internal bool TryGetDirectTabularSaveCandidateColumnByHeader(
             ExcelSheet sheet,
             string header,

--- a/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Metadata.cs
+++ b/OfficeIMO.Excel/ExcelDocument.DirectDataSet.Metadata.cs
@@ -655,9 +655,30 @@ namespace OfficeIMO.Excel {
             out int columnIndex,
             out int startRow,
             out int endRow) {
+            return TryGetDirectTabularSaveCandidateColumnByHeader(
+                sheet,
+                header,
+                includeHeader,
+                options,
+                out columnIndex,
+                out startRow,
+                out endRow,
+                out _);
+        }
+
+        internal bool TryGetDirectTabularSaveCandidateColumnByHeader(
+            ExcelSheet sheet,
+            string header,
+            bool includeHeader,
+            ExcelReadOptions? options,
+            out int columnIndex,
+            out int startRow,
+            out int endRow,
+            out bool candidateAvailable) {
             columnIndex = 0;
             startRow = 0;
             endRow = -1;
+            candidateAvailable = false;
             if (sheet == null) throw new ArgumentNullException(nameof(sheet));
             if (string.IsNullOrWhiteSpace(header) || !ReferenceEquals(sheet.Document, this)) {
                 return false;
@@ -674,6 +695,7 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
+            candidateAvailable = true;
             bool normalizeHeaders = options?.NormalizeHeaders ?? true;
             string normalizedHeader = ExcelHeaderNameHelper.NormalizeHeader(header, normalizeHeaders);
             var headers = ExcelHeaderNameHelper.BuildUniqueHeaders(

--- a/OfficeIMO.Excel/ExcelDocument.SheetRename.cs
+++ b/OfficeIMO.Excel/ExcelDocument.SheetRename.cs
@@ -342,7 +342,7 @@ namespace OfficeIMO.Excel {
                     return false;
                 }
 
-                replacement = QuoteSheetNameReference(rewrittenFirst) + ":" + QuoteSheetNameReference(rewrittenSecond) + "!";
+                replacement = QuoteSheetRangeReference(rewrittenFirst, rewrittenSecond) + "!";
                 consumed = afterSecondToken - startIndex + 1;
                 return true;
             }
@@ -358,7 +358,7 @@ namespace OfficeIMO.Excel {
                     return false;
                 }
 
-                replacement = QuoteSheetNameReference(rewrittenFirst) + ":" + QuoteSheetNameReference(rewrittenSecond) + "!";
+                replacement = QuoteSheetRangeReference(rewrittenFirst, rewrittenSecond) + "!";
                 consumed = afterFirstToken - startIndex + 1;
                 return true;
             }
@@ -444,6 +444,10 @@ namespace OfficeIMO.Excel {
 
         private static string QuoteSheetNameReference(string sheetName) {
             return $"'{EscapeSheetName(sheetName)}'";
+        }
+
+        private static string QuoteSheetRangeReference(string firstSheetName, string secondSheetName) {
+            return $"'{EscapeSheetName(firstSheetName)}:{EscapeSheetName(secondSheetName)}'";
         }
 
         private static bool IsExternalSheetToken(string sheetToken) {

--- a/OfficeIMO.Excel/ExcelDocument.SheetRename.cs
+++ b/OfficeIMO.Excel/ExcelDocument.SheetRename.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -272,8 +273,17 @@ namespace OfficeIMO.Excel {
                 return text;
             }
 
+            return ReplaceSheetNameReferences(text, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                [oldSheetName] = newSheetName
+            });
+        }
+
+        internal static string ReplaceSheetNameReferences(string text, IReadOnlyDictionary<string, string> sheetNameMap) {
+            if (string.IsNullOrEmpty(text) || sheetNameMap.Count == 0) {
+                return text;
+            }
+
             var builder = new StringBuilder(text.Length + 16);
-            string replacement = $"'{EscapeSheetName(newSheetName)}'!";
             bool changed = false;
             bool inStringLiteral = false;
 
@@ -293,22 +303,9 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                if (!inStringLiteral && ch == '\'') {
-                    int closingQuote = FindQuotedTokenEnd(text, i);
-                    if (closingQuote > i && closingQuote + 1 < text.Length && text[closingQuote + 1] == '!') {
-                        string quotedName = text.Substring(i + 1, closingQuote - i - 1).Replace("''", "'");
-                        if (!IsExternalSheetToken(quotedName) && string.Equals(quotedName, oldSheetName, StringComparison.OrdinalIgnoreCase)) {
-                            builder.Append(replacement);
-                            i = closingQuote + 2;
-                            changed = true;
-                            continue;
-                        }
-                    }
-                }
-
-                if (!inStringLiteral && IsBareSheetReferenceStart(text, i, oldSheetName)) {
+                if (!inStringLiteral && TryRewriteSheetReferenceAt(text, i, sheetNameMap, out string? replacement, out int consumed)) {
                     builder.Append(replacement);
-                    i += oldSheetName.Length + 1;
+                    i += consumed;
                     changed = true;
                     continue;
                 }
@@ -318,6 +315,110 @@ namespace OfficeIMO.Excel {
             }
 
             return changed ? builder.ToString() : text;
+        }
+
+        private static bool TryRewriteSheetReferenceAt(
+            string text,
+            int startIndex,
+            IReadOnlyDictionary<string, string> sheetNameMap,
+            out string? replacement,
+            out int consumed) {
+            replacement = null;
+            consumed = 0;
+
+            if (!TryReadSheetToken(text, startIndex, out string? firstSheetName, out int afterFirstToken, out bool firstExternal)) {
+                return false;
+            }
+
+            if (afterFirstToken < text.Length && text[afterFirstToken] == ':'
+                && TryReadSheetToken(text, afterFirstToken + 1, out string? secondSheetName, out int afterSecondToken, out bool secondExternal)
+                && afterSecondToken < text.Length
+                && text[afterSecondToken] == '!'
+                && !firstExternal
+                && !secondExternal) {
+                string rewrittenFirst = ResolveMappedSheetName(firstSheetName!, sheetNameMap, out bool firstChanged);
+                string rewrittenSecond = ResolveMappedSheetName(secondSheetName!, sheetNameMap, out bool secondChanged);
+                if (!firstChanged && !secondChanged) {
+                    return false;
+                }
+
+                replacement = QuoteSheetNameReference(rewrittenFirst) + ":" + QuoteSheetNameReference(rewrittenSecond) + "!";
+                consumed = afterSecondToken - startIndex + 1;
+                return true;
+            }
+
+            if (afterFirstToken >= text.Length || text[afterFirstToken] != '!' || firstExternal) {
+                return false;
+            }
+
+            string rewritten = ResolveMappedSheetName(firstSheetName!, sheetNameMap, out bool changed);
+            if (!changed) {
+                return false;
+            }
+
+            replacement = QuoteSheetNameReference(rewritten) + "!";
+            consumed = afterFirstToken - startIndex + 1;
+            return true;
+        }
+
+        private static bool TryReadSheetToken(
+            string text,
+            int startIndex,
+            out string? sheetName,
+            out int afterToken,
+            out bool isExternal) {
+            sheetName = null;
+            afterToken = startIndex;
+            isExternal = false;
+
+            if (startIndex < 0 || startIndex >= text.Length) {
+                return false;
+            }
+
+            if (text[startIndex] == '\'') {
+                int closingQuote = FindQuotedTokenEnd(text, startIndex);
+                if (closingQuote <= startIndex) {
+                    return false;
+                }
+
+                string quotedName = text.Substring(startIndex + 1, closingQuote - startIndex - 1).Replace("''", "'");
+                sheetName = quotedName;
+                afterToken = closingQuote + 1;
+                isExternal = IsExternalSheetToken(quotedName);
+                return true;
+            }
+
+            if (!IsBareSheetReferenceBoundary(text, startIndex)) {
+                return false;
+            }
+
+            int index = startIndex;
+            while (index < text.Length && IsBareSheetNameCharacter(text[index])) {
+                index++;
+            }
+
+            if (index == startIndex) {
+                return false;
+            }
+
+            sheetName = text.Substring(startIndex, index - startIndex);
+            afterToken = index;
+            isExternal = IsExternalSheetToken(sheetName);
+            return true;
+        }
+
+        private static string ResolveMappedSheetName(string sheetName, IReadOnlyDictionary<string, string> sheetNameMap, out bool changed) {
+            if (sheetNameMap.TryGetValue(sheetName, out string? mapped) && !string.IsNullOrEmpty(mapped)) {
+                changed = !string.Equals(sheetName, mapped, StringComparison.Ordinal);
+                return mapped!;
+            }
+
+            changed = false;
+            return sheetName;
+        }
+
+        private static string QuoteSheetNameReference(string sheetName) {
+            return $"'{EscapeSheetName(sheetName)}'";
         }
 
         private static bool IsExternalSheetToken(string sheetToken) {
@@ -392,24 +493,7 @@ namespace OfficeIMO.Excel {
             return -1;
         }
 
-        private static bool IsBareSheetReferenceStart(string text, int startIndex, string oldSheetName) {
-            if (string.IsNullOrEmpty(oldSheetName)) {
-                return false;
-            }
-
-            int endIndex = startIndex + oldSheetName.Length;
-            if (endIndex >= text.Length) {
-                return false;
-            }
-
-            if (!string.Equals(text.Substring(startIndex, oldSheetName.Length), oldSheetName, StringComparison.OrdinalIgnoreCase)) {
-                return false;
-            }
-
-            if (text[endIndex] != '!') {
-                return false;
-            }
-
+        private static bool IsBareSheetReferenceBoundary(string text, int startIndex) {
             if (startIndex == 0) {
                 return true;
             }
@@ -420,6 +504,10 @@ namespace OfficeIMO.Excel {
             }
 
             return true;
+        }
+
+        private static bool IsBareSheetNameCharacter(char value) {
+            return char.IsLetterOrDigit(value) || value == '_' || value == '.';
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelDocument.SheetRename.cs
+++ b/OfficeIMO.Excel/ExcelDocument.SheetRename.cs
@@ -351,6 +351,18 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
+            if (TrySplitQuotedThreeDimensionalSheetRange(firstSheetName!, out string? firstRangeSheet, out string? secondRangeSheet)) {
+                string rewrittenFirst = ResolveMappedSheetName(firstRangeSheet!, sheetNameMap, out bool firstChanged);
+                string rewrittenSecond = ResolveMappedSheetName(secondRangeSheet!, sheetNameMap, out bool secondChanged);
+                if (!firstChanged && !secondChanged) {
+                    return false;
+                }
+
+                replacement = QuoteSheetNameReference(rewrittenFirst) + ":" + QuoteSheetNameReference(rewrittenSecond) + "!";
+                consumed = afterFirstToken - startIndex + 1;
+                return true;
+            }
+
             string rewritten = ResolveMappedSheetName(firstSheetName!, sheetNameMap, out bool changed);
             if (!changed) {
                 return false;
@@ -359,6 +371,19 @@ namespace OfficeIMO.Excel {
             replacement = QuoteSheetNameReference(rewritten) + "!";
             consumed = afterFirstToken - startIndex + 1;
             return true;
+        }
+
+        private static bool TrySplitQuotedThreeDimensionalSheetRange(string sheetToken, out string? firstSheetName, out string? secondSheetName) {
+            firstSheetName = null;
+            secondSheetName = null;
+            int separator = sheetToken.IndexOf(':');
+            if (separator <= 0 || separator >= sheetToken.Length - 1) {
+                return false;
+            }
+
+            firstSheetName = sheetToken.Substring(0, separator);
+            secondSheetName = sheetToken.Substring(separator + 1);
+            return !IsExternalSheetToken(firstSheetName) && !IsExternalSheetToken(secondSheetName);
         }
 
         private static bool TryReadSheetToken(

--- a/OfficeIMO.Excel/ExcelDocument.WorkbookMerge.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorkbookMerge.cs
@@ -1,6 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeFormula = DocumentFormat.OpenXml.Office.Excel.Formula;
 
 namespace OfficeIMO.Excel {
     /// <summary>
@@ -20,6 +24,7 @@ namespace OfficeIMO.Excel {
             List<ExcelSheet> sourceSheets = ResolveWorkbookMergeSheets(sourceDocument, options).ToList();
             var importedSourceNames = new List<string>(sourceSheets.Count);
             var createdTargetNames = new List<string>(sourceSheets.Count);
+            var sheetNameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (ExcelSheet sourceSheet in sourceSheets) {
                 string requestedName = (options.SheetNamePrefix ?? string.Empty) + sourceSheet.Name;
@@ -28,8 +33,10 @@ namespace OfficeIMO.Excel {
                 });
                 importedSourceNames.Add(sourceSheet.Name);
                 createdTargetNames.Add(targetSheet.Name);
+                sheetNameMap[sourceSheet.Name] = targetSheet.Name;
             }
 
+            RewriteMergedWorksheetReferences(createdTargetNames, sheetNameMap);
             MarkPackageDirty();
             return new ExcelWorkbookMergeResult(importedSourceNames, createdTargetNames);
         }
@@ -46,6 +53,87 @@ namespace OfficeIMO.Excel {
             }
 
             return options.SheetNames.Select(sourceDocument.GetSheet);
+        }
+
+        private void RewriteMergedWorksheetReferences(IEnumerable<string> copiedSheetNames, IReadOnlyDictionary<string, string> sheetNameMap) {
+            if (sheetNameMap.Count == 0) {
+                return;
+            }
+
+            foreach (string copiedSheetName in copiedSheetNames) {
+                ExcelSheet copiedSheet = GetSheet(copiedSheetName);
+                WorksheetPart worksheetPart = copiedSheet.WorksheetPart;
+                Worksheet worksheet = worksheetPart.Worksheet ?? throw new InvalidOperationException("Worksheet is missing.");
+                bool worksheetChanged = RewriteWorksheetFormulaSheetReferences(worksheet, sheetNameMap);
+
+                foreach (TableDefinitionPart tablePart in worksheetPart.TableDefinitionParts) {
+                    Table? table = tablePart.Table;
+                    if (table == null) {
+                        continue;
+                    }
+
+                    bool tableChanged = false;
+                    foreach (CalculatedColumnFormula formula in table.Descendants<CalculatedColumnFormula>()) {
+                        tableChanged |= RewriteFormulaSheetReference(formula, sheetNameMap);
+                    }
+
+                    foreach (TotalsRowFormula formula in table.Descendants<TotalsRowFormula>()) {
+                        tableChanged |= RewriteFormulaSheetReference(formula, sheetNameMap);
+                    }
+
+                    if (tableChanged) {
+                        table.Save();
+                    }
+                }
+
+                if (worksheetChanged) {
+                    worksheet.Save();
+                }
+            }
+        }
+
+        private static bool RewriteWorksheetFormulaSheetReferences(Worksheet worksheet, IReadOnlyDictionary<string, string> sheetNameMap) {
+            bool changed = false;
+            foreach (CellFormula formula in worksheet.Descendants<CellFormula>()) {
+                changed |= RewriteFormulaSheetReference(formula, sheetNameMap);
+            }
+
+            foreach (Formula formula in worksheet.Descendants<Formula>()) {
+                changed |= RewriteFormulaSheetReference(formula, sheetNameMap);
+            }
+
+            foreach (Formula1 formula in worksheet.Descendants<Formula1>()) {
+                changed |= RewriteFormulaSheetReference(formula, sheetNameMap);
+            }
+
+            foreach (Formula2 formula in worksheet.Descendants<Formula2>()) {
+                changed |= RewriteFormulaSheetReference(formula, sheetNameMap);
+            }
+
+            foreach (OfficeFormula formula in worksheet.Descendants<OfficeFormula>()) {
+                changed |= RewriteFormulaSheetReference(formula, sheetNameMap);
+            }
+
+            return changed;
+        }
+
+        private static bool RewriteFormulaSheetReference(OpenXmlLeafTextElement formula, IReadOnlyDictionary<string, string> sheetNameMap) {
+            string? text = formula.Text;
+            if (string.IsNullOrEmpty(text)) {
+                return false;
+            }
+
+            string updated = text!;
+            foreach (KeyValuePair<string, string> mapping in sheetNameMap) {
+                updated = ReplaceSheetNameReferences(updated, mapping.Key, mapping.Value);
+            }
+
+            if (string.Equals(updated, text, StringComparison.Ordinal)) {
+                return false;
+            }
+
+            formula.Text = updated;
+            return true;
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelDocument.WorkbookMerge.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorkbookMerge.cs
@@ -23,7 +23,9 @@ namespace OfficeIMO.Excel {
 
             foreach (ExcelSheet sourceSheet in sourceSheets) {
                 string requestedName = (options.SheetNamePrefix ?? string.Empty) + sourceSheet.Name;
-                ExcelSheet targetSheet = CopyWorkSheetFrom(sourceDocument, sourceSheet.Name, requestedName, options.SheetNameValidationMode);
+                ExcelSheet targetSheet = CopyWorkSheetFrom(sourceDocument, sourceSheet.Name, requestedName, options.SheetNameValidationMode, new ExcelWorksheetCopyOptions {
+                    CopyMode = options.CopyMode
+                });
                 importedSourceNames.Add(sourceSheet.Name);
                 createdTargetNames.Add(targetSheet.Name);
             }

--- a/OfficeIMO.Excel/ExcelDocument.WorkbookMerge.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorkbookMerge.cs
@@ -25,26 +25,35 @@ namespace OfficeIMO.Excel {
             var importedSourceNames = new List<string>(sourceSheets.Count);
             var createdTargetNames = new List<string>(sourceSheets.Count);
             var sheetNameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var tableNameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (ExcelSheet sourceSheet in sourceSheets) {
                 string requestedName = (options.SheetNamePrefix ?? string.Empty) + sourceSheet.Name;
-                ExcelSheet targetSheet = options.CopyMode == ExcelWorksheetCopyMode.Values
-                    ? CopyWorkSheetFromValues(sourceDocument, sourceSheet.Name, requestedName, options.SheetNameValidationMode)
-                    : CopyWorkSheetFromPackage(
+                ExcelSheet targetSheet;
+                if (options.CopyMode == ExcelWorksheetCopyMode.Values) {
+                    targetSheet = CopyWorkSheetFromValues(sourceDocument, sourceSheet.Name, requestedName, options.SheetNameValidationMode);
+                } else {
+                    WorksheetPackageCopyResult copyResult = CopyWorkSheetFromPackage(
                         sourceDocument,
                         sourceSheet.Name,
                         requestedName,
                         options.SheetNameValidationMode,
                         rewriteCopiedReferences: false,
                         copyReferencedDefinedNames: false);
+                    targetSheet = copyResult.Sheet;
+                    foreach (var tableName in copyResult.TableNameMap) {
+                        tableNameMap[tableName.Key] = tableName.Value;
+                    }
+                }
+
                 importedSourceNames.Add(sourceSheet.Name);
                 createdTargetNames.Add(targetSheet.Name);
                 sheetNameMap[sourceSheet.Name] = targetSheet.Name;
             }
 
-            RewriteMergedWorksheetReferences(createdTargetNames, sheetNameMap);
+            RewriteMergedWorksheetReferences(createdTargetNames, sheetNameMap, tableNameMap);
             for (int index = 0; index < importedSourceNames.Count; index++) {
-                CopyReferencedDefinedNamesFromSource(sourceDocument, GetSheet(createdTargetNames[index]), sheetNameMap);
+                CopyReferencedDefinedNamesFromSource(sourceDocument, GetSheet(createdTargetNames[index]), sheetNameMap, tableNameMap);
             }
 
             MarkPackageDirty();
@@ -65,15 +74,18 @@ namespace OfficeIMO.Excel {
             return options.SheetNames.Select(sourceDocument.GetSheet);
         }
 
-        private void RewriteMergedWorksheetReferences(IEnumerable<string> copiedSheetNames, IReadOnlyDictionary<string, string> sheetNameMap) {
-            if (sheetNameMap.Count == 0) {
+        private void RewriteMergedWorksheetReferences(
+            IEnumerable<string> copiedSheetNames,
+            IReadOnlyDictionary<string, string> sheetNameMap,
+            IReadOnlyDictionary<string, string> tableNameMap) {
+            if (sheetNameMap.Count == 0 && tableNameMap.Count == 0) {
                 return;
             }
 
             foreach (string copiedSheetName in copiedSheetNames) {
                 ExcelSheet copiedSheet = GetSheet(copiedSheetName);
                 WorksheetPart worksheetPart = copiedSheet.WorksheetPart;
-                RewriteCopiedWorksheetReferences(worksheetPart, sheetNameMap);
+                RewriteCopiedWorksheetReferences(worksheetPart, sheetNameMap, tableNameMap);
             }
         }
 

--- a/OfficeIMO.Excel/ExcelDocument.WorkbookMerge.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorkbookMerge.cs
@@ -26,6 +26,7 @@ namespace OfficeIMO.Excel {
             var createdTargetNames = new List<string>(sourceSheets.Count);
             var sheetNameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             var tableNameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var externalReferenceMaps = new Dictionary<string, IReadOnlyDictionary<int, int>>(StringComparer.OrdinalIgnoreCase);
 
             foreach (ExcelSheet sourceSheet in sourceSheets) {
                 string requestedName = (options.SheetNamePrefix ?? string.Empty) + sourceSheet.Name;
@@ -50,6 +51,10 @@ namespace OfficeIMO.Excel {
                     foreach (var tableName in copyResult.TableNameMap) {
                         tableNameMap[tableName.Key] = tableName.Value;
                     }
+
+                    if (copyResult.ExternalReferenceMap.Count > 0) {
+                        externalReferenceMaps[targetSheet.Name] = copyResult.ExternalReferenceMap;
+                    }
                 }
 
                 importedSourceNames.Add(sourceSheet.Name);
@@ -59,7 +64,9 @@ namespace OfficeIMO.Excel {
 
             RewriteMergedWorksheetReferences(createdTargetNames, sheetNameMap, tableNameMap);
             for (int index = 0; index < importedSourceNames.Count; index++) {
-                CopyReferencedDefinedNamesFromSource(sourceDocument, GetSheet(createdTargetNames[index]), sheetNameMap, tableNameMap);
+                ExcelSheet targetSheet = GetSheet(createdTargetNames[index]);
+                externalReferenceMaps.TryGetValue(targetSheet.Name, out IReadOnlyDictionary<int, int>? externalReferenceMap);
+                CopyReferencedDefinedNamesFromSource(sourceDocument, targetSheet, sheetNameMap, tableNameMap, externalReferenceMap);
             }
 
             MarkPackageDirty();

--- a/OfficeIMO.Excel/ExcelDocument.WorkbookMerge.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorkbookMerge.cs
@@ -33,7 +33,11 @@ namespace OfficeIMO.Excel {
                 if (options.CopyMode == ExcelWorksheetCopyMode.Values) {
                     targetSheet = CopyWorkSheetFromValues(sourceDocument, sourceSheet.Name, requestedName, options.SheetNameValidationMode);
                 } else if (ReferenceEquals(sourceDocument, this)) {
-                    targetSheet = CopyWorkSheet(sourceSheet, requestedName, options.SheetNameValidationMode);
+                    WorksheetPackageCopyResult copyResult = CopyWorkSheetWithinWorkbook(sourceSheet, requestedName, options.SheetNameValidationMode);
+                    targetSheet = copyResult.Sheet;
+                    foreach (var tableName in copyResult.TableNameMap) {
+                        tableNameMap[tableName.Key] = tableName.Value;
+                    }
                 } else {
                     WorksheetPackageCopyResult copyResult = CopyWorkSheetFromPackage(
                         sourceDocument,

--- a/OfficeIMO.Excel/ExcelDocument.WorkbookMerge.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorkbookMerge.cs
@@ -37,6 +37,10 @@ namespace OfficeIMO.Excel {
             }
 
             RewriteMergedWorksheetReferences(createdTargetNames, sheetNameMap);
+            for (int index = 0; index < importedSourceNames.Count; index++) {
+                CopyReferencedDefinedNamesFromSource(sourceDocument, importedSourceNames[index], createdTargetNames[index], sheetNameMap);
+            }
+
             MarkPackageDirty();
             return new ExcelWorkbookMergeResult(importedSourceNames, createdTargetNames);
         }
@@ -63,36 +67,11 @@ namespace OfficeIMO.Excel {
             foreach (string copiedSheetName in copiedSheetNames) {
                 ExcelSheet copiedSheet = GetSheet(copiedSheetName);
                 WorksheetPart worksheetPart = copiedSheet.WorksheetPart;
-                Worksheet worksheet = worksheetPart.Worksheet ?? throw new InvalidOperationException("Worksheet is missing.");
-                bool worksheetChanged = RewriteWorksheetFormulaSheetReferences(worksheet, sheetNameMap);
-
-                foreach (TableDefinitionPart tablePart in worksheetPart.TableDefinitionParts) {
-                    Table? table = tablePart.Table;
-                    if (table == null) {
-                        continue;
-                    }
-
-                    bool tableChanged = false;
-                    foreach (CalculatedColumnFormula formula in table.Descendants<CalculatedColumnFormula>()) {
-                        tableChanged |= RewriteFormulaSheetReference(formula, sheetNameMap);
-                    }
-
-                    foreach (TotalsRowFormula formula in table.Descendants<TotalsRowFormula>()) {
-                        tableChanged |= RewriteFormulaSheetReference(formula, sheetNameMap);
-                    }
-
-                    if (tableChanged) {
-                        table.Save();
-                    }
-                }
-
-                if (worksheetChanged) {
-                    worksheet.Save();
-                }
+                RewriteCopiedWorksheetReferences(worksheetPart, sheetNameMap);
             }
         }
 
-        private static bool RewriteWorksheetFormulaSheetReferences(Worksheet worksheet, IReadOnlyDictionary<string, string> sheetNameMap) {
+        private static bool RewriteWorksheetSheetReferences(Worksheet worksheet, IReadOnlyDictionary<string, string> sheetNameMap) {
             bool changed = false;
             foreach (CellFormula formula in worksheet.Descendants<CellFormula>()) {
                 changed |= RewriteFormulaSheetReference(formula, sheetNameMap);
@@ -114,6 +93,19 @@ namespace OfficeIMO.Excel {
                 changed |= RewriteFormulaSheetReference(formula, sheetNameMap);
             }
 
+            foreach (Hyperlink hyperlink in worksheet.Descendants<Hyperlink>()) {
+                string? location = hyperlink.Location?.Value;
+                if (string.IsNullOrEmpty(location)) {
+                    continue;
+                }
+
+                string updated = ReplaceSheetNameReferences(location!, sheetNameMap);
+                if (!string.Equals(updated, location, StringComparison.Ordinal)) {
+                    hyperlink.Location = updated;
+                    changed = true;
+                }
+            }
+
             return changed;
         }
 
@@ -123,10 +115,7 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            string updated = text!;
-            foreach (KeyValuePair<string, string> mapping in sheetNameMap) {
-                updated = ReplaceSheetNameReferences(updated, mapping.Key, mapping.Value);
-            }
+            string updated = ReplaceSheetNameReferences(text!, sheetNameMap);
 
             if (string.Equals(updated, text, StringComparison.Ordinal)) {
                 return false;

--- a/OfficeIMO.Excel/ExcelDocument.WorkbookMerge.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorkbookMerge.cs
@@ -28,9 +28,15 @@ namespace OfficeIMO.Excel {
 
             foreach (ExcelSheet sourceSheet in sourceSheets) {
                 string requestedName = (options.SheetNamePrefix ?? string.Empty) + sourceSheet.Name;
-                ExcelSheet targetSheet = CopyWorkSheetFrom(sourceDocument, sourceSheet.Name, requestedName, options.SheetNameValidationMode, new ExcelWorksheetCopyOptions {
-                    CopyMode = options.CopyMode
-                });
+                ExcelSheet targetSheet = options.CopyMode == ExcelWorksheetCopyMode.Values
+                    ? CopyWorkSheetFromValues(sourceDocument, sourceSheet.Name, requestedName, options.SheetNameValidationMode)
+                    : CopyWorkSheetFromPackage(
+                        sourceDocument,
+                        sourceSheet.Name,
+                        requestedName,
+                        options.SheetNameValidationMode,
+                        rewriteCopiedReferences: false,
+                        copyReferencedDefinedNames: false);
                 importedSourceNames.Add(sourceSheet.Name);
                 createdTargetNames.Add(targetSheet.Name);
                 sheetNameMap[sourceSheet.Name] = targetSheet.Name;
@@ -38,7 +44,7 @@ namespace OfficeIMO.Excel {
 
             RewriteMergedWorksheetReferences(createdTargetNames, sheetNameMap);
             for (int index = 0; index < importedSourceNames.Count; index++) {
-                CopyReferencedDefinedNamesFromSource(sourceDocument, importedSourceNames[index], createdTargetNames[index], sheetNameMap);
+                CopyReferencedDefinedNamesFromSource(sourceDocument, GetSheet(createdTargetNames[index]), sheetNameMap);
             }
 
             MarkPackageDirty();

--- a/OfficeIMO.Excel/ExcelDocument.WorkbookMerge.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorkbookMerge.cs
@@ -32,6 +32,8 @@ namespace OfficeIMO.Excel {
                 ExcelSheet targetSheet;
                 if (options.CopyMode == ExcelWorksheetCopyMode.Values) {
                     targetSheet = CopyWorkSheetFromValues(sourceDocument, sourceSheet.Name, requestedName, options.SheetNameValidationMode);
+                } else if (ReferenceEquals(sourceDocument, this)) {
+                    targetSheet = CopyWorkSheet(sourceSheet, requestedName, options.SheetNameValidationMode);
                 } else {
                     WorksheetPackageCopyResult copyResult = CopyWorkSheetFromPackage(
                         sourceDocument,

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetCopyReferences.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetCopyReferences.cs
@@ -39,17 +39,13 @@ namespace OfficeIMO.Excel {
 
         private void CopyReferencedDefinedNamesFromSource(
             ExcelDocument sourceDocument,
-            string sourceSheetName,
-            string targetSheetName,
+            ExcelSheet targetSheet,
             IReadOnlyDictionary<string, string> sheetNameMap) {
             DefinedNames? sourceDefinedNames = sourceDocument.WorkbookRoot.DefinedNames;
             if (sourceDefinedNames == null) {
                 return;
             }
 
-            ExcelSheet sourceSheet = sourceDocument.GetSheet(sourceSheetName);
-            ExcelSheet targetSheet = GetSheet(targetSheetName);
-            ushort sourceSheetPosition = sourceDocument.GetSheetPositionIndex(sourceSheet);
             ushort targetSheetPosition = GetSheetPositionIndex(targetSheet);
             WorksheetPart targetWorksheetPart = targetSheet.WorksheetPart;
             List<string> formulaTexts = CollectFormulaTexts(targetWorksheetPart).ToList();
@@ -57,26 +53,35 @@ namespace OfficeIMO.Excel {
                 return;
             }
 
+            var sourceSheetNamesByPosition = sourceDocument.GetSheetNamesByPosition();
             DefinedNames targetDefinedNames = WorkbookRoot.DefinedNames ??= new DefinedNames();
             foreach (DefinedName sourceName in sourceDefinedNames.Elements<DefinedName>().ToList()) {
                 string? name = sourceName.Name?.Value;
                 if (string.IsNullOrWhiteSpace(name)
                     || name!.StartsWith("_xlnm.", StringComparison.OrdinalIgnoreCase)
-                    || (sourceName.LocalSheetId != null && sourceName.LocalSheetId.Value != sourceSheetPosition)
                     || !formulaTexts.Any(text => ContainsDefinedNameToken(text, name))) {
                     continue;
                 }
 
+                ushort destinationSheetPosition = targetSheetPosition;
+                if (sourceName.LocalSheetId != null) {
+                    if (!sourceSheetNamesByPosition.TryGetValue((ushort)sourceName.LocalSheetId.Value, out string? sourceNameOwner)
+                        || !sheetNameMap.TryGetValue(sourceNameOwner, out string? targetNameOwner)
+                        || !TryGetSheetPositionIndexByName(targetNameOwner, out destinationSheetPosition)) {
+                        continue;
+                    }
+                }
+
                 foreach (DefinedName existing in targetDefinedNames.Elements<DefinedName>()
                     .Where(item => item.LocalSheetId != null
-                        && item.LocalSheetId.Value == targetSheetPosition
+                        && item.LocalSheetId.Value == destinationSheetPosition
                         && string.Equals(item.Name?.Value, name, StringComparison.OrdinalIgnoreCase))
                     .ToList()) {
                     existing.Remove();
                 }
 
                 var clone = (DefinedName)sourceName.CloneNode(true);
-                clone.LocalSheetId = targetSheetPosition;
+                clone.LocalSheetId = destinationSheetPosition;
                 clone.Name = name;
                 if (!string.IsNullOrEmpty(clone.Text)) {
                     clone.Text = ReplaceSheetNameReferences(clone.Text!, sheetNameMap);
@@ -86,6 +91,34 @@ namespace OfficeIMO.Excel {
             }
 
             WorkbookRoot.Save();
+        }
+
+        private Dictionary<ushort, string> GetSheetNamesByPosition() {
+            var names = new Dictionary<ushort, string>();
+            ushort position = 0;
+            foreach (Sheet sheet in WorkbookRoot.Sheets?.Elements<Sheet>() ?? Enumerable.Empty<Sheet>()) {
+                string? name = sheet.Name?.Value;
+                if (!string.IsNullOrEmpty(name)) {
+                    names[position] = name!;
+                }
+
+                position++;
+            }
+
+            return names;
+        }
+
+        private bool TryGetSheetPositionIndexByName(string sheetName, out ushort position) {
+            position = 0;
+            foreach (Sheet sheet in WorkbookRoot.Sheets?.Elements<Sheet>() ?? Enumerable.Empty<Sheet>()) {
+                if (string.Equals(sheet.Name?.Value, sheetName, StringComparison.OrdinalIgnoreCase)) {
+                    return true;
+                }
+
+                position++;
+            }
+
+            return false;
         }
 
         private static IEnumerable<string> CollectFormulaTexts(WorksheetPart worksheetPart) {

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetCopyReferences.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetCopyReferences.cs
@@ -67,17 +67,31 @@ namespace OfficeIMO.Excel {
             }
 
             var sourceSheetNamesByPosition = sourceDocument.GetSheetNamesByPosition();
+            string? currentSourceSheetName = sheetNameMap
+                .FirstOrDefault(mapping => string.Equals(mapping.Value, targetSheet.Name, StringComparison.OrdinalIgnoreCase))
+                .Key;
             DefinedNames targetDefinedNames = WorkbookRoot.DefinedNames ??= new DefinedNames();
             var copiedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             List<DefinedName> sourceNames = sourceDefinedNames.Elements<DefinedName>()
                 .Where(name => !string.IsNullOrWhiteSpace(name.Name?.Value)
                     && !name.Name!.Value!.StartsWith("_xlnm.", StringComparison.OrdinalIgnoreCase))
                 .ToList();
+            var localNamesForCurrentSourceSheet = new HashSet<string>(sourceNames
+                .Where(name => name.LocalSheetId != null
+                    && !string.IsNullOrEmpty(currentSourceSheetName)
+                    && sourceSheetNamesByPosition.TryGetValue((ushort)name.LocalSheetId.Value, out string? owner)
+                    && string.Equals(owner, currentSourceSheetName, StringComparison.OrdinalIgnoreCase)
+                    && !string.IsNullOrWhiteSpace(name.Name?.Value))
+                .Select(name => name.Name!.Value!), StringComparer.OrdinalIgnoreCase);
             bool copied;
             do {
                 copied = false;
                 foreach (DefinedName sourceName in sourceNames) {
                     string? name = sourceName.Name?.Value;
+                    if (sourceName.LocalSheetId == null && localNamesForCurrentSourceSheet.Contains(name!)) {
+                        continue;
+                    }
+
                     string copyKey = name + "|" + (sourceName.LocalSheetId?.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty);
                     if (copiedNames.Contains(copyKey)
                         || !formulaTexts.Any(text => ContainsDefinedNameToken(text, name!))) {

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetCopyReferences.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetCopyReferences.cs
@@ -53,7 +53,8 @@ namespace OfficeIMO.Excel {
             ExcelDocument sourceDocument,
             ExcelSheet targetSheet,
             IReadOnlyDictionary<string, string> sheetNameMap,
-            IReadOnlyDictionary<string, string>? tableNameMap = null) {
+            IReadOnlyDictionary<string, string>? tableNameMap = null,
+            IReadOnlyDictionary<int, int>? externalReferenceMap = null) {
             DefinedNames? sourceDefinedNames = sourceDocument.WorkbookRoot.DefinedNames;
             if (sourceDefinedNames == null) {
                 return;
@@ -122,6 +123,10 @@ namespace OfficeIMO.Excel {
                         clone.Text = ReplaceSheetNameReferences(clone.Text!, sheetNameMap);
                         if (tableNameMap?.Count > 0) {
                             clone.Text = RewriteStructuredTableReferences(clone.Text!, tableNameMap);
+                        }
+
+                        if (externalReferenceMap?.Count > 0) {
+                            clone.Text = RewriteExternalWorkbookReferenceIndexes(clone.Text!, externalReferenceMap);
                         }
 
                         formulaTexts.Add(clone.Text!);

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetCopyReferences.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetCopyReferences.cs
@@ -8,9 +8,16 @@ using OfficeFormula = DocumentFormat.OpenXml.Office.Excel.Formula;
 
 namespace OfficeIMO.Excel {
     public partial class ExcelDocument {
-        private void RewriteCopiedWorksheetReferences(WorksheetPart worksheetPart, IReadOnlyDictionary<string, string> sheetNameMap) {
+        private void RewriteCopiedWorksheetReferences(
+            WorksheetPart worksheetPart,
+            IReadOnlyDictionary<string, string> sheetNameMap,
+            IReadOnlyDictionary<string, string>? tableNameMap = null) {
             Worksheet worksheet = worksheetPart.Worksheet ?? throw new InvalidOperationException("Worksheet is missing.");
             bool worksheetChanged = RewriteWorksheetSheetReferences(worksheet, sheetNameMap);
+            if (tableNameMap?.Count > 0) {
+                RewriteStructuredTableReferences(worksheet, tableNameMap);
+                worksheetChanged = true;
+            }
 
             foreach (TableDefinitionPart tablePart in worksheetPart.TableDefinitionParts) {
                 Table? table = tablePart.Table;
@@ -27,6 +34,11 @@ namespace OfficeIMO.Excel {
                     tableChanged |= RewriteFormulaSheetReference(formula, sheetNameMap);
                 }
 
+                if (tableNameMap?.Count > 0) {
+                    RewriteStructuredTableReferences(table, tableNameMap);
+                    tableChanged = true;
+                }
+
                 if (tableChanged) {
                     table.Save();
                 }
@@ -40,7 +52,8 @@ namespace OfficeIMO.Excel {
         private void CopyReferencedDefinedNamesFromSource(
             ExcelDocument sourceDocument,
             ExcelSheet targetSheet,
-            IReadOnlyDictionary<string, string> sheetNameMap) {
+            IReadOnlyDictionary<string, string> sheetNameMap,
+            IReadOnlyDictionary<string, string>? tableNameMap = null) {
             DefinedNames? sourceDefinedNames = sourceDocument.WorkbookRoot.DefinedNames;
             if (sourceDefinedNames == null) {
                 return;
@@ -55,40 +68,57 @@ namespace OfficeIMO.Excel {
 
             var sourceSheetNamesByPosition = sourceDocument.GetSheetNamesByPosition();
             DefinedNames targetDefinedNames = WorkbookRoot.DefinedNames ??= new DefinedNames();
-            foreach (DefinedName sourceName in sourceDefinedNames.Elements<DefinedName>().ToList()) {
-                string? name = sourceName.Name?.Value;
-                if (string.IsNullOrWhiteSpace(name)
-                    || name!.StartsWith("_xlnm.", StringComparison.OrdinalIgnoreCase)
-                    || !formulaTexts.Any(text => ContainsDefinedNameToken(text, name))) {
-                    continue;
-                }
-
-                ushort destinationSheetPosition = targetSheetPosition;
-                if (sourceName.LocalSheetId != null) {
-                    if (!sourceSheetNamesByPosition.TryGetValue((ushort)sourceName.LocalSheetId.Value, out string? sourceNameOwner)
-                        || !sheetNameMap.TryGetValue(sourceNameOwner, out string? targetNameOwner)
-                        || !TryGetSheetPositionIndexByName(targetNameOwner, out destinationSheetPosition)) {
+            var copiedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            List<DefinedName> sourceNames = sourceDefinedNames.Elements<DefinedName>()
+                .Where(name => !string.IsNullOrWhiteSpace(name.Name?.Value)
+                    && !name.Name!.Value!.StartsWith("_xlnm.", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            bool copied;
+            do {
+                copied = false;
+                foreach (DefinedName sourceName in sourceNames) {
+                    string? name = sourceName.Name?.Value;
+                    string copyKey = name + "|" + (sourceName.LocalSheetId?.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty);
+                    if (copiedNames.Contains(copyKey)
+                        || !formulaTexts.Any(text => ContainsDefinedNameToken(text, name!))) {
                         continue;
                     }
-                }
 
-                foreach (DefinedName existing in targetDefinedNames.Elements<DefinedName>()
-                    .Where(item => item.LocalSheetId != null
-                        && item.LocalSheetId.Value == destinationSheetPosition
-                        && string.Equals(item.Name?.Value, name, StringComparison.OrdinalIgnoreCase))
-                    .ToList()) {
-                    existing.Remove();
-                }
+                    ushort destinationSheetPosition = targetSheetPosition;
+                    if (sourceName.LocalSheetId != null) {
+                        if (!sourceSheetNamesByPosition.TryGetValue((ushort)sourceName.LocalSheetId.Value, out string? sourceNameOwner)
+                            || !sheetNameMap.TryGetValue(sourceNameOwner, out string? targetNameOwner)
+                            || !TryGetSheetPositionIndexByName(targetNameOwner, out destinationSheetPosition)) {
+                            continue;
+                        }
+                    }
 
-                var clone = (DefinedName)sourceName.CloneNode(true);
-                clone.LocalSheetId = destinationSheetPosition;
-                clone.Name = name;
-                if (!string.IsNullOrEmpty(clone.Text)) {
-                    clone.Text = ReplaceSheetNameReferences(clone.Text!, sheetNameMap);
-                }
+                    foreach (DefinedName existing in targetDefinedNames.Elements<DefinedName>()
+                        .Where(item => item.LocalSheetId != null
+                            && item.LocalSheetId.Value == destinationSheetPosition
+                            && string.Equals(item.Name?.Value, name, StringComparison.OrdinalIgnoreCase))
+                        .ToList()) {
+                        existing.Remove();
+                    }
 
-                targetDefinedNames.Append(clone);
+                    var clone = (DefinedName)sourceName.CloneNode(true);
+                    clone.LocalSheetId = destinationSheetPosition;
+                    clone.Name = name;
+                    if (!string.IsNullOrEmpty(clone.Text)) {
+                        clone.Text = ReplaceSheetNameReferences(clone.Text!, sheetNameMap);
+                        if (tableNameMap?.Count > 0) {
+                            clone.Text = RewriteStructuredTableReferences(clone.Text!, tableNameMap);
+                        }
+
+                        formulaTexts.Add(clone.Text!);
+                    }
+
+                    targetDefinedNames.Append(clone);
+                    copiedNames.Add(copyKey);
+                    copied = true;
+                }
             }
+            while (copied);
 
             WorkbookRoot.Save();
         }

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetCopyReferences.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetCopyReferences.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeFormula = DocumentFormat.OpenXml.Office.Excel.Formula;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelDocument {
+        private void RewriteCopiedWorksheetReferences(WorksheetPart worksheetPart, IReadOnlyDictionary<string, string> sheetNameMap) {
+            Worksheet worksheet = worksheetPart.Worksheet ?? throw new InvalidOperationException("Worksheet is missing.");
+            bool worksheetChanged = RewriteWorksheetSheetReferences(worksheet, sheetNameMap);
+
+            foreach (TableDefinitionPart tablePart in worksheetPart.TableDefinitionParts) {
+                Table? table = tablePart.Table;
+                if (table == null) {
+                    continue;
+                }
+
+                bool tableChanged = false;
+                foreach (CalculatedColumnFormula formula in table.Descendants<CalculatedColumnFormula>()) {
+                    tableChanged |= RewriteFormulaSheetReference(formula, sheetNameMap);
+                }
+
+                foreach (TotalsRowFormula formula in table.Descendants<TotalsRowFormula>()) {
+                    tableChanged |= RewriteFormulaSheetReference(formula, sheetNameMap);
+                }
+
+                if (tableChanged) {
+                    table.Save();
+                }
+            }
+
+            if (worksheetChanged) {
+                worksheet.Save();
+            }
+        }
+
+        private void CopyReferencedDefinedNamesFromSource(
+            ExcelDocument sourceDocument,
+            string sourceSheetName,
+            string targetSheetName,
+            IReadOnlyDictionary<string, string> sheetNameMap) {
+            DefinedNames? sourceDefinedNames = sourceDocument.WorkbookRoot.DefinedNames;
+            if (sourceDefinedNames == null) {
+                return;
+            }
+
+            ExcelSheet sourceSheet = sourceDocument.GetSheet(sourceSheetName);
+            ExcelSheet targetSheet = GetSheet(targetSheetName);
+            ushort sourceSheetPosition = sourceDocument.GetSheetPositionIndex(sourceSheet);
+            ushort targetSheetPosition = GetSheetPositionIndex(targetSheet);
+            WorksheetPart targetWorksheetPart = targetSheet.WorksheetPart;
+            List<string> formulaTexts = CollectFormulaTexts(targetWorksheetPart).ToList();
+            if (formulaTexts.Count == 0) {
+                return;
+            }
+
+            DefinedNames targetDefinedNames = WorkbookRoot.DefinedNames ??= new DefinedNames();
+            foreach (DefinedName sourceName in sourceDefinedNames.Elements<DefinedName>().ToList()) {
+                string? name = sourceName.Name?.Value;
+                if (string.IsNullOrWhiteSpace(name)
+                    || name!.StartsWith("_xlnm.", StringComparison.OrdinalIgnoreCase)
+                    || (sourceName.LocalSheetId != null && sourceName.LocalSheetId.Value != sourceSheetPosition)
+                    || !formulaTexts.Any(text => ContainsDefinedNameToken(text, name))) {
+                    continue;
+                }
+
+                foreach (DefinedName existing in targetDefinedNames.Elements<DefinedName>()
+                    .Where(item => item.LocalSheetId != null
+                        && item.LocalSheetId.Value == targetSheetPosition
+                        && string.Equals(item.Name?.Value, name, StringComparison.OrdinalIgnoreCase))
+                    .ToList()) {
+                    existing.Remove();
+                }
+
+                var clone = (DefinedName)sourceName.CloneNode(true);
+                clone.LocalSheetId = targetSheetPosition;
+                clone.Name = name;
+                if (!string.IsNullOrEmpty(clone.Text)) {
+                    clone.Text = ReplaceSheetNameReferences(clone.Text!, sheetNameMap);
+                }
+
+                targetDefinedNames.Append(clone);
+            }
+
+            WorkbookRoot.Save();
+        }
+
+        private static IEnumerable<string> CollectFormulaTexts(WorksheetPart worksheetPart) {
+            Worksheet worksheet = worksheetPart.Worksheet ?? throw new InvalidOperationException("Worksheet is missing.");
+            foreach (CellFormula formula in worksheet.Descendants<CellFormula>()) {
+                if (!string.IsNullOrEmpty(formula.Text)) {
+                    yield return formula.Text!;
+                }
+            }
+
+            foreach (Formula formula in worksheet.Descendants<Formula>()) {
+                if (!string.IsNullOrEmpty(formula.Text)) {
+                    yield return formula.Text!;
+                }
+            }
+
+            foreach (Formula1 formula in worksheet.Descendants<Formula1>()) {
+                if (!string.IsNullOrEmpty(formula.Text)) {
+                    yield return formula.Text!;
+                }
+            }
+
+            foreach (Formula2 formula in worksheet.Descendants<Formula2>()) {
+                if (!string.IsNullOrEmpty(formula.Text)) {
+                    yield return formula.Text!;
+                }
+            }
+
+            foreach (OfficeFormula formula in worksheet.Descendants<OfficeFormula>()) {
+                if (!string.IsNullOrEmpty(formula.Text)) {
+                    yield return formula.Text!;
+                }
+            }
+
+            foreach (TableDefinitionPart tablePart in worksheetPart.TableDefinitionParts) {
+                Table? table = tablePart.Table;
+                if (table == null) {
+                    continue;
+                }
+
+                foreach (CalculatedColumnFormula formula in table.Descendants<CalculatedColumnFormula>()) {
+                    if (!string.IsNullOrEmpty(formula.Text)) {
+                        yield return formula.Text!;
+                    }
+                }
+
+                foreach (TotalsRowFormula formula in table.Descendants<TotalsRowFormula>()) {
+                    if (!string.IsNullOrEmpty(formula.Text)) {
+                        yield return formula.Text!;
+                    }
+                }
+            }
+        }
+
+        private static bool ContainsDefinedNameToken(string formula, string definedName) {
+            for (int index = 0; index <= formula.Length - definedName.Length; index++) {
+                if (!string.Equals(formula.Substring(index, definedName.Length), definedName, StringComparison.OrdinalIgnoreCase)) {
+                    continue;
+                }
+
+                int afterIndex = index + definedName.Length;
+                if ((index == 0 || !IsDefinedNameCharacter(formula[index - 1]))
+                    && (afterIndex == formula.Length || !IsDefinedNameCharacter(formula[afterIndex]))) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsDefinedNameCharacter(char value) {
+            return char.IsLetterOrDigit(value) || value == '_' || value == '.' || value == '\\';
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
@@ -633,14 +633,30 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
+                bool tableChanged = false;
                 foreach (CalculatedColumnFormula formula in tablePart.Table.Descendants<CalculatedColumnFormula>()) {
-                    formula.Text = RewriteExternalWorkbookReferenceIndexes(formula.Text, externalReferenceMap);
+                    tableChanged |= RewriteExternalWorkbookReferenceIndexFormula(formula, externalReferenceMap);
                 }
 
                 foreach (TotalsRowFormula formula in tablePart.Table.Descendants<TotalsRowFormula>()) {
-                    formula.Text = RewriteExternalWorkbookReferenceIndexes(formula.Text, externalReferenceMap);
+                    tableChanged |= RewriteExternalWorkbookReferenceIndexFormula(formula, externalReferenceMap);
+                }
+
+                if (tableChanged) {
+                    tablePart.Table.Save();
                 }
             }
+        }
+
+        private static bool RewriteExternalWorkbookReferenceIndexFormula(OpenXmlLeafTextElement formula, IReadOnlyDictionary<int, int> externalReferenceMap) {
+            string text = formula.Text;
+            string rewritten = RewriteExternalWorkbookReferenceIndexes(text, externalReferenceMap);
+            if (string.Equals(rewritten, text, StringComparison.Ordinal)) {
+                return false;
+            }
+
+            formula.Text = rewritten;
+            return true;
         }
 
         private static string RewriteExternalWorkbookReferenceIndexes(string? formula, IReadOnlyDictionary<int, int> externalReferenceMap) {

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
@@ -363,6 +363,7 @@ namespace OfficeIMO.Excel {
             RemoveElementsByLocalName(worksheet, "pivotTableDefinition");
             RemoveElementsByLocalName(worksheet, "pivotTableDefinitions");
             RemoveElementsByLocalName(worksheet, "queryTableParts");
+            RemoveElementsByLocalName(worksheet, "customProperties");
 
             foreach (Hyperlinks hyperlinks in worksheet.Elements<Hyperlinks>().ToList()) {
                 foreach (Hyperlink hyperlink in hyperlinks.Elements<Hyperlink>().Where(h => h.Id != null).ToList()) {

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
@@ -425,6 +425,7 @@ namespace OfficeIMO.Excel {
                 var copiedTable = (Table)sourceTable.CloneNode(true);
                 copiedTable.Id = GetNextUniqueTableId();
                 string? sourceTableName = sourceTable.Name?.Value ?? sourceTable.DisplayName?.Value;
+                string? sourceDisplayName = sourceTable.DisplayName?.Value;
                 string tableName = CreateUniqueCopiedTableName(sourceTableName);
                 copiedTable.Name = tableName;
                 copiedTable.DisplayName = tableName;
@@ -434,6 +435,10 @@ namespace OfficeIMO.Excel {
                 copiedTables.Add(copiedTable);
                 if (!string.IsNullOrWhiteSpace(sourceTableName)) {
                     tableNameMap[sourceTableName!] = tableName;
+                }
+
+                if (!string.IsNullOrWhiteSpace(sourceDisplayName)) {
+                    tableNameMap[sourceDisplayName!] = tableName;
                 }
 
                 copiedTableParts ??= EnsureTableParts(copiedPart.Worksheet!);
@@ -623,7 +628,7 @@ namespace OfficeIMO.Excel {
                 string tableName = mapping.Key;
                 if (index > 0) {
                     char previous = formula[index - 1];
-                    if (char.IsLetterOrDigit(previous) || previous == '_' || previous == '\\' || previous == '\'' || previous == '!') {
+                    if (char.IsLetterOrDigit(previous) || previous == '_' || previous == '\\' || previous == '\'' || previous == '!' || previous == '[') {
                         continue;
                     }
                 }

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
@@ -573,6 +573,109 @@ namespace OfficeIMO.Excel {
             }
         }
 
+        private static void RewriteCopiedWorksheetExternalReferences(WorksheetPart worksheetPart, IReadOnlyDictionary<int, int> externalReferenceMap) {
+            if (externalReferenceMap.Count == 0) {
+                return;
+            }
+
+            foreach (CellFormula formula in worksheetPart.Worksheet!.Descendants<CellFormula>()) {
+                formula.Text = RewriteExternalWorkbookReferenceIndexes(formula.Text, externalReferenceMap);
+            }
+
+            foreach (Formula formula in worksheetPart.Worksheet!.Descendants<Formula>()) {
+                formula.Text = RewriteExternalWorkbookReferenceIndexes(formula.Text, externalReferenceMap);
+            }
+
+            foreach (Formula1 formula in worksheetPart.Worksheet!.Descendants<Formula1>()) {
+                formula.Text = RewriteExternalWorkbookReferenceIndexes(formula.Text, externalReferenceMap);
+            }
+
+            foreach (Formula2 formula in worksheetPart.Worksheet!.Descendants<Formula2>()) {
+                formula.Text = RewriteExternalWorkbookReferenceIndexes(formula.Text, externalReferenceMap);
+            }
+
+            foreach (OfficeFormula formula in worksheetPart.Worksheet!.Descendants<OfficeFormula>()) {
+                formula.Text = RewriteExternalWorkbookReferenceIndexes(formula.Text, externalReferenceMap);
+            }
+
+            foreach (TableDefinitionPart tablePart in worksheetPart.TableDefinitionParts) {
+                if (tablePart.Table == null) {
+                    continue;
+                }
+
+                foreach (CalculatedColumnFormula formula in tablePart.Table.Descendants<CalculatedColumnFormula>()) {
+                    formula.Text = RewriteExternalWorkbookReferenceIndexes(formula.Text, externalReferenceMap);
+                }
+
+                foreach (TotalsRowFormula formula in tablePart.Table.Descendants<TotalsRowFormula>()) {
+                    formula.Text = RewriteExternalWorkbookReferenceIndexes(formula.Text, externalReferenceMap);
+                }
+            }
+        }
+
+        private static string RewriteExternalWorkbookReferenceIndexes(string? formula, IReadOnlyDictionary<int, int> externalReferenceMap) {
+            if (string.IsNullOrEmpty(formula) || externalReferenceMap.Count == 0) {
+                return formula ?? string.Empty;
+            }
+
+            var rewritten = new System.Text.StringBuilder(formula!.Length);
+            bool inStringLiteral = false;
+            for (int index = 0; index < formula!.Length;) {
+                char current = formula[index];
+                if (current == '"') {
+                    rewritten.Append(current);
+                    if (inStringLiteral && index + 1 < formula.Length && formula[index + 1] == '"') {
+                        rewritten.Append(formula[index + 1]);
+                        index += 2;
+                        continue;
+                    }
+
+                    inStringLiteral = !inStringLiteral;
+                    index++;
+                    continue;
+                }
+
+                if (!inStringLiteral && current == '[' && TryReadExternalWorkbookIndex(formula, index, out int sourceIndex, out int closeIndex) && externalReferenceMap.TryGetValue(sourceIndex, out int targetIndex)) {
+                    rewritten.Append('[')
+                        .Append(targetIndex.ToString(CultureInfo.InvariantCulture))
+                        .Append(']');
+                    index = closeIndex + 1;
+                    continue;
+                }
+
+                rewritten.Append(current);
+                index++;
+            }
+
+            return rewritten.ToString();
+        }
+
+        private static bool TryReadExternalWorkbookIndex(string formula, int bracketIndex, out int sourceIndex, out int closeIndex) {
+            sourceIndex = 0;
+            closeIndex = bracketIndex;
+            int index = bracketIndex + 1;
+            if (index >= formula.Length || !char.IsDigit(formula[index])) {
+                return false;
+            }
+
+            while (index < formula.Length && char.IsDigit(formula[index])) {
+                int digit = formula[index] - '0';
+                if (sourceIndex > (int.MaxValue - digit) / 10) {
+                    return false;
+                }
+
+                sourceIndex = (sourceIndex * 10) + digit;
+                index++;
+            }
+
+            if (index >= formula.Length || formula[index] != ']') {
+                return false;
+            }
+
+            closeIndex = index;
+            return sourceIndex > 0;
+        }
+
         private static string RewriteStructuredTableReferences(string? formula, IReadOnlyDictionary<string, string> tableNameMap) {
             if (string.IsNullOrEmpty(formula) || tableNameMap.Count == 0) {
                 return formula ?? string.Empty;
@@ -657,7 +760,7 @@ namespace OfficeIMO.Excel {
         }
 
         private static bool IsFormulaTokenBoundary(char value) {
-            return !(char.IsLetterOrDigit(value) || value == '_' || value == '\\' || value == '\'' || value == '!' || value == ':');
+            return !(char.IsLetterOrDigit(value) || value == '_' || value == '\\' || value == '\'' || value == '!' || value == ':' || value == '.');
         }
 
         private static string MakeUnusedRelationshipId(WorksheetPart worksheetPart) {

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
@@ -351,6 +351,9 @@ namespace OfficeIMO.Excel {
             worksheet.RemoveAllChildren<LegacyDrawing>();
             worksheet.RemoveAllChildren<LegacyDrawingHeaderFooter>();
             worksheet.RemoveAllChildren<TableParts>();
+            worksheet.RemoveAllChildren<OleObjects>();
+            worksheet.RemoveAllChildren<Controls>();
+            worksheet.RemoveAllChildren<Picture>();
 
             foreach (Hyperlinks hyperlinks in worksheet.Elements<Hyperlinks>().ToList()) {
                 foreach (Hyperlink hyperlink in hyperlinks.Elements<Hyperlink>().Where(h => h.Id != null).ToList()) {
@@ -363,7 +366,7 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        private void CopyWorksheetTables(WorksheetPart sourcePart, WorksheetPart copiedPart) {
+        private Dictionary<string, string> CopyWorksheetTables(WorksheetPart sourcePart, WorksheetPart copiedPart) {
             TableParts? copiedTableParts = null;
             var tableNameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             var copiedTables = new List<Table>();
@@ -408,6 +411,8 @@ namespace OfficeIMO.Excel {
             if (copiedTableParts != null) {
                 copiedTableParts.Count = (uint)copiedTableParts.Elements<TablePart>().Count();
             }
+
+            return tableNameMap;
         }
 
         private uint GetNextUniqueTableId() {
@@ -489,6 +494,18 @@ namespace OfficeIMO.Excel {
 
         private static void RewriteStructuredTableReferences(Worksheet worksheet, IReadOnlyDictionary<string, string> tableNameMap) {
             foreach (CellFormula formula in worksheet.Descendants<CellFormula>()) {
+                formula.Text = RewriteStructuredTableReferences(formula.Text, tableNameMap);
+            }
+
+            foreach (Formula formula in worksheet.Descendants<Formula>()) {
+                formula.Text = RewriteStructuredTableReferences(formula.Text, tableNameMap);
+            }
+
+            foreach (Formula1 formula in worksheet.Descendants<Formula1>()) {
+                formula.Text = RewriteStructuredTableReferences(formula.Text, tableNameMap);
+            }
+
+            foreach (Formula2 formula in worksheet.Descendants<Formula2>()) {
                 formula.Text = RewriteStructuredTableReferences(formula.Text, tableNameMap);
             }
         }

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
@@ -45,7 +45,7 @@ namespace OfficeIMO.Excel {
                 WorksheetPart copiedPart = WorkbookPartRoot.AddNewPart<WorksheetPart>();
                 copiedPart.Worksheet = (Worksheet)sourcePart.Worksheet!.CloneNode(true);
                 RemoveRelationshipBackedWorksheetFeatures(copiedPart.Worksheet);
-                CopyWorksheetTables(sourcePart, copiedPart);
+                CopyWorksheetTables(sourcePart, copiedPart, rewriteCopiedTableReferences: true);
                 copiedPart.Worksheet.Save();
 
                 Sheet sheet = AppendWorksheetElement(copiedPart, validatedName);

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
@@ -34,6 +34,10 @@ namespace OfficeIMO.Excel {
         /// <param name="validationMode">How to validate or sanitize <paramref name="newSheetName"/>.</param>
         /// <returns>The copied worksheet.</returns>
         public ExcelSheet CopyWorkSheet(ExcelSheet sourceSheet, string newSheetName, SheetNameValidationMode validationMode = SheetNameValidationMode.Sanitize) {
+            return CopyWorkSheetWithinWorkbook(sourceSheet, newSheetName, validationMode).Sheet;
+        }
+
+        private WorksheetPackageCopyResult CopyWorkSheetWithinWorkbook(ExcelSheet sourceSheet, string newSheetName, SheetNameValidationMode validationMode) {
             if (sourceSheet == null) throw new ArgumentNullException(nameof(sourceSheet));
             if (!ReferenceEquals(sourceSheet.Document, this)) {
                 throw new ArgumentException("Source worksheet must belong to this workbook. Use CopyWorkSheetFrom to copy between workbooks.", nameof(sourceSheet));
@@ -45,13 +49,13 @@ namespace OfficeIMO.Excel {
                 WorksheetPart copiedPart = WorkbookPartRoot.AddNewPart<WorksheetPart>();
                 copiedPart.Worksheet = (Worksheet)sourcePart.Worksheet!.CloneNode(true);
                 RemoveRelationshipBackedWorksheetFeatures(copiedPart.Worksheet);
-                CopyWorksheetTables(sourcePart, copiedPart, rewriteCopiedTableReferences: true);
+                Dictionary<string, string> tableNameMap = CopyWorksheetTables(sourcePart, copiedPart, rewriteCopiedTableReferences: true);
                 copiedPart.Worksheet.Save();
 
                 Sheet sheet = AppendWorksheetElement(copiedPart, validatedName);
                 MarkSheetCacheDirty();
                 WorkbookRoot.Save();
-                return new ExcelSheet(this, _spreadSheetDocument, sheet);
+                return new WorksheetPackageCopyResult(new ExcelSheet(this, _spreadSheetDocument, sheet), tableNameMap);
             });
         }
 

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
@@ -410,6 +410,23 @@ namespace OfficeIMO.Excel {
             }
         }
 
+        private static void RemoveExtensionsContainingLocalNames(OpenXmlElement root, params string[] localNames) {
+            var names = new HashSet<string>(localNames, StringComparer.Ordinal);
+            foreach (OpenXmlElement extension in root.Descendants<OpenXmlElement>()
+                .Where(element => string.Equals(element.LocalName, "ext", StringComparison.Ordinal)
+                    && element.Descendants<OpenXmlElement>().Any(descendant => names.Contains(descendant.LocalName)))
+                .ToList()) {
+                extension.Remove();
+            }
+
+            foreach (OpenXmlElement extensionList in root.Descendants<OpenXmlElement>()
+                .Where(element => string.Equals(element.LocalName, "extLst", StringComparison.Ordinal)
+                    && !element.ChildElements.Any())
+                .ToList()) {
+                extensionList.Remove();
+            }
+        }
+
         private Dictionary<string, string> CopyWorksheetTables(WorksheetPart sourcePart, WorksheetPart copiedPart, bool rewriteCopiedTableReferences = false) {
             TableParts? copiedTableParts = null;
             var tableNameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -424,6 +441,7 @@ namespace OfficeIMO.Excel {
                 TableDefinitionPart copiedTablePart = copiedPart.AddNewPart<TableDefinitionPart>(relationshipId);
                 var copiedTable = (Table)sourceTable.CloneNode(true);
                 copiedTable.Id = GetNextUniqueTableId();
+                StripCopiedTableQueryBindings(copiedTable);
                 string? sourceTableName = sourceTable.Name?.Value ?? sourceTable.DisplayName?.Value;
                 string? sourceDisplayName = sourceTable.DisplayName?.Value;
                 string tableName = CreateUniqueCopiedTableName(sourceTableName);
@@ -462,6 +480,18 @@ namespace OfficeIMO.Excel {
             }
 
             return tableNameMap;
+        }
+
+        private static void StripCopiedTableQueryBindings(Table table) {
+            table.ConnectionId = null;
+            foreach (TableColumn column in table.Descendants<TableColumn>()) {
+                column.QueryTableFieldId = null;
+            }
+
+            RemoveElementsByLocalName(table, "queryTable");
+            RemoveElementsByLocalName(table, "queryTableField");
+            RemoveElementsByLocalName(table, "queryTableFields");
+            RemoveExtensionsContainingLocalNames(table, "queryTable", "queryTableField", "queryTableFields");
         }
 
         private uint GetNextUniqueTableId() {
@@ -635,7 +665,11 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                if (!inStringLiteral && current == '[' && TryReadExternalWorkbookIndex(formula, index, out int sourceIndex, out int closeIndex) && externalReferenceMap.TryGetValue(sourceIndex, out int targetIndex)) {
+                if (!inStringLiteral
+                    && current == '['
+                    && TryReadExternalWorkbookIndex(formula, index, out int sourceIndex, out int closeIndex)
+                    && LooksLikeExternalWorkbookReference(formula, index, closeIndex)
+                    && externalReferenceMap.TryGetValue(sourceIndex, out int targetIndex)) {
                     rewritten.Append('[')
                         .Append(targetIndex.ToString(CultureInfo.InvariantCulture))
                         .Append(']');
@@ -648,6 +682,16 @@ namespace OfficeIMO.Excel {
             }
 
             return rewritten.ToString();
+        }
+
+        private static bool LooksLikeExternalWorkbookReference(string formula, int bracketIndex, int closeIndex) {
+            if (bracketIndex > 0 && formula[bracketIndex - 1] == '[') {
+                return false;
+            }
+
+            int nextIndex = closeIndex + 1;
+            return nextIndex < formula.Length
+                && (formula[nextIndex] == '\'' || char.IsLetterOrDigit(formula[nextIndex]) || formula[nextIndex] == '_');
         }
 
         private static bool TryReadExternalWorkbookIndex(string formula, int bracketIndex, out int sourceIndex, out int closeIndex) {

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
@@ -2,6 +2,7 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System.Globalization;
+using OfficeFormula = DocumentFormat.OpenXml.Office.Excel.Formula;
 
 namespace OfficeIMO.Excel {
     public partial class ExcelDocument {
@@ -384,7 +385,7 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        private Dictionary<string, string> CopyWorksheetTables(WorksheetPart sourcePart, WorksheetPart copiedPart) {
+        private Dictionary<string, string> CopyWorksheetTables(WorksheetPart sourcePart, WorksheetPart copiedPart, bool rewriteCopiedTableReferences = false) {
             TableParts? copiedTableParts = null;
             var tableNameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             var copiedTables = new List<Table>();
@@ -414,12 +415,12 @@ namespace OfficeIMO.Excel {
                 copiedTableParts.Append(new TablePart { Id = copiedPart.GetIdOfPart(copiedTablePart) });
             }
 
-            if (tableNameMap.Count > 0) {
+            if (rewriteCopiedTableReferences && tableNameMap.Count > 0) {
                 RewriteStructuredTableReferences(copiedPart.Worksheet!, tableNameMap);
             }
 
             foreach (Table copiedTable in copiedTables) {
-                if (tableNameMap.Count > 0) {
+                if (rewriteCopiedTableReferences && tableNameMap.Count > 0) {
                     RewriteStructuredTableReferences(copiedTable, tableNameMap);
                 }
 
@@ -524,6 +525,10 @@ namespace OfficeIMO.Excel {
             }
 
             foreach (Formula2 formula in worksheet.Descendants<Formula2>()) {
+                formula.Text = RewriteStructuredTableReferences(formula.Text, tableNameMap);
+            }
+
+            foreach (OfficeFormula formula in worksheet.Descendants<OfficeFormula>()) {
                 formula.Text = RewriteStructuredTableReferences(formula.Text, tableNameMap);
             }
         }

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
@@ -90,11 +90,11 @@ namespace OfficeIMO.Excel {
         public ExcelSheet CopyWorkSheetFrom(ExcelDocument sourceDocument, string sourceSheetName, string newSheetName, SheetNameValidationMode validationMode, ExcelWorksheetCopyOptions? options) {
             if (sourceDocument == null) throw new ArgumentNullException(nameof(sourceDocument));
             if (string.IsNullOrWhiteSpace(sourceSheetName)) throw new ArgumentNullException(nameof(sourceSheetName));
-            if (ReferenceEquals(sourceDocument, this)) {
+            options ??= new ExcelWorksheetCopyOptions();
+            if (ReferenceEquals(sourceDocument, this) && options.CopyMode != ExcelWorksheetCopyMode.Values) {
                 return CopyWorkSheet(sourceSheetName, newSheetName, validationMode);
             }
 
-            options ??= new ExcelWorksheetCopyOptions();
             return options.CopyMode == ExcelWorksheetCopyMode.Values
                 ? CopyWorkSheetFromValues(sourceDocument, sourceSheetName, newSheetName, validationMode)
                 : CopyWorkSheetFromPackage(sourceDocument, sourceSheetName, newSheetName, validationMode);

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
@@ -355,6 +355,15 @@ namespace OfficeIMO.Excel {
             worksheet.RemoveAllChildren<Controls>();
             worksheet.RemoveAllChildren<Picture>();
 
+            PageSetup? pageSetup = worksheet.GetFirstChild<PageSetup>();
+            if (pageSetup != null) {
+                pageSetup.Id = null;
+            }
+
+            RemoveElementsByLocalName(worksheet, "pivotTableDefinition");
+            RemoveElementsByLocalName(worksheet, "pivotTableDefinitions");
+            RemoveElementsByLocalName(worksheet, "queryTableParts");
+
             foreach (Hyperlinks hyperlinks in worksheet.Elements<Hyperlinks>().ToList()) {
                 foreach (Hyperlink hyperlink in hyperlinks.Elements<Hyperlink>().Where(h => h.Id != null).ToList()) {
                     hyperlink.Remove();
@@ -363,6 +372,14 @@ namespace OfficeIMO.Excel {
                 if (!hyperlinks.Elements<Hyperlink>().Any()) {
                     hyperlinks.Remove();
                 }
+            }
+        }
+
+        private static void RemoveElementsByLocalName(OpenXmlElement root, string localName) {
+            foreach (OpenXmlElement element in root.Descendants<OpenXmlElement>()
+                .Where(element => string.Equals(element.LocalName, localName, StringComparison.Ordinal))
+                .ToList()) {
+                element.Remove();
             }
         }
 

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
@@ -365,6 +365,7 @@ namespace OfficeIMO.Excel {
             RemoveElementsByLocalName(worksheet, "pivotTableDefinitions");
             RemoveElementsByLocalName(worksheet, "queryTableParts");
             RemoveElementsByLocalName(worksheet, "customProperties");
+            RemoveWorksheetExtensionsContainingLocalNames(worksheet, "slicerList", "slicerRef", "timelineRefs", "timelineRef");
 
             foreach (Hyperlinks hyperlinks in worksheet.Elements<Hyperlinks>().ToList()) {
                 foreach (Hyperlink hyperlink in hyperlinks.Elements<Hyperlink>().Where(h => h.Id != null).ToList()) {
@@ -374,6 +375,26 @@ namespace OfficeIMO.Excel {
                 if (!hyperlinks.Elements<Hyperlink>().Any()) {
                     hyperlinks.Remove();
                 }
+            }
+        }
+
+        private static void RemoveWorksheetExtensionsContainingLocalNames(Worksheet worksheet, params string[] localNames) {
+            WorksheetExtensionList? extensionList = worksheet.GetFirstChild<WorksheetExtensionList>();
+            if (extensionList == null) {
+                return;
+            }
+
+            var names = new HashSet<string>(localNames, StringComparer.Ordinal);
+            foreach (OpenXmlElement extension in extensionList.Elements<OpenXmlElement>().ToList()) {
+                bool remove = extension.Descendants<OpenXmlElement>()
+                    .Any(element => names.Contains(element.LocalName));
+                if (remove) {
+                    extension.Remove();
+                }
+            }
+
+            if (!extensionList.Elements<OpenXmlElement>().Any()) {
+                extensionList.Remove();
             }
         }
 
@@ -598,12 +619,15 @@ namespace OfficeIMO.Excel {
                 string tableName = mapping.Key;
                 if (index > 0) {
                     char previous = formula[index - 1];
-                    if (char.IsLetterOrDigit(previous) || previous == '_' || previous == '\\') {
+                    if (char.IsLetterOrDigit(previous) || previous == '_' || previous == '\\' || previous == '\'' || previous == '!') {
                         continue;
                     }
                 }
 
-                if (index + tableName.Length >= formula.Length || formula[index + tableName.Length] != '[') {
+                int nextIndex = index + tableName.Length;
+                bool hasStructuredSpecifier = nextIndex < formula.Length && formula[nextIndex] == '[';
+                bool hasBareReferenceBoundary = nextIndex >= formula.Length || IsFormulaTokenBoundary(formula[nextIndex]);
+                if (!hasStructuredSpecifier && !hasBareReferenceBoundary) {
                     continue;
                 }
 
@@ -617,6 +641,10 @@ namespace OfficeIMO.Excel {
             }
 
             return false;
+        }
+
+        private static bool IsFormulaTokenBoundary(char value) {
+            return !(char.IsLetterOrDigit(value) || value == '_' || value == '\\' || value == '\'' || value == '!' || value == ':');
         }
 
         private static string MakeUnusedRelationshipId(WorksheetPart worksheetPart) {

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
@@ -631,6 +631,10 @@ namespace OfficeIMO.Excel {
                 int nextIndex = index + tableName.Length;
                 bool hasStructuredSpecifier = nextIndex < formula.Length && formula[nextIndex] == '[';
                 bool hasBareReferenceBoundary = nextIndex >= formula.Length || IsFormulaTokenBoundary(formula[nextIndex]);
+                if (!hasStructuredSpecifier && nextIndex < formula.Length && formula[nextIndex] == '(') {
+                    continue;
+                }
+
                 if (!hasStructuredSpecifier && !hasBareReferenceBoundary) {
                     continue;
                 }

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetOperations.cs
@@ -62,8 +62,7 @@ namespace OfficeIMO.Excel {
         }
 
         /// <summary>
-        /// Copies a worksheet from another workbook into this workbook. Values are copied through the reader/writer
-        /// surface so callers can combine workbooks without sharing package parts.
+        /// Copies a worksheet from another workbook into this workbook.
         /// </summary>
         /// <param name="sourceDocument">Workbook containing the source worksheet.</param>
         /// <param name="sourceSheetName">Name of the worksheet to copy.</param>
@@ -71,33 +70,29 @@ namespace OfficeIMO.Excel {
         /// <param name="validationMode">How to validate or sanitize <paramref name="newSheetName"/>.</param>
         /// <returns>The copied worksheet.</returns>
         public ExcelSheet CopyWorkSheetFrom(ExcelDocument sourceDocument, string sourceSheetName, string newSheetName, SheetNameValidationMode validationMode = SheetNameValidationMode.Sanitize) {
+            return CopyWorkSheetFrom(sourceDocument, sourceSheetName, newSheetName, validationMode, options: null);
+        }
+
+        /// <summary>
+        /// Copies a worksheet from another workbook into this workbook.
+        /// </summary>
+        /// <param name="sourceDocument">Workbook containing the source worksheet.</param>
+        /// <param name="sourceSheetName">Name of the worksheet to copy.</param>
+        /// <param name="newSheetName">Requested name for the copied worksheet.</param>
+        /// <param name="validationMode">How to validate or sanitize <paramref name="newSheetName"/>.</param>
+        /// <param name="options">Copy strategy options.</param>
+        /// <returns>The copied worksheet.</returns>
+        public ExcelSheet CopyWorkSheetFrom(ExcelDocument sourceDocument, string sourceSheetName, string newSheetName, SheetNameValidationMode validationMode, ExcelWorksheetCopyOptions? options) {
             if (sourceDocument == null) throw new ArgumentNullException(nameof(sourceDocument));
             if (string.IsNullOrWhiteSpace(sourceSheetName)) throw new ArgumentNullException(nameof(sourceSheetName));
             if (ReferenceEquals(sourceDocument, this)) {
                 return CopyWorkSheet(sourceSheetName, newSheetName, validationMode);
             }
 
-            ExcelSheet sourceSheet = sourceDocument.GetSheet(sourceSheetName);
-            string usedRange = sourceSheet.GetUsedRangeA1();
-            var (startRow, startColumn, _, _) = A1.ParseRange(usedRange);
-            object?[,] values;
-            using (var reader = sourceDocument.CreateReader()) {
-                values = reader.GetSheet(sourceSheet.Name).ReadRange(usedRange);
-            }
-
-            ExcelSheet targetSheet = AddWorkSheet(newSheetName, validationMode);
-            for (int rowOffset = 0; rowOffset < values.GetLength(0); rowOffset++) {
-                for (int columnOffset = 0; columnOffset < values.GetLength(1); columnOffset++) {
-                    object? value = values[rowOffset, columnOffset];
-                    if (value == null) continue;
-                    targetSheet.CellValue(startRow + rowOffset, startColumn + columnOffset, value);
-                }
-            }
-
-            CopyWorksheetTables(sourceSheet.WorksheetPart, targetSheet.WorksheetPart);
-            targetSheet.WorksheetPart.Worksheet!.Save();
-
-            return targetSheet;
+            options ??= new ExcelWorksheetCopyOptions();
+            return options.CopyMode == ExcelWorksheetCopyMode.Values
+                ? CopyWorkSheetFromValues(sourceDocument, sourceSheetName, newSheetName, validationMode)
+                : CopyWorkSheetFromPackage(sourceDocument, sourceSheetName, newSheetName, validationMode);
         }
 
         /// <summary>
@@ -105,6 +100,13 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public ExcelSheet CopyWorksheetFrom(ExcelDocument sourceDocument, string sourceSheetName, string newSheetName, SheetNameValidationMode validationMode = SheetNameValidationMode.Sanitize) {
             return CopyWorkSheetFrom(sourceDocument, sourceSheetName, newSheetName, validationMode);
+        }
+
+        /// <summary>
+        /// Copies a worksheet from another workbook into this workbook.
+        /// </summary>
+        public ExcelSheet CopyWorksheetFrom(ExcelDocument sourceDocument, string sourceSheetName, string newSheetName, SheetNameValidationMode validationMode, ExcelWorksheetCopyOptions? options) {
+            return CopyWorkSheetFrom(sourceDocument, sourceSheetName, newSheetName, validationMode, options);
         }
 
         /// <summary>

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
@@ -30,10 +30,10 @@ namespace OfficeIMO.Excel {
         }
 
         private ExcelSheet CopyWorkSheetFromPackage(ExcelDocument sourceDocument, string sourceSheetName, string newSheetName, SheetNameValidationMode validationMode) {
-            return CopyWorkSheetFromPackage(sourceDocument, sourceSheetName, newSheetName, validationMode, rewriteCopiedReferences: true, copyReferencedDefinedNames: true);
+            return CopyWorkSheetFromPackage(sourceDocument, sourceSheetName, newSheetName, validationMode, rewriteCopiedReferences: true, copyReferencedDefinedNames: true).Sheet;
         }
 
-        private ExcelSheet CopyWorkSheetFromPackage(
+        private WorksheetPackageCopyResult CopyWorkSheetFromPackage(
             ExcelDocument sourceDocument,
             string sourceSheetName,
             string newSheetName,
@@ -52,7 +52,7 @@ namespace OfficeIMO.Excel {
                 WorksheetStyleCopyMap styleMap = RemapCopiedWorksheetStyles(sourceDocument.WorkbookPartRoot.WorkbookStylesPart?.Stylesheet, WorkbookPartRoot, copiedPart.Worksheet);
                 RemapCopiedWorksheetConditionalFormats(copiedPart.Worksheet, styleMap.DifferentialFormats);
                 RemoveRelationshipBackedWorksheetFeatures(copiedPart.Worksheet);
-                CopyWorksheetTables(sourcePart, copiedPart);
+                IReadOnlyDictionary<string, string> tableNameMap = CopyWorksheetTables(sourcePart, copiedPart);
 
                 Sheet sheet = AppendWorksheetElement(copiedPart, validatedName);
                 var targetSheet = new ExcelSheet(this, _spreadSheetDocument, sheet);
@@ -61,17 +61,17 @@ namespace OfficeIMO.Excel {
                     [sourceSheet.Name] = targetSheet.Name
                 };
                 if (rewriteCopiedReferences) {
-                    RewriteCopiedWorksheetReferences(copiedPart, sheetNameMap);
+                    RewriteCopiedWorksheetReferences(copiedPart, sheetNameMap, tableNameMap);
                 }
 
                 if (copyReferencedDefinedNames) {
-                    CopyReferencedDefinedNamesFromSource(sourceDocument, targetSheet, sheetNameMap);
+                    CopyReferencedDefinedNamesFromSource(sourceDocument, targetSheet, sheetNameMap, tableNameMap);
                 }
 
                 copiedPart.Worksheet.Save();
                 MarkPackageDirty();
                 WorkbookRoot.Save();
-                return targetSheet;
+                return new WorksheetPackageCopyResult(targetSheet, tableNameMap);
             });
         }
 
@@ -126,6 +126,8 @@ namespace OfficeIMO.Excel {
                 uint? oldStyleIndex = cell.StyleIndex?.Value;
                 if (oldStyleIndex.HasValue && cellFormatMap.TryGetValue(oldStyleIndex.Value, out uint newStyleIndex)) {
                     cell.StyleIndex = newStyleIndex;
+                } else if (!oldStyleIndex.HasValue && cellFormatMap.TryGetValue(0U, out uint newDefaultStyleIndex)) {
+                    cell.StyleIndex = newDefaultStyleIndex;
                 }
             }
 
@@ -337,6 +339,17 @@ namespace OfficeIMO.Excel {
 
             internal IReadOnlyDictionary<uint, uint> CellFormats { get; }
             internal IReadOnlyDictionary<uint, uint> DifferentialFormats { get; }
+        }
+
+        private sealed class WorksheetPackageCopyResult {
+            internal WorksheetPackageCopyResult(ExcelSheet sheet, IReadOnlyDictionary<string, string> tableNameMap) {
+                Sheet = sheet;
+                TableNameMap = tableNameMap;
+            }
+
+            internal ExcelSheet Sheet { get; }
+
+            internal IReadOnlyDictionary<string, string> TableNameMap { get; }
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
@@ -1,4 +1,5 @@
 using DocumentFormat.OpenXml;
+using A = DocumentFormat.OpenXml.Drawing;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System;
@@ -51,10 +52,12 @@ namespace OfficeIMO.Excel {
                 WorksheetPart copiedPart = WorkbookPartRoot.AddNewPart<WorksheetPart>();
                 copiedPart.Worksheet = (Worksheet)sourcePart.Worksheet!.CloneNode(true);
                 RewriteSharedStringCellsToInlineStrings(copiedPart.Worksheet, sourceDocument.WorkbookPartRoot.SharedStringTablePart);
-                WorksheetStyleCopyMap styleMap = RemapCopiedWorksheetStyles(sourceDocument.WorkbookPartRoot.WorkbookStylesPart?.Stylesheet, WorkbookPartRoot, copiedPart.Worksheet);
+                WorksheetStyleCopyMap styleMap = RemapCopiedWorksheetStyles(sourceDocument.WorkbookPartRoot, WorkbookPartRoot, copiedPart.Worksheet);
                 RemapCopiedWorksheetConditionalFormats(copiedPart.Worksheet, styleMap.DifferentialFormats);
                 RemoveRelationshipBackedWorksheetFeatures(copiedPart.Worksheet);
                 IReadOnlyDictionary<string, string> tableNameMap = CopyWorksheetTables(sourcePart, copiedPart);
+                bool copiedFormulas = copiedPart.Worksheet.Descendants<CellFormula>()
+                    .Any(formula => !string.IsNullOrWhiteSpace(formula.Text));
 
                 Sheet sheet = AppendWorksheetElement(copiedPart, validatedName);
                 var targetSheet = new ExcelSheet(this, _spreadSheetDocument, sheet);
@@ -71,7 +74,11 @@ namespace OfficeIMO.Excel {
                 }
 
                 copiedPart.Worksheet.Save();
-                MarkPackageDirty();
+                if (copiedFormulas) {
+                    MarkRequiresSavePreflight();
+                } else {
+                    MarkPackageDirty();
+                }
                 WorkbookRoot.Save();
                 return new WorksheetPackageCopyResult(targetSheet, tableNameMap);
             });
@@ -107,7 +114,8 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        private static WorksheetStyleCopyMap RemapCopiedWorksheetStyles(Stylesheet? sourceStylesheet, WorkbookPart targetWorkbookPart, Worksheet worksheet) {
+        private static WorksheetStyleCopyMap RemapCopiedWorksheetStyles(WorkbookPart sourceWorkbookPart, WorkbookPart targetWorkbookPart, Worksheet worksheet) {
+            Stylesheet? sourceStylesheet = sourceWorkbookPart.WorkbookStylesPart?.Stylesheet;
             if (sourceStylesheet?.CellFormats == null) {
                 return WorksheetStyleCopyMap.Empty;
             }
@@ -116,13 +124,14 @@ namespace OfficeIMO.Excel {
             Stylesheet targetStylesheet = targetStylesPart.Stylesheet ??= CreateDefaultStylesheet();
             EnsureStylesheetPrimitives(targetStylesheet);
 
+            var colorResolver = WorkbookStyleColorResolver.Create(sourceWorkbookPart, sourceStylesheet);
             Dictionary<uint, uint> numberingMap = AppendNumberingFormats(sourceStylesheet, targetStylesheet);
-            Dictionary<uint, uint> fontMap = AppendStyleElements<Fonts, Font>(sourceStylesheet.Fonts, targetStylesheet.Fonts!, (container, count) => container.Count = count);
-            Dictionary<uint, uint> fillMap = AppendStyleElements<Fills, Fill>(sourceStylesheet.Fills, targetStylesheet.Fills!, (container, count) => container.Count = count);
-            Dictionary<uint, uint> borderMap = AppendStyleElements<Borders, Border>(sourceStylesheet.Borders, targetStylesheet.Borders!, (container, count) => container.Count = count);
+            Dictionary<uint, uint> fontMap = AppendStyleElements<Fonts, Font>(sourceStylesheet.Fonts, targetStylesheet.Fonts!, (container, count) => container.Count = count, colorResolver);
+            Dictionary<uint, uint> fillMap = AppendStyleElements<Fills, Fill>(sourceStylesheet.Fills, targetStylesheet.Fills!, (container, count) => container.Count = count, colorResolver);
+            Dictionary<uint, uint> borderMap = AppendStyleElements<Borders, Border>(sourceStylesheet.Borders, targetStylesheet.Borders!, (container, count) => container.Count = count, colorResolver);
             Dictionary<uint, uint> styleFormatMap = AppendCellStyleFormats(sourceStylesheet.CellStyleFormats, targetStylesheet.CellStyleFormats!, numberingMap, fontMap, fillMap, borderMap);
             Dictionary<uint, uint> cellFormatMap = AppendCellFormats(sourceStylesheet.CellFormats, targetStylesheet.CellFormats!, numberingMap, fontMap, fillMap, borderMap, styleFormatMap);
-            Dictionary<uint, uint> differentialFormatMap = AppendDifferentialFormats(sourceStylesheet.DifferentialFormats, targetStylesheet.DifferentialFormats!);
+            Dictionary<uint, uint> differentialFormatMap = AppendDifferentialFormats(sourceStylesheet.DifferentialFormats, targetStylesheet.DifferentialFormats!, colorResolver);
             var inheritedStyleCells = BuildInheritedStyleCellSet(worksheet);
 
             foreach (Cell cell in worksheet.Descendants<Cell>()) {
@@ -256,7 +265,11 @@ namespace OfficeIMO.Excel {
             return formats;
         }
 
-        private static Dictionary<uint, uint> AppendStyleElements<TContainer, TElement>(TContainer? source, TContainer target, Action<TContainer, uint> setCount)
+        private static Dictionary<uint, uint> AppendStyleElements<TContainer, TElement>(
+            TContainer? source,
+            TContainer target,
+            Action<TContainer, uint> setCount,
+            WorkbookStyleColorResolver colorResolver)
             where TContainer : OpenXmlCompositeElement
             where TElement : OpenXmlElement {
             var map = new Dictionary<uint, uint>();
@@ -268,7 +281,9 @@ namespace OfficeIMO.Excel {
             uint index = 0;
             foreach (TElement element in source.Elements<TElement>()) {
                 uint newIndex = offset + index;
-                target.Append(element.CloneNode(true));
+                var copied = element.CloneNode(true);
+                colorResolver.NormalizeThemeAndIndexedColors(copied);
+                target.Append(copied);
                 map[index] = newIndex;
                 index++;
             }
@@ -343,7 +358,7 @@ namespace OfficeIMO.Excel {
             return map;
         }
 
-        private static Dictionary<uint, uint> AppendDifferentialFormats(DifferentialFormats? source, DifferentialFormats target) {
+        private static Dictionary<uint, uint> AppendDifferentialFormats(DifferentialFormats? source, DifferentialFormats target, WorkbookStyleColorResolver colorResolver) {
             var map = new Dictionary<uint, uint>();
             if (source == null) {
                 return map;
@@ -353,7 +368,9 @@ namespace OfficeIMO.Excel {
             uint index = 0;
             foreach (DifferentialFormat sourceFormat in source.Elements<DifferentialFormat>()) {
                 uint newIndex = offset + index;
-                target.Append(sourceFormat.CloneNode(true));
+                var copied = sourceFormat.CloneNode(true);
+                colorResolver.NormalizeThemeAndIndexedColors(copied);
+                target.Append(copied);
                 map[index] = newIndex;
                 index++;
             }
@@ -395,6 +412,177 @@ namespace OfficeIMO.Excel {
             internal ExcelSheet Sheet { get; }
 
             internal IReadOnlyDictionary<string, string> TableNameMap { get; }
+        }
+
+        private sealed class WorkbookStyleColorResolver {
+            private static readonly string[] DefaultIndexedColors = {
+                "FF000000", "FFFFFFFF", "FFFF0000", "FF00FF00", "FF0000FF", "FFFFFF00", "FFFF00FF", "FF00FFFF",
+                "FF000000", "FFFFFFFF", "FFFF0000", "FF00FF00", "FF0000FF", "FFFFFF00", "FFFF00FF", "FF00FFFF",
+                "FF800000", "FF008000", "FF000080", "FF808000", "FF800080", "FF008080", "FFC0C0C0", "FF808080",
+                "FF9999FF", "FF993366", "FFFFFFCC", "FFCCFFFF", "FF660066", "FFFF8080", "FF0066CC", "FFCCCCFF",
+                "FF000080", "FFFF00FF", "FFFFFF00", "FF00FFFF", "FF800080", "FF800000", "FF008080", "FF0000FF",
+                "FF00CCFF", "FFCCFFFF", "FFCCFFCC", "FFFFFF99", "FF99CCFF", "FFFF99CC", "FFCC99FF", "FFFFCC99",
+                "FF3366FF", "FF33CCCC", "FF99CC00", "FFFFCC00", "FFFF9900", "FFFF6600", "FF666699", "FF969696",
+                "FF003366", "FF339966", "FF003300", "FF333300", "FF993300", "FF993366", "FF333399", "FF333333"
+            };
+
+            private readonly Dictionary<uint, string> _themeColors;
+            private readonly Dictionary<uint, string> _indexedColors;
+
+            private WorkbookStyleColorResolver(Dictionary<uint, string> themeColors, Dictionary<uint, string> indexedColors) {
+                _themeColors = themeColors;
+                _indexedColors = indexedColors;
+            }
+
+            internal static WorkbookStyleColorResolver Create(WorkbookPart workbookPart, Stylesheet sourceStylesheet) {
+                return new WorkbookStyleColorResolver(ReadThemeColors(workbookPart), ReadIndexedColors(sourceStylesheet));
+            }
+
+            internal void NormalizeThemeAndIndexedColors(OpenXmlElement element) {
+                foreach (ColorType color in EnumerateColorTypes(element)) {
+                    NormalizeColor(color);
+                }
+            }
+
+            private void NormalizeColor(ColorType color) {
+                string? argb = null;
+                if (color.Theme?.Value is uint themeIndex && _themeColors.TryGetValue(themeIndex, out string? themeColor)) {
+                    argb = themeColor;
+                } else if (color.Indexed?.Value is uint indexed && _indexedColors.TryGetValue(indexed, out string? indexedColor)) {
+                    argb = indexedColor;
+                }
+
+                if (argb == null) {
+                    return;
+                }
+
+                if (color.Tint?.Value is double tint && Math.Abs(tint) > 0.0000001D) {
+                    argb = ApplyTint(argb, tint);
+                }
+
+                color.Rgb = argb;
+                color.Theme = null;
+                color.Indexed = null;
+                color.Tint = null;
+            }
+
+            private static IEnumerable<ColorType> EnumerateColorTypes(OpenXmlElement element) {
+                if (element is ColorType color) {
+                    yield return color;
+                }
+
+                foreach (ColorType child in element.Descendants<ColorType>()) {
+                    yield return child;
+                }
+            }
+
+            private static Dictionary<uint, string> ReadThemeColors(WorkbookPart workbookPart) {
+                var colors = new Dictionary<uint, string>();
+                A.ColorScheme? scheme = workbookPart.GetPartsOfType<ThemePart>()
+                    .FirstOrDefault()
+                    ?.Theme
+                    ?.ThemeElements
+                    ?.ColorScheme;
+                if (scheme == null) {
+                    AddDefaultThemeColors(colors);
+                    return colors;
+                }
+
+                AddThemeColor(colors, 0U, scheme.GetFirstChild<A.Light1Color>());
+                AddThemeColor(colors, 1U, scheme.GetFirstChild<A.Dark1Color>());
+                AddThemeColor(colors, 2U, scheme.GetFirstChild<A.Light2Color>());
+                AddThemeColor(colors, 3U, scheme.GetFirstChild<A.Dark2Color>());
+                AddThemeColor(colors, 4U, scheme.GetFirstChild<A.Accent1Color>());
+                AddThemeColor(colors, 5U, scheme.GetFirstChild<A.Accent2Color>());
+                AddThemeColor(colors, 6U, scheme.GetFirstChild<A.Accent3Color>());
+                AddThemeColor(colors, 7U, scheme.GetFirstChild<A.Accent4Color>());
+                AddThemeColor(colors, 8U, scheme.GetFirstChild<A.Accent5Color>());
+                AddThemeColor(colors, 9U, scheme.GetFirstChild<A.Accent6Color>());
+                AddThemeColor(colors, 10U, scheme.GetFirstChild<A.Hyperlink>());
+                AddThemeColor(colors, 11U, scheme.GetFirstChild<A.FollowedHyperlinkColor>());
+                if (colors.Count == 0) {
+                    AddDefaultThemeColors(colors);
+                }
+
+                return colors;
+            }
+
+            private static void AddDefaultThemeColors(Dictionary<uint, string> colors) {
+                colors[0U] = "FFFFFFFF";
+                colors[1U] = "FF000000";
+                colors[2U] = "FFEEECE1";
+                colors[3U] = "FF1F497D";
+                colors[4U] = "FF4F81BD";
+                colors[5U] = "FFC0504D";
+                colors[6U] = "FF9BBB59";
+                colors[7U] = "FF8064A2";
+                colors[8U] = "FF4BACC6";
+                colors[9U] = "FFF79646";
+                colors[10U] = "FF0000FF";
+                colors[11U] = "FF800080";
+            }
+
+            private static void AddThemeColor(Dictionary<uint, string> colors, uint index, OpenXmlCompositeElement? colorElement) {
+                string? rgb = colorElement?.GetFirstChild<A.RgbColorModelHex>()?.Val?.Value
+                    ?? colorElement?.GetFirstChild<A.SystemColor>()?.LastColor?.Value;
+                if (string.IsNullOrWhiteSpace(rgb)) {
+                    return;
+                }
+
+                colors[index] = ToArgb(rgb!);
+            }
+
+            private static Dictionary<uint, string> ReadIndexedColors(Stylesheet sourceStylesheet) {
+                var colors = new Dictionary<uint, string>();
+                for (uint index = 0; index < DefaultIndexedColors.Length; index++) {
+                    colors[index] = DefaultIndexedColors[index];
+                }
+
+                IndexedColors? indexedColors = sourceStylesheet.Colors?.IndexedColors;
+                if (indexedColors == null) {
+                    return colors;
+                }
+
+                uint customIndex = 0;
+                foreach (RgbColor color in indexedColors.Elements<RgbColor>()) {
+                    string? rgb = color.Rgb?.Value;
+                    if (!string.IsNullOrWhiteSpace(rgb)) {
+                        colors[customIndex] = ToArgb(rgb!);
+                    }
+
+                    customIndex++;
+                }
+
+                return colors;
+            }
+
+            private static string ToArgb(string rgb) {
+                string value = rgb.Trim().TrimStart('#');
+                if (value.Length == 6) {
+                    return "FF" + value.ToUpperInvariant();
+                }
+
+                return value.ToUpperInvariant();
+            }
+
+            private static string ApplyTint(string argb, double tint) {
+                string normalized = ToArgb(argb);
+                byte alpha = Convert.ToByte(normalized.Substring(0, 2), 16);
+                byte red = Convert.ToByte(normalized.Substring(2, 2), 16);
+                byte green = Convert.ToByte(normalized.Substring(4, 2), 16);
+                byte blue = Convert.ToByte(normalized.Substring(6, 2), 16);
+                return alpha.ToString("X2", CultureInfo.InvariantCulture)
+                    + ApplyTintChannel(red, tint).ToString("X2", CultureInfo.InvariantCulture)
+                    + ApplyTintChannel(green, tint).ToString("X2", CultureInfo.InvariantCulture)
+                    + ApplyTintChannel(blue, tint).ToString("X2", CultureInfo.InvariantCulture);
+            }
+
+            private static byte ApplyTintChannel(byte channel, double tint) {
+                double value = tint < 0
+                    ? channel * (1D + tint)
+                    : channel * (1D - tint) + (255D * tint);
+                return (byte)Math.Max(0D, Math.Min(255D, Math.Round(value)));
+            }
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
@@ -1,6 +1,7 @@
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
+using System.Collections.Generic;
 using System.Globalization;
 
 namespace OfficeIMO.Excel {
@@ -41,13 +42,19 @@ namespace OfficeIMO.Excel {
                 RemapCopiedWorksheetConditionalFormats(copiedPart.Worksheet, styleMap.DifferentialFormats);
                 RemoveRelationshipBackedWorksheetFeatures(copiedPart.Worksheet);
                 CopyWorksheetTables(sourcePart, copiedPart);
-                copiedPart.Worksheet.Save();
 
                 Sheet sheet = AppendWorksheetElement(copiedPart, validatedName);
+                var targetSheet = new ExcelSheet(this, _spreadSheetDocument, sheet);
+                var sheetNameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+                    [sourceSheet.Name] = targetSheet.Name
+                };
+                RewriteCopiedWorksheetReferences(copiedPart, sheetNameMap);
+                CopyReferencedDefinedNamesFromSource(sourceDocument, sourceSheet.Name, targetSheet.Name, sheetNameMap);
+                copiedPart.Worksheet.Save();
                 MarkSheetCacheDirty();
                 MarkPackageDirty();
                 WorkbookRoot.Save();
-                return new ExcelSheet(this, _spreadSheetDocument, sheet);
+                return targetSheet;
             });
         }
 

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
@@ -129,9 +129,11 @@ namespace OfficeIMO.Excel {
             double offset = targetDateSystem == ExcelDateSystem.NineteenFour
                 ? -ExcelDateSystemConverter.Date1904OffsetDays
                 : ExcelDateSystemConverter.Date1904OffsetDays;
+            Dictionary<int, uint> rowStyleIndexes = BuildRowStyleIndexMap(worksheet);
+            (int Min, int Max, uint StyleIndex)[] columnStyleIndexes = BuildColumnStyleIndexRanges(worksheet);
 
             foreach (Cell cell in worksheet.Descendants<Cell>()) {
-                if (cell.CellFormula != null || !IsNumericDateCell(cell, styles)) {
+                if (cell.CellFormula != null || !IsNumericDateCell(cell, styles, GetEffectiveStyleIndex(cell, rowStyleIndexes, columnStyleIndexes))) {
                     continue;
                 }
 
@@ -142,6 +144,62 @@ namespace OfficeIMO.Excel {
 
                 cell.CellValue = new CellValue((serial + offset).ToString(CultureInfo.InvariantCulture));
             }
+        }
+
+        private static Dictionary<int, uint> BuildRowStyleIndexMap(Worksheet worksheet) {
+            return worksheet.Descendants<Row>()
+                .Where(row => row.RowIndex != null && row.StyleIndex != null)
+                .ToDictionary(
+                    row => (int)row.RowIndex!.Value,
+                    row => row.StyleIndex!.Value,
+                    EqualityComparer<int>.Default);
+        }
+
+        private static (int Min, int Max, uint StyleIndex)[] BuildColumnStyleIndexRanges(Worksheet worksheet) {
+            return worksheet.Elements<Columns>()
+                .SelectMany(columns => columns.Elements<Column>())
+                .Where(column => column.Style != null)
+                .Select(column => (
+                    Min: (int)(column.Min?.Value ?? 1U),
+                    Max: (int)(column.Max?.Value ?? column.Min?.Value ?? 1U),
+                    StyleIndex: column.Style!.Value))
+                .ToArray();
+        }
+
+        private static uint? GetEffectiveStyleIndex(
+            Cell cell,
+            IReadOnlyDictionary<int, uint> rowStyleIndexes,
+            IReadOnlyList<(int Min, int Max, uint StyleIndex)> columnStyleIndexes) {
+            if (cell.StyleIndex?.Value is uint cellStyleIndex) {
+                return cellStyleIndex;
+            }
+
+            string? reference = cell.CellReference?.Value;
+            if (string.IsNullOrWhiteSpace(reference)) {
+                return null;
+            }
+
+            (int row, int column) = A1.ParseCellRef(reference!);
+            if (rowStyleIndexes.TryGetValue(row, out uint rowStyleIndex)) {
+                return rowStyleIndex;
+            }
+
+            foreach (var columnStyle in columnStyleIndexes) {
+                if (column >= columnStyle.Min && column <= columnStyle.Max) {
+                    return columnStyle.StyleIndex;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool IsNumericDateCell(Cell cell, StylesCache styles, uint? styleIndex) {
+            if (!styleIndex.HasValue || !styles.IsDateLike(styleIndex.Value)) {
+                return false;
+            }
+
+            CellValues? dataType = cell.DataType?.Value;
+            return dataType == null || dataType == CellValues.Number;
         }
 
         private static void StripCopiedCellMetadataReferences(Worksheet worksheet) {

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
@@ -30,6 +30,17 @@ namespace OfficeIMO.Excel {
         }
 
         private ExcelSheet CopyWorkSheetFromPackage(ExcelDocument sourceDocument, string sourceSheetName, string newSheetName, SheetNameValidationMode validationMode) {
+            return CopyWorkSheetFromPackage(sourceDocument, sourceSheetName, newSheetName, validationMode, rewriteCopiedReferences: true, copyReferencedDefinedNames: true);
+        }
+
+        private ExcelSheet CopyWorkSheetFromPackage(
+            ExcelDocument sourceDocument,
+            string sourceSheetName,
+            string newSheetName,
+            SheetNameValidationMode validationMode,
+            bool rewriteCopiedReferences,
+            bool copyReferencedDefinedNames) {
+            sourceDocument.MaterializeDeferredDataSetImport();
             ExcelSheet sourceSheet = sourceDocument.GetSheet(sourceSheetName);
 
             return Locking.ExecuteWrite(EnsureLock(), () => {
@@ -45,13 +56,19 @@ namespace OfficeIMO.Excel {
 
                 Sheet sheet = AppendWorksheetElement(copiedPart, validatedName);
                 var targetSheet = new ExcelSheet(this, _spreadSheetDocument, sheet);
+                MarkSheetCacheDirty();
                 var sheetNameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
                     [sourceSheet.Name] = targetSheet.Name
                 };
-                RewriteCopiedWorksheetReferences(copiedPart, sheetNameMap);
-                CopyReferencedDefinedNamesFromSource(sourceDocument, sourceSheet.Name, targetSheet.Name, sheetNameMap);
+                if (rewriteCopiedReferences) {
+                    RewriteCopiedWorksheetReferences(copiedPart, sheetNameMap);
+                }
+
+                if (copyReferencedDefinedNames) {
+                    CopyReferencedDefinedNamesFromSource(sourceDocument, targetSheet, sheetNameMap);
+                }
+
                 copiedPart.Worksheet.Save();
-                MarkSheetCacheDirty();
                 MarkPackageDirty();
                 WorkbookRoot.Save();
                 return targetSheet;

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
@@ -37,13 +37,15 @@ namespace OfficeIMO.Excel {
                 WorksheetPart copiedPart = WorkbookPartRoot.AddNewPart<WorksheetPart>();
                 copiedPart.Worksheet = (Worksheet)sourcePart.Worksheet!.CloneNode(true);
                 RewriteSharedStringCellsToInlineStrings(copiedPart.Worksheet, sourceDocument.WorkbookPartRoot.SharedStringTablePart);
-                RemapCopiedWorksheetStyles(sourceDocument.WorkbookPartRoot.WorkbookStylesPart?.Stylesheet, WorkbookPartRoot, copiedPart.Worksheet);
+                WorksheetStyleCopyMap styleMap = RemapCopiedWorksheetStyles(sourceDocument.WorkbookPartRoot.WorkbookStylesPart?.Stylesheet, WorkbookPartRoot, copiedPart.Worksheet);
+                RemapCopiedWorksheetConditionalFormats(copiedPart.Worksheet, styleMap.DifferentialFormats);
                 RemoveRelationshipBackedWorksheetFeatures(copiedPart.Worksheet);
                 CopyWorksheetTables(sourcePart, copiedPart);
                 copiedPart.Worksheet.Save();
 
                 Sheet sheet = AppendWorksheetElement(copiedPart, validatedName);
                 MarkSheetCacheDirty();
+                MarkPackageDirty();
                 WorkbookRoot.Save();
                 return new ExcelSheet(this, _spreadSheetDocument, sheet);
             });
@@ -79,9 +81,9 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        private static void RemapCopiedWorksheetStyles(Stylesheet? sourceStylesheet, WorkbookPart targetWorkbookPart, Worksheet worksheet) {
+        private static WorksheetStyleCopyMap RemapCopiedWorksheetStyles(Stylesheet? sourceStylesheet, WorkbookPart targetWorkbookPart, Worksheet worksheet) {
             if (sourceStylesheet?.CellFormats == null) {
-                return;
+                return WorksheetStyleCopyMap.Empty;
             }
 
             WorkbookStylesPart targetStylesPart = targetWorkbookPart.WorkbookStylesPart ?? targetWorkbookPart.AddNewPart<WorkbookStylesPart>();
@@ -94,6 +96,7 @@ namespace OfficeIMO.Excel {
             Dictionary<uint, uint> borderMap = AppendStyleElements<Borders, Border>(sourceStylesheet.Borders, targetStylesheet.Borders!, (container, count) => container.Count = count);
             Dictionary<uint, uint> styleFormatMap = AppendCellStyleFormats(sourceStylesheet.CellStyleFormats, targetStylesheet.CellStyleFormats!, numberingMap, fontMap, fillMap, borderMap);
             Dictionary<uint, uint> cellFormatMap = AppendCellFormats(sourceStylesheet.CellFormats, targetStylesheet.CellFormats!, numberingMap, fontMap, fillMap, borderMap, styleFormatMap);
+            Dictionary<uint, uint> differentialFormatMap = AppendDifferentialFormats(sourceStylesheet.DifferentialFormats, targetStylesheet.DifferentialFormats!);
 
             foreach (Cell cell in worksheet.Descendants<Cell>()) {
                 uint? oldStyleIndex = cell.StyleIndex?.Value;
@@ -102,8 +105,36 @@ namespace OfficeIMO.Excel {
                 }
             }
 
+            foreach (Row row in worksheet.Descendants<Row>()) {
+                uint? oldStyleIndex = row.StyleIndex?.Value;
+                if (oldStyleIndex.HasValue && cellFormatMap.TryGetValue(oldStyleIndex.Value, out uint newStyleIndex)) {
+                    row.StyleIndex = newStyleIndex;
+                }
+            }
+
+            foreach (Column column in worksheet.Descendants<Column>()) {
+                uint? oldStyleIndex = column.Style?.Value;
+                if (oldStyleIndex.HasValue && cellFormatMap.TryGetValue(oldStyleIndex.Value, out uint newStyleIndex)) {
+                    column.Style = newStyleIndex;
+                }
+            }
+
             EnsureStylesheetPrimitives(targetStylesheet);
             targetStylesheet.Save();
+            return new WorksheetStyleCopyMap(cellFormatMap, differentialFormatMap);
+        }
+
+        private static void RemapCopiedWorksheetConditionalFormats(Worksheet worksheet, IReadOnlyDictionary<uint, uint> differentialFormatMap) {
+            if (differentialFormatMap.Count == 0) {
+                return;
+            }
+
+            foreach (ConditionalFormattingRule rule in worksheet.Descendants<ConditionalFormattingRule>()) {
+                uint? oldDxfId = rule.FormatId?.Value;
+                if (oldDxfId.HasValue && differentialFormatMap.TryGetValue(oldDxfId.Value, out uint newDxfId)) {
+                    rule.FormatId = newDxfId;
+                }
+            }
         }
 
         private static Dictionary<uint, uint> AppendNumberingFormats(Stylesheet sourceStylesheet, Stylesheet targetStylesheet) {
@@ -241,12 +272,47 @@ namespace OfficeIMO.Excel {
             return map;
         }
 
+        private static Dictionary<uint, uint> AppendDifferentialFormats(DifferentialFormats? source, DifferentialFormats target) {
+            var map = new Dictionary<uint, uint>();
+            if (source == null) {
+                return map;
+            }
+
+            uint offset = (uint)target.Elements<DifferentialFormat>().Count();
+            uint index = 0;
+            foreach (DifferentialFormat sourceFormat in source.Elements<DifferentialFormat>()) {
+                uint newIndex = offset + index;
+                target.Append(sourceFormat.CloneNode(true));
+                map[index] = newIndex;
+                index++;
+            }
+
+            target.Count = (uint)target.Elements<DifferentialFormat>().Count();
+            return map;
+        }
+
         private static uint MapValue(uint? value, IReadOnlyDictionary<uint, uint> map) {
             if (!value.HasValue) {
                 return 0U;
             }
 
             return map.TryGetValue(value.Value, out uint mapped) ? mapped : value.Value;
+        }
+
+        private sealed class WorksheetStyleCopyMap {
+            internal static readonly WorksheetStyleCopyMap Empty = new WorksheetStyleCopyMap(
+                new Dictionary<uint, uint>(),
+                new Dictionary<uint, uint>());
+
+            internal WorksheetStyleCopyMap(
+                IReadOnlyDictionary<uint, uint> cellFormats,
+                IReadOnlyDictionary<uint, uint> differentialFormats) {
+                CellFormats = cellFormats;
+                DifferentialFormats = differentialFormats;
+            }
+
+            internal IReadOnlyDictionary<uint, uint> CellFormats { get; }
+            internal IReadOnlyDictionary<uint, uint> DifferentialFormats { get; }
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
@@ -215,6 +215,22 @@ namespace OfficeIMO.Excel {
                     rule.FormatId = newDxfId;
                 }
             }
+
+            foreach (OpenXmlElement element in worksheet.Descendants<OpenXmlElement>()) {
+                foreach (OpenXmlAttribute attribute in element.GetAttributes()) {
+                    if (!string.Equals(attribute.LocalName, "dxfId", StringComparison.Ordinal)
+                        || !uint.TryParse(attribute.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out uint oldDxfId)
+                        || !differentialFormatMap.TryGetValue(oldDxfId, out uint newDxfId)) {
+                        continue;
+                    }
+
+                    element.SetAttribute(new OpenXmlAttribute(
+                        attribute.Prefix,
+                        attribute.LocalName,
+                        attribute.NamespaceUri,
+                        newDxfId.ToString(CultureInfo.InvariantCulture)));
+                }
+            }
         }
 
         private static Dictionary<uint, uint> AppendNumberingFormats(Stylesheet sourceStylesheet, Stylesheet targetStylesheet) {

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
@@ -1,8 +1,10 @@
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 
 namespace OfficeIMO.Excel {
     public partial class ExcelDocument {
@@ -24,7 +26,7 @@ namespace OfficeIMO.Excel {
                 }
             }
 
-            CopyWorksheetTables(sourceSheet.WorksheetPart, targetSheet.WorksheetPart);
+            CopyWorksheetTables(sourceSheet.WorksheetPart, targetSheet.WorksheetPart, rewriteCopiedTableReferences: true);
             targetSheet.WorksheetPart.Worksheet!.Save();
             return targetSheet;
         }
@@ -121,12 +123,15 @@ namespace OfficeIMO.Excel {
             Dictionary<uint, uint> styleFormatMap = AppendCellStyleFormats(sourceStylesheet.CellStyleFormats, targetStylesheet.CellStyleFormats!, numberingMap, fontMap, fillMap, borderMap);
             Dictionary<uint, uint> cellFormatMap = AppendCellFormats(sourceStylesheet.CellFormats, targetStylesheet.CellFormats!, numberingMap, fontMap, fillMap, borderMap, styleFormatMap);
             Dictionary<uint, uint> differentialFormatMap = AppendDifferentialFormats(sourceStylesheet.DifferentialFormats, targetStylesheet.DifferentialFormats!);
+            var inheritedStyleCells = BuildInheritedStyleCellSet(worksheet);
 
             foreach (Cell cell in worksheet.Descendants<Cell>()) {
                 uint? oldStyleIndex = cell.StyleIndex?.Value;
                 if (oldStyleIndex.HasValue && cellFormatMap.TryGetValue(oldStyleIndex.Value, out uint newStyleIndex)) {
                     cell.StyleIndex = newStyleIndex;
-                } else if (!oldStyleIndex.HasValue && cellFormatMap.TryGetValue(0U, out uint newDefaultStyleIndex)) {
+                } else if (!oldStyleIndex.HasValue
+                    && !CellHasInheritedRowOrColumnStyle(cell, inheritedStyleCells)
+                    && cellFormatMap.TryGetValue(0U, out uint newDefaultStyleIndex)) {
                     cell.StyleIndex = newDefaultStyleIndex;
                 }
             }
@@ -148,6 +153,46 @@ namespace OfficeIMO.Excel {
             EnsureStylesheetPrimitives(targetStylesheet);
             targetStylesheet.Save();
             return new WorksheetStyleCopyMap(cellFormatMap, differentialFormatMap);
+        }
+
+        private static HashSet<string> BuildInheritedStyleCellSet(Worksheet worksheet) {
+            string[] cells = worksheet.Descendants<Cell>()
+                .Select(cell => cell.CellReference?.Value)
+                .Where(reference => !string.IsNullOrEmpty(reference))
+                .Select(reference => reference!)
+                .ToArray();
+            if (cells.Length == 0) {
+                return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            var styledRows = new HashSet<int>(worksheet.Descendants<Row>()
+                .Where(row => row.StyleIndex != null && row.RowIndex != null)
+                .Select(row => (int)row.RowIndex!.Value));
+            var styledColumns = worksheet.Elements<Columns>()
+                .SelectMany(columns => columns.Elements<Column>())
+                .Where(column => column.Style != null)
+                .Select(column => (
+                    Min: (int)(column.Min?.Value ?? 1U),
+                    Max: (int)(column.Max?.Value ?? column.Min?.Value ?? 1U)))
+                .ToArray();
+            if (styledRows.Count == 0 && styledColumns.Length == 0) {
+                return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            var inherited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (string reference in cells) {
+                (int row, int column) = A1.ParseCellRef(reference);
+                if (styledRows.Contains(row) || styledColumns.Any(range => column >= range.Min && column <= range.Max)) {
+                    inherited.Add(reference);
+                }
+            }
+
+            return inherited;
+        }
+
+        private static bool CellHasInheritedRowOrColumnStyle(Cell cell, HashSet<string> inheritedStyleCells) {
+            string? reference = cell.CellReference?.Value;
+            return !string.IsNullOrEmpty(reference) && inheritedStyleCells.Contains(reference!);
         }
 
         private static void RemapCopiedWorksheetConditionalFormats(Worksheet worksheet, IReadOnlyDictionary<uint, uint> differentialFormatMap) {

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
@@ -57,6 +57,7 @@ namespace OfficeIMO.Excel {
                 ConvertCopiedWorksheetDateSerials(copiedPart.Worksheet, sourceDocument.DateSystem, DateSystem);
                 StripCopiedCellMetadataReferences(copiedPart.Worksheet);
                 RemoveRelationshipBackedWorksheetFeatures(copiedPart.Worksheet);
+                IReadOnlyDictionary<int, int> externalReferenceMap = CopyExternalWorkbookReferencesFromSource(sourceDocument);
                 IReadOnlyDictionary<string, string> tableNameMap = CopyWorksheetTables(sourcePart, copiedPart);
                 bool copiedFormulas = copiedPart.Worksheet.Descendants<CellFormula>()
                     .Any(formula => !string.IsNullOrWhiteSpace(formula.Text));
@@ -69,6 +70,10 @@ namespace OfficeIMO.Excel {
                 };
                 if (rewriteCopiedReferences) {
                     RewriteCopiedWorksheetReferences(copiedPart, sheetNameMap, tableNameMap);
+                }
+
+                if (externalReferenceMap.Count > 0) {
+                    RewriteCopiedWorksheetExternalReferences(copiedPart, externalReferenceMap);
                 }
 
                 if (copyReferencedDefinedNames) {
@@ -116,6 +121,51 @@ namespace OfficeIMO.Excel {
             }
         }
 
+        private IReadOnlyDictionary<int, int> CopyExternalWorkbookReferencesFromSource(ExcelDocument sourceDocument) {
+            if (ReferenceEquals(sourceDocument.WorkbookPartRoot, WorkbookPartRoot)) {
+                return new Dictionary<int, int>();
+            }
+
+            ExternalReferences? sourceReferences = sourceDocument.WorkbookPartRoot.Workbook?.ExternalReferences;
+            if (sourceReferences == null) {
+                return new Dictionary<int, int>();
+            }
+
+            ExternalReferences targetReferences = WorkbookRoot.ExternalReferences ??= new ExternalReferences();
+            int targetIndex = targetReferences.Elements<ExternalReference>().Count() + 1;
+            int sourceIndex = 1;
+            var referenceMap = new Dictionary<int, int>();
+
+            foreach (ExternalReference sourceReference in sourceReferences.Elements<ExternalReference>()) {
+                string? sourceRelationshipId = sourceReference.Id?.Value;
+                if (string.IsNullOrWhiteSpace(sourceRelationshipId)) {
+                    sourceIndex++;
+                    continue;
+                }
+
+                OpenXmlPart sourcePart;
+                try {
+                    sourcePart = sourceDocument.WorkbookPartRoot.GetPartById(sourceRelationshipId!);
+                } catch (ArgumentOutOfRangeException) {
+                    sourceIndex++;
+                    continue;
+                }
+
+                OpenXmlPart copiedPart = WorkbookPartRoot.AddPart(sourcePart);
+                string targetRelationshipId = WorkbookPartRoot.GetIdOfPart(copiedPart);
+                targetReferences.Append(new ExternalReference { Id = targetRelationshipId });
+                referenceMap[sourceIndex] = targetIndex;
+                targetIndex++;
+                sourceIndex++;
+            }
+
+            if (referenceMap.Count > 0) {
+                WorkbookRoot.Save();
+            }
+
+            return referenceMap;
+        }
+
         private void ConvertCopiedWorksheetDateSerials(Worksheet worksheet, ExcelDateSystem sourceDateSystem, ExcelDateSystem targetDateSystem) {
             if (sourceDateSystem == targetDateSystem || _spreadSheetDocument == null) {
                 return;
@@ -133,7 +183,7 @@ namespace OfficeIMO.Excel {
             (int Min, int Max, uint StyleIndex)[] columnStyleIndexes = BuildColumnStyleIndexRanges(worksheet);
 
             foreach (Cell cell in worksheet.Descendants<Cell>()) {
-                if (cell.CellFormula != null || !IsNumericDateCell(cell, styles, GetEffectiveStyleIndex(cell, rowStyleIndexes, columnStyleIndexes))) {
+                if (cell.CellFormula != null || !IsDateSystemShiftCell(cell, styles, GetEffectiveStyleIndex(cell, rowStyleIndexes, columnStyleIndexes))) {
                     continue;
                 }
 
@@ -193,8 +243,8 @@ namespace OfficeIMO.Excel {
             return null;
         }
 
-        private static bool IsNumericDateCell(Cell cell, StylesCache styles, uint? styleIndex) {
-            if (!styleIndex.HasValue || !styles.IsDateLike(styleIndex.Value)) {
+        private static bool IsDateSystemShiftCell(Cell cell, StylesCache styles, uint? styleIndex) {
+            if (!styleIndex.HasValue || !styles.IsDateSystemShiftStyle(styleIndex.Value)) {
                 return false;
             }
 

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
@@ -43,6 +43,7 @@ namespace OfficeIMO.Excel {
             SheetNameValidationMode validationMode,
             bool rewriteCopiedReferences,
             bool copyReferencedDefinedNames) {
+            MaterializeDeferredDataSetImport();
             sourceDocument.MaterializeDeferredDataSetImport();
             ExcelSheet sourceSheet = sourceDocument.GetSheet(sourceSheetName);
 
@@ -87,7 +88,7 @@ namespace OfficeIMO.Excel {
                     MarkPackageDirty();
                 }
                 WorkbookRoot.Save();
-                return new WorksheetPackageCopyResult(targetSheet, tableNameMap);
+                return new WorksheetPackageCopyResult(targetSheet, tableNameMap, externalReferenceMap);
             });
         }
 
@@ -565,14 +566,20 @@ namespace OfficeIMO.Excel {
         }
 
         private sealed class WorksheetPackageCopyResult {
-            internal WorksheetPackageCopyResult(ExcelSheet sheet, IReadOnlyDictionary<string, string> tableNameMap) {
+            internal WorksheetPackageCopyResult(
+                ExcelSheet sheet,
+                IReadOnlyDictionary<string, string> tableNameMap,
+                IReadOnlyDictionary<int, int>? externalReferenceMap = null) {
                 Sheet = sheet;
                 TableNameMap = tableNameMap;
+                ExternalReferenceMap = externalReferenceMap ?? new Dictionary<int, int>();
             }
 
             internal ExcelSheet Sheet { get; }
 
             internal IReadOnlyDictionary<string, string> TableNameMap { get; }
+
+            internal IReadOnlyDictionary<int, int> ExternalReferenceMap { get; }
         }
 
         private sealed class WorkbookStyleColorResolver {

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
@@ -54,6 +54,8 @@ namespace OfficeIMO.Excel {
                 RewriteSharedStringCellsToInlineStrings(copiedPart.Worksheet, sourceDocument.WorkbookPartRoot.SharedStringTablePart);
                 WorksheetStyleCopyMap styleMap = RemapCopiedWorksheetStyles(sourceDocument.WorkbookPartRoot, WorkbookPartRoot, copiedPart.Worksheet);
                 RemapCopiedWorksheetConditionalFormats(copiedPart.Worksheet, styleMap.DifferentialFormats);
+                ConvertCopiedWorksheetDateSerials(copiedPart.Worksheet, sourceDocument.DateSystem, DateSystem);
+                StripCopiedCellMetadataReferences(copiedPart.Worksheet);
                 RemoveRelationshipBackedWorksheetFeatures(copiedPart.Worksheet);
                 IReadOnlyDictionary<string, string> tableNameMap = CopyWorksheetTables(sourcePart, copiedPart);
                 bool copiedFormulas = copiedPart.Worksheet.Descendants<CellFormula>()
@@ -111,6 +113,41 @@ namespace OfficeIMO.Excel {
                 cell.CellValue = null;
                 cell.InlineString = inline;
                 cell.DataType = CellValues.InlineString;
+            }
+        }
+
+        private void ConvertCopiedWorksheetDateSerials(Worksheet worksheet, ExcelDateSystem sourceDateSystem, ExcelDateSystem targetDateSystem) {
+            if (sourceDateSystem == targetDateSystem || _spreadSheetDocument == null) {
+                return;
+            }
+
+            StylesCache styles = StylesCache.Build(_spreadSheetDocument);
+            if (!styles.HasDateStyles) {
+                return;
+            }
+
+            double offset = targetDateSystem == ExcelDateSystem.NineteenFour
+                ? -ExcelDateSystemConverter.Date1904OffsetDays
+                : ExcelDateSystemConverter.Date1904OffsetDays;
+
+            foreach (Cell cell in worksheet.Descendants<Cell>()) {
+                if (cell.CellFormula != null || !IsNumericDateCell(cell, styles)) {
+                    continue;
+                }
+
+                string? text = cell.CellValue?.Text;
+                if (!double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out double serial)) {
+                    continue;
+                }
+
+                cell.CellValue = new CellValue((serial + offset).ToString(CultureInfo.InvariantCulture));
+            }
+        }
+
+        private static void StripCopiedCellMetadataReferences(Worksheet worksheet) {
+            foreach (Cell cell in worksheet.Descendants<Cell>()) {
+                cell.RemoveAttribute("cm", string.Empty);
+                cell.RemoveAttribute("vm", string.Empty);
             }
         }
 

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
@@ -1,0 +1,252 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using System.Globalization;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelDocument {
+        private ExcelSheet CopyWorkSheetFromValues(ExcelDocument sourceDocument, string sourceSheetName, string newSheetName, SheetNameValidationMode validationMode) {
+            ExcelSheet sourceSheet = sourceDocument.GetSheet(sourceSheetName);
+            string usedRange = sourceSheet.GetUsedRangeA1();
+            var (startRow, startColumn, _, _) = A1.ParseRange(usedRange);
+            object?[,] values;
+            using (var reader = sourceDocument.CreateReader()) {
+                values = reader.GetSheet(sourceSheet.Name).ReadRange(usedRange);
+            }
+
+            ExcelSheet targetSheet = AddWorkSheet(newSheetName, validationMode);
+            for (int rowOffset = 0; rowOffset < values.GetLength(0); rowOffset++) {
+                for (int columnOffset = 0; columnOffset < values.GetLength(1); columnOffset++) {
+                    object? value = values[rowOffset, columnOffset];
+                    if (value == null) continue;
+                    targetSheet.CellValue(startRow + rowOffset, startColumn + columnOffset, value);
+                }
+            }
+
+            CopyWorksheetTables(sourceSheet.WorksheetPart, targetSheet.WorksheetPart);
+            targetSheet.WorksheetPart.Worksheet!.Save();
+            return targetSheet;
+        }
+
+        private ExcelSheet CopyWorkSheetFromPackage(ExcelDocument sourceDocument, string sourceSheetName, string newSheetName, SheetNameValidationMode validationMode) {
+            ExcelSheet sourceSheet = sourceDocument.GetSheet(sourceSheetName);
+
+            return Locking.ExecuteWrite(EnsureLock(), () => {
+                string validatedName = ValidateOrSanitizeSheetName(newSheetName, validationMode, currentSheetName: null);
+                WorksheetPart sourcePart = sourceSheet.WorksheetPart;
+                WorksheetPart copiedPart = WorkbookPartRoot.AddNewPart<WorksheetPart>();
+                copiedPart.Worksheet = (Worksheet)sourcePart.Worksheet!.CloneNode(true);
+                RewriteSharedStringCellsToInlineStrings(copiedPart.Worksheet, sourceDocument.WorkbookPartRoot.SharedStringTablePart);
+                RemapCopiedWorksheetStyles(sourceDocument.WorkbookPartRoot.WorkbookStylesPart?.Stylesheet, WorkbookPartRoot, copiedPart.Worksheet);
+                RemoveRelationshipBackedWorksheetFeatures(copiedPart.Worksheet);
+                CopyWorksheetTables(sourcePart, copiedPart);
+                copiedPart.Worksheet.Save();
+
+                Sheet sheet = AppendWorksheetElement(copiedPart, validatedName);
+                MarkSheetCacheDirty();
+                WorkbookRoot.Save();
+                return new ExcelSheet(this, _spreadSheetDocument, sheet);
+            });
+        }
+
+        private static void RewriteSharedStringCellsToInlineStrings(Worksheet worksheet, SharedStringTablePart? sharedStringTablePart) {
+            SharedStringTable? table = sharedStringTablePart?.SharedStringTable;
+            if (table == null) {
+                return;
+            }
+
+            var sharedItems = table.Elements<SharedStringItem>().ToList();
+            foreach (Cell cell in worksheet.Descendants<Cell>()) {
+                if (cell.DataType?.Value != CellValues.SharedString || cell.CellValue?.Text == null) {
+                    continue;
+                }
+
+                if (!int.TryParse(cell.CellValue.Text, NumberStyles.Integer, CultureInfo.InvariantCulture, out int index) ||
+                    index < 0 ||
+                    index >= sharedItems.Count) {
+                    continue;
+                }
+
+                SharedStringItem item = sharedItems[index];
+                var inline = new InlineString();
+                foreach (OpenXmlElement child in item.ChildElements) {
+                    inline.Append(child.CloneNode(true));
+                }
+
+                cell.CellValue = null;
+                cell.InlineString = inline;
+                cell.DataType = CellValues.InlineString;
+            }
+        }
+
+        private static void RemapCopiedWorksheetStyles(Stylesheet? sourceStylesheet, WorkbookPart targetWorkbookPart, Worksheet worksheet) {
+            if (sourceStylesheet?.CellFormats == null) {
+                return;
+            }
+
+            WorkbookStylesPart targetStylesPart = targetWorkbookPart.WorkbookStylesPart ?? targetWorkbookPart.AddNewPart<WorkbookStylesPart>();
+            Stylesheet targetStylesheet = targetStylesPart.Stylesheet ??= CreateDefaultStylesheet();
+            EnsureStylesheetPrimitives(targetStylesheet);
+
+            Dictionary<uint, uint> numberingMap = AppendNumberingFormats(sourceStylesheet, targetStylesheet);
+            Dictionary<uint, uint> fontMap = AppendStyleElements<Fonts, Font>(sourceStylesheet.Fonts, targetStylesheet.Fonts!, (container, count) => container.Count = count);
+            Dictionary<uint, uint> fillMap = AppendStyleElements<Fills, Fill>(sourceStylesheet.Fills, targetStylesheet.Fills!, (container, count) => container.Count = count);
+            Dictionary<uint, uint> borderMap = AppendStyleElements<Borders, Border>(sourceStylesheet.Borders, targetStylesheet.Borders!, (container, count) => container.Count = count);
+            Dictionary<uint, uint> styleFormatMap = AppendCellStyleFormats(sourceStylesheet.CellStyleFormats, targetStylesheet.CellStyleFormats!, numberingMap, fontMap, fillMap, borderMap);
+            Dictionary<uint, uint> cellFormatMap = AppendCellFormats(sourceStylesheet.CellFormats, targetStylesheet.CellFormats!, numberingMap, fontMap, fillMap, borderMap, styleFormatMap);
+
+            foreach (Cell cell in worksheet.Descendants<Cell>()) {
+                uint? oldStyleIndex = cell.StyleIndex?.Value;
+                if (oldStyleIndex.HasValue && cellFormatMap.TryGetValue(oldStyleIndex.Value, out uint newStyleIndex)) {
+                    cell.StyleIndex = newStyleIndex;
+                }
+            }
+
+            EnsureStylesheetPrimitives(targetStylesheet);
+            targetStylesheet.Save();
+        }
+
+        private static Dictionary<uint, uint> AppendNumberingFormats(Stylesheet sourceStylesheet, Stylesheet targetStylesheet) {
+            var map = new Dictionary<uint, uint>();
+            if (sourceStylesheet.NumberingFormats == null) {
+                return map;
+            }
+
+            NumberingFormats targetFormats = targetStylesheet.NumberingFormats ?? InsertNumberingFormats(targetStylesheet);
+            uint nextCustomId = Math.Max(164U, targetFormats.Elements<NumberingFormat>()
+                .Select(format => format.NumberFormatId?.Value ?? 0U)
+                .DefaultIfEmpty(163U)
+                .Max() + 1U);
+
+            foreach (NumberingFormat sourceFormat in sourceStylesheet.NumberingFormats.Elements<NumberingFormat>()) {
+                uint oldId = sourceFormat.NumberFormatId?.Value ?? 0U;
+                if (oldId < 164U) {
+                    map[oldId] = oldId;
+                    continue;
+                }
+
+                string? sourceCode = sourceFormat.FormatCode?.Value;
+                NumberingFormat? existing = targetFormats.Elements<NumberingFormat>()
+                    .FirstOrDefault(format => string.Equals(format.FormatCode?.Value, sourceCode, StringComparison.Ordinal));
+                if (existing?.NumberFormatId?.Value is uint existingId) {
+                    map[oldId] = existingId;
+                    continue;
+                }
+
+                var copied = (NumberingFormat)sourceFormat.CloneNode(true);
+                copied.NumberFormatId = nextCustomId++;
+                targetFormats.Append(copied);
+                map[oldId] = copied.NumberFormatId!.Value;
+            }
+
+            targetFormats.Count = (uint)targetFormats.Elements<NumberingFormat>().Count();
+            return map;
+        }
+
+        private static NumberingFormats InsertNumberingFormats(Stylesheet stylesheet) {
+            var formats = new NumberingFormats();
+            if (stylesheet.Fonts != null) {
+                stylesheet.InsertBefore(formats, stylesheet.Fonts);
+            } else {
+                stylesheet.PrependChild(formats);
+            }
+
+            return formats;
+        }
+
+        private static Dictionary<uint, uint> AppendStyleElements<TContainer, TElement>(TContainer? source, TContainer target, Action<TContainer, uint> setCount)
+            where TContainer : OpenXmlCompositeElement
+            where TElement : OpenXmlElement {
+            var map = new Dictionary<uint, uint>();
+            uint offset = (uint)target.Elements<TElement>().Count();
+            if (source == null) {
+                return map;
+            }
+
+            uint index = 0;
+            foreach (TElement element in source.Elements<TElement>()) {
+                uint newIndex = offset + index;
+                target.Append(element.CloneNode(true));
+                map[index] = newIndex;
+                index++;
+            }
+
+            setCount(target, (uint)target.Elements<TElement>().Count());
+            return map;
+        }
+
+        private static Dictionary<uint, uint> AppendCellFormats(
+            CellFormats? source,
+            CellFormats target,
+            IReadOnlyDictionary<uint, uint> numberingMap,
+            IReadOnlyDictionary<uint, uint> fontMap,
+            IReadOnlyDictionary<uint, uint> fillMap,
+            IReadOnlyDictionary<uint, uint> borderMap,
+            IReadOnlyDictionary<uint, uint>? formatMap) {
+            var map = new Dictionary<uint, uint>();
+            if (source == null) {
+                return map;
+            }
+
+            uint offset = (uint)target.Elements<CellFormat>().Count();
+            uint index = 0;
+            foreach (CellFormat sourceFormat in source.Elements<CellFormat>()) {
+                uint newIndex = offset + index;
+                var copied = (CellFormat)sourceFormat.CloneNode(true);
+                copied.NumberFormatId = MapValue(copied.NumberFormatId?.Value, numberingMap);
+                copied.FontId = MapValue(copied.FontId?.Value, fontMap);
+                copied.FillId = MapValue(copied.FillId?.Value, fillMap);
+                copied.BorderId = MapValue(copied.BorderId?.Value, borderMap);
+                if (formatMap != null) {
+                    copied.FormatId = MapValue(copied.FormatId?.Value, formatMap);
+                }
+
+                target.Append(copied);
+                map[index] = newIndex;
+                index++;
+            }
+
+            target.Count = (uint)target.Elements<CellFormat>().Count();
+            return map;
+        }
+
+        private static Dictionary<uint, uint> AppendCellStyleFormats(
+            CellStyleFormats? source,
+            CellStyleFormats target,
+            IReadOnlyDictionary<uint, uint> numberingMap,
+            IReadOnlyDictionary<uint, uint> fontMap,
+            IReadOnlyDictionary<uint, uint> fillMap,
+            IReadOnlyDictionary<uint, uint> borderMap) {
+            var map = new Dictionary<uint, uint>();
+            if (source == null) {
+                return map;
+            }
+
+            uint offset = (uint)target.Elements<CellFormat>().Count();
+            uint index = 0;
+            foreach (CellFormat sourceFormat in source.Elements<CellFormat>()) {
+                uint newIndex = offset + index;
+                var copied = (CellFormat)sourceFormat.CloneNode(true);
+                copied.NumberFormatId = MapValue(copied.NumberFormatId?.Value, numberingMap);
+                copied.FontId = MapValue(copied.FontId?.Value, fontMap);
+                copied.FillId = MapValue(copied.FillId?.Value, fillMap);
+                copied.BorderId = MapValue(copied.BorderId?.Value, borderMap);
+
+                target.Append(copied);
+                map[index] = newIndex;
+                index++;
+            }
+
+            target.Count = (uint)target.Elements<CellFormat>().Count();
+            return map;
+        }
+
+        private static uint MapValue(uint? value, IReadOnlyDictionary<uint, uint> map) {
+            if (!value.HasValue) {
+                return 0U;
+            }
+
+            return map.TryGetValue(value.Value, out uint mapped) ? mapped : value.Value;
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
@@ -77,7 +77,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 if (copyReferencedDefinedNames) {
-                    CopyReferencedDefinedNamesFromSource(sourceDocument, targetSheet, sheetNameMap, tableNameMap);
+                    CopyReferencedDefinedNamesFromSource(sourceDocument, targetSheet, sheetNameMap, tableNameMap, externalReferenceMap);
                 }
 
                 copiedPart.Worksheet.Save();

--- a/OfficeIMO.Excel/ExcelNumberFormatClassifier.cs
+++ b/OfficeIMO.Excel/ExcelNumberFormatClassifier.cs
@@ -57,6 +57,59 @@ namespace OfficeIMO.Excel {
             return lower.Contains(':') || lower.Contains('/') || lower.Contains('-');
         }
 
+        internal static bool LooksLikeDateSystemFormat(string? code) {
+            if (string.IsNullOrWhiteSpace(code)) {
+                return false;
+            }
+
+            string normalized = StripLiteralsAndEscapes(code!);
+            if (string.IsNullOrWhiteSpace(normalized)) {
+                return false;
+            }
+
+            string lower = normalized.ToLowerInvariant();
+            bool hasDay = false;
+            bool hasYear = false;
+            bool hasHour = false;
+            bool hasSecond = false;
+            bool hasMonth = false;
+
+            foreach (char ch in lower) {
+                switch (ch) {
+                    case 'd':
+                        hasDay = true;
+                        break;
+                    case 'y':
+                        hasYear = true;
+                        break;
+                    case 'h':
+                        hasHour = true;
+                        break;
+                    case 's':
+                        hasSecond = true;
+                        break;
+                    case 'm':
+                        hasMonth = true;
+                        break;
+                }
+            }
+
+            if (hasDay || hasYear) {
+                return true;
+            }
+
+            if (hasHour || hasSecond || lower.IndexOf("am/pm", StringComparison.Ordinal) >= 0 || lower.IndexOf("a/p", StringComparison.Ordinal) >= 0) {
+                return false;
+            }
+
+            if (!hasMonth) {
+                return false;
+            }
+
+            string letterTokens = new string(lower.Where(char.IsLetter).ToArray());
+            return letterTokens.Length > 0 && letterTokens.All(ch => ch == 'm');
+        }
+
         private static string StripLiteralsAndEscapes(string code) {
             var builder = new System.Text.StringBuilder(code.Length);
 

--- a/OfficeIMO.Excel/ExcelNumberFormatClassifier.cs
+++ b/OfficeIMO.Excel/ExcelNumberFormatClassifier.cs
@@ -5,7 +5,7 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            string normalized = StripLiteralsAndEscapes(code!);
+            string normalized = StripLiteralsAndEscapes(code!, includeElapsedBracketTokens: true);
             if (string.IsNullOrWhiteSpace(normalized)) {
                 return false;
             }
@@ -62,7 +62,7 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            string normalized = StripLiteralsAndEscapes(code!);
+            string normalized = StripLiteralsAndEscapes(code!, includeElapsedBracketTokens: false);
             if (string.IsNullOrWhiteSpace(normalized)) {
                 return false;
             }
@@ -98,19 +98,20 @@ namespace OfficeIMO.Excel {
                 return true;
             }
 
-            if (hasHour || hasSecond || lower.IndexOf("am/pm", StringComparison.Ordinal) >= 0 || lower.IndexOf("a/p", StringComparison.Ordinal) >= 0) {
-                return false;
-            }
-
             if (!hasMonth) {
                 return false;
             }
 
-            string letterTokens = new string(lower.Where(char.IsLetter).ToArray());
-            return letterTokens.Length > 0 && letterTokens.All(ch => ch == 'm');
+            bool hasMeridiem = lower.IndexOf("am/pm", StringComparison.Ordinal) >= 0 || lower.IndexOf("a/p", StringComparison.Ordinal) >= 0;
+            if (!hasHour && !hasSecond && !hasMeridiem) {
+                string letterTokens = new string(lower.Where(char.IsLetter).ToArray());
+                return letterTokens.Length > 0 && letterTokens.All(ch => ch == 'm');
+            }
+
+            return ContainsMonthToken(lower);
         }
 
-        private static string StripLiteralsAndEscapes(string code) {
+        private static string StripLiteralsAndEscapes(string code, bool includeElapsedBracketTokens) {
             var builder = new System.Text.StringBuilder(code.Length);
 
             for (int i = 0; i < code.Length; i++) {
@@ -127,7 +128,7 @@ namespace OfficeIMO.Excel {
                         }
                         break;
                     case '[':
-                        i = ProcessBracketSection(code, i, builder);
+                        i = ProcessBracketSection(code, i, builder, includeElapsedBracketTokens);
                         break;
                     default:
                         builder.Append(ch);
@@ -150,18 +151,68 @@ namespace OfficeIMO.Excel {
             return code.Length - 1;
         }
 
-        private static int ProcessBracketSection(string code, int bracketStart, System.Text.StringBuilder builder) {
+        private static int ProcessBracketSection(string code, int bracketStart, System.Text.StringBuilder builder, bool includeElapsedBracketTokens) {
             int close = code.IndexOf(']', bracketStart + 1);
             if (close < 0) {
                 return code.Length - 1;
             }
 
             string token = code.Substring(bracketStart + 1, close - bracketStart - 1).Trim().ToLowerInvariant();
-            if (token.Length > 0 && token.All(ch => ch is 'h' or 'm' or 's')) {
+            if (includeElapsedBracketTokens && token.Length > 0 && token.All(ch => ch is 'h' or 'm' or 's')) {
                 builder.Append(token);
             }
 
             return close;
+        }
+
+        private static bool ContainsMonthToken(string format) {
+            for (int index = 0; index < format.Length; index++) {
+                if (format[index] != 'm') {
+                    continue;
+                }
+
+                int start = index;
+                while (index + 1 < format.Length && format[index + 1] == 'm') {
+                    index++;
+                }
+
+                int end = index;
+                if (!IsMinuteToken(format, start, end)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsMinuteToken(string format, int start, int end) {
+            return IsAdjacentTimeToken(format, end + 1, searchForward: true)
+                || IsAdjacentTimeToken(format, start - 1, searchForward: false);
+        }
+
+        private static bool IsAdjacentTimeToken(string format, int index, bool searchForward) {
+            bool sawColon = false;
+            while (index >= 0 && index < format.Length) {
+                char ch = format[index];
+                if (ch == ':') {
+                    sawColon = true;
+                    index += searchForward ? 1 : -1;
+                    continue;
+                }
+
+                if (char.IsWhiteSpace(ch)) {
+                    return false;
+                }
+
+                if (!char.IsLetter(ch)) {
+                    index += searchForward ? 1 : -1;
+                    continue;
+                }
+
+                return sawColon && (ch == 'h' || ch == 's');
+            }
+
+            return false;
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelSheet.ColumnFormatPlan.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ColumnFormatPlan.cs
@@ -105,14 +105,26 @@ namespace OfficeIMO.Excel {
             }
 
             var headerValues = new string?[columnCount];
+            bool hasExplicitHeader = false;
             for (int offset = 0; offset < columnCount; offset++) {
                 headerValues[offset] = TryGetCellText(headerRow, firstColumn + offset, out string text) ? text : null;
+                if (!string.IsNullOrWhiteSpace(headerValues[offset])) {
+                    hasExplicitHeader = true;
+                }
+            }
+
+            if (!hasExplicitHeader) {
+                return false;
             }
 
             bool normalizeHeaders = options?.NormalizeHeaders ?? true;
             var headers = ExcelHeaderNameHelper.BuildUniqueHeaders(columnCount, c => headerValues[c], normalizeHeaders);
             string normalizedHeader = ExcelHeaderNameHelper.NormalizeHeader(header, normalizeHeaders);
             for (int offset = 0; offset < headers.Length; offset++) {
+                if (string.IsNullOrWhiteSpace(headerValues[offset])) {
+                    continue;
+                }
+
                 if (string.Equals(headers[offset], normalizedHeader, StringComparison.OrdinalIgnoreCase)) {
                     columnIndex = firstColumn + offset;
                     return true;

--- a/OfficeIMO.Excel/ExcelSheet.ColumnFormatPlan.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ColumnFormatPlan.cs
@@ -69,12 +69,18 @@ namespace OfficeIMO.Excel {
             out int columnIndex,
             out bool directCandidateMatched,
             out bool directCandidateAvailable) {
+            columnIndex = 0;
             directCandidateMatched = false;
             directCandidateAvailable = false;
 
             bool allowDirectCandidateLookup = !headerRow.HasValue || headerRow.Value == 1;
             if (allowDirectCandidateLookup
                 && Document.TryGetDirectTabularSaveCandidateColumnByHeader(this, rule.Header, includeHeader, options, out columnIndex, out _, out _, out directCandidateAvailable)) {
+                directCandidateMatched = true;
+                return true;
+            }
+
+            if (allowDirectCandidateLookup && directCandidateAvailable && columnIndex > 0) {
                 directCandidateMatched = true;
                 return true;
             }

--- a/OfficeIMO.Excel/ExcelSheet.ColumnFormatPlan.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ColumnFormatPlan.cs
@@ -33,7 +33,12 @@ namespace OfficeIMO.Excel {
                 }
 
                 if (directCandidateMatched && !ruleIncludeHeader) {
-                    if (!Document.TrySetDirectTabularSaveCandidateColumnNumberFormat(this, columnIndex, numberFormat)) {
+                    bool updateMaterializedWorksheet = Document.HasMaterializedDirectTabularFastSaveWorksheet(this);
+                    if (Document.TrySetDirectTabularSaveCandidateColumnNumberFormat(this, columnIndex, numberFormat)) {
+                        if (updateMaterializedWorksheet) {
+                            ApplyColumnNumberFormat(columnIndex, headerRow, ruleIncludeHeader, numberFormat);
+                        }
+                    } else {
                         ApplyColumnNumberFormat(columnIndex, headerRow, ruleIncludeHeader, numberFormat);
                     }
                 } else if (directCandidateMatched) {
@@ -43,10 +48,6 @@ namespace OfficeIMO.Excel {
                 }
 
                 if (autoFit || rule.AutoFit) {
-                    if (directCandidateAvailable) {
-                        MaterializeDeferredDataSetImportIfNeeded();
-                    }
-
                     AutoFitColumn(columnIndex);
                 }
 
@@ -83,11 +84,6 @@ namespace OfficeIMO.Excel {
             if (allowDirectCandidateLookup && directCandidateAvailable && columnIndex > 0) {
                 directCandidateMatched = true;
                 return true;
-            }
-
-            if (allowDirectCandidateLookup && directCandidateAvailable) {
-                columnIndex = 0;
-                return false;
             }
 
             return headerRow.HasValue

--- a/OfficeIMO.Excel/ExcelSheet.ColumnFormatPlan.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ColumnFormatPlan.cs
@@ -6,19 +6,23 @@ namespace OfficeIMO.Excel {
         /// <param name="plan">Column format plan to apply.</param>
         /// <param name="includeHeader">True to include header cells in every rule unless a rule already includes them.</param>
         /// <param name="autoFit">True to auto-fit every resolved formatted column.</param>
+        /// <param name="headerRow">Optional one-based row containing the headers used to resolve column names.</param>
         /// <param name="options">Read options used while resolving headers.</param>
         /// <returns>One result per configured rule.</returns>
         public IReadOnlyList<ExcelColumnFormatResult> ApplyColumnFormatPlan(
             ExcelColumnFormatPlan plan,
             bool includeHeader = false,
             bool autoFit = false,
+            int? headerRow = null,
             ExcelReadOptions? options = null) {
             if (plan == null) throw new ArgumentNullException(nameof(plan));
+            if (headerRow.HasValue && headerRow.Value <= 0) throw new ArgumentOutOfRangeException(nameof(headerRow), "Header row must be 1 or greater.");
 
             var results = new List<ExcelColumnFormatResult>(plan.Rules.Count);
             foreach (ExcelColumnFormatRule rule in plan.Rules) {
                 string numberFormat = rule.ResolveNumberFormat();
-                if (!TryGetColumnIndexByHeader(rule.Header, out int columnIndex, options)) {
+                bool ruleIncludeHeader = includeHeader || rule.IncludeHeader;
+                if (!TryResolveColumnFormatRule(rule, ruleIncludeHeader, headerRow, options, out int columnIndex, out bool directCandidateMatched, out bool directCandidateAvailable)) {
                     results.Add(new ExcelColumnFormatResult(
                         rule.Header,
                         columnIndex: null,
@@ -28,8 +32,21 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                ColumnStyleByHeader(rule.Header, includeHeader || rule.IncludeHeader, options).NumberFormat(numberFormat);
+                if (directCandidateMatched && !ruleIncludeHeader) {
+                    if (!Document.TrySetDirectTabularSaveCandidateColumnNumberFormat(this, columnIndex, numberFormat)) {
+                        ApplyColumnNumberFormat(columnIndex, headerRow, ruleIncludeHeader, numberFormat);
+                    }
+                } else if (directCandidateMatched) {
+                    ColumnStyleByHeader(rule.Header, ruleIncludeHeader, options).NumberFormat(numberFormat);
+                } else {
+                    ApplyColumnNumberFormat(columnIndex, headerRow, ruleIncludeHeader, numberFormat);
+                }
+
                 if (autoFit || rule.AutoFit) {
+                    if (directCandidateAvailable) {
+                        MaterializeDeferredDataSetImportIfNeeded();
+                    }
+
                     AutoFitColumn(columnIndex);
                 }
 
@@ -42,6 +59,82 @@ namespace OfficeIMO.Excel {
             }
 
             return results;
+        }
+
+        private bool TryResolveColumnFormatRule(
+            ExcelColumnFormatRule rule,
+            bool includeHeader,
+            int? headerRow,
+            ExcelReadOptions? options,
+            out int columnIndex,
+            out bool directCandidateMatched,
+            out bool directCandidateAvailable) {
+            directCandidateMatched = false;
+            directCandidateAvailable = false;
+
+            bool allowDirectCandidateLookup = !headerRow.HasValue || headerRow.Value == 1;
+            if (allowDirectCandidateLookup
+                && Document.TryGetDirectTabularSaveCandidateColumnByHeader(this, rule.Header, includeHeader, options, out columnIndex, out _, out _, out directCandidateAvailable)) {
+                directCandidateMatched = true;
+                return true;
+            }
+
+            if (allowDirectCandidateLookup && directCandidateAvailable) {
+                columnIndex = 0;
+                return false;
+            }
+
+            return headerRow.HasValue
+                ? TryGetColumnIndexByHeaderRow(rule.Header, headerRow.Value, out columnIndex, options)
+                : TryGetColumnIndexByHeader(rule.Header, out columnIndex, options);
+        }
+
+        private bool TryGetColumnIndexByHeaderRow(string header, int headerRow, out int columnIndex, ExcelReadOptions? options) {
+            columnIndex = 0;
+            if (string.IsNullOrWhiteSpace(header)) {
+                return false;
+            }
+
+            string usedRange = GetUsedRangeA1();
+            var (_, firstColumn, _, lastColumn) = A1.ParseRange(usedRange);
+            int columnCount = lastColumn - firstColumn + 1;
+            if (columnCount <= 0) {
+                return false;
+            }
+
+            var headerValues = new string?[columnCount];
+            for (int offset = 0; offset < columnCount; offset++) {
+                headerValues[offset] = TryGetCellText(headerRow, firstColumn + offset, out string text) ? text : null;
+            }
+
+            bool normalizeHeaders = options?.NormalizeHeaders ?? true;
+            var headers = ExcelHeaderNameHelper.BuildUniqueHeaders(columnCount, c => headerValues[c], normalizeHeaders);
+            string normalizedHeader = ExcelHeaderNameHelper.NormalizeHeader(header, normalizeHeaders);
+            for (int offset = 0; offset < headers.Length; offset++) {
+                if (string.Equals(headers[offset], normalizedHeader, StringComparison.OrdinalIgnoreCase)) {
+                    columnIndex = firstColumn + offset;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private void ApplyColumnNumberFormat(int columnIndex, int? headerRow, bool includeHeader, string numberFormat) {
+            string usedRange = GetUsedRangeA1();
+            var (usedStartRow, _, usedEndRow, _) = A1.ParseRange(usedRange);
+            int startRow = headerRow.HasValue
+                ? (includeHeader ? headerRow.Value : headerRow.Value + 1)
+                : (includeHeader ? usedStartRow : usedStartRow + 1);
+            if (startRow > usedEndRow) {
+                return;
+            }
+
+            string column = A1.ColumnIndexToLetters(columnIndex);
+            FormatRange(
+                column + startRow.ToString(System.Globalization.CultureInfo.InvariantCulture) + ":" +
+                column + usedEndRow.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                numberFormat);
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelSheet.ColumnFormatPlan.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ColumnFormatPlan.cs
@@ -1,0 +1,47 @@
+namespace OfficeIMO.Excel {
+    public partial class ExcelSheet {
+        /// <summary>
+        /// Applies reusable header-based column number formats to the worksheet.
+        /// </summary>
+        /// <param name="plan">Column format plan to apply.</param>
+        /// <param name="includeHeader">True to include header cells in every rule unless a rule already includes them.</param>
+        /// <param name="autoFit">True to auto-fit every resolved formatted column.</param>
+        /// <param name="options">Read options used while resolving headers.</param>
+        /// <returns>One result per configured rule.</returns>
+        public IReadOnlyList<ExcelColumnFormatResult> ApplyColumnFormatPlan(
+            ExcelColumnFormatPlan plan,
+            bool includeHeader = false,
+            bool autoFit = false,
+            ExcelReadOptions? options = null) {
+            if (plan == null) throw new ArgumentNullException(nameof(plan));
+
+            var results = new List<ExcelColumnFormatResult>(plan.Rules.Count);
+            foreach (ExcelColumnFormatRule rule in plan.Rules) {
+                string numberFormat = rule.ResolveNumberFormat();
+                if (!TryGetColumnIndexByHeader(rule.Header, out int columnIndex, options)) {
+                    results.Add(new ExcelColumnFormatResult(
+                        rule.Header,
+                        columnIndex: null,
+                        applied: false,
+                        numberFormat,
+                        warning: $"Header '{rule.Header}' was not found on worksheet '{Name}'."));
+                    continue;
+                }
+
+                ColumnStyleByHeader(rule.Header, includeHeader || rule.IncludeHeader, options).NumberFormat(numberFormat);
+                if (autoFit || rule.AutoFit) {
+                    AutoFitColumn(columnIndex);
+                }
+
+                results.Add(new ExcelColumnFormatResult(
+                    rule.Header,
+                    columnIndex,
+                    applied: true,
+                    numberFormat,
+                    warning: null));
+            }
+
+            return results;
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.Headers.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Headers.cs
@@ -460,7 +460,8 @@ namespace OfficeIMO.Excel {
 
             var opt = options ?? DefaultHeaderReadOptions;
             var map = GetHeaderMapCached(opt);
-            return map.TryGetValue(header, out columnIndex);
+            string normalizedHeader = ExcelHeaderNameHelper.NormalizeHeader(header, opt.NormalizeHeaders);
+            return map.TryGetValue(normalizedHeader, out columnIndex);
         }
 
         /// <summary>

--- a/OfficeIMO.Excel/ExcelWorkbookMergeOptions.cs
+++ b/OfficeIMO.Excel/ExcelWorkbookMergeOptions.cs
@@ -19,5 +19,10 @@ namespace OfficeIMO.Excel {
         /// Gets or sets sheet name validation behavior for imported worksheets.
         /// </summary>
         public SheetNameValidationMode SheetNameValidationMode { get; set; } = SheetNameValidationMode.Sanitize;
+
+        /// <summary>
+        /// Gets or sets the worksheet copy strategy used for imported sheets.
+        /// </summary>
+        public ExcelWorksheetCopyMode CopyMode { get; set; } = ExcelWorksheetCopyMode.Package;
     }
 }

--- a/OfficeIMO.Excel/ExcelWorksheetCopyMode.cs
+++ b/OfficeIMO.Excel/ExcelWorksheetCopyMode.cs
@@ -1,0 +1,16 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Controls how worksheets are copied between workbooks.
+    /// </summary>
+    public enum ExcelWorksheetCopyMode {
+        /// <summary>
+        /// Copy cell values through the workbook reader and writer surface.
+        /// </summary>
+        Values = 0,
+
+        /// <summary>
+        /// Copy worksheet XML directly, rewriting workbook-scoped references such as shared strings and styles.
+        /// </summary>
+        Package = 1
+    }
+}

--- a/OfficeIMO.Excel/ExcelWorksheetCopyOptions.cs
+++ b/OfficeIMO.Excel/ExcelWorksheetCopyOptions.cs
@@ -1,0 +1,11 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Options for copying worksheets between workbooks.
+    /// </summary>
+    public sealed class ExcelWorksheetCopyOptions {
+        /// <summary>
+        /// Gets or sets the copy strategy. Package copy preserves worksheet XML and avoids object materialization.
+        /// </summary>
+        public ExcelWorksheetCopyMode CopyMode { get; set; } = ExcelWorksheetCopyMode.Package;
+    }
+}

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.XmlValues.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.XmlValues.cs
@@ -606,7 +606,7 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                string text = inlineReader.ReadElementContentAsString();
+                string text = ReadXmlTextElement(inlineReader);
                 if (builder != null) {
                     builder.Append(text);
                 } else if (first == null) {
@@ -619,6 +619,25 @@ namespace OfficeIMO.Excel {
             }
 
             return builder?.ToString() ?? first ?? string.Empty;
+        }
+
+        private static string ReadXmlTextElement(XmlReader textReader) {
+            if (textReader.IsEmptyElement) {
+                return string.Empty;
+            }
+
+            int depth = textReader.Depth;
+            if (!textReader.Read()) {
+                return string.Empty;
+            }
+
+            string text = textReader.NodeType == XmlNodeType.Text
+                || textReader.NodeType == XmlNodeType.SignificantWhitespace
+                || textReader.NodeType == XmlNodeType.Whitespace
+                    ? textReader.Value
+                    : string.Empty;
+            SkipXmlElementContent(textReader, depth, "t");
+            return text;
         }
 
         private static int ParsePositiveIntAttribute(string? value) {

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.XmlValues.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.XmlValues.cs
@@ -627,17 +627,37 @@ namespace OfficeIMO.Excel {
             }
 
             int depth = textReader.Depth;
-            if (!textReader.Read()) {
-                return string.Empty;
+            string? first = null;
+            System.Text.StringBuilder? builder = null;
+            while (textReader.Read()) {
+                if (textReader.NodeType == XmlNodeType.EndElement && textReader.Depth == depth && textReader.LocalName == "t") {
+                    break;
+                }
+
+                if (!IsXmlTextNode(textReader.NodeType)) {
+                    continue;
+                }
+
+                string text = textReader.Value;
+                if (builder != null) {
+                    builder.Append(text);
+                } else if (first == null) {
+                    first = text;
+                } else {
+                    builder = new System.Text.StringBuilder(first.Length + text.Length);
+                    builder.Append(first);
+                    builder.Append(text);
+                }
             }
 
-            string text = textReader.NodeType == XmlNodeType.Text
-                || textReader.NodeType == XmlNodeType.SignificantWhitespace
-                || textReader.NodeType == XmlNodeType.Whitespace
-                    ? textReader.Value
-                    : string.Empty;
-            SkipXmlElementContent(textReader, depth, "t");
-            return text;
+            return builder?.ToString() ?? first ?? string.Empty;
+        }
+
+        private static bool IsXmlTextNode(XmlNodeType nodeType) {
+            return nodeType == XmlNodeType.Text
+                || nodeType == XmlNodeType.CDATA
+                || nodeType == XmlNodeType.SignificantWhitespace
+                || nodeType == XmlNodeType.Whitespace;
         }
 
         private static int ParsePositiveIntAttribute(string? value) {

--- a/OfficeIMO.Excel/Read/Helpers/StylesCache.cs
+++ b/OfficeIMO.Excel/Read/Helpers/StylesCache.cs
@@ -32,6 +32,7 @@ namespace OfficeIMO.Excel {
         private static readonly bool[] EmptyDateStyleIndexes = Array.Empty<bool>();
         private static readonly XmlReaderSettings StylesXmlReaderSettings = CreateStylesXmlReaderSettings();
         private bool[] _dateStyleIndexes = EmptyDateStyleIndexes;
+        private bool[] _dateSystemShiftStyleIndexes = EmptyDateStyleIndexes;
 
         private StylesCache() { }
 
@@ -63,8 +64,8 @@ namespace OfficeIMO.Excel {
             if (xfs != null) {
                 int idx = 0;
                 foreach (var cf in xfs.Elements<CellFormat>()) {
-                    if (idx == cache._dateStyleIndexes.Length) {
-                        Array.Resize(ref cache._dateStyleIndexes, Math.Max(4, idx * 2));
+                    if (idx >= cache._dateStyleIndexes.Length) {
+                        Array.Resize(ref cache._dateStyleIndexes, Math.Max(4, (idx + 1) * 2));
                     }
 
                     var nId = (uint)(cf.NumberFormatId?.Value ?? 0);
@@ -74,13 +75,25 @@ namespace OfficeIMO.Excel {
                         cache.HasDateStyles = true;
                     }
 
+                    if (IsDateSystemShiftNumberFormat(nId, nf)) {
+                        if (idx >= cache._dateSystemShiftStyleIndexes.Length) {
+                            Array.Resize(ref cache._dateSystemShiftStyleIndexes, Math.Max(4, (idx + 1) * 2));
+                        }
+
+                        cache._dateSystemShiftStyleIndexes[idx] = true;
+                    }
+
                     idx++;
                 }
 
                 if (idx == 0) {
                     cache._dateStyleIndexes = EmptyDateStyleIndexes;
+                    cache._dateSystemShiftStyleIndexes = EmptyDateStyleIndexes;
                 } else if (idx < cache._dateStyleIndexes.Length) {
                     Array.Resize(ref cache._dateStyleIndexes, idx);
+                    if (idx < cache._dateSystemShiftStyleIndexes.Length) {
+                        Array.Resize(ref cache._dateSystemShiftStyleIndexes, idx);
+                    }
                 }
             }
 
@@ -88,6 +101,8 @@ namespace OfficeIMO.Excel {
         }
 
         public bool IsDateLike(uint styleIndex) => styleIndex < (uint)_dateStyleIndexes.Length && _dateStyleIndexes[styleIndex];
+
+        public bool IsDateSystemShiftStyle(uint styleIndex) => styleIndex < (uint)_dateSystemShiftStyleIndexes.Length && _dateSystemShiftStyleIndexes[styleIndex];
 
         private static bool TryBuildXmlFast(WorkbookStylesPart sp, StylesCache cache) {
             try {
@@ -157,7 +172,9 @@ namespace OfficeIMO.Excel {
                 }
 
                 if (index == cache._dateStyleIndexes.Length) {
-                    Array.Resize(ref cache._dateStyleIndexes, Math.Max(4, index * 2));
+                    int newSize = Math.Max(4, index * 2);
+                    Array.Resize(ref cache._dateStyleIndexes, newSize);
+                    Array.Resize(ref cache._dateSystemShiftStyleIndexes, newSize);
                 }
 
                 if (TryParseUIntAttribute(reader.GetAttribute("numFmtId"), out uint numberFormatId)
@@ -166,13 +183,22 @@ namespace OfficeIMO.Excel {
                     cache.HasDateStyles = true;
                 }
 
+                if (TryParseUIntAttribute(reader.GetAttribute("numFmtId"), out uint shiftNumberFormatId)
+                    && IsDateSystemShiftNumberFormat(shiftNumberFormatId, numberingFormats)) {
+                    cache._dateSystemShiftStyleIndexes[index] = true;
+                }
+
                 index++;
             }
 
             if (index == 0) {
                 cache._dateStyleIndexes = EmptyDateStyleIndexes;
+                cache._dateSystemShiftStyleIndexes = EmptyDateStyleIndexes;
             } else if (index < cache._dateStyleIndexes.Length) {
                 Array.Resize(ref cache._dateStyleIndexes, index);
+                if (index < cache._dateSystemShiftStyleIndexes.Length) {
+                    Array.Resize(ref cache._dateSystemShiftStyleIndexes, index);
+                }
             }
         }
 
@@ -183,9 +209,19 @@ namespace OfficeIMO.Excel {
                     && ExcelNumberFormatClassifier.LooksLikeDateFormat(code));
         }
 
+        private static bool IsDateSystemShiftNumberFormat(uint id, Dictionary<uint, string>? numberingFormats) {
+            return IsBuiltInDateSystemShiftFormat(id)
+                || (numberingFormats != null
+                    && numberingFormats.TryGetValue(id, out string? code)
+                    && ExcelNumberFormatClassifier.LooksLikeDateSystemFormat(code));
+        }
+
         private static bool IsBuiltInDate(uint id)
             => id is 14 or 15 or 16 or 17 or 18 or 19 or 20 or 21 or 22
                 or 27 or 30 or 36 or 45 or 46 or 47;
+
+        private static bool IsBuiltInDateSystemShiftFormat(uint id)
+            => id is 14 or 15 or 16 or 17 or 22 or 27 or 30 or 36;
 
         private static XmlReaderSettings CreateStylesXmlReaderSettings() {
             return new XmlReaderSettings {

--- a/OfficeIMO.Tests/Excel.BestOfBar.cs
+++ b/OfficeIMO.Tests/Excel.BestOfBar.cs
@@ -202,5 +202,48 @@ namespace OfficeIMO.Tests {
             Assert.Contains(nameof(ExcelNumberPreset.Currency), ExcelNumberFormats.GetPresetNames());
             Assert.Equal("0.00%", ExcelNumberFormats.Get(ExcelNumberPreset.Percent, decimals: 2));
         }
+
+        [Fact]
+        public void Test_ExcelBestOfBar_ColumnFormatPlan_AppliesHeaderFormats() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelBestOfBar.ColumnFormatPlan.xlsx");
+
+            var table = new DataTable("Sales");
+            table.Columns.Add("Id", typeof(string));
+            table.Columns.Add("Revenue", typeof(decimal));
+            table.Columns.Add("Rate", typeof(decimal));
+            table.Columns.Add("Created", typeof(DateTime));
+            table.Rows.Add("00042", 1234.5M, 0.125M, new DateTime(2026, 6, 23));
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.InsertDataTableAsTable(table, 1, 1, includeHeaders: true, tableName: "Sales", style: ExcelTableStyle.TableStyleMedium2);
+
+                var plan = new ExcelColumnFormatPlan()
+                    .Text("Id")
+                    .Currency(0, System.Globalization.CultureInfo.GetCultureInfo("en-US"), "Revenue")
+                    .Add("Rate", ExcelNumberPreset.Percent, decimals: 1)
+                    .Add("Created", ExcelNumberPreset.DateShort);
+
+                IReadOnlyList<ExcelColumnFormatResult> results = sheet.ApplyColumnFormatPlan(plan, autoFit: true);
+                IReadOnlyList<ExcelColumnFormatResult> missing = sheet.ApplyColumnFormatPlan(
+                    new ExcelColumnFormatPlan().Add("Missing", ExcelNumberPreset.Integer));
+
+                Assert.All(results, result => Assert.True(result.Applied));
+                Assert.Equal(new[] { 1, 2, 3, 4 }, results.Select(result => result.ColumnIndex!.Value).ToArray());
+                Assert.Single(missing);
+                Assert.False(missing[0].Applied);
+                Assert.Contains("Missing", missing[0].Warning);
+                document.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            var cells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>()
+                .ToDictionary(cell => cell.CellReference!.Value!);
+
+            Assert.Equal("@", GetCellNumberFormatCode(spreadsheet, cells["A2"]));
+            Assert.Contains("$", GetCellNumberFormatCode(spreadsheet, cells["B2"]) ?? string.Empty);
+            Assert.Equal("0.0%", GetCellNumberFormatCode(spreadsheet, cells["C2"]));
+            Assert.Equal("yyyy-mm-dd", GetCellNumberFormatCode(spreadsheet, cells["D2"]));
+        }
     }
 }

--- a/OfficeIMO.Tests/Excel.BestOfBar.cs
+++ b/OfficeIMO.Tests/Excel.BestOfBar.cs
@@ -287,6 +287,25 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ExcelBestOfBar_ColumnFormatPlan_RejectsBlankExplicitHeaderRows() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelBestOfBar.ColumnFormatPlan.BlankExplicitHeader.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(3, 1, 42);
+
+                IReadOnlyList<ExcelColumnFormatResult> results = sheet.ApplyColumnFormatPlan(
+                    new ExcelColumnFormatPlan().Add("Column1", ExcelNumberPreset.Integer),
+                    headerRow: 2);
+
+                Assert.Single(results);
+                Assert.False(results[0].Applied);
+                Assert.Null(results[0].ColumnIndex);
+                document.Save();
+            }
+        }
+
+        [Fact]
         public void Test_ExcelBestOfBar_ColumnFormatPlan_NormalizesDefaultHeaderLookup() {
             string filePath = Path.Combine(_directoryWithFiles, "ExcelBestOfBar.ColumnFormatPlan.DefaultHeaderLookup.xlsx");
 

--- a/OfficeIMO.Tests/Excel.BestOfBar.cs
+++ b/OfficeIMO.Tests/Excel.BestOfBar.cs
@@ -338,5 +338,97 @@ namespace OfficeIMO.Tests {
             Assert.Contains("A1", cells.Keys);
             Assert.DoesNotContain("A2", cells.Keys);
         }
+
+        [Fact]
+        public void Test_ExcelBestOfBar_ColumnFormatPlan_FormatsPreservedOverlayHeaders() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelBestOfBar.ColumnFormatPlan.OverlayHeader.xlsx");
+
+            var table = new DataTable("Rows");
+            table.Columns.Add("Name", typeof(string));
+            table.Rows.Add("Alpha");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.InsertDataTableAsTable(table, 1, 1, includeHeaders: true, tableName: "Rows", style: ExcelTableStyle.TableStyleMedium2);
+                sheet.CellValue(1, 2, "Score");
+                sheet.CellValue(2, 2, 42);
+
+                IReadOnlyList<ExcelColumnFormatResult> results = sheet.ApplyColumnFormatPlan(
+                    new ExcelColumnFormatPlan().Add("Score", ExcelNumberPreset.Integer));
+
+                Assert.Single(results);
+                Assert.True(results[0].Applied);
+                Assert.Equal(2, results[0].ColumnIndex);
+                document.Save(filePath, openExcel: false, options: new ExcelSaveOptions { DisableFastPackageWriter = true });
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            var cells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>()
+                .ToDictionary(cell => cell.CellReference!.Value!);
+
+            Assert.Equal("#,##0", GetCellNumberFormatCode(spreadsheet, cells["B2"]));
+        }
+
+        [Fact]
+        public void Test_ExcelBestOfBar_ColumnFormatPlan_UpdatesMaterializedDomForStandardSaveFallback() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelBestOfBar.ColumnFormatPlan.MaterializedFallback.xlsx");
+
+            var table = new DataTable("Rows");
+            table.Columns.Add("Name", typeof(string));
+            table.Columns.Add("Amount", typeof(decimal));
+            table.Rows.Add("Alpha", 12.5M);
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.InsertDataTableAsTable(table, 1, 1, includeHeaders: true, tableName: "Rows", style: ExcelTableStyle.TableStyleMedium2);
+                Assert.True(sheet.TryGetCellText(2, 1, out _));
+
+                IReadOnlyList<ExcelColumnFormatResult> results = sheet.ApplyColumnFormatPlan(
+                    new ExcelColumnFormatPlan().Currency(System.Globalization.CultureInfo.GetCultureInfo("en-US"), "Amount"));
+
+                Assert.Single(results);
+                Assert.True(results[0].Applied);
+                Assert.Equal(2, results[0].ColumnIndex);
+                document.Save(filePath, openExcel: false, options: new ExcelSaveOptions { DisableFastPackageWriter = true });
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            var cells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>()
+                .ToDictionary(cell => cell.CellReference!.Value!);
+
+            Assert.Contains("$", GetCellNumberFormatCode(spreadsheet, cells["B2"]) ?? string.Empty);
+        }
+
+        [Fact]
+        public void Test_ExcelBestOfBar_ColumnFormatPlan_AutoFitKeepsDirectPackageWriter() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelBestOfBar.ColumnFormatPlan.DirectAutoFit.xlsx");
+
+            var table = new DataTable("Rows");
+            table.Columns.Add("Name", typeof(string));
+            table.Columns.Add("Amount", typeof(decimal));
+            table.Rows.Add("Long descriptive customer name", 1234.5M);
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.InsertDataTableAsTable(table, 1, 1, includeHeaders: true, tableName: "Rows", style: ExcelTableStyle.TableStyleMedium2);
+
+                IReadOnlyList<ExcelColumnFormatResult> results = sheet.ApplyColumnFormatPlan(
+                    new ExcelColumnFormatPlan()
+                        .Text("Name")
+                        .Currency(System.Globalization.CultureInfo.GetCultureInfo("en-US"), "Amount"),
+                    autoFit: true);
+
+                Assert.All(results, result => Assert.True(result.Applied));
+                document.Save();
+                Assert.Equal(ExcelSavePackageWriter.DirectDataSetPackage, document.LastSaveDiagnostics.Writer);
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            var cells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>()
+                .ToDictionary(cell => cell.CellReference!.Value!);
+
+            Assert.Equal("@", GetCellNumberFormatCode(spreadsheet, cells["A2"]));
+            Assert.Contains("$", GetCellNumberFormatCode(spreadsheet, cells["B2"]) ?? string.Empty);
+        }
     }
 }

--- a/OfficeIMO.Tests/Excel.BestOfBar.cs
+++ b/OfficeIMO.Tests/Excel.BestOfBar.cs
@@ -245,5 +245,45 @@ namespace OfficeIMO.Tests {
             Assert.Equal("0.0%", GetCellNumberFormatCode(spreadsheet, cells["C2"]));
             Assert.Equal("yyyy-mm-dd", GetCellNumberFormatCode(spreadsheet, cells["D2"]));
         }
+
+        [Fact]
+        public void Test_ExcelBestOfBar_ColumnFormatPlan_HonorsExactAndExplicitHeaderRows() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelBestOfBar.ColumnFormatPlan.HeaderRows.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "Report");
+                sheet.CellValue(2, 1, "Value");
+                sheet.CellValue(2, 2, "  Value  ");
+                sheet.CellValue(3, 1, 10);
+                sheet.CellValue(3, 2, 20);
+
+                var exactPlan = new ExcelColumnFormatPlan().Add("  Value  ", ExcelNumberPreset.Integer);
+                IReadOnlyList<ExcelColumnFormatResult> exactResults = sheet.ApplyColumnFormatPlan(
+                    exactPlan,
+                    headerRow: 2,
+                    options: new ExcelReadOptions { NormalizeHeaders = false });
+
+                var titlePlan = new ExcelColumnFormatPlan().Currency(System.Globalization.CultureInfo.GetCultureInfo("en-US"), "Value");
+                IReadOnlyList<ExcelColumnFormatResult> titleResults = sheet.ApplyColumnFormatPlan(
+                    titlePlan,
+                    headerRow: 2);
+
+                Assert.Single(exactResults);
+                Assert.True(exactResults[0].Applied);
+                Assert.Equal(2, exactResults[0].ColumnIndex);
+                Assert.Single(titleResults);
+                Assert.True(titleResults[0].Applied);
+                Assert.Equal(1, titleResults[0].ColumnIndex);
+                document.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            var cells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>()
+                .ToDictionary(cell => cell.CellReference!.Value!);
+
+            Assert.Contains("$", GetCellNumberFormatCode(spreadsheet, cells["A3"]) ?? string.Empty);
+            Assert.Equal("#,##0", GetCellNumberFormatCode(spreadsheet, cells["B3"]));
+        }
     }
 }

--- a/OfficeIMO.Tests/Excel.BestOfBar.cs
+++ b/OfficeIMO.Tests/Excel.BestOfBar.cs
@@ -285,5 +285,58 @@ namespace OfficeIMO.Tests {
             Assert.Contains("$", GetCellNumberFormatCode(spreadsheet, cells["A3"]) ?? string.Empty);
             Assert.Equal("#,##0", GetCellNumberFormatCode(spreadsheet, cells["B3"]));
         }
+
+        [Fact]
+        public void Test_ExcelBestOfBar_ColumnFormatPlan_NormalizesDefaultHeaderLookup() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelBestOfBar.ColumnFormatPlan.DefaultHeaderLookup.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.CellValue(1, 1, "  Value  ");
+                sheet.CellValue(2, 1, 42);
+
+                IReadOnlyList<ExcelColumnFormatResult> results = sheet.ApplyColumnFormatPlan(
+                    new ExcelColumnFormatPlan().Add("  Value  ", ExcelNumberPreset.Integer));
+
+                Assert.Single(results);
+                Assert.True(results[0].Applied);
+                Assert.Equal(1, results[0].ColumnIndex);
+                document.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            var cells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>()
+                .ToDictionary(cell => cell.CellReference!.Value!);
+
+            Assert.Equal("#,##0", GetCellNumberFormatCode(spreadsheet, cells["A2"]));
+        }
+
+        [Fact]
+        public void Test_ExcelBestOfBar_ColumnFormatPlan_AllowsHeaderOnlyDirectExports() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelBestOfBar.ColumnFormatPlan.HeaderOnlyDirect.xlsx");
+
+            var table = new DataTable("Counts");
+            table.Columns.Add("Count", typeof(int));
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Data");
+                sheet.InsertDataTableAsTable(table, 1, 1, includeHeaders: true, tableName: "Counts", style: ExcelTableStyle.TableStyleMedium2);
+
+                IReadOnlyList<ExcelColumnFormatResult> results = sheet.ApplyColumnFormatPlan(
+                    new ExcelColumnFormatPlan().Add("Count", ExcelNumberPreset.Integer));
+
+                Assert.Single(results);
+                Assert.True(results[0].Applied);
+                Assert.Equal(1, results[0].ColumnIndex);
+                document.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            var cells = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet.Descendants<Cell>()
+                .ToDictionary(cell => cell.CellReference!.Value!);
+
+            Assert.Contains("A1", cells.Keys);
+            Assert.DoesNotContain("A2", cells.Keys);
+        }
     }
 }

--- a/OfficeIMO.Tests/Excel.ReaderHeaders.cs
+++ b/OfficeIMO.Tests/Excel.ReaderHeaders.cs
@@ -529,7 +529,7 @@ namespace OfficeIMO.Tests {
                         xml = reader.ReadToEnd();
                     }
 
-                    xml = xml.Replace("placeholder", "Alpha<![CDATA[Beta]]>Gamma", StringComparison.Ordinal);
+                    xml = xml.Replace("placeholder", "Alpha<![CDATA[Beta]]>Gamma");
 
                     sheetEntry.Delete();
                     ZipArchiveEntry replacement = archive.CreateEntry(sheetEntryName);

--- a/OfficeIMO.Tests/Excel.ReaderHeaders.cs
+++ b/OfficeIMO.Tests/Excel.ReaderHeaders.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Data;
 using System.Globalization;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -493,6 +494,53 @@ namespace OfficeIMO.Tests {
 
                 Assert.Equal("Shared Rich", values[0, 0]);
                 Assert.Equal("Inline Rich", values[0, 1]);
+            } finally {
+                if (File.Exists(filePath)) {
+                    File.Delete(filePath);
+                }
+            }
+        }
+
+        [Fact]
+        public void Reader_ReadRange_PreservesAdjacentTextNodesInsideInlineStringText() {
+            string filePath = Path.Combine(_directoryWithFiles, "ReaderInlineStringSplitTextNode.xlsx");
+
+            try {
+                using (var document = ExcelDocument.Create(filePath)) {
+                    var sheet = document.AddWorkSheet("Data");
+                    sheet.CellValue(1, 1, "placeholder");
+                    document.Save();
+                }
+
+                using (var spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                    var worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
+                    Cell cell = worksheetPart.Worksheet.Descendants<Cell>().First(c => c.CellReference?.Value == "A1");
+                    cell.CellValue = null;
+                    cell.DataType = CellValues.InlineString;
+                    cell.InlineString = new InlineString(new Text("placeholder"));
+                    worksheetPart.Worksheet.Save();
+                }
+
+                using (var archive = ZipFile.Open(filePath, ZipArchiveMode.Update)) {
+                    ZipArchiveEntry sheetEntry = archive.Entries.Single(entry => entry.FullName.StartsWith("xl/worksheets/sheet", StringComparison.Ordinal) && entry.FullName.EndsWith(".xml", StringComparison.Ordinal));
+                    string sheetEntryName = sheetEntry.FullName;
+                    string xml;
+                    using (var reader = new StreamReader(sheetEntry.Open())) {
+                        xml = reader.ReadToEnd();
+                    }
+
+                    xml = xml.Replace("placeholder", "Alpha<![CDATA[Beta]]>Gamma", StringComparison.Ordinal);
+
+                    sheetEntry.Delete();
+                    ZipArchiveEntry replacement = archive.CreateEntry(sheetEntryName);
+                    using var writer = new StreamWriter(replacement.Open());
+                    writer.Write(xml);
+                }
+
+                using var excelReader = ExcelDocumentReader.Open(filePath);
+                object?[,] values = excelReader.GetSheet("Data").ReadRange("A1:A1");
+
+                Assert.Equal("AlphaBetaGamma", values[0, 0]);
             } finally {
                 if (File.Exists(filePath)) {
                     File.Delete(filePath);

--- a/OfficeIMO.Tests/Excel.WorkbookMerge.cs
+++ b/OfficeIMO.Tests/Excel.WorkbookMerge.cs
@@ -107,6 +107,7 @@ namespace OfficeIMO.Tests {
                 source.Save();
             }
 
+            AddWorkbookDefinedName(sourcePath, "TaxRate", "0.99");
             AddWorkbookDefinedName(sourcePath, "PeopleTotal", "SUM(People[Amount])");
             AddWorkbookDefinedName(sourcePath, "TotalWithTax", "PeopleTotal*TaxRate");
 
@@ -131,13 +132,16 @@ namespace OfficeIMO.Tests {
                 Cell formulaCell = summaryPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A1");
                 Hyperlink hyperlink = Assert.Single(summaryPart.Worksheet.Descendants<Hyperlink>());
                 Formula1 validationFormula = Assert.Single(summaryPart.Worksheet.Descendants<Formula1>());
-                DefinedName taxRate = Assert.Single(spreadsheet.WorkbookPart!.Workbook.DefinedNames!.Elements<DefinedName>(), name => name.Name == "TaxRate");
+                DefinedName taxRate = spreadsheet.WorkbookPart!.Workbook.DefinedNames!.Elements<DefinedName>()
+                    .Single(name => name.Name == "TaxRate"
+                        && name.LocalSheetId != null
+                        && name.Text == "'Imported Data'!$C$2");
                 DefinedName peopleTotal = Assert.Single(spreadsheet.WorkbookPart!.Workbook.DefinedNames!.Elements<DefinedName>(), name => name.Name == "PeopleTotal");
                 DefinedName totalWithTax = Assert.Single(spreadsheet.WorkbookPart!.Workbook.DefinedNames!.Elements<DefinedName>(), name => name.Name == "TotalWithTax");
 
                 Assert.NotEqual("People", copiedPeopleTableName);
                 Assert.Equal("'Imported Data'!B2", selfFormulaCell.CellFormula?.Text);
-                Assert.Equal($"'Imported Data'!B2+'Imported Imported Data'!A1+'Imported Data'!TaxRate+SUM({copiedPeopleTableName}[Amount])+TotalWithTax+SUM('Imported Jan':'Imported Mar'!A1)+SUM('Imported Jan 2026':'Imported Mar 2026'!A1)", formulaCell.CellFormula?.Text);
+                Assert.Equal($"'Imported Data'!B2+'Imported Imported Data'!A1+'Imported Data'!TaxRate+SUM({copiedPeopleTableName}[Amount])+TotalWithTax+SUM('Imported Jan:Imported Mar'!A1)+SUM('Imported Jan 2026:Imported Mar 2026'!A1)", formulaCell.CellFormula?.Text);
                 Assert.Equal("'Imported Data'!A1", hyperlink.Location?.Value);
                 Assert.Equal("COUNTIF('Imported Data'!$A$1:$A$1,\">0\")>0", validationFormula.Text);
                 Assert.Equal("'Imported Data'!$C$2", taxRate.Text);

--- a/OfficeIMO.Tests/Excel.WorkbookMerge.cs
+++ b/OfficeIMO.Tests/Excel.WorkbookMerge.cs
@@ -154,6 +154,38 @@ namespace OfficeIMO.Tests {
             File.Delete(targetPath);
         }
 
+        [Fact]
+        public void Test_ExcelWorkbookMerge_SameWorkbookPackageModeUsesWorksheetCopyPath() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelWorkbookMerge.SameWorkbookPackageMode.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                ExcelSheet source = document.AddWorkSheet("Source");
+                source.CellValue(1, 1, "Amount");
+                source.CellValue(2, 1, 10);
+                source.AddTable("A1:A2", hasHeader: true, name: "Sales", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
+                source.CellFormula(3, 1, "SUM(Sales[Amount])");
+
+                ExcelWorkbookMergeResult result = document.MergeWorkbookFrom(document, new ExcelWorkbookMergeOptions {
+                    SheetNames = new[] { "Source" },
+                    SheetNamePrefix = "Copy ",
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+
+                Assert.Equal(new[] { "Source" }, result.SourceSheets);
+                Assert.Equal(new[] { "Copy Source" }, result.TargetSheets);
+                Assert.Equal("A1:A2", document.GetSheet("Copy Source").GetTableRange("Sales2"));
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Copy Source");
+                Cell formulaCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A3");
+                Assert.Equal("SUM(Sales2[Amount])", formulaCell.CellFormula?.Text);
+            }
+
+            File.Delete(filePath);
+        }
+
         private static void AddWorkbookDefinedName(string path, string name, string reference) {
             using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(path, true);
             Workbook workbook = spreadsheet.WorkbookPart!.Workbook;

--- a/OfficeIMO.Tests/Excel.WorkbookMerge.cs
+++ b/OfficeIMO.Tests/Excel.WorkbookMerge.cs
@@ -78,8 +78,18 @@ namespace OfficeIMO.Tests {
                 ExcelSheet data = source.AddWorkSheet("Data");
                 data.CellValue(1, 1, 42);
 
+                ExcelSheet importedData = source.AddWorkSheet("Imported Data");
+                importedData.CellValue(1, 1, 84);
+
+                ExcelSheet jan = source.AddWorkSheet("Jan");
+                jan.CellValue(1, 1, 1);
+
+                ExcelSheet mar = source.AddWorkSheet("Mar");
+                mar.CellValue(1, 1, 3);
+
                 ExcelSheet summary = source.AddWorkSheet("Summary");
-                summary.CellFormula(1, 1, "Data!A1");
+                summary.CellFormula(1, 1, "Data!A1+'Imported Data'!A1+SUM(Jan:Mar!A1)");
+                summary.SetInternalLink(2, 1, "Data!A1", "Go");
                 summary.ValidationCustomFormula("B2", "COUNTIF(Data!$A$1:$A$1,\">0\")>0");
                 source.Save();
             }
@@ -97,9 +107,11 @@ namespace OfficeIMO.Tests {
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
                 WorksheetPart summaryPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported Summary");
                 Cell formulaCell = summaryPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A1");
+                Hyperlink hyperlink = Assert.Single(summaryPart.Worksheet.Descendants<Hyperlink>());
                 Formula1 validationFormula = Assert.Single(summaryPart.Worksheet.Descendants<Formula1>());
 
-                Assert.Equal("'Imported Data'!A1", formulaCell.CellFormula?.Text);
+                Assert.Equal("'Imported Data'!A1+'Imported Imported Data'!A1+SUM('Imported Jan':'Imported Mar'!A1)", formulaCell.CellFormula?.Text);
+                Assert.Equal("'Imported Data'!A1", hyperlink.Location?.Value);
                 Assert.Equal("COUNTIF('Imported Data'!$A$1:$A$1,\">0\")>0", validationFormula.Text);
             }
 

--- a/OfficeIMO.Tests/Excel.WorkbookMerge.cs
+++ b/OfficeIMO.Tests/Excel.WorkbookMerge.cs
@@ -77,6 +77,8 @@ namespace OfficeIMO.Tests {
             using (var source = ExcelDocument.Create(sourcePath)) {
                 ExcelSheet data = source.AddWorkSheet("Data");
                 data.CellValue(1, 1, 42);
+                data.CellFormula(2, 1, "Data!A1");
+                source.SetNamedRange("TaxRate", "A1", data, save: false);
 
                 ExcelSheet importedData = source.AddWorkSheet("Imported Data");
                 importedData.CellValue(1, 1, 84);
@@ -87,8 +89,14 @@ namespace OfficeIMO.Tests {
                 ExcelSheet mar = source.AddWorkSheet("Mar");
                 mar.CellValue(1, 1, 3);
 
+                ExcelSheet jan2026 = source.AddWorkSheet("Jan 2026");
+                jan2026.CellValue(1, 1, 1);
+
+                ExcelSheet mar2026 = source.AddWorkSheet("Mar 2026");
+                mar2026.CellValue(1, 1, 3);
+
                 ExcelSheet summary = source.AddWorkSheet("Summary");
-                summary.CellFormula(1, 1, "Data!A1+'Imported Data'!A1+SUM(Jan:Mar!A1)");
+                summary.CellFormula(1, 1, "Data!A1+'Imported Data'!A1+Data!TaxRate+SUM(Jan:Mar!A1)+SUM('Jan 2026:Mar 2026'!A1)");
                 summary.SetInternalLink(2, 1, "Data!A1", "Go");
                 summary.ValidationCustomFormula("B2", "COUNTIF(Data!$A$1:$A$1,\">0\")>0");
                 source.Save();
@@ -105,14 +113,20 @@ namespace OfficeIMO.Tests {
             }
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
+                WorksheetPart dataPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported Data");
+                Cell selfFormulaCell = dataPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A2");
                 WorksheetPart summaryPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported Summary");
                 Cell formulaCell = summaryPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A1");
                 Hyperlink hyperlink = Assert.Single(summaryPart.Worksheet.Descendants<Hyperlink>());
                 Formula1 validationFormula = Assert.Single(summaryPart.Worksheet.Descendants<Formula1>());
+                DefinedName taxRate = Assert.Single(spreadsheet.WorkbookPart!.Workbook.DefinedNames!.Elements<DefinedName>(), name => name.Name == "TaxRate");
 
-                Assert.Equal("'Imported Data'!A1+'Imported Imported Data'!A1+SUM('Imported Jan':'Imported Mar'!A1)", formulaCell.CellFormula?.Text);
+                Assert.Equal("'Imported Data'!A1", selfFormulaCell.CellFormula?.Text);
+                Assert.Equal("'Imported Data'!A1+'Imported Imported Data'!A1+'Imported Data'!TaxRate+SUM('Imported Jan':'Imported Mar'!A1)+SUM('Imported Jan 2026':'Imported Mar 2026'!A1)", formulaCell.CellFormula?.Text);
                 Assert.Equal("'Imported Data'!A1", hyperlink.Location?.Value);
                 Assert.Equal("COUNTIF('Imported Data'!$A$1:$A$1,\">0\")>0", validationFormula.Text);
+                Assert.Equal("'Imported Data'!$A$1", taxRate.Text);
+                Assert.NotNull(taxRate.LocalSheetId);
             }
 
             File.Delete(sourcePath);

--- a/OfficeIMO.Tests/Excel.WorkbookMerge.cs
+++ b/OfficeIMO.Tests/Excel.WorkbookMerge.cs
@@ -1,4 +1,7 @@
 using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
 using OfficeIMO.Excel;
 using Xunit;
 
@@ -64,6 +67,44 @@ namespace OfficeIMO.Tests {
             Assert.Equal(2, reloaded.Sheets.Count);
             Assert.True(reloaded["Source"].TryGetCellText(1, 1, out var value));
             Assert.Equal("Imported", value);
+        }
+
+        [Fact]
+        public void Test_ExcelWorkbookMerge_RewritesCopiedWorksheetFormulasForPrefixedNames() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "ExcelWorkbookMerge.FormulaSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "ExcelWorkbookMerge.FormulaTarget.xlsx");
+
+            using (var source = ExcelDocument.Create(sourcePath)) {
+                ExcelSheet data = source.AddWorkSheet("Data");
+                data.CellValue(1, 1, 42);
+
+                ExcelSheet summary = source.AddWorkSheet("Summary");
+                summary.CellFormula(1, 1, "Data!A1");
+                summary.ValidationCustomFormula("B2", "COUNTIF(Data!$A$1:$A$1,\">0\")>0");
+                source.Save();
+            }
+
+            using (var target = ExcelDocument.Create(targetPath))
+            using (var source = ExcelDocument.Load(sourcePath, readOnly: true)) {
+                target.AddWorkSheet("Existing").CellValue(1, 1, "Existing");
+                target.MergeWorkbookFrom(source, new ExcelWorkbookMergeOptions {
+                    SheetNamePrefix = "Imported ",
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                target.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
+                WorksheetPart summaryPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported Summary");
+                Cell formulaCell = summaryPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A1");
+                Formula1 validationFormula = Assert.Single(summaryPart.Worksheet.Descendants<Formula1>());
+
+                Assert.Equal("'Imported Data'!A1", formulaCell.CellFormula?.Text);
+                Assert.Equal("COUNTIF('Imported Data'!$A$1:$A$1,\">0\")>0", validationFormula.Text);
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
         }
     }
 }

--- a/OfficeIMO.Tests/Excel.WorkbookMerge.cs
+++ b/OfficeIMO.Tests/Excel.WorkbookMerge.cs
@@ -155,6 +155,44 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ExcelWorkbookMerge_RemapsExternalReferencesInCopiedDefinedNames() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "ExcelWorkbookMerge.ExternalNameSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "ExcelWorkbookMerge.ExternalNameTarget.xlsx");
+
+            using (var source = ExcelDocument.Create(sourcePath)) {
+                ExcelSheet data = source.AddWorkSheet("Data");
+                data.CellFormula(1, 1, "ExternalValue");
+                source.Save();
+            }
+
+            using (var target = ExcelDocument.Create(targetPath)) {
+                target.AddWorkSheet("Existing").CellFormula(1, 1, "[1]Sheet1!B1");
+                target.Save();
+            }
+
+            AddExternalWorkbookReference(sourcePath);
+            AddWorkbookDefinedName(sourcePath, "ExternalValue", "[1]Sheet1!A1");
+            AddExternalWorkbookReference(targetPath);
+
+            using (var target = ExcelDocument.Load(targetPath))
+            using (var source = ExcelDocument.Load(sourcePath, readOnly: true)) {
+                target.MergeWorkbookFrom(source, new ExcelWorkbookMergeOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                target.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
+                DefinedName copiedName = Assert.Single(spreadsheet.WorkbookPart!.Workbook.DefinedNames!.Elements<DefinedName>(),
+                    name => string.Equals(name.Name?.Value, "ExternalValue", System.StringComparison.OrdinalIgnoreCase));
+                Assert.Equal("[2]Sheet1!A1", copiedName.Text);
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
         public void Test_ExcelWorkbookMerge_SameWorkbookPackageModeUsesWorksheetCopyPath() {
             string filePath = Path.Combine(_directoryWithFiles, "ExcelWorkbookMerge.SameWorkbookPackageMode.xlsx");
 

--- a/OfficeIMO.Tests/Excel.WorkbookMerge.cs
+++ b/OfficeIMO.Tests/Excel.WorkbookMerge.cs
@@ -76,9 +76,14 @@ namespace OfficeIMO.Tests {
 
             using (var source = ExcelDocument.Create(sourcePath)) {
                 ExcelSheet data = source.AddWorkSheet("Data");
-                data.CellValue(1, 1, 42);
-                data.CellFormula(2, 1, "Data!A1");
-                source.SetNamedRange("TaxRate", "A1", data, save: false);
+                data.CellValue(1, 1, "Name");
+                data.CellValue(1, 2, "Amount");
+                data.CellValue(2, 1, "Ada");
+                data.CellValue(2, 2, 42);
+                data.CellValue(2, 3, 0.2);
+                data.CellFormula(3, 2, "Data!B2");
+                data.AddTable("A1:B2", hasHeader: true, name: "People", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
+                source.SetNamedRange("TaxRate", "C2", data, save: false);
 
                 ExcelSheet importedData = source.AddWorkSheet("Imported Data");
                 importedData.CellValue(1, 1, 84);
@@ -96,15 +101,21 @@ namespace OfficeIMO.Tests {
                 mar2026.CellValue(1, 1, 3);
 
                 ExcelSheet summary = source.AddWorkSheet("Summary");
-                summary.CellFormula(1, 1, "Data!A1+'Imported Data'!A1+Data!TaxRate+SUM(Jan:Mar!A1)+SUM('Jan 2026:Mar 2026'!A1)");
+                summary.CellFormula(1, 1, "Data!B2+'Imported Data'!A1+Data!TaxRate+SUM(People[Amount])+TotalWithTax+SUM(Jan:Mar!A1)+SUM('Jan 2026:Mar 2026'!A1)");
                 summary.SetInternalLink(2, 1, "Data!A1", "Go");
                 summary.ValidationCustomFormula("B2", "COUNTIF(Data!$A$1:$A$1,\">0\")>0");
                 source.Save();
             }
 
+            AddWorkbookDefinedName(sourcePath, "PeopleTotal", "SUM(People[Amount])");
+            AddWorkbookDefinedName(sourcePath, "TotalWithTax", "PeopleTotal*TaxRate");
+
             using (var target = ExcelDocument.Create(targetPath))
             using (var source = ExcelDocument.Load(sourcePath, readOnly: true)) {
-                target.AddWorkSheet("Existing").CellValue(1, 1, "Existing");
+                ExcelSheet existing = target.AddWorkSheet("Existing");
+                existing.CellValue(1, 1, "Name");
+                existing.CellValue(2, 1, "Grace");
+                existing.AddTable("A1:A2", hasHeader: true, name: "People", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
                 target.MergeWorkbookFrom(source, new ExcelWorkbookMergeOptions {
                     SheetNamePrefix = "Imported ",
                     CopyMode = ExcelWorksheetCopyMode.Package
@@ -114,23 +125,39 @@ namespace OfficeIMO.Tests {
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
                 WorksheetPart dataPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported Data");
-                Cell selfFormulaCell = dataPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A2");
+                Cell selfFormulaCell = dataPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "B3");
+                string copiedPeopleTableName = Assert.Single(dataPart.TableDefinitionParts).Table.Name!.Value!;
                 WorksheetPart summaryPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported Summary");
                 Cell formulaCell = summaryPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A1");
                 Hyperlink hyperlink = Assert.Single(summaryPart.Worksheet.Descendants<Hyperlink>());
                 Formula1 validationFormula = Assert.Single(summaryPart.Worksheet.Descendants<Formula1>());
                 DefinedName taxRate = Assert.Single(spreadsheet.WorkbookPart!.Workbook.DefinedNames!.Elements<DefinedName>(), name => name.Name == "TaxRate");
+                DefinedName peopleTotal = Assert.Single(spreadsheet.WorkbookPart!.Workbook.DefinedNames!.Elements<DefinedName>(), name => name.Name == "PeopleTotal");
+                DefinedName totalWithTax = Assert.Single(spreadsheet.WorkbookPart!.Workbook.DefinedNames!.Elements<DefinedName>(), name => name.Name == "TotalWithTax");
 
-                Assert.Equal("'Imported Data'!A1", selfFormulaCell.CellFormula?.Text);
-                Assert.Equal("'Imported Data'!A1+'Imported Imported Data'!A1+'Imported Data'!TaxRate+SUM('Imported Jan':'Imported Mar'!A1)+SUM('Imported Jan 2026':'Imported Mar 2026'!A1)", formulaCell.CellFormula?.Text);
+                Assert.NotEqual("People", copiedPeopleTableName);
+                Assert.Equal("'Imported Data'!B2", selfFormulaCell.CellFormula?.Text);
+                Assert.Equal($"'Imported Data'!B2+'Imported Imported Data'!A1+'Imported Data'!TaxRate+SUM({copiedPeopleTableName}[Amount])+TotalWithTax+SUM('Imported Jan':'Imported Mar'!A1)+SUM('Imported Jan 2026':'Imported Mar 2026'!A1)", formulaCell.CellFormula?.Text);
                 Assert.Equal("'Imported Data'!A1", hyperlink.Location?.Value);
                 Assert.Equal("COUNTIF('Imported Data'!$A$1:$A$1,\">0\")>0", validationFormula.Text);
-                Assert.Equal("'Imported Data'!$A$1", taxRate.Text);
+                Assert.Equal("'Imported Data'!$C$2", taxRate.Text);
+                Assert.Equal($"SUM({copiedPeopleTableName}[Amount])", peopleTotal.Text);
+                Assert.Equal("PeopleTotal*TaxRate", totalWithTax.Text);
                 Assert.NotNull(taxRate.LocalSheetId);
             }
 
             File.Delete(sourcePath);
             File.Delete(targetPath);
+        }
+
+        private static void AddWorkbookDefinedName(string path, string name, string reference) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(path, true);
+            Workbook workbook = spreadsheet.WorkbookPart!.Workbook;
+            workbook.DefinedNames ??= new DefinedNames();
+            workbook.DefinedNames.Append(new DefinedName(reference) {
+                Name = name
+            });
+            workbook.Save();
         }
     }
 }

--- a/OfficeIMO.Tests/Excel.WorksheetOperations.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetOperations.cs
@@ -989,6 +989,69 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeConvertsMonthTimeDateSerialsAcrossDateSystems() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageMonthTimeDateSystemSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageMonthTimeDateSystemTarget.xlsx");
+            var date = new DateTime(2026, 6, 23, 14, 30, 0);
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                sourceDocument.DateSystem = ExcelDateSystem.NineteenFour;
+                ExcelSheet source = sourceDocument.AddWorkSheet("Dates");
+                source.CellValue(1, 1, "Created");
+                source.CellValue(2, 1, date);
+                source.CellAt(2, 1).SetNumberFormat("mmm h:mm");
+                sourceDocument.Save();
+            }
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "Dates", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false);
+            WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+            Cell dateCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A2");
+            Assert.Equal(date.ToOADate(), double.Parse(dateCell.CellValue!.Text, CultureInfo.InvariantCulture), 6);
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeDoesNotShiftBracketedElapsedMinuteSerialsAcrossDateSystems() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageElapsedMinuteSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageElapsedMinuteTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                sourceDocument.DateSystem = ExcelDateSystem.NineteenFour;
+                ExcelSheet source = sourceDocument.AddWorkSheet("Elapsed");
+                source.CellValue(1, 1, "Duration");
+                source.CellValue(2, 1, 1.25D);
+                source.CellAt(2, 1).SetNumberFormat("[m]:ss");
+                sourceDocument.Save();
+            }
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "Elapsed", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false);
+            WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+            Cell durationCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A2");
+            Assert.Equal(1.25D, double.Parse(durationCell.CellValue!.Text, CultureInfo.InvariantCulture), 6);
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
         public void Test_CopyWorkSheetFrom_PackageModeCopiesExternalWorkbookReferences() {
             string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageExternalLinkSource.xlsx");
             string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageExternalLinkTarget.xlsx");
@@ -1260,6 +1323,38 @@ namespace OfficeIMO.Tests {
 
             File.Delete(sourcePath);
             File.Delete(targetPath);
+        }
+
+        [Fact]
+        public void Test_CopyWorkSheetFrom_ValuesModeHonorsSameWorkbookSource() {
+            string filePath = Path.Combine(_directoryWithFiles, "WorksheetCopyValuesModeSameWorkbook.xlsx");
+
+            using (var document = ExcelDocument.Create(filePath)) {
+                ExcelSheet source = document.AddWorkSheet("Source");
+                source.CellValue(1, 1, "Name");
+                source.CellValue(2, 1, "Ada");
+                source.CellBold(1, 1, true);
+                ExcelSheet copied = document.CopyWorkSheetFrom(document, "Source", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Values
+                });
+
+                Assert.Equal("Imported", copied.Name);
+                Assert.Equal("A1:A2", copied.GetUsedRangeA1());
+                document.Save();
+            }
+
+            using (var document = ExcelDocument.Load(filePath, readOnly: true)) {
+                Assert.True(document["Imported"].TryGetCellText(2, 1, out var value));
+                Assert.Equal("Ada", value);
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false)) {
+                WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+                Cell headerCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A1");
+                Assert.True(headerCell.StyleIndex == null || headerCell.StyleIndex.Value == 0U);
+            }
+
+            File.Delete(filePath);
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Excel.WorksheetOperations.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetOperations.cs
@@ -602,6 +602,7 @@ namespace OfficeIMO.Tests {
                 source.CellFormula(3, 1, "ROWS(People)");
                 source.CellFormula(4, 1, "'People'!A1+ROWS(People)");
                 source.CellFormula(5, 1, "SUM(Sales[People])+ROWS(People)");
+                source.CellFormula(6, 1, "People.Total+ROWS(People)");
                 sourceDocument.Save();
             }
 
@@ -631,10 +632,12 @@ namespace OfficeIMO.Tests {
                 Cell bareTableFormula = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A3");
                 Cell sheetQualifiedFormula = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A4");
                 Cell bracketedColumnFormula = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A5");
+                Cell dottedNameFormula = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A6");
                 Assert.Equal($"COUNTIF({copiedTableName}[Name],B2)>0", formula.Text);
                 Assert.Equal($"ROWS({copiedTableName})", bareTableFormula.CellFormula?.Text);
                 Assert.Equal($"'People'!A1+ROWS({copiedTableName})", sheetQualifiedFormula.CellFormula?.Text);
                 Assert.Equal($"SUM(Sales[People])+ROWS({copiedTableName})", bracketedColumnFormula.CellFormula?.Text);
+                Assert.Equal($"People.Total+ROWS({copiedTableName})", dottedNameFormula.CellFormula?.Text);
             }
 
             File.Delete(sourcePath);
@@ -956,6 +959,74 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeDoesNotShiftTimeOnlySerialsAcrossDateSystems() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageTimeOnlySource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageTimeOnlyTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                sourceDocument.DateSystem = ExcelDateSystem.NineteenFour;
+                ExcelSheet source = sourceDocument.AddWorkSheet("Times");
+                source.CellValue(1, 1, "Elapsed");
+                source.CellValue(2, 1, TimeSpan.FromHours(12));
+                sourceDocument.Save();
+            }
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "Times", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false);
+            WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+            Cell timeCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A2");
+            Assert.Equal(0.5D, double.Parse(timeCell.CellValue!.Text, CultureInfo.InvariantCulture), 6);
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeCopiesExternalWorkbookReferences() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageExternalLinkSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageExternalLinkTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                ExcelSheet source = sourceDocument.AddWorkSheet("External");
+                source.CellFormula(1, 1, "[1]Sheet1!A1");
+                sourceDocument.Save();
+            }
+
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                targetDocument.AddWorkSheet("Existing").CellFormula(1, 1, "[1]Sheet1!B1");
+                targetDocument.Save();
+            }
+
+            AddExternalWorkbookReference(sourcePath);
+            AddExternalWorkbookReference(targetPath);
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Load(targetPath)) {
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "External", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
+                WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+                Cell copiedFormula = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A1");
+                Assert.Equal("[2]Sheet1!A1", copiedFormula.CellFormula?.Text);
+                Assert.Equal(2, spreadsheet.WorkbookPart!.Workbook.ExternalReferences!.Elements<ExternalReference>().Count());
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
         public void Test_CopyWorkSheetFrom_PackageModeStripsCellMetadataIndexes() {
             string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageMetadataSource.xlsx");
             string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageMetadataTarget.xlsx");
@@ -1225,6 +1296,22 @@ namespace OfficeIMO.Tests {
                     SheetId = 1
                 });
             calculationChainPart.CalculationChain.Save();
+        }
+
+        private static void AddExternalWorkbookReference(string path) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(path, true);
+            WorkbookPart workbookPart = spreadsheet.WorkbookPart!;
+            ExternalWorkbookPart externalPart = workbookPart.AddNewPart<ExternalWorkbookPart>();
+            externalPart.ExternalLink = new ExternalLink(
+                new ExternalBook(
+                    new SheetNames(
+                        new SheetName { Val = "Sheet1" })));
+            externalPart.ExternalLink.Save();
+
+            string relationshipId = workbookPart.GetIdOfPart(externalPart);
+            workbookPart.Workbook.ExternalReferences ??= new ExternalReferences();
+            workbookPart.Workbook.ExternalReferences.Append(new ExternalReference { Id = relationshipId });
+            workbookPart.Workbook.Save();
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Excel.WorksheetOperations.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetOperations.cs
@@ -421,6 +421,44 @@ namespace OfficeIMO.Tests {
                 Assert.Empty(worksheet.Elements<Controls>());
                 Assert.Empty(worksheet.Elements<Picture>());
                 Assert.Empty(worksheet.Elements<LegacyDrawing>());
+                Assert.Null(worksheet.GetFirstChild<PageSetup>()?.Id?.Value);
+                Assert.Empty(worksheet.Descendants<OpenXmlElement>().Where(element => element.LocalName == "queryTableParts"));
+                Assert.Empty(worksheet.Descendants<OpenXmlElement>().Where(element => element.LocalName == "pivotTableDefinition"));
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeRewritesSelfReferencesAndNamedRanges() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageFormulaSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageFormulaTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                ExcelSheet source = sourceDocument.AddWorkSheet("Source");
+                source.CellValue(1, 1, 10);
+                source.CellFormula(2, 1, "Source!A1*TaxRate");
+                sourceDocument.SetNamedRange("TaxRate", "A1", source);
+                sourceDocument.Save();
+            }
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "Source", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
+                WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+                Cell formulaCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A2");
+                DefinedName definedName = Assert.Single(spreadsheet.WorkbookPart!.Workbook.DefinedNames!.Elements<DefinedName>(), name => name.Name == "TaxRate");
+
+                Assert.Equal("'Imported'!A1*TaxRate", formulaCell.CellFormula?.Text);
+                Assert.Equal("'Imported'!$A$1", definedName.Text);
+                Assert.NotNull(definedName.LocalSheetId);
             }
 
             File.Delete(sourcePath);
@@ -547,6 +585,15 @@ namespace OfficeIMO.Tests {
             worksheet.Append(new Controls());
             worksheet.Append(new Picture { Id = "rId999" });
             worksheet.Append(new LegacyDrawing { Id = "rId998" });
+            worksheet.Append(new PageSetup { Id = "rId997" });
+            var queryTableParts = new OpenXmlUnknownElement(string.Empty, "queryTableParts", "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+            var queryTablePart = new OpenXmlUnknownElement(string.Empty, "queryTablePart", "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+            queryTablePart.SetAttribute(new OpenXmlAttribute("r", "id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships", "rId996"));
+            queryTableParts.Append(queryTablePart);
+            worksheet.Append(queryTableParts);
+            var pivotTableDefinition = new OpenXmlUnknownElement(string.Empty, "pivotTableDefinition", "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+            pivotTableDefinition.SetAttribute(new OpenXmlAttribute("r", "id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships", "rId995"));
+            worksheet.Append(pivotTableDefinition);
             worksheet.Save();
         }
 

--- a/OfficeIMO.Tests/Excel.WorksheetOperations.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetOperations.cs
@@ -632,6 +632,48 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeDoesNotRewriteFunctionCallsAsTableReferences() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageFunctionNameTableSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageFunctionNameTableTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                ExcelSheet source = sourceDocument.AddWorkSheet("Source");
+                source.CellValue(1, 1, "Value");
+                source.CellValue(2, 1, 10);
+                source.AddTable("A1:A2", hasHeader: true, name: "SUM", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
+                source.CellFormula(4, 1, "SUM(A2:A2)+ROWS(SUM)");
+                sourceDocument.Save();
+            }
+
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                ExcelSheet existing = targetDocument.AddWorkSheet("Existing");
+                existing.CellValue(1, 1, "Value");
+                existing.CellValue(2, 1, 20);
+                existing.AddTable("A1:A2", hasHeader: true, name: "SUM", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
+                targetDocument.Save();
+            }
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Load(targetPath)) {
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "Source", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
+                WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+                string copiedTableName = Assert.Single(copiedPart.TableDefinitionParts).Table.Name!.Value!;
+                Assert.NotEqual("SUM", copiedTableName);
+                Cell formulaCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A4");
+                Assert.Equal($"SUM(A2:A2)+ROWS({copiedTableName})", formulaCell.CellFormula?.Text);
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
         public void Test_CopyWorkSheetFrom_PackageModeRewritesStructuredReferencesOnce() {
             string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageStructuredOnceSource.xlsx");
             string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageStructuredOnceTarget.xlsx");

--- a/OfficeIMO.Tests/Excel.WorksheetOperations.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetOperations.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Linq;
 using System.Data;
+using System.Globalization;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
@@ -753,6 +754,104 @@ namespace OfficeIMO.Tests {
                 WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
                 Cell formulaCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A2");
                 Assert.Equal("A1*2", formulaCell.CellFormula?.Text);
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
+        public void Test_MergeWorkbookFrom_SameWorkbookRewritesCopiedTableReferences() {
+            string filePath = Path.Combine(_directoryWithFiles, "WorkbookMergeSameWorkbookTables.xlsx");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet source = document.AddWorkSheet("Source");
+                source.CellValue(1, 1, "Name");
+                source.CellValue(1, 2, "Amount");
+                source.CellValue(2, 1, "Alpha");
+                source.CellValue(2, 2, 10);
+                source.AddTable("A1:B2", hasHeader: true, name: "People", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
+
+                ExcelSheet summary = document.AddWorkSheet("Summary");
+                summary.CellFormula(1, 1, "SUM(People[Amount])");
+
+                document.MergeWorkbookFrom(document, new ExcelWorkbookMergeOptions {
+                    SheetNames = new[] { "Source", "Summary" },
+                    SheetNamePrefix = "Copy_"
+                });
+
+                document.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            WorksheetPart copiedSummary = GetWorksheetPartByNameForOperations(spreadsheet, "Copy_Summary");
+            Cell formulaCell = copiedSummary.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A1");
+            Assert.Equal("SUM(People2[Amount])", formulaCell.CellFormula?.Text);
+        }
+
+        [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeConvertsDateSerialsAcrossDateSystems() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageDateSystemSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageDateSystemTarget.xlsx");
+            var date = new DateTime(2026, 6, 23);
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                sourceDocument.DateSystem = ExcelDateSystem.NineteenFour;
+                ExcelSheet source = sourceDocument.AddWorkSheet("Dates");
+                source.CellValue(1, 1, "Created");
+                source.CellValue(2, 1, date);
+                sourceDocument.Save();
+            }
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "Dates", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false);
+            WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+            Cell dateCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A2");
+            Assert.Equal(date.ToOADate(), double.Parse(dateCell.CellValue!.Text, CultureInfo.InvariantCulture), 6);
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeStripsCellMetadataIndexes() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageMetadataSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageMetadataTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                ExcelSheet source = sourceDocument.AddWorkSheet("Metadata");
+                source.CellValue(1, 1, "Name");
+                source.CellValue(2, 1, "Alpha");
+                sourceDocument.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(sourcePath, true)) {
+                WorksheetPart worksheetPart = GetWorksheetPartByNameForOperations(spreadsheet, "Metadata");
+                Cell cell = worksheetPart.Worksheet.Descendants<Cell>().Single(item => item.CellReference?.Value == "A2");
+                cell.SetAttribute(new OpenXmlAttribute(string.Empty, "cm", string.Empty, "1"));
+                cell.SetAttribute(new OpenXmlAttribute(string.Empty, "vm", string.Empty, "2"));
+                worksheetPart.Worksheet.Save();
+            }
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "Metadata", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
+                WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+                Cell copiedCell = copiedPart.Worksheet.Descendants<Cell>().Single(item => item.CellReference?.Value == "A2");
+                Assert.DoesNotContain(copiedCell.GetAttributes(), attribute => attribute.LocalName == "cm" || attribute.LocalName == "vm");
             }
 
             File.Delete(sourcePath);

--- a/OfficeIMO.Tests/Excel.WorksheetOperations.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetOperations.cs
@@ -379,6 +379,47 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModePreservesRowAndColumnStyleInheritance() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageInheritedStyleSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageInheritedStyleTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                ExcelSheet source = sourceDocument.AddWorkSheet("Inherited");
+                source.CellValue(1, 1, "Row inherited");
+                source.CellValue(2, 2, "Column inherited");
+                sourceDocument.Save();
+            }
+
+            AddDefaultBoldFontStyle(sourcePath);
+            AddSourceRowAndColumnStyles(sourcePath, "Inherited");
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                targetDocument.AddWorkSheet("Existing").CellValue(1, 1, "Existing");
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "Inherited", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
+                WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+                Cell rowInheritedCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A1");
+                Cell columnInheritedCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "B2");
+                Row styledRow = copiedPart.Worksheet.Descendants<Row>().Single(row => row.RowIndex?.Value == 1U);
+                Column styledColumn = copiedPart.Worksheet.Elements<Columns>().Single().Elements<Column>().Single(column => column.Min?.Value == 2U);
+
+                Assert.Null(rowInheritedCell.StyleIndex);
+                Assert.Null(columnInheritedCell.StyleIndex);
+                Assert.NotNull(styledRow.StyleIndex);
+                Assert.NotNull(styledColumn.Style);
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
         public void Test_CopyWorkSheetFrom_PackageModeStreamSavePersistsCopiedSheet() {
             using var sourceStream = new MemoryStream();
             using var targetSeedStream = new MemoryStream();
@@ -578,6 +619,55 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeRewritesStructuredReferencesOnce() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageStructuredOnceSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageStructuredOnceTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                ExcelSheet source = sourceDocument.AddWorkSheet("Source");
+                source.CellValue(1, 1, "Amount");
+                source.CellValue(2, 1, 10);
+                source.AddTable("A1:A2", hasHeader: true, name: "Sales", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
+                source.CellValue(4, 1, "Amount");
+                source.CellValue(5, 1, 20);
+                source.AddTable("A4:A5", hasHeader: true, name: "Sales2", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
+                source.CellFormula(7, 1, "SUM(Sales[Amount])");
+                sourceDocument.Save();
+            }
+
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                ExcelSheet existing = targetDocument.AddWorkSheet("Existing");
+                existing.CellValue(1, 1, "Amount");
+                existing.CellValue(2, 1, 1);
+                existing.AddTable("A1:A2", hasHeader: true, name: "Sales", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
+                targetDocument.Save();
+            }
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Load(targetPath)) {
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "Source", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
+                WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+                string[] copiedTableNames = copiedPart.TableDefinitionParts
+                    .Select(part => part.Table.Name!.Value!)
+                    .OrderBy(name => name)
+                    .ToArray();
+                Cell formulaCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A7");
+
+                Assert.Equal(new[] { "Sales2", "Sales22" }, copiedTableNames);
+                Assert.Equal("SUM(Sales2[Amount])", formulaCell.CellFormula?.Text);
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
         public void Test_CopyWorkSheetFrom_ValuesModeKeepsReaderWriterFallback() {
             string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyValuesModeSource.xlsx");
             string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyValuesModeTarget.xlsx");
@@ -683,6 +773,44 @@ namespace OfficeIMO.Tests {
             defaultFormat.FontId = stylesheet.Fonts.Count!.Value - 1U;
             defaultFormat.ApplyFont = true;
             stylesheet.Save();
+        }
+
+        private static void AddSourceRowAndColumnStyles(string path, string sheetName) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(path, true);
+            WorksheetPart worksheetPart = GetWorksheetPartByNameForOperations(spreadsheet, sheetName);
+            Worksheet worksheet = worksheetPart.Worksheet;
+            SheetData sheetData = worksheet.GetFirstChild<SheetData>()!;
+            Stylesheet stylesheet = spreadsheet.WorkbookPart!.WorkbookStylesPart!.Stylesheet!;
+
+            stylesheet.Fonts ??= new Fonts();
+            stylesheet.Fonts.Append(new Font(new Italic()));
+            stylesheet.Fonts.Count = (uint)stylesheet.Fonts.Elements<Font>().Count();
+            uint fontId = stylesheet.Fonts.Count!.Value - 1U;
+
+            stylesheet.CellFormats ??= new CellFormats();
+            stylesheet.CellFormats.Append(new CellFormat {
+                FontId = fontId,
+                FillId = 0U,
+                BorderId = 0U,
+                FormatId = 0U,
+                ApplyFont = true
+            });
+            stylesheet.CellFormats.Count = (uint)stylesheet.CellFormats.Elements<CellFormat>().Count();
+            uint styleIndex = stylesheet.CellFormats.Count!.Value - 1U;
+
+            Row row = sheetData.Elements<Row>().Single(item => item.RowIndex?.Value == 1U);
+            row.StyleIndex = styleIndex;
+            row.CustomFormat = true;
+            worksheet.InsertBefore(new Columns(new Column {
+                Min = 2U,
+                Max = 2U,
+                Style = styleIndex,
+                Width = 14D,
+                CustomWidth = true
+            }), sheetData);
+
+            stylesheet.Save();
+            worksheet.Save();
         }
 
         private static void AddDummyDifferentialFormat(string path) {

--- a/OfficeIMO.Tests/Excel.WorksheetOperations.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetOperations.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Linq;
+using System.Data;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using OfficeIMO.Excel;
@@ -250,6 +251,128 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("SourceSales", copiedTable.Name?.Value);
                 Assert.Equal("A1:B3", copiedTable.Reference?.Value);
                 Assert.Equal("TableStyleMedium9", copiedTable.TableStyleInfo?.Name?.Value);
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModePreservesHeaderOnlyStyles() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageHeaderSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageHeaderTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                ExcelSheet source = sourceDocument.AddWorkSheet("Headers");
+                source.CellValue(1, 1, "Region");
+                source.CellValue(1, 2, "Revenue");
+                source.CellBold(1, 1, true);
+                source.CellBold(1, 2, true);
+                source.CellBackground(1, 1, "#D9EAD3");
+                source.CellBackground(1, 2, "#D9EAD3");
+                sourceDocument.Save();
+            }
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                targetDocument.AddWorkSheet("Summary").CellValue(1, 1, "Summary");
+                ExcelSheet copied = targetDocument.CopyWorkSheetFrom(sourceDocument, "Headers", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+
+                Assert.Equal("Imported", copied.Name);
+                Assert.Equal("A1:B1", copied.GetUsedRangeA1());
+                targetDocument.Save();
+            }
+
+            using (var targetDocument = ExcelDocument.Load(targetPath, readOnly: true)) {
+                Assert.True(targetDocument["Imported"].TryGetCellText(1, 1, out var header));
+                Assert.Equal("Region", header);
+                Assert.Equal("A1:B1", targetDocument["Imported"].GetUsedRangeA1());
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
+                WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+                Cell headerCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A1");
+                Assert.Equal(CellValues.InlineString, headerCell.DataType?.Value);
+                Assert.NotNull(headerCell.StyleIndex);
+                Assert.NotEqual(0U, headerCell.StyleIndex!.Value);
+
+                Stylesheet stylesheet = spreadsheet.WorkbookPart!.WorkbookStylesPart!.Stylesheet!;
+                CellFormat headerFormat = stylesheet.CellFormats!.Elements<CellFormat>().ElementAt((int)headerCell.StyleIndex!.Value);
+                Assert.True(headerFormat.ApplyFont?.Value ?? false);
+                Assert.True(headerFormat.ApplyFill?.Value ?? false);
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeDataTableReadsInlineStrings() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageInlineSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageInlineTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                ExcelSheet source = sourceDocument.AddWorkSheet("External");
+                source.CellValue(1, 1, "Name");
+                source.CellValue(2, 1, "Imported");
+                sourceDocument.Save();
+            }
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "External", "ExternalCopy", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using (var reader = ExcelDocumentReader.Open(targetPath)) {
+                var table = reader.GetSheet("ExternalCopy").ReadRangeAsDataTable("A1:A2");
+                Assert.Single(table.Columns);
+                Assert.Equal("Name", table.Columns[0].ColumnName);
+                DataRow row = Assert.Single(table.Rows.Cast<DataRow>());
+                Assert.Equal("Imported", row["Name"]);
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
+        public void Test_CopyWorkSheetFrom_ValuesModeKeepsReaderWriterFallback() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyValuesModeSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyValuesModeTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                ExcelSheet source = sourceDocument.AddWorkSheet("Source");
+                source.CellValue(1, 1, "Name");
+                source.CellValue(2, 1, "Ada");
+                source.CellBold(1, 1, true);
+                sourceDocument.Save();
+            }
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                ExcelSheet copied = targetDocument.CopyWorkSheetFrom(sourceDocument, "Source", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Values
+                });
+
+                Assert.Equal("Imported", copied.Name);
+                Assert.Equal("A1:A2", copied.GetUsedRangeA1());
+                targetDocument.Save();
+            }
+
+            using (var targetDocument = ExcelDocument.Load(targetPath, readOnly: true)) {
+                Assert.True(targetDocument["Imported"].TryGetCellText(2, 1, out var value));
+                Assert.Equal("Ada", value);
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
+                WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+                Cell headerCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A1");
+                Assert.True(headerCell.StyleIndex == null || headerCell.StyleIndex.Value == 0U);
             }
 
             File.Delete(sourcePath);

--- a/OfficeIMO.Tests/Excel.WorksheetOperations.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetOperations.cs
@@ -1027,6 +1027,126 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeRemapsExternalWorkbookReferencesInDefinedNames() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageExternalDefinedNameSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageExternalDefinedNameTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                ExcelSheet source = sourceDocument.AddWorkSheet("External");
+                source.CellFormula(1, 1, "ExternalValue");
+                sourceDocument.Save();
+            }
+
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                targetDocument.AddWorkSheet("Existing").CellFormula(1, 1, "[1]Sheet1!B1");
+                targetDocument.Save();
+            }
+
+            AddExternalWorkbookReference(sourcePath);
+            AddDefinedName(sourcePath, "ExternalValue", "[1]Sheet1!A1");
+            AddExternalWorkbookReference(targetPath);
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Load(targetPath)) {
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "External", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
+                DefinedName copiedName = Assert.Single(spreadsheet.WorkbookPart!.Workbook.DefinedNames!.Elements<DefinedName>(),
+                    name => string.Equals(name.Name?.Value, "ExternalValue", StringComparison.OrdinalIgnoreCase));
+                Assert.Equal("[2]Sheet1!A1", copiedName.Text);
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeDoesNotRemapNumericStructuredReferenceColumnsAsExternalLinks() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageNumericStructuredColumnSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageNumericStructuredColumnTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                ExcelSheet source = sourceDocument.AddWorkSheet("Structured");
+                source.CellValue(1, 1, "1");
+                source.CellValue(2, 1, 7);
+                source.AddTable("A1:A2", hasHeader: true, name: "People", style: OfficeIMO.Excel.TableStyle.TableStyleMedium2, includeAutoFilter: true);
+                source.CellFormula(4, 1, "SUM(People[1])");
+                sourceDocument.Save();
+            }
+
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                ExcelSheet existing = targetDocument.AddWorkSheet("Existing");
+                existing.CellValue(1, 1, "1");
+                existing.CellValue(2, 1, 3);
+                existing.AddTable("A1:A2", hasHeader: true, name: "People", style: OfficeIMO.Excel.TableStyle.TableStyleMedium2, includeAutoFilter: true);
+                existing.CellFormula(4, 1, "[1]Sheet1!B1");
+                targetDocument.Save();
+            }
+
+            AddExternalWorkbookReference(sourcePath);
+            AddExternalWorkbookReference(targetPath);
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Load(targetPath)) {
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "Structured", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
+                WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+                Cell copiedFormula = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A4");
+                Assert.Equal("SUM(People2[1])", copiedFormula.CellFormula?.Text);
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeStripsCopiedTableQueryBindings() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageQueryTableSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageQueryTableTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                ExcelSheet source = sourceDocument.AddWorkSheet("Query");
+                source.CellValue(1, 1, "Name");
+                source.CellValue(2, 1, "Ada");
+                source.AddTable("A1:A2", hasHeader: true, name: "QueryTable", style: OfficeIMO.Excel.TableStyle.TableStyleMedium2, includeAutoFilter: true);
+                sourceDocument.Save();
+            }
+
+            AddTableQueryBindings(sourcePath, "Query");
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "Query", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
+                WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+                Table table = Assert.Single(copiedPart.TableDefinitionParts).Table!;
+                Assert.Null(table.ConnectionId);
+                Assert.All(table.Descendants<TableColumn>(), column => Assert.Null(column.QueryTableFieldId));
+                Assert.DoesNotContain(table.Descendants<OpenXmlElement>(), element =>
+                    string.Equals(element.LocalName, "queryTable", StringComparison.Ordinal)
+                    || string.Equals(element.LocalName, "queryTableField", StringComparison.Ordinal)
+                    || string.Equals(element.LocalName, "queryTableFields", StringComparison.Ordinal));
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
         public void Test_CopyWorkSheetFrom_PackageModeStripsCellMetadataIndexes() {
             string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageMetadataSource.xlsx");
             string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageMetadataTarget.xlsx");
@@ -1312,6 +1432,32 @@ namespace OfficeIMO.Tests {
             workbookPart.Workbook.ExternalReferences ??= new ExternalReferences();
             workbookPart.Workbook.ExternalReferences.Append(new ExternalReference { Id = relationshipId });
             workbookPart.Workbook.Save();
+        }
+
+        private static void AddDefinedName(string path, string name, string formula) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(path, true);
+            Workbook workbook = spreadsheet.WorkbookPart!.Workbook;
+            workbook.DefinedNames ??= new DefinedNames();
+            workbook.DefinedNames.Append(new DefinedName(formula) { Name = name });
+            workbook.Save();
+        }
+
+        private static void AddTableQueryBindings(string path, string sheetName) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(path, true);
+            WorksheetPart worksheetPart = GetWorksheetPartByNameForOperations(spreadsheet, sheetName);
+            Table table = worksheetPart.TableDefinitionParts.Single().Table!;
+            table.ConnectionId = 1U;
+            TableColumn column = table.Descendants<TableColumn>().Single();
+            column.QueryTableFieldId = 1U;
+
+            var extensionList = table.GetFirstChild<TableExtensionList>() ?? table.AppendChild(new TableExtensionList());
+            var extension = new TableExtension { Uri = "{00000000-0000-0000-0000-000000000001}" };
+            var queryTableFields = new OpenXmlUnknownElement("x14", "queryTableFields", "http://schemas.microsoft.com/office/spreadsheetml/2009/9/main");
+            var queryTableField = new OpenXmlUnknownElement("x14", "queryTableField", "http://schemas.microsoft.com/office/spreadsheetml/2009/9/main");
+            queryTableFields.Append(queryTableField);
+            extension.Append(queryTableFields);
+            extensionList.Append(extension);
+            table.Save();
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Excel.WorksheetOperations.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetOperations.cs
@@ -342,6 +342,43 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeMapsSourceDefaultStyleToUnstyledCells() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageDefaultStyleSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageDefaultStyleTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                ExcelSheet source = sourceDocument.AddWorkSheet("StyledDefault");
+                source.CellValue(1, 1, "Default styled");
+                sourceDocument.Save();
+            }
+
+            AddDefaultBoldFontStyle(sourcePath);
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                targetDocument.AddWorkSheet("Existing").CellValue(1, 1, "Existing");
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "StyledDefault", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
+                WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+                Cell copiedCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A1");
+                Assert.NotNull(copiedCell.StyleIndex);
+
+                Stylesheet stylesheet = spreadsheet.WorkbookPart!.WorkbookStylesPart!.Stylesheet!;
+                CellFormat copiedFormat = stylesheet.CellFormats!.Elements<CellFormat>().ElementAt((int)copiedCell.StyleIndex!.Value);
+                Font copiedFont = stylesheet.Fonts!.Elements<Font>().ElementAt((int)copiedFormat.FontId!.Value);
+                Assert.NotNull(copiedFont.Bold);
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
         public void Test_CopyWorkSheetFrom_PackageModeStreamSavePersistsCopiedSheet() {
             using var sourceStream = new MemoryStream();
             using var targetSeedStream = new MemoryStream();
@@ -422,8 +459,9 @@ namespace OfficeIMO.Tests {
                 Assert.Empty(worksheet.Elements<Picture>());
                 Assert.Empty(worksheet.Elements<LegacyDrawing>());
                 Assert.Null(worksheet.GetFirstChild<PageSetup>()?.Id?.Value);
-                Assert.Empty(worksheet.Descendants<OpenXmlElement>().Where(element => element.LocalName == "queryTableParts"));
-                Assert.Empty(worksheet.Descendants<OpenXmlElement>().Where(element => element.LocalName == "pivotTableDefinition"));
+                Assert.DoesNotContain(worksheet.Descendants<OpenXmlElement>(), element => element.LocalName == "queryTableParts");
+                Assert.DoesNotContain(worksheet.Descendants<OpenXmlElement>(), element => element.LocalName == "pivotTableDefinition");
+                Assert.DoesNotContain(worksheet.Descendants<OpenXmlElement>(), element => element.LocalName == "customProperties");
             }
 
             File.Delete(sourcePath);
@@ -618,6 +656,11 @@ namespace OfficeIMO.Tests {
             worksheet.Append(new Picture { Id = "rId999" });
             worksheet.Append(new LegacyDrawing { Id = "rId998" });
             worksheet.Append(new PageSetup { Id = "rId997" });
+            var customProperties = new OpenXmlUnknownElement(string.Empty, "customProperties", "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+            var customProperty = new OpenXmlUnknownElement(string.Empty, "customPr", "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+            customProperty.SetAttribute(new OpenXmlAttribute("r", "id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships", "rId994"));
+            customProperties.Append(customProperty);
+            worksheet.Append(customProperties);
             var queryTableParts = new OpenXmlUnknownElement(string.Empty, "queryTableParts", "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
             var queryTablePart = new OpenXmlUnknownElement(string.Empty, "queryTablePart", "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
             queryTablePart.SetAttribute(new OpenXmlAttribute("r", "id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships", "rId996"));
@@ -627,6 +670,19 @@ namespace OfficeIMO.Tests {
             pivotTableDefinition.SetAttribute(new OpenXmlAttribute("r", "id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships", "rId995"));
             worksheet.Append(pivotTableDefinition);
             worksheet.Save();
+        }
+
+        private static void AddDefaultBoldFontStyle(string path) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(path, true);
+            Stylesheet stylesheet = spreadsheet.WorkbookPart!.WorkbookStylesPart!.Stylesheet!;
+            stylesheet.Fonts ??= new Fonts();
+            stylesheet.Fonts.Append(new Font(new Bold()));
+            stylesheet.Fonts.Count = (uint)stylesheet.Fonts.Elements<Font>().Count();
+
+            CellFormat defaultFormat = stylesheet.CellFormats!.Elements<CellFormat>().First();
+            defaultFormat.FontId = stylesheet.Fonts.Count!.Value - 1U;
+            defaultFormat.ApplyFont = true;
+            stylesheet.Save();
         }
 
         private static void AddDummyDifferentialFormat(string path) {

--- a/OfficeIMO.Tests/Excel.WorksheetOperations.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetOperations.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Linq;
 using System.Data;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using OfficeIMO.Excel;
@@ -341,6 +342,134 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeStreamSavePersistsCopiedSheet() {
+            using var sourceStream = new MemoryStream();
+            using var targetSeedStream = new MemoryStream();
+            using var savedStream = new MemoryStream();
+
+            using (var sourceDocument = ExcelDocument.Create(sourceStream, autoSave: false)) {
+                sourceDocument.AddWorkSheet("Source").CellValue(1, 1, "Copied");
+                sourceDocument.Save(sourceStream);
+            }
+
+            using (var targetDocument = ExcelDocument.Create(targetSeedStream, autoSave: false)) {
+                targetDocument.AddWorkSheet("Existing").CellValue(1, 1, "Existing");
+                targetDocument.Save(targetSeedStream);
+            }
+
+            sourceStream.Position = 0;
+            targetSeedStream.Position = 0;
+            using (var sourceDocument = ExcelDocument.Load(sourceStream, readOnly: true))
+            using (var targetDocument = ExcelDocument.Load(targetSeedStream, readOnly: false, autoSave: false)) {
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "Source", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save(savedStream);
+            }
+
+            savedStream.Position = 0;
+            using var reloaded = ExcelDocument.Load(savedStream, readOnly: true);
+            Assert.Equal(2, reloaded.Sheets.Count);
+            Assert.True(reloaded["Imported"].TryGetCellText(1, 1, out var value));
+            Assert.Equal("Copied", value);
+        }
+
+        [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeRemapsStylesAndConditionalFormatDxf() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageStyleSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageStyleTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                ExcelSheet source = sourceDocument.AddWorkSheet("Styled");
+                source.CellValue(1, 1, 10);
+                source.CellBackground(1, 1, "#D9EAD3");
+                sourceDocument.Save();
+            }
+
+            AddSourceWorksheetPackageArtifacts(sourcePath, "Styled");
+
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                targetDocument.AddWorkSheet("Existing").CellValue(1, 1, "Existing");
+                targetDocument.Save();
+            }
+
+            AddDummyDifferentialFormat(targetPath);
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Load(targetPath)) {
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "Styled", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
+                WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+                Worksheet worksheet = copiedPart.Worksheet;
+                Stylesheet stylesheet = spreadsheet.WorkbookPart!.WorkbookStylesPart!.Stylesheet!;
+                uint cellFormatCount = (uint)stylesheet.CellFormats!.Elements<CellFormat>().Count();
+                uint differentialFormatCount = (uint)stylesheet.DifferentialFormats!.Elements<DifferentialFormat>().Count();
+
+                Row row = Assert.Single(worksheet.Descendants<Row>(), item => item.RowIndex?.Value == 1U);
+                Column column = Assert.Single(worksheet.Elements<Columns>().Single().Elements<Column>());
+                ConditionalFormattingRule rule = Assert.Single(worksheet.Descendants<ConditionalFormattingRule>());
+
+                Assert.True(row.StyleIndex?.Value > 0U && row.StyleIndex.Value < cellFormatCount);
+                Assert.True(column.Style?.Value > 0U && column.Style.Value < cellFormatCount);
+                Assert.True(rule.FormatId?.Value == 1U && rule.FormatId.Value < differentialFormatCount);
+                Assert.Empty(worksheet.Elements<OleObjects>());
+                Assert.Empty(worksheet.Elements<Controls>());
+                Assert.Empty(worksheet.Elements<Picture>());
+                Assert.Empty(worksheet.Elements<LegacyDrawing>());
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeRewritesStructuredReferencesInWorksheetFormulas() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageStructuredSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageStructuredTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                ExcelSheet source = sourceDocument.AddWorkSheet("Source");
+                source.CellValue(1, 1, "Name");
+                source.CellValue(2, 1, "Ada");
+                source.AddTable("A1:A2", hasHeader: true, name: "People", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
+                source.ValidationCustomFormula("B2", "COUNTIF(People[Name],B2)>0");
+                sourceDocument.Save();
+            }
+
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                ExcelSheet existing = targetDocument.AddWorkSheet("Existing");
+                existing.CellValue(1, 1, "Name");
+                existing.CellValue(2, 1, "Grace");
+                existing.AddTable("A1:A2", hasHeader: true, name: "People", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
+                targetDocument.Save();
+            }
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Load(targetPath)) {
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "Source", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
+                WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+                string copiedTableName = Assert.Single(copiedPart.TableDefinitionParts).Table.Name!.Value!;
+                Assert.NotEqual("People", copiedTableName);
+                Formula1 formula = Assert.Single(copiedPart.Worksheet.Descendants<Formula1>());
+                Assert.Equal($"COUNTIF({copiedTableName}[Name],B2)>0", formula.Text);
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
         public void Test_CopyWorkSheetFrom_ValuesModeKeepsReaderWriterFallback() {
             string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyValuesModeSource.xlsx");
             string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyValuesModeTarget.xlsx");
@@ -377,6 +506,57 @@ namespace OfficeIMO.Tests {
 
             File.Delete(sourcePath);
             File.Delete(targetPath);
+        }
+
+        private static void AddSourceWorksheetPackageArtifacts(string path, string sheetName) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(path, true);
+            WorksheetPart worksheetPart = GetWorksheetPartByNameForOperations(spreadsheet, sheetName);
+            Worksheet worksheet = worksheetPart.Worksheet;
+            Cell cell = worksheet.Descendants<Cell>().Single(item => item.CellReference?.Value == "A1");
+            uint styleIndex = cell.StyleIndex?.Value ?? 0U;
+
+            SheetData sheetData = worksheet.GetFirstChild<SheetData>()!;
+            Row row = sheetData.Elements<Row>().Single(item => item.RowIndex?.Value == 1U);
+            row.StyleIndex = styleIndex;
+            row.CustomFormat = true;
+            worksheet.InsertBefore(new Columns(new Column {
+                Min = 1U,
+                Max = 1U,
+                Style = styleIndex,
+                Width = 14D,
+                CustomWidth = true
+            }), sheetData);
+
+            Stylesheet stylesheet = spreadsheet.WorkbookPart!.WorkbookStylesPart!.Stylesheet!;
+            stylesheet.DifferentialFormats ??= new DifferentialFormats();
+            stylesheet.DifferentialFormats.Append(new DifferentialFormat(new Fill(new PatternFill(new ForegroundColor { Rgb = "FFFF0000" }) {
+                PatternType = PatternValues.Solid
+            })));
+            stylesheet.DifferentialFormats.Count = (uint)stylesheet.DifferentialFormats.Elements<DifferentialFormat>().Count();
+            stylesheet.Save();
+
+            worksheet.Append(new ConditionalFormatting(
+                new ConditionalFormattingRule(new Formula("A1>0")) {
+                    Type = ConditionalFormatValues.Expression,
+                    FormatId = 0U,
+                    Priority = 1
+                }) {
+                SequenceOfReferences = new ListValue<StringValue> { InnerText = "A1" }
+            });
+            worksheet.Append(new OleObjects());
+            worksheet.Append(new Controls());
+            worksheet.Append(new Picture { Id = "rId999" });
+            worksheet.Append(new LegacyDrawing { Id = "rId998" });
+            worksheet.Save();
+        }
+
+        private static void AddDummyDifferentialFormat(string path) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(path, true);
+            Stylesheet stylesheet = spreadsheet.WorkbookPart!.WorkbookStylesPart!.Stylesheet!;
+            stylesheet.DifferentialFormats ??= new DifferentialFormats();
+            stylesheet.DifferentialFormats.Append(new DifferentialFormat(new Font(new Bold())));
+            stylesheet.DifferentialFormats.Count = (uint)stylesheet.DifferentialFormats.Elements<DifferentialFormat>().Count();
+            stylesheet.Save();
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Excel.WorksheetOperations.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetOperations.cs
@@ -466,6 +466,38 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeMaterializesDeferredDirectExports() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageDeferredSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageDeferredTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath))
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                ExcelSheet source = sourceDocument.AddWorkSheet("Source");
+                var table = new DataTable();
+                table.Columns.Add("Name", typeof(string));
+                table.Columns.Add("Count", typeof(int));
+                table.Rows.Add("Alpha", 1);
+                table.Rows.Add("Beta", 2);
+                source.InsertDataTableAsTable(table, tableName: "Items");
+
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "Source", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using (var targetDocument = ExcelDocument.Load(targetPath, readOnly: true)) {
+                Assert.True(targetDocument["Imported"].TryGetCellText(1, 1, out var header));
+                Assert.True(targetDocument["Imported"].TryGetCellText(3, 1, out var value));
+                Assert.Equal("Name", header);
+                Assert.Equal("Beta", value);
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
         public void Test_CopyWorkSheetFrom_PackageModeRewritesStructuredReferencesInWorksheetFormulas() {
             string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageStructuredSource.xlsx");
             string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageStructuredTarget.xlsx");

--- a/OfficeIMO.Tests/Excel.WorksheetOperations.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetOperations.cs
@@ -503,6 +503,12 @@ namespace OfficeIMO.Tests {
                 Assert.DoesNotContain(worksheet.Descendants<OpenXmlElement>(), element => element.LocalName == "queryTableParts");
                 Assert.DoesNotContain(worksheet.Descendants<OpenXmlElement>(), element => element.LocalName == "pivotTableDefinition");
                 Assert.DoesNotContain(worksheet.Descendants<OpenXmlElement>(), element => element.LocalName == "customProperties");
+                Assert.DoesNotContain(worksheet.Descendants<OpenXmlElement>(), element => element.LocalName == "slicerList");
+                Assert.DoesNotContain(worksheet.Descendants<OpenXmlElement>(), element => element.LocalName == "timelineRefs");
+
+                OpenXmlElement extensionRule = Assert.Single(worksheet.Descendants<OpenXmlElement>(),
+                    element => element.LocalName == "cfRule" && element.NamespaceUri.IndexOf("spreadsheetml/2009", StringComparison.OrdinalIgnoreCase) >= 0);
+                Assert.Equal("1", extensionRule.GetAttribute("dxfId", string.Empty).Value);
             }
 
             File.Delete(sourcePath);
@@ -587,6 +593,8 @@ namespace OfficeIMO.Tests {
                 source.CellValue(2, 1, "Ada");
                 source.AddTable("A1:A2", hasHeader: true, name: "People", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
                 source.ValidationCustomFormula("B2", "COUNTIF(People[Name],B2)>0");
+                source.CellFormula(3, 1, "ROWS(People)");
+                source.CellFormula(4, 1, "'People'!A1+ROWS(People)");
                 sourceDocument.Save();
             }
 
@@ -611,7 +619,11 @@ namespace OfficeIMO.Tests {
                 string copiedTableName = Assert.Single(copiedPart.TableDefinitionParts).Table.Name!.Value!;
                 Assert.NotEqual("People", copiedTableName);
                 Formula1 formula = Assert.Single(copiedPart.Worksheet.Descendants<Formula1>());
+                Cell bareTableFormula = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A3");
+                Cell sheetQualifiedFormula = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A4");
                 Assert.Equal($"COUNTIF({copiedTableName}[Name],B2)>0", formula.Text);
+                Assert.Equal($"ROWS({copiedTableName})", bareTableFormula.CellFormula?.Text);
+                Assert.Equal($"'People'!A1+ROWS({copiedTableName})", sheetQualifiedFormula.CellFormula?.Text);
             }
 
             File.Delete(sourcePath);
@@ -839,6 +851,34 @@ namespace OfficeIMO.Tests {
             var pivotTableDefinition = new OpenXmlUnknownElement(string.Empty, "pivotTableDefinition", "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
             pivotTableDefinition.SetAttribute(new OpenXmlAttribute("r", "id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships", "rId995"));
             worksheet.Append(pivotTableDefinition);
+
+            var extensionList = worksheet.GetFirstChild<WorksheetExtensionList>() ?? worksheet.AppendChild(new WorksheetExtensionList());
+            var slicerExtension = new WorksheetExtension { Uri = "{A8765BA9-456A-4DAB-B4F3-ACF838C121DE}" };
+            var slicerList = new OpenXmlUnknownElement("x14", "slicerList", "http://schemas.microsoft.com/office/spreadsheetml/2009/9/main");
+            var slicer = new OpenXmlUnknownElement("x14", "slicer", "http://schemas.microsoft.com/office/spreadsheetml/2009/9/main");
+            slicer.SetAttribute(new OpenXmlAttribute("r", "id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships", "rId993"));
+            slicerList.Append(slicer);
+            slicerExtension.Append(slicerList);
+            extensionList.Append(slicerExtension);
+
+            var timelineExtension = new WorksheetExtension { Uri = "{7E03D99C-DC04-49d9-9315-930204A7B6E9}" };
+            var timelineRefs = new OpenXmlUnknownElement("x15", "timelineRefs", "http://schemas.microsoft.com/office/spreadsheetml/2010/11/main");
+            var timelineRef = new OpenXmlUnknownElement("x15", "timelineRef", "http://schemas.microsoft.com/office/spreadsheetml/2010/11/main");
+            timelineRef.SetAttribute(new OpenXmlAttribute("r", "id", "http://schemas.openxmlformats.org/officeDocument/2006/relationships", "rId992"));
+            timelineRefs.Append(timelineRef);
+            timelineExtension.Append(timelineRefs);
+            extensionList.Append(timelineExtension);
+
+            var conditionalExtension = new WorksheetExtension { Uri = "{78C0D931-6437-407d-A8EE-F0AAD7539E65}" };
+            var conditionalFormattings = new OpenXmlUnknownElement("x14", "conditionalFormattings", "http://schemas.microsoft.com/office/spreadsheetml/2009/9/main");
+            var conditionalFormatting = new OpenXmlUnknownElement("x14", "conditionalFormatting", "http://schemas.microsoft.com/office/spreadsheetml/2009/9/main");
+            var extensionRule = new OpenXmlUnknownElement("x14", "cfRule", "http://schemas.microsoft.com/office/spreadsheetml/2009/9/main");
+            extensionRule.SetAttribute(new OpenXmlAttribute(string.Empty, "type", string.Empty, "expression"));
+            extensionRule.SetAttribute(new OpenXmlAttribute(string.Empty, "dxfId", string.Empty, "0"));
+            conditionalFormatting.Append(extensionRule);
+            conditionalFormattings.Append(conditionalFormatting);
+            conditionalExtension.Append(conditionalFormattings);
+            extensionList.Append(conditionalExtension);
             worksheet.Save();
         }
 

--- a/OfficeIMO.Tests/Excel.WorksheetOperations.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetOperations.cs
@@ -668,6 +668,86 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeResolvesThemeAndIndexedStyleColors() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageThemeColorSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageThemeColorTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                ExcelSheet source = sourceDocument.AddWorkSheet("ThemeStyled");
+                source.CellValue(1, 1, "Theme styled");
+                sourceDocument.Save();
+            }
+
+            AddThemeAndIndexedStyle(sourcePath, "ThemeStyled");
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                targetDocument.AddWorkSheet("Existing").CellValue(1, 1, "Existing");
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "ThemeStyled", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
+                WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+                Cell copiedCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A1");
+                Stylesheet stylesheet = spreadsheet.WorkbookPart!.WorkbookStylesPart!.Stylesheet!;
+                CellFormat copiedFormat = stylesheet.CellFormats!.Elements<CellFormat>().ElementAt((int)copiedCell.StyleIndex!.Value);
+                Font copiedFont = stylesheet.Fonts!.Elements<Font>().ElementAt((int)copiedFormat.FontId!.Value);
+                Fill copiedFill = stylesheet.Fills!.Elements<Fill>().ElementAt((int)copiedFormat.FillId!.Value);
+                Color fontColor = copiedFont.Color!;
+                ForegroundColor fillColor = copiedFill.PatternFill!.ForegroundColor!;
+
+                Assert.NotNull(fontColor.Rgb);
+                Assert.Null(fontColor.Theme);
+                Assert.NotNull(fillColor.Rgb);
+                Assert.Null(fillColor.Indexed);
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeRemovesStaleCalculationChainForCopiedFormulas() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageCalcChainSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageCalcChainTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                ExcelSheet source = sourceDocument.AddWorkSheet("FormulaSource");
+                source.CellValue(1, 1, 10);
+                source.CellFormula(2, 1, "A1*2");
+                sourceDocument.Save();
+            }
+
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                targetDocument.AddWorkSheet("Existing").CellValue(1, 1, "Existing");
+                targetDocument.Save();
+            }
+
+            AddDummyCalculationChain(targetPath);
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Load(targetPath)) {
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "FormulaSource", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
+                Assert.Null(spreadsheet.WorkbookPart!.CalculationChainPart);
+                WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+                Cell formulaCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A2");
+                Assert.Equal("A1*2", formulaCell.CellFormula?.Text);
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
         public void Test_CopyWorkSheetFrom_ValuesModeKeepsReaderWriterFallback() {
             string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyValuesModeSource.xlsx");
             string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyValuesModeTarget.xlsx");
@@ -820,6 +900,57 @@ namespace OfficeIMO.Tests {
             stylesheet.DifferentialFormats.Append(new DifferentialFormat(new Font(new Bold())));
             stylesheet.DifferentialFormats.Count = (uint)stylesheet.DifferentialFormats.Elements<DifferentialFormat>().Count();
             stylesheet.Save();
+        }
+
+        private static void AddThemeAndIndexedStyle(string path, string sheetName) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(path, true);
+            WorksheetPart worksheetPart = GetWorksheetPartByNameForOperations(spreadsheet, sheetName);
+            Worksheet worksheet = worksheetPart.Worksheet;
+            Cell cell = worksheet.Descendants<Cell>().Single(item => item.CellReference?.Value == "A1");
+            Stylesheet stylesheet = spreadsheet.WorkbookPart!.WorkbookStylesPart!.Stylesheet!;
+
+            stylesheet.Fonts ??= new Fonts();
+            stylesheet.Fonts.Append(new Font(new Color { Theme = 4U }));
+            stylesheet.Fonts.Count = (uint)stylesheet.Fonts.Elements<Font>().Count();
+            uint fontId = stylesheet.Fonts.Count!.Value - 1U;
+
+            stylesheet.Fills ??= new Fills();
+            stylesheet.Fills.Append(new Fill(new PatternFill(new ForegroundColor { Indexed = 10U }) {
+                PatternType = PatternValues.Solid
+            }));
+            stylesheet.Fills.Count = (uint)stylesheet.Fills.Elements<Fill>().Count();
+            uint fillId = stylesheet.Fills.Count!.Value - 1U;
+
+            stylesheet.CellFormats ??= new CellFormats();
+            stylesheet.CellFormats.Append(new CellFormat {
+                FontId = fontId,
+                FillId = fillId,
+                BorderId = 0U,
+                FormatId = 0U,
+                ApplyFont = true,
+                ApplyFill = true
+            });
+            stylesheet.CellFormats.Count = (uint)stylesheet.CellFormats.Elements<CellFormat>().Count();
+
+            cell.StyleIndex = stylesheet.CellFormats.Count!.Value - 1U;
+            stylesheet.Save();
+            worksheet.Save();
+        }
+
+        private static void AddDummyCalculationChain(string path) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(path, true);
+            WorkbookPart workbookPart = spreadsheet.WorkbookPart!;
+            if (workbookPart.CalculationChainPart != null) {
+                workbookPart.DeletePart(workbookPart.CalculationChainPart);
+            }
+
+            CalculationChainPart calculationChainPart = workbookPart.AddNewPart<CalculationChainPart>();
+            calculationChainPart.CalculationChain = new CalculationChain(
+                new CalculationCell {
+                    CellReference = "A1",
+                    SheetId = 1
+                });
+            calculationChainPart.CalculationChain.Save();
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Excel.WorksheetOperations.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetOperations.cs
@@ -1147,6 +1147,84 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeSavesTableFormulaExternalReferenceRemaps() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageTableExternalFormulaSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageTableExternalFormulaTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                ExcelSheet source = sourceDocument.AddWorkSheet("TableFormula");
+                source.CellValue(1, 1, "Name");
+                source.CellValue(1, 2, "External");
+                source.CellValue(2, 1, "Ada");
+                source.CellValue(2, 2, 0);
+                source.AddTable("A1:B2", hasHeader: true, name: "ExternalTable", style: OfficeIMO.Excel.TableStyle.TableStyleMedium2, includeAutoFilter: true);
+                sourceDocument.Save();
+            }
+
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                targetDocument.AddWorkSheet("Existing").CellFormula(1, 1, "[1]Sheet1!B1");
+                targetDocument.Save();
+            }
+
+            AddExternalWorkbookReference(sourcePath);
+            AddTableCalculatedColumnFormula(sourcePath, "TableFormula", "External", "[1]Sheet1!A1");
+            AddExternalWorkbookReference(targetPath);
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Load(targetPath)) {
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "TableFormula", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
+                WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+                Table table = Assert.Single(copiedPart.TableDefinitionParts).Table!;
+                CalculatedColumnFormula formula = Assert.Single(table.Descendants<CalculatedColumnFormula>());
+                Assert.Equal("[2]Sheet1!A1", formula.Text);
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeMaterializesTargetDeferredImportsBeforeCopy() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageDeferredTargetSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageDeferredTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                sourceDocument.AddWorkSheet("Source").CellValue(1, 1, "Copied");
+                sourceDocument.Save();
+            }
+
+            var dataSet = new DataSet("Deferred");
+            DataTable table = dataSet.Tables.Add("Pending");
+            table.Columns.Add("Name", typeof(string));
+            table.Rows.Add("Ada");
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                targetDocument.InsertDataSet(dataSet, createTables: true, autoFit: false);
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "Source", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using (var reloaded = ExcelDocument.Load(targetPath, readOnly: true)) {
+                Assert.True(reloaded["Pending"].TryGetCellText(2, 1, out var pendingValue));
+                Assert.Equal("Ada", pendingValue);
+                Assert.True(reloaded["Imported"].TryGetCellText(1, 1, out var copiedValue));
+                Assert.Equal("Copied", copiedValue);
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
         public void Test_CopyWorkSheetFrom_PackageModeStripsCellMetadataIndexes() {
             string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageMetadataSource.xlsx");
             string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageMetadataTarget.xlsx");
@@ -1457,6 +1535,17 @@ namespace OfficeIMO.Tests {
             queryTableFields.Append(queryTableField);
             extension.Append(queryTableFields);
             extensionList.Append(extension);
+            table.Save();
+        }
+
+        private static void AddTableCalculatedColumnFormula(string path, string sheetName, string columnName, string formula) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(path, true);
+            WorksheetPart worksheetPart = GetWorksheetPartByNameForOperations(spreadsheet, sheetName);
+            Table table = worksheetPart.TableDefinitionParts.Single().Table!;
+            TableColumn column = table.Descendants<TableColumn>()
+                .Single(item => string.Equals(item.Name?.Value, columnName, StringComparison.OrdinalIgnoreCase));
+            column.RemoveAllChildren<CalculatedColumnFormula>();
+            column.Append(new CalculatedColumnFormula(formula));
             table.Save();
         }
 

--- a/OfficeIMO.Tests/Excel.WorksheetOperations.cs
+++ b/OfficeIMO.Tests/Excel.WorksheetOperations.cs
@@ -593,9 +593,15 @@ namespace OfficeIMO.Tests {
                 source.CellValue(1, 1, "Name");
                 source.CellValue(2, 1, "Ada");
                 source.AddTable("A1:A2", hasHeader: true, name: "People", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
+                source.CellValue(1, 3, "People");
+                source.CellValue(1, 4, "Amount");
+                source.CellValue(2, 3, "Ada");
+                source.CellValue(2, 4, 10);
+                source.AddTable("C1:D2", hasHeader: true, name: "Sales", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
                 source.ValidationCustomFormula("B2", "COUNTIF(People[Name],B2)>0");
                 source.CellFormula(3, 1, "ROWS(People)");
                 source.CellFormula(4, 1, "'People'!A1+ROWS(People)");
+                source.CellFormula(5, 1, "SUM(Sales[People])+ROWS(People)");
                 sourceDocument.Save();
             }
 
@@ -617,14 +623,18 @@ namespace OfficeIMO.Tests {
 
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
                 WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
-                string copiedTableName = Assert.Single(copiedPart.TableDefinitionParts).Table.Name!.Value!;
+                string copiedTableName = copiedPart.TableDefinitionParts
+                    .Select(part => part.Table.Name!.Value!)
+                    .Single(name => !string.Equals(name, "Sales", StringComparison.OrdinalIgnoreCase));
                 Assert.NotEqual("People", copiedTableName);
                 Formula1 formula = Assert.Single(copiedPart.Worksheet.Descendants<Formula1>());
                 Cell bareTableFormula = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A3");
                 Cell sheetQualifiedFormula = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A4");
+                Cell bracketedColumnFormula = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A5");
                 Assert.Equal($"COUNTIF({copiedTableName}[Name],B2)>0", formula.Text);
                 Assert.Equal($"ROWS({copiedTableName})", bareTableFormula.CellFormula?.Text);
                 Assert.Equal($"'People'!A1+ROWS({copiedTableName})", sheetQualifiedFormula.CellFormula?.Text);
+                Assert.Equal($"SUM(Sales[People])+ROWS({copiedTableName})", bracketedColumnFormula.CellFormula?.Text);
             }
 
             File.Delete(sourcePath);
@@ -667,6 +677,53 @@ namespace OfficeIMO.Tests {
                 Assert.NotEqual("SUM", copiedTableName);
                 Cell formulaCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A4");
                 Assert.Equal($"SUM(A2:A2)+ROWS({copiedTableName})", formulaCell.CellFormula?.Text);
+            }
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeRewritesTableDisplayNameReferences() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageDisplayNameSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageDisplayNameTarget.xlsx");
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                ExcelSheet source = sourceDocument.AddWorkSheet("Source");
+                source.CellValue(1, 1, "Amount");
+                source.CellValue(2, 1, 10);
+                source.AddTable("A1:A2", hasHeader: true, name: "Internal", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
+                source.CellFormula(4, 1, "SUM(Visible[Amount])");
+                sourceDocument.Save();
+            }
+
+            SetTableDisplayName(sourcePath, "Source", "Internal", "Visible");
+
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                ExcelSheet existing = targetDocument.AddWorkSheet("Existing");
+                existing.CellValue(1, 1, "Amount");
+                existing.CellValue(2, 1, 20);
+                existing.AddTable("A1:A2", hasHeader: true, name: "Internal", OfficeIMO.Excel.TableStyle.TableStyleMedium9);
+                targetDocument.Save();
+            }
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Load(targetPath)) {
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "Source", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
+                WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+                Table copiedTable = Assert.Single(copiedPart.TableDefinitionParts).Table;
+                string copiedTableName = copiedTable.Name!.Value!;
+                Cell formulaCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A4");
+
+                Assert.NotEqual("Internal", copiedTableName);
+                Assert.Equal(copiedTableName, copiedTable.DisplayName?.Value);
+                Assert.Equal($"SUM({copiedTableName}[Amount])", formulaCell.CellFormula?.Text);
             }
 
             File.Delete(sourcePath);
@@ -856,6 +913,42 @@ namespace OfficeIMO.Tests {
             using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false);
             WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
             Cell dateCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A2");
+            Assert.Equal(date.ToOADate(), double.Parse(dateCell.CellValue!.Text, CultureInfo.InvariantCulture), 6);
+
+            File.Delete(sourcePath);
+            File.Delete(targetPath);
+        }
+
+        [Fact]
+        public void Test_CopyWorkSheetFrom_PackageModeConvertsDateSerialsWithInheritedRowStyle() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageDateSystemInheritedRowSource.xlsx");
+            string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyPackageDateSystemInheritedRowTarget.xlsx");
+            var date = new DateTime(2026, 6, 23);
+
+            using (var sourceDocument = ExcelDocument.Create(sourcePath)) {
+                sourceDocument.DateSystem = ExcelDateSystem.NineteenFour;
+                ExcelSheet source = sourceDocument.AddWorkSheet("Dates");
+                source.CellValue(1, 1, "Created");
+                source.CellValue(2, 1, date);
+                sourceDocument.Save();
+            }
+
+            MoveCellStyleToRow(sourcePath, "Dates", "A2");
+
+            using (var sourceDocument = ExcelDocument.Load(sourcePath, readOnly: true))
+            using (var targetDocument = ExcelDocument.Create(targetPath)) {
+                targetDocument.CopyWorkSheetFrom(sourceDocument, "Dates", "Imported", SheetNameValidationMode.Sanitize, new ExcelWorksheetCopyOptions {
+                    CopyMode = ExcelWorksheetCopyMode.Package
+                });
+                targetDocument.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false);
+            WorksheetPart copiedPart = GetWorksheetPartByNameForOperations(spreadsheet, "Imported");
+            Cell dateCell = copiedPart.Worksheet.Descendants<Cell>().Single(cell => cell.CellReference?.Value == "A2");
+            Row row = copiedPart.Worksheet.Descendants<Row>().Single(item => item.RowIndex?.Value == 2U);
+            Assert.Null(dateCell.StyleIndex);
+            Assert.NotNull(row.StyleIndex);
             Assert.Equal(date.ToOADate(), double.Parse(dateCell.CellValue!.Text, CultureInfo.InvariantCulture), 6);
 
             File.Delete(sourcePath);
@@ -1493,6 +1586,29 @@ namespace OfficeIMO.Tests {
             }
 
             File.Delete(filePath);
+        }
+
+        private static void SetTableDisplayName(string path, string sheetName, string tableName, string displayName) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(path, true);
+            WorksheetPart worksheetPart = GetWorksheetPartByNameForOperations(spreadsheet, sheetName);
+            Table table = worksheetPart.TableDefinitionParts
+                .Select(part => part.Table)
+                .Single(table => string.Equals(table?.Name?.Value, tableName, StringComparison.OrdinalIgnoreCase));
+            table.DisplayName = displayName;
+            table.Save();
+        }
+
+        private static void MoveCellStyleToRow(string path, string sheetName, string cellReference) {
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(path, true);
+            WorksheetPart worksheetPart = GetWorksheetPartByNameForOperations(spreadsheet, sheetName);
+            Cell cell = worksheetPart.Worksheet.Descendants<Cell>().Single(item => item.CellReference?.Value == cellReference);
+            Assert.NotNull(cell.StyleIndex);
+            (int rowIndex, _) = A1.ParseCellRef(cellReference);
+            Row row = worksheetPart.Worksheet.Descendants<Row>().Single(item => item.RowIndex?.Value == (uint)rowIndex);
+            row.StyleIndex = cell.StyleIndex!.Value;
+            row.CustomFormat = true;
+            cell.StyleIndex = null;
+            worksheetPart.Worksheet.Save();
         }
 
         private static WorksheetPart GetWorksheetPartByNameForOperations(SpreadsheetDocument document, string sheetName) {


### PR DESCRIPTION
## Summary
- add reusable OfficeIMO Excel column format plans that resolve columns by header
- apply preset/custom number formats through ExcelSheet while returning missing-header results
- cover text, currency, percent, and date formatting with an Excel XML regression test

## Validation
- dotnet build OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Release -m:1 --no-restore
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release --framework net8.0 --filter "FullyQualifiedName=OfficeIMO.Tests.Excel.Test_ExcelBestOfBar_ColumnFormatPlan_AppliesHeaderFormats" -m:1 --no-restore