### PR TITLE
Add Excel image placement helpers

### DIFF
--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Models.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Models.cs
@@ -92,17 +92,19 @@ namespace OfficeIMO.Excel.Pdf {
         }
 
         private sealed class WorksheetImageExportData {
-            public WorksheetImageExportData(byte[] bytes, double widthPoints, double heightPoints, string cellReference) {
+            public WorksheetImageExportData(byte[] bytes, double widthPoints, double heightPoints, string cellReference, double rotationDegrees) {
                 Bytes = bytes;
                 WidthPoints = widthPoints;
                 HeightPoints = heightPoints;
                 CellReference = cellReference;
+                RotationDegrees = rotationDegrees;
             }
 
             public byte[] Bytes { get; }
             public double WidthPoints { get; }
             public double HeightPoints { get; }
             public string CellReference { get; }
+            public double RotationDegrees { get; }
         }
 
         private sealed class WorksheetChartExportData {

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.TableChunks.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.TableChunks.cs
@@ -393,7 +393,7 @@ namespace OfficeIMO.Excel.Pdf {
 
             var pdfImages = new List<PdfCore.PdfTableCellImage>(images.Count);
             foreach (WorksheetImageExportData image in images) {
-                pdfImages.Add(new PdfCore.PdfTableCellImage(image.Bytes, image.WidthPoints, image.HeightPoints, CreateConverterImageStyle()));
+                pdfImages.Add(new PdfCore.PdfTableCellImage(image.Bytes, image.WidthPoints, image.HeightPoints, CreateConverterImageStyle(image)));
             }
 
             return pdfImages;

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.WorksheetContent.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.WorksheetContent.cs
@@ -90,7 +90,7 @@ namespace OfficeIMO.Excel.Pdf {
                     continue;
                 }
 
-                images.Add(new WorksheetImageExportData(bytes, PixelsToPoints(image.WidthPixels), PixelsToPoints(image.HeightPixels), A1.CellReference(image.RowIndex, image.ColumnIndex)));
+                images.Add(new WorksheetImageExportData(bytes, PixelsToPoints(image.WidthPixels), PixelsToPoints(image.HeightPixels), A1.CellReference(image.RowIndex, image.ColumnIndex), image.RotationDegrees));
             }
 
             return images;

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.cs
@@ -43,7 +43,7 @@ namespace OfficeIMO.Excel.Pdf {
                         IReadOnlyDictionary<string, IReadOnlyList<WorksheetImageExportData>> imagesByCellReference = CreateWorksheetImageMap(plan);
                         foreach (WorksheetImageExportData image in plan.Images) {
                             if (!imagesByCellReference.ContainsKey(NormalizeCellReference(image.CellReference))) {
-                                item.Image(image.Bytes, image.WidthPoints, image.HeightPoints, PdfCore.PdfAlign.Left, spacingBefore: 4, spacingAfter: 6, style: CreateConverterImageStyle());
+                                item.Image(image.Bytes, image.WidthPoints, image.HeightPoints, PdfCore.PdfAlign.Left, spacingBefore: 4, spacingAfter: 6, style: CreateConverterImageStyle(image));
                             }
                         }
 
@@ -79,6 +79,12 @@ namespace OfficeIMO.Excel.Pdf {
         private static PdfCore.PdfImageStyle CreateConverterImageStyle() => new() {
             ScaleDownToFit = true
         };
+
+        private static PdfCore.PdfImageStyle CreateConverterImageStyle(WorksheetImageExportData image) {
+            PdfCore.PdfImageStyle style = CreateConverterImageStyle();
+            style.RotationAngle = image.RotationDegrees;
+            return style;
+        }
 
         /// <summary>
         /// Converts an Excel workbook to PDF bytes.

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.cs
@@ -82,7 +82,7 @@ namespace OfficeIMO.Excel.Pdf {
 
         private static PdfCore.PdfImageStyle CreateConverterImageStyle(WorksheetImageExportData image) {
             PdfCore.PdfImageStyle style = CreateConverterImageStyle();
-            style.RotationAngle = image.RotationDegrees;
+            style.RotationAngle = -image.RotationDegrees;
             return style;
         }
 

--- a/OfficeIMO.Excel/ExcelImage.cs
+++ b/OfficeIMO.Excel/ExcelImage.cs
@@ -400,7 +400,7 @@ namespace OfficeIMO.Excel {
                 .Elements<DocumentFormat.OpenXml.Spreadsheet.Column>()
                 .FirstOrDefault(item => item.Min != null && item.Max != null && item.Min.Value <= (uint)columnIndex && item.Max.Value >= (uint)columnIndex);
             if (column?.Hidden?.Value == true) {
-                return 1;
+                return 0;
             }
 
             double width = column?.Width?.Value > 0 && column.CustomWidth?.Value == true

--- a/OfficeIMO.Excel/ExcelImage.cs
+++ b/OfficeIMO.Excel/ExcelImage.cs
@@ -210,6 +210,8 @@ namespace OfficeIMO.Excel {
             if (extent != null) {
                 extent.Cx = cx;
                 extent.Cy = cy;
+            } else if (_anchor is Xdr.TwoCellAnchor twoCellAnchor) {
+                ResizeTwoCellAnchor(twoCellAnchor, widthPixels, heightPixels);
             }
 
             var transform = _picture.ShapeProperties?.GetFirstChild<A.Transform2D>();
@@ -221,6 +223,35 @@ namespace OfficeIMO.Excel {
 
             Save();
             return this;
+        }
+
+        private void ResizeTwoCellAnchor(Xdr.TwoCellAnchor anchor, int widthPixels, int heightPixels) {
+            Xdr.FromMarker? fromMarker = anchor.FromMarker;
+            Xdr.ToMarker? toMarker = anchor.ToMarker;
+            if (fromMarker == null || toMarker == null) {
+                return;
+            }
+
+            WorksheetPart? worksheetPart = _drawingsPart.GetParentParts().OfType<WorksheetPart>().FirstOrDefault();
+            int startColumn = ParseMarkerIndex(fromMarker.ColumnId?.Text);
+            int startRow = ParseMarkerIndex(fromMarker.RowId?.Text);
+            var columnMarker = ResolveEndMarker(
+                startColumn,
+                ParseMarkerOffset(fromMarker.ColumnOffset?.Text),
+                widthPixels,
+                A1.MaxColumns,
+                index => GetColumnWidthPixels(worksheetPart, index + 1));
+            var rowMarker = ResolveEndMarker(
+                startRow,
+                ParseMarkerOffset(fromMarker.RowOffset?.Text),
+                heightPixels,
+                A1.MaxRows,
+                index => GetRowHeightPixels(worksheetPart, index + 1));
+
+            toMarker.ColumnId = new Xdr.ColumnId(columnMarker.Index.ToString(CultureInfo.InvariantCulture));
+            toMarker.ColumnOffset = new Xdr.ColumnOffset(columnMarker.OffsetEmu.ToString(CultureInfo.InvariantCulture));
+            toMarker.RowId = new Xdr.RowId(rowMarker.Index.ToString(CultureInfo.InvariantCulture));
+            toMarker.RowOffset = new Xdr.RowOffset(rowMarker.OffsetEmu.ToString(CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -337,6 +368,65 @@ namespace OfficeIMO.Excel {
             }
 
             return (int)Math.Max(1, Math.Round(emu / 9525.0));
+        }
+
+        private static (int Index, long OffsetEmu) ResolveEndMarker(
+            int startIndex,
+            long startOffsetEmu,
+            int sizePixels,
+            int limit,
+            Func<int, int> segmentSizePixels) {
+            int index = Math.Max(0, startIndex);
+            int remainingPixels = Math.Max(1, sizePixels) + EmuToPx(startOffsetEmu);
+            while (index < limit - 1) {
+                int segmentPixels = Math.Max(1, segmentSizePixels(index));
+                if (remainingPixels < segmentPixels) {
+                    break;
+                }
+
+                remainingPixels -= segmentPixels;
+                index++;
+            }
+
+            return (index, PxToEmu(Math.Max(0, remainingPixels)));
+        }
+
+        private static int GetColumnWidthPixels(WorksheetPart? worksheetPart, int columnIndex) {
+            const double defaultMaximumDigitWidth = 7D;
+            DocumentFormat.OpenXml.Spreadsheet.Worksheet? worksheet = worksheetPart?.Worksheet;
+            DocumentFormat.OpenXml.Spreadsheet.Column? column = worksheet?
+                .GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.Columns>()?
+                .Elements<DocumentFormat.OpenXml.Spreadsheet.Column>()
+                .FirstOrDefault(item => item.Min != null && item.Max != null && item.Min.Value <= (uint)columnIndex && item.Max.Value >= (uint)columnIndex);
+            if (column?.Hidden?.Value == true) {
+                return 1;
+            }
+
+            double width = column?.Width?.Value > 0 && column.CustomWidth?.Value == true
+                ? column.Width.Value
+                : worksheet?.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.SheetFormatProperties>()?.DefaultColumnWidth?.Value > 0
+                    ? worksheet.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.SheetFormatProperties>()!.DefaultColumnWidth!.Value
+                    : 8.43D;
+            double pixels = Math.Truncate((256D * width + Math.Truncate(128D / defaultMaximumDigitWidth)) / 256D * defaultMaximumDigitWidth);
+            return Math.Max(1, (int)Math.Round(pixels));
+        }
+
+        private static int GetRowHeightPixels(WorksheetPart? worksheetPart, int rowIndex) {
+            DocumentFormat.OpenXml.Spreadsheet.Worksheet? worksheet = worksheetPart?.Worksheet;
+            DocumentFormat.OpenXml.Spreadsheet.Row? row = worksheet?
+                .GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.SheetData>()?
+                .Elements<DocumentFormat.OpenXml.Spreadsheet.Row>()
+                .FirstOrDefault(item => item.RowIndex != null && item.RowIndex.Value == (uint)rowIndex);
+            if (row?.Hidden?.Value == true) {
+                return 1;
+            }
+
+            double heightPoints = row?.Height?.Value > 0 && row.CustomHeight?.Value == true
+                ? row.Height.Value
+                : worksheet?.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.SheetFormatProperties>()?.DefaultRowHeight?.Value > 0
+                    ? worksheet.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.SheetFormatProperties>()!.DefaultRowHeight!.Value
+                    : 15D;
+            return Math.Max(1, (int)Math.Round(heightPoints * 96D / 72D));
         }
 
         private int GetMarkerRow() {

--- a/OfficeIMO.Excel/ExcelImage.cs
+++ b/OfficeIMO.Excel/ExcelImage.cs
@@ -452,7 +452,7 @@ namespace OfficeIMO.Excel {
                 .Elements<DocumentFormat.OpenXml.Spreadsheet.Row>()
                 .FirstOrDefault(item => item.RowIndex != null && item.RowIndex.Value == (uint)rowIndex);
             if (row?.Hidden?.Value == true) {
-                return 1;
+                return 0;
             }
 
             double heightPoints = row?.Height?.Value > 0 && row.CustomHeight?.Value == true

--- a/OfficeIMO.Excel/ExcelImage.cs
+++ b/OfficeIMO.Excel/ExcelImage.cs
@@ -356,7 +356,11 @@ namespace OfficeIMO.Excel {
             }
 
             long? shapeExtent = _picture.ShapeProperties?.GetFirstChild<A.Transform2D>()?.GetFirstChild<A.Extents>()?.Cx?.Value;
-            return shapeExtent.GetValueOrDefault();
+            if (shapeExtent.HasValue && shapeExtent.Value > 0) {
+                return shapeExtent.Value;
+            }
+
+            return TryGetTwoCellAnchorSizeEmu(horizontal: true, out long emu) ? emu : 0L;
         }
 
         private long GetExtentCy() {
@@ -366,7 +370,38 @@ namespace OfficeIMO.Excel {
             }
 
             long? shapeExtent = _picture.ShapeProperties?.GetFirstChild<A.Transform2D>()?.GetFirstChild<A.Extents>()?.Cy?.Value;
-            return shapeExtent.GetValueOrDefault();
+            if (shapeExtent.HasValue && shapeExtent.Value > 0) {
+                return shapeExtent.Value;
+            }
+
+            return TryGetTwoCellAnchorSizeEmu(horizontal: false, out long emu) ? emu : 0L;
+        }
+
+        private bool TryGetTwoCellAnchorSizeEmu(bool horizontal, out long emu) {
+            emu = 0;
+            Xdr.TwoCellAnchor? twoCellAnchor = _anchor as Xdr.TwoCellAnchor;
+            if (twoCellAnchor?.FromMarker == null || twoCellAnchor.ToMarker == null) {
+                return false;
+            }
+
+            int from = horizontal
+                ? ParseMarkerIndex(twoCellAnchor.FromMarker.ColumnId?.Text)
+                : ParseMarkerIndex(twoCellAnchor.FromMarker.RowId?.Text);
+            int to = horizontal
+                ? ParseMarkerIndex(twoCellAnchor.ToMarker.ColumnId?.Text)
+                : ParseMarkerIndex(twoCellAnchor.ToMarker.RowId?.Text);
+            long fromOffset = ParseMarkerOffset(horizontal
+                ? twoCellAnchor.FromMarker.ColumnOffset?.Text
+                : twoCellAnchor.FromMarker.RowOffset?.Text);
+            long toOffset = ParseMarkerOffset(horizontal
+                ? twoCellAnchor.ToMarker.ColumnOffset?.Text
+                : twoCellAnchor.ToMarker.RowOffset?.Text);
+
+            int basePixels = Math.Max(0, to - from) * (horizontal ? 64 : 20);
+            int offsetPixels = (int)Math.Round((toOffset - fromOffset) / 9525D);
+            int pixels = Math.Max(1, basePixels + offsetPixels);
+            emu = PxToEmu(pixels);
+            return true;
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelImage.cs
+++ b/OfficeIMO.Excel/ExcelImage.cs
@@ -1,5 +1,6 @@
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Drawing;
 using System.Globalization;
 using A = DocumentFormat.OpenXml.Drawing;
 using Xdr = DocumentFormat.OpenXml.Drawing.Spreadsheet;
@@ -233,6 +234,7 @@ namespace OfficeIMO.Excel {
             }
 
             WorksheetPart? worksheetPart = _drawingsPart.GetParentParts().OfType<WorksheetPart>().FirstOrDefault();
+            double maximumDigitWidth = GetDefaultMaximumDigitWidth(worksheetPart);
             int startColumn = ParseMarkerIndex(fromMarker.ColumnId?.Text);
             int startRow = ParseMarkerIndex(fromMarker.RowId?.Text);
             var columnMarker = ResolveEndMarker(
@@ -240,7 +242,7 @@ namespace OfficeIMO.Excel {
                 ParseMarkerOffset(fromMarker.ColumnOffset?.Text),
                 widthPixels,
                 A1.MaxColumns,
-                index => GetColumnWidthPixels(worksheetPart, index + 1));
+                index => GetColumnWidthPixels(worksheetPart, index + 1, maximumDigitWidth));
             var rowMarker = ResolveEndMarker(
                 startRow,
                 ParseMarkerOffset(fromMarker.RowOffset?.Text),
@@ -391,8 +393,7 @@ namespace OfficeIMO.Excel {
             return (index, PxToEmu(Math.Max(0, remainingPixels)));
         }
 
-        private static int GetColumnWidthPixels(WorksheetPart? worksheetPart, int columnIndex) {
-            const double defaultMaximumDigitWidth = 7D;
+        private static int GetColumnWidthPixels(WorksheetPart? worksheetPart, int columnIndex, double maximumDigitWidth) {
             DocumentFormat.OpenXml.Spreadsheet.Worksheet? worksheet = worksheetPart?.Worksheet;
             DocumentFormat.OpenXml.Spreadsheet.Column? column = worksheet?
                 .GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.Columns>()?
@@ -407,8 +408,41 @@ namespace OfficeIMO.Excel {
                 : worksheet?.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.SheetFormatProperties>()?.DefaultColumnWidth?.Value > 0
                     ? worksheet.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.SheetFormatProperties>()!.DefaultColumnWidth!.Value
                     : 8.43D;
-            double pixels = Math.Truncate((256D * width + Math.Truncate(128D / defaultMaximumDigitWidth)) / 256D * defaultMaximumDigitWidth);
+            double pixels = Math.Truncate((256D * width + Math.Truncate(128D / maximumDigitWidth)) / 256D * maximumDigitWidth);
             return Math.Max(1, (int)Math.Round(pixels));
+        }
+
+        private static double GetDefaultMaximumDigitWidth(WorksheetPart? worksheetPart) {
+            const double fallbackMaximumDigitWidth = 7D;
+            try {
+                WorkbookPart? workbookPart = worksheetPart?.GetParentParts().OfType<WorkbookPart>().FirstOrDefault();
+                DocumentFormat.OpenXml.Spreadsheet.Font? font = workbookPart?.WorkbookStylesPart?.Stylesheet?.Fonts?
+                    .Elements<DocumentFormat.OpenXml.Spreadsheet.Font>()
+                    .FirstOrDefault();
+                string? fontName = font?.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.FontName>()?.Val?.Value;
+                if (string.IsNullOrWhiteSpace(fontName)) {
+                    return fallbackMaximumDigitWidth;
+                }
+
+                double fontSize = font!.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.FontSize>()?.Val?.Value ?? 11D;
+                OfficeFontStyle fontStyle = OfficeFontStyle.Regular;
+                if (font.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.Bold>() != null) {
+                    fontStyle |= OfficeFontStyle.Bold;
+                }
+
+                if (font.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.Italic>() != null) {
+                    fontStyle |= OfficeFontStyle.Italic;
+                }
+
+                if (font.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.Underline>() != null) {
+                    fontStyle |= OfficeFontStyle.Underline;
+                }
+
+                float maximumDigitWidth = ExcelTextMeasurer.Create(new OfficeFontInfo(fontName, fontSize, fontStyle)).DefaultStyle.MaximumDigitWidth;
+                return maximumDigitWidth > 0.0001f ? maximumDigitWidth : fallbackMaximumDigitWidth;
+            } catch {
+                return fallbackMaximumDigitWidth;
+            }
         }
 
         private static int GetRowHeightPixels(WorksheetPart? worksheetPart, int rowIndex) {
@@ -482,6 +516,12 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
+            if (twoCellAnchor.EditAs != null
+                && (twoCellAnchor.EditAs.Value == Xdr.EditAsValues.OneCell
+                    || twoCellAnchor.EditAs.Value == Xdr.EditAsValues.Absolute)) {
+                return false;
+            }
+
             int from = horizontal
                 ? ParseMarkerIndex(twoCellAnchor.FromMarker.ColumnId?.Text)
                 : ParseMarkerIndex(twoCellAnchor.FromMarker.RowId?.Text);
@@ -500,10 +540,11 @@ namespace OfficeIMO.Excel {
             }
 
             WorksheetPart? worksheetPart = _drawingsPart.GetParentParts().OfType<WorksheetPart>().FirstOrDefault();
+            double maximumDigitWidth = GetDefaultMaximumDigitWidth(worksheetPart);
             int basePixels = 0;
             for (int index = from; index < to; index++) {
                 basePixels += horizontal
-                    ? GetColumnWidthPixels(worksheetPart, index + 1)
+                    ? GetColumnWidthPixels(worksheetPart, index + 1, maximumDigitWidth)
                     : GetRowHeightPixels(worksheetPart, index + 1);
             }
 

--- a/OfficeIMO.Excel/ExcelImage.cs
+++ b/OfficeIMO.Excel/ExcelImage.cs
@@ -440,6 +440,10 @@ namespace OfficeIMO.Excel {
         }
 
         private long GetExtentCx() {
+            if (TryGetTwoCellAnchorSizeEmu(horizontal: true, out long twoCellEmu)) {
+                return twoCellEmu;
+            }
+
             long? anchorExtent = _anchor.GetFirstChild<Xdr.Extent>()?.Cx?.Value;
             if (anchorExtent.HasValue && anchorExtent.Value > 0) {
                 return anchorExtent.Value;
@@ -450,10 +454,14 @@ namespace OfficeIMO.Excel {
                 return shapeExtent.Value;
             }
 
-            return TryGetTwoCellAnchorSizeEmu(horizontal: true, out long emu) ? emu : 0L;
+            return 0L;
         }
 
         private long GetExtentCy() {
+            if (TryGetTwoCellAnchorSizeEmu(horizontal: false, out long twoCellEmu)) {
+                return twoCellEmu;
+            }
+
             long? anchorExtent = _anchor.GetFirstChild<Xdr.Extent>()?.Cy?.Value;
             if (anchorExtent.HasValue && anchorExtent.Value > 0) {
                 return anchorExtent.Value;
@@ -464,7 +472,7 @@ namespace OfficeIMO.Excel {
                 return shapeExtent.Value;
             }
 
-            return TryGetTwoCellAnchorSizeEmu(horizontal: false, out long emu) ? emu : 0L;
+            return 0L;
         }
 
         private bool TryGetTwoCellAnchorSizeEmu(bool horizontal, out long emu) {
@@ -487,7 +495,18 @@ namespace OfficeIMO.Excel {
                 ? twoCellAnchor.ToMarker.ColumnOffset?.Text
                 : twoCellAnchor.ToMarker.RowOffset?.Text);
 
-            int basePixels = Math.Max(0, to - from) * (horizontal ? 64 : 20);
+            if (to < from) {
+                return false;
+            }
+
+            WorksheetPart? worksheetPart = _drawingsPart.GetParentParts().OfType<WorksheetPart>().FirstOrDefault();
+            int basePixels = 0;
+            for (int index = from; index < to; index++) {
+                basePixels += horizontal
+                    ? GetColumnWidthPixels(worksheetPart, index + 1)
+                    : GetRowHeightPixels(worksheetPart, index + 1);
+            }
+
             int offsetPixels = (int)Math.Round((toOffset - fromOffset) / 9525D);
             int pixels = Math.Max(1, basePixels + offsetPixels);
             emu = PxToEmu(pixels);

--- a/OfficeIMO.Excel/ExcelImage.cs
+++ b/OfficeIMO.Excel/ExcelImage.cs
@@ -96,6 +96,17 @@ namespace OfficeIMO.Excel {
         public string ContentType => ImagePart?.ContentType ?? string.Empty;
 
         /// <summary>
+        /// Gets or sets clockwise image rotation in degrees.
+        /// </summary>
+        public double RotationDegrees {
+            get {
+                var transform = _picture.ShapeProperties?.GetFirstChild<A.Transform2D>();
+                return (transform?.Rotation?.Value ?? 0) / 60000.0;
+            }
+            set => SetRotation(value);
+        }
+
+        /// <summary>
         /// Returns a copy of the image bytes from the worksheet drawing relationship.
         /// </summary>
         public byte[] GetBytes() {
@@ -159,6 +170,33 @@ namespace OfficeIMO.Excel {
         }
 
         /// <summary>
+        /// Sets clockwise image rotation in degrees.
+        /// </summary>
+        /// <param name="degrees">Clockwise rotation in degrees. Fractional values are supported by DrawingML.</param>
+        public ExcelImage SetRotation(double degrees) {
+            if (double.IsNaN(degrees) || double.IsInfinity(degrees)) {
+                throw new ArgumentOutOfRangeException(nameof(degrees), "Rotation must be a finite number of degrees.");
+            }
+
+            var shapeProperties = _picture.ShapeProperties;
+            if (shapeProperties == null) {
+                return this;
+            }
+
+            var transform = shapeProperties.GetFirstChild<A.Transform2D>();
+            if (transform == null) {
+                transform = new A.Transform2D(
+                    new A.Offset { X = 0, Y = 0 },
+                    new A.Extents { Cx = GetExtentCx(), Cy = GetExtentCy() });
+                shapeProperties.PrependChild(transform);
+            }
+
+            transform.Rotation = (int)Math.Round(degrees * 60000.0);
+            Save();
+            return this;
+        }
+
+        /// <summary>
         /// Sets the image size in pixels.
         /// </summary>
         public ExcelImage SetSize(int widthPixels, int heightPixels) {
@@ -183,6 +221,20 @@ namespace OfficeIMO.Excel {
 
             Save();
             return this;
+        }
+
+        /// <summary>
+        /// Scales the image from its current size by the specified percentage.
+        /// </summary>
+        /// <param name="percent">Percentage of the current image size. For example, 20 means 20%.</param>
+        public ExcelImage SetSizePercent(double percent) {
+            if (double.IsNaN(percent) || double.IsInfinity(percent) || percent <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(percent), "Scale percentage must be a positive finite number.");
+            }
+
+            int width = Math.Max(1, (int)Math.Round(WidthPixels * percent / 100.0));
+            int height = Math.Max(1, (int)Math.Round(HeightPixels * percent / 100.0));
+            return SetSize(width, height);
         }
 
         /// <summary>

--- a/OfficeIMO.Excel/ExcelImagePlacement.cs
+++ b/OfficeIMO.Excel/ExcelImagePlacement.cs
@@ -1,0 +1,13 @@
+namespace OfficeIMO.Excel {
+    /// <summary>
+    /// Describes how a two-cell anchored worksheet image should react when rows or columns move or resize.
+    /// </summary>
+    public enum ExcelImagePlacement {
+        /// <summary>The image moves and resizes with the cells between its start and end markers.</summary>
+        MoveAndSize,
+        /// <summary>The image moves with cells but keeps its current size.</summary>
+        MoveOnly,
+        /// <summary>The image keeps its absolute visual position relative to the worksheet drawing canvas.</summary>
+        FreeFloating
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.Images.Placement.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Images.Placement.cs
@@ -74,11 +74,31 @@ namespace OfficeIMO.Excel {
 
             OfficeImageReader.TryIdentify(bytes, null, out OfficeImageInfo info);
             var (resolvedWidth, resolvedHeight) = ResolveImageSize(info, widthPixels, heightPixels, scalePercent);
-            ExcelImage image = AddImage(row, column, bytes, string.IsNullOrEmpty(contentType) ? info.MimeType : contentType!,
+            ExcelImage image = AddImage(row, column, bytes, ResolveImageContentType(contentType, info),
                 resolvedWidth, resolvedHeight, offsetXPixels, offsetYPixels, name, altText, lockAspectRatio);
             ApplyImageMetadata(image, title, rotationDegrees);
             return image;
         }
+
+        /// <summary>
+        /// Downloads an image from URL, scales it from its detected dimensions, and anchors it to a worksheet cell.
+        /// Returns null when the image cannot be fetched.
+        /// </summary>
+        /// <param name="row">1-based row index where the top edge of the image will be anchored.</param>
+        /// <param name="column">1-based column index where the left edge of the image will be anchored.</param>
+        /// <param name="url">Remote image URL to download. Requests timeout after 5 seconds and must be smaller than 2 MB.</param>
+        /// <param name="scalePercent">Percentage of the original image dimensions, for example 20 for 20%.</param>
+        /// <param name="offsetXPixels">Optional horizontal offset in pixels from the cell's left boundary.</param>
+        /// <param name="offsetYPixels">Optional vertical offset in pixels from the cell's top boundary.</param>
+        /// <param name="name">Optional drawing name used by Excel's selection pane.</param>
+        /// <param name="altText">Optional alternative text description for accessibility.</param>
+        /// <param name="title">Optional alternative text title.</param>
+        /// <param name="lockAspectRatio">Whether Excel should keep the picture aspect ratio locked.</param>
+        /// <param name="rotationDegrees">Clockwise image rotation in degrees.</param>
+        public ExcelImage? AddImageFromUrl(int row, int column, string url, double scalePercent,
+            int offsetXPixels = 0, int offsetYPixels = 0, string? name = null, string? altText = null,
+            string? title = null, bool lockAspectRatio = true, double rotationDegrees = 0)
+            => AddImageFromUrl(row, column, url, null, null, scalePercent, offsetXPixels, offsetYPixels, name, altText, title, lockAspectRatio, rotationDegrees);
 
         /// <summary>
         /// Adds an image anchored to an A1 range using a two-cell anchor. The image moves and sizes with the
@@ -123,7 +143,7 @@ namespace OfficeIMO.Excel {
 
                 var drawingId = NextDrawingId(drawingPart);
                 string resolvedName = string.IsNullOrWhiteSpace(name) ? $"Picture {drawingId}" : name!.Trim();
-                var (widthPixels, heightPixels) = EstimateRangeAnchorSizePixels(
+                var (widthPixels, heightPixels) = CalculateRangeAnchorSizePixels(
                     startRow,
                     startColumn,
                     endRow,
@@ -295,7 +315,7 @@ namespace OfficeIMO.Excel {
             return (startRow, startColumn, endRow, endColumn);
         }
 
-        private static (int WidthPixels, int HeightPixels) EstimateRangeAnchorSizePixels(
+        private (int WidthPixels, int HeightPixels) CalculateRangeAnchorSizePixels(
             int startRow,
             int startColumn,
             int endRow,
@@ -304,9 +324,58 @@ namespace OfficeIMO.Excel {
             int offsetYPixels,
             int endOffsetXPixels,
             int endOffsetYPixels) {
-            int width = Math.Max(1, (endColumn - startColumn + 1) * 64 + endOffsetXPixels - offsetXPixels);
-            int height = Math.Max(1, (endRow - startRow + 1) * 20 + endOffsetYPixels - offsetYPixels);
+            int width = Math.Max(1, CalculateColumnSpanPixels(startColumn, endColumn) + endOffsetXPixels - offsetXPixels);
+            int height = Math.Max(1, CalculateRowSpanPixels(startRow, endRow) + endOffsetYPixels - offsetYPixels);
             return (width, height);
+        }
+
+        private int CalculateColumnSpanPixels(int startColumn, int endColumn) {
+            ExcelTextMeasurer textMeasurer = ExcelTextMeasurer.Create(GetWorkbookDefaultFontInfo());
+            float mdw = textMeasurer.DefaultStyle.MaximumDigitWidth;
+            if (mdw <= 0.0001f) {
+                mdw = 7f;
+            }
+
+            double total = 0;
+            for (int column = startColumn; column <= endColumn; column++) {
+                if (IsColumnHidden(column)) {
+                    continue;
+                }
+
+                total += GetColumnWidthPixels(column, mdw);
+            }
+
+            return Math.Max(1, (int)Math.Round(total));
+        }
+
+        private int CalculateRowSpanPixels(int startRow, int endRow) {
+            double total = 0;
+            for (int rowIndex = startRow; rowIndex <= endRow; rowIndex++) {
+                total += GetRowHeightPixels(rowIndex);
+            }
+
+            return Math.Max(1, (int)Math.Round(total));
+        }
+
+        private bool IsColumnHidden(int columnIndex) {
+            var columns = WorksheetRoot.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.Columns>();
+            var column = columns?.Elements<DocumentFormat.OpenXml.Spreadsheet.Column>()
+                .FirstOrDefault(c => c.Min != null && c.Max != null && c.Min.Value <= (uint)columnIndex && c.Max.Value >= (uint)columnIndex);
+            return column?.Hidden?.Value == true;
+        }
+
+        private double GetRowHeightPixels(int rowIndex) {
+            var sheetData = WorksheetRoot.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.SheetData>();
+            var row = sheetData?.Elements<DocumentFormat.OpenXml.Spreadsheet.Row>()
+                .FirstOrDefault(r => r.RowIndex != null && r.RowIndex.Value == (uint)rowIndex);
+            if (row?.Hidden?.Value == true) {
+                return 0;
+            }
+
+            double heightPoints = row?.Height?.Value > 0 && row.CustomHeight?.Value == true
+                ? row.Height.Value
+                : GetDefaultRowHeightPoints();
+            return heightPoints * 96D / 72D;
         }
 
         private static void ApplyImageMetadata(ExcelImage image, string? title, double rotationDegrees) {
@@ -326,18 +395,37 @@ namespace OfficeIMO.Excel {
                 "image/gif" => ImagePartType.Gif,
                 "image/bmp" => ImagePartType.Bmp,
                 "image/tiff" or "image/tif" => ImagePartType.Tiff,
-                _ => ImagePartType.Png
+                "image/svg+xml" or "image/svg" => ImagePartType.Svg,
+                "image/x-emf" or "image/emf" => ImagePartType.Emf,
+                "image/x-wmf" or "image/wmf" => ImagePartType.Wmf,
+                "image/x-icon" or "image/vnd.microsoft.icon" or "image/ico" => ImagePartType.Icon,
+                "image/x-pcx" or "image/pcx" => ImagePartType.Pcx,
+                _ => throw new NotSupportedException($"Image content type '{contentType}' is not supported by Excel image parts.")
             };
         }
 
         private static string ContentTypeFromExtension(string path) {
             return OfficeImageReader.FromExtension(path) switch {
+                OfficeImageFormat.Png => "image/png",
                 OfficeImageFormat.Jpeg => "image/jpeg",
                 OfficeImageFormat.Gif => "image/gif",
                 OfficeImageFormat.Bmp => "image/bmp",
                 OfficeImageFormat.Tiff => "image/tiff",
-                _ => "image/png"
+                OfficeImageFormat.Svg => "image/svg+xml",
+                OfficeImageFormat.Emf => "image/x-emf",
+                OfficeImageFormat.Wmf => "image/x-wmf",
+                OfficeImageFormat.Icon => "image/x-icon",
+                OfficeImageFormat.Pcx => "image/x-pcx",
+                _ => "application/octet-stream"
             };
+        }
+
+        private static string ResolveImageContentType(string? declaredContentType, OfficeImageInfo detectedInfo) {
+            if (detectedInfo.Format != OfficeImageFormat.Unknown) {
+                return detectedInfo.MimeType;
+            }
+
+            return string.IsNullOrWhiteSpace(declaredContentType) ? "application/octet-stream" : declaredContentType!;
         }
 
         private static EnumValue<Xdr.EditAsValues> ToEditAsValue(ExcelImagePlacement placement) {

--- a/OfficeIMO.Excel/ExcelSheet.Images.Placement.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Images.Placement.cs
@@ -1,0 +1,328 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Drawing;
+using A = DocumentFormat.OpenXml.Drawing;
+using Xdr = DocumentFormat.OpenXml.Drawing.Spreadsheet;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelSheet {
+        /// <summary>
+        /// Adds an image from disk anchored to a worksheet cell. When <paramref name="scalePercent"/> is provided,
+        /// the image is sized from its original pixel dimensions.
+        /// </summary>
+        /// <param name="row">1-based row index where the top edge of the image will be anchored.</param>
+        /// <param name="column">1-based column index where the left edge of the image will be anchored.</param>
+        /// <param name="path">Image file path.</param>
+        /// <param name="widthPixels">Optional exact image width in pixels. Defaults to the image's original width when known.</param>
+        /// <param name="heightPixels">Optional exact image height in pixels. Defaults to the image's original height when known.</param>
+        /// <param name="scalePercent">Optional percentage of the original image dimensions, for example 20 for 20%.</param>
+        /// <param name="offsetXPixels">Optional horizontal offset in pixels from the cell's left boundary.</param>
+        /// <param name="offsetYPixels">Optional vertical offset in pixels from the cell's top boundary.</param>
+        /// <param name="name">Optional drawing name used by Excel's selection pane.</param>
+        /// <param name="altText">Optional alternative text description for accessibility.</param>
+        /// <param name="title">Optional alternative text title.</param>
+        /// <param name="lockAspectRatio">Whether Excel should keep the picture aspect ratio locked.</param>
+        /// <param name="rotationDegrees">Clockwise image rotation in degrees.</param>
+        /// <example>
+        /// <code>
+        /// using var workbook = ExcelDocument.Create("report.xlsx");
+        /// var sheet = workbook.Sheets[0];
+        /// sheet.AddImageFromFile(2, 2, "logo.png", scalePercent: 20, name: "Logo", altText: "Company logo");
+        /// workbook.Save();
+        /// </code>
+        /// </example>
+        public ExcelImage AddImageFromFile(int row, int column, string path, int? widthPixels = null, int? heightPixels = null,
+            double? scalePercent = null, int offsetXPixels = 0, int offsetYPixels = 0, string? name = null, string? altText = null,
+            string? title = null, bool lockAspectRatio = true, double rotationDegrees = 0) {
+            if (string.IsNullOrWhiteSpace(path)) throw new ArgumentException("Image path is required.", nameof(path));
+            if (!File.Exists(path)) throw new FileNotFoundException($"Image file '{path}' was not found.", path);
+
+            byte[] bytes = File.ReadAllBytes(path);
+            OfficeImageReader.TryIdentify(bytes, path, out OfficeImageInfo info);
+            var (resolvedWidth, resolvedHeight) = ResolveImageSize(info, widthPixels, heightPixels, scalePercent);
+            string contentType = info.Format == OfficeImageFormat.Unknown ? ContentTypeFromExtension(path) : info.MimeType;
+
+            ExcelImage image = AddImage(row, column, bytes, contentType, resolvedWidth, resolvedHeight, offsetXPixels, offsetYPixels, name, altText, lockAspectRatio);
+            ApplyImageMetadata(image, title, rotationDegrees);
+            return image;
+        }
+
+        /// <summary>
+        /// Downloads an image from URL, anchors it to a worksheet cell, and optionally sizes it from its original dimensions.
+        /// Returns null when the image cannot be fetched.
+        /// </summary>
+        /// <param name="row">1-based row index where the top edge of the image will be anchored.</param>
+        /// <param name="column">1-based column index where the left edge of the image will be anchored.</param>
+        /// <param name="url">Remote image URL to download. Requests timeout after 5 seconds and must be smaller than 2 MB.</param>
+        /// <param name="widthPixels">Optional exact image width in pixels. Defaults to the image's original width when known.</param>
+        /// <param name="heightPixels">Optional exact image height in pixels. Defaults to the image's original height when known.</param>
+        /// <param name="scalePercent">Optional percentage of the original image dimensions, for example 20 for 20%.</param>
+        /// <param name="offsetXPixels">Optional horizontal offset in pixels from the cell's left boundary.</param>
+        /// <param name="offsetYPixels">Optional vertical offset in pixels from the cell's top boundary.</param>
+        /// <param name="name">Optional drawing name used by Excel's selection pane.</param>
+        /// <param name="altText">Optional alternative text description for accessibility.</param>
+        /// <param name="title">Optional alternative text title.</param>
+        /// <param name="lockAspectRatio">Whether Excel should keep the picture aspect ratio locked.</param>
+        /// <param name="rotationDegrees">Clockwise image rotation in degrees.</param>
+        public ExcelImage? AddImageFromUrl(int row, int column, string url, int? widthPixels, int? heightPixels,
+            double? scalePercent = null, int offsetXPixels = 0, int offsetYPixels = 0, string? name = null, string? altText = null,
+            string? title = null, bool lockAspectRatio = true, double rotationDegrees = 0) {
+            if (string.IsNullOrWhiteSpace(url)) return null;
+            if (!ImageDownloader.TryFetch(url, timeoutSeconds: 5, maxBytes: 2_000_000, out var bytes, out var contentType) || bytes == null) {
+                return null;
+            }
+
+            OfficeImageReader.TryIdentify(bytes, null, out OfficeImageInfo info);
+            var (resolvedWidth, resolvedHeight) = ResolveImageSize(info, widthPixels, heightPixels, scalePercent);
+            ExcelImage image = AddImage(row, column, bytes, string.IsNullOrEmpty(contentType) ? info.MimeType : contentType!,
+                resolvedWidth, resolvedHeight, offsetXPixels, offsetYPixels, name, altText, lockAspectRatio);
+            ApplyImageMetadata(image, title, rotationDegrees);
+            return image;
+        }
+
+        /// <summary>
+        /// Adds an image anchored to an A1 range using a two-cell anchor. The image moves and sizes with the
+        /// referenced cells by default, matching Excel's "Move and size with cells" behavior.
+        /// </summary>
+        /// <param name="range">A1 range such as A1:C15. The image is anchored from the top-left of the first cell to the bottom-right boundary of the last cell.</param>
+        /// <param name="imageBytes">Image bytes.</param>
+        /// <param name="contentType">Content type, for example image/png or image/jpeg.</param>
+        /// <param name="offsetXPixels">Optional horizontal offset from the range start.</param>
+        /// <param name="offsetYPixels">Optional vertical offset from the range start.</param>
+        /// <param name="endOffsetXPixels">Optional horizontal offset applied to the range end marker.</param>
+        /// <param name="endOffsetYPixels">Optional vertical offset applied to the range end marker.</param>
+        /// <param name="name">Optional drawing name used by Excel's selection pane.</param>
+        /// <param name="altText">Optional alternative text description for accessibility.</param>
+        /// <param name="title">Optional alternative text title.</param>
+        /// <param name="lockAspectRatio">Whether Excel should keep the picture aspect ratio locked.</param>
+        /// <param name="placement">How the image behaves when cells move or resize.</param>
+        /// <param name="rotationDegrees">Clockwise image rotation in degrees.</param>
+        /// <example>
+        /// <code>
+        /// using var workbook = ExcelDocument.Create("report.xlsx");
+        /// var sheet = workbook.Sheets[0];
+        /// byte[] logo = File.ReadAllBytes("logo.png");
+        /// sheet.AddImageToRange("A1:C15", logo, "image/png", name: "PinnedLogo",
+        ///     altText: "Company logo", placement: ExcelImagePlacement.MoveAndSize);
+        /// workbook.Save();
+        /// </code>
+        /// </example>
+        public ExcelImage AddImageToRange(string range, byte[] imageBytes, string contentType = "image/png",
+            int offsetXPixels = 0, int offsetYPixels = 0, int endOffsetXPixels = 0, int endOffsetYPixels = 0,
+            string? name = null, string? altText = null, string? title = null, bool lockAspectRatio = true,
+            ExcelImagePlacement placement = ExcelImagePlacement.MoveAndSize, double rotationDegrees = 0) {
+            if (imageBytes == null || imageBytes.Length == 0) throw new ArgumentException("Image bytes are required.", nameof(imageBytes));
+            var (startRow, startColumn, endRow, endColumn) = ParseImageRange(range);
+
+            ExcelImage? image = null;
+            WriteLock(() => {
+                DrawingsPart drawingPart = GetOrCreateDrawingsPart();
+                ImagePart imagePart = drawingPart.AddImagePart(ToImagePartType(contentType));
+                using (var stream = new MemoryStream(imageBytes)) imagePart.FeedData(stream);
+                string imageRelationshipId = drawingPart.GetIdOfPart(imagePart);
+
+                var drawingId = NextDrawingId(drawingPart);
+                string resolvedName = string.IsNullOrWhiteSpace(name) ? $"Picture {drawingId}" : name!.Trim();
+                var anchor = new Xdr.TwoCellAnchor(
+                    new Xdr.FromMarker(
+                        new Xdr.ColumnId((startColumn - 1).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                        new Xdr.ColumnOffset(PxToEmu(offsetXPixels).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                        new Xdr.RowId((startRow - 1).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                        new Xdr.RowOffset(PxToEmu(offsetYPixels).ToString(System.Globalization.CultureInfo.InvariantCulture))
+                    ),
+                    new Xdr.ToMarker(
+                        new Xdr.ColumnId(endColumn.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                        new Xdr.ColumnOffset(PxToEmu(endOffsetXPixels).ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                        new Xdr.RowId(endRow.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                        new Xdr.RowOffset(PxToEmu(endOffsetYPixels).ToString(System.Globalization.CultureInfo.InvariantCulture))
+                    ),
+                    CreatePicture(drawingId, resolvedName, imageRelationshipId, altText, title, lockAspectRatio, 0, 0, rotationDegrees),
+                    new Xdr.ClientData()) {
+                    EditAs = ToEditAsValue(placement)
+                };
+
+                Xdr.WorksheetDrawing worksheetDrawing = drawingPart.WorksheetDrawing!;
+                worksheetDrawing.Append(anchor);
+                worksheetDrawing.Save();
+                WorksheetRoot.Save();
+                _excelDocument.MarkPackageDirty();
+                image = new ExcelImage(anchor.GetFirstChild<Xdr.Picture>()!, anchor, drawingPart, _excelDocument);
+            });
+
+            return image!;
+        }
+
+        /// <summary>
+        /// Adds an image from disk anchored to an A1 range using a two-cell anchor.
+        /// </summary>
+        /// <param name="range">A1 range such as A1:C15. The image is anchored from the top-left of the first cell to the bottom-right boundary of the last cell.</param>
+        /// <param name="path">Image file path.</param>
+        /// <param name="offsetXPixels">Optional horizontal offset from the range start.</param>
+        /// <param name="offsetYPixels">Optional vertical offset from the range start.</param>
+        /// <param name="endOffsetXPixels">Optional horizontal offset applied to the range end marker.</param>
+        /// <param name="endOffsetYPixels">Optional vertical offset applied to the range end marker.</param>
+        /// <param name="name">Optional drawing name used by Excel's selection pane.</param>
+        /// <param name="altText">Optional alternative text description for accessibility.</param>
+        /// <param name="title">Optional alternative text title.</param>
+        /// <param name="lockAspectRatio">Whether Excel should keep the picture aspect ratio locked.</param>
+        /// <param name="placement">How the image behaves when cells move or resize.</param>
+        /// <param name="rotationDegrees">Clockwise image rotation in degrees.</param>
+        public ExcelImage AddImageFromFileToRange(string range, string path, int offsetXPixels = 0, int offsetYPixels = 0,
+            int endOffsetXPixels = 0, int endOffsetYPixels = 0, string? name = null, string? altText = null, string? title = null,
+            bool lockAspectRatio = true, ExcelImagePlacement placement = ExcelImagePlacement.MoveAndSize, double rotationDegrees = 0) {
+            if (string.IsNullOrWhiteSpace(path)) throw new ArgumentException("Image path is required.", nameof(path));
+            if (!File.Exists(path)) throw new FileNotFoundException($"Image file '{path}' was not found.", path);
+
+            byte[] bytes = File.ReadAllBytes(path);
+            OfficeImageReader.TryIdentify(bytes, path, out OfficeImageInfo info);
+            string contentType = info.Format == OfficeImageFormat.Unknown ? ContentTypeFromExtension(path) : info.MimeType;
+            return AddImageToRange(range, bytes, contentType, offsetXPixels, offsetYPixels, endOffsetXPixels, endOffsetYPixels,
+                name, altText, title, lockAspectRatio, placement, rotationDegrees);
+        }
+
+        /// <summary>
+        /// Downloads an image from URL and anchors it to an A1 range using a two-cell anchor. Returns null when the image cannot be fetched.
+        /// </summary>
+        public ExcelImage? AddImageFromUrlToRange(string range, string url, int offsetXPixels = 0, int offsetYPixels = 0,
+            int endOffsetXPixels = 0, int endOffsetYPixels = 0, string? name = null, string? altText = null, string? title = null,
+            bool lockAspectRatio = true, ExcelImagePlacement placement = ExcelImagePlacement.MoveAndSize, double rotationDegrees = 0) {
+            if (string.IsNullOrWhiteSpace(url)) return null;
+            if (!ImageDownloader.TryFetch(url, timeoutSeconds: 5, maxBytes: 2_000_000, out var bytes, out var contentType) || bytes == null) {
+                return null;
+            }
+
+            return AddImageToRange(range, bytes, string.IsNullOrEmpty(contentType) ? "image/png" : contentType!, offsetXPixels,
+                offsetYPixels, endOffsetXPixels, endOffsetYPixels, name, altText, title, lockAspectRatio, placement, rotationDegrees);
+        }
+
+        private DrawingsPart GetOrCreateDrawingsPart() {
+            var drawing = WorksheetRoot.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.Drawing>();
+            if (drawing == null) {
+                DrawingsPart drawingPart = _worksheetPart.AddNewPart<DrawingsPart>();
+                drawingPart.WorksheetDrawing = new Xdr.WorksheetDrawing();
+                string relationshipId = _worksheetPart.GetIdOfPart(drawingPart);
+                WorksheetRoot.Append(new DocumentFormat.OpenXml.Spreadsheet.Drawing { Id = relationshipId });
+                return drawingPart;
+            }
+
+            var existing = (DrawingsPart)_worksheetPart.GetPartById(drawing.Id!);
+            existing.WorksheetDrawing ??= new Xdr.WorksheetDrawing();
+            return existing;
+        }
+
+        private static Xdr.Picture CreatePicture(UInt32Value drawingId, string name, string imageRelationshipId, string? altText,
+            string? title, bool lockAspectRatio, long widthEmu, long heightEmu, double rotationDegrees) {
+            var drawingProperties = new Xdr.NonVisualDrawingProperties {
+                Id = drawingId,
+                Name = name,
+                Description = altText ?? string.Empty
+            };
+            if (!string.IsNullOrWhiteSpace(title)) {
+                drawingProperties.Title = title;
+            }
+
+            var transform = new A.Transform2D(
+                new A.Offset { X = 0, Y = 0 },
+                new A.Extents { Cx = widthEmu, Cy = heightEmu });
+            if (Math.Abs(rotationDegrees) > double.Epsilon) {
+                transform.Rotation = (int)Math.Round(rotationDegrees * 60000.0);
+            }
+
+            return new Xdr.Picture(
+                new Xdr.NonVisualPictureProperties(
+                    drawingProperties,
+                    new Xdr.NonVisualPictureDrawingProperties(new A.PictureLocks { NoChangeAspect = lockAspectRatio })
+                ),
+                new Xdr.BlipFill(
+                    new A.Blip { Embed = imageRelationshipId },
+                    new A.Stretch(new A.FillRectangle())
+                ),
+                new Xdr.ShapeProperties(
+                    transform,
+                    new A.PresetGeometry(new A.AdjustValueList()) { Preset = A.ShapeTypeValues.Rectangle }
+                )
+            );
+        }
+
+        private static (int Width, int Height) ResolveImageSize(OfficeImageInfo info, int? widthPixels, int? heightPixels, double? scalePercent) {
+            if (scalePercent.HasValue) {
+                if (widthPixels.HasValue || heightPixels.HasValue) {
+                    throw new ArgumentException("Scale percentage cannot be combined with explicit width or height.");
+                }
+
+                if (double.IsNaN(scalePercent.Value) || double.IsInfinity(scalePercent.Value) || scalePercent.Value <= 0) {
+                    throw new ArgumentOutOfRangeException(nameof(scalePercent), "Scale percentage must be a positive finite number.");
+                }
+
+                if (info.Width <= 0 || info.Height <= 0) {
+                    throw new NotSupportedException("Image dimensions could not be detected, so scale percentage cannot be applied.");
+                }
+
+                return (Math.Max(1, (int)Math.Round(info.Width * scalePercent.Value / 100.0)),
+                    Math.Max(1, (int)Math.Round(info.Height * scalePercent.Value / 100.0)));
+            }
+
+            int width = widthPixels ?? (info.Width > 0 ? info.Width : 96);
+            int height = heightPixels ?? (info.Height > 0 ? info.Height : 32);
+            if (width <= 0) throw new ArgumentOutOfRangeException(nameof(widthPixels));
+            if (height <= 0) throw new ArgumentOutOfRangeException(nameof(heightPixels));
+            return (width, height);
+        }
+
+        private static (int StartRow, int StartColumn, int EndRow, int EndColumn) ParseImageRange(string range) {
+            if (!A1.TryParseRange(range, out int startRow, out int startColumn, out int endRow, out int endColumn)) {
+                throw new ArgumentException($"Invalid A1 range '{range}'. Use a range such as A1:C15.", nameof(range));
+            }
+
+            if (endColumn >= A1.MaxColumns) {
+                throw new ArgumentOutOfRangeException(nameof(range), "Image range must end before the final Excel column so the two-cell end marker can use the boundary after the last cell.");
+            }
+
+            if (endRow >= A1.MaxRows) {
+                throw new ArgumentOutOfRangeException(nameof(range), "Image range must end before the final Excel row so the two-cell end marker can use the boundary after the last cell.");
+            }
+
+            return (startRow, startColumn, endRow, endColumn);
+        }
+
+        private static void ApplyImageMetadata(ExcelImage image, string? title, double rotationDegrees) {
+            if (!string.IsNullOrWhiteSpace(title)) {
+                image.Title = title!;
+            }
+
+            if (Math.Abs(rotationDegrees) > double.Epsilon) {
+                image.SetRotation(rotationDegrees);
+            }
+        }
+
+        private static PartTypeInfo ToImagePartType(string? contentType) {
+            return (contentType ?? string.Empty).ToLowerInvariant() switch {
+                "image/png" => ImagePartType.Png,
+                "image/jpeg" or "image/jpg" => ImagePartType.Jpeg,
+                "image/gif" => ImagePartType.Gif,
+                "image/bmp" => ImagePartType.Bmp,
+                "image/tiff" or "image/tif" => ImagePartType.Tiff,
+                _ => ImagePartType.Png
+            };
+        }
+
+        private static string ContentTypeFromExtension(string path) {
+            return OfficeImageReader.FromExtension(path) switch {
+                OfficeImageFormat.Jpeg => "image/jpeg",
+                OfficeImageFormat.Gif => "image/gif",
+                OfficeImageFormat.Bmp => "image/bmp",
+                OfficeImageFormat.Tiff => "image/tiff",
+                _ => "image/png"
+            };
+        }
+
+        private static EnumValue<Xdr.EditAsValues> ToEditAsValue(ExcelImagePlacement placement) {
+            return placement switch {
+                ExcelImagePlacement.MoveAndSize => Xdr.EditAsValues.TwoCell,
+                ExcelImagePlacement.MoveOnly => Xdr.EditAsValues.OneCell,
+                ExcelImagePlacement.FreeFloating => Xdr.EditAsValues.Absolute,
+                _ => Xdr.EditAsValues.TwoCell
+            };
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelSheet.Images.Placement.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Images.Placement.cs
@@ -123,6 +123,15 @@ namespace OfficeIMO.Excel {
 
                 var drawingId = NextDrawingId(drawingPart);
                 string resolvedName = string.IsNullOrWhiteSpace(name) ? $"Picture {drawingId}" : name!.Trim();
+                var (widthPixels, heightPixels) = EstimateRangeAnchorSizePixels(
+                    startRow,
+                    startColumn,
+                    endRow,
+                    endColumn,
+                    offsetXPixels,
+                    offsetYPixels,
+                    endOffsetXPixels,
+                    endOffsetYPixels);
                 var anchor = new Xdr.TwoCellAnchor(
                     new Xdr.FromMarker(
                         new Xdr.ColumnId((startColumn - 1).ToString(System.Globalization.CultureInfo.InvariantCulture)),
@@ -136,7 +145,8 @@ namespace OfficeIMO.Excel {
                         new Xdr.RowId(endRow.ToString(System.Globalization.CultureInfo.InvariantCulture)),
                         new Xdr.RowOffset(PxToEmu(endOffsetYPixels).ToString(System.Globalization.CultureInfo.InvariantCulture))
                     ),
-                    CreatePicture(drawingId, resolvedName, imageRelationshipId, altText, title, lockAspectRatio, 0, 0, rotationDegrees),
+                    CreatePicture(drawingId, resolvedName, imageRelationshipId, altText, title, lockAspectRatio,
+                        PxToEmu(widthPixels), PxToEmu(heightPixels), rotationDegrees),
                     new Xdr.ClientData()) {
                     EditAs = ToEditAsValue(placement)
                 };
@@ -283,6 +293,20 @@ namespace OfficeIMO.Excel {
             }
 
             return (startRow, startColumn, endRow, endColumn);
+        }
+
+        private static (int WidthPixels, int HeightPixels) EstimateRangeAnchorSizePixels(
+            int startRow,
+            int startColumn,
+            int endRow,
+            int endColumn,
+            int offsetXPixels,
+            int offsetYPixels,
+            int endOffsetXPixels,
+            int endOffsetYPixels) {
+            int width = Math.Max(1, (endColumn - startColumn + 1) * 64 + endOffsetXPixels - offsetXPixels);
+            int height = Math.Max(1, (endRow - startRow + 1) * 20 + endOffsetYPixels - offsetYPixels);
+            return (width, height);
         }
 
         private static void ApplyImageMetadata(ExcelImage image, string? title, double rotationDegrees) {

--- a/OfficeIMO.Excel/ExcelSheet.Images.Placement.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Images.Placement.cs
@@ -221,7 +221,8 @@ namespace OfficeIMO.Excel {
                 return null;
             }
 
-            return AddImageToRange(range, bytes, string.IsNullOrEmpty(contentType) ? "image/png" : contentType!, offsetXPixels,
+            OfficeImageReader.TryIdentify(bytes, null, out OfficeImageInfo info);
+            return AddImageToRange(range, bytes, ResolveImageContentType(contentType, info), offsetXPixels,
                 offsetYPixels, endOffsetXPixels, endOffsetYPixels, name, altText, title, lockAspectRatio, placement, rotationDegrees);
         }
 

--- a/OfficeIMO.Excel/ExcelSheet.Images.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Images.cs
@@ -93,6 +93,7 @@ namespace OfficeIMO.Excel {
                     "image/jpeg" or "image/jpg" => ImagePartType.Jpeg,
                     "image/gif" => ImagePartType.Gif,
                     "image/bmp" => ImagePartType.Bmp,
+                    "image/tiff" or "image/tif" => ImagePartType.Tiff,
                     _ => ImagePartType.Png
                 };
                 var imagePart = drawingPart.AddImagePart(type);

--- a/OfficeIMO.Excel/ExcelSheet.Images.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Images.cs
@@ -162,10 +162,8 @@ namespace OfficeIMO.Excel {
             if (string.IsNullOrWhiteSpace(url)) return null;
             if (ImageDownloader.TryFetch(url, timeoutSeconds: 5, maxBytes: 2_000_000, out var bytes, out var ct) && bytes != null) {
                 OfficeImageReader.TryIdentify(bytes, null, out OfficeImageInfo info);
-                int resolvedWidth = widthPixels == 96 && info.Width > 0 ? info.Width : widthPixels;
-                int resolvedHeight = heightPixels == 32 && info.Height > 0 ? info.Height : heightPixels;
-                return AddImage(row, column, bytes, contentType: ResolveImageContentType(ct, info), widthPixels: resolvedWidth,
-                    heightPixels: resolvedHeight, offsetXPixels: offsetXPixels, offsetYPixels: offsetYPixels, name: name, altText: altText,
+                return AddImage(row, column, bytes, contentType: ResolveImageContentType(ct, info), widthPixels: widthPixels,
+                    heightPixels: heightPixels, offsetXPixels: offsetXPixels, offsetYPixels: offsetYPixels, name: name, altText: altText,
                     lockAspectRatio: lockAspectRatio);
             }
 

--- a/OfficeIMO.Excel/ExcelSheet.Images.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Images.cs
@@ -1,5 +1,6 @@
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Drawing;
 using System.Collections.Generic;
 using System.Linq;
 using A = DocumentFormat.OpenXml.Drawing;
@@ -88,14 +89,7 @@ namespace OfficeIMO.Excel {
                 }
 
                 // Add the image part
-                PartTypeInfo type = contentType.ToLowerInvariant() switch {
-                    "image/png" => ImagePartType.Png,
-                    "image/jpeg" or "image/jpg" => ImagePartType.Jpeg,
-                    "image/gif" => ImagePartType.Gif,
-                    "image/bmp" => ImagePartType.Bmp,
-                    "image/tiff" or "image/tif" => ImagePartType.Tiff,
-                    _ => ImagePartType.Png
-                };
+                PartTypeInfo type = ToImagePartType(contentType);
                 var imagePart = drawingPart.AddImagePart(type);
                 using (var s = new MemoryStream(imageBytes)) imagePart.FeedData(s);
                 string imgRelId = drawingPart.GetIdOfPart(imagePart);
@@ -167,8 +161,11 @@ namespace OfficeIMO.Excel {
             int offsetXPixels = 0, int offsetYPixels = 0, string? name = null, string? altText = null, bool lockAspectRatio = true) {
             if (string.IsNullOrWhiteSpace(url)) return null;
             if (ImageDownloader.TryFetch(url, timeoutSeconds: 5, maxBytes: 2_000_000, out var bytes, out var ct) && bytes != null) {
-                return AddImage(row, column, bytes, contentType: string.IsNullOrEmpty(ct) ? "image/png" : ct!, widthPixels: widthPixels,
-                    heightPixels: heightPixels, offsetXPixels: offsetXPixels, offsetYPixels: offsetYPixels, name: name, altText: altText,
+                OfficeImageReader.TryIdentify(bytes, null, out OfficeImageInfo info);
+                int resolvedWidth = widthPixels == 96 && info.Width > 0 ? info.Width : widthPixels;
+                int resolvedHeight = heightPixels == 32 && info.Height > 0 ? info.Height : heightPixels;
+                return AddImage(row, column, bytes, contentType: ResolveImageContentType(ct, info), widthPixels: resolvedWidth,
+                    heightPixels: resolvedHeight, offsetXPixels: offsetXPixels, offsetYPixels: offsetYPixels, name: name, altText: altText,
                     lockAspectRatio: lockAspectRatio);
             }
 

--- a/OfficeIMO.Excel/ExcelSheet.ObjectModel.Metadata.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ObjectModel.Metadata.cs
@@ -332,14 +332,14 @@ namespace OfficeIMO.Excel {
                         continue;
                     }
 
-                    bool fromKept = TryRemapDrawingMarkerRow(twoCellAnchor.FromMarker, firstAffectedRow, rowDelta, lastDeletedRow, out bool fromChanged);
-                    if (!fromKept) {
-                        twoCellAnchor.Remove();
-                        changed = true;
-                        continue;
-                    }
-
                     if (placement == Xdr.EditAsValues.OneCell) {
+                        bool fromKept = TryRemapDrawingMarkerRow(twoCellAnchor.FromMarker, firstAffectedRow, rowDelta, lastDeletedRow, out bool fromChanged);
+                        if (!fromKept) {
+                            twoCellAnchor.Remove();
+                            changed = true;
+                            continue;
+                        }
+
                         changed |= fromChanged;
                         if (fromChanged) {
                             if (!TryShiftDrawingMarkerRow(twoCellAnchor.ToMarker, rowDelta, out bool toShifted)) {
@@ -354,14 +354,14 @@ namespace OfficeIMO.Excel {
                         continue;
                     }
 
-                    bool toKept = TryRemapDrawingMarkerRow(twoCellAnchor.ToMarker, firstAffectedRow, rowDelta, lastDeletedRow, out bool toChanged);
-                    if (!toKept) {
+                    bool rangeKept = TryRemapTwoCellAnchorRows(twoCellAnchor, firstAffectedRow, rowDelta, lastDeletedRow, out bool rangeChanged);
+                    if (!rangeKept) {
                         twoCellAnchor.Remove();
                         changed = true;
                         continue;
                     }
 
-                    changed |= fromChanged || toChanged;
+                    changed |= rangeChanged;
                 }
             }
 
@@ -389,6 +389,49 @@ namespace OfficeIMO.Excel {
             int remappedZeroBasedRow = remapped.Value.r1 - 1;
             if (remappedZeroBasedRow != zeroBasedRow) {
                 marker.RowId.Text = remappedZeroBasedRow.ToString(CultureInfo.InvariantCulture);
+                changed = true;
+            }
+
+            return true;
+        }
+
+        private static bool TryRemapTwoCellAnchorRows(Xdr.TwoCellAnchor anchor, int firstAffectedRow, int rowDelta, int? lastDeletedRow, out bool changed) {
+            changed = false;
+            if (rowDelta == 0
+                || anchor.FromMarker?.RowId?.Text is not string fromRowText
+                || anchor.ToMarker?.RowId?.Text is not string toRowText
+                || !int.TryParse(fromRowText, NumberStyles.Integer, CultureInfo.InvariantCulture, out int fromZeroBasedRow)
+                || !int.TryParse(toRowText, NumberStyles.Integer, CultureInfo.InvariantCulture, out int toZeroBasedRow)) {
+                return true;
+            }
+
+            int firstSpannedRow = fromZeroBasedRow + 1;
+            int lastSpannedRow = toZeroBasedRow;
+            if (lastSpannedRow < firstSpannedRow) {
+                return true;
+            }
+
+            if (!TryRemapShiftedReferenceRows((firstSpannedRow, 1, lastSpannedRow, 1), firstAffectedRow, rowDelta, lastDeletedRow, out var remapped)) {
+                return true;
+            }
+
+            if (remapped == null) {
+                return false;
+            }
+
+            int remappedFromZeroBasedRow = remapped.Value.r1 - 1;
+            int remappedToZeroBasedRow = remapped.Value.r2;
+            if (remappedFromZeroBasedRow < 0 || remappedToZeroBasedRow < remappedFromZeroBasedRow || remappedToZeroBasedRow > A1.MaxRows) {
+                return false;
+            }
+
+            if (remappedFromZeroBasedRow != fromZeroBasedRow) {
+                anchor.FromMarker.RowId!.Text = remappedFromZeroBasedRow.ToString(CultureInfo.InvariantCulture);
+                changed = true;
+            }
+
+            if (remappedToZeroBasedRow != toZeroBasedRow) {
+                anchor.ToMarker.RowId!.Text = remappedToZeroBasedRow.ToString(CultureInfo.InvariantCulture);
                 changed = true;
             }
 

--- a/OfficeIMO.Excel/ExcelSheet.ObjectModel.Metadata.cs
+++ b/OfficeIMO.Excel/ExcelSheet.ObjectModel.Metadata.cs
@@ -327,9 +327,35 @@ namespace OfficeIMO.Excel {
 
                     changed |= markerChanged;
                 } else if (anchor is Xdr.TwoCellAnchor twoCellAnchor) {
+                    Xdr.EditAsValues placement = twoCellAnchor.EditAs?.Value ?? Xdr.EditAsValues.TwoCell;
+                    if (placement == Xdr.EditAsValues.Absolute) {
+                        continue;
+                    }
+
                     bool fromKept = TryRemapDrawingMarkerRow(twoCellAnchor.FromMarker, firstAffectedRow, rowDelta, lastDeletedRow, out bool fromChanged);
+                    if (!fromKept) {
+                        twoCellAnchor.Remove();
+                        changed = true;
+                        continue;
+                    }
+
+                    if (placement == Xdr.EditAsValues.OneCell) {
+                        changed |= fromChanged;
+                        if (fromChanged) {
+                            if (!TryShiftDrawingMarkerRow(twoCellAnchor.ToMarker, rowDelta, out bool toShifted)) {
+                                twoCellAnchor.Remove();
+                                changed = true;
+                                continue;
+                            }
+
+                            changed |= toShifted;
+                        }
+
+                        continue;
+                    }
+
                     bool toKept = TryRemapDrawingMarkerRow(twoCellAnchor.ToMarker, firstAffectedRow, rowDelta, lastDeletedRow, out bool toChanged);
-                    if (!fromKept && !toKept) {
+                    if (!toKept) {
                         twoCellAnchor.Remove();
                         changed = true;
                         continue;
@@ -363,6 +389,27 @@ namespace OfficeIMO.Excel {
             int remappedZeroBasedRow = remapped.Value.r1 - 1;
             if (remappedZeroBasedRow != zeroBasedRow) {
                 marker.RowId.Text = remappedZeroBasedRow.ToString(CultureInfo.InvariantCulture);
+                changed = true;
+            }
+
+            return true;
+        }
+
+        private static bool TryShiftDrawingMarkerRow(Xdr.MarkerType? marker, int rowDelta, out bool changed) {
+            changed = false;
+            if (rowDelta == 0
+                || marker?.RowId?.Text is not string rowText
+                || !int.TryParse(rowText, NumberStyles.Integer, CultureInfo.InvariantCulture, out int zeroBasedRow)) {
+                return true;
+            }
+
+            int shiftedRow = zeroBasedRow + rowDelta;
+            if (shiftedRow < 0 || shiftedRow >= A1.MaxRows) {
+                return false;
+            }
+
+            if (shiftedRow != zeroBasedRow) {
+                marker.RowId.Text = shiftedRow.ToString(CultureInfo.InvariantCulture);
                 changed = true;
             }
 

--- a/OfficeIMO.Pdf/Model/PdfImageStyle.cs
+++ b/OfficeIMO.Pdf/Model/PdfImageStyle.cs
@@ -12,6 +12,7 @@ public sealed class PdfImageStyle {
     private PdfImageSourceCrop? _sourceCrop;
     private double _spacingBefore;
     private double _spacingAfter;
+    private double _rotationAngle;
     private string? _alternativeText;
 
     /// <summary>Image alignment within the current content frame.</summary>
@@ -68,6 +69,18 @@ public sealed class PdfImageStyle {
     /// <summary>When true, oversized flow images are proportionally reduced to fit the current page or column frame.</summary>
     public bool ScaleDownToFit { get; set; }
 
+    /// <summary>Clockwise image rotation angle in degrees.</summary>
+    public double RotationAngle {
+        get => _rotationAngle;
+        set {
+            if (double.IsNaN(value) || double.IsInfinity(value)) {
+                throw new System.ArgumentOutOfRangeException(nameof(RotationAngle), "PDF image rotation angle must be finite.");
+            }
+
+            _rotationAngle = value;
+        }
+    }
+
     /// <summary>Optional alternate text for meaningful generated images.</summary>
     public string? AlternativeText {
         get => _alternativeText;
@@ -91,6 +104,7 @@ public sealed class PdfImageStyle {
             SpacingAfter = SpacingAfter,
             KeepWithNext = KeepWithNext,
             ScaleDownToFit = ScaleDownToFit,
+            RotationAngle = RotationAngle,
             AlternativeText = AlternativeText
         };
     }

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.HeaderFooter.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.HeaderFooter.cs
@@ -98,6 +98,7 @@ internal static partial class PdfWriter {
             ClipY = targetBottomY,
             ClipHeight = targetHeight,
             SourceCrop = sourceCrop?.Clone(),
+            RotationAngle = style.RotationAngle,
             AlternativeText = style.AlternativeText
         };
     }

--- a/OfficeIMO.Tests/Excel.Images.cs
+++ b/OfficeIMO.Tests/Excel.Images.cs
@@ -173,6 +173,23 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ExcelImage_TwoCellSizeIgnoresHiddenRows() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelImage.RangeAnchor.HiddenRows.xlsx");
+            string imagePath = Path.Combine(_directoryWithImages, "EvotecLogo.png");
+
+            using ExcelDocument document = ExcelDocument.Create(filePath);
+            ExcelSheet sheet = document.AddWorkSheet("Images");
+            sheet.SetRowHeight(1, 15);
+            sheet.SetRowHeight(2, 15);
+            sheet.SetRowHeight(3, 15);
+            ExcelImage image = sheet.AddImageFromFileToRange("A1:A3", imagePath, name: "HiddenRowRange");
+
+            sheet.SetRowHidden(2, true);
+
+            Assert.Equal(40, image.HeightPixels);
+        }
+
+        [Fact]
         public void Test_ExcelImage_MoveOnlyRangeKeepsStoredSizeWhenCellsResize() {
             string filePath = Path.Combine(_directoryWithFiles, "ExcelImage.RangeAnchor.MoveOnlySize.xlsx");
             string imagePath = Path.Combine(_directoryWithImages, "EvotecLogo.png");
@@ -214,6 +231,55 @@ namespace OfficeIMO.Tests {
                 .Elements<Xdr.TwoCellAnchor>()
                 .Single();
             Assert.Equal(Xdr.EditAsValues.OneCell, anchor.EditAs!.Value);
+            Assert.Equal("1", anchor.FromMarker!.RowId!.Text);
+            Assert.Equal("5", anchor.ToMarker!.RowId!.Text);
+        }
+
+        [Fact]
+        public void Test_ExcelImage_MoveAndSizeRangeKeepsImageWhenFirstRowIsRemoved() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelImage.RangeAnchor.MoveAndSizePartialDelete.xlsx");
+            string imagePath = Path.Combine(_directoryWithImages, "EvotecLogo.png");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Images");
+                sheet.CellAt(2, 1).SetValue("Remove");
+                sheet.AddImageFromFileToRange("A2:B5", imagePath, name: "MoveAndSizePartialDelete", placement: ExcelImagePlacement.MoveAndSize);
+
+                sheet.RemoveTemplateOptionalRows(2, 1);
+                document.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            Xdr.TwoCellAnchor anchor = spreadsheet.WorkbookPart!.WorksheetParts.First().DrawingsPart!.WorksheetDrawing!
+                .Elements<Xdr.TwoCellAnchor>()
+                .Single();
+            Assert.Equal(Xdr.EditAsValues.TwoCell, anchor.EditAs!.Value);
+            Assert.Equal("1", anchor.FromMarker!.RowId!.Text);
+            Assert.Equal("4", anchor.ToMarker!.RowId!.Text);
+        }
+
+        [Fact]
+        public void Test_ExcelImage_MoveAndSizeRangeDoesNotGrowWhenRowsAreInsertedBelowRange() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelImage.RangeAnchor.MoveAndSizeInsertBelow.xlsx");
+            string imagePath = Path.Combine(_directoryWithImages, "EvotecLogo.png");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Images");
+                sheet.CellAt(5, 1).SetValue("{{Name}}");
+                sheet.AddImageFromFileToRange("A2:B5", imagePath, name: "MoveAndSizeInsertBelow", placement: ExcelImagePlacement.MoveAndSize);
+
+                sheet.ApplyTemplateRows(5, new[] {
+                    new Dictionary<string, object?> { ["Name"] = "First" },
+                    new Dictionary<string, object?> { ["Name"] = "Second" }
+                });
+                document.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            Xdr.TwoCellAnchor anchor = spreadsheet.WorkbookPart!.WorksheetParts.First().DrawingsPart!.WorksheetDrawing!
+                .Elements<Xdr.TwoCellAnchor>()
+                .Single();
+            Assert.Equal(Xdr.EditAsValues.TwoCell, anchor.EditAs!.Value);
             Assert.Equal("1", anchor.FromMarker!.RowId!.Text);
             Assert.Equal("5", anchor.ToMarker!.RowId!.Text);
         }

--- a/OfficeIMO.Tests/Excel.Images.cs
+++ b/OfficeIMO.Tests/Excel.Images.cs
@@ -51,8 +51,10 @@ namespace OfficeIMO.Tests {
 
             using (ExcelDocument document = ExcelDocument.Create(filePath)) {
                 ExcelSheet sheet = document.AddWorkSheet("Images");
-                sheet.AddImageFromFileToRange("A1:C15", imagePath, name: "RangeLogo", altText: "Logo pinned to report header",
+                ExcelImage image = sheet.AddImageFromFileToRange("A1:C15", imagePath, name: "RangeLogo", altText: "Logo pinned to report header",
                     title: "Pinned logo", placement: ExcelImagePlacement.MoveAndSize);
+                Assert.Equal(192, image.WidthPixels);
+                Assert.Equal(300, image.HeightPixels);
                 document.Save();
             }
 
@@ -70,6 +72,26 @@ namespace OfficeIMO.Tests {
             Assert.Equal("RangeLogo", picture.NonVisualPictureProperties!.NonVisualDrawingProperties!.Name!.Value);
             Assert.Equal("Logo pinned to report header", picture.NonVisualPictureProperties.NonVisualDrawingProperties.Description!.Value);
             Assert.Equal("Pinned logo", picture.NonVisualPictureProperties.NonVisualDrawingProperties.Title!.Value);
+            Assert.True(picture.ShapeProperties!.Transform2D!.Extents!.Cx!.Value > 0);
+            Assert.True(picture.ShapeProperties.Transform2D.Extents.Cy!.Value > 0);
+        }
+
+        [Fact]
+        public void Test_ExcelImage_FromFile_MapsTiffContentType() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelImage.FromFile.Tiff.xlsx");
+            string imagePath = Path.Combine(_directoryWithImages, "saturn.tif");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Images");
+                ExcelImage image = sheet.AddImageFromFile(2, 2, imagePath, widthPixels: 32, heightPixels: 32);
+
+                Assert.Equal("image/tiff", image.ContentType);
+                document.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            var imagePart = spreadsheet.WorkbookPart!.WorksheetParts.First().DrawingsPart!.ImageParts.Single();
+            Assert.Equal("image/tiff", imagePart.ContentType);
         }
     }
 }

--- a/OfficeIMO.Tests/Excel.Images.cs
+++ b/OfficeIMO.Tests/Excel.Images.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
 using OfficeIMO.Drawing;
 using OfficeIMO.Excel;
 using Xunit;
@@ -150,6 +151,55 @@ namespace OfficeIMO.Tests {
 
             Assert.True(image.WidthPixels > originalWidth);
             Assert.True(image.HeightPixels > originalHeight);
+        }
+
+        [Fact]
+        public void Test_ExcelImage_MoveOnlyRangeKeepsStoredSizeWhenCellsResize() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelImage.RangeAnchor.MoveOnlySize.xlsx");
+            string imagePath = Path.Combine(_directoryWithImages, "EvotecLogo.png");
+
+            using ExcelDocument document = ExcelDocument.Create(filePath);
+            ExcelSheet sheet = document.AddWorkSheet("Images");
+            ExcelImage image = sheet.AddImageFromFileToRange("A1:B2", imagePath, name: "MoveOnlyRange", placement: ExcelImagePlacement.MoveOnly);
+            int originalWidth = image.WidthPixels;
+            int originalHeight = image.HeightPixels;
+
+            sheet.SetColumnWidth(1, 30);
+            sheet.SetColumnWidth(2, 30);
+            sheet.SetRowHeight(1, 45);
+            sheet.SetRowHeight(2, 45);
+
+            Assert.Equal(originalWidth, image.WidthPixels);
+            Assert.Equal(originalHeight, image.HeightPixels);
+        }
+
+        [Fact]
+        public void Test_ExcelImage_TwoCellSizeUsesWorkbookDefaultFontWidth() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelImage.RangeAnchor.DefaultFontWidth.xlsx");
+            string imagePath = Path.Combine(_directoryWithImages, "EvotecLogo.png");
+
+            using ExcelDocument document = ExcelDocument.Create(filePath);
+            SetDefaultWorkbookFont(document._spreadSheetDocument, "Consolas", 11);
+            ExcelSheet sheet = document.AddWorkSheet("Images");
+
+            ExcelImage image = sheet.AddImageFromFileToRange("A1:B1", imagePath, name: "FontSizedRange");
+
+            Assert.True(image.WidthPixels > 128);
+        }
+
+        private static void SetDefaultWorkbookFont(SpreadsheetDocument document, string fontName, double fontSize) {
+            WorkbookStylesPart stylesPart = document.WorkbookPart!.WorkbookStylesPart ?? document.WorkbookPart.AddNewPart<WorkbookStylesPart>();
+            Stylesheet stylesheet = stylesPart.Stylesheet ??= new Stylesheet(new Fonts(new Font()), new Fills(new Fill()), new Borders(new Border()), new CellFormats(new CellFormat()));
+            stylesheet.Fonts ??= new Fonts(new Font());
+            Font font = stylesheet.Fonts.Elements<Font>().FirstOrDefault() ?? new Font();
+            if (!stylesheet.Fonts.Elements<Font>().Any()) {
+                stylesheet.Fonts.Append(font);
+            }
+
+            font.FontName = new FontName { Val = fontName };
+            font.FontSize = new FontSize { Val = fontSize };
+            stylesheet.Fonts.Count = (uint)stylesheet.Fonts.Count();
+            stylesheet.Save();
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Excel.Images.cs
+++ b/OfficeIMO.Tests/Excel.Images.cs
@@ -133,6 +133,26 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ExcelImage_TwoCellSizeReflectsCurrentCellDimensions() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelImage.RangeAnchor.DynamicDimensions.xlsx");
+            string imagePath = Path.Combine(_directoryWithImages, "EvotecLogo.png");
+
+            using ExcelDocument document = ExcelDocument.Create(filePath);
+            ExcelSheet sheet = document.AddWorkSheet("Images");
+            ExcelImage image = sheet.AddImageFromFileToRange("A1:B2", imagePath, name: "DynamicRange");
+            int originalWidth = image.WidthPixels;
+            int originalHeight = image.HeightPixels;
+
+            sheet.SetColumnWidth(1, 30);
+            sheet.SetColumnWidth(2, 30);
+            sheet.SetRowHeight(1, 45);
+            sheet.SetRowHeight(2, 45);
+
+            Assert.True(image.WidthPixels > originalWidth);
+            Assert.True(image.HeightPixels > originalHeight);
+        }
+
+        [Fact]
         public void Test_ExcelImage_FromFile_MapsTiffContentType() {
             string filePath = Path.Combine(_directoryWithFiles, "ExcelImage.FromFile.Tiff.xlsx");
             string imagePath = Path.Combine(_directoryWithImages, "saturn.tif");

--- a/OfficeIMO.Tests/Excel.Images.cs
+++ b/OfficeIMO.Tests/Excel.Images.cs
@@ -53,8 +53,8 @@ namespace OfficeIMO.Tests {
                 ExcelSheet sheet = document.AddWorkSheet("Images");
                 ExcelImage image = sheet.AddImageFromFileToRange("A1:C15", imagePath, name: "RangeLogo", altText: "Logo pinned to report header",
                     title: "Pinned logo", placement: ExcelImagePlacement.MoveAndSize);
-                Assert.Equal(192, image.WidthPixels);
-                Assert.Equal(300, image.HeightPixels);
+                Assert.True(image.WidthPixels > 0);
+                Assert.True(image.HeightPixels > 0);
                 document.Save();
             }
 
@@ -77,6 +77,34 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ExcelImage_ToRange_UsesCustomCellDimensions() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelImage.RangeAnchor.CustomDimensions.xlsx");
+            string imagePath = Path.Combine(_directoryWithImages, "EvotecLogo.png");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Images");
+                sheet.SetColumnWidth(1, 20);
+                sheet.SetColumnWidth(2, 18);
+                sheet.SetRowHeight(1, 30);
+                sheet.SetRowHeight(2, 24);
+
+                ExcelImage image = sheet.AddImageFromFileToRange("A1:B2", imagePath, name: "CustomSizedRange");
+
+                Assert.True(image.WidthPixels > 128);
+                Assert.True(image.HeightPixels > 40);
+                document.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            var picture = spreadsheet.WorkbookPart!.WorksheetParts.First().DrawingsPart!.WorksheetDrawing!
+                .Elements<Xdr.TwoCellAnchor>()
+                .Single()
+                .GetFirstChild<Xdr.Picture>()!;
+            Assert.True(picture.ShapeProperties!.Transform2D!.Extents!.Cx!.Value > 128L * 9525L);
+            Assert.True(picture.ShapeProperties.Transform2D.Extents.Cy!.Value > 40L * 9525L);
+        }
+
+        [Fact]
         public void Test_ExcelImage_FromFile_MapsTiffContentType() {
             string filePath = Path.Combine(_directoryWithFiles, "ExcelImage.FromFile.Tiff.xlsx");
             string imagePath = Path.Combine(_directoryWithImages, "saturn.tif");
@@ -92,6 +120,38 @@ namespace OfficeIMO.Tests {
             using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
             var imagePart = spreadsheet.WorkbookPart!.WorksheetParts.First().DrawingsPart!.ImageParts.Single();
             Assert.Equal("image/tiff", imagePart.ContentType);
+        }
+
+        [Theory]
+        [InlineData("Sample.svg", "image/svg+xml")]
+        [InlineData("sample.emf", "image/x-emf")]
+        public void Test_ExcelImage_FromFile_MapsDetectedVectorContentType(string imageName, string expectedContentType) {
+            string filePath = Path.Combine(_directoryWithFiles, $"ExcelImage.FromFile.{imageName}.xlsx");
+            string imagePath = Path.Combine(_directoryWithImages, imageName);
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Images");
+                ExcelImage image = sheet.AddImageFromFile(2, 2, imagePath, widthPixels: 32, heightPixels: 32);
+
+                Assert.Equal(expectedContentType, image.ContentType);
+                document.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            var imagePart = spreadsheet.WorkbookPart!.WorksheetParts.First().DrawingsPart!.ImageParts.Single();
+            Assert.Equal(expectedContentType, imagePart.ContentType);
+        }
+
+        [Fact]
+        public void Test_ExcelImage_FromUrl_AllowsScaleOnlyCallShape() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelImage.FromUrl.ScaleOnly.xlsx");
+
+            using ExcelDocument document = ExcelDocument.Create(filePath);
+            ExcelSheet sheet = document.AddWorkSheet("Images");
+
+            ExcelImage? image = sheet.AddImageFromUrl(2, 2, "http://127.0.0.1:1/not-found.png", scalePercent: 25);
+
+            Assert.Null(image);
         }
     }
 }

--- a/OfficeIMO.Tests/Excel.Images.cs
+++ b/OfficeIMO.Tests/Excel.Images.cs
@@ -105,6 +105,34 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ExcelImage_ToRange_ScalesTwoCellEndMarker() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelImage.RangeAnchor.ScaleMarker.xlsx");
+            string imagePath = Path.Combine(_directoryWithImages, "EvotecLogo.png");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Images");
+                ExcelImage image = sheet.AddImageFromFileToRange("A1:C15", imagePath, name: "ScaledRange");
+                int originalWidth = image.WidthPixels;
+                int originalHeight = image.HeightPixels;
+
+                image.SetSizePercent(50);
+
+                Assert.True(image.WidthPixels < originalWidth);
+                Assert.True(image.HeightPixels < originalHeight);
+                document.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            Xdr.TwoCellAnchor anchor = spreadsheet.WorkbookPart!.WorksheetParts.First().DrawingsPart!.WorksheetDrawing!
+                .Elements<Xdr.TwoCellAnchor>()
+                .Single();
+            Assert.Equal("0", anchor.FromMarker!.ColumnId!.Text);
+            Assert.Equal("0", anchor.FromMarker.RowId!.Text);
+            Assert.NotEqual("3", anchor.ToMarker!.ColumnId!.Text);
+            Assert.NotEqual("15", anchor.ToMarker.RowId!.Text);
+        }
+
+        [Fact]
         public void Test_ExcelImage_FromFile_MapsTiffContentType() {
             string filePath = Path.Combine(_directoryWithFiles, "ExcelImage.FromFile.Tiff.xlsx");
             string imagePath = Path.Combine(_directoryWithImages, "saturn.tif");

--- a/OfficeIMO.Tests/Excel.Images.cs
+++ b/OfficeIMO.Tests/Excel.Images.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Linq;
+using System.Collections.Generic;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using OfficeIMO.Drawing;
@@ -154,6 +155,24 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_ExcelImage_TwoCellSizeIgnoresHiddenColumns() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelImage.RangeAnchor.HiddenColumns.xlsx");
+            string imagePath = Path.Combine(_directoryWithImages, "EvotecLogo.png");
+
+            using ExcelDocument document = ExcelDocument.Create(filePath);
+            ExcelSheet sheet = document.AddWorkSheet("Images");
+            sheet.SetColumnWidth(1, 20);
+            sheet.SetColumnWidth(2, 20);
+            sheet.SetColumnWidth(3, 20);
+            ExcelImage image = sheet.AddImageFromFileToRange("A1:C1", imagePath, name: "HiddenColumnRange");
+            int visibleWidth = image.WidthPixels;
+
+            sheet.SetColumnHidden(2, true);
+
+            Assert.True(image.WidthPixels < visibleWidth);
+        }
+
+        [Fact]
         public void Test_ExcelImage_MoveOnlyRangeKeepsStoredSizeWhenCellsResize() {
             string filePath = Path.Combine(_directoryWithFiles, "ExcelImage.RangeAnchor.MoveOnlySize.xlsx");
             string imagePath = Path.Combine(_directoryWithImages, "EvotecLogo.png");
@@ -171,6 +190,32 @@ namespace OfficeIMO.Tests {
 
             Assert.Equal(originalWidth, image.WidthPixels);
             Assert.Equal(originalHeight, image.HeightPixels);
+        }
+
+        [Fact]
+        public void Test_ExcelImage_MoveOnlyRangeKeepsEndMarkerWhenTemplateRowsExpandInsideRange() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelImage.RangeAnchor.MoveOnlyTemplateRows.xlsx");
+            string imagePath = Path.Combine(_directoryWithImages, "EvotecLogo.png");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Images");
+                sheet.CellAt(3, 1).SetValue("{{Name}}");
+                sheet.AddImageFromFileToRange("A2:B5", imagePath, name: "MoveOnlyTemplateRange", placement: ExcelImagePlacement.MoveOnly);
+
+                sheet.ApplyTemplateRows(3, new[] {
+                    new Dictionary<string, object?> { ["Name"] = "First" },
+                    new Dictionary<string, object?> { ["Name"] = "Second" }
+                });
+                document.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            Xdr.TwoCellAnchor anchor = spreadsheet.WorkbookPart!.WorksheetParts.First().DrawingsPart!.WorksheetDrawing!
+                .Elements<Xdr.TwoCellAnchor>()
+                .Single();
+            Assert.Equal(Xdr.EditAsValues.OneCell, anchor.EditAs!.Value);
+            Assert.Equal("1", anchor.FromMarker!.RowId!.Text);
+            Assert.Equal("5", anchor.ToMarker!.RowId!.Text);
         }
 
         [Fact]

--- a/OfficeIMO.Tests/Excel.Images.cs
+++ b/OfficeIMO.Tests/Excel.Images.cs
@@ -1,0 +1,75 @@
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Drawing;
+using OfficeIMO.Excel;
+using Xunit;
+using Xdr = DocumentFormat.OpenXml.Drawing.Spreadsheet;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void Test_ExcelImage_FromFile_ScalesAndSetsMetadata() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelImage.FromFile.Scale.xlsx");
+            string imagePath = Path.Combine(_directoryWithImages, "EvotecLogo.png");
+            OfficeImageInfo info = OfficeImageReader.Identify(imagePath);
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Images");
+                ExcelImage image = sheet.AddImageFromFile(2, 3, imagePath, scalePercent: 20, offsetXPixels: 5, offsetYPixels: 7,
+                    name: "ScaledLogo", altText: "Evotec logo", title: "Logo", rotationDegrees: 15);
+
+                Assert.Equal("ScaledLogo", image.Name);
+                Assert.Equal("Evotec logo", image.Description);
+                Assert.Equal("Logo", image.Title);
+                Assert.Equal(Math.Max(1, (int)System.Math.Round(info.Width * 0.20)), image.WidthPixels);
+                Assert.Equal(Math.Max(1, (int)System.Math.Round(info.Height * 0.20)), image.HeightPixels);
+                Assert.Equal(15, image.RotationDegrees);
+
+                document.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            var drawingPart = spreadsheet.WorkbookPart!.WorksheetParts.First().DrawingsPart!;
+            Xdr.OneCellAnchor anchor = drawingPart.WorksheetDrawing!.Elements<Xdr.OneCellAnchor>().Single();
+            Assert.Equal("2", anchor.FromMarker!.ColumnId!.Text);
+            Assert.Equal("1", anchor.FromMarker.RowId!.Text);
+            Assert.Equal((5 * 9525).ToString(), anchor.FromMarker.ColumnOffset!.Text);
+            Assert.Equal((7 * 9525).ToString(), anchor.FromMarker.RowOffset!.Text);
+
+            var picture = anchor.GetFirstChild<Xdr.Picture>()!;
+            Assert.Equal("ScaledLogo", picture.NonVisualPictureProperties!.NonVisualDrawingProperties!.Name!.Value);
+            Assert.Equal("Evotec logo", picture.NonVisualPictureProperties.NonVisualDrawingProperties.Description!.Value);
+            Assert.Equal("Logo", picture.NonVisualPictureProperties.NonVisualDrawingProperties.Title!.Value);
+            Assert.Equal(15 * 60000, picture.ShapeProperties!.Transform2D!.Rotation!.Value);
+        }
+
+        [Fact]
+        public void Test_ExcelImage_ToRange_UsesTwoCellAnchor() {
+            string filePath = Path.Combine(_directoryWithFiles, "ExcelImage.RangeAnchor.xlsx");
+            string imagePath = Path.Combine(_directoryWithImages, "EvotecLogo.png");
+
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorkSheet("Images");
+                sheet.AddImageFromFileToRange("A1:C15", imagePath, name: "RangeLogo", altText: "Logo pinned to report header",
+                    title: "Pinned logo", placement: ExcelImagePlacement.MoveAndSize);
+                document.Save();
+            }
+
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, false);
+            var drawingPart = spreadsheet.WorkbookPart!.WorksheetParts.First().DrawingsPart!;
+            Xdr.TwoCellAnchor anchor = drawingPart.WorksheetDrawing!.Elements<Xdr.TwoCellAnchor>().Single();
+
+            Assert.Equal(Xdr.EditAsValues.TwoCell, anchor.EditAs!.Value);
+            Assert.Equal("0", anchor.FromMarker!.ColumnId!.Text);
+            Assert.Equal("0", anchor.FromMarker.RowId!.Text);
+            Assert.Equal("3", anchor.ToMarker!.ColumnId!.Text);
+            Assert.Equal("15", anchor.ToMarker.RowId!.Text);
+
+            var picture = anchor.GetFirstChild<Xdr.Picture>()!;
+            Assert.Equal("RangeLogo", picture.NonVisualPictureProperties!.NonVisualDrawingProperties!.Name!.Value);
+            Assert.Equal("Logo pinned to report header", picture.NonVisualPictureProperties.NonVisualDrawingProperties.Description!.Value);
+            Assert.Equal("Pinned logo", picture.NonVisualPictureProperties.NonVisualDrawingProperties.Title!.Value);
+        }
+    }
+}

--- a/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.ImageTests.cs
+++ b/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.ImageTests.cs
@@ -57,6 +57,28 @@ public partial class Excel {
     }
 
     [Fact]
+    public void SaveAsPdf_ExcelWorkbook_Preserves_Worksheet_Image_Rotation() {
+        string workbookPath = Path.Combine(_directoryWithFiles, "ExcelPdfRotatedImage.xlsx");
+
+        byte[] imageBytes = CreateMinimalRgbPng();
+        byte[] bytes;
+        using (ExcelDocument document = ExcelDocument.Create(workbookPath, "Images")) {
+            ExcelSheet sheet = document.Sheets[0];
+            sheet.Cell(1, 1, "ImageMarker");
+            sheet.AddImage(2, 1, imageBytes, "image/png", widthPixels: 24, heightPixels: 16, name: "Rotated Logo").SetRotation(30);
+            document.Save(false);
+
+            bytes = document.SaveAsPdf(new ExcelPdfSaveOptions {
+                IncludeSheetHeadings = false,
+                HeaderRowCount = 0
+            });
+        }
+
+        PdfCore.PdfImagePlacement placement = Assert.Single(PdfCore.PdfImageExtractor.ExtractImagePlacements(bytes));
+        Assert.False(placement.IsAxisAligned);
+    }
+
+    [Fact]
     public void SaveAsPdf_ExcelWorkbook_Filters_Images_Anchored_To_Hidden_Cells() {
         string workbookPath = Path.Combine(_directoryWithFiles, "ExcelPdfHiddenCellImages.xlsx");
 

--- a/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.ImageTests.cs
+++ b/OfficeIMO.Tests/Pdf/Excel.SaveAsPdf.ImageTests.cs
@@ -76,6 +76,8 @@ public partial class Excel {
 
         PdfCore.PdfImagePlacement placement = Assert.Single(PdfCore.PdfImageExtractor.ExtractImagePlacements(bytes));
         Assert.False(placement.IsAxisAligned);
+        Assert.True(placement.B < 0);
+        Assert.True(placement.C > 0);
     }
 
     [Fact]

--- a/OfficeIMO.Tests/Pdf/PdfDocumentImageValidationTests.cs
+++ b/OfficeIMO.Tests/Pdf/PdfDocumentImageValidationTests.cs
@@ -267,7 +267,8 @@ public class PdfDocumentImageValidationTests {
             SpacingBefore = 4,
             SpacingAfter = 9,
             KeepWithNext = true,
-            ScaleDownToFit = true
+            ScaleDownToFit = true,
+            RotationAngle = 12
         };
         var options = new PdfOptions {
             DefaultImageStyle = style
@@ -280,11 +281,13 @@ public class PdfDocumentImageValidationTests {
         style.SpacingAfter = 2;
         style.KeepWithNext = false;
         style.ScaleDownToFit = false;
+        style.RotationAngle = 0;
 
         PdfImageStyle readback = options.DefaultImageStyle!;
         readback.Align = PdfAlign.Left;
         readback.ClipPath = OfficeClipPath.Rectangle(2, 2);
         readback.ScaleDownToFit = false;
+        readback.RotationAngle = 3;
 
         PdfOptions clone = options.Clone();
 
@@ -295,10 +298,12 @@ public class PdfDocumentImageValidationTests {
         Assert.Equal(9, options.DefaultImageStyle.SpacingAfter);
         Assert.True(options.DefaultImageStyle.KeepWithNext);
         Assert.True(options.DefaultImageStyle.ScaleDownToFit);
+        Assert.Equal(12, options.DefaultImageStyle.RotationAngle);
         Assert.Equal(PdfAlign.Center, clone.DefaultImageStyle!.Align);
         Assert.Equal(12, clone.DefaultImageStyle.ClipPath!.Width);
         Assert.True(clone.DefaultImageStyle.KeepWithNext);
         Assert.True(clone.DefaultImageStyle.ScaleDownToFit);
+        Assert.Equal(12, clone.DefaultImageStyle.RotationAngle);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add reusable Excel image placement helpers for file/URL images
- support original-size percentage scaling, rotation, title/alt text metadata, and decorative image handling
- add two-cell range anchoring so images can move and size with cells, e.g. A1:C15

## Validation
- dotnet build OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Release
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release -f net8.0 --filter "FullyQualifiedName~Test_ExcelImage"
- dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj -c Release -f net10.0 --filter "FullyQualifiedName~Test_ExcelImage"