### PR TITLE
Add normal legacy XLS load flow

### DIFF
--- a/Docs/officeimo.excel.legacy-xls-roadmap.md
+++ b/Docs/officeimo.excel.legacy-xls-roadmap.md
@@ -21,18 +21,28 @@ projector owns mapping decisions into OfficeIMO's Open XML workbook model.
 
 ## Current Public API Shape
 
-Legacy `.xls` import is currently explicit. Callers use
-`ExcelDocument.LoadLegacyXls(...)` when they want the projected `ExcelDocument`,
-or `ExcelDocument.LoadLegacyXlsWithReport(...)` when they also want the parsed
-legacy workbook, diagnostics, and import report. Normal `ExcelDocument.Load(...)`
-continues to mean Open XML workbook loading.
+Legacy `.xls` import is part of the normal workbook loading flow. Callers use
+`ExcelDocument.Load(...)` for both Open XML workbooks and legacy binary `.xls`
+workbooks:
 
-That explicit surface is intentional for the current preview-quality import
-phase: it makes `.xls` conversion visible, keeps unsupported/preserve-only
-features easy to inspect, and avoids silently implying full `.xls` edit/save
-support. A future convenience API can be considered after the import model,
-diagnostics, and user expectations are settled, but native `.xls` save remains
-out of scope for this roadmap.
+```csharp
+using var document = ExcelDocument.Load("legacy.xls");
+document.Save("converted.xlsx");
+```
+
+OfficeIMO detects ZIP/Open XML packages and routes them through the existing
+Open XML loader. OLE compound legacy workbooks are routed through the first-party
+legacy XLS importer, then projected into the normal `ExcelDocument` model.
+Saving produces Open XML `.xlsx` content. Native `.xls` writing is not supported;
+attempts to save a legacy-loaded document to `.xls`, including implicit
+`Save()` back to the original `.xls` path, throw a clear exception.
+
+`ExcelDocument.LoadLegacyXls(...)` and `ExcelDocument.LoadLegacyXlsWithReport(...)`
+remain available for tests and advanced diagnostics. Normal callers should not
+need a separate method. Import diagnostics and preserve-only/unsupported legacy
+features are attached to the loaded `ExcelDocument` and surfaced through
+`InspectFeatures()`; hard blockers such as encrypted/password-protected legacy
+workbooks or unsupported BIFF versions fail the normal load.
 
 ## Phase 1 - Foundation
 

--- a/OfficeIMO.Excel/ExcelDocument.CreateLoad.cs
+++ b/OfficeIMO.Excel/ExcelDocument.CreateLoad.cs
@@ -307,9 +307,7 @@ namespace OfficeIMO.Excel {
                 throw new InvalidDataException("Legacy XLS import failed: " + FormatLegacyXlsDiagnostics(errors));
             }
 
-            ExcelDocument document = workbook.ToExcelDocument();
-            document.MarkLoadedFromLegacyXls(filePath, workbook);
-            return document;
+            return ProjectLoadedLegacyXlsWorkbook(workbook, filePath);
         }
 
         private static string FormatLegacyXlsDiagnostics(IEnumerable<LegacyXlsImportDiagnostic> diagnostics) {

--- a/OfficeIMO.Excel/ExcelDocument.CreateLoad.cs
+++ b/OfficeIMO.Excel/ExcelDocument.CreateLoad.cs
@@ -2,6 +2,9 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using DocumentFormat.OpenXml.Validation;
+using OfficeIMO.Excel.LegacyXls;
+using OfficeIMO.Excel.LegacyXls.Diagnostics;
+using OfficeIMO.Excel.LegacyXls.Model;
 using OfficeIMO.Excel.Utilities;
 using OfficeIMO.Shared;
 using System.IO.Packaging;
@@ -167,6 +170,10 @@ namespace OfficeIMO.Excel {
             bool leaveOriginalStreamOpen = true) {
             if (bytes == null) throw new ArgumentNullException(nameof(bytes));
 
+            if (ExcelDocumentLoadRouting.IsLegacyXls(bytes, filePath)) {
+                return LoadLegacyXlsFromNormalFlow(bytes, readOnly, autoSave, filePath, openSettings);
+            }
+
             var effectiveOpenSettings = CreateOpenSettings(openSettings, autoSave);
             bool shouldCopyBack = copyBackToSource && originalStream != null;
             bool shouldCopyBackToFilePath = !shouldCopyBack && !string.IsNullOrEmpty(filePath) && ShouldCopyBackToSource(readOnly, autoSave, openSettings);
@@ -278,6 +285,42 @@ namespace OfficeIMO.Excel {
             }
 
             return openSettings?.AutoSave == true;
+        }
+
+        private static ExcelDocument LoadLegacyXlsFromNormalFlow(
+            byte[] bytes,
+            bool readOnly,
+            bool autoSave,
+            string? filePath,
+            OpenSettings? openSettings) {
+            if (ShouldCopyBackToSource(readOnly, autoSave, openSettings)) {
+                throw new NotSupportedException("Auto-save is not supported when loading legacy binary .xls files. Save to a new .xlsx path instead.");
+            }
+
+            LegacyXlsWorkbook workbook = LegacyXlsWorkbook.Load(bytes, new LegacyXlsImportOptions {
+                ReportUnsupportedRecords = true
+            });
+            LegacyXlsImportDiagnostic[] errors = workbook.Diagnostics
+                .Where(diagnostic => diagnostic.Severity == LegacyXlsDiagnosticSeverity.Error)
+                .ToArray();
+            if (errors.Length > 0) {
+                throw new InvalidDataException("Legacy XLS import failed: " + FormatLegacyXlsDiagnostics(errors));
+            }
+
+            ExcelDocument document = workbook.ToExcelDocument();
+            document.MarkLoadedFromLegacyXls(filePath, workbook);
+            return document;
+        }
+
+        private static string FormatLegacyXlsDiagnostics(IEnumerable<LegacyXlsImportDiagnostic> diagnostics) {
+            const int maxDiagnostics = 6;
+            LegacyXlsImportDiagnostic[] selected = diagnostics.Take(maxDiagnostics + 1).ToArray();
+            string message = string.Join("; ", selected.Take(maxDiagnostics).Select(diagnostic => diagnostic.ToString()));
+            if (selected.Length > maxDiagnostics) {
+                message += $"; +{selected.Length - maxDiagnostics} more";
+            }
+
+            return message;
         }
 
         /// <summary>

--- a/OfficeIMO.Excel/ExcelDocument.LegacyXls.cs
+++ b/OfficeIMO.Excel/ExcelDocument.LegacyXls.cs
@@ -18,7 +18,7 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public static LegacyXlsLoadResult LoadLegacyXlsWithReport(string path, LegacyXlsImportOptions? options = null) {
             LegacyXlsWorkbook workbook = LegacyXlsWorkbook.Load(path, options);
-            return new LegacyXlsLoadResult(ProjectLoadedLegacyXlsWorkbook(workbook, path), workbook);
+            return CreateLegacyXlsLoadResult(workbook, path);
         }
 
         /// <summary>
@@ -36,7 +36,15 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public static LegacyXlsLoadResult LoadLegacyXlsWithReport(Stream stream, LegacyXlsImportOptions? options = null) {
             LegacyXlsWorkbook workbook = LegacyXlsWorkbook.Load(stream, options);
-            return new LegacyXlsLoadResult(ProjectLoadedLegacyXlsWorkbook(workbook, sourcePath: null), workbook);
+            return CreateLegacyXlsLoadResult(workbook, sourcePath: null);
+        }
+
+        private static LegacyXlsLoadResult CreateLegacyXlsLoadResult(LegacyXlsWorkbook workbook, string? sourcePath) {
+            try {
+                return new LegacyXlsLoadResult(ProjectLoadedLegacyXlsWorkbook(workbook, sourcePath), workbook);
+            } catch (InvalidDataException exception) {
+                return new LegacyXlsLoadResult(document: null, workbook, exception);
+            }
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelDocument.LegacyXls.cs
+++ b/OfficeIMO.Excel/ExcelDocument.LegacyXls.cs
@@ -9,9 +9,7 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public static ExcelDocument LoadLegacyXls(string path, LegacyXlsImportOptions? options = null) {
             LegacyXlsWorkbook workbook = LegacyXlsWorkbook.Load(path, options);
-            ExcelDocument document = workbook.ToExcelDocument();
-            document.MarkLoadedFromLegacyXls(path, workbook);
-            return document;
+            return ProjectLoadedLegacyXlsWorkbook(workbook, path);
         }
 
         /// <summary>
@@ -20,9 +18,7 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public static LegacyXlsLoadResult LoadLegacyXlsWithReport(string path, LegacyXlsImportOptions? options = null) {
             LegacyXlsWorkbook workbook = LegacyXlsWorkbook.Load(path, options);
-            ExcelDocument document = workbook.ToExcelDocument();
-            document.MarkLoadedFromLegacyXls(path, workbook);
-            return new LegacyXlsLoadResult(document, workbook);
+            return new LegacyXlsLoadResult(ProjectLoadedLegacyXlsWorkbook(workbook, path), workbook);
         }
 
         /// <summary>
@@ -31,9 +27,7 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public static ExcelDocument LoadLegacyXls(Stream stream, LegacyXlsImportOptions? options = null) {
             LegacyXlsWorkbook workbook = LegacyXlsWorkbook.Load(stream, options);
-            ExcelDocument document = workbook.ToExcelDocument();
-            document.MarkLoadedFromLegacyXls(sourcePath: null, workbook);
-            return document;
+            return ProjectLoadedLegacyXlsWorkbook(workbook, sourcePath: null);
         }
 
         /// <summary>
@@ -42,9 +36,7 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public static LegacyXlsLoadResult LoadLegacyXlsWithReport(Stream stream, LegacyXlsImportOptions? options = null) {
             LegacyXlsWorkbook workbook = LegacyXlsWorkbook.Load(stream, options);
-            ExcelDocument document = workbook.ToExcelDocument();
-            document.MarkLoadedFromLegacyXls(sourcePath: null, workbook);
-            return new LegacyXlsLoadResult(document, workbook);
+            return new LegacyXlsLoadResult(ProjectLoadedLegacyXlsWorkbook(workbook, sourcePath: null), workbook);
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelDocument.LegacyXls.cs
+++ b/OfficeIMO.Excel/ExcelDocument.LegacyXls.cs
@@ -8,7 +8,10 @@ namespace OfficeIMO.Excel {
         /// The resulting document saves as Open XML `.xlsx`; native `.xls` save is intentionally out of scope.
         /// </summary>
         public static ExcelDocument LoadLegacyXls(string path, LegacyXlsImportOptions? options = null) {
-            return LegacyXlsWorkbook.Load(path, options).ToExcelDocument();
+            LegacyXlsWorkbook workbook = LegacyXlsWorkbook.Load(path, options);
+            ExcelDocument document = workbook.ToExcelDocument();
+            document.MarkLoadedFromLegacyXls(path, workbook);
+            return document;
         }
 
         /// <summary>
@@ -17,7 +20,9 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public static LegacyXlsLoadResult LoadLegacyXlsWithReport(string path, LegacyXlsImportOptions? options = null) {
             LegacyXlsWorkbook workbook = LegacyXlsWorkbook.Load(path, options);
-            return new LegacyXlsLoadResult(workbook.ToExcelDocument(), workbook);
+            ExcelDocument document = workbook.ToExcelDocument();
+            document.MarkLoadedFromLegacyXls(path, workbook);
+            return new LegacyXlsLoadResult(document, workbook);
         }
 
         /// <summary>
@@ -25,7 +30,10 @@ namespace OfficeIMO.Excel {
         /// The resulting document saves as Open XML `.xlsx`; native `.xls` save is intentionally out of scope.
         /// </summary>
         public static ExcelDocument LoadLegacyXls(Stream stream, LegacyXlsImportOptions? options = null) {
-            return LegacyXlsWorkbook.Load(stream, options).ToExcelDocument();
+            LegacyXlsWorkbook workbook = LegacyXlsWorkbook.Load(stream, options);
+            ExcelDocument document = workbook.ToExcelDocument();
+            document.MarkLoadedFromLegacyXls(sourcePath: null, workbook);
+            return document;
         }
 
         /// <summary>
@@ -34,7 +42,9 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public static LegacyXlsLoadResult LoadLegacyXlsWithReport(Stream stream, LegacyXlsImportOptions? options = null) {
             LegacyXlsWorkbook workbook = LegacyXlsWorkbook.Load(stream, options);
-            return new LegacyXlsLoadResult(workbook.ToExcelDocument(), workbook);
+            ExcelDocument document = workbook.ToExcelDocument();
+            document.MarkLoadedFromLegacyXls(sourcePath: null, workbook);
+            return new LegacyXlsLoadResult(document, workbook);
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelDocument.LegacyXlsState.cs
+++ b/OfficeIMO.Excel/ExcelDocument.LegacyXlsState.cs
@@ -42,12 +42,24 @@ namespace OfficeIMO.Excel {
             }
         }
 
+        internal static ExcelDocument ProjectLoadedLegacyXlsWorkbook(LegacyXlsWorkbook workbook, string? sourcePath) {
+            if (workbook == null) throw new ArgumentNullException(nameof(workbook));
+
+            if (workbook.Worksheets.Count == 0) {
+                throw new InvalidDataException("Legacy XLS import failed: no supported worksheets were projected. Unsupported legacy sheet content cannot be saved as a normal .xlsx workbook.");
+            }
+
+            ExcelDocument document = workbook.ToExcelDocument();
+            document.MarkLoadedFromLegacyXls(sourcePath, workbook);
+            return document;
+        }
+
         private void EnsureLegacyXlsCanSaveToPath(string path) {
             if (!WasLoadedFromLegacyXls) {
                 return;
             }
 
-            if (!ExcelDocumentLoadRouting.HasLegacyXlsExtension(path)) {
+            if (!ExcelDocumentLoadRouting.HasLegacyBinaryExcelExtension(path)) {
                 return;
             }
 

--- a/OfficeIMO.Excel/ExcelDocument.LegacyXlsState.cs
+++ b/OfficeIMO.Excel/ExcelDocument.LegacyXlsState.cs
@@ -1,0 +1,60 @@
+using OfficeIMO.Excel.LegacyXls.Diagnostics;
+using OfficeIMO.Excel.LegacyXls.Model;
+
+namespace OfficeIMO.Excel {
+    public partial class ExcelDocument {
+        private LegacyXlsImportDiagnostic[] _legacyXlsImportDiagnostics = Array.Empty<LegacyXlsImportDiagnostic>();
+        private LegacyXlsUnsupportedFeature[] _legacyXlsUnsupportedFeatures = Array.Empty<LegacyXlsUnsupportedFeature>();
+        private LegacyXlsUnsupportedSheet[] _legacyXlsUnsupportedSheets = Array.Empty<LegacyXlsUnsupportedSheet>();
+        private string? _legacyXlsSourcePath;
+
+        /// <summary>
+        /// Gets whether this workbook was projected from a legacy binary XLS source through normal loading.
+        /// </summary>
+        public bool WasLoadedFromLegacyXls { get; private set; }
+
+        /// <summary>
+        /// Gets diagnostics produced while importing a legacy binary XLS source through normal loading.
+        /// </summary>
+        public IReadOnlyList<LegacyXlsImportDiagnostic> LegacyXlsImportDiagnostics => _legacyXlsImportDiagnostics;
+
+        /// <summary>
+        /// Gets unsupported or preserve-only legacy XLS features discovered during normal loading.
+        /// </summary>
+        public IReadOnlyList<LegacyXlsUnsupportedFeature> LegacyXlsUnsupportedFeatures => _legacyXlsUnsupportedFeatures;
+
+        /// <summary>
+        /// Gets legacy XLS sheet entries that were discovered but not projected as normal worksheets.
+        /// </summary>
+        public IReadOnlyList<LegacyXlsUnsupportedSheet> LegacyXlsUnsupportedSheets => _legacyXlsUnsupportedSheets;
+
+        internal void MarkLoadedFromLegacyXls(string? sourcePath, LegacyXlsWorkbook workbook) {
+            if (workbook == null) throw new ArgumentNullException(nameof(workbook));
+
+            WasLoadedFromLegacyXls = true;
+            _legacyXlsSourcePath = sourcePath;
+            _legacyXlsImportDiagnostics = workbook.Diagnostics.ToArray();
+            _legacyXlsUnsupportedFeatures = workbook.UnsupportedFeatures.ToArray();
+            _legacyXlsUnsupportedSheets = workbook.UnsupportedSheets.ToArray();
+
+            if (!string.IsNullOrEmpty(sourcePath)) {
+                FilePath = sourcePath!;
+            }
+        }
+
+        private void EnsureLegacyXlsCanSaveToPath(string path) {
+            if (!WasLoadedFromLegacyXls) {
+                return;
+            }
+
+            if (!ExcelDocumentLoadRouting.HasLegacyXlsExtension(path)) {
+                return;
+            }
+
+            string source = string.IsNullOrWhiteSpace(_legacyXlsSourcePath)
+                ? "a legacy binary .xls source"
+                : $"legacy binary .xls source '{_legacyXlsSourcePath}'";
+            throw new NotSupportedException($"Native XLS saving is not supported. This workbook was loaded from {source}; save it to an .xlsx path instead.");
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.LoadRouting.cs
+++ b/OfficeIMO.Excel/ExcelDocument.LoadRouting.cs
@@ -1,0 +1,43 @@
+namespace OfficeIMO.Excel {
+    internal static class ExcelDocumentLoadRouting {
+        private static readonly byte[] ZipSignature = { 0x50, 0x4B };
+        private static readonly byte[] OleCompoundSignature = { 0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1 };
+
+        internal static bool IsLegacyXls(byte[] bytes, string? filePath) {
+            if (HasOleCompoundSignature(bytes)) {
+                return true;
+            }
+
+            if (HasZipSignature(bytes)) {
+                return false;
+            }
+
+            return HasLegacyXlsExtension(filePath);
+        }
+
+        internal static bool HasLegacyXlsExtension(string? filePath) {
+            return !string.IsNullOrWhiteSpace(filePath)
+                && string.Equals(Path.GetExtension(filePath), ".xls", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool HasZipSignature(byte[] bytes) {
+            return bytes.Length >= ZipSignature.Length
+                && bytes[0] == ZipSignature[0]
+                && bytes[1] == ZipSignature[1];
+        }
+
+        private static bool HasOleCompoundSignature(byte[] bytes) {
+            if (bytes.Length < OleCompoundSignature.Length) {
+                return false;
+            }
+
+            for (int i = 0; i < OleCompoundSignature.Length; i++) {
+                if (bytes[i] != OleCompoundSignature[i]) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/OfficeIMO.Excel/ExcelDocument.LoadRouting.cs
+++ b/OfficeIMO.Excel/ExcelDocument.LoadRouting.cs
@@ -20,6 +20,19 @@ namespace OfficeIMO.Excel {
                 && string.Equals(Path.GetExtension(filePath), ".xls", StringComparison.OrdinalIgnoreCase);
         }
 
+        internal static bool HasLegacyBinaryExcelExtension(string? filePath) {
+            if (string.IsNullOrWhiteSpace(filePath)) {
+                return false;
+            }
+
+            string extension = Path.GetExtension(filePath);
+            return string.Equals(extension, ".xls", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(extension, ".xlt", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(extension, ".xla", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(extension, ".xlm", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(extension, ".xlw", StringComparison.OrdinalIgnoreCase);
+        }
+
         private static bool HasZipSignature(byte[] bytes) {
             return bytes.Length >= ZipSignature.Length
                 && bytes[0] == ZipSignature[0]

--- a/OfficeIMO.Excel/ExcelDocument.Save.Public.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Save.Public.cs
@@ -77,6 +77,14 @@ namespace OfficeIMO.Excel {
         }
 
         /// <summary>
+        /// Saves the document without opening it.
+        /// </summary>
+        /// <param name="filePath">Path to save to.</param>
+        public void Save(string filePath) {
+            Save(filePath, openExcel: false);
+        }
+
+        /// <summary>
         /// Saves the document and optionally opens it.
         /// </summary>
         /// <param name="filePath">Path to save to.</param>
@@ -103,6 +111,7 @@ namespace OfficeIMO.Excel {
 
             var path = string.IsNullOrEmpty(filePath) ? FilePath : filePath;
             var originalFilePath = FilePath;
+            EnsureLegacyXlsCanSaveToPath(path);
 
             // Ensure target directory is writable
             if (File.Exists(path) && new FileInfo(path).IsReadOnly) {
@@ -189,6 +198,7 @@ namespace OfficeIMO.Excel {
 
             var path = string.IsNullOrEmpty(filePath) ? FilePath : filePath;
             var originalFilePath = FilePath;
+            EnsureLegacyXlsCanSaveToPath(path);
             if (File.Exists(path) && new FileInfo(path).IsReadOnly) {
                 throw new IOException($"Failed to save to '{path}'. The file is read-only.");
             }
@@ -292,6 +302,7 @@ namespace OfficeIMO.Excel {
 
             var target = string.IsNullOrEmpty(filePath) ? FilePath : filePath;
             var originalFilePath = FilePath;
+            EnsureLegacyXlsCanSaveToPath(target);
             if (File.Exists(target) && new FileInfo(target).IsReadOnly) {
                 throw new IOException($"Failed to save to '{target}'. The file is read-only.");
             }

--- a/OfficeIMO.Excel/ExcelFeatureReport.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.cs
@@ -654,12 +654,12 @@ namespace OfficeIMO.Excel {
                 "Legacy XLS import warnings should be reviewed before relying on full fidelity.",
                 warnings.Select(FormatLegacyXlsDiagnostic).ToArray());
 
-            Add(features, "Compatibility", "Legacy XLS preserve-only features", ExcelFeatureSupportLevel.Preserved, _legacyXlsUnsupportedFeatures.Length, null,
-                "Some legacy XLS features were detected as unsupported or preserve-only import metadata.",
+            Add(features, "Compatibility", "Legacy XLS unsupported features", ExcelFeatureSupportLevel.Unsupported, _legacyXlsUnsupportedFeatures.Length, null,
+                "Some legacy XLS features were detected as unsupported import metadata and are not written to the converted .xlsx package.",
                 _legacyXlsUnsupportedFeatures.Select(FormatLegacyXlsUnsupportedFeature).ToArray());
 
-            Add(features, "Compatibility", "Legacy XLS unsupported sheets", ExcelFeatureSupportLevel.Preserved, _legacyXlsUnsupportedSheets.Length, null,
-                "Some legacy XLS sheet entries were discovered but not projected as normal worksheets.",
+            Add(features, "Compatibility", "Legacy XLS unsupported sheets", ExcelFeatureSupportLevel.Unsupported, _legacyXlsUnsupportedSheets.Length, null,
+                "Some legacy XLS sheet entries were discovered but not projected as normal worksheets and are not written to the converted .xlsx package.",
                 _legacyXlsUnsupportedSheets.Select(FormatLegacyXlsUnsupportedSheet).ToArray());
         }
 

--- a/OfficeIMO.Excel/ExcelFeatureReport.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.cs
@@ -1,4 +1,6 @@
 using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Excel.LegacyXls.Diagnostics;
+using OfficeIMO.Excel.LegacyXls.Model;
 using System.Text;
 
 namespace OfficeIMO.Excel {
@@ -632,7 +634,49 @@ namespace OfficeIMO.Excel {
             Add(features, "Compatibility", "Embedded packages", ExcelFeatureSupportLevel.Preserved, embeddedPackageDetails.Count, null,
                 "Embedded packages are preserve-only package content.", embeddedPackageDetails);
 
+            AddLegacyXlsImportFeatures(features);
+
             return new ExcelFeatureReport(features);
+        }
+
+        private void AddLegacyXlsImportFeatures(List<ExcelFeatureFinding> features) {
+            if (!WasLoadedFromLegacyXls) {
+                return;
+            }
+
+            Add(features, "Compatibility", "Legacy XLS source", ExcelFeatureSupportLevel.Editable, 1, null,
+                "Legacy binary XLS content was projected into the normal OfficeIMO Excel model. Saving writes Open XML .xlsx content; native .xls writing is not supported.");
+
+            LegacyXlsImportDiagnostic[] warnings = _legacyXlsImportDiagnostics
+                .Where(diagnostic => diagnostic.Severity == LegacyXlsDiagnosticSeverity.Warning)
+                .ToArray();
+            Add(features, "Compatibility", "Legacy XLS import diagnostics", ExcelFeatureSupportLevel.Preserved, warnings.Length, null,
+                "Legacy XLS import warnings should be reviewed before relying on full fidelity.",
+                warnings.Select(FormatLegacyXlsDiagnostic).ToArray());
+
+            Add(features, "Compatibility", "Legacy XLS preserve-only features", ExcelFeatureSupportLevel.Preserved, _legacyXlsUnsupportedFeatures.Length, null,
+                "Some legacy XLS features were detected as unsupported or preserve-only import metadata.",
+                _legacyXlsUnsupportedFeatures.Select(FormatLegacyXlsUnsupportedFeature).ToArray());
+
+            Add(features, "Compatibility", "Legacy XLS unsupported sheets", ExcelFeatureSupportLevel.Preserved, _legacyXlsUnsupportedSheets.Length, null,
+                "Some legacy XLS sheet entries were discovered but not projected as normal worksheets.",
+                _legacyXlsUnsupportedSheets.Select(FormatLegacyXlsUnsupportedSheet).ToArray());
+        }
+
+        private static string FormatLegacyXlsDiagnostic(LegacyXlsImportDiagnostic diagnostic) {
+            string scope = diagnostic.SheetName == null ? "(workbook)" : diagnostic.SheetName;
+            string detail = string.IsNullOrWhiteSpace(diagnostic.DetailCode) ? diagnostic.Code : diagnostic.DetailCode!;
+            return $"{scope}: {diagnostic.Code} ({detail}) - {diagnostic.Message}";
+        }
+
+        private static string FormatLegacyXlsUnsupportedFeature(LegacyXlsUnsupportedFeature feature) {
+            string scope = feature.SheetName == null ? "(workbook)" : feature.SheetName;
+            string detail = string.IsNullOrWhiteSpace(feature.DetailCode) ? feature.Code : feature.DetailCode!;
+            return $"{scope}: {feature.Kind} ({detail}) - {feature.Description}";
+        }
+
+        private static string FormatLegacyXlsUnsupportedSheet(LegacyXlsUnsupportedSheet sheet) {
+            return $"{sheet.Name}: {sheet.Kind} ({sheet.VisibilityName})";
         }
 
         private static void Add(List<ExcelFeatureFinding> features, string category, string name, ExcelFeatureSupportLevel supportLevel, int count,

--- a/OfficeIMO.Excel/LegacyXls/LegacyXlsLoadResult.cs
+++ b/OfficeIMO.Excel/LegacyXls/LegacyXlsLoadResult.cs
@@ -6,15 +6,28 @@ namespace OfficeIMO.Excel.LegacyXls {
     /// Contains the projected OfficeIMO document and the legacy XLS import report produced from the same parse.
     /// </summary>
     public sealed class LegacyXlsLoadResult : IDisposable {
-        internal LegacyXlsLoadResult(ExcelDocument document, LegacyXlsWorkbook workbook) {
-            Document = document ?? throw new ArgumentNullException(nameof(document));
+        private readonly ExcelDocument? _document;
+
+        internal LegacyXlsLoadResult(ExcelDocument? document, LegacyXlsWorkbook workbook, Exception? projectionException = null) {
+            _document = document;
             Workbook = workbook ?? throw new ArgumentNullException(nameof(workbook));
+            ProjectionException = projectionException;
         }
 
         /// <summary>
         /// Gets the normal OfficeIMO Excel document projected from supported legacy XLS content.
         /// </summary>
-        public ExcelDocument Document { get; }
+        public ExcelDocument Document => _document ?? throw new InvalidOperationException("No OfficeIMO Excel document was projected from the legacy XLS workbook. Inspect Workbook, Diagnostics, ImportReport, and ProjectionException for import details.", ProjectionException);
+
+        /// <summary>
+        /// Gets whether supported legacy XLS content was projected into a normal OfficeIMO Excel document.
+        /// </summary>
+        public bool HasDocument => _document != null;
+
+        /// <summary>
+        /// Gets the projection failure captured while preserving parser diagnostics for report callers.
+        /// </summary>
+        public Exception? ProjectionException { get; }
 
         /// <summary>
         /// Gets the neutral legacy XLS workbook model produced by the parser.
@@ -72,7 +85,7 @@ namespace OfficeIMO.Excel.LegacyXls {
         /// Disposes the projected OfficeIMO document.
         /// </summary>
         public void Dispose() {
-            Document.Dispose();
+            _document?.Dispose();
         }
 
         private static string FormatDiagnostics(IEnumerable<LegacyXlsImportDiagnostic> diagnostics) {

--- a/OfficeIMO.Excel/README.md
+++ b/OfficeIMO.Excel/README.md
@@ -64,9 +64,10 @@ document.Save("converted.xlsx");
 ```
 
 Legacy `.xls` files load through the normal `ExcelDocument.Load` entry point.
-Unsupported or preserve-only legacy features are reported through
-`InspectFeatures()` and the legacy import diagnostics attached to the document.
-Saving back to `.xls` is intentionally blocked until native XLS writing exists.
+Unsupported legacy features are reported through `InspectFeatures()` and the
+legacy import diagnostics attached to the document. Saving back to legacy binary
+formats such as `.xls` or `.xlt` is intentionally blocked until native XLS
+writing exists.
 
 ### Map rows to objects
 

--- a/OfficeIMO.Excel/README.md
+++ b/OfficeIMO.Excel/README.md
@@ -3,7 +3,7 @@
 [![nuget version](https://img.shields.io/nuget/v/OfficeIMO.Excel)](https://www.nuget.org/packages/OfficeIMO.Excel)
 [![nuget downloads](https://img.shields.io/nuget/dt/OfficeIMO.Excel?label=nuget%20downloads)](https://www.nuget.org/packages/OfficeIMO.Excel)
 
-`OfficeIMO.Excel` is the main Excel package in the OfficeIMO family. It creates, edits, reads, and saves `.xlsx` workbooks without COM automation and without Microsoft Excel installed.
+`OfficeIMO.Excel` is the main Excel package in the OfficeIMO family. It creates, edits, reads, and saves `.xlsx` workbooks without COM automation and without Microsoft Excel installed. It can also open legacy binary `.xls` workbooks and project supported content into the normal OfficeIMO Excel model; saving produces `.xlsx` content, and native `.xls` writing is not supported.
 
 If OfficeIMO saves you time, please consider supporting the work through [GitHub Sponsors](https://github.com/sponsors/PrzemyslawKlys) or [PayPal](https://paypal.me/PrzemyslawKlys). PowerShell users should use [PSWriteOffice](https://github.com/EvotecIT/PSWriteOffice) for the PowerShell-facing experience.
 
@@ -53,6 +53,20 @@ foreach (var row in sheet.Rows()) {
     Console.WriteLine(row["Name"]);
 }
 ```
+
+### Convert a legacy XLS workbook
+
+```csharp
+using var document = ExcelDocument.Load("legacy.xls");
+ExcelFeatureReport report = document.InspectFeatures();
+
+document.Save("converted.xlsx");
+```
+
+Legacy `.xls` files load through the normal `ExcelDocument.Load` entry point.
+Unsupported or preserve-only legacy features are reported through
+`InspectFeatures()` and the legacy import diagnostics attached to the document.
+Saving back to `.xls` is intentionally blocked until native XLS writing exists.
 
 ### Map rows to objects
 

--- a/OfficeIMO.Tests/Excel.LegacyXls.NormalLoad.cs
+++ b/OfficeIMO.Tests/Excel.LegacyXls.NormalLoad.cs
@@ -1,0 +1,166 @@
+using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.LegacyXls;
+using OfficeIMO.Excel.LegacyXls.Diagnostics;
+using OfficeIMO.Excel.LegacyXls.Model;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class Excel {
+        [Fact]
+        public void LegacyXls_NormalLoad_PathProjectsToExcelDocumentAndSavesXlsx() {
+            byte[] compound = CreateMinimalLegacyXlsCompound();
+            string sourcePath = WriteTempWorkbook(compound, ".xls");
+            string outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".xlsx");
+
+            try {
+                using ExcelDocument document = ExcelDocument.Load(sourcePath);
+
+                Assert.True(document.WasLoadedFromLegacyXls);
+                Assert.Equal(sourcePath, document.FilePath);
+                Assert.DoesNotContain(document.LegacyXlsImportDiagnostics, diagnostic => diagnostic.Severity == LegacyXlsDiagnosticSeverity.Error);
+                Assert.True(document.Sheets[0].TryGetCellText(1, 1, out string? header));
+                Assert.Equal("Name", header);
+
+                document.Save(outputPath);
+
+                using ExcelDocument converted = ExcelDocument.Load(outputPath);
+                Assert.False(converted.WasLoadedFromLegacyXls);
+                Assert.True(converted.Sheets[0].TryGetCellText(2, 2, out string? amount));
+                Assert.Equal("42", amount);
+            } finally {
+                TryDelete(sourcePath);
+                TryDelete(outputPath);
+            }
+        }
+
+        [Fact]
+        public async Task LegacyXls_NormalLoad_AsyncPathProjectsToExcelDocument() {
+            byte[] compound = CreateMinimalLegacyXlsCompound();
+            string sourcePath = WriteTempWorkbook(compound, ".xls");
+
+            try {
+                using ExcelDocument document = await ExcelDocument.LoadAsync(sourcePath);
+
+                Assert.True(document.WasLoadedFromLegacyXls);
+                Assert.True(document.Sheets[0].TryGetCellText(2, 2, out string? amount));
+                Assert.Equal("42", amount);
+            } finally {
+                TryDelete(sourcePath);
+            }
+        }
+
+        [Fact]
+        public void LegacyXls_NormalLoad_StreamProjectsToExcelDocumentAndSavesOpenXmlStream() {
+            byte[] compound = CreateMinimalLegacyXlsCompound();
+
+            using ExcelDocument document = ExcelDocument.Load(new MemoryStream(compound));
+            using var output = new MemoryStream();
+
+            document.Save(output);
+            output.Position = 0;
+            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(output, false);
+
+            Assert.True(document.WasLoadedFromLegacyXls);
+            Assert.NotNull(spreadsheet.WorkbookPart);
+        }
+
+        [Fact]
+        public async Task LegacyXls_NormalLoad_AsyncStreamProjectsToExcelDocument() {
+            byte[] compound = CreateMinimalLegacyXlsCompound();
+
+            using ExcelDocument document = await ExcelDocument.LoadAsync(new MemoryStream(compound));
+
+            Assert.True(document.WasLoadedFromLegacyXls);
+            Assert.True(document.Sheets[0].TryGetCellText(1, 1, out string? header));
+            Assert.Equal("Name", header);
+        }
+
+        [Fact]
+        public void LegacyXls_NormalLoad_RejectsAutoSave() {
+            byte[] compound = CreateMinimalLegacyXlsCompound();
+            string sourcePath = WriteTempWorkbook(compound, ".xls");
+
+            try {
+                NotSupportedException exception = Assert.Throws<NotSupportedException>(() => ExcelDocument.Load(sourcePath, autoSave: true));
+
+                Assert.Contains("Auto-save is not supported", exception.Message, StringComparison.OrdinalIgnoreCase);
+            } finally {
+                TryDelete(sourcePath);
+            }
+        }
+
+        [Fact]
+        public void LegacyXls_NormalLoad_RejectsNativeXlsSaveTargets() {
+            byte[] compound = CreateMinimalLegacyXlsCompound();
+            string sourcePath = WriteTempWorkbook(compound, ".xls");
+            string xlsOutputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".xls");
+
+            try {
+                using ExcelDocument document = ExcelDocument.Load(sourcePath);
+
+                NotSupportedException implicitSave = Assert.Throws<NotSupportedException>(() => document.Save());
+                NotSupportedException explicitSave = Assert.Throws<NotSupportedException>(() => document.Save(xlsOutputPath));
+
+                Assert.Contains("Native XLS saving is not supported", implicitSave.Message, StringComparison.OrdinalIgnoreCase);
+                Assert.Contains("Native XLS saving is not supported", explicitSave.Message, StringComparison.OrdinalIgnoreCase);
+            } finally {
+                TryDelete(sourcePath);
+                TryDelete(xlsOutputPath);
+            }
+        }
+
+        [Fact]
+        public void LegacyXls_NormalLoad_ThrowsForHardImportErrors() {
+            byte[] workbookStream = LegacyXlsTestWorkbookBuilder.CreateEncryptedWorkbookStream();
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);
+            string sourcePath = WriteTempWorkbook(compound, ".xls");
+
+            try {
+                InvalidDataException exception = Assert.Throws<InvalidDataException>(() => ExcelDocument.Load(sourcePath));
+
+                Assert.Contains("Legacy XLS import failed", exception.Message, StringComparison.OrdinalIgnoreCase);
+                Assert.Contains("XLS-BIFF-FILEPASS-UNSUPPORTED", exception.Message, StringComparison.Ordinal);
+            } finally {
+                TryDelete(sourcePath);
+            }
+        }
+
+        [Fact]
+        public void LegacyXls_NormalLoad_ExposesImportDiagnosticsThroughFeatureReport() {
+            byte[] workbookStream = LegacyXlsTestWorkbookBuilder.CreateUnsupportedFeatureWorkbookStream();
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);
+
+            using ExcelDocument document = ExcelDocument.Load(new MemoryStream(compound));
+
+            Assert.True(document.WasLoadedFromLegacyXls);
+            Assert.NotEmpty(document.LegacyXlsUnsupportedFeatures);
+
+            ExcelFeatureReport report = document.InspectFeatures();
+            ExcelFeatureFinding finding = Assert.Single(report.FindFeatures("Legacy XLS preserve-only features"));
+
+            Assert.Equal(ExcelFeatureSupportLevel.Preserved, finding.SupportLevel);
+            Assert.NotEmpty(finding.Details);
+            Assert.True(report.HasAdvancedFeatures);
+            Assert.Throws<InvalidOperationException>(() => report.EnsureNoAdvancedFeatures());
+        }
+
+        private static byte[] CreateMinimalLegacyXlsCompound() {
+            byte[] workbookStream = LegacyXlsTestWorkbookBuilder.CreateMinimalWorkbookStream();
+            return LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);
+        }
+
+        private static string WriteTempWorkbook(byte[] bytes, string extension) {
+            string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + extension);
+            File.WriteAllBytes(path, bytes);
+            return path;
+        }
+
+        private static void TryDelete(string path) {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Tests/Excel.LegacyXls.NormalLoad.cs
+++ b/OfficeIMO.Tests/Excel.LegacyXls.NormalLoad.cs
@@ -112,6 +112,40 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void LegacyXls_ExplicitLoad_RejectsNativeXlsSaveTargets() {
+            byte[] compound = CreateMinimalLegacyXlsCompound();
+            string sourcePath = WriteTempWorkbook(compound, ".xls");
+            string xlsOutputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".xls");
+
+            try {
+                using ExcelDocument document = ExcelDocument.LoadLegacyXls(sourcePath);
+
+                Assert.True(document.WasLoadedFromLegacyXls);
+                Assert.Equal(sourcePath, document.FilePath);
+                Assert.Throws<NotSupportedException>(() => document.Save());
+                Assert.Throws<NotSupportedException>(() => document.Save(xlsOutputPath));
+            } finally {
+                TryDelete(sourcePath);
+                TryDelete(xlsOutputPath);
+            }
+        }
+
+        [Fact]
+        public void LegacyXls_ExplicitLoadWithReport_RejectsNativeXlsSaveTargets() {
+            byte[] compound = CreateMinimalLegacyXlsCompound();
+            string xlsOutputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".xls");
+
+            try {
+                using LegacyXlsLoadResult result = ExcelDocument.LoadLegacyXlsWithReport(new MemoryStream(compound));
+
+                Assert.True(result.Document.WasLoadedFromLegacyXls);
+                Assert.Throws<NotSupportedException>(() => result.Document.Save(xlsOutputPath));
+            } finally {
+                TryDelete(xlsOutputPath);
+            }
+        }
+
+        [Fact]
         public void LegacyXls_NormalLoad_ThrowsForHardImportErrors() {
             byte[] workbookStream = LegacyXlsTestWorkbookBuilder.CreateEncryptedWorkbookStream();
             byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);

--- a/OfficeIMO.Tests/Excel.LegacyXls.NormalLoad.cs
+++ b/OfficeIMO.Tests/Excel.LegacyXls.NormalLoad.cs
@@ -112,6 +112,25 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void LegacyXls_NormalLoad_RejectsLegacyTemplateSaveTargets() {
+            byte[] compound = CreateMinimalLegacyXlsCompound();
+            string sourcePath = WriteTempWorkbook(compound, ".xlt");
+            string xltOutputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".xlt");
+
+            try {
+                using ExcelDocument document = ExcelDocument.Load(sourcePath);
+
+                Assert.True(document.WasLoadedFromLegacyXls);
+                Assert.Equal(sourcePath, document.FilePath);
+                Assert.Throws<NotSupportedException>(() => document.Save());
+                Assert.Throws<NotSupportedException>(() => document.Save(xltOutputPath));
+            } finally {
+                TryDelete(sourcePath);
+                TryDelete(xltOutputPath);
+            }
+        }
+
+        [Fact]
         public void LegacyXls_ExplicitLoad_RejectsNativeXlsSaveTargets() {
             byte[] compound = CreateMinimalLegacyXlsCompound();
             string sourcePath = WriteTempWorkbook(compound, ".xls");
@@ -146,6 +165,18 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void LegacyXls_NormalAndExplicitLoad_ThrowWhenNoSupportedWorksheetsAreProjected() {
+            byte[] workbookStream = LegacyXlsTestWorkbookBuilder.CreateChartOnlyWorkbookStream();
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);
+
+            InvalidDataException normalException = Assert.Throws<InvalidDataException>(() => ExcelDocument.Load(new MemoryStream(compound)));
+            InvalidDataException explicitException = Assert.Throws<InvalidDataException>(() => ExcelDocument.LoadLegacyXls(new MemoryStream(compound)));
+
+            Assert.Contains("no supported worksheets", normalException.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("no supported worksheets", explicitException.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
         public void LegacyXls_NormalLoad_ThrowsForHardImportErrors() {
             byte[] workbookStream = LegacyXlsTestWorkbookBuilder.CreateEncryptedWorkbookStream();
             byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);
@@ -172,11 +203,12 @@ namespace OfficeIMO.Tests {
             Assert.NotEmpty(document.LegacyXlsUnsupportedFeatures);
 
             ExcelFeatureReport report = document.InspectFeatures();
-            ExcelFeatureFinding finding = Assert.Single(report.FindFeatures("Legacy XLS preserve-only features"));
+            ExcelFeatureFinding finding = Assert.Single(report.FindFeatures("Legacy XLS unsupported features"));
 
-            Assert.Equal(ExcelFeatureSupportLevel.Preserved, finding.SupportLevel);
+            Assert.Equal(ExcelFeatureSupportLevel.Unsupported, finding.SupportLevel);
             Assert.NotEmpty(finding.Details);
             Assert.True(report.HasAdvancedFeatures);
+            Assert.Throws<InvalidOperationException>(() => report.EnsureNoUnsupportedFeatures());
             Assert.Throws<InvalidOperationException>(() => report.EnsureNoAdvancedFeatures());
         }
 
@@ -194,6 +226,24 @@ namespace OfficeIMO.Tests {
         private static void TryDelete(string path) {
             if (File.Exists(path)) {
                 File.Delete(path);
+            }
+        }
+
+        private static partial class LegacyXlsTestWorkbookBuilder {
+            internal static byte[] CreateChartOnlyWorkbookStream() {
+                using var stream = new MemoryStream();
+                WriteRecord(stream, 0x0809, new byte[] { 0x00, 0x06, 0x05, 0x00, 0xdb, 0x0b, 0xcc, 0x07 });
+                long chartBoundSheetPosition = stream.Position;
+                WriteRecord(stream, 0x0085, BuildBoundSheetPayload(0, "ChartOnly", sheetType: 0x02));
+                WriteRecord(stream, 0x000a, Array.Empty<byte>());
+
+                int chartSheetOffset = checked((int)stream.Position);
+                WriteRecord(stream, 0x0809, new byte[] { 0x00, 0x06, 0x20, 0x00, 0xdb, 0x0b, 0xcc, 0x07 });
+                WriteRecord(stream, 0x000a, Array.Empty<byte>());
+
+                byte[] bytes = stream.ToArray();
+                Buffer.BlockCopy(BitConverter.GetBytes(chartSheetOffset), 0, bytes, checked((int)chartBoundSheetPosition + 4), 4);
+                return bytes;
             }
         }
     }

--- a/OfficeIMO.Tests/Excel.LegacyXls.NormalLoad.cs
+++ b/OfficeIMO.Tests/Excel.LegacyXls.NormalLoad.cs
@@ -177,6 +177,48 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void LegacyXls_LoadLegacyXlsWithReport_ReturnsReportWhenNoSupportedWorksheetsAreProjected() {
+            byte[] workbookStream = LegacyXlsTestWorkbookBuilder.CreateChartOnlyWorkbookStream();
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);
+
+            using LegacyXlsLoadResult result = ExcelDocument.LoadLegacyXlsWithReport(new MemoryStream(compound));
+
+            Assert.False(result.HasDocument);
+            Assert.NotNull(result.ProjectionException);
+            Assert.IsType<InvalidDataException>(result.ProjectionException);
+            Assert.Equal(0, result.ImportReport.WorksheetCount);
+            Assert.Equal(1, result.ImportReport.UnsupportedSheetCount);
+            Assert.False(result.HasImportErrors);
+
+            InvalidOperationException documentException = Assert.Throws<InvalidOperationException>(() => result.Document);
+            Assert.Contains("No OfficeIMO Excel document", documentException.Message, StringComparison.Ordinal);
+            Assert.Same(result.ProjectionException, documentException.InnerException);
+        }
+
+        [Fact]
+        public void LegacyXls_LoadLegacyXlsWithReport_ReturnsDiagnosticsForHardImportErrors() {
+            byte[] workbookStream = LegacyXlsTestWorkbookBuilder.CreateEncryptedWorkbookStream();
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);
+            string sourcePath = WriteTempWorkbook(compound, ".xls");
+
+            try {
+                using LegacyXlsLoadResult result = ExcelDocument.LoadLegacyXlsWithReport(sourcePath);
+
+                Assert.False(result.HasDocument);
+                Assert.NotNull(result.ProjectionException);
+                Assert.True(result.HasImportErrors);
+                Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "XLS-BIFF-FILEPASS-UNSUPPORTED");
+                Assert.Equal(0, result.ImportReport.WorksheetCount);
+
+                InvalidOperationException documentException = Assert.Throws<InvalidOperationException>(() => result.Document);
+                Assert.Contains("No OfficeIMO Excel document", documentException.Message, StringComparison.Ordinal);
+                Assert.Same(result.ProjectionException, documentException.InnerException);
+            } finally {
+                TryDelete(sourcePath);
+            }
+        }
+
+        [Fact]
         public void LegacyXls_NormalLoad_ThrowsForHardImportErrors() {
             byte[] workbookStream = LegacyXlsTestWorkbookBuilder.CreateEncryptedWorkbookStream();
             byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);

--- a/OfficeIMO.Tests/Excel.LegacyXls.cs
+++ b/OfficeIMO.Tests/Excel.LegacyXls.cs
@@ -323,7 +323,7 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void LegacyXls_LoadLegacyXlsWithReport_ReturnsValidWorkbookWhenLegacyWorkbookHasNoSheets() {
+        public void LegacyXls_LoadLegacyXlsWithReport_ReturnsReportWhenLegacyWorkbookHasNoSheets() {
             byte[] workbookStream = LegacyXlsTestWorkbookBuilder.CreateEncryptedWorkbookStream();
             byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);
 
@@ -331,15 +331,15 @@ namespace OfficeIMO.Tests {
                 ReportUnsupportedRecords = true
             });
 
-            Assert.Single(result.Document.Sheets);
-            Assert.Equal("Sheet1", result.Document.Sheets[0].Name);
+            Assert.False(result.HasDocument);
+            Assert.NotNull(result.ProjectionException);
+            Assert.True(result.HasImportErrors);
+            Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "XLS-BIFF-FILEPASS-UNSUPPORTED");
             Assert.Equal(0, result.ImportReport.WorksheetCount);
 
-            using var output = new MemoryStream();
-            result.Document.Save(output);
-            using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(new MemoryStream(output.ToArray()), false);
-            Sheet sheet = Assert.Single(spreadsheet.WorkbookPart!.Workbook.Sheets!.Elements<Sheet>());
-            Assert.Equal("Sheet1", sheet.Name!.Value);
+            InvalidOperationException documentException = Assert.Throws<InvalidOperationException>(() => result.Document);
+            Assert.Contains("No OfficeIMO Excel document", documentException.Message, StringComparison.Ordinal);
+            Assert.Same(result.ProjectionException, documentException.InnerException);
         }
 
         [Fact]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ PowerShell users should start with [EvotecIT/PSWriteOffice](https://github.com/E
 | Package | Purpose |
 | --- | --- |
 | [OfficeIMO.Word](OfficeIMO.Word/README.md) | Create, edit, inspect, and convert `.docx` documents. |
-| [OfficeIMO.Excel](OfficeIMO.Excel/README.md) | Create and modify `.xlsx` workbooks, worksheets, tables, ranges, styles, and reports. |
+| [OfficeIMO.Excel](OfficeIMO.Excel/README.md) | Create and modify `.xlsx` workbooks, open legacy `.xls` workbooks, worksheets, tables, ranges, styles, and reports. |
 | [OfficeIMO.PowerPoint](OfficeIMO.PowerPoint/README.md) | Generate `.pptx` presentations programmatically. |
 | [OfficeIMO.Visio](OfficeIMO.Visio/README.md) | Create, inspect, validate, and export `.vsdx` diagrams without Visio automation. |
 | [OfficeIMO.Pdf](OfficeIMO.Pdf/README.md) | Dependency-free PDF creation, reading, inspection, page operations, and converter engine support. |


### PR DESCRIPTION
## Summary
- routes legacy binary XLS sources through normal `ExcelDocument.Load` path/stream detection
- marks projected documents as legacy-loaded and blocks native XLS save/autosave targets
- exposes legacy XLS diagnostics through document/report surfaces while preserving `LoadLegacyXlsWithReport` diagnostics when projection cannot create a document
- updates docs to describe normal XLS opening and XLSX-only saving

## Validation
- `dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "LegacyXls_NormalLoad|LegacyXls_ExplicitLoad|LegacyXls_NormalAndExplicitLoad|LegacyXls_LoadLegacyXlsWithReport" --no-restore -p:WarningLevel=0`
- `dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "LegacyXls" --no-restore -p:WarningLevel=0`
- `dotnet build OfficeIMO.Excel\OfficeIMO.Excel.csproj -c Release --no-restore -p:WarningLevel=0`
- `dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net10.0 --filter "LegacyXls_NormalLoad|LegacyXls_ExplicitLoad|LegacyXls_NormalAndExplicitLoad|LegacyXls_LoadLegacyXlsWithReport" --no-restore -p:WarningLevel=0`
- `dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net472 --filter "LegacyXls_NormalLoad|LegacyXls_ExplicitLoad|LegacyXls_NormalAndExplicitLoad|LegacyXls_LoadLegacyXlsWithReport" --no-restore -p:WarningLevel=0`

## Notes
- Replaces closed stacked PR #1997 after #1995 was squash-merged into `master`.