### PR TITLE
Silence CodeQL manual-build caching warning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+          dependency-caching: false
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Restore and Build


### PR DESCRIPTION
## Summary
- disable CodeQL dependency caching for the manual C# analysis lane
- keep the existing production-only manual build that avoids restoring/building the full test matrix in CodeQL

## Why
The current successful CodeQL run still emits a warning because dependency-overlay creation only applies to `build-mode: none`; our lane intentionally uses `build-mode: manual` so CodeQL falls back to a normal database. Disabling dependency caching removes that noisy warning without changing the build or analysis scope.

## Validation
- `git diff --check`