### PR TITLE
Improve CSV streaming performance and benchmarks

### DIFF
--- a/OfficeIMO.CSV.Benchmarks/CsvBenchmarks.cs
+++ b/OfficeIMO.CSV.Benchmarks/CsvBenchmarks.cs
@@ -5,6 +5,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using CsvHelperReader = CsvHelper.CsvReader;
 using CsvHelperWriter = CsvHelper.CsvWriter;
+using SylvanCsvDataReader = Sylvan.Data.Csv.CsvDataReader;
 
 namespace OfficeIMO.CSV.Benchmarks;
 
@@ -33,10 +34,13 @@ public class CsvBenchmarks
     [Params(1000, 10000, 25000)]
     public int RowCount { get; set; }
 
+    [Params(CsvBenchmarkShape.Mixed, CsvBenchmarkShape.Quoted, CsvBenchmarkShape.Multiline)]
+    public CsvBenchmarkShape Shape { get; set; }
+
     [GlobalSetup]
     public void Setup()
     {
-        _rows = CsvBenchmarkData.Create(RowCount);
+        _rows = CsvBenchmarkData.Create(RowCount, Shape);
         _projectedRows = _rows.Select(ProjectRow).ToArray();
 
         using var writer = new StringWriter(CultureInfo.InvariantCulture);
@@ -189,6 +193,24 @@ public class CsvBenchmarks
     }
 
     [Benchmark]
+    public int Sylvan_ReadFields()
+    {
+        using var reader = new StringReader(_csvText);
+        using var csv = SylvanCsvDataReader.Create(reader);
+        var fieldCount = 0;
+        while (csv.Read())
+        {
+            for (var i = 0; i < csv.FieldCount; i++)
+            {
+                _ = csv.GetString(i);
+                fieldCount++;
+            }
+        }
+
+        return fieldCount;
+    }
+
+    [Benchmark]
     public int CsvHelper_ReadTypedRecords()
     {
         using var reader = new StringReader(_csvText);
@@ -220,6 +242,13 @@ public class CsvBenchmarks
     }
 }
 
+public enum CsvBenchmarkShape
+{
+    Mixed,
+    Quoted,
+    Multiline
+}
+
 public sealed class CsvBenchmarkRow
 {
     public int Id { get; set; }
@@ -238,23 +267,40 @@ internal static class CsvBenchmarkData
 {
     private static readonly string[] Regions = ["NA", "EU", "APAC", "LATAM"];
 
-    public static CsvBenchmarkRow[] Create(int count)
+    public static CsvBenchmarkRow[] Create(int count, CsvBenchmarkShape shape)
     {
         var rows = new CsvBenchmarkRow[count];
         for (var i = 1; i <= count; i++)
         {
+            var region = Regions[i % Regions.Length];
+            var name = string.Create(CultureInfo.InvariantCulture, $"Server-{i:000000}");
+            var department = string.Create(CultureInfo.InvariantCulture, $"Department-{i % 25}");
+            var notes = string.Create(CultureInfo.InvariantCulture, $"Benchmark row {i}");
+
+            switch (shape)
+            {
+                case CsvBenchmarkShape.Quoted:
+                    name = string.Create(CultureInfo.InvariantCulture, $"Server,{i:000000}");
+                    department = string.Create(CultureInfo.InvariantCulture, $"Department \"{i % 25}\"");
+                    notes = string.Create(CultureInfo.InvariantCulture, $"Benchmark row {i}, \"quoted\", region {region}");
+                    break;
+                case CsvBenchmarkShape.Multiline:
+                    notes = string.Create(CultureInfo.InvariantCulture, $"Benchmark row {i}\ncontinued value {i % 10}");
+                    break;
+            }
+
             rows[i - 1] = new CsvBenchmarkRow
             {
                 Id = i,
-                Name = string.Create(CultureInfo.InvariantCulture, $"Server-{i:000000}"),
-                Department = string.Create(CultureInfo.InvariantCulture, $"Department-{i % 25}"),
-                Region = Regions[i % Regions.Length],
+                Name = name,
+                Department = department,
+                Region = region,
                 IsEnabled = i % 3 != 0,
                 Created = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMinutes(i),
                 Score = Math.Round((decimal)((i * 1.137) % 1000), 3),
                 Owner = string.Create(CultureInfo.InvariantCulture, $"owner{i % 250}@example.test"),
                 TicketCount = i % 17,
-                Notes = string.Create(CultureInfo.InvariantCulture, $"Benchmark row {i}")
+                Notes = notes
             };
         }
 

--- a/OfficeIMO.CSV.Benchmarks/CsvWideBenchmarks.cs
+++ b/OfficeIMO.CSV.Benchmarks/CsvWideBenchmarks.cs
@@ -1,0 +1,242 @@
+#nullable enable
+
+using System.Globalization;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using CsvHelperReader = CsvHelper.CsvReader;
+using CsvHelperWriter = CsvHelper.CsvWriter;
+using SylvanCsvDataReader = Sylvan.Data.Csv.CsvDataReader;
+
+namespace OfficeIMO.CSV.Benchmarks;
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net80)]
+public class CsvWideBenchmarks
+{
+    private static readonly string[] Headers = CreateHeaders();
+
+    private object?[][] _rows = [];
+    private string _csvText = string.Empty;
+
+    [Params(1000, 10000, 25000)]
+    public int RowCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _rows = CsvWideBenchmarkData.Create(RowCount);
+
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        using var csv = new CsvObjectWriter(writer, new CsvSaveOptions { NewLine = "\n" }, leaveOpen: true);
+        foreach (var row in _rows)
+        {
+            csv.WriteRow(Headers, row);
+        }
+
+        _csvText = writer.ToString();
+    }
+
+    [Benchmark(Baseline = true)]
+    public int OfficeIMO_WriteProjectedRows()
+    {
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        using var csv = new CsvObjectWriter(writer, new CsvSaveOptions { NewLine = "\n" }, leaveOpen: true);
+        foreach (var row in _rows)
+        {
+            csv.WriteRow(Headers, row);
+        }
+
+        return writer.GetStringBuilder().Length;
+    }
+
+    [Benchmark]
+    public int CsvHelper_WriteProjectedRows()
+    {
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        using var csv = new CsvHelperWriter(writer, CultureInfo.InvariantCulture);
+        foreach (var header in Headers)
+        {
+            csv.WriteField(header);
+        }
+
+        csv.NextRecord();
+        foreach (var row in _rows)
+        {
+            foreach (var value in row)
+            {
+                csv.WriteField(value);
+            }
+
+            csv.NextRecord();
+        }
+
+        return writer.GetStringBuilder().Length;
+    }
+
+    [Benchmark]
+    public int OfficeIMO_ReadRowsReusableCallback()
+    {
+        using var reader = new StringReader(_csvText);
+        var fieldCount = 0;
+        CsvDocument.ReadRowsReusable(reader, (_, values) =>
+        {
+            fieldCount += values.Count;
+        });
+
+        return fieldCount;
+    }
+
+    [Benchmark]
+    public int OfficeIMO_ReadRecordsReusableSkipHeader()
+    {
+        using var reader = new StringReader(_csvText);
+        var fieldCount = 0;
+        CsvDocument.ReadRecordsReusable(
+            reader,
+            values =>
+            {
+                fieldCount += values.Count;
+            },
+            new CsvLoadOptions { SkipInitialRecords = 1 });
+
+        return fieldCount;
+    }
+
+    [Benchmark]
+    public int OfficeIMO_ReadFieldSpansSkipHeader()
+    {
+        using var reader = new StringReader(_csvText);
+        var fieldCount = 0;
+        CsvDocument.ReadFieldSpans(
+            reader,
+            (_, _, _) =>
+            {
+                fieldCount++;
+            },
+            new CsvLoadOptions { SkipInitialRecords = 1 });
+
+        return fieldCount;
+    }
+
+    [Benchmark]
+    public int OfficeIMO_ReadFieldSpanVisitorSkipHeader()
+    {
+        using var reader = new StringReader(_csvText);
+        var visitor = new CountingFieldSpanVisitor();
+        CsvDocument.ReadFieldSpans(
+            reader,
+            ref visitor,
+            new CsvLoadOptions { SkipInitialRecords = 1 });
+
+        return visitor.FieldCount;
+    }
+
+    [Benchmark]
+    public int CsvHelper_ReadFields()
+    {
+        using var reader = new StringReader(_csvText);
+        using var csv = new CsvHelperReader(reader, CultureInfo.InvariantCulture);
+        var fieldCount = 0;
+        if (!csv.Read())
+        {
+            return fieldCount;
+        }
+
+        csv.ReadHeader();
+        while (csv.Read())
+        {
+            for (var i = 0; i < Headers.Length; i++)
+            {
+                _ = csv.GetField(i);
+                fieldCount++;
+            }
+        }
+
+        return fieldCount;
+    }
+
+    [Benchmark]
+    public int Sylvan_ReadFields()
+    {
+        using var reader = new StringReader(_csvText);
+        using var csv = SylvanCsvDataReader.Create(reader);
+        var fieldCount = 0;
+        while (csv.Read())
+        {
+            for (var i = 0; i < csv.FieldCount; i++)
+            {
+                _ = csv.GetString(i);
+                fieldCount++;
+            }
+        }
+
+        return fieldCount;
+    }
+
+    [Benchmark]
+    public int Sylvan_ReadFieldSpans()
+    {
+        using var reader = new StringReader(_csvText);
+        using var csv = SylvanCsvDataReader.Create(reader);
+        var fieldCount = 0;
+        while (csv.Read())
+        {
+            for (var i = 0; i < csv.FieldCount; i++)
+            {
+                _ = csv.GetFieldSpan(i);
+                fieldCount++;
+            }
+        }
+
+        return fieldCount;
+    }
+
+    private static string[] CreateHeaders()
+    {
+        var headers = new string[40];
+        headers[0] = "Id";
+        headers[1] = "Name";
+        headers[2] = "Created";
+        headers[3] = "Enabled";
+        for (var i = 4; i < headers.Length; i++)
+        {
+            headers[i] = string.Create(CultureInfo.InvariantCulture, $"Metric{i - 3}");
+        }
+
+        return headers;
+    }
+
+    private struct CountingFieldSpanVisitor : ICsvFieldSpanVisitor
+    {
+        public int FieldCount { get; private set; }
+
+        public void VisitField(int recordIndex, int fieldIndex, ReadOnlySpan<char> value)
+        {
+            FieldCount++;
+        }
+    }
+}
+
+internal static class CsvWideBenchmarkData
+{
+    public static object?[][] Create(int count)
+    {
+        var rows = new object?[count][];
+        for (var i = 1; i <= count; i++)
+        {
+            var row = new object?[40];
+            row[0] = i;
+            row[1] = string.Create(CultureInfo.InvariantCulture, $"Wide-{i:000000}");
+            row[2] = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(i);
+            row[3] = i % 2 == 0;
+            for (var column = 4; column < row.Length; column++)
+            {
+                row[column] = Math.Round((decimal)(((i + column - 3) * 1.017) % 10000), 4);
+            }
+
+            rows[i - 1] = row;
+        }
+
+        return rows;
+    }
+}

--- a/OfficeIMO.CSV.Benchmarks/OfficeIMO.CSV.Benchmarks.csproj
+++ b/OfficeIMO.CSV.Benchmarks/OfficeIMO.CSV.Benchmarks.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="CsvHelper" Version="33.1.0" />
+    <PackageReference Include="Sylvan.Data.Csv" Version="1.4.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OfficeIMO.CSV.Benchmarks/README.md
+++ b/OfficeIMO.CSV.Benchmarks/README.md
@@ -5,9 +5,9 @@ This project compares raw .NET CSV paths without PowerShell object overhead. Use
 ## Run
 
 ```powershell
-dotnet run --project .\OfficeIMO.CSV.Benchmarks\OfficeIMO.CSV.Benchmarks.csproj -c Release -f net8.0 -- --filter *CsvBenchmarks*
+dotnet run --project .\OfficeIMO.CSV.Benchmarks\OfficeIMO.CSV.Benchmarks.csproj -c Release -f net8.0 -- --filter *Csv*Benchmarks*
 ```
 
-The suite compares OfficeIMO.CSV object writing, OfficeIMO.CSV projected-row writing, OfficeIMO.CSV streaming/in-memory reads, CsvHelper typed record writing, CsvHelper projected-row writing, CsvHelper raw field reads, and CsvHelper typed record reads.
+The suite compares OfficeIMO.CSV object writing, OfficeIMO.CSV projected-row writing, OfficeIMO.CSV reusable reads, OfficeIMO.CSV field-span reads, CsvHelper typed/projected writes, CsvHelper raw/typed reads, and Sylvan raw/string/span field reads.
 
-CsvHelper is a benchmark-only dependency in this project. It should not be added to `OfficeIMO.CSV` unless a future design decision intentionally changes the runtime dependency model.
+CsvHelper and Sylvan.Data.Csv are benchmark-only dependencies in this project. They should not be added to `OfficeIMO.CSV` unless a future design decision intentionally changes the runtime dependency model.

--- a/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
@@ -217,6 +217,26 @@ public class CsvStreamingTests
     }
 
     [Fact]
+    public void ReadFieldSpans_PreservesTrimmedWhitespaceDelimiterOnlyRows()
+    {
+        var fields = new List<string>();
+        using var reader = new StringReader("Name\tValue\n \t \nAlpha\t1\n");
+
+        CsvDocument.ReadFieldSpans(
+            reader,
+            (recordIndex, fieldIndex, value) => fields.Add($"{recordIndex}:{fieldIndex}:{value.ToString()}"),
+            new CsvLoadOptions {
+                Delimiter = '\t',
+                SkipInitialRecords = 1,
+                TrimWhitespace = true
+            });
+
+        Assert.Equal(
+            new[] { "0:0:", "0:1:", "1:0:Alpha", "1:1:1" },
+            fields);
+    }
+
+    [Fact]
     public void ReadFieldSpans_DetectsDelimiterAfterSkippedMetadata()
     {
         var fields = new List<string>();

--- a/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
@@ -136,6 +136,89 @@ public class CsvStreamingTests
         Assert.Equal(new[] { "Alpha", "1" }, records[1]);
     }
 
+#if NET8_0_OR_GREATER
+    [Fact]
+    public void ReadFieldSpans_CanSkipInitialRecords()
+    {
+        var fields = new List<string>();
+        using var reader = new StringReader("metadata\nName,Value\nAlpha,1\n");
+
+        CsvDocument.ReadFieldSpans(
+            reader,
+            (recordIndex, fieldIndex, value) => fields.Add($"{recordIndex}:{fieldIndex}:{value.ToString()}"),
+            new CsvLoadOptions { SkipInitialRecords = 1 });
+
+        Assert.Equal(
+            new[] { "0:0:Name", "0:1:Value", "1:0:Alpha", "1:1:1" },
+            fields);
+    }
+
+    [Fact]
+    public void ReadFieldSpans_ReadsWideUnquotedRecords()
+    {
+        var headers = string.Join(",", Enumerable.Range(0, 12).Select(index => $"H{index}"));
+        var values = Enumerable.Range(0, 12).Select(index => new string((char)('A' + index), 40) + index).ToArray();
+        var fields = new List<string>();
+        using var reader = new StringReader(headers + "\n" + string.Join(",", values) + "\n");
+
+        CsvDocument.ReadFieldSpans(
+            reader,
+            (recordIndex, fieldIndex, value) => fields.Add($"{recordIndex}:{fieldIndex}:{value.ToString()}"),
+            new CsvLoadOptions { SkipInitialRecords = 1 });
+
+        Assert.Equal(
+            values.Select((value, index) => $"0:{index}:{value}").ToArray(),
+            fields);
+    }
+
+    [Fact]
+    public void ReadFieldSpans_FallsBackForQuotedMultilineRecords()
+    {
+        var fields = new List<string>();
+        using var reader = new StringReader("Name,Note\nAlpha,\"one\ntwo\"\n");
+
+        CsvDocument.ReadFieldSpans(
+            reader,
+            (recordIndex, fieldIndex, value) => fields.Add($"{recordIndex}:{fieldIndex}:{value.ToString()}"),
+            new CsvLoadOptions { SkipInitialRecords = 1 });
+
+        Assert.Equal(new[] { "0:0:Alpha", "0:1:one\ntwo" }, fields);
+    }
+
+    [Fact]
+    public void ReadFieldSpans_DoesNotEmitSkippedBlankLines()
+    {
+        var fields = new List<string>();
+        using var reader = new StringReader("Name,Value\n\nAlpha,1\n");
+
+        CsvDocument.ReadFieldSpans(
+            reader,
+            (recordIndex, fieldIndex, value) => fields.Add($"{recordIndex}:{fieldIndex}:{value.ToString()}"),
+            new CsvLoadOptions { SkipInitialRecords = 1 });
+
+        Assert.Equal(new[] { "0:0:Alpha", "0:1:1" }, fields);
+    }
+
+    [Fact]
+    public void ReadFieldSpans_DetectsDelimiterAfterSkippedMetadata()
+    {
+        var fields = new List<string>();
+        using var reader = new StringReader("metadata,with,commas\nName;Value\nAlpha;1\n");
+
+        CsvDocument.ReadFieldSpans(
+            reader,
+            (recordIndex, fieldIndex, value) => fields.Add($"{recordIndex}:{fieldIndex}:{value.ToString()}"),
+            new CsvLoadOptions {
+                DetectDelimiter = true,
+                SkipInitialRecords = 1
+            });
+
+        Assert.Equal(
+            new[] { "0:0:Name", "0:1:Value", "1:0:Alpha", "1:1:1" },
+            fields);
+    }
+#endif
+
     [Fact]
     public void LoadFromStream_InMemoryMode_ParsesRows()
     {

--- a/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
@@ -200,6 +200,23 @@ public class CsvStreamingTests
     }
 
     [Fact]
+    public void ReadFieldSpans_DoesNotEmitTrimmedWhitespaceOnlyLines()
+    {
+        var fields = new List<string>();
+        using var reader = new StringReader("Name,Value\n   \t  \nAlpha,1\n");
+
+        CsvDocument.ReadFieldSpans(
+            reader,
+            (recordIndex, fieldIndex, value) => fields.Add($"{recordIndex}:{fieldIndex}:{value.ToString()}"),
+            new CsvLoadOptions {
+                SkipInitialRecords = 1,
+                TrimWhitespace = true
+            });
+
+        Assert.Equal(new[] { "0:0:Alpha", "0:1:1" }, fields);
+    }
+
+    [Fact]
     public void ReadFieldSpans_DetectsDelimiterAfterSkippedMetadata()
     {
         var fields = new List<string>();

--- a/OfficeIMO.CSV/CsvDocument.Fields.cs
+++ b/OfficeIMO.CSV/CsvDocument.Fields.cs
@@ -1,0 +1,95 @@
+#nullable enable
+
+using System.Text;
+
+namespace OfficeIMO.CSV;
+
+public sealed partial class CsvDocument
+{
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Reads CSV fields from a file in a single pass without materializing unquoted fields as strings.
+    /// </summary>
+    /// <param name="path">Source CSV path.</param>
+    /// <param name="fieldAction">Action receiving each field as a transient span.</param>
+    /// <param name="options">Optional load settings. Header handling is not applied; records are emitted as parsed.</param>
+    public static void ReadFieldSpans(string path, CsvFieldSpanAction fieldAction, CsvLoadOptions? options = null)
+    {
+        if (fieldAction == null)
+        {
+            throw new ArgumentNullException(nameof(fieldAction));
+        }
+
+        var visitor = new CsvFieldSpanActionVisitor(fieldAction);
+        ReadFieldSpans(path, ref visitor, options);
+    }
+
+    /// <summary>
+    /// Reads CSV fields from a file in a single pass without materializing unquoted fields as strings.
+    /// </summary>
+    /// <typeparam name="TVisitor">Struct visitor type receiving each field.</typeparam>
+    /// <param name="path">Source CSV path.</param>
+    /// <param name="fieldVisitor">Visitor receiving each field as a transient span.</param>
+    /// <param name="options">Optional load settings. Header handling is not applied; records are emitted as parsed.</param>
+    public static void ReadFieldSpans<TVisitor>(string path, ref TVisitor fieldVisitor, CsvLoadOptions? options = null)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            throw new ArgumentException("File path cannot be empty.", nameof(path));
+        }
+
+        options = CreateRawRecordOptions(options);
+        var encoding = options.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        var readerFactory = () => new StreamReader(path, encoding, detectEncodingFromByteOrderMarks: true, bufferSize: FileBufferSize);
+        var resolvedOptions = ResolveLoadOptions(readerFactory, options, useHeaderDiscoveryForDelimiterDetection: false);
+        using var reader = readerFactory();
+        ReadFieldSpans(reader, ref fieldVisitor, resolvedOptions);
+    }
+
+    /// <summary>
+    /// Reads CSV fields from a reader in a single pass without materializing unquoted fields as strings.
+    /// </summary>
+    /// <param name="reader">Source text reader.</param>
+    /// <param name="fieldAction">Action receiving each field as a transient span.</param>
+    /// <param name="options">Optional load settings. Header handling is not applied; records are emitted as parsed.</param>
+    public static void ReadFieldSpans(TextReader reader, CsvFieldSpanAction fieldAction, CsvLoadOptions? options = null)
+    {
+        if (fieldAction == null)
+        {
+            throw new ArgumentNullException(nameof(fieldAction));
+        }
+
+        var visitor = new CsvFieldSpanActionVisitor(fieldAction);
+        ReadFieldSpans(reader, ref visitor, options);
+    }
+
+    /// <summary>
+    /// Reads CSV fields from a reader in a single pass without materializing unquoted fields as strings.
+    /// </summary>
+    /// <typeparam name="TVisitor">Struct visitor type receiving each field.</typeparam>
+    /// <param name="reader">Source text reader.</param>
+    /// <param name="fieldVisitor">Visitor receiving each field as a transient span.</param>
+    /// <param name="options">Optional load settings. Header handling is not applied; records are emitted as parsed.</param>
+    public static void ReadFieldSpans<TVisitor>(TextReader reader, ref TVisitor fieldVisitor, CsvLoadOptions? options = null)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        if (reader == null)
+        {
+            throw new ArgumentNullException(nameof(reader));
+        }
+
+        options = CreateRawRecordOptions(options);
+        if (options.DetectDelimiter)
+        {
+            var text = reader.ReadToEnd();
+            var resolvedOptions = ResolveLoadOptions(() => new StringReader(text), options, useHeaderDiscoveryForDelimiterDetection: false);
+            using var bufferedReader = new StringReader(text);
+            ReadFieldSpans(bufferedReader, ref fieldVisitor, resolvedOptions);
+            return;
+        }
+
+        CsvParser.ReadFieldSpans(reader, options, GetInitialRecordsToSkip(options), ref fieldVisitor);
+    }
+#endif
+}

--- a/OfficeIMO.CSV/CsvFieldSpanAction.cs
+++ b/OfficeIMO.CSV/CsvFieldSpanAction.cs
@@ -1,0 +1,13 @@
+#nullable enable
+
+namespace OfficeIMO.CSV;
+
+#if NET8_0_OR_GREATER
+/// <summary>
+/// Receives a parsed CSV field as a transient character span.
+/// </summary>
+/// <param name="recordIndex">Zero-based emitted record index after skipped records and comments.</param>
+/// <param name="fieldIndex">Zero-based field index inside the current record.</param>
+/// <param name="value">Field value. The span is only valid for the duration of the callback.</param>
+public delegate void CsvFieldSpanAction(int recordIndex, int fieldIndex, ReadOnlySpan<char> value);
+#endif

--- a/OfficeIMO.CSV/CsvLineReader.cs
+++ b/OfficeIMO.CSV/CsvLineReader.cs
@@ -1,0 +1,628 @@
+#nullable enable
+
+using System.Text;
+
+namespace OfficeIMO.CSV;
+
+internal sealed class CsvLineReader
+{
+    private const int DefaultBufferSize = 32 * 1024;
+    private readonly TextReader _reader;
+    private readonly char[] _buffer;
+    private int _position;
+    private int _length;
+    private bool _endOfReader;
+
+    public CsvLineReader(TextReader reader)
+    {
+        _reader = reader ?? throw new ArgumentNullException(nameof(reader));
+        _buffer = new char[DefaultBufferSize];
+    }
+
+    public CsvLineReadResult ReadUnquotedRecordOrLine(char delimiter, bool trim, char commentCharacter, List<string> fields, out string? line, out string separator)
+    {
+        fields.Clear();
+        line = null;
+        separator = string.Empty;
+
+        if (!EnsureBuffered())
+        {
+            return CsvLineReadResult.EndOfReader;
+        }
+
+        var segmentStart = _position;
+        var segmentLength = _length - _position;
+        if (segmentLength == 0)
+        {
+            return CsvLineReadResult.EndOfReader;
+        }
+
+        if (_buffer[segmentStart] == commentCharacter)
+        {
+            line = ReadLine(out separator);
+            return CsvLineReadResult.Line;
+        }
+
+        var newlineIndex = IndexOfNewline(segmentStart, segmentLength);
+        if (newlineIndex < 0)
+        {
+            line = ReadLine(out separator);
+            return CsvLineReadResult.Line;
+        }
+
+        var lineLength = newlineIndex - segmentStart;
+        if (Array.IndexOf(_buffer, '"', segmentStart, lineLength) >= 0)
+        {
+            line = ReadLine(out separator);
+            return CsvLineReadResult.Line;
+        }
+
+        AddUnquotedFields(segmentStart, newlineIndex, delimiter, trim, fields);
+        _position = newlineIndex;
+        ConsumeLineSeparator(_buffer[newlineIndex], out separator);
+        return CsvLineReadResult.UnquotedRecord;
+    }
+
+#if NET8_0_OR_GREATER
+    public CsvLineReadResult ReadUnquotedFieldSpansOrLine<TVisitor>(
+        char delimiter,
+        bool trim,
+        char commentCharacter,
+        bool allowEmpty,
+        bool emitFields,
+        int recordIndex,
+        ref TVisitor fieldVisitor,
+        out int fieldCount,
+        out bool isEmptyRecord,
+        out string? line,
+        out string separator)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        fieldCount = 0;
+        isEmptyRecord = false;
+        line = null;
+        separator = string.Empty;
+
+        if (!EnsureBuffered())
+        {
+            return CsvLineReadResult.EndOfReader;
+        }
+
+        var segmentStart = _position;
+        var segmentLength = _length - _position;
+        if (segmentLength == 0)
+        {
+            return CsvLineReadResult.EndOfReader;
+        }
+
+        if (_buffer[segmentStart] == commentCharacter)
+        {
+            line = ReadLine(out separator);
+            return CsvLineReadResult.Line;
+        }
+
+        if (!trim &&
+            delimiter <= byte.MaxValue &&
+            System.Runtime.Intrinsics.X86.Avx2.IsSupported &&
+            TryReadUnquotedFieldSpansOrLineAvx2(
+                delimiter,
+                allowEmpty,
+                emitFields,
+                recordIndex,
+                ref fieldVisitor,
+                out fieldCount,
+                out isEmptyRecord,
+                out separator,
+                out var readResult))
+        {
+            return readResult;
+        }
+
+        var specialIndex = _buffer.AsSpan(segmentStart, segmentLength).IndexOfAny('"', '\r', '\n');
+        while (specialIndex < 0 && TryExtendCurrentSegment())
+        {
+            segmentStart = _position;
+            segmentLength = _length - _position;
+            specialIndex = _buffer.AsSpan(segmentStart, segmentLength).IndexOfAny('"', '\r', '\n');
+        }
+
+        var endsAtReaderEnd = false;
+        if (specialIndex < 0)
+        {
+            if (!_endOfReader || segmentStart == 0 && segmentLength == _buffer.Length)
+            {
+                line = ReadLine(out separator);
+                return CsvLineReadResult.Line;
+            }
+
+            specialIndex = segmentLength;
+            endsAtReaderEnd = true;
+        }
+
+        var newlineIndex = segmentStart + specialIndex;
+        if (!endsAtReaderEnd && _buffer[newlineIndex] == '"')
+        {
+            line = ReadLine(out separator);
+            return CsvLineReadResult.Line;
+        }
+
+        var lineLength = newlineIndex - segmentStart;
+        fieldCount = VisitUnquotedFieldSpans(segmentStart, newlineIndex, delimiter, trim, allowEmpty || lineLength != 0, emitFields, recordIndex, ref fieldVisitor, out var firstFieldLength);
+        isEmptyRecord = fieldCount == 1 && firstFieldLength == 0;
+        _position = newlineIndex;
+        if (endsAtReaderEnd)
+        {
+            separator = string.Empty;
+        }
+        else
+        {
+            ConsumeLineSeparator(_buffer[newlineIndex], out separator);
+        }
+
+        return CsvLineReadResult.UnquotedRecord;
+    }
+#endif
+
+    public string? ReadLine(out string separator)
+    {
+        separator = string.Empty;
+        StringBuilder? builder = null;
+
+        while (true)
+        {
+            if (!EnsureBuffered())
+            {
+                return builder?.ToString();
+            }
+
+            var segmentStart = _position;
+            var newlineIndex = IndexOfNewline(_position, _length - _position);
+            if (newlineIndex >= 0)
+            {
+                _position = newlineIndex;
+                return CompleteLine(builder, segmentStart, newlineIndex, _buffer[newlineIndex], out separator);
+            }
+
+            _position = _length;
+            builder ??= new StringBuilder(Math.Max(256, _length - segmentStart));
+            builder.Append(_buffer, segmentStart, _length - segmentStart);
+        }
+    }
+
+    private int IndexOfNewline(int start, int count)
+    {
+        var lineFeed = Array.IndexOf(_buffer, '\n', start, count);
+        var carriageReturn = Array.IndexOf(_buffer, '\r', start, count);
+        if (lineFeed < 0)
+        {
+            return carriageReturn;
+        }
+
+        if (carriageReturn < 0)
+        {
+            return lineFeed;
+        }
+
+        return Math.Min(lineFeed, carriageReturn);
+    }
+
+    private void AddUnquotedFields(int start, int end, char delimiter, bool trim, List<string> fields)
+    {
+        var fieldStart = start;
+        for (var i = start; i < end; i++)
+        {
+            if (_buffer[i] != delimiter)
+            {
+                continue;
+            }
+
+            fields.Add(GetUnquotedField(fieldStart, i - fieldStart, trim));
+            fieldStart = i + 1;
+        }
+
+        fields.Add(GetUnquotedField(fieldStart, end - fieldStart, trim));
+    }
+
+    private string GetUnquotedField(int start, int length, bool trim)
+    {
+        if (length == 0)
+        {
+            return string.Empty;
+        }
+
+        if (!trim)
+        {
+            return new string(_buffer, start, length);
+        }
+
+        var end = start + length - 1;
+        while (start <= end && char.IsWhiteSpace(_buffer[start]))
+        {
+            start++;
+        }
+
+        while (end >= start && char.IsWhiteSpace(_buffer[end]))
+        {
+            end--;
+        }
+
+        return end < start ? string.Empty : new string(_buffer, start, end - start + 1);
+    }
+
+#if NET8_0_OR_GREATER
+    private int VisitUnquotedFieldSpans<TVisitor>(
+        int start,
+        int end,
+        char delimiter,
+        bool trim,
+        bool emitNonEmptyRecord,
+        bool emitFields,
+        int recordIndex,
+        ref TVisitor fieldVisitor,
+        out int firstFieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        if (!trim)
+        {
+            return VisitUntrimmedUnquotedFieldSpans(start, end, delimiter, emitNonEmptyRecord && emitFields, recordIndex, ref fieldVisitor, out firstFieldLength);
+        }
+
+        var fieldIndex = 0;
+        var fieldStart = start;
+        var emit = emitNonEmptyRecord && emitFields;
+        firstFieldLength = 0;
+        for (var i = start; i < end; i++)
+        {
+            if (_buffer[i] != delimiter)
+            {
+                continue;
+            }
+
+            VisitFieldSpan(fieldStart, i - fieldStart, trim: true, emit, recordIndex, fieldIndex, ref fieldVisitor, ref firstFieldLength);
+            fieldIndex++;
+            fieldStart = i + 1;
+        }
+
+        VisitFieldSpan(fieldStart, end - fieldStart, trim: true, emit, recordIndex, fieldIndex, ref fieldVisitor, ref firstFieldLength);
+        return fieldIndex + 1;
+    }
+
+    private int VisitUntrimmedUnquotedFieldSpans<TVisitor>(
+        int start,
+        int end,
+        char delimiter,
+        bool emit,
+        int recordIndex,
+        ref TVisitor fieldVisitor,
+        out int firstFieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        var fieldIndex = 0;
+        var fieldStart = start;
+        firstFieldLength = 0;
+        for (var i = start; i < end; i++)
+        {
+            if (_buffer[i] != delimiter)
+            {
+                continue;
+            }
+
+            var length = i - fieldStart;
+            if (fieldIndex == 0)
+            {
+                firstFieldLength = length;
+            }
+
+            if (emit)
+            {
+                fieldVisitor.VisitField(recordIndex, fieldIndex, _buffer.AsSpan(fieldStart, length));
+            }
+
+            fieldIndex++;
+            fieldStart = i + 1;
+        }
+
+        var finalLength = end - fieldStart;
+        if (fieldIndex == 0)
+        {
+            firstFieldLength = finalLength;
+        }
+
+        if (emit)
+        {
+            fieldVisitor.VisitField(recordIndex, fieldIndex, _buffer.AsSpan(fieldStart, finalLength));
+        }
+
+        return fieldIndex + 1;
+    }
+
+    private int VisitIndexedUntrimmedUnquotedFieldSpans<TVisitor>(
+        int start,
+        int end,
+        ReadOnlySpan<int> delimiterIndexes,
+        bool emit,
+        int recordIndex,
+        ref TVisitor fieldVisitor,
+        out int firstFieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        var fieldIndex = 0;
+        var fieldStart = start;
+        firstFieldLength = 0;
+        foreach (var delimiterIndex in delimiterIndexes)
+        {
+            var length = delimiterIndex - fieldStart;
+            if (fieldIndex == 0)
+            {
+                firstFieldLength = length;
+            }
+
+            if (emit)
+            {
+                fieldVisitor.VisitField(recordIndex, fieldIndex, _buffer.AsSpan(fieldStart, length));
+            }
+
+            fieldIndex++;
+            fieldStart = delimiterIndex + 1;
+        }
+
+        var finalLength = end - fieldStart;
+        if (fieldIndex == 0)
+        {
+            firstFieldLength = finalLength;
+        }
+
+        if (emit)
+        {
+            fieldVisitor.VisitField(recordIndex, fieldIndex, _buffer.AsSpan(fieldStart, finalLength));
+        }
+
+        return fieldIndex + 1;
+    }
+
+    private bool TryReadUnquotedFieldSpansOrLineAvx2<TVisitor>(
+        char delimiter,
+        bool allowEmpty,
+        bool emitFields,
+        int recordIndex,
+        ref TVisitor fieldVisitor,
+        out int fieldCount,
+        out bool isEmptyRecord,
+        out string separator,
+        out CsvLineReadResult readResult)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        fieldCount = 0;
+        isEmptyRecord = false;
+        separator = string.Empty;
+        readResult = CsvLineReadResult.Line;
+
+        var start = _position;
+        var end = _length - 32;
+        if (start > end)
+        {
+            return false;
+        }
+
+        Span<int> delimiterIndexes = stackalloc int[256];
+        var delimiterCount = 0;
+        var pos = start;
+        var delimiterVector = System.Runtime.Intrinsics.Vector256.Create((byte)delimiter);
+        var quoteVector = System.Runtime.Intrinsics.Vector256.Create((byte)'"');
+        var carriageReturnVector = System.Runtime.Intrinsics.Vector256.Create((byte)'\r');
+        var lineFeedVector = System.Runtime.Intrinsics.Vector256.Create((byte)'\n');
+
+        while (pos <= end)
+        {
+            var values = System.Runtime.InteropServices.MemoryMarshal.Cast<char, short>(_buffer.AsSpan(pos, 32));
+            var first = System.Runtime.Intrinsics.Vector256.LoadUnsafe(ref System.Runtime.InteropServices.MemoryMarshal.GetReference(values));
+            var second = System.Runtime.Intrinsics.Vector256.LoadUnsafe(ref System.Runtime.InteropServices.MemoryMarshal.GetReference(values.Slice(16)));
+            var packed = System.Runtime.Intrinsics.X86.Avx2.PackUnsignedSaturate(first, second);
+            var packedBytes = System.Runtime.Intrinsics.Vector256.AsByte(
+                System.Runtime.Intrinsics.X86.Avx2.Permute4x64(System.Runtime.Intrinsics.Vector256.AsInt64(packed), 0b11_01_10_00));
+
+            var delimiterMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, delimiterVector));
+            var quoteMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, quoteVector));
+            var carriageReturnMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, carriageReturnVector));
+            var lineFeedMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, lineFeedVector));
+            var terminalMask = quoteMask | carriageReturnMask | lineFeedMask;
+
+            if (terminalMask != 0)
+            {
+                var terminalOffset = System.Numerics.BitOperations.TrailingZeroCount(terminalMask);
+                var delimiterMaskBeforeTerminal = delimiterMask & ((1u << terminalOffset) - 1u);
+                if (!AddDelimiterIndexes(delimiterMaskBeforeTerminal, pos, delimiterIndexes, ref delimiterCount))
+                {
+                    return false;
+                }
+
+                if (((quoteMask >> terminalOffset) & 1u) != 0)
+                {
+                    return false;
+                }
+
+                var newlineIndex = pos + terminalOffset;
+                var lineLength = newlineIndex - start;
+                fieldCount = VisitIndexedUntrimmedUnquotedFieldSpans(
+                    start,
+                    newlineIndex,
+                    delimiterIndexes.Slice(0, delimiterCount),
+                    (allowEmpty || lineLength != 0) && emitFields,
+                    recordIndex,
+                    ref fieldVisitor,
+                    out var firstFieldLength);
+                isEmptyRecord = fieldCount == 1 && firstFieldLength == 0;
+                _position = newlineIndex;
+                ConsumeLineSeparator(_buffer[newlineIndex], out separator);
+                readResult = CsvLineReadResult.UnquotedRecord;
+                return true;
+            }
+
+            if (!AddDelimiterIndexes(delimiterMask, pos, delimiterIndexes, ref delimiterCount))
+            {
+                return false;
+            }
+
+            pos += 32;
+        }
+
+        return false;
+    }
+
+    private static bool AddDelimiterIndexes(uint delimiterMask, int chunkStart, Span<int> delimiterIndexes, ref int delimiterCount)
+    {
+        while (delimiterMask != 0)
+        {
+            if (delimiterCount == delimiterIndexes.Length)
+            {
+                return false;
+            }
+
+            var offset = System.Numerics.BitOperations.TrailingZeroCount(delimiterMask);
+            delimiterIndexes[delimiterCount++] = chunkStart + offset;
+            delimiterMask &= delimiterMask - 1;
+        }
+
+        return true;
+    }
+
+    private void VisitFieldSpan<TVisitor>(
+        int start,
+        int length,
+        bool trim,
+        bool emit,
+        int recordIndex,
+        int fieldIndex,
+        ref TVisitor fieldVisitor,
+        ref int firstFieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        var span = _buffer.AsSpan(start, length);
+        if (trim)
+        {
+            span = span.Trim();
+        }
+
+        if (fieldIndex == 0)
+        {
+            firstFieldLength = span.Length;
+        }
+
+        if (emit)
+        {
+            fieldVisitor.VisitField(recordIndex, fieldIndex, span);
+        }
+    }
+#endif
+
+    private string CompleteLine(StringBuilder? builder, int segmentStart, int lineEnd, char newline, out string separator)
+    {
+        var line = builder is null
+            ? new string(_buffer, segmentStart, lineEnd - segmentStart)
+            : AppendAndGetString(builder, segmentStart, lineEnd - segmentStart);
+
+        ConsumeLineSeparator(newline, out separator);
+        return line;
+    }
+
+    private void ConsumeLineSeparator(char newline, out string separator)
+    {
+        _position++;
+        if (newline == '\r')
+        {
+            separator = ConsumeLineFeedAfterCarriageReturn() ? "\r\n" : "\r";
+        }
+        else
+        {
+            separator = "\n";
+        }
+    }
+
+    private string AppendAndGetString(StringBuilder builder, int start, int count)
+    {
+        if (count > 0)
+        {
+            builder.Append(_buffer, start, count);
+        }
+
+        return builder.ToString();
+    }
+
+    private bool ConsumeLineFeedAfterCarriageReturn()
+    {
+        if (!EnsureBuffered())
+        {
+            return false;
+        }
+
+        if (_buffer[_position] != '\n')
+        {
+            return false;
+        }
+
+        _position++;
+        return true;
+    }
+
+    private bool EnsureBuffered()
+    {
+        if (_position < _length)
+        {
+            return true;
+        }
+
+        if (_endOfReader)
+        {
+            return false;
+        }
+
+        _length = _reader.Read(_buffer, 0, _buffer.Length);
+        _position = 0;
+        if (_length > 0)
+        {
+            return true;
+        }
+
+        _endOfReader = true;
+        return false;
+    }
+
+#if NET8_0_OR_GREATER
+    private bool TryExtendCurrentSegment()
+    {
+        var remaining = _length - _position;
+        if (_position == 0 || remaining >= _buffer.Length)
+        {
+            return false;
+        }
+
+        if (remaining > 0)
+        {
+            Array.Copy(_buffer, _position, _buffer, 0, remaining);
+        }
+
+        _position = 0;
+        _length = remaining;
+        var read = _reader.Read(_buffer, remaining, _buffer.Length - remaining);
+        if (read == 0)
+        {
+            _endOfReader = true;
+            return false;
+        }
+
+        _length += read;
+        return true;
+    }
+#endif
+}
+
+internal enum CsvLineReadResult
+{
+    EndOfReader,
+    UnquotedRecord,
+    Line
+}

--- a/OfficeIMO.CSV/CsvLineReader.cs
+++ b/OfficeIMO.CSV/CsvLineReader.cs
@@ -148,7 +148,7 @@ internal sealed class CsvLineReader
 
         var lineLength = newlineIndex - segmentStart;
         var emitNonEmptyRecord = allowEmpty || (trim
-            ? HasNonWhitespace(segmentStart, newlineIndex)
+            ? HasNonWhitespaceOrDelimiter(segmentStart, newlineIndex, delimiter)
             : lineLength != 0);
         fieldCount = VisitUnquotedFieldSpans(segmentStart, newlineIndex, delimiter, trim, emitNonEmptyRecord, emitFields, recordIndex, ref fieldVisitor, out var firstFieldLength);
         isEmptyRecord = fieldCount == 1 && firstFieldLength == 0;
@@ -253,11 +253,12 @@ internal sealed class CsvLineReader
     }
 
 #if NET8_0_OR_GREATER
-    private bool HasNonWhitespace(int start, int end)
+    private bool HasNonWhitespaceOrDelimiter(int start, int end, char delimiter)
     {
         for (var i = start; i < end; i++)
         {
-            if (!char.IsWhiteSpace(_buffer[i]))
+            var value = _buffer[i];
+            if (value == delimiter || !char.IsWhiteSpace(value))
             {
                 return true;
             }

--- a/OfficeIMO.CSV/CsvLineReader.cs
+++ b/OfficeIMO.CSV/CsvLineReader.cs
@@ -147,7 +147,10 @@ internal sealed class CsvLineReader
         }
 
         var lineLength = newlineIndex - segmentStart;
-        fieldCount = VisitUnquotedFieldSpans(segmentStart, newlineIndex, delimiter, trim, allowEmpty || lineLength != 0, emitFields, recordIndex, ref fieldVisitor, out var firstFieldLength);
+        var emitNonEmptyRecord = allowEmpty || (trim
+            ? HasNonWhitespace(segmentStart, newlineIndex)
+            : lineLength != 0);
+        fieldCount = VisitUnquotedFieldSpans(segmentStart, newlineIndex, delimiter, trim, emitNonEmptyRecord, emitFields, recordIndex, ref fieldVisitor, out var firstFieldLength);
         isEmptyRecord = fieldCount == 1 && firstFieldLength == 0;
         _position = newlineIndex;
         if (endsAtReaderEnd)
@@ -250,6 +253,19 @@ internal sealed class CsvLineReader
     }
 
 #if NET8_0_OR_GREATER
+    private bool HasNonWhitespace(int start, int end)
+    {
+        for (var i = start; i < end; i++)
+        {
+            if (!char.IsWhiteSpace(_buffer[i]))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private int VisitUnquotedFieldSpans<TVisitor>(
         int start,
         int end,

--- a/OfficeIMO.CSV/CsvObjectWriter.cs
+++ b/OfficeIMO.CSV/CsvObjectWriter.cs
@@ -19,6 +19,8 @@ public sealed class CsvObjectWriter : IDisposable
     private readonly bool _leaveOpen;
     private readonly StringBuilder _rowBuffer = new(1024);
     private IReadOnlyList<string>? _columns;
+    private Func<object, object?[], bool>? _propertyProjector;
+    private object?[]? _propertyValues;
     private bool _disposed;
 
     /// <summary>
@@ -63,9 +65,29 @@ public sealed class CsvObjectWriter : IDisposable
             throw new InvalidOperationException("Data rows cannot contain null entries.");
         }
 
+        if (_columns != null &&
+            _propertyProjector != null &&
+            _propertyValues != null &&
+            _propertyProjector(item, _propertyValues))
+        {
+            WriteBuffered(_propertyValues);
+            return;
+        }
+
         var itemColumns = ObjectDataHelpers.GetColumnNames(item);
-        EnsureColumns(itemColumns, requireOrder: !ObjectDataHelpers.IsDictionaryLike(item));
+        var dictionaryLike = ObjectDataHelpers.IsDictionaryLike(item);
+        EnsureColumns(itemColumns, requireOrder: !dictionaryLike);
         var columns = _columns!;
+
+        if (!dictionaryLike &&
+            ObjectDataHelpers.TryCreatePropertyProjector(item, columns, out var projector))
+        {
+            _propertyProjector = projector;
+            _propertyValues = new object?[columns.Count];
+            projector!(item, _propertyValues);
+            WriteBuffered(_propertyValues);
+            return;
+        }
 
         var values = new object?[columns.Count];
         for (var i = 0; i < columns.Count; i++)
@@ -133,6 +155,84 @@ public sealed class CsvObjectWriter : IDisposable
         EnsureColumns(columns);
 
         WriteBuffered(values);
+    }
+
+    /// <summary>
+    /// Writes one already-projected row using the column order that was established by a previous row.
+    /// </summary>
+    /// <param name="values">Values in the same order as the established CSV columns.</param>
+    /// <remarks>
+    /// Use this only when the caller already owns schema validation and can guarantee stable column order.
+    /// The method still validates that the row width matches the established header.
+    /// </remarks>
+    public void WriteTrustedRow(object?[] values)
+    {
+        ThrowIfDisposed();
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(values);
+#else
+        if (values == null)
+        {
+            throw new ArgumentNullException(nameof(values));
+        }
+#endif
+
+        if (_columns == null)
+        {
+            throw new InvalidOperationException("Columns must be established before writing trusted rows.");
+        }
+
+        if (values.Length != _columns.Count)
+        {
+            throw new CsvException($"Row contains {values.Length} values but header defines {_columns.Count} columns.");
+        }
+
+        WriteBuffered(values);
+    }
+
+    /// <summary>
+    /// Writes one already-formatted text row using the column order that was established by a previous row.
+    /// </summary>
+    /// <param name="values">Text values in the same order as the established CSV columns.</param>
+    /// <remarks>
+    /// Use this only when the caller already owns schema validation and culture-aware value formatting.
+    /// The method still applies CSV escaping and validates that the row width matches the established header.
+    /// </remarks>
+    public void WriteTrustedTextRow(string?[] values)
+    {
+        ThrowIfDisposed();
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(values);
+#else
+        if (values == null)
+        {
+            throw new ArgumentNullException(nameof(values));
+        }
+#endif
+
+        if (_columns == null)
+        {
+            throw new InvalidOperationException("Columns must be established before writing trusted rows.");
+        }
+
+        if (values.Length != _columns.Count)
+        {
+            throw new CsvException($"Row contains {values.Length} values but header defines {_columns.Count} columns.");
+        }
+
+        if (_useDefaultWritePath)
+        {
+            CsvWriter.WriteRecordBufferedDefault(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine);
+            return;
+        }
+
+        if (_useAlwaysQuotedWritePath)
+        {
+            CsvWriter.WriteRecordBufferedAlwaysQuoted(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine);
+            return;
+        }
+
+        CsvWriter.WriteRecordBuffered<string?>(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns);
     }
 
     /// <summary>

--- a/OfficeIMO.CSV/CsvParser.Quoted.cs
+++ b/OfficeIMO.CSV/CsvParser.Quoted.cs
@@ -1,0 +1,441 @@
+#nullable enable
+
+using System.Text;
+
+namespace OfficeIMO.CSV;
+
+internal static partial class CsvParser
+{
+    private enum QuotedRecordParseResult
+    {
+        Complete,
+        Invalid,
+        Incomplete
+    }
+
+    private static bool TryParseQuotedRecord(string text, char delimiter, bool trim, out string[] fields)
+    {
+        fields = Array.Empty<string>();
+        if (text.Length > 0 && text[0] == '"' && TryParseStrictQuotedRecord(text, delimiter, trim, out fields))
+        {
+            return true;
+        }
+
+        var standardResult = TryParseStandardQuotedRecord(text, delimiter, trim, out fields);
+        if (standardResult == QuotedRecordParseResult.Complete)
+        {
+            return true;
+        }
+
+        if (standardResult == QuotedRecordParseResult.Incomplete)
+        {
+            return false;
+        }
+
+        var buffer = new StringBuilder();
+        var parsedFields = new List<string>(16);
+        var inQuotes = false;
+        var fieldWasQuoted = false;
+        var afterClosingQuote = false;
+
+        for (var i = 0; i < text.Length; i++)
+        {
+            var c = text[i];
+
+            if (inQuotes)
+            {
+                if (c == '"')
+                {
+                    if (i + 1 < text.Length && text[i + 1] == '"')
+                    {
+                        i++;
+                        buffer.Append('"');
+                    }
+                    else
+                    {
+                        inQuotes = false;
+                        afterClosingQuote = true;
+                    }
+                }
+                else
+                {
+                    buffer.Append(c);
+                }
+
+                continue;
+            }
+
+            if (c == '"')
+            {
+                if (afterClosingQuote)
+                {
+                    buffer.Append(c);
+                    afterClosingQuote = false;
+                    continue;
+                }
+
+                if (trim && IsWhitespaceOnly(buffer))
+                {
+                    buffer.Clear();
+                }
+
+                inQuotes = true;
+                fieldWasQuoted = true;
+                continue;
+            }
+
+            if (c == delimiter)
+            {
+                AddQuotedField(parsedFields, buffer, trim, ref fieldWasQuoted);
+                afterClosingQuote = false;
+                continue;
+            }
+
+            if (afterClosingQuote && char.IsWhiteSpace(c) && trim)
+            {
+                continue;
+            }
+
+            afterClosingQuote = false;
+            buffer.Append(c);
+        }
+
+        if (inQuotes)
+        {
+            return false;
+        }
+
+        AddQuotedField(parsedFields, buffer, trim, ref fieldWasQuoted);
+        fields = parsedFields.ToArray();
+        return true;
+    }
+
+    private static bool TryParseQuotedRecord(string text, char delimiter, bool trim, List<string> fields)
+    {
+        fields.Clear();
+        var standardResult = TryParseStandardQuotedRecord(text, delimiter, trim, fields);
+        if (standardResult == QuotedRecordParseResult.Complete)
+        {
+            return true;
+        }
+
+        fields.Clear();
+        if (standardResult == QuotedRecordParseResult.Incomplete)
+        {
+            return false;
+        }
+
+        return TryParseFlexibleQuotedRecord(text, delimiter, trim, fields);
+    }
+
+    private static bool TryParseFlexibleQuotedRecord(string text, char delimiter, bool trim, List<string> parsedFields)
+    {
+        var buffer = new StringBuilder();
+        var inQuotes = false;
+        var fieldWasQuoted = false;
+        var afterClosingQuote = false;
+
+        for (var i = 0; i < text.Length; i++)
+        {
+            var c = text[i];
+
+            if (inQuotes)
+            {
+                if (c == '"')
+                {
+                    if (i + 1 < text.Length && text[i + 1] == '"')
+                    {
+                        i++;
+                        buffer.Append('"');
+                    }
+                    else
+                    {
+                        inQuotes = false;
+                        afterClosingQuote = true;
+                    }
+                }
+                else
+                {
+                    buffer.Append(c);
+                }
+
+                continue;
+            }
+
+            if (c == '"')
+            {
+                if (afterClosingQuote)
+                {
+                    buffer.Append(c);
+                    afterClosingQuote = false;
+                    continue;
+                }
+
+                if (trim && IsWhitespaceOnly(buffer))
+                {
+                    buffer.Clear();
+                }
+
+                inQuotes = true;
+                fieldWasQuoted = true;
+                continue;
+            }
+
+            if (c == delimiter)
+            {
+                AddQuotedField(parsedFields, buffer, trim, ref fieldWasQuoted);
+                afterClosingQuote = false;
+                continue;
+            }
+
+            if (afterClosingQuote && char.IsWhiteSpace(c) && trim)
+            {
+                continue;
+            }
+
+            afterClosingQuote = false;
+            buffer.Append(c);
+        }
+
+        if (inQuotes)
+        {
+            parsedFields.Clear();
+            return false;
+        }
+
+        AddQuotedField(parsedFields, buffer, trim, ref fieldWasQuoted);
+        return true;
+    }
+
+    private static QuotedRecordParseResult TryParseStandardQuotedRecord(string text, char delimiter, bool trim, out string[] fields)
+    {
+        var parsedFields = new List<string>(16);
+        var result = TryParseStandardQuotedRecord(text, delimiter, trim, parsedFields);
+        fields = result == QuotedRecordParseResult.Complete ? parsedFields.ToArray() : Array.Empty<string>();
+        return result;
+    }
+
+    private static QuotedRecordParseResult TryParseStandardQuotedRecord(string text, char delimiter, bool trim, List<string> parsedFields)
+    {
+        var index = 0;
+
+        while (index < text.Length)
+        {
+            if (text[index] == delimiter)
+            {
+                parsedFields.Add(string.Empty);
+                index++;
+                if (index == text.Length)
+                {
+                    parsedFields.Add(string.Empty);
+                }
+
+                continue;
+            }
+
+            if (text[index] == '"')
+            {
+                var quotedResult = TryReadStandardQuotedField(text, ref index, trim, delimiter, out var quotedValue);
+                if (quotedResult != QuotedRecordParseResult.Complete)
+                {
+                    return quotedResult;
+                }
+
+                parsedFields.Add(quotedValue);
+            }
+            else
+            {
+                var start = index;
+                while (index < text.Length && text[index] != delimiter)
+                {
+                    if (text[index] == '"')
+                    {
+                        return QuotedRecordParseResult.Invalid;
+                    }
+
+                    index++;
+                }
+
+                parsedFields.Add(GetUnquotedField(text, start, index - start, trim));
+            }
+
+            if (index == text.Length)
+            {
+                return QuotedRecordParseResult.Complete;
+            }
+
+            if (text[index] != delimiter)
+            {
+                return QuotedRecordParseResult.Invalid;
+            }
+
+            index++;
+            if (index == text.Length)
+            {
+                parsedFields.Add(string.Empty);
+            }
+        }
+
+        return QuotedRecordParseResult.Complete;
+    }
+
+    private static QuotedRecordParseResult TryReadStandardQuotedField(string text, ref int index, bool trim, char delimiter, out string value)
+    {
+        index++;
+        var start = index;
+        StringBuilder? builder = null;
+
+        while (index < text.Length)
+        {
+            if (text[index] != '"')
+            {
+                index++;
+                continue;
+            }
+
+            if (index + 1 < text.Length && text[index + 1] == '"')
+            {
+                builder ??= new StringBuilder();
+                builder.Append(text, start, index - start);
+                builder.Append('"');
+                index += 2;
+                start = index;
+                continue;
+            }
+
+            value = builder is null
+                ? text.Substring(start, index - start)
+                : AppendAndGetString(builder, text, start, index - start);
+            index++;
+
+            if (trim)
+            {
+                while (index < text.Length && text[index] != delimiter && char.IsWhiteSpace(text[index]))
+                {
+                    index++;
+                }
+            }
+
+            if (index < text.Length && text[index] != delimiter)
+            {
+                value = string.Empty;
+                return QuotedRecordParseResult.Invalid;
+            }
+
+            return QuotedRecordParseResult.Complete;
+        }
+
+        value = string.Empty;
+        return QuotedRecordParseResult.Incomplete;
+    }
+
+    private static string AppendAndGetString(StringBuilder builder, string text, int start, int count)
+    {
+        if (count > 0)
+        {
+            builder.Append(text, start, count);
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool IsWhitespaceOnly(StringBuilder buffer)
+    {
+        for (var i = 0; i < buffer.Length; i++)
+        {
+            if (!char.IsWhiteSpace(buffer[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryParseStrictQuotedRecord(string text, char delimiter, bool trim, out string[] fields)
+    {
+        if (text.Length == 0)
+        {
+            fields = new[] { string.Empty };
+            return true;
+        }
+
+        var fieldCount = 1;
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (text[i] == delimiter)
+            {
+                fieldCount++;
+            }
+        }
+
+        fields = new string[fieldCount];
+
+        var index = 0;
+        var fieldIndex = 0;
+        while (index < text.Length)
+        {
+            if (text[index] != '"')
+            {
+                fields = Array.Empty<string>();
+                return false;
+            }
+
+            index++;
+            var start = index;
+            while (index < text.Length && text[index] != '"')
+            {
+                index++;
+            }
+
+            if (index >= text.Length)
+            {
+                fields = Array.Empty<string>();
+                return false;
+            }
+
+            if (index + 1 < text.Length && text[index + 1] == '"')
+            {
+                fields = Array.Empty<string>();
+                return false;
+            }
+
+            var value = text.Substring(start, index - start);
+            fields[fieldIndex++] = value;
+            index++;
+
+            if (index == text.Length)
+            {
+                return fieldIndex == fields.Length;
+            }
+
+            if (text[index] != delimiter)
+            {
+                fields = Array.Empty<string>();
+                return false;
+            }
+
+            index++;
+            if (index == text.Length)
+            {
+                fields = Array.Empty<string>();
+                return false;
+            }
+        }
+
+        return fieldIndex == fields.Length;
+    }
+
+    private static void AddQuotedField(List<string> fields, StringBuilder buffer, bool trim, ref bool fieldWasQuoted)
+    {
+        var value = buffer.ToString();
+        if (trim && !fieldWasQuoted)
+        {
+            value = value.Trim();
+        }
+
+        fields.Add(value);
+        buffer.Clear();
+        fieldWasQuoted = false;
+    }
+}

--- a/OfficeIMO.CSV/CsvParser.cs
+++ b/OfficeIMO.CSV/CsvParser.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace OfficeIMO.CSV;
 
-internal static class CsvParser
+internal static partial class CsvParser
 {
     private readonly struct CsvLine
     {
@@ -85,6 +85,30 @@ internal static class CsvParser
         ReadLineOrQuotedReusableWithMetadata(reader, options, recordAction);
     }
 
+#if NET8_0_OR_GREATER
+    internal static void ReadFieldSpans(TextReader reader, CsvLoadOptions options, int recordsToSkip, CsvFieldSpanAction fieldAction)
+    {
+        if (fieldAction == null)
+        {
+            throw new ArgumentNullException(nameof(fieldAction));
+        }
+
+        var visitor = new CsvFieldSpanActionVisitor(fieldAction);
+        ReadFieldSpans(reader, options, recordsToSkip, ref visitor);
+    }
+
+    internal static void ReadFieldSpans<TVisitor>(TextReader reader, CsvLoadOptions options, int recordsToSkip, ref TVisitor fieldVisitor)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        if (recordsToSkip < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(recordsToSkip), "SkipInitialRecords cannot be negative.");
+        }
+
+        ReadFieldSpansLineOrQuoted(reader, options, recordsToSkip, ref fieldVisitor);
+    }
+#endif
+
     private static void ReadLineOrQuoted(TextReader reader, CsvLoadOptions options, Action<string[]> recordAction)
     {
         var delimiter = options.Delimiter;
@@ -93,11 +117,12 @@ internal static class CsvParser
         var lineNumber = 1;
         var emittedRecordCount = 0;
         var pendingLines = new Queue<CsvLine>();
+        var lineReader = new CsvLineReader(reader);
 
-        while (ReadLineWithSeparator(reader, pendingLines, out var lineSeparator) is { } line)
+        while (ReadLineWithSeparator(lineReader, pendingLines, out var lineSeparator) is { } line)
         {
             var startsWithCommentCharacter = IsRawCommentLine(line, options);
-            if (TrySkipCommentRecordBeforeParsing(reader, pendingLines, startsWithCommentCharacter, line, lineSeparator, options, emittedRecordCount, ref lineNumber))
+            if (TrySkipCommentRecordBeforeParsing(lineReader, pendingLines, startsWithCommentCharacter, line, lineSeparator, options, emittedRecordCount, ref lineNumber))
             {
                 lineNumber++;
                 continue;
@@ -123,7 +148,7 @@ internal static class CsvParser
                 var pendingSeparator = lineSeparator;
                 while (true)
                 {
-                    var next = ReadLineWithSeparator(reader, pendingLines, out var nextSeparator);
+                    var next = ReadLineWithSeparator(lineReader, pendingLines, out var nextSeparator);
                     if (next == null)
                     {
                         throw new CsvParseException("Unterminated quoted field.", lineNumber);
@@ -174,11 +199,12 @@ internal static class CsvParser
         var lineNumber = 1;
         var emittedRecordCount = 0;
         var pendingLines = new Queue<CsvLine>();
+        var lineReader = new CsvLineReader(reader);
 
-        while (ReadLineWithSeparator(reader, pendingLines, out var lineSeparator) is { } line)
+        while (ReadLineWithSeparator(lineReader, pendingLines, out var lineSeparator) is { } line)
         {
             var startsWithCommentCharacter = IsRawCommentLine(line, options);
-            if (TrySkipCommentRecordBeforeParsing(reader, pendingLines, startsWithCommentCharacter, line, lineSeparator, options, emittedRecordCount, ref lineNumber))
+            if (TrySkipCommentRecordBeforeParsing(lineReader, pendingLines, startsWithCommentCharacter, line, lineSeparator, options, emittedRecordCount, ref lineNumber))
             {
                 lineNumber++;
                 continue;
@@ -204,7 +230,7 @@ internal static class CsvParser
                 var pendingSeparator = lineSeparator;
                 while (true)
                 {
-                    var next = ReadLineWithSeparator(reader, pendingLines, out var nextSeparator);
+                    var next = ReadLineWithSeparator(lineReader, pendingLines, out var nextSeparator);
                     if (next == null)
                     {
                         throw new CsvParseException("Unterminated quoted field.", lineNumber);
@@ -238,7 +264,112 @@ internal static class CsvParser
 
     private static void ReadLineOrQuotedReusable(TextReader reader, CsvLoadOptions options, Action<IReadOnlyList<string>> recordAction)
     {
-        ReadLineOrQuotedReusableWithMetadata(reader, options, record => recordAction(record.Values));
+        var delimiter = options.Delimiter;
+        var trim = options.TrimWhitespace;
+        var allowEmpty = options.AllowEmptyLines;
+        var lineNumber = 1;
+        var reusableRecord = new List<string>(64);
+        var reusableQuotedRecord = new List<string>(64);
+        var emittedRecordCount = 0;
+        var pendingLines = new Queue<CsvLine>();
+        var lineReader = new CsvLineReader(reader);
+
+        while (pendingLines.Count > 0 || true)
+        {
+            string? fastLine = null;
+            string lineSeparator;
+            CsvLineReadResult readResult;
+            if (pendingLines.Count == 0)
+            {
+                readResult = lineReader.ReadUnquotedRecordOrLine(delimiter, trim, options.CommentCharacter, reusableRecord, out fastLine, out lineSeparator);
+            }
+            else
+            {
+                lineSeparator = string.Empty;
+                readResult = CsvLineReadResult.Line;
+            }
+
+            if (readResult == CsvLineReadResult.EndOfReader)
+            {
+                break;
+            }
+
+            if (readResult == CsvLineReadResult.UnquotedRecord)
+            {
+                if (ShouldEmitRecord(reusableRecord, allowEmpty))
+                {
+                    recordAction(reusableRecord);
+                    emittedRecordCount++;
+                }
+
+                lineNumber++;
+                continue;
+            }
+
+            var line = pendingLines.Count > 0
+                ? ReadLineWithSeparator(lineReader, pendingLines, out lineSeparator)
+                : fastLine;
+            if (line is null)
+            {
+                break;
+            }
+
+            var startsWithCommentCharacter = IsRawCommentLine(line, options);
+            if (TrySkipCommentRecordBeforeParsing(lineReader, pendingLines, startsWithCommentCharacter, line, lineSeparator, options, emittedRecordCount, ref lineNumber))
+            {
+                lineNumber++;
+                continue;
+            }
+
+            if (TrySplitUnquotedRecord(line, delimiter, trim, reusableRecord))
+            {
+                if (!ShouldSkipCommentRecord(startsWithCommentCharacter, line, options, emittedRecordCount) &&
+                    ShouldEmitRecord(reusableRecord, allowEmpty))
+                {
+                    recordAction(reusableRecord);
+                    emittedRecordCount++;
+                }
+
+                lineNumber++;
+                continue;
+            }
+
+            if (!TryParseQuotedRecord(line, delimiter, trim, reusableQuotedRecord))
+            {
+                var logicalRecord = new StringBuilder(line);
+                var pendingSeparator = lineSeparator;
+                while (true)
+                {
+                    var next = ReadLineWithSeparator(lineReader, pendingLines, out var nextSeparator);
+                    if (next == null)
+                    {
+                        throw new CsvParseException("Unterminated quoted field.", lineNumber);
+                    }
+
+                    logicalRecord.Append(pendingSeparator);
+                    logicalRecord.Append(next);
+                    lineNumber++;
+
+                    if (TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, reusableQuotedRecord))
+                    {
+                        break;
+                    }
+
+                    pendingSeparator = nextSeparator;
+                }
+            }
+
+            if (ShouldEmitRecord(reusableQuotedRecord, allowEmpty))
+            {
+                if (!ShouldSkipCommentRecord(startsWithCommentCharacter, line, options, emittedRecordCount))
+                {
+                    recordAction(reusableQuotedRecord);
+                    emittedRecordCount++;
+                }
+            }
+
+            lineNumber++;
+        }
     }
 
     private static void ReadLineOrQuotedReusableWithMetadata(TextReader reader, CsvLoadOptions options, Action<CsvParsedRecord> recordAction)
@@ -247,14 +378,54 @@ internal static class CsvParser
         var trim = options.TrimWhitespace;
         var allowEmpty = options.AllowEmptyLines;
         var lineNumber = 1;
-        var reusableRecord = new List<string>(16);
+        var reusableRecord = new List<string>(64);
+        var reusableQuotedRecord = new List<string>(64);
         var emittedRecordCount = 0;
         var pendingLines = new Queue<CsvLine>();
+        var lineReader = new CsvLineReader(reader);
 
-        while (ReadLineWithSeparator(reader, pendingLines, out var lineSeparator) is { } line)
+        while (pendingLines.Count > 0 || true)
         {
+            string? fastLine = null;
+            string lineSeparator;
+            CsvLineReadResult readResult;
+            if (pendingLines.Count == 0)
+            {
+                readResult = lineReader.ReadUnquotedRecordOrLine(delimiter, trim, options.CommentCharacter, reusableRecord, out fastLine, out lineSeparator);
+            }
+            else
+            {
+                lineSeparator = string.Empty;
+                readResult = CsvLineReadResult.Line;
+            }
+
+            if (readResult == CsvLineReadResult.EndOfReader)
+            {
+                break;
+            }
+
+            if (readResult == CsvLineReadResult.UnquotedRecord)
+            {
+                if (ShouldEmitRecord(reusableRecord, allowEmpty))
+                {
+                    recordAction(new CsvParsedRecord(reusableRecord, startsWithCommentCharacter: false));
+                    emittedRecordCount++;
+                }
+
+                lineNumber++;
+                continue;
+            }
+
+            var line = pendingLines.Count > 0
+                ? ReadLineWithSeparator(lineReader, pendingLines, out lineSeparator)
+                : fastLine;
+            if (line is null)
+            {
+                break;
+            }
+
             var startsWithCommentCharacter = IsRawCommentLine(line, options);
-            if (TrySkipCommentRecordBeforeParsing(reader, pendingLines, startsWithCommentCharacter, line, lineSeparator, options, emittedRecordCount, ref lineNumber))
+            if (TrySkipCommentRecordBeforeParsing(lineReader, pendingLines, startsWithCommentCharacter, line, lineSeparator, options, emittedRecordCount, ref lineNumber))
             {
                 lineNumber++;
                 continue;
@@ -273,6 +444,145 @@ internal static class CsvParser
                 continue;
             }
 
+            if (!TryParseQuotedRecord(line, delimiter, trim, reusableQuotedRecord))
+            {
+                var logicalRecord = new StringBuilder(line);
+                var pendingSeparator = lineSeparator;
+                while (true)
+                {
+                    var next = ReadLineWithSeparator(lineReader, pendingLines, out var nextSeparator);
+                    if (next == null)
+                    {
+                        throw new CsvParseException("Unterminated quoted field.", lineNumber);
+                    }
+
+                    logicalRecord.Append(pendingSeparator);
+                    logicalRecord.Append(next);
+                    lineNumber++;
+
+                    if (TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, reusableQuotedRecord))
+                    {
+                        break;
+                    }
+
+                    pendingSeparator = nextSeparator;
+                }
+            }
+
+            if (ShouldEmitRecord(reusableQuotedRecord, allowEmpty))
+            {
+                if (!ShouldSkipCommentRecord(startsWithCommentCharacter, line, options, emittedRecordCount))
+                {
+                    recordAction(new CsvParsedRecord(reusableQuotedRecord, startsWithCommentCharacter));
+                    emittedRecordCount++;
+                }
+            }
+
+            lineNumber++;
+        }
+    }
+
+#if NET8_0_OR_GREATER
+    private static void ReadFieldSpansLineOrQuoted<TVisitor>(TextReader reader, CsvLoadOptions options, int recordsToSkip, ref TVisitor fieldVisitor)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        var delimiter = options.Delimiter;
+        var trim = options.TrimWhitespace;
+        var allowEmpty = options.AllowEmptyLines;
+        var lineNumber = 1;
+        var emittedRecordCount = 0;
+        var recordIndex = 0;
+        var pendingLines = new Queue<CsvLine>();
+        var lineReader = new CsvLineReader(reader);
+
+        while (pendingLines.Count > 0 || true)
+        {
+            string? fastLine = null;
+            string lineSeparator;
+            CsvLineReadResult readResult;
+            if (pendingLines.Count == 0)
+            {
+                readResult = lineReader.ReadUnquotedFieldSpansOrLine(
+                    delimiter,
+                    trim,
+                    options.CommentCharacter,
+                    allowEmpty,
+                    recordsToSkip == 0,
+                    recordIndex,
+                    ref fieldVisitor,
+                    out var fieldCount,
+                    out var isEmptyRecord,
+                    out fastLine,
+                    out lineSeparator);
+
+                if (readResult == CsvLineReadResult.EndOfReader)
+                {
+                    break;
+                }
+
+                if (readResult == CsvLineReadResult.UnquotedRecord)
+                {
+                    if (fieldCount != 0 && (allowEmpty || !isEmptyRecord))
+                    {
+                        if (recordsToSkip > 0)
+                        {
+                            recordsToSkip--;
+                        }
+                        else
+                        {
+                            recordIndex++;
+                        }
+
+                        emittedRecordCount++;
+                    }
+
+                    lineNumber++;
+                    continue;
+                }
+            }
+            else
+            {
+                lineSeparator = string.Empty;
+                readResult = CsvLineReadResult.Line;
+            }
+
+            var line = pendingLines.Count > 0
+                ? ReadLineWithSeparator(lineReader, pendingLines, out lineSeparator)
+                : fastLine;
+            if (line is null)
+            {
+                break;
+            }
+
+            var startsWithCommentCharacter = IsRawCommentLine(line, options);
+            if (TrySkipCommentRecordBeforeParsing(lineReader, pendingLines, startsWithCommentCharacter, line, lineSeparator, options, emittedRecordCount, ref lineNumber))
+            {
+                lineNumber++;
+                continue;
+            }
+
+            if (TrySplitUnquotedRecord(line, delimiter, trim, out var record))
+            {
+                if (!ShouldSkipCommentRecord(startsWithCommentCharacter, line, options, emittedRecordCount) &&
+                    ShouldEmitRecord(record, allowEmpty))
+                {
+                    if (recordsToSkip > 0)
+                    {
+                        recordsToSkip--;
+                    }
+                    else
+                    {
+                        VisitParsedFields(record, recordIndex, ref fieldVisitor);
+                        recordIndex++;
+                    }
+
+                    emittedRecordCount++;
+                }
+
+                lineNumber++;
+                continue;
+            }
+
             string[] fields;
             if (!TryParseQuotedRecord(line, delimiter, trim, out fields))
             {
@@ -280,7 +590,7 @@ internal static class CsvParser
                 var pendingSeparator = lineSeparator;
                 while (true)
                 {
-                    var next = ReadLineWithSeparator(reader, pendingLines, out var nextSeparator);
+                    var next = ReadLineWithSeparator(lineReader, pendingLines, out var nextSeparator);
                     if (next == null)
                     {
                         throw new CsvParseException("Unterminated quoted field.", lineNumber);
@@ -303,7 +613,16 @@ internal static class CsvParser
             {
                 if (!ShouldSkipCommentRecord(startsWithCommentCharacter, line, options, emittedRecordCount))
                 {
-                    recordAction(new CsvParsedRecord(fields, startsWithCommentCharacter));
+                    if (recordsToSkip > 0)
+                    {
+                        recordsToSkip--;
+                    }
+                    else
+                    {
+                        VisitParsedFields(fields, recordIndex, ref fieldVisitor);
+                        recordIndex++;
+                    }
+
                     emittedRecordCount++;
                 }
             }
@@ -311,6 +630,16 @@ internal static class CsvParser
             lineNumber++;
         }
     }
+
+    private static void VisitParsedFields<TVisitor>(IReadOnlyList<string> fields, int recordIndex, ref TVisitor fieldVisitor)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        for (var fieldIndex = 0; fieldIndex < fields.Count; fieldIndex++)
+        {
+            fieldVisitor.VisitField(recordIndex, fieldIndex, fields[fieldIndex].AsSpan());
+        }
+    }
+#endif
 
     private static bool TrySplitUnquotedRecord(string line, char delimiter, bool trim, out string[] fields)
     {
@@ -406,179 +735,6 @@ internal static class CsvParser
         return line.Substring(start, end - start + 1);
     }
 
-    private static bool TryParseQuotedRecord(string text, char delimiter, bool trim, out string[] fields)
-    {
-        fields = Array.Empty<string>();
-        if (text.Length > 0 && text[0] == '"' && TryParseStrictQuotedRecord(text, delimiter, trim, out fields))
-        {
-            return true;
-        }
-
-        var buffer = new StringBuilder();
-        var parsedFields = new List<string>(16);
-        var inQuotes = false;
-        var fieldWasQuoted = false;
-        var afterClosingQuote = false;
-
-        for (var i = 0; i < text.Length; i++)
-        {
-            var c = text[i];
-
-            if (inQuotes)
-            {
-                if (c == '"')
-                {
-                    if (i + 1 < text.Length && text[i + 1] == '"')
-                    {
-                        i++;
-                        buffer.Append('"');
-                    }
-                    else
-                    {
-                        inQuotes = false;
-                        afterClosingQuote = true;
-                    }
-                }
-                else
-                {
-                    buffer.Append(c);
-                }
-
-                continue;
-            }
-
-            if (c == '"')
-            {
-                if (afterClosingQuote)
-                {
-                    buffer.Append(c);
-                    afterClosingQuote = false;
-                    continue;
-                }
-
-                if (trim && IsWhitespaceOnly(buffer))
-                {
-                    buffer.Clear();
-                }
-
-                inQuotes = true;
-                fieldWasQuoted = true;
-                continue;
-            }
-
-            if (c == delimiter)
-            {
-                AddField(parsedFields, buffer, trim, ref fieldWasQuoted);
-                afterClosingQuote = false;
-                continue;
-            }
-
-            if (afterClosingQuote && char.IsWhiteSpace(c) && trim)
-            {
-                continue;
-            }
-
-            afterClosingQuote = false;
-            buffer.Append(c);
-        }
-
-        if (inQuotes)
-        {
-            return false;
-        }
-
-        AddField(parsedFields, buffer, trim, ref fieldWasQuoted);
-        fields = parsedFields.ToArray();
-        return true;
-    }
-
-    private static bool IsWhitespaceOnly(StringBuilder buffer)
-    {
-        for (var i = 0; i < buffer.Length; i++)
-        {
-            if (!char.IsWhiteSpace(buffer[i]))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private static bool TryParseStrictQuotedRecord(string text, char delimiter, bool trim, out string[] fields)
-    {
-        if (text.Length == 0)
-        {
-            fields = new[] { string.Empty };
-            return true;
-        }
-
-        var fieldCount = 1;
-        for (var i = 0; i < text.Length; i++)
-        {
-            if (text[i] == delimiter)
-            {
-                fieldCount++;
-            }
-        }
-
-        fields = new string[fieldCount];
-
-        var index = 0;
-        var fieldIndex = 0;
-        while (index < text.Length)
-        {
-            if (text[index] != '"')
-            {
-                fields = Array.Empty<string>();
-                return false;
-            }
-
-            index++;
-            var start = index;
-            while (index < text.Length && text[index] != '"')
-            {
-                index++;
-            }
-
-            if (index >= text.Length)
-            {
-                fields = Array.Empty<string>();
-                return false;
-            }
-
-            if (index + 1 < text.Length && text[index + 1] == '"')
-            {
-                fields = Array.Empty<string>();
-                return false;
-            }
-
-            var value = text.Substring(start, index - start);
-            fields[fieldIndex++] = value;
-            index++;
-
-            if (index == text.Length)
-            {
-                return fieldIndex == fields.Length;
-            }
-
-            if (text[index] != delimiter)
-            {
-                fields = Array.Empty<string>();
-                return false;
-            }
-
-            index++;
-            if (index == text.Length)
-            {
-                fields = Array.Empty<string>();
-                return false;
-            }
-        }
-
-        return fieldIndex == fields.Length;
-    }
-
     private static bool ShouldSkipCommentRecord(bool startsWithCommentCharacter, string firstLine, CsvLoadOptions options, int emittedRecordCount)
     {
         if (!options.SkipCommentRows || !startsWithCommentCharacter)
@@ -589,7 +745,7 @@ internal static class CsvParser
         return !CanReadW3CFieldsHeader(options, emittedRecordCount) || !IsW3CFieldsLine(firstLine, options);
     }
 
-    private static bool TrySkipCommentRecordBeforeParsing(TextReader reader, Queue<CsvLine> pendingLines, bool startsWithCommentCharacter, string firstLine, string firstLineSeparator, CsvLoadOptions options, int emittedRecordCount, ref int lineNumber)
+    private static bool TrySkipCommentRecordBeforeParsing(CsvLineReader reader, Queue<CsvLine> pendingLines, bool startsWithCommentCharacter, string firstLine, string firstLineSeparator, CsvLoadOptions options, int emittedRecordCount, ref int lineNumber)
     {
         if (!ShouldSkipCommentRecordBeforeParsing(startsWithCommentCharacter, firstLine, options, emittedRecordCount))
         {
@@ -690,45 +846,7 @@ internal static class CsvParser
     private static bool IsW3CFieldsLine(string line, CsvLoadOptions options) =>
         options.RecognizeW3CFieldsHeader && line.StartsWith("#Fields:", StringComparison.OrdinalIgnoreCase);
 
-    private static string? ReadLineWithSeparator(TextReader reader, out string separator)
-    {
-        separator = string.Empty;
-        var builder = new StringBuilder();
-        while (true)
-        {
-            var value = reader.Read();
-            if (value < 0)
-            {
-                return builder.Length == 0 ? null : builder.ToString();
-            }
-
-            var ch = (char)value;
-            if (ch == '\r')
-            {
-                if (reader.Peek() == '\n')
-                {
-                    reader.Read();
-                    separator = "\r\n";
-                }
-                else
-                {
-                    separator = "\r";
-                }
-
-                return builder.ToString();
-            }
-
-            if (ch == '\n')
-            {
-                separator = "\n";
-                return builder.ToString();
-            }
-
-            builder.Append(ch);
-        }
-    }
-
-    private static string? ReadLineWithSeparator(TextReader reader, Queue<CsvLine> pendingLines, out string separator)
+    private static string? ReadLineWithSeparator(CsvLineReader reader, Queue<CsvLine> pendingLines, out string separator)
     {
         if (pendingLines.Count > 0)
         {
@@ -737,20 +855,7 @@ internal static class CsvParser
             return pending.Text;
         }
 
-        return ReadLineWithSeparator(reader, out separator);
-    }
-
-    private static void AddField(List<string> fields, StringBuilder buffer, bool trim, ref bool fieldWasQuoted)
-    {
-        var value = buffer.ToString();
-        if (trim && !fieldWasQuoted)
-        {
-            value = value.Trim();
-        }
-
-        fields.Add(value);
-        buffer.Clear();
-        fieldWasQuoted = false;
+        return reader.ReadLine(out separator);
     }
 
     private static bool ShouldEmitRecord(IReadOnlyList<string> fields, bool allowEmpty)

--- a/OfficeIMO.CSV/CsvWriter.cs
+++ b/OfficeIMO.CSV/CsvWriter.cs
@@ -208,6 +208,32 @@ internal static class CsvWriter
         WriteBufferedRecordLine(writer, buffer, newLine);
     }
 
+    internal static void WriteRecordBufferedDefault(
+        TextWriter writer,
+        StringBuilder buffer,
+        string?[] values,
+        char delimiter,
+        string newLine)
+    {
+        if (buffer == null)
+        {
+            throw new ArgumentNullException(nameof(buffer));
+        }
+
+        buffer.Clear();
+        for (var i = 0; i < values.Length; i++)
+        {
+            if (i > 0)
+            {
+                buffer.Append(delimiter);
+            }
+
+            AppendEscapedTextDefault(buffer, values[i], delimiter);
+        }
+
+        WriteBufferedRecordLine(writer, buffer, newLine);
+    }
+
     internal static void WriteRecordBufferedAlwaysQuoted(
         TextWriter writer,
         StringBuilder buffer,
@@ -230,6 +256,32 @@ internal static class CsvWriter
             }
 
             AppendAlwaysQuotedValue(buffer, values[i], culture);
+        }
+
+        WriteBufferedRecordLine(writer, buffer, newLine);
+    }
+
+    internal static void WriteRecordBufferedAlwaysQuoted(
+        TextWriter writer,
+        StringBuilder buffer,
+        string?[] values,
+        char delimiter,
+        string newLine)
+    {
+        if (buffer == null)
+        {
+            throw new ArgumentNullException(nameof(buffer));
+        }
+
+        buffer.Clear();
+        for (var i = 0; i < values.Length; i++)
+        {
+            if (i > 0)
+            {
+                buffer.Append(delimiter);
+            }
+
+            AppendAlwaysQuotedTextValue(buffer, values[i]);
         }
 
         WriteBufferedRecordLine(writer, buffer, newLine);
@@ -355,21 +407,21 @@ internal static class CsvWriter
 
     private static bool IsKnownCsvSafeSpanFormattedValue(object value)
     {
-        return value is byte
+        return value is decimal
+            or int
+            or DateTime
+            or double
+            or long
+            or DateTimeOffset
+            or Guid
+            or TimeSpan
+            or float
+            or byte
             or sbyte
             or short
             or ushort
-            or int
             or uint
-            or long
-            or ulong
-            or float
-            or double
-            or decimal
-            or DateTime
-            or DateTimeOffset
-            or TimeSpan
-            or Guid;
+            or ulong;
     }
 
     private static void WriteBufferedRecordLine(TextWriter writer, StringBuilder buffer, string newLine)
@@ -380,10 +432,19 @@ internal static class CsvWriter
             writer.WriteLine(buffer);
             return;
         }
-#endif
+
+        writer.Write(buffer);
+        writer.Write(newLine);
+#else
+        if (string.Equals(newLine, writer.NewLine, StringComparison.Ordinal))
+        {
+            writer.WriteLine(buffer.ToString());
+            return;
+        }
 
         buffer.Append(newLine);
-        writer.Write(buffer);
+        writer.Write(buffer.ToString());
+#endif
     }
 
     private static void AppendEscapedValue(
@@ -529,6 +590,18 @@ internal static class CsvWriter
 #endif
 
         AppendQuotedText(buffer, FormatValue(value, culture));
+    }
+
+    private static void AppendAlwaysQuotedTextValue(StringBuilder buffer, string? value)
+    {
+        buffer.Append('"');
+        if (value == null)
+        {
+            buffer.Append('"');
+            return;
+        }
+
+        AppendQuotedText(buffer, value);
     }
 
     private static void AppendQuotedText(StringBuilder buffer, string text)
@@ -734,33 +807,69 @@ internal static class CsvWriter
 
     private static void WriteEscapedDefault(StringBuilder writer, string text, char delimiter)
     {
-        if (!NeedsQuotes(text, delimiter))
+        var specialIndex = IndexOfCsvSpecial(text, delimiter);
+        if (specialIndex < 0)
         {
             writer.Append(text);
             return;
         }
 
         writer.Append('"');
-        if (text.IndexOf('"') < 0)
+        if (text.IndexOf('"', specialIndex) < 0)
         {
             writer.Append(text);
             writer.Append('"');
             return;
         }
 
-        foreach (var ch in text)
+        var segmentStart = 0;
+        for (var i = specialIndex; i < text.Length; i++)
         {
-            if (ch == '\"')
+            if (text[i] == '"')
             {
+                writer.Append(text, segmentStart, i - segmentStart);
                 writer.Append("\"\"");
-            }
-            else
-            {
-                writer.Append(ch);
+                segmentStart = i + 1;
             }
         }
 
+        if (segmentStart < text.Length)
+        {
+            writer.Append(text, segmentStart, text.Length - segmentStart);
+        }
+
         writer.Append('"');
+    }
+
+    private static void AppendEscapedTextDefault(StringBuilder writer, string? text, char delimiter)
+    {
+        if (text == null)
+        {
+            return;
+        }
+
+        WriteEscapedDefault(writer, text, delimiter);
+    }
+
+    private static int IndexOfCsvSpecial(string text, char delimiter)
+    {
+#if NET8_0_OR_GREATER
+        if (delimiter == ',')
+        {
+            return text.AsSpan().IndexOfAny(DefaultCommaQuoteCharacters);
+        }
+#endif
+
+        for (var i = 0; i < text.Length; i++)
+        {
+            var ch = text[i];
+            if (ch == '"' || ch == '\n' || ch == '\r' || ch == delimiter)
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
 #if NET6_0_OR_GREATER

--- a/OfficeIMO.CSV/ICsvFieldSpanVisitor.cs
+++ b/OfficeIMO.CSV/ICsvFieldSpanVisitor.cs
@@ -1,0 +1,34 @@
+#nullable enable
+
+namespace OfficeIMO.CSV;
+
+#if NET8_0_OR_GREATER
+/// <summary>
+/// Receives CSV fields as transient spans during a single-pass read.
+/// </summary>
+public interface ICsvFieldSpanVisitor
+{
+    /// <summary>
+    /// Visits one parsed field. The span is valid only for the duration of the call.
+    /// </summary>
+    /// <param name="recordIndex">Zero-based emitted record index.</param>
+    /// <param name="fieldIndex">Zero-based field index within the record.</param>
+    /// <param name="value">The field value. Do not capture the span beyond this method.</param>
+    void VisitField(int recordIndex, int fieldIndex, ReadOnlySpan<char> value);
+}
+
+internal readonly struct CsvFieldSpanActionVisitor : ICsvFieldSpanVisitor
+{
+    private readonly CsvFieldSpanAction _action;
+
+    public CsvFieldSpanActionVisitor(CsvFieldSpanAction action)
+    {
+        _action = action ?? throw new ArgumentNullException(nameof(action));
+    }
+
+    public void VisitField(int recordIndex, int fieldIndex, ReadOnlySpan<char> value)
+    {
+        _action(recordIndex, fieldIndex, value);
+    }
+}
+#endif

--- a/OfficeIMO.Shared/ObjectDataHelpers.cs
+++ b/OfficeIMO.Shared/ObjectDataHelpers.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 
 namespace OfficeIMO.Shared;
@@ -130,6 +131,31 @@ internal static class ObjectDataHelpers
         return GetPropertyPlan(item.GetType()).TryGetValue(item, column, out var propertyValue) ? propertyValue : null;
     }
 
+    /// <summary>
+    /// Creates a reusable projector for a fixed CLR object type and column order.
+    /// </summary>
+#if NET5_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Uses reflection over arbitrary object graphs. For AOT-safe usage, map values explicitly or pre-flatten items.")]
+#endif
+    internal static bool TryCreatePropertyProjector(object item, IReadOnlyList<string> columns, out Func<object, object?[], bool>? projector)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(item);
+        ArgumentNullException.ThrowIfNull(columns);
+#else
+        if (item == null) throw new ArgumentNullException(nameof(item));
+        if (columns == null) throw new ArgumentNullException(nameof(columns));
+#endif
+
+        projector = null;
+        if (IsDictionaryLike(item))
+        {
+            return false;
+        }
+
+        return GetPropertyPlan(item.GetType()).TryCreateProjector(columns, out projector);
+    }
+
     private static ObjectPropertyPlan GetPropertyPlan(Type type) => PropertyPlans.GetOrAdd(type, CreatePropertyPlan);
 
     private static ObjectPropertyPlan CreatePropertyPlan(Type type)
@@ -140,17 +166,19 @@ internal static class ObjectDataHelpers
             .OrderBy(static p => p.MetadataToken)
             .ToArray();
 
-        return new ObjectPropertyPlan(properties);
+        return new ObjectPropertyPlan(type, properties);
     }
 
     private sealed class ObjectPropertyPlan
     {
         private readonly Dictionary<string, PropertyInfo> _propertiesByName;
+        private readonly Type _type;
 
-        public ObjectPropertyPlan(IReadOnlyList<PropertyInfo> properties)
+        public ObjectPropertyPlan(Type type, IReadOnlyList<PropertyInfo> properties)
         {
             var columnNames = new string[properties.Count];
             _propertiesByName = new Dictionary<string, PropertyInfo>(properties.Count, StringComparer.Ordinal);
+            _type = type;
             for (var i = 0; i < properties.Count; i++)
             {
                 var property = properties[i];
@@ -173,6 +201,69 @@ internal static class ObjectDataHelpers
 
             value = null;
             return false;
+        }
+
+        public bool TryCreateProjector(IReadOnlyList<string> columns, out Func<object, object?[], bool>? projector)
+        {
+            var accessors = new Func<object, object?>[columns.Count];
+            for (var i = 0; i < columns.Count; i++)
+            {
+                if (!_propertiesByName.TryGetValue(columns[i], out var property))
+                {
+                    projector = null;
+                    return false;
+                }
+
+                accessors[i] = CreateAccessor(property);
+            }
+
+            projector = CreateProjector(_type, accessors);
+            return true;
+        }
+
+        private static Func<object, object?[], bool> CreateProjector(Type type, Func<object, object?>[] accessors)
+        {
+            return (item, values) =>
+            {
+                if (item == null || item.GetType() != type)
+                {
+                    return false;
+                }
+
+#if NET6_0_OR_GREATER
+                ArgumentNullException.ThrowIfNull(values);
+#else
+                if (values == null) throw new ArgumentNullException(nameof(values));
+#endif
+
+                if (values.Length != accessors.Length)
+                {
+                    throw new ArgumentException("Value buffer length must match the projector column count.", nameof(values));
+                }
+
+                for (var i = 0; i < accessors.Length; i++)
+                {
+                    values[i] = accessors[i](item);
+                }
+
+                return true;
+            };
+        }
+
+        private static Func<object, object?> CreateAccessor(PropertyInfo property)
+        {
+#if NET5_0_OR_GREATER
+            if (System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported)
+            {
+                var item = Expression.Parameter(typeof(object), "item");
+                var typedItem = Expression.Convert(item, property.DeclaringType!);
+                var value = Expression.Property(typedItem, property);
+                var boxedValue = Expression.Convert(value, typeof(object));
+                return Expression.Lambda<Func<object, object?>>(boxedValue, item).Compile();
+            }
+#endif
+
+            return property.GetValue;
         }
     }
 }


### PR DESCRIPTION
## Summary
- adds span-based CSV field reading APIs for low-allocation C# read paths
- improves the shared CSV parser and writer hot paths, including buffered line reading, reusable quoted-record parsing, and AVX2 acceleration for unquoted rows
- expands OfficeIMO CSV benchmarks to compare wide read/write shapes against CsvHelper and Sylvan

## Notes
The new fast paths are guarded by normal CSV parsing rules. Quoted, multiline, trimmed, unsupported delimiter, and non-AVX2 cases fall back to the existing parser behavior instead of taking a benchmark-specific shortcut.

## Validation
- OfficeIMO.CSV tests passed across net472, net8.0, and net10.0
- OfficeIMO.CSV project built across netstandard2.0, net472, net8.0, and net10.0
- CSV field-span benchmark shows OfficeIMO ahead of Sylvan on 1k, 10k, and 25k row wide reads
