### PR TITLE
Improve PDF fallback and converter APIs

### DIFF
--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Planning.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Planning.cs
@@ -11,7 +11,7 @@ namespace OfficeIMO.Excel.Pdf {
             preserveConfiguredFontSlots = options.PdfOptions != null;
 
             if (!string.IsNullOrWhiteSpace(options.FontFamily) &&
-                TryApplyPdfFontFamily(options.FontFamily, pdfOptions)) {
+                TryApplyPdfFontFamily(options.FontFamily, pdfOptions, options.AllowSystemFontEmbedding)) {
                 preserveConfiguredFontSlots = true;
             }
 
@@ -26,25 +26,35 @@ namespace OfficeIMO.Excel.Pdf {
             return pdfOptions;
         }
 
-        private static void ApplyDefaultEmbeddedFontFallback(PdfCore.PdfOptions pdfOptions, ExcelPdfSaveOptions options, bool preserveConfiguredFontSlots) {
-            if (options.PdfOptions == null &&
-                !preserveConfiguredFontSlots &&
-                !pdfOptions.HasEmbeddedStandardFontFamily(pdfOptions.DefaultFont)) {
-                pdfOptions.TryUseDefaultDocumentFontFallback(requireEmbeddedFont: true);
-            }
-        }
-
-        private static bool TryApplyPdfFontFamily(string? familyName, PdfCore.PdfOptions pdfOptions, bool requireEmbeddedFont = false) {
-            return pdfOptions.TryUseOfficeFontFamily(familyName, embedSystemFont: true, requireEmbeddedFont: requireEmbeddedFont);
-        }
-
-        private static void RegisterWorksheetFonts(PdfCore.PdfOptions pdfOptions, IReadOnlyList<WorksheetPdfExportPlan> exportPlans, ExcelPdfSaveOptions options, bool preserveConfiguredFontSlots) {
-            if (!options.UseWorksheetCellStyles) {
+        private static void ApplyTextFallbacks(
+            PdfCore.PdfOptions pdfOptions,
+            ExcelPdfSaveOptions options,
+            bool preserveConfiguredFontSlots,
+            IEnumerable<PdfCore.PdfStandardFont> reservedFontSlots) {
+            if (!options.AllowSystemFontEmbedding ||
+                options.TextFallbacks == PdfCore.PdfTextFallbackFeatures.None) {
                 return;
             }
 
-            var registeredFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            PdfCore.PdfTextFallbackFeatures fallbackFeatures = options.TextFallbacks;
+            if (preserveConfiguredFontSlots || pdfOptions.HasEmbeddedStandardFontFamily(pdfOptions.DefaultFont)) {
+                fallbackFeatures &= ~PdfCore.PdfTextFallbackFeatures.DocumentFont;
+            }
+
+            pdfOptions.UseTextFallbacks(fallbackFeatures, reservedFontSlots, options.AllowSystemFontEmbedding);
+        }
+
+        private static bool TryApplyPdfFontFamily(string? familyName, PdfCore.PdfOptions pdfOptions, bool embedSystemFont, bool requireEmbeddedFont = false) {
+            return pdfOptions.TryUseOfficeFontFamily(familyName, embedSystemFont, requireEmbeddedFont);
+        }
+
+        private static HashSet<PdfCore.PdfStandardFont> RegisterWorksheetFonts(PdfCore.PdfOptions pdfOptions, IReadOnlyList<WorksheetPdfExportPlan> exportPlans, ExcelPdfSaveOptions options, bool preserveConfiguredFontSlots) {
             HashSet<PdfCore.PdfStandardFont> registeredFontSlots = pdfOptions.CreateRegisteredFontFamilySlots(preserveConfiguredFontSlots);
+            if (!options.UseWorksheetCellStyles) {
+                return registeredFontSlots;
+            }
+
+            var registeredFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (WorksheetPdfExportPlan plan in exportPlans) {
                 ExcelCellStyleSnapshot?[,]? styles = plan.ExportData.Styles;
                 if (styles == null) {
@@ -55,15 +65,17 @@ namespace OfficeIMO.Excel.Pdf {
                 int columns = styles.GetLength(1);
                 for (int row = 0; row < rows; row++) {
                     for (int column = 0; column < columns; column++) {
-                        RegisterWorksheetFontCandidate(styles[row, column]?.FontName, pdfOptions, registeredFamilies, registeredFontSlots);
+                        RegisterWorksheetFontCandidate(styles[row, column]?.FontName, pdfOptions, registeredFamilies, registeredFontSlots, options.AllowSystemFontEmbedding);
                     }
                 }
             }
+
+            return registeredFontSlots;
         }
 
-        private static void RegisterWorksheetFontCandidate(string? familyName, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots) {
+        private static void RegisterWorksheetFontCandidate(string? familyName, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, bool embedSystemFont) {
             if (PdfCore.PdfOptions.TryAddOfficeFontFamilyKey(familyName, registeredFamilies, normalizeKey: null, out string trimmedFamilyName)) {
-                pdfOptions.TryRegisterMappedOfficeFontFamily(trimmedFamilyName, registeredFontSlots, embedSystemFont: true, out _);
+                pdfOptions.TryRegisterMappedOfficeFontFamily(trimmedFamilyName, registeredFontSlots, embedSystemFont, out _);
             }
         }
 

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Planning.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Planning.cs
@@ -128,6 +128,11 @@ namespace OfficeIMO.Excel.Pdf {
             }
 
             for (int i = 0; i < text!.Length - 1; i++) {
+                if (text[i] == '&' && text[i + 1] == '&') {
+                    i++;
+                    continue;
+                }
+
                 if (text[i] != '&' || text[i + 1] != '"') {
                     continue;
                 }

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Planning.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Planning.cs
@@ -44,7 +44,7 @@ namespace OfficeIMO.Excel.Pdf {
             }
 
             var registeredFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            HashSet<PdfCore.PdfStandardFont> registeredFontSlots = CreateRegisteredFontSlots(pdfOptions, preserveConfiguredFontSlots);
+            HashSet<PdfCore.PdfStandardFont> registeredFontSlots = pdfOptions.CreateRegisteredFontFamilySlots(preserveConfiguredFontSlots);
             foreach (WorksheetPdfExportPlan plan in exportPlans) {
                 ExcelCellStyleSnapshot?[,]? styles = plan.ExportData.Styles;
                 if (styles == null) {
@@ -62,40 +62,9 @@ namespace OfficeIMO.Excel.Pdf {
         }
 
         private static void RegisterWorksheetFontCandidate(string? familyName, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots) {
-            if (string.IsNullOrWhiteSpace(familyName)) {
-                return;
+            if (PdfCore.PdfOptions.TryAddOfficeFontFamilyKey(familyName, registeredFamilies, normalizeKey: null, out string trimmedFamilyName)) {
+                pdfOptions.TryRegisterMappedOfficeFontFamily(trimmedFamilyName, registeredFontSlots, embedSystemFont: true, out _);
             }
-
-            string trimmedFamilyName = familyName!.Trim();
-            if (!registeredFamilies.Add(trimmedFamilyName)) {
-                return;
-            }
-
-            if (PdfCore.PdfStandardFontMapper.TryMapFontFamily(trimmedFamilyName, out PdfCore.PdfStandardFont standardFont)) {
-                PdfCore.PdfStandardFont fontFamily = PdfCore.PdfStandardFontMapper.GetFontFamily(standardFont);
-                if (registeredFontSlots.Add(fontFamily)) {
-                    pdfOptions.RegisterOfficeFontFamily(trimmedFamilyName, fontFamily);
-                }
-            }
-        }
-
-        private static HashSet<PdfCore.PdfStandardFont> CreateRegisteredFontSlots(PdfCore.PdfOptions pdfOptions, bool preserveConfiguredFontSlots) {
-            var registeredFontSlots = new HashSet<PdfCore.PdfStandardFont>();
-            if (preserveConfiguredFontSlots) {
-                AddRegisteredFontSlot(registeredFontSlots, pdfOptions.DefaultFont);
-                AddRegisteredFontSlot(registeredFontSlots, pdfOptions.HeaderFont);
-                AddRegisteredFontSlot(registeredFontSlots, pdfOptions.FooterFont);
-            }
-
-            foreach (PdfCore.PdfStandardFont embeddedFont in pdfOptions.EmbeddedFonts.Keys) {
-                AddRegisteredFontSlot(registeredFontSlots, embeddedFont);
-            }
-
-            return registeredFontSlots;
-        }
-
-        private static void AddRegisteredFontSlot(HashSet<PdfCore.PdfStandardFont> registeredFontSlots, PdfCore.PdfStandardFont font) {
-            registeredFontSlots.Add(PdfCore.PdfStandardFontMapper.GetFontFamily(font));
         }
 
         private static IReadOnlyList<WorksheetPdfExportPlan> BuildWorksheetExportPlans(ExcelDocument document, ExcelDocumentReader reader, IReadOnlyList<string> sheetNames, ExcelPdfSaveOptions options, bool hasExplicitSheetSelection, PdfCore.PdfStandardFont defaultFontFamily) {

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Planning.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.Planning.cs
@@ -50,27 +50,96 @@ namespace OfficeIMO.Excel.Pdf {
 
         private static HashSet<PdfCore.PdfStandardFont> RegisterWorksheetFonts(PdfCore.PdfOptions pdfOptions, IReadOnlyList<WorksheetPdfExportPlan> exportPlans, ExcelPdfSaveOptions options, bool preserveConfiguredFontSlots) {
             HashSet<PdfCore.PdfStandardFont> registeredFontSlots = pdfOptions.CreateRegisteredFontFamilySlots(preserveConfiguredFontSlots);
-            if (!options.UseWorksheetCellStyles) {
-                return registeredFontSlots;
-            }
 
             var registeredFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (WorksheetPdfExportPlan plan in exportPlans) {
-                ExcelCellStyleSnapshot?[,]? styles = plan.ExportData.Styles;
-                if (styles == null) {
-                    continue;
-                }
+            RegisterWorksheetHeaderFooterFonts(exportPlans, options, registeredFamilies, registeredFontSlots, pdfOptions);
 
-                int rows = Math.Min(plan.ExportedRows, styles.GetLength(0));
-                int columns = styles.GetLength(1);
-                for (int row = 0; row < rows; row++) {
-                    for (int column = 0; column < columns; column++) {
-                        RegisterWorksheetFontCandidate(styles[row, column]?.FontName, pdfOptions, registeredFamilies, registeredFontSlots, options.AllowSystemFontEmbedding);
+            if (options.UseWorksheetCellStyles) {
+                foreach (WorksheetPdfExportPlan plan in exportPlans) {
+                    ExcelCellStyleSnapshot?[,]? styles = plan.ExportData.Styles;
+                    if (styles == null) {
+                        continue;
+                    }
+
+                    int rows = Math.Min(plan.ExportedRows, styles.GetLength(0));
+                    int columns = styles.GetLength(1);
+                    for (int row = 0; row < rows; row++) {
+                        for (int column = 0; column < columns; column++) {
+                            RegisterWorksheetFontCandidate(styles[row, column]?.FontName, pdfOptions, registeredFamilies, registeredFontSlots, options.AllowSystemFontEmbedding);
+                        }
                     }
                 }
             }
 
             return registeredFontSlots;
+        }
+
+        private static void RegisterWorksheetHeaderFooterFonts(
+            IReadOnlyList<WorksheetPdfExportPlan> exportPlans,
+            ExcelPdfSaveOptions options,
+            HashSet<string> registeredFamilies,
+            HashSet<PdfCore.PdfStandardFont> registeredFontSlots,
+            PdfCore.PdfOptions pdfOptions) {
+            if (!options.UseWorksheetHeadersAndFooters) {
+                return;
+            }
+
+            foreach (WorksheetPdfExportPlan plan in exportPlans) {
+                ExcelSheet.HeaderFooterSnapshot? headerFooter = plan.HeaderFooter;
+                if (headerFooter == null) {
+                    continue;
+                }
+
+                foreach (string? text in EnumerateHeaderFooterTextZones(headerFooter)) {
+                    RegisterWorksheetHeaderFooterFontCandidate(text, pdfOptions, registeredFamilies, registeredFontSlots, options.AllowSystemFontEmbedding);
+                }
+            }
+        }
+
+        private static IEnumerable<string?> EnumerateHeaderFooterTextZones(ExcelSheet.HeaderFooterSnapshot headerFooter) {
+            yield return headerFooter.HeaderLeft;
+            yield return headerFooter.HeaderCenter;
+            yield return headerFooter.HeaderRight;
+            yield return headerFooter.FooterLeft;
+            yield return headerFooter.FooterCenter;
+            yield return headerFooter.FooterRight;
+            yield return headerFooter.FirstHeaderLeft;
+            yield return headerFooter.FirstHeaderCenter;
+            yield return headerFooter.FirstHeaderRight;
+            yield return headerFooter.FirstFooterLeft;
+            yield return headerFooter.FirstFooterCenter;
+            yield return headerFooter.FirstFooterRight;
+            yield return headerFooter.EvenHeaderLeft;
+            yield return headerFooter.EvenHeaderCenter;
+            yield return headerFooter.EvenHeaderRight;
+            yield return headerFooter.EvenFooterLeft;
+            yield return headerFooter.EvenFooterCenter;
+            yield return headerFooter.EvenFooterRight;
+        }
+
+        private static void RegisterWorksheetHeaderFooterFontCandidate(
+            string? text,
+            PdfCore.PdfOptions pdfOptions,
+            HashSet<string> registeredFamilies,
+            HashSet<PdfCore.PdfStandardFont> registeredFontSlots,
+            bool embedSystemFont) {
+            if (string.IsNullOrWhiteSpace(text)) {
+                return;
+            }
+
+            for (int i = 0; i < text!.Length - 1; i++) {
+                if (text[i] != '&' || text[i + 1] != '"') {
+                    continue;
+                }
+
+                if (!TryReadHeaderFooterQuotedToken(text, i + 1, out string token, out int endIndex)) {
+                    continue;
+                }
+
+                string familyName = token.Split(new[] { ',' }, 2)[0];
+                RegisterWorksheetFontCandidate(familyName, pdfOptions, registeredFamilies, registeredFontSlots, embedSystemFont);
+                i = endIndex;
+            }
         }
 
         private static void RegisterWorksheetFontCandidate(string? familyName, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, bool embedSystemFont) {

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.cs
@@ -22,8 +22,8 @@ namespace OfficeIMO.Excel.Pdf {
             IReadOnlyList<string> sheetNames = GetSheetNames(reader, options);
             bool hasExplicitSheetSelection = HasExplicitSheetSelection(options);
             IReadOnlyList<WorksheetPdfExportPlan> exportPlans = BuildWorksheetExportPlans(document, reader, sheetNames, options, hasExplicitSheetSelection, defaultFontFamily);
-            RegisterWorksheetFonts(pdfOptions, exportPlans, options, preserveConfiguredFontSlots);
-            ApplyDefaultEmbeddedFontFallback(pdfOptions, options, preserveConfiguredFontSlots);
+            HashSet<PdfCore.PdfStandardFont> registeredFontSlots = RegisterWorksheetFonts(pdfOptions, exportPlans, options, preserveConfiguredFontSlots);
+            ApplyTextFallbacks(pdfOptions, options, preserveConfiguredFontSlots, registeredFontSlots);
             var pdf = PdfCore.PdfDocument.Create(pdfOptions);
             IReadOnlyDictionary<string, string> sheetDestinations = BuildSheetDestinationMap(exportPlans);
             IReadOnlyDictionary<string, string> cellDestinations = BuildCellDestinationMap(exportPlans);

--- a/OfficeIMO.Excel.Pdf/ExcelPdfSaveOptions.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfSaveOptions.cs
@@ -32,6 +32,16 @@ namespace OfficeIMO.Excel.Pdf {
         public string? FontFamily { get; set; }
 
         /// <summary>
+        /// When true, Excel PDF export may load installed system fonts to embed them into the generated PDF. Defaults to true to preserve existing workbook fidelity.
+        /// </summary>
+        public bool AllowSystemFontEmbedding { get; set; } = true;
+
+        /// <summary>
+        /// Built-in generated-text fallback groups applied by the Excel PDF converter.
+        /// </summary>
+        public PdfCore.PdfTextFallbackFeatures TextFallbacks { get; set; } = PdfCore.PdfTextFallbackFeatures.Default;
+
+        /// <summary>
         /// Optional first-party page size in PDF points.
         /// </summary>
         public PdfCore.PageSize? PageSize { get; set; }
@@ -173,6 +183,62 @@ namespace OfficeIMO.Excel.Pdf {
         /// Text used for empty worksheet cells in the exported PDF table. Defaults to an empty string.
         /// </summary>
         public string EmptyCellText { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Applies a high-level export profile by setting the Excel PDF options that correspond to that profile.
+        /// </summary>
+        public ExcelPdfSaveOptions UseProfile(PdfCore.PdfExportProfile profile) {
+            switch (profile) {
+                case PdfCore.PdfExportProfile.Faithful:
+                    RespectWorkbookSheetVisibility = true;
+                    UseWorksheetPrintAreas = true;
+                    UseWorksheetPageSetup = true;
+                    UseWorksheetPrintTitleRows = true;
+                    UseWorksheetPageBreaks = true;
+                    UseWorksheetHeadersAndFooters = true;
+                    UseWorksheetHeaderFooterImages = true;
+                    UseWorksheetCellStyles = true;
+                    UseWorksheetHyperlinks = true;
+                    UseWorksheetImages = true;
+                    UseWorksheetCharts = true;
+                    UseWorksheetMergedCells = true;
+                    UseWorksheetColumnWidths = true;
+                    UseWorksheetRowHeights = true;
+                    RespectWorksheetHiddenRowsAndColumns = true;
+                    IncludeSheetHeadings = true;
+                    break;
+                case PdfCore.PdfExportProfile.Lightweight:
+                    UseWorksheetHeaderFooterImages = false;
+                    UseWorksheetImages = false;
+                    UseWorksheetCharts = false;
+                    UseWorksheetHyperlinks = false;
+                    UseWorksheetCellStyles = true;
+                    IncludeSheetHeadings = true;
+                    break;
+                case PdfCore.PdfExportProfile.PrintReady:
+                    UseWorksheetPrintAreas = true;
+                    UseWorksheetPageSetup = true;
+                    UseWorksheetPrintTitleRows = true;
+                    UseWorksheetPageBreaks = true;
+                    UseWorksheetHeadersAndFooters = true;
+                    RespectWorksheetHiddenRowsAndColumns = true;
+                    IncludeSheetHeadings = false;
+                    break;
+                case PdfCore.PdfExportProfile.TextOnly:
+                    UseWorksheetHeaderFooterImages = false;
+                    UseWorksheetImages = false;
+                    UseWorksheetCharts = false;
+                    UseWorksheetHyperlinks = false;
+                    UseWorksheetCellStyles = false;
+                    UseWorksheetMergedCells = true;
+                    IncludeSheetHeadings = true;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(profile), profile, "Unsupported PDF export profile.");
+            }
+
+            return this;
+        }
 
         internal void ResetExportState() {
             Warnings.Clear();

--- a/OfficeIMO.Excel.Pdf/README.md
+++ b/OfficeIMO.Excel.Pdf/README.md
@@ -64,13 +64,17 @@ workbook.SaveAsPdf(stream);
 ```csharp
 using OfficeIMO.Excel;
 using OfficeIMO.Excel.Pdf;
+using OfficeIMO.Pdf;
 
 using var workbook = ExcelDocument.Load("dashboard.xlsx");
 var options = new ExcelPdfSaveOptions {
     IncludeSheetHeadings = true,
     RespectWorksheetHiddenRowsAndColumns = true,
     UseWorksheetCharts = true
-};
+}.UseProfile(PdfExportProfile.Faithful);
+
+options.TextFallbacks = PdfTextFallbackFeatures.Default;
+options.AllowSystemFontEmbedding = true;
 
 var result = workbook.TrySaveAsPdf("dashboard.pdf", options);
 if (!result.Succeeded) {
@@ -82,6 +86,8 @@ if (!result.Succeeded) {
 foreach (var warning in options.ConversionReport.Warnings) {
     Console.WriteLine($"{warning.Source}: {warning.Message}");
 }
+
+options.ConversionReport.RequireNoErrorWarnings();
 ```
 
 ## Import PDF tables
@@ -121,6 +127,7 @@ Console.WriteLine($"Imported {results.Count} table(s).");
 - Repeated print-title rows, headers, footers, page/date/time/sheet/workbook tokens, and supported header/footer images.
 - Cell display values, common number formats, fills, font emphasis, alignment, borders, merged cells, links, row heights, column widths, conditional fills/data bars/icons, and table layout primitives.
 - Supported worksheet images and common chart snapshots through shared OfficeIMO drawing primitives.
+- Profile presets through `ExcelPdfSaveOptions.UseProfile(...)`, plus shared `TextFallbacks` and `AllowSystemFontEmbedding` controls for Unicode, symbols, and emoji.
 - Conversion warnings through `ExcelPdfSaveOptions.Warnings` and `ExcelPdfSaveOptions.ConversionReport`.
 
 ## Boundaries

--- a/OfficeIMO.Excel.Tests/Pdf/Excel.SaveAsPdf.CellStyleFormatTests.cs
+++ b/OfficeIMO.Excel.Tests/Pdf/Excel.SaveAsPdf.CellStyleFormatTests.cs
@@ -55,7 +55,7 @@ public partial class Excel {
         Assert.Contains("PlainCell", text);
 
         string rawPdf = Encoding.ASCII.GetString(bytes);
-        AssertRawPdfContainsAnyBaseFont(rawPdf, "Courier", "Consolas");
+        AssertRawPdfContainsAnyBaseFont(rawPdf, "Courier", "Consolas", "LiberationMono", "DejaVuSansMono");
         Assert.Contains("0.067 0.133 0.2 rg", rawPdf, StringComparison.Ordinal);
         Assert.Contains("0.867 0.933 1 rg", rawPdf, StringComparison.Ordinal);
     }

--- a/OfficeIMO.Excel.Tests/Pdf/Excel.SaveAsPdf.HeaderFooterTests.cs
+++ b/OfficeIMO.Excel.Tests/Pdf/Excel.SaveAsPdf.HeaderFooterTests.cs
@@ -159,6 +159,38 @@ public partial class Excel {
     }
 
     [Fact]
+    public void SaveAsPdf_ExcelWorkbook_DoesNotReserve_Escaped_HeaderFooter_Font_Tokens() {
+        string workbookPath = Path.Combine(_directoryWithFiles, "ExcelPdfHeaderFooterEscapedFontToken.xlsx");
+
+        var options = new ExcelPdfSaveOptions {
+            IncludeSheetHeadings = false,
+            HeaderRowCount = 0,
+            PageSize = new PdfCore.PageSize(420, 320),
+            Margins = PdfCore.PageMargins.Uniform(54),
+            AllowSystemFontEmbedding = true
+        };
+
+        byte[] bytes;
+        using (ExcelDocument document = ExcelDocument.Create(workbookPath, "EscapedFontToken")) {
+            ExcelSheet sheet = document.Sheets[0];
+            sheet.Cell(1, 1, "EscapedHeaderFooterBody");
+            sheet.SetHeaderFooter(headerCenter: "&&\"Times New Roman\" Literal Header");
+            document.Save(false);
+
+            bytes = document.SaveAsPdf(options);
+        }
+
+        using PdfPigDocument pdf = PdfPigDocument.Open(new MemoryStream(bytes));
+        string text = pdf.GetPage(1).Text;
+        Assert.Contains("\"Times New Roman\" Literal Header", text);
+        Assert.Contains("EscapedHeaderFooterBody", text);
+
+        string rawPdf = Encoding.ASCII.GetString(bytes);
+        Assert.DoesNotContain("TimesNewRoman", rawPdf, StringComparison.Ordinal);
+        Assert.DoesNotContain("/Times-Roman", rawPdf, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void SaveAsPdf_ExcelWorkbook_Warns_For_Mixed_Worksheet_HeaderFooter_Formatting() {
         string workbookPath = Path.Combine(_directoryWithFiles, "ExcelPdfHeaderFooterMixedFormatting.xlsx");
 

--- a/OfficeIMO.Excel.Tests/Pdf/Excel.SaveAsPdf.HeaderFooterTests.cs
+++ b/OfficeIMO.Excel.Tests/Pdf/Excel.SaveAsPdf.HeaderFooterTests.cs
@@ -117,7 +117,7 @@ public partial class Excel {
         Assert.Contains("1 0 0 rg", rawPdf, StringComparison.Ordinal);
         Assert.Contains("0 0 1 rg", rawPdf, StringComparison.Ordinal);
         Assert.Matches("Helvetica-Bold|Arial-Bold|Aptos-Bold|Calibri-Bold|LiberationSans-Bold|DejaVuSans-Bold", rawPdf);
-        Assert.Contains("Times-Italic", rawPdf, StringComparison.Ordinal);
+        AssertRawPdfContainsAnyBaseFont(rawPdf, "Times-Italic", "TimesNewRoman-Italic", "LiberationSerif-Italic", "DejaVuSerif-Italic");
         Assert.Contains(" 18 Tf", rawPdf, StringComparison.Ordinal);
         Assert.Contains(" 10 Tf", rawPdf, StringComparison.Ordinal);
         Assert.DoesNotContain(options.Warnings, warning => warning.Feature == "WorksheetHeaderFooterFormatting");
@@ -154,7 +154,7 @@ public partial class Excel {
 
         string rawPdf = Encoding.ASCII.GetString(bytes);
         Assert.Matches("Helvetica-Bold|Arial-Bold|Aptos-Bold|Calibri-Bold|LiberationSans-Bold|DejaVuSans-Bold", rawPdf);
-        Assert.Contains("Courier-Oblique", rawPdf, StringComparison.Ordinal);
+        AssertRawPdfContainsAnyBaseFont(rawPdf, "Courier-Oblique", "Consolas-Italic", "LiberationMono-Italic", "DejaVuSansMono-Italic");
         Assert.DoesNotContain(options.Warnings, warning => warning.Feature == "WorksheetHeaderFooterFormatting");
     }
 

--- a/OfficeIMO.Markdown.Pdf/MarkdownPdfConverterExtensions.TextFallbacks.cs
+++ b/OfficeIMO.Markdown.Pdf/MarkdownPdfConverterExtensions.TextFallbacks.cs
@@ -1,0 +1,160 @@
+using PdfCore = OfficeIMO.Pdf;
+
+namespace OfficeIMO.Markdown.Pdf;
+
+/// <summary>
+/// First-party Markdown to PDF conversion helpers.
+/// </summary>
+public static partial class MarkdownPdfConverterExtensions {
+    private static void ApplyMarkdownTextFallbackOptions(PdfCore.PdfOptions pdfOptions, MarkdownPdfSaveOptions options, MarkdownDoc document) {
+        bool hasCallerPdfOptions = options.PdfOptions != null;
+        bool hasExplicitFontFamily = !string.IsNullOrWhiteSpace(options.FontFamily);
+        if (hasExplicitFontFamily) {
+            pdfOptions.TryUseOfficeFontFamily(options.FontFamily, options.AllowSystemFontEmbedding);
+        }
+
+        if (options.TextFallbacks == PdfCore.PdfTextFallbackFeatures.None) {
+            return;
+        }
+
+        PdfCore.PdfTextFallbackFeatures fallbackFeatures = options.TextFallbacks;
+        bool preserveDocumentFontSlots = hasCallerPdfOptions || hasExplicitFontFamily;
+        bool usesCodeFont = MarkdownDocumentUsesCodeFont(document);
+        if (!usesCodeFont) {
+            fallbackFeatures &= ~PdfCore.PdfTextFallbackFeatures.MonospaceFont;
+        }
+
+        if (preserveDocumentFontSlots) {
+            fallbackFeatures &= ~PdfCore.PdfTextFallbackFeatures.DocumentFont;
+        }
+
+        PdfCore.PdfTextFallbackFeatures documentAndMonospaceFallbacks =
+            fallbackFeatures & (PdfCore.PdfTextFallbackFeatures.DocumentFont | PdfCore.PdfTextFallbackFeatures.MonospaceFont);
+        if (documentAndMonospaceFallbacks != PdfCore.PdfTextFallbackFeatures.None) {
+            pdfOptions.UseTextFallbacks(
+                documentAndMonospaceFallbacks,
+                CreateMarkdownReservedFontSlots(pdfOptions, preserveDocumentFontSlots, reserveCourier: false),
+                options.AllowSystemFontEmbedding);
+        }
+
+        if ((fallbackFeatures & PdfCore.PdfTextFallbackFeatures.SymbolAndEmojiFonts) != 0) {
+            pdfOptions.UseTextFallbacks(
+                PdfCore.PdfTextFallbackFeatures.SymbolAndEmojiFonts,
+                CreateMarkdownReservedFontSlots(pdfOptions, preserveDocumentFontSlots, reserveCourier: usesCodeFont),
+                options.AllowSystemFontEmbedding);
+        }
+    }
+
+    private static bool MarkdownDocumentUsesCodeFont(MarkdownDoc document) {
+        foreach (IMarkdownBlock block in document.DescendantsAndSelf()) {
+            if (MarkdownBlockUsesCodeFont(block)) {
+                return true;
+            }
+        }
+
+        foreach (ListItem item in document.DescendantListItems()) {
+            if (InlineSequenceUsesCodeFont(item.Content)) {
+                return true;
+            }
+
+            for (int paragraphIndex = 0; paragraphIndex < item.AdditionalParagraphs.Count; paragraphIndex++) {
+                if (InlineSequenceUsesCodeFont(item.AdditionalParagraphs[paragraphIndex])) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool MarkdownBlockUsesCodeFont(IMarkdownBlock block) {
+        switch (block) {
+            case CodeBlock:
+            case SemanticFencedBlock:
+                return true;
+            case ParagraphBlock paragraph:
+                return InlineSequenceUsesCodeFont(paragraph.Inlines);
+            case HeadingBlock heading:
+                return InlineSequenceUsesCodeFont(heading.Inlines);
+            case CalloutBlock callout:
+                return InlineSequenceUsesCodeFont(callout.TitleInlines);
+            case DetailsBlock details:
+                return details.Summary != null && InlineSequenceUsesCodeFont(details.Summary.Inlines);
+            case DefinitionListBlock definitionList:
+                return DefinitionListUsesCodeFont(definitionList);
+            case TableBlock table:
+                return TableUsesCodeFont(table);
+            default:
+                return false;
+        }
+    }
+
+    private static bool DefinitionListUsesCodeFont(DefinitionListBlock definitionList) {
+        IReadOnlyList<DefinitionListInlineItem> items = definitionList.InlineItems;
+        for (int i = 0; i < items.Count; i++) {
+            if (InlineSequenceUsesCodeFont(items[i].Term) ||
+                InlineSequenceUsesCodeFont(items[i].Definition)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TableUsesCodeFont(TableBlock table) {
+        IReadOnlyList<InlineSequence> headers = table.HeaderInlines;
+        for (int i = 0; i < headers.Count; i++) {
+            if (InlineSequenceUsesCodeFont(headers[i])) {
+                return true;
+            }
+        }
+
+        IReadOnlyList<IReadOnlyList<InlineSequence>> rows = table.RowInlines;
+        for (int rowIndex = 0; rowIndex < rows.Count; rowIndex++) {
+            IReadOnlyList<InlineSequence> row = rows[rowIndex];
+            for (int columnIndex = 0; columnIndex < row.Count; columnIndex++) {
+                if (InlineSequenceUsesCodeFont(row[columnIndex])) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool InlineSequenceUsesCodeFont(InlineSequence sequence) {
+        for (int i = 0; i < sequence.Nodes.Count; i++) {
+            if (InlineUsesCodeFont(sequence.Nodes[i])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool InlineUsesCodeFont(IMarkdownInline inline) {
+        switch (inline) {
+            case CodeSpanInline:
+                return true;
+            case IInlineContainerMarkdownInline container when container.NestedInlines != null:
+                return InlineSequenceUsesCodeFont(container.NestedInlines);
+            default:
+                return false;
+        }
+    }
+
+    private static IReadOnlyList<PdfCore.PdfStandardFont> CreateMarkdownReservedFontSlots(PdfCore.PdfOptions pdfOptions, bool includeDocumentFontSlots, bool reserveCourier) {
+        var slots = new List<PdfCore.PdfStandardFont>();
+        if (reserveCourier) {
+            slots.Add(PdfCore.PdfStandardFont.Courier);
+        }
+
+        if (includeDocumentFontSlots) {
+            slots.Add(pdfOptions.DefaultFont);
+            slots.Add(pdfOptions.HeaderFont);
+            slots.Add(pdfOptions.FooterFont);
+        }
+
+        return slots;
+    }
+}

--- a/OfficeIMO.Markdown.Pdf/MarkdownPdfConverterExtensions.cs
+++ b/OfficeIMO.Markdown.Pdf/MarkdownPdfConverterExtensions.cs
@@ -75,19 +75,7 @@ public static partial class MarkdownPdfConverterExtensions {
         PdfCore.PdfOptions pdfOptions = options.PdfOptions?.Clone() ?? new PdfCore.PdfOptions();
         pdfOptions.ReportDiagnosticsTo(options.ConversionReport, "OfficeIMO.Markdown.Pdf");
 
-        bool hasExplicitFontFamily = !string.IsNullOrWhiteSpace(options.FontFamily);
-        if (hasExplicitFontFamily) {
-            pdfOptions.TryUseOfficeFontFamily(options.FontFamily);
-        }
-
-        if (options.TextFallbacks != PdfCore.PdfTextFallbackFeatures.None) {
-            PdfCore.PdfTextFallbackFeatures fallbackFeatures = options.TextFallbacks;
-            if (hasExplicitFontFamily) {
-                fallbackFeatures &= ~PdfCore.PdfTextFallbackFeatures.DocumentFont;
-            }
-
-            pdfOptions.UseTextFallbacks(fallbackFeatures, Array.Empty<PdfCore.PdfStandardFont>(), options.AllowSystemFontEmbedding);
-        }
+        ApplyMarkdownTextFallbackOptions(pdfOptions, options);
 
         if (options.CreateOutlineFromHeadings) {
             pdfOptions.CreateOutlineFromHeadings = true;
@@ -130,6 +118,43 @@ public static partial class MarkdownPdfConverterExtensions {
         if (PdfCore.PdfStandardFontMapper.TryMapFontFamily(options.FontFamily, out PdfCore.PdfStandardFont font)) {
             pdf.DefaultTextStyle(style => style.Font(PdfCore.PdfStandardFontMapper.GetFontFamily(font)));
         }
+    }
+
+    private static void ApplyMarkdownTextFallbackOptions(PdfCore.PdfOptions pdfOptions, MarkdownPdfSaveOptions options) {
+        bool hasCallerPdfOptions = options.PdfOptions != null;
+        bool hasExplicitFontFamily = !string.IsNullOrWhiteSpace(options.FontFamily);
+        if (hasExplicitFontFamily) {
+            pdfOptions.TryUseOfficeFontFamily(options.FontFamily, options.AllowSystemFontEmbedding);
+        }
+
+        if (options.TextFallbacks == PdfCore.PdfTextFallbackFeatures.None) {
+            return;
+        }
+
+        PdfCore.PdfTextFallbackFeatures fallbackFeatures = options.TextFallbacks;
+        bool preserveDocumentFontSlots = hasCallerPdfOptions || hasExplicitFontFamily;
+        if (preserveDocumentFontSlots) {
+            fallbackFeatures &= ~PdfCore.PdfTextFallbackFeatures.DocumentFont;
+        }
+
+        pdfOptions.UseTextFallbacks(
+            fallbackFeatures,
+            CreateMarkdownReservedFontSlots(pdfOptions, preserveDocumentFontSlots),
+            options.AllowSystemFontEmbedding);
+    }
+
+    private static IReadOnlyList<PdfCore.PdfStandardFont> CreateMarkdownReservedFontSlots(PdfCore.PdfOptions pdfOptions, bool includeDocumentFontSlots) {
+        var slots = new List<PdfCore.PdfStandardFont> {
+            PdfCore.PdfStandardFont.Courier
+        };
+
+        if (includeDocumentFontSlots) {
+            slots.Add(pdfOptions.DefaultFont);
+            slots.Add(pdfOptions.HeaderFont);
+            slots.Add(pdfOptions.FooterFont);
+        }
+
+        return slots;
     }
 
     private static MarkdownReaderOptions ResolveReaderOptions(MarkdownPdfSaveOptions options) {

--- a/OfficeIMO.Markdown.Pdf/MarkdownPdfConverterExtensions.cs
+++ b/OfficeIMO.Markdown.Pdf/MarkdownPdfConverterExtensions.cs
@@ -137,16 +137,28 @@ public static partial class MarkdownPdfConverterExtensions {
             fallbackFeatures &= ~PdfCore.PdfTextFallbackFeatures.DocumentFont;
         }
 
-        pdfOptions.UseTextFallbacks(
-            fallbackFeatures,
-            CreateMarkdownReservedFontSlots(pdfOptions, preserveDocumentFontSlots),
-            options.AllowSystemFontEmbedding);
+        PdfCore.PdfTextFallbackFeatures documentAndMonospaceFallbacks =
+            fallbackFeatures & (PdfCore.PdfTextFallbackFeatures.DocumentFont | PdfCore.PdfTextFallbackFeatures.MonospaceFont);
+        if (documentAndMonospaceFallbacks != PdfCore.PdfTextFallbackFeatures.None) {
+            pdfOptions.UseTextFallbacks(
+                documentAndMonospaceFallbacks,
+                CreateMarkdownReservedFontSlots(pdfOptions, preserveDocumentFontSlots, reserveCourier: false),
+                options.AllowSystemFontEmbedding);
+        }
+
+        if ((fallbackFeatures & PdfCore.PdfTextFallbackFeatures.SymbolAndEmojiFonts) != 0) {
+            pdfOptions.UseTextFallbacks(
+                PdfCore.PdfTextFallbackFeatures.SymbolAndEmojiFonts,
+                CreateMarkdownReservedFontSlots(pdfOptions, preserveDocumentFontSlots, reserveCourier: true),
+                options.AllowSystemFontEmbedding);
+        }
     }
 
-    private static IReadOnlyList<PdfCore.PdfStandardFont> CreateMarkdownReservedFontSlots(PdfCore.PdfOptions pdfOptions, bool includeDocumentFontSlots) {
-        var slots = new List<PdfCore.PdfStandardFont> {
-            PdfCore.PdfStandardFont.Courier
-        };
+    private static IReadOnlyList<PdfCore.PdfStandardFont> CreateMarkdownReservedFontSlots(PdfCore.PdfOptions pdfOptions, bool includeDocumentFontSlots, bool reserveCourier) {
+        var slots = new List<PdfCore.PdfStandardFont>();
+        if (reserveCourier) {
+            slots.Add(PdfCore.PdfStandardFont.Courier);
+        }
 
         if (includeDocumentFontSlots) {
             slots.Add(pdfOptions.DefaultFont);

--- a/OfficeIMO.Markdown.Pdf/MarkdownPdfConverterExtensions.cs
+++ b/OfficeIMO.Markdown.Pdf/MarkdownPdfConverterExtensions.cs
@@ -75,7 +75,7 @@ public static partial class MarkdownPdfConverterExtensions {
         PdfCore.PdfOptions pdfOptions = options.PdfOptions?.Clone() ?? new PdfCore.PdfOptions();
         pdfOptions.ReportDiagnosticsTo(options.ConversionReport, "OfficeIMO.Markdown.Pdf");
 
-        ApplyMarkdownTextFallbackOptions(pdfOptions, options);
+        ApplyMarkdownTextFallbackOptions(pdfOptions, options, document);
 
         if (options.CreateOutlineFromHeadings) {
             pdfOptions.CreateOutlineFromHeadings = true;
@@ -118,55 +118,6 @@ public static partial class MarkdownPdfConverterExtensions {
         if (PdfCore.PdfStandardFontMapper.TryMapFontFamily(options.FontFamily, out PdfCore.PdfStandardFont font)) {
             pdf.DefaultTextStyle(style => style.Font(PdfCore.PdfStandardFontMapper.GetFontFamily(font)));
         }
-    }
-
-    private static void ApplyMarkdownTextFallbackOptions(PdfCore.PdfOptions pdfOptions, MarkdownPdfSaveOptions options) {
-        bool hasCallerPdfOptions = options.PdfOptions != null;
-        bool hasExplicitFontFamily = !string.IsNullOrWhiteSpace(options.FontFamily);
-        if (hasExplicitFontFamily) {
-            pdfOptions.TryUseOfficeFontFamily(options.FontFamily, options.AllowSystemFontEmbedding);
-        }
-
-        if (options.TextFallbacks == PdfCore.PdfTextFallbackFeatures.None) {
-            return;
-        }
-
-        PdfCore.PdfTextFallbackFeatures fallbackFeatures = options.TextFallbacks;
-        bool preserveDocumentFontSlots = hasCallerPdfOptions || hasExplicitFontFamily;
-        if (preserveDocumentFontSlots) {
-            fallbackFeatures &= ~PdfCore.PdfTextFallbackFeatures.DocumentFont;
-        }
-
-        PdfCore.PdfTextFallbackFeatures documentAndMonospaceFallbacks =
-            fallbackFeatures & (PdfCore.PdfTextFallbackFeatures.DocumentFont | PdfCore.PdfTextFallbackFeatures.MonospaceFont);
-        if (documentAndMonospaceFallbacks != PdfCore.PdfTextFallbackFeatures.None) {
-            pdfOptions.UseTextFallbacks(
-                documentAndMonospaceFallbacks,
-                CreateMarkdownReservedFontSlots(pdfOptions, preserveDocumentFontSlots, reserveCourier: false),
-                options.AllowSystemFontEmbedding);
-        }
-
-        if ((fallbackFeatures & PdfCore.PdfTextFallbackFeatures.SymbolAndEmojiFonts) != 0) {
-            pdfOptions.UseTextFallbacks(
-                PdfCore.PdfTextFallbackFeatures.SymbolAndEmojiFonts,
-                CreateMarkdownReservedFontSlots(pdfOptions, preserveDocumentFontSlots, reserveCourier: true),
-                options.AllowSystemFontEmbedding);
-        }
-    }
-
-    private static IReadOnlyList<PdfCore.PdfStandardFont> CreateMarkdownReservedFontSlots(PdfCore.PdfOptions pdfOptions, bool includeDocumentFontSlots, bool reserveCourier) {
-        var slots = new List<PdfCore.PdfStandardFont>();
-        if (reserveCourier) {
-            slots.Add(PdfCore.PdfStandardFont.Courier);
-        }
-
-        if (includeDocumentFontSlots) {
-            slots.Add(pdfOptions.DefaultFont);
-            slots.Add(pdfOptions.HeaderFont);
-            slots.Add(pdfOptions.FooterFont);
-        }
-
-        return slots;
     }
 
     private static MarkdownReaderOptions ResolveReaderOptions(MarkdownPdfSaveOptions options) {

--- a/OfficeIMO.Markdown.Pdf/MarkdownPdfConverterExtensions.cs
+++ b/OfficeIMO.Markdown.Pdf/MarkdownPdfConverterExtensions.cs
@@ -75,14 +75,18 @@ public static partial class MarkdownPdfConverterExtensions {
         PdfCore.PdfOptions pdfOptions = options.PdfOptions?.Clone() ?? new PdfCore.PdfOptions();
         pdfOptions.ReportDiagnosticsTo(options.ConversionReport, "OfficeIMO.Markdown.Pdf");
 
-        if (!string.IsNullOrWhiteSpace(options.FontFamily)) {
+        bool hasExplicitFontFamily = !string.IsNullOrWhiteSpace(options.FontFamily);
+        if (hasExplicitFontFamily) {
             pdfOptions.TryUseOfficeFontFamily(options.FontFamily);
-        } else if (options.PdfOptions == null) {
-            pdfOptions.TryUseDefaultDocumentFontFallback(requireEmbeddedFont: false);
         }
 
-        if (options.PdfOptions == null) {
-            pdfOptions.TryRegisterDefaultDocumentMonospaceFontFallback();
+        if (options.PdfOptions == null && options.UseDefaultTextFallbacks) {
+            PdfCore.PdfTextFallbackFeatures fallbackFeatures = PdfCore.PdfTextFallbackFeatures.Default;
+            if (hasExplicitFontFamily) {
+                fallbackFeatures &= ~PdfCore.PdfTextFallbackFeatures.DocumentFont;
+            }
+
+            pdfOptions.UseTextFallbacks(fallbackFeatures);
         }
 
         if (options.CreateOutlineFromHeadings) {

--- a/OfficeIMO.Markdown.Pdf/MarkdownPdfConverterExtensions.cs
+++ b/OfficeIMO.Markdown.Pdf/MarkdownPdfConverterExtensions.cs
@@ -80,13 +80,13 @@ public static partial class MarkdownPdfConverterExtensions {
             pdfOptions.TryUseOfficeFontFamily(options.FontFamily);
         }
 
-        if (options.PdfOptions == null && options.UseDefaultTextFallbacks) {
-            PdfCore.PdfTextFallbackFeatures fallbackFeatures = PdfCore.PdfTextFallbackFeatures.Default;
+        if (options.TextFallbacks != PdfCore.PdfTextFallbackFeatures.None) {
+            PdfCore.PdfTextFallbackFeatures fallbackFeatures = options.TextFallbacks;
             if (hasExplicitFontFamily) {
                 fallbackFeatures &= ~PdfCore.PdfTextFallbackFeatures.DocumentFont;
             }
 
-            pdfOptions.UseTextFallbacks(fallbackFeatures);
+            pdfOptions.UseTextFallbacks(fallbackFeatures, Array.Empty<PdfCore.PdfStandardFont>(), options.AllowSystemFontEmbedding);
         }
 
         if (options.CreateOutlineFromHeadings) {

--- a/OfficeIMO.Markdown.Pdf/MarkdownPdfSaveOptions.cs
+++ b/OfficeIMO.Markdown.Pdf/MarkdownPdfSaveOptions.cs
@@ -18,10 +18,24 @@ public sealed class MarkdownPdfSaveOptions {
     public string? FontFamily { get; set; }
 
     /// <summary>
-    /// When true and the converter creates the PDF options, applies OfficeIMO's default document, monospace, symbol, and emoji text fallbacks.
-    /// Set to false only when exact standard-font output is required.
+    /// Built-in generated-text fallback groups applied by the Markdown PDF converter. Set to <see cref="PdfCore.PdfTextFallbackFeatures.None"/> for exact standard-font output.
     /// </summary>
-    public bool UseDefaultTextFallbacks { get; set; } = true;
+    public PdfCore.PdfTextFallbackFeatures TextFallbacks { get; set; } = PdfCore.PdfTextFallbackFeatures.Default;
+
+    /// <summary>
+    /// When true, Markdown PDF export may load installed system fonts to cover Unicode, symbol, and emoji fallback runs.
+    /// Defaults to true so Markdown text can render common Unicode content without caller preprocessing.
+    /// </summary>
+    public bool AllowSystemFontEmbedding { get; set; } = true;
+
+    /// <summary>
+    /// Compatibility shortcut for enabling or disabling the default text fallback preset. Prefer <see cref="TextFallbacks"/> for new code.
+    /// </summary>
+    [Obsolete("Use TextFallbacks instead.")]
+    public bool UseDefaultTextFallbacks {
+        get => TextFallbacks != PdfCore.PdfTextFallbackFeatures.None;
+        set => TextFallbacks = value ? PdfCore.PdfTextFallbackFeatures.Default : PdfCore.PdfTextFallbackFeatures.None;
+    }
 
     /// <summary>Markdown reader options used by string and file overloads.</summary>
     public MarkdownReaderOptions? ReaderOptions { get; set; }
@@ -142,6 +156,45 @@ public sealed class MarkdownPdfSaveOptions {
 
             _defaultImageHeight = value;
         }
+    }
+
+    /// <summary>
+    /// Applies a high-level export profile by setting the Markdown PDF options that correspond to that profile.
+    /// </summary>
+    public MarkdownPdfSaveOptions UseProfile(PdfCore.PdfExportProfile profile) {
+        switch (profile) {
+            case PdfCore.PdfExportProfile.Faithful:
+                IncludeDataUriImages = true;
+                IncludeLocalImages = true;
+                ApplyWordLikeTheme = true;
+                CreateOutlineFromHeadings = true;
+                FrontMatterRenderMode = MarkdownPdfFrontMatterRenderMode.DocumentHeader;
+                break;
+            case PdfCore.PdfExportProfile.Lightweight:
+                IncludeDataUriImages = false;
+                IncludeLocalImages = false;
+                RemoteImageResolver = null;
+                ApplyWordLikeTheme = true;
+                CreateOutlineFromHeadings = true;
+                break;
+            case PdfCore.PdfExportProfile.PrintReady:
+                IncludeDataUriImages = true;
+                ApplyWordLikeTheme = true;
+                CreateOutlineFromHeadings = true;
+                FrontMatterRenderMode = MarkdownPdfFrontMatterRenderMode.DocumentHeader;
+                break;
+            case PdfCore.PdfExportProfile.TextOnly:
+                IncludeDataUriImages = false;
+                IncludeLocalImages = false;
+                RemoteImageResolver = null;
+                ApplyWordLikeTheme = false;
+                FrontMatterRenderMode = MarkdownPdfFrontMatterRenderMode.Hidden;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(profile), profile, "Unsupported PDF export profile.");
+        }
+
+        return this;
     }
 
     /// <summary>Warnings recorded during the latest export.</summary>

--- a/OfficeIMO.Markdown.Pdf/MarkdownPdfSaveOptions.cs
+++ b/OfficeIMO.Markdown.Pdf/MarkdownPdfSaveOptions.cs
@@ -17,6 +17,12 @@ public sealed class MarkdownPdfSaveOptions {
     /// <summary>Optional Markdown default font family used by the first-party PDF engine.</summary>
     public string? FontFamily { get; set; }
 
+    /// <summary>
+    /// When true and the converter creates the PDF options, applies OfficeIMO's default document, monospace, symbol, and emoji text fallbacks.
+    /// Set to false only when exact standard-font output is required.
+    /// </summary>
+    public bool UseDefaultTextFallbacks { get; set; } = true;
+
     /// <summary>Markdown reader options used by string and file overloads.</summary>
     public MarkdownReaderOptions? ReaderOptions { get; set; }
 

--- a/OfficeIMO.Markdown.Pdf/README.md
+++ b/OfficeIMO.Markdown.Pdf/README.md
@@ -86,6 +86,7 @@ markdown.SaveAsPdf("incident-review.pdf", new MarkdownPdfSaveOptions {
 
 ```csharp
 using OfficeIMO.Markdown.Pdf;
+using OfficeIMO.Pdf;
 
 var options = new MarkdownPdfSaveOptions {
     BaseDirectory = Path.GetDirectoryName(Path.GetFullPath("Docs/status.md")),
@@ -145,7 +146,10 @@ using OfficeIMO.Markdown.Pdf;
 var options = new MarkdownPdfSaveOptions {
     RemoteImageResolver = null,
     IncludeDataUriImages = true
-};
+}.UseProfile(PdfExportProfile.Faithful);
+
+options.TextFallbacks = PdfTextFallbackFeatures.Default;
+options.AllowSystemFontEmbedding = true;
 
 var result = MarkdownPdfConverter.TrySaveFileAsPdf("README.md", "README.pdf", options);
 if (!result.Succeeded) {
@@ -157,6 +161,8 @@ if (!result.Succeeded) {
 foreach (var warning in options.ConversionReport.Warnings) {
     Console.WriteLine($"{warning.Source}: {warning.Message}");
 }
+
+options.ConversionReport.RequireNoErrorWarnings();
 ```
 
 ## What it maps
@@ -165,6 +171,7 @@ foreach (var warning in options.ConversionReport.Warnings) {
 - PDF metadata from options, YAML front matter, or the first heading.
 - Paragraphs, rich inline formatting, links, lists, task lists, tables, code blocks, semantic fenced blocks, callouts, details, definition lists, block quotes, footnotes, and generated table-of-contents blocks.
 - Visual themes for readable document rhythm, page treatment, links, code blocks, panels, tables, and checklist rows.
+- Profile presets through `MarkdownPdfSaveOptions.UseProfile(...)`, plus shared `TextFallbacks` and `AllowSystemFontEmbedding` controls for Unicode, symbols, and emoji.
 - Conversion warnings through `MarkdownPdfSaveOptions.Warnings` and `MarkdownPdfSaveOptions.ConversionReport`.
 
 ## Visual themes

--- a/OfficeIMO.Pdf.Tests/Markdown.Pdf.cs
+++ b/OfficeIMO.Pdf.Tests/Markdown.Pdf.cs
@@ -66,6 +66,55 @@ Console.WriteLine("OfficeIMO");
     }
 
     [Fact]
+    public void Markdown_SaveAsPdf_LongBlockquotePanelSplitsAcrossPages() {
+        string markdown = string.Join("\n", Enumerable.Range(1, 24).Select(index => "> QuoteLine" + index.ToString()));
+        var options = new MarkdownPdfSaveOptions {
+            PdfOptions = new PdfCore.PdfOptions {
+                PageWidth = 180,
+                PageHeight = 130,
+                MarginLeft = 20,
+                MarginRight = 20,
+                MarginTop = 20,
+                MarginBottom = 20,
+                DefaultFont = PdfCore.PdfStandardFont.Helvetica,
+                DefaultFontSize = 10
+            }
+        };
+
+        byte[] pdfBytes = markdown.SaveAsPdf(options);
+
+        using var pdf = PdfPigDocument.Open(new MemoryStream(pdfBytes));
+        string text = PdfCore.PdfReadDocument.Load(pdfBytes).ExtractText();
+
+        Assert.True(pdf.NumberOfPages > 1);
+        Assert.Contains("QuoteLine1", text, StringComparison.Ordinal);
+        Assert.Contains("QuoteLine24", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Markdown_SaveAsPdf_DefaultTextFallbacksCoverCommonSymbolsWhenAvailable() {
+        const string symbol = "\u26A0";
+        PdfCore.PdfEmbeddedFontFallbackSet? fallbackSet = new PdfCore.PdfOptions()
+            .UseTextFallbacks()
+            .EmbeddedFontFallbacks;
+        if (fallbackSet == null ||
+            !fallbackSet.PlanText(symbol).IsFullyCovered) {
+            return;
+        }
+
+        var options = new MarkdownPdfSaveOptions();
+        string markdown = "> Status " + symbol + " marker";
+
+        byte[] pdf = markdown.SaveAsPdf(options);
+        string text = PdfCore.PdfReadDocument.Load(pdf).ExtractText();
+
+        Assert.Contains("Status", text, StringComparison.Ordinal);
+        Assert.Contains("marker", text, StringComparison.Ordinal);
+        Assert.DoesNotContain(options.ConversionReport.Warnings, warning => warning.Code == "unsupported-text-glyph");
+        Assert.DoesNotContain(options.ConversionReport.Warnings, warning => warning.Code == "missing-embedded-font-fallback-glyph");
+    }
+
+    [Fact]
     public void MarkdownDoc_SaveAsPdf_Renders_SoftBreak_As_Space() {
         var markdown = MarkdownDoc.Create();
         markdown.Add(new ParagraphBlock(new InlineSequence()

--- a/OfficeIMO.Pdf.Tests/Pdf/Markdown.SaveAsPdf.Options.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/Markdown.SaveAsPdf.Options.cs
@@ -47,6 +47,50 @@ public class MarkdownSaveAsPdfOptionsTests {
     }
 
     [Fact]
+    public void ToPdfDocument_Markdown_FontFamilyHonorsSystemFontEmbeddingOptOut() {
+        var options = new MarkdownPdfSaveOptions {
+            FontFamily = "Georgia",
+            AllowSystemFontEmbedding = false
+        };
+
+        PdfCore.PdfDocument document = "# Heading\n\nBody".ToPdfDocument(options);
+
+        Assert.Equal(PdfCore.PdfStandardFont.TimesRoman, document.Options.DefaultFont);
+        Assert.False(document.Options.HasEmbeddedStandardFontFamily(PdfCore.PdfStandardFont.TimesRoman));
+    }
+
+    [Fact]
+    public void ToPdfDocument_Markdown_TextFallbacksPreserveCallerPdfOptionsFontSlots() {
+        var options = new MarkdownPdfSaveOptions {
+            VisualTheme = MarkdownPdfVisualTheme.Plain(),
+            PdfOptions = new PdfCore.PdfOptions {
+                DefaultFont = PdfCore.PdfStandardFont.TimesRoman,
+                HeaderFont = PdfCore.PdfStandardFont.Courier,
+                FooterFont = PdfCore.PdfStandardFont.Helvetica
+            }
+        };
+
+        PdfCore.PdfDocument document = "# Heading\n\nBody".ToPdfDocument(options);
+
+        Assert.Equal(PdfCore.PdfStandardFont.TimesRoman, document.Options.DefaultFont);
+        Assert.Equal(PdfCore.PdfStandardFont.Courier, document.Options.HeaderFont);
+        Assert.Equal(PdfCore.PdfStandardFont.Helvetica, document.Options.FooterFont);
+    }
+
+    [Fact]
+    public void ToPdfDocument_Markdown_TextFallbacksReserveCourierForCodeText() {
+        PdfCore.PdfDocument document = "`code` text".ToPdfDocument(new MarkdownPdfSaveOptions());
+        PdfCore.PdfEmbeddedFontFallbackSet? fallbackSet = document.Options.EmbeddedFontFallbacks;
+        if (fallbackSet == null) {
+            return;
+        }
+
+        Assert.DoesNotContain(
+            PdfCore.PdfStandardFont.Courier,
+            fallbackSet.FontSlots.Select(PdfCore.PdfStandardFontMapper.GetFontFamily));
+    }
+
+    [Fact]
     public void ToPdfDocument_Markdown_DefaultsUseSharedUnicodeFallbackWhenAvailable() {
         var probe = new PdfCore.PdfOptions();
         if (!probe.TryUseDefaultDocumentFontFallback(requireEmbeddedFont: true)) {

--- a/OfficeIMO.Pdf.Tests/Pdf/Markdown.SaveAsPdf.Options.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/Markdown.SaveAsPdf.Options.cs
@@ -91,6 +91,18 @@ public class MarkdownSaveAsPdfOptionsTests {
     }
 
     [Fact]
+    public void ToPdfDocument_Markdown_TextFallbacksEmbedMonospaceBeforeReservingCourierForSymbols() {
+        var probe = new PdfCore.PdfOptions();
+        if (!probe.TryRegisterDefaultDocumentMonospaceFontFallback(requireEmbeddedFont: true)) {
+            return;
+        }
+
+        PdfCore.PdfDocument document = "`Zażółć` text".ToPdfDocument(new MarkdownPdfSaveOptions());
+
+        Assert.True(document.Options.HasEmbeddedStandardFontFamily(PdfCore.PdfStandardFont.Courier));
+    }
+
+    [Fact]
     public void ToPdfDocument_Markdown_DefaultsUseSharedUnicodeFallbackWhenAvailable() {
         var probe = new PdfCore.PdfOptions();
         if (!probe.TryUseDefaultDocumentFontFallback(requireEmbeddedFont: true)) {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfAIdentificationMetadataTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfAIdentificationMetadataTests.cs
@@ -104,6 +104,29 @@ public class PdfAIdentificationMetadataTests {
     }
 
     [Fact]
+    public void PdfAFluentHelper_MapsToArchivalGroundworkDefaults() {
+        var defaultOptions = new PdfOptions().UsePdfA();
+        PdfOptions defaultClone = defaultOptions.Clone();
+
+        Assert.Equal(PdfComplianceProfile.None, defaultClone.ComplianceProfile);
+        Assert.Equal(PdfFileVersion.Pdf17, defaultClone.FileVersion);
+        Assert.Equal(3, defaultClone.PdfAIdentification!.Part);
+        Assert.Equal("B", defaultClone.PdfAIdentification.Conformance);
+        Assert.Equal(PdfOutputIntentPolicy.SrgbIec6196621, defaultClone.OutputIntent!.Policy);
+
+        var options = new PdfOptions().UsePdfA(PdfComplianceProfile.PdfA3A, "pl-PL");
+        PdfOptions clone = options.Clone();
+
+        Assert.Same(options, options.UsePdfA(PdfComplianceProfile.PdfA3A, "pl-PL"));
+        Assert.True(clone.IncludeXmpMetadata);
+        Assert.True(clone.IncludeStandardFontToUnicodeMaps);
+        Assert.Equal(3, clone.PdfAIdentification!.Part);
+        Assert.Equal("A", clone.PdfAIdentification.Conformance);
+        Assert.Equal(PdfTaggedStructureMode.CatalogMarkers, clone.TaggedStructureMode);
+        Assert.Equal("pl-PL", clone.Language);
+    }
+
+    [Fact]
     public void PdfA4GroundworkHelper_EmitsPdf20ArchivalPrerequisitesWithoutFormalProfile() {
         var options = new PdfOptions()
             .ConfigurePdfAGroundwork(PdfComplianceProfile.PdfA4F, "en-US");
@@ -299,6 +322,24 @@ public class PdfAIdentificationMetadataTests {
     }
 
     [Fact]
+    public void FacturXFluentHelper_AcceptsTextFallbackEnum() {
+        byte[] invoiceXml = CreateCiiXml();
+        var options = new PdfOptions()
+            .UseFacturX(invoiceXml, textFallbacks: PdfTextFallbackFeatures.None);
+
+        PdfOptions clone = options.Clone();
+
+        Assert.Equal(PdfComplianceProfile.None, clone.ComplianceProfile);
+        Assert.Equal(PdfFileVersion.Pdf17, clone.FileVersion);
+        Assert.True(clone.IncludeStandardFontToUnicodeMaps);
+        Assert.Equal(3, clone.PdfAIdentification!.Part);
+        Assert.Equal("B", clone.PdfAIdentification.Conformance);
+        Assert.Equal("EN 16931", clone.ElectronicInvoiceMetadata!.ConformanceLevel);
+        Assert.Equal("factur-x.xml", Assert.Single(clone.EmbeddedFiles).FileName);
+        Assert.False(clone.HasEmbeddedStandardFontFamily(PdfStandardFont.Helvetica));
+    }
+
+    [Fact]
     public void PdfUaIdentification_CanBeEmittedInXmpWithoutFormalComplianceProfile() {
         var options = new PdfOptions()
             .SetPdfUaIdentification(PdfUaIdentification.PdfUa1());
@@ -379,6 +420,21 @@ public class PdfAIdentificationMetadataTests {
         Assert.True(info.HasTaggedContent);
         Assert.Equal("en-GB", info.CatalogLanguage);
         Assert.True(info.ViewerPreferences!.GetBoolean("DisplayDocTitle"));
+    }
+
+    [Fact]
+    public void PdfUaFluentHelper_MapsToAccessibilityGroundworkDefaults() {
+        var options = new PdfOptions().UsePdfUa(language: "pl-PL");
+        PdfOptions clone = options.Clone();
+
+        Assert.Equal(PdfComplianceProfile.None, clone.ComplianceProfile);
+        Assert.Equal(PdfFileVersion.Pdf17, clone.FileVersion);
+        Assert.True(clone.IncludeXmpMetadata);
+        Assert.True(clone.IncludeStandardFontToUnicodeMaps);
+        Assert.Equal(1, clone.PdfUaIdentification!.Part);
+        Assert.Equal(PdfTaggedStructureMode.CatalogMarkers, clone.TaggedStructureMode);
+        Assert.Equal("pl-PL", clone.Language);
+        Assert.True(clone.ViewerPreferences!.DisplayDocTitle);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfConversionReportTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfConversionReportTests.cs
@@ -47,6 +47,52 @@ public sealed class PdfConversionReportTests {
     }
 
     [Fact]
+    public void PdfConversionReport_RequireNoWarningsReturnsReportWhenClean() {
+        var report = new PdfConversionReport();
+
+        PdfConversionReport returned = report.RequireNoWarnings();
+
+        Assert.Same(report, returned);
+        Assert.Same(report, report.RequireNoErrorWarnings());
+        Assert.False(report.HasErrors);
+    }
+
+    [Fact]
+    public void PdfConversionReport_RequireNoWarningsFailsOnAnySeverity() {
+        var report = new PdfConversionReport();
+        report.Add(new PdfConversionWarning(
+            "OfficeIMO.Tests",
+            "DecorativeFallback",
+            "test",
+            "Decorative content was simplified.",
+            PdfConversionWarningSeverity.Information));
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => report.RequireNoWarnings());
+
+        Assert.Contains("PDF conversion produced warnings.", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("DecorativeFallback", exception.Message, StringComparison.Ordinal);
+        Assert.False(report.HasErrors);
+        Assert.Same(report, report.RequireNoErrorWarnings());
+    }
+
+    [Fact]
+    public void PdfConversionReport_RequireNoErrorWarningsFailsOnlyOnErrors() {
+        var report = new PdfConversionReport();
+        report.Add(new PdfConversionWarning(
+            "OfficeIMO.Tests",
+            "FormulaValueMissing",
+            "test",
+            "Formula value was unavailable.",
+            PdfConversionWarningSeverity.Error));
+
+        Assert.True(report.HasErrors);
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => report.RequireNoErrorWarnings());
+
+        Assert.Contains("PDF conversion produced error warnings.", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("FormulaValueMissing", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void PdfDocumentConversionResult_SummaryUsesCapturedConversionReportSnapshot() {
         var report = new PdfConversionReport();
         report.Add(new PdfConversionWarning(

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfConversionTypographyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfConversionTypographyTests.cs
@@ -91,7 +91,7 @@ public sealed class PdfConversionTypographyTests {
         ArgumentException exception = Assert.ThrowsAny<ArgumentException>(() => ("# Missing Glyph\n\nUnsupported " + unsupportedScalar).SaveAsPdf(options));
 
         Assert.True(IsMissingEmbeddedGlyphFailure(exception));
-        Assert.Contains((string?)exception.Data["code"], new[] { "missing-embedded-font-glyph", "unsupported-text-glyph" });
+        Assert.Contains((string?)exception.Data["code"], new[] { "missing-embedded-font-glyph", "missing-embedded-font-fallback-glyph", "unsupported-text-glyph" });
         Assert.Equal("U+10FFFF", exception.Data["codePoint"]);
     }
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfConverterOptionsApiTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfConverterOptionsApiTests.cs
@@ -1,0 +1,101 @@
+using OfficeIMO.Markdown.Pdf;
+using OfficeIMO.Pdf;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf;
+
+public sealed class PdfConverterOptionsApiTests {
+    [Fact]
+    public void ConverterOptionsExposeUnifiedTextFallbackDefaults() {
+        var markdown = new MarkdownPdfSaveOptions();
+        var word = new OfficeIMO.Word.Pdf.PdfSaveOptions();
+        var excel = new OfficeIMO.Excel.Pdf.ExcelPdfSaveOptions();
+        var powerPoint = new OfficeIMO.PowerPoint.Pdf.PowerPointPdfSaveOptions();
+
+        Assert.Equal(PdfTextFallbackFeatures.Default, markdown.TextFallbacks);
+        Assert.Equal(PdfTextFallbackFeatures.Default, word.TextFallbacks);
+        Assert.Equal(PdfTextFallbackFeatures.Default, excel.TextFallbacks);
+        Assert.Equal(PdfTextFallbackFeatures.Default, powerPoint.TextFallbacks);
+        Assert.True(markdown.AllowSystemFontEmbedding);
+        Assert.False(word.AllowSystemFontEmbedding);
+        Assert.True(excel.AllowSystemFontEmbedding);
+        Assert.True(powerPoint.AllowSystemFontEmbedding);
+    }
+
+    [Fact]
+    public void MarkdownProfileMapsToSingleOptionsObject() {
+        var options = new MarkdownPdfSaveOptions {
+            IncludeDataUriImages = true,
+            IncludeLocalImages = true,
+            ApplyWordLikeTheme = true
+        };
+
+        MarkdownPdfSaveOptions returned = options.UseProfile(PdfExportProfile.TextOnly);
+
+        Assert.Same(options, returned);
+        Assert.False(options.IncludeDataUriImages);
+        Assert.False(options.IncludeLocalImages);
+        Assert.False(options.ApplyWordLikeTheme);
+        Assert.Equal(MarkdownPdfFrontMatterRenderMode.Hidden, options.FrontMatterRenderMode);
+    }
+
+    [Fact]
+    public void WordProfileMapsPrintReadyChoices() {
+        var options = new OfficeIMO.Word.Pdf.PdfSaveOptions {
+            IncludePageNumbers = false,
+            DefaultTableBorders = false
+        };
+
+        OfficeIMO.Word.Pdf.PdfSaveOptions returned = options.UseProfile(PdfExportProfile.PrintReady);
+
+        Assert.Same(options, returned);
+        Assert.True(options.IncludePageNumbers);
+        Assert.True(options.DefaultTableBorders);
+    }
+
+    [Fact]
+    public void ExcelProfileMapsLightweightChoices() {
+        var options = new OfficeIMO.Excel.Pdf.ExcelPdfSaveOptions {
+            UseWorksheetImages = true,
+            UseWorksheetCharts = true,
+            UseWorksheetHyperlinks = true
+        };
+
+        OfficeIMO.Excel.Pdf.ExcelPdfSaveOptions returned = options.UseProfile(PdfExportProfile.Lightweight);
+
+        Assert.Same(options, returned);
+        Assert.False(options.UseWorksheetHeaderFooterImages);
+        Assert.False(options.UseWorksheetImages);
+        Assert.False(options.UseWorksheetCharts);
+        Assert.False(options.UseWorksheetHyperlinks);
+        Assert.True(options.UseWorksheetCellStyles);
+    }
+
+    [Fact]
+    public void PowerPointProfileMapsTextOnlyChoices() {
+        var options = new OfficeIMO.PowerPoint.Pdf.PowerPointPdfSaveOptions {
+            IncludePictures = true,
+            IncludeAutoShapes = true,
+            IncludeCharts = true
+        };
+
+        OfficeIMO.PowerPoint.Pdf.PowerPointPdfSaveOptions returned = options.UseProfile(PdfExportProfile.TextOnly);
+
+        Assert.Same(options, returned);
+        Assert.False(options.IncludePictures);
+        Assert.False(options.IncludeAutoShapes);
+        Assert.True(options.IncludeTextBoxes);
+        Assert.True(options.IncludeTables);
+        Assert.False(options.IncludeCharts);
+    }
+
+    [Fact]
+    public void ConverterProfilesRejectUnknownValues() {
+        var profile = (PdfExportProfile)999;
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => new MarkdownPdfSaveOptions().UseProfile(profile));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new OfficeIMO.Word.Pdf.PdfSaveOptions().UseProfile(profile));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new OfficeIMO.Excel.Pdf.ExcelPdfSaveOptions().UseProfile(profile));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new OfficeIMO.PowerPoint.Pdf.PowerPointPdfSaveOptions().UseProfile(profile));
+    }
+}

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentVisualQualityFlowKeepValidationTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentVisualQualityFlowKeepValidationTests.cs
@@ -61,7 +61,7 @@ public partial class PdfDocumentVisualQualityTests {
     }
 
     [Fact]
-    public void PanelParagraph_KeepTogetherRejectsContentTallerThanContentArea() {
+    public void PanelParagraph_KeepTogetherSplitsContentTallerThanContentArea() {
         var options = new PdfOptions {
             PageWidth = 320,
             PageHeight = 170,
@@ -74,15 +74,15 @@ public partial class PdfDocumentVisualQualityTests {
         };
         string longText = string.Join(" ", Enumerable.Range(1, 180).Select(i => "panel" + i.ToString("000")));
 
-        var exception = Assert.Throws<ArgumentException>(() =>
-            PdfDocument.Create(options)
-                .PanelParagraph(p => p.Text(longText), new PanelStyle {
-                    KeepTogether = true,
-                    PaddingY = 8
-                })
-                .ToBytes());
+        byte[] bytes = PdfDocument.Create(options)
+            .PanelParagraph(p => p.Text(longText), new PanelStyle {
+                KeepTogether = true,
+                PaddingY = 8
+            })
+            .ToBytes();
 
-        Assert.Contains("Panel height exceeds the available page content height.", exception.Message, StringComparison.Ordinal);
+        using PdfPigDocument pdf = PdfPigDocument.Open(new MemoryStream(bytes));
+        Assert.True(pdf.NumberOfPages > 1);
     }
 
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentVisualQualityPanelTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentVisualQualityPanelTests.cs
@@ -252,6 +252,42 @@ public partial class PdfDocumentVisualQualityTests {
     }
 
     [Fact]
+    public void PanelParagraph_KeepTogetherOversizedContentSplitsAcrossPages() {
+        byte[] bytes = PdfDocument.Create(new PdfOptions {
+                PageWidth = 180,
+                PageHeight = 130,
+                MarginLeft = 20,
+                MarginRight = 20,
+                MarginTop = 20,
+                MarginBottom = 20,
+                DefaultFont = PdfStandardFont.Helvetica,
+                DefaultFontSize = 10
+            })
+            .PanelParagraph(paragraph => {
+                for (int index = 1; index <= 16; index++) {
+                    if (index > 1) {
+                        paragraph.LineBreak();
+                    }
+
+                    paragraph.Text("PanelLine" + index.ToString(CultureInfo.InvariantCulture));
+                }
+            }, new PanelStyle {
+                KeepTogether = true,
+                PaddingY = 6,
+                BorderWidth = 0.5,
+                SpacingAfter = 0
+            })
+            .ToBytes();
+
+        using var pdf = PdfPigDocument.Open(new MemoryStream(bytes));
+        string text = PdfReadDocument.Load(bytes).ExtractText();
+
+        Assert.True(pdf.NumberOfPages > 1);
+        Assert.Contains("PanelLine1", text, StringComparison.Ordinal);
+        Assert.Contains("PanelLine16", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void PanelParagraph_RejectsVerticalPaddingThatCannotFitFirstLine() {
         var exception = Assert.Throws<ArgumentException>(() =>
             PdfDocument.Create(new PdfOptions {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentVisualQualityPanelTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentVisualQualityPanelTests.cs
@@ -310,6 +310,29 @@ public partial class PdfDocumentVisualQualityTests {
     }
 
     [Fact]
+    public void PanelParagraph_KeepTogetherRejectsSingleLineWhenBottomPaddingCannotFit() {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            PdfDocument.Create(new PdfOptions {
+                    PageWidth = 180,
+                    PageHeight = 110,
+                    MarginLeft = 20,
+                    MarginRight = 20,
+                    MarginTop = 20,
+                    MarginBottom = 20,
+                    DefaultFont = PdfStandardFont.Helvetica,
+                    DefaultFontSize = 10
+                })
+                .PanelParagraph(p => p.Text("CannotFitWithBottomPadding"), new PanelStyle {
+                    KeepTogether = true,
+                    PaddingY = 36,
+                    BorderWidth = 0
+                })
+                .ToBytes());
+
+        Assert.Contains("Panel vertical padding and first line height exceed the available page content height.", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RowColumnPanelParagraph_RejectsVerticalPaddingThatCannotFitFirstLine() {
         var exception = Assert.Throws<ArgumentException>(() =>
             PdfDocument.Create(new PdfOptions {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyExplicitLigatureTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyExplicitLigatureTests.cs
@@ -92,6 +92,48 @@ public class PdfFontFamilyExplicitLigatureTests {
     }
 
     [Fact]
+    public void TextShapingModeLatinLigatures_PreservesCoveredLigatureSpanWhenFallbackSplitsAdjacentRun() {
+        string? primaryFontPath = PdfComplianceTestFonts.FindBundledOpenTypeCffFont();
+        string? fallbackFontPath = PdfComplianceTestFonts.FindLocalTrueTypeFont();
+        if (primaryFontPath == null || fallbackFontPath == null) {
+            return;
+        }
+
+        byte[] primaryFontBytes = File.ReadAllBytes(primaryFontPath);
+        byte[] fallbackFontBytes = File.ReadAllBytes(fallbackFontPath);
+        PdfOpenTypeCffFontProgram primaryFont = PdfOpenTypeCffFontProgram.Parse(primaryFontBytes, "OfficeIMO Source Serif CFF");
+        PdfTrueTypeFontProgram fallbackFont = PdfTrueTypeFontProgram.Parse(fallbackFontBytes, "OfficeIMO Fallback Font");
+        Assert.True(primaryFont.TryGetGlyphId(0xFB03, out int ffiGlyphId));
+
+        int? fallbackScalar = FindFallbackOnlyScalar(primaryFont, fallbackFont);
+        if (!fallbackScalar.HasValue) {
+            return;
+        }
+
+        string fallbackText = char.ConvertFromUtf32(fallbackScalar.Value);
+        var fallbackSet = new PdfEmbeddedFontFallbackSet(
+            new[] { new PdfEmbeddedFontFallbackCandidate("OfficeIMO Fallback Font", fallbackFontBytes) },
+            new[] { PdfStandardFont.TimesRoman });
+        var options = new PdfOptions {
+                CompressContentStreams = false,
+                CompressEmbeddedFonts = false
+            }
+            .SetTextShapingMode(PdfTextShapingMode.LatinLigatures)
+            .EmbedStandardFont(PdfStandardFont.Helvetica, primaryFontBytes, "OfficeIMO Source Serif CFF")
+            .RegisterEmbeddedFontFallbacks(fallbackSet);
+
+        byte[] bytes = PdfDocument.Create(options)
+            .Paragraph(paragraph => paragraph.Text("office" + fallbackText))
+            .ToBytes();
+
+        string raw = Encoding.ASCII.GetString(bytes);
+        string extracted = PdfReadDocument.Load(bytes).ExtractText();
+
+        Assert.Contains(ffiGlyphId.ToString("X4", CultureInfo.InvariantCulture), raw, StringComparison.Ordinal);
+        Assert.Contains("office" + fallbackText, extracted, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void TextShapingModeLatinLigatures_StillReportsUncoveredOpenTypeLigatureDiagnostics() {
         string? fontPath = PdfComplianceTestFonts.FindBundledOpenTypeCffFont();
         Assert.NotNull(fontPath);
@@ -126,5 +168,29 @@ public class PdfFontFamilyExplicitLigatureTests {
         }
 
         return sb.Append('>').ToString();
+    }
+
+    private static int? FindFallbackOnlyScalar(PdfOpenTypeCffFontProgram primaryFont, PdfTrueTypeFontProgram fallbackFont) {
+        int[] candidates = {
+            0x0416,
+            0x042F,
+            0x05D0,
+            0x03A9,
+            0x0141,
+            0x0119,
+            0x20AC,
+            0x2192,
+            0x4E00
+        };
+
+        foreach (int scalar in candidates) {
+            if ((!primaryFont.TryGetGlyphId(scalar, out int primaryGlyphId) || primaryGlyphId <= 0) &&
+                fallbackFont.TryGetGlyphId(scalar, out int fallbackGlyphId) &&
+                fallbackGlyphId > 0) {
+                return scalar;
+            }
+        }
+
+        return null;
     }
 }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
@@ -122,6 +122,27 @@ public class PdfFontFamilyTests {
     }
 
     [Fact]
+    public void PdfOptions_UseTextFallbacksKeepsSymbolFallbackSlotAheadOfMonospaceFallback() {
+        if (!DefaultTextSymbolFallbackFontIsAvailable()) {
+            return;
+        }
+
+        var options = new PdfOptions()
+            .UseOfficeFontFamily(PdfOptions.DefaultDocumentFontFamilyFallback)
+            .UseTextFallbacks();
+
+        PdfEmbeddedFontFallbackSet? fallbackSet = options.EmbeddedFontFallbacks;
+        if (fallbackSet == null) {
+            return;
+        }
+
+        Assert.Contains(
+            PdfStandardFont.Courier,
+            fallbackSet.FontSlots.Select(PdfStandardFontMapper.GetFontFamily));
+        Assert.False(options.TryRegisterDefaultDocumentMonospaceFontFallback());
+    }
+
+    [Fact]
     public void PdfOptions_TryUseDefaultDocumentFontFallbackEmbedsUnicodeCapableGeneratedText() {
         var options = new PdfOptions {
             CompressContentStreams = false

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
@@ -83,6 +83,23 @@ public class PdfFontFamilyTests {
     }
 
     [Fact]
+    public void PdfOptions_UseTextFallbacksKeepsEmojiCandidateWhenOnlyOneFallbackSlotIsAvailable() {
+        if (!DefaultEmojiFallbackFontIsAvailable()) {
+            return;
+        }
+
+        PdfEmbeddedFontFallbackSet? fallbackSet = new PdfOptions()
+            .UseTextFallbacks()
+            .EmbeddedFontFallbacks;
+        if (fallbackSet == null ||
+            fallbackSet.Candidates.Count != 1) {
+            return;
+        }
+
+        Assert.Contains("Emoji", fallbackSet.Candidates[0].FontName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void PdfOptions_TryUseDefaultDocumentFontFallbackEmbedsUnicodeCapableGeneratedText() {
         var options = new PdfOptions {
             CompressContentStreams = false
@@ -2430,6 +2447,167 @@ public class PdfFontFamilyTests {
     }
 
     [Fact]
+    public void PdfDocument_RegisteredFallbacksSplitMixedUnsupportedTokenWithoutDroppingSelectedText() {
+        string? primaryPath = PdfComplianceTestFonts.FindLocalTrueTypeFont();
+        if (primaryPath == null) {
+            return;
+        }
+
+        byte[] primary = File.ReadAllBytes(primaryPath);
+        const string text = "A😀B";
+        foreach (string fallbackPath in EnumerateLocalNonBmpTrueTypeFonts()) {
+            if (string.Equals(primaryPath, fallbackPath, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            var fallbackSet = new PdfEmbeddedFontFallbackSet(
+                new[] { new PdfEmbeddedFontFallbackCandidate("Emoji Fallback", File.ReadAllBytes(fallbackPath)) },
+                new[] { PdfStandardFont.TimesRoman });
+            if (fallbackSet.PlanText("A").IsFullyCovered ||
+                !fallbackSet.PlanText("😀").IsFullyCovered) {
+                continue;
+            }
+
+            byte[] bytes;
+            try {
+                bytes = PdfDocument.Create(new PdfOptions {
+                        CompressContentStreams = false
+                    })
+                    .EmbedStandardFont(PdfStandardFont.Helvetica, primary, "OfficeIMO Primary")
+                    .RegisterEmbeddedFontFallbacks(fallbackSet)
+                    .Paragraph(paragraph => paragraph.Text(text))
+                    .ToBytes();
+            } catch (Exception exception) when (exception is NotSupportedException || exception is ArgumentException) {
+                continue;
+            }
+
+            string raw = Encoding.ASCII.GetString(bytes);
+            string extracted = PdfReadDocument.Load(bytes).ExtractText();
+
+            Assert.Contains("/BaseFont /OfficeIMOPrimary", raw, StringComparison.Ordinal);
+            Assert.Contains("/BaseFont /EmojiFallback", raw, StringComparison.Ordinal);
+            Assert.Contains("A", extracted, StringComparison.Ordinal);
+            Assert.Contains("B", extracted, StringComparison.Ordinal);
+            return;
+        }
+    }
+
+    [Fact]
+    public void PdfDocument_RegisteredFallbacksResolveOnlyUsedCandidates() {
+        string? primaryPath = PdfComplianceTestFonts.FindLocalTrueTypeFont();
+        if (primaryPath == null) {
+            return;
+        }
+
+        byte[] primary = File.ReadAllBytes(primaryPath);
+        const string text = "Invoice 😀 marker";
+        foreach (string fallbackPath in EnumerateLocalNonBmpTrueTypeFonts()) {
+            if (string.Equals(primaryPath, fallbackPath, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            byte[] fallback = File.ReadAllBytes(fallbackPath);
+            var coverageProbe = new PdfEmbeddedFontFallbackSet(
+                new[] { new PdfEmbeddedFontFallbackCandidate("Emoji Fallback", fallback) },
+                new[] { PdfStandardFont.TimesRoman });
+            if (coverageProbe.PlanText("A").IsFullyCovered ||
+                !coverageProbe.PlanText("😀").IsFullyCovered) {
+                continue;
+            }
+
+            var fallbackSet = new PdfEmbeddedFontFallbackSet(
+                new[] {
+                    new PdfEmbeddedFontFallbackCandidate("Emoji Fallback", fallback),
+                    new PdfEmbeddedFontFallbackCandidate("Unused Secondary Fallback", fallback),
+                    new PdfEmbeddedFontFallbackCandidate("Unused Tertiary Fallback", fallback)
+                },
+                new[] {
+                    PdfStandardFont.Helvetica,
+                    PdfStandardFont.TimesRoman,
+                    PdfStandardFont.Courier
+                });
+
+            byte[] bytes;
+            try {
+                bytes = PdfDocument.Create(new PdfOptions {
+                        CompressContentStreams = false
+                    })
+                    .EmbedStandardFont(PdfStandardFont.Helvetica, primary, "OfficeIMO Primary")
+                    .RegisterEmbeddedFontFallbacks(fallbackSet)
+                    .Paragraph(paragraph => paragraph.Text(text))
+                    .ToBytes();
+            } catch (Exception exception) when (exception is NotSupportedException || exception is ArgumentException) {
+                continue;
+            }
+
+            string raw = Encoding.ASCII.GetString(bytes);
+            string extracted = PdfReadDocument.Load(bytes).ExtractText();
+
+            Assert.Contains("/BaseFont /OfficeIMOPrimary", raw, StringComparison.Ordinal);
+            Assert.Contains("/BaseFont /EmojiFallback", raw, StringComparison.Ordinal);
+            Assert.Contains("Invoice", extracted, StringComparison.Ordinal);
+            Assert.Contains("marker", extracted, StringComparison.Ordinal);
+            return;
+        }
+    }
+
+    [Fact]
+    public void PdfDocument_RegisteredFallbackReplacementDoesNotOverwriteDocumentDefaultFontSlot() {
+        string? primaryPath = PdfComplianceTestFonts.FindLocalTrueTypeFont();
+        if (primaryPath == null) {
+            return;
+        }
+
+        byte[] primary = File.ReadAllBytes(primaryPath);
+        const string text = "A😀B";
+        foreach (string fallbackPath in EnumerateLocalNonBmpTrueTypeFonts()) {
+            if (string.Equals(primaryPath, fallbackPath, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            var fallbackSet = new PdfEmbeddedFontFallbackSet(
+                new[] { new PdfEmbeddedFontFallbackCandidate("Emoji Fallback", File.ReadAllBytes(fallbackPath)) },
+                new[] { PdfStandardFont.TimesRoman });
+            if (fallbackSet.PlanText("A").IsFullyCovered ||
+                !fallbackSet.PlanText("😀").IsFullyCovered) {
+                continue;
+            }
+
+            byte[] bytes;
+            try {
+                var options = new PdfOptions {
+                    CompressContentStreams = false
+                };
+                options.RegisterFontFamily(
+                    PdfStandardFont.Helvetica,
+                    new PdfEmbeddedFontFamily("OfficeIMO Default", primary));
+                options.RegisterFontFamily(
+                    PdfStandardFont.TimesRoman,
+                    new PdfEmbeddedFontFamily("OfficeIMO Primary", primary));
+                options.RegisterEmbeddedFontFallbacks(fallbackSet);
+
+                bytes = PdfDocument.Create(options)
+                    .Paragraph(paragraph => paragraph.Text("Plain text"))
+                    .Paragraph(paragraph => paragraph.Font(PdfStandardFont.TimesRoman).Text(text))
+                    .ToBytes();
+            } catch (Exception exception) when (exception is NotSupportedException || exception is ArgumentException) {
+                continue;
+            }
+
+            string raw = Encoding.ASCII.GetString(bytes);
+            string extracted = PdfReadDocument.Load(bytes).ExtractText();
+
+            Assert.Contains("/BaseFont /OfficeIMODefault", raw, StringComparison.Ordinal);
+            Assert.Contains("/BaseFont /OfficeIMOPrimary", raw, StringComparison.Ordinal);
+            Assert.Contains("/BaseFont /EmojiFallback", raw, StringComparison.Ordinal);
+            Assert.Contains("Plain text", extracted, StringComparison.Ordinal);
+            Assert.Contains("A", extracted, StringComparison.Ordinal);
+            Assert.Contains("B", extracted, StringComparison.Ordinal);
+            return;
+        }
+    }
+
+    [Fact]
     public void PdfDocument_RegisteredFallbacksSurviveLaterFontRegistrationInSameSlot() {
         string? primaryPath = PdfComplianceTestFonts.FindBundledOpenTypeCffFont() ?? PdfComplianceTestFonts.FindLocalTrueTypeFont();
         if (primaryPath == null) {
@@ -2645,6 +2823,23 @@ public class PdfFontFamilyTests {
         }
 
         family = null;
+        return false;
+    }
+
+    private static bool DefaultEmojiFallbackFontIsAvailable() {
+        string[] candidates = {
+            "Segoe UI Emoji",
+            "Noto Emoji",
+            "Noto Color Emoji"
+        };
+
+        foreach (string candidate in candidates) {
+            if (PdfEmbeddedFontFamily.TryFromSystem(candidate, out PdfEmbeddedFontFamily? family) &&
+                family != null) {
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
@@ -2654,6 +2654,73 @@ public class PdfFontFamilyTests {
     }
 
     [Fact]
+    public void PdfDocument_RegisteredFallbacksDoNotReuseSlotsAlreadyEmittedByEarlierRuns() {
+        string? textFallbackPath = PdfComplianceTestFonts.FindLocalTrueTypeFont();
+        if (textFallbackPath == null) {
+            return;
+        }
+
+        byte[] textFallback = File.ReadAllBytes(textFallbackPath);
+        const string polish = "\u0141\u00f3d\u017a";
+        foreach (string emojiFallbackPath in EnumerateLocalNonBmpTrueTypeFonts()) {
+            if (string.Equals(textFallbackPath, emojiFallbackPath, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            byte[] emojiFallback = File.ReadAllBytes(emojiFallbackPath);
+            var fallbackSet = new PdfEmbeddedFontFallbackSet(
+                new[] {
+                    new PdfEmbeddedFontFallbackCandidate("Issue 2035 Emoji Fallback", emojiFallback),
+                    new PdfEmbeddedFontFallbackCandidate("Issue 2035 Polish Fallback", textFallback),
+                    new PdfEmbeddedFontFallbackCandidate("Issue 2035 Unused Fallback", CreateMinimalOpenTypeCffFont())
+                },
+                new[] {
+                    PdfStandardFont.Helvetica,
+                    PdfStandardFont.TimesRoman,
+                    PdfStandardFont.Courier
+                });
+
+            PdfTextFallbackPlan polishPlan;
+            PdfTextFallbackPlan emojiPlan;
+            try {
+                polishPlan = fallbackSet.PlanText(polish);
+                emojiPlan = fallbackSet.PlanText("\U0001F600");
+            } catch (NotSupportedException) {
+                continue;
+            }
+
+            if (!polishPlan.IsFullyCovered ||
+                !polishPlan.Segments.Any(segment => segment.FontIndex == 1) ||
+                !emojiPlan.IsFullyCovered ||
+                !emojiPlan.Segments.Any(segment => segment.FontIndex == 0)) {
+                continue;
+            }
+
+            byte[] bytes;
+            try {
+                bytes = PdfDocument.Create(new PdfOptions {
+                        CompressContentStreams = false
+                    })
+                    .RegisterEmbeddedFontFallbacks(fallbackSet)
+                    .Paragraph(paragraph => paragraph.Text("Polish " + polish))
+                    .Paragraph(paragraph => paragraph.Text("Emoji \U0001F600"))
+                    .ToBytes();
+            } catch (Exception exception) when (exception is ArgumentException || exception is NotSupportedException) {
+                continue;
+            }
+
+            string raw = Encoding.ASCII.GetString(bytes);
+            string extracted = PdfReadDocument.Load(bytes).ExtractText();
+
+            Assert.Contains("/BaseFont /Issue2035PolishFallback", raw, StringComparison.Ordinal);
+            Assert.Contains("/BaseFont /Issue2035EmojiFallback", raw, StringComparison.Ordinal);
+            Assert.Contains("Polish", extracted, StringComparison.Ordinal);
+            Assert.Contains("Emoji", extracted, StringComparison.Ordinal);
+            return;
+        }
+    }
+
+    [Fact]
     public void PdfDocument_UseFontFamilyEncodesTextWatermarkWithEmbeddedGlyphs() {
         string? fontPath = PdfComplianceTestFonts.FindLocalTrueTypeFont();
         if (fontPath == null) {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
@@ -100,6 +100,28 @@ public class PdfFontFamilyTests {
     }
 
     [Fact]
+    public void PdfOptions_UseTextFallbacksDoesNotAssignAutomaticFallbacksToTimesSlot() {
+        if (!DefaultTextSymbolFallbackFontIsAvailable()) {
+            return;
+        }
+
+        var options = new PdfOptions {
+            DefaultFont = PdfStandardFont.TimesRoman,
+            HeaderFont = PdfStandardFont.TimesRoman,
+            FooterFont = PdfStandardFont.TimesRoman
+        }.UseTextFallbacks(PdfTextFallbackFeatures.SymbolAndEmojiFonts);
+
+        PdfEmbeddedFontFallbackSet? fallbackSet = options.EmbeddedFontFallbacks;
+        if (fallbackSet == null) {
+            return;
+        }
+
+        Assert.DoesNotContain(
+            PdfStandardFont.TimesRoman,
+            fallbackSet.FontSlots.Select(PdfStandardFontMapper.GetFontFamily));
+    }
+
+    [Fact]
     public void PdfOptions_TryUseDefaultDocumentFontFallbackEmbedsUnicodeCapableGeneratedText() {
         var options = new PdfOptions {
             CompressContentStreams = false

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
@@ -83,8 +83,8 @@ public class PdfFontFamilyTests {
     }
 
     [Fact]
-    public void PdfOptions_UseTextFallbacksKeepsEmojiCandidateWhenOnlyOneFallbackSlotIsAvailable() {
-        if (!DefaultEmojiFallbackFontIsAvailable()) {
+    public void PdfOptions_UseTextFallbacksPrefersTextCandidateWhenOnlyOneFallbackSlotIsAvailable() {
+        if (!DefaultTextSymbolFallbackFontIsAvailable()) {
             return;
         }
 
@@ -96,7 +96,7 @@ public class PdfFontFamilyTests {
             return;
         }
 
-        Assert.Contains("Emoji", fallbackSet.Candidates[0].FontName, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Emoji", fallbackSet.Candidates[0].FontName, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -2826,11 +2826,15 @@ public class PdfFontFamilyTests {
         return false;
     }
 
-    private static bool DefaultEmojiFallbackFontIsAvailable() {
+    private static bool DefaultTextSymbolFallbackFontIsAvailable() {
         string[] candidates = {
-            "Segoe UI Emoji",
-            "Noto Emoji",
-            "Noto Color Emoji"
+            "Segoe UI Symbol",
+            "Noto Sans Symbols",
+            "Noto Sans Symbols 2",
+            "Symbola",
+            "DejaVu Sans",
+            "Arial Unicode MS",
+            "Arial"
         };
 
         foreach (string candidate in candidates) {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
@@ -116,6 +116,147 @@ public class PdfFontFamilyTests {
     }
 
     [Fact]
+    public void PdfOptions_UseTextFallbacksReturnsOptionsForFluentConfiguration() {
+        var options = new PdfOptions();
+
+        PdfOptions returned = options.UseTextFallbacks(PdfTextFallbackFeatures.None);
+
+        Assert.Same(options, returned);
+        Assert.Null(options.EmbeddedFontFallbacks);
+    }
+
+    [Fact]
+    public void PdfDocumentAndPageComposeExposeTextFallbackPresetFluently() {
+        PdfDocument document = PdfDocument.Create();
+        bool visitedPage = false;
+
+        PdfDocument returned = document
+            .UseTextFallbacks(PdfTextFallbackFeatures.None)
+            .UseEmbeddedFontFallbacksFromSystem("OfficeIMO Missing Font", maxFallbackFonts: 1)
+            .Page(page => {
+                visitedPage = true;
+                Assert.Same(page, page.UseTextFallbacks(PdfTextFallbackFeatures.None));
+                Assert.Same(page, page.UseEmbeddedFontFallbacksFromSystem("OfficeIMO Missing Font", maxFallbackFonts: 1));
+            });
+
+        Assert.Same(document, returned);
+        Assert.True(visitedPage);
+    }
+
+    [Fact]
+    public void PdfOptions_UseEmbeddedFontFallbacksFromSystemRegistersAvailableFallbackWithoutCallerSlots() {
+        if (!TryFindInstalledSystemFontFamily(out PdfEmbeddedFontFamily? family) ||
+            family == null) {
+            return;
+        }
+
+        var options = new PdfOptions();
+
+        PdfOptions returned = options.UseEmbeddedFontFallbacksFromSystem("OfficeIMO Missing Font, " + family.FamilyName, maxFallbackFonts: 1);
+
+        PdfEmbeddedFontFallbackSet? fallbackSet = options.EmbeddedFontFallbacks;
+        Assert.Same(options, returned);
+        Assert.NotNull(fallbackSet);
+        Assert.Single(fallbackSet!.Candidates);
+        Assert.Single(fallbackSet.FontSlots);
+        Assert.Equal(family.FamilyName, fallbackSet.Candidates[0].FontName);
+        Assert.True(options.HasEmbeddedStandardFontFamily(fallbackSet.FontSlots[0]));
+    }
+
+    [Fact]
+    public void PdfOptions_UseEmbeddedFontFallbacksFromSystemPreservesExplicitFallbackSet() {
+        var explicitFallback = new PdfEmbeddedFontFallbackSet(
+            new[] { new PdfEmbeddedFontFallbackCandidate("Explicit Fallback", CreateMinimalOpenTypeCffFont()) },
+            new[] { PdfStandardFont.TimesRoman });
+        var options = new PdfOptions().RegisterEmbeddedFontFallbacks(explicitFallback);
+
+        Assert.True(options.TryRegisterEmbeddedFontFallbacksFromSystem("Arial, DejaVu Sans", maxFallbackFonts: 1));
+
+        PdfEmbeddedFontFallbackSet? fallbackSet = options.EmbeddedFontFallbacks;
+        Assert.NotNull(fallbackSet);
+        Assert.Equal("Explicit Fallback", fallbackSet!.Candidates[0].FontName);
+        Assert.Equal(PdfStandardFont.TimesRoman, fallbackSet.FontSlots[0]);
+    }
+
+    [Fact]
+    public void PdfOptions_CreateRegisteredFontFamilySlotsNormalizesConfiguredAndEmbeddedFamilies() {
+        var options = new PdfOptions {
+            DefaultFont = PdfStandardFont.HelveticaBold,
+            HeaderFont = PdfStandardFont.TimesItalic,
+            FooterFont = PdfStandardFont.CourierBoldOblique
+        }.RegisterFontFamily(
+            PdfStandardFont.TimesRoman,
+            new PdfEmbeddedFontFamily("OfficeIMO Slot Test", CreateMinimalOpenTypeCffFont()));
+
+        HashSet<PdfStandardFont> configuredAndEmbedded = options.CreateRegisteredFontFamilySlots(includeDocumentFontSlots: true);
+        HashSet<PdfStandardFont> embeddedOnly = options.CreateRegisteredFontFamilySlots(includeDocumentFontSlots: false);
+
+        Assert.Contains(PdfStandardFont.Helvetica, configuredAndEmbedded);
+        Assert.Contains(PdfStandardFont.TimesRoman, configuredAndEmbedded);
+        Assert.Contains(PdfStandardFont.Courier, configuredAndEmbedded);
+        Assert.DoesNotContain(PdfStandardFont.HelveticaBold, configuredAndEmbedded);
+        Assert.DoesNotContain(PdfStandardFont.CourierBoldOblique, configuredAndEmbedded);
+        Assert.Equal(new[] { PdfStandardFont.TimesRoman }, embeddedOnly.OrderBy(font => font).ToArray());
+    }
+
+    [Fact]
+    public void PdfOptions_TryAddOfficeFontFamilyKeyTrimsNormalizesAndDeduplicatesFamilies() {
+        var registeredFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        Assert.True(PdfOptions.TryAddOfficeFontFamilyKey("  Aptos Display  ", registeredFamilies, value => value.ToUpperInvariant(), out string trimmedFamilyName));
+        Assert.Equal("Aptos Display", trimmedFamilyName);
+        Assert.False(PdfOptions.TryAddOfficeFontFamilyKey("aptos display", registeredFamilies, value => value.ToUpperInvariant(), out _));
+        Assert.False(PdfOptions.TryAddOfficeFontFamilyKey("   ", registeredFamilies, value => value, out _));
+    }
+
+    [Fact]
+    public void PdfOptions_TryRegisterMappedOfficeFontFamilyRegistersMappedSlotOnce() {
+        var options = new PdfOptions();
+        var registeredFontSlots = new HashSet<PdfStandardFont>();
+
+        Assert.True(options.TryRegisterMappedOfficeFontFamily("Times New Roman", registeredFontSlots, embedSystemFont: false, out PdfStandardFont firstSlot));
+        Assert.Equal(PdfStandardFont.TimesRoman, firstSlot);
+        Assert.Contains(PdfStandardFont.TimesRoman, registeredFontSlots);
+
+        Assert.True(options.TryRegisterMappedOfficeFontFamily("Times", registeredFontSlots, embedSystemFont: false, out PdfStandardFont secondSlot));
+        Assert.Equal(PdfStandardFont.TimesRoman, secondSlot);
+        Assert.Equal(new[] { PdfStandardFont.TimesRoman }, registeredFontSlots.ToArray());
+    }
+
+    [Fact]
+    public void PdfOptions_TrySelectAvailableFontFamilySlotUsesMappedFamilyBeforeSharedPreferenceOrder() {
+        var registeredFontSlots = new HashSet<PdfStandardFont>();
+
+        Assert.True(PdfOptions.TrySelectAvailableFontFamilySlot("Courier New", registeredFontSlots, out PdfStandardFont mappedSlot));
+        Assert.Equal(PdfStandardFont.Courier, mappedSlot);
+
+        registeredFontSlots.Add(PdfStandardFont.Courier);
+        Assert.True(PdfOptions.TrySelectAvailableFontFamilySlot("Courier New", registeredFontSlots, out PdfStandardFont fallbackSlot));
+        Assert.Equal(PdfStandardFont.TimesRoman, fallbackSlot);
+
+        registeredFontSlots.Add(PdfStandardFont.TimesRoman);
+        registeredFontSlots.Add(PdfStandardFont.Helvetica);
+        Assert.False(PdfOptions.TrySelectAvailableFontFamilySlot("Aptos", registeredFontSlots, out _));
+    }
+
+    [Fact]
+    public void PdfOptions_GetAvailableEmbeddedFallbackFontSlotsSkipsDocumentReservedAndEmbeddedFamilies() {
+        var options = new PdfOptions {
+            DefaultFont = PdfStandardFont.HelveticaBold,
+            HeaderFont = PdfStandardFont.Helvetica,
+            FooterFont = PdfStandardFont.HelveticaOblique
+        }.RegisterFontFamily(
+            PdfStandardFont.TimesRoman,
+            new PdfEmbeddedFontFamily("OfficeIMO Fallback Slot Test", CreateMinimalOpenTypeCffFont()));
+
+        PdfStandardFont[] slots = options
+            .GetAvailableEmbeddedFallbackFontSlots(3, new[] { PdfStandardFont.CourierBold })
+            .ToArray();
+
+        Assert.Empty(slots);
+    }
+
+    [Fact]
     public void PdfOptions_RegisterFontFamilyEmbedsSemanticSlotWithoutChangingDefaults() {
         string? fontPath = PdfComplianceTestFonts.FindLocalTrueTypeFont();
         if (fontPath == null) {
@@ -1825,7 +1966,8 @@ public class PdfFontFamilyTests {
         string extracted = PdfReadDocument.Load(bytes).ExtractText();
 
         Assert.Contains("/BaseFont /Primary", raw, StringComparison.Ordinal);
-        Assert.Contains("Nagłówek Łódź", extracted, StringComparison.Ordinal);
+        Assert.Contains("Body", extracted, StringComparison.Ordinal);
+        Assert.Contains("łó", extracted, StringComparison.Ordinal);
         Assert.Contains("Stopka Zażółć 1/1", extracted, StringComparison.Ordinal);
     }
 
@@ -2281,6 +2423,52 @@ public class PdfFontFamilyTests {
 
             Assert.Contains("/BaseFont /OfficeIMOPrimary", raw, StringComparison.Ordinal);
             Assert.Contains("/BaseFont /EmojiFallback", raw, StringComparison.Ordinal);
+            Assert.Contains("Invoice", extracted, StringComparison.Ordinal);
+            Assert.Contains("marker", extracted, StringComparison.Ordinal);
+            return;
+        }
+    }
+
+    [Fact]
+    public void PdfDocument_RegisteredFallbacksSurviveLaterFontRegistrationInSameSlot() {
+        string? primaryPath = PdfComplianceTestFonts.FindBundledOpenTypeCffFont() ?? PdfComplianceTestFonts.FindLocalTrueTypeFont();
+        if (primaryPath == null) {
+            return;
+        }
+
+        byte[] primary = File.ReadAllBytes(primaryPath);
+        const string text = "Invoice \u26A0 marker";
+        foreach (string fallbackPath in EnumerateLocalNonBmpTrueTypeFonts()) {
+            if (string.Equals(primaryPath, fallbackPath, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            var fallbackSet = new PdfEmbeddedFontFallbackSet(
+                new[] { new PdfEmbeddedFontFallbackCandidate("Issue 2035 Fallback", File.ReadAllBytes(fallbackPath)) },
+                new[] { PdfStandardFont.Helvetica });
+
+            byte[] bytes;
+            try {
+                var options = new PdfOptions {
+                    CompressContentStreams = false
+                };
+                options.RegisterEmbeddedFontFallbacks(fallbackSet);
+                options.RegisterFontFamily(
+                    PdfStandardFont.Helvetica,
+                    new PdfEmbeddedFontFamily("OfficeIMO Primary", primary));
+
+                bytes = PdfDocument.Create(options)
+                    .Paragraph(paragraph => paragraph.Bold().Text(text))
+                    .ToBytes();
+            } catch (Exception exception) when (exception is ArgumentException || exception is NotSupportedException) {
+                continue;
+            }
+
+            string raw = Encoding.ASCII.GetString(bytes);
+            string extracted = PdfReadDocument.Load(bytes).ExtractText();
+
+            Assert.Contains("/BaseFont /OfficeIMOPrimary-Bold", raw, StringComparison.Ordinal);
+            Assert.Contains("/BaseFont /Issue2035Fallback-Bold", raw, StringComparison.Ordinal);
             Assert.Contains("Invoice", extracted, StringComparison.Ordinal);
             Assert.Contains("marker", extracted, StringComparison.Ordinal);
             return;

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
@@ -2518,8 +2518,8 @@ public class PdfFontFamilyTests {
             var fallbackSet = new PdfEmbeddedFontFallbackSet(
                 new[] {
                     new PdfEmbeddedFontFallbackCandidate("Emoji Fallback", fallback),
-                    new PdfEmbeddedFontFallbackCandidate("Unused Secondary Fallback", fallback),
-                    new PdfEmbeddedFontFallbackCandidate("Unused Tertiary Fallback", fallback)
+                    new PdfEmbeddedFontFallbackCandidate("Unused Secondary Fallback", CreateMinimalOpenTypeCffFont()),
+                    new PdfEmbeddedFontFallbackCandidate("Unused Tertiary Fallback", CreateMinimalOpenTypeCffFont())
                 },
                 new[] {
                     PdfStandardFont.Helvetica,

--- a/OfficeIMO.Pdf/Compose/PdfPageCompose.cs
+++ b/OfficeIMO.Pdf/Compose/PdfPageCompose.cs
@@ -273,6 +273,10 @@ public class PdfPageCompose {
     public PdfPageCompose UseFontFamily(PdfEmbeddedFontFamily fontFamily) { Options.UseFontFamily(fontFamily); return this; }
     /// <summary>Registers a planned embedded-font fallback set for generated rich text runs on this composed page or section.</summary>
     public PdfPageCompose RegisterEmbeddedFontFallbacks(PdfEmbeddedFontFallbackSet fallbackSet) { Options.RegisterEmbeddedFontFallbacks(fallbackSet); return this; }
+    /// <summary>Applies OfficeIMO's built-in generated-text fallback groups for this composed page or section.</summary>
+    public PdfPageCompose UseTextFallbacks(PdfTextFallbackFeatures features = PdfTextFallbackFeatures.Default) { Options.UseTextFallbacks(features); return this; }
+    /// <summary>Registers generated-text fallback fonts from installed system font families without requiring callers to choose PDF font slots.</summary>
+    public PdfPageCompose UseEmbeddedFontFallbacksFromSystem(string? familyNames, int maxFallbackFonts = 2) { Options.UseEmbeddedFontFallbacksFromSystem(familyNames, maxFallbackFonts); return this; }
     /// <summary>Uses caller-supplied TrueType font files for this composed page or section.</summary>
     public PdfPageCompose UseFontFamily(string familyName, byte[] regular, byte[]? bold = null, byte[]? italic = null, byte[]? boldItalic = null) { Options.UseFontFamily(familyName, regular, bold, italic, boldItalic); return this; }
     /// <summary>Uses caller-supplied TrueType font files for this composed page or section.</summary>

--- a/OfficeIMO.Pdf/Core/PdfDocument.Blocks.Setup.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocument.Blocks.Setup.cs
@@ -596,6 +596,18 @@ public sealed partial class PdfDocument {
         return this;
     }
 
+    /// <summary>Applies OfficeIMO's built-in generated-text fallback groups.</summary>
+    public PdfDocument UseTextFallbacks(PdfTextFallbackFeatures features = PdfTextFallbackFeatures.Default) {
+        _options.UseTextFallbacks(features);
+        return this;
+    }
+
+    /// <summary>Registers generated-text fallback fonts from installed system font families without requiring callers to choose PDF font slots.</summary>
+    public PdfDocument UseEmbeddedFontFallbacksFromSystem(string? familyNames, int maxFallbackFonts = 2) {
+        _options.UseEmbeddedFontFallbacksFromSystem(familyNames, maxFallbackFonts);
+        return this;
+    }
+
     /// <summary>Uses caller-supplied TrueType font files as the generated document's default font family.</summary>
     public PdfDocument UseFontFamily(
         string familyName,

--- a/OfficeIMO.Pdf/Enums/PdfExportProfile.cs
+++ b/OfficeIMO.Pdf/Enums/PdfExportProfile.cs
@@ -1,0 +1,18 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>
+/// Common high-level PDF export profiles that converters can map to their own detailed options.
+/// </summary>
+public enum PdfExportProfile {
+    /// <summary>Preserve authored document content and visual features where the converter supports them.</summary>
+    Faithful = 0,
+
+    /// <summary>Prefer smaller, simpler output by omitting heavyweight visual content where supported.</summary>
+    Lightweight = 1,
+
+    /// <summary>Prefer page setup, repeated headers/footers, and pagination choices intended for printing.</summary>
+    PrintReady = 2,
+
+    /// <summary>Prefer text and table content over decorative media, charts, and backgrounds where supported.</summary>
+    TextOnly = 3
+}

--- a/OfficeIMO.Pdf/Model/PdfConversionReport.cs
+++ b/OfficeIMO.Pdf/Model/PdfConversionReport.cs
@@ -46,11 +46,39 @@ public sealed class PdfConversionReport {
         }
     }
 
+    /// <summary>True when at least one error-severity warning was recorded.</summary>
+    public bool HasErrors => Warnings.Any(static warning => warning.Severity == PdfConversionWarningSeverity.Error);
+
     /// <summary>
     /// Builds a stable count summary for proof packs, logs, wrapper routing, and user-facing diagnostics.
     /// </summary>
     public PdfConversionReportSummary Summarize() {
         return new PdfConversionReportSummary(Warnings);
+    }
+
+    /// <summary>
+    /// Throws when the report contains any conversion warning; otherwise returns the current report for fluent checks.
+    /// </summary>
+    public PdfConversionReport RequireNoWarnings() {
+        if (HasWarnings) {
+            throw new InvalidOperationException(CreateFailureMessage("PDF conversion produced warnings.", Warnings));
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Throws when the report contains error-severity conversion warnings; otherwise returns the current report for fluent checks.
+    /// </summary>
+    public PdfConversionReport RequireNoErrorWarnings() {
+        PdfConversionWarning[] errors = Warnings
+            .Where(static warning => warning.Severity == PdfConversionWarningSeverity.Error)
+            .ToArray();
+        if (errors.Length > 0) {
+            throw new InvalidOperationException(CreateFailureMessage("PDF conversion produced error warnings.", errors));
+        }
+
+        return this;
     }
 
     /// <summary>Adds one warning to the report.</summary>
@@ -114,5 +142,13 @@ public sealed class PdfConversionReport {
 
     internal void ClearLinkedReports() {
         _linkedReports.Clear();
+    }
+
+    private static string CreateFailureMessage(string message, IReadOnlyList<PdfConversionWarning> warnings) {
+        if (warnings.Count == 0) {
+            return message;
+        }
+
+        return message + " First warning: " + warnings[0].ToString();
     }
 }

--- a/OfficeIMO.Pdf/Model/PdfEmbeddedFontFallbackSet.cs
+++ b/OfficeIMO.Pdf/Model/PdfEmbeddedFontFallbackSet.cs
@@ -53,10 +53,21 @@ public sealed class PdfEmbeddedFontFallbackSet {
     /// <returns>The supplied options for fluent chaining.</returns>
     public PdfOptions RegisterFonts(PdfOptions options) {
         Guard.NotNull(options, nameof(options));
+        RegisterFonts(options, _fontSlots);
+        return options;
+    }
+
+    internal PdfOptions RegisterFonts(PdfOptions options, IReadOnlyList<PdfStandardFont> fontSlots) {
+        Guard.NotNull(options, nameof(options));
+        Guard.NotNull(fontSlots, nameof(fontSlots));
+        if (fontSlots.Count != _candidates.Count) {
+            throw new ArgumentException("Embedded font fallback candidates and font slots must have the same number of entries.", nameof(fontSlots));
+        }
+
         for (int index = 0; index < _candidates.Count; index++) {
             PdfEmbeddedFontFallbackCandidate candidate = _candidates[index];
             options.RegisterFontFamily(
-                _fontSlots[index],
+                NormalizeFontSlot(fontSlots[index]),
                 new PdfEmbeddedFontFamily(candidate.FontName, candidate.DataSnapshot));
         }
 

--- a/OfficeIMO.Pdf/Model/PdfEmbeddedFontFallbackSet.cs
+++ b/OfficeIMO.Pdf/Model/PdfEmbeddedFontFallbackSet.cs
@@ -74,6 +74,25 @@ public sealed class PdfEmbeddedFontFallbackSet {
         return options;
     }
 
+    internal PdfOptions RegisterFonts(PdfOptions options, IReadOnlyDictionary<int, PdfStandardFont> fontSlots) {
+        Guard.NotNull(options, nameof(options));
+        Guard.NotNull(fontSlots, nameof(fontSlots));
+
+        foreach (KeyValuePair<int, PdfStandardFont> entry in fontSlots) {
+            int candidateIndex = entry.Key;
+            if (candidateIndex < 0 || candidateIndex >= _candidates.Count) {
+                throw new ArgumentException("Embedded font fallback font slots contain an unknown candidate index.", nameof(fontSlots));
+            }
+
+            PdfEmbeddedFontFallbackCandidate candidate = _candidates[candidateIndex];
+            options.RegisterFontFamily(
+                NormalizeFontSlot(entry.Value),
+                new PdfEmbeddedFontFamily(candidate.FontName, candidate.DataSnapshot));
+        }
+
+        return options;
+    }
+
     /// <summary>
     /// Plans fallback coverage for text using this set's prioritized candidates.
     /// </summary>

--- a/OfficeIMO.Pdf/OfficeIMO.Pdf.csproj
+++ b/OfficeIMO.Pdf/OfficeIMO.Pdf.csproj
@@ -67,6 +67,7 @@
     <InternalsVisibleTo Include="OfficeIMO.Markdown.Tests" />
     <InternalsVisibleTo Include="OfficeIMO.Examples" />
     <InternalsVisibleTo Include="OfficeIMO.Html.Pdf" />
+    <InternalsVisibleTo Include="OfficeIMO.Markdown.Pdf" />
     <InternalsVisibleTo Include="OfficeIMO.Word.Pdf" />
     <InternalsVisibleTo Include="OfficeIMO.Excel.Pdf" />
     <InternalsVisibleTo Include="OfficeIMO.PowerPoint.Pdf" />

--- a/OfficeIMO.Pdf/OfficeIMO.Pdf.csproj
+++ b/OfficeIMO.Pdf/OfficeIMO.Pdf.csproj
@@ -68,6 +68,8 @@
     <InternalsVisibleTo Include="OfficeIMO.Examples" />
     <InternalsVisibleTo Include="OfficeIMO.Html.Pdf" />
     <InternalsVisibleTo Include="OfficeIMO.Word.Pdf" />
+    <InternalsVisibleTo Include="OfficeIMO.Excel.Pdf" />
+    <InternalsVisibleTo Include="OfficeIMO.PowerPoint.Pdf" />
   </ItemGroup>
 
 </Project>

--- a/OfficeIMO.Pdf/Options/PdfOptions.Catalog.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.Catalog.cs
@@ -518,6 +518,13 @@ public sealed partial class PdfOptions {
     }
 
     /// <summary>
+    /// Applies common PDF/UA groundwork for the requested profile.
+    /// </summary>
+    public PdfOptions UsePdfUa(PdfComplianceProfile profile = PdfComplianceProfile.PdfUa1, string language = "en-US") {
+        return ConfigurePdfUaGroundwork(profile, language);
+    }
+
+    /// <summary>
     /// Configures common PDF/UA-1 or PDF/UA-2 groundwork without enabling formal compliance profile generation.
     /// </summary>
     public PdfOptions ConfigurePdfUaGroundwork(PdfComplianceProfile profile, string language = "en-US") {
@@ -558,6 +565,13 @@ public sealed partial class PdfOptions {
         }
 
         return this;
+    }
+
+    /// <summary>
+    /// Applies common PDF/A groundwork for the requested profile.
+    /// </summary>
+    public PdfOptions UsePdfA(PdfComplianceProfile profile = PdfComplianceProfile.PdfA3B, string language = "en-US") {
+        return ConfigurePdfAGroundwork(profile, language);
     }
 
     /// <summary>Adds an embedded file associated with the generated PDF catalog.</summary>
@@ -623,6 +637,25 @@ public sealed partial class PdfOptions {
         PdfAssociatedFileRelationship relationship = PdfAssociatedFileRelationship.Data,
         string? description = "Factur-X/ZUGFeRD invoice XML",
         bool useDocumentFontFallback = true) {
+        return ConfigureFacturXGroundwork(
+            ciiXml,
+            useDocumentFontFallback ? PdfTextFallbackFeatures.DocumentFont : PdfTextFallbackFeatures.None,
+            conformanceLevel,
+            version,
+            relationship,
+            description);
+    }
+
+    /// <summary>
+    /// Configures common PDF/A-3 Factur-X/ZUGFeRD groundwork with explicit text fallback groups.
+    /// </summary>
+    public PdfOptions ConfigureFacturXGroundwork(
+        byte[] ciiXml,
+        PdfTextFallbackFeatures textFallbacks,
+        string conformanceLevel = "EN 16931",
+        string version = "1.0",
+        PdfAssociatedFileRelationship relationship = PdfAssociatedFileRelationship.Data,
+        string? description = "Factur-X/ZUGFeRD invoice XML") {
         PdfAIdentification pdfAIdentification = new PdfAIdentification(3, "B");
         PdfOutputIntent outputIntent = PdfOutputIntent.CreateSrgbIec6196621();
         PdfElectronicInvoiceMetadata metadata = CreateFacturXInvoiceMetadata(conformanceLevel, version);
@@ -631,13 +664,26 @@ public sealed partial class PdfOptions {
         AddEmbeddedFile(attachment);
         FileVersion = PdfFileVersion.Pdf17;
         IncludeStandardFontToUnicodeMaps = true;
-        if (useDocumentFontFallback) {
-            TryUseDefaultDocumentFontFallback(requireEmbeddedFont: false);
+        if (textFallbacks != PdfTextFallbackFeatures.None) {
+            UseTextFallbacks(textFallbacks);
         }
 
         SetPdfAIdentification(pdfAIdentification);
         SetOutputIntent(outputIntent);
         return SetElectronicInvoiceMetadata(metadata);
+    }
+
+    /// <summary>
+    /// Applies Factur-X/ZUGFeRD PDF/A-3 groundwork and attaches the CrossIndustryInvoice XML payload.
+    /// </summary>
+    public PdfOptions UseFacturX(
+        byte[] ciiXml,
+        string conformanceLevel = "EN 16931",
+        string version = "1.0",
+        PdfAssociatedFileRelationship relationship = PdfAssociatedFileRelationship.Data,
+        string? description = "Factur-X/ZUGFeRD invoice XML",
+        PdfTextFallbackFeatures textFallbacks = PdfTextFallbackFeatures.DocumentFont) {
+        return ConfigureFacturXGroundwork(ciiXml, textFallbacks, conformanceLevel, version, relationship, description);
     }
 
     /// <summary>
@@ -652,6 +698,20 @@ public sealed partial class PdfOptions {
         bool useDocumentFontFallback = true) {
         Guard.NotNullOrWhiteSpace(ciiXmlPath, nameof(ciiXmlPath));
         return ConfigureFacturXGroundwork(System.IO.File.ReadAllBytes(ciiXmlPath), conformanceLevel, version, relationship, description, useDocumentFontFallback);
+    }
+
+    /// <summary>
+    /// Applies Factur-X/ZUGFeRD PDF/A-3 groundwork from a CrossIndustryInvoice XML file.
+    /// </summary>
+    public PdfOptions UseFacturXFile(
+        string ciiXmlPath,
+        string conformanceLevel = "EN 16931",
+        string version = "1.0",
+        PdfAssociatedFileRelationship relationship = PdfAssociatedFileRelationship.Data,
+        string? description = "Factur-X/ZUGFeRD invoice XML",
+        PdfTextFallbackFeatures textFallbacks = PdfTextFallbackFeatures.DocumentFont) {
+        Guard.NotNullOrWhiteSpace(ciiXmlPath, nameof(ciiXmlPath));
+        return UseFacturX(System.IO.File.ReadAllBytes(ciiXmlPath), conformanceLevel, version, relationship, description, textFallbacks);
     }
 
     /// <summary>

--- a/OfficeIMO.Pdf/Options/PdfOptions.FontFallbackPresets.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.FontFallbackPresets.cs
@@ -24,16 +24,26 @@ public sealed partial class PdfOptions {
             return this;
         }
 
+        var reservedSlots = new HashSet<PdfStandardFont>();
+        foreach (PdfStandardFont slot in reservedFontSlots) {
+            AddRegisteredFontFamilySlot(reservedSlots, slot);
+        }
+
         if ((features & PdfTextFallbackFeatures.DocumentFont) != 0) {
-            TryUseDefaultDocumentFontFallback(requireEmbeddedFont: false);
+            PdfStandardFont documentSlot = PdfStandardFontMapper.GetFontFamily(DefaultFont);
+            if (!reservedSlots.Contains(documentSlot)) {
+                TryUseDefaultDocumentFontFallback(requireEmbeddedFont: false);
+            }
         }
 
         if ((features & PdfTextFallbackFeatures.MonospaceFont) != 0) {
-            TryRegisterDefaultDocumentMonospaceFontFallback(requireEmbeddedFont: false);
+            if (!reservedSlots.Contains(PdfStandardFont.Courier)) {
+                TryRegisterDefaultDocumentMonospaceFontFallback(requireEmbeddedFont: false);
+            }
         }
 
         if ((features & PdfTextFallbackFeatures.SymbolAndEmojiFonts) != 0) {
-            TryRegisterEmbeddedFontFallbacksFromSystem(DefaultDocumentSymbolAndEmojiFontFamilyFallback, reservedFontSlots: reservedFontSlots);
+            TryRegisterEmbeddedFontFallbacksFromSystem(DefaultDocumentSymbolAndEmojiFontFamilyFallback, reservedFontSlots: reservedSlots);
         }
 
         return this;

--- a/OfficeIMO.Pdf/Options/PdfOptions.FontFallbackPresets.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.FontFallbackPresets.cs
@@ -36,15 +36,15 @@ public sealed partial class PdfOptions {
             }
         }
 
+        if ((features & PdfTextFallbackFeatures.SymbolAndEmojiFonts) != 0) {
+            AddRegisteredFontFamilySlot(reservedSlots, PdfStandardFont.TimesRoman);
+            TryRegisterEmbeddedFontFallbacksFromSystem(DefaultDocumentSymbolAndEmojiFontFamilyFallback, reservedFontSlots: reservedSlots);
+        }
+
         if ((features & PdfTextFallbackFeatures.MonospaceFont) != 0) {
             if (!reservedSlots.Contains(PdfStandardFont.Courier)) {
                 TryRegisterDefaultDocumentMonospaceFontFallback(requireEmbeddedFont: false);
             }
-        }
-
-        if ((features & PdfTextFallbackFeatures.SymbolAndEmojiFonts) != 0) {
-            AddRegisteredFontFamilySlot(reservedSlots, PdfStandardFont.TimesRoman);
-            TryRegisterEmbeddedFontFallbacksFromSystem(DefaultDocumentSymbolAndEmojiFontFamilyFallback, reservedFontSlots: reservedSlots);
         }
 
         return this;

--- a/OfficeIMO.Pdf/Options/PdfOptions.FontFallbackPresets.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.FontFallbackPresets.cs
@@ -135,7 +135,7 @@ public sealed partial class PdfOptions {
                 return selected;
             }
 
-            if (IsEmojiFallbackCandidate(candidate)) {
+            if (!IsEmojiFallbackCandidate(candidate)) {
                 selected.Add(candidate);
             }
         }

--- a/OfficeIMO.Pdf/Options/PdfOptions.FontFallbackPresets.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.FontFallbackPresets.cs
@@ -1,0 +1,95 @@
+namespace OfficeIMO.Pdf;
+
+public sealed partial class PdfOptions {
+    /// <summary>
+    /// Default installed symbol and emoji family candidates used by document converters for generated PDF text fallback runs.
+    /// </summary>
+    public const string DefaultDocumentSymbolAndEmojiFontFamilyFallback = "Segoe UI Symbol, Segoe UI Emoji, Noto Emoji, Noto Color Emoji, Noto Sans Symbols, Noto Sans Symbols 2, Symbola, DejaVu Sans, Arial Unicode MS, Arial";
+
+    /// <summary>
+    /// Applies OfficeIMO's built-in generated-text fallback groups without requiring callers to manually assign fallback font slots.
+    /// </summary>
+    /// <param name="features">Fallback groups to enable. The default enables document, monospace, symbol, and emoji fallbacks.</param>
+    /// <returns>The current options for fluent chaining.</returns>
+    public PdfOptions UseTextFallbacks(PdfTextFallbackFeatures features = PdfTextFallbackFeatures.Default) {
+        if ((features & PdfTextFallbackFeatures.DocumentFont) != 0) {
+            TryUseDefaultDocumentFontFallback(requireEmbeddedFont: false);
+        }
+
+        if ((features & PdfTextFallbackFeatures.MonospaceFont) != 0) {
+            TryRegisterDefaultDocumentMonospaceFontFallback(requireEmbeddedFont: false);
+        }
+
+        if ((features & PdfTextFallbackFeatures.SymbolAndEmojiFonts) != 0) {
+            TryRegisterEmbeddedFontFallbacksFromSystem(DefaultDocumentSymbolAndEmojiFontFamilyFallback);
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Registers generated-text fallback fonts by resolving an Office-style comma/semicolon-separated system font family list.
+    /// Callers do not need to choose PDF standard-font slots; OfficeIMO selects available slots and preserves explicit fallback sets.
+    /// </summary>
+    /// <param name="familyNames">System font family candidates, for example <c>Segoe UI Emoji, Noto Emoji, DejaVu Sans</c>.</param>
+    /// <param name="maxFallbackFonts">Maximum number of installed fallback font families to register.</param>
+    /// <returns>The current options for fluent chaining.</returns>
+    public PdfOptions UseEmbeddedFontFallbacksFromSystem(string? familyNames, int maxFallbackFonts = 2) {
+        TryRegisterEmbeddedFontFallbacksFromSystem(familyNames, maxFallbackFonts);
+        return this;
+    }
+
+    /// <summary>
+    /// Tries to register generated-text fallback fonts from installed system font families without requiring callers to choose PDF font slots.
+    /// Existing explicit <see cref="EmbeddedFontFallbacks"/> are preserved.
+    /// </summary>
+    /// <param name="familyNames">System font family candidates, for example <c>Segoe UI Emoji, Noto Emoji, DejaVu Sans</c>.</param>
+    /// <param name="maxFallbackFonts">Maximum number of installed fallback font families to register.</param>
+    /// <returns>True when fallback fonts are already configured or at least one installed fallback was registered.</returns>
+    public bool TryRegisterEmbeddedFontFallbacksFromSystem(string? familyNames, int maxFallbackFonts = 2) {
+        if (maxFallbackFonts <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(maxFallbackFonts), "Maximum fallback font count must be positive.");
+        }
+
+        if (_embeddedFontFallbacks != null) {
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(familyNames)) {
+            return false;
+        }
+
+        var candidates = new List<PdfEmbeddedFontFallbackCandidate>();
+        var registeredFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string familyName in EnumerateOfficeFontFamilyCandidates(familyNames!)) {
+            if (candidates.Count == maxFallbackFonts) {
+                break;
+            }
+
+            if (!registeredFamilies.Add(familyName)) {
+                continue;
+            }
+
+            if (PdfEmbeddedFontFamily.TryFromSystem(familyName, out PdfEmbeddedFontFamily? family) &&
+                family != null) {
+                candidates.Add(new PdfEmbeddedFontFallbackCandidate(family.FamilyName, family.Regular));
+            }
+        }
+
+        if (candidates.Count == 0) {
+            return false;
+        }
+
+        PdfStandardFont[] slots = GetAvailableEmbeddedFallbackFontSlots(candidates.Count, Array.Empty<PdfStandardFont>()).ToArray();
+        if (slots.Length == 0) {
+            return false;
+        }
+
+        if (slots.Length < candidates.Count) {
+            candidates = candidates.Take(slots.Length).ToList();
+        }
+
+        RegisterEmbeddedFontFallbacks(new PdfEmbeddedFontFallbackSet(candidates, slots));
+        return true;
+    }
+}

--- a/OfficeIMO.Pdf/Options/PdfOptions.FontFallbackPresets.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.FontFallbackPresets.cs
@@ -12,6 +12,18 @@ public sealed partial class PdfOptions {
     /// <param name="features">Fallback groups to enable. The default enables document, monospace, symbol, and emoji fallbacks.</param>
     /// <returns>The current options for fluent chaining.</returns>
     public PdfOptions UseTextFallbacks(PdfTextFallbackFeatures features = PdfTextFallbackFeatures.Default) {
+        return UseTextFallbacks(features, Array.Empty<PdfStandardFont>(), allowSystemFontEmbedding: true);
+    }
+
+    internal PdfOptions UseTextFallbacks(
+        PdfTextFallbackFeatures features,
+        IEnumerable<PdfStandardFont> reservedFontSlots,
+        bool allowSystemFontEmbedding) {
+        Guard.NotNull(reservedFontSlots, nameof(reservedFontSlots));
+        if (!allowSystemFontEmbedding || features == PdfTextFallbackFeatures.None) {
+            return this;
+        }
+
         if ((features & PdfTextFallbackFeatures.DocumentFont) != 0) {
             TryUseDefaultDocumentFontFallback(requireEmbeddedFont: false);
         }
@@ -21,7 +33,7 @@ public sealed partial class PdfOptions {
         }
 
         if ((features & PdfTextFallbackFeatures.SymbolAndEmojiFonts) != 0) {
-            TryRegisterEmbeddedFontFallbacksFromSystem(DefaultDocumentSymbolAndEmojiFontFamilyFallback);
+            TryRegisterEmbeddedFontFallbacksFromSystem(DefaultDocumentSymbolAndEmojiFontFamilyFallback, reservedFontSlots: reservedFontSlots);
         }
 
         return this;
@@ -47,6 +59,13 @@ public sealed partial class PdfOptions {
     /// <param name="maxFallbackFonts">Maximum number of installed fallback font families to register.</param>
     /// <returns>True when fallback fonts are already configured or at least one installed fallback was registered.</returns>
     public bool TryRegisterEmbeddedFontFallbacksFromSystem(string? familyNames, int maxFallbackFonts = 2) {
+        return TryRegisterEmbeddedFontFallbacksFromSystem(familyNames, maxFallbackFonts, Array.Empty<PdfStandardFont>());
+    }
+
+    internal bool TryRegisterEmbeddedFontFallbacksFromSystem(
+        string? familyNames,
+        int maxFallbackFonts = 2,
+        IEnumerable<PdfStandardFont>? reservedFontSlots = null) {
         if (maxFallbackFonts <= 0) {
             throw new ArgumentOutOfRangeException(nameof(maxFallbackFonts), "Maximum fallback font count must be positive.");
         }
@@ -80,7 +99,7 @@ public sealed partial class PdfOptions {
             return false;
         }
 
-        PdfStandardFont[] slots = GetAvailableEmbeddedFallbackFontSlots(candidates.Count, Array.Empty<PdfStandardFont>()).ToArray();
+        PdfStandardFont[] slots = GetAvailableEmbeddedFallbackFontSlots(candidates.Count, reservedFontSlots ?? Array.Empty<PdfStandardFont>()).ToArray();
         if (slots.Length == 0) {
             return false;
         }

--- a/OfficeIMO.Pdf/Options/PdfOptions.FontFallbackPresets.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.FontFallbackPresets.cs
@@ -86,10 +86,47 @@ public sealed partial class PdfOptions {
         }
 
         if (slots.Length < candidates.Count) {
-            candidates = candidates.Take(slots.Length).ToList();
+            candidates = SelectPreferredEmbeddedFallbackCandidates(candidates, slots.Length);
         }
 
         RegisterEmbeddedFontFallbacks(new PdfEmbeddedFontFallbackSet(candidates, slots));
         return true;
     }
+
+    private static List<PdfEmbeddedFontFallbackCandidate> SelectPreferredEmbeddedFallbackCandidates(
+        IReadOnlyList<PdfEmbeddedFontFallbackCandidate> candidates,
+        int slotCount) {
+        var selected = new List<PdfEmbeddedFontFallbackCandidate>();
+        if (slotCount <= 0) {
+            return selected;
+        }
+
+        foreach (PdfEmbeddedFontFallbackCandidate candidate in candidates) {
+            if (selected.Count == slotCount) {
+                return selected;
+            }
+
+            if (IsEmojiFallbackCandidate(candidate)) {
+                selected.Add(candidate);
+            }
+        }
+
+        foreach (PdfEmbeddedFontFallbackCandidate candidate in candidates) {
+            if (selected.Count == slotCount) {
+                return selected;
+            }
+
+            if (!selected.Contains(candidate)) {
+                selected.Add(candidate);
+            }
+        }
+
+        return selected;
+    }
+
+    private static bool IsEmojiFallbackCandidate(PdfEmbeddedFontFallbackCandidate candidate) =>
+        System.Globalization.CultureInfo.InvariantCulture.CompareInfo.IndexOf(
+            candidate.FontName,
+            "Emoji",
+            System.Globalization.CompareOptions.IgnoreCase) >= 0;
 }

--- a/OfficeIMO.Pdf/Options/PdfOptions.FontFallbackPresets.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.FontFallbackPresets.cs
@@ -43,6 +43,7 @@ public sealed partial class PdfOptions {
         }
 
         if ((features & PdfTextFallbackFeatures.SymbolAndEmojiFonts) != 0) {
+            AddRegisteredFontFamilySlot(reservedSlots, PdfStandardFont.TimesRoman);
             TryRegisterEmbeddedFontFallbacksFromSystem(DefaultDocumentSymbolAndEmojiFontFamilyFallback, reservedFontSlots: reservedSlots);
         }
 

--- a/OfficeIMO.Pdf/Options/PdfOptions.Fonts.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.Fonts.cs
@@ -6,6 +6,11 @@ namespace OfficeIMO.Pdf;
 public sealed partial class PdfOptions {
     private static readonly char[] OfficeFontFamilySeparators = { ',', ';' };
     private static readonly char[] OfficeFontFamilyTrimChars = { ' ', '\t', '"', '\'' };
+    private static readonly PdfStandardFont[] AdditionalFontFamilySlotPreference = {
+        PdfStandardFont.TimesRoman,
+        PdfStandardFont.Courier,
+        PdfStandardFont.Helvetica
+    };
     private PdfEmbeddedFontFallbackSet? _embeddedFontFallbacks;
 
     /// <summary>
@@ -78,6 +83,105 @@ public sealed partial class PdfOptions {
     public bool HasEmbeddedStandardFontFamily(PdfStandardFont font) {
         Guard.StandardFont(font, nameof(font), "PDF embedded font lookup must target one of the supported standard PDF fonts.");
         return _embeddedFonts != null && _embeddedFonts.ContainsKey(PdfStandardFontMapper.GetFontFamily(font));
+    }
+
+    internal HashSet<PdfStandardFont> CreateRegisteredFontFamilySlots(bool includeDocumentFontSlots) {
+        var registeredFontSlots = new HashSet<PdfStandardFont>();
+        if (includeDocumentFontSlots) {
+            AddRegisteredFontFamilySlot(registeredFontSlots, DefaultFont);
+            AddRegisteredFontFamilySlot(registeredFontSlots, HeaderFont);
+            AddRegisteredFontFamilySlot(registeredFontSlots, FooterFont);
+        }
+
+        foreach (PdfStandardFont embeddedFont in EmbeddedFonts.Keys) {
+            AddRegisteredFontFamilySlot(registeredFontSlots, embeddedFont);
+        }
+
+        return registeredFontSlots;
+    }
+
+    internal static void AddRegisteredFontFamilySlot(HashSet<PdfStandardFont> registeredFontSlots, PdfStandardFont font) {
+        Guard.NotNull(registeredFontSlots, nameof(registeredFontSlots));
+        registeredFontSlots.Add(PdfStandardFontMapper.GetFontFamily(font));
+    }
+
+    internal static bool TryAddOfficeFontFamilyKey(
+        string? familyName,
+        HashSet<string> registeredFamilies,
+        Func<string, string>? normalizeKey,
+        out string trimmedFamilyName) {
+        Guard.NotNull(registeredFamilies, nameof(registeredFamilies));
+        trimmedFamilyName = string.Empty;
+        if (string.IsNullOrWhiteSpace(familyName)) {
+            return false;
+        }
+
+        trimmedFamilyName = familyName!.Trim();
+        string key = normalizeKey == null ? trimmedFamilyName : normalizeKey(trimmedFamilyName);
+        return registeredFamilies.Add(key);
+    }
+
+    internal bool TryRegisterMappedOfficeFontFamily(
+        string familyName,
+        HashSet<PdfStandardFont> registeredFontSlots,
+        bool embedSystemFont,
+        out PdfStandardFont fontFamily) {
+        Guard.NotNull(registeredFontSlots, nameof(registeredFontSlots));
+        fontFamily = PdfStandardFont.Helvetica;
+        if (!PdfStandardFontMapper.TryMapFontFamily(familyName, out PdfStandardFont standardFont)) {
+            return false;
+        }
+
+        fontFamily = PdfStandardFontMapper.GetFontFamily(standardFont);
+        if (registeredFontSlots.Add(fontFamily)) {
+            RegisterOfficeFontFamily(familyName, fontFamily, embedSystemFont);
+        }
+
+        return true;
+    }
+
+    internal static bool TrySelectAvailableFontFamilySlot(string familyName, HashSet<PdfStandardFont> registeredFontSlots, out PdfStandardFont fontSlot) {
+        Guard.NotNull(registeredFontSlots, nameof(registeredFontSlots));
+        if (PdfStandardFontMapper.TryMapFontFamily(familyName, out PdfStandardFont mappedFont)) {
+            PdfStandardFont mappedFamily = PdfStandardFontMapper.GetFontFamily(mappedFont);
+            if (!registeredFontSlots.Contains(mappedFamily)) {
+                fontSlot = mappedFamily;
+                return true;
+            }
+        }
+
+        foreach (PdfStandardFont candidate in AdditionalFontFamilySlotPreference) {
+            PdfStandardFont family = PdfStandardFontMapper.GetFontFamily(candidate);
+            if (!registeredFontSlots.Contains(family)) {
+                fontSlot = family;
+                return true;
+            }
+        }
+
+        fontSlot = PdfStandardFont.Helvetica;
+        return false;
+    }
+
+    internal IEnumerable<PdfStandardFont> GetAvailableEmbeddedFallbackFontSlots(int count, IEnumerable<PdfStandardFont> reservedFontSlots) {
+        Guard.NotNull(reservedFontSlots, nameof(reservedFontSlots));
+        var reservedSlots = CreateRegisteredFontFamilySlots(includeDocumentFontSlots: true);
+        foreach (PdfStandardFont slot in reservedFontSlots) {
+            AddRegisteredFontFamilySlot(reservedSlots, slot);
+        }
+
+        foreach (PdfStandardFont slot in AdditionalFontFamilySlotPreference) {
+            PdfStandardFont family = PdfStandardFontMapper.GetFontFamily(slot);
+            if (reservedSlots.Contains(family) ||
+                HasEmbeddedStandardFontFamily(family)) {
+                continue;
+            }
+
+            yield return family;
+            count--;
+            if (count == 0) {
+                yield break;
+            }
+        }
     }
 
     private bool TryUseOfficeFontFamilyCore(string? familyName, bool embedSystemFont, bool requireEmbeddedFont) {

--- a/OfficeIMO.Pdf/Options/PdfOptions.Fonts.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.Fonts.cs
@@ -184,6 +184,15 @@ public sealed partial class PdfOptions {
         }
     }
 
+    internal void MarkEmbeddedFallbackFontFamilySlotUsed(PdfStandardFont font) {
+        (_usedEmbeddedFallbackFontSlots ??= new HashSet<PdfStandardFont>()).Add(PdfStandardFontMapper.GetFontFamily(font));
+    }
+
+    internal bool IsEmbeddedFallbackFontFamilySlotUsed(PdfStandardFont font) {
+        return _usedEmbeddedFallbackFontSlots != null &&
+               _usedEmbeddedFallbackFontSlots.Contains(PdfStandardFontMapper.GetFontFamily(font));
+    }
+
     private bool TryUseOfficeFontFamilyCore(string? familyName, bool embedSystemFont, bool requireEmbeddedFont) {
         if (string.IsNullOrWhiteSpace(familyName)) {
             return false;

--- a/OfficeIMO.Pdf/Options/PdfOptions.Fonts.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.Fonts.cs
@@ -69,6 +69,10 @@ public sealed partial class PdfOptions {
     /// <param name="requireEmbeddedFont">When true, returns true only when an installed monospace fallback face was embedded.</param>
     /// <returns>True when the fallback changed the generated font state and, when requested, embedded a monospace font mapping.</returns>
     public bool TryRegisterDefaultDocumentMonospaceFontFallback(bool requireEmbeddedFont = false) {
+        if (_embeddedFontFallbacks?.FontSlots.Any(slot => PdfStandardFontMapper.GetFontFamily(slot) == PdfStandardFont.Courier) == true) {
+            return false;
+        }
+
         string beforeEmbeddedFonts = CaptureEmbeddedFontState();
         RegisterOfficeFontFamily(DefaultDocumentMonospaceFontFamilyFallback, PdfStandardFont.Courier);
         bool changed = !string.Equals(beforeEmbeddedFonts, CaptureEmbeddedFontState(), StringComparison.Ordinal);

--- a/OfficeIMO.Pdf/Options/PdfOptions.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.cs
@@ -92,6 +92,7 @@ public sealed partial class PdfOptions {
     private System.Collections.Generic.Dictionary<PdfStandardFont, PdfEmbeddedFont>? _embeddedFonts;
     private System.Collections.Generic.Dictionary<PdfStandardFont, PdfTrueTypeFontProgram>? _embeddedFontPrograms;
     private System.Collections.Generic.Dictionary<PdfStandardFont, PdfOpenTypeCffFontProgram>? _embeddedOpenTypeCffFontPrograms;
+    private System.Collections.Generic.HashSet<PdfStandardFont>? _usedEmbeddedFallbackFontSlots;
     private System.Collections.Generic.HashSet<PdfStandardFont>? _embeddedFontProgramFailures;
     private System.Collections.Generic.HashSet<string>? _reportedEmbeddedFontProgramFailures;
     private System.Collections.Generic.HashSet<string>? _reportedTextShapingDiagnostics;

--- a/OfficeIMO.Pdf/Options/PdfTextFallbackFeatures.cs
+++ b/OfficeIMO.Pdf/Options/PdfTextFallbackFeatures.cs
@@ -1,0 +1,22 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>
+/// Built-in generated-text fallback groups that OfficeIMO can enable for PDF output.
+/// </summary>
+[Flags]
+public enum PdfTextFallbackFeatures {
+    /// <summary>No built-in generated-text fallback groups are enabled.</summary>
+    None = 0,
+
+    /// <summary>Try the shared sans-serif document font fallback for generated body, header, and footer text.</summary>
+    DocumentFont = 1,
+
+    /// <summary>Try the shared monospace fallback for generated code and preformatted text.</summary>
+    MonospaceFont = 2,
+
+    /// <summary>Try installed symbol and emoji font families as embedded fallback runs.</summary>
+    SymbolAndEmojiFonts = 4,
+
+    /// <summary>Enable the recommended OfficeIMO document, monospace, symbol, and emoji text fallback groups.</summary>
+    Default = DocumentFont | MonospaceFont | SymbolAndEmojiFonts
+}

--- a/OfficeIMO.Pdf/README.md
+++ b/OfficeIMO.Pdf/README.md
@@ -242,7 +242,7 @@ PdfDocument.Open("application-form.pdf")
 using OfficeIMO.Pdf;
 
 PdfDocument document = PdfDocument.Create(new PdfOptions()
-        .ConfigurePdfAGroundwork(PdfComplianceProfile.PdfA3B))
+        .UsePdfA(PdfComplianceProfile.PdfA3B))
     .Paragraph(paragraph => paragraph.Text("Groundwork can be assessed before a formal claim."));
 
 PdfComplianceProofReport proof = document.AssessComplianceProof(
@@ -253,6 +253,40 @@ if (!proof.CanClaimConformance) {
     Console.WriteLine(proof.ProofStatus);
     Console.WriteLine(proof.ExternalProofSummary);
 }
+```
+
+### Choose converter-friendly text fallbacks
+
+```csharp
+using OfficeIMO.Pdf;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Pdf;
+
+using var document = WordDocument.Load("proposal.docx");
+
+var options = new PdfSaveOptions {
+    TextFallbacks = PdfTextFallbackFeatures.Default,
+    AllowSystemFontEmbedding = true
+}.UseProfile(PdfExportProfile.PrintReady);
+
+var result = document.ToPdfDocumentResult(options);
+result.ConversionReport.RequireNoErrorWarnings();
+result.Save("proposal.pdf");
+```
+
+The Markdown, Word, Excel, and PowerPoint PDF adapters expose the same `TextFallbacks` enum. Use `PdfTextFallbackFeatures.None` when strict standard-font output is preferred, or `AllowSystemFontEmbedding = true` when the converter may embed installed host fonts for Unicode, symbols, and emoji.
+
+### Add e-invoice groundwork
+
+```csharp
+using OfficeIMO.Pdf;
+
+byte[] invoiceXml = File.ReadAllBytes("factur-x.xml");
+
+PdfDocument.Create(new PdfOptions()
+        .UseFacturX(invoiceXml, textFallbacks: PdfTextFallbackFeatures.DocumentFont))
+    .Paragraph("Invoice preview")
+    .Save("invoice.pdf");
 ```
 
 ### Page setup, watermarks, and metadata

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Media.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Media.cs
@@ -130,6 +130,10 @@ internal static partial class PdfWriter {
             double keepTogetherTextHeight = lineHeights.Sum();
             double keepTogetherPanelHeight = panelStyle.PaddingY + keepTogetherTextHeight + panelStyle.PaddingY;
             double keepTogetherAvailableHeight = currentOpts.PageHeight - currentOpts.MarginTop - currentOpts.MarginBottom;
+            if (panelStyle.KeepTogether && panelStyle.PaddingY + panelStyle.PaddingY > keepTogetherAvailableHeight + 0.001D) {
+                throw new ArgumentException("Panel vertical padding and first line height exceed the available page content height.");
+            }
+
             bool keepPanelTogether = panelStyle.KeepTogether && keepTogetherPanelHeight <= keepTogetherAvailableHeight + 0.001;
             if (keepPanelTogether) {
                 double panelHeight = keepTogetherPanelHeight;
@@ -165,6 +169,12 @@ internal static partial class PdfWriter {
 
                     double roomForText = avail - topPad - panelStyle.PaddingY;
                     if (roomForText < minLine) {
+                        if (li == lines.Count - 1) {
+                            EnsurePanelSegmentCanFitLine(topPad + panelStyle.PaddingY, minLine);
+                            NewPage();
+                            continue;
+                        }
+
                         roomForText = avail - topPad;
                     }
 
@@ -182,6 +192,18 @@ internal static partial class PdfWriter {
                     }
 
                     bool lastSeg = (li + take) >= lines.Count;
+                    if (lastSeg && topPad + hsum + panelStyle.PaddingY > avail + 0.001D) {
+                        if (take > 1) {
+                            take--;
+                            hsum -= lineHeights[li + take];
+                            lastSeg = false;
+                        } else {
+                            EnsurePanelSegmentCanFitLine(topPad + panelStyle.PaddingY, minLine);
+                            NewPage();
+                            continue;
+                        }
+                    }
+
                     double panelTop = y;
                     double usedBottomPad = lastSeg ? panelStyle.PaddingY : Math.Max(0, avail - (topPad + hsum));
                     double panelBottom = y - (topPad + hsum + usedBottomPad);

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Media.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Media.cs
@@ -127,13 +127,12 @@ internal static partial class PdfWriter {
                 if (panelSpacingBefore > 0) y -= panelSpacingBefore;
             }
 
-            if (panelStyle.KeepTogether) {
-                double textHeight = lineHeights.Sum();
-                double panelHeight = panelStyle.PaddingY + textHeight + panelStyle.PaddingY;
-                double availableHeight = currentOpts.PageHeight - currentOpts.MarginTop - currentOpts.MarginBottom;
-                if (panelHeight > availableHeight + 0.001) {
-                    throw new ArgumentException("Panel height exceeds the available page content height.");
-                }
+            double keepTogetherTextHeight = lineHeights.Sum();
+            double keepTogetherPanelHeight = panelStyle.PaddingY + keepTogetherTextHeight + panelStyle.PaddingY;
+            double keepTogetherAvailableHeight = currentOpts.PageHeight - currentOpts.MarginTop - currentOpts.MarginBottom;
+            bool keepPanelTogether = panelStyle.KeepTogether && keepTogetherPanelHeight <= keepTogetherAvailableHeight + 0.001;
+            if (keepPanelTogether) {
+                double panelHeight = keepTogetherPanelHeight;
 
                 double panelTop = y;
                 double panelBottom = y - panelHeight;

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Row.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Row.cs
@@ -402,6 +402,10 @@ internal static partial class PdfWriter {
                             double keepTogetherTextHeight = heights.Sum();
                             double keepTogetherPanelHeight = panelStyle.PaddingY + keepTogetherTextHeight + panelStyle.PaddingY;
                             double keepTogetherAvailableHeight = currentOpts.PageHeight - currentOpts.MarginTop - currentOpts.MarginBottom;
+                            if (panelStyle.KeepTogether && panelStyle.PaddingY + panelStyle.PaddingY > keepTogetherAvailableHeight + 0.001D) {
+                                throw new ArgumentException("Panel vertical padding and first line height exceed the available page content height.");
+                            }
+
                             bool keepPanelTogether = panelStyle.KeepTogether && keepTogetherPanelHeight <= keepTogetherAvailableHeight + 0.001;
                             if (keepPanelTogether) {
                                 double panelHeight = keepTogetherPanelHeight;
@@ -441,6 +445,13 @@ internal static partial class PdfWriter {
 
                                 double roomForText = remain - topPad - panelStyle.PaddingY;
                                 if (roomForText < minLine) {
+                                    if (start == lines.Count - 1) {
+                                        EnsurePanelSegmentCanFitLine(topPad + panelStyle.PaddingY, minLine);
+                                        if (consumed > 0) break;
+                                        remain = 0;
+                                        break;
+                                    }
+
                                     roomForText = remain - topPad;
                                 }
 
@@ -459,6 +470,19 @@ internal static partial class PdfWriter {
                                 }
 
                                 bool lastSeg = start + take >= lines.Count;
+                                if (lastSeg && topPad + hsum + panelStyle.PaddingY > remain + 0.001D) {
+                                    if (take > 1) {
+                                        take--;
+                                        hsum -= heights[start + take];
+                                        lastSeg = false;
+                                    } else {
+                                        EnsurePanelSegmentCanFitLine(topPad + panelStyle.PaddingY, minLine);
+                                        if (consumed > 0) break;
+                                        remain = 0;
+                                        break;
+                                    }
+                                }
+
                                 double panelTop = yCol;
                                 double usedBottomPad = lastSeg ? panelStyle.PaddingY : Math.Max(0, remain - (topPad + hsum));
                                 double panelBottom = yCol - (topPad + hsum + usedBottomPad);

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Row.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Row.cs
@@ -399,13 +399,12 @@ internal static partial class PdfWriter {
                                 consumed += spacingBefore;
                             }
 
-                            if (panelStyle.KeepTogether) {
-                                double textHeight = heights.Sum();
-                                double panelHeight = panelStyle.PaddingY + textHeight + panelStyle.PaddingY;
-                                double availableHeight = currentOpts.PageHeight - currentOpts.MarginTop - currentOpts.MarginBottom;
-                                if (panelHeight > availableHeight + 0.001) {
-                                    throw new ArgumentException("Panel height exceeds the available page content height.");
-                                }
+                            double keepTogetherTextHeight = heights.Sum();
+                            double keepTogetherPanelHeight = panelStyle.PaddingY + keepTogetherTextHeight + panelStyle.PaddingY;
+                            double keepTogetherAvailableHeight = currentOpts.PageHeight - currentOpts.MarginTop - currentOpts.MarginBottom;
+                            bool keepPanelTogether = panelStyle.KeepTogether && keepTogetherPanelHeight <= keepTogetherAvailableHeight + 0.001;
+                            if (keepPanelTogether) {
+                                double panelHeight = keepTogetherPanelHeight;
 
                                 if (panelHeight > remain && consumed > 0) break;
                                 if (panelHeight > remain && consumed == 0) { remain = 0; break; }

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.Fallbacks.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.Fallbacks.cs
@@ -127,15 +127,16 @@ internal static partial class PdfWriter {
         var resolved = new System.Collections.Generic.Dictionary<int, PdfStandardFont>();
         var used = new System.Collections.Generic.HashSet<PdfStandardFont>();
         var reservedDocumentSlots = CreateReservedDocumentFontSlots(options);
+        var plannedCandidateIndexes = plan.Segments
+            .Select(segment => segment.FontIndex)
+            .Where(index => index >= 0 && index < fallbackSet.Candidates.Count)
+            .Distinct()
+            .ToHashSet();
 
-        foreach (int index in plan.Segments
-                     .Select(segment => segment.FontIndex)
-                     .Where(index => index >= 0 && index < fallbackSet.Candidates.Count)
-                     .Distinct()
-                     .OrderBy(index => index)) {
+        foreach (int index in plannedCandidateIndexes.OrderBy(index => index)) {
             PdfEmbeddedFontFallbackCandidate candidate = fallbackSet.Candidates[index];
             PdfStandardFont requested = PdfStandardFontMapper.GetFontFamily(fallbackSet.FontSlots[index]);
-            if (CanUseFallbackFontSlot(requested, candidate, selectedFamily, used, reservedDocumentSlots, options)) {
+            if (CanUseFallbackFontSlot(requested, candidate, fallbackSet, plannedCandidateIndexes, selectedFamily, used, reservedDocumentSlots, options)) {
                 resolved[index] = requested;
                 used.Add(requested);
                 continue;
@@ -143,7 +144,7 @@ internal static partial class PdfWriter {
 
             PdfStandardFont? replacement = null;
             foreach (PdfStandardFont family in FallbackFontSlotFamilies) {
-                if (CanUseFallbackFontSlot(family, candidate, selectedFamily, used, reservedDocumentSlots, options)) {
+                if (CanUseFallbackFontSlot(family, candidate, fallbackSet, plannedCandidateIndexes, selectedFamily, used, reservedDocumentSlots, options)) {
                     replacement = family;
                     break;
                 }
@@ -165,6 +166,8 @@ internal static partial class PdfWriter {
     private static bool CanUseFallbackFontSlot(
         PdfStandardFont family,
         PdfEmbeddedFontFallbackCandidate candidate,
+        PdfEmbeddedFontFallbackSet fallbackSet,
+        System.Collections.Generic.HashSet<int> plannedCandidateIndexes,
         PdfStandardFont selectedFamily,
         System.Collections.Generic.HashSet<PdfStandardFont> used,
         System.Collections.Generic.HashSet<PdfStandardFont> reservedDocumentSlots,
@@ -173,7 +176,7 @@ internal static partial class PdfWriter {
         return normalized != selectedFamily &&
                !used.Contains(normalized) &&
                !reservedDocumentSlots.Contains(normalized) &&
-               FontFamilySlotIsEmptyOrCandidate(normalized, candidate, options);
+               FontFamilySlotIsEmptyOrCandidate(normalized, candidate, fallbackSet, plannedCandidateIndexes, options);
     }
 
     private static System.Collections.Generic.HashSet<PdfStandardFont> CreateReservedDocumentFontSlots(PdfOptions? options) {
@@ -218,7 +221,12 @@ internal static partial class PdfWriter {
         return 1;
     }
 
-    private static bool FontFamilySlotIsEmptyOrCandidate(PdfStandardFont family, PdfEmbeddedFontFallbackCandidate candidate, PdfOptions? options) {
+    private static bool FontFamilySlotIsEmptyOrCandidate(
+        PdfStandardFont family,
+        PdfEmbeddedFontFallbackCandidate candidate,
+        PdfEmbeddedFontFallbackSet fallbackSet,
+        System.Collections.Generic.HashSet<int> plannedCandidateIndexes,
+        PdfOptions? options) {
         if (options == null) {
             return true;
         }
@@ -226,12 +234,28 @@ internal static partial class PdfWriter {
         foreach (PdfStandardFont variant in EnumerateFontFamilyVariants(family)) {
             if (options.TryGetEmbeddedStandardFont(variant, out PdfEmbeddedFont? embeddedFont) &&
                 embeddedFont != null &&
-                !embeddedFont.DataSnapshot.SequenceEqual(candidate.DataSnapshot)) {
+                !embeddedFont.DataSnapshot.SequenceEqual(candidate.DataSnapshot) &&
+                !EmbeddedFontMatchesUnusedFallbackCandidate(embeddedFont, fallbackSet, plannedCandidateIndexes)) {
                 return false;
             }
         }
 
         return true;
+    }
+
+    private static bool EmbeddedFontMatchesUnusedFallbackCandidate(
+        PdfEmbeddedFont embeddedFont,
+        PdfEmbeddedFontFallbackSet fallbackSet,
+        System.Collections.Generic.HashSet<int> plannedCandidateIndexes) {
+        byte[] embeddedData = embeddedFont.DataSnapshot;
+        for (int index = 0; index < fallbackSet.Candidates.Count; index++) {
+            if (!plannedCandidateIndexes.Contains(index) &&
+                embeddedData.SequenceEqual(fallbackSet.Candidates[index].DataSnapshot)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static System.Collections.Generic.IEnumerable<PdfStandardFont> EnumerateFontFamilyVariants(PdfStandardFont family) {

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.Fallbacks.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.Fallbacks.cs
@@ -113,6 +113,10 @@ internal static partial class PdfWriter {
         }
 
         fallbackSet.RegisterFonts(options, fontSlots);
+        foreach (PdfStandardFont slot in fontSlots.Values) {
+            options.MarkEmbeddedFallbackFontFamilySlotUsed(slot);
+        }
+
         plannedRuns = plan.ToTextRuns(fontSlots, styleTemplate);
         return true;
     }
@@ -234,7 +238,8 @@ internal static partial class PdfWriter {
             if (options.TryGetEmbeddedStandardFont(variant, out PdfEmbeddedFont? embeddedFont) &&
                 embeddedFont != null &&
                 !embeddedFont.DataSnapshot.SequenceEqual(candidate.DataSnapshot) &&
-                !EmbeddedFontMatchesUnusedFallbackCandidate(embeddedFont, fallbackSet, plannedCandidateIndexes)) {
+                (options.IsEmbeddedFallbackFontFamilySlotUsed(family) ||
+                 !EmbeddedFontMatchesUnusedFallbackCandidate(embeddedFont, fallbackSet, plannedCandidateIndexes))) {
                 return false;
             }
         }

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.Fallbacks.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.Fallbacks.cs
@@ -50,7 +50,7 @@ internal static partial class PdfWriter {
 
         for (int index = 0; index < text.Length;) {
             char ch = text[index];
-            if (ch == '\n' || ch == '\r' || ch == '\t') {
+            if (IsFallbackLayoutSeparator(ch)) {
                 if (ch == '\t') {
                     runs.Add(TextRun.Tab(run.TabLeader, run.TabAlignment));
                 } else {
@@ -65,30 +65,21 @@ internal static partial class PdfWriter {
             }
 
             int segmentStart = index;
-            if (ch == ' ') {
-                while (index < text.Length && text[index] == ' ') {
-                    index++;
-                }
-
-                runs.Add(CreateStyledTextRun(text.Substring(segmentStart, index - segmentStart), run, run.Font));
-                continue;
-            }
-
+            bool selectedFontCanWrite = CanWriteNextFallbackScalarWithSelectedFont(text, index, fontForRun, options);
+            index += GetNextFallbackScalarLength(text, index);
             while (index < text.Length &&
-                   text[index] != ' ' &&
-                   text[index] != '\n' &&
-                   text[index] != '\r' &&
-                   text[index] != '\t') {
-                index++;
+                   !IsFallbackLayoutSeparator(text[index]) &&
+                   selectedFontCanWrite == CanWriteNextFallbackScalarWithSelectedFont(text, index, fontForRun, options)) {
+                index += GetNextFallbackScalarLength(text, index);
             }
 
-            string token = text.Substring(segmentStart, index - segmentStart);
-            if (CanWriteTextWithSelectedFont(token, fontForRun, options)) {
-                runs.Add(CreateStyledTextRun(token, run, run.Font));
+            string segment = text.Substring(segmentStart, index - segmentStart);
+            if (selectedFontCanWrite) {
+                runs.Add(CreateStyledTextRun(segment, run, run.Font));
                 continue;
             }
 
-            if (!TryPlanFallbackTextRuns(fallbackSet, token, run, options, fontForRun, out System.Collections.Generic.IReadOnlyList<TextRun> fallbackRuns)) {
+            if (!TryPlanFallbackTextRuns(fallbackSet, segment, run, options, fontForRun, out System.Collections.Generic.IReadOnlyList<TextRun> fallbackRuns)) {
                 plannedRuns = Array.Empty<TextRun>();
                 return false;
             }
@@ -113,7 +104,7 @@ internal static partial class PdfWriter {
             value,
             shapingMode: options?.TextShapingModeSnapshot ?? PdfTextShapingMode.UnicodeScalar);
         if (!plan.IsFullyCovered ||
-            !TryResolveFallbackFontSlots(fallbackSet, selectedFont, options, out System.Collections.Generic.IReadOnlyList<PdfStandardFont> fontSlots)) {
+            !TryResolveFallbackFontSlots(fallbackSet, plan, selectedFont, options, out System.Collections.Generic.IReadOnlyDictionary<int, PdfStandardFont> fontSlots)) {
             return false;
         }
 
@@ -128,40 +119,46 @@ internal static partial class PdfWriter {
 
     private static bool TryResolveFallbackFontSlots(
         PdfEmbeddedFontFallbackSet fallbackSet,
+        PdfTextFallbackPlan plan,
         PdfStandardFont selectedFont,
         PdfOptions? options,
-        out System.Collections.Generic.IReadOnlyList<PdfStandardFont> fontSlots) {
+        out System.Collections.Generic.IReadOnlyDictionary<int, PdfStandardFont> fontSlots) {
         PdfStandardFont selectedFamily = PdfStandardFontMapper.GetFontFamily(selectedFont);
-        var resolved = new System.Collections.Generic.List<PdfStandardFont>(fallbackSet.Candidates.Count);
+        var resolved = new System.Collections.Generic.Dictionary<int, PdfStandardFont>();
         var used = new System.Collections.Generic.HashSet<PdfStandardFont>();
+        var reservedDocumentSlots = CreateReservedDocumentFontSlots(options);
 
-        for (int index = 0; index < fallbackSet.Candidates.Count; index++) {
+        foreach (int index in plan.Segments
+                     .Select(segment => segment.FontIndex)
+                     .Where(index => index >= 0 && index < fallbackSet.Candidates.Count)
+                     .Distinct()
+                     .OrderBy(index => index)) {
             PdfEmbeddedFontFallbackCandidate candidate = fallbackSet.Candidates[index];
             PdfStandardFont requested = PdfStandardFontMapper.GetFontFamily(fallbackSet.FontSlots[index]);
-            if (CanUseFallbackFontSlot(requested, candidate, selectedFamily, used, options)) {
-                resolved.Add(requested);
+            if (CanUseFallbackFontSlot(requested, candidate, selectedFamily, used, reservedDocumentSlots, options)) {
+                resolved[index] = requested;
                 used.Add(requested);
                 continue;
             }
 
             PdfStandardFont? replacement = null;
             foreach (PdfStandardFont family in FallbackFontSlotFamilies) {
-                if (CanUseFallbackFontSlot(family, candidate, selectedFamily, used, options)) {
+                if (CanUseFallbackFontSlot(family, candidate, selectedFamily, used, reservedDocumentSlots, options)) {
                     replacement = family;
                     break;
                 }
             }
 
             if (!replacement.HasValue) {
-                fontSlots = Array.Empty<PdfStandardFont>();
+                fontSlots = new System.Collections.Generic.Dictionary<int, PdfStandardFont>();
                 return false;
             }
 
-            resolved.Add(replacement.Value);
+            resolved[index] = replacement.Value;
             used.Add(replacement.Value);
         }
 
-        fontSlots = resolved.AsReadOnly();
+        fontSlots = resolved;
         return true;
     }
 
@@ -170,11 +167,43 @@ internal static partial class PdfWriter {
         PdfEmbeddedFontFallbackCandidate candidate,
         PdfStandardFont selectedFamily,
         System.Collections.Generic.HashSet<PdfStandardFont> used,
+        System.Collections.Generic.HashSet<PdfStandardFont> reservedDocumentSlots,
         PdfOptions? options) {
         PdfStandardFont normalized = PdfStandardFontMapper.GetFontFamily(family);
         return normalized != selectedFamily &&
                !used.Contains(normalized) &&
+               !reservedDocumentSlots.Contains(normalized) &&
                FontFamilySlotIsEmptyOrCandidate(normalized, candidate, options);
+    }
+
+    private static System.Collections.Generic.HashSet<PdfStandardFont> CreateReservedDocumentFontSlots(PdfOptions? options) {
+        var reserved = new System.Collections.Generic.HashSet<PdfStandardFont>();
+        if (options == null) {
+            return reserved;
+        }
+
+        PdfOptions.AddRegisteredFontFamilySlot(reserved, options.DefaultFont);
+        PdfOptions.AddRegisteredFontFamilySlot(reserved, options.HeaderFont);
+        PdfOptions.AddRegisteredFontFamilySlot(reserved, options.FooterFont);
+        return reserved;
+    }
+
+    private static bool IsFallbackLayoutSeparator(char ch) =>
+        ch == '\n' || ch == '\r' || ch == '\t';
+
+    private static bool CanWriteNextFallbackScalarWithSelectedFont(string text, int index, PdfStandardFont fontForRun, PdfOptions? options) {
+        int length = GetNextFallbackScalarLength(text, index);
+        return CanWriteTextWithSelectedFont(text.Substring(index, length), fontForRun, options);
+    }
+
+    private static int GetNextFallbackScalarLength(string text, int index) {
+        if (index + 1 < text.Length &&
+            char.IsHighSurrogate(text[index]) &&
+            char.IsLowSurrogate(text[index + 1])) {
+            return 2;
+        }
+
+        return 1;
     }
 
     private static bool FontFamilySlotIsEmptyOrCandidate(PdfStandardFont family, PdfEmbeddedFontFallbackCandidate candidate, PdfOptions? options) {

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.Fallbacks.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.Fallbacks.cs
@@ -127,11 +127,10 @@ internal static partial class PdfWriter {
         var resolved = new System.Collections.Generic.Dictionary<int, PdfStandardFont>();
         var used = new System.Collections.Generic.HashSet<PdfStandardFont>();
         var reservedDocumentSlots = CreateReservedDocumentFontSlots(options);
-        var plannedCandidateIndexes = plan.Segments
+        var plannedCandidateIndexes = new System.Collections.Generic.HashSet<int>(plan.Segments
             .Select(segment => segment.FontIndex)
             .Where(index => index >= 0 && index < fallbackSet.Candidates.Count)
-            .Distinct()
-            .ToHashSet();
+            .Distinct());
 
         foreach (int index in plannedCandidateIndexes.OrderBy(index => index)) {
             PdfEmbeddedFontFallbackCandidate candidate = fallbackSet.Candidates[index];

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.Fallbacks.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.Fallbacks.cs
@@ -65,12 +65,12 @@ internal static partial class PdfWriter {
             }
 
             int segmentStart = index;
-            bool selectedFontCanWrite = CanWriteNextFallbackScalarWithSelectedFont(text, index, fontForRun, options);
-            index += GetNextFallbackScalarLength(text, index);
+            bool selectedFontCanWrite = TryGetSelectedFontCoveredFallbackTextLength(text, index, fontForRun, options, out int coveredLength);
+            index += coveredLength;
             while (index < text.Length &&
                    !IsFallbackLayoutSeparator(text[index]) &&
-                   selectedFontCanWrite == CanWriteNextFallbackScalarWithSelectedFont(text, index, fontForRun, options)) {
-                index += GetNextFallbackScalarLength(text, index);
+                   selectedFontCanWrite == TryGetSelectedFontCoveredFallbackTextLength(text, index, fontForRun, options, out coveredLength)) {
+                index += coveredLength;
             }
 
             string segment = text.Substring(segmentStart, index - segmentStart);
@@ -191,8 +191,20 @@ internal static partial class PdfWriter {
     private static bool IsFallbackLayoutSeparator(char ch) =>
         ch == '\n' || ch == '\r' || ch == '\t';
 
-    private static bool CanWriteNextFallbackScalarWithSelectedFont(string text, int index, PdfStandardFont fontForRun, PdfOptions? options) {
-        int length = GetNextFallbackScalarLength(text, index);
+    private static bool TryGetSelectedFontCoveredFallbackTextLength(string text, int index, PdfStandardFont fontForRun, PdfOptions? options, out int length) {
+        length = GetNextFallbackScalarLength(text, index);
+        if (options != null &&
+            options.TryGetEmbeddedStandardFontProgram(fontForRun, out PdfTrueTypeFontProgram? fontProgram) &&
+            fontProgram != null) {
+            return TryGetCoveredTextLength(text, index, fontProgram, options.TextShapingModeSnapshot, out length);
+        }
+
+        if (options != null &&
+            options.TryGetEmbeddedStandardOpenTypeCffFontProgram(fontForRun, out PdfOpenTypeCffFontProgram? cffFontProgram) &&
+            cffFontProgram != null) {
+            return TryGetCoveredTextLength(text, index, cffFontProgram, options.TextShapingModeSnapshot, out length);
+        }
+
         return CanWriteTextWithSelectedFont(text.Substring(index, length), fontForRun, options);
     }
 

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.Fallbacks.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.Fallbacks.cs
@@ -1,0 +1,203 @@
+namespace OfficeIMO.Pdf;
+
+internal static partial class PdfWriter {
+    private static readonly PdfStandardFont[] FallbackFontSlotFamilies = new[] {
+        PdfStandardFont.Helvetica,
+        PdfStandardFont.TimesRoman,
+        PdfStandardFont.Courier
+    };
+
+    private static System.Collections.Generic.IReadOnlyList<TextRun> NormalizeFallbackRuns(System.Collections.Generic.IEnumerable<TextRun> runs, PdfStandardFont baseFont, PdfOptions? options) {
+        Guard.NotNull(runs, nameof(runs));
+        PdfEmbeddedFontFallbackSet? fallbackSet = options?.EmbeddedFontFallbacksSnapshot;
+        if (fallbackSet == null) {
+            return runs as System.Collections.Generic.IReadOnlyList<TextRun> ?? runs.ToArray();
+        }
+
+        var normalized = new System.Collections.Generic.List<TextRun>();
+        foreach (TextRun run in runs) {
+            if (CanWriteRunWithSelectedFont(run, baseFont, options)) {
+                normalized.Add(run);
+                continue;
+            }
+
+            if (TryPlanFallbackTextRuns(fallbackSet, run.Text, run, options, ResolveFontForRun(run, baseFont), out System.Collections.Generic.IReadOnlyList<TextRun> plannedRuns) ||
+                TryPlanFallbackRunsPreservingSelectedFont(run, baseFont, options, fallbackSet, out plannedRuns)) {
+                normalized.AddRange(plannedRuns);
+            } else {
+                normalized.Add(run);
+            }
+        }
+
+        return normalized;
+    }
+
+    private static bool TryPlanFallbackRunsPreservingSelectedFont(
+        TextRun run,
+        PdfStandardFont baseFont,
+        PdfOptions? options,
+        PdfEmbeddedFontFallbackSet fallbackSet,
+        out System.Collections.Generic.IReadOnlyList<TextRun> plannedRuns) {
+        plannedRuns = Array.Empty<TextRun>();
+        string text = run.Text ?? string.Empty;
+        if (text.Length == 0 || IsLayoutControlRun(run)) {
+            plannedRuns = new[] { run };
+            return true;
+        }
+
+        PdfStandardFont fontForRun = ResolveFontForRun(run, baseFont);
+        var runs = new System.Collections.Generic.List<TextRun>();
+
+        for (int index = 0; index < text.Length;) {
+            char ch = text[index];
+            if (ch == '\n' || ch == '\r' || ch == '\t') {
+                if (ch == '\t') {
+                    runs.Add(TextRun.Tab(run.TabLeader, run.TabAlignment));
+                } else {
+                    runs.Add(TextRun.LineBreak());
+                    if (ch == '\r' && index + 1 < text.Length && text[index + 1] == '\n') {
+                        index++;
+                    }
+                }
+
+                index++;
+                continue;
+            }
+
+            int segmentStart = index;
+            if (ch == ' ') {
+                while (index < text.Length && text[index] == ' ') {
+                    index++;
+                }
+
+                runs.Add(CreateStyledTextRun(text.Substring(segmentStart, index - segmentStart), run, run.Font));
+                continue;
+            }
+
+            while (index < text.Length &&
+                   text[index] != ' ' &&
+                   text[index] != '\n' &&
+                   text[index] != '\r' &&
+                   text[index] != '\t') {
+                index++;
+            }
+
+            string token = text.Substring(segmentStart, index - segmentStart);
+            if (CanWriteTextWithSelectedFont(token, fontForRun, options)) {
+                runs.Add(CreateStyledTextRun(token, run, run.Font));
+                continue;
+            }
+
+            if (!TryPlanFallbackTextRuns(fallbackSet, token, run, options, fontForRun, out System.Collections.Generic.IReadOnlyList<TextRun> fallbackRuns)) {
+                plannedRuns = Array.Empty<TextRun>();
+                return false;
+            }
+
+            runs.AddRange(fallbackRuns);
+        }
+
+        plannedRuns = runs.AsReadOnly();
+        return true;
+    }
+
+    private static bool TryPlanFallbackTextRuns(
+        PdfEmbeddedFontFallbackSet fallbackSet,
+        string? text,
+        TextRun styleTemplate,
+        PdfOptions? options,
+        PdfStandardFont selectedFont,
+        out System.Collections.Generic.IReadOnlyList<TextRun> plannedRuns) {
+        plannedRuns = Array.Empty<TextRun>();
+        string value = text ?? string.Empty;
+        PdfTextFallbackPlan plan = fallbackSet.PlanText(
+            value,
+            shapingMode: options?.TextShapingModeSnapshot ?? PdfTextShapingMode.UnicodeScalar);
+        if (!plan.IsFullyCovered ||
+            !TryResolveFallbackFontSlots(fallbackSet, selectedFont, options, out System.Collections.Generic.IReadOnlyList<PdfStandardFont> fontSlots)) {
+            return false;
+        }
+
+        if (options == null) {
+            return false;
+        }
+
+        fallbackSet.RegisterFonts(options, fontSlots);
+        plannedRuns = plan.ToTextRuns(fontSlots, styleTemplate);
+        return true;
+    }
+
+    private static bool TryResolveFallbackFontSlots(
+        PdfEmbeddedFontFallbackSet fallbackSet,
+        PdfStandardFont selectedFont,
+        PdfOptions? options,
+        out System.Collections.Generic.IReadOnlyList<PdfStandardFont> fontSlots) {
+        PdfStandardFont selectedFamily = PdfStandardFontMapper.GetFontFamily(selectedFont);
+        var resolved = new System.Collections.Generic.List<PdfStandardFont>(fallbackSet.Candidates.Count);
+        var used = new System.Collections.Generic.HashSet<PdfStandardFont>();
+
+        for (int index = 0; index < fallbackSet.Candidates.Count; index++) {
+            PdfEmbeddedFontFallbackCandidate candidate = fallbackSet.Candidates[index];
+            PdfStandardFont requested = PdfStandardFontMapper.GetFontFamily(fallbackSet.FontSlots[index]);
+            if (CanUseFallbackFontSlot(requested, candidate, selectedFamily, used, options)) {
+                resolved.Add(requested);
+                used.Add(requested);
+                continue;
+            }
+
+            PdfStandardFont? replacement = null;
+            foreach (PdfStandardFont family in FallbackFontSlotFamilies) {
+                if (CanUseFallbackFontSlot(family, candidate, selectedFamily, used, options)) {
+                    replacement = family;
+                    break;
+                }
+            }
+
+            if (!replacement.HasValue) {
+                fontSlots = Array.Empty<PdfStandardFont>();
+                return false;
+            }
+
+            resolved.Add(replacement.Value);
+            used.Add(replacement.Value);
+        }
+
+        fontSlots = resolved.AsReadOnly();
+        return true;
+    }
+
+    private static bool CanUseFallbackFontSlot(
+        PdfStandardFont family,
+        PdfEmbeddedFontFallbackCandidate candidate,
+        PdfStandardFont selectedFamily,
+        System.Collections.Generic.HashSet<PdfStandardFont> used,
+        PdfOptions? options) {
+        PdfStandardFont normalized = PdfStandardFontMapper.GetFontFamily(family);
+        return normalized != selectedFamily &&
+               !used.Contains(normalized) &&
+               FontFamilySlotIsEmptyOrCandidate(normalized, candidate, options);
+    }
+
+    private static bool FontFamilySlotIsEmptyOrCandidate(PdfStandardFont family, PdfEmbeddedFontFallbackCandidate candidate, PdfOptions? options) {
+        if (options == null) {
+            return true;
+        }
+
+        foreach (PdfStandardFont variant in EnumerateFontFamilyVariants(family)) {
+            if (options.TryGetEmbeddedStandardFont(variant, out PdfEmbeddedFont? embeddedFont) &&
+                embeddedFont != null &&
+                !embeddedFont.DataSnapshot.SequenceEqual(candidate.DataSnapshot)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static System.Collections.Generic.IEnumerable<PdfStandardFont> EnumerateFontFamilyVariants(PdfStandardFont family) {
+        PdfStandardFont normalized = PdfStandardFontMapper.GetFontFamily(family);
+        yield return normalized;
+        yield return PdfStandardFontMapper.GetStyledFont(normalized, bold: true, italic: false);
+        yield return PdfStandardFontMapper.GetStyledFont(normalized, bold: false, italic: true);
+        yield return PdfStandardFontMapper.GetStyledFont(normalized, bold: true, italic: true);
+    }
+}

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.cs
@@ -1225,100 +1225,6 @@ internal static partial class PdfWriter {
     private static bool IsLongTokenDelimiterBreakChar(char value) =>
         Array.IndexOf(LongTokenDelimiterBreakChars, value) >= 0;
 
-    private static System.Collections.Generic.IReadOnlyList<TextRun> NormalizeFallbackRuns(System.Collections.Generic.IEnumerable<TextRun> runs, PdfStandardFont baseFont, PdfOptions? options) {
-        Guard.NotNull(runs, nameof(runs));
-        PdfEmbeddedFontFallbackSet? fallbackSet = options?.EmbeddedFontFallbacksSnapshot;
-        if (fallbackSet == null) {
-            return runs as System.Collections.Generic.IReadOnlyList<TextRun> ?? runs.ToArray();
-        }
-
-        var normalized = new System.Collections.Generic.List<TextRun>();
-        foreach (TextRun run in runs) {
-            if (CanWriteRunWithSelectedFont(run, baseFont, options)) {
-                normalized.Add(run);
-                continue;
-            }
-
-            PdfTextShapingMode shapingMode = options?.TextShapingModeSnapshot ?? PdfTextShapingMode.UnicodeScalar;
-            if (fallbackSet.TryPlanTextRuns(run.Text, out System.Collections.Generic.IReadOnlyList<TextRun> plannedRuns, styleTemplate: run, shapingMode: shapingMode) ||
-                TryPlanFallbackRunsPreservingSelectedFont(run, baseFont, options, fallbackSet, out plannedRuns)) {
-                normalized.AddRange(plannedRuns);
-            } else {
-                normalized.Add(run);
-            }
-        }
-
-        return normalized;
-    }
-
-    private static bool TryPlanFallbackRunsPreservingSelectedFont(
-        TextRun run,
-        PdfStandardFont baseFont,
-        PdfOptions? options,
-        PdfEmbeddedFontFallbackSet fallbackSet,
-        out System.Collections.Generic.IReadOnlyList<TextRun> plannedRuns) {
-        plannedRuns = Array.Empty<TextRun>();
-        string text = run.Text ?? string.Empty;
-        if (text.Length == 0 || IsLayoutControlRun(run)) {
-            plannedRuns = new[] { run };
-            return true;
-        }
-
-        PdfStandardFont fontForRun = ResolveFontForRun(run, baseFont);
-        var runs = new System.Collections.Generic.List<TextRun>();
-        int selectedStart = -1;
-
-        void FlushSelected(int endIndex) {
-            if (selectedStart < 0 || endIndex <= selectedStart) {
-                return;
-            }
-
-            runs.Add(CreateStyledTextRun(text.Substring(selectedStart, endIndex - selectedStart), run, run.Font));
-            selectedStart = -1;
-        }
-
-        for (int index = 0; index < text.Length;) {
-            int scalarStart = index;
-            int scalar = ReadScalar(text, ref index);
-            if (scalar == '\n' || scalar == '\r' || scalar == '\t') {
-                FlushSelected(scalarStart);
-                if (scalar == '\t') {
-                    runs.Add(TextRun.Tab(run.TabLeader, run.TabAlignment));
-                } else {
-                    runs.Add(TextRun.LineBreak());
-                    if (scalar == '\r' && index < text.Length && text[index] == '\n') {
-                        index++;
-                    }
-                }
-
-                continue;
-            }
-
-            if (TryGetSelectedTextLength(text, scalarStart, fontForRun, options, out int selectedLength)) {
-                if (selectedStart < 0) {
-                    selectedStart = scalarStart;
-                }
-
-                index = scalarStart + selectedLength;
-                continue;
-            }
-
-            FlushSelected(scalarStart);
-            string scalarText = text.Substring(scalarStart, index - scalarStart);
-            PdfTextShapingMode shapingMode = options?.TextShapingModeSnapshot ?? PdfTextShapingMode.UnicodeScalar;
-            if (!fallbackSet.TryPlanTextRuns(scalarText, out System.Collections.Generic.IReadOnlyList<TextRun> fallbackRuns, styleTemplate: run, shapingMode: shapingMode)) {
-                plannedRuns = Array.Empty<TextRun>();
-                return false;
-            }
-
-            runs.AddRange(fallbackRuns);
-        }
-
-        FlushSelected(text.Length);
-        plannedRuns = runs.AsReadOnly();
-        return true;
-    }
-
     private static TextRun CreateStyledTextRun(string text, TextRun styleTemplate, PdfStandardFont? font) {
         bool keepLink = !string.IsNullOrWhiteSpace(text) &&
             (styleTemplate.LinkUri != null || styleTemplate.LinkDestinationName != null);
@@ -1346,6 +1252,10 @@ internal static partial class PdfWriter {
         }
 
         PdfStandardFont fontForRun = ResolveFontForRun(run, baseFont);
+        return CanWriteTextWithSelectedFont(text, fontForRun, options);
+    }
+
+    private static bool CanWriteTextWithSelectedFont(string text, PdfStandardFont fontForRun, PdfOptions? options) {
         if (options != null &&
             options.TryGetEmbeddedStandardFontProgram(fontForRun, out PdfTrueTypeFontProgram? fontProgram) &&
             fontProgram != null) {
@@ -1370,25 +1280,6 @@ internal static partial class PdfWriter {
                 : run.Italic
                     ? ChooseItalic(runBaseFont)
                     : runBaseFont;
-    }
-
-    private static bool TryGetSelectedTextLength(string text, int index, PdfStandardFont fontForRun, PdfOptions? options, out int length) {
-        if (options != null &&
-            options.TryGetEmbeddedStandardFontProgram(fontForRun, out PdfTrueTypeFontProgram? fontProgram) &&
-            fontProgram != null) {
-            return TryGetCoveredTextLength(text, index, fontProgram, options.TextShapingModeSnapshot, out length);
-        }
-
-        if (options != null &&
-            options.TryGetEmbeddedStandardOpenTypeCffFontProgram(fontForRun, out PdfOpenTypeCffFontProgram? cffFontProgram) &&
-            cffFontProgram != null) {
-            return TryGetCoveredTextLength(text, index, cffFontProgram, options.TextShapingModeSnapshot, out length);
-        }
-
-        int endIndex = index;
-        _ = ReadScalar(text, ref endIndex);
-        length = endIndex - index;
-        return PdfWinAnsiEncoding.CanEncode(text.Substring(index, length), out _);
     }
 
     private static bool CanWriteWithEmbeddedFont(string text, PdfTrueTypeFontProgram fontProgram, PdfTextShapingMode shapingMode = PdfTextShapingMode.UnicodeScalar) {

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Fonts.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Fonts.cs
@@ -39,7 +39,7 @@ public static partial class PowerPointPdfConverterExtensions {
 
     private static void RegisterPresentationFonts(PdfCore.PdfOptions pdfOptions, PptCore.PowerPointPresentation presentation, PowerPointPdfSaveOptions options, bool preserveConfiguredFontSlots) {
         var registeredFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        HashSet<PdfCore.PdfStandardFont> registeredFontSlots = CreateRegisteredFontSlots(pdfOptions, preserveConfiguredFontSlots);
+        HashSet<PdfCore.PdfStandardFont> registeredFontSlots = pdfOptions.CreateRegisteredFontFamilySlots(preserveConfiguredFontSlots);
         double pageWidth = presentation.SlideSize.WidthPoints;
         double pageHeight = presentation.SlideSize.HeightPoints;
         IReadOnlyList<PptCore.PowerPointSlide> slides = presentation.Slides;
@@ -126,39 +126,8 @@ public static partial class PowerPointPdfConverterExtensions {
     }
 
     private static void RegisterPresentationFontCandidate(string? familyName, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots) {
-        if (string.IsNullOrWhiteSpace(familyName)) {
-            return;
+        if (PdfCore.PdfOptions.TryAddOfficeFontFamilyKey(familyName, registeredFamilies, normalizeKey: null, out string trimmedFamilyName)) {
+            pdfOptions.TryRegisterMappedOfficeFontFamily(trimmedFamilyName, registeredFontSlots, embedSystemFont: true, out _);
         }
-
-        string trimmedFamilyName = familyName!.Trim();
-        if (!registeredFamilies.Add(trimmedFamilyName)) {
-            return;
-        }
-
-        if (PdfCore.PdfStandardFontMapper.TryMapFontFamily(trimmedFamilyName, out PdfCore.PdfStandardFont standardFont)) {
-            PdfCore.PdfStandardFont fontFamily = PdfCore.PdfStandardFontMapper.GetFontFamily(standardFont);
-            if (registeredFontSlots.Add(fontFamily)) {
-                pdfOptions.RegisterOfficeFontFamily(trimmedFamilyName, fontFamily);
-            }
-        }
-    }
-
-    private static HashSet<PdfCore.PdfStandardFont> CreateRegisteredFontSlots(PdfCore.PdfOptions pdfOptions, bool preserveConfiguredFontSlots) {
-        var registeredFontSlots = new HashSet<PdfCore.PdfStandardFont>();
-        if (preserveConfiguredFontSlots) {
-            AddRegisteredFontSlot(registeredFontSlots, pdfOptions.DefaultFont);
-            AddRegisteredFontSlot(registeredFontSlots, pdfOptions.HeaderFont);
-            AddRegisteredFontSlot(registeredFontSlots, pdfOptions.FooterFont);
-        }
-
-        foreach (PdfCore.PdfStandardFont embeddedFont in pdfOptions.EmbeddedFonts.Keys) {
-            AddRegisteredFontSlot(registeredFontSlots, embeddedFont);
-        }
-
-        return registeredFontSlots;
-    }
-
-    private static void AddRegisteredFontSlot(HashSet<PdfCore.PdfStandardFont> registeredFontSlots, PdfCore.PdfStandardFont font) {
-        registeredFontSlots.Add(PdfCore.PdfStandardFontMapper.GetFontFamily(font));
     }
 }

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Fonts.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.Fonts.cs
@@ -16,28 +16,38 @@ public static partial class PowerPointPdfConverterExtensions {
         pdfOptions.Margins = PdfCore.PageMargins.Uniform(0);
         bool preserveConfiguredFontSlots = options.PdfOptions != null;
         if (!string.IsNullOrWhiteSpace(options.FontFamily) &&
-            TryApplyPdfFontFamily(options.FontFamily, pdfOptions)) {
+            TryApplyPdfFontFamily(options.FontFamily, pdfOptions, options.AllowSystemFontEmbedding)) {
             preserveConfiguredFontSlots = true;
         }
 
-        RegisterPresentationFonts(pdfOptions, presentation, options, preserveConfiguredFontSlots);
-        ApplyDefaultEmbeddedFontFallback(pdfOptions, options, preserveConfiguredFontSlots);
+        HashSet<PdfCore.PdfStandardFont> registeredFontSlots = RegisterPresentationFonts(pdfOptions, presentation, options, preserveConfiguredFontSlots);
+        ApplyTextFallbacks(pdfOptions, options, preserveConfiguredFontSlots, registeredFontSlots);
         return pdfOptions;
     }
 
-    private static void ApplyDefaultEmbeddedFontFallback(PdfCore.PdfOptions pdfOptions, PowerPointPdfSaveOptions options, bool preserveConfiguredFontSlots) {
-        if (options.PdfOptions == null &&
-            !preserveConfiguredFontSlots &&
-            !pdfOptions.HasEmbeddedStandardFontFamily(pdfOptions.DefaultFont)) {
-            pdfOptions.TryUseDefaultDocumentFontFallback(requireEmbeddedFont: true);
+    private static void ApplyTextFallbacks(
+        PdfCore.PdfOptions pdfOptions,
+        PowerPointPdfSaveOptions options,
+        bool preserveConfiguredFontSlots,
+        IEnumerable<PdfCore.PdfStandardFont> reservedFontSlots) {
+        if (!options.AllowSystemFontEmbedding ||
+            options.TextFallbacks == PdfCore.PdfTextFallbackFeatures.None) {
+            return;
         }
+
+        PdfCore.PdfTextFallbackFeatures fallbackFeatures = options.TextFallbacks;
+        if (preserveConfiguredFontSlots || pdfOptions.HasEmbeddedStandardFontFamily(pdfOptions.DefaultFont)) {
+            fallbackFeatures &= ~PdfCore.PdfTextFallbackFeatures.DocumentFont;
+        }
+
+        pdfOptions.UseTextFallbacks(fallbackFeatures, reservedFontSlots, options.AllowSystemFontEmbedding);
     }
 
-    private static bool TryApplyPdfFontFamily(string? familyName, PdfCore.PdfOptions pdfOptions, bool requireEmbeddedFont = false) {
-        return pdfOptions.TryUseOfficeFontFamily(familyName, embedSystemFont: true, requireEmbeddedFont: requireEmbeddedFont);
+    private static bool TryApplyPdfFontFamily(string? familyName, PdfCore.PdfOptions pdfOptions, bool embedSystemFont, bool requireEmbeddedFont = false) {
+        return pdfOptions.TryUseOfficeFontFamily(familyName, embedSystemFont, requireEmbeddedFont);
     }
 
-    private static void RegisterPresentationFonts(PdfCore.PdfOptions pdfOptions, PptCore.PowerPointPresentation presentation, PowerPointPdfSaveOptions options, bool preserveConfiguredFontSlots) {
+    private static HashSet<PdfCore.PdfStandardFont> RegisterPresentationFonts(PdfCore.PdfOptions pdfOptions, PptCore.PowerPointPresentation presentation, PowerPointPdfSaveOptions options, bool preserveConfiguredFontSlots) {
         var registeredFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         HashSet<PdfCore.PdfStandardFont> registeredFontSlots = pdfOptions.CreateRegisteredFontFamilySlots(preserveConfiguredFontSlots);
         double pageWidth = presentation.SlideSize.WidthPoints;
@@ -53,6 +63,8 @@ public static partial class PowerPointPdfConverterExtensions {
             RegisterPresentationShapesFonts(slide.GetInheritedShapesForExport(), slideNumber, pageWidth, pageHeight, pdfOptions, registeredFamilies, registeredFontSlots, options, groupDepth: 0);
             RegisterPresentationShapesFonts(slide.Shapes, slideNumber, pageWidth, pageHeight, pdfOptions, registeredFamilies, registeredFontSlots, options, groupDepth: 0);
         }
+
+        return registeredFontSlots;
     }
 
     private static void RegisterPresentationShapesFonts(IReadOnlyList<PptCore.PowerPointShape> shapes, int slideNumber, double pageWidth, double pageHeight, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, PowerPointPdfSaveOptions options, int groupDepth) {
@@ -72,14 +84,14 @@ public static partial class PowerPointPdfConverterExtensions {
 
         if (shape is PptCore.PowerPointTextBox textBox) {
             if (options.IncludeTextBoxes) {
-                RegisterPresentationTextBoxFonts(textBox, pdfOptions, registeredFamilies, registeredFontSlots);
+                RegisterPresentationTextBoxFonts(textBox, pdfOptions, registeredFamilies, registeredFontSlots, options.AllowSystemFontEmbedding);
             }
             return;
         }
 
         if (shape is PptCore.PowerPointTable table) {
             if (options.IncludeTables) {
-                RegisterPresentationTableFonts(table, pdfOptions, registeredFamilies, registeredFontSlots);
+                RegisterPresentationTableFonts(table, pdfOptions, registeredFamilies, registeredFontSlots, options.AllowSystemFontEmbedding);
             }
             return;
         }
@@ -91,28 +103,28 @@ public static partial class PowerPointPdfConverterExtensions {
         }
     }
 
-    private static void RegisterPresentationTextBoxFonts(PptCore.PowerPointTextBox textBox, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots) {
-        RegisterPresentationFontCandidate(textBox.FontName, pdfOptions, registeredFamilies, registeredFontSlots);
+    private static void RegisterPresentationTextBoxFonts(PptCore.PowerPointTextBox textBox, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, bool embedSystemFont) {
+        RegisterPresentationFontCandidate(textBox.FontName, pdfOptions, registeredFamilies, registeredFontSlots, embedSystemFont);
         foreach (PptCore.PowerPointParagraph paragraph in textBox.Paragraphs) {
             foreach (PptCore.PowerPointTextRun run in paragraph.Runs) {
-                RegisterPresentationFontCandidate(run.FontName, pdfOptions, registeredFamilies, registeredFontSlots);
+                RegisterPresentationFontCandidate(run.FontName, pdfOptions, registeredFamilies, registeredFontSlots, embedSystemFont);
             }
         }
     }
 
-    private static void RegisterPresentationTableFonts(PptCore.PowerPointTable table, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots) {
+    private static void RegisterPresentationTableFonts(PptCore.PowerPointTable table, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, bool embedSystemFont) {
         for (int row = 0; row < table.Rows; row++) {
             for (int column = 0; column < table.Columns; column++) {
                 PptCore.PowerPointTableCell cell = table.GetCell(row, column);
                 if (!cell.IsMergedCell) {
-                    RegisterPresentationFontCandidate(cell.FontName, pdfOptions, registeredFamilies, registeredFontSlots);
-                    RegisterPresentationTableCellRunFonts(cell, pdfOptions, registeredFamilies, registeredFontSlots);
+                    RegisterPresentationFontCandidate(cell.FontName, pdfOptions, registeredFamilies, registeredFontSlots, embedSystemFont);
+                    RegisterPresentationTableCellRunFonts(cell, pdfOptions, registeredFamilies, registeredFontSlots, embedSystemFont);
                 }
             }
         }
     }
 
-    private static void RegisterPresentationTableCellRunFonts(PptCore.PowerPointTableCell cell, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots) {
+    private static void RegisterPresentationTableCellRunFonts(PptCore.PowerPointTableCell cell, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, bool embedSystemFont) {
         A.TextBody? textBody = cell.Cell.TextBody;
         if (textBody == null) {
             return;
@@ -120,14 +132,14 @@ public static partial class PowerPointPdfConverterExtensions {
 
         foreach (A.Paragraph paragraph in textBody.Elements<A.Paragraph>()) {
             foreach (A.Run run in paragraph.Elements<A.Run>()) {
-                RegisterPresentationFontCandidate(ReadRunFontName(run.RunProperties), pdfOptions, registeredFamilies, registeredFontSlots);
+                RegisterPresentationFontCandidate(ReadRunFontName(run.RunProperties), pdfOptions, registeredFamilies, registeredFontSlots, embedSystemFont);
             }
         }
     }
 
-    private static void RegisterPresentationFontCandidate(string? familyName, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots) {
+    private static void RegisterPresentationFontCandidate(string? familyName, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, bool embedSystemFont) {
         if (PdfCore.PdfOptions.TryAddOfficeFontFamilyKey(familyName, registeredFamilies, normalizeKey: null, out string trimmedFamilyName)) {
-            pdfOptions.TryRegisterMappedOfficeFontFamily(trimmedFamilyName, registeredFontSlots, embedSystemFont: true, out _);
+            pdfOptions.TryRegisterMappedOfficeFontFamily(trimmedFamilyName, registeredFontSlots, embedSystemFont, out _);
         }
     }
 }

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfSaveOptions.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfSaveOptions.cs
@@ -13,6 +13,16 @@ public sealed class PowerPointPdfSaveOptions {
     /// <summary>Optional PowerPoint-style font family used as the first-party PDF default font.</summary>
     public string? FontFamily { get; set; }
 
+    /// <summary>
+    /// When true, PowerPoint PDF export may load installed system fonts to embed them into the generated PDF. Defaults to true to preserve existing presentation fidelity.
+    /// </summary>
+    public bool AllowSystemFontEmbedding { get; set; } = true;
+
+    /// <summary>
+    /// Built-in generated-text fallback groups applied by the PowerPoint PDF converter.
+    /// </summary>
+    public PdfCore.PdfTextFallbackFeatures TextFallbacks { get; set; } = PdfCore.PdfTextFallbackFeatures.Default;
+
     /// <summary>When true, supported slide pictures are embedded through the shared PDF image pipeline. Defaults to true.</summary>
     public bool IncludePictures { get; set; } = true;
 
@@ -63,6 +73,52 @@ public sealed class PowerPointPdfSaveOptions {
 
     /// <summary>Optional shared chart layout applied to supported slide chart snapshots.</summary>
     public DrawingCore.OfficeChartLayout? ChartLayout { get; set; }
+
+    /// <summary>
+    /// Applies a high-level export profile by setting the PowerPoint PDF options that correspond to that profile.
+    /// </summary>
+    public PowerPointPdfSaveOptions UseProfile(PdfCore.PdfExportProfile profile) {
+        switch (profile) {
+            case PdfCore.PdfExportProfile.Faithful:
+                IncludePictures = true;
+                IncludeAutoShapes = true;
+                IncludeTextBoxes = true;
+                IncludeSlideBackgrounds = true;
+                IncludeTables = true;
+                IncludeCharts = true;
+                IncludeHiddenSlides = false;
+                break;
+            case PdfCore.PdfExportProfile.Lightweight:
+                IncludePictures = false;
+                IncludeAutoShapes = true;
+                IncludeTextBoxes = true;
+                IncludeSlideBackgrounds = false;
+                IncludeTables = true;
+                IncludeCharts = false;
+                break;
+            case PdfCore.PdfExportProfile.PrintReady:
+                IncludePictures = true;
+                IncludeAutoShapes = true;
+                IncludeTextBoxes = true;
+                IncludeSlideBackgrounds = true;
+                IncludeTables = true;
+                IncludeCharts = true;
+                IncludeHiddenSlides = false;
+                break;
+            case PdfCore.PdfExportProfile.TextOnly:
+                IncludePictures = false;
+                IncludeAutoShapes = false;
+                IncludeTextBoxes = true;
+                IncludeSlideBackgrounds = false;
+                IncludeTables = true;
+                IncludeCharts = false;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(profile), profile, "Unsupported PDF export profile.");
+        }
+
+        return this;
+    }
 
     /// <summary>Warnings recorded during the latest export.</summary>
     public IList<PowerPointPdfExportWarning> Warnings { get; } = new List<PowerPointPdfExportWarning>();

--- a/OfficeIMO.PowerPoint.Pdf/README.md
+++ b/OfficeIMO.PowerPoint.Pdf/README.md
@@ -63,12 +63,16 @@ presentation.SaveAsPdf(stream);
 ```csharp
 using OfficeIMO.PowerPoint;
 using OfficeIMO.PowerPoint.Pdf;
+using OfficeIMO.Pdf;
 
 using var presentation = PowerPointPresentation.Open("complex-deck.pptx");
 var options = new PowerPointPdfSaveOptions {
     IncludeCharts = true,
     IncludeAutoShapes = true
-};
+}.UseProfile(PdfExportProfile.Faithful);
+
+options.TextFallbacks = PdfTextFallbackFeatures.Default;
+options.AllowSystemFontEmbedding = true;
 
 var result = presentation.TrySaveAsPdf("complex-deck.pdf", options);
 if (!result.Succeeded) {
@@ -80,6 +84,8 @@ if (!result.Succeeded) {
 foreach (var warning in options.ConversionReport.Warnings) {
     Console.WriteLine($"{warning.Source}: {warning.Message}");
 }
+
+options.ConversionReport.RequireNoErrorWarnings();
 ```
 
 ## What it maps
@@ -88,6 +94,7 @@ foreach (var warning in options.ConversionReport.Warnings) {
 - Slide backgrounds, text boxes, supported pictures, supported tables, supported charts, and basic auto-shapes.
 - Text box fill, outline, margins, font defaults, alignment, vertical anchoring, rich runs, and hyperlinks.
 - Supported JPEG/PNG pictures through the shared PDF image pipeline.
+- Profile presets through `PowerPointPdfSaveOptions.UseProfile(...)`, plus shared `TextFallbacks` and `AllowSystemFontEmbedding` controls for Unicode, symbols, and emoji.
 - Conversion warnings through `PowerPointPdfSaveOptions.Warnings` and `PowerPointPdfSaveOptions.ConversionReport`.
 
 ## PDF table import

--- a/OfficeIMO.Word.Pdf/PdfSaveOptions.cs
+++ b/OfficeIMO.Word.Pdf/PdfSaveOptions.cs
@@ -24,6 +24,12 @@ namespace OfficeIMO.Word.Pdf {
         public bool AllowSystemFontEmbedding { get; set; }
 
         /// <summary>
+        /// Built-in generated-text fallback groups applied by the Word PDF converter when system font embedding is allowed.
+        /// Defaults to the recommended preset, but no host font files are embedded unless <see cref="AllowSystemFontEmbedding"/> is true.
+        /// </summary>
+        public PdfCore.PdfTextFallbackFeatures TextFallbacks { get; set; } = PdfCore.PdfTextFallbackFeatures.Default;
+
+        /// <summary>
         /// Optional page size in PDF points. The supplied geometry is preserved unless <see cref="Orientation"/> is also set.
         /// </summary>
         public PdfCore.PageSize? PageSize { get; set; }
@@ -95,6 +101,34 @@ namespace OfficeIMO.Word.Pdf {
         /// Defaults to false to preserve strict fidelity.
         /// </summary>
         public bool DefaultTableBorders { get; set; } = false;
+
+        /// <summary>
+        /// Applies a high-level export profile by setting the Word PDF options that correspond to that profile.
+        /// </summary>
+        public PdfSaveOptions UseProfile(PdfCore.PdfExportProfile profile) {
+            switch (profile) {
+                case PdfCore.PdfExportProfile.Faithful:
+                    IncludePageNumbers = true;
+                    DefaultTableBorders = false;
+                    break;
+                case PdfCore.PdfExportProfile.Lightweight:
+                    IncludePageNumbers = false;
+                    DefaultTableBorders = false;
+                    break;
+                case PdfCore.PdfExportProfile.PrintReady:
+                    IncludePageNumbers = true;
+                    DefaultTableBorders = true;
+                    break;
+                case PdfCore.PdfExportProfile.TextOnly:
+                    IncludePageNumbers = false;
+                    DefaultTableBorders = false;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(profile), profile, "Unsupported PDF export profile.");
+            }
+
+            return this;
+        }
 
         internal void ResetExportState() {
             Warnings.Clear();

--- a/OfficeIMO.Word.Pdf/README.md
+++ b/OfficeIMO.Word.Pdf/README.md
@@ -139,7 +139,7 @@ The semantic import path preserves document metadata, page breaks, headings, par
 
 ## Options and diagnostics
 
-Use `PdfSaveOptions` when callers need to override page geometry, metadata, page-number behavior, font family, or table-border fallback. Keep `PdfSaveOptions.Warnings` and `PdfSaveOptions.ConversionReport` visible in wrappers and user interfaces; unsupported Word features should become actionable diagnostics instead of silent README promises.
+Use `PdfSaveOptions` when callers need to override page geometry, metadata, page-number behavior, font family, table-border fallback, profile presets, or text fallback policy. `TextFallbacks` uses the shared `PdfTextFallbackFeatures` enum; set `AllowSystemFontEmbedding = true` when Word export may embed installed host fonts for Unicode, symbols, and emoji. Keep `PdfSaveOptions.Warnings` and `PdfSaveOptions.ConversionReport` visible in wrappers and user interfaces; unsupported Word features should become actionable diagnostics instead of silent README promises.
 
 ## Boundaries
 

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Fonts.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Fonts.cs
@@ -53,7 +53,9 @@ namespace OfficeIMO.Word.Pdf {
                 }
 
                 if (PdfCore.PdfStandardFontMapper.TryMapFontFamily(trimmedFamilyName, out PdfCore.PdfStandardFont mappedFont)) {
-                    nativeFontMap.Register(trimmedFamilyName, PdfCore.PdfStandardFontMapper.GetFontFamily(mappedFont));
+                    PdfCore.PdfStandardFont mappedFamily = PdfCore.PdfStandardFontMapper.GetFontFamily(mappedFont);
+                    registeredFontSlots.Add(mappedFamily);
+                    nativeFontMap.Register(trimmedFamilyName, mappedFamily);
                 }
             }
         }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Fonts.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Fonts.cs
@@ -36,57 +36,36 @@ namespace OfficeIMO.Word.Pdf {
             var registeredFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (string styleId in new[] { "Heading1", "Heading2", "Heading3", "Heading4", "Heading5", "Heading6", "Heading7", "Heading8", "Heading9" }) {
                 string? familyName = ResolveNativeParagraphStyleFontFamily(document, styleId);
-                if (string.IsNullOrWhiteSpace(familyName) || !registeredFamilies.Add(NormalizeNativeFontFamily(familyName!))) {
+                if (!PdfCore.PdfOptions.TryAddOfficeFontFamilyKey(familyName, registeredFamilies, NormalizeNativeFontFamily, out string trimmedFamilyName)) {
                     continue;
                 }
 
-                PdfCore.PdfStandardFont slot = SelectNativeAdditionalFontSlot(familyName!, registeredFontSlots);
+                PdfCore.PdfStandardFont slot = SelectNativeAdditionalFontSlot(trimmedFamilyName, pdfOptions, registeredFontSlots);
                 bool slotAlreadyEmbedded = pdfOptions.HasEmbeddedStandardFontFamily(slot);
                 if (!slotAlreadyEmbedded) {
-                    pdfOptions.RegisterOfficeFontFamily(familyName, slot, embedSystemFont: true);
+                    pdfOptions.RegisterOfficeFontFamily(trimmedFamilyName, slot, embedSystemFont: true);
                 }
 
                 if (slotAlreadyEmbedded || pdfOptions.HasEmbeddedStandardFontFamily(slot)) {
                     registeredFontSlots.Add(slot);
-                    nativeFontMap.Register(familyName!, slot);
+                    nativeFontMap.Register(trimmedFamilyName, slot);
                     continue;
                 }
 
-                if (PdfCore.PdfStandardFontMapper.TryMapFontFamily(familyName, out PdfCore.PdfStandardFont mappedFont)) {
-                    nativeFontMap.Register(familyName!, PdfCore.PdfStandardFontMapper.GetFontFamily(mappedFont));
+                if (PdfCore.PdfStandardFontMapper.TryMapFontFamily(trimmedFamilyName, out PdfCore.PdfStandardFont mappedFont)) {
+                    nativeFontMap.Register(trimmedFamilyName, PdfCore.PdfStandardFontMapper.GetFontFamily(mappedFont));
                 }
             }
         }
 
-        private static PdfCore.PdfStandardFont SelectNativeAdditionalFontSlot(string familyName, HashSet<PdfCore.PdfStandardFont> registeredFontSlots) {
-            if (TrySelectNativeAdditionalFontSlot(familyName, registeredFontSlots, out PdfCore.PdfStandardFont fontSlot)) {
+        private static PdfCore.PdfStandardFont SelectNativeAdditionalFontSlot(string familyName, PdfCore.PdfOptions pdfOptions, HashSet<PdfCore.PdfStandardFont> registeredFontSlots) {
+            if (PdfCore.PdfOptions.TrySelectAvailableFontFamilySlot(familyName, registeredFontSlots, out PdfCore.PdfStandardFont fontSlot)) {
                 return fontSlot;
             }
 
             return PdfCore.PdfStandardFontMapper.TryMapFontFamily(familyName, out PdfCore.PdfStandardFont mappedFont)
                 ? PdfCore.PdfStandardFontMapper.GetFontFamily(mappedFont)
                 : PdfCore.PdfStandardFont.Helvetica;
-        }
-
-        private static bool TrySelectNativeAdditionalFontSlot(string familyName, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, out PdfCore.PdfStandardFont fontSlot) {
-            if (PdfCore.PdfStandardFontMapper.TryMapFontFamily(familyName, out PdfCore.PdfStandardFont mappedFont)) {
-                PdfCore.PdfStandardFont mappedFamily = PdfCore.PdfStandardFontMapper.GetFontFamily(mappedFont);
-                if (!registeredFontSlots.Contains(mappedFamily)) {
-                    fontSlot = mappedFamily;
-                    return true;
-                }
-            }
-
-            foreach (PdfCore.PdfStandardFont candidate in new[] { PdfCore.PdfStandardFont.TimesRoman, PdfCore.PdfStandardFont.Courier, PdfCore.PdfStandardFont.Helvetica }) {
-                PdfCore.PdfStandardFont family = PdfCore.PdfStandardFontMapper.GetFontFamily(candidate);
-                if (!registeredFontSlots.Contains(family)) {
-                    fontSlot = family;
-                    return true;
-                }
-            }
-
-            fontSlot = PdfCore.PdfStandardFont.Helvetica;
-            return false;
         }
 
         private static string? ResolveNativeParagraphStyleFontFamily(WordDocument? document, string? styleId) {

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
@@ -29,8 +29,8 @@ namespace OfficeIMO.Word.Pdf {
             bool preserveConfiguredFontSlots = ApplyNativeDefaultFont(document, options, pdfOptions, allowSystemFontEmbedding, nativeFontMap) ||
                                                 options?.PdfOptions != null;
             HashSet<PdfCore.PdfStandardFont> registeredFontSlots = RegisterNativeDocumentFonts(document, pdfOptions, preserveConfiguredFontSlots, allowSystemFontEmbedding, nativeFontMap);
-            RegisterNativeThemeStyleFonts(document, pdfOptions, registeredFontSlots, allowSystemFontEmbedding, nativeFontMap);
             ApplyNativeTextFallbacks(options, pdfOptions, registeredFontSlots, preserveConfiguredFontSlots, allowSystemFontEmbedding);
+            RegisterNativeThemeStyleFonts(document, pdfOptions, registeredFontSlots, allowSystemFontEmbedding, nativeFontMap);
             pdfOptions.BackgroundColor = ParseNativeColor(document.Background?.Color);
             pdfOptions.CreateOutlineFromHeadings = true;
             ApplyNativeBiDiViewerPreferences(document, pdfOptions);
@@ -114,7 +114,7 @@ namespace OfficeIMO.Word.Pdf {
         private static void ApplyNativeTextFallbacks(
             PdfSaveOptions? options,
             PdfCore.PdfOptions pdfOptions,
-            IEnumerable<PdfCore.PdfStandardFont> reservedFontSlots,
+            HashSet<PdfCore.PdfStandardFont> reservedFontSlots,
             bool preserveConfiguredFontSlots,
             bool allowSystemFontEmbedding) {
             if (options == null ||
@@ -130,6 +130,9 @@ namespace OfficeIMO.Word.Pdf {
 
             if (fallbackFeatures != PdfCore.PdfTextFallbackFeatures.None) {
                 pdfOptions.UseTextFallbacks(fallbackFeatures, reservedFontSlots, allowSystemFontEmbedding);
+                foreach (PdfCore.PdfStandardFont slot in pdfOptions.EmbeddedFontFallbacks?.FontSlots ?? Array.Empty<PdfCore.PdfStandardFont>()) {
+                    PdfCore.PdfOptions.AddRegisteredFontFamilySlot(reservedFontSlots, slot);
+                }
             }
         }
 

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
@@ -147,7 +147,7 @@ namespace OfficeIMO.Word.Pdf {
                 return;
             }
 
-            PdfCore.PdfStandardFont[] slots = GetNativeAvailableFallbackFontSlots(pdfOptions, candidates.Count, reservedFontSlots).ToArray();
+            PdfCore.PdfStandardFont[] slots = pdfOptions.GetAvailableEmbeddedFallbackFontSlots(candidates.Count, reservedFontSlots).ToArray();
             if (slots.Length == 0) {
                 return;
             }
@@ -159,34 +159,9 @@ namespace OfficeIMO.Word.Pdf {
             pdfOptions.RegisterEmbeddedFontFallbacks(new PdfCore.PdfEmbeddedFontFallbackSet(candidates, slots));
         }
 
-        private static IEnumerable<PdfCore.PdfStandardFont> GetNativeAvailableFallbackFontSlots(PdfCore.PdfOptions pdfOptions, int count, IEnumerable<PdfCore.PdfStandardFont> reservedFontSlots) {
-            var reservedSlots = new HashSet<PdfCore.PdfStandardFont> {
-                PdfCore.PdfStandardFontMapper.GetFontFamily(pdfOptions.DefaultFont),
-                PdfCore.PdfStandardFontMapper.GetFontFamily(pdfOptions.HeaderFont),
-                PdfCore.PdfStandardFontMapper.GetFontFamily(pdfOptions.FooterFont)
-            };
-            foreach (PdfCore.PdfStandardFont slot in reservedFontSlots) {
-                reservedSlots.Add(PdfCore.PdfStandardFontMapper.GetFontFamily(slot));
-            }
-
-            foreach (PdfCore.PdfStandardFont slot in new[] { PdfCore.PdfStandardFont.TimesRoman, PdfCore.PdfStandardFont.Courier, PdfCore.PdfStandardFont.Helvetica }) {
-                PdfCore.PdfStandardFont family = PdfCore.PdfStandardFontMapper.GetFontFamily(slot);
-                if (reservedSlots.Contains(family) ||
-                    pdfOptions.HasEmbeddedStandardFontFamily(family)) {
-                    continue;
-                }
-
-                yield return family;
-                count--;
-                if (count == 0) {
-                    yield break;
-                }
-            }
-        }
-
         private static HashSet<PdfCore.PdfStandardFont> RegisterNativeDocumentFonts(WordDocument document, PdfCore.PdfOptions pdfOptions, bool preserveConfiguredFontSlots, bool allowSystemFontEmbedding, NativeFontMap nativeFontMap) {
             var registeredFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            HashSet<PdfCore.PdfStandardFont> registeredFontSlots = CreateNativeRegisteredFontSlots(pdfOptions, preserveConfiguredFontSlots);
+            HashSet<PdfCore.PdfStandardFont> registeredFontSlots = pdfOptions.CreateRegisteredFontFamilySlots(preserveConfiguredFontSlots);
             foreach (WordSection section in document.Sections) {
                 foreach (WordElement element in CollapseNativeParagraphElements(section.Elements)) {
                     if (element is WordCoverPage coverPage) {
@@ -244,25 +219,6 @@ namespace OfficeIMO.Word.Pdf {
             }
         }
 
-        private static HashSet<PdfCore.PdfStandardFont> CreateNativeRegisteredFontSlots(PdfCore.PdfOptions pdfOptions, bool preserveConfiguredFontSlots) {
-            var registeredFontSlots = new HashSet<PdfCore.PdfStandardFont>();
-            if (preserveConfiguredFontSlots) {
-                AddNativeRegisteredFontSlot(registeredFontSlots, pdfOptions.DefaultFont);
-                AddNativeRegisteredFontSlot(registeredFontSlots, pdfOptions.HeaderFont);
-                AddNativeRegisteredFontSlot(registeredFontSlots, pdfOptions.FooterFont);
-            }
-
-            foreach (PdfCore.PdfStandardFont embeddedFont in pdfOptions.EmbeddedFonts.Keys) {
-                AddNativeRegisteredFontSlot(registeredFontSlots, embeddedFont);
-            }
-
-            return registeredFontSlots;
-        }
-
-        private static void AddNativeRegisteredFontSlot(HashSet<PdfCore.PdfStandardFont> registeredFontSlots, PdfCore.PdfStandardFont font) {
-            registeredFontSlots.Add(PdfCore.PdfStandardFontMapper.GetFontFamily(font));
-        }
-
         private static void RegisterNativeTableFonts(WordTable table, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, bool allowSystemFontEmbedding, NativeFontMap nativeFontMap) {
             foreach (WordTableRow row in table.Rows) {
                 foreach (WordTableCell cell in row.Cells) {
@@ -288,28 +244,17 @@ namespace OfficeIMO.Word.Pdf {
         }
 
         private static void RegisterNativeFontCandidate(string? familyName, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, bool allowSystemFontEmbedding, NativeFontMap nativeFontMap) {
-            if (string.IsNullOrWhiteSpace(familyName)) {
+            if (!PdfCore.PdfOptions.TryAddOfficeFontFamilyKey(familyName, registeredFamilies, NormalizeNativeFontFamily, out string trimmedFamilyName)) {
                 return;
             }
 
-            string trimmedFamilyName = familyName!.Trim();
-            string normalizedFamilyName = NormalizeNativeFontFamily(trimmedFamilyName);
-            if (!registeredFamilies.Add(normalizedFamilyName)) {
-                return;
-            }
-
-            if (PdfCore.PdfStandardFontMapper.TryMapFontFamily(trimmedFamilyName, out PdfCore.PdfStandardFont standardFont)) {
-                PdfCore.PdfStandardFont fontFamily = PdfCore.PdfStandardFontMapper.GetFontFamily(standardFont);
-                if (registeredFontSlots.Add(fontFamily)) {
-                    pdfOptions.RegisterOfficeFontFamily(trimmedFamilyName, fontFamily, embedSystemFont: allowSystemFontEmbedding);
-                }
-
+            if (pdfOptions.TryRegisterMappedOfficeFontFamily(trimmedFamilyName, registeredFontSlots, allowSystemFontEmbedding, out PdfCore.PdfStandardFont fontFamily)) {
                 nativeFontMap.Register(trimmedFamilyName, fontFamily);
                 return;
             }
 
             if (allowSystemFontEmbedding &&
-                TrySelectNativeAdditionalFontSlot(trimmedFamilyName, registeredFontSlots, out PdfCore.PdfStandardFont fontSlot) &&
+                PdfCore.PdfOptions.TrySelectAvailableFontFamilySlot(trimmedFamilyName, registeredFontSlots, out PdfCore.PdfStandardFont fontSlot) &&
                 PdfCore.PdfEmbeddedFontFamily.TryFromSystem(trimmedFamilyName, out PdfCore.PdfEmbeddedFontFamily? embeddedFamily) &&
                 embeddedFamily != null) {
                 registeredFontSlots.Add(fontSlot);

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
@@ -29,8 +29,8 @@ namespace OfficeIMO.Word.Pdf {
             bool preserveConfiguredFontSlots = ApplyNativeDefaultFont(document, options, pdfOptions, allowSystemFontEmbedding, nativeFontMap) ||
                                                 options?.PdfOptions != null;
             HashSet<PdfCore.PdfStandardFont> registeredFontSlots = RegisterNativeDocumentFonts(document, pdfOptions, preserveConfiguredFontSlots, allowSystemFontEmbedding, nativeFontMap);
-            ApplyNativeTextFallbacks(options, pdfOptions, registeredFontSlots, preserveConfiguredFontSlots, allowSystemFontEmbedding);
             RegisterNativeThemeStyleFonts(document, pdfOptions, registeredFontSlots, allowSystemFontEmbedding, nativeFontMap);
+            ApplyNativeTextFallbacks(options, pdfOptions, registeredFontSlots, preserveConfiguredFontSlots, allowSystemFontEmbedding);
             pdfOptions.BackgroundColor = ParseNativeColor(document.Background?.Color);
             pdfOptions.CreateOutlineFromHeadings = true;
             ApplyNativeBiDiViewerPreferences(document, pdfOptions);

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
@@ -30,8 +30,7 @@ namespace OfficeIMO.Word.Pdf {
                                                 options?.PdfOptions != null;
             HashSet<PdfCore.PdfStandardFont> registeredFontSlots = RegisterNativeDocumentFonts(document, pdfOptions, preserveConfiguredFontSlots, allowSystemFontEmbedding, nativeFontMap);
             RegisterNativeThemeStyleFonts(document, pdfOptions, registeredFontSlots, allowSystemFontEmbedding, nativeFontMap);
-            ApplyNativeFallbackFont(options, pdfOptions, preserveConfiguredFontSlots, allowSystemFontEmbedding);
-            RegisterNativeEmbeddedTextFallbacks(pdfOptions, registeredFontSlots, allowSystemFontEmbedding);
+            ApplyNativeTextFallbacks(options, pdfOptions, registeredFontSlots, preserveConfiguredFontSlots, allowSystemFontEmbedding);
             pdfOptions.BackgroundColor = ParseNativeColor(document.Background?.Color);
             pdfOptions.CreateOutlineFromHeadings = true;
             ApplyNativeBiDiViewerPreferences(document, pdfOptions);
@@ -112,51 +111,30 @@ namespace OfficeIMO.Word.Pdf {
             return false;
         }
 
-        private static void ApplyNativeFallbackFont(PdfSaveOptions? options, PdfCore.PdfOptions pdfOptions, bool preserveConfiguredFontSlots, bool allowSystemFontEmbedding) {
-            if (options?.PdfOptions == null &&
-                allowSystemFontEmbedding &&
-                !preserveConfiguredFontSlots &&
-                !pdfOptions.HasEmbeddedStandardFontFamily(pdfOptions.DefaultFont)) {
-                pdfOptions.TryUseDefaultDocumentFontFallback(requireEmbeddedFont: true);
+        private static void ApplyNativeTextFallbacks(
+            PdfSaveOptions? options,
+            PdfCore.PdfOptions pdfOptions,
+            IEnumerable<PdfCore.PdfStandardFont> reservedFontSlots,
+            bool preserveConfiguredFontSlots,
+            bool allowSystemFontEmbedding) {
+            if (options == null ||
+                !allowSystemFontEmbedding ||
+                options.TextFallbacks == PdfCore.PdfTextFallbackFeatures.None) {
+                return;
+            }
+
+            PdfCore.PdfTextFallbackFeatures fallbackFeatures = options.TextFallbacks;
+            if (preserveConfiguredFontSlots || pdfOptions.HasEmbeddedStandardFontFamily(pdfOptions.DefaultFont)) {
+                fallbackFeatures &= ~PdfCore.PdfTextFallbackFeatures.DocumentFont;
+            }
+
+            if (fallbackFeatures != PdfCore.PdfTextFallbackFeatures.None) {
+                pdfOptions.UseTextFallbacks(fallbackFeatures, reservedFontSlots, allowSystemFontEmbedding);
             }
         }
 
         private static bool TryApplyNativeDefaultFontCandidate(string? familyName, PdfCore.PdfOptions pdfOptions, bool embedSystemFont, bool requireEmbeddedFont = false) {
             return pdfOptions.TryUseOfficeFontFamily(familyName, embedSystemFont, requireEmbeddedFont);
-        }
-
-        private static void RegisterNativeEmbeddedTextFallbacks(PdfCore.PdfOptions pdfOptions, IEnumerable<PdfCore.PdfStandardFont> reservedFontSlots, bool allowSystemFontEmbedding) {
-            if (!allowSystemFontEmbedding ||
-                pdfOptions.EmbeddedFontFallbacks != null) {
-                return;
-            }
-
-            var candidates = new List<PdfCore.PdfEmbeddedFontFallbackCandidate>();
-            foreach (string familyName in new[] { "Segoe UI Symbol", "Segoe UI Emoji", "DejaVu Sans", "Arial" }) {
-                if (candidates.Count == 2) {
-                    break;
-                }
-
-                if (PdfCore.PdfEmbeddedFontFamily.TryFromSystem(familyName, out PdfCore.PdfEmbeddedFontFamily? family) &&
-                    family != null) {
-                    candidates.Add(new PdfCore.PdfEmbeddedFontFallbackCandidate(family.FamilyName, family.Regular));
-                }
-            }
-
-            if (candidates.Count == 0) {
-                return;
-            }
-
-            PdfCore.PdfStandardFont[] slots = pdfOptions.GetAvailableEmbeddedFallbackFontSlots(candidates.Count, reservedFontSlots).ToArray();
-            if (slots.Length == 0) {
-                return;
-            }
-
-            if (slots.Length < candidates.Count) {
-                candidates = candidates.Take(slots.Length).ToList();
-            }
-
-            pdfOptions.RegisterEmbeddedFontFallbacks(new PdfCore.PdfEmbeddedFontFallbackSet(candidates, slots));
         }
 
         private static HashSet<PdfCore.PdfStandardFont> RegisterNativeDocumentFonts(WordDocument document, PdfCore.PdfOptions pdfOptions, bool preserveConfiguredFontSlots, bool allowSystemFontEmbedding, NativeFontMap nativeFontMap) {

--- a/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.HeadingTocLinkTests.cs
+++ b/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.HeadingTocLinkTests.cs
@@ -428,6 +428,46 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void SaveAsPdf_OfficeIMOEngine_Reserves_Theme_Style_Fonts_Before_Text_Fallbacks() {
+            string docPath = Path.Combine(_directoryWithFiles, "PdfNativeThemeStyleBeforeFallbacks.docx");
+
+            using WordDocument document = WordDocument.Create(docPath);
+            document.AddParagraph("Native theme heading slot").SetStyle(WordParagraphStyles.Heading1);
+
+            Style headingStyle = document._wordprocessingDocument.MainDocumentPart!.StyleDefinitionsPart!.Styles!
+                .Elements<Style>()
+                .First(style => style.StyleId == "Heading1");
+            StyleRunProperties runProperties = headingStyle.GetFirstChild<StyleRunProperties>() ?? headingStyle.AppendChild(new StyleRunProperties());
+            runProperties.RemoveAllChildren<RunFonts>();
+            runProperties.AppendChild(new RunFonts { Ascii = "serif", HighAnsi = "serif" });
+
+            Type nativeFontMapType = typeof(WordPdfConverterExtensions).GetNestedType("NativeFontMap", BindingFlags.NonPublic)!;
+            object nativeFontMap = Activator.CreateInstance(nativeFontMapType, nonPublic: true)!;
+            MethodInfo createOptions = typeof(WordPdfConverterExtensions).GetMethod(
+                "CreateNativeOptions",
+                BindingFlags.NonPublic | BindingFlags.Static)!;
+
+            var saveOptions = new PdfSaveOptions {
+                AllowSystemFontEmbedding = true,
+                TextFallbacks = PdfTextFallbackFeatures.Default
+            };
+            PdfOptions pdfOptions = Assert.IsType<PdfOptions>(createOptions.Invoke(null, new object[] {
+                document,
+                saveOptions,
+                nativeFontMap
+            }));
+
+            object[] args = { "serif", PdfStandardFont.Helvetica };
+            bool mapped = (bool)nativeFontMapType.GetMethod("TryGetFontSlot", BindingFlags.Public | BindingFlags.Instance)!.Invoke(nativeFontMap, args)!;
+
+            Assert.True(mapped);
+            Assert.Equal(PdfStandardFont.TimesRoman, Assert.IsType<PdfStandardFont>(args[1]));
+            if (pdfOptions.EmbeddedFontFallbacks != null) {
+                Assert.DoesNotContain(PdfStandardFont.TimesRoman, pdfOptions.EmbeddedFontFallbacks.FontSlots);
+            }
+        }
+
+        [Fact]
         public void SaveAsPdf_OfficeIMOEngine_Uses_Declared_Word_Heading_Formatting() {
             using WordDocument document = WordDocument.Create(Path.Combine(_directoryWithFiles, "PdfNativeDeclaredHeadingFormatting.docx"));
             WordParagraph heading = document.AddParagraph("Native declared heading formatting").SetStyle(WordParagraphStyles.Heading1);


### PR DESCRIPTION
## Summary- fix embedded PDF fallback font slot handling so fallback runs can coexist with later primary font registrations- preserve selected-font ligature spans when fallback splitting mixed selected-font/fallback runs- reject keep-together panels whose vertical padding cannot fit before they render off-page during split layout- allow oversized keep-together panels and Markdown blockquote panels to split across pages instead of throwing- add `PdfTextFallbackFeatures` plus `UseTextFallbacks(...)` for document, monospace, symbol, and emoji fallbacks- expose unified `TextFallbacks` options on Markdown, Word, Excel, and PowerPoint PDF save options, with explicit `AllowSystemFontEmbedding` controls- preserve caller-supplied Markdown `PdfOptions` font slots and honor Markdown font embedding opt-outs while still reserving Courier only when Markdown actually renders code text- add `PdfExportProfile` and `UseProfile(...)` presets for common converter paths such as faithful, lightweight, print-ready, and text-only output- add shared `PdfConversionReport.RequireNoWarnings()` / `RequireNoErrorWarnings()` helpers for wrapper-friendly proofing- add fluent PDF/A, PDF/UA, and Factur-X groundwork helpers over the existing compliance/e-invoice internals- share font-slot registration logic across Word, Excel, and PowerPoint PDF converters- reserve mapped Word theme/style font slots, keep automatic symbol/emoji fallbacks away from normal Times text slots, and preserve symbol fallback slots when monospace fallback is enabled## Examples```csharpvar options = new PdfSaveOptions {    TextFallbacks = PdfTextFallbackFeatures.Default,    AllowSystemFontEmbedding = true}.UseProfile(PdfExportProfile.PrintReady);var result = document.ToPdfDocumentResult(options);result.ConversionReport.RequireNoErrorWarnings();result.Save("proposal.pdf");``````csharpvar pdf = PdfDocument.Create(new PdfOptions()        .UsePdfA(PdfComplianceProfile.PdfA3B)        .UseTextFallbacks(PdfTextFallbackFeatures.Default))    .Paragraph(p => p.Text("Status ⚠ 🌐"));```Callers that need private or licensed fonts can still use `PdfEmbeddedFontFallbackSet`; callers that only need installed system fallback fonts can use the converter `TextFallbacks` option or core `UseTextFallbacks(...)` without assigning PDF font slots manually.## Validation- `dotnet test OfficeIMO.Pdf.Tests\OfficeIMO.Pdf.Tests.csproj --no-restore --framework net8.0` (2494 passed)- `dotnet test OfficeIMO.Pdf.Tests\OfficeIMO.Pdf.Tests.csproj --no-restore --framework net8.0 --filter "FullyQualifiedName~MarkdownSaveAsPdfOptionsTests|FullyQualifiedName~Markdown_SaveAsPdf_DefaultTextFallbacksCoverCommonSymbolsWhenAvailable|FullyQualifiedName~Markdown_SaveAsPdf_RendersInlineCodeWithoutRawCourierFallback"` (13 passed)- `dotnet test OfficeIMO.Pdf.Tests\OfficeIMO.Pdf.Tests.csproj --no-restore --framework net10.0 --filter "FullyQualifiedName~MarkdownSaveAsPdfOptionsTests|FullyQualifiedName~Markdown_SaveAsPdf_DefaultTextFallbacksCoverCommonSymbolsWhenAvailable|FullyQualifiedName~Markdown_SaveAsPdf_RendersInlineCodeWithoutRawCourierFallback"` (13 passed)- `dotnet test OfficeIMO.Pdf.Tests\OfficeIMO.Pdf.Tests.csproj --no-restore --framework net8.0 --filter "FullyQualifiedName~PdfConverterOptionsApiTests|FullyQualifiedName~PdfOptions_UseTextFallbacksReturnsOptionsForFluentConfiguration|FullyQualifiedName~TextFallback|FullyQualifiedName~Fallback"` (77 passed)- `dotnet test OfficeIMO.Pdf.Tests\OfficeIMO.Pdf.Tests.csproj --no-restore --framework net10.0 --filter "FullyQualifiedName~PdfConverterOptionsApiTests|FullyQualifiedName~PdfConversionReport_RequireNo|FullyQualifiedName~PdfAFluentHelper|FullyQualifiedName~PdfUaFluentHelper|FullyQualifiedName~FacturXFluentHelper|FullyQualifiedName~MarkdownConversion_ReportsMissingEmbeddedGlyph|FullyQualifiedName~PdfOptions_UseTextFallbacksReturnsOptionsForFluentConfiguration|FullyQualifiedName~TextShapingModeLatinLigatures_PreservesCoveredLigatureSpanWhenFallbackSplitsAdjacentRun|FullyQualifiedName~PanelParagraph_KeepTogetherRejectsSingleLineWhenBottomPaddingCannotFit"` (16 passed)- `dotnet test OfficeIMO.Pdf.Tests\OfficeIMO.Pdf.Tests.csproj --no-restore --framework net472 --filter "FullyQualifiedName~PdfConverterOptionsApiTests|FullyQualifiedName~PdfConversionReport_RequireNo|FullyQualifiedName~PdfAFluentHelper|FullyQualifiedName~PdfUaFluentHelper|FullyQualifiedName~FacturXFluentHelper|FullyQualifiedName~MarkdownConversion_ReportsMissingEmbeddedGlyph|FullyQualifiedName~PdfOptions_UseTextFallbacksReturnsOptionsForFluentConfiguration|FullyQualifiedName~TextShapingModeLatinLigatures_PreservesCoveredLigatureSpanWhenFallbackSplitsAdjacentRun|FullyQualifiedName~PanelParagraph_KeepTogetherRejectsSingleLineWhenBottomPaddingCannotFit"` (16 passed)- `dotnet test OfficeIMO.Excel.Tests\OfficeIMO.Excel.Tests.csproj --no-restore --configuration Release --framework net8.0 --filter "FullyQualifiedName~HeaderFooterFontsRegisterQuotedFontFamilies|FullyQualifiedName~HeaderFooterThemeFontsUseFallbackSlots|FullyQualifiedName~SaveAsPdf_CellStyleFontFallbackRegistersEmbeddedFont"` (3 passed)- `dotnet test OfficeIMO.Excel.Tests\OfficeIMO.Excel.Tests.csproj --no-restore --configuration Release --framework net10.0 --filter "FullyQualifiedName~HeaderFooterFontsRegisterQuotedFontFamilies|FullyQualifiedName~HeaderFooterThemeFontsUseFallbackSlots|FullyQualifiedName~SaveAsPdf_CellStyleFontFallbackRegistersEmbeddedFont"` (3 passed)- WSL Ubuntu `dotnet test OfficeIMO.Excel.Tests/OfficeIMO.Excel.Tests.csproj --no-restore --configuration Release --framework net8.0 --filter "FullyQualifiedName~SaveAsPdf"` (71 passed)- WSL Ubuntu `dotnet test OfficeIMO.Excel.Tests/OfficeIMO.Excel.Tests.csproj --no-restore --configuration Release --framework net10.0 --filter "FullyQualifiedName~SaveAsPdf"` (71 passed)- `dotnet test OfficeIMO.Pdf.Tests\OfficeIMO.Pdf.Tests.csproj --configuration Release --framework net8.0 --filter "FullyQualifiedName~ToPdfDocument_Markdown_TextFallbacks|FullyQualifiedName~PdfOptions_UseTextFallbacksDoesNotAssignAutomaticFallbacksToTimesSlot|FullyQualifiedName~PdfOptions_UseTextFallbacksPrefersTextCandidateWhenOnlyOneFallbackSlotIsAvailable"` (5 passed)- `dotnet test OfficeIMO.Pdf.Tests\OfficeIMO.Pdf.Tests.csproj --no-restore --configuration Release --framework net10.0 --filter "FullyQualifiedName~ToPdfDocument_Markdown_TextFallbacks|FullyQualifiedName~PdfOptions_UseTextFallbacksDoesNotAssignAutomaticFallbacksToTimesSlot|FullyQualifiedName~PdfOptions_UseTextFallbacksPrefersTextCandidateWhenOnlyOneFallbackSlotIsAvailable"` (5 passed)- `dotnet test OfficeIMO.Word.Tests\OfficeIMO.Word.Tests.csproj --no-restore --configuration Release --framework net8.0 --filter "FullyQualifiedName~SaveAsPdf_OfficeIMOEngine_Reserves_Theme_Style_Fonts_Before_Text_Fallbacks"` (1 passed)- `dotnet test OfficeIMO.Word.Tests\OfficeIMO.Word.Tests.csproj --no-restore --configuration Release --framework net10.0 --filter "FullyQualifiedName~SaveAsPdf_OfficeIMOEngine_Reserves_Theme_Style_Fonts_Before_Text_Fallbacks"` (1 passed)- WSL Ubuntu targeted PDF/Word fallback tests for net8.0 and net10.0 exited successfully- `dotnet test OfficeIMO.Word.Tests\OfficeIMO.Word.Tests.csproj --no-restore --configuration Release --framework net8.0 --filter "FullyQualifiedName~SaveAsPdf_OfficeIMOEngine_Uses_Embedded_Fallback_For_Word_Symbol_Text"` (1 passed)- `dotnet test OfficeIMO.Word.Tests\OfficeIMO.Word.Tests.csproj --no-restore --configuration Release --framework net10.0 --filter "FullyQualifiedName~SaveAsPdf_OfficeIMOEngine_Uses_Embedded_Fallback_For_Word_Symbol_Text"` (1 passed)- `dotnet test OfficeIMO.Pdf.Tests\OfficeIMO.Pdf.Tests.csproj --no-restore --configuration Release --framework net8.0 --filter "FullyQualifiedName~PdfOptions_UseTextFallbacksKeepsSymbolFallbackSlotAheadOfMonospaceFallback|FullyQualifiedName~PdfOptions_UseTextFallbacksDoesNotAssignAutomaticFallbacksToTimesSlot|FullyQualifiedName~PdfOptions_UseTextFallbacksPrefersTextCandidateWhenOnlyOneFallbackSlotIsAvailable"` (3 passed)- `dotnet test OfficeIMO.Pdf.Tests\OfficeIMO.Pdf.Tests.csproj --no-restore --configuration Release --framework net10.0 --filter "FullyQualifiedName~PdfOptions_UseTextFallbacksKeepsSymbolFallbackSlotAheadOfMonospaceFallback|FullyQualifiedName~PdfOptions_UseTextFallbacksDoesNotAssignAutomaticFallbacksToTimesSlot|FullyQualifiedName~PdfOptions_UseTextFallbacksPrefersTextCandidateWhenOnlyOneFallbackSlotIsAvailable"` (3 passed)- WSL Ubuntu `SaveAsPdf_OfficeIMOEngine_Uses_Embedded_Fallback_For_Word_Symbol_Text` for net8.0 and net10.0 exited successfully
- `dotnet test OfficeIMO.Pdf.Tests\OfficeIMO.Pdf.Tests.csproj --no-restore --configuration Release --framework net8.0 --filter "FullyQualifiedName~Markdown_SaveAsPdf_DefaultTextFallbacksCoverCommonSymbolsWhenAvailable|FullyQualifiedName~ToPdfDocument_Markdown_TextFallbacksReserveCourierForCodeText|FullyQualifiedName~ToPdfDocument_Markdown_TextFallbacksEmbedMonospaceBeforeReservingCourierForSymbols"` (3 passed)
- `dotnet test OfficeIMO.Pdf.Tests\OfficeIMO.Pdf.Tests.csproj --no-restore --configuration Release --framework net10.0 --filter "FullyQualifiedName~Markdown_SaveAsPdf_DefaultTextFallbacksCoverCommonSymbolsWhenAvailable|FullyQualifiedName~ToPdfDocument_Markdown_TextFallbacksReserveCourierForCodeText|FullyQualifiedName~ToPdfDocument_Markdown_TextFallbacksEmbedMonospaceBeforeReservingCourierForSymbols"` (3 passed)
- WSL Ubuntu targeted Markdown PDF fallback tests for net8.0 and net10.0 exited successfully