### PR TITLE
Add compressed CSV file IO

### DIFF
--- a/OfficeIMO.CSV.Tests/CsvDocumentFromObjectsTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvDocumentFromObjectsTests.cs
@@ -297,6 +297,104 @@ public class CsvDocumentFromObjectsTests
     }
 
     [Fact]
+    public void Save_Load_RoundTripsGZipByExtension()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "OfficeIMO.CSV.RoundTrip." + Guid.NewGuid().ToString("N") + ".csv.gz");
+        try
+        {
+            new CsvDocument()
+                .WithHeader("Name", "Value")
+                .AddRow("Alpha", 1)
+                .Save(path, new CsvSaveOptions { NewLine = "\n" });
+
+            var parsed = CsvDocument.Load(path);
+            var row = Assert.Single(parsed.AsEnumerable());
+
+            Assert.Equal("Alpha", row.AsString("Name"));
+            Assert.Equal(1, row.AsInt32("Value"));
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void ReadRowsReusable_ReadsGZipByExtension()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "OfficeIMO.CSV.Stream." + Guid.NewGuid().ToString("N") + ".csv.gz");
+        try
+        {
+            new CsvDocument()
+                .WithHeader("Name", "Value")
+                .AddRow("Alpha", 1)
+                .AddRow("Beta", 2)
+                .Save(path, new CsvSaveOptions { NewLine = "\n" });
+
+            var rows = new List<string>();
+            CsvDocument.ReadRowsReusable(path, (_, row) => rows.Add(row[0] + "|" + row[1]));
+
+            Assert.Equal(new[] { "Alpha|1", "Beta|2" }, rows);
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void Load_EnforcesMaxDecompressedBytes()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "OfficeIMO.CSV.Bounded." + Guid.NewGuid().ToString("N") + ".csv.gz");
+        try
+        {
+            new CsvDocument()
+                .WithHeader("Name", "Value")
+                .AddRow("Alpha", 1)
+                .Save(path, new CsvSaveOptions { NewLine = "\n" });
+
+            Assert.Throws<InvalidOperationException>(() =>
+                CsvDocument.Load(path, new CsvLoadOptions { MaxDecompressedBytes = 4 }));
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void SaveObjects_UsesCompressionFromDestinationExtension()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "OfficeIMO.CSV.SaveObjects." + Guid.NewGuid().ToString("N") + ".csv.gz");
+        try
+        {
+            CsvDocument.SaveObjects(path, new object?[] { new { Name = "A", Value = 1 } }, new CsvSaveOptions { NewLine = "\n" });
+
+            var parsed = CsvDocument.Load(path);
+            var row = Assert.Single(parsed.AsEnumerable());
+
+            Assert.Equal("A", row.AsString("Name"));
+            Assert.Equal(1, row.AsInt32("Value"));
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
     public void SaveObjects_DoesNotReplaceExistingFileWhenInputIsEmpty()
     {
         var path = Path.Combine(Path.GetTempPath(), "OfficeIMO.CSV.SaveObjects.Preserve." + Guid.NewGuid().ToString("N") + ".csv");

--- a/OfficeIMO.CSV.Tests/CsvDocumentFromObjectsTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvDocumentFromObjectsTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using OfficeIMO.CSV;
 using Xunit;
@@ -443,6 +444,37 @@ public class CsvDocumentFromObjectsTests
 
             Assert.Throws<InvalidOperationException>(() =>
                 CsvDocument.Load(path, new CsvLoadOptions { MaxDecompressedBytes = 4 }));
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void Save_InvalidCompressionLevelDoesNotTruncateExistingFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "OfficeIMO.CSV.InvalidCompressionLevel." + Guid.NewGuid().ToString("N") + ".csv.gz");
+        const string original = "Name,Value\nOriginal,1\n";
+        try
+        {
+            File.WriteAllText(path, original);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new CsvDocument()
+                    .WithHeader("Name", "Value")
+                    .AddRow("Replacement", 2)
+                    .Save(path, new CsvSaveOptions
+                    {
+                        CompressionType = CsvCompressionType.GZip,
+                        CompressionLevel = (CompressionLevel)123,
+                        NewLine = "\n"
+                    }));
+
+            Assert.Equal(original, File.ReadAllText(path));
         }
         finally
         {

--- a/OfficeIMO.CSV.Tests/CsvDocumentFromObjectsTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvDocumentFromObjectsTests.cs
@@ -349,6 +349,88 @@ public class CsvDocumentFromObjectsTests
     }
 
     [Fact]
+    public void ReadRecords_ReadsGZipByExtension()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "OfficeIMO.CSV.RawRecords." + Guid.NewGuid().ToString("N") + ".csv.gz");
+        try
+        {
+            new CsvDocument()
+                .WithHeader("Name", "Value")
+                .AddRow("Alpha", 1)
+                .Save(path, new CsvSaveOptions { NewLine = "\n" });
+
+            var records = CsvDocument.ReadRecords(path).ToArray();
+
+            Assert.Equal(2, records.Length);
+            Assert.Equal(new[] { "Name", "Value" }, records[0]);
+            Assert.Equal(new[] { "Alpha", "1" }, records[1]);
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void ReadRecordsReusable_ReadsGZipByExtension()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "OfficeIMO.CSV.RawRecordsReusable." + Guid.NewGuid().ToString("N") + ".csv.gz");
+        try
+        {
+            new CsvDocument()
+                .WithHeader("Name", "Value")
+                .AddRow("Alpha", 1)
+                .AddRow("Beta", 2)
+                .Save(path, new CsvSaveOptions { NewLine = "\n" });
+
+            var records = new List<string[]>();
+            CsvDocument.ReadRecordsReusable(path, values => records.Add(values.ToArray()));
+
+            Assert.Equal(3, records.Count);
+            Assert.Equal(new[] { "Name", "Value" }, records[0]);
+            Assert.Equal(new[] { "Alpha", "1" }, records[1]);
+            Assert.Equal(new[] { "Beta", "2" }, records[2]);
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+#if NET8_0_OR_GREATER
+    [Fact]
+    public void ReadFieldSpans_ReadsGZipByExtension()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "OfficeIMO.CSV.FieldSpans." + Guid.NewGuid().ToString("N") + ".csv.gz");
+        try
+        {
+            new CsvDocument()
+                .WithHeader("Name", "Value")
+                .AddRow("Alpha", 1)
+                .Save(path, new CsvSaveOptions { NewLine = "\n" });
+
+            var fields = new List<string>();
+            CsvDocument.ReadFieldSpans(path, (recordIndex, fieldIndex, value) => fields.Add($"{recordIndex}:{fieldIndex}:{value.ToString()}"));
+
+            Assert.Equal(new[] { "0:0:Name", "0:1:Value", "1:0:Alpha", "1:1:1" }, fields);
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+#endif
+
+    [Fact]
     public void Load_EnforcesMaxDecompressedBytes()
     {
         var path = Path.Combine(Path.GetTempPath(), "OfficeIMO.CSV.Bounded." + Guid.NewGuid().ToString("N") + ".csv.gz");
@@ -370,6 +452,38 @@ public class CsvDocumentFromObjectsTests
             }
         }
     }
+
+#if !NET8_0_OR_GREATER
+    [Fact]
+    public void Save_UnsupportedCompressionDoesNotTruncateExistingFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "OfficeIMO.CSV.UnsupportedCompression." + Guid.NewGuid().ToString("N") + ".csv.br");
+        const string original = "Name,Value\nOriginal,1\n";
+        try
+        {
+            File.WriteAllText(path, original);
+
+            Assert.Throws<PlatformNotSupportedException>(() =>
+                new CsvDocument()
+                    .WithHeader("Name", "Value")
+                    .AddRow("Replacement", 2)
+                    .Save(path, new CsvSaveOptions
+                    {
+                        CompressionType = CsvCompressionType.Brotli,
+                        NewLine = "\n"
+                    }));
+
+            Assert.Equal(original, File.ReadAllText(path));
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+#endif
 
     [Fact]
     public void SaveObjects_UsesCompressionFromDestinationExtension()

--- a/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
@@ -35,6 +35,35 @@ public class CsvStreamingTests
     }
 
     [Fact]
+    public void StreamingMode_ClonesFileOpenOptionsBeforeEnumeration()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), "OfficeIMO.CSV.StreamingClone." + Guid.NewGuid().ToString("N") + ".csv.gz");
+        try
+        {
+            new CsvDocument()
+                .WithHeader("Id", "Name")
+                .AddRow(1, "Alice")
+                .Save(tempPath, new CsvSaveOptions { NewLine = "\n" });
+
+            var options = new CsvLoadOptions { Mode = CsvLoadMode.Stream };
+            var doc = CsvDocument.Load(tempPath, options);
+
+            options.CompressionType = CsvCompressionType.None;
+            options.MaxDecompressedBytes = 1;
+
+            var row = Assert.Single(doc.AsEnumerable());
+            Assert.Equal("Alice", row.AsString("Name"));
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+            {
+                File.Delete(tempPath);
+            }
+        }
+    }
+
+    [Fact]
     public void StreamingMode_Disallows_FilterUntilMaterialized()
     {
         var csv = "Id,Value\n1,A\n2,B\n";

--- a/OfficeIMO.CSV/CsvCompressionType.cs
+++ b/OfficeIMO.CSV/CsvCompressionType.cs
@@ -1,0 +1,27 @@
+#nullable enable
+
+namespace OfficeIMO.CSV;
+
+/// <summary>
+/// Compression format used when reading or writing CSV files.
+/// </summary>
+public enum CsvCompressionType
+{
+    /// <summary>No compression is used.</summary>
+    None,
+
+    /// <summary>Infer compression from the file extension; unknown extensions are treated as uncompressed CSV.</summary>
+    Auto,
+
+    /// <summary>GZip compression, commonly used by <c>.csv.gz</c> and <c>.gzip</c> files.</summary>
+    GZip,
+
+    /// <summary>Raw Deflate compression, commonly used by <c>.deflate</c> files.</summary>
+    Deflate,
+
+    /// <summary>Brotli compression, commonly used by <c>.br</c> files.</summary>
+    Brotli,
+
+    /// <summary>ZLib compression, commonly used by <c>.zlib</c> files.</summary>
+    ZLib
+}

--- a/OfficeIMO.CSV/CsvDocument.Fields.cs
+++ b/OfficeIMO.CSV/CsvDocument.Fields.cs
@@ -1,7 +1,5 @@
 #nullable enable
 
-using System.Text;
-
 namespace OfficeIMO.CSV;
 
 public sealed partial class CsvDocument
@@ -40,8 +38,7 @@ public sealed partial class CsvDocument
         }
 
         options = CreateRawRecordOptions(options);
-        var encoding = options.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-        var readerFactory = () => new StreamReader(path, encoding, detectEncodingFromByteOrderMarks: true, bufferSize: FileBufferSize);
+        var readerFactory = () => CsvFile.OpenTextReader(path, options, FileBufferSize);
         var resolvedOptions = ResolveLoadOptions(readerFactory, options, useHeaderDiscoveryForDelimiterDetection: false);
         using var reader = readerFactory();
         ReadFieldSpans(reader, ref fieldVisitor, resolvedOptions);

--- a/OfficeIMO.CSV/CsvDocument.Loading.cs
+++ b/OfficeIMO.CSV/CsvDocument.Loading.cs
@@ -13,7 +13,7 @@ public sealed partial class CsvDocument
     {
         options ??= new CsvLoadOptions();
         var encoding = options.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-        return LoadInternal(() => new StreamReader(path, encoding, detectEncodingFromByteOrderMarks: true, bufferSize: FileBufferSize), options, encoding);
+        return LoadInternal(() => CsvFile.OpenTextReader(path, options, FileBufferSize), options, encoding);
     }
 
     /// <summary>
@@ -35,8 +35,7 @@ public sealed partial class CsvDocument
         }
 
         options ??= new CsvLoadOptions();
-        var encoding = options.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-        var readerFactory = () => new StreamReader(path, encoding, detectEncodingFromByteOrderMarks: true, bufferSize: FileBufferSize);
+        var readerFactory = () => CsvFile.OpenTextReader(path, options, FileBufferSize);
         var resolvedOptions = ResolveLoadOptions(readerFactory, options);
         using var reader = readerFactory();
         ReadRows(reader, rowAction, resolvedOptions);
@@ -61,8 +60,7 @@ public sealed partial class CsvDocument
         }
 
         options ??= new CsvLoadOptions();
-        var encoding = options.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-        var readerFactory = () => new StreamReader(path, encoding, detectEncodingFromByteOrderMarks: true, bufferSize: FileBufferSize);
+        var readerFactory = () => CsvFile.OpenTextReader(path, options, FileBufferSize);
         var resolvedOptions = ResolveLoadOptions(readerFactory, options);
         using var reader = readerFactory();
         ReadRowsReusable(reader, rowAction, resolvedOptions);

--- a/OfficeIMO.CSV/CsvDocument.Loading.cs
+++ b/OfficeIMO.CSV/CsvDocument.Loading.cs
@@ -11,9 +11,9 @@ public sealed partial class CsvDocument
     /// </summary>
     public static CsvDocument Load(string path, CsvLoadOptions? options = null)
     {
-        options ??= new CsvLoadOptions();
-        var encoding = options.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-        return LoadInternal(() => CsvFile.OpenTextReader(path, options, FileBufferSize), options, encoding);
+        var fileOptions = options?.Clone() ?? new CsvLoadOptions();
+        var encoding = fileOptions.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        return LoadInternal(() => CsvFile.OpenTextReader(path, fileOptions, FileBufferSize), fileOptions, encoding);
     }
 
     /// <summary>
@@ -34,9 +34,9 @@ public sealed partial class CsvDocument
             throw new ArgumentNullException(nameof(rowAction));
         }
 
-        options ??= new CsvLoadOptions();
-        var readerFactory = () => CsvFile.OpenTextReader(path, options, FileBufferSize);
-        var resolvedOptions = ResolveLoadOptions(readerFactory, options);
+        var fileOptions = options?.Clone() ?? new CsvLoadOptions();
+        var readerFactory = () => CsvFile.OpenTextReader(path, fileOptions, FileBufferSize);
+        var resolvedOptions = ResolveLoadOptions(readerFactory, fileOptions);
         using var reader = readerFactory();
         ReadRows(reader, rowAction, resolvedOptions);
     }
@@ -59,9 +59,9 @@ public sealed partial class CsvDocument
             throw new ArgumentNullException(nameof(rowAction));
         }
 
-        options ??= new CsvLoadOptions();
-        var readerFactory = () => CsvFile.OpenTextReader(path, options, FileBufferSize);
-        var resolvedOptions = ResolveLoadOptions(readerFactory, options);
+        var fileOptions = options?.Clone() ?? new CsvLoadOptions();
+        var readerFactory = () => CsvFile.OpenTextReader(path, fileOptions, FileBufferSize);
+        var resolvedOptions = ResolveLoadOptions(readerFactory, fileOptions);
         using var reader = readerFactory();
         ReadRowsReusable(reader, rowAction, resolvedOptions);
     }
@@ -248,7 +248,7 @@ public sealed partial class CsvDocument
             throw new ArgumentException("Stream must be readable.", nameof(stream));
         }
 
-        options ??= new CsvLoadOptions();
+        options = options?.Clone() ?? new CsvLoadOptions();
         var encoding = options.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
         if (options.Mode == CsvLoadMode.Stream || options.DetectDelimiter)
@@ -283,7 +283,7 @@ public sealed partial class CsvDocument
     /// </summary>
     public static CsvDocument Parse(string text, CsvLoadOptions? options = null)
     {
-        options ??= new CsvLoadOptions();
+        options = options?.Clone() ?? new CsvLoadOptions();
         var encoding = options.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
         return LoadInternal(() => new StringReader(text), options, encoding);
     }

--- a/OfficeIMO.CSV/CsvDocument.Records.cs
+++ b/OfficeIMO.CSV/CsvDocument.Records.cs
@@ -1,7 +1,5 @@
 #nullable enable
 
-using System.Text;
-
 namespace OfficeIMO.CSV;
 
 public sealed partial class CsvDocument
@@ -19,8 +17,7 @@ public sealed partial class CsvDocument
         }
 
         options = CreateRawRecordOptions(options);
-        var encoding = options.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-        var readerFactory = () => new StreamReader(path, encoding, detectEncodingFromByteOrderMarks: true, bufferSize: FileBufferSize);
+        var readerFactory = () => CsvFile.OpenTextReader(path, options, FileBufferSize);
         var resolvedOptions = ResolveLoadOptions(readerFactory, options, useHeaderDiscoveryForDelimiterDetection: false);
 
         return ReadRecordsIterator(readerFactory, resolvedOptions, disposeReader: true);
@@ -68,8 +65,7 @@ public sealed partial class CsvDocument
         }
 
         options = CreateRawRecordOptions(options);
-        var encoding = options.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-        var readerFactory = () => new StreamReader(path, encoding, detectEncodingFromByteOrderMarks: true, bufferSize: FileBufferSize);
+        var readerFactory = () => CsvFile.OpenTextReader(path, options, FileBufferSize);
         var resolvedOptions = ResolveLoadOptions(readerFactory, options, useHeaderDiscoveryForDelimiterDetection: false);
         using var reader = readerFactory();
         ReadRecordsReusable(reader, recordAction, resolvedOptions);

--- a/OfficeIMO.CSV/CsvDocument.cs
+++ b/OfficeIMO.CSV/CsvDocument.cs
@@ -162,7 +162,6 @@ public sealed partial class CsvDocument
         }
 
         options ??= new CsvSaveOptions();
-        var encoding = options.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
         var fullPath = Path.GetFullPath(path);
         var directory = Path.GetDirectoryName(fullPath);
         if (!string.IsNullOrEmpty(directory))
@@ -176,7 +175,7 @@ public sealed partial class CsvDocument
 
         try
         {
-            using (var writer = new StreamWriter(temporaryPath, append: false, encoding, bufferSize: 256 * 1024))
+            using (var writer = CsvFile.CreateTextWriterForCompressionPath(temporaryPath, fullPath, options, bufferSize: 256 * 1024))
             {
                 WriteObjects(writer, items, options);
             }
@@ -238,8 +237,7 @@ public sealed partial class CsvDocument
             Encoding = _encoding
         };
 
-        var encoding = options.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-        using var writer = new StreamWriter(path, append: false, encoding, bufferSize: FileBufferSize);
+        using var writer = CsvFile.CreateTextWriter(path, options, append: false, bufferSize: FileBufferSize);
         CsvWriter.Write(writer, this, options);
         return this;
     }

--- a/OfficeIMO.CSV/CsvFile.cs
+++ b/OfficeIMO.CSV/CsvFile.cs
@@ -1,0 +1,210 @@
+#nullable enable
+
+using System.IO.Compression;
+using System.Text;
+
+namespace OfficeIMO.CSV;
+
+/// <summary>
+/// Opens CSV file readers and writers with OfficeIMO CSV encoding and compression options.
+/// </summary>
+public static class CsvFile
+{
+    /// <summary>
+    /// Opens a text reader for a CSV file, applying compression from the supplied options or file extension.
+    /// </summary>
+    public static TextReader OpenTextReader(string path, CsvLoadOptions? options = null, int bufferSize = 256 * 1024)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            throw new ArgumentException("File path cannot be empty.", nameof(path));
+        }
+
+        options ??= new CsvLoadOptions();
+        var encoding = options.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        var stream = OpenReadStream(path, options, bufferSize);
+        return new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks: true, bufferSize: bufferSize);
+    }
+
+    /// <summary>
+    /// Creates a text writer for a CSV file, applying compression from the supplied options or file extension.
+    /// </summary>
+    public static TextWriter CreateTextWriter(string path, CsvSaveOptions? options = null, bool append = false, int bufferSize = 256 * 1024)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            throw new ArgumentException("File path cannot be empty.", nameof(path));
+        }
+
+        options ??= new CsvSaveOptions();
+        var encoding = options.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        var stream = CreateWriteStream(path, options, append, bufferSize);
+        return new StreamWriter(stream, encoding, bufferSize: bufferSize);
+    }
+
+    internal static TextWriter CreateTextWriterForCompressionPath(
+        string writePath,
+        string compressionPath,
+        CsvSaveOptions options,
+        int bufferSize = 256 * 1024)
+    {
+        var encoding = options.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        var stream = CreateWriteStream(writePath, ResolveCompression(options.CompressionType, compressionPath), options.CompressionLevel, append: false, bufferSize);
+        return new StreamWriter(stream, encoding, bufferSize: bufferSize);
+    }
+
+    /// <summary>
+    /// Resolves an explicit or extension-inferred compression type for a CSV path.
+    /// </summary>
+    public static CsvCompressionType ResolveCompression(CsvCompressionType compressionType, string path)
+    {
+        if (compressionType != CsvCompressionType.Auto)
+        {
+            return compressionType;
+        }
+
+        var extension = Path.GetExtension(path);
+        if (string.Equals(extension, ".gz", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(extension, ".gzip", StringComparison.OrdinalIgnoreCase))
+        {
+            return CsvCompressionType.GZip;
+        }
+
+        if (string.Equals(extension, ".deflate", StringComparison.OrdinalIgnoreCase))
+        {
+            return CsvCompressionType.Deflate;
+        }
+
+        if (string.Equals(extension, ".br", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(extension, ".brotli", StringComparison.OrdinalIgnoreCase))
+        {
+            return CsvCompressionType.Brotli;
+        }
+
+        if (string.Equals(extension, ".zlib", StringComparison.OrdinalIgnoreCase))
+        {
+            return CsvCompressionType.ZLib;
+        }
+
+        return CsvCompressionType.None;
+    }
+
+    private static Stream OpenReadStream(string path, CsvLoadOptions options, int bufferSize)
+    {
+        var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize, FileOptions.SequentialScan);
+        Stream stream = WrapReadStream(fileStream, ResolveCompression(options.CompressionType, path));
+        if (options.MaxDecompressedBytes is { } maxBytes)
+        {
+            if (maxBytes < 0)
+            {
+                fileStream.Dispose();
+                throw new ArgumentOutOfRangeException(nameof(options), "MaxDecompressedBytes cannot be negative.");
+            }
+
+            stream = new CsvBoundedReadStream(stream, maxBytes);
+        }
+
+        return stream;
+    }
+
+    private static Stream CreateWriteStream(string path, CsvSaveOptions options, bool append, int bufferSize) =>
+        CreateWriteStream(path, ResolveCompression(options.CompressionType, path), options.CompressionLevel, append, bufferSize);
+
+    private static Stream CreateWriteStream(string path, CsvCompressionType compressionType, CompressionLevel compressionLevel, bool append, int bufferSize)
+    {
+        if (append && compressionType != CsvCompressionType.None)
+        {
+            throw new NotSupportedException("Appending to compressed CSV files is not supported.");
+        }
+
+        var mode = append ? FileMode.Append : FileMode.Create;
+        var fileStream = new FileStream(path, mode, FileAccess.Write, FileShare.Read, bufferSize, FileOptions.SequentialScan);
+        return WrapWriteStream(fileStream, compressionType, compressionLevel);
+    }
+
+    private static Stream WrapReadStream(Stream stream, CsvCompressionType compressionType) =>
+        compressionType switch
+        {
+            CsvCompressionType.None => stream,
+            CsvCompressionType.GZip => new GZipStream(stream, CompressionMode.Decompress, leaveOpen: false),
+            CsvCompressionType.Deflate => new DeflateStream(stream, CompressionMode.Decompress, leaveOpen: false),
+#if NET8_0_OR_GREATER
+            CsvCompressionType.Brotli => new BrotliStream(stream, CompressionMode.Decompress, leaveOpen: false),
+            CsvCompressionType.ZLib => new ZLibStream(stream, CompressionMode.Decompress, leaveOpen: false),
+#else
+            CsvCompressionType.Brotli => throw new PlatformNotSupportedException("Brotli CSV compression requires a .NET runtime that supports BrotliStream."),
+            CsvCompressionType.ZLib => throw new PlatformNotSupportedException("ZLib CSV compression requires a .NET runtime that supports ZLibStream."),
+#endif
+            _ => throw new ArgumentOutOfRangeException(nameof(compressionType), compressionType, "Unsupported CSV compression type.")
+        };
+
+    private static Stream WrapWriteStream(Stream stream, CsvCompressionType compressionType, CompressionLevel compressionLevel) =>
+        compressionType switch
+        {
+            CsvCompressionType.None => stream,
+            CsvCompressionType.GZip => new GZipStream(stream, compressionLevel, leaveOpen: false),
+            CsvCompressionType.Deflate => new DeflateStream(stream, compressionLevel, leaveOpen: false),
+#if NET8_0_OR_GREATER
+            CsvCompressionType.Brotli => new BrotliStream(stream, compressionLevel, leaveOpen: false),
+            CsvCompressionType.ZLib => new ZLibStream(stream, compressionLevel, leaveOpen: false),
+#else
+            CsvCompressionType.Brotli => throw new PlatformNotSupportedException("Brotli CSV compression requires a .NET runtime that supports BrotliStream."),
+            CsvCompressionType.ZLib => throw new PlatformNotSupportedException("ZLib CSV compression requires a .NET runtime that supports ZLibStream."),
+#endif
+            _ => throw new ArgumentOutOfRangeException(nameof(compressionType), compressionType, "Unsupported CSV compression type.")
+        };
+
+    private sealed class CsvBoundedReadStream : Stream
+    {
+        private readonly Stream _inner;
+        private readonly long _maxBytes;
+        private long _bytesRead;
+
+        public CsvBoundedReadStream(Stream inner, long maxBytes)
+        {
+            _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+            _maxBytes = maxBytes;
+        }
+
+        public override bool CanRead => _inner.CanRead;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => _inner.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var read = _inner.Read(buffer, offset, count);
+            _bytesRead += read;
+            if (_bytesRead > _maxBytes)
+            {
+                throw new InvalidOperationException($"CSV decompressed data exceeded the configured limit of {_maxBytes} bytes.");
+            }
+
+            return read;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/OfficeIMO.CSV/CsvFile.cs
+++ b/OfficeIMO.CSV/CsvFile.cs
@@ -114,6 +114,7 @@ public static class CsvFile
     private static Stream CreateWriteStream(string path, CsvCompressionType compressionType, CompressionLevel compressionLevel, bool append, int bufferSize)
     {
         EnsureCompressionSupported(compressionType);
+        EnsureCompressionLevelSupported(compressionType, compressionLevel);
         if (append && compressionType != CsvCompressionType.None)
         {
             throw new NotSupportedException("Appending to compressed CSV files is not supported.");
@@ -155,6 +156,19 @@ public static class CsvFile
 #endif
             _ => throw new ArgumentOutOfRangeException(nameof(compressionType), compressionType, "Unsupported CSV compression type.")
         };
+
+    private static void EnsureCompressionLevelSupported(CsvCompressionType compressionType, CompressionLevel compressionLevel)
+    {
+        if (compressionType == CsvCompressionType.None)
+        {
+            return;
+        }
+
+        if (!Enum.IsDefined(typeof(CompressionLevel), compressionLevel))
+        {
+            throw new ArgumentOutOfRangeException(nameof(compressionLevel), compressionLevel, "Unsupported CSV compression level.");
+        }
+    }
 
     private static void EnsureCompressionSupported(CsvCompressionType compressionType)
     {

--- a/OfficeIMO.CSV/CsvFile.cs
+++ b/OfficeIMO.CSV/CsvFile.cs
@@ -91,17 +91,18 @@ public static class CsvFile
 
     private static Stream OpenReadStream(string path, CsvLoadOptions options, int bufferSize)
     {
-        var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize, FileOptions.SequentialScan);
-        Stream stream = WrapReadStream(fileStream, ResolveCompression(options.CompressionType, path));
-        if (options.MaxDecompressedBytes is { } maxBytes)
+        var compressionType = ResolveCompression(options.CompressionType, path);
+        EnsureCompressionSupported(compressionType);
+        if (options.MaxDecompressedBytes is { } maxBytes && maxBytes < 0)
         {
-            if (maxBytes < 0)
-            {
-                fileStream.Dispose();
-                throw new ArgumentOutOfRangeException(nameof(options), "MaxDecompressedBytes cannot be negative.");
-            }
+            throw new ArgumentOutOfRangeException(nameof(options), "MaxDecompressedBytes cannot be negative.");
+        }
 
-            stream = new CsvBoundedReadStream(stream, maxBytes);
+        var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize, FileOptions.SequentialScan);
+        Stream stream = WrapReadStream(fileStream, compressionType);
+        if (options.MaxDecompressedBytes is { } maxBytesLimit)
+        {
+            stream = new CsvBoundedReadStream(stream, maxBytesLimit);
         }
 
         return stream;
@@ -112,6 +113,7 @@ public static class CsvFile
 
     private static Stream CreateWriteStream(string path, CsvCompressionType compressionType, CompressionLevel compressionLevel, bool append, int bufferSize)
     {
+        EnsureCompressionSupported(compressionType);
         if (append && compressionType != CsvCompressionType.None)
         {
             throw new NotSupportedException("Appending to compressed CSV files is not supported.");
@@ -153,6 +155,29 @@ public static class CsvFile
 #endif
             _ => throw new ArgumentOutOfRangeException(nameof(compressionType), compressionType, "Unsupported CSV compression type.")
         };
+
+    private static void EnsureCompressionSupported(CsvCompressionType compressionType)
+    {
+        switch (compressionType)
+        {
+            case CsvCompressionType.None:
+            case CsvCompressionType.GZip:
+            case CsvCompressionType.Deflate:
+                return;
+#if NET8_0_OR_GREATER
+            case CsvCompressionType.Brotli:
+            case CsvCompressionType.ZLib:
+                return;
+#else
+            case CsvCompressionType.Brotli:
+                throw new PlatformNotSupportedException("Brotli CSV compression requires a .NET runtime that supports BrotliStream.");
+            case CsvCompressionType.ZLib:
+                throw new PlatformNotSupportedException("ZLib CSV compression requires a .NET runtime that supports ZLibStream.");
+#endif
+            default:
+                throw new ArgumentOutOfRangeException(nameof(compressionType), compressionType, "Unsupported CSV compression type.");
+        }
+    }
 
     private sealed class CsvBoundedReadStream : Stream
     {

--- a/OfficeIMO.CSV/CsvLoadOptions.cs
+++ b/OfficeIMO.CSV/CsvLoadOptions.cs
@@ -105,6 +105,16 @@ public sealed class CsvLoadOptions
     public Encoding? Encoding { get; set; }
 
     /// <summary>
+    /// Gets or sets compression used when reading from files. Default infers compression from the file extension.
+    /// </summary>
+    public CsvCompressionType CompressionType { get; set; } = CsvCompressionType.Auto;
+
+    /// <summary>
+    /// Gets or sets an optional limit for decompressed bytes read from compressed CSV files.
+    /// </summary>
+    public long? MaxDecompressedBytes { get; set; }
+
+    /// <summary>
     /// Creates a shallow copy of the options instance.
     /// </summary>
     public CsvLoadOptions Clone() => (CsvLoadOptions)MemberwiseClone();

--- a/OfficeIMO.CSV/CsvSaveOptions.cs
+++ b/OfficeIMO.CSV/CsvSaveOptions.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System.Globalization;
+using System.IO.Compression;
 using System.Text;
 
 namespace OfficeIMO.CSV;
@@ -36,6 +37,16 @@ public sealed class CsvSaveOptions
     /// Gets or sets the text encoding used when writing to files. Defaults to UTF-8 without BOM when omitted.
     /// </summary>
     public Encoding? Encoding { get; set; }
+
+    /// <summary>
+    /// Gets or sets compression used when writing files. Default infers compression from the file extension.
+    /// </summary>
+    public CsvCompressionType CompressionType { get; set; } = CsvCompressionType.Auto;
+
+    /// <summary>
+    /// Gets or sets the compression level used when writing compressed CSV files.
+    /// </summary>
+    public CompressionLevel CompressionLevel { get; set; } = CompressionLevel.Optimal;
 
     /// <summary>
     /// Gets or sets how formula-like values are handled before writing CSV output. Default preserves values exactly.


### PR DESCRIPTION
## Summary
- add reusable compressed CSV file I/O to `OfficeIMO.CSV`
- support automatic compression selection for `.gz`, `.gzip`, `.deflate`, `.br`, `.brotli`, and `.zlib` paths
- add a decompressed-size guard for compressed reads and focused round-trip/file-preservation tests

## Notes
- This is split from the older CSV performance branch so the compressed file feature can be reviewed independently.
- Brotli and ZLib use the platform streams only on runtimes that expose them; older targets throw a clear `PlatformNotSupportedException` for those modes before opening/truncating destination files.
- Compressed append is intentionally rejected because appending independent compressed payloads does not produce a normal CSV append contract.

## Validation
- `dotnet test .\OfficeIMO.CSV.Tests\OfficeIMO.CSV.Tests.csproj -c Release -f net8.0 -v:minimal`
- `dotnet test .\OfficeIMO.CSV.Tests\OfficeIMO.CSV.Tests.csproj -c Release -f net472 -v:minimal`