### PR TITLE
Add Markdown HTML compatibility profiles

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -416,6 +416,7 @@ jobs:
           markdown_partitions = (
               "OfficeIMO.Tests.Markdown.",
               "OfficeIMO.Tests.MarkdownSuite",
+              "OfficeIMO.Tests.MarkdownHtmlToMarkdownCompatibilityTests",
               "OfficeIMO.Tests.MarkdownHtmlToMarkdownTests",
               "OfficeIMO.Tests.Markdown_",
               "OfficeIMO.Tests.MarkdownTranscript",
@@ -451,7 +452,7 @@ jobs:
               ;;
             markdown-suite)
               run_markdown_tests "markdown-suite" 'FullyQualifiedName~OfficeIMO.Tests.MarkdownSuite'
-              run_markdown_tests "markdown-named" 'FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlToMarkdownTests|FullyQualifiedName~OfficeIMO.Tests.Markdown_|FullyQualifiedName~OfficeIMO.Tests.MarkdownTranscript|FullyQualifiedName~OfficeIMO.Tests.MarkdownReaderBomTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownBlankLinesTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownDefinitionLinesTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownOrderedListsTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownStreamingPreviewTests|FullyQualifiedName~OfficeIMO.Tests.Markdown_Renderer|FullyQualifiedName~OfficeIMO.Tests.Markdown_IntelligenceX'
+              run_markdown_tests "markdown-named" 'FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlToMarkdownCompatibilityTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownHtmlToMarkdownTests|FullyQualifiedName~OfficeIMO.Tests.Markdown_|FullyQualifiedName~OfficeIMO.Tests.MarkdownTranscript|FullyQualifiedName~OfficeIMO.Tests.MarkdownReaderBomTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownBlankLinesTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownDefinitionLinesTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownOrderedListsTests|FullyQualifiedName~OfficeIMO.Tests.MarkdownStreamingPreviewTests|FullyQualifiedName~OfficeIMO.Tests.Markdown_Renderer|FullyQualifiedName~OfficeIMO.Tests.Markdown_IntelligenceX'
               ;;
             pdf-visual-inspector)
               run_pdf_tests "pdf-visual-inspector" 'FullyQualifiedName~OfficeIMO.Tests.Pdf.PdfDocumentVisualQualityTests|FullyQualifiedName~OfficeIMO.Tests.Pdf.PdfInspectorTests|FullyQualifiedName~OfficeIMO.Tests.Pdf.PdfReaderAndFooterRegressionTests|FullyQualifiedName~OfficeIMO.Tests.Pdf.MarkdownSaveAsPdfVisualTests|FullyQualifiedName~OfficeIMO.Tests.Pdf.PdfDocumentRasterVisualBaselineTests'

--- a/OfficeIMO.Markdown.Benchmarks/HtmlToMarkdownBenchmarkCorpus.cs
+++ b/OfficeIMO.Markdown.Benchmarks/HtmlToMarkdownBenchmarkCorpus.cs
@@ -1,0 +1,134 @@
+using System.Text;
+
+namespace OfficeIMO.Markdown.Benchmarks;
+
+internal static class HtmlToMarkdownBenchmarkCorpus {
+    private static readonly IReadOnlyDictionary<string, string> Corpora = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+        ["Article"] = BuildArticle(),
+        ["LargeArticle"] = BuildLargeArticle(),
+        ["Table"] = BuildTable(),
+        ["NestedLists"] = BuildNestedLists(),
+        ["MixedDocument"] = BuildMixedDocument()
+    };
+
+    public static IEnumerable<string> Names => Corpora.Keys;
+
+    public static string Get(string name) => Corpora[name];
+
+    public static string GetExpectedFragment(string name) => name switch {
+        "Article" => "OfficeIMO Markdown Notes",
+        "LargeArticle" => "Section 120",
+        "Table" => "Capability 240",
+        "NestedLists" => "Check 40.8",
+        "MixedDocument" => "Release Report",
+        _ => throw new ArgumentOutOfRangeException(nameof(name), name, "Unknown benchmark corpus.")
+    };
+
+    private static string BuildArticle() {
+        const string section = """
+<article>
+  <h1>OfficeIMO Markdown Notes</h1>
+  <p>OfficeIMO can convert <strong>HTML</strong> into <a href="https://example.com/docs">Markdown</a>.</p>
+  <p>The converter keeps code such as <code>MarkdownDoc.Create()</code> readable.</p>
+  <blockquote><p>Representative fixtures should look like real docs.</p></blockquote>
+  <ul>
+    <li>Parse the document</li>
+    <li>Build a typed model</li>
+    <li>Render Markdown</li>
+  </ul>
+</article>
+""";
+
+        return section;
+    }
+
+    private static string BuildLargeArticle() {
+        var builder = new StringBuilder();
+        builder.AppendLine("<main>");
+        for (int i = 1; i <= 120; i++) {
+            builder.AppendLine("<section>");
+            builder.Append("<h2>Section ").Append(i).AppendLine("</h2>");
+            builder.Append("<p>Paragraph ").Append(i).Append(" links to <a href=\"https://example.com/docs/")
+                .Append(i)
+                .Append("\">https://example.com/docs/")
+                .Append(i)
+                .AppendLine("</a> and contains <strong>important</strong> details.</p>");
+            builder.AppendLine("<p>Second paragraph includes <em>emphasis</em>, <code>inline code</code>, and normal text.</p>");
+            builder.AppendLine("</section>");
+        }
+
+        builder.AppendLine("</main>");
+        return builder.ToString();
+    }
+
+    private static string BuildTable() {
+        var builder = new StringBuilder();
+        builder.AppendLine("<table>");
+        builder.AppendLine("<thead><tr><th>Area</th><th>Status</th><th>Notes</th></tr></thead>");
+        builder.AppendLine("<tbody>");
+        for (int row = 1; row <= 240; row++) {
+            builder.Append("<tr><td>Capability ")
+                .Append(row)
+                .Append("</td><td>Active</td><td>Uses <strong>typed</strong> conversion and <a href=\"https://example.com/cases/")
+                .Append(row)
+                .Append("\">case ")
+                .Append(row)
+                .AppendLine("</a>.</td></tr>");
+        }
+
+        builder.AppendLine("</tbody>");
+        builder.AppendLine("</table>");
+        return builder.ToString();
+    }
+
+    private static string BuildNestedLists() {
+        var builder = new StringBuilder();
+        builder.AppendLine("<article><h1>Checklist</h1><ol>");
+        for (int section = 1; section <= 40; section++) {
+            builder.Append("<li>Section ")
+                .Append(section)
+                .AppendLine("<ul>");
+            for (int item = 1; item <= 8; item++) {
+                builder.Append("<li><strong>Check ")
+                    .Append(section)
+                    .Append('.')
+                    .Append(item)
+                    .Append("</strong> with <a href=\"https://example.com/runbooks/")
+                    .Append(section)
+                    .Append('/')
+                    .Append(item)
+                    .AppendLine("\">runbook</a></li>");
+            }
+
+            builder.AppendLine("</ul></li>");
+        }
+
+        builder.AppendLine("</ol></article>");
+        return builder.ToString();
+    }
+
+    private static string BuildMixedDocument() {
+        return """
+<article>
+  <h1>Release Report</h1>
+  <p><a href="https://example.com">https://example.com</a></p>
+  <figure>
+    <img src="https://example.com/logo.png" alt="Logo" width="256" height="128" />
+    <figcaption>Project logo</figcaption>
+  </figure>
+  <details>
+    <summary>Deployment details</summary>
+    <p>Staging is complete and production is pending.</p>
+  </details>
+  <pre><code class="language-csharp">var doc = MarkdownDoc.Create();
+doc.H1("Status");</code></pre>
+  <table>
+    <tr><th>Name</th><th>Value</th></tr>
+    <tr><td>Runtime</td><td>.NET</td></tr>
+    <tr><td>Mode</td><td>Benchmark</td></tr>
+  </table>
+  <custom-widget data-id="42"><strong>Custom</strong> payload</custom-widget>
+</article>
+""";
+    }
+}

--- a/OfficeIMO.Markdown.Benchmarks/HtmlToMarkdownBenchmarks.cs
+++ b/OfficeIMO.Markdown.Benchmarks/HtmlToMarkdownBenchmarks.cs
@@ -1,0 +1,76 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using OfficeIMO.Markdown.Html;
+
+namespace OfficeIMO.Markdown.Benchmarks;
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net80)]
+public class HtmlToMarkdownBenchmarks {
+    private HtmlToMarkdownConverter _officeConverter = null!;
+    private HtmlToMarkdownOptions _officeOptions = null!;
+    private HtmlToMarkdownOptions _githubOptions = null!;
+    private HtmlToMarkdownOptions _commonMarkOptions = null!;
+    private ReverseMarkdown.Converter _reverseDefault = null!;
+    private ReverseMarkdown.Converter _reverseGitHub = null!;
+    private ReverseMarkdown.Converter _reverseCommonMark = null!;
+    private string _html = string.Empty;
+
+    [ParamsSource(nameof(CorpusNames))]
+    public string CorpusName { get; set; } = string.Empty;
+
+    public IEnumerable<string> CorpusNames() => HtmlToMarkdownBenchmarkCorpus.Names;
+
+    [GlobalSetup]
+    public void Setup() {
+        _officeConverter = new HtmlToMarkdownConverter();
+        _officeOptions = HtmlToMarkdownOptions.CreateOfficeIMOProfile();
+        _githubOptions = HtmlToMarkdownOptions.CreateGitHubFlavoredMarkdownProfile();
+        _commonMarkOptions = HtmlToMarkdownOptions.CreateCommonMarkProfile();
+        _reverseDefault = new ReverseMarkdown.Converter();
+        _reverseGitHub = new ReverseMarkdown.Converter(new ReverseMarkdown.Config {
+            Flavor = ReverseMarkdown.Config.MarkdownFlavor.GitHub,
+            Links = { SmartHref = true }
+        });
+        _reverseCommonMark = new ReverseMarkdown.Converter(new ReverseMarkdown.Config {
+            Flavor = ReverseMarkdown.Config.MarkdownFlavor.CommonMark
+        });
+        _html = HtmlToMarkdownBenchmarkCorpus.Get(CorpusName);
+        ValidateConverterOutputs(HtmlToMarkdownBenchmarkCorpus.GetExpectedFragment(CorpusName));
+    }
+
+    [Benchmark(Baseline = true)]
+    public string OfficeIMO_GitHub_Profile() => _officeConverter.Convert(_html, _githubOptions);
+
+    [Benchmark]
+    public string OfficeIMO_CommonMark_Profile() => _officeConverter.Convert(_html, _commonMarkOptions);
+
+    [Benchmark]
+    public string OfficeIMO_Default_Profile() => _officeConverter.Convert(_html, _officeOptions);
+
+    [Benchmark]
+    public string ReverseMarkdown_GitHub_Profile() => _reverseGitHub.Convert(_html);
+
+    [Benchmark]
+    public string ReverseMarkdown_CommonMark_Profile() => _reverseCommonMark.Convert(_html);
+
+    [Benchmark]
+    public string ReverseMarkdown_Default_Profile() => _reverseDefault.Convert(_html);
+
+    private void ValidateConverterOutputs(string expectedFragment) {
+        ValidateOutput(nameof(OfficeIMO_GitHub_Profile), OfficeIMO_GitHub_Profile(), expectedFragment);
+        ValidateOutput(nameof(OfficeIMO_CommonMark_Profile), OfficeIMO_CommonMark_Profile(), expectedFragment);
+        ValidateOutput(nameof(OfficeIMO_Default_Profile), OfficeIMO_Default_Profile(), expectedFragment);
+        ValidateOutput(nameof(ReverseMarkdown_GitHub_Profile), ReverseMarkdown_GitHub_Profile(), expectedFragment);
+        ValidateOutput(nameof(ReverseMarkdown_CommonMark_Profile), ReverseMarkdown_CommonMark_Profile(), expectedFragment);
+        ValidateOutput(nameof(ReverseMarkdown_Default_Profile), ReverseMarkdown_Default_Profile(), expectedFragment);
+    }
+
+    private static void ValidateOutput(string laneName, string markdown, string expectedFragment) {
+        if (string.IsNullOrWhiteSpace(markdown) ||
+            !markdown.Contains(expectedFragment, StringComparison.Ordinal)) {
+            throw new InvalidOperationException(
+                $"{laneName} did not preserve expected benchmark content '{expectedFragment}'.");
+        }
+    }
+}

--- a/OfficeIMO.Markdown.Benchmarks/OfficeIMO.Markdown.Benchmarks.csproj
+++ b/OfficeIMO.Markdown.Benchmarks/OfficeIMO.Markdown.Benchmarks.csproj
@@ -12,10 +12,12 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="Markdig" Version="1.3.2" />
+    <PackageReference Include="ReverseMarkdown" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\OfficeIMO.Markdown\OfficeIMO.Markdown.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Markdown.Html\OfficeIMO.Markdown.Html.csproj" />
   </ItemGroup>
 
 </Project>

--- a/OfficeIMO.Markdown.Benchmarks/README.md
+++ b/OfficeIMO.Markdown.Benchmarks/README.md
@@ -14,6 +14,13 @@ Run a narrower benchmark by class when you only need one lane:
 
 ```powershell
 dotnet run --project OfficeIMO.Markdown.Benchmarks/OfficeIMO.Markdown.Benchmarks.csproj -c Release -f net8.0 -- --filter *MarkdownTransformBenchmarks*
+dotnet run --project OfficeIMO.Markdown.Benchmarks/OfficeIMO.Markdown.Benchmarks.csproj -c Release -f net8.0 -- --filter *HtmlToMarkdownBenchmarks*
+```
+
+For a quick harness smoke without publication-grade timing, use BenchmarkDotNet's dry job:
+
+```powershell
+dotnet run --project OfficeIMO.Markdown.Benchmarks/OfficeIMO.Markdown.Benchmarks.csproj -c Release -f net8.0 -- --filter *HtmlToMarkdownBenchmarks* --job Dry --warmupCount 1 --iterationCount 1
 ```
 
 ## Corpus
@@ -26,10 +33,12 @@ Benchmark classes currently cover:
 - syntax-tree parse cost
 - HTML render cost against the current Markdig baseline
 - document normalization transform cost, including syntax-tree diagnostics
+- HTML-to-Markdown conversion cost across OfficeIMO output profiles and the current ReverseMarkdown benchmark-only baseline
 
 ## Boundaries
 
 - Benchmark scenarios belong here.
 - Runtime Markdown behavior belongs in `OfficeIMO.Markdown`.
 - Renderer host behavior belongs in `OfficeIMO.MarkdownRenderer`.
+- ReverseMarkdown is a benchmark-only comparison package in this project and must not become a runtime dependency.
 - Release decisions should use benchmark evidence together with correctness tests and representative document fixtures.

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.Flow.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.Flow.cs
@@ -73,7 +73,7 @@ public sealed partial class HtmlToMarkdownConverter {
                 list.Start = start;
             }
 
-            foreach (var item in element.Children.Where(child => child.TagName.Equals("LI", StringComparison.OrdinalIgnoreCase))) {
+            foreach (var item in element.Children.Where(child => HasEffectiveTagName(child, context, "LI"))) {
                 list.Items.Add(ConvertListItem(item, context));
             }
 
@@ -81,7 +81,7 @@ public sealed partial class HtmlToMarkdownConverter {
         }
 
         var unordered = new UnorderedListBlock();
-        foreach (var item in element.Children.Where(child => child.TagName.Equals("LI", StringComparison.OrdinalIgnoreCase))) {
+        foreach (var item in element.Children.Where(child => HasEffectiveTagName(child, context, "LI"))) {
             unordered.Items.Add(ConvertListItem(item, context));
         }
         return unordered;
@@ -94,7 +94,7 @@ public sealed partial class HtmlToMarkdownConverter {
 
         foreach (var child in element.ChildNodes) {
             if (child is IElement childElement
-                && childElement.TagName.Equals("INPUT", StringComparison.OrdinalIgnoreCase)
+                && HasEffectiveTagName(childElement, context, "INPUT")
                 && string.Equals(childElement.GetAttribute("type"), "checkbox", StringComparison.OrdinalIgnoreCase)) {
                 isTask = true;
                 isChecked = childElement.HasAttribute("checked");

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.Flow.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.Flow.cs
@@ -46,8 +46,8 @@ public sealed partial class HtmlToMarkdownConverter {
             return false;
         }
 
-        bool isStandaloneMedia = onlyElement.TagName.Equals("IMG", StringComparison.OrdinalIgnoreCase)
-                                 || onlyElement.TagName.Equals("PICTURE", StringComparison.OrdinalIgnoreCase)
+        bool isStandaloneMedia = HasEffectiveTagName(onlyElement, context, "IMG")
+                                 || HasEffectiveTagName(onlyElement, context, "PICTURE")
                                  || CanConvertAnchorToLinkedImageBlock(onlyElement, context);
         if (!isStandaloneMedia) {
             return false;

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.ImageSources.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.ImageSources.cs
@@ -31,7 +31,45 @@ public sealed partial class HtmlToMarkdownConverter {
     }
 
     private static string ResolvePictureSource(IElement pictureElement, ConversionContext context) {
-        return HtmlImageSourceResolver.ResolvePictureSource(pictureElement, context.Options.BaseUri, context.Options.UrlPolicy);
+        foreach (string candidate in ResolvePictureSourceCandidates(pictureElement, context)) {
+            if (!string.IsNullOrWhiteSpace(candidate)) {
+                return candidate;
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private static IReadOnlyList<string> ResolvePictureSourceCandidates(IElement pictureElement, ConversionContext context) {
+        var candidates = new List<string>();
+        if (pictureElement == null || context == null) {
+            return candidates;
+        }
+
+        foreach (var child in pictureElement.Children) {
+            if (!HasEffectiveTagName(child, context, "SOURCE")) {
+                continue;
+            }
+
+            AddResolvedCandidate(candidates, ResolveUrlFromSrcSetAttributes(child, context, "srcset", "data-srcset", "data-original-srcset", "data-lazy-srcset"));
+            AddResolvedCandidate(candidates, ResolveUrlAttributes(child, context, "src", "data-src", "data-original-src", "data-lazy-src"));
+        }
+
+        var imageElement = FindFirstDescendantByEffectiveTagName(pictureElement, context, "IMG");
+        if (imageElement != null) {
+            AddResolvedCandidate(candidates, ResolveUrlFromSrcSetAttributes(imageElement, context, "srcset", "data-srcset", "data-original-srcset", "data-lazy-srcset"));
+            AddResolvedCandidate(candidates, ResolveUrlAttributes(imageElement, context, "src", "data-src", "data-original", "data-original-src", "data-lazy-src"));
+        }
+
+        return candidates;
+    }
+
+    private static void AddResolvedCandidate(IList<string> candidates, string? value) {
+        if (candidates == null || string.IsNullOrWhiteSpace(value)) {
+            return;
+        }
+
+        candidates.Add(value!);
     }
 
     private static string ResolveUrlFromSrcSet(string? rawSrcSet, ConversionContext context) {
@@ -112,7 +150,7 @@ public sealed partial class HtmlToMarkdownConverter {
         }
 
         if (HasUsableImageCandidateWithoutSideEffects(
-            HtmlImageSourceResolver.ResolvePictureSourceCandidates(element, context.Options.BaseUri, context.Options.UrlPolicy),
+            ResolvePictureSourceCandidates(element, context),
             context)) {
             return true;
         }

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.ImageSources.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.ImageSources.cs
@@ -31,10 +31,8 @@ public sealed partial class HtmlToMarkdownConverter {
     }
 
     private static string ResolvePictureSource(IElement pictureElement, ConversionContext context) {
-        foreach (string candidate in ResolvePictureSourceCandidates(pictureElement, context)) {
-            if (!string.IsNullOrWhiteSpace(candidate)) {
-                return candidate;
-            }
+        if (TryResolveUsableImageCandidate(ResolvePictureSourceCandidates(pictureElement, context), context, out string source)) {
+            return source;
         }
 
         return string.Empty;
@@ -51,11 +49,28 @@ public sealed partial class HtmlToMarkdownConverter {
                 continue;
             }
 
-            AddResolvedCandidate(candidates, ResolveUrlFromSrcSetAttributes(child, context, "srcset", "data-srcset", "data-original-srcset", "data-lazy-srcset"));
+            AddResolvedSrcSetCandidateAttributes(candidates, child, context, "srcset", "data-srcset", "data-original-srcset", "data-lazy-srcset");
             AddResolvedCandidate(candidates, ResolveUrlAttributes(child, context, "src", "data-src", "data-original-src", "data-lazy-src"));
         }
 
         return candidates;
+    }
+
+    private static void AddResolvedSrcSetCandidateAttributes(IList<string> candidates, IElement element, ConversionContext context, params string[] attributeNames) {
+        if (candidates == null || element == null || context == null || attributeNames == null) {
+            return;
+        }
+
+        for (int i = 0; i < attributeNames.Length; i++) {
+            IReadOnlyList<HtmlSrcSetCandidate> srcSetCandidates = HtmlImageSourceResolver.ResolveSrcSetCandidates(
+                element.GetAttribute(attributeNames[i]),
+                context.Options.BaseUri,
+                context.Options.UrlPolicy);
+
+            for (int candidateIndex = 0; candidateIndex < srcSetCandidates.Count; candidateIndex++) {
+                AddResolvedCandidate(candidates, srcSetCandidates[candidateIndex].Url);
+            }
+        }
     }
 
     private static void AddResolvedCandidate(IList<string> candidates, string? value) {

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.ImageSources.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.ImageSources.cs
@@ -55,12 +55,6 @@ public sealed partial class HtmlToMarkdownConverter {
             AddResolvedCandidate(candidates, ResolveUrlAttributes(child, context, "src", "data-src", "data-original-src", "data-lazy-src"));
         }
 
-        var imageElement = FindFirstDescendantByEffectiveTagName(pictureElement, context, "IMG");
-        if (imageElement != null) {
-            AddResolvedCandidate(candidates, ResolveUrlFromSrcSetAttributes(imageElement, context, "srcset", "data-srcset", "data-original-srcset", "data-lazy-srcset"));
-            AddResolvedCandidate(candidates, ResolveUrlAttributes(imageElement, context, "src", "data-src", "data-original", "data-original-src", "data-lazy-src"));
-        }
-
         return candidates;
     }
 

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.ImageSources.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.ImageSources.cs
@@ -99,7 +99,7 @@ public sealed partial class HtmlToMarkdownConverter {
             return false;
         }
 
-        if (fallbackMediaElement.TagName.Equals("PICTURE", StringComparison.OrdinalIgnoreCase)) {
+        if (HasEffectiveTagName(fallbackMediaElement, context, "PICTURE")) {
             return CanCreatePictureImageBlockWithoutSideEffects(fallbackMediaElement, context);
         }
 
@@ -117,7 +117,7 @@ public sealed partial class HtmlToMarkdownConverter {
             return true;
         }
 
-        var imageElement = element.QuerySelector("img");
+        var imageElement = FindFirstDescendantByEffectiveTagName(element, context, "IMG");
         return imageElement != null && CanCreateImageBlockWithoutSideEffects(imageElement, context);
     }
 
@@ -197,13 +197,13 @@ public sealed partial class HtmlToMarkdownConverter {
             return false;
         }
 
-        if (fallbackMediaElement.TagName.Equals("PICTURE", StringComparison.OrdinalIgnoreCase)) {
+        if (HasEffectiveTagName(fallbackMediaElement, context, "PICTURE")) {
             var pictureImage = ConvertPictureElement(fallbackMediaElement, context).OfType<ImageBlock>().FirstOrDefault();
             if (pictureImage == null) {
                 return false;
             }
 
-            image = MergeImageMetadata(element, pictureImage, fallbackMediaElement.QuerySelector("img"));
+            image = MergeImageMetadata(element, pictureImage, FindFirstDescendantByEffectiveTagName(fallbackMediaElement, context, "IMG"));
             return true;
         }
 
@@ -283,7 +283,7 @@ public sealed partial class HtmlToMarkdownConverter {
     private static List<ImagePictureSource> CollectPictureSources(IElement pictureElement, ConversionContext context) {
         var sources = new List<ImagePictureSource>();
         foreach (var child in pictureElement.Children) {
-            if (!child.TagName.Equals("SOURCE", StringComparison.OrdinalIgnoreCase)) {
+            if (!HasEffectiveTagName(child, context, "SOURCE")) {
                 continue;
             }
 
@@ -513,7 +513,7 @@ public sealed partial class HtmlToMarkdownConverter {
 
     private static bool TryCreateLinkedImageBlockFromAnchor(IElement anchorElement, ConversionContext context, out ImageBlock image) {
         image = null!;
-        if (anchorElement == null || !anchorElement.TagName.Equals("A", StringComparison.OrdinalIgnoreCase)) {
+        if (anchorElement == null || !HasEffectiveTagName(anchorElement, context, "A")) {
             return false;
         }
 
@@ -522,11 +522,11 @@ public sealed partial class HtmlToMarkdownConverter {
             return false;
         }
 
-        if (!TryResolveAnchorMediaElement(anchorElement, out var mediaElement)) {
+        if (!TryResolveAnchorMediaElement(anchorElement, context, out var mediaElement)) {
             return false;
         }
 
-        if (mediaElement.TagName.Equals("IMG", StringComparison.OrdinalIgnoreCase)
+        if (HasEffectiveTagName(mediaElement, context, "IMG")
             && TryCreateImageBlock(mediaElement, context, out image)) {
             image.LinkUrl = href;
             image.LinkTitle = anchorElement.GetAttribute("title");
@@ -535,7 +535,7 @@ public sealed partial class HtmlToMarkdownConverter {
             return true;
         }
 
-        if (!mediaElement.TagName.Equals("PICTURE", StringComparison.OrdinalIgnoreCase)) {
+        if (!HasEffectiveTagName(mediaElement, context, "PICTURE")) {
             return false;
         }
 

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.Media.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.Media.cs
@@ -22,7 +22,7 @@ public sealed partial class HtmlToMarkdownConverter {
         bool hasUnsafePictureCandidate = HasRejectedPictureSourceCandidate(element, context)
                                          || (context.Options.Base64Images != HtmlBase64ImageHandling.Include
                                              && HasBase64PictureCandidate(element, context));
-        var imageElement = element.QuerySelector("img");
+        var imageElement = FindFirstDescendantByEffectiveTagName(element, context, "IMG");
         if (imageElement != null && TryCreateImageBlock(imageElement, context, out var imageBlock)) {
             if (!string.IsNullOrWhiteSpace(preferredSrc) && !TryApplyBase64ImageHandling(ref preferredSrc, context)) {
                 preferredSrc = string.Empty;
@@ -55,10 +55,10 @@ public sealed partial class HtmlToMarkdownConverter {
     }
 
     private static IEnumerable<IMarkdownBlock> ConvertFigureElement(IElement element, ConversionContext context) {
-        var directCaption = element.Children.FirstOrDefault(child => child.TagName.Equals("FIGCAPTION", StringComparison.OrdinalIgnoreCase));
-        var directMediaContainer = element.Children.FirstOrDefault(child => TryResolveFigureMediaElement(child, out _));
+        var directCaption = FindDirectChildByEffectiveTagName(element, context, "FIGCAPTION");
+        var directMediaContainer = element.Children.FirstOrDefault(child => TryResolveFigureMediaElement(child, context, out _));
 
-        if (directMediaContainer != null && TryResolveFigureMediaElement(directMediaContainer, out var directMedia)) {
+        if (directMediaContainer != null && TryResolveFigureMediaElement(directMediaContainer, context, out var directMedia)) {
             var figureBlocks = new List<IMarkdownBlock>();
             foreach (var child in element.ChildNodes) {
                 if (ReferenceEquals(child, directCaption)) {
@@ -80,13 +80,13 @@ public sealed partial class HtmlToMarkdownConverter {
             }
         }
 
-        var imageElement = element.QuerySelector("img");
+        var imageElement = FindFirstDescendantByEffectiveTagName(element, context, "IMG");
         if (imageElement == null) {
-            var pictureElement = element.QuerySelector("picture");
+            var pictureElement = FindFirstDescendantByEffectiveTagName(element, context, "PICTURE");
             if (pictureElement != null) {
                 var pictureBlocks = ConvertPictureElement(pictureElement, context).ToList();
                 if (pictureBlocks.Count > 0) {
-                    ApplyFigureCaptionToMedia(pictureBlocks, directCaption ?? element.QuerySelector("figcaption"));
+                    ApplyFigureCaptionToMedia(pictureBlocks, directCaption ?? FindFirstDescendantByEffectiveTagName(element, context, "FIGCAPTION"));
 
                     return pictureBlocks;
                 }
@@ -105,7 +105,7 @@ public sealed partial class HtmlToMarkdownConverter {
         }
 
         var blocks = ConvertImageElement(imageElement, context).ToList();
-        ApplyFigureCaptionToMedia(blocks, directCaption ?? element.QuerySelector("figcaption"));
+        ApplyFigureCaptionToMedia(blocks, directCaption ?? FindFirstDescendantByEffectiveTagName(element, context, "FIGCAPTION"));
 
         return blocks;
     }
@@ -118,24 +118,24 @@ public sealed partial class HtmlToMarkdownConverter {
         imageBlock.Caption = NormalizeBlockText(captionElement.TextContent);
     }
 
-    private static bool IsLinkedFigureMediaAnchor(IElement element) {
-        return TryResolveAnchorMediaElement(element, out _);
+    private static bool IsLinkedFigureMediaAnchor(IElement element, ConversionContext context) {
+        return TryResolveAnchorMediaElement(element, context, out _);
     }
 
-    private static bool TryResolveFigureMediaElement(IElement element, out IElement mediaElement) {
+    private static bool TryResolveFigureMediaElement(IElement element, ConversionContext context, out IElement mediaElement) {
         return TryResolvePureWrapperElement(
             element,
             candidate =>
-                candidate.TagName.Equals("IMG", StringComparison.OrdinalIgnoreCase)
-                || candidate.TagName.Equals("PICTURE", StringComparison.OrdinalIgnoreCase)
-                || IsLinkedFigureMediaAnchor(candidate),
-            candidate => !candidate.TagName.Equals("FIGCAPTION", StringComparison.OrdinalIgnoreCase),
+                HasEffectiveTagName(candidate, context, "IMG")
+                || HasEffectiveTagName(candidate, context, "PICTURE")
+                || IsLinkedFigureMediaAnchor(candidate, context),
+            candidate => !HasEffectiveTagName(candidate, context, "FIGCAPTION"),
             out mediaElement);
     }
 
-    private static bool TryResolveAnchorMediaElement(IElement element, out IElement mediaElement) {
+    private static bool TryResolveAnchorMediaElement(IElement element, ConversionContext context, out IElement mediaElement) {
         mediaElement = null!;
-        if (element == null || !element.TagName.Equals("A", StringComparison.OrdinalIgnoreCase) || HasVisibleOwnTextNodes(element)) {
+        if (element == null || !HasEffectiveTagName(element, context, "A") || HasVisibleOwnTextNodes(element)) {
             return false;
         }
 
@@ -147,17 +147,17 @@ public sealed partial class HtmlToMarkdownConverter {
                     continue;
                 case IElement childElement when IsIgnorableMediaWrapperChild(childElement):
                     continue;
-                case IElement childElement when childElement.TagName.Equals("IMG", StringComparison.OrdinalIgnoreCase)
-                    || childElement.TagName.Equals("PICTURE", StringComparison.OrdinalIgnoreCase):
+                case IElement childElement when HasEffectiveTagName(childElement, context, "IMG")
+                    || HasEffectiveTagName(childElement, context, "PICTURE"):
                     mediaElement = childElement;
                     return true;
-                case IElement childElement when !childElement.TagName.Equals("A", StringComparison.OrdinalIgnoreCase)
+                case IElement childElement when !HasEffectiveTagName(childElement, context, "A")
                     && TryResolvePureWrapperElement(
                         childElement,
                         candidate =>
-                            candidate.TagName.Equals("IMG", StringComparison.OrdinalIgnoreCase)
-                            || candidate.TagName.Equals("PICTURE", StringComparison.OrdinalIgnoreCase),
-                        candidate => !candidate.TagName.Equals("A", StringComparison.OrdinalIgnoreCase),
+                            HasEffectiveTagName(candidate, context, "IMG")
+                            || HasEffectiveTagName(candidate, context, "PICTURE"),
+                        candidate => !HasEffectiveTagName(candidate, context, "A"),
                         out mediaElement):
                     return true;
                 default:
@@ -234,11 +234,11 @@ public sealed partial class HtmlToMarkdownConverter {
     }
 
     private static List<IMarkdownBlock> ConvertFigureMediaElement(IElement element, ConversionContext context) {
-        if (element.TagName.Equals("PICTURE", StringComparison.OrdinalIgnoreCase)) {
+        if (HasEffectiveTagName(element, context, "PICTURE")) {
             return ConvertPictureElement(element, context).ToList();
         }
 
-        if (element.TagName.Equals("IMG", StringComparison.OrdinalIgnoreCase)) {
+        if (HasEffectiveTagName(element, context, "IMG")) {
             return ConvertImageElement(element, context).ToList();
         }
 
@@ -255,7 +255,7 @@ public sealed partial class HtmlToMarkdownConverter {
         }
 
         foreach (var child in element.Children) {
-            if (!child.TagName.Equals("SOURCE", StringComparison.OrdinalIgnoreCase)) {
+            if (!HasEffectiveTagName(child, context, "SOURCE")) {
                 continue;
             }
 
@@ -265,7 +265,7 @@ public sealed partial class HtmlToMarkdownConverter {
             }
         }
 
-        var imageElement = element.QuerySelector("img");
+        var imageElement = FindFirstDescendantByEffectiveTagName(element, context, "IMG");
         if (imageElement == null) {
             return false;
         }
@@ -280,7 +280,7 @@ public sealed partial class HtmlToMarkdownConverter {
         }
 
         foreach (var child in element.Children) {
-            if (!child.TagName.Equals("SOURCE", StringComparison.OrdinalIgnoreCase)) {
+            if (!HasEffectiveTagName(child, context, "SOURCE")) {
                 continue;
             }
 
@@ -290,7 +290,7 @@ public sealed partial class HtmlToMarkdownConverter {
             }
         }
 
-        var imageElement = element.QuerySelector("img");
+        var imageElement = FindFirstDescendantByEffectiveTagName(element, context, "IMG");
         if (imageElement == null) {
             return false;
         }
@@ -304,11 +304,11 @@ public sealed partial class HtmlToMarkdownConverter {
             return false;
         }
 
-        if (element.TagName.Equals("PICTURE", StringComparison.OrdinalIgnoreCase)) {
+        if (HasEffectiveTagName(element, context, "PICTURE")) {
             return HasRejectedPictureSourceCandidate(element, context);
         }
 
-        return element.TagName.Equals("IMG", StringComparison.OrdinalIgnoreCase)
+        return HasEffectiveTagName(element, context, "IMG")
                && (HasRejectedSrcSetAttribute(element, context, "srcset", "data-srcset", "data-original-srcset", "data-lazy-srcset")
                    || HasRejectedUrlAttribute(element, context, "src", "data-src", "data-original", "data-original-src", "data-lazy-src"));
     }
@@ -318,18 +318,18 @@ public sealed partial class HtmlToMarkdownConverter {
             return false;
         }
 
-        if (element.TagName.Equals("PICTURE", StringComparison.OrdinalIgnoreCase)) {
+        if (HasEffectiveTagName(element, context, "PICTURE")) {
             return HasBlockedBase64PictureCandidate(element, context);
         }
 
-        return element.TagName.Equals("IMG", StringComparison.OrdinalIgnoreCase)
+        return HasEffectiveTagName(element, context, "IMG")
                && (HasBlockedBase64SrcSetAttribute(element, context, "srcset", "data-srcset", "data-original-srcset", "data-lazy-srcset")
                    || HasBlockedBase64UrlAttribute(element, context, "src", "data-src", "data-original", "data-original-src", "data-lazy-src"));
     }
 
     private static bool HasBlockedBase64PictureCandidate(IElement element, ConversionContext context) {
         foreach (var child in element.Children) {
-            if (!child.TagName.Equals("SOURCE", StringComparison.OrdinalIgnoreCase)) {
+            if (!HasEffectiveTagName(child, context, "SOURCE")) {
                 continue;
             }
 
@@ -339,7 +339,7 @@ public sealed partial class HtmlToMarkdownConverter {
             }
         }
 
-        var imageElement = element.QuerySelector("img");
+        var imageElement = FindFirstDescendantByEffectiveTagName(element, context, "IMG");
         if (imageElement == null) {
             return false;
         }

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.Structured.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.Structured.cs
@@ -6,7 +6,7 @@ namespace OfficeIMO.Markdown.Html;
 public sealed partial class HtmlToMarkdownConverter {
     private static DetailsBlock ConvertDetailsElement(IElement element, ConversionContext context) {
         SummaryBlock? summary = null;
-        var summaryElement = element.Children.FirstOrDefault(child => child.TagName.Equals("SUMMARY", StringComparison.OrdinalIgnoreCase));
+        var summaryElement = element.Children.FirstOrDefault(child => HasEffectiveTagName(child, context, "SUMMARY"));
         if (summaryElement != null) {
             summary = new SummaryBlock(NormalizeInlineSequenceForBlock(ConvertInlineNodesToInlineSequence(summaryElement.ChildNodes, context)));
         }
@@ -46,7 +46,7 @@ public sealed partial class HtmlToMarkdownConverter {
         }
 
         foreach (var child in element.Children) {
-            if (child.TagName.Equals("DT", StringComparison.OrdinalIgnoreCase)) {
+            if (HasEffectiveTagName(child, context, "DT")) {
                 if (hasDefinitionsForCurrentGroup) {
                     FlushPendingGroup();
                 }
@@ -58,7 +58,7 @@ public sealed partial class HtmlToMarkdownConverter {
                 continue;
             }
 
-            if (child.TagName.Equals("DD", StringComparison.OrdinalIgnoreCase) && pendingTerms.Count > 0) {
+            if (HasEffectiveTagName(child, context, "DD") && pendingTerms.Count > 0) {
                 pendingDefinitions ??= new List<DefinitionListDefinition>();
                 pendingDefinitions.Add(new DefinitionListDefinition(ConvertDefinitionValueToBlocks(child, context)));
                 hasDefinitionsForCurrentGroup = true;

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.Tables.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.Tables.cs
@@ -14,19 +14,19 @@ public sealed partial class HtmlToMarkdownConverter {
         var columnWidthPoints = new List<double?>();
         var columnWidthWeights = new List<double?>();
         int maxExpandedColumns = context.Options.MaxTableExpandedColumns;
-        CaptureColumnGroupAlignments(element, columnAlignments, maxExpandedColumns: maxExpandedColumns);
-        CaptureColumnGroupWidths(element, columnWidthPoints, columnWidthWeights, maxExpandedColumns: maxExpandedColumns);
+        CaptureColumnGroupAlignments(element, context, columnAlignments, maxExpandedColumns: maxExpandedColumns);
+        CaptureColumnGroupWidths(element, context, columnWidthPoints, columnWidthWeights, maxExpandedColumns: maxExpandedColumns);
         var activeRowSpans = new List<int>();
 
-        foreach (var row in EnumerateTableRows(element)) {
+        foreach (var row in EnumerateTableRows(element, context)) {
             var cells = row.Children
-                .Where(child => child.TagName.Equals("TH", StringComparison.OrdinalIgnoreCase) || child.TagName.Equals("TD", StringComparison.OrdinalIgnoreCase))
+                .Where(child => HasEffectiveTagName(child, context, "TH") || HasEffectiveTagName(child, context, "TD"))
                 .ToList();
             if (cells.Count == 0) {
                 continue;
             }
 
-            bool isHeaderRow = !headerWritten && cells.All(cell => cell.TagName.Equals("TH", StringComparison.OrdinalIgnoreCase));
+            bool isHeaderRow = !headerWritten && cells.All(cell => HasEffectiveTagName(cell, context, "TH"));
             var renderedCells = new List<string>(cells.Count);
             var structuredCells = new List<TableCell>(cells.Count);
             int logicalColumn = 0;
@@ -128,12 +128,12 @@ public sealed partial class HtmlToMarkdownConverter {
         }
     }
 
-    private static void CaptureColumnGroupAlignments(IElement table, List<ColumnAlignment> alignments, int maxExpandedColumns) {
+    private static void CaptureColumnGroupAlignments(IElement table, ConversionContext context, List<ColumnAlignment> alignments, int maxExpandedColumns) {
         int columnIndex = 0;
         foreach (var child in table.Children) {
-            if (child.TagName.Equals("COLGROUP", StringComparison.OrdinalIgnoreCase)) {
+            if (HasEffectiveTagName(child, context, "COLGROUP")) {
                 var colElements = child.Children
-                    .Where(static col => col.TagName.Equals("COL", StringComparison.OrdinalIgnoreCase))
+                    .Where(col => HasEffectiveTagName(col, context, "COL"))
                     .ToList();
                 var groupAlignment = ParseAlignment(child);
                 if (colElements.Count == 0) {
@@ -153,7 +153,7 @@ public sealed partial class HtmlToMarkdownConverter {
                 continue;
             }
 
-            if (child.TagName.Equals("COL", StringComparison.OrdinalIgnoreCase)) {
+            if (HasEffectiveTagName(child, context, "COL")) {
                 columnIndex = CaptureSpannedColumnAlignment(alignments, columnIndex, child, ParseAlignment(child), replaceExisting: false, maxExpandedColumns: maxExpandedColumns);
             }
         }
@@ -173,12 +173,12 @@ public sealed partial class HtmlToMarkdownConverter {
         return columnIndex + boundedSpan;
     }
 
-    private static void CaptureColumnGroupWidths(IElement table, List<double?> widthPoints, List<double?> widthWeights, int maxExpandedColumns) {
+    private static void CaptureColumnGroupWidths(IElement table, ConversionContext context, List<double?> widthPoints, List<double?> widthWeights, int maxExpandedColumns) {
         int columnIndex = 0;
         foreach (var child in table.Children) {
-            if (child.TagName.Equals("COLGROUP", StringComparison.OrdinalIgnoreCase)) {
+            if (HasEffectiveTagName(child, context, "COLGROUP")) {
                 var colElements = child.Children
-                    .Where(static col => col.TagName.Equals("COL", StringComparison.OrdinalIgnoreCase))
+                    .Where(col => HasEffectiveTagName(col, context, "COL"))
                     .ToList();
                 ColumnWidthHint groupWidth = ParseColumnWidth(child);
                 if (colElements.Count == 0) {
@@ -198,7 +198,7 @@ public sealed partial class HtmlToMarkdownConverter {
                 continue;
             }
 
-            if (child.TagName.Equals("COL", StringComparison.OrdinalIgnoreCase)) {
+            if (HasEffectiveTagName(child, context, "COL")) {
                 columnIndex = CaptureSpannedColumnWidth(widthPoints, widthWeights, columnIndex, child, ParseColumnWidth(child), replaceExisting: false, maxExpandedColumns: maxExpandedColumns);
             }
         }
@@ -326,20 +326,20 @@ public sealed partial class HtmlToMarkdownConverter {
         }
     }
 
-    private static IEnumerable<IElement> EnumerateTableRows(IElement table) {
+    private static IEnumerable<IElement> EnumerateTableRows(IElement table, ConversionContext context) {
         foreach (var child in table.Children) {
-            if (child.TagName.Equals("TR", StringComparison.OrdinalIgnoreCase)) {
+            if (HasEffectiveTagName(child, context, "TR")) {
                 yield return child;
                 continue;
             }
 
-            if (!child.TagName.Equals("THEAD", StringComparison.OrdinalIgnoreCase)
-                && !child.TagName.Equals("TBODY", StringComparison.OrdinalIgnoreCase)
-                && !child.TagName.Equals("TFOOT", StringComparison.OrdinalIgnoreCase)) {
+            if (!HasEffectiveTagName(child, context, "THEAD")
+                && !HasEffectiveTagName(child, context, "TBODY")
+                && !HasEffectiveTagName(child, context, "TFOOT")) {
                 continue;
             }
 
-            foreach (var row in child.Children.Where(static row => row.TagName.Equals("TR", StringComparison.OrdinalIgnoreCase))) {
+            foreach (var row in child.Children.Where(row => HasEffectiveTagName(row, context, "TR"))) {
                 yield return row;
             }
         }

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.cs
@@ -56,16 +56,16 @@ public sealed partial class HtmlToMarkdownConverter {
         return blocks;
     }
 
-    private static bool IsBlockElement(IElement element) {
-        return s_BlockTags.Contains(element.TagName);
+    private static bool IsBlockElement(IElement element, ConversionContext context) {
+        return s_BlockTags.Contains(GetEffectiveTagName(element, context));
     }
 
-    private static bool IsInlineElement(IElement element) {
-        return s_InlineTags.Contains(element.TagName);
+    private static bool IsInlineElement(IElement element, ConversionContext context) {
+        return s_InlineTags.Contains(GetEffectiveTagName(element, context));
     }
 
     private static bool ShouldTreatAsBlockElement(IElement element, ConversionContext context) {
-        if (IsBlockElement(element)) {
+        if (IsBlockElement(element, context)) {
             return true;
         }
 
@@ -77,7 +77,9 @@ public sealed partial class HtmlToMarkdownConverter {
             return true;
         }
 
-        if (context.Options.PreserveUnsupportedBlocks && !IsInlineElement(element)) {
+        if (context.Options.UnknownBlockHandling != HtmlUnknownTagHandling.Bypass
+            && context.Options.PreserveUnsupportedBlocks
+            && !IsInlineElement(element, context)) {
             return true;
         }
 
@@ -119,6 +121,10 @@ public sealed partial class HtmlToMarkdownConverter {
     }
 
     private static IEnumerable<IMarkdownBlock> ConvertElementToBlocks(IElement element, ConversionContext context) {
+        if (IsPassThroughTag(element, context)) {
+            return new IMarkdownBlock[] { new HtmlRawBlock(element.OuterHtml) };
+        }
+
         if (TryConvertVisualContractElement(element, context, out var visualBlock)) {
             return new IMarkdownBlock[] { visualBlock };
         }
@@ -135,7 +141,7 @@ public sealed partial class HtmlToMarkdownConverter {
             return customBlocks;
         }
 
-        string tag = element.TagName;
+        string tag = GetEffectiveTagName(element, context);
         switch (tag) {
             case "P":
                 return ConvertParagraphElement(element, context);
@@ -214,20 +220,7 @@ public sealed partial class HtmlToMarkdownConverter {
 
                 return new IMarkdownBlock[] { new ParagraphBlock(inlineSequence) };
             default:
-                if (context.Options.PreserveUnsupportedBlocks) {
-                    return new IMarkdownBlock[] { new HtmlRawBlock(element.OuterHtml) };
-                }
-
-                if (HasDirectBlockChildren(element, context)) {
-                    return ConvertNodesToBlocks(element.ChildNodes, context);
-                }
-
-                var fallbackInline = NormalizeInlineSequenceForBlock(ConvertInlineNodesToInlineSequence(element.ChildNodes, context));
-                if (!HasVisibleInlineContent(fallbackInline)) {
-                    return Array.Empty<IMarkdownBlock>();
-                }
-
-                return new IMarkdownBlock[] { new ParagraphBlock(fallbackInline) };
+                return ConvertUnknownElementToBlocks(element, context);
         }
     }
 

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.cs
@@ -223,7 +223,7 @@ public sealed partial class HtmlToMarkdownConverter {
     }
 
     private static bool HasRejectedHref(IElement element, ConversionContext context) {
-        if (element == null || context == null || !element.TagName.Equals("A", StringComparison.OrdinalIgnoreCase)) {
+        if (element == null || context == null || !HasEffectiveTagName(element, context, "A")) {
             return false;
         }
 

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.cs
@@ -77,14 +77,7 @@ public sealed partial class HtmlToMarkdownConverter {
             return true;
         }
 
-        if (context.Options.UnknownBlockHandling == HtmlUnknownTagHandling.Bypass
-            && !IsInlineElement(element, context)) {
-            return true;
-        }
-
-        if (context.Options.UnknownBlockHandling != HtmlUnknownTagHandling.Bypass
-            && context.Options.PreserveUnsupportedBlocks
-            && !IsInlineElement(element, context)) {
+        if (!IsInlineElement(element, context)) {
             return true;
         }
 

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.cs
@@ -77,6 +77,11 @@ public sealed partial class HtmlToMarkdownConverter {
             return true;
         }
 
+        if (context.Options.UnknownBlockHandling == HtmlUnknownTagHandling.Bypass
+            && !IsInlineElement(element, context)) {
+            return true;
+        }
+
         if (context.Options.UnknownBlockHandling != HtmlUnknownTagHandling.Bypass
             && context.Options.PreserveUnsupportedBlocks
             && !IsInlineElement(element, context)) {

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.cs
@@ -87,7 +87,7 @@ public sealed partial class HtmlToMarkdownConverter {
     private static bool CanConvertAnchorToLinkedImageBlock(IElement element, ConversionContext context) {
         if (element == null
             || context == null
-            || !element.TagName.Equals("A", StringComparison.OrdinalIgnoreCase)) {
+            || !HasEffectiveTagName(element, context, "A")) {
             return false;
         }
 
@@ -96,15 +96,15 @@ public sealed partial class HtmlToMarkdownConverter {
             return false;
         }
 
-        if (!TryResolveAnchorMediaElement(element, out var mediaElement)) {
+        if (!TryResolveAnchorMediaElement(element, context, out var mediaElement)) {
             return false;
         }
 
-        if (mediaElement.TagName.Equals("IMG", StringComparison.OrdinalIgnoreCase)) {
+        if (HasEffectiveTagName(mediaElement, context, "IMG")) {
             return CanCreateImageBlockWithoutSideEffects(mediaElement, context);
         }
 
-        return mediaElement.TagName.Equals("PICTURE", StringComparison.OrdinalIgnoreCase)
+        return HasEffectiveTagName(mediaElement, context, "PICTURE")
                && CanCreatePictureImageBlockWithoutSideEffects(mediaElement, context);
     }
 
@@ -235,8 +235,8 @@ public sealed partial class HtmlToMarkdownConverter {
         blocks = Array.Empty<IMarkdownBlock>();
         if (element == null
             || context == null
-            || !element.TagName.Equals("A", StringComparison.OrdinalIgnoreCase)
-            || !TryResolveAnchorMediaElement(element, out var mediaElement)) {
+            || !HasEffectiveTagName(element, context, "A")
+            || !TryResolveAnchorMediaElement(element, context, out var mediaElement)) {
             return false;
         }
 

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.cs
@@ -78,10 +78,66 @@ public sealed partial class HtmlToMarkdownConverter {
         }
 
         if (!IsInlineElement(element, context)) {
-            return true;
+            if (IsVisualContractElement(element)
+                || (context.Options.PreserveUnsupportedBlocks
+                    && context.Options.UnknownBlockHandling == HtmlUnknownTagHandling.Preserve)) {
+                return true;
+            }
+
+            if (HasVisibleInlineSibling(element, context)) {
+                return false;
+            }
+
+            return context.Options.UnknownBlockHandling != HtmlUnknownTagHandling.Preserve;
         }
 
         return false;
+    }
+
+    private static bool IsVisualContractElement(IElement element) {
+        if (element == null) {
+            return false;
+        }
+
+        var attributes = new List<KeyValuePair<string, string?>>();
+        foreach (var attribute in element.Attributes) {
+            attributes.Add(new KeyValuePair<string, string?>(attribute.Name, attribute.Value));
+        }
+
+        return MarkdownVisualElementContract.TryParse(attributes, out _);
+    }
+
+    private static bool HasVisibleInlineSibling(IElement element, ConversionContext context) {
+        if (element == null || element.ParentElement == null) {
+            return false;
+        }
+
+        foreach (var sibling in element.ParentElement.ChildNodes) {
+            if (ReferenceEquals(sibling, element)) {
+                continue;
+            }
+
+            if (IsVisibleInlineFlowNode(sibling, context)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsVisibleInlineFlowNode(INode node, ConversionContext context) {
+        switch (node) {
+            case IText text:
+                return !string.IsNullOrWhiteSpace(text.Data);
+            case IElement element:
+                if (ShouldIgnoreElement(element, context) || IsBlockElement(element, context)) {
+                    return false;
+                }
+
+                return !HasDirectBlockChildren(element, context);
+            default:
+                return false;
+        }
     }
 
     private static bool CanConvertAnchorToLinkedImageBlock(IElement element, ConversionContext context) {

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Filters.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Filters.cs
@@ -1,0 +1,48 @@
+using AngleSharp.Dom;
+
+namespace OfficeIMO.Markdown.Html;
+
+public sealed partial class HtmlToMarkdownConverter {
+    private static void ApplyHtmlFilters(IElement? root, HtmlToMarkdownOptions options) {
+        if (root == null || options == null) {
+            return;
+        }
+
+        if (options.ExcludeSelectors.Count > 0) {
+            foreach (string selector in options.ExcludeSelectors) {
+                if (string.IsNullOrWhiteSpace(selector)) {
+                    continue;
+                }
+
+                var matches = root.QuerySelectorAll(selector).ToList();
+                for (int i = 0; i < matches.Count; i++) {
+                    RemoveElement(matches[i]);
+                }
+            }
+        }
+
+        if (options.ElementFilters.Count == 0) {
+            return;
+        }
+
+        var elements = root.QuerySelectorAll("*").ToList();
+        for (int i = 0; i < elements.Count; i++) {
+            var element = elements[i];
+            if (element.Parent == null) {
+                continue;
+            }
+
+            for (int j = 0; j < options.ElementFilters.Count; j++) {
+                var filter = options.ElementFilters[j];
+                if (filter != null && filter(element)) {
+                    RemoveElement(element);
+                    break;
+                }
+            }
+        }
+    }
+
+    private static void RemoveElement(IElement element) {
+        element.Parent?.RemoveChild(element);
+    }
+}

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Inlines.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Inlines.cs
@@ -39,11 +39,16 @@ public sealed partial class HtmlToMarkdownConverter {
     }
 
     private static void AppendInlineElement(InlineSequence sequence, IElement element, ConversionContext? context) {
+        if (IsPassThroughTag(element, context)) {
+            sequence.AddRaw(new HtmlRawInline(element.OuterHtml));
+            return;
+        }
+
         if (TryConvertConfiguredInlineElementConverters(sequence, element, context)) {
             return;
         }
 
-        string tag = element.TagName;
+        string tag = GetEffectiveTagName(element, context);
         switch (tag) {
             case "BR":
                 sequence.HardBreak();
@@ -93,23 +98,10 @@ public sealed partial class HtmlToMarkdownConverter {
             case "SAMP":
             case "VAR":
             case "LABEL":
-                var childNodes = element.ChildNodes as IList<INode> ?? element.ChildNodes.ToList();
-                for (int i = 0; i < childNodes.Count; i++) {
-                    bool trimEnd = NextVisibleInlineNodeIsBoundary(childNodes, i + 1, context);
-                    AppendInlineNode(sequence, childNodes[i], context, trimEnd);
-                }
+                AppendInlineElementChildren(sequence, element, context);
                 return;
             default:
-                if (context != null && context.Options.PreserveUnsupportedInlineHtml) {
-                    sequence.AddRaw(new HtmlRawInline(element.OuterHtml));
-                    return;
-                }
-
-                var fallbackNodes = element.ChildNodes as IList<INode> ?? element.ChildNodes.ToList();
-                for (int i = 0; i < fallbackNodes.Count; i++) {
-                    bool trimEnd = NextVisibleInlineNodeIsBoundary(fallbackNodes, i + 1, context);
-                    AppendInlineNode(sequence, fallbackNodes[i], context, trimEnd);
-                }
+                AppendUnknownInlineElement(sequence, element, context);
                 return;
         }
     }
@@ -154,6 +146,9 @@ public sealed partial class HtmlToMarkdownConverter {
                 if (context != null && ShouldIgnoreElement(element, context)) {
                     return string.Empty;
                 }
+                if (IsPassThroughTag(element, context)) {
+                    return element.OuterHtml;
+                }
                 return ConvertInlineElementToMarkdown(element, context);
             default:
                 return string.Empty;
@@ -161,7 +156,7 @@ public sealed partial class HtmlToMarkdownConverter {
     }
 
     private static string ConvertInlineElementToMarkdown(IElement element, ConversionContext? context) {
-        string tag = element.TagName;
+        string tag = GetEffectiveTagName(element, context);
         switch (tag) {
             case "BR":
                 return "  \n";
@@ -207,10 +202,7 @@ public sealed partial class HtmlToMarkdownConverter {
             case "LABEL":
                 return ConvertInlineNodesToMarkdown(element.ChildNodes, context);
             default:
-                if (context != null && context.Options.PreserveUnsupportedInlineHtml) {
-                    return element.OuterHtml;
-                }
-                return ConvertInlineNodesToMarkdown(element.ChildNodes, context);
+                return ConvertUnknownInlineElementToMarkdown(element, context);
         }
     }
 
@@ -247,6 +239,10 @@ public sealed partial class HtmlToMarkdownConverter {
             return label;
         }
 
+        if (context?.Options.SmartHref == true && TryConvertSmartHrefToPlainText(label, href, out string plainText)) {
+            return EscapeInlineText(plainText);
+        }
+
         string title = element.GetAttribute("title") ?? string.Empty;
         string titlePart = title.Length == 0
             ? string.Empty
@@ -270,12 +266,70 @@ public sealed partial class HtmlToMarkdownConverter {
             return;
         }
 
+        if (context?.Options.SmartHref == true
+            && TryConvertSmartHrefToPlainText(ConvertInlineNodesToMarkdown(element.ChildNodes, context).Trim(), href, out string plainText)) {
+            sequence.Text(plainText);
+            return;
+        }
+
         sequence.AddRaw(new LinkInline(
             label,
             href,
             element.GetAttribute("title"),
             element.GetAttribute("target"),
             element.GetAttribute("rel")));
+    }
+
+    private static bool TryConvertSmartHrefToPlainText(string label, string href, out string plainText) {
+        plainText = string.Empty;
+        if (string.IsNullOrWhiteSpace(label) || string.IsNullOrWhiteSpace(href)) {
+            return false;
+        }
+
+        string normalizedLabel = NormalizeSmartHrefText(label);
+        string normalizedHref = href.Trim();
+        if (normalizedLabel.Length == 0 || normalizedHref.Length == 0) {
+            return false;
+        }
+
+        if (string.Equals(normalizedLabel, normalizedHref, StringComparison.OrdinalIgnoreCase)) {
+            plainText = normalizedHref;
+            return true;
+        }
+
+        if (normalizedHref.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(normalizedLabel, normalizedHref.Substring("mailto:".Length), StringComparison.OrdinalIgnoreCase)) {
+            plainText = normalizedLabel;
+            return true;
+        }
+
+        if (normalizedHref.StartsWith("tel:", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(normalizedLabel, normalizedHref.Substring("tel:".Length), StringComparison.OrdinalIgnoreCase)) {
+            plainText = normalizedLabel;
+            return true;
+        }
+
+        if (normalizedHref.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(normalizedLabel, normalizedHref.Substring("http://".Length), StringComparison.OrdinalIgnoreCase)) {
+            plainText = normalizedHref;
+            return true;
+        }
+
+        if (normalizedHref.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(normalizedLabel, normalizedHref.Substring("https://".Length), StringComparison.OrdinalIgnoreCase)) {
+            plainText = normalizedHref;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static string NormalizeSmartHrefText(string value) {
+        return value
+            .Replace("\\.", ".")
+            .Replace("\\-", "-")
+            .Replace("\\_", "_")
+            .Trim();
     }
 
     private static string ConvertInlineImageToMarkdown(IElement element, ConversionContext? context) {

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Inlines.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Inlines.cs
@@ -303,12 +303,6 @@ public sealed partial class HtmlToMarkdownConverter {
             return true;
         }
 
-        if (normalizedHref.StartsWith("tel:", StringComparison.OrdinalIgnoreCase)
-            && string.Equals(normalizedLabel, normalizedHref.Substring("tel:".Length), StringComparison.OrdinalIgnoreCase)) {
-            plainText = normalizedLabel;
-            return true;
-        }
-
         if (normalizedHref.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
             && string.Equals(normalizedLabel, normalizedHref.Substring("http://".Length), StringComparison.OrdinalIgnoreCase)) {
             plainText = normalizedHref;

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Tags.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Tags.cs
@@ -1,0 +1,118 @@
+using AngleSharp.Dom;
+using OfficeIMO.Markdown;
+
+namespace OfficeIMO.Markdown.Html;
+
+public sealed partial class HtmlToMarkdownConverter {
+    private static string GetEffectiveTagName(IElement element, ConversionContext? context) {
+        string tagName = element?.TagName ?? string.Empty;
+        if (context?.Options.TagAliases == null || context.Options.TagAliases.Count == 0) {
+            return tagName;
+        }
+
+        if (!context.Options.TagAliases.TryGetValue(tagName, out string? alias)
+            && !context.Options.TagAliases.TryGetValue(tagName.ToLowerInvariant(), out alias)) {
+            return tagName;
+        }
+
+        return string.IsNullOrWhiteSpace(alias)
+            ? tagName
+            : alias.Trim().ToUpperInvariant();
+    }
+
+    private static bool IsPassThroughTag(IElement element, ConversionContext? context) {
+        if (element == null || context?.Options.PassThroughTags == null || context.Options.PassThroughTags.Count == 0) {
+            return false;
+        }
+
+        string originalTag = element.TagName;
+        string effectiveTag = GetEffectiveTagName(element, context);
+        return context.Options.PassThroughTags.Contains(originalTag)
+               || context.Options.PassThroughTags.Contains(effectiveTag);
+    }
+
+    private static IEnumerable<IMarkdownBlock> ConvertUnknownElementToBlocks(IElement element, ConversionContext context) {
+        switch (context.Options.UnknownBlockHandling) {
+            case HtmlUnknownTagHandling.Drop:
+                return Array.Empty<IMarkdownBlock>();
+            case HtmlUnknownTagHandling.Bypass:
+                return ConvertUnknownElementChildrenToBlocks(element, context);
+            case HtmlUnknownTagHandling.Raise:
+                throw new NotSupportedException($"Unsupported HTML block element '{element.TagName}' cannot be converted to Markdown.");
+            case HtmlUnknownTagHandling.Preserve:
+            default:
+                if (context.Options.PreserveUnsupportedBlocks) {
+                    return new IMarkdownBlock[] { new HtmlRawBlock(element.OuterHtml) };
+                }
+
+                return ConvertUnknownElementChildrenToBlocks(element, context);
+        }
+    }
+
+    private static IEnumerable<IMarkdownBlock> ConvertUnknownElementChildrenToBlocks(IElement element, ConversionContext context) {
+        if (HasDirectBlockChildren(element, context)) {
+            return ConvertNodesToBlocks(element.ChildNodes, context);
+        }
+
+        var fallbackInline = NormalizeInlineSequenceForBlock(ConvertInlineNodesToInlineSequence(element.ChildNodes, context));
+        if (!HasVisibleInlineContent(fallbackInline)) {
+            return Array.Empty<IMarkdownBlock>();
+        }
+
+        return new IMarkdownBlock[] { new ParagraphBlock(fallbackInline) };
+    }
+
+    private static void AppendUnknownInlineElement(InlineSequence sequence, IElement element, ConversionContext? context) {
+        if (context == null) {
+            AppendInlineElementChildren(sequence, element, context);
+            return;
+        }
+
+        switch (context.Options.UnknownInlineHandling) {
+            case HtmlUnknownTagHandling.Drop:
+                return;
+            case HtmlUnknownTagHandling.Bypass:
+                AppendInlineElementChildren(sequence, element, context);
+                return;
+            case HtmlUnknownTagHandling.Raise:
+                throw new NotSupportedException($"Unsupported HTML inline element '{element.TagName}' cannot be converted to Markdown.");
+            case HtmlUnknownTagHandling.Preserve:
+            default:
+                if (context.Options.PreserveUnsupportedInlineHtml) {
+                    sequence.AddRaw(new HtmlRawInline(element.OuterHtml));
+                    return;
+                }
+
+                AppendInlineElementChildren(sequence, element, context);
+                return;
+        }
+    }
+
+    private static string ConvertUnknownInlineElementToMarkdown(IElement element, ConversionContext? context) {
+        if (context == null) {
+            return ConvertInlineNodesToMarkdown(element.ChildNodes, context);
+        }
+
+        switch (context.Options.UnknownInlineHandling) {
+            case HtmlUnknownTagHandling.Drop:
+                return string.Empty;
+            case HtmlUnknownTagHandling.Bypass:
+                return ConvertInlineNodesToMarkdown(element.ChildNodes, context);
+            case HtmlUnknownTagHandling.Raise:
+                throw new NotSupportedException($"Unsupported HTML inline element '{element.TagName}' cannot be converted to Markdown.");
+            case HtmlUnknownTagHandling.Preserve:
+            default:
+                return context.Options.PreserveUnsupportedInlineHtml
+                    ? element.OuterHtml
+                    : ConvertInlineNodesToMarkdown(element.ChildNodes, context);
+        }
+    }
+
+    private static void AppendInlineElementChildren(InlineSequence sequence, IElement element, ConversionContext? context) {
+        var childNodes = element.ChildNodes as IList<INode> ?? element.ChildNodes.ToList();
+        for (int i = 0; i < childNodes.Count; i++) {
+            bool trimEnd = NextVisibleInlineNodeIsBoundary(childNodes, i + 1, context);
+            AppendInlineNode(sequence, childNodes[i], context, trimEnd);
+        }
+    }
+}

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Tags.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Tags.cs
@@ -20,6 +20,10 @@ public sealed partial class HtmlToMarkdownConverter {
             : alias.Trim().ToUpperInvariant();
     }
 
+    private static bool HasEffectiveTagName(IElement element, ConversionContext? context, string tagName) {
+        return string.Equals(GetEffectiveTagName(element, context), tagName, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static bool IsPassThroughTag(IElement element, ConversionContext? context) {
         if (element == null || context?.Options.PassThroughTags == null || context.Options.PassThroughTags.Count == 0) {
             return false;

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Tags.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Tags.cs
@@ -100,6 +100,18 @@ public sealed partial class HtmlToMarkdownConverter {
             return;
         }
 
+        if (!IsInlineElement(element, context) && context.Options.UnknownInlineHandling == HtmlUnknownTagHandling.Preserve) {
+            switch (context.Options.UnknownBlockHandling) {
+                case HtmlUnknownTagHandling.Drop:
+                    return;
+                case HtmlUnknownTagHandling.Bypass:
+                    AppendInlineElementChildren(sequence, element, context);
+                    return;
+                case HtmlUnknownTagHandling.Raise:
+                    throw new NotSupportedException($"Unsupported HTML inline element '{element.TagName}' cannot be converted to Markdown.");
+            }
+        }
+
         switch (context.Options.UnknownInlineHandling) {
             case HtmlUnknownTagHandling.Drop:
                 return;

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Tags.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Tags.cs
@@ -24,6 +24,34 @@ public sealed partial class HtmlToMarkdownConverter {
         return string.Equals(GetEffectiveTagName(element, context), tagName, StringComparison.OrdinalIgnoreCase);
     }
 
+    private static IElement? FindFirstDescendantByEffectiveTagName(IElement element, ConversionContext? context, string tagName) {
+        if (element == null) {
+            return null;
+        }
+
+        foreach (var descendant in element.QuerySelectorAll("*")) {
+            if (HasEffectiveTagName(descendant, context, tagName)) {
+                return descendant;
+            }
+        }
+
+        return null;
+    }
+
+    private static IElement? FindDirectChildByEffectiveTagName(IElement element, ConversionContext? context, string tagName) {
+        if (element == null) {
+            return null;
+        }
+
+        foreach (var child in element.Children) {
+            if (HasEffectiveTagName(child, context, tagName)) {
+                return child;
+            }
+        }
+
+        return null;
+    }
+
     private static bool IsPassThroughTag(IElement element, ConversionContext? context) {
         if (element == null || context?.Options.PassThroughTags == null || context.Options.PassThroughTags.Count == 0) {
             return false;

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.cs
@@ -47,8 +47,8 @@ public sealed partial class HtmlToMarkdownConverter {
         ValidateInputLength(html, effectiveOptions.MaxInputCharacters, nameof(html));
 
         var document = HtmlDocumentParser.ParseDocument(html);
-        effectiveOptions.BaseUri = HtmlDocumentParser.ResolveEffectiveBaseUri(document, effectiveOptions.BaseUri);
         ApplyHtmlFilters(document.DocumentElement, effectiveOptions);
+        effectiveOptions.BaseUri = HtmlDocumentParser.ResolveEffectiveBaseUri(document, effectiveOptions.BaseUri);
         var context = new ConversionContext(effectiveOptions);
 
         INode root = HtmlDocumentParser.GetConversionRoot(document, effectiveOptions.UseBodyContentsOnly);

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.cs
@@ -48,6 +48,7 @@ public sealed partial class HtmlToMarkdownConverter {
 
         var document = HtmlDocumentParser.ParseDocument(html);
         effectiveOptions.BaseUri = HtmlDocumentParser.ResolveEffectiveBaseUri(document, effectiveOptions.BaseUri);
+        ApplyHtmlFilters(document.DocumentElement, effectiveOptions);
         var context = new ConversionContext(effectiveOptions);
 
         INode root = HtmlDocumentParser.GetConversionRoot(document, effectiveOptions.UseBodyContentsOnly);

--- a/OfficeIMO.Markdown.Html/Options/HtmlToMarkdownOptions.cs
+++ b/OfficeIMO.Markdown.Html/Options/HtmlToMarkdownOptions.cs
@@ -1,5 +1,6 @@
 namespace OfficeIMO.Markdown.Html;
 
+using AngleSharp.Dom;
 using OfficeIMO.Html;
 
 /// <summary>
@@ -12,6 +13,32 @@ public sealed class HtmlToMarkdownOptions {
 
     /// <summary>Creates the default OfficeIMO-flavored conversion profile.</summary>
     public static HtmlToMarkdownOptions CreateOfficeIMOProfile() => new HtmlToMarkdownOptions();
+
+    /// <summary>Creates conversion options for the requested Markdown output profile.</summary>
+    public static HtmlToMarkdownOptions CreateProfile(MarkdownOutputProfile profile) =>
+        profile switch {
+            MarkdownOutputProfile.OfficeIMO => CreateOfficeIMOProfile(),
+            MarkdownOutputProfile.CommonMark => CreateCommonMarkProfile(),
+            MarkdownOutputProfile.GitHubFlavoredMarkdown => CreateGitHubFlavoredMarkdownProfile(),
+            MarkdownOutputProfile.Portable => CreatePortableProfile(),
+            _ => throw new ArgumentOutOfRangeException(nameof(profile), profile, "Unknown HTML-to-Markdown output profile.")
+        };
+
+    /// <summary>
+    /// Creates a CommonMark-oriented conversion profile. The intermediate OfficeIMO document model is preserved,
+    /// while markdown serialization avoids GitHub-only output where practical.
+    /// </summary>
+    public static HtmlToMarkdownOptions CreateCommonMarkProfile() => new HtmlToMarkdownOptions {
+        MarkdownWriteOptions = MarkdownWriteOptions.CreateCommonMarkProfile()
+    };
+
+    /// <summary>
+    /// Creates a GitHub Flavored Markdown-oriented conversion profile for README and GitHub documentation output.
+    /// </summary>
+    public static HtmlToMarkdownOptions CreateGitHubFlavoredMarkdownProfile() => new HtmlToMarkdownOptions {
+        SmartHref = true,
+        MarkdownWriteOptions = MarkdownWriteOptions.CreateGitHubFlavoredMarkdownProfile()
+    };
 
     /// <summary>
     /// Creates a portable conversion profile that serializes the converted document with portable markdown fallbacks.
@@ -44,6 +71,21 @@ public sealed class HtmlToMarkdownOptions {
     /// When true, unsupported inline elements are emitted as raw HTML inside inline Markdown.
     /// </summary>
     public bool PreserveUnsupportedInlineHtml { get; set; } = true;
+
+    /// <summary>
+    /// When true, links whose label already represents the target are emitted as plain text.
+    /// </summary>
+    public bool SmartHref { get; set; }
+
+    /// <summary>
+    /// Controls how unsupported block-level elements are converted.
+    /// </summary>
+    public HtmlUnknownTagHandling UnknownBlockHandling { get; set; } = HtmlUnknownTagHandling.Preserve;
+
+    /// <summary>
+    /// Controls how unsupported inline elements are converted.
+    /// </summary>
+    public HtmlUnknownTagHandling UnknownInlineHandling { get; set; } = HtmlUnknownTagHandling.Preserve;
 
     /// <summary>
     /// When true, plain text imported from HTML is escaped when it could be interpreted as a Markdown block marker.
@@ -135,6 +177,26 @@ public sealed class HtmlToMarkdownOptions {
     public List<MarkdownVisualElementRoundTripHint> VisualElementRoundTripHints { get; } = new();
 
     /// <summary>
+    /// CSS selectors for elements that should be removed before conversion.
+    /// </summary>
+    public HashSet<string> ExcludeSelectors { get; } = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Predicates for elements that should be removed before conversion. Return <see langword="true"/> to remove an element.
+    /// </summary>
+    public List<Func<IElement, bool>> ElementFilters { get; } = new();
+
+    /// <summary>
+    /// Maps an HTML tag name to another tag name before built-in conversion is selected.
+    /// </summary>
+    public Dictionary<string, string> TagAliases { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Tag names that should be emitted as raw HTML without converting their children.
+    /// </summary>
+    public HashSet<string> PassThroughTags { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Marks a renderer plugin's HTML-ingestion contract as applied to these options.
     /// </summary>
     public bool TryMarkPluginApplied(string pluginId) {
@@ -211,6 +273,9 @@ public sealed class HtmlToMarkdownOptions {
             RemoveScriptsAndStyles = RemoveScriptsAndStyles,
             PreserveUnsupportedBlocks = PreserveUnsupportedBlocks,
             PreserveUnsupportedInlineHtml = PreserveUnsupportedInlineHtml,
+            SmartHref = SmartHref,
+            UnknownBlockHandling = UnknownBlockHandling,
+            UnknownInlineHandling = UnknownInlineHandling,
             EscapeMarkdownLineStarts = EscapeMarkdownLineStarts,
             UrlPolicy = UrlPolicy?.Clone() ?? HtmlUrlPolicy.CreateOfficeIMOProfile(),
             Base64Images = Base64Images,
@@ -247,6 +312,31 @@ public sealed class HtmlToMarkdownOptions {
             var hint = VisualElementRoundTripHints[i];
             if (hint != null) {
                 clone.VisualElementRoundTripHints.Add(hint);
+            }
+        }
+
+        foreach (var selector in ExcludeSelectors) {
+            if (!string.IsNullOrWhiteSpace(selector)) {
+                clone.ExcludeSelectors.Add(selector);
+            }
+        }
+
+        for (var i = 0; i < ElementFilters.Count; i++) {
+            var filter = ElementFilters[i];
+            if (filter != null) {
+                clone.ElementFilters.Add(filter);
+            }
+        }
+
+        foreach (var alias in TagAliases) {
+            if (!string.IsNullOrWhiteSpace(alias.Key) && !string.IsNullOrWhiteSpace(alias.Value)) {
+                clone.TagAliases[alias.Key] = alias.Value;
+            }
+        }
+
+        foreach (var tagName in PassThroughTags) {
+            if (!string.IsNullOrWhiteSpace(tagName)) {
+                clone.PassThroughTags.Add(tagName);
             }
         }
 

--- a/OfficeIMO.Markdown.Html/Options/HtmlToMarkdownOptions.cs
+++ b/OfficeIMO.Markdown.Html/Options/HtmlToMarkdownOptions.cs
@@ -29,6 +29,7 @@ public sealed class HtmlToMarkdownOptions {
     /// while markdown serialization avoids GitHub-only output where practical.
     /// </summary>
     public static HtmlToMarkdownOptions CreateCommonMarkProfile() => new HtmlToMarkdownOptions {
+        EscapeMarkdownLineStarts = true,
         MarkdownWriteOptions = MarkdownWriteOptions.CreateCommonMarkProfile()
     };
 

--- a/OfficeIMO.Markdown.Html/Options/HtmlUnknownTagHandling.cs
+++ b/OfficeIMO.Markdown.Html/Options/HtmlUnknownTagHandling.cs
@@ -1,0 +1,18 @@
+namespace OfficeIMO.Markdown.Html;
+
+/// <summary>
+/// Controls how HTML-to-Markdown conversion handles elements that do not map to a built-in Markdown construct.
+/// </summary>
+public enum HtmlUnknownTagHandling {
+    /// <summary>Preserve the original HTML for the unsupported element when the matching preserve option is enabled.</summary>
+    Preserve,
+
+    /// <summary>Drop the unsupported element and its children.</summary>
+    Drop,
+
+    /// <summary>Ignore the unsupported element wrapper and convert its children.</summary>
+    Bypass,
+
+    /// <summary>Fail conversion when an unsupported element is encountered.</summary>
+    Raise
+}

--- a/OfficeIMO.Markdown.Html/README.md
+++ b/OfficeIMO.Markdown.Html/README.md
@@ -30,11 +30,34 @@ var options = new HtmlToMarkdownOptions {
     BaseUri = new Uri("https://example.com/docs/"),
     UseBodyContentsOnly = true,
     PreserveUnsupportedBlocks = true,
-    PreserveUnsupportedInlineHtml = true
+    PreserveUnsupportedInlineHtml = true,
+    SmartHref = true
 };
 
 string markdown = "<p><a href=\"guide/start\">Docs</a></p>".ToMarkdown(options);
 ```
+
+### Compatibility controls
+
+```csharp
+var options = new HtmlToMarkdownOptions {
+    SmartHref = true,
+    UnknownBlockHandling = HtmlUnknownTagHandling.Bypass,
+    UnknownInlineHandling = HtmlUnknownTagHandling.Bypass
+};
+
+options.ExcludeSelectors.Add(".ad, .cookie-banner");
+options.TagAliases["highlight"] = "mark";
+options.PassThroughTags.Add("custom-widget");
+
+string markdown = html.ToMarkdown(options);
+```
+
+- `SmartHref` emits self-describing links such as `<a href="https://example.com">https://example.com</a>` as plain text.
+- `ExcludeSelectors` and `ElementFilters` remove matching HTML before conversion.
+- `TagAliases` lets custom or legacy tag names reuse built-in converters.
+- `PassThroughTags` preserves selected elements as raw HTML.
+- `UnknownBlockHandling` and `UnknownInlineHandling` choose whether unknown elements are preserved, bypassed, dropped, or rejected.
 
 ## What it maps
 
@@ -47,11 +70,16 @@ string markdown = "<p><a href=\"guide/start\">Docs</a></p>".ToMarkdown(options);
 ## Profiles
 
 - Use the OfficeIMO profile when the downstream consumer is `OfficeIMO.Markdown` or `OfficeIMO.MarkdownRenderer`.
+- Use the GitHub Flavored Markdown profile for README and GitHub documentation output.
+- Use the CommonMark profile when output should avoid GitHub-only constructs such as pipe tables; HTML tables are emitted as raw HTML.
 - Use the portable profile when output should remain friendly to generic Markdown engines.
 
 ```csharp
-var options = HtmlToMarkdownOptions.CreatePortableProfile();
-string portable = "<blockquote><p><strong>Example</strong></p></blockquote>".ToMarkdown(options);
+var github = HtmlToMarkdownOptions.CreateGitHubFlavoredMarkdownProfile();
+string readme = "<p><a href=\"https://example.com\">https://example.com</a></p>".ToMarkdown(github);
+
+var commonMark = HtmlToMarkdownOptions.CreateCommonMarkProfile();
+string portableTable = "<table><tr><th>Name</th></tr><tr><td>Value</td></tr></table>".ToMarkdown(commonMark);
 ```
 
 ## Boundaries

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_Compatibility_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_Compatibility_Tests.cs
@@ -145,6 +145,26 @@ public sealed class MarkdownHtmlToMarkdownCompatibilityTests {
     }
 
     [Fact]
+    public void HtmlToMarkdown_PictureFallbackImageKeepsLazyImageSourceAheadOfPlaceholder() {
+        const string html = """
+<picture>
+  <img src="transparent.gif" data-src="real.png" alt="Photo">
+</picture>
+""";
+
+        var options = new HtmlToMarkdownOptions {
+            BaseUri = new Uri("https://example.com/docs/")
+        };
+
+        var document = new HtmlToMarkdownConverter().ConvertToDocument(html, options);
+        var image = Assert.IsType<ImageBlock>(Assert.Single(document.Blocks));
+
+        Assert.Equal("https://example.com/docs/real.png", image.Path);
+        Assert.Equal("https://example.com/docs/real.png", image.PictureFallbackPath);
+        Assert.Equal("Photo", image.Alt);
+    }
+
+    [Fact]
     public void HtmlToMarkdown_PassThroughTags_PreserveOriginalHtmlEvenForKnownTags() {
         const string html = "<p>Keep <strong>literal</strong></p>";
 
@@ -214,6 +234,25 @@ public sealed class MarkdownHtmlToMarkdownCompatibilityTests {
         Assert.Throws<NotSupportedException>(() => html.ToMarkdown(new HtmlToMarkdownOptions {
             UnknownInlineHandling = HtmlUnknownTagHandling.Raise
         }));
+    }
+
+    [Fact]
+    public void HtmlToMarkdown_UnknownInlineFlow_DoesNotCreateParagraphBoundaries() {
+        const string html = "Hello <x-chip>world</x-chip>!";
+
+        string bypassed = Normalize(html.ToMarkdown(new HtmlToMarkdownOptions {
+            UnknownBlockHandling = HtmlUnknownTagHandling.Bypass
+        }));
+        string dropped = Normalize(html.ToMarkdown(new HtmlToMarkdownOptions {
+            UnknownBlockHandling = HtmlUnknownTagHandling.Drop
+        }));
+        string preservedInline = Normalize(html.ToMarkdown(new HtmlToMarkdownOptions {
+            PreserveUnsupportedBlocks = false
+        }));
+
+        Assert.Equal("Hello world!", bypassed);
+        Assert.Equal("Hello !", dropped);
+        Assert.Equal("Hello <x-chip>world</x-chip>!", preservedInline);
     }
 
     [Fact]

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_Compatibility_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_Compatibility_Tests.cs
@@ -1,0 +1,156 @@
+using OfficeIMO.Markdown.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class MarkdownHtmlToMarkdownCompatibilityTests {
+    [Fact]
+    public void HtmlToMarkdown_SmartHref_EmitsPlainTextForSelfLinks() {
+        const string html = """
+<p>
+  <a href="https://example.com">https://example.com</a>
+  <a href="mailto:user@example.com">user@example.com</a>
+  <a href="https://example.com/docs">Docs</a>
+</p>
+""";
+
+        string markdown = Normalize(html.ToMarkdown(new HtmlToMarkdownOptions {
+            SmartHref = true
+        }));
+
+        Assert.Contains("https://example.com user@example.com [Docs](https://example.com/docs)", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("[https://example.com]", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("[user@example.com]", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HtmlToMarkdown_FiltersElementsWithSelectorsAndPredicates() {
+        const string html = """
+<article>
+  <p>Keep</p>
+  <aside class="ad">Advertisement</aside>
+  <p data-skip="true">Drop me</p>
+</article>
+""";
+
+        var options = new HtmlToMarkdownOptions();
+        options.ExcludeSelectors.Add(".ad");
+        options.ElementFilters.Add(element => string.Equals(element.GetAttribute("data-skip"), "true", StringComparison.Ordinal));
+
+        string markdown = Normalize(html.ToMarkdown(options));
+
+        Assert.Equal("Keep", markdown);
+    }
+
+    [Fact]
+    public void HtmlToMarkdown_TagAliases_MapUnsupportedTagsToBuiltInConverters() {
+        const string html = "<p><highlight>Important</highlight> and <custom-bold>bold</custom-bold></p>";
+
+        var options = new HtmlToMarkdownOptions {
+            PreserveUnsupportedInlineHtml = false
+        };
+        options.TagAliases["highlight"] = "mark";
+        options.TagAliases["custom-bold"] = "strong";
+
+        string markdown = Normalize(html.ToMarkdown(options));
+
+        Assert.Equal("==Important== and **bold**", markdown);
+    }
+
+    [Fact]
+    public void HtmlToMarkdown_PassThroughTags_PreserveOriginalHtmlEvenForKnownTags() {
+        const string html = "<p>Keep <strong>literal</strong></p>";
+
+        var options = new HtmlToMarkdownOptions();
+        options.PassThroughTags.Add("strong");
+
+        string markdown = Normalize(html.ToMarkdown(options));
+
+        Assert.Equal("Keep <strong>literal</strong>", markdown);
+    }
+
+    [Fact]
+    public void HtmlToMarkdown_UnknownBlockHandling_CanBypassDropPreserveOrRaise() {
+        const string html = "<x-card><p>Inner <strong>text</strong></p></x-card>";
+
+        string bypassed = Normalize(html.ToMarkdown(new HtmlToMarkdownOptions {
+            UnknownBlockHandling = HtmlUnknownTagHandling.Bypass
+        }));
+        string dropped = Normalize(html.ToMarkdown(new HtmlToMarkdownOptions {
+            UnknownBlockHandling = HtmlUnknownTagHandling.Drop
+        }));
+        string preserved = Normalize(html.ToMarkdown(new HtmlToMarkdownOptions {
+            UnknownBlockHandling = HtmlUnknownTagHandling.Preserve
+        }));
+
+        Assert.Equal("Inner **text**", bypassed);
+        Assert.Equal(string.Empty, dropped);
+        Assert.Contains("<x-card>", preserved, StringComparison.Ordinal);
+        Assert.Throws<NotSupportedException>(() => html.ToMarkdown(new HtmlToMarkdownOptions {
+            UnknownBlockHandling = HtmlUnknownTagHandling.Raise
+        }));
+    }
+
+    [Fact]
+    public void HtmlToMarkdown_UnknownInlineHandling_CanBypassDropPreserveOrRaise() {
+        const string html = "<p>Before <x-chip>inside</x-chip> after</p>";
+
+        string bypassed = Normalize(html.ToMarkdown(new HtmlToMarkdownOptions {
+            UnknownInlineHandling = HtmlUnknownTagHandling.Bypass
+        }));
+        string dropped = Normalize(html.ToMarkdown(new HtmlToMarkdownOptions {
+            UnknownInlineHandling = HtmlUnknownTagHandling.Drop
+        }));
+        string preserved = Normalize(html.ToMarkdown(new HtmlToMarkdownOptions {
+            UnknownInlineHandling = HtmlUnknownTagHandling.Preserve
+        }));
+
+        Assert.Equal("Before inside after", bypassed);
+        Assert.Contains("Before", dropped, StringComparison.Ordinal);
+        Assert.Contains("after", dropped, StringComparison.Ordinal);
+        Assert.DoesNotContain("inside", dropped, StringComparison.Ordinal);
+        Assert.DoesNotContain("x-chip", dropped, StringComparison.Ordinal);
+        Assert.Equal("Before <x-chip>inside</x-chip> after", preserved);
+        Assert.Throws<NotSupportedException>(() => html.ToMarkdown(new HtmlToMarkdownOptions {
+            UnknownInlineHandling = HtmlUnknownTagHandling.Raise
+        }));
+    }
+
+    [Fact]
+    public void HtmlToMarkdown_GitHubProfile_UsesSmartHrefAndPipeTables() {
+        const string html = """
+<article>
+  <p><a href="https://example.com">https://example.com</a></p>
+  <table><tr><th>Name</th><th>Value</th></tr><tr><td>Area</td><td>Markdown</td></tr></table>
+</article>
+""";
+
+        string markdown = Normalize(html.ToMarkdown(HtmlToMarkdownOptions.CreateGitHubFlavoredMarkdownProfile()));
+
+        Assert.Contains("https://example.com", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("[https://example.com]", markdown, StringComparison.Ordinal);
+        Assert.Contains("| Name | Value |", markdown, StringComparison.Ordinal);
+        Assert.Contains("| --- | --- |", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HtmlToMarkdown_CommonMarkProfile_UsesRawHtmlForTablesAndKeepsExplicitSelfLinks() {
+        const string html = """
+<article>
+  <p><a href="https://example.com">https://example.com</a></p>
+  <table><tr><th>Name</th><th>Value</th></tr><tr><td>Area</td><td>Markdown</td></tr></table>
+</article>
+""";
+
+        string markdown = Normalize(html.ToMarkdown(HtmlToMarkdownOptions.CreateCommonMarkProfile()));
+
+        Assert.Contains("[https://example.com](https://example.com)", markdown, StringComparison.Ordinal);
+        Assert.Contains("<table>", markdown, StringComparison.Ordinal);
+        Assert.Contains("<th>Name</th>", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("| Name | Value |", markdown, StringComparison.Ordinal);
+    }
+
+    private static string Normalize(string value) {
+        return value.Replace("\r\n", "\n").Trim();
+    }
+}

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_Compatibility_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_Compatibility_Tests.cs
@@ -145,6 +145,24 @@ public sealed class MarkdownHtmlToMarkdownCompatibilityTests {
     }
 
     [Fact]
+    public void HtmlToMarkdown_TagAliases_MapStandaloneParagraphMediaToImageBlock() {
+        const string html = """
+<p><custom-img src="photo.png" alt="Photo"></custom-img></p>
+""";
+
+        var options = new HtmlToMarkdownOptions {
+            BaseUri = new Uri("https://example.com/docs/")
+        };
+        options.TagAliases["custom-img"] = "img";
+
+        var document = new HtmlToMarkdownConverter().ConvertToDocument(html, options);
+        var image = Assert.IsType<ImageBlock>(Assert.Single(document.Blocks));
+
+        Assert.Equal("https://example.com/docs/photo.png", image.Path);
+        Assert.Equal("Photo", image.Alt);
+    }
+
+    [Fact]
     public void HtmlToMarkdown_PictureFallbackImageKeepsLazyImageSourceAheadOfPlaceholder() {
         const string html = """
 <picture>

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_Compatibility_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_Compatibility_Tests.cs
@@ -1,3 +1,4 @@
+using OfficeIMO.Markdown;
 using OfficeIMO.Markdown.Html;
 using Xunit;
 
@@ -44,6 +45,25 @@ public sealed class MarkdownHtmlToMarkdownCompatibilityTests {
     }
 
     [Fact]
+    public void HtmlToMarkdown_FiltersBaseElementBeforeResolvingRelativeUrls() {
+        const string html = """
+<html>
+  <head><base href="https://external.example/"></head>
+  <body><p><a href="guide">Guide</a></p></body>
+</html>
+""";
+
+        var options = new HtmlToMarkdownOptions {
+            BaseUri = new Uri("https://docs.example/root/")
+        };
+        options.ExcludeSelectors.Add("base");
+
+        string markdown = Normalize(html.ToMarkdown(options));
+
+        Assert.Equal("[Guide](https://docs.example/root/guide)", markdown);
+    }
+
+    [Fact]
     public void HtmlToMarkdown_TagAliases_MapUnsupportedTagsToBuiltInConverters() {
         const string html = "<p><highlight>Important</highlight> and <custom-bold>bold</custom-bold></p>";
 
@@ -69,6 +89,33 @@ public sealed class MarkdownHtmlToMarkdownCompatibilityTests {
         string markdown = Normalize(html.ToMarkdown(options));
 
         Assert.Equal("- First\n- **Second**", markdown);
+    }
+
+    [Fact]
+    public void HtmlToMarkdown_TagAliases_MapMediaChildrenToBuiltInConverters() {
+        const string html = """
+<custom-figure>
+  <custom-picture>
+    <custom-img src="media/photo.png" alt="Photo">
+  </custom-picture>
+  <custom-caption>Caption text</custom-caption>
+</custom-figure>
+""";
+
+        var options = new HtmlToMarkdownOptions {
+            BaseUri = new Uri("https://example.com/docs/")
+        };
+        options.TagAliases["custom-figure"] = "figure";
+        options.TagAliases["custom-picture"] = "picture";
+        options.TagAliases["custom-img"] = "img";
+        options.TagAliases["custom-caption"] = "figcaption";
+
+        var document = new HtmlToMarkdownConverter().ConvertToDocument(html, options);
+        var image = Assert.IsType<ImageBlock>(Assert.Single(document.Blocks));
+
+        Assert.Equal("https://example.com/docs/media/photo.png", image.Path);
+        Assert.Equal("Photo", image.Alt);
+        Assert.Equal("Caption text", image.Caption);
     }
 
     [Fact]
@@ -166,6 +213,7 @@ public sealed class MarkdownHtmlToMarkdownCompatibilityTests {
 <article>
   <p><a href="https://example.com">https://example.com</a></p>
   <p><del>old</del> and <mark>new</mark></p>
+  <ul><li><input type="checkbox" checked>Done</li><li><input type="checkbox">Open</li></ul>
   <table><tr><th>Name</th><th>Value</th></tr><tr><td>Area</td><td>Markdown</td></tr></table>
 </article>
 """;
@@ -177,6 +225,9 @@ public sealed class MarkdownHtmlToMarkdownCompatibilityTests {
         Assert.Contains("<mark>new</mark>", markdown, StringComparison.Ordinal);
         Assert.DoesNotContain("~~old~~", markdown, StringComparison.Ordinal);
         Assert.DoesNotContain("==new==", markdown, StringComparison.Ordinal);
+        Assert.Contains("<input", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("- [x]", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("- [ ]", markdown, StringComparison.Ordinal);
         Assert.Contains("<table>", markdown, StringComparison.Ordinal);
         Assert.Contains("<th>Name</th>", markdown, StringComparison.Ordinal);
         Assert.DoesNotContain("| Name | Value |", markdown, StringComparison.Ordinal);

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_Compatibility_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_Compatibility_Tests.cs
@@ -119,6 +119,32 @@ public sealed class MarkdownHtmlToMarkdownCompatibilityTests {
     }
 
     [Fact]
+    public void HtmlToMarkdown_TagAliases_MapPictureSourcesToPreferredImagePath() {
+        const string html = """
+<custom-picture>
+  <custom-source srcset="large.png 2x">
+  <custom-img src="small.png" alt="Photo">
+</custom-picture>
+""";
+
+        var options = new HtmlToMarkdownOptions {
+            BaseUri = new Uri("https://example.com/docs/")
+        };
+        options.TagAliases["custom-picture"] = "picture";
+        options.TagAliases["custom-source"] = "source";
+        options.TagAliases["custom-img"] = "img";
+
+        var document = new HtmlToMarkdownConverter().ConvertToDocument(html, options);
+        var image = Assert.IsType<ImageBlock>(Assert.Single(document.Blocks));
+        var source = Assert.Single(image.PictureSources);
+
+        Assert.Equal("https://example.com/docs/large.png", image.Path);
+        Assert.Equal("https://example.com/docs/small.png", image.PictureFallbackPath);
+        Assert.Equal("https://example.com/docs/large.png", source.Path);
+        Assert.Equal("Photo", image.Alt);
+    }
+
+    [Fact]
     public void HtmlToMarkdown_PassThroughTags_PreserveOriginalHtmlEvenForKnownTags() {
         const string html = "<p>Keep <strong>literal</strong></p>";
 
@@ -231,6 +257,30 @@ public sealed class MarkdownHtmlToMarkdownCompatibilityTests {
         Assert.Contains("<table>", markdown, StringComparison.Ordinal);
         Assert.Contains("<th>Name</th>", markdown, StringComparison.Ordinal);
         Assert.DoesNotContain("| Name | Value |", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HtmlToMarkdown_CommonMarkProfile_EscapesLineStartsThatWouldBecomeBlocks() {
+        const string html = "<p># not heading</p><p>- not list</p>";
+
+        string markdown = Normalize(html.ToMarkdown(HtmlToMarkdownOptions.CreateCommonMarkProfile()));
+
+        Assert.Equal("\\# not heading\n\n\\- not list", markdown);
+    }
+
+    [Fact]
+    public void HtmlToMarkdown_TagAliases_UnwrapRejectedAnchorHrefs() {
+        const string html = "<custom-link href=\"javascript:alert(1)\"><img src=\"ok.png\" alt=\"Ok\"></custom-link>";
+
+        var options = new HtmlToMarkdownOptions {
+            BaseUri = new Uri("https://example.com/docs/")
+        };
+        options.TagAliases["custom-link"] = "a";
+
+        string markdown = Normalize(html.ToMarkdown(options));
+
+        Assert.Equal("![Ok](https://example.com/docs/ok.png)", markdown);
+        Assert.DoesNotContain("javascript:", markdown, StringComparison.OrdinalIgnoreCase);
     }
 
     private static string Normalize(string value) {

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_Compatibility_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_Compatibility_Tests.cs
@@ -10,6 +10,7 @@ public sealed class MarkdownHtmlToMarkdownCompatibilityTests {
 <p>
   <a href="https://example.com">https://example.com</a>
   <a href="mailto:user@example.com">user@example.com</a>
+  <a href="tel:+15551234567">+15551234567</a>
   <a href="https://example.com/docs">Docs</a>
 </p>
 """;
@@ -18,7 +19,7 @@ public sealed class MarkdownHtmlToMarkdownCompatibilityTests {
             SmartHref = true
         }));
 
-        Assert.Contains("https://example.com user@example.com [Docs](https://example.com/docs)", markdown, StringComparison.Ordinal);
+        Assert.Contains("https://example.com user@example.com [+15551234567](tel:+15551234567) [Docs](https://example.com/docs)", markdown, StringComparison.Ordinal);
         Assert.DoesNotContain("[https://example.com]", markdown, StringComparison.Ordinal);
         Assert.DoesNotContain("[user@example.com]", markdown, StringComparison.Ordinal);
     }
@@ -98,12 +99,21 @@ public sealed class MarkdownHtmlToMarkdownCompatibilityTests {
         string bypassedInlineOnly = Normalize("<custom-widget><strong>Custom</strong> payload</custom-widget>".ToMarkdown(new HtmlToMarkdownOptions {
             UnknownBlockHandling = HtmlUnknownTagHandling.Bypass
         }));
+        string droppedInlineOnly = Normalize("<custom-widget><strong>Custom</strong> payload</custom-widget>".ToMarkdown(new HtmlToMarkdownOptions {
+            PreserveUnsupportedBlocks = false,
+            UnknownBlockHandling = HtmlUnknownTagHandling.Drop
+        }));
 
         Assert.Equal("Inner **text**", bypassed);
         Assert.Equal("**Custom** payload", bypassedInlineOnly);
+        Assert.Equal(string.Empty, droppedInlineOnly);
         Assert.Equal(string.Empty, dropped);
         Assert.Contains("<x-card>", preserved, StringComparison.Ordinal);
         Assert.Throws<NotSupportedException>(() => html.ToMarkdown(new HtmlToMarkdownOptions {
+            UnknownBlockHandling = HtmlUnknownTagHandling.Raise
+        }));
+        Assert.Throws<NotSupportedException>(() => "<custom-widget>payload</custom-widget>".ToMarkdown(new HtmlToMarkdownOptions {
+            PreserveUnsupportedBlocks = false,
             UnknownBlockHandling = HtmlUnknownTagHandling.Raise
         }));
     }
@@ -155,6 +165,7 @@ public sealed class MarkdownHtmlToMarkdownCompatibilityTests {
         const string html = """
 <article>
   <p><a href="https://example.com">https://example.com</a></p>
+  <p><del>old</del> and <mark>new</mark></p>
   <table><tr><th>Name</th><th>Value</th></tr><tr><td>Area</td><td>Markdown</td></tr></table>
 </article>
 """;
@@ -162,6 +173,10 @@ public sealed class MarkdownHtmlToMarkdownCompatibilityTests {
         string markdown = Normalize(html.ToMarkdown(HtmlToMarkdownOptions.CreateCommonMarkProfile()));
 
         Assert.Contains("[https://example.com](https://example.com)", markdown, StringComparison.Ordinal);
+        Assert.Contains("<del>old</del>", markdown, StringComparison.Ordinal);
+        Assert.Contains("<mark>new</mark>", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("~~old~~", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("==new==", markdown, StringComparison.Ordinal);
         Assert.Contains("<table>", markdown, StringComparison.Ordinal);
         Assert.Contains("<th>Name</th>", markdown, StringComparison.Ordinal);
         Assert.DoesNotContain("| Name | Value |", markdown, StringComparison.Ordinal);

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_Compatibility_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_Compatibility_Tests.cs
@@ -58,6 +58,19 @@ public sealed class MarkdownHtmlToMarkdownCompatibilityTests {
     }
 
     [Fact]
+    public void HtmlToMarkdown_TagAliases_MapStructuredChildrenToBuiltInConverters() {
+        const string html = "<custom-list><custom-item>First</custom-item><custom-item><strong>Second</strong></custom-item></custom-list>";
+
+        var options = new HtmlToMarkdownOptions();
+        options.TagAliases["custom-list"] = "ul";
+        options.TagAliases["custom-item"] = "li";
+
+        string markdown = Normalize(html.ToMarkdown(options));
+
+        Assert.Equal("- First\n- **Second**", markdown);
+    }
+
+    [Fact]
     public void HtmlToMarkdown_PassThroughTags_PreserveOriginalHtmlEvenForKnownTags() {
         const string html = "<p>Keep <strong>literal</strong></p>";
 
@@ -82,8 +95,12 @@ public sealed class MarkdownHtmlToMarkdownCompatibilityTests {
         string preserved = Normalize(html.ToMarkdown(new HtmlToMarkdownOptions {
             UnknownBlockHandling = HtmlUnknownTagHandling.Preserve
         }));
+        string bypassedInlineOnly = Normalize("<custom-widget><strong>Custom</strong> payload</custom-widget>".ToMarkdown(new HtmlToMarkdownOptions {
+            UnknownBlockHandling = HtmlUnknownTagHandling.Bypass
+        }));
 
         Assert.Equal("Inner **text**", bypassed);
+        Assert.Equal("**Custom** payload", bypassedInlineOnly);
         Assert.Equal(string.Empty, dropped);
         Assert.Contains("<x-card>", preserved, StringComparison.Ordinal);
         Assert.Throws<NotSupportedException>(() => html.ToMarkdown(new HtmlToMarkdownOptions {

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_Tests.cs
@@ -281,6 +281,36 @@ public sealed class MarkdownHtmlToMarkdownTests {
     }
 
     [Fact]
+    public void HtmlToMarkdown_TriesLaterPictureSourcesAfterMalformedBase64Source() {
+        string directory = Path.Combine(Path.GetTempPath(), "OfficeIMO.HtmlImages." + Guid.NewGuid().ToString("N"));
+        try {
+            const string html = """
+<picture>
+  <source srcset="data:image/png;base64,not-valid-base64">
+  <source srcset="large.png 2x">
+  <img src="small.png" alt="Photo">
+</picture>
+""";
+
+            foreach (HtmlBase64ImageHandling handling in new[] { HtmlBase64ImageHandling.Skip, HtmlBase64ImageHandling.SaveToFile }) {
+                MarkdownDoc document = html.LoadFromHtml(new HtmlToMarkdownOptions {
+                    BaseUri = new Uri("https://example.test/articles/"),
+                    Base64Images = handling,
+                    Base64ImageOutputDirectory = directory
+                });
+
+                var image = Assert.IsType<ImageBlock>(Assert.Single(document.Blocks));
+                Assert.Equal("https://example.test/articles/large.png", image.Path);
+                Assert.DoesNotContain("data:image", document.ToMarkdown(), StringComparison.OrdinalIgnoreCase);
+            }
+        } finally {
+            if (Directory.Exists(directory)) {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public void HtmlToMarkdown_PreservesPictureFallbackImageSrcInsteadOfSrcSetCandidate() {
         const string html = """
 <picture>

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_Write_Profile_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_Write_Profile_Tests.cs
@@ -262,6 +262,53 @@ Lead[^1]
     }
 
     [Fact]
+    public void CommonMark_Write_Profile_Renders_CustomContainers_As_Raw_Html() {
+        var doc = MarkdownDoc.Create().Add(new CustomContainerBlock(
+            "note",
+            new IMarkdownBlock[] {
+                new ParagraphBlock(new InlineSequence().Text("Body"))
+            }));
+
+        var markdown = doc.ToMarkdown(MarkdownWriteOptions.CreateCommonMarkProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.Equal("<div class=\"note\"><p>Body</p></div>", markdown);
+        Assert.DoesNotContain(":::", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CommonMark_Write_Profile_Escapes_DirectParagraphLineStarts() {
+        var doc = MarkdownDoc.Create().Add(new ParagraphBlock(new InlineSequence()
+            .Text("# not heading")
+            .SoftBreak()
+            .Text("- not list")
+            .SoftBreak()
+            .Text("1. not ordered")));
+
+        var markdown = doc.ToMarkdown(MarkdownWriteOptions.CreateCommonMarkProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.Equal("\\# not heading\n\\- not list\n1\\. not ordered", markdown);
+    }
+
+    [Fact]
+    public void CommonMark_Write_Profile_Renders_Attributed_Blocks_As_Raw_Html() {
+        var readerOptions = MarkdownReaderOptions.CreateOfficeIMOProfile();
+        readerOptions.GenericAttributes = true;
+        var doc = MarkdownReader.Parse("""
+# Title {#intro .lead}
+
+{#para .note}
+Text
+""", readerOptions);
+
+        var markdown = doc.ToMarkdown(MarkdownWriteOptions.CreateCommonMarkProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.Contains("<h1 id=\"intro\" class=\"lead\">Title</h1>", markdown, StringComparison.Ordinal);
+        Assert.Contains("<p id=\"para\" class=\"note\">Text</p>", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("{#intro", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("{#para", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CommonMark_Write_Profile_Renders_NonCommonMark_Inlines_As_Raw_Html() {
         var scalarDoc = MarkdownDoc.Create()
             .Add(new ParagraphBlock(new InlineSequence()
@@ -287,6 +334,18 @@ Lead[^1]
         Assert.DoesNotContain("++added", sequenceMarkdown, StringComparison.Ordinal);
         Assert.DoesNotContain("^up", sequenceMarkdown, StringComparison.Ordinal);
         Assert.DoesNotContain("~down", sequenceMarkdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CommonMark_Write_Profile_Renders_InlineFallbackAttributes_As_HtmlAttributes() {
+        var readerOptions = MarkdownReaderOptions.CreateOfficeIMOProfile();
+        readerOptions.GenericAttributes = true;
+        var doc = MarkdownReader.Parse("~~old~~{#gone .muted}", readerOptions);
+
+        var markdown = doc.ToMarkdown(MarkdownWriteOptions.CreateCommonMarkProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.Equal("<del id=\"gone\" class=\"muted\">old</del>", markdown);
+        Assert.DoesNotContain("{#gone", markdown, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -325,6 +384,15 @@ Lead[^1]
         Assert.Contains(
             MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).BlockRenderExtensions,
             extension => string.Equals(extension.Name, MarkdownBlockRenderBuiltInExtensions.CommonMarkDetailsMarkdownName, StringComparison.Ordinal));
+        Assert.Contains(
+            MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).BlockRenderExtensions,
+            extension => string.Equals(extension.Name, MarkdownBlockRenderBuiltInExtensions.CommonMarkCustomContainerMarkdownName, StringComparison.Ordinal));
+        Assert.Contains(
+            MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).BlockRenderExtensions,
+            extension => string.Equals(extension.Name, MarkdownBlockRenderBuiltInExtensions.CommonMarkParagraphLineStartMarkdownName, StringComparison.Ordinal));
+        Assert.Contains(
+            MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).BlockRenderExtensions,
+            extension => string.Equals(extension.Name, MarkdownBlockRenderBuiltInExtensions.CommonMarkAttributedBlockMarkdownName, StringComparison.Ordinal));
         Assert.Contains(
             MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).InlineRenderExtensions,
             extension => string.Equals(extension.Name, MarkdownInlineRenderBuiltInExtensions.CommonMarkStrikethroughMarkdownName, StringComparison.Ordinal));

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_Write_Profile_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_Write_Profile_Tests.cs
@@ -169,6 +169,51 @@ Lead[^1]
     }
 
     [Fact]
+    public void CommonMark_Write_Profile_Renders_Tables_As_Raw_Html() {
+        var table = new TableBlock();
+        table.Headers.Add("Name");
+        table.Headers.Add("Value");
+        table.Rows.Add(new[] { "Area", "Markdown" });
+        var doc = MarkdownDoc.Create().Add(table);
+
+        var markdown = doc.ToMarkdown(MarkdownWriteOptions.CreateCommonMarkProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.StartsWith("<table>", markdown, StringComparison.Ordinal);
+        Assert.Contains("<th>Name</th>", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("| Name | Value |", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GitHubFlavoredMarkdown_Write_Profile_Keeps_Pipe_Tables_And_Portable_Images() {
+        var table = new TableBlock();
+        table.Headers.Add("Name");
+        table.Headers.Add("Value");
+        table.Rows.Add(new[] { "Area", "Markdown" });
+        var doc = MarkdownDoc.Create()
+            .Add(new ImageBlock("https://example.com/logo.png", "Logo", width: 256, height: 128))
+            .Add(table);
+
+        var markdown = doc.ToMarkdown(MarkdownWriteOptions.CreateGitHubFlavoredMarkdownProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.Contains("![Logo](https://example.com/logo.png)", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("{width=", markdown, StringComparison.Ordinal);
+        Assert.Contains("| Name | Value |", markdown, StringComparison.Ordinal);
+        Assert.Contains("| --- | --- |", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MarkdownWriteOptions_CreateProfile_Maps_Named_Output_Profiles() {
+        Assert.Empty(MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.OfficeIMO).BlockRenderExtensions);
+        Assert.Contains(
+            MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).BlockRenderExtensions,
+            extension => string.Equals(extension.Name, MarkdownBlockRenderBuiltInExtensions.CommonMarkTableMarkdownName, StringComparison.Ordinal));
+        Assert.Equal(MarkdownImageRenderingMode.PortableMarkdown, MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.GitHubFlavoredMarkdown).ImageRenderingMode);
+        Assert.Contains(
+            MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.Portable).BlockRenderExtensions,
+            extension => string.Equals(extension.Name, MarkdownBlockRenderBuiltInExtensions.PortableCalloutMarkdownName, StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Html_Image_Profile_Renders_Linked_Image_Blocks_As_Raw_Html() {
         var doc = MarkdownDoc.Create()
             .Add(new ImageBlock(

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_Write_Profile_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_Write_Profile_Tests.cs
@@ -199,6 +199,21 @@ Lead[^1]
     }
 
     [Fact]
+    public void CommonMark_Write_Profile_Renders_Task_Lists_As_Raw_Html() {
+        var list = new UnorderedListBlock();
+        list.Items.Add(ListItem.Task("Done", done: true));
+        list.Items.Add(ListItem.Task("Open"));
+        var doc = MarkdownDoc.Create().Add(list);
+
+        var markdown = doc.ToMarkdown(MarkdownWriteOptions.CreateCommonMarkProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.StartsWith("<ul", markdown, StringComparison.Ordinal);
+        Assert.Contains("type=\"checkbox\"", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("- [x]", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("- [ ]", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void GitHubFlavoredMarkdown_Write_Profile_Keeps_Pipe_Tables_And_Portable_Images() {
         var table = new TableBlock();
         table.Headers.Add("Name");
@@ -222,6 +237,9 @@ Lead[^1]
         Assert.Contains(
             MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).BlockRenderExtensions,
             extension => string.Equals(extension.Name, MarkdownBlockRenderBuiltInExtensions.CommonMarkTableMarkdownName, StringComparison.Ordinal));
+        Assert.Contains(
+            MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).BlockRenderExtensions,
+            extension => string.Equals(extension.Name, MarkdownBlockRenderBuiltInExtensions.CommonMarkTaskListMarkdownName, StringComparison.Ordinal));
         Assert.Contains(
             MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).InlineRenderExtensions,
             extension => string.Equals(extension.Name, MarkdownInlineRenderBuiltInExtensions.CommonMarkStrikethroughMarkdownName, StringComparison.Ordinal));

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_Write_Profile_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_Write_Profile_Tests.cs
@@ -244,6 +244,52 @@ Lead[^1]
     }
 
     [Fact]
+    public void CommonMark_Write_Profile_Renders_Details_As_Raw_Html() {
+        var details = new DetailsBlock(
+            new SummaryBlock("More"),
+            new IMarkdownBlock[] {
+                new ParagraphBlock(new InlineSequence().Bold("Hidden"))
+            },
+            open: true);
+        var doc = MarkdownDoc.Create().Add(details);
+
+        var markdown = doc.ToMarkdown(MarkdownWriteOptions.CreateCommonMarkProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.StartsWith("<details open>", markdown, StringComparison.Ordinal);
+        Assert.Contains("<summary>More</summary>", markdown, StringComparison.Ordinal);
+        Assert.Contains("<strong>Hidden</strong>", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("**Hidden**", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CommonMark_Write_Profile_Renders_NonCommonMark_Inlines_As_Raw_Html() {
+        var scalarDoc = MarkdownDoc.Create()
+            .Add(new ParagraphBlock(new InlineSequence()
+                .Inserted("added")
+                .Superscript("up")
+                .Subscript("down")));
+
+        var scalarMarkdown = scalarDoc.ToMarkdown(MarkdownWriteOptions.CreateCommonMarkProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.Equal("<ins>added</ins> <sup>up</sup> <sub>down</sub>", scalarMarkdown);
+
+        var readerOptions = MarkdownReaderOptions.CreateOfficeIMOProfile();
+        readerOptions.Inserted = true;
+        readerOptions.Superscript = true;
+        readerOptions.Subscript = true;
+        var sequenceDoc = MarkdownReader.Parse("++added **bold**++ ^up **bold**^ ~down **bold**~", readerOptions);
+
+        var sequenceMarkdown = sequenceDoc.ToMarkdown(MarkdownWriteOptions.CreateCommonMarkProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.Contains("<ins>added <strong>bold</strong></ins>", sequenceMarkdown, StringComparison.Ordinal);
+        Assert.Contains("<sup>up <strong>bold</strong></sup>", sequenceMarkdown, StringComparison.Ordinal);
+        Assert.Contains("<sub>down <strong>bold</strong></sub>", sequenceMarkdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("++added", sequenceMarkdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("^up", sequenceMarkdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("~down", sequenceMarkdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void GitHubFlavoredMarkdown_Write_Profile_Keeps_Pipe_Tables_And_Portable_Images() {
         var table = new TableBlock();
         table.Headers.Add("Name");
@@ -277,11 +323,23 @@ Lead[^1]
             MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).BlockRenderExtensions,
             extension => string.Equals(extension.Name, MarkdownBlockRenderBuiltInExtensions.CommonMarkFootnoteDefinitionMarkdownName, StringComparison.Ordinal));
         Assert.Contains(
+            MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).BlockRenderExtensions,
+            extension => string.Equals(extension.Name, MarkdownBlockRenderBuiltInExtensions.CommonMarkDetailsMarkdownName, StringComparison.Ordinal));
+        Assert.Contains(
             MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).InlineRenderExtensions,
             extension => string.Equals(extension.Name, MarkdownInlineRenderBuiltInExtensions.CommonMarkStrikethroughMarkdownName, StringComparison.Ordinal));
         Assert.Contains(
             MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).InlineRenderExtensions,
             extension => string.Equals(extension.Name, MarkdownInlineRenderBuiltInExtensions.CommonMarkFootnoteReferenceMarkdownName, StringComparison.Ordinal));
+        Assert.Contains(
+            MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).InlineRenderExtensions,
+            extension => string.Equals(extension.Name, MarkdownInlineRenderBuiltInExtensions.CommonMarkInsertedMarkdownName, StringComparison.Ordinal));
+        Assert.Contains(
+            MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).InlineRenderExtensions,
+            extension => string.Equals(extension.Name, MarkdownInlineRenderBuiltInExtensions.CommonMarkSuperscriptMarkdownName, StringComparison.Ordinal));
+        Assert.Contains(
+            MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).InlineRenderExtensions,
+            extension => string.Equals(extension.Name, MarkdownInlineRenderBuiltInExtensions.CommonMarkSubscriptMarkdownName, StringComparison.Ordinal));
         Assert.Equal(MarkdownImageRenderingMode.PortableMarkdown, MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.GitHubFlavoredMarkdown).ImageRenderingMode);
         Assert.Contains(
             MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.Portable).BlockRenderExtensions,

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_Write_Profile_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_Write_Profile_Tests.cs
@@ -349,6 +349,45 @@ Text
     }
 
     [Fact]
+    public void CommonMark_Write_Profile_Renders_Attributed_CommonMark_Inlines_As_Raw_Html() {
+        var readerOptions = MarkdownReaderOptions.CreateOfficeIMOProfile();
+        readerOptions.GenericAttributes = true;
+        var doc = MarkdownReader.Parse("**bold**{#strong .lead} [link](https://example.test){.go}", readerOptions);
+
+        var markdown = doc.ToMarkdown(MarkdownWriteOptions.CreateCommonMarkProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.Contains("<strong id=\"strong\" class=\"lead\">bold</strong>", markdown, StringComparison.Ordinal);
+        Assert.Contains("<a href=\"https://example.test\" class=\"go\">link</a>", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("{#strong", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("{.go", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CommonMark_Write_Profile_Renders_Attributed_ListItems_As_Raw_Html() {
+        var readerOptions = MarkdownReaderOptions.CreateOfficeIMOProfile();
+        readerOptions.GenericAttributes = true;
+        var doc = MarkdownReader.Parse("- Item {#one .picked}", readerOptions);
+
+        var markdown = doc.ToMarkdown(MarkdownWriteOptions.CreateCommonMarkProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.Equal("<ul><li id=\"one\" class=\"picked\">Item</li></ul>", markdown);
+        Assert.DoesNotContain("{#one", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CommonMark_Write_Profile_Omits_FrontMatter() {
+        var doc = MarkdownDoc.Create()
+            .FrontMatter(new Dictionary<string, object?> { ["title"] = "OfficeIMO" })
+            .H1("Title");
+
+        var markdown = doc.ToMarkdown(MarkdownWriteOptions.CreateCommonMarkProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.Equal("# Title", markdown);
+        Assert.DoesNotContain("---", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("title:", markdown, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void GitHubFlavoredMarkdown_Write_Profile_Keeps_Pipe_Tables_And_Portable_Images() {
         var table = new TableBlock();
         table.Headers.Add("Name");
@@ -367,8 +406,28 @@ Text
     }
 
     [Fact]
+    public void GitHubFlavoredMarkdown_Write_Profile_Renders_OfficeOnly_Inlines_As_Raw_Html() {
+        var doc = MarkdownDoc.Create()
+            .Add(new ParagraphBlock(new InlineSequence()
+                .Strike("old")
+                .Highlight("new")
+                .Inserted("added")
+                .Superscript("up")
+                .Subscript("down")));
+
+        var markdown = doc.ToMarkdown(MarkdownWriteOptions.CreateGitHubFlavoredMarkdownProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.Equal("~~old~~ <mark>new</mark> <ins>added</ins> <sup>up</sup> <sub>down</sub>", markdown);
+        Assert.DoesNotContain("==new==", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("++added++", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("^up^", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("~down~", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void MarkdownWriteOptions_CreateProfile_Maps_Named_Output_Profiles() {
         Assert.Empty(MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.OfficeIMO).BlockRenderExtensions);
+        Assert.Equal(MarkdownFrontMatterRenderingMode.Omit, MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).FrontMatterRendering);
         Assert.Contains(
             MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).BlockRenderExtensions,
             extension => string.Equals(extension.Name, MarkdownBlockRenderBuiltInExtensions.CommonMarkTableMarkdownName, StringComparison.Ordinal));
@@ -408,7 +467,16 @@ Text
         Assert.Contains(
             MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).InlineRenderExtensions,
             extension => string.Equals(extension.Name, MarkdownInlineRenderBuiltInExtensions.CommonMarkSubscriptMarkdownName, StringComparison.Ordinal));
+        Assert.Contains(
+            MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).InlineRenderExtensions,
+            extension => string.Equals(extension.Name, MarkdownInlineRenderBuiltInExtensions.CommonMarkAttributedInlineMarkdownName, StringComparison.Ordinal));
         Assert.Equal(MarkdownImageRenderingMode.PortableMarkdown, MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.GitHubFlavoredMarkdown).ImageRenderingMode);
+        Assert.Contains(
+            MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.GitHubFlavoredMarkdown).InlineRenderExtensions,
+            extension => string.Equals(extension.Name, MarkdownInlineRenderBuiltInExtensions.GitHubHighlightMarkdownName, StringComparison.Ordinal));
+        Assert.Contains(
+            MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.GitHubFlavoredMarkdown).InlineRenderExtensions,
+            extension => string.Equals(extension.Name, MarkdownInlineRenderBuiltInExtensions.GitHubAttributedInlineMarkdownName, StringComparison.Ordinal));
         Assert.Contains(
             MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.Portable).BlockRenderExtensions,
             extension => string.Equals(extension.Name, MarkdownBlockRenderBuiltInExtensions.PortableCalloutMarkdownName, StringComparison.Ordinal));

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_Write_Profile_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_Write_Profile_Tests.cs
@@ -214,6 +214,36 @@ Lead[^1]
     }
 
     [Fact]
+    public void CommonMark_Write_Profile_Renders_Definition_Lists_As_Raw_Html() {
+        var list = new DefinitionListBlock();
+        list.AddEntry(new DefinitionListEntry(
+            new InlineSequence().Text("Term"),
+            new IMarkdownBlock[] { new ParagraphBlock(new InlineSequence().Text("Definition")) }));
+        var doc = MarkdownDoc.Create().Add(list);
+
+        var markdown = doc.ToMarkdown(MarkdownWriteOptions.CreateCommonMarkProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.StartsWith("<dl>", markdown, StringComparison.Ordinal);
+        Assert.Contains("<dt>Term</dt>", markdown, StringComparison.Ordinal);
+        Assert.Contains("<dd>Definition</dd>", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain(": Definition", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CommonMark_Write_Profile_Renders_Footnotes_As_Raw_Html() {
+        var doc = MarkdownDoc.Create()
+            .Add(new ParagraphBlock(new InlineSequence().Text("Lead").FootnoteRef("1")))
+            .Add(new FootnoteDefinitionBlock("1", "Footnote text"));
+
+        var markdown = doc.ToMarkdown(MarkdownWriteOptions.CreateCommonMarkProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.Contains("<sup id=\"fnref:1\"><a href=\"#fn:1\">1</a></sup>", markdown, StringComparison.Ordinal);
+        Assert.Contains("<p id=\"fn:1\"><sup>1</sup> Footnote text", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("[^1]", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("[^1]:", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void GitHubFlavoredMarkdown_Write_Profile_Keeps_Pipe_Tables_And_Portable_Images() {
         var table = new TableBlock();
         table.Headers.Add("Name");
@@ -241,8 +271,17 @@ Lead[^1]
             MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).BlockRenderExtensions,
             extension => string.Equals(extension.Name, MarkdownBlockRenderBuiltInExtensions.CommonMarkTaskListMarkdownName, StringComparison.Ordinal));
         Assert.Contains(
+            MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).BlockRenderExtensions,
+            extension => string.Equals(extension.Name, MarkdownBlockRenderBuiltInExtensions.CommonMarkDefinitionListMarkdownName, StringComparison.Ordinal));
+        Assert.Contains(
+            MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).BlockRenderExtensions,
+            extension => string.Equals(extension.Name, MarkdownBlockRenderBuiltInExtensions.CommonMarkFootnoteDefinitionMarkdownName, StringComparison.Ordinal));
+        Assert.Contains(
             MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).InlineRenderExtensions,
             extension => string.Equals(extension.Name, MarkdownInlineRenderBuiltInExtensions.CommonMarkStrikethroughMarkdownName, StringComparison.Ordinal));
+        Assert.Contains(
+            MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).InlineRenderExtensions,
+            extension => string.Equals(extension.Name, MarkdownInlineRenderBuiltInExtensions.CommonMarkFootnoteReferenceMarkdownName, StringComparison.Ordinal));
         Assert.Equal(MarkdownImageRenderingMode.PortableMarkdown, MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.GitHubFlavoredMarkdown).ImageRenderingMode);
         Assert.Contains(
             MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.Portable).BlockRenderExtensions,

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_Write_Profile_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_Write_Profile_Tests.cs
@@ -184,6 +184,21 @@ Lead[^1]
     }
 
     [Fact]
+    public void CommonMark_Write_Profile_Renders_Gfm_Only_Inlines_As_Raw_Html() {
+        var paragraph = new ParagraphBlock(new InlineSequence()
+            .Strike("old")
+            .Text("and")
+            .Highlight("new"));
+        var doc = MarkdownDoc.Create().Add(paragraph);
+
+        var markdown = doc.ToMarkdown(MarkdownWriteOptions.CreateCommonMarkProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.Equal("<del>old</del> and <mark>new</mark>", markdown);
+        Assert.DoesNotContain("~~old~~", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("==new==", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void GitHubFlavoredMarkdown_Write_Profile_Keeps_Pipe_Tables_And_Portable_Images() {
         var table = new TableBlock();
         table.Headers.Add("Name");
@@ -207,6 +222,9 @@ Lead[^1]
         Assert.Contains(
             MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).BlockRenderExtensions,
             extension => string.Equals(extension.Name, MarkdownBlockRenderBuiltInExtensions.CommonMarkTableMarkdownName, StringComparison.Ordinal));
+        Assert.Contains(
+            MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).InlineRenderExtensions,
+            extension => string.Equals(extension.Name, MarkdownInlineRenderBuiltInExtensions.CommonMarkStrikethroughMarkdownName, StringComparison.Ordinal));
         Assert.Equal(MarkdownImageRenderingMode.PortableMarkdown, MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.GitHubFlavoredMarkdown).ImageRenderingMode);
         Assert.Contains(
             MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.Portable).BlockRenderExtensions,

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_Write_Profile_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_Write_Profile_Tests.cs
@@ -375,6 +375,24 @@ Text
     }
 
     [Fact]
+    public void CommonMark_Write_Profile_Renders_Nested_Child_ListItem_Attributes_As_Raw_Html() {
+        var readerOptions = MarkdownReaderOptions.CreateOfficeIMOProfile();
+        readerOptions.GenericAttributes = true;
+        var childDocument = MarkdownReader.Parse("- Child {#child .picked}", readerOptions);
+        var childList = Assert.IsType<UnorderedListBlock>(Assert.Single(childDocument.Blocks));
+        var parentItem = ListItem.Text("Parent");
+        parentItem.Children.Add(childList);
+        var outerList = new UnorderedListBlock();
+        outerList.Items.Add(parentItem);
+        var doc = MarkdownDoc.Create().Add(outerList);
+
+        var markdown = doc.ToMarkdown(MarkdownWriteOptions.CreateCommonMarkProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.Contains("<li id=\"child\" class=\"picked\">Child</li>", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("{#child", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CommonMark_Write_Profile_Omits_FrontMatter() {
         var doc = MarkdownDoc.Create()
             .FrontMatter(new Dictionary<string, object?> { ["title"] = "OfficeIMO" })
@@ -385,6 +403,22 @@ Text
         Assert.Equal("# Title", markdown);
         Assert.DoesNotContain("---", markdown, StringComparison.Ordinal);
         Assert.DoesNotContain("title:", markdown, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CommonMark_Write_Profile_Omits_AbbreviationDefinitions() {
+        var readerOptions = MarkdownReaderOptions.CreateOfficeIMOProfile();
+        readerOptions.Abbreviations = true;
+        var doc = MarkdownReader.Parse("""
+HTML text
+
+*[HTML]: Hyper Text Markup Language
+""", readerOptions);
+
+        var markdown = doc.ToMarkdown(MarkdownWriteOptions.CreateCommonMarkProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.Equal("HTML text", markdown);
+        Assert.DoesNotContain("*[HTML]:", markdown, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -425,9 +459,80 @@ Text
     }
 
     [Fact]
+    public void GitHubFlavoredMarkdown_Write_Profile_Escapes_DirectParagraphLineStarts() {
+        var doc = MarkdownDoc.Create().Add(new ParagraphBlock(new InlineSequence()
+            .Text("# not heading")
+            .SoftBreak()
+            .Text("- not list")));
+
+        var markdown = doc.ToMarkdown(MarkdownWriteOptions.CreateGitHubFlavoredMarkdownProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.Equal("\\# not heading\n\\- not list", markdown);
+    }
+
+    [Fact]
+    public void GitHubFlavoredMarkdown_Write_Profile_Renders_NonGfm_Blocks_As_Raw_Html() {
+        var definitionList = new DefinitionListBlock();
+        definitionList.AddEntry(new DefinitionListEntry(
+            new InlineSequence().Text("Term"),
+            new IMarkdownBlock[] { new ParagraphBlock(new InlineSequence().Text("Definition")) }));
+        var doc = MarkdownDoc.Create()
+            .Add(new CustomContainerBlock(
+                "note",
+                new IMarkdownBlock[] {
+                    new ParagraphBlock(new InlineSequence().Text("Body"))
+                }))
+            .Add(definitionList);
+
+        var markdown = doc.ToMarkdown(MarkdownWriteOptions.CreateGitHubFlavoredMarkdownProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.Contains("<div class=\"note\"><p>Body</p></div>", markdown, StringComparison.Ordinal);
+        Assert.Contains("<dl>", markdown, StringComparison.Ordinal);
+        Assert.Contains("<dt>Term</dt>", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain(":::", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain(": Definition", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GitHubFlavoredMarkdown_Write_Profile_Renders_Attributed_Blocks_As_Raw_Html() {
+        var readerOptions = MarkdownReaderOptions.CreateOfficeIMOProfile();
+        readerOptions.GenericAttributes = true;
+        var doc = MarkdownReader.Parse("""
+# Title {#intro .lead}
+
+{#para .note}
+Text
+""", readerOptions);
+
+        var markdown = doc.ToMarkdown(MarkdownWriteOptions.CreateGitHubFlavoredMarkdownProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.Contains("<h1 id=\"intro\" class=\"lead\">Title</h1>", markdown, StringComparison.Ordinal);
+        Assert.Contains("<p id=\"para\" class=\"note\">Text</p>", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("{#intro", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("{#para", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GitHubFlavoredMarkdown_Write_Profile_Omits_AbbreviationDefinitions() {
+        var readerOptions = MarkdownReaderOptions.CreateOfficeIMOProfile();
+        readerOptions.Abbreviations = true;
+        var doc = MarkdownReader.Parse("""
+HTML text
+
+*[HTML]: Hyper Text Markup Language
+""", readerOptions);
+
+        var markdown = doc.ToMarkdown(MarkdownWriteOptions.CreateGitHubFlavoredMarkdownProfile()).Replace("\r\n", "\n").Trim();
+
+        Assert.Equal("HTML text", markdown);
+        Assert.DoesNotContain("*[HTML]:", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void MarkdownWriteOptions_CreateProfile_Maps_Named_Output_Profiles() {
         Assert.Empty(MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.OfficeIMO).BlockRenderExtensions);
         Assert.Equal(MarkdownFrontMatterRenderingMode.Omit, MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).FrontMatterRendering);
+        Assert.Equal(MarkdownAbbreviationDefinitionRenderingMode.Omit, MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).AbbreviationDefinitionRendering);
         Assert.Contains(
             MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.CommonMark).BlockRenderExtensions,
             extension => string.Equals(extension.Name, MarkdownBlockRenderBuiltInExtensions.CommonMarkTableMarkdownName, StringComparison.Ordinal));
@@ -477,6 +582,16 @@ Text
         Assert.Contains(
             MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.GitHubFlavoredMarkdown).InlineRenderExtensions,
             extension => string.Equals(extension.Name, MarkdownInlineRenderBuiltInExtensions.GitHubAttributedInlineMarkdownName, StringComparison.Ordinal));
+        Assert.Equal(MarkdownAbbreviationDefinitionRenderingMode.Omit, MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.GitHubFlavoredMarkdown).AbbreviationDefinitionRendering);
+        Assert.Contains(
+            MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.GitHubFlavoredMarkdown).BlockRenderExtensions,
+            extension => string.Equals(extension.Name, MarkdownBlockRenderBuiltInExtensions.GitHubCustomContainerMarkdownName, StringComparison.Ordinal));
+        Assert.Contains(
+            MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.GitHubFlavoredMarkdown).BlockRenderExtensions,
+            extension => string.Equals(extension.Name, MarkdownBlockRenderBuiltInExtensions.GitHubParagraphLineStartMarkdownName, StringComparison.Ordinal));
+        Assert.Contains(
+            MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.GitHubFlavoredMarkdown).BlockRenderExtensions,
+            extension => string.Equals(extension.Name, MarkdownBlockRenderBuiltInExtensions.GitHubAttributedBlockMarkdownName, StringComparison.Ordinal));
         Assert.Contains(
             MarkdownWriteOptions.CreateProfile(MarkdownOutputProfile.Portable).BlockRenderExtensions,
             extension => string.Equals(extension.Name, MarkdownBlockRenderBuiltInExtensions.PortableCalloutMarkdownName, StringComparison.Ordinal));

--- a/OfficeIMO.Markdown/Blocks/ListItem.cs
+++ b/OfficeIMO.Markdown/Blocks/ListItem.cs
@@ -103,10 +103,12 @@ public sealed class ListItem : MarkdownObject, IChildMarkdownBlockContainer, ISy
 
     internal string RenderHtml() => RenderHtml(forceLoose: false);
 
-    internal string RenderHtml(bool forceLoose) {
+    internal string RenderHtml(bool forceLoose, bool renderGenericAttributeConsumedWhitespace = true) {
         bool renderLoose = forceLoose || ForceLoose;
         string checkbox = BuildCheckboxHtml();
-        string attributeWhitespace = RenderGenericAttributeConsumedWhitespace();
+        string attributeWhitespace = renderGenericAttributeConsumedWhitespace
+            ? RenderGenericAttributeConsumedWhitespace()
+            : string.Empty;
         if (!renderLoose && AdditionalParagraphs.Count == 0 && Children.Count == 0) {
             return checkbox + Content.RenderHtml() + attributeWhitespace;
         }

--- a/OfficeIMO.Markdown/Blocks/MarkdownListRendering.cs
+++ b/OfficeIMO.Markdown/Blocks/MarkdownListRendering.cs
@@ -35,7 +35,8 @@ internal static class MarkdownListRendering {
         string listTag,
         IReadOnlyList<ListItem> items,
         MarkdownAttributeSet? attributes,
-        Func<int, string> topLevelAttributesFactory) {
+        Func<int, string> topLevelAttributesFactory,
+        bool renderItemAttributes = false) {
         var sb = new System.Text.StringBuilder();
 
         bool ContainsTasksInScope(int startIndex, int level) {
@@ -102,9 +103,18 @@ internal static class MarkdownListRendering {
 
             int scopeStart = scopeStartByLevel[level];
             bool renderLoose = IsLooseInScope(scopeStart, level);
-            bool useGitHubTaskListHtml = HtmlRenderContext.Options?.GitHubTaskListHtml == true;
-            sb.Append(item.IsTask && !useGitHubTaskListHtml ? "<li class=\"task-list-item\">" : "<li>")
-                .Append(item.RenderHtml(renderLoose));
+            var options = HtmlRenderContext.Options;
+            bool useGitHubTaskListHtml = options?.GitHubTaskListHtml == true;
+            var itemClasses = item.IsTask && !useGitHubTaskListHtml
+                ? new[] { "task-list-item" }
+                : null;
+            var itemAttributes = renderItemAttributes
+                ? item.Attributes
+                : null;
+            sb.Append("<li")
+                .Append(MarkdownHtmlAttributes.Render(itemAttributes, options, additionalClasses: itemClasses))
+                .Append('>')
+                .Append(item.RenderHtml(renderLoose, renderGenericAttributeConsumedWhitespace: !renderItemAttributes));
             liOpen = true;
         }
 

--- a/OfficeIMO.Markdown/Blocks/MarkdownListRendering.cs
+++ b/OfficeIMO.Markdown/Blocks/MarkdownListRendering.cs
@@ -38,6 +38,7 @@ internal static class MarkdownListRendering {
         Func<int, string> topLevelAttributesFactory,
         bool renderItemAttributes = false) {
         var sb = new System.Text.StringBuilder();
+        renderItemAttributes = renderItemAttributes || HtmlRenderContext.RenderListItemAttributes;
 
         bool ContainsTasksInScope(int startIndex, int level) {
             for (int i = startIndex; i < items.Count; i++) {

--- a/OfficeIMO.Markdown/Blocks/OrderedListBlock.cs
+++ b/OfficeIMO.Markdown/Blocks/OrderedListBlock.cs
@@ -48,11 +48,15 @@ public sealed class OrderedListBlock : MarkdownBlock, IMarkdownListBlock, ISynta
 
     /// <inheritdoc />
     string IMarkdownBlock.RenderHtml() =>
+        RenderHtml(renderItemAttributes: false);
+
+    internal string RenderHtml(bool renderItemAttributes) =>
         MarkdownListRendering.RenderHtml(
             "ol",
             Items,
             Attributes,
-            _ => RenderOrderedListAttributes());
+            _ => RenderOrderedListAttributes(),
+            renderItemAttributes);
 
     IReadOnlyList<ListItem> IMarkdownListBlock.ListItems => ListItems;
     MarkdownSyntaxKind IMarkdownListBlock.ListSyntaxKind => MarkdownSyntaxKind.OrderedList;

--- a/OfficeIMO.Markdown/Blocks/UnorderedListBlock.cs
+++ b/OfficeIMO.Markdown/Blocks/UnorderedListBlock.cs
@@ -21,7 +21,10 @@ public sealed class UnorderedListBlock : MarkdownBlock, IMarkdownListBlock, ISyn
             });
     /// <inheritdoc />
     string IMarkdownBlock.RenderHtml() =>
-        MarkdownListRendering.RenderHtml("ul", Items, Attributes, _ => string.Empty);
+        RenderHtml(renderItemAttributes: false);
+
+    internal string RenderHtml(bool renderItemAttributes) =>
+        MarkdownListRendering.RenderHtml("ul", Items, Attributes, _ => string.Empty, renderItemAttributes);
 
     IReadOnlyList<ListItem> IMarkdownListBlock.ListItems => ListItems;
     MarkdownSyntaxKind IMarkdownListBlock.ListSyntaxKind => MarkdownSyntaxKind.UnorderedList;

--- a/OfficeIMO.Markdown/Core/MarkdownDoc.cs
+++ b/OfficeIMO.Markdown/Core/MarkdownDoc.cs
@@ -546,8 +546,9 @@ public class MarkdownDoc : MarkdownObject {
         var context = new MarkdownWriteContext(this, blocks, options, headingCatalog);
         using var _ctx = MarkdownRenderContext.Push(context);
         StringBuilder sb = new StringBuilder();
-        if (_frontMatter != null) {
-            sb.AppendLine(_frontMatter.RenderFrontMatter());
+        var renderedFrontMatter = RenderFrontMatter(_frontMatter, options);
+        if (!string.IsNullOrEmpty(renderedFrontMatter)) {
+            sb.AppendLine(renderedFrontMatter);
             sb.AppendLine();
         }
 
@@ -748,6 +749,18 @@ public class MarkdownDoc : MarkdownObject {
 
     private static string RenderMarkdownBlock(IMarkdownBlock block, MarkdownWriteContext context) {
         return MarkdownBlockRenderDispatcher.RenderMarkdown(block, context);
+    }
+
+    private static string? RenderFrontMatter(IFrontMatterMarkdownBlock? frontMatter, MarkdownWriteOptions options) {
+        if (frontMatter == null) {
+            return null;
+        }
+
+        return options.FrontMatterRendering switch {
+            MarkdownFrontMatterRenderingMode.Preserve => frontMatter.RenderFrontMatter(),
+            MarkdownFrontMatterRenderingMode.Omit => null,
+            _ => throw new ArgumentOutOfRangeException(nameof(options.FrontMatterRendering), options.FrontMatterRendering, "Unknown front matter rendering mode.")
+        };
     }
 
     private static bool AppendParseOwnedAbbreviationDefinitions(StringBuilder sb, MarkdownParseResult? parseResult) {

--- a/OfficeIMO.Markdown/Core/MarkdownDoc.cs
+++ b/OfficeIMO.Markdown/Core/MarkdownDoc.cs
@@ -552,7 +552,7 @@ public class MarkdownDoc : MarkdownObject {
             sb.AppendLine();
         }
 
-        if (AppendParseOwnedAbbreviationDefinitions(sb, _parseResult) && blocks.Count > 0) {
+        if (AppendParseOwnedAbbreviationDefinitions(sb, _parseResult, options) && blocks.Count > 0) {
             sb.AppendLine();
         }
 
@@ -763,7 +763,15 @@ public class MarkdownDoc : MarkdownObject {
         };
     }
 
-    private static bool AppendParseOwnedAbbreviationDefinitions(StringBuilder sb, MarkdownParseResult? parseResult) {
+    private static bool AppendParseOwnedAbbreviationDefinitions(StringBuilder sb, MarkdownParseResult? parseResult, MarkdownWriteOptions options) {
+        if (options.AbbreviationDefinitionRendering == MarkdownAbbreviationDefinitionRenderingMode.Omit) {
+            return false;
+        }
+
+        if (options.AbbreviationDefinitionRendering != MarkdownAbbreviationDefinitionRenderingMode.Preserve) {
+            throw new ArgumentOutOfRangeException(nameof(options.AbbreviationDefinitionRendering), options.AbbreviationDefinitionRendering, "Unknown abbreviation definition rendering mode.");
+        }
+
         if (parseResult == null || parseResult.AbbreviationDefinitions.Count == 0) {
             return false;
         }

--- a/OfficeIMO.Markdown/Options/MarkdownAbbreviationDefinitionRenderingMode.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownAbbreviationDefinitionRenderingMode.cs
@@ -1,0 +1,11 @@
+namespace OfficeIMO.Markdown;
+
+/// <summary>
+/// Controls how parse-owned abbreviation definitions are emitted by <see cref="MarkdownDoc.ToMarkdown(MarkdownWriteOptions?)"/>.
+/// </summary>
+public enum MarkdownAbbreviationDefinitionRenderingMode {
+    /// <summary>Preserve abbreviation definition syntax in the generated Markdown.</summary>
+    Preserve,
+    /// <summary>Do not emit parse-owned abbreviation definitions.</summary>
+    Omit
+}

--- a/OfficeIMO.Markdown/Options/MarkdownBlockRenderBuiltInExtensions.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownBlockRenderBuiltInExtensions.cs
@@ -25,6 +25,12 @@ public static class MarkdownBlockRenderBuiltInExtensions {
     public const string CommonMarkFootnoteDefinitionMarkdownName = "CommonMark.FootnoteDefinition.Markdown";
     /// <summary>Stable registration name for the CommonMark details markdown fallback.</summary>
     public const string CommonMarkDetailsMarkdownName = "CommonMark.Details.Markdown";
+    /// <summary>Stable registration name for the CommonMark custom-container markdown fallback.</summary>
+    public const string CommonMarkCustomContainerMarkdownName = "CommonMark.CustomContainer.Markdown";
+    /// <summary>Stable registration name for the CommonMark paragraph line-start markdown fallback.</summary>
+    public const string CommonMarkParagraphLineStartMarkdownName = "CommonMark.ParagraphLineStart.Markdown";
+    /// <summary>Stable registration name for the CommonMark attributed block markdown fallback.</summary>
+    public const string CommonMarkAttributedBlockMarkdownName = "CommonMark.AttributedBlock.Markdown";
 
     /// <summary>Adds a portable markdown fallback for OfficeIMO callout blocks.</summary>
     public static void AddPortableCalloutMarkdownFallback(MarkdownWriteOptions options) {
@@ -121,6 +127,51 @@ public static class MarkdownBlockRenderBuiltInExtensions {
             }
 
             return ((IMarkdownBlock)details).RenderHtml();
+        });
+    }
+
+    /// <summary>Adds a CommonMark-compatible markdown fallback for custom containers by emitting raw HTML.</summary>
+    public static void AddCommonMarkCustomContainerMarkdownFallback(MarkdownWriteOptions options) {
+        if (options == null) {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        AddIfMissing(options.BlockRenderExtensions, CommonMarkCustomContainerMarkdownName, typeof(CustomContainerBlock), static (block, _) => {
+            if (block is not CustomContainerBlock container) {
+                return null;
+            }
+
+            return ((IMarkdownBlock)container).RenderHtml();
+        });
+    }
+
+    /// <summary>Adds CommonMark-compatible paragraph text escaping for line-start block markers.</summary>
+    public static void AddCommonMarkParagraphLineStartMarkdownFallback(MarkdownWriteOptions options) {
+        if (options == null) {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        AddIfMissing(options.BlockRenderExtensions, CommonMarkParagraphLineStartMarkdownName, typeof(ParagraphBlock), static (block, _) => {
+            if (block is not ParagraphBlock paragraph || !paragraph.Attributes.IsEmpty) {
+                return null;
+            }
+
+            return paragraph.Inlines.RenderMarkdownWithTextEscaper(MarkdownEscaper.EscapeTextAndLineStarts);
+        });
+    }
+
+    /// <summary>Adds a CommonMark-compatible markdown fallback for attributed blocks by emitting raw HTML.</summary>
+    public static void AddCommonMarkAttributedBlockMarkdownFallback(MarkdownWriteOptions options) {
+        if (options == null) {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        AddIfMissing(options.BlockRenderExtensions, CommonMarkAttributedBlockMarkdownName, typeof(MarkdownBlock), static (block, _) => {
+            if (block is not MarkdownObject markdownObject || markdownObject.Attributes.IsEmpty) {
+                return null;
+            }
+
+            return block.RenderHtml();
         });
     }
 

--- a/OfficeIMO.Markdown/Options/MarkdownBlockRenderBuiltInExtensions.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownBlockRenderBuiltInExtensions.cs
@@ -23,6 +23,8 @@ public static class MarkdownBlockRenderBuiltInExtensions {
     public const string CommonMarkDefinitionListMarkdownName = "CommonMark.DefinitionList.Markdown";
     /// <summary>Stable registration name for the CommonMark footnote-definition markdown fallback.</summary>
     public const string CommonMarkFootnoteDefinitionMarkdownName = "CommonMark.FootnoteDefinition.Markdown";
+    /// <summary>Stable registration name for the CommonMark details markdown fallback.</summary>
+    public const string CommonMarkDetailsMarkdownName = "CommonMark.Details.Markdown";
 
     /// <summary>Adds a portable markdown fallback for OfficeIMO callout blocks.</summary>
     public static void AddPortableCalloutMarkdownFallback(MarkdownWriteOptions options) {
@@ -104,6 +106,21 @@ public static class MarkdownBlockRenderBuiltInExtensions {
             }
 
             return ((IMarkdownBlock)footnote).RenderHtml();
+        });
+    }
+
+    /// <summary>Adds a CommonMark-compatible markdown fallback for details blocks by emitting raw HTML.</summary>
+    public static void AddCommonMarkDetailsMarkdownFallback(MarkdownWriteOptions options) {
+        if (options == null) {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        AddIfMissing(options.BlockRenderExtensions, CommonMarkDetailsMarkdownName, typeof(DetailsBlock), static (block, _) => {
+            if (block is not DetailsBlock details) {
+                return null;
+            }
+
+            return ((IMarkdownBlock)details).RenderHtml();
         });
     }
 

--- a/OfficeIMO.Markdown/Options/MarkdownBlockRenderBuiltInExtensions.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownBlockRenderBuiltInExtensions.cs
@@ -167,11 +167,15 @@ public static class MarkdownBlockRenderBuiltInExtensions {
         }
 
         AddIfMissing(options.BlockRenderExtensions, CommonMarkAttributedBlockMarkdownName, typeof(MarkdownBlock), static (block, _) => {
-            if (block is not MarkdownObject markdownObject || markdownObject.Attributes.IsEmpty) {
-                return null;
+            if (block is IMarkdownListBlock listBlock && ContainsAttributedListItem(listBlock.ListItems)) {
+                return RenderListHtmlWithItemAttributes(listBlock);
             }
 
-            return block.RenderHtml();
+            if (block is MarkdownObject markdownObject && !markdownObject.Attributes.IsEmpty) {
+                return block.RenderHtml();
+            }
+
+            return null;
         });
     }
 
@@ -325,6 +329,41 @@ public static class MarkdownBlockRenderBuiltInExtensions {
         }
 
         return false;
+    }
+
+    private static bool ContainsAttributedListItem(IReadOnlyList<ListItem> items) {
+        if (items == null || items.Count == 0) {
+            return false;
+        }
+
+        for (int i = 0; i < items.Count; i++) {
+            var item = items[i];
+            if (item == null) {
+                continue;
+            }
+
+            if (!item.Attributes.IsEmpty) {
+                return true;
+            }
+
+            for (int childIndex = 0; childIndex < item.Children.Count; childIndex++) {
+                if (item.Children[childIndex] is IMarkdownListBlock childList
+                    && ContainsAttributedListItem(childList.ListItems)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static string RenderListHtmlWithItemAttributes(IMarkdownListBlock listBlock) {
+        return listBlock switch {
+            UnorderedListBlock unordered => unordered.RenderHtml(renderItemAttributes: true),
+            OrderedListBlock ordered => ordered.RenderHtml(renderItemAttributes: true),
+            IMarkdownBlock block => block.RenderHtml(),
+            _ => string.Empty
+        };
     }
 
     private static string RenderPortableCalloutHtml(CalloutBlock callout, HtmlOptions? options) {

--- a/OfficeIMO.Markdown/Options/MarkdownBlockRenderBuiltInExtensions.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownBlockRenderBuiltInExtensions.cs
@@ -17,6 +17,8 @@ public static class MarkdownBlockRenderBuiltInExtensions {
     public const string PortableFootnoteSectionHtmlName = "Portable.Footnotes.Html";
     /// <summary>Stable registration name for the CommonMark table markdown fallback.</summary>
     public const string CommonMarkTableMarkdownName = "CommonMark.Table.Markdown";
+    /// <summary>Stable registration name for the CommonMark task-list markdown fallback.</summary>
+    public const string CommonMarkTaskListMarkdownName = "CommonMark.TaskList.Markdown";
 
     /// <summary>Adds a portable markdown fallback for OfficeIMO callout blocks.</summary>
     public static void AddPortableCalloutMarkdownFallback(MarkdownWriteOptions options) {
@@ -45,6 +47,29 @@ public static class MarkdownBlockRenderBuiltInExtensions {
             }
 
             return ((IMarkdownBlock)table).RenderHtml();
+        });
+    }
+
+    /// <summary>Adds a CommonMark-compatible markdown fallback for task lists by emitting raw HTML lists.</summary>
+    public static void AddCommonMarkTaskListMarkdownFallback(MarkdownWriteOptions options) {
+        if (options == null) {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        AddIfMissing(options.BlockRenderExtensions, CommonMarkTaskListMarkdownName, typeof(UnorderedListBlock), static (block, _) => {
+            if (block is not UnorderedListBlock list || !ContainsTaskListItem(list.Items)) {
+                return null;
+            }
+
+            return ((IMarkdownBlock)list).RenderHtml();
+        });
+
+        AddIfMissing(options.BlockRenderExtensions, CommonMarkTaskListMarkdownName + ".Ordered", typeof(OrderedListBlock), static (block, _) => {
+            if (block is not OrderedListBlock list || !ContainsTaskListItem(list.Items)) {
+                return null;
+            }
+
+            return ((IMarkdownBlock)list).RenderHtml();
         });
     }
 
@@ -172,6 +197,32 @@ public static class MarkdownBlockRenderBuiltInExtensions {
         }
 
         return PrefixQuoteLines(string.Join("\n\n", parts));
+    }
+
+    private static bool ContainsTaskListItem(IReadOnlyList<ListItem> items) {
+        if (items == null || items.Count == 0) {
+            return false;
+        }
+
+        for (int i = 0; i < items.Count; i++) {
+            var item = items[i];
+            if (item == null) {
+                continue;
+            }
+
+            if (item.IsTask) {
+                return true;
+            }
+
+            for (int childIndex = 0; childIndex < item.Children.Count; childIndex++) {
+                if (item.Children[childIndex] is IMarkdownListBlock childList
+                    && ContainsTaskListItem(childList.ListItems)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     private static string RenderPortableCalloutHtml(CalloutBlock callout, HtmlOptions? options) {

--- a/OfficeIMO.Markdown/Options/MarkdownBlockRenderBuiltInExtensions.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownBlockRenderBuiltInExtensions.cs
@@ -19,6 +19,10 @@ public static class MarkdownBlockRenderBuiltInExtensions {
     public const string CommonMarkTableMarkdownName = "CommonMark.Table.Markdown";
     /// <summary>Stable registration name for the CommonMark task-list markdown fallback.</summary>
     public const string CommonMarkTaskListMarkdownName = "CommonMark.TaskList.Markdown";
+    /// <summary>Stable registration name for the CommonMark definition-list markdown fallback.</summary>
+    public const string CommonMarkDefinitionListMarkdownName = "CommonMark.DefinitionList.Markdown";
+    /// <summary>Stable registration name for the CommonMark footnote-definition markdown fallback.</summary>
+    public const string CommonMarkFootnoteDefinitionMarkdownName = "CommonMark.FootnoteDefinition.Markdown";
 
     /// <summary>Adds a portable markdown fallback for OfficeIMO callout blocks.</summary>
     public static void AddPortableCalloutMarkdownFallback(MarkdownWriteOptions options) {
@@ -70,6 +74,36 @@ public static class MarkdownBlockRenderBuiltInExtensions {
             }
 
             return ((IMarkdownBlock)list).RenderHtml();
+        });
+    }
+
+    /// <summary>Adds a CommonMark-compatible markdown fallback for definition lists by emitting raw HTML.</summary>
+    public static void AddCommonMarkDefinitionListMarkdownFallback(MarkdownWriteOptions options) {
+        if (options == null) {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        AddIfMissing(options.BlockRenderExtensions, CommonMarkDefinitionListMarkdownName, typeof(DefinitionListBlock), static (block, _) => {
+            if (block is not DefinitionListBlock definitionList) {
+                return null;
+            }
+
+            return ((IMarkdownBlock)definitionList).RenderHtml();
+        });
+    }
+
+    /// <summary>Adds a CommonMark-compatible markdown fallback for footnote definitions by emitting raw HTML.</summary>
+    public static void AddCommonMarkFootnoteDefinitionMarkdownFallback(MarkdownWriteOptions options) {
+        if (options == null) {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        AddIfMissing(options.BlockRenderExtensions, CommonMarkFootnoteDefinitionMarkdownName, typeof(FootnoteDefinitionBlock), static (block, _) => {
+            if (block is not FootnoteDefinitionBlock footnote) {
+                return null;
+            }
+
+            return ((IMarkdownBlock)footnote).RenderHtml();
         });
     }
 

--- a/OfficeIMO.Markdown/Options/MarkdownBlockRenderBuiltInExtensions.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownBlockRenderBuiltInExtensions.cs
@@ -31,6 +31,14 @@ public static class MarkdownBlockRenderBuiltInExtensions {
     public const string CommonMarkParagraphLineStartMarkdownName = "CommonMark.ParagraphLineStart.Markdown";
     /// <summary>Stable registration name for the CommonMark attributed block markdown fallback.</summary>
     public const string CommonMarkAttributedBlockMarkdownName = "CommonMark.AttributedBlock.Markdown";
+    /// <summary>Stable registration name for the GitHub definition-list markdown fallback.</summary>
+    public const string GitHubDefinitionListMarkdownName = "GitHub.DefinitionList.Markdown";
+    /// <summary>Stable registration name for the GitHub custom-container markdown fallback.</summary>
+    public const string GitHubCustomContainerMarkdownName = "GitHub.CustomContainer.Markdown";
+    /// <summary>Stable registration name for the GitHub paragraph line-start markdown fallback.</summary>
+    public const string GitHubParagraphLineStartMarkdownName = "GitHub.ParagraphLineStart.Markdown";
+    /// <summary>Stable registration name for the GitHub attributed block markdown fallback.</summary>
+    public const string GitHubAttributedBlockMarkdownName = "GitHub.AttributedBlock.Markdown";
 
     /// <summary>Adds a portable markdown fallback for OfficeIMO callout blocks.</summary>
     public static void AddPortableCalloutMarkdownFallback(MarkdownWriteOptions options) {
@@ -91,13 +99,7 @@ public static class MarkdownBlockRenderBuiltInExtensions {
             throw new ArgumentNullException(nameof(options));
         }
 
-        AddIfMissing(options.BlockRenderExtensions, CommonMarkDefinitionListMarkdownName, typeof(DefinitionListBlock), static (block, _) => {
-            if (block is not DefinitionListBlock definitionList) {
-                return null;
-            }
-
-            return ((IMarkdownBlock)definitionList).RenderHtml();
-        });
+        AddDefinitionListHtmlMarkdownFallback(options, CommonMarkDefinitionListMarkdownName);
     }
 
     /// <summary>Adds a CommonMark-compatible markdown fallback for footnote definitions by emitting raw HTML.</summary>
@@ -136,13 +138,7 @@ public static class MarkdownBlockRenderBuiltInExtensions {
             throw new ArgumentNullException(nameof(options));
         }
 
-        AddIfMissing(options.BlockRenderExtensions, CommonMarkCustomContainerMarkdownName, typeof(CustomContainerBlock), static (block, _) => {
-            if (block is not CustomContainerBlock container) {
-                return null;
-            }
-
-            return ((IMarkdownBlock)container).RenderHtml();
-        });
+        AddCustomContainerHtmlMarkdownFallback(options, CommonMarkCustomContainerMarkdownName);
     }
 
     /// <summary>Adds CommonMark-compatible paragraph text escaping for line-start block markers.</summary>
@@ -151,13 +147,7 @@ public static class MarkdownBlockRenderBuiltInExtensions {
             throw new ArgumentNullException(nameof(options));
         }
 
-        AddIfMissing(options.BlockRenderExtensions, CommonMarkParagraphLineStartMarkdownName, typeof(ParagraphBlock), static (block, _) => {
-            if (block is not ParagraphBlock paragraph || !paragraph.Attributes.IsEmpty) {
-                return null;
-            }
-
-            return paragraph.Inlines.RenderMarkdownWithTextEscaper(MarkdownEscaper.EscapeTextAndLineStarts);
-        });
+        AddParagraphLineStartMarkdownFallback(options, CommonMarkParagraphLineStartMarkdownName);
     }
 
     /// <summary>Adds a CommonMark-compatible markdown fallback for attributed blocks by emitting raw HTML.</summary>
@@ -166,17 +156,43 @@ public static class MarkdownBlockRenderBuiltInExtensions {
             throw new ArgumentNullException(nameof(options));
         }
 
-        AddIfMissing(options.BlockRenderExtensions, CommonMarkAttributedBlockMarkdownName, typeof(MarkdownBlock), static (block, _) => {
-            if (block is IMarkdownListBlock listBlock && ContainsAttributedListItem(listBlock.ListItems)) {
-                return RenderListHtmlWithItemAttributes(listBlock);
-            }
+        AddAttributedBlockHtmlMarkdownFallback(options, CommonMarkAttributedBlockMarkdownName);
+    }
 
-            if (block is MarkdownObject markdownObject && !markdownObject.Attributes.IsEmpty) {
-                return block.RenderHtml();
-            }
+    /// <summary>Adds a GitHub-compatible markdown fallback for definition lists by emitting raw HTML.</summary>
+    public static void AddGitHubDefinitionListMarkdownFallback(MarkdownWriteOptions options) {
+        if (options == null) {
+            throw new ArgumentNullException(nameof(options));
+        }
 
-            return null;
-        });
+        AddDefinitionListHtmlMarkdownFallback(options, GitHubDefinitionListMarkdownName);
+    }
+
+    /// <summary>Adds a GitHub-compatible markdown fallback for custom containers by emitting raw HTML.</summary>
+    public static void AddGitHubCustomContainerMarkdownFallback(MarkdownWriteOptions options) {
+        if (options == null) {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        AddCustomContainerHtmlMarkdownFallback(options, GitHubCustomContainerMarkdownName);
+    }
+
+    /// <summary>Adds GitHub-compatible paragraph text escaping for line-start block markers.</summary>
+    public static void AddGitHubParagraphLineStartMarkdownFallback(MarkdownWriteOptions options) {
+        if (options == null) {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        AddParagraphLineStartMarkdownFallback(options, GitHubParagraphLineStartMarkdownName);
+    }
+
+    /// <summary>Adds a GitHub-compatible markdown fallback for attributed blocks by emitting raw HTML.</summary>
+    public static void AddGitHubAttributedBlockMarkdownFallback(MarkdownWriteOptions options) {
+        if (options == null) {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        AddAttributedBlockHtmlMarkdownFallback(options, GitHubAttributedBlockMarkdownName);
     }
 
     /// <summary>Adds a portable HTML fallback for OfficeIMO callout blocks.</summary>
@@ -280,6 +296,50 @@ public static class MarkdownBlockRenderBuiltInExtensions {
         }
     }
 
+    private static void AddDefinitionListHtmlMarkdownFallback(MarkdownWriteOptions options, string name) {
+        AddIfMissing(options.BlockRenderExtensions, name, typeof(DefinitionListBlock), static (block, _) => {
+            if (block is not DefinitionListBlock definitionList) {
+                return null;
+            }
+
+            return ((IMarkdownBlock)definitionList).RenderHtml();
+        });
+    }
+
+    private static void AddCustomContainerHtmlMarkdownFallback(MarkdownWriteOptions options, string name) {
+        AddIfMissing(options.BlockRenderExtensions, name, typeof(CustomContainerBlock), static (block, _) => {
+            if (block is not CustomContainerBlock container) {
+                return null;
+            }
+
+            return ((IMarkdownBlock)container).RenderHtml();
+        });
+    }
+
+    private static void AddParagraphLineStartMarkdownFallback(MarkdownWriteOptions options, string name) {
+        AddIfMissing(options.BlockRenderExtensions, name, typeof(ParagraphBlock), static (block, _) => {
+            if (block is not ParagraphBlock paragraph || !paragraph.Attributes.IsEmpty) {
+                return null;
+            }
+
+            return paragraph.Inlines.RenderMarkdownWithTextEscaper(MarkdownEscaper.EscapeTextAndLineStarts);
+        });
+    }
+
+    private static void AddAttributedBlockHtmlMarkdownFallback(MarkdownWriteOptions options, string name) {
+        AddIfMissing(options.BlockRenderExtensions, name, typeof(MarkdownBlock), static (block, _) => {
+            if (block is IMarkdownListBlock listBlock && ContainsAttributedListItem(listBlock.ListItems)) {
+                return RenderListHtmlWithItemAttributes(listBlock);
+            }
+
+            if (block is MarkdownObject markdownObject && !markdownObject.Attributes.IsEmpty) {
+                return block.RenderHtml();
+            }
+
+            return null;
+        });
+    }
+
     private static string RenderPortableCalloutMarkdown(CalloutBlock callout) {
         var titleMarkdown = callout.TitleInlines.RenderMarkdown();
         var visibleTitle = string.IsNullOrWhiteSpace(titleMarkdown)
@@ -358,6 +418,7 @@ public static class MarkdownBlockRenderBuiltInExtensions {
     }
 
     private static string RenderListHtmlWithItemAttributes(IMarkdownListBlock listBlock) {
+        using var _ = HtmlRenderContext.PushRenderListItemAttributes();
         return listBlock switch {
             UnorderedListBlock unordered => unordered.RenderHtml(renderItemAttributes: true),
             OrderedListBlock ordered => ordered.RenderHtml(renderItemAttributes: true),

--- a/OfficeIMO.Markdown/Options/MarkdownBlockRenderBuiltInExtensions.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownBlockRenderBuiltInExtensions.cs
@@ -15,6 +15,8 @@ public static class MarkdownBlockRenderBuiltInExtensions {
     public const string PortableTocHtmlName = "Portable.Toc.Html";
     /// <summary>Stable registration name for the portable footnote section HTML fallback.</summary>
     public const string PortableFootnoteSectionHtmlName = "Portable.Footnotes.Html";
+    /// <summary>Stable registration name for the CommonMark table markdown fallback.</summary>
+    public const string CommonMarkTableMarkdownName = "CommonMark.Table.Markdown";
 
     /// <summary>Adds a portable markdown fallback for OfficeIMO callout blocks.</summary>
     public static void AddPortableCalloutMarkdownFallback(MarkdownWriteOptions options) {
@@ -28,6 +30,21 @@ public static class MarkdownBlockRenderBuiltInExtensions {
             }
 
             return RenderPortableCalloutMarkdown(callout);
+        });
+    }
+
+    /// <summary>Adds a CommonMark-compatible markdown fallback for tables by emitting raw HTML tables.</summary>
+    public static void AddCommonMarkTableMarkdownFallback(MarkdownWriteOptions options) {
+        if (options == null) {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        AddIfMissing(options.BlockRenderExtensions, CommonMarkTableMarkdownName, typeof(TableBlock), static (block, _) => {
+            if (block is not TableBlock table) {
+                return null;
+            }
+
+            return ((IMarkdownBlock)table).RenderHtml();
         });
     }
 

--- a/OfficeIMO.Markdown/Options/MarkdownFrontMatterRenderingMode.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownFrontMatterRenderingMode.cs
@@ -1,0 +1,12 @@
+namespace OfficeIMO.Markdown;
+
+/// <summary>
+/// Controls how document front matter is emitted during Markdown serialization.
+/// </summary>
+public enum MarkdownFrontMatterRenderingMode {
+    /// <summary>Preserve YAML front matter fences and entries.</summary>
+    Preserve,
+
+    /// <summary>Omit front matter from the serialized Markdown document.</summary>
+    Omit
+}

--- a/OfficeIMO.Markdown/Options/MarkdownInlineRenderBuiltInExtensions.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownInlineRenderBuiltInExtensions.cs
@@ -71,6 +71,6 @@ public static class MarkdownInlineRenderBuiltInExtensions {
 
         return html == null
             ? null
-            : MarkdownInlineAttributeRenderer.RenderMarkdown(inline, html);
+            : MarkdownInlineAttributeRenderer.RenderHtml(inline, html, null);
     }
 }

--- a/OfficeIMO.Markdown/Options/MarkdownInlineRenderBuiltInExtensions.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownInlineRenderBuiltInExtensions.cs
@@ -1,0 +1,54 @@
+namespace OfficeIMO.Markdown;
+
+/// <summary>
+/// Built-in inline render extension registrations for portable or host-specific output shaping.
+/// </summary>
+public static class MarkdownInlineRenderBuiltInExtensions {
+    /// <summary>Stable registration name for the CommonMark strikethrough markdown fallback.</summary>
+    public const string CommonMarkStrikethroughMarkdownName = "CommonMark.Strikethrough.Markdown";
+
+    /// <summary>Stable registration name for the CommonMark highlight markdown fallback.</summary>
+    public const string CommonMarkHighlightMarkdownName = "CommonMark.Highlight.Markdown";
+
+    /// <summary>Adds CommonMark-compatible markdown fallbacks for GFM-only inline constructs.</summary>
+    public static void AddCommonMarkGfmInlineMarkdownFallbacks(MarkdownWriteOptions options) {
+        if (options == null) {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        AddIfMissing(options.InlineRenderExtensions, CommonMarkStrikethroughMarkdownName, typeof(StrikethroughInline), RenderHtmlFallback);
+        AddIfMissing(options.InlineRenderExtensions, CommonMarkStrikethroughMarkdownName + ".Sequence", typeof(StrikethroughSequenceInline), RenderHtmlFallback);
+        AddIfMissing(options.InlineRenderExtensions, CommonMarkHighlightMarkdownName, typeof(HighlightInline), RenderHtmlFallback);
+        AddIfMissing(options.InlineRenderExtensions, CommonMarkHighlightMarkdownName + ".Sequence", typeof(HighlightSequenceInline), RenderHtmlFallback);
+    }
+
+    private static void AddIfMissing(
+        List<MarkdownInlineMarkdownRenderExtension> extensions,
+        string name,
+        Type inlineType,
+        MarkdownInlineMarkdownRenderer renderer) {
+        if (extensions == null) {
+            throw new ArgumentNullException(nameof(extensions));
+        }
+
+        if (extensions.Any(extension => string.Equals(extension.Name, name, StringComparison.OrdinalIgnoreCase))) {
+            return;
+        }
+
+        extensions.Add(new MarkdownInlineMarkdownRenderExtension(name, inlineType, renderer));
+    }
+
+    private static string? RenderHtmlFallback(IMarkdownInline inline, MarkdownWriteOptions _) {
+        string? html = inline switch {
+            StrikethroughInline strikethrough => strikethrough.RenderHtml(),
+            StrikethroughSequenceInline strikethrough => strikethrough.RenderHtml(),
+            HighlightInline highlight => highlight.RenderHtml(),
+            HighlightSequenceInline highlight => highlight.RenderHtml(),
+            _ => null
+        };
+
+        return html == null
+            ? null
+            : MarkdownInlineAttributeRenderer.RenderMarkdown(inline, html);
+    }
+}

--- a/OfficeIMO.Markdown/Options/MarkdownInlineRenderBuiltInExtensions.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownInlineRenderBuiltInExtensions.cs
@@ -17,6 +17,18 @@ public static class MarkdownInlineRenderBuiltInExtensions {
     public const string CommonMarkSuperscriptMarkdownName = "CommonMark.Superscript.Markdown";
     /// <summary>Stable registration name for the CommonMark subscript markdown fallback.</summary>
     public const string CommonMarkSubscriptMarkdownName = "CommonMark.Subscript.Markdown";
+    /// <summary>Stable registration name for the CommonMark attributed inline markdown fallback.</summary>
+    public const string CommonMarkAttributedInlineMarkdownName = "CommonMark.AttributedInline.Markdown";
+    /// <summary>Stable registration name for the GitHub highlight markdown fallback.</summary>
+    public const string GitHubHighlightMarkdownName = "GitHub.Highlight.Markdown";
+    /// <summary>Stable registration name for the GitHub inserted markdown fallback.</summary>
+    public const string GitHubInsertedMarkdownName = "GitHub.Inserted.Markdown";
+    /// <summary>Stable registration name for the GitHub superscript markdown fallback.</summary>
+    public const string GitHubSuperscriptMarkdownName = "GitHub.Superscript.Markdown";
+    /// <summary>Stable registration name for the GitHub subscript markdown fallback.</summary>
+    public const string GitHubSubscriptMarkdownName = "GitHub.Subscript.Markdown";
+    /// <summary>Stable registration name for the GitHub attributed inline markdown fallback.</summary>
+    public const string GitHubAttributedInlineMarkdownName = "GitHub.AttributedInline.Markdown";
 
     /// <summary>Adds CommonMark-compatible markdown fallbacks for GFM-only inline constructs.</summary>
     public static void AddCommonMarkGfmInlineMarkdownFallbacks(MarkdownWriteOptions options) {
@@ -35,6 +47,40 @@ public static class MarkdownInlineRenderBuiltInExtensions {
         AddIfMissing(options.InlineRenderExtensions, CommonMarkSuperscriptMarkdownName + ".Sequence", typeof(SuperscriptSequenceInline), RenderHtmlFallback);
         AddIfMissing(options.InlineRenderExtensions, CommonMarkSubscriptMarkdownName, typeof(SubscriptInline), RenderHtmlFallback);
         AddIfMissing(options.InlineRenderExtensions, CommonMarkSubscriptMarkdownName + ".Sequence", typeof(SubscriptSequenceInline), RenderHtmlFallback);
+    }
+
+    /// <summary>Adds a CommonMark-compatible markdown fallback for attributed inline nodes by emitting raw HTML.</summary>
+    public static void AddCommonMarkAttributedInlineMarkdownFallback(MarkdownWriteOptions options) {
+        if (options == null) {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        AddIfMissing(options.InlineRenderExtensions, CommonMarkAttributedInlineMarkdownName, typeof(MarkdownInline), RenderAttributedHtmlFallback);
+    }
+
+    /// <summary>Adds GitHub-compatible markdown fallbacks for OfficeIMO-only inline constructs.</summary>
+    public static void AddGitHubOfficeInlineMarkdownFallbacks(MarkdownWriteOptions options) {
+        if (options == null) {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        AddIfMissing(options.InlineRenderExtensions, GitHubHighlightMarkdownName, typeof(HighlightInline), RenderHtmlFallback);
+        AddIfMissing(options.InlineRenderExtensions, GitHubHighlightMarkdownName + ".Sequence", typeof(HighlightSequenceInline), RenderHtmlFallback);
+        AddIfMissing(options.InlineRenderExtensions, GitHubInsertedMarkdownName, typeof(InsertedInline), RenderHtmlFallback);
+        AddIfMissing(options.InlineRenderExtensions, GitHubInsertedMarkdownName + ".Sequence", typeof(InsertedSequenceInline), RenderHtmlFallback);
+        AddIfMissing(options.InlineRenderExtensions, GitHubSuperscriptMarkdownName, typeof(SuperscriptInline), RenderHtmlFallback);
+        AddIfMissing(options.InlineRenderExtensions, GitHubSuperscriptMarkdownName + ".Sequence", typeof(SuperscriptSequenceInline), RenderHtmlFallback);
+        AddIfMissing(options.InlineRenderExtensions, GitHubSubscriptMarkdownName, typeof(SubscriptInline), RenderHtmlFallback);
+        AddIfMissing(options.InlineRenderExtensions, GitHubSubscriptMarkdownName + ".Sequence", typeof(SubscriptSequenceInline), RenderHtmlFallback);
+    }
+
+    /// <summary>Adds a GitHub-compatible markdown fallback for attributed inline nodes by emitting raw HTML.</summary>
+    public static void AddGitHubAttributedInlineMarkdownFallback(MarkdownWriteOptions options) {
+        if (options == null) {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        AddIfMissing(options.InlineRenderExtensions, GitHubAttributedInlineMarkdownName, typeof(MarkdownInline), RenderAttributedHtmlFallback);
     }
 
     private static void AddIfMissing(
@@ -71,6 +117,27 @@ public static class MarkdownInlineRenderBuiltInExtensions {
 
         return html == null
             ? null
-            : MarkdownInlineAttributeRenderer.RenderHtml(inline, html, null);
+            : RenderHtmlWithAttributes(inline, html);
+    }
+
+    private static string? RenderAttributedHtmlFallback(IMarkdownInline inline, MarkdownWriteOptions _) {
+        if (inline is not MarkdownObject markdownObject
+            || markdownObject.Attributes.IsEmpty
+            || inline is not IRenderableMarkdownInline renderable) {
+            return null;
+        }
+
+        return RenderHtmlWithAttributes(inline, renderable.RenderHtml());
+    }
+
+    private static string RenderHtmlWithAttributes(IMarkdownInline inline, string html) {
+        var rendered = MarkdownInlineAttributeRenderer.RenderHtml(inline, html, null);
+        if (!string.Equals(rendered, html, StringComparison.Ordinal)
+            || inline is not MarkdownObject markdownObject
+            || markdownObject.Attributes.IsEmpty) {
+            return rendered;
+        }
+
+        return "<span" + MarkdownHtmlAttributes.Render(markdownObject.Attributes, null) + ">" + html + "</span>";
     }
 }

--- a/OfficeIMO.Markdown/Options/MarkdownInlineRenderBuiltInExtensions.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownInlineRenderBuiltInExtensions.cs
@@ -11,6 +11,12 @@ public static class MarkdownInlineRenderBuiltInExtensions {
     public const string CommonMarkHighlightMarkdownName = "CommonMark.Highlight.Markdown";
     /// <summary>Stable registration name for the CommonMark footnote-reference markdown fallback.</summary>
     public const string CommonMarkFootnoteReferenceMarkdownName = "CommonMark.FootnoteReference.Markdown";
+    /// <summary>Stable registration name for the CommonMark inserted markdown fallback.</summary>
+    public const string CommonMarkInsertedMarkdownName = "CommonMark.Inserted.Markdown";
+    /// <summary>Stable registration name for the CommonMark superscript markdown fallback.</summary>
+    public const string CommonMarkSuperscriptMarkdownName = "CommonMark.Superscript.Markdown";
+    /// <summary>Stable registration name for the CommonMark subscript markdown fallback.</summary>
+    public const string CommonMarkSubscriptMarkdownName = "CommonMark.Subscript.Markdown";
 
     /// <summary>Adds CommonMark-compatible markdown fallbacks for GFM-only inline constructs.</summary>
     public static void AddCommonMarkGfmInlineMarkdownFallbacks(MarkdownWriteOptions options) {
@@ -23,6 +29,12 @@ public static class MarkdownInlineRenderBuiltInExtensions {
         AddIfMissing(options.InlineRenderExtensions, CommonMarkHighlightMarkdownName, typeof(HighlightInline), RenderHtmlFallback);
         AddIfMissing(options.InlineRenderExtensions, CommonMarkHighlightMarkdownName + ".Sequence", typeof(HighlightSequenceInline), RenderHtmlFallback);
         AddIfMissing(options.InlineRenderExtensions, CommonMarkFootnoteReferenceMarkdownName, typeof(FootnoteRefInline), RenderHtmlFallback);
+        AddIfMissing(options.InlineRenderExtensions, CommonMarkInsertedMarkdownName, typeof(InsertedInline), RenderHtmlFallback);
+        AddIfMissing(options.InlineRenderExtensions, CommonMarkInsertedMarkdownName + ".Sequence", typeof(InsertedSequenceInline), RenderHtmlFallback);
+        AddIfMissing(options.InlineRenderExtensions, CommonMarkSuperscriptMarkdownName, typeof(SuperscriptInline), RenderHtmlFallback);
+        AddIfMissing(options.InlineRenderExtensions, CommonMarkSuperscriptMarkdownName + ".Sequence", typeof(SuperscriptSequenceInline), RenderHtmlFallback);
+        AddIfMissing(options.InlineRenderExtensions, CommonMarkSubscriptMarkdownName, typeof(SubscriptInline), RenderHtmlFallback);
+        AddIfMissing(options.InlineRenderExtensions, CommonMarkSubscriptMarkdownName + ".Sequence", typeof(SubscriptSequenceInline), RenderHtmlFallback);
     }
 
     private static void AddIfMissing(
@@ -48,6 +60,12 @@ public static class MarkdownInlineRenderBuiltInExtensions {
             HighlightInline highlight => highlight.RenderHtml(),
             HighlightSequenceInline highlight => highlight.RenderHtml(),
             FootnoteRefInline footnote => footnote.RenderHtml(),
+            InsertedInline inserted => inserted.RenderHtml(),
+            InsertedSequenceInline inserted => inserted.RenderHtml(),
+            SuperscriptInline superscript => superscript.RenderHtml(),
+            SuperscriptSequenceInline superscript => superscript.RenderHtml(),
+            SubscriptInline subscript => subscript.RenderHtml(),
+            SubscriptSequenceInline subscript => subscript.RenderHtml(),
             _ => null
         };
 

--- a/OfficeIMO.Markdown/Options/MarkdownInlineRenderBuiltInExtensions.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownInlineRenderBuiltInExtensions.cs
@@ -9,6 +9,8 @@ public static class MarkdownInlineRenderBuiltInExtensions {
 
     /// <summary>Stable registration name for the CommonMark highlight markdown fallback.</summary>
     public const string CommonMarkHighlightMarkdownName = "CommonMark.Highlight.Markdown";
+    /// <summary>Stable registration name for the CommonMark footnote-reference markdown fallback.</summary>
+    public const string CommonMarkFootnoteReferenceMarkdownName = "CommonMark.FootnoteReference.Markdown";
 
     /// <summary>Adds CommonMark-compatible markdown fallbacks for GFM-only inline constructs.</summary>
     public static void AddCommonMarkGfmInlineMarkdownFallbacks(MarkdownWriteOptions options) {
@@ -20,6 +22,7 @@ public static class MarkdownInlineRenderBuiltInExtensions {
         AddIfMissing(options.InlineRenderExtensions, CommonMarkStrikethroughMarkdownName + ".Sequence", typeof(StrikethroughSequenceInline), RenderHtmlFallback);
         AddIfMissing(options.InlineRenderExtensions, CommonMarkHighlightMarkdownName, typeof(HighlightInline), RenderHtmlFallback);
         AddIfMissing(options.InlineRenderExtensions, CommonMarkHighlightMarkdownName + ".Sequence", typeof(HighlightSequenceInline), RenderHtmlFallback);
+        AddIfMissing(options.InlineRenderExtensions, CommonMarkFootnoteReferenceMarkdownName, typeof(FootnoteRefInline), RenderHtmlFallback);
     }
 
     private static void AddIfMissing(
@@ -44,6 +47,7 @@ public static class MarkdownInlineRenderBuiltInExtensions {
             StrikethroughSequenceInline strikethrough => strikethrough.RenderHtml(),
             HighlightInline highlight => highlight.RenderHtml(),
             HighlightSequenceInline highlight => highlight.RenderHtml(),
+            FootnoteRefInline footnote => footnote.RenderHtml(),
             _ => null
         };
 

--- a/OfficeIMO.Markdown/Options/MarkdownOutputProfile.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownOutputProfile.cs
@@ -1,0 +1,18 @@
+namespace OfficeIMO.Markdown;
+
+/// <summary>
+/// Named Markdown writer profiles for common output compatibility targets.
+/// </summary>
+public enum MarkdownOutputProfile {
+    /// <summary>OfficeIMO defaults including richer OfficeIMO markdown extensions.</summary>
+    OfficeIMO,
+
+    /// <summary>CommonMark-oriented output that avoids GitHub-only markdown syntax where practical.</summary>
+    CommonMark,
+
+    /// <summary>GitHub Flavored Markdown-oriented output for README and GitHub documentation workflows.</summary>
+    GitHubFlavoredMarkdown,
+
+    /// <summary>Portable OfficeIMO subset for stricter or parity-sensitive hosts.</summary>
+    Portable
+}

--- a/OfficeIMO.Markdown/Options/MarkdownWriteOptions.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownWriteOptions.cs
@@ -28,6 +28,7 @@ public sealed class MarkdownWriteOptions {
         var options = CreatePortableProfile();
         options.OutputLineEnding = "\n";
         options.FrontMatterRendering = MarkdownFrontMatterRenderingMode.Omit;
+        options.AbbreviationDefinitionRendering = MarkdownAbbreviationDefinitionRenderingMode.Omit;
         MarkdownBlockRenderBuiltInExtensions.AddCommonMarkTableMarkdownFallback(options);
         MarkdownBlockRenderBuiltInExtensions.AddCommonMarkTaskListMarkdownFallback(options);
         MarkdownBlockRenderBuiltInExtensions.AddCommonMarkDefinitionListMarkdownFallback(options);
@@ -47,9 +48,14 @@ public sealed class MarkdownWriteOptions {
     public static MarkdownWriteOptions CreateGitHubFlavoredMarkdownProfile() {
         var options = new MarkdownWriteOptions {
             ImageRenderingMode = MarkdownImageRenderingMode.PortableMarkdown,
+            AbbreviationDefinitionRendering = MarkdownAbbreviationDefinitionRenderingMode.Omit,
             OutputLineEnding = "\n",
             UnorderedListMarker = '-'
         };
+        MarkdownBlockRenderBuiltInExtensions.AddGitHubDefinitionListMarkdownFallback(options);
+        MarkdownBlockRenderBuiltInExtensions.AddGitHubCustomContainerMarkdownFallback(options);
+        MarkdownBlockRenderBuiltInExtensions.AddGitHubParagraphLineStartMarkdownFallback(options);
+        MarkdownBlockRenderBuiltInExtensions.AddGitHubAttributedBlockMarkdownFallback(options);
         MarkdownInlineRenderBuiltInExtensions.AddGitHubOfficeInlineMarkdownFallbacks(options);
         MarkdownInlineRenderBuiltInExtensions.AddGitHubAttributedInlineMarkdownFallback(options);
         return options;
@@ -81,6 +87,11 @@ public sealed class MarkdownWriteOptions {
     /// Controls how YAML front matter is emitted by <see cref="MarkdownDoc.ToMarkdown(MarkdownWriteOptions?)"/>.
     /// </summary>
     public MarkdownFrontMatterRenderingMode FrontMatterRendering { get; set; } = MarkdownFrontMatterRenderingMode.Preserve;
+
+    /// <summary>
+    /// Controls how parse-owned abbreviation definitions are emitted by <see cref="MarkdownDoc.ToMarkdown(MarkdownWriteOptions?)"/>.
+    /// </summary>
+    public MarkdownAbbreviationDefinitionRenderingMode AbbreviationDefinitionRendering { get; set; } = MarkdownAbbreviationDefinitionRenderingMode.Preserve;
 
     /// <summary>
     /// Optional line ending to use in rendered Markdown. When unset, the platform default is used.
@@ -139,6 +150,7 @@ public sealed class MarkdownWriteOptions {
         var clone = new MarkdownWriteOptions {
             ImageRenderingMode = ImageRenderingMode,
             FrontMatterRendering = FrontMatterRendering,
+            AbbreviationDefinitionRendering = AbbreviationDefinitionRendering,
             OutputLineEnding = OutputLineEnding,
             UnorderedListMarker = UnorderedListMarker
         };

--- a/OfficeIMO.Markdown/Options/MarkdownWriteOptions.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownWriteOptions.cs
@@ -10,6 +10,36 @@ public sealed class MarkdownWriteOptions {
     /// <summary>Creates default OfficeIMO-flavored markdown writer options.</summary>
     public static MarkdownWriteOptions CreateOfficeIMOProfile() => new MarkdownWriteOptions();
 
+    /// <summary>Creates writer options for the requested output profile.</summary>
+    public static MarkdownWriteOptions CreateProfile(MarkdownOutputProfile profile) =>
+        profile switch {
+            MarkdownOutputProfile.OfficeIMO => CreateOfficeIMOProfile(),
+            MarkdownOutputProfile.CommonMark => CreateCommonMarkProfile(),
+            MarkdownOutputProfile.GitHubFlavoredMarkdown => CreateGitHubFlavoredMarkdownProfile(),
+            MarkdownOutputProfile.Portable => CreatePortableProfile(),
+            _ => throw new ArgumentOutOfRangeException(nameof(profile), profile, "Unknown markdown output profile.")
+        };
+
+    /// <summary>
+    /// Creates a CommonMark-oriented writer profile. GitHub-only constructs such as pipe tables are
+    /// emitted using portable raw HTML fallbacks when a plain CommonMark representation does not exist.
+    /// </summary>
+    public static MarkdownWriteOptions CreateCommonMarkProfile() {
+        var options = CreatePortableProfile();
+        options.OutputLineEnding = "\n";
+        MarkdownBlockRenderBuiltInExtensions.AddCommonMarkTableMarkdownFallback(options);
+        return options;
+    }
+
+    /// <summary>
+    /// Creates a GitHub Flavored Markdown-oriented writer profile for README and GitHub documentation output.
+    /// </summary>
+    public static MarkdownWriteOptions CreateGitHubFlavoredMarkdownProfile() => new MarkdownWriteOptions {
+        ImageRenderingMode = MarkdownImageRenderingMode.PortableMarkdown,
+        OutputLineEnding = "\n",
+        UnorderedListMarker = '-'
+    };
+
     /// <summary>
     /// Creates a more portable markdown writer profile that degrades OfficeIMO-only blocks into broadly compatible markdown.
     /// </summary>

--- a/OfficeIMO.Markdown/Options/MarkdownWriteOptions.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownWriteOptions.cs
@@ -28,6 +28,7 @@ public sealed class MarkdownWriteOptions {
         var options = CreatePortableProfile();
         options.OutputLineEnding = "\n";
         MarkdownBlockRenderBuiltInExtensions.AddCommonMarkTableMarkdownFallback(options);
+        MarkdownBlockRenderBuiltInExtensions.AddCommonMarkTaskListMarkdownFallback(options);
         MarkdownInlineRenderBuiltInExtensions.AddCommonMarkGfmInlineMarkdownFallbacks(options);
         return options;
     }

--- a/OfficeIMO.Markdown/Options/MarkdownWriteOptions.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownWriteOptions.cs
@@ -29,6 +29,8 @@ public sealed class MarkdownWriteOptions {
         options.OutputLineEnding = "\n";
         MarkdownBlockRenderBuiltInExtensions.AddCommonMarkTableMarkdownFallback(options);
         MarkdownBlockRenderBuiltInExtensions.AddCommonMarkTaskListMarkdownFallback(options);
+        MarkdownBlockRenderBuiltInExtensions.AddCommonMarkDefinitionListMarkdownFallback(options);
+        MarkdownBlockRenderBuiltInExtensions.AddCommonMarkFootnoteDefinitionMarkdownFallback(options);
         MarkdownInlineRenderBuiltInExtensions.AddCommonMarkGfmInlineMarkdownFallbacks(options);
         return options;
     }

--- a/OfficeIMO.Markdown/Options/MarkdownWriteOptions.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownWriteOptions.cs
@@ -31,6 +31,7 @@ public sealed class MarkdownWriteOptions {
         MarkdownBlockRenderBuiltInExtensions.AddCommonMarkTaskListMarkdownFallback(options);
         MarkdownBlockRenderBuiltInExtensions.AddCommonMarkDefinitionListMarkdownFallback(options);
         MarkdownBlockRenderBuiltInExtensions.AddCommonMarkFootnoteDefinitionMarkdownFallback(options);
+        MarkdownBlockRenderBuiltInExtensions.AddCommonMarkDetailsMarkdownFallback(options);
         MarkdownInlineRenderBuiltInExtensions.AddCommonMarkGfmInlineMarkdownFallbacks(options);
         return options;
     }

--- a/OfficeIMO.Markdown/Options/MarkdownWriteOptions.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownWriteOptions.cs
@@ -27,6 +27,7 @@ public sealed class MarkdownWriteOptions {
     public static MarkdownWriteOptions CreateCommonMarkProfile() {
         var options = CreatePortableProfile();
         options.OutputLineEnding = "\n";
+        options.FrontMatterRendering = MarkdownFrontMatterRenderingMode.Omit;
         MarkdownBlockRenderBuiltInExtensions.AddCommonMarkTableMarkdownFallback(options);
         MarkdownBlockRenderBuiltInExtensions.AddCommonMarkTaskListMarkdownFallback(options);
         MarkdownBlockRenderBuiltInExtensions.AddCommonMarkDefinitionListMarkdownFallback(options);
@@ -36,17 +37,23 @@ public sealed class MarkdownWriteOptions {
         MarkdownBlockRenderBuiltInExtensions.AddCommonMarkParagraphLineStartMarkdownFallback(options);
         MarkdownBlockRenderBuiltInExtensions.AddCommonMarkAttributedBlockMarkdownFallback(options);
         MarkdownInlineRenderBuiltInExtensions.AddCommonMarkGfmInlineMarkdownFallbacks(options);
+        MarkdownInlineRenderBuiltInExtensions.AddCommonMarkAttributedInlineMarkdownFallback(options);
         return options;
     }
 
     /// <summary>
     /// Creates a GitHub Flavored Markdown-oriented writer profile for README and GitHub documentation output.
     /// </summary>
-    public static MarkdownWriteOptions CreateGitHubFlavoredMarkdownProfile() => new MarkdownWriteOptions {
-        ImageRenderingMode = MarkdownImageRenderingMode.PortableMarkdown,
-        OutputLineEnding = "\n",
-        UnorderedListMarker = '-'
-    };
+    public static MarkdownWriteOptions CreateGitHubFlavoredMarkdownProfile() {
+        var options = new MarkdownWriteOptions {
+            ImageRenderingMode = MarkdownImageRenderingMode.PortableMarkdown,
+            OutputLineEnding = "\n",
+            UnorderedListMarker = '-'
+        };
+        MarkdownInlineRenderBuiltInExtensions.AddGitHubOfficeInlineMarkdownFallbacks(options);
+        MarkdownInlineRenderBuiltInExtensions.AddGitHubAttributedInlineMarkdownFallback(options);
+        return options;
+    }
 
     /// <summary>
     /// Creates a more portable markdown writer profile that degrades OfficeIMO-only blocks into broadly compatible markdown.
@@ -69,6 +76,11 @@ public sealed class MarkdownWriteOptions {
     /// Controls how image blocks and image inlines are serialized back to markdown text.
     /// </summary>
     public MarkdownImageRenderingMode ImageRenderingMode { get; set; } = MarkdownImageRenderingMode.RichMarkdown;
+
+    /// <summary>
+    /// Controls how YAML front matter is emitted by <see cref="MarkdownDoc.ToMarkdown(MarkdownWriteOptions?)"/>.
+    /// </summary>
+    public MarkdownFrontMatterRenderingMode FrontMatterRendering { get; set; } = MarkdownFrontMatterRenderingMode.Preserve;
 
     /// <summary>
     /// Optional line ending to use in rendered Markdown. When unset, the platform default is used.
@@ -126,6 +138,7 @@ public sealed class MarkdownWriteOptions {
     public MarkdownWriteOptions Clone() {
         var clone = new MarkdownWriteOptions {
             ImageRenderingMode = ImageRenderingMode,
+            FrontMatterRendering = FrontMatterRendering,
             OutputLineEnding = OutputLineEnding,
             UnorderedListMarker = UnorderedListMarker
         };

--- a/OfficeIMO.Markdown/Options/MarkdownWriteOptions.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownWriteOptions.cs
@@ -32,6 +32,9 @@ public sealed class MarkdownWriteOptions {
         MarkdownBlockRenderBuiltInExtensions.AddCommonMarkDefinitionListMarkdownFallback(options);
         MarkdownBlockRenderBuiltInExtensions.AddCommonMarkFootnoteDefinitionMarkdownFallback(options);
         MarkdownBlockRenderBuiltInExtensions.AddCommonMarkDetailsMarkdownFallback(options);
+        MarkdownBlockRenderBuiltInExtensions.AddCommonMarkCustomContainerMarkdownFallback(options);
+        MarkdownBlockRenderBuiltInExtensions.AddCommonMarkParagraphLineStartMarkdownFallback(options);
+        MarkdownBlockRenderBuiltInExtensions.AddCommonMarkAttributedBlockMarkdownFallback(options);
         MarkdownInlineRenderBuiltInExtensions.AddCommonMarkGfmInlineMarkdownFallbacks(options);
         return options;
     }

--- a/OfficeIMO.Markdown/Options/MarkdownWriteOptions.cs
+++ b/OfficeIMO.Markdown/Options/MarkdownWriteOptions.cs
@@ -28,6 +28,7 @@ public sealed class MarkdownWriteOptions {
         var options = CreatePortableProfile();
         options.OutputLineEnding = "\n";
         MarkdownBlockRenderBuiltInExtensions.AddCommonMarkTableMarkdownFallback(options);
+        MarkdownInlineRenderBuiltInExtensions.AddCommonMarkGfmInlineMarkdownFallbacks(options);
         return options;
     }
 

--- a/OfficeIMO.Markdown/Utilities/HtmlRenderContext.cs
+++ b/OfficeIMO.Markdown/Utilities/HtmlRenderContext.cs
@@ -7,10 +7,12 @@ internal static class HtmlRenderContext {
     private static readonly System.Threading.AsyncLocal<HtmlOptions?> s_Options = new();
     private static readonly System.Threading.AsyncLocal<HtmlFootnoteRenderState?> s_Footnotes = new();
     private static readonly System.Threading.AsyncLocal<MarkdownBodyRenderContext?> s_BodyContext = new();
+    private static readonly System.Threading.AsyncLocal<int> s_RenderListItemAttributesDepth = new();
 
     internal static HtmlOptions? Options => s_Options.Value;
     internal static HtmlFootnoteRenderState? Footnotes => s_Footnotes.Value;
     internal static MarkdownBodyRenderContext? BodyContext => s_BodyContext.Value;
+    internal static bool RenderListItemAttributes => s_RenderListItemAttributesDepth.Value > 0;
 
     internal static IDisposable Push(HtmlOptions options, HtmlFootnoteRenderState? footnotes = null) {
         var prior = s_Options.Value;
@@ -24,6 +26,11 @@ internal static class HtmlRenderContext {
         var prior = s_BodyContext.Value;
         s_BodyContext.Value = context;
         return new BodyContextPopper(prior);
+    }
+
+    internal static IDisposable PushRenderListItemAttributes() {
+        s_RenderListItemAttributesDepth.Value++;
+        return new RenderListItemAttributesPopper();
     }
 
     private readonly struct Popper : IDisposable {
@@ -50,6 +57,13 @@ internal static class HtmlRenderContext {
 
         public void Dispose() {
             s_BodyContext.Value = _prior;
+        }
+    }
+
+    private readonly struct RenderListItemAttributesPopper : IDisposable {
+        public void Dispose() {
+            var current = s_RenderListItemAttributesDepth.Value;
+            s_RenderListItemAttributesDepth.Value = current > 0 ? current - 1 : 0;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add reusable Markdown output profiles for OfficeIMO, CommonMark, GitHub Flavored Markdown, and portable output
- add HTML-to-Markdown compatibility controls for smart links, tag aliases, element filters, pass-through tags, and unknown tag handling
- harden compatibility edge cases for filtered base URLs, aliased media/structured children, rejected aliased anchors, CommonMark-safe line starts, GFM/list/definition/details/custom-container/footnote/inline-extension fallbacks, attributed CommonMark output, CommonMark front matter and abbreviation-definition omission, GitHub-safe OfficeIMO-only inline and non-GFM/attributed block fallbacks, nested list-item attribute preservation, lazy/base64 picture fallbacks, inline-flow unknown tags, and `tel:` links
- add BenchmarkDotNet coverage comparing OfficeIMO HTML conversion profiles with ReverseMarkdown across article, large article, table, nested list, and mixed-document corpora

## Notes
This keeps OfficeIMO's model-first implementation as the default path. The benchmark results show ReverseMarkdown is faster and allocates less for direct conversion, especially on large HTML input, but the current implementation favors complete typed conversion behavior over raw speed for now.

## Validation
- `dotnet test OfficeIMO.Markdown.Tests\OfficeIMO.Markdown.Tests.csproj --no-restore`
- `dotnet build OfficeIMO.Markdown.Benchmarks\OfficeIMO.Markdown.Benchmarks.csproj -c Release -f net8.0 --no-restore`
- `git diff --check`
- real Release benchmark matrix: 30 lanes completed successfully; generated artifacts were removed after collecting the summary