### PR TITLE
Expand OfficeIMO CSV parity and benchmark visibility

### DIFF
--- a/OfficeIMO.CSV.Benchmarks/BenchmarkArrayDataReader.cs
+++ b/OfficeIMO.CSV.Benchmarks/BenchmarkArrayDataReader.cs
@@ -1,0 +1,175 @@
+#nullable enable
+
+using System.Collections;
+using System.Data;
+using System.Data.Common;
+
+namespace OfficeIMO.CSV.Benchmarks;
+
+internal sealed class BenchmarkArrayDataReader : DbDataReader
+{
+    private readonly string[] _headers;
+    private readonly object?[][] _rows;
+    private readonly Type[] _fieldTypes;
+    private readonly Dictionary<string, int> _ordinals;
+    private int _rowIndex = -1;
+    private bool _closed;
+
+    public BenchmarkArrayDataReader(string[] headers, object?[][] rows)
+    {
+        _headers = headers;
+        _rows = rows;
+        _fieldTypes = CreateFieldTypes(headers, rows);
+        _ordinals = new Dictionary<string, int>(headers.Length, StringComparer.OrdinalIgnoreCase);
+
+        for (var i = 0; i < headers.Length; i++)
+        {
+            _ordinals[headers[i]] = i;
+        }
+    }
+
+    public override object this[int ordinal] => GetValue(ordinal);
+
+    public override object this[string name] => GetValue(GetOrdinal(name));
+
+    public override int Depth => 0;
+
+    public override int FieldCount => _headers.Length;
+
+    public override bool HasRows => _rows.Length > 0;
+
+    public override bool IsClosed => _closed;
+
+    public override int RecordsAffected => -1;
+
+    public override bool GetBoolean(int ordinal) => (bool)CurrentRow[ordinal]!;
+
+    public override byte GetByte(int ordinal) => (byte)CurrentRow[ordinal]!;
+
+    public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override char GetChar(int ordinal) => (char)CurrentRow[ordinal]!;
+
+    public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override string GetDataTypeName(int ordinal) => _fieldTypes[ordinal].Name;
+
+    public override DateTime GetDateTime(int ordinal) => (DateTime)CurrentRow[ordinal]!;
+
+    public override decimal GetDecimal(int ordinal) => (decimal)CurrentRow[ordinal]!;
+
+    public override double GetDouble(int ordinal) => (double)CurrentRow[ordinal]!;
+
+    public override IEnumerator GetEnumerator()
+    {
+        while (Read())
+        {
+            yield return this;
+        }
+    }
+
+    public override Type GetFieldType(int ordinal) => _fieldTypes[ordinal];
+
+    public override float GetFloat(int ordinal) => (float)CurrentRow[ordinal]!;
+
+    public override Guid GetGuid(int ordinal) => (Guid)CurrentRow[ordinal]!;
+
+    public override short GetInt16(int ordinal) => (short)CurrentRow[ordinal]!;
+
+    public override int GetInt32(int ordinal) => (int)CurrentRow[ordinal]!;
+
+    public override long GetInt64(int ordinal) => (long)CurrentRow[ordinal]!;
+
+    public override string GetName(int ordinal) => _headers[ordinal];
+
+    public override int GetOrdinal(string name)
+    {
+        if (_ordinals.TryGetValue(name, out var ordinal))
+        {
+            return ordinal;
+        }
+
+        throw new IndexOutOfRangeException(name);
+    }
+
+    public override string GetString(int ordinal) => (string)CurrentRow[ordinal]!;
+
+    public override object GetValue(int ordinal) => CurrentRow[ordinal] ?? DBNull.Value;
+
+    public override int GetValues(object[] values)
+    {
+        var row = CurrentRow;
+        var count = Math.Min(values.Length, row.Length);
+        for (var i = 0; i < count; i++)
+        {
+            values[i] = row[i] ?? DBNull.Value;
+        }
+
+        return count;
+    }
+
+    public override bool IsDBNull(int ordinal) => CurrentRow[ordinal] == null;
+
+    public override bool NextResult() => false;
+
+    public override bool Read()
+    {
+        if (_closed)
+        {
+            return false;
+        }
+
+        var next = _rowIndex + 1;
+        if (next >= _rows.Length)
+        {
+            return false;
+        }
+
+        _rowIndex = next;
+        return true;
+    }
+
+    public override void Close()
+    {
+        _closed = true;
+    }
+
+    public override DataTable? GetSchemaTable() => null;
+
+    private object?[] CurrentRow
+    {
+        get
+        {
+            if (_rowIndex < 0 || _rowIndex >= _rows.Length)
+            {
+                throw new InvalidOperationException("The reader is not positioned on a row.");
+            }
+
+            return _rows[_rowIndex];
+        }
+    }
+
+    private static Type[] CreateFieldTypes(string[] headers, object?[][] rows)
+    {
+        var types = new Type[headers.Length];
+        if (rows.Length == 0)
+        {
+            Array.Fill(types, typeof(string));
+            return types;
+        }
+
+        var firstRow = rows[0];
+        for (var i = 0; i < headers.Length; i++)
+        {
+            types[i] = firstRow[i]?.GetType() ?? typeof(string);
+        }
+
+        return types;
+    }
+}

--- a/OfficeIMO.CSV.Benchmarks/CsvBenchmarks.cs
+++ b/OfficeIMO.CSV.Benchmarks/CsvBenchmarks.cs
@@ -239,6 +239,14 @@ public class CsvBenchmarks
     }
 
     [Benchmark]
+    public int OfficeIMO_ReadTextRowFieldSpansMaterialized()
+    {
+        var visitor = new CsvMaterializingRowFieldSpanVisitor();
+        CsvDocument.ReadRowFieldSpansFromText(_csvText, ref visitor);
+        return visitor.FieldCount + visitor.TextLength;
+    }
+
+    [Benchmark]
     public int OfficeIMO_ReadFieldSpansMaterialized()
     {
         using var reader = new StringReader(_csvText);

--- a/OfficeIMO.CSV.Benchmarks/CsvBenchmarks.cs
+++ b/OfficeIMO.CSV.Benchmarks/CsvBenchmarks.cs
@@ -3,9 +3,19 @@
 using System.Globalization;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
+using nietras.SeparatedValues;
 using CsvHelperReader = CsvHelper.CsvReader;
 using CsvHelperWriter = CsvHelper.CsvWriter;
+using DataplatCsvDataReader = Dataplat.Dbatools.Csv.Reader.CsvDataReader;
+using DataplatCsvReaderOptions = Dataplat.Dbatools.Csv.Reader.CsvReaderOptions;
+using DataplatCsvWriter = Dataplat.Dbatools.Csv.Writer.CsvWriter;
+using DataplatCsvWriterOptions = Dataplat.Dbatools.Csv.Writer.CsvWriterOptions;
+using SepLib = nietras.SeparatedValues.Sep;
+using SepReaderOptions = nietras.SeparatedValues.SepReaderOptions;
+using SepWriterOptions = nietras.SeparatedValues.SepWriterOptions;
 using SylvanCsvDataReader = Sylvan.Data.Csv.CsvDataReader;
+using SylvanCsvDataWriter = Sylvan.Data.Csv.CsvDataWriter;
+using SylvanCsvDataWriterOptions = Sylvan.Data.Csv.CsvDataWriterOptions;
 
 namespace OfficeIMO.CSV.Benchmarks;
 
@@ -29,7 +39,13 @@ public class CsvBenchmarks
 
     private CsvBenchmarkRow[] _rows = [];
     private object?[][] _projectedRows = [];
+    private string?[][] _projectedTextRows = [];
     private string _csvText = string.Empty;
+    private static readonly DataplatCsvReaderOptions DataplatReaderOptions = new() { HasHeaderRow = true };
+    private static readonly DataplatCsvWriterOptions DataplatWriterOptions = new() { NewLine = "\n" };
+    private static readonly SepReaderOptions SepReadOptions = SepLib.New(',').Reader(options => options with { Unescape = true });
+    private static readonly SepWriterOptions SepWriteOptions = SepLib.New(',').Writer(options => options with { WriteHeader = true, Escape = true });
+    private static readonly SylvanCsvDataWriterOptions SylvanWriterOptions = new() { NewLine = "\n" };
 
     [Params(1000, 10000, 25000)]
     public int RowCount { get; set; }
@@ -42,6 +58,7 @@ public class CsvBenchmarks
     {
         _rows = CsvBenchmarkData.Create(RowCount, Shape);
         _projectedRows = _rows.Select(ProjectRow).ToArray();
+        _projectedTextRows = _projectedRows.Select(ProjectTextRow).ToArray();
 
         using var writer = new StringWriter(CultureInfo.InvariantCulture);
         CsvDocument.WriteObjects(writer, _rows, new CsvSaveOptions { NewLine = "\n" });
@@ -64,6 +81,25 @@ public class CsvBenchmarks
         foreach (object?[] row in _projectedRows)
         {
             csv.WriteRow(Headers, row);
+        }
+
+        return writer.GetStringBuilder().Length;
+    }
+
+    [Benchmark]
+    public int OfficeIMO_WriteTrustedTextRows()
+    {
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        using var csv = new CsvObjectWriter(writer, new CsvSaveOptions { NewLine = "\n" }, leaveOpen: true);
+        if (_projectedTextRows.Length == 0)
+        {
+            return 0;
+        }
+
+        csv.WriteRow(Headers, _projectedTextRows[0]);
+        for (var i = 1; i < _projectedTextRows.Length; i++)
+        {
+            csv.WriteTrustedTextRow(_projectedTextRows[i]);
         }
 
         return writer.GetStringBuilder().Length;
@@ -117,6 +153,57 @@ public class CsvBenchmarks
     }
 
     [Benchmark]
+    public int Sylvan_WriteProjectedRows()
+    {
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        using var reader = new BenchmarkArrayDataReader(Headers, _projectedRows);
+        using var csv = SylvanCsvDataWriter.Create(writer, SylvanWriterOptions);
+        csv.Write(reader);
+        return writer.GetStringBuilder().Length;
+    }
+
+    [Benchmark]
+    public int Dataplat_WriteProjectedRows()
+    {
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        using var csv = new DataplatCsvWriter(writer, DataplatWriterOptions);
+        csv.WriteHeader(Headers);
+        foreach (object?[] row in _projectedRows)
+        {
+            csv.WriteRow(row);
+        }
+
+        return writer.GetStringBuilder().Length;
+    }
+
+    [Benchmark]
+    public int Dataplat_WriteFromReader()
+    {
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        using var reader = new BenchmarkArrayDataReader(Headers, _projectedRows);
+        using var csv = new DataplatCsvWriter(writer, DataplatWriterOptions);
+        csv.WriteFromReader(reader);
+        return writer.GetStringBuilder().Length;
+    }
+
+    [Benchmark]
+    public int Sep_WriteProjectedRows()
+    {
+        var options = SepWriteOptions;
+        using var csv = options.ToText();
+        foreach (string?[] row in _projectedTextRows)
+        {
+            using var csvRow = csv.NewRow();
+            for (var i = 0; i < Headers.Length; i++)
+            {
+                csvRow[Headers[i]].Set(row[i].AsSpan());
+            }
+        }
+
+        return csv.ToString().Length;
+    }
+
+    [Benchmark]
     public int OfficeIMO_ReadRowsCallback()
     {
         using var reader = new StringReader(_csvText);
@@ -140,6 +227,53 @@ public class CsvBenchmarks
         });
 
         return fieldCount;
+    }
+
+    [Benchmark]
+    public int OfficeIMO_ReadRowFieldSpansMaterialized()
+    {
+        using var reader = new StringReader(_csvText);
+        var visitor = new CsvMaterializingRowFieldSpanVisitor();
+        CsvDocument.ReadRowFieldSpans(reader, ref visitor);
+        return visitor.FieldCount + visitor.TextLength;
+    }
+
+    [Benchmark]
+    public int OfficeIMO_ReadFieldSpansMaterialized()
+    {
+        using var reader = new StringReader(_csvText);
+        var visitor = new CsvMaterializingFieldSpanVisitor();
+        CsvDocument.ReadFieldSpans(
+            reader,
+            ref visitor,
+            new CsvLoadOptions { SkipInitialRecords = 1 });
+        visitor.Complete();
+        return visitor.FieldCount + visitor.TextLength;
+    }
+
+    [Benchmark]
+    public int OfficeIMO_ReadFieldSpanVisitorSkipHeader()
+    {
+        using var reader = new StringReader(_csvText);
+        var visitor = new CountingFieldSpanVisitor();
+        CsvDocument.ReadFieldSpans(
+            reader,
+            ref visitor,
+            new CsvLoadOptions { SkipInitialRecords = 1 });
+
+        return visitor.FieldCount + visitor.TextLength;
+    }
+
+    [Benchmark]
+    public int OfficeIMO_ReadTextFieldSpanVisitorSkipHeader()
+    {
+        var visitor = new CountingFieldSpanVisitor();
+        CsvDocument.ReadFieldSpansFromText(
+            _csvText,
+            ref visitor,
+            new CsvLoadOptions { SkipInitialRecords = 1 });
+
+        return visitor.FieldCount + visitor.TextLength;
     }
 
     [Benchmark]
@@ -184,8 +318,8 @@ public class CsvBenchmarks
         {
             for (var i = 0; i < Headers.Length; i++)
             {
-                _ = csv.GetField(i);
-                fieldCount++;
+                string? value = csv.GetField(i);
+                fieldCount += 1 + (value?.Length ?? 0);
             }
         }
 
@@ -202,8 +336,75 @@ public class CsvBenchmarks
         {
             for (var i = 0; i < csv.FieldCount; i++)
             {
-                _ = csv.GetString(i);
-                fieldCount++;
+                fieldCount += 1 + csv.GetString(i).Length;
+            }
+        }
+
+        return fieldCount;
+    }
+
+    [Benchmark]
+    public int Sylvan_ReadFieldSpans()
+    {
+        using var reader = new StringReader(_csvText);
+        using var csv = SylvanCsvDataReader.Create(reader);
+        var fieldCount = 0;
+        while (csv.Read())
+        {
+            for (var i = 0; i < csv.FieldCount; i++)
+            {
+                fieldCount += 1 + csv.GetFieldSpan(i).Length;
+            }
+        }
+
+        return fieldCount;
+    }
+
+    [Benchmark]
+    public int Dataplat_ReadFields()
+    {
+        using var reader = new StringReader(_csvText);
+        using var csv = new DataplatCsvDataReader(reader, DataplatReaderOptions);
+        var fieldCount = 0;
+        while (csv.Read())
+        {
+            for (var i = 0; i < csv.FieldCount; i++)
+            {
+                fieldCount += 1 + csv.GetString(i).Length;
+            }
+        }
+
+        return fieldCount;
+    }
+
+    [Benchmark]
+    public int Sep_ReadFields()
+    {
+        var options = SepReadOptions;
+        using var csv = options.FromText(_csvText);
+        var fieldCount = 0;
+        foreach (var row in csv)
+        {
+            for (var i = 0; i < row.ColCount; i++)
+            {
+                fieldCount += 1 + row[i].ToString().Length;
+            }
+        }
+
+        return fieldCount;
+    }
+
+    [Benchmark]
+    public int Sep_ReadFieldSpans()
+    {
+        var options = SepReadOptions;
+        using var csv = options.FromText(_csvText);
+        var fieldCount = 0;
+        foreach (var row in csv)
+        {
+            for (var i = 0; i < row.ColCount; i++)
+            {
+                fieldCount += 1 + row[i].Span.Length;
             }
         }
 
@@ -239,6 +440,30 @@ public class CsvBenchmarks
             row.TicketCount,
             row.Notes
         ];
+    }
+
+    private static string?[] ProjectTextRow(object?[] row)
+    {
+        var values = new string?[row.Length];
+        for (var i = 0; i < row.Length; i++)
+        {
+            values[i] = Convert.ToString(row[i], CultureInfo.InvariantCulture);
+        }
+
+        return values;
+    }
+
+    private struct CountingFieldSpanVisitor : ICsvFieldSpanVisitor
+    {
+        public int FieldCount { get; private set; }
+
+        public int TextLength { get; private set; }
+
+        public void VisitField(int recordIndex, int fieldIndex, ReadOnlySpan<char> value)
+        {
+            FieldCount++;
+            TextLength += value.Length;
+        }
     }
 }
 

--- a/OfficeIMO.CSV.Benchmarks/CsvBenchmarks.cs
+++ b/OfficeIMO.CSV.Benchmarks/CsvBenchmarks.cs
@@ -464,6 +464,13 @@ public class CsvBenchmarks
             FieldCount++;
             TextLength += value.Length;
         }
+
+        public bool TryVisitEscapedField(int recordIndex, int fieldIndex, ReadOnlySpan<char> escapedValue, int unescapedLength)
+        {
+            FieldCount++;
+            TextLength += unescapedLength;
+            return true;
+        }
     }
 }
 

--- a/OfficeIMO.CSV.Benchmarks/CsvMaterializingFieldSpanVisitor.cs
+++ b/OfficeIMO.CSV.Benchmarks/CsvMaterializingFieldSpanVisitor.cs
@@ -1,0 +1,69 @@
+#nullable enable
+
+namespace OfficeIMO.CSV.Benchmarks;
+
+internal struct CsvMaterializingFieldSpanVisitor : ICsvFieldSpanVisitor
+{
+    private readonly List<string> _currentRow;
+    private int _currentRecordIndex;
+
+    public CsvMaterializingFieldSpanVisitor()
+    {
+        _currentRow = new List<string>(64);
+        _currentRecordIndex = -1;
+        FieldCount = 0;
+        RowCount = 0;
+        TextLength = 0;
+    }
+
+    public int FieldCount { get; private set; }
+
+    public int RowCount { get; private set; }
+
+    public int TextLength { get; private set; }
+
+    public void VisitField(int recordIndex, int fieldIndex, ReadOnlySpan<char> value)
+    {
+        if (recordIndex != _currentRecordIndex)
+        {
+            if (_currentRecordIndex >= 0)
+            {
+                RowCount++;
+            }
+
+            _currentRecordIndex = recordIndex;
+            _currentRow.Clear();
+        }
+
+        var text = value.ToString();
+        _currentRow.Add(text);
+        TextLength += text.Length;
+        FieldCount++;
+    }
+
+    public void VisitFieldValue(int recordIndex, int fieldIndex, string value)
+    {
+        if (recordIndex != _currentRecordIndex)
+        {
+            if (_currentRecordIndex >= 0)
+            {
+                RowCount++;
+            }
+
+            _currentRecordIndex = recordIndex;
+            _currentRow.Clear();
+        }
+
+        _currentRow.Add(value);
+        TextLength += value.Length;
+        FieldCount++;
+    }
+
+    public void Complete()
+    {
+        if (_currentRecordIndex >= 0)
+        {
+            RowCount++;
+        }
+    }
+}

--- a/OfficeIMO.CSV.Benchmarks/CsvMaterializingRowFieldSpanVisitor.cs
+++ b/OfficeIMO.CSV.Benchmarks/CsvMaterializingRowFieldSpanVisitor.cs
@@ -1,0 +1,34 @@
+#nullable enable
+
+namespace OfficeIMO.CSV.Benchmarks;
+
+internal struct CsvMaterializingRowFieldSpanVisitor : ICsvRowFieldSpanVisitor
+{
+    public int FieldCount { get; private set; }
+
+    public int RowCount { get; private set; }
+
+    public int TextLength { get; private set; }
+
+    public void BeginRow(IReadOnlyList<string> header, int rowIndex)
+    {
+    }
+
+    public void VisitField(int rowIndex, int fieldIndex, ReadOnlySpan<char> value)
+    {
+        var text = value.ToString();
+        TextLength += text.Length;
+        FieldCount++;
+    }
+
+    public void VisitFieldValue(int rowIndex, int fieldIndex, string value)
+    {
+        TextLength += value.Length;
+        FieldCount++;
+    }
+
+    public void EndRow(int rowIndex, int fieldCount)
+    {
+        RowCount++;
+    }
+}

--- a/OfficeIMO.CSV.Benchmarks/CsvWideBenchmarks.cs
+++ b/OfficeIMO.CSV.Benchmarks/CsvWideBenchmarks.cs
@@ -398,6 +398,13 @@ public class CsvWideBenchmarks
             FieldCount++;
             TextLength += value.Length;
         }
+
+        public bool TryVisitEscapedField(int recordIndex, int fieldIndex, ReadOnlySpan<char> escapedValue, int unescapedLength)
+        {
+            FieldCount++;
+            TextLength += unescapedLength;
+            return true;
+        }
     }
 }
 

--- a/OfficeIMO.CSV.Benchmarks/CsvWideBenchmarks.cs
+++ b/OfficeIMO.CSV.Benchmarks/CsvWideBenchmarks.cs
@@ -183,6 +183,14 @@ public class CsvWideBenchmarks
     }
 
     [Benchmark]
+    public int OfficeIMO_ReadTextRowFieldSpansMaterialized()
+    {
+        var visitor = new CsvMaterializingRowFieldSpanVisitor();
+        CsvDocument.ReadRowFieldSpansFromText(_csvText, ref visitor);
+        return visitor.FieldCount + visitor.TextLength;
+    }
+
+    [Benchmark]
     public int OfficeIMO_ReadRecordsReusableSkipHeader()
     {
         using var reader = new StringReader(_csvText);

--- a/OfficeIMO.CSV.Benchmarks/CsvWideBenchmarks.cs
+++ b/OfficeIMO.CSV.Benchmarks/CsvWideBenchmarks.cs
@@ -3,9 +3,19 @@
 using System.Globalization;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
+using nietras.SeparatedValues;
 using CsvHelperReader = CsvHelper.CsvReader;
 using CsvHelperWriter = CsvHelper.CsvWriter;
+using DataplatCsvDataReader = Dataplat.Dbatools.Csv.Reader.CsvDataReader;
+using DataplatCsvReaderOptions = Dataplat.Dbatools.Csv.Reader.CsvReaderOptions;
+using DataplatCsvWriter = Dataplat.Dbatools.Csv.Writer.CsvWriter;
+using DataplatCsvWriterOptions = Dataplat.Dbatools.Csv.Writer.CsvWriterOptions;
+using SepLib = nietras.SeparatedValues.Sep;
+using SepReaderOptions = nietras.SeparatedValues.SepReaderOptions;
+using SepWriterOptions = nietras.SeparatedValues.SepWriterOptions;
 using SylvanCsvDataReader = Sylvan.Data.Csv.CsvDataReader;
+using SylvanCsvDataWriter = Sylvan.Data.Csv.CsvDataWriter;
+using SylvanCsvDataWriterOptions = Sylvan.Data.Csv.CsvDataWriterOptions;
 
 namespace OfficeIMO.CSV.Benchmarks;
 
@@ -14,8 +24,14 @@ namespace OfficeIMO.CSV.Benchmarks;
 public class CsvWideBenchmarks
 {
     private static readonly string[] Headers = CreateHeaders();
+    private static readonly DataplatCsvReaderOptions DataplatReaderOptions = new() { HasHeaderRow = true };
+    private static readonly DataplatCsvWriterOptions DataplatWriterOptions = new() { NewLine = "\n" };
+    private static readonly SepReaderOptions SepReadOptions = SepLib.New(',').Reader(options => options with { Unescape = true });
+    private static readonly SepWriterOptions SepWriteOptions = SepLib.New(',').Writer(options => options with { WriteHeader = true, Escape = true });
+    private static readonly SylvanCsvDataWriterOptions SylvanWriterOptions = new() { NewLine = "\n" };
 
     private object?[][] _rows = [];
+    private string?[][] _textRows = [];
     private string _csvText = string.Empty;
 
     [Params(1000, 10000, 25000)]
@@ -25,6 +41,7 @@ public class CsvWideBenchmarks
     public void Setup()
     {
         _rows = CsvWideBenchmarkData.Create(RowCount);
+        _textRows = _rows.Select(ProjectTextRow).ToArray();
 
         using var writer = new StringWriter(CultureInfo.InvariantCulture);
         using var csv = new CsvObjectWriter(writer, new CsvSaveOptions { NewLine = "\n" }, leaveOpen: true);
@@ -44,6 +61,25 @@ public class CsvWideBenchmarks
         foreach (var row in _rows)
         {
             csv.WriteRow(Headers, row);
+        }
+
+        return writer.GetStringBuilder().Length;
+    }
+
+    [Benchmark]
+    public int OfficeIMO_WriteTrustedTextRows()
+    {
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        using var csv = new CsvObjectWriter(writer, new CsvSaveOptions { NewLine = "\n" }, leaveOpen: true);
+        if (_textRows.Length == 0)
+        {
+            return 0;
+        }
+
+        csv.WriteRow(Headers, _textRows[0]);
+        for (var i = 1; i < _textRows.Length; i++)
+        {
+            csv.WriteTrustedTextRow(_textRows[i]);
         }
 
         return writer.GetStringBuilder().Length;
@@ -74,6 +110,57 @@ public class CsvWideBenchmarks
     }
 
     [Benchmark]
+    public int Sylvan_WriteProjectedRows()
+    {
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        using var reader = new BenchmarkArrayDataReader(Headers, _rows);
+        using var csv = SylvanCsvDataWriter.Create(writer, SylvanWriterOptions);
+        csv.Write(reader);
+        return writer.GetStringBuilder().Length;
+    }
+
+    [Benchmark]
+    public int Dataplat_WriteProjectedRows()
+    {
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        using var csv = new DataplatCsvWriter(writer, DataplatWriterOptions);
+        csv.WriteHeader(Headers);
+        foreach (var row in _rows)
+        {
+            csv.WriteRow(row);
+        }
+
+        return writer.GetStringBuilder().Length;
+    }
+
+    [Benchmark]
+    public int Dataplat_WriteFromReader()
+    {
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        using var reader = new BenchmarkArrayDataReader(Headers, _rows);
+        using var csv = new DataplatCsvWriter(writer, DataplatWriterOptions);
+        csv.WriteFromReader(reader);
+        return writer.GetStringBuilder().Length;
+    }
+
+    [Benchmark]
+    public int Sep_WriteProjectedRows()
+    {
+        var options = SepWriteOptions;
+        using var csv = options.ToText();
+        foreach (string?[] row in _textRows)
+        {
+            using var csvRow = csv.NewRow();
+            for (var i = 0; i < Headers.Length; i++)
+            {
+                csvRow[Headers[i]].Set(row[i].AsSpan());
+            }
+        }
+
+        return csv.ToString().Length;
+    }
+
+    [Benchmark]
     public int OfficeIMO_ReadRowsReusableCallback()
     {
         using var reader = new StringReader(_csvText);
@@ -84,6 +171,15 @@ public class CsvWideBenchmarks
         });
 
         return fieldCount;
+    }
+
+    [Benchmark]
+    public int OfficeIMO_ReadRowFieldSpansMaterialized()
+    {
+        using var reader = new StringReader(_csvText);
+        var visitor = new CsvMaterializingRowFieldSpanVisitor();
+        CsvDocument.ReadRowFieldSpans(reader, ref visitor);
+        return visitor.FieldCount + visitor.TextLength;
     }
 
     [Benchmark]
@@ -128,7 +224,32 @@ public class CsvWideBenchmarks
             ref visitor,
             new CsvLoadOptions { SkipInitialRecords = 1 });
 
-        return visitor.FieldCount;
+        return visitor.FieldCount + visitor.TextLength;
+    }
+
+    [Benchmark]
+    public int OfficeIMO_ReadTextFieldSpanVisitorSkipHeader()
+    {
+        var visitor = new CountingFieldSpanVisitor();
+        CsvDocument.ReadFieldSpansFromText(
+            _csvText,
+            ref visitor,
+            new CsvLoadOptions { SkipInitialRecords = 1 });
+
+        return visitor.FieldCount + visitor.TextLength;
+    }
+
+    [Benchmark]
+    public int OfficeIMO_ReadFieldSpansMaterializedSkipHeader()
+    {
+        using var reader = new StringReader(_csvText);
+        var visitor = new CsvMaterializingFieldSpanVisitor();
+        CsvDocument.ReadFieldSpans(
+            reader,
+            ref visitor,
+            new CsvLoadOptions { SkipInitialRecords = 1 });
+        visitor.Complete();
+        return visitor.FieldCount + visitor.TextLength;
     }
 
     [Benchmark]
@@ -147,8 +268,8 @@ public class CsvWideBenchmarks
         {
             for (var i = 0; i < Headers.Length; i++)
             {
-                _ = csv.GetField(i);
-                fieldCount++;
+                string? value = csv.GetField(i);
+                fieldCount += 1 + (value?.Length ?? 0);
             }
         }
 
@@ -165,8 +286,7 @@ public class CsvWideBenchmarks
         {
             for (var i = 0; i < csv.FieldCount; i++)
             {
-                _ = csv.GetString(i);
-                fieldCount++;
+                fieldCount += 1 + csv.GetString(i).Length;
             }
         }
 
@@ -183,8 +303,58 @@ public class CsvWideBenchmarks
         {
             for (var i = 0; i < csv.FieldCount; i++)
             {
-                _ = csv.GetFieldSpan(i);
-                fieldCount++;
+                fieldCount += 1 + csv.GetFieldSpan(i).Length;
+            }
+        }
+
+        return fieldCount;
+    }
+
+    [Benchmark]
+    public int Dataplat_ReadFields()
+    {
+        using var reader = new StringReader(_csvText);
+        using var csv = new DataplatCsvDataReader(reader, DataplatReaderOptions);
+        var fieldCount = 0;
+        while (csv.Read())
+        {
+            for (var i = 0; i < csv.FieldCount; i++)
+            {
+                fieldCount += 1 + csv.GetString(i).Length;
+            }
+        }
+
+        return fieldCount;
+    }
+
+    [Benchmark]
+    public int Sep_ReadFields()
+    {
+        var options = SepReadOptions;
+        using var csv = options.FromText(_csvText);
+        var fieldCount = 0;
+        foreach (var row in csv)
+        {
+            for (var i = 0; i < row.ColCount; i++)
+            {
+                fieldCount += 1 + row[i].ToString().Length;
+            }
+        }
+
+        return fieldCount;
+    }
+
+    [Benchmark]
+    public int Sep_ReadFieldSpans()
+    {
+        var options = SepReadOptions;
+        using var csv = options.FromText(_csvText);
+        var fieldCount = 0;
+        foreach (var row in csv)
+        {
+            for (var i = 0; i < row.ColCount; i++)
+            {
+                fieldCount += 1 + row[i].Span.Length;
             }
         }
 
@@ -206,13 +376,27 @@ public class CsvWideBenchmarks
         return headers;
     }
 
+    private static string?[] ProjectTextRow(object?[] row)
+    {
+        var values = new string?[row.Length];
+        for (var i = 0; i < row.Length; i++)
+        {
+            values[i] = Convert.ToString(row[i], CultureInfo.InvariantCulture);
+        }
+
+        return values;
+    }
+
     private struct CountingFieldSpanVisitor : ICsvFieldSpanVisitor
     {
         public int FieldCount { get; private set; }
 
+        public int TextLength { get; private set; }
+
         public void VisitField(int recordIndex, int fieldIndex, ReadOnlySpan<char> value)
         {
             FieldCount++;
+            TextLength += value.Length;
         }
     }
 }

--- a/OfficeIMO.CSV.Benchmarks/OfficeIMO.CSV.Benchmarks.csproj
+++ b/OfficeIMO.CSV.Benchmarks/OfficeIMO.CSV.Benchmarks.csproj
@@ -12,6 +12,8 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="CsvHelper" Version="33.1.0" />
+    <PackageReference Include="Dataplat.Dbatools.Csv" Version="1.1.15" />
+    <PackageReference Include="Sep" Version="0.15.0" />
     <PackageReference Include="Sylvan.Data.Csv" Version="1.4.4" />
   </ItemGroup>
 

--- a/OfficeIMO.CSV.Benchmarks/README.md
+++ b/OfficeIMO.CSV.Benchmarks/README.md
@@ -8,6 +8,6 @@ This project compares raw .NET CSV paths without PowerShell object overhead. Use
 dotnet run --project .\OfficeIMO.CSV.Benchmarks\OfficeIMO.CSV.Benchmarks.csproj -c Release -f net8.0 -- --filter *Csv*Benchmarks*
 ```
 
-The suite compares OfficeIMO.CSV object writing, OfficeIMO.CSV projected-row writing, OfficeIMO.CSV reusable reads, OfficeIMO.CSV field-span reads, CsvHelper typed/projected writes, CsvHelper raw/typed reads, and Sylvan raw/string/span field reads.
+The suite compares OfficeIMO.CSV object writing, OfficeIMO.CSV projected-row writing, OfficeIMO.CSV trusted text-row writing, OfficeIMO.CSV reusable reads, OfficeIMO.CSV field-span reads, CsvHelper typed/projected writes, CsvHelper raw/typed reads, Sylvan raw/string/span field reads and data-reader writes, Dataplat.Dbatools.Csv reader/writer paths, and Sep strict reader/writer paths.
 
-CsvHelper and Sylvan.Data.Csv are benchmark-only dependencies in this project. They should not be added to `OfficeIMO.CSV` unless a future design decision intentionally changes the runtime dependency model.
+CsvHelper, Sylvan.Data.Csv, Dataplat.Dbatools.Csv, and Sep are benchmark-only dependencies in this project. They should not be added to `OfficeIMO.CSV` unless a future design decision intentionally changes the runtime dependency model.

--- a/OfficeIMO.CSV.Benchmarks/README.md
+++ b/OfficeIMO.CSV.Benchmarks/README.md
@@ -8,6 +8,37 @@ This project compares raw .NET CSV paths without PowerShell object overhead. Use
 dotnet run --project .\OfficeIMO.CSV.Benchmarks\OfficeIMO.CSV.Benchmarks.csproj -c Release -f net8.0 -- --filter *Csv*Benchmarks*
 ```
 
+For a write-focused competitor pass:
+
+```powershell
+dotnet run --project .\OfficeIMO.CSV.Benchmarks\OfficeIMO.CSV.Benchmarks.csproj -c Release -f net8.0 -- --filter "*Write*" --job short --warmupCount 1 --iterationCount 3
+```
+
 The suite compares OfficeIMO.CSV object writing, OfficeIMO.CSV projected-row writing, OfficeIMO.CSV trusted text-row writing, OfficeIMO.CSV reusable reads, OfficeIMO.CSV field-span reads, CsvHelper typed/projected writes, CsvHelper raw/typed reads, Sylvan raw/string/span field reads and data-reader writes, Dataplat.Dbatools.Csv reader/writer paths, and Sep strict reader/writer paths.
 
 CsvHelper, Sylvan.Data.Csv, Dataplat.Dbatools.Csv, and Sep are benchmark-only dependencies in this project. They should not be added to `OfficeIMO.CSV` unless a future design decision intentionally changes the runtime dependency model.
+
+## Current Write Snapshot
+
+Fresh local short-job run on 2026-07-07:
+
+```powershell
+dotnet run --project .\OfficeIMO.CSV.Benchmarks\OfficeIMO.CSV.Benchmarks.csproj -c Release -f net8.0 -- --filter "*Write*" --job short --warmupCount 1 --iterationCount 3
+```
+
+The table shows the fastest method per shape/row-count lane. Treat this as a quick comparison snapshot; run a longer BenchmarkDotNet job before making release claims or budget gates.
+
+| Shape | Rows | Fastest method | Mean |
+| --- | ---: | --- | ---: |
+| Mixed | 1000 | OfficeIMO_WriteTrustedTextRows | 0.08 ms |
+| Mixed | 10000 | OfficeIMO_WriteTrustedTextRows | 0.98 ms |
+| Mixed | 25000 | OfficeIMO_WriteTrustedTextRows | 2.28 ms |
+| Multiline | 1000 | OfficeIMO_WriteTrustedTextRows | 0.12 ms |
+| Multiline | 10000 | OfficeIMO_WriteTrustedTextRows | 1.37 ms |
+| Multiline | 25000 | OfficeIMO_WriteTrustedTextRows | 3.79 ms |
+| Quoted | 1000 | OfficeIMO_WriteTrustedTextRows | 0.14 ms |
+| Quoted | 10000 | OfficeIMO_WriteTrustedTextRows | 1.27 ms |
+| Quoted | 25000 | OfficeIMO_WriteTrustedTextRows | 4.22 ms |
+| Wide | 1000 | OfficeIMO_WriteTrustedTextRows | 0.28 ms |
+| Wide | 10000 | OfficeIMO_WriteTrustedTextRows | 3.41 ms |
+| Wide | 25000 | OfficeIMO_WriteTrustedTextRows | 9.45 ms |

--- a/OfficeIMO.CSV.Tests/App.config
+++ b/OfficeIMO.CSV.Tests/App.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/OfficeIMO.CSV.Tests/CsvHeaderNormalizationTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvHeaderNormalizationTests.cs
@@ -1,0 +1,59 @@
+using System.Linq;
+using OfficeIMO.CSV;
+using Xunit;
+
+namespace OfficeIMO.CSV.Tests;
+
+public class CsvHeaderNormalizationTests
+{
+    [Fact]
+    public void Duplicate_Headers_Are_Renamed_By_Default()
+    {
+        var parsed = CsvDocument.Parse("Name,Name,Value\nAlpha,Beta,1\n");
+        var row = Assert.Single(parsed.AsEnumerable());
+
+        Assert.Equal(new[] { "Name", "Name_2", "Value" }, parsed.Header);
+        Assert.Equal("Alpha", row.AsString("Name"));
+        Assert.Equal("Beta", row.AsString("Name_2"));
+    }
+
+    [Fact]
+    public void Duplicate_Headers_Can_Be_Preserved()
+    {
+        var parsed = CsvDocument.Parse(
+            "Name,Name\nAlpha,Beta\n",
+            new CsvLoadOptions { DuplicateHeaderBehavior = CsvDuplicateHeaderBehavior.Preserve });
+
+        Assert.Equal(new[] { "Name", "Name" }, parsed.Header);
+        Assert.Equal("Alpha", parsed.AsEnumerable().Single().AsString("Name"));
+    }
+
+    [Fact]
+    public void Duplicate_Headers_Can_Throw()
+    {
+        var ex = Assert.Throws<CsvException>(() => CsvDocument.Parse(
+            "Name,Name\nAlpha,Beta\n",
+            new CsvLoadOptions { DuplicateHeaderBehavior = CsvDuplicateHeaderBehavior.Throw }));
+
+        Assert.Contains("duplicate column name 'Name'", ex.Message);
+    }
+
+    [Fact]
+    public void Duplicate_Header_Renaming_Avoids_Existing_Names()
+    {
+        var parsed = CsvDocument.Parse("Name,Name,Name_2\nAlpha,Beta,Gamma\n");
+
+        Assert.Equal(new[] { "Name", "Name_3", "Name_2" }, parsed.Header);
+    }
+
+    [Fact]
+    public void W3C_Duplicate_Headers_Are_Normalized()
+    {
+        var parsed = CsvDocument.Parse("#Fields: date time time\n2026-07-07 10:00 10:01\n", new CsvLoadOptions { Delimiter = ' ' });
+        var row = Assert.Single(parsed.AsEnumerable());
+
+        Assert.Equal(new[] { "date", "time", "time_2" }, parsed.Header);
+        Assert.Equal("10:00", row.AsString("time"));
+        Assert.Equal("10:01", row.AsString("time_2"));
+    }
+}

--- a/OfficeIMO.CSV.Tests/CsvLoadFeatureParityTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvLoadFeatureParityTests.cs
@@ -70,6 +70,27 @@ public class CsvLoadFeatureParityTests
     }
 
     [Fact]
+    public void Quote_Parsing_Defaults_To_Lenient_Mode()
+    {
+        var parsed = CsvDocument.Parse("Name,Value\nAlpha,\"one\"two\n");
+
+        var row = Assert.Single(parsed.AsEnumerable());
+
+        Assert.Equal("onetwo", row.AsString("Value"));
+    }
+
+    [Fact]
+    public void Quote_Parsing_Strict_Mode_Rejects_Invalid_Quoted_Field()
+    {
+        var ex = Assert.Throws<CsvParseException>(() =>
+            CsvDocument.Parse(
+                "Name,Value\nAlpha,\"one\"two\n",
+                new CsvLoadOptions { QuoteParsingMode = CsvQuoteParsingMode.Strict }));
+
+        Assert.Contains("Invalid quoted field", ex.Message);
+    }
+
+    [Fact]
     public void Schema_Validation_Uses_Custom_DateTime_Formats()
     {
         var parsed = CsvDocument.Parse(
@@ -113,6 +134,45 @@ public class CsvLoadFeatureParityTests
         });
 
         Assert.Equal("Name,Created,Value\nAlpha,20260707-1345,<null>\n", text);
+    }
+
+    [Fact]
+    public void WriteObjects_Uses_Null_Token_And_DateTime_Format()
+    {
+        var rows = new[] {
+            new {
+                Name = "Alpha",
+                Created = new DateTime(2026, 7, 7, 13, 45, 0, DateTimeKind.Utc),
+                Value = (string?)null
+            }
+        };
+
+        using var writer = new StringWriter();
+        CsvDocument.WriteObjects(
+            writer,
+            rows,
+            new CsvSaveOptions {
+                NewLine = "\n",
+                NullValue = "<null>",
+                DateTimeFormat = "yyyyMMdd-HHmm"
+            });
+
+        Assert.Equal("Name,Created,Value\nAlpha,20260707-1345,<null>\n", writer.ToString());
+    }
+
+    [Fact]
+    public void CsvObjectWriter_TextRows_Use_Null_Token_When_Configured()
+    {
+        using var writer = new StringWriter();
+        using (var csv = new CsvObjectWriter(
+            writer,
+            new CsvSaveOptions { NewLine = "\n", NullValue = "<null>" },
+            leaveOpen: true))
+        {
+            csv.WriteTextRow(new[] { "Name", "Value" }, new string?[] { "Alpha", null });
+        }
+
+        Assert.Equal("Name,Value\nAlpha,<null>\n", writer.ToString());
     }
 
     [Fact]

--- a/OfficeIMO.CSV.Tests/CsvLoadFeatureParityTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvLoadFeatureParityTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using OfficeIMO.CSV;
+using Xunit;
+
+namespace OfficeIMO.CSV.Tests;
+
+public class CsvLoadFeatureParityTests
+{
+    [Fact]
+    public void Load_Appends_Static_Columns_To_Materialized_Rows()
+    {
+        var parsed = CsvDocument.Parse(
+            "Name,Value\nAlpha,1\nBeta,2\n",
+            new CsvLoadOptions {
+                StaticColumns = new Dictionary<string, object?> {
+                    ["SourceFile"] = "input.csv",
+                    ["BatchId"] = 42
+                }
+            });
+
+        Assert.Equal(new[] { "Name", "Value", "SourceFile", "BatchId" }, parsed.Header);
+        var row = parsed.AsEnumerable().First();
+        Assert.Equal("input.csv", row.AsString("SourceFile"));
+        Assert.Equal(42, row.Get<int>("BatchId"));
+    }
+
+    [Fact]
+    public void Load_Appends_Static_Columns_In_Streaming_Mode()
+    {
+        var parsed = CsvDocument.Parse(
+            "Name,Value\nAlpha,1\n",
+            new CsvLoadOptions {
+                Mode = CsvLoadMode.Stream,
+                StaticColumns = new Dictionary<string, object?> {
+                    ["SourceFile"] = "stream.csv"
+                }
+            });
+
+        var row = Assert.Single(parsed.AsEnumerable());
+
+        Assert.Equal(new[] { "Name", "Value", "SourceFile" }, parsed.Header);
+        Assert.Equal("stream.csv", row.AsString("SourceFile"));
+    }
+
+    [Fact]
+    public void Load_Converts_Configured_Null_Token_To_Null()
+    {
+        var parsed = CsvDocument.Parse(
+            "Name,Value\nAlpha,<null>\n",
+            new CsvLoadOptions { NullValue = "<null>" });
+
+        var row = Assert.Single(parsed.AsEnumerable());
+
+        Assert.Null(row["Value"]);
+    }
+
+    [Fact]
+    public void Rows_Use_Custom_DateTime_Formats_For_Typed_Conversion()
+    {
+        var parsed = CsvDocument.Parse(
+            "Created\n07-Jul-2026\n",
+            new CsvLoadOptions { DateTimeFormats = new[] { "dd-MMM-yyyy" } });
+
+        var row = Assert.Single(parsed.AsEnumerable());
+
+        Assert.Equal(new DateTime(2026, 7, 7), row.AsDateTime("Created"));
+    }
+
+    [Fact]
+    public void Schema_Validation_Uses_Custom_DateTime_Formats()
+    {
+        var parsed = CsvDocument.Parse(
+            "Created\n07-Jul-2026\n",
+            new CsvLoadOptions { DateTimeFormats = new[] { "dd-MMM-yyyy" } })
+            .EnsureSchema(schema => schema.Column("Created").AsDateTime().Required());
+
+        parsed.Validate(out var errors);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void ReadRows_Appends_Static_Columns()
+    {
+        var seen = new List<string>();
+
+        CsvDocument.ReadRows(
+            new StringReader("Name,Value\nAlpha,1\n"),
+            (header, values) => seen.Add($"{string.Join("|", header)}={string.Join("|", values)}"),
+            new CsvLoadOptions {
+                StaticColumns = new Dictionary<string, object?> {
+                    ["SourceFile"] = "read.csv"
+                }
+            });
+
+        Assert.Equal("Name|Value|SourceFile=Alpha|1|read.csv", Assert.Single(seen));
+    }
+
+    [Fact]
+    public void Save_Uses_Null_Token_And_DateTime_Format()
+    {
+        var document = new CsvDocument()
+            .WithHeader("Name", "Created", "Value")
+            .AddRow("Alpha", new DateTime(2026, 7, 7, 13, 45, 0, DateTimeKind.Utc), null);
+
+        var text = document.ToString(new CsvSaveOptions {
+            NewLine = "\n",
+            NullValue = "<null>",
+            DateTimeFormat = "yyyyMMdd-HHmm"
+        });
+
+        Assert.Equal("Name,Created,Value\nAlpha,20260707-1345,<null>\n", text);
+    }
+
+    [Fact]
+    public void Save_NoClobber_Throws_When_File_Exists()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "OfficeIMO.CSV.NoClobber." + Guid.NewGuid().ToString("N") + ".csv");
+        try
+        {
+            File.WriteAllText(path, "existing");
+            var document = new CsvDocument().WithHeader("Name").AddRow("Alpha");
+
+            Assert.Throws<IOException>(() => document.Save(path, new CsvSaveOptions { NoClobber = true }));
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void Save_Appends_To_Existing_File_When_Requested()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "OfficeIMO.CSV.Append." + Guid.NewGuid().ToString("N") + ".csv");
+        try
+        {
+            File.WriteAllText(path, "Name\nAlpha\n");
+            new CsvDocument()
+                .WithHeader("Name")
+                .AddRow("Beta")
+                .Save(path, new CsvSaveOptions { Append = true, IncludeHeader = false, NewLine = "\n" });
+
+            Assert.Equal("Name\nAlpha\nBeta\n", File.ReadAllText(path));
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/OfficeIMO.CSV.Tests/CsvMappingTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvMappingTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using OfficeIMO.CSV;
@@ -18,6 +19,11 @@ public class CsvMappingTests
         public string City { get; init; } = string.Empty;
     }
 
+    private sealed record EventRow
+    {
+        public DateTime Created { get; init; }
+    }
+
     [Fact]
     public void Maps_To_Typed_Record()
     {
@@ -36,5 +42,18 @@ public class CsvMappingTests
         Assert.Equal(2, people.Count);
         Assert.Equal("Dominika", people[1].Name);
         Assert.Equal(30, people[1].Age);
+    }
+
+    [Fact]
+    public void Map_Uses_Document_DateTime_Formats()
+    {
+        var doc = CsvDocument.Parse(
+            "Created\n07-Jul-2026\n",
+            new CsvLoadOptions { DateTimeFormats = new[] { "dd-MMM-yyyy" } });
+
+        var row = Assert.Single(doc.Map<EventRow>(map => map
+            .FromColumn<DateTime>("Created", (item, value) => item with { Created = value })));
+
+        Assert.Equal(new DateTime(2026, 7, 7), row.Created);
     }
 }

--- a/OfficeIMO.CSV.Tests/CsvSchemaTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvSchemaTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using OfficeIMO.CSV;
 using Xunit;
@@ -36,6 +37,45 @@ public class CsvSchemaTests
 
         var ex = Assert.Throws<CsvValidationException>(() => doc.ValidateOrThrow());
         Assert.Contains(ex.Errors, e => e.ColumnName == "Age");
+    }
+
+    [Fact]
+    public void InferSchema_Detects_Types_And_Required_Columns()
+    {
+        var doc = CsvDocument.Parse("Id,Amount,Active,Created,Note\n1,12.5,true,2026-07-07,Alpha\n2,13.7,false,2026-07-08,\n");
+
+        var schema = doc.InferSchema();
+
+        Assert.Equal(typeof(int), schema.Columns[0].DataType);
+        Assert.Equal(typeof(decimal), schema.Columns[1].DataType);
+        Assert.Equal(typeof(bool), schema.Columns[2].DataType);
+        Assert.Equal(typeof(DateTime), schema.Columns[3].DataType);
+        Assert.Equal(typeof(string), schema.Columns[4].DataType);
+        Assert.True(schema.Columns[0].IsRequired);
+        Assert.False(schema.Columns[4].IsRequired);
+    }
+
+    [Fact]
+    public void InferSchema_Uses_Configured_DateTime_Formats()
+    {
+        var doc = CsvDocument.Parse(
+            "Created\n07-Jul-2026\n",
+            new CsvLoadOptions { DateTimeFormats = new[] { "dd-MMM-yyyy" } });
+
+        var schema = doc.InferSchema();
+
+        Assert.Equal(typeof(DateTime), Assert.Single(schema.Columns).DataType);
+    }
+
+    [Fact]
+    public void EnsureInferredSchema_Attaches_Schema_For_Validation()
+    {
+        var doc = CsvDocument.Parse("Id,Name\n1,Alice\n2,Bob\n")
+            .EnsureInferredSchema();
+
+        doc.Validate(out var errors);
+
+        Assert.Empty(errors);
     }
 
     [Fact]

--- a/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
@@ -506,6 +506,31 @@ public class CsvStreamingTests
         Assert.Equal(new[] { "0:0:Alpha", "0:1:one", "0:2:1" }, fields);
     }
 
+    [Fact]
+    public void ReadFieldSpansFromText_ReadsEmptyFieldAfterQuotedField()
+    {
+        var fields = new List<string>();
+
+        CsvDocument.ReadFieldSpansFromText(
+            "Id,Name,Department,Region,Note,Empty,Value\n1,Alpha,Ops,EU,\"one\",,1\n",
+            (recordIndex, fieldIndex, value) => fields.Add($"{recordIndex}:{fieldIndex}:{value.ToString()}"),
+            new CsvLoadOptions { SkipInitialRecords = 1 });
+
+        Assert.Equal(
+            new[] { "0:0:1", "0:1:Alpha", "0:2:Ops", "0:3:EU", "0:4:one", "0:5:", "0:6:1" },
+            fields);
+    }
+
+    [Fact]
+    public void ReadFieldSpansFromText_RejectsUnexpectedCharacterAfterQuotedField()
+    {
+        Assert.Throws<CsvParseException>(() =>
+            CsvDocument.ReadFieldSpansFromText(
+                "Id,Name,Department,Region,Note,Value\n1,Alpha,Ops,EU,\"one\"x,1\n",
+                static (_, _, _) => { },
+                new CsvLoadOptions { SkipInitialRecords = 1 }));
+    }
+
 #endif
 
     [Fact]

--- a/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
@@ -441,6 +441,22 @@ public class CsvStreamingTests
     }
 
     [Fact]
+    public void ReadFieldSpansFromText_CanVisitEscapedQuotedFieldsWithoutCompacting()
+    {
+        var fields = new List<string>();
+        var visitor = new EscapedFieldCapturingVisitor(fields);
+
+        CsvDocument.ReadFieldSpansFromText(
+            "Name,Note\nAlpha,\"one \"\"quoted\"\" value\"\n",
+            ref visitor,
+            new CsvLoadOptions { SkipInitialRecords = 1 });
+
+        Assert.Equal(
+            new[] { "field:0:0:Alpha", "escaped:0:1:one \"\"quoted\"\" value:18" },
+            fields);
+    }
+
+    [Fact]
     public void ReadFieldSpansFromText_DoesNotEmitSkippedBlankOrWhitespaceOnlyLines()
     {
         var fields = new List<string>();
@@ -606,6 +622,27 @@ public class CsvStreamingTests
         public void EndRow(int rowIndex, int fieldCount)
         {
             _events.Add($"end:{rowIndex}:{fieldCount}");
+        }
+    }
+
+    private readonly struct EscapedFieldCapturingVisitor : ICsvFieldSpanVisitor
+    {
+        private readonly List<string> _events;
+
+        public EscapedFieldCapturingVisitor(List<string> events)
+        {
+            _events = events;
+        }
+
+        public void VisitField(int recordIndex, int fieldIndex, ReadOnlySpan<char> value)
+        {
+            _events.Add($"field:{recordIndex}:{fieldIndex}:{value.ToString()}");
+        }
+
+        public bool TryVisitEscapedField(int recordIndex, int fieldIndex, ReadOnlySpan<char> escapedValue, int unescapedLength)
+        {
+            _events.Add($"escaped:{recordIndex}:{fieldIndex}:{escapedValue.ToString()}:{unescapedLength}");
+            return true;
         }
     }
 #endif

--- a/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
@@ -191,6 +191,75 @@ public class CsvStreamingTests
     }
 
     [Fact]
+    public void ReadRowFieldSpansFromText_StreamsMultilineRows()
+    {
+        var events = new List<string>();
+        var visitor = new CapturingRowFieldSpanVisitor(events);
+
+        CsvDocument.ReadRowFieldSpansFromText("Name,Note\nAlpha,\"one\ntwo\"\n", ref visitor);
+
+        Assert.Equal(
+            new[]
+            {
+                "begin:0:Name|Note",
+                "field:0:0:Alpha",
+                "field:0:1:one\ntwo",
+                "end:0:2"
+            },
+            events);
+    }
+
+    [Fact]
+    public void ReadRowFieldSpansFromText_DetectDelimiterSkipsInitialRecordsAfterLeadingComments()
+    {
+        var events = new List<string>();
+        var visitor = new CapturingRowFieldSpanVisitor(events);
+
+        CsvDocument.ReadRowFieldSpansFromText(
+            "#note\nmetadata,with,commas\nName;Value\nAlpha;1\n",
+            ref visitor,
+            new CsvLoadOptions {
+                DetectDelimiter = true,
+                SkipInitialRecords = 1
+            });
+
+        Assert.Equal(
+            new[]
+            {
+                "begin:0:Name|Value",
+                "field:0:0:Alpha",
+                "field:0:1:1",
+                "end:0:2"
+            },
+            events);
+    }
+
+    [Fact]
+    public void ReadRowFieldSpansFromText_UsesExplicitHeader()
+    {
+        var events = new List<string>();
+        var visitor = new CapturingRowFieldSpanVisitor(events);
+
+        CsvDocument.ReadRowFieldSpansFromText(
+            "Alpha;1\n",
+            ref visitor,
+            new CsvLoadOptions {
+                Delimiter = ';',
+                Header = new[] { "Name", "Value" }
+            });
+
+        Assert.Equal(
+            new[]
+            {
+                "begin:0:Name|Value",
+                "field:0:0:Alpha",
+                "field:0:1:1",
+                "end:0:2"
+            },
+            events);
+    }
+
+    [Fact]
     public void ReadRowFieldSpans_DetectDelimiterSkipsInitialRecordsAfterLeadingComments()
     {
         var events = new List<string>();

--- a/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
@@ -210,6 +210,88 @@ public class CsvStreamingTests
     }
 
     [Fact]
+    public void ReadRowFieldSpansFromText_SkipsPreHeaderCommentsByDefault()
+    {
+        var events = new List<string>();
+        var visitor = new CapturingRowFieldSpanVisitor(events);
+
+        CsvDocument.ReadRowFieldSpansFromText("#Version: 1.0\nName,Value\nAlpha,1\n", ref visitor);
+
+        Assert.Equal(
+            new[]
+            {
+                "begin:0:Name|Value",
+                "field:0:0:Alpha",
+                "field:0:1:1",
+                "end:0:2"
+            },
+            events);
+    }
+
+    [Fact]
+    public void ReadRowFieldSpans_Appends_Static_Columns()
+    {
+        var events = new List<string>();
+        var visitor = new CapturingRowFieldSpanVisitor(events);
+        using var reader = new StringReader("Name,Value\nAlpha,1\n");
+
+        CsvDocument.ReadRowFieldSpans(
+            reader,
+            ref visitor,
+            new CsvLoadOptions {
+                StaticColumns = new Dictionary<string, object?> {
+                    ["SourceFile"] = "input.csv"
+                }
+            });
+
+        Assert.Equal(
+            new[]
+            {
+                "begin:0:Name|Value|SourceFile",
+                "field:0:0:Alpha",
+                "field:0:1:1",
+                "field:0:2:input.csv",
+                "end:0:3"
+            },
+            events);
+    }
+
+    [Fact]
+    public void ReadRowFieldSpans_ReadsGZipByExtension()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "OfficeIMO.CSV.RowFieldSpans." + Guid.NewGuid().ToString("N") + ".csv.gz");
+        try
+        {
+            new CsvDocument()
+                .WithHeader("Name", "Value")
+                .AddRow("Alpha", 1)
+                .Save(path, new CsvSaveOptions { NewLine = "\n" });
+
+            var events = new List<string>();
+            var visitor = new CapturingRowFieldSpanVisitor(events);
+
+            CsvDocument.ReadRowFieldSpans(path, ref visitor);
+
+            Assert.Equal(
+                new[]
+                {
+                    "begin:0:Name|Value",
+                    "field:0:0:Alpha",
+                    "field:0:1:1",
+                    "end:0:2"
+                },
+                events);
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
     public void ReadRowFieldSpansFromText_DetectDelimiterSkipsInitialRecordsAfterLeadingComments()
     {
         var events = new List<string>();
@@ -507,6 +589,19 @@ public class CsvStreamingTests
             new CsvLoadOptions { SkipInitialRecords = 1 });
 
         Assert.Equal(new[] { "0:0:Alpha", "0:1:one\n\"two\"" }, fields);
+    }
+
+    [Fact]
+    public void ReadFieldSpansFromText_PreservesFlexibleMultilineQuotedParsing()
+    {
+        var fields = new List<string>();
+
+        CsvDocument.ReadFieldSpansFromText(
+            "Name,Note,Value\nA,b\"c\nd\",E\n",
+            (recordIndex, fieldIndex, value) => fields.Add($"{recordIndex}:{fieldIndex}:{value.ToString()}"),
+            new CsvLoadOptions { SkipInitialRecords = 1 });
+
+        Assert.Equal(new[] { "0:0:A", "0:1:bc\nd", "0:2:E" }, fields);
     }
 
     [Fact]

--- a/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
@@ -167,6 +167,120 @@ public class CsvStreamingTests
 
 #if NET8_0_OR_GREATER
     [Fact]
+    public void ReadRowFieldSpans_StreamsHeaderAndRows()
+    {
+        var events = new List<string>();
+        var visitor = new CapturingRowFieldSpanVisitor(events);
+        using var reader = new StringReader("Name,Value\nA,1\nB,2\n");
+
+        CsvDocument.ReadRowFieldSpans(reader, ref visitor);
+
+        Assert.Equal(
+            new[]
+            {
+                "begin:0:Name|Value",
+                "field:0:0:A",
+                "field:0:1:1",
+                "end:0:2",
+                "begin:1:Name|Value",
+                "field:1:0:B",
+                "field:1:1:2",
+                "end:1:2"
+            },
+            events);
+    }
+
+    [Fact]
+    public void ReadRowFieldSpans_DetectDelimiterSkipsInitialRecordsAfterLeadingComments()
+    {
+        var events = new List<string>();
+        var visitor = new CapturingRowFieldSpanVisitor(events);
+        using var reader = new StringReader("#note\nmetadata,with,commas\nName;Value\nAlpha;1\n");
+
+        CsvDocument.ReadRowFieldSpans(
+            reader,
+            ref visitor,
+            new CsvLoadOptions {
+                DetectDelimiter = true,
+                SkipInitialRecords = 1
+            });
+
+        Assert.Equal(
+            new[]
+            {
+                "begin:0:Name|Value",
+                "field:0:0:Alpha",
+                "field:0:1:1",
+                "end:0:2"
+            },
+            events);
+    }
+
+    [Fact]
+    public void ReadRowFieldSpans_RecognizesW3CFieldsHeader()
+    {
+        var events = new List<string>();
+        var visitor = new CapturingRowFieldSpanVisitor(events);
+        using var reader = new StringReader("#Version: 1.0\n#Fields: date time cs-uri\n2026-01-01 00:00 /index.html\n");
+
+        CsvDocument.ReadRowFieldSpans(
+            reader,
+            ref visitor,
+            new CsvLoadOptions { Delimiter = ' ' });
+
+        Assert.Equal(
+            new[]
+            {
+                "begin:0:date|time|cs-uri",
+                "field:0:0:2026-01-01",
+                "field:0:1:00:00",
+                "field:0:2:/index.html",
+                "end:0:3"
+            },
+            events);
+    }
+
+    [Fact]
+    public void ReadRowFieldSpans_NoHeaderGeneratesDefaultHeaderAndPreservesFirstRow()
+    {
+        var events = new List<string>();
+        var visitor = new CapturingRowFieldSpanVisitor(events);
+        using var reader = new StringReader("A,1\nB,2\n");
+
+        CsvDocument.ReadRowFieldSpans(
+            reader,
+            ref visitor,
+            new CsvLoadOptions { HasHeaderRow = false });
+
+        Assert.Equal(
+            new[]
+            {
+                "begin:0:Column1|Column2",
+                "field:0:0:A",
+                "field:0:1:1",
+                "end:0:2",
+                "begin:1:Column1|Column2",
+                "field:1:0:B",
+                "field:1:1:2",
+                "end:1:2"
+            },
+            events);
+    }
+
+    [Fact]
+    public void ReadRowFieldSpans_StrictPolicyThrowsOnMismatchedDataRow()
+    {
+        var events = new List<string>();
+        var visitor = new CapturingRowFieldSpanVisitor(events);
+        using var reader = new StringReader("Name,Value\nAlpha,1,extra\n");
+
+        Assert.Throws<CsvException>(() => CsvDocument.ReadRowFieldSpans(
+            reader,
+            ref visitor,
+            new CsvLoadOptions { ColumnCountMismatchPolicy = CsvColumnCountMismatchPolicy.Strict }));
+    }
+
+    [Fact]
     public void ReadFieldSpans_CanSkipInitialRecords()
     {
         var fields = new List<string>();
@@ -212,6 +326,20 @@ public class CsvStreamingTests
             new CsvLoadOptions { SkipInitialRecords = 1 });
 
         Assert.Equal(new[] { "0:0:Alpha", "0:1:one\ntwo" }, fields);
+    }
+
+    [Fact]
+    public void ReadFieldSpans_UnescapesQuotedFieldsWithoutMaterializedFallback()
+    {
+        var fields = new List<string>();
+        using var reader = new StringReader("Name,Note\nAlpha,\"one \"\"quoted\"\" value\"\n");
+
+        CsvDocument.ReadFieldSpans(
+            reader,
+            (recordIndex, fieldIndex, value) => fields.Add($"{recordIndex}:{fieldIndex}:{value.ToString()}"),
+            new CsvLoadOptions { SkipInitialRecords = 1 });
+
+        Assert.Equal(new[] { "0:0:Alpha", "0:1:one \"quoted\" value" }, fields);
     }
 
     [Fact]
@@ -283,6 +411,85 @@ public class CsvStreamingTests
             new[] { "0:0:Name", "0:1:Value", "1:0:Alpha", "1:1:1" },
             fields);
     }
+
+    [Fact]
+    public void ReadFieldSpansFromText_CanSkipInitialRecords()
+    {
+        var fields = new List<string>();
+
+        CsvDocument.ReadFieldSpansFromText(
+            "metadata\nName,Value\nAlpha,1\n",
+            (recordIndex, fieldIndex, value) => fields.Add($"{recordIndex}:{fieldIndex}:{value.ToString()}"),
+            new CsvLoadOptions { SkipInitialRecords = 1 });
+
+        Assert.Equal(
+            new[] { "0:0:Name", "0:1:Value", "1:0:Alpha", "1:1:1" },
+            fields);
+    }
+
+    [Fact]
+    public void ReadFieldSpansFromText_ReadsQuotedMultilineAndEscapedFields()
+    {
+        var fields = new List<string>();
+
+        CsvDocument.ReadFieldSpansFromText(
+            "Name,Note\nAlpha,\"one\n\"\"two\"\"\"\n",
+            (recordIndex, fieldIndex, value) => fields.Add($"{recordIndex}:{fieldIndex}:{value.ToString()}"),
+            new CsvLoadOptions { SkipInitialRecords = 1 });
+
+        Assert.Equal(new[] { "0:0:Alpha", "0:1:one\n\"two\"" }, fields);
+    }
+
+    [Fact]
+    public void ReadFieldSpansFromText_DoesNotEmitSkippedBlankOrWhitespaceOnlyLines()
+    {
+        var fields = new List<string>();
+
+        CsvDocument.ReadFieldSpansFromText(
+            "Name,Value\n\n   \t  \nAlpha,1\n",
+            (recordIndex, fieldIndex, value) => fields.Add($"{recordIndex}:{fieldIndex}:{value.ToString()}"),
+            new CsvLoadOptions {
+                SkipInitialRecords = 1,
+                TrimWhitespace = true
+            });
+
+        Assert.Equal(new[] { "0:0:Alpha", "0:1:1" }, fields);
+    }
+
+    [Fact]
+    public void ReadFieldSpansFromText_DetectsDelimiterAfterSkippedMetadata()
+    {
+        var fields = new List<string>();
+
+        CsvDocument.ReadFieldSpansFromText(
+            "metadata,with,commas\nName;Value\nAlpha;1\n",
+            (recordIndex, fieldIndex, value) => fields.Add($"{recordIndex}:{fieldIndex}:{value.ToString()}"),
+            new CsvLoadOptions {
+                DetectDelimiter = true,
+                SkipInitialRecords = 1
+            });
+
+        Assert.Equal(
+            new[] { "0:0:Name", "0:1:Value", "1:0:Alpha", "1:1:1" },
+            fields);
+    }
+
+    [Fact]
+    public void ReadFieldSpansFromText_TrimWhitespaceAllowsSpacesAfterQuotedField()
+    {
+        var fields = new List<string>();
+
+        CsvDocument.ReadFieldSpansFromText(
+            "Name,Note,Value\nAlpha,\"one\"  ,1\n",
+            (recordIndex, fieldIndex, value) => fields.Add($"{recordIndex}:{fieldIndex}:{value.ToString()}"),
+            new CsvLoadOptions {
+                SkipInitialRecords = 1,
+                TrimWhitespace = true
+            });
+
+        Assert.Equal(new[] { "0:0:Alpha", "0:1:one", "0:2:1" }, fields);
+    }
+
 #endif
 
     [Fact]
@@ -375,4 +582,31 @@ public class CsvStreamingTests
             base.Dispose(disposing);
         }
     }
+
+#if NET8_0_OR_GREATER
+    private readonly struct CapturingRowFieldSpanVisitor : ICsvRowFieldSpanVisitor
+    {
+        private readonly List<string> _events;
+
+        public CapturingRowFieldSpanVisitor(List<string> events)
+        {
+            _events = events;
+        }
+
+        public void BeginRow(IReadOnlyList<string> header, int rowIndex)
+        {
+            _events.Add($"begin:{rowIndex}:{string.Join("|", header)}");
+        }
+
+        public void VisitField(int rowIndex, int fieldIndex, ReadOnlySpan<char> value)
+        {
+            _events.Add($"field:{rowIndex}:{fieldIndex}:{value.ToString()}");
+        }
+
+        public void EndRow(int rowIndex, int fieldCount)
+        {
+            _events.Add($"end:{rowIndex}:{fieldCount}");
+        }
+    }
+#endif
 }

--- a/OfficeIMO.CSV.Tests/OfficeIMO.CSV.Tests.csproj
+++ b/OfficeIMO.CSV.Tests/OfficeIMO.CSV.Tests.csproj
@@ -6,6 +6,11 @@
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
@@ -21,6 +26,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OfficeIMO.CSV/CsvDocument.Fields.cs
+++ b/OfficeIMO.CSV/CsvDocument.Fields.cs
@@ -67,6 +67,57 @@ public sealed partial class CsvDocument
     }
 
     /// <summary>
+    /// Reads CSV data rows from text in a single pass, applying header discovery while avoiding string materialization for unquoted data fields.
+    /// </summary>
+    /// <typeparam name="TVisitor">Struct visitor type receiving each data row and field.</typeparam>
+    /// <param name="text">Source CSV text.</param>
+    /// <param name="rowVisitor">Visitor receiving normalized headers and transient data field spans.</param>
+    /// <param name="options">Optional load settings.</param>
+    public static void ReadRowFieldSpansFromText<TVisitor>(string text, ref TVisitor rowVisitor, CsvLoadOptions? options = null)
+        where TVisitor : struct, ICsvRowFieldSpanVisitor
+    {
+        if (text == null)
+        {
+            throw new ArgumentNullException(nameof(text));
+        }
+
+        ReadRowFieldSpans(text.AsSpan(), ref rowVisitor, options);
+    }
+
+    /// <summary>
+    /// Reads CSV data rows from text in a single pass, applying header discovery while avoiding string materialization for unquoted data fields.
+    /// </summary>
+    /// <typeparam name="TVisitor">Struct visitor type receiving each data row and field.</typeparam>
+    /// <param name="text">Source CSV text.</param>
+    /// <param name="rowVisitor">Visitor receiving normalized headers and transient data field spans.</param>
+    /// <param name="options">Optional load settings.</param>
+    public static void ReadRowFieldSpans<TVisitor>(ReadOnlySpan<char> text, ref TVisitor rowVisitor, CsvLoadOptions? options = null)
+        where TVisitor : struct, ICsvRowFieldSpanVisitor
+    {
+        options ??= new CsvLoadOptions();
+        if (options.DetectDelimiter)
+        {
+            var sourceText = text.ToString();
+            var resolvedOptions = ResolveLoadOptions(() => new StringReader(sourceText), options);
+            using var bufferedReader = new StringReader(sourceText);
+            ReadRowFieldSpans(bufferedReader, ref rowVisitor, resolvedOptions);
+            return;
+        }
+
+        var explicitHeader = NormalizeExplicitHeader(options);
+        if (explicitHeader is not null)
+        {
+            ReadRowFieldSpansWithHeader(text, explicitHeader, options, GetInitialRecordsToSkip(options), ref rowVisitor);
+            return;
+        }
+
+        var visitor = new CsvHeaderAwareFieldSpanVisitor<TVisitor>(rowVisitor, options, firstRecordIsData: !options.HasHeaderRow);
+        CsvParser.ReadFieldSpans(text, options, GetInitialRecordsToSkip(options), ref visitor);
+        visitor.Complete();
+        rowVisitor = visitor.RowVisitor;
+    }
+
+    /// <summary>
     /// Reads CSV fields from a file in a single pass without materializing unquoted fields as strings.
     /// </summary>
     /// <param name="path">Source CSV path.</param>
@@ -217,6 +268,20 @@ public sealed partial class CsvDocument
     {
         var visitor = new CsvHeaderAwareFieldSpanVisitor<TVisitor>(rowVisitor, options, firstRecordIsData: false, header: header);
         CsvParser.ReadFieldSpans(reader, options, recordsToSkip, ref visitor);
+        visitor.Complete();
+        rowVisitor = visitor.RowVisitor;
+    }
+
+    private static void ReadRowFieldSpansWithHeader<TVisitor>(
+        ReadOnlySpan<char> text,
+        IReadOnlyList<string> header,
+        CsvLoadOptions options,
+        int recordsToSkip,
+        ref TVisitor rowVisitor)
+        where TVisitor : struct, ICsvRowFieldSpanVisitor
+    {
+        var visitor = new CsvHeaderAwareFieldSpanVisitor<TVisitor>(rowVisitor, options, firstRecordIsData: false, header: header);
+        CsvParser.ReadFieldSpans(text, options, recordsToSkip, ref visitor);
         visitor.Complete();
         rowVisitor = visitor.RowVisitor;
     }

--- a/OfficeIMO.CSV/CsvDocument.Fields.cs
+++ b/OfficeIMO.CSV/CsvDocument.Fields.cs
@@ -6,6 +6,67 @@ public sealed partial class CsvDocument
 {
 #if NET8_0_OR_GREATER
     /// <summary>
+    /// Reads CSV data rows from a file in a single pass, applying header discovery while avoiding string materialization for unquoted data fields.
+    /// </summary>
+    /// <typeparam name="TVisitor">Struct visitor type receiving each data row and field.</typeparam>
+    /// <param name="path">Source CSV path.</param>
+    /// <param name="rowVisitor">Visitor receiving normalized headers and transient data field spans.</param>
+    /// <param name="options">Optional load settings.</param>
+    public static void ReadRowFieldSpans<TVisitor>(string path, ref TVisitor rowVisitor, CsvLoadOptions? options = null)
+        where TVisitor : struct, ICsvRowFieldSpanVisitor
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            throw new ArgumentException("File path cannot be empty.", nameof(path));
+        }
+
+        options ??= new CsvLoadOptions();
+        var encoding = options.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        var readerFactory = () => new StreamReader(path, encoding, detectEncodingFromByteOrderMarks: true, bufferSize: FileBufferSize);
+        var resolvedOptions = ResolveLoadOptions(readerFactory, options);
+        using var reader = readerFactory();
+        ReadRowFieldSpans(reader, ref rowVisitor, resolvedOptions);
+    }
+
+    /// <summary>
+    /// Reads CSV data rows from a reader in a single pass, applying header discovery while avoiding string materialization for unquoted data fields.
+    /// </summary>
+    /// <typeparam name="TVisitor">Struct visitor type receiving each data row and field.</typeparam>
+    /// <param name="reader">Source text reader.</param>
+    /// <param name="rowVisitor">Visitor receiving normalized headers and transient data field spans.</param>
+    /// <param name="options">Optional load settings.</param>
+    public static void ReadRowFieldSpans<TVisitor>(TextReader reader, ref TVisitor rowVisitor, CsvLoadOptions? options = null)
+        where TVisitor : struct, ICsvRowFieldSpanVisitor
+    {
+        if (reader == null)
+        {
+            throw new ArgumentNullException(nameof(reader));
+        }
+
+        options ??= new CsvLoadOptions();
+        if (options.DetectDelimiter)
+        {
+            var text = reader.ReadToEnd();
+            var resolvedOptions = ResolveLoadOptions(() => new StringReader(text), options);
+            using var bufferedReader = new StringReader(text);
+            ReadRowFieldSpans(bufferedReader, ref rowVisitor, resolvedOptions);
+            return;
+        }
+
+        var explicitHeader = NormalizeExplicitHeader(options);
+        if (explicitHeader is not null)
+        {
+            ReadRowFieldSpansWithHeader(reader, explicitHeader, options, GetInitialRecordsToSkip(options), ref rowVisitor);
+            return;
+        }
+
+        var visitor = new CsvHeaderAwareFieldSpanVisitor<TVisitor>(rowVisitor, options, firstRecordIsData: !options.HasHeaderRow);
+        CsvParser.ReadFieldSpans(reader, options, GetInitialRecordsToSkip(options), ref visitor);
+        visitor.Complete();
+        rowVisitor = visitor.RowVisitor;
+    }
+
+    /// <summary>
     /// Reads CSV fields from a file in a single pass without materializing unquoted fields as strings.
     /// </summary>
     /// <param name="path">Source CSV path.</param>
@@ -87,6 +148,245 @@ public sealed partial class CsvDocument
         }
 
         CsvParser.ReadFieldSpans(reader, options, GetInitialRecordsToSkip(options), ref fieldVisitor);
+    }
+
+    /// <summary>
+    /// Reads CSV fields from text in a single pass without materializing unquoted fields as strings.
+    /// </summary>
+    /// <param name="text">Source CSV text.</param>
+    /// <param name="fieldAction">Action receiving each field as a transient span.</param>
+    /// <param name="options">Optional load settings. Header handling is not applied; records are emitted as parsed.</param>
+    public static void ReadFieldSpansFromText(string text, CsvFieldSpanAction fieldAction, CsvLoadOptions? options = null)
+    {
+        if (fieldAction == null)
+        {
+            throw new ArgumentNullException(nameof(fieldAction));
+        }
+
+        var visitor = new CsvFieldSpanActionVisitor(fieldAction);
+        ReadFieldSpansFromText(text, ref visitor, options);
+    }
+
+    /// <summary>
+    /// Reads CSV fields from text in a single pass without materializing unquoted fields as strings.
+    /// </summary>
+    /// <typeparam name="TVisitor">Struct visitor type receiving each field.</typeparam>
+    /// <param name="text">Source CSV text.</param>
+    /// <param name="fieldVisitor">Visitor receiving each field as a transient span.</param>
+    /// <param name="options">Optional load settings. Header handling is not applied; records are emitted as parsed.</param>
+    public static void ReadFieldSpansFromText<TVisitor>(string text, ref TVisitor fieldVisitor, CsvLoadOptions? options = null)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        if (text == null)
+        {
+            throw new ArgumentNullException(nameof(text));
+        }
+
+        ReadFieldSpans(text.AsSpan(), ref fieldVisitor, options);
+    }
+
+    /// <summary>
+    /// Reads CSV fields from text in a single pass without materializing unquoted fields as strings.
+    /// </summary>
+    /// <typeparam name="TVisitor">Struct visitor type receiving each field.</typeparam>
+    /// <param name="text">Source CSV text.</param>
+    /// <param name="fieldVisitor">Visitor receiving each field as a transient span.</param>
+    /// <param name="options">Optional load settings. Header handling is not applied; records are emitted as parsed.</param>
+    public static void ReadFieldSpans<TVisitor>(ReadOnlySpan<char> text, ref TVisitor fieldVisitor, CsvLoadOptions? options = null)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        options = CreateRawRecordOptions(options);
+        if (options.DetectDelimiter)
+        {
+            var sourceText = text.ToString();
+            var resolvedOptions = ResolveLoadOptions(() => new StringReader(sourceText), options, useHeaderDiscoveryForDelimiterDetection: false);
+            CsvParser.ReadFieldSpans(sourceText.AsSpan(), resolvedOptions, GetInitialRecordsToSkip(resolvedOptions), ref fieldVisitor);
+            return;
+        }
+
+        CsvParser.ReadFieldSpans(text, options, GetInitialRecordsToSkip(options), ref fieldVisitor);
+    }
+
+    private static void ReadRowFieldSpansWithHeader<TVisitor>(
+        TextReader reader,
+        IReadOnlyList<string> header,
+        CsvLoadOptions options,
+        int recordsToSkip,
+        ref TVisitor rowVisitor)
+        where TVisitor : struct, ICsvRowFieldSpanVisitor
+    {
+        var visitor = new CsvHeaderAwareFieldSpanVisitor<TVisitor>(rowVisitor, options, firstRecordIsData: false, header: header);
+        CsvParser.ReadFieldSpans(reader, options, recordsToSkip, ref visitor);
+        visitor.Complete();
+        rowVisitor = visitor.RowVisitor;
+    }
+
+    private struct CsvHeaderAwareFieldSpanVisitor<TVisitor> : ICsvFieldSpanVisitor
+        where TVisitor : struct, ICsvRowFieldSpanVisitor
+    {
+        private readonly CsvLoadOptions _options;
+        private readonly List<string> _headerFields;
+        private readonly bool _firstRecordIsData;
+        private TVisitor _rowVisitor;
+        private IReadOnlyList<string>? _header;
+        private int _currentRecordIndex;
+        private int _currentFieldCount;
+        private int _rowIndex;
+        private bool _hasCurrentRecord;
+        private bool _hasRowStarted;
+        private bool _needsHeader;
+
+        public CsvHeaderAwareFieldSpanVisitor(TVisitor rowVisitor, CsvLoadOptions options, bool firstRecordIsData, IReadOnlyList<string>? header = null)
+        {
+            _rowVisitor = rowVisitor;
+            _options = options;
+            _firstRecordIsData = firstRecordIsData;
+            _header = header;
+            _headerFields = new List<string>(64);
+            _currentRecordIndex = 0;
+            _currentFieldCount = 0;
+            _rowIndex = 0;
+            _hasCurrentRecord = false;
+            _hasRowStarted = false;
+            _needsHeader = header is null;
+        }
+
+        public readonly TVisitor RowVisitor => _rowVisitor;
+
+        public void VisitField(int recordIndex, int fieldIndex, ReadOnlySpan<char> value)
+        {
+            BeginOrAdvanceRecord(recordIndex);
+            _currentFieldCount++;
+            if (_needsHeader)
+            {
+                _headerFields.Add(value.ToString());
+                return;
+            }
+
+            var header = _header!;
+            if (!_hasRowStarted)
+            {
+                _rowVisitor.BeginRow(header, _rowIndex);
+                _hasRowStarted = true;
+            }
+
+            if (fieldIndex < header.Count)
+            {
+                _rowVisitor.VisitField(_rowIndex, fieldIndex, value);
+            }
+        }
+
+        public void VisitFieldValue(int recordIndex, int fieldIndex, string value)
+        {
+            BeginOrAdvanceRecord(recordIndex);
+            _currentFieldCount++;
+            if (_needsHeader)
+            {
+                _headerFields.Add(value);
+                return;
+            }
+
+            var header = _header!;
+            if (!_hasRowStarted)
+            {
+                _rowVisitor.BeginRow(header, _rowIndex);
+                _hasRowStarted = true;
+            }
+
+            if (fieldIndex < header.Count)
+            {
+                _rowVisitor.VisitFieldValue(_rowIndex, fieldIndex, value);
+            }
+        }
+
+        private void BeginOrAdvanceRecord(int recordIndex)
+        {
+            if (!_hasCurrentRecord)
+            {
+                BeginRecord(recordIndex);
+            }
+            else if (recordIndex != _currentRecordIndex)
+            {
+                CompleteCurrentRecord();
+                BeginRecord(recordIndex);
+            }
+        }
+
+        public void Complete()
+        {
+            if (_hasCurrentRecord)
+            {
+                CompleteCurrentRecord();
+            }
+        }
+
+        private void BeginRecord(int recordIndex)
+        {
+            _hasCurrentRecord = true;
+            _hasRowStarted = false;
+            _currentRecordIndex = recordIndex;
+            _currentFieldCount = 0;
+            if (_needsHeader)
+            {
+                _headerFields.Clear();
+            }
+        }
+
+        private void CompleteCurrentRecord()
+        {
+            if (_needsHeader)
+            {
+                if (_firstRecordIsData)
+                {
+                    _header = GenerateDefaultHeader(_headerFields.Count);
+                    _needsHeader = false;
+                    EmitBufferedFirstDataRow();
+                    return;
+                }
+
+                _header = ResolveHeader(_headerFields, _options);
+                _needsHeader = false;
+                return;
+            }
+
+            var header = _header!;
+            if (_options.ColumnCountMismatchPolicy == CsvColumnCountMismatchPolicy.Strict &&
+                _currentFieldCount != header.Count)
+            {
+                throw new CsvException($"Row contains {_currentFieldCount} values but header defines {header.Count} columns.");
+            }
+
+            if (!_hasRowStarted)
+            {
+                _rowVisitor.BeginRow(header, _rowIndex);
+            }
+
+            _rowVisitor.EndRow(_rowIndex, _currentFieldCount);
+            _rowIndex++;
+        }
+
+        private void EmitBufferedFirstDataRow()
+        {
+            var header = _header!;
+            _rowVisitor.BeginRow(header, _rowIndex);
+            for (var i = 0; i < _headerFields.Count; i++)
+            {
+                _rowVisitor.VisitFieldValue(_rowIndex, i, _headerFields[i]);
+            }
+
+            _rowVisitor.EndRow(_rowIndex, _headerFields.Count);
+            _rowIndex++;
+        }
+
+        private static IReadOnlyList<string> ResolveHeader(IReadOnlyList<string> fields, CsvLoadOptions options)
+        {
+            if (TryGetW3CFieldsHeader(fields, options, out var w3cHeader))
+            {
+                return w3cHeader;
+            }
+
+            return NormalizeParsedHeader(fields, options);
+        }
     }
 #endif
 }

--- a/OfficeIMO.CSV/CsvDocument.Fields.cs
+++ b/OfficeIMO.CSV/CsvDocument.Fields.cs
@@ -447,7 +447,7 @@ public sealed partial class CsvDocument
         {
             if (TryGetW3CFieldsHeader(fields, options, out var w3cHeader))
             {
-                return w3cHeader;
+                return NormalizeParsedHeader(w3cHeader, options);
             }
 
             return NormalizeParsedHeader(fields, options);

--- a/OfficeIMO.CSV/CsvDocument.Fields.cs
+++ b/OfficeIMO.CSV/CsvDocument.Fields.cs
@@ -21,8 +21,7 @@ public sealed partial class CsvDocument
         }
 
         options ??= new CsvLoadOptions();
-        var encoding = options.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-        var readerFactory = () => new StreamReader(path, encoding, detectEncodingFromByteOrderMarks: true, bufferSize: FileBufferSize);
+        var readerFactory = () => CsvFile.OpenTextReader(path, options, FileBufferSize);
         var resolvedOptions = ResolveLoadOptions(readerFactory, options);
         using var reader = readerFactory();
         ReadRowFieldSpans(reader, ref rowVisitor, resolvedOptions);
@@ -294,6 +293,7 @@ public sealed partial class CsvDocument
         private readonly bool _firstRecordIsData;
         private TVisitor _rowVisitor;
         private IReadOnlyList<string>? _header;
+        private int _sourceHeaderCount;
         private int _currentRecordIndex;
         private int _currentFieldCount;
         private int _rowIndex;
@@ -306,7 +306,8 @@ public sealed partial class CsvDocument
             _rowVisitor = rowVisitor;
             _options = options;
             _firstRecordIsData = firstRecordIsData;
-            _header = header;
+            _sourceHeaderCount = header?.Count ?? 0;
+            _header = header is null ? null : AppendStaticColumnsToHeader(header, options);
             _headerFields = new List<string>(64);
             _currentRecordIndex = 0;
             _currentFieldCount = 0;
@@ -329,13 +330,14 @@ public sealed partial class CsvDocument
             }
 
             var header = _header!;
+            var sourceHeaderCount = GetSourceHeaderCount();
             if (!_hasRowStarted)
             {
                 _rowVisitor.BeginRow(header, _rowIndex);
                 _hasRowStarted = true;
             }
 
-            if (fieldIndex < header.Count)
+            if (fieldIndex < sourceHeaderCount)
             {
                 _rowVisitor.VisitField(_rowIndex, fieldIndex, value);
             }
@@ -352,13 +354,14 @@ public sealed partial class CsvDocument
             }
 
             var header = _header!;
+            var sourceHeaderCount = GetSourceHeaderCount();
             if (!_hasRowStarted)
             {
                 _rowVisitor.BeginRow(header, _rowIndex);
                 _hasRowStarted = true;
             }
 
-            if (fieldIndex < header.Count)
+            if (fieldIndex < sourceHeaderCount)
             {
                 _rowVisitor.VisitFieldValue(_rowIndex, fieldIndex, value);
             }
@@ -409,16 +412,17 @@ public sealed partial class CsvDocument
                     return;
                 }
 
-                _header = ResolveHeader(_headerFields, _options);
+                ResolveCurrentHeader();
                 _needsHeader = false;
                 return;
             }
 
             var header = _header!;
+            var sourceHeaderCount = GetSourceHeaderCount();
             if (_options.ColumnCountMismatchPolicy == CsvColumnCountMismatchPolicy.Strict &&
-                _currentFieldCount != header.Count)
+                _currentFieldCount != sourceHeaderCount)
             {
-                throw new CsvException($"Row contains {_currentFieldCount} values but header defines {header.Count} columns.");
+                throw new CsvException($"Row contains {_currentFieldCount} values but header defines {sourceHeaderCount} columns.");
             }
 
             if (!_hasRowStarted)
@@ -426,12 +430,16 @@ public sealed partial class CsvDocument
                 _rowVisitor.BeginRow(header, _rowIndex);
             }
 
-            _rowVisitor.EndRow(_rowIndex, _currentFieldCount);
+            var emittedFieldCount = AppendStaticFields(sourceHeaderCount);
+            _rowVisitor.EndRow(_rowIndex, emittedFieldCount);
             _rowIndex++;
         }
 
         private void EmitBufferedFirstDataRow()
         {
+            var sourceHeader = GenerateDefaultHeader(_headerFields.Count);
+            _sourceHeaderCount = sourceHeader.Count;
+            _header = AppendStaticColumnsToHeader(sourceHeader, _options);
             var header = _header!;
             _rowVisitor.BeginRow(header, _rowIndex);
             for (var i = 0; i < _headerFields.Count; i++)
@@ -439,11 +447,39 @@ public sealed partial class CsvDocument
                 _rowVisitor.VisitFieldValue(_rowIndex, i, _headerFields[i]);
             }
 
-            _rowVisitor.EndRow(_rowIndex, _headerFields.Count);
+            var emittedFieldCount = AppendStaticFields(_headerFields.Count);
+            _rowVisitor.EndRow(_rowIndex, emittedFieldCount);
             _rowIndex++;
         }
 
-        private static IReadOnlyList<string> ResolveHeader(IReadOnlyList<string> fields, CsvLoadOptions options)
+        private void ResolveCurrentHeader()
+        {
+            var sourceHeader = ResolveSourceHeader(_headerFields, _options);
+            _sourceHeaderCount = sourceHeader.Count;
+            _header = AppendStaticColumnsToHeader(sourceHeader, _options);
+        }
+
+        private int AppendStaticFields(int sourceHeaderCount)
+        {
+            var emittedFieldCount = _currentFieldCount;
+            if (_options.StaticColumns is null || _options.StaticColumns.Count == 0)
+            {
+                return emittedFieldCount;
+            }
+
+            var fieldIndex = sourceHeaderCount;
+            foreach (var staticColumn in _options.StaticColumns)
+            {
+                _rowVisitor.VisitFieldValue(_rowIndex, fieldIndex++, Convert.ToString(staticColumn.Value, _options.Culture) ?? string.Empty);
+                emittedFieldCount++;
+            }
+
+            return emittedFieldCount;
+        }
+
+        private int GetSourceHeaderCount() => _sourceHeaderCount == 0 ? _header!.Count : _sourceHeaderCount;
+
+        private static IReadOnlyList<string> ResolveSourceHeader(IReadOnlyList<string> fields, CsvLoadOptions options)
         {
             if (TryGetW3CFieldsHeader(fields, options, out var w3cHeader))
             {

--- a/OfficeIMO.CSV/CsvDocument.Loading.cs
+++ b/OfficeIMO.CSV/CsvDocument.Loading.cs
@@ -191,6 +191,35 @@ public sealed partial class CsvDocument
         IReadOnlyList<string>? header = null;
         if (options.HasHeaderRow)
         {
+            if (!options.SkipCommentRows)
+            {
+                CsvParser.ReadRecordsReusableWithMetadataUntilAccepted(
+                    reader,
+                    options,
+                    record =>
+                    {
+                        var isW3CFieldsHeader = TryGetW3CFieldsHeader(record.Values, options, out var w3cHeader);
+                        if (options.SkipCommentRowsBeforeHeader && IsCommentRecord(record, options) && !isW3CFieldsHeader)
+                        {
+                            return false;
+                        }
+
+                        if (recordsToSkip > 0)
+                        {
+                            recordsToSkip--;
+                            return false;
+                        }
+
+                        header = isW3CFieldsHeader
+                            ? w3cHeader
+                            : NormalizeParsedHeader(record.Values, options);
+                        return true;
+                    },
+                    values => InvokeRowAction(rowAction, header!, values, options.ColumnCountMismatchPolicy));
+
+                return;
+            }
+
             CsvParser.ReadRecordsReusableWithMetadata(reader, options, record =>
             {
                 if (header is null)

--- a/OfficeIMO.CSV/CsvDocument.Loading.cs
+++ b/OfficeIMO.CSV/CsvDocument.Loading.cs
@@ -100,7 +100,7 @@ public sealed partial class CsvDocument
         {
             ReadRecordsSkippingInitial(reader, options, recordsToSkip, record =>
             {
-                InvokeRowAction(rowAction, explicitHeader, record, options.ColumnCountMismatchPolicy);
+                InvokeRowAction(rowAction, AppendStaticColumnsToHeader(explicitHeader, options), record, options);
             });
 
             return;
@@ -127,15 +127,15 @@ public sealed partial class CsvDocument
 
                     if (isW3CFieldsHeader)
                     {
-                        header = w3cHeader;
+                        header = AppendStaticColumnsToHeader(NormalizeParsedHeader(w3cHeader, options), options);
                         return;
                     }
 
-                    header = NormalizeParsedHeader(record.Values, options);
+                    header = AppendStaticColumnsToHeader(NormalizeParsedHeader(record.Values, options), options);
                     return;
                 }
 
-                InvokeRowAction(rowAction, header, record.Values, options.ColumnCountMismatchPolicy);
+                InvokeRowAction(rowAction, header, record.Values, options);
             });
 
             return;
@@ -143,8 +143,8 @@ public sealed partial class CsvDocument
 
         ReadRecordsSkippingInitial(reader, options, recordsToSkip, record =>
         {
-            header ??= GenerateDefaultHeader(record.Length);
-            InvokeRowAction(rowAction, header, record, options.ColumnCountMismatchPolicy);
+            header ??= AppendStaticColumnsToHeader(GenerateDefaultHeader(record.Length), options);
+            InvokeRowAction(rowAction, header, record, options);
         });
     }
 
@@ -182,7 +182,7 @@ public sealed partial class CsvDocument
         {
             ReadRecordsReusableSkippingInitial(reader, options, recordsToSkip, record =>
             {
-                InvokeRowAction(rowAction, explicitHeader, record, options.ColumnCountMismatchPolicy);
+                InvokeRowAction(rowAction, AppendStaticColumnsToHeader(explicitHeader, options), record, options);
             });
 
             return;
@@ -211,11 +211,11 @@ public sealed partial class CsvDocument
                         }
 
                         header = isW3CFieldsHeader
-                            ? w3cHeader
-                            : NormalizeParsedHeader(record.Values, options);
+                            ? AppendStaticColumnsToHeader(NormalizeParsedHeader(w3cHeader, options), options)
+                            : AppendStaticColumnsToHeader(NormalizeParsedHeader(record.Values, options), options);
                         return true;
                     },
-                    values => InvokeRowAction(rowAction, header!, values, options.ColumnCountMismatchPolicy));
+                    values => InvokeRowAction(rowAction, header!, values, options));
 
                 return;
             }
@@ -238,15 +238,15 @@ public sealed partial class CsvDocument
 
                     if (isW3CFieldsHeader)
                     {
-                        header = w3cHeader;
+                        header = AppendStaticColumnsToHeader(NormalizeParsedHeader(w3cHeader, options), options);
                         return;
                     }
 
-                    header = NormalizeParsedHeader(record.Values, options);
+                    header = AppendStaticColumnsToHeader(NormalizeParsedHeader(record.Values, options), options);
                     return;
                 }
 
-                InvokeRowAction(rowAction, header, record.Values, options.ColumnCountMismatchPolicy);
+                InvokeRowAction(rowAction, header, record.Values, options);
             });
 
             return;
@@ -254,8 +254,8 @@ public sealed partial class CsvDocument
 
         ReadRecordsReusableSkippingInitial(reader, options, recordsToSkip, record =>
         {
-            header ??= GenerateDefaultHeader(record.Count);
-            InvokeRowAction(rowAction, header, record, options.ColumnCountMismatchPolicy);
+            header ??= AppendStaticColumnsToHeader(GenerateDefaultHeader(record.Count), options);
+            InvokeRowAction(rowAction, header, record, options);
         });
     }
 
@@ -321,12 +321,12 @@ public sealed partial class CsvDocument
     {
         options = ResolveLoadOptions(readerFactory, options);
         var initialRecordsToSkip = GetInitialRecordsToSkip(options);
-        var document = new CsvDocument(options.Mode, options.Delimiter, options.Culture, encoding, options.ColumnCountMismatchPolicy);
+        var document = new CsvDocument(options.Mode, options.Delimiter, options.Culture, encoding, options.ColumnCountMismatchPolicy, options.DateTimeFormats);
 
         var explicitHeader = NormalizeExplicitHeader(options);
         if (explicitHeader is not null)
         {
-            document.SetHeader(explicitHeader);
+            document.SetHeader(AppendStaticColumnsToHeader(explicitHeader, options));
             if (options.Mode == CsvLoadMode.InMemory)
             {
                 using var explicitHeaderReader = readerFactory();
@@ -339,12 +339,12 @@ public sealed partial class CsvDocument
                         continue;
                     }
 
-                    document.AddParsedRowInternal(record, options.ColumnCountMismatchPolicy);
+                    document.AddParsedRowInternal(record, options);
                 }
             }
             else
             {
-                document._streamingSource = new CsvStreamingSource(readerFactory, options, skipRecordCount: initialRecordsToSkip);
+                document._streamingSource = new CsvStreamingSource(readerFactory, options, skipRecordCount: initialRecordsToSkip, document._header.Count);
             }
 
             return document;
@@ -366,12 +366,12 @@ public sealed partial class CsvDocument
             {
                 while (enumerator.MoveNext())
                 {
-                    document.AddParsedRowInternal(enumerator.Current.Values, options.ColumnCountMismatchPolicy);
+                    document.AddParsedRowInternal(enumerator.Current.Values, options);
                 }
             }
             else
             {
-                document._streamingSource = new CsvStreamingSource(readerFactory, options, consumedRecordCount);
+                document._streamingSource = new CsvStreamingSource(readerFactory, options, consumedRecordCount, document._header.Count);
             }
 
             return document;
@@ -389,19 +389,19 @@ public sealed partial class CsvDocument
         }
 
         var firstRecord = enumerator.Current;
-        document.SetHeader(GenerateDefaultHeader(firstRecord.Values.Count));
+        document.SetHeader(AppendStaticColumnsToHeader(GenerateDefaultHeader(firstRecord.Values.Count), options));
 
         if (options.Mode == CsvLoadMode.InMemory)
         {
-            document.AddParsedRowInternal(firstRecord.Values, options.ColumnCountMismatchPolicy);
+            document.AddParsedRowInternal(firstRecord.Values, options);
             while (enumerator.MoveNext())
             {
-                document.AddParsedRowInternal(enumerator.Current.Values, options.ColumnCountMismatchPolicy);
+                document.AddParsedRowInternal(enumerator.Current.Values, options);
             }
         }
         else
         {
-            document._streamingSource = new CsvStreamingSource(readerFactory, options, skipRecordCount: initialRecordsToSkip);
+            document._streamingSource = new CsvStreamingSource(readerFactory, options, skipRecordCount: initialRecordsToSkip, document._header.Count);
         }
 
         return document;
@@ -428,9 +428,9 @@ public sealed partial class CsvDocument
         Action<IReadOnlyList<string>, IReadOnlyList<string>> rowAction,
         IReadOnlyList<string> header,
         IReadOnlyList<string> values,
-        CsvColumnCountMismatchPolicy policy)
+        CsvLoadOptions options)
     {
-        rowAction(header, AlignParsedStringValues(values, header.Count, policy));
+        rowAction(header, BuildParsedStringValues(values, header.Count, options));
     }
 
     private static string[]? NormalizeExplicitHeader(CsvLoadOptions options)
@@ -481,11 +481,11 @@ public sealed partial class CsvDocument
 
             if (isW3CFieldsHeader)
             {
-                header = w3cHeader;
+                header = AppendStaticColumnsToHeader(NormalizeParsedHeader(w3cHeader, options), options);
                 return true;
             }
 
-            header = NormalizeParsedHeader(record.Values, options);
+            header = AppendStaticColumnsToHeader(NormalizeParsedHeader(record.Values, options), options);
             return true;
         }
 

--- a/OfficeIMO.CSV/CsvDocument.Rows.cs
+++ b/OfficeIMO.CSV/CsvDocument.Rows.cs
@@ -34,17 +34,18 @@ public sealed partial class CsvDocument
 
     private static IReadOnlyList<string> NormalizeParsedHeader(IReadOnlyList<string> header, CsvLoadOptions options)
     {
-        if (!options.GenerateMissingHeaderNames)
+        if (!options.GenerateMissingHeaderNames && options.DuplicateHeaderBehavior == CsvDuplicateHeaderBehavior.Preserve)
         {
             return header.ToArray();
         }
 
         var result = new string[header.Count];
         var generated = 1;
+        var assigned = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < header.Count; i++)
         {
             var name = header[i];
-            if (string.IsNullOrEmpty(name))
+            if (string.IsNullOrEmpty(name) && options.GenerateMissingHeaderNames)
             {
                 do
                 {
@@ -53,10 +54,114 @@ public sealed partial class CsvDocument
                 while (header.Contains(name, StringComparer.OrdinalIgnoreCase) || result.Contains(name, StringComparer.OrdinalIgnoreCase));
             }
 
+            if (!string.IsNullOrEmpty(name) && !assigned.Add(name))
+            {
+                name = options.DuplicateHeaderBehavior switch
+                {
+                    CsvDuplicateHeaderBehavior.Preserve => name,
+                    CsvDuplicateHeaderBehavior.Rename => CreateUniqueDuplicateHeaderName(name, header, result),
+                    CsvDuplicateHeaderBehavior.Throw => throw new CsvException($"CSV header contains duplicate column name '{name}'."),
+                    _ => throw new ArgumentOutOfRangeException(nameof(options), options.DuplicateHeaderBehavior, "Unsupported duplicate CSV header behavior.")
+                };
+
+                assigned.Add(name);
+            }
+
             result[i] = name;
         }
 
         return result;
+    }
+
+    private static string CreateUniqueDuplicateHeaderName(string name, IReadOnlyList<string> sourceHeader, IReadOnlyList<string?> assignedHeader)
+    {
+        var suffix = 2;
+        string candidate;
+        do
+        {
+            candidate = $"{name}_{suffix++}";
+        }
+        while (sourceHeader.Contains(candidate, StringComparer.OrdinalIgnoreCase) ||
+               assignedHeader.Contains(candidate, StringComparer.OrdinalIgnoreCase));
+
+        return candidate;
+    }
+
+    internal static IReadOnlyList<string> AppendStaticColumnsToHeader(IReadOnlyList<string> header, CsvLoadOptions options)
+    {
+        if (options.StaticColumns is null || options.StaticColumns.Count == 0)
+        {
+            return header;
+        }
+
+        var combined = new string[header.Count + options.StaticColumns.Count];
+        for (var i = 0; i < header.Count; i++)
+        {
+            combined[i] = header[i];
+        }
+
+        var index = header.Count;
+        foreach (var staticColumn in options.StaticColumns)
+        {
+            combined[index++] = staticColumn.Key;
+        }
+
+        return NormalizeParsedHeader(combined, options);
+    }
+
+    internal static IReadOnlyList<string> BuildParsedStringValues(IReadOnlyList<string> values, int headerCount, CsvLoadOptions options)
+    {
+        var staticCount = options.StaticColumns?.Count ?? 0;
+        var sourceHeaderCount = headerCount - staticCount;
+        var aligned = AlignParsedStringValues(values, sourceHeaderCount, options.ColumnCountMismatchPolicy);
+        if (staticCount == 0)
+        {
+            return aligned;
+        }
+
+        var result = new string[headerCount];
+        for (var i = 0; i < aligned.Count; i++)
+        {
+            result[i] = aligned[i];
+        }
+
+        var index = aligned.Count;
+        foreach (var staticColumn in options.StaticColumns!)
+        {
+            result[index++] = Convert.ToString(staticColumn.Value, options.Culture) ?? string.Empty;
+        }
+
+        return result;
+    }
+
+    internal static object?[] BuildParsedObjectValues(IReadOnlyList<string> values, int headerCount, CsvLoadOptions options)
+    {
+        var staticCount = options.StaticColumns?.Count ?? 0;
+        var sourceHeaderCount = headerCount - staticCount;
+        var alignedStrings = AlignParsedStringValues(values, sourceHeaderCount, options.ColumnCountMismatchPolicy);
+        var aligned = new object?[headerCount];
+        for (var i = 0; i < alignedStrings.Count; i++)
+        {
+            aligned[i] = NormalizeLoadedValue(alignedStrings[i], options);
+        }
+
+        if (staticCount > 0)
+        {
+            var index = alignedStrings.Count;
+            foreach (var staticColumn in options.StaticColumns!)
+            {
+                aligned[index++] = staticColumn.Value;
+            }
+        }
+
+        return aligned;
+    }
+
+    private static object? NormalizeLoadedValue(string value, CsvLoadOptions options)
+    {
+        return options.NullValue is not null && string.Equals(value, options.NullValue, StringComparison.Ordinal)
+            ? null
+            : value;
     }
 
     private static IReadOnlyList<string> AlignParsedStringValues(IReadOnlyList<string> values, int headerCount, CsvColumnCountMismatchPolicy policy)

--- a/OfficeIMO.CSV/CsvDocument.SchemaInference.cs
+++ b/OfficeIMO.CSV/CsvDocument.SchemaInference.cs
@@ -1,0 +1,181 @@
+#nullable enable
+
+using System.Globalization;
+
+namespace OfficeIMO.CSV;
+
+public sealed partial class CsvDocument
+{
+    /// <summary>
+    /// Infers a schema from the document header and sampled row values.
+    /// </summary>
+    /// <param name="sampleSize">Maximum number of rows to inspect. Defaults to 1000.</param>
+    /// <returns>A schema containing one inferred column for each header field.</returns>
+    public CsvSchema InferSchema(int sampleSize = 1000)
+    {
+        if (sampleSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sampleSize), "Sample size must be greater than zero.");
+        }
+
+        var columns = new InferredColumn[_header.Count];
+        for (var i = 0; i < _header.Count; i++)
+        {
+            columns[i] = new InferredColumn(_header[i]);
+        }
+
+        var sampledRows = 0;
+        foreach (var row in AsEnumerable())
+        {
+            if (sampledRows >= sampleSize)
+            {
+                break;
+            }
+
+            for (var i = 0; i < columns.Length; i++)
+            {
+                var value = i < row.FieldCount ? row[i] : null;
+                columns[i].Observe(value, _culture, _dateTimeFormats);
+            }
+
+            sampledRows++;
+        }
+
+        var schemaColumns = new List<CsvSchemaColumn>(columns.Length);
+        foreach (var column in columns)
+        {
+            schemaColumns.Add(column.ToSchemaColumn(sampledRows));
+        }
+
+        return new CsvSchema(schemaColumns);
+    }
+
+    /// <summary>
+    /// Infers and attaches a schema to the document so subsequent validation uses the sampled structure.
+    /// </summary>
+    /// <param name="sampleSize">Maximum number of rows to inspect. Defaults to 1000.</param>
+    /// <returns>The current document.</returns>
+    public CsvDocument EnsureInferredSchema(int sampleSize = 1000)
+    {
+        _schema = InferSchema(sampleSize);
+        return this;
+    }
+
+    private sealed class InferredColumn
+    {
+        private bool _hasMissingValue;
+        private bool _hasObservedValue;
+        private bool _canInt32 = true;
+        private bool _canInt64 = true;
+        private bool _canDecimal = true;
+        private bool _canDouble = true;
+        private bool _canBoolean = true;
+        private bool _canDateTime = true;
+
+        public InferredColumn(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+
+        public void Observe(object? value, CultureInfo culture, IReadOnlyList<string>? dateTimeFormats)
+        {
+            if (value is null || value is string { Length: 0 })
+            {
+                _hasMissingValue = true;
+                return;
+            }
+
+            _hasObservedValue = true;
+            if (value is string text)
+            {
+                ObserveString(text, culture, dateTimeFormats);
+                return;
+            }
+
+            ObserveTyped(value);
+        }
+
+        public CsvSchemaColumn ToSchemaColumn(int sampledRows)
+        {
+            return new CsvSchemaColumn(Name)
+            {
+                DataType = ResolveDataType(),
+                IsRequired = sampledRows > 0 && _hasObservedValue && !_hasMissingValue
+            };
+        }
+
+        private void ObserveString(string text, CultureInfo culture, IReadOnlyList<string>? dateTimeFormats)
+        {
+            _canInt32 &= int.TryParse(text, NumberStyles.Any, culture, out _);
+            _canInt64 &= long.TryParse(text, NumberStyles.Any, culture, out _);
+            _canDecimal &= decimal.TryParse(text, NumberStyles.Any, culture, out _);
+            _canDouble &= double.TryParse(text, NumberStyles.Any, culture, out _);
+            _canBoolean &= IsBooleanText(text);
+            _canDateTime &= TryParseDateTime(text, culture, dateTimeFormats);
+        }
+
+        private void ObserveTyped(object value)
+        {
+            var type = Nullable.GetUnderlyingType(value.GetType()) ?? value.GetType();
+
+            _canInt32 &= type == typeof(byte) || type == typeof(short) || type == typeof(int);
+            _canInt64 &= _canInt32 || type == typeof(long);
+            _canDecimal &= _canInt64 || type == typeof(decimal);
+            _canDouble &= _canDecimal || type == typeof(float) || type == typeof(double);
+            _canBoolean &= type == typeof(bool);
+            _canDateTime &= type == typeof(DateTime);
+        }
+
+        private Type ResolveDataType()
+        {
+            if (!_hasObservedValue)
+            {
+                return typeof(string);
+            }
+
+            if (_canInt32)
+            {
+                return typeof(int);
+            }
+
+            if (_canInt64)
+            {
+                return typeof(long);
+            }
+
+            if (_canDecimal)
+            {
+                return typeof(decimal);
+            }
+
+            if (_canDouble)
+            {
+                return typeof(double);
+            }
+
+            if (_canBoolean)
+            {
+                return typeof(bool);
+            }
+
+            return _canDateTime ? typeof(DateTime) : typeof(string);
+        }
+
+        private static bool IsBooleanText(string text) =>
+            string.Equals(text, "true", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(text, "false", StringComparison.OrdinalIgnoreCase);
+
+        private static bool TryParseDateTime(string text, CultureInfo culture, IReadOnlyList<string>? dateTimeFormats)
+        {
+            if (dateTimeFormats is { Count: > 0 } &&
+                DateTime.TryParseExact(text, dateTimeFormats.ToArray(), culture, DateTimeStyles.None, out _))
+            {
+                return true;
+            }
+
+            return DateTime.TryParse(text, culture, DateTimeStyles.None, out _);
+        }
+    }
+}

--- a/OfficeIMO.CSV/CsvDocument.cs
+++ b/OfficeIMO.CSV/CsvDocument.cs
@@ -21,6 +21,7 @@ public sealed partial class CsvDocument
     private CultureInfo _culture;
     private Encoding _encoding;
     private CsvColumnCountMismatchPolicy _columnCountMismatchPolicy;
+    private string[]? _dateTimeFormats;
     private CsvSchema? _schema;
 
     /// <summary>
@@ -35,13 +36,14 @@ public sealed partial class CsvDocument
         _columnCountMismatchPolicy = CsvColumnCountMismatchPolicy.Strict;
     }
 
-    private CsvDocument(CsvLoadMode mode, char delimiter, CultureInfo culture, Encoding encoding, CsvColumnCountMismatchPolicy columnCountMismatchPolicy)
+    private CsvDocument(CsvLoadMode mode, char delimiter, CultureInfo culture, Encoding encoding, CsvColumnCountMismatchPolicy columnCountMismatchPolicy, string[]? dateTimeFormats = null)
     {
         _mode = mode;
         _delimiter = delimiter;
         _culture = culture;
         _encoding = encoding;
         _columnCountMismatchPolicy = columnCountMismatchPolicy;
+        _dateTimeFormats = dateTimeFormats;
     }
 
     /// <summary>
@@ -163,10 +165,22 @@ public sealed partial class CsvDocument
 
         options ??= new CsvSaveOptions();
         var fullPath = Path.GetFullPath(path);
+        if (options.NoClobber && File.Exists(fullPath))
+        {
+            throw new IOException($"The file '{fullPath}' already exists.");
+        }
+
         var directory = Path.GetDirectoryName(fullPath);
         if (!string.IsNullOrEmpty(directory))
         {
             Directory.CreateDirectory(directory);
+        }
+
+        if (options.Append)
+        {
+            using var appendWriter = CsvFile.CreateTextWriter(fullPath, options, append: true, bufferSize: FileBufferSize);
+            WriteObjects(appendWriter, items, options);
+            return;
         }
 
         var temporaryPath = Path.Combine(
@@ -221,6 +235,11 @@ public sealed partial class CsvDocument
     public Encoding Encoding => _encoding;
 
     /// <summary>
+    /// Gets the configured date/time formats used by typed conversions.
+    /// </summary>
+    public IReadOnlyList<string>? DateTimeFormats => _dateTimeFormats;
+
+    /// <summary>
     /// Gets the load mode of the document.
     /// </summary>
     public CsvLoadMode Mode => _mode;
@@ -237,7 +256,13 @@ public sealed partial class CsvDocument
             Encoding = _encoding
         };
 
-        using var writer = CsvFile.CreateTextWriter(path, options, append: false, bufferSize: FileBufferSize);
+        var fullPath = Path.GetFullPath(path);
+        if (options.NoClobber && File.Exists(fullPath))
+        {
+            throw new IOException($"The file '{fullPath}' already exists.");
+        }
+
+        using var writer = CsvFile.CreateTextWriter(fullPath, options, append: options.Append, bufferSize: FileBufferSize);
         CsvWriter.Write(writer, this, options);
         return this;
     }
@@ -322,6 +347,20 @@ public sealed partial class CsvDocument
     public CsvDocument WithCulture(CultureInfo culture)
     {
         _culture = culture ?? throw new ArgumentNullException(nameof(culture));
+        return this;
+    }
+
+    /// <summary>
+    /// Sets additional date/time formats used by typed row conversion and schema validation.
+    /// </summary>
+    public CsvDocument WithDateTimeFormats(params string[] formats)
+    {
+        if (formats == null)
+        {
+            throw new ArgumentNullException(nameof(formats));
+        }
+
+        _dateTimeFormats = formats.ToArray();
         return this;
     }
 
@@ -564,16 +603,9 @@ public sealed partial class CsvDocument
         _rows.Add(new CsvRow(this, aligned));
     }
 
-    private void AddParsedRowInternal(IReadOnlyList<string> values, CsvColumnCountMismatchPolicy policy)
+    private void AddParsedRowInternal(IReadOnlyList<string> values, CsvLoadOptions options)
     {
-        var alignedStrings = AlignParsedStringValues(values, _header.Count, policy);
-        var aligned = new object?[alignedStrings.Count];
-        for (var i = 0; i < alignedStrings.Count; i++)
-        {
-            aligned[i] = alignedStrings[i];
-        }
-
-        _rows.Add(new CsvRow(this, aligned));
+        _rows.Add(new CsvRow(this, BuildParsedObjectValues(values, _header.Count, options)));
     }
 
     private void SetHeader(IEnumerable<string> headers)

--- a/OfficeIMO.CSV/CsvDuplicateHeaderBehavior.cs
+++ b/OfficeIMO.CSV/CsvDuplicateHeaderBehavior.cs
@@ -1,0 +1,18 @@
+#nullable enable
+
+namespace OfficeIMO.CSV;
+
+/// <summary>
+/// Controls how duplicate CSV header names are handled when parsing input.
+/// </summary>
+public enum CsvDuplicateHeaderBehavior
+{
+    /// <summary>Preserve duplicate header names exactly as they appear in the CSV source.</summary>
+    Preserve,
+
+    /// <summary>Rename duplicate header names by appending a numeric suffix such as <c>_2</c>.</summary>
+    Rename,
+
+    /// <summary>Throw a <see cref="CsvException"/> when a duplicate header name is encountered.</summary>
+    Throw
+}

--- a/OfficeIMO.CSV/CsvLineReader.FieldSpans.Quoted.cs
+++ b/OfficeIMO.CSV/CsvLineReader.FieldSpans.Quoted.cs
@@ -6,6 +6,7 @@ internal sealed partial class CsvLineReader
 {
 #if NET8_0_OR_GREATER
     private const int StandardQuotedFieldSpanCapacity = 64;
+    private const int DirectUnescapeQuotedFieldMinimumLength = 32;
 
     private bool TryReadStandardQuotedFieldSpansOrLine<TVisitor>(
         char delimiter,
@@ -426,11 +427,51 @@ internal sealed partial class CsvLineReader
                     continue;
                 }
 
+                if (field.Length >= DirectUnescapeQuotedFieldMinimumLength)
+                {
+                    fieldVisitor.VisitFieldValue(recordIndex, fieldIndex, CreateUnescapedQuotedField(field));
+                    continue;
+                }
+
                 value = CompactEscapedQuotedField(field.Start, field.End, field.FirstEscapedQuote);
             }
 
             fieldVisitor.VisitField(recordIndex, fieldIndex, value);
         }
+    }
+
+    private string CreateUnescapedQuotedField(StandardCsvFieldSpan field)
+    {
+        return string.Create(field.Length, (this, field), static (destination, state) =>
+        {
+            var reader = state.Item1;
+            var source = reader._buffer;
+            var fieldValue = state.field;
+            var readIndex = fieldValue.Start;
+            var end = fieldValue.End;
+            var writeIndex = 0;
+
+            while (readIndex < end)
+            {
+                var quoteIndex = Array.IndexOf(source, '"', readIndex, end - readIndex);
+                if (quoteIndex < 0 || quoteIndex + 1 >= end || source[quoteIndex + 1] != '"')
+                {
+                    var segmentLength = end - readIndex;
+                    source.AsSpan(readIndex, segmentLength).CopyTo(destination[writeIndex..]);
+                    break;
+                }
+
+                if (quoteIndex > readIndex)
+                {
+                    var segmentLength = quoteIndex - readIndex;
+                    source.AsSpan(readIndex, segmentLength).CopyTo(destination[writeIndex..]);
+                    writeIndex += segmentLength;
+                }
+
+                destination[writeIndex++] = '"';
+                readIndex = quoteIndex + 2;
+            }
+        });
     }
 
     private ReadOnlySpan<char> CompactEscapedQuotedField(int start, int end, int firstEscapedQuote)

--- a/OfficeIMO.CSV/CsvLineReader.FieldSpans.Quoted.cs
+++ b/OfficeIMO.CSV/CsvLineReader.FieldSpans.Quoted.cs
@@ -1,0 +1,508 @@
+#nullable enable
+
+namespace OfficeIMO.CSV;
+
+internal sealed partial class CsvLineReader
+{
+#if NET8_0_OR_GREATER
+    private const int StandardQuotedFieldSpanCapacity = 64;
+
+    private bool TryReadStandardQuotedFieldSpansOrLine<TVisitor>(
+        char delimiter,
+        bool trim,
+        bool allowEmpty,
+        bool emitFields,
+        int recordIndex,
+        ref TVisitor fieldVisitor,
+        out int fieldCount,
+        out bool isEmptyRecord,
+        out string separator,
+        out CsvLineReadResult readResult)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        fieldCount = 0;
+        isEmptyRecord = false;
+        separator = string.Empty;
+        readResult = CsvLineReadResult.Line;
+
+        var start = _position;
+        Span<StandardCsvFieldSpan> fields = stackalloc StandardCsvFieldSpan[StandardQuotedFieldSpanCapacity];
+        if (!TryParseStandardQuotedFieldSpans(start, delimiter, trim, fields, out var fieldCountValue, out var firstFieldLength, out var recordEnd))
+        {
+            return false;
+        }
+
+        var emit = emitFields && (allowEmpty || recordEnd > start);
+        fieldCount = fieldCountValue;
+        if (emit)
+        {
+            VisitStandardQuotedFieldSpans(fields.Slice(0, fieldCount), recordIndex, ref fieldVisitor);
+        }
+
+        isEmptyRecord = fieldCount == 1 && firstFieldLength == 0;
+        _position = recordEnd;
+        ConsumeLineSeparator(_buffer[recordEnd], out separator);
+        readResult = CsvLineReadResult.UnquotedRecord;
+        return true;
+    }
+
+    private bool TryReadStandardQuotedFieldSpansOrLineFromPrefix<TVisitor>(
+        char delimiter,
+        bool allowEmpty,
+        bool emitFields,
+        int recordIndex,
+        ReadOnlySpan<int> delimiterIndexesBeforeQuote,
+        int quoteIndex,
+        ref TVisitor fieldVisitor,
+        out int fieldCount,
+        out bool isEmptyRecord,
+        out string separator,
+        out CsvLineReadResult readResult)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        fieldCount = 0;
+        isEmptyRecord = false;
+        separator = string.Empty;
+        readResult = CsvLineReadResult.Line;
+
+        var start = _position;
+        Span<StandardCsvFieldSpan> fields = stackalloc StandardCsvFieldSpan[StandardQuotedFieldSpanCapacity];
+        var firstFieldLength = 0;
+        var fieldStart = start;
+        foreach (var delimiterIndex in delimiterIndexesBeforeQuote)
+        {
+            if (delimiterIndex < fieldStart || delimiterIndex >= quoteIndex)
+            {
+                return false;
+            }
+
+            var field = new StandardCsvFieldSpan(
+                fieldStart,
+                delimiterIndex,
+                delimiterIndex - fieldStart,
+                hasEscapedQuotes: false,
+                firstEscapedQuote: -1);
+            if (!TryAddStandardField(fields, ref fieldCount, field, ref firstFieldLength))
+            {
+                return false;
+            }
+
+            fieldStart = delimiterIndex + 1;
+        }
+
+        if (fieldStart != quoteIndex)
+        {
+            return false;
+        }
+
+        var index = quoteIndex;
+        if (!TryParsePrefixedStandardQuotedField(ref index, out var quotedField) ||
+            !TryAddStandardField(fields, ref fieldCount, quotedField, ref firstFieldLength))
+        {
+            return false;
+        }
+
+        if (!TryParseStandardQuotedFieldSpanTail(
+                ref index,
+                delimiter,
+                fields,
+                ref fieldCount,
+                ref firstFieldLength,
+                out var recordEnd))
+        {
+            return false;
+        }
+
+        var emit = emitFields && (allowEmpty || recordEnd > start);
+        if (emit)
+        {
+            VisitStandardQuotedFieldSpans(fields.Slice(0, fieldCount), recordIndex, ref fieldVisitor);
+        }
+
+        isEmptyRecord = fieldCount == 1 && firstFieldLength == 0;
+        _position = recordEnd;
+        ConsumeLineSeparator(_buffer[recordEnd], out separator);
+        readResult = CsvLineReadResult.UnquotedRecord;
+        return true;
+    }
+
+    private bool TryParseStandardQuotedFieldSpans(
+        int start,
+        char delimiter,
+        bool trim,
+        Span<StandardCsvFieldSpan> fields,
+        out int fieldCount,
+        out int firstFieldLength,
+        out int recordEnd)
+    {
+        fieldCount = 0;
+        firstFieldLength = 0;
+        recordEnd = -1;
+        var index = start;
+        var pendingTrailingField = false;
+
+        while (index < _length)
+        {
+            var value = _buffer[index];
+            if (value == '\r' || value == '\n')
+            {
+                if (pendingTrailingField && !TryAddStandardField(fields, ref fieldCount, StandardCsvFieldSpan.Empty, ref firstFieldLength))
+                {
+                    return false;
+                }
+
+                recordEnd = index;
+                return true;
+            }
+
+            if (value == delimiter)
+            {
+                if (!TryAddStandardField(fields, ref fieldCount, StandardCsvFieldSpan.Empty, ref firstFieldLength))
+                {
+                    return false;
+                }
+
+                index++;
+                pendingTrailingField = true;
+                continue;
+            }
+
+            StandardCsvFieldSpan field;
+            if (value == '"')
+            {
+                if (!TryParseStandardQuotedField(ref index, delimiter, trim, out field))
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                if (!TryParseStandardUnquotedField(ref index, delimiter, trim, out field))
+                {
+                    return false;
+                }
+            }
+
+            if (!TryAddStandardField(fields, ref fieldCount, field, ref firstFieldLength))
+            {
+                return false;
+            }
+
+            pendingTrailingField = false;
+            if (index >= _length)
+            {
+                return false;
+            }
+
+            value = _buffer[index];
+            if (value == delimiter)
+            {
+                index++;
+                pendingTrailingField = true;
+                continue;
+            }
+
+            if (value == '\r' || value == '\n')
+            {
+                recordEnd = index;
+                return true;
+            }
+
+            return false;
+        }
+
+        return false;
+    }
+
+    private bool TryParseStandardQuotedField(ref int index, char delimiter, bool trim, out StandardCsvFieldSpan field)
+    {
+        index++;
+        var valueStart = index;
+        var escapeCount = 0;
+        var firstEscapedQuote = -1;
+
+        while (index < _length)
+        {
+            if (_buffer[index] != '"')
+            {
+                index++;
+                continue;
+            }
+
+            if (index + 1 < _length && _buffer[index + 1] == '"')
+            {
+                if (firstEscapedQuote < 0)
+                {
+                    firstEscapedQuote = index;
+                }
+
+                escapeCount++;
+                index += 2;
+                continue;
+            }
+
+            var valueEnd = index;
+            index++;
+            if (trim)
+            {
+                while (index < _length &&
+                       _buffer[index] != delimiter &&
+                       _buffer[index] != '\r' &&
+                       _buffer[index] != '\n' &&
+                       char.IsWhiteSpace(_buffer[index]))
+                {
+                    index++;
+                }
+            }
+
+            field = new StandardCsvFieldSpan(valueStart, valueEnd, valueEnd - valueStart - escapeCount, escapeCount != 0, firstEscapedQuote);
+            return index < _length;
+        }
+
+        field = default;
+        return false;
+    }
+
+    private bool TryParsePrefixedStandardQuotedField(ref int index, out StandardCsvFieldSpan field)
+    {
+        index++;
+        var valueStart = index;
+        var escapeCount = 0;
+        var firstEscapedQuote = -1;
+
+        while (index < _length)
+        {
+            var quoteOffset = _buffer.AsSpan(index, _length - index).IndexOf('"');
+            if (quoteOffset < 0)
+            {
+                field = default;
+                return false;
+            }
+
+            index += quoteOffset;
+            if (index + 1 < _length && _buffer[index + 1] == '"')
+            {
+                if (firstEscapedQuote < 0)
+                {
+                    firstEscapedQuote = index;
+                }
+
+                escapeCount++;
+                index += 2;
+                continue;
+            }
+
+            var valueEnd = index;
+            index++;
+            field = new StandardCsvFieldSpan(valueStart, valueEnd, valueEnd - valueStart - escapeCount, escapeCount != 0, firstEscapedQuote);
+            return index < _length;
+        }
+
+        field = default;
+        return false;
+    }
+
+    private bool TryParseStandardUnquotedField(
+        ref int index,
+        char delimiter,
+        bool trim,
+        out StandardCsvFieldSpan field)
+    {
+        var start = index;
+        while (index < _length)
+        {
+            var value = _buffer[index];
+            if (value == '"')
+            {
+                field = default;
+                return false;
+            }
+
+            if (value == delimiter || value == '\r' || value == '\n')
+            {
+                break;
+            }
+
+            index++;
+        }
+
+        var valueStart = start;
+        var valueEnd = index;
+        if (trim)
+        {
+            while (valueStart < valueEnd && char.IsWhiteSpace(_buffer[valueStart]))
+            {
+                valueStart++;
+            }
+
+            while (valueEnd > valueStart && char.IsWhiteSpace(_buffer[valueEnd - 1]))
+            {
+                valueEnd--;
+            }
+        }
+
+        field = new StandardCsvFieldSpan(valueStart, valueEnd, valueEnd - valueStart, hasEscapedQuotes: false, firstEscapedQuote: -1);
+        return index < _length;
+    }
+
+    private bool TryParseStandardQuotedFieldSpanTail(
+        ref int index,
+        char delimiter,
+        Span<StandardCsvFieldSpan> fields,
+        ref int fieldCount,
+        ref int firstFieldLength,
+        out int recordEnd)
+    {
+        recordEnd = -1;
+        var pendingTrailingField = false;
+
+        while (index < _length)
+        {
+            var value = _buffer[index];
+            if (value == '\r' || value == '\n')
+            {
+                if (pendingTrailingField && !TryAddStandardField(fields, ref fieldCount, StandardCsvFieldSpan.Empty, ref firstFieldLength))
+                {
+                    return false;
+                }
+
+                recordEnd = index;
+                return true;
+            }
+
+            if (value == delimiter)
+            {
+                index++;
+                pendingTrailingField = true;
+                continue;
+            }
+
+            if (!pendingTrailingField)
+            {
+                return false;
+            }
+
+            StandardCsvFieldSpan field;
+            if (value == '"')
+            {
+                if (!TryParseStandardQuotedField(ref index, delimiter, trim: false, out field))
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                if (!TryParseStandardUnquotedField(ref index, delimiter, trim: false, out field))
+                {
+                    return false;
+                }
+            }
+
+            if (!TryAddStandardField(fields, ref fieldCount, field, ref firstFieldLength))
+            {
+                return false;
+            }
+
+            pendingTrailingField = false;
+        }
+
+        return false;
+    }
+
+    private void VisitStandardQuotedFieldSpans<TVisitor>(
+        ReadOnlySpan<StandardCsvFieldSpan> fields,
+        int recordIndex,
+        ref TVisitor fieldVisitor)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        for (var fieldIndex = 0; fieldIndex < fields.Length; fieldIndex++)
+        {
+            var field = fields[fieldIndex];
+            var value = field.HasEscapedQuotes
+                ? CompactEscapedQuotedField(field.Start, field.End, field.FirstEscapedQuote)
+                : _buffer.AsSpan(field.Start, field.Length);
+            fieldVisitor.VisitField(recordIndex, fieldIndex, value);
+        }
+    }
+
+    private ReadOnlySpan<char> CompactEscapedQuotedField(int start, int end, int firstEscapedQuote)
+    {
+        var index = firstEscapedQuote >= start && firstEscapedQuote < end ? firstEscapedQuote : start;
+        var segmentStart = index;
+        var writeIndex = index;
+
+        while (index < end)
+        {
+            if (_buffer[index] != '"' || index + 1 >= end || _buffer[index + 1] != '"')
+            {
+                index++;
+                continue;
+            }
+
+            if (index > segmentStart)
+            {
+                var segmentLength = index - segmentStart;
+                Array.Copy(_buffer, segmentStart, _buffer, writeIndex, segmentLength);
+                writeIndex += segmentLength;
+            }
+
+            _buffer[writeIndex++] = '"';
+            index += 2;
+            segmentStart = index;
+        }
+
+        if (index > segmentStart)
+        {
+            var segmentLength = index - segmentStart;
+            Array.Copy(_buffer, segmentStart, _buffer, writeIndex, segmentLength);
+            writeIndex += segmentLength;
+        }
+
+        return _buffer.AsSpan(start, writeIndex - start);
+    }
+
+    private static bool TryAddStandardField(
+        Span<StandardCsvFieldSpan> fields,
+        ref int fieldCount,
+        StandardCsvFieldSpan field,
+        ref int firstFieldLength)
+    {
+        if (fieldCount >= fields.Length)
+        {
+            return false;
+        }
+
+        if (fieldCount == 0)
+        {
+            firstFieldLength = field.Length;
+        }
+
+        fields[fieldCount++] = field;
+        return true;
+    }
+
+    private readonly struct StandardCsvFieldSpan
+    {
+        public static readonly StandardCsvFieldSpan Empty = new(0, 0, 0, hasEscapedQuotes: false, firstEscapedQuote: -1);
+
+        public StandardCsvFieldSpan(int start, int end, int length, bool hasEscapedQuotes, int firstEscapedQuote)
+        {
+            Start = start;
+            End = end;
+            Length = length;
+            HasEscapedQuotes = hasEscapedQuotes;
+            FirstEscapedQuote = firstEscapedQuote;
+        }
+
+        public int Start { get; }
+
+        public int End { get; }
+
+        public int Length { get; }
+
+        public bool HasEscapedQuotes { get; }
+
+        public int FirstEscapedQuote { get; }
+    }
+#endif
+}

--- a/OfficeIMO.CSV/CsvLineReader.FieldSpans.Quoted.cs
+++ b/OfficeIMO.CSV/CsvLineReader.FieldSpans.Quoted.cs
@@ -418,9 +418,17 @@ internal sealed partial class CsvLineReader
         for (var fieldIndex = 0; fieldIndex < fields.Length; fieldIndex++)
         {
             var field = fields[fieldIndex];
-            var value = field.HasEscapedQuotes
-                ? CompactEscapedQuotedField(field.Start, field.End, field.FirstEscapedQuote)
-                : _buffer.AsSpan(field.Start, field.Length);
+            ReadOnlySpan<char> value = _buffer.AsSpan(field.Start, field.End - field.Start);
+            if (field.HasEscapedQuotes)
+            {
+                if (fieldVisitor.TryVisitEscapedField(recordIndex, fieldIndex, value, field.Length))
+                {
+                    continue;
+                }
+
+                value = CompactEscapedQuotedField(field.Start, field.End, field.FirstEscapedQuote);
+            }
+
             fieldVisitor.VisitField(recordIndex, fieldIndex, value);
         }
     }

--- a/OfficeIMO.CSV/CsvLineReader.cs
+++ b/OfficeIMO.CSV/CsvLineReader.cs
@@ -1,12 +1,17 @@
 #nullable enable
 
+using System.Buffers;
 using System.Text;
 
 namespace OfficeIMO.CSV;
 
-internal sealed class CsvLineReader
+internal sealed partial class CsvLineReader : IDisposable
 {
     private const int DefaultBufferSize = 32 * 1024;
+#if NET8_0_OR_GREATER
+    private const int UnquotedDelimiterIndexCapacity = 64;
+    private const int QuotedPrefixReuseMinimumDelimiterCount = 4;
+#endif
     private readonly TextReader _reader;
     private readonly char[] _buffer;
     private int _position;
@@ -16,7 +21,12 @@ internal sealed class CsvLineReader
     public CsvLineReader(TextReader reader)
     {
         _reader = reader ?? throw new ArgumentNullException(nameof(reader));
-        _buffer = new char[DefaultBufferSize];
+        _buffer = ArrayPool<char>.Shared.Rent(DefaultBufferSize);
+    }
+
+    public void Dispose()
+    {
+        ArrayPool<char>.Shared.Return(_buffer);
     }
 
     public CsvLineReadResult ReadUnquotedRecordOrLine(char delimiter, bool trim, char commentCharacter, List<string> fields, out string? line, out string separator)
@@ -42,6 +52,16 @@ internal sealed class CsvLineReader
             line = ReadLine(out separator);
             return CsvLineReadResult.Line;
         }
+
+#if NET8_0_OR_GREATER
+        if (!trim &&
+            delimiter <= byte.MaxValue &&
+            System.Runtime.Intrinsics.X86.Avx2.IsSupported &&
+            TryReadUnquotedRecordOrLineAvx2(delimiter, fields, out line, out separator, out var readResult))
+        {
+            return readResult;
+        }
+#endif
 
         var newlineIndex = IndexOfNewline(segmentStart, segmentLength);
         if (newlineIndex < 0)
@@ -142,6 +162,21 @@ internal sealed class CsvLineReader
         var newlineIndex = segmentStart + specialIndex;
         if (!endsAtReaderEnd && _buffer[newlineIndex] == '"')
         {
+            if (TryReadStandardQuotedFieldSpansOrLine(
+                    delimiter,
+                    trim,
+                    allowEmpty,
+                    emitFields,
+                    recordIndex,
+                    ref fieldVisitor,
+                    out fieldCount,
+                    out isEmptyRecord,
+                    out separator,
+                    out var quotedReadResult))
+            {
+                return quotedReadResult;
+            }
+
             line = ReadLine(out separator);
             return CsvLineReadResult.Line;
         }
@@ -253,6 +288,96 @@ internal sealed class CsvLineReader
     }
 
 #if NET8_0_OR_GREATER
+    private bool TryReadUnquotedRecordOrLineAvx2(
+        char delimiter,
+        List<string> fields,
+        out string? line,
+        out string separator,
+        out CsvLineReadResult readResult)
+    {
+        line = null;
+        separator = string.Empty;
+        readResult = CsvLineReadResult.Line;
+
+        var start = _position;
+        var end = _length - 32;
+        if (start > end)
+        {
+            return false;
+        }
+
+        Span<int> delimiterIndexes = stackalloc int[UnquotedDelimiterIndexCapacity];
+        var delimiterCount = 0;
+        var pos = start;
+        var delimiterVector = System.Runtime.Intrinsics.Vector256.Create((byte)delimiter);
+        var quoteVector = System.Runtime.Intrinsics.Vector256.Create((byte)'"');
+        var carriageReturnVector = System.Runtime.Intrinsics.Vector256.Create((byte)'\r');
+        var lineFeedVector = System.Runtime.Intrinsics.Vector256.Create((byte)'\n');
+
+        while (pos <= end)
+        {
+            var values = System.Runtime.InteropServices.MemoryMarshal.Cast<char, short>(_buffer.AsSpan(pos, 32));
+            var first = System.Runtime.Intrinsics.Vector256.LoadUnsafe(ref System.Runtime.InteropServices.MemoryMarshal.GetReference(values));
+            var second = System.Runtime.Intrinsics.Vector256.LoadUnsafe(ref System.Runtime.InteropServices.MemoryMarshal.GetReference(values.Slice(16)));
+            var packed = System.Runtime.Intrinsics.X86.Avx2.PackUnsignedSaturate(first, second);
+            var packedBytes = System.Runtime.Intrinsics.Vector256.AsByte(
+                System.Runtime.Intrinsics.X86.Avx2.Permute4x64(System.Runtime.Intrinsics.Vector256.AsInt64(packed), 0b11_01_10_00));
+
+            var delimiterMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, delimiterVector));
+            var quoteMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, quoteVector));
+            var carriageReturnMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, carriageReturnVector));
+            var lineFeedMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, lineFeedVector));
+            var terminalMask = quoteMask | carriageReturnMask | lineFeedMask;
+
+            if (terminalMask != 0)
+            {
+                var terminalOffset = System.Numerics.BitOperations.TrailingZeroCount(terminalMask);
+                var delimiterMaskBeforeTerminal = delimiterMask & ((1u << terminalOffset) - 1u);
+                if (!AddDelimiterIndexes(delimiterMaskBeforeTerminal, pos, delimiterIndexes, ref delimiterCount))
+                {
+                    return false;
+                }
+
+                if (((quoteMask >> terminalOffset) & 1u) != 0)
+                {
+                    return false;
+                }
+
+                var newlineIndex = pos + terminalOffset;
+                AddIndexedUnquotedFields(start, newlineIndex, delimiterIndexes.Slice(0, delimiterCount), fields);
+                _position = newlineIndex;
+                ConsumeLineSeparator(_buffer[newlineIndex], out separator);
+                readResult = CsvLineReadResult.UnquotedRecord;
+                return true;
+            }
+
+            if (!AddDelimiterIndexes(delimiterMask, pos, delimiterIndexes, ref delimiterCount))
+            {
+                return false;
+            }
+
+            pos += 32;
+        }
+
+        return false;
+    }
+
+    private void AddIndexedUnquotedFields(int start, int end, ReadOnlySpan<int> delimiterIndexes, List<string> fields)
+    {
+        var fieldStart = start;
+        foreach (var delimiterIndex in delimiterIndexes)
+        {
+            fields.Add(GetUnquotedField(fieldStart, delimiterIndex - fieldStart, trim: false));
+            fieldStart = delimiterIndex + 1;
+        }
+
+        fields.Add(GetUnquotedField(fieldStart, end - fieldStart, trim: false));
+    }
+
     private bool HasNonWhitespaceOrDelimiter(int start, int end, char delimiter)
     {
         for (var i = start; i < end; i++)
@@ -421,7 +546,7 @@ internal sealed class CsvLineReader
             return false;
         }
 
-        Span<int> delimiterIndexes = stackalloc int[256];
+        Span<int> delimiterIndexes = stackalloc int[UnquotedDelimiterIndexCapacity];
         var delimiterCount = 0;
         var pos = start;
         var delimiterVector = System.Runtime.Intrinsics.Vector256.Create((byte)delimiter);
@@ -459,6 +584,24 @@ internal sealed class CsvLineReader
 
                 if (((quoteMask >> terminalOffset) & 1u) != 0)
                 {
+                    var quoteIndex = pos + terminalOffset;
+                    if (delimiterCount >= QuotedPrefixReuseMinimumDelimiterCount &&
+                        TryReadStandardQuotedFieldSpansOrLineFromPrefix(
+                            delimiter,
+                            allowEmpty,
+                            emitFields,
+                            recordIndex,
+                            delimiterIndexes.Slice(0, delimiterCount),
+                            quoteIndex,
+                            ref fieldVisitor,
+                            out fieldCount,
+                            out isEmptyRecord,
+                            out separator,
+                            out readResult))
+                    {
+                        return true;
+                    }
+
                     return false;
                 }
 

--- a/OfficeIMO.CSV/CsvLoadOptions.cs
+++ b/OfficeIMO.CSV/CsvLoadOptions.cs
@@ -56,6 +56,27 @@ public sealed class CsvLoadOptions
     public bool GenerateMissingHeaderNames { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets how duplicate header names are handled. Default renames duplicate headers to keep name-based row access unambiguous.
+    /// </summary>
+    public CsvDuplicateHeaderBehavior DuplicateHeaderBehavior { get; set; } = CsvDuplicateHeaderBehavior.Rename;
+
+    /// <summary>
+    /// Gets or sets a token that should be materialized as <c>null</c> when loading rows into a <see cref="CsvDocument"/>.
+    /// Raw string streaming callbacks preserve the source text.
+    /// </summary>
+    public string? NullValue { get; set; }
+
+    /// <summary>
+    /// Gets or sets additional date/time formats used by typed row conversion and schema validation.
+    /// </summary>
+    public string[]? DateTimeFormats { get; set; }
+
+    /// <summary>
+    /// Gets or sets columns appended to every loaded row, useful for source file names, import timestamps, or batch metadata.
+    /// </summary>
+    public IReadOnlyDictionary<string, object?>? StaticColumns { get; set; }
+
+    /// <summary>
     /// Gets or sets how parsed records are handled when their field count differs from the header count.
     /// Default pads missing fields and ignores extras, matching common PowerShell CSV import behavior.
     /// </summary>

--- a/OfficeIMO.CSV/CsvLoadOptions.cs
+++ b/OfficeIMO.CSV/CsvLoadOptions.cs
@@ -72,6 +72,12 @@ public sealed class CsvLoadOptions
     public string[]? DateTimeFormats { get; set; }
 
     /// <summary>
+    /// Gets or sets how malformed quoted fields are handled. Default is <see cref="CsvQuoteParsingMode.Lenient"/>
+    /// to preserve common PowerShell-style import behavior.
+    /// </summary>
+    public CsvQuoteParsingMode QuoteParsingMode { get; set; } = CsvQuoteParsingMode.Lenient;
+
+    /// <summary>
     /// Gets or sets columns appended to every loaded row, useful for source file names, import timestamps, or batch metadata.
     /// </summary>
     public IReadOnlyDictionary<string, object?>? StaticColumns { get; set; }

--- a/OfficeIMO.CSV/CsvMapper.cs
+++ b/OfficeIMO.CSV/CsvMapper.cs
@@ -35,7 +35,7 @@ internal interface ICsvMappingEntry<T>
 {
     string ColumnName { get; }
 
-    T Apply(T instance, object? rawValue, CultureInfo culture);
+    T Apply(T instance, object? rawValue, CultureInfo culture, IReadOnlyList<string>? dateTimeFormats);
 }
 
 internal sealed class CsvMappingEntry<T, TValue> : ICsvMappingEntry<T>
@@ -48,9 +48,9 @@ internal sealed class CsvMappingEntry<T, TValue> : ICsvMappingEntry<T>
 
     public string ColumnName { get; }
 
-    public T Apply(T instance, object? rawValue, CultureInfo culture)
+    public T Apply(T instance, object? rawValue, CultureInfo culture, IReadOnlyList<string>? dateTimeFormats)
     {
-        var value = CsvValueConverter.ConvertTo<TValue>(rawValue, culture);
+        var value = CsvValueConverter.ConvertTo<TValue>(rawValue, culture, dateTimeFormats);
         return _assign(instance, value!);
     }
 
@@ -89,7 +89,7 @@ public static class CsvMappingExtensions
             foreach (var binding in bindings)
             {
                 var rawValue = row[binding.ColumnIndex];
-                instance = binding.Entry.Apply(instance, rawValue, document.Culture);
+                instance = binding.Entry.Apply(instance, rawValue, document.Culture, document.DateTimeFormats);
             }
 
             yield return instance;

--- a/OfficeIMO.CSV/CsvObjectWriter.cs
+++ b/OfficeIMO.CSV/CsvObjectWriter.cs
@@ -593,6 +593,6 @@ public sealed class CsvObjectWriter : IDisposable
             return;
         }
 
-        CsvWriter.WriteRecordDefaultAdaptive(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine);
+        CsvWriter.WriteRecordBufferedDefault(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine);
     }
 }

--- a/OfficeIMO.CSV/CsvObjectWriter.cs
+++ b/OfficeIMO.CSV/CsvObjectWriter.cs
@@ -18,6 +18,7 @@ public sealed class CsvObjectWriter : IDisposable
     private readonly bool _useAlwaysQuotedWritePath;
     private readonly bool _leaveOpen;
     private readonly StringBuilder _rowBuffer = new(1024);
+    private const int WideTextRowThreshold = 20;
     private IReadOnlyList<string>? _columns;
     private Func<object, object?[], bool>? _propertyProjector;
     private Func<object, string?[], CultureInfo, bool>? _propertyTextProjector;
@@ -303,7 +304,7 @@ public sealed class CsvObjectWriter : IDisposable
 
         if (_useDefaultWritePath)
         {
-            CsvWriter.WriteRecordBufferedDefault(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine);
+            WriteDefaultTextRecord(values);
             return;
         }
 
@@ -554,7 +555,7 @@ public sealed class CsvObjectWriter : IDisposable
     {
         if (_useDefaultWritePath)
         {
-            CsvWriter.WriteRecordBufferedDefault(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine);
+            WriteDefaultTextRecord(values);
             return;
         }
 
@@ -582,5 +583,16 @@ public sealed class CsvObjectWriter : IDisposable
         }
 
         CsvWriter.WriteTextRecordBuffered(_writer, _rowBuffer, valueCount, state, valueAccessor, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns);
+    }
+
+    private void WriteDefaultTextRecord(string?[] values)
+    {
+        if (values.Length >= WideTextRowThreshold)
+        {
+            CsvWriter.WriteRecordBufferedDefault(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine);
+            return;
+        }
+
+        CsvWriter.WriteRecordDefaultAdaptive(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine);
     }
 }

--- a/OfficeIMO.CSV/CsvObjectWriter.cs
+++ b/OfficeIMO.CSV/CsvObjectWriter.cs
@@ -180,6 +180,34 @@ public sealed class CsvObjectWriter : IDisposable
     }
 
     /// <summary>
+    /// Writes one already-formatted text row using the provided column order.
+    /// </summary>
+    /// <param name="columns">Column names for the first row and validation for later rows.</param>
+    /// <param name="values">Text values in the same order as <paramref name="columns"/>.</param>
+    /// <remarks>
+    /// Use this when the caller already owns culture-aware value formatting.
+    /// The method still applies CSV escaping and validates that the row width matches the header.
+    /// </remarks>
+    public void WriteTextRow(IReadOnlyList<string> columns, string?[] values)
+    {
+        ThrowIfDisposed();
+        if (columns == null)
+        {
+            throw new ArgumentNullException(nameof(columns));
+        }
+
+        if (values == null)
+        {
+            throw new ArgumentNullException(nameof(values));
+        }
+
+        ValidateProjectedValueCount(columns, values.Length);
+        EnsureColumns(columns);
+
+        WriteTextBuffered(values);
+    }
+
+    /// <summary>
     /// Writes one already-projected row using the column order that was established by a previous row.
     /// </summary>
     /// <param name="values">Values in the same order as the established CSV columns.</param>
@@ -244,7 +272,7 @@ public sealed class CsvObjectWriter : IDisposable
 
         if (_useDefaultWritePath)
         {
-            CsvWriter.WriteRecordDefault(_writer, values, _options.Delimiter, _options.NewLine);
+            CsvWriter.WriteRecordDefaultAdaptive(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine);
             return;
         }
 
@@ -416,7 +444,7 @@ public sealed class CsvObjectWriter : IDisposable
     {
         if (_useDefaultWritePath)
         {
-            CsvWriter.WriteRecordDefault(_writer, values, _options.Delimiter, _options.NewLine);
+            CsvWriter.WriteRecordDefaultAdaptive(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine);
             return;
         }
 

--- a/OfficeIMO.CSV/CsvObjectWriter.cs
+++ b/OfficeIMO.CSV/CsvObjectWriter.cs
@@ -20,7 +20,9 @@ public sealed class CsvObjectWriter : IDisposable
     private readonly StringBuilder _rowBuffer = new(1024);
     private IReadOnlyList<string>? _columns;
     private Func<object, object?[], bool>? _propertyProjector;
+    private Func<object, string?[], CultureInfo, bool>? _propertyTextProjector;
     private object?[]? _propertyValues;
+    private string?[]? _propertyTextValues;
     private bool _disposed;
 
     /// <summary>
@@ -66,6 +68,15 @@ public sealed class CsvObjectWriter : IDisposable
         }
 
         if (_columns != null &&
+            _propertyTextProjector != null &&
+            _propertyTextValues != null &&
+            _propertyTextProjector(item, _propertyTextValues, _options.Culture))
+        {
+            WriteTextBuffered(_propertyTextValues);
+            return;
+        }
+
+        if (_columns != null &&
             _propertyProjector != null &&
             _propertyValues != null &&
             _propertyProjector(item, _propertyValues))
@@ -78,6 +89,17 @@ public sealed class CsvObjectWriter : IDisposable
         var dictionaryLike = ObjectDataHelpers.IsDictionaryLike(item);
         EnsureColumns(itemColumns, requireOrder: !dictionaryLike);
         var columns = _columns!;
+
+        if (_useDefaultWritePath &&
+            !dictionaryLike &&
+            ObjectDataHelpers.TryCreatePropertyTextProjector(item, columns, out var textProjector))
+        {
+            _propertyTextProjector = textProjector;
+            _propertyTextValues = new string?[columns.Count];
+            textProjector!(item, _propertyTextValues, _options.Culture);
+            WriteTextBuffered(_propertyTextValues);
+            return;
+        }
 
         if (!dictionaryLike &&
             ObjectDataHelpers.TryCreatePropertyProjector(item, columns, out var projector))
@@ -222,7 +244,7 @@ public sealed class CsvObjectWriter : IDisposable
 
         if (_useDefaultWritePath)
         {
-            CsvWriter.WriteRecordBufferedDefault(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine);
+            CsvWriter.WriteRecordDefault(_writer, values, _options.Delimiter, _options.NewLine);
             return;
         }
 
@@ -388,5 +410,22 @@ public sealed class CsvObjectWriter : IDisposable
         }
 
         CsvWriter.WriteRecordBuffered(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns);
+    }
+
+    private void WriteTextBuffered(string?[] values)
+    {
+        if (_useDefaultWritePath)
+        {
+            CsvWriter.WriteRecordDefault(_writer, values, _options.Delimiter, _options.NewLine);
+            return;
+        }
+
+        if (_useAlwaysQuotedWritePath)
+        {
+            CsvWriter.WriteRecordBufferedAlwaysQuoted(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine);
+            return;
+        }
+
+        CsvWriter.WriteRecordBuffered<string?>(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns);
     }
 }

--- a/OfficeIMO.CSV/CsvObjectWriter.cs
+++ b/OfficeIMO.CSV/CsvObjectWriter.cs
@@ -303,7 +303,7 @@ public sealed class CsvObjectWriter : IDisposable
 
         if (_useDefaultWritePath)
         {
-            CsvWriter.WriteRecordDefaultAdaptive(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine);
+            CsvWriter.WriteRecordBufferedDefault(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine);
             return;
         }
 
@@ -554,7 +554,7 @@ public sealed class CsvObjectWriter : IDisposable
     {
         if (_useDefaultWritePath)
         {
-            CsvWriter.WriteRecordDefaultAdaptive(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine);
+            CsvWriter.WriteRecordBufferedDefault(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine);
             return;
         }
 

--- a/OfficeIMO.CSV/CsvObjectWriter.cs
+++ b/OfficeIMO.CSV/CsvObjectWriter.cs
@@ -241,6 +241,37 @@ public sealed class CsvObjectWriter : IDisposable
     }
 
     /// <summary>
+    /// Writes one already-projected row using a caller-provided value accessor and the established column order.
+    /// </summary>
+    /// <typeparam name="TState">State type used by the value accessor.</typeparam>
+    /// <param name="valueCount">Number of values exposed by <paramref name="valueAccessor"/>.</param>
+    /// <param name="state">Caller state passed to <paramref name="valueAccessor"/> for each column index.</param>
+    /// <param name="valueAccessor">Function that returns the value for a column index.</param>
+    public void WriteTrustedRow<TState>(
+        int valueCount,
+        TState state,
+        Func<TState, int, object?> valueAccessor)
+    {
+        ThrowIfDisposed();
+        if (valueAccessor == null)
+        {
+            throw new ArgumentNullException(nameof(valueAccessor));
+        }
+
+        if (_columns == null)
+        {
+            throw new InvalidOperationException("Columns must be established before writing trusted rows.");
+        }
+
+        if (valueCount != _columns.Count)
+        {
+            throw new CsvException($"Row contains {valueCount} values but header defines {_columns.Count} columns.");
+        }
+
+        WriteBuffered(valueCount, state, valueAccessor);
+    }
+
+    /// <summary>
     /// Writes one already-formatted text row using the column order that was established by a previous row.
     /// </summary>
     /// <param name="values">Text values in the same order as the established CSV columns.</param>
@@ -286,6 +317,68 @@ public sealed class CsvObjectWriter : IDisposable
     }
 
     /// <summary>
+    /// Writes one already-formatted text row using a caller-provided value accessor.
+    /// </summary>
+    /// <typeparam name="TState">State type used by the value accessor.</typeparam>
+    /// <param name="columns">Column names for the first row and validation for later rows.</param>
+    /// <param name="valueCount">Number of values exposed by <paramref name="valueAccessor"/>.</param>
+    /// <param name="state">Caller state passed to <paramref name="valueAccessor"/> for each column index.</param>
+    /// <param name="valueAccessor">Function that returns the already-formatted text for a column index.</param>
+    public void WriteTextRow<TState>(
+        IReadOnlyList<string> columns,
+        int valueCount,
+        TState state,
+        Func<TState, int, string?> valueAccessor)
+    {
+        ThrowIfDisposed();
+        if (columns == null)
+        {
+            throw new ArgumentNullException(nameof(columns));
+        }
+
+        if (valueAccessor == null)
+        {
+            throw new ArgumentNullException(nameof(valueAccessor));
+        }
+
+        ValidateProjectedValueCount(columns, valueCount);
+        EnsureColumns(columns);
+
+        WriteTextBuffered(valueCount, state, valueAccessor);
+    }
+
+    /// <summary>
+    /// Writes one already-formatted text row using the column order that was established by a previous row.
+    /// </summary>
+    /// <typeparam name="TState">State type used by the value accessor.</typeparam>
+    /// <param name="valueCount">Number of values exposed by <paramref name="valueAccessor"/>.</param>
+    /// <param name="state">Caller state passed to <paramref name="valueAccessor"/> for each column index.</param>
+    /// <param name="valueAccessor">Function that returns the already-formatted text for a column index.</param>
+    public void WriteTrustedTextRow<TState>(
+        int valueCount,
+        TState state,
+        Func<TState, int, string?> valueAccessor)
+    {
+        ThrowIfDisposed();
+        if (valueAccessor == null)
+        {
+            throw new ArgumentNullException(nameof(valueAccessor));
+        }
+
+        if (_columns == null)
+        {
+            throw new InvalidOperationException("Columns must be established before writing trusted rows.");
+        }
+
+        if (valueCount != _columns.Count)
+        {
+            throw new CsvException($"Row contains {valueCount} values but header defines {_columns.Count} columns.");
+        }
+
+        WriteTextBuffered(valueCount, state, valueAccessor);
+    }
+
+    /// <summary>
     /// Writes one projected row using a caller-provided value accessor.
     /// </summary>
     /// <typeparam name="TState">State type used by the value accessor.</typeparam>
@@ -313,7 +406,7 @@ public sealed class CsvObjectWriter : IDisposable
         ValidateProjectedValueCount(columns, valueCount);
         EnsureColumns(columns);
 
-        CsvWriter.WriteRecordBuffered(_writer, _rowBuffer, valueCount, state, valueAccessor, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns);
+        WriteBuffered(valueCount, state, valueAccessor);
     }
 
     /// <inheritdoc />
@@ -440,6 +533,23 @@ public sealed class CsvObjectWriter : IDisposable
         CsvWriter.WriteRecordBuffered(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns);
     }
 
+    private void WriteBuffered<TState>(int valueCount, TState state, Func<TState, int, object?> valueAccessor)
+    {
+        if (_useDefaultWritePath)
+        {
+            CsvWriter.WriteRecordBufferedDefault(_writer, _rowBuffer, valueCount, state, valueAccessor, _options.Delimiter, _options.NewLine, _options.Culture);
+            return;
+        }
+
+        if (_useAlwaysQuotedWritePath)
+        {
+            CsvWriter.WriteRecordBuffered(_writer, _rowBuffer, valueCount, state, valueAccessor, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns);
+            return;
+        }
+
+        CsvWriter.WriteRecordBuffered(_writer, _rowBuffer, valueCount, state, valueAccessor, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns);
+    }
+
     private void WriteTextBuffered(string?[] values)
     {
         if (_useDefaultWritePath)
@@ -455,5 +565,22 @@ public sealed class CsvObjectWriter : IDisposable
         }
 
         CsvWriter.WriteRecordBuffered<string?>(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns);
+    }
+
+    private void WriteTextBuffered<TState>(int valueCount, TState state, Func<TState, int, string?> valueAccessor)
+    {
+        if (_useDefaultWritePath)
+        {
+            CsvWriter.WriteRecordBufferedDefault(_writer, _rowBuffer, valueCount, state, valueAccessor, _options.Delimiter, _options.NewLine);
+            return;
+        }
+
+        if (_useAlwaysQuotedWritePath)
+        {
+            CsvWriter.WriteRecordBufferedAlwaysQuoted(_writer, _rowBuffer, valueCount, state, valueAccessor, _options.Delimiter, _options.NewLine);
+            return;
+        }
+
+        CsvWriter.WriteTextRecordBuffered(_writer, _rowBuffer, valueCount, state, valueAccessor, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns);
     }
 }

--- a/OfficeIMO.CSV/CsvObjectWriter.cs
+++ b/OfficeIMO.CSV/CsvObjectWriter.cs
@@ -16,6 +16,7 @@ public sealed class CsvObjectWriter : IDisposable
     private readonly HashSet<string>? _quoteFields;
     private readonly bool _useDefaultWritePath;
     private readonly bool _useAlwaysQuotedWritePath;
+    private readonly bool _useFormattedValueOptions;
     private readonly bool _leaveOpen;
     private readonly StringBuilder _rowBuffer = new(1024);
     private const int WideTextRowThreshold = 20;
@@ -37,10 +38,13 @@ public sealed class CsvObjectWriter : IDisposable
         _writer = writer ?? throw new ArgumentNullException(nameof(writer));
         _options = options ?? new CsvSaveOptions();
         _quoteFields = CsvWriter.CreateQuoteFieldSet(_options.QuoteFields);
-        _useDefaultWritePath = _options.FormulaInjectionPolicy == CsvFormulaInjectionPolicy.Preserve
+        _useFormattedValueOptions = _options.NullValue is not null || _options.DateTimeFormat is not null || _options.UseUtc;
+        _useDefaultWritePath = !_useFormattedValueOptions
+            && _options.FormulaInjectionPolicy == CsvFormulaInjectionPolicy.Preserve
             && _options.QuoteMode == CsvQuoteMode.AsNeeded
             && _quoteFields == null;
-        _useAlwaysQuotedWritePath = _options.FormulaInjectionPolicy == CsvFormulaInjectionPolicy.Preserve
+        _useAlwaysQuotedWritePath = !_useFormattedValueOptions
+            && _options.FormulaInjectionPolicy == CsvFormulaInjectionPolicy.Preserve
             && _options.QuoteMode == CsvQuoteMode.Always
             && _quoteFields == null;
         _leaveOpen = leaveOpen;
@@ -152,7 +156,7 @@ public sealed class CsvObjectWriter : IDisposable
         }
         else
         {
-            CsvWriter.WriteRecordBuffered(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns);
+            CsvWriter.WriteRecordBuffered(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns, _options.DateTimeFormat, _options.UseUtc, _options.NullValue);
         }
     }
 
@@ -314,7 +318,7 @@ public sealed class CsvObjectWriter : IDisposable
             return;
         }
 
-        CsvWriter.WriteRecordBuffered<string?>(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns);
+        CsvWriter.WriteRecordBuffered<string?>(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns, _options.DateTimeFormat, _options.UseUtc, _options.NullValue);
     }
 
     /// <summary>
@@ -531,7 +535,7 @@ public sealed class CsvObjectWriter : IDisposable
             return;
         }
 
-        CsvWriter.WriteRecordBuffered(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns);
+        CsvWriter.WriteRecordBuffered(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns, _options.DateTimeFormat, _options.UseUtc, _options.NullValue);
     }
 
     private void WriteBuffered<TState>(int valueCount, TState state, Func<TState, int, object?> valueAccessor)
@@ -544,11 +548,11 @@ public sealed class CsvObjectWriter : IDisposable
 
         if (_useAlwaysQuotedWritePath)
         {
-            CsvWriter.WriteRecordBuffered(_writer, _rowBuffer, valueCount, state, valueAccessor, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns);
+            CsvWriter.WriteRecordBuffered(_writer, _rowBuffer, valueCount, state, valueAccessor, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns, _options.DateTimeFormat, _options.UseUtc, _options.NullValue);
             return;
         }
 
-        CsvWriter.WriteRecordBuffered(_writer, _rowBuffer, valueCount, state, valueAccessor, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns);
+        CsvWriter.WriteRecordBuffered(_writer, _rowBuffer, valueCount, state, valueAccessor, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns, _options.DateTimeFormat, _options.UseUtc, _options.NullValue);
     }
 
     private void WriteTextBuffered(string?[] values)
@@ -565,7 +569,7 @@ public sealed class CsvObjectWriter : IDisposable
             return;
         }
 
-        CsvWriter.WriteRecordBuffered<string?>(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns);
+        CsvWriter.WriteRecordBuffered<string?>(_writer, _rowBuffer, values, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns, _options.DateTimeFormat, _options.UseUtc, _options.NullValue);
     }
 
     private void WriteTextBuffered<TState>(int valueCount, TState state, Func<TState, int, string?> valueAccessor)
@@ -582,7 +586,7 @@ public sealed class CsvObjectWriter : IDisposable
             return;
         }
 
-        CsvWriter.WriteTextRecordBuffered(_writer, _rowBuffer, valueCount, state, valueAccessor, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns);
+        CsvWriter.WriteTextRecordBuffered(_writer, _rowBuffer, valueCount, state, valueAccessor, _options.Delimiter, _options.NewLine, _options.Culture, _options.FormulaInjectionPolicy, _options.QuoteMode, _quoteFields, _columns, _options.DateTimeFormat, _options.UseUtc, _options.NullValue);
     }
 
     private void WriteDefaultTextRecord(string?[] values)

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.Flexible.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.Flexible.cs
@@ -1,0 +1,90 @@
+#nullable enable
+
+namespace OfficeIMO.CSV;
+
+internal static partial class CsvParser
+{
+#if NET8_0_OR_GREATER
+    private static bool HasUnexpectedQuoteInTextUnquotedField(ReadOnlySpan<char> text, char delimiter, int position)
+    {
+        var fieldStart = position;
+        for (var i = position; i < text.Length; i++)
+        {
+            var value = text[i];
+            if (value == '\r' || value == '\n')
+            {
+                return false;
+            }
+
+            if (value == delimiter)
+            {
+                fieldStart = i + 1;
+                continue;
+            }
+
+            if (value == '"')
+            {
+                return i != fieldStart;
+            }
+        }
+
+        return false;
+    }
+
+    private static int ReadFlexibleTextRecordFieldSpans<TVisitor>(
+        ReadOnlySpan<char> text,
+        char delimiter,
+        bool trim,
+        bool emitFields,
+        int recordIndex,
+        ref int position,
+        ref TVisitor fieldVisitor,
+        out int firstFieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        var recordStart = position;
+        var scan = recordStart;
+        var fields = new List<string>(16);
+
+        while (scan <= text.Length)
+        {
+            var lineEnd = scan;
+            while (lineEnd < text.Length && text[lineEnd] != '\r' && text[lineEnd] != '\n')
+            {
+                lineEnd++;
+            }
+
+            var candidate = text.Slice(recordStart, lineEnd - recordStart).ToString();
+            if (TryParseQuotedRecord(candidate, delimiter, trim, strictQuotes: false, lineNumber: 0, fields))
+            {
+                firstFieldLength = fields.Count == 0 ? 0 : fields[0].Length;
+                if (emitFields)
+                {
+                    for (var i = 0; i < fields.Count; i++)
+                    {
+                        fieldVisitor.VisitFieldValue(recordIndex, i, fields[i]);
+                    }
+                }
+
+                position = lineEnd;
+                if (position < text.Length)
+                {
+                    ConsumeTextLineSeparator(text, ref position);
+                }
+
+                return fields.Count;
+            }
+
+            if (lineEnd >= text.Length)
+            {
+                throw new CsvParseException("Unterminated quoted field.", 0);
+            }
+
+            scan = lineEnd;
+            ConsumeTextLineSeparator(text, ref scan);
+        }
+
+        throw new CsvParseException("Unterminated quoted field.", 0);
+    }
+#endif
+}

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.QuoteAwareAvx2.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.QuoteAwareAvx2.cs
@@ -39,9 +39,126 @@ internal static partial class CsvParser
         Span<TextQuoteAwareFieldSpan> fields = stackalloc TextQuoteAwareFieldSpan[TextQuoteAwareFieldSpanCapacity];
         var fieldStart = recordStart;
         var quoteCount = 0;
-        var index = recordStart;
-        var end = text.Length - 32;
+        return ContinueTextQuoteAwareRecordFieldSpansAvx2(
+            text,
+            delimiter,
+            allowEmpty,
+            emitFields,
+            recordIndex,
+            recordStart,
+            recordStart,
+            ref fieldStart,
+            ref quoteCount,
+            fields,
+            ref fieldCount,
+            ref position,
+            ref fieldVisitor,
+            ref scratch,
+            out firstFieldLength);
+    }
 
+    private static bool TryReadTextQuoteAwareRecordFieldSpansAvx2FromCurrentChunk<TVisitor>(
+        ReadOnlySpan<char> text,
+        char delimiter,
+        bool allowEmpty,
+        bool emitFields,
+        int recordIndex,
+        int recordStart,
+        int chunkStart,
+        uint delimiterMask,
+        uint quoteMask,
+        uint carriageReturnMask,
+        uint lineFeedMask,
+        ref int position,
+        ref TVisitor fieldVisitor,
+        ref char[]? scratch,
+        out int fieldCount,
+        out int firstFieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        fieldCount = 0;
+        firstFieldLength = 0;
+        if (!Avx2.IsSupported || delimiter > byte.MaxValue)
+        {
+            return false;
+        }
+
+        Span<TextQuoteAwareFieldSpan> fields = stackalloc TextQuoteAwareFieldSpan[TextQuoteAwareFieldSpanCapacity];
+        var fieldStart = recordStart;
+        var quoteCount = 0;
+        var specialMask = delimiterMask | quoteMask | carriageReturnMask | lineFeedMask;
+        if (!ProcessTextQuoteAwareMask(
+            text,
+            specialMask,
+            delimiterMask,
+            quoteMask,
+            carriageReturnMask,
+            lineFeedMask,
+            chunkStart,
+            ref fieldStart,
+            ref quoteCount,
+            fields,
+            ref fieldCount,
+            out var recordEnd,
+            out var nextPosition))
+        {
+            return false;
+        }
+
+        if (recordEnd >= 0)
+        {
+            return CompleteTextQuoteAwareRecord(
+                text,
+                fields.Slice(0, fieldCount),
+                allowEmpty,
+                emitFields,
+                recordIndex,
+                recordStart,
+                nextPosition,
+                ref position,
+                ref fieldVisitor,
+                ref scratch,
+                out firstFieldLength);
+        }
+
+        return ContinueTextQuoteAwareRecordFieldSpansAvx2(
+            text,
+            delimiter,
+            allowEmpty,
+            emitFields,
+            recordIndex,
+            recordStart,
+            chunkStart + 32,
+            ref fieldStart,
+            ref quoteCount,
+            fields,
+            ref fieldCount,
+            ref position,
+            ref fieldVisitor,
+            ref scratch,
+            out firstFieldLength);
+    }
+
+    private static bool ContinueTextQuoteAwareRecordFieldSpansAvx2<TVisitor>(
+        ReadOnlySpan<char> text,
+        char delimiter,
+        bool allowEmpty,
+        bool emitFields,
+        int recordIndex,
+        int recordStart,
+        int index,
+        ref int fieldStart,
+        ref int quoteCount,
+        Span<TextQuoteAwareFieldSpan> fields,
+        ref int fieldCount,
+        ref int position,
+        ref TVisitor fieldVisitor,
+        ref char[]? scratch,
+        out int firstFieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        firstFieldLength = 0;
+        var end = text.Length - 32;
         var delimiterVector = Vector256.Create((byte)delimiter);
         var quoteVector = Vector256.Create((byte)'"');
         var carriageReturnVector = Vector256.Create((byte)'\r');

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.QuoteAwareAvx2.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.QuoteAwareAvx2.cs
@@ -3,8 +3,10 @@
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+#if NET8_0_OR_GREATER
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
+#endif
 
 namespace OfficeIMO.CSV;
 

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.QuoteAwareAvx2.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.QuoteAwareAvx2.cs
@@ -1,0 +1,470 @@
+#nullable enable
+
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+namespace OfficeIMO.CSV;
+
+internal static partial class CsvParser
+{
+#if NET8_0_OR_GREATER
+    private const int TextQuoteAwareFieldSpanCapacity = 64;
+
+    private static bool TryReadTextQuoteAwareRecordFieldSpansAvx2<TVisitor>(
+        ReadOnlySpan<char> text,
+        char delimiter,
+        bool allowEmpty,
+        bool emitFields,
+        int recordIndex,
+        int recordStart,
+        ref int position,
+        ref TVisitor fieldVisitor,
+        ref char[]? scratch,
+        out int fieldCount,
+        out int firstFieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        fieldCount = 0;
+        firstFieldLength = 0;
+        if (!Avx2.IsSupported || delimiter > byte.MaxValue)
+        {
+            return false;
+        }
+
+        Span<TextQuoteAwareFieldSpan> fields = stackalloc TextQuoteAwareFieldSpan[TextQuoteAwareFieldSpanCapacity];
+        var fieldStart = recordStart;
+        var quoteCount = 0;
+        var index = recordStart;
+        var end = text.Length - 32;
+
+        var delimiterVector = Vector256.Create((byte)delimiter);
+        var quoteVector = Vector256.Create((byte)'"');
+        var carriageReturnVector = Vector256.Create((byte)'\r');
+        var lineFeedVector = Vector256.Create((byte)'\n');
+
+        while (index <= end)
+        {
+            var values = MemoryMarshal.Cast<char, short>(text.Slice(index, 32));
+            var first = Vector256.LoadUnsafe(ref MemoryMarshal.GetReference(values));
+            var second = Vector256.LoadUnsafe(ref MemoryMarshal.GetReference(values.Slice(16)));
+            var packed = Avx2.PackUnsignedSaturate(first, second);
+            var packedBytes = Vector256.AsByte(
+                Avx2.Permute4x64(Vector256.AsInt64(packed), 0b11_01_10_00));
+
+            var delimiterMask = (uint)Avx2.MoveMask(Avx2.CompareEqual(packedBytes, delimiterVector));
+            var quoteMask = (uint)Avx2.MoveMask(Avx2.CompareEqual(packedBytes, quoteVector));
+            var carriageReturnMask = (uint)Avx2.MoveMask(Avx2.CompareEqual(packedBytes, carriageReturnVector));
+            var lineFeedMask = (uint)Avx2.MoveMask(Avx2.CompareEqual(packedBytes, lineFeedVector));
+            var specialMask = delimiterMask | quoteMask | carriageReturnMask | lineFeedMask;
+
+            if (specialMask != 0)
+            {
+                if (!ProcessTextQuoteAwareMask(
+                    text,
+                    specialMask,
+                    delimiterMask,
+                    quoteMask,
+                    carriageReturnMask,
+                    lineFeedMask,
+                    index,
+                    ref fieldStart,
+                    ref quoteCount,
+                    fields,
+                    ref fieldCount,
+                    out var recordEnd,
+                    out var nextPosition))
+                {
+                    return false;
+                }
+
+                if (recordEnd >= 0)
+                {
+                    return CompleteTextQuoteAwareRecord(
+                        text,
+                        fields.Slice(0, fieldCount),
+                        allowEmpty,
+                        emitFields,
+                        recordIndex,
+                        recordStart,
+                        nextPosition,
+                        ref position,
+                        ref fieldVisitor,
+                        ref scratch,
+                        out firstFieldLength);
+                }
+            }
+
+            index += 32;
+        }
+
+        if (!ProcessTextQuoteAwareTail(
+            text,
+            delimiter,
+            index,
+            ref fieldStart,
+            ref quoteCount,
+            fields,
+            ref fieldCount,
+            out var tailNextPosition))
+        {
+            return false;
+        }
+
+        return CompleteTextQuoteAwareRecord(
+            text,
+            fields.Slice(0, fieldCount),
+            allowEmpty,
+            emitFields,
+            recordIndex,
+            recordStart,
+            tailNextPosition,
+            ref position,
+            ref fieldVisitor,
+            ref scratch,
+            out firstFieldLength);
+    }
+
+    private static bool ProcessTextQuoteAwareMask(
+        ReadOnlySpan<char> text,
+        uint specialMask,
+        uint delimiterMask,
+        uint quoteMask,
+        uint carriageReturnMask,
+        uint lineFeedMask,
+        int chunkStart,
+        ref int fieldStart,
+        ref int quoteCount,
+        Span<TextQuoteAwareFieldSpan> fields,
+        ref int fieldCount,
+        out int recordEnd,
+        out int nextPosition)
+    {
+        recordEnd = -1;
+        nextPosition = -1;
+
+        while (specialMask != 0)
+        {
+            var offset = BitOperations.TrailingZeroCount(specialMask);
+            var bit = 1u << offset;
+            specialMask &= specialMask - 1;
+
+            if ((bit & quoteMask) != 0)
+            {
+                quoteCount++;
+                continue;
+            }
+
+            if ((quoteCount & 1) != 0)
+            {
+                if ((bit & (carriageReturnMask | lineFeedMask)) != 0)
+                {
+                    return false;
+                }
+
+                continue;
+            }
+
+            var absoluteIndex = chunkStart + offset;
+            if ((bit & delimiterMask) != 0)
+            {
+                if (!TryAddTextQuoteAwareField(fields, ref fieldCount, fieldStart, absoluteIndex, quoteCount))
+                {
+                    return false;
+                }
+
+                fieldStart = absoluteIndex + 1;
+                quoteCount = 0;
+                continue;
+            }
+
+            if ((bit & (carriageReturnMask | lineFeedMask)) != 0)
+            {
+                if (!TryAddTextQuoteAwareField(fields, ref fieldCount, fieldStart, absoluteIndex, quoteCount))
+                {
+                    return false;
+                }
+
+                recordEnd = absoluteIndex;
+                nextPosition = absoluteIndex + 1;
+                if ((bit & carriageReturnMask) != 0 &&
+                    nextPosition < text.Length &&
+                    text[nextPosition] == '\n')
+                {
+                    nextPosition++;
+                }
+
+                return true;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool ProcessTextQuoteAwareTail(
+        ReadOnlySpan<char> text,
+        char delimiter,
+        int index,
+        ref int fieldStart,
+        ref int quoteCount,
+        Span<TextQuoteAwareFieldSpan> fields,
+        ref int fieldCount,
+        out int nextPosition)
+    {
+        while (index < text.Length)
+        {
+            var value = text[index];
+            if (value == '"')
+            {
+                quoteCount++;
+                index++;
+                continue;
+            }
+
+            if ((quoteCount & 1) == 0)
+            {
+                if (value == delimiter)
+                {
+                    if (!TryAddTextQuoteAwareField(fields, ref fieldCount, fieldStart, index, quoteCount))
+                    {
+                        nextPosition = -1;
+                        return false;
+                    }
+
+                    fieldStart = index + 1;
+                    quoteCount = 0;
+                }
+                else if (value == '\r' || value == '\n')
+                {
+                    if (!TryAddTextQuoteAwareField(fields, ref fieldCount, fieldStart, index, quoteCount))
+                    {
+                        nextPosition = -1;
+                        return false;
+                    }
+
+                    nextPosition = index + 1;
+                    if (value == '\r' && nextPosition < text.Length && text[nextPosition] == '\n')
+                    {
+                        nextPosition++;
+                    }
+
+                    return true;
+                }
+            }
+            else if (value == '\r' || value == '\n')
+            {
+                nextPosition = -1;
+                return false;
+            }
+
+            index++;
+        }
+
+        if (quoteCount != 0 && (quoteCount & 1) != 0)
+        {
+            nextPosition = -1;
+            return false;
+        }
+
+        if (!TryAddTextQuoteAwareField(fields, ref fieldCount, fieldStart, text.Length, quoteCount))
+        {
+            nextPosition = -1;
+            return false;
+        }
+
+        nextPosition = text.Length;
+        return true;
+    }
+
+    private static bool CompleteTextQuoteAwareRecord<TVisitor>(
+        ReadOnlySpan<char> text,
+        ReadOnlySpan<TextQuoteAwareFieldSpan> fields,
+        bool allowEmpty,
+        bool emitFields,
+        int recordIndex,
+        int recordStart,
+        int nextPosition,
+        ref int position,
+        ref TVisitor fieldVisitor,
+        ref char[]? scratch,
+        out int firstFieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        firstFieldLength = 0;
+        if (fields.Length == 0)
+        {
+            return false;
+        }
+
+        if (emitFields && (allowEmpty || fields[^1].End > recordStart))
+        {
+            if (!VisitTextQuoteAwareFieldSpans(text, fields, recordIndex, ref fieldVisitor, ref scratch, out firstFieldLength))
+            {
+                return false;
+            }
+        }
+        else
+        {
+            if (!TryGetTextQuoteAwareFirstFieldLength(text, fields[0], out firstFieldLength))
+            {
+                return false;
+            }
+        }
+
+        position = nextPosition;
+        return true;
+    }
+
+    private static bool VisitTextQuoteAwareFieldSpans<TVisitor>(
+        ReadOnlySpan<char> text,
+        ReadOnlySpan<TextQuoteAwareFieldSpan> fields,
+        int recordIndex,
+        ref TVisitor fieldVisitor,
+        ref char[]? scratch,
+        out int firstFieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        firstFieldLength = 0;
+        for (var fieldIndex = 0; fieldIndex < fields.Length; fieldIndex++)
+        {
+            var field = fields[fieldIndex];
+            if (!TryVisitTextQuoteAwareField(text, field, recordIndex, fieldIndex, ref fieldVisitor, ref scratch, out var fieldLength))
+            {
+                return false;
+            }
+
+            if (fieldIndex == 0)
+            {
+                firstFieldLength = fieldLength;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryVisitTextQuoteAwareField<TVisitor>(
+        ReadOnlySpan<char> text,
+        TextQuoteAwareFieldSpan field,
+        int recordIndex,
+        int fieldIndex,
+        ref TVisitor fieldVisitor,
+        ref char[]? scratch,
+        out int fieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        if (field.QuoteCount == 0)
+        {
+            fieldLength = field.End - field.Start;
+            fieldVisitor.VisitField(recordIndex, fieldIndex, text.Slice(field.Start, fieldLength));
+            return true;
+        }
+
+        return TryVisitTextQuoteAwareQuotedField(text, field, recordIndex, fieldIndex, ref fieldVisitor, ref scratch, out fieldLength);
+    }
+
+    private static bool TryVisitTextQuoteAwareQuotedField<TVisitor>(
+        ReadOnlySpan<char> text,
+        TextQuoteAwareFieldSpan field,
+        int recordIndex,
+        int fieldIndex,
+        ref TVisitor fieldVisitor,
+        ref char[]? scratch,
+        out int fieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        var rawLength = field.End - field.Start;
+        if ((field.QuoteCount & 1) != 0 ||
+            rawLength < 2 ||
+            text[field.Start] != '"' ||
+            text[field.End - 1] != '"')
+        {
+            fieldLength = 0;
+            return false;
+        }
+
+        var escapedQuoteCount = (field.QuoteCount - 2) / 2;
+        fieldLength = rawLength - 2 - escapedQuoteCount;
+        var value = text.Slice(field.Start + 1, rawLength - 2);
+        if (escapedQuoteCount == 0)
+        {
+            fieldVisitor.VisitField(recordIndex, fieldIndex, value);
+            return true;
+        }
+
+        if (fieldVisitor.TryVisitEscapedField(recordIndex, fieldIndex, value, fieldLength))
+        {
+            return true;
+        }
+
+        var firstEscapedQuote = value.IndexOf('"');
+        if (firstEscapedQuote < 0)
+        {
+            return false;
+        }
+
+        var unescaped = UnescapeTextQuotedField(value, firstEscapedQuote, fieldLength, ref scratch);
+        fieldVisitor.VisitField(recordIndex, fieldIndex, unescaped);
+        return true;
+    }
+
+    private static bool TryGetTextQuoteAwareFirstFieldLength(
+        ReadOnlySpan<char> text,
+        TextQuoteAwareFieldSpan field,
+        out int fieldLength)
+    {
+        if (field.QuoteCount == 0)
+        {
+            fieldLength = field.End - field.Start;
+            return true;
+        }
+
+        var rawLength = field.End - field.Start;
+        if ((field.QuoteCount & 1) != 0 ||
+            rawLength < 2 ||
+            text[field.Start] != '"' ||
+            text[field.End - 1] != '"')
+        {
+            fieldLength = 0;
+            return false;
+        }
+
+        fieldLength = rawLength - 2 - ((field.QuoteCount - 2) / 2);
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool TryAddTextQuoteAwareField(
+        Span<TextQuoteAwareFieldSpan> fields,
+        ref int fieldCount,
+        int start,
+        int end,
+        int quoteCount)
+    {
+        if (fieldCount >= fields.Length)
+        {
+            return false;
+        }
+
+        fields[fieldCount++] = new TextQuoteAwareFieldSpan(start, end, quoteCount);
+        return true;
+    }
+
+    private readonly struct TextQuoteAwareFieldSpan
+    {
+        public TextQuoteAwareFieldSpan(int start, int end, int quoteCount)
+        {
+            Start = start;
+            End = end;
+            QuoteCount = quoteCount;
+        }
+
+        public int Start { get; }
+
+        public int End { get; }
+
+        public int QuoteCount { get; }
+    }
+#endif
+}

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.QuoteAwareAvx2.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.QuoteAwareAvx2.cs
@@ -39,9 +39,11 @@ internal static partial class CsvParser
         Span<TextQuoteAwareFieldSpan> fields = stackalloc TextQuoteAwareFieldSpan[TextQuoteAwareFieldSpanCapacity];
         var fieldStart = recordStart;
         var quoteCount = 0;
+        var delimiterVector = Vector256.Create((byte)delimiter);
         return ContinueTextQuoteAwareRecordFieldSpansAvx2(
             text,
             delimiter,
+            delimiterVector,
             allowEmpty,
             emitFields,
             recordIndex,
@@ -69,6 +71,7 @@ internal static partial class CsvParser
         uint quoteMask,
         uint carriageReturnMask,
         uint lineFeedMask,
+        Vector256<byte> delimiterVector,
         ref int position,
         ref TVisitor fieldVisitor,
         ref char[]? scratch,
@@ -124,6 +127,7 @@ internal static partial class CsvParser
         return ContinueTextQuoteAwareRecordFieldSpansAvx2(
             text,
             delimiter,
+            delimiterVector,
             allowEmpty,
             emitFields,
             recordIndex,
@@ -142,6 +146,7 @@ internal static partial class CsvParser
     private static bool ContinueTextQuoteAwareRecordFieldSpansAvx2<TVisitor>(
         ReadOnlySpan<char> text,
         char delimiter,
+        Vector256<byte> delimiterVector,
         bool allowEmpty,
         bool emitFields,
         int recordIndex,
@@ -159,10 +164,6 @@ internal static partial class CsvParser
     {
         firstFieldLength = 0;
         var end = text.Length - 32;
-        var delimiterVector = Vector256.Create((byte)delimiter);
-        var quoteVector = Vector256.Create((byte)'"');
-        var carriageReturnVector = Vector256.Create((byte)'\r');
-        var lineFeedVector = Vector256.Create((byte)'\n');
 
         while (index <= end)
         {
@@ -174,9 +175,9 @@ internal static partial class CsvParser
                 Avx2.Permute4x64(Vector256.AsInt64(packed), 0b11_01_10_00));
 
             var delimiterMask = (uint)Avx2.MoveMask(Avx2.CompareEqual(packedBytes, delimiterVector));
-            var quoteMask = (uint)Avx2.MoveMask(Avx2.CompareEqual(packedBytes, quoteVector));
-            var carriageReturnMask = (uint)Avx2.MoveMask(Avx2.CompareEqual(packedBytes, carriageReturnVector));
-            var lineFeedMask = (uint)Avx2.MoveMask(Avx2.CompareEqual(packedBytes, lineFeedVector));
+            var quoteMask = (uint)Avx2.MoveMask(Avx2.CompareEqual(packedBytes, QuoteByteVector));
+            var carriageReturnMask = (uint)Avx2.MoveMask(Avx2.CompareEqual(packedBytes, CarriageReturnByteVector));
+            var lineFeedMask = (uint)Avx2.MoveMask(Avx2.CompareEqual(packedBytes, LineFeedByteVector));
             var specialMask = delimiterMask | quoteMask | carriageReturnMask | lineFeedMask;
 
             if (specialMask != 0)

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.QuoteFreeAvx2.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.QuoteFreeAvx2.cs
@@ -2,6 +2,7 @@ namespace OfficeIMO.CSV;
 
 internal static partial class CsvParser
 {
+#if NET8_0_OR_GREATER
     private static bool TryReadTextQuoteFreeRecordFieldSpansAvx2<TVisitor>(
         ReadOnlySpan<char> text,
         char delimiter,
@@ -163,4 +164,5 @@ internal static partial class CsvParser
         position = text.Length;
         return true;
     }
+#endif
 }

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.QuoteFreeAvx2.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.QuoteFreeAvx2.cs
@@ -1,0 +1,166 @@
+namespace OfficeIMO.CSV;
+
+internal static partial class CsvParser
+{
+    private static bool TryReadTextQuoteFreeRecordFieldSpansAvx2<TVisitor>(
+        ReadOnlySpan<char> text,
+        char delimiter,
+        bool allowEmpty,
+        bool emitFields,
+        int recordIndex,
+        System.Runtime.Intrinsics.Vector256<byte> delimiterVector,
+        ref int position,
+        ref TVisitor fieldVisitor,
+        out int fieldCount,
+        out int firstFieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        fieldCount = 0;
+        firstFieldLength = 0;
+
+        var start = position;
+        var end = text.Length - 32;
+        if (start > end)
+        {
+            return false;
+        }
+
+        var fieldStart = start;
+        var fieldIndex = 0;
+        var pos = start;
+
+        while (pos <= end)
+        {
+            var values = System.Runtime.InteropServices.MemoryMarshal.Cast<char, short>(text.Slice(pos, 32));
+            var first = System.Runtime.Intrinsics.Vector256.LoadUnsafe(ref System.Runtime.InteropServices.MemoryMarshal.GetReference(values));
+            var second = System.Runtime.Intrinsics.Vector256.LoadUnsafe(ref System.Runtime.InteropServices.MemoryMarshal.GetReference(values.Slice(16)));
+            var packed = System.Runtime.Intrinsics.X86.Avx2.PackUnsignedSaturate(first, second);
+            var packedBytes = System.Runtime.Intrinsics.Vector256.AsByte(
+                System.Runtime.Intrinsics.X86.Avx2.Permute4x64(System.Runtime.Intrinsics.Vector256.AsInt64(packed), 0b11_01_10_00));
+
+            var delimiterMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, delimiterVector));
+            var carriageReturnMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, CarriageReturnByteVector));
+            var lineFeedMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, LineFeedByteVector));
+            var terminalMask = carriageReturnMask | lineFeedMask;
+            var specialMask = delimiterMask | terminalMask;
+
+            if (specialMask != 0)
+            {
+                while (specialMask != 0)
+                {
+                    var offset = System.Numerics.BitOperations.TrailingZeroCount(specialMask);
+                    var bit = 1u << offset;
+                    specialMask &= specialMask - 1;
+                    var absoluteIndex = pos + offset;
+
+                    if ((bit & delimiterMask) != 0)
+                    {
+                        var length = absoluteIndex - fieldStart;
+                        if (fieldIndex == 0)
+                        {
+                            firstFieldLength = length;
+                        }
+
+                        if (emitFields)
+                        {
+                            fieldVisitor.VisitField(recordIndex, fieldIndex, text.Slice(fieldStart, length));
+                        }
+
+                        fieldIndex++;
+                        fieldStart = absoluteIndex + 1;
+                        continue;
+                    }
+
+                    var lineLength = absoluteIndex - start;
+                    var emitRecordFields = (allowEmpty || lineLength != 0) && emitFields;
+                    var finalLength = absoluteIndex - fieldStart;
+                    if (fieldIndex == 0)
+                    {
+                        firstFieldLength = finalLength;
+                    }
+
+                    if (emitRecordFields)
+                    {
+                        fieldVisitor.VisitField(recordIndex, fieldIndex, text.Slice(fieldStart, finalLength));
+                    }
+
+                    fieldCount = fieldIndex + 1;
+                    position = absoluteIndex;
+                    ConsumeTextLineSeparator(text, ref position);
+                    return true;
+                }
+            }
+
+            pos += 32;
+        }
+
+        while (pos < text.Length)
+        {
+            var value = text[pos];
+            if (value == delimiter)
+            {
+                var length = pos - fieldStart;
+                if (fieldIndex == 0)
+                {
+                    firstFieldLength = length;
+                }
+
+                if (emitFields)
+                {
+                    fieldVisitor.VisitField(recordIndex, fieldIndex, text.Slice(fieldStart, length));
+                }
+
+                fieldIndex++;
+                fieldStart = pos + 1;
+                pos++;
+                continue;
+            }
+
+            if (value == '\r' || value == '\n')
+            {
+                var lineLength = pos - start;
+                var emitRecordFields = (allowEmpty || lineLength != 0) && emitFields;
+                var finalLength = pos - fieldStart;
+                if (fieldIndex == 0)
+                {
+                    firstFieldLength = finalLength;
+                }
+
+                if (emitRecordFields)
+                {
+                    fieldVisitor.VisitField(recordIndex, fieldIndex, text.Slice(fieldStart, finalLength));
+                }
+
+                fieldCount = fieldIndex + 1;
+                position = pos;
+                ConsumeTextLineSeparator(text, ref position);
+                return true;
+            }
+
+            pos++;
+        }
+
+        if (pos == start)
+        {
+            return false;
+        }
+
+        var tailLength = text.Length - fieldStart;
+        if (fieldIndex == 0)
+        {
+            firstFieldLength = tailLength;
+        }
+
+        if ((allowEmpty || text.Length != start) && emitFields)
+        {
+            fieldVisitor.VisitField(recordIndex, fieldIndex, text.Slice(fieldStart, tailLength));
+        }
+
+        fieldCount = fieldIndex + 1;
+        position = text.Length;
+        return true;
+    }
+}

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.Quoted.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.Quoted.cs
@@ -8,6 +8,118 @@ internal static partial class CsvParser
     private const int TextStandardQuotedFieldSpanCapacity = 64;
     private const int TextQuotedPrefixReuseMinimumDelimiterCount = 4;
 
+    private static bool TryReadTextFinalQuotedRecordFieldSpansFromPrefix<TVisitor>(
+        ReadOnlySpan<char> text,
+        char delimiter,
+        bool emitFields,
+        int recordIndex,
+        ReadOnlySpan<int> delimiterIndexesBeforeQuote,
+        int quoteIndex,
+        ref int position,
+        ref TVisitor fieldVisitor,
+        ref char[]? scratch,
+        out int fieldCount,
+        out int firstFieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        fieldCount = 0;
+        firstFieldLength = 0;
+        var start = position;
+        if (delimiterIndexesBeforeQuote.Length == 0 ||
+            delimiterIndexesBeforeQuote[^1] + 1 != quoteIndex)
+        {
+            return false;
+        }
+
+        var quotedPosition = quoteIndex + 1;
+        var valueStart = quotedPosition;
+        var escapeCount = 0;
+        var firstEscapedQuote = -1;
+        while (quotedPosition < text.Length)
+        {
+            var quoteOffset = text.Slice(quotedPosition).IndexOf('"');
+            if (quoteOffset < 0)
+            {
+                return false;
+            }
+
+            quotedPosition += quoteOffset;
+            if (quotedPosition + 1 < text.Length && text[quotedPosition + 1] == '"')
+            {
+                if (firstEscapedQuote < 0)
+                {
+                    firstEscapedQuote = quotedPosition;
+                }
+
+                escapeCount++;
+                quotedPosition += 2;
+                continue;
+            }
+
+            break;
+        }
+
+        if (quotedPosition >= text.Length)
+        {
+            return false;
+        }
+
+        var valueEnd = quotedPosition;
+        var nextPosition = quotedPosition + 1;
+        if (nextPosition < text.Length)
+        {
+            var separator = text[nextPosition];
+            if (separator == '\r')
+            {
+                nextPosition++;
+                if (nextPosition < text.Length && text[nextPosition] == '\n')
+                {
+                    nextPosition++;
+                }
+            }
+            else if (separator == '\n')
+            {
+                nextPosition++;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        var fieldStart = start;
+        foreach (var delimiterIndex in delimiterIndexesBeforeQuote)
+        {
+            VisitTextField(text.Slice(fieldStart, delimiterIndex - fieldStart), emitFields, recordIndex, fieldCount, ref fieldVisitor, ref firstFieldLength);
+            fieldCount++;
+            fieldStart = delimiterIndex + 1;
+        }
+
+        var field = text.Slice(valueStart, valueEnd - valueStart);
+        var fieldLength = field.Length - escapeCount;
+        if (fieldCount == 0)
+        {
+            firstFieldLength = fieldLength;
+        }
+
+        if (emitFields)
+        {
+            if (escapeCount == 0)
+            {
+                fieldVisitor.VisitField(recordIndex, fieldCount, field);
+            }
+            else if (!fieldVisitor.TryVisitEscapedField(recordIndex, fieldCount, field, fieldLength))
+            {
+                var unescaped = UnescapeTextQuotedField(field, firstEscapedQuote - valueStart, fieldLength, ref scratch);
+                fieldVisitor.VisitField(recordIndex, fieldCount, unescaped);
+            }
+        }
+
+        fieldCount++;
+        position = nextPosition;
+        return true;
+    }
+
     private static bool TryReadTextQuotedRecordFieldSpansFromPrefix<TVisitor>(
         ReadOnlySpan<char> text,
         char delimiter,

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.Quoted.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.Quoted.cs
@@ -244,9 +244,19 @@ internal static partial class CsvParser
         for (var fieldIndex = 0; fieldIndex < fields.Length; fieldIndex++)
         {
             var field = fields[fieldIndex];
-            var value = field.HasEscapedQuotes
-                ? UnescapeTextQuotedField(text.Slice(field.Start, field.End - field.Start), field.FirstEscapedQuote - field.Start, field.Length, ref scratch)
-                : text.Slice(field.Start, field.Length);
+            var value = text.Slice(field.Start, field.End - field.Start);
+            if (field.HasEscapedQuotes)
+            {
+                if (fieldVisitor.TryVisitEscapedField(recordIndex, fieldIndex, value, field.Length))
+                {
+                    continue;
+                }
+
+                var unescaped = UnescapeTextQuotedField(value, field.FirstEscapedQuote - field.Start, field.Length, ref scratch);
+                fieldVisitor.VisitField(recordIndex, fieldIndex, unescaped);
+                continue;
+            }
+
             fieldVisitor.VisitField(recordIndex, fieldIndex, value);
         }
     }

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.Quoted.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.Quoted.cs
@@ -8,6 +8,176 @@ internal static partial class CsvParser
     private const int TextStandardQuotedFieldSpanCapacity = 64;
     private const int TextQuotedPrefixReuseMinimumDelimiterCount = 4;
 
+    private static bool TryReadTextQuotedRecordFieldSpansFromPrefix<TVisitor>(
+        ReadOnlySpan<char> text,
+        char delimiter,
+        bool emitFields,
+        int recordIndex,
+        ReadOnlySpan<int> delimiterIndexesBeforeQuote,
+        int quoteIndex,
+        ref int position,
+        ref TVisitor fieldVisitor,
+        ref char[]? scratch,
+        out int fieldCount,
+        out int firstFieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        fieldCount = 0;
+        firstFieldLength = 0;
+        var start = position;
+        var fieldStart = start;
+
+        foreach (var delimiterIndex in delimiterIndexesBeforeQuote)
+        {
+            if (delimiterIndex < fieldStart || delimiterIndex >= quoteIndex)
+            {
+                return false;
+            }
+
+            fieldStart = delimiterIndex + 1;
+        }
+
+        if (fieldStart != quoteIndex)
+        {
+            return false;
+        }
+
+        fieldStart = start;
+        foreach (var delimiterIndex in delimiterIndexesBeforeQuote)
+        {
+            VisitTextField(text.Slice(fieldStart, delimiterIndex - fieldStart), emitFields, recordIndex, fieldCount, ref fieldVisitor, ref firstFieldLength);
+            fieldCount++;
+            fieldStart = delimiterIndex + 1;
+        }
+
+        position = quoteIndex;
+        if (!TryVisitTextQuotedField(text, delimiter, trim: false, emitFields, recordIndex, fieldCount, ref position, ref fieldVisitor, ref scratch, out var quotedLength))
+        {
+            throw new CsvParseException("Unterminated quoted field.", 0);
+        }
+
+        if (fieldCount == 0)
+        {
+            firstFieldLength = quotedLength;
+        }
+
+        fieldCount++;
+        var pendingTrailingField = false;
+        if (!TryConsumeTextQuotedFieldSeparator(text, delimiter, ref position, ref pendingTrailingField, out var recordEnded))
+        {
+            throw new CsvParseException("Unexpected character after CSV field.", 0);
+        }
+
+        if (recordEnded)
+        {
+            return true;
+        }
+
+        while (position < text.Length)
+        {
+            var value = text[position];
+            if (value == delimiter)
+            {
+                if (pendingTrailingField)
+                {
+                    VisitTextField(text.Slice(position, 0), emitFields, recordIndex, fieldCount, ref fieldVisitor, ref firstFieldLength);
+                    fieldCount++;
+                }
+
+                position++;
+                pendingTrailingField = true;
+                continue;
+            }
+
+            if (value == '\r' || value == '\n')
+            {
+                if (pendingTrailingField)
+                {
+                    VisitTextField(text.Slice(position, 0), emitFields, recordIndex, fieldCount, ref fieldVisitor, ref firstFieldLength);
+                    fieldCount++;
+                }
+
+                ConsumeTextLineSeparator(text, ref position);
+                return true;
+            }
+
+            pendingTrailingField = false;
+            if (value == '"')
+            {
+                if (!TryVisitTextQuotedField(text, delimiter, trim: false, emitFields, recordIndex, fieldCount, ref position, ref fieldVisitor, ref scratch, out quotedLength))
+                {
+                    throw new CsvParseException("Unterminated quoted field.", 0);
+                }
+
+                if (fieldCount == 0)
+                {
+                    firstFieldLength = quotedLength;
+                }
+
+                if (!TryConsumeTextQuotedFieldSeparator(text, delimiter, ref position, ref pendingTrailingField, out recordEnded))
+                {
+                    throw new CsvParseException("Unexpected character after CSV field.", 0);
+                }
+
+                fieldCount++;
+                if (recordEnded)
+                {
+                    return true;
+                }
+
+                continue;
+            }
+            else
+            {
+                var field = ReadTextUnquotedField(text, delimiter, trim: false, ref position);
+                VisitTextField(field, emitFields, recordIndex, fieldCount, ref fieldVisitor, ref firstFieldLength);
+            }
+
+            fieldCount++;
+            pendingTrailingField = false;
+        }
+
+        if (pendingTrailingField)
+        {
+            VisitTextField(text.Slice(text.Length, 0), emitFields, recordIndex, fieldCount, ref fieldVisitor, ref firstFieldLength);
+            fieldCount++;
+        }
+
+        return true;
+    }
+
+    private static bool TryConsumeTextQuotedFieldSeparator(
+        ReadOnlySpan<char> text,
+        char delimiter,
+        ref int position,
+        ref bool pendingTrailingField,
+        out bool recordEnded)
+    {
+        recordEnded = false;
+        if (position >= text.Length)
+        {
+            recordEnded = true;
+            return true;
+        }
+
+        var value = text[position];
+        if (value == delimiter)
+        {
+            position++;
+            pendingTrailingField = true;
+            return true;
+        }
+
+        if (value == '\r' || value == '\n')
+        {
+            ConsumeTextLineSeparator(text, ref position);
+            recordEnded = true;
+            return true;
+        }
+
+        return false;
+    }
+
     private static bool TryReadTextStandardQuotedRecordFieldSpansFromPrefix<TVisitor>(
         ReadOnlySpan<char> text,
         char delimiter,

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.Quoted.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.Quoted.cs
@@ -33,11 +33,34 @@ internal static partial class CsvParser
 
         var quotedPosition = quoteIndex + 1;
         var valueStart = quotedPosition;
+        var quoteOffset = text.Slice(quotedPosition).IndexOf('"');
+        if (quoteOffset < 0)
+        {
+            return false;
+        }
+
+        quotedPosition += quoteOffset;
+        if (quotedPosition + 1 >= text.Length || text[quotedPosition + 1] != '"')
+        {
+            return CompleteTextFinalUnescapedQuotedRecordFieldSpansFromPrefix(
+                text,
+                emitFields,
+                recordIndex,
+                delimiterIndexesBeforeQuote,
+                start,
+                valueStart,
+                quotedPosition,
+                ref position,
+                ref fieldVisitor,
+                out fieldCount,
+                out firstFieldLength);
+        }
+
         var escapeCount = 0;
-        var firstEscapedQuote = -1;
+        var firstEscapedQuote = quotedPosition;
         while (quotedPosition < text.Length)
         {
-            var quoteOffset = text.Slice(quotedPosition).IndexOf('"');
+            quoteOffset = text.Slice(quotedPosition).IndexOf('"');
             if (quoteOffset < 0)
             {
                 return false;
@@ -46,11 +69,6 @@ internal static partial class CsvParser
             quotedPosition += quoteOffset;
             if (quotedPosition + 1 < text.Length && text[quotedPosition + 1] == '"')
             {
-                if (firstEscapedQuote < 0)
-                {
-                    firstEscapedQuote = quotedPosition;
-                }
-
                 escapeCount++;
                 quotedPosition += 2;
                 continue;
@@ -113,6 +131,70 @@ internal static partial class CsvParser
                 var unescaped = UnescapeTextQuotedField(field, firstEscapedQuote - valueStart, fieldLength, ref scratch);
                 fieldVisitor.VisitField(recordIndex, fieldCount, unescaped);
             }
+        }
+
+        fieldCount++;
+        position = nextPosition;
+        return true;
+    }
+
+    private static bool CompleteTextFinalUnescapedQuotedRecordFieldSpansFromPrefix<TVisitor>(
+        ReadOnlySpan<char> text,
+        bool emitFields,
+        int recordIndex,
+        ReadOnlySpan<int> delimiterIndexesBeforeQuote,
+        int start,
+        int valueStart,
+        int valueEnd,
+        ref int position,
+        ref TVisitor fieldVisitor,
+        out int fieldCount,
+        out int firstFieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        var nextPosition = valueEnd + 1;
+        if (nextPosition < text.Length)
+        {
+            var separator = text[nextPosition];
+            if (separator == '\n')
+            {
+                nextPosition++;
+            }
+            else if (separator == '\r')
+            {
+                nextPosition++;
+                if (nextPosition < text.Length && text[nextPosition] == '\n')
+                {
+                    nextPosition++;
+                }
+            }
+            else
+            {
+                fieldCount = 0;
+                firstFieldLength = 0;
+                return false;
+            }
+        }
+
+        fieldCount = 0;
+        firstFieldLength = 0;
+        var fieldStart = start;
+        foreach (var delimiterIndex in delimiterIndexesBeforeQuote)
+        {
+            VisitTextField(text.Slice(fieldStart, delimiterIndex - fieldStart), emitFields, recordIndex, fieldCount, ref fieldVisitor, ref firstFieldLength);
+            fieldCount++;
+            fieldStart = delimiterIndex + 1;
+        }
+
+        var field = text.Slice(valueStart, valueEnd - valueStart);
+        if (fieldCount == 0)
+        {
+            firstFieldLength = field.Length;
+        }
+
+        if (emitFields)
+        {
+            fieldVisitor.VisitField(recordIndex, fieldCount, field);
         }
 
         fieldCount++;

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.Quoted.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.Quoted.cs
@@ -105,13 +105,14 @@ internal static partial class CsvParser
             }
         }
 
-        var fieldStart = start;
-        foreach (var delimiterIndex in delimiterIndexesBeforeQuote)
-        {
-            VisitTextField(text.Slice(fieldStart, delimiterIndex - fieldStart), emitFields, recordIndex, fieldCount, ref fieldVisitor, ref firstFieldLength);
-            fieldCount++;
-            fieldStart = delimiterIndex + 1;
-        }
+        fieldCount = VisitTextPrefixFieldsFromDelimiterIndexes(
+            text,
+            start,
+            delimiterIndexesBeforeQuote,
+            emitFields,
+            recordIndex,
+            ref fieldVisitor,
+            out firstFieldLength);
 
         var field = text.Slice(valueStart, valueEnd - valueStart);
         var fieldLength = field.Length - escapeCount;
@@ -176,15 +177,14 @@ internal static partial class CsvParser
             }
         }
 
-        fieldCount = 0;
-        firstFieldLength = 0;
-        var fieldStart = start;
-        foreach (var delimiterIndex in delimiterIndexesBeforeQuote)
-        {
-            VisitTextField(text.Slice(fieldStart, delimiterIndex - fieldStart), emitFields, recordIndex, fieldCount, ref fieldVisitor, ref firstFieldLength);
-            fieldCount++;
-            fieldStart = delimiterIndex + 1;
-        }
+        fieldCount = VisitTextPrefixFieldsFromDelimiterIndexes(
+            text,
+            start,
+            delimiterIndexesBeforeQuote,
+            emitFields,
+            recordIndex,
+            ref fieldVisitor,
+            out firstFieldLength);
 
         var field = text.Slice(valueStart, valueEnd - valueStart);
         if (fieldCount == 0)
@@ -200,6 +200,43 @@ internal static partial class CsvParser
         fieldCount++;
         position = nextPosition;
         return true;
+    }
+
+    private static int VisitTextPrefixFieldsFromDelimiterIndexes<TVisitor>(
+        ReadOnlySpan<char> text,
+        int start,
+        ReadOnlySpan<int> delimiterIndexes,
+        bool emitFields,
+        int recordIndex,
+        ref TVisitor fieldVisitor,
+        out int firstFieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        if (!emitFields)
+        {
+            firstFieldLength = delimiterIndexes.Length == 0
+                ? 0
+                : delimiterIndexes[0] - start;
+            return delimiterIndexes.Length;
+        }
+
+        var fieldCount = 0;
+        var fieldStart = start;
+        firstFieldLength = 0;
+        foreach (var delimiterIndex in delimiterIndexes)
+        {
+            var length = delimiterIndex - fieldStart;
+            if (fieldCount == 0)
+            {
+                firstFieldLength = length;
+            }
+
+            fieldVisitor.VisitField(recordIndex, fieldCount, text.Slice(fieldStart, length));
+            fieldCount++;
+            fieldStart = delimiterIndex + 1;
+        }
+
+        return fieldCount;
     }
 
     private static bool TryReadTextQuotedRecordFieldSpansFromPrefix<TVisitor>(

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.Quoted.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.Quoted.cs
@@ -1,5 +1,7 @@
 #nullable enable
 
+using System.Runtime.CompilerServices;
+
 namespace OfficeIMO.CSV;
 
 internal static partial class CsvParser
@@ -8,6 +10,7 @@ internal static partial class CsvParser
     private const int TextStandardQuotedFieldSpanCapacity = 64;
     private const int TextQuotedPrefixReuseMinimumDelimiterCount = 4;
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool TryReadTextFinalQuotedRecordFieldSpansFromPrefix<TVisitor>(
         ReadOnlySpan<char> text,
         char delimiter,
@@ -42,18 +45,51 @@ internal static partial class CsvParser
         quotedPosition += quoteOffset;
         if (quotedPosition + 1 >= text.Length || text[quotedPosition + 1] != '"')
         {
-            return CompleteTextFinalUnescapedQuotedRecordFieldSpansFromPrefix(
+            var unescapedNextPosition = quotedPosition + 1;
+            if (unescapedNextPosition < text.Length)
+            {
+                var separator = text[unescapedNextPosition];
+                if (separator == '\n')
+                {
+                    unescapedNextPosition++;
+                }
+                else if (separator == '\r')
+                {
+                    unescapedNextPosition++;
+                    if (unescapedNextPosition < text.Length && text[unescapedNextPosition] == '\n')
+                    {
+                        unescapedNextPosition++;
+                    }
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            fieldCount = VisitTextPrefixFieldsFromDelimiterIndexes(
                 text,
+                start,
+                delimiterIndexesBeforeQuote,
                 emitFields,
                 recordIndex,
-                delimiterIndexesBeforeQuote,
-                start,
-                valueStart,
-                quotedPosition,
-                ref position,
                 ref fieldVisitor,
-                out fieldCount,
                 out firstFieldLength);
+
+            var unescapedField = text.Slice(valueStart, quotedPosition - valueStart);
+            if (fieldCount == 0)
+            {
+                firstFieldLength = unescapedField.Length;
+            }
+
+            if (emitFields)
+            {
+                fieldVisitor.VisitField(recordIndex, fieldCount, unescapedField);
+            }
+
+            fieldCount++;
+            position = unescapedNextPosition;
+            return true;
         }
 
         var escapeCount = 0;
@@ -139,69 +175,7 @@ internal static partial class CsvParser
         return true;
     }
 
-    private static bool CompleteTextFinalUnescapedQuotedRecordFieldSpansFromPrefix<TVisitor>(
-        ReadOnlySpan<char> text,
-        bool emitFields,
-        int recordIndex,
-        ReadOnlySpan<int> delimiterIndexesBeforeQuote,
-        int start,
-        int valueStart,
-        int valueEnd,
-        ref int position,
-        ref TVisitor fieldVisitor,
-        out int fieldCount,
-        out int firstFieldLength)
-        where TVisitor : struct, ICsvFieldSpanVisitor
-    {
-        var nextPosition = valueEnd + 1;
-        if (nextPosition < text.Length)
-        {
-            var separator = text[nextPosition];
-            if (separator == '\n')
-            {
-                nextPosition++;
-            }
-            else if (separator == '\r')
-            {
-                nextPosition++;
-                if (nextPosition < text.Length && text[nextPosition] == '\n')
-                {
-                    nextPosition++;
-                }
-            }
-            else
-            {
-                fieldCount = 0;
-                firstFieldLength = 0;
-                return false;
-            }
-        }
-
-        fieldCount = VisitTextPrefixFieldsFromDelimiterIndexes(
-            text,
-            start,
-            delimiterIndexesBeforeQuote,
-            emitFields,
-            recordIndex,
-            ref fieldVisitor,
-            out firstFieldLength);
-
-        var field = text.Slice(valueStart, valueEnd - valueStart);
-        if (fieldCount == 0)
-        {
-            firstFieldLength = field.Length;
-        }
-
-        if (emitFields)
-        {
-            fieldVisitor.VisitField(recordIndex, fieldCount, field);
-        }
-
-        fieldCount++;
-        position = nextPosition;
-        return true;
-    }
-
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int VisitTextPrefixFieldsFromDelimiterIndexes<TVisitor>(
         ReadOnlySpan<char> text,
         int start,

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.Quoted.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.Quoted.cs
@@ -1,0 +1,296 @@
+#nullable enable
+
+namespace OfficeIMO.CSV;
+
+internal static partial class CsvParser
+{
+#if NET8_0_OR_GREATER
+    private const int TextStandardQuotedFieldSpanCapacity = 64;
+    private const int TextQuotedPrefixReuseMinimumDelimiterCount = 4;
+
+    private static bool TryReadTextStandardQuotedRecordFieldSpansFromPrefix<TVisitor>(
+        ReadOnlySpan<char> text,
+        char delimiter,
+        bool allowEmpty,
+        bool emitFields,
+        int recordIndex,
+        ReadOnlySpan<int> delimiterIndexesBeforeQuote,
+        int quoteIndex,
+        ref int position,
+        ref TVisitor fieldVisitor,
+        ref char[]? scratch,
+        out int fieldCount,
+        out int firstFieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        fieldCount = 0;
+        firstFieldLength = 0;
+        var start = position;
+        Span<TextStandardFieldSpan> fields = stackalloc TextStandardFieldSpan[TextStandardQuotedFieldSpanCapacity];
+        var fieldStart = start;
+
+        foreach (var delimiterIndex in delimiterIndexesBeforeQuote)
+        {
+            if (delimiterIndex < fieldStart || delimiterIndex >= quoteIndex)
+            {
+                return false;
+            }
+
+            var field = new TextStandardFieldSpan(
+                fieldStart,
+                delimiterIndex,
+                delimiterIndex - fieldStart,
+                hasEscapedQuotes: false,
+                firstEscapedQuote: -1);
+            if (!TryAddTextStandardField(fields, ref fieldCount, field, ref firstFieldLength))
+            {
+                return false;
+            }
+
+            fieldStart = delimiterIndex + 1;
+        }
+
+        if (fieldStart != quoteIndex)
+        {
+            return false;
+        }
+
+        var index = quoteIndex;
+        if (!TryParseTextStandardQuotedField(text, delimiter, ref index, out var quotedField) ||
+            !TryAddTextStandardField(fields, ref fieldCount, quotedField, ref firstFieldLength) ||
+            !TryParseTextStandardQuotedFieldSpanTail(text, delimiter, ref index, fields, ref fieldCount, ref firstFieldLength, out var recordEnd))
+        {
+            return false;
+        }
+
+        if (emitFields && (allowEmpty || recordEnd > start))
+        {
+            VisitTextStandardFieldSpans(text, fields.Slice(0, fieldCount), recordIndex, ref fieldVisitor, ref scratch);
+        }
+
+        position = recordEnd;
+        if (position < text.Length)
+        {
+            ConsumeTextLineSeparator(text, ref position);
+        }
+
+        return true;
+    }
+
+    private static bool TryParseTextStandardQuotedFieldSpanTail(
+        ReadOnlySpan<char> text,
+        char delimiter,
+        ref int index,
+        Span<TextStandardFieldSpan> fields,
+        ref int fieldCount,
+        ref int firstFieldLength,
+        out int recordEnd)
+    {
+        recordEnd = -1;
+        var pendingTrailingField = false;
+
+        while (index < text.Length)
+        {
+            var value = text[index];
+            if (value == '\r' || value == '\n')
+            {
+                if (pendingTrailingField &&
+                    !TryAddTextStandardField(fields, ref fieldCount, new TextStandardFieldSpan(index, index, 0, hasEscapedQuotes: false, firstEscapedQuote: -1), ref firstFieldLength))
+                {
+                    return false;
+                }
+
+                recordEnd = index;
+                return true;
+            }
+
+            if (value == delimiter)
+            {
+                index++;
+                pendingTrailingField = true;
+                continue;
+            }
+
+            if (!pendingTrailingField)
+            {
+                return false;
+            }
+
+            TextStandardFieldSpan field;
+            if (value == '"')
+            {
+                if (!TryParseTextStandardQuotedField(text, delimiter, ref index, out field))
+                {
+                    return false;
+                }
+            }
+            else if (!TryParseTextStandardUnquotedField(text, delimiter, ref index, out field))
+            {
+                return false;
+            }
+
+            if (!TryAddTextStandardField(fields, ref fieldCount, field, ref firstFieldLength))
+            {
+                return false;
+            }
+
+            pendingTrailingField = false;
+        }
+
+        if (pendingTrailingField &&
+            !TryAddTextStandardField(fields, ref fieldCount, new TextStandardFieldSpan(text.Length, text.Length, 0, hasEscapedQuotes: false, firstEscapedQuote: -1), ref firstFieldLength))
+        {
+            return false;
+        }
+
+        recordEnd = text.Length;
+        return fieldCount != 0;
+    }
+
+    private static bool TryParseTextStandardQuotedField(
+        ReadOnlySpan<char> text,
+        char delimiter,
+        ref int index,
+        out TextStandardFieldSpan field)
+    {
+        index++;
+        var valueStart = index;
+        var escapeCount = 0;
+        var firstEscapedQuote = -1;
+
+        while (index < text.Length)
+        {
+            var quoteOffset = text.Slice(index).IndexOf('"');
+            if (quoteOffset < 0)
+            {
+                field = default;
+                return false;
+            }
+
+            index += quoteOffset;
+            if (index + 1 < text.Length && text[index + 1] == '"')
+            {
+                if (firstEscapedQuote < 0)
+                {
+                    firstEscapedQuote = index;
+                }
+
+                escapeCount++;
+                index += 2;
+                continue;
+            }
+
+            var valueEnd = index;
+            index++;
+            if (index < text.Length &&
+                text[index] != delimiter &&
+                text[index] != '\r' &&
+                text[index] != '\n')
+            {
+                field = default;
+                return false;
+            }
+
+            field = new TextStandardFieldSpan(valueStart, valueEnd, valueEnd - valueStart - escapeCount, escapeCount != 0, firstEscapedQuote);
+            return true;
+        }
+
+        field = default;
+        return false;
+    }
+
+    private static bool TryParseTextStandardUnquotedField(
+        ReadOnlySpan<char> text,
+        char delimiter,
+        ref int index,
+        out TextStandardFieldSpan field)
+    {
+        var start = index;
+        var remaining = text.Slice(index);
+        var terminatorOffset = delimiter switch
+        {
+            ',' => remaining.IndexOfAny(CommaTextFieldTerminators),
+            ';' => remaining.IndexOfAny(SemicolonTextFieldTerminators),
+            '\t' => remaining.IndexOfAny(TabTextFieldTerminators),
+            _ => remaining.IndexOfAny(new[] { delimiter, '\r', '\n', '"' })
+        };
+
+        if (terminatorOffset < 0)
+        {
+            index = text.Length;
+        }
+        else
+        {
+            index += terminatorOffset;
+            if (text[index] == '"')
+            {
+                field = default;
+                return false;
+            }
+        }
+
+        field = new TextStandardFieldSpan(start, index, index - start, hasEscapedQuotes: false, firstEscapedQuote: -1);
+        return true;
+    }
+
+    private static void VisitTextStandardFieldSpans<TVisitor>(
+        ReadOnlySpan<char> text,
+        ReadOnlySpan<TextStandardFieldSpan> fields,
+        int recordIndex,
+        ref TVisitor fieldVisitor,
+        ref char[]? scratch)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        for (var fieldIndex = 0; fieldIndex < fields.Length; fieldIndex++)
+        {
+            var field = fields[fieldIndex];
+            var value = field.HasEscapedQuotes
+                ? UnescapeTextQuotedField(text.Slice(field.Start, field.End - field.Start), field.FirstEscapedQuote - field.Start, field.Length, ref scratch)
+                : text.Slice(field.Start, field.Length);
+            fieldVisitor.VisitField(recordIndex, fieldIndex, value);
+        }
+    }
+
+    private static bool TryAddTextStandardField(
+        Span<TextStandardFieldSpan> fields,
+        ref int fieldCount,
+        TextStandardFieldSpan field,
+        ref int firstFieldLength)
+    {
+        if (fieldCount >= fields.Length)
+        {
+            return false;
+        }
+
+        if (fieldCount == 0)
+        {
+            firstFieldLength = field.Length;
+        }
+
+        fields[fieldCount++] = field;
+        return true;
+    }
+
+    private readonly struct TextStandardFieldSpan
+    {
+        public TextStandardFieldSpan(int start, int end, int length, bool hasEscapedQuotes, int firstEscapedQuote)
+        {
+            Start = start;
+            End = end;
+            Length = length;
+            HasEscapedQuotes = hasEscapedQuotes;
+            FirstEscapedQuote = firstEscapedQuote;
+        }
+
+        public int Start { get; }
+
+        public int End { get; }
+
+        public int Length { get; }
+
+        public bool HasEscapedQuotes { get; }
+
+        public int FirstEscapedQuote { get; }
+    }
+#endif
+}

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
@@ -295,6 +295,7 @@ internal static partial class CsvParser
                             quoteMask,
                             carriageReturnMask,
                             lineFeedMask,
+                            delimiterVector,
                             ref position,
                             ref fieldVisitor,
                             ref scratch,

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
@@ -13,6 +13,7 @@ internal static partial class CsvParser
     private static readonly System.Runtime.Intrinsics.Vector256<byte> QuoteByteVector = System.Runtime.Intrinsics.Vector256.Create((byte)'"');
     private static readonly System.Runtime.Intrinsics.Vector256<byte> CarriageReturnByteVector = System.Runtime.Intrinsics.Vector256.Create((byte)'\r');
     private static readonly System.Runtime.Intrinsics.Vector256<byte> LineFeedByteVector = System.Runtime.Intrinsics.Vector256.Create((byte)'\n');
+    private const int TextQuoteFreeProbeMinimumLength = 2_000_000;
 
     internal static void ReadFieldSpans<TVisitor>(
         ReadOnlySpan<char> text,
@@ -28,6 +29,7 @@ internal static partial class CsvParser
         var recordIndex = 0;
         var emittedRecordCount = 0;
         var useAvx2UnquotedFastPath = true;
+        var textMayContainQuote = text.Length < TextQuoteFreeProbeMinimumLength || text.IndexOf('"') >= 0;
         var unquotedDelimiterIndexCapacity = 64;
         char[]? scratch = null;
         var delimiterVector = System.Runtime.Intrinsics.Vector256<byte>.Zero;
@@ -74,6 +76,7 @@ internal static partial class CsvParser
                         recordIndex,
                         ref useAvx2UnquotedFastPath,
                         ref unquotedDelimiterIndexCapacity,
+                        textMayContainQuote,
                         delimiterVector,
                         ref position,
                         ref fieldVisitor,
@@ -133,6 +136,7 @@ internal static partial class CsvParser
         int recordIndex,
         ref bool useAvx2UnquotedFastPath,
         ref int unquotedDelimiterIndexCapacity,
+        bool textMayContainQuote,
         System.Runtime.Intrinsics.Vector256<byte> delimiterVector,
         ref int position,
         ref TVisitor fieldVisitor,
@@ -146,6 +150,26 @@ internal static partial class CsvParser
 
 #if NET8_0_OR_GREATER
         var encounteredQuote = false;
+        if (useAvx2UnquotedFastPath &&
+            !trim &&
+            delimiter <= byte.MaxValue &&
+            System.Runtime.Intrinsics.X86.Avx2.IsSupported &&
+            !textMayContainQuote &&
+            TryReadTextQuoteFreeRecordFieldSpansAvx2(
+                text,
+                delimiter,
+                allowEmpty,
+                emitFields,
+                recordIndex,
+                delimiterVector,
+                ref position,
+                ref fieldVisitor,
+                out fieldCount,
+                out firstFieldLength))
+        {
+            return true;
+        }
+
         if (useAvx2UnquotedFastPath &&
             !trim &&
             delimiter <= byte.MaxValue &&
@@ -175,7 +199,9 @@ internal static partial class CsvParser
 #endif
 
         var start = position;
-        var specialOffset = text.Slice(start).IndexOfAny('"', '\r', '\n');
+        var specialOffset = textMayContainQuote
+            ? text.Slice(start).IndexOfAny('"', '\r', '\n')
+            : text.Slice(start).IndexOfAny('\r', '\n');
         var endsAtTextEnd = false;
         int recordEnd;
         if (specialOffset < 0)

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
@@ -1,0 +1,764 @@
+#nullable enable
+
+using System.Buffers;
+
+namespace OfficeIMO.CSV;
+
+internal static partial class CsvParser
+{
+#if NET8_0_OR_GREATER
+    private static readonly SearchValues<char> CommaTextFieldTerminators = SearchValues.Create(",\r\n\"");
+    private static readonly SearchValues<char> SemicolonTextFieldTerminators = SearchValues.Create(";\r\n\"");
+    private static readonly SearchValues<char> TabTextFieldTerminators = SearchValues.Create("\t\r\n\"");
+
+    internal static void ReadFieldSpans<TVisitor>(
+        ReadOnlySpan<char> text,
+        CsvLoadOptions options,
+        int recordsToSkip,
+        ref TVisitor fieldVisitor)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        var delimiter = options.Delimiter;
+        var trim = options.TrimWhitespace;
+        var allowEmpty = options.AllowEmptyLines;
+        var position = 0;
+        var recordIndex = 0;
+        var emittedRecordCount = 0;
+        var useAvx2UnquotedFastPath = true;
+        char[]? scratch = null;
+
+        try
+        {
+            while (position < text.Length)
+            {
+                var recordStart = position;
+                if (TrySkipTextEmptyRecord(text, trim, allowEmpty, ref position))
+                {
+                    continue;
+                }
+
+                var skipCommentRecord = options.SkipCommentRows &&
+                    text[position] == options.CommentCharacter &&
+                    !CanReadW3CFieldsHeader(options, emittedRecordCount);
+                var emitFields = recordsToSkip == 0 && !skipCommentRecord;
+                int fieldCount;
+                int firstFieldLength;
+                if (skipCommentRecord ||
+                    !TryReadTextUnquotedRecordFieldSpans(
+                        text,
+                        delimiter,
+                        trim,
+                        allowEmpty,
+                        emitFields,
+                        recordIndex,
+                        ref useAvx2UnquotedFastPath,
+                        ref position,
+                        ref fieldVisitor,
+                        ref scratch,
+                        out fieldCount,
+                        out firstFieldLength))
+                {
+                    fieldCount = ReadTextRecordFieldSpans(
+                        text,
+                        delimiter,
+                        trim,
+                        emitFields,
+                        recordIndex,
+                        ref position,
+                        ref fieldVisitor,
+                        ref scratch,
+                        out firstFieldLength);
+                }
+
+                var isEmptyRecord = fieldCount == 1 && firstFieldLength == 0;
+                var shouldEmit = fieldCount != 0 && (allowEmpty || !isEmptyRecord);
+                if (!shouldEmit || skipCommentRecord)
+                {
+                    continue;
+                }
+
+                if (recordsToSkip > 0)
+                {
+                    recordsToSkip--;
+                    continue;
+                }
+
+                recordIndex++;
+                emittedRecordCount++;
+
+                if (position == recordStart)
+                {
+                    break;
+                }
+            }
+        }
+        finally
+        {
+            if (scratch != null)
+            {
+                ArrayPool<char>.Shared.Return(scratch);
+            }
+        }
+    }
+
+    private static bool TryReadTextUnquotedRecordFieldSpans<TVisitor>(
+        ReadOnlySpan<char> text,
+        char delimiter,
+        bool trim,
+        bool allowEmpty,
+        bool emitFields,
+        int recordIndex,
+        ref bool useAvx2UnquotedFastPath,
+        ref int position,
+        ref TVisitor fieldVisitor,
+        ref char[]? scratch,
+        out int fieldCount,
+        out int firstFieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        fieldCount = 0;
+        firstFieldLength = 0;
+
+#if NET8_0_OR_GREATER
+        var encounteredQuote = false;
+        if (useAvx2UnquotedFastPath &&
+            !trim &&
+            delimiter <= byte.MaxValue &&
+            System.Runtime.Intrinsics.X86.Avx2.IsSupported &&
+            TryReadTextUnquotedRecordFieldSpansAvx2(
+                text,
+                delimiter,
+                allowEmpty,
+                emitFields,
+                recordIndex,
+                ref position,
+                ref fieldVisitor,
+                ref scratch,
+                out fieldCount,
+                out firstFieldLength,
+                out encounteredQuote))
+        {
+            return true;
+        }
+
+        if (encounteredQuote)
+        {
+            useAvx2UnquotedFastPath = false;
+        }
+#endif
+
+        var start = position;
+        var specialOffset = text.Slice(start).IndexOfAny('"', '\r', '\n');
+        var endsAtTextEnd = false;
+        int recordEnd;
+        if (specialOffset < 0)
+        {
+            recordEnd = text.Length;
+            endsAtTextEnd = true;
+        }
+        else
+        {
+            recordEnd = start + specialOffset;
+            if (text[recordEnd] == '"')
+            {
+                return false;
+            }
+        }
+
+        var emitNonEmptyRecord = allowEmpty || (trim
+            ? HasTextNonWhitespaceOrDelimiter(text.Slice(start, recordEnd - start), delimiter)
+            : recordEnd != start);
+        fieldCount = VisitTextUnquotedFieldSpans(
+            text,
+            start,
+            recordEnd,
+            delimiter,
+            trim,
+            emitNonEmptyRecord && emitFields,
+            recordIndex,
+            ref fieldVisitor,
+            out firstFieldLength);
+        position = recordEnd;
+        if (!endsAtTextEnd)
+        {
+            ConsumeTextLineSeparator(text, ref position);
+        }
+
+        return true;
+    }
+
+    private static bool TryReadTextUnquotedRecordFieldSpansAvx2<TVisitor>(
+        ReadOnlySpan<char> text,
+        char delimiter,
+        bool allowEmpty,
+        bool emitFields,
+        int recordIndex,
+        ref int position,
+        ref TVisitor fieldVisitor,
+        ref char[]? scratch,
+        out int fieldCount,
+        out int firstFieldLength,
+        out bool encounteredQuote)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        fieldCount = 0;
+        firstFieldLength = 0;
+        encounteredQuote = false;
+
+        var start = position;
+        var end = text.Length - 32;
+        if (start > end)
+        {
+            return false;
+        }
+
+        Span<int> delimiterIndexes = stackalloc int[64];
+        var delimiterCount = 0;
+        var pos = start;
+        var delimiterVector = System.Runtime.Intrinsics.Vector256.Create((byte)delimiter);
+        var quoteVector = System.Runtime.Intrinsics.Vector256.Create((byte)'"');
+        var carriageReturnVector = System.Runtime.Intrinsics.Vector256.Create((byte)'\r');
+        var lineFeedVector = System.Runtime.Intrinsics.Vector256.Create((byte)'\n');
+
+        while (pos <= end)
+        {
+            var values = System.Runtime.InteropServices.MemoryMarshal.Cast<char, short>(text.Slice(pos, 32));
+            var first = System.Runtime.Intrinsics.Vector256.LoadUnsafe(ref System.Runtime.InteropServices.MemoryMarshal.GetReference(values));
+            var second = System.Runtime.Intrinsics.Vector256.LoadUnsafe(ref System.Runtime.InteropServices.MemoryMarshal.GetReference(values.Slice(16)));
+            var packed = System.Runtime.Intrinsics.X86.Avx2.PackUnsignedSaturate(first, second);
+            var packedBytes = System.Runtime.Intrinsics.Vector256.AsByte(
+                System.Runtime.Intrinsics.X86.Avx2.Permute4x64(System.Runtime.Intrinsics.Vector256.AsInt64(packed), 0b11_01_10_00));
+
+            var delimiterMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, delimiterVector));
+            var quoteMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, quoteVector));
+            var carriageReturnMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, carriageReturnVector));
+            var lineFeedMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, lineFeedVector));
+            var terminalMask = quoteMask | carriageReturnMask | lineFeedMask;
+
+            if (terminalMask != 0)
+            {
+                var terminalOffset = System.Numerics.BitOperations.TrailingZeroCount(terminalMask);
+                var delimiterMaskBeforeTerminal = delimiterMask & ((1u << terminalOffset) - 1u);
+                if (!AddTextDelimiterIndexes(delimiterMaskBeforeTerminal, pos, delimiterIndexes, ref delimiterCount))
+                {
+                    return false;
+                }
+
+                if (((quoteMask >> terminalOffset) & 1u) != 0)
+                {
+                    encounteredQuote = true;
+                    var quoteIndex = pos + terminalOffset;
+                    if (delimiterCount >= TextQuotedPrefixReuseMinimumDelimiterCount &&
+                        TryReadTextStandardQuotedRecordFieldSpansFromPrefix(
+                            text,
+                            delimiter,
+                            allowEmpty,
+                            emitFields,
+                            recordIndex,
+                            delimiterIndexes.Slice(0, delimiterCount),
+                            quoteIndex,
+                            ref position,
+                            ref fieldVisitor,
+                            ref scratch,
+                            out fieldCount,
+                            out firstFieldLength))
+                    {
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                var recordEnd = pos + terminalOffset;
+                var lineLength = recordEnd - start;
+                fieldCount = VisitIndexedTextUntrimmedUnquotedFieldSpans(
+                    text,
+                    start,
+                    recordEnd,
+                    delimiterIndexes.Slice(0, delimiterCount),
+                    (allowEmpty || lineLength != 0) && emitFields,
+                    recordIndex,
+                    ref fieldVisitor,
+                    out firstFieldLength);
+                position = recordEnd;
+                ConsumeTextLineSeparator(text, ref position);
+                return true;
+            }
+
+            if (!AddTextDelimiterIndexes(delimiterMask, pos, delimiterIndexes, ref delimiterCount))
+            {
+                return false;
+            }
+
+            pos += 32;
+        }
+
+        return false;
+    }
+
+    private static int VisitIndexedTextUntrimmedUnquotedFieldSpans<TVisitor>(
+        ReadOnlySpan<char> text,
+        int start,
+        int end,
+        ReadOnlySpan<int> delimiterIndexes,
+        bool emit,
+        int recordIndex,
+        ref TVisitor fieldVisitor,
+        out int firstFieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        var fieldIndex = 0;
+        var fieldStart = start;
+        firstFieldLength = 0;
+        foreach (var delimiterIndex in delimiterIndexes)
+        {
+            var length = delimiterIndex - fieldStart;
+            if (fieldIndex == 0)
+            {
+                firstFieldLength = length;
+            }
+
+            if (emit)
+            {
+                fieldVisitor.VisitField(recordIndex, fieldIndex, text.Slice(fieldStart, length));
+            }
+
+            fieldIndex++;
+            fieldStart = delimiterIndex + 1;
+        }
+
+        var finalLength = end - fieldStart;
+        if (fieldIndex == 0)
+        {
+            firstFieldLength = finalLength;
+        }
+
+        if (emit)
+        {
+            fieldVisitor.VisitField(recordIndex, fieldIndex, text.Slice(fieldStart, finalLength));
+        }
+
+        return fieldIndex + 1;
+    }
+
+    private static bool AddTextDelimiterIndexes(uint delimiterMask, int chunkStart, Span<int> delimiterIndexes, ref int delimiterCount)
+    {
+        while (delimiterMask != 0)
+        {
+            if (delimiterCount == delimiterIndexes.Length)
+            {
+                return false;
+            }
+
+            var offset = System.Numerics.BitOperations.TrailingZeroCount(delimiterMask);
+            delimiterIndexes[delimiterCount++] = chunkStart + offset;
+            delimiterMask &= delimiterMask - 1;
+        }
+
+        return true;
+    }
+
+    private static bool HasTextNonWhitespaceOrDelimiter(ReadOnlySpan<char> text, char delimiter)
+    {
+        foreach (var value in text)
+        {
+            if (value == delimiter || !char.IsWhiteSpace(value))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static int VisitTextUnquotedFieldSpans<TVisitor>(
+        ReadOnlySpan<char> text,
+        int start,
+        int end,
+        char delimiter,
+        bool trim,
+        bool emit,
+        int recordIndex,
+        ref TVisitor fieldVisitor,
+        out int firstFieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        var fieldIndex = 0;
+        var fieldStart = start;
+        firstFieldLength = 0;
+        for (var i = start; i < end; i++)
+        {
+            if (text[i] != delimiter)
+            {
+                continue;
+            }
+
+            VisitTextField(text.Slice(fieldStart, i - fieldStart), trim, emit, recordIndex, fieldIndex, ref fieldVisitor, ref firstFieldLength);
+            fieldIndex++;
+            fieldStart = i + 1;
+        }
+
+        VisitTextField(text.Slice(fieldStart, end - fieldStart), trim, emit, recordIndex, fieldIndex, ref fieldVisitor, ref firstFieldLength);
+        return fieldIndex + 1;
+    }
+
+    private static bool TrySkipTextEmptyRecord(ReadOnlySpan<char> text, bool trim, bool allowEmpty, ref int position)
+    {
+        if (allowEmpty)
+        {
+            return false;
+        }
+
+        if (text[position] == '\r' || text[position] == '\n')
+        {
+            ConsumeTextLineSeparator(text, ref position);
+            return true;
+        }
+
+        if (!trim)
+        {
+            return false;
+        }
+
+        var scan = position;
+        while (scan < text.Length)
+        {
+            var value = text[scan];
+            if (value == '\r' || value == '\n')
+            {
+                position = scan;
+                ConsumeTextLineSeparator(text, ref position);
+                return true;
+            }
+
+            if (!char.IsWhiteSpace(value))
+            {
+                return false;
+            }
+
+            scan++;
+        }
+
+        position = scan;
+        return true;
+    }
+
+    private static int ReadTextRecordFieldSpans<TVisitor>(
+        ReadOnlySpan<char> text,
+        char delimiter,
+        bool trim,
+        bool emitFields,
+        int recordIndex,
+        ref int position,
+        ref TVisitor fieldVisitor,
+        ref char[]? scratch,
+        out int firstFieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        var fieldIndex = 0;
+        var pendingTrailingField = false;
+        firstFieldLength = 0;
+
+        while (position < text.Length)
+        {
+            var value = text[position];
+            if (value == '\r' || value == '\n')
+            {
+                if (pendingTrailingField || fieldIndex == 0)
+                {
+                    VisitTextField(text.Slice(position, 0), emitFields, recordIndex, fieldIndex, ref fieldVisitor, ref firstFieldLength);
+                    fieldIndex++;
+                }
+
+                ConsumeTextLineSeparator(text, ref position);
+                return fieldIndex;
+            }
+
+            if (value == delimiter)
+            {
+                VisitTextField(text.Slice(position, 0), emitFields, recordIndex, fieldIndex, ref fieldVisitor, ref firstFieldLength);
+                fieldIndex++;
+                position++;
+                pendingTrailingField = true;
+                continue;
+            }
+
+            pendingTrailingField = false;
+            if (value == '"')
+            {
+                if (!TryVisitTextQuotedField(text, delimiter, trim, emitFields, recordIndex, fieldIndex, ref position, ref fieldVisitor, ref scratch, out var quotedLength))
+                {
+                    throw new CsvParseException("Unterminated quoted field.", 0);
+                }
+
+                if (fieldIndex == 0)
+                {
+                    firstFieldLength = quotedLength;
+                }
+            }
+            else
+            {
+                var field = ReadTextUnquotedField(text, delimiter, trim, ref position);
+                VisitTextField(field, emitFields, recordIndex, fieldIndex, ref fieldVisitor, ref firstFieldLength);
+            }
+
+            fieldIndex++;
+            if (position >= text.Length)
+            {
+                return fieldIndex;
+            }
+
+            value = text[position];
+            if (value == delimiter)
+            {
+                position++;
+                pendingTrailingField = true;
+                continue;
+            }
+
+            if (value == '\r' || value == '\n')
+            {
+                ConsumeTextLineSeparator(text, ref position);
+                return fieldIndex;
+            }
+
+            throw new CsvParseException("Unexpected character after CSV field.", 0);
+        }
+
+        if (pendingTrailingField)
+        {
+            VisitTextField(text.Slice(text.Length, 0), emitFields, recordIndex, fieldIndex, ref fieldVisitor, ref firstFieldLength);
+            fieldIndex++;
+        }
+
+        return fieldIndex;
+    }
+
+    private static ReadOnlySpan<char> ReadTextUnquotedField(ReadOnlySpan<char> text, char delimiter, bool trim, ref int position)
+    {
+        var start = position;
+        var remaining = text.Slice(position);
+        var terminatorOffset = delimiter switch
+        {
+            ',' => remaining.IndexOfAny(CommaTextFieldTerminators),
+            ';' => remaining.IndexOfAny(SemicolonTextFieldTerminators),
+            '\t' => remaining.IndexOfAny(TabTextFieldTerminators),
+            _ => remaining.IndexOfAny(new[] { delimiter, '\r', '\n', '"' })
+        };
+        if (terminatorOffset < 0)
+        {
+            position = text.Length;
+        }
+        else
+        {
+            position += terminatorOffset;
+            if (text[position] == '"')
+            {
+                throw new CsvParseException("Unexpected quote in unquoted CSV field.", 0);
+            }
+        }
+
+        var field = text.Slice(start, position - start);
+        return trim ? TrimTextField(field) : field;
+    }
+
+    private static bool TryVisitTextQuotedField<TVisitor>(
+        ReadOnlySpan<char> text,
+        char delimiter,
+        bool trim,
+        bool emitFields,
+        int recordIndex,
+        int fieldIndex,
+        ref int position,
+        ref TVisitor fieldVisitor,
+        ref char[]? scratch,
+        out int fieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        position++;
+        var valueStart = position;
+        var escapeCount = 0;
+        var firstEscapedQuote = -1;
+
+        while (position < text.Length)
+        {
+            var quoteOffset = text.Slice(position).IndexOf('"');
+            if (quoteOffset < 0)
+            {
+                fieldLength = 0;
+                return false;
+            }
+
+            position += quoteOffset;
+            if (position + 1 < text.Length && text[position + 1] == '"')
+            {
+                if (firstEscapedQuote < 0)
+                {
+                    firstEscapedQuote = position;
+                }
+
+                escapeCount++;
+                position += 2;
+                continue;
+            }
+
+            var valueEnd = position;
+            position++;
+            if (trim)
+            {
+                while (position < text.Length &&
+                    text[position] != delimiter &&
+                    text[position] != '\r' &&
+                    text[position] != '\n' &&
+                    char.IsWhiteSpace(text[position]))
+                {
+                    position++;
+                }
+            }
+
+            fieldLength = valueEnd - valueStart - escapeCount;
+            if (!emitFields)
+            {
+                return true;
+            }
+
+            var field = text.Slice(valueStart, valueEnd - valueStart);
+            if (escapeCount == 0)
+            {
+                fieldVisitor.VisitField(recordIndex, fieldIndex, field);
+                return true;
+            }
+
+            var unescaped = UnescapeTextQuotedField(field, firstEscapedQuote - valueStart, fieldLength, ref scratch);
+            fieldVisitor.VisitField(recordIndex, fieldIndex, unescaped);
+            return true;
+        }
+
+        fieldLength = 0;
+        return false;
+    }
+
+    private static ReadOnlySpan<char> UnescapeTextQuotedField(
+        ReadOnlySpan<char> field,
+        int firstEscapedQuote,
+        int fieldLength,
+        ref char[]? scratch)
+    {
+        if (scratch == null || scratch.Length < fieldLength)
+        {
+            if (scratch != null)
+            {
+                ArrayPool<char>.Shared.Return(scratch);
+            }
+
+            scratch = ArrayPool<char>.Shared.Rent(fieldLength);
+        }
+
+        var readIndex = firstEscapedQuote >= 0 ? firstEscapedQuote : 0;
+        if (readIndex > 0)
+        {
+            field.Slice(0, readIndex).CopyTo(scratch.AsSpan());
+        }
+
+        var writeIndex = readIndex;
+        while (readIndex < field.Length)
+        {
+            var quoteOffset = field.Slice(readIndex).IndexOf('"');
+            if (quoteOffset < 0)
+            {
+                field.Slice(readIndex).CopyTo(scratch.AsSpan(writeIndex));
+                writeIndex += field.Length - readIndex;
+                break;
+            }
+
+            if (quoteOffset > 0)
+            {
+                field.Slice(readIndex, quoteOffset).CopyTo(scratch.AsSpan(writeIndex));
+                writeIndex += quoteOffset;
+                readIndex += quoteOffset;
+            }
+
+            if (readIndex + 1 < field.Length && field[readIndex + 1] == '"')
+            {
+                scratch[writeIndex++] = '"';
+                readIndex += 2;
+                continue;
+            }
+
+            scratch[writeIndex++] = field[readIndex++];
+        }
+
+        return scratch.AsSpan(0, writeIndex);
+    }
+
+    private static void VisitTextField<TVisitor>(
+        ReadOnlySpan<char> value,
+        bool emitFields,
+        int recordIndex,
+        int fieldIndex,
+        ref TVisitor fieldVisitor,
+        ref int firstFieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        if (fieldIndex == 0)
+        {
+            firstFieldLength = value.Length;
+        }
+
+        if (emitFields)
+        {
+            fieldVisitor.VisitField(recordIndex, fieldIndex, value);
+        }
+    }
+
+    private static void VisitTextField<TVisitor>(
+        ReadOnlySpan<char> value,
+        bool trim,
+        bool emitFields,
+        int recordIndex,
+        int fieldIndex,
+        ref TVisitor fieldVisitor,
+        ref int firstFieldLength)
+        where TVisitor : struct, ICsvFieldSpanVisitor
+    {
+        if (trim)
+        {
+            value = TrimTextField(value);
+        }
+
+        VisitTextField(value, emitFields, recordIndex, fieldIndex, ref fieldVisitor, ref firstFieldLength);
+    }
+
+    private static ReadOnlySpan<char> TrimTextField(ReadOnlySpan<char> field)
+    {
+        var start = 0;
+        var end = field.Length;
+        while (start < end && char.IsWhiteSpace(field[start]))
+        {
+            start++;
+        }
+
+        while (end > start && char.IsWhiteSpace(field[end - 1]))
+        {
+            end--;
+        }
+
+        return field.Slice(start, end - start);
+    }
+
+    private static void ConsumeTextLineSeparator(ReadOnlySpan<char> text, ref int position)
+    {
+        if (text[position] == '\r' && position + 1 < text.Length && text[position + 1] == '\n')
+        {
+            position += 2;
+            return;
+        }
+
+        position++;
+    }
+#endif
+}

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
@@ -270,7 +270,19 @@ internal static partial class CsvParser
 
                     var quoteIndex = pos + terminalOffset;
                     if (delimiterCount >= TextQuotedPrefixReuseMinimumDelimiterCount &&
-                        (TryReadTextQuotedRecordFieldSpansFromPrefix(
+                        (TryReadTextFinalQuotedRecordFieldSpansFromPrefix(
+                            text,
+                            delimiter,
+                            emitFields,
+                            recordIndex,
+                            delimiterIndexes.Slice(0, delimiterCount),
+                            quoteIndex,
+                            ref position,
+                            ref fieldVisitor,
+                            ref scratch,
+                            out fieldCount,
+                            out firstFieldLength) ||
+                         TryReadTextQuotedRecordFieldSpansFromPrefix(
                             text,
                             delimiter,
                             emitFields,

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
@@ -251,6 +251,23 @@ internal static partial class CsvParser
                 if (((quoteMask >> terminalOffset) & 1u) != 0)
                 {
                     encounteredQuote = true;
+                    if (delimiterCount <= 2 &&
+                        TryReadTextQuoteAwareRecordFieldSpansAvx2(
+                            text,
+                            delimiter,
+                            allowEmpty,
+                            emitFields,
+                            recordIndex,
+                            start,
+                            ref position,
+                            ref fieldVisitor,
+                            ref scratch,
+                            out fieldCount,
+                            out firstFieldLength))
+                    {
+                        return true;
+                    }
+
                     var quoteIndex = pos + terminalOffset;
                     if (delimiterCount >= TextQuotedPrefixReuseMinimumDelimiterCount &&
                         (TryReadTextQuotedRecordFieldSpansFromPrefix(

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
@@ -253,7 +253,19 @@ internal static partial class CsvParser
                     encounteredQuote = true;
                     var quoteIndex = pos + terminalOffset;
                     if (delimiterCount >= TextQuotedPrefixReuseMinimumDelimiterCount &&
-                        TryReadTextStandardQuotedRecordFieldSpansFromPrefix(
+                        (TryReadTextQuotedRecordFieldSpansFromPrefix(
+                            text,
+                            delimiter,
+                            emitFields,
+                            recordIndex,
+                            delimiterIndexes.Slice(0, delimiterCount),
+                            quoteIndex,
+                            ref position,
+                            ref fieldVisitor,
+                            ref scratch,
+                            out fieldCount,
+                            out firstFieldLength) ||
+                         TryReadTextStandardQuotedRecordFieldSpansFromPrefix(
                             text,
                             delimiter,
                             allowEmpty,
@@ -265,7 +277,7 @@ internal static partial class CsvParser
                             ref fieldVisitor,
                             ref scratch,
                             out fieldCount,
-                            out firstFieldLength))
+                            out firstFieldLength)))
                     {
                         return true;
                     }

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
@@ -13,7 +13,7 @@ internal static partial class CsvParser
     private static readonly System.Runtime.Intrinsics.Vector256<byte> QuoteByteVector = System.Runtime.Intrinsics.Vector256.Create((byte)'"');
     private static readonly System.Runtime.Intrinsics.Vector256<byte> CarriageReturnByteVector = System.Runtime.Intrinsics.Vector256.Create((byte)'\r');
     private static readonly System.Runtime.Intrinsics.Vector256<byte> LineFeedByteVector = System.Runtime.Intrinsics.Vector256.Create((byte)'\n');
-    private const int TextQuoteFreeProbeMinimumLength = 2_000_000;
+    private const int TextQuoteFreeProbeMinimumLength = 64 * 1024;
 
     internal static void ReadFieldSpans<TVisitor>(
         ReadOnlySpan<char> text,

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
@@ -252,13 +252,18 @@ internal static partial class CsvParser
                 {
                     encounteredQuote = true;
                     if (delimiterCount <= 2 &&
-                        TryReadTextQuoteAwareRecordFieldSpansAvx2(
+                        TryReadTextQuoteAwareRecordFieldSpansAvx2FromCurrentChunk(
                             text,
                             delimiter,
                             allowEmpty,
                             emitFields,
                             recordIndex,
                             start,
+                            pos,
+                            delimiterMask,
+                            quoteMask,
+                            carriageReturnMask,
+                            lineFeedMask,
                             ref position,
                             ref fieldVisitor,
                             ref scratch,

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
@@ -40,6 +40,15 @@ internal static partial class CsvParser
                 var skipCommentRecord = options.SkipCommentRows &&
                     text[position] == options.CommentCharacter &&
                     !CanReadW3CFieldsHeader(options, emittedRecordCount);
+                if (recordsToSkip > 0 &&
+                    !skipCommentRecord &&
+                    !trim &&
+                    TrySkipTextUnquotedRecord(text, ref position))
+                {
+                    recordsToSkip--;
+                    continue;
+                }
+
                 var emitFields = recordsToSkip == 0 && !skipCommentRecord;
                 int fieldCount;
                 int firstFieldLength;
@@ -490,6 +499,27 @@ internal static partial class CsvParser
         }
 
         position = scan;
+        return true;
+    }
+
+    private static bool TrySkipTextUnquotedRecord(ReadOnlySpan<char> text, ref int position)
+    {
+        var start = position;
+        var specialOffset = text.Slice(start).IndexOfAny('"', '\r', '\n');
+        if (specialOffset < 0)
+        {
+            position = text.Length;
+            return text.Length != start;
+        }
+
+        var recordEnd = start + specialOffset;
+        if (text[recordEnd] == '"' || recordEnd == start)
+        {
+            return false;
+        }
+
+        position = recordEnd;
+        ConsumeTextLineSeparator(text, ref position);
         return true;
     }
 

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
@@ -633,6 +633,11 @@ internal static partial class CsvParser
                 return true;
             }
 
+            if (fieldVisitor.TryVisitEscapedField(recordIndex, fieldIndex, field, fieldLength))
+            {
+                return true;
+            }
+
             var unescaped = UnescapeTextQuotedField(field, firstEscapedQuote - valueStart, fieldLength, ref scratch);
             fieldVisitor.VisitField(recordIndex, fieldIndex, unescaped);
             return true;

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
@@ -10,6 +10,9 @@ internal static partial class CsvParser
     private static readonly SearchValues<char> CommaTextFieldTerminators = SearchValues.Create(",\r\n\"");
     private static readonly SearchValues<char> SemicolonTextFieldTerminators = SearchValues.Create(";\r\n\"");
     private static readonly SearchValues<char> TabTextFieldTerminators = SearchValues.Create("\t\r\n\"");
+    private static readonly System.Runtime.Intrinsics.Vector256<byte> QuoteByteVector = System.Runtime.Intrinsics.Vector256.Create((byte)'"');
+    private static readonly System.Runtime.Intrinsics.Vector256<byte> CarriageReturnByteVector = System.Runtime.Intrinsics.Vector256.Create((byte)'\r');
+    private static readonly System.Runtime.Intrinsics.Vector256<byte> LineFeedByteVector = System.Runtime.Intrinsics.Vector256.Create((byte)'\n');
 
     internal static void ReadFieldSpans<TVisitor>(
         ReadOnlySpan<char> text,
@@ -25,7 +28,15 @@ internal static partial class CsvParser
         var recordIndex = 0;
         var emittedRecordCount = 0;
         var useAvx2UnquotedFastPath = true;
+        var unquotedDelimiterIndexCapacity = 64;
         char[]? scratch = null;
+        var delimiterVector = System.Runtime.Intrinsics.Vector256<byte>.Zero;
+        if (!trim &&
+            delimiter <= byte.MaxValue &&
+            System.Runtime.Intrinsics.X86.Avx2.IsSupported)
+        {
+            delimiterVector = System.Runtime.Intrinsics.Vector256.Create((byte)delimiter);
+        }
 
         try
         {
@@ -43,8 +54,9 @@ internal static partial class CsvParser
                 if (recordsToSkip > 0 &&
                     !skipCommentRecord &&
                     !trim &&
-                    TrySkipTextUnquotedRecord(text, ref position))
+                    TrySkipTextUnquotedRecord(text, delimiter, ref position, out var skippedDelimiterCount))
                 {
+                    unquotedDelimiterIndexCapacity = GetTextDelimiterIndexCapacity(skippedDelimiterCount);
                     recordsToSkip--;
                     continue;
                 }
@@ -61,6 +73,8 @@ internal static partial class CsvParser
                         emitFields,
                         recordIndex,
                         ref useAvx2UnquotedFastPath,
+                        ref unquotedDelimiterIndexCapacity,
+                        delimiterVector,
                         ref position,
                         ref fieldVisitor,
                         ref scratch,
@@ -118,6 +132,8 @@ internal static partial class CsvParser
         bool emitFields,
         int recordIndex,
         ref bool useAvx2UnquotedFastPath,
+        ref int unquotedDelimiterIndexCapacity,
+        System.Runtime.Intrinsics.Vector256<byte> delimiterVector,
         ref int position,
         ref TVisitor fieldVisitor,
         ref char[]? scratch,
@@ -140,6 +156,8 @@ internal static partial class CsvParser
                 allowEmpty,
                 emitFields,
                 recordIndex,
+                ref unquotedDelimiterIndexCapacity,
+                delimiterVector,
                 ref position,
                 ref fieldVisitor,
                 ref scratch,
@@ -202,6 +220,8 @@ internal static partial class CsvParser
         bool allowEmpty,
         bool emitFields,
         int recordIndex,
+        ref int delimiterIndexCapacity,
+        System.Runtime.Intrinsics.Vector256<byte> delimiterVector,
         ref int position,
         ref TVisitor fieldVisitor,
         ref char[]? scratch,
@@ -221,13 +241,14 @@ internal static partial class CsvParser
             return false;
         }
 
-        Span<int> delimiterIndexes = stackalloc int[64];
+        Span<int> delimiterIndexes = delimiterIndexCapacity switch
+        {
+            16 => stackalloc int[16],
+            32 => stackalloc int[32],
+            _ => stackalloc int[64],
+        };
         var delimiterCount = 0;
         var pos = start;
-        var delimiterVector = System.Runtime.Intrinsics.Vector256.Create((byte)delimiter);
-        var quoteVector = System.Runtime.Intrinsics.Vector256.Create((byte)'"');
-        var carriageReturnVector = System.Runtime.Intrinsics.Vector256.Create((byte)'\r');
-        var lineFeedVector = System.Runtime.Intrinsics.Vector256.Create((byte)'\n');
 
         while (pos <= end)
         {
@@ -241,11 +262,11 @@ internal static partial class CsvParser
             var delimiterMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
                 System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, delimiterVector));
             var quoteMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
-                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, quoteVector));
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, QuoteByteVector));
             var carriageReturnMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
-                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, carriageReturnVector));
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, CarriageReturnByteVector));
             var lineFeedMask = (uint)System.Runtime.Intrinsics.X86.Avx2.MoveMask(
-                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, lineFeedVector));
+                System.Runtime.Intrinsics.X86.Avx2.CompareEqual(packedBytes, LineFeedByteVector));
             var terminalMask = quoteMask | carriageReturnMask | lineFeedMask;
 
             if (terminalMask != 0)
@@ -254,6 +275,7 @@ internal static partial class CsvParser
                 var delimiterMaskBeforeTerminal = delimiterMask & ((1u << terminalOffset) - 1u);
                 if (!AddTextDelimiterIndexes(delimiterMaskBeforeTerminal, pos, delimiterIndexes, ref delimiterCount))
                 {
+                    delimiterIndexCapacity = 64;
                     return false;
                 }
 
@@ -346,6 +368,7 @@ internal static partial class CsvParser
 
             if (!AddTextDelimiterIndexes(delimiterMask, pos, delimiterIndexes, ref delimiterCount))
             {
+                delimiterIndexCapacity = 64;
                 return false;
             }
 
@@ -366,6 +389,14 @@ internal static partial class CsvParser
         out int firstFieldLength)
         where TVisitor : struct, ICsvFieldSpanVisitor
     {
+        if (!emit)
+        {
+            firstFieldLength = delimiterIndexes.Length == 0
+                ? end - start
+                : delimiterIndexes[0] - start;
+            return delimiterIndexes.Length + 1;
+        }
+
         var fieldIndex = 0;
         var fieldStart = start;
         firstFieldLength = 0;
@@ -377,10 +408,7 @@ internal static partial class CsvParser
                 firstFieldLength = length;
             }
 
-            if (emit)
-            {
-                fieldVisitor.VisitField(recordIndex, fieldIndex, text.Slice(fieldStart, length));
-            }
+            fieldVisitor.VisitField(recordIndex, fieldIndex, text.Slice(fieldStart, length));
 
             fieldIndex++;
             fieldStart = delimiterIndex + 1;
@@ -392,10 +420,7 @@ internal static partial class CsvParser
             firstFieldLength = finalLength;
         }
 
-        if (emit)
-        {
-            fieldVisitor.VisitField(recordIndex, fieldIndex, text.Slice(fieldStart, finalLength));
-        }
+        fieldVisitor.VisitField(recordIndex, fieldIndex, text.Slice(fieldStart, finalLength));
 
         return fieldIndex + 1;
     }
@@ -502,12 +527,14 @@ internal static partial class CsvParser
         return true;
     }
 
-    private static bool TrySkipTextUnquotedRecord(ReadOnlySpan<char> text, ref int position)
+    private static bool TrySkipTextUnquotedRecord(ReadOnlySpan<char> text, char delimiter, ref int position, out int delimiterCount)
     {
+        delimiterCount = 0;
         var start = position;
         var specialOffset = text.Slice(start).IndexOfAny('"', '\r', '\n');
         if (specialOffset < 0)
         {
+            delimiterCount = CountTextDelimiters(text.Slice(start), delimiter);
             position = text.Length;
             return text.Length != start;
         }
@@ -518,9 +545,34 @@ internal static partial class CsvParser
             return false;
         }
 
+        delimiterCount = CountTextDelimiters(text.Slice(start, recordEnd - start), delimiter);
         position = recordEnd;
         ConsumeTextLineSeparator(text, ref position);
         return true;
+    }
+
+    private static int GetTextDelimiterIndexCapacity(int delimiterCount)
+    {
+        if (delimiterCount <= 16)
+        {
+            return 16;
+        }
+
+        return delimiterCount <= 32 ? 32 : 64;
+    }
+
+    private static int CountTextDelimiters(ReadOnlySpan<char> text, char delimiter)
+    {
+        var delimiterCount = 0;
+        foreach (var value in text)
+        {
+            if (value == delimiter)
+            {
+                delimiterCount++;
+            }
+        }
+
+        return delimiterCount;
     }
 
     private static int ReadTextRecordFieldSpans<TVisitor>(

--- a/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
+++ b/OfficeIMO.CSV/CsvParser.FieldSpans.Text.cs
@@ -24,6 +24,7 @@ internal static partial class CsvParser
     {
         var delimiter = options.Delimiter;
         var trim = options.TrimWhitespace;
+        var strictQuotes = options.QuoteParsingMode == CsvQuoteParsingMode.Strict;
         var allowEmpty = options.AllowEmptyLines;
         var position = 0;
         var recordIndex = 0;
@@ -50,9 +51,17 @@ internal static partial class CsvParser
                     continue;
                 }
 
-                var skipCommentRecord = options.SkipCommentRows &&
-                    text[position] == options.CommentCharacter &&
-                    !CanReadW3CFieldsHeader(options, emittedRecordCount);
+                var startsWithCommentCharacter = text[position] == options.CommentCharacter;
+                var isW3CFieldsHeader = startsWithCommentCharacter &&
+                    CanReadW3CFieldsHeader(options, emittedRecordCount) &&
+                    IsTextW3CFieldsLine(text, position);
+                var skipCommentRecord = startsWithCommentCharacter &&
+                    !isW3CFieldsHeader &&
+                    (options.SkipCommentRows ||
+                        (options.HasHeaderRow &&
+                            options.Header is null &&
+                            options.SkipCommentRowsBeforeHeader &&
+                            emittedRecordCount <= GetParserInitialRecordsToSkip(options)));
                 if (recordsToSkip > 0 &&
                     !skipCommentRecord &&
                     !trim &&
@@ -88,6 +97,7 @@ internal static partial class CsvParser
                         text,
                         delimiter,
                         trim,
+                        strictQuotes,
                         emitFields,
                         recordIndex,
                         ref position,
@@ -606,6 +616,7 @@ internal static partial class CsvParser
         ReadOnlySpan<char> text,
         char delimiter,
         bool trim,
+        bool strictQuotes,
         bool emitFields,
         int recordIndex,
         ref int position,
@@ -614,6 +625,20 @@ internal static partial class CsvParser
         out int firstFieldLength)
         where TVisitor : struct, ICsvFieldSpanVisitor
     {
+        var recordStart = position;
+        if (!strictQuotes && HasUnexpectedQuoteInTextUnquotedField(text, delimiter, recordStart))
+        {
+            return ReadFlexibleTextRecordFieldSpans(
+                text,
+                delimiter,
+                trim,
+                emitFields,
+                recordIndex,
+                ref position,
+                ref fieldVisitor,
+                out firstFieldLength);
+        }
+
         var fieldIndex = 0;
         var pendingTrailingField = false;
         firstFieldLength = 0;
@@ -657,7 +682,12 @@ internal static partial class CsvParser
             }
             else
             {
-                var field = ReadTextUnquotedField(text, delimiter, trim, ref position);
+                if (!TryReadTextUnquotedField(text, delimiter, trim, position, out var field, out var nextPosition))
+                {
+                    throw new CsvParseException("Unexpected quote in unquoted CSV field.", 0);
+                }
+
+                position = nextPosition;
                 VisitTextField(field, emitFields, recordIndex, fieldIndex, ref fieldVisitor, ref firstFieldLength);
             }
 
@@ -695,6 +725,23 @@ internal static partial class CsvParser
 
     private static ReadOnlySpan<char> ReadTextUnquotedField(ReadOnlySpan<char> text, char delimiter, bool trim, ref int position)
     {
+        if (!TryReadTextUnquotedField(text, delimiter, trim, position, out var field, out var nextPosition))
+        {
+            throw new CsvParseException("Unexpected quote in unquoted CSV field.", 0);
+        }
+
+        position = nextPosition;
+        return field;
+    }
+
+    private static bool TryReadTextUnquotedField(
+        ReadOnlySpan<char> text,
+        char delimiter,
+        bool trim,
+        int position,
+        out ReadOnlySpan<char> field,
+        out int nextPosition)
+    {
         var start = position;
         var remaining = text.Slice(position);
         var terminatorOffset = delimiter switch
@@ -706,19 +753,25 @@ internal static partial class CsvParser
         };
         if (terminatorOffset < 0)
         {
-            position = text.Length;
+            nextPosition = text.Length;
         }
         else
         {
-            position += terminatorOffset;
-            if (text[position] == '"')
+            nextPosition = position + terminatorOffset;
+            if (text[nextPosition] == '"')
             {
-                throw new CsvParseException("Unexpected quote in unquoted CSV field.", 0);
+                field = default;
+                return false;
             }
         }
 
-        var field = text.Slice(start, position - start);
-        return trim ? TrimTextField(field) : field;
+        field = text.Slice(start, nextPosition - start);
+        if (trim)
+        {
+            field = TrimTextField(field);
+        }
+
+        return true;
     }
 
     private static bool TryVisitTextQuotedField<TVisitor>(
@@ -919,6 +972,17 @@ internal static partial class CsvParser
         }
 
         position++;
+    }
+
+    private static bool IsTextW3CFieldsLine(ReadOnlySpan<char> text, int position)
+    {
+        const string prefix = "#Fields:";
+        if (text.Length - position < prefix.Length)
+        {
+            return false;
+        }
+
+        return text.Slice(position, prefix.Length).Equals(prefix.AsSpan(), StringComparison.OrdinalIgnoreCase);
     }
 #endif
 }

--- a/OfficeIMO.CSV/CsvParser.Quoted.cs
+++ b/OfficeIMO.CSV/CsvParser.Quoted.cs
@@ -13,7 +13,7 @@ internal static partial class CsvParser
         Incomplete
     }
 
-    private static bool TryParseQuotedRecord(string text, char delimiter, bool trim, out string[] fields)
+    private static bool TryParseQuotedRecord(string text, char delimiter, bool trim, bool strictQuotes, int lineNumber, out string[] fields)
     {
         fields = Array.Empty<string>();
         if (text.Length > 0 && text[0] == '"' && TryParseStrictQuotedRecord(text, delimiter, trim, out fields))
@@ -30,6 +30,11 @@ internal static partial class CsvParser
         if (standardResult == QuotedRecordParseResult.Incomplete)
         {
             return false;
+        }
+
+        if (strictQuotes)
+        {
+            throw new CsvParseException("Invalid quoted field.", lineNumber);
         }
 
         var buffer = new StringBuilder();
@@ -110,7 +115,7 @@ internal static partial class CsvParser
         return true;
     }
 
-    private static bool TryParseQuotedRecord(string text, char delimiter, bool trim, List<string> fields)
+    private static bool TryParseQuotedRecord(string text, char delimiter, bool trim, bool strictQuotes, int lineNumber, List<string> fields)
     {
         fields.Clear();
         var standardResult = TryParseStandardQuotedRecord(text, delimiter, trim, fields);
@@ -125,8 +130,19 @@ internal static partial class CsvParser
             return false;
         }
 
+        if (strictQuotes)
+        {
+            throw new CsvParseException("Invalid quoted field.", lineNumber);
+        }
+
         return TryParseFlexibleQuotedRecord(text, delimiter, trim, fields);
     }
+
+    private static bool TryParseQuotedRecordLenient(string text, char delimiter, bool trim, out string[] fields) =>
+        TryParseQuotedRecord(text, delimiter, trim, strictQuotes: false, lineNumber: 0, out fields);
+
+    private static bool TryParseQuotedRecordLenient(string text, char delimiter, bool trim, List<string> fields) =>
+        TryParseQuotedRecord(text, delimiter, trim, strictQuotes: false, lineNumber: 0, fields);
 
     private static bool TryParseFlexibleQuotedRecord(string text, char delimiter, bool trim, List<string> parsedFields)
     {
@@ -215,11 +231,12 @@ internal static partial class CsvParser
         string firstLineSeparator,
         char delimiter,
         bool trim,
+        bool strictQuotes,
         List<string> parsedFields,
         ref int lineNumber)
     {
         parsedFields.Clear();
-        return TryParseStandardQuotedRecordContinuations(
+        var result = TryParseStandardQuotedRecordContinuations(
             reader,
             pendingLines,
             firstLine,
@@ -227,7 +244,14 @@ internal static partial class CsvParser
             delimiter,
             trim,
             parsedFields,
-            ref lineNumber) == QuotedRecordParseResult.Complete;
+            ref lineNumber);
+
+        if (result == QuotedRecordParseResult.Invalid && strictQuotes)
+        {
+            throw new CsvParseException("Invalid quoted field.", lineNumber);
+        }
+
+        return result == QuotedRecordParseResult.Complete;
     }
 
     private static QuotedRecordParseResult TryParseStandardQuotedRecordContinuations(

--- a/OfficeIMO.CSV/CsvParser.Quoted.cs
+++ b/OfficeIMO.CSV/CsvParser.Quoted.cs
@@ -207,6 +207,319 @@ internal static partial class CsvParser
         return true;
     }
 
+#if NET8_0_OR_GREATER
+    private static bool TryParseQuotedRecordContinuations(
+        CsvLineReader reader,
+        Queue<CsvLine> pendingLines,
+        string firstLine,
+        string firstLineSeparator,
+        char delimiter,
+        bool trim,
+        List<string> parsedFields,
+        ref int lineNumber)
+    {
+        parsedFields.Clear();
+        return TryParseStandardQuotedRecordContinuations(
+            reader,
+            pendingLines,
+            firstLine,
+            firstLineSeparator,
+            delimiter,
+            trim,
+            parsedFields,
+            ref lineNumber) == QuotedRecordParseResult.Complete;
+    }
+
+    private static QuotedRecordParseResult TryParseStandardQuotedRecordContinuations(
+        CsvLineReader reader,
+        Queue<CsvLine> pendingLines,
+        string firstLine,
+        string firstLineSeparator,
+        char delimiter,
+        bool trim,
+        List<string> parsedFields,
+        ref int lineNumber)
+    {
+        var line = firstLine;
+        var lineSeparator = firstLineSeparator;
+        var index = 0;
+
+        while (index < line.Length)
+        {
+            if (line[index] == delimiter)
+            {
+                parsedFields.Add(string.Empty);
+                index++;
+                if (index == line.Length)
+                {
+                    parsedFields.Add(string.Empty);
+                }
+
+                continue;
+            }
+
+            if (line[index] == '"')
+            {
+                var quotedResult = TryReadStandardQuotedFieldContinuations(
+                    reader,
+                    pendingLines,
+                    ref line,
+                    ref lineSeparator,
+                    ref index,
+                    trim,
+                    delimiter,
+                    out var quotedValue,
+                    ref lineNumber);
+                if (quotedResult != QuotedRecordParseResult.Complete)
+                {
+                    parsedFields.Clear();
+                    return quotedResult;
+                }
+
+                parsedFields.Add(quotedValue);
+            }
+            else
+            {
+                var start = index;
+                var specialIndex = line.AsSpan(index).IndexOfAny(delimiter, '"');
+                if (specialIndex >= 0 && line[index + specialIndex] == '"')
+                {
+                    parsedFields.Clear();
+                    return QuotedRecordParseResult.Invalid;
+                }
+
+                index = specialIndex >= 0 ? index + specialIndex : line.Length;
+
+                parsedFields.Add(GetUnquotedField(line, start, index - start, trim));
+            }
+
+            if (index == line.Length)
+            {
+                return QuotedRecordParseResult.Complete;
+            }
+
+            if (line[index] != delimiter)
+            {
+                parsedFields.Clear();
+                return QuotedRecordParseResult.Invalid;
+            }
+
+            index++;
+            if (index == line.Length)
+            {
+                parsedFields.Add(string.Empty);
+            }
+        }
+
+        return QuotedRecordParseResult.Complete;
+    }
+
+    private static QuotedRecordParseResult TryReadStandardQuotedFieldContinuations(
+        CsvLineReader reader,
+        Queue<CsvLine> pendingLines,
+        ref string line,
+        ref string lineSeparator,
+        ref int index,
+        bool trim,
+        char delimiter,
+        out string value,
+        ref int lineNumber)
+    {
+        index++;
+        var start = index;
+        StringBuilder? builder = null;
+
+        while (true)
+        {
+            while (index < line.Length)
+            {
+                var quoteIndex = line.IndexOf('"', index);
+                if (quoteIndex < 0)
+                {
+                    break;
+                }
+
+                index = quoteIndex;
+                if (index + 1 < line.Length && line[index + 1] == '"')
+                {
+                    builder ??= new StringBuilder();
+                    builder.Append(line, start, index - start);
+                    builder.Append('"');
+                    index += 2;
+                    start = index;
+                    continue;
+                }
+
+                value = builder is null
+                    ? line.Substring(start, index - start)
+                    : AppendAndGetString(builder, line, start, index - start);
+                index++;
+
+                if (trim)
+                {
+                    while (index < line.Length && line[index] != delimiter && char.IsWhiteSpace(line[index]))
+                    {
+                        index++;
+                    }
+                }
+
+                if (index < line.Length && line[index] != delimiter)
+                {
+                    value = string.Empty;
+                    return QuotedRecordParseResult.Invalid;
+                }
+
+                return QuotedRecordParseResult.Complete;
+            }
+
+            var currentLine = line;
+            var currentStart = start;
+            var currentSeparator = lineSeparator;
+            var next = ReadLineWithSeparator(reader, pendingLines, out lineSeparator);
+            if (next == null)
+            {
+                value = string.Empty;
+                return QuotedRecordParseResult.Incomplete;
+            }
+
+            line = next;
+            index = 0;
+            start = 0;
+            lineNumber++;
+            if (builder is null &&
+                TryCompleteSingleContinuationQuotedField(
+                    currentLine,
+                    currentStart,
+                    currentSeparator,
+                    line,
+                    trim,
+                    delimiter,
+                    ref index,
+                    out value))
+            {
+                return QuotedRecordParseResult.Complete;
+            }
+
+            builder ??= new StringBuilder(currentLine.Length - currentStart + currentSeparator.Length + line.Length + 128);
+            builder.Append(currentLine, currentStart, currentLine.Length - currentStart);
+            builder.Append(currentSeparator);
+        }
+    }
+
+    private static bool TryParseFlexibleQuotedRecordContinuations(
+        CsvLineReader reader,
+        Queue<CsvLine> pendingLines,
+        string firstLine,
+        string firstLineSeparator,
+        char delimiter,
+        bool trim,
+        List<string> parsedFields,
+        ref int lineNumber)
+    {
+        parsedFields.Clear();
+        var buffer = new StringBuilder(firstLine.Length + firstLineSeparator.Length + 128);
+        var inQuotes = false;
+        var fieldWasQuoted = false;
+        var afterClosingQuote = false;
+        var line = firstLine;
+        var lineSeparator = firstLineSeparator;
+
+        while (true)
+        {
+            ParseQuotedLineSegment(line, delimiter, trim, parsedFields, buffer, ref inQuotes, ref fieldWasQuoted, ref afterClosingQuote);
+            if (!inQuotes)
+            {
+                AddQuotedField(parsedFields, buffer, trim, ref fieldWasQuoted);
+                return true;
+            }
+
+            buffer.Append(lineSeparator);
+            var next = ReadLineWithSeparator(reader, pendingLines, out lineSeparator);
+            if (next == null)
+            {
+                parsedFields.Clear();
+                return false;
+            }
+
+            line = next;
+            lineNumber++;
+        }
+    }
+
+    private static void ParseQuotedLineSegment(
+        string text,
+        char delimiter,
+        bool trim,
+        List<string> parsedFields,
+        StringBuilder buffer,
+        ref bool inQuotes,
+        ref bool fieldWasQuoted,
+        ref bool afterClosingQuote)
+    {
+        for (var i = 0; i < text.Length; i++)
+        {
+            var c = text[i];
+
+            if (inQuotes)
+            {
+                if (c == '"')
+                {
+                    if (i + 1 < text.Length && text[i + 1] == '"')
+                    {
+                        i++;
+                        buffer.Append('"');
+                    }
+                    else
+                    {
+                        inQuotes = false;
+                        afterClosingQuote = true;
+                    }
+                }
+                else
+                {
+                    buffer.Append(c);
+                }
+
+                continue;
+            }
+
+            if (c == '"')
+            {
+                if (afterClosingQuote)
+                {
+                    buffer.Append(c);
+                    afterClosingQuote = false;
+                    continue;
+                }
+
+                if (trim && IsWhitespaceOnly(buffer))
+                {
+                    buffer.Clear();
+                }
+
+                inQuotes = true;
+                fieldWasQuoted = true;
+                continue;
+            }
+
+            if (c == delimiter)
+            {
+                AddQuotedField(parsedFields, buffer, trim, ref fieldWasQuoted);
+                afterClosingQuote = false;
+                continue;
+            }
+
+            if (afterClosingQuote && char.IsWhiteSpace(c) && trim)
+            {
+                continue;
+            }
+
+            afterClosingQuote = false;
+            buffer.Append(c);
+        }
+    }
+#endif
+
     private static QuotedRecordParseResult TryParseStandardQuotedRecord(string text, char delimiter, bool trim, out string[] fields)
     {
         var parsedFields = new List<string>(16);
@@ -246,15 +559,14 @@ internal static partial class CsvParser
             else
             {
                 var start = index;
-                while (index < text.Length && text[index] != delimiter)
+                var delimiterIndex = text.IndexOf(delimiter, index);
+                var quoteIndex = text.IndexOf('"', index);
+                if (quoteIndex >= 0 && (delimiterIndex < 0 || quoteIndex < delimiterIndex))
                 {
-                    if (text[index] == '"')
-                    {
-                        return QuotedRecordParseResult.Invalid;
-                    }
-
-                    index++;
+                    return QuotedRecordParseResult.Invalid;
                 }
+
+                index = delimiterIndex >= 0 ? delimiterIndex : text.Length;
 
                 parsedFields.Add(GetUnquotedField(text, start, index - start, trim));
             }
@@ -287,12 +599,13 @@ internal static partial class CsvParser
 
         while (index < text.Length)
         {
-            if (text[index] != '"')
+            var quoteIndex = text.IndexOf('"', index);
+            if (quoteIndex < 0)
             {
-                index++;
-                continue;
+                break;
             }
 
+            index = quoteIndex;
             if (index + 1 < text.Length && text[index + 1] == '"')
             {
                 builder ??= new StringBuilder();
@@ -338,6 +651,61 @@ internal static partial class CsvParser
 
         return builder.ToString();
     }
+
+#if NET8_0_OR_GREATER
+    private static bool TryCompleteSingleContinuationQuotedField(
+        string firstLine,
+        int firstStart,
+        string separator,
+        string secondLine,
+        bool trim,
+        char delimiter,
+        ref int index,
+        out string value)
+    {
+        var quoteIndex = secondLine.IndexOf('"');
+        if (quoteIndex < 0 ||
+            quoteIndex + 1 < secondLine.Length && secondLine[quoteIndex + 1] == '"')
+        {
+            value = string.Empty;
+            return false;
+        }
+
+        var afterQuote = quoteIndex + 1;
+        if (trim)
+        {
+            while (afterQuote < secondLine.Length &&
+                   secondLine[afterQuote] != delimiter &&
+                   char.IsWhiteSpace(secondLine[afterQuote]))
+            {
+                afterQuote++;
+            }
+        }
+
+        if (afterQuote < secondLine.Length && secondLine[afterQuote] != delimiter)
+        {
+            value = string.Empty;
+            return false;
+        }
+
+        var firstLength = firstLine.Length - firstStart;
+        value = string.Create(
+            firstLength + separator.Length + quoteIndex,
+            (firstLine, firstStart, firstLength, separator, secondLine, quoteIndex),
+            static (destination, state) =>
+            {
+                var position = 0;
+                state.firstLine.AsSpan(state.firstStart, state.firstLength).CopyTo(destination);
+                position += state.firstLength;
+                state.separator.AsSpan().CopyTo(destination[position..]);
+                position += state.separator.Length;
+                state.secondLine.AsSpan(0, state.quoteIndex).CopyTo(destination[position..]);
+            });
+
+        index = afterQuote;
+        return true;
+    }
+#endif
 
     private static bool IsWhitespaceOnly(StringBuilder buffer)
     {

--- a/OfficeIMO.CSV/CsvParser.Quoted.cs
+++ b/OfficeIMO.CSV/CsvParser.Quoted.cs
@@ -663,9 +663,8 @@ internal static partial class CsvParser
         ref int index,
         out string value)
     {
-        var quoteIndex = secondLine.IndexOf('"');
-        if (quoteIndex < 0 ||
-            quoteIndex + 1 < secondLine.Length && secondLine[quoteIndex + 1] == '"')
+        var quoteIndex = FindClosingQuote(secondLine, 0, out var secondEscapedQuoteCount);
+        if (quoteIndex < 0)
         {
             value = string.Empty;
             return false;
@@ -689,21 +688,105 @@ internal static partial class CsvParser
         }
 
         var firstLength = firstLine.Length - firstStart;
+        var firstEscapedQuoteCount = CountEscapedQuotes(firstLine, firstStart, firstLine.Length);
         value = string.Create(
-            firstLength + separator.Length + quoteIndex,
-            (firstLine, firstStart, firstLength, separator, secondLine, quoteIndex),
+            firstLength - firstEscapedQuoteCount + separator.Length + quoteIndex - secondEscapedQuoteCount,
+            (firstLine, firstStart, firstLength, firstEscapedQuoteCount, separator, secondLine, quoteIndex, secondEscapedQuoteCount),
             static (destination, state) =>
             {
                 var position = 0;
-                state.firstLine.AsSpan(state.firstStart, state.firstLength).CopyTo(destination);
-                position += state.firstLength;
+                position += CopyUnescapedQuotedSegment(
+                    state.firstLine.AsSpan(state.firstStart, state.firstLength),
+                    state.firstEscapedQuoteCount,
+                    destination);
                 state.separator.AsSpan().CopyTo(destination[position..]);
                 position += state.separator.Length;
-                state.secondLine.AsSpan(0, state.quoteIndex).CopyTo(destination[position..]);
+                CopyUnescapedQuotedSegment(
+                    state.secondLine.AsSpan(0, state.quoteIndex),
+                    state.secondEscapedQuoteCount,
+                    destination[position..]);
             });
 
         index = afterQuote;
         return true;
+    }
+
+    private static int FindClosingQuote(string text, int start, out int escapedQuoteCount)
+    {
+        escapedQuoteCount = 0;
+        var index = start;
+        while (index < text.Length)
+        {
+            var quoteIndex = text.IndexOf('"', index);
+            if (quoteIndex < 0)
+            {
+                return -1;
+            }
+
+            if (quoteIndex + 1 < text.Length && text[quoteIndex + 1] == '"')
+            {
+                escapedQuoteCount++;
+                index = quoteIndex + 2;
+                continue;
+            }
+
+            return quoteIndex;
+        }
+
+        return -1;
+    }
+
+    private static int CountEscapedQuotes(string text, int start, int end)
+    {
+        var count = 0;
+        var index = start;
+        while (index < end)
+        {
+            var quoteIndex = text.IndexOf('"', index, end - index);
+            if (quoteIndex < 0 || quoteIndex + 1 >= end || text[quoteIndex + 1] != '"')
+            {
+                return count;
+            }
+
+            count++;
+            index = quoteIndex + 2;
+        }
+
+        return count;
+    }
+
+    private static int CopyUnescapedQuotedSegment(ReadOnlySpan<char> source, int escapedQuoteCount, Span<char> destination)
+    {
+        if (escapedQuoteCount == 0)
+        {
+            source.CopyTo(destination);
+            return source.Length;
+        }
+
+        var readIndex = 0;
+        var writeIndex = 0;
+        while (readIndex < source.Length)
+        {
+            var quoteOffset = source[readIndex..].IndexOf('"');
+            if (quoteOffset < 0)
+            {
+                source[readIndex..].CopyTo(destination[writeIndex..]);
+                writeIndex += source.Length - readIndex;
+                break;
+            }
+
+            if (quoteOffset > 0)
+            {
+                source.Slice(readIndex, quoteOffset).CopyTo(destination[writeIndex..]);
+                writeIndex += quoteOffset;
+                readIndex += quoteOffset;
+            }
+
+            destination[writeIndex++] = '"';
+            readIndex += 2;
+        }
+
+        return writeIndex;
     }
 #endif
 

--- a/OfficeIMO.CSV/CsvParser.ReusableHeader.cs
+++ b/OfficeIMO.CSV/CsvParser.ReusableHeader.cs
@@ -31,6 +31,7 @@ internal static partial class CsvParser
     {
         var delimiter = options.Delimiter;
         var trim = options.TrimWhitespace;
+        var strictQuotes = options.QuoteParsingMode == CsvQuoteParsingMode.Strict;
         var allowEmpty = options.AllowEmptyLines;
         var lineNumber = 1;
         var reusableRecord = new List<string>(64);
@@ -101,7 +102,7 @@ internal static partial class CsvParser
                 continue;
             }
 
-            if (!TryParseQuotedRecord(line, delimiter, trim, reusableQuotedRecord))
+            if (!TryParseQuotedRecord(line, delimiter, trim, strictQuotes, lineNumber, reusableQuotedRecord))
             {
                 var logicalRecord = new System.Text.StringBuilder(line);
                 var pendingSeparator = lineSeparator;
@@ -117,7 +118,7 @@ internal static partial class CsvParser
                     logicalRecord.Append(next);
                     lineNumber++;
 
-                    if (TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, reusableQuotedRecord))
+                    if (TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, strictQuotes, lineNumber, reusableQuotedRecord))
                     {
                         break;
                     }

--- a/OfficeIMO.CSV/CsvParser.ReusableHeader.cs
+++ b/OfficeIMO.CSV/CsvParser.ReusableHeader.cs
@@ -1,0 +1,155 @@
+#nullable enable
+
+namespace OfficeIMO.CSV;
+
+internal static partial class CsvParser
+{
+    internal static void ReadRecordsReusableWithMetadataUntilAccepted(
+        TextReader reader,
+        CsvLoadOptions options,
+        Func<CsvParsedRecord, bool> metadataRecordAction,
+        Action<IReadOnlyList<string>> recordAction)
+    {
+        if (metadataRecordAction == null)
+        {
+            throw new ArgumentNullException(nameof(metadataRecordAction));
+        }
+
+        if (recordAction == null)
+        {
+            throw new ArgumentNullException(nameof(recordAction));
+        }
+
+        ReadLineOrQuotedReusableWithMetadataUntilAccepted(reader, options, metadataRecordAction, recordAction);
+    }
+
+    private static void ReadLineOrQuotedReusableWithMetadataUntilAccepted(
+        TextReader reader,
+        CsvLoadOptions options,
+        Func<CsvParsedRecord, bool> metadataRecordAction,
+        Action<IReadOnlyList<string>> recordAction)
+    {
+        var delimiter = options.Delimiter;
+        var trim = options.TrimWhitespace;
+        var allowEmpty = options.AllowEmptyLines;
+        var lineNumber = 1;
+        var reusableRecord = new List<string>(64);
+        var reusableQuotedRecord = new List<string>(64);
+        var emittedRecordCount = 0;
+        var pendingLines = new Queue<CsvLine>();
+        var metadataAccepted = false;
+        using var lineReader = new CsvLineReader(reader);
+
+        while (pendingLines.Count > 0 || true)
+        {
+            string? fastLine = null;
+            string lineSeparator;
+            CsvLineReadResult readResult;
+            if (pendingLines.Count == 0)
+            {
+                readResult = lineReader.ReadUnquotedRecordOrLine(delimiter, trim, options.CommentCharacter, reusableRecord, out fastLine, out lineSeparator);
+            }
+            else
+            {
+                lineSeparator = string.Empty;
+                readResult = CsvLineReadResult.Line;
+            }
+
+            if (readResult == CsvLineReadResult.EndOfReader)
+            {
+                break;
+            }
+
+            if (readResult == CsvLineReadResult.UnquotedRecord)
+            {
+                if (ShouldEmitRecord(reusableRecord, allowEmpty))
+                {
+                    ProcessReusableRecord(reusableRecord, startsWithCommentCharacter: false, metadataRecordAction, recordAction, ref metadataAccepted);
+                    emittedRecordCount++;
+                }
+
+                lineNumber++;
+                continue;
+            }
+
+            var line = pendingLines.Count > 0
+                ? ReadLineWithSeparator(lineReader, pendingLines, out lineSeparator)
+                : fastLine;
+            if (line is null)
+            {
+                break;
+            }
+
+            var startsWithCommentCharacter = IsRawCommentLine(line, options);
+            if (!metadataAccepted &&
+                TrySkipCommentRecordBeforeParsing(lineReader, pendingLines, startsWithCommentCharacter, line, lineSeparator, options, emittedRecordCount, ref lineNumber))
+            {
+                lineNumber++;
+                continue;
+            }
+
+            if (TrySplitUnquotedRecord(line, delimiter, trim, reusableRecord))
+            {
+                if (!ShouldSkipCommentRecord(startsWithCommentCharacter, line, options, emittedRecordCount) &&
+                    ShouldEmitRecord(reusableRecord, allowEmpty))
+                {
+                    ProcessReusableRecord(reusableRecord, startsWithCommentCharacter, metadataRecordAction, recordAction, ref metadataAccepted);
+                    emittedRecordCount++;
+                }
+
+                lineNumber++;
+                continue;
+            }
+
+            if (!TryParseQuotedRecord(line, delimiter, trim, reusableQuotedRecord))
+            {
+                var logicalRecord = new System.Text.StringBuilder(line);
+                var pendingSeparator = lineSeparator;
+                while (true)
+                {
+                    var next = ReadLineWithSeparator(lineReader, pendingLines, out var nextSeparator);
+                    if (next == null)
+                    {
+                        throw new CsvParseException("Unterminated quoted field.", lineNumber);
+                    }
+
+                    logicalRecord.Append(pendingSeparator);
+                    logicalRecord.Append(next);
+                    lineNumber++;
+
+                    if (TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, reusableQuotedRecord))
+                    {
+                        break;
+                    }
+
+                    pendingSeparator = nextSeparator;
+                }
+            }
+
+            if (ShouldEmitRecord(reusableQuotedRecord, allowEmpty) &&
+                !ShouldSkipCommentRecord(startsWithCommentCharacter, line, options, emittedRecordCount))
+            {
+                ProcessReusableRecord(reusableQuotedRecord, startsWithCommentCharacter, metadataRecordAction, recordAction, ref metadataAccepted);
+                emittedRecordCount++;
+            }
+
+            lineNumber++;
+        }
+    }
+
+    private static void ProcessReusableRecord(
+        IReadOnlyList<string> record,
+        bool startsWithCommentCharacter,
+        Func<CsvParsedRecord, bool> metadataRecordAction,
+        Action<IReadOnlyList<string>> recordAction,
+        ref bool metadataAccepted)
+    {
+        if (metadataAccepted)
+        {
+            recordAction(record);
+            return;
+        }
+
+        metadataAccepted = metadataRecordAction(new CsvParsedRecord(record, startsWithCommentCharacter));
+    }
+}

--- a/OfficeIMO.CSV/CsvParser.cs
+++ b/OfficeIMO.CSV/CsvParser.cs
@@ -113,6 +113,7 @@ internal static partial class CsvParser
     {
         var delimiter = options.Delimiter;
         var trim = options.TrimWhitespace;
+        var strictQuotes = options.QuoteParsingMode == CsvQuoteParsingMode.Strict;
         var allowEmpty = options.AllowEmptyLines;
         var lineNumber = 1;
         var emittedRecordCount = 0;
@@ -142,7 +143,7 @@ internal static partial class CsvParser
             }
 
             string[] fields;
-            if (!TryParseQuotedRecord(line, delimiter, trim, out fields))
+            if (!TryParseQuotedRecord(line, delimiter, trim, strictQuotes, lineNumber, out fields))
             {
                 var logicalRecord = new StringBuilder(line);
                 var pendingSeparator = lineSeparator;
@@ -158,7 +159,7 @@ internal static partial class CsvParser
                     logicalRecord.Append(next);
                     lineNumber++;
 
-                    if (TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, out fields))
+                    if (TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, strictQuotes, lineNumber, out fields))
                     {
                         break;
                     }
@@ -195,6 +196,7 @@ internal static partial class CsvParser
     {
         var delimiter = options.Delimiter;
         var trim = options.TrimWhitespace;
+        var strictQuotes = options.QuoteParsingMode == CsvQuoteParsingMode.Strict;
         var allowEmpty = options.AllowEmptyLines;
         var lineNumber = 1;
         var emittedRecordCount = 0;
@@ -224,7 +226,7 @@ internal static partial class CsvParser
             }
 
             string[] fields;
-            if (!TryParseQuotedRecord(line, delimiter, trim, out fields))
+            if (!TryParseQuotedRecord(line, delimiter, trim, strictQuotes, lineNumber, out fields))
             {
                 var logicalRecord = new StringBuilder(line);
                 var pendingSeparator = lineSeparator;
@@ -240,7 +242,7 @@ internal static partial class CsvParser
                     logicalRecord.Append(next);
                     lineNumber++;
 
-                    if (TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, out fields))
+                    if (TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, strictQuotes, lineNumber, out fields))
                     {
                         break;
                     }
@@ -266,6 +268,7 @@ internal static partial class CsvParser
     {
         var delimiter = options.Delimiter;
         var trim = options.TrimWhitespace;
+        var strictQuotes = options.QuoteParsingMode == CsvQuoteParsingMode.Strict;
         var allowEmpty = options.AllowEmptyLines;
         var lineNumber = 1;
         var reusableRecord = new List<string>(64);
@@ -334,7 +337,7 @@ internal static partial class CsvParser
                 continue;
             }
 
-            if (!TryParseQuotedRecord(line, delimiter, trim, reusableQuotedRecord))
+            if (!TryParseQuotedRecord(line, delimiter, trim, strictQuotes, lineNumber, reusableQuotedRecord))
             {
                 var logicalRecord = new StringBuilder(line);
                 var pendingSeparator = lineSeparator;
@@ -350,7 +353,7 @@ internal static partial class CsvParser
                     logicalRecord.Append(next);
                     lineNumber++;
 
-                    if (TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, reusableQuotedRecord))
+                    if (TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, strictQuotes, lineNumber, reusableQuotedRecord))
                     {
                         break;
                     }
@@ -376,6 +379,7 @@ internal static partial class CsvParser
     {
         var delimiter = options.Delimiter;
         var trim = options.TrimWhitespace;
+        var strictQuotes = options.QuoteParsingMode == CsvQuoteParsingMode.Strict;
         var allowEmpty = options.AllowEmptyLines;
         var lineNumber = 1;
         var reusableRecord = new List<string>(64);
@@ -444,7 +448,7 @@ internal static partial class CsvParser
                 continue;
             }
 
-            if (!TryParseQuotedRecord(line, delimiter, trim, reusableQuotedRecord))
+            if (!TryParseQuotedRecord(line, delimiter, trim, strictQuotes, lineNumber, reusableQuotedRecord))
             {
                 var logicalRecord = new StringBuilder(line);
                 var pendingSeparator = lineSeparator;
@@ -460,7 +464,7 @@ internal static partial class CsvParser
                     logicalRecord.Append(next);
                     lineNumber++;
 
-                    if (TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, reusableQuotedRecord))
+                    if (TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, strictQuotes, lineNumber, reusableQuotedRecord))
                     {
                         break;
                     }
@@ -488,6 +492,7 @@ internal static partial class CsvParser
     {
         var delimiter = options.Delimiter;
         var trim = options.TrimWhitespace;
+        var strictQuotes = options.QuoteParsingMode == CsvQuoteParsingMode.Strict;
         var allowEmpty = options.AllowEmptyLines;
         var lineNumber = 1;
         var emittedRecordCount = 0;
@@ -591,9 +596,10 @@ internal static partial class CsvParser
                     lineSeparator,
                     delimiter,
                     trim,
+                    strictQuotes,
                     reusableQuotedRecord,
                     ref lineNumber) &&
-                !TryParseQuotedRecord(line, delimiter, trim, reusableQuotedRecord))
+                !TryParseQuotedRecord(line, delimiter, trim, strictQuotes, lineNumber, reusableQuotedRecord))
             {
                 throw new CsvParseException("Unterminated quoted field.", lineNumber);
             }
@@ -741,7 +747,7 @@ internal static partial class CsvParser
             return false;
         }
 
-        if (TryParseQuotedRecord(firstLine, options.Delimiter, options.TrimWhitespace, out _))
+        if (TryParseQuotedRecordLenient(firstLine, options.Delimiter, options.TrimWhitespace, out _))
         {
             return true;
         }
@@ -760,7 +766,7 @@ internal static partial class CsvParser
 
             continuations.Add(new CsvLine(next, nextSeparator));
             var candidate = string.Concat(logicalRecord.ToString(), pendingSeparator, next);
-            if (TryParseQuotedRecord(candidate, options.Delimiter, options.TrimWhitespace, out _))
+            if (TryParseQuotedRecordLenient(candidate, options.Delimiter, options.TrimWhitespace, out _))
             {
                 lineNumber += continuations.Count;
                 return true;

--- a/OfficeIMO.CSV/CsvParser.cs
+++ b/OfficeIMO.CSV/CsvParser.cs
@@ -117,7 +117,7 @@ internal static partial class CsvParser
         var lineNumber = 1;
         var emittedRecordCount = 0;
         var pendingLines = new Queue<CsvLine>();
-        var lineReader = new CsvLineReader(reader);
+        using var lineReader = new CsvLineReader(reader);
 
         while (ReadLineWithSeparator(lineReader, pendingLines, out var lineSeparator) is { } line)
         {
@@ -199,7 +199,7 @@ internal static partial class CsvParser
         var lineNumber = 1;
         var emittedRecordCount = 0;
         var pendingLines = new Queue<CsvLine>();
-        var lineReader = new CsvLineReader(reader);
+        using var lineReader = new CsvLineReader(reader);
 
         while (ReadLineWithSeparator(lineReader, pendingLines, out var lineSeparator) is { } line)
         {
@@ -272,7 +272,7 @@ internal static partial class CsvParser
         var reusableQuotedRecord = new List<string>(64);
         var emittedRecordCount = 0;
         var pendingLines = new Queue<CsvLine>();
-        var lineReader = new CsvLineReader(reader);
+        using var lineReader = new CsvLineReader(reader);
 
         while (pendingLines.Count > 0 || true)
         {
@@ -382,7 +382,7 @@ internal static partial class CsvParser
         var reusableQuotedRecord = new List<string>(64);
         var emittedRecordCount = 0;
         var pendingLines = new Queue<CsvLine>();
-        var lineReader = new CsvLineReader(reader);
+        using var lineReader = new CsvLineReader(reader);
 
         while (pendingLines.Count > 0 || true)
         {
@@ -492,8 +492,9 @@ internal static partial class CsvParser
         var lineNumber = 1;
         var emittedRecordCount = 0;
         var recordIndex = 0;
+        var reusableQuotedRecord = new List<string>(64);
         var pendingLines = new Queue<CsvLine>();
-        var lineReader = new CsvLineReader(reader);
+        using var lineReader = new CsvLineReader(reader);
 
         while (pendingLines.Count > 0 || true)
         {
@@ -561,7 +562,7 @@ internal static partial class CsvParser
                 continue;
             }
 
-            if (TrySplitUnquotedRecord(line, delimiter, trim, out var record))
+            if (line.IndexOf('"') < 0 && TrySplitUnquotedRecord(line, delimiter, trim, out var record))
             {
                 if (!ShouldSkipCommentRecord(startsWithCommentCharacter, line, options, emittedRecordCount) &&
                     ShouldEmitRecord(record, allowEmpty))
@@ -583,33 +584,21 @@ internal static partial class CsvParser
                 continue;
             }
 
-            string[] fields;
-            if (!TryParseQuotedRecord(line, delimiter, trim, out fields))
+            if (!TryParseQuotedRecordContinuations(
+                    lineReader,
+                    pendingLines,
+                    line,
+                    lineSeparator,
+                    delimiter,
+                    trim,
+                    reusableQuotedRecord,
+                    ref lineNumber) &&
+                !TryParseQuotedRecord(line, delimiter, trim, reusableQuotedRecord))
             {
-                var logicalRecord = new StringBuilder(line);
-                var pendingSeparator = lineSeparator;
-                while (true)
-                {
-                    var next = ReadLineWithSeparator(lineReader, pendingLines, out var nextSeparator);
-                    if (next == null)
-                    {
-                        throw new CsvParseException("Unterminated quoted field.", lineNumber);
-                    }
-
-                    logicalRecord.Append(pendingSeparator);
-                    logicalRecord.Append(next);
-                    lineNumber++;
-
-                    if (TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, out fields))
-                    {
-                        break;
-                    }
-
-                    pendingSeparator = nextSeparator;
-                }
+                throw new CsvParseException("Unterminated quoted field.", lineNumber);
             }
 
-            if (ShouldEmitRecord(fields, allowEmpty))
+            if (ShouldEmitRecord(reusableQuotedRecord, allowEmpty))
             {
                 if (!ShouldSkipCommentRecord(startsWithCommentCharacter, line, options, emittedRecordCount))
                 {
@@ -619,7 +608,7 @@ internal static partial class CsvParser
                     }
                     else
                     {
-                        VisitParsedFields(fields, recordIndex, ref fieldVisitor);
+                        VisitParsedFields(reusableQuotedRecord, recordIndex, ref fieldVisitor);
                         recordIndex++;
                     }
 
@@ -636,7 +625,7 @@ internal static partial class CsvParser
     {
         for (var fieldIndex = 0; fieldIndex < fields.Count; fieldIndex++)
         {
-            fieldVisitor.VisitField(recordIndex, fieldIndex, fields[fieldIndex].AsSpan());
+            fieldVisitor.VisitFieldValue(recordIndex, fieldIndex, fields[fieldIndex]);
         }
     }
 #endif

--- a/OfficeIMO.CSV/CsvQuoteParsingMode.cs
+++ b/OfficeIMO.CSV/CsvQuoteParsingMode.cs
@@ -1,0 +1,19 @@
+#nullable enable
+
+namespace OfficeIMO.CSV;
+
+/// <summary>
+/// Controls how quoted CSV fields are parsed when input does not strictly follow RFC-style quoting.
+/// </summary>
+public enum CsvQuoteParsingMode
+{
+    /// <summary>
+    /// Preserve the forgiving parser behavior used by PowerShell-style CSV import workflows.
+    /// </summary>
+    Lenient = 0,
+
+    /// <summary>
+    /// Reject malformed quoted fields instead of falling back to permissive parsing.
+    /// </summary>
+    Strict = 1
+}

--- a/OfficeIMO.CSV/CsvRow.cs
+++ b/OfficeIMO.CSV/CsvRow.cs
@@ -48,7 +48,7 @@ public sealed class CsvRow
     public T? Get<T>(int index)
     {
         var value = Values[index];
-        return CsvValueConverter.ConvertTo<T>(value, _document.Culture);
+        return CsvValueConverter.ConvertTo<T>(value, _document.Culture, _document.DateTimeFormats);
     }
 
     /// <summary>

--- a/OfficeIMO.CSV/CsvSaveOptions.cs
+++ b/OfficeIMO.CSV/CsvSaveOptions.cs
@@ -49,6 +49,31 @@ public sealed class CsvSaveOptions
     public CompressionLevel CompressionLevel { get; set; } = CompressionLevel.Optimal;
 
     /// <summary>
+    /// Gets or sets the token written for <c>null</c> values. Defaults to an empty field.
+    /// </summary>
+    public string? NullValue { get; set; }
+
+    /// <summary>
+    /// Gets or sets a custom date/time format used when writing <see cref="DateTime"/> and <see cref="DateTimeOffset"/> values.
+    /// </summary>
+    public string? DateTimeFormat { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether date/time values are converted to UTC before formatting.
+    /// </summary>
+    public bool UseUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether file output appends to an existing CSV file.
+    /// </summary>
+    public bool Append { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether file output should fail if the destination already exists.
+    /// </summary>
+    public bool NoClobber { get; set; }
+
+    /// <summary>
     /// Gets or sets how formula-like values are handled before writing CSV output. Default preserves values exactly.
     /// </summary>
     public CsvFormulaInjectionPolicy FormulaInjectionPolicy { get; set; } = CsvFormulaInjectionPolicy.Preserve;

--- a/OfficeIMO.CSV/CsvStreamingSource.cs
+++ b/OfficeIMO.CSV/CsvStreamingSource.cs
@@ -7,12 +7,14 @@ internal sealed class CsvStreamingSource
     private readonly Func<TextReader> _readerFactory;
     private readonly CsvLoadOptions _options;
     private readonly int _skipRecordCount;
+    private readonly int _headerCount;
 
-    public CsvStreamingSource(Func<TextReader> readerFactory, CsvLoadOptions options, int skipRecordCount)
+    public CsvStreamingSource(Func<TextReader> readerFactory, CsvLoadOptions options, int skipRecordCount, int headerCount)
     {
         _readerFactory = readerFactory;
         _options = options.Clone();
         _skipRecordCount = skipRecordCount;
+        _headerCount = headerCount;
     }
 
     public IEnumerable<object?[]> ReadRows()
@@ -27,7 +29,7 @@ internal sealed class CsvStreamingSource
                 continue;
             }
 
-            yield return record.Cast<object?>().ToArray();
+            yield return CsvDocument.BuildParsedObjectValues(record, _headerCount, _options);
         }
     }
 }

--- a/OfficeIMO.CSV/CsvValidator.cs
+++ b/OfficeIMO.CSV/CsvValidator.cs
@@ -44,7 +44,7 @@ internal static class CsvValidator
 
                 if (column.DataType is not null)
                 {
-                    if (!CsvValueConverter.TryConvert(value, column.DataType, document.Culture, out _, out var error))
+                    if (!CsvValueConverter.TryConvert(value, column.DataType, document.Culture, document.DateTimeFormats, out _, out var error))
                     {
                         errors.Add(new CsvValidationError(rowIndex, column.Name, error ?? "Invalid value."));
                         continue;

--- a/OfficeIMO.CSV/CsvValueConverter.cs
+++ b/OfficeIMO.CSV/CsvValueConverter.cs
@@ -6,10 +6,10 @@ namespace OfficeIMO.CSV;
 
 internal static class CsvValueConverter
 {
-    public static T? ConvertTo<T>(object? value, CultureInfo culture)
+    public static T? ConvertTo<T>(object? value, CultureInfo culture, IReadOnlyList<string>? dateTimeFormats = null)
     {
         var targetType = typeof(T);
-        if (!TryConvert(value, targetType, culture, out var result, out var error))
+        if (!TryConvert(value, targetType, culture, dateTimeFormats, out var result, out var error))
         {
             throw new CsvException(error ?? $"Value '{value}' cannot be converted to {targetType.Name}");
         }
@@ -17,7 +17,7 @@ internal static class CsvValueConverter
         return (T?)result;
     }
 
-    public static bool TryConvert(object? value, Type targetType, CultureInfo culture, out object? result, out string? error)
+    public static bool TryConvert(object? value, Type targetType, CultureInfo culture, IReadOnlyList<string>? dateTimeFormats, out object? result, out string? error)
     {
         error = null;
         result = null;
@@ -45,7 +45,7 @@ internal static class CsvValueConverter
 
         if (value is string s)
         {
-            return TryConvertFromString(s, effectiveType, culture, out result, out error);
+            return TryConvertFromString(s, effectiveType, culture, dateTimeFormats, out result, out error);
         }
 
         try
@@ -61,7 +61,7 @@ internal static class CsvValueConverter
         }
     }
 
-    private static bool TryConvertFromString(string text, Type targetType, CultureInfo culture, out object? result, out string? error)
+    private static bool TryConvertFromString(string text, Type targetType, CultureInfo culture, IReadOnlyList<string>? dateTimeFormats, out object? result, out string? error)
     {
         error = null;
         result = null;
@@ -184,6 +184,13 @@ internal static class CsvValueConverter
 
             if (targetType == typeof(DateTime))
             {
+                if (dateTimeFormats is { Count: > 0 } &&
+                    DateTime.TryParseExact(text, dateTimeFormats.ToArray(), culture, DateTimeStyles.None, out var formattedDateTime))
+                {
+                    result = formattedDateTime;
+                    return true;
+                }
+
                 result = DateTime.Parse(text, culture, DateTimeStyles.None);
                 return true;
             }

--- a/OfficeIMO.CSV/CsvWriter.cs
+++ b/OfficeIMO.CSV/CsvWriter.cs
@@ -253,6 +253,22 @@ internal static class CsvWriter
         writer.Write(newLine);
     }
 
+    internal static void WriteRecordDefaultAdaptive(
+        TextWriter writer,
+        StringBuilder buffer,
+        string?[] values,
+        char delimiter,
+        string newLine)
+    {
+        if (!TextRowNeedsEscaping(values, delimiter))
+        {
+            WritePlainTextRecord(writer, values, delimiter, newLine);
+            return;
+        }
+
+        WriteRecordBufferedDefault(writer, buffer, values, delimiter, newLine);
+    }
+
     internal static void WriteRecordBufferedAlwaysQuoted(
         TextWriter writer,
         StringBuilder buffer,
@@ -928,6 +944,38 @@ internal static class CsvWriter
         }
 
         WriteEscapedDefault(writer, text, delimiter);
+    }
+
+    private static bool TextRowNeedsEscaping(string?[] values, char delimiter)
+    {
+        for (var i = 0; i < values.Length; i++)
+        {
+            var text = values[i];
+            if (text != null && IndexOfCsvSpecial(text, delimiter) >= 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void WritePlainTextRecord(TextWriter writer, string?[] values, char delimiter, string newLine)
+    {
+        for (var i = 0; i < values.Length; i++)
+        {
+            if (i > 0)
+            {
+                writer.Write(delimiter);
+            }
+
+            if (values[i] != null)
+            {
+                writer.Write(values[i]);
+            }
+        }
+
+        writer.Write(newLine);
     }
 
     private static int IndexOfCsvSpecial(string text, char delimiter)

--- a/OfficeIMO.CSV/CsvWriter.cs
+++ b/OfficeIMO.CSV/CsvWriter.cs
@@ -234,6 +234,25 @@ internal static class CsvWriter
         WriteBufferedRecordLine(writer, buffer, newLine);
     }
 
+    internal static void WriteRecordDefault(
+        TextWriter writer,
+        string?[] values,
+        char delimiter,
+        string newLine)
+    {
+        for (var i = 0; i < values.Length; i++)
+        {
+            if (i > 0)
+            {
+                writer.Write(delimiter);
+            }
+
+            WriteEscapedDefault(writer, values[i], delimiter);
+        }
+
+        writer.Write(newLine);
+    }
+
     internal static void WriteRecordBufferedAlwaysQuoted(
         TextWriter writer,
         StringBuilder buffer,
@@ -839,6 +858,66 @@ internal static class CsvWriter
         }
 
         writer.Append('"');
+    }
+
+    private static void WriteEscapedDefault(TextWriter writer, string? text, char delimiter)
+    {
+        if (text == null)
+        {
+            return;
+        }
+
+        var specialIndex = IndexOfCsvSpecial(text, delimiter);
+        if (specialIndex < 0)
+        {
+            writer.Write(text);
+            return;
+        }
+
+        WriteEscapedDefault(writer, text, specialIndex);
+    }
+
+    private static void WriteEscapedDefault(TextWriter writer, string text, int specialIndex)
+    {
+        writer.Write('"');
+        if (text.IndexOf('"', specialIndex) < 0)
+        {
+            writer.Write(text);
+            writer.Write('"');
+            return;
+        }
+
+        var segmentStart = 0;
+        for (var i = specialIndex; i < text.Length; i++)
+        {
+            if (text[i] == '"')
+            {
+                WriteTextSegment(writer, text, segmentStart, i - segmentStart);
+                writer.Write("\"\"");
+                segmentStart = i + 1;
+            }
+        }
+
+        if (segmentStart < text.Length)
+        {
+            WriteTextSegment(writer, text, segmentStart, text.Length - segmentStart);
+        }
+
+        writer.Write('"');
+    }
+
+    private static void WriteTextSegment(TextWriter writer, string text, int start, int length)
+    {
+        if (length <= 0)
+        {
+            return;
+        }
+
+#if NET6_0_OR_GREATER
+        writer.Write(text.AsSpan(start, length));
+#else
+        writer.Write(text.Substring(start, length));
+#endif
     }
 
     private static void AppendEscapedTextDefault(StringBuilder writer, string? text, char delimiter)

--- a/OfficeIMO.CSV/CsvWriter.cs
+++ b/OfficeIMO.CSV/CsvWriter.cs
@@ -234,6 +234,73 @@ internal static class CsvWriter
         WriteBufferedRecordLine(writer, buffer, newLine);
     }
 
+    internal static void WriteRecordBufferedDefault<TState>(
+        TextWriter writer,
+        StringBuilder buffer,
+        int valueCount,
+        TState state,
+        Func<TState, int, object?> valueAccessor,
+        char delimiter,
+        string newLine,
+        CultureInfo culture)
+    {
+        if (buffer == null)
+        {
+            throw new ArgumentNullException(nameof(buffer));
+        }
+
+        if (valueAccessor == null)
+        {
+            throw new ArgumentNullException(nameof(valueAccessor));
+        }
+
+        buffer.Clear();
+        for (var i = 0; i < valueCount; i++)
+        {
+            if (i > 0)
+            {
+                buffer.Append(delimiter);
+            }
+
+            AppendEscapedValueDefault(buffer, valueAccessor(state, i), delimiter, culture);
+        }
+
+        WriteBufferedRecordLine(writer, buffer, newLine);
+    }
+
+    internal static void WriteRecordBufferedDefault<TState>(
+        TextWriter writer,
+        StringBuilder buffer,
+        int valueCount,
+        TState state,
+        Func<TState, int, string?> valueAccessor,
+        char delimiter,
+        string newLine)
+    {
+        if (buffer == null)
+        {
+            throw new ArgumentNullException(nameof(buffer));
+        }
+
+        if (valueAccessor == null)
+        {
+            throw new ArgumentNullException(nameof(valueAccessor));
+        }
+
+        buffer.Clear();
+        for (var i = 0; i < valueCount; i++)
+        {
+            if (i > 0)
+            {
+                buffer.Append(delimiter);
+            }
+
+            AppendEscapedTextDefault(buffer, valueAccessor(state, i), delimiter);
+        }
+
+        WriteBufferedRecordLine(writer, buffer, newLine);
+    }
+
     internal static void WriteRecordDefault(
         TextWriter writer,
         string?[] values,
@@ -322,6 +389,39 @@ internal static class CsvWriter
         WriteBufferedRecordLine(writer, buffer, newLine);
     }
 
+    internal static void WriteRecordBufferedAlwaysQuoted<TState>(
+        TextWriter writer,
+        StringBuilder buffer,
+        int valueCount,
+        TState state,
+        Func<TState, int, string?> valueAccessor,
+        char delimiter,
+        string newLine)
+    {
+        if (buffer == null)
+        {
+            throw new ArgumentNullException(nameof(buffer));
+        }
+
+        if (valueAccessor == null)
+        {
+            throw new ArgumentNullException(nameof(valueAccessor));
+        }
+
+        buffer.Clear();
+        for (var i = 0; i < valueCount; i++)
+        {
+            if (i > 0)
+            {
+                buffer.Append(delimiter);
+            }
+
+            AppendAlwaysQuotedTextValue(buffer, valueAccessor(state, i));
+        }
+
+        WriteBufferedRecordLine(writer, buffer, newLine);
+    }
+
     internal static void WriteRecordBufferedAlwaysQuoted(
         TextWriter writer,
         StringBuilder buffer,
@@ -393,6 +493,44 @@ internal static class CsvWriter
         int valueCount,
         TState state,
         Func<TState, int, object?> valueAccessor,
+        char delimiter,
+        string newLine,
+        CultureInfo culture,
+        CsvFormulaInjectionPolicy formulaInjectionPolicy,
+        CsvQuoteMode quoteMode,
+        ISet<string>? quoteFields,
+        IReadOnlyList<string>? fieldNames)
+    {
+        if (buffer == null)
+        {
+            throw new ArgumentNullException(nameof(buffer));
+        }
+
+        if (valueAccessor == null)
+        {
+            throw new ArgumentNullException(nameof(valueAccessor));
+        }
+
+        buffer.Clear();
+        for (var i = 0; i < valueCount; i++)
+        {
+            if (i > 0)
+            {
+                buffer.Append(delimiter);
+            }
+
+            AppendEscapedValue(buffer, valueAccessor(state, i), delimiter, culture, formulaInjectionPolicy, quoteMode, ShouldQuoteField(quoteFields, fieldNames, i));
+        }
+
+        WriteBufferedRecordLine(writer, buffer, newLine);
+    }
+
+    internal static void WriteTextRecordBuffered<TState>(
+        TextWriter writer,
+        StringBuilder buffer,
+        int valueCount,
+        TState state,
+        Func<TState, int, string?> valueAccessor,
         char delimiter,
         string newLine,
         CultureInfo culture,

--- a/OfficeIMO.CSV/CsvWriter.cs
+++ b/OfficeIMO.CSV/CsvWriter.cs
@@ -29,7 +29,7 @@ internal static class CsvWriter
 
         foreach (var row in document.AsEnumerable())
         {
-            WriteRecord(writer, row.Values, delimiter, newLine, culture, formulaInjectionPolicy, quoteMode, quoteFields, document.Header);
+            WriteRecord(writer, row.Values, delimiter, newLine, culture, formulaInjectionPolicy, quoteMode, quoteFields, document.Header, options.DateTimeFormat, options.UseUtc, options.NullValue);
         }
     }
 
@@ -61,7 +61,10 @@ internal static class CsvWriter
         CsvFormulaInjectionPolicy formulaInjectionPolicy,
         CsvQuoteMode quoteMode,
         ISet<string>? quoteFields,
-        IReadOnlyList<string>? fieldNames)
+        IReadOnlyList<string>? fieldNames,
+        string? dateTimeFormat = null,
+        bool useUtc = false,
+        string? nullValue = null)
     {
         var first = true;
         var index = 0;
@@ -76,7 +79,7 @@ internal static class CsvWriter
                 first = false;
             }
 
-            var text = FormatValue(value, culture);
+            var text = FormatValue(value, culture, dateTimeFormat, useUtc, nullValue);
             if (formulaInjectionPolicy == CsvFormulaInjectionPolicy.Escape)
             {
                 text = ApplyFormulaInjectionPolicy(text, formulaInjectionPolicy);
@@ -98,7 +101,10 @@ internal static class CsvWriter
         CsvFormulaInjectionPolicy formulaInjectionPolicy,
         CsvQuoteMode quoteMode,
         ISet<string>? quoteFields,
-        IReadOnlyList<string>? fieldNames)
+        IReadOnlyList<string>? fieldNames,
+        string? dateTimeFormat = null,
+        bool useUtc = false,
+        string? nullValue = null)
     {
         for (var i = 0; i < values.Count; i++)
         {
@@ -107,7 +113,7 @@ internal static class CsvWriter
                 writer.Write(delimiter);
             }
 
-            var text = FormatValue(values[i], culture);
+            var text = FormatValue(values[i], culture, dateTimeFormat, useUtc, nullValue);
             if (formulaInjectionPolicy == CsvFormulaInjectionPolicy.Escape)
             {
                 text = ApplyFormulaInjectionPolicy(text, formulaInjectionPolicy);
@@ -563,11 +569,35 @@ internal static class CsvWriter
         WriteBufferedRecordLine(writer, buffer, newLine);
     }
 
-    private static string FormatValue(object? value, CultureInfo culture)
+    private static string FormatValue(object? value, CultureInfo culture, string? dateTimeFormat = null, bool useUtc = false, string? nullValue = null)
     {
         if (value is null)
         {
-            return string.Empty;
+            return nullValue ?? string.Empty;
+        }
+
+        if (value is DateTime dateTime)
+        {
+            if (useUtc)
+            {
+                dateTime = dateTime.ToUniversalTime();
+            }
+
+            return string.IsNullOrEmpty(dateTimeFormat)
+                ? dateTime.ToString(null, culture)
+                : dateTime.ToString(dateTimeFormat, culture);
+        }
+
+        if (value is DateTimeOffset dateTimeOffset)
+        {
+            if (useUtc)
+            {
+                dateTimeOffset = dateTimeOffset.ToUniversalTime();
+            }
+
+            return string.IsNullOrEmpty(dateTimeFormat)
+                ? dateTimeOffset.ToString(null, culture)
+                : dateTimeOffset.ToString(dateTimeFormat, culture);
         }
 
         if (value is IFormattable formattable)

--- a/OfficeIMO.CSV/CsvWriter.cs
+++ b/OfficeIMO.CSV/CsvWriter.cs
@@ -329,7 +329,7 @@ internal static class CsvWriter
     {
         if (!TextRowNeedsEscaping(values, delimiter))
         {
-            WritePlainTextRecord(writer, values, delimiter, newLine);
+            WritePlainTextRecordBuffered(writer, buffer, values, delimiter, newLine);
             return;
         }
 
@@ -1098,22 +1098,28 @@ internal static class CsvWriter
         return false;
     }
 
-    private static void WritePlainTextRecord(TextWriter writer, string?[] values, char delimiter, string newLine)
+    private static void WritePlainTextRecordBuffered(TextWriter writer, StringBuilder buffer, string?[] values, char delimiter, string newLine)
     {
+        if (buffer == null)
+        {
+            throw new ArgumentNullException(nameof(buffer));
+        }
+
+        buffer.Clear();
         for (var i = 0; i < values.Length; i++)
         {
             if (i > 0)
             {
-                writer.Write(delimiter);
+                buffer.Append(delimiter);
             }
 
             if (values[i] != null)
             {
-                writer.Write(values[i]);
+                buffer.Append(values[i]);
             }
         }
 
-        writer.Write(newLine);
+        WriteBufferedRecordLine(writer, buffer, newLine);
     }
 
     private static int IndexOfCsvSpecial(string text, char delimiter)

--- a/OfficeIMO.CSV/CsvWriter.cs
+++ b/OfficeIMO.CSV/CsvWriter.cs
@@ -135,7 +135,10 @@ internal static class CsvWriter
         CsvFormulaInjectionPolicy formulaInjectionPolicy,
         CsvQuoteMode quoteMode,
         ISet<string>? quoteFields,
-        IReadOnlyList<string>? fieldNames)
+        IReadOnlyList<string>? fieldNames,
+        string? dateTimeFormat = null,
+        bool useUtc = false,
+        string? nullValue = null)
     {
         if (buffer == null)
         {
@@ -150,7 +153,7 @@ internal static class CsvWriter
                 buffer.Append(delimiter);
             }
 
-            AppendEscapedValue(buffer, values[i], delimiter, culture, formulaInjectionPolicy, quoteMode, ShouldQuoteField(quoteFields, fieldNames, i));
+            AppendEscapedValue(buffer, values[i], delimiter, culture, formulaInjectionPolicy, quoteMode, ShouldQuoteField(quoteFields, fieldNames, i), dateTimeFormat, useUtc, nullValue);
         }
 
         WriteBufferedRecordLine(writer, buffer, newLine);
@@ -166,7 +169,10 @@ internal static class CsvWriter
         CsvFormulaInjectionPolicy formulaInjectionPolicy,
         CsvQuoteMode quoteMode,
         ISet<string>? quoteFields,
-        IReadOnlyList<string>? fieldNames)
+        IReadOnlyList<string>? fieldNames,
+        string? dateTimeFormat = null,
+        bool useUtc = false,
+        string? nullValue = null)
     {
         if (buffer == null)
         {
@@ -181,7 +187,7 @@ internal static class CsvWriter
                 buffer.Append(delimiter);
             }
 
-            AppendEscapedValue(buffer, values[i], delimiter, culture, formulaInjectionPolicy, quoteMode, ShouldQuoteField(quoteFields, fieldNames, i));
+            AppendEscapedValue(buffer, values[i], delimiter, culture, formulaInjectionPolicy, quoteMode, ShouldQuoteField(quoteFields, fieldNames, i), dateTimeFormat, useUtc, nullValue);
         }
 
         WriteBufferedRecordLine(writer, buffer, newLine);
@@ -467,7 +473,10 @@ internal static class CsvWriter
         CsvFormulaInjectionPolicy formulaInjectionPolicy,
         CsvQuoteMode quoteMode,
         ISet<string>? quoteFields,
-        IReadOnlyList<string>? fieldNames)
+        IReadOnlyList<string>? fieldNames,
+        string? dateTimeFormat = null,
+        bool useUtc = false,
+        string? nullValue = null)
     {
         if (valueAccessor == null)
         {
@@ -481,7 +490,7 @@ internal static class CsvWriter
                 writer.Write(delimiter);
             }
 
-            var text = FormatValue(valueAccessor(state, i), culture);
+            var text = FormatValue(valueAccessor(state, i), culture, dateTimeFormat, useUtc, nullValue);
             if (formulaInjectionPolicy == CsvFormulaInjectionPolicy.Escape)
             {
                 text = ApplyFormulaInjectionPolicy(text, formulaInjectionPolicy);
@@ -505,7 +514,10 @@ internal static class CsvWriter
         CsvFormulaInjectionPolicy formulaInjectionPolicy,
         CsvQuoteMode quoteMode,
         ISet<string>? quoteFields,
-        IReadOnlyList<string>? fieldNames)
+        IReadOnlyList<string>? fieldNames,
+        string? dateTimeFormat = null,
+        bool useUtc = false,
+        string? nullValue = null)
     {
         if (buffer == null)
         {
@@ -525,7 +537,7 @@ internal static class CsvWriter
                 buffer.Append(delimiter);
             }
 
-            AppendEscapedValue(buffer, valueAccessor(state, i), delimiter, culture, formulaInjectionPolicy, quoteMode, ShouldQuoteField(quoteFields, fieldNames, i));
+            AppendEscapedValue(buffer, valueAccessor(state, i), delimiter, culture, formulaInjectionPolicy, quoteMode, ShouldQuoteField(quoteFields, fieldNames, i), dateTimeFormat, useUtc, nullValue);
         }
 
         WriteBufferedRecordLine(writer, buffer, newLine);
@@ -543,7 +555,10 @@ internal static class CsvWriter
         CsvFormulaInjectionPolicy formulaInjectionPolicy,
         CsvQuoteMode quoteMode,
         ISet<string>? quoteFields,
-        IReadOnlyList<string>? fieldNames)
+        IReadOnlyList<string>? fieldNames,
+        string? dateTimeFormat = null,
+        bool useUtc = false,
+        string? nullValue = null)
     {
         if (buffer == null)
         {
@@ -563,7 +578,7 @@ internal static class CsvWriter
                 buffer.Append(delimiter);
             }
 
-            AppendEscapedValue(buffer, valueAccessor(state, i), delimiter, culture, formulaInjectionPolicy, quoteMode, ShouldQuoteField(quoteFields, fieldNames, i));
+            AppendEscapedValue(buffer, valueAccessor(state, i), delimiter, culture, formulaInjectionPolicy, quoteMode, ShouldQuoteField(quoteFields, fieldNames, i), dateTimeFormat, useUtc, nullValue);
         }
 
         WriteBufferedRecordLine(writer, buffer, newLine);
@@ -657,11 +672,18 @@ internal static class CsvWriter
         CultureInfo culture,
         CsvFormulaInjectionPolicy formulaInjectionPolicy,
         CsvQuoteMode quoteMode,
-        bool forceQuote)
+        bool forceQuote,
+        string? dateTimeFormat = null,
+        bool useUtc = false,
+        string? nullValue = null)
     {
         if (value is null)
         {
-            if (quoteMode == CsvQuoteMode.Always || forceQuote)
+            if (nullValue is not null)
+            {
+                WriteEscaped(buffer, nullValue, delimiter, quoteMode, forceQuote);
+            }
+            else if (quoteMode == CsvQuoteMode.Always || forceQuote)
             {
                 buffer.Append("\"\"");
             }
@@ -677,6 +699,19 @@ internal static class CsvWriter
             }
 
             WriteEscaped(buffer, text, delimiter, quoteMode, forceQuote);
+            return;
+        }
+
+        if ((dateTimeFormat is not null || useUtc) &&
+            (value is DateTime || value is DateTimeOffset))
+        {
+            var formattedDate = FormatValue(value, culture, dateTimeFormat, useUtc, nullValue);
+            if (formulaInjectionPolicy == CsvFormulaInjectionPolicy.Escape)
+            {
+                formattedDate = ApplyFormulaInjectionPolicy(formattedDate, formulaInjectionPolicy);
+            }
+
+            WriteEscaped(buffer, formattedDate, delimiter, quoteMode, forceQuote);
             return;
         }
 

--- a/OfficeIMO.CSV/ICsvFieldSpanVisitor.cs
+++ b/OfficeIMO.CSV/ICsvFieldSpanVisitor.cs
@@ -17,6 +17,19 @@ public interface ICsvFieldSpanVisitor
     void VisitField(int recordIndex, int fieldIndex, ReadOnlySpan<char> value);
 
     /// <summary>
+    /// Optionally visits an escaped quoted field without forcing the parser to compact doubled quotes into a scratch buffer.
+    /// </summary>
+    /// <param name="recordIndex">Zero-based emitted record index.</param>
+    /// <param name="fieldIndex">Zero-based field index within the record.</param>
+    /// <param name="escapedValue">The quoted field content without surrounding quotes, preserving doubled quote escape sequences.</param>
+    /// <param name="unescapedLength">Length of the field after CSV quote unescaping.</param>
+    /// <returns><see langword="true" /> when the visitor consumed the escaped field; otherwise the parser falls back to <see cref="VisitField" /> with an unescaped span.</returns>
+    bool TryVisitEscapedField(int recordIndex, int fieldIndex, ReadOnlySpan<char> escapedValue, int unescapedLength)
+    {
+        return false;
+    }
+
+    /// <summary>
     /// Visits one parsed string field. Implement this to avoid copying fields that were already materialized while parsing quoted records.
     /// </summary>
     /// <param name="recordIndex">Zero-based emitted record index.</param>

--- a/OfficeIMO.CSV/ICsvFieldSpanVisitor.cs
+++ b/OfficeIMO.CSV/ICsvFieldSpanVisitor.cs
@@ -15,6 +15,17 @@ public interface ICsvFieldSpanVisitor
     /// <param name="fieldIndex">Zero-based field index within the record.</param>
     /// <param name="value">The field value. Do not capture the span beyond this method.</param>
     void VisitField(int recordIndex, int fieldIndex, ReadOnlySpan<char> value);
+
+    /// <summary>
+    /// Visits one parsed string field. Implement this to avoid copying fields that were already materialized while parsing quoted records.
+    /// </summary>
+    /// <param name="recordIndex">Zero-based emitted record index.</param>
+    /// <param name="fieldIndex">Zero-based field index within the record.</param>
+    /// <param name="value">The field value.</param>
+    void VisitFieldValue(int recordIndex, int fieldIndex, string value)
+    {
+        VisitField(recordIndex, fieldIndex, value.AsSpan());
+    }
 }
 
 internal readonly struct CsvFieldSpanActionVisitor : ICsvFieldSpanVisitor

--- a/OfficeIMO.CSV/ICsvRowFieldSpanVisitor.cs
+++ b/OfficeIMO.CSV/ICsvRowFieldSpanVisitor.cs
@@ -1,0 +1,44 @@
+#nullable enable
+
+namespace OfficeIMO.CSV;
+
+#if NET8_0_OR_GREATER
+/// <summary>
+/// Receives header-aware CSV data rows as transient field spans during a single-pass read.
+/// </summary>
+public interface ICsvRowFieldSpanVisitor
+{
+    /// <summary>
+    /// Starts a data row. The header has already been discovered, normalized, and validated.
+    /// </summary>
+    /// <param name="header">Normalized header names for the row.</param>
+    /// <param name="rowIndex">Zero-based emitted data row index.</param>
+    void BeginRow(IReadOnlyList<string> header, int rowIndex);
+
+    /// <summary>
+    /// Visits one data field. The span is valid only for the duration of the call.
+    /// </summary>
+    /// <param name="rowIndex">Zero-based emitted data row index.</param>
+    /// <param name="fieldIndex">Zero-based field index within the normalized header width.</param>
+    /// <param name="value">The field value. Do not capture the span beyond this method.</param>
+    void VisitField(int rowIndex, int fieldIndex, ReadOnlySpan<char> value);
+
+    /// <summary>
+    /// Visits one parsed string field. Implement this to avoid copying fields that were already materialized while parsing quoted records.
+    /// </summary>
+    /// <param name="rowIndex">Zero-based emitted data row index.</param>
+    /// <param name="fieldIndex">Zero-based field index within the normalized header width.</param>
+    /// <param name="value">The field value.</param>
+    void VisitFieldValue(int rowIndex, int fieldIndex, string value)
+    {
+        VisitField(rowIndex, fieldIndex, value.AsSpan());
+    }
+
+    /// <summary>
+    /// Completes a data row after all emitted field spans have been visited.
+    /// </summary>
+    /// <param name="rowIndex">Zero-based emitted data row index.</param>
+    /// <param name="fieldCount">Number of fields parsed from the source row before column-count alignment.</param>
+    void EndRow(int rowIndex, int fieldCount);
+}
+#endif

--- a/OfficeIMO.CSV/OfficeIMO.CSV.csproj
+++ b/OfficeIMO.CSV/OfficeIMO.CSV.csproj
@@ -55,6 +55,10 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+  </ItemGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="OfficeIMO.CSV.Tests" />
   </ItemGroup>

--- a/OfficeIMO.CSV/README.md
+++ b/OfficeIMO.CSV/README.md
@@ -38,11 +38,14 @@ new CsvDocument()
 
 - Keeps headers and rows as a first-class document model instead of ad hoc string arrays.
 - Loads from files, streams, or text and saves through configurable delimiter, culture, encoding, and newline options.
+- Reads and writes compressed CSV files with extension-based detection for gzip, deflate, Brotli, and zlib.
 - Can escape formula-like values during save when producing CSV files that people will open in spreadsheet applications.
+- Handles real-world import details such as duplicate headers, generated blank headers, null tokens, static metadata columns, custom date formats, comments, W3C `#Fields:` headers, and mismatched row lengths.
 - Supports `AddRow`, `AddColumn`, `RemoveColumn`, `SortBy`, `Filter`, and `Transform`.
 - Provides schema validation with required columns, typed columns, defaults, and custom rules.
 - Maps rows to typed objects with explicit no-reflection mapping.
 - Supports streaming mode for large files and explicit materialization when transforms are needed.
+- Includes benchmark lanes against Dataplat/dbatools CSV, Sep, Sylvan, CsvHelper, and OfficeIMO fast paths.
 
 ## Schema example
 
@@ -151,6 +154,75 @@ var transformed = CsvDocument.Load("large.csv", new CsvLoadOptions {
     .SortBy(row => row.AsInt32("Id"));
 
 transformed.Save("ready.csv");
+```
+
+## Real-world headers
+
+CSV exports often contain blank or repeated header names. By default, blank headers are generated as `H1`, `H2`, and duplicate names are renamed with suffixes so name-based row access stays unambiguous:
+
+```csharp
+var document = CsvDocument.Parse("Name,Name\nAlpha,Beta\n");
+
+Console.WriteLine(string.Join(", ", document.Header));
+// Name, Name_2
+```
+
+Use `DuplicateHeaderBehavior` when a pipeline needs to preserve source names exactly or reject ambiguous files:
+
+```csharp
+var strict = new CsvLoadOptions {
+    DuplicateHeaderBehavior = CsvDuplicateHeaderBehavior.Throw
+};
+
+CsvDocument.Load("input.csv", strict);
+```
+
+Append static metadata columns during import when a database or audit pipeline needs source context on every row:
+
+```csharp
+var document = CsvDocument.Load("input.csv", new CsvLoadOptions {
+    StaticColumns = new Dictionary<string, object?> {
+        ["SourceFile"] = "input.csv",
+        ["ImportedUtc"] = DateTime.UtcNow
+    }
+});
+```
+
+Use `NullValue` and `DateTimeFormats` when a CSV producer uses explicit null tokens or non-default date shapes:
+
+```csharp
+var document = CsvDocument.Load("input.csv", new CsvLoadOptions {
+    NullValue = "<null>",
+    DateTimeFormats = new[] { "dd-MMM-yyyy", "yyyyMMdd-HHmmss" }
+});
+
+DateTime created = document.AsEnumerable().First().AsDateTime("Created");
+```
+
+## Export options
+
+CSV output supports null tokens, date/time formatting, UTC conversion, append, no-clobber checks, compression, quoting, encoding, and formula escaping:
+
+```csharp
+CsvDocument.Load("input.csv")
+    .Save("output.csv.gz", new CsvSaveOptions {
+        NullValue = "<null>",
+        DateTimeFormat = "yyyy-MM-ddTHH:mm:ssZ",
+        UseUtc = true,
+        CompressionType = CsvCompressionType.Auto,
+        FormulaInjectionPolicy = CsvFormulaInjectionPolicy.Escape,
+        NewLine = "\n"
+    });
+```
+
+Append without rewriting the header:
+
+```csharp
+CsvDocument.Load("next.csv")
+    .Save("combined.csv", new CsvSaveOptions {
+        Append = true,
+        IncludeHeader = false
+    });
 ```
 
 ## Objects and ad hoc data

--- a/OfficeIMO.CSV/README.md
+++ b/OfficeIMO.CSV/README.md
@@ -42,7 +42,7 @@ new CsvDocument()
 - Can escape formula-like values during save when producing CSV files that people will open in spreadsheet applications.
 - Handles real-world import details such as duplicate headers, generated blank headers, null tokens, static metadata columns, custom date formats, comments, W3C `#Fields:` headers, and mismatched row lengths.
 - Supports `AddRow`, `AddColumn`, `RemoveColumn`, `SortBy`, `Filter`, and `Transform`.
-- Provides schema validation with required columns, typed columns, defaults, and custom rules.
+- Provides schema inference and schema validation with required columns, typed columns, defaults, and custom rules.
 - Maps rows to typed objects with explicit no-reflection mapping.
 - Supports streaming mode for large files and explicit materialization when transforms are needed.
 - Includes benchmark lanes against Dataplat/dbatools CSV, Sep, Sylvan, CsvHelper, and OfficeIMO fast paths.
@@ -72,6 +72,18 @@ document.Validate(out var errors);
 foreach (var error in errors) {
     Console.WriteLine($"{error.RowIndex}:{error.ColumnName} - {error.Message}");
 }
+```
+
+Infer a schema from sampled rows when the incoming file should define the import contract:
+
+```csharp
+var document = CsvDocument.Load("input.csv", new CsvLoadOptions {
+    DateTimeFormats = new[] { "dd-MMM-yyyy" }
+});
+
+CsvSchema inferred = document.InferSchema(sampleSize: 1000);
+document.EnsureInferredSchema()
+    .ValidateOrThrow();
 ```
 
 ## Typed mapping
@@ -199,6 +211,14 @@ var document = CsvDocument.Load("input.csv", new CsvLoadOptions {
 DateTime created = document.AsEnumerable().First().AsDateTime("Created");
 ```
 
+The parser defaults to lenient quoted-field handling for compatibility with common PowerShell CSV imports. Use strict mode when malformed quotes should fail the import:
+
+```csharp
+var document = CsvDocument.Load("input.csv", new CsvLoadOptions {
+    QuoteParsingMode = CsvQuoteParsingMode.Strict
+});
+```
+
 ## Export options
 
 CSV output supports null tokens, date/time formatting, UTC conversion, append, no-clobber checks, compression, quoting, encoding, and formula escaping:
@@ -239,6 +259,17 @@ CsvDocument.FromObjects(rows)
     .Save("summary.csv");
 ```
 
+Use direct object writing for larger exports when the caller does not need to materialize a `CsvDocument` first. The same save options are honored, including null tokens, date/time formatting, UTC conversion, compression, append, and no-clobber checks:
+
+```csharp
+CsvDocument.SaveObjects("summary.csv.gz", rows, new CsvSaveOptions {
+    NullValue = "<null>",
+    DateTimeFormat = "yyyy-MM-ddTHH:mm:ssZ",
+    UseUtc = true,
+    CompressionType = CsvCompressionType.Auto
+});
+```
+
 Parse text when a service receives CSV payloads without a temporary file:
 
 ```csharp
@@ -256,6 +287,7 @@ string normalized = document.ToString(new CsvSaveOptions {
 ## Boundaries
 
 - This package owns CSV parsing, writing, transforms, and validation.
+- Delimiters are single characters. Multi-character delimiter support is not advertised until the parser, writer, delimiter detection, and benchmark lanes can all support it consistently.
 - Reader integration belongs in `OfficeIMO.Reader.Csv`.
 - Excel workbook behavior belongs in `OfficeIMO.Excel`.
 

--- a/OfficeIMO.Shared/ObjectDataHelpers.cs
+++ b/OfficeIMO.Shared/ObjectDataHelpers.cs
@@ -203,13 +203,13 @@ internal static class ObjectDataHelpers
         private Func<object, object?[], bool>? _defaultProjector;
         private Func<object, string?[], CultureInfo, bool>? _defaultTextProjector;
 
-        public ObjectPropertyPlan(Type type, IReadOnlyList<PropertyInfo> properties)
+        public ObjectPropertyPlan(Type type, PropertyInfo[] properties)
         {
-            var columnNames = new string[properties.Count];
-            _properties = new PropertyInfo[properties.Count];
-            _propertiesByName = new Dictionary<string, PropertyInfo>(properties.Count, StringComparer.Ordinal);
+            var columnNames = new string[properties.Length];
+            _properties = new PropertyInfo[properties.Length];
+            _propertiesByName = new Dictionary<string, PropertyInfo>(properties.Length, StringComparer.Ordinal);
             _type = type;
-            for (var i = 0; i < properties.Count; i++)
+            for (var i = 0; i < properties.Length; i++)
             {
                 var property = properties[i];
                 _properties[i] = property;
@@ -220,7 +220,7 @@ internal static class ObjectDataHelpers
             ColumnNames = columnNames;
         }
 
-        public IReadOnlyList<string> ColumnNames { get; }
+        public string[] ColumnNames { get; }
 
         public bool TryGetValue(object item, string column, out object? value)
         {
@@ -284,7 +284,7 @@ internal static class ObjectDataHelpers
 
         private bool IsDefaultColumnOrder(IReadOnlyList<string> columns)
         {
-            if (columns.Count != ColumnNames.Count)
+            if (columns.Count != ColumnNames.Length)
             {
                 return false;
             }
@@ -300,7 +300,7 @@ internal static class ObjectDataHelpers
             return true;
         }
 
-        private Func<object, object?[], bool> CreateProjector(IReadOnlyList<PropertyInfo> properties)
+        private Func<object, object?[], bool> CreateProjector(PropertyInfo[] properties)
         {
 #if NET5_0_OR_GREATER
             if (System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported)
@@ -309,8 +309,8 @@ internal static class ObjectDataHelpers
             }
 #endif
 
-            var accessors = new Func<object, object?>[properties.Count];
-            for (var i = 0; i < properties.Count; i++)
+            var accessors = new Func<object, object?>[properties.Length];
+            for (var i = 0; i < properties.Length; i++)
             {
                 accessors[i] = CreateAccessor(properties[i]);
             }
@@ -318,7 +318,7 @@ internal static class ObjectDataHelpers
             return CreateProjector(_type, accessors);
         }
 
-        private Func<object, string?[], CultureInfo, bool> CreateTextProjector(IReadOnlyList<PropertyInfo> properties)
+        private Func<object, string?[], CultureInfo, bool> CreateTextProjector(PropertyInfo[] properties)
         {
 #if NET5_0_OR_GREATER
             if (System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported)
@@ -327,8 +327,8 @@ internal static class ObjectDataHelpers
             }
 #endif
 
-            var accessors = new Func<object, CultureInfo, string?>[properties.Count];
-            for (var i = 0; i < properties.Count; i++)
+            var accessors = new Func<object, CultureInfo, string?>[properties.Length];
+            for (var i = 0; i < properties.Length; i++)
             {
                 accessors[i] = CreateTextAccessor(properties[i]);
             }
@@ -337,13 +337,13 @@ internal static class ObjectDataHelpers
         }
 
 #if NET5_0_OR_GREATER
-        private static Func<object, object?[], bool> CreateCompiledProjector(Type type, IReadOnlyList<PropertyInfo> properties)
+        private static Func<object, object?[], bool> CreateCompiledProjector(Type type, PropertyInfo[] properties)
         {
             var item = Expression.Parameter(typeof(object), "item");
             var values = Expression.Parameter(typeof(object?[]), "values");
             var typedItem = Expression.Variable(type, "typedItem");
             var returnTarget = Expression.Label(typeof(bool));
-            var expressions = new List<Expression>(properties.Count + 6);
+            var expressions = new List<Expression>(properties.Length + 6);
 
             expressions.Add(Expression.IfThen(
                 Expression.OrElse(
@@ -360,7 +360,7 @@ internal static class ObjectDataHelpers
                     Expression.Constant("values")))));
 
             expressions.Add(Expression.IfThen(
-                Expression.NotEqual(Expression.ArrayLength(values), Expression.Constant(properties.Count)),
+                Expression.NotEqual(Expression.ArrayLength(values), Expression.Constant(properties.Length)),
                 Expression.Throw(Expression.New(
                     typeof(ArgumentException).GetConstructor(new[] { typeof(string), typeof(string) })!,
                     Expression.Constant("Value buffer length must match the projector column count."),
@@ -368,7 +368,7 @@ internal static class ObjectDataHelpers
 
             expressions.Add(Expression.Assign(typedItem, Expression.Convert(item, type)));
 
-            for (var i = 0; i < properties.Count; i++)
+            for (var i = 0; i < properties.Length; i++)
             {
                 expressions.Add(Expression.Assign(
                     Expression.ArrayAccess(values, Expression.Constant(i)),
@@ -384,14 +384,14 @@ internal static class ObjectDataHelpers
                 values).Compile();
         }
 
-        private static Func<object, string?[], CultureInfo, bool> CreateCompiledTextProjector(Type type, IReadOnlyList<PropertyInfo> properties)
+        private static Func<object, string?[], CultureInfo, bool> CreateCompiledTextProjector(Type type, PropertyInfo[] properties)
         {
             var item = Expression.Parameter(typeof(object), "item");
             var values = Expression.Parameter(typeof(string?[]), "values");
             var culture = Expression.Parameter(typeof(CultureInfo), "culture");
             var typedItem = Expression.Variable(type, "typedItem");
             var returnTarget = Expression.Label(typeof(bool));
-            var expressions = new List<Expression>(properties.Count + 7);
+            var expressions = new List<Expression>(properties.Length + 7);
 
             expressions.Add(Expression.IfThen(
                 Expression.OrElse(
@@ -414,7 +414,7 @@ internal static class ObjectDataHelpers
                     Expression.Constant("culture")))));
 
             expressions.Add(Expression.IfThen(
-                Expression.NotEqual(Expression.ArrayLength(values), Expression.Constant(properties.Count)),
+                Expression.NotEqual(Expression.ArrayLength(values), Expression.Constant(properties.Length)),
                 Expression.Throw(Expression.New(
                     typeof(ArgumentException).GetConstructor(new[] { typeof(string), typeof(string) })!,
                     Expression.Constant("Value buffer length must match the projector column count."),
@@ -422,7 +422,7 @@ internal static class ObjectDataHelpers
 
             expressions.Add(Expression.Assign(typedItem, Expression.Convert(item, type)));
 
-            for (var i = 0; i < properties.Count; i++)
+            for (var i = 0; i < properties.Length; i++)
             {
                 expressions.Add(Expression.Assign(
                     Expression.ArrayAccess(values, Expression.Constant(i)),

--- a/OfficeIMO.Shared/ObjectDataHelpers.cs
+++ b/OfficeIMO.Shared/ObjectDataHelpers.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -156,6 +157,31 @@ internal static class ObjectDataHelpers
         return GetPropertyPlan(item.GetType()).TryCreateProjector(columns, out projector);
     }
 
+    /// <summary>
+    /// Creates a reusable text projector for a fixed CLR object type and column order.
+    /// </summary>
+#if NET5_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Uses reflection over arbitrary object graphs. For AOT-safe usage, map values explicitly or pre-flatten items.")]
+#endif
+    internal static bool TryCreatePropertyTextProjector(object item, IReadOnlyList<string> columns, out Func<object, string?[], CultureInfo, bool>? projector)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(item);
+        ArgumentNullException.ThrowIfNull(columns);
+#else
+        if (item == null) throw new ArgumentNullException(nameof(item));
+        if (columns == null) throw new ArgumentNullException(nameof(columns));
+#endif
+
+        projector = null;
+        if (IsDictionaryLike(item))
+        {
+            return false;
+        }
+
+        return GetPropertyPlan(item.GetType()).TryCreateTextProjector(columns, out projector);
+    }
+
     private static ObjectPropertyPlan GetPropertyPlan(Type type) => PropertyPlans.GetOrAdd(type, CreatePropertyPlan);
 
     private static ObjectPropertyPlan CreatePropertyPlan(Type type)
@@ -171,17 +197,22 @@ internal static class ObjectDataHelpers
 
     private sealed class ObjectPropertyPlan
     {
+        private readonly PropertyInfo[] _properties;
         private readonly Dictionary<string, PropertyInfo> _propertiesByName;
         private readonly Type _type;
+        private Func<object, object?[], bool>? _defaultProjector;
+        private Func<object, string?[], CultureInfo, bool>? _defaultTextProjector;
 
         public ObjectPropertyPlan(Type type, IReadOnlyList<PropertyInfo> properties)
         {
             var columnNames = new string[properties.Count];
+            _properties = new PropertyInfo[properties.Count];
             _propertiesByName = new Dictionary<string, PropertyInfo>(properties.Count, StringComparer.Ordinal);
             _type = type;
             for (var i = 0; i < properties.Count; i++)
             {
                 var property = properties[i];
+                _properties[i] = property;
                 columnNames[i] = property.Name;
                 _propertiesByName[property.Name] = property;
             }
@@ -205,7 +236,13 @@ internal static class ObjectDataHelpers
 
         public bool TryCreateProjector(IReadOnlyList<string> columns, out Func<object, object?[], bool>? projector)
         {
-            var accessors = new Func<object, object?>[columns.Count];
+            if (IsDefaultColumnOrder(columns))
+            {
+                projector = _defaultProjector ??= CreateProjector(_properties);
+                return true;
+            }
+
+            var properties = new PropertyInfo[columns.Count];
             for (var i = 0; i < columns.Count; i++)
             {
                 if (!_propertiesByName.TryGetValue(columns[i], out var property))
@@ -214,12 +251,194 @@ internal static class ObjectDataHelpers
                     return false;
                 }
 
-                accessors[i] = CreateAccessor(property);
+                properties[i] = property;
             }
 
-            projector = CreateProjector(_type, accessors);
+            projector = CreateProjector(properties);
             return true;
         }
+
+        public bool TryCreateTextProjector(IReadOnlyList<string> columns, out Func<object, string?[], CultureInfo, bool>? projector)
+        {
+            if (IsDefaultColumnOrder(columns))
+            {
+                projector = _defaultTextProjector ??= CreateTextProjector(_properties);
+                return true;
+            }
+
+            var properties = new PropertyInfo[columns.Count];
+            for (var i = 0; i < columns.Count; i++)
+            {
+                if (!_propertiesByName.TryGetValue(columns[i], out var property))
+                {
+                    projector = null;
+                    return false;
+                }
+
+                properties[i] = property;
+            }
+
+            projector = CreateTextProjector(properties);
+            return true;
+        }
+
+        private bool IsDefaultColumnOrder(IReadOnlyList<string> columns)
+        {
+            if (columns.Count != ColumnNames.Count)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < columns.Count; i++)
+            {
+                if (!string.Equals(columns[i], ColumnNames[i], StringComparison.Ordinal))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private Func<object, object?[], bool> CreateProjector(IReadOnlyList<PropertyInfo> properties)
+        {
+#if NET5_0_OR_GREATER
+            if (System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported)
+            {
+                return CreateCompiledProjector(_type, properties);
+            }
+#endif
+
+            var accessors = new Func<object, object?>[properties.Count];
+            for (var i = 0; i < properties.Count; i++)
+            {
+                accessors[i] = CreateAccessor(properties[i]);
+            }
+
+            return CreateProjector(_type, accessors);
+        }
+
+        private Func<object, string?[], CultureInfo, bool> CreateTextProjector(IReadOnlyList<PropertyInfo> properties)
+        {
+#if NET5_0_OR_GREATER
+            if (System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported)
+            {
+                return CreateCompiledTextProjector(_type, properties);
+            }
+#endif
+
+            var accessors = new Func<object, CultureInfo, string?>[properties.Count];
+            for (var i = 0; i < properties.Count; i++)
+            {
+                accessors[i] = CreateTextAccessor(properties[i]);
+            }
+
+            return CreateTextProjector(_type, accessors);
+        }
+
+#if NET5_0_OR_GREATER
+        private static Func<object, object?[], bool> CreateCompiledProjector(Type type, IReadOnlyList<PropertyInfo> properties)
+        {
+            var item = Expression.Parameter(typeof(object), "item");
+            var values = Expression.Parameter(typeof(object?[]), "values");
+            var typedItem = Expression.Variable(type, "typedItem");
+            var returnTarget = Expression.Label(typeof(bool));
+            var expressions = new List<Expression>(properties.Count + 6);
+
+            expressions.Add(Expression.IfThen(
+                Expression.OrElse(
+                    Expression.Equal(item, Expression.Constant(null, typeof(object))),
+                    Expression.NotEqual(
+                        Expression.Call(item, typeof(object).GetMethod(nameof(GetType))!),
+                        Expression.Constant(type))),
+                Expression.Return(returnTarget, Expression.Constant(false))));
+
+            expressions.Add(Expression.IfThen(
+                Expression.Equal(values, Expression.Constant(null, typeof(object?[]))),
+                Expression.Throw(Expression.New(
+                    typeof(ArgumentNullException).GetConstructor(new[] { typeof(string) })!,
+                    Expression.Constant("values")))));
+
+            expressions.Add(Expression.IfThen(
+                Expression.NotEqual(Expression.ArrayLength(values), Expression.Constant(properties.Count)),
+                Expression.Throw(Expression.New(
+                    typeof(ArgumentException).GetConstructor(new[] { typeof(string), typeof(string) })!,
+                    Expression.Constant("Value buffer length must match the projector column count."),
+                    Expression.Constant("values")))));
+
+            expressions.Add(Expression.Assign(typedItem, Expression.Convert(item, type)));
+
+            for (var i = 0; i < properties.Count; i++)
+            {
+                expressions.Add(Expression.Assign(
+                    Expression.ArrayAccess(values, Expression.Constant(i)),
+                    Expression.Convert(Expression.Property(typedItem, properties[i]), typeof(object))));
+            }
+
+            expressions.Add(Expression.Return(returnTarget, Expression.Constant(true)));
+            expressions.Add(Expression.Label(returnTarget, Expression.Constant(false)));
+
+            return Expression.Lambda<Func<object, object?[], bool>>(
+                Expression.Block(new[] { typedItem }, expressions),
+                item,
+                values).Compile();
+        }
+
+        private static Func<object, string?[], CultureInfo, bool> CreateCompiledTextProjector(Type type, IReadOnlyList<PropertyInfo> properties)
+        {
+            var item = Expression.Parameter(typeof(object), "item");
+            var values = Expression.Parameter(typeof(string?[]), "values");
+            var culture = Expression.Parameter(typeof(CultureInfo), "culture");
+            var typedItem = Expression.Variable(type, "typedItem");
+            var returnTarget = Expression.Label(typeof(bool));
+            var expressions = new List<Expression>(properties.Count + 7);
+
+            expressions.Add(Expression.IfThen(
+                Expression.OrElse(
+                    Expression.Equal(item, Expression.Constant(null, typeof(object))),
+                    Expression.NotEqual(
+                        Expression.Call(item, typeof(object).GetMethod(nameof(GetType))!),
+                        Expression.Constant(type))),
+                Expression.Return(returnTarget, Expression.Constant(false))));
+
+            expressions.Add(Expression.IfThen(
+                Expression.Equal(values, Expression.Constant(null, typeof(string?[]))),
+                Expression.Throw(Expression.New(
+                    typeof(ArgumentNullException).GetConstructor(new[] { typeof(string) })!,
+                    Expression.Constant("values")))));
+
+            expressions.Add(Expression.IfThen(
+                Expression.Equal(culture, Expression.Constant(null, typeof(CultureInfo))),
+                Expression.Throw(Expression.New(
+                    typeof(ArgumentNullException).GetConstructor(new[] { typeof(string) })!,
+                    Expression.Constant("culture")))));
+
+            expressions.Add(Expression.IfThen(
+                Expression.NotEqual(Expression.ArrayLength(values), Expression.Constant(properties.Count)),
+                Expression.Throw(Expression.New(
+                    typeof(ArgumentException).GetConstructor(new[] { typeof(string), typeof(string) })!,
+                    Expression.Constant("Value buffer length must match the projector column count."),
+                    Expression.Constant("values")))));
+
+            expressions.Add(Expression.Assign(typedItem, Expression.Convert(item, type)));
+
+            for (var i = 0; i < properties.Count; i++)
+            {
+                expressions.Add(Expression.Assign(
+                    Expression.ArrayAccess(values, Expression.Constant(i)),
+                    CreateFormatExpression(Expression.Property(typedItem, properties[i]), culture)));
+            }
+
+            expressions.Add(Expression.Return(returnTarget, Expression.Constant(true)));
+            expressions.Add(Expression.Label(returnTarget, Expression.Constant(false)));
+
+            return Expression.Lambda<Func<object, string?[], CultureInfo, bool>>(
+                Expression.Block(new[] { typedItem }, expressions),
+                item,
+                values,
+                culture).Compile();
+        }
+#endif
 
         private static Func<object, object?[], bool> CreateProjector(Type type, Func<object, object?>[] accessors)
         {
@@ -250,6 +469,37 @@ internal static class ObjectDataHelpers
             };
         }
 
+        private static Func<object, string?[], CultureInfo, bool> CreateTextProjector(Type type, Func<object, CultureInfo, string?>[] accessors)
+        {
+            return (item, values, culture) =>
+            {
+                if (item == null || item.GetType() != type)
+                {
+                    return false;
+                }
+
+#if NET6_0_OR_GREATER
+                ArgumentNullException.ThrowIfNull(values);
+                ArgumentNullException.ThrowIfNull(culture);
+#else
+                if (values == null) throw new ArgumentNullException(nameof(values));
+                if (culture == null) throw new ArgumentNullException(nameof(culture));
+#endif
+
+                if (values.Length != accessors.Length)
+                {
+                    throw new ArgumentException("Value buffer length must match the projector column count.", nameof(values));
+                }
+
+                for (var i = 0; i < accessors.Length; i++)
+                {
+                    values[i] = accessors[i](item, culture);
+                }
+
+                return true;
+            };
+        }
+
         private static Func<object, object?> CreateAccessor(PropertyInfo property)
         {
 #if NET5_0_OR_GREATER
@@ -264,6 +514,79 @@ internal static class ObjectDataHelpers
 #endif
 
             return property.GetValue;
+        }
+
+        private static Func<object, CultureInfo, string?> CreateTextAccessor(PropertyInfo property)
+        {
+            var accessor = CreateAccessor(property);
+            return (item, culture) => FormatProjectedValue(accessor(item), culture);
+        }
+
+#if NET5_0_OR_GREATER
+        private static Expression CreateFormatExpression(Expression value, Expression culture)
+        {
+            if (value.Type == typeof(string))
+            {
+                return value;
+            }
+
+            if (!value.Type.IsValueType)
+            {
+                return Expression.Call(
+                    typeof(ObjectPropertyPlan).GetMethod(nameof(FormatProjectedValue), BindingFlags.NonPublic | BindingFlags.Static)!,
+                    Expression.Convert(value, typeof(object)),
+                    culture);
+            }
+
+            var nullableType = Nullable.GetUnderlyingType(value.Type);
+            if (nullableType != null)
+            {
+                var hasValue = Expression.Property(value, nameof(Nullable<int>.HasValue));
+                var nullableValue = Expression.Property(value, nameof(Nullable<int>.Value));
+                return Expression.Condition(
+                    hasValue,
+                    CreateFormatExpression(nullableValue, culture),
+                    Expression.Constant(null, typeof(string)));
+            }
+
+            if (typeof(IFormattable).IsAssignableFrom(value.Type))
+            {
+                var toStringWithProvider = value.Type.GetMethod(
+                    nameof(ToString),
+                    new[] { typeof(string), typeof(IFormatProvider) });
+                if (toStringWithProvider != null)
+                {
+                    return Expression.Call(
+                        value,
+                        toStringWithProvider,
+                        Expression.Constant(null, typeof(string)),
+                        culture);
+                }
+
+                return Expression.Call(
+                    Expression.Convert(value, typeof(IFormattable)),
+                    typeof(IFormattable).GetMethod(nameof(IFormattable.ToString), new[] { typeof(string), typeof(IFormatProvider) })!,
+                    Expression.Constant(null, typeof(string)),
+                    culture);
+            }
+
+            return Expression.Call(value, value.Type.GetMethod(nameof(ToString), Type.EmptyTypes)!);
+        }
+#endif
+
+        private static string? FormatProjectedValue(object? value, CultureInfo culture)
+        {
+            if (value is null)
+            {
+                return null;
+            }
+
+            if (value is IFormattable formattable)
+            {
+                return formattable.ToString(null, culture);
+            }
+
+            return value.ToString();
         }
     }
 }


### PR DESCRIPTION
## Summary
- expand OfficeIMO.CSV import parity with duplicate-header handling, null tokens, static metadata columns, custom date/time formats, strict quote parsing, and schema inference
- extend export parity across document saves, direct object writing, and text-row writing with null tokens, date/time formatting, UTC conversion, append, and no-clobber checks
- align row-span APIs with normal load/read behavior for compressed files, pre-header comments, static columns, mapped custom date formats, and lenient multiline quote handling
- document the CSV feature surface, benchmark visibility, and the current single-character delimiter boundary so comparisons stay honest
- add focused tests for real-world header handling, import/export options, streaming and row-span parity, strict quote behavior, schema inference, and net472 coverage

## Validation
- dotnet test .\OfficeIMO.CSV.Tests\OfficeIMO.CSV.Tests.csproj -c Release -f net8.0 -v:minimal
- dotnet test .\OfficeIMO.CSV.Tests\OfficeIMO.CSV.Tests.csproj -c Release -f net10.0 -v:minimal
- dotnet test .\OfficeIMO.CSV.Tests\OfficeIMO.CSV.Tests.csproj -c Release -f net472 -v:minimal
- dotnet run --project .\OfficeIMO.CSV.Benchmarks\OfficeIMO.CSV.Benchmarks.csproj -c Release -f net8.0 -- --list flat
- git diff --check

## Notes
- This keeps third-party CSV packages benchmark-only; OfficeIMO.CSV does not take runtime dependencies on Dataplat, Sep, Sylvan, or CsvHelper.
- Multi-character delimiters remain a documented boundary until parser, writer, delimiter detection, field spans, and benchmark lanes can support them consistently.
- The Codex review feedback from the previous head was addressed in `b5317d4e2`; unsupported compression truncation was already covered by current source and tests.
