### PR TITLE
Bump OfficeIMO CSV package version

### DIFF
--- a/OfficeIMO.CSV/OfficeIMO.CSV.csproj
+++ b/OfficeIMO.CSV/OfficeIMO.CSV.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>OfficeIMO.CSV</AssemblyName>
     <AssemblyTitle>OfficeIMO.CSV</AssemblyTitle>
 
-    <VersionPrefix>0.1.53</VersionPrefix>
+    <VersionPrefix>0.1.54</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0;net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Company>Evotec</Company>


### PR DESCRIPTION
## Summary
- bump OfficeIMO.CSV from 0.1.53 to 0.1.54 after the CSV parity merge

## Notes
- NuGet already has OfficeIMO.CSV 0.1.53, so the merged CSV parity API needs a new package version before PSWriteOffice can consume it from CI.

## Validation
- dotnet build .\OfficeIMO.CSV\OfficeIMO.CSV.csproj -c Release -f net8.0
- git diff --check