### PR TITLE
Preserve rich Reader results and enforce stream limits

### DIFF
--- a/Docs/officeimo.document-intelligence-roadmap.md
+++ b/Docs/officeimo.document-intelligence-roadmap.md
@@ -157,6 +157,7 @@ This branch starts the shared model and adapter path:
 - Asset-only facades now exist for the core Reader pipeline, returning normalized asset manifests without requiring callers to inspect the full read-result envelope.
 - `OfficeIMO.Reader.Pdf` maps logical PDF readback into the shared envelope and JSON output.
 - `OfficeIMO.Reader.Visio` is an optional adapter over `OfficeIMO.Visio`, with page chunks, Shape Data tables, blocks, links, and optional SVG/PNG preview asset metadata.
+- Reader handlers can register native path and stream `OfficeDocumentReadResult` delegates. The generic `DocumentReader.ReadDocument(...)` entry point preserves PDF and Visio rich results, while legacy chunk reads project the same result's chunks when a handler is rich-result-only.
 - Document-level metadata entries now carry stable catalog, outline, destination, open-action, viewer-preference, and form-summary facts without making the shared Reader model depend on PDF-specific types.
 - PDF source preflight capability flags now flow into metadata, and read/rewrite blockers flow into shared diagnostics as stable `pdf-read-blocker` and `pdf-rewrite-blocker` entries for file and stream readback.
 - OCR readiness is represented as `OcrCandidates` plus `ocr-needed` diagnostics for image-only PDF pages and embedded Office image assets, without adding an OCR engine or service dependency to the core.

--- a/OfficeIMO.Reader.Pdf/DocumentReaderPdfRegistrationExtensions.cs
+++ b/OfficeIMO.Reader.Pdf/DocumentReaderPdfRegistrationExtensions.cs
@@ -32,6 +32,17 @@ public static class DocumentReaderPdfRegistrationExtensions {
                 sourceName: sourceName,
                 readerOptions: readerOptions,
                 pdfOptions: ReaderPdfOptionsCloner.CloneNullable(registeredOptions),
+                cancellationToken: ct),
+            ReadDocumentPath = (path, readerOptions, ct) => DocumentReaderPdfExtensions.ReadPdfDocument(
+                pdfPath: path,
+                readerOptions: readerOptions,
+                pdfOptions: ReaderPdfOptionsCloner.CloneNullable(registeredOptions),
+                cancellationToken: ct),
+            ReadDocumentStream = (stream, sourceName, readerOptions, ct) => DocumentReaderPdfExtensions.ReadPdfDocument(
+                pdfStream: stream,
+                sourceName: sourceName,
+                readerOptions: readerOptions,
+                pdfOptions: ReaderPdfOptionsCloner.CloneNullable(registeredOptions),
                 cancellationToken: ct)
         }, replaceExisting);
     }

--- a/OfficeIMO.Reader.Tests/Reader.Pdf.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Pdf.Modular.cs
@@ -2155,6 +2155,18 @@ public sealed class ReaderPdfModularTests {
                 c.Kind == ReaderInputKind.Pdf &&
                 string.Equals(c.Location.Path, "registry.pdf", StringComparison.OrdinalIgnoreCase) &&
                 (c.Markdown ?? c.Text).Contains("Reader PDF page one", StringComparison.Ordinal));
+
+            stream.Position = 0;
+            OfficeDocumentReadResult result = DocumentReader.ReadDocument(stream, "registry.pdf");
+            Assert.Contains("officeimo.pdf.logical-document", result.CapabilitiesUsed);
+            Assert.Equal(2, result.Pages.Count);
+            Assert.NotEmpty(result.Blocks);
+
+            ReaderHandlerCapability capability = Assert.Single(
+                DocumentReader.GetCapabilities(includeBuiltIn: false, includeCustom: true),
+                item => item.Id == DocumentReaderPdfRegistrationExtensions.HandlerId);
+            Assert.True(capability.SupportsDocumentPath);
+            Assert.True(capability.SupportsDocumentStream);
         } finally {
             DocumentReaderPdfRegistrationExtensions.UnregisterPdfHandler();
         }

--- a/OfficeIMO.Reader.Tests/Reader.Registry.RichDocuments.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Registry.RichDocuments.cs
@@ -60,4 +60,35 @@ public sealed partial class ReaderRegistryTests {
             if (File.Exists(file)) File.Delete(file);
         }
     }
+
+    [Fact]
+    public void DocumentReader_RichStreamHandler_EnforcesNonSeekableInputLimitBeforeDispatch() {
+        const string handlerId = "officeimo.tests.custom.rich.limit";
+        const string extension = ".richlimitix";
+        bool handlerInvoked = false;
+
+        try {
+            DocumentReader.UnregisterHandler(handlerId);
+            DocumentReader.RegisterHandler(new ReaderHandlerRegistration {
+                Id = handlerId,
+                Kind = ReaderInputKind.Text,
+                Extensions = new[] { extension },
+                ReadDocumentStream = (stream, sourceName, options, cancellationToken) => {
+                    handlerInvoked = true;
+                    return new OfficeDocumentReadResult { Kind = ReaderInputKind.Text };
+                }
+            });
+            using var stream = new NonSeekableReadStream(new byte[128]);
+
+            IOException exception = Assert.Throws<IOException>(() => DocumentReader.ReadDocument(
+                stream,
+                "sample" + extension,
+                new ReaderOptions { MaxInputBytes = 16 }));
+
+            Assert.Contains("Input exceeds MaxInputBytes", exception.Message, StringComparison.Ordinal);
+            Assert.False(handlerInvoked);
+        } finally {
+            DocumentReader.UnregisterHandler(handlerId);
+        }
+    }
 }

--- a/OfficeIMO.Reader.Tests/Reader.Registry.RichDocuments.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Registry.RichDocuments.cs
@@ -1,0 +1,63 @@
+using OfficeIMO.Reader;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed partial class ReaderRegistryTests {
+    [Fact]
+    public void DocumentReader_RegisterHandler_RichDocumentOnly_ProjectsChunksAndPreservesEnvelope() {
+        const string handlerId = "officeimo.tests.custom.rich";
+        const string extension = ".richix";
+        string file = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + extension);
+
+        try {
+            DocumentReader.UnregisterHandler(handlerId);
+            DocumentReader.RegisterHandler(new ReaderHandlerRegistration {
+                Id = handlerId,
+                DisplayName = "Rich document test handler",
+                Kind = ReaderInputKind.Text,
+                Extensions = new[] { extension },
+                ReadDocumentPath = (path, options, ct) => new OfficeDocumentReadResult {
+                    Kind = ReaderInputKind.Text,
+                    Source = new OfficeDocumentSource { Path = path },
+                    CapabilitiesUsed = new[] { handlerId, "officeimo.tests.rich-envelope" },
+                    Chunks = new[] {
+                        new ReaderChunk {
+                            Id = "rich-0001",
+                            Kind = ReaderInputKind.Text,
+                            Location = new ReaderLocation { Path = path, BlockIndex = 0 },
+                            Text = "rich-document-output"
+                        }
+                    },
+                    Links = new[] {
+                        new OfficeDocumentLink {
+                            Id = "rich-link-0001",
+                            Kind = "external",
+                            Uri = "https://example.test/rich",
+                            Location = new ReaderLocation { Path = path }
+                        }
+                    }
+                }
+            });
+            File.WriteAllText(file, "input");
+
+            ReaderChunk chunk = Assert.Single(DocumentReader.Read(file));
+            Assert.Equal("rich-document-output", chunk.Text);
+
+            OfficeDocumentReadResult result = DocumentReader.ReadDocument(file);
+            Assert.Contains("officeimo.tests.rich-envelope", result.CapabilitiesUsed);
+            Assert.Equal("https://example.test/rich", Assert.Single(result.Links).Uri);
+
+            ReaderHandlerCapability capability = Assert.Single(
+                DocumentReader.GetCapabilities(includeBuiltIn: false, includeCustom: true),
+                item => item.Id == handlerId);
+            Assert.True(capability.SupportsPath);
+            Assert.False(capability.SupportsStream);
+            Assert.True(capability.SupportsDocumentPath);
+            Assert.False(capability.SupportsDocumentStream);
+        } finally {
+            DocumentReader.UnregisterHandler(handlerId);
+            if (File.Exists(file)) File.Delete(file);
+        }
+    }
+}

--- a/OfficeIMO.Reader.Tests/Reader.Registry.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Registry.cs
@@ -19,7 +19,7 @@ namespace OfficeIMO.Tests;
 public sealed class ReaderRegistryNonParallelCollection;
 
 [Collection("ReaderRegistryNonParallel")]
-public sealed class ReaderRegistryTests {
+public sealed partial class ReaderRegistryTests {
     [Fact]
     public void DocumentReader_GetCapabilities_IncludesBuiltInHandlers() {
         try {
@@ -77,6 +77,8 @@ public sealed class ReaderRegistryTests {
             (c.Text?.Contains("officeimo.reader.capability", StringComparison.Ordinal) ?? false));
         Assert.Contains(chunks, c =>
             (c.Text?.Contains("$.handlers[0].id", StringComparison.Ordinal) ?? false));
+        Assert.Contains("\"supportsDocumentPath\":", jsonA, StringComparison.Ordinal);
+        Assert.Contains("\"supportsDocumentStream\":", jsonA, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/OfficeIMO.Reader.Tests/Reader.Visio.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Visio.Modular.cs
@@ -172,7 +172,8 @@ public sealed class ReaderVisioModularTests {
     [Fact]
     public void DocumentReaderVisio_Registration_DispatchesVisioStream() {
         try {
-            DocumentReaderVisioRegistrationExtensions.RegisterVisioHandler();
+            DocumentReaderVisioRegistrationExtensions.RegisterVisioHandler(
+                new ReaderVisioOptions { IncludeSvgPreviewAssets = true });
             using MemoryStream stream = BuildSampleVisio();
 
             List<ReaderChunk> chunks = DocumentReader.Read(stream, "registered.vsdx").ToList();
@@ -180,6 +181,18 @@ public sealed class ReaderVisioModularTests {
             ReaderChunk chunk = Assert.Single(chunks);
             Assert.Equal(ReaderInputKind.Visio, chunk.Kind);
             Assert.Contains("Gateway", chunk.Markdown, StringComparison.Ordinal);
+
+            stream.Position = 0;
+            OfficeDocumentReadResult result = DocumentReader.ReadDocument(stream, "registered.vsdx");
+            Assert.Contains("officeimo.visio.inspection-snapshot", result.CapabilitiesUsed);
+            Assert.NotEmpty(result.Links);
+            Assert.Equal("preview-svg", Assert.Single(result.Assets).Kind);
+
+            ReaderHandlerCapability capability = Assert.Single(
+                DocumentReader.GetCapabilities(includeBuiltIn: false, includeCustom: true),
+                item => item.Id == DocumentReaderVisioRegistrationExtensions.HandlerId);
+            Assert.True(capability.SupportsDocumentPath);
+            Assert.True(capability.SupportsDocumentStream);
         } finally {
             DocumentReaderVisioRegistrationExtensions.UnregisterVisioHandler();
         }

--- a/OfficeIMO.Reader.Visio/DocumentReaderVisioRegistrationExtensions.cs
+++ b/OfficeIMO.Reader.Visio/DocumentReaderVisioRegistrationExtensions.cs
@@ -39,6 +39,17 @@ public static class DocumentReaderVisioRegistrationExtensions {
                 sourceName: sourceName,
                 readerOptions: readerOptions,
                 visioOptions: ReaderVisioOptionsCloner.CloneNullable(registeredOptions),
+                cancellationToken: ct),
+            ReadDocumentPath = (path, readerOptions, ct) => DocumentReaderVisioExtensions.ReadVisioDocument(
+                visioPath: path,
+                readerOptions: readerOptions,
+                visioOptions: ReaderVisioOptionsCloner.CloneNullable(registeredOptions),
+                cancellationToken: ct),
+            ReadDocumentStream = (stream, sourceName, readerOptions, ct) => DocumentReaderVisioExtensions.ReadVisioDocument(
+                visioStream: stream,
+                sourceName: sourceName,
+                readerOptions: readerOptions,
+                visioOptions: ReaderVisioOptionsCloner.CloneNullable(registeredOptions),
                 cancellationToken: ct)
         };
 

--- a/OfficeIMO.Reader/DocumentReader.Document.cs
+++ b/OfficeIMO.Reader/DocumentReader.Document.cs
@@ -60,9 +60,20 @@ public static partial class DocumentReader {
         }
 
         if (hasCustomStreamHandler && customStreamHandler.ReadDocumentStream != null) {
-            return ValidateDocumentResult(
-                customStreamHandler.ReadDocumentStream(stream, logicalSourceName, opt, cancellationToken),
-                customStreamHandler.Id);
+            Stream handlerStream = ReaderInputLimits.EnsureSeekableReadStream(
+                stream,
+                opt.MaxInputBytes,
+                cancellationToken,
+                out bool ownsHandlerStream);
+            try {
+                return ValidateDocumentResult(
+                    customStreamHandler.ReadDocumentStream(handlerStream, logicalSourceName, opt, cancellationToken),
+                    customStreamHandler.Id);
+            } finally {
+                if (ownsHandlerStream) {
+                    handlerStream.Dispose();
+                }
+            }
         }
 
         using MemoryStream snapshot = CopyToMemory(stream, cancellationToken, opt.MaxInputBytes);

--- a/OfficeIMO.Reader/DocumentReader.Document.cs
+++ b/OfficeIMO.Reader/DocumentReader.Document.cs
@@ -23,7 +23,15 @@ public static partial class DocumentReader {
 
         ReaderOptions opt = NormalizeOptions(options);
         ReaderInputKind kind = DetectKind(path);
-        bool customPathReaderOwnsExtension = TryResolveCustomHandlerByPath(path, out CustomReaderHandler customPathHandler) && customPathHandler.ReadPath != null;
+        bool hasCustomPathHandler = TryResolveCustomHandlerByPath(path, out CustomReaderHandler customPathHandler);
+        if (hasCustomPathHandler && customPathHandler.ReadDocumentPath != null) {
+            EnforceFileSize(path, opt.MaxInputBytes);
+            return ValidateDocumentResult(
+                customPathHandler.ReadDocumentPath(path, opt, cancellationToken),
+                customPathHandler.Id);
+        }
+
+        bool customPathReaderOwnsExtension = hasCustomPathHandler && customPathHandler.ReadPath != null;
         ReaderChunk[] chunks = Read(path, opt, cancellationToken).ToArray();
         IReadOnlyList<OfficeDocumentAsset> assets = customPathReaderOwnsExtension
             ? Array.Empty<OfficeDocumentAsset>()
@@ -46,19 +54,38 @@ public static partial class DocumentReader {
         ReaderOptions opt = NormalizeOptions(options);
         string logicalSourceName = NormalizeLogicalSourceName(sourceName, "memory");
         ReaderInputKind kind = string.IsNullOrWhiteSpace(logicalSourceName) ? ReaderInputKind.Unknown : DetectKind(logicalSourceName);
-        bool customStreamReaderOwnsExtension = TryResolveCustomHandlerBySourceName(logicalSourceName, out CustomReaderHandler customStreamHandler) && customStreamHandler.ReadStream != null;
+        bool hasCustomStreamHandler = TryResolveCustomHandlerBySourceName(logicalSourceName, out CustomReaderHandler customStreamHandler);
         if (stream.CanSeek) {
             ReaderInputLimits.EnforceSeekableStreamRemainingSize(stream, opt.MaxInputBytes);
+        }
+
+        if (hasCustomStreamHandler && customStreamHandler.ReadDocumentStream != null) {
+            return ValidateDocumentResult(
+                customStreamHandler.ReadDocumentStream(stream, logicalSourceName, opt, cancellationToken),
+                customStreamHandler.Id);
         }
 
         using MemoryStream snapshot = CopyToMemory(stream, cancellationToken, opt.MaxInputBytes);
         ReaderChunk[] chunks = Read(snapshot, logicalSourceName, opt, cancellationToken).ToArray();
         snapshot.Position = 0;
+        bool customStreamReaderOwnsExtension = hasCustomStreamHandler && customStreamHandler.ReadStream != null;
         IReadOnlyList<OfficeDocumentAsset> assets = customStreamReaderOwnsExtension
             ? Array.Empty<OfficeDocumentAsset>()
             : ReadOpenXmlImageAssets(snapshot, logicalSourceName, kind, opt, cancellationToken);
         ReaderInputKind fallbackKind = customStreamReaderOwnsExtension ? customStreamHandler.Kind : kind;
         return BuildChunkDocumentResult(chunks, logicalSourceName, fallbackKind, BuildStreamDocumentSource(snapshot, logicalSourceName, chunks), assets);
+    }
+
+    private static IReadOnlyList<ReaderChunk> GetDocumentResultChunks(OfficeDocumentReadResult? result, string handlerId) {
+        return ValidateDocumentResult(result, handlerId).Chunks ?? Array.Empty<ReaderChunk>();
+    }
+
+    private static OfficeDocumentReadResult ValidateDocumentResult(OfficeDocumentReadResult? result, string handlerId) {
+        if (result == null) {
+            throw new InvalidOperationException($"Reader handler '{handlerId}' returned a null document result.");
+        }
+
+        return result;
     }
 
     /// <summary>

--- a/OfficeIMO.Reader/DocumentReader.Models.cs
+++ b/OfficeIMO.Reader/DocumentReader.Models.cs
@@ -41,7 +41,9 @@ public static partial class DocumentReader {
             ReaderWarningBehavior warningBehavior,
             bool deterministicOutput,
             Func<string, ReaderOptions, CancellationToken, IEnumerable<ReaderChunk>>? readPath,
-            Func<Stream, string?, ReaderOptions, CancellationToken, IEnumerable<ReaderChunk>>? readStream) {
+            Func<Stream, string?, ReaderOptions, CancellationToken, IEnumerable<ReaderChunk>>? readStream,
+            Func<string, ReaderOptions, CancellationToken, OfficeDocumentReadResult>? readDocumentPath,
+            Func<Stream, string?, ReaderOptions, CancellationToken, OfficeDocumentReadResult>? readDocumentStream) {
             Id = id;
             DisplayName = displayName;
             Description = description;
@@ -52,6 +54,8 @@ public static partial class DocumentReader {
             DeterministicOutput = deterministicOutput;
             ReadPath = readPath;
             ReadStream = readStream;
+            ReadDocumentPath = readDocumentPath;
+            ReadDocumentStream = readDocumentStream;
         }
 
         public string Id { get; }
@@ -64,6 +68,8 @@ public static partial class DocumentReader {
         public bool DeterministicOutput { get; }
         public Func<string, ReaderOptions, CancellationToken, IEnumerable<ReaderChunk>>? ReadPath { get; }
         public Func<Stream, string?, ReaderOptions, CancellationToken, IEnumerable<ReaderChunk>>? ReadStream { get; }
+        public Func<string, ReaderOptions, CancellationToken, OfficeDocumentReadResult>? ReadDocumentPath { get; }
+        public Func<Stream, string?, ReaderOptions, CancellationToken, OfficeDocumentReadResult>? ReadDocumentStream { get; }
 
         public ReaderHandlerCapability ToCapability() {
             return new ReaderHandlerCapability {
@@ -73,8 +79,10 @@ public static partial class DocumentReader {
                 Kind = Kind,
                 Extensions = Extensions.ToArray(),
                 IsBuiltIn = false,
-                SupportsPath = ReadPath != null,
-                SupportsStream = ReadStream != null,
+                SupportsPath = ReadPath != null || ReadDocumentPath != null,
+                SupportsStream = ReadStream != null || ReadDocumentStream != null,
+                SupportsDocumentPath = ReadDocumentPath != null,
+                SupportsDocumentStream = ReadDocumentStream != null,
                 SchemaId = ReaderCapabilitySchema.Id,
                 SchemaVersion = ReaderCapabilitySchema.Version,
                 DefaultMaxInputBytes = DefaultMaxInputBytes,

--- a/OfficeIMO.Reader/DocumentReader.Path.cs
+++ b/OfficeIMO.Reader/DocumentReader.Path.cs
@@ -48,8 +48,11 @@ public static partial class DocumentReader {
         SourceInfo source,
         CancellationToken cancellationToken) {
         IEnumerable<ReaderChunk> raw;
-        if (TryResolveCustomHandlerByPath(path, out var customPathHandler) && customPathHandler.ReadPath != null) {
-            raw = customPathHandler.ReadPath(path, opt, cancellationToken);
+        if (TryResolveCustomHandlerByPath(path, out var customPathHandler) &&
+            (customPathHandler.ReadPath != null || customPathHandler.ReadDocumentPath != null)) {
+            raw = customPathHandler.ReadPath != null
+                ? customPathHandler.ReadPath(path, opt, cancellationToken)
+                : GetDocumentResultChunks(customPathHandler.ReadDocumentPath!(path, opt, cancellationToken), customPathHandler.Id);
         } else {
             var kind = DetectKind(path);
             raw = kind switch {

--- a/OfficeIMO.Reader/DocumentReader.Registry.cs
+++ b/OfficeIMO.Reader/DocumentReader.Registry.cs
@@ -57,6 +57,8 @@ public static partial class DocumentReader {
             IsBuiltIn = capability.IsBuiltIn,
             SupportsPath = capability.SupportsPath,
             SupportsStream = capability.SupportsStream,
+            SupportsDocumentPath = capability.SupportsDocumentPath,
+            SupportsDocumentStream = capability.SupportsDocumentStream,
             SchemaId = capability.SchemaId,
             SchemaVersion = capability.SchemaVersion,
             DefaultMaxInputBytes = capability.DefaultMaxInputBytes,

--- a/OfficeIMO.Reader/DocumentReader.Streams.cs
+++ b/OfficeIMO.Reader/DocumentReader.Streams.cs
@@ -49,8 +49,11 @@ public static partial class DocumentReader {
             var source = BuildSourceInfoFromStream(readStream, logicalSourceName, opt.ComputeHashes);
 
             IEnumerable<ReaderChunk> raw;
-            if (TryResolveCustomHandlerBySourceName(logicalSourceName, out var customStreamHandler) && customStreamHandler.ReadStream != null) {
-                raw = customStreamHandler.ReadStream(readStream, logicalSourceName, opt, cancellationToken);
+            if (TryResolveCustomHandlerBySourceName(logicalSourceName, out var customStreamHandler) &&
+                (customStreamHandler.ReadStream != null || customStreamHandler.ReadDocumentStream != null)) {
+                raw = customStreamHandler.ReadStream != null
+                    ? customStreamHandler.ReadStream(readStream, logicalSourceName, opt, cancellationToken)
+                    : GetDocumentResultChunks(customStreamHandler.ReadDocumentStream!(readStream, logicalSourceName, opt, cancellationToken), customStreamHandler.Id);
             } else {
                 var kind = string.IsNullOrWhiteSpace(logicalSourceName) ? ReaderInputKind.Unknown : DetectKind(logicalSourceName!);
                 raw = kind switch {

--- a/OfficeIMO.Reader/DocumentReader.cs
+++ b/OfficeIMO.Reader/DocumentReader.cs
@@ -157,8 +157,13 @@ public static partial class DocumentReader {
         var id = (registration.Id ?? string.Empty).Trim();
         if (id.Length == 0) throw new ArgumentException("Handler Id cannot be empty.", nameof(registration));
 
-        if (registration.ReadPath == null && registration.ReadStream == null) {
-            throw new ArgumentException("Handler must define ReadPath and/or ReadStream.", nameof(registration));
+        if (registration.ReadPath == null &&
+            registration.ReadStream == null &&
+            registration.ReadDocumentPath == null &&
+            registration.ReadDocumentStream == null) {
+            throw new ArgumentException(
+                "Handler must define a chunk reader or rich document reader for paths and/or streams.",
+                nameof(registration));
         }
         if (registration.DefaultMaxInputBytes.HasValue && registration.DefaultMaxInputBytes.Value < 1) {
             throw new ArgumentException("DefaultMaxInputBytes must be greater than 0 when specified.", nameof(registration));
@@ -231,7 +236,9 @@ public static partial class DocumentReader {
                 warningBehavior: registration.WarningBehavior,
                 deterministicOutput: registration.DeterministicOutput,
                 readPath: registration.ReadPath,
-                readStream: registration.ReadStream);
+                readStream: registration.ReadStream,
+                readDocumentPath: registration.ReadDocumentPath,
+                readDocumentStream: registration.ReadDocumentStream);
 
             CustomHandlersById[id] = custom;
             foreach (var ext in custom.Extensions) {

--- a/OfficeIMO.Reader/README.md
+++ b/OfficeIMO.Reader/README.md
@@ -122,11 +122,27 @@ DocumentReader.RegisterHandler(new ReaderHandlerRegistration {
 });
 ```
 
+Handlers that already expose a structured document model can register rich result delegates instead of rebuilding that model as chunks first:
+
+```csharp
+DocumentReader.RegisterHandler(new ReaderHandlerRegistration {
+    Id = "custom-rich-reader",
+    DisplayName = "Custom rich reader",
+    Kind = ReaderInputKind.Text,
+    Extensions = new[] { ".rich" },
+    ReadDocumentPath = (path, options, cancellationToken) => ReadRichDocument(path),
+    ReadDocumentStream = (stream, sourceName, options, cancellationToken) => ReadRichDocument(stream, sourceName)
+});
+```
+
+`DocumentReader.ReadDocument(...)` dispatches directly to these delegates. Existing `DocumentReader.Read(...)` calls remain usable by projecting the returned result's `Chunks` collection. A handler may continue to register `ReadPath` and `ReadStream` when chunk production is its native contract.
+
 ## Host contracts
 
 - `ReaderOptions` controls chunk size, table row limits, footnotes/notes, Excel ranges, Markdown heading chunking, hashes, and input budgets.
 - `ReaderFolderOptions` controls recursion, file limits, byte limits, reparse-point handling, and deterministic folder order.
 - `DocumentReader.GetCapabilities()` and `GetCapabilityManifestJson()` expose a stable host-discovery surface.
+- Capability records distinguish basic path/stream support from native rich-result support through `SupportsDocumentPath` and `SupportsDocumentStream`.
 - Custom handlers can be registered with `DocumentReader.RegisterHandler(...)`.
 
 ## Boundaries

--- a/OfficeIMO.Reader/ReaderCapabilityManifestJson.cs
+++ b/OfficeIMO.Reader/ReaderCapabilityManifestJson.cs
@@ -58,6 +58,8 @@ internal static class ReaderCapabilityManifestJson {
             WriteBoolean("isBuiltIn", handler.IsBuiltIn, trailingComma: true);
             WriteBoolean("supportsPath", handler.SupportsPath, trailingComma: true);
             WriteBoolean("supportsStream", handler.SupportsStream, trailingComma: true);
+            WriteBoolean("supportsDocumentPath", handler.SupportsDocumentPath, trailingComma: true);
+            WriteBoolean("supportsDocumentStream", handler.SupportsDocumentStream, trailingComma: true);
             WriteString("schemaId", handler.SchemaId ?? ReaderCapabilitySchema.Id, trailingComma: true);
             WriteNumber("schemaVersion", handler.SchemaVersion, trailingComma: true);
             WriteNullableNumber("defaultMaxInputBytes", handler.DefaultMaxInputBytes, trailingComma: true);

--- a/OfficeIMO.Reader/ReaderHandlerModels.cs
+++ b/OfficeIMO.Reader/ReaderHandlerModels.cs
@@ -46,6 +46,20 @@ public sealed class ReaderHandlerRegistration {
     public Func<Stream, string?, ReaderOptions, CancellationToken, IEnumerable<ReaderChunk>>? ReadStream { get; set; }
 
     /// <summary>
+    /// Optional path-based rich document reader delegate. When present,
+    /// <see cref="DocumentReader.ReadDocument(string, ReaderOptions?, CancellationToken)"/>
+    /// dispatches directly to this delegate instead of rebuilding a generic result from chunks.
+    /// </summary>
+    public Func<string, ReaderOptions, CancellationToken, OfficeDocumentReadResult>? ReadDocumentPath { get; set; }
+
+    /// <summary>
+    /// Optional stream-based rich document reader delegate. The delegate must not close the caller-owned stream.
+    /// When present, <see cref="DocumentReader.ReadDocument(Stream, string?, ReaderOptions?, CancellationToken)"/>
+    /// dispatches directly to this delegate instead of rebuilding a generic result from chunks.
+    /// </summary>
+    public Func<Stream, string?, ReaderOptions, CancellationToken, OfficeDocumentReadResult>? ReadDocumentStream { get; set; }
+
+    /// <summary>
     /// Optional advertised default max input bytes for this handler.
     /// Null means "no handler-specific default advertised".
     /// </summary>
@@ -107,6 +121,16 @@ public sealed class ReaderHandlerCapability {
     public bool SupportsStream { get; set; }
 
     /// <summary>
+    /// True when the handler supplies a native path-based <see cref="OfficeDocumentReadResult"/> projection.
+    /// </summary>
+    public bool SupportsDocumentPath { get; set; }
+
+    /// <summary>
+    /// True when the handler supplies a native stream-based <see cref="OfficeDocumentReadResult"/> projection.
+    /// </summary>
+    public bool SupportsDocumentStream { get; set; }
+
+    /// <summary>
     /// Capability schema identifier for host integration contracts.
     /// </summary>
     public string SchemaId { get; set; } = ReaderCapabilitySchema.Id;
@@ -145,7 +169,7 @@ public static class ReaderCapabilitySchema {
     /// <summary>
     /// Current schema version.
     /// </summary>
-    public const int Version = 1;
+    public const int Version = 2;
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

- let Reader handlers return native `OfficeDocumentReadResult` values for path and stream inputs
- preserve chunk-only registrations and project chunks for existing `DocumentReader.Read(...)` callers
- route registered PDF and Visio reads through their rich envelopes so pages, links, assets, forms, metadata, and diagnostics survive dispatch
- enforce `MaxInputBytes` before buffering seekable or unknown-length rich streams while preserving caller stream ownership
- advertise native rich-result support in capability manifests

## Compatibility

Existing path and stream chunk registrations continue to work. Capability manifest version 2 adds rich path and stream flags without removing the established facade.

## Validation

Reader contracts pass on .NET 8 and .NET 10, and the affected Reader projects build for `netstandard2.0`.

## Review order

This is the foundation PR for the stacked Reader maturity series.

## Stack links

Slice 1 of 9. Next: [#2047](https://github.com/EvotecIT/OfficeIMO/pull/2047)