### PR TITLE
Add isolated OfficeDocumentReader instances

### DIFF
--- a/Docs/officeimo.document-intelligence-roadmap.md
+++ b/Docs/officeimo.document-intelligence-roadmap.md
@@ -1,6 +1,6 @@
 # OfficeIMO Document Intelligence Roadmap
 
-Date: 2026-06-10
+Date: 2026-07-10
 
 ## Purpose
 
@@ -32,7 +32,9 @@ Keep this roadmap aligned with the current owner documents and proof manifests:
 
 `OfficeIMO.Reader` is already a stable ingestion facade. It reads Word, Excel, PowerPoint, Markdown, PDF, HTML, ZIP, EPUB, CSV, JSON, XML, YAML, and plain text-like formats into `ReaderChunk` instances with stable IDs, location metadata, hashes, table metadata, folder traversal, warning chunks, progress callbacks, detailed source summaries, handler registration, capability manifests, and host bootstrap helpers.
 
-`OfficeIMO.Reader.Pdf` now registers PDF ingestion through the same reader facade. The next step is not another reader switch statement; it is a shared result model that can expose chunks, Markdown, JSON, HTML, assets, diagnostics, source maps, and format-specific logical blocks from the same extraction run.
+`OfficeIMO.Reader.Pdf` registers PDF ingestion through the same reader facade. The shared `OfficeDocumentReadResult` model now carries chunks, assets, diagnostics, source maps, and normalized format-specific content from one extraction run. Further format fidelity belongs in the owning format packages and their narrow Reader adapters, not in another central reader switch statement.
+
+Reader hosts can now use `OfficeDocumentReaderBuilder` to compose modular adapters and custom handlers, then freeze that configuration into an immutable `OfficeDocumentReader`. Each instance owns its routing snapshot, so concurrent services can use different handlers for the same extension without process-global interference. The static registration API remains a compatibility surface for existing applications.
 
 ### Markdown
 
@@ -158,6 +160,7 @@ This branch starts the shared model and adapter path:
 - `OfficeIMO.Reader.Pdf` maps logical PDF readback into the shared envelope and JSON output.
 - `OfficeIMO.Reader.Visio` is an optional adapter over `OfficeIMO.Visio`, with page chunks, Shape Data tables, blocks, links, and optional SVG/PNG preview asset metadata.
 - Reader handlers can register native path and stream `OfficeDocumentReadResult` delegates. The generic `DocumentReader.ReadDocument(...)` entry point preserves PDF and Visio rich results, while legacy chunk reads project the same result's chunks when a handler is rich-result-only.
+- `OfficeDocumentReaderBuilder` and `OfficeDocumentReader` provide instance-scoped handler routing, capability manifests, file/stream/byte reads, and folder ingestion. Every modular Reader adapter exposes a matching `Add...Handler()` builder extension, while the static registry remains backward compatible.
 - Document-level metadata entries now carry stable catalog, outline, destination, open-action, viewer-preference, and form-summary facts without making the shared Reader model depend on PDF-specific types.
 - PDF source preflight capability flags now flow into metadata, and read/rewrite blockers flow into shared diagnostics as stable `pdf-read-blocker` and `pdf-rewrite-blocker` entries for file and stream readback.
 - OCR readiness is represented as `OcrCandidates` plus `ocr-needed` diagnostics for image-only PDF pages and embedded Office image assets, without adding an OCR engine or service dependency to the core.

--- a/OfficeIMO.Reader.Csv/DocumentReaderCsvRegistrationExtensions.cs
+++ b/OfficeIMO.Reader.Csv/DocumentReaderCsvRegistrationExtensions.cs
@@ -30,9 +30,43 @@ public static class DocumentReaderCsvRegistrationExtensions {
     /// </param>
     /// <param name="preserveExistingCustomExtensions">When true, leaves extensions already owned by other custom handlers untouched.</param>
     public static void RegisterCsvHandler(CsvReadOptions? csvOptions, bool replaceExisting, bool preserveExistingCustomExtensions) {
-        var registered = Clone(csvOptions);
+        ReaderHandlerRegistration registration = CreateRegistration(csvOptions);
 
-        var registration = new ReaderHandlerRegistration {
+        if (preserveExistingCustomExtensions) {
+            DocumentReader.RegisterHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
+        } else {
+            DocumentReader.RegisterHandler(registration, replaceExisting);
+        }
+    }
+
+    /// <summary>
+    /// Adds CSV/TSV ingestion to an isolated reader builder.
+    /// </summary>
+    public static OfficeDocumentReaderBuilder AddCsvHandler(
+        this OfficeDocumentReaderBuilder builder,
+        CsvReadOptions? csvOptions = null,
+        bool replaceExisting = true,
+        bool preserveExistingCustomExtensions = false) {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+        ReaderHandlerRegistration registration = CreateRegistration(csvOptions);
+        if (preserveExistingCustomExtensions) {
+            builder.AddHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
+        } else {
+            builder.AddHandler(registration, replaceExisting);
+        }
+        return builder;
+    }
+
+    /// <summary>
+    /// Unregisters CSV/TSV ingestion handler from <see cref="DocumentReader"/>.
+    /// </summary>
+    public static bool UnregisterCsvHandler() {
+        return DocumentReader.UnregisterHandler(HandlerId);
+    }
+
+    private static ReaderHandlerRegistration CreateRegistration(CsvReadOptions? csvOptions) {
+        CsvReadOptions? registered = Clone(csvOptions);
+        return new ReaderHandlerRegistration {
             Id = HandlerId,
             DisplayName = "CSV Reader Adapter",
             Description = "Modular CSV/TSV parser with table-aware chunk output.",
@@ -50,19 +84,6 @@ public static class DocumentReaderCsvRegistrationExtensions {
                 csvOptions: Clone(registered),
                 cancellationToken: ct)
         };
-
-        if (preserveExistingCustomExtensions) {
-            DocumentReader.RegisterHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
-        } else {
-            DocumentReader.RegisterHandler(registration, replaceExisting);
-        }
-    }
-
-    /// <summary>
-    /// Unregisters CSV/TSV ingestion handler from <see cref="DocumentReader"/>.
-    /// </summary>
-    public static bool UnregisterCsvHandler() {
-        return DocumentReader.UnregisterHandler(HandlerId);
     }
 
     private static CsvReadOptions? Clone(CsvReadOptions? options) {

--- a/OfficeIMO.Reader.Epub/DocumentReaderEpubRegistrationExtensions.cs
+++ b/OfficeIMO.Reader.Epub/DocumentReaderEpubRegistrationExtensions.cs
@@ -23,9 +23,43 @@ public static class DocumentReaderEpubRegistrationExtensions {
     /// Registers EPUB ingestion into <see cref="DocumentReader"/> for the <c>.epub</c> extension.
     /// </summary>
     public static void RegisterEpubHandler(EpubReadOptions? epubOptions, bool replaceExisting, bool preserveExistingCustomExtensions) {
-        var registeredOptions = Clone(epubOptions);
+        ReaderHandlerRegistration registration = CreateRegistration(epubOptions);
 
-        var registration = new ReaderHandlerRegistration {
+        if (preserveExistingCustomExtensions) {
+            DocumentReader.RegisterHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
+        } else {
+            DocumentReader.RegisterHandler(registration, replaceExisting);
+        }
+    }
+
+    /// <summary>
+    /// Adds EPUB ingestion to an isolated reader builder.
+    /// </summary>
+    public static OfficeDocumentReaderBuilder AddEpubHandler(
+        this OfficeDocumentReaderBuilder builder,
+        EpubReadOptions? epubOptions = null,
+        bool replaceExisting = false,
+        bool preserveExistingCustomExtensions = false) {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+        ReaderHandlerRegistration registration = CreateRegistration(epubOptions);
+        if (preserveExistingCustomExtensions) {
+            builder.AddHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
+        } else {
+            builder.AddHandler(registration, replaceExisting);
+        }
+        return builder;
+    }
+
+    /// <summary>
+    /// Unregisters EPUB ingestion handler from <see cref="DocumentReader"/>.
+    /// </summary>
+    public static bool UnregisterEpubHandler() {
+        return DocumentReader.UnregisterHandler(HandlerId);
+    }
+
+    private static ReaderHandlerRegistration CreateRegistration(EpubReadOptions? epubOptions) {
+        EpubReadOptions? registeredOptions = Clone(epubOptions);
+        return new ReaderHandlerRegistration {
             Id = HandlerId,
             DisplayName = "EPUB Reader Adapter",
             Description = "Modular EPUB adapter that emits chapter-oriented Reader chunks.",
@@ -43,19 +77,6 @@ public static class DocumentReaderEpubRegistrationExtensions {
                 epubOptions: Clone(registeredOptions),
                 cancellationToken: ct)
         };
-
-        if (preserveExistingCustomExtensions) {
-            DocumentReader.RegisterHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
-        } else {
-            DocumentReader.RegisterHandler(registration, replaceExisting);
-        }
-    }
-
-    /// <summary>
-    /// Unregisters EPUB ingestion handler from <see cref="DocumentReader"/>.
-    /// </summary>
-    public static bool UnregisterEpubHandler() {
-        return DocumentReader.UnregisterHandler(HandlerId);
     }
 
     private static EpubReadOptions? Clone(EpubReadOptions? options) {

--- a/OfficeIMO.Reader.Html/DocumentReaderHtmlRegistrationExtensions.cs
+++ b/OfficeIMO.Reader.Html/DocumentReaderHtmlRegistrationExtensions.cs
@@ -21,9 +21,43 @@ public static class DocumentReaderHtmlRegistrationExtensions {
     /// Registers HTML ingestion into <see cref="DocumentReader"/> for <c>.html</c>, <c>.htm</c>, and <c>.xhtml</c>.
     /// </summary>
     public static void RegisterHtmlHandler(ReaderHtmlOptions? htmlOptions, bool replaceExisting, bool preserveExistingCustomExtensions) {
-        var registeredOptions = ReaderHtmlOptionsCloner.CloneNullable(htmlOptions);
+        ReaderHandlerRegistration registration = CreateRegistration(htmlOptions);
 
-        var registration = new ReaderHandlerRegistration {
+        if (preserveExistingCustomExtensions) {
+            DocumentReader.RegisterHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
+        } else {
+            DocumentReader.RegisterHandler(registration, replaceExisting);
+        }
+    }
+
+    /// <summary>
+    /// Adds HTML ingestion to an isolated reader builder.
+    /// </summary>
+    public static OfficeDocumentReaderBuilder AddHtmlHandler(
+        this OfficeDocumentReaderBuilder builder,
+        ReaderHtmlOptions? htmlOptions = null,
+        bool replaceExisting = false,
+        bool preserveExistingCustomExtensions = false) {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+        ReaderHandlerRegistration registration = CreateRegistration(htmlOptions);
+        if (preserveExistingCustomExtensions) {
+            builder.AddHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
+        } else {
+            builder.AddHandler(registration, replaceExisting);
+        }
+        return builder;
+    }
+
+    /// <summary>
+    /// Unregisters HTML ingestion handler from <see cref="DocumentReader"/>.
+    /// </summary>
+    public static bool UnregisterHtmlHandler() {
+        return DocumentReader.UnregisterHandler(HandlerId);
+    }
+
+    private static ReaderHandlerRegistration CreateRegistration(ReaderHtmlOptions? htmlOptions) {
+        ReaderHtmlOptions? registeredOptions = ReaderHtmlOptionsCloner.CloneNullable(htmlOptions);
+        return new ReaderHandlerRegistration {
             Id = HandlerId,
             DisplayName = "HTML Reader Adapter",
             Description = "Modular HTML adapter using OfficeIMO.Markdown.Html.",
@@ -41,18 +75,5 @@ public static class DocumentReaderHtmlRegistrationExtensions {
                 htmlOptions: ReaderHtmlOptionsCloner.CloneNullable(registeredOptions),
                 cancellationToken: ct)
         };
-
-        if (preserveExistingCustomExtensions) {
-            DocumentReader.RegisterHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
-        } else {
-            DocumentReader.RegisterHandler(registration, replaceExisting);
-        }
-    }
-
-    /// <summary>
-    /// Unregisters HTML ingestion handler from <see cref="DocumentReader"/>.
-    /// </summary>
-    public static bool UnregisterHtmlHandler() {
-        return DocumentReader.UnregisterHandler(HandlerId);
     }
 }

--- a/OfficeIMO.Reader.Json/DocumentReaderJsonRegistrationExtensions.cs
+++ b/OfficeIMO.Reader.Json/DocumentReaderJsonRegistrationExtensions.cs
@@ -30,9 +30,43 @@ public static class DocumentReaderJsonRegistrationExtensions {
     /// </param>
     /// <param name="preserveExistingCustomExtensions">When true, leaves extensions already owned by other custom handlers untouched.</param>
     public static void RegisterJsonHandler(JsonReadOptions? jsonOptions, bool replaceExisting, bool preserveExistingCustomExtensions) {
-        var registered = Clone(jsonOptions);
+        ReaderHandlerRegistration registration = CreateRegistration(jsonOptions);
 
-        var registration = new ReaderHandlerRegistration {
+        if (preserveExistingCustomExtensions) {
+            DocumentReader.RegisterHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
+        } else {
+            DocumentReader.RegisterHandler(registration, replaceExisting);
+        }
+    }
+
+    /// <summary>
+    /// Adds JSON ingestion to an isolated reader builder.
+    /// </summary>
+    public static OfficeDocumentReaderBuilder AddJsonHandler(
+        this OfficeDocumentReaderBuilder builder,
+        JsonReadOptions? jsonOptions = null,
+        bool replaceExisting = true,
+        bool preserveExistingCustomExtensions = false) {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+        ReaderHandlerRegistration registration = CreateRegistration(jsonOptions);
+        if (preserveExistingCustomExtensions) {
+            builder.AddHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
+        } else {
+            builder.AddHandler(registration, replaceExisting);
+        }
+        return builder;
+    }
+
+    /// <summary>
+    /// Unregisters JSON ingestion handler from <see cref="DocumentReader"/>.
+    /// </summary>
+    public static bool UnregisterJsonHandler() {
+        return DocumentReader.UnregisterHandler(HandlerId);
+    }
+
+    private static ReaderHandlerRegistration CreateRegistration(JsonReadOptions? jsonOptions) {
+        JsonReadOptions? registered = Clone(jsonOptions);
+        return new ReaderHandlerRegistration {
             Id = HandlerId,
             DisplayName = "JSON Reader Adapter",
             Description = "Modular JSON AST parser with path/type/value chunk output.",
@@ -50,19 +84,6 @@ public static class DocumentReaderJsonRegistrationExtensions {
                 jsonOptions: Clone(registered),
                 cancellationToken: ct)
         };
-
-        if (preserveExistingCustomExtensions) {
-            DocumentReader.RegisterHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
-        } else {
-            DocumentReader.RegisterHandler(registration, replaceExisting);
-        }
-    }
-
-    /// <summary>
-    /// Unregisters JSON ingestion handler from <see cref="DocumentReader"/>.
-    /// </summary>
-    public static bool UnregisterJsonHandler() {
-        return DocumentReader.UnregisterHandler(HandlerId);
     }
 
     private static JsonReadOptions? Clone(JsonReadOptions? options) {

--- a/OfficeIMO.Reader.Pdf/DocumentReaderPdfRegistrationExtensions.cs
+++ b/OfficeIMO.Reader.Pdf/DocumentReaderPdfRegistrationExtensions.cs
@@ -14,9 +14,30 @@ public static class DocumentReaderPdfRegistrationExtensions {
     /// </summary>
     [ReaderHandlerRegistrar(HandlerId)]
     public static void RegisterPdfHandler(ReaderPdfOptions? pdfOptions = null, bool replaceExisting = true) {
-        var registeredOptions = ReaderPdfOptionsCloner.CloneNullable(pdfOptions);
+        DocumentReader.RegisterHandler(CreateRegistration(pdfOptions), replaceExisting);
+    }
 
-        DocumentReader.RegisterHandler(new ReaderHandlerRegistration {
+    /// <summary>
+    /// Adds PDF ingestion to an isolated reader builder.
+    /// </summary>
+    public static OfficeDocumentReaderBuilder AddPdfHandler(
+        this OfficeDocumentReaderBuilder builder,
+        ReaderPdfOptions? pdfOptions = null,
+        bool replaceExisting = true) {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+        return builder.AddHandler(CreateRegistration(pdfOptions), replaceExisting);
+    }
+
+    /// <summary>
+    /// Unregisters PDF ingestion handler from <see cref="DocumentReader"/>.
+    /// </summary>
+    public static bool UnregisterPdfHandler() {
+        return DocumentReader.UnregisterHandler(HandlerId);
+    }
+
+    private static ReaderHandlerRegistration CreateRegistration(ReaderPdfOptions? pdfOptions) {
+        ReaderPdfOptions? registeredOptions = ReaderPdfOptionsCloner.CloneNullable(pdfOptions);
+        return new ReaderHandlerRegistration {
             Id = HandlerId,
             DisplayName = "PDF Reader Adapter",
             Description = "Modular PDF adapter using OfficeIMO.Pdf logical read model.",
@@ -44,13 +65,6 @@ public static class DocumentReaderPdfRegistrationExtensions {
                 readerOptions: readerOptions,
                 pdfOptions: ReaderPdfOptionsCloner.CloneNullable(registeredOptions),
                 cancellationToken: ct)
-        }, replaceExisting);
-    }
-
-    /// <summary>
-    /// Unregisters PDF ingestion handler from <see cref="DocumentReader"/>.
-    /// </summary>
-    public static bool UnregisterPdfHandler() {
-        return DocumentReader.UnregisterHandler(HandlerId);
+        };
     }
 }

--- a/OfficeIMO.Reader.Rtf/DocumentReaderRtfRegistrationExtensions.cs
+++ b/OfficeIMO.Reader.Rtf/DocumentReaderRtfRegistrationExtensions.cs
@@ -14,9 +14,30 @@ public static class DocumentReaderRtfRegistrationExtensions {
     /// </summary>
     [ReaderHandlerRegistrar(HandlerId)]
     public static void RegisterRtfHandler(ReaderRtfOptions? rtfOptions = null, bool replaceExisting = true) {
-        var registeredOptions = ReaderRtfOptionsCloner.CloneNullable(rtfOptions);
+        DocumentReader.RegisterHandler(CreateRegistration(rtfOptions), replaceExisting);
+    }
 
-        DocumentReader.RegisterHandler(new ReaderHandlerRegistration {
+    /// <summary>
+    /// Adds RTF ingestion to an isolated reader builder.
+    /// </summary>
+    public static OfficeDocumentReaderBuilder AddRtfHandler(
+        this OfficeDocumentReaderBuilder builder,
+        ReaderRtfOptions? rtfOptions = null,
+        bool replaceExisting = true) {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+        return builder.AddHandler(CreateRegistration(rtfOptions), replaceExisting);
+    }
+
+    /// <summary>
+    /// Unregisters RTF ingestion handler from <see cref="DocumentReader"/>.
+    /// </summary>
+    public static bool UnregisterRtfHandler() {
+        return DocumentReader.UnregisterHandler(HandlerId);
+    }
+
+    private static ReaderHandlerRegistration CreateRegistration(ReaderRtfOptions? rtfOptions) {
+        ReaderRtfOptions? registeredOptions = ReaderRtfOptionsCloner.CloneNullable(rtfOptions);
+        return new ReaderHandlerRegistration {
             Id = HandlerId,
             DisplayName = "RTF Reader Adapter",
             Description = "Modular RTF adapter using OfficeIMO.Rtf semantic read model.",
@@ -33,13 +54,6 @@ public static class DocumentReaderRtfRegistrationExtensions {
                 readerOptions: readerOptions,
                 rtfOptions: ReaderRtfOptionsCloner.CloneNullable(registeredOptions),
                 cancellationToken: ct)
-        }, replaceExisting);
-    }
-
-    /// <summary>
-    /// Unregisters RTF ingestion handler from <see cref="DocumentReader"/>.
-    /// </summary>
-    public static bool UnregisterRtfHandler() {
-        return DocumentReader.UnregisterHandler(HandlerId);
+        };
     }
 }

--- a/OfficeIMO.Reader.Tests/Reader.InstanceAdapters.cs
+++ b/OfficeIMO.Reader.Tests/Reader.InstanceAdapters.cs
@@ -1,0 +1,72 @@
+using OfficeIMO.Reader;
+using OfficeIMO.Reader.Csv;
+using OfficeIMO.Reader.Epub;
+using OfficeIMO.Reader.Html;
+using OfficeIMO.Reader.Json;
+using OfficeIMO.Reader.Pdf;
+using OfficeIMO.Reader.Rtf;
+using OfficeIMO.Reader.Text;
+using OfficeIMO.Reader.Visio;
+using OfficeIMO.Reader.Xml;
+using OfficeIMO.Reader.Yaml;
+using OfficeIMO.Reader.Zip;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class ReaderInstanceAdapterTests {
+    [Fact]
+    public void ModularAdapters_CanConfigureIsolatedReaders() {
+        AssertHandler(
+            new OfficeDocumentReaderBuilder().AddCsvHandler().Build(),
+            DocumentReaderCsvRegistrationExtensions.HandlerId);
+        AssertHandler(
+            new OfficeDocumentReaderBuilder().AddEpubHandler().Build(),
+            DocumentReaderEpubRegistrationExtensions.HandlerId);
+        AssertHandler(
+            new OfficeDocumentReaderBuilder().AddHtmlHandler().Build(),
+            DocumentReaderHtmlRegistrationExtensions.HandlerId);
+        AssertHandler(
+            new OfficeDocumentReaderBuilder().AddJsonHandler().Build(),
+            DocumentReaderJsonRegistrationExtensions.HandlerId);
+        AssertHandler(
+            new OfficeDocumentReaderBuilder().AddPdfHandler().Build(),
+            DocumentReaderPdfRegistrationExtensions.HandlerId);
+        AssertHandler(
+            new OfficeDocumentReaderBuilder().AddRtfHandler().Build(),
+            DocumentReaderRtfRegistrationExtensions.HandlerId);
+        AssertHandler(
+            new OfficeDocumentReaderBuilder().AddStructuredTextHandler().Build(),
+            DocumentReaderTextRegistrationExtensions.HandlerId);
+        AssertHandler(
+            new OfficeDocumentReaderBuilder().AddVisioHandler().Build(),
+            DocumentReaderVisioRegistrationExtensions.HandlerId);
+        AssertHandler(
+            new OfficeDocumentReaderBuilder().AddXmlHandler().Build(),
+            DocumentReaderXmlRegistrationExtensions.HandlerId);
+        AssertHandler(
+            new OfficeDocumentReaderBuilder().AddYamlHandler().Build(),
+            DocumentReaderYamlRegistrationExtensions.HandlerId);
+        AssertHandler(
+            new OfficeDocumentReaderBuilder().AddZipHandler().Build(),
+            DocumentReaderZipRegistrationExtensions.HandlerId);
+    }
+
+    [Fact]
+    public void JsonAdapter_RoutesThroughInstanceWithoutStaticRegistration() {
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+            .AddJsonHandler(new JsonReadOptions { IncludeMarkdown = false })
+            .Build();
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes("{\"name\":\"OfficeIMO\"}"));
+
+        ReaderChunk[] chunks = reader.Read(stream, "sample.json").ToArray();
+
+        Assert.NotEmpty(chunks);
+        Assert.Contains(chunks, chunk => chunk.Text?.Contains("OfficeIMO", StringComparison.Ordinal) == true);
+    }
+
+    private static void AssertHandler(OfficeDocumentReader reader, string expectedHandlerId) {
+        ReaderHandlerCapability capability = Assert.Single(reader.GetCapabilities(includeBuiltIn: false, includeCustom: true));
+        Assert.Equal(expectedHandlerId, capability.Id);
+    }
+}

--- a/OfficeIMO.Reader.Tests/Reader.InstanceScoped.cs
+++ b/OfficeIMO.Reader.Tests/Reader.InstanceScoped.cs
@@ -1,0 +1,204 @@
+using OfficeIMO.Reader;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class ReaderInstanceScopedTests {
+    [Fact]
+    public async Task OfficeDocumentReader_IsolatesHandlersAcrossConcurrentInstances() {
+        const string extension = ".instanceix";
+        string file = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + extension);
+        File.WriteAllText(file, "input");
+
+        try {
+            OfficeDocumentReader first = BuildReader("officeimo.tests.instance.first", extension, "first-output");
+            OfficeDocumentReader second = BuildReader("officeimo.tests.instance.second", extension, "second-output");
+
+            Task<ReaderChunk> firstRead = Task.Run(() => Assert.Single(first.Read(file)));
+            Task<ReaderChunk> secondRead = Task.Run(() => Assert.Single(second.Read(file)));
+            ReaderChunk[] chunks = await Task.WhenAll(firstRead, secondRead);
+
+            Assert.Equal("first-output", chunks[0].Text);
+            Assert.Equal("second-output", chunks[1].Text);
+            Assert.Equal("officeimo.tests.instance.first", Assert.Single(first.GetCapabilities(false, true)).Id);
+            Assert.Equal("officeimo.tests.instance.second", Assert.Single(second.GetCapabilities(false, true)).Id);
+        } finally {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public void OfficeDocumentReader_BuildCapturesImmutableHandlerSnapshot() {
+        const string extension = ".snapshotix";
+        string file = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + extension);
+        File.WriteAllText(file, "input");
+
+        try {
+            var builder = new OfficeDocumentReaderBuilder();
+            builder.AddHandler(CreateRegistration("officeimo.tests.snapshot.first", extension, "before-build"));
+            OfficeDocumentReader first = builder.Build();
+
+            builder.AddHandler(
+                CreateRegistration("officeimo.tests.snapshot.second", extension, "after-build"),
+                replaceExisting: true);
+            OfficeDocumentReader second = builder.Build();
+
+            Assert.Equal("before-build", Assert.Single(first.Read(file)).Text);
+            Assert.Equal("after-build", Assert.Single(second.Read(file)).Text);
+            Assert.Equal("officeimo.tests.snapshot.first", Assert.Single(first.GetCapabilities(false, true)).Id);
+            Assert.Equal("officeimo.tests.snapshot.second", Assert.Single(second.GetCapabilities(false, true)).Id);
+        } finally {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public void OfficeDocumentReader_PreservesRichResultForInstanceHandler() {
+        const string extension = ".instancerichix";
+        var builder = new OfficeDocumentReaderBuilder();
+        builder.AddHandler(new ReaderHandlerRegistration {
+            Id = "officeimo.tests.instance.rich",
+            Kind = ReaderInputKind.Text,
+            Extensions = new[] { extension },
+            ReadDocumentStream = (stream, sourceName, options, cancellationToken) => new OfficeDocumentReadResult {
+                Kind = ReaderInputKind.Text,
+                Source = new OfficeDocumentSource { Path = sourceName },
+                CapabilitiesUsed = new[] { "officeimo.tests.instance.rich" },
+                Chunks = new[] {
+                    new ReaderChunk {
+                        Id = "instance-rich-0001",
+                        Kind = ReaderInputKind.Text,
+                        Text = "rich-instance-output"
+                    }
+                },
+                Links = new[] {
+                    new OfficeDocumentLink {
+                        Id = "instance-link-0001",
+                        Kind = "external",
+                        Uri = "https://example.test/instance"
+                    }
+                }
+            }
+        });
+        OfficeDocumentReader reader = builder.Build();
+
+        using var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+        OfficeDocumentReadResult result = reader.ReadDocument(stream, "sample" + extension);
+
+        Assert.Equal("rich-instance-output", Assert.Single(result.Chunks).Text);
+        Assert.Equal("https://example.test/instance", Assert.Single(result.Links).Uri);
+        Assert.True(Assert.Single(reader.GetCapabilities(false, true)).SupportsDocumentStream);
+    }
+
+    [Fact]
+    public void OfficeDocumentReader_KeepsScopeCorrectForInterleavedEnumerators() {
+        const string extension = ".interleavedix";
+        string file = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + extension);
+        File.WriteAllText(file, "input");
+
+        try {
+            OfficeDocumentReader first = BuildDetectingReader("officeimo.tests.interleaved.first", extension, ReaderInputKind.Csv);
+            OfficeDocumentReader second = BuildDetectingReader("officeimo.tests.interleaved.second", extension, ReaderInputKind.Json);
+
+            using IEnumerator<ReaderChunk> firstChunks = first.Read(file).GetEnumerator();
+            using IEnumerator<ReaderChunk> secondChunks = second.Read(file).GetEnumerator();
+
+            Assert.True(firstChunks.MoveNext());
+            Assert.Equal(nameof(ReaderInputKind.Csv), firstChunks.Current.Text);
+            Assert.True(secondChunks.MoveNext());
+            Assert.Equal(nameof(ReaderInputKind.Json), secondChunks.Current.Text);
+            Assert.True(firstChunks.MoveNext());
+            Assert.Equal(nameof(ReaderInputKind.Csv), firstChunks.Current.Text);
+            Assert.True(secondChunks.MoveNext());
+            Assert.Equal(nameof(ReaderInputKind.Json), secondChunks.Current.Text);
+        } finally {
+            File.Delete(file);
+        }
+    }
+
+    private static OfficeDocumentReader BuildReader(string id, string extension, string output) {
+        return new OfficeDocumentReaderBuilder()
+            .AddHandler(CreateRegistration(id, extension, output))
+            .Build();
+    }
+
+    private static ReaderHandlerRegistration CreateRegistration(string id, string extension, string output) {
+        return new ReaderHandlerRegistration {
+            Id = id,
+            Kind = ReaderInputKind.Text,
+            Extensions = new[] { extension },
+            ReadPath = (path, options, cancellationToken) => new[] {
+                new ReaderChunk {
+                    Id = id + ":0001",
+                    Kind = ReaderInputKind.Text,
+                    Location = new ReaderLocation { Path = path },
+                    Text = output
+                }
+            }
+        };
+    }
+
+    private static OfficeDocumentReader BuildDetectingReader(string id, string extension, ReaderInputKind kind) {
+        return new OfficeDocumentReaderBuilder()
+            .AddHandler(new ReaderHandlerRegistration {
+                Id = id,
+                Kind = kind,
+                Extensions = new[] { extension },
+                ReadPath = (path, options, cancellationToken) => DetectKindForEachChunk(extension)
+            })
+            .Build();
+    }
+
+    private static IEnumerable<ReaderChunk> DetectKindForEachChunk(string extension) {
+        for (int index = 0; index < 2; index++) {
+            ReaderInputKind detected = DocumentReader.DetectKind("nested" + extension);
+            yield return new ReaderChunk {
+                Id = "nested:" + index,
+                Kind = detected,
+                Text = detected.ToString()
+            };
+        }
+    }
+}
+
+public sealed partial class ReaderRegistryTests {
+    [Fact]
+    public void OfficeDocumentReader_IsNotAffectedByStaticRegistration() {
+        const string staticHandlerId = "officeimo.tests.instance.static";
+        const string instanceHandlerId = "officeimo.tests.instance.isolated";
+        const string extension = ".staticisolationix";
+        string file = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + extension);
+
+        try {
+            DocumentReader.UnregisterHandler(staticHandlerId);
+            DocumentReader.RegisterHandler(new ReaderHandlerRegistration {
+                Id = staticHandlerId,
+                Kind = ReaderInputKind.Text,
+                Extensions = new[] { extension },
+                ReadPath = (path, options, cancellationToken) => new[] {
+                    new ReaderChunk { Id = "static", Kind = ReaderInputKind.Text, Text = "static-output" }
+                }
+            });
+
+            OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+                .AddHandler(new ReaderHandlerRegistration {
+                    Id = instanceHandlerId,
+                    Kind = ReaderInputKind.Text,
+                    Extensions = new[] { extension },
+                    ReadPath = (path, options, cancellationToken) => new[] {
+                        new ReaderChunk { Id = "instance", Kind = ReaderInputKind.Text, Text = "instance-output" }
+                    }
+                })
+                .Build();
+            File.WriteAllText(file, "input");
+
+            Assert.Equal("static-output", Assert.Single(DocumentReader.Read(file)).Text);
+            Assert.Equal("instance-output", Assert.Single(reader.Read(file)).Text);
+            Assert.Equal(instanceHandlerId, Assert.Single(reader.GetCapabilities(false, true)).Id);
+        } finally {
+            DocumentReader.UnregisterHandler(staticHandlerId);
+            File.Delete(file);
+        }
+    }
+}

--- a/OfficeIMO.Reader.Text/DocumentReaderTextRegistrationExtensions.cs
+++ b/OfficeIMO.Reader.Text/DocumentReaderTextRegistrationExtensions.cs
@@ -17,9 +17,30 @@ public static class DocumentReaderTextRegistrationExtensions {
     /// Defaults to true because these extensions are already handled by the built-in plain text path.
     /// </param>
     public static void RegisterStructuredTextHandler(StructuredTextReadOptions? structuredOptions = null, bool replaceExisting = true) {
-        var registered = Clone(structuredOptions);
+        DocumentReader.RegisterHandler(CreateRegistration(structuredOptions), replaceExisting);
+    }
 
-        DocumentReader.RegisterHandler(new ReaderHandlerRegistration {
+    /// <summary>
+    /// Adds structured text compatibility ingestion to an isolated reader builder.
+    /// </summary>
+    public static OfficeDocumentReaderBuilder AddStructuredTextHandler(
+        this OfficeDocumentReaderBuilder builder,
+        StructuredTextReadOptions? structuredOptions = null,
+        bool replaceExisting = true) {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+        return builder.AddHandler(CreateRegistration(structuredOptions), replaceExisting);
+    }
+
+    /// <summary>
+    /// Unregisters structured text compatibility handler from <see cref="DocumentReader"/>.
+    /// </summary>
+    public static bool UnregisterStructuredTextHandler() {
+        return DocumentReader.UnregisterHandler(HandlerId);
+    }
+
+    private static ReaderHandlerRegistration CreateRegistration(StructuredTextReadOptions? structuredOptions) {
+        StructuredTextReadOptions? registered = Clone(structuredOptions);
+        return new ReaderHandlerRegistration {
             Id = HandlerId,
             DisplayName = "Structured Text Reader Compatibility Adapter",
             Description = "Compatibility adapter that delegates CSV/JSON/XML to dedicated modular handlers.",
@@ -36,14 +57,7 @@ public static class DocumentReaderTextRegistrationExtensions {
                 readerOptions: readerOptions,
                 structuredOptions: Clone(registered),
                 cancellationToken: ct)
-        }, replaceExisting);
-    }
-
-    /// <summary>
-    /// Unregisters structured text compatibility handler from <see cref="DocumentReader"/>.
-    /// </summary>
-    public static bool UnregisterStructuredTextHandler() {
-        return DocumentReader.UnregisterHandler(HandlerId);
+        };
     }
 
     private static StructuredTextReadOptions? Clone(StructuredTextReadOptions? options) {

--- a/OfficeIMO.Reader.Visio/DocumentReaderVisioRegistrationExtensions.cs
+++ b/OfficeIMO.Reader.Visio/DocumentReaderVisioRegistrationExtensions.cs
@@ -21,9 +21,43 @@ public static class DocumentReaderVisioRegistrationExtensions {
     /// Registers Visio ingestion into <see cref="DocumentReader"/> for VSDX/VSDM/VSTX/VSTM files and streams.
     /// </summary>
     public static void RegisterVisioHandler(ReaderVisioOptions? visioOptions, bool replaceExisting, bool preserveExistingCustomExtensions) {
-        var registeredOptions = ReaderVisioOptionsCloner.CloneNullable(visioOptions);
+        ReaderHandlerRegistration registration = CreateRegistration(visioOptions);
 
-        var registration = new ReaderHandlerRegistration {
+        if (preserveExistingCustomExtensions) {
+            DocumentReader.RegisterHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
+        } else {
+            DocumentReader.RegisterHandler(registration, replaceExisting);
+        }
+    }
+
+    /// <summary>
+    /// Adds Visio ingestion to an isolated reader builder.
+    /// </summary>
+    public static OfficeDocumentReaderBuilder AddVisioHandler(
+        this OfficeDocumentReaderBuilder builder,
+        ReaderVisioOptions? visioOptions = null,
+        bool replaceExisting = false,
+        bool preserveExistingCustomExtensions = false) {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+        ReaderHandlerRegistration registration = CreateRegistration(visioOptions);
+        if (preserveExistingCustomExtensions) {
+            builder.AddHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
+        } else {
+            builder.AddHandler(registration, replaceExisting);
+        }
+        return builder;
+    }
+
+    /// <summary>
+    /// Unregisters Visio ingestion handler from <see cref="DocumentReader"/>.
+    /// </summary>
+    public static bool UnregisterVisioHandler() {
+        return DocumentReader.UnregisterHandler(HandlerId);
+    }
+
+    private static ReaderHandlerRegistration CreateRegistration(ReaderVisioOptions? visioOptions) {
+        ReaderVisioOptions? registeredOptions = ReaderVisioOptionsCloner.CloneNullable(visioOptions);
+        return new ReaderHandlerRegistration {
             Id = HandlerId,
             DisplayName = "Visio Reader Adapter",
             Description = "Modular Visio adapter using OfficeIMO.Visio inspection snapshots.",
@@ -52,18 +86,5 @@ public static class DocumentReaderVisioRegistrationExtensions {
                 visioOptions: ReaderVisioOptionsCloner.CloneNullable(registeredOptions),
                 cancellationToken: ct)
         };
-
-        if (preserveExistingCustomExtensions) {
-            DocumentReader.RegisterHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
-        } else {
-            DocumentReader.RegisterHandler(registration, replaceExisting);
-        }
-    }
-
-    /// <summary>
-    /// Unregisters Visio ingestion handler from <see cref="DocumentReader"/>.
-    /// </summary>
-    public static bool UnregisterVisioHandler() {
-        return DocumentReader.UnregisterHandler(HandlerId);
     }
 }

--- a/OfficeIMO.Reader.Xml/DocumentReaderXmlRegistrationExtensions.cs
+++ b/OfficeIMO.Reader.Xml/DocumentReaderXmlRegistrationExtensions.cs
@@ -30,9 +30,43 @@ public static class DocumentReaderXmlRegistrationExtensions {
     /// </param>
     /// <param name="preserveExistingCustomExtensions">When true, leaves extensions already owned by other custom handlers untouched.</param>
     public static void RegisterXmlHandler(XmlReadOptions? xmlOptions, bool replaceExisting, bool preserveExistingCustomExtensions) {
-        var registered = Clone(xmlOptions);
+        ReaderHandlerRegistration registration = CreateRegistration(xmlOptions);
 
-        var registration = new ReaderHandlerRegistration {
+        if (preserveExistingCustomExtensions) {
+            DocumentReader.RegisterHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
+        } else {
+            DocumentReader.RegisterHandler(registration, replaceExisting);
+        }
+    }
+
+    /// <summary>
+    /// Adds XML ingestion to an isolated reader builder.
+    /// </summary>
+    public static OfficeDocumentReaderBuilder AddXmlHandler(
+        this OfficeDocumentReaderBuilder builder,
+        XmlReadOptions? xmlOptions = null,
+        bool replaceExisting = true,
+        bool preserveExistingCustomExtensions = false) {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+        ReaderHandlerRegistration registration = CreateRegistration(xmlOptions);
+        if (preserveExistingCustomExtensions) {
+            builder.AddHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
+        } else {
+            builder.AddHandler(registration, replaceExisting);
+        }
+        return builder;
+    }
+
+    /// <summary>
+    /// Unregisters XML ingestion handler from <see cref="DocumentReader"/>.
+    /// </summary>
+    public static bool UnregisterXmlHandler() {
+        return DocumentReader.UnregisterHandler(HandlerId);
+    }
+
+    private static ReaderHandlerRegistration CreateRegistration(XmlReadOptions? xmlOptions) {
+        XmlReadOptions? registered = Clone(xmlOptions);
+        return new ReaderHandlerRegistration {
             Id = HandlerId,
             DisplayName = "XML Reader Adapter",
             Description = "Modular XML tree parser with path/type/value chunk output.",
@@ -50,19 +84,6 @@ public static class DocumentReaderXmlRegistrationExtensions {
                 xmlOptions: Clone(registered),
                 cancellationToken: ct)
         };
-
-        if (preserveExistingCustomExtensions) {
-            DocumentReader.RegisterHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
-        } else {
-            DocumentReader.RegisterHandler(registration, replaceExisting);
-        }
-    }
-
-    /// <summary>
-    /// Unregisters XML ingestion handler from <see cref="DocumentReader"/>.
-    /// </summary>
-    public static bool UnregisterXmlHandler() {
-        return DocumentReader.UnregisterHandler(HandlerId);
     }
 
     private static XmlReadOptions? Clone(XmlReadOptions? options) {

--- a/OfficeIMO.Reader.Yaml/DocumentReaderYamlRegistrationExtensions.cs
+++ b/OfficeIMO.Reader.Yaml/DocumentReaderYamlRegistrationExtensions.cs
@@ -19,9 +19,43 @@ public static class DocumentReaderYamlRegistrationExtensions {
     /// <param name="preserveExistingCustomExtensions">When true, leaves extensions already owned by other custom handlers untouched.</param>
     [ReaderHandlerRegistrar(HandlerId)]
     public static void RegisterYamlHandler(YamlReadOptions? yamlOptions = null, bool replaceExisting = true, bool preserveExistingCustomExtensions = false) {
-        var registered = Clone(yamlOptions);
+        ReaderHandlerRegistration registration = CreateRegistration(yamlOptions);
 
-        var registration = new ReaderHandlerRegistration {
+        if (preserveExistingCustomExtensions) {
+            DocumentReader.RegisterHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
+        } else {
+            DocumentReader.RegisterHandler(registration, replaceExisting);
+        }
+    }
+
+    /// <summary>
+    /// Adds YAML ingestion to an isolated reader builder.
+    /// </summary>
+    public static OfficeDocumentReaderBuilder AddYamlHandler(
+        this OfficeDocumentReaderBuilder builder,
+        YamlReadOptions? yamlOptions = null,
+        bool replaceExisting = true,
+        bool preserveExistingCustomExtensions = false) {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+        ReaderHandlerRegistration registration = CreateRegistration(yamlOptions);
+        if (preserveExistingCustomExtensions) {
+            builder.AddHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
+        } else {
+            builder.AddHandler(registration, replaceExisting);
+        }
+        return builder;
+    }
+
+    /// <summary>
+    /// Unregisters YAML ingestion handler from <see cref="DocumentReader"/>.
+    /// </summary>
+    public static bool UnregisterYamlHandler() {
+        return DocumentReader.UnregisterHandler(HandlerId);
+    }
+
+    private static ReaderHandlerRegistration CreateRegistration(YamlReadOptions? yamlOptions) {
+        YamlReadOptions? registered = Clone(yamlOptions);
+        return new ReaderHandlerRegistration {
             Id = HandlerId,
             DisplayName = "YAML Reader Adapter",
             Description = "Modular YAML parser with path/type/value chunk output.",
@@ -39,19 +73,6 @@ public static class DocumentReaderYamlRegistrationExtensions {
                 yamlOptions: Clone(registered),
                 cancellationToken: ct)
         };
-
-        if (preserveExistingCustomExtensions) {
-            DocumentReader.RegisterHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
-        } else {
-            DocumentReader.RegisterHandler(registration, replaceExisting);
-        }
-    }
-
-    /// <summary>
-    /// Unregisters YAML ingestion handler from <see cref="DocumentReader"/>.
-    /// </summary>
-    public static bool UnregisterYamlHandler() {
-        return DocumentReader.UnregisterHandler(HandlerId);
     }
 
     private static YamlReadOptions? Clone(YamlReadOptions? options) {

--- a/OfficeIMO.Reader.Zip/DocumentReaderZipRegistrationExtensions.cs
+++ b/OfficeIMO.Reader.Zip/DocumentReaderZipRegistrationExtensions.cs
@@ -30,10 +30,47 @@ public static class DocumentReaderZipRegistrationExtensions {
         ReaderZipOptions? readerZipOptions,
         bool replaceExisting,
         bool preserveExistingCustomExtensions) {
-        var registeredZipOptions = Clone(zipOptions);
-        var registeredReaderZipOptions = Clone(readerZipOptions);
+        ReaderHandlerRegistration registration = CreateRegistration(zipOptions, readerZipOptions);
 
-        var registration = new ReaderHandlerRegistration {
+        if (preserveExistingCustomExtensions) {
+            DocumentReader.RegisterHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
+        } else {
+            DocumentReader.RegisterHandler(registration, replaceExisting);
+        }
+    }
+
+    /// <summary>
+    /// Adds ZIP ingestion to an isolated reader builder.
+    /// </summary>
+    public static OfficeDocumentReaderBuilder AddZipHandler(
+        this OfficeDocumentReaderBuilder builder,
+        ZipTraversalOptions? zipOptions = null,
+        ReaderZipOptions? readerZipOptions = null,
+        bool replaceExisting = false,
+        bool preserveExistingCustomExtensions = false) {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+        ReaderHandlerRegistration registration = CreateRegistration(zipOptions, readerZipOptions);
+        if (preserveExistingCustomExtensions) {
+            builder.AddHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
+        } else {
+            builder.AddHandler(registration, replaceExisting);
+        }
+        return builder;
+    }
+
+    /// <summary>
+    /// Unregisters ZIP ingestion handler from <see cref="DocumentReader"/>.
+    /// </summary>
+    public static bool UnregisterZipHandler() {
+        return DocumentReader.UnregisterHandler(HandlerId);
+    }
+
+    private static ReaderHandlerRegistration CreateRegistration(
+        ZipTraversalOptions? zipOptions,
+        ReaderZipOptions? readerZipOptions) {
+        ZipTraversalOptions? registeredZipOptions = Clone(zipOptions);
+        ReaderZipOptions? registeredReaderZipOptions = Clone(readerZipOptions);
+        return new ReaderHandlerRegistration {
             Id = HandlerId,
             DisplayName = "ZIP Reader Adapter",
             Description = "Modular ZIP adapter that traverses archives and emits Reader chunks.",
@@ -53,19 +90,6 @@ public static class DocumentReaderZipRegistrationExtensions {
                 readerZipOptions: Clone(registeredReaderZipOptions),
                 cancellationToken: ct)
         };
-
-        if (preserveExistingCustomExtensions) {
-            DocumentReader.RegisterHandlerPreservingExistingCustomExtensions(registration, replaceExisting);
-        } else {
-            DocumentReader.RegisterHandler(registration, replaceExisting);
-        }
-    }
-
-    /// <summary>
-    /// Unregisters ZIP ingestion handler from <see cref="DocumentReader"/>.
-    /// </summary>
-    public static bool UnregisterZipHandler() {
-        return DocumentReader.UnregisterHandler(HandlerId);
     }
 
     private static ZipTraversalOptions? Clone(ZipTraversalOptions? options) {

--- a/OfficeIMO.Reader/DocumentReader.Document.cs
+++ b/OfficeIMO.Reader/DocumentReader.Document.cs
@@ -23,7 +23,7 @@ public static partial class DocumentReader {
 
         ReaderOptions opt = NormalizeOptions(options);
         ReaderInputKind kind = DetectKind(path);
-        bool hasCustomPathHandler = TryResolveCustomHandlerByPath(path, out CustomReaderHandler customPathHandler);
+        bool hasCustomPathHandler = TryResolveCustomHandlerByPath(path, out ReaderHandlerDescriptor customPathHandler);
         if (hasCustomPathHandler && customPathHandler.ReadDocumentPath != null) {
             EnforceFileSize(path, opt.MaxInputBytes);
             return ValidateDocumentResult(
@@ -54,7 +54,7 @@ public static partial class DocumentReader {
         ReaderOptions opt = NormalizeOptions(options);
         string logicalSourceName = NormalizeLogicalSourceName(sourceName, "memory");
         ReaderInputKind kind = string.IsNullOrWhiteSpace(logicalSourceName) ? ReaderInputKind.Unknown : DetectKind(logicalSourceName);
-        bool hasCustomStreamHandler = TryResolveCustomHandlerBySourceName(logicalSourceName, out CustomReaderHandler customStreamHandler);
+        bool hasCustomStreamHandler = TryResolveCustomHandlerBySourceName(logicalSourceName, out ReaderHandlerDescriptor customStreamHandler);
         if (stream.CanSeek) {
             ReaderInputLimits.EnforceSeekableStreamRemainingSize(stream, opt.MaxInputBytes);
         }

--- a/OfficeIMO.Reader/DocumentReader.Models.cs
+++ b/OfficeIMO.Reader/DocumentReader.Models.cs
@@ -30,68 +30,6 @@ public static partial class DocumentReader {
         public ReaderHandlerRegistrarDescriptor Descriptor { get; }
     }
 
-    private sealed class CustomReaderHandler {
-        public CustomReaderHandler(
-            string id,
-            string displayName,
-            string? description,
-            ReaderInputKind kind,
-            IReadOnlyList<string> extensions,
-            long? defaultMaxInputBytes,
-            ReaderWarningBehavior warningBehavior,
-            bool deterministicOutput,
-            Func<string, ReaderOptions, CancellationToken, IEnumerable<ReaderChunk>>? readPath,
-            Func<Stream, string?, ReaderOptions, CancellationToken, IEnumerable<ReaderChunk>>? readStream,
-            Func<string, ReaderOptions, CancellationToken, OfficeDocumentReadResult>? readDocumentPath,
-            Func<Stream, string?, ReaderOptions, CancellationToken, OfficeDocumentReadResult>? readDocumentStream) {
-            Id = id;
-            DisplayName = displayName;
-            Description = description;
-            Kind = kind;
-            Extensions = extensions;
-            DefaultMaxInputBytes = defaultMaxInputBytes;
-            WarningBehavior = warningBehavior;
-            DeterministicOutput = deterministicOutput;
-            ReadPath = readPath;
-            ReadStream = readStream;
-            ReadDocumentPath = readDocumentPath;
-            ReadDocumentStream = readDocumentStream;
-        }
-
-        public string Id { get; }
-        public string DisplayName { get; }
-        public string? Description { get; }
-        public ReaderInputKind Kind { get; }
-        public IReadOnlyList<string> Extensions { get; }
-        public long? DefaultMaxInputBytes { get; }
-        public ReaderWarningBehavior WarningBehavior { get; }
-        public bool DeterministicOutput { get; }
-        public Func<string, ReaderOptions, CancellationToken, IEnumerable<ReaderChunk>>? ReadPath { get; }
-        public Func<Stream, string?, ReaderOptions, CancellationToken, IEnumerable<ReaderChunk>>? ReadStream { get; }
-        public Func<string, ReaderOptions, CancellationToken, OfficeDocumentReadResult>? ReadDocumentPath { get; }
-        public Func<Stream, string?, ReaderOptions, CancellationToken, OfficeDocumentReadResult>? ReadDocumentStream { get; }
-
-        public ReaderHandlerCapability ToCapability() {
-            return new ReaderHandlerCapability {
-                Id = Id,
-                DisplayName = DisplayName,
-                Description = Description,
-                Kind = Kind,
-                Extensions = Extensions.ToArray(),
-                IsBuiltIn = false,
-                SupportsPath = ReadPath != null || ReadDocumentPath != null,
-                SupportsStream = ReadStream != null || ReadDocumentStream != null,
-                SupportsDocumentPath = ReadDocumentPath != null,
-                SupportsDocumentStream = ReadDocumentStream != null,
-                SchemaId = ReaderCapabilitySchema.Id,
-                SchemaVersion = ReaderCapabilitySchema.Version,
-                DefaultMaxInputBytes = DefaultMaxInputBytes,
-                WarningBehavior = WarningBehavior,
-                DeterministicOutput = DeterministicOutput
-            };
-        }
-    }
-
     private sealed class FolderIngestState {
         public int FilesScanned { get; set; }
         public int FilesParsed { get; set; }

--- a/OfficeIMO.Reader/DocumentReader.Registry.cs
+++ b/OfficeIMO.Reader/DocumentReader.Registry.cs
@@ -272,7 +272,7 @@ public static partial class DocumentReader {
         return hasReplaceExisting;
     }
 
-    private static string NormalizeExtension(string? extension) {
+    internal static string NormalizeExtension(string? extension) {
         var value = extension ?? string.Empty;
         if (string.IsNullOrWhiteSpace(value)) return string.Empty;
         var ext = value.Trim();
@@ -280,23 +280,6 @@ public static partial class DocumentReader {
             ext = "." + ext;
         }
         return ext.ToLowerInvariant();
-    }
-
-    private static List<string> NormalizeRegistrationExtensions(IReadOnlyList<string>? extensions) {
-        var list = new List<string>();
-        if (extensions == null) return list;
-
-        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var ext in extensions) {
-            var normalized = NormalizeExtension(ext);
-            if (normalized.Length == 0) continue;
-            if (set.Add(normalized)) {
-                list.Add(normalized);
-            }
-        }
-
-        list.Sort(StringComparer.Ordinal);
-        return list;
     }
 
     private static HashSet<string> BuildBuiltInExtensionSet() {
@@ -311,44 +294,18 @@ public static partial class DocumentReader {
         return set;
     }
 
-    private static bool TryResolveCustomHandlerByPath(string path, out CustomReaderHandler handler) {
+    private static bool TryResolveCustomHandlerByPath(string path, out ReaderHandlerDescriptor handler) {
         var ext = NormalizeExtension(TryGetExtension(path));
         return TryResolveCustomHandlerByExtension(ext, out handler);
     }
 
-    private static bool TryResolveCustomHandlerBySourceName(string? sourceName, out CustomReaderHandler handler) {
+    private static bool TryResolveCustomHandlerBySourceName(string? sourceName, out ReaderHandlerDescriptor handler) {
         var ext = NormalizeExtension(TryGetExtension(sourceName ?? string.Empty));
         return TryResolveCustomHandlerByExtension(ext, out handler);
     }
 
-    private static bool TryResolveCustomHandlerByExtension(string ext, out CustomReaderHandler handler) {
-        handler = null!;
-        if (string.IsNullOrWhiteSpace(ext)) return false;
-
-        lock (HandlerRegistrySync) {
-            if (!CustomHandlerIdByExtension.TryGetValue(ext, out var handlerId)) {
-                return false;
-            }
-            if (!CustomHandlersById.TryGetValue(handlerId, out var resolved) || resolved == null) {
-                return false;
-            }
-            handler = resolved;
-            return true;
-        }
-    }
-
-    private static bool RemoveCustomHandlerUnsafe(string handlerId) {
-        if (!CustomHandlersById.TryGetValue(handlerId, out var existing)) return false;
-
-        CustomHandlersById.Remove(handlerId);
-        foreach (var ext in existing.Extensions) {
-            if (CustomHandlerIdByExtension.TryGetValue(ext, out var current) &&
-                string.Equals(current, handlerId, StringComparison.OrdinalIgnoreCase)) {
-                CustomHandlerIdByExtension.Remove(ext);
-            }
-        }
-
-        return true;
+    private static bool TryResolveCustomHandlerByExtension(string ext, out ReaderHandlerDescriptor handler) {
+        return GetActiveHandlerRegistry().TryResolve(ext, out handler);
     }
 
     private static ReaderOptions NormalizeOptions(ReaderOptions? options) {
@@ -470,22 +427,12 @@ public static partial class DocumentReader {
     }
 
     private static IReadOnlyList<string> GetDefaultAndRegisteredFolderExtensions() {
-        lock (HandlerRegistrySync) {
-            if (CustomHandlerIdByExtension.Count == 0) {
-                return DefaultFolderExtensions;
-            }
-
-            var merged = new string[DefaultFolderExtensions.Length + CustomHandlerIdByExtension.Count];
-            Array.Copy(DefaultFolderExtensions, merged, DefaultFolderExtensions.Length);
-
-            int index = DefaultFolderExtensions.Length;
-            foreach (var extension in CustomHandlerIdByExtension.Keys) {
-                merged[index] = extension;
-                index++;
-            }
-
-            return merged;
+        IReadOnlyList<string> customExtensions = GetActiveHandlerRegistry().Extensions;
+        if (customExtensions.Count == 0) {
+            return DefaultFolderExtensions;
         }
+
+        return DefaultFolderExtensions.Concat(customExtensions).ToArray();
     }
 
     private static IEnumerable<string> EnumerateFilesSafeDeterministic(string folderPath, ReaderFolderOptions options, CancellationToken cancellationToken) {

--- a/OfficeIMO.Reader/DocumentReader.RegistryScope.cs
+++ b/OfficeIMO.Reader/DocumentReader.RegistryScope.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading;
+
+namespace OfficeIMO.Reader;
+
+public static partial class DocumentReader {
+    private static readonly AsyncLocal<ReaderHandlerRegistrySnapshot?> ActiveHandlerRegistry = new AsyncLocal<ReaderHandlerRegistrySnapshot?>();
+
+    internal static IDisposable UseHandlerRegistry(ReaderHandlerRegistrySnapshot snapshot) {
+        if (snapshot == null) throw new ArgumentNullException(nameof(snapshot));
+
+        ReaderHandlerRegistrySnapshot? previous = ActiveHandlerRegistry.Value;
+        ActiveHandlerRegistry.Value = snapshot;
+        return new ReaderHandlerRegistryScope(previous);
+    }
+
+    private static ReaderHandlerRegistrySnapshot GetActiveHandlerRegistry() {
+        return ActiveHandlerRegistry.Value ?? HandlerRegistry.CaptureSnapshot();
+    }
+
+    private sealed class ReaderHandlerRegistryScope : IDisposable {
+        private readonly ReaderHandlerRegistrySnapshot? _previous;
+        private bool _disposed;
+
+        public ReaderHandlerRegistryScope(ReaderHandlerRegistrySnapshot? previous) {
+            _previous = previous;
+        }
+
+        public void Dispose() {
+            if (_disposed) {
+                return;
+            }
+
+            ActiveHandlerRegistry.Value = _previous;
+            _disposed = true;
+        }
+    }
+}

--- a/OfficeIMO.Reader/DocumentReader.cs
+++ b/OfficeIMO.Reader/DocumentReader.cs
@@ -25,7 +25,8 @@ namespace OfficeIMO.Reader;
 /// <remarks>
 /// This facade is intentionally dependency-free and deterministic.
 /// It normalizes extraction into <see cref="ReaderChunk"/> instances with stable IDs and location metadata.
-/// The API is thread-safe as it does not use shared mutable state.
+/// Read operations are thread-safe. The legacy static registration methods update a process-wide
+/// compatibility registry; use <see cref="OfficeDocumentReaderBuilder"/> for isolated immutable readers.
 /// </remarks>
 public static partial class DocumentReader {
     private static readonly string[] DefaultFolderExtensions = {
@@ -100,10 +101,8 @@ public static partial class DocumentReader {
         }
     };
 
-    private static readonly HashSet<string> BuiltInExtensions = BuildBuiltInExtensionSet();
-    private static readonly object HandlerRegistrySync = new object();
-    private static readonly Dictionary<string, CustomReaderHandler> CustomHandlersById = new Dictionary<string, CustomReaderHandler>(StringComparer.OrdinalIgnoreCase);
-    private static readonly Dictionary<string, string> CustomHandlerIdByExtension = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    internal static readonly HashSet<string> BuiltInExtensions = BuildBuiltInExtensionSet();
+    private static readonly ReaderHandlerRegistry HandlerRegistry = new ReaderHandlerRegistry(BuiltInExtensions);
 
     private static string? TryGetExtension(string path) {
         if (path == null) return null;
@@ -152,111 +151,14 @@ public static partial class DocumentReader {
     }
 
     private static IReadOnlyList<string> RegisterHandlerCore(ReaderHandlerRegistration registration, bool replaceExisting, bool preserveExistingCustomExtensions) {
-        if (registration == null) throw new ArgumentNullException(nameof(registration));
-
-        var id = (registration.Id ?? string.Empty).Trim();
-        if (id.Length == 0) throw new ArgumentException("Handler Id cannot be empty.", nameof(registration));
-
-        if (registration.ReadPath == null &&
-            registration.ReadStream == null &&
-            registration.ReadDocumentPath == null &&
-            registration.ReadDocumentStream == null) {
-            throw new ArgumentException(
-                "Handler must define a chunk reader or rich document reader for paths and/or streams.",
-                nameof(registration));
-        }
-        if (registration.DefaultMaxInputBytes.HasValue && registration.DefaultMaxInputBytes.Value < 1) {
-            throw new ArgumentException("DefaultMaxInputBytes must be greater than 0 when specified.", nameof(registration));
-        }
-
-        var normalizedExtensions = NormalizeRegistrationExtensions(registration.Extensions);
-        if (normalizedExtensions.Count == 0) {
-            throw new ArgumentException("Handler must define at least one extension.", nameof(registration));
-        }
-
-        lock (HandlerRegistrySync) {
-            var effectiveExtensions = normalizedExtensions;
-            if (preserveExistingCustomExtensions) {
-                effectiveExtensions = new List<string>(normalizedExtensions.Count);
-                foreach (var ext in normalizedExtensions) {
-                    if (CustomHandlerIdByExtension.TryGetValue(ext, out var existing) &&
-                        !string.Equals(existing, id, StringComparison.OrdinalIgnoreCase)) {
-                        continue;
-                    }
-
-                    effectiveExtensions.Add(ext);
-                }
-
-                if (effectiveExtensions.Count == 0) {
-                    return Array.Empty<string>();
-                }
-            }
-
-            if (!replaceExisting) {
-                if (CustomHandlersById.ContainsKey(id)) {
-                    throw new InvalidOperationException($"Handler '{id}' is already registered.");
-                }
-
-                foreach (var ext in effectiveExtensions) {
-                    if (BuiltInExtensions.Contains(ext)) {
-                        throw new InvalidOperationException($"Extension '{ext}' is handled by a built-in reader. Use replaceExisting=true to override.");
-                    }
-                    if (CustomHandlerIdByExtension.ContainsKey(ext)) {
-                        throw new InvalidOperationException($"Extension '{ext}' is already handled by a custom reader.");
-                    }
-                }
-            } else {
-                var toRemove = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                if (CustomHandlersById.ContainsKey(id)) {
-                    toRemove.Add(id);
-                }
-                foreach (var ext in normalizedExtensions) {
-                    if (preserveExistingCustomExtensions &&
-                        CustomHandlerIdByExtension.TryGetValue(ext, out var existingForPreservedExtension) &&
-                        !string.Equals(existingForPreservedExtension, id, StringComparison.OrdinalIgnoreCase)) {
-                        continue;
-                    }
-
-                    if (CustomHandlerIdByExtension.TryGetValue(ext, out var existing)) {
-                        toRemove.Add(existing);
-                    }
-                }
-                foreach (var existingId in toRemove) {
-                    RemoveCustomHandlerUnsafe(existingId);
-                }
-            }
-
-            var custom = new CustomReaderHandler(
-                id: id,
-                displayName: string.IsNullOrWhiteSpace(registration.DisplayName) ? id : registration.DisplayName!.Trim(),
-                description: registration.Description,
-                kind: registration.Kind,
-                extensions: effectiveExtensions.ToArray(),
-                defaultMaxInputBytes: registration.DefaultMaxInputBytes,
-                warningBehavior: registration.WarningBehavior,
-                deterministicOutput: registration.DeterministicOutput,
-                readPath: registration.ReadPath,
-                readStream: registration.ReadStream,
-                readDocumentPath: registration.ReadDocumentPath,
-                readDocumentStream: registration.ReadDocumentStream);
-
-            CustomHandlersById[id] = custom;
-            foreach (var ext in custom.Extensions) {
-                CustomHandlerIdByExtension[ext] = custom.Id;
-            }
-
-            return custom.Extensions.ToArray();
-        }
+        return HandlerRegistry.Register(registration, replaceExisting, preserveExistingCustomExtensions);
     }
 
     /// <summary>
     /// Unregisters a custom handler by identifier.
     /// </summary>
     public static bool UnregisterHandler(string handlerId) {
-        if (string.IsNullOrWhiteSpace(handlerId)) return false;
-        lock (HandlerRegistrySync) {
-            return RemoveCustomHandlerUnsafe(handlerId.Trim());
-        }
+        return HandlerRegistry.Unregister(handlerId);
     }
 
     /// <summary>
@@ -266,20 +168,19 @@ public static partial class DocumentReader {
         var list = new List<ReaderHandlerCapability>();
         var customCapabilities = new List<ReaderHandlerCapability>();
         Dictionary<string, ExtensionOverrideCoverage>? overriddenBuiltInExtensions = null;
+        ReaderHandlerRegistrySnapshot snapshot = GetActiveHandlerRegistry();
 
         if (includeCustom) {
-            lock (HandlerRegistrySync) {
-                foreach (var custom in CustomHandlersById.Values.OrderBy(static c => c.Id, StringComparer.Ordinal)) {
-                    ReaderHandlerCapability capability = custom.ToCapability();
-                    customCapabilities.Add(capability);
-                    if (includeBuiltIn) {
-                        for (int extensionIndex = 0; extensionIndex < capability.Extensions.Count; extensionIndex++) {
-                            string extension = capability.Extensions[extensionIndex];
-                            if (BuiltInExtensions.Contains(extension)) {
-                                overriddenBuiltInExtensions ??= new Dictionary<string, ExtensionOverrideCoverage>(StringComparer.OrdinalIgnoreCase);
-                                overriddenBuiltInExtensions.TryGetValue(extension, out ExtensionOverrideCoverage coverage);
-                                overriddenBuiltInExtensions[extension] = coverage.Add(capability.SupportsPath, capability.SupportsStream);
-                            }
+            foreach (ReaderHandlerDescriptor custom in snapshot.Handlers) {
+                ReaderHandlerCapability capability = custom.ToCapability();
+                customCapabilities.Add(capability);
+                if (includeBuiltIn) {
+                    for (int extensionIndex = 0; extensionIndex < capability.Extensions.Count; extensionIndex++) {
+                        string extension = capability.Extensions[extensionIndex];
+                        if (BuiltInExtensions.Contains(extension)) {
+                            overriddenBuiltInExtensions ??= new Dictionary<string, ExtensionOverrideCoverage>(StringComparer.OrdinalIgnoreCase);
+                            overriddenBuiltInExtensions.TryGetValue(extension, out ExtensionOverrideCoverage coverage);
+                            overriddenBuiltInExtensions[extension] = coverage.Add(capability.SupportsPath, capability.SupportsStream);
                         }
                     }
                 }

--- a/OfficeIMO.Reader/OfficeDocumentReader.cs
+++ b/OfficeIMO.Reader/OfficeDocumentReader.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>
+/// Immutable, instance-scoped OfficeIMO document reader suitable for services and concurrent hosts.
+/// </summary>
+/// <remarks>
+/// Handler routing is frozen when the reader is built. Static <see cref="DocumentReader"/> registrations
+/// and other <see cref="OfficeDocumentReader"/> instances cannot change this reader's behavior.
+/// </remarks>
+public sealed class OfficeDocumentReader {
+    private readonly ReaderHandlerRegistrySnapshot _handlers;
+
+    internal OfficeDocumentReader(ReaderHandlerRegistrySnapshot handlers) {
+        _handlers = handlers ?? throw new ArgumentNullException(nameof(handlers));
+    }
+
+    /// <summary>
+    /// Gets a reader with built-in handlers and no custom registrations.
+    /// </summary>
+    public static OfficeDocumentReader Default { get; } = new OfficeDocumentReaderBuilder().Build();
+
+    /// <summary>
+    /// Reads a supported file using this reader's frozen handler configuration.
+    /// </summary>
+    public IEnumerable<ReaderChunk> Read(
+        string path,
+        ReaderOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        return Scope(DocumentReader.Read(path, options, cancellationToken));
+    }
+
+    /// <summary>
+    /// Reads a supported stream using this reader's frozen handler configuration.
+    /// </summary>
+    public IEnumerable<ReaderChunk> Read(
+        Stream stream,
+        string? sourceName = null,
+        ReaderOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        return Scope(DocumentReader.Read(stream, sourceName, options, cancellationToken));
+    }
+
+    /// <summary>
+    /// Reads supported bytes using this reader's frozen handler configuration.
+    /// </summary>
+    public IEnumerable<ReaderChunk> Read(
+        byte[] bytes,
+        string? sourceName = null,
+        ReaderOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        return Scope(DocumentReader.Read(bytes, sourceName, options, cancellationToken));
+    }
+
+    /// <summary>
+    /// Reads a file into the shared rich document envelope.
+    /// </summary>
+    public OfficeDocumentReadResult ReadDocument(
+        string path,
+        ReaderOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        using (DocumentReader.UseHandlerRegistry(_handlers)) {
+            return DocumentReader.ReadDocument(path, options, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Reads a stream into the shared rich document envelope.
+    /// </summary>
+    public OfficeDocumentReadResult ReadDocument(
+        Stream stream,
+        string? sourceName = null,
+        ReaderOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        using (DocumentReader.UseHandlerRegistry(_handlers)) {
+            return DocumentReader.ReadDocument(stream, sourceName, options, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Reads bytes into the shared rich document envelope.
+    /// </summary>
+    public OfficeDocumentReadResult ReadDocument(
+        byte[] bytes,
+        string? sourceName = null,
+        ReaderOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        using (DocumentReader.UseHandlerRegistry(_handlers)) {
+            return DocumentReader.ReadDocument(bytes, sourceName, options, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Reads a file into the shared rich document JSON envelope.
+    /// </summary>
+    public string ReadDocumentJson(
+        string path,
+        ReaderOptions? options = null,
+        bool indented = false,
+        CancellationToken cancellationToken = default) {
+        using (DocumentReader.UseHandlerRegistry(_handlers)) {
+            return DocumentReader.ReadDocumentJson(path, options, indented, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Reads a stream into the shared rich document JSON envelope.
+    /// </summary>
+    public string ReadDocumentJson(
+        Stream stream,
+        string? sourceName = null,
+        ReaderOptions? options = null,
+        bool indented = false,
+        CancellationToken cancellationToken = default) {
+        using (DocumentReader.UseHandlerRegistry(_handlers)) {
+            return DocumentReader.ReadDocumentJson(stream, sourceName, options, indented, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Reads bytes into the shared rich document JSON envelope.
+    /// </summary>
+    public string ReadDocumentJson(
+        byte[] bytes,
+        string? sourceName = null,
+        ReaderOptions? options = null,
+        bool indented = false,
+        CancellationToken cancellationToken = default) {
+        using (DocumentReader.UseHandlerRegistry(_handlers)) {
+            return DocumentReader.ReadDocumentJson(bytes, sourceName, options, indented, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Enumerates a folder using this reader's registered extensions and handlers.
+    /// </summary>
+    public IEnumerable<ReaderChunk> ReadFolder(
+        string folderPath,
+        ReaderFolderOptions? folderOptions = null,
+        ReaderOptions? options = null,
+        Action<ReaderProgress>? onProgress = null,
+        CancellationToken cancellationToken = default) {
+        return Scope(DocumentReader.ReadFolder(folderPath, folderOptions, options, onProgress, cancellationToken));
+    }
+
+    /// <summary>
+    /// Enumerates a folder as one source-level payload per file.
+    /// </summary>
+    public IEnumerable<ReaderSourceDocument> ReadFolderDocuments(
+        string folderPath,
+        ReaderFolderOptions? folderOptions = null,
+        ReaderOptions? options = null,
+        Action<ReaderProgress>? onProgress = null,
+        CancellationToken cancellationToken = default) {
+        return Scope(DocumentReader.ReadFolderDocuments(folderPath, folderOptions, options, onProgress, cancellationToken));
+    }
+
+    /// <summary>
+    /// Reads a folder and returns materialized ingestion details.
+    /// </summary>
+    public ReaderIngestResult ReadFolderDetailed(
+        string folderPath,
+        ReaderFolderOptions? folderOptions = null,
+        ReaderOptions? options = null,
+        bool includeChunks = true,
+        Action<ReaderProgress>? onProgress = null,
+        CancellationToken cancellationToken = default) {
+        using (DocumentReader.UseHandlerRegistry(_handlers)) {
+            return DocumentReader.ReadFolderDetailed(folderPath, folderOptions, options, includeChunks, onProgress, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Reads a file or folder and returns source-level document payloads with optional chunk shaping.
+    /// </summary>
+    public ReaderPathDocumentResult ReadPathDocumentsDetailed(
+        string path,
+        ReaderFolderOptions? folderOptions = null,
+        ReaderOptions? options = null,
+        bool includeDocumentChunks = true,
+        int? maxReturnedChunks = null,
+        Action<ReaderProgress>? onProgress = null,
+        CancellationToken cancellationToken = default) {
+        using (DocumentReader.UseHandlerRegistry(_handlers)) {
+            return DocumentReader.ReadPathDocumentsDetailed(
+                path,
+                folderOptions,
+                options,
+                includeDocumentChunks,
+                maxReturnedChunks,
+                onProgress,
+                cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Detects a reader input kind using this reader's handler configuration.
+    /// </summary>
+    public ReaderInputKind DetectKind(string path) {
+        using (DocumentReader.UseHandlerRegistry(_handlers)) {
+            return DocumentReader.DetectKind(path);
+        }
+    }
+
+    /// <summary>
+    /// Lists capabilities visible to this reader instance.
+    /// </summary>
+    public IReadOnlyList<ReaderHandlerCapability> GetCapabilities(bool includeBuiltIn = true, bool includeCustom = true) {
+        using (DocumentReader.UseHandlerRegistry(_handlers)) {
+            return DocumentReader.GetCapabilities(includeBuiltIn, includeCustom);
+        }
+    }
+
+    /// <summary>
+    /// Builds a capability manifest for this reader instance.
+    /// </summary>
+    public ReaderCapabilityManifest GetCapabilityManifest(bool includeBuiltIn = true, bool includeCustom = true) {
+        using (DocumentReader.UseHandlerRegistry(_handlers)) {
+            return DocumentReader.GetCapabilityManifest(includeBuiltIn, includeCustom);
+        }
+    }
+
+    /// <summary>
+    /// Builds a JSON capability manifest for this reader instance.
+    /// </summary>
+    public string GetCapabilityManifestJson(bool includeBuiltIn = true, bool includeCustom = true, bool indented = false) {
+        using (DocumentReader.UseHandlerRegistry(_handlers)) {
+            return DocumentReader.GetCapabilityManifestJson(includeBuiltIn, includeCustom, indented);
+        }
+    }
+
+    private IEnumerable<T> Scope<T>(IEnumerable<T> source) {
+        return new ReaderHandlerScopedEnumerable<T>(_handlers, source);
+    }
+}

--- a/OfficeIMO.Reader/OfficeDocumentReaderBuilder.cs
+++ b/OfficeIMO.Reader/OfficeDocumentReaderBuilder.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>
+/// Builds an <see cref="OfficeDocumentReader"/> with an isolated handler configuration.
+/// </summary>
+/// <remarks>
+/// A builder may be reused or changed after <see cref="Build"/>. Each built reader retains its own
+/// immutable snapshot and is unaffected by later builder or static <see cref="DocumentReader"/> registrations.
+/// </remarks>
+public sealed class OfficeDocumentReaderBuilder {
+    private readonly ReaderHandlerRegistry _handlers = new ReaderHandlerRegistry(DocumentReader.BuiltInExtensions);
+
+    /// <summary>
+    /// Adds a handler to this reader configuration.
+    /// </summary>
+    /// <param name="registration">Handler registration.</param>
+    /// <param name="replaceExisting">Whether conflicting custom handlers and built-in extensions may be replaced.</param>
+    /// <returns>This builder.</returns>
+    public OfficeDocumentReaderBuilder AddHandler(ReaderHandlerRegistration registration, bool replaceExisting = false) {
+        _handlers.Register(registration, replaceExisting, preserveExistingCustomExtensions: false);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a handler while leaving extensions already owned by other custom handlers untouched.
+    /// </summary>
+    /// <param name="registration">Handler registration.</param>
+    /// <param name="replaceExisting">Whether a handler with the same identifier and built-in extensions may be replaced.</param>
+    /// <returns>This builder.</returns>
+    public OfficeDocumentReaderBuilder AddHandlerPreservingExistingCustomExtensions(
+        ReaderHandlerRegistration registration,
+        bool replaceExisting = false) {
+        _handlers.Register(registration, replaceExisting, preserveExistingCustomExtensions: true);
+        return this;
+    }
+
+    /// <summary>
+    /// Creates an immutable, thread-safe reader from the current configuration.
+    /// </summary>
+    public OfficeDocumentReader Build() {
+        return new OfficeDocumentReader(_handlers.CaptureSnapshot());
+    }
+}

--- a/OfficeIMO.Reader/README.md
+++ b/OfficeIMO.Reader/README.md
@@ -57,7 +57,7 @@ Built-in and modular adapters can extract:
 
 ## Modular adapters
 
-Install and register only the adapters you need:
+For services and concurrent hosts, build an isolated reader with only the adapters you need:
 
 ```csharp
 using OfficeIMO.Reader.Csv;
@@ -71,17 +71,23 @@ using OfficeIMO.Reader.Xml;
 using OfficeIMO.Reader.Yaml;
 using OfficeIMO.Reader.Zip;
 
-DocumentReaderCsvRegistrationExtensions.RegisterCsvHandler();
-DocumentReaderEpubRegistrationExtensions.RegisterEpubHandler();
-DocumentReaderHtmlRegistrationExtensions.RegisterHtmlHandler();
-DocumentReaderJsonRegistrationExtensions.RegisterJsonHandler();
-DocumentReaderPdfRegistrationExtensions.RegisterPdfHandler();
-DocumentReaderRtfRegistrationExtensions.RegisterRtfHandler();
-DocumentReaderVisioRegistrationExtensions.RegisterVisioHandler();
-DocumentReaderXmlRegistrationExtensions.RegisterXmlHandler();
-DocumentReaderYamlRegistrationExtensions.RegisterYamlHandler();
-DocumentReaderZipRegistrationExtensions.RegisterZipHandler();
+OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+    .AddCsvHandler()
+    .AddEpubHandler()
+    .AddHtmlHandler()
+    .AddJsonHandler()
+    .AddPdfHandler()
+    .AddRtfHandler()
+    .AddVisioHandler()
+    .AddXmlHandler()
+    .AddYamlHandler()
+    .AddZipHandler()
+    .Build();
+
+var chunks = reader.Read(@"C:\Docs\data.json").ToList();
 ```
+
+`Build()` freezes the handler configuration. The resulting `OfficeDocumentReader` is safe to reuse across concurrent reads, is unaffected by later builder changes, and cannot see handlers registered on another reader. The static `DocumentReader.RegisterHandler(...)` and adapter `Register...Handler()` methods remain available for compatibility, but they update a process-wide registry.
 
 ## Host examples
 
@@ -90,12 +96,13 @@ DocumentReaderZipRegistrationExtensions.RegisterZipHandler();
 ```csharp
 using OfficeIMO.Reader;
 
-var capabilities = DocumentReader.GetCapabilities();
+var reader = new OfficeDocumentReaderBuilder().Build();
+var capabilities = reader.GetCapabilities();
 foreach (var capability in capabilities) {
     Console.WriteLine($"{capability.Id}: {string.Join(", ", capability.Extensions)}");
 }
 
-string manifestJson = DocumentReader.GetCapabilityManifestJson();
+string manifestJson = reader.GetCapabilityManifestJson();
 ```
 
 ### Register a custom handler
@@ -103,7 +110,8 @@ string manifestJson = DocumentReader.GetCapabilityManifestJson();
 ```csharp
 using OfficeIMO.Reader;
 
-DocumentReader.RegisterHandler(new ReaderHandlerRegistration {
+OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+    .AddHandler(new ReaderHandlerRegistration {
     Id = "custom-audit",
     DisplayName = "Custom audit reader",
     Kind = ReaderInputKind.Text,
@@ -119,31 +127,35 @@ DocumentReader.RegisterHandler(new ReaderHandlerRegistration {
             }
         };
     }
-});
+})
+    .Build();
 ```
 
 Handlers that already expose a structured document model can register rich result delegates instead of rebuilding that model as chunks first:
 
 ```csharp
-DocumentReader.RegisterHandler(new ReaderHandlerRegistration {
+OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+    .AddHandler(new ReaderHandlerRegistration {
     Id = "custom-rich-reader",
     DisplayName = "Custom rich reader",
     Kind = ReaderInputKind.Text,
     Extensions = new[] { ".rich" },
     ReadDocumentPath = (path, options, cancellationToken) => ReadRichDocument(path),
     ReadDocumentStream = (stream, sourceName, options, cancellationToken) => ReadRichDocument(stream, sourceName)
-});
+})
+    .Build();
 ```
 
-`DocumentReader.ReadDocument(...)` dispatches directly to these delegates. Existing `DocumentReader.Read(...)` calls remain usable by projecting the returned result's `Chunks` collection. A handler may continue to register `ReadPath` and `ReadStream` when chunk production is its native contract.
+`reader.ReadDocument(...)` dispatches directly to these delegates. Existing `reader.Read(...)` calls remain usable by projecting the returned result's `Chunks` collection. A handler may continue to register `ReadPath` and `ReadStream` when chunk production is its native contract.
 
 ## Host contracts
 
 - `ReaderOptions` controls chunk size, table row limits, footnotes/notes, Excel ranges, Markdown heading chunking, hashes, and input budgets.
 - `ReaderFolderOptions` controls recursion, file limits, byte limits, reparse-point handling, and deterministic folder order.
-- `DocumentReader.GetCapabilities()` and `GetCapabilityManifestJson()` expose a stable host-discovery surface.
+- `OfficeDocumentReader.GetCapabilities()` and `GetCapabilityManifestJson()` expose the frozen configuration of that reader instance.
 - Capability records distinguish basic path/stream support from native rich-result support through `SupportsDocumentPath` and `SupportsDocumentStream`.
-- Custom handlers can be registered with `DocumentReader.RegisterHandler(...)`.
+- `OfficeDocumentReaderBuilder.AddHandler(...)` is the recommended custom-handler path for services and concurrent hosts.
+- Static `DocumentReader` registration is retained as a process-wide compatibility surface.
 
 ## Boundaries
 

--- a/OfficeIMO.Reader/ReaderHandlerModels.cs
+++ b/OfficeIMO.Reader/ReaderHandlerModels.cs
@@ -7,7 +7,8 @@ using System.Threading;
 namespace OfficeIMO.Reader;
 
 /// <summary>
-/// Custom handler registration model for extending <see cref="DocumentReader"/> without hard dependencies.
+/// Custom handler registration model for extending <see cref="DocumentReader"/> or configuring
+/// an isolated <see cref="OfficeDocumentReaderBuilder"/> without hard dependencies.
 /// </summary>
 public sealed class ReaderHandlerRegistration {
     /// <summary>

--- a/OfficeIMO.Reader/ReaderHandlerRegistry.cs
+++ b/OfficeIMO.Reader/ReaderHandlerRegistry.cs
@@ -1,0 +1,292 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+namespace OfficeIMO.Reader;
+
+internal sealed class ReaderHandlerRegistry {
+    private readonly HashSet<string> _builtInExtensions;
+    private readonly Dictionary<string, ReaderHandlerDescriptor> _handlersById = new Dictionary<string, ReaderHandlerDescriptor>(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, string> _handlerIdByExtension = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    private readonly object _sync = new object();
+
+    public ReaderHandlerRegistry(IEnumerable<string> builtInExtensions) {
+        _builtInExtensions = new HashSet<string>(builtInExtensions ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+    }
+
+    public IReadOnlyList<string> Register(ReaderHandlerRegistration registration, bool replaceExisting, bool preserveExistingCustomExtensions) {
+        ReaderHandlerDescriptor handler = ReaderHandlerDescriptor.Create(registration);
+
+        lock (_sync) {
+            IReadOnlyList<string> effectiveExtensions = handler.Extensions;
+            if (preserveExistingCustomExtensions) {
+                var preserved = new List<string>(handler.Extensions.Count);
+                foreach (string extension in handler.Extensions) {
+                    if (_handlerIdByExtension.TryGetValue(extension, out string? existing) &&
+                        !string.Equals(existing, handler.Id, StringComparison.OrdinalIgnoreCase)) {
+                        continue;
+                    }
+
+                    preserved.Add(extension);
+                }
+
+                if (preserved.Count == 0) {
+                    return Array.Empty<string>();
+                }
+
+                effectiveExtensions = preserved.ToArray();
+                handler = handler.WithExtensions(effectiveExtensions);
+            }
+
+            if (!replaceExisting) {
+                ValidateNoConflicts(handler.Id, effectiveExtensions);
+            } else {
+                RemoveConflicts(handler.Id, handler.Extensions, preserveExistingCustomExtensions);
+            }
+
+            _handlersById[handler.Id] = handler;
+            foreach (string extension in handler.Extensions) {
+                _handlerIdByExtension[extension] = handler.Id;
+            }
+
+            return handler.Extensions.ToArray();
+        }
+    }
+
+    public bool Unregister(string handlerId) {
+        if (string.IsNullOrWhiteSpace(handlerId)) {
+            return false;
+        }
+
+        lock (_sync) {
+            return RemoveUnsafe(handlerId.Trim());
+        }
+    }
+
+    public ReaderHandlerRegistrySnapshot CaptureSnapshot() {
+        lock (_sync) {
+            return new ReaderHandlerRegistrySnapshot(
+                new Dictionary<string, ReaderHandlerDescriptor>(_handlersById, StringComparer.OrdinalIgnoreCase),
+                new Dictionary<string, string>(_handlerIdByExtension, StringComparer.OrdinalIgnoreCase));
+        }
+    }
+
+    private void ValidateNoConflicts(string handlerId, IReadOnlyList<string> extensions) {
+        if (_handlersById.ContainsKey(handlerId)) {
+            throw new InvalidOperationException($"Handler '{handlerId}' is already registered.");
+        }
+
+        foreach (string extension in extensions) {
+            if (_builtInExtensions.Contains(extension)) {
+                throw new InvalidOperationException($"Extension '{extension}' is handled by a built-in reader. Use replaceExisting=true to override.");
+            }
+
+            if (_handlerIdByExtension.ContainsKey(extension)) {
+                throw new InvalidOperationException($"Extension '{extension}' is already handled by a custom reader.");
+            }
+        }
+    }
+
+    private void RemoveConflicts(string handlerId, IReadOnlyList<string> extensions, bool preserveExistingCustomExtensions) {
+        var toRemove = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (_handlersById.ContainsKey(handlerId)) {
+            toRemove.Add(handlerId);
+        }
+
+        foreach (string extension in extensions) {
+            if (preserveExistingCustomExtensions &&
+                _handlerIdByExtension.TryGetValue(extension, out string? preservedHandlerId) &&
+                !string.Equals(preservedHandlerId, handlerId, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            if (_handlerIdByExtension.TryGetValue(extension, out string? existingHandlerId)) {
+                toRemove.Add(existingHandlerId);
+            }
+        }
+
+        foreach (string existingHandlerId in toRemove) {
+            RemoveUnsafe(existingHandlerId);
+        }
+    }
+
+    private bool RemoveUnsafe(string handlerId) {
+        if (!_handlersById.TryGetValue(handlerId, out ReaderHandlerDescriptor? existing)) {
+            return false;
+        }
+
+        _handlersById.Remove(handlerId);
+        foreach (string extension in existing.Extensions) {
+            if (_handlerIdByExtension.TryGetValue(extension, out string? current) &&
+                string.Equals(current, handlerId, StringComparison.OrdinalIgnoreCase)) {
+                _handlerIdByExtension.Remove(extension);
+            }
+        }
+
+        return true;
+    }
+}
+
+internal sealed class ReaderHandlerRegistrySnapshot {
+    private readonly IReadOnlyDictionary<string, ReaderHandlerDescriptor> _handlersById;
+    private readonly IReadOnlyDictionary<string, string> _handlerIdByExtension;
+
+    public ReaderHandlerRegistrySnapshot(
+        IReadOnlyDictionary<string, ReaderHandlerDescriptor> handlersById,
+        IReadOnlyDictionary<string, string> handlerIdByExtension) {
+        _handlersById = handlersById;
+        _handlerIdByExtension = handlerIdByExtension;
+    }
+
+    public IReadOnlyList<ReaderHandlerDescriptor> Handlers => _handlersById.Values
+        .OrderBy(static handler => handler.Id, StringComparer.Ordinal)
+        .ToArray();
+
+    public IReadOnlyList<string> Extensions => _handlerIdByExtension.Keys
+        .OrderBy(static extension => extension, StringComparer.Ordinal)
+        .ToArray();
+
+    public bool TryResolve(string extension, out ReaderHandlerDescriptor handler) {
+        handler = null!;
+        if (string.IsNullOrWhiteSpace(extension) ||
+            !_handlerIdByExtension.TryGetValue(extension, out string? handlerId) ||
+            !_handlersById.TryGetValue(handlerId, out ReaderHandlerDescriptor? resolved)) {
+            return false;
+        }
+
+        handler = resolved;
+        return true;
+    }
+}
+
+internal sealed class ReaderHandlerDescriptor {
+    private ReaderHandlerDescriptor(
+        string id,
+        string displayName,
+        string? description,
+        ReaderInputKind kind,
+        IReadOnlyList<string> extensions,
+        long? defaultMaxInputBytes,
+        ReaderWarningBehavior warningBehavior,
+        bool deterministicOutput,
+        Func<string, ReaderOptions, CancellationToken, IEnumerable<ReaderChunk>>? readPath,
+        Func<Stream, string?, ReaderOptions, CancellationToken, IEnumerable<ReaderChunk>>? readStream,
+        Func<string, ReaderOptions, CancellationToken, OfficeDocumentReadResult>? readDocumentPath,
+        Func<Stream, string?, ReaderOptions, CancellationToken, OfficeDocumentReadResult>? readDocumentStream) {
+        Id = id;
+        DisplayName = displayName;
+        Description = description;
+        Kind = kind;
+        Extensions = extensions;
+        DefaultMaxInputBytes = defaultMaxInputBytes;
+        WarningBehavior = warningBehavior;
+        DeterministicOutput = deterministicOutput;
+        ReadPath = readPath;
+        ReadStream = readStream;
+        ReadDocumentPath = readDocumentPath;
+        ReadDocumentStream = readDocumentStream;
+    }
+
+    public string Id { get; }
+    public string DisplayName { get; }
+    public string? Description { get; }
+    public ReaderInputKind Kind { get; }
+    public IReadOnlyList<string> Extensions { get; }
+    public long? DefaultMaxInputBytes { get; }
+    public ReaderWarningBehavior WarningBehavior { get; }
+    public bool DeterministicOutput { get; }
+    public Func<string, ReaderOptions, CancellationToken, IEnumerable<ReaderChunk>>? ReadPath { get; }
+    public Func<Stream, string?, ReaderOptions, CancellationToken, IEnumerable<ReaderChunk>>? ReadStream { get; }
+    public Func<string, ReaderOptions, CancellationToken, OfficeDocumentReadResult>? ReadDocumentPath { get; }
+    public Func<Stream, string?, ReaderOptions, CancellationToken, OfficeDocumentReadResult>? ReadDocumentStream { get; }
+
+    public static ReaderHandlerDescriptor Create(ReaderHandlerRegistration registration) {
+        if (registration == null) throw new ArgumentNullException(nameof(registration));
+
+        string id = (registration.Id ?? string.Empty).Trim();
+        if (id.Length == 0) throw new ArgumentException("Handler Id cannot be empty.", nameof(registration));
+        if (registration.ReadPath == null &&
+            registration.ReadStream == null &&
+            registration.ReadDocumentPath == null &&
+            registration.ReadDocumentStream == null) {
+            throw new ArgumentException(
+                "Handler must define a chunk reader or rich document reader for paths and/or streams.",
+                nameof(registration));
+        }
+
+        if (registration.DefaultMaxInputBytes.HasValue && registration.DefaultMaxInputBytes.Value < 1) {
+            throw new ArgumentException("DefaultMaxInputBytes must be greater than 0 when specified.", nameof(registration));
+        }
+
+        IReadOnlyList<string> extensions = NormalizeExtensions(registration.Extensions);
+        if (extensions.Count == 0) {
+            throw new ArgumentException("Handler must define at least one extension.", nameof(registration));
+        }
+
+        return new ReaderHandlerDescriptor(
+            id,
+            string.IsNullOrWhiteSpace(registration.DisplayName) ? id : registration.DisplayName!.Trim(),
+            registration.Description,
+            registration.Kind,
+            extensions,
+            registration.DefaultMaxInputBytes,
+            registration.WarningBehavior,
+            registration.DeterministicOutput,
+            registration.ReadPath,
+            registration.ReadStream,
+            registration.ReadDocumentPath,
+            registration.ReadDocumentStream);
+    }
+
+    public ReaderHandlerDescriptor WithExtensions(IReadOnlyList<string> extensions) {
+        return new ReaderHandlerDescriptor(
+            Id,
+            DisplayName,
+            Description,
+            Kind,
+            extensions.ToArray(),
+            DefaultMaxInputBytes,
+            WarningBehavior,
+            DeterministicOutput,
+            ReadPath,
+            ReadStream,
+            ReadDocumentPath,
+            ReadDocumentStream);
+    }
+
+    public ReaderHandlerCapability ToCapability() {
+        return new ReaderHandlerCapability {
+            Id = Id,
+            DisplayName = DisplayName,
+            Description = Description,
+            Kind = Kind,
+            Extensions = Extensions.ToArray(),
+            IsBuiltIn = false,
+            SupportsPath = ReadPath != null || ReadDocumentPath != null,
+            SupportsStream = ReadStream != null || ReadDocumentStream != null,
+            SupportsDocumentPath = ReadDocumentPath != null,
+            SupportsDocumentStream = ReadDocumentStream != null,
+            SchemaId = ReaderCapabilitySchema.Id,
+            SchemaVersion = ReaderCapabilitySchema.Version,
+            DefaultMaxInputBytes = DefaultMaxInputBytes,
+            WarningBehavior = WarningBehavior,
+            DeterministicOutput = DeterministicOutput
+        };
+    }
+
+    private static IReadOnlyList<string> NormalizeExtensions(IReadOnlyList<string>? extensions) {
+        var normalized = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (extensions != null) {
+            foreach (string extension in extensions) {
+                string value = DocumentReader.NormalizeExtension(extension);
+                if (value.Length > 0) {
+                    normalized.Add(value);
+                }
+            }
+        }
+
+        return normalized.OrderBy(static extension => extension, StringComparer.Ordinal).ToArray();
+    }
+}

--- a/OfficeIMO.Reader/ReaderHandlerScopedEnumerable.cs
+++ b/OfficeIMO.Reader/ReaderHandlerScopedEnumerable.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace OfficeIMO.Reader;
+
+internal sealed class ReaderHandlerScopedEnumerable<T> : IEnumerable<T> {
+    private readonly ReaderHandlerRegistrySnapshot _handlers;
+    private readonly IEnumerable<T> _source;
+
+    public ReaderHandlerScopedEnumerable(ReaderHandlerRegistrySnapshot handlers, IEnumerable<T> source) {
+        _handlers = handlers ?? throw new ArgumentNullException(nameof(handlers));
+        _source = source ?? throw new ArgumentNullException(nameof(source));
+    }
+
+    public IEnumerator<T> GetEnumerator() {
+        using (DocumentReader.UseHandlerRegistry(_handlers)) {
+            return new ReaderHandlerScopedEnumerator<T>(_handlers, _source.GetEnumerator());
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() {
+        return GetEnumerator();
+    }
+}
+
+internal sealed class ReaderHandlerScopedEnumerator<T> : IEnumerator<T> {
+    private readonly ReaderHandlerRegistrySnapshot _handlers;
+    private readonly IEnumerator<T> _inner;
+
+    public ReaderHandlerScopedEnumerator(ReaderHandlerRegistrySnapshot handlers, IEnumerator<T> inner) {
+        _handlers = handlers ?? throw new ArgumentNullException(nameof(handlers));
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+    }
+
+    public T Current {
+        get {
+            using (DocumentReader.UseHandlerRegistry(_handlers)) {
+                return _inner.Current;
+            }
+        }
+    }
+
+    object IEnumerator.Current => Current!;
+
+    public bool MoveNext() {
+        using (DocumentReader.UseHandlerRegistry(_handlers)) {
+            return _inner.MoveNext();
+        }
+    }
+
+    public void Reset() {
+        using (DocumentReader.UseHandlerRegistry(_handlers)) {
+            _inner.Reset();
+        }
+    }
+
+    public void Dispose() {
+        using (DocumentReader.UseHandlerRegistry(_handlers)) {
+            _inner.Dispose();
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -223,10 +223,12 @@ using OfficeIMO.Reader;
 using OfficeIMO.Reader.Pdf;
 using OfficeIMO.Reader.Zip;
 
-DocumentReaderPdfRegistrationExtensions.RegisterPdfHandler();
-DocumentReaderZipRegistrationExtensions.RegisterZipHandler();
+OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+    .AddPdfHandler()
+    .AddZipHandler()
+    .Build();
 
-var chunks = DocumentReader.ReadFolder("KnowledgeBase",
+var chunks = reader.ReadFolder("KnowledgeBase",
     new ReaderFolderOptions {
         Recurse = true,
         MaxFiles = 500,


### PR DESCRIPTION
## Summary

- add instance-scoped `OfficeDocumentReader`, builder, and handler registry APIs
- snapshot registrations and options so one reader cannot leak configuration into another
- let modular adapters register against an explicit instance registry
- retain the static `DocumentReader` facade as the compatible default reader
- keep lazy enumerations bound to the registry snapshot that created them

## Why it matters

Hosts can now run different Reader configurations side by side without process-wide mutable registration state.

## Validation

Focused instance-isolation and modular-adapter contracts pass with the full Reader suite on .NET 8 and .NET 10.

## Review order

This is slice 2 of the stacked Reader maturity series and is based on `codex/reader-maturity-foundation`.

## Stack links

Slice 2 of 9. Previous: [#2046](https://github.com/EvotecIT/OfficeIMO/pull/2046) · Next: [#2048](https://github.com/EvotecIT/OfficeIMO/pull/2048)