### PR TITLE
Add deterministic Reader processing and extraction

### DIFF
--- a/Docs/officeimo.document-intelligence-roadmap.md
+++ b/Docs/officeimo.document-intelligence-roadmap.md
@@ -163,6 +163,9 @@ This branch starts the shared model and adapter path:
 - `OfficeDocumentReaderBuilder` and `OfficeDocumentReader` provide instance-scoped handler routing, capability manifests, file/stream/byte reads, and folder ingestion. Every modular Reader adapter exposes a matching `Add...Handler()` builder extension, while the static registry remains backward compatible.
 - Reader registrations can expose native asynchronous rich-result delegates. `ReadAsync(...)` and `ReadDocumentAsync(...)` await those delegates directly, non-seekable inputs use an asynchronous bounded snapshot, and synchronous format engines use a bounded worker fallback. `ReadDocumentsAsync(...)` adds deterministic multi-file execution with explicit concurrency and document-count limits.
 - Reader detection now reports extension kind, content kind, confidence, media type, bounded evidence, and mismatch state. Reads preserve known-extension behavior by default, can prefer content for mislabeled inputs, and can route unknown extensions to a unique registered handler by detected kind. Generic and native rich results expose detection, parsing, limit, truncation, unsupported-content, read, and OCR findings through structured diagnostics instead of warning strings alone.
+- Reader instances can freeze an ordered processor pipeline with explicit throw, continue-with-diagnostic, or stop-with-diagnostic failure policy. Sync and async document, chunk, JSON, structured, and bounded batch reads use the same configured pipeline; folder chunk enumeration remains unchanged.
+- Opt-in shared-model processors now normalize blocks, list and heading levels, tables, and links; classify repeated page-boundary artifacts; and filter assets together with dependent OCR candidates. Hosts can add typed sync or async processors without adding format-specific behavior to the facade.
+- Bounded structured extraction now exposes metadata, forms, key/value and Path/Type/Value rows, Visio Shape Data, heading sections, named tables, chart summaries, quality/readiness summaries, and source diagnostics through a deterministic non-generic result and JSON serializer.
 - Document-level metadata entries now carry stable catalog, outline, destination, open-action, viewer-preference, and form-summary facts without making the shared Reader model depend on PDF-specific types.
 - PDF source preflight capability flags now flow into metadata, and read/rewrite blockers flow into shared diagnostics as stable `pdf-read-blocker` and `pdf-rewrite-blocker` entries for file and stream readback.
 - OCR readiness is represented as `OcrCandidates` plus `ocr-needed` diagnostics for image-only PDF pages and embedded Office image assets, without adding an OCR engine or service dependency to the core.
@@ -288,34 +291,20 @@ Goal: align HTML, Markdown, Word, PDF, and Reader output into one portable docum
 
 Goal: deterministic cleanup and enrichment across formats.
 
-- Add typed processors over the shared model:
-  - header/footer/artifact classification;
-  - table cleanup;
-  - list cleanup;
-  - heading normalization;
-  - link normalization;
-  - form/key-value extraction;
-  - asset filtering;
-  - diagram shape/connector enrichment;
-  - host custom processors.
-- Keep processors ordered, deterministic, diagnosable, and testable.
-- Reuse the `OfficeIMO.Markdown` transform pattern where it fits.
+- The ordered immutable pipeline, sync/async processor contract, step evidence, cancellation, and explicit failure policies are implemented.
+- Opt-in processors cover header/footer/artifact classification, table cleanup, list and heading normalization, link normalization, and asset/OCR-candidate filtering.
+- Host custom processors are supported through a typed interface, base class, or delegates. Instances used by a shared reader must be safe for concurrent calls.
+- Form/key-value projection is available through structured extraction rather than a mutating cleanup step.
+- Diagram shape/connector enrichment remains adapter-owned work for the Visio fidelity track.
 
 ### P9 - Structured Extraction
 
 Goal: expose schema-friendly extraction without making the core depend on AI services.
 
-- Add deterministic extraction helpers for:
-  - key-value rows;
-  - headings and following paragraphs;
-  - named tables;
-  - form fields;
-  - shape data;
-  - document metadata;
-  - chart data summaries;
-  - visual quality and compliance-readiness summaries.
-- Add `ExtractStructured<T>()` only after the non-generic model is stable.
-- Add optional host-supplied model interfaces later, but keep cloud/client SDKs out of the core packages.
+- The bounded non-generic extractor covers key/value and Path/Type/Value rows, headings and following paragraphs, named tables, forms, Visio Shape Data, metadata, chart summaries, visual/table quality, chunk readiness, and security/OCR/limit diagnostics.
+- Schema-friendly JSON serialization is available with an independent schema id/version. The stable rich transport remains `OfficeDocumentReadResult` version 5.
+- `ExtractStructured<T>()` remains deferred until the non-generic contract has downstream use and compatibility evidence.
+- Optional host-supplied model interfaces remain later work; cloud and client SDKs stay out of the core package.
 
 ### P10 - OCR-Ready Core
 

--- a/OfficeIMO.Reader.Tests/Reader.ProcessorPipeline.cs
+++ b/OfficeIMO.Reader.Tests/Reader.ProcessorPipeline.cs
@@ -89,6 +89,42 @@ public sealed class ReaderProcessorPipelineTests {
     }
 
     [Fact]
+    public void Pipeline_ContinuePolicyRetainsFailureDiagnosticWhenLaterStepReplacesDocument() {
+        OfficeDocumentProcessorPipeline pipeline = new OfficeDocumentProcessorPipelineBuilder()
+            .Add(Failing("broken"))
+            .Add(new DelegateOfficeDocumentProcessor("replace", (_, _) => new OfficeDocumentReadResult()))
+            .Build();
+
+        OfficeDocumentProcessingResult result = pipeline.Process(
+            new OfficeDocumentReadResult(),
+            new OfficeDocumentProcessingOptions {
+                FailureBehavior = OfficeDocumentProcessorFailureBehavior.ContinueWithDiagnostic
+            });
+
+        OfficeDocumentDiagnostic diagnostic = Assert.Single(result.Document.Diagnostics);
+        Assert.Equal("processor-failed", diagnostic.Code);
+        Assert.Equal("broken", diagnostic.Attributes["processorId"]);
+    }
+
+    [Fact]
+    public async Task Pipeline_ContinuePolicyRetainsFailureDiagnosticWhenAsyncStepReplacesDocument() {
+        OfficeDocumentProcessorPipeline pipeline = new OfficeDocumentProcessorPipelineBuilder()
+            .Add(Failing("broken"))
+            .Add(new DelegateOfficeDocumentProcessor("replace", (_, _) => new OfficeDocumentReadResult()))
+            .Build();
+
+        OfficeDocumentProcessingResult result = await pipeline.ProcessAsync(
+            new OfficeDocumentReadResult(),
+            new OfficeDocumentProcessingOptions {
+                FailureBehavior = OfficeDocumentProcessorFailureBehavior.ContinueWithDiagnostic
+            });
+
+        OfficeDocumentDiagnostic diagnostic = Assert.Single(result.Document.Diagnostics);
+        Assert.Equal("processor-failed", diagnostic.Code);
+        Assert.Equal("broken", diagnostic.Attributes["processorId"]);
+    }
+
+    [Fact]
     public void Pipeline_StopPolicyMarksLaterStepsSkipped() {
         bool laterRan = false;
         OfficeDocumentProcessorPipeline pipeline = new OfficeDocumentProcessorPipelineBuilder()
@@ -149,6 +185,35 @@ public sealed class ReaderProcessorPipelineTests {
 
         using JsonDocument json = JsonDocument.Parse(first.ReadDocumentJson(markdown, "note.md"));
         Assert.Equal("Applied", json.RootElement.GetProperty("metadata")[0].GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public async Task InstanceReader_RefreshesProcessorReplacementChunkMetadata() {
+        const string processedText = "processor replacement body";
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+            .AddProcessor(new DelegateOfficeDocumentProcessor("replace-chunk", (document, _) => {
+                return new OfficeDocumentReadResult {
+                    Chunks = new[] {
+                        new ReaderChunk {
+                            Id = "replacement",
+                            Kind = ReaderInputKind.Markdown,
+                            Text = processedText,
+                            SourceId = "stale-source",
+                            SourceHash = "stale-source-hash",
+                            ChunkHash = "stale-chunk-hash",
+                            TokenEstimate = 999
+                        }
+                    }
+                };
+            }))
+            .Build();
+        byte[] markdown = Encoding.UTF8.GetBytes("Original body");
+
+        OfficeDocumentReadResult sync = reader.ReadDocument(markdown, "note.md");
+        OfficeDocumentReadResult asyncResult = await reader.ReadDocumentAsync(markdown, "note.md");
+
+        AssertRefreshedChunk(sync, processedText);
+        AssertRefreshedChunk(asyncResult, processedText);
     }
 
     [Fact]
@@ -265,6 +330,15 @@ public sealed class ReaderProcessorPipelineTests {
 
     private static IOfficeDocumentProcessor Failing(string id) =>
         new DelegateOfficeDocumentProcessor(id, (_, _) => throw new FormatException("bad input"));
+
+    private static void AssertRefreshedChunk(OfficeDocumentReadResult document, string expectedText) {
+        ReaderChunk chunk = Assert.Single(document.Chunks);
+        Assert.Equal(document.Source.SourceId, chunk.SourceId);
+        Assert.Equal(document.Source.SourceHash, chunk.SourceHash);
+        Assert.Equal((expectedText.Length + 3) / 4, chunk.TokenEstimate);
+        Assert.NotEqual("stale-chunk-hash", chunk.ChunkHash);
+        Assert.Equal(64, chunk.ChunkHash?.Length);
+    }
 
     private sealed class InvalidIdProcessor : IOfficeDocumentProcessor {
         public string Id => " invalid ";

--- a/OfficeIMO.Reader.Tests/Reader.ProcessorPipeline.cs
+++ b/OfficeIMO.Reader.Tests/Reader.ProcessorPipeline.cs
@@ -245,8 +245,12 @@ public sealed class ReaderProcessorPipelineTests {
             Links = new[] { link },
             Assets = new[] { kept, removed },
             OcrCandidates = new[] {
-                new OfficeDocumentOcrCandidate { Id = "keep-ocr", AssetId = "keep" },
-                new OfficeDocumentOcrCandidate { Id = "drop-ocr", AssetId = "drop" }
+                new OfficeDocumentOcrCandidate { Id = "keep-ocr", AssetId = "keep", Reason = "Keep OCR", Location = new ReaderLocation { BlockAnchor = "keep" } },
+                new OfficeDocumentOcrCandidate { Id = "drop-ocr", AssetId = "drop", Reason = "Drop OCR", Location = new ReaderLocation { BlockAnchor = "drop" } }
+            },
+            Diagnostics = new[] {
+                new OfficeDocumentDiagnostic { Code = "ocr-needed", Message = "Keep OCR", Location = new ReaderLocation { BlockAnchor = "keep" } },
+                new OfficeDocumentDiagnostic { Code = "ocr-needed", Message = "Drop OCR", Location = new ReaderLocation { BlockAnchor = "drop" } }
             }
         };
         OfficeDocumentProcessorPipeline pipeline = new OfficeDocumentProcessorPipelineBuilder()
@@ -268,6 +272,9 @@ public sealed class ReaderProcessorPipelineTests {
         Assert.Equal("https://example.test", link.Uri);
         Assert.Equal("keep", Assert.Single(result.Assets).Id);
         Assert.Equal("keep-ocr", Assert.Single(result.OcrCandidates).Id);
+        OfficeDocumentDiagnostic ocrDiagnostic = Assert.Single(result.Diagnostics, diagnostic => diagnostic.Code == "ocr-needed");
+        Assert.Equal("Keep OCR", ocrDiagnostic.Message);
+        Assert.Equal("keep", ocrDiagnostic.Location!.BlockAnchor);
     }
 
     [Fact]

--- a/OfficeIMO.Reader.Tests/Reader.ProcessorPipeline.cs
+++ b/OfficeIMO.Reader.Tests/Reader.ProcessorPipeline.cs
@@ -250,6 +250,25 @@ public sealed class ReaderProcessorPipelineTests {
     }
 
     [Fact]
+    public void InstanceReader_RebuildsChunkDerivedAggregatesAfterTextProcessing() {
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+            .AddProcessor(new DelegateOfficeDocumentProcessor("redact", (document, _) => {
+                foreach (ReaderChunk chunk in document.Chunks) chunk.Text = "[redacted]";
+                return document;
+            }))
+            .Build();
+        byte[] source = Encoding.UTF8.GetBytes("# Secret\n\nSensitive body");
+
+        OfficeDocumentReadResult document = reader.ReadDocument(source, "secret.md");
+
+        Assert.Equal("[redacted]", document.Markdown);
+        Assert.All(document.Blocks, block => Assert.Equal("[redacted]", block.Text));
+        string json = reader.ReadDocumentJson(source, "secret.md");
+        Assert.Contains("[redacted]", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("Sensitive body", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void BuiltInProcessorsNormalizeAndFilterSharedModels() {
         var kept = new OfficeDocumentAsset { Id = "keep", Kind = "image", LengthBytes = 10 };
         var removed = new OfficeDocumentAsset { Id = "drop", Kind = "preview", LengthBytes = 1000 };
@@ -325,6 +344,45 @@ public sealed class ReaderProcessorPipelineTests {
         Assert.Empty(Assert.Single(document.Pages).Assets);
         Assert.Equal("shared-ocr", Assert.Single(document.OcrCandidates).Id);
         Assert.Equal("ocr-needed", Assert.Single(document.Diagnostics).Code);
+    }
+
+    [Fact]
+    public void AssetFilter_PreservesUnrelatedOcrDiagnosticsWithoutCandidates() {
+        var document = new OfficeDocumentReadResult {
+            Assets = new[] { new OfficeDocumentAsset { Id = "drop", LengthBytes = 1000 } },
+            OcrCandidates = new[] {
+                new OfficeDocumentOcrCandidate {
+                    Id = "drop-ocr",
+                    AssetId = "drop",
+                    Reason = "Removed image OCR",
+                    Location = new ReaderLocation { BlockAnchor = "drop" }
+                }
+            },
+            Diagnostics = new[] {
+                new OfficeDocumentDiagnostic {
+                    Code = "ocr-needed",
+                    Message = "Removed image OCR",
+                    Location = new ReaderLocation { BlockAnchor = "drop" }
+                },
+                new OfficeDocumentDiagnostic {
+                    Code = "ocr-needed",
+                    Message = "Page-level OCR remains required",
+                    Location = new ReaderLocation { Page = 9 },
+                    Attributes = new Dictionary<string, string> { ["providerEvidence"] = "adapter-owned" }
+                }
+            }
+        };
+
+        new OfficeDocumentProcessorPipelineBuilder()
+            .Add(new OfficeDocumentAssetFilterProcessor(asset => asset.LengthBytes <= 100))
+            .Build()
+            .Process(document);
+
+        Assert.Empty(document.Assets);
+        Assert.Empty(document.OcrCandidates);
+        OfficeDocumentDiagnostic remaining = Assert.Single(document.Diagnostics);
+        Assert.Equal("Page-level OCR remains required", remaining.Message);
+        Assert.Equal("adapter-owned", remaining.Attributes["providerEvidence"]);
     }
 
     [Fact]

--- a/OfficeIMO.Reader.Tests/Reader.ProcessorPipeline.cs
+++ b/OfficeIMO.Reader.Tests/Reader.ProcessorPipeline.cs
@@ -283,6 +283,7 @@ public sealed class ReaderProcessorPipelineTests {
             Tables = new[] { table },
             Links = new[] { link },
             Assets = new[] { kept, removed },
+            Metadata = new[] { new OfficeDocumentMetadataEntry { Id = "reader-asset-count", Value = "2", ValueType = "count" } },
             OcrCandidates = new[] {
                 new OfficeDocumentOcrCandidate { Id = "keep-ocr", AssetId = "keep", Reason = "Keep OCR", Location = new ReaderLocation { BlockAnchor = "keep" } },
                 new OfficeDocumentOcrCandidate { Id = "drop-ocr", AssetId = "drop", Reason = "Drop OCR", Location = new ReaderLocation { BlockAnchor = "drop" } }
@@ -310,10 +311,68 @@ public sealed class ReaderProcessorPipelineTests {
         Assert.Equal("uri", link.Kind);
         Assert.Equal("https://example.test", link.Uri);
         Assert.Equal("keep", Assert.Single(result.Assets).Id);
+        Assert.Equal("1", Assert.Single(result.Metadata, metadata => metadata.Id == "reader-asset-count").Value);
         Assert.Equal("keep-ocr", Assert.Single(result.OcrCandidates).Id);
         OfficeDocumentDiagnostic ocrDiagnostic = Assert.Single(result.Diagnostics, diagnostic => diagnostic.Code == "ocr-needed");
         Assert.Equal("Keep OCR", ocrDiagnostic.Message);
         Assert.Equal("keep", ocrDiagnostic.Location!.BlockAnchor);
+    }
+
+    [Fact]
+    public void TableNormalization_UpdatesAggregateAndChunkTableInstances() {
+        var aggregate = new ReaderTable {
+            Columns = new[] { " Key " },
+            Rows = new[] { (IReadOnlyList<string>)new[] { " Value ", " Extra " } }
+        };
+        var chunkTable = new ReaderTable {
+            Columns = new[] { " Key " },
+            Rows = new[] { (IReadOnlyList<string>)new[] { " Value ", " Extra " } }
+        };
+        var document = new OfficeDocumentReadResult {
+            Tables = new[] { aggregate },
+            Chunks = new[] { new ReaderChunk { Tables = new[] { chunkTable } } }
+        };
+
+        new OfficeDocumentProcessorPipelineBuilder()
+            .Add(new OfficeDocumentTableNormalizationProcessor())
+            .Build()
+            .Process(document);
+
+        Assert.Equal(new[] { "Key", "Column2" }, aggregate.Columns);
+        Assert.Equal(new[] { "Key", "Column2" }, chunkTable.Columns);
+        Assert.Equal(new[] { "Value", "Extra" }, Assert.Single(chunkTable.Rows));
+    }
+
+    [Fact]
+    public void StructuredExtraction_UsesPageLocationFallbackAndDeduplicatesPageTableClone() {
+        var aggregate = new ReaderTable {
+            Title = "Settings",
+            Location = new ReaderLocation { Path = "settings.pdf", Page = 7, TableIndex = 0 },
+            Columns = new[] { "Key", "Value" },
+            Rows = new[] { (IReadOnlyList<string>)new[] { "Mode", "Safe" } }
+        };
+        var pageTable = new ReaderTable {
+            Title = aggregate.Title,
+            Columns = aggregate.Columns,
+            Rows = aggregate.Rows
+        };
+        var document = new OfficeDocumentReadResult {
+            Tables = new[] { aggregate },
+            Pages = new[] {
+                new OfficeDocumentPage {
+                    Number = 7,
+                    Location = new ReaderLocation { Path = "settings.pdf" },
+                    Tables = new[] { pageTable }
+                }
+            }
+        };
+
+        OfficeDocumentStructuredExtractionResult extracted = OfficeDocumentStructuredExtractor.Extract(document);
+
+        Assert.Single(extracted.Records, record => record.Category == "key-value");
+        ReaderTable selected = Assert.Single(extracted.Tables);
+        Assert.Equal(7, selected.Location!.Page);
+        Assert.Equal("settings.pdf", selected.Location.Path);
     }
 
     [Fact]

--- a/OfficeIMO.Reader.Tests/Reader.ProcessorPipeline.cs
+++ b/OfficeIMO.Reader.Tests/Reader.ProcessorPipeline.cs
@@ -230,6 +230,26 @@ public sealed class ReaderProcessorPipelineTests {
     }
 
     [Fact]
+    public void InstanceReader_PreservesProcessorChunkHashWhenHashComputationIsDisabled() {
+        const string suppliedHash = "processor-owned-hash";
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+            .AddProcessor(new DelegateOfficeDocumentProcessor("supply-hash", (document, _) => {
+                document.Chunks = new[] {
+                    new ReaderChunk { Id = "replacement", Text = "processed", ChunkHash = suppliedHash }
+                };
+                return document;
+            }))
+            .Build();
+
+        ReaderChunk chunk = Assert.Single(reader.Read(
+            Encoding.UTF8.GetBytes("Original body"),
+            "note.md",
+            new ReaderOptions { ComputeHashes = false }));
+
+        Assert.Equal(suppliedHash, chunk.ChunkHash);
+    }
+
+    [Fact]
     public void BuiltInProcessorsNormalizeAndFilterSharedModels() {
         var kept = new OfficeDocumentAsset { Id = "keep", Kind = "image", LengthBytes = 10 };
         var removed = new OfficeDocumentAsset { Id = "drop", Kind = "preview", LengthBytes = 1000 };
@@ -275,6 +295,53 @@ public sealed class ReaderProcessorPipelineTests {
         OfficeDocumentDiagnostic ocrDiagnostic = Assert.Single(result.Diagnostics, diagnostic => diagnostic.Code == "ocr-needed");
         Assert.Equal("Keep OCR", ocrDiagnostic.Message);
         Assert.Equal("keep", ocrDiagnostic.Location!.BlockAnchor);
+    }
+
+    [Fact]
+    public void AssetFilter_KeepsOcrForAnAssetIdThatSurvivesInAnotherScope() {
+        var document = new OfficeDocumentReadResult {
+            Assets = new[] {
+                new OfficeDocumentAsset { Id = "shared", LengthBytes = 10 }
+            },
+            Pages = new[] {
+                new OfficeDocumentPage {
+                    Assets = new[] { new OfficeDocumentAsset { Id = "shared", LengthBytes = null } }
+                }
+            },
+            OcrCandidates = new[] {
+                new OfficeDocumentOcrCandidate { Id = "shared-ocr", AssetId = "shared" }
+            },
+            Diagnostics = new[] {
+                new OfficeDocumentDiagnostic { Code = "ocr-needed", Message = "OCR shared asset" }
+            }
+        };
+
+        new OfficeDocumentProcessorPipelineBuilder()
+            .Add(new OfficeDocumentAssetFilterProcessor(asset => asset.LengthBytes.HasValue))
+            .Build()
+            .Process(document);
+
+        Assert.Equal("shared", Assert.Single(document.Assets).Id);
+        Assert.Empty(Assert.Single(document.Pages).Assets);
+        Assert.Equal("shared-ocr", Assert.Single(document.OcrCandidates).Id);
+        Assert.Equal("ocr-needed", Assert.Single(document.Diagnostics).Code);
+    }
+
+    [Fact]
+    public void BlockNormalization_AllowsNullKindWhenKindNormalizationIsDisabled() {
+        var block = new OfficeDocumentBlock { Kind = null!, Level = 3 };
+        var document = new OfficeDocumentReadResult { Blocks = new[] { block } };
+        new OfficeDocumentProcessorPipelineBuilder()
+            .Add(new OfficeDocumentBlockNormalizationProcessor(
+                new OfficeDocumentBlockNormalizationOptions {
+                    NormalizeKinds = false,
+                    NormalizeLevels = true
+                }))
+            .Build()
+            .Process(document);
+
+        Assert.Null(block.Kind);
+        Assert.Equal(3, block.Level);
     }
 
     [Fact]

--- a/OfficeIMO.Reader.Tests/Reader.ProcessorPipeline.cs
+++ b/OfficeIMO.Reader.Tests/Reader.ProcessorPipeline.cs
@@ -1,0 +1,280 @@
+using OfficeIMO.Reader;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class ReaderProcessorPipelineTests {
+    [Fact]
+    public void PipelineBuilder_FreezesOrderAndRejectsDuplicateIds() {
+        var builder = new OfficeDocumentProcessorPipelineBuilder()
+            .Add(PassThrough("first"));
+        OfficeDocumentProcessorPipeline firstSnapshot = builder.Build();
+
+        builder.Add(PassThrough("second"));
+        OfficeDocumentProcessorPipeline secondSnapshot = builder.Build();
+
+        Assert.Equal(new[] { "first" }, firstSnapshot.Processors.Select(processor => processor.Id));
+        Assert.Equal(new[] { "first", "second" }, secondSnapshot.Processors.Select(processor => processor.Id));
+        Assert.Throws<InvalidOperationException>(() => builder.Add(PassThrough("FIRST")));
+        Assert.Throws<ArgumentException>(() => builder.Add(new InvalidIdProcessor()));
+    }
+
+    [Fact]
+    public void Pipeline_ExecutesSynchronouslyInRegistrationOrder() {
+        var observed = new List<string>();
+        OfficeDocumentProcessorPipeline pipeline = new OfficeDocumentProcessorPipelineBuilder()
+            .Add(Recording("first", observed))
+            .Add(Recording("second", observed))
+            .Build();
+
+        OfficeDocumentProcessingResult result = pipeline.Process(new OfficeDocumentReadResult());
+
+        Assert.Equal(new[] { "first:0/2", "second:1/2" }, observed);
+        Assert.True(result.Succeeded);
+        Assert.Equal(new[] {
+            OfficeDocumentProcessorStepStatus.Completed,
+            OfficeDocumentProcessorStepStatus.Completed
+        }, result.Steps.Select(step => step.Status));
+    }
+
+    [Fact]
+    public async Task Pipeline_UsesExplicitAsyncProcessorsInOrder() {
+        var observed = new List<string>();
+        var processor = new DelegateOfficeDocumentProcessor(
+            "async",
+            (document, _) => throw new InvalidOperationException("Sync path should not run."),
+            async (document, context) => {
+                await Task.Yield();
+                observed.Add(context.ProcessorId);
+                document.Source.Title = "processed asynchronously";
+                return document;
+            });
+        OfficeDocumentProcessorPipeline pipeline = new OfficeDocumentProcessorPipelineBuilder().Add(processor).Build();
+
+        OfficeDocumentProcessingResult result = await pipeline.ProcessAsync(new OfficeDocumentReadResult());
+
+        Assert.Equal("async", Assert.Single(observed));
+        Assert.Equal("processed asynchronously", result.Document.Source.Title);
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void Pipeline_ContinuePolicyAddsDiagnosticAndRunsLaterSteps() {
+        bool laterRan = false;
+        OfficeDocumentProcessorPipeline pipeline = new OfficeDocumentProcessorPipelineBuilder()
+            .Add(Failing("broken"))
+            .Add(new DelegateOfficeDocumentProcessor("later", (document, _) => {
+                laterRan = true;
+                return document;
+            }))
+            .Build();
+
+        OfficeDocumentProcessingResult result = pipeline.Process(
+            new OfficeDocumentReadResult(),
+            new OfficeDocumentProcessingOptions {
+                FailureBehavior = OfficeDocumentProcessorFailureBehavior.ContinueWithDiagnostic
+            });
+
+        Assert.True(laterRan);
+        Assert.False(result.Succeeded);
+        Assert.Equal(OfficeDocumentProcessorStepStatus.Failed, result.Steps[0].Status);
+        Assert.Equal(OfficeDocumentProcessorStepStatus.Completed, result.Steps[1].Status);
+        OfficeDocumentDiagnostic diagnostic = Assert.Single(result.Document.Diagnostics);
+        Assert.Equal("processor-failed", diagnostic.Code);
+        Assert.Equal("broken", diagnostic.Attributes["processorId"]);
+        Assert.True(diagnostic.IsRecoverable == true);
+    }
+
+    [Fact]
+    public void Pipeline_StopPolicyMarksLaterStepsSkipped() {
+        bool laterRan = false;
+        OfficeDocumentProcessorPipeline pipeline = new OfficeDocumentProcessorPipelineBuilder()
+            .Add(Failing("broken"))
+            .Add(new DelegateOfficeDocumentProcessor("later", (document, _) => {
+                laterRan = true;
+                return document;
+            }))
+            .Build();
+
+        OfficeDocumentProcessingResult result = pipeline.Process(
+            new OfficeDocumentReadResult(),
+            new OfficeDocumentProcessingOptions {
+                FailureBehavior = OfficeDocumentProcessorFailureBehavior.StopWithDiagnostic
+            });
+
+        Assert.False(laterRan);
+        Assert.Equal(OfficeDocumentProcessorStepStatus.Failed, result.Steps[0].Status);
+        Assert.Equal(OfficeDocumentProcessorStepStatus.Skipped, result.Steps[1].Status);
+        Assert.True(Assert.Single(result.Document.Diagnostics).IsRecoverable == false);
+    }
+
+    [Fact]
+    public void Pipeline_ThrowPolicyWrapsProcessorIdentity() {
+        OfficeDocumentProcessorPipeline pipeline = new OfficeDocumentProcessorPipelineBuilder()
+            .Add(Failing("broken"))
+            .Build();
+
+        OfficeDocumentProcessorException exception = Assert.Throws<OfficeDocumentProcessorException>(
+            () => pipeline.Process(new OfficeDocumentReadResult()));
+
+        Assert.Equal("broken", exception.ProcessorId);
+        Assert.Equal(0, exception.ProcessorIndex);
+        Assert.IsType<FormatException>(exception.InnerException);
+    }
+
+    [Fact]
+    public async Task InstanceReader_AppliesFrozenPipelineToEveryDocumentSurface() {
+        byte[] markdown = Encoding.UTF8.GetBytes("# Title\n\nBody");
+        var builder = new OfficeDocumentReaderBuilder()
+            .AddProcessor(new DelegateOfficeDocumentProcessor("mark", (document, _) => {
+                foreach (ReaderChunk chunk in document.Chunks) chunk.Text = "processed:" + chunk.Text;
+                document.Metadata = new[] {
+                    new OfficeDocumentMetadataEntry { Id = "processor", Category = "processor", Name = "Applied", Value = "true" }
+                };
+                return document;
+            }));
+        OfficeDocumentReader first = builder.Build();
+        builder.AddProcessor(PassThrough("later"));
+        OfficeDocumentReader second = builder.Build();
+
+        Assert.Equal(1, first.ProcessorPipeline.Count);
+        Assert.Equal(2, second.ProcessorPipeline.Count);
+        Assert.StartsWith("processed:", Assert.Single(first.Read(markdown, "note.md")).Text, StringComparison.Ordinal);
+        Assert.StartsWith("processed:", Assert.Single(first.ReadDocument(markdown, "note.md").Chunks).Text, StringComparison.Ordinal);
+        Assert.StartsWith("processed:", Assert.Single(await first.ReadAsync(markdown, "note.md")).Text, StringComparison.Ordinal);
+        Assert.StartsWith("processed:", Assert.Single((await first.ReadDocumentAsync(markdown, "note.md")).Chunks).Text, StringComparison.Ordinal);
+
+        using JsonDocument json = JsonDocument.Parse(first.ReadDocumentJson(markdown, "note.md"));
+        Assert.Equal("Applied", json.RootElement.GetProperty("metadata")[0].GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public void InstanceReader_ProjectsNullProcessorChunksAsAnEmptyCollection() {
+        byte[] markdown = Encoding.UTF8.GetBytes("Body");
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+            .AddProcessor(new DelegateOfficeDocumentProcessor("clear-chunks", (document, _) => {
+                document.Chunks = null!;
+                return document;
+            }))
+            .Build();
+
+        Assert.Empty(reader.Read(markdown, "note.md"));
+    }
+
+    [Fact]
+    public void BuiltInProcessorsNormalizeAndFilterSharedModels() {
+        var kept = new OfficeDocumentAsset { Id = "keep", Kind = "image", LengthBytes = 10 };
+        var removed = new OfficeDocumentAsset { Id = "drop", Kind = "preview", LengthBytes = 1000 };
+        var table = new ReaderTable {
+            Title = "  Settings  ",
+            Columns = new[] { " Key ", " " },
+            Rows = new[] { (IReadOnlyList<string>)new[] { " A ", " 1 ", " extra " } }
+        };
+        var link = new OfficeDocumentLink { Id = " l1 ", Kind = " URI ", Uri = " https://example.test " };
+        var result = new OfficeDocumentReadResult {
+            Blocks = new[] { new OfficeDocumentBlock { Id = "h", Kind = " Heading ", Text = " Title ", Level = 9 } },
+            Tables = new[] { table },
+            Links = new[] { link },
+            Assets = new[] { kept, removed },
+            OcrCandidates = new[] {
+                new OfficeDocumentOcrCandidate { Id = "keep-ocr", AssetId = "keep" },
+                new OfficeDocumentOcrCandidate { Id = "drop-ocr", AssetId = "drop" }
+            }
+        };
+        OfficeDocumentProcessorPipeline pipeline = new OfficeDocumentProcessorPipelineBuilder()
+            .Add(new OfficeDocumentBlockNormalizationProcessor())
+            .Add(new OfficeDocumentTableNormalizationProcessor())
+            .Add(new OfficeDocumentLinkNormalizationProcessor())
+            .Add(new OfficeDocumentAssetFilterProcessor(asset => asset.LengthBytes <= 100))
+            .Build();
+
+        pipeline.Process(result);
+
+        Assert.Equal("heading", Assert.Single(result.Blocks).Kind);
+        Assert.Equal("Title", Assert.Single(result.Blocks).Text);
+        Assert.Equal(6, Assert.Single(result.Blocks).Level);
+        Assert.Equal(new[] { "Key", "Column2", "Column3" }, table.Columns);
+        Assert.Equal(new[] { "A", "1", "extra" }, Assert.Single(table.Rows));
+        Assert.Equal("Settings", table.Title);
+        Assert.Equal("uri", link.Kind);
+        Assert.Equal("https://example.test", link.Uri);
+        Assert.Equal("keep", Assert.Single(result.Assets).Id);
+        Assert.Equal("keep-ocr", Assert.Single(result.OcrCandidates).Id);
+    }
+
+    [Fact]
+    public void ArtifactClassifierUsesRepeatedPageBoundaries() {
+        OfficeDocumentPage[] pages = Enumerable.Range(1, 3)
+            .Select(page => new OfficeDocumentPage {
+                Number = page,
+                Blocks = new[] {
+                    new OfficeDocumentBlock { Id = "h" + page, Kind = "paragraph", Text = "Company Confidential" },
+                    new OfficeDocumentBlock { Id = "b" + page, Kind = "paragraph", Text = "Body " + page },
+                    new OfficeDocumentBlock { Id = "f" + page, Kind = "paragraph", Text = "Page footer" }
+                }
+            })
+            .ToArray();
+        var document = new OfficeDocumentReadResult { Pages = pages };
+
+        new OfficeDocumentProcessorPipelineBuilder()
+            .Add(new OfficeDocumentArtifactClassificationProcessor())
+            .Build()
+            .Process(document);
+
+        Assert.All(pages, page => Assert.Equal("header", page.Blocks[0].Kind));
+        Assert.All(pages, page => Assert.Equal("footer", page.Blocks[2].Kind));
+        Assert.All(pages, page => Assert.Equal("paragraph", page.Blocks[1].Kind));
+    }
+
+    [Fact]
+    public void ArtifactClassifierDoesNotRelabelMatchingBodyText() {
+        OfficeDocumentPage[] pages = Enumerable.Range(1, 3)
+            .Select(page => new OfficeDocumentPage {
+                Number = page,
+                Blocks = new[] {
+                    new OfficeDocumentBlock { Id = "h" + page, Kind = "paragraph", Text = "Repeated text" },
+                    new OfficeDocumentBlock { Id = "b" + page, Kind = "paragraph", Text = "Repeated text" },
+                    new OfficeDocumentBlock { Id = "f" + page, Kind = "paragraph", Text = "Footer " + page }
+                }
+            })
+            .ToArray();
+        var document = new OfficeDocumentReadResult { Pages = pages };
+
+        new OfficeDocumentProcessorPipelineBuilder()
+            .Add(new OfficeDocumentArtifactClassificationProcessor(
+                new OfficeDocumentArtifactClassificationOptions { BoundaryBlockCount = 1 }))
+            .Build()
+            .Process(document);
+
+        Assert.All(pages, page => Assert.Equal("header", page.Blocks[0].Kind));
+        Assert.All(pages, page => Assert.Equal("paragraph", page.Blocks[1].Kind));
+        Assert.All(pages, page => Assert.Equal("paragraph", page.Blocks[2].Kind));
+    }
+
+    private static IOfficeDocumentProcessor PassThrough(string id) =>
+        new DelegateOfficeDocumentProcessor(id, (document, _) => document);
+
+    private static IOfficeDocumentProcessor Recording(string id, ICollection<string> observed) =>
+        new DelegateOfficeDocumentProcessor(id, (document, context) => {
+            observed.Add($"{context.ProcessorId}:{context.ProcessorIndex}/{context.ProcessorCount}");
+            return document;
+        });
+
+    private static IOfficeDocumentProcessor Failing(string id) =>
+        new DelegateOfficeDocumentProcessor(id, (_, _) => throw new FormatException("bad input"));
+
+    private sealed class InvalidIdProcessor : IOfficeDocumentProcessor {
+        public string Id => " invalid ";
+
+        public OfficeDocumentReadResult Process(
+            OfficeDocumentReadResult document,
+            OfficeDocumentProcessorContext context) => document;
+
+        public Task<OfficeDocumentReadResult> ProcessAsync(
+            OfficeDocumentReadResult document,
+            OfficeDocumentProcessorContext context) => Task.FromResult(document);
+    }
+}

--- a/OfficeIMO.Reader.Tests/Reader.StructuredExtraction.cs
+++ b/OfficeIMO.Reader.Tests/Reader.StructuredExtraction.cs
@@ -83,6 +83,56 @@ public sealed class ReaderStructuredExtractionTests {
     }
 
     [Fact]
+    public void Extract_IncludesAndDeduplicatesPageFormsBeforeApplyingLimit() {
+        var documentForm = new OfficeDocumentFormField { Id = "customer", Name = "Customer" };
+        var pageDuplicate = new OfficeDocumentFormField { Id = "customer", Name = "Customer duplicate" };
+        var pageOnly = new OfficeDocumentFormField { Id = "approval", Name = "Approval" };
+        var document = new OfficeDocumentReadResult {
+            Forms = new[] { documentForm },
+            Pages = new[] {
+                new OfficeDocumentPage { Forms = new[] { pageDuplicate, pageOnly } }
+            }
+        };
+
+        OfficeDocumentStructuredExtractionResult result = OfficeDocumentStructuredExtractor.Extract(
+            document,
+            new OfficeDocumentStructuredExtractionOptions { MaxForms = 2 });
+
+        Assert.Equal(new[] { "customer", "approval" }, result.Forms.Select(form => form.Id));
+        Assert.Equal(
+            new[] { "customer", "approval" },
+            result.Records.Where(record => record.Category == "form").Select(record => record.SourceObjectId));
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Code == "structured-form-limit");
+    }
+
+    [Fact]
+    public void Extract_ChecksCancellationWhileScanningNonReadinessDiagnostics() {
+        var document = new OfficeDocumentReadResult {
+            Diagnostics = new[] {
+                new OfficeDocumentDiagnostic { Code = "general", Category = OfficeDocumentDiagnosticCategory.General }
+            }
+        };
+        var options = new OfficeDocumentStructuredExtractionOptions {
+            IncludeMetadata = false,
+            IncludeForms = false,
+            IncludeKeyValueRows = false,
+            IncludeShapeData = false,
+            IncludeChartSummaries = false,
+            IncludeQualitySummaries = true,
+            IncludeSections = false,
+            IncludeNamedTables = false,
+            IncludeSourceDiagnostics = false
+        };
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() => OfficeDocumentStructuredExtractor.Extract(
+            document,
+            options,
+            cancellation.Token));
+    }
+
+    [Fact]
     public void StructuredJson_RejectsUnsupportedSchemaVersions() {
         var result = new OfficeDocumentStructuredExtractionResult { SchemaVersion = 2 };
 

--- a/OfficeIMO.Reader.Tests/Reader.StructuredExtraction.cs
+++ b/OfficeIMO.Reader.Tests/Reader.StructuredExtraction.cs
@@ -139,6 +139,25 @@ public sealed class ReaderStructuredExtractionTests {
     }
 
     [Fact]
+    public void Extract_KeepsAnonymousFormsFromSeparateIdlessChunks() {
+        var document = new OfficeDocumentReadResult {
+            Chunks = new[] {
+                new ReaderChunk {
+                    FormFields = new[] { new ReaderFormField { Value = "first" } }
+                },
+                new ReaderChunk {
+                    FormFields = new[] { new ReaderFormField { Value = "second" } }
+                }
+            }
+        };
+
+        OfficeDocumentStructuredExtractionResult result = OfficeDocumentStructuredExtractor.Extract(document);
+
+        Assert.Equal(new[] { "chunk-0000-form-0000", "chunk-0001-form-0000" }, result.Forms.Select(form => form.Id));
+        Assert.Equal(new[] { "first", "second" }, result.Forms.Select(form => form.Value));
+    }
+
+    [Fact]
     public void Extract_MergesDocumentAndPageBlocksWhenBuildingSections() {
         var heading = new OfficeDocumentBlock { Id = "heading", Kind = "heading", Text = "Overview", Level = 1 };
         var pageHeadingDuplicate = new OfficeDocumentBlock { Id = "heading", Kind = "heading", Text = "Overview", Level = 1 };

--- a/OfficeIMO.Reader.Tests/Reader.StructuredExtraction.cs
+++ b/OfficeIMO.Reader.Tests/Reader.StructuredExtraction.cs
@@ -106,6 +106,57 @@ public sealed class ReaderStructuredExtractionTests {
     }
 
     [Fact]
+    public void Extract_ProjectsChunkOnlyFormFieldsIntoTypedFormsAndRecords() {
+        var document = new OfficeDocumentReadResult {
+            Chunks = new[] {
+                new ReaderChunk {
+                    Id = "chunk-1",
+                    Location = new ReaderLocation { Path = "form.pdf", Page = 2 },
+                    FormFields = new[] {
+                        new ReaderFormField {
+                            Name = "Contact.Email",
+                            FieldType = "Tx",
+                            Value = "person@example.test",
+                            IsRequired = true,
+                            PageNumbers = new[] { 2 }
+                        }
+                    }
+                }
+            }
+        };
+
+        OfficeDocumentStructuredExtractionResult result = OfficeDocumentStructuredExtractor.Extract(document);
+
+        OfficeDocumentFormField form = Assert.Single(result.Forms);
+        Assert.Equal("Contact.Email", form.Id);
+        Assert.Equal("Tx", form.Kind);
+        Assert.Equal("person@example.test", form.Value);
+        Assert.Equal(2, form.Location.Page);
+        Assert.Contains(result.Records, record =>
+            record.Category == "form" &&
+            record.SourceObjectId == "Contact.Email" &&
+            record.Value == "person@example.test");
+    }
+
+    [Fact]
+    public void Extract_MergesDocumentAndPageBlocksWhenBuildingSections() {
+        var heading = new OfficeDocumentBlock { Id = "heading", Kind = "heading", Text = "Overview", Level = 1 };
+        var pageHeadingDuplicate = new OfficeDocumentBlock { Id = "heading", Kind = "heading", Text = "Overview", Level = 1 };
+        var pageBody = new OfficeDocumentBlock { Id = "page-body", Kind = "paragraph", Text = "Page-only body" };
+        var document = new OfficeDocumentReadResult {
+            Blocks = new[] { heading },
+            Pages = new[] { new OfficeDocumentPage { Number = 1, Blocks = new[] { pageHeadingDuplicate, pageBody } } }
+        };
+
+        OfficeDocumentStructuredExtractionResult result = OfficeDocumentStructuredExtractor.Extract(document);
+
+        OfficeDocumentStructuredSection section = Assert.Single(result.Sections);
+        Assert.Equal("Overview", section.Heading);
+        Assert.Equal("Page-only body", section.Text);
+        Assert.Equal(new[] { "heading", "page-body" }, section.BlockIds);
+    }
+
+    [Fact]
     public void Extract_ChecksCancellationWhileScanningNonReadinessDiagnostics() {
         var document = new OfficeDocumentReadResult {
             Diagnostics = new[] {

--- a/OfficeIMO.Reader.Tests/Reader.StructuredExtraction.cs
+++ b/OfficeIMO.Reader.Tests/Reader.StructuredExtraction.cs
@@ -176,6 +176,110 @@ public sealed class ReaderStructuredExtractionTests {
     }
 
     [Fact]
+    public void Extract_OrdersPageOnlyBlocksWithTheirDocumentHeadings() {
+        var document = new OfficeDocumentReadResult {
+            Blocks = new[] {
+                new OfficeDocumentBlock {
+                    Id = "heading-1",
+                    Kind = "heading",
+                    Text = "Page One",
+                    Location = new ReaderLocation { Page = 1, SourceBlockIndex = 0 }
+                },
+                new OfficeDocumentBlock {
+                    Id = "heading-2",
+                    Kind = "heading",
+                    Text = "Page Two",
+                    Location = new ReaderLocation { Page = 2, SourceBlockIndex = 0 }
+                }
+            },
+            Pages = new[] {
+                new OfficeDocumentPage {
+                    Number = 1,
+                    Blocks = new[] {
+                        new OfficeDocumentBlock {
+                            Id = "body-1",
+                            Kind = "paragraph",
+                            Text = "First page body",
+                            Location = new ReaderLocation { Page = 1, SourceBlockIndex = 1 }
+                        }
+                    }
+                },
+                new OfficeDocumentPage {
+                    Number = 2,
+                    Blocks = new[] {
+                        new OfficeDocumentBlock {
+                            Id = "body-2",
+                            Kind = "paragraph",
+                            Text = "Second page body",
+                            Location = new ReaderLocation { Page = 2, SourceBlockIndex = 1 }
+                        }
+                    }
+                }
+            }
+        };
+
+        OfficeDocumentStructuredExtractionResult result = OfficeDocumentStructuredExtractor.Extract(document);
+
+        Assert.Equal(new[] { "Page One", "Page Two" }, result.Sections.Select(section => section.Heading));
+        Assert.Equal(new[] { "First page body", "Second page body" }, result.Sections.Select(section => section.Text));
+    }
+
+    [Fact]
+    public void Extract_DeduplicatesChunkTablesAndVisualsPromotedWithFallbackLocations() {
+        var chunkLocation = new ReaderLocation { Path = "report.md", Page = 1, BlockAnchor = "chunk-1" };
+        var chunkTable = new ReaderTable {
+            Title = "Settings",
+            Columns = new[] { "Key", "Value" },
+            Rows = new[] { (IReadOnlyList<string>)new[] { "Region", "EU" } },
+            TotalRowCount = 1,
+            Diagnostics = new ReaderTableDiagnostics { Confidence = 0.9 }
+        };
+        var promotedTable = new ReaderTable {
+            Title = chunkTable.Title,
+            Location = new ReaderLocation { Path = "report.md", Page = 1, BlockAnchor = "chunk-1", TableIndex = 0 },
+            Columns = chunkTable.Columns,
+            Rows = chunkTable.Rows,
+            TotalRowCount = chunkTable.TotalRowCount,
+            Diagnostics = chunkTable.Diagnostics
+        };
+        var chunkVisual = new ReaderVisual {
+            Kind = "chart",
+            Language = "ix-chart",
+            Content = "{\"type\":\"bar\"}",
+            PayloadHash = "chart-hash",
+            SourceName = "Revenue"
+        };
+        var promotedVisual = new ReaderVisual {
+            Kind = chunkVisual.Kind,
+            Language = chunkVisual.Language,
+            Content = chunkVisual.Content,
+            PayloadHash = chunkVisual.PayloadHash,
+            SourceName = chunkVisual.SourceName,
+            Location = new ReaderLocation { Path = "report.md", Page = 1, BlockAnchor = "chunk-1" }
+        };
+        var document = new OfficeDocumentReadResult {
+            Tables = new[] { promotedTable },
+            Visuals = new[] { promotedVisual },
+            Chunks = new[] {
+                new ReaderChunk {
+                    Id = "chunk-1",
+                    Location = chunkLocation,
+                    Tables = new[] { chunkTable },
+                    Visuals = new[] { chunkVisual }
+                }
+            }
+        };
+
+        OfficeDocumentStructuredExtractionResult result = OfficeDocumentStructuredExtractor.Extract(document);
+
+        Assert.Single(result.Tables);
+        Assert.Single(result.Records, record => record.Category == "key-value" && record.Name == "Region");
+        Assert.Single(result.Records, record => record.Category == "quality-summary" && record.Name == "Settings");
+        Assert.Single(result.Records, record => record.Category == "chart-summary");
+        Assert.Single(result.Records, record => record.Category == "visual-summary");
+    }
+
+    [Fact]
     public void Extract_ChecksCancellationWhileScanningNonReadinessDiagnostics() {
         var document = new OfficeDocumentReadResult {
             Diagnostics = new[] {

--- a/OfficeIMO.Reader.Tests/Reader.StructuredExtraction.cs
+++ b/OfficeIMO.Reader.Tests/Reader.StructuredExtraction.cs
@@ -1,0 +1,205 @@
+using OfficeIMO.Reader;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class ReaderStructuredExtractionTests {
+    [Fact]
+    public void Extract_ProducesDeterministicTypedSectionsAndRecords() {
+        OfficeDocumentReadResult document = CreateRepresentativeDocument();
+
+        OfficeDocumentStructuredExtractionResult result = OfficeDocumentStructuredExtractor.Extract(document);
+
+        Assert.Equal(OfficeDocumentStructuredExtractionSchema.Id, result.SchemaId);
+        Assert.Equal(OfficeDocumentStructuredExtractionSchema.Version, result.SchemaVersion);
+        Assert.Equal(new[] { null, "Overview", "Details" }, result.Sections.Select(section => section.Heading));
+        Assert.Equal("Intro", result.Sections[0].Text);
+        Assert.Equal("First paragraph\nSecond paragraph", result.Sections[1].Text);
+        Assert.Equal(new[] { "named-values", "shape-data" }, result.Tables.Select(table => table.Title));
+        Assert.Equal("customer", Assert.Single(result.Forms).Id);
+
+        Assert.Contains(result.Records, record => record.Category == "metadata" && record.Name == "Author" && record.Value == "Ada");
+        Assert.Contains(result.Records, record => record.Category == "form" && record.Name == "Customer" && record.Value == "Contoso");
+        Assert.Contains(result.Records, record => record.Category == "key-value" && record.Name == "Region" && record.Value == "EU");
+        Assert.Contains(result.Records, record => record.Category == "shape-data" && record.Name == "Owner" && record.Value == "Operations");
+        Assert.Contains(result.Records, record =>
+            record.Category == "chart-summary" &&
+            record.Value == "bar" &&
+            record.Attributes["datasetCount"] == "1" &&
+            record.Attributes["pointCount"] == "2");
+        Assert.Contains(result.Records, record => record.Category == "quality-summary" && record.Name == "named-values");
+        Assert.Contains(result.Records, record => record.Category == "visual-summary" && record.Name == "Revenue");
+        Assert.Contains(result.Records, record => record.Category == "readiness-summary" && record.Value == "review");
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "encrypted-source");
+
+        string first = result.ToJson();
+        string second = OfficeDocumentStructuredExtractor.Extract(document).ToJson();
+        Assert.Equal(first, second);
+        using JsonDocument json = JsonDocument.Parse(first);
+        Assert.Equal(OfficeDocumentStructuredExtractionSchema.Id, json.RootElement.GetProperty("schemaId").GetString());
+        Assert.Equal("Security", json.RootElement.GetProperty("diagnostics")[0].GetProperty("category").GetString());
+    }
+
+    [Fact]
+    public void Extract_EnforcesIndependentHardLimitsWithDiagnostics() {
+        OfficeDocumentStructuredExtractionResult result = OfficeDocumentStructuredExtractor.Extract(
+            CreateRepresentativeDocument(),
+            new OfficeDocumentStructuredExtractionOptions {
+                MaxRecords = 1,
+                MaxSections = 1,
+                MaxSectionCharacters = 3,
+                MaxTables = 1,
+                MaxForms = 1,
+                MaxDiagnostics = 1
+            });
+
+        Assert.Single(result.Records);
+        Assert.Single(result.Sections);
+        Assert.Equal("Int", result.Sections[0].Text);
+        Assert.True(result.Sections[0].Truncated);
+        Assert.Single(result.Tables);
+        Assert.Single(result.Forms);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "structured-record-limit");
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "structured-section-limit");
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "structured-section-character-limit");
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "structured-table-limit");
+    }
+
+    [Fact]
+    public void Extract_RejectsInvalidLimitsAndHonorsCancellation() {
+        Assert.Throws<ArgumentOutOfRangeException>(() => OfficeDocumentStructuredExtractor.Extract(
+            new OfficeDocumentReadResult(),
+            new OfficeDocumentStructuredExtractionOptions { MaxRecords = 0 }));
+
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        Assert.Throws<OperationCanceledException>(() => OfficeDocumentStructuredExtractor.Extract(
+            CreateRepresentativeDocument(),
+            cancellationToken: cancellation.Token));
+    }
+
+    [Fact]
+    public void StructuredJson_RejectsUnsupportedSchemaVersions() {
+        var result = new OfficeDocumentStructuredExtractionResult { SchemaVersion = 2 };
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => result.ToJson());
+
+        Assert.Contains("version 2", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task StaticStructuredReadSupportsSyncAndAsyncByteSurfaces() {
+        byte[] markdown = Encoding.UTF8.GetBytes("# Overview\n\nUseful body");
+
+        OfficeDocumentStructuredExtractionResult sync = DocumentReader.ReadStructured(markdown, "note.md");
+        OfficeDocumentStructuredExtractionResult asyncResult = await DocumentReader.ReadStructuredAsync(markdown, "note.md");
+
+        Assert.NotEmpty(sync.Sections);
+        Assert.Contains("Overview", sync.Sections[0].Heading ?? sync.Sections[0].Text, StringComparison.Ordinal);
+        Assert.Equal(sync.ToJson(), asyncResult.ToJson());
+    }
+
+    [Fact]
+    public async Task InstanceStructuredReadAppliesConfiguredProcessorsFirst() {
+        byte[] markdown = Encoding.UTF8.GetBytes("# Overview\n\nUseful body");
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+            .AddProcessor(new DelegateOfficeDocumentProcessor("metadata", (document, _) => {
+                document.Metadata = new[] {
+                    new OfficeDocumentMetadataEntry { Id = "processed", Name = "Processed", Value = "yes" }
+                };
+                return document;
+            }))
+            .Build();
+
+        OfficeDocumentStructuredExtractionResult sync = reader.ReadStructured(markdown, "note.md");
+        OfficeDocumentStructuredExtractionResult asyncResult = await reader.ReadStructuredAsync(markdown, "note.md");
+
+        Assert.Contains(sync.Records, record => record.Name == "Processed" && record.Value == "yes");
+        Assert.Contains(asyncResult.Records, record => record.Name == "Processed" && record.Value == "yes");
+    }
+
+    private static OfficeDocumentReadResult CreateRepresentativeDocument() {
+        var namedTable = new ReaderTable {
+            Title = "named-values",
+            Columns = new[] { "Key", "Value" },
+            Rows = new[] { (IReadOnlyList<string>)new[] { "Region", "EU" } },
+            TotalRowCount = 1,
+            Diagnostics = new ReaderTableDiagnostics {
+                Confidence = 0.9,
+                SchemaConfidence = 0.8,
+                CellCompleteness = 1,
+                ColumnGeometryConfidence = 0.7,
+                SourceRowCount = 1,
+                ExpectedCellCount = 2,
+                FilledCellCount = 2,
+                HasGeometry = true
+            }
+        };
+        var shapeData = new ReaderTable {
+            Title = "shape-data",
+            Kind = "visio-shape-data",
+            Columns = new[] { "OwnerType", "OwnerId", "Name", "Label", "Value", "Type", "Prompt" },
+            Rows = new[] {
+                (IReadOnlyList<string>)new[] { "Shape", "7", "Owner", "", "Operations", "string", "Responsible team" }
+            },
+            TotalRowCount = 1
+        };
+        var chart = new ReaderVisual {
+            Kind = "chart",
+            Language = "ix-chart",
+            SourceName = "Revenue",
+            PayloadHash = "chart-hash",
+            Content = "{\"type\":\"bar\",\"data\":{\"labels\":[\"Q1\",\"Q2\"],\"datasets\":[{\"data\":[1,2]}]}}",
+            Width = 640,
+            Height = 480,
+            PlacementCount = 1,
+            HasGeometry = true,
+            IsAxisAligned = true
+        };
+        return new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource { Path = "representative.docx", Title = "Representative" },
+            Blocks = new[] {
+                new OfficeDocumentBlock { Id = "preamble", Kind = "paragraph", Text = "Intro" },
+                new OfficeDocumentBlock { Id = "overview", Kind = "heading", Text = "Overview", Level = 1 },
+                new OfficeDocumentBlock { Id = "p1", Kind = "paragraph", Text = "First paragraph" },
+                new OfficeDocumentBlock { Id = "p2", Kind = "paragraph", Text = "Second paragraph" },
+                new OfficeDocumentBlock { Id = "details", Kind = "heading", Text = "Details", Level = 2 },
+                new OfficeDocumentBlock { Id = "p3", Kind = "paragraph", Text = "Final paragraph" }
+            },
+            Metadata = new[] {
+                new OfficeDocumentMetadataEntry { Id = "author", Category = "core", Name = "Author", Value = "Ada" }
+            },
+            Forms = new[] {
+                new OfficeDocumentFormField { Id = "customer", Name = "Customer", Kind = "text", Value = "Contoso", IsRequired = true }
+            },
+            Tables = new[] { namedTable, shapeData },
+            Visuals = new[] { chart },
+            Chunks = new[] {
+                new ReaderChunk {
+                    Id = "chunk-1",
+                    Text = "Useful body",
+                    Diagnostics = new ReaderChunkDiagnostics {
+                        SourceKind = "word",
+                        TableCount = 2,
+                        ImageCount = 1,
+                        FormFieldCount = 1,
+                        HasSecurityState = true,
+                        HasEncryption = true
+                    }
+                }
+            },
+            Diagnostics = new[] {
+                new OfficeDocumentDiagnostic {
+                    Category = OfficeDocumentDiagnosticCategory.Security,
+                    Code = "encrypted-source",
+                    Message = "Source reports encryption.",
+                    IsRecoverable = true
+                }
+            }
+        };
+    }
+}

--- a/OfficeIMO.Reader/DocumentReader.ProcessedChunks.cs
+++ b/OfficeIMO.Reader/DocumentReader.ProcessedChunks.cs
@@ -9,10 +9,12 @@ public static partial class DocumentReader {
     internal static OfficeDocumentReadResult RefreshProcessedChunks(
         OfficeDocumentReadResult document,
         OfficeDocumentSource sourceFallback,
+        ProcessedChunkAggregateSnapshot aggregateSnapshot,
         bool computeHashes,
         CancellationToken cancellationToken) {
         if (document == null) throw new ArgumentNullException(nameof(document));
         if (sourceFallback == null) throw new ArgumentNullException(nameof(sourceFallback));
+        if (aggregateSnapshot == null) throw new ArgumentNullException(nameof(aggregateSnapshot));
 
         IReadOnlyList<ReaderChunk> chunks = document.Chunks ?? Array.Empty<ReaderChunk>();
         OfficeDocumentSource documentSource = document.Source ?? new OfficeDocumentSource();
@@ -45,6 +47,7 @@ public static partial class DocumentReader {
         if (string.IsNullOrWhiteSpace(documentSource.Subject)) documentSource.Subject = sourceFallback.Subject;
         if (string.IsNullOrWhiteSpace(documentSource.Keywords)) documentSource.Keywords = sourceFallback.Keywords;
 
+        AlignProcessedChunkRepresentations(chunks, aggregateSnapshot);
         for (int index = 0; index < chunks.Count; index++) {
             cancellationToken.ThrowIfCancellationRequested();
             ReaderChunk chunk = chunks[index]
@@ -58,7 +61,187 @@ public static partial class DocumentReader {
         }
 
         document.Chunks = chunks;
+        RefreshChunkDerivedAggregates(document, chunks, aggregateSnapshot, cancellationToken);
         return document;
+    }
+
+    private static void AlignProcessedChunkRepresentations(
+        IReadOnlyList<ReaderChunk> chunks,
+        ProcessedChunkAggregateSnapshot snapshot) {
+        if (!snapshot.ChunkDerived) return;
+        for (int index = 0; index < chunks.Count; index++) {
+            ReaderChunk chunk = chunks[index];
+            ProcessedChunkState? prior = FindOriginalChunk(chunk, index, snapshot.Chunks);
+            if (!prior.HasValue) continue;
+            bool textChanged = !string.Equals(chunk.Text, prior.Value.Text, StringComparison.Ordinal);
+            bool markdownChanged = !string.Equals(chunk.Markdown, prior.Value.Markdown, StringComparison.Ordinal);
+            if (textChanged && !markdownChanged) chunk.Markdown = null;
+        }
+    }
+
+    internal static ProcessedChunkAggregateSnapshot CaptureProcessedChunkAggregates(OfficeDocumentReadResult document) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        IReadOnlyList<ReaderChunk> chunks = document.Chunks ?? Array.Empty<ReaderChunk>();
+        IReadOnlyList<OfficeDocumentBlock> blocks = document.Blocks ?? Array.Empty<OfficeDocumentBlock>();
+        bool chunkDerived = chunks.Count == blocks.Count;
+        if (chunkDerived) {
+            for (int index = 0; index < chunks.Count; index++) {
+                ReaderChunk chunk = chunks[index];
+                OfficeDocumentBlock block = blocks[index];
+                string expectedId = !string.IsNullOrWhiteSpace(chunk.Id)
+                    ? chunk.Id
+                    : "chunk-" + index.ToString("D4", System.Globalization.CultureInfo.InvariantCulture);
+                string expectedKind = string.IsNullOrWhiteSpace(chunk.Location.SourceBlockKind)
+                    ? "chunk"
+                    : chunk.Location.SourceBlockKind!;
+                if (block == null ||
+                    !string.Equals(block.Id, expectedId, StringComparison.Ordinal) ||
+                    !string.Equals(block.Kind, expectedKind, StringComparison.Ordinal) ||
+                    !string.Equals(block.Text, chunk.Text ?? string.Empty, StringComparison.Ordinal) ||
+                    !ReferenceEquals(block.Location, chunk.Location)) {
+                    chunkDerived = false;
+                    break;
+                }
+            }
+        }
+        if (chunkDerived && !string.Equals(document.Markdown, BuildChunkDocumentMarkdown(chunks), StringComparison.Ordinal)) {
+            chunkDerived = false;
+        }
+
+        return new ProcessedChunkAggregateSnapshot(
+            document,
+            chunkDerived,
+            document.Markdown,
+            chunks.Select(static chunk => new ProcessedChunkState(chunk, chunk?.Id, chunk?.Text, chunk?.Markdown)).ToArray(),
+            blocks.Select(static block => new ProcessedBlockState(block, block?.Id, block?.Kind, block?.Text, block?.Location)).ToArray());
+    }
+
+    private static void RefreshChunkDerivedAggregates(
+        OfficeDocumentReadResult document,
+        IReadOnlyList<ReaderChunk> chunks,
+        ProcessedChunkAggregateSnapshot snapshot,
+        CancellationToken cancellationToken) {
+        if (!snapshot.ChunkDerived || !ChunksChanged(chunks, snapshot.Chunks)) return;
+        bool sameDocument = ReferenceEquals(document, snapshot.Document);
+        if ((sameDocument && string.Equals(document.Markdown, snapshot.Markdown, StringComparison.Ordinal)) ||
+            (!sameDocument && string.IsNullOrWhiteSpace(document.Markdown))) {
+            document.Markdown = BuildProcessedChunkMarkdown(chunks, snapshot.Chunks);
+        }
+
+        bool blocksUnchanged = sameDocument && BlocksRemainOriginal(document.Blocks, snapshot.Blocks);
+        if (!blocksUnchanged && (sameDocument || (document.Blocks?.Count ?? 0) > 0)) return;
+
+        OfficeDocumentBlock[] rebuilt = BuildChunkDocumentBlocks(chunks).ToArray();
+        bool rebuildPageBlocks = sameDocument && PageBlocksRemainOriginal(document.Pages, snapshot.Blocks);
+        document.Blocks = rebuilt;
+        if (rebuildPageBlocks) RebuildPageBlocks(document.Pages, rebuilt, cancellationToken);
+    }
+
+    private static bool ChunksChanged(
+        IReadOnlyList<ReaderChunk> chunks,
+        IReadOnlyList<ProcessedChunkState> original) {
+        if (chunks.Count != original.Count) return true;
+        for (int index = 0; index < chunks.Count; index++) {
+            ReaderChunk chunk = chunks[index];
+            ProcessedChunkState state = original[index];
+            if (!ReferenceEquals(chunk, state.Chunk) ||
+                !string.Equals(chunk.Id, state.Id, StringComparison.Ordinal) ||
+                !string.Equals(chunk.Text, state.Text, StringComparison.Ordinal) ||
+                !string.Equals(chunk.Markdown, state.Markdown, StringComparison.Ordinal)) return true;
+        }
+        return false;
+    }
+
+    private static bool BlocksRemainOriginal(
+        IReadOnlyList<OfficeDocumentBlock>? blocks,
+        IReadOnlyList<ProcessedBlockState> original) {
+        if (blocks == null || blocks.Count != original.Count) return false;
+        for (int index = 0; index < blocks.Count; index++) {
+            OfficeDocumentBlock block = blocks[index];
+            ProcessedBlockState state = original[index];
+            if (!ReferenceEquals(block, state.Block) ||
+                !string.Equals(block.Id, state.Id, StringComparison.Ordinal) ||
+                !string.Equals(block.Kind, state.Kind, StringComparison.Ordinal) ||
+                !string.Equals(block.Text, state.Text, StringComparison.Ordinal) ||
+                !ReferenceEquals(block.Location, state.Location)) return false;
+        }
+        return true;
+    }
+
+    private static bool PageBlocksRemainOriginal(
+        IReadOnlyList<OfficeDocumentPage>? pages,
+        IReadOnlyList<ProcessedBlockState> original) {
+        if (pages == null) return false;
+        var originalBlocks = new HashSet<OfficeDocumentBlock>(
+            original.Where(static state => state.Block != null).Select(static state => state.Block!),
+            ReferenceIdentityComparer<OfficeDocumentBlock>.Instance);
+        foreach (OfficeDocumentPage page in pages) {
+            if (page?.Blocks == null) continue;
+            foreach (OfficeDocumentBlock block in page.Blocks) {
+                if (block != null && !originalBlocks.Contains(block)) return false;
+            }
+        }
+        return true;
+    }
+
+    private static string? BuildProcessedChunkMarkdown(
+        IReadOnlyList<ReaderChunk> chunks,
+        IReadOnlyList<ProcessedChunkState> original) {
+        var parts = new List<string>();
+        for (int index = 0; index < chunks.Count; index++) {
+            ReaderChunk chunk = chunks[index];
+            ProcessedChunkState? prior = FindOriginalChunk(chunk, index, original);
+            bool textChanged = prior.HasValue && !string.Equals(chunk.Text, prior.Value.Text, StringComparison.Ordinal);
+            bool markdownChanged = prior.HasValue && !string.Equals(chunk.Markdown, prior.Value.Markdown, StringComparison.Ordinal);
+            string? value = textChanged && !markdownChanged
+                ? chunk.Text
+                : (string.IsNullOrWhiteSpace(chunk.Markdown) ? chunk.Text : chunk.Markdown);
+            if (!string.IsNullOrWhiteSpace(value)) parts.Add(value!);
+        }
+        return parts.Count == 0 ? null : string.Join(Environment.NewLine + Environment.NewLine, parts);
+    }
+
+    private static ProcessedChunkState? FindOriginalChunk(
+        ReaderChunk chunk,
+        int index,
+        IReadOnlyList<ProcessedChunkState> original) {
+        if (index < original.Count && ReferenceEquals(chunk, original[index].Chunk)) return original[index];
+        for (int stateIndex = 0; stateIndex < original.Count; stateIndex++) {
+            if (ReferenceEquals(chunk, original[stateIndex].Chunk)) return original[stateIndex];
+        }
+        if (!string.IsNullOrWhiteSpace(chunk.Id)) {
+            ProcessedChunkState? match = null;
+            for (int stateIndex = 0; stateIndex < original.Count; stateIndex++) {
+                if (!string.Equals(chunk.Id, original[stateIndex].Id, StringComparison.Ordinal)) continue;
+                if (match.HasValue) return null;
+                match = original[stateIndex];
+            }
+            return match;
+        }
+        return null;
+    }
+
+    private static void RebuildPageBlocks(
+        IReadOnlyList<OfficeDocumentPage>? pages,
+        IReadOnlyList<OfficeDocumentBlock> blocks,
+        CancellationToken cancellationToken) {
+        foreach (OfficeDocumentPage page in pages ?? Array.Empty<OfficeDocumentPage>()) {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (page == null) continue;
+            page.Blocks = blocks.Where(block => BelongsToPage(block.Location, page)).ToArray();
+        }
+    }
+
+    private static bool BelongsToPage(ReaderLocation location, OfficeDocumentPage page) {
+        string? containerKind = page.Location?.SourceBlockKind;
+        if (string.Equals(containerKind, "slide", StringComparison.OrdinalIgnoreCase)) {
+            return location.Slide == (page.Location?.Slide ?? page.Number);
+        }
+        if (string.Equals(containerKind, "sheet", StringComparison.OrdinalIgnoreCase)) {
+            string? sheet = page.Location?.Sheet ?? page.Name;
+            return string.Equals(location.Sheet, sheet, StringComparison.Ordinal);
+        }
+        return location.Page == (page.Location?.Page ?? page.Number);
     }
 
     private static string FirstNonEmpty(string? first, string? second, string? third, string fallback) {
@@ -73,4 +256,60 @@ public static partial class DocumentReader {
         if (!string.IsNullOrWhiteSpace(second)) return second;
         return string.IsNullOrWhiteSpace(third) ? null : third;
     }
+}
+
+internal sealed class ProcessedChunkAggregateSnapshot {
+    internal ProcessedChunkAggregateSnapshot(
+        OfficeDocumentReadResult document,
+        bool chunkDerived,
+        string? markdown,
+        IReadOnlyList<ProcessedChunkState> chunks,
+        IReadOnlyList<ProcessedBlockState> blocks) {
+        Document = document;
+        ChunkDerived = chunkDerived;
+        Markdown = markdown;
+        Chunks = chunks;
+        Blocks = blocks;
+    }
+
+    internal OfficeDocumentReadResult Document { get; }
+    internal bool ChunkDerived { get; }
+    internal string? Markdown { get; }
+    internal IReadOnlyList<ProcessedChunkState> Chunks { get; }
+    internal IReadOnlyList<ProcessedBlockState> Blocks { get; }
+}
+
+internal readonly struct ProcessedChunkState {
+    internal ProcessedChunkState(ReaderChunk? chunk, string? id, string? text, string? markdown) {
+        Chunk = chunk;
+        Id = id;
+        Text = text;
+        Markdown = markdown;
+    }
+
+    internal ReaderChunk? Chunk { get; }
+    internal string? Id { get; }
+    internal string? Text { get; }
+    internal string? Markdown { get; }
+}
+
+internal readonly struct ProcessedBlockState {
+    internal ProcessedBlockState(
+        OfficeDocumentBlock? block,
+        string? id,
+        string? kind,
+        string? text,
+        ReaderLocation? location) {
+        Block = block;
+        Id = id;
+        Kind = kind;
+        Text = text;
+        Location = location;
+    }
+
+    internal OfficeDocumentBlock? Block { get; }
+    internal string? Id { get; }
+    internal string? Kind { get; }
+    internal string? Text { get; }
+    internal ReaderLocation? Location { get; }
 }

--- a/OfficeIMO.Reader/DocumentReader.ProcessedChunks.cs
+++ b/OfficeIMO.Reader/DocumentReader.ProcessedChunks.cs
@@ -54,7 +54,7 @@ public static partial class DocumentReader {
             chunk.SourceLastWriteUtc = sourceLastWriteUtc;
             chunk.SourceLengthBytes = sourceLengthBytes;
             chunk.TokenEstimate = EstimateTokenCount(chunk.Markdown ?? chunk.Text);
-            chunk.ChunkHash = computeHashes ? ComputeChunkHash(chunk) : null;
+            if (computeHashes) chunk.ChunkHash = ComputeChunkHash(chunk);
         }
 
         document.Chunks = chunks;

--- a/OfficeIMO.Reader/DocumentReader.ProcessedChunks.cs
+++ b/OfficeIMO.Reader/DocumentReader.ProcessedChunks.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace OfficeIMO.Reader;
+
+public static partial class DocumentReader {
+    internal static OfficeDocumentReadResult RefreshProcessedChunks(
+        OfficeDocumentReadResult document,
+        OfficeDocumentSource sourceFallback,
+        bool computeHashes,
+        CancellationToken cancellationToken) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        if (sourceFallback == null) throw new ArgumentNullException(nameof(sourceFallback));
+
+        IReadOnlyList<ReaderChunk> chunks = document.Chunks ?? Array.Empty<ReaderChunk>();
+        OfficeDocumentSource documentSource = document.Source ?? new OfficeDocumentSource();
+        ReaderChunk? firstChunk = chunks.FirstOrDefault(chunk => chunk != null);
+        string sourcePath = FirstNonEmpty(
+            documentSource.Path,
+            sourceFallback.Path,
+            firstChunk?.Location?.Path,
+            "memory");
+        string sourceId = FirstNonEmpty(
+            documentSource.SourceId,
+            sourceFallback.SourceId,
+            null,
+            BuildSourceId(sourcePath));
+        string? sourceHash = FirstNonEmptyOrNull(
+            documentSource.SourceHash,
+            sourceFallback.SourceHash,
+            null);
+        DateTime? sourceLastWriteUtc = documentSource.LastWriteUtc ?? sourceFallback.LastWriteUtc;
+        long? sourceLengthBytes = documentSource.LengthBytes ?? sourceFallback.LengthBytes;
+
+        document.Source = documentSource;
+        if (string.IsNullOrWhiteSpace(documentSource.Path)) documentSource.Path = sourcePath;
+        if (string.IsNullOrWhiteSpace(documentSource.SourceId)) documentSource.SourceId = sourceId;
+        if (string.IsNullOrWhiteSpace(documentSource.SourceHash)) documentSource.SourceHash = sourceHash;
+        documentSource.LastWriteUtc ??= sourceLastWriteUtc;
+        documentSource.LengthBytes ??= sourceLengthBytes;
+        if (string.IsNullOrWhiteSpace(documentSource.Title)) documentSource.Title = sourceFallback.Title;
+        if (string.IsNullOrWhiteSpace(documentSource.Author)) documentSource.Author = sourceFallback.Author;
+        if (string.IsNullOrWhiteSpace(documentSource.Subject)) documentSource.Subject = sourceFallback.Subject;
+        if (string.IsNullOrWhiteSpace(documentSource.Keywords)) documentSource.Keywords = sourceFallback.Keywords;
+
+        for (int index = 0; index < chunks.Count; index++) {
+            cancellationToken.ThrowIfCancellationRequested();
+            ReaderChunk chunk = chunks[index]
+                ?? throw new InvalidOperationException($"Processed document chunk at index {index} is null.");
+            chunk.SourceId = sourceId;
+            chunk.SourceHash = sourceHash;
+            chunk.SourceLastWriteUtc = sourceLastWriteUtc;
+            chunk.SourceLengthBytes = sourceLengthBytes;
+            chunk.TokenEstimate = EstimateTokenCount(chunk.Markdown ?? chunk.Text);
+            chunk.ChunkHash = computeHashes ? ComputeChunkHash(chunk) : null;
+        }
+
+        document.Chunks = chunks;
+        return document;
+    }
+
+    private static string FirstNonEmpty(string? first, string? second, string? third, string fallback) {
+        if (!string.IsNullOrWhiteSpace(first)) return first!;
+        if (!string.IsNullOrWhiteSpace(second)) return second!;
+        if (!string.IsNullOrWhiteSpace(third)) return third!;
+        return fallback;
+    }
+
+    private static string? FirstNonEmptyOrNull(string? first, string? second, string? third) {
+        if (!string.IsNullOrWhiteSpace(first)) return first;
+        if (!string.IsNullOrWhiteSpace(second)) return second;
+        return string.IsNullOrWhiteSpace(third) ? null : third;
+    }
+}

--- a/OfficeIMO.Reader/DocumentReader.Structured.cs
+++ b/OfficeIMO.Reader/DocumentReader.Structured.cs
@@ -1,0 +1,92 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Reader;
+
+public static partial class DocumentReader {
+    /// <summary>Extracts a bounded structured view from an already-read document.</summary>
+    public static OfficeDocumentStructuredExtractionResult ExtractStructured(
+        OfficeDocumentReadResult document,
+        OfficeDocumentStructuredExtractionOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        return OfficeDocumentStructuredExtractor.Extract(document, options, cancellationToken);
+    }
+
+    /// <summary>Reads a file and extracts a bounded structured view.</summary>
+    public static OfficeDocumentStructuredExtractionResult ReadStructured(
+        string path,
+        ReaderOptions? readerOptions = null,
+        OfficeDocumentStructuredExtractionOptions? structuredOptions = null,
+        CancellationToken cancellationToken = default) {
+        return ExtractStructured(ReadDocument(path, readerOptions, cancellationToken), structuredOptions, cancellationToken);
+    }
+
+    /// <summary>Reads a stream and extracts a bounded structured view.</summary>
+    public static OfficeDocumentStructuredExtractionResult ReadStructured(
+        Stream stream,
+        string? sourceName = null,
+        ReaderOptions? readerOptions = null,
+        OfficeDocumentStructuredExtractionOptions? structuredOptions = null,
+        CancellationToken cancellationToken = default) {
+        return ExtractStructured(
+            ReadDocument(stream, sourceName, readerOptions, cancellationToken),
+            structuredOptions,
+            cancellationToken);
+    }
+
+    /// <summary>Reads bytes and extracts a bounded structured view.</summary>
+    public static OfficeDocumentStructuredExtractionResult ReadStructured(
+        byte[] bytes,
+        string? sourceName = null,
+        ReaderOptions? readerOptions = null,
+        OfficeDocumentStructuredExtractionOptions? structuredOptions = null,
+        CancellationToken cancellationToken = default) {
+        if (bytes == null) throw new ArgumentNullException(nameof(bytes));
+        using var stream = new MemoryStream(bytes, writable: false);
+        return ReadStructured(stream, sourceName, readerOptions, structuredOptions, cancellationToken);
+    }
+
+    /// <summary>Asynchronously reads a file and extracts a bounded structured view.</summary>
+    public static async Task<OfficeDocumentStructuredExtractionResult> ReadStructuredAsync(
+        string path,
+        ReaderOptions? readerOptions = null,
+        OfficeDocumentStructuredExtractionOptions? structuredOptions = null,
+        CancellationToken cancellationToken = default) {
+        OfficeDocumentReadResult document = await ReadDocumentAsync(path, readerOptions, cancellationToken).ConfigureAwait(false);
+        return ExtractStructured(document, structuredOptions, cancellationToken);
+    }
+
+    /// <summary>Asynchronously reads a stream and extracts a bounded structured view.</summary>
+    public static async Task<OfficeDocumentStructuredExtractionResult> ReadStructuredAsync(
+        Stream stream,
+        string? sourceName = null,
+        ReaderOptions? readerOptions = null,
+        OfficeDocumentStructuredExtractionOptions? structuredOptions = null,
+        CancellationToken cancellationToken = default) {
+        OfficeDocumentReadResult document = await ReadDocumentAsync(
+            stream,
+            sourceName,
+            readerOptions,
+            cancellationToken).ConfigureAwait(false);
+        return ExtractStructured(document, structuredOptions, cancellationToken);
+    }
+
+    /// <summary>Asynchronously reads bytes and extracts a bounded structured view.</summary>
+    public static async Task<OfficeDocumentStructuredExtractionResult> ReadStructuredAsync(
+        byte[] bytes,
+        string? sourceName = null,
+        ReaderOptions? readerOptions = null,
+        OfficeDocumentStructuredExtractionOptions? structuredOptions = null,
+        CancellationToken cancellationToken = default) {
+        if (bytes == null) throw new ArgumentNullException(nameof(bytes));
+        using var stream = new MemoryStream(bytes, writable: false);
+        return await ReadStructuredAsync(
+            stream,
+            sourceName,
+            readerOptions,
+            structuredOptions,
+            cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/OfficeIMO.Reader/IOfficeDocumentProcessor.cs
+++ b/OfficeIMO.Reader/IOfficeDocumentProcessor.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>
+/// Processes one rich document result as an ordered step in an <see cref="OfficeDocumentProcessorPipeline"/>.
+/// Implementations used by an <see cref="OfficeDocumentReader"/> must be safe for concurrent calls.
+/// </summary>
+public interface IOfficeDocumentProcessor {
+    /// <summary>Stable processor identifier used in diagnostics and execution reports.</summary>
+    string Id { get; }
+
+    /// <summary>Processes a document synchronously.</summary>
+    OfficeDocumentReadResult Process(
+        OfficeDocumentReadResult document,
+        OfficeDocumentProcessorContext context);
+
+    /// <summary>Processes a document asynchronously.</summary>
+    Task<OfficeDocumentReadResult> ProcessAsync(
+        OfficeDocumentReadResult document,
+        OfficeDocumentProcessorContext context);
+}
+
+/// <summary>
+/// Base class for synchronous processors. The asynchronous path delegates to <see cref="Process"/>.
+/// </summary>
+public abstract class OfficeDocumentProcessorBase : IOfficeDocumentProcessor {
+    /// <summary>Creates a processor with a stable identifier.</summary>
+    protected OfficeDocumentProcessorBase(string id) {
+        if (string.IsNullOrWhiteSpace(id)) {
+            throw new ArgumentException("Processor id cannot be empty.", nameof(id));
+        }
+        Id = id.Trim();
+    }
+
+    /// <inheritdoc />
+    public string Id { get; }
+
+    /// <inheritdoc />
+    public abstract OfficeDocumentReadResult Process(
+        OfficeDocumentReadResult document,
+        OfficeDocumentProcessorContext context);
+
+    /// <inheritdoc />
+    public virtual Task<OfficeDocumentReadResult> ProcessAsync(
+        OfficeDocumentReadResult document,
+        OfficeDocumentProcessorContext context) {
+        return Task.FromResult(Process(document, context));
+    }
+}
+
+/// <summary>
+/// Adapts caller-owned delegates into a typed processor without requiring a custom class.
+/// </summary>
+public sealed class DelegateOfficeDocumentProcessor : IOfficeDocumentProcessor {
+    private readonly Func<OfficeDocumentReadResult, OfficeDocumentProcessorContext, OfficeDocumentReadResult> _process;
+    private readonly Func<OfficeDocumentReadResult, OfficeDocumentProcessorContext, Task<OfficeDocumentReadResult>> _processAsync;
+
+    /// <summary>Creates a processor backed by a synchronous delegate.</summary>
+    public DelegateOfficeDocumentProcessor(
+        string id,
+        Func<OfficeDocumentReadResult, OfficeDocumentProcessorContext, OfficeDocumentReadResult> process) {
+        if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("Processor id cannot be empty.", nameof(id));
+        Id = id.Trim();
+        _process = process ?? throw new ArgumentNullException(nameof(process));
+        _processAsync = (document, context) => Task.FromResult(_process(document, context));
+    }
+
+    /// <summary>Creates a processor with explicit synchronous and asynchronous delegates.</summary>
+    public DelegateOfficeDocumentProcessor(
+        string id,
+        Func<OfficeDocumentReadResult, OfficeDocumentProcessorContext, OfficeDocumentReadResult> process,
+        Func<OfficeDocumentReadResult, OfficeDocumentProcessorContext, Task<OfficeDocumentReadResult>> processAsync) {
+        if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("Processor id cannot be empty.", nameof(id));
+        Id = id.Trim();
+        _process = process ?? throw new ArgumentNullException(nameof(process));
+        _processAsync = processAsync ?? throw new ArgumentNullException(nameof(processAsync));
+    }
+
+    /// <inheritdoc />
+    public string Id { get; }
+
+    /// <inheritdoc />
+    public OfficeDocumentReadResult Process(
+        OfficeDocumentReadResult document,
+        OfficeDocumentProcessorContext context) {
+        return _process(document, context);
+    }
+
+    /// <inheritdoc />
+    public Task<OfficeDocumentReadResult> ProcessAsync(
+        OfficeDocumentReadResult document,
+        OfficeDocumentProcessorContext context) {
+        return _processAsync(document, context);
+    }
+}

--- a/OfficeIMO.Reader/OfficeDocumentModelTraversal.cs
+++ b/OfficeIMO.Reader/OfficeDocumentModelTraversal.cs
@@ -67,6 +67,79 @@ internal static class OfficeDocumentModelTraversal {
                 }
             }
         }
+        foreach (ReaderChunk chunk in document.Chunks ?? System.Array.Empty<ReaderChunk>()) {
+            if (chunk?.FormFields == null) continue;
+            for (int index = 0; index < chunk.FormFields.Count; index++) {
+                ReaderFormField field = chunk.FormFields[index];
+                if (field == null) continue;
+                OfficeDocumentFormField form = ProjectChunkForm(chunk, field, index);
+                if (seenIds.Add(form.Id)) yield return form;
+            }
+        }
+    }
+
+    private static OfficeDocumentFormField ProjectChunkForm(ReaderChunk chunk, ReaderFormField field, int index) {
+        ReaderFormWidget? widget = field.Widgets == null || field.Widgets.Count == 0 ? null : field.Widgets[0];
+        return new OfficeDocumentFormField {
+            Id = BuildChunkFormId(chunk, field, index),
+            Name = FirstNonEmpty(field.Name, field.PartialName, field.AlternateName, field.MappingName),
+            Kind = string.IsNullOrWhiteSpace(field.FieldType) ? field.Kind.ToString().ToLowerInvariant() : field.FieldType!,
+            Value = BuildChunkFormValue(field),
+            IsReadOnly = field.IsReadOnly,
+            IsRequired = field.IsRequired,
+            Location = BuildChunkFormLocation(chunk.Location, widget?.PageNumber, field.PageNumbers),
+            Region = widget == null ? null : new OfficeDocumentRegion {
+                X = widget.X1,
+                Y = widget.Y1,
+                Width = widget.Width,
+                Height = widget.Height
+            }
+        };
+    }
+
+    private static string BuildChunkFormId(ReaderChunk chunk, ReaderFormField field, int index) {
+        string? identity = FirstNonEmpty(field.Name, field.PartialName, field.MappingName, field.AlternateName);
+        if (!string.IsNullOrWhiteSpace(identity)) return identity!;
+        string chunkId = string.IsNullOrWhiteSpace(chunk.Id) ? "chunk" : chunk.Id;
+        return chunkId + "-form-" + index.ToString("D4", System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static string? BuildChunkFormValue(ReaderFormField field) {
+        if (field.Value != null) return field.Value;
+        if (field.Values == null || field.Values.Count == 0) return null;
+        return string.Join("\n", field.Values);
+    }
+
+    private static string? FirstNonEmpty(params string?[] values) {
+        for (int index = 0; index < values.Length; index++) {
+            if (!string.IsNullOrWhiteSpace(values[index])) return values[index];
+        }
+        return null;
+    }
+
+    private static ReaderLocation BuildChunkFormLocation(
+        ReaderLocation? source,
+        int? widgetPage,
+        IReadOnlyList<int>? fieldPages) {
+        source ??= new ReaderLocation();
+        return new ReaderLocation {
+            Path = source.Path,
+            BlockIndex = source.BlockIndex,
+            SourceBlockIndex = source.SourceBlockIndex,
+            StartLine = source.StartLine,
+            EndLine = source.EndLine,
+            NormalizedStartLine = source.NormalizedStartLine,
+            NormalizedEndLine = source.NormalizedEndLine,
+            HeadingPath = source.HeadingPath,
+            HeadingSlug = source.HeadingSlug,
+            SourceBlockKind = source.SourceBlockKind,
+            BlockAnchor = source.BlockAnchor,
+            Sheet = source.Sheet,
+            A1Range = source.A1Range,
+            Slide = source.Slide,
+            Page = widgetPage ?? (fieldPages == null || fieldPages.Count == 0 ? source.Page : fieldPages[0]),
+            TableIndex = source.TableIndex
+        };
     }
 }
 

--- a/OfficeIMO.Reader/OfficeDocumentModelTraversal.cs
+++ b/OfficeIMO.Reader/OfficeDocumentModelTraversal.cs
@@ -1,37 +1,82 @@
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace OfficeIMO.Reader;
 
 internal static class OfficeDocumentModelTraversal {
     internal static IEnumerable<OfficeDocumentBlock> Blocks(OfficeDocumentReadResult document) {
         var seen = new HashSet<OfficeDocumentBlock>(ReferenceIdentityComparer<OfficeDocumentBlock>.Instance);
+        var ordered = new List<OrderedBlock>();
+        int insertionIndex = 0;
         foreach (OfficeDocumentBlock block in document.Blocks ?? System.Array.Empty<OfficeDocumentBlock>()) {
-            if (block != null && seen.Add(block)) yield return block;
+            if (block != null && seen.Add(block)) ordered.Add(new OrderedBlock(block, insertionIndex++));
         }
         foreach (OfficeDocumentPage page in document.Pages ?? System.Array.Empty<OfficeDocumentPage>()) {
             if (page?.Blocks == null) continue;
             foreach (OfficeDocumentBlock block in page.Blocks) {
-                if (block != null && seen.Add(block)) yield return block;
+                if (block != null && seen.Add(block)) ordered.Add(new OrderedBlock(block, insertionIndex++));
             }
         }
+        ordered.Sort(CompareBlocks);
+        for (int index = 0; index < ordered.Count; index++) yield return ordered[index].Block;
     }
 
     internal static IEnumerable<ReaderTable> Tables(OfficeDocumentReadResult document) {
         var seen = new HashSet<ReaderTable>(ReferenceIdentityComparer<ReaderTable>.Instance);
+        var aggregateIdentityCounts = new Dictionary<string, int>(StringComparer.Ordinal);
         foreach (ReaderTable table in document.Tables ?? System.Array.Empty<ReaderTable>()) {
-            if (table != null && seen.Add(table)) yield return table;
+            if (table == null || !seen.Add(table)) continue;
+            IncrementIdentity(aggregateIdentityCounts, BuildTableIdentity(table, null, null));
+            yield return table;
         }
         foreach (OfficeDocumentPage page in document.Pages ?? System.Array.Empty<OfficeDocumentPage>()) {
             if (page?.Tables == null) continue;
             foreach (ReaderTable table in page.Tables) {
-                if (table != null && seen.Add(table)) yield return table;
+                if (table == null || !seen.Add(table)) continue;
+                string identity = BuildTableIdentity(table, null, null);
+                if (aggregateIdentityCounts.ContainsKey(identity)) continue;
+                IncrementIdentity(aggregateIdentityCounts, identity);
+                yield return table;
             }
         }
+        var chunkIdentityCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        int fallbackTableIndex = 0;
         foreach (ReaderChunk chunk in document.Chunks ?? System.Array.Empty<ReaderChunk>()) {
             if (chunk?.Tables == null) continue;
             foreach (ReaderTable table in chunk.Tables) {
-                if (table != null && seen.Add(table)) yield return table;
+                if (table == null || !seen.Add(table)) {
+                    fallbackTableIndex++;
+                    continue;
+                }
+                string identity = BuildTableIdentity(table, chunk.Location, fallbackTableIndex++);
+                int occurrence = IncrementIdentity(chunkIdentityCounts, identity);
+                if (aggregateIdentityCounts.TryGetValue(identity, out int aggregateCount) && occurrence <= aggregateCount) continue;
+                yield return table;
+            }
+        }
+    }
+
+    internal static IEnumerable<ReaderVisual> Visuals(OfficeDocumentReadResult document) {
+        var seen = new HashSet<ReaderVisual>(ReferenceIdentityComparer<ReaderVisual>.Instance);
+        var aggregateIdentityCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (ReaderVisual visual in document.Visuals ?? Array.Empty<ReaderVisual>()) {
+            if (visual == null || !seen.Add(visual)) continue;
+            IncrementIdentity(aggregateIdentityCounts, BuildVisualIdentity(visual, null));
+            yield return visual;
+        }
+
+        var chunkIdentityCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (ReaderChunk chunk in document.Chunks ?? Array.Empty<ReaderChunk>()) {
+            if (chunk?.Visuals == null) continue;
+            foreach (ReaderVisual visual in chunk.Visuals) {
+                if (visual == null || !seen.Add(visual)) continue;
+                string identity = BuildVisualIdentity(visual, chunk.Location);
+                int occurrence = IncrementIdentity(chunkIdentityCounts, identity);
+                if (aggregateIdentityCounts.TryGetValue(identity, out int aggregateCount) && occurrence <= aggregateCount) continue;
+                yield return visual;
             }
         }
     }
@@ -152,6 +197,112 @@ internal static class OfficeDocumentModelTraversal {
             Page = widgetPage ?? (fieldPages == null || fieldPages.Count == 0 ? source.Page : fieldPages[0]),
             TableIndex = source.TableIndex
         };
+    }
+
+    private static int CompareBlocks(OrderedBlock left, OrderedBlock right) {
+        int comparison = string.CompareOrdinal(BuildContainerOrderKey(left.Block.Location), BuildContainerOrderKey(right.Block.Location));
+        if (comparison != 0) return comparison;
+        comparison = BuildBlockPosition(left.Block.Location).CompareTo(BuildBlockPosition(right.Block.Location));
+        return comparison != 0 ? comparison : left.InsertionIndex.CompareTo(right.InsertionIndex);
+    }
+
+    private static string BuildContainerOrderKey(ReaderLocation? location) {
+        if (location == null) return "9|";
+        if (location.Page.HasValue) return "0|" + location.Page.Value.ToString("D10", CultureInfo.InvariantCulture);
+        if (location.Slide.HasValue) return "1|" + location.Slide.Value.ToString("D10", CultureInfo.InvariantCulture);
+        if (!string.IsNullOrWhiteSpace(location.Sheet)) return "2|" + location.Sheet;
+        return "9|";
+    }
+
+    private static int BuildBlockPosition(ReaderLocation? location) =>
+        location?.SourceBlockIndex
+        ?? location?.BlockIndex
+        ?? location?.StartLine
+        ?? location?.NormalizedStartLine
+        ?? int.MaxValue;
+
+    private static int IncrementIdentity(IDictionary<string, int> counts, string identity) {
+        counts.TryGetValue(identity, out int count);
+        count++;
+        counts[identity] = count;
+        return count;
+    }
+
+    private static string BuildTableIdentity(ReaderTable table, ReaderLocation? fallback, int? fallbackTableIndex) {
+        var builder = new StringBuilder();
+        AppendIdentity(builder, table.PayloadHash);
+        AppendIdentity(builder, table.CallId);
+        AppendIdentity(builder, table.Kind);
+        AppendIdentity(builder, table.Title);
+        AppendLocationIdentity(builder, table.Location, fallback, fallbackTableIndex);
+        AppendIdentity(builder, table.Columns);
+        foreach (IReadOnlyList<string> row in table.Rows ?? Array.Empty<IReadOnlyList<string>>()) AppendIdentity(builder, row);
+        AppendIdentity(builder, table.TotalRowCount.ToString(CultureInfo.InvariantCulture));
+        return builder.ToString();
+    }
+
+    private static string BuildVisualIdentity(ReaderVisual visual, ReaderLocation? fallback) {
+        var builder = new StringBuilder();
+        AppendIdentity(builder, visual.PayloadHash);
+        AppendIdentity(builder, visual.Kind);
+        AppendIdentity(builder, visual.Language);
+        AppendIdentity(builder, visual.SourceName);
+        AppendIdentity(builder, visual.MimeType);
+        AppendIdentity(builder, visual.Content);
+        AppendLocationIdentity(builder, visual.Location, fallback, null);
+        return builder.ToString();
+    }
+
+    private static void AppendLocationIdentity(
+        StringBuilder builder,
+        ReaderLocation? location,
+        ReaderLocation? fallback,
+        int? fallbackTableIndex) {
+        AppendIdentity(builder, Prefer(location?.Path, fallback?.Path));
+        AppendIdentity(builder, Prefer(location?.Sheet, fallback?.Sheet));
+        AppendIdentity(builder, Prefer(location?.A1Range, fallback?.A1Range));
+        AppendIdentity(builder, Prefer(location?.HeadingPath, fallback?.HeadingPath));
+        AppendIdentity(builder, Prefer(location?.HeadingSlug, fallback?.HeadingSlug));
+        AppendIdentity(builder, Prefer(location?.SourceBlockKind, fallback?.SourceBlockKind));
+        AppendIdentity(builder, Prefer(location?.BlockAnchor, fallback?.BlockAnchor));
+        AppendIdentity(builder, (location?.Page ?? fallback?.Page)?.ToString(CultureInfo.InvariantCulture));
+        AppendIdentity(builder, (location?.Slide ?? fallback?.Slide)?.ToString(CultureInfo.InvariantCulture));
+        AppendIdentity(builder, (location?.BlockIndex ?? fallback?.BlockIndex)?.ToString(CultureInfo.InvariantCulture));
+        AppendIdentity(builder, (location?.SourceBlockIndex ?? fallback?.SourceBlockIndex)?.ToString(CultureInfo.InvariantCulture));
+        AppendIdentity(builder, (location?.StartLine ?? fallback?.StartLine)?.ToString(CultureInfo.InvariantCulture));
+        AppendIdentity(builder, (location?.TableIndex ?? fallbackTableIndex ?? fallback?.TableIndex)?.ToString(CultureInfo.InvariantCulture));
+    }
+
+    private static string? Prefer(string? value, string? fallback) =>
+        string.IsNullOrWhiteSpace(value) ? fallback : value;
+
+    private static void AppendIdentity(StringBuilder builder, IReadOnlyList<string>? values) {
+        if (values == null) {
+            AppendIdentity(builder, (string?)null);
+            return;
+        }
+        AppendIdentity(builder, values.Count.ToString(CultureInfo.InvariantCulture));
+        for (int index = 0; index < values.Count; index++) AppendIdentity(builder, values[index]);
+    }
+
+    private static void AppendIdentity(StringBuilder builder, string? value) {
+        if (value == null) {
+            builder.Append("-1:");
+            return;
+        }
+        builder.Append(value.Length.ToString(CultureInfo.InvariantCulture));
+        builder.Append(':');
+        builder.Append(value);
+    }
+
+    private readonly struct OrderedBlock {
+        internal OrderedBlock(OfficeDocumentBlock block, int insertionIndex) {
+            Block = block;
+            InsertionIndex = insertionIndex;
+        }
+
+        internal OfficeDocumentBlock Block { get; }
+        internal int InsertionIndex { get; }
     }
 }
 

--- a/OfficeIMO.Reader/OfficeDocumentModelTraversal.cs
+++ b/OfficeIMO.Reader/OfficeDocumentModelTraversal.cs
@@ -67,21 +67,27 @@ internal static class OfficeDocumentModelTraversal {
                 }
             }
         }
-        foreach (ReaderChunk chunk in document.Chunks ?? System.Array.Empty<ReaderChunk>()) {
+        IReadOnlyList<ReaderChunk> chunks = document.Chunks ?? System.Array.Empty<ReaderChunk>();
+        for (int chunkIndex = 0; chunkIndex < chunks.Count; chunkIndex++) {
+            ReaderChunk chunk = chunks[chunkIndex];
             if (chunk?.FormFields == null) continue;
             for (int index = 0; index < chunk.FormFields.Count; index++) {
                 ReaderFormField field = chunk.FormFields[index];
                 if (field == null) continue;
-                OfficeDocumentFormField form = ProjectChunkForm(chunk, field, index);
+                OfficeDocumentFormField form = ProjectChunkForm(chunk, field, chunkIndex, index);
                 if (seenIds.Add(form.Id)) yield return form;
             }
         }
     }
 
-    private static OfficeDocumentFormField ProjectChunkForm(ReaderChunk chunk, ReaderFormField field, int index) {
+    private static OfficeDocumentFormField ProjectChunkForm(
+        ReaderChunk chunk,
+        ReaderFormField field,
+        int chunkIndex,
+        int fieldIndex) {
         ReaderFormWidget? widget = field.Widgets == null || field.Widgets.Count == 0 ? null : field.Widgets[0];
         return new OfficeDocumentFormField {
-            Id = BuildChunkFormId(chunk, field, index),
+            Id = BuildChunkFormId(chunk, field, chunkIndex, fieldIndex),
             Name = FirstNonEmpty(field.Name, field.PartialName, field.AlternateName, field.MappingName),
             Kind = string.IsNullOrWhiteSpace(field.FieldType) ? field.Kind.ToString().ToLowerInvariant() : field.FieldType!,
             Value = BuildChunkFormValue(field),
@@ -97,11 +103,17 @@ internal static class OfficeDocumentModelTraversal {
         };
     }
 
-    private static string BuildChunkFormId(ReaderChunk chunk, ReaderFormField field, int index) {
+    private static string BuildChunkFormId(
+        ReaderChunk chunk,
+        ReaderFormField field,
+        int chunkIndex,
+        int fieldIndex) {
         string? identity = FirstNonEmpty(field.Name, field.PartialName, field.MappingName, field.AlternateName);
         if (!string.IsNullOrWhiteSpace(identity)) return identity!;
-        string chunkId = string.IsNullOrWhiteSpace(chunk.Id) ? "chunk" : chunk.Id;
-        return chunkId + "-form-" + index.ToString("D4", System.Globalization.CultureInfo.InvariantCulture);
+        string chunkId = string.IsNullOrWhiteSpace(chunk.Id)
+            ? "chunk-" + chunkIndex.ToString("D4", System.Globalization.CultureInfo.InvariantCulture)
+            : chunk.Id;
+        return chunkId + "-form-" + fieldIndex.ToString("D4", System.Globalization.CultureInfo.InvariantCulture);
     }
 
     private static string? BuildChunkFormValue(ReaderFormField field) {

--- a/OfficeIMO.Reader/OfficeDocumentModelTraversal.cs
+++ b/OfficeIMO.Reader/OfficeDocumentModelTraversal.cs
@@ -48,6 +48,26 @@ internal static class OfficeDocumentModelTraversal {
             }
         }
     }
+
+    internal static IEnumerable<OfficeDocumentFormField> Forms(OfficeDocumentReadResult document) {
+        var seen = new HashSet<OfficeDocumentFormField>(ReferenceIdentityComparer<OfficeDocumentFormField>.Instance);
+        var seenIds = new HashSet<string>(System.StringComparer.Ordinal);
+        foreach (OfficeDocumentFormField form in document.Forms ?? System.Array.Empty<OfficeDocumentFormField>()) {
+            if (form != null && seen.Add(form) &&
+                (string.IsNullOrWhiteSpace(form.Id) || seenIds.Add(form.Id))) {
+                yield return form;
+            }
+        }
+        foreach (OfficeDocumentPage page in document.Pages ?? System.Array.Empty<OfficeDocumentPage>()) {
+            if (page?.Forms == null) continue;
+            foreach (OfficeDocumentFormField form in page.Forms) {
+                if (form != null && seen.Add(form) &&
+                    (string.IsNullOrWhiteSpace(form.Id) || seenIds.Add(form.Id))) {
+                    yield return form;
+                }
+            }
+        }
+    }
 }
 
 internal sealed class ReferenceIdentityComparer<T> : IEqualityComparer<T> where T : class {

--- a/OfficeIMO.Reader/OfficeDocumentModelTraversal.cs
+++ b/OfficeIMO.Reader/OfficeDocumentModelTraversal.cs
@@ -34,12 +34,14 @@ internal static class OfficeDocumentModelTraversal {
         }
         foreach (OfficeDocumentPage page in document.Pages ?? System.Array.Empty<OfficeDocumentPage>()) {
             if (page?.Tables == null) continue;
-            foreach (ReaderTable table in page.Tables) {
+            for (int tableIndex = 0; tableIndex < page.Tables.Count; tableIndex++) {
+                ReaderTable table = page.Tables[tableIndex];
                 if (table == null || !seen.Add(table)) continue;
-                string identity = BuildTableIdentity(table, null, null);
+                ReaderTable scopedTable = WithPageLocationFallback(table, page, tableIndex);
+                string identity = BuildTableIdentity(scopedTable, null, null);
                 if (aggregateIdentityCounts.ContainsKey(identity)) continue;
                 IncrementIdentity(aggregateIdentityCounts, identity);
-                yield return table;
+                yield return scopedTable;
             }
         }
         var chunkIdentityCounts = new Dictionary<string, int>(StringComparer.Ordinal);
@@ -55,6 +57,23 @@ internal static class OfficeDocumentModelTraversal {
                 int occurrence = IncrementIdentity(chunkIdentityCounts, identity);
                 if (aggregateIdentityCounts.TryGetValue(identity, out int aggregateCount) && occurrence <= aggregateCount) continue;
                 yield return table;
+            }
+        }
+    }
+
+    internal static IEnumerable<ReaderTable> TableInstances(OfficeDocumentReadResult document) {
+        var seen = new HashSet<ReaderTable>(ReferenceIdentityComparer<ReaderTable>.Instance);
+        foreach (ReaderTable table in document.Tables ?? Array.Empty<ReaderTable>()) {
+            if (table != null && seen.Add(table)) yield return table;
+        }
+        foreach (OfficeDocumentPage page in document.Pages ?? Array.Empty<OfficeDocumentPage>()) {
+            foreach (ReaderTable table in page?.Tables ?? Array.Empty<ReaderTable>()) {
+                if (table != null && seen.Add(table)) yield return table;
+            }
+        }
+        foreach (ReaderChunk chunk in document.Chunks ?? Array.Empty<ReaderChunk>()) {
+            foreach (ReaderTable table in chunk?.Tables ?? Array.Empty<ReaderTable>()) {
+                if (table != null && seen.Add(table)) yield return table;
             }
         }
     }
@@ -239,6 +258,73 @@ internal static class OfficeDocumentModelTraversal {
         foreach (IReadOnlyList<string> row in table.Rows ?? Array.Empty<IReadOnlyList<string>>()) AppendIdentity(builder, row);
         AppendIdentity(builder, table.TotalRowCount.ToString(CultureInfo.InvariantCulture));
         return builder.ToString();
+    }
+
+    private static ReaderTable WithPageLocationFallback(ReaderTable table, OfficeDocumentPage page, int tableIndex) {
+        ReaderLocation fallback = BuildPageLocation(page);
+        if (table.Location != null && !NeedsLocationFallback(table.Location)) return table;
+        return new ReaderTable {
+            Title = table.Title,
+            Kind = table.Kind,
+            CallId = table.CallId,
+            Summary = table.Summary,
+            PayloadHash = table.PayloadHash,
+            Location = MergeLocation(table.Location, fallback, tableIndex),
+            Columns = table.Columns,
+            ColumnProfiles = table.ColumnProfiles,
+            Diagnostics = table.Diagnostics,
+            Rows = table.Rows,
+            TotalRowCount = table.TotalRowCount,
+            Truncated = table.Truncated
+        };
+    }
+
+    private static ReaderLocation BuildPageLocation(OfficeDocumentPage page) {
+        ReaderLocation source = page.Location ?? new ReaderLocation();
+        return new ReaderLocation {
+            Path = source.Path,
+            BlockIndex = source.BlockIndex,
+            SourceBlockIndex = source.SourceBlockIndex,
+            StartLine = source.StartLine,
+            EndLine = source.EndLine,
+            NormalizedStartLine = source.NormalizedStartLine,
+            NormalizedEndLine = source.NormalizedEndLine,
+            HeadingPath = source.HeadingPath,
+            HeadingSlug = source.HeadingSlug,
+            SourceBlockKind = source.SourceBlockKind,
+            BlockAnchor = source.BlockAnchor,
+            Sheet = source.Sheet,
+            A1Range = source.A1Range,
+            Slide = source.Slide,
+            Page = source.Page ?? page.Number,
+            TableIndex = source.TableIndex
+        };
+    }
+
+    private static bool NeedsLocationFallback(ReaderLocation location) {
+        return string.IsNullOrWhiteSpace(location.Path)
+            || (!location.Page.HasValue && !location.Slide.HasValue && string.IsNullOrWhiteSpace(location.Sheet));
+    }
+
+    private static ReaderLocation MergeLocation(ReaderLocation? location, ReaderLocation fallback, int fallbackTableIndex) {
+        return new ReaderLocation {
+            Path = Prefer(location?.Path, fallback.Path),
+            BlockIndex = location?.BlockIndex ?? fallback.BlockIndex,
+            SourceBlockIndex = location?.SourceBlockIndex ?? fallback.SourceBlockIndex,
+            StartLine = location?.StartLine ?? fallback.StartLine,
+            EndLine = location?.EndLine ?? fallback.EndLine,
+            NormalizedStartLine = location?.NormalizedStartLine ?? fallback.NormalizedStartLine,
+            NormalizedEndLine = location?.NormalizedEndLine ?? fallback.NormalizedEndLine,
+            HeadingPath = Prefer(location?.HeadingPath, fallback.HeadingPath),
+            HeadingSlug = Prefer(location?.HeadingSlug, fallback.HeadingSlug),
+            SourceBlockKind = Prefer(location?.SourceBlockKind, fallback.SourceBlockKind),
+            BlockAnchor = Prefer(location?.BlockAnchor, fallback.BlockAnchor),
+            Sheet = Prefer(location?.Sheet, fallback.Sheet),
+            A1Range = Prefer(location?.A1Range, fallback.A1Range),
+            Slide = location?.Slide ?? fallback.Slide,
+            Page = location?.Page ?? fallback.Page,
+            TableIndex = location?.TableIndex ?? fallback.TableIndex ?? fallbackTableIndex
+        };
     }
 
     private static string BuildVisualIdentity(ReaderVisual visual, ReaderLocation? fallback) {

--- a/OfficeIMO.Reader/OfficeDocumentModelTraversal.cs
+++ b/OfficeIMO.Reader/OfficeDocumentModelTraversal.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace OfficeIMO.Reader;
+
+internal static class OfficeDocumentModelTraversal {
+    internal static IEnumerable<OfficeDocumentBlock> Blocks(OfficeDocumentReadResult document) {
+        var seen = new HashSet<OfficeDocumentBlock>(ReferenceIdentityComparer<OfficeDocumentBlock>.Instance);
+        foreach (OfficeDocumentBlock block in document.Blocks ?? System.Array.Empty<OfficeDocumentBlock>()) {
+            if (block != null && seen.Add(block)) yield return block;
+        }
+        foreach (OfficeDocumentPage page in document.Pages ?? System.Array.Empty<OfficeDocumentPage>()) {
+            if (page?.Blocks == null) continue;
+            foreach (OfficeDocumentBlock block in page.Blocks) {
+                if (block != null && seen.Add(block)) yield return block;
+            }
+        }
+    }
+
+    internal static IEnumerable<ReaderTable> Tables(OfficeDocumentReadResult document) {
+        var seen = new HashSet<ReaderTable>(ReferenceIdentityComparer<ReaderTable>.Instance);
+        foreach (ReaderTable table in document.Tables ?? System.Array.Empty<ReaderTable>()) {
+            if (table != null && seen.Add(table)) yield return table;
+        }
+        foreach (OfficeDocumentPage page in document.Pages ?? System.Array.Empty<OfficeDocumentPage>()) {
+            if (page?.Tables == null) continue;
+            foreach (ReaderTable table in page.Tables) {
+                if (table != null && seen.Add(table)) yield return table;
+            }
+        }
+        foreach (ReaderChunk chunk in document.Chunks ?? System.Array.Empty<ReaderChunk>()) {
+            if (chunk?.Tables == null) continue;
+            foreach (ReaderTable table in chunk.Tables) {
+                if (table != null && seen.Add(table)) yield return table;
+            }
+        }
+    }
+
+    internal static IEnumerable<OfficeDocumentLink> Links(OfficeDocumentReadResult document) {
+        var seen = new HashSet<OfficeDocumentLink>(ReferenceIdentityComparer<OfficeDocumentLink>.Instance);
+        foreach (OfficeDocumentLink link in document.Links ?? System.Array.Empty<OfficeDocumentLink>()) {
+            if (link != null && seen.Add(link)) yield return link;
+        }
+        foreach (OfficeDocumentPage page in document.Pages ?? System.Array.Empty<OfficeDocumentPage>()) {
+            if (page?.Links == null) continue;
+            foreach (OfficeDocumentLink link in page.Links) {
+                if (link != null && seen.Add(link)) yield return link;
+            }
+        }
+    }
+}
+
+internal sealed class ReferenceIdentityComparer<T> : IEqualityComparer<T> where T : class {
+    internal static ReferenceIdentityComparer<T> Instance { get; } = new ReferenceIdentityComparer<T>();
+
+    public bool Equals(T? x, T? y) => ReferenceEquals(x, y);
+
+    public int GetHashCode(T obj) => RuntimeHelpers.GetHashCode(obj);
+}

--- a/OfficeIMO.Reader/OfficeDocumentProcessingModels.cs
+++ b/OfficeIMO.Reader/OfficeDocumentProcessingModels.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>Controls how a processor pipeline responds to processor failures.</summary>
+public enum OfficeDocumentProcessorFailureBehavior {
+    /// <summary>Throw an <see cref="OfficeDocumentProcessorException"/> immediately.</summary>
+    Throw = 0,
+    /// <summary>Add a structured diagnostic and continue with the next processor.</summary>
+    ContinueWithDiagnostic,
+    /// <summary>Add a structured diagnostic and skip the remaining processors.</summary>
+    StopWithDiagnostic
+}
+
+/// <summary>Execution options for an ordered document processor pipeline.</summary>
+public sealed class OfficeDocumentProcessingOptions {
+    /// <summary>Failure behavior. The default preserves fail-fast behavior.</summary>
+    public OfficeDocumentProcessorFailureBehavior FailureBehavior { get; set; } = OfficeDocumentProcessorFailureBehavior.Throw;
+
+    internal OfficeDocumentProcessingOptions Clone() => new OfficeDocumentProcessingOptions {
+        FailureBehavior = FailureBehavior
+    };
+}
+
+/// <summary>Immutable context for one processor invocation.</summary>
+public sealed class OfficeDocumentProcessorContext {
+    internal OfficeDocumentProcessorContext(
+        string processorId,
+        int processorIndex,
+        int processorCount,
+        CancellationToken cancellationToken) {
+        ProcessorId = processorId;
+        ProcessorIndex = processorIndex;
+        ProcessorCount = processorCount;
+        CancellationToken = cancellationToken;
+    }
+
+    /// <summary>Stable processor identifier.</summary>
+    public string ProcessorId { get; }
+
+    /// <summary>Zero-based processor index in configured execution order.</summary>
+    public int ProcessorIndex { get; }
+
+    /// <summary>Total configured processor count.</summary>
+    public int ProcessorCount { get; }
+
+    /// <summary>Cancellation token for this processing operation.</summary>
+    public CancellationToken CancellationToken { get; }
+}
+
+/// <summary>Status of one configured processor step.</summary>
+public enum OfficeDocumentProcessorStepStatus {
+    /// <summary>The processor completed and returned a document.</summary>
+    Completed = 0,
+    /// <summary>The processor failed and failure policy retained a diagnostic.</summary>
+    Failed,
+    /// <summary>The processor was not invoked because a previous step stopped the pipeline.</summary>
+    Skipped
+}
+
+/// <summary>Deterministic execution record for one processor step.</summary>
+public sealed class OfficeDocumentProcessorStepResult {
+    internal OfficeDocumentProcessorStepResult(
+        string processorId,
+        int processorIndex,
+        OfficeDocumentProcessorStepStatus status,
+        OfficeDocumentDiagnostic? diagnostic = null) {
+        ProcessorId = processorId;
+        ProcessorIndex = processorIndex;
+        Status = status;
+        Diagnostic = diagnostic;
+    }
+
+    /// <summary>Stable processor identifier.</summary>
+    public string ProcessorId { get; }
+
+    /// <summary>Zero-based configured execution index.</summary>
+    public int ProcessorIndex { get; }
+
+    /// <summary>Execution status.</summary>
+    public OfficeDocumentProcessorStepStatus Status { get; }
+
+    /// <summary>Structured failure diagnostic when <see cref="Status"/> is <see cref="OfficeDocumentProcessorStepStatus.Failed"/>.</summary>
+    public OfficeDocumentDiagnostic? Diagnostic { get; }
+}
+
+/// <summary>Processed document plus deterministic per-step execution evidence.</summary>
+public sealed class OfficeDocumentProcessingResult {
+    internal OfficeDocumentProcessingResult(
+        OfficeDocumentReadResult document,
+        IReadOnlyList<OfficeDocumentProcessorStepResult> steps) {
+        Document = document;
+        Steps = steps;
+    }
+
+    /// <summary>Final document returned by the pipeline.</summary>
+    public OfficeDocumentReadResult Document { get; }
+
+    /// <summary>One record per configured processor, in execution order.</summary>
+    public IReadOnlyList<OfficeDocumentProcessorStepResult> Steps { get; }
+
+    /// <summary>True when every configured processor completed.</summary>
+    public bool Succeeded {
+        get {
+            for (int index = 0; index < Steps.Count; index++) {
+                if (Steps[index].Status != OfficeDocumentProcessorStepStatus.Completed) return false;
+            }
+            return true;
+        }
+    }
+}
+
+/// <summary>Wraps a fail-fast processor failure with stable processor identity and order.</summary>
+public sealed class OfficeDocumentProcessorException : Exception {
+    internal OfficeDocumentProcessorException(string processorId, int processorIndex, Exception innerException)
+        : base($"Document processor '{processorId}' failed at index {processorIndex}: {innerException.Message}", innerException) {
+        ProcessorId = processorId;
+        ProcessorIndex = processorIndex;
+    }
+
+    /// <summary>Processor that failed.</summary>
+    public string ProcessorId { get; }
+
+    /// <summary>Zero-based configured processor index.</summary>
+    public int ProcessorIndex { get; }
+}

--- a/OfficeIMO.Reader/OfficeDocumentProcessorPipeline.cs
+++ b/OfficeIMO.Reader/OfficeDocumentProcessorPipeline.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>Immutable processor pipeline that executes processors in registration order.</summary>
+public sealed class OfficeDocumentProcessorPipeline {
+    private readonly IOfficeDocumentProcessor[] _processors;
+    private readonly ReadOnlyCollection<IOfficeDocumentProcessor> _processorView;
+
+    internal OfficeDocumentProcessorPipeline(IOfficeDocumentProcessor[] processors) {
+        _processors = processors ?? throw new ArgumentNullException(nameof(processors));
+        _processorView = Array.AsReadOnly(_processors);
+    }
+
+    /// <summary>Empty reusable pipeline.</summary>
+    public static OfficeDocumentProcessorPipeline Empty { get; } = new OfficeDocumentProcessorPipeline(Array.Empty<IOfficeDocumentProcessor>());
+
+    /// <summary>Configured processors in deterministic execution order.</summary>
+    public IReadOnlyList<IOfficeDocumentProcessor> Processors => _processorView;
+
+    /// <summary>Configured processor count.</summary>
+    public int Count => _processors.Length;
+
+    /// <summary>Processes a document synchronously in configured order.</summary>
+    public OfficeDocumentProcessingResult Process(
+        OfficeDocumentReadResult document,
+        OfficeDocumentProcessingOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        OfficeDocumentProcessorFailureBehavior failureBehavior = Normalize(options).FailureBehavior;
+        var steps = new OfficeDocumentProcessorStepResult[_processors.Length];
+        OfficeDocumentReadResult current = document;
+
+        for (int index = 0; index < _processors.Length; index++) {
+            cancellationToken.ThrowIfCancellationRequested();
+            IOfficeDocumentProcessor processor = _processors[index];
+            var context = new OfficeDocumentProcessorContext(processor.Id, index, _processors.Length, cancellationToken);
+            try {
+                current = processor.Process(current, context)
+                    ?? throw new InvalidOperationException("Processor returned a null document result.");
+                steps[index] = Completed(processor, index);
+            } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+                throw;
+            } catch (Exception exception) {
+                if (failureBehavior == OfficeDocumentProcessorFailureBehavior.Throw) {
+                    throw new OfficeDocumentProcessorException(processor.Id, index, exception);
+                }
+                OfficeDocumentDiagnostic diagnostic = BuildFailureDiagnostic(processor, index, exception, failureBehavior);
+                AppendDiagnostic(current, diagnostic);
+                steps[index] = Failed(processor, index, diagnostic);
+                if (failureBehavior == OfficeDocumentProcessorFailureBehavior.StopWithDiagnostic) {
+                    MarkRemainingSkipped(steps, index + 1);
+                    break;
+                }
+            }
+        }
+
+        return new OfficeDocumentProcessingResult(current, steps);
+    }
+
+    /// <summary>Processes a document asynchronously in configured order.</summary>
+    public async Task<OfficeDocumentProcessingResult> ProcessAsync(
+        OfficeDocumentReadResult document,
+        OfficeDocumentProcessingOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        OfficeDocumentProcessorFailureBehavior failureBehavior = Normalize(options).FailureBehavior;
+        var steps = new OfficeDocumentProcessorStepResult[_processors.Length];
+        OfficeDocumentReadResult current = document;
+
+        for (int index = 0; index < _processors.Length; index++) {
+            cancellationToken.ThrowIfCancellationRequested();
+            IOfficeDocumentProcessor processor = _processors[index];
+            var context = new OfficeDocumentProcessorContext(processor.Id, index, _processors.Length, cancellationToken);
+            try {
+                Task<OfficeDocumentReadResult> task = processor.ProcessAsync(current, context)
+                    ?? throw new InvalidOperationException("Processor returned a null asynchronous operation.");
+                current = await task.ConfigureAwait(false)
+                    ?? throw new InvalidOperationException("Processor returned a null document result.");
+                steps[index] = Completed(processor, index);
+            } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+                throw;
+            } catch (Exception exception) {
+                if (failureBehavior == OfficeDocumentProcessorFailureBehavior.Throw) {
+                    throw new OfficeDocumentProcessorException(processor.Id, index, exception);
+                }
+                OfficeDocumentDiagnostic diagnostic = BuildFailureDiagnostic(processor, index, exception, failureBehavior);
+                AppendDiagnostic(current, diagnostic);
+                steps[index] = Failed(processor, index, diagnostic);
+                if (failureBehavior == OfficeDocumentProcessorFailureBehavior.StopWithDiagnostic) {
+                    MarkRemainingSkipped(steps, index + 1);
+                    break;
+                }
+            }
+        }
+
+        return new OfficeDocumentProcessingResult(current, steps);
+    }
+
+    internal static string ValidateProcessorId(string? id, string paramName) {
+        if (string.IsNullOrWhiteSpace(id)) {
+            throw new ArgumentException("Processor id cannot be empty.", paramName);
+        }
+        string normalized = id!.Trim();
+        if (!string.Equals(id, normalized, StringComparison.Ordinal)) {
+            throw new ArgumentException("Processor id cannot contain leading or trailing whitespace.", paramName);
+        }
+        return normalized;
+    }
+
+    private static OfficeDocumentProcessingOptions Normalize(OfficeDocumentProcessingOptions? options) {
+        OfficeDocumentProcessingOptions effective = options?.Clone() ?? new OfficeDocumentProcessingOptions();
+        if (!Enum.IsDefined(typeof(OfficeDocumentProcessorFailureBehavior), effective.FailureBehavior)) {
+            throw new ArgumentOutOfRangeException(nameof(options), effective.FailureBehavior, "Unknown processor failure behavior.");
+        }
+        return effective;
+    }
+
+    private OfficeDocumentProcessorStepResult Completed(IOfficeDocumentProcessor processor, int index) =>
+        new OfficeDocumentProcessorStepResult(processor.Id, index, OfficeDocumentProcessorStepStatus.Completed);
+
+    private OfficeDocumentProcessorStepResult Failed(
+        IOfficeDocumentProcessor processor,
+        int index,
+        OfficeDocumentDiagnostic diagnostic) =>
+        new OfficeDocumentProcessorStepResult(processor.Id, index, OfficeDocumentProcessorStepStatus.Failed, diagnostic);
+
+    private void MarkRemainingSkipped(OfficeDocumentProcessorStepResult[] steps, int startIndex) {
+        for (int index = startIndex; index < _processors.Length; index++) {
+            steps[index] = new OfficeDocumentProcessorStepResult(
+                _processors[index].Id,
+                index,
+                OfficeDocumentProcessorStepStatus.Skipped);
+        }
+    }
+
+    private static OfficeDocumentDiagnostic BuildFailureDiagnostic(
+        IOfficeDocumentProcessor processor,
+        int index,
+        Exception exception,
+        OfficeDocumentProcessorFailureBehavior failureBehavior) {
+        return new OfficeDocumentDiagnostic {
+            Severity = OfficeDocumentDiagnosticSeverity.Error,
+            Category = OfficeDocumentDiagnosticCategory.General,
+            Code = "processor-failed",
+            Message = $"Document processor '{processor.Id}' failed: {exception.Message}",
+            Source = "officeimo.reader.processor." + processor.Id,
+            IsRecoverable = failureBehavior == OfficeDocumentProcessorFailureBehavior.ContinueWithDiagnostic,
+            Attributes = new SortedDictionary<string, string>(StringComparer.Ordinal) {
+                ["exceptionType"] = exception.GetType().FullName ?? exception.GetType().Name,
+                ["processorId"] = processor.Id,
+                ["processorIndex"] = index.ToString(CultureInfo.InvariantCulture)
+            }
+        };
+    }
+
+    private static void AppendDiagnostic(OfficeDocumentReadResult document, OfficeDocumentDiagnostic diagnostic) {
+        IReadOnlyList<OfficeDocumentDiagnostic>? existing = document.Diagnostics;
+        int count = existing?.Count ?? 0;
+        var diagnostics = new OfficeDocumentDiagnostic[count + 1];
+        for (int index = 0; index < count; index++) diagnostics[index] = existing![index];
+        diagnostics[count] = diagnostic;
+        document.Diagnostics = diagnostics;
+    }
+}

--- a/OfficeIMO.Reader/OfficeDocumentProcessorPipeline.cs
+++ b/OfficeIMO.Reader/OfficeDocumentProcessorPipeline.cs
@@ -34,6 +34,7 @@ public sealed class OfficeDocumentProcessorPipeline {
         if (document == null) throw new ArgumentNullException(nameof(document));
         OfficeDocumentProcessorFailureBehavior failureBehavior = Normalize(options).FailureBehavior;
         var steps = new OfficeDocumentProcessorStepResult[_processors.Length];
+        var retainedFailureDiagnostics = new List<OfficeDocumentDiagnostic>();
         OfficeDocumentReadResult current = document;
 
         for (int index = 0; index < _processors.Length; index++) {
@@ -43,6 +44,7 @@ public sealed class OfficeDocumentProcessorPipeline {
             try {
                 current = processor.Process(current, context)
                     ?? throw new InvalidOperationException("Processor returned a null document result.");
+                AppendDiagnostics(current, retainedFailureDiagnostics);
                 steps[index] = Completed(processor, index);
             } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
                 throw;
@@ -52,6 +54,7 @@ public sealed class OfficeDocumentProcessorPipeline {
                 }
                 OfficeDocumentDiagnostic diagnostic = BuildFailureDiagnostic(processor, index, exception, failureBehavior);
                 AppendDiagnostic(current, diagnostic);
+                retainedFailureDiagnostics.Add(diagnostic);
                 steps[index] = Failed(processor, index, diagnostic);
                 if (failureBehavior == OfficeDocumentProcessorFailureBehavior.StopWithDiagnostic) {
                     MarkRemainingSkipped(steps, index + 1);
@@ -71,6 +74,7 @@ public sealed class OfficeDocumentProcessorPipeline {
         if (document == null) throw new ArgumentNullException(nameof(document));
         OfficeDocumentProcessorFailureBehavior failureBehavior = Normalize(options).FailureBehavior;
         var steps = new OfficeDocumentProcessorStepResult[_processors.Length];
+        var retainedFailureDiagnostics = new List<OfficeDocumentDiagnostic>();
         OfficeDocumentReadResult current = document;
 
         for (int index = 0; index < _processors.Length; index++) {
@@ -82,6 +86,7 @@ public sealed class OfficeDocumentProcessorPipeline {
                     ?? throw new InvalidOperationException("Processor returned a null asynchronous operation.");
                 current = await task.ConfigureAwait(false)
                     ?? throw new InvalidOperationException("Processor returned a null document result.");
+                AppendDiagnostics(current, retainedFailureDiagnostics);
                 steps[index] = Completed(processor, index);
             } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
                 throw;
@@ -91,6 +96,7 @@ public sealed class OfficeDocumentProcessorPipeline {
                 }
                 OfficeDocumentDiagnostic diagnostic = BuildFailureDiagnostic(processor, index, exception, failureBehavior);
                 AppendDiagnostic(current, diagnostic);
+                retainedFailureDiagnostics.Add(diagnostic);
                 steps[index] = Failed(processor, index, diagnostic);
                 if (failureBehavior == OfficeDocumentProcessorFailureBehavior.StopWithDiagnostic) {
                     MarkRemainingSkipped(steps, index + 1);
@@ -166,5 +172,40 @@ public sealed class OfficeDocumentProcessorPipeline {
         for (int index = 0; index < count; index++) diagnostics[index] = existing![index];
         diagnostics[count] = diagnostic;
         document.Diagnostics = diagnostics;
+    }
+
+    private static void AppendDiagnostics(
+        OfficeDocumentReadResult document,
+        IReadOnlyList<OfficeDocumentDiagnostic> diagnostics) {
+        for (int index = 0; index < diagnostics.Count; index++) {
+            OfficeDocumentDiagnostic diagnostic = diagnostics[index];
+            if (!ContainsProcessorFailure(document.Diagnostics, diagnostic)) {
+                AppendDiagnostic(document, diagnostic);
+            }
+        }
+    }
+
+    private static bool ContainsProcessorFailure(
+        IReadOnlyList<OfficeDocumentDiagnostic>? diagnostics,
+        OfficeDocumentDiagnostic expected) {
+        if (diagnostics == null) return false;
+        expected.Attributes.TryGetValue("processorId", out string? expectedProcessorId);
+        expected.Attributes.TryGetValue("processorIndex", out string? expectedProcessorIndex);
+        for (int index = 0; index < diagnostics.Count; index++) {
+            OfficeDocumentDiagnostic? candidate = diagnostics[index];
+            if (candidate == null) continue;
+            if (ReferenceEquals(candidate, expected)) return true;
+            if (!string.Equals(candidate.Code, expected.Code, StringComparison.Ordinal) ||
+                candidate.Attributes == null ||
+                !candidate.Attributes.TryGetValue("processorId", out string? processorId) ||
+                !candidate.Attributes.TryGetValue("processorIndex", out string? processorIndex)) {
+                continue;
+            }
+            if (string.Equals(processorId, expectedProcessorId, StringComparison.Ordinal) &&
+                string.Equals(processorIndex, expectedProcessorIndex, StringComparison.Ordinal)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/OfficeIMO.Reader/OfficeDocumentProcessorPipelineBuilder.cs
+++ b/OfficeIMO.Reader/OfficeDocumentProcessorPipelineBuilder.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>Builds an immutable, ordered document processor pipeline.</summary>
+public sealed class OfficeDocumentProcessorPipelineBuilder {
+    private readonly List<IOfficeDocumentProcessor> _processors = new List<IOfficeDocumentProcessor>();
+    private readonly HashSet<string> _ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Number of processors currently configured.</summary>
+    public int Count => _processors.Count;
+
+    /// <summary>Adds a processor at the end of the deterministic execution order.</summary>
+    public OfficeDocumentProcessorPipelineBuilder Add(IOfficeDocumentProcessor processor) {
+        if (processor == null) throw new ArgumentNullException(nameof(processor));
+        string id = OfficeDocumentProcessorPipeline.ValidateProcessorId(processor.Id, nameof(processor));
+        if (!_ids.Add(id)) {
+            throw new InvalidOperationException($"A document processor with id '{id}' is already registered.");
+        }
+        _processors.Add(processor);
+        return this;
+    }
+
+    /// <summary>Adds processors in enumeration order.</summary>
+    public OfficeDocumentProcessorPipelineBuilder AddRange(IEnumerable<IOfficeDocumentProcessor> processors) {
+        if (processors == null) throw new ArgumentNullException(nameof(processors));
+        foreach (IOfficeDocumentProcessor processor in processors) Add(processor);
+        return this;
+    }
+
+    /// <summary>Removes a processor by stable identifier.</summary>
+    public bool Remove(string processorId) {
+        if (string.IsNullOrWhiteSpace(processorId)) return false;
+        for (int index = 0; index < _processors.Count; index++) {
+            if (!string.Equals(_processors[index].Id, processorId, StringComparison.OrdinalIgnoreCase)) continue;
+            _processors.RemoveAt(index);
+            _ids.Remove(processorId);
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>Removes every configured processor.</summary>
+    public OfficeDocumentProcessorPipelineBuilder Clear() {
+        _processors.Clear();
+        _ids.Clear();
+        return this;
+    }
+
+    /// <summary>Creates an immutable pipeline snapshot.</summary>
+    public OfficeDocumentProcessorPipeline Build() {
+        return _processors.Count == 0
+            ? OfficeDocumentProcessorPipeline.Empty
+            : new OfficeDocumentProcessorPipeline(_processors.ToArray());
+    }
+}

--- a/OfficeIMO.Reader/OfficeDocumentReader.Processors.cs
+++ b/OfficeIMO.Reader/OfficeDocumentReader.Processors.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Reader;
+
+public sealed partial class OfficeDocumentReader {
+    /// <summary>Processes an already-read document through this reader's frozen pipeline.</summary>
+    public OfficeDocumentProcessingResult ProcessDocument(
+        OfficeDocumentReadResult document,
+        CancellationToken cancellationToken = default) {
+        return ProcessorPipeline.Process(document, _processingOptions, cancellationToken);
+    }
+
+    /// <summary>Processes an already-read document asynchronously through this reader's frozen pipeline.</summary>
+    public Task<OfficeDocumentProcessingResult> ProcessDocumentAsync(
+        OfficeDocumentReadResult document,
+        CancellationToken cancellationToken = default) {
+        return ProcessorPipeline.ProcessAsync(document, _processingOptions, cancellationToken);
+    }
+
+    private OfficeDocumentReadResult ProcessDocumentResult(
+        OfficeDocumentReadResult document,
+        CancellationToken cancellationToken) {
+        if (ProcessorPipeline.Count == 0) return document;
+        return ProcessorPipeline.Process(document, _processingOptions, cancellationToken).Document;
+    }
+
+    private async Task<OfficeDocumentReadResult> ExecuteProcessedDocumentAsync(
+        Func<Task<OfficeDocumentReadResult>> read,
+        CancellationToken cancellationToken) {
+        return await ExecuteAsync(async () => {
+            OfficeDocumentReadResult document = await read().ConfigureAwait(false);
+            if (ProcessorPipeline.Count == 0) return document;
+            OfficeDocumentProcessingResult processed = await ProcessorPipeline
+                .ProcessAsync(document, _processingOptions, cancellationToken)
+                .ConfigureAwait(false);
+            return processed.Document;
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<IReadOnlyList<ReaderChunk>> ExecuteProcessedChunksAsync(
+        Func<Task<OfficeDocumentReadResult>> read,
+        CancellationToken cancellationToken) {
+        OfficeDocumentReadResult document = await ExecuteProcessedDocumentAsync(read, cancellationToken).ConfigureAwait(false);
+        return document.Chunks ?? Array.Empty<ReaderChunk>();
+    }
+}

--- a/OfficeIMO.Reader/OfficeDocumentReader.Processors.cs
+++ b/OfficeIMO.Reader/OfficeDocumentReader.Processors.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -22,28 +23,55 @@ public sealed partial class OfficeDocumentReader {
 
     private OfficeDocumentReadResult ProcessDocumentResult(
         OfficeDocumentReadResult document,
+        bool computeHashes,
         CancellationToken cancellationToken) {
         if (ProcessorPipeline.Count == 0) return document;
-        return ProcessorPipeline.Process(document, _processingOptions, cancellationToken).Document;
+        OfficeDocumentSource source = SnapshotSource(document);
+        OfficeDocumentReadResult processed = ProcessorPipeline
+            .Process(document, _processingOptions, cancellationToken)
+            .Document;
+        return DocumentReader.RefreshProcessedChunks(processed, source, computeHashes, cancellationToken);
     }
 
     private async Task<OfficeDocumentReadResult> ExecuteProcessedDocumentAsync(
         Func<Task<OfficeDocumentReadResult>> read,
+        bool computeHashes,
         CancellationToken cancellationToken) {
         return await ExecuteAsync(async () => {
             OfficeDocumentReadResult document = await read().ConfigureAwait(false);
             if (ProcessorPipeline.Count == 0) return document;
+            OfficeDocumentSource source = SnapshotSource(document);
             OfficeDocumentProcessingResult processed = await ProcessorPipeline
                 .ProcessAsync(document, _processingOptions, cancellationToken)
                 .ConfigureAwait(false);
-            return processed.Document;
+            return DocumentReader.RefreshProcessedChunks(processed.Document, source, computeHashes, cancellationToken);
         }, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<IReadOnlyList<ReaderChunk>> ExecuteProcessedChunksAsync(
         Func<Task<OfficeDocumentReadResult>> read,
+        bool computeHashes,
         CancellationToken cancellationToken) {
-        OfficeDocumentReadResult document = await ExecuteProcessedDocumentAsync(read, cancellationToken).ConfigureAwait(false);
+        OfficeDocumentReadResult document = await ExecuteProcessedDocumentAsync(
+            read,
+            computeHashes,
+            cancellationToken).ConfigureAwait(false);
         return document.Chunks ?? Array.Empty<ReaderChunk>();
+    }
+
+    private static OfficeDocumentSource SnapshotSource(OfficeDocumentReadResult document) {
+        OfficeDocumentSource source = document.Source ?? new OfficeDocumentSource();
+        ReaderChunk? firstChunk = document.Chunks?.FirstOrDefault(chunk => chunk != null);
+        return new OfficeDocumentSource {
+            Path = string.IsNullOrWhiteSpace(source.Path) ? firstChunk?.Location?.Path : source.Path,
+            SourceId = string.IsNullOrWhiteSpace(source.SourceId) ? firstChunk?.SourceId : source.SourceId,
+            SourceHash = string.IsNullOrWhiteSpace(source.SourceHash) ? firstChunk?.SourceHash : source.SourceHash,
+            LastWriteUtc = source.LastWriteUtc ?? firstChunk?.SourceLastWriteUtc,
+            LengthBytes = source.LengthBytes ?? firstChunk?.SourceLengthBytes,
+            Title = source.Title,
+            Author = source.Author,
+            Subject = source.Subject,
+            Keywords = source.Keywords
+        };
     }
 }

--- a/OfficeIMO.Reader/OfficeDocumentReader.Processors.cs
+++ b/OfficeIMO.Reader/OfficeDocumentReader.Processors.cs
@@ -27,10 +27,11 @@ public sealed partial class OfficeDocumentReader {
         CancellationToken cancellationToken) {
         if (ProcessorPipeline.Count == 0) return document;
         OfficeDocumentSource source = SnapshotSource(document);
+        ProcessedChunkAggregateSnapshot aggregates = DocumentReader.CaptureProcessedChunkAggregates(document);
         OfficeDocumentReadResult processed = ProcessorPipeline
             .Process(document, _processingOptions, cancellationToken)
             .Document;
-        return DocumentReader.RefreshProcessedChunks(processed, source, computeHashes, cancellationToken);
+        return DocumentReader.RefreshProcessedChunks(processed, source, aggregates, computeHashes, cancellationToken);
     }
 
     private async Task<OfficeDocumentReadResult> ExecuteProcessedDocumentAsync(
@@ -41,10 +42,11 @@ public sealed partial class OfficeDocumentReader {
             OfficeDocumentReadResult document = await read().ConfigureAwait(false);
             if (ProcessorPipeline.Count == 0) return document;
             OfficeDocumentSource source = SnapshotSource(document);
+            ProcessedChunkAggregateSnapshot aggregates = DocumentReader.CaptureProcessedChunkAggregates(document);
             OfficeDocumentProcessingResult processed = await ProcessorPipeline
                 .ProcessAsync(document, _processingOptions, cancellationToken)
                 .ConfigureAwait(false);
-            return DocumentReader.RefreshProcessedChunks(processed.Document, source, computeHashes, cancellationToken);
+            return DocumentReader.RefreshProcessedChunks(processed.Document, source, aggregates, computeHashes, cancellationToken);
         }, cancellationToken).ConfigureAwait(false);
     }
 

--- a/OfficeIMO.Reader/OfficeDocumentReader.Structured.cs
+++ b/OfficeIMO.Reader/OfficeDocumentReader.Structured.cs
@@ -1,0 +1,92 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Reader;
+
+public sealed partial class OfficeDocumentReader {
+    /// <summary>Extracts a bounded structured view from an already-read document.</summary>
+    public OfficeDocumentStructuredExtractionResult ExtractStructured(
+        OfficeDocumentReadResult document,
+        OfficeDocumentStructuredExtractionOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        return OfficeDocumentStructuredExtractor.Extract(document, options, cancellationToken);
+    }
+
+    /// <summary>Reads a file through this reader's processors and extracts a bounded structured view.</summary>
+    public OfficeDocumentStructuredExtractionResult ReadStructured(
+        string path,
+        ReaderOptions? readerOptions = null,
+        OfficeDocumentStructuredExtractionOptions? structuredOptions = null,
+        CancellationToken cancellationToken = default) {
+        return ExtractStructured(ReadDocument(path, readerOptions, cancellationToken), structuredOptions, cancellationToken);
+    }
+
+    /// <summary>Reads a stream through this reader's processors and extracts a bounded structured view.</summary>
+    public OfficeDocumentStructuredExtractionResult ReadStructured(
+        Stream stream,
+        string? sourceName = null,
+        ReaderOptions? readerOptions = null,
+        OfficeDocumentStructuredExtractionOptions? structuredOptions = null,
+        CancellationToken cancellationToken = default) {
+        return ExtractStructured(
+            ReadDocument(stream, sourceName, readerOptions, cancellationToken),
+            structuredOptions,
+            cancellationToken);
+    }
+
+    /// <summary>Reads bytes through this reader's processors and extracts a bounded structured view.</summary>
+    public OfficeDocumentStructuredExtractionResult ReadStructured(
+        byte[] bytes,
+        string? sourceName = null,
+        ReaderOptions? readerOptions = null,
+        OfficeDocumentStructuredExtractionOptions? structuredOptions = null,
+        CancellationToken cancellationToken = default) {
+        if (bytes == null) throw new ArgumentNullException(nameof(bytes));
+        using var stream = new MemoryStream(bytes, writable: false);
+        return ReadStructured(stream, sourceName, readerOptions, structuredOptions, cancellationToken);
+    }
+
+    /// <summary>Asynchronously reads a file through this reader's processors and extracts a bounded structured view.</summary>
+    public async Task<OfficeDocumentStructuredExtractionResult> ReadStructuredAsync(
+        string path,
+        ReaderOptions? readerOptions = null,
+        OfficeDocumentStructuredExtractionOptions? structuredOptions = null,
+        CancellationToken cancellationToken = default) {
+        OfficeDocumentReadResult document = await ReadDocumentAsync(path, readerOptions, cancellationToken).ConfigureAwait(false);
+        return ExtractStructured(document, structuredOptions, cancellationToken);
+    }
+
+    /// <summary>Asynchronously reads a stream through this reader's processors and extracts a bounded structured view.</summary>
+    public async Task<OfficeDocumentStructuredExtractionResult> ReadStructuredAsync(
+        Stream stream,
+        string? sourceName = null,
+        ReaderOptions? readerOptions = null,
+        OfficeDocumentStructuredExtractionOptions? structuredOptions = null,
+        CancellationToken cancellationToken = default) {
+        OfficeDocumentReadResult document = await ReadDocumentAsync(
+            stream,
+            sourceName,
+            readerOptions,
+            cancellationToken).ConfigureAwait(false);
+        return ExtractStructured(document, structuredOptions, cancellationToken);
+    }
+
+    /// <summary>Asynchronously reads bytes through this reader's processors and extracts a bounded structured view.</summary>
+    public async Task<OfficeDocumentStructuredExtractionResult> ReadStructuredAsync(
+        byte[] bytes,
+        string? sourceName = null,
+        ReaderOptions? readerOptions = null,
+        OfficeDocumentStructuredExtractionOptions? structuredOptions = null,
+        CancellationToken cancellationToken = default) {
+        if (bytes == null) throw new ArgumentNullException(nameof(bytes));
+        using var stream = new MemoryStream(bytes, writable: false);
+        return await ReadStructuredAsync(
+            stream,
+            sourceName,
+            readerOptions,
+            structuredOptions,
+            cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/OfficeIMO.Reader/OfficeDocumentReader.cs
+++ b/OfficeIMO.Reader/OfficeDocumentReader.cs
@@ -13,12 +13,19 @@ namespace OfficeIMO.Reader;
 /// Handler routing is frozen when the reader is built. Static <see cref="DocumentReader"/> registrations
 /// and other <see cref="OfficeDocumentReader"/> instances cannot change this reader's behavior.
 /// </remarks>
-public sealed class OfficeDocumentReader {
+public sealed partial class OfficeDocumentReader {
     private readonly ReaderHandlerRegistrySnapshot _handlers;
     private readonly SemaphoreSlim _asyncGate;
+    private readonly OfficeDocumentProcessingOptions _processingOptions;
 
-    internal OfficeDocumentReader(ReaderHandlerRegistrySnapshot handlers, int maxConcurrentReads) {
+    internal OfficeDocumentReader(
+        ReaderHandlerRegistrySnapshot handlers,
+        int maxConcurrentReads,
+        OfficeDocumentProcessorPipeline processorPipeline,
+        OfficeDocumentProcessingOptions processingOptions) {
         _handlers = handlers ?? throw new ArgumentNullException(nameof(handlers));
+        ProcessorPipeline = processorPipeline ?? throw new ArgumentNullException(nameof(processorPipeline));
+        _processingOptions = processingOptions ?? throw new ArgumentNullException(nameof(processingOptions));
         if (maxConcurrentReads < 1 || maxConcurrentReads > DocumentReader.MaximumConcurrentReads) {
             throw new ArgumentOutOfRangeException(nameof(maxConcurrentReads));
         }
@@ -36,6 +43,12 @@ public sealed class OfficeDocumentReader {
     /// </summary>
     public int MaxConcurrentReads { get; }
 
+    /// <summary>Gets this reader's immutable ordered processor pipeline.</summary>
+    public OfficeDocumentProcessorPipeline ProcessorPipeline { get; }
+
+    /// <summary>Gets the configured processor failure behavior.</summary>
+    public OfficeDocumentProcessorFailureBehavior ProcessorFailureBehavior => _processingOptions.FailureBehavior;
+
     /// <summary>
     /// Reads a supported file using this reader's frozen handler configuration.
     /// </summary>
@@ -43,7 +56,8 @@ public sealed class OfficeDocumentReader {
         string path,
         ReaderOptions? options = null,
         CancellationToken cancellationToken = default) {
-        return Scope(DocumentReader.Read(path, options, cancellationToken));
+        if (ProcessorPipeline.Count == 0) return Scope(DocumentReader.Read(path, options, cancellationToken));
+        return ReadDocument(path, options, cancellationToken).Chunks ?? Array.Empty<ReaderChunk>();
     }
 
     /// <summary>
@@ -54,7 +68,8 @@ public sealed class OfficeDocumentReader {
         string? sourceName = null,
         ReaderOptions? options = null,
         CancellationToken cancellationToken = default) {
-        return Scope(DocumentReader.Read(stream, sourceName, options, cancellationToken));
+        if (ProcessorPipeline.Count == 0) return Scope(DocumentReader.Read(stream, sourceName, options, cancellationToken));
+        return ReadDocument(stream, sourceName, options, cancellationToken).Chunks ?? Array.Empty<ReaderChunk>();
     }
 
     /// <summary>
@@ -65,7 +80,8 @@ public sealed class OfficeDocumentReader {
         string? sourceName = null,
         ReaderOptions? options = null,
         CancellationToken cancellationToken = default) {
-        return Scope(DocumentReader.Read(bytes, sourceName, options, cancellationToken));
+        if (ProcessorPipeline.Count == 0) return Scope(DocumentReader.Read(bytes, sourceName, options, cancellationToken));
+        return ReadDocument(bytes, sourceName, options, cancellationToken).Chunks ?? Array.Empty<ReaderChunk>();
     }
 
     /// <summary>
@@ -75,7 +91,12 @@ public sealed class OfficeDocumentReader {
         string path,
         ReaderOptions? options = null,
         CancellationToken cancellationToken = default) {
-        return ExecuteAsync(() => DocumentReader.ReadAsync(path, options, cancellationToken), cancellationToken);
+        if (ProcessorPipeline.Count == 0) {
+            return ExecuteAsync(() => DocumentReader.ReadAsync(path, options, cancellationToken), cancellationToken);
+        }
+        return ExecuteProcessedChunksAsync(
+            () => DocumentReader.ReadDocumentAsync(path, options, cancellationToken),
+            cancellationToken);
     }
 
     /// <summary>
@@ -86,7 +107,12 @@ public sealed class OfficeDocumentReader {
         string? sourceName = null,
         ReaderOptions? options = null,
         CancellationToken cancellationToken = default) {
-        return ExecuteAsync(() => DocumentReader.ReadAsync(stream, sourceName, options, cancellationToken), cancellationToken);
+        if (ProcessorPipeline.Count == 0) {
+            return ExecuteAsync(() => DocumentReader.ReadAsync(stream, sourceName, options, cancellationToken), cancellationToken);
+        }
+        return ExecuteProcessedChunksAsync(
+            () => DocumentReader.ReadDocumentAsync(stream, sourceName, options, cancellationToken),
+            cancellationToken);
     }
 
     /// <summary>
@@ -97,7 +123,12 @@ public sealed class OfficeDocumentReader {
         string? sourceName = null,
         ReaderOptions? options = null,
         CancellationToken cancellationToken = default) {
-        return ExecuteAsync(() => DocumentReader.ReadAsync(bytes, sourceName, options, cancellationToken), cancellationToken);
+        if (ProcessorPipeline.Count == 0) {
+            return ExecuteAsync(() => DocumentReader.ReadAsync(bytes, sourceName, options, cancellationToken), cancellationToken);
+        }
+        return ExecuteProcessedChunksAsync(
+            () => DocumentReader.ReadDocumentAsync(bytes, sourceName, options, cancellationToken),
+            cancellationToken);
     }
 
     /// <summary>
@@ -108,7 +139,7 @@ public sealed class OfficeDocumentReader {
         ReaderOptions? options = null,
         CancellationToken cancellationToken = default) {
         using (DocumentReader.UseHandlerRegistry(_handlers)) {
-            return DocumentReader.ReadDocument(path, options, cancellationToken);
+            return ProcessDocumentResult(DocumentReader.ReadDocument(path, options, cancellationToken), cancellationToken);
         }
     }
 
@@ -121,7 +152,7 @@ public sealed class OfficeDocumentReader {
         ReaderOptions? options = null,
         CancellationToken cancellationToken = default) {
         using (DocumentReader.UseHandlerRegistry(_handlers)) {
-            return DocumentReader.ReadDocument(stream, sourceName, options, cancellationToken);
+            return ProcessDocumentResult(DocumentReader.ReadDocument(stream, sourceName, options, cancellationToken), cancellationToken);
         }
     }
 
@@ -134,7 +165,7 @@ public sealed class OfficeDocumentReader {
         ReaderOptions? options = null,
         CancellationToken cancellationToken = default) {
         using (DocumentReader.UseHandlerRegistry(_handlers)) {
-            return DocumentReader.ReadDocument(bytes, sourceName, options, cancellationToken);
+            return ProcessDocumentResult(DocumentReader.ReadDocument(bytes, sourceName, options, cancellationToken), cancellationToken);
         }
     }
 
@@ -145,7 +176,9 @@ public sealed class OfficeDocumentReader {
         string path,
         ReaderOptions? options = null,
         CancellationToken cancellationToken = default) {
-        return ExecuteAsync(() => DocumentReader.ReadDocumentAsync(path, options, cancellationToken), cancellationToken);
+        return ExecuteProcessedDocumentAsync(
+            () => DocumentReader.ReadDocumentAsync(path, options, cancellationToken),
+            cancellationToken);
     }
 
     /// <summary>
@@ -156,7 +189,9 @@ public sealed class OfficeDocumentReader {
         string? sourceName = null,
         ReaderOptions? options = null,
         CancellationToken cancellationToken = default) {
-        return ExecuteAsync(() => DocumentReader.ReadDocumentAsync(stream, sourceName, options, cancellationToken), cancellationToken);
+        return ExecuteProcessedDocumentAsync(
+            () => DocumentReader.ReadDocumentAsync(stream, sourceName, options, cancellationToken),
+            cancellationToken);
     }
 
     /// <summary>
@@ -167,7 +202,9 @@ public sealed class OfficeDocumentReader {
         string? sourceName = null,
         ReaderOptions? options = null,
         CancellationToken cancellationToken = default) {
-        return ExecuteAsync(() => DocumentReader.ReadDocumentAsync(bytes, sourceName, options, cancellationToken), cancellationToken);
+        return ExecuteProcessedDocumentAsync(
+            () => DocumentReader.ReadDocumentAsync(bytes, sourceName, options, cancellationToken),
+            cancellationToken);
     }
 
     /// <summary>
@@ -195,9 +232,7 @@ public sealed class OfficeDocumentReader {
         ReaderOptions? options = null,
         bool indented = false,
         CancellationToken cancellationToken = default) {
-        using (DocumentReader.UseHandlerRegistry(_handlers)) {
-            return DocumentReader.ReadDocumentJson(path, options, indented, cancellationToken);
-        }
+        return OfficeDocumentReadResultJson.Serialize(ReadDocument(path, options, cancellationToken), indented);
     }
 
     /// <summary>
@@ -209,9 +244,9 @@ public sealed class OfficeDocumentReader {
         ReaderOptions? options = null,
         bool indented = false,
         CancellationToken cancellationToken = default) {
-        using (DocumentReader.UseHandlerRegistry(_handlers)) {
-            return DocumentReader.ReadDocumentJson(stream, sourceName, options, indented, cancellationToken);
-        }
+        return OfficeDocumentReadResultJson.Serialize(
+            ReadDocument(stream, sourceName, options, cancellationToken),
+            indented);
     }
 
     /// <summary>
@@ -223,9 +258,9 @@ public sealed class OfficeDocumentReader {
         ReaderOptions? options = null,
         bool indented = false,
         CancellationToken cancellationToken = default) {
-        using (DocumentReader.UseHandlerRegistry(_handlers)) {
-            return DocumentReader.ReadDocumentJson(bytes, sourceName, options, indented, cancellationToken);
-        }
+        return OfficeDocumentReadResultJson.Serialize(
+            ReadDocument(bytes, sourceName, options, cancellationToken),
+            indented);
     }
 
     /// <summary>

--- a/OfficeIMO.Reader/OfficeDocumentReader.cs
+++ b/OfficeIMO.Reader/OfficeDocumentReader.cs
@@ -96,6 +96,7 @@ public sealed partial class OfficeDocumentReader {
         }
         return ExecuteProcessedChunksAsync(
             () => DocumentReader.ReadDocumentAsync(path, options, cancellationToken),
+            options?.ComputeHashes ?? true,
             cancellationToken);
     }
 
@@ -112,6 +113,7 @@ public sealed partial class OfficeDocumentReader {
         }
         return ExecuteProcessedChunksAsync(
             () => DocumentReader.ReadDocumentAsync(stream, sourceName, options, cancellationToken),
+            options?.ComputeHashes ?? true,
             cancellationToken);
     }
 
@@ -128,6 +130,7 @@ public sealed partial class OfficeDocumentReader {
         }
         return ExecuteProcessedChunksAsync(
             () => DocumentReader.ReadDocumentAsync(bytes, sourceName, options, cancellationToken),
+            options?.ComputeHashes ?? true,
             cancellationToken);
     }
 
@@ -139,7 +142,10 @@ public sealed partial class OfficeDocumentReader {
         ReaderOptions? options = null,
         CancellationToken cancellationToken = default) {
         using (DocumentReader.UseHandlerRegistry(_handlers)) {
-            return ProcessDocumentResult(DocumentReader.ReadDocument(path, options, cancellationToken), cancellationToken);
+            return ProcessDocumentResult(
+                DocumentReader.ReadDocument(path, options, cancellationToken),
+                options?.ComputeHashes ?? true,
+                cancellationToken);
         }
     }
 
@@ -152,7 +158,10 @@ public sealed partial class OfficeDocumentReader {
         ReaderOptions? options = null,
         CancellationToken cancellationToken = default) {
         using (DocumentReader.UseHandlerRegistry(_handlers)) {
-            return ProcessDocumentResult(DocumentReader.ReadDocument(stream, sourceName, options, cancellationToken), cancellationToken);
+            return ProcessDocumentResult(
+                DocumentReader.ReadDocument(stream, sourceName, options, cancellationToken),
+                options?.ComputeHashes ?? true,
+                cancellationToken);
         }
     }
 
@@ -165,7 +174,10 @@ public sealed partial class OfficeDocumentReader {
         ReaderOptions? options = null,
         CancellationToken cancellationToken = default) {
         using (DocumentReader.UseHandlerRegistry(_handlers)) {
-            return ProcessDocumentResult(DocumentReader.ReadDocument(bytes, sourceName, options, cancellationToken), cancellationToken);
+            return ProcessDocumentResult(
+                DocumentReader.ReadDocument(bytes, sourceName, options, cancellationToken),
+                options?.ComputeHashes ?? true,
+                cancellationToken);
         }
     }
 
@@ -178,6 +190,7 @@ public sealed partial class OfficeDocumentReader {
         CancellationToken cancellationToken = default) {
         return ExecuteProcessedDocumentAsync(
             () => DocumentReader.ReadDocumentAsync(path, options, cancellationToken),
+            options?.ComputeHashes ?? true,
             cancellationToken);
     }
 
@@ -191,6 +204,7 @@ public sealed partial class OfficeDocumentReader {
         CancellationToken cancellationToken = default) {
         return ExecuteProcessedDocumentAsync(
             () => DocumentReader.ReadDocumentAsync(stream, sourceName, options, cancellationToken),
+            options?.ComputeHashes ?? true,
             cancellationToken);
     }
 
@@ -204,6 +218,7 @@ public sealed partial class OfficeDocumentReader {
         CancellationToken cancellationToken = default) {
         return ExecuteProcessedDocumentAsync(
             () => DocumentReader.ReadDocumentAsync(bytes, sourceName, options, cancellationToken),
+            options?.ComputeHashes ?? true,
             cancellationToken);
     }
 

--- a/OfficeIMO.Reader/OfficeDocumentReaderBuilder.Processors.cs
+++ b/OfficeIMO.Reader/OfficeDocumentReaderBuilder.Processors.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+
+namespace OfficeIMO.Reader;
+
+public sealed partial class OfficeDocumentReaderBuilder {
+    private readonly OfficeDocumentProcessorPipelineBuilder _processorPipelineBuilder = new OfficeDocumentProcessorPipelineBuilder();
+    private OfficeDocumentProcessingOptions _processingOptions = new OfficeDocumentProcessingOptions();
+
+    /// <summary>Adds a document processor after existing processors.</summary>
+    public OfficeDocumentReaderBuilder AddProcessor(IOfficeDocumentProcessor processor) {
+        _processorPipelineBuilder.Add(processor);
+        return this;
+    }
+
+    /// <summary>Adds document processors in enumeration order.</summary>
+    public OfficeDocumentReaderBuilder AddProcessors(IEnumerable<IOfficeDocumentProcessor> processors) {
+        _processorPipelineBuilder.AddRange(processors);
+        return this;
+    }
+
+    /// <summary>Replaces configured processors with a snapshot of an existing pipeline.</summary>
+    public OfficeDocumentReaderBuilder UseProcessorPipeline(OfficeDocumentProcessorPipeline pipeline) {
+        if (pipeline == null) throw new ArgumentNullException(nameof(pipeline));
+        _processorPipelineBuilder.Clear().AddRange(pipeline.Processors);
+        return this;
+    }
+
+    /// <summary>Removes a configured processor by stable identifier.</summary>
+    public bool RemoveProcessor(string processorId) {
+        return _processorPipelineBuilder.Remove(processorId);
+    }
+
+    /// <summary>Removes all configured processors.</summary>
+    public OfficeDocumentReaderBuilder ClearProcessors() {
+        _processorPipelineBuilder.Clear();
+        return this;
+    }
+
+    /// <summary>Sets processor failure behavior for the built reader.</summary>
+    public OfficeDocumentReaderBuilder WithProcessorFailureBehavior(
+        OfficeDocumentProcessorFailureBehavior failureBehavior) {
+        if (!Enum.IsDefined(typeof(OfficeDocumentProcessorFailureBehavior), failureBehavior)) {
+            throw new ArgumentOutOfRangeException(nameof(failureBehavior));
+        }
+        _processingOptions = new OfficeDocumentProcessingOptions { FailureBehavior = failureBehavior };
+        return this;
+    }
+}

--- a/OfficeIMO.Reader/OfficeDocumentReaderBuilder.cs
+++ b/OfficeIMO.Reader/OfficeDocumentReaderBuilder.cs
@@ -9,7 +9,7 @@ namespace OfficeIMO.Reader;
 /// A builder may be reused or changed after <see cref="Build"/>. Each built reader retains its own
 /// immutable snapshot and is unaffected by later builder or static <see cref="DocumentReader"/> registrations.
 /// </remarks>
-public sealed class OfficeDocumentReaderBuilder {
+public sealed partial class OfficeDocumentReaderBuilder {
     private readonly ReaderHandlerRegistry _handlers = new ReaderHandlerRegistry(DocumentReader.BuiltInExtensions);
     private int _maxConcurrentReads = DocumentReader.DefaultMaxConcurrentReads;
 
@@ -57,6 +57,10 @@ public sealed class OfficeDocumentReaderBuilder {
     /// Creates an immutable, thread-safe reader from the current configuration.
     /// </summary>
     public OfficeDocumentReader Build() {
-        return new OfficeDocumentReader(_handlers.CaptureSnapshot(), _maxConcurrentReads);
+        return new OfficeDocumentReader(
+            _handlers.CaptureSnapshot(),
+            _maxConcurrentReads,
+            _processorPipelineBuilder.Build(),
+            _processingOptions.Clone());
     }
 }

--- a/OfficeIMO.Reader/Processors/OfficeDocumentArtifactClassificationProcessor.cs
+++ b/OfficeIMO.Reader/Processors/OfficeDocumentArtifactClassificationProcessor.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>Options for repeated page-boundary artifact classification.</summary>
+public sealed class OfficeDocumentArtifactClassificationOptions {
+    /// <summary>Minimum number of distinct pages on which boundary text must repeat.</summary>
+    public int MinimumPageOccurrences { get; set; } = 2;
+
+    /// <summary>Number of non-empty blocks inspected at each page boundary.</summary>
+    public int BoundaryBlockCount { get; set; } = 2;
+
+    /// <summary>Maximum normalized text length eligible for artifact classification.</summary>
+    public int MaximumTextLength { get; set; } = 200;
+
+    internal OfficeDocumentArtifactClassificationOptions Clone() => new OfficeDocumentArtifactClassificationOptions {
+        MinimumPageOccurrences = MinimumPageOccurrences,
+        BoundaryBlockCount = BoundaryBlockCount,
+        MaximumTextLength = MaximumTextLength
+    };
+}
+
+/// <summary>
+/// Classifies short text repeated at page starts or ends as header, footer, or artifact blocks.
+/// </summary>
+public sealed class OfficeDocumentArtifactClassificationProcessor : OfficeDocumentProcessorBase {
+    private readonly OfficeDocumentArtifactClassificationOptions _options;
+
+    /// <summary>Creates the processor.</summary>
+    public OfficeDocumentArtifactClassificationProcessor(OfficeDocumentArtifactClassificationOptions? options = null)
+        : base("officeimo.reader.classify-artifacts") {
+        _options = (options ?? new OfficeDocumentArtifactClassificationOptions()).Clone();
+        if (_options.MinimumPageOccurrences < 2) throw new ArgumentOutOfRangeException(nameof(options), "Minimum page occurrences must be at least 2.");
+        if (_options.BoundaryBlockCount < 1) throw new ArgumentOutOfRangeException(nameof(options), "Boundary block count must be positive.");
+        if (_options.MaximumTextLength < 1) throw new ArgumentOutOfRangeException(nameof(options), "Maximum text length must be positive.");
+    }
+
+    /// <inheritdoc />
+    public override OfficeDocumentReadResult Process(
+        OfficeDocumentReadResult document,
+        OfficeDocumentProcessorContext context) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        IReadOnlyList<OfficeDocumentPage> pages = document.Pages ?? Array.Empty<OfficeDocumentPage>();
+        if (pages.Count < _options.MinimumPageOccurrences) return document;
+
+        Dictionary<string, int> headerCounts = CountBoundaryText(pages, fromStart: true, context);
+        Dictionary<string, int> footerCounts = CountBoundaryText(pages, fromStart: false, context);
+        HashSet<string> headers = SelectRepeated(headerCounts);
+        HashSet<string> footers = SelectRepeated(footerCounts);
+        if (headers.Count == 0 && footers.Count == 0) return document;
+
+        ApplyBoundaryClassifications(document, pages, headers, footers, context);
+        return document;
+    }
+
+    private void ApplyBoundaryClassifications(
+        OfficeDocumentReadResult document,
+        IReadOnlyList<OfficeDocumentPage> pages,
+        ISet<string> headers,
+        ISet<string> footers,
+        OfficeDocumentProcessorContext context) {
+        var classifications = new Dictionary<OfficeDocumentBlock, string>(ReferenceIdentityComparer<OfficeDocumentBlock>.Instance);
+        for (int pageIndex = 0; pageIndex < pages.Count; pageIndex++) {
+            context.CancellationToken.ThrowIfCancellationRequested();
+            IReadOnlyList<OfficeDocumentBlock> blocks = pages[pageIndex]?.Blocks ?? Array.Empty<OfficeDocumentBlock>();
+            ClassifyBoundarySide(blocks, fromStart: true, headers, "header", classifications);
+            ClassifyBoundarySide(blocks, fromStart: false, footers, "footer", classifications);
+        }
+
+        var classificationsById = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (KeyValuePair<OfficeDocumentBlock, string> classification in classifications) {
+            classification.Key.Kind = classification.Value;
+            if (!string.IsNullOrWhiteSpace(classification.Key.Id)) {
+                MergeClassification(classificationsById, classification.Key.Id, classification.Value);
+            }
+        }
+
+        foreach (OfficeDocumentBlock block in document.Blocks ?? Array.Empty<OfficeDocumentBlock>()) {
+            context.CancellationToken.ThrowIfCancellationRequested();
+            if (block != null &&
+                !string.IsNullOrWhiteSpace(block.Id) &&
+                classificationsById.TryGetValue(block.Id, out string? kind)) {
+                block.Kind = kind;
+            }
+        }
+    }
+
+    private void ClassifyBoundarySide(
+        IReadOnlyList<OfficeDocumentBlock> blocks,
+        bool fromStart,
+        ISet<string> repeated,
+        string kind,
+        IDictionary<OfficeDocumentBlock, string> classifications) {
+        int accepted = 0;
+        for (int offset = 0; offset < blocks.Count && accepted < _options.BoundaryBlockCount; offset++) {
+            int blockIndex = fromStart ? offset : blocks.Count - 1 - offset;
+            OfficeDocumentBlock? block = blocks[blockIndex];
+            string text = NormalizeText(block?.Text);
+            if (text.Length == 0 || text.Length > _options.MaximumTextLength) continue;
+            accepted++;
+            if (block != null && repeated.Contains(text)) MergeClassification(classifications, block, kind);
+        }
+    }
+
+    private static void MergeClassification<TKey>(IDictionary<TKey, string> classifications, TKey key, string kind) {
+        if (classifications.TryGetValue(key, out string? existing) && !string.Equals(existing, kind, StringComparison.Ordinal)) {
+            classifications[key] = "artifact";
+        } else {
+            classifications[key] = kind;
+        }
+    }
+
+    private Dictionary<string, int> CountBoundaryText(
+        IReadOnlyList<OfficeDocumentPage> pages,
+        bool fromStart,
+        OfficeDocumentProcessorContext context) {
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (int pageIndex = 0; pageIndex < pages.Count; pageIndex++) {
+            context.CancellationToken.ThrowIfCancellationRequested();
+            IReadOnlyList<OfficeDocumentBlock> blocks = pages[pageIndex]?.Blocks ?? Array.Empty<OfficeDocumentBlock>();
+            var onPage = new HashSet<string>(StringComparer.Ordinal);
+            int accepted = 0;
+            for (int offset = 0; offset < blocks.Count && accepted < _options.BoundaryBlockCount; offset++) {
+                int blockIndex = fromStart ? offset : blocks.Count - 1 - offset;
+                string text = NormalizeText(blocks[blockIndex]?.Text);
+                if (text.Length == 0 || text.Length > _options.MaximumTextLength) continue;
+                accepted++;
+                onPage.Add(text);
+            }
+            foreach (string text in onPage) {
+                counts[text] = counts.TryGetValue(text, out int count) ? count + 1 : 1;
+            }
+        }
+        return counts;
+    }
+
+    private HashSet<string> SelectRepeated(Dictionary<string, int> counts) {
+        var repeated = new HashSet<string>(StringComparer.Ordinal);
+        foreach (KeyValuePair<string, int> entry in counts) {
+            if (entry.Value >= _options.MinimumPageOccurrences) repeated.Add(entry.Key);
+        }
+        return repeated;
+    }
+
+    private static string NormalizeText(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) return string.Empty;
+        var normalized = new StringBuilder(value!.Length);
+        bool pendingSpace = false;
+        for (int index = 0; index < value.Length; index++) {
+            char character = value[index];
+            if (char.IsWhiteSpace(character)) {
+                pendingSpace = normalized.Length > 0;
+                continue;
+            }
+            if (pendingSpace) normalized.Append(' ');
+            normalized.Append(character);
+            pendingSpace = false;
+        }
+        return normalized.ToString();
+    }
+}

--- a/OfficeIMO.Reader/Processors/OfficeDocumentAssetFilterProcessor.cs
+++ b/OfficeIMO.Reader/Processors/OfficeDocumentAssetFilterProcessor.cs
@@ -33,6 +33,7 @@ public sealed class OfficeDocumentAssetFilterProcessor : OfficeDocumentProcessor
         foreach (OfficeDocumentPage page in document.Pages ?? Array.Empty<OfficeDocumentPage>()) {
             page.OcrCandidates = FilterCandidates(page.OcrCandidates, removedIds);
         }
+        document.Diagnostics = RebuildOcrDiagnostics(document);
         return document;
     }
 
@@ -62,5 +63,40 @@ public sealed class OfficeDocumentAssetFilterProcessor : OfficeDocumentProcessor
             .Where(candidate => candidate != null &&
                 (string.IsNullOrWhiteSpace(candidate.AssetId) || !removedIds.Contains(candidate.AssetId!)))
             .ToArray();
+    }
+
+    private static IReadOnlyList<OfficeDocumentDiagnostic> RebuildOcrDiagnostics(OfficeDocumentReadResult document) {
+        var diagnostics = (document.Diagnostics ?? Array.Empty<OfficeDocumentDiagnostic>())
+            .Where(static diagnostic => diagnostic != null &&
+                !string.Equals(diagnostic.Code, "ocr-needed", StringComparison.Ordinal))
+            .ToList();
+        var seenIds = new HashSet<string>(StringComparer.Ordinal);
+        var seenCandidates = new HashSet<OfficeDocumentOcrCandidate>(ReferenceIdentityComparer<OfficeDocumentOcrCandidate>.Instance);
+        foreach (OfficeDocumentOcrCandidate candidate in EnumerateCandidates(document)) {
+            if (candidate == null || !seenCandidates.Add(candidate)) continue;
+            if (!string.IsNullOrWhiteSpace(candidate.Id) && !seenIds.Add(candidate.Id)) continue;
+            diagnostics.Add(new OfficeDocumentDiagnostic {
+                Severity = OfficeDocumentDiagnosticSeverity.Warning,
+                Category = OfficeDocumentDiagnosticCategory.Ocr,
+                Code = "ocr-needed",
+                Message = candidate.Reason ?? "OCR may be needed before text extraction is complete.",
+                Source = "officeimo.reader.filter-assets",
+                IsRecoverable = true,
+                Location = candidate.Location
+            });
+        }
+        return diagnostics.Count == 0 ? Array.Empty<OfficeDocumentDiagnostic>() : diagnostics.ToArray();
+    }
+
+    private static IEnumerable<OfficeDocumentOcrCandidate> EnumerateCandidates(OfficeDocumentReadResult document) {
+        foreach (OfficeDocumentOcrCandidate candidate in document.OcrCandidates ?? Array.Empty<OfficeDocumentOcrCandidate>()) {
+            if (candidate != null) yield return candidate;
+        }
+        foreach (OfficeDocumentPage page in document.Pages ?? Array.Empty<OfficeDocumentPage>()) {
+            if (page?.OcrCandidates == null) continue;
+            foreach (OfficeDocumentOcrCandidate candidate in page.OcrCandidates) {
+                if (candidate != null) yield return candidate;
+            }
+        }
     }
 }

--- a/OfficeIMO.Reader/Processors/OfficeDocumentAssetFilterProcessor.cs
+++ b/OfficeIMO.Reader/Processors/OfficeDocumentAssetFilterProcessor.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>Filters shared assets and removes OCR candidates that target removed asset ids.</summary>
+public sealed class OfficeDocumentAssetFilterProcessor : OfficeDocumentProcessorBase {
+    private readonly Func<OfficeDocumentAsset, bool> _predicate;
+
+    /// <summary>
+    /// Creates the processor. The predicate must be deterministic and safe for concurrent calls when used by a shared reader.
+    /// </summary>
+    public OfficeDocumentAssetFilterProcessor(Func<OfficeDocumentAsset, bool> predicate)
+        : base("officeimo.reader.filter-assets") {
+        _predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
+    }
+
+    /// <inheritdoc />
+    public override OfficeDocumentReadResult Process(
+        OfficeDocumentReadResult document,
+        OfficeDocumentProcessorContext context) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        var removedIds = new HashSet<string>(StringComparer.Ordinal);
+        document.Assets = FilterAssets(document.Assets, removedIds, context.CancellationToken);
+        foreach (OfficeDocumentPage page in document.Pages ?? Array.Empty<OfficeDocumentPage>()) {
+            context.CancellationToken.ThrowIfCancellationRequested();
+            page.Assets = FilterAssets(page.Assets, removedIds, context.CancellationToken);
+        }
+
+        if (removedIds.Count == 0) return document;
+        document.OcrCandidates = FilterCandidates(document.OcrCandidates, removedIds);
+        foreach (OfficeDocumentPage page in document.Pages ?? Array.Empty<OfficeDocumentPage>()) {
+            page.OcrCandidates = FilterCandidates(page.OcrCandidates, removedIds);
+        }
+        return document;
+    }
+
+    private IReadOnlyList<OfficeDocumentAsset> FilterAssets(
+        IReadOnlyList<OfficeDocumentAsset>? assets,
+        ISet<string> removedIds,
+        System.Threading.CancellationToken cancellationToken) {
+        if (assets == null || assets.Count == 0) return Array.Empty<OfficeDocumentAsset>();
+        var kept = new List<OfficeDocumentAsset>(assets.Count);
+        for (int index = 0; index < assets.Count; index++) {
+            cancellationToken.ThrowIfCancellationRequested();
+            OfficeDocumentAsset asset = assets[index];
+            if (asset != null && _predicate(asset)) {
+                kept.Add(asset);
+            } else if (asset != null && !string.IsNullOrWhiteSpace(asset.Id)) {
+                removedIds.Add(asset.Id);
+            }
+        }
+        return kept.Count == 0 ? Array.Empty<OfficeDocumentAsset>() : kept.ToArray();
+    }
+
+    private static IReadOnlyList<OfficeDocumentOcrCandidate> FilterCandidates(
+        IReadOnlyList<OfficeDocumentOcrCandidate>? candidates,
+        ISet<string> removedIds) {
+        if (candidates == null || candidates.Count == 0) return Array.Empty<OfficeDocumentOcrCandidate>();
+        return candidates
+            .Where(candidate => candidate != null &&
+                (string.IsNullOrWhiteSpace(candidate.AssetId) || !removedIds.Contains(candidate.AssetId!)))
+            .ToArray();
+    }
+}

--- a/OfficeIMO.Reader/Processors/OfficeDocumentAssetFilterProcessor.cs
+++ b/OfficeIMO.Reader/Processors/OfficeDocumentAssetFilterProcessor.cs
@@ -28,6 +28,7 @@ public sealed class OfficeDocumentAssetFilterProcessor : OfficeDocumentProcessor
             context.CancellationToken.ThrowIfCancellationRequested();
             page.Assets = FilterAssets(page.Assets, removedIds, keptIds, context.CancellationToken);
         }
+        document.Metadata = RefreshAssetCountMetadata(document.Metadata, document.Assets.Count);
 
         removedIds.ExceptWith(keptIds);
         if (removedIds.Count == 0) return document;
@@ -40,6 +41,26 @@ public sealed class OfficeDocumentAssetFilterProcessor : OfficeDocumentProcessor
         }
         document.Diagnostics = FilterOcrDiagnostics(document, removedIds, removedCandidates);
         return document;
+    }
+
+    private static IReadOnlyList<OfficeDocumentMetadataEntry> RefreshAssetCountMetadata(
+        IReadOnlyList<OfficeDocumentMetadataEntry>? metadata,
+        int assetCount) {
+        if (metadata == null || metadata.Count == 0) return Array.Empty<OfficeDocumentMetadataEntry>();
+        var refreshed = new List<OfficeDocumentMetadataEntry>(metadata.Count);
+        bool emittedCount = false;
+        foreach (OfficeDocumentMetadataEntry entry in metadata) {
+            if (entry == null) continue;
+            if (!string.Equals(entry.Id, "reader-asset-count", StringComparison.Ordinal)) {
+                refreshed.Add(entry);
+                continue;
+            }
+            if (emittedCount || assetCount == 0) continue;
+            entry.Value = assetCount.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            refreshed.Add(entry);
+            emittedCount = true;
+        }
+        return refreshed.Count == 0 ? Array.Empty<OfficeDocumentMetadataEntry>() : refreshed.ToArray();
     }
 
     private IReadOnlyList<OfficeDocumentAsset> FilterAssets(

--- a/OfficeIMO.Reader/Processors/OfficeDocumentAssetFilterProcessor.cs
+++ b/OfficeIMO.Reader/Processors/OfficeDocumentAssetFilterProcessor.cs
@@ -22,12 +22,14 @@ public sealed class OfficeDocumentAssetFilterProcessor : OfficeDocumentProcessor
         OfficeDocumentProcessorContext context) {
         if (document == null) throw new ArgumentNullException(nameof(document));
         var removedIds = new HashSet<string>(StringComparer.Ordinal);
-        document.Assets = FilterAssets(document.Assets, removedIds, context.CancellationToken);
+        var keptIds = new HashSet<string>(StringComparer.Ordinal);
+        document.Assets = FilterAssets(document.Assets, removedIds, keptIds, context.CancellationToken);
         foreach (OfficeDocumentPage page in document.Pages ?? Array.Empty<OfficeDocumentPage>()) {
             context.CancellationToken.ThrowIfCancellationRequested();
-            page.Assets = FilterAssets(page.Assets, removedIds, context.CancellationToken);
+            page.Assets = FilterAssets(page.Assets, removedIds, keptIds, context.CancellationToken);
         }
 
+        removedIds.ExceptWith(keptIds);
         if (removedIds.Count == 0) return document;
         document.OcrCandidates = FilterCandidates(document.OcrCandidates, removedIds);
         foreach (OfficeDocumentPage page in document.Pages ?? Array.Empty<OfficeDocumentPage>()) {
@@ -40,6 +42,7 @@ public sealed class OfficeDocumentAssetFilterProcessor : OfficeDocumentProcessor
     private IReadOnlyList<OfficeDocumentAsset> FilterAssets(
         IReadOnlyList<OfficeDocumentAsset>? assets,
         ISet<string> removedIds,
+        ISet<string> keptIds,
         System.Threading.CancellationToken cancellationToken) {
         if (assets == null || assets.Count == 0) return Array.Empty<OfficeDocumentAsset>();
         var kept = new List<OfficeDocumentAsset>(assets.Count);
@@ -48,6 +51,7 @@ public sealed class OfficeDocumentAssetFilterProcessor : OfficeDocumentProcessor
             OfficeDocumentAsset asset = assets[index];
             if (asset != null && _predicate(asset)) {
                 kept.Add(asset);
+                if (!string.IsNullOrWhiteSpace(asset.Id)) keptIds.Add(asset.Id);
             } else if (asset != null && !string.IsNullOrWhiteSpace(asset.Id)) {
                 removedIds.Add(asset.Id);
             }

--- a/OfficeIMO.Reader/Processors/OfficeDocumentAssetFilterProcessor.cs
+++ b/OfficeIMO.Reader/Processors/OfficeDocumentAssetFilterProcessor.cs
@@ -31,11 +31,14 @@ public sealed class OfficeDocumentAssetFilterProcessor : OfficeDocumentProcessor
 
         removedIds.ExceptWith(keptIds);
         if (removedIds.Count == 0) return document;
+        IReadOnlyList<OfficeDocumentOcrCandidate> removedCandidates = EnumerateCandidates(document)
+            .Where(candidate => !string.IsNullOrWhiteSpace(candidate.AssetId) && removedIds.Contains(candidate.AssetId!))
+            .ToArray();
         document.OcrCandidates = FilterCandidates(document.OcrCandidates, removedIds);
         foreach (OfficeDocumentPage page in document.Pages ?? Array.Empty<OfficeDocumentPage>()) {
             page.OcrCandidates = FilterCandidates(page.OcrCandidates, removedIds);
         }
-        document.Diagnostics = RebuildOcrDiagnostics(document);
+        document.Diagnostics = FilterOcrDiagnostics(document, removedIds, removedCandidates);
         return document;
     }
 
@@ -69,28 +72,48 @@ public sealed class OfficeDocumentAssetFilterProcessor : OfficeDocumentProcessor
             .ToArray();
     }
 
-    private static IReadOnlyList<OfficeDocumentDiagnostic> RebuildOcrDiagnostics(OfficeDocumentReadResult document) {
-        var diagnostics = (document.Diagnostics ?? Array.Empty<OfficeDocumentDiagnostic>())
-            .Where(static diagnostic => diagnostic != null &&
-                !string.Equals(diagnostic.Code, "ocr-needed", StringComparison.Ordinal))
-            .ToList();
-        var seenIds = new HashSet<string>(StringComparer.Ordinal);
-        var seenCandidates = new HashSet<OfficeDocumentOcrCandidate>(ReferenceIdentityComparer<OfficeDocumentOcrCandidate>.Instance);
-        foreach (OfficeDocumentOcrCandidate candidate in EnumerateCandidates(document)) {
-            if (candidate == null || !seenCandidates.Add(candidate)) continue;
-            if (!string.IsNullOrWhiteSpace(candidate.Id) && !seenIds.Add(candidate.Id)) continue;
-            diagnostics.Add(new OfficeDocumentDiagnostic {
-                Severity = OfficeDocumentDiagnosticSeverity.Warning,
-                Category = OfficeDocumentDiagnosticCategory.Ocr,
-                Code = "ocr-needed",
-                Message = candidate.Reason ?? "OCR may be needed before text extraction is complete.",
-                Source = "officeimo.reader.filter-assets",
-                IsRecoverable = true,
-                Location = candidate.Location
-            });
+    private static IReadOnlyList<OfficeDocumentDiagnostic> FilterOcrDiagnostics(
+        OfficeDocumentReadResult document,
+        ISet<string> removedIds,
+        IReadOnlyList<OfficeDocumentOcrCandidate> removedCandidates) {
+        var removedSignatures = new HashSet<string>(
+            removedCandidates.Select(candidate => BuildOcrSignature(candidate.Reason, candidate.Location)),
+            StringComparer.Ordinal);
+        var remainingSignatures = new HashSet<string>(
+            EnumerateCandidates(document).Select(candidate => BuildOcrSignature(candidate.Reason, candidate.Location)),
+            StringComparer.Ordinal);
+        var diagnostics = new List<OfficeDocumentDiagnostic>();
+        foreach (OfficeDocumentDiagnostic diagnostic in document.Diagnostics ?? Array.Empty<OfficeDocumentDiagnostic>()) {
+            if (diagnostic == null) continue;
+            if (!string.Equals(diagnostic.Code, "ocr-needed", StringComparison.Ordinal)) {
+                diagnostics.Add(diagnostic);
+                continue;
+            }
+            if (IsTiedToRemovedAsset(diagnostic, removedIds)) continue;
+            string signature = BuildOcrSignature(diagnostic.Message, diagnostic.Location);
+            if (removedSignatures.Contains(signature) && !remainingSignatures.Contains(signature)) continue;
+            diagnostics.Add(diagnostic);
         }
         return diagnostics.Count == 0 ? Array.Empty<OfficeDocumentDiagnostic>() : diagnostics.ToArray();
     }
+
+    private static bool IsTiedToRemovedAsset(OfficeDocumentDiagnostic diagnostic, ISet<string> removedIds) {
+        if (!string.IsNullOrWhiteSpace(diagnostic.Location?.BlockAnchor) &&
+            removedIds.Contains(diagnostic.Location!.BlockAnchor!)) return true;
+        return diagnostic.Attributes != null &&
+            diagnostic.Attributes.TryGetValue("assetId", out string? assetId) &&
+            !string.IsNullOrWhiteSpace(assetId) &&
+            removedIds.Contains(assetId!);
+    }
+
+    private static string BuildOcrSignature(string? reason, ReaderLocation? location) => string.Join("|", new[] {
+        reason ?? string.Empty,
+        location?.Path ?? string.Empty,
+        location?.Page?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty,
+        location?.Slide?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty,
+        location?.Sheet ?? string.Empty,
+        location?.BlockAnchor ?? string.Empty
+    });
 
     private static IEnumerable<OfficeDocumentOcrCandidate> EnumerateCandidates(OfficeDocumentReadResult document) {
         foreach (OfficeDocumentOcrCandidate candidate in document.OcrCandidates ?? Array.Empty<OfficeDocumentOcrCandidate>()) {

--- a/OfficeIMO.Reader/Processors/OfficeDocumentBlockNormalizationProcessor.cs
+++ b/OfficeIMO.Reader/Processors/OfficeDocumentBlockNormalizationProcessor.cs
@@ -47,7 +47,7 @@ public sealed class OfficeDocumentBlockNormalizationProcessor : OfficeDocumentPr
             if (_options.NormalizeLevels && block.Level.HasValue) {
                 if (string.Equals(block.Kind, "heading", StringComparison.OrdinalIgnoreCase)) {
                     block.Level = Math.Max(1, Math.Min(6, block.Level.Value));
-                } else if (block.Kind.IndexOf("list", StringComparison.OrdinalIgnoreCase) >= 0) {
+                } else if ((block.Kind?.IndexOf("list", StringComparison.OrdinalIgnoreCase) ?? -1) >= 0) {
                     block.Level = Math.Max(1, block.Level.Value);
                 }
             }

--- a/OfficeIMO.Reader/Processors/OfficeDocumentBlockNormalizationProcessor.cs
+++ b/OfficeIMO.Reader/Processors/OfficeDocumentBlockNormalizationProcessor.cs
@@ -1,0 +1,57 @@
+using System;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>Options for deterministic block, heading, and list normalization.</summary>
+public sealed class OfficeDocumentBlockNormalizationOptions {
+    /// <summary>Trim block text.</summary>
+    public bool TrimText { get; set; } = true;
+
+    /// <summary>Trim and lowercase block kind identifiers.</summary>
+    public bool NormalizeKinds { get; set; } = true;
+
+    /// <summary>Trim list and leader markers.</summary>
+    public bool TrimMarkers { get; set; } = true;
+
+    /// <summary>Clamp heading levels to 1-6 and list levels to a minimum of 1.</summary>
+    public bool NormalizeLevels { get; set; } = true;
+
+    internal OfficeDocumentBlockNormalizationOptions Clone() => new OfficeDocumentBlockNormalizationOptions {
+        TrimText = TrimText,
+        NormalizeKinds = NormalizeKinds,
+        TrimMarkers = TrimMarkers,
+        NormalizeLevels = NormalizeLevels
+    };
+}
+
+/// <summary>Normalizes shared logical blocks without invoking a format-specific parser.</summary>
+public sealed class OfficeDocumentBlockNormalizationProcessor : OfficeDocumentProcessorBase {
+    private readonly OfficeDocumentBlockNormalizationOptions _options;
+
+    /// <summary>Creates the processor.</summary>
+    public OfficeDocumentBlockNormalizationProcessor(OfficeDocumentBlockNormalizationOptions? options = null)
+        : base("officeimo.reader.normalize-blocks") {
+        _options = (options ?? new OfficeDocumentBlockNormalizationOptions()).Clone();
+    }
+
+    /// <inheritdoc />
+    public override OfficeDocumentReadResult Process(
+        OfficeDocumentReadResult document,
+        OfficeDocumentProcessorContext context) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        foreach (OfficeDocumentBlock block in OfficeDocumentModelTraversal.Blocks(document)) {
+            context.CancellationToken.ThrowIfCancellationRequested();
+            if (_options.TrimText) block.Text = (block.Text ?? string.Empty).Trim();
+            if (_options.NormalizeKinds) block.Kind = (block.Kind ?? string.Empty).Trim().ToLowerInvariant();
+            if (_options.TrimMarkers && block.Marker != null) block.Marker = block.Marker.Trim();
+            if (_options.NormalizeLevels && block.Level.HasValue) {
+                if (string.Equals(block.Kind, "heading", StringComparison.OrdinalIgnoreCase)) {
+                    block.Level = Math.Max(1, Math.Min(6, block.Level.Value));
+                } else if (block.Kind.IndexOf("list", StringComparison.OrdinalIgnoreCase) >= 0) {
+                    block.Level = Math.Max(1, block.Level.Value);
+                }
+            }
+        }
+        return document;
+    }
+}

--- a/OfficeIMO.Reader/Processors/OfficeDocumentLinkNormalizationProcessor.cs
+++ b/OfficeIMO.Reader/Processors/OfficeDocumentLinkNormalizationProcessor.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>Normalizes scalar link and destination values without resolving or fetching targets.</summary>
+public sealed class OfficeDocumentLinkNormalizationProcessor : OfficeDocumentProcessorBase {
+    /// <summary>Creates the processor.</summary>
+    public OfficeDocumentLinkNormalizationProcessor()
+        : base("officeimo.reader.normalize-links") {
+    }
+
+    /// <inheritdoc />
+    public override OfficeDocumentReadResult Process(
+        OfficeDocumentReadResult document,
+        OfficeDocumentProcessorContext context) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        foreach (OfficeDocumentLink link in OfficeDocumentModelTraversal.Links(document)) {
+            context.CancellationToken.ThrowIfCancellationRequested();
+            link.Id = (link.Id ?? string.Empty).Trim();
+            link.Kind = (link.Kind ?? string.Empty).Trim().ToLowerInvariant();
+            link.Uri = TrimOrNull(link.Uri);
+            link.DestinationName = TrimOrNull(link.DestinationName);
+            link.DestinationMode = TrimOrNull(link.DestinationMode);
+            link.NamedAction = TrimOrNull(link.NamedAction);
+            link.RemoteFile = TrimOrNull(link.RemoteFile);
+            link.RemoteDestinationName = TrimOrNull(link.RemoteDestinationName);
+            link.RemoteDestinationMode = TrimOrNull(link.RemoteDestinationMode);
+            link.Text = TrimOrNull(link.Text);
+        }
+        return document;
+    }
+
+    private static string? TrimOrNull(string? value) {
+        if (value == null) return null;
+        string trimmed = value.Trim();
+        return trimmed.Length == 0 ? null : trimmed;
+    }
+}

--- a/OfficeIMO.Reader/Processors/OfficeDocumentTableNormalizationProcessor.cs
+++ b/OfficeIMO.Reader/Processors/OfficeDocumentTableNormalizationProcessor.cs
@@ -37,7 +37,7 @@ public sealed class OfficeDocumentTableNormalizationProcessor : OfficeDocumentPr
         OfficeDocumentReadResult document,
         OfficeDocumentProcessorContext context) {
         if (document == null) throw new ArgumentNullException(nameof(document));
-        foreach (ReaderTable table in OfficeDocumentModelTraversal.Tables(document)) {
+        foreach (ReaderTable table in OfficeDocumentModelTraversal.TableInstances(document)) {
             context.CancellationToken.ThrowIfCancellationRequested();
             Normalize(table);
         }

--- a/OfficeIMO.Reader/Processors/OfficeDocumentTableNormalizationProcessor.cs
+++ b/OfficeIMO.Reader/Processors/OfficeDocumentTableNormalizationProcessor.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>Options for deterministic table cleanup.</summary>
+public sealed class OfficeDocumentTableNormalizationOptions {
+    /// <summary>Trim column names and cell values.</summary>
+    public bool TrimValues { get; set; } = true;
+
+    /// <summary>Generate deterministic names for blank columns.</summary>
+    public bool FillMissingColumnNames { get; set; } = true;
+
+    /// <summary>Pad rows so every row has the same width.</summary>
+    public bool RectangularRows { get; set; } = true;
+
+    internal OfficeDocumentTableNormalizationOptions Clone() => new OfficeDocumentTableNormalizationOptions {
+        TrimValues = TrimValues,
+        FillMissingColumnNames = FillMissingColumnNames,
+        RectangularRows = RectangularRows
+    };
+}
+
+/// <summary>Normalizes table widths, column labels, cells, and column profiles.</summary>
+public sealed class OfficeDocumentTableNormalizationProcessor : OfficeDocumentProcessorBase {
+    private readonly OfficeDocumentTableNormalizationOptions _options;
+
+    /// <summary>Creates the processor.</summary>
+    public OfficeDocumentTableNormalizationProcessor(OfficeDocumentTableNormalizationOptions? options = null)
+        : base("officeimo.reader.normalize-tables") {
+        _options = (options ?? new OfficeDocumentTableNormalizationOptions()).Clone();
+    }
+
+    /// <inheritdoc />
+    public override OfficeDocumentReadResult Process(
+        OfficeDocumentReadResult document,
+        OfficeDocumentProcessorContext context) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        foreach (ReaderTable table in OfficeDocumentModelTraversal.Tables(document)) {
+            context.CancellationToken.ThrowIfCancellationRequested();
+            Normalize(table);
+        }
+        return document;
+    }
+
+    private void Normalize(ReaderTable table) {
+        IReadOnlyList<string> sourceColumns = table.Columns ?? Array.Empty<string>();
+        IReadOnlyList<IReadOnlyList<string>> sourceRows = table.Rows ?? Array.Empty<IReadOnlyList<string>>();
+        int width = sourceColumns.Count;
+        for (int rowIndex = 0; rowIndex < sourceRows.Count; rowIndex++) {
+            width = Math.Max(width, sourceRows[rowIndex]?.Count ?? 0);
+        }
+
+        var columns = new string[width];
+        for (int columnIndex = 0; columnIndex < width; columnIndex++) {
+            string value = columnIndex < sourceColumns.Count ? sourceColumns[columnIndex] ?? string.Empty : string.Empty;
+            if (_options.TrimValues) value = value.Trim();
+            if (_options.FillMissingColumnNames && value.Length == 0) {
+                value = "Column" + (columnIndex + 1).ToString(CultureInfo.InvariantCulture);
+            }
+            columns[columnIndex] = value;
+        }
+
+        var rows = new IReadOnlyList<string>[sourceRows.Count];
+        for (int rowIndex = 0; rowIndex < sourceRows.Count; rowIndex++) {
+            IReadOnlyList<string>? sourceRow = sourceRows[rowIndex];
+            int rowWidth = _options.RectangularRows ? width : sourceRow?.Count ?? 0;
+            var row = new string[rowWidth];
+            for (int columnIndex = 0; columnIndex < rowWidth; columnIndex++) {
+                string value = sourceRow != null && columnIndex < sourceRow.Count
+                    ? sourceRow[columnIndex] ?? string.Empty
+                    : string.Empty;
+                row[columnIndex] = _options.TrimValues ? value.Trim() : value;
+            }
+            rows[rowIndex] = row;
+        }
+
+        table.Columns = columns;
+        table.Rows = rows;
+        table.TotalRowCount = Math.Max(table.TotalRowCount, rows.Length);
+        table.ColumnProfiles = ReaderTableProfiler.CreateProfiles(columns, rows);
+        if (_options.TrimValues && table.Title != null) table.Title = table.Title.Trim();
+        if (_options.TrimValues && table.Kind != null) table.Kind = table.Kind.Trim();
+    }
+}

--- a/OfficeIMO.Reader/README.md
+++ b/OfficeIMO.Reader/README.md
@@ -115,6 +115,56 @@ IReadOnlyList<OfficeDocumentReadResult> documents = await reader.ReadDocumentsAs
 
 `ReadDocumentsAsync(...)` starts no more than the configured degree of parallelism, rejects input beyond `MaxDocuments`, cancels sibling workers after a failure, and returns results in the same order as the input paths. Handlers can provide `ReadDocumentPathAsync` or `ReadDocumentStreamAsync` for native asynchronous work. Existing synchronous format engines remain compatible and are scheduled through the instance's bounded worker gate.
 
+## Ordered document processors
+
+Processors are opt-in transformations over `OfficeDocumentReadResult`. The builder freezes their order with the handler configuration, and the reader applies them to `Read(...)`, `ReadAsync(...)`, rich document reads, JSON reads, structured reads, and `ReadDocumentsAsync(...)`:
+
+```csharp
+OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+    .AddProcessor(new OfficeDocumentBlockNormalizationProcessor())
+    .AddProcessor(new OfficeDocumentTableNormalizationProcessor())
+    .AddProcessor(new OfficeDocumentLinkNormalizationProcessor())
+    .AddProcessor(new OfficeDocumentArtifactClassificationProcessor())
+    .AddProcessor(new OfficeDocumentAssetFilterProcessor(
+        asset => asset.LengthBytes <= 5 * 1024 * 1024))
+    .WithProcessorFailureBehavior(
+        OfficeDocumentProcessorFailureBehavior.ContinueWithDiagnostic)
+    .Build();
+
+OfficeDocumentReadResult document = reader.ReadDocument(@"C:\Docs\Policy.docx");
+```
+
+The built-ins normalize shared blocks, list and heading levels, tables, and links; classify repeated page-boundary text; and filter assets together with dependent OCR candidates. They do not run unless registered, so an unconfigured reader preserves existing output. Add host behavior with `OfficeDocumentProcessorBase`, `IOfficeDocumentProcessor`, or `DelegateOfficeDocumentProcessor`.
+
+The default failure policy is `Throw`. `ContinueWithDiagnostic` records `processor-failed` and runs later steps, while `StopWithDiagnostic` records the failure and marks later steps as skipped. Call `ProcessDocument(...)` or `ProcessDocumentAsync(...)` directly when the host needs the per-step `OfficeDocumentProcessingResult`. Processor instances attached to a shared reader must be safe for concurrent calls and should avoid retaining per-document state.
+
+Folder enumeration remains a chunk/source traversal surface and does not run rich-document processors automatically. Use `ReadDocumentsAsync(...)` when every file must pass through the configured document pipeline.
+
+## Bounded structured extraction
+
+Structured extraction projects the shared document model into deterministic scalar records, heading sections, named tables, typed forms, and diagnostics without adding an AI client or format-specific dependency:
+
+```csharp
+OfficeDocumentStructuredExtractionResult extracted = reader.ReadStructured(
+    @"C:\Docs\Policy.docx",
+    structuredOptions: new OfficeDocumentStructuredExtractionOptions {
+        MaxRecords = 5_000,
+        MaxSections = 500,
+        MaxSectionCharacters = 50_000,
+        MaxTables = 250,
+        MaxForms = 1_000,
+        MaxDiagnostics = 500
+    });
+
+foreach (OfficeDocumentStructuredRecord record in extracted.Records) {
+    Console.WriteLine($"{record.Category}: {record.Name} = {record.Value}");
+}
+
+string json = extracted.ToJson(indented: true);
+```
+
+The extractor recognizes metadata, forms, two-column key/value tables, Path/Type/Value tables, Visio Shape Data, chart summaries, table and visual quality, chunk readiness, and security/OCR/limit diagnostics. Each collection and section body has an explicit positive limit; reaching a bound adds a structured limit diagnostic instead of silently growing output. The non-generic schema-friendly shape is versioned independently from the stable `OfficeDocumentReadResult` transport. It is currently a serialization and host-integration contract; a generic `ExtractStructured<T>()` mapper and model-assisted extraction are intentionally outside the core package.
+
 ## Stable document transport
 
 `OfficeDocumentReadResult` schema version 5 is the first stable JSON transport contract. Versions 1 through 4 were experimental and are deliberately rejected when reading transport payloads.
@@ -223,6 +273,8 @@ OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
 - `DocumentReader.Detect(...)` / `DetectAsync(...)` and `OfficeDocumentReader.Detect(...)` / `DetectAsync(...)` expose bounded extension/content evidence, confidence, media type, and mismatch state.
 - `OfficeDocumentDiagnostic` carries stable categories, codes, sources, recoverability, and attributes so hosts do not need to parse warning text.
 - `OfficeDocumentReadResultJson` reads and writes stable schema version 5 envelopes; `OfficeDocumentReadResultSchema.GetJsonSchema()` exposes the packaged schema artifact.
+- `OfficeDocumentProcessorPipeline` freezes ordered processors and reports each completed, failed, or skipped step.
+- `OfficeDocumentStructuredExtractor` produces bounded non-generic records, sections, named tables, forms, and diagnostics without AI dependencies.
 - `OfficeDocumentReaderBuilder.AddHandler(...)` is the recommended custom-handler path for services and concurrent hosts.
 - Static `DocumentReader` registration is retained as a process-wide compatibility surface.
 

--- a/OfficeIMO.Reader/Structured/OfficeDocumentStructuredExtractionJson.cs
+++ b/OfficeIMO.Reader/Structured/OfficeDocumentStructuredExtractionJson.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>Deterministic JSON serialization for structured extraction results.</summary>
+public static class OfficeDocumentStructuredExtractionJson {
+    /// <summary>Serializes a current structured extraction result.</summary>
+    public static string Serialize(OfficeDocumentStructuredExtractionResult result, bool indented = false) {
+        if (result == null) throw new ArgumentNullException(nameof(result));
+        if (!string.Equals(result.SchemaId, OfficeDocumentStructuredExtractionSchema.Id, StringComparison.Ordinal) ||
+            result.SchemaVersion != OfficeDocumentStructuredExtractionSchema.Version) {
+            throw new InvalidOperationException(
+                $"Structured extraction schema '{result.SchemaId}' version {result.SchemaVersion} is not supported.");
+        }
+        return JsonSerializer.Serialize(result, CreateOptions(indented));
+    }
+
+    /// <summary>Serializes a current structured extraction result.</summary>
+    public static string ToJson(this OfficeDocumentStructuredExtractionResult result, bool indented = false) {
+        return Serialize(result, indented);
+    }
+
+    private static JsonSerializerOptions CreateOptions(bool indented) {
+        var options = new JsonSerializerOptions {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = indented
+        };
+        options.Converters.Add(new JsonStringEnumConverter(namingPolicy: null, allowIntegerValues: false));
+        return options;
+    }
+}

--- a/OfficeIMO.Reader/Structured/OfficeDocumentStructuredExtractionModels.cs
+++ b/OfficeIMO.Reader/Structured/OfficeDocumentStructuredExtractionModels.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>Version identifiers for schema-friendly structured extraction output.</summary>
+public static class OfficeDocumentStructuredExtractionSchema {
+    /// <summary>Structured extraction schema identifier.</summary>
+    public const string Id = "officeimo.document.structured-extraction";
+
+    /// <summary>Current structured extraction schema version.</summary>
+    public const int Version = 1;
+}
+
+/// <summary>Bounded options for deterministic structured extraction.</summary>
+public sealed class OfficeDocumentStructuredExtractionOptions {
+    /// <summary>Include document metadata as scalar records.</summary>
+    public bool IncludeMetadata { get; set; } = true;
+
+    /// <summary>Include form fields as scalar records and typed form entries.</summary>
+    public bool IncludeForms { get; set; } = true;
+
+    /// <summary>Extract rows from two-column and Path/Type/Value tables.</summary>
+    public bool IncludeKeyValueRows { get; set; } = true;
+
+    /// <summary>Extract Visio shape-data rows.</summary>
+    public bool IncludeShapeData { get; set; } = true;
+
+    /// <summary>Include deterministic chart summaries.</summary>
+    public bool IncludeChartSummaries { get; set; } = true;
+
+    /// <summary>Include visual, table, and chunk readiness summaries.</summary>
+    public bool IncludeQualitySummaries { get; set; } = true;
+
+    /// <summary>Build heading-and-following-content sections.</summary>
+    public bool IncludeSections { get; set; } = true;
+
+    /// <summary>Include tables with non-empty titles.</summary>
+    public bool IncludeNamedTables { get; set; } = true;
+
+    /// <summary>Copy source diagnostics into the extraction result.</summary>
+    public bool IncludeSourceDiagnostics { get; set; } = true;
+
+    /// <summary>Maximum scalar records. Default: 10,000.</summary>
+    public int MaxRecords { get; set; } = 10_000;
+
+    /// <summary>Maximum sections. Default: 1,000.</summary>
+    public int MaxSections { get; set; } = 1_000;
+
+    /// <summary>Maximum characters retained in one section. Default: 100,000.</summary>
+    public int MaxSectionCharacters { get; set; } = 100_000;
+
+    /// <summary>Maximum named tables. Default: 1,000.</summary>
+    public int MaxTables { get; set; } = 1_000;
+
+    /// <summary>Maximum typed forms. Default: 5,000.</summary>
+    public int MaxForms { get; set; } = 5_000;
+
+    /// <summary>Maximum copied source diagnostics. Default: 1,000.</summary>
+    public int MaxDiagnostics { get; set; } = 1_000;
+
+    internal OfficeDocumentStructuredExtractionOptions Clone() => new OfficeDocumentStructuredExtractionOptions {
+        IncludeMetadata = IncludeMetadata,
+        IncludeForms = IncludeForms,
+        IncludeKeyValueRows = IncludeKeyValueRows,
+        IncludeShapeData = IncludeShapeData,
+        IncludeChartSummaries = IncludeChartSummaries,
+        IncludeQualitySummaries = IncludeQualitySummaries,
+        IncludeSections = IncludeSections,
+        IncludeNamedTables = IncludeNamedTables,
+        IncludeSourceDiagnostics = IncludeSourceDiagnostics,
+        MaxRecords = MaxRecords,
+        MaxSections = MaxSections,
+        MaxSectionCharacters = MaxSectionCharacters,
+        MaxTables = MaxTables,
+        MaxForms = MaxForms,
+        MaxDiagnostics = MaxDiagnostics
+    };
+}
+
+/// <summary>One schema-friendly scalar record extracted from the shared document model.</summary>
+public sealed class OfficeDocumentStructuredRecord {
+    /// <summary>Deterministic record id within the extraction result.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Stable record category such as metadata, form, key-value, shape-data, chart-summary, or quality-summary.</summary>
+    public string Category { get; set; } = string.Empty;
+
+    /// <summary>Record name or key.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Scalar value when available.</summary>
+    public string? Value { get; set; }
+
+    /// <summary>Normalized or source-provided value type.</summary>
+    public string? ValueType { get; set; }
+
+    /// <summary>Source object identifier when available.</summary>
+    public string? SourceObjectId { get; set; }
+
+    /// <summary>Source location when available.</summary>
+    public ReaderLocation? Location { get; set; }
+
+    /// <summary>Additional deterministic scalar attributes.</summary>
+    public IReadOnlyDictionary<string, string> Attributes { get; set; } = new SortedDictionary<string, string>(StringComparer.Ordinal);
+}
+
+/// <summary>Heading and the following logical content up to the next heading.</summary>
+public sealed class OfficeDocumentStructuredSection {
+    /// <summary>Deterministic section id in source order.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Heading text, or null for preamble content.</summary>
+    public string? Heading { get; set; }
+
+    /// <summary>Heading level when available.</summary>
+    public int? Level { get; set; }
+
+    /// <summary>Following block text joined with newlines and bounded by extraction options.</summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>Source block ids participating in this section.</summary>
+    public IReadOnlyList<string> BlockIds { get; set; } = Array.Empty<string>();
+
+    /// <summary>Heading or first-content location.</summary>
+    public ReaderLocation? Location { get; set; }
+
+    /// <summary>True when section text was truncated by <see cref="OfficeDocumentStructuredExtractionOptions.MaxSectionCharacters"/>.</summary>
+    public bool Truncated { get; set; }
+}
+
+/// <summary>Bounded, schema-friendly extraction of a shared document result.</summary>
+public sealed class OfficeDocumentStructuredExtractionResult {
+    /// <summary>Structured extraction schema identifier.</summary>
+    public string SchemaId { get; set; } = OfficeDocumentStructuredExtractionSchema.Id;
+
+    /// <summary>Structured extraction schema version.</summary>
+    public int SchemaVersion { get; set; } = OfficeDocumentStructuredExtractionSchema.Version;
+
+    /// <summary>Source document metadata.</summary>
+    public OfficeDocumentSource Source { get; set; } = new OfficeDocumentSource();
+
+    /// <summary>Scalar structured records in deterministic category/source order.</summary>
+    public IReadOnlyList<OfficeDocumentStructuredRecord> Records { get; set; } = Array.Empty<OfficeDocumentStructuredRecord>();
+
+    /// <summary>Heading-based sections in source order.</summary>
+    public IReadOnlyList<OfficeDocumentStructuredSection> Sections { get; set; } = Array.Empty<OfficeDocumentStructuredSection>();
+
+    /// <summary>Named tables in source order.</summary>
+    public IReadOnlyList<ReaderTable> Tables { get; set; } = Array.Empty<ReaderTable>();
+
+    /// <summary>Typed form fields in source order.</summary>
+    public IReadOnlyList<OfficeDocumentFormField> Forms { get; set; } = Array.Empty<OfficeDocumentFormField>();
+
+    /// <summary>Source and extraction-limit diagnostics.</summary>
+    public IReadOnlyList<OfficeDocumentDiagnostic> Diagnostics { get; set; } = Array.Empty<OfficeDocumentDiagnostic>();
+}

--- a/OfficeIMO.Reader/Structured/OfficeDocumentStructuredExtractor.Records.cs
+++ b/OfficeIMO.Reader/Structured/OfficeDocumentStructuredExtractor.Records.cs
@@ -25,10 +25,8 @@ public static partial class OfficeDocumentStructuredExtractor {
         }
     }
 
-    private static void AddForms(OfficeDocumentReadResult document, ExtractionState state) {
-        IReadOnlyList<OfficeDocumentFormField> forms = document.Forms ?? Array.Empty<OfficeDocumentFormField>();
-        int count = Math.Min(forms.Count, state.Options.MaxForms);
-        for (int index = 0; index < count; index++) {
+    private static void AddForms(IReadOnlyList<OfficeDocumentFormField> forms, ExtractionState state) {
+        for (int index = 0; index < forms.Count; index++) {
             state.CancellationToken.ThrowIfCancellationRequested();
             OfficeDocumentFormField form = forms[index];
             if (!state.TryAdd(new OfficeDocumentStructuredRecord {

--- a/OfficeIMO.Reader/Structured/OfficeDocumentStructuredExtractor.Records.cs
+++ b/OfficeIMO.Reader/Structured/OfficeDocumentStructuredExtractor.Records.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace OfficeIMO.Reader;
+
+public static partial class OfficeDocumentStructuredExtractor {
+    private static void AddMetadata(OfficeDocumentReadResult document, ExtractionState state) {
+        IReadOnlyList<OfficeDocumentMetadataEntry> metadata = document.Metadata ?? Array.Empty<OfficeDocumentMetadataEntry>();
+        for (int index = 0; index < metadata.Count; index++) {
+            state.CancellationToken.ThrowIfCancellationRequested();
+            OfficeDocumentMetadataEntry entry = metadata[index];
+            var attributes = CopyAttributes(entry.Attributes);
+            if (!string.IsNullOrWhiteSpace(entry.Category)) attributes["metadataCategory"] = entry.Category;
+            if (!state.TryAdd(new OfficeDocumentStructuredRecord {
+                Id = "metadata-" + index.ToString("D4", CultureInfo.InvariantCulture),
+                Category = "metadata",
+                Name = entry.Name ?? string.Empty,
+                Value = entry.Value,
+                ValueType = entry.ValueType,
+                SourceObjectId = string.IsNullOrWhiteSpace(entry.SourceObjectId) ? entry.Id : entry.SourceObjectId,
+                Location = entry.Location,
+                Attributes = attributes
+            })) return;
+        }
+    }
+
+    private static void AddForms(OfficeDocumentReadResult document, ExtractionState state) {
+        IReadOnlyList<OfficeDocumentFormField> forms = document.Forms ?? Array.Empty<OfficeDocumentFormField>();
+        int count = Math.Min(forms.Count, state.Options.MaxForms);
+        for (int index = 0; index < count; index++) {
+            state.CancellationToken.ThrowIfCancellationRequested();
+            OfficeDocumentFormField form = forms[index];
+            if (!state.TryAdd(new OfficeDocumentStructuredRecord {
+                Id = "form-" + index.ToString("D4", CultureInfo.InvariantCulture),
+                Category = "form",
+                Name = string.IsNullOrWhiteSpace(form.Name) ? form.Id : form.Name!,
+                Value = form.Value,
+                ValueType = form.Kind,
+                SourceObjectId = form.Id,
+                Location = form.Location,
+                Attributes = new SortedDictionary<string, string>(StringComparer.Ordinal) {
+                    ["isReadOnly"] = form.IsReadOnly ? "true" : "false",
+                    ["isRequired"] = form.IsRequired ? "true" : "false"
+                }
+            })) return;
+        }
+    }
+
+    private static void AddKeyValueRows(OfficeDocumentReadResult document, ExtractionState state) {
+        int tableIndex = 0;
+        foreach (ReaderTable table in OfficeDocumentModelTraversal.Tables(document)) {
+            state.CancellationToken.ThrowIfCancellationRequested();
+            IReadOnlyList<string> columns = table.Columns ?? Array.Empty<string>();
+            if (IsShapeDataTable(table)) {
+                tableIndex++;
+                continue;
+            }
+
+            int pathIndex = FindColumn(columns, "path");
+            int typeIndex = FindColumn(columns, "type");
+            int valueIndex = FindColumn(columns, "value");
+            bool pathValue = pathIndex >= 0 && valueIndex >= 0;
+            bool twoColumn = columns.Count == 2;
+            if (!pathValue && !twoColumn) {
+                tableIndex++;
+                continue;
+            }
+
+            IReadOnlyList<IReadOnlyList<string>> rows = table.Rows ?? Array.Empty<IReadOnlyList<string>>();
+            for (int rowIndex = 0; rowIndex < rows.Count; rowIndex++) {
+                IReadOnlyList<string> row = rows[rowIndex] ?? Array.Empty<string>();
+                int nameIndex = pathValue ? pathIndex : 0;
+                int scalarIndex = pathValue ? valueIndex : 1;
+                string name = GetCell(row, nameIndex).Trim();
+                if (name.Length == 0) continue;
+                var attributes = BuildTableAttributes(table, tableIndex, rowIndex);
+                string category = pathValue ? "structured-value" : "key-value";
+                if (!state.TryAdd(new OfficeDocumentStructuredRecord {
+                    Id = category + "-" + tableIndex.ToString("D4", CultureInfo.InvariantCulture) + "-" + rowIndex.ToString("D6", CultureInfo.InvariantCulture),
+                    Category = category,
+                    Name = name,
+                    Value = GetCell(row, scalarIndex),
+                    ValueType = typeIndex >= 0 ? GetCell(row, typeIndex) : null,
+                    Location = table.Location,
+                    Attributes = attributes
+                })) return;
+            }
+            tableIndex++;
+        }
+    }
+
+    private static void AddShapeData(OfficeDocumentReadResult document, ExtractionState state) {
+        int tableIndex = 0;
+        foreach (ReaderTable table in OfficeDocumentModelTraversal.Tables(document)) {
+            state.CancellationToken.ThrowIfCancellationRequested();
+            if (!IsShapeDataTable(table)) {
+                tableIndex++;
+                continue;
+            }
+
+            IReadOnlyList<string> columns = table.Columns ?? Array.Empty<string>();
+            int ownerTypeIndex = FindColumn(columns, "ownertype");
+            int ownerIdIndex = FindColumn(columns, "ownerid");
+            int ownerTextIndex = FindColumn(columns, "ownertext");
+            int nameIndex = FindColumn(columns, "name");
+            int labelIndex = FindColumn(columns, "label");
+            int valueIndex = FindColumn(columns, "value");
+            int typeIndex = FindColumn(columns, "type");
+            int promptIndex = FindColumn(columns, "prompt");
+            IReadOnlyList<IReadOnlyList<string>> rows = table.Rows ?? Array.Empty<IReadOnlyList<string>>();
+            for (int rowIndex = 0; rowIndex < rows.Count; rowIndex++) {
+                IReadOnlyList<string> row = rows[rowIndex] ?? Array.Empty<string>();
+                string label = GetCell(row, labelIndex).Trim();
+                string name = label.Length == 0 ? GetCell(row, nameIndex).Trim() : label;
+                if (name.Length == 0) continue;
+                string ownerType = GetCell(row, ownerTypeIndex).Trim();
+                string ownerId = GetCell(row, ownerIdIndex).Trim();
+                var attributes = BuildTableAttributes(table, tableIndex, rowIndex);
+                AddIfPresent(attributes, "ownerType", ownerType);
+                AddIfPresent(attributes, "ownerId", ownerId);
+                AddIfPresent(attributes, "ownerText", GetCell(row, ownerTextIndex));
+                AddIfPresent(attributes, "prompt", GetCell(row, promptIndex));
+                if (!state.TryAdd(new OfficeDocumentStructuredRecord {
+                    Id = "shape-data-" + tableIndex.ToString("D4", CultureInfo.InvariantCulture) + "-" + rowIndex.ToString("D6", CultureInfo.InvariantCulture),
+                    Category = "shape-data",
+                    Name = name,
+                    Value = GetCell(row, valueIndex),
+                    ValueType = GetCell(row, typeIndex),
+                    SourceObjectId = ownerType.Length == 0 ? ownerId : ownerType + ":" + ownerId,
+                    Location = table.Location,
+                    Attributes = attributes
+                })) return;
+            }
+            tableIndex++;
+        }
+    }
+
+    private static bool IsShapeDataTable(ReaderTable table) =>
+        string.Equals(table.Kind?.Trim(), "visio-shape-data", StringComparison.OrdinalIgnoreCase);
+
+    private static int FindColumn(IReadOnlyList<string> columns, string name) {
+        for (int index = 0; index < columns.Count; index++) {
+            if (string.Equals(columns[index]?.Trim(), name, StringComparison.OrdinalIgnoreCase)) return index;
+        }
+        return -1;
+    }
+
+    private static string GetCell(IReadOnlyList<string> row, int index) =>
+        index >= 0 && index < row.Count ? row[index] ?? string.Empty : string.Empty;
+
+    private static SortedDictionary<string, string> BuildTableAttributes(ReaderTable table, int tableIndex, int rowIndex) {
+        var attributes = new SortedDictionary<string, string>(StringComparer.Ordinal) {
+            ["rowIndex"] = rowIndex.ToString(CultureInfo.InvariantCulture),
+            ["tableIndex"] = tableIndex.ToString(CultureInfo.InvariantCulture),
+            ["tableTruncated"] = table.Truncated ? "true" : "false",
+            ["totalRowCount"] = table.TotalRowCount.ToString(CultureInfo.InvariantCulture)
+        };
+        AddIfPresent(attributes, "tableKind", table.Kind);
+        AddIfPresent(attributes, "tableTitle", table.Title);
+        return attributes;
+    }
+
+    private static SortedDictionary<string, string> CopyAttributes(IReadOnlyDictionary<string, string>? source) {
+        var attributes = new SortedDictionary<string, string>(StringComparer.Ordinal);
+        if (source == null) return attributes;
+        foreach (KeyValuePair<string, string> item in source) attributes[item.Key] = item.Value;
+        return attributes;
+    }
+
+    private static void AddIfPresent(IDictionary<string, string> attributes, string name, string? value) {
+        if (!string.IsNullOrWhiteSpace(value)) attributes[name] = value!.Trim();
+    }
+}

--- a/OfficeIMO.Reader/Structured/OfficeDocumentStructuredExtractor.Sections.cs
+++ b/OfficeIMO.Reader/Structured/OfficeDocumentStructuredExtractor.Sections.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace OfficeIMO.Reader;
+
+public static partial class OfficeDocumentStructuredExtractor {
+    private static IReadOnlyList<OfficeDocumentStructuredSection> BuildSections(
+        OfficeDocumentReadResult document,
+        ExtractionState state) {
+        IReadOnlyList<OfficeDocumentBlock> blocks = GetSectionBlocks(document);
+        if (blocks.Count == 0) return Array.Empty<OfficeDocumentStructuredSection>();
+
+        var sections = new List<OfficeDocumentStructuredSection>();
+        SectionBuilder? current = null;
+        for (int blockIndex = 0; blockIndex < blocks.Count; blockIndex++) {
+            state.CancellationToken.ThrowIfCancellationRequested();
+            OfficeDocumentBlock block = blocks[blockIndex];
+            if (IsHeading(block)) {
+                if (current != null) AddSection(sections, current, state);
+                if (sections.Count >= state.Options.MaxSections) break;
+                current = new SectionBuilder(
+                    block.Text?.Trim(),
+                    block.Level,
+                    block.Location,
+                    state.Options.MaxSectionCharacters);
+                current.AddBlockId(block.Id);
+                continue;
+            }
+
+            current ??= new SectionBuilder(
+                heading: null,
+                level: null,
+                block.Location,
+                state.Options.MaxSectionCharacters);
+            current.AddBlock(block);
+        }
+        if (current != null && sections.Count < state.Options.MaxSections) AddSection(sections, current, state);
+        if (RequiresMoreSections(blocks, sections, current, state.Options.MaxSections)) {
+            state.AddLimitDiagnostic("structured-section-limit", state.Options.MaxSections, "sections");
+        }
+        return sections.Count == 0 ? Array.Empty<OfficeDocumentStructuredSection>() : sections.ToArray();
+    }
+
+    private static IReadOnlyList<OfficeDocumentBlock> GetSectionBlocks(OfficeDocumentReadResult document) {
+        if (document.Blocks != null && document.Blocks.Count > 0) return document.Blocks;
+        var blocks = new List<OfficeDocumentBlock>();
+        foreach (OfficeDocumentPage page in document.Pages ?? Array.Empty<OfficeDocumentPage>()) {
+            if (page?.Blocks == null) continue;
+            blocks.AddRange(page.Blocks);
+        }
+        return blocks.Count == 0 ? Array.Empty<OfficeDocumentBlock>() : blocks.ToArray();
+    }
+
+    private static bool IsHeading(OfficeDocumentBlock block) =>
+        string.Equals(block.Kind?.Trim(), "heading", StringComparison.OrdinalIgnoreCase);
+
+    private static void AddSection(
+        ICollection<OfficeDocumentStructuredSection> sections,
+        SectionBuilder builder,
+        ExtractionState state) {
+        int index = sections.Count;
+        sections.Add(new OfficeDocumentStructuredSection {
+            Id = "section-" + index.ToString("D4", CultureInfo.InvariantCulture),
+            Heading = builder.Heading,
+            Level = builder.Level,
+            Text = builder.Text,
+            BlockIds = builder.BlockIds,
+            Location = builder.Location,
+            Truncated = builder.Truncated
+        });
+        if (builder.Truncated) {
+            state.AddLimitDiagnostic("structured-section-character-limit", state.Options.MaxSectionCharacters, "section characters");
+        }
+    }
+
+    private static bool RequiresMoreSections(
+        IReadOnlyList<OfficeDocumentBlock> blocks,
+        IReadOnlyList<OfficeDocumentStructuredSection> sections,
+        SectionBuilder? current,
+        int maxSections) {
+        if (sections.Count < maxSections) return false;
+        int headingCount = 0;
+        bool hasPreamble = false;
+        for (int index = 0; index < blocks.Count; index++) {
+            if (IsHeading(blocks[index])) headingCount++;
+            else if (headingCount == 0) hasPreamble = true;
+        }
+        int required = headingCount + (hasPreamble ? 1 : 0);
+        return required > maxSections || (current != null && sections.Count >= maxSections && required > sections.Count);
+    }
+
+    private sealed class SectionBuilder {
+        private readonly int _maxCharacters;
+        private readonly StringBuilder _text = new StringBuilder();
+        private readonly List<string> _blockIds = new List<string>();
+
+        internal SectionBuilder(string? heading, int? level, ReaderLocation? location, int maxCharacters) {
+            Heading = string.IsNullOrWhiteSpace(heading) ? null : heading;
+            Level = level;
+            Location = location;
+            _maxCharacters = maxCharacters;
+        }
+
+        internal string? Heading { get; }
+        internal int? Level { get; }
+        internal ReaderLocation? Location { get; }
+        internal string Text => _text.ToString();
+        internal IReadOnlyList<string> BlockIds => _blockIds.Count == 0 ? Array.Empty<string>() : _blockIds.ToArray();
+        internal bool Truncated { get; private set; }
+
+        internal void AddBlock(OfficeDocumentBlock block) {
+            AddBlockId(block.Id);
+            string value = block.Text?.Trim() ?? string.Empty;
+            if (value.Length == 0 || Truncated) return;
+            int separatorLength = _text.Length == 0 ? 0 : 1;
+            int remaining = _maxCharacters - _text.Length - separatorLength;
+            if (remaining <= 0) {
+                Truncated = true;
+                return;
+            }
+            if (separatorLength > 0) _text.Append('\n');
+            if (value.Length <= remaining) {
+                _text.Append(value);
+                return;
+            }
+            _text.Append(value, 0, remaining);
+            Truncated = true;
+        }
+
+        internal void AddBlockId(string? id) {
+            if (!string.IsNullOrWhiteSpace(id)) _blockIds.Add(id!);
+        }
+    }
+}

--- a/OfficeIMO.Reader/Structured/OfficeDocumentStructuredExtractor.Sections.cs
+++ b/OfficeIMO.Reader/Structured/OfficeDocumentStructuredExtractor.Sections.cs
@@ -44,11 +44,10 @@ public static partial class OfficeDocumentStructuredExtractor {
     }
 
     private static IReadOnlyList<OfficeDocumentBlock> GetSectionBlocks(OfficeDocumentReadResult document) {
-        if (document.Blocks != null && document.Blocks.Count > 0) return document.Blocks;
         var blocks = new List<OfficeDocumentBlock>();
-        foreach (OfficeDocumentPage page in document.Pages ?? Array.Empty<OfficeDocumentPage>()) {
-            if (page?.Blocks == null) continue;
-            blocks.AddRange(page.Blocks);
+        var seenIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (OfficeDocumentBlock block in OfficeDocumentModelTraversal.Blocks(document)) {
+            if (string.IsNullOrWhiteSpace(block.Id) || seenIds.Add(block.Id)) blocks.Add(block);
         }
         return blocks.Count == 0 ? Array.Empty<OfficeDocumentBlock>() : blocks.ToArray();
     }

--- a/OfficeIMO.Reader/Structured/OfficeDocumentStructuredExtractor.Summaries.cs
+++ b/OfficeIMO.Reader/Structured/OfficeDocumentStructuredExtractor.Summaries.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.Json;
+
+namespace OfficeIMO.Reader;
+
+public static partial class OfficeDocumentStructuredExtractor {
+    private static void AddChartSummaries(OfficeDocumentReadResult document, ExtractionState state) {
+        int chartIndex = 0;
+        foreach (ReaderVisual visual in EnumerateVisuals(document)) {
+            state.CancellationToken.ThrowIfCancellationRequested();
+            if (!IsChart(visual)) continue;
+            var attributes = new SortedDictionary<string, string>(StringComparer.Ordinal);
+            AddIfPresent(attributes, "language", visual.Language);
+            AddIfPresent(attributes, "mimeType", visual.MimeType);
+            AddIfPresent(attributes, "payloadHash", visual.PayloadHash);
+            string? chartType = TryReadChartSummary(visual.Content, attributes);
+            if (!state.TryAdd(new OfficeDocumentStructuredRecord {
+                Id = "chart-summary-" + chartIndex.ToString("D4", CultureInfo.InvariantCulture),
+                Category = "chart-summary",
+                Name = string.IsNullOrWhiteSpace(visual.SourceName) ? "Chart" : visual.SourceName!,
+                Value = chartType ?? visual.Kind,
+                ValueType = "chart",
+                SourceObjectId = visual.PayloadHash,
+                Location = visual.Location,
+                Attributes = attributes
+            })) return;
+            chartIndex++;
+        }
+    }
+
+    private static void AddQualitySummaries(OfficeDocumentReadResult document, ExtractionState state) {
+        AddTableQualitySummaries(document, state);
+        AddVisualQualitySummaries(document, state);
+        AddChunkReadinessSummaries(document, state);
+        AddDiagnosticReadinessSummaries(document, state);
+    }
+
+    private static void AddTableQualitySummaries(OfficeDocumentReadResult document, ExtractionState state) {
+        int index = 0;
+        foreach (ReaderTable table in OfficeDocumentModelTraversal.Tables(document)) {
+            state.CancellationToken.ThrowIfCancellationRequested();
+            ReaderTableDiagnostics? diagnostics = table.Diagnostics;
+            if (diagnostics == null) {
+                index++;
+                continue;
+            }
+            var attributes = new SortedDictionary<string, string>(StringComparer.Ordinal) {
+                ["cellCompleteness"] = Format(diagnostics.CellCompleteness),
+                ["columnGeometryConfidence"] = Format(diagnostics.ColumnGeometryConfidence),
+                ["filledCellCount"] = diagnostics.FilledCellCount.ToString(CultureInfo.InvariantCulture),
+                ["hasGeometry"] = diagnostics.HasGeometry ? "true" : "false",
+                ["missingCellCount"] = diagnostics.MissingCellCount.ToString(CultureInfo.InvariantCulture),
+                ["schemaConfidence"] = Format(diagnostics.SchemaConfidence),
+                ["sourceRowCount"] = diagnostics.SourceRowCount.ToString(CultureInfo.InvariantCulture)
+            };
+            if (!state.TryAdd(new OfficeDocumentStructuredRecord {
+                Id = "table-quality-" + index.ToString("D4", CultureInfo.InvariantCulture),
+                Category = "quality-summary",
+                Name = string.IsNullOrWhiteSpace(table.Title) ? "Table " + (index + 1).ToString(CultureInfo.InvariantCulture) : table.Title!,
+                Value = Format(diagnostics.Confidence),
+                ValueType = "confidence",
+                Location = table.Location,
+                Attributes = attributes
+            })) return;
+            index++;
+        }
+    }
+
+    private static void AddVisualQualitySummaries(OfficeDocumentReadResult document, ExtractionState state) {
+        int index = 0;
+        foreach (ReaderVisual visual in EnumerateVisuals(document)) {
+            state.CancellationToken.ThrowIfCancellationRequested();
+            var attributes = new SortedDictionary<string, string>(StringComparer.Ordinal) {
+                ["hasGeometry"] = visual.HasGeometry ? "true" : "false",
+                ["isAxisAligned"] = visual.IsAxisAligned.HasValue
+                    ? (visual.IsAxisAligned.Value ? "true" : "false")
+                    : "unknown",
+                ["placementCount"] = visual.PlacementCount.ToString(CultureInfo.InvariantCulture)
+            };
+            AddNullableNumber(attributes, "height", visual.Height);
+            AddNullableNumber(attributes, "width", visual.Width);
+            AddIfPresent(attributes, "language", visual.Language);
+            AddIfPresent(attributes, "mimeType", visual.MimeType);
+            if (!state.TryAdd(new OfficeDocumentStructuredRecord {
+                Id = "visual-quality-" + index.ToString("D4", CultureInfo.InvariantCulture),
+                Category = "visual-summary",
+                Name = string.IsNullOrWhiteSpace(visual.SourceName) ? visual.Kind ?? "visual" : visual.SourceName!,
+                Value = visual.Kind,
+                ValueType = "visual-kind",
+                SourceObjectId = visual.PayloadHash,
+                Location = visual.Location,
+                Attributes = attributes
+            })) return;
+            index++;
+        }
+    }
+
+    private static void AddChunkReadinessSummaries(OfficeDocumentReadResult document, ExtractionState state) {
+        IReadOnlyList<ReaderChunk> chunks = document.Chunks ?? Array.Empty<ReaderChunk>();
+        for (int index = 0; index < chunks.Count; index++) {
+            state.CancellationToken.ThrowIfCancellationRequested();
+            ReaderChunk chunk = chunks[index];
+            ReaderChunkDiagnostics? diagnostics = chunk.Diagnostics;
+            if (diagnostics == null) continue;
+            var attributes = new SortedDictionary<string, string>(StringComparer.Ordinal) {
+                ["attachmentCount"] = diagnostics.AttachmentCount.ToString(CultureInfo.InvariantCulture),
+                ["formFieldCount"] = diagnostics.FormFieldCount.ToString(CultureInfo.InvariantCulture),
+                ["hasActiveContent"] = diagnostics.HasActiveContent ? "true" : "false",
+                ["hasEncryption"] = diagnostics.HasEncryption ? "true" : "false",
+                ["hasSecurityState"] = diagnostics.HasSecurityState ? "true" : "false",
+                ["hasSignatures"] = diagnostics.HasSignatures ? "true" : "false",
+                ["imageCount"] = diagnostics.ImageCount.ToString(CultureInfo.InvariantCulture),
+                ["linkCount"] = diagnostics.LinkCount.ToString(CultureInfo.InvariantCulture),
+                ["potentiallyUnsafeActionCount"] = diagnostics.PotentiallyUnsafeActionCount.ToString(CultureInfo.InvariantCulture),
+                ["tableCount"] = diagnostics.TableCount.ToString(CultureInfo.InvariantCulture)
+            };
+            if (!state.TryAdd(new OfficeDocumentStructuredRecord {
+                Id = "readiness-" + index.ToString("D4", CultureInfo.InvariantCulture),
+                Category = "readiness-summary",
+                Name = string.IsNullOrWhiteSpace(diagnostics.SourceKind) ? chunk.Id : diagnostics.SourceKind,
+                Value = diagnostics.HasActiveContent || diagnostics.HasSecurityState ? "review" : "ready",
+                ValueType = "readiness",
+                SourceObjectId = chunk.Id,
+                Location = chunk.Location,
+                Attributes = attributes
+            })) return;
+        }
+    }
+
+    private static void AddDiagnosticReadinessSummaries(OfficeDocumentReadResult document, ExtractionState state) {
+        IReadOnlyList<OfficeDocumentDiagnostic> diagnostics = document.Diagnostics ?? Array.Empty<OfficeDocumentDiagnostic>();
+        for (int index = 0; index < diagnostics.Count; index++) {
+            OfficeDocumentDiagnostic diagnostic = diagnostics[index];
+            if (!IsReadinessDiagnostic(diagnostic)) continue;
+            var attributes = CopyAttributes(diagnostic.Attributes);
+            AddIfPresent(attributes, "source", diagnostic.Source);
+            attributes["severity"] = diagnostic.Severity.ToString();
+            if (!state.TryAdd(new OfficeDocumentStructuredRecord {
+                Id = "diagnostic-readiness-" + index.ToString("D4", CultureInfo.InvariantCulture),
+                Category = "readiness-summary",
+                Name = diagnostic.Code,
+                Value = diagnostic.Message,
+                ValueType = diagnostic.Category.ToString(),
+                Location = diagnostic.Location,
+                Attributes = attributes
+            })) return;
+        }
+    }
+
+    private static IEnumerable<ReaderVisual> EnumerateVisuals(OfficeDocumentReadResult document) {
+        var seen = new HashSet<ReaderVisual>(ReferenceIdentityComparer<ReaderVisual>.Instance);
+        foreach (ReaderVisual visual in document.Visuals ?? Array.Empty<ReaderVisual>()) {
+            if (visual != null && seen.Add(visual)) yield return visual;
+        }
+        foreach (ReaderChunk chunk in document.Chunks ?? Array.Empty<ReaderChunk>()) {
+            if (chunk?.Visuals == null) continue;
+            foreach (ReaderVisual visual in chunk.Visuals) {
+                if (visual != null && seen.Add(visual)) yield return visual;
+            }
+        }
+    }
+
+    private static bool IsChart(ReaderVisual visual) =>
+        string.Equals(visual.Kind?.Trim(), "chart", StringComparison.OrdinalIgnoreCase) ||
+        (!string.IsNullOrWhiteSpace(visual.Language) && visual.Language!.IndexOf("chart", StringComparison.OrdinalIgnoreCase) >= 0);
+
+    private static string? TryReadChartSummary(string? content, IDictionary<string, string> attributes) {
+        if (string.IsNullOrWhiteSpace(content)) return null;
+        attributes["contentLength"] = content!.Length.ToString(CultureInfo.InvariantCulture);
+        try {
+            using JsonDocument json = JsonDocument.Parse(content);
+            JsonElement root = json.RootElement;
+            string? type = root.TryGetProperty("type", out JsonElement typeElement) && typeElement.ValueKind == JsonValueKind.String
+                ? typeElement.GetString()
+                : null;
+            if (root.TryGetProperty("data", out JsonElement data) && data.ValueKind == JsonValueKind.Object) {
+                if (data.TryGetProperty("labels", out JsonElement labels) && labels.ValueKind == JsonValueKind.Array) {
+                    attributes["labelCount"] = labels.GetArrayLength().ToString(CultureInfo.InvariantCulture);
+                }
+                if (data.TryGetProperty("datasets", out JsonElement datasets) && datasets.ValueKind == JsonValueKind.Array) {
+                    attributes["datasetCount"] = datasets.GetArrayLength().ToString(CultureInfo.InvariantCulture);
+                    int pointCount = 0;
+                    foreach (JsonElement dataset in datasets.EnumerateArray()) {
+                        if (dataset.ValueKind == JsonValueKind.Object &&
+                            dataset.TryGetProperty("data", out JsonElement points) &&
+                            points.ValueKind == JsonValueKind.Array) {
+                            pointCount += points.GetArrayLength();
+                        }
+                    }
+                    attributes["pointCount"] = pointCount.ToString(CultureInfo.InvariantCulture);
+                }
+            }
+            return type;
+        } catch (JsonException) {
+            attributes["jsonValid"] = "false";
+            return null;
+        }
+    }
+
+    private static bool IsReadinessDiagnostic(OfficeDocumentDiagnostic diagnostic) {
+        if (diagnostic.Category == OfficeDocumentDiagnosticCategory.Security ||
+            diagnostic.Category == OfficeDocumentDiagnosticCategory.Ocr ||
+            diagnostic.Category == OfficeDocumentDiagnosticCategory.Limit) return true;
+        string code = diagnostic.Code ?? string.Empty;
+        return code.IndexOf("compliance", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               code.IndexOf("preflight", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               code.IndexOf("quality", StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    private static string Format(double value) => value.ToString("R", CultureInfo.InvariantCulture);
+
+    private static void AddNullableNumber(IDictionary<string, string> attributes, string name, double? value) {
+        if (value.HasValue) attributes[name] = Format(value.Value);
+    }
+
+    private static void AddNullableNumber(IDictionary<string, string> attributes, string name, int? value) {
+        if (value.HasValue) attributes[name] = value.Value.ToString(CultureInfo.InvariantCulture);
+    }
+}

--- a/OfficeIMO.Reader/Structured/OfficeDocumentStructuredExtractor.Summaries.cs
+++ b/OfficeIMO.Reader/Structured/OfficeDocumentStructuredExtractor.Summaries.cs
@@ -132,6 +132,7 @@ public static partial class OfficeDocumentStructuredExtractor {
     private static void AddDiagnosticReadinessSummaries(OfficeDocumentReadResult document, ExtractionState state) {
         IReadOnlyList<OfficeDocumentDiagnostic> diagnostics = document.Diagnostics ?? Array.Empty<OfficeDocumentDiagnostic>();
         for (int index = 0; index < diagnostics.Count; index++) {
+            state.CancellationToken.ThrowIfCancellationRequested();
             OfficeDocumentDiagnostic diagnostic = diagnostics[index];
             if (!IsReadinessDiagnostic(diagnostic)) continue;
             var attributes = CopyAttributes(diagnostic.Attributes);

--- a/OfficeIMO.Reader/Structured/OfficeDocumentStructuredExtractor.Summaries.cs
+++ b/OfficeIMO.Reader/Structured/OfficeDocumentStructuredExtractor.Summaries.cs
@@ -151,16 +151,7 @@ public static partial class OfficeDocumentStructuredExtractor {
     }
 
     private static IEnumerable<ReaderVisual> EnumerateVisuals(OfficeDocumentReadResult document) {
-        var seen = new HashSet<ReaderVisual>(ReferenceIdentityComparer<ReaderVisual>.Instance);
-        foreach (ReaderVisual visual in document.Visuals ?? Array.Empty<ReaderVisual>()) {
-            if (visual != null && seen.Add(visual)) yield return visual;
-        }
-        foreach (ReaderChunk chunk in document.Chunks ?? Array.Empty<ReaderChunk>()) {
-            if (chunk?.Visuals == null) continue;
-            foreach (ReaderVisual visual in chunk.Visuals) {
-                if (visual != null && seen.Add(visual)) yield return visual;
-            }
-        }
+        foreach (ReaderVisual visual in OfficeDocumentModelTraversal.Visuals(document)) yield return visual;
     }
 
     private static bool IsChart(ReaderVisual visual) =>

--- a/OfficeIMO.Reader/Structured/OfficeDocumentStructuredExtractor.cs
+++ b/OfficeIMO.Reader/Structured/OfficeDocumentStructuredExtractor.cs
@@ -17,9 +17,12 @@ public static partial class OfficeDocumentStructuredExtractor {
         OfficeDocumentStructuredExtractionOptions effective = Normalize(options);
         var state = new ExtractionState(effective, cancellationToken);
         state.CopySourceDiagnostics(document.Diagnostics);
+        IReadOnlyList<OfficeDocumentFormField> forms = effective.IncludeForms
+            ? SelectForms(document, state)
+            : Array.Empty<OfficeDocumentFormField>();
 
         if (effective.IncludeMetadata) AddMetadata(document, state);
-        if (effective.IncludeForms) AddForms(document, state);
+        if (effective.IncludeForms) AddForms(forms, state);
         if (effective.IncludeKeyValueRows) AddKeyValueRows(document, state);
         if (effective.IncludeShapeData) AddShapeData(document, state);
         if (effective.IncludeChartSummaries) AddChartSummaries(document, state);
@@ -31,10 +34,6 @@ public static partial class OfficeDocumentStructuredExtractor {
         IReadOnlyList<ReaderTable> tables = effective.IncludeNamedTables
             ? SelectNamedTables(document, state)
             : Array.Empty<ReaderTable>();
-        IReadOnlyList<OfficeDocumentFormField> forms = effective.IncludeForms
-            ? SelectForms(document, state)
-            : Array.Empty<OfficeDocumentFormField>();
-
         return new OfficeDocumentStructuredExtractionResult {
             Source = document.Source ?? new OfficeDocumentSource(),
             Records = state.Records.Count == 0 ? Array.Empty<OfficeDocumentStructuredRecord>() : state.Records.ToArray(),
@@ -79,13 +78,16 @@ public static partial class OfficeDocumentStructuredExtractor {
     private static IReadOnlyList<OfficeDocumentFormField> SelectForms(
         OfficeDocumentReadResult document,
         ExtractionState state) {
-        IReadOnlyList<OfficeDocumentFormField> forms = document.Forms ?? Array.Empty<OfficeDocumentFormField>();
-        int count = Math.Min(forms.Count, state.Options.MaxForms);
-        if (forms.Count > count) state.AddLimitDiagnostic("structured-form-limit", state.Options.MaxForms, "forms");
-        if (count == 0) return Array.Empty<OfficeDocumentFormField>();
-        var selected = new OfficeDocumentFormField[count];
-        for (int index = 0; index < count; index++) selected[index] = forms[index];
-        return selected;
+        var selected = new List<OfficeDocumentFormField>();
+        foreach (OfficeDocumentFormField form in OfficeDocumentModelTraversal.Forms(document)) {
+            state.CancellationToken.ThrowIfCancellationRequested();
+            if (selected.Count >= state.Options.MaxForms) {
+                state.AddLimitDiagnostic("structured-form-limit", state.Options.MaxForms, "forms");
+                break;
+            }
+            selected.Add(form);
+        }
+        return selected.Count == 0 ? Array.Empty<OfficeDocumentFormField>() : selected.ToArray();
     }
 
     internal sealed class ExtractionState {

--- a/OfficeIMO.Reader/Structured/OfficeDocumentStructuredExtractor.cs
+++ b/OfficeIMO.Reader/Structured/OfficeDocumentStructuredExtractor.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>Deterministically extracts bounded schema-friendly records from a shared document result.</summary>
+public static partial class OfficeDocumentStructuredExtractor {
+    /// <summary>Extracts sections, scalar records, named tables, forms, and diagnostics.</summary>
+    public static OfficeDocumentStructuredExtractionResult Extract(
+        OfficeDocumentReadResult document,
+        OfficeDocumentStructuredExtractionOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        OfficeDocumentStructuredExtractionOptions effective = Normalize(options);
+        var state = new ExtractionState(effective, cancellationToken);
+        state.CopySourceDiagnostics(document.Diagnostics);
+
+        if (effective.IncludeMetadata) AddMetadata(document, state);
+        if (effective.IncludeForms) AddForms(document, state);
+        if (effective.IncludeKeyValueRows) AddKeyValueRows(document, state);
+        if (effective.IncludeShapeData) AddShapeData(document, state);
+        if (effective.IncludeChartSummaries) AddChartSummaries(document, state);
+        if (effective.IncludeQualitySummaries) AddQualitySummaries(document, state);
+
+        IReadOnlyList<OfficeDocumentStructuredSection> sections = effective.IncludeSections
+            ? BuildSections(document, state)
+            : Array.Empty<OfficeDocumentStructuredSection>();
+        IReadOnlyList<ReaderTable> tables = effective.IncludeNamedTables
+            ? SelectNamedTables(document, state)
+            : Array.Empty<ReaderTable>();
+        IReadOnlyList<OfficeDocumentFormField> forms = effective.IncludeForms
+            ? SelectForms(document, state)
+            : Array.Empty<OfficeDocumentFormField>();
+
+        return new OfficeDocumentStructuredExtractionResult {
+            Source = document.Source ?? new OfficeDocumentSource(),
+            Records = state.Records.Count == 0 ? Array.Empty<OfficeDocumentStructuredRecord>() : state.Records.ToArray(),
+            Sections = sections,
+            Tables = tables,
+            Forms = forms,
+            Diagnostics = state.Diagnostics.Count == 0 ? Array.Empty<OfficeDocumentDiagnostic>() : state.Diagnostics.ToArray()
+        };
+    }
+
+    private static OfficeDocumentStructuredExtractionOptions Normalize(OfficeDocumentStructuredExtractionOptions? options) {
+        OfficeDocumentStructuredExtractionOptions effective = (options ?? new OfficeDocumentStructuredExtractionOptions()).Clone();
+        ValidatePositive(effective.MaxRecords, nameof(effective.MaxRecords));
+        ValidatePositive(effective.MaxSections, nameof(effective.MaxSections));
+        ValidatePositive(effective.MaxSectionCharacters, nameof(effective.MaxSectionCharacters));
+        ValidatePositive(effective.MaxTables, nameof(effective.MaxTables));
+        ValidatePositive(effective.MaxForms, nameof(effective.MaxForms));
+        ValidatePositive(effective.MaxDiagnostics, nameof(effective.MaxDiagnostics));
+        return effective;
+    }
+
+    private static void ValidatePositive(int value, string name) {
+        if (value <= 0) throw new ArgumentOutOfRangeException(name, value, "Structured extraction limits must be positive.");
+    }
+
+    private static IReadOnlyList<ReaderTable> SelectNamedTables(
+        OfficeDocumentReadResult document,
+        ExtractionState state) {
+        var selected = new List<ReaderTable>();
+        foreach (ReaderTable table in OfficeDocumentModelTraversal.Tables(document)) {
+            state.CancellationToken.ThrowIfCancellationRequested();
+            if (string.IsNullOrWhiteSpace(table.Title)) continue;
+            if (selected.Count >= state.Options.MaxTables) {
+                state.AddLimitDiagnostic("structured-table-limit", state.Options.MaxTables, "named tables");
+                break;
+            }
+            selected.Add(table);
+        }
+        return selected.Count == 0 ? Array.Empty<ReaderTable>() : selected.ToArray();
+    }
+
+    private static IReadOnlyList<OfficeDocumentFormField> SelectForms(
+        OfficeDocumentReadResult document,
+        ExtractionState state) {
+        IReadOnlyList<OfficeDocumentFormField> forms = document.Forms ?? Array.Empty<OfficeDocumentFormField>();
+        int count = Math.Min(forms.Count, state.Options.MaxForms);
+        if (forms.Count > count) state.AddLimitDiagnostic("structured-form-limit", state.Options.MaxForms, "forms");
+        if (count == 0) return Array.Empty<OfficeDocumentFormField>();
+        var selected = new OfficeDocumentFormField[count];
+        for (int index = 0; index < count; index++) selected[index] = forms[index];
+        return selected;
+    }
+
+    internal sealed class ExtractionState {
+        private readonly HashSet<string> _limitCodes = new HashSet<string>(StringComparer.Ordinal);
+
+        internal ExtractionState(
+            OfficeDocumentStructuredExtractionOptions options,
+            CancellationToken cancellationToken) {
+            Options = options;
+            CancellationToken = cancellationToken;
+        }
+
+        internal OfficeDocumentStructuredExtractionOptions Options { get; }
+        internal CancellationToken CancellationToken { get; }
+        internal List<OfficeDocumentStructuredRecord> Records { get; } = new List<OfficeDocumentStructuredRecord>();
+        internal List<OfficeDocumentDiagnostic> Diagnostics { get; } = new List<OfficeDocumentDiagnostic>();
+
+        internal bool TryAdd(OfficeDocumentStructuredRecord record) {
+            CancellationToken.ThrowIfCancellationRequested();
+            if (Records.Count >= Options.MaxRecords) {
+                AddLimitDiagnostic("structured-record-limit", Options.MaxRecords, "records");
+                return false;
+            }
+            record.Attributes = SortAttributes(record.Attributes);
+            Records.Add(record);
+            return true;
+        }
+
+        internal void CopySourceDiagnostics(IReadOnlyList<OfficeDocumentDiagnostic>? source) {
+            if (!Options.IncludeSourceDiagnostics || source == null || source.Count == 0) return;
+            int count = Math.Min(source.Count, Options.MaxDiagnostics);
+            for (int index = 0; index < count; index++) {
+                CancellationToken.ThrowIfCancellationRequested();
+                Diagnostics.Add(source[index]);
+            }
+            if (source.Count > count) AddLimitDiagnostic("structured-diagnostic-limit", Options.MaxDiagnostics, "diagnostics");
+        }
+
+        internal void AddLimitDiagnostic(string code, int limit, string noun) {
+            if (!_limitCodes.Add(code)) return;
+            Diagnostics.Add(new OfficeDocumentDiagnostic {
+                Severity = OfficeDocumentDiagnosticSeverity.Warning,
+                Category = OfficeDocumentDiagnosticCategory.Limit,
+                Code = code,
+                Message = $"Structured extraction reached the configured {noun} limit ({limit.ToString(CultureInfo.InvariantCulture)}).",
+                Source = "officeimo.reader.structured-extraction",
+                IsRecoverable = true,
+                Attributes = new SortedDictionary<string, string>(StringComparer.Ordinal) {
+                    ["limit"] = limit.ToString(CultureInfo.InvariantCulture),
+                    ["target"] = noun
+                }
+            });
+        }
+
+        private static IReadOnlyDictionary<string, string> SortAttributes(IReadOnlyDictionary<string, string>? attributes) {
+            var sorted = new SortedDictionary<string, string>(StringComparer.Ordinal);
+            if (attributes == null) return sorted;
+            foreach (KeyValuePair<string, string> attribute in attributes) sorted[attribute.Key] = attribute.Value;
+            return sorted;
+        }
+    }
+}


### PR DESCRIPTION
## Summary\n\n- add ordered synchronous and asynchronous document processor contracts\n- snapshot processor pipelines through the instance Reader builder\n- include reusable normalization, asset filtering, and artifact classification processors\n- expose structured records, sections, summaries, diagnostics, and JSON output\n- merge document, page, and chunk scopes in source order with stable de-duplication\n- normalize every table instance while de-duplicating logical tables for structured output\n- carry page provenance into page-scoped tables and keep derived asset-count metadata current after filtering\n- keep processed chunks, Markdown, blocks, page blocks, hashes, and JSON coherent after text changes\n- filter OCR candidates only when no asset with the same id survives and preserve unrelated adapter diagnostics\n- keep traversal and extraction logic in Reader core while facade methods remain thin\n\n## Why it matters\n\nHosts can build repeatable post-read workflows and consume useful structured data without rewalking every format model themselves.\n\n## Validation\n\n- complete Reader suite: 465/465 passed on .NET 8 and .NET 10\n- GitHub Actions: Windows, Ubuntu, macOS, CodeQL, AOT, PDF gallery/core, and every test partition passed\n- processor ordering, aggregate coherence, provenance, de-duplication, cancellation, failure policy, extraction, and JSON contracts are covered\n\n## Stack links\n\nSlice 6 of 9. Previous: [#2050](https://github.com/EvotecIT/OfficeIMO/pull/2050) · Next: [#2052](https://github.com/EvotecIT/OfficeIMO/pull/2052)