### PR TITLE
Add token-aware Reader chunk hierarchies

### DIFF
--- a/Docs/benchmarks/officeimo.reader.foundation-2026-07-10.md
+++ b/Docs/benchmarks/officeimo.reader.foundation-2026-07-10.md
@@ -66,6 +66,17 @@ Bounded detection completed between 2.0 μs and 151.9 μs for the Markdown, PDF,
 
 Schema version 5 transport measured 977.9 μs / 877.69 KB to serialize and 2.022 ms / 1.10 MB to deserialize the representative Markdown rich result.
 
+## Hierarchical chunking
+
+The token-aware hierarchy lane uses the same deterministic 80-section Markdown result, a 512-token chunk cap, 64-token overlap, hierarchy context, and the built-in heuristic token counter. A focused short run measured:
+
+| Lane | Mean | Allocated |
+| --- | ---: | ---: |
+| Build chunk hierarchy | 286.2 μs | 1.10 MB |
+| Serialize hierarchy JSON | 1.174 ms | 969.53 KB |
+
+The hierarchy builder run includes deterministic SHA-256 leaf IDs and hashes, source-span evidence, context accounting, and flattened document/heading nodes. These values establish regression evidence for the first implementation; they are not tokenizer-independent throughput claims. Exact host tokenizers should be benchmarked through their `IReaderTokenCounter` implementation.
+
 ## Next performance targets
 
 The evidence identifies three owner-level allocation priorities:

--- a/Docs/officeimo.document-intelligence-roadmap.md
+++ b/Docs/officeimo.document-intelligence-roadmap.md
@@ -166,6 +166,7 @@ This branch starts the shared model and adapter path:
 - Reader instances can freeze an ordered processor pipeline with explicit throw, continue-with-diagnostic, or stop-with-diagnostic failure policy. Sync and async document, chunk, JSON, structured, and bounded batch reads use the same configured pipeline; folder chunk enumeration remains unchanged.
 - Opt-in shared-model processors now normalize blocks, list and heading levels, tables, and links; classify repeated page-boundary artifacts; and filter assets together with dependent OCR candidates. Hosts can add typed sync or async processors without adding format-specific behavior to the facade.
 - Bounded structured extraction now exposes metadata, forms, key/value and Path/Type/Value rows, Visio Shape Data, heading sections, named tables, chart summaries, quality/readiness summaries, and source diagnostics through a deterministic non-generic result and JSON serializer.
+- Token-aware hierarchical chunking now keeps `ReaderChunk` as the leaf contract while adding document, page/slide/sheet, and heading nodes; exact source character spans; deterministic IDs/hashes; configurable overlap and context; host token counters; structured bounds diagnostics; and an independently versioned JSON sidecar.
 - Document-level metadata entries now carry stable catalog, outline, destination, open-action, viewer-preference, and form-summary facts without making the shared Reader model depend on PDF-specific types.
 - PDF source preflight capability flags now flow into metadata, and read/rewrite blockers flow into shared diagnostics as stable `pdf-read-blocker` and `pdf-rewrite-blocker` entries for file and stream readback.
 - OCR readiness is represented as `OcrCandidates` plus `ocr-needed` diagnostics for image-only PDF pages and embedded Office image assets, without adding an OCR engine or service dependency to the core.
@@ -197,7 +198,7 @@ Render through `OfficeIMO.Markdown` for portable document output. Use direct HTM
 
 ### Chunks
 
-Keep `ReaderChunk` as the ingestion contract. Add richer source maps and optional block/table/image/form/diagram references rather than replacing the existing chunk model.
+Keep `ReaderChunk` as the ingestion contract. Token-aware hierarchy is an opt-in sidecar around those leaves, so stable v5 transport does not need another chunk model or breaking fields. Continue improving source maps and optional block/table/image/form/diagram references in owning adapters.
 
 ### Assets
 

--- a/OfficeIMO.Reader.Benchmarks/README.md
+++ b/OfficeIMO.Reader.Benchmarks/README.md
@@ -7,6 +7,7 @@
 - rich `ReadDocument(...)` extraction across CSV, EPUB, Excel, HTML, JSON, Markdown, PDF, PowerPoint, RTF, Visio, Word, XML, YAML, and ZIP
 - bounded content detection for text, signature-based, and ZIP-container formats
 - version 5 JSON transport serialization and deserialization
+- token-aware hierarchy construction and hierarchy JSON serialization
 - Markdown parser, heading/table chunking, and paragraph-only chunking isolation for regression diagnosis
 
 The corpus is generated deterministically during benchmark setup. Document creation is outside measured operations, while every measured read starts from the same immutable byte payload. Hashing is disabled in the extraction lane so format parsing and result projection remain visible; hosts that rely on source hashing should benchmark that option separately for their storage layer.
@@ -23,6 +24,7 @@ Run one lane or format:
 
 ```powershell
 dotnet run --project OfficeIMO.Reader.Benchmarks/OfficeIMO.Reader.Benchmarks.csproj -c Release -f net8.0 -- --filter *ReaderDetectionBenchmarks*
+dotnet run --project OfficeIMO.Reader.Benchmarks/OfficeIMO.Reader.Benchmarks.csproj -c Release -f net8.0 -- --filter *ReaderHierarchicalChunkingBenchmarks*
 dotnet run --project OfficeIMO.Reader.Benchmarks/OfficeIMO.Reader.Benchmarks.csproj -c Release -f net8.0 -- --filter "*ReaderDocumentBenchmarks*Pdf*"
 ```
 

--- a/OfficeIMO.Reader.Benchmarks/ReaderBenchmarks.cs
+++ b/OfficeIMO.Reader.Benchmarks/ReaderBenchmarks.cs
@@ -100,6 +100,38 @@ public class ReaderTransportBenchmarks {
 
 [MemoryDiagnoser]
 [ShortRunJob(RuntimeMoniker.Net80)]
+public class ReaderHierarchicalChunkingBenchmarks {
+    private OfficeDocumentReadResult _document = null!;
+    private ReaderHierarchicalChunkingOptions _options = null!;
+    private ReaderChunkHierarchyResult _hierarchy = null!;
+
+    [GlobalSetup]
+    public void Setup() {
+        ReaderBenchmarkInput input = ReaderBenchmarkCorpus.Get("Markdown");
+        _document = ReaderDocumentBenchmarks.CreateReader().ReadDocument(
+            input.Bytes,
+            input.SourceName,
+            new ReaderOptions { ComputeHashes = false, MaxChars = 4_000, MaxTableRows = 5_000 });
+        _options = new ReaderHierarchicalChunkingOptions {
+            MaxTokens = 512,
+            OverlapTokens = 64,
+            MaxInputChunks = 10_000,
+            MaxOutputChunks = 50_000,
+            IncludeContextInText = true
+        };
+        _hierarchy = ReaderHierarchicalChunker.Chunk(_document, _options);
+    }
+
+    [Benchmark]
+    public ReaderChunkHierarchyResult ChunkHierarchy() =>
+        ReaderHierarchicalChunker.Chunk(_document, _options);
+
+    [Benchmark]
+    public string SerializeHierarchy() => _hierarchy.ToJson();
+}
+
+[MemoryDiagnoser]
+[ShortRunJob(RuntimeMoniker.Net80)]
 public class ReaderMarkdownPipelineBenchmarks {
     private byte[] _bytes = Array.Empty<byte>();
     private string _markdown = string.Empty;

--- a/OfficeIMO.Reader.Epub/DocumentReaderEpubExtensions.cs
+++ b/OfficeIMO.Reader.Epub/DocumentReaderEpubExtensions.cs
@@ -86,7 +86,7 @@ public static class DocumentReaderEpubExtensions {
                         Path = BuildVirtualPath(sourcePath, chapter.Path),
                         BlockIndex = blockIndex,
                         SourceBlockIndex = chapter.Order > 0 ? chapter.Order - 1 : null,
-                        HeadingPath = chapter.Title
+                        HeadingPath = ReaderHeadingPath.Combine(new[] { chapter.Title })
                     },
                     Text = piece,
                     Markdown = BuildMarkdown(chapter.Title, piece),

--- a/OfficeIMO.Reader.Epub/DocumentReaderEpubExtensions.cs
+++ b/OfficeIMO.Reader.Epub/DocumentReaderEpubExtensions.cs
@@ -79,15 +79,19 @@ public static class DocumentReaderEpubExtensions {
                 var chunkId = BuildId(fileName, chapter.Order, chunkPart);
                 var wasSplit = chapter.Text.Length > maxChars;
 
+                var location = new ReaderLocation {
+                    Path = BuildVirtualPath(sourcePath, chapter.Path),
+                    BlockIndex = blockIndex,
+                    SourceBlockIndex = chapter.Order > 0 ? chapter.Order - 1 : null,
+                    HeadingPath = string.IsNullOrWhiteSpace(chapter.Title) ? null : chapter.Title.Trim()
+                };
+                ReaderHeadingPath.SetHierarchyPath(
+                    location,
+                    ReaderHeadingPath.Combine(new[] { chapter.Title }));
                 var chunk = EnrichChunk(new ReaderChunk {
                     Id = chunkId,
                     Kind = ReaderInputKind.Epub,
-                    Location = new ReaderLocation {
-                        Path = BuildVirtualPath(sourcePath, chapter.Path),
-                        BlockIndex = blockIndex,
-                        SourceBlockIndex = chapter.Order > 0 ? chapter.Order - 1 : null,
-                        HeadingPath = ReaderHeadingPath.Combine(new[] { chapter.Title })
-                    },
+                    Location = location,
                     Text = piece,
                     Markdown = BuildMarkdown(chapter.Title, piece),
                     Warnings = wasSplit ? new[] { "Chapter content was split due to MaxChars." } : null

--- a/OfficeIMO.Reader.Epub/DocumentReaderEpubExtensions.cs
+++ b/OfficeIMO.Reader.Epub/DocumentReaderEpubExtensions.cs
@@ -79,15 +79,17 @@ public static class DocumentReaderEpubExtensions {
                 var chunkId = BuildId(fileName, chapter.Order, chunkPart);
                 var wasSplit = chapter.Text.Length > maxChars;
 
+                string? chapterTitle = chapter.Title;
+                string? displayHeading = string.IsNullOrWhiteSpace(chapterTitle) ? null : chapterTitle!.Trim();
                 var location = new ReaderLocation {
                     Path = BuildVirtualPath(sourcePath, chapter.Path),
                     BlockIndex = blockIndex,
                     SourceBlockIndex = chapter.Order > 0 ? chapter.Order - 1 : null,
-                    HeadingPath = string.IsNullOrWhiteSpace(chapter.Title) ? null : chapter.Title.Trim()
+                    HeadingPath = displayHeading
                 };
                 ReaderHeadingPath.SetHierarchyPath(
                     location,
-                    ReaderHeadingPath.Combine(new[] { chapter.Title }));
+                    ReaderHeadingPath.Combine(new[] { chapterTitle }));
                 var chunk = EnrichChunk(new ReaderChunk {
                     Id = chunkId,
                     Kind = ReaderInputKind.Epub,

--- a/OfficeIMO.Reader.Html/DocumentReaderHtmlExtensions.cs
+++ b/OfficeIMO.Reader.Html/DocumentReaderHtmlExtensions.cs
@@ -107,15 +107,17 @@ public static class DocumentReaderHtmlExtensions {
                 ? sourceTables
                 : Array.Empty<ReaderTable>();
 
+            var location = new ReaderLocation {
+                Path = logicalSourceName,
+                BlockIndex = chunkIndex,
+                StartLine = part.StartLine,
+                HeadingPath = part.HeadingPath
+            };
+            ReaderHeadingPath.SetHierarchyPath(location, part.HierarchyHeadingPath);
             yield return EnrichChunk(new ReaderChunk {
                 Id = string.Concat("html-", chunkIndex.ToString("D4", CultureInfo.InvariantCulture)),
                 Kind = ReaderInputKind.Html,
-                Location = new ReaderLocation {
-                    Path = logicalSourceName,
-                    BlockIndex = chunkIndex,
-                    StartLine = part.StartLine,
-                    HeadingPath = part.HeadingPath
-                },
+                Location = location,
                 Text = part.Text,
                 Markdown = part.Text,
                 Tables = tables.Count > 0 ? tables : null,
@@ -140,6 +142,7 @@ public static class DocumentReaderHtmlExtensions {
         var currentWarnings = new List<string>(2);
         int currentStartLine = 1;
         string? currentHeadingPath = null;
+        string? currentHierarchyHeadingPath = null;
 
         void FlushCurrent() {
             if (currentText.Length == 0) return;
@@ -150,6 +153,7 @@ public static class DocumentReaderHtmlExtensions {
                     text,
                     currentStartLine,
                     currentHeadingPath,
+                    currentHierarchyHeadingPath,
                     currentWarnings.Count == 0 ? null : currentWarnings.ToArray()));
             }
 
@@ -181,6 +185,7 @@ public static class DocumentReaderHtmlExtensions {
             if (currentText.Length == 0) {
                 currentStartLine = lineNo;
                 currentHeadingPath = chunkByHeadings ? BuildHeadingPath(headingStack) : null;
+                currentHierarchyHeadingPath = chunkByHeadings ? BuildHierarchyHeadingPath(headingStack) : null;
             }
 
             if (line.Length > maxChars) {
@@ -194,6 +199,7 @@ public static class DocumentReaderHtmlExtensions {
                     if (currentText.Length == 0) {
                         currentStartLine = lineNo;
                         currentHeadingPath = chunkByHeadings ? BuildHeadingPath(headingStack) : null;
+                        currentHierarchyHeadingPath = chunkByHeadings ? BuildHierarchyHeadingPath(headingStack) : null;
                     }
 
                     int take = Math.Min(maxChars, line.Length - segmentIndex);
@@ -214,6 +220,7 @@ public static class DocumentReaderHtmlExtensions {
                 FlushCurrent();
                 currentStartLine = lineNo;
                 currentHeadingPath = chunkByHeadings ? BuildHeadingPath(headingStack) : null;
+                currentHierarchyHeadingPath = chunkByHeadings ? BuildHierarchyHeadingPath(headingStack) : null;
             }
 
             AppendLine(currentText, line);
@@ -264,6 +271,7 @@ public static class DocumentReaderHtmlExtensions {
 
         level = i;
         text = line.Substring(i).Trim();
+        text = text.Replace("\\\\", "\\");
         if (text.Length == 0) text = "Heading " + level.ToString(CultureInfo.InvariantCulture);
         return true;
     }
@@ -279,6 +287,14 @@ public static class DocumentReaderHtmlExtensions {
     }
 
     private static string? BuildHeadingPath(List<(int Level, string Text)> stack) {
+        string[] values = stack
+            .Select(static heading => heading.Text.Trim())
+            .Where(static heading => heading.Length > 0)
+            .ToArray();
+        return values.Length == 0 ? null : string.Join(" > ", values);
+    }
+
+    private static string? BuildHierarchyHeadingPath(List<(int Level, string Text)> stack) {
         return ReaderHeadingPath.Combine(stack.Select(static heading => heading.Text));
     }
 
@@ -501,16 +517,18 @@ public static class DocumentReaderHtmlExtensions {
     }
 
     private sealed class MarkdownPart {
-        public MarkdownPart(string text, int startLine, string? headingPath, IReadOnlyList<string>? warnings) {
+        public MarkdownPart(string text, int startLine, string? headingPath, string? hierarchyHeadingPath, IReadOnlyList<string>? warnings) {
             Text = text;
             StartLine = startLine;
             HeadingPath = headingPath;
+            HierarchyHeadingPath = hierarchyHeadingPath;
             Warnings = warnings;
         }
 
         public string Text { get; }
         public int StartLine { get; }
         public string? HeadingPath { get; }
+        public string? HierarchyHeadingPath { get; }
         public IReadOnlyList<string>? Warnings { get; }
     }
 

--- a/OfficeIMO.Reader.Html/DocumentReaderHtmlExtensions.cs
+++ b/OfficeIMO.Reader.Html/DocumentReaderHtmlExtensions.cs
@@ -1,4 +1,5 @@
 using OfficeIMO.Markdown.Html;
+using System.Linq;
 
 namespace OfficeIMO.Reader.Html;
 
@@ -278,16 +279,7 @@ public static class DocumentReaderHtmlExtensions {
     }
 
     private static string? BuildHeadingPath(List<(int Level, string Text)> stack) {
-        if (stack.Count == 0) return null;
-
-        var sb = new StringBuilder();
-        for (int i = 0; i < stack.Count; i++) {
-            if (i > 0) sb.Append(" > ");
-            sb.Append(stack[i].Text);
-        }
-
-        var value = sb.ToString().Trim();
-        return value.Length == 0 ? null : value;
+        return ReaderHeadingPath.Combine(stack.Select(static heading => heading.Text));
     }
 
     private static bool WouldExceed(int maxChars, StringBuilder current, string nextLine) {

--- a/OfficeIMO.Reader.Tests/Reader.Contract.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Contract.cs
@@ -65,6 +65,12 @@ public sealed class ReaderContractTests {
 
     [Fact]
     public void OfficeDocumentReadResultJson_RoundTripsCurrentTransportShape() {
+        var chunkLocation = new ReaderLocation {
+            Path = "report.pdf",
+            Page = 1,
+            HeadingPath = "Q1 > Q2"
+        };
+        ReaderHeadingPath.SetHierarchyPath(chunkLocation, ReaderHeadingPath.Combine(new[] { "Q1 > Q2" }));
         var original = new OfficeDocumentReadResult {
             Kind = ReaderInputKind.Pdf,
             Source = new OfficeDocumentSource {
@@ -79,7 +85,7 @@ public sealed class ReaderContractTests {
                     Id = "chunk-1",
                     Kind = ReaderInputKind.Pdf,
                     Text = "Report body",
-                    Location = new ReaderLocation { Path = "report.pdf", Page = 1 }
+                    Location = chunkLocation
                 }
             },
             Tables = new[] {
@@ -111,7 +117,14 @@ public sealed class ReaderContractTests {
         Assert.Equal(ReaderInputKind.Pdf, restored.Kind);
         Assert.Equal("report.pdf", restored.Source.Path);
         Assert.Equal("officeimo.reader.pdf", Assert.Single(restored.CapabilitiesUsed));
-        Assert.Equal("Report body", Assert.Single(restored.Chunks).Text);
+        ReaderChunk restoredChunk = Assert.Single(restored.Chunks);
+        Assert.Equal("Report body", restoredChunk.Text);
+        Assert.Equal("Q1 > Q2", restoredChunk.Location.HeadingPath);
+        Assert.Equal(@"Q1 \> Q2", restoredChunk.Location.HierarchyHeadingPath);
+        ReaderChunkHierarchyNode restoredHeading = Assert.Single(
+            ReaderHierarchicalChunker.Chunk(restored).Nodes,
+            node => node.Kind == ReaderChunkHierarchyNodeKind.Heading);
+        Assert.Equal("Q1 > Q2", restoredHeading.Title);
         Assert.Equal("2", Assert.Single(Assert.Single(restored.Tables).Rows)[1]);
         OfficeDocumentDiagnostic diagnostic = Assert.Single(restored.Diagnostics);
         Assert.Equal(OfficeDocumentDiagnosticCategory.Content, diagnostic.Category);

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Modular.cs
@@ -230,6 +230,38 @@ public sealed class ReaderEpubModularTests {
     }
 
     [Fact]
+    public void DocumentReaderEpub_PreservesLiteralChapterTitleAndAllowsVirtualChapterSources() {
+        var epubPath = Path.Combine(Path.GetTempPath(), "officeimo-epub-" + Guid.NewGuid().ToString("N") + ".epub");
+        try {
+            BuildEpubWithSpine(epubPath, "Q1 &gt; Q2\\Back");
+            var chunks = DocumentReaderEpubExtensions.ReadEpub(
+                epubPath,
+                readerOptions: new ReaderOptions { MaxChars = 4_000 },
+                epubOptions: new EpubReadOptions { PreferSpineOrder = true }).ToList();
+
+            ReaderChunk chapter = Assert.Single(
+                chunks,
+                chunk => chunk.Location.Path?.Contains("::OEBPS/chapter2.xhtml", StringComparison.OrdinalIgnoreCase) ?? false);
+            Assert.Equal("Q1 > Q2\\Back", chapter.Location.HeadingPath);
+            Assert.NotEqual(chunks[0].SourceId, chunks[1].SourceId);
+
+            var document = new OfficeDocumentReadResult {
+                Kind = ReaderInputKind.Epub,
+                Source = new OfficeDocumentSource { SourceId = "book", Path = epubPath },
+                Chunks = chunks
+            };
+            ReaderChunkHierarchyResult hierarchy = ReaderHierarchicalChunker.Chunk(document);
+            Assert.Equal(chunks.Count, hierarchy.Chunks.Count);
+            Assert.Contains(
+                hierarchy.Nodes,
+                node => node.Kind == ReaderChunkHierarchyNodeKind.Heading &&
+                        string.Equals(node.Title, "Q1 > Q2\\Back", StringComparison.Ordinal));
+        } finally {
+            if (File.Exists(epubPath)) File.Delete(epubPath);
+        }
+    }
+
+    [Fact]
     public void DocumentReaderEpub_DirectStreamRead_EmitsLogicalSourceMetadata() {
         var epubPath = Path.Combine(Path.GetTempPath(), "officeimo-epub-" + Guid.NewGuid().ToString("N") + ".epub");
         try {
@@ -307,7 +339,7 @@ public sealed class ReaderEpubModularTests {
         }
     }
 
-    private static void BuildEpubWithSpine(string epubPath) {
+    private static void BuildEpubWithSpine(string epubPath, string secondTitleXml = "Second") {
         using var fs = new FileStream(epubPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
         using var archive = new ZipArchive(fs, ZipArchiveMode.Create, leaveOpen: false);
 
@@ -336,14 +368,14 @@ public sealed class ReaderEpubModularTests {
         WriteTextEntry(archive, "OEBPS/nav.xhtml",
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
             "<html xmlns=\"http://www.w3.org/1999/xhtml\"><body><nav epub:type=\"toc\" xmlns:epub=\"http://www.idpf.org/2007/ops\"><ol>" +
-            "<li><a href=\"chapter2.xhtml\">Second</a></li>" +
+            "<li><a href=\"chapter2.xhtml\">" + secondTitleXml + "</a></li>" +
             "<li><a href=\"chapter1.xhtml\">First</a></li>" +
             "</ol></nav></body></html>");
 
         WriteTextEntry(archive, "OEBPS/toc.ncx",
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
             "<ncx xmlns=\"http://www.daisy.org/z3986/2005/ncx/\" version=\"2005-1\"><navMap>" +
-            "<navPoint id=\"n1\"><navLabel><text>Second</text></navLabel><content src=\"chapter2.xhtml\"/></navPoint>" +
+            "<navPoint id=\"n1\"><navLabel><text>" + secondTitleXml + "</text></navLabel><content src=\"chapter2.xhtml\"/></navPoint>" +
             "<navPoint id=\"n2\"><navLabel><text>First</text></navLabel><content src=\"chapter1.xhtml\"/></navPoint>" +
             "</navMap></ncx>");
 

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -195,6 +195,28 @@ public sealed class ReaderHierarchicalChunkingTests {
     }
 
     [Fact]
+    public void Chunk_UsesProcessorUpdatedPublicHeadingPathInsteadOfStaleHint() {
+        ReaderChunk chunk = Assert.Single(DocumentReader.Read(
+            Encoding.UTF8.GetBytes("# Original > Literal\n\nBody"),
+            "note.md"));
+        chunk.Location.HeadingPath = "Processed";
+
+        ReaderChunkHierarchyResult hierarchy = ReaderHierarchicalChunker.Chunk(
+            new[] { chunk },
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 100,
+                OverlapTokens = 0,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+
+        ReaderChunkHierarchyNode heading = Assert.Single(
+            hierarchy.Nodes,
+            node => node.Kind == ReaderChunkHierarchyNodeKind.Heading);
+        Assert.Equal("Processed", heading.Title);
+    }
+
+    [Fact]
     public void Chunk_InheritsMissingEnvelopeProvenanceAndReplacesWhitespacePath() {
         ReaderChunk source = CreateChunk("source", "body");
         source.SourceId = "chunk-id";

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -451,6 +451,83 @@ public sealed class ReaderHierarchicalChunkingTests {
     }
 
     [Fact]
+    public void Chunk_SeparatesRepeatedFallbackAncestorHeadingsByPerLevelSlug() {
+        var document = new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource { SourceId = "repeated-ancestors" },
+            Blocks = new[] {
+                new OfficeDocumentBlock { Id = "overview-a", Kind = "heading", Level = 1, Text = "Overview" },
+                new OfficeDocumentBlock { Id = "details-a", Kind = "heading", Level = 2, Text = "Details" },
+                new OfficeDocumentBlock { Id = "body-a", Kind = "paragraph", Text = "First body" },
+                new OfficeDocumentBlock { Id = "overview-b", Kind = "heading", Level = 1, Text = "Overview" },
+                new OfficeDocumentBlock { Id = "details-b", Kind = "heading", Level = 2, Text = "Details" },
+                new OfficeDocumentBlock { Id = "body-b", Kind = "paragraph", Text = "Second body" }
+            }
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(document);
+
+        ReaderChunkHierarchyNode[] overviews = result.Nodes
+            .Where(node => node.Kind == ReaderChunkHierarchyNodeKind.Heading && node.Title == "Overview")
+            .ToArray();
+        Assert.Equal(2, overviews.Length);
+        Assert.All(overviews, overview => Assert.Single(
+            overview.ChildNodeIds.Select(id => result.Nodes.Single(node => node.Id == id)),
+            child => child.Kind == ReaderChunkHierarchyNodeKind.Heading && child.Title == "Details"));
+    }
+
+    [Fact]
+    public void Chunk_InheritsEnvelopeSourceIdForPathOnlyChunks() {
+        ReaderChunk first = CreateChunk("chunk", "body");
+        first.SourceId = null;
+        first.Location.Path = "shared-name.txt";
+        var firstDocument = new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource { SourceId = "tenant-a", Path = "shared-name.txt" },
+            Chunks = new[] { first }
+        };
+        ReaderChunk second = CreateChunk("chunk", "body");
+        second.SourceId = null;
+        second.Location.Path = "shared-name.txt";
+        var secondDocument = new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource { SourceId = "tenant-b", Path = "shared-name.txt" },
+            Chunks = new[] { second }
+        };
+
+        ReaderChunkHierarchyResult firstResult = ReaderHierarchicalChunker.Chunk(firstDocument);
+        ReaderChunkHierarchyResult secondResult = ReaderHierarchicalChunker.Chunk(secondDocument);
+
+        Assert.Equal("tenant-a", Assert.Single(firstResult.Chunks).SourceId);
+        Assert.NotEqual(Assert.Single(firstResult.Chunks).Id, Assert.Single(secondResult.Chunks).Id);
+    }
+
+    [Fact]
+    public void Chunk_LengthPrefixesSegmentIdentityFields() {
+        ReaderChunk first = CreateChunk("c", "body");
+        first.SourceId = "a|b";
+        ReaderChunk second = CreateChunk("b|c", "body");
+        second.SourceId = "a";
+
+        string firstId = Assert.Single(ReaderHierarchicalChunker.Chunk(new[] { first }).Chunks).Id;
+        string secondId = Assert.Single(ReaderHierarchicalChunker.Chunk(new[] { second }).Chunks).Id;
+
+        Assert.NotEqual(firstId, secondId);
+    }
+
+    [Fact]
+    public void Chunk_InfersSourceFromFirstIdentifiedChunk() {
+        ReaderChunk anonymous = CreateChunk("anonymous", "preface");
+        anonymous.SourceId = null;
+        anonymous.Location.Path = null;
+        ReaderChunk identified = CreateChunk("identified", "body");
+        identified.SourceId = null;
+        identified.Location.Path = "guide.txt";
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(new[] { anonymous, identified });
+
+        Assert.Equal("guide.txt", result.Source.Path);
+        Assert.Equal("guide.txt", result.Nodes.Single(node => node.Kind == ReaderChunkHierarchyNodeKind.Document).Title);
+    }
+
+    [Fact]
     public void Chunk_DerivesContextTokensFromCombinedTokenizerOutput() {
         ReaderChunk source = CreateChunk("source", "a", page: 3);
 

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -173,6 +173,98 @@ public sealed class ReaderHierarchicalChunkingTests {
     }
 
     [Fact]
+    public void MarkdownRead_PreservesRawHeadingPathWhileHierarchyKeepsLiteralDelimiter() {
+        byte[] markdown = Encoding.UTF8.GetBytes("# Q1 > Q2\\Back\n\nBody");
+        ReaderChunk normal = Assert.Single(DocumentReader.Read(markdown, "note.md"));
+
+        Assert.Equal("Q1 > Q2\\Back", normal.Location.HeadingPath);
+
+        ReaderChunkHierarchyResult hierarchy = DocumentReader.ReadHierarchical(
+            markdown,
+            "note.md",
+            chunkingOptions: new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 100,
+                OverlapTokens = 0,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+        ReaderChunkHierarchyNode heading = Assert.Single(
+            hierarchy.Nodes,
+            node => node.Kind == ReaderChunkHierarchyNodeKind.Heading);
+        Assert.Equal("Q1 > Q2\\Back", heading.Title);
+    }
+
+    [Fact]
+    public void Chunk_InheritsMissingEnvelopeProvenanceAndReplacesWhitespacePath() {
+        ReaderChunk source = CreateChunk("source", "body");
+        source.SourceId = "chunk-id";
+        source.SourceHash = null;
+        source.SourceLastWriteUtc = null;
+        source.SourceLengthBytes = null;
+        source.Location.Path = "   ";
+        DateTime lastWrite = new DateTime(2026, 7, 11, 1, 2, 3, DateTimeKind.Utc);
+        var document = new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource {
+                SourceId = "envelope-id",
+                Path = "source.md",
+                SourceHash = "source-hash",
+                LastWriteUtc = lastWrite,
+                LengthBytes = 123
+            },
+            Chunks = new[] { source }
+        };
+
+        ReaderChunk inherited = Assert.Single(ReaderHierarchicalChunker.Chunk(
+            document,
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 10,
+                OverlapTokens = 0,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            }).Chunks);
+
+        Assert.Equal("chunk-id", inherited.SourceId);
+        Assert.Equal("source.md", inherited.Location.Path);
+        Assert.Equal("source-hash", inherited.SourceHash);
+        Assert.Equal(lastWrite, inherited.SourceLastWriteUtc);
+        Assert.Equal(123, inherited.SourceLengthBytes);
+    }
+
+    [Fact]
+    public void Chunk_SeparatesDelimitedHeadingKeysAndRootIdentityNamespaces() {
+        ReaderChunk literalMarker = CreateChunk("literal", "one", headingPath: "A|slug:x");
+        ReaderChunk slugIdentity = CreateChunk("slugged", "two", headingPath: "A", headingSlug: "x");
+        var options = new ReaderHierarchicalChunkingOptions {
+            MaxTokens = 10,
+            OverlapTokens = 0,
+            IncludeContextInText = false,
+            TokenCounter = WordCounter
+        };
+
+        ReaderChunkHierarchyResult headings = ReaderHierarchicalChunker.Chunk(
+            new[] { literalMarker, slugIdentity },
+            options);
+        Assert.Equal(2, headings.Nodes.Count(node => node.Kind == ReaderChunkHierarchyNodeKind.Heading));
+
+        var sourceIdDocument = new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource { SourceId = "foo" },
+            Chunks = new[] { CreateChunk("source", "body") }
+        };
+        sourceIdDocument.Chunks[0].SourceId = "foo";
+        sourceIdDocument.Chunks[0].Location.Path = null;
+        var pathDocument = new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource { Path = "foo" },
+            Chunks = new[] { CreateChunk("source", "body") }
+        };
+        pathDocument.Chunks[0].SourceId = null;
+        pathDocument.Chunks[0].Location.Path = "foo";
+
+        Assert.NotEqual(
+            ReaderHierarchicalChunker.Chunk(sourceIdDocument, options).RootNodeId,
+            ReaderHierarchicalChunker.Chunk(pathDocument, options).RootNodeId);
+    }
+
+    [Fact]
     public void Chunk_ReportsInputLimitOnlyWhenAnotherChunkExists() {
         var options = new ReaderHierarchicalChunkingOptions {
             MaxTokens = 10,

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -1,4 +1,5 @@
 using OfficeIMO.Reader;
+using System.Collections;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -127,6 +128,135 @@ public sealed class ReaderHierarchicalChunkingTests {
         Assert.DoesNotContain("Page 3", omitted.Chunks[0].Text, StringComparison.Ordinal);
         Assert.Equal("Page 3 > Root > Child", omitted.Segments[0].Context);
         Assert.Contains(omitted.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-context-omitted");
+    }
+
+    [Fact]
+    public void Chunk_FallsBackToTextWhenPreferredMarkdownIsEmpty() {
+        ReaderChunk source = CreateChunk("source", "plain text body");
+        source.Markdown = string.Empty;
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(
+            new[] { source },
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 10,
+                OverlapTokens = 0,
+                IncludeContextInText = false,
+                PreferMarkdown = true,
+                TokenCounter = WordCounter
+            });
+
+        ReaderChunk chunk = Assert.Single(result.Chunks);
+        Assert.Equal("plain text body", chunk.Text);
+        Assert.Null(chunk.Markdown);
+    }
+
+    [Fact]
+    public void Chunk_PreservesFullHeadingIdentityWhenDisplayTitlesAreTruncated() {
+        ReaderChunk first = CreateChunk("first", "one", headingPath: "ABCDE-first");
+        ReaderChunk second = CreateChunk("second", "two", headingPath: "ABCDE-second");
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(
+            new[] { first, second },
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 10,
+                OverlapTokens = 0,
+                MaxContextCharacters = 5,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+
+        ReaderChunkHierarchyNode[] headings = result.Nodes
+            .Where(node => node.Kind == ReaderChunkHierarchyNodeKind.Heading)
+            .ToArray();
+        Assert.Equal(2, headings.Length);
+        Assert.All(headings, heading => Assert.Equal("ABCDE", heading.Title));
+        Assert.Equal(2, headings.Select(heading => heading.Id).Distinct(StringComparer.Ordinal).Count());
+    }
+
+    [Fact]
+    public void Chunk_StopsLazyFallbackTraversalAtInputBound() {
+        var document = new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource { SourceId = "lazy-blocks" },
+            Blocks = new ThrowAfterFirstBlockList()
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(
+            document,
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 10,
+                OverlapTokens = 0,
+                MaxInputChunks = 1,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+
+        Assert.Single(result.Chunks);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-input-chunk-limit");
+    }
+
+    [Fact]
+    public void Chunk_BoundsLeafTitlesAndPathsWithoutChangingLeafIdentity() {
+        ReaderChunk source = CreateChunk("stable-id", "body");
+        source.Location.Page = null;
+        source.Location.BlockAnchor = new string('a', 50);
+        var options = new ReaderHierarchicalChunkingOptions {
+            MaxTokens = 10,
+            OverlapTokens = 0,
+            MaxContextCharacters = 5,
+            IncludeContextInText = false,
+            TokenCounter = WordCounter
+        };
+
+        ReaderChunkHierarchyResult bounded = ReaderHierarchicalChunker.Chunk(new[] { source }, options);
+        ReaderChunkHierarchyNode boundedLeaf = Assert.Single(
+            bounded.Nodes,
+            node => node.Kind == ReaderChunkHierarchyNodeKind.Chunk);
+        options.MaxContextCharacters = 10;
+        ReaderChunkHierarchyNode widerLeaf = Assert.Single(
+            ReaderHierarchicalChunker.Chunk(new[] { source }, options).Nodes,
+            node => node.Kind == ReaderChunkHierarchyNodeKind.Chunk);
+
+        Assert.Equal(5, boundedLeaf.Title.Length);
+        Assert.InRange(boundedLeaf.Path.Length, 1, 5);
+        Assert.Equal(boundedLeaf.Id, widerLeaf.Id);
+    }
+
+    [Fact]
+    public void Chunk_OmitsContextWhenItLeavesNoRoomForFirstSourceToken() {
+        ReaderChunk source = CreateChunk("source", "a", headingPath: "Context");
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(
+            new[] { source },
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 2,
+                OverlapTokens = 0,
+                IncludeContextInText = true,
+                TokenCounter = new NonAdditiveContextTokenCounter()
+            });
+
+        Assert.Equal("a", Assert.Single(result.Chunks).Text);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-context-omitted");
+    }
+
+    [Fact]
+    public void Chunk_UsesPathIdentityForSegmentIdsWhenSourceIdIsMissing() {
+        ReaderChunk first = CreateChunk("same", "body");
+        first.SourceId = null;
+        first.Location.Path = "first.txt";
+        ReaderChunk second = CreateChunk("same", "body");
+        second.SourceId = null;
+        second.Location.Path = "second.txt";
+        var options = new ReaderHierarchicalChunkingOptions {
+            MaxTokens = 10,
+            OverlapTokens = 0,
+            IncludeContextInText = false,
+            TokenCounter = WordCounter
+        };
+
+        string firstId = Assert.Single(ReaderHierarchicalChunker.Chunk(new[] { first }, options).Chunks).Id;
+        string secondId = Assert.Single(ReaderHierarchicalChunker.Chunk(new[] { second }, options).Chunks).Id;
+
+        Assert.NotEqual(firstId, secondId);
     }
 
     [Fact]
@@ -359,5 +489,36 @@ public sealed class ReaderHierarchicalChunkingTests {
     private sealed class NegativeTokenCounter : IReaderTokenCounter {
         public string Id => "tests.negative-v1";
         public int CountTokens(string text) => -1;
+    }
+
+    private sealed class NonAdditiveContextTokenCounter : IReaderTokenCounter {
+        public string Id => "tests.non-additive-context-v1";
+
+        public int CountTokens(string text) {
+            if (text.Length == 0) return 0;
+            if (text.EndsWith("\n\n", StringComparison.Ordinal)) return 1;
+            return text.Contains("\n\n", StringComparison.Ordinal) ? 3 : 1;
+        }
+    }
+
+    private sealed class ThrowAfterFirstBlockList : IReadOnlyList<OfficeDocumentBlock> {
+        private readonly OfficeDocumentBlock _first = new OfficeDocumentBlock {
+            Id = "first",
+            Kind = "paragraph",
+            Text = "first block"
+        };
+
+        public int Count => 2;
+
+        public OfficeDocumentBlock this[int index] => index == 0
+            ? _first
+            : throw new InvalidOperationException("The input bound should stop before reading another block.");
+
+        public IEnumerator<OfficeDocumentBlock> GetEnumerator() {
+            yield return _first;
+            throw new InvalidOperationException("The input bound should stop before reading another block.");
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -1,5 +1,4 @@
 using OfficeIMO.Reader;
-using System.Collections;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -174,24 +173,24 @@ public sealed class ReaderHierarchicalChunkingTests {
     }
 
     [Fact]
-    public void Chunk_StopsLazyFallbackTraversalAtInputBound() {
-        var document = new OfficeDocumentReadResult {
-            Source = new OfficeDocumentSource { SourceId = "lazy-blocks" },
-            Blocks = new ThrowAfterFirstBlockList()
+    public void Chunk_ReportsInputLimitOnlyWhenAnotherChunkExists() {
+        var options = new ReaderHierarchicalChunkingOptions {
+            MaxTokens = 10,
+            OverlapTokens = 0,
+            MaxInputChunks = 1,
+            IncludeContextInText = false,
+            TokenCounter = WordCounter
         };
 
-        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(
-            document,
-            new ReaderHierarchicalChunkingOptions {
-                MaxTokens = 10,
-                OverlapTokens = 0,
-                MaxInputChunks = 1,
-                IncludeContextInText = false,
-                TokenCounter = WordCounter
-            });
+        ReaderChunkHierarchyResult exact = ReaderHierarchicalChunker.Chunk(
+            new[] { CreateChunk("first", "first block") },
+            options);
+        ReaderChunkHierarchyResult truncated = ReaderHierarchicalChunker.Chunk(
+            new[] { CreateChunk("first", "first block"), CreateChunk("second", "second block") },
+            options);
 
-        Assert.Single(result.Chunks);
-        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-input-chunk-limit");
+        Assert.DoesNotContain(exact.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-input-chunk-limit");
+        Assert.Contains(truncated.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-input-chunk-limit");
     }
 
     [Fact]
@@ -327,12 +326,13 @@ public sealed class ReaderHierarchicalChunkingTests {
 
     [Fact]
     public void Chunk_PrefersPageScopeForBlocksAlsoPresentAtDocumentLevel() {
-        var shared = new OfficeDocumentBlock { Id = "shared", Kind = "paragraph", Text = "Page body" };
+        var documentBlock = new OfficeDocumentBlock { Id = "shared", Kind = "paragraph", Text = "Page body" };
+        var pageClone = new OfficeDocumentBlock { Id = "shared", Kind = "paragraph", Text = "Page body" };
         var document = new OfficeDocumentReadResult {
             Source = new OfficeDocumentSource { Path = "pages.pdf" },
-            Blocks = new[] { shared },
+            Blocks = new[] { documentBlock },
             Pages = new[] {
-                new OfficeDocumentPage { Number = 7, Blocks = new[] { shared } }
+                new OfficeDocumentPage { Number = 7, Blocks = new[] { pageClone } }
             }
         };
 
@@ -340,6 +340,45 @@ public sealed class ReaderHierarchicalChunkingTests {
 
         Assert.Equal(7, Assert.Single(result.Chunks).Location.Page);
         Assert.Equal("Page 7", Assert.Single(result.Nodes, node => node.Kind == ReaderChunkHierarchyNodeKind.Container).Title);
+    }
+
+    [Fact]
+    public void Chunk_UsesSheetContainerKindForBlockOnlyResults() {
+        var document = new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource { Path = "workbook.xlsx" },
+            Pages = new[] {
+                new OfficeDocumentPage {
+                    Number = 2,
+                    Name = "Inventory",
+                    Location = new ReaderLocation { SourceBlockKind = "sheet" },
+                    Blocks = new[] { new OfficeDocumentBlock { Id = "sheet-body", Kind = "paragraph", Text = "Sheet body" } }
+                }
+            }
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(document);
+
+        ReaderLocation location = Assert.Single(result.Chunks).Location;
+        Assert.Equal("Inventory", location.Sheet);
+        Assert.Null(location.Page);
+        Assert.Equal("Sheet: Inventory", Assert.Single(result.Nodes, node => node.Kind == ReaderChunkHierarchyNodeKind.Container).Title);
+    }
+
+    [Fact]
+    public void Chunk_PreservesLiteralHeadingSeparators() {
+        var document = new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource { SourceId = "literal-heading" },
+            Blocks = new[] {
+                new OfficeDocumentBlock { Id = "quarter", Kind = "heading", Level = 1, Text = "Q1 > Q2" },
+                new OfficeDocumentBlock { Id = "body", Kind = "paragraph", Text = "Comparison" }
+            }
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(document);
+
+        ReaderChunkHierarchyNode heading = Assert.Single(result.Nodes, node => node.Kind == ReaderChunkHierarchyNodeKind.Heading);
+        Assert.Equal("Q1 > Q2", heading.Title);
+        Assert.Equal("Q1 > Q2", result.Segments[1].Context);
     }
 
     [Fact]
@@ -673,24 +712,4 @@ public sealed class ReaderHierarchicalChunkingTests {
         }
     }
 
-    private sealed class ThrowAfterFirstBlockList : IReadOnlyList<OfficeDocumentBlock> {
-        private readonly OfficeDocumentBlock _first = new OfficeDocumentBlock {
-            Id = "first",
-            Kind = "paragraph",
-            Text = "first block"
-        };
-
-        public int Count => 2;
-
-        public OfficeDocumentBlock this[int index] => index == 0
-            ? _first
-            : throw new InvalidOperationException("The input bound should stop before reading another block.");
-
-        public IEnumerator<OfficeDocumentBlock> GetEnumerator() {
-            yield return _first;
-            throw new InvalidOperationException("The input bound should stop before reading another block.");
-        }
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-    }
 }

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -479,6 +479,34 @@ public sealed class ReaderHierarchicalChunkingTests {
     }
 
     [Fact]
+    public void Chunk_InheritsSheetContainerWhenBlockSheetIsWhitespace() {
+        var document = new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource { Path = "workbook.xlsx" },
+            Pages = new[] {
+                new OfficeDocumentPage {
+                    Number = 2,
+                    Name = "Inventory",
+                    Location = new ReaderLocation { SourceBlockKind = "sheet" },
+                    Blocks = new[] {
+                        new OfficeDocumentBlock {
+                            Id = "sheet-body",
+                            Kind = "paragraph",
+                            Text = "Sheet body",
+                            Location = new ReaderLocation { Sheet = " " }
+                        }
+                    }
+                }
+            }
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(document);
+
+        ReaderLocation location = Assert.Single(result.Chunks).Location;
+        Assert.Equal("Inventory", location.Sheet);
+        Assert.Null(location.Page);
+    }
+
+    [Fact]
     public void Chunk_PreservesLiteralHeadingSeparators() {
         var document = new OfficeDocumentReadResult {
             Source = new OfficeDocumentSource { SourceId = "literal-heading" },
@@ -493,6 +521,16 @@ public sealed class ReaderHierarchicalChunkingTests {
         ReaderChunkHierarchyNode heading = Assert.Single(result.Nodes, node => node.Kind == ReaderChunkHierarchyNodeKind.Heading);
         Assert.Equal("Q1 > Q2", heading.Title);
         Assert.Equal("Q1 > Q2", result.Segments[1].Context);
+        Assert.Equal("Q1 > Q2", result.Chunks[1].Location.HeadingPath);
+    }
+
+    [Fact]
+    public void Chunk_PreservesRawEscapesInContextWithoutHierarchyMetadata() {
+        ReaderChunk source = CreateChunk("raw-context", "Body", headingPath: @"Q1 \> Q2\\Back");
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(new[] { source });
+
+        Assert.Equal(@"Q1 \> Q2\\Back", Assert.Single(result.Segments).Context);
     }
 
     [Fact]
@@ -587,6 +625,50 @@ public sealed class ReaderHierarchicalChunkingTests {
         Assert.All(overviews, overview => Assert.Single(
             overview.ChildNodeIds.Select(id => result.Nodes.Single(node => node.Id == id)),
             child => child.Kind == ReaderChunkHierarchyNodeKind.Heading && child.Title == "Details"));
+    }
+
+    [Fact]
+    public void Chunk_PreservesFallbackSlugIdentityWhenHeadingDepthCollapses() {
+        var document = new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource { SourceId = "collapsed-repeated-ancestors" },
+            Blocks = new[] {
+                new OfficeDocumentBlock { Id = "overview-a", Kind = "heading", Level = 1, Text = "Overview" },
+                new OfficeDocumentBlock { Id = "details-a", Kind = "heading", Level = 2, Text = "Details" },
+                new OfficeDocumentBlock { Id = "body-a", Kind = "paragraph", Text = "First body" },
+                new OfficeDocumentBlock { Id = "overview-b", Kind = "heading", Level = 1, Text = "Overview" },
+                new OfficeDocumentBlock { Id = "details-b", Kind = "heading", Level = 2, Text = "Details" },
+                new OfficeDocumentBlock { Id = "body-b", Kind = "paragraph", Text = "Second body" }
+            }
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(
+            document,
+            new ReaderHierarchicalChunkingOptions { MaxHierarchyDepth = 1 });
+
+        ReaderChunkHierarchyNode[] headings = result.Nodes
+            .Where(node => node.Kind == ReaderChunkHierarchyNodeKind.Heading)
+            .ToArray();
+        Assert.Equal(4, headings.Length);
+        Assert.Equal(4, headings.Select(heading => heading.Id).Distinct(StringComparer.Ordinal).Count());
+    }
+
+    [Fact]
+    public void Chunk_SeparatesEncodedHeadingPathsAfterDepthCollapse() {
+        ReaderChunk literal = CreateChunk("literal", "One", headingPath: "A > B > C");
+        ReaderHeadingPath.SetHierarchyPath(literal.Location, ReaderHeadingPath.Combine(new[] { "A > B", "C" }));
+        ReaderChunk nested = CreateChunk("nested", "Two", headingPath: "A > B > C");
+        ReaderHeadingPath.SetHierarchyPath(nested.Location, ReaderHeadingPath.Combine(new[] { "A", "B", "C" }));
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(
+            new[] { literal, nested },
+            new ReaderHierarchicalChunkingOptions { MaxHierarchyDepth = 1 });
+
+        ReaderChunkHierarchyNode[] headings = result.Nodes
+            .Where(node => node.Kind == ReaderChunkHierarchyNodeKind.Heading)
+            .ToArray();
+        Assert.Equal(2, headings.Length);
+        Assert.All(headings, heading => Assert.Equal("A > B > C", heading.Title));
+        Assert.NotEqual(headings[0].Id, headings[1].Id);
     }
 
     [Fact]

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -1,0 +1,363 @@
+using OfficeIMO.Reader;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class ReaderHierarchicalChunkingTests {
+    private static readonly IReaderTokenCounter WordCounter = new WordTokenCounter();
+
+    [Fact]
+    public void Chunk_SplitsToHardTokenBoundsWithDeterministicOverlapAndIds() {
+        ReaderChunk source = CreateChunk(
+            "source-1",
+            "one two three four five six seven eight nine ten",
+            page: 1,
+            headingPath: "Root > Child");
+        var options = new ReaderHierarchicalChunkingOptions {
+            MaxTokens = 4,
+            OverlapTokens = 1,
+            IncludeContextInText = false,
+            TokenCounter = WordCounter
+        };
+
+        ReaderChunkHierarchyResult first = ReaderHierarchicalChunker.Chunk(new[] { source }, options);
+        ReaderChunkHierarchyResult second = ReaderHierarchicalChunker.Chunk(new[] { source }, options);
+
+        Assert.True(first.Chunks.Count > 1);
+        Assert.All(first.Chunks, chunk => Assert.InRange(chunk.TokenEstimate ?? -1, 1, 4));
+        Assert.Equal(first.Chunks.Select(chunk => chunk.Id), second.Chunks.Select(chunk => chunk.Id));
+        Assert.Equal(first.Chunks.Select(chunk => chunk.Text), second.Chunks.Select(chunk => chunk.Text));
+        Assert.Equal("one two three four five six seven eight nine ten", source.Text);
+        Assert.Null(source.ChunkHash);
+
+        for (int index = 1; index < first.Segments.Count; index++) {
+            Assert.True(first.Segments[index].StartCharacter < first.Segments[index - 1].EndCharacter);
+            Assert.InRange(first.Segments[index].OverlapTokenCount, 1, 1);
+        }
+        Assert.Equal(0, first.Segments[0].StartCharacter);
+        Assert.Equal(source.Text.Length, first.Segments[first.Segments.Count - 1].EndCharacter);
+        Assert.All(first.Segments, segment => Assert.Equal(
+            source.Text.Substring(segment.StartCharacter, segment.EndCharacter - segment.StartCharacter),
+            first.Chunks[segment.SegmentIndex].Text));
+        Assert.Equal(first.OutputTokenCount, first.Chunks.Sum(chunk => chunk.TokenEstimate ?? 0));
+        Assert.Equal(first.OverlapTokenCount, first.Segments.Sum(segment => segment.OverlapTokenCount));
+    }
+
+    [Fact]
+    public void Chunk_BuildsDocumentContainerHeadingAndLeafHierarchy() {
+        var document = new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource { SourceId = "doc-1", Path = "guide.pdf", Title = "Guide" },
+            Chunks = new[] {
+                CreateChunk("c1", "alpha beta", page: 1, headingPath: "Root > Child", headingSlug: "child"),
+                CreateChunk("c2", "gamma delta", page: 1, headingPath: "Root > Child", headingSlug: "child"),
+                CreateChunk("c3", "epsilon", page: 2, headingPath: "Appendix", headingSlug: "appendix")
+            }
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(
+            document,
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 100,
+                OverlapTokens = 0,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+
+        ReaderChunkHierarchyNode root = Assert.Single(result.Nodes, node => node.Kind == ReaderChunkHierarchyNodeKind.Document);
+        Assert.Equal("Guide", root.Title);
+        Assert.Equal(result.RootNodeId, root.Id);
+        Assert.Equal(2, root.ChildNodeIds.Count);
+        Assert.Equal(result.OutputTokenCount, root.TokenCount);
+        Assert.Equal(2, result.Nodes.Count(node => node.Kind == ReaderChunkHierarchyNodeKind.Container));
+        Assert.Equal(3, result.Nodes.Count(node => node.Kind == ReaderChunkHierarchyNodeKind.Heading));
+        Assert.Equal(3, result.Nodes.Count(node => node.Kind == ReaderChunkHierarchyNodeKind.Chunk));
+
+        ReaderChunkHierarchyNode child = Assert.Single(result.Nodes, node => node.Kind == ReaderChunkHierarchyNodeKind.Heading && node.Title == "Child");
+        Assert.Equal(2, child.ChildNodeIds.Count);
+        Assert.Equal(4L, child.TokenCount);
+    }
+
+    [Fact]
+    public void Chunk_PreservesStructuredSidecarsOnceAcrossSplitSegments() {
+        var table = new ReaderTable { Title = "Data", Columns = new[] { "A" } };
+        ReaderChunk source = CreateChunk("source", "one two three four five six");
+        source.Tables = new[] { table };
+        source.Warnings = new[] { "source warning" };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(
+            new[] { source },
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 2,
+                OverlapTokens = 0,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+
+        Assert.True(result.Chunks.Count > 1);
+        Assert.Same(table, Assert.Single(Assert.IsAssignableFrom<IReadOnlyList<ReaderTable>>(result.Chunks[0].Tables)));
+        Assert.Equal("source warning", Assert.Single(result.Chunks[0].Warnings!));
+        Assert.All(result.Chunks.Skip(1), chunk => {
+            Assert.Null(chunk.Tables);
+            Assert.Null(chunk.Warnings);
+        });
+    }
+
+    [Fact]
+    public void Chunk_AddsContextWithinBudgetOrRetainsItAsMetadata() {
+        ReaderChunk source = CreateChunk("source", "alpha beta gamma", page: 3, headingPath: "Root > Child");
+        var withContext = new ReaderHierarchicalChunkingOptions {
+            MaxTokens = 10,
+            OverlapTokens = 0,
+            IncludeContextInText = true,
+            TokenCounter = WordCounter
+        };
+
+        ReaderChunkHierarchyResult included = ReaderHierarchicalChunker.Chunk(new[] { source }, withContext);
+
+        Assert.StartsWith("Page 3 > Root > Child\n\n", Assert.Single(included.Chunks).Text, StringComparison.Ordinal);
+        Assert.True(Assert.Single(included.Segments).ContextTokenCount > 0);
+        Assert.InRange(Assert.Single(included.Chunks).TokenEstimate ?? -1, 1, 10);
+
+        withContext.MaxTokens = 3;
+        ReaderChunkHierarchyResult omitted = ReaderHierarchicalChunker.Chunk(new[] { source }, withContext);
+        Assert.DoesNotContain("Page 3", omitted.Chunks[0].Text, StringComparison.Ordinal);
+        Assert.Equal("Page 3 > Root > Child", omitted.Segments[0].Context);
+        Assert.Contains(omitted.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-context-omitted");
+    }
+
+    [Fact]
+    public void Chunk_EnforcesInputOutputAndDepthBoundsWithDiagnostics() {
+        ReaderChunk[] chunks = {
+            CreateChunk("c1", "one two three four five six", headingPath: "A > B > C > D"),
+            CreateChunk("c2", "seven eight")
+        };
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(
+            chunks,
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 2,
+                OverlapTokens = 0,
+                MaxInputChunks = 1,
+                MaxOutputChunks = 2,
+                MaxHierarchyDepth = 2,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+
+        Assert.Equal(2, result.Chunks.Count);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-output-chunk-limit");
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-depth-limit");
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-input-chunk-limit");
+
+        ReaderChunkHierarchyResult inputBound = ReaderHierarchicalChunker.Chunk(
+            chunks,
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 100,
+                OverlapTokens = 0,
+                MaxInputChunks = 1,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+        Assert.Single(inputBound.Chunks);
+        Assert.Contains(inputBound.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-input-chunk-limit");
+    }
+
+    [Fact]
+    public void Chunk_IsDeterministicJsonAndRejectsInvalidContracts() {
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(
+            new[] { CreateChunk("source", "alpha beta") },
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 10,
+                OverlapTokens = 0,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+
+        Assert.Equal(result.ToJson(), ReaderHierarchicalChunker.Chunk(
+            new[] { CreateChunk("source", "alpha beta") },
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 10,
+                OverlapTokens = 0,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            }).ToJson());
+        using JsonDocument json = JsonDocument.Parse(result.ToJson());
+        Assert.Equal(ReaderChunkHierarchySchema.Id, json.RootElement.GetProperty("schemaId").GetString());
+        Assert.Equal("Document", json.RootElement.GetProperty("nodes")[0].GetProperty("kind").GetString());
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => ReaderHierarchicalChunker.Chunk(
+            Array.Empty<ReaderChunk>(),
+            new ReaderHierarchicalChunkingOptions { MaxTokens = 1, OverlapTokens = 1 }));
+        Assert.Throws<InvalidOperationException>(() => new ReaderChunkHierarchyResult { SchemaVersion = 2 }.ToJson());
+    }
+
+    [Fact]
+    public void Chunk_HonorsCancellationAndValidatesTokenCounters() {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        Assert.Throws<OperationCanceledException>(() => ReaderHierarchicalChunker.Chunk(
+            new[] { CreateChunk("source", "alpha") },
+            cancellationToken: cancellation.Token));
+        Assert.Throws<InvalidOperationException>(() => ReaderHierarchicalChunker.Chunk(
+            new[] { CreateChunk("source", "alpha") },
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 10,
+                OverlapTokens = 0,
+                TokenCounter = new NegativeTokenCounter()
+            }));
+    }
+
+    [Fact]
+    public void Chunk_FallsBackToRichBlocksAndInfersHeadingPaths() {
+        var document = new OfficeDocumentReadResult {
+            Kind = ReaderInputKind.Word,
+            Source = new OfficeDocumentSource { SourceId = "rich-document", Title = "Rich" },
+            Blocks = new[] {
+                new OfficeDocumentBlock { Id = "root", Kind = "heading", Level = 1, Text = "Root" },
+                new OfficeDocumentBlock { Id = "body", Kind = "paragraph", Text = "Root body" },
+                new OfficeDocumentBlock { Id = "child", Kind = "heading", Level = 2, Text = "Child" },
+                new OfficeDocumentBlock { Id = "child-body", Kind = "paragraph", Text = "Child body" }
+            }
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(
+            document,
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 100,
+                OverlapTokens = 0,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+
+        Assert.Equal(4, result.Chunks.Count);
+        Assert.Contains(result.Nodes, node => node.Kind == ReaderChunkHierarchyNodeKind.Heading && node.Title == "Root");
+        Assert.Contains(result.Nodes, node => node.Kind == ReaderChunkHierarchyNodeKind.Heading && node.Title == "Child");
+        Assert.Equal("Root > Child", result.Segments[3].Context);
+        Assert.Equal("paragraph", result.Chunks[3].Location.SourceBlockKind);
+    }
+
+    [Fact]
+    public void Chunk_BoundsContextAndRejectsMixedSourceCollections() {
+        ReaderChunk source = CreateChunk("source", "alpha beta", headingPath: "abcdefghij");
+        ReaderChunkHierarchyResult bounded = ReaderHierarchicalChunker.Chunk(
+            new[] { source },
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 10,
+                OverlapTokens = 0,
+                MaxContextCharacters = 5,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+
+        Assert.Equal("abcde", Assert.Single(bounded.Segments).Context);
+        Assert.Contains(bounded.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-context-character-limit");
+
+        source.Location.HeadingPath = "😀abcdef";
+        bounded = ReaderHierarchicalChunker.Chunk(
+            new[] { source },
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 10,
+                OverlapTokens = 0,
+                MaxContextCharacters = 2,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+        Assert.Equal("😀", Assert.Single(bounded.Segments).Context);
+
+        ReaderChunk other = CreateChunk("other", "gamma");
+        other.SourceId = "another-source";
+        Assert.Throws<InvalidOperationException>(() => ReaderHierarchicalChunker.Chunk(
+            new[] { source, other },
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 10,
+                OverlapTokens = 0,
+                TokenCounter = WordCounter
+            }));
+    }
+
+    [Fact]
+    public void Chunk_MakesProgressAcrossUnicodeAndSmallHeuristicBudgets() {
+        const string text = "alpha 😀 beta. gamma\n\ndelta 😀 epsilon zeta eta theta";
+        for (int maxTokens = 1; maxTokens <= 16; maxTokens++) {
+            ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(
+                new[] { CreateChunk("unicode", text) },
+                new ReaderHierarchicalChunkingOptions {
+                    MaxTokens = maxTokens,
+                    OverlapTokens = Math.Min(2, maxTokens - 1),
+                    IncludeContextInText = false
+                });
+
+            Assert.NotEmpty(result.Chunks);
+            Assert.All(result.Chunks, chunk => Assert.InRange(chunk.TokenEstimate ?? -1, 0, maxTokens));
+            Assert.Equal(0, result.Segments[0].StartCharacter);
+            Assert.Equal(text.Length, result.Segments[result.Segments.Count - 1].EndCharacter);
+            for (int index = 1; index < result.Segments.Count; index++) {
+                Assert.True(result.Segments[index].StartCharacter <= result.Segments[index - 1].EndCharacter);
+                Assert.True(result.Segments[index].StartCharacter > result.Segments[index - 1].StartCharacter);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task StaticAndInstanceReadSurfacesSupportSyncAsyncAndProcessors() {
+        byte[] markdown = Encoding.UTF8.GetBytes("# Overview\n\nUseful body");
+        var options = new ReaderHierarchicalChunkingOptions {
+            MaxTokens = 100,
+            OverlapTokens = 0,
+            IncludeContextInText = false
+        };
+
+        ReaderChunkHierarchyResult staticSync = DocumentReader.ReadHierarchical(markdown, "note.md", chunkingOptions: options);
+        ReaderChunkHierarchyResult staticAsync = await DocumentReader.ReadHierarchicalAsync(markdown, "note.md", chunkingOptions: options);
+        Assert.Equal(staticSync.ToJson(), staticAsync.ToJson());
+
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+            .AddProcessor(new DelegateOfficeDocumentProcessor("prefix", (document, _) => {
+                foreach (ReaderChunk chunk in document.Chunks) {
+                    chunk.Text = "processed " + chunk.Text;
+                    chunk.Markdown = null;
+                }
+                return document;
+            }))
+            .Build();
+        ReaderChunkHierarchyResult instanceSync = reader.ReadHierarchical(markdown, "note.md", chunkingOptions: options);
+        ReaderChunkHierarchyResult instanceAsync = await reader.ReadHierarchicalAsync(markdown, "note.md", chunkingOptions: options);
+        Assert.StartsWith("processed ", Assert.Single(instanceSync.Chunks).Text, StringComparison.Ordinal);
+        Assert.Equal(instanceSync.ToJson(), instanceAsync.ToJson());
+    }
+
+    private static ReaderChunk CreateChunk(
+        string id,
+        string text,
+        int? page = null,
+        string? headingPath = null,
+        string? headingSlug = null) => new ReaderChunk {
+            Id = id,
+            Kind = ReaderInputKind.Text,
+            SourceId = "source-document",
+            Text = text,
+            Location = new ReaderLocation {
+                Path = "source.txt",
+                Page = page,
+                HeadingPath = headingPath,
+                HeadingSlug = headingSlug,
+                BlockAnchor = id
+            }
+        };
+
+    private sealed class WordTokenCounter : IReaderTokenCounter {
+        public string Id => "tests.words-v1";
+
+        public int CountTokens(string text) => string.IsNullOrWhiteSpace(text)
+            ? 0
+            : text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Length;
+    }
+
+    private sealed class NegativeTokenCounter : IReaderTokenCounter {
+        public string Id => "tests.negative-v1";
+        public int CountTokens(string text) => -1;
+    }
+}

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -260,6 +260,92 @@ public sealed class ReaderHierarchicalChunkingTests {
     }
 
     [Fact]
+    public void Chunk_InheritsEnvelopePathForExistingChunksWithoutSourceIdentity() {
+        ReaderChunk source = CreateChunk("same", "body");
+        source.SourceId = null;
+        source.Location.Path = null;
+        var first = new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource { Path = "first.txt" },
+            Chunks = new[] { source }
+        };
+        var second = new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource { Path = "second.txt" },
+            Chunks = new[] { source }
+        };
+        var options = new ReaderHierarchicalChunkingOptions {
+            MaxTokens = 10,
+            OverlapTokens = 0,
+            IncludeContextInText = false,
+            TokenCounter = WordCounter
+        };
+
+        ReaderChunk firstChunk = Assert.Single(ReaderHierarchicalChunker.Chunk(first, options).Chunks);
+        ReaderChunk secondChunk = Assert.Single(ReaderHierarchicalChunker.Chunk(second, options).Chunks);
+
+        Assert.Equal("first.txt", firstChunk.Location.Path);
+        Assert.NotEqual(firstChunk.Id, secondChunk.Id);
+        Assert.Null(source.Location.Path);
+    }
+
+    [Fact]
+    public void Chunk_UsesEnvelopePathForFallbackBlockIdentity() {
+        var block = new OfficeDocumentBlock { Id = "same", Kind = "paragraph", Text = "body" };
+        var first = new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource { Path = "first.txt" },
+            Blocks = new[] { block }
+        };
+        var second = new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource { Path = "second.txt" },
+            Blocks = new[] { block }
+        };
+
+        ReaderChunk firstChunk = Assert.Single(ReaderHierarchicalChunker.Chunk(first).Chunks);
+        ReaderChunk secondChunk = Assert.Single(ReaderHierarchicalChunker.Chunk(second).Chunks);
+
+        Assert.Equal("first.txt", firstChunk.Location.Path);
+        Assert.NotEqual(firstChunk.Id, secondChunk.Id);
+    }
+
+    [Fact]
+    public void Chunk_InheritsPageContainerForPageOnlyBlocks() {
+        var document = new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource { Path = "pages.pdf" },
+            Pages = new[] {
+                new OfficeDocumentPage {
+                    Number = 4,
+                    Blocks = new[] { new OfficeDocumentBlock { Id = "p4", Kind = "paragraph", Text = "Page body" } }
+                }
+            }
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(document);
+
+        Assert.Equal(4, Assert.Single(result.Chunks).Location.Page);
+        ReaderChunkHierarchyNode page = Assert.Single(result.Nodes, node => node.Kind == ReaderChunkHierarchyNodeKind.Container);
+        Assert.Equal("Page 4", page.Title);
+    }
+
+    [Fact]
+    public void Chunk_DerivesContextTokensFromCombinedTokenizerOutput() {
+        ReaderChunk source = CreateChunk("source", "a", page: 3);
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(
+            new[] { source },
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 10,
+                OverlapTokens = 0,
+                IncludeContextInText = true,
+                TokenCounter = new NonAdditiveContextTokenCounter()
+            });
+
+        ReaderChunkSegment segment = Assert.Single(result.Segments);
+        Assert.Equal(3, segment.TokenCount);
+        Assert.Equal(1, segment.ContentTokenCount);
+        Assert.Equal(2, segment.ContextTokenCount);
+        Assert.Equal(2, result.ContextTokenCount);
+    }
+
+    [Fact]
     public void Chunk_EnforcesInputOutputAndDepthBoundsWithDiagnostics() {
         ReaderChunk[] chunks = {
             CreateChunk("c1", "one two three four five six", headingPath: "A > B > C > D"),

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -326,6 +326,92 @@ public sealed class ReaderHierarchicalChunkingTests {
     }
 
     [Fact]
+    public void Chunk_PrefersPageScopeForBlocksAlsoPresentAtDocumentLevel() {
+        var shared = new OfficeDocumentBlock { Id = "shared", Kind = "paragraph", Text = "Page body" };
+        var document = new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource { Path = "pages.pdf" },
+            Blocks = new[] { shared },
+            Pages = new[] {
+                new OfficeDocumentPage { Number = 7, Blocks = new[] { shared } }
+            }
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(document);
+
+        Assert.Equal(7, Assert.Single(result.Chunks).Location.Page);
+        Assert.Equal("Page 7", Assert.Single(result.Nodes, node => node.Kind == ReaderChunkHierarchyNodeKind.Container).Title);
+    }
+
+    [Fact]
+    public void Chunk_InfersSourceIdentityWithoutDroppingEnvelopeTitle() {
+        ReaderChunk firstChunk = CreateChunk("same", "body");
+        firstChunk.SourceId = null;
+        firstChunk.Location.Path = "first.txt";
+        ReaderChunk secondChunk = CreateChunk("same", "body");
+        secondChunk.SourceId = null;
+        secondChunk.Location.Path = "second.txt";
+        var first = new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource { Title = "Shared title" },
+            Chunks = new[] { firstChunk }
+        };
+        var second = new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource { Title = "Shared title" },
+            Chunks = new[] { secondChunk }
+        };
+
+        ReaderChunkHierarchyResult firstResult = ReaderHierarchicalChunker.Chunk(first);
+        ReaderChunkHierarchyResult secondResult = ReaderHierarchicalChunker.Chunk(second);
+
+        Assert.Equal("Shared title", firstResult.Source.Title);
+        Assert.Equal("first.txt", firstResult.Source.Path);
+        Assert.NotEqual(firstResult.RootNodeId, secondResult.RootNodeId);
+    }
+
+    [Fact]
+    public void Chunk_UsesSlideContainerKindForBlockOnlyResults() {
+        var document = new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource { Path = "slides.pptx" },
+            Pages = new[] {
+                new OfficeDocumentPage {
+                    Number = 3,
+                    Location = new ReaderLocation { SourceBlockKind = "slide" },
+                    Blocks = new[] { new OfficeDocumentBlock { Id = "slide-body", Kind = "paragraph", Text = "Slide body" } }
+                }
+            }
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(document);
+
+        ReaderLocation location = Assert.Single(result.Chunks).Location;
+        Assert.Equal(3, location.Slide);
+        Assert.Null(location.Page);
+        Assert.Equal("Slide 3", Assert.Single(result.Nodes, node => node.Kind == ReaderChunkHierarchyNodeKind.Container).Title);
+    }
+
+    [Fact]
+    public void Chunk_PropagatesHeadingSlugsToFallbackBodyBlocks() {
+        var document = new OfficeDocumentReadResult {
+            Source = new OfficeDocumentSource { SourceId = "repeated-headings" },
+            Blocks = new[] {
+                new OfficeDocumentBlock { Id = "overview-a", Kind = "heading", Level = 1, Text = "Overview" },
+                new OfficeDocumentBlock { Id = "body-a", Kind = "paragraph", Text = "First body" },
+                new OfficeDocumentBlock { Id = "overview-b", Kind = "heading", Level = 1, Text = "Overview" },
+                new OfficeDocumentBlock { Id = "body-b", Kind = "paragraph", Text = "Second body" }
+            }
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(document);
+
+        Assert.Equal("overview-a", result.Chunks[1].Location.HeadingSlug);
+        Assert.Equal("overview-b", result.Chunks[3].Location.HeadingSlug);
+        ReaderChunkHierarchyNode[] headings = result.Nodes
+            .Where(node => node.Kind == ReaderChunkHierarchyNodeKind.Heading && node.Title == "Overview")
+            .ToArray();
+        Assert.Equal(2, headings.Length);
+        Assert.All(headings, heading => Assert.Equal(2, heading.ChildNodeIds.Count));
+    }
+
+    [Fact]
     public void Chunk_DerivesContextTokensFromCombinedTokenizerOutput() {
         ReaderChunk source = CreateChunk("source", "a", page: 3);
 

--- a/OfficeIMO.Reader.Tests/Reader.Html.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Html.Modular.cs
@@ -61,6 +61,24 @@ public sealed class ReaderHtmlModularTests {
     }
 
     [Fact]
+    public void DocumentReaderHtml_PreservesLiteralHeadingDisplayAndHierarchy() {
+        const string title = "Q1 > Q2\\Back";
+        var chunks = DocumentReaderHtmlExtensions.ReadHtmlString(
+            html: "<html><body><h1>Q1 &gt; Q2\\Back</h1><p>Body.</p></body></html>",
+            sourceName: "literal-heading.html",
+            readerOptions: new ReaderOptions { MaxChars = 8_000 }).ToList();
+
+        ReaderChunk chunk = Assert.Single(chunks);
+        Assert.Equal(title, chunk.Location.HeadingPath);
+
+        ReaderChunkHierarchyResult hierarchy = ReaderHierarchicalChunker.Chunk(chunks);
+        ReaderChunkHierarchyNode heading = Assert.Single(
+            hierarchy.Nodes,
+            node => node.Kind == ReaderChunkHierarchyNodeKind.Heading);
+        Assert.Equal(title, heading.Title);
+    }
+
+    [Fact]
     public void DocumentReaderHtml_ReadHtmlString_CanDisableHeadingChunking() {
         var html = "<html><body><h1>Hello HTML</h1><p>Body text.</p><h2>Second</h2><p>More.</p></body></html>";
 

--- a/OfficeIMO.Reader/DocumentReader.Chunking.cs
+++ b/OfficeIMO.Reader/DocumentReader.Chunking.cs
@@ -317,6 +317,7 @@ public static partial class DocumentReader {
                 EndLine = sourceEndLine,
                 HeadingPath = headingPath,
                 HierarchyHeadingPath = hierarchyHeadingPath,
+                HierarchyHeadingDisplayPath = headingPath,
                 HeadingSlug = headingSlug,
                 SourceBlockKind = sourceBlockKind,
                 BlockAnchor = blockAnchor,

--- a/OfficeIMO.Reader/DocumentReader.Chunking.cs
+++ b/OfficeIMO.Reader/DocumentReader.Chunking.cs
@@ -127,6 +127,7 @@ public static partial class DocumentReader {
         int? lastSourceEndLine = null;
         int? firstSourceBlockIndex = null;
         string? firstHeadingPath = null;
+        string? firstHierarchyHeadingPath = null;
         string? firstHeadingSlug = null;
         string? firstSourceBlockKind = null;
         string? firstBlockAnchor = null;
@@ -139,7 +140,7 @@ public static partial class DocumentReader {
             ct.ThrowIfCancellationRequested();
 
             if (block.StartsHeading && current.Length > 0) {
-                yield return BuildMarkdownChunk(sourceName ?? fileName, fileName, chunkIndex, firstSourceStartLine, lastSourceEndLine, firstLine, lastLine, firstSourceBlockIndex, firstHeadingPath, firstHeadingSlug, firstSourceBlockKind, firstBlockAnchor, current.ToString().TrimEnd(), warnings, tables, visuals);
+                yield return BuildMarkdownChunk(sourceName ?? fileName, fileName, chunkIndex, firstSourceStartLine, lastSourceEndLine, firstLine, lastLine, firstSourceBlockIndex, firstHeadingPath, firstHierarchyHeadingPath, firstHeadingSlug, firstSourceBlockKind, firstBlockAnchor, current.ToString().TrimEnd(), warnings, tables, visuals);
                 chunkIndex++;
                 current.Clear();
                 warnings.Clear();
@@ -152,13 +153,14 @@ public static partial class DocumentReader {
                 lastSourceEndLine = null;
                 firstSourceBlockIndex = null;
                 firstHeadingPath = null;
+                firstHierarchyHeadingPath = null;
                 firstHeadingSlug = null;
                 firstSourceBlockKind = null;
                 firstBlockAnchor = null;
             }
 
             if (WouldExceedMarkdownBlock(opt, current, block.Markdown)) {
-                yield return BuildMarkdownChunk(sourceName ?? fileName, fileName, chunkIndex, firstSourceStartLine, lastSourceEndLine, firstLine, lastLine, firstSourceBlockIndex, firstHeadingPath, firstHeadingSlug, firstSourceBlockKind, firstBlockAnchor, current.ToString().TrimEnd(), warnings, tables, visuals);
+                yield return BuildMarkdownChunk(sourceName ?? fileName, fileName, chunkIndex, firstSourceStartLine, lastSourceEndLine, firstLine, lastLine, firstSourceBlockIndex, firstHeadingPath, firstHierarchyHeadingPath, firstHeadingSlug, firstSourceBlockKind, firstBlockAnchor, current.ToString().TrimEnd(), warnings, tables, visuals);
                 chunkIndex++;
                 current.Clear();
                 warnings.Clear();
@@ -171,6 +173,7 @@ public static partial class DocumentReader {
                 lastSourceEndLine = null;
                 firstSourceBlockIndex = null;
                 firstHeadingPath = null;
+                firstHierarchyHeadingPath = null;
                 firstHeadingSlug = null;
                 firstSourceBlockKind = null;
                 firstBlockAnchor = null;
@@ -180,6 +183,7 @@ public static partial class DocumentReader {
             if (firstSourceStartLine == null) firstSourceStartLine = block.SourceStartLine;
             if (firstSourceBlockIndex == null) firstSourceBlockIndex = block.BlockIndex;
             if (firstHeadingPath == null) firstHeadingPath = block.HeadingPath;
+            if (firstHierarchyHeadingPath == null) firstHierarchyHeadingPath = block.HierarchyHeadingPath;
             if (firstHeadingSlug == null) firstHeadingSlug = block.HeadingSlug;
             if (firstSourceBlockKind == null) firstSourceBlockKind = block.BlockKind;
             if (firstBlockAnchor == null) firstBlockAnchor = block.BlockAnchor;
@@ -204,7 +208,7 @@ public static partial class DocumentReader {
         }
 
         if (current.Length > 0) {
-            yield return BuildMarkdownChunk(sourceName ?? fileName, fileName, chunkIndex, firstSourceStartLine, lastSourceEndLine, firstLine, lastLine, firstSourceBlockIndex, firstHeadingPath, firstHeadingSlug, firstSourceBlockKind, firstBlockAnchor, current.ToString().TrimEnd(), warnings, tables, visuals);
+            yield return BuildMarkdownChunk(sourceName ?? fileName, fileName, chunkIndex, firstSourceStartLine, lastSourceEndLine, firstLine, lastLine, firstSourceBlockIndex, firstHeadingPath, firstHierarchyHeadingPath, firstHeadingSlug, firstSourceBlockKind, firstBlockAnchor, current.ToString().TrimEnd(), warnings, tables, visuals);
         }
     }
 
@@ -293,6 +297,7 @@ public static partial class DocumentReader {
         int? lastLine,
         int? firstSourceBlockIndex,
         string? headingPath,
+        string? hierarchyHeadingPath,
         string? headingSlug,
         string? sourceBlockKind,
         string? blockAnchor,
@@ -311,6 +316,7 @@ public static partial class DocumentReader {
                 StartLine = sourceStartLine,
                 EndLine = sourceEndLine,
                 HeadingPath = headingPath,
+                HierarchyHeadingPath = hierarchyHeadingPath,
                 HeadingSlug = headingSlug,
                 SourceBlockKind = sourceBlockKind,
                 BlockAnchor = blockAnchor,
@@ -774,6 +780,14 @@ public static partial class DocumentReader {
     }
 
     private static string? BuildHeadingPath(List<MarkdownHeadingState> stack) {
+        string[] values = stack
+            .Select(static heading => heading.Text.Trim())
+            .Where(static heading => heading.Length > 0)
+            .ToArray();
+        return values.Length == 0 ? null : string.Join(" > ", values);
+    }
+
+    private static string? BuildHierarchyHeadingPath(List<MarkdownHeadingState> stack) {
         return ReaderHeadingPath.Combine(stack.Select(static heading => heading.Text));
     }
 

--- a/OfficeIMO.Reader/DocumentReader.Chunking.cs
+++ b/OfficeIMO.Reader/DocumentReader.Chunking.cs
@@ -774,14 +774,7 @@ public static partial class DocumentReader {
     }
 
     private static string? BuildHeadingPath(List<MarkdownHeadingState> stack) {
-        if (stack.Count == 0) return null;
-        var sb = new StringBuilder();
-        for (int i = 0; i < stack.Count; i++) {
-            if (i > 0) sb.Append(" > ");
-            sb.Append(stack[i].Text);
-        }
-        var s = sb.ToString().Trim();
-        return s.Length == 0 ? null : s;
+        return ReaderHeadingPath.Combine(stack.Select(static heading => heading.Text));
     }
 
     private static string? BuildHeadingSlug(List<MarkdownHeadingState> stack) {

--- a/OfficeIMO.Reader/DocumentReader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader/DocumentReader.HierarchicalChunking.cs
@@ -1,0 +1,89 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Reader;
+
+public static partial class DocumentReader {
+    /// <summary>Token-chunks an already-read rich document and builds its hierarchy.</summary>
+    public static ReaderChunkHierarchyResult ChunkDocument(
+        OfficeDocumentReadResult document,
+        ReaderHierarchicalChunkingOptions? options = null,
+        CancellationToken cancellationToken = default) =>
+        ReaderHierarchicalChunker.Chunk(document, options, cancellationToken);
+
+    /// <summary>Reads a file and returns bounded token-aware hierarchical chunks.</summary>
+    public static ReaderChunkHierarchyResult ReadHierarchical(
+        string path,
+        ReaderOptions? readerOptions = null,
+        ReaderHierarchicalChunkingOptions? chunkingOptions = null,
+        CancellationToken cancellationToken = default) =>
+        ChunkDocument(ReadDocument(path, readerOptions, cancellationToken), chunkingOptions, cancellationToken);
+
+    /// <summary>Reads a stream and returns bounded token-aware hierarchical chunks.</summary>
+    public static ReaderChunkHierarchyResult ReadHierarchical(
+        Stream stream,
+        string? sourceName = null,
+        ReaderOptions? readerOptions = null,
+        ReaderHierarchicalChunkingOptions? chunkingOptions = null,
+        CancellationToken cancellationToken = default) =>
+        ChunkDocument(
+            ReadDocument(stream, sourceName, readerOptions, cancellationToken),
+            chunkingOptions,
+            cancellationToken);
+
+    /// <summary>Reads bytes and returns bounded token-aware hierarchical chunks.</summary>
+    public static ReaderChunkHierarchyResult ReadHierarchical(
+        byte[] bytes,
+        string? sourceName = null,
+        ReaderOptions? readerOptions = null,
+        ReaderHierarchicalChunkingOptions? chunkingOptions = null,
+        CancellationToken cancellationToken = default) {
+        if (bytes == null) throw new ArgumentNullException(nameof(bytes));
+        using var stream = new MemoryStream(bytes, writable: false);
+        return ReadHierarchical(stream, sourceName, readerOptions, chunkingOptions, cancellationToken);
+    }
+
+    /// <summary>Asynchronously reads a file and returns bounded token-aware hierarchical chunks.</summary>
+    public static async Task<ReaderChunkHierarchyResult> ReadHierarchicalAsync(
+        string path,
+        ReaderOptions? readerOptions = null,
+        ReaderHierarchicalChunkingOptions? chunkingOptions = null,
+        CancellationToken cancellationToken = default) {
+        OfficeDocumentReadResult document = await ReadDocumentAsync(path, readerOptions, cancellationToken).ConfigureAwait(false);
+        return ChunkDocument(document, chunkingOptions, cancellationToken);
+    }
+
+    /// <summary>Asynchronously reads a stream and returns bounded token-aware hierarchical chunks.</summary>
+    public static async Task<ReaderChunkHierarchyResult> ReadHierarchicalAsync(
+        Stream stream,
+        string? sourceName = null,
+        ReaderOptions? readerOptions = null,
+        ReaderHierarchicalChunkingOptions? chunkingOptions = null,
+        CancellationToken cancellationToken = default) {
+        OfficeDocumentReadResult document = await ReadDocumentAsync(
+            stream,
+            sourceName,
+            readerOptions,
+            cancellationToken).ConfigureAwait(false);
+        return ChunkDocument(document, chunkingOptions, cancellationToken);
+    }
+
+    /// <summary>Asynchronously reads bytes and returns bounded token-aware hierarchical chunks.</summary>
+    public static async Task<ReaderChunkHierarchyResult> ReadHierarchicalAsync(
+        byte[] bytes,
+        string? sourceName = null,
+        ReaderOptions? readerOptions = null,
+        ReaderHierarchicalChunkingOptions? chunkingOptions = null,
+        CancellationToken cancellationToken = default) {
+        if (bytes == null) throw new ArgumentNullException(nameof(bytes));
+        using var stream = new MemoryStream(bytes, writable: false);
+        return await ReadHierarchicalAsync(
+            stream,
+            sourceName,
+            readerOptions,
+            chunkingOptions,
+            cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/OfficeIMO.Reader/DocumentReader.Markdown.cs
+++ b/OfficeIMO.Reader/DocumentReader.Markdown.cs
@@ -60,6 +60,7 @@ public static partial class DocumentReader {
             }
 
             string? headingPath = BuildHeadingPath(headingStack);
+            string? hierarchyHeadingPath = BuildHierarchyHeadingPath(headingStack);
             string? headingSlug = BuildHeadingSlug(headingStack);
             string blockKind = GetMarkdownBlockKind(block);
             string blockAnchor = BuildMarkdownBlockAnchor(headingSlug, blockKind, i, startsHeading);
@@ -94,6 +95,7 @@ public static partial class DocumentReader {
                 sourceStartLine: sourceStartLine,
                 sourceEndLine: sourceEndLine,
                 headingPath: headingPath,
+                hierarchyHeadingPath: hierarchyHeadingPath,
                 headingSlug: headingSlug,
                 blockKind: blockKind,
                 blockAnchor: blockAnchor,

--- a/OfficeIMO.Reader/DocumentReader.Models.cs
+++ b/OfficeIMO.Reader/DocumentReader.Models.cs
@@ -39,13 +39,14 @@ public static partial class DocumentReader {
     }
 
     private sealed class MarkdownChunkBlock {
-        public MarkdownChunkBlock(int blockIndex, int startLine, int endLine, int sourceStartLine, int sourceEndLine, string? headingPath, string? headingSlug, string blockKind, string blockAnchor, string markdown, bool startsHeading, IReadOnlyList<ReaderTable> tables, IReadOnlyList<ReaderVisual> visuals) {
+        public MarkdownChunkBlock(int blockIndex, int startLine, int endLine, int sourceStartLine, int sourceEndLine, string? headingPath, string? hierarchyHeadingPath, string? headingSlug, string blockKind, string blockAnchor, string markdown, bool startsHeading, IReadOnlyList<ReaderTable> tables, IReadOnlyList<ReaderVisual> visuals) {
             BlockIndex = blockIndex;
             StartLine = startLine;
             EndLine = endLine;
             SourceStartLine = sourceStartLine;
             SourceEndLine = sourceEndLine;
             HeadingPath = headingPath;
+            HierarchyHeadingPath = hierarchyHeadingPath;
             HeadingSlug = headingSlug;
             BlockKind = string.IsNullOrWhiteSpace(blockKind) ? "unknown" : blockKind;
             BlockAnchor = string.IsNullOrWhiteSpace(blockAnchor) ? "block-" + blockIndex.ToString(CultureInfo.InvariantCulture) : blockAnchor;
@@ -61,6 +62,7 @@ public static partial class DocumentReader {
         public int SourceStartLine { get; }
         public int SourceEndLine { get; }
         public string? HeadingPath { get; }
+        public string? HierarchyHeadingPath { get; }
         public string? HeadingSlug { get; }
         public string BlockKind { get; }
         public string BlockAnchor { get; }

--- a/OfficeIMO.Reader/OfficeDocumentReadResultJson.cs
+++ b/OfficeIMO.Reader/OfficeDocumentReadResultJson.cs
@@ -605,6 +605,7 @@ public static partial class OfficeDocumentReadResultJson {
             normalizedStartLine = location.NormalizedStartLine,
             normalizedEndLine = location.NormalizedEndLine,
             headingPath = location.HeadingPath,
+            hierarchyHeadingPath = location.HierarchyHeadingPath,
             headingSlug = location.HeadingSlug,
             sourceBlockKind = location.SourceBlockKind,
             blockAnchor = location.BlockAnchor,

--- a/OfficeIMO.Reader/OfficeDocumentReader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader/OfficeDocumentReader.HierarchicalChunking.cs
@@ -1,0 +1,89 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Reader;
+
+public sealed partial class OfficeDocumentReader {
+    /// <summary>Token-chunks an already-read rich document and builds its hierarchy.</summary>
+    public ReaderChunkHierarchyResult ChunkDocument(
+        OfficeDocumentReadResult document,
+        ReaderHierarchicalChunkingOptions? options = null,
+        CancellationToken cancellationToken = default) =>
+        ReaderHierarchicalChunker.Chunk(document, options, cancellationToken);
+
+    /// <summary>Reads a file through configured processors and returns hierarchical chunks.</summary>
+    public ReaderChunkHierarchyResult ReadHierarchical(
+        string path,
+        ReaderOptions? readerOptions = null,
+        ReaderHierarchicalChunkingOptions? chunkingOptions = null,
+        CancellationToken cancellationToken = default) =>
+        ChunkDocument(ReadDocument(path, readerOptions, cancellationToken), chunkingOptions, cancellationToken);
+
+    /// <summary>Reads a stream through configured processors and returns hierarchical chunks.</summary>
+    public ReaderChunkHierarchyResult ReadHierarchical(
+        Stream stream,
+        string? sourceName = null,
+        ReaderOptions? readerOptions = null,
+        ReaderHierarchicalChunkingOptions? chunkingOptions = null,
+        CancellationToken cancellationToken = default) =>
+        ChunkDocument(
+            ReadDocument(stream, sourceName, readerOptions, cancellationToken),
+            chunkingOptions,
+            cancellationToken);
+
+    /// <summary>Reads bytes through configured processors and returns hierarchical chunks.</summary>
+    public ReaderChunkHierarchyResult ReadHierarchical(
+        byte[] bytes,
+        string? sourceName = null,
+        ReaderOptions? readerOptions = null,
+        ReaderHierarchicalChunkingOptions? chunkingOptions = null,
+        CancellationToken cancellationToken = default) {
+        if (bytes == null) throw new ArgumentNullException(nameof(bytes));
+        using var stream = new MemoryStream(bytes, writable: false);
+        return ReadHierarchical(stream, sourceName, readerOptions, chunkingOptions, cancellationToken);
+    }
+
+    /// <summary>Asynchronously reads a file through configured processors and returns hierarchical chunks.</summary>
+    public async Task<ReaderChunkHierarchyResult> ReadHierarchicalAsync(
+        string path,
+        ReaderOptions? readerOptions = null,
+        ReaderHierarchicalChunkingOptions? chunkingOptions = null,
+        CancellationToken cancellationToken = default) {
+        OfficeDocumentReadResult document = await ReadDocumentAsync(path, readerOptions, cancellationToken).ConfigureAwait(false);
+        return ChunkDocument(document, chunkingOptions, cancellationToken);
+    }
+
+    /// <summary>Asynchronously reads a stream through configured processors and returns hierarchical chunks.</summary>
+    public async Task<ReaderChunkHierarchyResult> ReadHierarchicalAsync(
+        Stream stream,
+        string? sourceName = null,
+        ReaderOptions? readerOptions = null,
+        ReaderHierarchicalChunkingOptions? chunkingOptions = null,
+        CancellationToken cancellationToken = default) {
+        OfficeDocumentReadResult document = await ReadDocumentAsync(
+            stream,
+            sourceName,
+            readerOptions,
+            cancellationToken).ConfigureAwait(false);
+        return ChunkDocument(document, chunkingOptions, cancellationToken);
+    }
+
+    /// <summary>Asynchronously reads bytes through configured processors and returns hierarchical chunks.</summary>
+    public async Task<ReaderChunkHierarchyResult> ReadHierarchicalAsync(
+        byte[] bytes,
+        string? sourceName = null,
+        ReaderOptions? readerOptions = null,
+        ReaderHierarchicalChunkingOptions? chunkingOptions = null,
+        CancellationToken cancellationToken = default) {
+        if (bytes == null) throw new ArgumentNullException(nameof(bytes));
+        using var stream = new MemoryStream(bytes, writable: false);
+        return await ReadHierarchicalAsync(
+            stream,
+            sourceName,
+            readerOptions,
+            chunkingOptions,
+            cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/OfficeIMO.Reader/README.md
+++ b/OfficeIMO.Reader/README.md
@@ -165,6 +165,36 @@ string json = extracted.ToJson(indented: true);
 
 The extractor recognizes metadata, forms, two-column key/value tables, Path/Type/Value tables, Visio Shape Data, chart summaries, table and visual quality, chunk readiness, and security/OCR/limit diagnostics. Each collection and section body has an explicit positive limit; reaching a bound adds a structured limit diagnostic instead of silently growing output. The non-generic schema-friendly shape is versioned independently from the stable `OfficeDocumentReadResult` transport. It is currently a serialization and host-integration contract; a generic `ExtractStructured<T>()` mapper and model-assisted extraction are intentionally outside the core package.
 
+## Token-aware hierarchical chunks
+
+`ReadHierarchical(...)` keeps `ReaderChunk` as the embedding leaf while adding document, page/slide/sheet, and heading nodes around it:
+
+```csharp
+ReaderChunkHierarchyResult hierarchy = reader.ReadHierarchical(
+    @"C:\Docs\Policy.docx",
+    chunkingOptions: new ReaderHierarchicalChunkingOptions {
+        MaxTokens = 800,
+        OverlapTokens = 80,
+        MaxInputChunks = 10_000,
+        MaxOutputChunks = 50_000,
+        MaxHierarchyDepth = 32,
+        MaxContextCharacters = 4_096,
+        IncludeContextInText = true
+    });
+
+foreach (ReaderChunk chunk in hierarchy.Chunks) {
+    StoreEmbedding(chunk.Id, chunk.Text, chunk.TokenEstimate ?? 0);
+}
+
+string sidecarJson = hierarchy.ToJson(indented: true);
+```
+
+The result records the selected token counter, original/output/overlap/context token totals, exact source character spans, deterministic leaf IDs and hashes, and a flattened hierarchy with explicit parent/child IDs. Splits prefer paragraph, line, sentence, and whitespace boundaries but enforce the token maximum even when a source block is larger. Structured tables, visuals, forms, actions, diagnostics, and warnings stay on the first segment so overlap does not duplicate sidecars.
+
+The dependency-free default uses the existing four-characters-per-token heuristic. Supply a deterministic, thread-safe `IReaderTokenCounter` when the embedding model needs its exact tokenizer. A hierarchy represents one source document and rejects mixed-source chunk collections. Context and input/output/depth bounds emit structured diagnostics; invalid token budgets or counters fail explicitly.
+
+This is an opt-in projection with its own schema id/version. It does not add fields to `ReaderChunk`, change normal reads, or alter the stable `OfficeDocumentReadResult` v5 transport. Static and instance sync/async file, stream, and byte overloads are available; instance reads apply configured processors before chunking.
+
 ## Stable document transport
 
 `OfficeDocumentReadResult` schema version 5 is the first stable JSON transport contract. Versions 1 through 4 were experimental and are deliberately rejected when reading transport payloads.
@@ -275,6 +305,7 @@ OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
 - `OfficeDocumentReadResultJson` reads and writes stable schema version 5 envelopes; `OfficeDocumentReadResultSchema.GetJsonSchema()` exposes the packaged schema artifact.
 - `OfficeDocumentProcessorPipeline` freezes ordered processors and reports each completed, failed, or skipped step.
 - `OfficeDocumentStructuredExtractor` produces bounded non-generic records, sections, named tables, forms, and diagnostics without AI dependencies.
+- `ReaderHierarchicalChunker` produces token-bounded `ReaderChunk` leaves, exact overlap spans, and document/container/heading hierarchy nodes.
 - `OfficeDocumentReaderBuilder.AddHandler(...)` is the recommended custom-handler path for services and concurrent hosts.
 - Static `DocumentReader` registration is retained as a process-wide compatibility surface.
 

--- a/OfficeIMO.Reader/ReaderChunkHierarchyJson.cs
+++ b/OfficeIMO.Reader/ReaderChunkHierarchyJson.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>Deterministic JSON serialization for hierarchical chunking results.</summary>
+public static class ReaderChunkHierarchyJson {
+    /// <summary>Serializes a current hierarchy result.</summary>
+    public static string Serialize(ReaderChunkHierarchyResult result, bool indented = false) {
+        if (result == null) throw new ArgumentNullException(nameof(result));
+        if (!string.Equals(result.SchemaId, ReaderChunkHierarchySchema.Id, StringComparison.Ordinal) ||
+            result.SchemaVersion != ReaderChunkHierarchySchema.Version) {
+            throw new InvalidOperationException(
+                $"Chunk hierarchy schema '{result.SchemaId}' version {result.SchemaVersion} is not supported.");
+        }
+        var options = new JsonSerializerOptions {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = indented
+        };
+        options.Converters.Add(new JsonStringEnumConverter(namingPolicy: null, allowIntegerValues: false));
+        return JsonSerializer.Serialize(result, options);
+    }
+
+    /// <summary>Serializes a current hierarchy result.</summary>
+    public static string ToJson(this ReaderChunkHierarchyResult result, bool indented = false) =>
+        Serialize(result, indented);
+}

--- a/OfficeIMO.Reader/ReaderHeadingPath.cs
+++ b/OfficeIMO.Reader/ReaderHeadingPath.cs
@@ -51,6 +51,16 @@ public static class ReaderHeadingPath {
         return parts.Count == 0 ? null : string.Join(Separator, parts);
     }
 
+    /// <summary>
+    /// Associates an escaped hierarchy-only path with the current public display path.
+    /// Reader adapters use this to preserve literal heading delimiters without changing normal output.
+    /// </summary>
+    public static void SetHierarchyPath(ReaderLocation location, string? hierarchyPath) {
+        if (location == null) throw new ArgumentNullException(nameof(location));
+        location.HierarchyHeadingPath = hierarchyPath;
+        location.HierarchyHeadingDisplayPath = location.HeadingPath;
+    }
+
     private static string Escape(string value) => value
         .Replace("\\", "\\\\")
         .Replace(">", "\\>");

--- a/OfficeIMO.Reader/ReaderHeadingPath.cs
+++ b/OfficeIMO.Reader/ReaderHeadingPath.cs
@@ -61,6 +61,15 @@ public static class ReaderHeadingPath {
         location.HierarchyHeadingDisplayPath = location.HeadingPath;
     }
 
+    internal static string? GetValidatedHierarchyPath(ReaderLocation location) {
+        string? hierarchyPath = location.HierarchyHeadingPath;
+        if (string.IsNullOrWhiteSpace(hierarchyPath)) return null;
+        string? displayPath = location.HierarchyHeadingDisplayPath ?? ToDisplayString(hierarchyPath);
+        return string.Equals(displayPath, location.HeadingPath, StringComparison.Ordinal)
+            ? hierarchyPath
+            : null;
+    }
+
     private static string Escape(string value) => value
         .Replace("\\", "\\\\")
         .Replace(">", "\\>");

--- a/OfficeIMO.Reader/ReaderHeadingPath.cs
+++ b/OfficeIMO.Reader/ReaderHeadingPath.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>Builds and parses escaped Reader heading paths.</summary>
+public static class ReaderHeadingPath {
+    private const string Separator = " > ";
+
+    /// <summary>Combines heading titles while escaping literal backslashes and greater-than signs.</summary>
+    public static string? Combine(IEnumerable<string?> headings) {
+        if (headings == null) throw new ArgumentNullException(nameof(headings));
+        string[] values = headings
+            .Where(static heading => !string.IsNullOrWhiteSpace(heading))
+            .Select(static heading => Escape(heading!.Trim()))
+            .ToArray();
+        return values.Length == 0 ? null : string.Join(Separator, values);
+    }
+
+    /// <summary>Parses an escaped path. Legacy unescaped separators continue to represent nesting.</summary>
+    public static IReadOnlyList<string> Split(string? path) {
+        if (string.IsNullOrWhiteSpace(path)) return Array.Empty<string>();
+        string value = path!.Trim();
+        var parts = new List<string>();
+        var current = new StringBuilder();
+        for (int index = 0; index < value.Length; index++) {
+            char character = value[index];
+            if (character == '\\' && index + 1 < value.Length &&
+                (value[index + 1] == '\\' || value[index + 1] == '>')) {
+                current.Append(value[++index]);
+                continue;
+            }
+            if (character == ' ' &&
+                index + Separator.Length <= value.Length &&
+                string.CompareOrdinal(value, index, Separator, 0, Separator.Length) == 0) {
+                AddPart(parts, current);
+                index += Separator.Length - 1;
+                continue;
+            }
+            current.Append(character);
+        }
+        AddPart(parts, current);
+        return parts.Count == 0 ? Array.Empty<string>() : parts.ToArray();
+    }
+
+    /// <summary>Returns the unescaped display form of a heading path.</summary>
+    public static string? ToDisplayString(string? path) {
+        IReadOnlyList<string> parts = Split(path);
+        return parts.Count == 0 ? null : string.Join(Separator, parts);
+    }
+
+    private static string Escape(string value) => value
+        .Replace("\\", "\\\\")
+        .Replace(">", "\\>");
+
+    private static void AddPart(ICollection<string> parts, StringBuilder current) {
+        string part = current.ToString().Trim();
+        current.Clear();
+        if (part.Length > 0) parts.Add(part);
+    }
+}

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.Hierarchy.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.Hierarchy.cs
@@ -46,9 +46,11 @@ public static partial class ReaderHierarchicalChunker {
                     state);
             }
 
-            HierarchyHeading[] headings = SplitHeadingPath(
-                location.HierarchyHeadingPath ?? location.HeadingPath,
-                state);
+            string? hierarchyHeadingPath = location.HierarchyHeadingPath;
+            if (!string.Equals(location.HierarchyHeadingDisplayPath, location.HeadingPath, StringComparison.Ordinal)) {
+                hierarchyHeadingPath = null;
+            }
+            HierarchyHeading[] headings = SplitHeadingPath(hierarchyHeadingPath ?? location.HeadingPath, state);
             state.HeadingSlugsByChunkId.TryGetValue(chunk.Id, out IReadOnlyList<string?>? fallbackHeadingSlugs);
             int remainingDepth = Math.Max(0, state.Options.MaxHierarchyDepth - parent.Depth);
             if (headings.Length > remainingDepth) {

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.Hierarchy.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.Hierarchy.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+
+namespace OfficeIMO.Reader;
+
+public static partial class ReaderHierarchicalChunker {
+    private static IReadOnlyList<ReaderChunkHierarchyNode> BuildHierarchy(
+        ChunkingState state,
+        OfficeDocumentSource source) {
+        string rootTitle = LimitHierarchyValue(BuildRootTitle(source), state);
+        var root = new MutableHierarchyNode(
+            "node:" + ComputeSha256Hex("document|" + (source.SourceId ?? source.Path ?? rootTitle)),
+            parentNodeId: null,
+            ReaderChunkHierarchyNodeKind.Document,
+            rootTitle,
+            depth: 0,
+            rootTitle);
+        var nodes = new List<MutableHierarchyNode> { root };
+        var nodesById = new Dictionary<string, MutableHierarchyNode>(StringComparer.Ordinal) { [root.Id] = root };
+        var reusable = new Dictionary<string, MutableHierarchyNode>(StringComparer.Ordinal);
+
+        for (int index = 0; index < state.Chunks.Count; index++) {
+            state.CancellationToken.ThrowIfCancellationRequested();
+            ReaderChunk chunk = state.Chunks[index];
+            ReaderLocation location = chunk.Location ?? new ReaderLocation();
+            MutableHierarchyNode parent = root;
+
+            string? containerKey = BuildContainerKey(location, state, out string? containerTitle);
+            if (containerKey != null && containerTitle != null && parent.Depth < state.Options.MaxHierarchyDepth) {
+                parent = GetOrCreateNode(
+                    parent,
+                    ReaderChunkHierarchyNodeKind.Container,
+                    containerKey,
+                    containerTitle,
+                    nodes,
+                    nodesById,
+                    reusable);
+            }
+
+            string[] headings = SplitHeadingPath(location.HeadingPath, state);
+            int remainingDepth = Math.Max(0, state.Options.MaxHierarchyDepth - parent.Depth);
+            if (headings.Length > remainingDepth) {
+                state.AddLimitDiagnostic("hierarchical-depth-limit", state.Options.MaxHierarchyDepth, "hierarchy depth");
+                headings = CollapseHeadingDepth(headings, remainingDepth);
+            }
+            for (int headingIndex = 0; headingIndex < headings.Length; headingIndex++) {
+                bool finalHeading = headingIndex == headings.Length - 1;
+                string key = "heading:" + headings[headingIndex];
+                if (finalHeading && !string.IsNullOrWhiteSpace(location.HeadingSlug)) {
+                    key += "|slug:" + location.HeadingSlug!.Trim();
+                }
+                parent = GetOrCreateNode(
+                    parent,
+                    ReaderChunkHierarchyNodeKind.Heading,
+                    key,
+                    headings[headingIndex],
+                    nodes,
+                    nodesById,
+                    reusable);
+            }
+
+            string leafTitle = !string.IsNullOrWhiteSpace(location.BlockAnchor)
+                ? location.BlockAnchor!
+                : "Chunk " + (index + 1).ToString(CultureInfo.InvariantCulture);
+            var leaf = new MutableHierarchyNode(
+                "node:" + ComputeSha256Hex(parent.Id + "|chunk|" + chunk.Id),
+                parent.Id,
+                ReaderChunkHierarchyNodeKind.Chunk,
+                leafTitle,
+                parent.Depth + 1,
+                parent.Path + " > " + leafTitle) {
+                ChunkId = chunk.Id,
+                TokenCount = chunk.TokenEstimate ?? state.Segments[index].TokenCount
+            };
+            nodes.Add(leaf);
+            nodesById.Add(leaf.Id, leaf);
+            parent.ChildNodeIds.Add(leaf.Id);
+            AddTokensToAncestors(parent, leaf.TokenCount, nodesById);
+        }
+
+        var result = new ReaderChunkHierarchyNode[nodes.Count];
+        for (int index = 0; index < nodes.Count; index++) result[index] = nodes[index].Freeze();
+        return result;
+    }
+
+    private static MutableHierarchyNode GetOrCreateNode(
+        MutableHierarchyNode parent,
+        ReaderChunkHierarchyNodeKind kind,
+        string key,
+        string title,
+        ICollection<MutableHierarchyNode> nodes,
+        IDictionary<string, MutableHierarchyNode> nodesById,
+        IDictionary<string, MutableHierarchyNode> reusable) {
+        string lookup = parent.Id + "|" + kind.ToString() + "|" + key;
+        if (reusable.TryGetValue(lookup, out MutableHierarchyNode? existing)) return existing;
+
+        var created = new MutableHierarchyNode(
+            "node:" + ComputeSha256Hex(lookup),
+            parent.Id,
+            kind,
+            title,
+            parent.Depth + 1,
+            parent.Path + " > " + title);
+        reusable.Add(lookup, created);
+        nodes.Add(created);
+        nodesById.Add(created.Id, created);
+        parent.ChildNodeIds.Add(created.Id);
+        return created;
+    }
+
+    private static void AddTokensToAncestors(
+        MutableHierarchyNode node,
+        long tokenCount,
+        IReadOnlyDictionary<string, MutableHierarchyNode> nodesById) {
+        MutableHierarchyNode? current = node;
+        while (current != null) {
+            current.TokenCount += tokenCount;
+            if (current.ParentNodeId == null || !nodesById.TryGetValue(current.ParentNodeId, out current)) break;
+        }
+    }
+
+    private static string BuildRootTitle(OfficeDocumentSource source) {
+        if (!string.IsNullOrWhiteSpace(source.Title)) return source.Title!.Trim();
+        if (!string.IsNullOrWhiteSpace(source.Path)) {
+            string name = Path.GetFileName(source.Path);
+            if (!string.IsNullOrWhiteSpace(name)) return name;
+        }
+        return "Document";
+    }
+
+    private static string? BuildContainerKey(ReaderLocation location, ChunkingState state, out string? title) {
+        if (!string.IsNullOrWhiteSpace(location.Sheet)) {
+            string sheet = LimitHierarchyValue(location.Sheet!.Trim(), state);
+            title = "Sheet: " + sheet;
+            return "sheet:" + sheet;
+        }
+        if (location.Slide.HasValue) {
+            title = "Slide " + location.Slide.Value.ToString(CultureInfo.InvariantCulture);
+            return "slide:" + location.Slide.Value.ToString(CultureInfo.InvariantCulture);
+        }
+        if (location.Page.HasValue) {
+            title = "Page " + location.Page.Value.ToString(CultureInfo.InvariantCulture);
+            return "page:" + location.Page.Value.ToString(CultureInfo.InvariantCulture);
+        }
+        title = null;
+        return null;
+    }
+
+    private static string[] SplitHeadingPath(string? headingPath, ChunkingState state) {
+        if (string.IsNullOrWhiteSpace(headingPath)) return Array.Empty<string>();
+        string normalized = LimitHierarchyValue(headingPath!.Trim(), state);
+        string[] candidates = normalized.Split(new[] { " > " }, StringSplitOptions.RemoveEmptyEntries);
+        var headings = new List<string>(candidates.Length);
+        for (int index = 0; index < candidates.Length; index++) {
+            string heading = candidates[index].Trim();
+            if (heading.Length > 0) headings.Add(heading);
+        }
+        return headings.Count == 0 ? Array.Empty<string>() : headings.ToArray();
+    }
+
+    private static string LimitHierarchyValue(string value, ChunkingState state) {
+        if (value.Length <= state.Options.MaxContextCharacters) return value;
+        state.AddLimitDiagnostic(
+            "hierarchical-context-character-limit",
+            state.Options.MaxContextCharacters,
+            "context characters");
+        return TruncateAtCharacterBoundary(value, state.Options.MaxContextCharacters);
+    }
+
+    private static string[] CollapseHeadingDepth(string[] headings, int availableDepth) {
+        if (availableDepth <= 0) return Array.Empty<string>();
+        if (headings.Length <= availableDepth) return headings;
+        var collapsed = new string[availableDepth];
+        for (int index = 0; index < availableDepth - 1; index++) collapsed[index] = headings[index];
+        collapsed[availableDepth - 1] = string.Join(" > ", headings, availableDepth - 1, headings.Length - availableDepth + 1);
+        return collapsed;
+    }
+
+    private sealed class MutableHierarchyNode {
+        internal MutableHierarchyNode(
+            string id,
+            string? parentNodeId,
+            ReaderChunkHierarchyNodeKind kind,
+            string title,
+            int depth,
+            string path) {
+            Id = id;
+            ParentNodeId = parentNodeId;
+            Kind = kind;
+            Title = title;
+            Depth = depth;
+            Path = path;
+        }
+
+        internal string Id { get; }
+        internal string? ParentNodeId { get; }
+        internal ReaderChunkHierarchyNodeKind Kind { get; }
+        internal string Title { get; }
+        internal int Depth { get; }
+        internal string Path { get; }
+        internal long TokenCount { get; set; }
+        internal List<string> ChildNodeIds { get; } = new List<string>();
+        internal string? ChunkId { get; set; }
+
+        internal ReaderChunkHierarchyNode Freeze() => new ReaderChunkHierarchyNode {
+            Id = Id,
+            ParentNodeId = ParentNodeId,
+            Kind = Kind,
+            Title = Title,
+            Depth = Depth,
+            Path = Path,
+            TokenCount = TokenCount,
+            ChildNodeIds = ChildNodeIds.Count == 0 ? Array.Empty<string>() : ChildNodeIds.ToArray(),
+            ChunkId = ChunkId
+        };
+    }
+}

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.Hierarchy.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.Hierarchy.cs
@@ -46,20 +46,21 @@ public static partial class ReaderHierarchicalChunker {
                     state);
             }
 
-            string? hierarchyHeadingPath = location.HierarchyHeadingPath;
-            if (!string.Equals(location.HierarchyHeadingDisplayPath, location.HeadingPath, StringComparison.Ordinal)) {
-                hierarchyHeadingPath = null;
-            }
+            string? hierarchyHeadingPath = ReaderHeadingPath.GetValidatedHierarchyPath(location);
             HierarchyHeading[] headings = SplitHeadingPath(hierarchyHeadingPath ?? location.HeadingPath, state);
             state.HeadingSlugsByChunkId.TryGetValue(chunk.Id, out IReadOnlyList<string?>? fallbackHeadingSlugs);
+            IReadOnlyList<string?>? headingSlugs = fallbackHeadingSlugs != null && fallbackHeadingSlugs.Count == headings.Length
+                ? fallbackHeadingSlugs
+                : null;
             int remainingDepth = Math.Max(0, state.Options.MaxHierarchyDepth - parent.Depth);
             if (headings.Length > remainingDepth) {
                 state.AddLimitDiagnostic("hierarchical-depth-limit", state.Options.MaxHierarchyDepth, "hierarchy depth");
+                if (headingSlugs != null) headingSlugs = CollapseHeadingSlugs(headingSlugs, remainingDepth);
                 headings = CollapseHeadingDepth(headings, remainingDepth, state);
             }
             for (int headingIndex = 0; headingIndex < headings.Length; headingIndex++) {
-                string? headingSlug = fallbackHeadingSlugs != null && fallbackHeadingSlugs.Count == headings.Length
-                    ? fallbackHeadingSlugs[headingIndex]
+                string? headingSlug = headingSlugs != null && headingSlugs.Count == headings.Length
+                    ? headingSlugs[headingIndex]
                     : headingIndex == headings.Length - 1
                         ? location.HeadingSlug
                         : null;
@@ -211,8 +212,21 @@ public static partial class ReaderHierarchicalChunker {
             titles[index] = headings[availableDepth - 1 + index].Title;
         }
         collapsed[availableDepth - 1] = new HierarchyHeading(
-            string.Join(" > ", identities),
+            BuildHierarchyIdentity(identities),
             LimitHierarchyValue(string.Join(" > ", titles), state));
+        return collapsed;
+    }
+
+    private static IReadOnlyList<string?> CollapseHeadingSlugs(
+        IReadOnlyList<string?> slugs,
+        int availableDepth) {
+        if (availableDepth <= 0) return Array.Empty<string?>();
+        if (slugs.Count <= availableDepth) return slugs;
+        var collapsed = new string?[availableDepth];
+        for (int index = 0; index < availableDepth - 1; index++) collapsed[index] = slugs[index];
+        var trailing = new string?[slugs.Count - availableDepth + 1];
+        for (int index = 0; index < trailing.Length; index++) trailing[index] = slugs[availableDepth - 1 + index];
+        collapsed[availableDepth - 1] = BuildHierarchyIdentity(trailing);
         return collapsed;
     }
 

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.Hierarchy.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.Hierarchy.cs
@@ -9,9 +9,15 @@ public static partial class ReaderHierarchicalChunker {
     private static IReadOnlyList<ReaderChunkHierarchyNode> BuildHierarchy(
         ChunkingState state,
         OfficeDocumentSource source) {
-        string rootTitle = LimitHierarchyValue(BuildRootTitle(source), state);
+        string rawRootTitle = BuildRootTitle(source);
+        string rootTitle = LimitHierarchyValue(rawRootTitle, state);
+        string rootIdentity = !string.IsNullOrWhiteSpace(source.SourceId)
+            ? source.SourceId!
+            : !string.IsNullOrWhiteSpace(source.Path)
+                ? source.Path!
+                : rawRootTitle;
         var root = new MutableHierarchyNode(
-            "node:" + ComputeSha256Hex("document|" + (source.SourceId ?? source.Path ?? rootTitle)),
+            "node:" + ComputeSha256Hex("document|" + rootIdentity),
             parentNodeId: null,
             ReaderChunkHierarchyNodeKind.Document,
             rootTitle,
@@ -36,18 +42,19 @@ public static partial class ReaderHierarchicalChunker {
                     containerTitle,
                     nodes,
                     nodesById,
-                    reusable);
+                    reusable,
+                    state);
             }
 
-            string[] headings = SplitHeadingPath(location.HeadingPath, state);
+            HierarchyHeading[] headings = SplitHeadingPath(location.HeadingPath, state);
             int remainingDepth = Math.Max(0, state.Options.MaxHierarchyDepth - parent.Depth);
             if (headings.Length > remainingDepth) {
                 state.AddLimitDiagnostic("hierarchical-depth-limit", state.Options.MaxHierarchyDepth, "hierarchy depth");
-                headings = CollapseHeadingDepth(headings, remainingDepth);
+                headings = CollapseHeadingDepth(headings, remainingDepth, state);
             }
             for (int headingIndex = 0; headingIndex < headings.Length; headingIndex++) {
                 bool finalHeading = headingIndex == headings.Length - 1;
-                string key = "heading:" + headings[headingIndex];
+                string key = "heading:" + headings[headingIndex].Identity;
                 if (finalHeading && !string.IsNullOrWhiteSpace(location.HeadingSlug)) {
                     key += "|slug:" + location.HeadingSlug!.Trim();
                 }
@@ -55,22 +62,24 @@ public static partial class ReaderHierarchicalChunker {
                     parent,
                     ReaderChunkHierarchyNodeKind.Heading,
                     key,
-                    headings[headingIndex],
+                    headings[headingIndex].Title,
                     nodes,
                     nodesById,
-                    reusable);
+                    reusable,
+                    state);
             }
 
-            string leafTitle = !string.IsNullOrWhiteSpace(location.BlockAnchor)
+            string rawLeafTitle = !string.IsNullOrWhiteSpace(location.BlockAnchor)
                 ? location.BlockAnchor!
                 : "Chunk " + (index + 1).ToString(CultureInfo.InvariantCulture);
+            string leafTitle = LimitHierarchyValue(rawLeafTitle, state);
             var leaf = new MutableHierarchyNode(
                 "node:" + ComputeSha256Hex(parent.Id + "|chunk|" + chunk.Id),
                 parent.Id,
                 ReaderChunkHierarchyNodeKind.Chunk,
                 leafTitle,
                 parent.Depth + 1,
-                parent.Path + " > " + leafTitle) {
+                LimitHierarchyValue(parent.Path + " > " + leafTitle, state)) {
                 ChunkId = chunk.Id,
                 TokenCount = chunk.TokenEstimate ?? state.Segments[index].TokenCount
             };
@@ -92,7 +101,8 @@ public static partial class ReaderHierarchicalChunker {
         string title,
         ICollection<MutableHierarchyNode> nodes,
         IDictionary<string, MutableHierarchyNode> nodesById,
-        IDictionary<string, MutableHierarchyNode> reusable) {
+        IDictionary<string, MutableHierarchyNode> reusable,
+        ChunkingState state) {
         string lookup = parent.Id + "|" + kind.ToString() + "|" + key;
         if (reusable.TryGetValue(lookup, out MutableHierarchyNode? existing)) return existing;
 
@@ -102,7 +112,7 @@ public static partial class ReaderHierarchicalChunker {
             kind,
             title,
             parent.Depth + 1,
-            parent.Path + " > " + title);
+            LimitHierarchyValue(parent.Path + " > " + title, state));
         reusable.Add(lookup, created);
         nodes.Add(created);
         nodesById.Add(created.Id, created);
@@ -132,32 +142,33 @@ public static partial class ReaderHierarchicalChunker {
 
     private static string? BuildContainerKey(ReaderLocation location, ChunkingState state, out string? title) {
         if (!string.IsNullOrWhiteSpace(location.Sheet)) {
-            string sheet = LimitHierarchyValue(location.Sheet!.Trim(), state);
-            title = "Sheet: " + sheet;
+            string sheet = location.Sheet!.Trim();
+            title = LimitHierarchyValue("Sheet: " + sheet, state);
             return "sheet:" + sheet;
         }
         if (location.Slide.HasValue) {
-            title = "Slide " + location.Slide.Value.ToString(CultureInfo.InvariantCulture);
+            title = LimitHierarchyValue("Slide " + location.Slide.Value.ToString(CultureInfo.InvariantCulture), state);
             return "slide:" + location.Slide.Value.ToString(CultureInfo.InvariantCulture);
         }
         if (location.Page.HasValue) {
-            title = "Page " + location.Page.Value.ToString(CultureInfo.InvariantCulture);
+            title = LimitHierarchyValue("Page " + location.Page.Value.ToString(CultureInfo.InvariantCulture), state);
             return "page:" + location.Page.Value.ToString(CultureInfo.InvariantCulture);
         }
         title = null;
         return null;
     }
 
-    private static string[] SplitHeadingPath(string? headingPath, ChunkingState state) {
-        if (string.IsNullOrWhiteSpace(headingPath)) return Array.Empty<string>();
-        string normalized = LimitHierarchyValue(headingPath!.Trim(), state);
-        string[] candidates = normalized.Split(new[] { " > " }, StringSplitOptions.RemoveEmptyEntries);
-        var headings = new List<string>(candidates.Length);
+    private static HierarchyHeading[] SplitHeadingPath(string? headingPath, ChunkingState state) {
+        if (string.IsNullOrWhiteSpace(headingPath)) return Array.Empty<HierarchyHeading>();
+        string[] candidates = headingPath!.Trim().Split(new[] { " > " }, StringSplitOptions.RemoveEmptyEntries);
+        var headings = new List<HierarchyHeading>(candidates.Length);
         for (int index = 0; index < candidates.Length; index++) {
             string heading = candidates[index].Trim();
-            if (heading.Length > 0) headings.Add(heading);
+            if (heading.Length > 0) headings.Add(new HierarchyHeading(
+                heading,
+                LimitHierarchyValue(heading, state)));
         }
-        return headings.Count == 0 ? Array.Empty<string>() : headings.ToArray();
+        return headings.Count == 0 ? Array.Empty<HierarchyHeading>() : headings.ToArray();
     }
 
     private static string LimitHierarchyValue(string value, ChunkingState state) {
@@ -169,13 +180,35 @@ public static partial class ReaderHierarchicalChunker {
         return TruncateAtCharacterBoundary(value, state.Options.MaxContextCharacters);
     }
 
-    private static string[] CollapseHeadingDepth(string[] headings, int availableDepth) {
-        if (availableDepth <= 0) return Array.Empty<string>();
+    private static HierarchyHeading[] CollapseHeadingDepth(
+        HierarchyHeading[] headings,
+        int availableDepth,
+        ChunkingState state) {
+        if (availableDepth <= 0) return Array.Empty<HierarchyHeading>();
         if (headings.Length <= availableDepth) return headings;
-        var collapsed = new string[availableDepth];
+        var collapsed = new HierarchyHeading[availableDepth];
         for (int index = 0; index < availableDepth - 1; index++) collapsed[index] = headings[index];
-        collapsed[availableDepth - 1] = string.Join(" > ", headings, availableDepth - 1, headings.Length - availableDepth + 1);
+        int collapsedCount = headings.Length - availableDepth + 1;
+        var identities = new string[collapsedCount];
+        var titles = new string[collapsedCount];
+        for (int index = 0; index < collapsedCount; index++) {
+            identities[index] = headings[availableDepth - 1 + index].Identity;
+            titles[index] = headings[availableDepth - 1 + index].Title;
+        }
+        collapsed[availableDepth - 1] = new HierarchyHeading(
+            string.Join(" > ", identities),
+            LimitHierarchyValue(string.Join(" > ", titles), state));
         return collapsed;
+    }
+
+    private readonly struct HierarchyHeading {
+        internal HierarchyHeading(string identity, string title) {
+            Identity = identity;
+            Title = title;
+        }
+
+        internal string Identity { get; }
+        internal string Title { get; }
     }
 
     private sealed class MutableHierarchyNode {

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.Hierarchy.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.Hierarchy.cs
@@ -47,16 +47,21 @@ public static partial class ReaderHierarchicalChunker {
             }
 
             HierarchyHeading[] headings = SplitHeadingPath(location.HeadingPath, state);
+            state.HeadingSlugsByChunkId.TryGetValue(chunk.Id, out IReadOnlyList<string?>? fallbackHeadingSlugs);
             int remainingDepth = Math.Max(0, state.Options.MaxHierarchyDepth - parent.Depth);
             if (headings.Length > remainingDepth) {
                 state.AddLimitDiagnostic("hierarchical-depth-limit", state.Options.MaxHierarchyDepth, "hierarchy depth");
                 headings = CollapseHeadingDepth(headings, remainingDepth, state);
             }
             for (int headingIndex = 0; headingIndex < headings.Length; headingIndex++) {
-                bool finalHeading = headingIndex == headings.Length - 1;
                 string key = "heading:" + headings[headingIndex].Identity;
-                if (finalHeading && !string.IsNullOrWhiteSpace(location.HeadingSlug)) {
-                    key += "|slug:" + location.HeadingSlug!.Trim();
+                string? headingSlug = fallbackHeadingSlugs != null && fallbackHeadingSlugs.Count == headings.Length
+                    ? fallbackHeadingSlugs[headingIndex]
+                    : headingIndex == headings.Length - 1
+                        ? location.HeadingSlug
+                        : null;
+                if (!string.IsNullOrWhiteSpace(headingSlug)) {
+                    key += "|slug:" + headingSlug!.Trim();
                 }
                 parent = GetOrCreateNode(
                     parent,

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.Hierarchy.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.Hierarchy.cs
@@ -12,10 +12,10 @@ public static partial class ReaderHierarchicalChunker {
         string rawRootTitle = BuildRootTitle(source);
         string rootTitle = LimitHierarchyValue(rawRootTitle, state);
         string rootIdentity = !string.IsNullOrWhiteSpace(source.SourceId)
-            ? source.SourceId!
+            ? "id:" + source.SourceId!
             : !string.IsNullOrWhiteSpace(source.Path)
-                ? source.Path!
-                : rawRootTitle;
+                ? "path:" + source.Path!
+                : "title:" + rawRootTitle;
         var root = new MutableHierarchyNode(
             "node:" + ComputeSha256Hex("document|" + rootIdentity),
             parentNodeId: null,
@@ -46,7 +46,9 @@ public static partial class ReaderHierarchicalChunker {
                     state);
             }
 
-            HierarchyHeading[] headings = SplitHeadingPath(location.HeadingPath, state);
+            HierarchyHeading[] headings = SplitHeadingPath(
+                location.HierarchyHeadingPath ?? location.HeadingPath,
+                state);
             state.HeadingSlugsByChunkId.TryGetValue(chunk.Id, out IReadOnlyList<string?>? fallbackHeadingSlugs);
             int remainingDepth = Math.Max(0, state.Options.MaxHierarchyDepth - parent.Depth);
             if (headings.Length > remainingDepth) {
@@ -54,15 +56,15 @@ public static partial class ReaderHierarchicalChunker {
                 headings = CollapseHeadingDepth(headings, remainingDepth, state);
             }
             for (int headingIndex = 0; headingIndex < headings.Length; headingIndex++) {
-                string key = "heading:" + headings[headingIndex].Identity;
                 string? headingSlug = fallbackHeadingSlugs != null && fallbackHeadingSlugs.Count == headings.Length
                     ? fallbackHeadingSlugs[headingIndex]
                     : headingIndex == headings.Length - 1
                         ? location.HeadingSlug
                         : null;
-                if (!string.IsNullOrWhiteSpace(headingSlug)) {
-                    key += "|slug:" + headingSlug!.Trim();
-                }
+                string key = BuildHierarchyIdentity(
+                    "heading",
+                    headings[headingIndex].Identity,
+                    string.IsNullOrWhiteSpace(headingSlug) ? null : headingSlug!.Trim());
                 parent = GetOrCreateNode(
                     parent,
                     ReaderChunkHierarchyNodeKind.Heading,
@@ -108,7 +110,7 @@ public static partial class ReaderHierarchicalChunker {
         IDictionary<string, MutableHierarchyNode> nodesById,
         IDictionary<string, MutableHierarchyNode> reusable,
         ChunkingState state) {
-        string lookup = parent.Id + "|" + kind.ToString() + "|" + key;
+        string lookup = BuildHierarchyIdentity(parent.Id, kind.ToString(), key);
         if (reusable.TryGetValue(lookup, out MutableHierarchyNode? existing)) return existing;
 
         var created = new MutableHierarchyNode(
@@ -123,6 +125,12 @@ public static partial class ReaderHierarchicalChunker {
         nodesById.Add(created.Id, created);
         parent.ChildNodeIds.Add(created.Id);
         return created;
+    }
+
+    private static string BuildHierarchyIdentity(params string?[] values) {
+        var builder = new System.Text.StringBuilder();
+        foreach (string? value in values) AppendSegmentIdentity(builder, value);
+        return builder.ToString();
     }
 
     private static void AddTokensToAncestors(

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.Hierarchy.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.Hierarchy.cs
@@ -159,10 +159,10 @@ public static partial class ReaderHierarchicalChunker {
     }
 
     private static HierarchyHeading[] SplitHeadingPath(string? headingPath, ChunkingState state) {
-        if (string.IsNullOrWhiteSpace(headingPath)) return Array.Empty<HierarchyHeading>();
-        string[] candidates = headingPath!.Trim().Split(new[] { " > " }, StringSplitOptions.RemoveEmptyEntries);
-        var headings = new List<HierarchyHeading>(candidates.Length);
-        for (int index = 0; index < candidates.Length; index++) {
+        IReadOnlyList<string> candidates = ReaderHeadingPath.Split(headingPath);
+        if (candidates.Count == 0) return Array.Empty<HierarchyHeading>();
+        var headings = new List<HierarchyHeading>(candidates.Count);
+        for (int index = 0; index < candidates.Count; index++) {
             string heading = candidates[index].Trim();
             if (heading.Length > 0) headings.Add(new HierarchyHeading(
                 heading,

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.Splitting.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.Splitting.cs
@@ -325,6 +325,7 @@ public static partial class ReaderHierarchicalChunker {
             NormalizedEndLine = source.NormalizedEndLine,
             HeadingPath = source.HeadingPath,
             HierarchyHeadingPath = source.HierarchyHeadingPath,
+            HierarchyHeadingDisplayPath = source.HierarchyHeadingDisplayPath,
             HeadingSlug = source.HeadingSlug,
             SourceBlockKind = source.SourceBlockKind,
             BlockAnchor = source.BlockAnchor,

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.Splitting.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.Splitting.cs
@@ -1,0 +1,346 @@
+using System;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace OfficeIMO.Reader;
+
+public static partial class ReaderHierarchicalChunker {
+    private static void SplitSourceChunk(ReaderChunk source, int inputIndex, ChunkingState state) {
+        ReaderHierarchicalChunkingOptions options = state.Options;
+        IReaderTokenCounter counter = options.TokenCounter;
+        bool markdownSelected = options.PreferMarkdown && source.Markdown != null;
+        string content = markdownSelected ? source.Markdown! : source.Text ?? string.Empty;
+        string? context = BuildContext(source.Location, state);
+        string prefix = BuildContextPrefix(context, content, state);
+        state.SourceTokenCount += CountTokens(counter, content);
+
+        if (content.Length == 0) {
+            EmitSegment(source, inputIndex, markdownSelected, content, prefix, context, 0, 0, 0, 0, state);
+            return;
+        }
+
+        int start = 0;
+        int previousEnd = 0;
+        int segmentIndex = 0;
+        while (start < content.Length) {
+            state.CancellationToken.ThrowIfCancellationRequested();
+            if (state.Chunks.Count >= options.MaxOutputChunks) {
+                state.OutputLimitReached = true;
+                state.AddLimitDiagnostic("hierarchical-output-chunk-limit", options.MaxOutputChunks, "output chunks");
+                return;
+            }
+
+            int end = FindSegmentEnd(content, start, prefix, options.MaxTokens, counter);
+            int overlapCharacters = segmentIndex == 0 ? 0 : Math.Max(0, previousEnd - start);
+            int overlapTokens = overlapCharacters == 0
+                ? 0
+                : CountTokens(counter, content.Substring(start, overlapCharacters));
+            EmitSegment(
+                source,
+                inputIndex,
+                markdownSelected,
+                content,
+                prefix,
+                context,
+                segmentIndex,
+                start,
+                end,
+                overlapTokens,
+                state);
+            state.Segments[state.Segments.Count - 1].OverlapCharacterCount = overlapCharacters;
+
+            if (end >= content.Length) return;
+            previousEnd = end;
+            start = FindNextStart(content, start, end, options.OverlapTokens, counter);
+            segmentIndex++;
+        }
+    }
+
+    private static string BuildContextPrefix(string? context, string content, ChunkingState state) {
+        if (!state.Options.IncludeContextInText || string.IsNullOrWhiteSpace(context)) return string.Empty;
+        string prefix = context + "\n\n";
+        int prefixTokens = CountTokens(state.Options.TokenCounter, prefix);
+        if (content.Length > 0 && prefixTokens >= state.Options.MaxTokens) {
+            state.AddDiagnostic(
+                "hierarchical-context-omitted",
+                "Hierarchy context exceeded the chunk token budget and was retained only as segment metadata.");
+            return string.Empty;
+        }
+        if (content.Length == 0 && prefixTokens > state.Options.MaxTokens) {
+            state.AddDiagnostic(
+                "hierarchical-context-omitted",
+                "Hierarchy context exceeded the chunk token budget and was retained only as segment metadata.");
+            return string.Empty;
+        }
+        return prefix;
+    }
+
+    private static int FindSegmentEnd(
+        string content,
+        int start,
+        string prefix,
+        int maxTokens,
+        IReaderTokenCounter counter) {
+        if (CountOutputTokens(counter, prefix, content, start, content.Length) <= maxTokens) return content.Length;
+
+        int firstEnd = NextCharacterBoundary(content, start);
+        if (CountOutputTokens(counter, prefix, content, start, firstEnd) > maxTokens) {
+            throw new InvalidOperationException(
+                $"Token counter '{counter.Id}' cannot fit one source character within MaxTokens={maxTokens.ToString(CultureInfo.InvariantCulture)}.");
+        }
+
+        int low = firstEnd;
+        int high = content.Length;
+        int best = firstEnd;
+        while (low <= high) {
+            int middle = low + ((high - low) / 2);
+            middle = ClampToCharacterBoundary(content, middle, low, high);
+            int count = CountOutputTokens(counter, prefix, content, start, middle);
+            if (count <= maxTokens) {
+                best = middle;
+                if (middle >= content.Length) break;
+                low = NextCharacterBoundary(content, middle);
+            } else {
+                high = PreviousCharacterBoundary(content, middle);
+            }
+        }
+
+        int preferred = FindPreferredEnd(content, start, best);
+        if (preferred > start && CountOutputTokens(counter, prefix, content, start, preferred) <= maxTokens) {
+            best = preferred;
+        }
+        while (best > start && CountOutputTokens(counter, prefix, content, start, best) > maxTokens) {
+            best = PreviousCharacterBoundary(content, best);
+        }
+        if (best <= start) throw new InvalidOperationException("Token-aware splitting could not make forward progress.");
+        return best;
+    }
+
+    private static int FindNextStart(
+        string content,
+        int segmentStart,
+        int segmentEnd,
+        int overlapTokens,
+        IReaderTokenCounter counter) {
+        if (overlapTokens <= 0) return segmentEnd;
+        int minimum = NextCharacterBoundary(content, segmentStart);
+        int low = minimum;
+        int high = segmentEnd;
+        int best = segmentEnd;
+        while (low <= high) {
+            int middle = ClampToCharacterBoundary(content, low + ((high - low) / 2), minimum, segmentEnd);
+            int count = CountTokens(counter, content.Substring(middle, segmentEnd - middle));
+            if (count <= overlapTokens) {
+                best = middle;
+                high = PreviousCharacterBoundary(content, middle);
+            } else {
+                if (middle >= segmentEnd) break;
+                low = NextCharacterBoundary(content, middle);
+            }
+        }
+
+        int preferred = FindPreferredStart(content, best, segmentEnd);
+        return preferred > segmentStart && preferred <= segmentEnd ? preferred : best;
+    }
+
+    private static int FindPreferredEnd(string text, int start, int maximumEnd) {
+        int minimum = start + Math.Max(1, (maximumEnd - start) / 2);
+        int boundary = FindBackward(text, minimum, maximumEnd, character => character == '\n');
+        if (boundary > start) return boundary;
+        boundary = FindBackward(text, minimum, maximumEnd, IsSentenceBoundary);
+        if (boundary > start) return boundary;
+        boundary = FindBackward(text, minimum, maximumEnd, char.IsWhiteSpace);
+        return boundary > start ? boundary : maximumEnd;
+    }
+
+    private static int FindPreferredStart(string text, int minimumStart, int end) {
+        int searchEnd = Math.Min(end, minimumStart + Math.Max(8, (end - minimumStart) / 3));
+        for (int index = minimumStart; index < searchEnd; index++) {
+            if (char.IsWhiteSpace(text[index])) return index + 1;
+        }
+        return minimumStart;
+    }
+
+    private static int FindBackward(string text, int minimum, int maximum, Func<char, bool> predicate) {
+        for (int index = maximum - 1; index >= minimum; index--) {
+            if (predicate(text[index])) return index + 1;
+        }
+        return -1;
+    }
+
+    private static bool IsSentenceBoundary(char character) =>
+        character == '.' || character == '!' || character == '?' || character == ';';
+
+    private static int NextCharacterBoundary(string text, int index) {
+        if (index >= text.Length) return text.Length;
+        return char.IsHighSurrogate(text[index]) && index + 1 < text.Length && char.IsLowSurrogate(text[index + 1])
+            ? index + 2
+            : index + 1;
+    }
+
+    private static int PreviousCharacterBoundary(string text, int index) {
+        if (index <= 0) return 0;
+        int previous = index - 1;
+        return previous > 0 && char.IsLowSurrogate(text[previous]) && char.IsHighSurrogate(text[previous - 1])
+            ? previous - 1
+            : previous;
+    }
+
+    private static int ClampToCharacterBoundary(string text, int index, int minimum, int maximum) {
+        int clamped = Math.Max(minimum, Math.Min(maximum, index));
+        if (clamped > minimum && clamped < text.Length && char.IsLowSurrogate(text[clamped]) && char.IsHighSurrogate(text[clamped - 1])) {
+            clamped--;
+        } else if (clamped < maximum && clamped < text.Length && char.IsLowSurrogate(text[clamped]) && clamped > 0 && char.IsHighSurrogate(text[clamped - 1])) {
+            clamped++;
+        }
+        return Math.Max(minimum, clamped);
+    }
+
+    private static void EmitSegment(
+        ReaderChunk source,
+        int inputIndex,
+        bool markdownSelected,
+        string sourceContent,
+        string prefix,
+        string? context,
+        int segmentIndex,
+        int start,
+        int end,
+        int overlapTokens,
+        ChunkingState state) {
+        if (state.Chunks.Count >= state.Options.MaxOutputChunks) {
+            state.OutputLimitReached = true;
+            state.AddLimitDiagnostic("hierarchical-output-chunk-limit", state.Options.MaxOutputChunks, "output chunks");
+            return;
+        }
+
+        string segmentContent = sourceContent.Substring(start, end - start);
+        string output = prefix + segmentContent;
+        int outputTokens = CountTokens(state.Options.TokenCounter, output);
+        if (outputTokens > state.Options.MaxTokens) {
+            throw new InvalidOperationException("Token-aware splitting emitted a chunk beyond the configured token budget.");
+        }
+        int contentTokens = CountTokens(state.Options.TokenCounter, segmentContent);
+        int contextTokens = prefix.Length == 0 ? 0 : CountTokens(state.Options.TokenCounter, prefix);
+        string chunkId = BuildSegmentId(source, inputIndex, segmentIndex, start, end);
+        var chunk = new ReaderChunk {
+            Id = chunkId,
+            Kind = source.Kind,
+            Location = CloneLocation(source.Location),
+            SourceId = source.SourceId,
+            SourceHash = source.SourceHash,
+            ChunkHash = ComputeSegmentHash(chunkId, output),
+            SourceLastWriteUtc = source.SourceLastWriteUtc,
+            SourceLengthBytes = source.SourceLengthBytes,
+            TokenEstimate = outputTokens,
+            Text = output,
+            Markdown = markdownSelected ? output : null,
+            Tables = segmentIndex == 0 ? source.Tables : null,
+            Visuals = segmentIndex == 0 ? source.Visuals : null,
+            FormFields = segmentIndex == 0 ? source.FormFields : null,
+            Actions = segmentIndex == 0 ? source.Actions : null,
+            Diagnostics = segmentIndex == 0 ? source.Diagnostics : null,
+            Warnings = segmentIndex == 0 ? source.Warnings : null
+        };
+        state.Chunks.Add(chunk);
+        state.Segments.Add(new ReaderChunkSegment {
+            ChunkId = chunkId,
+            SourceChunkId = source.Id ?? string.Empty,
+            SegmentIndex = segmentIndex,
+            StartCharacter = start,
+            EndCharacter = end,
+            OverlapTokenCount = overlapTokens,
+            ContentTokenCount = contentTokens,
+            ContextTokenCount = contextTokens,
+            TokenCount = outputTokens,
+            Context = context
+        });
+        state.OutputTokenCount += outputTokens;
+        state.OverlapTokenCount += overlapTokens;
+        state.ContextTokenCount += contextTokens;
+    }
+
+    private static int CountOutputTokens(
+        IReaderTokenCounter counter,
+        string prefix,
+        string content,
+        int start,
+        int end) {
+        return CountTokens(counter, prefix + content.Substring(start, end - start));
+    }
+
+    private static int CountTokens(IReaderTokenCounter counter, string value) {
+        int count = counter.CountTokens(value ?? string.Empty);
+        if (count < 0) {
+            throw new InvalidOperationException($"Token counter '{counter.Id}' returned a negative count.");
+        }
+        return count;
+    }
+
+    private static string? BuildContext(ReaderLocation? location, ChunkingState state) {
+        if (location == null) return null;
+        var builder = new StringBuilder();
+        if (!string.IsNullOrWhiteSpace(location.Sheet)) AppendContext(builder, "Sheet: " + location.Sheet!.Trim());
+        else if (location.Slide.HasValue) AppendContext(builder, "Slide " + location.Slide.Value.ToString(CultureInfo.InvariantCulture));
+        else if (location.Page.HasValue) AppendContext(builder, "Page " + location.Page.Value.ToString(CultureInfo.InvariantCulture));
+        if (!string.IsNullOrWhiteSpace(location.HeadingPath)) AppendContext(builder, location.HeadingPath!.Trim());
+        if (builder.Length == 0) return null;
+        string context = builder.ToString();
+        if (context.Length <= state.Options.MaxContextCharacters) return context;
+        state.AddLimitDiagnostic(
+            "hierarchical-context-character-limit",
+            state.Options.MaxContextCharacters,
+            "context characters");
+        return TruncateAtCharacterBoundary(context, state.Options.MaxContextCharacters);
+    }
+
+    private static void AppendContext(StringBuilder builder, string value) {
+        if (builder.Length > 0) builder.Append(" > ");
+        builder.Append(value);
+    }
+
+    private static ReaderLocation CloneLocation(ReaderLocation? source) {
+        if (source == null) return new ReaderLocation();
+        return new ReaderLocation {
+            Path = source.Path,
+            BlockIndex = source.BlockIndex,
+            SourceBlockIndex = source.SourceBlockIndex,
+            StartLine = source.StartLine,
+            EndLine = source.EndLine,
+            NormalizedStartLine = source.NormalizedStartLine,
+            NormalizedEndLine = source.NormalizedEndLine,
+            HeadingPath = source.HeadingPath,
+            HeadingSlug = source.HeadingSlug,
+            SourceBlockKind = source.SourceBlockKind,
+            BlockAnchor = source.BlockAnchor,
+            Sheet = source.Sheet,
+            A1Range = source.A1Range,
+            Slide = source.Slide,
+            Page = source.Page,
+            TableIndex = source.TableIndex
+        };
+    }
+
+    private static string BuildSegmentId(ReaderChunk source, int inputIndex, int segmentIndex, int start, int end) {
+        string value = string.Join("|",
+            source.SourceId ?? string.Empty,
+            source.Id ?? string.Empty,
+            inputIndex.ToString(CultureInfo.InvariantCulture),
+            segmentIndex.ToString(CultureInfo.InvariantCulture),
+            start.ToString(CultureInfo.InvariantCulture),
+            end.ToString(CultureInfo.InvariantCulture));
+        return "rag:" + ComputeSha256Hex(value);
+    }
+
+    private static string ComputeSegmentHash(string chunkId, string content) =>
+        ComputeSha256Hex(chunkId + "|" + content);
+
+    private static string ComputeSha256Hex(string value) {
+        using SHA256 sha = SHA256.Create();
+        byte[] hash = sha.ComputeHash(Encoding.UTF8.GetBytes(value ?? string.Empty));
+        var builder = new StringBuilder(hash.Length * 2);
+        for (int index = 0; index < hash.Length; index++) builder.Append(hash[index].ToString("x2", CultureInfo.InvariantCulture));
+        return builder.ToString();
+    }
+}

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.Splitting.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.Splitting.cs
@@ -296,7 +296,10 @@ public static partial class ReaderHierarchicalChunker {
         if (!string.IsNullOrWhiteSpace(location.Sheet)) AppendContext(builder, "Sheet: " + location.Sheet!.Trim());
         else if (location.Slide.HasValue) AppendContext(builder, "Slide " + location.Slide.Value.ToString(CultureInfo.InvariantCulture));
         else if (location.Page.HasValue) AppendContext(builder, "Page " + location.Page.Value.ToString(CultureInfo.InvariantCulture));
-        string? headingDisplay = ReaderHeadingPath.ToDisplayString(location.HeadingPath);
+        string? hierarchyPath = ReaderHeadingPath.GetValidatedHierarchyPath(location);
+        string? headingDisplay = hierarchyPath == null
+            ? location.HeadingPath
+            : ReaderHeadingPath.ToDisplayString(hierarchyPath);
         if (!string.IsNullOrWhiteSpace(headingDisplay)) AppendContext(builder, headingDisplay!);
         if (builder.Length == 0) return null;
         string context = builder.ToString();

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.Splitting.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.Splitting.cs
@@ -324,6 +324,7 @@ public static partial class ReaderHierarchicalChunker {
             NormalizedStartLine = source.NormalizedStartLine,
             NormalizedEndLine = source.NormalizedEndLine,
             HeadingPath = source.HeadingPath,
+            HierarchyHeadingPath = source.HierarchyHeadingPath,
             HeadingSlug = source.HeadingSlug,
             SourceBlockKind = source.SourceBlockKind,
             BlockAnchor = source.BlockAnchor,

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.Splitting.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.Splitting.cs
@@ -234,7 +234,7 @@ public static partial class ReaderHierarchicalChunker {
             throw new InvalidOperationException("Token-aware splitting emitted a chunk beyond the configured token budget.");
         }
         int contentTokens = CountTokens(state.Options.TokenCounter, segmentContent);
-        int contextTokens = prefix.Length == 0 ? 0 : CountTokens(state.Options.TokenCounter, prefix);
+        int contextTokens = prefix.Length == 0 ? 0 : Math.Max(0, outputTokens - contentTokens);
         string chunkId = BuildSegmentId(source, inputIndex, segmentIndex, start, end);
         var chunk = new ReaderChunk {
             Id = chunkId,

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.Splitting.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.Splitting.cs
@@ -296,7 +296,8 @@ public static partial class ReaderHierarchicalChunker {
         if (!string.IsNullOrWhiteSpace(location.Sheet)) AppendContext(builder, "Sheet: " + location.Sheet!.Trim());
         else if (location.Slide.HasValue) AppendContext(builder, "Slide " + location.Slide.Value.ToString(CultureInfo.InvariantCulture));
         else if (location.Page.HasValue) AppendContext(builder, "Page " + location.Page.Value.ToString(CultureInfo.InvariantCulture));
-        if (!string.IsNullOrWhiteSpace(location.HeadingPath)) AppendContext(builder, location.HeadingPath!.Trim());
+        string? headingDisplay = ReaderHeadingPath.ToDisplayString(location.HeadingPath);
+        if (!string.IsNullOrWhiteSpace(headingDisplay)) AppendContext(builder, headingDisplay!);
         if (builder.Length == 0) return null;
         string context = builder.ToString();
         if (context.Length <= state.Options.MaxContextCharacters) return context;

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.Splitting.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.Splitting.cs
@@ -9,7 +9,7 @@ public static partial class ReaderHierarchicalChunker {
     private static void SplitSourceChunk(ReaderChunk source, int inputIndex, ChunkingState state) {
         ReaderHierarchicalChunkingOptions options = state.Options;
         IReaderTokenCounter counter = options.TokenCounter;
-        bool markdownSelected = options.PreferMarkdown && source.Markdown != null;
+        bool markdownSelected = options.PreferMarkdown && !string.IsNullOrWhiteSpace(source.Markdown);
         string content = markdownSelected ? source.Markdown! : source.Text ?? string.Empty;
         string? context = BuildContext(source.Location, state);
         string prefix = BuildContextPrefix(context, content, state);
@@ -65,6 +65,18 @@ public static partial class ReaderHierarchicalChunker {
             state.AddDiagnostic(
                 "hierarchical-context-omitted",
                 "Hierarchy context exceeded the chunk token budget and was retained only as segment metadata.");
+            return string.Empty;
+        }
+        if (content.Length > 0 &&
+            CountOutputTokens(
+                state.Options.TokenCounter,
+                prefix,
+                content,
+                0,
+                NextCharacterBoundary(content, 0)) > state.Options.MaxTokens) {
+            state.AddDiagnostic(
+                "hierarchical-context-omitted",
+                "Hierarchy context left no room for source content and was retained only as segment metadata.");
             return string.Empty;
         }
         if (content.Length == 0 && prefixTokens > state.Options.MaxTokens) {
@@ -324,7 +336,7 @@ public static partial class ReaderHierarchicalChunker {
 
     private static string BuildSegmentId(ReaderChunk source, int inputIndex, int segmentIndex, int start, int end) {
         string value = string.Join("|",
-            source.SourceId ?? string.Empty,
+            GetSourceIdentity(source) ?? string.Empty,
             source.Id ?? string.Empty,
             inputIndex.ToString(CultureInfo.InvariantCulture),
             segmentIndex.ToString(CultureInfo.InvariantCulture),

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.Splitting.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.Splitting.cs
@@ -336,14 +336,24 @@ public static partial class ReaderHierarchicalChunker {
     }
 
     private static string BuildSegmentId(ReaderChunk source, int inputIndex, int segmentIndex, int start, int end) {
-        string value = string.Join("|",
-            GetSourceIdentity(source) ?? string.Empty,
-            source.Id ?? string.Empty,
-            inputIndex.ToString(CultureInfo.InvariantCulture),
-            segmentIndex.ToString(CultureInfo.InvariantCulture),
-            start.ToString(CultureInfo.InvariantCulture),
-            end.ToString(CultureInfo.InvariantCulture));
-        return "rag:" + ComputeSha256Hex(value);
+        var identity = new StringBuilder();
+        AppendSegmentIdentity(identity, GetSourceIdentity(source));
+        AppendSegmentIdentity(identity, source.Id);
+        AppendSegmentIdentity(identity, inputIndex.ToString(CultureInfo.InvariantCulture));
+        AppendSegmentIdentity(identity, segmentIndex.ToString(CultureInfo.InvariantCulture));
+        AppendSegmentIdentity(identity, start.ToString(CultureInfo.InvariantCulture));
+        AppendSegmentIdentity(identity, end.ToString(CultureInfo.InvariantCulture));
+        return "rag:" + ComputeSha256Hex(identity.ToString());
+    }
+
+    private static void AppendSegmentIdentity(StringBuilder builder, string? value) {
+        if (value == null) {
+            builder.Append("-1:");
+            return;
+        }
+        builder.Append(value.Length.ToString(CultureInfo.InvariantCulture));
+        builder.Append(':');
+        builder.Append(value);
     }
 
     private static string ComputeSegmentHash(string chunkId, string content) =>

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.cs
@@ -125,7 +125,8 @@ public static partial class ReaderHierarchicalChunker {
             location.BlockAnchor ??= string.IsNullOrWhiteSpace(block.Id) ? "block-" + index.ToString(CultureInfo.InvariantCulture) : block.Id;
             if (isHeading) UpdateFallbackHeadings(headings, block.Level ?? 1, text, location.BlockAnchor);
             if (string.IsNullOrWhiteSpace(location.HeadingPath)) {
-                location.HeadingPath = BuildFallbackHeadingPath(headings);
+                location.HeadingPath = BuildFallbackHeadingDisplayPath(headings);
+                ReaderHeadingPath.SetHierarchyPath(location, BuildFallbackHierarchyHeadingPath(headings));
                 location.HeadingSlug ??= BuildFallbackHeadingSlug(headings);
             } else if (isHeading) {
                 location.HeadingSlug ??= location.BlockAnchor;
@@ -255,17 +256,19 @@ public static partial class ReaderHierarchicalChunker {
     private static void InheritPageLocation(ReaderLocation location, OfficeDocumentPage? page) {
         if (page == null) return;
         ReaderLocation container = page.Location ?? new ReaderLocation();
-        location.Path ??= container.Path;
-        location.Sheet ??= container.Sheet;
-        location.A1Range ??= container.A1Range;
+        if (string.IsNullOrWhiteSpace(location.Path)) location.Path = container.Path;
+        if (string.IsNullOrWhiteSpace(location.Sheet)) location.Sheet = container.Sheet;
+        if (string.IsNullOrWhiteSpace(location.A1Range)) location.A1Range = container.A1Range;
         location.Slide ??= container.Slide;
         string? containerKind = container.SourceBlockKind?.Trim();
         if (string.Equals(containerKind, "sheet", StringComparison.OrdinalIgnoreCase)) {
-            location.Sheet ??= !string.IsNullOrWhiteSpace(page.Name)
-                ? page.Name
-                : page.Number > 0
-                    ? "Sheet " + page.Number.Value.ToString(CultureInfo.InvariantCulture)
-                    : null;
+            if (string.IsNullOrWhiteSpace(location.Sheet)) {
+                location.Sheet = !string.IsNullOrWhiteSpace(page.Name)
+                    ? page.Name
+                    : page.Number > 0
+                        ? "Sheet " + page.Number.Value.ToString(CultureInfo.InvariantCulture)
+                        : null;
+            }
         }
         if (!location.Page.HasValue &&
             !location.Slide.HasValue &&
@@ -294,8 +297,17 @@ public static partial class ReaderHierarchicalChunker {
         headings.Add(new FallbackHeading(effectiveLevel, title, slug));
     }
 
-    private static string? BuildFallbackHeadingPath(IReadOnlyList<FallbackHeading> headings) {
+    private static string? BuildFallbackHierarchyHeadingPath(IReadOnlyList<FallbackHeading> headings) {
         return ReaderHeadingPath.Combine(headings.Select(heading => heading.Title));
+    }
+
+    private static string? BuildFallbackHeadingDisplayPath(IReadOnlyList<FallbackHeading> headings) {
+        string[] titles = headings
+            .Select(heading => heading.Title)
+            .Where(title => !string.IsNullOrWhiteSpace(title))
+            .Select(title => title.Trim())
+            .ToArray();
+        return titles.Length == 0 ? null : string.Join(" > ", titles);
     }
 
     private static string? BuildFallbackHeadingSlug(IReadOnlyList<FallbackHeading> headings) =>

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.cs
@@ -2,12 +2,16 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace OfficeIMO.Reader;
 
 /// <summary>Creates bounded token-aware chunks and a document/container/heading hierarchy.</summary>
 public static partial class ReaderHierarchicalChunker {
+    private static readonly ConditionalWeakTable<ReaderChunk, FallbackHeadingIdentityPath> FallbackHeadingIdentities =
+        new ConditionalWeakTable<ReaderChunk, FallbackHeadingIdentityPath>();
+
     /// <summary>Chunks an already-read rich document.</summary>
     public static ReaderChunkHierarchyResult Chunk(
         OfficeDocumentReadResult document,
@@ -120,7 +124,7 @@ public static partial class ReaderHierarchicalChunker {
                 location.HeadingSlug ??= location.BlockAnchor;
             }
             string sourceIdentity = document.Source?.SourceId ?? document.Source?.Path ?? string.Empty;
-            yield return new ReaderChunk {
+            var sourceChunk = new ReaderChunk {
                 Id = "block:" + ComputeSha256Hex(sourceIdentity + "|" + block.Id + "|" + index.ToString(CultureInfo.InvariantCulture)),
                 Kind = document.Kind,
                 Location = location,
@@ -130,6 +134,10 @@ public static partial class ReaderHierarchicalChunker {
                 SourceLengthBytes = document.Source?.LengthBytes,
                 Text = text
             };
+            FallbackHeadingIdentities.Add(
+                sourceChunk,
+                new FallbackHeadingIdentityPath(headings.Select(heading => heading.Slug).ToArray()));
+            yield return sourceChunk;
             index++;
         }
         if (index == 0 && !string.IsNullOrEmpty(document.Markdown)) {
@@ -204,10 +212,13 @@ public static partial class ReaderHierarchicalChunker {
     }
 
     private static ReaderChunk InheritDocumentSource(ReaderChunk chunk, OfficeDocumentSource? source) {
-        if (GetSourceIdentity(chunk) != null || source == null ||
+        if (source == null ||
             (string.IsNullOrWhiteSpace(source.SourceId) && string.IsNullOrWhiteSpace(source.Path))) {
             return chunk;
         }
+        bool inheritSourceId = string.IsNullOrWhiteSpace(chunk.SourceId) && !string.IsNullOrWhiteSpace(source.SourceId);
+        bool inheritPath = string.IsNullOrWhiteSpace(chunk.Location?.Path) && !string.IsNullOrWhiteSpace(source.Path);
+        if (!inheritSourceId && !inheritPath) return chunk;
 
         ReaderLocation location = CloneLocation(chunk.Location);
         location.Path ??= source.Path;
@@ -215,7 +226,7 @@ public static partial class ReaderHierarchicalChunker {
             Id = chunk.Id,
             Kind = chunk.Kind,
             Location = location,
-            SourceId = source.SourceId,
+            SourceId = inheritSourceId ? source.SourceId : chunk.SourceId,
             SourceHash = chunk.SourceHash ?? source.SourceHash,
             ChunkHash = chunk.ChunkHash,
             SourceLastWriteUtc = chunk.SourceLastWriteUtc ?? source.LastWriteUtc,
@@ -303,7 +314,7 @@ public static partial class ReaderHierarchicalChunker {
 
     private static OfficeDocumentSource InferSource(IReadOnlyList<ReaderChunk> chunks) {
         if (chunks.Count == 0) return new OfficeDocumentSource();
-        ReaderChunk first = chunks[0];
+        ReaderChunk first = chunks.FirstOrDefault(chunk => GetSourceIdentity(chunk) != null) ?? chunks[0];
         return new OfficeDocumentSource {
             Path = first.Location?.Path,
             SourceId = first.SourceId,
@@ -352,6 +363,8 @@ public static partial class ReaderHierarchicalChunker {
         internal List<ReaderChunk> Chunks { get; } = new List<ReaderChunk>();
         internal List<ReaderChunkSegment> Segments { get; } = new List<ReaderChunkSegment>();
         internal List<OfficeDocumentDiagnostic> Diagnostics { get; } = new List<OfficeDocumentDiagnostic>();
+        internal Dictionary<string, IReadOnlyList<string?>> HeadingSlugsByChunkId { get; } =
+            new Dictionary<string, IReadOnlyList<string?>>(StringComparer.Ordinal);
         internal long SourceTokenCount { get; set; }
         internal long OutputTokenCount { get; set; }
         internal long OverlapTokenCount { get; set; }
@@ -365,7 +378,13 @@ public static partial class ReaderHierarchicalChunker {
             else if (sourceIdentity != null && !string.Equals(SourceIdentity, sourceIdentity, StringComparison.Ordinal)) {
                 throw new InvalidOperationException("One chunk hierarchy cannot contain chunks from multiple source documents.");
             }
+            int firstOutputIndex = Chunks.Count;
             SplitSourceChunk(source, inputIndex, this);
+            if (FallbackHeadingIdentities.TryGetValue(source, out FallbackHeadingIdentityPath? identityPath)) {
+                for (int index = firstOutputIndex; index < Chunks.Count; index++) {
+                    HeadingSlugsByChunkId[Chunks[index].Id] = identityPath.Slugs;
+                }
+            }
         }
 
         internal void AddLimitDiagnostic(string code, int limit, string target) {
@@ -426,5 +445,13 @@ public static partial class ReaderHierarchicalChunker {
         internal int Level { get; }
         internal string Title { get; }
         internal string? Slug { get; }
+    }
+
+    private sealed class FallbackHeadingIdentityPath {
+        internal FallbackHeadingIdentityPath(IReadOnlyList<string?> slugs) {
+            Slugs = slugs;
+        }
+
+        internal IReadOnlyList<string?> Slugs { get; }
     }
 }

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.cs
@@ -22,7 +22,8 @@ public static partial class ReaderHierarchicalChunker {
             GetSourceChunks(document),
             document.Source ?? new OfficeDocumentSource(),
             Normalize(options),
-            cancellationToken);
+            cancellationToken,
+            enforceSingleSourceIdentity: false);
     }
 
     /// <summary>Chunks an existing source-ordered collection.</summary>
@@ -31,15 +32,21 @@ public static partial class ReaderHierarchicalChunker {
         ReaderHierarchicalChunkingOptions? options = null,
         CancellationToken cancellationToken = default) {
         if (chunks == null) throw new ArgumentNullException(nameof(chunks));
-        return ChunkCore(chunks, new OfficeDocumentSource(), Normalize(options), cancellationToken);
+        return ChunkCore(
+            chunks,
+            new OfficeDocumentSource(),
+            Normalize(options),
+            cancellationToken,
+            enforceSingleSourceIdentity: true);
     }
 
     private static ReaderChunkHierarchyResult ChunkCore(
         IEnumerable<ReaderChunk> source,
         OfficeDocumentSource sourceInfo,
         ReaderHierarchicalChunkingOptions options,
-        CancellationToken cancellationToken) {
-        var state = new ChunkingState(options, cancellationToken);
+        CancellationToken cancellationToken,
+        bool enforceSingleSourceIdentity) {
+        var state = new ChunkingState(options, cancellationToken, enforceSingleSourceIdentity);
         int inputIndex = 0;
         using IEnumerator<ReaderChunk> enumerator = source.GetEnumerator();
         while (!state.OutputLimitReached) {
@@ -353,15 +360,20 @@ public static partial class ReaderHierarchicalChunker {
     private sealed class ChunkingState {
         private readonly HashSet<string> _diagnosticCodes = new HashSet<string>(StringComparer.Ordinal);
 
-        internal ChunkingState(ReaderHierarchicalChunkingOptions options, CancellationToken cancellationToken) {
+        internal ChunkingState(
+            ReaderHierarchicalChunkingOptions options,
+            CancellationToken cancellationToken,
+            bool enforceSingleSourceIdentity) {
             Options = options;
             CancellationToken = cancellationToken;
             TokenCounterId = options.TokenCounter.Id;
+            EnforceSingleSourceIdentity = enforceSingleSourceIdentity;
         }
 
         internal ReaderHierarchicalChunkingOptions Options { get; }
         internal CancellationToken CancellationToken { get; }
         internal string TokenCounterId { get; }
+        internal bool EnforceSingleSourceIdentity { get; }
         internal List<ReaderChunk> Chunks { get; } = new List<ReaderChunk>();
         internal List<ReaderChunkSegment> Segments { get; } = new List<ReaderChunkSegment>();
         internal List<OfficeDocumentDiagnostic> Diagnostics { get; } = new List<OfficeDocumentDiagnostic>();
@@ -377,7 +389,8 @@ public static partial class ReaderHierarchicalChunker {
         internal void AddSourceChunk(ReaderChunk source, int inputIndex) {
             string? sourceIdentity = GetSourceIdentity(source);
             if (SourceIdentity == null) SourceIdentity = sourceIdentity;
-            else if (sourceIdentity != null && !string.Equals(SourceIdentity, sourceIdentity, StringComparison.Ordinal)) {
+            else if (EnforceSingleSourceIdentity && sourceIdentity != null &&
+                     !string.Equals(SourceIdentity, sourceIdentity, StringComparison.Ordinal)) {
                 throw new InvalidOperationException("One chunk hierarchy cannot contain chunks from multiple source documents.");
             }
             int firstOutputIndex = Chunks.Count;

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.cs
@@ -37,12 +37,15 @@ public static partial class ReaderHierarchicalChunker {
         CancellationToken cancellationToken) {
         var state = new ChunkingState(options, cancellationToken);
         int inputIndex = 0;
-        foreach (ReaderChunk? chunk in source) {
+        using IEnumerator<ReaderChunk> enumerator = source.GetEnumerator();
+        while (!state.OutputLimitReached) {
             cancellationToken.ThrowIfCancellationRequested();
             if (inputIndex >= options.MaxInputChunks) {
                 state.AddLimitDiagnostic("hierarchical-input-chunk-limit", options.MaxInputChunks, "input chunks");
                 break;
             }
+            if (!enumerator.MoveNext()) break;
+            ReaderChunk? chunk = enumerator.Current;
             if (chunk == null) {
                 state.AddDiagnostic("hierarchical-null-input-chunk", "A null input chunk was skipped.");
                 inputIndex++;
@@ -50,7 +53,6 @@ public static partial class ReaderHierarchicalChunker {
             }
             state.AddSourceChunk(chunk, inputIndex);
             inputIndex++;
-            if (state.OutputLimitReached) break;
         }
 
         OfficeDocumentSource effectiveSource = HasSourceIdentity(sourceInfo)
@@ -92,9 +94,11 @@ public static partial class ReaderHierarchicalChunker {
 
     private static IEnumerable<ReaderChunk> GetSourceChunks(OfficeDocumentReadResult document) {
         IReadOnlyList<ReaderChunk> chunks = document.Chunks ?? Array.Empty<ReaderChunk>();
-        if (chunks.Count > 0) return chunks;
+        if (chunks.Count > 0) {
+            for (int chunkIndex = 0; chunkIndex < chunks.Count; chunkIndex++) yield return chunks[chunkIndex];
+            yield break;
+        }
 
-        var fallback = new List<ReaderChunk>();
         var headings = new List<KeyValuePair<int, string>>();
         int index = 0;
         foreach (OfficeDocumentBlock block in OfficeDocumentModelTraversal.Blocks(document)) {
@@ -107,7 +111,7 @@ public static partial class ReaderHierarchicalChunker {
             location.BlockAnchor ??= string.IsNullOrWhiteSpace(block.Id) ? "block-" + index.ToString(CultureInfo.InvariantCulture) : block.Id;
             location.HeadingPath ??= BuildFallbackHeadingPath(headings);
             if (isHeading) location.HeadingSlug ??= string.IsNullOrWhiteSpace(block.Id) ? null : block.Id;
-            fallback.Add(new ReaderChunk {
+            yield return new ReaderChunk {
                 Id = "block:" + ComputeSha256Hex((document.Source?.SourceId ?? string.Empty) + "|" + block.Id + "|" + index.ToString(CultureInfo.InvariantCulture)),
                 Kind = document.Kind,
                 Location = location,
@@ -116,11 +120,11 @@ public static partial class ReaderHierarchicalChunker {
                 SourceLastWriteUtc = document.Source?.LastWriteUtc,
                 SourceLengthBytes = document.Source?.LengthBytes,
                 Text = text
-            });
+            };
             index++;
         }
-        if (fallback.Count == 0 && !string.IsNullOrEmpty(document.Markdown)) {
-            fallback.Add(new ReaderChunk {
+        if (index == 0 && !string.IsNullOrEmpty(document.Markdown)) {
+            yield return new ReaderChunk {
                 Id = "document:" + ComputeSha256Hex((document.Source?.SourceId ?? document.Source?.Path ?? string.Empty) + "|markdown"),
                 Kind = document.Kind,
                 Location = new ReaderLocation { Path = document.Source?.Path },
@@ -130,9 +134,8 @@ public static partial class ReaderHierarchicalChunker {
                 SourceLengthBytes = document.Source?.LengthBytes,
                 Text = document.Markdown!,
                 Markdown = document.Markdown
-            });
+            };
         }
-        return fallback;
     }
 
     private static void UpdateFallbackHeadings(List<KeyValuePair<int, string>> headings, int level, string text) {
@@ -215,12 +218,7 @@ public static partial class ReaderHierarchicalChunker {
         internal string? SourceIdentity { get; set; }
 
         internal void AddSourceChunk(ReaderChunk source, int inputIndex) {
-            string? sourcePath = source.Location?.Path;
-            string? sourceIdentity = !string.IsNullOrWhiteSpace(source.SourceId)
-                ? "id:" + source.SourceId
-                : !string.IsNullOrWhiteSpace(sourcePath)
-                    ? "path:" + sourcePath
-                    : null;
+            string? sourceIdentity = GetSourceIdentity(source);
             if (SourceIdentity == null) SourceIdentity = sourceIdentity;
             else if (sourceIdentity != null && !string.Equals(SourceIdentity, sourceIdentity, StringComparison.Ordinal)) {
                 throw new InvalidOperationException("One chunk hierarchy cannot contain chunks from multiple source documents.");
@@ -255,5 +253,14 @@ public static partial class ReaderHierarchicalChunker {
                 IsRecoverable = true
             });
         }
+    }
+
+    private static string? GetSourceIdentity(ReaderChunk source) {
+        string? sourcePath = source.Location?.Path;
+        return !string.IsNullOrWhiteSpace(source.SourceId)
+            ? "id:" + source.SourceId
+            : !string.IsNullOrWhiteSpace(sourcePath)
+                ? "path:" + sourcePath
+                : null;
     }
 }

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>Creates bounded token-aware chunks and a document/container/heading hierarchy.</summary>
+public static partial class ReaderHierarchicalChunker {
+    /// <summary>Chunks an already-read rich document.</summary>
+    public static ReaderChunkHierarchyResult Chunk(
+        OfficeDocumentReadResult document,
+        ReaderHierarchicalChunkingOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        return ChunkCore(
+            GetSourceChunks(document),
+            document.Source ?? new OfficeDocumentSource(),
+            Normalize(options),
+            cancellationToken);
+    }
+
+    /// <summary>Chunks an existing source-ordered collection.</summary>
+    public static ReaderChunkHierarchyResult Chunk(
+        IEnumerable<ReaderChunk> chunks,
+        ReaderHierarchicalChunkingOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        if (chunks == null) throw new ArgumentNullException(nameof(chunks));
+        return ChunkCore(chunks, new OfficeDocumentSource(), Normalize(options), cancellationToken);
+    }
+
+    private static ReaderChunkHierarchyResult ChunkCore(
+        IEnumerable<ReaderChunk> source,
+        OfficeDocumentSource sourceInfo,
+        ReaderHierarchicalChunkingOptions options,
+        CancellationToken cancellationToken) {
+        var state = new ChunkingState(options, cancellationToken);
+        int inputIndex = 0;
+        foreach (ReaderChunk? chunk in source) {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (inputIndex >= options.MaxInputChunks) {
+                state.AddLimitDiagnostic("hierarchical-input-chunk-limit", options.MaxInputChunks, "input chunks");
+                break;
+            }
+            if (chunk == null) {
+                state.AddDiagnostic("hierarchical-null-input-chunk", "A null input chunk was skipped.");
+                inputIndex++;
+                continue;
+            }
+            state.AddSourceChunk(chunk, inputIndex);
+            inputIndex++;
+            if (state.OutputLimitReached) break;
+        }
+
+        OfficeDocumentSource effectiveSource = HasSourceIdentity(sourceInfo)
+            ? sourceInfo
+            : InferSource(state.Chunks);
+        IReadOnlyList<ReaderChunkHierarchyNode> nodes = BuildHierarchy(state, effectiveSource);
+        return new ReaderChunkHierarchyResult {
+            Source = CloneSource(effectiveSource),
+            TokenCounterId = state.TokenCounterId,
+            RootNodeId = nodes.Count == 0 ? string.Empty : nodes[0].Id,
+            SourceTokenCount = state.SourceTokenCount,
+            OutputTokenCount = state.OutputTokenCount,
+            OverlapTokenCount = state.OverlapTokenCount,
+            ContextTokenCount = state.ContextTokenCount,
+            Chunks = state.Chunks.Count == 0 ? Array.Empty<ReaderChunk>() : state.Chunks.ToArray(),
+            Segments = state.Segments.Count == 0 ? Array.Empty<ReaderChunkSegment>() : state.Segments.ToArray(),
+            Nodes = nodes,
+            Diagnostics = state.Diagnostics.Count == 0 ? Array.Empty<OfficeDocumentDiagnostic>() : state.Diagnostics.ToArray()
+        };
+    }
+
+    private static ReaderHierarchicalChunkingOptions Normalize(ReaderHierarchicalChunkingOptions? options) {
+        ReaderHierarchicalChunkingOptions effective = (options ?? new ReaderHierarchicalChunkingOptions()).Clone();
+        if (effective.MaxTokens <= 0) throw new ArgumentOutOfRangeException(nameof(effective.MaxTokens));
+        if (effective.OverlapTokens < 0 || effective.OverlapTokens >= effective.MaxTokens) {
+            throw new ArgumentOutOfRangeException(nameof(effective.OverlapTokens), "Overlap must be non-negative and smaller than MaxTokens.");
+        }
+        if (effective.MaxInputChunks <= 0) throw new ArgumentOutOfRangeException(nameof(effective.MaxInputChunks));
+        if (effective.MaxOutputChunks <= 0) throw new ArgumentOutOfRangeException(nameof(effective.MaxOutputChunks));
+        if (effective.MaxHierarchyDepth <= 0) throw new ArgumentOutOfRangeException(nameof(effective.MaxHierarchyDepth));
+        if (effective.MaxContextCharacters <= 0) throw new ArgumentOutOfRangeException(nameof(effective.MaxContextCharacters));
+        if (effective.TokenCounter == null) throw new ArgumentNullException(nameof(effective.TokenCounter));
+        string counterId = effective.TokenCounter.Id;
+        if (string.IsNullOrWhiteSpace(counterId) || !string.Equals(counterId, counterId.Trim(), StringComparison.Ordinal)) {
+            throw new ArgumentException("Token counter id must be non-empty and normalized.", nameof(effective.TokenCounter));
+        }
+        return effective;
+    }
+
+    private static IEnumerable<ReaderChunk> GetSourceChunks(OfficeDocumentReadResult document) {
+        IReadOnlyList<ReaderChunk> chunks = document.Chunks ?? Array.Empty<ReaderChunk>();
+        if (chunks.Count > 0) return chunks;
+
+        var fallback = new List<ReaderChunk>();
+        var headings = new List<KeyValuePair<int, string>>();
+        int index = 0;
+        foreach (OfficeDocumentBlock block in OfficeDocumentModelTraversal.Blocks(document)) {
+            string text = block.Text ?? string.Empty;
+            bool isHeading = string.Equals(block.Kind?.Trim(), "heading", StringComparison.OrdinalIgnoreCase);
+            if (isHeading) UpdateFallbackHeadings(headings, block.Level ?? 1, text);
+            ReaderLocation location = CloneLocation(block.Location);
+            location.SourceBlockIndex ??= index;
+            location.SourceBlockKind ??= block.Kind;
+            location.BlockAnchor ??= string.IsNullOrWhiteSpace(block.Id) ? "block-" + index.ToString(CultureInfo.InvariantCulture) : block.Id;
+            location.HeadingPath ??= BuildFallbackHeadingPath(headings);
+            if (isHeading) location.HeadingSlug ??= string.IsNullOrWhiteSpace(block.Id) ? null : block.Id;
+            fallback.Add(new ReaderChunk {
+                Id = "block:" + ComputeSha256Hex((document.Source?.SourceId ?? string.Empty) + "|" + block.Id + "|" + index.ToString(CultureInfo.InvariantCulture)),
+                Kind = document.Kind,
+                Location = location,
+                SourceId = document.Source?.SourceId,
+                SourceHash = document.Source?.SourceHash,
+                SourceLastWriteUtc = document.Source?.LastWriteUtc,
+                SourceLengthBytes = document.Source?.LengthBytes,
+                Text = text
+            });
+            index++;
+        }
+        if (fallback.Count == 0 && !string.IsNullOrEmpty(document.Markdown)) {
+            fallback.Add(new ReaderChunk {
+                Id = "document:" + ComputeSha256Hex((document.Source?.SourceId ?? document.Source?.Path ?? string.Empty) + "|markdown"),
+                Kind = document.Kind,
+                Location = new ReaderLocation { Path = document.Source?.Path },
+                SourceId = document.Source?.SourceId,
+                SourceHash = document.Source?.SourceHash,
+                SourceLastWriteUtc = document.Source?.LastWriteUtc,
+                SourceLengthBytes = document.Source?.LengthBytes,
+                Text = document.Markdown!,
+                Markdown = document.Markdown
+            });
+        }
+        return fallback;
+    }
+
+    private static void UpdateFallbackHeadings(List<KeyValuePair<int, string>> headings, int level, string text) {
+        int effectiveLevel = Math.Max(1, level);
+        for (int index = headings.Count - 1; index >= 0; index--) {
+            if (headings[index].Key >= effectiveLevel) headings.RemoveAt(index);
+        }
+        string title = string.IsNullOrWhiteSpace(text)
+            ? "Heading " + effectiveLevel.ToString(CultureInfo.InvariantCulture)
+            : text.Trim();
+        headings.Add(new KeyValuePair<int, string>(effectiveLevel, title));
+    }
+
+    private static string? BuildFallbackHeadingPath(IReadOnlyList<KeyValuePair<int, string>> headings) {
+        if (headings.Count == 0) return null;
+        return string.Join(" > ", headings.Select(heading => heading.Value));
+    }
+
+    private static bool HasSourceIdentity(OfficeDocumentSource source) =>
+        !string.IsNullOrWhiteSpace(source.SourceId) ||
+        !string.IsNullOrWhiteSpace(source.Path) ||
+        !string.IsNullOrWhiteSpace(source.Title);
+
+    private static OfficeDocumentSource InferSource(IReadOnlyList<ReaderChunk> chunks) {
+        if (chunks.Count == 0) return new OfficeDocumentSource();
+        ReaderChunk first = chunks[0];
+        return new OfficeDocumentSource {
+            Path = first.Location?.Path,
+            SourceId = first.SourceId,
+            SourceHash = first.SourceHash,
+            LastWriteUtc = first.SourceLastWriteUtc,
+            LengthBytes = first.SourceLengthBytes
+        };
+    }
+
+    private static string TruncateAtCharacterBoundary(string value, int maximumCharacters) {
+        if (value.Length <= maximumCharacters) return value;
+        int length = maximumCharacters;
+        if (length > 0 &&
+            length < value.Length &&
+            char.IsHighSurrogate(value[length - 1]) &&
+            char.IsLowSurrogate(value[length])) {
+            length--;
+        }
+        return length == 0 ? string.Empty : value.Substring(0, length);
+    }
+
+    private static OfficeDocumentSource CloneSource(OfficeDocumentSource source) => new OfficeDocumentSource {
+        Path = source.Path,
+        SourceId = source.SourceId,
+        SourceHash = source.SourceHash,
+        LastWriteUtc = source.LastWriteUtc,
+        LengthBytes = source.LengthBytes,
+        Title = source.Title,
+        Author = source.Author,
+        Subject = source.Subject,
+        Keywords = source.Keywords
+    };
+
+    private sealed class ChunkingState {
+        private readonly HashSet<string> _diagnosticCodes = new HashSet<string>(StringComparer.Ordinal);
+
+        internal ChunkingState(ReaderHierarchicalChunkingOptions options, CancellationToken cancellationToken) {
+            Options = options;
+            CancellationToken = cancellationToken;
+            TokenCounterId = options.TokenCounter.Id;
+        }
+
+        internal ReaderHierarchicalChunkingOptions Options { get; }
+        internal CancellationToken CancellationToken { get; }
+        internal string TokenCounterId { get; }
+        internal List<ReaderChunk> Chunks { get; } = new List<ReaderChunk>();
+        internal List<ReaderChunkSegment> Segments { get; } = new List<ReaderChunkSegment>();
+        internal List<OfficeDocumentDiagnostic> Diagnostics { get; } = new List<OfficeDocumentDiagnostic>();
+        internal long SourceTokenCount { get; set; }
+        internal long OutputTokenCount { get; set; }
+        internal long OverlapTokenCount { get; set; }
+        internal long ContextTokenCount { get; set; }
+        internal bool OutputLimitReached { get; set; }
+        internal string? SourceIdentity { get; set; }
+
+        internal void AddSourceChunk(ReaderChunk source, int inputIndex) {
+            string? sourcePath = source.Location?.Path;
+            string? sourceIdentity = !string.IsNullOrWhiteSpace(source.SourceId)
+                ? "id:" + source.SourceId
+                : !string.IsNullOrWhiteSpace(sourcePath)
+                    ? "path:" + sourcePath
+                    : null;
+            if (SourceIdentity == null) SourceIdentity = sourceIdentity;
+            else if (sourceIdentity != null && !string.Equals(SourceIdentity, sourceIdentity, StringComparison.Ordinal)) {
+                throw new InvalidOperationException("One chunk hierarchy cannot contain chunks from multiple source documents.");
+            }
+            SplitSourceChunk(source, inputIndex, this);
+        }
+
+        internal void AddLimitDiagnostic(string code, int limit, string target) {
+            if (!_diagnosticCodes.Add(code)) return;
+            Diagnostics.Add(new OfficeDocumentDiagnostic {
+                Severity = OfficeDocumentDiagnosticSeverity.Warning,
+                Category = OfficeDocumentDiagnosticCategory.Limit,
+                Code = code,
+                Message = $"Hierarchical chunking reached the configured {target} limit ({limit.ToString(CultureInfo.InvariantCulture)}).",
+                Source = "officeimo.reader.hierarchical-chunker",
+                IsRecoverable = true,
+                Attributes = new SortedDictionary<string, string>(StringComparer.Ordinal) {
+                    ["limit"] = limit.ToString(CultureInfo.InvariantCulture),
+                    ["target"] = target
+                }
+            });
+        }
+
+        internal void AddDiagnostic(string code, string message) {
+            if (!_diagnosticCodes.Add(code)) return;
+            Diagnostics.Add(new OfficeDocumentDiagnostic {
+                Severity = OfficeDocumentDiagnosticSeverity.Warning,
+                Category = OfficeDocumentDiagnosticCategory.General,
+                Code = code,
+                Message = message,
+                Source = "officeimo.reader.hierarchical-chunker",
+                IsRecoverable = true
+            });
+        }
+    }
+}

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.cs
@@ -55,9 +55,7 @@ public static partial class ReaderHierarchicalChunker {
             inputIndex++;
         }
 
-        OfficeDocumentSource effectiveSource = HasSourceIdentity(sourceInfo)
-            ? sourceInfo
-            : InferSource(state.Chunks);
+        OfficeDocumentSource effectiveSource = ResolveSource(sourceInfo, state.Chunks);
         IReadOnlyList<ReaderChunkHierarchyNode> nodes = BuildHierarchy(state, effectiveSource);
         return new ReaderChunkHierarchyResult {
             Source = CloneSource(effectiveSource),
@@ -102,21 +100,25 @@ public static partial class ReaderHierarchicalChunker {
             yield break;
         }
 
-        var headings = new List<KeyValuePair<int, string>>();
+        var headings = new List<FallbackHeading>();
         int index = 0;
         foreach (FallbackBlock fallback in EnumerateFallbackBlocks(document)) {
             OfficeDocumentBlock block = fallback.Block;
             string text = block.Text ?? string.Empty;
             bool isHeading = string.Equals(block.Kind?.Trim(), "heading", StringComparison.OrdinalIgnoreCase);
-            if (isHeading) UpdateFallbackHeadings(headings, block.Level ?? 1, text);
             ReaderLocation location = CloneLocation(block.Location);
             InheritPageLocation(location, fallback.Page);
             location.Path ??= document.Source?.Path;
             location.SourceBlockIndex ??= index;
             location.SourceBlockKind ??= block.Kind;
             location.BlockAnchor ??= string.IsNullOrWhiteSpace(block.Id) ? "block-" + index.ToString(CultureInfo.InvariantCulture) : block.Id;
-            location.HeadingPath ??= BuildFallbackHeadingPath(headings);
-            if (isHeading) location.HeadingSlug ??= string.IsNullOrWhiteSpace(block.Id) ? null : block.Id;
+            if (isHeading) UpdateFallbackHeadings(headings, block.Level ?? 1, text, location.BlockAnchor);
+            if (string.IsNullOrWhiteSpace(location.HeadingPath)) {
+                location.HeadingPath = BuildFallbackHeadingPath(headings);
+                location.HeadingSlug ??= BuildFallbackHeadingSlug(headings);
+            } else if (isHeading) {
+                location.HeadingSlug ??= location.BlockAnchor;
+            }
             string sourceIdentity = document.Source?.SourceId ?? document.Source?.Path ?? string.Empty;
             yield return new ReaderChunk {
                 Id = "block:" + ComputeSha256Hex(sourceIdentity + "|" + block.Id + "|" + index.ToString(CultureInfo.InvariantCulture)),
@@ -147,15 +149,32 @@ public static partial class ReaderHierarchicalChunker {
 
     private static IEnumerable<FallbackBlock> EnumerateFallbackBlocks(OfficeDocumentReadResult document) {
         var seen = new HashSet<OfficeDocumentBlock>(ReferenceIdentityComparer<OfficeDocumentBlock>.Instance);
+        IReadOnlyList<OfficeDocumentPage> pages = document.Pages ?? Array.Empty<OfficeDocumentPage>();
+        IReadOnlyDictionary<OfficeDocumentBlock, OfficeDocumentPage> pageByBlock = IndexPageBlocks(pages);
         foreach (OfficeDocumentBlock block in document.Blocks ?? Array.Empty<OfficeDocumentBlock>()) {
-            if (block != null && seen.Add(block)) yield return new FallbackBlock(block, null);
+            if (block == null || !seen.Add(block)) continue;
+            pageByBlock.TryGetValue(block, out OfficeDocumentPage? page);
+            yield return new FallbackBlock(block, page);
         }
-        foreach (OfficeDocumentPage page in document.Pages ?? Array.Empty<OfficeDocumentPage>()) {
+        foreach (OfficeDocumentPage page in pages) {
             if (page?.Blocks == null) continue;
             foreach (OfficeDocumentBlock block in page.Blocks) {
                 if (block != null && seen.Add(block)) yield return new FallbackBlock(block, page);
             }
         }
+    }
+
+    private static IReadOnlyDictionary<OfficeDocumentBlock, OfficeDocumentPage> IndexPageBlocks(
+        IReadOnlyList<OfficeDocumentPage> pages) {
+        var pageByBlock = new Dictionary<OfficeDocumentBlock, OfficeDocumentPage>(
+            ReferenceIdentityComparer<OfficeDocumentBlock>.Instance);
+        foreach (OfficeDocumentPage page in pages) {
+            if (page?.Blocks == null) continue;
+            foreach (OfficeDocumentBlock block in page.Blocks) {
+                if (block != null && !pageByBlock.ContainsKey(block)) pageByBlock.Add(block, page);
+            }
+        }
+        return pageByBlock;
     }
 
     private static ReaderChunk InheritDocumentSource(ReaderChunk chunk, OfficeDocumentSource? source) {
@@ -194,29 +213,60 @@ public static partial class ReaderHierarchicalChunker {
         location.Sheet ??= container.Sheet;
         location.A1Range ??= container.A1Range;
         location.Slide ??= container.Slide;
-        location.Page ??= page.Number > 0 ? page.Number : container.Page;
+        if (!location.Page.HasValue &&
+            !location.Slide.HasValue &&
+            string.IsNullOrWhiteSpace(location.Sheet)) {
+            int? number = page.Number > 0 ? page.Number : container.Page;
+            if (string.Equals(container.SourceBlockKind?.Trim(), "slide", StringComparison.OrdinalIgnoreCase)) {
+                location.Slide = number;
+            } else {
+                location.Page = number;
+            }
+        }
     }
 
-    private static void UpdateFallbackHeadings(List<KeyValuePair<int, string>> headings, int level, string text) {
+    private static void UpdateFallbackHeadings(
+        List<FallbackHeading> headings,
+        int level,
+        string text,
+        string? slug) {
         int effectiveLevel = Math.Max(1, level);
         for (int index = headings.Count - 1; index >= 0; index--) {
-            if (headings[index].Key >= effectiveLevel) headings.RemoveAt(index);
+            if (headings[index].Level >= effectiveLevel) headings.RemoveAt(index);
         }
         string title = string.IsNullOrWhiteSpace(text)
             ? "Heading " + effectiveLevel.ToString(CultureInfo.InvariantCulture)
             : text.Trim();
-        headings.Add(new KeyValuePair<int, string>(effectiveLevel, title));
+        headings.Add(new FallbackHeading(effectiveLevel, title, slug));
     }
 
-    private static string? BuildFallbackHeadingPath(IReadOnlyList<KeyValuePair<int, string>> headings) {
+    private static string? BuildFallbackHeadingPath(IReadOnlyList<FallbackHeading> headings) {
         if (headings.Count == 0) return null;
-        return string.Join(" > ", headings.Select(heading => heading.Value));
+        return string.Join(" > ", headings.Select(heading => heading.Title));
     }
 
-    private static bool HasSourceIdentity(OfficeDocumentSource source) =>
-        !string.IsNullOrWhiteSpace(source.SourceId) ||
-        !string.IsNullOrWhiteSpace(source.Path) ||
-        !string.IsNullOrWhiteSpace(source.Title);
+    private static string? BuildFallbackHeadingSlug(IReadOnlyList<FallbackHeading> headings) =>
+        headings.Count == 0 ? null : headings[headings.Count - 1].Slug;
+
+    private static OfficeDocumentSource ResolveSource(
+        OfficeDocumentSource source,
+        IReadOnlyList<ReaderChunk> chunks) {
+        OfficeDocumentSource inferred = InferSource(chunks);
+        return new OfficeDocumentSource {
+            Path = PreferSourceValue(source.Path, inferred.Path),
+            SourceId = PreferSourceValue(source.SourceId, inferred.SourceId),
+            SourceHash = PreferSourceValue(source.SourceHash, inferred.SourceHash),
+            LastWriteUtc = source.LastWriteUtc ?? inferred.LastWriteUtc,
+            LengthBytes = source.LengthBytes ?? inferred.LengthBytes,
+            Title = source.Title,
+            Author = source.Author,
+            Subject = source.Subject,
+            Keywords = source.Keywords
+        };
+    }
+
+    private static string? PreferSourceValue(string? preferred, string? fallback) =>
+        !string.IsNullOrWhiteSpace(preferred) ? preferred : fallback;
 
     private static OfficeDocumentSource InferSource(IReadOnlyList<ReaderChunk> chunks) {
         if (chunks.Count == 0) return new OfficeDocumentSource();
@@ -331,5 +381,17 @@ public static partial class ReaderHierarchicalChunker {
 
         internal OfficeDocumentBlock Block { get; }
         internal OfficeDocumentPage? Page { get; }
+    }
+
+    private readonly struct FallbackHeading {
+        internal FallbackHeading(int level, string title, string? slug) {
+            Level = level;
+            Title = title;
+            Slug = slug;
+        }
+
+        internal int Level { get; }
+        internal string Title { get; }
+        internal string? Slug { get; }
     }
 }

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.cs
@@ -40,11 +40,11 @@ public static partial class ReaderHierarchicalChunker {
         using IEnumerator<ReaderChunk> enumerator = source.GetEnumerator();
         while (!state.OutputLimitReached) {
             cancellationToken.ThrowIfCancellationRequested();
+            if (!enumerator.MoveNext()) break;
             if (inputIndex >= options.MaxInputChunks) {
                 state.AddLimitDiagnostic("hierarchical-input-chunk-limit", options.MaxInputChunks, "input chunks");
                 break;
             }
-            if (!enumerator.MoveNext()) break;
             ReaderChunk? chunk = enumerator.Current;
             if (chunk == null) {
                 state.AddDiagnostic("hierarchical-null-input-chunk", "A null input chunk was skipped.");
@@ -149,19 +149,31 @@ public static partial class ReaderHierarchicalChunker {
 
     private static IEnumerable<FallbackBlock> EnumerateFallbackBlocks(OfficeDocumentReadResult document) {
         var seen = new HashSet<OfficeDocumentBlock>(ReferenceIdentityComparer<OfficeDocumentBlock>.Instance);
+        var seenIds = new HashSet<string>(StringComparer.Ordinal);
         IReadOnlyList<OfficeDocumentPage> pages = document.Pages ?? Array.Empty<OfficeDocumentPage>();
         IReadOnlyDictionary<OfficeDocumentBlock, OfficeDocumentPage> pageByBlock = IndexPageBlocks(pages);
+        IReadOnlyDictionary<string, OfficeDocumentPage> pageByBlockId = IndexPageBlockIds(pages);
         foreach (OfficeDocumentBlock block in document.Blocks ?? Array.Empty<OfficeDocumentBlock>()) {
-            if (block == null || !seen.Add(block)) continue;
-            pageByBlock.TryGetValue(block, out OfficeDocumentPage? page);
+            if (!TryRegisterFallbackBlock(block, seen, seenIds)) continue;
+            if (!pageByBlock.TryGetValue(block, out OfficeDocumentPage? page) && !string.IsNullOrWhiteSpace(block.Id)) {
+                pageByBlockId.TryGetValue(block.Id!, out page);
+            }
             yield return new FallbackBlock(block, page);
         }
         foreach (OfficeDocumentPage page in pages) {
             if (page?.Blocks == null) continue;
             foreach (OfficeDocumentBlock block in page.Blocks) {
-                if (block != null && seen.Add(block)) yield return new FallbackBlock(block, page);
+                if (TryRegisterFallbackBlock(block, seen, seenIds)) yield return new FallbackBlock(block, page);
             }
         }
+    }
+
+    private static bool TryRegisterFallbackBlock(
+        OfficeDocumentBlock? block,
+        ISet<OfficeDocumentBlock> seen,
+        ISet<string> seenIds) {
+        if (block == null || !seen.Add(block)) return false;
+        return string.IsNullOrWhiteSpace(block.Id) || seenIds.Add(block.Id!);
     }
 
     private static IReadOnlyDictionary<OfficeDocumentBlock, OfficeDocumentPage> IndexPageBlocks(
@@ -175,6 +187,20 @@ public static partial class ReaderHierarchicalChunker {
             }
         }
         return pageByBlock;
+    }
+
+    private static IReadOnlyDictionary<string, OfficeDocumentPage> IndexPageBlockIds(
+        IReadOnlyList<OfficeDocumentPage> pages) {
+        var pageByBlockId = new Dictionary<string, OfficeDocumentPage>(StringComparer.Ordinal);
+        foreach (OfficeDocumentPage page in pages) {
+            if (page?.Blocks == null) continue;
+            foreach (OfficeDocumentBlock block in page.Blocks) {
+                if (block != null && !string.IsNullOrWhiteSpace(block.Id) && !pageByBlockId.ContainsKey(block.Id!)) {
+                    pageByBlockId.Add(block.Id!, page);
+                }
+            }
+        }
+        return pageByBlockId;
     }
 
     private static ReaderChunk InheritDocumentSource(ReaderChunk chunk, OfficeDocumentSource? source) {
@@ -213,11 +239,19 @@ public static partial class ReaderHierarchicalChunker {
         location.Sheet ??= container.Sheet;
         location.A1Range ??= container.A1Range;
         location.Slide ??= container.Slide;
+        string? containerKind = container.SourceBlockKind?.Trim();
+        if (string.Equals(containerKind, "sheet", StringComparison.OrdinalIgnoreCase)) {
+            location.Sheet ??= !string.IsNullOrWhiteSpace(page.Name)
+                ? page.Name
+                : page.Number > 0
+                    ? "Sheet " + page.Number.Value.ToString(CultureInfo.InvariantCulture)
+                    : null;
+        }
         if (!location.Page.HasValue &&
             !location.Slide.HasValue &&
             string.IsNullOrWhiteSpace(location.Sheet)) {
             int? number = page.Number > 0 ? page.Number : container.Page;
-            if (string.Equals(container.SourceBlockKind?.Trim(), "slide", StringComparison.OrdinalIgnoreCase)) {
+            if (string.Equals(containerKind, "slide", StringComparison.OrdinalIgnoreCase)) {
                 location.Slide = number;
             } else {
                 location.Page = number;
@@ -241,8 +275,7 @@ public static partial class ReaderHierarchicalChunker {
     }
 
     private static string? BuildFallbackHeadingPath(IReadOnlyList<FallbackHeading> headings) {
-        if (headings.Count == 0) return null;
-        return string.Join(" > ", headings.Select(heading => heading.Title));
+        return ReaderHeadingPath.Combine(headings.Select(heading => heading.Title));
     }
 
     private static string? BuildFallbackHeadingSlug(IReadOnlyList<FallbackHeading> headings) =>

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.cs
@@ -212,25 +212,27 @@ public static partial class ReaderHierarchicalChunker {
     }
 
     private static ReaderChunk InheritDocumentSource(ReaderChunk chunk, OfficeDocumentSource? source) {
-        if (source == null ||
-            (string.IsNullOrWhiteSpace(source.SourceId) && string.IsNullOrWhiteSpace(source.Path))) {
-            return chunk;
-        }
+        if (source == null) return chunk;
         bool inheritSourceId = string.IsNullOrWhiteSpace(chunk.SourceId) && !string.IsNullOrWhiteSpace(source.SourceId);
         bool inheritPath = string.IsNullOrWhiteSpace(chunk.Location?.Path) && !string.IsNullOrWhiteSpace(source.Path);
-        if (!inheritSourceId && !inheritPath) return chunk;
+        bool inheritSourceHash = string.IsNullOrWhiteSpace(chunk.SourceHash) && !string.IsNullOrWhiteSpace(source.SourceHash);
+        bool inheritLastWriteUtc = !chunk.SourceLastWriteUtc.HasValue && source.LastWriteUtc.HasValue;
+        bool inheritLengthBytes = !chunk.SourceLengthBytes.HasValue && source.LengthBytes.HasValue;
+        if (!inheritSourceId && !inheritPath && !inheritSourceHash && !inheritLastWriteUtc && !inheritLengthBytes) {
+            return chunk;
+        }
 
         ReaderLocation location = CloneLocation(chunk.Location);
-        location.Path ??= source.Path;
+        if (inheritPath) location.Path = source.Path;
         return new ReaderChunk {
             Id = chunk.Id,
             Kind = chunk.Kind,
             Location = location,
             SourceId = inheritSourceId ? source.SourceId : chunk.SourceId,
-            SourceHash = chunk.SourceHash ?? source.SourceHash,
+            SourceHash = inheritSourceHash ? source.SourceHash : chunk.SourceHash,
             ChunkHash = chunk.ChunkHash,
-            SourceLastWriteUtc = chunk.SourceLastWriteUtc ?? source.LastWriteUtc,
-            SourceLengthBytes = chunk.SourceLengthBytes ?? source.LengthBytes,
+            SourceLastWriteUtc = inheritLastWriteUtc ? source.LastWriteUtc : chunk.SourceLastWriteUtc,
+            SourceLengthBytes = inheritLengthBytes ? source.LengthBytes : chunk.SourceLengthBytes,
             TokenEstimate = chunk.TokenEstimate,
             Text = chunk.Text,
             Markdown = chunk.Markdown,

--- a/OfficeIMO.Reader/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunker.cs
@@ -95,24 +95,31 @@ public static partial class ReaderHierarchicalChunker {
     private static IEnumerable<ReaderChunk> GetSourceChunks(OfficeDocumentReadResult document) {
         IReadOnlyList<ReaderChunk> chunks = document.Chunks ?? Array.Empty<ReaderChunk>();
         if (chunks.Count > 0) {
-            for (int chunkIndex = 0; chunkIndex < chunks.Count; chunkIndex++) yield return chunks[chunkIndex];
+            for (int chunkIndex = 0; chunkIndex < chunks.Count; chunkIndex++) {
+                ReaderChunk? chunk = chunks[chunkIndex];
+                yield return chunk == null ? null! : InheritDocumentSource(chunk, document.Source);
+            }
             yield break;
         }
 
         var headings = new List<KeyValuePair<int, string>>();
         int index = 0;
-        foreach (OfficeDocumentBlock block in OfficeDocumentModelTraversal.Blocks(document)) {
+        foreach (FallbackBlock fallback in EnumerateFallbackBlocks(document)) {
+            OfficeDocumentBlock block = fallback.Block;
             string text = block.Text ?? string.Empty;
             bool isHeading = string.Equals(block.Kind?.Trim(), "heading", StringComparison.OrdinalIgnoreCase);
             if (isHeading) UpdateFallbackHeadings(headings, block.Level ?? 1, text);
             ReaderLocation location = CloneLocation(block.Location);
+            InheritPageLocation(location, fallback.Page);
+            location.Path ??= document.Source?.Path;
             location.SourceBlockIndex ??= index;
             location.SourceBlockKind ??= block.Kind;
             location.BlockAnchor ??= string.IsNullOrWhiteSpace(block.Id) ? "block-" + index.ToString(CultureInfo.InvariantCulture) : block.Id;
             location.HeadingPath ??= BuildFallbackHeadingPath(headings);
             if (isHeading) location.HeadingSlug ??= string.IsNullOrWhiteSpace(block.Id) ? null : block.Id;
+            string sourceIdentity = document.Source?.SourceId ?? document.Source?.Path ?? string.Empty;
             yield return new ReaderChunk {
-                Id = "block:" + ComputeSha256Hex((document.Source?.SourceId ?? string.Empty) + "|" + block.Id + "|" + index.ToString(CultureInfo.InvariantCulture)),
+                Id = "block:" + ComputeSha256Hex(sourceIdentity + "|" + block.Id + "|" + index.ToString(CultureInfo.InvariantCulture)),
                 Kind = document.Kind,
                 Location = location,
                 SourceId = document.Source?.SourceId,
@@ -136,6 +143,58 @@ public static partial class ReaderHierarchicalChunker {
                 Markdown = document.Markdown
             };
         }
+    }
+
+    private static IEnumerable<FallbackBlock> EnumerateFallbackBlocks(OfficeDocumentReadResult document) {
+        var seen = new HashSet<OfficeDocumentBlock>(ReferenceIdentityComparer<OfficeDocumentBlock>.Instance);
+        foreach (OfficeDocumentBlock block in document.Blocks ?? Array.Empty<OfficeDocumentBlock>()) {
+            if (block != null && seen.Add(block)) yield return new FallbackBlock(block, null);
+        }
+        foreach (OfficeDocumentPage page in document.Pages ?? Array.Empty<OfficeDocumentPage>()) {
+            if (page?.Blocks == null) continue;
+            foreach (OfficeDocumentBlock block in page.Blocks) {
+                if (block != null && seen.Add(block)) yield return new FallbackBlock(block, page);
+            }
+        }
+    }
+
+    private static ReaderChunk InheritDocumentSource(ReaderChunk chunk, OfficeDocumentSource? source) {
+        if (GetSourceIdentity(chunk) != null || source == null ||
+            (string.IsNullOrWhiteSpace(source.SourceId) && string.IsNullOrWhiteSpace(source.Path))) {
+            return chunk;
+        }
+
+        ReaderLocation location = CloneLocation(chunk.Location);
+        location.Path ??= source.Path;
+        return new ReaderChunk {
+            Id = chunk.Id,
+            Kind = chunk.Kind,
+            Location = location,
+            SourceId = source.SourceId,
+            SourceHash = chunk.SourceHash ?? source.SourceHash,
+            ChunkHash = chunk.ChunkHash,
+            SourceLastWriteUtc = chunk.SourceLastWriteUtc ?? source.LastWriteUtc,
+            SourceLengthBytes = chunk.SourceLengthBytes ?? source.LengthBytes,
+            TokenEstimate = chunk.TokenEstimate,
+            Text = chunk.Text,
+            Markdown = chunk.Markdown,
+            Tables = chunk.Tables,
+            Visuals = chunk.Visuals,
+            FormFields = chunk.FormFields,
+            Actions = chunk.Actions,
+            Diagnostics = chunk.Diagnostics,
+            Warnings = chunk.Warnings
+        };
+    }
+
+    private static void InheritPageLocation(ReaderLocation location, OfficeDocumentPage? page) {
+        if (page == null) return;
+        ReaderLocation container = page.Location ?? new ReaderLocation();
+        location.Path ??= container.Path;
+        location.Sheet ??= container.Sheet;
+        location.A1Range ??= container.A1Range;
+        location.Slide ??= container.Slide;
+        location.Page ??= page.Number > 0 ? page.Number : container.Page;
     }
 
     private static void UpdateFallbackHeadings(List<KeyValuePair<int, string>> headings, int level, string text) {
@@ -262,5 +321,15 @@ public static partial class ReaderHierarchicalChunker {
             : !string.IsNullOrWhiteSpace(sourcePath)
                 ? "path:" + sourcePath
                 : null;
+    }
+
+    private readonly struct FallbackBlock {
+        internal FallbackBlock(OfficeDocumentBlock block, OfficeDocumentPage? page) {
+            Block = block;
+            Page = page;
+        }
+
+        internal OfficeDocumentBlock Block { get; }
+        internal OfficeDocumentPage? Page { get; }
     }
 }

--- a/OfficeIMO.Reader/ReaderHierarchicalChunkingModels.cs
+++ b/OfficeIMO.Reader/ReaderHierarchicalChunkingModels.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>Schema identifiers for the independently versioned hierarchical chunking result.</summary>
+public static class ReaderChunkHierarchySchema {
+    /// <summary>Schema identifier.</summary>
+    public const string Id = "officeimo.reader.chunk-hierarchy";
+
+    /// <summary>Current schema version.</summary>
+    public const int Version = 1;
+}
+
+/// <summary>Options for bounded, token-aware hierarchical chunking.</summary>
+public sealed class ReaderHierarchicalChunkingOptions {
+    /// <summary>Maximum tokens in each output chunk, including optional context. Default: 800.</summary>
+    public int MaxTokens { get; set; } = 800;
+
+    /// <summary>Maximum content tokens repeated from the previous segment. Default: 80.</summary>
+    public int OverlapTokens { get; set; } = 80;
+
+    /// <summary>Maximum source chunks inspected. Default: 10,000.</summary>
+    public int MaxInputChunks { get; set; } = 10_000;
+
+    /// <summary>Maximum output chunks emitted. Default: 50,000.</summary>
+    public int MaxOutputChunks { get; set; } = 50_000;
+
+    /// <summary>Maximum container and heading hierarchy depth below the document root. Default: 32.</summary>
+    public int MaxHierarchyDepth { get; set; } = 32;
+
+    /// <summary>Maximum characters retained in one hierarchy breadcrumb or title. Default: 4,096.</summary>
+    public int MaxContextCharacters { get; set; } = 4_096;
+
+    /// <summary>Prefer a source chunk's Markdown over plain text when available. Default: true.</summary>
+    public bool PreferMarkdown { get; set; } = true;
+
+    /// <summary>Prefix output text with its container and heading breadcrumb when it fits the token budget. Default: true.</summary>
+    public bool IncludeContextInText { get; set; } = true;
+
+    /// <summary>Token counter. Defaults to the dependency-free OfficeIMO heuristic.</summary>
+    public IReaderTokenCounter TokenCounter { get; set; } = ReaderHeuristicTokenCounter.Instance;
+
+    internal ReaderHierarchicalChunkingOptions Clone() => new ReaderHierarchicalChunkingOptions {
+        MaxTokens = MaxTokens,
+        OverlapTokens = OverlapTokens,
+        MaxInputChunks = MaxInputChunks,
+        MaxOutputChunks = MaxOutputChunks,
+        MaxHierarchyDepth = MaxHierarchyDepth,
+        MaxContextCharacters = MaxContextCharacters,
+        PreferMarkdown = PreferMarkdown,
+        IncludeContextInText = IncludeContextInText,
+        TokenCounter = TokenCounter
+    };
+}
+
+/// <summary>Kind of one node in a flattened chunk hierarchy.</summary>
+public enum ReaderChunkHierarchyNodeKind {
+    /// <summary>Document root.</summary>
+    Document = 0,
+    /// <summary>Page, slide, or sheet container.</summary>
+    Container,
+    /// <summary>Logical heading level.</summary>
+    Heading,
+    /// <summary>Leaf pointing to one output chunk.</summary>
+    Chunk
+}
+
+/// <summary>One node in a deterministic flattened hierarchy.</summary>
+public sealed class ReaderChunkHierarchyNode {
+    /// <summary>Deterministic node identifier.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Parent node identifier, or null for the document root.</summary>
+    public string? ParentNodeId { get; set; }
+
+    /// <summary>Node kind.</summary>
+    public ReaderChunkHierarchyNodeKind Kind { get; set; }
+
+    /// <summary>Human-readable title.</summary>
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>Hierarchy depth, with the root at zero.</summary>
+    public int Depth { get; set; }
+
+    /// <summary>Breadcrumb from the root to this node.</summary>
+    public string Path { get; set; } = string.Empty;
+
+    /// <summary>Output tokens in this node and all descendants.</summary>
+    public long TokenCount { get; set; }
+
+    /// <summary>Child node identifiers in source order.</summary>
+    public IReadOnlyList<string> ChildNodeIds { get; set; } = Array.Empty<string>();
+
+    /// <summary>Output chunk identifier for a leaf node.</summary>
+    public string? ChunkId { get; set; }
+}
+
+/// <summary>Exact source-span and token evidence for one output chunk.</summary>
+public sealed class ReaderChunkSegment {
+    /// <summary>Output chunk identifier.</summary>
+    public string ChunkId { get; set; } = string.Empty;
+
+    /// <summary>Source chunk identifier.</summary>
+    public string SourceChunkId { get; set; } = string.Empty;
+
+    /// <summary>Zero-based segment index within the source chunk.</summary>
+    public int SegmentIndex { get; set; }
+
+    /// <summary>Inclusive character offset in the selected source representation.</summary>
+    public int StartCharacter { get; set; }
+
+    /// <summary>Exclusive character offset in the selected source representation.</summary>
+    public int EndCharacter { get; set; }
+
+    /// <summary>Characters repeated from the previous segment.</summary>
+    public int OverlapCharacterCount { get; set; }
+
+    /// <summary>Repeated content tokens from the previous segment.</summary>
+    public int OverlapTokenCount { get; set; }
+
+    /// <summary>Tokens contributed by source content.</summary>
+    public int ContentTokenCount { get; set; }
+
+    /// <summary>Tokens contributed by the optional hierarchy prefix.</summary>
+    public int ContextTokenCount { get; set; }
+
+    /// <summary>Total tokens in the output chunk.</summary>
+    public int TokenCount { get; set; }
+
+    /// <summary>Container and heading breadcrumb available to retrieval hosts.</summary>
+    public string? Context { get; set; }
+}
+
+/// <summary>Bounded token-aware chunks plus their deterministic hierarchy and evidence.</summary>
+public sealed class ReaderChunkHierarchyResult {
+    /// <summary>Hierarchy schema identifier.</summary>
+    public string SchemaId { get; set; } = ReaderChunkHierarchySchema.Id;
+
+    /// <summary>Hierarchy schema version.</summary>
+    public int SchemaVersion { get; set; } = ReaderChunkHierarchySchema.Version;
+
+    /// <summary>Source document metadata.</summary>
+    public OfficeDocumentSource Source { get; set; } = new OfficeDocumentSource();
+
+    /// <summary>Token counter identifier.</summary>
+    public string TokenCounterId { get; set; } = string.Empty;
+
+    /// <summary>Document root node identifier.</summary>
+    public string RootNodeId { get; set; } = string.Empty;
+
+    /// <summary>Original source tokens before overlap and hierarchy context.</summary>
+    public long SourceTokenCount { get; set; }
+
+    /// <summary>Total tokens emitted across output chunks.</summary>
+    public long OutputTokenCount { get; set; }
+
+    /// <summary>Total repeated overlap tokens across output chunks.</summary>
+    public long OverlapTokenCount { get; set; }
+
+    /// <summary>Total hierarchy-context tokens added to output chunks.</summary>
+    public long ContextTokenCount { get; set; }
+
+    /// <summary>Embedding-ready leaf chunks in source order.</summary>
+    public IReadOnlyList<ReaderChunk> Chunks { get; set; } = Array.Empty<ReaderChunk>();
+
+    /// <summary>Source span and token evidence aligned to <see cref="Chunks"/>.</summary>
+    public IReadOnlyList<ReaderChunkSegment> Segments { get; set; } = Array.Empty<ReaderChunkSegment>();
+
+    /// <summary>Flattened hierarchy nodes with explicit parent/child ids.</summary>
+    public IReadOnlyList<ReaderChunkHierarchyNode> Nodes { get; set; } = Array.Empty<ReaderChunkHierarchyNode>();
+
+    /// <summary>Limit and content diagnostics produced during chunking.</summary>
+    public IReadOnlyList<OfficeDocumentDiagnostic> Diagnostics { get; set; } = Array.Empty<OfficeDocumentDiagnostic>();
+}

--- a/OfficeIMO.Reader/ReaderModels.cs
+++ b/OfficeIMO.Reader/ReaderModels.cs
@@ -391,6 +391,12 @@ public sealed class ReaderLocation {
     public string? HeadingPath { get; set; }
 
     /// <summary>
+    /// Escaped heading path used internally by hierarchy projections. Normal Reader output keeps
+    /// <see cref="HeadingPath"/> as the original display value.
+    /// </summary>
+    internal string? HierarchyHeadingPath { get; set; }
+
+    /// <summary>
     /// Optional unique slug/anchor for the active heading section.
     /// </summary>
     public string? HeadingSlug { get; set; }

--- a/OfficeIMO.Reader/ReaderModels.cs
+++ b/OfficeIMO.Reader/ReaderModels.cs
@@ -396,6 +396,9 @@ public sealed class ReaderLocation {
     /// </summary>
     internal string? HierarchyHeadingPath { get; set; }
 
+    /// <summary>Display-path snapshot associated with <see cref="HierarchyHeadingPath"/>.</summary>
+    internal string? HierarchyHeadingDisplayPath { get; set; }
+
     /// <summary>
     /// Optional unique slug/anchor for the active heading section.
     /// </summary>

--- a/OfficeIMO.Reader/ReaderModels.cs
+++ b/OfficeIMO.Reader/ReaderModels.cs
@@ -391,10 +391,11 @@ public sealed class ReaderLocation {
     public string? HeadingPath { get; set; }
 
     /// <summary>
-    /// Escaped heading path used internally by hierarchy projections. Normal Reader output keeps
-    /// <see cref="HeadingPath"/> as the original display value.
+    /// Escaped heading path used by hierarchy projections. Normal Reader output keeps
+    /// <see cref="HeadingPath"/> as the original display value. This value is transported so a
+    /// serialized read result can reproduce the same hierarchy as the in-memory result.
     /// </summary>
-    internal string? HierarchyHeadingPath { get; set; }
+    public string? HierarchyHeadingPath { get; set; }
 
     /// <summary>Display-path snapshot associated with <see cref="HierarchyHeadingPath"/>.</summary>
     internal string? HierarchyHeadingDisplayPath { get; set; }

--- a/OfficeIMO.Reader/ReaderTokenCounters.cs
+++ b/OfficeIMO.Reader/ReaderTokenCounters.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>Counts tokens for deterministic chunk budgeting.</summary>
+/// <remarks>
+/// Implementations used concurrently must be thread-safe. Counts must be deterministic and non-negative.
+/// </remarks>
+public interface IReaderTokenCounter {
+    /// <summary>Stable counter identifier retained in chunking evidence.</summary>
+    string Id { get; }
+
+    /// <summary>Counts tokens in the supplied text.</summary>
+    int CountTokens(string text);
+}
+
+/// <summary>Dependency-free token estimate using approximately four characters per token.</summary>
+public sealed class ReaderHeuristicTokenCounter : IReaderTokenCounter {
+    private ReaderHeuristicTokenCounter() {
+    }
+
+    /// <summary>Shared stateless instance.</summary>
+    public static ReaderHeuristicTokenCounter Instance { get; } = new ReaderHeuristicTokenCounter();
+
+    /// <inheritdoc />
+    public string Id => "officeimo.reader.heuristic-v1";
+
+    /// <inheritdoc />
+    public int CountTokens(string text) {
+        if (string.IsNullOrEmpty(text)) return 0;
+        return Math.Max(1, (text.Length + 3) / 4);
+    }
+}


### PR DESCRIPTION
## Summary

- add configurable token counters with hard token-aware chunk and overlap limits
- project deterministic document, container, heading, and leaf nodes for retrieval pipelines
- preserve page, slide, sheet, source, provenance, and repeated-heading identity
- keep normal Reader heading paths as display text while transporting collision-safe hierarchy paths
- keep hierarchy identity deterministic across depth limits, serialization, processors, and virtual EPUB chapters
- expose the capability through static and instance Reader APIs with stable JSON output
- extend Reader benchmark coverage for hierarchical chunking

## Why it matters

Reader output can now feed retrieval and RAG pipelines with bounded leaves while retaining enough source hierarchy and citation metadata to reconstruct context safely.

## Validation

- full Reader suite: 508/508 on .NET 8 and 508/508 on .NET 10
- focused hierarchy/transport regressions: 6/6 on .NET 8 and .NET 10
- production Reader build: netstandard2.0, zero warnings and zero errors
- GitHub Actions: 30/30 checks passed
- all inline review threads resolved; delayed post-push sweep clean

## Series

Track 2 of the Reader maturity series. Previous: #2051. Next: #2053.
