### PR TITLE
Add rich Reader format mappings

### DIFF
--- a/OfficeIMO.Epub/EpubDocument.cs
+++ b/OfficeIMO.Epub/EpubDocument.cs
@@ -35,6 +35,11 @@ public sealed class EpubDocument {
     public IReadOnlyList<EpubChapter> Chapters { get; set; } = Array.Empty<EpubChapter>();
 
     /// <summary>
+    /// OPF manifest resources in deterministic package order.
+    /// </summary>
+    public IReadOnlyList<EpubResource> Resources { get; set; } = Array.Empty<EpubResource>();
+
+    /// <summary>
     /// Non-fatal warnings encountered during extraction.
     /// </summary>
     public IReadOnlyList<string> Warnings { get; set; } = Array.Empty<string>();

--- a/OfficeIMO.Epub/EpubReadOptions.cs
+++ b/OfficeIMO.Epub/EpubReadOptions.cs
@@ -20,6 +20,20 @@ public sealed class EpubReadOptions {
     public bool IncludeRawHtml { get; set; }
 
     /// <summary>
+    /// When true, includes bounded manifest resource payloads.
+    /// </summary>
+    public bool IncludeResourceData { get; set; }
+
+    /// <summary>Maximum number of manifest resources returned.</summary>
+    public int MaxResources { get; set; } = 2_000;
+
+    /// <summary>Maximum payload size for one manifest resource.</summary>
+    public long MaxResourceBytes { get; set; } = 8L * 1024 * 1024;
+
+    /// <summary>Maximum combined payload size returned for manifest resources.</summary>
+    public long MaxTotalResourceBytes { get; set; } = 64L * 1024 * 1024;
+
+    /// <summary>
     /// When true, chapter order is deterministic by internal path.
     /// </summary>
     public bool DeterministicOrder { get; set; } = true;

--- a/OfficeIMO.Epub/EpubReader.cs
+++ b/OfficeIMO.Epub/EpubReader.cs
@@ -49,7 +49,7 @@ public static class EpubReader {
             }
 
             var text = ExtractVisibleText(chapterDocument);
-            if (text.Length == 0) {
+            if (text.Length == 0 && (!effective.IncludeRawHtml || !HasStructuredChapterContent(chapterDocument))) {
                 continue;
             }
 
@@ -82,6 +82,24 @@ public static class EpubReader {
             Resources = resources,
             Warnings = warnings
         };
+    }
+
+    private static bool HasStructuredChapterContent(XDocument document) {
+        return document.Descendants().Any(static element => {
+            string name = element.Name.LocalName;
+            return name.Equals("img", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("picture", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("svg", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("table", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("form", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("input", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("select", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("textarea", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("audio", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("video", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("object", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("canvas", StringComparison.OrdinalIgnoreCase);
+        });
     }
 
     private static IReadOnlyList<EpubResource> BuildResources(

--- a/OfficeIMO.Epub/EpubReader.cs
+++ b/OfficeIMO.Epub/EpubReader.cs
@@ -70,6 +70,8 @@ public static class EpubReader {
             });
         }
 
+        IReadOnlyList<EpubResource> resources = BuildResources(entryIndex, package, effective, warnings);
+
         return new EpubDocument {
             Title = ResolveDocumentTitle(package, chapters),
             Identifier = package?.Identifier,
@@ -77,8 +79,52 @@ public static class EpubReader {
             Creator = package?.Creator,
             OpfPath = package?.OpfPath,
             Chapters = chapters,
+            Resources = resources,
             Warnings = warnings
         };
+    }
+
+    private static IReadOnlyList<EpubResource> BuildResources(
+        IReadOnlyDictionary<string, ZipArchiveEntry> entryIndex,
+        EpubPackage? package,
+        EpubReadOptions options,
+        List<string> warnings) {
+        if (package == null || package.Manifest.Count == 0) return Array.Empty<EpubResource>();
+        var resources = new List<EpubResource>(Math.Min(package.Manifest.Count, options.MaxResources));
+        long totalPayloadBytes = 0;
+        IEnumerable<ManifestItem> items = package.Manifest.Values;
+        if (options.DeterministicOrder) items = items.OrderBy(static item => item.FullPath, StringComparer.Ordinal);
+        foreach (ManifestItem item in items) {
+            if (resources.Count >= options.MaxResources) {
+                warnings.Add($"EPUB manifest resources were truncated at MaxResources ({options.MaxResources}).");
+                break;
+            }
+            if (!entryIndex.TryGetValue(item.FullPath, out ZipArchiveEntry? entry)) {
+                warnings.Add($"EPUB manifest resource '{item.FullPath}' was not found in archive.");
+                continue;
+            }
+
+            byte[]? data = null;
+            if (options.IncludeResourceData) {
+                if (entry.Length > options.MaxResourceBytes) {
+                    warnings.Add($"Skipped payload for EPUB resource '{item.FullPath}' because size {entry.Length} exceeds MaxResourceBytes ({options.MaxResourceBytes}).");
+                } else if (entry.Length > options.MaxTotalResourceBytes - totalPayloadBytes) {
+                    warnings.Add($"Skipped payload for EPUB resource '{item.FullPath}' because MaxTotalResourceBytes ({options.MaxTotalResourceBytes}) was reached.");
+                } else {
+                    data = ReadEntryBytes(entry);
+                    totalPayloadBytes += data.LongLength;
+                }
+            }
+            resources.Add(new EpubResource {
+                Id = item.Id,
+                Path = item.FullPath,
+                MediaType = item.MediaType,
+                Properties = item.Properties,
+                LengthBytes = entry.Length,
+                Data = data
+            });
+        }
+        return resources;
     }
 
     private static Dictionary<string, ZipArchiveEntry> BuildEntryIndex(ZipArchive archive) {
@@ -407,6 +453,15 @@ public static class EpubReader {
         return reader.ReadToEnd();
     }
 
+    private static byte[] ReadEntryBytes(ZipArchiveEntry entry) {
+        using Stream entryStream = entry.Open();
+        using var memory = entry.Length > 0 && entry.Length <= int.MaxValue
+            ? new MemoryStream((int)entry.Length)
+            : new MemoryStream();
+        entryStream.CopyTo(memory);
+        return memory.ToArray();
+    }
+
     private static bool TryParseXml(string content, out XDocument? document) {
         document = null;
         if (string.IsNullOrWhiteSpace(content)) return false;
@@ -616,6 +671,10 @@ public static class EpubReader {
             MaxChapters = source.MaxChapters,
             MaxChapterBytes = source.MaxChapterBytes,
             IncludeRawHtml = source.IncludeRawHtml,
+            IncludeResourceData = source.IncludeResourceData,
+            MaxResources = source.MaxResources,
+            MaxResourceBytes = source.MaxResourceBytes,
+            MaxTotalResourceBytes = source.MaxTotalResourceBytes,
             DeterministicOrder = source.DeterministicOrder,
             PreferSpineOrder = source.PreferSpineOrder,
             IncludeNonLinearSpineItems = source.IncludeNonLinearSpineItems,
@@ -626,6 +685,9 @@ public static class EpubReader {
         if (normalized.MaxChapterBytes.HasValue && normalized.MaxChapterBytes.Value < 1) {
             normalized.MaxChapterBytes = 1;
         }
+        if (normalized.MaxResources < 1) normalized.MaxResources = 1;
+        if (normalized.MaxResourceBytes < 1) normalized.MaxResourceBytes = 1;
+        if (normalized.MaxTotalResourceBytes < 1) normalized.MaxTotalResourceBytes = 1;
 
         return normalized;
     }

--- a/OfficeIMO.Epub/EpubResource.cs
+++ b/OfficeIMO.Epub/EpubResource.cs
@@ -1,0 +1,22 @@
+namespace OfficeIMO.Epub;
+
+/// <summary>Manifest resource discovered in an EPUB package.</summary>
+public sealed class EpubResource {
+    /// <summary>OPF manifest item identifier.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Normalized archive path.</summary>
+    public string Path { get; set; } = string.Empty;
+
+    /// <summary>Declared media type.</summary>
+    public string? MediaType { get; set; }
+
+    /// <summary>Space-separated OPF properties.</summary>
+    public string? Properties { get; set; }
+
+    /// <summary>Uncompressed resource length.</summary>
+    public long LengthBytes { get; set; }
+
+    /// <summary>Optional bounded resource payload requested by the caller.</summary>
+    public byte[]? Data { get; set; }
+}

--- a/OfficeIMO.Epub/README.md
+++ b/OfficeIMO.Epub/README.md
@@ -34,6 +34,23 @@ foreach (string warning in book.Warnings) {
 }
 ```
 
+### Inspect bounded manifest resources
+
+```csharp
+EpubDocument book = EpubReader.Read("book.epub", new EpubReadOptions {
+    IncludeResourceData = true,
+    MaxResources = 500,
+    MaxResourceBytes = 4L * 1024L * 1024L,
+    MaxTotalResourceBytes = 32L * 1024L * 1024L
+});
+
+foreach (EpubResource resource in book.Resources) {
+    Console.WriteLine($"{resource.Path} ({resource.MediaType}, {resource.LengthBytes} bytes)");
+}
+```
+
+Manifest metadata is returned even when payload loading is disabled. Payload inclusion is opt-in and bounded per resource, in total, and by resource count; skipped payloads produce warnings.
+
 ## What it does
 
 - Opens EPUB files as ZIP containers.
@@ -41,6 +58,7 @@ foreach (string warning in book.Warnings) {
 - Follows OPF manifest and spine ordering.
 - Reads nav/NCX labels for chapter titles when available.
 - Extracts chapter text from XHTML/XML ASTs.
+- Returns deterministic OPF manifest resources with optional bounded payloads.
 - Emits extraction warnings for malformed or unreadable content.
 
 ## Examples
@@ -106,7 +124,7 @@ foreach (string warning in book.Warnings) {
 
 - This package owns reusable EPUB parsing primitives.
 - Reader integration belongs in `OfficeIMO.Reader.Epub`.
-- It is still conservative while fuller OPF, spine, and navigation semantics evolve.
+- The parser is read-only and does not attempt CSS layout, scripting, DRM, or package mutation.
 
 ## Targets and license
 

--- a/OfficeIMO.Excel/ExcelDocument.Inspection.cs
+++ b/OfficeIMO.Excel/ExcelDocument.Inspection.cs
@@ -21,8 +21,14 @@ namespace OfficeIMO.Excel {
 
             try {
                 snapshot.Title = _spreadSheetDocument.PackageProperties.Title;
+                snapshot.Author = _spreadSheetDocument.PackageProperties.Creator;
+                snapshot.Subject = _spreadSheetDocument.PackageProperties.Subject;
+                snapshot.Keywords = _spreadSheetDocument.PackageProperties.Keywords;
             } catch {
                 snapshot.Title = null;
+                snapshot.Author = null;
+                snapshot.Subject = null;
+                snapshot.Keywords = null;
             }
 
             using (var reader = CreateReader(effectiveOptions)) {

--- a/OfficeIMO.Excel/ExcelInspectionSnapshot.cs
+++ b/OfficeIMO.Excel/ExcelInspectionSnapshot.cs
@@ -11,6 +11,15 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public string? Title { get; internal set; }
 
+        /// <summary>Workbook creator, when present in package properties.</summary>
+        public string? Author { get; internal set; }
+
+        /// <summary>Workbook subject, when present in package properties.</summary>
+        public string? Subject { get; internal set; }
+
+        /// <summary>Workbook keywords, when present in package properties.</summary>
+        public string? Keywords { get; internal set; }
+
         /// <summary>
         /// File path associated with the workbook, when the document was created from a path.
         /// </summary>

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.cs
@@ -1,4 +1,5 @@
 using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
 using OfficeIMO.Html;
 using OfficeIMO.Markdown;
 
@@ -44,10 +45,7 @@ public sealed partial class HtmlToMarkdownConverter {
     public MarkdownDoc ConvertToDocument(string html, HtmlToMarkdownOptions? options = null) {
         if (html == null) throw new ArgumentNullException(nameof(html));
         var effectiveOptions = options?.Clone() ?? new HtmlToMarkdownOptions();
-        ValidateInputLength(html, effectiveOptions.MaxInputCharacters, nameof(html));
-
-        var document = HtmlDocumentParser.ParseDocument(html);
-        ApplyHtmlFilters(document.DocumentElement, effectiveOptions);
+        IHtmlDocument document = ParseFilteredDocumentCore(html, effectiveOptions);
         effectiveOptions.BaseUri = HtmlDocumentParser.ResolveEffectiveBaseUri(document, effectiveOptions.BaseUri);
         var context = new ConversionContext(effectiveOptions);
 
@@ -62,6 +60,25 @@ public sealed partial class HtmlToMarkdownConverter {
             markdown,
             effectiveOptions.DocumentTransforms,
             new MarkdownDocumentTransformContext(MarkdownDocumentTransformSource.HtmlToMarkdown, effectiveOptions));
+    }
+
+    /// <summary>
+    /// Parses HTML and applies the same selector and element filters used by Markdown conversion.
+    /// </summary>
+    /// <param name="html">HTML fragment or document.</param>
+    /// <param name="options">Optional conversion options containing exclusion filters.</param>
+    /// <returns>The filtered parsed HTML document.</returns>
+    public IHtmlDocument ParseFilteredDocument(string html, HtmlToMarkdownOptions? options = null) {
+        if (html == null) throw new ArgumentNullException(nameof(html));
+        HtmlToMarkdownOptions effectiveOptions = options?.Clone() ?? new HtmlToMarkdownOptions();
+        return ParseFilteredDocumentCore(html, effectiveOptions);
+    }
+
+    private static IHtmlDocument ParseFilteredDocumentCore(string html, HtmlToMarkdownOptions effectiveOptions) {
+        ValidateInputLength(html, effectiveOptions.MaxInputCharacters, nameof(html));
+        IHtmlDocument document = HtmlDocumentParser.ParseDocument(html);
+        ApplyHtmlFilters(document.DocumentElement, effectiveOptions);
+        return document;
     }
 
     private static bool ShouldIgnoreElement(IElement element, ConversionContext context) {

--- a/OfficeIMO.PowerPoint/Extraction/PowerPointExtractionExtensions.cs
+++ b/OfficeIMO.PowerPoint/Extraction/PowerPointExtractionExtensions.cs
@@ -1,9 +1,7 @@
-using DocumentFormat.OpenXml.Presentation;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;
-using A = DocumentFormat.OpenXml.Drawing;
 
 namespace OfficeIMO.PowerPoint;
 
@@ -71,8 +69,7 @@ public static class PowerPointExtractionExtensions {
             }
 
             if (extract.IncludeNotes) {
-                var notes = ReadNotesTextNoCreate(slide).Trim();
-                if (notes.Length > 0) {
+                if (slide.Notes.TryGetExistingText(out string notes)) {
                     md.AppendLine("### Notes");
                     md.AppendLine();
                     md.AppendLine(notes);
@@ -166,53 +163,6 @@ public static class PowerPointExtractionExtensions {
             .Replace("|", "\\|");
     }
 
-    private static string ReadNotesTextNoCreate(PowerPointSlide slide) {
-        // Avoid side effects: PowerPointSlide.Notes.Text will create a NotesSlidePart if absent.
-        // For extraction we only read notes when they already exist.
-        try {
-            var notesPart = slide.SlidePart.NotesSlidePart;
-            var notesSlide = notesPart?.NotesSlide;
-            if (notesSlide == null) return string.Empty;
-
-            List<string> blocks = notesSlide.CommonSlideData?.ShapeTree?
-                .Elements<Shape>()
-                .Select(ReadShapeText)
-                .Where(text => !string.IsNullOrWhiteSpace(text))
-                .ToList() ?? new List<string>();
-            return string.Join("\n\n", blocks);
-        } catch {
-            return string.Empty;
-        }
-    }
-
-    private static string ReadShapeText(Shape shape) {
-        List<string> paragraphs = shape.TextBody?
-            .Elements<A.Paragraph>()
-            .Select(ReadParagraphText)
-            .Where(text => !string.IsNullOrWhiteSpace(text))
-            .ToList() ?? new List<string>();
-        return string.Join("\n", paragraphs);
-    }
-
-    private static string ReadParagraphText(A.Paragraph paragraph) {
-        var builder = new StringBuilder();
-        foreach (DocumentFormat.OpenXml.OpenXmlElement child in paragraph.ChildElements) {
-            switch (child) {
-                case A.Run run:
-                    builder.Append(run.Text?.Text ?? string.Empty);
-                    break;
-                case A.Break:
-                    builder.AppendLine();
-                    break;
-                case A.Field field:
-                    builder.Append(field.Text?.Text ?? string.Empty);
-                    break;
-            }
-        }
-
-        return NormalizeText(builder.ToString());
-    }
-
     private static string NormalizeText(string? text) {
         return (text ?? string.Empty).Trim();
     }
@@ -222,4 +172,3 @@ public static class PowerPointExtractionExtensions {
         return $"{kind}:{safe}:s{slideNumber}";
     }
 }
-

--- a/OfficeIMO.PowerPoint/PowerPointNotes.cs
+++ b/OfficeIMO.PowerPoint/PowerPointNotes.cs
@@ -153,6 +153,32 @@ namespace OfficeIMO.PowerPoint {
             }
         }
 
+        /// <summary>
+        /// Tries to read speaker notes that already exist without creating a notes part.
+        /// </summary>
+        /// <param name="text">The existing speaker-notes text, or an empty string when none exists.</param>
+        /// <returns><see langword="true"/> when non-empty speaker notes were found.</returns>
+        public bool TryGetExistingText(out string text) {
+            text = string.Empty;
+            try {
+                NotesSlide? notesSlide = _slidePart.NotesSlidePart?.NotesSlide;
+                ShapeTree? shapeTree = notesSlide?.CommonSlideData?.ShapeTree;
+                if (shapeTree == null) {
+                    return false;
+                }
+
+                text = string.Join(
+                    Environment.NewLine + Environment.NewLine,
+                    shapeTree.Elements<Shape>()
+                        .Select(ReadShapeText)
+                        .Where(static value => !string.IsNullOrWhiteSpace(value))).Trim();
+                return text.Length > 0;
+            } catch {
+                text = string.Empty;
+                return false;
+            }
+        }
+
         internal void Save() {
             _slidePart.NotesSlidePart?.NotesSlide?.Save();
         }
@@ -258,6 +284,15 @@ namespace OfficeIMO.PowerPoint {
             }
 
             return builder.ToString();
+        }
+
+        private static string ReadShapeText(Shape shape) {
+            return string.Join(
+                Environment.NewLine,
+                shape.TextBody?.Elements<A.Paragraph>()
+                    .Select(ReadParagraphText)
+                    .Where(static value => !string.IsNullOrWhiteSpace(value))
+                ?? Enumerable.Empty<string>());
         }
 
         private HashSet<string> GetRelationshipIds() {

--- a/OfficeIMO.PowerPoint/PowerPointShape.cs
+++ b/OfficeIMO.PowerPoint/PowerPointShape.cs
@@ -68,6 +68,22 @@ namespace OfficeIMO.PowerPoint {
         }
 
         /// <summary>
+        ///     External click hyperlink assigned to the shape, when present.
+        /// </summary>
+        public Uri? Hyperlink {
+            get {
+                if (OwnerSlide == null) return null;
+                string? relationshipId = GetNonVisualDrawingProperties(create: false)?
+                    .GetFirstChild<A.HyperlinkOnClick>()?
+                    .Id;
+                if (string.IsNullOrWhiteSpace(relationshipId)) return null;
+                return OwnerSlide.SlidePart.HyperlinkRelationships
+                    .FirstOrDefault(relationship => string.Equals(relationship.Id, relationshipId, StringComparison.Ordinal))?
+                    .Uri;
+            }
+        }
+
+        /// <summary>
         ///     Placeholder type associated with the shape, if any.
         /// </summary>
         public PlaceholderValues? ShapePlaceholderType => GetPlaceholderShape()?.Type?.Value;

--- a/OfficeIMO.Reader.Epub/DocumentReaderEpubExtensions.Document.cs
+++ b/OfficeIMO.Reader.Epub/DocumentReaderEpubExtensions.Document.cs
@@ -64,6 +64,7 @@ public static partial class DocumentReaderEpubExtensions {
             var chapterTables = new List<ReaderTable>();
             var chapterLinks = new List<OfficeDocumentLink>();
             var chapterForms = new List<OfficeDocumentFormField>();
+            var chapterAssets = new List<OfficeDocumentAsset>();
             if (!string.IsNullOrWhiteSpace(chapter.Html)) {
                 OfficeDocumentReadResult htmlResult = DocumentReaderHtmlExtensions.ReadHtmlStringDocument(
                     chapter.Html!,
@@ -77,7 +78,7 @@ public static partial class DocumentReaderEpubExtensions {
                 chapterLinks.AddRange(htmlResult.Links);
                 chapterForms.AddRange(htmlResult.Forms);
                 visuals.AddRange(htmlResult.Visuals);
-                assets.AddRange(htmlResult.Assets.Where(static asset => asset.PayloadBytes != null));
+                AddEpubChapterAssets(source.Path, chapter.Path, htmlResult.Assets, assets, chapterAssets);
                 diagnostics.AddRange(htmlResult.Diagnostics);
             }
             if (chapterBlocks.Count == 0) {
@@ -100,6 +101,7 @@ public static partial class DocumentReaderEpubExtensions {
                 Location = new ReaderLocation { Path = virtualPath, SourceBlockIndex = chapterIndex, SourceBlockKind = "chapter", BlockAnchor = "epub-chapter-" + (chapterIndex + 1).ToString("D4", CultureInfo.InvariantCulture) },
                 Blocks = chapterBlocks,
                 Tables = chapterTables,
+                Assets = chapterAssets,
                 Links = chapterLinks,
                 Forms = chapterForms
             });
@@ -137,7 +139,7 @@ public static partial class DocumentReaderEpubExtensions {
             MaxChapters = source.MaxChapters,
             MaxChapterBytes = source.MaxChapterBytes,
             IncludeRawHtml = true,
-            IncludeResourceData = true,
+            IncludeResourceData = options == null || source.IncludeResourceData,
             MaxResources = source.MaxResources,
             MaxResourceBytes = source.MaxResourceBytes,
             MaxTotalResourceBytes = source.MaxTotalResourceBytes,
@@ -174,6 +176,69 @@ public static partial class DocumentReaderEpubExtensions {
         }
     }
 
+    private static void AddEpubChapterAssets(
+        string sourcePath,
+        string chapterPath,
+        IReadOnlyList<OfficeDocumentAsset> htmlAssets,
+        List<OfficeDocumentAsset> documentAssets,
+        List<OfficeDocumentAsset> chapterAssets) {
+        foreach (OfficeDocumentAsset htmlAsset in htmlAssets) {
+            OfficeDocumentAsset? mappedAsset = null;
+            if (htmlAsset.PayloadBytes == null) {
+                string? resourcePath = ResolveEpubResourcePath(chapterPath, htmlAsset.SourceObjectId);
+                if (!string.IsNullOrWhiteSpace(resourcePath)) {
+                    string virtualResourcePath = BuildVirtualPath(sourcePath, resourcePath!);
+                    mappedAsset = documentAssets.FirstOrDefault(asset => string.Equals(asset.Location.Path, virtualResourcePath, StringComparison.Ordinal));
+                }
+            }
+
+            if (mappedAsset == null) {
+                mappedAsset = htmlAsset;
+                documentAssets.Add(mappedAsset);
+            }
+            if (!chapterAssets.Contains(mappedAsset)) chapterAssets.Add(mappedAsset);
+        }
+    }
+
+    private static string? ResolveEpubResourcePath(string chapterPath, string? sourceObjectId) {
+        if (string.IsNullOrWhiteSpace(sourceObjectId)) return null;
+        string candidate = sourceObjectId!.Trim();
+        int fragmentIndex = candidate.IndexOfAny(new[] { '#', '?' });
+        if (fragmentIndex >= 0) candidate = candidate.Substring(0, fragmentIndex);
+        if (candidate.Length == 0
+            || candidate.StartsWith("data:", StringComparison.OrdinalIgnoreCase)
+            || Uri.TryCreate(candidate, UriKind.Absolute, out _)) {
+            return null;
+        }
+
+        try {
+            candidate = Uri.UnescapeDataString(candidate).Replace('\\', '/');
+        } catch {
+            candidate = candidate.Replace('\\', '/');
+        }
+
+        string combined;
+        if (candidate.StartsWith("/", StringComparison.Ordinal)) {
+            combined = candidate.TrimStart('/');
+        } else {
+            int lastSlash = chapterPath.LastIndexOf('/');
+            string chapterDirectory = lastSlash < 0 ? string.Empty : chapterPath.Substring(0, lastSlash + 1);
+            combined = chapterDirectory + candidate;
+        }
+
+        var segments = new List<string>();
+        foreach (string segment in combined.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries)) {
+            if (segment == ".") continue;
+            if (segment == "..") {
+                if (segments.Count == 0) return null;
+                segments.RemoveAt(segments.Count - 1);
+            } else {
+                segments.Add(segment);
+            }
+        }
+        return segments.Count == 0 ? null : string.Join("/", segments);
+    }
+
     private static void PrefixHtmlProjection(string prefix, OfficeDocumentReadResult result, ref int tableIndex) {
         foreach (OfficeDocumentBlock block in result.Blocks) {
             block.Id = prefix + block.Id;
@@ -195,6 +260,10 @@ public static partial class DocumentReaderEpubExtensions {
         }
         foreach (OfficeDocumentAsset asset in result.Assets) {
             asset.Id = prefix + asset.Id;
+            string? extension = string.IsNullOrWhiteSpace(asset.Extension)
+                ? Path.GetExtension(asset.FileName)
+                : asset.Extension;
+            asset.FileName = OfficeDocumentAssetNaming.BuildFileName(asset.Id, extension);
             if (!string.IsNullOrWhiteSpace(asset.Location.BlockAnchor)) asset.Location.BlockAnchor = prefix + asset.Location.BlockAnchor;
         }
         foreach (ReaderVisual visual in result.Visuals) {

--- a/OfficeIMO.Reader.Epub/DocumentReaderEpubExtensions.Document.cs
+++ b/OfficeIMO.Reader.Epub/DocumentReaderEpubExtensions.Document.cs
@@ -127,10 +127,24 @@ public static partial class DocumentReaderEpubExtensions {
         result.Links = links;
         result.Forms = forms;
         result.Visuals = visuals;
-        result.Pages = pages;
+        result.Pages = AttachEpubOcrCandidates(pages, result.OcrCandidates);
         result.Diagnostics = result.Diagnostics.Concat(diagnostics).ToArray();
         result.Metadata = BuildEpubMetadata(document, blocks.Count, tables.Count, links.Count, assets.Count);
         return result;
+    }
+
+    private static IReadOnlyList<OfficeDocumentPage> AttachEpubOcrCandidates(
+        IReadOnlyList<OfficeDocumentPage> pages,
+        IReadOnlyList<OfficeDocumentOcrCandidate> candidates) {
+        foreach (OfficeDocumentPage page in pages) {
+            var pageAssetIds = new HashSet<string>(
+                page.Assets.Where(static asset => !string.IsNullOrWhiteSpace(asset.Id)).Select(static asset => asset.Id),
+                StringComparer.Ordinal);
+            page.OcrCandidates = candidates
+                .Where(candidate => !string.IsNullOrWhiteSpace(candidate.AssetId) && pageAssetIds.Contains(candidate.AssetId!))
+                .ToArray();
+        }
+        return pages;
     }
 
     private static EpubReadOptions CreateRichOptions(EpubReadOptions? options) {

--- a/OfficeIMO.Reader.Epub/DocumentReaderEpubExtensions.Document.cs
+++ b/OfficeIMO.Reader.Epub/DocumentReaderEpubExtensions.Document.cs
@@ -79,7 +79,8 @@ public static partial class DocumentReaderEpubExtensions {
                 chapterForms.AddRange(htmlResult.Forms);
                 visuals.AddRange(htmlResult.Visuals);
                 AddEpubChapterAssets(source.Path, chapter.Path, htmlResult.Assets, assets, chapterAssets);
-                diagnostics.AddRange(htmlResult.Diagnostics);
+                diagnostics.AddRange(htmlResult.Diagnostics.Where(static diagnostic =>
+                    !string.Equals(diagnostic.Code, "ocr-needed", StringComparison.Ordinal)));
             }
             if (chapterBlocks.Count == 0) {
                 string anchor = "epub-chapter-" + (chapterIndex + 1).ToString("D4", CultureInfo.InvariantCulture);

--- a/OfficeIMO.Reader.Epub/DocumentReaderEpubExtensions.Document.cs
+++ b/OfficeIMO.Reader.Epub/DocumentReaderEpubExtensions.Document.cs
@@ -1,0 +1,228 @@
+using OfficeIMO.Epub;
+using OfficeIMO.Reader;
+using OfficeIMO.Reader.Html;
+using System.Linq;
+
+namespace OfficeIMO.Reader.Epub;
+
+public static partial class DocumentReaderEpubExtensions {
+    /// <summary>Reads an EPUB file into the shared rich document envelope.</summary>
+    public static OfficeDocumentReadResult ReadEpubDocument(string epubPath, ReaderOptions? readerOptions = null, EpubReadOptions? epubOptions = null, CancellationToken cancellationToken = default) {
+        if (epubPath == null) throw new ArgumentNullException(nameof(epubPath));
+        if (epubPath.Length == 0) throw new ArgumentException("EPUB path cannot be empty.", nameof(epubPath));
+        if (!File.Exists(epubPath)) throw new FileNotFoundException($"EPUB file '{epubPath}' doesn't exist.", epubPath);
+        ReaderOptions effective = readerOptions ?? new ReaderOptions();
+        ReaderInputLimits.EnforceFileSize(epubPath, effective.MaxInputBytes);
+        SourceMetadata source = BuildSourceMetadataFromPath(epubPath, effective.ComputeHashes);
+        EpubDocument document = EpubReader.Read(epubPath, CreateRichOptions(epubOptions));
+        return BuildEpubDocumentResult(document, source, effective, cancellationToken);
+    }
+
+    /// <summary>Reads an EPUB stream into the shared rich document envelope.</summary>
+    public static OfficeDocumentReadResult ReadEpubDocument(Stream epubStream, string? sourceName = null, ReaderOptions? readerOptions = null, EpubReadOptions? epubOptions = null, CancellationToken cancellationToken = default) {
+        if (epubStream == null) throw new ArgumentNullException(nameof(epubStream));
+        if (!epubStream.CanRead) throw new ArgumentException("EPUB stream must be readable.", nameof(epubStream));
+        ReaderOptions effective = readerOptions ?? new ReaderOptions();
+        string logicalSourceName = string.IsNullOrWhiteSpace(sourceName) ? "document.epub" : sourceName!.Trim();
+        Stream parseStream = ReaderInputLimits.EnsureSeekableReadStream(epubStream, effective.MaxInputBytes, cancellationToken, out bool ownsParseStream);
+        try {
+            SourceMetadata source = BuildSourceMetadataFromStream(parseStream, logicalSourceName, effective.ComputeHashes);
+            if (parseStream.CanSeek) parseStream.Position = 0;
+            EpubDocument document = EpubReader.Read(parseStream, CreateRichOptions(epubOptions));
+            return BuildEpubDocumentResult(document, source, effective, cancellationToken);
+        } finally {
+            if (ownsParseStream) parseStream.Dispose();
+        }
+    }
+
+    /// <summary>Reads an EPUB file into the shared rich document JSON envelope.</summary>
+    public static string ReadEpubDocumentJson(string epubPath, ReaderOptions? readerOptions = null, EpubReadOptions? epubOptions = null, bool indented = false, CancellationToken cancellationToken = default) {
+        return OfficeDocumentReadResultJson.Serialize(ReadEpubDocument(epubPath, readerOptions, epubOptions, cancellationToken), indented);
+    }
+
+    /// <summary>Reads an EPUB stream into the shared rich document JSON envelope.</summary>
+    public static string ReadEpubDocumentJson(Stream epubStream, string? sourceName = null, ReaderOptions? readerOptions = null, EpubReadOptions? epubOptions = null, bool indented = false, CancellationToken cancellationToken = default) {
+        return OfficeDocumentReadResultJson.Serialize(ReadEpubDocument(epubStream, sourceName, readerOptions, epubOptions, cancellationToken), indented);
+    }
+
+    private static OfficeDocumentReadResult BuildEpubDocumentResult(EpubDocument document, SourceMetadata source, ReaderOptions readerOptions, CancellationToken cancellationToken) {
+        ReaderChunk[] chunks = ReadEpubDocument(document, source, readerOptions, cancellationToken).ToArray();
+        List<OfficeDocumentAsset> assets = BuildEpubAssets(document, source.Path).ToList();
+        var blocks = new List<OfficeDocumentBlock>();
+        var tables = new List<ReaderTable>();
+        var links = new List<OfficeDocumentLink>();
+        var forms = new List<OfficeDocumentFormField>();
+        var visuals = new List<ReaderVisual>();
+        var diagnostics = new List<OfficeDocumentDiagnostic>();
+        var pages = new List<OfficeDocumentPage>();
+        int tableIndex = 0;
+        for (int chapterIndex = 0; chapterIndex < document.Chapters.Count; chapterIndex++) {
+            cancellationToken.ThrowIfCancellationRequested();
+            EpubChapter chapter = document.Chapters[chapterIndex];
+            string virtualPath = BuildVirtualPath(source.Path, chapter.Path);
+            var chapterBlocks = new List<OfficeDocumentBlock>();
+            var chapterTables = new List<ReaderTable>();
+            var chapterLinks = new List<OfficeDocumentLink>();
+            var chapterForms = new List<OfficeDocumentFormField>();
+            if (!string.IsNullOrWhiteSpace(chapter.Html)) {
+                OfficeDocumentReadResult htmlResult = DocumentReaderHtmlExtensions.ReadHtmlStringDocument(
+                    chapter.Html!,
+                    virtualPath,
+                    readerOptions,
+                    cancellationToken: cancellationToken);
+                string prefix = "epub-chapter-" + (chapterIndex + 1).ToString("D4", CultureInfo.InvariantCulture) + "-";
+                PrefixHtmlProjection(prefix, htmlResult, ref tableIndex);
+                chapterBlocks.AddRange(htmlResult.Blocks);
+                chapterTables.AddRange(htmlResult.Tables);
+                chapterLinks.AddRange(htmlResult.Links);
+                chapterForms.AddRange(htmlResult.Forms);
+                visuals.AddRange(htmlResult.Visuals);
+                assets.AddRange(htmlResult.Assets.Where(static asset => asset.PayloadBytes != null));
+                diagnostics.AddRange(htmlResult.Diagnostics);
+            }
+            if (chapterBlocks.Count == 0) {
+                string anchor = "epub-chapter-" + (chapterIndex + 1).ToString("D4", CultureInfo.InvariantCulture);
+                chapterBlocks.Add(new OfficeDocumentBlock {
+                    Id = anchor,
+                    Kind = "chapter",
+                    Text = chapter.Text,
+                    Level = 1,
+                    Location = new ReaderLocation { Path = virtualPath, SourceBlockIndex = chapterIndex, SourceBlockKind = "chapter", BlockAnchor = anchor }
+                });
+            }
+            blocks.AddRange(chapterBlocks);
+            tables.AddRange(chapterTables);
+            links.AddRange(chapterLinks);
+            forms.AddRange(chapterForms);
+            pages.Add(new OfficeDocumentPage {
+                Number = chapter.Order,
+                Name = chapter.Title,
+                Location = new ReaderLocation { Path = virtualPath, SourceBlockIndex = chapterIndex, SourceBlockKind = "chapter", BlockAnchor = "epub-chapter-" + (chapterIndex + 1).ToString("D4", CultureInfo.InvariantCulture) },
+                Blocks = chapterBlocks,
+                Tables = chapterTables,
+                Links = chapterLinks,
+                Forms = chapterForms
+            });
+        }
+
+        var documentSource = new OfficeDocumentSource {
+            Path = source.Path,
+            SourceId = source.SourceId,
+            SourceHash = source.SourceHash,
+            LastWriteUtc = source.LastWriteUtc,
+            LengthBytes = source.LengthBytes,
+            Title = document.Title,
+            Author = document.Creator
+        };
+        OfficeDocumentReadResult result = DocumentReader.CreateDocumentResult(
+            chunks,
+            ReaderInputKind.Epub,
+            documentSource,
+            new[] { "officeimo.reader.epub.rich-v5", "officeimo.epub.package-model", "officeimo.html.logical-document" },
+            assets);
+        result.Blocks = blocks;
+        result.Tables = tables;
+        result.Links = links;
+        result.Forms = forms;
+        result.Visuals = visuals;
+        result.Pages = pages;
+        result.Diagnostics = result.Diagnostics.Concat(diagnostics).ToArray();
+        result.Metadata = BuildEpubMetadata(document, blocks.Count, tables.Count, links.Count, assets.Count);
+        return result;
+    }
+
+    private static EpubReadOptions CreateRichOptions(EpubReadOptions? options) {
+        EpubReadOptions source = options ?? new EpubReadOptions();
+        return new EpubReadOptions {
+            MaxChapters = source.MaxChapters,
+            MaxChapterBytes = source.MaxChapterBytes,
+            IncludeRawHtml = true,
+            IncludeResourceData = true,
+            MaxResources = source.MaxResources,
+            MaxResourceBytes = source.MaxResourceBytes,
+            MaxTotalResourceBytes = source.MaxTotalResourceBytes,
+            DeterministicOrder = source.DeterministicOrder,
+            PreferSpineOrder = source.PreferSpineOrder,
+            IncludeNonLinearSpineItems = source.IncludeNonLinearSpineItems,
+            FallbackToHtmlScan = source.FallbackToHtmlScan
+        };
+    }
+
+    private static IEnumerable<OfficeDocumentAsset> BuildEpubAssets(EpubDocument document, string sourcePath) {
+        int assetIndex = 0;
+        foreach (EpubResource resource in document.Resources) {
+            if (string.IsNullOrWhiteSpace(resource.MediaType) || !resource.MediaType!.StartsWith("image/", StringComparison.OrdinalIgnoreCase)) continue;
+            string id = "epub-image-" + assetIndex.ToString("D4", CultureInfo.InvariantCulture);
+            string extension = Path.GetExtension(resource.Path);
+            yield return new OfficeDocumentAsset {
+                Id = id,
+                Kind = "image",
+                MediaType = resource.MediaType,
+                Extension = string.IsNullOrWhiteSpace(extension) ? null : extension,
+                FileName = OfficeDocumentAssetNaming.BuildFileName(id, extension),
+                LengthBytes = resource.LengthBytes,
+                PayloadHash = resource.Data == null ? null : ComputeEpubPayloadHash(resource.Data),
+                PayloadBytes = resource.Data,
+                SourceObjectId = resource.Id,
+                Location = new ReaderLocation {
+                    Path = BuildVirtualPath(sourcePath, resource.Path),
+                    SourceBlockKind = "image",
+                    BlockAnchor = id
+                }
+            };
+            assetIndex++;
+        }
+    }
+
+    private static void PrefixHtmlProjection(string prefix, OfficeDocumentReadResult result, ref int tableIndex) {
+        foreach (OfficeDocumentBlock block in result.Blocks) {
+            block.Id = prefix + block.Id;
+            if (!string.IsNullOrWhiteSpace(block.Location.BlockAnchor)) block.Location.BlockAnchor = prefix + block.Location.BlockAnchor;
+        }
+        foreach (ReaderTable table in result.Tables) {
+            if (table.Location != null) {
+                table.Location.TableIndex = tableIndex++;
+                if (!string.IsNullOrWhiteSpace(table.Location.BlockAnchor)) table.Location.BlockAnchor = prefix + table.Location.BlockAnchor;
+            }
+        }
+        foreach (OfficeDocumentLink link in result.Links) {
+            link.Id = prefix + link.Id;
+            if (!string.IsNullOrWhiteSpace(link.Location.BlockAnchor)) link.Location.BlockAnchor = prefix + link.Location.BlockAnchor;
+        }
+        foreach (OfficeDocumentFormField form in result.Forms) {
+            form.Id = prefix + form.Id;
+            if (!string.IsNullOrWhiteSpace(form.Location.BlockAnchor)) form.Location.BlockAnchor = prefix + form.Location.BlockAnchor;
+        }
+        foreach (OfficeDocumentAsset asset in result.Assets) {
+            asset.Id = prefix + asset.Id;
+            if (!string.IsNullOrWhiteSpace(asset.Location.BlockAnchor)) asset.Location.BlockAnchor = prefix + asset.Location.BlockAnchor;
+        }
+        foreach (ReaderVisual visual in result.Visuals) {
+            if (visual.Location != null && !string.IsNullOrWhiteSpace(visual.Location.BlockAnchor)) visual.Location.BlockAnchor = prefix + visual.Location.BlockAnchor;
+        }
+    }
+
+    private static IReadOnlyList<OfficeDocumentMetadataEntry> BuildEpubMetadata(EpubDocument document, int blockCount, int tableCount, int linkCount, int assetCount) {
+        var metadata = new List<OfficeDocumentMetadataEntry> {
+            EpubMetadata("epub-chapter-count", "ChapterCount", document.Chapters.Count, "count"),
+            EpubMetadata("epub-resource-count", "ResourceCount", document.Resources.Count, "count"),
+            EpubMetadata("epub-block-count", "BlockCount", blockCount, "count"),
+            EpubMetadata("epub-table-count", "TableCount", tableCount, "count"),
+            EpubMetadata("epub-link-count", "LinkCount", linkCount, "count"),
+            EpubMetadata("epub-asset-count", "AssetCount", assetCount, "count")
+        };
+        if (!string.IsNullOrWhiteSpace(document.Identifier)) metadata.Add(EpubMetadata("epub-identifier", "Identifier", document.Identifier!, "string"));
+        if (!string.IsNullOrWhiteSpace(document.Language)) metadata.Add(EpubMetadata("epub-language", "Language", document.Language!, "string"));
+        if (!string.IsNullOrWhiteSpace(document.OpfPath)) metadata.Add(EpubMetadata("epub-package-path", "PackagePath", document.OpfPath!, "string"));
+        return metadata;
+    }
+
+    private static OfficeDocumentMetadataEntry EpubMetadata(string id, string name, object value, string valueType) => new OfficeDocumentMetadataEntry {
+        Id = id, Category = "epub.package", Name = name, Value = Convert.ToString(value, CultureInfo.InvariantCulture), ValueType = valueType
+    };
+
+    private static string ComputeEpubPayloadHash(byte[] bytes) {
+        using var stream = new MemoryStream(bytes, writable: false);
+        return ComputeSha256Hex(stream);
+    }
+}

--- a/OfficeIMO.Reader.Epub/DocumentReaderEpubExtensions.Document.cs
+++ b/OfficeIMO.Reader.Epub/DocumentReaderEpubExtensions.Document.cs
@@ -71,6 +71,7 @@ public static partial class DocumentReaderEpubExtensions {
                     virtualPath,
                     readerOptions,
                     cancellationToken: cancellationToken);
+                ResolveEpubChapterLinks(source.Path, chapter.Path, htmlResult.Links);
                 string prefix = "epub-chapter-" + (chapterIndex + 1).ToString("D4", CultureInfo.InvariantCulture) + "-";
                 PrefixHtmlProjection(prefix, htmlResult, ref tableIndex);
                 chapterBlocks.AddRange(htmlResult.Blocks);
@@ -222,6 +223,7 @@ public static partial class DocumentReaderEpubExtensions {
         if (fragmentIndex >= 0) candidate = candidate.Substring(0, fragmentIndex);
         if (candidate.Length == 0
             || candidate.StartsWith("data:", StringComparison.OrdinalIgnoreCase)
+            || candidate.StartsWith("//", StringComparison.Ordinal)
             || Uri.TryCreate(candidate, UriKind.Absolute, out _)) {
             return null;
         }
@@ -252,6 +254,21 @@ public static partial class DocumentReaderEpubExtensions {
             }
         }
         return segments.Count == 0 ? null : string.Join("/", segments);
+    }
+
+    private static void ResolveEpubChapterLinks(
+        string sourcePath,
+        string chapterPath,
+        IReadOnlyList<OfficeDocumentLink> links) {
+        foreach (OfficeDocumentLink link in links) {
+            if (string.IsNullOrWhiteSpace(link.Uri)) continue;
+            string rawUri = link.Uri!.Trim();
+            string? resourcePath = ResolveEpubResourcePath(chapterPath, rawUri);
+            if (resourcePath == null) continue;
+            int suffixIndex = rawUri.IndexOfAny(new[] { '?', '#' });
+            string suffix = suffixIndex < 0 ? string.Empty : rawUri.Substring(suffixIndex);
+            link.Uri = BuildVirtualPath(sourcePath, resourcePath) + suffix;
+        }
     }
 
     private static void PrefixHtmlProjection(string prefix, OfficeDocumentReadResult result, ref int tableIndex) {

--- a/OfficeIMO.Reader.Epub/DocumentReaderEpubExtensions.cs
+++ b/OfficeIMO.Reader.Epub/DocumentReaderEpubExtensions.cs
@@ -6,7 +6,7 @@ namespace OfficeIMO.Reader.Epub;
 /// <summary>
 /// EPUB ingestion adapter for <see cref="DocumentReader"/>.
 /// </summary>
-public static class DocumentReaderEpubExtensions {
+public static partial class DocumentReaderEpubExtensions {
     /// <summary>
     /// Reads EPUB content from a file path and emits normalized chunks.
     /// </summary>

--- a/OfficeIMO.Reader.Epub/DocumentReaderEpubRegistrationExtensions.cs
+++ b/OfficeIMO.Reader.Epub/DocumentReaderEpubRegistrationExtensions.cs
@@ -75,6 +75,17 @@ public static class DocumentReaderEpubRegistrationExtensions {
                 sourceName: sourceName,
                 readerOptions: readerOptions,
                 epubOptions: Clone(registeredOptions),
+                cancellationToken: ct),
+            ReadDocumentPath = (path, readerOptions, ct) => DocumentReaderEpubExtensions.ReadEpubDocument(
+                epubPath: path,
+                readerOptions: readerOptions,
+                epubOptions: Clone(registeredOptions),
+                cancellationToken: ct),
+            ReadDocumentStream = (stream, sourceName, readerOptions, ct) => DocumentReaderEpubExtensions.ReadEpubDocument(
+                epubStream: stream,
+                sourceName: sourceName,
+                readerOptions: readerOptions,
+                epubOptions: Clone(registeredOptions),
                 cancellationToken: ct)
         };
     }
@@ -85,6 +96,10 @@ public static class DocumentReaderEpubRegistrationExtensions {
             MaxChapters = options.MaxChapters,
             MaxChapterBytes = options.MaxChapterBytes,
             IncludeRawHtml = options.IncludeRawHtml,
+            IncludeResourceData = options.IncludeResourceData,
+            MaxResources = options.MaxResources,
+            MaxResourceBytes = options.MaxResourceBytes,
+            MaxTotalResourceBytes = options.MaxTotalResourceBytes,
             DeterministicOrder = options.DeterministicOrder,
             PreferSpineOrder = options.PreferSpineOrder,
             IncludeNonLinearSpineItems = options.IncludeNonLinearSpineItems,

--- a/OfficeIMO.Reader.Epub/OfficeIMO.Reader.Epub.csproj
+++ b/OfficeIMO.Reader.Epub/OfficeIMO.Reader.Epub.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\OfficeIMO.Reader\OfficeIMO.Reader.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Reader.Html\OfficeIMO.Reader.Html.csproj" />
     <ProjectReference Include="..\OfficeIMO.Epub\OfficeIMO.Epub.csproj" />
   </ItemGroup>
 

--- a/OfficeIMO.Reader.Epub/README.md
+++ b/OfficeIMO.Reader.Epub/README.md
@@ -64,6 +64,28 @@ foreach (string warning in chunks.SelectMany(chunk => chunk.Warnings ?? Array.Em
 }
 ```
 
+### Read chapters and packaged images as one rich result
+
+```csharp
+OfficeDocumentReadResult document = DocumentReaderEpubExtensions.ReadEpubDocument(
+    "book.epub",
+    epubOptions: new EpubReadOptions {
+        MaxResources = 500,
+        MaxResourceBytes = 4L * 1024L * 1024L,
+        MaxTotalResourceBytes = 32L * 1024L * 1024L
+    });
+
+foreach (OfficeDocumentPage chapter in document.Pages) {
+    Console.WriteLine($"{chapter.Number}. {chapter.Name}");
+}
+
+foreach (OfficeDocumentAsset image in document.Assets) {
+    Console.WriteLine($"{image.FileName}: {image.LengthBytes} bytes");
+}
+```
+
+The rich reader always requests bounded chapter HTML and manifest payloads from `OfficeIMO.Epub` so it can reuse the HTML semantic mapping. After registration, `DocumentReader.ReadDocument("book.epub")` uses this native result path.
+
 ## What it emits
 
 - Chapter-to-chunk projection.
@@ -72,6 +94,7 @@ foreach (string warning in chunks.SelectMany(chunk => chunk.Warnings ?? Array.Em
 - Warning chunks propagated from EPUB parser warnings.
 - Virtual source paths such as `.epub::chapter.xhtml` for traceability.
 - Path and stream dispatch, including non-seekable stream support.
+- A schema-v5 rich result with chapter pages, HTML blocks, tables, links, forms, manifest image assets, metadata, and structured parser diagnostics.
 
 ## Boundaries
 

--- a/OfficeIMO.Reader.Html/DocumentReaderHtmlExtensions.Document.cs
+++ b/OfficeIMO.Reader.Html/DocumentReaderHtmlExtensions.Document.cs
@@ -67,18 +67,15 @@ public static partial class DocumentReaderHtmlExtensions {
         HtmlToMarkdownOptions projectionOptions = effectiveHtmlOptions.HtmlToMarkdownOptions ?? HtmlToMarkdownOptions.CreateOfficeIMOProfile();
         bool hasProjectionFilters = projectionOptions.ExcludeSelectors.Count > 0 || projectionOptions.ElementFilters.Count > 0;
         string projectedHtml = html;
-        HtmlLogicalDocument logical;
         ReaderHtmlOptions chunkHtmlOptions = effectiveHtmlOptions;
+        var filtered = new HtmlToMarkdownConverter().ParseFilteredDocument(html, projectionOptions);
+        projectionOptions.BaseUri = HtmlDocumentParser.ResolveEffectiveBaseUri(filtered, projectionOptions.BaseUri);
+        HtmlLogicalDocument logical = HtmlLogicalDocumentBuilder.FromDocument(filtered, useBodyContentsOnly: false);
         if (hasProjectionFilters) {
-            var filtered = new HtmlToMarkdownConverter().ParseFilteredDocument(html, projectionOptions);
-            projectionOptions.BaseUri = HtmlDocumentParser.ResolveEffectiveBaseUri(filtered, projectionOptions.BaseUri);
-            logical = HtmlLogicalDocumentBuilder.FromDocument(filtered, useBodyContentsOnly: false);
             projectedHtml = filtered.DocumentElement?.OuterHtml ?? html;
             chunkHtmlOptions = effectiveHtmlOptions.Clone();
             chunkHtmlOptions.HtmlToMarkdownOptions?.ExcludeSelectors.Clear();
             chunkHtmlOptions.HtmlToMarkdownOptions?.ElementFilters.Clear();
-        } else {
-            logical = HtmlLogicalDocumentBuilder.FromHtml(html, useBodyContentsOnly: false);
         }
         ReaderChunk[] chunks = ReadHtmlString(projectedHtml, source, readerOptions, chunkHtmlOptions, cancellationToken).ToArray();
         HtmlProjection projection = ProjectHtml(logical, source.Path, readerOptions.MaxTableRows, projectionOptions, cancellationToken);
@@ -262,6 +259,9 @@ public static partial class DocumentReaderHtmlExtensions {
     private static OfficeDocumentFormField MapHtmlFormControl(HtmlLogicalNode node, string? path, int index) {
         node.Attributes.TryGetValue("name", out string? name);
         bool hasValue = node.Attributes.TryGetValue("value", out string? value);
+        string kind = node.Attributes.TryGetValue("type", out string? type) && !string.IsNullOrWhiteSpace(type)
+            ? type
+            : node.Name;
         if (!hasValue && string.Equals(node.Name, "textarea", StringComparison.OrdinalIgnoreCase)) {
             value = GetHtmlNodeText(node);
         } else if (!hasValue && string.Equals(node.Name, "select", StringComparison.OrdinalIgnoreCase)) {
@@ -273,11 +273,17 @@ public static partial class DocumentReaderHtmlExtensions {
                     ? optionValue
                     : GetHtmlNodeText(option)));
         }
+        if (string.Equals(kind, "checkbox", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(kind, "radio", StringComparison.OrdinalIgnoreCase)) {
+            value = node.Attributes.ContainsKey("checked")
+                ? hasValue ? value : "on"
+                : null;
+        }
         string id = "html-form-" + index.ToString("D4", CultureInfo.InvariantCulture);
         return new OfficeDocumentFormField {
             Id = id,
             Name = name,
-            Kind = node.Attributes.TryGetValue("type", out string? type) && !string.IsNullOrWhiteSpace(type) ? type : node.Name,
+            Kind = kind,
             Value = value,
             IsReadOnly = node.Attributes.ContainsKey("readonly") || node.Attributes.ContainsKey("disabled"),
             IsRequired = node.Attributes.ContainsKey("required"),

--- a/OfficeIMO.Reader.Html/DocumentReaderHtmlExtensions.Document.cs
+++ b/OfficeIMO.Reader.Html/DocumentReaderHtmlExtensions.Document.cs
@@ -128,20 +128,23 @@ public static partial class DocumentReaderHtmlExtensions {
         cancellationToken.ThrowIfCancellationRequested();
         string? nextListName = node.Kind == HtmlLogicalNodeKind.List ? node.Name : listName;
         int nextListLevel = node.Kind == HtmlLogicalNodeKind.List ? listLevel + 1 : listLevel;
+        ReaderTable? mappedTable = node.Kind == HtmlLogicalNodeKind.Table
+            ? MapHtmlTable(node, path, tableIndex++, maxTableRows)
+            : null;
         if (IsHtmlBlock(node.Kind)) {
             string kind = NormalizeHtmlBlockKind(node.Kind);
             string anchor = "html-" + kind + "-" + blockIndex.ToString("D4", CultureInfo.InvariantCulture);
             projection.Blocks.Add(new OfficeDocumentBlock {
                 Id = anchor,
                 Kind = kind,
-                Text = GetHtmlNodeText(node),
+                Text = mappedTable == null ? GetHtmlNodeText(node) : BuildHtmlTableBlockText(mappedTable),
                 Level = node.Kind == HtmlLogicalNodeKind.Heading ? ParseHtmlHeadingLevel(node.Name) : node.Kind == HtmlLogicalNodeKind.ListItem ? nextListLevel : null,
                 Marker = node.Kind == HtmlLogicalNodeKind.ListItem ? (string.Equals(nextListName, "ol", StringComparison.OrdinalIgnoreCase) ? "1." : "-") : null,
                 Location = BuildHtmlLocation(path, blockIndex, kind, anchor)
             });
             blockIndex++;
         }
-        if (node.Kind == HtmlLogicalNodeKind.Table) projection.Tables.Add(MapHtmlTable(node, path, tableIndex++, maxTableRows));
+        if (mappedTable != null) projection.Tables.Add(mappedTable);
         if (node.Kind == HtmlLogicalNodeKind.Link && node.Attributes.TryGetValue("href", out string? href)) {
             string resolvedHref = HtmlUrlPolicyEvaluator.ResolveUrl(href, htmlOptions.BaseUri, htmlOptions.UrlPolicy);
             if (!string.IsNullOrWhiteSpace(resolvedHref)) {
@@ -205,10 +208,9 @@ public static partial class DocumentReaderHtmlExtensions {
     }
 
     private static OfficeDocumentAsset? MapHtmlImage(HtmlLogicalNode node, string? path, int index, HtmlToMarkdownOptions htmlOptions) {
-        node.Attributes.TryGetValue("src", out string? source);
         node.Attributes.TryGetValue("alt", out string? altText);
         node.Attributes.TryGetValue("title", out string? title);
-        string resolvedSource = HtmlUrlPolicyEvaluator.ResolveUrl(source, htmlOptions.BaseUri, htmlOptions.UrlPolicy);
+        string resolvedSource = ResolveHtmlImageSource(node, htmlOptions);
         if (string.IsNullOrWhiteSpace(resolvedSource)) return null;
         byte[]? payload = null;
         string? mediaType = null;
@@ -239,7 +241,10 @@ public static partial class DocumentReaderHtmlExtensions {
 
     private static OfficeDocumentFormField MapHtmlFormControl(HtmlLogicalNode node, string? path, int index) {
         node.Attributes.TryGetValue("name", out string? name);
-        node.Attributes.TryGetValue("value", out string? value);
+        bool hasValue = node.Attributes.TryGetValue("value", out string? value);
+        if (!hasValue && string.Equals(node.Name, "textarea", StringComparison.OrdinalIgnoreCase)) {
+            value = GetHtmlNodeText(node);
+        }
         string id = "html-form-" + index.ToString("D4", CultureInfo.InvariantCulture);
         return new OfficeDocumentFormField {
             Id = id,
@@ -250,6 +255,29 @@ public static partial class DocumentReaderHtmlExtensions {
             IsRequired = node.Attributes.ContainsKey("required"),
             Location = BuildHtmlLocation(path, null, "form-control", id)
         };
+    }
+
+    private static string BuildHtmlTableBlockText(ReaderTable table) {
+        IEnumerable<IReadOnlyList<string>> rows = table.Columns.Count == 0
+            ? table.Rows
+            : new[] { table.Columns }.Concat(table.Rows);
+        return string.Join(Environment.NewLine, rows.Select(static row => string.Join(" | ", row)));
+    }
+
+    private static string ResolveHtmlImageSource(HtmlLogicalNode node, HtmlToMarkdownOptions options) {
+        foreach (string attribute in new[] { "data-src", "data-original", "data-original-src", "data-lazy-src" }) {
+            if (!node.Attributes.TryGetValue(attribute, out string? value)) continue;
+            string resolved = HtmlUrlPolicyEvaluator.ResolveUrl(value, options.BaseUri, options.UrlPolicy);
+            if (!string.IsNullOrWhiteSpace(resolved)) return resolved;
+        }
+        foreach (string attribute in new[] { "srcset", "data-srcset", "data-original-srcset", "data-lazy-srcset" }) {
+            if (!node.Attributes.TryGetValue(attribute, out string? value)) continue;
+            string resolved = HtmlImageSourceResolver.ResolveUrlFromSrcSet(value, options.BaseUri, options.UrlPolicy);
+            if (!string.IsNullOrWhiteSpace(resolved)) return resolved;
+        }
+        return node.Attributes.TryGetValue("src", out string? source)
+            ? HtmlUrlPolicyEvaluator.ResolveUrl(source, options.BaseUri, options.UrlPolicy)
+            : string.Empty;
     }
 
     private static ReaderVisual MapHtmlVisual(

--- a/OfficeIMO.Reader.Html/DocumentReaderHtmlExtensions.Document.cs
+++ b/OfficeIMO.Reader.Html/DocumentReaderHtmlExtensions.Document.cs
@@ -1,0 +1,341 @@
+using OfficeIMO.Html;
+using OfficeIMO.Reader;
+using System.Linq;
+using System.Security.Cryptography;
+
+namespace OfficeIMO.Reader.Html;
+
+public static partial class DocumentReaderHtmlExtensions {
+    /// <summary>Reads an HTML file into the shared rich document envelope.</summary>
+    public static OfficeDocumentReadResult ReadHtmlDocument(string htmlPath, ReaderOptions? readerOptions = null, ReaderHtmlOptions? htmlOptions = null, CancellationToken cancellationToken = default) {
+        if (htmlPath == null) throw new ArgumentNullException(nameof(htmlPath));
+        if (htmlPath.Length == 0) throw new ArgumentException("HTML path cannot be empty.", nameof(htmlPath));
+        if (!File.Exists(htmlPath)) throw new FileNotFoundException($"HTML file '{htmlPath}' doesn't exist.", htmlPath);
+        ReaderOptions effective = readerOptions ?? new ReaderOptions();
+        ReaderInputLimits.EnforceFileSize(htmlPath, effective.MaxInputBytes);
+        SourceMetadata source = BuildSourceMetadataFromPath(htmlPath, effective.ComputeHashes);
+        using var stream = new FileStream(htmlPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        string html = ReadAllText(stream, cancellationToken);
+        return BuildHtmlDocumentResult(html, source, effective, htmlOptions, cancellationToken);
+    }
+
+    /// <summary>Reads an HTML stream into the shared rich document envelope.</summary>
+    public static OfficeDocumentReadResult ReadHtmlDocument(Stream htmlStream, string? sourceName = null, ReaderOptions? readerOptions = null, ReaderHtmlOptions? htmlOptions = null, CancellationToken cancellationToken = default) {
+        if (htmlStream == null) throw new ArgumentNullException(nameof(htmlStream));
+        if (!htmlStream.CanRead) throw new ArgumentException("HTML stream must be readable.", nameof(htmlStream));
+        ReaderOptions effective = readerOptions ?? new ReaderOptions();
+        string logicalSourceName = string.IsNullOrWhiteSpace(sourceName) ? "document.html" : sourceName!.Trim();
+        var source = new SourceMetadata { Path = logicalSourceName, SourceId = BuildSourceId(logicalSourceName) };
+        Stream parseStream = ReaderInputLimits.EnsureSeekableReadStream(htmlStream, effective.MaxInputBytes, cancellationToken, out bool ownsParseStream);
+        try {
+            UpdateSourceMetadataFromSeekableStream(source, parseStream, effective.ComputeHashes);
+            string html = ReadAllText(parseStream, cancellationToken);
+            return BuildHtmlDocumentResult(html, source, effective, htmlOptions, cancellationToken);
+        } finally {
+            if (ownsParseStream) parseStream.Dispose();
+        }
+    }
+
+    /// <summary>Reads an HTML string into the shared rich document envelope.</summary>
+    public static OfficeDocumentReadResult ReadHtmlStringDocument(string html, string sourceName = "document.html", ReaderOptions? readerOptions = null, ReaderHtmlOptions? htmlOptions = null, CancellationToken cancellationToken = default) {
+        if (html == null) throw new ArgumentNullException(nameof(html));
+        if (sourceName == null) throw new ArgumentNullException(nameof(sourceName));
+        ReaderOptions effective = readerOptions ?? new ReaderOptions();
+        string logicalSourceName = string.IsNullOrWhiteSpace(sourceName) ? "document.html" : sourceName.Trim();
+        SourceMetadata source = BuildSourceMetadataFromHtmlString(logicalSourceName, html, effective.ComputeHashes);
+        return BuildHtmlDocumentResult(html, source, effective, htmlOptions, cancellationToken);
+    }
+
+    /// <summary>Reads an HTML file into the shared rich document JSON envelope.</summary>
+    public static string ReadHtmlDocumentJson(string htmlPath, ReaderOptions? readerOptions = null, ReaderHtmlOptions? htmlOptions = null, bool indented = false, CancellationToken cancellationToken = default) {
+        return OfficeDocumentReadResultJson.Serialize(ReadHtmlDocument(htmlPath, readerOptions, htmlOptions, cancellationToken), indented);
+    }
+
+    /// <summary>Reads an HTML stream into the shared rich document JSON envelope.</summary>
+    public static string ReadHtmlDocumentJson(Stream htmlStream, string? sourceName = null, ReaderOptions? readerOptions = null, ReaderHtmlOptions? htmlOptions = null, bool indented = false, CancellationToken cancellationToken = default) {
+        return OfficeDocumentReadResultJson.Serialize(ReadHtmlDocument(htmlStream, sourceName, readerOptions, htmlOptions, cancellationToken), indented);
+    }
+
+    /// <summary>Reads an HTML string into the shared rich document JSON envelope.</summary>
+    public static string ReadHtmlStringDocumentJson(string html, string sourceName = "document.html", ReaderOptions? readerOptions = null, ReaderHtmlOptions? htmlOptions = null, bool indented = false, CancellationToken cancellationToken = default) {
+        return OfficeDocumentReadResultJson.Serialize(ReadHtmlStringDocument(html, sourceName, readerOptions, htmlOptions, cancellationToken), indented);
+    }
+
+    private static OfficeDocumentReadResult BuildHtmlDocumentResult(string html, SourceMetadata source, ReaderOptions readerOptions, ReaderHtmlOptions? htmlOptions, CancellationToken cancellationToken) {
+        ReaderChunk[] chunks = ReadHtmlString(html, source, readerOptions, htmlOptions, cancellationToken).ToArray();
+        HtmlLogicalDocument logical = HtmlLogicalDocumentBuilder.FromHtml(html, useBodyContentsOnly: false);
+        HtmlProjection projection = ProjectHtml(logical, source.Path, readerOptions.MaxTableRows, cancellationToken);
+        var documentSource = new OfficeDocumentSource {
+            Path = source.Path,
+            SourceId = source.SourceId,
+            SourceHash = source.SourceHash,
+            LastWriteUtc = source.LastWriteUtc,
+            LengthBytes = source.LengthBytes,
+            Title = FindHtmlMetadata(logical.Root, "title", null),
+            Author = FindHtmlMetadata(logical.Root, "meta", "author"),
+            Subject = FindHtmlMetadata(logical.Root, "meta", "description"),
+            Keywords = FindHtmlMetadata(logical.Root, "meta", "keywords")
+        };
+        OfficeDocumentReadResult result = DocumentReader.CreateDocumentResult(
+            chunks,
+            ReaderInputKind.Html,
+            documentSource,
+            new[] { "officeimo.reader.html.rich-v5", "officeimo.html.logical-document" }.Concat(logical.Capabilities.Select(static capability => "officeimo.html." + capability)),
+            projection.Assets);
+        result.Html = html;
+        result.Blocks = projection.Blocks;
+        result.Tables = projection.Tables;
+        result.Links = projection.Links;
+        result.Forms = projection.Forms;
+        result.Visuals = projection.Visuals;
+        result.Metadata = BuildHtmlMetadata(logical, projection);
+        return result;
+    }
+
+    private static HtmlProjection ProjectHtml(HtmlLogicalDocument document, string? path, int maxTableRows, CancellationToken cancellationToken) {
+        var projection = new HtmlProjection();
+        int blockIndex = 0;
+        int tableIndex = 0;
+        int linkIndex = 0;
+        int assetIndex = 0;
+        int formIndex = 0;
+        TraverseHtml(document.Root, null, 0, path, maxTableRows, projection, ref blockIndex, ref tableIndex, ref linkIndex, ref assetIndex, ref formIndex, cancellationToken);
+        return projection;
+    }
+
+    private static void TraverseHtml(
+        HtmlLogicalNode node,
+        string? listName,
+        int listLevel,
+        string? path,
+        int maxTableRows,
+        HtmlProjection projection,
+        ref int blockIndex,
+        ref int tableIndex,
+        ref int linkIndex,
+        ref int assetIndex,
+        ref int formIndex,
+        CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        string? nextListName = node.Kind == HtmlLogicalNodeKind.List ? node.Name : listName;
+        int nextListLevel = node.Kind == HtmlLogicalNodeKind.List ? listLevel + 1 : listLevel;
+        if (IsHtmlBlock(node.Kind)) {
+            string kind = NormalizeHtmlBlockKind(node.Kind);
+            string anchor = "html-" + kind + "-" + blockIndex.ToString("D4", CultureInfo.InvariantCulture);
+            projection.Blocks.Add(new OfficeDocumentBlock {
+                Id = anchor,
+                Kind = kind,
+                Text = GetHtmlNodeText(node),
+                Level = node.Kind == HtmlLogicalNodeKind.Heading ? ParseHtmlHeadingLevel(node.Name) : node.Kind == HtmlLogicalNodeKind.ListItem ? nextListLevel : null,
+                Marker = node.Kind == HtmlLogicalNodeKind.ListItem ? (string.Equals(nextListName, "ol", StringComparison.OrdinalIgnoreCase) ? "1." : "-") : null,
+                Location = BuildHtmlLocation(path, blockIndex, kind, anchor)
+            });
+            blockIndex++;
+        }
+        if (node.Kind == HtmlLogicalNodeKind.Table) projection.Tables.Add(MapHtmlTable(node, path, tableIndex++, maxTableRows));
+        if (node.Kind == HtmlLogicalNodeKind.Link && node.Attributes.TryGetValue("href", out string? href) && !string.IsNullOrWhiteSpace(href)) {
+            projection.Links.Add(new OfficeDocumentLink {
+                Id = "html-link-" + linkIndex.ToString("D4", CultureInfo.InvariantCulture),
+                Kind = href.StartsWith("#", StringComparison.Ordinal) ? "internal" : "uri",
+                Uri = href.StartsWith("#", StringComparison.Ordinal) ? null : href,
+                DestinationName = href.StartsWith("#", StringComparison.Ordinal) ? href.Substring(1) : null,
+                Text = GetHtmlNodeText(node),
+                Location = BuildHtmlLocation(path, null, "hyperlink", "html-link-" + linkIndex.ToString("D4", CultureInfo.InvariantCulture))
+            });
+            linkIndex++;
+        }
+        if (node.Kind == HtmlLogicalNodeKind.Image) {
+            OfficeDocumentAsset asset = MapHtmlImage(node, path, assetIndex++);
+            projection.Assets.Add(asset);
+            projection.Visuals.Add(MapHtmlVisual(node, asset.Location, asset.PayloadHash, asset.MediaType));
+        } else if (node.Kind == HtmlLogicalNodeKind.Media) {
+            string anchor = "html-media-" + projection.Visuals.Count.ToString("D4", CultureInfo.InvariantCulture);
+            projection.Visuals.Add(MapHtmlVisual(node, BuildHtmlLocation(path, null, "media", anchor), null, null));
+        }
+        if (node.Kind == HtmlLogicalNodeKind.FormControl) {
+            projection.Forms.Add(MapHtmlFormControl(node, path, formIndex++));
+        }
+        foreach (HtmlLogicalNode child in node.Children) {
+            TraverseHtml(child, nextListName, nextListLevel, path, maxTableRows, projection, ref blockIndex, ref tableIndex, ref linkIndex, ref assetIndex, ref formIndex, cancellationToken);
+        }
+    }
+
+    private static ReaderTable MapHtmlTable(HtmlLogicalNode table, string? path, int tableIndex, int maxRows) {
+        List<HtmlLogicalNode> rows = GetHtmlTableRows(table).ToList();
+        int columnCount = rows.Count == 0 ? 0 : rows.Max(row => row.Children.Count(child => child.Kind == HtmlLogicalNodeKind.TableCell));
+        IReadOnlyList<string> columns = rows.Count == 0
+            ? Array.Empty<string>()
+            : BuildHtmlTableRow(rows[0], columnCount, true);
+        int totalRows = Math.Max(0, rows.Count - 1);
+        int emittedRows = maxRows > 0 ? Math.Min(totalRows, maxRows) : totalRows;
+        IReadOnlyList<IReadOnlyList<string>> values = rows.Skip(1).Take(emittedRows).Select(row => BuildHtmlTableRow(row, columnCount, false)).ToArray();
+        return new ReaderTable {
+            Title = table.Children.FirstOrDefault(child => child.Kind == HtmlLogicalNodeKind.TableCaption)?.Text ?? "HTML table " + (tableIndex + 1).ToString(CultureInfo.InvariantCulture),
+            Kind = "html-table",
+            Location = BuildHtmlLocation(path, null, "table", "html-table-" + tableIndex.ToString("D4", CultureInfo.InvariantCulture), tableIndex),
+            Columns = columns,
+            ColumnProfiles = ReaderTableProfiler.CreateProfiles(columns, values),
+            Rows = values,
+            TotalRowCount = totalRows,
+            Truncated = emittedRows < totalRows
+        };
+    }
+
+    private static IReadOnlyList<string> BuildHtmlTableRow(HtmlLogicalNode row, int columnCount, bool fallbacks) {
+        HtmlLogicalNode[] cells = row.Children.Where(child => child.Kind == HtmlLogicalNodeKind.TableCell).ToArray();
+        return Enumerable.Range(0, columnCount).Select(index => {
+            string value = index < cells.Length ? GetHtmlNodeText(cells[index]) : string.Empty;
+            return string.IsNullOrWhiteSpace(value) && fallbacks ? "Column " + (index + 1).ToString(CultureInfo.InvariantCulture) : value;
+        }).ToArray();
+    }
+
+    private static OfficeDocumentAsset MapHtmlImage(HtmlLogicalNode node, string? path, int index) {
+        node.Attributes.TryGetValue("src", out string? source);
+        node.Attributes.TryGetValue("alt", out string? altText);
+        node.Attributes.TryGetValue("title", out string? title);
+        byte[]? payload = null;
+        string? mediaType = null;
+        string? extension = null;
+        if (HtmlImageDataUri.TryParse(source, out HtmlImageDataUri dataUri) && dataUri.TryDecodeBytes(out byte[] bytes)) {
+            payload = bytes;
+            mediaType = dataUri.MediaType;
+            extension = dataUri.FileExtension;
+        }
+        string id = "html-image-" + index.ToString("D4", CultureInfo.InvariantCulture);
+        return new OfficeDocumentAsset {
+            Id = id,
+            Kind = "image",
+            MediaType = mediaType,
+            Extension = extension,
+            FileName = extension == null ? null : OfficeDocumentAssetNaming.BuildFileName(id, extension),
+            AltText = altText,
+            Title = title,
+            LengthBytes = payload?.LongLength,
+            PayloadHash = payload == null ? null : ComputeHtmlHash(payload),
+            PayloadBytes = payload,
+            SourceObjectId = payload == null ? source : "data-uri",
+            Location = BuildHtmlLocation(path, null, "image", id)
+        };
+    }
+
+    private static OfficeDocumentFormField MapHtmlFormControl(HtmlLogicalNode node, string? path, int index) {
+        node.Attributes.TryGetValue("name", out string? name);
+        node.Attributes.TryGetValue("value", out string? value);
+        string id = "html-form-" + index.ToString("D4", CultureInfo.InvariantCulture);
+        return new OfficeDocumentFormField {
+            Id = id,
+            Name = name,
+            Kind = node.Attributes.TryGetValue("type", out string? type) && !string.IsNullOrWhiteSpace(type) ? type : node.Name,
+            Value = value,
+            IsReadOnly = node.Attributes.ContainsKey("readonly") || node.Attributes.ContainsKey("disabled"),
+            IsRequired = node.Attributes.ContainsKey("required"),
+            Location = BuildHtmlLocation(path, null, "form-control", id)
+        };
+    }
+
+    private static ReaderVisual MapHtmlVisual(
+        HtmlLogicalNode node,
+        ReaderLocation location,
+        string? payloadHash,
+        string? mediaType) {
+        node.Attributes.TryGetValue("src", out string? source);
+        node.Attributes.TryGetValue("alt", out string? altText);
+        node.Attributes.TryGetValue("title", out string? title);
+        if (mediaType == null && node.Attributes.TryGetValue("type", out string? declaredType)) mediaType = declaredType;
+        string content = altText ?? title ?? GetHtmlNodeText(node);
+        if (string.IsNullOrWhiteSpace(content)) content = source ?? node.Name;
+        return new ReaderVisual {
+            Kind = node.Kind == HtmlLogicalNodeKind.Image ? "image" : "media",
+            Language = node.Name,
+            Content = content,
+            PayloadHash = payloadHash,
+            SourceName = source,
+            MimeType = mediaType,
+            PlacementCount = 1,
+            Location = new ReaderLocation {
+                Path = location.Path,
+                SourceBlockIndex = location.SourceBlockIndex,
+                SourceBlockKind = location.SourceBlockKind,
+                BlockAnchor = location.BlockAnchor
+            }
+        };
+    }
+
+    private static IReadOnlyList<OfficeDocumentMetadataEntry> BuildHtmlMetadata(HtmlLogicalDocument logical, HtmlProjection projection) {
+        return new[] {
+            CountHtmlMetadata("html-block-count", "BlockCount", projection.Blocks.Count),
+            CountHtmlMetadata("html-table-count", "TableCount", projection.Tables.Count),
+            CountHtmlMetadata("html-link-count", "LinkCount", projection.Links.Count),
+            CountHtmlMetadata("html-image-count", "ImageCount", projection.Assets.Count),
+            CountHtmlMetadata("html-form-count", "FormFieldCount", projection.Forms.Count),
+            CountHtmlMetadata("html-visual-count", "VisualCount", projection.Visuals.Count),
+            CountHtmlMetadata("html-heading-count", "HeadingCount", logical.Count(HtmlLogicalNodeKind.Heading))
+        };
+    }
+
+    private static OfficeDocumentMetadataEntry CountHtmlMetadata(string id, string name, int count) => new OfficeDocumentMetadataEntry {
+        Id = id, Category = "html.summary", Name = name, Value = count.ToString(CultureInfo.InvariantCulture), ValueType = "count"
+    };
+
+    private static string? FindHtmlMetadata(HtmlLogicalNode node, string elementName, string? metaName) {
+        if (node.Kind == HtmlLogicalNodeKind.Metadata && string.Equals(node.Name, elementName, StringComparison.OrdinalIgnoreCase)) {
+            if (metaName == null) return node.Text;
+            if (node.Attributes.TryGetValue("name", out string? name) && string.Equals(name, metaName, StringComparison.OrdinalIgnoreCase)
+                && node.Attributes.TryGetValue("content", out string? content)) return content;
+        }
+        foreach (HtmlLogicalNode child in node.Children) {
+            string? value = FindHtmlMetadata(child, elementName, metaName);
+            if (!string.IsNullOrWhiteSpace(value)) return value;
+        }
+        return null;
+    }
+
+    private static IEnumerable<HtmlLogicalNode> Descendants(HtmlLogicalNode node, HtmlLogicalNodeKind kind) {
+        foreach (HtmlLogicalNode child in node.Children) {
+            if (child.Kind == kind) yield return child;
+            foreach (HtmlLogicalNode descendant in Descendants(child, kind)) yield return descendant;
+        }
+    }
+
+    private static IEnumerable<HtmlLogicalNode> GetHtmlTableRows(HtmlLogicalNode node) {
+        foreach (HtmlLogicalNode child in node.Children) {
+            if (child.Kind == HtmlLogicalNodeKind.Table) continue;
+            if (child.Kind == HtmlLogicalNodeKind.TableRow) yield return child;
+            foreach (HtmlLogicalNode row in GetHtmlTableRows(child)) yield return row;
+        }
+    }
+
+    private static string GetHtmlNodeText(HtmlLogicalNode node) {
+        if (!string.IsNullOrWhiteSpace(node.Text)) return node.Text;
+        return string.Join(" ", Descendants(node, HtmlLogicalNodeKind.Text).Select(static child => child.Text).Where(static text => !string.IsNullOrWhiteSpace(text)));
+    }
+
+    private static bool IsHtmlBlock(HtmlLogicalNodeKind kind) => kind == HtmlLogicalNodeKind.Heading || kind == HtmlLogicalNodeKind.Paragraph
+        || kind == HtmlLogicalNodeKind.ListItem || kind == HtmlLogicalNodeKind.Table || kind == HtmlLogicalNodeKind.Figure
+        || kind == HtmlLogicalNodeKind.Image || kind == HtmlLogicalNodeKind.Media || kind == HtmlLogicalNodeKind.Form;
+
+    private static string NormalizeHtmlBlockKind(HtmlLogicalNodeKind kind) => kind switch {
+        HtmlLogicalNodeKind.ListItem => "list-item",
+        _ => kind.ToString().ToLowerInvariant()
+    };
+
+    private static int? ParseHtmlHeadingLevel(string name) => name.Length == 2 && name[0] == 'h' && name[1] >= '1' && name[1] <= '6' ? name[1] - '0' : null;
+
+    private static ReaderLocation BuildHtmlLocation(string? path, int? blockIndex, string kind, string anchor, int? tableIndex = null) => new ReaderLocation {
+        Path = path, SourceBlockIndex = blockIndex, SourceBlockKind = kind, BlockAnchor = anchor, TableIndex = tableIndex
+    };
+
+    private static string ComputeHtmlHash(byte[] bytes) {
+        using var sha = SHA256.Create();
+        return string.Concat(sha.ComputeHash(bytes).Select(static value => value.ToString("x2", CultureInfo.InvariantCulture)));
+    }
+
+    private sealed class HtmlProjection {
+        internal List<OfficeDocumentBlock> Blocks { get; } = new List<OfficeDocumentBlock>();
+        internal List<ReaderTable> Tables { get; } = new List<ReaderTable>();
+        internal List<OfficeDocumentLink> Links { get; } = new List<OfficeDocumentLink>();
+        internal List<OfficeDocumentAsset> Assets { get; } = new List<OfficeDocumentAsset>();
+        internal List<OfficeDocumentFormField> Forms { get; } = new List<OfficeDocumentFormField>();
+        internal List<ReaderVisual> Visuals { get; } = new List<ReaderVisual>();
+    }
+}

--- a/OfficeIMO.Reader.Html/DocumentReaderHtmlExtensions.Document.cs
+++ b/OfficeIMO.Reader.Html/DocumentReaderHtmlExtensions.Document.cs
@@ -1,4 +1,5 @@
 using OfficeIMO.Html;
+using OfficeIMO.Markdown.Html;
 using OfficeIMO.Reader;
 using System.Linq;
 using System.Security.Cryptography;
@@ -62,9 +63,11 @@ public static partial class DocumentReaderHtmlExtensions {
     }
 
     private static OfficeDocumentReadResult BuildHtmlDocumentResult(string html, SourceMetadata source, ReaderOptions readerOptions, ReaderHtmlOptions? htmlOptions, CancellationToken cancellationToken) {
-        ReaderChunk[] chunks = ReadHtmlString(html, source, readerOptions, htmlOptions, cancellationToken).ToArray();
+        ReaderHtmlOptions effectiveHtmlOptions = ReaderHtmlOptionsCloner.CloneOrDefault(htmlOptions);
+        HtmlToMarkdownOptions projectionOptions = effectiveHtmlOptions.HtmlToMarkdownOptions ?? HtmlToMarkdownOptions.CreateOfficeIMOProfile();
+        ReaderChunk[] chunks = ReadHtmlString(html, source, readerOptions, effectiveHtmlOptions, cancellationToken).ToArray();
         HtmlLogicalDocument logical = HtmlLogicalDocumentBuilder.FromHtml(html, useBodyContentsOnly: false);
-        HtmlProjection projection = ProjectHtml(logical, source.Path, readerOptions.MaxTableRows, cancellationToken);
+        HtmlProjection projection = ProjectHtml(logical, source.Path, readerOptions.MaxTableRows, projectionOptions, cancellationToken);
         var documentSource = new OfficeDocumentSource {
             Path = source.Path,
             SourceId = source.SourceId,
@@ -92,14 +95,19 @@ public static partial class DocumentReaderHtmlExtensions {
         return result;
     }
 
-    private static HtmlProjection ProjectHtml(HtmlLogicalDocument document, string? path, int maxTableRows, CancellationToken cancellationToken) {
+    private static HtmlProjection ProjectHtml(
+        HtmlLogicalDocument document,
+        string? path,
+        int maxTableRows,
+        HtmlToMarkdownOptions htmlOptions,
+        CancellationToken cancellationToken) {
         var projection = new HtmlProjection();
         int blockIndex = 0;
         int tableIndex = 0;
         int linkIndex = 0;
         int assetIndex = 0;
         int formIndex = 0;
-        TraverseHtml(document.Root, null, 0, path, maxTableRows, projection, ref blockIndex, ref tableIndex, ref linkIndex, ref assetIndex, ref formIndex, cancellationToken);
+        TraverseHtml(document.Root, null, 0, path, maxTableRows, htmlOptions, projection, ref blockIndex, ref tableIndex, ref linkIndex, ref assetIndex, ref formIndex, cancellationToken);
         return projection;
     }
 
@@ -109,6 +117,7 @@ public static partial class DocumentReaderHtmlExtensions {
         int listLevel,
         string? path,
         int maxTableRows,
+        HtmlToMarkdownOptions htmlOptions,
         HtmlProjection projection,
         ref int blockIndex,
         ref int tableIndex,
@@ -133,21 +142,27 @@ public static partial class DocumentReaderHtmlExtensions {
             blockIndex++;
         }
         if (node.Kind == HtmlLogicalNodeKind.Table) projection.Tables.Add(MapHtmlTable(node, path, tableIndex++, maxTableRows));
-        if (node.Kind == HtmlLogicalNodeKind.Link && node.Attributes.TryGetValue("href", out string? href) && !string.IsNullOrWhiteSpace(href)) {
-            projection.Links.Add(new OfficeDocumentLink {
-                Id = "html-link-" + linkIndex.ToString("D4", CultureInfo.InvariantCulture),
-                Kind = href.StartsWith("#", StringComparison.Ordinal) ? "internal" : "uri",
-                Uri = href.StartsWith("#", StringComparison.Ordinal) ? null : href,
-                DestinationName = href.StartsWith("#", StringComparison.Ordinal) ? href.Substring(1) : null,
-                Text = GetHtmlNodeText(node),
-                Location = BuildHtmlLocation(path, null, "hyperlink", "html-link-" + linkIndex.ToString("D4", CultureInfo.InvariantCulture))
-            });
-            linkIndex++;
+        if (node.Kind == HtmlLogicalNodeKind.Link && node.Attributes.TryGetValue("href", out string? href)) {
+            string resolvedHref = HtmlUrlPolicyEvaluator.ResolveUrl(href, htmlOptions.BaseUri, htmlOptions.UrlPolicy);
+            if (!string.IsNullOrWhiteSpace(resolvedHref)) {
+                projection.Links.Add(new OfficeDocumentLink {
+                    Id = "html-link-" + linkIndex.ToString("D4", CultureInfo.InvariantCulture),
+                    Kind = resolvedHref.StartsWith("#", StringComparison.Ordinal) ? "internal" : "uri",
+                    Uri = resolvedHref.StartsWith("#", StringComparison.Ordinal) ? null : resolvedHref,
+                    DestinationName = resolvedHref.StartsWith("#", StringComparison.Ordinal) ? resolvedHref.Substring(1) : null,
+                    Text = GetHtmlNodeText(node),
+                    Location = BuildHtmlLocation(path, null, "hyperlink", "html-link-" + linkIndex.ToString("D4", CultureInfo.InvariantCulture))
+                });
+                linkIndex++;
+            }
         }
         if (node.Kind == HtmlLogicalNodeKind.Image) {
-            OfficeDocumentAsset asset = MapHtmlImage(node, path, assetIndex++);
-            projection.Assets.Add(asset);
-            projection.Visuals.Add(MapHtmlVisual(node, asset.Location, asset.PayloadHash, asset.MediaType));
+            OfficeDocumentAsset? asset = MapHtmlImage(node, path, assetIndex, htmlOptions);
+            if (asset != null) {
+                assetIndex++;
+                projection.Assets.Add(asset);
+                projection.Visuals.Add(MapHtmlVisual(node, asset.Location, asset.PayloadHash, asset.MediaType, asset.SourceObjectId));
+            }
         } else if (node.Kind == HtmlLogicalNodeKind.Media) {
             string anchor = "html-media-" + projection.Visuals.Count.ToString("D4", CultureInfo.InvariantCulture);
             projection.Visuals.Add(MapHtmlVisual(node, BuildHtmlLocation(path, null, "media", anchor), null, null));
@@ -156,7 +171,7 @@ public static partial class DocumentReaderHtmlExtensions {
             projection.Forms.Add(MapHtmlFormControl(node, path, formIndex++));
         }
         foreach (HtmlLogicalNode child in node.Children) {
-            TraverseHtml(child, nextListName, nextListLevel, path, maxTableRows, projection, ref blockIndex, ref tableIndex, ref linkIndex, ref assetIndex, ref formIndex, cancellationToken);
+            TraverseHtml(child, nextListName, nextListLevel, path, maxTableRows, htmlOptions, projection, ref blockIndex, ref tableIndex, ref linkIndex, ref assetIndex, ref formIndex, cancellationToken);
         }
     }
 
@@ -189,14 +204,18 @@ public static partial class DocumentReaderHtmlExtensions {
         }).ToArray();
     }
 
-    private static OfficeDocumentAsset MapHtmlImage(HtmlLogicalNode node, string? path, int index) {
+    private static OfficeDocumentAsset? MapHtmlImage(HtmlLogicalNode node, string? path, int index, HtmlToMarkdownOptions htmlOptions) {
         node.Attributes.TryGetValue("src", out string? source);
         node.Attributes.TryGetValue("alt", out string? altText);
         node.Attributes.TryGetValue("title", out string? title);
+        string resolvedSource = HtmlUrlPolicyEvaluator.ResolveUrl(source, htmlOptions.BaseUri, htmlOptions.UrlPolicy);
+        if (string.IsNullOrWhiteSpace(resolvedSource)) return null;
         byte[]? payload = null;
         string? mediaType = null;
         string? extension = null;
-        if (HtmlImageDataUri.TryParse(source, out HtmlImageDataUri dataUri) && dataUri.TryDecodeBytes(out byte[] bytes)) {
+        if (HtmlImageDataUri.TryParse(resolvedSource, out HtmlImageDataUri dataUri)) {
+            if (dataUri.IsBase64 && htmlOptions.Base64Images != HtmlBase64ImageHandling.Include) return null;
+            if (!dataUri.TryDecodeBytes(out byte[] bytes)) return null;
             payload = bytes;
             mediaType = dataUri.MediaType;
             extension = dataUri.FileExtension;
@@ -213,7 +232,7 @@ public static partial class DocumentReaderHtmlExtensions {
             LengthBytes = payload?.LongLength,
             PayloadHash = payload == null ? null : ComputeHtmlHash(payload),
             PayloadBytes = payload,
-            SourceObjectId = payload == null ? source : "data-uri",
+            SourceObjectId = payload == null ? resolvedSource : "data-uri",
             Location = BuildHtmlLocation(path, null, "image", id)
         };
     }
@@ -237,8 +256,10 @@ public static partial class DocumentReaderHtmlExtensions {
         HtmlLogicalNode node,
         ReaderLocation location,
         string? payloadHash,
-        string? mediaType) {
+        string? mediaType,
+        string? sourceOverride = null) {
         node.Attributes.TryGetValue("src", out string? source);
+        if (!string.IsNullOrWhiteSpace(sourceOverride)) source = sourceOverride;
         node.Attributes.TryGetValue("alt", out string? altText);
         node.Attributes.TryGetValue("title", out string? title);
         if (mediaType == null && node.Attributes.TryGetValue("type", out string? declaredType)) mediaType = declaredType;

--- a/OfficeIMO.Reader.Html/DocumentReaderHtmlExtensions.Document.cs
+++ b/OfficeIMO.Reader.Html/DocumentReaderHtmlExtensions.Document.cs
@@ -65,8 +65,22 @@ public static partial class DocumentReaderHtmlExtensions {
     private static OfficeDocumentReadResult BuildHtmlDocumentResult(string html, SourceMetadata source, ReaderOptions readerOptions, ReaderHtmlOptions? htmlOptions, CancellationToken cancellationToken) {
         ReaderHtmlOptions effectiveHtmlOptions = ReaderHtmlOptionsCloner.CloneOrDefault(htmlOptions);
         HtmlToMarkdownOptions projectionOptions = effectiveHtmlOptions.HtmlToMarkdownOptions ?? HtmlToMarkdownOptions.CreateOfficeIMOProfile();
-        ReaderChunk[] chunks = ReadHtmlString(html, source, readerOptions, effectiveHtmlOptions, cancellationToken).ToArray();
-        HtmlLogicalDocument logical = HtmlLogicalDocumentBuilder.FromHtml(html, useBodyContentsOnly: false);
+        bool hasProjectionFilters = projectionOptions.ExcludeSelectors.Count > 0 || projectionOptions.ElementFilters.Count > 0;
+        string projectedHtml = html;
+        HtmlLogicalDocument logical;
+        ReaderHtmlOptions chunkHtmlOptions = effectiveHtmlOptions;
+        if (hasProjectionFilters) {
+            var filtered = new HtmlToMarkdownConverter().ParseFilteredDocument(html, projectionOptions);
+            projectionOptions.BaseUri = HtmlDocumentParser.ResolveEffectiveBaseUri(filtered, projectionOptions.BaseUri);
+            logical = HtmlLogicalDocumentBuilder.FromDocument(filtered, useBodyContentsOnly: false);
+            projectedHtml = filtered.DocumentElement?.OuterHtml ?? html;
+            chunkHtmlOptions = effectiveHtmlOptions.Clone();
+            chunkHtmlOptions.HtmlToMarkdownOptions?.ExcludeSelectors.Clear();
+            chunkHtmlOptions.HtmlToMarkdownOptions?.ElementFilters.Clear();
+        } else {
+            logical = HtmlLogicalDocumentBuilder.FromHtml(html, useBodyContentsOnly: false);
+        }
+        ReaderChunk[] chunks = ReadHtmlString(projectedHtml, source, readerOptions, chunkHtmlOptions, cancellationToken).ToArray();
         HtmlProjection projection = ProjectHtml(logical, source.Path, readerOptions.MaxTableRows, projectionOptions, cancellationToken);
         var documentSource = new OfficeDocumentSource {
             Path = source.Path,
@@ -85,7 +99,7 @@ public static partial class DocumentReaderHtmlExtensions {
             documentSource,
             new[] { "officeimo.reader.html.rich-v5", "officeimo.html.logical-document" }.Concat(logical.Capabilities.Select(static capability => "officeimo.html." + capability)),
             projection.Assets);
-        result.Html = html;
+        result.Html = projectedHtml;
         result.Blocks = projection.Blocks;
         result.Tables = projection.Tables;
         result.Links = projection.Links;
@@ -170,7 +184,8 @@ public static partial class DocumentReaderHtmlExtensions {
             string anchor = "html-media-" + projection.Visuals.Count.ToString("D4", CultureInfo.InvariantCulture);
             projection.Visuals.Add(MapHtmlVisual(node, BuildHtmlLocation(path, null, "media", anchor), null, null));
         }
-        if (node.Kind == HtmlLogicalNodeKind.FormControl) {
+        if (node.Kind == HtmlLogicalNodeKind.FormControl &&
+            !string.Equals(node.Name, "option", StringComparison.OrdinalIgnoreCase)) {
             projection.Forms.Add(MapHtmlFormControl(node, path, formIndex++));
         }
         foreach (HtmlLogicalNode child in node.Children) {
@@ -181,12 +196,17 @@ public static partial class DocumentReaderHtmlExtensions {
     private static ReaderTable MapHtmlTable(HtmlLogicalNode table, string? path, int tableIndex, int maxRows) {
         List<HtmlLogicalNode> rows = GetHtmlTableRows(table).ToList();
         int columnCount = rows.Count == 0 ? 0 : rows.Max(row => row.Children.Count(child => child.Kind == HtmlLogicalNodeKind.TableCell));
-        IReadOnlyList<string> columns = rows.Count == 0
-            ? Array.Empty<string>()
-            : BuildHtmlTableRow(rows[0], columnCount, true);
-        int totalRows = Math.Max(0, rows.Count - 1);
+        bool hasHeaderRow = rows.Count > 0 && rows[0].Children.Any(child =>
+            child.Kind == HtmlLogicalNodeKind.TableCell && string.Equals(child.Name, "th", StringComparison.OrdinalIgnoreCase));
+        IReadOnlyList<string> columns = hasHeaderRow
+            ? BuildHtmlTableRow(rows[0], columnCount, true)
+            : Enumerable.Range(1, columnCount)
+                .Select(index => "Column " + index.ToString(CultureInfo.InvariantCulture))
+                .ToArray();
+        int dataStart = hasHeaderRow ? 1 : 0;
+        int totalRows = Math.Max(0, rows.Count - dataStart);
         int emittedRows = maxRows > 0 ? Math.Min(totalRows, maxRows) : totalRows;
-        IReadOnlyList<IReadOnlyList<string>> values = rows.Skip(1).Take(emittedRows).Select(row => BuildHtmlTableRow(row, columnCount, false)).ToArray();
+        IReadOnlyList<IReadOnlyList<string>> values = rows.Skip(dataStart).Take(emittedRows).Select(row => BuildHtmlTableRow(row, columnCount, false)).ToArray();
         return new ReaderTable {
             Title = table.Children.FirstOrDefault(child => child.Kind == HtmlLogicalNodeKind.TableCaption)?.Text ?? "HTML table " + (tableIndex + 1).ToString(CultureInfo.InvariantCulture),
             Kind = "html-table",
@@ -244,6 +264,14 @@ public static partial class DocumentReaderHtmlExtensions {
         bool hasValue = node.Attributes.TryGetValue("value", out string? value);
         if (!hasValue && string.Equals(node.Name, "textarea", StringComparison.OrdinalIgnoreCase)) {
             value = GetHtmlNodeText(node);
+        } else if (!hasValue && string.Equals(node.Name, "select", StringComparison.OrdinalIgnoreCase)) {
+            HtmlLogicalNode[] options = EnumerateHtmlOptions(node).ToArray();
+            HtmlLogicalNode[] selected = options.Where(option => option.Attributes.ContainsKey("selected")).ToArray();
+            if (selected.Length == 0 && options.Length > 0) selected = new[] { options[0] };
+            value = string.Join("\n", selected.Select(option =>
+                option.Attributes.TryGetValue("value", out string? optionValue) && !string.IsNullOrWhiteSpace(optionValue)
+                    ? optionValue
+                    : GetHtmlNodeText(option)));
         }
         string id = "html-form-" + index.ToString("D4", CultureInfo.InvariantCulture);
         return new OfficeDocumentFormField {
@@ -255,6 +283,16 @@ public static partial class DocumentReaderHtmlExtensions {
             IsRequired = node.Attributes.ContainsKey("required"),
             Location = BuildHtmlLocation(path, null, "form-control", id)
         };
+    }
+
+    private static IEnumerable<HtmlLogicalNode> EnumerateHtmlOptions(HtmlLogicalNode node) {
+        foreach (HtmlLogicalNode child in node.Children) {
+            if (child.Kind == HtmlLogicalNodeKind.FormControl &&
+                string.Equals(child.Name, "option", StringComparison.OrdinalIgnoreCase)) {
+                yield return child;
+            }
+            foreach (HtmlLogicalNode descendant in EnumerateHtmlOptions(child)) yield return descendant;
+        }
     }
 
     private static string BuildHtmlTableBlockText(ReaderTable table) {

--- a/OfficeIMO.Reader.Html/DocumentReaderHtmlExtensions.cs
+++ b/OfficeIMO.Reader.Html/DocumentReaderHtmlExtensions.cs
@@ -6,7 +6,7 @@ namespace OfficeIMO.Reader.Html;
 /// <summary>
 /// HTML ingestion adapter for <see cref="DocumentReader"/>.
 /// </summary>
-public static class DocumentReaderHtmlExtensions {
+public static partial class DocumentReaderHtmlExtensions {
     /// <summary>
     /// Reads an HTML file and emits normalized chunks.
     /// </summary>

--- a/OfficeIMO.Reader.Html/DocumentReaderHtmlRegistrationExtensions.cs
+++ b/OfficeIMO.Reader.Html/DocumentReaderHtmlRegistrationExtensions.cs
@@ -73,6 +73,17 @@ public static class DocumentReaderHtmlRegistrationExtensions {
                 sourceName: sourceName,
                 readerOptions: readerOptions,
                 htmlOptions: ReaderHtmlOptionsCloner.CloneNullable(registeredOptions),
+                cancellationToken: ct),
+            ReadDocumentPath = (path, readerOptions, ct) => DocumentReaderHtmlExtensions.ReadHtmlDocument(
+                htmlPath: path,
+                readerOptions: readerOptions,
+                htmlOptions: ReaderHtmlOptionsCloner.CloneNullable(registeredOptions),
+                cancellationToken: ct),
+            ReadDocumentStream = (stream, sourceName, readerOptions, ct) => DocumentReaderHtmlExtensions.ReadHtmlDocument(
+                htmlStream: stream,
+                sourceName: sourceName,
+                readerOptions: readerOptions,
+                htmlOptions: ReaderHtmlOptionsCloner.CloneNullable(registeredOptions),
                 cancellationToken: ct)
         };
     }

--- a/OfficeIMO.Reader.Html/OfficeIMO.Reader.Html.csproj
+++ b/OfficeIMO.Reader.Html/OfficeIMO.Reader.Html.csproj
@@ -28,6 +28,7 @@
   <ItemGroup>
     <ProjectReference Include="..\OfficeIMO.Reader\OfficeIMO.Reader.csproj" />
     <ProjectReference Include="..\OfficeIMO.Markdown.Html\OfficeIMO.Markdown.Html.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Html\OfficeIMO.Html.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/OfficeIMO.Reader.Html/README.md
+++ b/OfficeIMO.Reader.Html/README.md
@@ -67,6 +67,23 @@ foreach (var table in tables) {
 }
 ```
 
+### Read the rich document result
+
+```csharp
+OfficeDocumentReadResult document =
+    DocumentReaderHtmlExtensions.ReadHtmlDocument("application.html");
+
+foreach (OfficeDocumentFormField field in document.Forms) {
+    Console.WriteLine($"{field.Name}: {field.Value}");
+}
+
+foreach (OfficeDocumentLink link in document.Links) {
+    Console.WriteLine(link.Uri ?? link.DestinationName);
+}
+```
+
+After registration, `DocumentReader.ReadDocument("application.html")` dispatches to this native rich mapping as well.
+
 ## What it emits
 
 - HTML converted to Markdown through `OfficeIMO.Markdown.Html`.
@@ -74,6 +91,7 @@ foreach (var table in tables) {
 - Table extraction with `ReaderTable.ColumnProfiles`.
 - Heading-aware chunk metadata when `ReaderOptions.MarkdownChunkByHeadings` is enabled.
 - HTML-to-Markdown profile, transform, converter, and visual round-trip option pass-through.
+- A schema-v5 rich result containing semantic blocks, figures, tables, links, form controls, media visuals, metadata, and bounded data-URI image assets.
 
 ## Boundaries
 

--- a/OfficeIMO.Reader.Rtf/DocumentReaderRtfExtensions.Document.cs
+++ b/OfficeIMO.Reader.Rtf/DocumentReaderRtfExtensions.Document.cs
@@ -1,0 +1,294 @@
+using OfficeIMO.Reader;
+using OfficeIMO.Rtf;
+using OfficeIMO.Rtf.Diagnostics;
+using System.Linq;
+
+namespace OfficeIMO.Reader.Rtf;
+
+public static partial class DocumentReaderRtfExtensions {
+    /// <summary>Reads an RTF file into the shared rich document envelope.</summary>
+    public static OfficeDocumentReadResult ReadRtfDocumentResult(string rtfPath, ReaderOptions? readerOptions = null, ReaderRtfOptions? rtfOptions = null, Encoding? encoding = null, CancellationToken cancellationToken = default) {
+        if (rtfPath == null) throw new ArgumentNullException(nameof(rtfPath));
+        if (rtfPath.Length == 0) throw new ArgumentException("RTF path cannot be empty.", nameof(rtfPath));
+        if (!File.Exists(rtfPath)) throw new FileNotFoundException($"RTF file '{rtfPath}' doesn't exist.", rtfPath);
+        ReaderOptions effectiveReaderOptions = readerOptions ?? new ReaderOptions();
+        ReaderRtfOptions effectiveRtfOptions = ReaderRtfOptionsCloner.CloneOrDefault(rtfOptions);
+        ReaderInputLimits.EnforceFileSize(rtfPath, effectiveReaderOptions.MaxInputBytes);
+        SourceMetadata source = BuildSourceMetadataFromPath(rtfPath, effectiveReaderOptions.ComputeHashes);
+        RtfReadResult readResult = RtfDocument.Load(rtfPath, ReaderRtfOptions.CloneReadOptions(effectiveRtfOptions.RtfReadOptions), encoding);
+        return BuildRtfDocumentResult(readResult, source, effectiveReaderOptions, effectiveRtfOptions, cancellationToken);
+    }
+
+    /// <summary>Reads an RTF stream into the shared rich document envelope.</summary>
+    public static OfficeDocumentReadResult ReadRtfDocumentResult(Stream rtfStream, string? sourceName = null, ReaderOptions? readerOptions = null, ReaderRtfOptions? rtfOptions = null, Encoding? encoding = null, CancellationToken cancellationToken = default) {
+        if (rtfStream == null) throw new ArgumentNullException(nameof(rtfStream));
+        if (!rtfStream.CanRead) throw new ArgumentException("RTF stream must be readable.", nameof(rtfStream));
+        ReaderOptions effectiveReaderOptions = readerOptions ?? new ReaderOptions();
+        ReaderRtfOptions effectiveRtfOptions = ReaderRtfOptionsCloner.CloneOrDefault(rtfOptions);
+        string logicalSourceName = NormalizeLogicalSourceName(sourceName, "document.rtf");
+        var source = new SourceMetadata { Path = logicalSourceName, SourceId = BuildSourceId(logicalSourceName) };
+        Stream parseStream = ReaderInputLimits.EnsureSeekableReadStream(rtfStream, effectiveReaderOptions.MaxInputBytes, cancellationToken, out bool ownsParseStream);
+        try {
+            long start = parseStream.CanSeek ? parseStream.Position : 0L;
+            UpdateSourceMetadataFromSeekableStream(source, parseStream, effectiveReaderOptions.ComputeHashes, start);
+            if (parseStream.CanSeek) parseStream.Position = start;
+            RtfReadResult readResult = RtfDocument.Load(parseStream, ReaderRtfOptions.CloneReadOptions(effectiveRtfOptions.RtfReadOptions), encoding);
+            return BuildRtfDocumentResult(readResult, source, effectiveReaderOptions, effectiveRtfOptions, cancellationToken);
+        } finally {
+            if (ownsParseStream) parseStream.Dispose();
+        }
+    }
+
+    /// <summary>Converts a loaded RTF semantic document into the shared rich document envelope.</summary>
+    public static OfficeDocumentReadResult ReadRtfDocumentResult(RtfDocument document, string sourceName = "document.rtf", ReaderOptions? readerOptions = null, ReaderRtfOptions? rtfOptions = null, CancellationToken cancellationToken = default) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        if (sourceName == null) throw new ArgumentNullException(nameof(sourceName));
+        ReaderOptions effectiveReaderOptions = readerOptions ?? new ReaderOptions();
+        ReaderRtfOptions effectiveRtfOptions = ReaderRtfOptionsCloner.CloneOrDefault(rtfOptions);
+        string logicalSourceName = NormalizeLogicalSourceName(sourceName, "document.rtf");
+        var source = new SourceMetadata { Path = logicalSourceName, SourceId = BuildSourceId(logicalSourceName) };
+        return BuildRtfDocumentResult(document, Array.Empty<RtfDiagnostic>(), source, effectiveReaderOptions, effectiveRtfOptions, cancellationToken);
+    }
+
+    /// <summary>Reads an RTF file into the shared rich document JSON envelope.</summary>
+    public static string ReadRtfDocumentResultJson(string rtfPath, ReaderOptions? readerOptions = null, ReaderRtfOptions? rtfOptions = null, Encoding? encoding = null, bool indented = false, CancellationToken cancellationToken = default) {
+        return OfficeDocumentReadResultJson.Serialize(ReadRtfDocumentResult(rtfPath, readerOptions, rtfOptions, encoding, cancellationToken), indented);
+    }
+
+    /// <summary>Reads an RTF stream into the shared rich document JSON envelope.</summary>
+    public static string ReadRtfDocumentResultJson(Stream rtfStream, string? sourceName = null, ReaderOptions? readerOptions = null, ReaderRtfOptions? rtfOptions = null, Encoding? encoding = null, bool indented = false, CancellationToken cancellationToken = default) {
+        return OfficeDocumentReadResultJson.Serialize(ReadRtfDocumentResult(rtfStream, sourceName, readerOptions, rtfOptions, encoding, cancellationToken), indented);
+    }
+
+    /// <summary>Converts a loaded RTF semantic document into the shared rich document JSON envelope.</summary>
+    public static string ReadRtfDocumentResultJson(RtfDocument document, string sourceName = "document.rtf", ReaderOptions? readerOptions = null, ReaderRtfOptions? rtfOptions = null, bool indented = false, CancellationToken cancellationToken = default) {
+        return OfficeDocumentReadResultJson.Serialize(ReadRtfDocumentResult(document, sourceName, readerOptions, rtfOptions, cancellationToken), indented);
+    }
+
+    private static OfficeDocumentReadResult BuildRtfDocumentResult(RtfReadResult readResult, SourceMetadata source, ReaderOptions readerOptions, ReaderRtfOptions rtfOptions, CancellationToken cancellationToken) {
+        return BuildRtfDocumentResult(readResult.Document, readResult.Diagnostics, source, readerOptions, rtfOptions, cancellationToken);
+    }
+
+    private static OfficeDocumentReadResult BuildRtfDocumentResult(RtfDocument document, IReadOnlyList<RtfDiagnostic> sourceDiagnostics, SourceMetadata source, ReaderOptions readerOptions, ReaderRtfOptions rtfOptions, CancellationToken cancellationToken) {
+        IReadOnlyList<RtfDiagnostic> includedDiagnostics = rtfOptions.IncludeDiagnostics ? sourceDiagnostics : Array.Empty<RtfDiagnostic>();
+        ReaderChunk[] chunks = ReadRtfDocument(document, source, readerOptions, rtfOptions, includedDiagnostics, cancellationToken).ToArray();
+        RtfRichProjection projection = ProjectRtfDocument(document, source.Path, readerOptions.MaxTableRows, rtfOptions, cancellationToken);
+        var documentSource = new OfficeDocumentSource {
+            Path = source.Path,
+            SourceId = source.SourceId,
+            SourceHash = source.SourceHash,
+            LastWriteUtc = source.LastWriteUtc,
+            LengthBytes = source.LengthBytes,
+            Title = document.Info.Title,
+            Author = document.Info.Author,
+            Subject = document.Info.Subject,
+            Keywords = document.Info.Keywords
+        };
+        OfficeDocumentReadResult result = DocumentReader.CreateDocumentResult(
+            chunks,
+            ReaderInputKind.Rtf,
+            documentSource,
+            new[] { "officeimo.reader.rtf.rich-v5", "officeimo.rtf.semantic-model" },
+            projection.Assets);
+        result.Blocks = projection.Blocks;
+        result.Tables = projection.Tables;
+        result.Links = projection.Links;
+        result.Forms = projection.Forms;
+        result.Visuals = projection.Visuals;
+        result.Metadata = BuildRtfMetadata(document, projection);
+        result.Diagnostics = result.Diagnostics.Concat(MapRtfDiagnostics(includedDiagnostics, source.Path)).ToArray();
+        return result;
+    }
+
+    private static RtfRichProjection ProjectRtfDocument(RtfDocument document, string sourcePath, int maxTableRows, ReaderRtfOptions options, CancellationToken cancellationToken) {
+        var projection = new RtfRichProjection();
+        int blockIndex = 0;
+        int tableIndex = 0;
+        int linkIndex = 0;
+        int assetIndex = 0;
+        int formIndex = 0;
+        foreach (IRtfBlock sourceBlock in document.Blocks) {
+            cancellationToken.ThrowIfCancellationRequested();
+            string kind = ResolveRtfBlockKind(sourceBlock);
+            ReaderLocation location = BuildRtfRichLocation(sourcePath, blockIndex, kind, "rtf-" + kind + "-" + blockIndex.ToString("D4", CultureInfo.InvariantCulture));
+            switch (sourceBlock) {
+                case RtfParagraph paragraph:
+                    projection.Blocks.Add(MapRtfParagraphBlock(paragraph, location));
+                    ProjectRtfParagraphContent(paragraph, location, projection, ref linkIndex, ref assetIndex, ref formIndex);
+                    break;
+                case RtfTable table:
+                    projection.Blocks.Add(new OfficeDocumentBlock { Id = location.BlockAnchor!, Kind = "table", Text = BuildRtfTableText(table), Location = location });
+                    ReaderTable mapped = BuildReaderTable(table, tableIndex);
+                    mapped.Kind = "rtf-table";
+                    mapped.Location = BuildRtfRichLocation(sourcePath, blockIndex, "table", location.BlockAnchor!, tableIndex);
+                    ApplyRtfTableLimit(mapped, maxTableRows);
+                    projection.Tables.Add(mapped);
+                    foreach (RtfTableRow row in table.Rows) foreach (RtfTableCell cell in row.Cells) foreach (RtfParagraph paragraph in cell.Paragraphs) ProjectRtfParagraphContent(paragraph, location, projection, ref linkIndex, ref assetIndex, ref formIndex);
+                    tableIndex++;
+                    break;
+                case RtfImage image when options.IncludeImagePlaceholders:
+                    projection.Blocks.Add(new OfficeDocumentBlock { Id = location.BlockAnchor!, Kind = "image", Text = image.Description ?? "RTF image", Location = location });
+                    AddRtfImage(image, location, projection, ref assetIndex);
+                    break;
+                case RtfObject rtfObject:
+                    projection.Blocks.Add(new OfficeDocumentBlock { Id = location.BlockAnchor!, Kind = "object", Text = rtfObject.ToPlainText(), Location = location });
+                    ProjectRtfParagraphContent(rtfObject.Result, location, projection, ref linkIndex, ref assetIndex, ref formIndex);
+                    if (rtfObject.ResultImage != null) AddRtfImage(rtfObject.ResultImage, location, projection, ref assetIndex);
+                    if (rtfObject.Data.Length > 0) projection.Assets.Add(BuildRtfObjectAsset(rtfObject, location, assetIndex++));
+                    break;
+                case RtfShape shape:
+                    projection.Blocks.Add(new OfficeDocumentBlock { Id = location.BlockAnchor!, Kind = "shape", Text = shape.ToPlainText(), Location = location });
+                    foreach (RtfParagraph paragraph in shape.TextBoxParagraphs) ProjectRtfParagraphContent(paragraph, location, projection, ref linkIndex, ref assetIndex, ref formIndex);
+                    break;
+            }
+            blockIndex++;
+        }
+        if (options.IncludeHeadersAndFooters) foreach (RtfHeaderFooter headerFooter in document.HeaderFooters) {
+            string id = "rtf-header-footer-" + blockIndex.ToString("D4", CultureInfo.InvariantCulture);
+            projection.Blocks.Add(new OfficeDocumentBlock {
+                Id = id,
+                Kind = "header-footer",
+                Text = headerFooter.ToPlainText(),
+                Location = BuildRtfRichLocation(sourcePath, blockIndex, "header-footer", id)
+            });
+            blockIndex++;
+        }
+        if (options.IncludeNotes) foreach (RtfNote note in document.Notes) {
+            string id = "rtf-note-" + blockIndex.ToString("D4", CultureInfo.InvariantCulture);
+            projection.Blocks.Add(new OfficeDocumentBlock {
+                Id = id,
+                Kind = "note",
+                Text = note.ToPlainText(),
+                Location = BuildRtfRichLocation(sourcePath, blockIndex, "note", id)
+            });
+            blockIndex++;
+        }
+        return projection;
+    }
+
+    private static OfficeDocumentBlock MapRtfParagraphBlock(RtfParagraph paragraph, ReaderLocation location) {
+        bool isList = paragraph.ListKind != RtfListKind.None;
+        return new OfficeDocumentBlock {
+            Id = location.BlockAnchor!, Kind = isList ? "list-item" : paragraph.OutlineLevel.HasValue ? "heading" : "paragraph",
+            Text = paragraph.ToPlainText(), Level = paragraph.OutlineLevel ?? paragraph.ListLevel,
+            Marker = paragraph.ListKind == RtfListKind.Decimal ? "1." : paragraph.ListKind == RtfListKind.Bullet ? "-" : null,
+            Location = location
+        };
+    }
+
+    private static void ProjectRtfParagraphContent(RtfParagraph paragraph, ReaderLocation location, RtfRichProjection projection, ref int linkIndex, ref int assetIndex, ref int formIndex) {
+        foreach (IRtfInline inline in paragraph.Inlines) {
+            if (inline is RtfRun run && run.Hyperlink != null) projection.Links.Add(BuildRtfLink(run.Hyperlink.ToString(), null, run.Text, location, linkIndex++));
+            else if (inline is RtfField field) {
+                RtfHyperlinkFieldInfo? hyperlink = field.HyperlinkField;
+                if (hyperlink != null && (hyperlink.Target != null || !string.IsNullOrWhiteSpace(hyperlink.SubAddress))) projection.Links.Add(BuildRtfLink(hyperlink.Target?.ToString(), hyperlink.SubAddress, hyperlink.ScreenTip ?? field.ToPlainText(), location, linkIndex++));
+                if (field.FormFieldData != null) projection.Forms.Add(BuildRtfForm(field, location, formIndex++));
+                ProjectRtfParagraphContent(field.Result, location, projection, ref linkIndex, ref assetIndex, ref formIndex);
+            } else if (inline is RtfImage image) AddRtfImage(image, location, projection, ref assetIndex);
+            else if (inline is RtfObject rtfObject) {
+                if (rtfObject.ResultImage != null) AddRtfImage(rtfObject.ResultImage, location, projection, ref assetIndex);
+                if (rtfObject.Data.Length > 0) projection.Assets.Add(BuildRtfObjectAsset(rtfObject, location, assetIndex++));
+            }
+        }
+    }
+
+    private static void AddRtfImage(RtfImage image, ReaderLocation owner, RtfRichProjection projection, ref int assetIndex) {
+        string id = "rtf-image-" + assetIndex.ToString("D4", CultureInfo.InvariantCulture);
+        string? mediaType = GetImageMimeType(image.Format);
+        string? extension = GetRtfImageExtension(image.Format);
+        ReaderLocation location = BuildRtfRichLocation(owner.Path!, owner.SourceBlockIndex, "image", id);
+        projection.Assets.Add(new OfficeDocumentAsset {
+            Id = id, Kind = "image", MediaType = mediaType, Extension = extension,
+            FileName = OfficeDocumentAssetNaming.BuildFileName(id, extension), AltText = image.Description,
+            Width = image.SourceWidth, Height = image.SourceHeight, LengthBytes = image.Data.LongLength,
+            PayloadHash = ComputeSha256Hex(image.Data), PayloadBytes = image.Data, Location = location
+        });
+        projection.Visuals.Add(new ReaderVisual {
+            Kind = "image", Language = "rtf-image", Content = image.Description ?? id, PayloadHash = ComputeSha256Hex(image.Data),
+            MimeType = mediaType, Width = image.SourceWidth, Height = image.SourceHeight,
+            PlacedWidth = image.DesiredWidthTwips, PlacedHeight = image.DesiredHeightTwips,
+            PlacementCount = 1, HasGeometry = image.DesiredWidthTwips.HasValue || image.DesiredHeightTwips.HasValue, Location = location
+        });
+        assetIndex++;
+    }
+
+    private static OfficeDocumentAsset BuildRtfObjectAsset(RtfObject value, ReaderLocation owner, int index) {
+        string id = "rtf-object-" + index.ToString("D4", CultureInfo.InvariantCulture);
+        return new OfficeDocumentAsset {
+            Id = id, Kind = "embedded-object", FileName = OfficeDocumentAssetNaming.BuildFileName(id, ".bin"),
+            Title = value.Name ?? value.ClassName, LengthBytes = value.Data.LongLength,
+            PayloadHash = ComputeSha256Hex(value.Data), PayloadBytes = value.Data,
+            Location = BuildRtfRichLocation(owner.Path!, owner.SourceBlockIndex, "embedded-object", id)
+        };
+    }
+
+    private static OfficeDocumentLink BuildRtfLink(string? uri, string? destination, string? text, ReaderLocation owner, int index) => new OfficeDocumentLink {
+        Id = "rtf-link-" + index.ToString("D4", CultureInfo.InvariantCulture), Kind = string.IsNullOrWhiteSpace(uri) ? "internal" : "uri",
+        Uri = uri, DestinationName = destination, Text = text,
+        Location = BuildRtfRichLocation(owner.Path!, owner.SourceBlockIndex, "hyperlink", owner.BlockAnchor + "-link-" + index.ToString("D4", CultureInfo.InvariantCulture))
+    };
+
+    private static OfficeDocumentFormField BuildRtfForm(RtfField field, ReaderLocation owner, int index) {
+        RtfFormFieldData data = field.FormFieldData!;
+        return new OfficeDocumentFormField {
+            Id = "rtf-form-" + index.ToString("D4", CultureInfo.InvariantCulture), Name = data.Name,
+            Kind = data.Kind?.ToString() ?? "unknown", Value = field.ToPlainText(), IsReadOnly = data.Protected == true,
+            Location = BuildRtfRichLocation(owner.Path!, owner.SourceBlockIndex, "form-field", "rtf-form-" + index.ToString("D4", CultureInfo.InvariantCulture))
+        };
+    }
+
+    private static void ApplyRtfTableLimit(ReaderTable table, int maxRows) {
+        table.ColumnProfiles = ReaderTableProfiler.CreateProfiles(table.Columns, table.Rows);
+        if (maxRows <= 0 || table.Rows.Count <= maxRows) return;
+        table.Rows = table.Rows.Take(maxRows).ToArray();
+        table.Truncated = true;
+        table.ColumnProfiles = ReaderTableProfiler.CreateProfiles(table.Columns, table.Rows);
+    }
+
+    private static string BuildRtfTableText(RtfTable table) {
+        return string.Join(Environment.NewLine, table.Rows.Select(row =>
+            string.Join(" | ", row.Cells.Select(static cell =>
+                string.Join(" ", cell.Paragraphs.Select(static paragraph => paragraph.ToPlainText()).Where(static text => !string.IsNullOrWhiteSpace(text)))))));
+    }
+
+    private static IEnumerable<OfficeDocumentDiagnostic> MapRtfDiagnostics(IReadOnlyList<RtfDiagnostic> diagnostics, string path) {
+        foreach (RtfDiagnostic diagnostic in diagnostics) yield return new OfficeDocumentDiagnostic {
+            Severity = diagnostic.Severity == RtfDiagnosticSeverity.Error ? OfficeDocumentDiagnosticSeverity.Error : diagnostic.Severity == RtfDiagnosticSeverity.Info ? OfficeDocumentDiagnosticSeverity.Information : OfficeDocumentDiagnosticSeverity.Warning,
+            Category = OfficeDocumentDiagnosticCategory.Parsing, Code = diagnostic.Code, Message = diagnostic.Message,
+            Source = "officeimo.rtf", IsRecoverable = diagnostic.Severity != RtfDiagnosticSeverity.Error,
+            Location = new ReaderLocation { Path = path, SourceBlockKind = "diagnostic", BlockAnchor = "rtf-position-" + diagnostic.Position.ToString(CultureInfo.InvariantCulture) }
+        };
+    }
+
+    private static IReadOnlyList<OfficeDocumentMetadataEntry> BuildRtfMetadata(RtfDocument document, RtfRichProjection projection) => new[] {
+        RtfMetadata("rtf-font-count", "FontCount", document.Fonts.Count), RtfMetadata("rtf-style-count", "StyleCount", document.Styles.Count),
+        RtfMetadata("rtf-block-count", "BlockCount", projection.Blocks.Count), RtfMetadata("rtf-table-count", "TableCount", projection.Tables.Count),
+        RtfMetadata("rtf-link-count", "LinkCount", projection.Links.Count), RtfMetadata("rtf-asset-count", "AssetCount", projection.Assets.Count),
+        RtfMetadata("rtf-form-count", "FormFieldCount", projection.Forms.Count)
+    };
+
+    private static OfficeDocumentMetadataEntry RtfMetadata(string id, string name, int count) => new OfficeDocumentMetadataEntry {
+        Id = id, Category = "rtf.summary", Name = name, Value = count.ToString(CultureInfo.InvariantCulture), ValueType = "count"
+    };
+
+    private static string ResolveRtfBlockKind(IRtfBlock block) => block is RtfParagraph paragraph && paragraph.ListKind != RtfListKind.None ? "list-item" : block switch {
+        RtfParagraph => "paragraph", RtfTable => "table", RtfImage => "image", RtfObject => "object", RtfShape => "shape", _ => "block"
+    };
+
+    private static string? GetRtfImageExtension(RtfImageFormat format) => format switch {
+        RtfImageFormat.Png => ".png", RtfImageFormat.Jpeg => ".jpg", RtfImageFormat.Emf => ".emf", RtfImageFormat.Wmf => ".wmf", RtfImageFormat.Dib => ".dib", _ => null
+    };
+
+    private static ReaderLocation BuildRtfRichLocation(string path, int? blockIndex, string kind, string anchor, int? tableIndex = null) => new ReaderLocation {
+        Path = path, SourceBlockIndex = blockIndex, SourceBlockKind = kind, BlockAnchor = anchor, TableIndex = tableIndex
+    };
+
+    private sealed class RtfRichProjection {
+        internal List<OfficeDocumentBlock> Blocks { get; } = new List<OfficeDocumentBlock>();
+        internal List<ReaderTable> Tables { get; } = new List<ReaderTable>();
+        internal List<OfficeDocumentAsset> Assets { get; } = new List<OfficeDocumentAsset>();
+        internal List<OfficeDocumentLink> Links { get; } = new List<OfficeDocumentLink>();
+        internal List<OfficeDocumentFormField> Forms { get; } = new List<OfficeDocumentFormField>();
+        internal List<ReaderVisual> Visuals { get; } = new List<ReaderVisual>();
+    }
+}

--- a/OfficeIMO.Reader.Rtf/DocumentReaderRtfExtensions.Document.cs
+++ b/OfficeIMO.Reader.Rtf/DocumentReaderRtfExtensions.Document.cs
@@ -117,11 +117,11 @@ public static partial class DocumentReaderRtfExtensions {
                     ProjectRtfParagraphContent(paragraph, location, projection, ref linkIndex, ref assetIndex, ref formIndex);
                     break;
                 case RtfTable table:
-                    projection.Blocks.Add(new OfficeDocumentBlock { Id = location.BlockAnchor!, Kind = "table", Text = BuildRtfTableText(table), Location = location });
                     ReaderTable mapped = BuildReaderTable(table, tableIndex);
                     mapped.Kind = "rtf-table";
                     mapped.Location = BuildRtfRichLocation(sourcePath, blockIndex, "table", location.BlockAnchor!, tableIndex);
                     ApplyRtfTableLimit(mapped, maxTableRows);
+                    projection.Blocks.Add(new OfficeDocumentBlock { Id = location.BlockAnchor!, Kind = "table", Text = BuildRtfTableText(mapped), Location = location });
                     projection.Tables.Add(mapped);
                     foreach (RtfTableRow row in table.Rows) foreach (RtfTableCell cell in row.Cells) foreach (RtfParagraph paragraph in cell.Paragraphs) ProjectRtfParagraphContent(paragraph, location, projection, ref linkIndex, ref assetIndex, ref formIndex);
                     tableIndex++;
@@ -145,22 +145,30 @@ public static partial class DocumentReaderRtfExtensions {
         }
         if (options.IncludeHeadersAndFooters) foreach (RtfHeaderFooter headerFooter in document.HeaderFooters) {
             string id = "rtf-header-footer-" + blockIndex.ToString("D4", CultureInfo.InvariantCulture);
+            ReaderLocation location = BuildRtfRichLocation(sourcePath, blockIndex, "header-footer", id);
             projection.Blocks.Add(new OfficeDocumentBlock {
                 Id = id,
                 Kind = "header-footer",
                 Text = headerFooter.ToPlainText(),
-                Location = BuildRtfRichLocation(sourcePath, blockIndex, "header-footer", id)
+                Location = location
             });
+            foreach (RtfParagraph paragraph in headerFooter.Paragraphs) {
+                ProjectRtfParagraphContent(paragraph, location, projection, ref linkIndex, ref assetIndex, ref formIndex);
+            }
             blockIndex++;
         }
         if (options.IncludeNotes) foreach (RtfNote note in document.Notes) {
             string id = "rtf-note-" + blockIndex.ToString("D4", CultureInfo.InvariantCulture);
+            ReaderLocation location = BuildRtfRichLocation(sourcePath, blockIndex, "note", id);
             projection.Blocks.Add(new OfficeDocumentBlock {
                 Id = id,
                 Kind = "note",
                 Text = note.ToPlainText(),
-                Location = BuildRtfRichLocation(sourcePath, blockIndex, "note", id)
+                Location = location
             });
+            foreach (RtfParagraph paragraph in note.Paragraphs) {
+                ProjectRtfParagraphContent(paragraph, location, projection, ref linkIndex, ref assetIndex, ref formIndex);
+            }
             blockIndex++;
         }
         return projection;
@@ -245,10 +253,8 @@ public static partial class DocumentReaderRtfExtensions {
         table.ColumnProfiles = ReaderTableProfiler.CreateProfiles(table.Columns, table.Rows);
     }
 
-    private static string BuildRtfTableText(RtfTable table) {
-        return string.Join(Environment.NewLine, table.Rows.Select(row =>
-            string.Join(" | ", row.Cells.Select(static cell =>
-                string.Join(" ", cell.Paragraphs.Select(static paragraph => paragraph.ToPlainText()).Where(static text => !string.IsNullOrWhiteSpace(text)))))));
+    private static string BuildRtfTableText(ReaderTable table) {
+        return string.Join(Environment.NewLine, table.Rows.Select(static row => string.Join(" | ", row)));
     }
 
     private static IEnumerable<OfficeDocumentDiagnostic> MapRtfDiagnostics(IReadOnlyList<RtfDiagnostic> diagnostics, string path) {

--- a/OfficeIMO.Reader.Rtf/DocumentReaderRtfRegistrationExtensions.cs
+++ b/OfficeIMO.Reader.Rtf/DocumentReaderRtfRegistrationExtensions.cs
@@ -53,6 +53,17 @@ public static class DocumentReaderRtfRegistrationExtensions {
                 sourceName: sourceName,
                 readerOptions: readerOptions,
                 rtfOptions: ReaderRtfOptionsCloner.CloneNullable(registeredOptions),
+                cancellationToken: ct),
+            ReadDocumentPath = (path, readerOptions, ct) => DocumentReaderRtfExtensions.ReadRtfDocumentResult(
+                rtfPath: path,
+                readerOptions: readerOptions,
+                rtfOptions: ReaderRtfOptionsCloner.CloneNullable(registeredOptions),
+                cancellationToken: ct),
+            ReadDocumentStream = (stream, sourceName, readerOptions, ct) => DocumentReaderRtfExtensions.ReadRtfDocumentResult(
+                rtfStream: stream,
+                sourceName: sourceName,
+                readerOptions: readerOptions,
+                rtfOptions: ReaderRtfOptionsCloner.CloneNullable(registeredOptions),
                 cancellationToken: ct)
         };
     }

--- a/OfficeIMO.Reader.Rtf/README.md
+++ b/OfficeIMO.Reader.Rtf/README.md
@@ -58,6 +58,23 @@ var chunks = DocumentReaderRtfExtensions.ReadRtf(stream, "large-note.rtf", new R
 rtfOptions.ConversionReport.RequireNoLoss();
 ```
 
+### Read the semantic RTF envelope
+
+```csharp
+OfficeDocumentReadResult document =
+    DocumentReaderRtfExtensions.ReadRtfDocumentResult("form.rtf");
+
+foreach (OfficeDocumentFormField field in document.Forms) {
+    Console.WriteLine($"{field.Name}: {field.Value}");
+}
+
+foreach (OfficeDocumentAsset asset in document.Assets) {
+    Console.WriteLine($"{asset.Kind}: {asset.FileName}");
+}
+```
+
+After registration, `DocumentReader.ReadDocument("form.rtf")` uses the same native rich mapping.
+
 ## What it emits
 
 - RTF input kind and deterministic source/chunk metadata.
@@ -65,6 +82,7 @@ rtfOptions.ConversionReport.RequireNoLoss();
 - Markdown-friendly table output plus `ReaderTable` payloads for parsed RTF tables.
 - Parser and binder diagnostics as reader warnings when requested.
 - A shared conversion report for flattened, omitted, and blocked features.
+- A schema-v5 rich result containing semantic blocks, tables, hyperlinks, form fields, image visuals and payloads, embedded-object assets, metadata, and structured diagnostics.
 
 ## Boundaries
 

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Modular.cs
@@ -28,6 +28,9 @@ public sealed class ReaderEpubModularTests {
             Assert.Contains(result.Blocks, block => block.Kind == "heading" && block.Text == "Two");
             Assert.Contains(result.Tables, table => table.Kind == "html-table" && table.Rows.Any(row => row.Contains("2")));
             Assert.Contains(result.Links, link => link.Uri == "https://example.test/chapter-two" && link.Text == "details");
+            Assert.Equal(
+                result.Source.Path + "::OEBPS/chapter2.xhtml#details",
+                Assert.Single(result.Links, link => link.Text == "next chapter").Uri);
             OfficeDocumentAsset asset = Assert.Single(result.Assets, item => item.MediaType == "image/png");
             Assert.NotNull(asset.PayloadBytes);
             Assert.True(asset.PayloadHashMatches(out _));
@@ -490,6 +493,7 @@ public sealed class ReaderEpubModularTests {
         WriteTextEntry(archive, "OEBPS/chapter1.xhtml",
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
             "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>Local One</title></head><body><h1>One</h1><p>First chapter text.</p>" +
+            "<p><a href=\"chapter2.xhtml#details\">next chapter</a></p>" +
             "<img src=\"data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==\" alt=\"Inline\"/></body></html>");
 
         WriteTextEntry(archive, "OEBPS/chapter2.xhtml",

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Modular.cs
@@ -31,6 +31,12 @@ public sealed class ReaderEpubModularTests {
             OfficeDocumentAsset asset = Assert.Single(result.Assets, item => item.MediaType == "image/png");
             Assert.NotNull(asset.PayloadBytes);
             Assert.True(asset.PayloadHashMatches(out _));
+            OfficeDocumentPage coverPage = Assert.Single(result.Pages, page => page.Location.Path?.EndsWith("::OEBPS/chapter2.xhtml", StringComparison.Ordinal) == true);
+            Assert.Contains(coverPage.Assets, pageAsset => ReferenceEquals(pageAsset, asset));
+            OfficeDocumentAsset[] inlineImages = result.Assets.Where(item => item.MediaType == "image/gif").ToArray();
+            Assert.Equal(2, inlineImages.Length);
+            Assert.Equal(2, inlineImages.Select(item => item.FileName).Distinct(StringComparer.Ordinal).Count());
+            Assert.All(result.Pages, page => Assert.Contains(page.Assets, pageAsset => pageAsset.MediaType == "image/gif"));
             ReaderVisual visual = Assert.Single(result.Visuals, item => item.Kind == "image" && item.SourceName == "images/cover.png");
             Assert.StartsWith("epub-chapter-0001-html-image-", visual.Location!.BlockAnchor!, StringComparison.Ordinal);
             using (FileStream stream = File.OpenRead(epubPath)) {
@@ -41,6 +47,26 @@ public sealed class ReaderEpubModularTests {
             Assert.Contains("officeimo.reader.epub.rich-v5", result.CapabilitiesUsed);
         } finally {
             DocumentReaderEpubRegistrationExtensions.UnregisterEpubHandler();
+            if (File.Exists(epubPath)) File.Delete(epubPath);
+        }
+    }
+
+    [Fact]
+    public void DocumentReaderEpub_RichDispatch_HonorsDisabledResourcePayloadsAndKeepsPageAssets() {
+        var epubPath = Path.Combine(Path.GetTempPath(), "officeimo-epub-" + Guid.NewGuid().ToString("N") + ".epub");
+        try {
+            BuildEpubWithSpine(epubPath);
+
+            OfficeDocumentReadResult result = DocumentReaderEpubExtensions.ReadEpubDocument(
+                epubPath,
+                epubOptions: new EpubReadOptions { IncludeResourceData = false });
+
+            OfficeDocumentAsset asset = Assert.Single(result.Assets, item => item.MediaType == "image/png");
+            Assert.Null(asset.PayloadBytes);
+            Assert.Null(asset.PayloadHash);
+            OfficeDocumentPage coverPage = Assert.Single(result.Pages, page => page.Location.Path?.EndsWith("::OEBPS/chapter2.xhtml", StringComparison.Ordinal) == true);
+            Assert.Contains(coverPage.Assets, pageAsset => ReferenceEquals(pageAsset, asset));
+        } finally {
             if (File.Exists(epubPath)) File.Delete(epubPath);
         }
     }
@@ -438,12 +464,15 @@ public sealed class ReaderEpubModularTests {
 
         WriteTextEntry(archive, "OEBPS/chapter1.xhtml",
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>Local One</title></head><body><h1>One</h1><p>First chapter text.</p></body></html>");
+            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>Local One</title></head><body><h1>One</h1><p>First chapter text.</p>" +
+            "<img src=\"data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==\" alt=\"Inline\"/></body></html>");
 
         WriteTextEntry(archive, "OEBPS/chapter2.xhtml",
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
             "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>Local Two</title></head><body><h1>Two</h1><p>Second chapter text. <a href=\"https://example.test/chapter-two\">details</a></p>" +
-            "<table><tr><th>Name</th><th>Qty</th></tr><tr><td>Chapter</td><td>2</td></tr></table><img src=\"images/cover.png\" alt=\"Cover\"/></body></html>");
+            "<table><tr><th>Name</th><th>Qty</th></tr><tr><td>Chapter</td><td>2</td></tr></table>" +
+            "<img src=\"data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==\" alt=\"Inline\"/>" +
+            "<img src=\"images/cover.png\" alt=\"Cover\"/></body></html>");
 
         WriteBinaryEntry(archive, "OEBPS/images/cover.png", new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 });
     }

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Modular.cs
@@ -13,6 +13,39 @@ internal static class ReaderCurrentDirectoryLock {
 
 public sealed class ReaderEpubModularTests {
     [Fact]
+    public void DocumentReaderEpub_RichDispatch_MapsChaptersTablesLinksAndManifestAssets() {
+        var epubPath = Path.Combine(Path.GetTempPath(), "officeimo-epub-" + Guid.NewGuid().ToString("N") + ".epub");
+        try {
+            BuildEpubWithSpine(epubPath);
+            DocumentReaderEpubRegistrationExtensions.RegisterEpubHandler(replaceExisting: true);
+
+            OfficeDocumentReadResult result = DocumentReader.ReadDocument(epubPath);
+
+            Assert.Equal(ReaderInputKind.Epub, result.Kind);
+            Assert.Equal("Demo Book", result.Source.Title);
+            Assert.Equal("OfficeIMO Team", result.Source.Author);
+            Assert.Equal(2, result.Pages.Count);
+            Assert.Contains(result.Blocks, block => block.Kind == "heading" && block.Text == "Two");
+            Assert.Contains(result.Tables, table => table.Kind == "html-table" && table.Rows.Any(row => row.Contains("2")));
+            Assert.Contains(result.Links, link => link.Uri == "https://example.test/chapter-two" && link.Text == "details");
+            OfficeDocumentAsset asset = Assert.Single(result.Assets, item => item.MediaType == "image/png");
+            Assert.NotNull(asset.PayloadBytes);
+            Assert.True(asset.PayloadHashMatches(out _));
+            ReaderVisual visual = Assert.Single(result.Visuals, item => item.Kind == "image" && item.SourceName == "images/cover.png");
+            Assert.StartsWith("epub-chapter-0001-html-image-", visual.Location!.BlockAnchor!, StringComparison.Ordinal);
+            using (FileStream stream = File.OpenRead(epubPath)) {
+                OfficeDocumentReadResult jsonResult = OfficeDocumentReadResultJson.Deserialize(
+                    DocumentReaderEpubExtensions.ReadEpubDocumentJson(stream, "book.epub"));
+                Assert.Equal(ReaderInputKind.Epub, jsonResult.Kind);
+            }
+            Assert.Contains("officeimo.reader.epub.rich-v5", result.CapabilitiesUsed);
+        } finally {
+            DocumentReaderEpubRegistrationExtensions.UnregisterEpubHandler();
+            if (File.Exists(epubPath)) File.Delete(epubPath);
+        }
+    }
+
+    [Fact]
     public void EpubReader_UsesOpfSpineOrderAndMetadata() {
         var epubPath = Path.Combine(Path.GetTempPath(), "officeimo-epub-" + Guid.NewGuid().ToString("N") + ".epub");
         try {
@@ -45,6 +78,29 @@ public sealed class ReaderEpubModularTests {
             Assert.Equal(2, second.SpineIndex);
             Assert.True(second.IsLinear);
             Assert.Contains("First chapter text.", second.Text, StringComparison.Ordinal);
+        } finally {
+            if (File.Exists(epubPath)) File.Delete(epubPath);
+        }
+    }
+
+    [Fact]
+    public void EpubReader_ManifestResourcePayloads_AreOptInAndBounded() {
+        var epubPath = Path.Combine(Path.GetTempPath(), "officeimo-epub-" + Guid.NewGuid().ToString("N") + ".epub");
+        try {
+            BuildEpubWithSpine(epubPath);
+
+            EpubDocument metadataOnly = EpubReader.Read(epubPath);
+            EpubResource imageMetadata = Assert.Single(metadataOnly.Resources, resource => resource.MediaType == "image/png");
+            Assert.Null(imageMetadata.Data);
+
+            EpubDocument bounded = EpubReader.Read(epubPath, new EpubReadOptions {
+                IncludeResourceData = true,
+                MaxResourceBytes = 4,
+                MaxTotalResourceBytes = 32
+            });
+            EpubResource boundedImage = Assert.Single(bounded.Resources, resource => resource.MediaType == "image/png");
+            Assert.Null(boundedImage.Data);
+            Assert.Contains(bounded.Warnings, warning => warning.Contains("MaxResourceBytes", StringComparison.Ordinal));
         } finally {
             if (File.Exists(epubPath)) File.Delete(epubPath);
         }
@@ -361,6 +417,7 @@ public sealed class ReaderEpubModularTests {
             "<item id=\"ncx\" href=\"toc.ncx\" media-type=\"application/x-dtbncx+xml\"/>" +
             "<item id=\"ch1\" href=\"chapter1.xhtml\" media-type=\"application/xhtml+xml\"/>" +
             "<item id=\"ch2\" href=\"chapter2.xhtml\" media-type=\"application/xhtml+xml\"/>" +
+            "<item id=\"cover\" href=\"images/cover.png\" media-type=\"image/png\" properties=\"cover-image\"/>" +
             "</manifest>" +
             "<spine toc=\"ncx\"><itemref idref=\"ch2\"/><itemref idref=\"ch1\"/></spine>" +
             "</package>");
@@ -385,7 +442,10 @@ public sealed class ReaderEpubModularTests {
 
         WriteTextEntry(archive, "OEBPS/chapter2.xhtml",
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>Local Two</title></head><body><h1>Two</h1><p>Second chapter text.</p></body></html>");
+            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>Local Two</title></head><body><h1>Two</h1><p>Second chapter text. <a href=\"https://example.test/chapter-two\">details</a></p>" +
+            "<table><tr><th>Name</th><th>Qty</th></tr><tr><td>Chapter</td><td>2</td></tr></table><img src=\"images/cover.png\" alt=\"Cover\"/></body></html>");
+
+        WriteBinaryEntry(archive, "OEBPS/images/cover.png", new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 });
     }
 
     private static void BuildEpubWithMalformedChapter(string epubPath) {
@@ -419,5 +479,11 @@ public sealed class ReaderEpubModularTests {
         using var stream = entry.Open();
         using var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), 4096, leaveOpen: false);
         writer.Write(content);
+    }
+
+    private static void WriteBinaryEntry(ZipArchive archive, string path, byte[] content) {
+        ZipArchiveEntry entry = archive.CreateEntry(path, CompressionLevel.Optimal);
+        using Stream stream = entry.Open();
+        stream.Write(content, 0, content.Length);
     }
 }

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Modular.cs
@@ -72,6 +72,30 @@ public sealed class ReaderEpubModularTests {
     }
 
     [Fact]
+    public void DocumentReaderEpub_RichDispatch_PreservesImageOnlySpinePagesAndPageOcrCandidates() {
+        var epubPath = Path.Combine(Path.GetTempPath(), "officeimo-epub-image-only-" + Guid.NewGuid().ToString("N") + ".epub");
+        try {
+            BuildImageOnlyEpub(epubPath);
+
+            EpubDocument document = EpubReader.Read(epubPath, new EpubReadOptions { IncludeRawHtml = true });
+            EpubChapter chapter = Assert.Single(document.Chapters);
+            Assert.Equal(string.Empty, chapter.Text);
+            Assert.NotNull(chapter.Html);
+
+            OfficeDocumentReadResult result = DocumentReaderEpubExtensions.ReadEpubDocument(epubPath);
+
+            OfficeDocumentPage page = Assert.Single(result.Pages);
+            OfficeDocumentAsset asset = Assert.Single(page.Assets);
+            Assert.Same(asset, Assert.Single(result.Assets));
+            OfficeDocumentOcrCandidate candidate = Assert.Single(result.OcrCandidates);
+            Assert.Equal(asset.Id, candidate.AssetId);
+            Assert.Same(candidate, Assert.Single(page.OcrCandidates));
+        } finally {
+            if (File.Exists(epubPath)) File.Delete(epubPath);
+        }
+    }
+
+    [Fact]
     public void EpubReader_UsesOpfSpineOrderAndMetadata() {
         var epubPath = Path.Combine(Path.GetTempPath(), "officeimo-epub-" + Guid.NewGuid().ToString("N") + ".epub");
         try {
@@ -474,6 +498,29 @@ public sealed class ReaderEpubModularTests {
             "<img src=\"data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==\" alt=\"Inline\"/>" +
             "<img src=\"images/cover.png\" alt=\"Cover\"/></body></html>");
 
+        WriteBinaryEntry(archive, "OEBPS/images/cover.png", new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 });
+    }
+
+    private static void BuildImageOnlyEpub(string epubPath) {
+        using var fs = new FileStream(epubPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+        using var archive = new ZipArchive(fs, ZipArchiveMode.Create, leaveOpen: false);
+
+        WriteTextEntry(archive, "mimetype", "application/epub+zip", CompressionLevel.NoCompression);
+        WriteTextEntry(archive, "META-INF/container.xml",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<container version=\"1.0\" xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\">" +
+            "<rootfiles><rootfile full-path=\"OEBPS/content.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles>" +
+            "</container>");
+        WriteTextEntry(archive, "OEBPS/content.opf",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<package version=\"3.0\" xmlns=\"http://www.idpf.org/2007/opf\">" +
+            "<manifest><item id=\"cover-page\" href=\"cover.xhtml\" media-type=\"application/xhtml+xml\"/>" +
+            "<item id=\"cover\" href=\"images/cover.png\" media-type=\"image/png\" properties=\"cover-image\"/></manifest>" +
+            "<spine><itemref idref=\"cover-page\"/></spine></package>");
+        WriteTextEntry(archive, "OEBPS/cover.xhtml",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>Cover</title></head>" +
+            "<body><img src=\"images/cover.png\" alt=\"Cover\"/></body></html>");
         WriteBinaryEntry(archive, "OEBPS/images/cover.png", new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 });
     }
 

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Modular.cs
@@ -90,6 +90,7 @@ public sealed class ReaderEpubModularTests {
             OfficeDocumentOcrCandidate candidate = Assert.Single(result.OcrCandidates);
             Assert.Equal(asset.Id, candidate.AssetId);
             Assert.Same(candidate, Assert.Single(page.OcrCandidates));
+            Assert.Single(result.Diagnostics, diagnostic => diagnostic.Code == "ocr-needed");
         } finally {
             if (File.Exists(epubPath)) File.Delete(epubPath);
         }

--- a/OfficeIMO.Reader.Tests/Reader.Html.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Html.Modular.cs
@@ -57,6 +57,29 @@ public sealed class ReaderHtmlModularTests {
         Assert.DoesNotContain(result.Links, item => item.Uri?.StartsWith("javascript:", StringComparison.OrdinalIgnoreCase) == true);
     }
 
+    [Fact]
+    public void DocumentReaderHtml_RichProjection_ResolvesDocumentBaseUriWithoutFilters() {
+        const string html = "<html><head><base href=\"https://example.test/docs/\"></head>"
+            + "<body><a href=\"guide.html\">Guide</a></body></html>";
+
+        OfficeDocumentReadResult result = DocumentReaderHtmlExtensions.ReadHtmlStringDocument(html, "guide.html");
+
+        Assert.Equal("https://example.test/docs/guide.html", Assert.Single(result.Links).Uri);
+    }
+
+    [Fact]
+    public void DocumentReaderHtml_RichProjection_RejectsOversizedInputBeforeLogicalProjection() {
+        const string html = "<p>This input exceeds its configured bound.</p>";
+
+        ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            DocumentReaderHtmlExtensions.ReadHtmlStringDocument(
+                html,
+                "bounded-rich.html",
+                htmlOptions: ReaderHtmlOptions.CreateUntrustedHtmlProfile(12)));
+
+        Assert.Contains("MaxInputCharacters", exception.Message, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData(HtmlBase64ImageHandling.Skip)]
     [InlineData(HtmlBase64ImageHandling.SaveToFile)]
@@ -146,6 +169,23 @@ public sealed class ReaderHtmlModularTests {
         Assert.Equal("status", form.Name);
         Assert.Equal("select", form.Kind);
         Assert.Equal("approved", form.Value);
+    }
+
+    [Fact]
+    public void DocumentReaderHtml_RichProjection_PreservesCheckedStateForCheckboxesAndRadios() {
+        const string html = "<form>"
+            + "<input type=\"checkbox\" name=\"unchecked\" value=\"yes\">"
+            + "<input type=\"checkbox\" name=\"checked\" value=\"yes\" checked>"
+            + "<input type=\"radio\" name=\"choice\" value=\"a\">"
+            + "<input type=\"radio\" name=\"choice\" value=\"b\" checked>"
+            + "</form>";
+
+        OfficeDocumentReadResult result = DocumentReaderHtmlExtensions.ReadHtmlStringDocument(html, "controls.html");
+
+        Assert.Null(Assert.Single(result.Forms, form => form.Name == "unchecked").Value);
+        Assert.Equal("yes", Assert.Single(result.Forms, form => form.Name == "checked").Value);
+        Assert.Null(result.Forms.Single(form => form.Kind == "radio" && form.Value == null).Value);
+        Assert.Equal("b", Assert.Single(result.Forms, form => form.Kind == "radio" && form.Value != null).Value);
     }
 
     [Fact]

--- a/OfficeIMO.Reader.Tests/Reader.Html.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Html.Modular.cs
@@ -9,6 +9,60 @@ namespace OfficeIMO.Tests;
 [Collection("ReaderRegistryNonParallel")]
 public sealed class ReaderHtmlModularTests {
     [Fact]
+    public void DocumentReaderHtml_RichDispatch_MapsMetadataStructureLinksFormsAndImages() {
+        const string html = "<html><head><title>Rich HTML</title><meta name=\"author\" content=\"OfficeIMO\"/></head><body>"
+            + "<h2>Inventory</h2><p>See <a href=\"https://example.test/inventory\">inventory</a>.</p>"
+            + "<table><tr><th>Name</th><th>Qty</th></tr><tr><td>Bandage</td><td>4</td></tr></table>"
+            + "<form><input type=\"text\" name=\"patient\" value=\"Ada\" required=\"required\"/></form>"
+            + "<img alt=\"Tiny image\" src=\"data:image/png;base64,iVBORw0KGgo=\"/></body></html>";
+        try {
+            DocumentReaderHtmlRegistrationExtensions.RegisterHtmlHandler(replaceExisting: true);
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(html), writable: false);
+
+            OfficeDocumentReadResult result = DocumentReader.ReadDocument(stream, "rich.html");
+
+            Assert.Equal("Rich HTML", result.Source.Title);
+            Assert.Equal("OfficeIMO", result.Source.Author);
+            Assert.Contains(result.Blocks, block => block.Kind == "heading" && block.Level == 2 && block.Text == "Inventory");
+            ReaderTable table = Assert.Single(result.Tables);
+            Assert.Equal("Bandage", table.Rows[0][0]);
+            Assert.Equal("https://example.test/inventory", Assert.Single(result.Links).Uri);
+            OfficeDocumentFormField form = Assert.Single(result.Forms);
+            Assert.Equal("patient", form.Name);
+            Assert.True(form.IsRequired);
+            OfficeDocumentAsset image = Assert.Single(result.Assets);
+            Assert.Equal("image/png", image.MediaType);
+            Assert.NotNull(image.PayloadBytes);
+            ReaderVisual visual = Assert.Single(result.Visuals);
+            Assert.Equal("image", visual.Kind);
+            Assert.Equal(image.PayloadHash, visual.PayloadHash);
+            stream.Position = 0;
+            OfficeDocumentReadResult jsonResult = OfficeDocumentReadResultJson.Deserialize(
+                DocumentReaderHtmlExtensions.ReadHtmlDocumentJson(stream, "rich.html"));
+            Assert.Equal(ReaderInputKind.Html, jsonResult.Kind);
+            Assert.Contains("officeimo.reader.html.rich-v5", result.CapabilitiesUsed);
+        } finally {
+            DocumentReaderHtmlRegistrationExtensions.UnregisterHtmlHandler();
+        }
+    }
+
+    [Fact]
+    public void DocumentReaderHtml_RichTables_DoNotFoldNestedRowsIntoParentTable() {
+        const string html = "<table><caption>Outer</caption><tr><th>Name</th></tr><tr><td>Parent"
+            + "<table><caption>Inner</caption><tr><th>Code</th></tr><tr><td>Nested</td></tr></table>"
+            + "</td></tr></table>";
+
+        OfficeDocumentReadResult result = DocumentReaderHtmlExtensions.ReadHtmlStringDocument(html, "nested.html");
+
+        Assert.Equal(2, result.Tables.Count);
+        ReaderTable outer = Assert.Single(result.Tables, table => table.Title == "Outer");
+        ReaderTable inner = Assert.Single(result.Tables, table => table.Title == "Inner");
+        Assert.Equal(1, outer.TotalRowCount);
+        Assert.Equal(1, inner.TotalRowCount);
+        Assert.Equal("Nested", inner.Rows[0][0]);
+    }
+
+    [Fact]
     public void DocumentReaderHtml_ReadHtmlString_EmitsChunks() {
         var html = "<html><body><h1>Hello HTML</h1><p>Body text.</p></body></html>";
 

--- a/OfficeIMO.Reader.Tests/Reader.Html.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Html.Modular.cs
@@ -101,6 +101,41 @@ public sealed class ReaderHtmlModularTests {
     }
 
     [Fact]
+    public void DocumentReaderHtml_RichTables_ApplyRowLimitToTableBlocks() {
+        const string html = "<table><tr><th>Name</th></tr><tr><td>Row 1</td></tr>"
+            + "<tr><td>Row 2</td></tr><tr><td>Row 3</td></tr></table>";
+
+        OfficeDocumentReadResult result = DocumentReaderHtmlExtensions.ReadHtmlStringDocument(
+            html,
+            "bounded.html",
+            new ReaderOptions { MaxTableRows = 1 });
+
+        ReaderTable table = Assert.Single(result.Tables);
+        Assert.Single(table.Rows);
+        Assert.True(table.Truncated);
+        OfficeDocumentBlock block = Assert.Single(result.Blocks, item => item.Kind == "table");
+        Assert.Contains("Row 1", block.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain("Row 2", block.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain("Row 3", block.Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DocumentReaderHtml_RichProjection_MapsTextareaAndResponsiveImageSources() {
+        const string html = "<form><textarea name=\"comments\">Hello there</textarea></form>"
+            + "<img alt=\"Responsive\" srcset=\"small.png 1x, large.png 2x\"/>"
+            + "<img alt=\"Lazy\" data-src=\"lazy.png\"/>"
+            + "<picture><source srcset=\"picture.png 1x\"/></picture>";
+
+        OfficeDocumentReadResult result = DocumentReaderHtmlExtensions.ReadHtmlStringDocument(html, "responsive.html");
+
+        OfficeDocumentFormField form = Assert.Single(result.Forms, item => item.Name == "comments");
+        Assert.Equal("Hello there", form.Value);
+        Assert.Contains(result.Assets, asset => asset.SourceObjectId == "small.png");
+        Assert.Contains(result.Assets, asset => asset.SourceObjectId == "lazy.png");
+        Assert.Contains(result.Assets, asset => asset.SourceObjectId == "picture.png");
+    }
+
+    [Fact]
     public void DocumentReaderHtml_ReadHtmlString_EmitsChunks() {
         var html = "<html><body><h1>Hello HTML</h1><p>Body text.</p></body></html>";
 

--- a/OfficeIMO.Reader.Tests/Reader.Html.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Html.Modular.cs
@@ -47,6 +47,44 @@ public sealed class ReaderHtmlModularTests {
     }
 
     [Fact]
+    public void DocumentReaderHtml_RichDispatch_AppliesConfiguredUrlPolicyToLinks() {
+        const string html = "<p><a href=\"javascript:alert(1)\">Unsafe</a> <a href=\"https://example.test/safe\">Safe</a></p>";
+
+        OfficeDocumentReadResult result = DocumentReaderHtmlExtensions.ReadHtmlStringDocument(html, "links.html");
+
+        OfficeDocumentLink link = Assert.Single(result.Links);
+        Assert.Equal("https://example.test/safe", link.Uri);
+        Assert.DoesNotContain(result.Links, item => item.Uri?.StartsWith("javascript:", StringComparison.OrdinalIgnoreCase) == true);
+    }
+
+    [Theory]
+    [InlineData(HtmlBase64ImageHandling.Skip)]
+    [InlineData(HtmlBase64ImageHandling.SaveToFile)]
+    public void DocumentReaderHtml_RichDispatch_RespectsBase64ImageHandling(HtmlBase64ImageHandling handling) {
+        const string html = "<img alt=\"Inline\" src=\"data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==\"/>";
+        string directory = Path.Combine(Path.GetTempPath(), "officeimo-reader-html-images-" + Guid.NewGuid().ToString("N"));
+        try {
+            var options = new ReaderHtmlOptions {
+                HtmlToMarkdownOptions = new HtmlToMarkdownOptions {
+                    Base64Images = handling,
+                    Base64ImageOutputDirectory = directory
+                }
+            };
+
+            OfficeDocumentReadResult result = DocumentReaderHtmlExtensions.ReadHtmlStringDocument(
+                html,
+                "inline-image.html",
+                htmlOptions: options);
+
+            Assert.Empty(result.Assets);
+            Assert.Empty(result.Visuals);
+            if (handling == HtmlBase64ImageHandling.SaveToFile) Assert.Single(Directory.EnumerateFiles(directory));
+        } finally {
+            if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void DocumentReaderHtml_RichTables_DoNotFoldNestedRowsIntoParentTable() {
         const string html = "<table><caption>Outer</caption><tr><th>Name</th></tr><tr><td>Parent"
             + "<table><caption>Inner</caption><tr><th>Code</th></tr><tr><td>Nested</td></tr></table>"

--- a/OfficeIMO.Reader.Tests/Reader.Html.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Html.Modular.cs
@@ -136,6 +136,57 @@ public sealed class ReaderHtmlModularTests {
     }
 
     [Fact]
+    public void DocumentReaderHtml_RichProjection_MapsSelectAsOneFormField() {
+        const string html = "<form><select name=\"status\"><option value=\"draft\">Draft</option>"
+            + "<option value=\"approved\" selected>Approved</option></select></form>";
+
+        OfficeDocumentReadResult result = DocumentReaderHtmlExtensions.ReadHtmlStringDocument(html, "select.html");
+
+        OfficeDocumentFormField form = Assert.Single(result.Forms);
+        Assert.Equal("status", form.Name);
+        Assert.Equal("select", form.Kind);
+        Assert.Equal("approved", form.Value);
+    }
+
+    [Fact]
+    public void DocumentReaderHtml_RichProjection_PreservesHeaderlessTableRows() {
+        const string html = "<table><tr><td>A</td></tr><tr><td>B</td></tr></table>";
+
+        ReaderTable table = Assert.Single(DocumentReaderHtmlExtensions.ReadHtmlStringDocument(html, "headerless.html").Tables);
+
+        Assert.Equal(new[] { "Column 1" }, table.Columns);
+        Assert.Equal(2, table.TotalRowCount);
+        Assert.Equal(new[] { "A", "B" }, table.Rows.Select(row => row[0]));
+    }
+
+    [Fact]
+    public void DocumentReaderHtml_RichProjection_AppliesConfiguredElementFilters() {
+        const string html = "<section class=\"private\"><p>Private text</p><a href=\"https://private.test\">Private link</a></section>"
+            + "<p id=\"delegate-private\">Delegate private</p><p>Public text</p>";
+        var markdownOptions = HtmlToMarkdownOptions.CreateOfficeIMOProfile();
+        markdownOptions.ExcludeSelectors.Add(".private");
+        int delegateMatchCount = 0;
+        markdownOptions.ElementFilters.Add(element => {
+            if (!string.Equals(element.Id, "delegate-private", StringComparison.Ordinal)) return false;
+            delegateMatchCount++;
+            return true;
+        });
+        var options = new ReaderHtmlOptions { HtmlToMarkdownOptions = markdownOptions };
+
+        OfficeDocumentReadResult result = DocumentReaderHtmlExtensions.ReadHtmlStringDocument(
+            html,
+            "filtered.html",
+            htmlOptions: options);
+
+        Assert.DoesNotContain(result.Blocks, block => block.Text.Contains("Private", StringComparison.OrdinalIgnoreCase));
+        Assert.Empty(result.Links);
+        Assert.DoesNotContain("Private text", result.Html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Delegate private", result.Html, StringComparison.Ordinal);
+        Assert.Contains(result.Blocks, block => block.Text.Contains("Public text", StringComparison.Ordinal));
+        Assert.Equal(1, delegateMatchCount);
+    }
+
+    [Fact]
     public void DocumentReaderHtml_ReadHtmlString_EmitsChunks() {
         var html = "<html><body><h1>Hello HTML</h1><p>Body text.</p></body></html>";
 

--- a/OfficeIMO.Reader.Tests/Reader.RichMappings.Office.cs
+++ b/OfficeIMO.Reader.Tests/Reader.RichMappings.Office.cs
@@ -16,7 +16,10 @@ public sealed class ReaderOfficeRichMappingTests {
             document.AddParagraph("Policy").Style = WordParagraphStyles.Heading1;
             document.AddParagraph("Read ").AddHyperLink("the policy", new Uri("https://example.test/policy"));
             WordParagraph noteReference = document.AddParagraph("Supporting references");
-            noteReference.AddFootNote("Footnote detail");
+            WordParagraph footnoteReference = noteReference.AddFootNote("Footnote detail ");
+            footnoteReference.FootNote!.Paragraphs![1].AddHyperLink(
+                "footnote source",
+                new Uri("https://example.test/footnote"));
             noteReference.AddEndNote("Endnote detail");
             WordTable table = document.AddTable(2, 2);
             table.Title = "Inventory";
@@ -37,7 +40,9 @@ public sealed class ReaderOfficeRichMappingTests {
         ReaderTable mapped = Assert.Single(result.Tables);
         Assert.Equal("Inventory", mapped.Title);
         Assert.Equal("Bandage", mapped.Rows[0][0]);
-        Assert.Equal("https://example.test/policy", Assert.Single(result.Links).Uri);
+        Assert.Equal("https://example.test/policy", Assert.Single(result.Links, link => link.Uri == "https://example.test/policy").Uri);
+        OfficeDocumentLink noteLink = Assert.Single(result.Links, link => link.Uri == "https://example.test/footnote");
+        Assert.StartsWith("word-footnote-", noteLink.Location.BlockAnchor, StringComparison.Ordinal);
         Assert.Contains(result.Blocks, block => block.Kind == "footnote" && block.Text.Contains("Footnote detail", StringComparison.Ordinal));
         Assert.Contains(result.Blocks, block => block.Kind == "endnote" && block.Text.Contains("Endnote detail", StringComparison.Ordinal));
         Assert.Contains("officeimo.word.inspection-snapshot", result.CapabilitiesUsed);

--- a/OfficeIMO.Reader.Tests/Reader.RichMappings.Office.cs
+++ b/OfficeIMO.Reader.Tests/Reader.RichMappings.Office.cs
@@ -51,6 +51,35 @@ public sealed class ReaderOfficeRichMappingTests {
     }
 
     [Fact]
+    public void DocumentReader_WordRichMapping_AppliesTableRowLimitToBlocksAndTables() {
+        using var stream = new MemoryStream();
+        using (WordDocument document = WordDocument.Create(stream)) {
+            WordTable table = document.AddTable(4, 2);
+            table.Rows[0].Cells[0].Paragraphs[0].Text = "Name";
+            table.Rows[0].Cells[1].Paragraphs[0].Text = "Qty";
+            for (int row = 1; row < 4; row++) {
+                table.Rows[row].Cells[0].Paragraphs[0].Text = "Row " + row;
+                table.Rows[row].Cells[1].Paragraphs[0].Text = row.ToString();
+            }
+            document.Save();
+        }
+        stream.Position = 0;
+
+        OfficeDocumentReadResult result = DocumentReader.ReadDocument(
+            stream,
+            "bounded.docx",
+            new ReaderOptions { MaxTableRows = 1 });
+
+        ReaderTable tableResult = Assert.Single(result.Tables);
+        Assert.Single(tableResult.Rows);
+        Assert.True(tableResult.Truncated);
+        OfficeDocumentBlock tableBlock = Assert.Single(result.Blocks, block => block.Kind == "table");
+        Assert.Contains("Row 1", tableBlock.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain("Row 2", tableBlock.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain("Row 3", tableBlock.Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void DocumentReader_ExcelRichMapping_UsesFormalTablesCellLinksAndProperties() {
         using var stream = new MemoryStream();
         using (ExcelDocument document = ExcelDocument.Create(stream)) {
@@ -143,6 +172,8 @@ public sealed class ReaderOfficeRichMappingTests {
             PowerPointTextBox title = slide.AddTextBox("Overview");
             title.AddParagraph("Summary");
             title.Paragraphs[0].Runs[0].SetHyperlink("https://example.test/deck");
+            PowerPointTextBox hidden = slide.AddTextBox("Hidden guidance");
+            hidden.Hidden = true;
             PowerPointTable table = slide.AddTable(2, 2);
             table.GetCell(0, 0).Text = "Name";
             table.GetCell(0, 1).Text = "Qty";
@@ -164,11 +195,12 @@ public sealed class ReaderOfficeRichMappingTests {
         Assert.True(page.Height > 0);
         Assert.Contains(result.Blocks, block => block.Kind == "paragraph" && block.Text == "Overview" && block.Region != null);
         Assert.Equal("Bandage", Assert.Single(result.Tables).Rows[0][0]);
+        Assert.Contains(result.Blocks, block => block.Text == "Hidden guidance");
         Assert.Equal("https://example.test/deck", Assert.Single(result.Links).Uri);
         ReaderVisual chart = Assert.Single(result.Visuals);
         Assert.Equal("chart", chart.Kind);
         Assert.Contains("Sales", chart.Content, StringComparison.Ordinal);
-        Assert.Equal("3", Assert.Single(result.Metadata, item => item.Name == "ShapeCount").Value);
+        Assert.Equal("4", Assert.Single(result.Metadata, item => item.Name == "ShapeCount").Value);
         OfficeDocumentBlock notes = Assert.Single(result.Blocks, block => block.Kind == "speaker-notes");
         Assert.Equal("Speaker guidance", notes.Text);
         Assert.Same(notes, Assert.Single(page.Blocks, block => block.Kind == "speaker-notes"));

--- a/OfficeIMO.Reader.Tests/Reader.RichMappings.Office.cs
+++ b/OfficeIMO.Reader.Tests/Reader.RichMappings.Office.cs
@@ -15,6 +15,9 @@ public sealed class ReaderOfficeRichMappingTests {
             document.BuiltinDocumentProperties.Creator = "OfficeIMO";
             document.AddParagraph("Policy").Style = WordParagraphStyles.Heading1;
             document.AddParagraph("Read ").AddHyperLink("the policy", new Uri("https://example.test/policy"));
+            WordParagraph noteReference = document.AddParagraph("Supporting references");
+            noteReference.AddFootNote("Footnote detail");
+            noteReference.AddEndNote("Endnote detail");
             WordTable table = document.AddTable(2, 2);
             table.Title = "Inventory";
             table.Rows[0].Cells[0].Paragraphs[0].Text = "Name";
@@ -35,7 +38,16 @@ public sealed class ReaderOfficeRichMappingTests {
         Assert.Equal("Inventory", mapped.Title);
         Assert.Equal("Bandage", mapped.Rows[0][0]);
         Assert.Equal("https://example.test/policy", Assert.Single(result.Links).Uri);
+        Assert.Contains(result.Blocks, block => block.Kind == "footnote" && block.Text.Contains("Footnote detail", StringComparison.Ordinal));
+        Assert.Contains(result.Blocks, block => block.Kind == "endnote" && block.Text.Contains("Endnote detail", StringComparison.Ordinal));
         Assert.Contains("officeimo.word.inspection-snapshot", result.CapabilitiesUsed);
+
+        stream.Position = 0;
+        OfficeDocumentReadResult withoutNotes = DocumentReader.ReadDocument(
+            stream,
+            "policy.docx",
+            new ReaderOptions { IncludeWordFootnotes = false });
+        Assert.DoesNotContain(withoutNotes.Blocks, block => block.Kind == "footnote" || block.Kind == "endnote");
     }
 
     [Fact]
@@ -51,6 +63,10 @@ public sealed class ReaderOfficeRichMappingTests {
             sheet.Cell(2, 2, 4);
             sheet.AddTable("A1:B2", hasHeader: true, name: "InventoryTable", style: TableStyle.TableStyleMedium2);
             sheet.SetHyperlink(2, 1, "https://example.test/bandage", display: "Bandage");
+            sheet.Cell(1, 4, "Loose");
+            sheet.Cell(1, 5, "Value");
+            sheet.Cell(2, 4, "Unstructured");
+            sheet.Cell(2, 5, 7);
             ExcelSheet rawSheet = document.AddWorkSheet("Raw");
             rawSheet.Cell(1, 1, "Metric");
             rawSheet.Cell(1, 2, "Value");
@@ -73,9 +89,47 @@ public sealed class ReaderOfficeRichMappingTests {
         Assert.Equal("Inventory", link.Location.Sheet);
         Assert.Equal("A2", link.Location.A1Range);
         Assert.Equal("https://example.test/bandage", link.Uri);
+        ReaderTable looseInventory = Assert.Single(result.Tables, table => table.Kind != "excel-table" && table.Location?.Sheet == "Inventory");
+        Assert.Contains(looseInventory.Columns, column => column == "Loose");
         OfficeDocumentPage inventoryPage = Assert.Single(result.Pages, page => page.Name == "Inventory");
-        Assert.Same(mapped, Assert.Single(inventoryPage.Tables));
+        Assert.Contains(inventoryPage.Tables, table => ReferenceEquals(table, mapped));
+        Assert.Contains(inventoryPage.Tables, table => ReferenceEquals(table, looseInventory));
         Assert.Contains("officeimo.excel.inspection-snapshot", result.CapabilitiesUsed);
+    }
+
+    [Fact]
+    public void DocumentReader_ExcelRichMapping_HonorsSelectedRangeAcrossRichArtifacts() {
+        using var stream = new MemoryStream();
+        using (ExcelDocument document = ExcelDocument.Create(stream)) {
+            ExcelSheet sheet = document.AddWorkSheet("Inventory");
+            sheet.Cell(1, 1, "Name");
+            sheet.Cell(1, 2, "Qty");
+            sheet.Cell(2, 1, "Bandage");
+            sheet.CellFormula(2, 2, "1+1");
+            sheet.Cell(3, 1, "Gauze");
+            sheet.Cell(3, 2, 3);
+            sheet.AddTable("A1:B3", hasHeader: true, name: "InventoryTable", style: TableStyle.TableStyleMedium2);
+            sheet.SetHyperlink(2, 1, "https://example.test/inside", display: "Bandage");
+            sheet.SetComment(2, 1, "Inside comment");
+            sheet.CellFormula(2, 4, "2+2");
+            sheet.SetHyperlink(2, 4, "https://example.test/outside", display: "Outside");
+            sheet.SetComment(2, 4, "Outside comment");
+            document.Save();
+        }
+        stream.Position = 0;
+
+        OfficeDocumentReadResult result = DocumentReader.ReadDocument(
+            stream,
+            "inventory.xlsx",
+            new ReaderOptions { ExcelA1Range = "A1:B2" });
+
+        OfficeDocumentLink link = Assert.Single(result.Links);
+        Assert.Equal("https://example.test/inside", link.Uri);
+        ReaderTable table = Assert.Single(result.Tables, candidate => candidate.Kind == "excel-table");
+        Assert.Equal("A1:B2", table.Location!.A1Range);
+        Assert.Single(table.Rows);
+        Assert.Equal("1", Assert.Single(result.Metadata, item => item.Name == "FormulaCount").Value);
+        Assert.Equal("1", Assert.Single(result.Metadata, item => item.Name == "CommentCount").Value);
     }
 
     [Fact]
@@ -85,6 +139,7 @@ public sealed class ReaderOfficeRichMappingTests {
             presentation.BuiltinDocumentProperties.Title = "Rich deck";
             presentation.BuiltinDocumentProperties.Creator = "OfficeIMO";
             PowerPointSlide slide = presentation.AddSlide();
+            slide.Notes.Text = "Speaker guidance";
             PowerPointTextBox title = slide.AddTextBox("Overview");
             title.AddParagraph("Summary");
             title.Paragraphs[0].Runs[0].SetHyperlink("https://example.test/deck");
@@ -114,6 +169,17 @@ public sealed class ReaderOfficeRichMappingTests {
         Assert.Equal("chart", chart.Kind);
         Assert.Contains("Sales", chart.Content, StringComparison.Ordinal);
         Assert.Equal("3", Assert.Single(result.Metadata, item => item.Name == "ShapeCount").Value);
+        OfficeDocumentBlock notes = Assert.Single(result.Blocks, block => block.Kind == "speaker-notes");
+        Assert.Equal("Speaker guidance", notes.Text);
+        Assert.Same(notes, Assert.Single(page.Blocks, block => block.Kind == "speaker-notes"));
         Assert.Contains("officeimo.powerpoint.chart-snapshot", result.CapabilitiesUsed);
+
+        stream.Position = 0;
+        OfficeDocumentReadResult withoutNotes = DocumentReader.ReadDocument(
+            stream,
+            "deck.pptx",
+            new ReaderOptions { IncludePowerPointNotes = false });
+        Assert.DoesNotContain(withoutNotes.Blocks, block => block.Kind == "speaker-notes");
+        Assert.DoesNotContain(Assert.Single(withoutNotes.Pages).Blocks, block => block.Kind == "speaker-notes");
     }
 }

--- a/OfficeIMO.Reader.Tests/Reader.RichMappings.Office.cs
+++ b/OfficeIMO.Reader.Tests/Reader.RichMappings.Office.cs
@@ -1,0 +1,119 @@
+using OfficeIMO.Excel;
+using OfficeIMO.PowerPoint;
+using OfficeIMO.Reader;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class ReaderOfficeRichMappingTests {
+    [Fact]
+    public void DocumentReader_WordRichMapping_UsesInspectionBlocksTablesLinksAndProperties() {
+        using var stream = new MemoryStream();
+        using (WordDocument document = WordDocument.Create(stream)) {
+            document.BuiltinDocumentProperties.Title = "Rich policy";
+            document.BuiltinDocumentProperties.Creator = "OfficeIMO";
+            document.AddParagraph("Policy").Style = WordParagraphStyles.Heading1;
+            document.AddParagraph("Read ").AddHyperLink("the policy", new Uri("https://example.test/policy"));
+            WordTable table = document.AddTable(2, 2);
+            table.Title = "Inventory";
+            table.Rows[0].Cells[0].Paragraphs[0].Text = "Name";
+            table.Rows[0].Cells[1].Paragraphs[0].Text = "Qty";
+            table.Rows[1].Cells[0].Paragraphs[0].Text = "Bandage";
+            table.Rows[1].Cells[1].Paragraphs[0].Text = "4";
+            document.Save();
+        }
+        stream.Position = 0;
+
+        OfficeDocumentReadResult result = DocumentReader.ReadDocument(stream, "policy.docx");
+
+        Assert.Equal("Rich policy", result.Source.Title);
+        Assert.Equal("OfficeIMO", result.Source.Author);
+        Assert.Contains(result.Blocks, block => block.Kind == "heading" && block.Level == 1 && block.Location.HeadingPath == "Policy");
+        Assert.Contains(result.Blocks, block => block.Kind == "paragraph" && block.Location.HeadingPath == "Policy");
+        ReaderTable mapped = Assert.Single(result.Tables);
+        Assert.Equal("Inventory", mapped.Title);
+        Assert.Equal("Bandage", mapped.Rows[0][0]);
+        Assert.Equal("https://example.test/policy", Assert.Single(result.Links).Uri);
+        Assert.Contains("officeimo.word.inspection-snapshot", result.CapabilitiesUsed);
+    }
+
+    [Fact]
+    public void DocumentReader_ExcelRichMapping_UsesFormalTablesCellLinksAndProperties() {
+        using var stream = new MemoryStream();
+        using (ExcelDocument document = ExcelDocument.Create(stream)) {
+            document.BuiltinDocumentProperties.Title = "Rich workbook";
+            document.BuiltinDocumentProperties.Creator = "OfficeIMO";
+            ExcelSheet sheet = document.AddWorkSheet("Inventory");
+            sheet.Cell(1, 1, "Name");
+            sheet.Cell(1, 2, "Qty");
+            sheet.Cell(2, 1, "Bandage");
+            sheet.Cell(2, 2, 4);
+            sheet.AddTable("A1:B2", hasHeader: true, name: "InventoryTable", style: TableStyle.TableStyleMedium2);
+            sheet.SetHyperlink(2, 1, "https://example.test/bandage", display: "Bandage");
+            ExcelSheet rawSheet = document.AddWorkSheet("Raw");
+            rawSheet.Cell(1, 1, "Metric");
+            rawSheet.Cell(1, 2, "Value");
+            rawSheet.Cell(2, 1, "Retries");
+            rawSheet.Cell(2, 2, 3);
+            document.Save();
+        }
+        stream.Position = 0;
+
+        OfficeDocumentReadResult result = DocumentReader.ReadDocument(stream, "inventory.xlsx");
+
+        Assert.Equal("Rich workbook", result.Source.Title);
+        Assert.Equal("OfficeIMO", result.Source.Author);
+        ReaderTable mapped = Assert.Single(result.Tables, table => table.Kind == "excel-table");
+        Assert.Equal("InventoryTable", mapped.Title);
+        Assert.Equal("excel-table", mapped.Kind);
+        Assert.Equal("Bandage", mapped.Rows[0][0]);
+        Assert.Contains(result.Tables, table => table.Location?.Sheet == "Raw");
+        OfficeDocumentLink link = Assert.Single(result.Links);
+        Assert.Equal("Inventory", link.Location.Sheet);
+        Assert.Equal("A2", link.Location.A1Range);
+        Assert.Equal("https://example.test/bandage", link.Uri);
+        OfficeDocumentPage inventoryPage = Assert.Single(result.Pages, page => page.Name == "Inventory");
+        Assert.Same(mapped, Assert.Single(inventoryPage.Tables));
+        Assert.Contains("officeimo.excel.inspection-snapshot", result.CapabilitiesUsed);
+    }
+
+    [Fact]
+    public void DocumentReader_PowerPointRichMapping_UsesShapesTablesChartsLinksAndSlideGeometry() {
+        using var stream = new MemoryStream();
+        using (PowerPointPresentation presentation = PowerPointPresentation.Create(stream)) {
+            presentation.BuiltinDocumentProperties.Title = "Rich deck";
+            presentation.BuiltinDocumentProperties.Creator = "OfficeIMO";
+            PowerPointSlide slide = presentation.AddSlide();
+            PowerPointTextBox title = slide.AddTextBox("Overview");
+            title.AddParagraph("Summary");
+            title.Paragraphs[0].Runs[0].SetHyperlink("https://example.test/deck");
+            PowerPointTable table = slide.AddTable(2, 2);
+            table.GetCell(0, 0).Text = "Name";
+            table.GetCell(0, 1).Text = "Qty";
+            table.GetCell(1, 0).Text = "Bandage";
+            table.GetCell(1, 1).Text = "4";
+            slide.AddChart(new PowerPointChartData(
+                new[] { "Q1", "Q2" },
+                new[] { new PowerPointChartSeries("Sales", new[] { 1D, 2D }) }));
+            presentation.Save();
+        }
+        stream.Position = 0;
+
+        OfficeDocumentReadResult result = DocumentReader.ReadDocument(stream, "deck.pptx");
+
+        Assert.Equal("Rich deck", result.Source.Title);
+        Assert.Equal("OfficeIMO", result.Source.Author);
+        OfficeDocumentPage page = Assert.Single(result.Pages);
+        Assert.True(page.Width > 0);
+        Assert.True(page.Height > 0);
+        Assert.Contains(result.Blocks, block => block.Kind == "paragraph" && block.Text == "Overview" && block.Region != null);
+        Assert.Equal("Bandage", Assert.Single(result.Tables).Rows[0][0]);
+        Assert.Equal("https://example.test/deck", Assert.Single(result.Links).Uri);
+        ReaderVisual chart = Assert.Single(result.Visuals);
+        Assert.Equal("chart", chart.Kind);
+        Assert.Contains("Sales", chart.Content, StringComparison.Ordinal);
+        Assert.Equal("3", Assert.Single(result.Metadata, item => item.Name == "ShapeCount").Value);
+        Assert.Contains("officeimo.powerpoint.chart-snapshot", result.CapabilitiesUsed);
+    }
+}

--- a/OfficeIMO.Reader.Tests/Reader.RichMappings.Office.cs
+++ b/OfficeIMO.Reader.Tests/Reader.RichMappings.Office.cs
@@ -23,6 +23,7 @@ public sealed class ReaderOfficeRichMappingTests {
             noteReference.AddEndNote("Endnote detail");
             WordTable table = document.AddTable(2, 2);
             table.Title = "Inventory";
+            table.RepeatAsHeaderRowAtTheTopOfEachPage = true;
             table.Rows[0].Cells[0].Paragraphs[0].Text = "Name";
             table.Rows[0].Cells[1].Paragraphs[0].Text = "Qty";
             table.Rows[1].Cells[0].Paragraphs[0].Text = "Bandage";
@@ -60,6 +61,7 @@ public sealed class ReaderOfficeRichMappingTests {
         using var stream = new MemoryStream();
         using (WordDocument document = WordDocument.Create(stream)) {
             WordTable table = document.AddTable(4, 2);
+            table.RepeatAsHeaderRowAtTheTopOfEachPage = true;
             table.Rows[0].Cells[0].Paragraphs[0].Text = "Name";
             table.Rows[0].Cells[1].Paragraphs[0].Text = "Qty";
             for (int row = 1; row < 4; row++) {
@@ -82,6 +84,25 @@ public sealed class ReaderOfficeRichMappingTests {
         Assert.Contains("Row 1", tableBlock.Text, StringComparison.Ordinal);
         Assert.DoesNotContain("Row 2", tableBlock.Text, StringComparison.Ordinal);
         Assert.DoesNotContain("Row 3", tableBlock.Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DocumentReader_WordRichMapping_PreservesHeaderlessFirstRow() {
+        using var stream = new MemoryStream();
+        using (WordDocument document = WordDocument.Create(stream)) {
+            WordTable table = document.AddTable(2, 1);
+            table.RepeatAsHeaderRowAtTheTopOfEachPage = false;
+            table.Rows[0].Cells[0].Paragraphs[0].Text = "First value";
+            table.Rows[1].Cells[0].Paragraphs[0].Text = "Second value";
+            document.Save();
+        }
+        stream.Position = 0;
+
+        ReaderTable mapped = Assert.Single(DocumentReader.ReadDocument(stream, "headerless.docx").Tables);
+
+        Assert.Equal(new[] { "Column 1" }, mapped.Columns);
+        Assert.Equal(2, mapped.TotalRowCount);
+        Assert.Equal(new[] { "First value", "Second value" }, mapped.Rows.Select(row => row[0]));
     }
 
     [Fact]
@@ -123,11 +144,11 @@ public sealed class ReaderOfficeRichMappingTests {
         Assert.Equal("Inventory", link.Location.Sheet);
         Assert.Equal("A2", link.Location.A1Range);
         Assert.Equal("https://example.test/bandage", link.Uri);
-        ReaderTable looseInventory = Assert.Single(result.Tables, table => table.Kind != "excel-table" && table.Location?.Sheet == "Inventory");
-        Assert.Contains(looseInventory.Columns, column => column == "Loose");
+        Assert.DoesNotContain(result.Tables, table => table.Kind != "excel-table" && table.Location?.Sheet == "Inventory");
+        Assert.Contains(result.Blocks, block => block.Location.Sheet == "Inventory" && block.Text.Contains("Unstructured", StringComparison.Ordinal));
         OfficeDocumentPage inventoryPage = Assert.Single(result.Pages, page => page.Name == "Inventory");
         Assert.Contains(inventoryPage.Tables, table => ReferenceEquals(table, mapped));
-        Assert.Contains(inventoryPage.Tables, table => ReferenceEquals(table, looseInventory));
+        Assert.Single(inventoryPage.Tables);
         Assert.Contains("officeimo.excel.inspection-snapshot", result.CapabilitiesUsed);
     }
 
@@ -218,5 +239,24 @@ public sealed class ReaderOfficeRichMappingTests {
             new ReaderOptions { IncludePowerPointNotes = false });
         Assert.DoesNotContain(withoutNotes.Blocks, block => block.Kind == "speaker-notes");
         Assert.DoesNotContain(Assert.Single(withoutNotes.Pages).Blocks, block => block.Kind == "speaker-notes");
+    }
+
+    [Fact]
+    public void DocumentReader_PowerPointRichMapping_PreservesHeaderlessFirstRow() {
+        using var stream = new MemoryStream();
+        using (PowerPointPresentation presentation = PowerPointPresentation.Create(stream)) {
+            PowerPointTable table = presentation.AddSlide().AddTable(2, 1);
+            table.HeaderRow = false;
+            table.GetCell(0, 0).Text = "First value";
+            table.GetCell(1, 0).Text = "Second value";
+            presentation.Save();
+        }
+        stream.Position = 0;
+
+        ReaderTable mapped = Assert.Single(DocumentReader.ReadDocument(stream, "headerless.pptx").Tables);
+
+        Assert.Equal(new[] { "Column 1" }, mapped.Columns);
+        Assert.Equal(2, mapped.TotalRowCount);
+        Assert.Equal(new[] { "First value", "Second value" }, mapped.Rows.Select(row => row[0]));
     }
 }

--- a/OfficeIMO.Reader.Tests/Reader.Rtf.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Rtf.Modular.cs
@@ -13,11 +13,13 @@ public sealed class ReaderRtfModularTests {
         RtfDocument document = RtfDocument.Create();
         document.Info.Title = "Rich RTF";
         document.Info.Author = "OfficeIMO";
-        document.AddHeader().AddParagraph("Confidential");
+        RtfParagraph headerParagraph = document.AddHeader().AddParagraph("Confidential ");
+        headerParagraph.AddText("header portal").SetHyperlink(new Uri("https://example.test/header"));
         RtfParagraph paragraph = document.AddParagraph("Portal ");
         paragraph.AddText("open").SetHyperlink(new Uri("https://example.test/rtf"));
         RtfNote sourceNote = document.AddNote(RtfNoteKind.Footnote);
-        sourceNote.AddParagraph("Review note");
+        RtfParagraph noteParagraph = sourceNote.AddParagraph("Review note ");
+        noteParagraph.AddText("note portal").SetHyperlink(new Uri("https://example.test/note"));
         paragraph.AddNoteReference(sourceNote, "1");
         RtfField field = paragraph.AddField("FORMTEXT");
         field.AddText("Ada");
@@ -34,7 +36,13 @@ public sealed class ReaderRtfModularTests {
 
         Assert.Equal("Rich RTF", result.Source.Title);
         Assert.Equal("OfficeIMO", result.Source.Author);
-        Assert.Equal("https://example.test/rtf", Assert.Single(result.Links).Uri);
+        Assert.Contains(result.Links, link => link.Uri == "https://example.test/rtf");
+        Assert.Contains(result.Links, link =>
+            link.Uri == "https://example.test/header" &&
+            link.Location.BlockAnchor?.StartsWith("rtf-header-footer-", StringComparison.Ordinal) == true);
+        Assert.Contains(result.Links, link =>
+            link.Uri == "https://example.test/note" &&
+            link.Location.BlockAnchor?.StartsWith("rtf-note-", StringComparison.Ordinal) == true);
         OfficeDocumentFormField form = Assert.Single(result.Forms);
         Assert.Equal("Patient", form.Name);
         Assert.True(form.IsReadOnly);
@@ -51,6 +59,28 @@ public sealed class ReaderRtfModularTests {
             DocumentReaderRtfExtensions.ReadRtfDocumentResultJson(document, "rich.rtf"));
         Assert.Equal(ReaderInputKind.Rtf, jsonResult.Kind);
         Assert.Contains("officeimo.reader.rtf.rich-v5", result.CapabilitiesUsed);
+    }
+
+    [Fact]
+    public void DocumentReaderRtf_RichTables_ApplyRowLimitToTableBlocks() {
+        RtfDocument document = RtfDocument.Create();
+        RtfTable table = document.AddTable(3, 1);
+        table.Rows[0].Cells[0].AddParagraph("Row 1");
+        table.Rows[1].Cells[0].AddParagraph("Row 2");
+        table.Rows[2].Cells[0].AddParagraph("Row 3");
+
+        OfficeDocumentReadResult result = DocumentReaderRtfExtensions.ReadRtfDocumentResult(
+            document,
+            "bounded.rtf",
+            new ReaderOptions { MaxTableRows = 1 });
+
+        ReaderTable mapped = Assert.Single(result.Tables);
+        Assert.Single(mapped.Rows);
+        Assert.True(mapped.Truncated);
+        OfficeDocumentBlock block = Assert.Single(result.Blocks, item => item.Kind == "table");
+        Assert.Contains("Row 1", block.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain("Row 2", block.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain("Row 3", block.Text, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/OfficeIMO.Reader.Tests/Reader.Rtf.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Rtf.Modular.cs
@@ -9,6 +9,51 @@ namespace OfficeIMO.Tests;
 [Collection("ReaderRegistryNonParallel")]
 public sealed class ReaderRtfModularTests {
     [Fact]
+    public void DocumentReaderRtf_RichResult_MapsMetadataLinksFormsTablesAndImagePayloads() {
+        RtfDocument document = RtfDocument.Create();
+        document.Info.Title = "Rich RTF";
+        document.Info.Author = "OfficeIMO";
+        document.AddHeader().AddParagraph("Confidential");
+        RtfParagraph paragraph = document.AddParagraph("Portal ");
+        paragraph.AddText("open").SetHyperlink(new Uri("https://example.test/rtf"));
+        RtfNote sourceNote = document.AddNote(RtfNoteKind.Footnote);
+        sourceNote.AddParagraph("Review note");
+        paragraph.AddNoteReference(sourceNote, "1");
+        RtfField field = paragraph.AddField("FORMTEXT");
+        field.AddText("Ada");
+        field.SetFormFieldData(data => { data.Kind = RtfFormFieldKind.Text; data.Name = "Patient"; data.Protected = true; });
+        RtfTable table = document.AddTable(2, 2);
+        table.Rows[0].Cells[0].AddParagraph("Name");
+        table.Rows[0].Cells[1].AddParagraph("Qty");
+        table.Rows[1].Cells[0].AddParagraph("Bandage");
+        table.Rows[1].Cells[1].AddParagraph("4");
+        RtfImage image = document.AddImage(RtfImageFormat.Png, new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 });
+        image.Description = "Tiny image";
+
+        OfficeDocumentReadResult result = DocumentReaderRtfExtensions.ReadRtfDocumentResult(document, "rich.rtf");
+
+        Assert.Equal("Rich RTF", result.Source.Title);
+        Assert.Equal("OfficeIMO", result.Source.Author);
+        Assert.Equal("https://example.test/rtf", Assert.Single(result.Links).Uri);
+        OfficeDocumentFormField form = Assert.Single(result.Forms);
+        Assert.Equal("Patient", form.Name);
+        Assert.True(form.IsReadOnly);
+        Assert.Equal("Bandage", Assert.Single(result.Tables).Rows[1][0]);
+        OfficeDocumentAsset asset = Assert.Single(result.Assets, item => item.Kind == "image");
+        Assert.NotNull(asset.PayloadBytes);
+        Assert.True(asset.PayloadHashMatches(out _));
+        Assert.Contains(result.Visuals, visual => visual.Kind == "image" && visual.PayloadHash == asset.PayloadHash);
+        OfficeDocumentBlock header = Assert.Single(result.Blocks, block => block.Kind == "header-footer");
+        OfficeDocumentBlock note = Assert.Single(result.Blocks, block => block.Kind == "note");
+        Assert.Equal(header.Id, header.Location.BlockAnchor);
+        Assert.Equal(note.Id, note.Location.BlockAnchor);
+        OfficeDocumentReadResult jsonResult = OfficeDocumentReadResultJson.Deserialize(
+            DocumentReaderRtfExtensions.ReadRtfDocumentResultJson(document, "rich.rtf"));
+        Assert.Equal(ReaderInputKind.Rtf, jsonResult.Kind);
+        Assert.Contains("officeimo.reader.rtf.rich-v5", result.CapabilitiesUsed);
+    }
+
+    [Fact]
     public void DocumentReaderRtf_ReadRtfDocument_EmitsParagraphChunks() {
         RtfDocument document = RtfDocument.Create();
         document.AddParagraph("Hello RTF reader.");

--- a/OfficeIMO.Reader.Tests/Reader.Visio.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Visio.Modular.cs
@@ -48,10 +48,14 @@ public sealed class ReaderVisioModularTests {
         Assert.Equal("topology.vsdx", result.Source.Path);
         Assert.Equal("Topology", result.Source.Title);
         Assert.Contains("officeimo.reader.visio", result.CapabilitiesUsed);
+        Assert.Contains("officeimo.reader.visio.rich-v5", result.CapabilitiesUsed);
         Assert.Contains("officeimo.visio.inspection-snapshot", result.CapabilitiesUsed);
+        Assert.Contains("officeimo.visio.topology-visual", result.CapabilitiesUsed);
         Assert.Contains("officeimo.visio.svg-preview", result.CapabilitiesUsed);
         OfficeDocumentPage page = Assert.Single(result.Pages);
         Assert.Equal("Topology", page.Name);
+        Assert.Equal(576D, page.Width);
+        Assert.Equal(360D, page.Height);
         Assert.Contains(result.Blocks, block => block.Kind == "shape" && block.Text.Contains("Gateway", StringComparison.Ordinal));
         Assert.Contains(result.Blocks, block => block.Kind == "connector" && block.Text.Contains("TLS", StringComparison.Ordinal));
         Assert.Same(Assert.Single(result.Tables), Assert.Single(page.Tables));
@@ -65,6 +69,13 @@ public sealed class ReaderVisioModularTests {
         Assert.False(string.IsNullOrWhiteSpace(asset.PayloadHash));
         Assert.NotNull(asset.PayloadBytes);
         Assert.Same(asset, Assert.Single(page.Assets));
+        ReaderVisual visual = Assert.Single(result.Visuals);
+        Assert.Equal("network", visual.Kind);
+        Assert.Equal("officeimo-visio-topology", visual.Language);
+        Assert.Contains("Gateway", visual.Content, StringComparison.Ordinal);
+        Assert.Contains("Service", visual.Content, StringComparison.Ordinal);
+        using JsonDocument topology = JsonDocument.Parse(visual.Content);
+        Assert.Equal("Gateway -> Service", topology.RootElement.GetProperty("edges")[0].GetProperty("label").GetString());
     }
 
     [Fact]

--- a/OfficeIMO.Reader.Visio/DocumentReaderVisioExtensions.Document.cs
+++ b/OfficeIMO.Reader.Visio/DocumentReaderVisioExtensions.Document.cs
@@ -1,4 +1,5 @@
 using OfficeIMO.Visio;
+using System.Text.Json;
 
 namespace OfficeIMO.Reader.Visio;
 
@@ -142,6 +143,7 @@ public static partial class DocumentReaderVisioExtensions {
         VisioPage[] snapshotOrderedPages = GetSnapshotOrderedPages(document, snapshot).ToArray();
         OfficeDocumentLink[] links = BuildDocumentLinks(snapshotOrderedPages, source).ToArray();
         OfficeDocumentAsset[] assets = BuildDocumentAssets(snapshotOrderedPages, source, visioOptions, cancellationToken).ToArray();
+        ReaderVisual[] visuals = BuildDocumentVisuals(snapshot, source).ToArray();
 
         return new OfficeDocumentReadResult {
             Kind = ReaderInputKind.Visio,
@@ -157,13 +159,14 @@ public static partial class DocumentReaderVisioExtensions {
             CapabilitiesUsed = BuildDocumentCapabilities(visioOptions),
             Markdown = chunks.Length == 0 ? null : string.Join(Environment.NewLine + Environment.NewLine, chunks.Select(static chunk => chunk.Markdown ?? chunk.Text)),
             Chunks = chunks,
+            Metadata = BuildDocumentMetadata(snapshot, tables, links, assets, visuals),
             Pages = BuildDocumentPages(snapshot, source, blocks, tables, links, assets),
             Blocks = blocks,
             Tables = tables,
             Assets = assets,
             Links = links,
             Forms = Array.Empty<OfficeDocumentFormField>(),
-            Visuals = Array.Empty<ReaderVisual>(),
+            Visuals = visuals,
             Diagnostics = Array.Empty<OfficeDocumentDiagnostic>()
         };
     }
@@ -171,7 +174,9 @@ public static partial class DocumentReaderVisioExtensions {
     private static IReadOnlyList<string> BuildDocumentCapabilities(ReaderVisioOptions options) {
         var capabilities = new List<string> {
             "officeimo.reader.visio",
-            "officeimo.visio.inspection-snapshot"
+            "officeimo.reader.visio.rich-v5",
+            "officeimo.visio.inspection-snapshot",
+            "officeimo.visio.topology-visual"
         };
         if (options.IncludeSvgPreviewAssets) {
             capabilities.Add("officeimo.visio.svg-preview");
@@ -193,10 +198,10 @@ public static partial class DocumentReaderVisioExtensions {
                     Text = BuildShapeBlockText(shape),
                     Location = BuildLocation(source, pageIndex, "shape", "page-" + (pageIndex + 1).ToString(CultureInfo.InvariantCulture) + "-shape-" + shape.Id),
                     Region = new OfficeDocumentRegion {
-                        X = shape.PinX - (shape.Width / 2D),
-                        Y = shape.PinY - (shape.Height / 2D),
-                        Width = shape.Width,
-                        Height = shape.Height
+                        X = InchesToPoints(shape.PinX - (shape.Width / 2D)),
+                        Y = InchesToPoints(shape.PinY - (shape.Height / 2D)),
+                        Width = InchesToPoints(shape.Width),
+                        Height = InchesToPoints(shape.Height)
                     }
                 };
             }
@@ -226,8 +231,8 @@ public static partial class DocumentReaderVisioExtensions {
             pages.Add(new OfficeDocumentPage {
                 Number = pageNumber,
                 Name = page.Name,
-                Width = page.Width,
-                Height = page.Height,
+                Width = InchesToPoints(page.Width),
+                Height = InchesToPoints(page.Height),
                 Location = BuildLocation(source, pageIndex, "page", "page-" + pageNumber.ToString(CultureInfo.InvariantCulture)),
                 Blocks = blocks.Where(block => block.Location.Page == pageNumber).ToArray(),
                 Tables = tables.Where(table => table.Location?.Page == pageNumber).ToArray(),
@@ -264,10 +269,10 @@ public static partial class DocumentReaderVisioExtensions {
                         ownerKind: "shape",
                         ownerId: shape.Id,
                         region: new OfficeDocumentRegion {
-                            X = shape.PinX - (shape.Width / 2D),
-                            Y = shape.PinY - (shape.Height / 2D),
-                            Width = shape.Width,
-                            Height = shape.Height
+                            X = InchesToPoints(shape.PinX - (shape.Width / 2D)),
+                            Y = InchesToPoints(shape.PinY - (shape.Height / 2D)),
+                            Width = InchesToPoints(shape.Width),
+                            Height = InchesToPoints(shape.Height)
                         });
                 }
             }
@@ -333,6 +338,89 @@ public static partial class DocumentReaderVisioExtensions {
             PayloadBytes = payload,
             Location = BuildLocation(source, pageIndex, kind, "page-" + (pageIndex + 1).ToString(CultureInfo.InvariantCulture) + "-" + kind)
         };
+    }
+
+    private static IEnumerable<ReaderVisual> BuildDocumentVisuals(VisioInspectionSnapshot snapshot, SourceMetadata source) {
+        for (int pageIndex = 0; pageIndex < snapshot.Pages.Count; pageIndex++) {
+            VisioInspectionPageSnapshot page = snapshot.Pages[pageIndex];
+            string content = JsonSerializer.Serialize(new {
+                page = new { id = page.Id, name = page.Name, width = page.Width, height = page.Height, layers = page.Layers },
+                nodes = page.Shapes.Select(static shape => new {
+                    id = shape.Id,
+                    name = shape.Name,
+                    text = shape.Text,
+                    type = shape.Type,
+                    master = shape.MasterNameU,
+                    parentId = shape.ParentId,
+                    x = shape.PinX,
+                    y = shape.PinY,
+                    width = shape.Width,
+                    height = shape.Height,
+                    angle = shape.Angle,
+                    layers = shape.Layers,
+                    data = shape.ShapeData.Select(static row => new { name = row.Name, label = row.Label, value = row.Value, type = row.Type }).ToArray()
+                }).ToArray(),
+                edges = page.Connectors.Select(static connector => new {
+                    id = connector.Id,
+                    source = connector.FromId,
+                    target = connector.ToId,
+                    kind = connector.Kind,
+                    label = connector.Label,
+                    waypoints = connector.Waypoints.Select(static point => new { x = point.X, y = point.Y }).ToArray(),
+                    data = connector.ShapeData.Select(static row => new { name = row.Name, label = row.Label, value = row.Value, type = row.Type }).ToArray()
+                }).ToArray()
+            });
+            yield return new ReaderVisual {
+                Kind = "network",
+                Language = "officeimo-visio-topology",
+                Content = content,
+                PayloadHash = ComputeSha256Hex(content),
+                SourceName = page.Name,
+                Width = InchesToPoints(page.Width),
+                Height = InchesToPoints(page.Height),
+                PlacedWidth = InchesToPoints(page.Width),
+                PlacedHeight = InchesToPoints(page.Height),
+                PlacementCount = 1,
+                HasGeometry = true,
+                IsAxisAligned = true,
+                Location = BuildLocation(source, pageIndex, "diagram", "page-" + (pageIndex + 1).ToString(CultureInfo.InvariantCulture) + "-topology")
+            };
+        }
+    }
+
+    private static IReadOnlyList<OfficeDocumentMetadataEntry> BuildDocumentMetadata(
+        VisioInspectionSnapshot snapshot,
+        IReadOnlyList<ReaderTable> tables,
+        IReadOnlyList<OfficeDocumentLink> links,
+        IReadOnlyList<OfficeDocumentAsset> assets,
+        IReadOnlyList<ReaderVisual> visuals) {
+        var metadata = new List<OfficeDocumentMetadataEntry> {
+            BuildVisioCountMetadata("visio-page-count", "PageCount", snapshot.Pages.Count),
+            BuildVisioCountMetadata("visio-shape-count", "ShapeCount", snapshot.ShapeCount),
+            BuildVisioCountMetadata("visio-connector-count", "ConnectorCount", snapshot.ConnectorCount),
+            BuildVisioCountMetadata("visio-table-count", "TableCount", tables.Count),
+            BuildVisioCountMetadata("visio-link-count", "LinkCount", links.Count),
+            BuildVisioCountMetadata("visio-asset-count", "AssetCount", assets.Count),
+            BuildVisioCountMetadata("visio-visual-count", "VisualCount", visuals.Count)
+        };
+        if (!string.IsNullOrWhiteSpace(snapshot.ThemeType)) metadata.Add(new OfficeDocumentMetadataEntry {
+            Id = "visio-theme", Category = "visio.document", Name = "Theme", Value = snapshot.ThemeType, ValueType = "string"
+        });
+        return metadata;
+    }
+
+    private static OfficeDocumentMetadataEntry BuildVisioCountMetadata(string id, string name, int count) {
+        return new OfficeDocumentMetadataEntry {
+            Id = id,
+            Category = "visio.summary",
+            Name = name,
+            Value = count.ToString(CultureInfo.InvariantCulture),
+            ValueType = "count"
+        };
+    }
+
+    private static double InchesToPoints(double value) {
+        return value * 72D;
     }
 
     private static string ResolveShapeKind(VisioInspectionShapeSnapshot shape) {

--- a/OfficeIMO.Reader.Visio/README.md
+++ b/OfficeIMO.Reader.Visio/README.md
@@ -65,11 +65,29 @@ var chunks = DocumentReader.ReadFolder("Architecture",
     }).ToList();
 ```
 
+### Read topology and geometry
+
+```csharp
+OfficeDocumentReadResult document =
+    DocumentReaderVisioExtensions.ReadVisioDocument("network.vsdx");
+
+foreach (ReaderVisual topology in document.Visuals) {
+    Console.WriteLine($"Page {topology.Location.Page}: {topology.Content}");
+}
+
+foreach (OfficeDocumentPage page in document.Pages) {
+    Console.WriteLine($"{page.Name}: {page.Width} x {page.Height} points");
+}
+```
+
+The topology visual is deterministic JSON describing page shapes and connector edges. Shared regions and page dimensions are expressed in points. After registration, `DocumentReader.ReadDocument("network.vsdx")` uses this native mapping.
+
 ## What it emits
 
 - Page-aware chunks for `.vsdx`, `.vsdm`, `.vstx`, and `.vstm` files.
 - Shape Data as `ReaderTable` rows.
 - Pages, shapes, connectors, hyperlinks, and optional preview asset metadata in the shared read result envelope.
+- Point-based geometry and one topology `ReaderVisual` per page for graph-aware consumers.
 
 ## Boundaries
 

--- a/OfficeIMO.Reader/DocumentReader.Document.cs
+++ b/OfficeIMO.Reader/DocumentReader.Document.cs
@@ -43,7 +43,10 @@ public static partial class DocumentReader {
             ? Array.Empty<OfficeDocumentAsset>()
             : ReadOpenXmlImageAssets(path, kind, opt, cancellationToken);
         ReaderInputKind fallbackKind = customPathReaderOwnsExtension ? customPathHandler.Kind : kind;
-        return BuildChunkDocumentResult(chunks, path, fallbackKind, BuildPathDocumentSource(path, chunks), assets, detection);
+        OfficeDocumentReadResult result = BuildChunkDocumentResult(chunks, path, fallbackKind, BuildPathDocumentSource(path, chunks), assets, detection);
+        return customPathReaderOwnsExtension
+            ? result
+            : EnrichBuiltInDocumentResult(path, kind, opt, result, cancellationToken);
     }
 
     /// <summary>
@@ -92,13 +95,19 @@ public static partial class DocumentReader {
                 ? Array.Empty<OfficeDocumentAsset>()
                 : ReadOpenXmlImageAssets(snapshot, logicalSourceName, kind, opt, cancellationToken);
             ReaderInputKind fallbackKind = customStreamReaderOwnsExtension ? customStreamHandler.Kind : kind;
-            return BuildChunkDocumentResult(
+            OfficeDocumentReadResult result = BuildChunkDocumentResult(
                 chunks,
                 logicalSourceName,
                 fallbackKind,
                 BuildStreamDocumentSource(snapshot, logicalSourceName, chunks),
                 assets,
                 detection);
+            if (customStreamReaderOwnsExtension) {
+                return result;
+            }
+
+            snapshot.Position = 0;
+            return EnrichBuiltInDocumentResult(snapshot, logicalSourceName, kind, opt, result, cancellationToken);
         } finally {
             if (ownsReadStream) {
                 readStream.Dispose();
@@ -310,12 +319,14 @@ public static partial class DocumentReader {
         var slideNumbers = chunks
             .Where(static chunk => chunk.Location.Slide.HasValue)
             .Select(static chunk => chunk.Location.Slide!.Value)
+            .Concat(tables.Where(static table => table.Location?.Slide != null).Select(static table => table.Location!.Slide!.Value))
             .Concat(assets.Where(static asset => asset.Location.Slide.HasValue).Select(static asset => asset.Location.Slide!.Value))
             .Concat(ocrCandidates.Where(static candidate => candidate.Location.Slide.HasValue).Select(static candidate => candidate.Location.Slide!.Value))
             .Distinct()
             .OrderBy(static slide => slide);
         foreach (int slideNumber in slideNumbers) {
             ReaderLocation location = chunks.FirstOrDefault(chunk => chunk.Location.Slide == slideNumber)?.Location
+                ?? tables.FirstOrDefault(table => table.Location?.Slide == slideNumber)?.Location
                 ?? assets.FirstOrDefault(asset => asset.Location.Slide == slideNumber)?.Location
                 ?? ocrCandidates.First(candidate => candidate.Location.Slide == slideNumber).Location;
             pages.Add(BuildChunkPage(
@@ -323,7 +334,7 @@ public static partial class DocumentReader {
                 name: null,
                 location: BuildContainerLocation(location, "slide"),
                 blocks: blocks.Where(block => block.Location.Slide == slideNumber).ToArray(),
-                tables: Array.Empty<ReaderTable>(),
+                tables: tables.Where(table => table.Location?.Slide == slideNumber).ToArray(),
                 assets: assets.Where(asset => asset.Location.Slide == slideNumber).ToArray(),
                 ocrCandidates: ocrCandidates.Where(candidate => candidate.Location.Slide == slideNumber).ToArray()));
         }

--- a/OfficeIMO.Reader/DocumentReader.DocumentResultFactory.cs
+++ b/OfficeIMO.Reader/DocumentReader.DocumentResultFactory.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OfficeIMO.Reader;
+
+public static partial class DocumentReader {
+    /// <summary>
+    /// Creates the shared v5 document envelope from adapter-produced chunks and optional source data.
+    /// </summary>
+    /// <remarks>
+    /// Format adapters can use this method for the common chunk, table, visual, page, metadata,
+    /// diagnostic, and OCR-candidate projection before adding format-owned rich structures.
+    /// </remarks>
+    public static OfficeDocumentReadResult CreateDocumentResult(
+        IEnumerable<ReaderChunk> chunks,
+        ReaderInputKind fallbackKind,
+        OfficeDocumentSource? source = null,
+        IEnumerable<string>? capabilities = null,
+        IReadOnlyList<OfficeDocumentAsset>? assets = null) {
+        if (chunks == null) throw new ArgumentNullException(nameof(chunks));
+        ReaderChunk[] materializedChunks = chunks.ToArray();
+        ReaderChunk? first = materializedChunks.Length == 0 ? null : materializedChunks[0];
+        OfficeDocumentSource effectiveSource = source ?? new OfficeDocumentSource {
+            Path = first?.Location.Path,
+            SourceId = first?.SourceId,
+            SourceHash = first?.SourceHash,
+            LastWriteUtc = first?.SourceLastWriteUtc,
+            LengthBytes = first?.SourceLengthBytes
+        };
+        string sourceName = effectiveSource.Path ?? first?.Location.Path ?? "memory";
+        OfficeDocumentReadResult result = BuildChunkDocumentResult(
+            materializedChunks,
+            sourceName,
+            fallbackKind,
+            effectiveSource,
+            assets);
+        if (capabilities != null) {
+            result.CapabilitiesUsed = result.CapabilitiesUsed
+                .Concat(capabilities)
+                .Where(static capability => !string.IsNullOrWhiteSpace(capability))
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+        }
+        return result;
+    }
+}

--- a/OfficeIMO.Reader/DocumentReader.ExcelRichMapping.cs
+++ b/OfficeIMO.Reader/DocumentReader.ExcelRichMapping.cs
@@ -1,0 +1,184 @@
+using OfficeIMO.Excel;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace OfficeIMO.Reader;
+
+public static partial class DocumentReader {
+    private static OfficeDocumentReadResult ApplyExcelRichMapping(
+        ExcelWorkbookSnapshot snapshot,
+        ReaderOptions options,
+        OfficeDocumentReadResult result) {
+        result.Source.Title = snapshot.Title;
+        result.Source.Author = snapshot.Author;
+        result.Source.Subject = snapshot.Subject;
+        result.Source.Keywords = snapshot.Keywords;
+
+        var selectedSheets = new HashSet<string>(
+            result.Pages
+                .Where(static page => !string.IsNullOrWhiteSpace(page.Name))
+                .Select(static page => page.Name!),
+            StringComparer.Ordinal);
+        if (selectedSheets.Count == 0 && !string.IsNullOrWhiteSpace(options.ExcelSheetName)) {
+            selectedSheets.Add(options.ExcelSheetName!.Trim());
+        }
+
+        ExcelWorksheetSnapshot[] worksheets = snapshot.Worksheets
+            .Where(sheet => selectedSheets.Count == 0 || selectedSheets.Contains(sheet.Name))
+            .ToArray();
+        OfficeDocumentLink[] links = BuildExcelLinks(worksheets, result.Source.Path).ToArray();
+        ReaderTable[] ownerTables = BuildExcelOwnerTables(worksheets, result.Source.Path, options.MaxTableRows).ToArray();
+        IReadOnlyList<ReaderTable> tables = MergeExcelTables(ownerTables, result.Tables);
+        IReadOnlyList<OfficeDocumentPage> pages = BuildExcelPages(result.Pages, result.Blocks, tables, result.Assets, links);
+
+        int formulaCount = worksheets.Sum(static sheet => sheet.Cells.Count(static cell => !string.IsNullOrWhiteSpace(cell.Formula)));
+        int commentCount = worksheets.Sum(static sheet => sheet.Cells.Count(static cell => cell.Comment != null || cell.ThreadedComment != null));
+        var metadata = new List<OfficeDocumentMetadataEntry> {
+            BuildCountMetadataEntry("excel-named-range-count", "excel.structure", "NamedRangeCount", snapshot.NamedRanges.Count),
+            BuildCountMetadataEntry("excel-formula-count", "excel.structure", "FormulaCount", formulaCount),
+            BuildCountMetadataEntry("excel-comment-count", "excel.structure", "CommentCount", commentCount)
+        };
+        if (!string.IsNullOrWhiteSpace(snapshot.ActiveWorksheetName)) {
+            metadata.Add(new OfficeDocumentMetadataEntry {
+                Id = "excel-active-worksheet",
+                Category = "excel.workbook",
+                Name = "ActiveWorksheet",
+                Value = snapshot.ActiveWorksheetName,
+                ValueType = "string"
+            });
+        }
+
+        return FinalizeRichMapping(
+            result,
+            new[] { "officeimo.excel.inspection-snapshot", "officeimo.reader.excel.rich-v5" },
+            result.Blocks,
+            tables,
+            links,
+            result.Visuals,
+            pages,
+            metadata);
+    }
+
+    private static IReadOnlyList<ReaderTable> MergeExcelTables(
+        IReadOnlyList<ReaderTable> ownerTables,
+        IReadOnlyList<ReaderTable> genericTables) {
+        if (ownerTables.Count == 0) return genericTables;
+        var formalTableSheets = new HashSet<string>(
+            ownerTables
+                .Where(static table => !string.IsNullOrWhiteSpace(table.Location?.Sheet))
+                .Select(static table => table.Location!.Sheet!),
+            StringComparer.Ordinal);
+        return ownerTables
+            .Concat(genericTables.Where(table => string.IsNullOrWhiteSpace(table.Location?.Sheet) || !formalTableSheets.Contains(table.Location!.Sheet!)))
+            .ToArray();
+    }
+
+    private static IEnumerable<OfficeDocumentLink> BuildExcelLinks(
+        IReadOnlyList<ExcelWorksheetSnapshot> worksheets,
+        string? sourcePath) {
+        int linkIndex = 0;
+        foreach (ExcelWorksheetSnapshot sheet in worksheets) {
+            foreach (ExcelCellSnapshot cell in sheet.Cells) {
+                ExcelHyperlinkSnapshot? hyperlink = cell.Hyperlink;
+                if (hyperlink == null || string.IsNullOrWhiteSpace(hyperlink.Target)) continue;
+                string a1 = A1.CellReference(cell.Row, cell.Column);
+                yield return new OfficeDocumentLink {
+                    Id = "excel-link-" + linkIndex.ToString("D4", CultureInfo.InvariantCulture),
+                    Kind = hyperlink.IsExternal ? "uri" : "internal",
+                    Uri = hyperlink.IsExternal ? hyperlink.Target : null,
+                    DestinationName = hyperlink.IsExternal ? null : hyperlink.Target,
+                    Text = hyperlink.Tooltip ?? Convert.ToString(cell.Value, CultureInfo.InvariantCulture),
+                    Location = new ReaderLocation {
+                        Path = sourcePath,
+                        Sheet = sheet.Name,
+                        A1Range = a1,
+                        SourceBlockKind = "hyperlink",
+                        BlockAnchor = "excel-" + SanitizeAnchor(sheet.Name) + "-" + a1.ToLowerInvariant() + "-link"
+                    }
+                };
+                linkIndex++;
+            }
+        }
+    }
+
+    private static IEnumerable<ReaderTable> BuildExcelOwnerTables(
+        IReadOnlyList<ExcelWorksheetSnapshot> worksheets,
+        string? sourcePath,
+        int maxRows) {
+        int tableIndex = 0;
+        foreach (ExcelWorksheetSnapshot sheet in worksheets) {
+            Dictionary<(int Row, int Column), ExcelCellSnapshot> cells = sheet.Cells.ToDictionary(static cell => (cell.Row, cell.Column));
+            foreach (ExcelTableSnapshot table in sheet.Tables) {
+                int columnCount = Math.Max(table.Columns.Count, table.EndColumn - table.StartColumn + 1);
+                IReadOnlyList<string> columns = Enumerable.Range(0, columnCount)
+                    .Select(index => index < table.Columns.Count && !string.IsNullOrWhiteSpace(table.Columns[index].Name)
+                        ? table.Columns[index].Name
+                        : GetExcelCellText(cells, table.StartRow, table.StartColumn + index, "Column " + (index + 1).ToString(CultureInfo.InvariantCulture)))
+                    .ToArray();
+                int firstDataRow = table.StartRow + (table.HasHeaderRow ? 1 : 0);
+                int lastDataRow = table.EndRow - (table.TotalsRowShown ? 1 : 0);
+                int totalRows = Math.Max(0, lastDataRow - firstDataRow + 1);
+                int emittedRows = maxRows > 0 ? Math.Min(totalRows, maxRows) : totalRows;
+                var rows = new List<IReadOnlyList<string>>(emittedRows);
+                for (int row = firstDataRow; row < firstDataRow + emittedRows; row++) {
+                    rows.Add(Enumerable.Range(0, columnCount)
+                        .Select(index => GetExcelCellText(cells, row, table.StartColumn + index, string.Empty))
+                        .ToArray());
+                }
+
+                yield return new ReaderTable {
+                    Title = table.Name,
+                    Kind = "excel-table",
+                    Location = new ReaderLocation {
+                        Path = sourcePath,
+                        Sheet = sheet.Name,
+                        A1Range = table.A1Range,
+                        SourceBlockKind = "table",
+                        BlockAnchor = "excel-" + SanitizeAnchor(sheet.Name) + "-table-" + tableIndex.ToString("D4", CultureInfo.InvariantCulture),
+                        TableIndex = tableIndex
+                    },
+                    Columns = columns,
+                    ColumnProfiles = ReaderTableProfiler.CreateProfiles(columns, rows),
+                    Rows = rows,
+                    TotalRowCount = totalRows,
+                    Truncated = emittedRows < totalRows
+                };
+                tableIndex++;
+            }
+        }
+    }
+
+    private static string GetExcelCellText(
+        IReadOnlyDictionary<(int Row, int Column), ExcelCellSnapshot> cells,
+        int row,
+        int column,
+        string fallback) {
+        if (!cells.TryGetValue((row, column), out ExcelCellSnapshot? cell) || cell.Value == null) return fallback;
+        string? value = Convert.ToString(cell.Value, CultureInfo.InvariantCulture);
+        return string.IsNullOrWhiteSpace(value) ? fallback : value!;
+    }
+
+    private static IReadOnlyList<OfficeDocumentPage> BuildExcelPages(
+        IReadOnlyList<OfficeDocumentPage> existingPages,
+        IReadOnlyList<OfficeDocumentBlock> blocks,
+        IReadOnlyList<ReaderTable> tables,
+        IReadOnlyList<OfficeDocumentAsset> assets,
+        IReadOnlyList<OfficeDocumentLink> links) {
+        foreach (OfficeDocumentPage page in existingPages) {
+            string? sheet = page.Name ?? page.Location.Sheet;
+            page.Blocks = blocks.Where(block => string.Equals(block.Location.Sheet, sheet, StringComparison.Ordinal)).ToArray();
+            page.Tables = tables.Where(table => string.Equals(table.Location?.Sheet, sheet, StringComparison.Ordinal)).ToArray();
+            page.Assets = assets.Where(asset => string.Equals(asset.Location.Sheet, sheet, StringComparison.Ordinal)).ToArray();
+            page.Links = links.Where(link => string.Equals(link.Location.Sheet, sheet, StringComparison.Ordinal)).ToArray();
+        }
+        return existingPages;
+    }
+
+    private static string SanitizeAnchor(string value) {
+        if (string.IsNullOrWhiteSpace(value)) return "item";
+        var chars = value.Trim().ToLowerInvariant().Select(static ch => char.IsLetterOrDigit(ch) ? ch : '-').ToArray();
+        return new string(chars).Trim('-');
+    }
+}

--- a/OfficeIMO.Reader/DocumentReader.ExcelRichMapping.cs
+++ b/OfficeIMO.Reader/DocumentReader.ExcelRichMapping.cs
@@ -28,13 +28,14 @@ public static partial class DocumentReader {
         ExcelWorksheetSnapshot[] worksheets = snapshot.Worksheets
             .Where(sheet => selectedSheets.Count == 0 || selectedSheets.Contains(sheet.Name))
             .ToArray();
-        OfficeDocumentLink[] links = BuildExcelLinks(worksheets, result.Source.Path).ToArray();
-        ReaderTable[] ownerTables = BuildExcelOwnerTables(worksheets, result.Source.Path, options.MaxTableRows).ToArray();
+        ExcelRangeSelection? selectedRange = ParseExcelRangeSelection(options.ExcelA1Range);
+        OfficeDocumentLink[] links = BuildExcelLinks(worksheets, result.Source.Path, selectedRange).ToArray();
+        ReaderTable[] ownerTables = BuildExcelOwnerTables(worksheets, result.Source.Path, options.MaxTableRows, selectedRange).ToArray();
         IReadOnlyList<ReaderTable> tables = MergeExcelTables(ownerTables, result.Tables);
         IReadOnlyList<OfficeDocumentPage> pages = BuildExcelPages(result.Pages, result.Blocks, tables, result.Assets, links);
 
-        int formulaCount = worksheets.Sum(static sheet => sheet.Cells.Count(static cell => !string.IsNullOrWhiteSpace(cell.Formula)));
-        int commentCount = worksheets.Sum(static sheet => sheet.Cells.Count(static cell => cell.Comment != null || cell.ThreadedComment != null));
+        int formulaCount = worksheets.Sum(sheet => sheet.Cells.Count(cell => IsCellSelected(cell, selectedRange) && !string.IsNullOrWhiteSpace(cell.Formula)));
+        int commentCount = worksheets.Sum(sheet => sheet.Cells.Count(cell => IsCellSelected(cell, selectedRange) && (cell.Comment != null || cell.ThreadedComment != null)));
         var metadata = new List<OfficeDocumentMetadataEntry> {
             BuildCountMetadataEntry("excel-named-range-count", "excel.structure", "NamedRangeCount", snapshot.NamedRanges.Count),
             BuildCountMetadataEntry("excel-formula-count", "excel.structure", "FormulaCount", formulaCount),
@@ -65,22 +66,33 @@ public static partial class DocumentReader {
         IReadOnlyList<ReaderTable> ownerTables,
         IReadOnlyList<ReaderTable> genericTables) {
         if (ownerTables.Count == 0) return genericTables;
-        var formalTableSheets = new HashSet<string>(
-            ownerTables
-                .Where(static table => !string.IsNullOrWhiteSpace(table.Location?.Sheet))
-                .Select(static table => table.Location!.Sheet!),
-            StringComparer.Ordinal);
         return ownerTables
-            .Concat(genericTables.Where(table => string.IsNullOrWhiteSpace(table.Location?.Sheet) || !formalTableSheets.Contains(table.Location!.Sheet!)))
+            .Concat(genericTables.Where(generic => !ownerTables.Any(owner => IsSameExcelTableRange(owner, generic))))
             .ToArray();
+    }
+
+    private static bool IsSameExcelTableRange(ReaderTable first, ReaderTable second) {
+        if (!string.Equals(first.Location?.Sheet, second.Location?.Sheet, StringComparison.Ordinal)
+            || string.IsNullOrWhiteSpace(first.Location?.A1Range)
+            || string.IsNullOrWhiteSpace(second.Location?.A1Range)) {
+            return false;
+        }
+
+        ExcelRangeSelection? firstRange = ParseExcelRangeSelection(first.Location!.A1Range);
+        ExcelRangeSelection? secondRange = ParseExcelRangeSelection(second.Location!.A1Range);
+        return firstRange.HasValue
+            && secondRange.HasValue
+            && firstRange.Value.Equals(secondRange.Value);
     }
 
     private static IEnumerable<OfficeDocumentLink> BuildExcelLinks(
         IReadOnlyList<ExcelWorksheetSnapshot> worksheets,
-        string? sourcePath) {
+        string? sourcePath,
+        ExcelRangeSelection? selectedRange) {
         int linkIndex = 0;
         foreach (ExcelWorksheetSnapshot sheet in worksheets) {
             foreach (ExcelCellSnapshot cell in sheet.Cells) {
+                if (!IsCellSelected(cell, selectedRange)) continue;
                 ExcelHyperlinkSnapshot? hyperlink = cell.Hyperlink;
                 if (hyperlink == null || string.IsNullOrWhiteSpace(hyperlink.Target)) continue;
                 string a1 = A1.CellReference(cell.Row, cell.Column);
@@ -106,25 +118,37 @@ public static partial class DocumentReader {
     private static IEnumerable<ReaderTable> BuildExcelOwnerTables(
         IReadOnlyList<ExcelWorksheetSnapshot> worksheets,
         string? sourcePath,
-        int maxRows) {
+        int maxRows,
+        ExcelRangeSelection? selectedRange) {
         int tableIndex = 0;
         foreach (ExcelWorksheetSnapshot sheet in worksheets) {
             Dictionary<(int Row, int Column), ExcelCellSnapshot> cells = sheet.Cells.ToDictionary(static cell => (cell.Row, cell.Column));
             foreach (ExcelTableSnapshot table in sheet.Tables) {
-                int columnCount = Math.Max(table.Columns.Count, table.EndColumn - table.StartColumn + 1);
+                ExcelRangeSelection tableRange = new ExcelRangeSelection(table.StartRow, table.StartColumn, table.EndRow, table.EndColumn);
+                ExcelRangeSelection? projectedRange = IntersectExcelRanges(tableRange, selectedRange);
+                if (!projectedRange.HasValue) continue;
+
+                int startColumn = projectedRange.Value.StartColumn;
+                int endColumn = projectedRange.Value.EndColumn;
+                int columnCount = endColumn - startColumn + 1;
                 IReadOnlyList<string> columns = Enumerable.Range(0, columnCount)
-                    .Select(index => index < table.Columns.Count && !string.IsNullOrWhiteSpace(table.Columns[index].Name)
-                        ? table.Columns[index].Name
-                        : GetExcelCellText(cells, table.StartRow, table.StartColumn + index, "Column " + (index + 1).ToString(CultureInfo.InvariantCulture)))
+                    .Select(index => {
+                        int tableColumnIndex = startColumn + index - table.StartColumn;
+                        return tableColumnIndex >= 0
+                            && tableColumnIndex < table.Columns.Count
+                            && !string.IsNullOrWhiteSpace(table.Columns[tableColumnIndex].Name)
+                                ? table.Columns[tableColumnIndex].Name
+                                : GetExcelCellText(cells, table.StartRow, startColumn + index, "Column " + (index + 1).ToString(CultureInfo.InvariantCulture));
+                    })
                     .ToArray();
-                int firstDataRow = table.StartRow + (table.HasHeaderRow ? 1 : 0);
-                int lastDataRow = table.EndRow - (table.TotalsRowShown ? 1 : 0);
+                int firstDataRow = Math.Max(projectedRange.Value.StartRow, table.StartRow + (table.HasHeaderRow ? 1 : 0));
+                int lastDataRow = Math.Min(projectedRange.Value.EndRow, table.EndRow - (table.TotalsRowShown ? 1 : 0));
                 int totalRows = Math.Max(0, lastDataRow - firstDataRow + 1);
                 int emittedRows = maxRows > 0 ? Math.Min(totalRows, maxRows) : totalRows;
                 var rows = new List<IReadOnlyList<string>>(emittedRows);
                 for (int row = firstDataRow; row < firstDataRow + emittedRows; row++) {
                     rows.Add(Enumerable.Range(0, columnCount)
-                        .Select(index => GetExcelCellText(cells, row, table.StartColumn + index, string.Empty))
+                        .Select(index => GetExcelCellText(cells, row, startColumn + index, string.Empty))
                         .ToArray());
                 }
 
@@ -134,7 +158,7 @@ public static partial class DocumentReader {
                     Location = new ReaderLocation {
                         Path = sourcePath,
                         Sheet = sheet.Name,
-                        A1Range = table.A1Range,
+                        A1Range = projectedRange.Value.ToA1Range(),
                         SourceBlockKind = "table",
                         BlockAnchor = "excel-" + SanitizeAnchor(sheet.Name) + "-table-" + tableIndex.ToString("D4", CultureInfo.InvariantCulture),
                         TableIndex = tableIndex
@@ -146,6 +170,71 @@ public static partial class DocumentReader {
                     Truncated = emittedRows < totalRows
                 };
                 tableIndex++;
+            }
+        }
+    }
+
+    private static ExcelRangeSelection? ParseExcelRangeSelection(string? a1Range) {
+        if (string.IsNullOrWhiteSpace(a1Range)
+            || !A1.TryParseRange(a1Range!, out int startRow, out int startColumn, out int endRow, out int endColumn)) {
+            return null;
+        }
+        return new ExcelRangeSelection(startRow, startColumn, endRow, endColumn);
+    }
+
+    private static ExcelRangeSelection? IntersectExcelRanges(ExcelRangeSelection range, ExcelRangeSelection? selection) {
+        if (!selection.HasValue) return range;
+        int startRow = Math.Max(range.StartRow, selection.Value.StartRow);
+        int startColumn = Math.Max(range.StartColumn, selection.Value.StartColumn);
+        int endRow = Math.Min(range.EndRow, selection.Value.EndRow);
+        int endColumn = Math.Min(range.EndColumn, selection.Value.EndColumn);
+        return startRow > endRow || startColumn > endColumn
+            ? (ExcelRangeSelection?)null
+            : new ExcelRangeSelection(startRow, startColumn, endRow, endColumn);
+    }
+
+    private static bool IsCellSelected(ExcelCellSnapshot cell, ExcelRangeSelection? selection) {
+        return !selection.HasValue
+            || (cell.Row >= selection.Value.StartRow
+                && cell.Row <= selection.Value.EndRow
+                && cell.Column >= selection.Value.StartColumn
+                && cell.Column <= selection.Value.EndColumn);
+    }
+
+    private readonly struct ExcelRangeSelection : IEquatable<ExcelRangeSelection> {
+        internal ExcelRangeSelection(int startRow, int startColumn, int endRow, int endColumn) {
+            StartRow = startRow;
+            StartColumn = startColumn;
+            EndRow = endRow;
+            EndColumn = endColumn;
+        }
+
+        internal int StartRow { get; }
+        internal int StartColumn { get; }
+        internal int EndRow { get; }
+        internal int EndColumn { get; }
+
+        internal string ToA1Range() {
+            return A1.CellReference(StartRow, StartColumn) + ":" + A1.CellReference(EndRow, EndColumn);
+        }
+
+        public bool Equals(ExcelRangeSelection other) {
+            return StartRow == other.StartRow
+                && StartColumn == other.StartColumn
+                && EndRow == other.EndRow
+                && EndColumn == other.EndColumn;
+        }
+
+        public override bool Equals(object? obj) {
+            return obj is ExcelRangeSelection other && Equals(other);
+        }
+
+        public override int GetHashCode() {
+            unchecked {
+                int hash = StartRow;
+                hash = (hash * 397) ^ StartColumn;
+                hash = (hash * 397) ^ EndRow;
+                return (hash * 397) ^ EndColumn;
             }
         }
     }

--- a/OfficeIMO.Reader/DocumentReader.ExcelRichMapping.cs
+++ b/OfficeIMO.Reader/DocumentReader.ExcelRichMapping.cs
@@ -67,11 +67,11 @@ public static partial class DocumentReader {
         IReadOnlyList<ReaderTable> genericTables) {
         if (ownerTables.Count == 0) return genericTables;
         return ownerTables
-            .Concat(genericTables.Where(generic => !ownerTables.Any(owner => IsSameExcelTableRange(owner, generic))))
+            .Concat(genericTables.Where(generic => !ownerTables.Any(owner => ExcelTableRangesOverlap(owner, generic))))
             .ToArray();
     }
 
-    private static bool IsSameExcelTableRange(ReaderTable first, ReaderTable second) {
+    private static bool ExcelTableRangesOverlap(ReaderTable first, ReaderTable second) {
         if (!string.Equals(first.Location?.Sheet, second.Location?.Sheet, StringComparison.Ordinal)
             || string.IsNullOrWhiteSpace(first.Location?.A1Range)
             || string.IsNullOrWhiteSpace(second.Location?.A1Range)) {
@@ -82,7 +82,10 @@ public static partial class DocumentReader {
         ExcelRangeSelection? secondRange = ParseExcelRangeSelection(second.Location!.A1Range);
         return firstRange.HasValue
             && secondRange.HasValue
-            && firstRange.Value.Equals(secondRange.Value);
+            && firstRange.Value.StartRow <= secondRange.Value.EndRow
+            && secondRange.Value.StartRow <= firstRange.Value.EndRow
+            && firstRange.Value.StartColumn <= secondRange.Value.EndColumn
+            && secondRange.Value.StartColumn <= firstRange.Value.EndColumn;
     }
 
     private static IEnumerable<OfficeDocumentLink> BuildExcelLinks(

--- a/OfficeIMO.Reader/DocumentReader.PowerPointRichMapping.cs
+++ b/OfficeIMO.Reader/DocumentReader.PowerPointRichMapping.cs
@@ -38,7 +38,6 @@ public static partial class DocumentReader {
             var slideLinks = new List<OfficeDocumentLink>();
             for (int shapeIndex = 0; shapeIndex < slide.Shapes.Count; shapeIndex++) {
                 PowerPointShape shape = slide.Shapes[shapeIndex];
-                if (shape.Hidden) continue;
                 shapeCount++;
                 string shapeAnchor = "powerpoint-slide-" + slideNumber.ToString("D4", CultureInfo.InvariantCulture)
                     + "-shape-" + (shape.Id?.ToString(CultureInfo.InvariantCulture) ?? shapeIndex.ToString(CultureInfo.InvariantCulture));
@@ -54,7 +53,7 @@ public static partial class DocumentReader {
                     slideBlocks.Add(new OfficeDocumentBlock {
                         Id = shapeAnchor,
                         Kind = "table",
-                        Text = string.Join(Environment.NewLine, table.RowItems.Select(static row => string.Join(" | ", row.Cells.Select(static cell => cell.Text)))),
+                        Text = BuildRichTableText(mapped),
                         Location = location,
                         Region = region
                     });

--- a/OfficeIMO.Reader/DocumentReader.PowerPointRichMapping.cs
+++ b/OfficeIMO.Reader/DocumentReader.PowerPointRichMapping.cs
@@ -1,0 +1,281 @@
+using DocumentFormat.OpenXml.Presentation;
+using OfficeIMO.PowerPoint;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+
+namespace OfficeIMO.Reader;
+
+public static partial class DocumentReader {
+    private static OfficeDocumentReadResult ApplyPowerPointRichMapping(
+        PowerPointPresentation presentation,
+        ReaderOptions options,
+        OfficeDocumentReadResult result,
+        CancellationToken cancellationToken) {
+        PowerPointBuiltinDocumentProperties properties = presentation.BuiltinDocumentProperties;
+        result.Source.Title = properties.Title;
+        result.Source.Author = properties.Creator;
+        result.Source.Subject = properties.Subject;
+        result.Source.Keywords = properties.Keywords;
+
+        var blocks = new List<OfficeDocumentBlock>();
+        var tables = new List<ReaderTable>();
+        var links = new List<OfficeDocumentLink>();
+        var visuals = new List<ReaderVisual>();
+        var pages = new List<OfficeDocumentPage>(presentation.Slides.Count);
+        int tableIndex = 0;
+        int linkIndex = 0;
+        int shapeCount = 0;
+        for (int slideIndex = 0; slideIndex < presentation.Slides.Count; slideIndex++) {
+            cancellationToken.ThrowIfCancellationRequested();
+            PowerPointSlide slide = presentation.Slides[slideIndex];
+            int slideNumber = slideIndex + 1;
+            var slideBlocks = new List<OfficeDocumentBlock>();
+            var slideTables = new List<ReaderTable>();
+            var slideLinks = new List<OfficeDocumentLink>();
+            for (int shapeIndex = 0; shapeIndex < slide.Shapes.Count; shapeIndex++) {
+                PowerPointShape shape = slide.Shapes[shapeIndex];
+                if (shape.Hidden) continue;
+                shapeCount++;
+                string shapeAnchor = "powerpoint-slide-" + slideNumber.ToString("D4", CultureInfo.InvariantCulture)
+                    + "-shape-" + (shape.Id?.ToString(CultureInfo.InvariantCulture) ?? shapeIndex.ToString(CultureInfo.InvariantCulture));
+                ReaderLocation location = BuildPowerPointLocation(result.Source.Path, slideNumber, shapeIndex, ResolvePowerPointShapeKind(shape), shapeAnchor);
+                OfficeDocumentRegion region = BuildPowerPointRegion(shape);
+
+                if (shape is PowerPointTextBox textBox) {
+                    ProjectPowerPointTextBox(textBox, location, region, slideBlocks, slideLinks, ref linkIndex);
+                } else if (shape is PowerPointTable table) {
+                    ReaderTable mapped = MapPowerPointTable(table, location, tableIndex++, options.MaxTableRows);
+                    tables.Add(mapped);
+                    slideTables.Add(mapped);
+                    slideBlocks.Add(new OfficeDocumentBlock {
+                        Id = shapeAnchor,
+                        Kind = "table",
+                        Text = string.Join(Environment.NewLine, table.RowItems.Select(static row => string.Join(" | ", row.Cells.Select(static cell => cell.Text)))),
+                        Location = location,
+                        Region = region
+                    });
+                    AddPowerPointTableLinks(table, location, slideLinks, ref linkIndex);
+                } else if (shape is PowerPointChart chart) {
+                    string chartText = shape.Name ?? "Chart";
+                    if (chart.TryGetSnapshot(out PowerPointChartSnapshot snapshot)) {
+                        chartText = snapshot.Title ?? snapshot.Name;
+                        string payload = BuildPowerPointChartPayload(snapshot);
+                        visuals.Add(new ReaderVisual {
+                            Kind = "chart",
+                            Language = "officeimo-powerpoint-chart",
+                            Content = payload,
+                            PayloadHash = ComputeSha256Hex(payload),
+                            SourceName = snapshot.Name,
+                            Width = snapshot.WidthPoints,
+                            Height = snapshot.HeightPoints,
+                            X = shape.LeftPoints,
+                            Y = shape.TopPoints,
+                            PlacedWidth = shape.WidthPoints,
+                            PlacedHeight = shape.HeightPoints,
+                            PlacementCount = 1,
+                            HasGeometry = true,
+                            IsAxisAligned = true,
+                            Location = BuildPowerPointLocation(result.Source.Path, slideNumber, shapeIndex, "chart", shapeAnchor)
+                        });
+                    }
+                    slideBlocks.Add(new OfficeDocumentBlock { Id = shapeAnchor, Kind = "chart", Text = chartText, Location = location, Region = region });
+                } else {
+                    slideBlocks.Add(new OfficeDocumentBlock {
+                        Id = shapeAnchor,
+                        Kind = ResolvePowerPointShapeKind(shape),
+                        Text = shape.AltText ?? shape.Name ?? shape.ShapeContentType.ToString(),
+                        Location = location,
+                        Region = region
+                    });
+                }
+
+                if (shape.Hyperlink != null) {
+                    slideLinks.Add(BuildPowerPointLink(
+                        "powerpoint-link-" + linkIndex.ToString("D4", CultureInfo.InvariantCulture),
+                        shape.Hyperlink.ToString(),
+                        shape.AltText ?? shape.Name,
+                        location,
+                        region));
+                    linkIndex++;
+                }
+            }
+
+            blocks.AddRange(slideBlocks);
+            links.AddRange(slideLinks);
+            pages.Add(new OfficeDocumentPage {
+                Number = slideNumber,
+                Name = ResolvePowerPointSlideName(slide, slideNumber),
+                Width = presentation.SlideSize.WidthPoints,
+                Height = presentation.SlideSize.HeightPoints,
+                Location = BuildPowerPointLocation(result.Source.Path, slideNumber, null, "slide", "powerpoint-slide-" + slideNumber.ToString("D4", CultureInfo.InvariantCulture)),
+                Blocks = slideBlocks,
+                Tables = slideTables,
+                Assets = result.Assets.Where(asset => asset.Location.Slide == slideNumber).ToArray(),
+                Links = slideLinks,
+                Forms = Array.Empty<OfficeDocumentFormField>()
+            });
+        }
+
+        var metadata = new[] {
+            BuildCountMetadataEntry("powerpoint-shape-count", "powerpoint.structure", "ShapeCount", shapeCount),
+            BuildCountMetadataEntry("powerpoint-chart-count", "powerpoint.structure", "ChartCount", visuals.Count)
+        };
+        return FinalizeRichMapping(
+            result,
+            new[] { "officeimo.powerpoint.shape-model", "officeimo.powerpoint.chart-snapshot", "officeimo.reader.powerpoint.rich-v5" },
+            blocks,
+            tables,
+            links,
+            visuals,
+            pages,
+            metadata);
+    }
+
+    private static void ProjectPowerPointTextBox(
+        PowerPointTextBox textBox,
+        ReaderLocation shapeLocation,
+        OfficeDocumentRegion region,
+        List<OfficeDocumentBlock> blocks,
+        List<OfficeDocumentLink> links,
+        ref int linkIndex) {
+        IReadOnlyList<PowerPointParagraph> paragraphs = textBox.Paragraphs;
+        if (paragraphs.Count == 0) {
+            blocks.Add(new OfficeDocumentBlock { Id = shapeLocation.BlockAnchor!, Kind = "text-box", Text = textBox.Text, Location = shapeLocation, Region = region });
+            return;
+        }
+
+        bool isTitle = textBox.ShapePlaceholderType == PlaceholderValues.Title || textBox.ShapePlaceholderType == PlaceholderValues.CenteredTitle;
+        for (int paragraphIndex = 0; paragraphIndex < paragraphs.Count; paragraphIndex++) {
+            PowerPointParagraph paragraph = paragraphs[paragraphIndex];
+            bool isList = paragraph.BulletCharacter != null || paragraph.IsNumbered;
+            string kind = isTitle ? "heading" : isList ? "list-item" : "paragraph";
+            ReaderLocation location = BuildPowerPointLocation(
+                shapeLocation.Path,
+                shapeLocation.Slide!.Value,
+                shapeLocation.SourceBlockIndex,
+                kind,
+                shapeLocation.BlockAnchor + "-paragraph-" + paragraphIndex.ToString("D4", CultureInfo.InvariantCulture));
+            blocks.Add(new OfficeDocumentBlock {
+                Id = location.BlockAnchor!,
+                Kind = kind,
+                Text = paragraph.Text,
+                Level = isTitle ? 1 : paragraph.Level,
+                Marker = paragraph.IsNumbered ? "1." : paragraph.BulletCharacter,
+                Location = location,
+                Region = region
+            });
+            AddPowerPointRunLinks(paragraph.Runs, location, region, links, ref linkIndex);
+        }
+    }
+
+    private static void AddPowerPointTableLinks(
+        PowerPointTable table,
+        ReaderLocation location,
+        List<OfficeDocumentLink> links,
+        ref int linkIndex) {
+        foreach (PowerPointTableRow row in table.RowItems) {
+            foreach (PowerPointTableCell cell in row.Cells) {
+                foreach (PowerPointParagraph paragraph in cell.Paragraphs) {
+                    AddPowerPointRunLinks(paragraph.Runs, location, BuildPowerPointRegion(table), links, ref linkIndex);
+                }
+            }
+        }
+    }
+
+    private static void AddPowerPointRunLinks(
+        IReadOnlyList<PowerPointTextRun> runs,
+        ReaderLocation location,
+        OfficeDocumentRegion region,
+        List<OfficeDocumentLink> links,
+        ref int linkIndex) {
+        for (int runIndex = 0; runIndex < runs.Count; runIndex++) {
+            PowerPointTextRun run = runs[runIndex];
+            if (run.Hyperlink == null) continue;
+            links.Add(BuildPowerPointLink(
+                "powerpoint-link-" + linkIndex.ToString("D4", CultureInfo.InvariantCulture),
+                run.Hyperlink.ToString(),
+                run.Text,
+                BuildPowerPointLocation(location.Path, location.Slide!.Value, location.SourceBlockIndex, "hyperlink", location.BlockAnchor + "-link-" + runIndex.ToString("D4", CultureInfo.InvariantCulture)),
+                region));
+            linkIndex++;
+        }
+    }
+
+    private static OfficeDocumentLink BuildPowerPointLink(string id, string uri, string? text, ReaderLocation location, OfficeDocumentRegion region) {
+        return new OfficeDocumentLink { Id = id, Kind = "uri", Uri = uri, Text = text, Location = location, Region = region };
+    }
+
+    private static ReaderTable MapPowerPointTable(PowerPointTable table, ReaderLocation location, int tableIndex, int maxRows) {
+        IReadOnlyList<PowerPointTableRow> sourceRows = table.RowItems;
+        int columnCount = Math.Max(table.Columns, sourceRows.Count == 0 ? 0 : sourceRows.Max(static row => row.Cells.Count));
+        IReadOnlyList<string> columns = sourceRows.Count == 0
+            ? BuildFallbackColumns(columnCount)
+            : Enumerable.Range(0, columnCount).Select(index => GetPowerPointCellText(sourceRows[0], index, "Column " + (index + 1).ToString(CultureInfo.InvariantCulture))).ToArray();
+        int totalRows = Math.Max(0, sourceRows.Count - 1);
+        int emittedRows = maxRows > 0 ? Math.Min(totalRows, maxRows) : totalRows;
+        IReadOnlyList<IReadOnlyList<string>> rows = sourceRows.Skip(1).Take(emittedRows)
+            .Select(row => (IReadOnlyList<string>)Enumerable.Range(0, columnCount).Select(index => GetPowerPointCellText(row, index, string.Empty)).ToArray())
+            .ToArray();
+        ReaderLocation tableLocation = BuildPowerPointLocation(location.Path, location.Slide!.Value, location.SourceBlockIndex, "table", location.BlockAnchor ?? "powerpoint-table-" + tableIndex.ToString("D4", CultureInfo.InvariantCulture));
+        tableLocation.TableIndex = tableIndex;
+        return new ReaderTable {
+            Title = table.Name ?? "PowerPoint table " + (tableIndex + 1).ToString(CultureInfo.InvariantCulture),
+            Kind = "powerpoint-table",
+            Location = tableLocation,
+            Columns = columns,
+            ColumnProfiles = ReaderTableProfiler.CreateProfiles(columns, rows),
+            Rows = rows,
+            TotalRowCount = totalRows,
+            Truncated = emittedRows < totalRows
+        };
+    }
+
+    private static string GetPowerPointCellText(PowerPointTableRow row, int index, string fallback) {
+        if (index >= row.Cells.Count || string.IsNullOrWhiteSpace(row.Cells[index].Text)) return fallback;
+        return row.Cells[index].Text;
+    }
+
+    private static string BuildPowerPointChartPayload(PowerPointChartSnapshot snapshot) {
+        return JsonSerializer.Serialize(new {
+            name = snapshot.Name,
+            title = snapshot.Title,
+            kind = snapshot.ChartKind.ToString(),
+            categories = snapshot.Data.Categories,
+            series = snapshot.Data.Series.Select(static series => new {
+                name = series.Name,
+                values = series.Values,
+                xValues = series.XValues,
+                kind = series.ChartKind?.ToString()
+            }).ToArray()
+        });
+    }
+
+    private static string ResolvePowerPointSlideName(PowerPointSlide slide, int slideNumber) {
+        PowerPointTextBox? title = slide.TextBoxes.FirstOrDefault(textBox =>
+            textBox.ShapePlaceholderType == PlaceholderValues.Title || textBox.ShapePlaceholderType == PlaceholderValues.CenteredTitle);
+        string? text = title?.Text?.Trim();
+        return string.IsNullOrWhiteSpace(text) ? "Slide " + slideNumber.ToString(CultureInfo.InvariantCulture) : text!;
+    }
+
+    private static string ResolvePowerPointShapeKind(PowerPointShape shape) {
+        return shape.ShapeContentType.ToString().ToLowerInvariant();
+    }
+
+    private static OfficeDocumentRegion BuildPowerPointRegion(PowerPointShape shape) {
+        return new OfficeDocumentRegion { X = shape.LeftPoints, Y = shape.TopPoints, Width = shape.WidthPoints, Height = shape.HeightPoints };
+    }
+
+    private static ReaderLocation BuildPowerPointLocation(string? path, int slide, int? sourceBlockIndex, string kind, string anchor) {
+        return new ReaderLocation {
+            Path = path,
+            Slide = slide,
+            SourceBlockIndex = sourceBlockIndex,
+            SourceBlockKind = kind,
+            BlockAnchor = anchor
+        };
+    }
+}

--- a/OfficeIMO.Reader/DocumentReader.PowerPointRichMapping.cs
+++ b/OfficeIMO.Reader/DocumentReader.PowerPointRichMapping.cs
@@ -221,12 +221,14 @@ public static partial class DocumentReader {
     private static ReaderTable MapPowerPointTable(PowerPointTable table, ReaderLocation location, int tableIndex, int maxRows) {
         IReadOnlyList<PowerPointTableRow> sourceRows = table.RowItems;
         int columnCount = Math.Max(table.Columns, sourceRows.Count == 0 ? 0 : sourceRows.Max(static row => row.Cells.Count));
-        IReadOnlyList<string> columns = sourceRows.Count == 0
-            ? BuildFallbackColumns(columnCount)
-            : Enumerable.Range(0, columnCount).Select(index => GetPowerPointCellText(sourceRows[0], index, "Column " + (index + 1).ToString(CultureInfo.InvariantCulture))).ToArray();
-        int totalRows = Math.Max(0, sourceRows.Count - 1);
+        bool hasHeaderRow = table.HeaderRow && sourceRows.Count > 0;
+        IReadOnlyList<string> columns = hasHeaderRow
+            ? Enumerable.Range(0, columnCount).Select(index => GetPowerPointCellText(sourceRows[0], index, "Column " + (index + 1).ToString(CultureInfo.InvariantCulture))).ToArray()
+            : BuildFallbackColumns(columnCount);
+        int dataStart = hasHeaderRow ? 1 : 0;
+        int totalRows = Math.Max(0, sourceRows.Count - dataStart);
         int emittedRows = maxRows > 0 ? Math.Min(totalRows, maxRows) : totalRows;
-        IReadOnlyList<IReadOnlyList<string>> rows = sourceRows.Skip(1).Take(emittedRows)
+        IReadOnlyList<IReadOnlyList<string>> rows = sourceRows.Skip(dataStart).Take(emittedRows)
             .Select(row => (IReadOnlyList<string>)Enumerable.Range(0, columnCount).Select(index => GetPowerPointCellText(row, index, string.Empty)).ToArray())
             .ToArray();
         ReaderLocation tableLocation = BuildPowerPointLocation(location.Path, location.Slide!.Value, location.SourceBlockIndex, "table", location.BlockAnchor ?? "powerpoint-table-" + tableIndex.ToString("D4", CultureInfo.InvariantCulture));

--- a/OfficeIMO.Reader/DocumentReader.PowerPointRichMapping.cs
+++ b/OfficeIMO.Reader/DocumentReader.PowerPointRichMapping.cs
@@ -104,6 +104,16 @@ public static partial class DocumentReader {
                 }
             }
 
+            if (options.IncludePowerPointNotes && slide.Notes.TryGetExistingText(out string notesText)) {
+                string notesAnchor = "powerpoint-slide-" + slideNumber.ToString("D4", CultureInfo.InvariantCulture) + "-notes";
+                slideBlocks.Add(new OfficeDocumentBlock {
+                    Id = notesAnchor,
+                    Kind = "speaker-notes",
+                    Text = notesText,
+                    Location = BuildPowerPointLocation(result.Source.Path, slideNumber, null, "speaker-notes", notesAnchor)
+                });
+            }
+
             blocks.AddRange(slideBlocks);
             links.AddRange(slideLinks);
             pages.Add(new OfficeDocumentPage {

--- a/OfficeIMO.Reader/DocumentReader.RichMappings.cs
+++ b/OfficeIMO.Reader/DocumentReader.RichMappings.cs
@@ -1,0 +1,154 @@
+using OfficeIMO.Excel;
+using OfficeIMO.PowerPoint;
+using OfficeIMO.Word;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+namespace OfficeIMO.Reader;
+
+public static partial class DocumentReader {
+    private static OfficeDocumentReadResult EnrichBuiltInDocumentResult(
+        string path,
+        ReaderInputKind kind,
+        ReaderOptions options,
+        OfficeDocumentReadResult result,
+        CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        switch (kind) {
+            case ReaderInputKind.Word:
+                using (WordDocument document = WordDocument.Load(path, readOnly: true, autoSave: false, openSettings: CreateOpenSettings(options))) {
+                    return ApplyWordRichMapping(document.CreateInspectionSnapshot(), options, result);
+                }
+            case ReaderInputKind.Excel:
+                using (ExcelDocument document = LoadExcelForRichMapping(path, options)) {
+                    return ApplyExcelRichMapping(document.CreateInspectionSnapshot(), options, result);
+                }
+            case ReaderInputKind.PowerPoint:
+                using (PowerPointPresentation presentation = PowerPointPresentation.OpenRead(path)) {
+                    return ApplyPowerPointRichMapping(presentation, options, result, cancellationToken);
+                }
+            default:
+                return result;
+        }
+    }
+
+    private static OfficeDocumentReadResult EnrichBuiltInDocumentResult(
+        Stream stream,
+        string sourceName,
+        ReaderInputKind kind,
+        ReaderOptions options,
+        OfficeDocumentReadResult result,
+        CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        switch (kind) {
+            case ReaderInputKind.Word:
+                stream.Position = 0;
+                using (WordDocument document = WordDocument.Load(stream, readOnly: true, autoSave: false, openSettings: CreateOpenSettings(options))) {
+                    return ApplyWordRichMapping(document.CreateInspectionSnapshot(), options, result);
+                }
+            case ReaderInputKind.Excel:
+                stream.Position = 0;
+                using (ExcelDocument document = LoadExcelForRichMapping(stream, sourceName, options)) {
+                    return ApplyExcelRichMapping(document.CreateInspectionSnapshot(), options, result);
+                }
+            case ReaderInputKind.PowerPoint:
+                stream.Position = 0;
+                using (PowerPointPresentation presentation = PowerPointPresentation.Open(stream, readOnly: true, autoSave: false)) {
+                    return ApplyPowerPointRichMapping(presentation, options, result, cancellationToken);
+                }
+            default:
+                return result;
+        }
+    }
+
+    private static ExcelDocument LoadExcelForRichMapping(string path, ReaderOptions options) {
+        return IsLegacyExcelExtension(path)
+            ? LoadLegacyExcelForReader(path, options)
+            : LoadOpenXmlExcelForReader(path, options);
+    }
+
+    private static ExcelDocument LoadExcelForRichMapping(Stream stream, string sourceName, ReaderOptions options) {
+        return IsLegacyExcelExtension(sourceName)
+            ? LoadLegacyExcelForReader(stream, options)
+            : LoadOpenXmlExcelForReader(stream, options);
+    }
+
+    private static OfficeDocumentReadResult FinalizeRichMapping(
+        OfficeDocumentReadResult result,
+        IReadOnlyList<string> capabilities,
+        IReadOnlyList<OfficeDocumentBlock> blocks,
+        IReadOnlyList<ReaderTable> tables,
+        IReadOnlyList<OfficeDocumentLink> links,
+        IReadOnlyList<ReaderVisual> visuals,
+        IReadOnlyList<OfficeDocumentPage> pages,
+        IReadOnlyList<OfficeDocumentMetadataEntry>? formatMetadata = null) {
+        result.CapabilitiesUsed = result.CapabilitiesUsed
+            .Concat(capabilities)
+            .Where(static capability => !string.IsNullOrWhiteSpace(capability))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        result.Blocks = blocks;
+        result.Tables = tables;
+        result.Links = links;
+        result.Visuals = visuals;
+
+        OfficeDocumentOcrCandidate[] ocrCandidates = BuildChunkDocumentOcrCandidates(blocks, result.Assets).ToArray();
+        result.OcrCandidates = ocrCandidates;
+        result.Pages = AttachOcrCandidates(pages, ocrCandidates);
+        result.Diagnostics = RefreshOcrDiagnostics(result.Diagnostics, ocrCandidates);
+
+        IReadOnlyList<OfficeDocumentMetadataEntry> summary = BuildChunkDocumentMetadata(
+            result.Kind,
+            result.Chunks,
+            blocks,
+            tables,
+            visuals,
+            result.Pages,
+            result.Assets);
+        result.Metadata = formatMetadata == null || formatMetadata.Count == 0
+            ? summary
+            : summary.Concat(formatMetadata).ToArray();
+        return result;
+    }
+
+    private static IReadOnlyList<OfficeDocumentPage> AttachOcrCandidates(
+        IReadOnlyList<OfficeDocumentPage> pages,
+        IReadOnlyList<OfficeDocumentOcrCandidate> candidates) {
+        for (int i = 0; i < pages.Count; i++) {
+            OfficeDocumentPage page = pages[i];
+            page.OcrCandidates = candidates.Where(candidate => IsSameContainer(candidate.Location, page.Location)).ToArray();
+        }
+        return pages;
+    }
+
+    private static bool IsSameContainer(ReaderLocation left, ReaderLocation right) {
+        if (right.Page.HasValue) return left.Page == right.Page;
+        if (right.Slide.HasValue) return left.Slide == right.Slide;
+        if (!string.IsNullOrWhiteSpace(right.Sheet)) return string.Equals(left.Sheet, right.Sheet, StringComparison.Ordinal);
+        return false;
+    }
+
+    private static IReadOnlyList<OfficeDocumentDiagnostic> RefreshOcrDiagnostics(
+        IReadOnlyList<OfficeDocumentDiagnostic> existing,
+        IReadOnlyList<OfficeDocumentOcrCandidate> candidates) {
+        var diagnostics = existing
+            .Where(static diagnostic => diagnostic.Category != OfficeDocumentDiagnosticCategory.Ocr)
+            .ToList();
+        for (int i = 0; i < candidates.Count; i++) {
+            OfficeDocumentOcrCandidate candidate = candidates[i];
+            diagnostics.Add(new OfficeDocumentDiagnostic {
+                Severity = OfficeDocumentDiagnosticSeverity.Warning,
+                Category = OfficeDocumentDiagnosticCategory.Ocr,
+                Code = "ocr-needed",
+                Message = candidate.Reason ?? "OCR may be needed before text extraction is complete.",
+                Source = "officeimo.reader",
+                IsRecoverable = true,
+                Location = candidate.Location
+            });
+        }
+        return diagnostics.Count == 0 ? Array.Empty<OfficeDocumentDiagnostic>() : diagnostics.ToArray();
+    }
+}

--- a/OfficeIMO.Reader/DocumentReader.RichTableText.cs
+++ b/OfficeIMO.Reader/DocumentReader.RichTableText.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OfficeIMO.Reader;
+
+public static partial class DocumentReader {
+    private static string BuildRichTableText(ReaderTable table) {
+        IEnumerable<IReadOnlyList<string>> rows = table.Columns.Count == 0
+            ? table.Rows
+            : new[] { table.Columns }.Concat(table.Rows);
+        return string.Join(
+            Environment.NewLine,
+            rows.Select(static row => string.Join(" | ", row)));
+    }
+}

--- a/OfficeIMO.Reader/DocumentReader.WordRichMapping.cs
+++ b/OfficeIMO.Reader/DocumentReader.WordRichMapping.cs
@@ -257,11 +257,13 @@ public static partial class DocumentReader {
 
     private static ReaderTable MapWordTable(WordTableSnapshot table, ReaderLocation location, int tableIndex, int maxRows) {
         int columnCount = Math.Max(table.ColumnCount, table.Rows.Count == 0 ? 0 : table.Rows.Max(static row => row.Cells.Count));
-        IReadOnlyList<string> columns = table.Rows.Count == 0
-            ? BuildFallbackColumns(columnCount)
-            : BuildWordRowValues(table.Rows[0], columnCount, useFallbacks: true);
-        int totalRowCount = Math.Max(0, table.Rows.Count - 1);
-        IEnumerable<WordTableRowSnapshot> sourceRows = table.Rows.Skip(1);
+        bool hasHeaderRow = table.RepeatHeaderRow && table.Rows.Count > 0;
+        IReadOnlyList<string> columns = hasHeaderRow
+            ? BuildWordRowValues(table.Rows[0], columnCount, useFallbacks: true)
+            : BuildFallbackColumns(columnCount);
+        int dataStart = hasHeaderRow ? 1 : 0;
+        int totalRowCount = Math.Max(0, table.Rows.Count - dataStart);
+        IEnumerable<WordTableRowSnapshot> sourceRows = table.Rows.Skip(dataStart);
         bool truncated = maxRows > 0 && totalRowCount > maxRows;
         if (truncated) sourceRows = sourceRows.Take(maxRows);
         IReadOnlyList<IReadOnlyList<string>> rows = sourceRows

--- a/OfficeIMO.Reader/DocumentReader.WordRichMapping.cs
+++ b/OfficeIMO.Reader/DocumentReader.WordRichMapping.cs
@@ -207,13 +207,13 @@ public static partial class DocumentReader {
                 AddWordParagraphLinks(paragraph, location, links, ref linkIndex);
             } else if (element is WordTableSnapshot table) {
                 location.HeadingPath = BuildWordHeadingPath(headingStack);
+                ReaderTable mapped = MapWordTable(table, location, tableIndex++, options.MaxTableRows);
                 blocks.Add(new OfficeDocumentBlock {
                     Id = anchor,
                     Kind = "table",
-                    Text = BuildWordTableText(table),
+                    Text = BuildRichTableText(mapped),
                     Location = location
                 });
-                ReaderTable mapped = MapWordTable(table, location, tableIndex++, options.MaxTableRows);
                 tables.Add(mapped);
                 foreach (WordTableRowSnapshot row in table.Rows) {
                     foreach (WordTableCellSnapshot cell in row.Cells) {
@@ -290,10 +290,6 @@ public static partial class DocumentReader {
 
     private static IReadOnlyList<string> BuildFallbackColumns(int count) {
         return Enumerable.Range(1, count).Select(index => "Column " + index.ToString(CultureInfo.InvariantCulture)).ToArray();
-    }
-
-    private static string BuildWordTableText(WordTableSnapshot table) {
-        return string.Join(Environment.NewLine, table.Rows.Select(row => string.Join(" | ", BuildWordRowValues(row, table.ColumnCount, useFallbacks: false))));
     }
 
     private static int? ResolveWordHeadingLevel(WordParagraphSnapshot paragraph) {

--- a/OfficeIMO.Reader/DocumentReader.WordRichMapping.cs
+++ b/OfficeIMO.Reader/DocumentReader.WordRichMapping.cs
@@ -1,0 +1,243 @@
+using OfficeIMO.Word;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace OfficeIMO.Reader;
+
+public static partial class DocumentReader {
+    private static OfficeDocumentReadResult ApplyWordRichMapping(
+        WordDocumentSnapshot snapshot,
+        ReaderOptions options,
+        OfficeDocumentReadResult result) {
+        result.Source.Title = snapshot.Title;
+        result.Source.Author = snapshot.Author;
+        result.Source.Subject = snapshot.Subject;
+        result.Source.Keywords = snapshot.Keywords;
+
+        var blocks = new List<OfficeDocumentBlock>();
+        var tables = new List<ReaderTable>();
+        var links = new List<OfficeDocumentLink>();
+        int sourceBlockIndex = 0;
+        int tableIndex = 0;
+        int linkIndex = 0;
+        for (int sectionIndex = 0; sectionIndex < snapshot.Sections.Count; sectionIndex++) {
+            WordSectionSnapshot section = snapshot.Sections[sectionIndex];
+            ProjectWordElements(
+                section.Elements,
+                result.Source.Path,
+                "section-" + (sectionIndex + 1).ToString("D4", CultureInfo.InvariantCulture),
+                options,
+                blocks,
+                tables,
+                links,
+                ref sourceBlockIndex,
+                ref tableIndex,
+                ref linkIndex);
+
+            ProjectWordHeaderFooter(section.DefaultHeader, sectionIndex, result.Source.Path, options, blocks, tables, links, ref sourceBlockIndex, ref tableIndex, ref linkIndex);
+            ProjectWordHeaderFooter(section.FirstHeader, sectionIndex, result.Source.Path, options, blocks, tables, links, ref sourceBlockIndex, ref tableIndex, ref linkIndex);
+            ProjectWordHeaderFooter(section.EvenHeader, sectionIndex, result.Source.Path, options, blocks, tables, links, ref sourceBlockIndex, ref tableIndex, ref linkIndex);
+            ProjectWordHeaderFooter(section.DefaultFooter, sectionIndex, result.Source.Path, options, blocks, tables, links, ref sourceBlockIndex, ref tableIndex, ref linkIndex);
+            ProjectWordHeaderFooter(section.FirstFooter, sectionIndex, result.Source.Path, options, blocks, tables, links, ref sourceBlockIndex, ref tableIndex, ref linkIndex);
+            ProjectWordHeaderFooter(section.EvenFooter, sectionIndex, result.Source.Path, options, blocks, tables, links, ref sourceBlockIndex, ref tableIndex, ref linkIndex);
+        }
+
+        var metadata = new[] {
+            BuildCountMetadataEntry("word-section-count", "word.structure", "SectionCount", snapshot.Sections.Count)
+        };
+        return FinalizeRichMapping(
+            result,
+            new[] { "officeimo.word.inspection-snapshot", "officeimo.reader.word.rich-v5" },
+            blocks,
+            tables,
+            links,
+            result.Visuals,
+            result.Pages,
+            metadata);
+    }
+
+    private static void ProjectWordHeaderFooter(
+        WordHeaderFooterSnapshot? headerFooter,
+        int sectionIndex,
+        string? sourcePath,
+        ReaderOptions options,
+        List<OfficeDocumentBlock> blocks,
+        List<ReaderTable> tables,
+        List<OfficeDocumentLink> links,
+        ref int sourceBlockIndex,
+        ref int tableIndex,
+        ref int linkIndex) {
+        if (headerFooter == null) return;
+        string owner = "section-" + (sectionIndex + 1).ToString("D4", CultureInfo.InvariantCulture)
+            + "-" + headerFooter.Kind + "-" + headerFooter.Variant;
+        ProjectWordElements(headerFooter.Elements, sourcePath, owner, options, blocks, tables, links, ref sourceBlockIndex, ref tableIndex, ref linkIndex);
+    }
+
+    private static void ProjectWordElements(
+        IReadOnlyList<WordBlockSnapshot> elements,
+        string? sourcePath,
+        string owner,
+        ReaderOptions options,
+        List<OfficeDocumentBlock> blocks,
+        List<ReaderTable> tables,
+        List<OfficeDocumentLink> links,
+        ref int sourceBlockIndex,
+        ref int tableIndex,
+        ref int linkIndex) {
+        var headingStack = new List<(int Level, string Text)>();
+        for (int elementIndex = 0; elementIndex < elements.Count; elementIndex++) {
+            WordBlockSnapshot element = elements[elementIndex];
+            string anchor = "word-" + owner + "-block-" + elementIndex.ToString("D4", CultureInfo.InvariantCulture);
+            ReaderLocation location = new ReaderLocation {
+                Path = sourcePath,
+                SourceBlockIndex = sourceBlockIndex,
+                SourceBlockKind = element.Kind,
+                BlockAnchor = anchor
+            };
+
+            if (element is WordParagraphSnapshot paragraph) {
+                int? headingLevel = ResolveWordHeadingLevel(paragraph);
+                if (headingLevel.HasValue) {
+                    for (int headingIndex = headingStack.Count - 1; headingIndex >= 0; headingIndex--) {
+                        if (headingStack[headingIndex].Level >= headingLevel.Value) headingStack.RemoveAt(headingIndex);
+                    }
+                    headingStack.Add((headingLevel.Value, string.IsNullOrWhiteSpace(paragraph.Text) ? "Heading " + headingLevel.Value.ToString(CultureInfo.InvariantCulture) : paragraph.Text));
+                }
+                location.HeadingPath = BuildWordHeadingPath(headingStack);
+                string kind = headingLevel.HasValue ? "heading" : paragraph.IsListItem ? "list-item" : "paragraph";
+                location.SourceBlockKind = kind;
+                blocks.Add(new OfficeDocumentBlock {
+                    Id = anchor,
+                    Kind = kind,
+                    Text = paragraph.Text,
+                    Level = headingLevel ?? paragraph.ListLevel,
+                    Marker = paragraph.IsListItem ? (paragraph.IsOrderedList == true ? "1." : "-") : null,
+                    Location = location
+                });
+                AddWordParagraphLinks(paragraph, location, links, ref linkIndex);
+            } else if (element is WordTableSnapshot table) {
+                location.HeadingPath = BuildWordHeadingPath(headingStack);
+                blocks.Add(new OfficeDocumentBlock {
+                    Id = anchor,
+                    Kind = "table",
+                    Text = BuildWordTableText(table),
+                    Location = location
+                });
+                ReaderTable mapped = MapWordTable(table, location, tableIndex++, options.MaxTableRows);
+                tables.Add(mapped);
+                foreach (WordTableRowSnapshot row in table.Rows) {
+                    foreach (WordTableCellSnapshot cell in row.Cells) {
+                        foreach (WordParagraphSnapshot cellParagraph in cell.Paragraphs) {
+                            AddWordParagraphLinks(cellParagraph, location, links, ref linkIndex);
+                        }
+                    }
+                }
+            }
+            sourceBlockIndex++;
+        }
+    }
+
+    private static void AddWordParagraphLinks(
+        WordParagraphSnapshot paragraph,
+        ReaderLocation ownerLocation,
+        List<OfficeDocumentLink> links,
+        ref int linkIndex) {
+        for (int runIndex = 0; runIndex < paragraph.Runs.Count; runIndex++) {
+            WordRunSnapshot run = paragraph.Runs[runIndex];
+            if (!run.IsHyperlink || (string.IsNullOrWhiteSpace(run.HyperlinkUri) && string.IsNullOrWhiteSpace(run.HyperlinkAnchor))) continue;
+            links.Add(new OfficeDocumentLink {
+                Id = "word-link-" + linkIndex.ToString("D4", CultureInfo.InvariantCulture),
+                Kind = string.IsNullOrWhiteSpace(run.HyperlinkUri) ? "internal" : "uri",
+                Uri = run.HyperlinkUri,
+                DestinationName = run.HyperlinkAnchor,
+                Text = run.Text,
+                Location = CloneWordLocation(ownerLocation, "hyperlink", ownerLocation.BlockAnchor + "-link-" + runIndex.ToString("D4", CultureInfo.InvariantCulture))
+            });
+            linkIndex++;
+        }
+    }
+
+    private static ReaderTable MapWordTable(WordTableSnapshot table, ReaderLocation location, int tableIndex, int maxRows) {
+        int columnCount = Math.Max(table.ColumnCount, table.Rows.Count == 0 ? 0 : table.Rows.Max(static row => row.Cells.Count));
+        IReadOnlyList<string> columns = table.Rows.Count == 0
+            ? BuildFallbackColumns(columnCount)
+            : BuildWordRowValues(table.Rows[0], columnCount, useFallbacks: true);
+        int totalRowCount = Math.Max(0, table.Rows.Count - 1);
+        IEnumerable<WordTableRowSnapshot> sourceRows = table.Rows.Skip(1);
+        bool truncated = maxRows > 0 && totalRowCount > maxRows;
+        if (truncated) sourceRows = sourceRows.Take(maxRows);
+        IReadOnlyList<IReadOnlyList<string>> rows = sourceRows
+            .Select(row => BuildWordRowValues(row, columnCount, useFallbacks: false))
+            .ToArray();
+        ReaderLocation tableLocation = CloneWordLocation(location, "table", location.BlockAnchor);
+        tableLocation.TableIndex = tableIndex;
+        return new ReaderTable {
+            Title = string.IsNullOrWhiteSpace(table.Title) ? "Word table " + (tableIndex + 1).ToString(CultureInfo.InvariantCulture) : table.Title,
+            Kind = "word-table",
+            Location = tableLocation,
+            Columns = columns,
+            ColumnProfiles = ReaderTableProfiler.CreateProfiles(columns, rows),
+            Rows = rows,
+            TotalRowCount = totalRowCount,
+            Truncated = truncated
+        };
+    }
+
+    private static IReadOnlyList<string> BuildWordRowValues(WordTableRowSnapshot row, int columnCount, bool useFallbacks) {
+        var values = new string[columnCount];
+        for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+            WordTableCellSnapshot? cell = row.Cells.FirstOrDefault(candidate => candidate.ColumnIndex == columnIndex)
+                ?? (columnIndex < row.Cells.Count ? row.Cells[columnIndex] : null);
+            string value = cell == null
+                ? string.Empty
+                : string.Join(" ", cell.Paragraphs.Select(static paragraph => paragraph.Text).Where(static text => !string.IsNullOrWhiteSpace(text)));
+            values[columnIndex] = string.IsNullOrWhiteSpace(value) && useFallbacks
+                ? "Column " + (columnIndex + 1).ToString(CultureInfo.InvariantCulture)
+                : value;
+        }
+        return values;
+    }
+
+    private static IReadOnlyList<string> BuildFallbackColumns(int count) {
+        return Enumerable.Range(1, count).Select(index => "Column " + index.ToString(CultureInfo.InvariantCulture)).ToArray();
+    }
+
+    private static string BuildWordTableText(WordTableSnapshot table) {
+        return string.Join(Environment.NewLine, table.Rows.Select(row => string.Join(" | ", BuildWordRowValues(row, table.ColumnCount, useFallbacks: false))));
+    }
+
+    private static int? ResolveWordHeadingLevel(WordParagraphSnapshot paragraph) {
+        string style = paragraph.StyleName ?? paragraph.StyleId ?? string.Empty;
+        if (style.IndexOf("heading", StringComparison.OrdinalIgnoreCase) < 0) return null;
+        for (int i = style.Length - 1; i >= 0; i--) {
+            if (style[i] >= '1' && style[i] <= '9') return style[i] - '0';
+        }
+        return 1;
+    }
+
+    private static string? BuildWordHeadingPath(IReadOnlyList<(int Level, string Text)> headings) {
+        return headings.Count == 0 ? null : string.Join(" > ", headings.Select(static heading => heading.Text));
+    }
+
+    private static ReaderLocation CloneWordLocation(ReaderLocation source, string kind, string? anchor) {
+        return new ReaderLocation {
+            Path = source.Path,
+            SourceBlockIndex = source.SourceBlockIndex,
+            HeadingPath = source.HeadingPath,
+            SourceBlockKind = kind,
+            BlockAnchor = anchor
+        };
+    }
+
+    private static OfficeDocumentMetadataEntry BuildCountMetadataEntry(string id, string category, string name, int count) {
+        return new OfficeDocumentMetadataEntry {
+            Id = id,
+            Category = category,
+            Name = name,
+            Value = count.ToString(CultureInfo.InvariantCulture),
+            ValueType = "count"
+        };
+    }
+}

--- a/OfficeIMO.Reader/DocumentReader.WordRichMapping.cs
+++ b/OfficeIMO.Reader/DocumentReader.WordRichMapping.cs
@@ -312,7 +312,7 @@ public static partial class DocumentReader {
     }
 
     private static string? BuildWordHeadingPath(IReadOnlyList<(int Level, string Text)> headings) {
-        return headings.Count == 0 ? null : string.Join(" > ", headings.Select(static heading => heading.Text));
+        return ReaderHeadingPath.Combine(headings.Select(static heading => heading.Text));
     }
 
     private static ReaderLocation CloneWordLocation(ReaderLocation source, string kind, string? anchor) {

--- a/OfficeIMO.Reader/DocumentReader.WordRichMapping.cs
+++ b/OfficeIMO.Reader/DocumentReader.WordRichMapping.cs
@@ -45,7 +45,7 @@ public static partial class DocumentReader {
         }
 
         if (options.IncludeWordFootnotes) {
-            ProjectWordNotes(snapshot, result.Source.Path, blocks, ref sourceBlockIndex);
+            ProjectWordNotes(snapshot, result.Source.Path, blocks, links, ref sourceBlockIndex, ref linkIndex);
         }
 
         var metadata = new[] {
@@ -66,17 +66,19 @@ public static partial class DocumentReader {
         WordDocumentSnapshot snapshot,
         string? sourcePath,
         List<OfficeDocumentBlock> blocks,
-        ref int sourceBlockIndex) {
+        List<OfficeDocumentLink> links,
+        ref int sourceBlockIndex,
+        ref int linkIndex) {
         var emitted = new HashSet<string>(StringComparer.Ordinal);
         int noteIndex = 0;
         foreach (WordSectionSnapshot section in snapshot.Sections) {
             foreach (WordParagraphSnapshot paragraph in EnumerateWordParagraphs(section)) {
                 foreach (WordRunSnapshot run in paragraph.Runs) {
                     if (run.Footnote != null) {
-                        ProjectWordNote("footnote", run.Footnote.ReferenceId, run.Footnote.Paragraphs, sourcePath, blocks, emitted, ref sourceBlockIndex, ref noteIndex);
+                        ProjectWordNote("footnote", run.Footnote.ReferenceId, run.Footnote.Paragraphs, sourcePath, blocks, links, emitted, ref sourceBlockIndex, ref noteIndex, ref linkIndex);
                     }
                     if (run.Endnote != null) {
-                        ProjectWordNote("endnote", run.Endnote.ReferenceId, run.Endnote.Paragraphs, sourcePath, blocks, emitted, ref sourceBlockIndex, ref noteIndex);
+                        ProjectWordNote("endnote", run.Endnote.ReferenceId, run.Endnote.Paragraphs, sourcePath, blocks, links, emitted, ref sourceBlockIndex, ref noteIndex, ref linkIndex);
                     }
                 }
             }
@@ -114,9 +116,11 @@ public static partial class DocumentReader {
         IReadOnlyList<WordParagraphSnapshot> noteParagraphs,
         string? sourcePath,
         List<OfficeDocumentBlock> blocks,
+        List<OfficeDocumentLink> links,
         HashSet<string> emitted,
         ref int sourceBlockIndex,
-        ref int noteIndex) {
+        ref int noteIndex,
+        ref int linkIndex) {
         string text = string.Join(
             Environment.NewLine,
             noteParagraphs.Select(static paragraph => paragraph.Text).Where(static value => !string.IsNullOrWhiteSpace(value)));
@@ -131,17 +135,21 @@ public static partial class DocumentReader {
             ? referenceId.Value.ToString(CultureInfo.InvariantCulture).Replace("-", "negative-")
             : noteIndex.ToString("D4", CultureInfo.InvariantCulture);
         string anchor = "word-" + kind + "-" + reference;
+        var location = new ReaderLocation {
+            Path = sourcePath,
+            SourceBlockIndex = sourceBlockIndex,
+            SourceBlockKind = kind,
+            BlockAnchor = anchor
+        };
         blocks.Add(new OfficeDocumentBlock {
             Id = anchor,
             Kind = kind,
             Text = text,
-            Location = new ReaderLocation {
-                Path = sourcePath,
-                SourceBlockIndex = sourceBlockIndex,
-                SourceBlockKind = kind,
-                BlockAnchor = anchor
-            }
+            Location = location
         });
+        foreach (WordParagraphSnapshot paragraph in noteParagraphs) {
+            AddWordParagraphLinks(paragraph, location, links, ref linkIndex);
+        }
         sourceBlockIndex++;
         noteIndex++;
     }

--- a/OfficeIMO.Reader/DocumentReader.WordRichMapping.cs
+++ b/OfficeIMO.Reader/DocumentReader.WordRichMapping.cs
@@ -44,6 +44,10 @@ public static partial class DocumentReader {
             ProjectWordHeaderFooter(section.EvenFooter, sectionIndex, result.Source.Path, options, blocks, tables, links, ref sourceBlockIndex, ref tableIndex, ref linkIndex);
         }
 
+        if (options.IncludeWordFootnotes) {
+            ProjectWordNotes(snapshot, result.Source.Path, blocks, ref sourceBlockIndex);
+        }
+
         var metadata = new[] {
             BuildCountMetadataEntry("word-section-count", "word.structure", "SectionCount", snapshot.Sections.Count)
         };
@@ -56,6 +60,90 @@ public static partial class DocumentReader {
             result.Visuals,
             result.Pages,
             metadata);
+    }
+
+    private static void ProjectWordNotes(
+        WordDocumentSnapshot snapshot,
+        string? sourcePath,
+        List<OfficeDocumentBlock> blocks,
+        ref int sourceBlockIndex) {
+        var emitted = new HashSet<string>(StringComparer.Ordinal);
+        int noteIndex = 0;
+        foreach (WordSectionSnapshot section in snapshot.Sections) {
+            foreach (WordParagraphSnapshot paragraph in EnumerateWordParagraphs(section)) {
+                foreach (WordRunSnapshot run in paragraph.Runs) {
+                    if (run.Footnote != null) {
+                        ProjectWordNote("footnote", run.Footnote.ReferenceId, run.Footnote.Paragraphs, sourcePath, blocks, emitted, ref sourceBlockIndex, ref noteIndex);
+                    }
+                    if (run.Endnote != null) {
+                        ProjectWordNote("endnote", run.Endnote.ReferenceId, run.Endnote.Paragraphs, sourcePath, blocks, emitted, ref sourceBlockIndex, ref noteIndex);
+                    }
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<WordParagraphSnapshot> EnumerateWordParagraphs(WordSectionSnapshot section) {
+        foreach (WordParagraphSnapshot paragraph in EnumerateWordParagraphs(section.Elements)) yield return paragraph;
+        foreach (WordHeaderFooterSnapshot? headerFooter in new[] {
+            section.DefaultHeader, section.FirstHeader, section.EvenHeader,
+            section.DefaultFooter, section.FirstFooter, section.EvenFooter
+        }) {
+            if (headerFooter == null) continue;
+            foreach (WordParagraphSnapshot paragraph in EnumerateWordParagraphs(headerFooter.Elements)) yield return paragraph;
+        }
+    }
+
+    private static IEnumerable<WordParagraphSnapshot> EnumerateWordParagraphs(IReadOnlyList<WordBlockSnapshot> elements) {
+        foreach (WordBlockSnapshot element in elements) {
+            if (element is WordParagraphSnapshot paragraph) {
+                yield return paragraph;
+            } else if (element is WordTableSnapshot table) {
+                foreach (WordTableRowSnapshot row in table.Rows) {
+                    foreach (WordTableCellSnapshot cell in row.Cells) {
+                        foreach (WordParagraphSnapshot cellParagraph in cell.Paragraphs) yield return cellParagraph;
+                    }
+                }
+            }
+        }
+    }
+
+    private static void ProjectWordNote(
+        string kind,
+        long? referenceId,
+        IReadOnlyList<WordParagraphSnapshot> noteParagraphs,
+        string? sourcePath,
+        List<OfficeDocumentBlock> blocks,
+        HashSet<string> emitted,
+        ref int sourceBlockIndex,
+        ref int noteIndex) {
+        string text = string.Join(
+            Environment.NewLine,
+            noteParagraphs.Select(static paragraph => paragraph.Text).Where(static value => !string.IsNullOrWhiteSpace(value)));
+        if (string.IsNullOrWhiteSpace(text)) return;
+
+        string identity = referenceId.HasValue
+            ? kind + ":" + referenceId.Value.ToString(CultureInfo.InvariantCulture)
+            : kind + ":ordinal:" + noteIndex.ToString(CultureInfo.InvariantCulture);
+        if (!emitted.Add(identity)) return;
+
+        string reference = referenceId.HasValue
+            ? referenceId.Value.ToString(CultureInfo.InvariantCulture).Replace("-", "negative-")
+            : noteIndex.ToString("D4", CultureInfo.InvariantCulture);
+        string anchor = "word-" + kind + "-" + reference;
+        blocks.Add(new OfficeDocumentBlock {
+            Id = anchor,
+            Kind = kind,
+            Text = text,
+            Location = new ReaderLocation {
+                Path = sourcePath,
+                SourceBlockIndex = sourceBlockIndex,
+                SourceBlockKind = kind,
+                BlockAnchor = anchor
+            }
+        });
+        sourceBlockIndex++;
+        noteIndex++;
     }
 
     private static void ProjectWordHeaderFooter(

--- a/OfficeIMO.Reader/README.md
+++ b/OfficeIMO.Reader/README.md
@@ -234,6 +234,22 @@ OfficeDocumentReadResult result = reader.ReadDocument(
 
 Seekable stream probes restore the original position. Prefix probing is capped at 4 MiB, and ZIP-based Office/Visio/EPUB inspection walks at most 4,096 local entries without decompressing archive payloads. Detection mismatches, detected unknown inputs, parser failures, limits, truncation, unsupported content, read failures, and OCR readiness are exposed through `OfficeDocumentDiagnostic` with stable `Category`, `Code`, `Source`, `IsRecoverable`, and `Attributes` fields.
 
+## Rich built-in document mappings
+
+Word, Excel, and PowerPoint rich reads use the format packages' public inspection models instead of reparsing Open XML in the Reader facade:
+
+```csharp
+OfficeDocumentReadResult word = DocumentReader.ReadDocument("policy.docx");
+OfficeDocumentReadResult workbook = DocumentReader.ReadDocument("forecast.xlsx");
+OfficeDocumentReadResult deck = DocumentReader.ReadDocument("briefing.pptx");
+
+Console.WriteLine($"{word.Blocks.Count} semantic Word blocks");
+Console.WriteLine($"{workbook.Tables.Count} named Excel tables");
+Console.WriteLine($"{deck.Visuals.Count} PowerPoint chart snapshots");
+```
+
+The Word mapping preserves headings, lists, links, tables, and header/footer content. Excel exposes worksheet locations, formal tables, cell links, formula/comment/named-range counts, and workbook properties. PowerPoint exposes slide-local blocks and tables, run and shape links, chart snapshots, and point-based geometry. Modular HTML, EPUB, RTF, and Visio adapters register the same native v5 result surface when their packages are installed.
+
 ## Host examples
 
 ### Capability discovery
@@ -292,6 +308,8 @@ OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
 ```
 
 `reader.ReadDocument(...)` dispatches directly to these delegates. Existing `reader.Read(...)` calls remain usable by projecting the returned result's `Chunks` collection. A handler may continue to register `ReadPath` and `ReadStream` when chunk production is its native contract.
+
+Adapter authors can call `DocumentReader.CreateDocumentResult(...)` to create the common v5 source, chunks, assets, diagnostics, and baseline collections, then replace or enrich format-owned blocks, pages, tables, links, forms, visuals, and metadata.
 
 ## Host contracts
 

--- a/OfficeIMO.Word/WordDocument.Inspection.cs
+++ b/OfficeIMO.Word/WordDocument.Inspection.cs
@@ -209,6 +209,7 @@ namespace OfficeIMO.Word {
                     HyperlinkUri = hyperlink?.Uri?.ToString(),
                     HyperlinkAnchor = hyperlink?.Anchor,
                     Footnote = BuildFootnoteSnapshot(run.FootNote),
+                    Endnote = BuildEndnoteSnapshot(run.EndNote),
                     InlineImage = image == null ? null : new WordInlineImageSnapshot {
                         FilePath = string.IsNullOrWhiteSpace(image.FilePath) ? null : image.FilePath,
                         FileName = image.FileName,
@@ -320,6 +321,27 @@ namespace OfficeIMO.Word {
             };
 
             foreach (var paragraphGroup in GroupParagraphs(paragraphs).Where(paragraph => paragraph.GetRuns().Any(run => run.FootNote == null))) {
+                snapshot.AddParagraph(BuildParagraphSnapshot(paragraphGroup));
+            }
+
+            return snapshot.Paragraphs.Count > 0 ? snapshot : null;
+        }
+
+        private WordEndnoteSnapshot? BuildEndnoteSnapshot(WordEndNote? endnote) {
+            if (endnote == null) {
+                return null;
+            }
+
+            var paragraphs = endnote.Paragraphs;
+            if (paragraphs == null || paragraphs.Count == 0) {
+                return null;
+            }
+
+            var snapshot = new WordEndnoteSnapshot {
+                ReferenceId = endnote.ReferenceId,
+            };
+
+            foreach (var paragraphGroup in GroupParagraphs(paragraphs).Where(paragraph => paragraph.GetRuns().Any(run => run.EndNote == null))) {
                 snapshot.AddParagraph(BuildParagraphSnapshot(paragraphGroup));
             }
 

--- a/OfficeIMO.Word/WordDocument.Inspection.cs
+++ b/OfficeIMO.Word/WordDocument.Inspection.cs
@@ -9,6 +9,9 @@ namespace OfficeIMO.Word {
             var snapshot = new WordDocumentSnapshot {
                 FilePath = string.IsNullOrWhiteSpace(FilePath) ? null : FilePath,
                 Title = BuiltinDocumentProperties?.Title,
+                Author = BuiltinDocumentProperties?.Creator,
+                Subject = BuiltinDocumentProperties?.Subject,
+                Keywords = BuiltinDocumentProperties?.Keywords,
             };
 
             for (int sectionIndex = 0; sectionIndex < Sections.Count; sectionIndex++) {

--- a/OfficeIMO.Word/WordInspectionSnapshot.cs
+++ b/OfficeIMO.Word/WordInspectionSnapshot.cs
@@ -6,6 +6,9 @@ namespace OfficeIMO.Word {
 
         public string? FilePath { get; internal set; }
         public string? Title { get; internal set; }
+        public string? Author { get; internal set; }
+        public string? Subject { get; internal set; }
+        public string? Keywords { get; internal set; }
         public IReadOnlyList<WordSectionSnapshot> Sections => _sections;
 
         internal void AddSection(WordSectionSnapshot section) {

--- a/OfficeIMO.Word/WordInspectionSnapshot.cs
+++ b/OfficeIMO.Word/WordInspectionSnapshot.cs
@@ -126,10 +126,23 @@ namespace OfficeIMO.Word {
         public string? HyperlinkUri { get; internal set; }
         public string? HyperlinkAnchor { get; internal set; }
         public WordFootnoteSnapshot? Footnote { get; internal set; }
+        public WordEndnoteSnapshot? Endnote { get; internal set; }
         public WordInlineImageSnapshot? InlineImage { get; internal set; }
     }
 
     public sealed class WordFootnoteSnapshot {
+        private readonly List<WordParagraphSnapshot> _paragraphs = new List<WordParagraphSnapshot>();
+
+        public long? ReferenceId { get; internal set; }
+        public IReadOnlyList<WordParagraphSnapshot> Paragraphs => _paragraphs;
+
+        internal void AddParagraph(WordParagraphSnapshot paragraph) {
+            if (paragraph == null) throw new ArgumentNullException(nameof(paragraph));
+            _paragraphs.Add(paragraph);
+        }
+    }
+
+    public sealed class WordEndnoteSnapshot {
         private readonly List<WordParagraphSnapshot> _paragraphs = new List<WordParagraphSnapshot>();
 
         public long? ReferenceId { get; internal set; }


### PR DESCRIPTION
## Summary

- preserve headings, lists, links, tables, headers, footers, notes, and document metadata in rich Word results
- expose Excel sheets, formal tables, formulas, comments, names, links, and workbook properties without duplicating overlapping generic tables
- map PowerPoint slide blocks, tables, links, chart snapshots, speaker notes, hidden shapes, and point geometry
- bring HTML, EPUB, RTF, and Visio adapters onto the shared schema-v5 rich result
- apply HTML size, selector, element, URL, base-URI, image, and form-control policies consistently to chunks and rich projections
- preserve EPUB chapter assets, OCR candidates, package-relative links, image-only spine entries, and resource payload opt-outs
- keep table rows bounded while retaining the first data row in headerless Word, HTML, and PowerPoint tables
- add small inspection capabilities to the owning format libraries so Reader remains a thin mapping layer

## Why it matters

Rich reads now retain the source structure needed for search, extraction, auditing, and retrieval across the main Office and modular formats. Callers can use one document-result model without losing format-specific locations, relationships, or bounded-output behavior.

## Compatibility

The change extends the existing schema-v5 result surface. Normal chunk reads remain available, and caller-selected format limits and filtering policies continue to apply to rich reads.

## Series

Track 3 of the Reader maturity series. Previous: #2052. Next: #2054.
