### PR TITLE
Add optional Reader OCR engines

### DIFF
--- a/Build/project.build.json
+++ b/Build/project.build.json
@@ -29,6 +29,8 @@
     "OfficeIMO.Reader.Epub": "0.0.X",
     "OfficeIMO.Reader.Html": "0.0.X",
     "OfficeIMO.Reader.Json": "0.0.X",
+    "OfficeIMO.Reader.Ocr.Process": "0.0.X",
+    "OfficeIMO.Reader.Ocr.Tesseract": "0.0.X",
     "OfficeIMO.Reader.Pdf": "0.0.X",
     "OfficeIMO.Reader.Rtf": "0.0.X",
     "OfficeIMO.Reader.Text": "0.0.X",
@@ -87,4 +89,3 @@
   "GitHubTagTemplate": "{Repo}-v{UtcTimestamp}",
   "GitHubReleaseName": "{Repo} {UtcDateTime}"
 }
-

--- a/Docs/officeimo.document-intelligence-roadmap.md
+++ b/Docs/officeimo.document-intelligence-roadmap.md
@@ -4,7 +4,7 @@ Date: 2026-07-10
 
 ## Purpose
 
-This roadmap describes the next OfficeIMO document-intelligence layer: a dependency-light, deterministic, .NET-native stack for reading, converting, inspecting, exporting, and preparing documents for search, automation, reporting, and AI ingestion.
+This roadmap describes the current OfficeIMO document-intelligence layer and its next fidelity work: a dependency-light, deterministic, .NET-native stack for reading, converting, inspecting, exporting, and preparing documents for search, automation, reporting, and AI ingestion.
 
 The roadmap is OfficeIMO-owned and intentionally product-general. The goal is to make the OfficeIMO family feel coherent:
 
@@ -113,28 +113,31 @@ These exporters should feed back into the same verification, logical readback, v
 
 ## Target Architecture
 
-The next layer should be a shared document readback model rather than a new one-off parser.
+The shared document readback model is the integration layer; new format work should extend it through owning packages rather than create another one-off parser.
 
-Proposed model names can evolve, but the shape should be stable:
+The stable envelope is:
 
 ```text
 OfficeDocumentReadResult
+  SchemaId
+  SchemaVersion
+  Kind
   Source
   CapabilitiesUsed
   Markdown
   Html
   Json
   Chunks
+  Metadata
   Assets
   Diagnostics
   Pages
   Blocks
   Tables
-  Images
   Links
   Forms
+  OcrCandidates
   Visuals
-  SourceMap
 ```
 
 Core principles:
@@ -145,9 +148,9 @@ Core principles:
 - Unsupported content should produce diagnostics and preserve source references where possible.
 - Heavy or platform-specific work remains optional and isolated.
 
-## Current Branch Implementation
+## Current Implementation
 
-This branch starts the shared model and adapter path:
+The current Reader stack provides the shared model and adapter path:
 
 - `OfficeDocumentReadResult` and deterministic JSON serialization live in `OfficeIMO.Reader`.
 - `DocumentReader` can return the shared envelope for existing chunk-based ingestion without changing `DocumentReader.Read(...)`, including generic summary metadata for chunks, blocks, tables, visuals, and known source containers.
@@ -220,44 +223,39 @@ Goal: make the roadmap OfficeIMO-owned, current, and easy to hand off.
 
 Goal: one result envelope for all output forms.
 
-- Add a read result model with Markdown, HTML, JSON, chunks, metadata, assets, diagnostics, pages, visuals, and source maps.
-- Add capability metadata similar to `DocumentReader.GetCapabilityManifest()`.
-- Start as internal or experimental until the model survives PDF, Word, Excel, PowerPoint, Markdown, HTML, and Visio examples.
-- Provide convenience APIs over `DocumentReader`, for example `ReadDocument(...)`, `ReadDocumentJson(...)`, `ReadAsMarkdown(...)`, and `ReadAsHtml(...)`.
-- Keep `DocumentReader.Read(...)` behavior stable.
+- `OfficeDocumentReadResult` schema version 5 is the stable envelope for chunks, metadata, assets, diagnostics, pages, blocks, tables, links, forms, visuals, OCR candidates, and source references.
+- Capability manifests describe chunk, rich-result, stream, and native async support for static and isolated readers.
+- Word, Excel, PowerPoint, Markdown, PDF, HTML, EPUB, RTF, Visio, and other modular adapters project into the shared result while their format packages retain parser ownership.
+- `ReadDocument(...)`, JSON transport, Markdown/HTML fields, table/asset/visual projections, processors, structured extraction, and hierarchical chunking provide host-facing convenience surfaces over the same result.
+- `DocumentReader.Read(...)` remains the compatible chunk surface.
 
 ### P2 - PDF Logical Model Integration
 
 Goal: make current PDF logical readback the first full adapter into the shared model.
 
-- Map `PdfLogicalDocument` pages, text blocks, headings, paragraphs, list items, tables, images, links, form widgets, metadata, outlines, destinations, viewer/catalog data, and diagnostics into the shared result.
-- Reuse `PdfLogicalDocument.ToMarkdown(...)` rather than creating a second PDF Markdown path.
-- Add JSON serialization for logical PDF readback.
-- Add asset manifest output for PDF images and form/widget metadata.
-- Add page-range readback APIs that preserve source page numbers and caller order.
-- Keep `PdfInspector.Preflight(...)`, `PdfConversionReport`, and compliance-readiness diagnostics visible in the read result.
+- `OfficeIMO.Reader.Pdf` maps logical pages, blocks, tables, images, links, form widgets, metadata, outlines, destinations, viewer/catalog data, and diagnostics into the shared result.
+- PDF Markdown reuses `PdfLogicalDocument.ToMarkdown(...)`, and rich results use the common version 5 JSON transport.
+- PDF image assets, form/widget metadata, preflight capabilities, and read/rewrite blockers remain visible to hosts.
+- Follow-up work should deepen image/form metadata, page-range workflows, compliance evidence, and logical fidelity in `OfficeIMO.Pdf` before adapting it in Reader.
 
 ### P3 - Tables And Structured Blocks
 
 Goal: make table and block output reliable enough for automation.
 
-- Normalize table output across PDF, Excel, Word, Markdown, HTML, CSV, JSON, XML, YAML, and PowerPoint table adapters.
-- Preserve table source references, row/column counts, span data, truncation state, captions/titles where known, and cell text.
-- Promote existing PDF-to-Word/Excel table import helpers into the shared table contract once confidence metadata is available.
-- Extend table-only extraction mode from Reader/PDF/Visio into examples, docs, and any remaining format-specific adapters.
-- Improve PDF table detection with span geometry, repeated x-bands, ruling lines where available, and page-continuation heuristics.
-- Expand deterministic CSV/Markdown/JSON table sidecar helpers into host-facing docs and end-to-end examples.
+- `ReaderTable` is the shared table contract, with source locations, columns, rows, truncation state, titles, and deterministic CSV/Markdown/JSON export helpers.
+- Word, Excel, PowerPoint, PDF, HTML, EPUB, RTF, Visio, Markdown, CSV, and structured adapters populate the contract where their owning models expose table data.
+- Table-only projections, export bundles, write-to-directory output, and caller-owned callbacks are available to hosts.
+- Follow-up work should add richer cell spans/confidence, improve PDF geometry and continuation heuristics, and expand end-to-end table examples.
 
 ### P4 - Assets And Visuals
 
 Goal: treat images, previews, charts, and diagram visuals as first-class output.
 
-- Generalize the PDF image manifest into `DocumentAsset`.
-- Continue enriching Word/Excel/PowerPoint image manifests with drawing anchors, crop metadata, broader alt/title metadata, and richer header/footer coverage.
-- Add chart snapshots and drawing quality diagnostics from `OfficeIMO.Drawing`.
-- Add Visio SVG/PNG preview output as visual assets when requested.
-- Include asset hash, media type, extension, dimensions, source page/slide/sheet/diagram page, relationship or object identity where known, and warnings.
-- Support output modes: asset-only readback, manifest-only envelope output, write-to-directory, embedded data URI for small assets, and caller-owned stream callbacks.
+- `OfficeDocumentAsset` carries stable IDs, hashes, media type, extension, dimensions, source location, relationship/object identity, suggested filenames, and materializable payloads where available.
+- Word, Excel, PowerPoint, PDF, HTML, EPUB, and Visio rich mappings expose assets and structured visuals without reparsing formats in Reader.
+- PowerPoint chart snapshots and optional Visio SVG/PNG previews flow through the shared visual/asset surfaces.
+- Asset-only and visual-only projections, manifest-only JSON, write-to-directory output, bounded data URIs, and caller-owned callbacks are available.
+- Follow-up work should deepen drawing anchors, crop metadata, alt/title coverage, header/footer assets, and visual quality evidence in the owning packages.
 
 ### P5 - Office Export Feedback Loop
 
@@ -273,11 +271,10 @@ Goal: use first-party PDF export as both product feature and verification path.
 
 Goal: make VSDX useful to ingestion and automation hosts.
 
-- Keep `OfficeIMO.Reader.Visio` as the optional adapter package unless package-boundary review says it belongs elsewhere.
-- Extract diagram pages as chunks with title, shapes, connectors, labels, Shape Data, hyperlinks, stencil identity, inspection summary, visual quality summary, and preview asset references.
-- Expose diagram tables/records where Shape Data schemas or graph records are present.
-- Optionally emit SVG/PNG previews through `ToSvg(...)`, `SaveAsSvg(...)`, `ToPng(...)`, and `SaveAsPng(...)`.
-- Keep VSDX semantics in `OfficeIMO.Visio`; Reader should adapt, not duplicate.
+- `OfficeIMO.Reader.Visio` remains the optional adapter over `OfficeIMO.Visio` inspection models.
+- It exposes diagram pages, chunks, blocks, Shape Data tables, hyperlinks, metadata, diagnostics, and optional SVG/PNG preview assets through the shared result.
+- Visio parsing, stencil identity, connectors, inspection, visual quality, and preview generation remain owned by `OfficeIMO.Visio`.
+- Follow-up work should project richer graph/stencil/quality evidence only after the owning inspection model exposes stable contracts.
 
 ### P7 - HTML And Portable Document Bridge
 
@@ -362,10 +359,10 @@ Goal: prove document intelligence with tests users can trust.
 5. Keep deterministic schema version 5 JSON stable and expand nested schema detail as shared models mature.
 6. Extend asset manifests to richer PDF form/widget assets, HTML/EPUB referenced media, and Office drawing anchors.
 7. Expand table-only extraction examples and adapter coverage beyond the initial Reader/PDF/Visio facades.
-8. Extend scan/OCR-needed diagnostics beyond image-only PDF pages into richer image-region and Office-document heuristics, still without an OCR implementation.
+8. Extend scan/OCR-needed diagnostics beyond image-only PDF pages into richer image-region and Office-document heuristics without adding an OCR provider dependency to the core package.
 9. Extend the Visio adapter with stencil profile, inspection summary, visual quality summary, and optional write-to-directory previews.
 10. Add HTML/Word/Markdown/PDF bridge fixtures at the block/table/asset level.
-11. Add docs/tests showing Word, Excel, PowerPoint, PDF, Markdown, HTML, and Visio flowing into the same result shape.
+11. Keep cross-format docs and contract tests current as Word, Excel, PowerPoint, PDF, Markdown, HTML, EPUB, RTF, and Visio mappings gain fidelity.
 
 ## Non-Goals For The Core
 

--- a/Docs/officeimo.document-intelligence-roadmap.md
+++ b/Docs/officeimo.document-intelligence-roadmap.md
@@ -313,8 +313,9 @@ Goal: prepare the model and pipeline for OCR while keeping the core honest.
 
 - Detect likely scanned pages or image-only regions. The first slice flags image-only PDF pages.
 - Add `ocr-needed` diagnostics and `OcrCandidate` records.
-- Add an `IOfficeOcrEngine` abstraction with line, word, character, bounding-box, confidence, language, and diagnostic output.
-- Add merge rules that combine OCR output with native text spans without losing source coordinates.
+- `IOfficeOcrEngine` now exposes line, word, and character spans with coordinate units, bounding boxes, confidence, language, provider identity, and structured diagnostics.
+- `ApplyOcrAsync(...)` resolves candidate assets and bounds candidate count, input bytes, concurrency, duration, recognized characters, and detailed spans before merging recognized text.
+- OCR merge rules retain native content, source containers, candidate geometry, unresolved candidates, and provider trace metadata.
 - Treat OCR results as another source layer that can be compared with native text, not as a replacement for native text.
 - Keep built-in high-quality OCR out of the no-dependency core unless a separate product decision is made.
 
@@ -322,11 +323,11 @@ Goal: prepare the model and pipeline for OCR while keeping the core honest.
 
 Goal: make advanced ingestion possible without changing the core dependency story.
 
-Optional packages can be added after the core contracts are stable:
+The first optional packages keep advanced execution outside the base dependency graph:
 
-- OCR via Windows inbox APIs.
-- OCR via configured external process or service.
-- OCR via native engine package.
+- `OfficeIMO.Reader.Ocr.Process` provides a bounded, versioned JSON file protocol for a configured executable or service bridge.
+- `OfficeIMO.Reader.Ocr.Tesseract` provides a thin Tesseract CLI adapter with TSV line/word geometry and installation discovery.
+- Windows inbox OCR remains a future platform-specific provider rather than a base-package dependency.
 - Model-assisted structured extraction through host-provided clients.
 - Audio/video/transcription adapters if needed by downstream products.
 

--- a/Docs/officeimo.reader.md
+++ b/Docs/officeimo.reader.md
@@ -188,4 +188,4 @@ Keep raw BenchmarkDotNet artifacts local. When a result is used as a release bas
 - Folder ingestion is best-effort: unreadable/corrupt/oversized files emit warning chunks and processing continues.
 - `ReadFolderDocuments(...)` yields per-source payloads (`ReaderSourceDocument`) for straightforward source/chunk table upserts.
 - `ReadFolderDetailed(...)` provides aggregate counts and per-file status with optional progress callbacks.
-- The core reader identifies OCR candidates but does not include an OCR engine. OCR providers belong in optional packages.
+- The core reader identifies OCR candidates and owns the bounded `IOfficeOcrEngine` execution/merge contract, but it does not include an OCR implementation. Use `OfficeIMO.Reader.Ocr.Process`, `OfficeIMO.Reader.Ocr.Tesseract`, or a host-supplied delegate engine when OCR should run.

--- a/Docs/officeimo.reader.md
+++ b/Docs/officeimo.reader.md
@@ -14,6 +14,38 @@ It is designed for deterministic ingestion. Format-specific parsing stays in the
 
 Reference the `OfficeIMO.Reader` NuGet package or add a project reference. Install only the modular adapter packages required by the host.
 
+The package README at `OfficeIMO.Reader/README.md` is the detailed API guide. The sections below summarize the stable host contracts and common ingestion patterns.
+
+## Current Reader Surfaces
+
+- `DocumentReader.Read(...)` returns compatible `ReaderChunk` sequences for indexing and folder traversal.
+- `ReadDocument(...)` returns the stable version 5 rich result with pages, blocks, tables, links, forms, assets, visuals, OCR candidates, metadata, and structured diagnostics.
+- `OfficeDocumentReaderBuilder` freezes handlers, options, processor order, and concurrency into an isolated reader for services and concurrent hosts.
+- Async file, stream, byte, and bounded multi-document APIs preserve cancellation, ordering, input limits, and caller-owned stream lifetime.
+- Ordered processors provide opt-in normalization, artifact classification, link/table cleanup, and asset filtering.
+- `ReadStructured(...)` emits bounded scalar records, sections, named tables, forms, and readiness diagnostics without an AI dependency.
+- `ReadHierarchical(...)` creates token-bounded RAG leaves with overlap, exact source spans, and document/container/heading ancestry.
+- `IOfficeOcrEngine` keeps OCR execution in a dependency-free core contract; process and Tesseract implementations are separate optional packages.
+
+For format adapters, prefer instance-scoped registration:
+
+```csharp
+using OfficeIMO.Reader;
+using OfficeIMO.Reader.Pdf;
+
+OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+    .AddPdfHandler()
+    .WithMaxConcurrentReads(4)
+    .AddProcessor(new OfficeDocumentBlockNormalizationProcessor())
+    .Build();
+
+OfficeDocumentReadResult document = await reader.ReadDocumentAsync(
+    "report.pdf",
+    cancellationToken: cancellationToken);
+```
+
+The static registration helpers remain available for compatibility, but they update process-wide state.
+
 ## Basic Use (File Path)
 
 ```csharp

--- a/Docs/officeimo.reader.modular-roadmap.md
+++ b/Docs/officeimo.reader.modular-roadmap.md
@@ -1,82 +1,68 @@
-# OfficeIMO Reader Modularization Roadmap (Internal Preview)
+# OfficeIMO Reader Package Ownership
 
-This plan introduces reusable format packages first, then composes them into Reader adapters.
-The goal is clean IntelligenceX integration without forcing one large dependency set on all users.
+This document records the current Reader package boundaries and the remaining modular follow-up work.
 
-## Principles
+## Current package shape
 
-- Keep `OfficeIMO.Reader` as the stable ingestion facade.
-- Move format-specific behavior into reusable packages.
-- Keep heavy features optional and isolated.
-- Preserve deterministic contracts (`ReaderChunk`, progress, warnings, source metadata).
+| Owner | Responsibility |
+| --- | --- |
+| `OfficeIMO.Reader` | Shared chunks and rich result, static compatibility facade, isolated reader instances, bounded sync/async execution, detection, diagnostics, processors, structured extraction, hierarchical chunking, and OCR execution contracts. |
+| Format packages | Parse and inspect their own formats. Reader must not duplicate Word, Excel, PowerPoint, Markdown, PDF, RTF, HTML, EPUB, Visio, CSV, ZIP, or other format logic. |
+| `OfficeIMO.Reader.*` adapters | Register path/stream handlers and project owning format models into the shared Reader contracts. |
+| `OfficeIMO.Reader.Ocr.Process` | Optional versioned external-process OCR bridge. |
+| `OfficeIMO.Reader.Ocr.Tesseract` | Optional Tesseract CLI provider with line and word geometry. |
 
-## Package Structure (Scaffolded)
+The modular adapters are working packages in the publishing pipeline, not placeholders:
 
-- `OfficeIMO.Zip`
-- `OfficeIMO.Epub`
-- `OfficeIMO.Reader.Zip`
+- `OfficeIMO.Reader.Csv`
 - `OfficeIMO.Reader.Epub`
-- `OfficeIMO.Reader.Text`
 - `OfficeIMO.Reader.Html`
+- `OfficeIMO.Reader.Json`
+- `OfficeIMO.Reader.Pdf`
+- `OfficeIMO.Reader.Rtf`
+- `OfficeIMO.Reader.Text`
+- `OfficeIMO.Reader.Visio`
+- `OfficeIMO.Reader.Xml`
 - `OfficeIMO.Reader.Yaml`
+- `OfficeIMO.Reader.Zip`
 - `OfficeIMO.Reader.Ocr.Process`
 - `OfficeIMO.Reader.Ocr.Tesseract`
 
-These packages are wired into the publishing pipeline; the OCR packages include working providers rather than placeholders.
+## Completed modularization contracts
 
-## Delivery Order (Low -> High Effort)
+- The static `DocumentReader` registration surface remains available for compatibility.
+- `OfficeDocumentReaderBuilder` freezes handlers, options, concurrency, and processors into an isolated `OfficeDocumentReader`.
+- Adapters expose matching builder extensions such as `AddPdfHandler()` and retain compatible static registration helpers.
+- Registrations can provide chunk delegates, native rich-result delegates, and native asynchronous path/stream delegates.
+- Path, stream, byte, and non-seekable input paths share the same bounded input behavior.
+- Capability manifests distinguish chunk, rich-result, and native async support.
+- The stable rich transport is `OfficeDocumentReadResult` schema version 5.
+- Ordered processors, bounded structured extraction, token-aware hierarchical chunking, and optional OCR build on the shared result instead of adding format-specific host pipelines.
+- OCR providers remain opt-in and do not change the core package dependency graph.
 
-1. ZIP path (low)
-- Harden archive traversal. (implemented in scaffold branch)
-- Add entry-level warning handling. (implemented in scaffold branch)
-- Support nested Office/text extraction from ZIP entries. (implemented in scaffold branch)
-- Add stream ingestion + registry stream dispatch. (implemented in scaffold branch)
-- Support non-seekable streams in adapter pipeline. (implemented in scaffold branch)
+## Ownership rules for new adapters
 
-2. EPUB path (low-medium)
-- Basic chapter extraction from XHTML/HTML entries.
-- Normalize into Reader chunks.
-- Add OPF/spine/nav-aware ordering in next pass. (implemented in scaffold branch)
-- Add stream ingestion + registry stream dispatch. (implemented in scaffold branch)
-- Support non-seekable streams in adapter pipeline. (implemented in scaffold branch)
+1. Put reusable parsing and inspection behavior in the owning format package.
+2. Keep the Reader adapter to registration, option translation, source mapping, and shared-model projection.
+3. Use `ReaderInputLimits` for file, byte, and stream bounds.
+4. Preserve caller-owned stream lifetime and position where the contract promises it.
+5. Emit stable structured diagnostics for limits, unsupported content, and recoverable failures.
+6. Add instance-builder registration alongside any static compatibility registration.
+7. Keep optional native, platform, cloud, or process dependencies outside `OfficeIMO.Reader`.
 
-3. Structured text path (medium)
-- CSV semantic chunks with tables.
-- JSON/XML/YAML structural chunkers. (implemented in scaffold branch)
-- Stable markdown previews and table metadata.
-- Add stream ingestion + registry stream dispatch. (implemented in scaffold branch)
-- Reuse `OfficeIMO.CSV` stream API for CSV path/stream parity. (implemented in scaffold branch)
+## Release gates
 
-4. HTML path (medium)
-- HTML -> Word -> Markdown bridge.
-- Chunking and source/citation metadata.
-- Performance and fidelity tuning for large inputs.
-- Add stream ingestion + registry stream dispatch. (implemented in scaffold branch)
-- Add configurable HTML/Markdown conversion options for adapter registration. (implemented in scaffold branch)
+Before publishing a new or changed adapter:
 
-5. Reader core modularization (medium-high)
-- Replace hardcoded switch routing with handler registry. (implemented in scaffold branch)
-- Add capability discovery for host apps. (implemented in scaffold branch)
-- Keep existing `DocumentReader.Read*` API behavior stable.
+- cover path, stream, byte, async, cancellation, limits, malformed input, and deterministic output where those surfaces apply;
+- validate source IDs, chunk IDs/hashes, locations, and rich-result relationships;
+- build every supported target framework and pack the affected public packages;
+- verify that optional dependencies are intentional and do not leak into the core package;
+- update the adapter README, the core Reader README, and the website Reader page when the public workflow changes.
 
-6. Optional heavy paths (high)
-- OCR/image text extraction through bounded process and Tesseract providers. (implemented)
-- Audio transcription.
-- URL/Youtube ingestion.
-- Keep each as separate opt-in package.
+## Follow-up candidates
 
-## IntelligenceX Integration Expectations
-
-- Current `OfficeImoReadTool` contract remains stable.
-- New formats become available incrementally via adapters.
-- Missing optional dependencies should emit warnings, not hard failures.
-- Capability listing can be surfaced to chat/tooling once handler registry lands.
-
-## Release Gating
-
-Before publishing any new package:
-
-- Add dedicated tests (success, error, limits, deterministic output).
-- Validate chunk IDs/source metadata stability.
-- Verify no regressions for existing Reader consumers.
-- Confirm package-level dependency footprint is intentional.
+- Continue increasing format fidelity in the owning packages and project that evidence through the adapters.
+- Add optional providers only when their dependency and runtime boundaries are clear.
+- Keep audio, video, URL, and transcription ingestion in separate packages if downstream products require them.
+- Keep email and attachment ingestion in the existing Mailozaurr owner; it is outside the current OfficeIMO Reader stack.

--- a/Docs/officeimo.reader.modular-roadmap.md
+++ b/Docs/officeimo.reader.modular-roadmap.md
@@ -19,8 +19,10 @@ The goal is clean IntelligenceX integration without forcing one large dependency
 - `OfficeIMO.Reader.Text`
 - `OfficeIMO.Reader.Html`
 - `OfficeIMO.Reader.Yaml`
+- `OfficeIMO.Reader.Ocr.Process`
+- `OfficeIMO.Reader.Ocr.Tesseract`
 
-These scaffolded packages are now wired into the publishing pipeline.
+These packages are wired into the publishing pipeline; the OCR packages include working providers rather than placeholders.
 
 ## Delivery Order (Low -> High Effort)
 
@@ -58,7 +60,7 @@ These scaffolded packages are now wired into the publishing pipeline.
 - Keep existing `DocumentReader.Read*` API behavior stable.
 
 6. Optional heavy paths (high)
-- OCR/image text extraction.
+- OCR/image text extraction through bounded process and Tesseract providers. (implemented)
 - Audio transcription.
 - URL/Youtube ingestion.
 - Keep each as separate opt-in package.

--- a/OfficeIMO.Reader.Ocr.Process/OfficeIMO.Reader.Ocr.Process.csproj
+++ b/OfficeIMO.Reader.Ocr.Process/OfficeIMO.Reader.Ocr.Process.csproj
@@ -1,0 +1,52 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>Optional process-protocol OCR engine for OfficeIMO.Reader.</Description>
+    <AssemblyName>OfficeIMO.Reader.Ocr.Process</AssemblyName>
+    <AssemblyTitle>OfficeIMO.Reader.Ocr.Process</AssemblyTitle>
+    <VersionPrefix>0.0.1</VersionPrefix>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <!-- No public baseline exists until the first 0.0.1 package is released. -->
+    <EnablePackageValidation>false</EnablePackageValidation>
+    <IsPackable>true</IsPackable>
+    <IsPublishable>true</IsPublishable>
+    <Company>Evotec</Company>
+    <Authors>Przemyslaw Klys</Authors>
+    <PackageId>OfficeIMO.Reader.Ocr.Process</PackageId>
+    <PackageTags>reader;ocr;process;ingestion;officeimo</PackageTags>
+    <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/EvotecIT/OfficeIMO</RepositoryUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <LangVersion>Latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OfficeIMO.Reader\OfficeIMO.Reader.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472'">
+    <PackageReference Include="System.Text.Json" Version="[10.0.7,11.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md">
+      <Pack>True</Pack>
+      <PackagePath>README.md</PackagePath>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.IO" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Text" />
+    <Using Include="System.Threading" />
+    <Using Include="System.Threading.Tasks" />
+  </ItemGroup>
+</Project>

--- a/OfficeIMO.Reader.Ocr.Process/OfficeOcrProcessFileNames.cs
+++ b/OfficeIMO.Reader.Ocr.Process/OfficeOcrProcessFileNames.cs
@@ -1,0 +1,23 @@
+using OfficeIMO.Reader;
+
+namespace OfficeIMO.Reader.Ocr.Process;
+
+/// <summary>Safe temporary filename helpers shared by process-based OCR providers.</summary>
+public static class OfficeOcrProcessFileNames {
+    /// <summary>Returns a bounded, filesystem-safe extension for an OCR asset.</summary>
+    public static string GetSafeAssetExtension(OfficeDocumentAsset asset) {
+        if (asset == null) throw new ArgumentNullException(nameof(asset));
+        string extension = asset.Extension ?? Path.GetExtension(asset.FileName ?? string.Empty);
+        if (string.IsNullOrWhiteSpace(extension)) extension = asset.MediaType switch {
+            "image/png" => ".png",
+            "image/jpeg" => ".jpg",
+            "image/tiff" => ".tiff",
+            "image/bmp" => ".bmp",
+            "image/webp" => ".webp",
+            _ => ".bin"
+        };
+        string safe = new string(extension.Where(static character => char.IsLetterOrDigit(character) || character == '.').ToArray());
+        if (safe.Length == 0 || safe.Length > 12) return ".bin";
+        return safe[0] == '.' ? safe : "." + safe;
+    }
+}

--- a/OfficeIMO.Reader.Ocr.Process/OfficeOcrProcessLifetime.cs
+++ b/OfficeIMO.Reader.Ocr.Process/OfficeOcrProcessLifetime.cs
@@ -1,0 +1,201 @@
+using Microsoft.Win32.SafeHandles;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace OfficeIMO.Reader.Ocr.Process;
+
+/// <summary>Owns the operating-system boundary used to terminate an OCR command and any descendants.</summary>
+internal sealed class OfficeOcrProcessLifetime : IDisposable {
+    private const int JobObjectExtendedLimitInformationClass = 9;
+    private const uint JobObjectLimitKillOnJobClose = 0x00002000;
+    private const int SigKill = 9;
+
+    private readonly LifetimeMode _mode;
+    private SafeFileHandle? _jobHandle;
+    private int _processGroupId;
+    private bool _disposed;
+
+    private OfficeOcrProcessLifetime(LifetimeMode mode) {
+        _mode = mode;
+    }
+
+    internal static OfficeOcrProcessLifetime Configure(
+        ProcessStartInfo startInfo,
+        string fileName,
+        IReadOnlyList<string> arguments) {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            return new OfficeOcrProcessLifetime(LifetimeMode.WindowsJob);
+        }
+
+        string? setSid = ResolveSetSid();
+        if (setSid != null) {
+            startInfo.FileName = setSid;
+            startInfo.Arguments = JoinArguments(new[] { fileName }.Concat(arguments));
+            return new OfficeOcrProcessLifetime(LifetimeMode.UnixProcessGroup);
+        }
+
+        const string macPerl = "/usr/bin/perl";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && File.Exists(macPerl)) {
+            startInfo.FileName = macPerl;
+            startInfo.Arguments = JoinArguments(new[] {
+                "-MPOSIX",
+                "-e",
+                "defined(POSIX::setsid()) or die qq(setsid failed: $!\\n); exec { $ARGV[0] } @ARGV; die qq(exec failed: $!\\n);",
+                fileName
+            }.Concat(arguments));
+            return new OfficeOcrProcessLifetime(LifetimeMode.UnixProcessGroup);
+        }
+
+        throw new PlatformNotSupportedException(
+            "Bounded OCR process execution requires a Windows Job Object, /usr/bin/setsid or /bin/setsid on Unix, or /usr/bin/perl with POSIX::setsid on macOS.");
+    }
+
+    internal void Attach(System.Diagnostics.Process process) {
+        if (_mode == LifetimeMode.UnixProcessGroup) {
+            _processGroupId = process.Id;
+            return;
+        }
+        if (_mode != LifetimeMode.WindowsJob) return;
+
+        SafeFileHandle? job = TryCreateWindowsJob();
+        if (job == null) {
+            TryKillDirectProcess(process);
+            throw new InvalidOperationException("Unable to create the Windows Job Object required for bounded OCR process execution.");
+        }
+        if (!AssignProcessToJobObject(job.DangerousGetHandle(), process.Handle)) {
+            job.Dispose();
+            TryKillDirectProcess(process);
+            throw new InvalidOperationException("Unable to assign the OCR process to the Windows Job Object required for bounded execution.");
+        }
+        _jobHandle = job;
+    }
+
+    internal void Terminate(System.Diagnostics.Process process) {
+        if (_jobHandle != null && !_jobHandle.IsInvalid && !_jobHandle.IsClosed) {
+            _ = TerminateJobObject(_jobHandle.DangerousGetHandle(), 1);
+        }
+        KillUnixProcessGroup();
+        TryKillDirectProcess(process);
+    }
+
+    public void Dispose() {
+        if (_disposed) return;
+        _disposed = true;
+        KillUnixProcessGroup();
+        _jobHandle?.Dispose();
+        _jobHandle = null;
+    }
+
+    private static string JoinArguments(IEnumerable<string> values) {
+        return string.Join(" ", values.Select(OfficeOcrProcessRunner.QuoteArgument));
+    }
+
+    private static string? ResolveSetSid() {
+        string[] candidates = { "/usr/bin/setsid", "/bin/setsid" };
+        return candidates.FirstOrDefault(File.Exists);
+    }
+
+    private void KillUnixProcessGroup() {
+        int processGroupId = Interlocked.Exchange(ref _processGroupId, 0);
+        if (processGroupId <= 0) return;
+        try {
+            _ = Kill(-processGroupId, SigKill);
+        } catch (DllNotFoundException) {
+        } catch (EntryPointNotFoundException) {
+        }
+    }
+
+    private static void TryKillDirectProcess(System.Diagnostics.Process process) {
+        try {
+            if (!process.HasExited) {
+#if NET8_0_OR_GREATER
+                process.Kill(entireProcessTree: true);
+#else
+                process.Kill();
+#endif
+            }
+        } catch (InvalidOperationException) {
+        } catch (System.ComponentModel.Win32Exception) {
+        } catch (NotSupportedException) {
+        }
+    }
+
+    private static SafeFileHandle? TryCreateWindowsJob() {
+        IntPtr rawHandle = CreateJobObject(IntPtr.Zero, null);
+        if (rawHandle == IntPtr.Zero || rawHandle == new IntPtr(-1)) return null;
+        var handle = new SafeFileHandle(rawHandle, ownsHandle: true);
+        var information = new JobObjectExtendedLimitInformation {
+            BasicLimitInformation = new JobObjectBasicLimitInformation {
+                LimitFlags = JobObjectLimitKillOnJobClose
+            }
+        };
+        int size = Marshal.SizeOf<JobObjectExtendedLimitInformation>();
+        IntPtr pointer = Marshal.AllocHGlobal(size);
+        try {
+            Marshal.StructureToPtr(information, pointer, fDeleteOld: false);
+            if (!SetInformationJobObject(handle.DangerousGetHandle(), JobObjectExtendedLimitInformationClass, pointer, (uint)size)) {
+                handle.Dispose();
+                return null;
+            }
+            return handle;
+        } finally {
+            Marshal.FreeHGlobal(pointer);
+        }
+    }
+
+    [DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+    private static extern int Kill(int pid, int signal);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr CreateJobObject(IntPtr jobAttributes, string? name);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetInformationJobObject(IntPtr job, int informationClass, IntPtr information, uint informationLength);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool AssignProcessToJobObject(IntPtr job, IntPtr process);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool TerminateJobObject(IntPtr job, uint exitCode);
+
+    private enum LifetimeMode {
+        UnixProcessGroup,
+        WindowsJob
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JobObjectBasicLimitInformation {
+        internal long PerProcessUserTimeLimit;
+        internal long PerJobUserTimeLimit;
+        internal uint LimitFlags;
+        internal UIntPtr MinimumWorkingSetSize;
+        internal UIntPtr MaximumWorkingSetSize;
+        internal uint ActiveProcessLimit;
+        internal UIntPtr Affinity;
+        internal uint PriorityClass;
+        internal uint SchedulingClass;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct IoCounters {
+        internal ulong ReadOperationCount;
+        internal ulong WriteOperationCount;
+        internal ulong OtherOperationCount;
+        internal ulong ReadTransferCount;
+        internal ulong WriteTransferCount;
+        internal ulong OtherTransferCount;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JobObjectExtendedLimitInformation {
+        internal JobObjectBasicLimitInformation BasicLimitInformation;
+        internal IoCounters IoInfo;
+        internal UIntPtr ProcessMemoryLimit;
+        internal UIntPtr JobMemoryLimit;
+        internal UIntPtr PeakProcessMemoryUsed;
+        internal UIntPtr PeakJobMemoryUsed;
+    }
+}

--- a/OfficeIMO.Reader.Ocr.Process/OfficeOcrProcessLifetime.cs
+++ b/OfficeIMO.Reader.Ocr.Process/OfficeOcrProcessLifetime.cs
@@ -50,24 +50,33 @@ internal sealed class OfficeOcrProcessLifetime : IDisposable {
             "Bounded OCR process execution requires a Windows Job Object, /usr/bin/setsid or /bin/setsid on Unix, or /usr/bin/perl with POSIX::setsid on macOS.");
     }
 
-    internal void Attach(System.Diagnostics.Process process) {
-        if (_mode == LifetimeMode.UnixProcessGroup) {
-            _processGroupId = process.Id;
-            return;
+    internal OfficeOcrStartedProcess Start(ProcessStartInfo startInfo) {
+        if (_mode == LifetimeMode.WindowsJob) {
+            return OfficeOcrWindowsSuspendedProcess.Start(startInfo, this);
         }
-        if (_mode != LifetimeMode.WindowsJob) return;
 
-        SafeFileHandle? job = TryCreateWindowsJob();
-        if (job == null) {
-            TryKillDirectProcess(process);
-            throw new InvalidOperationException("Unable to create the Windows Job Object required for bounded OCR process execution.");
+        var process = new System.Diagnostics.Process { StartInfo = startInfo, EnableRaisingEvents = true };
+        try {
+            if (!process.Start()) throw new InvalidOperationException("Failed to start OCR process '" + startInfo.FileName + "'.");
+            _processGroupId = process.Id;
+            return new OfficeOcrStartedProcess(process, process.StandardOutput, process.StandardError);
+        } catch {
+            process.Dispose();
+            throw;
         }
-        if (!AssignProcessToJobObject(job.DangerousGetHandle(), process.Handle)) {
-            job.Dispose();
-            TryKillDirectProcess(process);
-            throw new InvalidOperationException("Unable to assign the OCR process to the Windows Job Object required for bounded execution.");
-        }
-        _jobHandle = job;
+    }
+
+    internal void PrepareWindowsJob() {
+        if (_mode != LifetimeMode.WindowsJob) throw new InvalidOperationException("A Windows Job Object is not configured for this process.");
+        _jobHandle = TryCreateWindowsJob()
+            ?? throw new InvalidOperationException("Unable to create the Windows Job Object required for bounded OCR process execution.");
+    }
+
+    internal bool AssignSuspendedWindowsProcess(IntPtr processHandle) {
+        return _jobHandle != null
+            && !_jobHandle.IsInvalid
+            && !_jobHandle.IsClosed
+            && AssignProcessToJobObject(_jobHandle.DangerousGetHandle(), processHandle);
     }
 
     internal void Terminate(System.Diagnostics.Process process) {

--- a/OfficeIMO.Reader.Ocr.Process/OfficeOcrProcessRunner.cs
+++ b/OfficeIMO.Reader.Ocr.Process/OfficeOcrProcessRunner.cs
@@ -72,11 +72,10 @@ public static class OfficeOcrProcessRunner {
         }
 
         using OfficeOcrProcessLifetime processLifetime = OfficeOcrProcessLifetime.Configure(startInfo, command.FileName, arguments);
-        using var process = new System.Diagnostics.Process { StartInfo = startInfo, EnableRaisingEvents = true };
-        if (!process.Start()) throw new InvalidOperationException("Failed to start OCR process '" + command.FileName + "'.");
-        processLifetime.Attach(process);
-        Task<BoundedText> outputTask = ReadBoundedAsync(process.StandardOutput, command.MaxStandardOutputCharacters);
-        Task<BoundedText> errorTask = ReadBoundedAsync(process.StandardError, command.MaxStandardErrorCharacters);
+        using OfficeOcrStartedProcess startedProcess = processLifetime.Start(startInfo);
+        System.Diagnostics.Process process = startedProcess.Process;
+        Task<BoundedText> outputTask = ReadBoundedAsync(startedProcess.StandardOutput, command.MaxStandardOutputCharacters);
+        Task<BoundedText> errorTask = ReadBoundedAsync(startedProcess.StandardError, command.MaxStandardErrorCharacters);
         try {
             await WaitForExitAsync(process, linked.Token).ConfigureAwait(false);
             BoundedText[] streams = await WaitWithCancellationAsync(Task.WhenAll(outputTask, errorTask), linked.Token).ConfigureAwait(false);
@@ -89,13 +88,13 @@ public static class OfficeOcrProcessRunner {
             };
         } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && timeout.IsCancellationRequested) {
             processLifetime.Terminate(process);
-            CloseRedirectedStreams(process);
+            startedProcess.CloseRedirectedStreams();
             ObserveReadFailure(outputTask);
             ObserveReadFailure(errorTask);
             throw new TimeoutException("OCR process exceeded timeout " + command.Timeout + ".");
         } catch {
             processLifetime.Terminate(process);
-            CloseRedirectedStreams(process);
+            startedProcess.CloseRedirectedStreams();
             ObserveReadFailure(outputTask);
             ObserveReadFailure(errorTask);
             throw;
@@ -110,11 +109,6 @@ public static class OfficeOcrProcessRunner {
             if (completed != operation) throw new OperationCanceledException(cancellationToken);
         }
         return await operation.ConfigureAwait(false);
-    }
-
-    private static void CloseRedirectedStreams(System.Diagnostics.Process process) {
-        try { process.StandardOutput.Dispose(); } catch (InvalidOperationException) { }
-        try { process.StandardError.Dispose(); } catch (InvalidOperationException) { }
     }
 
     private static void ObserveReadFailure(Task operation) {

--- a/OfficeIMO.Reader.Ocr.Process/OfficeOcrProcessRunner.cs
+++ b/OfficeIMO.Reader.Ocr.Process/OfficeOcrProcessRunner.cs
@@ -76,22 +76,54 @@ public static class OfficeOcrProcessRunner {
         Task<BoundedText> errorTask = ReadBoundedAsync(process.StandardError, command.MaxStandardErrorCharacters);
         try {
             await WaitForExitAsync(process, linked.Token).ConfigureAwait(false);
+            BoundedText[] streams = await WaitWithCancellationAsync(Task.WhenAll(outputTask, errorTask), linked.Token).ConfigureAwait(false);
+            return new OfficeOcrProcessResult {
+                ExitCode = process.ExitCode,
+                StandardOutput = streams[0].Text,
+                StandardError = streams[1].Text,
+                StandardOutputTruncated = streams[0].Truncated,
+                StandardErrorTruncated = streams[1].Truncated
+            };
         } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && timeout.IsCancellationRequested) {
             TryKill(process);
+            CloseRedirectedStreams(process);
+            ObserveReadFailure(outputTask);
+            ObserveReadFailure(errorTask);
             throw new TimeoutException("OCR process exceeded timeout " + command.Timeout + ".");
         } catch {
             TryKill(process);
+            CloseRedirectedStreams(process);
+            ObserveReadFailure(outputTask);
+            ObserveReadFailure(errorTask);
             throw;
         }
+    }
 
-        BoundedText[] streams = await Task.WhenAll(outputTask, errorTask).ConfigureAwait(false);
-        return new OfficeOcrProcessResult {
-            ExitCode = process.ExitCode,
-            StandardOutput = streams[0].Text,
-            StandardError = streams[1].Text,
-            StandardOutputTruncated = streams[0].Truncated,
-            StandardErrorTruncated = streams[1].Truncated
-        };
+    private static async Task<T> WaitWithCancellationAsync<T>(Task<T> operation, CancellationToken cancellationToken) {
+        if (operation.IsCompleted) return await operation.ConfigureAwait(false);
+        var cancellation = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using (cancellationToken.Register(() => cancellation.TrySetResult(null))) {
+            Task completed = await Task.WhenAny(operation, cancellation.Task).ConfigureAwait(false);
+            if (completed != operation) throw new OperationCanceledException(cancellationToken);
+        }
+        return await operation.ConfigureAwait(false);
+    }
+
+    private static void CloseRedirectedStreams(System.Diagnostics.Process process) {
+        try { process.StandardOutput.Dispose(); } catch (InvalidOperationException) { }
+        try { process.StandardError.Dispose(); } catch (InvalidOperationException) { }
+    }
+
+    private static void ObserveReadFailure(Task operation) {
+        if (operation.IsCompleted) {
+            _ = operation.Exception;
+            return;
+        }
+        _ = operation.ContinueWith(
+            static completed => { _ = completed.Exception; },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnFaulted,
+            TaskScheduler.Default);
     }
 
     private static async Task<BoundedText> ReadBoundedAsync(TextReader reader, int maxCharacters) {

--- a/OfficeIMO.Reader.Ocr.Process/OfficeOcrProcessRunner.cs
+++ b/OfficeIMO.Reader.Ocr.Process/OfficeOcrProcessRunner.cs
@@ -57,9 +57,10 @@ public static class OfficeOcrProcessRunner {
         using var timeout = new CancellationTokenSource(command.Timeout);
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeout.Token);
 
+        IReadOnlyList<string> arguments = command.Arguments ?? Array.Empty<string>();
         var startInfo = new ProcessStartInfo {
             FileName = command.FileName,
-            Arguments = string.Join(" ", (command.Arguments ?? Array.Empty<string>()).Select(QuoteArgument)),
+            Arguments = string.Join(" ", arguments.Select(QuoteArgument)),
             UseShellExecute = false,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -70,8 +71,10 @@ public static class OfficeOcrProcessRunner {
             startInfo.EnvironmentVariables[variable.Key] = variable.Value;
         }
 
+        using OfficeOcrProcessLifetime processLifetime = OfficeOcrProcessLifetime.Configure(startInfo, command.FileName, arguments);
         using var process = new System.Diagnostics.Process { StartInfo = startInfo, EnableRaisingEvents = true };
         if (!process.Start()) throw new InvalidOperationException("Failed to start OCR process '" + command.FileName + "'.");
+        processLifetime.Attach(process);
         Task<BoundedText> outputTask = ReadBoundedAsync(process.StandardOutput, command.MaxStandardOutputCharacters);
         Task<BoundedText> errorTask = ReadBoundedAsync(process.StandardError, command.MaxStandardErrorCharacters);
         try {
@@ -85,13 +88,13 @@ public static class OfficeOcrProcessRunner {
                 StandardErrorTruncated = streams[1].Truncated
             };
         } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && timeout.IsCancellationRequested) {
-            TryKill(process);
+            processLifetime.Terminate(process);
             CloseRedirectedStreams(process);
             ObserveReadFailure(outputTask);
             ObserveReadFailure(errorTask);
             throw new TimeoutException("OCR process exceeded timeout " + command.Timeout + ".");
         } catch {
-            TryKill(process);
+            processLifetime.Terminate(process);
             CloseRedirectedStreams(process);
             ObserveReadFailure(outputTask);
             ObserveReadFailure(errorTask);
@@ -148,7 +151,6 @@ public static class OfficeOcrProcessRunner {
         handler = (_, _) => completion.TrySetResult(null);
         process.Exited += handler;
         registration = cancellationToken.Register(() => {
-            TryKill(process);
             completion.TrySetCanceled();
         });
         if (process.HasExited) completion.TrySetResult(null);
@@ -161,19 +163,6 @@ public static class OfficeOcrProcessRunner {
         } finally {
             process.Exited -= handler;
             registration.Dispose();
-        }
-    }
-
-    private static void TryKill(System.Diagnostics.Process process) {
-        try {
-            if (!process.HasExited) {
-#if NET8_0_OR_GREATER
-                process.Kill(entireProcessTree: true);
-#else
-                process.Kill();
-#endif
-            }
-        } catch (InvalidOperationException) {
         }
     }
 

--- a/OfficeIMO.Reader.Ocr.Process/OfficeOcrProcessRunner.cs
+++ b/OfficeIMO.Reader.Ocr.Process/OfficeOcrProcessRunner.cs
@@ -1,0 +1,183 @@
+using System.Diagnostics;
+
+namespace OfficeIMO.Reader.Ocr.Process;
+
+/// <summary>One direct executable invocation used by optional OCR providers.</summary>
+public sealed class OfficeOcrProcessCommand {
+    /// <summary>Executable path or name resolved by the operating system.</summary>
+    public string FileName { get; set; } = string.Empty;
+
+    /// <summary>Argument values passed directly to the executable without invoking a shell.</summary>
+    public IReadOnlyList<string> Arguments { get; set; } = Array.Empty<string>();
+
+    /// <summary>Optional working directory.</summary>
+    public string? WorkingDirectory { get; set; }
+
+    /// <summary>Optional environment values applied to the child process.</summary>
+    public IReadOnlyDictionary<string, string> EnvironmentVariables { get; set; } = new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <summary>Maximum process duration. Defaults to two minutes.</summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromMinutes(2);
+
+    /// <summary>Maximum retained standard-output characters. The stream is drained after the bound is reached.</summary>
+    public int MaxStandardOutputCharacters { get; set; } = 64 * 1024;
+
+    /// <summary>Maximum retained standard-error characters. The stream is drained after the bound is reached.</summary>
+    public int MaxStandardErrorCharacters { get; set; } = 64 * 1024;
+}
+
+/// <summary>Bounded output from one direct executable invocation.</summary>
+public sealed class OfficeOcrProcessResult {
+    /// <summary>Child process exit code.</summary>
+    public int ExitCode { get; set; }
+
+    /// <summary>Retained standard output.</summary>
+    public string StandardOutput { get; set; } = string.Empty;
+
+    /// <summary>Retained standard error.</summary>
+    public string StandardError { get; set; } = string.Empty;
+
+    /// <summary>Whether standard output exceeded its retention bound.</summary>
+    public bool StandardOutputTruncated { get; set; }
+
+    /// <summary>Whether standard error exceeded its retention bound.</summary>
+    public bool StandardErrorTruncated { get; set; }
+}
+
+/// <summary>Runs a configured executable directly with bounded output, timeout, and cancellation handling.</summary>
+public static class OfficeOcrProcessRunner {
+    /// <summary>Runs one process command without invoking a command shell.</summary>
+    public static async Task<OfficeOcrProcessResult> RunAsync(OfficeOcrProcessCommand command, CancellationToken cancellationToken = default) {
+        if (command == null) throw new ArgumentNullException(nameof(command));
+        if (string.IsNullOrWhiteSpace(command.FileName)) throw new ArgumentException("Process filename cannot be empty.", nameof(command));
+        if (command.Timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(command.Timeout));
+        if (command.MaxStandardOutputCharacters < 1) throw new ArgumentOutOfRangeException(nameof(command.MaxStandardOutputCharacters));
+        if (command.MaxStandardErrorCharacters < 1) throw new ArgumentOutOfRangeException(nameof(command.MaxStandardErrorCharacters));
+        cancellationToken.ThrowIfCancellationRequested();
+        using var timeout = new CancellationTokenSource(command.Timeout);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeout.Token);
+
+        var startInfo = new ProcessStartInfo {
+            FileName = command.FileName,
+            Arguments = string.Join(" ", (command.Arguments ?? Array.Empty<string>()).Select(QuoteArgument)),
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+        if (!string.IsNullOrWhiteSpace(command.WorkingDirectory)) startInfo.WorkingDirectory = command.WorkingDirectory;
+        foreach (KeyValuePair<string, string> variable in command.EnvironmentVariables ?? new Dictionary<string, string>()) {
+            startInfo.EnvironmentVariables[variable.Key] = variable.Value;
+        }
+
+        using var process = new System.Diagnostics.Process { StartInfo = startInfo, EnableRaisingEvents = true };
+        if (!process.Start()) throw new InvalidOperationException("Failed to start OCR process '" + command.FileName + "'.");
+        Task<BoundedText> outputTask = ReadBoundedAsync(process.StandardOutput, command.MaxStandardOutputCharacters);
+        Task<BoundedText> errorTask = ReadBoundedAsync(process.StandardError, command.MaxStandardErrorCharacters);
+        try {
+            await WaitForExitAsync(process, linked.Token).ConfigureAwait(false);
+        } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && timeout.IsCancellationRequested) {
+            TryKill(process);
+            throw new TimeoutException("OCR process exceeded timeout " + command.Timeout + ".");
+        } catch {
+            TryKill(process);
+            throw;
+        }
+
+        BoundedText[] streams = await Task.WhenAll(outputTask, errorTask).ConfigureAwait(false);
+        return new OfficeOcrProcessResult {
+            ExitCode = process.ExitCode,
+            StandardOutput = streams[0].Text,
+            StandardError = streams[1].Text,
+            StandardOutputTruncated = streams[0].Truncated,
+            StandardErrorTruncated = streams[1].Truncated
+        };
+    }
+
+    private static async Task<BoundedText> ReadBoundedAsync(TextReader reader, int maxCharacters) {
+        var builder = new StringBuilder(Math.Min(maxCharacters, 4096));
+        var buffer = new char[4096];
+        bool truncated = false;
+        while (true) {
+            int read = await reader.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
+            if (read == 0) break;
+            int remaining = maxCharacters - builder.Length;
+            if (remaining > 0) builder.Append(buffer, 0, Math.Min(remaining, read));
+            if (read > remaining) truncated = true;
+        }
+        return new BoundedText(builder.ToString(), truncated);
+    }
+
+    private static Task WaitForExitAsync(System.Diagnostics.Process process, CancellationToken cancellationToken) {
+        if (process.HasExited) return Task.CompletedTask;
+        var completion = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        EventHandler? handler = null;
+        CancellationTokenRegistration registration = default;
+        handler = (_, _) => completion.TrySetResult(null);
+        process.Exited += handler;
+        registration = cancellationToken.Register(() => {
+            TryKill(process);
+            completion.TrySetCanceled();
+        });
+        if (process.HasExited) completion.TrySetResult(null);
+        return CompleteAndCleanupAsync(completion.Task, process, handler, registration);
+    }
+
+    private static async Task CompleteAndCleanupAsync(Task task, System.Diagnostics.Process process, EventHandler handler, CancellationTokenRegistration registration) {
+        try {
+            await task.ConfigureAwait(false);
+        } finally {
+            process.Exited -= handler;
+            registration.Dispose();
+        }
+    }
+
+    private static void TryKill(System.Diagnostics.Process process) {
+        try {
+            if (!process.HasExited) {
+#if NET8_0_OR_GREATER
+                process.Kill(entireProcessTree: true);
+#else
+                process.Kill();
+#endif
+            }
+        } catch (InvalidOperationException) {
+        }
+    }
+
+    internal static string QuoteArgument(string value) {
+        if (value == null) return "\"\"";
+        if (value.Length > 0 && value.All(static ch => !char.IsWhiteSpace(ch) && ch != '\"')) return value;
+        var builder = new StringBuilder(value.Length + 2);
+        builder.Append('\"');
+        int slashes = 0;
+        foreach (char character in value) {
+            if (character == '\\') {
+                slashes++;
+                continue;
+            }
+            if (character == '\"') {
+                builder.Append('\\', (slashes * 2) + 1);
+                builder.Append('\"');
+                slashes = 0;
+                continue;
+            }
+            if (slashes > 0) builder.Append('\\', slashes);
+            slashes = 0;
+            builder.Append(character);
+        }
+        if (slashes > 0) builder.Append('\\', slashes * 2);
+        builder.Append('\"');
+        return builder.ToString();
+    }
+
+    private sealed class BoundedText {
+        internal BoundedText(string text, bool truncated) {
+            Text = text;
+            Truncated = truncated;
+        }
+
+        internal string Text { get; }
+        internal bool Truncated { get; }
+    }
+}

--- a/OfficeIMO.Reader.Ocr.Process/OfficeOcrStartedProcess.cs
+++ b/OfficeIMO.Reader.Ocr.Process/OfficeOcrStartedProcess.cs
@@ -1,0 +1,30 @@
+namespace OfficeIMO.Reader.Ocr.Process;
+
+/// <summary>Owns a started OCR process and its redirected readers.</summary>
+internal sealed class OfficeOcrStartedProcess : IDisposable {
+    private bool _disposed;
+
+    internal OfficeOcrStartedProcess(System.Diagnostics.Process process, TextReader standardOutput, TextReader standardError) {
+        Process = process;
+        StandardOutput = standardOutput;
+        StandardError = standardError;
+    }
+
+    internal System.Diagnostics.Process Process { get; }
+
+    internal TextReader StandardOutput { get; }
+
+    internal TextReader StandardError { get; }
+
+    internal void CloseRedirectedStreams() {
+        try { StandardOutput.Dispose(); } catch (ObjectDisposedException) { }
+        try { StandardError.Dispose(); } catch (ObjectDisposedException) { }
+    }
+
+    public void Dispose() {
+        if (_disposed) return;
+        _disposed = true;
+        CloseRedirectedStreams();
+        Process.Dispose();
+    }
+}

--- a/OfficeIMO.Reader.Ocr.Process/OfficeOcrTemporaryStorage.cs
+++ b/OfficeIMO.Reader.Ocr.Process/OfficeOcrTemporaryStorage.cs
@@ -1,0 +1,78 @@
+using Microsoft.Win32.SafeHandles;
+using System.Runtime.InteropServices;
+
+namespace OfficeIMO.Reader.Ocr.Process;
+
+/// <summary>Creates private per-request storage for OCR payloads and provider output.</summary>
+internal static class OfficeOcrTemporaryStorage {
+    private const uint OwnerDirectoryMode = 0x1C0; // 0700
+    private const uint OwnerFileMode = 0x180; // 0600
+
+    internal static string CreateRequestDirectory(string temporaryRoot, string prefix) {
+        Directory.CreateDirectory(temporaryRoot);
+        string requestDirectory = Path.Combine(temporaryRoot, prefix + Guid.NewGuid().ToString("N"));
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Directory.CreateDirectory(requestDirectory);
+            return requestDirectory;
+        }
+
+        if (CreateDirectory(requestDirectory, OwnerDirectoryMode) != 0) {
+            throw BuildIOException("create the private OCR request directory", Marshal.GetLastWin32Error());
+        }
+        if (ChangeMode(requestDirectory, OwnerDirectoryMode) == 0) return requestDirectory;
+
+        int error = Marshal.GetLastWin32Error();
+        TryDeleteDirectory(requestDirectory);
+        throw BuildIOException("set private permissions on the OCR request directory", error);
+    }
+
+    internal static void WriteAllBytes(string path, byte[] payload) {
+        if (payload == null) throw new ArgumentNullException(nameof(payload));
+        using FileStream stream = CreatePrivateFile(path);
+        stream.Write(payload, 0, payload.Length);
+    }
+
+    internal static void EnsurePrivateFile(string path) {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        if (ChangeMode(path, OwnerFileMode) != 0) {
+            throw BuildIOException("set private permissions on an OCR temporary file", Marshal.GetLastWin32Error());
+        }
+    }
+
+    private static FileStream CreatePrivateFile(string path) {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            return new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+        }
+
+        int descriptor = CreateFile(path, OwnerFileMode);
+        if (descriptor < 0) throw BuildIOException("create a private OCR temporary file", Marshal.GetLastWin32Error());
+        var handle = new SafeFileHandle(new IntPtr(descriptor), ownsHandle: true);
+        try {
+            return new FileStream(handle, FileAccess.Write);
+        } catch {
+            handle.Dispose();
+            throw;
+        }
+    }
+
+    private static IOException BuildIOException(string operation, int error) {
+        return new IOException("Unable to " + operation + " (OS error " + error + ").");
+    }
+
+    private static void TryDeleteDirectory(string path) {
+        try {
+            if (Directory.Exists(path)) Directory.Delete(path, recursive: true);
+        } catch (IOException) {
+        } catch (UnauthorizedAccessException) {
+        }
+    }
+
+    [DllImport("libc", EntryPoint = "mkdir", SetLastError = true)]
+    private static extern int CreateDirectory(string path, uint mode);
+
+    [DllImport("libc", EntryPoint = "creat", SetLastError = true)]
+    private static extern int CreateFile(string path, uint mode);
+
+    [DllImport("libc", EntryPoint = "chmod", SetLastError = true)]
+    private static extern int ChangeMode(string path, uint mode);
+}

--- a/OfficeIMO.Reader.Ocr.Process/OfficeOcrWindowsSuspendedProcess.cs
+++ b/OfficeIMO.Reader.Ocr.Process/OfficeOcrWindowsSuspendedProcess.cs
@@ -1,0 +1,306 @@
+using Microsoft.Win32.SafeHandles;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace OfficeIMO.Reader.Ocr.Process;
+
+/// <summary>Creates a Windows OCR process suspended so it cannot escape its Job Object before assignment.</summary>
+internal static class OfficeOcrWindowsSuspendedProcess {
+    private const uint CreateNoWindow = 0x08000000;
+    private const uint CreateSuspended = 0x00000004;
+    private const uint CreateUnicodeEnvironment = 0x00000400;
+    private const uint ExtendedStartupInfoPresent = 0x00080000;
+    private const uint HandleFlagInherit = 0x00000001;
+    private const int ProcThreadAttributeHandleList = 0x00020002;
+    private const uint StartfUseStdHandles = 0x00000100;
+
+    internal static OfficeOcrStartedProcess Start(System.Diagnostics.ProcessStartInfo startInfo, OfficeOcrProcessLifetime lifetime) {
+        lifetime.PrepareWindowsJob();
+        CreatePipePair(out SafeFileHandle outputRead, out SafeFileHandle outputWrite);
+        using (outputWrite)
+        using (outputRead) {
+            CreatePipePair(out SafeFileHandle errorRead, out SafeFileHandle errorWrite);
+            using (errorWrite)
+            using (errorRead) {
+                CreateInputPipePair(out SafeFileHandle inputRead, out SafeFileHandle inputWrite);
+                using (inputRead)
+                using (inputWrite) {
+                    using ProcessAttributeList attributes = ProcessAttributeList.Create(new[] {
+                        inputRead.DangerousGetHandle(),
+                        outputWrite.DangerousGetHandle(),
+                        errorWrite.DangerousGetHandle()
+                    });
+                    var startupInfo = new StartupInfoEx {
+                        StartupInfo = new StartupInfo {
+                            Size = Marshal.SizeOf<StartupInfoEx>(),
+                            Flags = StartfUseStdHandles,
+                            StandardInput = inputRead.DangerousGetHandle(),
+                            StandardOutput = outputWrite.DangerousGetHandle(),
+                            StandardError = errorWrite.DangerousGetHandle()
+                        },
+                        AttributeList = attributes.Pointer
+                    };
+                    var commandLine = new StringBuilder(OfficeOcrProcessRunner.QuoteArgument(startInfo.FileName)
+                        + (string.IsNullOrWhiteSpace(startInfo.Arguments) ? string.Empty : " " + startInfo.Arguments));
+                    IntPtr environment = BuildEnvironmentBlock(startInfo);
+                    ProcessInformation processInformation = default;
+                    try {
+                        if (!CreateProcess(
+                            null,
+                            commandLine,
+                            IntPtr.Zero,
+                            IntPtr.Zero,
+                            inheritHandles: true,
+                            CreateSuspended | CreateNoWindow | CreateUnicodeEnvironment | ExtendedStartupInfoPresent,
+                            environment,
+                            string.IsNullOrWhiteSpace(startInfo.WorkingDirectory) ? null : startInfo.WorkingDirectory,
+                            ref startupInfo,
+                            out processInformation)) {
+                            throw new Win32Exception(Marshal.GetLastWin32Error(), "Unable to create the suspended OCR process.");
+                        }
+
+                        using var processHandle = new SafeFileHandle(processInformation.Process, ownsHandle: true);
+                        using var threadHandle = new SafeFileHandle(processInformation.Thread, ownsHandle: true);
+                        if (!lifetime.AssignSuspendedWindowsProcess(processHandle.DangerousGetHandle())) {
+                            int error = Marshal.GetLastWin32Error();
+                            _ = TerminateProcess(processHandle.DangerousGetHandle(), 1);
+                            throw new Win32Exception(error, "Unable to assign the suspended OCR process to its Windows Job Object.");
+                        }
+
+                        System.Diagnostics.Process process;
+                        try {
+                            process = System.Diagnostics.Process.GetProcessById(unchecked((int)processInformation.ProcessId));
+                            process.EnableRaisingEvents = true;
+                        } catch {
+                            _ = TerminateProcess(processHandle.DangerousGetHandle(), 1);
+                            throw;
+                        }
+
+                        if (ResumeThread(threadHandle.DangerousGetHandle()) == uint.MaxValue) {
+                            int error = Marshal.GetLastWin32Error();
+                            _ = TerminateProcess(processHandle.DangerousGetHandle(), 1);
+                            process.Dispose();
+                            throw new Win32Exception(error, "Unable to resume the OCR process after Job Object assignment.");
+                        }
+
+                        var output = new StreamReader(
+                            new FileStream(TransferOwnership(outputRead), FileAccess.Read, 4096, isAsync: false),
+                            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false),
+                            detectEncodingFromByteOrderMarks: true);
+                        var errorReader = new StreamReader(
+                            new FileStream(TransferOwnership(errorRead), FileAccess.Read, 4096, isAsync: false),
+                            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false),
+                            detectEncodingFromByteOrderMarks: true);
+                        return new OfficeOcrStartedProcess(process, output, errorReader);
+                    } finally {
+                        if (environment != IntPtr.Zero) Marshal.FreeHGlobal(environment);
+                    }
+                }
+            }
+        }
+    }
+
+    private static SafeFileHandle TransferOwnership(SafeFileHandle source) {
+        IntPtr handle = source.DangerousGetHandle();
+        source.SetHandleAsInvalid();
+        return new SafeFileHandle(handle, ownsHandle: true);
+    }
+
+    private static void CreatePipePair(out SafeFileHandle read, out SafeFileHandle write) {
+        var securityAttributes = new SecurityAttributes {
+            Length = Marshal.SizeOf<SecurityAttributes>(),
+            InheritHandle = true
+        };
+        if (!CreatePipe(out read, out write, ref securityAttributes, 0)) {
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "Unable to create an OCR process pipe.");
+        }
+        if (!SetHandleInformation(read.DangerousGetHandle(), HandleFlagInherit, 0)) {
+            int error = Marshal.GetLastWin32Error();
+            read.Dispose();
+            write.Dispose();
+            throw new Win32Exception(error, "Unable to restrict OCR process pipe inheritance.");
+        }
+    }
+
+    private static void CreateInputPipePair(out SafeFileHandle read, out SafeFileHandle write) {
+        var securityAttributes = new SecurityAttributes {
+            Length = Marshal.SizeOf<SecurityAttributes>(),
+            InheritHandle = true
+        };
+        if (!CreatePipe(out read, out write, ref securityAttributes, 0)) {
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "Unable to create an OCR process input pipe.");
+        }
+        if (!SetHandleInformation(write.DangerousGetHandle(), HandleFlagInherit, 0)) {
+            int error = Marshal.GetLastWin32Error();
+            read.Dispose();
+            write.Dispose();
+            throw new Win32Exception(error, "Unable to restrict OCR process input-pipe inheritance.");
+        }
+    }
+
+    private static IntPtr BuildEnvironmentBlock(System.Diagnostics.ProcessStartInfo startInfo) {
+        string[] keys = startInfo.EnvironmentVariables.Keys.Cast<string>()
+            .OrderBy(static key => key, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var block = new StringBuilder();
+        foreach (string key in keys) {
+            block.Append(key).Append('=').Append(startInfo.EnvironmentVariables[key]).Append('\0');
+        }
+        if (keys.Length == 0) block.Append('\0');
+        return Marshal.StringToHGlobalUni(block.ToString());
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CreatePipe(out SafeFileHandle readPipe, out SafeFileHandle writePipe, ref SecurityAttributes pipeAttributes, uint size);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetHandleInformation(IntPtr handle, uint mask, uint flags);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CreateProcess(
+        string? applicationName,
+        [In, Out] StringBuilder commandLine,
+        IntPtr processAttributes,
+        IntPtr threadAttributes,
+        [MarshalAs(UnmanagedType.Bool)] bool inheritHandles,
+        uint creationFlags,
+        IntPtr environment,
+        string? currentDirectory,
+        ref StartupInfoEx startupInfo,
+        out ProcessInformation processInformation);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool InitializeProcThreadAttributeList(
+        IntPtr attributeList,
+        int attributeCount,
+        int flags,
+        ref IntPtr size);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool UpdateProcThreadAttribute(
+        IntPtr attributeList,
+        uint flags,
+        IntPtr attribute,
+        IntPtr value,
+        IntPtr size,
+        IntPtr previousValue,
+        IntPtr returnSize);
+
+    [DllImport("kernel32.dll")]
+    private static extern void DeleteProcThreadAttributeList(IntPtr attributeList);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern uint ResumeThread(IntPtr thread);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool TerminateProcess(IntPtr process, uint exitCode);
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct StartupInfo {
+        internal int Size;
+        internal string? Reserved;
+        internal string? Desktop;
+        internal string? Title;
+        internal uint X;
+        internal uint Y;
+        internal uint XSize;
+        internal uint YSize;
+        internal uint XCountChars;
+        internal uint YCountChars;
+        internal uint FillAttribute;
+        internal uint Flags;
+        internal ushort ShowWindow;
+        internal ushort Reserved2;
+        internal IntPtr Reserved2Pointer;
+        internal IntPtr StandardInput;
+        internal IntPtr StandardOutput;
+        internal IntPtr StandardError;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct StartupInfoEx {
+        internal StartupInfo StartupInfo;
+        internal IntPtr AttributeList;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct ProcessInformation {
+        internal IntPtr Process;
+        internal IntPtr Thread;
+        internal uint ProcessId;
+        internal uint ThreadId;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SecurityAttributes {
+        internal int Length;
+        internal IntPtr SecurityDescriptor;
+        [MarshalAs(UnmanagedType.Bool)] internal bool InheritHandle;
+    }
+
+    private sealed class ProcessAttributeList : IDisposable {
+        private IntPtr _handleList;
+
+        private ProcessAttributeList(IntPtr pointer, IntPtr handleList) {
+            Pointer = pointer;
+            _handleList = handleList;
+        }
+
+        internal IntPtr Pointer { get; private set; }
+
+        internal static ProcessAttributeList Create(IReadOnlyList<IntPtr> handles) {
+            IntPtr size = IntPtr.Zero;
+            _ = InitializeProcThreadAttributeList(IntPtr.Zero, 1, 0, ref size);
+            if (size == IntPtr.Zero) {
+                throw new Win32Exception(Marshal.GetLastWin32Error(), "Unable to size the OCR process attribute list.");
+            }
+
+            IntPtr attributes = Marshal.AllocHGlobal(size);
+            IntPtr handleList = Marshal.AllocHGlobal(IntPtr.Size * handles.Count);
+            bool initialized = false;
+            try {
+                if (!InitializeProcThreadAttributeList(attributes, 1, 0, ref size)) {
+                    throw new Win32Exception(Marshal.GetLastWin32Error(), "Unable to initialize the OCR process attribute list.");
+                }
+                initialized = true;
+                for (int index = 0; index < handles.Count; index++) {
+                    Marshal.WriteIntPtr(handleList, index * IntPtr.Size, handles[index]);
+                }
+                if (!UpdateProcThreadAttribute(
+                    attributes,
+                    0,
+                    new IntPtr(ProcThreadAttributeHandleList),
+                    handleList,
+                    new IntPtr(IntPtr.Size * handles.Count),
+                    IntPtr.Zero,
+                    IntPtr.Zero)) {
+                    throw new Win32Exception(Marshal.GetLastWin32Error(), "Unable to restrict inherited OCR process handles.");
+                }
+                return new ProcessAttributeList(attributes, handleList);
+            } catch {
+                if (initialized) DeleteProcThreadAttributeList(attributes);
+                Marshal.FreeHGlobal(attributes);
+                Marshal.FreeHGlobal(handleList);
+                throw;
+            }
+        }
+
+        public void Dispose() {
+            if (Pointer != IntPtr.Zero) {
+                DeleteProcThreadAttributeList(Pointer);
+                Marshal.FreeHGlobal(Pointer);
+                Pointer = IntPtr.Zero;
+            }
+            if (_handleList != IntPtr.Zero) {
+                Marshal.FreeHGlobal(_handleList);
+                _handleList = IntPtr.Zero;
+            }
+        }
+    }
+}

--- a/OfficeIMO.Reader.Ocr.Process/ProcessOfficeOcrEngine.cs
+++ b/OfficeIMO.Reader.Ocr.Process/ProcessOfficeOcrEngine.cs
@@ -1,0 +1,168 @@
+using OfficeIMO.Reader;
+
+namespace OfficeIMO.Reader.Ocr.Process;
+
+/// <summary>Runs an external executable that implements the OfficeIMO OCR JSON file protocol.</summary>
+public sealed class ProcessOfficeOcrEngine : IOfficeOcrEngine {
+    private readonly OptionsSnapshot _options;
+
+    /// <summary>Creates a process-backed OCR engine from an immutable option snapshot.</summary>
+    public ProcessOfficeOcrEngine(ProcessOfficeOcrEngineOptions options) {
+        _options = OptionsSnapshot.Create(options);
+    }
+
+    /// <inheritdoc />
+    public string Id => _options.Id;
+
+    /// <inheritdoc />
+    public OfficeOcrEngineCapabilities Capabilities => _options.Capabilities.Clone();
+
+    /// <inheritdoc />
+    public async ValueTask<OfficeOcrEngineResult> RecognizeAsync(OfficeOcrEngineRequest request, CancellationToken cancellationToken = default) {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+        if (request.Payload == null || request.Payload.Length == 0) throw new ArgumentException("OCR request payload cannot be empty.", nameof(request));
+        if (request.Payload.LongLength > _options.MaxInputBytes) throw new IOException("OCR request payload exceeds MaxInputBytes (" + _options.MaxInputBytes + ").");
+        cancellationToken.ThrowIfCancellationRequested();
+        string temporaryRoot = Path.GetFullPath(_options.TemporaryDirectory ?? Path.GetTempPath());
+        string requestDirectory = Path.Combine(temporaryRoot, "officeimo-ocr-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(requestDirectory);
+        try {
+            string inputPath = Path.Combine(requestDirectory, "input" + OfficeOcrProcessFileNames.GetSafeAssetExtension(request.Asset));
+            string requestPath = Path.Combine(requestDirectory, "request.json");
+            string outputPath = Path.Combine(requestDirectory, "result.json");
+            File.WriteAllBytes(inputPath, request.Payload);
+            var processRequest = new ProcessOfficeOcrRequest {
+                CandidateId = request.Candidate.Id,
+                CandidateKind = request.Candidate.Kind,
+                AssetId = request.Asset.Id,
+                MediaType = request.Asset.MediaType,
+                SourcePath = request.Source.Path,
+                InputPath = inputPath,
+                OutputPath = outputPath,
+                Language = request.Language,
+                Location = request.Candidate.Location,
+                Region = request.Candidate.Region,
+                ProviderOptions = request.ProviderOptions
+            };
+            File.WriteAllText(requestPath, ProcessOfficeOcrProtocol.SerializeRequest(processRequest, indented: true), new UTF8Encoding(false));
+            IReadOnlyList<string> arguments = _options.Arguments.Select(argument => ExpandArgument(argument, processRequest, requestPath)).ToArray();
+            OfficeOcrProcessResult processResult = await OfficeOcrProcessRunner.RunAsync(new OfficeOcrProcessCommand {
+                FileName = _options.FileName,
+                Arguments = arguments,
+                WorkingDirectory = _options.WorkingDirectory,
+                EnvironmentVariables = _options.EnvironmentVariables,
+                Timeout = _options.Timeout,
+                MaxStandardOutputCharacters = _options.MaxProcessOutputCharacters,
+                MaxStandardErrorCharacters = _options.MaxProcessOutputCharacters
+            }, cancellationToken).ConfigureAwait(false);
+            if (processResult.ExitCode != 0) {
+                throw new InvalidOperationException("OCR process exited with code " + processResult.ExitCode + ": " + processResult.StandardError);
+            }
+            if (!File.Exists(outputPath)) throw new FileNotFoundException("OCR process did not create its response file.", outputPath);
+            long outputLength = new FileInfo(outputPath).Length;
+            if (outputLength > _options.MaxOutputBytes) throw new IOException("OCR process response exceeds MaxOutputBytes (" + _options.MaxOutputBytes + ").");
+            OfficeOcrEngineResult result = ProcessOfficeOcrProtocol.DeserializeResult(File.ReadAllText(outputPath, Encoding.UTF8));
+            if (string.IsNullOrWhiteSpace(result.Provider)) result.Provider = Id;
+            if (!string.IsNullOrWhiteSpace(processResult.StandardError)) {
+                result.Diagnostics = (result.Diagnostics ?? Array.Empty<OfficeDocumentDiagnostic>()).Concat(new[] {
+                    new OfficeDocumentDiagnostic {
+                        Severity = OfficeDocumentDiagnosticSeverity.Warning,
+                        Category = OfficeDocumentDiagnosticCategory.Ocr,
+                        Code = "ocr-process-stderr",
+                        Message = processResult.StandardError,
+                        Source = Id,
+                        IsRecoverable = true,
+                        Location = request.Candidate.Location,
+                        Attributes = new Dictionary<string, string>(StringComparer.Ordinal) {
+                            ["truncated"] = processResult.StandardErrorTruncated ? "true" : "false"
+                        }
+                    }
+                }).ToArray();
+            }
+            if (processResult.StandardOutputTruncated) {
+                result.Diagnostics = (result.Diagnostics ?? Array.Empty<OfficeDocumentDiagnostic>()).Concat(new[] {
+                    new OfficeDocumentDiagnostic {
+                        Severity = OfficeDocumentDiagnosticSeverity.Warning,
+                        Category = OfficeDocumentDiagnosticCategory.Limit,
+                        Code = "ocr-process-stdout-limit",
+                        Message = "OCR process standard output exceeded its configured retention limit.",
+                        Source = Id,
+                        IsRecoverable = true,
+                        Location = request.Candidate.Location
+                    }
+                }).ToArray();
+            }
+            return result;
+        } finally {
+            if (!_options.KeepTemporaryFiles) TryDeleteDirectory(requestDirectory);
+        }
+    }
+
+    private static string ExpandArgument(string value, ProcessOfficeOcrRequest request, string requestPath) {
+        return (value ?? string.Empty)
+            .Replace("{request}", requestPath)
+            .Replace("{input}", request.InputPath)
+            .Replace("{output}", request.OutputPath)
+            .Replace("{language}", request.Language ?? string.Empty)
+            .Replace("{candidateId}", request.CandidateId)
+            .Replace("{assetId}", request.AssetId);
+    }
+
+    private static void TryDeleteDirectory(string path) {
+        try {
+            if (Directory.Exists(path)) Directory.Delete(path, recursive: true);
+        } catch (IOException) {
+        } catch (UnauthorizedAccessException) {
+        }
+    }
+
+    private sealed class OptionsSnapshot {
+        internal string FileName { get; private set; } = string.Empty;
+        internal IReadOnlyList<string> Arguments { get; private set; } = Array.Empty<string>();
+        internal string Id { get; private set; } = string.Empty;
+        internal string? WorkingDirectory { get; private set; }
+        internal IReadOnlyDictionary<string, string> EnvironmentVariables { get; private set; } = new Dictionary<string, string>();
+        internal string? TemporaryDirectory { get; private set; }
+        internal TimeSpan Timeout { get; private set; }
+        internal long MaxOutputBytes { get; private set; }
+        internal long MaxInputBytes { get; private set; }
+        internal int MaxProcessOutputCharacters { get; private set; }
+        internal bool KeepTemporaryFiles { get; private set; }
+        internal OfficeOcrEngineCapabilities Capabilities { get; private set; } = new OfficeOcrEngineCapabilities();
+
+        internal static OptionsSnapshot Create(ProcessOfficeOcrEngineOptions options) {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            if (string.IsNullOrWhiteSpace(options.FileName)) throw new ArgumentException("OCR process filename cannot be empty.", nameof(options));
+            if (string.IsNullOrWhiteSpace(options.Id)) throw new ArgumentException("OCR process id cannot be empty.", nameof(options));
+            if (options.Timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(options.Timeout));
+            if (options.MaxOutputBytes < 1) throw new ArgumentOutOfRangeException(nameof(options.MaxOutputBytes));
+            if (options.MaxInputBytes < 1) throw new ArgumentOutOfRangeException(nameof(options.MaxInputBytes));
+            if (options.MaxProcessOutputCharacters < 1) throw new ArgumentOutOfRangeException(nameof(options.MaxProcessOutputCharacters));
+            OfficeOcrEngineCapabilities capabilities = options.Capabilities ?? new OfficeOcrEngineCapabilities();
+            return new OptionsSnapshot {
+                FileName = options.FileName.Trim(),
+                Arguments = (options.Arguments ?? Array.Empty<string>()).ToArray(),
+                Id = options.Id.Trim(),
+                WorkingDirectory = string.IsNullOrWhiteSpace(options.WorkingDirectory) ? null : options.WorkingDirectory,
+                EnvironmentVariables = options.EnvironmentVariables == null
+                    ? new Dictionary<string, string>(StringComparer.Ordinal)
+                    : options.EnvironmentVariables.ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal),
+                TemporaryDirectory = string.IsNullOrWhiteSpace(options.TemporaryDirectory) ? null : options.TemporaryDirectory,
+                Timeout = options.Timeout,
+                MaxOutputBytes = options.MaxOutputBytes,
+                MaxInputBytes = options.MaxInputBytes,
+                MaxProcessOutputCharacters = options.MaxProcessOutputCharacters,
+                KeepTemporaryFiles = options.KeepTemporaryFiles,
+                Capabilities = new OfficeOcrEngineCapabilities {
+                    SupportedMediaTypes = (capabilities.SupportedMediaTypes ?? Array.Empty<string>()).ToArray(),
+                    SupportedLanguages = (capabilities.SupportedLanguages ?? Array.Empty<string>()).ToArray(),
+                    SupportsLineSpans = capabilities.SupportsLineSpans,
+                    SupportsWordSpans = capabilities.SupportsWordSpans,
+                    SupportsCharacterSpans = capabilities.SupportsCharacterSpans,
+                    SupportsConfidence = capabilities.SupportsConfidence,
+                    SupportsConcurrentRequests = capabilities.SupportsConcurrentRequests
+                }
+            };
+        }
+    }
+}

--- a/OfficeIMO.Reader.Ocr.Process/ProcessOfficeOcrEngine.cs
+++ b/OfficeIMO.Reader.Ocr.Process/ProcessOfficeOcrEngine.cs
@@ -24,13 +24,12 @@ public sealed class ProcessOfficeOcrEngine : IOfficeOcrEngine {
         if (request.Payload.LongLength > _options.MaxInputBytes) throw new IOException("OCR request payload exceeds MaxInputBytes (" + _options.MaxInputBytes + ").");
         cancellationToken.ThrowIfCancellationRequested();
         string temporaryRoot = Path.GetFullPath(_options.TemporaryDirectory ?? Path.GetTempPath());
-        string requestDirectory = Path.Combine(temporaryRoot, "officeimo-ocr-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(requestDirectory);
+        string requestDirectory = OfficeOcrTemporaryStorage.CreateRequestDirectory(temporaryRoot, "officeimo-ocr-");
         try {
             string inputPath = Path.Combine(requestDirectory, "input" + OfficeOcrProcessFileNames.GetSafeAssetExtension(request.Asset));
             string requestPath = Path.Combine(requestDirectory, "request.json");
             string outputPath = Path.Combine(requestDirectory, "result.json");
-            File.WriteAllBytes(inputPath, request.Payload);
+            OfficeOcrTemporaryStorage.WriteAllBytes(inputPath, request.Payload);
             var processRequest = new ProcessOfficeOcrRequest {
                 CandidateId = request.Candidate.Id,
                 CandidateKind = request.Candidate.Kind,
@@ -44,7 +43,9 @@ public sealed class ProcessOfficeOcrEngine : IOfficeOcrEngine {
                 Region = request.Candidate.Region,
                 ProviderOptions = request.ProviderOptions
             };
-            File.WriteAllText(requestPath, ProcessOfficeOcrProtocol.SerializeRequest(processRequest, indented: true), new UTF8Encoding(false));
+            OfficeOcrTemporaryStorage.WriteAllBytes(
+                requestPath,
+                new UTF8Encoding(false).GetBytes(ProcessOfficeOcrProtocol.SerializeRequest(processRequest, indented: true)));
             IReadOnlyList<string> arguments = _options.Arguments.Select(argument => ExpandArgument(argument, processRequest, requestPath)).ToArray();
             OfficeOcrProcessResult processResult = await OfficeOcrProcessRunner.RunAsync(new OfficeOcrProcessCommand {
                 FileName = _options.FileName,
@@ -59,6 +60,7 @@ public sealed class ProcessOfficeOcrEngine : IOfficeOcrEngine {
                 throw new InvalidOperationException("OCR process exited with code " + processResult.ExitCode + ": " + processResult.StandardError);
             }
             if (!File.Exists(outputPath)) throw new FileNotFoundException("OCR process did not create its response file.", outputPath);
+            OfficeOcrTemporaryStorage.EnsurePrivateFile(outputPath);
             long outputLength = new FileInfo(outputPath).Length;
             if (outputLength > _options.MaxOutputBytes) throw new IOException("OCR process response exceeds MaxOutputBytes (" + _options.MaxOutputBytes + ").");
             OfficeOcrEngineResult result = ProcessOfficeOcrProtocol.DeserializeResult(File.ReadAllText(outputPath, Encoding.UTF8));

--- a/OfficeIMO.Reader.Ocr.Process/ProcessOfficeOcrEngineOptions.cs
+++ b/OfficeIMO.Reader.Ocr.Process/ProcessOfficeOcrEngineOptions.cs
@@ -1,0 +1,51 @@
+using OfficeIMO.Reader;
+
+namespace OfficeIMO.Reader.Ocr.Process;
+
+/// <summary>Configures the generic JSON file-protocol OCR process engine.</summary>
+public sealed class ProcessOfficeOcrEngineOptions {
+    /// <summary>Direct executable path or name. Required.</summary>
+    public string FileName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Argument templates. Supported placeholders are <c>{request}</c>, <c>{input}</c>, <c>{output}</c>,
+    /// <c>{language}</c>, <c>{candidateId}</c>, and <c>{assetId}</c>.
+    /// </summary>
+    public IReadOnlyList<string> Arguments { get; set; } = new[] { "{request}" };
+
+    /// <summary>Stable engine identifier. Defaults to <c>process</c>.</summary>
+    public string Id { get; set; } = "process";
+
+    /// <summary>Optional working directory for the executable.</summary>
+    public string? WorkingDirectory { get; set; }
+
+    /// <summary>Optional environment values applied to the child process.</summary>
+    public IReadOnlyDictionary<string, string> EnvironmentVariables { get; set; } = new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <summary>Optional parent directory for isolated per-request temporary folders.</summary>
+    public string? TemporaryDirectory { get; set; }
+
+    /// <summary>Maximum process duration. Defaults to two minutes.</summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromMinutes(2);
+
+    /// <summary>Maximum JSON response size. Defaults to 16 MiB.</summary>
+    public long MaxOutputBytes { get; set; } = 16L * 1024L * 1024L;
+
+    /// <summary>Maximum input payload size accepted by direct engine calls. Defaults to 25 MiB.</summary>
+    public long MaxInputBytes { get; set; } = 25L * 1024L * 1024L;
+
+    /// <summary>Maximum retained standard-output and standard-error characters.</summary>
+    public int MaxProcessOutputCharacters { get; set; } = 64 * 1024;
+
+    /// <summary>Whether isolated temporary files are retained after recognition.</summary>
+    public bool KeepTemporaryFiles { get; set; }
+
+    /// <summary>Capabilities advertised by the external protocol implementation.</summary>
+    public OfficeOcrEngineCapabilities Capabilities { get; set; } = new OfficeOcrEngineCapabilities {
+        SupportsLineSpans = true,
+        SupportsWordSpans = true,
+        SupportsCharacterSpans = true,
+        SupportsConfidence = true,
+        SupportsConcurrentRequests = true
+    };
+}

--- a/OfficeIMO.Reader.Ocr.Process/ProcessOfficeOcrProtocol.cs
+++ b/OfficeIMO.Reader.Ocr.Process/ProcessOfficeOcrProtocol.cs
@@ -90,11 +90,23 @@ public static class ProcessOfficeOcrProtocol {
     /// <summary>Deserializes an engine result from the process response file.</summary>
     public static OfficeOcrEngineResult DeserializeResult(string json) {
         if (json == null) throw new ArgumentNullException(nameof(json));
+        using (JsonDocument document = JsonDocument.Parse(json)) {
+            if (document.RootElement.ValueKind != JsonValueKind.Object) throw new InvalidDataException("OCR process response must be a JSON object.");
+            if (!HasProperty(document.RootElement, "schemaId")) throw new InvalidDataException("OCR process response did not contain schemaId.");
+            if (!HasProperty(document.RootElement, "schemaVersion")) throw new InvalidDataException("OCR process response did not contain schemaVersion.");
+        }
         ProcessOfficeOcrResponse? response = JsonSerializer.Deserialize<ProcessOfficeOcrResponse>(json, JsonOptions);
         if (response == null) throw new InvalidDataException("OCR process response was empty.");
         if (!string.Equals(response.SchemaId, ResponseSchemaId, StringComparison.Ordinal)) throw new InvalidDataException("OCR process response schema id is not supported.");
         if (response.SchemaVersion != Version) throw new InvalidDataException("OCR process response schema version is not supported.");
         return response.Result ?? throw new InvalidDataException("OCR process response did not contain an engine result.");
+    }
+
+    private static bool HasProperty(JsonElement element, string name) {
+        foreach (JsonProperty property in element.EnumerateObject()) {
+            if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase)) return true;
+        }
+        return false;
     }
 
     private static JsonSerializerOptions CreateOptions() {

--- a/OfficeIMO.Reader.Ocr.Process/ProcessOfficeOcrProtocol.cs
+++ b/OfficeIMO.Reader.Ocr.Process/ProcessOfficeOcrProtocol.cs
@@ -1,0 +1,108 @@
+using OfficeIMO.Reader;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OfficeIMO.Reader.Ocr.Process;
+
+/// <summary>Portable request file written for an external OCR process.</summary>
+public sealed class ProcessOfficeOcrRequest {
+    /// <summary>Protocol schema identifier.</summary>
+    public string SchemaId { get; set; } = ProcessOfficeOcrProtocol.RequestSchemaId;
+
+    /// <summary>Protocol schema version.</summary>
+    public int SchemaVersion { get; set; } = ProcessOfficeOcrProtocol.Version;
+
+    /// <summary>Candidate identifier.</summary>
+    public string CandidateId { get; set; } = string.Empty;
+
+    /// <summary>Candidate kind.</summary>
+    public string CandidateKind { get; set; } = string.Empty;
+
+    /// <summary>Asset identifier.</summary>
+    public string AssetId { get; set; } = string.Empty;
+
+    /// <summary>Asset media type.</summary>
+    public string? MediaType { get; set; }
+
+    /// <summary>Source document path or logical name.</summary>
+    public string? SourcePath { get; set; }
+
+    /// <summary>Absolute path to the materialized input payload.</summary>
+    public string InputPath { get; set; } = string.Empty;
+
+    /// <summary>Absolute path where the process must write an <see cref="OfficeOcrEngineResult"/> JSON object.</summary>
+    public string OutputPath { get; set; } = string.Empty;
+
+    /// <summary>Requested language expression.</summary>
+    public string? Language { get; set; }
+
+    /// <summary>Candidate source location.</summary>
+    public ReaderLocation Location { get; set; } = new ReaderLocation();
+
+    /// <summary>Candidate source region.</summary>
+    public OfficeDocumentRegion? Region { get; set; }
+
+    /// <summary>Provider-specific scalar options.</summary>
+    public IReadOnlyDictionary<string, string> ProviderOptions { get; set; } = new Dictionary<string, string>(StringComparer.Ordinal);
+}
+
+/// <summary>Versioned response file written by an external OCR process.</summary>
+public sealed class ProcessOfficeOcrResponse {
+    /// <summary>Protocol response schema identifier.</summary>
+    public string SchemaId { get; set; } = ProcessOfficeOcrProtocol.ResponseSchemaId;
+
+    /// <summary>Protocol schema version.</summary>
+    public int SchemaVersion { get; set; } = ProcessOfficeOcrProtocol.Version;
+
+    /// <summary>OCR engine output returned by the external process.</summary>
+    public OfficeOcrEngineResult? Result { get; set; }
+}
+
+/// <summary>JSON helpers and schema constants for the external OCR process protocol.</summary>
+public static class ProcessOfficeOcrProtocol {
+    /// <summary>Request schema identifier.</summary>
+    public const string RequestSchemaId = "officeimo.reader.ocr.process-request";
+
+    /// <summary>Response schema identifier.</summary>
+    public const string ResponseSchemaId = "officeimo.reader.ocr.process-response";
+
+    /// <summary>Current protocol version.</summary>
+    public const int Version = 1;
+
+    private static readonly JsonSerializerOptions JsonOptions = CreateOptions();
+
+    /// <summary>Serializes a process request using camel-case properties and string enum values.</summary>
+    public static string SerializeRequest(ProcessOfficeOcrRequest request, bool indented = false) {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+        JsonSerializerOptions options = CreateOptions();
+        options.WriteIndented = indented;
+        return JsonSerializer.Serialize(request, options);
+    }
+
+    /// <summary>Serializes an engine result suitable for the process response file.</summary>
+    public static string SerializeResult(OfficeOcrEngineResult result, bool indented = false) {
+        if (result == null) throw new ArgumentNullException(nameof(result));
+        JsonSerializerOptions options = CreateOptions();
+        options.WriteIndented = indented;
+        return JsonSerializer.Serialize(new ProcessOfficeOcrResponse { Result = result }, options);
+    }
+
+    /// <summary>Deserializes an engine result from the process response file.</summary>
+    public static OfficeOcrEngineResult DeserializeResult(string json) {
+        if (json == null) throw new ArgumentNullException(nameof(json));
+        ProcessOfficeOcrResponse? response = JsonSerializer.Deserialize<ProcessOfficeOcrResponse>(json, JsonOptions);
+        if (response == null) throw new InvalidDataException("OCR process response was empty.");
+        if (!string.Equals(response.SchemaId, ResponseSchemaId, StringComparison.Ordinal)) throw new InvalidDataException("OCR process response schema id is not supported.");
+        if (response.SchemaVersion != Version) throw new InvalidDataException("OCR process response schema version is not supported.");
+        return response.Result ?? throw new InvalidDataException("OCR process response did not contain an engine result.");
+    }
+
+    private static JsonSerializerOptions CreateOptions() {
+        var options = new JsonSerializerOptions {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            PropertyNameCaseInsensitive = true
+        };
+        options.Converters.Add(new JsonStringEnumConverter());
+        return options;
+    }
+}

--- a/OfficeIMO.Reader.Ocr.Process/Properties/AssemblyInfo.cs
+++ b/OfficeIMO.Reader.Ocr.Process/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("OfficeIMO.Reader.Ocr.Tesseract")]
+[assembly: InternalsVisibleTo("OfficeIMO.Reader.Tests")]

--- a/OfficeIMO.Reader.Ocr.Process/README.md
+++ b/OfficeIMO.Reader.Ocr.Process/README.md
@@ -40,7 +40,7 @@ Available argument placeholders are `{request}`, `{input}`, `{output}`, `{langua
 - Process stdout and stderr, response JSON size, and runtime are bounded separately by `ProcessOfficeOcrEngineOptions`.
 - The runner contains descendants in a kill-on-close Windows Job Object, a `setsid` process group on Linux/Unix, or a POSIX session launched through the system Perl on macOS. It fails closed when the host cannot provide one of those containment boundaries.
 - Executable paths, arguments, environment variables, and provider options are trusted host configuration. Do not build them directly from document content.
-- Payload bytes are temporary local files and are deleted by default. Set `KeepTemporaryFiles` only for controlled diagnostics.
+- Payload bytes are stored in owner-only per-request directories/files on Unix and are deleted by default. Set `KeepTemporaryFiles` only for controlled diagnostics.
 
 ## Targets and license
 

--- a/OfficeIMO.Reader.Ocr.Process/README.md
+++ b/OfficeIMO.Reader.Ocr.Process/README.md
@@ -1,0 +1,47 @@
+# OfficeIMO.Reader.Ocr.Process - external OCR process provider
+
+[![nuget version](https://img.shields.io/nuget/v/OfficeIMO.Reader.Ocr.Process)](https://www.nuget.org/packages/OfficeIMO.Reader.Ocr.Process)
+
+`OfficeIMO.Reader.Ocr.Process` connects `OfficeIMO.Reader` to a caller-configured executable through a versioned JSON file protocol. The executable runs directly—no command shell is inserted by the provider.
+
+## Install
+
+```powershell
+dotnet add package OfficeIMO.Reader.Ocr.Process
+```
+
+## Configure an engine
+
+```csharp
+using OfficeIMO.Reader;
+using OfficeIMO.Reader.Ocr.Process;
+
+var engine = new ProcessOfficeOcrEngine(new ProcessOfficeOcrEngineOptions {
+    FileName = "/opt/my-ocr/recognize",
+    Arguments = new[] { "--request", "{request}" },
+    Id = "my-ocr",
+    Timeout = TimeSpan.FromMinutes(1),
+    MaxOutputBytes = 8L * 1024L * 1024L
+});
+
+OfficeDocumentReadResult source = DocumentReader.ReadDocument("scan.docx");
+OfficeDocumentOcrExecutionResult execution = await source.ApplyOcrAsync(engine);
+
+Console.WriteLine(execution.Document.Markdown);
+```
+
+Each call receives an isolated request directory. The provider writes the candidate payload and a camel-case request JSON file with schema id `officeimo.reader.ocr.process-request`, version `1`. The request's `outputPath` identifies where the executable must write a response envelope with schema id `officeimo.reader.ocr.process-response`, version `1`, and an `OfficeOcrEngineResult` in its `result` property. Use `ProcessOfficeOcrProtocol.SerializeResult(...)` when the external bridge is implemented in .NET.
+
+Available argument placeholders are `{request}`, `{input}`, `{output}`, `{language}`, `{candidateId}`, and `{assetId}`. They are substituted as individual process arguments, not shell text.
+
+## Operational boundaries
+
+- Candidate count, input bytes, concurrency, engine duration, recognized text, and span counts remain bounded by `OfficeDocumentOcrExecutionOptions`.
+- Process stdout and stderr, response JSON size, and runtime are bounded separately by `ProcessOfficeOcrEngineOptions`.
+- Executable paths, arguments, environment variables, and provider options are trusted host configuration. Do not build them directly from document content.
+- Payload bytes are temporary local files and are deleted by default. Set `KeepTemporaryFiles` only for controlled diagnostics.
+
+## Targets and license
+
+- Targets: `netstandard2.0`, `net8.0`, `net10.0` (`net472` is also included on Windows builds).
+- License: MIT.

--- a/OfficeIMO.Reader.Ocr.Process/README.md
+++ b/OfficeIMO.Reader.Ocr.Process/README.md
@@ -38,6 +38,7 @@ Available argument placeholders are `{request}`, `{input}`, `{output}`, `{langua
 
 - Candidate count, input bytes, concurrency, engine duration, recognized text, and span counts remain bounded by `OfficeDocumentOcrExecutionOptions`.
 - Process stdout and stderr, response JSON size, and runtime are bounded separately by `ProcessOfficeOcrEngineOptions`.
+- The runner contains descendants in a kill-on-close Windows Job Object, a `setsid` process group on Linux/Unix, or a POSIX session launched through the system Perl on macOS. It fails closed when the host cannot provide one of those containment boundaries.
 - Executable paths, arguments, environment variables, and provider options are trusted host configuration. Do not build them directly from document content.
 - Payload bytes are temporary local files and are deleted by default. Set `KeepTemporaryFiles` only for controlled diagnostics.
 

--- a/OfficeIMO.Reader.Ocr.Tesseract/OfficeIMO.Reader.Ocr.Tesseract.csproj
+++ b/OfficeIMO.Reader.Ocr.Tesseract/OfficeIMO.Reader.Ocr.Tesseract.csproj
@@ -1,0 +1,50 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>Optional Tesseract CLI OCR engine for OfficeIMO.Reader.</Description>
+    <AssemblyName>OfficeIMO.Reader.Ocr.Tesseract</AssemblyName>
+    <AssemblyTitle>OfficeIMO.Reader.Ocr.Tesseract</AssemblyTitle>
+    <VersionPrefix>0.0.1</VersionPrefix>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <!-- No public baseline exists until the first 0.0.1 package is released. -->
+    <EnablePackageValidation>false</EnablePackageValidation>
+    <IsPackable>true</IsPackable>
+    <IsPublishable>true</IsPublishable>
+    <Company>Evotec</Company>
+    <Authors>Przemyslaw Klys</Authors>
+    <PackageId>OfficeIMO.Reader.Ocr.Tesseract</PackageId>
+    <PackageTags>reader;ocr;tesseract;ingestion;officeimo</PackageTags>
+    <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/EvotecIT/OfficeIMO</RepositoryUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <LangVersion>Latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OfficeIMO.Reader\OfficeIMO.Reader.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Reader.Ocr.Process\OfficeIMO.Reader.Ocr.Process.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md">
+      <Pack>True</Pack>
+      <PackagePath>README.md</PackagePath>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.Globalization" />
+    <Using Include="System.IO" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Text" />
+    <Using Include="System.Threading" />
+    <Using Include="System.Threading.Tasks" />
+  </ItemGroup>
+</Project>

--- a/OfficeIMO.Reader.Ocr.Tesseract/Properties/AssemblyInfo.cs
+++ b/OfficeIMO.Reader.Ocr.Tesseract/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("OfficeIMO.Reader.Tests")]

--- a/OfficeIMO.Reader.Ocr.Tesseract/README.md
+++ b/OfficeIMO.Reader.Ocr.Tesseract/README.md
@@ -52,6 +52,8 @@ The provider parses Tesseract TSV into line and word spans with pixel bounding b
 
 `GetVersionAsync()` and `GetLanguagesAsync()` provide explicit installation discovery. Missing executables, trained data, unsupported input formats, and nonzero process exits surface as engine failures; `ApplyOcrAsync` converts them to structured diagnostics when `ContinueOnError` is enabled.
 
+Per-request payload and output files use owner-only Unix directories and permissions. Temporary files are deleted by default; enable `KeepTemporaryFiles` only for controlled diagnostics.
+
 ## Targets and licenses
 
 - Targets: `netstandard2.0`, `net8.0`, `net10.0` (`net472` is also included on Windows builds).

--- a/OfficeIMO.Reader.Ocr.Tesseract/README.md
+++ b/OfficeIMO.Reader.Ocr.Tesseract/README.md
@@ -1,0 +1,59 @@
+# OfficeIMO.Reader.Ocr.Tesseract - Tesseract OCR provider
+
+[![nuget version](https://img.shields.io/nuget/v/OfficeIMO.Reader.Ocr.Tesseract)](https://www.nuget.org/packages/OfficeIMO.Reader.Ocr.Tesseract)
+
+`OfficeIMO.Reader.Ocr.Tesseract` is an optional `IOfficeOcrEngine` backed by an installed Tesseract command-line executable. It does not bundle native binaries or trained language data.
+
+## Install
+
+```powershell
+dotnet add package OfficeIMO.Reader.Ocr.Tesseract
+```
+
+Install Tesseract separately for the host operating system, then verify the executable and required languages:
+
+```text
+tesseract --version
+tesseract --list-langs
+```
+
+Tesseract 5 is the current stable major line. Its command contract supports image input, language expressions, and TSV output; see the [official Tesseract manual](https://github.com/tesseract-ocr/tesseract/blob/main/doc/tesseract.1.asc).
+
+## Recognize Reader candidates
+
+```csharp
+using OfficeIMO.Reader;
+using OfficeIMO.Reader.Ocr.Tesseract;
+
+OfficeDocumentReadResult source = DocumentReader.ReadDocument("scanned.pdf");
+var engine = new TesseractOcrEngine(new TesseractOcrEngineOptions {
+    ExecutablePath = "tesseract",
+    Language = "eng+pol",
+    PageSegmentationMode = 3,
+    Timeout = TimeSpan.FromMinutes(1)
+});
+
+OfficeDocumentOcrExecutionResult execution = await source.ApplyOcrAsync(
+    engine,
+    new OfficeDocumentOcrExecutionOptions {
+        MaxCandidates = 25,
+        MaxDegreeOfParallelism = 2,
+        MaxTotalInputBytes = 64L * 1024L * 1024L
+    });
+
+foreach (OfficeDocumentOcrRecognition recognition in execution.Recognitions) {
+    foreach (OfficeOcrTextSpan span in recognition.Result.Spans) {
+        Console.WriteLine($"{span.Level}: {span.Text} ({span.Confidence:P0})");
+    }
+}
+```
+
+The provider parses Tesseract TSV into line and word spans with pixel bounding boxes and normalized confidence. Tesseract TSV does not expose character boxes, so `SupportsCharacterSpans` is false. A process or delegate engine can still return character spans through the shared core contract.
+
+`GetVersionAsync()` and `GetLanguagesAsync()` provide explicit installation discovery. Missing executables, trained data, unsupported input formats, and nonzero process exits surface as engine failures; `ApplyOcrAsync` converts them to structured diagnostics when `ContinueOnError` is enabled.
+
+## Targets and licenses
+
+- Targets: `netstandard2.0`, `net8.0`, `net10.0` (`net472` is also included on Windows builds).
+- OfficeIMO provider license: MIT.
+- Tesseract is an external dependency distributed under its own Apache 2.0 license.

--- a/OfficeIMO.Reader.Ocr.Tesseract/TesseractOcrEngine.Discovery.cs
+++ b/OfficeIMO.Reader.Ocr.Tesseract/TesseractOcrEngine.Discovery.cs
@@ -1,0 +1,40 @@
+using OfficeIMO.Reader.Ocr.Process;
+
+namespace OfficeIMO.Reader.Ocr.Tesseract;
+
+public sealed partial class TesseractOcrEngine {
+    /// <summary>Returns the first line from <c>tesseract --version</c>.</summary>
+    public async Task<string> GetVersionAsync(CancellationToken cancellationToken = default) {
+        OfficeOcrProcessResult result = await RunDiscoveryAsync(new[] { "--version" }, cancellationToken).ConfigureAwait(false);
+        if (result.ExitCode != 0) throw new InvalidOperationException("Tesseract version discovery failed: " + result.StandardError);
+        return result.StandardOutput.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault()?.Trim() ?? string.Empty;
+    }
+
+    /// <summary>Returns sorted language identifiers from <c>tesseract --list-langs</c>.</summary>
+    public async Task<IReadOnlyList<string>> GetLanguagesAsync(CancellationToken cancellationToken = default) {
+        var arguments = new List<string> { "--list-langs" };
+        if (!string.IsNullOrWhiteSpace(_options.TessdataDirectory)) {
+            arguments.Add("--tessdata-dir");
+            arguments.Add(_options.TessdataDirectory!);
+        }
+        OfficeOcrProcessResult result = await RunDiscoveryAsync(arguments, cancellationToken).ConfigureAwait(false);
+        if (result.ExitCode != 0) throw new InvalidOperationException("Tesseract language discovery failed: " + result.StandardError);
+        return result.StandardOutput
+            .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(static line => line.Trim())
+            .Where(static line => line.Length > 0 && !line.StartsWith("List of available languages", StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static line => line, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private Task<OfficeOcrProcessResult> RunDiscoveryAsync(IReadOnlyList<string> arguments, CancellationToken cancellationToken) {
+        return OfficeOcrProcessRunner.RunAsync(new OfficeOcrProcessCommand {
+            FileName = _options.ExecutablePath,
+            Arguments = arguments,
+            Timeout = _options.Timeout,
+            MaxStandardOutputCharacters = _options.MaxProcessOutputCharacters,
+            MaxStandardErrorCharacters = _options.MaxProcessOutputCharacters
+        }, cancellationToken);
+    }
+}

--- a/OfficeIMO.Reader.Ocr.Tesseract/TesseractOcrEngine.cs
+++ b/OfficeIMO.Reader.Ocr.Tesseract/TesseractOcrEngine.cs
@@ -1,0 +1,172 @@
+using OfficeIMO.Reader;
+using OfficeIMO.Reader.Ocr.Process;
+
+namespace OfficeIMO.Reader.Ocr.Tesseract;
+
+/// <summary>Optional cross-platform OCR engine backed by an installed Tesseract command-line executable.</summary>
+public sealed partial class TesseractOcrEngine : IOfficeOcrEngine {
+    private readonly OptionsSnapshot _options;
+    private readonly OfficeOcrEngineCapabilities _capabilities;
+
+    /// <summary>Creates a Tesseract engine from an immutable option snapshot.</summary>
+    public TesseractOcrEngine(TesseractOcrEngineOptions? options = null) {
+        _options = OptionsSnapshot.Create(options);
+        _capabilities = new OfficeOcrEngineCapabilities {
+            SupportedMediaTypes = new[] { "image/*" },
+            SupportsLineSpans = true,
+            SupportsWordSpans = true,
+            SupportsCharacterSpans = false,
+            SupportsConfidence = true,
+            SupportsConcurrentRequests = true
+        };
+    }
+
+    /// <inheritdoc />
+    public string Id => "tesseract-cli";
+
+    /// <inheritdoc />
+    public OfficeOcrEngineCapabilities Capabilities => _capabilities.Clone();
+
+    /// <inheritdoc />
+    public async ValueTask<OfficeOcrEngineResult> RecognizeAsync(OfficeOcrEngineRequest request, CancellationToken cancellationToken = default) {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+        if (request.Payload == null || request.Payload.Length == 0) throw new ArgumentException("OCR request payload cannot be empty.", nameof(request));
+        if (request.Payload.LongLength > _options.MaxInputBytes) throw new IOException("OCR request payload exceeds MaxInputBytes (" + _options.MaxInputBytes + ").");
+        if (!string.IsNullOrWhiteSpace(request.Asset.MediaType) && !request.Asset.MediaType!.StartsWith("image/", StringComparison.OrdinalIgnoreCase)) throw new NotSupportedException("Tesseract provider accepts image assets only.");
+        cancellationToken.ThrowIfCancellationRequested();
+        string temporaryRoot = Path.GetFullPath(_options.TemporaryDirectory ?? Path.GetTempPath());
+        string requestDirectory = Path.Combine(temporaryRoot, "officeimo-tesseract-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(requestDirectory);
+        try {
+            string inputPath = Path.Combine(requestDirectory, "input" + OfficeOcrProcessFileNames.GetSafeAssetExtension(request.Asset));
+            string outputBase = Path.Combine(requestDirectory, "result");
+            string outputPath = outputBase + ".tsv";
+            File.WriteAllBytes(inputPath, request.Payload);
+            string? language = string.IsNullOrWhiteSpace(request.Language) ? _options.Language : request.Language!.Trim();
+            OfficeOcrProcessResult processResult = await OfficeOcrProcessRunner.RunAsync(new OfficeOcrProcessCommand {
+                FileName = _options.ExecutablePath,
+                Arguments = BuildRecognitionArguments(inputPath, outputBase, language),
+                Timeout = _options.Timeout,
+                MaxStandardOutputCharacters = _options.MaxProcessOutputCharacters,
+                MaxStandardErrorCharacters = _options.MaxProcessOutputCharacters
+            }, cancellationToken).ConfigureAwait(false);
+            if (processResult.ExitCode != 0) {
+                throw new InvalidOperationException("Tesseract exited with code " + processResult.ExitCode + ": " + processResult.StandardError);
+            }
+            if (!File.Exists(outputPath)) throw new FileNotFoundException("Tesseract did not create the expected TSV output.", outputPath);
+            long outputLength = new FileInfo(outputPath).Length;
+            if (outputLength > _options.MaxOutputBytes) throw new IOException("Tesseract TSV output exceeds MaxOutputBytes (" + _options.MaxOutputBytes + ").");
+            OfficeOcrEngineResult result = TesseractTsvParser.Parse(File.ReadAllText(outputPath, Encoding.UTF8), language);
+            if (!string.IsNullOrWhiteSpace(processResult.StandardError)) {
+                result.Diagnostics = (result.Diagnostics ?? Array.Empty<OfficeDocumentDiagnostic>()).Concat(new[] {
+                    new OfficeDocumentDiagnostic {
+                        Severity = OfficeDocumentDiagnosticSeverity.Warning,
+                        Category = OfficeDocumentDiagnosticCategory.Ocr,
+                        Code = "tesseract-stderr",
+                        Message = processResult.StandardError,
+                        Source = Id,
+                        IsRecoverable = true,
+                        Location = request.Candidate.Location,
+                        Attributes = new Dictionary<string, string>(StringComparer.Ordinal) {
+                            ["truncated"] = processResult.StandardErrorTruncated ? "true" : "false"
+                        }
+                    }
+                }).ToArray();
+            }
+            if (processResult.StandardOutputTruncated) {
+                result.Diagnostics = (result.Diagnostics ?? Array.Empty<OfficeDocumentDiagnostic>()).Concat(new[] {
+                    new OfficeDocumentDiagnostic {
+                        Severity = OfficeDocumentDiagnosticSeverity.Warning,
+                        Category = OfficeDocumentDiagnosticCategory.Limit,
+                        Code = "tesseract-stdout-limit",
+                        Message = "Tesseract standard output exceeded its configured retention limit.",
+                        Source = Id,
+                        IsRecoverable = true,
+                        Location = request.Candidate.Location
+                    }
+                }).ToArray();
+            }
+            return result;
+        } finally {
+            if (!_options.KeepTemporaryFiles) TryDeleteDirectory(requestDirectory);
+        }
+    }
+
+    internal IReadOnlyList<string> BuildRecognitionArguments(string inputPath, string outputBase, string? language) {
+        var arguments = new List<string> { inputPath, outputBase };
+        if (!string.IsNullOrWhiteSpace(language)) {
+            arguments.Add("-l");
+            arguments.Add(language!);
+        }
+        if (!string.IsNullOrWhiteSpace(_options.TessdataDirectory)) {
+            arguments.Add("--tessdata-dir");
+            arguments.Add(_options.TessdataDirectory!);
+        }
+        if (_options.EngineMode.HasValue) {
+            arguments.Add("--oem");
+            arguments.Add(_options.EngineMode.Value.ToString(CultureInfo.InvariantCulture));
+        }
+        if (_options.PageSegmentationMode.HasValue) {
+            arguments.Add("--psm");
+            arguments.Add(_options.PageSegmentationMode.Value.ToString(CultureInfo.InvariantCulture));
+        }
+        if (_options.Dpi.HasValue) {
+            arguments.Add("--dpi");
+            arguments.Add(_options.Dpi.Value.ToString(CultureInfo.InvariantCulture));
+        }
+        arguments.AddRange(_options.AdditionalArguments);
+        arguments.Add("tsv");
+        return arguments;
+    }
+
+    private static void TryDeleteDirectory(string path) {
+        try {
+            if (Directory.Exists(path)) Directory.Delete(path, recursive: true);
+        } catch (IOException) {
+        } catch (UnauthorizedAccessException) {
+        }
+    }
+
+    private sealed class OptionsSnapshot {
+        internal string ExecutablePath { get; private set; } = string.Empty;
+        internal string? Language { get; private set; }
+        internal string? TessdataDirectory { get; private set; }
+        internal int? EngineMode { get; private set; }
+        internal int? PageSegmentationMode { get; private set; }
+        internal int? Dpi { get; private set; }
+        internal IReadOnlyList<string> AdditionalArguments { get; private set; } = Array.Empty<string>();
+        internal string? TemporaryDirectory { get; private set; }
+        internal TimeSpan Timeout { get; private set; }
+        internal long MaxOutputBytes { get; private set; }
+        internal long MaxInputBytes { get; private set; }
+        internal int MaxProcessOutputCharacters { get; private set; }
+        internal bool KeepTemporaryFiles { get; private set; }
+
+        internal static OptionsSnapshot Create(TesseractOcrEngineOptions? options) {
+            TesseractOcrEngineOptions source = options ?? new TesseractOcrEngineOptions();
+            if (string.IsNullOrWhiteSpace(source.ExecutablePath)) throw new ArgumentException("Tesseract executable path cannot be empty.", nameof(options));
+            if (source.EngineMode.HasValue && (source.EngineMode.Value < 0 || source.EngineMode.Value > 3)) throw new ArgumentOutOfRangeException(nameof(source.EngineMode));
+            if (source.PageSegmentationMode.HasValue && (source.PageSegmentationMode.Value < 0 || source.PageSegmentationMode.Value > 13)) throw new ArgumentOutOfRangeException(nameof(source.PageSegmentationMode));
+            if (source.Dpi.HasValue && source.Dpi.Value < 1) throw new ArgumentOutOfRangeException(nameof(source.Dpi));
+            if (source.Timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(source.Timeout));
+            if (source.MaxOutputBytes < 1) throw new ArgumentOutOfRangeException(nameof(source.MaxOutputBytes));
+            if (source.MaxInputBytes < 1) throw new ArgumentOutOfRangeException(nameof(source.MaxInputBytes));
+            if (source.MaxProcessOutputCharacters < 1) throw new ArgumentOutOfRangeException(nameof(source.MaxProcessOutputCharacters));
+            return new OptionsSnapshot {
+                ExecutablePath = source.ExecutablePath.Trim(),
+                Language = string.IsNullOrWhiteSpace(source.Language) ? null : source.Language!.Trim(),
+                TessdataDirectory = string.IsNullOrWhiteSpace(source.TessdataDirectory) ? null : source.TessdataDirectory,
+                EngineMode = source.EngineMode,
+                PageSegmentationMode = source.PageSegmentationMode,
+                Dpi = source.Dpi,
+                AdditionalArguments = (source.AdditionalArguments ?? Array.Empty<string>()).ToArray(),
+                TemporaryDirectory = string.IsNullOrWhiteSpace(source.TemporaryDirectory) ? null : source.TemporaryDirectory,
+                Timeout = source.Timeout,
+                MaxOutputBytes = source.MaxOutputBytes,
+                MaxInputBytes = source.MaxInputBytes,
+                MaxProcessOutputCharacters = source.MaxProcessOutputCharacters,
+                KeepTemporaryFiles = source.KeepTemporaryFiles
+            };
+        }
+    }
+}

--- a/OfficeIMO.Reader.Ocr.Tesseract/TesseractOcrEngine.cs
+++ b/OfficeIMO.Reader.Ocr.Tesseract/TesseractOcrEngine.cs
@@ -35,13 +35,12 @@ public sealed partial class TesseractOcrEngine : IOfficeOcrEngine {
         if (!string.IsNullOrWhiteSpace(request.Asset.MediaType) && !request.Asset.MediaType!.StartsWith("image/", StringComparison.OrdinalIgnoreCase)) throw new NotSupportedException("Tesseract provider accepts image assets only.");
         cancellationToken.ThrowIfCancellationRequested();
         string temporaryRoot = Path.GetFullPath(_options.TemporaryDirectory ?? Path.GetTempPath());
-        string requestDirectory = Path.Combine(temporaryRoot, "officeimo-tesseract-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(requestDirectory);
+        string requestDirectory = OfficeOcrTemporaryStorage.CreateRequestDirectory(temporaryRoot, "officeimo-tesseract-");
         try {
             string inputPath = Path.Combine(requestDirectory, "input" + OfficeOcrProcessFileNames.GetSafeAssetExtension(request.Asset));
             string outputBase = Path.Combine(requestDirectory, "result");
             string outputPath = outputBase + ".tsv";
-            File.WriteAllBytes(inputPath, request.Payload);
+            OfficeOcrTemporaryStorage.WriteAllBytes(inputPath, request.Payload);
             string? language = string.IsNullOrWhiteSpace(request.Language) ? _options.Language : request.Language!.Trim();
             OfficeOcrProcessResult processResult = await OfficeOcrProcessRunner.RunAsync(new OfficeOcrProcessCommand {
                 FileName = _options.ExecutablePath,
@@ -54,6 +53,7 @@ public sealed partial class TesseractOcrEngine : IOfficeOcrEngine {
                 throw new InvalidOperationException("Tesseract exited with code " + processResult.ExitCode + ": " + processResult.StandardError);
             }
             if (!File.Exists(outputPath)) throw new FileNotFoundException("Tesseract did not create the expected TSV output.", outputPath);
+            OfficeOcrTemporaryStorage.EnsurePrivateFile(outputPath);
             long outputLength = new FileInfo(outputPath).Length;
             if (outputLength > _options.MaxOutputBytes) throw new IOException("Tesseract TSV output exceeds MaxOutputBytes (" + _options.MaxOutputBytes + ").");
             OfficeOcrEngineResult result = TesseractTsvParser.Parse(File.ReadAllText(outputPath, Encoding.UTF8), language);

--- a/OfficeIMO.Reader.Ocr.Tesseract/TesseractOcrEngine.cs
+++ b/OfficeIMO.Reader.Ocr.Tesseract/TesseractOcrEngine.cs
@@ -5,6 +5,21 @@ namespace OfficeIMO.Reader.Ocr.Tesseract;
 
 /// <summary>Optional cross-platform OCR engine backed by an installed Tesseract command-line executable.</summary>
 public sealed partial class TesseractOcrEngine : IOfficeOcrEngine {
+    private static readonly string[] TesseractMediaTypes = {
+        "image/png",
+        "image/jpeg",
+        "image/jpg",
+        "image/tiff",
+        "image/jp2",
+        "image/gif",
+        "image/webp",
+        "image/bmp",
+        "image/x-portable-anymap",
+        "image/x-portable-bitmap",
+        "image/x-portable-graymap",
+        "image/x-portable-pixmap"
+    };
+
     private readonly OptionsSnapshot _options;
     private readonly OfficeOcrEngineCapabilities _capabilities;
 
@@ -12,7 +27,7 @@ public sealed partial class TesseractOcrEngine : IOfficeOcrEngine {
     public TesseractOcrEngine(TesseractOcrEngineOptions? options = null) {
         _options = OptionsSnapshot.Create(options);
         _capabilities = new OfficeOcrEngineCapabilities {
-            SupportedMediaTypes = new[] { "image/*" },
+            SupportedMediaTypes = TesseractMediaTypes,
             SupportsLineSpans = true,
             SupportsWordSpans = true,
             SupportsCharacterSpans = false,
@@ -32,7 +47,10 @@ public sealed partial class TesseractOcrEngine : IOfficeOcrEngine {
         if (request == null) throw new ArgumentNullException(nameof(request));
         if (request.Payload == null || request.Payload.Length == 0) throw new ArgumentException("OCR request payload cannot be empty.", nameof(request));
         if (request.Payload.LongLength > _options.MaxInputBytes) throw new IOException("OCR request payload exceeds MaxInputBytes (" + _options.MaxInputBytes + ").");
-        if (!string.IsNullOrWhiteSpace(request.Asset.MediaType) && !request.Asset.MediaType!.StartsWith("image/", StringComparison.OrdinalIgnoreCase)) throw new NotSupportedException("Tesseract provider accepts image assets only.");
+        if (string.IsNullOrWhiteSpace(request.Asset.MediaType) ||
+            !TesseractMediaTypes.Contains(request.Asset.MediaType!, StringComparer.OrdinalIgnoreCase)) {
+            throw new NotSupportedException("Tesseract provider accepts supported raster image assets only.");
+        }
         cancellationToken.ThrowIfCancellationRequested();
         string temporaryRoot = Path.GetFullPath(_options.TemporaryDirectory ?? Path.GetTempPath());
         string requestDirectory = OfficeOcrTemporaryStorage.CreateRequestDirectory(temporaryRoot, "officeimo-tesseract-");

--- a/OfficeIMO.Reader.Ocr.Tesseract/TesseractOcrEngineOptions.cs
+++ b/OfficeIMO.Reader.Ocr.Tesseract/TesseractOcrEngineOptions.cs
@@ -1,0 +1,43 @@
+namespace OfficeIMO.Reader.Ocr.Tesseract;
+
+/// <summary>Configures the optional Tesseract command-line OCR engine.</summary>
+public sealed class TesseractOcrEngineOptions {
+    /// <summary>Executable path or name. Defaults to <c>tesseract</c>.</summary>
+    public string ExecutablePath { get; set; } = "tesseract";
+
+    /// <summary>Default Tesseract language expression, such as <c>eng</c> or <c>eng+pol</c>.</summary>
+    public string? Language { get; set; } = "eng";
+
+    /// <summary>Optional tessdata directory passed through <c>--tessdata-dir</c>.</summary>
+    public string? TessdataDirectory { get; set; }
+
+    /// <summary>Optional OCR engine mode from 0 through 3.</summary>
+    public int? EngineMode { get; set; }
+
+    /// <summary>Optional page segmentation mode from 0 through 13.</summary>
+    public int? PageSegmentationMode { get; set; }
+
+    /// <summary>Optional input DPI passed through <c>--dpi</c>.</summary>
+    public int? Dpi { get; set; }
+
+    /// <summary>Additional direct Tesseract arguments inserted before the <c>tsv</c> output config.</summary>
+    public IReadOnlyList<string> AdditionalArguments { get; set; } = Array.Empty<string>();
+
+    /// <summary>Optional parent directory for isolated per-request temporary folders.</summary>
+    public string? TemporaryDirectory { get; set; }
+
+    /// <summary>Maximum recognition process duration. Defaults to two minutes.</summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromMinutes(2);
+
+    /// <summary>Maximum TSV result size. Defaults to 32 MiB.</summary>
+    public long MaxOutputBytes { get; set; } = 32L * 1024L * 1024L;
+
+    /// <summary>Maximum input payload size accepted by direct engine calls. Defaults to 25 MiB.</summary>
+    public long MaxInputBytes { get; set; } = 25L * 1024L * 1024L;
+
+    /// <summary>Maximum retained process output characters.</summary>
+    public int MaxProcessOutputCharacters { get; set; } = 64 * 1024;
+
+    /// <summary>Whether isolated temporary files are retained after recognition.</summary>
+    public bool KeepTemporaryFiles { get; set; }
+}

--- a/OfficeIMO.Reader.Ocr.Tesseract/TesseractTsvParser.cs
+++ b/OfficeIMO.Reader.Ocr.Tesseract/TesseractTsvParser.cs
@@ -1,0 +1,145 @@
+using OfficeIMO.Reader;
+
+namespace OfficeIMO.Reader.Ocr.Tesseract;
+
+internal static class TesseractTsvParser {
+    internal static OfficeOcrEngineResult Parse(string tsv, string? language) {
+        if (tsv == null) throw new ArgumentNullException(nameof(tsv));
+        string[] lines = tsv.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+        int headerIndex = Array.FindIndex(lines, static line => !string.IsNullOrWhiteSpace(line));
+        if (headerIndex < 0 || !lines[headerIndex].TrimStart('\uFEFF').StartsWith("level\tpage_num\tblock_num", StringComparison.Ordinal)) {
+            throw new InvalidDataException("Tesseract TSV output is missing the expected header.");
+        }
+
+        var words = new List<WordRow>();
+        int invalidRowCount = 0;
+        for (int lineIndex = headerIndex + 1; lineIndex < lines.Length; lineIndex++) {
+            if (string.IsNullOrWhiteSpace(lines[lineIndex])) continue;
+            string[] columns = lines[lineIndex].Split(new[] { '\t' }, 12, StringSplitOptions.None);
+            if (columns.Length < 11 || !TryParseWord(columns, lineIndex, out WordRow? word)) {
+                invalidRowCount++;
+                continue;
+            }
+            if (word != null) words.Add(word);
+        }
+
+        var spans = new List<OfficeOcrTextSpan>();
+        var recognizedLines = new List<string>();
+        int sequence = 0;
+        IEnumerable<IGrouping<(int Page, int Block, int Paragraph, int Line), WordRow>> groups = words
+            .GroupBy(static word => (word.Page, word.Block, word.Paragraph, word.Line))
+            .OrderBy(static group => group.Min(word => word.SourceIndex));
+        foreach (IGrouping<(int Page, int Block, int Paragraph, int Line), WordRow> group in groups) {
+            WordRow[] lineWords = group.OrderBy(static word => word.SourceIndex).ToArray();
+            string lineText = string.Join(" ", lineWords.Select(static word => word.Text));
+            recognizedLines.Add(lineText);
+            spans.Add(new OfficeOcrTextSpan {
+                Sequence = sequence++,
+                Level = OfficeOcrTextSpanLevel.Line,
+                Text = lineText,
+                Confidence = AverageConfidence(lineWords),
+                Language = language,
+                PageNumber = group.Key.Page,
+                Region = Union(lineWords),
+                CoordinateUnit = OfficeOcrCoordinateUnit.Pixels
+            });
+            foreach (WordRow word in lineWords) {
+                spans.Add(new OfficeOcrTextSpan {
+                    Sequence = sequence++,
+                    Level = OfficeOcrTextSpanLevel.Word,
+                    Text = word.Text,
+                    Confidence = word.Confidence,
+                    Language = language,
+                    PageNumber = word.Page,
+                    Region = new OfficeDocumentRegion { X = word.Left, Y = word.Top, Width = word.Width, Height = word.Height },
+                    CoordinateUnit = OfficeOcrCoordinateUnit.Pixels
+                });
+            }
+        }
+
+        IReadOnlyList<OfficeDocumentDiagnostic> diagnostics = invalidRowCount == 0
+            ? Array.Empty<OfficeDocumentDiagnostic>()
+            : new[] {
+                new OfficeDocumentDiagnostic {
+                    Severity = OfficeDocumentDiagnosticSeverity.Warning,
+                    Category = OfficeDocumentDiagnosticCategory.Ocr,
+                    Code = "tesseract-tsv-row-invalid",
+                    Message = "One or more malformed Tesseract TSV rows were ignored.",
+                    Source = "tesseract-cli",
+                    IsRecoverable = true,
+                    Attributes = new Dictionary<string, string>(StringComparer.Ordinal) {
+                        ["invalidRowCount"] = invalidRowCount.ToString(CultureInfo.InvariantCulture)
+                    }
+                }
+            };
+        return new OfficeOcrEngineResult {
+            Text = string.Join(Environment.NewLine, recognizedLines),
+            Confidence = AverageConfidence(words),
+            Language = language,
+            Provider = "tesseract-cli",
+            Model = string.IsNullOrWhiteSpace(language) ? null : "tessdata:" + language,
+            Spans = spans,
+            Diagnostics = diagnostics
+        };
+    }
+
+    private static bool TryParseWord(string[] columns, int sourceIndex, out WordRow? word) {
+        word = null;
+        if (!int.TryParse(columns[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out int level)) return false;
+        if (level != 5) return true;
+        if (!int.TryParse(columns[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out int page)
+            || !int.TryParse(columns[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out int block)
+            || !int.TryParse(columns[3], NumberStyles.Integer, CultureInfo.InvariantCulture, out int paragraph)
+            || !int.TryParse(columns[4], NumberStyles.Integer, CultureInfo.InvariantCulture, out int line)
+            || !int.TryParse(columns[6], NumberStyles.Integer, CultureInfo.InvariantCulture, out int left)
+            || !int.TryParse(columns[7], NumberStyles.Integer, CultureInfo.InvariantCulture, out int top)
+            || !int.TryParse(columns[8], NumberStyles.Integer, CultureInfo.InvariantCulture, out int width)
+            || !int.TryParse(columns[9], NumberStyles.Integer, CultureInfo.InvariantCulture, out int height)
+            || !double.TryParse(columns[10], NumberStyles.Float, CultureInfo.InvariantCulture, out double confidence)) return false;
+        string text = columns.Length > 11 ? columns[11].Trim() : string.Empty;
+        if (text.Length == 0) return true;
+        word = new WordRow(sourceIndex, page, block, paragraph, line, left, top, width, height, confidence < 0D ? null : confidence / 100D, text);
+        return true;
+    }
+
+    private static double? AverageConfidence(IEnumerable<WordRow> words) {
+        double[] values = words.Where(static word => word.Confidence.HasValue).Select(static word => word.Confidence!.Value).ToArray();
+        return values.Length == 0 ? null : values.Average();
+    }
+
+    private static OfficeDocumentRegion Union(IReadOnlyList<WordRow> words) {
+        int left = words.Min(static word => word.Left);
+        int top = words.Min(static word => word.Top);
+        int right = words.Max(static word => word.Left + word.Width);
+        int bottom = words.Max(static word => word.Top + word.Height);
+        return new OfficeDocumentRegion { X = left, Y = top, Width = right - left, Height = bottom - top };
+    }
+
+    private sealed class WordRow {
+        internal WordRow(int sourceIndex, int page, int block, int paragraph, int line, int left, int top, int width, int height, double? confidence, string text) {
+            SourceIndex = sourceIndex;
+            Page = page;
+            Block = block;
+            Paragraph = paragraph;
+            Line = line;
+            Left = left;
+            Top = top;
+            Width = width;
+            Height = height;
+            Confidence = confidence;
+            Text = text;
+        }
+
+        internal int SourceIndex { get; }
+        internal int Page { get; }
+        internal int Block { get; }
+        internal int Paragraph { get; }
+        internal int Line { get; }
+        internal int Left { get; }
+        internal int Top { get; }
+        internal int Width { get; }
+        internal int Height { get; }
+        internal double? Confidence { get; }
+        internal string Text { get; }
+    }
+}

--- a/OfficeIMO.Reader.Tests/OfficeIMO.Reader.Tests.csproj
+++ b/OfficeIMO.Reader.Tests/OfficeIMO.Reader.Tests.csproj
@@ -36,6 +36,8 @@
     <ProjectReference Include="..\OfficeIMO.Reader\OfficeIMO.Reader.csproj" />
     <ProjectReference Include="..\OfficeIMO.Reader.AsciiDoc\OfficeIMO.Reader.AsciiDoc.csproj" />
     <ProjectReference Include="..\OfficeIMO.Reader.Latex\OfficeIMO.Reader.Latex.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Reader.Ocr.Process\OfficeIMO.Reader.Ocr.Process.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Reader.Ocr.Tesseract\OfficeIMO.Reader.Ocr.Tesseract.csproj" />
     <ProjectReference Include="..\OfficeIMO.Reader.Csv\OfficeIMO.Reader.Csv.csproj" />
     <ProjectReference Include="..\OfficeIMO.Reader.Epub\OfficeIMO.Reader.Epub.csproj" />
     <ProjectReference Include="..\OfficeIMO.Reader.Html\OfficeIMO.Reader.Html.csproj" />

--- a/OfficeIMO.Reader.Tests/Reader.Ocr.Core.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Ocr.Core.cs
@@ -64,6 +64,28 @@ public sealed class ReaderOcrCoreTests {
     }
 
     [Fact]
+    public async Task ApplyOcrAsync_DoesNotResolveMultiImagePageToItsFirstImageAsset() {
+        OfficeDocumentReadResult source = CreateDocument(2);
+        source.OcrCandidates = new[] {
+            new OfficeDocumentOcrCandidate {
+                Id = "page-ocr",
+                Kind = "page",
+                AssetId = source.Assets[0].Id,
+                ImageCount = 2,
+                Location = source.OcrCandidates[0].Location
+            }
+        };
+        var engine = new RecordingOcrEngine();
+
+        OfficeDocumentOcrExecutionResult execution = await source.ApplyOcrAsync(engine);
+
+        Assert.Empty(engine.CandidateIds);
+        Assert.Equal(0, execution.Report.AttemptedCandidateCount);
+        Assert.Single(execution.Document.OcrCandidates);
+        Assert.Contains(execution.Diagnostics, diagnostic => diagnostic.Code == "ocr-asset-ambiguous");
+    }
+
+    [Fact]
     public async Task ApplyOcrAsync_BoundsProviderTextSpansAndConfidenceDiagnostics() {
         OfficeDocumentReadResult source = CreateDocument(1);
         var engine = new DelegateOfficeOcrEngine("bounded-fixture", (request, cancellationToken) => new ValueTask<OfficeOcrEngineResult>(new OfficeOcrEngineResult {

--- a/OfficeIMO.Reader.Tests/Reader.Ocr.Core.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Ocr.Core.cs
@@ -174,6 +174,80 @@ public sealed class ReaderOcrCoreTests {
     }
 
     [Fact]
+    public async Task ApplyOcrAsync_HoldsNonConcurrentEngineGateUntilTimedOutCallSettles() {
+        var engine = new NonCooperativeSerialOcrEngine();
+        var timeoutOptions = new OfficeDocumentOcrExecutionOptions {
+            CandidateTimeout = TimeSpan.FromMilliseconds(20),
+            ContinueOnError = true
+        };
+
+        try {
+            OfficeDocumentOcrExecutionResult first = await CreateDocument(1).ApplyOcrAsync(engine, timeoutOptions);
+            Assert.Contains(first.Diagnostics, diagnostic => diagnostic.Code == "ocr-engine-timeout");
+
+            Task<OfficeDocumentOcrExecutionResult> second = CreateDocument(1).ApplyOcrAsync(
+                engine,
+                new OfficeDocumentOcrExecutionOptions { CandidateTimeout = TimeSpan.FromSeconds(2) });
+            Task earlyStart = await Task.WhenAny(engine.SecondCallStarted, Task.Delay(TimeSpan.FromMilliseconds(100)));
+            Assert.NotSame(engine.SecondCallStarted, earlyStart);
+
+            engine.CompleteFirstCall();
+            await second.WaitAsync(TimeSpan.FromSeconds(2));
+
+            Assert.Equal(1, engine.MaximumConcurrentCalls);
+        } finally {
+            engine.CompleteFirstCall();
+        }
+    }
+
+    [Fact]
+    public async Task ApplyOcrAsync_DoesNotStartAnotherCandidateWhileTimedOutSerialCallRuns() {
+        var engine = new NonCooperativeSerialOcrEngine();
+
+        try {
+            OfficeDocumentOcrExecutionResult execution = await CreateDocument(2).ApplyOcrAsync(
+                engine,
+                new OfficeDocumentOcrExecutionOptions {
+                    CandidateTimeout = TimeSpan.FromMilliseconds(20),
+                    ContinueOnError = true
+                });
+
+            Assert.Equal(1, engine.CallCount);
+            Assert.Equal(1, execution.Report.AttemptedCandidateCount);
+            Assert.Equal(1, execution.Report.FailedCandidateCount);
+            Assert.Equal(1, execution.Report.SkippedCandidateCount);
+            Assert.Equal(1, execution.Report.InputBytes);
+            Assert.Equal(2, execution.Diagnostics.Count(diagnostic => diagnostic.Code == "ocr-engine-timeout"));
+            Assert.Equal(1, engine.MaximumConcurrentCalls);
+        } finally {
+            engine.CompleteFirstCall();
+        }
+    }
+
+    [Fact]
+    public async Task ApplyOcrAsync_DoesNotExceedParallelismWhenConcurrentEngineIgnoresTimeout() {
+        var engine = new NonCooperativeConcurrentOcrEngine();
+
+        try {
+            OfficeDocumentOcrExecutionResult execution = await CreateDocument(4).ApplyOcrAsync(
+                engine,
+                new OfficeDocumentOcrExecutionOptions {
+                    CandidateTimeout = TimeSpan.FromMilliseconds(20),
+                    ContinueOnError = true,
+                    MaxDegreeOfParallelism = 2
+                });
+
+            Assert.Equal(2, engine.CallCount);
+            Assert.Equal(2, engine.MaximumConcurrentCalls);
+            Assert.Equal(2, execution.Report.AttemptedCandidateCount);
+            Assert.Equal(2, execution.Report.FailedCandidateCount);
+            Assert.Equal(2, execution.Report.SkippedCandidateCount);
+        } finally {
+            engine.CompleteCalls();
+        }
+    }
+
+    [Fact]
     public async Task OfficeDocumentOcrProcessor_FreezesOptionsForReaderPipeline() {
         var options = new OfficeDocumentOcrExecutionOptions { MaxCandidates = 1 };
         var processor = new OfficeDocumentOcrProcessor(new RecordingOcrEngine(), options);
@@ -235,6 +309,83 @@ public sealed class ReaderOcrCoreTests {
             Diagnostics = diagnostics,
             Pages = pages
         };
+    }
+
+    private sealed class NonCooperativeSerialOcrEngine : IOfficeOcrEngine {
+        private readonly TaskCompletionSource<OfficeOcrEngineResult> _firstCall = new TaskCompletionSource<OfficeOcrEngineResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<object?> _secondCallStarted = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _activeCalls;
+        private int _callCount;
+        private int _maximumConcurrentCalls;
+
+        public string Id => "non-cooperative-serial-fixture";
+
+        public OfficeOcrEngineCapabilities Capabilities { get; } = new OfficeOcrEngineCapabilities {
+            SupportedMediaTypes = new[] { "image/*" },
+            SupportsConcurrentRequests = false
+        };
+
+        internal int MaximumConcurrentCalls => _maximumConcurrentCalls;
+
+        internal int CallCount => _callCount;
+
+        internal Task SecondCallStarted => _secondCallStarted.Task;
+
+        internal void CompleteFirstCall() {
+            _firstCall.TrySetResult(new OfficeOcrEngineResult { Text = "first" });
+        }
+
+        public async ValueTask<OfficeOcrEngineResult> RecognizeAsync(OfficeOcrEngineRequest request, CancellationToken cancellationToken = default) {
+            int call = Interlocked.Increment(ref _callCount);
+            int active = Interlocked.Increment(ref _activeCalls);
+            while (true) {
+                int current = _maximumConcurrentCalls;
+                if (active <= current || Interlocked.CompareExchange(ref _maximumConcurrentCalls, active, current) == current) break;
+            }
+            try {
+                if (call == 1) return await _firstCall.Task.ConfigureAwait(false);
+                _secondCallStarted.TrySetResult(null);
+                return new OfficeOcrEngineResult { Text = "second" };
+            } finally {
+                Interlocked.Decrement(ref _activeCalls);
+            }
+        }
+    }
+
+    private sealed class NonCooperativeConcurrentOcrEngine : IOfficeOcrEngine {
+        private readonly TaskCompletionSource<OfficeOcrEngineResult> _completion = new TaskCompletionSource<OfficeOcrEngineResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _activeCalls;
+        private int _callCount;
+        private int _maximumConcurrentCalls;
+
+        public string Id => "non-cooperative-concurrent-fixture";
+
+        public OfficeOcrEngineCapabilities Capabilities { get; } = new OfficeOcrEngineCapabilities {
+            SupportedMediaTypes = new[] { "image/*" },
+            SupportsConcurrentRequests = true
+        };
+
+        internal int CallCount => _callCount;
+
+        internal int MaximumConcurrentCalls => _maximumConcurrentCalls;
+
+        internal void CompleteCalls() {
+            _completion.TrySetResult(new OfficeOcrEngineResult { Text = "late" });
+        }
+
+        public async ValueTask<OfficeOcrEngineResult> RecognizeAsync(OfficeOcrEngineRequest request, CancellationToken cancellationToken = default) {
+            Interlocked.Increment(ref _callCount);
+            int active = Interlocked.Increment(ref _activeCalls);
+            while (true) {
+                int current = _maximumConcurrentCalls;
+                if (active <= current || Interlocked.CompareExchange(ref _maximumConcurrentCalls, active, current) == current) break;
+            }
+            try {
+                return await _completion.Task.ConfigureAwait(false);
+            } finally {
+                Interlocked.Decrement(ref _activeCalls);
+            }
+        }
     }
 
     private sealed class RecordingOcrEngine : IOfficeOcrEngine {

--- a/OfficeIMO.Reader.Tests/Reader.Ocr.Core.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Ocr.Core.cs
@@ -86,6 +86,19 @@ public sealed class ReaderOcrCoreTests {
     }
 
     [Fact]
+    public async Task ApplyOcrAsync_RejectsUnknownMediaTypeForRestrictedEngine() {
+        OfficeDocumentReadResult source = CreateDocument(1);
+        source.Assets[0].MediaType = null;
+        var engine = new RecordingOcrEngine();
+
+        OfficeDocumentOcrExecutionResult execution = await source.ApplyOcrAsync(engine);
+
+        Assert.Empty(engine.CandidateIds);
+        Assert.Equal(0, execution.Report.AttemptedCandidateCount);
+        Assert.Contains(execution.Diagnostics, diagnostic => diagnostic.Code == "ocr-media-type-unsupported");
+    }
+
+    [Fact]
     public async Task ApplyOcrAsync_BoundsProviderTextSpansAndConfidenceDiagnostics() {
         OfficeDocumentReadResult source = CreateDocument(1);
         var engine = new DelegateOfficeOcrEngine("bounded-fixture", (request, cancellationToken) => new ValueTask<OfficeOcrEngineResult>(new OfficeOcrEngineResult {
@@ -272,6 +285,23 @@ public sealed class ReaderOcrCoreTests {
     }
 
     [Fact]
+    public async Task ApplyOcrAsync_DoesNotStartQueuedCandidatesAfterFailFastFailure() {
+        var engine = new FailFastConcurrentOcrEngine();
+        Task<OfficeDocumentOcrExecutionResult> execution = CreateDocument(5).ApplyOcrAsync(
+            engine,
+            new OfficeDocumentOcrExecutionOptions {
+                ContinueOnError = false,
+                MaxDegreeOfParallelism = 2
+            });
+
+        await engine.SecondCallStarted;
+        engine.FailFirstCall();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => execution);
+        Assert.Equal(2, engine.CallCount);
+    }
+
+    [Fact]
     public async Task OfficeDocumentOcrProcessor_FreezesOptionsForReaderPipeline() {
         var options = new OfficeDocumentOcrExecutionOptions { MaxCandidates = 1 };
         var processor = new OfficeDocumentOcrProcessor(new RecordingOcrEngine(), options);
@@ -409,6 +439,38 @@ public sealed class ReaderOcrCoreTests {
             } finally {
                 Interlocked.Decrement(ref _activeCalls);
             }
+        }
+    }
+
+    private sealed class FailFastConcurrentOcrEngine : IOfficeOcrEngine {
+        private readonly TaskCompletionSource<object?> _failFirstCall = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<object?> _secondCallStarted = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _callCount;
+
+        public string Id => "fail-fast-concurrent-fixture";
+
+        public OfficeOcrEngineCapabilities Capabilities { get; } = new OfficeOcrEngineCapabilities {
+            SupportedMediaTypes = new[] { "image/*" },
+            SupportsConcurrentRequests = true
+        };
+
+        internal int CallCount => _callCount;
+
+        internal Task SecondCallStarted => _secondCallStarted.Task;
+
+        internal void FailFirstCall() {
+            _failFirstCall.TrySetResult(null);
+        }
+
+        public async ValueTask<OfficeOcrEngineResult> RecognizeAsync(OfficeOcrEngineRequest request, CancellationToken cancellationToken = default) {
+            int call = Interlocked.Increment(ref _callCount);
+            if (call == 1) {
+                await _failFirstCall.Task.ConfigureAwait(false);
+                throw new InvalidOperationException("Provider failure.");
+            }
+            _secondCallStarted.TrySetResult(null);
+            await Task.Delay(TimeSpan.FromMilliseconds(50), cancellationToken).ConfigureAwait(false);
+            return new OfficeOcrEngineResult { Text = "recognized" };
         }
     }
 

--- a/OfficeIMO.Reader.Tests/Reader.Ocr.Core.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Ocr.Core.cs
@@ -1,0 +1,240 @@
+using OfficeIMO.Reader;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class ReaderOcrCoreTests {
+    [Fact]
+    public async Task ApplyOcrAsync_PreservesCandidateOrderAndDetailedSpansUnderConcurrency() {
+        OfficeDocumentReadResult source = CreateDocument(2);
+        var engine = new RecordingOcrEngine();
+
+        OfficeDocumentOcrExecutionResult execution = await source.ApplyOcrAsync(engine, new OfficeDocumentOcrExecutionOptions {
+            Language = "en",
+            MaxDegreeOfParallelism = 2
+        });
+
+        Assert.Equal(2, execution.Report.CandidateCount);
+        Assert.Equal(2, execution.Report.AttemptedCandidateCount);
+        Assert.Equal(2, execution.Report.RecognizedCandidateCount);
+        Assert.Equal(0, execution.Report.SkippedCandidateCount);
+        Assert.Equal(2, execution.Report.EffectiveDegreeOfParallelism);
+        Assert.Equal(2, execution.Report.LineSpanCount);
+        Assert.Equal(2, execution.Report.WordSpanCount);
+        Assert.Equal(2, execution.Report.CharacterSpanCount);
+        Assert.True(engine.MaximumConcurrentCalls >= 2);
+        Assert.Equal(new[] { "ocr-1", "ocr-2" }, execution.Recognitions.Select(item => item.CandidateId).ToArray());
+        Assert.Contains(execution.Recognitions[0].Result.Spans, span => span.Level == OfficeOcrTextSpanLevel.Line);
+        Assert.Contains(execution.Recognitions[0].Result.Spans, span => span.Level == OfficeOcrTextSpanLevel.Word);
+        Assert.Contains(execution.Recognitions[0].Result.Spans, span => span.Level == OfficeOcrTextSpanLevel.Character);
+        Assert.Empty(execution.Document.OcrCandidates);
+        Assert.Equal(2, execution.Document.Blocks.Count(block => block.Kind == "ocr-text"));
+        Assert.DoesNotContain(execution.Document.Diagnostics, diagnostic => diagnostic.Code == "ocr-needed");
+        Assert.Contains("officeimo.reader.ocr-execution", execution.Document.CapabilitiesUsed);
+        Assert.Contains("officeimo.reader.ocr-engine.fixture-engine", execution.Document.CapabilitiesUsed);
+        Assert.Equal("2", Assert.Single(execution.Document.Metadata, item => item.Id == "reader-ocr-execution-recognized-count").Value);
+    }
+
+    [Fact]
+    public async Task ApplyOcrAsync_EnforcesCandidateAssetHashAndPayloadLimitsBeforeCallingEngine() {
+        OfficeDocumentReadResult source = CreateDocument(5);
+        source.OcrCandidates[1].AssetId = "missing";
+        source.Assets[2].PayloadHash = new string('0', 64);
+        source.Assets[3].PayloadBytes = new byte[] { 1, 2, 3 };
+        source.Assets[3].LengthBytes = 3;
+        var engine = new RecordingOcrEngine();
+
+        OfficeDocumentOcrExecutionResult execution = await source.ApplyOcrAsync(engine, new OfficeDocumentOcrExecutionOptions {
+            MaxCandidates = 4,
+            MaxInputBytesPerCandidate = 2,
+            MaxTotalInputBytes = 8
+        });
+
+        Assert.Equal(new[] { "ocr-1" }, engine.CandidateIds);
+        Assert.Equal(1, execution.Report.AttemptedCandidateCount);
+        Assert.Equal(1, execution.Report.RecognizedCandidateCount);
+        Assert.Equal(4, execution.Report.SkippedCandidateCount);
+        Assert.Contains(execution.Diagnostics, diagnostic => diagnostic.Code == "ocr-candidate-limit");
+        Assert.Contains(execution.Diagnostics, diagnostic => diagnostic.Code == "ocr-asset-missing");
+        Assert.Contains(execution.Diagnostics, diagnostic => diagnostic.Code == "ocr-payload-hash-mismatch");
+        Assert.Contains(execution.Diagnostics, diagnostic => diagnostic.Code == "ocr-input-limit");
+        Assert.Equal(4, execution.Document.OcrCandidates.Count);
+    }
+
+    [Fact]
+    public async Task ApplyOcrAsync_BoundsProviderTextSpansAndConfidenceDiagnostics() {
+        OfficeDocumentReadResult source = CreateDocument(1);
+        var engine = new DelegateOfficeOcrEngine("bounded-fixture", (request, cancellationToken) => new ValueTask<OfficeOcrEngineResult>(new OfficeOcrEngineResult {
+            Text = "1234567890",
+            Confidence = 1.5,
+            Spans = new[] {
+                new OfficeOcrTextSpan { Sequence = 0, Level = OfficeOcrTextSpanLevel.Line, Text = "1234567890", Confidence = -0.5 },
+                new OfficeOcrTextSpan { Sequence = 1, Level = OfficeOcrTextSpanLevel.Word, Text = "12345" },
+                new OfficeOcrTextSpan { Sequence = 2, Level = OfficeOcrTextSpanLevel.Character, Text = "1" }
+            }
+        }));
+
+        OfficeDocumentOcrExecutionResult execution = await source.ApplyOcrAsync(engine, new OfficeDocumentOcrExecutionOptions {
+            MaxRecognizedCharactersPerCandidate = 5,
+            MaxSpansPerCandidate = 2
+        });
+
+        Assert.Equal("12345", Assert.Single(execution.Document.Blocks, block => block.Kind == "ocr-text").Text);
+        OfficeOcrEngineResult result = Assert.Single(execution.Recognitions).Result;
+        Assert.Equal(1D, result.Confidence);
+        Assert.Equal(0D, result.Spans[0].Confidence);
+        Assert.Equal(2, result.Spans.Count);
+        Assert.Contains(execution.Diagnostics, diagnostic => diagnostic.Code == "ocr-text-limit");
+        Assert.Contains(execution.Diagnostics, diagnostic => diagnostic.Code == "ocr-span-limit");
+        Assert.Single(execution.Diagnostics, diagnostic => diagnostic.Code == "ocr-confidence-out-of-range");
+    }
+
+    [Fact]
+    public async Task ApplyOcrAsync_ConvertsPerCandidateTimeoutToRecoverableDiagnostic() {
+        OfficeDocumentReadResult source = CreateDocument(1);
+        var engine = new DelegateOfficeOcrEngine("slow-fixture", async (request, cancellationToken) => {
+            await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+            return new OfficeOcrEngineResult { Text = "late" };
+        });
+
+        OfficeDocumentOcrExecutionResult execution = await source.ApplyOcrAsync(engine, new OfficeDocumentOcrExecutionOptions {
+            CandidateTimeout = TimeSpan.FromMilliseconds(20),
+            ContinueOnError = true
+        });
+
+        Assert.Equal(1, execution.Report.FailedCandidateCount);
+        Assert.Equal(0, execution.Report.RecognizedCandidateCount);
+        Assert.Empty(execution.Recognitions);
+        Assert.Single(execution.Document.OcrCandidates);
+        Assert.Contains(execution.Diagnostics, diagnostic => diagnostic.Code == "ocr-engine-timeout" && diagnostic.IsRecoverable == true);
+    }
+
+    [Fact]
+    public async Task ApplyOcrAsync_SerializesConcurrentExecutionsForNonConcurrentEngineInstance() {
+        var engine = new RecordingOcrEngine(supportsConcurrentRequests: false);
+
+        await Task.WhenAll(
+            CreateDocument(1).ApplyOcrAsync(engine),
+            CreateDocument(1).ApplyOcrAsync(engine));
+
+        Assert.Equal(1, engine.MaximumConcurrentCalls);
+    }
+
+    [Fact]
+    public async Task OfficeDocumentOcrProcessor_FreezesOptionsForReaderPipeline() {
+        var options = new OfficeDocumentOcrExecutionOptions { MaxCandidates = 1 };
+        var processor = new OfficeDocumentOcrProcessor(new RecordingOcrEngine(), options);
+        options.MaxCandidates = 2;
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder().AddProcessor(processor).Build();
+
+        OfficeDocumentProcessingResult processing = await reader.ProcessDocumentAsync(CreateDocument(2));
+
+        Assert.True(processing.Succeeded);
+        Assert.Equal(1, processing.Document.Blocks.Count(block => block.Kind == "ocr-text"));
+        Assert.Single(processing.Document.OcrCandidates);
+        Assert.Equal("1", Assert.Single(processing.Document.Metadata, item => item.Id == "reader-ocr-execution-attempted-count").Value);
+
+        OfficeDocumentProcessingResult synchronous = reader.ProcessDocument(CreateDocument(2));
+        Assert.True(synchronous.Succeeded);
+        Assert.Equal(1, synchronous.Document.Blocks.Count(block => block.Kind == "ocr-text"));
+    }
+
+    private static OfficeDocumentReadResult CreateDocument(int count) {
+        var assets = new List<OfficeDocumentAsset>();
+        var candidates = new List<OfficeDocumentOcrCandidate>();
+        var diagnostics = new List<OfficeDocumentDiagnostic>();
+        var pages = new List<OfficeDocumentPage>();
+        for (int index = 1; index <= count; index++) {
+            byte[] payload = new[] { (byte)index };
+            string assetId = "asset-" + index;
+            var location = new ReaderLocation { Path = "scan.pdf", Page = index, SourceBlockKind = "image", BlockAnchor = assetId };
+            assets.Add(new OfficeDocumentAsset {
+                Id = assetId,
+                Kind = "image",
+                MediaType = "image/png",
+                Extension = ".png",
+                LengthBytes = payload.LongLength,
+                PayloadBytes = payload,
+                PayloadHash = OfficeDocumentAssetHash.ComputeSha256Hex(payload),
+                Location = location
+            });
+            var candidate = new OfficeDocumentOcrCandidate {
+                Id = "ocr-" + index,
+                Kind = "image",
+                AssetId = assetId,
+                Location = location,
+                Region = new OfficeDocumentRegion { X = 0, Y = 0, Width = 10, Height = 10 }
+            };
+            candidates.Add(candidate);
+            diagnostics.Add(new OfficeDocumentDiagnostic {
+                Category = OfficeDocumentDiagnosticCategory.Ocr,
+                Code = "ocr-needed",
+                Message = "OCR needed.",
+                Location = location
+            });
+            pages.Add(new OfficeDocumentPage { Number = index, Location = new ReaderLocation { Path = "scan.pdf", Page = index }, OcrCandidates = new[] { candidate } });
+        }
+        return new OfficeDocumentReadResult {
+            Kind = ReaderInputKind.Pdf,
+            Source = new OfficeDocumentSource { Path = "scan.pdf", SourceId = "scan" },
+            Assets = assets,
+            OcrCandidates = candidates,
+            Diagnostics = diagnostics,
+            Pages = pages
+        };
+    }
+
+    private sealed class RecordingOcrEngine : IOfficeOcrEngine {
+        private readonly List<string> _candidateIds = new List<string>();
+        private int _activeCalls;
+        private int _maximumConcurrentCalls;
+
+        internal RecordingOcrEngine(bool supportsConcurrentRequests = true) {
+            Capabilities = new OfficeOcrEngineCapabilities {
+                SupportedMediaTypes = new[] { "image/*" },
+                SupportsLineSpans = true,
+                SupportsWordSpans = true,
+                SupportsCharacterSpans = true,
+                SupportsConfidence = true,
+                SupportsConcurrentRequests = supportsConcurrentRequests
+            };
+        }
+
+        public string Id => "fixture-engine";
+
+        public OfficeOcrEngineCapabilities Capabilities { get; }
+
+        internal IReadOnlyList<string> CandidateIds {
+            get { lock (_candidateIds) return _candidateIds.ToArray(); }
+        }
+
+        internal int MaximumConcurrentCalls => _maximumConcurrentCalls;
+
+        public async ValueTask<OfficeOcrEngineResult> RecognizeAsync(OfficeOcrEngineRequest request, CancellationToken cancellationToken = default) {
+            lock (_candidateIds) _candidateIds.Add(request.Candidate.Id);
+            int active = Interlocked.Increment(ref _activeCalls);
+            while (true) {
+                int current = _maximumConcurrentCalls;
+                if (active <= current || Interlocked.CompareExchange(ref _maximumConcurrentCalls, active, current) == current) break;
+            }
+            try {
+                await Task.Delay(request.Candidate.Id == "ocr-1" ? 40 : 5, cancellationToken);
+                string text = "Text for " + request.Candidate.Id;
+                return new OfficeOcrEngineResult {
+                    Text = text,
+                    Confidence = 0.9,
+                    Language = request.Language,
+                    Spans = new[] {
+                        new OfficeOcrTextSpan { Sequence = 0, Level = OfficeOcrTextSpanLevel.Line, Text = text },
+                        new OfficeOcrTextSpan { Sequence = 1, Level = OfficeOcrTextSpanLevel.Word, Text = "Text" },
+                        new OfficeOcrTextSpan { Sequence = 2, Level = OfficeOcrTextSpanLevel.Character, Text = "T" }
+                    }
+                };
+            } finally {
+                Interlocked.Decrement(ref _activeCalls);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Reader.Tests/Reader.Ocr.Core.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Ocr.Core.cs
@@ -214,7 +214,9 @@ public sealed class ReaderOcrCoreTests {
             Assert.NotSame(engine.SecondCallStarted, earlyStart);
 
             engine.CompleteFirstCall();
-            await second.WaitAsync(TimeSpan.FromSeconds(2));
+            Task completed = await Task.WhenAny(second, Task.Delay(TimeSpan.FromSeconds(2)));
+            Assert.Same(second, completed);
+            await second;
 
             Assert.Equal(1, engine.MaximumConcurrentCalls);
         } finally {

--- a/OfficeIMO.Reader.Tests/Reader.Ocr.Core.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Ocr.Core.cs
@@ -112,6 +112,57 @@ public sealed class ReaderOcrCoreTests {
     }
 
     [Fact]
+    public async Task ApplyOcrAsync_EnforcesTimeoutWhenEngineIgnoresCancellation() {
+        OfficeDocumentReadResult source = CreateDocument(1);
+        var completion = new TaskCompletionSource<OfficeOcrEngineResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var engine = new DelegateOfficeOcrEngine(
+            "non-cooperative-fixture",
+            (_, _) => new ValueTask<OfficeOcrEngineResult>(completion.Task));
+
+        try {
+            Task<OfficeDocumentOcrExecutionResult> executionTask = source.ApplyOcrAsync(engine, new OfficeDocumentOcrExecutionOptions {
+                CandidateTimeout = TimeSpan.FromMilliseconds(20),
+                ContinueOnError = true
+            });
+            Task completed = await Task.WhenAny(executionTask, Task.Delay(TimeSpan.FromSeconds(2)));
+
+            Assert.Same(executionTask, completed);
+            OfficeDocumentOcrExecutionResult execution = await executionTask;
+            Assert.Equal(1, execution.Report.FailedCandidateCount);
+            Assert.Contains(execution.Diagnostics, diagnostic => diagnostic.Code == "ocr-engine-timeout");
+        } finally {
+            completion.TrySetResult(new OfficeOcrEngineResult { Text = "late" });
+        }
+    }
+
+    [Fact]
+    public async Task ApplyOcrAsync_RemovesNonFiniteConfidenceAndNullProviderDiagnostics() {
+        OfficeDocumentReadResult source = CreateDocument(1);
+        var engine = new DelegateOfficeOcrEngine("permissive-fixture", (_, _) => new ValueTask<OfficeOcrEngineResult>(new OfficeOcrEngineResult {
+            Text = "recognized",
+            Confidence = double.NaN,
+            Spans = new[] {
+                new OfficeOcrTextSpan { Sequence = 0, Level = OfficeOcrTextSpanLevel.Word, Text = "recognized", Confidence = double.PositiveInfinity }
+            },
+            Diagnostics = new OfficeDocumentDiagnostic[] {
+                null!,
+                new OfficeDocumentDiagnostic { Code = "provider-warning", Message = "Provider warning." }
+            }
+        }));
+
+        OfficeDocumentOcrExecutionResult execution = await source.ApplyOcrAsync(engine);
+
+        OfficeOcrEngineResult result = Assert.Single(execution.Recognitions).Result;
+        Assert.Null(result.Confidence);
+        Assert.Null(Assert.Single(result.Spans).Confidence);
+        OfficeDocumentDiagnostic providerDiagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(OfficeDocumentDiagnosticCategory.Ocr, providerDiagnostic.Category);
+        Assert.Equal("permissive-fixture", providerDiagnostic.Source);
+        Assert.NotNull(providerDiagnostic.Location);
+        Assert.Single(execution.Diagnostics, diagnostic => diagnostic.Code == "ocr-confidence-out-of-range");
+    }
+
+    [Fact]
     public async Task ApplyOcrAsync_SerializesConcurrentExecutionsForNonConcurrentEngineInstance() {
         var engine = new RecordingOcrEngine(supportsConcurrentRequests: false);
 

--- a/OfficeIMO.Reader.Tests/Reader.Ocr.Process.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Ocr.Process.cs
@@ -1,6 +1,7 @@
 using OfficeIMO.Reader;
 using OfficeIMO.Reader.Ocr.Process;
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
@@ -50,23 +51,31 @@ public sealed class ReaderOcrProcessTests {
     }
 
     [Fact]
-    public async Task OfficeOcrProcessRunner_KeepsTimeoutActiveWhileDrainingInheritedPipes() {
+    public async Task OfficeOcrProcessRunner_TerminatesWrapperDescendantsAfterTimeout() {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
         string directory = Path.Combine(Path.GetTempPath(), "officeimo-ocr-runner-pipe-test-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);
+        int? childProcessId = null;
         try {
             string scriptPath = Path.Combine(directory, "inherited-pipe.sh");
-            File.WriteAllText(scriptPath, "(trap '' HUP; sleep 2) &\nexit 0\n");
+            string childProcessPath = Path.Combine(directory, "child.pid");
+            File.WriteAllText(scriptPath, "(trap '' HUP; sleep 30) &\necho $! > \"$1\"\nexit 0\n");
             var stopwatch = Stopwatch.StartNew();
 
             await Assert.ThrowsAsync<TimeoutException>(() => OfficeOcrProcessRunner.RunAsync(new OfficeOcrProcessCommand {
                 FileName = "/bin/sh",
-                Arguments = new[] { scriptPath },
+                Arguments = new[] { scriptPath, childProcessPath },
                 Timeout = TimeSpan.FromMilliseconds(100)
             }));
 
             Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(1.5), "The process runner waited for inherited pipe handles after its timeout.");
+            Assert.True(File.Exists(childProcessPath), "The wrapper did not record its child process id.");
+            childProcessId = int.Parse(File.ReadAllText(childProcessPath), CultureInfo.InvariantCulture);
+            Assert.True(
+                await WaitForProcessExitAsync(childProcessId.Value, TimeSpan.FromSeconds(2)),
+                "The process runner left a wrapper child alive after its timeout.");
         } finally {
+            if (childProcessId.HasValue) TryKillProcess(childProcessId.Value);
             if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
         }
     }
@@ -114,6 +123,29 @@ public sealed class ReaderOcrProcessTests {
             Assert.Empty(Directory.EnumerateDirectories(directory, "officeimo-ocr-*"));
         } finally {
             if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static async Task<bool> WaitForProcessExitAsync(int processId, TimeSpan timeout) {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < timeout) {
+            try {
+                using System.Diagnostics.Process process = System.Diagnostics.Process.GetProcessById(processId);
+                if (process.HasExited) return true;
+            } catch (ArgumentException) {
+                return true;
+            }
+            await Task.Delay(20);
+        }
+        return false;
+    }
+
+    private static void TryKillProcess(int processId) {
+        try {
+            using System.Diagnostics.Process process = System.Diagnostics.Process.GetProcessById(processId);
+            if (!process.HasExited) process.Kill();
+        } catch (ArgumentException) {
+        } catch (InvalidOperationException) {
         }
     }
 }

--- a/OfficeIMO.Reader.Tests/Reader.Ocr.Process.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Ocr.Process.cs
@@ -10,6 +10,37 @@ namespace OfficeIMO.Tests;
 
 public sealed class ReaderOcrProcessTests {
     [Fact]
+    public void OfficeOcrTemporaryStorage_CreatesOwnerOnlyUnixDirectoryAndFile() {
+#if NET8_0_OR_GREATER
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        string root = Path.Combine(Path.GetTempPath(), "officeimo-private-ocr-test-" + Guid.NewGuid().ToString("N"));
+        try {
+            string requestDirectory = OfficeOcrTemporaryStorage.CreateRequestDirectory(root, "request-");
+            string payloadPath = Path.Combine(requestDirectory, "payload.bin");
+            string outputPath = Path.Combine(requestDirectory, "result.json");
+            OfficeOcrTemporaryStorage.WriteAllBytes(payloadPath, new byte[] { 1, 2, 3 });
+            File.WriteAllText(outputPath, "{}");
+            OfficeOcrTemporaryStorage.EnsurePrivateFile(outputPath);
+
+            const UnixFileMode allPermissions = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                | UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute
+                | UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+            Assert.Equal(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute,
+                File.GetUnixFileMode(requestDirectory) & allPermissions);
+            Assert.Equal(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite,
+                File.GetUnixFileMode(payloadPath) & allPermissions);
+            Assert.Equal(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite,
+                File.GetUnixFileMode(outputPath) & allPermissions);
+        } finally {
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+#endif
+    }
+
+    [Fact]
     public void ProcessOfficeOcrProtocol_RejectsIncompatibleResponseVersion() {
         const string json = "{\"schemaId\":\"officeimo.reader.ocr.process-response\",\"schemaVersion\":2,\"result\":{\"text\":\"late\"}}";
 

--- a/OfficeIMO.Reader.Tests/Reader.Ocr.Process.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Ocr.Process.cs
@@ -1,0 +1,87 @@
+using OfficeIMO.Reader;
+using OfficeIMO.Reader.Ocr.Process;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class ReaderOcrProcessTests {
+    [Fact]
+    public void ProcessOfficeOcrProtocol_RejectsIncompatibleResponseVersion() {
+        const string json = "{\"schemaId\":\"officeimo.reader.ocr.process-response\",\"schemaVersion\":2,\"result\":{\"text\":\"late\"}}";
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() => ProcessOfficeOcrProtocol.DeserializeResult(json));
+
+        Assert.Contains("version", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task OfficeOcrProcessRunner_DrainsAndBoundsStandardOutput() {
+        string directory = Path.Combine(Path.GetTempPath(), "officeimo-ocr-runner-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try {
+            bool windows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            string scriptPath = Path.Combine(directory, windows ? "output.cmd" : "output.sh");
+            File.WriteAllText(scriptPath, windows ? "@echo 1234567890\r\n" : "printf 1234567890\n");
+            OfficeOcrProcessResult result = await OfficeOcrProcessRunner.RunAsync(new OfficeOcrProcessCommand {
+                FileName = windows ? Environment.GetEnvironmentVariable("ComSpec") ?? "cmd.exe" : "/bin/sh",
+                Arguments = windows ? new[] { "/d", "/c", scriptPath } : new[] { scriptPath },
+                MaxStandardOutputCharacters = 5,
+                MaxStandardErrorCharacters = 5
+            });
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal("12345", result.StandardOutput);
+            Assert.True(result.StandardOutputTruncated);
+        } finally {
+            if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ProcessOfficeOcrEngine_RoundTripsVersionedJsonProtocolWithoutShellExpansion() {
+        string directory = Path.Combine(Path.GetTempPath(), "officeimo-ocr-process-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try {
+            string responsePath = Path.Combine(directory, "fixture result.json");
+            File.WriteAllText(responsePath, ProcessOfficeOcrProtocol.SerializeResult(new OfficeOcrEngineResult {
+                Text = "Invoice 1042",
+                Confidence = 0.97,
+                Language = "eng",
+                Provider = "fixture-process",
+                Spans = new[] {
+                    new OfficeOcrTextSpan { Sequence = 0, Level = OfficeOcrTextSpanLevel.Character, Text = "I", Confidence = 0.99 }
+                }
+            }));
+            bool windows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            string scriptPath = Path.Combine(directory, windows ? "copy response.cmd" : "copy response.sh");
+            File.WriteAllText(scriptPath, windows ? "@copy /Y \"%~1\" \"%~2\" >nul\r\n" : "cp \"$1\" \"$2\"\n");
+            var arguments = windows
+                ? new[] { "/d", "/c", scriptPath, responsePath, "{output}" }
+                : new[] { scriptPath, responsePath, "{output}" };
+            var engine = new ProcessOfficeOcrEngine(new ProcessOfficeOcrEngineOptions {
+                FileName = windows ? Environment.GetEnvironmentVariable("ComSpec") ?? "cmd.exe" : "/bin/sh",
+                Arguments = arguments,
+                Id = "fixture-process",
+                TemporaryDirectory = directory
+            });
+            byte[] payload = new byte[] { 1, 2, 3 };
+
+            OfficeOcrEngineResult result = await engine.RecognizeAsync(new OfficeOcrEngineRequest {
+                Candidate = new OfficeDocumentOcrCandidate { Id = "ocr-1", Kind = "image", AssetId = "asset-1" },
+                Asset = new OfficeDocumentAsset { Id = "asset-1", Kind = "image", MediaType = "image/png", Extension = ".png" },
+                Payload = payload,
+                Language = "eng",
+                Source = new OfficeDocumentSource { Path = "scan.pdf" }
+            });
+
+            Assert.Equal("Invoice 1042", result.Text);
+            Assert.Equal("fixture-process", result.Provider);
+            Assert.Equal(OfficeOcrTextSpanLevel.Character, Assert.Single(result.Spans).Level);
+            Assert.Empty(Directory.EnumerateDirectories(directory, "officeimo-ocr-*"));
+        } finally {
+            if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/OfficeIMO.Reader.Tests/Reader.Ocr.Process.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Ocr.Process.cs
@@ -1,5 +1,6 @@
 using OfficeIMO.Reader;
 using OfficeIMO.Reader.Ocr.Process;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
@@ -14,6 +15,15 @@ public sealed class ReaderOcrProcessTests {
         InvalidDataException exception = Assert.Throws<InvalidDataException>(() => ProcessOfficeOcrProtocol.DeserializeResult(json));
 
         Assert.Contains("version", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("{\"schemaVersion\":1,\"result\":{\"text\":\"unversioned\"}}", "schemaId")]
+    [InlineData("{\"schemaId\":\"officeimo.reader.ocr.process-response\",\"result\":{\"text\":\"unversioned\"}}", "schemaVersion")]
+    public void ProcessOfficeOcrProtocol_RejectsMissingResponseSchemaFields(string json, string field) {
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() => ProcessOfficeOcrProtocol.DeserializeResult(json));
+
+        Assert.Contains(field, exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -34,6 +44,28 @@ public sealed class ReaderOcrProcessTests {
             Assert.Equal(0, result.ExitCode);
             Assert.Equal("12345", result.StandardOutput);
             Assert.True(result.StandardOutputTruncated);
+        } finally {
+            if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task OfficeOcrProcessRunner_KeepsTimeoutActiveWhileDrainingInheritedPipes() {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        string directory = Path.Combine(Path.GetTempPath(), "officeimo-ocr-runner-pipe-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try {
+            string scriptPath = Path.Combine(directory, "inherited-pipe.sh");
+            File.WriteAllText(scriptPath, "(trap '' HUP; sleep 2) &\nexit 0\n");
+            var stopwatch = Stopwatch.StartNew();
+
+            await Assert.ThrowsAsync<TimeoutException>(() => OfficeOcrProcessRunner.RunAsync(new OfficeOcrProcessCommand {
+                FileName = "/bin/sh",
+                Arguments = new[] { scriptPath },
+                Timeout = TimeSpan.FromMilliseconds(100)
+            }));
+
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(1.5), "The process runner waited for inherited pipe handles after its timeout.");
         } finally {
             if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
         }

--- a/OfficeIMO.Reader.Tests/Reader.Ocr.Tesseract.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Ocr.Tesseract.cs
@@ -1,0 +1,49 @@
+using OfficeIMO.Reader;
+using OfficeIMO.Reader.Ocr.Tesseract;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class ReaderOcrTesseractTests {
+    [Fact]
+    public void TesseractTsvParser_MapsLinesWordsConfidenceAndPixelGeometry() {
+        const string tsv = "level\tpage_num\tblock_num\tpar_num\tline_num\tword_num\tleft\ttop\twidth\theight\tconf\ttext\n"
+            + "1\t1\t0\t0\t0\t0\t0\t0\t200\t100\t-1\t\n"
+            + "5\t1\t1\t1\t1\t1\t10\t20\t40\t10\t90\tInvoice\n"
+            + "5\t1\t1\t1\t1\t2\t55\t20\t30\t10\t80\t1042\n"
+            + "5\t1\t1\t1\t2\t1\t10\t40\t50\t12\t100\tTotal\n";
+
+        OfficeOcrEngineResult result = TesseractTsvParser.Parse(tsv, "eng");
+
+        Assert.Equal("Invoice 1042" + Environment.NewLine + "Total", result.Text);
+        Assert.Equal(0.9D, result.Confidence!.Value, precision: 6);
+        Assert.Equal(2, result.Spans.Count(span => span.Level == OfficeOcrTextSpanLevel.Line));
+        Assert.Equal(3, result.Spans.Count(span => span.Level == OfficeOcrTextSpanLevel.Word));
+        OfficeOcrTextSpan firstLine = Assert.Single(result.Spans, span => span.Level == OfficeOcrTextSpanLevel.Line && span.Text == "Invoice 1042");
+        Assert.Equal(10D, firstLine.Region!.X);
+        Assert.Equal(75D, firstLine.Region.Width);
+        Assert.Equal(OfficeOcrCoordinateUnit.Pixels, firstLine.CoordinateUnit);
+        Assert.Equal("tesseract-cli", result.Provider);
+    }
+
+    [Fact]
+    public void TesseractOcrEngine_BuildsOptionsBeforeTsvOutputConfig() {
+        var engine = new TesseractOcrEngine(new TesseractOcrEngineOptions {
+            TessdataDirectory = "/models",
+            EngineMode = 1,
+            PageSegmentationMode = 6,
+            Dpi = 300,
+            AdditionalArguments = new[] { "quiet" }
+        });
+
+        IReadOnlyList<string> arguments = engine.BuildRecognitionArguments("input image.png", "result", "eng+pol");
+
+        Assert.Equal("input image.png", arguments[0]);
+        Assert.Equal("result", arguments[1]);
+        Assert.Contains("eng+pol", arguments);
+        Assert.Contains("/models", arguments);
+        Assert.Contains("300", arguments);
+        Assert.Equal("quiet", arguments[arguments.Count - 2]);
+        Assert.Equal("tsv", arguments[arguments.Count - 1]);
+    }
+}

--- a/OfficeIMO.Reader.Tests/Reader.Ocr.Tesseract.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Ocr.Tesseract.cs
@@ -46,4 +46,16 @@ public sealed class ReaderOcrTesseractTests {
         Assert.Equal("quiet", arguments[arguments.Count - 2]);
         Assert.Equal("tsv", arguments[arguments.Count - 1]);
     }
+
+    [Fact]
+    public void TesseractOcrEngine_AdvertisesRasterFormatsOnly() {
+        var engine = new TesseractOcrEngine();
+
+        Assert.Contains("image/png", engine.Capabilities.SupportedMediaTypes);
+        Assert.Contains("image/jpeg", engine.Capabilities.SupportedMediaTypes);
+        Assert.DoesNotContain("image/*", engine.Capabilities.SupportedMediaTypes);
+        Assert.DoesNotContain("image/svg+xml", engine.Capabilities.SupportedMediaTypes);
+        Assert.DoesNotContain("image/x-emf", engine.Capabilities.SupportedMediaTypes);
+        Assert.DoesNotContain("image/x-wmf", engine.Capabilities.SupportedMediaTypes);
+    }
 }

--- a/OfficeIMO.Reader/Ocr/IOfficeOcrEngine.cs
+++ b/OfficeIMO.Reader/Ocr/IOfficeOcrEngine.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>
+/// Recognizes text for one bounded OCR candidate without coupling the Reader core to a specific engine or service SDK.
+/// </summary>
+public interface IOfficeOcrEngine {
+    /// <summary>Stable provider identifier used in diagnostics and enrichment metadata.</summary>
+    string Id { get; }
+
+    /// <summary>Capabilities exposed by this engine instance.</summary>
+    OfficeOcrEngineCapabilities Capabilities { get; }
+
+    /// <summary>Recognizes text and optional detailed spans for one candidate asset.</summary>
+    ValueTask<OfficeOcrEngineResult> RecognizeAsync(OfficeOcrEngineRequest request, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Adapts a caller-owned OCR callback, including cloud SDK integrations, to <see cref="IOfficeOcrEngine"/>.
+/// </summary>
+public sealed class DelegateOfficeOcrEngine : IOfficeOcrEngine {
+    private readonly Func<OfficeOcrEngineRequest, CancellationToken, ValueTask<OfficeOcrEngineResult>> _recognizeAsync;
+    private readonly OfficeOcrEngineCapabilities _capabilities;
+
+    /// <summary>Creates a callback-backed OCR engine.</summary>
+    public DelegateOfficeOcrEngine(
+        string id,
+        Func<OfficeOcrEngineRequest, CancellationToken, ValueTask<OfficeOcrEngineResult>> recognizeAsync,
+        OfficeOcrEngineCapabilities? capabilities = null) {
+        if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("OCR engine id cannot be empty.", nameof(id));
+        Id = id.Trim();
+        _recognizeAsync = recognizeAsync ?? throw new ArgumentNullException(nameof(recognizeAsync));
+        _capabilities = (capabilities ?? new OfficeOcrEngineCapabilities()).Clone();
+    }
+
+    /// <inheritdoc />
+    public string Id { get; }
+
+    /// <inheritdoc />
+    public OfficeOcrEngineCapabilities Capabilities => _capabilities.Clone();
+
+    /// <inheritdoc />
+    public ValueTask<OfficeOcrEngineResult> RecognizeAsync(OfficeOcrEngineRequest request, CancellationToken cancellationToken = default) {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+        return _recognizeAsync(request, cancellationToken);
+    }
+}

--- a/OfficeIMO.Reader/Ocr/OfficeDocumentOcrExecution.Concurrency.cs
+++ b/OfficeIMO.Reader/Ocr/OfficeDocumentOcrExecution.Concurrency.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Reader;
+
+public static partial class OfficeDocumentOcrExecutionExtensions {
+    private static void ReleaseSharedEngineGate(SemaphoreSlim gate, AbandonedOcrOperationTracker operations) {
+        IReadOnlyList<Task> pending = operations.GetPendingOperations();
+        if (pending.Count == 0) {
+            gate.Release();
+            return;
+        }
+
+        _ = ReleaseSharedEngineGateWhenSettledAsync(gate, pending);
+    }
+
+    private static async Task ReleaseSharedEngineGateWhenSettledAsync(SemaphoreSlim gate, IReadOnlyList<Task> pending) {
+        try {
+            await Task.WhenAll(pending).ConfigureAwait(false);
+        } catch {
+            // ExecuteCandidateAsync observes provider failures. The shared gate still has to be released.
+        } finally {
+            gate.Release();
+        }
+    }
+
+    private sealed class AbandonedOcrOperationTracker {
+        private readonly object _sync = new object();
+        private readonly List<Task> _operations = new List<Task>();
+
+        internal bool HasPendingOperations {
+            get {
+                lock (_sync) {
+                    return _operations.Any(static operation => !operation.IsCompleted);
+                }
+            }
+        }
+
+        internal void Track(Task? operation) {
+            if (operation == null || operation.IsCompleted) return;
+            lock (_sync) {
+                if (!operation.IsCompleted) _operations.Add(operation);
+            }
+        }
+
+        internal IReadOnlyList<Task> GetPendingOperations() {
+            lock (_sync) {
+                return _operations.Where(static operation => !operation.IsCompleted).ToArray();
+            }
+        }
+    }
+}

--- a/OfficeIMO.Reader/Ocr/OfficeDocumentOcrExecution.Validation.cs
+++ b/OfficeIMO.Reader/Ocr/OfficeDocumentOcrExecution.Validation.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OfficeIMO.Reader;
+
+public static partial class OfficeDocumentOcrExecutionExtensions {
+    private static List<CandidateJob> BuildJobs(
+        OfficeDocumentReadResult document,
+        IReadOnlyList<OfficeDocumentOcrCandidate> candidates,
+        IReadOnlyList<OfficeDocumentAsset> assets,
+        OfficeOcrEngineCapabilities capabilities,
+        string engineId,
+        ExecutionOptionsSnapshot options,
+        List<OfficeDocumentDiagnostic> diagnostics) {
+        var jobs = new List<CandidateJob>(Math.Min(candidates.Count, options.MaxCandidates));
+        if (candidates.Count > options.MaxCandidates) {
+            diagnostics.Add(new OfficeDocumentDiagnostic {
+                Severity = OfficeDocumentDiagnosticSeverity.Warning,
+                Category = OfficeDocumentDiagnosticCategory.Limit,
+                Code = "ocr-candidate-limit",
+                Message = "OCR candidates were limited to MaxCandidates (" + options.MaxCandidates + ").",
+                Source = engineId,
+                IsRecoverable = true,
+                Location = document.Source == null ? null : new ReaderLocation { Path = document.Source.Path },
+                Attributes = new Dictionary<string, string>(StringComparer.Ordinal) {
+                    ["candidateCount"] = candidates.Count.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                    ["selectedCount"] = options.MaxCandidates.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                }
+            });
+        }
+
+        long totalBytes = 0;
+        int selectedCount = Math.Min(candidates.Count, options.MaxCandidates);
+        for (int index = 0; index < selectedCount; index++) {
+            OfficeDocumentOcrCandidate candidate = candidates[index];
+            OfficeDocumentAsset? asset = ResolveAsset(candidate, assets, out string? resolutionCode);
+            if (asset == null) {
+                diagnostics.Add(BuildDiagnostic(
+                    candidate,
+                    null,
+                    engineId,
+                    OfficeDocumentDiagnosticSeverity.Warning,
+                    OfficeDocumentDiagnosticCategory.Ocr,
+                    resolutionCode ?? "ocr-asset-missing",
+                    resolutionCode == "ocr-asset-ambiguous"
+                        ? "The OCR candidate does not identify one unambiguous source asset."
+                        : "The OCR candidate's source asset was not found.",
+                    true));
+                continue;
+            }
+
+            byte[]? sourcePayload = asset.PayloadBytes;
+            if (sourcePayload == null || sourcePayload.Length == 0) {
+                diagnostics.Add(BuildDiagnostic(candidate, asset, engineId, OfficeDocumentDiagnosticSeverity.Warning, OfficeDocumentDiagnosticCategory.Ocr,
+                    "ocr-asset-payload-missing", "The OCR source asset has no materialized payload bytes.", true));
+                continue;
+            }
+            if (sourcePayload.LongLength > options.MaxInputBytesPerCandidate) {
+                diagnostics.Add(BuildDiagnostic(candidate, asset, engineId, OfficeDocumentDiagnosticSeverity.Warning, OfficeDocumentDiagnosticCategory.Limit,
+                    "ocr-input-limit", "The OCR source asset exceeds MaxInputBytesPerCandidate.", true,
+                    BuildLimitAttributes(sourcePayload.LongLength, options.MaxInputBytesPerCandidate)));
+                continue;
+            }
+            if (sourcePayload.LongLength > options.MaxTotalInputBytes - totalBytes) {
+                diagnostics.Add(BuildDiagnostic(candidate, asset, engineId, OfficeDocumentDiagnosticSeverity.Warning, OfficeDocumentDiagnosticCategory.Limit,
+                    "ocr-total-input-limit", "The OCR source asset was skipped because MaxTotalInputBytes was reached.", true,
+                    BuildLimitAttributes(totalBytes + sourcePayload.LongLength, options.MaxTotalInputBytes)));
+                continue;
+            }
+            if (!IsSupportedMediaType(asset.MediaType, capabilities.SupportedMediaTypes)) {
+                diagnostics.Add(BuildDiagnostic(candidate, asset, engineId, OfficeDocumentDiagnosticSeverity.Warning, OfficeDocumentDiagnosticCategory.Ocr,
+                    "ocr-media-type-unsupported", "The OCR engine does not advertise support for media type '" + asset.MediaType + "'.", true));
+                continue;
+            }
+            if (options.RequirePayloadHashMatch && !string.IsNullOrWhiteSpace(asset.PayloadHash) && !asset.PayloadHashMatches(out string? actualHash)) {
+                diagnostics.Add(BuildDiagnostic(candidate, asset, engineId, OfficeDocumentDiagnosticSeverity.Error, OfficeDocumentDiagnosticCategory.Input,
+                    "ocr-payload-hash-mismatch", "The OCR source asset payload does not match its declared hash.", false,
+                    new Dictionary<string, string>(StringComparer.Ordinal) { ["actualHash"] = actualHash ?? string.Empty }));
+                continue;
+            }
+
+            byte[] payload = sourcePayload.ToArray();
+            jobs.Add(new CandidateJob(index, candidate, asset, payload));
+            totalBytes += payload.LongLength;
+        }
+        return jobs;
+    }
+
+    private static OfficeDocumentAsset? ResolveAsset(
+        OfficeDocumentOcrCandidate candidate,
+        IReadOnlyList<OfficeDocumentAsset> assets,
+        out string? resolutionCode) {
+        resolutionCode = null;
+        if (!string.IsNullOrWhiteSpace(candidate.AssetId)) {
+            OfficeDocumentAsset? exact = assets.FirstOrDefault(asset => string.Equals(asset.Id, candidate.AssetId, StringComparison.Ordinal));
+            if (exact == null) resolutionCode = "ocr-asset-missing";
+            return exact;
+        }
+
+        OfficeDocumentAsset[] matches = assets
+            .Where(static asset => string.Equals(asset.Kind, "image", StringComparison.OrdinalIgnoreCase))
+            .Where(asset => IsSameContainer(candidate.Location, asset.Location))
+            .Take(2)
+            .ToArray();
+        if (matches.Length == 1) return matches[0];
+        resolutionCode = matches.Length == 0 ? "ocr-asset-missing" : "ocr-asset-ambiguous";
+        return null;
+    }
+
+    private static bool IsSameContainer(ReaderLocation candidate, ReaderLocation asset) {
+        if (candidate.Page.HasValue) return candidate.Page == asset.Page;
+        if (candidate.Slide.HasValue) return candidate.Slide == asset.Slide;
+        if (!string.IsNullOrWhiteSpace(candidate.Sheet)) return string.Equals(candidate.Sheet, asset.Sheet, StringComparison.Ordinal);
+        if (!string.IsNullOrWhiteSpace(candidate.A1Range)) return string.Equals(candidate.A1Range, asset.A1Range, StringComparison.Ordinal);
+        return string.Equals(candidate.Path, asset.Path, StringComparison.Ordinal);
+    }
+
+    private static bool IsSupportedMediaType(string? mediaType, IReadOnlyList<string>? supported) {
+        if (string.IsNullOrWhiteSpace(mediaType) || supported == null || supported.Count == 0) return true;
+        foreach (string declared in supported) {
+            if (string.IsNullOrWhiteSpace(declared)) continue;
+            if (string.Equals(declared, mediaType, StringComparison.OrdinalIgnoreCase)) return true;
+            if (declared.EndsWith("/*", StringComparison.Ordinal) && mediaType!.StartsWith(declared.Substring(0, declared.Length - 1), StringComparison.OrdinalIgnoreCase)) return true;
+        }
+        return false;
+    }
+
+    private static void NormalizeEngineResult(
+        OfficeOcrEngineResult result,
+        string engineId,
+        ExecutionOptionsSnapshot options,
+        OfficeDocumentOcrCandidate candidate,
+        List<OfficeDocumentDiagnostic> executionDiagnostics) {
+        result.Text = result.Text?.Trim() ?? string.Empty;
+        if (result.Text.Length > options.MaxRecognizedCharactersPerCandidate) {
+            result.Text = TruncateText(result.Text, options.MaxRecognizedCharactersPerCandidate);
+            executionDiagnostics.Add(BuildDiagnostic(candidate, null, engineId, OfficeDocumentDiagnosticSeverity.Warning, OfficeDocumentDiagnosticCategory.Limit,
+                "ocr-text-limit", "OCR recognized text was truncated at MaxRecognizedCharactersPerCandidate.", true));
+        }
+        result.Provider = string.IsNullOrWhiteSpace(result.Provider) ? engineId : result.Provider!.Trim();
+        result.Language = string.IsNullOrWhiteSpace(result.Language) ? options.Language : result.Language!.Trim();
+        bool adjustedConfidence = false;
+        result.Confidence = NormalizeConfidence(result.Confidence, ref adjustedConfidence);
+        OfficeOcrTextSpan[] sourceSpans = (result.Spans ?? Array.Empty<OfficeOcrTextSpan>())
+            .Where(static span => span != null)
+            .OrderBy(static span => span.Sequence)
+            .ThenBy(static span => span.Level)
+            .ToArray();
+        if (sourceSpans.Length > options.MaxSpansPerCandidate) {
+            sourceSpans = sourceSpans.Take(options.MaxSpansPerCandidate).ToArray();
+            executionDiagnostics.Add(BuildDiagnostic(candidate, null, engineId, OfficeDocumentDiagnosticSeverity.Warning, OfficeDocumentDiagnosticCategory.Limit,
+                "ocr-span-limit", "OCR detailed spans were truncated at MaxSpansPerCandidate.", true));
+        }
+        OfficeOcrTextSpan[] spans = sourceSpans;
+        for (int index = 0; index < spans.Length; index++) {
+            OfficeOcrTextSpan span = spans[index];
+            span.Sequence = index;
+            span.Text = span.Text?.Trim() ?? string.Empty;
+            span.Language = string.IsNullOrWhiteSpace(span.Language) ? result.Language : span.Language!.Trim();
+            span.Confidence = NormalizeConfidence(span.Confidence, ref adjustedConfidence);
+        }
+        result.Spans = spans;
+        if (adjustedConfidence) {
+            executionDiagnostics.Add(BuildDiagnostic(candidate, null, engineId, OfficeDocumentDiagnosticSeverity.Warning, OfficeDocumentDiagnosticCategory.Ocr,
+                "ocr-confidence-out-of-range", "One or more OCR confidence values were outside the normalized 0 through 1 range and were clamped.", true));
+        }
+
+        OfficeDocumentDiagnostic[] providerDiagnostics = (result.Diagnostics ?? Array.Empty<OfficeDocumentDiagnostic>()).ToArray();
+        foreach (OfficeDocumentDiagnostic diagnostic in providerDiagnostics) {
+            if (diagnostic.Category == OfficeDocumentDiagnosticCategory.General) diagnostic.Category = OfficeDocumentDiagnosticCategory.Ocr;
+            if (string.IsNullOrWhiteSpace(diagnostic.Source)) diagnostic.Source = engineId;
+            if (diagnostic.Location == null) diagnostic.Location = candidate.Location;
+        }
+        result.Diagnostics = providerDiagnostics;
+    }
+
+    private static double? NormalizeConfidence(double? value, ref bool adjusted) {
+        if (!value.HasValue || (value.Value >= 0D && value.Value <= 1D)) return value;
+        adjusted = true;
+        return value.Value < 0D ? 0D : 1D;
+    }
+
+    private static string TruncateText(string value, int maxCharacters) {
+        int length = maxCharacters;
+        if (length > 0 && length < value.Length && char.IsHighSurrogate(value[length - 1]) && char.IsLowSurrogate(value[length])) length--;
+        return value.Substring(0, length);
+    }
+
+    private static Dictionary<string, string> BuildLimitAttributes(long actual, long limit) {
+        return new Dictionary<string, string>(StringComparer.Ordinal) {
+            ["actualBytes"] = actual.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            ["limitBytes"] = limit.ToString(System.Globalization.CultureInfo.InvariantCulture)
+        };
+    }
+
+    private static OfficeDocumentDiagnostic BuildDiagnostic(
+        OfficeDocumentOcrCandidate candidate,
+        OfficeDocumentAsset? asset,
+        string source,
+        OfficeDocumentDiagnosticSeverity severity,
+        OfficeDocumentDiagnosticCategory category,
+        string code,
+        string message,
+        bool recoverable,
+        IReadOnlyDictionary<string, string>? attributes = null) {
+        var details = attributes == null
+            ? new Dictionary<string, string>(StringComparer.Ordinal)
+            : attributes.ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal);
+        details["candidateId"] = candidate.Id;
+        if (asset != null) details["assetId"] = asset.Id;
+        return new OfficeDocumentDiagnostic {
+            Severity = severity,
+            Category = category,
+            Code = code,
+            Message = message,
+            Source = source,
+            IsRecoverable = recoverable,
+            Location = candidate.Location,
+            Attributes = details
+        };
+    }
+}

--- a/OfficeIMO.Reader/Ocr/OfficeDocumentOcrExecution.Validation.cs
+++ b/OfficeIMO.Reader/Ocr/OfficeDocumentOcrExecution.Validation.cs
@@ -95,6 +95,10 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
         if (!string.IsNullOrWhiteSpace(candidate.AssetId)) {
             OfficeDocumentAsset? exact = assets.FirstOrDefault(asset => string.Equals(asset.Id, candidate.AssetId, StringComparison.Ordinal));
             if (exact == null) resolutionCode = "ocr-asset-missing";
+            if (exact != null && IsAmbiguousMultiImagePage(candidate)) {
+                resolutionCode = "ocr-asset-ambiguous";
+                return null;
+            }
             return exact;
         }
 
@@ -106,6 +110,11 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
         if (matches.Length == 1) return matches[0];
         resolutionCode = matches.Length == 0 ? "ocr-asset-missing" : "ocr-asset-ambiguous";
         return null;
+    }
+
+    private static bool IsAmbiguousMultiImagePage(OfficeDocumentOcrCandidate candidate) {
+        return candidate.ImageCount.GetValueOrDefault() > 1
+            && string.Equals(candidate.Kind, "page", StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool IsSameContainer(ReaderLocation candidate, ReaderLocation asset) {

--- a/OfficeIMO.Reader/Ocr/OfficeDocumentOcrExecution.Validation.cs
+++ b/OfficeIMO.Reader/Ocr/OfficeDocumentOcrExecution.Validation.cs
@@ -69,8 +69,9 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
                 continue;
             }
             if (!IsSupportedMediaType(asset.MediaType, capabilities.SupportedMediaTypes)) {
+                string mediaType = string.IsNullOrWhiteSpace(asset.MediaType) ? "(unknown)" : asset.MediaType!;
                 diagnostics.Add(BuildDiagnostic(candidate, asset, engineId, OfficeDocumentDiagnosticSeverity.Warning, OfficeDocumentDiagnosticCategory.Ocr,
-                    "ocr-media-type-unsupported", "The OCR engine does not advertise support for media type '" + asset.MediaType + "'.", true));
+                    "ocr-media-type-unsupported", "The OCR engine does not advertise support for media type '" + mediaType + "'.", true));
                 continue;
             }
             if (options.RequirePayloadHashMatch && !string.IsNullOrWhiteSpace(asset.PayloadHash) && !asset.PayloadHashMatches(out string? actualHash)) {
@@ -126,7 +127,8 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
     }
 
     private static bool IsSupportedMediaType(string? mediaType, IReadOnlyList<string>? supported) {
-        if (string.IsNullOrWhiteSpace(mediaType) || supported == null || supported.Count == 0) return true;
+        if (supported == null || supported.Count == 0) return true;
+        if (string.IsNullOrWhiteSpace(mediaType)) return false;
         foreach (string declared in supported) {
             if (string.IsNullOrWhiteSpace(declared)) continue;
             if (string.Equals(declared, mediaType, StringComparison.OrdinalIgnoreCase)) return true;

--- a/OfficeIMO.Reader/Ocr/OfficeDocumentOcrExecution.Validation.cs
+++ b/OfficeIMO.Reader/Ocr/OfficeDocumentOcrExecution.Validation.cs
@@ -163,10 +163,12 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
         result.Spans = spans;
         if (adjustedConfidence) {
             executionDiagnostics.Add(BuildDiagnostic(candidate, null, engineId, OfficeDocumentDiagnosticSeverity.Warning, OfficeDocumentDiagnosticCategory.Ocr,
-                "ocr-confidence-out-of-range", "One or more OCR confidence values were outside the normalized 0 through 1 range and were clamped.", true));
+                "ocr-confidence-out-of-range", "One or more OCR confidence values were normalized; non-finite values were removed and out-of-range values were clamped.", true));
         }
 
-        OfficeDocumentDiagnostic[] providerDiagnostics = (result.Diagnostics ?? Array.Empty<OfficeDocumentDiagnostic>()).ToArray();
+        OfficeDocumentDiagnostic[] providerDiagnostics = (result.Diagnostics ?? Array.Empty<OfficeDocumentDiagnostic>())
+            .Where(static diagnostic => diagnostic != null)
+            .ToArray();
         foreach (OfficeDocumentDiagnostic diagnostic in providerDiagnostics) {
             if (diagnostic.Category == OfficeDocumentDiagnosticCategory.General) diagnostic.Category = OfficeDocumentDiagnosticCategory.Ocr;
             if (string.IsNullOrWhiteSpace(diagnostic.Source)) diagnostic.Source = engineId;
@@ -176,7 +178,12 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
     }
 
     private static double? NormalizeConfidence(double? value, ref bool adjusted) {
-        if (!value.HasValue || (value.Value >= 0D && value.Value <= 1D)) return value;
+        if (!value.HasValue) return null;
+        if (double.IsNaN(value.Value) || double.IsInfinity(value.Value)) {
+            adjusted = true;
+            return null;
+        }
+        if (value.Value >= 0D && value.Value <= 1D) return value;
         adjusted = true;
         return value.Value < 0D ? 0D : 1D;
     }

--- a/OfficeIMO.Reader/Ocr/OfficeDocumentOcrExecution.cs
+++ b/OfficeIMO.Reader/Ocr/OfficeDocumentOcrExecution.cs
@@ -1,0 +1,312 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>Runs optional OCR engines against bounded Reader candidates and merges recognized text.</summary>
+public static partial class OfficeDocumentOcrExecutionExtensions {
+    private static readonly ConditionalWeakTable<IOfficeOcrEngine, SemaphoreSlim> NonConcurrentEngineGates = new ConditionalWeakTable<IOfficeOcrEngine, SemaphoreSlim>();
+
+    /// <summary>
+    /// Executes an OCR engine over validated candidate assets, preserves deterministic result order, and enriches the document.
+    /// </summary>
+    public static async Task<OfficeDocumentOcrExecutionResult> ApplyOcrAsync(
+        this OfficeDocumentReadResult document,
+        IOfficeOcrEngine engine,
+        OfficeDocumentOcrExecutionOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        if (engine == null) throw new ArgumentNullException(nameof(engine));
+        if (string.IsNullOrWhiteSpace(engine.Id)) throw new ArgumentException("OCR engine id cannot be empty.", nameof(engine));
+
+        ExecutionOptionsSnapshot effective = ExecutionOptionsSnapshot.Create(options);
+        IReadOnlyList<OfficeDocumentOcrCandidate> candidates = document.OcrCandidates ?? Array.Empty<OfficeDocumentOcrCandidate>();
+        IReadOnlyList<OfficeDocumentAsset> assets = document.Assets ?? Array.Empty<OfficeDocumentAsset>();
+        OfficeOcrEngineCapabilities capabilities = (engine.Capabilities ?? new OfficeOcrEngineCapabilities()).Clone();
+        var diagnostics = new List<OfficeDocumentDiagnostic>();
+        List<CandidateJob> jobs = BuildJobs(document, candidates, assets, capabilities, engine.Id, effective, diagnostics);
+        int degree = capabilities.SupportsConcurrentRequests ? Math.Min(effective.MaxDegreeOfParallelism, Math.Max(1, jobs.Count)) : 1;
+
+        CandidateOutcome[] outcomes;
+        SemaphoreSlim? sharedEngineGate = !capabilities.SupportsConcurrentRequests && jobs.Count > 0
+            ? NonConcurrentEngineGates.GetValue(engine, static _ => new SemaphoreSlim(1, 1))
+            : null;
+        if (sharedEngineGate != null) await sharedEngineGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            using var gate = new SemaphoreSlim(degree, degree);
+            Task<CandidateOutcome>[] tasks = jobs
+                .Select(job => ExecuteCandidateAsync(document, engine, job, effective, gate, cancellationToken))
+                .ToArray();
+            outcomes = await Task.WhenAll(tasks).ConfigureAwait(false);
+        } finally {
+            sharedEngineGate?.Release();
+        }
+
+        var recognitions = new List<OfficeDocumentOcrRecognition>(outcomes.Length);
+        var recognizedText = new List<OfficeDocumentOcrTextResult>(outcomes.Length);
+        int failedCount = 0;
+        int emptyCount = 0;
+        foreach (CandidateOutcome outcome in outcomes.OrderBy(static outcome => outcome.Job.Index)) {
+            if (outcome.FailureDiagnostic != null) {
+                failedCount++;
+                diagnostics.Add(outcome.FailureDiagnostic);
+                continue;
+            }
+
+            OfficeOcrEngineResult engineResult = outcome.Result ?? new OfficeOcrEngineResult();
+            NormalizeEngineResult(engineResult, engine.Id, effective, outcome.Job.Candidate, diagnostics);
+            recognitions.Add(new OfficeDocumentOcrRecognition {
+                CandidateId = outcome.Job.Candidate.Id,
+                AssetId = outcome.Job.Asset.Id,
+                Result = engineResult
+            });
+            diagnostics.AddRange(engineResult.Diagnostics ?? Array.Empty<OfficeDocumentDiagnostic>());
+            if (string.IsNullOrWhiteSpace(engineResult.Text)) {
+                emptyCount++;
+                diagnostics.Add(BuildDiagnostic(
+                    outcome.Job.Candidate,
+                    outcome.Job.Asset,
+                    engine.Id,
+                    OfficeDocumentDiagnosticSeverity.Warning,
+                    OfficeDocumentDiagnosticCategory.Ocr,
+                    "ocr-empty-result",
+                    "The OCR engine completed without recognized text.",
+                    true));
+                continue;
+            }
+
+            recognizedText.Add(new OfficeDocumentOcrTextResult {
+                CandidateId = outcome.Job.Candidate.Id,
+                Text = engineResult.Text,
+                Confidence = engineResult.Confidence,
+                Language = engineResult.Language,
+                Provider = engineResult.Provider,
+                Model = engineResult.Model
+            });
+        }
+
+        OfficeDocumentOcrEnrichmentResult enrichment = document.ApplyOcrResults(recognizedText, effective.EnrichmentOptions);
+        OfficeDocumentReadResult enriched = enrichment.Document;
+        enriched.CapabilitiesUsed = AppendCapabilities(enriched.CapabilitiesUsed, engine.Id);
+        enriched.Diagnostics = (enriched.Diagnostics ?? Array.Empty<OfficeDocumentDiagnostic>()).Concat(diagnostics).ToArray();
+        int skippedCount = candidates.Count - jobs.Count;
+        var report = new OfficeDocumentOcrExecutionReport {
+            EngineId = engine.Id,
+            CandidateCount = candidates.Count,
+            SelectedCandidateCount = Math.Min(candidates.Count, effective.MaxCandidates),
+            AttemptedCandidateCount = jobs.Count,
+            RecognizedCandidateCount = recognizedText.Count,
+            EmptyCandidateCount = emptyCount,
+            SkippedCandidateCount = skippedCount,
+            FailedCandidateCount = failedCount,
+            LineSpanCount = CountSpans(recognitions, OfficeOcrTextSpanLevel.Line),
+            WordSpanCount = CountSpans(recognitions, OfficeOcrTextSpanLevel.Word),
+            CharacterSpanCount = CountSpans(recognitions, OfficeOcrTextSpanLevel.Character),
+            InputBytes = jobs.Sum(static job => (long)job.Payload.LongLength),
+            EffectiveDegreeOfParallelism = jobs.Count == 0 ? 0 : degree
+        };
+        enriched.Metadata = BuildExecutionMetadata(enriched.Metadata, report);
+
+        return new OfficeDocumentOcrExecutionResult {
+            Document = enriched,
+            Recognitions = recognitions,
+            Diagnostics = diagnostics,
+            Report = report
+        };
+    }
+
+    private static async Task<CandidateOutcome> ExecuteCandidateAsync(
+        OfficeDocumentReadResult document,
+        IOfficeOcrEngine engine,
+        CandidateJob job,
+        ExecutionOptionsSnapshot options,
+        SemaphoreSlim gate,
+        CancellationToken cancellationToken) {
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            cancellationToken.ThrowIfCancellationRequested();
+            var request = new OfficeOcrEngineRequest {
+                Candidate = job.Candidate,
+                Asset = job.Asset,
+                Payload = job.Payload,
+                Language = options.Language,
+                Source = document.Source ?? new OfficeDocumentSource(),
+                ProviderOptions = options.ProviderOptions
+            };
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(options.CandidateTimeout);
+            try {
+                OfficeOcrEngineResult result = await engine.RecognizeAsync(request, timeout.Token).ConfigureAwait(false);
+                return CandidateOutcome.Success(job, result);
+            } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && timeout.IsCancellationRequested && options.ContinueOnError) {
+                return CandidateOutcome.Failure(job, BuildDiagnostic(
+                    job.Candidate,
+                    job.Asset,
+                    engine.Id,
+                    OfficeDocumentDiagnosticSeverity.Error,
+                    OfficeDocumentDiagnosticCategory.Ocr,
+                    "ocr-engine-timeout",
+                    "OCR engine exceeded CandidateTimeout (" + options.CandidateTimeout + ").",
+                    true));
+            } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && timeout.IsCancellationRequested) {
+                throw new TimeoutException("OCR engine exceeded CandidateTimeout (" + options.CandidateTimeout + ").");
+            }
+        } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+            throw;
+        } catch (Exception exception) when (options.ContinueOnError) {
+            return CandidateOutcome.Failure(job, BuildDiagnostic(
+                job.Candidate,
+                job.Asset,
+                engine.Id,
+                OfficeDocumentDiagnosticSeverity.Error,
+                OfficeDocumentDiagnosticCategory.Ocr,
+                "ocr-engine-failed",
+                "OCR engine failed for candidate '" + job.Candidate.Id + "': " + exception.Message,
+                true,
+                new Dictionary<string, string>(StringComparer.Ordinal) { ["exceptionType"] = exception.GetType().FullName ?? exception.GetType().Name }));
+        } finally {
+            gate.Release();
+        }
+    }
+
+    private static IReadOnlyList<string> AppendCapabilities(IReadOnlyList<string>? existing, string engineId) {
+        return (existing ?? Array.Empty<string>())
+            .Concat(new[] { "officeimo.reader.ocr-execution", "officeimo.reader.ocr-engine." + NormalizeCapabilityToken(engineId) })
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static string NormalizeCapabilityToken(string value) {
+        char[] chars = value.Trim().ToLowerInvariant().Select(static ch => char.IsLetterOrDigit(ch) ? ch : '-').ToArray();
+        return new string(chars).Trim('-');
+    }
+
+    private static IReadOnlyList<OfficeDocumentMetadataEntry> BuildExecutionMetadata(
+        IReadOnlyList<OfficeDocumentMetadataEntry>? existing,
+        OfficeDocumentOcrExecutionReport report) {
+        var entries = (existing ?? Array.Empty<OfficeDocumentMetadataEntry>())
+            .Where(static entry => !entry.Id.StartsWith("reader-ocr-execution-", StringComparison.Ordinal))
+            .ToList();
+        AddExecutionCount(entries, "candidate-count", "CandidateCount", report.CandidateCount);
+        AddExecutionCount(entries, "attempted-count", "AttemptedCount", report.AttemptedCandidateCount);
+        AddExecutionCount(entries, "recognized-count", "RecognizedCount", report.RecognizedCandidateCount);
+        AddExecutionCount(entries, "empty-count", "EmptyCount", report.EmptyCandidateCount);
+        AddExecutionCount(entries, "skipped-count", "SkippedCount", report.SkippedCandidateCount);
+        AddExecutionCount(entries, "failed-count", "FailedCount", report.FailedCandidateCount);
+        AddExecutionCount(entries, "line-span-count", "LineSpanCount", report.LineSpanCount);
+        AddExecutionCount(entries, "word-span-count", "WordSpanCount", report.WordSpanCount);
+        AddExecutionCount(entries, "character-span-count", "CharacterSpanCount", report.CharacterSpanCount);
+        entries.Add(new OfficeDocumentMetadataEntry {
+            Id = "reader-ocr-execution-input-bytes",
+            Category = "reader.ocr.execution",
+            Name = "InputBytes",
+            Value = report.InputBytes.ToString(CultureInfo.InvariantCulture),
+            ValueType = "number",
+            Attributes = new Dictionary<string, string>(StringComparer.Ordinal) { ["engine"] = report.EngineId }
+        });
+        return entries;
+    }
+
+    private static void AddExecutionCount(List<OfficeDocumentMetadataEntry> entries, string idSuffix, string name, int value) {
+        entries.Add(new OfficeDocumentMetadataEntry {
+            Id = "reader-ocr-execution-" + idSuffix,
+            Category = "reader.ocr.execution",
+            Name = name,
+            Value = value.ToString(CultureInfo.InvariantCulture),
+            ValueType = "count"
+        });
+    }
+
+    private static int CountSpans(IReadOnlyList<OfficeDocumentOcrRecognition> recognitions, OfficeOcrTextSpanLevel level) {
+        return recognitions.Sum(recognition => (recognition.Result.Spans ?? Array.Empty<OfficeOcrTextSpan>()).Count(span => span.Level == level));
+    }
+
+    private sealed class CandidateJob {
+        internal CandidateJob(int index, OfficeDocumentOcrCandidate candidate, OfficeDocumentAsset asset, byte[] payload) {
+            Index = index;
+            Candidate = candidate;
+            Asset = asset;
+            Payload = payload;
+        }
+
+        internal int Index { get; }
+        internal OfficeDocumentOcrCandidate Candidate { get; }
+        internal OfficeDocumentAsset Asset { get; }
+        internal byte[] Payload { get; }
+    }
+
+    private sealed class CandidateOutcome {
+        private CandidateOutcome(CandidateJob job, OfficeOcrEngineResult? result, OfficeDocumentDiagnostic? failureDiagnostic) {
+            Job = job;
+            Result = result;
+            FailureDiagnostic = failureDiagnostic;
+        }
+
+        internal CandidateJob Job { get; }
+        internal OfficeOcrEngineResult? Result { get; }
+        internal OfficeDocumentDiagnostic? FailureDiagnostic { get; }
+
+        internal static CandidateOutcome Success(CandidateJob job, OfficeOcrEngineResult result) => new CandidateOutcome(job, result, null);
+        internal static CandidateOutcome Failure(CandidateJob job, OfficeDocumentDiagnostic diagnostic) => new CandidateOutcome(job, null, diagnostic);
+    }
+
+    private sealed class ExecutionOptionsSnapshot {
+        private ExecutionOptionsSnapshot() { }
+
+        internal string? Language { get; private set; }
+        internal int MaxCandidates { get; private set; }
+        internal long MaxInputBytesPerCandidate { get; private set; }
+        internal long MaxTotalInputBytes { get; private set; }
+        internal int MaxDegreeOfParallelism { get; private set; }
+        internal TimeSpan CandidateTimeout { get; private set; }
+        internal int MaxRecognizedCharactersPerCandidate { get; private set; }
+        internal int MaxSpansPerCandidate { get; private set; }
+        internal bool ContinueOnError { get; private set; }
+        internal bool RequirePayloadHashMatch { get; private set; }
+        internal IReadOnlyDictionary<string, string> ProviderOptions { get; private set; } = new Dictionary<string, string>(StringComparer.Ordinal);
+        internal OfficeDocumentOcrEnrichmentOptions EnrichmentOptions { get; private set; } = new OfficeDocumentOcrEnrichmentOptions();
+
+        internal static ExecutionOptionsSnapshot Create(OfficeDocumentOcrExecutionOptions? options) {
+            OfficeDocumentOcrExecutionOptions source = options ?? new OfficeDocumentOcrExecutionOptions();
+            if (source.MaxCandidates < 1) throw new ArgumentOutOfRangeException(nameof(source.MaxCandidates));
+            if (source.MaxInputBytesPerCandidate < 1) throw new ArgumentOutOfRangeException(nameof(source.MaxInputBytesPerCandidate));
+            if (source.MaxTotalInputBytes < 1) throw new ArgumentOutOfRangeException(nameof(source.MaxTotalInputBytes));
+            if (source.MaxDegreeOfParallelism < 1) throw new ArgumentOutOfRangeException(nameof(source.MaxDegreeOfParallelism));
+            if (source.CandidateTimeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(source.CandidateTimeout));
+            if (source.MaxRecognizedCharactersPerCandidate < 1) throw new ArgumentOutOfRangeException(nameof(source.MaxRecognizedCharactersPerCandidate));
+            if (source.MaxSpansPerCandidate < 1) throw new ArgumentOutOfRangeException(nameof(source.MaxSpansPerCandidate));
+            return new ExecutionOptionsSnapshot {
+                Language = string.IsNullOrWhiteSpace(source.Language) ? null : source.Language!.Trim(),
+                MaxCandidates = source.MaxCandidates,
+                MaxInputBytesPerCandidate = source.MaxInputBytesPerCandidate,
+                MaxTotalInputBytes = source.MaxTotalInputBytes,
+                MaxDegreeOfParallelism = source.MaxDegreeOfParallelism,
+                CandidateTimeout = source.CandidateTimeout,
+                MaxRecognizedCharactersPerCandidate = source.MaxRecognizedCharactersPerCandidate,
+                MaxSpansPerCandidate = source.MaxSpansPerCandidate,
+                ContinueOnError = source.ContinueOnError,
+                RequirePayloadHashMatch = source.RequirePayloadHashMatch,
+                ProviderOptions = source.ProviderOptions == null
+                    ? new Dictionary<string, string>(StringComparer.Ordinal)
+                    : source.ProviderOptions.ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal),
+                EnrichmentOptions = CloneEnrichmentOptions(source.EnrichmentOptions)
+            };
+        }
+
+        private static OfficeDocumentOcrEnrichmentOptions CloneEnrichmentOptions(OfficeDocumentOcrEnrichmentOptions? source) {
+            source ??= new OfficeDocumentOcrEnrichmentOptions();
+            return new OfficeDocumentOcrEnrichmentOptions {
+                RemoveResolvedCandidates = source.RemoveResolvedCandidates,
+                RemoveResolvedOcrNeededDiagnostics = source.RemoveResolvedOcrNeededDiagnostics,
+                AppendRecognizedTextToMarkdown = source.AppendRecognizedTextToMarkdown,
+                BlockKind = source.BlockKind
+            };
+        }
+    }
+}

--- a/OfficeIMO.Reader/Ocr/OfficeDocumentOcrExecution.cs
+++ b/OfficeIMO.Reader/Ocr/OfficeDocumentOcrExecution.cs
@@ -37,11 +37,12 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
             ? NonConcurrentEngineGates.GetValue(engine, static _ => new SemaphoreSlim(1, 1))
             : null;
         var abandonedOperations = new AbandonedOcrOperationTracker();
+        var failFast = effective.ContinueOnError ? null : new OcrFailFastState();
         if (sharedEngineGate != null) await sharedEngineGate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try {
             using var gate = new SemaphoreSlim(degree, degree);
             Task<CandidateOutcome>[] tasks = jobs
-                .Select(job => ExecuteCandidateAsync(document, engine, job, effective, gate, abandonedOperations, cancellationToken))
+                .Select(job => ExecuteCandidateAsync(document, engine, job, effective, gate, abandonedOperations, failFast, cancellationToken))
                 .ToArray();
             outcomes = await Task.WhenAll(tasks).ConfigureAwait(false);
         } finally {
@@ -130,10 +131,22 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
         ExecutionOptionsSnapshot options,
         SemaphoreSlim gate,
         AbandonedOcrOperationTracker abandonedOperations,
+        OcrFailFastState? failFast,
         CancellationToken cancellationToken) {
         await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try {
             cancellationToken.ThrowIfCancellationRequested();
+            if (failFast != null && failFast.HasFailed) {
+                return CandidateOutcome.Skipped(job, BuildDiagnostic(
+                    job.Candidate,
+                    job.Asset,
+                    engine.Id,
+                    OfficeDocumentDiagnosticSeverity.Warning,
+                    OfficeDocumentDiagnosticCategory.Ocr,
+                    "ocr-fail-fast-skipped",
+                    "OCR was not started because an earlier candidate failed and ContinueOnError is disabled.",
+                    true));
+            }
             if (abandonedOperations.HasPendingOperations) {
                 return CandidateOutcome.Skipped(job, BuildDiagnostic(
                     job.Candidate,
@@ -193,6 +206,9 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
                 "OCR engine failed for candidate '" + job.Candidate.Id + "': " + exception.Message,
                 true,
                 new Dictionary<string, string>(StringComparer.Ordinal) { ["exceptionType"] = exception.GetType().FullName ?? exception.GetType().Name }));
+        } catch (Exception) {
+            failFast?.SignalFailure();
+            throw;
         } finally {
             gate.Release();
         }
@@ -304,6 +320,16 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
         internal static CandidateOutcome Success(CandidateJob job, OfficeOcrEngineResult result) => new CandidateOutcome(job, result, null, true);
         internal static CandidateOutcome Failure(CandidateJob job, OfficeDocumentDiagnostic diagnostic) => new CandidateOutcome(job, null, diagnostic, true);
         internal static CandidateOutcome Skipped(CandidateJob job, OfficeDocumentDiagnostic diagnostic) => new CandidateOutcome(job, null, diagnostic, false);
+    }
+
+    private sealed class OcrFailFastState {
+        private int _failed;
+
+        internal bool HasFailed => Volatile.Read(ref _failed) != 0;
+
+        internal void SignalFailure() {
+            Interlocked.Exchange(ref _failed, 1);
+        }
     }
 
     private sealed class ExecutionOptionsSnapshot {

--- a/OfficeIMO.Reader/Ocr/OfficeDocumentOcrExecution.cs
+++ b/OfficeIMO.Reader/Ocr/OfficeDocumentOcrExecution.cs
@@ -140,21 +140,29 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
             };
             using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             timeout.CancelAfter(options.CandidateTimeout);
+            Task<OfficeOcrEngineResult>? recognitionTask = null;
             try {
-                OfficeOcrEngineResult result = await engine.RecognizeAsync(request, timeout.Token).ConfigureAwait(false);
+                recognitionTask = engine.RecognizeAsync(request, timeout.Token).AsTask();
+                OfficeOcrEngineResult result = await WaitWithCancellationAsync(recognitionTask, timeout.Token).ConfigureAwait(false);
                 return CandidateOutcome.Success(job, result);
-            } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && timeout.IsCancellationRequested && options.ContinueOnError) {
-                return CandidateOutcome.Failure(job, BuildDiagnostic(
-                    job.Candidate,
-                    job.Asset,
-                    engine.Id,
-                    OfficeDocumentDiagnosticSeverity.Error,
-                    OfficeDocumentDiagnosticCategory.Ocr,
-                    "ocr-engine-timeout",
-                    "OCR engine exceeded CandidateTimeout (" + options.CandidateTimeout + ").",
-                    true));
-            } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && timeout.IsCancellationRequested) {
-                throw new TimeoutException("OCR engine exceeded CandidateTimeout (" + options.CandidateTimeout + ").");
+            } catch (OperationCanceledException) {
+                ObserveBackgroundFailure(recognitionTask);
+                if (cancellationToken.IsCancellationRequested) throw;
+                if (timeout.IsCancellationRequested && options.ContinueOnError) {
+                    return CandidateOutcome.Failure(job, BuildDiagnostic(
+                        job.Candidate,
+                        job.Asset,
+                        engine.Id,
+                        OfficeDocumentDiagnosticSeverity.Error,
+                        OfficeDocumentDiagnosticCategory.Ocr,
+                        "ocr-engine-timeout",
+                        "OCR engine exceeded CandidateTimeout (" + options.CandidateTimeout + ").",
+                        true));
+                }
+                if (timeout.IsCancellationRequested) {
+                    throw new TimeoutException("OCR engine exceeded CandidateTimeout (" + options.CandidateTimeout + ").");
+                }
+                throw;
             }
         } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
             throw;
@@ -172,6 +180,29 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
         } finally {
             gate.Release();
         }
+    }
+
+    private static async Task<T> WaitWithCancellationAsync<T>(Task<T> operation, CancellationToken cancellationToken) {
+        if (operation.IsCompleted) return await operation.ConfigureAwait(false);
+        var cancellation = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using (cancellationToken.Register(() => cancellation.TrySetResult(null))) {
+            Task completed = await Task.WhenAny(operation, cancellation.Task).ConfigureAwait(false);
+            if (completed != operation) throw new OperationCanceledException(cancellationToken);
+        }
+        return await operation.ConfigureAwait(false);
+    }
+
+    private static void ObserveBackgroundFailure(Task? operation) {
+        if (operation == null) return;
+        if (operation.IsCompleted) {
+            _ = operation.Exception;
+            return;
+        }
+        _ = operation.ContinueWith(
+            static completed => { _ = completed.Exception; },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnFaulted,
+            TaskScheduler.Default);
     }
 
     private static IReadOnlyList<string> AppendCapabilities(IReadOnlyList<string>? existing, string engineId) {

--- a/OfficeIMO.Reader/Ocr/OfficeDocumentOcrExecution.cs
+++ b/OfficeIMO.Reader/Ocr/OfficeDocumentOcrExecution.cs
@@ -36,24 +36,27 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
         SemaphoreSlim? sharedEngineGate = !capabilities.SupportsConcurrentRequests && jobs.Count > 0
             ? NonConcurrentEngineGates.GetValue(engine, static _ => new SemaphoreSlim(1, 1))
             : null;
+        var abandonedOperations = new AbandonedOcrOperationTracker();
         if (sharedEngineGate != null) await sharedEngineGate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try {
             using var gate = new SemaphoreSlim(degree, degree);
             Task<CandidateOutcome>[] tasks = jobs
-                .Select(job => ExecuteCandidateAsync(document, engine, job, effective, gate, cancellationToken))
+                .Select(job => ExecuteCandidateAsync(document, engine, job, effective, gate, abandonedOperations, cancellationToken))
                 .ToArray();
             outcomes = await Task.WhenAll(tasks).ConfigureAwait(false);
         } finally {
-            sharedEngineGate?.Release();
+            if (sharedEngineGate != null) ReleaseSharedEngineGate(sharedEngineGate, abandonedOperations);
         }
 
         var recognitions = new List<OfficeDocumentOcrRecognition>(outcomes.Length);
         var recognizedText = new List<OfficeDocumentOcrTextResult>(outcomes.Length);
         int failedCount = 0;
         int emptyCount = 0;
+        int attemptedCount = 0;
         foreach (CandidateOutcome outcome in outcomes.OrderBy(static outcome => outcome.Job.Index)) {
+            if (outcome.WasAttempted) attemptedCount++;
             if (outcome.FailureDiagnostic != null) {
-                failedCount++;
+                if (outcome.WasAttempted) failedCount++;
                 diagnostics.Add(outcome.FailureDiagnostic);
                 continue;
             }
@@ -94,12 +97,12 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
         OfficeDocumentReadResult enriched = enrichment.Document;
         enriched.CapabilitiesUsed = AppendCapabilities(enriched.CapabilitiesUsed, engine.Id);
         enriched.Diagnostics = (enriched.Diagnostics ?? Array.Empty<OfficeDocumentDiagnostic>()).Concat(diagnostics).ToArray();
-        int skippedCount = candidates.Count - jobs.Count;
+        int skippedCount = candidates.Count - attemptedCount;
         var report = new OfficeDocumentOcrExecutionReport {
             EngineId = engine.Id,
             CandidateCount = candidates.Count,
             SelectedCandidateCount = Math.Min(candidates.Count, effective.MaxCandidates),
-            AttemptedCandidateCount = jobs.Count,
+            AttemptedCandidateCount = attemptedCount,
             RecognizedCandidateCount = recognizedText.Count,
             EmptyCandidateCount = emptyCount,
             SkippedCandidateCount = skippedCount,
@@ -107,8 +110,8 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
             LineSpanCount = CountSpans(recognitions, OfficeOcrTextSpanLevel.Line),
             WordSpanCount = CountSpans(recognitions, OfficeOcrTextSpanLevel.Word),
             CharacterSpanCount = CountSpans(recognitions, OfficeOcrTextSpanLevel.Character),
-            InputBytes = jobs.Sum(static job => (long)job.Payload.LongLength),
-            EffectiveDegreeOfParallelism = jobs.Count == 0 ? 0 : degree
+            InputBytes = outcomes.Where(static outcome => outcome.WasAttempted).Sum(static outcome => (long)outcome.Job.Payload.LongLength),
+            EffectiveDegreeOfParallelism = attemptedCount == 0 ? 0 : degree
         };
         enriched.Metadata = BuildExecutionMetadata(enriched.Metadata, report);
 
@@ -126,10 +129,22 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
         CandidateJob job,
         ExecutionOptionsSnapshot options,
         SemaphoreSlim gate,
+        AbandonedOcrOperationTracker abandonedOperations,
         CancellationToken cancellationToken) {
         await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try {
             cancellationToken.ThrowIfCancellationRequested();
+            if (abandonedOperations.HasPendingOperations) {
+                return CandidateOutcome.Skipped(job, BuildDiagnostic(
+                    job.Candidate,
+                    job.Asset,
+                    engine.Id,
+                    OfficeDocumentDiagnosticSeverity.Error,
+                    OfficeDocumentDiagnosticCategory.Ocr,
+                    "ocr-engine-timeout",
+                    "OCR was not started because an earlier timed-out call is still running for this execution.",
+                    true));
+            }
             var request = new OfficeOcrEngineRequest {
                 Candidate = job.Candidate,
                 Asset = job.Asset,
@@ -146,6 +161,7 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
                 OfficeOcrEngineResult result = await WaitWithCancellationAsync(recognitionTask, timeout.Token).ConfigureAwait(false);
                 return CandidateOutcome.Success(job, result);
             } catch (OperationCanceledException) {
+                abandonedOperations.Track(recognitionTask);
                 ObserveBackgroundFailure(recognitionTask);
                 if (cancellationToken.IsCancellationRequested) throw;
                 if (timeout.IsCancellationRequested && options.ContinueOnError) {
@@ -273,18 +289,21 @@ public static partial class OfficeDocumentOcrExecutionExtensions {
     }
 
     private sealed class CandidateOutcome {
-        private CandidateOutcome(CandidateJob job, OfficeOcrEngineResult? result, OfficeDocumentDiagnostic? failureDiagnostic) {
+        private CandidateOutcome(CandidateJob job, OfficeOcrEngineResult? result, OfficeDocumentDiagnostic? failureDiagnostic, bool wasAttempted) {
             Job = job;
             Result = result;
             FailureDiagnostic = failureDiagnostic;
+            WasAttempted = wasAttempted;
         }
 
         internal CandidateJob Job { get; }
         internal OfficeOcrEngineResult? Result { get; }
         internal OfficeDocumentDiagnostic? FailureDiagnostic { get; }
+        internal bool WasAttempted { get; }
 
-        internal static CandidateOutcome Success(CandidateJob job, OfficeOcrEngineResult result) => new CandidateOutcome(job, result, null);
-        internal static CandidateOutcome Failure(CandidateJob job, OfficeDocumentDiagnostic diagnostic) => new CandidateOutcome(job, null, diagnostic);
+        internal static CandidateOutcome Success(CandidateJob job, OfficeOcrEngineResult result) => new CandidateOutcome(job, result, null, true);
+        internal static CandidateOutcome Failure(CandidateJob job, OfficeDocumentDiagnostic diagnostic) => new CandidateOutcome(job, null, diagnostic, true);
+        internal static CandidateOutcome Skipped(CandidateJob job, OfficeDocumentDiagnostic diagnostic) => new CandidateOutcome(job, null, diagnostic, false);
     }
 
     private sealed class ExecutionOptionsSnapshot {

--- a/OfficeIMO.Reader/Ocr/OfficeDocumentOcrExecutionModels.cs
+++ b/OfficeIMO.Reader/Ocr/OfficeDocumentOcrExecutionModels.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>Controls bounded execution of an optional OCR engine over a document read result.</summary>
+public sealed class OfficeDocumentOcrExecutionOptions {
+    /// <summary>Language or provider-specific language expression requested for every candidate.</summary>
+    public string? Language { get; set; }
+
+    /// <summary>Maximum candidates considered in one execution. Defaults to 100.</summary>
+    public int MaxCandidates { get; set; } = 100;
+
+    /// <summary>Maximum payload size passed to the engine for one candidate. Defaults to 25 MiB.</summary>
+    public long MaxInputBytesPerCandidate { get; set; } = 25L * 1024L * 1024L;
+
+    /// <summary>Maximum combined payload size passed to the engine. Defaults to 100 MiB.</summary>
+    public long MaxTotalInputBytes { get; set; } = 100L * 1024L * 1024L;
+
+    /// <summary>Maximum concurrent engine calls. Defaults to 1 and is forced to 1 for engines that do not advertise concurrency.</summary>
+    public int MaxDegreeOfParallelism { get; set; } = 1;
+
+    /// <summary>Maximum duration allowed for one engine call. Defaults to two minutes.</summary>
+    public TimeSpan CandidateTimeout { get; set; } = TimeSpan.FromMinutes(2);
+
+    /// <summary>Maximum recognized text characters accepted from one engine response. Defaults to 1,000,000.</summary>
+    public int MaxRecognizedCharactersPerCandidate { get; set; } = 1_000_000;
+
+    /// <summary>Maximum detailed spans accepted from one engine response. Defaults to 100,000.</summary>
+    public int MaxSpansPerCandidate { get; set; } = 100_000;
+
+    /// <summary>Whether one provider failure should become a diagnostic while remaining candidates continue.</summary>
+    public bool ContinueOnError { get; set; } = true;
+
+    /// <summary>Whether a declared asset payload hash must match before bytes are passed to an engine.</summary>
+    public bool RequirePayloadHashMatch { get; set; } = true;
+
+    /// <summary>Provider-specific scalar options copied into every engine request.</summary>
+    public IReadOnlyDictionary<string, string> ProviderOptions { get; set; } = new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <summary>Controls how recognized text is merged into the shared read result.</summary>
+    public OfficeDocumentOcrEnrichmentOptions EnrichmentOptions { get; set; } = new OfficeDocumentOcrEnrichmentOptions();
+
+    /// <summary>Creates an independent execution configuration snapshot.</summary>
+    public OfficeDocumentOcrExecutionOptions Clone() {
+        OfficeDocumentOcrEnrichmentOptions enrichment = EnrichmentOptions ?? new OfficeDocumentOcrEnrichmentOptions();
+        return new OfficeDocumentOcrExecutionOptions {
+            Language = Language,
+            MaxCandidates = MaxCandidates,
+            MaxInputBytesPerCandidate = MaxInputBytesPerCandidate,
+            MaxTotalInputBytes = MaxTotalInputBytes,
+            MaxDegreeOfParallelism = MaxDegreeOfParallelism,
+            CandidateTimeout = CandidateTimeout,
+            MaxRecognizedCharactersPerCandidate = MaxRecognizedCharactersPerCandidate,
+            MaxSpansPerCandidate = MaxSpansPerCandidate,
+            ContinueOnError = ContinueOnError,
+            RequirePayloadHashMatch = RequirePayloadHashMatch,
+            ProviderOptions = ProviderOptions == null
+                ? new Dictionary<string, string>(StringComparer.Ordinal)
+                : ProviderOptions.ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal),
+            EnrichmentOptions = new OfficeDocumentOcrEnrichmentOptions {
+                RemoveResolvedCandidates = enrichment.RemoveResolvedCandidates,
+                RemoveResolvedOcrNeededDiagnostics = enrichment.RemoveResolvedOcrNeededDiagnostics,
+                AppendRecognizedTextToMarkdown = enrichment.AppendRecognizedTextToMarkdown,
+                BlockKind = enrichment.BlockKind
+            }
+        };
+    }
+}
+
+/// <summary>Observable counters from one bounded OCR execution.</summary>
+public sealed class OfficeDocumentOcrExecutionReport {
+    /// <summary>Configured engine identifier.</summary>
+    public string EngineId { get; set; } = string.Empty;
+
+    /// <summary>Total candidates in the source read result.</summary>
+    public int CandidateCount { get; set; }
+
+    /// <summary>Candidates selected before asset and payload validation.</summary>
+    public int SelectedCandidateCount { get; set; }
+
+    /// <summary>Candidates whose payloads were passed to the engine.</summary>
+    public int AttemptedCandidateCount { get; set; }
+
+    /// <summary>Engine calls that returned non-empty recognized text.</summary>
+    public int RecognizedCandidateCount { get; set; }
+
+    /// <summary>Successful engine calls that returned no recognized text.</summary>
+    public int EmptyCandidateCount { get; set; }
+
+    /// <summary>Candidates skipped by configured limits, missing payloads, unsupported media, or integrity checks.</summary>
+    public int SkippedCandidateCount { get; set; }
+
+    /// <summary>Engine calls that failed and were converted to diagnostics.</summary>
+    public int FailedCandidateCount { get; set; }
+
+    /// <summary>Detailed line spans returned by successful engine calls.</summary>
+    public int LineSpanCount { get; set; }
+
+    /// <summary>Detailed word spans returned by successful engine calls.</summary>
+    public int WordSpanCount { get; set; }
+
+    /// <summary>Detailed character spans returned by successful engine calls.</summary>
+    public int CharacterSpanCount { get; set; }
+
+    /// <summary>Total validated payload bytes passed to the engine.</summary>
+    public long InputBytes { get; set; }
+
+    /// <summary>Maximum concurrency actually used for this engine instance.</summary>
+    public int EffectiveDegreeOfParallelism { get; set; }
+}
+
+/// <summary>Document, detailed recognition output, diagnostics, and counters from optional OCR execution.</summary>
+public sealed class OfficeDocumentOcrExecutionResult {
+    /// <summary>Document enriched with successfully recognized text.</summary>
+    public OfficeDocumentReadResult Document { get; set; } = new OfficeDocumentReadResult();
+
+    /// <summary>Successful engine responses in source candidate order, including empty-text responses.</summary>
+    public IReadOnlyList<OfficeDocumentOcrRecognition> Recognitions { get; set; } = Array.Empty<OfficeDocumentOcrRecognition>();
+
+    /// <summary>Execution, provider, validation, and limit diagnostics emitted during this run.</summary>
+    public IReadOnlyList<OfficeDocumentDiagnostic> Diagnostics { get; set; } = Array.Empty<OfficeDocumentDiagnostic>();
+
+    /// <summary>Observable execution counters.</summary>
+    public OfficeDocumentOcrExecutionReport Report { get; set; } = new OfficeDocumentOcrExecutionReport();
+}

--- a/OfficeIMO.Reader/Ocr/OfficeDocumentOcrExecutionModels.cs
+++ b/OfficeIMO.Reader/Ocr/OfficeDocumentOcrExecutionModels.cs
@@ -89,7 +89,7 @@ public sealed class OfficeDocumentOcrExecutionReport {
     /// <summary>Successful engine calls that returned no recognized text.</summary>
     public int EmptyCandidateCount { get; set; }
 
-    /// <summary>Candidates skipped by configured limits, missing payloads, unsupported media, or integrity checks.</summary>
+    /// <summary>Candidates skipped by configured limits, validation checks, or engine capacity held by a timed-out call.</summary>
     public int SkippedCandidateCount { get; set; }
 
     /// <summary>Engine calls that failed and were converted to diagnostics.</summary>

--- a/OfficeIMO.Reader/Ocr/OfficeDocumentOcrProcessor.cs
+++ b/OfficeIMO.Reader/Ocr/OfficeDocumentOcrProcessor.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>Runs a configured OCR engine as an ordered rich-document processor step.</summary>
+public sealed class OfficeDocumentOcrProcessor : IOfficeDocumentProcessor {
+    private readonly IOfficeOcrEngine _engine;
+    private readonly OfficeDocumentOcrExecutionOptions _options;
+
+    /// <summary>Creates an OCR processor with a frozen execution configuration.</summary>
+    public OfficeDocumentOcrProcessor(
+        IOfficeOcrEngine engine,
+        OfficeDocumentOcrExecutionOptions? options = null,
+        string id = "ocr-execution") {
+        _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+        if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("Processor id cannot be empty.", nameof(id));
+        Id = id.Trim();
+        _options = (options ?? new OfficeDocumentOcrExecutionOptions()).Clone();
+    }
+
+    /// <inheritdoc />
+    public string Id { get; }
+
+    /// <inheritdoc />
+    public OfficeDocumentReadResult Process(OfficeDocumentReadResult document, OfficeDocumentProcessorContext context) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        if (context == null) throw new ArgumentNullException(nameof(context));
+        return Task.Run(
+            async () => (await document.ApplyOcrAsync(_engine, _options, context.CancellationToken).ConfigureAwait(false)).Document,
+            context.CancellationToken).GetAwaiter().GetResult();
+    }
+
+    /// <inheritdoc />
+    public async Task<OfficeDocumentReadResult> ProcessAsync(OfficeDocumentReadResult document, OfficeDocumentProcessorContext context) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        if (context == null) throw new ArgumentNullException(nameof(context));
+        OfficeDocumentOcrExecutionResult result = await document.ApplyOcrAsync(_engine, _options, context.CancellationToken).ConfigureAwait(false);
+        return result.Document;
+    }
+}

--- a/OfficeIMO.Reader/Ocr/OfficeOcrModels.cs
+++ b/OfficeIMO.Reader/Ocr/OfficeOcrModels.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>Capabilities exposed by one configured OCR engine.</summary>
+public sealed class OfficeOcrEngineCapabilities {
+    /// <summary>Media types accepted by the engine. An empty collection means the provider does not pre-declare a restriction.</summary>
+    public IReadOnlyList<string> SupportedMediaTypes { get; set; } = Array.Empty<string>();
+
+    /// <summary>Language identifiers known to the engine. An empty collection means language discovery is provider-specific.</summary>
+    public IReadOnlyList<string> SupportedLanguages { get; set; } = Array.Empty<string>();
+
+    /// <summary>Whether line-level text spans can be returned.</summary>
+    public bool SupportsLineSpans { get; set; }
+
+    /// <summary>Whether word-level text spans can be returned.</summary>
+    public bool SupportsWordSpans { get; set; }
+
+    /// <summary>Whether character-level text spans can be returned.</summary>
+    public bool SupportsCharacterSpans { get; set; }
+
+    /// <summary>Whether confidence values can be returned.</summary>
+    public bool SupportsConfidence { get; set; }
+
+    /// <summary>Whether the same engine instance accepts concurrent recognition requests.</summary>
+    public bool SupportsConcurrentRequests { get; set; }
+
+    /// <summary>Creates an independent capability snapshot.</summary>
+    public OfficeOcrEngineCapabilities Clone() {
+        return new OfficeOcrEngineCapabilities {
+            SupportedMediaTypes = (SupportedMediaTypes ?? Array.Empty<string>()).ToArray(),
+            SupportedLanguages = (SupportedLanguages ?? Array.Empty<string>()).ToArray(),
+            SupportsLineSpans = SupportsLineSpans,
+            SupportsWordSpans = SupportsWordSpans,
+            SupportsCharacterSpans = SupportsCharacterSpans,
+            SupportsConfidence = SupportsConfidence,
+            SupportsConcurrentRequests = SupportsConcurrentRequests
+        };
+    }
+}
+
+/// <summary>One bounded recognition request passed to an OCR engine.</summary>
+public sealed class OfficeOcrEngineRequest {
+    /// <summary>OCR candidate being resolved.</summary>
+    public OfficeDocumentOcrCandidate Candidate { get; set; } = new OfficeDocumentOcrCandidate();
+
+    /// <summary>Materialized asset associated with the candidate.</summary>
+    public OfficeDocumentAsset Asset { get; set; } = new OfficeDocumentAsset();
+
+    /// <summary>Validated asset payload supplied to the engine.</summary>
+    public byte[] Payload { get; set; } = Array.Empty<byte>();
+
+    /// <summary>Requested language or language expression, when configured.</summary>
+    public string? Language { get; set; }
+
+    /// <summary>Source document metadata for provider-side correlation.</summary>
+    public OfficeDocumentSource Source { get; set; } = new OfficeDocumentSource();
+
+    /// <summary>Provider-specific scalar options supplied by the host.</summary>
+    public IReadOnlyDictionary<string, string> ProviderOptions { get; set; } = new Dictionary<string, string>(StringComparer.Ordinal);
+}
+
+/// <summary>Recognition output returned by an OCR engine.</summary>
+public sealed class OfficeOcrEngineResult {
+    /// <summary>Recognized plain text in source reading order.</summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>Overall normalized confidence from 0 through 1, when available.</summary>
+    public double? Confidence { get; set; }
+
+    /// <summary>Detected or requested language identifier, when available.</summary>
+    public string? Language { get; set; }
+
+    /// <summary>Provider identifier reported by the engine.</summary>
+    public string? Provider { get; set; }
+
+    /// <summary>Provider model, engine, or trained-data identifier, when available.</summary>
+    public string? Model { get; set; }
+
+    /// <summary>Optional line, word, and character spans in reading order.</summary>
+    public IReadOnlyList<OfficeOcrTextSpan> Spans { get; set; } = Array.Empty<OfficeOcrTextSpan>();
+
+    /// <summary>Structured provider diagnostics produced during recognition.</summary>
+    public IReadOnlyList<OfficeDocumentDiagnostic> Diagnostics { get; set; } = Array.Empty<OfficeDocumentDiagnostic>();
+}
+
+/// <summary>Granularity of one recognized OCR text span.</summary>
+public enum OfficeOcrTextSpanLevel {
+    /// <summary>One recognized text line.</summary>
+    Line = 1,
+    /// <summary>One recognized word or token.</summary>
+    Word = 2,
+    /// <summary>One recognized character or grapheme.</summary>
+    Character = 3
+}
+
+/// <summary>Coordinate unit used by an OCR span region.</summary>
+public enum OfficeOcrCoordinateUnit {
+    /// <summary>Source image pixels.</summary>
+    Pixels = 0,
+    /// <summary>Document points, where 72 points equal one inch.</summary>
+    Points = 1,
+    /// <summary>Normalized coordinates from 0 through 1.</summary>
+    Normalized = 2
+}
+
+/// <summary>Detailed recognized line, word, or character with optional confidence and geometry.</summary>
+public sealed class OfficeOcrTextSpan {
+    /// <summary>Zero-based sequence within the provider's emitted reading order.</summary>
+    public int Sequence { get; set; }
+
+    /// <summary>Span granularity.</summary>
+    public OfficeOcrTextSpanLevel Level { get; set; }
+
+    /// <summary>Recognized text for this span.</summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>Normalized confidence from 0 through 1, when available.</summary>
+    public double? Confidence { get; set; }
+
+    /// <summary>Detected or requested language identifier, when available.</summary>
+    public string? Language { get; set; }
+
+    /// <summary>One-based source page within a multi-page payload, when applicable.</summary>
+    public int? PageNumber { get; set; }
+
+    /// <summary>Bounding region in <see cref="CoordinateUnit"/> when available.</summary>
+    public OfficeDocumentRegion? Region { get; set; }
+
+    /// <summary>Coordinate unit used by <see cref="Region"/>.</summary>
+    public OfficeOcrCoordinateUnit CoordinateUnit { get; set; } = OfficeOcrCoordinateUnit.Pixels;
+}
+
+/// <summary>One candidate recognition paired with its engine output.</summary>
+public sealed class OfficeDocumentOcrRecognition {
+    /// <summary>Candidate identifier.</summary>
+    public string CandidateId { get; set; } = string.Empty;
+
+    /// <summary>Resolved asset identifier.</summary>
+    public string AssetId { get; set; } = string.Empty;
+
+    /// <summary>Engine output, including detailed spans and provider diagnostics.</summary>
+    public OfficeOcrEngineResult Result { get; set; } = new OfficeOcrEngineResult();
+}

--- a/OfficeIMO.Reader/README.md
+++ b/OfficeIMO.Reader/README.md
@@ -209,7 +209,7 @@ Console.WriteLine(restored.SchemaVersion); // 5
 string jsonSchema = OfficeDocumentReadResultSchema.GetJsonSchema();
 ```
 
-The package embeds the versioned JSON Schema and also ships it as `schemas/officeimo.document.read-result.v5.schema.json`. Deserialization accepts only the current schema id/version, rejects unknown top-level members and incomplete envelopes, and returns a typed `OfficeDocumentReadResultSchemaException` for incompatible versions. Every pack of the core and modular Reader packages runs NuGet package validation against the currently published package version, so accidental public API breaks fail packaging.
+The package embeds the versioned JSON Schema and also ships it as `schemas/officeimo.document.read-result.v5.schema.json`. Deserialization accepts only the current schema id/version, rejects unknown top-level members and incomplete envelopes, and returns a typed `OfficeDocumentReadResultSchemaException` for incompatible versions. Published core and modular Reader packages run NuGet package validation against their current public versions, so accidental API breaks fail packaging. A brand-new package opts out only until its first public baseline exists.
 
 ## Content detection and structured diagnostics
 
@@ -249,6 +249,42 @@ Console.WriteLine($"{deck.Visuals.Count} PowerPoint chart snapshots");
 ```
 
 The Word mapping preserves headings, lists, links, tables, and header/footer content. Excel exposes worksheet locations, formal tables, cell links, formula/comment/named-range counts, and workbook properties. PowerPoint exposes slide-local blocks and tables, run and shape links, chart snapshots, and point-based geometry. Modular HTML, EPUB, RTF, and Visio adapters register the same native v5 result surface when their packages are installed.
+
+## Optional OCR execution
+
+The core defines `IOfficeOcrEngine` and runs caller-supplied engines without taking an OCR or cloud SDK dependency. Execution resolves candidate assets, validates payload hashes and media types, and bounds candidate count, per-candidate and total bytes, concurrency, duration, recognized characters, and detailed spans:
+
+```csharp
+var engine = new DelegateOfficeOcrEngine(
+    "host-vision-service",
+    async (request, cancellationToken) => {
+        HostVisionResponse response = await visionClient.RecognizeAsync(
+            request.Payload,
+            request.Language,
+            cancellationToken);
+
+        return new OfficeOcrEngineResult {
+            Text = response.Text,
+            Confidence = response.Confidence,
+            Language = response.Language,
+            Provider = "host-vision-service"
+        };
+    });
+
+OfficeDocumentReadResult source = DocumentReader.ReadDocument("scanned.pdf");
+OfficeDocumentOcrExecutionResult execution = await source.ApplyOcrAsync(
+    engine,
+    new OfficeDocumentOcrExecutionOptions {
+        MaxCandidates = 25,
+        MaxDegreeOfParallelism = 2
+    });
+```
+
+To run the same frozen configuration automatically for every rich read, register `new OfficeDocumentOcrProcessor(engine, executionOptions)` with `OfficeDocumentReaderBuilder.AddProcessor(...)`. Engines that do not advertise concurrent-request support are serialized per engine instance even when several reader operations run concurrently.
+
+`execution.Document` contains merged `ocr-text` blocks/chunks while unresolved candidates and diagnostics remain intact. `execution.Recognitions` carries optional line, word, and character spans with confidence, language, bounding boxes, and coordinate units. Detailed provider spans intentionally stay outside the stable v5 transport; the merged text and trace metadata use the existing schema.
+
+Use `OfficeIMO.Reader.Ocr.Process` for a versioned local executable/service bridge or `OfficeIMO.Reader.Ocr.Tesseract` for an installed Tesseract CLI. Neither package is pulled transitively by `OfficeIMO.Reader`.
 
 ## Host examples
 
@@ -351,6 +387,8 @@ The benchmark corpus is generated deterministically before measurement. Benchmar
 - [OfficeIMO.Reader.Visio](../OfficeIMO.Reader.Visio/README.md)
 - [OfficeIMO.Reader.Html](../OfficeIMO.Reader.Html/README.md)
 - [OfficeIMO.Reader.Csv](../OfficeIMO.Reader.Csv/README.md)
+- [OfficeIMO.Reader.Ocr.Process](../OfficeIMO.Reader.Ocr.Process/README.md)
+- [OfficeIMO.Reader.Ocr.Tesseract](../OfficeIMO.Reader.Ocr.Tesseract/README.md)
 - [OfficeIMO.Reader.Json](../OfficeIMO.Reader.Json/README.md)
 - [OfficeIMO.Reader.Xml](../OfficeIMO.Reader.Xml/README.md)
 - [OfficeIMO.Reader.Yaml](../OfficeIMO.Reader.Yaml/README.md)

--- a/OfficeIMO.Shared.Tests/PackageDependencyGuardrails.cs
+++ b/OfficeIMO.Shared.Tests/PackageDependencyGuardrails.cs
@@ -435,6 +435,19 @@ public sealed class PackageDependencyGuardrailTests {
     }
 
     [Theory]
+    [InlineData("OfficeIMO.Reader.Ocr.Process")]
+    [InlineData("OfficeIMO.Reader.Ocr.Tesseract")]
+    public void ReaderOcrPackages_AreIncludedInProjectBuildVersionMap(string packageId) {
+        var projectBuildPath = GetRepositoryPath("Build/project.build.json");
+        Assert.True(File.Exists(projectBuildPath), "Project build file is missing: " + projectBuildPath);
+
+        using JsonDocument document = JsonDocument.Parse(File.ReadAllText(projectBuildPath));
+        JsonElement expectedVersionMap = document.RootElement.GetProperty("ExpectedVersionMap");
+
+        Assert.Equal("0.0.X", expectedVersionMap.GetProperty(packageId).GetString());
+    }
+
+    [Theory]
     [InlineData("OfficeIMO.Word/OfficeIMO.Word.csproj")]
     [InlineData("OfficeIMO.Excel/OfficeIMO.Excel.csproj")]
     [InlineData("OfficeIMO.Visio/OfficeIMO.Visio.csproj")]

--- a/OfficeIMO.sln
+++ b/OfficeIMO.sln
@@ -146,6 +146,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.MarkdownRenderer"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OfficeIMO.Reader", "OfficeIMO.Reader\OfficeIMO.Reader.csproj", "{3731577E-0CFF-4089-9A55-94CF0527A8E5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Reader.Ocr.Process", "OfficeIMO.Reader.Ocr.Process\OfficeIMO.Reader.Ocr.Process.csproj", "{A8F9B0C1-D2E3-4F50-9123-456789ABCDEF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Reader.Ocr.Tesseract", "OfficeIMO.Reader.Ocr.Tesseract\OfficeIMO.Reader.Ocr.Tesseract.csproj", "{B9C0D1E2-F3A4-5061-A234-56789ABCDEF0}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Zip", "OfficeIMO.Zip\OfficeIMO.Zip.csproj", "{485EC640-7670-441B-81DD-BE927EC43429}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Epub", "OfficeIMO.Epub\OfficeIMO.Epub.csproj", "{EDEE7993-1CA3-4081-96FA-3F4EA51C08D5}"
@@ -288,6 +292,30 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A8F9B0C1-D2E3-4F50-9123-456789ABCDEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A8F9B0C1-D2E3-4F50-9123-456789ABCDEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A8F9B0C1-D2E3-4F50-9123-456789ABCDEF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A8F9B0C1-D2E3-4F50-9123-456789ABCDEF}.Debug|x64.Build.0 = Debug|Any CPU
+		{A8F9B0C1-D2E3-4F50-9123-456789ABCDEF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A8F9B0C1-D2E3-4F50-9123-456789ABCDEF}.Debug|x86.Build.0 = Debug|Any CPU
+		{A8F9B0C1-D2E3-4F50-9123-456789ABCDEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A8F9B0C1-D2E3-4F50-9123-456789ABCDEF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A8F9B0C1-D2E3-4F50-9123-456789ABCDEF}.Release|x64.ActiveCfg = Release|Any CPU
+		{A8F9B0C1-D2E3-4F50-9123-456789ABCDEF}.Release|x64.Build.0 = Release|Any CPU
+		{A8F9B0C1-D2E3-4F50-9123-456789ABCDEF}.Release|x86.ActiveCfg = Release|Any CPU
+		{A8F9B0C1-D2E3-4F50-9123-456789ABCDEF}.Release|x86.Build.0 = Release|Any CPU
+		{B9C0D1E2-F3A4-5061-A234-56789ABCDEF0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B9C0D1E2-F3A4-5061-A234-56789ABCDEF0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B9C0D1E2-F3A4-5061-A234-56789ABCDEF0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B9C0D1E2-F3A4-5061-A234-56789ABCDEF0}.Debug|x64.Build.0 = Debug|Any CPU
+		{B9C0D1E2-F3A4-5061-A234-56789ABCDEF0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B9C0D1E2-F3A4-5061-A234-56789ABCDEF0}.Debug|x86.Build.0 = Debug|Any CPU
+		{B9C0D1E2-F3A4-5061-A234-56789ABCDEF0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B9C0D1E2-F3A4-5061-A234-56789ABCDEF0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B9C0D1E2-F3A4-5061-A234-56789ABCDEF0}.Release|x64.ActiveCfg = Release|Any CPU
+		{B9C0D1E2-F3A4-5061-A234-56789ABCDEF0}.Release|x64.Build.0 = Release|Any CPU
+		{B9C0D1E2-F3A4-5061-A234-56789ABCDEF0}.Release|x86.ActiveCfg = Release|Any CPU
+		{B9C0D1E2-F3A4-5061-A234-56789ABCDEF0}.Release|x86.Build.0 = Release|Any CPU
 		{FDCF73EE-953A-4063-AFA1-C6C395C8B9CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FDCF73EE-953A-4063-AFA1-C6C395C8B9CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FDCF73EE-953A-4063-AFA1-C6C395C8B9CD}.Debug|x64.ActiveCfg = Debug|Any CPU

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ PowerShell users should start with [EvotecIT/PSWriteOffice](https://github.com/E
 | [OfficeIMO.Reader.Epub](OfficeIMO.Reader.Epub/README.md) | EPUB reader adapter. |
 | [OfficeIMO.Reader.Html](OfficeIMO.Reader.Html/README.md) | HTML reader adapter. |
 | [OfficeIMO.Reader.Json](OfficeIMO.Reader.Json/README.md) | JSON reader adapter. |
+| [OfficeIMO.Reader.Ocr.Process](OfficeIMO.Reader.Ocr.Process/README.md) | Optional versioned external-process OCR provider. |
+| [OfficeIMO.Reader.Ocr.Tesseract](OfficeIMO.Reader.Ocr.Tesseract/README.md) | Optional Tesseract CLI OCR provider. |
 | [OfficeIMO.Reader.Pdf](OfficeIMO.Reader.Pdf/README.md) | PDF reader adapter. |
 | [OfficeIMO.Reader.Rtf](OfficeIMO.Reader.Rtf/README.md) | Bounded RTF chunks, tables, visuals, warnings, and provenance. |
 | [OfficeIMO.Reader.Text](OfficeIMO.Reader.Text/README.md) | Structured text compatibility adapter. |

--- a/Website/content/docs/reader/index.md
+++ b/Website/content/docs/reader/index.md
@@ -1,88 +1,157 @@
 ---
 title: Reader and Extraction
-description: Overview of the OfficeIMO.Reader package for unified document extraction and AI-ready chunking workflows.
+description: Deterministic document extraction, rich results, structured records, RAG chunking, and optional OCR with OfficeIMO.Reader.
 order: 55
 ---
 
 # Reader and Extraction
 
-`OfficeIMO.Reader` provides a single extraction surface for the built-in formats currently handled in the repo, plus optional adapters for adjacent document types. Instead of maintaining separate parsing pipelines for `.docx`, `.xlsx`, `.pptx`, Markdown, PDF, CSV, JSON, XML, YAML, HTML, EPUB, ZIP, or text-like files, you can normalize them into one chunk model and then feed that output into indexing, search, and AI workflows.
+`OfficeIMO.Reader` is the shared read-only extraction facade for Office and adjacent document formats. It can return simple `ReaderChunk` sequences for indexing, or a rich `OfficeDocumentReadResult` with pages, blocks, tables, links, forms, assets, visuals, OCR candidates, metadata, and structured diagnostics.
 
-## Best fit scenarios
+Format-specific parsing stays in the owning OfficeIMO package. Optional adapters and OCR providers remain separate packages, so applications install only the formats and runtimes they need.
 
-- Build ingestion pipelines for RAG, semantic search, or compliance review.
-- Normalize mixed document folders into one extraction and chunking model.
-- Preserve headings, citations, token estimates, and source hashes while preparing content for downstream tools.
-- Run extraction in background workers, containers, Azure Functions, or scheduled jobs.
+## Install
 
-## Core workflow
+Install the core package and any modular adapters used by the application:
 
-1. Extract a file into `ReaderChunk` instances with text, markdown, tables, visuals, and source information.
-2. Tune `ReaderOptions` so emitted slices stay deterministic and sized for search or AI prompts.
-3. Store chunks, citations, and source identifiers in your vector store, search index, or audit trail.
+```powershell
+dotnet add package OfficeIMO.Reader
+dotnet add package OfficeIMO.Reader.Pdf
+dotnet add package OfficeIMO.Reader.Html
+dotnet add package OfficeIMO.Reader.Epub
+```
 
-## Quick start
+The core package reads Word, Excel, PowerPoint, and Markdown. Adapter packages add PDF, CSV/TSV, EPUB, HTML, JSON, XML, YAML, RTF, Visio, ZIP, and structured text support.
+
+## Choose the result you need
+
+Use `Read(...)` for indexing-friendly chunks:
 
 ```csharp
 using OfficeIMO.Reader;
 
-var chunks = DocumentReader.Read("proposal.docx", new ReaderOptions
-{
-    MaxChars = 4_000,
-    IncludeWordFootnotes = true,
-    ComputeHashes = true
-}).ToList();
-
-foreach (var chunk in chunks)
-{
-    Console.WriteLine($"{chunk.Id} :: {chunk.Kind}");
+foreach (ReaderChunk chunk in DocumentReader.Read("proposal.docx")) {
     Console.WriteLine(chunk.Location.HeadingPath ?? chunk.Location.Path);
-    Console.WriteLine(chunk.TokenEstimate);
+    Console.WriteLine(chunk.Markdown ?? chunk.Text);
 }
 ```
 
-## Formats and behavior
+Use `ReadDocument(...)` when the host needs the complete normalized document:
 
-| Input | Typical use |
-|-------|-------------|
-| Word (`.docx`) | Rich business documents, reports, contracts, and templates |
-| Excel (`.xlsx`) | Workbook content, tabular reports, and structured exports |
-| PowerPoint (`.pptx`) | Slide decks, speaker notes, and presentation narratives |
-| Markdown | Documentation, changelogs, developer notes, and generated content |
-| PDF | Published exports, archival documents, and third-party handoffs |
-| CSV/TSV | Structured flat files through `OfficeIMO.Reader.Csv` |
-| JSON | API exports and structured payloads through `OfficeIMO.Reader.Json` |
-| XML | Element-oriented documents through `OfficeIMO.Reader.Xml` |
-| YAML | Configuration files and manifests through `OfficeIMO.Reader.Yaml` |
-| HTML | Web pages and exported fragments through `OfficeIMO.Reader.Html` |
-| EPUB | Books and packaged publications through `OfficeIMO.Reader.Epub` |
-| ZIP | Archive traversal through `OfficeIMO.Reader.Zip` |
+```csharp
+OfficeDocumentReadResult document = DocumentReader.ReadDocument("proposal.docx");
 
-## Adapter packages
+Console.WriteLine($"{document.Pages.Count} pages or source containers");
+Console.WriteLine($"{document.Tables.Count} tables");
+Console.WriteLine($"{document.Assets.Count} assets");
 
-The core package covers the main Office-oriented extraction flow. Add adapter packages only when the deployment needs those input families:
+string json = OfficeDocumentReadResultJson.Serialize(document, indented: true);
+```
 
-- `OfficeIMO.Reader.Csv` for CSV and TSV ingestion.
-- `OfficeIMO.Reader.Json` for JSON payloads.
-- `OfficeIMO.Reader.Xml` for XML documents.
-- `OfficeIMO.Reader.Yaml` for YAML configuration files, manifests, and multi-document streams.
-- `OfficeIMO.Reader.Text` when CSV, JSON, and XML adapters should travel together.
-- `OfficeIMO.Reader.Html` for HTML normalization through the Markdown pipeline.
-- `OfficeIMO.Reader.Epub` for EPUB publications.
-- `OfficeIMO.Reader.Zip` for safe archive traversal.
+The rich JSON envelope uses stable schema version 5. The package embeds and ships its JSON Schema, rejects incomplete or incompatible envelopes, and preserves structured diagnostics rather than requiring consumers to parse warning text.
 
-Use the [Reader API reference](/api/reader/) for the core `DocumentReader`, `ReaderOptions`, chunk, manifest, and handler registration types. Adapter-specific APIs are documented through their package README files until the website generates separate adapter reference sections.
+## Isolated readers for services
 
-## Design goals
+The static `DocumentReader` facade remains available for compatible process-wide registration. Services and concurrent hosts should freeze their adapters, options, and processors into an isolated reader instance:
 
-- **Deterministic chunking** so repeated runs produce stable chunk boundaries.
-- **Heading-aware extraction** so downstream systems retain document structure.
-- **Citation-friendly location data** so search and AI responses can reference original sources.
-- **Incremental indexing support** through source IDs, hashes, and per-document chunk summaries.
-- **Container-friendly execution** with no Office installation requirements.
+```csharp
+using OfficeIMO.Reader;
+using OfficeIMO.Reader.Epub;
+using OfficeIMO.Reader.Html;
+using OfficeIMO.Reader.Pdf;
 
-## Related packages
+OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+    .AddPdfHandler()
+    .AddHtmlHandler()
+    .AddEpubHandler()
+    .WithMaxConcurrentReads(4)
+    .Build();
 
-- [OfficeIMO.Word](/products/word/) for producing `.docx` content before ingestion.
-- [OfficeIMO.Markdown](/products/markdown/) for rendering, transforming, and re-emitting extracted content.
-- [AOT and Trimming](/docs/advanced/aot-trimming/) for lean deployment guidance.
+OfficeDocumentReadResult result = await reader.ReadDocumentAsync(
+    "handbook.pdf",
+    cancellationToken: cancellationToken);
+```
+
+`Build()` snapshots the configuration. Different reader instances can use different handlers for the same extension without leaking registration state. Async path, stream, byte, and bounded batch APIs preserve input limits, cancellation, deterministic ordering, and caller-owned stream lifetimes.
+
+## Detection and bounds
+
+Reader combines extension, media-type, signature, and structured container evidence. Normal reads preserve known-extension routing; hosts can opt into content-first routing for mislabeled uploads:
+
+```csharp
+ReaderDetectionResult detection = reader.Detect("upload.bin");
+
+OfficeDocumentReadResult result = reader.ReadDocument(
+    "upload.bin",
+    new ReaderOptions {
+        DetectionMode = ReaderDetectionMode.PreferContent,
+        MaxInputBytes = 100L * 1024 * 1024,
+        MaxTableRows = 1_000
+    });
+```
+
+Detection reports the selected kind, extension/content evidence, confidence, media type, and mismatch state. Input bytes, folder totals, document counts, concurrency, table rows, output characters, and other expansion points have explicit bounds.
+
+## Processing and structured extraction
+
+Register ordered processors when every rich read should receive the same deterministic cleanup or filtering:
+
+```csharp
+OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+    .AddProcessor(new OfficeDocumentBlockNormalizationProcessor())
+    .AddProcessor(new OfficeDocumentTableNormalizationProcessor())
+    .AddProcessor(new OfficeDocumentLinkNormalizationProcessor())
+    .WithProcessorFailureBehavior(
+        OfficeDocumentProcessorFailureBehavior.ContinueWithDiagnostic)
+    .Build();
+
+OfficeDocumentStructuredExtractionResult extracted = reader.ReadStructured(
+    "contract.docx",
+    structuredOptions: new OfficeDocumentStructuredExtractionOptions {
+        MaxRecords = 5_000,
+        MaxSections = 500,
+        MaxTables = 250
+    });
+```
+
+The structured extractor emits bounded scalar records, heading sections, named tables, forms, chart and visual summaries, and readiness/security/OCR diagnostics. It is deterministic and does not add an AI client dependency.
+
+## Token-aware RAG chunks
+
+`ReadHierarchical(...)` splits large source chunks by a token budget while preserving document, page/slide/sheet, and heading ancestry:
+
+```csharp
+ReaderChunkHierarchyResult hierarchy = reader.ReadHierarchical(
+    "policy.docx",
+    chunkingOptions: new ReaderHierarchicalChunkingOptions {
+        MaxTokens = 800,
+        OverlapTokens = 80,
+        MaxInputChunks = 10_000,
+        MaxOutputChunks = 50_000
+    });
+
+foreach (ReaderChunk chunk in hierarchy.Chunks) {
+    StoreEmbedding(chunk.Id, chunk.Text, chunk.TokenEstimate ?? 0);
+}
+```
+
+The result includes deterministic leaf IDs and hashes, exact source spans, overlap/context totals, and a flattened hierarchy sidecar. Supply an `IReaderTokenCounter` when the embedding model requires its exact tokenizer.
+
+## Optional OCR
+
+The core `IOfficeOcrEngine` contract executes OCR candidates with bounded count, bytes, concurrency, duration, recognized text, and geometry spans. OCR output is merged as an additional source layer without replacing native text.
+
+- `OfficeIMO.Reader.Ocr.Process` bridges a configured executable or service through a versioned JSON protocol.
+- `OfficeIMO.Reader.Ocr.Tesseract` uses a separately installed Tesseract CLI and exposes TSV line/word geometry.
+- Hosts can implement `IOfficeOcrEngine` or use `DelegateOfficeOcrEngine` for another local or cloud provider.
+
+Neither provider is a transitive dependency of `OfficeIMO.Reader`.
+
+## Package and ownership boundaries
+
+- `OfficeIMO.Reader` owns the shared result, routing, limits, diagnostics, processing, structured extraction, and hierarchy contracts.
+- Word, Excel, PowerPoint, Markdown, PDF, RTF, HTML, EPUB, Visio, and other format packages own their parsing and inspection models.
+- Modular Reader packages adapt those models into the shared result.
+- Storage, vector databases, AI clients, and platform-specific services belong in the consuming application or an opt-in provider.
+
+See the [OfficeIMO.Reader package README](https://github.com/EvotecIT/OfficeIMO/blob/master/OfficeIMO.Reader/README.md) for the complete API walkthrough and the [Reader API reference](/api/reader/) for generated type documentation.


### PR DESCRIPTION
## Summary

- define a dependency-free `IOfficeOcrEngine` contract with text, confidence, language, diagnostics, and line, word, or character spans
- execute candidates with bounded count, bytes, concurrency, duration, output text, span count, payload integrity, and deterministic merge behavior
- keep non-cooperative engines within the configured concurrency boundary and serialize non-concurrent engine instances until abandoned calls settle
- reject ambiguous multi-image page candidates instead of treating their first image asset as the whole page
- add an immutable OCR processor for ordered Reader pipelines
- add `OfficeIMO.Reader.Ocr.Process` with a versioned JSON file protocol, direct no-shell process execution, and descendant containment
- create Windows OCR processes suspended, restrict inherited handles, assign the Job Object, and only then resume execution
- add `OfficeIMO.Reader.Ocr.Tesseract` with TSV line and word geometry plus version and language discovery
- create Unix OCR request directories and files with owner-only permissions, and delete temporary artifacts by default
- include both optional providers in the normal release build map while keeping the base Reader package free of OCR runtime dependencies
- refresh the Reader owner docs, package-boundary guide, document-intelligence roadmap, and website guide for the completed P0 and Tracks 1-4 surface

## Operational boundary

The Tesseract provider requires a separately installed Tesseract CLI. Local validation covers its deterministic TSV parser and argument contract; the generic provider test exercises a real child-process protocol boundary.

## Validation

- full Reader suite: 558/558 on .NET 8 and 558/558 on .NET 10
- Reader tests compile for .NET Framework 4.7.2 with zero warnings and zero errors
- both optional OCR providers build cleanly for `netstandard2.0`
- replacement GitHub Actions matrix validates the rebased, final PR head

## Scope

This completes Reader Track 4 on top of the merged P0 and Tracks 1-3 work. Track 5 email ingestion is intentionally excluded for separate ownership.


