### PR TITLE
Unify HTML conversion APIs and round-trip fidelity

### DIFF
--- a/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.IO.cs
+++ b/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.IO.cs
@@ -1,0 +1,47 @@
+using OfficeIMO.Html;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Excel.Html;
+
+public static partial class ExcelHtmlConverterExtensions {
+    /// <summary>Writes a workbook as UTF-8 HTML to a stream and leaves the stream open.</summary>
+    public static void SaveAsHtml(this ExcelDocument workbook, Stream stream, ExcelHtmlSaveOptions? options = null) {
+        if (workbook == null) throw new ArgumentNullException(nameof(workbook));
+        HtmlTextIO.Write(stream, workbook.ToHtml(options));
+    }
+
+    /// <summary>Writes a worksheet as UTF-8 HTML to a stream and leaves the stream open.</summary>
+    public static void SaveAsHtml(this ExcelSheet sheet, Stream stream, ExcelHtmlSaveOptions? options = null) {
+        if (sheet == null) throw new ArgumentNullException(nameof(sheet));
+        HtmlTextIO.Write(stream, sheet.ToHtml(options));
+    }
+
+    /// <summary>Asynchronously writes a workbook as UTF-8 HTML.</summary>
+    public static async Task SaveAsHtmlAsync(this ExcelDocument workbook, string path, ExcelHtmlSaveOptions? options = null, CancellationToken cancellationToken = default) {
+        if (workbook == null) throw new ArgumentNullException(nameof(workbook));
+        cancellationToken.ThrowIfCancellationRequested();
+        await HtmlTextIO.WriteAsync(path, workbook.ToHtml(options), cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Asynchronously writes a workbook as UTF-8 HTML to a stream and leaves it open.</summary>
+    public static async Task SaveAsHtmlAsync(this ExcelDocument workbook, Stream stream, ExcelHtmlSaveOptions? options = null, CancellationToken cancellationToken = default) {
+        if (workbook == null) throw new ArgumentNullException(nameof(workbook));
+        cancellationToken.ThrowIfCancellationRequested();
+        await HtmlTextIO.WriteAsync(stream, workbook.ToHtml(options), cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Asynchronously writes a worksheet as UTF-8 HTML.</summary>
+    public static async Task SaveAsHtmlAsync(this ExcelSheet sheet, string path, ExcelHtmlSaveOptions? options = null, CancellationToken cancellationToken = default) {
+        if (sheet == null) throw new ArgumentNullException(nameof(sheet));
+        cancellationToken.ThrowIfCancellationRequested();
+        await HtmlTextIO.WriteAsync(path, sheet.ToHtml(options), cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Asynchronously writes a worksheet as UTF-8 HTML to a stream and leaves it open.</summary>
+    public static async Task SaveAsHtmlAsync(this ExcelSheet sheet, Stream stream, ExcelHtmlSaveOptions? options = null, CancellationToken cancellationToken = default) {
+        if (sheet == null) throw new ArgumentNullException(nameof(sheet));
+        cancellationToken.ThrowIfCancellationRequested();
+        await HtmlTextIO.WriteAsync(stream, sheet.ToHtml(options), cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.MergedCells.cs
+++ b/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.MergedCells.cs
@@ -71,33 +71,23 @@ public static partial class ExcelHtmlConverterExtensions {
 
     private sealed class ExcelMergeExportMap {
         private readonly Dictionary<long, ExcelMergeExportRange> _origins = new();
-        private readonly HashSet<long> _coveredCells = new();
+        private readonly List<ExcelMergeExportRange> _ranges = new();
 
         internal int Count => _origins.Count;
 
         internal bool TryAdd(ExcelMergeExportRange merge) {
-            for (int row = merge.StartRow; row <= merge.EndRow; row++) {
-                for (int column = merge.StartColumn; column <= merge.EndColumn; column++) {
-                    long key = GetCellKey(row, column);
-                    if (_coveredCells.Contains(key) || _origins.ContainsKey(key)) {
-                        return false;
-                    }
-                }
+            if (_ranges.Any(existing => existing.Intersects(merge))) {
+                return false;
             }
 
             _origins.Add(GetCellKey(merge.StartRow, merge.StartColumn), merge);
-            for (int row = merge.StartRow; row <= merge.EndRow; row++) {
-                for (int column = merge.StartColumn; column <= merge.EndColumn; column++) {
-                    if (row != merge.StartRow || column != merge.StartColumn) {
-                        _coveredCells.Add(GetCellKey(row, column));
-                    }
-                }
-            }
+            _ranges.Add(merge);
 
             return true;
         }
 
-        internal bool IsCoveredCell(int row, int column) => _coveredCells.Contains(GetCellKey(row, column));
+        internal bool IsCoveredCell(int row, int column) =>
+            _ranges.Any(range => range.Contains(row, column) && (row != range.StartRow || column != range.StartColumn));
 
         internal bool TryGetOrigin(int row, int column, out ExcelMergeExportRange merge) =>
             _origins.TryGetValue(GetCellKey(row, column), out merge);
@@ -124,6 +114,13 @@ public static partial class ExcelHtmlConverterExtensions {
         internal int ColumnSpan => EndColumn - StartColumn + 1;
 
         internal string A1Range => A1.CellReference(StartRow, StartColumn) + ":" + A1.CellReference(EndRow, EndColumn);
+
+        internal bool Contains(int row, int column) =>
+            row >= StartRow && row <= EndRow && column >= StartColumn && column <= EndColumn;
+
+        internal bool Intersects(ExcelMergeExportRange other) =>
+            StartRow <= other.EndRow && EndRow >= other.StartRow
+            && StartColumn <= other.EndColumn && EndColumn >= other.StartColumn;
     }
 
     private static long GetCellKey(int row, int column) => ((long)row << 32) | (uint)column;

--- a/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.MergedCells.cs
+++ b/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.MergedCells.cs
@@ -1,0 +1,130 @@
+using OfficeIMO.Html;
+
+namespace OfficeIMO.Excel.Html;
+
+public static partial class ExcelHtmlConverterExtensions {
+    private static string ExpandUsedRangeForMerges(ExcelSheet sheet, string usedRange, IReadOnlyList<ExcelMergedRangeSnapshot> mergedRanges) {
+        ParseUsedRange(usedRange, out int firstRow, out int firstColumn, out int rowCount, out int columnCount);
+        int lastRow = firstRow + Math.Max(1, rowCount) - 1;
+        int lastColumn = firstColumn + Math.Max(1, columnCount) - 1;
+
+        if (mergedRanges.Count > 0 && !SheetHasUsedCells(sheet, firstRow, firstColumn, rowCount, columnCount)) {
+            ExcelMergedRangeSnapshot firstMerge = mergedRanges[0];
+            firstRow = firstMerge.StartRow;
+            firstColumn = firstMerge.StartColumn;
+            lastRow = firstMerge.EndRow;
+            lastColumn = firstMerge.EndColumn;
+        }
+
+        foreach (ExcelMergedRangeSnapshot merge in mergedRanges) {
+            firstRow = Math.Min(firstRow, merge.StartRow);
+            firstColumn = Math.Min(firstColumn, merge.StartColumn);
+            lastRow = Math.Max(lastRow, merge.EndRow);
+            lastColumn = Math.Max(lastColumn, merge.EndColumn);
+        }
+
+        return A1.CellReference(firstRow, firstColumn) + ":" + A1.CellReference(lastRow, lastColumn);
+    }
+
+    private static ExcelMergeExportMap BuildMergeExportMap(
+        IReadOnlyList<ExcelMergedRangeSnapshot> mergedRanges,
+        int firstRow,
+        int firstColumn,
+        int rowCount,
+        int columnCount) {
+        int lastRow = firstRow + rowCount - 1;
+        int lastColumn = firstColumn + columnCount - 1;
+        var map = new ExcelMergeExportMap();
+
+        foreach (ExcelMergedRangeSnapshot merge in mergedRanges) {
+            int startRow = Math.Max(firstRow, merge.StartRow);
+            int startColumn = Math.Max(firstColumn, merge.StartColumn);
+            int endRow = Math.Min(lastRow, merge.EndRow);
+            int endColumn = Math.Min(lastColumn, merge.EndColumn);
+            if (startRow > endRow || startColumn > endColumn) {
+                continue;
+            }
+
+            map.TryAdd(new ExcelMergeExportRange(startRow, startColumn, endRow, endColumn));
+        }
+
+        return map;
+    }
+
+    private static void AppendMergeAttributes(StringBuilder body, ExcelMergeExportRange merge) {
+        if (merge.RowSpan > 1) {
+            body.Append(" rowspan=\"")
+                .Append(merge.RowSpan.ToString(CultureInfo.InvariantCulture))
+                .Append('"');
+        }
+
+        if (merge.ColumnSpan > 1) {
+            body.Append(" colspan=\"")
+                .Append(merge.ColumnSpan.ToString(CultureInfo.InvariantCulture))
+                .Append('"');
+        }
+
+        body.Append(" data-officeimo-merge=\"")
+            .Append(OfficeHtmlText.EscapeAttribute(merge.A1Range))
+            .Append('"');
+    }
+
+    private sealed class ExcelMergeExportMap {
+        private readonly Dictionary<long, ExcelMergeExportRange> _origins = new();
+        private readonly HashSet<long> _coveredCells = new();
+
+        internal int Count => _origins.Count;
+
+        internal bool TryAdd(ExcelMergeExportRange merge) {
+            for (int row = merge.StartRow; row <= merge.EndRow; row++) {
+                for (int column = merge.StartColumn; column <= merge.EndColumn; column++) {
+                    long key = GetCellKey(row, column);
+                    if (_coveredCells.Contains(key) || _origins.ContainsKey(key)) {
+                        return false;
+                    }
+                }
+            }
+
+            _origins.Add(GetCellKey(merge.StartRow, merge.StartColumn), merge);
+            for (int row = merge.StartRow; row <= merge.EndRow; row++) {
+                for (int column = merge.StartColumn; column <= merge.EndColumn; column++) {
+                    if (row != merge.StartRow || column != merge.StartColumn) {
+                        _coveredCells.Add(GetCellKey(row, column));
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        internal bool IsCoveredCell(int row, int column) => _coveredCells.Contains(GetCellKey(row, column));
+
+        internal bool TryGetOrigin(int row, int column, out ExcelMergeExportRange merge) =>
+            _origins.TryGetValue(GetCellKey(row, column), out merge);
+    }
+
+    private readonly struct ExcelMergeExportRange {
+        internal ExcelMergeExportRange(int startRow, int startColumn, int endRow, int endColumn) {
+            StartRow = startRow;
+            StartColumn = startColumn;
+            EndRow = endRow;
+            EndColumn = endColumn;
+        }
+
+        internal int StartRow { get; }
+
+        internal int StartColumn { get; }
+
+        internal int EndRow { get; }
+
+        internal int EndColumn { get; }
+
+        internal int RowSpan => EndRow - StartRow + 1;
+
+        internal int ColumnSpan => EndColumn - StartColumn + 1;
+
+        internal string A1Range => A1.CellReference(StartRow, StartColumn) + ":" + A1.CellReference(EndRow, EndColumn);
+    }
+
+    private static long GetCellKey(int row, int column) => ((long)row << 32) | (uint)column;
+}

--- a/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.cs
+++ b/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.cs
@@ -6,7 +6,7 @@ namespace OfficeIMO.Excel.Html;
 /// <summary>
 /// Extension methods enabling HTML conversions for OfficeIMO Excel documents.
 /// </summary>
-public static class ExcelHtmlConverterExtensions {
+public static partial class ExcelHtmlConverterExtensions {
     /// <summary>
     /// Converts a workbook to HTML.
     /// </summary>
@@ -34,7 +34,7 @@ public static class ExcelHtmlConverterExtensions {
     /// </summary>
     public static void SaveAsHtml(this ExcelDocument workbook, string path, ExcelHtmlSaveOptions? options = null) {
         if (string.IsNullOrWhiteSpace(path)) throw new ArgumentException("HTML path cannot be empty.", nameof(path));
-        File.WriteAllText(path, workbook.ToHtml(options), Encoding.UTF8);
+        HtmlTextIO.Write(path, workbook.ToHtml(options));
     }
 
     /// <summary>
@@ -42,7 +42,7 @@ public static class ExcelHtmlConverterExtensions {
     /// </summary>
     public static void SaveAsHtml(this ExcelSheet sheet, string path, ExcelHtmlSaveOptions? options = null) {
         if (string.IsNullOrWhiteSpace(path)) throw new ArgumentException("HTML path cannot be empty.", nameof(path));
-        File.WriteAllText(path, sheet.ToHtml(options), Encoding.UTF8);
+        HtmlTextIO.Write(path, sheet.ToHtml(options));
     }
 
     private static string ConvertWorkbookSemantic(ExcelDocument workbook, ExcelHtmlSaveOptions options) {
@@ -103,7 +103,8 @@ public static class ExcelHtmlConverterExtensions {
     }
 
     private static void AppendSheetTable(StringBuilder body, ExcelSheet sheet, ExcelHtmlSaveOptions options) {
-        string usedRange = sheet.GetUsedRangeA1();
+        IReadOnlyList<ExcelMergedRangeSnapshot> mergedRanges = sheet.GetMergedRanges();
+        string usedRange = ExpandUsedRangeForMerges(sheet, sheet.GetUsedRangeA1(), mergedRanges);
         body.Append("<section class=\"officeimo-sheet\" data-officeimo-sheet=\"")
             .Append(OfficeHtmlText.EscapeAttribute(sheet.Name))
             .Append("\" data-officeimo-range=\"")
@@ -117,23 +118,50 @@ public static class ExcelHtmlConverterExtensions {
         int maxRows = options.MaxRowsPerSheet.HasValue
             ? Math.Min(rowCount, options.MaxRowsPerSheet.Value)
             : rowCount;
-        if (rowCount == 0 || columnCount == 0 || maxRows == 0 || !SheetHasUsedCells(sheet, firstRow, firstColumn, rowCount, columnCount)) {
+        ExcelMergeExportMap mergeMap = BuildMergeExportMap(mergedRanges, firstRow, firstColumn, maxRows, columnCount);
+        if (rowCount == 0 || columnCount == 0 || maxRows == 0 || (!SheetHasUsedCells(sheet, firstRow, firstColumn, rowCount, columnCount) && mergeMap.Count == 0)) {
             body.Append("<p class=\"officeimo-muted\">No used cells.</p>");
             AppendSheetFeatureInventory(body, sheet, GetFeatureInventoryWindow(firstRow, maxRows, rowCount));
             body.Append("</section>");
             return;
         }
 
-        body.Append("<table class=\"officeimo-table\"><tbody>");
+        bool firstRowIsHeader = options.HeaderMode == ExcelHtmlHeaderMode.FirstRow;
+        body.Append("<table class=\"officeimo-table\">");
+        if (firstRowIsHeader) {
+            body.Append("<thead>");
+        } else {
+            body.Append("<tbody>");
+        }
+
         for (int row = 0; row < maxRows; row++) {
+            if (row == 1 && firstRowIsHeader) {
+                body.Append("</thead><tbody>");
+            }
+
             body.Append("<tr>");
             for (int column = 0; column < columnCount; column++) {
-                string tag = row == 0 ? "th" : "td";
+                string tag = firstRowIsHeader && row == 0 ? "th" : "td";
                 int cellRow = firstRow + row;
                 int cellColumn = firstColumn + column;
+                if (mergeMap.IsCoveredCell(cellRow, cellColumn)) {
+                    continue;
+                }
+
                 bool hasSnapshot = sheet.TryGetCellValueSnapshot(cellRow, cellColumn, out ExcelCellValueSnapshot? snapshot) && snapshot != null;
                 string cellText = ReadCellText(sheet, cellRow, cellColumn, options.EmptyCellText);
-                body.Append('<').Append(tag);
+                body.Append('<').Append(tag)
+                    .Append(" data-officeimo-cell=\"")
+                    .Append(OfficeHtmlText.EscapeAttribute(A1.CellReference(cellRow, cellColumn)))
+                    .Append('"');
+                if (mergeMap.TryGetOrigin(cellRow, cellColumn, out ExcelMergeExportRange merge)) {
+                    AppendMergeAttributes(body, merge);
+                }
+
+                if (tag == "th") {
+                    body.Append(" scope=\"col\"");
+                }
+
                 if (hasSnapshot) {
                     ExcelCellValueSnapshot cellSnapshot = snapshot!;
                     body.Append(" data-officeimo-value-kind=\"")
@@ -153,7 +181,7 @@ public static class ExcelHtmlConverterExtensions {
             body.Append("</tr>");
         }
 
-        body.Append("</tbody></table>");
+        body.Append(firstRowIsHeader && maxRows == 1 ? "</thead></table>" : "</tbody></table>");
         if (maxRows < rowCount) {
             body.Append("<p class=\"officeimo-diagnostic\">Rows truncated: ")
                 .Append(maxRows.ToString(CultureInfo.InvariantCulture))
@@ -658,6 +686,7 @@ public static class ExcelHtmlConverterExtensions {
             ExcelCellValueKind.Boolean => "boolean",
             ExcelCellValueKind.Error => "error",
             ExcelCellValueKind.Formula => "formula",
+            ExcelCellValueKind.DateTime => "date-time",
             ExcelCellValueKind.Other => "other",
             _ => "text"
         };
@@ -666,7 +695,9 @@ public static class ExcelHtmlConverterExtensions {
         ShouldUseDisplayTextRawValue(snapshot, cellText) ? "text" : ToHtmlValueKind(snapshot.Kind);
 
     private static string ToHtmlRawValue(ExcelCellValueSnapshot snapshot, string cellText) =>
-        ShouldUseDisplayTextRawValue(snapshot, cellText) ? cellText : snapshot.RawValue;
+        snapshot.Kind == ExcelCellValueKind.DateTime && snapshot.DateTimeValue.HasValue
+            ? snapshot.DateTimeValue.Value.ToString("O", CultureInfo.InvariantCulture)
+            : ShouldUseDisplayTextRawValue(snapshot, cellText) ? cellText : snapshot.RawValue;
 
     private static bool ShouldUseDisplayTextRawValue(ExcelCellValueSnapshot snapshot, string cellText) =>
         snapshot.Kind == ExcelCellValueKind.Text ||

--- a/OfficeIMO.Excel.Html/ExcelHtmlHeaderMode.cs
+++ b/OfficeIMO.Excel.Html/ExcelHtmlHeaderMode.cs
@@ -1,0 +1,12 @@
+namespace OfficeIMO.Excel.Html;
+
+/// <summary>
+/// Controls which worksheet rows are represented as HTML column headers.
+/// </summary>
+public enum ExcelHtmlHeaderMode {
+    /// <summary>Exports every worksheet row as table data.</summary>
+    None,
+
+    /// <summary>Exports the first used-range row as a column header row.</summary>
+    FirstRow
+}

--- a/OfficeIMO.Excel.Html/ExcelHtmlSaveOptions.cs
+++ b/OfficeIMO.Excel.Html/ExcelHtmlSaveOptions.cs
@@ -24,6 +24,12 @@ public sealed class ExcelHtmlSaveOptions {
     /// <summary>Text used for empty cells.</summary>
     public string EmptyCellText { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Controls worksheet header semantics. Defaults to <see cref="ExcelHtmlHeaderMode.FirstRow"/>
+    /// for compatibility with earlier OfficeIMO HTML output.
+    /// </summary>
+    public ExcelHtmlHeaderMode HeaderMode { get; set; } = ExcelHtmlHeaderMode.FirstRow;
+
     /// <summary>Options used by the existing Excel SVG visual export lane.</summary>
     public ExcelWorkbookImageExportOptions? VisualOptions { get; set; }
 }

--- a/OfficeIMO.Excel.Html/HtmlExcelConverterExtensions.Diagnostics.cs
+++ b/OfficeIMO.Excel.Html/HtmlExcelConverterExtensions.Diagnostics.cs
@@ -1,0 +1,18 @@
+using OfficeIMO.Html;
+
+namespace OfficeIMO.Excel.Html;
+
+public static partial class HtmlExcelConverterExtensions {
+    private const string ImportComponentName = "OfficeIMO.Excel.Html";
+
+    private static void AddImportDiagnostic(
+        HtmlToExcelResult result,
+        string code,
+        string message,
+        HtmlDiagnosticSeverity severity = HtmlDiagnosticSeverity.Warning,
+        HtmlConversionLossKind lossKind = HtmlConversionLossKind.None,
+        string? source = null,
+        string? detail = null) {
+        result.Diagnostics.Add(ImportComponentName, code, message, severity, source, detail, lossKind);
+    }
+}

--- a/OfficeIMO.Excel.Html/HtmlExcelConverterExtensions.IO.cs
+++ b/OfficeIMO.Excel.Html/HtmlExcelConverterExtensions.IO.cs
@@ -1,0 +1,23 @@
+using OfficeIMO.Html;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Excel.Html;
+
+public static partial class HtmlExcelConverterExtensions {
+    /// <summary>Reads semantic HTML from a stream and imports a workbook.</summary>
+    public static ExcelDocument ToExcelDocument(this Stream htmlStream, HtmlToExcelOptions? options = null) =>
+        HtmlTextIO.Read(htmlStream).ToExcelDocument(options);
+
+    /// <summary>Reads semantic HTML from a stream and returns a workbook plus structured evidence.</summary>
+    public static HtmlToExcelResult ToExcelDocumentResult(this Stream htmlStream, HtmlToExcelOptions? options = null) =>
+        HtmlTextIO.Read(htmlStream).ToExcelDocumentResult(options);
+
+    /// <summary>Asynchronously reads semantic HTML from a stream and imports a workbook.</summary>
+    public static async Task<ExcelDocument> ToExcelDocumentAsync(this Stream htmlStream, HtmlToExcelOptions? options = null, CancellationToken cancellationToken = default) =>
+        (await HtmlTextIO.ReadAsync(htmlStream, cancellationToken).ConfigureAwait(false)).ToExcelDocument(options);
+
+    /// <summary>Asynchronously reads semantic HTML from a stream and returns structured evidence.</summary>
+    public static async Task<HtmlToExcelResult> ToExcelDocumentResultAsync(this Stream htmlStream, HtmlToExcelOptions? options = null, CancellationToken cancellationToken = default) =>
+        (await HtmlTextIO.ReadAsync(htmlStream, cancellationToken).ConfigureAwait(false)).ToExcelDocumentResult(options);
+}

--- a/OfficeIMO.Excel.Html/HtmlExcelConverterExtensions.MergedCells.cs
+++ b/OfficeIMO.Excel.Html/HtmlExcelConverterExtensions.MergedCells.cs
@@ -1,0 +1,169 @@
+using AngleSharp.Dom;
+using OfficeIMO.Html;
+
+namespace OfficeIMO.Excel.Html;
+
+public static partial class HtmlExcelConverterExtensions {
+    private static void ImportTableGrid(
+        IElement table,
+        ExcelSheet sheet,
+        HtmlToExcelResult result,
+        HtmlToExcelOptions options,
+        int firstRow,
+        int firstColumn) {
+        if (options.MaxTableCells <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(options.MaxTableCells), "MaxTableCells must be greater than zero.");
+        }
+
+        var occupiedCells = new HashSet<long>();
+        int rowOffset = 0;
+
+        foreach (IElement row in EnumerateDirectTableRows(table)) {
+            int rowIndex = firstRow + rowOffset;
+            if (rowIndex > A1.MaxRows) {
+                AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TargetLimitExceeded,
+                    "HTML table rows exceeded the Excel worksheet row limit; remaining rows were skipped.", lossKind: HtmlConversionLossKind.Omission);
+                break;
+            }
+
+            int columnIndex = firstColumn;
+            foreach (IElement cell in row.Children.Where(IsTableCell)) {
+                while (occupiedCells.Contains(GetImportCellKey(rowIndex, columnIndex))) {
+                    columnIndex++;
+                }
+
+                if (columnIndex > A1.MaxColumns) {
+                    AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TargetLimitExceeded,
+                        "HTML table columns exceeded the Excel worksheet column limit in row " + rowIndex.ToString(CultureInfo.InvariantCulture) + "; remaining cells in the row were skipped.", lossKind: HtmlConversionLossKind.Omission);
+                    break;
+                }
+
+                int cellRow = rowIndex;
+                int cellColumn = columnIndex;
+                string? semanticReference = cell.GetAttribute("data-officeimo-cell");
+                if (TryParseCellReference(semanticReference, out int semanticRow, out int semanticColumn)
+                    && semanticRow <= A1.MaxRows
+                    && semanticColumn <= A1.MaxColumns) {
+                    cellRow = semanticRow;
+                    cellColumn = semanticColumn;
+                } else if (!string.IsNullOrWhiteSpace(semanticReference)) {
+                    AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ContentApproximated,
+                        "Cell coordinate '" + semanticReference + "' was outside the Excel worksheet grid and the table position was used instead.", lossKind: HtmlConversionLossKind.Approximation);
+                }
+
+                if (occupiedCells.Contains(GetImportCellKey(cellRow, cellColumn))) {
+                    AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TableSpanInvalid,
+                        "Cell " + BuildCellReference(cellRow, cellColumn) + " overlapped an earlier HTML table span and was moved to the next available column.", lossKind: HtmlConversionLossKind.Approximation);
+                    cellRow = rowIndex;
+                    cellColumn = columnIndex;
+                }
+
+                int rowSpan = ReadSpan(cell, "rowspan", cellRow, A1.MaxRows, cellRow, cellColumn, result);
+                int columnSpan = ReadSpan(cell, "colspan", cellColumn, A1.MaxColumns, cellRow, cellColumn, result);
+                long spanArea = (long)rowSpan * columnSpan;
+                if (spanArea > options.MaxTableCells - occupiedCells.Count) {
+                    if (occupiedCells.Count >= options.MaxTableCells) {
+                        AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TargetLimitExceeded,
+                            "HTML table exceeded the configured MaxTableCells limit; remaining cells were skipped.", lossKind: HtmlConversionLossKind.Omission);
+                        return;
+                    }
+
+                    AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TargetLimitExceeded,
+                        "Cell " + BuildCellReference(cellRow, cellColumn) + " contained a span that exceeded the configured MaxTableCells limit; the span was ignored.", lossKind: HtmlConversionLossKind.Approximation);
+                    rowSpan = 1;
+                    columnSpan = 1;
+                }
+
+                if (SpanOverlaps(occupiedCells, cellRow, cellColumn, rowSpan, columnSpan)) {
+                    AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TableSpanInvalid,
+                        "Cell " + BuildCellReference(cellRow, cellColumn) + " contained an overlapping HTML table span; the span was ignored.", lossKind: HtmlConversionLossKind.Approximation);
+                    rowSpan = 1;
+                    columnSpan = 1;
+                }
+
+                ReserveSpan(occupiedCells, cellRow, cellColumn, rowSpan, columnSpan);
+
+                string text = NormalizeText(cell.TextContent);
+                if (!IsSemanticEmptyCell(cell) && (text.Length > 0 || cell.GetAttribute("data-officeimo-value") != null)) {
+                    SetCellValue(sheet, cellRow, cellColumn, cell, text, result);
+                    result.Cells++;
+                }
+
+                if (rowSpan > 1 || columnSpan > 1) {
+                    sheet.MergeRange(BuildRangeReference(cellRow, cellColumn, cellRow + rowSpan - 1, cellColumn + columnSpan - 1));
+                    result.MergedRanges++;
+                }
+
+                columnIndex = Math.Max(columnIndex, cellColumn + columnSpan);
+            }
+
+            rowOffset++;
+        }
+    }
+
+    private static IEnumerable<IElement> EnumerateDirectTableRows(IElement table) {
+        foreach (IElement child in table.Children) {
+            if (IsElement(child, "tr")) {
+                yield return child;
+                continue;
+            }
+
+            if (!IsElement(child, "thead") && !IsElement(child, "tbody") && !IsElement(child, "tfoot")) {
+                continue;
+            }
+
+            foreach (IElement row in child.Children.Where(candidate => IsElement(candidate, "tr"))) {
+                yield return row;
+            }
+        }
+    }
+
+    private static bool IsTableCell(IElement element) => IsElement(element, "th") || IsElement(element, "td");
+
+    private static int ReadSpan(
+        IElement cell,
+        string attributeName,
+        int start,
+        int maximum,
+        int cellRow,
+        int cellColumn,
+        HtmlToExcelResult result) {
+        string? rawValue = cell.GetAttribute(attributeName);
+        if (string.IsNullOrWhiteSpace(rawValue)) {
+            return 1;
+        }
+
+        if (!int.TryParse(rawValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out int span)
+            || span <= 0
+            || start > maximum
+            || span > maximum - start + 1) {
+            AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TableSpanInvalid,
+                "Cell " + BuildCellReference(cellRow, cellColumn) + " contained an invalid " + attributeName + " value; a span of 1 was used.", lossKind: HtmlConversionLossKind.Approximation);
+            return 1;
+        }
+
+        return span;
+    }
+
+    private static bool SpanOverlaps(HashSet<long> occupiedCells, int row, int column, int rowSpan, int columnSpan) {
+        for (int currentRow = row; currentRow < row + rowSpan; currentRow++) {
+            for (int currentColumn = column; currentColumn < column + columnSpan; currentColumn++) {
+                if (occupiedCells.Contains(GetImportCellKey(currentRow, currentColumn))) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static void ReserveSpan(HashSet<long> occupiedCells, int row, int column, int rowSpan, int columnSpan) {
+        for (int currentRow = row; currentRow < row + rowSpan; currentRow++) {
+            for (int currentColumn = column; currentColumn < column + columnSpan; currentColumn++) {
+                occupiedCells.Add(GetImportCellKey(currentRow, currentColumn));
+            }
+        }
+    }
+
+    private static long GetImportCellKey(int row, int column) => ((long)row << 32) | (uint)column;
+}

--- a/OfficeIMO.Excel.Html/HtmlExcelConverterExtensions.cs
+++ b/OfficeIMO.Excel.Html/HtmlExcelConverterExtensions.cs
@@ -7,13 +7,21 @@ namespace OfficeIMO.Excel.Html;
 /// <summary>
 /// Extension methods for importing semantic OfficeIMO Excel HTML.
 /// </summary>
-public static class HtmlExcelConverterExtensions {
+public static partial class HtmlExcelConverterExtensions {
     /// <summary>
     /// Imports semantic OfficeIMO Excel HTML into a native workbook.
     /// </summary>
     /// <example><code>using ExcelDocument workbook = html.ToExcelDocument();</code></example>
-    public static ExcelDocument ToExcelDocument(this string html, HtmlToExcelOptions? options = null) =>
-        ToExcelDocumentResult(html, options).Workbook;
+    public static ExcelDocument ToExcelDocument(this string html, HtmlToExcelOptions? options = null) {
+        return GetWorkbookOrThrow(ToExcelDocumentResult(html, options));
+    }
+
+    /// <summary>
+    /// Imports a prepared shared HTML conversion document into a native workbook without reparsing its adapter DOM.
+    /// </summary>
+    public static ExcelDocument ToExcelDocument(this HtmlConversionDocument document, HtmlToExcelOptions? options = null) {
+        return GetWorkbookOrThrow(ToExcelDocumentResult(document, options));
+    }
 
     /// <summary>
     /// Imports semantic OfficeIMO Excel HTML into a native workbook and returns import evidence.
@@ -21,16 +29,26 @@ public static class HtmlExcelConverterExtensions {
     /// <example><code>HtmlToExcelResult result = html.ToExcelDocumentResult();</code></example>
     public static HtmlToExcelResult ToExcelDocumentResult(this string html, HtmlToExcelOptions? options = null) {
         if (html == null) throw new ArgumentNullException(nameof(html));
-        options ??= new HtmlToExcelOptions();
+        return ImportDocument(HtmlDocumentParser.ParseDocument(html), options ?? new HtmlToExcelOptions());
+    }
 
-        IHtmlDocument document = HtmlDocumentParser.ParseDocument(html);
+    /// <summary>
+    /// Imports a prepared shared HTML conversion document and returns the workbook plus structured evidence.
+    /// </summary>
+    public static HtmlToExcelResult ToExcelDocumentResult(this HtmlConversionDocument document, HtmlToExcelOptions? options = null) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        return ImportDocument(document.DocumentForConversion, options ?? new HtmlToExcelOptions());
+    }
+
+    private static HtmlToExcelResult ImportDocument(IHtmlDocument document, HtmlToExcelOptions options) {
         var stream = new MemoryStream();
         ExcelDocument workbook = ExcelDocument.Create(stream);
         var result = new HtmlToExcelResult(workbook);
 
         List<IElement> sheetSections = document.QuerySelectorAll("section.officeimo-sheet").ToList();
         if (sheetSections.Count == 0) {
-            result.Diagnostics.Add("No semantic Excel sheet sections were found.");
+            AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.SemanticContentMissing,
+                "No semantic Excel sheet sections were found.", HtmlDiagnosticSeverity.Error, HtmlConversionLossKind.Failure);
             workbook.AddWorkSheet("Imported");
             return result;
         }
@@ -39,7 +57,7 @@ public static class HtmlExcelConverterExtensions {
         foreach (IElement section in sheetSections) {
             ExcelSheet sheet = workbook.AddWorkSheet(GetUniqueSheetName(GetSheetName(section), usedNames));
             result.Sheets++;
-            ImportTable(section, sheet, result);
+            ImportTable(section, sheet, result, options);
             if (options.ImportFormulas) {
                 ImportFormulas(section, sheet, result);
             }
@@ -58,6 +76,15 @@ public static class HtmlExcelConverterExtensions {
         return result;
     }
 
+    private static ExcelDocument GetWorkbookOrThrow(HtmlToExcelResult result) {
+        if (result.Succeeded) {
+            return result.Workbook;
+        }
+
+        result.Workbook.Dispose();
+        throw new HtmlConversionException(result.Diagnostics.Diagnostics);
+    }
+
     private static void ApplySheetVisibility(IElement section, ExcelSheet sheet) {
         string? visibility = section.GetAttribute("data-officeimo-visibility");
         if (string.IsNullOrWhiteSpace(visibility)) {
@@ -71,29 +98,16 @@ public static class HtmlExcelConverterExtensions {
         }
     }
 
-    private static void ImportTable(IElement section, ExcelSheet sheet, HtmlToExcelResult result) {
+    private static void ImportTable(IElement section, ExcelSheet sheet, HtmlToExcelResult result, HtmlToExcelOptions options) {
         IElement? table = section.Children.FirstOrDefault(child => IsElement(child, "table"));
         if (table == null) {
-            result.Diagnostics.Add("Sheet '" + sheet.Name + "' did not contain a direct semantic table.");
+            AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.SemanticBlockMissing,
+                "Sheet '" + sheet.Name + "' did not contain a direct semantic table.", lossKind: HtmlConversionLossKind.Omission);
             return;
         }
 
         ReadRangeOrigin(section.GetAttribute("data-officeimo-range"), out int firstRow, out int firstColumn);
-        int rowIndex = firstRow;
-        foreach (IElement row in table.QuerySelectorAll("tr")) {
-            int columnIndex = firstColumn;
-            foreach (IElement cell in row.Children.Where(child => IsElement(child, "th") || IsElement(child, "td"))) {
-                string text = NormalizeText(cell.TextContent);
-                if (!IsSemanticEmptyCell(cell) && (text.Length > 0 || cell.GetAttribute("data-officeimo-value") != null)) {
-                    SetCellValue(sheet, rowIndex, columnIndex, cell, text, result);
-                    result.Cells++;
-                }
-
-                columnIndex++;
-            }
-
-            rowIndex++;
-        }
+        ImportTableGrid(table, sheet, result, options, firstRow, firstColumn);
     }
 
     private static void ReadRangeOrigin(string? range, out int row, out int column) {
@@ -140,7 +154,8 @@ public static class HtmlExcelConverterExtensions {
                 return;
             }
 
-            result.Diagnostics.Add("Cell " + BuildCellReference(row, column) + " contained a semantic number value that could not be parsed and was imported as text.");
+            AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.SemanticValueInvalid,
+                "Cell " + BuildCellReference(row, column) + " contained a semantic number value that could not be parsed and was imported as text.", lossKind: HtmlConversionLossKind.Approximation);
         } else if (kind.Equals("boolean", StringComparison.OrdinalIgnoreCase)) {
             if (rawValue.Equals("1", StringComparison.OrdinalIgnoreCase) || rawValue.Equals("true", StringComparison.OrdinalIgnoreCase)) {
                 sheet.CellValue(row, column, true);
@@ -152,10 +167,19 @@ public static class HtmlExcelConverterExtensions {
                 return;
             }
 
-            result.Diagnostics.Add("Cell " + BuildCellReference(row, column) + " contained a semantic boolean value that could not be parsed and was imported as text.");
+            AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.SemanticValueInvalid,
+                "Cell " + BuildCellReference(row, column) + " contained a semantic boolean value that could not be parsed and was imported as text.", lossKind: HtmlConversionLossKind.Approximation);
         } else if (kind.Equals("text", StringComparison.OrdinalIgnoreCase)) {
             sheet.CellValue(row, column, rawValue);
             return;
+        } else if (kind.Equals("date-time", StringComparison.OrdinalIgnoreCase)) {
+            if (DateTime.TryParse(rawValue, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTime dateTime)) {
+                sheet.CellValue(row, column, dateTime);
+                return;
+            }
+
+            AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.SemanticValueInvalid,
+                "Cell " + BuildCellReference(row, column) + " contained a semantic date/time value that could not be parsed and was imported as text.", lossKind: HtmlConversionLossKind.Approximation);
         } else if (kind.Equals("formula", StringComparison.OrdinalIgnoreCase)) {
             sheet.CellFormula(row, column, rawValue);
             return;
@@ -219,7 +243,8 @@ public static class HtmlExcelConverterExtensions {
         }
 
         if (!dataUri.TryDecodeBytes(out byte[] bytes)) {
-            result.Diagnostics.Add("Image inventory item '" + NormalizeText(item.QuerySelector(".officeimo-feature-label")?.TextContent) + "' could not be decoded.");
+            AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ResourceDecodeFailed,
+                "Image inventory item '" + NormalizeText(item.QuerySelector(".officeimo-feature-label")?.TextContent) + "' could not be decoded.", lossKind: HtmlConversionLossKind.Omission);
             return;
         }
 
@@ -234,7 +259,8 @@ public static class HtmlExcelConverterExtensions {
         if (IsAbsoluteImageAnchor(item) && TryReadIntAttribute(item, "data-officeimo-x", out int xPixels) && TryReadIntAttribute(item, "data-officeimo-y", out int yPixels)) {
             importedImage = sheet.AddImageAbsolute(xPixels, yPixels, bytes, dataUri.MediaType, width, height, name: name.Length == 0 ? null : name, altText: description.Length == 0 ? null : description);
         } else if (IsAbsoluteImageAnchor(item)) {
-            result.Diagnostics.Add("Image inventory item '" + (name.Length == 0 ? "Image" : name) + "' used an absolute anchor without semantic x/y coordinates and was restored to its fallback cell anchor.");
+            AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ContentApproximated,
+                "Image inventory item '" + (name.Length == 0 ? "Image" : name) + "' used an absolute anchor without semantic x/y coordinates and was restored to its fallback cell anchor.", lossKind: HtmlConversionLossKind.Approximation);
             importedImage = sheet.AddImage(row, column, bytes, dataUri.MediaType, width, height, offsetX, offsetY, name: name.Length == 0 ? null : name, altText: description.Length == 0 ? null : description);
         } else if (IsTwoCellImageAnchor(item)) {
             importedImage = AddTwoCellImage(item, sheet, result, bytes, dataUri.MediaType, row, column, width, height, offsetX, offsetY, name, description);
@@ -283,7 +309,8 @@ public static class HtmlExcelConverterExtensions {
             return importedImage;
         }
 
-        result.Diagnostics.Add("Image inventory item '" + (name.Length == 0 ? "Image" : name) + "' used a two-cell anchor without semantic ending marker coordinates and was restored to its fallback cell anchor.");
+        AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ContentApproximated,
+            "Image inventory item '" + (name.Length == 0 ? "Image" : name) + "' used a two-cell anchor without semantic ending marker coordinates and was restored to its fallback cell anchor.", lossKind: HtmlConversionLossKind.Approximation);
         return sheet.AddImage(row, column, bytes, contentType, width, height, offsetX, offsetY, name: name.Length == 0 ? null : name, altText: description.Length == 0 ? null : description);
     }
 
@@ -297,14 +324,17 @@ public static class HtmlExcelConverterExtensions {
             } else if (!string.IsNullOrWhiteSpace(range) && !string.Equals(range, "A1", StringComparison.OrdinalIgnoreCase)) {
                 sheet.AddChartFromRange(range, row: row, column: column, widthPixels: width, heightPixels: height, type: type, title: title.Length == 0 ? null : title);
             } else {
-                result.Diagnostics.Add("Chart inventory item '" + title + "' on sheet '" + sheet.Name + "' did not contain semantic chart data and no usable table range was available.");
+                AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ContentOmitted,
+                    "Chart inventory item '" + title + "' on sheet '" + sheet.Name + "' did not contain semantic chart data and no usable table range was available.", lossKind: HtmlConversionLossKind.Omission);
                 return;
             }
 
             result.Charts++;
             chartIndex++;
         } catch (Exception ex) {
-            result.Diagnostics.Add("Chart inventory item '" + title + "' could not be restored as a native chart: " + ex.Message);
+            AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ArtifactCreationFailed,
+                "Chart inventory item '" + title + "' could not be restored as a native chart: " + ex.Message,
+                lossKind: HtmlConversionLossKind.Omission, detail: ex.GetType().Name);
         }
     }
 

--- a/OfficeIMO.Excel.Html/HtmlToExcelOptions.cs
+++ b/OfficeIMO.Excel.Html/HtmlToExcelOptions.cs
@@ -5,6 +5,11 @@ namespace OfficeIMO.Excel.Html;
 /// </summary>
 public sealed class HtmlToExcelOptions {
     /// <summary>
+    /// Maximum number of HTML table grid slots imported across each worksheet table, including merged spans.
+    /// </summary>
+    public int MaxTableCells { get; set; } = 50_000;
+
+    /// <summary>
     /// Imports embedded data URI images from the semantic image inventory.
     /// </summary>
     public bool ImportImages { get; set; } = true;

--- a/OfficeIMO.Excel.Html/HtmlToExcelResult.cs
+++ b/OfficeIMO.Excel.Html/HtmlToExcelResult.cs
@@ -1,17 +1,17 @@
+using OfficeIMO.Html;
+
 namespace OfficeIMO.Excel.Html;
 
 /// <summary>
 /// Summary of a semantic Excel HTML import.
 /// </summary>
-public sealed class HtmlToExcelResult {
-    internal HtmlToExcelResult(ExcelDocument workbook) {
-        Workbook = workbook ?? throw new ArgumentNullException(nameof(workbook));
-    }
+public sealed class HtmlToExcelResult : HtmlConversionResult<ExcelDocument> {
+    internal HtmlToExcelResult(ExcelDocument workbook) : base(workbook) { }
 
     /// <summary>
     /// Imported workbook.
     /// </summary>
-    public ExcelDocument Workbook { get; }
+    public ExcelDocument Workbook => Artifact;
 
     /// <summary>
     /// Number of imported worksheets.
@@ -22,6 +22,11 @@ public sealed class HtmlToExcelResult {
     /// Number of imported worksheet table cells.
     /// </summary>
     public int Cells { get; internal set; }
+
+    /// <summary>
+    /// Number of merged worksheet ranges restored from the HTML table grid.
+    /// </summary>
+    public int MergedRanges { get; internal set; }
 
     /// <summary>
     /// Number of formulas restored from semantic formula inventory.
@@ -43,8 +48,4 @@ public sealed class HtmlToExcelResult {
     /// </summary>
     public int Charts { get; internal set; }
 
-    /// <summary>
-    /// Import diagnostics for skipped or approximate rich content.
-    /// </summary>
-    public IList<string> Diagnostics { get; } = new List<string>();
 }

--- a/OfficeIMO.Excel.Html/README.md
+++ b/OfficeIMO.Excel.Html/README.md
@@ -1,3 +1,35 @@
 # OfficeIMO.Excel.Html
 
 First-party HTML adapter for OfficeIMO.Excel. It exports semantic worksheet tables or visual review HTML using the shared OfficeIMO.Html profile contracts and the existing Excel SVG image exporter.
+
+## Semantic round trips
+
+```csharp
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.Html;
+
+using ExcelDocument workbook = ExcelDocument.Load("report.xlsx", readOnly: true);
+string html = workbook.ToHtml(new ExcelHtmlSaveOptions {
+    HeaderMode = ExcelHtmlHeaderMode.FirstRow
+});
+
+HtmlToExcelResult result = html.ToExcelDocumentResult();
+using ExcelDocument imported = result.GetArtifactOrThrow();
+imported.Save("report-roundtrip.xlsx");
+```
+
+Semantic output preserves worksheet names and visibility, used-range coordinates, typed text/number/boolean/date-time values, formulas, comments, merged ranges, embedded image inventory, and supported chart inventory. HTML `rowspan` and `colspan` values become native Excel merged ranges.
+
+`HeaderMode` makes the first-row assumption explicit. `FirstRow` is the compatibility default and emits a real `thead` with column headers. Use `None` when every row is data.
+
+`ToExcelDocument()` is the convenience API. It throws `HtmlConversionException` when no semantic `section.officeimo-sheet` envelope exists. Use `ToExcelDocumentResult()` to receive the workbook plus structured diagnostics and loss classification. `HtmlToExcelOptions.MaxTableCells` bounds imported table grids, including merged spans.
+
+Path, stream, and async save/import methods use UTF-8 without a byte-order mark. Stream overloads leave caller-owned streams open.
+
+## Visual review
+
+Set `Profile = OfficeHtmlConversionProfile.ExcelVisualReview` to emit review HTML through OfficeIMO's dependency-free SVG renderer. Visual-review HTML is presentation evidence; use semantic tables when the HTML must be imported back into Excel.
+
+## Targets
+
+`netstandard2.0`, `net8.0`, and `net10.0`; `net472` is included when building on Windows.

--- a/OfficeIMO.Excel/ExcelCellValueSnapshot.cs
+++ b/OfficeIMO.Excel/ExcelCellValueSnapshot.cs
@@ -16,18 +16,21 @@ namespace OfficeIMO.Excel {
         /// <summary>The cell stores a formula.</summary>
         Formula,
         /// <summary>The cell stores a value kind not explicitly mapped by OfficeIMO.</summary>
-        Other
+        Other,
+        /// <summary>The cell stores a numeric Excel serial with a date-like number format.</summary>
+        DateTime
     }
 
     /// <summary>
     /// Describes a native worksheet cell value without requiring callers to inspect OpenXML directly.
     /// </summary>
     public sealed class ExcelCellValueSnapshot {
-        internal ExcelCellValueSnapshot(ExcelCellValueKind kind, string text, string rawValue, CellValues? openXmlType) {
+        internal ExcelCellValueSnapshot(ExcelCellValueKind kind, string text, string rawValue, CellValues? openXmlType, DateTime? dateTimeValue = null) {
             Kind = kind;
             Text = text;
             RawValue = rawValue;
             OpenXmlType = openXmlType;
+            DateTimeValue = dateTimeValue;
         }
 
         /// <summary>Native value kind for the cell.</summary>
@@ -41,5 +44,10 @@ namespace OfficeIMO.Excel {
 
         /// <summary>Underlying OpenXML cell type hint, when present.</summary>
         public CellValues? OpenXmlType { get; }
+
+        /// <summary>
+        /// Resolved date/time value when <see cref="Kind"/> is <see cref="ExcelCellValueKind.DateTime"/>.
+        /// </summary>
+        public DateTime? DateTimeValue { get; }
     }
 }

--- a/OfficeIMO.Excel/ExcelSheet.CellValue.Styles.cs
+++ b/OfficeIMO.Excel/ExcelSheet.CellValue.Styles.cs
@@ -257,7 +257,19 @@ namespace OfficeIMO.Excel {
                 string rawValue = kind == ExcelCellValueKind.Formula
                     ? cell.CellFormula?.Text ?? string.Empty
                     : cell.CellValue?.InnerText ?? text;
-                snapshot = new ExcelCellValueSnapshot(kind, text, rawValue, dataType);
+                DateTime? dateTimeValue = null;
+                if (kind == ExcelCellValueKind.Number
+                    && double.TryParse(rawValue, NumberStyles.Float, CultureInfo.InvariantCulture, out double serial)
+                    && GetCellStyle(row, column).IsDateLike) {
+                    try {
+                        dateTimeValue = ExcelDateSystemConverter.FromSerial(serial, _excelDocument.DateSystem);
+                        kind = ExcelCellValueKind.DateTime;
+                    } catch (ArgumentException) {
+                        // Retain the numeric kind when the serial cannot be represented by DateTime.
+                    }
+                }
+
+                snapshot = new ExcelCellValueSnapshot(kind, text, rawValue, dataType, dateTimeValue);
                 return true;
             } catch {
                 return false;

--- a/OfficeIMO.Html.Pdf/HtmlPdfConverterExtensions.cs
+++ b/OfficeIMO.Html.Pdf/HtmlPdfConverterExtensions.cs
@@ -67,14 +67,14 @@ public static partial class HtmlPdfConverterExtensions {
     /// <summary>Converts a shared HTML conversion document to a PDF document plus diagnostics.</summary>
     public static PdfCore.PdfDocumentConversionResult ToPdfResult(this HtmlConversionDocument document, HtmlPdfSaveOptions? options = null) {
         if (document == null) throw new ArgumentNullException(nameof(document));
-        return document.HtmlForConversion.ToPdfResult(options);
+        HtmlPdfRenderResult rendered = HtmlPdfRenderedConverter.Convert(document.DocumentForConversion, Normalize(options));
+        return CreateResult(rendered);
     }
 
     /// <summary>Reads UTF-8 HTML from a stream and converts it to a PDF document plus diagnostics.</summary>
     public static PdfCore.PdfDocumentConversionResult ToPdfResult(this Stream htmlStream, HtmlPdfSaveOptions? options = null) {
         if (htmlStream == null) throw new ArgumentNullException(nameof(htmlStream));
-        using var reader = new StreamReader(htmlStream, Encoding.UTF8, true, 4096, true);
-        return reader.ReadToEnd().ToPdfResult(options);
+        return HtmlTextIO.Read(htmlStream).ToPdfResult(options);
     }
 
     /// <summary>Asynchronously converts HTML to a PDF document plus an immutable diagnostics snapshot.</summary>
@@ -87,15 +87,18 @@ public static partial class HtmlPdfConverterExtensions {
     }
 
     /// <summary>Asynchronously converts a shared HTML conversion document to a PDF document plus diagnostics.</summary>
-    public static Task<PdfCore.PdfDocumentConversionResult> ToPdfResultAsync(this HtmlConversionDocument document, HtmlPdfSaveOptions? options = null, CancellationToken cancellationToken = default) {
+    public static async Task<PdfCore.PdfDocumentConversionResult> ToPdfResultAsync(this HtmlConversionDocument document, HtmlPdfSaveOptions? options = null, CancellationToken cancellationToken = default) {
         if (document == null) throw new ArgumentNullException(nameof(document));
-        return document.HtmlForConversion.ToPdfResultAsync(options, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+        HtmlPdfRenderResult rendered = await HtmlPdfRenderedConverter.ConvertAsync(document.DocumentForConversion, Normalize(options), cancellationToken).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+        return CreateResult(rendered);
     }
 
     /// <summary>Asynchronously reads UTF-8 HTML from a stream and converts it to a PDF document plus diagnostics.</summary>
     public static async Task<PdfCore.PdfDocumentConversionResult> ToPdfResultAsync(this Stream htmlStream, HtmlPdfSaveOptions? options = null, CancellationToken cancellationToken = default) {
         if (htmlStream == null) throw new ArgumentNullException(nameof(htmlStream));
-        string html = await ReadHtmlAsync(htmlStream, cancellationToken).ConfigureAwait(false);
+        string html = await HtmlTextIO.ReadAsync(htmlStream, cancellationToken).ConfigureAwait(false);
         return await html.ToPdfResultAsync(options, cancellationToken).ConfigureAwait(false);
     }
 
@@ -132,14 +135,4 @@ public static partial class HtmlPdfConverterExtensions {
         _ => PdfCore.PdfConversionWarningSeverity.Warning
     };
 
-    private static async Task<string> ReadHtmlAsync(Stream stream, CancellationToken cancellationToken) {
-        using var reader = new StreamReader(stream, Encoding.UTF8, true, 4096, true);
-#if NET8_0_OR_GREATER
-        return await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
-#else
-        string html = await reader.ReadToEndAsync().ConfigureAwait(false);
-        cancellationToken.ThrowIfCancellationRequested();
-        return html;
-#endif
-    }
 }

--- a/OfficeIMO.Html.Pdf/HtmlPdfConverterExtensions.cs
+++ b/OfficeIMO.Html.Pdf/HtmlPdfConverterExtensions.cs
@@ -67,7 +67,9 @@ public static partial class HtmlPdfConverterExtensions {
     /// <summary>Converts a shared HTML conversion document to a PDF document plus diagnostics.</summary>
     public static PdfCore.PdfDocumentConversionResult ToPdfResult(this HtmlConversionDocument document, HtmlPdfSaveOptions? options = null) {
         if (document == null) throw new ArgumentNullException(nameof(document));
-        HtmlPdfRenderResult rendered = HtmlPdfRenderedConverter.Convert(document.DocumentForConversion, Normalize(options));
+        HtmlPdfRenderResult rendered = HtmlPdfRenderedConverter.Convert(
+            document.CreateDocumentForConversion(HtmlCssMediaContext.Print),
+            Normalize(options));
         return CreateResult(rendered);
     }
 
@@ -90,7 +92,10 @@ public static partial class HtmlPdfConverterExtensions {
     public static async Task<PdfCore.PdfDocumentConversionResult> ToPdfResultAsync(this HtmlConversionDocument document, HtmlPdfSaveOptions? options = null, CancellationToken cancellationToken = default) {
         if (document == null) throw new ArgumentNullException(nameof(document));
         cancellationToken.ThrowIfCancellationRequested();
-        HtmlPdfRenderResult rendered = await HtmlPdfRenderedConverter.ConvertAsync(document.DocumentForConversion, Normalize(options), cancellationToken).ConfigureAwait(false);
+        HtmlPdfRenderResult rendered = await HtmlPdfRenderedConverter.ConvertAsync(
+            document.CreateDocumentForConversion(HtmlCssMediaContext.Print),
+            Normalize(options),
+            cancellationToken).ConfigureAwait(false);
         cancellationToken.ThrowIfCancellationRequested();
         return CreateResult(rendered);
     }

--- a/OfficeIMO.Html.Pdf/HtmlPdfRenderedConverter.cs
+++ b/OfficeIMO.Html.Pdf/HtmlPdfRenderedConverter.cs
@@ -1,4 +1,5 @@
 using OfficeIMO.Drawing;
+using AngleSharp.Html.Dom;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -16,9 +17,22 @@ internal static class HtmlPdfRenderedConverter {
         return CreatePdf(rendered, options, CancellationToken.None);
     }
 
+    internal static HtmlPdfRenderResult Convert(IHtmlDocument document, HtmlPdfSaveOptions options) {
+        HtmlRenderOptions renderOptions = ResolveRenderOptions(options);
+        HtmlRenderDocument rendered = HtmlRenderEngine.Render(document, renderOptions);
+        return CreatePdf(rendered, options, CancellationToken.None);
+    }
+
     internal static async Task<HtmlPdfRenderResult> ConvertAsync(string html, HtmlPdfSaveOptions options, CancellationToken cancellationToken) {
         HtmlRenderOptions renderOptions = ResolveRenderOptions(options);
         HtmlRenderDocument rendered = await HtmlRenderEngine.RenderAsync(html, renderOptions, cancellationToken).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+        return CreatePdf(rendered, options, cancellationToken);
+    }
+
+    internal static async Task<HtmlPdfRenderResult> ConvertAsync(IHtmlDocument document, HtmlPdfSaveOptions options, CancellationToken cancellationToken) {
+        HtmlRenderOptions renderOptions = ResolveRenderOptions(options);
+        HtmlRenderDocument rendered = await HtmlRenderEngine.RenderAsync(document, renderOptions, cancellationToken).ConfigureAwait(false);
         cancellationToken.ThrowIfCancellationRequested();
         return CreatePdf(rendered, options, cancellationToken);
     }

--- a/OfficeIMO.Html.Tests/Html.ArtifactRoundTrips.cs
+++ b/OfficeIMO.Html.Tests/Html.ArtifactRoundTrips.cs
@@ -1,0 +1,81 @@
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.Html;
+using OfficeIMO.Html;
+using OfficeIMO.Html.Pdf;
+using OfficeIMO.Markdown.Html;
+using OfficeIMO.PowerPoint;
+using OfficeIMO.PowerPoint.Html;
+using OfficeIMO.Rtf;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using PdfCore = OfficeIMO.Pdf;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public class HtmlArtifactRoundTrips {
+    private const string Marker = "OfficeIMO artifact marker";
+
+    [Fact]
+    public void GenericHtml_ProducesReadableWordRtfMarkdownPdfAndSvgArtifactsFromOnePreparedDocument() {
+        HtmlConversionDocument source = HtmlConversionDocumentBuilder.Build(
+            "<h1>Conversion proof</h1><p>" + Marker + "</p><ul><li>First</li><li>Second</li></ul>");
+
+        HtmlToWordResult wordResult = source.ToWordDocumentResult();
+        using var docx = new MemoryStream();
+        wordResult.Document.Save(docx);
+        using WordDocument reopenedWord = WordDocument.Load(new MemoryStream(docx.ToArray()), readOnly: true);
+
+        HtmlToRtfResult rtfResult = source.ToRtfDocumentResult();
+        string rtf = rtfResult.Document.ToRtf();
+        RtfReadResult reopenedRtf = RtfDocument.Read(rtf);
+
+        string markdown = source.ToMarkdown();
+        byte[] pdf = source.ToPdf();
+        string svg = source.ToSvg();
+
+        Assert.NotEmpty(reopenedWord.Find(Marker, StringComparison.Ordinal));
+        Assert.Contains(Marker, string.Join("\n", reopenedRtf.Document.Paragraphs.Select(paragraph => paragraph.ToPlainText())), StringComparison.Ordinal);
+        Assert.Contains(Marker, markdown, StringComparison.Ordinal);
+        Assert.Contains(Marker, PdfCore.PdfReadDocument.Load(pdf).ExtractText(), StringComparison.Ordinal);
+        Assert.Contains(Marker, svg, StringComparison.Ordinal);
+        Assert.True(pdf.Length > 100);
+        Assert.StartsWith("{\\rtf", rtf, StringComparison.Ordinal);
+        Assert.True(wordResult.Succeeded);
+        Assert.True(rtfResult.Succeeded);
+    }
+
+    [Fact]
+    public void SemanticHtml_ProducesReopenableXlsxAndPptxArtifacts() {
+        using ExcelDocument sourceWorkbook = ExcelDocument.Create(new MemoryStream());
+        ExcelSheet sourceSheet = sourceWorkbook.AddWorkSheet("Evidence");
+        sourceSheet.CellValue(1, 1, "Label");
+        sourceSheet.CellValue(2, 1, Marker);
+        sourceSheet.MergeRange("A2:B2");
+        HtmlToExcelResult excelResult = sourceWorkbook.ToHtml().ToExcelDocumentResult();
+        using var xlsx = new MemoryStream();
+        excelResult.Workbook.Save(xlsx);
+        using ExcelDocument reopenedWorkbook = ExcelDocument.Load(new MemoryStream(xlsx.ToArray()), readOnly: true);
+
+        using PowerPointPresentation sourcePresentation = PowerPointPresentation.Create(new MemoryStream());
+        PowerPointTable sourceTable = sourcePresentation.Slides[0].AddTablePoints(2, 2, 40, 60, 300, 120);
+        sourceTable.GetCell(0, 0).Text = Marker;
+        sourceTable.MergeCells(0, 0, 0, 1);
+        HtmlToPowerPointResult powerPointResult = sourcePresentation.ToHtml().ToPowerPointPresentationResult();
+        using var pptx = new MemoryStream();
+        powerPointResult.Presentation.Save(pptx);
+        using PowerPointPresentation reopenedPresentation = PowerPointPresentation.Open(new MemoryStream(pptx.ToArray()), readOnly: true);
+
+        ExcelSheet reopenedSheet = Assert.Single(reopenedWorkbook.Sheets);
+        Assert.True(reopenedSheet.TryGetCellText(2, 1, out string excelText));
+        Assert.Equal(Marker, excelText);
+        Assert.Equal("A2:B2", Assert.Single(reopenedSheet.GetMergedRanges()).A1Range);
+        PowerPointTable reopenedTable = Assert.Single(Assert.Single(reopenedPresentation.Slides).Tables);
+        Assert.Equal(Marker, reopenedTable.GetCell(0, 0).Text);
+        Assert.Equal((1, 2), reopenedTable.GetCell(0, 0).Merge);
+        Assert.True(xlsx.Length > 100);
+        Assert.True(pptx.Length > 100);
+        Assert.True(excelResult.Succeeded);
+        Assert.True(powerPointResult.Succeeded);
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.EnginePlatform.cs
+++ b/OfficeIMO.Html.Tests/Html.EnginePlatform.cs
@@ -306,6 +306,7 @@ public partial class Html {
         });
 
         Assert.Equal(HtmlConversionProfile.Document, conversion.ProfileContract.Profile);
+        Assert.Equal(HtmlInputTrust.Untrusted, conversion.Trust);
         Assert.Contains("forms", conversion.LogicalDocument.Capabilities);
         Assert.Contains("images", conversion.LogicalDocument.Capabilities);
         Assert.Contains("font-family", conversion.StyleSummary.PropertyNames);
@@ -341,8 +342,13 @@ public partial class Html {
         string markdown = conversion.ToMarkdown();
         Assert.Contains("# Canonical Contract", markdown);
         HtmlToWordOptions sharedWordDefaults = WordHtmlConverterExtensions.CreateWordOptionsForSharedDocument(conversion.ProfileContract.Profile);
-        Assert.Equal(ImageProcessingMode.Embed, sharedWordDefaults.ImageProcessing);
-        Assert.True(sharedWordDefaults.AllowDocumentStylesheetLinks);
+        Assert.Equal(ImageProcessingMode.EmbedDataUriOnly, sharedWordDefaults.ImageProcessing);
+        Assert.False(sharedWordDefaults.AllowDocumentStylesheetLinks);
+        HtmlToWordOptions trustedWordDefaults = WordHtmlConverterExtensions.CreateWordOptionsForSharedDocument(
+            conversion.ProfileContract.Profile,
+            HtmlInputTrust.Trusted);
+        Assert.Equal(ImageProcessingMode.Embed, trustedWordDefaults.ImageProcessing);
+        Assert.True(trustedWordDefaults.AllowDocumentStylesheetLinks);
         using var wordDocument = WordHtmlConverterExtensions.ToWordDocument(conversion);
         Assert.NotNull(wordDocument);
 
@@ -461,8 +467,8 @@ public partial class Html {
         Assert.DoesNotContain(print.ResourceManifest.Resources, resource => resource.Source == "file:///secret/print-future.png");
         Assert.Contains("background-image", print.StyleSummary.PropertyNames);
 
-        string screenWordHtml = WordHtmlConverterExtensions.PrepareHtmlForSharedWordConversion(screen);
-        string printWordHtml = WordHtmlConverterExtensions.PrepareHtmlForSharedWordConversion(print);
+        string screenWordHtml = screen.DocumentForConversion.DocumentElement?.OuterHtml ?? string.Empty;
+        string printWordHtml = print.DocumentForConversion.DocumentElement?.OuterHtml ?? string.Empty;
         Assert.Contains("https://example.test/images/screen-chart.png", screenWordHtml);
         Assert.DoesNotContain("https://example.test/images/print-chart.png", screenWordHtml);
         Assert.DoesNotContain("https://example.test/images/screen-chart.png", printWordHtml);

--- a/OfficeIMO.Html.Tests/Html.EnginePlatform.cs
+++ b/OfficeIMO.Html.Tests/Html.EnginePlatform.cs
@@ -426,6 +426,10 @@ public partial class Html {
                 <link rel="stylesheet" media="print" href="file:///secret/print-only-link.css">
                 <style media="screen">
                     .total { color: #ff0000; }
+                    .print-only { display: none; }
+                </style>
+                <style media="print">
+                    .print-only { display: block; }
                 </style>
                 <style>
                     @media print { @supports (color: red) { .total { background-image: url(file:///secret/print-total.png); color: #123456; } } }
@@ -439,6 +443,7 @@ public partial class Html {
             <body>
                 <main>
                     <p class="total">Total</p>
+                    <p class="print-only">Print target retained</p>
                     <picture>
                         <source media="screen" srcset="https://example.test/images/screen-chart.png 1x">
                         <source media="print/*c*/ and (color)" type="image/avif" srcset="https://example.test/images/ignored-print-chart.avif 1x">
@@ -469,11 +474,14 @@ public partial class Html {
 
         string screenWordHtml = screen.DocumentForConversion.DocumentElement?.OuterHtml ?? string.Empty;
         string printWordHtml = print.DocumentForConversion.DocumentElement?.OuterHtml ?? string.Empty;
+        string screenRetargetedToPrint = screen.CreateDocumentForConversion(HtmlCssMediaContext.Print).DocumentElement?.OuterHtml ?? string.Empty;
         Assert.Contains("https://example.test/images/screen-chart.png", screenWordHtml);
         Assert.DoesNotContain("https://example.test/images/print-chart.png", screenWordHtml);
         Assert.DoesNotContain("https://example.test/images/screen-chart.png", printWordHtml);
         Assert.DoesNotContain("https://example.test/images/ignored-print-chart.avif", printWordHtml);
         Assert.Contains("https://example.test/images/print-chart.png", printWordHtml);
+        Assert.DoesNotContain(".print-only { display: none; }", screenRetargetedToPrint, StringComparison.Ordinal);
+        Assert.Contains(".print-only { display: block; }", screenRetargetedToPrint, StringComparison.Ordinal);
         string printMarkdown = print.ToMarkdown();
         Assert.DoesNotContain("https://example.test/images/screen-chart.png", printMarkdown);
         Assert.DoesNotContain("https://example.test/images/ignored-print-chart.avif", printMarkdown);
@@ -489,6 +497,8 @@ public partial class Html {
 
         byte[] printPdf = print.ToPdf();
         Assert.NotEmpty(printPdf);
+        string retargetedPdfText = OfficeIMO.Pdf.PdfReadDocument.Load(screen.ToPdf()).ExtractText();
+        Assert.Contains("Print target retained", retargetedPdfText, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.ExcelMergedCells.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.ExcelMergedCells.cs
@@ -1,0 +1,84 @@
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.Html;
+using OfficeIMO.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public class HtmlOfficeAdaptersExcelMergedCells {
+    [Fact]
+    public void ExcelHtml_RoundTripsMergedCellsWithoutDuplicatingCoveredCells() {
+        using ExcelDocument workbook = ExcelDocument.Create(new MemoryStream());
+        ExcelSheet sheet = workbook.AddWorkSheet("Merged");
+        sheet.CellValue(1, 1, "Quarterly result");
+        sheet.CellValue(1, 4, "Status");
+        sheet.CellValue(4, 2, "Approved");
+        sheet.MergeRange("A1:C2");
+        sheet.MergeRange("B4:C4");
+
+        string html = workbook.ToHtml(new ExcelHtmlSaveOptions {
+            Profile = OfficeHtmlConversionProfile.ExcelSemanticTables
+        });
+
+        Assert.Contains("data-officeimo-cell=\"A1\" rowspan=\"2\" colspan=\"3\" data-officeimo-merge=\"A1:C2\"", html, StringComparison.Ordinal);
+        Assert.Contains("data-officeimo-cell=\"B4\" colspan=\"2\" data-officeimo-merge=\"B4:C4\"", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("data-officeimo-cell=\"B1\"", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("data-officeimo-cell=\"A2\"", html, StringComparison.Ordinal);
+
+        HtmlToExcelResult result = html.ToExcelDocumentResult();
+        using ExcelDocument imported = result.Workbook;
+        ExcelSheet importedSheet = Assert.Single(imported.Sheets);
+        string[] mergedRanges = importedSheet.GetMergedRanges().Select(merge => merge.A1Range).OrderBy(range => range).ToArray();
+
+        Assert.Equal(2, result.MergedRanges);
+        Assert.Equal(new[] { "A1:C2", "B4:C4" }, mergedRanges);
+        Assert.True(importedSheet.TryGetCellValueSnapshot(1, 1, out ExcelCellValueSnapshot? title));
+        Assert.Equal("Quarterly result", title!.Text);
+        Assert.True(importedSheet.TryGetCellValueSnapshot(4, 2, out ExcelCellValueSnapshot? approval));
+        Assert.Equal("Approved", approval!.Text);
+    }
+
+    [Fact]
+    public void ExcelHtml_ImportsGenericTableRowAndColumnSpans() {
+        const string html = """
+            <main>
+              <section class="officeimo-sheet" data-officeimo-sheet="Generic" data-officeimo-range="B2:E4">
+                <table>
+                  <tr><th rowspan="2" colspan="2">Group</th><th>Q1</th></tr>
+                  <tr><td>10</td></tr>
+                  <tr><td>Tail</td><td colspan="2">Summary</td></tr>
+                </table>
+              </section>
+            </main>
+            """;
+
+        HtmlToExcelResult result = html.ToExcelDocumentResult();
+        using ExcelDocument workbook = result.Workbook;
+        ExcelSheet sheet = Assert.Single(workbook.Sheets);
+
+        Assert.Equal(2, result.MergedRanges);
+        Assert.Equal(new[] { "B2:C3", "C4:D4" }, sheet.GetMergedRanges().Select(merge => merge.A1Range).OrderBy(range => range).ToArray());
+        Assert.True(sheet.TryGetCellValueSnapshot(2, 4, out ExcelCellValueSnapshot? q1));
+        Assert.Equal("Q1", q1!.Text);
+        Assert.True(sheet.TryGetCellValueSnapshot(3, 4, out ExcelCellValueSnapshot? ten));
+        Assert.Equal("10", ten!.Text);
+    }
+
+    [Fact]
+    public void ExcelHtml_TruncationClipsMergedRangeToExportedRows() {
+        using ExcelDocument workbook = ExcelDocument.Create(new MemoryStream());
+        ExcelSheet sheet = workbook.AddWorkSheet("Clipped");
+        sheet.CellValue(1, 1, "Visible");
+        sheet.MergeRange("A1:B3");
+
+        string html = workbook.ToHtml(new ExcelHtmlSaveOptions {
+            Profile = OfficeHtmlConversionProfile.ExcelSemanticTables,
+            MaxRowsPerSheet = 2
+        });
+        HtmlToExcelResult result = html.ToExcelDocumentResult();
+        using ExcelDocument imported = result.Workbook;
+
+        Assert.Contains("data-officeimo-merge=\"A1:B2\"", html, StringComparison.Ordinal);
+        Assert.Equal("A1:B2", Assert.Single(Assert.Single(imported.Sheets).GetMergedRanges()).A1Range);
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.ExcelSemantics.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.ExcelSemantics.cs
@@ -1,0 +1,61 @@
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.Html;
+using OfficeIMO.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public class HtmlOfficeAdaptersExcelSemantics {
+    [Fact]
+    public void ExcelHtml_HeaderModeMakesHeaderIntentExplicit() {
+        using ExcelDocument workbook = ExcelDocument.Create(new MemoryStream());
+        ExcelSheet sheet = workbook.AddWorkSheet("Data");
+        sheet.CellValue(1, 1, "Not a header");
+        sheet.CellValue(2, 1, "Second row");
+
+        string defaultHtml = workbook.ToHtml();
+        string dataOnlyHtml = workbook.ToHtml(new ExcelHtmlSaveOptions {
+            HeaderMode = ExcelHtmlHeaderMode.None
+        });
+
+        Assert.Contains("<thead><tr><th data-officeimo-cell=\"A1\" scope=\"col\"", defaultHtml, StringComparison.Ordinal);
+        Assert.Contains("<tbody><tr><td data-officeimo-cell=\"A1\"", dataOnlyHtml, StringComparison.Ordinal);
+        Assert.DoesNotContain("<thead>", dataOnlyHtml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExcelHtml_RoundTripsDateFormattedSerialAsDateTime() {
+        DateTime expected = new(2026, 7, 11, 14, 15, 16, DateTimeKind.Unspecified);
+        using ExcelDocument workbook = ExcelDocument.Create(new MemoryStream());
+        ExcelSheet sheet = workbook.AddWorkSheet("Dates");
+        sheet.CellValue(1, 1, "When");
+        sheet.CellValue(2, 1, expected);
+
+        string html = workbook.ToHtml();
+        HtmlToExcelResult result = html.ToExcelDocumentResult();
+        using ExcelDocument imported = result.Workbook;
+        ExcelSheet importedSheet = Assert.Single(imported.Sheets);
+
+        Assert.Contains("data-officeimo-value-kind=\"date-time\" data-officeimo-value=\"2026-07-11T14:15:16.0000000\"", html, StringComparison.Ordinal);
+        Assert.True(importedSheet.TryGetCellValueSnapshot(2, 1, out ExcelCellValueSnapshot? snapshot));
+        Assert.Equal(ExcelCellValueKind.DateTime, snapshot!.Kind);
+        Assert.Equal(expected, snapshot.DateTimeValue);
+        Assert.True(importedSheet.GetCellStyle(2, 1).IsDateLike);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void ExcelHtml_TableCellLimitRejectsOversizedSpanWithoutAllocation() {
+        const string html = """
+            <section class="officeimo-sheet" data-officeimo-sheet="Limited">
+              <table><tr><td rowspan="50000" colspan="16000">Value</td></tr></table>
+            </section>
+            """;
+
+        HtmlToExcelResult result = html.ToExcelDocumentResult(new HtmlToExcelOptions { MaxTableCells = 4 });
+        using ExcelDocument workbook = result.Workbook;
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == HtmlConversionDiagnosticCodes.TargetLimitExceeded);
+        Assert.Empty(Assert.Single(workbook.Sheets).GetMergedRanges());
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.PowerPointOrder.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.PowerPointOrder.cs
@@ -7,6 +7,31 @@ namespace OfficeIMO.Tests;
 
 public class HtmlOfficeAdaptersPowerPointOrder {
     [Fact]
+    public void PowerPointHtml_RoundTripsShapesAtTheSlideOrigin() {
+        using PowerPointPresentation presentation = PowerPointPresentation.Create(new MemoryStream());
+        PowerPointSlide slide = presentation.Slides[0];
+        slide.AddTextBoxPoints("Origin text", 0, 0, 180, 35);
+        PowerPointTable table = slide.AddTablePoints(1, 1, 0, 0, 220, 60);
+        table.GetCell(0, 0).Text = "Origin table";
+
+        string html = presentation.ToHtml(new PowerPointHtmlSaveOptions {
+            Profile = OfficeHtmlConversionProfile.PowerPointSemanticSlides
+        });
+        HtmlToPowerPointResult result = html.ToPowerPointPresentationResult();
+        using PowerPointPresentation imported = result.Presentation;
+        PowerPointSlide importedSlide = Assert.Single(imported.Slides);
+
+        Assert.Contains("data-officeimo-left=\"0\" data-officeimo-top=\"0\"", html, StringComparison.Ordinal);
+        PowerPointTextBox importedText = Assert.Single(importedSlide.TextBoxes);
+        PowerPointTable importedTable = Assert.Single(importedSlide.Tables);
+        Assert.Equal(0D, importedText.LeftPoints, 3);
+        Assert.Equal(0D, importedText.TopPoints, 3);
+        Assert.Equal(0D, importedTable.LeftPoints, 3);
+        Assert.Equal(0D, importedTable.TopPoints, 3);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
     public void PowerPointHtml_RoundTripsUnifiedShapeReadingOrderAndGeometry() {
         using PowerPointPresentation presentation = PowerPointPresentation.Create(new MemoryStream());
         PowerPointSlide slide = presentation.Slides[0];

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.PowerPointOrder.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.PowerPointOrder.cs
@@ -1,0 +1,46 @@
+using OfficeIMO.Html;
+using OfficeIMO.PowerPoint;
+using OfficeIMO.PowerPoint.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public class HtmlOfficeAdaptersPowerPointOrder {
+    [Fact]
+    public void PowerPointHtml_RoundTripsUnifiedShapeReadingOrderAndGeometry() {
+        using PowerPointPresentation presentation = PowerPointPresentation.Create(new MemoryStream());
+        PowerPointSlide slide = presentation.Slides[0];
+        PowerPointTextBox firstText = slide.AddTextBoxPoints("First text", 30, 40, 180, 35);
+        using (var image = new MemoryStream(Convert.FromBase64String(
+                   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAEAQH/69DjmQAAAABJRU5ErkJggg=="))) {
+            slide.AddPicturePoints(image, ImagePartType.Png, 60, 90, 70, 50).Name = "Middle picture";
+        }
+
+        PowerPointTable table = slide.AddTablePoints(1, 1, 90, 150, 220, 60);
+        table.GetCell(0, 0).Text = "Ordered table";
+        PowerPointTextBox lastText = slide.AddTextBoxPoints("Last text", 120, 230, 190, 40);
+        table.MoveToReadingOrder(0);
+
+        string html = presentation.ToHtml(new PowerPointHtmlSaveOptions {
+            Profile = OfficeHtmlConversionProfile.PowerPointSemanticSlides
+        });
+        HtmlToPowerPointResult result = html.ToPowerPointPresentationResult();
+        using PowerPointPresentation imported = result.Presentation;
+        PowerPointSlide importedSlide = Assert.Single(imported.Slides);
+        PowerPointShape[] orderedShapes = importedSlide.Shapes.OrderBy(shape => shape.DrawingOrder).ToArray();
+
+        Assert.Collection(
+            orderedShapes,
+            shape => Assert.IsType<PowerPointTable>(shape),
+            shape => Assert.Same(firstText.GetType(), shape.GetType()),
+            shape => Assert.IsType<PowerPointPicture>(shape),
+            shape => Assert.Same(lastText.GetType(), shape.GetType()));
+        PowerPointTable importedTable = Assert.IsType<PowerPointTable>(orderedShapes[0]);
+        Assert.Equal(90D, importedTable.LeftPoints, 3);
+        Assert.Equal(150D, importedTable.TopPoints, 3);
+        PowerPointTextBox importedLastText = Assert.IsType<PowerPointTextBox>(orderedShapes[3]);
+        Assert.Equal(120D, importedLastText.LeftPoints, 3);
+        Assert.Equal(230D, importedLastText.TopPoints, 3);
+        Assert.Empty(result.Diagnostics);
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.PowerPointTables.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.PowerPointTables.cs
@@ -1,0 +1,74 @@
+using OfficeIMO.Html;
+using OfficeIMO.PowerPoint;
+using OfficeIMO.PowerPoint.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public class HtmlOfficeAdaptersPowerPointTables {
+    [Fact]
+    public void PowerPointHtml_RoundTripsMergedTableCells() {
+        using PowerPointPresentation presentation = PowerPointPresentation.Create(new MemoryStream());
+        PowerPointSlide slide = presentation.Slides[0];
+        PowerPointTable table = slide.AddTablePoints(3, 3, 70, 90, 360, 150);
+        table.GetCell(0, 0).Text = "Merged heading";
+        table.GetCell(2, 0).Text = "Tail";
+        table.MergeCells(0, 0, 1, 1);
+        table.MergeCells(2, 1, 2, 2);
+
+        string html = presentation.ToHtml();
+        HtmlToPowerPointResult result = html.ToPowerPointPresentationResult();
+        using PowerPointPresentation imported = result.Presentation;
+        PowerPointTable importedTable = Assert.Single(Assert.Single(imported.Slides).Tables);
+
+        Assert.Contains("<td rowspan=\"2\" colspan=\"2\">Merged heading</td>", html, StringComparison.Ordinal);
+        Assert.Contains("<td colspan=\"2\"></td>", html, StringComparison.Ordinal);
+        Assert.Equal(2, result.MergedRanges);
+        Assert.Equal((2, 2), importedTable.GetCell(0, 0).Merge);
+        Assert.True(importedTable.GetCell(0, 1).IsMergedCell);
+        Assert.Equal((1, 2), importedTable.GetCell(2, 1).Merge);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void PowerPointHtml_ImportsGenericSpansAndDataAttributeGeometry() {
+        const string html = """
+            <section class="officeimo-slide">
+              <table data-officeimo-left="123" data-officeimo-top="234" data-officeimo-width="345" data-officeimo-height="156">
+                <tbody>
+                  <tr><th rowspan="2" colspan="2">Group</th><th>Value</th></tr>
+                  <tr><td>42</td></tr>
+                </tbody>
+              </table>
+            </section>
+            """;
+
+        HtmlToPowerPointResult result = html.ToPowerPointPresentationResult();
+        using PowerPointPresentation presentation = result.Presentation;
+        PowerPointTable table = Assert.Single(Assert.Single(presentation.Slides).Tables);
+
+        Assert.Equal(1, result.MergedRanges);
+        Assert.Equal((2, 2), table.GetCell(0, 0).Merge);
+        Assert.Equal("42", table.GetCell(1, 2).Text);
+        Assert.Equal(123D, table.LeftPoints, 3);
+        Assert.Equal(234D, table.TopPoints, 3);
+        Assert.Equal(345D, table.WidthPoints, 3);
+        Assert.Equal(156D, table.HeightPoints, 3);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void PowerPointHtml_TableCellLimitRejectsOversizedSpanWithoutAllocation() {
+        const string html = """
+            <section class="officeimo-slide">
+              <table><tr><td rowspan="50000" colspan="50000">Value</td></tr></table>
+            </section>
+            """;
+
+        HtmlToPowerPointResult result = html.ToPowerPointPresentationResult(new HtmlToPowerPointOptions { MaxTableCells = 4 });
+        using PowerPointPresentation presentation = result.Presentation;
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == HtmlConversionDiagnosticCodes.TargetLimitExceeded);
+        Assert.Equal((1, 1), Assert.Single(Assert.Single(presentation.Slides).Tables).GetCell(0, 0).Merge);
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.StreamIO.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.StreamIO.cs
@@ -1,0 +1,82 @@
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.Html;
+using OfficeIMO.Html;
+using OfficeIMO.Html.Pdf;
+using OfficeIMO.Markdown.Html;
+using OfficeIMO.PowerPoint;
+using OfficeIMO.PowerPoint.Html;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public class HtmlOfficeAdaptersStreamIO {
+    [Fact]
+    public async Task ExcelHtml_StreamAndAsyncApisUseUtf8WithoutBomAndLeaveStreamsOpen() {
+        using ExcelDocument workbook = ExcelDocument.Create(new MemoryStream());
+        workbook.AddWorkSheet("Data").CellValue(1, 1, "Zażółć");
+        using var htmlStream = new MemoryStream();
+
+        await workbook.SaveAsHtmlAsync(htmlStream);
+
+        Assert.True(htmlStream.CanWrite);
+        byte[] htmlBytes = htmlStream.ToArray();
+        Assert.False(HasUtf8Bom(htmlBytes));
+        htmlStream.Position = 0;
+        HtmlToExcelResult result = await htmlStream.ToExcelDocumentResultAsync();
+        using ExcelDocument imported = result.Workbook;
+        Assert.True(result.Succeeded);
+        Assert.True(htmlStream.CanRead);
+    }
+
+    [Fact]
+    public async Task PowerPointHtml_StreamAndAsyncApisUseUtf8WithoutBomAndLeaveStreamsOpen() {
+        using PowerPointPresentation presentation = PowerPointPresentation.Create(new MemoryStream());
+        presentation.Slides[0].AddTextBox("Zażółć");
+        using var htmlStream = new MemoryStream();
+
+        await presentation.SaveAsHtmlAsync(htmlStream);
+
+        Assert.True(htmlStream.CanWrite);
+        byte[] htmlBytes = htmlStream.ToArray();
+        Assert.False(HasUtf8Bom(htmlBytes));
+        htmlStream.Position = 0;
+        HtmlToPowerPointResult result = await htmlStream.ToPowerPointPresentationResultAsync();
+        using PowerPointPresentation imported = result.Presentation;
+        Assert.True(result.Succeeded);
+        Assert.True(htmlStream.CanRead);
+    }
+
+    [Fact]
+    public async Task SharedHtmlTextIOIsUsedByWordMarkdownAndPdfStreams() {
+        using WordDocument word = "<p>Zażółć</p>".ToWordDocument();
+        using var wordHtml = new MemoryStream();
+        await word.SaveAsHtmlAsync(wordHtml);
+        Assert.False(HasUtf8Bom(wordHtml.ToArray()));
+        Assert.True(wordHtml.CanWrite);
+
+        wordHtml.Position = 0;
+        HtmlToWordResult wordResult = await wordHtml.ToWordDocumentResultAsync();
+        using WordDocument importedWord = wordResult.Document;
+        Assert.True(wordHtml.CanRead);
+        Assert.True(wordResult.Succeeded);
+
+        byte[] bomHtml = Encoding.UTF8.GetPreamble()
+            .Concat(Encoding.UTF8.GetBytes("<p>Stream marker</p>"))
+            .ToArray();
+        using var markdownStream = new MemoryStream(bomHtml);
+        Assert.Contains("Stream marker", markdownStream.ToMarkdown(), StringComparison.Ordinal);
+        Assert.True(markdownStream.CanRead);
+
+        using var pdfStream = new MemoryStream(bomHtml);
+        var pdfResult = await pdfStream.ToPdfResultAsync();
+        Assert.True(pdfStream.CanRead);
+        Assert.NotEmpty(pdfResult.ToBytes());
+    }
+
+    private static bool HasUtf8Bom(byte[] bytes) =>
+        bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF;
+}

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.StructuredResults.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.StructuredResults.cs
@@ -1,0 +1,54 @@
+using OfficeIMO.Excel.Html;
+using OfficeIMO.Excel;
+using OfficeIMO.Html;
+using OfficeIMO.PowerPoint.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public class HtmlOfficeAdaptersStructuredResults {
+    [Fact]
+    public void SharedConversionDocumentFeedsExcelAndPowerPointAdapters() {
+        HtmlConversionDocument excelSource = HtmlConversionDocumentBuilder.Build("""
+            <main><section class="officeimo-sheet" data-officeimo-sheet="Data" data-officeimo-range="A1:A1">
+              <table><tr><td>42</td></tr></table>
+            </section></main>
+            """);
+        HtmlConversionDocument powerPointSource = HtmlConversionDocumentBuilder.Build("""
+            <main><section class="officeimo-slide"><p>Prepared slide</p></section></main>
+            """);
+
+        HtmlToExcelResult excelResult = excelSource.ToExcelDocumentResult();
+        using OfficeIMO.Excel.ExcelDocument workbook = excelResult.Workbook;
+        HtmlToPowerPointResult powerPointResult = powerPointSource.ToPowerPointPresentationResult();
+        using OfficeIMO.PowerPoint.PowerPointPresentation presentation = powerPointResult.Presentation;
+
+        Assert.True(excelResult.Succeeded);
+        Assert.True(powerPointResult.Succeeded);
+        Assert.True(Assert.Single(workbook.Sheets).TryGetCellValueSnapshot(1, 1, out ExcelCellValueSnapshot? value));
+        Assert.Equal("42", value!.Text);
+        Assert.Contains(Assert.Single(presentation.Slides).TextBoxes, textBox => textBox.Text == "Prepared slide");
+    }
+
+    [Fact]
+    public void ExcelHtml_ConvenienceImportThrowsWhenSemanticEnvelopeIsMissing() {
+        HtmlConversionException exception = Assert.Throws<HtmlConversionException>(() =>
+            "<main><p>Not an Excel envelope</p></main>".ToExcelDocument());
+
+        HtmlDiagnostic diagnostic = Assert.Single(exception.Diagnostics);
+        Assert.Equal(HtmlConversionDiagnosticCodes.SemanticContentMissing, diagnostic.Code);
+        Assert.Equal(HtmlDiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Equal(HtmlConversionLossKind.Failure, diagnostic.LossKind);
+    }
+
+    [Fact]
+    public void PowerPointHtml_ConvenienceImportThrowsWhenSemanticEnvelopeIsMissing() {
+        HtmlConversionException exception = Assert.Throws<HtmlConversionException>(() =>
+            "<main><p>Not a PowerPoint envelope</p></main>".ToPowerPointPresentation());
+
+        HtmlDiagnostic diagnostic = Assert.Single(exception.Diagnostics);
+        Assert.Equal(HtmlConversionDiagnosticCodes.SemanticContentMissing, diagnostic.Code);
+        Assert.Equal(HtmlDiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Equal(HtmlConversionLossKind.Failure, diagnostic.LossKind);
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.cs
@@ -468,7 +468,11 @@ public class HtmlOfficeAdapters {
         imported.Save();
 
         Assert.Equal("Imported", importedSheet.Name);
-        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Contains("No semantic Excel sheet sections", StringComparison.Ordinal));
+        HtmlDiagnostic diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(HtmlConversionDiagnosticCodes.SemanticContentMissing, diagnostic.Code);
+        Assert.Equal(HtmlDiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Equal(HtmlConversionLossKind.Failure, diagnostic.LossKind);
+        Assert.Contains("No semantic Excel sheet sections", diagnostic.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -846,7 +850,7 @@ public class HtmlOfficeAdapters {
         });
 
         Assert.Contains("data-officeimo-profile=\"PowerPointSemanticSlides\"", html, StringComparison.Ordinal);
-        Assert.Contains("<p>Roadmap</p>", html, StringComparison.Ordinal);
+        Assert.Contains(">Roadmap</p>", html, StringComparison.Ordinal);
         Assert.Contains("HTML end to end", html, StringComparison.Ordinal);
         Assert.Contains("Presenter reminder", html, StringComparison.Ordinal);
         Assert.Contains("officeimo-source-markdown", html, StringComparison.Ordinal);
@@ -1104,7 +1108,7 @@ public class HtmlOfficeAdapters {
         Assert.Equal(1, result.Pictures);
         Assert.Equal(1, result.Charts);
         Assert.Equal(1, result.Notes);
-        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Contains("placeholder values", StringComparison.Ordinal));
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Message.Contains("placeholder values", StringComparison.Ordinal));
         Assert.Contains(importedSlide.TextBoxes, textBox => textBox.Text.Contains("Roundtrip Roadmap", StringComparison.Ordinal));
         Assert.Contains(importedSlide.TextBoxes, textBox => textBox.Text.Contains("HTML end to end", StringComparison.Ordinal));
         Assert.Contains(importedSlide.Tables, importedTable => importedTable.GetCell(1, 1).Text == "Rich proof");
@@ -1366,7 +1370,7 @@ public class HtmlOfficeAdapters {
 
         Assert.True(importedChart.TryGetSnapshot(out PowerPointChartSnapshot? snapshot));
         Assert.Equal(new[] { "Q1", string.Empty, "Q3" }, snapshot!.Data.Categories);
-        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Contains("placeholder values", StringComparison.Ordinal));
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Message.Contains("placeholder values", StringComparison.Ordinal));
     }
 
     [Theory]
@@ -1436,7 +1440,7 @@ public class HtmlOfficeAdapters {
         Assert.Equal(1, result.Charts);
         Assert.True(importedChart.TryGetSnapshot(out PowerPointChartSnapshot? snapshot));
         Assert.Equal(PowerPointChartSnapshotKind.ClusteredColumn, snapshot!.ChartKind);
-        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Contains("used chart kind '" + chartKind + "' and was imported as a clustered column fallback", StringComparison.Ordinal));
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Message.Contains("used chart kind '" + chartKind + "' and was imported as a clustered column fallback", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/OfficeIMO.Html.Tests/Html.Rendering.Limits.cs
+++ b/OfficeIMO.Html.Tests/Html.Rendering.Limits.cs
@@ -6,6 +6,14 @@ namespace OfficeIMO.Tests;
 
 public sealed partial class HtmlRenderingTests {
     [Fact]
+    public void HtmlRender_DefaultInputBudgetCanRepresentDefaultInlineResourceBudget() {
+        var options = new HtmlRenderOptions();
+        long base64Characters = 4L * ((options.MaxTotalResourceBytes + 2L) / 3L);
+
+        Assert.True(options.MaxInputCharacters >= base64Characters);
+    }
+
+    [Fact]
     public void HtmlRenderer_RejectsSourceBeforeParsingWhenCharacterBudgetIsExceeded() {
         var options = new HtmlRenderOptions { MaxInputCharacters = 10 };
 

--- a/OfficeIMO.Html.Tests/Html.RtfStructuredResult.cs
+++ b/OfficeIMO.Html.Tests/Html.RtfStructuredResult.cs
@@ -1,0 +1,23 @@
+using OfficeIMO.Html;
+using OfficeIMO.Rtf;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public class HtmlRtfStructuredResult {
+    [Fact]
+    public void HtmlRtf_UsesSharedResultAndLossDiagnosticsWithoutReparsingSharedDocument() {
+        HtmlConversionDocument source = HtmlConversionDocumentBuilder.Build("<p><unknown>Value</unknown></p>");
+        var options = new HtmlToRtfOptions { PreserveUnknownTagsAsText = true };
+
+        HtmlToRtfResult import = source.ToRtfDocumentResult(options);
+        import.Document.AddParagraph().AddObject(RtfObjectKind.Embedded, new byte[] { 1, 2, 3 });
+        RtfToHtmlResult export = import.Document.ToHtmlResult();
+
+        Assert.True(import.Succeeded);
+        Assert.True(export.Succeeded);
+        Assert.Contains("Value", export.Html, StringComparison.Ordinal);
+        Assert.Equal(options.HtmlDiagnostics.Count, options.Diagnostics.Count);
+        Assert.Contains(export.Diagnostics, diagnostic => diagnostic.LossKind == HtmlConversionLossKind.Omission);
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.WordStructuredResult.cs
+++ b/OfficeIMO.Html.Tests/Html.WordStructuredResult.cs
@@ -1,0 +1,39 @@
+using OfficeIMO.Html;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public class HtmlWordStructuredResult {
+    [Fact]
+    public void WordHtml_ResultCarriesOnlyCurrentConversionDiagnostics() {
+        var options = new HtmlToWordOptions {
+            UnsupportedCssHandling = HtmlUnsupportedCssHandling.Warn
+        };
+
+        HtmlToWordResult first = "<p style='future-property:value'>First</p>".ToWordDocumentResult(options);
+        HtmlToWordResult second = "<p>Second</p>".ToWordDocumentResult(options);
+        try {
+            Assert.Contains(first.Diagnostics, diagnostic => diagnostic.Code == "UnsupportedCssDeclaration");
+            Assert.Empty(second.Diagnostics);
+            Assert.True(first.Succeeded);
+            Assert.True(second.Succeeded);
+        } finally {
+            first.Document.Dispose();
+            second.Document.Dispose();
+        }
+    }
+
+    [Fact]
+    public void WordHtml_UsesConversionScopedMissingStyleResolver() {
+        var options = new HtmlToWordOptions {
+            StyleMissingHandler = args => args.Style = WordParagraphStyles.Heading1
+        };
+
+        HtmlToWordResult result = "<p class='custom-heading'>Heading</p>".ToWordDocumentResult(options);
+        using WordDocument document = result.Document;
+
+        Assert.Equal(WordParagraphStyles.Heading1, Assert.Single(document.Paragraphs).Style);
+    }
+}

--- a/OfficeIMO.Html/Diagnostics/HtmlConversionDiagnosticCodes.cs
+++ b/OfficeIMO.Html/Diagnostics/HtmlConversionDiagnosticCodes.cs
@@ -1,0 +1,36 @@
+namespace OfficeIMO.Html;
+
+/// <summary>
+/// Stable diagnostic codes shared by OfficeIMO HTML target adapters.
+/// </summary>
+public static class HtmlConversionDiagnosticCodes {
+    /// <summary>The expected format-specific semantic envelope was not present.</summary>
+    public const string SemanticContentMissing = "SemanticContentMissing";
+
+    /// <summary>An expected semantic table or content block was not present.</summary>
+    public const string SemanticBlockMissing = "SemanticBlockMissing";
+
+    /// <summary>A semantic scalar value could not be parsed as its declared type.</summary>
+    public const string SemanticValueInvalid = "SemanticValueInvalid";
+
+    /// <summary>An embedded resource could not be decoded.</summary>
+    public const string ResourceDecodeFailed = "ResourceDecodeFailed";
+
+    /// <summary>A resource media type is not supported by the target adapter.</summary>
+    public const string ResourceTypeUnsupported = "ResourceTypeUnsupported";
+
+    /// <summary>Content was restored through an approximate fallback.</summary>
+    public const string ContentApproximated = "ContentApproximated";
+
+    /// <summary>Content could not be represented in the target and was omitted.</summary>
+    public const string ContentOmitted = "ContentOmitted";
+
+    /// <summary>Target artifact construction failed.</summary>
+    public const string ArtifactCreationFailed = "ArtifactCreationFailed";
+
+    /// <summary>Input exceeded a target format grid or structural limit.</summary>
+    public const string TargetLimitExceeded = "TargetLimitExceeded";
+
+    /// <summary>An invalid or overlapping table span was normalized.</summary>
+    public const string TableSpanInvalid = "TableSpanInvalid";
+}

--- a/OfficeIMO.Html/Diagnostics/HtmlConversionLossKind.cs
+++ b/OfficeIMO.Html/Diagnostics/HtmlConversionLossKind.cs
@@ -1,0 +1,18 @@
+namespace OfficeIMO.Html;
+
+/// <summary>
+/// Classifies the conversion impact represented by a diagnostic independently from its severity.
+/// </summary>
+public enum HtmlConversionLossKind {
+    /// <summary>No content fidelity loss is represented.</summary>
+    None,
+
+    /// <summary>Content was retained through an approximate or fallback representation.</summary>
+    Approximation,
+
+    /// <summary>Some source content could not be represented and was omitted.</summary>
+    Omission,
+
+    /// <summary>The requested conversion could not produce a usable semantic result.</summary>
+    Failure
+}

--- a/OfficeIMO.Html/Diagnostics/HtmlDiagnostic.cs
+++ b/OfficeIMO.Html/Diagnostics/HtmlDiagnostic.cs
@@ -13,13 +13,22 @@ public sealed class HtmlDiagnostic {
     /// <param name="severity">Diagnostic severity.</param>
     /// <param name="source">Optional HTML, resource, or artifact source associated with the diagnostic.</param>
     /// <param name="detail">Optional low-level detail, such as an exception type, status text, or limit data.</param>
-    public HtmlDiagnostic(string component, string code, string message, HtmlDiagnosticSeverity severity = HtmlDiagnosticSeverity.Warning, string? source = null, string? detail = null) {
+    /// <param name="lossKind">Conversion fidelity impact represented by the diagnostic.</param>
+    public HtmlDiagnostic(
+        string component,
+        string code,
+        string message,
+        HtmlDiagnosticSeverity severity = HtmlDiagnosticSeverity.Warning,
+        string? source = null,
+        string? detail = null,
+        HtmlConversionLossKind lossKind = HtmlConversionLossKind.None) {
         Component = component ?? throw new ArgumentNullException(nameof(component));
         Code = code ?? throw new ArgumentNullException(nameof(code));
         Message = message ?? throw new ArgumentNullException(nameof(message));
         Severity = severity;
         Source = source;
         Detail = detail;
+        LossKind = lossKind;
     }
 
     /// <summary>
@@ -51,6 +60,11 @@ public sealed class HtmlDiagnostic {
     /// Optional low-level detail, such as an exception type, status text, or limit data.
     /// </summary>
     public string? Detail { get; }
+
+    /// <summary>
+    /// Describes whether this diagnostic represents approximation, omission, or complete conversion failure.
+    /// </summary>
+    public HtmlConversionLossKind LossKind { get; }
 
     /// <inheritdoc />
     public override string ToString() {

--- a/OfficeIMO.Html/Diagnostics/HtmlDiagnosticReport.cs
+++ b/OfficeIMO.Html/Diagnostics/HtmlDiagnosticReport.cs
@@ -3,7 +3,7 @@ namespace OfficeIMO.Html;
 /// <summary>
 /// Mutable report of diagnostics emitted by OfficeIMO HTML workflows.
 /// </summary>
-public sealed class HtmlDiagnosticReport {
+public sealed class HtmlDiagnosticReport : IReadOnlyList<HtmlDiagnostic> {
     private readonly List<HtmlDiagnostic> _diagnostics = new List<HtmlDiagnostic>();
 
     /// <summary>
@@ -15,6 +15,9 @@ public sealed class HtmlDiagnosticReport {
     /// Number of diagnostics currently captured.
     /// </summary>
     public int Count => _diagnostics.Count;
+
+    /// <summary>Gets a diagnostic by emission index.</summary>
+    public HtmlDiagnostic this[int index] => _diagnostics[index];
 
     /// <summary>
     /// Indicates whether any captured diagnostic has error severity.
@@ -42,8 +45,16 @@ public sealed class HtmlDiagnosticReport {
     /// <param name="severity">Diagnostic severity.</param>
     /// <param name="source">Optional HTML, resource, or artifact source associated with the diagnostic.</param>
     /// <param name="detail">Optional low-level detail.</param>
-    public void Add(string component, string code, string message, HtmlDiagnosticSeverity severity = HtmlDiagnosticSeverity.Warning, string? source = null, string? detail = null) {
-        Add(new HtmlDiagnostic(component, code, message, severity, source, detail));
+    /// <param name="lossKind">Conversion fidelity impact represented by the diagnostic.</param>
+    public void Add(
+        string component,
+        string code,
+        string message,
+        HtmlDiagnosticSeverity severity = HtmlDiagnosticSeverity.Warning,
+        string? source = null,
+        string? detail = null,
+        HtmlConversionLossKind lossKind = HtmlConversionLossKind.None) {
+        Add(new HtmlDiagnostic(component, code, message, severity, source, detail, lossKind));
     }
 
     /// <summary>
@@ -76,4 +87,10 @@ public sealed class HtmlDiagnosticReport {
         clone.AddRange(_diagnostics);
         return clone;
     }
+
+    /// <inheritdoc />
+    public IEnumerator<HtmlDiagnostic> GetEnumerator() => _diagnostics.GetEnumerator();
+
+    /// <inheritdoc />
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/OfficeIMO.Html/Engine/HtmlActiveMediaFilter.cs
+++ b/OfficeIMO.Html/Engine/HtmlActiveMediaFilter.cs
@@ -28,42 +28,7 @@ public static class HtmlActiveMediaFilter {
             IHtmlDocument parsed = HtmlDocumentParser.ParseDocument(isFragment
                 ? "<html><body><" + FragmentRootElementName + ">" + html + "</" + FragmentRootElementName + "></body></html>"
                 : html);
-            bool changed = false;
-            foreach (IHtmlLinkElement linkElement in parsed.QuerySelectorAll("link").OfType<IHtmlLinkElement>()) {
-                if (string.Equals(linkElement.Relation, "stylesheet", StringComparison.OrdinalIgnoreCase)
-                    && !HtmlComputedStyleEngine.IsApplicableMedia(linkElement.GetAttribute("media") ?? string.Empty, mediaContext)) {
-                    linkElement.Remove();
-                    changed = true;
-                }
-            }
-
-            foreach (IElement sourceElement in parsed.QuerySelectorAll("picture > source")) {
-                if (!HtmlComputedStyleEngine.IsApplicableMedia(sourceElement.GetAttribute("media") ?? string.Empty, mediaContext)) {
-                    sourceElement.Remove();
-                    changed = true;
-                    continue;
-                }
-
-                if (!HtmlPictureSourceSupport.IsSupportedConversionContentType(sourceElement.GetAttribute("type"))) {
-                    sourceElement.Remove();
-                    changed = true;
-                }
-            }
-
-            foreach (IHtmlStyleElement styleElement in parsed.QuerySelectorAll("style").OfType<IHtmlStyleElement>()) {
-                if (!IsCssStyleElement(styleElement)
-                    || !HtmlComputedStyleEngine.IsApplicableMedia(styleElement.GetAttribute("media") ?? string.Empty, mediaContext)) {
-                    styleElement.Remove();
-                    changed = true;
-                    continue;
-                }
-
-                string expanded = ExpandActiveMediaStyleRules(styleElement.TextContent, mediaContext, out bool stylesheetChanged);
-                if (stylesheetChanged) {
-                    styleElement.TextContent = expanded;
-                    changed = true;
-                }
-            }
+            bool changed = FilterDocument(parsed, mediaContext);
 
             if (!changed) {
                 return html;
@@ -77,6 +42,56 @@ public static class HtmlActiveMediaFilter {
         } catch {
             return html;
         }
+    }
+
+    /// <summary>
+    /// Removes inactive media content from a prepared DOM in place without serializing and reparsing it.
+    /// </summary>
+    /// <returns>Whether the document was changed.</returns>
+    public static bool Filter(IHtmlDocument document, HtmlCssMediaContext mediaContext) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        return FilterDocument(document, mediaContext);
+    }
+
+    private static bool FilterDocument(IHtmlDocument parsed, HtmlCssMediaContext mediaContext) {
+        bool changed = false;
+        foreach (IHtmlLinkElement linkElement in parsed.QuerySelectorAll("link").OfType<IHtmlLinkElement>()) {
+            if (string.Equals(linkElement.Relation, "stylesheet", StringComparison.OrdinalIgnoreCase)
+                && !HtmlComputedStyleEngine.IsApplicableMedia(linkElement.GetAttribute("media") ?? string.Empty, mediaContext)) {
+                linkElement.Remove();
+                changed = true;
+            }
+        }
+
+        foreach (IElement sourceElement in parsed.QuerySelectorAll("picture > source")) {
+            if (!HtmlComputedStyleEngine.IsApplicableMedia(sourceElement.GetAttribute("media") ?? string.Empty, mediaContext)) {
+                sourceElement.Remove();
+                changed = true;
+                continue;
+            }
+
+            if (!HtmlPictureSourceSupport.IsSupportedConversionContentType(sourceElement.GetAttribute("type"))) {
+                sourceElement.Remove();
+                changed = true;
+            }
+        }
+
+        foreach (IHtmlStyleElement styleElement in parsed.QuerySelectorAll("style").OfType<IHtmlStyleElement>()) {
+            if (!IsCssStyleElement(styleElement)
+                || !HtmlComputedStyleEngine.IsApplicableMedia(styleElement.GetAttribute("media") ?? string.Empty, mediaContext)) {
+                styleElement.Remove();
+                changed = true;
+                continue;
+            }
+
+            string expanded = ExpandActiveMediaStyleRules(styleElement.TextContent, mediaContext, out bool stylesheetChanged);
+            if (stylesheetChanged) {
+                styleElement.TextContent = expanded;
+                changed = true;
+            }
+        }
+
+        return changed;
     }
 
     private static bool ContainsHtmlDocumentElement(string html) {

--- a/OfficeIMO.Html/Engine/HtmlConversionDocument.cs
+++ b/OfficeIMO.Html/Engine/HtmlConversionDocument.cs
@@ -1,4 +1,5 @@
 using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
 
 namespace OfficeIMO.Html;
 
@@ -8,7 +9,10 @@ namespace OfficeIMO.Html;
 public sealed class HtmlConversionDocument {
     internal HtmlConversionDocument(
         string sourceHtml,
+        IHtmlDocument sourceDocument,
+        IHtmlDocument documentForConversion,
         HtmlConversionProfileContract profileContract,
+        HtmlInputTrust trust,
         HtmlLogicalDocument logicalDocument,
         IReadOnlyDictionary<IElement, HtmlComputedStyle> computedStyles,
         HtmlComputedStyleSummary styleSummary,
@@ -17,7 +21,10 @@ public sealed class HtmlConversionDocument {
         string normalizedHtml,
         string adapterHtml) {
         SourceHtml = sourceHtml ?? throw new ArgumentNullException(nameof(sourceHtml));
+        SourceDocument = sourceDocument ?? throw new ArgumentNullException(nameof(sourceDocument));
+        DocumentForConversion = documentForConversion ?? throw new ArgumentNullException(nameof(documentForConversion));
         ProfileContract = profileContract ?? throw new ArgumentNullException(nameof(profileContract));
+        Trust = trust;
         LogicalDocument = logicalDocument ?? throw new ArgumentNullException(nameof(logicalDocument));
         ComputedStyles = computedStyles ?? throw new ArgumentNullException(nameof(computedStyles));
         StyleSummary = styleSummary ?? throw new ArgumentNullException(nameof(styleSummary));
@@ -30,8 +37,17 @@ public sealed class HtmlConversionDocument {
     /// <summary>Original HTML supplied by the caller.</summary>
     public string SourceHtml { get; }
 
+    /// <summary>Parsed source DOM used by logical, style, and resource analysis.</summary>
+    public IHtmlDocument SourceDocument { get; }
+
+    /// <summary>Policy-normalized DOM prepared for read-only target adapter consumption.</summary>
+    public IHtmlDocument DocumentForConversion { get; }
+
     /// <summary>Profile contract advertised to target adapters and galleries.</summary>
     public HtmlConversionProfileContract ProfileContract { get; }
+
+    /// <summary>Caller-assigned input trust boundary used by downstream adapters.</summary>
+    public HtmlInputTrust Trust { get; }
 
     /// <summary>Normalized logical structure used for semantic scoring and adapter planning.</summary>
     public HtmlLogicalDocument LogicalDocument { get; }

--- a/OfficeIMO.Html/Engine/HtmlConversionDocument.cs
+++ b/OfficeIMO.Html/Engine/HtmlConversionDocument.cs
@@ -10,6 +10,7 @@ public sealed class HtmlConversionDocument {
     internal HtmlConversionDocument(
         string sourceHtml,
         IHtmlDocument sourceDocument,
+        IHtmlDocument adapterDocument,
         IHtmlDocument documentForConversion,
         HtmlConversionProfileContract profileContract,
         HtmlInputTrust trust,
@@ -22,6 +23,7 @@ public sealed class HtmlConversionDocument {
         string adapterHtml) {
         SourceHtml = sourceHtml ?? throw new ArgumentNullException(nameof(sourceHtml));
         SourceDocument = sourceDocument ?? throw new ArgumentNullException(nameof(sourceDocument));
+        AdapterDocument = adapterDocument ?? throw new ArgumentNullException(nameof(adapterDocument));
         DocumentForConversion = documentForConversion ?? throw new ArgumentNullException(nameof(documentForConversion));
         ProfileContract = profileContract ?? throw new ArgumentNullException(nameof(profileContract));
         Trust = trust;
@@ -40,8 +42,21 @@ public sealed class HtmlConversionDocument {
     /// <summary>Parsed source DOM used by logical, style, and resource analysis.</summary>
     public IHtmlDocument SourceDocument { get; }
 
-    /// <summary>Policy-normalized DOM prepared for read-only target adapter consumption.</summary>
+    /// <summary>Policy-normalized DOM filtered for the conversion profile's default media context.</summary>
     public IHtmlDocument DocumentForConversion { get; }
+
+    private IHtmlDocument AdapterDocument { get; }
+
+    /// <summary>
+    /// Creates a policy-normalized DOM filtered for a target media context without reparsing source HTML or mutating shared state.
+    /// </summary>
+    /// <param name="mediaContext">Screen or print media context selected by the target adapter.</param>
+    /// <returns>An independent DOM clone that the target adapter may safely mutate.</returns>
+    public IHtmlDocument CreateDocumentForConversion(HtmlCssMediaContext mediaContext) {
+        IHtmlDocument document = HtmlDocumentParser.CloneDocument(AdapterDocument);
+        HtmlActiveMediaFilter.Filter(document, mediaContext);
+        return document;
+    }
 
     /// <summary>Profile contract advertised to target adapters and galleries.</summary>
     public HtmlConversionProfileContract ProfileContract { get; }

--- a/OfficeIMO.Html/Engine/HtmlConversionDocumentBuilder.cs
+++ b/OfficeIMO.Html/Engine/HtmlConversionDocumentBuilder.cs
@@ -29,13 +29,15 @@ public static class HtmlConversionDocumentBuilder {
             : string.Empty;
         string adapterHtml = HtmlNormalizer.Normalize(document, ConfigureAdapterNormalization(document, options));
         IHtmlDocument adapterDocument = HtmlDocumentParser.ParseDocument(adapterHtml);
-        HtmlActiveMediaFilter.Filter(adapterDocument, mediaContext);
-        adapterHtml = adapterDocument.DocumentElement?.OuterHtml ?? adapterHtml;
+        IHtmlDocument documentForConversion = HtmlDocumentParser.CloneDocument(adapterDocument);
+        HtmlActiveMediaFilter.Filter(documentForConversion, mediaContext);
+        string filteredAdapterHtml = documentForConversion.DocumentElement?.OuterHtml ?? adapterHtml;
 
         return new HtmlConversionDocument(
             html,
             document,
             adapterDocument,
+            documentForConversion,
             HtmlConversionProfileContracts.Get(options.Profile),
             options.Trust,
             logical,
@@ -44,7 +46,7 @@ public static class HtmlConversionDocumentBuilder {
             manifest,
             resourcePlan,
             normalized,
-            adapterHtml);
+            filteredAdapterHtml);
     }
 
     private static HtmlNormalizationOptions ConfigureNormalization(IHtmlDocument document, HtmlConversionDocumentOptions options) {

--- a/OfficeIMO.Html/Engine/HtmlConversionDocumentBuilder.cs
+++ b/OfficeIMO.Html/Engine/HtmlConversionDocumentBuilder.cs
@@ -28,10 +28,16 @@ public static class HtmlConversionDocumentBuilder {
             ? HtmlNormalizer.Normalize(document, ConfigureNormalization(document, options))
             : string.Empty;
         string adapterHtml = HtmlNormalizer.Normalize(document, ConfigureAdapterNormalization(document, options));
+        IHtmlDocument adapterDocument = HtmlDocumentParser.ParseDocument(adapterHtml);
+        HtmlActiveMediaFilter.Filter(adapterDocument, mediaContext);
+        adapterHtml = adapterDocument.DocumentElement?.OuterHtml ?? adapterHtml;
 
         return new HtmlConversionDocument(
             html,
+            document,
+            adapterDocument,
             HtmlConversionProfileContracts.Get(options.Profile),
+            options.Trust,
             logical,
             styles,
             styleSummary,

--- a/OfficeIMO.Html/Engine/HtmlConversionDocumentOptions.cs
+++ b/OfficeIMO.Html/Engine/HtmlConversionDocumentOptions.cs
@@ -7,6 +7,11 @@ public sealed class HtmlConversionDocumentOptions {
     /// <summary>Conversion profile the document should advertise to downstream adapters.</summary>
     public HtmlConversionProfile Profile { get; set; } = HtmlConversionProfile.Semantic;
 
+    /// <summary>
+    /// Caller-assigned input trust boundary. This is independent from the semantic or visual fidelity profile.
+    /// </summary>
+    public HtmlInputTrust Trust { get; set; } = HtmlInputTrust.Untrusted;
+
     /// <summary>Optional base URI used for URL normalization and resource planning.</summary>
     public Uri? BaseUri { get; set; }
 

--- a/OfficeIMO.Html/Engine/HtmlConversionException.cs
+++ b/OfficeIMO.Html/Engine/HtmlConversionException.cs
@@ -1,0 +1,34 @@
+namespace OfficeIMO.Html;
+
+/// <summary>
+/// Thrown when an HTML conversion cannot satisfy its requested semantic contract.
+/// </summary>
+public sealed class HtmlConversionException : InvalidOperationException {
+    /// <summary>Creates an exception from structured conversion diagnostics.</summary>
+    public HtmlConversionException(IEnumerable<HtmlDiagnostic> diagnostics)
+        : this(ToDiagnosticList(diagnostics)) {
+    }
+
+    private HtmlConversionException(IReadOnlyList<HtmlDiagnostic> diagnostics)
+        : base(CreateMessage(diagnostics)) {
+        Diagnostics = diagnostics;
+    }
+
+    /// <summary>Diagnostics that caused the conversion to fail.</summary>
+    public IReadOnlyList<HtmlDiagnostic> Diagnostics { get; }
+
+    private static IReadOnlyList<HtmlDiagnostic> ToDiagnosticList(IEnumerable<HtmlDiagnostic> diagnostics) {
+        if (diagnostics == null) {
+            throw new ArgumentNullException(nameof(diagnostics));
+        }
+
+        return diagnostics.ToList().AsReadOnly();
+    }
+
+    private static string CreateMessage(IReadOnlyList<HtmlDiagnostic> diagnostics) {
+        HtmlDiagnostic? error = diagnostics.FirstOrDefault(item => item.Severity == HtmlDiagnosticSeverity.Error);
+        return error == null
+            ? "HTML conversion failed."
+            : "HTML conversion failed: " + error.Message;
+    }
+}

--- a/OfficeIMO.Html/Engine/HtmlConversionResult.cs
+++ b/OfficeIMO.Html/Engine/HtmlConversionResult.cs
@@ -1,0 +1,32 @@
+namespace OfficeIMO.Html;
+
+/// <summary>
+/// Shared result contract for HTML conversions that produce a native target artifact.
+/// </summary>
+/// <typeparam name="TArtifact">Native artifact type produced by the adapter.</typeparam>
+public abstract class HtmlConversionResult<TArtifact> {
+    /// <summary>Creates a conversion result for the supplied artifact.</summary>
+    protected HtmlConversionResult(TArtifact artifact) {
+        Artifact = artifact ?? throw new ArgumentNullException(nameof(artifact));
+    }
+
+    /// <summary>Native artifact produced by the conversion.</summary>
+    public TArtifact Artifact { get; }
+
+    /// <summary>Structured conversion diagnostics in emission order.</summary>
+    public HtmlDiagnosticReport Diagnostics { get; } = new HtmlDiagnosticReport();
+
+    /// <summary>Whether conversion completed without an error diagnostic.</summary>
+    public bool Succeeded => !Diagnostics.HasErrors;
+
+    /// <summary>
+    /// Returns the native artifact when conversion succeeded, or throws a structured conversion exception.
+    /// </summary>
+    public TArtifact GetArtifactOrThrow() {
+        if (!Succeeded) {
+            throw new HtmlConversionException(Diagnostics.Diagnostics);
+        }
+
+        return Artifact;
+    }
+}

--- a/OfficeIMO.Html/Engine/HtmlInputTrust.cs
+++ b/OfficeIMO.Html/Engine/HtmlInputTrust.cs
@@ -1,0 +1,16 @@
+namespace OfficeIMO.Html;
+
+/// <summary>
+/// Declares the caller-assigned trust boundary for HTML input independently from conversion fidelity.
+/// </summary>
+public enum HtmlInputTrust {
+    /// <summary>
+    /// Input is not trusted; adapters should use bounded, offline-safe resource defaults.
+    /// </summary>
+    Untrusted,
+
+    /// <summary>
+    /// Input is trusted by the caller; adapters may enable document-provided resources within their configured policies.
+    /// </summary>
+    Trusted
+}

--- a/OfficeIMO.Html/Parsing/HtmlDocumentParser.cs
+++ b/OfficeIMO.Html/Parsing/HtmlDocumentParser.cs
@@ -18,6 +18,15 @@ public static class HtmlDocumentParser {
     }
 
     /// <summary>
+    /// Creates a deep DOM clone so a target adapter can safely apply local transformations without reparsing text.
+    /// </summary>
+    public static IHtmlDocument CloneDocument(IHtmlDocument document) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        return document.Clone(true) as IHtmlDocument
+            ?? throw new InvalidOperationException("The HTML DOM implementation did not produce a document clone.");
+    }
+
+    /// <summary>
     /// Resolves the effective base URI from a parsed document and optional caller-provided fallback.
     /// </summary>
     public static Uri? ResolveEffectiveBaseUri(IHtmlDocument document, Uri? fallbackBaseUri) {

--- a/OfficeIMO.Html/Parsing/HtmlTextIO.cs
+++ b/OfficeIMO.Html/Parsing/HtmlTextIO.cs
@@ -1,0 +1,67 @@
+namespace OfficeIMO.Html;
+
+/// <summary>
+/// Consistent UTF-8 text I/O for OfficeIMO HTML adapters. The default encoding is UTF-8 without a byte-order mark.
+/// </summary>
+public static class HtmlTextIO {
+    private static readonly Encoding Utf8NoBom = new UTF8Encoding(false);
+
+    /// <summary>Reads HTML text while detecting a byte-order mark and leaving the source stream open.</summary>
+    public static string Read(Stream stream) {
+        ValidateReadable(stream);
+        using var reader = new StreamReader(stream, Utf8NoBom, true, 4096, true);
+        return reader.ReadToEnd();
+    }
+
+    /// <summary>Asynchronously reads HTML text while leaving the source stream open.</summary>
+    public static async Task<string> ReadAsync(Stream stream, CancellationToken cancellationToken = default) {
+        ValidateReadable(stream);
+        cancellationToken.ThrowIfCancellationRequested();
+        using var reader = new StreamReader(stream, Utf8NoBom, true, 4096, true);
+#if NET8_0_OR_GREATER
+        return await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+#else
+        string text = await reader.ReadToEndAsync().ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+        return text;
+#endif
+    }
+
+    /// <summary>Writes HTML text to a file as UTF-8 without a byte-order mark.</summary>
+    public static void Write(string path, string html) {
+        if (string.IsNullOrWhiteSpace(path)) throw new ArgumentException("An HTML output path is required.", nameof(path));
+        File.WriteAllBytes(path, Utf8NoBom.GetBytes(html ?? throw new ArgumentNullException(nameof(html))));
+    }
+
+    /// <summary>Writes HTML text to a stream as UTF-8 without a byte-order mark and leaves it open.</summary>
+    public static void Write(Stream stream, string html) {
+        ValidateWritable(stream);
+        byte[] bytes = Utf8NoBom.GetBytes(html ?? throw new ArgumentNullException(nameof(html)));
+        stream.Write(bytes, 0, bytes.Length);
+    }
+
+    /// <summary>Asynchronously writes HTML text to a file as UTF-8 without a byte-order mark.</summary>
+    public static async Task WriteAsync(string path, string html, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(path)) throw new ArgumentException("An HTML output path is required.", nameof(path));
+        byte[] bytes = Utf8NoBom.GetBytes(html ?? throw new ArgumentNullException(nameof(html)));
+        using var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 81920, true);
+        await stream.WriteAsync(bytes, 0, bytes.Length, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Asynchronously writes HTML text to a stream as UTF-8 without a byte-order mark and leaves it open.</summary>
+    public static async Task WriteAsync(Stream stream, string html, CancellationToken cancellationToken = default) {
+        ValidateWritable(stream);
+        byte[] bytes = Utf8NoBom.GetBytes(html ?? throw new ArgumentNullException(nameof(html)));
+        await stream.WriteAsync(bytes, 0, bytes.Length, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static void ValidateReadable(Stream stream) {
+        if (stream == null) throw new ArgumentNullException(nameof(stream));
+        if (!stream.CanRead) throw new ArgumentException("The HTML input stream must be readable.", nameof(stream));
+    }
+
+    private static void ValidateWritable(Stream stream) {
+        if (stream == null) throw new ArgumentNullException(nameof(stream));
+        if (!stream.CanWrite) throw new ArgumentException("The HTML output stream must be writable.", nameof(stream));
+    }
+}

--- a/OfficeIMO.Html/README.md
+++ b/OfficeIMO.Html/README.md
@@ -108,13 +108,16 @@ var scenario = new HtmlCapabilityGalleryScenario(
     "HTML import, DOCX validation, and round-trip export proof");
 ```
 
-`HtmlDiagnosticReport` and the capability-gallery contracts provide a common shape for HTML converters, PDF bridges, readers, tests, and future documentation generators. Format-specific packages can keep their existing compatibility APIs while also publishing shared diagnostics and artifact metadata for market-facing proof galleries.
+`HtmlDiagnosticReport` and the capability-gallery contracts provide a common shape for HTML converters, PDF bridges, readers, tests, and documentation generators.
+
+Native adapters use `HtmlConversionResult<TArtifact>` when callers need conversion evidence. Each diagnostic has a stable code, severity, and `LossKind` (`Approximation`, `Omission`, or `Failure`). Convenience methods still return the native artifact directly; they throw `HtmlConversionException` when required semantic content is missing. Result methods retain the artifact and diagnostics so applications can decide how to handle the failure.
 
 ## Conversion Document And Normalized HTML
 
 ```csharp
 var conversion = HtmlConversionDocumentBuilder.Build(html, new HtmlConversionDocumentOptions {
     Profile = HtmlConversionProfile.Document,
+    Trust = HtmlInputTrust.Untrusted,
     BaseUri = new Uri("https://example.com/reports/"),
     UrlPolicy = HtmlUrlPolicy.CreateWebOnlyProfile()
 });
@@ -124,9 +127,11 @@ var resources = conversion.ResourcePlan.GetSummary(HtmlResourceKind.Image);
 var styles = conversion.StyleSummary;
 ```
 
-`HtmlConversionDocument` is the shared conversion contract for OfficeIMO HTML workflows. It keeps the original source HTML together with the logical document model, computed-style summary, resource manifest, resource dependency plan, normalized HTML, and profile contract.
+`HtmlConversionDocument` is the shared conversion contract for OfficeIMO HTML workflows. It parses once and keeps the source DOM, policy-normalized adapter DOM, logical document model, computed-style summary, resource manifest, resource dependency plan, normalized HTML, profile contract, and caller-assigned trust boundary.
 
-Target packages can accept this shared document while keeping target-specific conversion in their owning packages. For example, `OfficeIMO.Word.Html` converts it to `WordDocument`, `OfficeIMO.Markdown.Html` converts it to `MarkdownDoc`, and `OfficeIMO.Html.Pdf` renders it directly to PDF.
+Target packages accept this shared document while keeping target-specific conversion in their owning packages. The prepared DOM can be sent to Word, Markdown, RTF, PDF, PNG, and SVG without reparsing it for every adapter. Excel and PowerPoint accept prepared documents when the HTML contains their semantic sheet or slide envelopes.
+
+Conversion profile and trust are separate decisions. A `Document` or `HighFidelityPrint` profile does not make external resources trusted. Leave `Trust` as `Untrusted` for user-supplied HTML; set it to `Trusted` only when the caller controls the document and resource locations.
 
 Normalized HTML output is policy-aware: URL-bearing attributes are resolved against the configured base URI, disallowed URLs are removed, boolean attributes are normalized, event-handler attributes are stripped by default, and non-document executable elements are skipped. It is intended for clean review, gallery proof, and downstream adapter input selection, not for pretending OfficeIMO is a browser layout engine.
 

--- a/OfficeIMO.Html/Rendering/HtmlImageExportExtensions.Results.Sources.cs
+++ b/OfficeIMO.Html/Rendering/HtmlImageExportExtensions.Results.Sources.cs
@@ -5,35 +5,35 @@ namespace OfficeIMO.Html;
 public static partial class HtmlImageExportExtensions {
     /// <summary>Renders one selected surface from a shared HTML conversion document to PNG plus dimensions and diagnostics.</summary>
     public static OfficeImageExportResult ToPngResult(this HtmlConversionDocument document, HtmlRenderOptions? options = null, int pageIndex = 0) =>
-        GetDocument(document).ExportImage(OfficeImageExportFormat.Png, options, pageIndex);
+        GetDocument(document, options).ExportImage(OfficeImageExportFormat.Png, options, pageIndex);
 
     /// <summary>Renders one selected surface from a shared HTML conversion document to SVG plus dimensions and diagnostics.</summary>
     public static OfficeImageExportResult ToSvgResult(this HtmlConversionDocument document, HtmlRenderOptions? options = null, int pageIndex = 0) =>
-        GetDocument(document).ExportImage(OfficeImageExportFormat.Svg, options, pageIndex);
+        GetDocument(document, options).ExportImage(OfficeImageExportFormat.Svg, options, pageIndex);
 
     /// <summary>Renders all surfaces from a shared HTML conversion document to PNG results.</summary>
     public static IReadOnlyList<OfficeImageExportResult> ToPngResults(this HtmlConversionDocument document, HtmlRenderOptions? options = null) =>
-        GetDocument(document).ExportImages(OfficeImageExportFormat.Png, options);
+        GetDocument(document, options).ExportImages(OfficeImageExportFormat.Png, options);
 
     /// <summary>Renders all surfaces from a shared HTML conversion document to SVG results.</summary>
     public static IReadOnlyList<OfficeImageExportResult> ToSvgResults(this HtmlConversionDocument document, HtmlRenderOptions? options = null) =>
-        GetDocument(document).ExportImages(OfficeImageExportFormat.Svg, options);
+        GetDocument(document, options).ExportImages(OfficeImageExportFormat.Svg, options);
 
     /// <summary>Asynchronously renders one selected surface from a shared HTML conversion document to PNG plus dimensions and diagnostics.</summary>
     public static Task<OfficeImageExportResult> ToPngResultAsync(this HtmlConversionDocument document, HtmlRenderOptions? options = null, int pageIndex = 0, CancellationToken cancellationToken = default) =>
-        GetDocument(document).ExportImageAsync(OfficeImageExportFormat.Png, options, pageIndex, cancellationToken);
+        GetDocument(document, options).ExportImageAsync(OfficeImageExportFormat.Png, options, pageIndex, cancellationToken);
 
     /// <summary>Asynchronously renders one selected surface from a shared HTML conversion document to SVG plus dimensions and diagnostics.</summary>
     public static Task<OfficeImageExportResult> ToSvgResultAsync(this HtmlConversionDocument document, HtmlRenderOptions? options = null, int pageIndex = 0, CancellationToken cancellationToken = default) =>
-        GetDocument(document).ExportImageAsync(OfficeImageExportFormat.Svg, options, pageIndex, cancellationToken);
+        GetDocument(document, options).ExportImageAsync(OfficeImageExportFormat.Svg, options, pageIndex, cancellationToken);
 
     /// <summary>Asynchronously renders all surfaces from a shared HTML conversion document to PNG results.</summary>
     public static Task<IReadOnlyList<OfficeImageExportResult>> ToPngResultsAsync(this HtmlConversionDocument document, HtmlRenderOptions? options = null, CancellationToken cancellationToken = default) =>
-        GetDocument(document).ExportImagesAsync(OfficeImageExportFormat.Png, options, cancellationToken);
+        GetDocument(document, options).ExportImagesAsync(OfficeImageExportFormat.Png, options, cancellationToken);
 
     /// <summary>Asynchronously renders all surfaces from a shared HTML conversion document to SVG results.</summary>
     public static Task<IReadOnlyList<OfficeImageExportResult>> ToSvgResultsAsync(this HtmlConversionDocument document, HtmlRenderOptions? options = null, CancellationToken cancellationToken = default) =>
-        GetDocument(document).ExportImagesAsync(OfficeImageExportFormat.Svg, options, cancellationToken);
+        GetDocument(document, options).ExportImagesAsync(OfficeImageExportFormat.Svg, options, cancellationToken);
 
     /// <summary>Reads UTF-8 HTML and renders one selected surface to PNG plus dimensions and diagnostics.</summary>
     public static OfficeImageExportResult ToPngResult(this Stream htmlStream, HtmlRenderOptions? options = null, int pageIndex = 0) =>

--- a/OfficeIMO.Html/Rendering/HtmlImageExportExtensions.Results.Sources.cs
+++ b/OfficeIMO.Html/Rendering/HtmlImageExportExtensions.Results.Sources.cs
@@ -5,35 +5,35 @@ namespace OfficeIMO.Html;
 public static partial class HtmlImageExportExtensions {
     /// <summary>Renders one selected surface from a shared HTML conversion document to PNG plus dimensions and diagnostics.</summary>
     public static OfficeImageExportResult ToPngResult(this HtmlConversionDocument document, HtmlRenderOptions? options = null, int pageIndex = 0) =>
-        GetHtml(document).ToPngResult(options, pageIndex);
+        GetDocument(document).ExportImage(OfficeImageExportFormat.Png, options, pageIndex);
 
     /// <summary>Renders one selected surface from a shared HTML conversion document to SVG plus dimensions and diagnostics.</summary>
     public static OfficeImageExportResult ToSvgResult(this HtmlConversionDocument document, HtmlRenderOptions? options = null, int pageIndex = 0) =>
-        GetHtml(document).ToSvgResult(options, pageIndex);
+        GetDocument(document).ExportImage(OfficeImageExportFormat.Svg, options, pageIndex);
 
     /// <summary>Renders all surfaces from a shared HTML conversion document to PNG results.</summary>
     public static IReadOnlyList<OfficeImageExportResult> ToPngResults(this HtmlConversionDocument document, HtmlRenderOptions? options = null) =>
-        GetHtml(document).ToPngResults(options);
+        GetDocument(document).ExportImages(OfficeImageExportFormat.Png, options);
 
     /// <summary>Renders all surfaces from a shared HTML conversion document to SVG results.</summary>
     public static IReadOnlyList<OfficeImageExportResult> ToSvgResults(this HtmlConversionDocument document, HtmlRenderOptions? options = null) =>
-        GetHtml(document).ToSvgResults(options);
+        GetDocument(document).ExportImages(OfficeImageExportFormat.Svg, options);
 
     /// <summary>Asynchronously renders one selected surface from a shared HTML conversion document to PNG plus dimensions and diagnostics.</summary>
     public static Task<OfficeImageExportResult> ToPngResultAsync(this HtmlConversionDocument document, HtmlRenderOptions? options = null, int pageIndex = 0, CancellationToken cancellationToken = default) =>
-        GetHtml(document).ToPngResultAsync(options, pageIndex, cancellationToken);
+        GetDocument(document).ExportImageAsync(OfficeImageExportFormat.Png, options, pageIndex, cancellationToken);
 
     /// <summary>Asynchronously renders one selected surface from a shared HTML conversion document to SVG plus dimensions and diagnostics.</summary>
     public static Task<OfficeImageExportResult> ToSvgResultAsync(this HtmlConversionDocument document, HtmlRenderOptions? options = null, int pageIndex = 0, CancellationToken cancellationToken = default) =>
-        GetHtml(document).ToSvgResultAsync(options, pageIndex, cancellationToken);
+        GetDocument(document).ExportImageAsync(OfficeImageExportFormat.Svg, options, pageIndex, cancellationToken);
 
     /// <summary>Asynchronously renders all surfaces from a shared HTML conversion document to PNG results.</summary>
     public static Task<IReadOnlyList<OfficeImageExportResult>> ToPngResultsAsync(this HtmlConversionDocument document, HtmlRenderOptions? options = null, CancellationToken cancellationToken = default) =>
-        GetHtml(document).ToPngResultsAsync(options, cancellationToken);
+        GetDocument(document).ExportImagesAsync(OfficeImageExportFormat.Png, options, cancellationToken);
 
     /// <summary>Asynchronously renders all surfaces from a shared HTML conversion document to SVG results.</summary>
     public static Task<IReadOnlyList<OfficeImageExportResult>> ToSvgResultsAsync(this HtmlConversionDocument document, HtmlRenderOptions? options = null, CancellationToken cancellationToken = default) =>
-        GetHtml(document).ToSvgResultsAsync(options, cancellationToken);
+        GetDocument(document).ExportImagesAsync(OfficeImageExportFormat.Svg, options, cancellationToken);
 
     /// <summary>Reads UTF-8 HTML and renders one selected surface to PNG plus dimensions and diagnostics.</summary>
     public static OfficeImageExportResult ToPngResult(this Stream htmlStream, HtmlRenderOptions? options = null, int pageIndex = 0) =>

--- a/OfficeIMO.Html/Rendering/HtmlImageExportExtensions.Sources.cs
+++ b/OfficeIMO.Html/Rendering/HtmlImageExportExtensions.Sources.cs
@@ -99,9 +99,10 @@ public static partial class HtmlImageExportExtensions {
     public static async Task SaveAsSvgAsync(this Stream htmlStream, Stream svgStream, HtmlRenderOptions? options = null, int pageIndex = 0, CancellationToken cancellationToken = default) =>
         await (await ReadHtmlAsync(htmlStream, cancellationToken).ConfigureAwait(false)).SaveAsSvgAsync(svgStream, options, pageIndex, cancellationToken).ConfigureAwait(false);
 
-    private static AngleSharp.Html.Dom.IHtmlDocument GetDocument(HtmlConversionDocument document) {
+    private static AngleSharp.Html.Dom.IHtmlDocument GetDocument(HtmlConversionDocument document, HtmlRenderOptions? options) {
         if (document == null) throw new ArgumentNullException(nameof(document));
-        return document.DocumentForConversion;
+        HtmlCssMediaContext mediaContext = options?.MediaContext ?? HtmlCssMediaContext.Screen;
+        return document.CreateDocumentForConversion(mediaContext);
     }
 
     private static async Task<byte[]> ToPngDocumentAsync(HtmlConversionDocument document, HtmlRenderOptions? options, int pageIndex, CancellationToken cancellationToken) =>

--- a/OfficeIMO.Html/Rendering/HtmlImageExportExtensions.Sources.cs
+++ b/OfficeIMO.Html/Rendering/HtmlImageExportExtensions.Sources.cs
@@ -5,11 +5,11 @@ namespace OfficeIMO.Html;
 public static partial class HtmlImageExportExtensions {
     /// <summary>Renders a shared HTML conversion document to PNG bytes.</summary>
     public static byte[] ToPng(this HtmlConversionDocument document, HtmlRenderOptions? options = null, int pageIndex = 0) =>
-        GetHtml(document).ToPng(options, pageIndex);
+        document.ToPngResult(options, pageIndex).Bytes;
 
     /// <summary>Renders a shared HTML conversion document to SVG text.</summary>
     public static string ToSvg(this HtmlConversionDocument document, HtmlRenderOptions? options = null, int pageIndex = 0) =>
-        GetHtml(document).ToSvg(options, pageIndex);
+        Encoding.UTF8.GetString(document.ToSvgResult(options, pageIndex).Bytes);
 
     /// <summary>Reads UTF-8 HTML from a stream and renders it to PNG bytes.</summary>
     public static byte[] ToPng(this Stream htmlStream, HtmlRenderOptions? options = null, int pageIndex = 0) =>
@@ -21,11 +21,11 @@ public static partial class HtmlImageExportExtensions {
 
     /// <summary>Asynchronously renders a shared HTML conversion document to PNG bytes.</summary>
     public static Task<byte[]> ToPngAsync(this HtmlConversionDocument document, HtmlRenderOptions? options = null, int pageIndex = 0, CancellationToken cancellationToken = default) =>
-        GetHtml(document).ToPngAsync(options, pageIndex, cancellationToken);
+        ToPngDocumentAsync(document, options, pageIndex, cancellationToken);
 
     /// <summary>Asynchronously renders a shared HTML conversion document to SVG text.</summary>
     public static Task<string> ToSvgAsync(this HtmlConversionDocument document, HtmlRenderOptions? options = null, int pageIndex = 0, CancellationToken cancellationToken = default) =>
-        GetHtml(document).ToSvgAsync(options, pageIndex, cancellationToken);
+        ToSvgDocumentAsync(document, options, pageIndex, cancellationToken);
 
     /// <summary>Asynchronously reads UTF-8 HTML from a stream and renders it to PNG bytes.</summary>
     public static async Task<byte[]> ToPngAsync(this Stream htmlStream, HtmlRenderOptions? options = null, int pageIndex = 0, CancellationToken cancellationToken = default) =>
@@ -37,19 +37,19 @@ public static partial class HtmlImageExportExtensions {
 
     /// <summary>Saves a shared HTML conversion document as a PNG file.</summary>
     public static void SaveAsPng(this HtmlConversionDocument document, string path, HtmlRenderOptions? options = null, int pageIndex = 0) =>
-        GetHtml(document).SaveAsPng(path, options, pageIndex);
+        WriteFile(path, document.ToPng(options, pageIndex));
 
     /// <summary>Saves a shared HTML conversion document as an SVG file.</summary>
     public static void SaveAsSvg(this HtmlConversionDocument document, string path, HtmlRenderOptions? options = null, int pageIndex = 0) =>
-        GetHtml(document).SaveAsSvg(path, options, pageIndex);
+        WriteFile(path, Encoding.UTF8.GetBytes(document.ToSvg(options, pageIndex)));
 
     /// <summary>Writes a shared HTML conversion document as PNG to a stream.</summary>
     public static void SaveAsPng(this HtmlConversionDocument document, Stream stream, HtmlRenderOptions? options = null, int pageIndex = 0) =>
-        GetHtml(document).SaveAsPng(stream, options, pageIndex);
+        WriteStream(stream, document.ToPng(options, pageIndex));
 
     /// <summary>Writes a shared HTML conversion document as SVG to a stream.</summary>
     public static void SaveAsSvg(this HtmlConversionDocument document, Stream stream, HtmlRenderOptions? options = null, int pageIndex = 0) =>
-        GetHtml(document).SaveAsSvg(stream, options, pageIndex);
+        WriteStream(stream, Encoding.UTF8.GetBytes(document.ToSvg(options, pageIndex)));
 
     /// <summary>Reads UTF-8 HTML from a stream and saves it as a PNG file.</summary>
     public static void SaveAsPng(this Stream htmlStream, string path, HtmlRenderOptions? options = null, int pageIndex = 0) =>
@@ -69,19 +69,19 @@ public static partial class HtmlImageExportExtensions {
 
     /// <summary>Asynchronously saves a shared HTML conversion document as a PNG file.</summary>
     public static Task SaveAsPngAsync(this HtmlConversionDocument document, string path, HtmlRenderOptions? options = null, int pageIndex = 0, CancellationToken cancellationToken = default) =>
-        GetHtml(document).SaveAsPngAsync(path, options, pageIndex, cancellationToken);
+        SaveDocumentPngAsync(document, path, options, pageIndex, cancellationToken);
 
     /// <summary>Asynchronously saves a shared HTML conversion document as an SVG file.</summary>
     public static Task SaveAsSvgAsync(this HtmlConversionDocument document, string path, HtmlRenderOptions? options = null, int pageIndex = 0, CancellationToken cancellationToken = default) =>
-        GetHtml(document).SaveAsSvgAsync(path, options, pageIndex, cancellationToken);
+        SaveDocumentSvgAsync(document, path, options, pageIndex, cancellationToken);
 
     /// <summary>Asynchronously writes a shared HTML conversion document as PNG to a stream.</summary>
     public static Task SaveAsPngAsync(this HtmlConversionDocument document, Stream stream, HtmlRenderOptions? options = null, int pageIndex = 0, CancellationToken cancellationToken = default) =>
-        GetHtml(document).SaveAsPngAsync(stream, options, pageIndex, cancellationToken);
+        SaveDocumentPngAsync(document, stream, options, pageIndex, cancellationToken);
 
     /// <summary>Asynchronously writes a shared HTML conversion document as SVG to a stream.</summary>
     public static Task SaveAsSvgAsync(this HtmlConversionDocument document, Stream stream, HtmlRenderOptions? options = null, int pageIndex = 0, CancellationToken cancellationToken = default) =>
-        GetHtml(document).SaveAsSvgAsync(stream, options, pageIndex, cancellationToken);
+        SaveDocumentSvgAsync(document, stream, options, pageIndex, cancellationToken);
 
     /// <summary>Asynchronously reads UTF-8 HTML and saves it as a PNG file.</summary>
     public static async Task SaveAsPngAsync(this Stream htmlStream, string path, HtmlRenderOptions? options = null, int pageIndex = 0, CancellationToken cancellationToken = default) =>
@@ -99,10 +99,28 @@ public static partial class HtmlImageExportExtensions {
     public static async Task SaveAsSvgAsync(this Stream htmlStream, Stream svgStream, HtmlRenderOptions? options = null, int pageIndex = 0, CancellationToken cancellationToken = default) =>
         await (await ReadHtmlAsync(htmlStream, cancellationToken).ConfigureAwait(false)).SaveAsSvgAsync(svgStream, options, pageIndex, cancellationToken).ConfigureAwait(false);
 
-    private static string GetHtml(HtmlConversionDocument document) {
+    private static AngleSharp.Html.Dom.IHtmlDocument GetDocument(HtmlConversionDocument document) {
         if (document == null) throw new ArgumentNullException(nameof(document));
-        return document.HtmlForConversion;
+        return document.DocumentForConversion;
     }
+
+    private static async Task<byte[]> ToPngDocumentAsync(HtmlConversionDocument document, HtmlRenderOptions? options, int pageIndex, CancellationToken cancellationToken) =>
+        (await document.ToPngResultAsync(options, pageIndex, cancellationToken).ConfigureAwait(false)).Bytes;
+
+    private static async Task<string> ToSvgDocumentAsync(HtmlConversionDocument document, HtmlRenderOptions? options, int pageIndex, CancellationToken cancellationToken) =>
+        Encoding.UTF8.GetString((await document.ToSvgResultAsync(options, pageIndex, cancellationToken).ConfigureAwait(false)).Bytes);
+
+    private static async Task SaveDocumentPngAsync(HtmlConversionDocument document, string path, HtmlRenderOptions? options, int pageIndex, CancellationToken cancellationToken) =>
+        await WriteFileAsync(path, await document.ToPngAsync(options, pageIndex, cancellationToken).ConfigureAwait(false), cancellationToken).ConfigureAwait(false);
+
+    private static async Task SaveDocumentSvgAsync(HtmlConversionDocument document, string path, HtmlRenderOptions? options, int pageIndex, CancellationToken cancellationToken) =>
+        await WriteFileAsync(path, Encoding.UTF8.GetBytes(await document.ToSvgAsync(options, pageIndex, cancellationToken).ConfigureAwait(false)), cancellationToken).ConfigureAwait(false);
+
+    private static async Task SaveDocumentPngAsync(HtmlConversionDocument document, Stream stream, HtmlRenderOptions? options, int pageIndex, CancellationToken cancellationToken) =>
+        await WriteStreamAsync(stream, await document.ToPngAsync(options, pageIndex, cancellationToken).ConfigureAwait(false), cancellationToken).ConfigureAwait(false);
+
+    private static async Task SaveDocumentSvgAsync(HtmlConversionDocument document, Stream stream, HtmlRenderOptions? options, int pageIndex, CancellationToken cancellationToken) =>
+        await WriteStreamAsync(stream, Encoding.UTF8.GetBytes(await document.ToSvgAsync(options, pageIndex, cancellationToken).ConfigureAwait(false)), cancellationToken).ConfigureAwait(false);
 
     private static string ReadHtml(Stream htmlStream) {
         if (htmlStream == null) throw new ArgumentNullException(nameof(htmlStream));

--- a/OfficeIMO.Html/Rendering/HtmlImageExportExtensions.cs
+++ b/OfficeIMO.Html/Rendering/HtmlImageExportExtensions.cs
@@ -1,10 +1,49 @@
 using System.Text;
+using AngleSharp.Html.Dom;
 using OfficeIMO.Drawing;
 
 namespace OfficeIMO.Html;
 
 /// <summary>Direct HTML-to-PNG and HTML-to-SVG helpers backed by the shared HTML render scene.</summary>
 public static partial class HtmlImageExportExtensions {
+    /// <summary>Exports one selected surface from a prepared HTML DOM as PNG or SVG.</summary>
+    public static OfficeImageExportResult ExportImage(this IHtmlDocument document, OfficeImageExportFormat format, HtmlRenderOptions? options = null, int pageIndex = 0) {
+        HtmlRenderOptions resolved = Normalize(options, pageIndex);
+        HtmlRenderDocument rendered = HtmlRenderEngine.Render(document, resolved);
+        if (pageIndex >= rendered.Pages.Count) throw new ArgumentOutOfRangeException(nameof(pageIndex), "The selected HTML render page does not exist.");
+        return RenderPage(rendered.Pages[pageIndex], format, resolved, rendered.Diagnostics, CancellationToken.None);
+    }
+
+    /// <summary>Exports all surfaces from a prepared HTML DOM as PNG or SVG.</summary>
+    public static IReadOnlyList<OfficeImageExportResult> ExportImages(this IHtmlDocument document, OfficeImageExportFormat format, HtmlRenderOptions? options = null) {
+        HtmlRenderOptions resolved = Normalize(options, 0);
+        HtmlRenderDocument rendered = HtmlRenderEngine.Render(document, resolved);
+        var results = new List<OfficeImageExportResult>(rendered.Pages.Count);
+        foreach (HtmlRenderPage page in rendered.Pages) results.Add(RenderPage(page, format, resolved, rendered.Diagnostics, CancellationToken.None));
+        return results.AsReadOnly();
+    }
+
+    /// <summary>Asynchronously exports one selected surface from a prepared HTML DOM.</summary>
+    public static async Task<OfficeImageExportResult> ExportImageAsync(this IHtmlDocument document, OfficeImageExportFormat format, HtmlRenderOptions? options = null, int pageIndex = 0, CancellationToken cancellationToken = default) {
+        HtmlRenderOptions resolved = Normalize(options, pageIndex);
+        HtmlRenderDocument rendered = await HtmlRenderEngine.RenderAsync(document, resolved, cancellationToken).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (pageIndex >= rendered.Pages.Count) throw new ArgumentOutOfRangeException(nameof(pageIndex), "The selected HTML render page does not exist.");
+        return RenderPage(rendered.Pages[pageIndex], format, resolved, rendered.Diagnostics, cancellationToken);
+    }
+
+    /// <summary>Asynchronously exports all surfaces from a prepared HTML DOM.</summary>
+    public static async Task<IReadOnlyList<OfficeImageExportResult>> ExportImagesAsync(this IHtmlDocument document, OfficeImageExportFormat format, HtmlRenderOptions? options = null, CancellationToken cancellationToken = default) {
+        HtmlRenderOptions resolved = Normalize(options, 0);
+        HtmlRenderDocument rendered = await HtmlRenderEngine.RenderAsync(document, resolved, cancellationToken).ConfigureAwait(false);
+        var results = new List<OfficeImageExportResult>(rendered.Pages.Count);
+        foreach (HtmlRenderPage page in rendered.Pages) {
+            cancellationToken.ThrowIfCancellationRequested();
+            results.Add(RenderPage(page, format, resolved, rendered.Diagnostics, cancellationToken));
+        }
+        return results.AsReadOnly();
+    }
+
     /// <summary>Exports one selected HTML surface as PNG or SVG.</summary>
     public static OfficeImageExportResult ExportImage(this string html, OfficeImageExportFormat format, HtmlRenderOptions? options = null, int pageIndex = 0) {
         HtmlRenderOptions resolved = Normalize(options, pageIndex);

--- a/OfficeIMO.Html/Rendering/HtmlRenderEngine.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderEngine.cs
@@ -18,6 +18,22 @@ public static class HtmlRenderEngine {
         resolved.Validate();
         HtmlRenderInputGuard.ValidateSource(html, resolved);
         IHtmlDocument document = HtmlDocumentParser.ParseDocument(html);
+        return RenderDocument(document, resolved);
+    }
+
+    /// <summary>
+    /// Renders a prepared HTML DOM without reparsing source text or mutating the caller's document.
+    /// </summary>
+    public static HtmlRenderDocument Render(IHtmlDocument document, HtmlRenderOptions? options = null) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        HtmlRenderOptions resolved = options?.Clone() ?? new HtmlRenderOptions();
+        resolved.Validate();
+        IHtmlDocument renderDocument = HtmlDocumentParser.CloneDocument(document);
+        HtmlRenderInputGuard.ValidateSource(renderDocument.DocumentElement?.OuterHtml ?? string.Empty, resolved);
+        return RenderDocument(renderDocument, resolved);
+    }
+
+    private static HtmlRenderDocument RenderDocument(IHtmlDocument document, HtmlRenderOptions resolved) {
         HtmlRenderInputGuard.ValidateDocument(document, resolved, CancellationToken.None);
         var diagnostics = new HtmlDiagnosticReport();
         var resourceOptions = new HtmlResourcePipelineOptions {
@@ -48,6 +64,23 @@ public static class HtmlRenderEngine {
         resolved.Validate();
         HtmlRenderInputGuard.ValidateSource(html, resolved);
         IHtmlDocument document = HtmlDocumentParser.ParseDocument(html);
+        return await RenderDocumentAsync(document, resolved, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Renders a prepared HTML DOM while resolving resources without reparsing or mutating the caller's document.
+    /// </summary>
+    public static async Task<HtmlRenderDocument> RenderAsync(IHtmlDocument document, HtmlRenderOptions? options = null, CancellationToken cancellationToken = default) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        cancellationToken.ThrowIfCancellationRequested();
+        HtmlRenderOptions resolved = options?.Clone() ?? new HtmlRenderOptions();
+        resolved.Validate();
+        IHtmlDocument renderDocument = HtmlDocumentParser.CloneDocument(document);
+        HtmlRenderInputGuard.ValidateSource(renderDocument.DocumentElement?.OuterHtml ?? string.Empty, resolved);
+        return await RenderDocumentAsync(renderDocument, resolved, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<HtmlRenderDocument> RenderDocumentAsync(IHtmlDocument document, HtmlRenderOptions resolved, CancellationToken cancellationToken) {
         HtmlRenderInputGuard.ValidateDocument(document, resolved, cancellationToken);
         var diagnostics = new HtmlDiagnosticReport();
         var resourceOptions = new HtmlResourcePipelineOptions {

--- a/OfficeIMO.Html/Rendering/HtmlRenderOptions.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderOptions.cs
@@ -85,8 +85,11 @@ public class HtmlRenderOptions : OfficeImageExportOptions {
     /// <summary>Maximum element nesting depth processed by the layout engine.</summary>
     public int MaxLayoutDepth { get; set; } = 256;
 
-    /// <summary>Maximum UTF-16 characters accepted in the source HTML string.</summary>
-    public int MaxInputCharacters { get; set; } = 16 * 1024 * 1024;
+    /// <summary>
+    /// Maximum UTF-16 characters accepted in the source HTML string. The default leaves enough room for
+    /// the default total resource budget when resources are embedded as base64 data URIs.
+    /// </summary>
+    public int MaxInputCharacters { get; set; } = 72 * 1024 * 1024;
 
     /// <summary>Maximum DOM nodes accepted after parsing and before style or layout work begins.</summary>
     public int MaxHtmlNodes { get; set; } = 100000;

--- a/OfficeIMO.Html/Rtf/HtmlRtfConversionReportMapper.cs
+++ b/OfficeIMO.Html/Rtf/HtmlRtfConversionReportMapper.cs
@@ -17,6 +17,23 @@ internal static class HtmlRtfConversionReportMapper {
             detail: diagnostic.Detail);
     }
 
+    public static void Add(HtmlDiagnosticReport report, HtmlRtfConversionDiagnostic diagnostic) {
+        HtmlDiagnosticSeverity severity = diagnostic.Severity == HtmlRtfConversionDiagnosticSeverity.Error
+            ? HtmlDiagnosticSeverity.Error
+            : diagnostic.Severity == HtmlRtfConversionDiagnosticSeverity.Warning
+                ? HtmlDiagnosticSeverity.Warning
+                : HtmlDiagnosticSeverity.Info;
+        RtfConversionAction action = GetAction(diagnostic);
+        HtmlConversionLossKind lossKind = diagnostic.Severity == HtmlRtfConversionDiagnosticSeverity.Error
+            ? HtmlConversionLossKind.Failure
+            : action == RtfConversionAction.Substituted
+                ? HtmlConversionLossKind.Approximation
+                : action == RtfConversionAction.Omitted || action == RtfConversionAction.Blocked
+                    ? HtmlConversionLossKind.Omission
+                    : HtmlConversionLossKind.None;
+        report.Add("OfficeIMO.Html.Rtf", diagnostic.Code, diagnostic.Message, severity, diagnostic.Source, diagnostic.Detail, lossKind);
+    }
+
     private static RtfConversionAction GetAction(HtmlRtfConversionDiagnostic diagnostic) {
         if (diagnostic.Severity == HtmlRtfConversionDiagnosticSeverity.Info) return RtfConversionAction.Preserved;
         if (diagnostic.Code.IndexOf("Rejected", StringComparison.OrdinalIgnoreCase) >= 0 ||

--- a/OfficeIMO.Html/Rtf/HtmlRtfConversionResults.cs
+++ b/OfficeIMO.Html/Rtf/HtmlRtfConversionResults.cs
@@ -1,0 +1,21 @@
+namespace OfficeIMO.Html;
+
+/// <summary>RTF document plus structured diagnostics from HTML import.</summary>
+public sealed class HtmlToRtfResult : HtmlConversionResult<RtfDocument> {
+    internal HtmlToRtfResult(RtfDocument document, IEnumerable<HtmlDiagnostic> diagnostics) : base(document) {
+        Diagnostics.AddRange(diagnostics);
+    }
+
+    /// <summary>Imported RTF document.</summary>
+    public RtfDocument Document => Artifact;
+}
+
+/// <summary>Semantic HTML plus structured diagnostics from RTF export.</summary>
+public sealed class RtfToHtmlResult : HtmlConversionResult<string> {
+    internal RtfToHtmlResult(string html, IEnumerable<HtmlDiagnostic> diagnostics) : base(html) {
+        Diagnostics.AddRange(diagnostics);
+    }
+
+    /// <summary>Exported semantic HTML.</summary>
+    public string Html => Artifact;
+}

--- a/OfficeIMO.Html/Rtf/HtmlRtfConverterExtensions.Results.cs
+++ b/OfficeIMO.Html/Rtf/HtmlRtfConverterExtensions.Results.cs
@@ -1,0 +1,30 @@
+namespace OfficeIMO.Html;
+
+public static partial class HtmlRtfConverterExtensions {
+    /// <summary>Imports HTML into RTF and returns structured conversion evidence.</summary>
+    public static HtmlToRtfResult ToRtfDocumentResult(this string html, HtmlToRtfOptions? options = null) {
+        if (html == null) throw new ArgumentNullException(nameof(html));
+        HtmlToRtfOptions resolved = options ?? new HtmlToRtfOptions();
+        int diagnosticStart = resolved.HtmlDiagnostics.Count;
+        RtfDocument document = RtfHtmlReader.Read(html, resolved);
+        return new HtmlToRtfResult(document, resolved.HtmlDiagnostics.Skip(diagnosticStart));
+    }
+
+    /// <summary>Imports a prepared shared HTML document into RTF and returns structured evidence.</summary>
+    public static HtmlToRtfResult ToRtfDocumentResult(this HtmlConversionDocument document, HtmlToRtfOptions? options = null) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        HtmlToRtfOptions resolved = options ?? new HtmlToRtfOptions();
+        int diagnosticStart = resolved.HtmlDiagnostics.Count;
+        RtfDocument rtfDocument = RtfHtmlReader.Read(document.DocumentForConversion, resolved);
+        return new HtmlToRtfResult(rtfDocument, resolved.HtmlDiagnostics.Skip(diagnosticStart));
+    }
+
+    /// <summary>Exports RTF to semantic HTML and returns structured conversion evidence.</summary>
+    public static RtfToHtmlResult ToHtmlResult(this RtfDocument document, RtfToHtmlOptions? options = null) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        RtfToHtmlOptions resolved = options ?? new RtfToHtmlOptions();
+        int diagnosticStart = resolved.HtmlDiagnostics.Count;
+        string html = document.ToHtml(resolved);
+        return new RtfToHtmlResult(html, resolved.HtmlDiagnostics.Skip(diagnosticStart));
+    }
+}

--- a/OfficeIMO.Html/Rtf/HtmlRtfConverterExtensions.cs
+++ b/OfficeIMO.Html/Rtf/HtmlRtfConverterExtensions.cs
@@ -77,6 +77,12 @@ public static partial class HtmlRtfConverterExtensions {
         return RtfHtmlReader.Read(html, options ?? new HtmlToRtfOptions());
     }
 
+    /// <summary>Loads a prepared shared HTML conversion document into an RTF document model without reparsing.</summary>
+    public static RtfDocument ToRtfDocument(this HtmlConversionDocument document, HtmlToRtfOptions? options = null) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        return RtfHtmlReader.Read(document.DocumentForConversion, options ?? new HtmlToRtfOptions());
+    }
+
     /// <summary>Loads encoded semantic HTML bytes into an RTF document model.</summary>
     public static RtfDocument ToRtfDocument(this byte[] htmlBytes, HtmlToRtfOptions? options = null, Encoding? encoding = null) {
         if (htmlBytes == null) {

--- a/OfficeIMO.Html/Rtf/HtmlToRtfOptions.Diagnostics.cs
+++ b/OfficeIMO.Html/Rtf/HtmlToRtfOptions.Diagnostics.cs
@@ -9,6 +9,7 @@ public sealed partial class HtmlToRtfOptions {
         var diagnostic = new HtmlRtfConversionDiagnostic(code, message, severity, source, detail);
         Diagnostics.Add(diagnostic);
         HtmlRtfConversionReportMapper.Add(ConversionReport, diagnostic);
+        HtmlRtfConversionReportMapper.Add(HtmlDiagnostics, diagnostic);
         DiagnosticHandler?.Invoke(diagnostic);
     }
 
@@ -16,6 +17,7 @@ public sealed partial class HtmlToRtfOptions {
         if (diagnostic == null) throw new ArgumentNullException(nameof(diagnostic));
         Diagnostics.Add(diagnostic);
         HtmlRtfConversionReportMapper.Add(ConversionReport, diagnostic);
+        HtmlRtfConversionReportMapper.Add(HtmlDiagnostics, diagnostic);
         DiagnosticHandler?.Invoke(diagnostic);
     }
 }

--- a/OfficeIMO.Html/Rtf/HtmlToRtfOptions.cs
+++ b/OfficeIMO.Html/Rtf/HtmlToRtfOptions.cs
@@ -58,6 +58,9 @@ public sealed partial class HtmlToRtfOptions {
     /// <summary>Shared cross-adapter fidelity and policy report for this conversion.</summary>
     public RtfConversionReport ConversionReport { get; } = new RtfConversionReport();
 
+    /// <summary>Shared HTML diagnostic report for cross-format aggregation.</summary>
+    public HtmlDiagnosticReport HtmlDiagnostics { get; } = new HtmlDiagnosticReport();
+
     /// <summary>
     /// Optional callback invoked whenever a conversion diagnostic is produced.
     /// </summary>

--- a/OfficeIMO.Html/Rtf/Internal/RtfHtmlReader.Dom.cs
+++ b/OfficeIMO.Html/Rtf/Internal/RtfHtmlReader.Dom.cs
@@ -6,6 +6,10 @@ namespace OfficeIMO.Html;
 internal static partial class RtfHtmlReader {
     private static void ReadDom(string html, HtmlToRtfOptions options, RtfDocument document) {
         IHtmlDocument htmlDocument = HtmlDocumentParser.ParseDocument(html);
+        ReadDom(htmlDocument, options, document);
+    }
+
+    private static void ReadDom(IHtmlDocument htmlDocument, HtmlToRtfOptions options, RtfDocument document) {
         Uri? effectiveBaseUri = HtmlDocumentParser.ResolveEffectiveBaseUri(htmlDocument, options.BaseUri);
         var context = new ReadContext(document, options, effectiveBaseUri);
         HtmlDomLimitTracker? limits = HtmlDomLimitTracker.Create(options.MaxHtmlNodes, options.MaxHtmlDepth);

--- a/OfficeIMO.Html/Rtf/Internal/RtfHtmlReader.cs
+++ b/OfficeIMO.Html/Rtf/Internal/RtfHtmlReader.cs
@@ -1,9 +1,17 @@
+using AngleSharp.Html.Dom;
+
 namespace OfficeIMO.Html;
 
 internal static partial class RtfHtmlReader {
     internal static RtfDocument Read(string html, HtmlToRtfOptions options) {
         RtfDocument document = RtfDocument.Create();
         ReadDom(html, options, document);
+        return document;
+    }
+
+    internal static RtfDocument Read(IHtmlDocument htmlDocument, HtmlToRtfOptions options) {
+        RtfDocument document = RtfDocument.Create();
+        ReadDom(htmlDocument, options, document);
         return document;
     }
 

--- a/OfficeIMO.Html/Rtf/RtfToHtmlOptions.cs
+++ b/OfficeIMO.Html/Rtf/RtfToHtmlOptions.cs
@@ -71,6 +71,9 @@ public sealed partial class RtfToHtmlOptions {
     /// <summary>Shared cross-adapter fidelity and policy report for this conversion.</summary>
     public RtfConversionReport ConversionReport { get; } = new RtfConversionReport();
 
+    /// <summary>Shared HTML diagnostic report for cross-format aggregation.</summary>
+    public HtmlDiagnosticReport HtmlDiagnostics { get; } = new HtmlDiagnosticReport();
+
     /// <summary>
     /// Optional callback invoked whenever a conversion diagnostic is produced.
     /// </summary>
@@ -103,6 +106,7 @@ public sealed partial class RtfToHtmlOptions {
         var diagnostic = new HtmlRtfConversionDiagnostic(code, message, severity, source, detail);
         Diagnostics.Add(diagnostic);
         HtmlRtfConversionReportMapper.Add(ConversionReport, diagnostic);
+        HtmlRtfConversionReportMapper.Add(HtmlDiagnostics, diagnostic);
         DiagnosticHandler?.Invoke(diagnostic);
     }
 }

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.cs
@@ -33,6 +33,14 @@ public sealed partial class HtmlToMarkdownConverter {
     }
 
     /// <summary>
+    /// Converts a prepared HTML DOM into Markdown text without reparsing source text.
+    /// </summary>
+    public string Convert(IHtmlDocument document, HtmlToMarkdownOptions? options = null) {
+        var effectiveOptions = options?.Clone() ?? new HtmlToMarkdownOptions();
+        return ConvertToDocument(document, effectiveOptions).ToMarkdown(effectiveOptions.MarkdownWriteOptions);
+    }
+
+    /// <summary>
     /// Converts HTML into a Markdown document model.
     /// </summary>
     /// <param name="html">HTML fragment or document to convert.</param>
@@ -46,6 +54,23 @@ public sealed partial class HtmlToMarkdownConverter {
         if (html == null) throw new ArgumentNullException(nameof(html));
         var effectiveOptions = options?.Clone() ?? new HtmlToMarkdownOptions();
         IHtmlDocument document = ParseFilteredDocumentCore(html, effectiveOptions);
+        return ConvertFilteredDocument(document, effectiveOptions);
+    }
+
+    /// <summary>
+    /// Converts a prepared HTML DOM into a Markdown document without mutating the caller's DOM.
+    /// </summary>
+    public MarkdownDoc ConvertToDocument(IHtmlDocument document, HtmlToMarkdownOptions? options = null) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        var effectiveOptions = options?.Clone() ?? new HtmlToMarkdownOptions();
+        IHtmlDocument filteredDocument = HtmlDocumentParser.CloneDocument(document);
+        string source = filteredDocument.DocumentElement?.OuterHtml ?? string.Empty;
+        ValidateInputLength(source, effectiveOptions.MaxInputCharacters, nameof(document));
+        ApplyHtmlFilters(filteredDocument.DocumentElement, effectiveOptions);
+        return ConvertFilteredDocument(filteredDocument, effectiveOptions);
+    }
+
+    private MarkdownDoc ConvertFilteredDocument(IHtmlDocument document, HtmlToMarkdownOptions effectiveOptions) {
         effectiveOptions.BaseUri = HtmlDocumentParser.ResolveEffectiveBaseUri(document, effectiveOptions.BaseUri);
         var context = new ConversionContext(effectiveOptions);
 

--- a/OfficeIMO.Markdown.Html/HtmlMarkdownConverterExtensions.cs
+++ b/OfficeIMO.Markdown.Html/HtmlMarkdownConverterExtensions.cs
@@ -26,7 +26,8 @@ public static class HtmlMarkdownConverterExtensions {
     /// <returns>The rendered Markdown text.</returns>
     public static string ToMarkdown(this HtmlConversionDocument document, HtmlToMarkdownOptions? options = null) {
         if (document == null) throw new ArgumentNullException(nameof(document));
-        return PrepareHtmlForSharedMarkdownConversion(document).ToMarkdown(options);
+        var converter = new HtmlToMarkdownConverter();
+        return converter.Convert(document.DocumentForConversion, options);
     }
 
     /// <summary>
@@ -37,8 +38,7 @@ public static class HtmlMarkdownConverterExtensions {
     /// <returns>The rendered Markdown text.</returns>
     public static string ToMarkdown(this Stream htmlStream, HtmlToMarkdownOptions? options = null) {
         if (htmlStream == null) throw new ArgumentNullException(nameof(htmlStream));
-        using var reader = new StreamReader(htmlStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 4096, leaveOpen: true);
-        return reader.ReadToEnd().ToMarkdown(options);
+        return HtmlTextIO.Read(htmlStream).ToMarkdown(options);
     }
 
     /// <summary>
@@ -61,14 +61,8 @@ public static class HtmlMarkdownConverterExtensions {
     /// <returns>A structural <see cref="MarkdownDoc"/> representing the converted Markdown.</returns>
     public static MarkdownDoc ToMarkdownDocument(this HtmlConversionDocument document, HtmlToMarkdownOptions? options = null) {
         if (document == null) throw new ArgumentNullException(nameof(document));
-        return PrepareHtmlForSharedMarkdownConversion(document).ToMarkdownDocument(options);
-    }
-
-    private static string PrepareHtmlForSharedMarkdownConversion(HtmlConversionDocument document) {
-        HtmlCssMediaContext mediaContext = document.ProfileContract.Profile == HtmlConversionProfile.HighFidelityPrint
-            ? HtmlCssMediaContext.Print
-            : HtmlCssMediaContext.Screen;
-        return HtmlActiveMediaFilter.Filter(document.HtmlForConversion, mediaContext);
+        var converter = new HtmlToMarkdownConverter();
+        return converter.ConvertToDocument(document.DocumentForConversion, options);
     }
 
     /// <summary>
@@ -79,7 +73,6 @@ public static class HtmlMarkdownConverterExtensions {
     /// <returns>A structural <see cref="MarkdownDoc"/> representing the converted Markdown.</returns>
     public static MarkdownDoc ToMarkdownDocument(this Stream htmlStream, HtmlToMarkdownOptions? options = null) {
         if (htmlStream == null) throw new ArgumentNullException(nameof(htmlStream));
-        using var reader = new StreamReader(htmlStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 4096, leaveOpen: true);
-        return reader.ReadToEnd().ToMarkdownDocument(options);
+        return HtmlTextIO.Read(htmlStream).ToMarkdownDocument(options);
     }
 }

--- a/OfficeIMO.Markdown.Html/README.md
+++ b/OfficeIMO.Markdown.Html/README.md
@@ -21,6 +21,18 @@ string markdown = "<h1>Hello</h1><p>Body</p>".ToMarkdown();
 MarkdownDoc document = "<h1>Hello</h1><p>Body</p>".ToMarkdownDocument();
 ```
 
+For multi-target workflows, prepare HTML once and reuse its normalized DOM:
+
+```csharp
+using OfficeIMO.Html;
+
+HtmlConversionDocument source = HtmlConversionDocumentBuilder.Build(html);
+string markdown = source.ToMarkdown();
+MarkdownDoc document = source.ToMarkdownDocument();
+```
+
+String, stream, and prepared-document overloads share the same conversion behavior. Adapter-local filtering works on a clone, so converting to Markdown does not mutate the document consumed by Word, RTF, PDF, or image output.
+
 ## Options
 
 ```csharp

--- a/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.Diagnostics.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.Diagnostics.cs
@@ -1,0 +1,18 @@
+using OfficeIMO.Html;
+
+namespace OfficeIMO.PowerPoint.Html;
+
+public static partial class HtmlPowerPointConverterExtensions {
+    private const string ImportComponentName = "OfficeIMO.PowerPoint.Html";
+
+    private static void AddImportDiagnostic(
+        HtmlToPowerPointResult result,
+        string code,
+        string message,
+        HtmlDiagnosticSeverity severity = HtmlDiagnosticSeverity.Warning,
+        HtmlConversionLossKind lossKind = HtmlConversionLossKind.None,
+        string? source = null,
+        string? detail = null) {
+        result.Diagnostics.Add(ImportComponentName, code, message, severity, source, detail, lossKind);
+    }
+}

--- a/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.IO.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.IO.cs
@@ -1,0 +1,24 @@
+using OfficeIMO.Html;
+using System.Threading;
+using System.Threading.Tasks;
+using PptCore = OfficeIMO.PowerPoint;
+
+namespace OfficeIMO.PowerPoint.Html;
+
+public static partial class HtmlPowerPointConverterExtensions {
+    /// <summary>Reads semantic HTML from a stream and imports a presentation.</summary>
+    public static PptCore.PowerPointPresentation ToPowerPointPresentation(this Stream htmlStream, HtmlToPowerPointOptions? options = null) =>
+        HtmlTextIO.Read(htmlStream).ToPowerPointPresentation(options);
+
+    /// <summary>Reads semantic HTML from a stream and returns a presentation plus structured evidence.</summary>
+    public static HtmlToPowerPointResult ToPowerPointPresentationResult(this Stream htmlStream, HtmlToPowerPointOptions? options = null) =>
+        HtmlTextIO.Read(htmlStream).ToPowerPointPresentationResult(options);
+
+    /// <summary>Asynchronously reads semantic HTML from a stream and imports a presentation.</summary>
+    public static async Task<PptCore.PowerPointPresentation> ToPowerPointPresentationAsync(this Stream htmlStream, HtmlToPowerPointOptions? options = null, CancellationToken cancellationToken = default) =>
+        (await HtmlTextIO.ReadAsync(htmlStream, cancellationToken).ConfigureAwait(false)).ToPowerPointPresentation(options);
+
+    /// <summary>Asynchronously reads semantic HTML from a stream and returns structured evidence.</summary>
+    public static async Task<HtmlToPowerPointResult> ToPowerPointPresentationResultAsync(this Stream htmlStream, HtmlToPowerPointOptions? options = null, CancellationToken cancellationToken = default) =>
+        (await HtmlTextIO.ReadAsync(htmlStream, cancellationToken).ConfigureAwait(false)).ToPowerPointPresentationResult(options);
+}

--- a/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.SemanticShapes.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.SemanticShapes.cs
@@ -1,0 +1,125 @@
+using AngleSharp.Dom;
+using PptCore = OfficeIMO.PowerPoint;
+
+namespace OfficeIMO.PowerPoint.Html;
+
+public static partial class HtmlPowerPointConverterExtensions {
+    private static void ImportSemanticShapes(
+        IElement section,
+        PptCore.PowerPointSlide slide,
+        HtmlToPowerPointOptions options,
+        HtmlToPowerPointResult result) {
+        var items = new List<PowerPointSemanticImportItem>();
+        int fallbackOrder = 0;
+
+        foreach (IElement element in section.Children) {
+            if (IsElement(element, "p")) {
+                items.Add(CreateSemanticImportItem(element, PowerPointSemanticImportKind.TextBox, fallbackOrder++));
+            } else if (options.ImportTables && IsElement(element, "table")) {
+                items.Add(CreateSemanticImportItem(element, PowerPointSemanticImportKind.Table, fallbackOrder++));
+            }
+        }
+
+        if (options.ImportPictures) {
+            foreach (IElement item in section.QuerySelectorAll("section.officeimo-images li")) {
+                items.Add(CreateSemanticImportItem(item, PowerPointSemanticImportKind.Picture, fallbackOrder++));
+            }
+        }
+
+        if (options.ImportChartInventory) {
+            foreach (IElement item in section.QuerySelectorAll("section.officeimo-charts li")) {
+                items.Add(CreateSemanticImportItem(item, PowerPointSemanticImportKind.Chart, fallbackOrder++));
+            }
+        }
+
+        double contentTop = 48D;
+        double pictureTop = 140D;
+        double chartTop = 220D;
+        foreach (PowerPointSemanticImportItem item in items
+            .OrderBy(item => item.LayerIndex ?? item.FallbackOrder)
+            .ThenBy(item => item.FallbackOrder)) {
+            switch (item.Kind) {
+                case PowerPointSemanticImportKind.TextBox:
+                    contentTop = ImportSemanticTextBox(item.Element, slide, contentTop, result);
+                    break;
+                case PowerPointSemanticImportKind.Table:
+                    contentTop = ImportTable(item.Element, slide, contentTop, options, result);
+                    break;
+                case PowerPointSemanticImportKind.Picture:
+                    ImportPicture(item.Element, slide, result, ref pictureTop);
+                    break;
+                case PowerPointSemanticImportKind.Chart:
+                    ImportChart(item.Element, slide, result, ref chartTop);
+                    break;
+            }
+        }
+    }
+
+    private static PowerPointSemanticImportItem CreateSemanticImportItem(
+        IElement element,
+        PowerPointSemanticImportKind kind,
+        int fallbackOrder) =>
+        new(element, kind, ReadOptionalIntAttribute(element, "data-officeimo-layer-index"), fallbackOrder);
+
+    private static double ImportSemanticTextBox(
+        IElement paragraph,
+        PptCore.PowerPointSlide slide,
+        double fallbackTop,
+        HtmlToPowerPointResult result) {
+        string text = PreserveText(paragraph.TextContent);
+        if (text.Length == 0) {
+            return fallbackTop;
+        }
+
+        ReadSemanticShapeGeometry(paragraph, 64D, fallbackTop, 620D, 48D,
+            out double left, out double top, out double width, out double height);
+        PptCore.PowerPointTextBox textBox = slide.AddTextBoxPoints(text, left, top, width, height);
+        ApplyShapeTransforms(paragraph, textBox);
+        result.TextBoxes++;
+        return Math.Max(fallbackTop + 58D, top + height + 10D);
+    }
+
+    private static void ReadSemanticShapeGeometry(
+        IElement element,
+        double fallbackLeft,
+        double fallbackTop,
+        double fallbackWidth,
+        double fallbackHeight,
+        out double left,
+        out double top,
+        out double width,
+        out double height) {
+        left = ReadOptionalDoubleAttribute(element, "data-officeimo-left") ?? fallbackLeft;
+        top = ReadOptionalDoubleAttribute(element, "data-officeimo-top") ?? fallbackTop;
+        width = Math.Max(1D, ReadOptionalDoubleAttribute(element, "data-officeimo-width") ?? fallbackWidth);
+        height = Math.Max(1D, ReadOptionalDoubleAttribute(element, "data-officeimo-height") ?? fallbackHeight);
+    }
+
+    private sealed class PowerPointSemanticImportItem {
+        internal PowerPointSemanticImportItem(
+            IElement element,
+            PowerPointSemanticImportKind kind,
+            int? layerIndex,
+            int fallbackOrder) {
+            Element = element;
+            Kind = kind;
+            LayerIndex = layerIndex;
+            FallbackOrder = fallbackOrder;
+        }
+
+        internal IElement Element { get; }
+
+        internal PowerPointSemanticImportKind Kind { get; }
+
+        internal int? LayerIndex { get; }
+
+        internal int FallbackOrder { get; }
+    }
+
+    private enum PowerPointSemanticImportKind {
+        TextBox,
+        Table,
+        Picture,
+        Chart
+    }
+}

--- a/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.Tables.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.Tables.cs
@@ -1,0 +1,190 @@
+using AngleSharp.Dom;
+using OfficeIMO.Html;
+using PptCore = OfficeIMO.PowerPoint;
+
+namespace OfficeIMO.PowerPoint.Html;
+
+public static partial class HtmlPowerPointConverterExtensions {
+    private static double ImportTable(
+        IElement tableElement,
+        PptCore.PowerPointSlide slide,
+        double top,
+        HtmlToPowerPointOptions options,
+        HtmlToPowerPointResult result) {
+        if (options.MaxTableCells <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(options.MaxTableCells), "MaxTableCells must be greater than zero.");
+        }
+
+        PowerPointHtmlTableGrid grid = BuildTableGrid(tableElement, options.MaxTableCells, result);
+        if (grid.Rows == 0 || grid.Columns == 0) {
+            return top;
+        }
+
+        double fallbackWidth = Math.Max(240D, grid.Columns * 150D);
+        double fallbackHeight = Math.Max(70D, grid.Rows * 34D);
+        ReadSemanticShapeGeometry(tableElement, 64D, top, fallbackWidth, fallbackHeight,
+            out double left, out double tableTop, out double width, out double height);
+        PptCore.PowerPointTable table = slide.AddTablePoints(grid.Rows, grid.Columns, left, tableTop, width, height);
+        foreach (PowerPointHtmlTableCell cell in grid.Cells) {
+            table.GetCell(cell.Row, cell.Column).Text = cell.Text;
+            if (cell.RowSpan > 1 || cell.ColumnSpan > 1) {
+                table.MergeCells(cell.Row, cell.Column, cell.Row + cell.RowSpan - 1, cell.Column + cell.ColumnSpan - 1);
+                result.MergedRanges++;
+            }
+        }
+
+        ApplyShapeTransforms(tableElement, table);
+        result.Tables++;
+        return Math.Max(top + Math.Max(90D, grid.Rows * 40D), tableTop + height + 20D);
+    }
+
+    private static PowerPointHtmlTableGrid BuildTableGrid(IElement table, int maxTableCells, HtmlToPowerPointResult result) {
+        var cells = new List<PowerPointHtmlTableCell>();
+        var occupied = new HashSet<long>();
+        int rowIndex = 0;
+        int rowExtent = 0;
+        int columnExtent = 0;
+
+        foreach (IElement row in EnumerateDirectTableRows(table)) {
+            int columnIndex = 0;
+            foreach (IElement element in row.Children.Where(IsPowerPointTableCell)) {
+                while (occupied.Contains(GetTableCellKey(rowIndex, columnIndex))) {
+                    columnIndex++;
+                }
+
+                int rowSpan = ReadPowerPointSpan(element, "rowspan", result);
+                int columnSpan = ReadPowerPointSpan(element, "colspan", result);
+                if ((long)rowSpan * columnSpan > maxTableCells) {
+                    AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TargetLimitExceeded,
+                        "An HTML table span exceeded the configured MaxTableCells limit; the span was ignored.", lossKind: HtmlConversionLossKind.Approximation);
+                    rowSpan = 1;
+                    columnSpan = 1;
+                }
+
+                long candidateRowsLong = Math.Max((long)rowExtent, (long)rowIndex + rowSpan);
+                long candidateColumnsLong = Math.Max((long)columnExtent, (long)columnIndex + columnSpan);
+                if (candidateRowsLong * candidateColumnsLong > maxTableCells) {
+                    rowSpan = 1;
+                    columnSpan = 1;
+                    int candidateRows = Math.Max(rowExtent, rowIndex + 1);
+                    int candidateColumns = Math.Max(columnExtent, columnIndex + 1);
+                    if ((long)candidateRows * candidateColumns > maxTableCells) {
+                        AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TargetLimitExceeded,
+                            "HTML table exceeded the configured MaxTableCells limit; remaining cells were skipped.", lossKind: HtmlConversionLossKind.Omission);
+                        return new PowerPointHtmlTableGrid(rowExtent, columnExtent, cells);
+                    }
+
+                    AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TargetLimitExceeded,
+                        "An HTML table span exceeded the configured MaxTableCells limit; the span was ignored.", lossKind: HtmlConversionLossKind.Approximation);
+                }
+
+                if (PowerPointSpanOverlaps(occupied, rowIndex, columnIndex, rowSpan, columnSpan)) {
+                    AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TableSpanInvalid,
+                        "An HTML table cell contained an overlapping span; the span was ignored.", lossKind: HtmlConversionLossKind.Approximation);
+                    rowSpan = 1;
+                    columnSpan = 1;
+                }
+
+                ReservePowerPointSpan(occupied, rowIndex, columnIndex, rowSpan, columnSpan);
+                cells.Add(new PowerPointHtmlTableCell(
+                    rowIndex,
+                    columnIndex,
+                    rowSpan,
+                    columnSpan,
+                    PreserveText(element.TextContent)));
+                rowExtent = Math.Max(rowExtent, rowIndex + rowSpan);
+                columnExtent = Math.Max(columnExtent, columnIndex + columnSpan);
+                columnIndex += columnSpan;
+            }
+
+            rowIndex++;
+            rowExtent = Math.Max(rowExtent, rowIndex);
+            if ((long)Math.Max(1, rowExtent) * Math.Max(1, columnExtent) > maxTableCells) {
+                AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TargetLimitExceeded,
+                    "HTML table exceeded the configured MaxTableCells limit; remaining rows were skipped.", lossKind: HtmlConversionLossKind.Omission);
+                break;
+            }
+        }
+
+        return new PowerPointHtmlTableGrid(rowExtent, columnExtent, cells);
+    }
+
+    private static IEnumerable<IElement> EnumerateDirectTableRows(IElement table) {
+        foreach (IElement child in table.Children) {
+            if (IsElement(child, "tr")) {
+                yield return child;
+            } else if (IsElement(child, "thead") || IsElement(child, "tbody") || IsElement(child, "tfoot")) {
+                foreach (IElement row in child.Children.Where(element => IsElement(element, "tr"))) {
+                    yield return row;
+                }
+            }
+        }
+    }
+
+    private static bool IsPowerPointTableCell(IElement element) => IsElement(element, "th") || IsElement(element, "td");
+
+    private static int ReadPowerPointSpan(IElement cell, string attributeName, HtmlToPowerPointResult result) {
+        string? raw = cell.GetAttribute(attributeName);
+        if (string.IsNullOrWhiteSpace(raw)) {
+            return 1;
+        }
+
+        if (!int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out int span) || span <= 0) {
+            AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.TableSpanInvalid,
+                "An HTML table cell contained an invalid " + attributeName + " value; a span of 1 was used.", lossKind: HtmlConversionLossKind.Approximation);
+            return 1;
+        }
+
+        return span;
+    }
+
+    private static bool PowerPointSpanOverlaps(HashSet<long> occupied, int row, int column, int rowSpan, int columnSpan) {
+        for (int currentRow = row; currentRow < row + rowSpan; currentRow++) {
+            for (int currentColumn = column; currentColumn < column + columnSpan; currentColumn++) {
+                if (occupied.Contains(GetTableCellKey(currentRow, currentColumn))) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static void ReservePowerPointSpan(HashSet<long> occupied, int row, int column, int rowSpan, int columnSpan) {
+        for (int currentRow = row; currentRow < row + rowSpan; currentRow++) {
+            for (int currentColumn = column; currentColumn < column + columnSpan; currentColumn++) {
+                occupied.Add(GetTableCellKey(currentRow, currentColumn));
+            }
+        }
+    }
+
+    private static long GetTableCellKey(int row, int column) => ((long)row << 32) | (uint)column;
+
+    private sealed class PowerPointHtmlTableGrid {
+        internal PowerPointHtmlTableGrid(int rows, int columns, IReadOnlyList<PowerPointHtmlTableCell> cells) {
+            Rows = rows;
+            Columns = columns;
+            Cells = cells;
+        }
+
+        internal int Rows { get; }
+        internal int Columns { get; }
+        internal IReadOnlyList<PowerPointHtmlTableCell> Cells { get; }
+    }
+
+    private sealed class PowerPointHtmlTableCell {
+        internal PowerPointHtmlTableCell(int row, int column, int rowSpan, int columnSpan, string text) {
+            Row = row;
+            Column = column;
+            RowSpan = rowSpan;
+            ColumnSpan = columnSpan;
+            Text = text;
+        }
+
+        internal int Row { get; }
+        internal int Column { get; }
+        internal int RowSpan { get; }
+        internal int ColumnSpan { get; }
+        internal string Text { get; }
+    }
+}

--- a/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
@@ -9,13 +9,21 @@ namespace OfficeIMO.PowerPoint.Html;
 /// <summary>
 /// Extension methods for importing semantic OfficeIMO PowerPoint HTML.
 /// </summary>
-public static class HtmlPowerPointConverterExtensions {
+public static partial class HtmlPowerPointConverterExtensions {
     /// <summary>
     /// Imports semantic OfficeIMO PowerPoint HTML into a native presentation.
     /// </summary>
     /// <example><code>using PowerPointPresentation presentation = html.ToPowerPointPresentation();</code></example>
-    public static PptCore.PowerPointPresentation ToPowerPointPresentation(this string html, HtmlToPowerPointOptions? options = null) =>
-        ToPowerPointPresentationResult(html, options).Presentation;
+    public static PptCore.PowerPointPresentation ToPowerPointPresentation(this string html, HtmlToPowerPointOptions? options = null) {
+        return GetPresentationOrThrow(ToPowerPointPresentationResult(html, options));
+    }
+
+    /// <summary>
+    /// Imports a prepared shared HTML conversion document without reparsing its adapter DOM.
+    /// </summary>
+    public static PptCore.PowerPointPresentation ToPowerPointPresentation(this HtmlConversionDocument document, HtmlToPowerPointOptions? options = null) {
+        return GetPresentationOrThrow(ToPowerPointPresentationResult(document, options));
+    }
 
     /// <summary>
     /// Imports semantic OfficeIMO PowerPoint HTML into a native presentation and returns import evidence.
@@ -23,16 +31,26 @@ public static class HtmlPowerPointConverterExtensions {
     /// <example><code>HtmlToPowerPointResult result = html.ToPowerPointPresentationResult();</code></example>
     public static HtmlToPowerPointResult ToPowerPointPresentationResult(this string html, HtmlToPowerPointOptions? options = null) {
         if (html == null) throw new ArgumentNullException(nameof(html));
-        options ??= new HtmlToPowerPointOptions();
+        return ImportDocument(HtmlDocumentParser.ParseDocument(html), options ?? new HtmlToPowerPointOptions());
+    }
 
-        IHtmlDocument document = HtmlDocumentParser.ParseDocument(html);
+    /// <summary>
+    /// Imports a prepared shared HTML conversion document and returns the presentation plus structured evidence.
+    /// </summary>
+    public static HtmlToPowerPointResult ToPowerPointPresentationResult(this HtmlConversionDocument document, HtmlToPowerPointOptions? options = null) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        return ImportDocument(document.DocumentForConversion, options ?? new HtmlToPowerPointOptions());
+    }
+
+    private static HtmlToPowerPointResult ImportDocument(IHtmlDocument document, HtmlToPowerPointOptions options) {
         var stream = new MemoryStream();
         PptCore.PowerPointPresentation presentation = PptCore.PowerPointPresentation.Create(stream);
         var result = new HtmlToPowerPointResult(presentation);
 
         List<IElement> slideSections = document.QuerySelectorAll("section.officeimo-slide").ToList();
         if (slideSections.Count == 0) {
-            result.Diagnostics.Add("No semantic PowerPoint slide sections were found.");
+            AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.SemanticContentMissing,
+                "No semantic PowerPoint slide sections were found.", HtmlDiagnosticSeverity.Error, HtmlConversionLossKind.Failure);
             return result;
         }
 
@@ -47,29 +65,18 @@ public static class HtmlPowerPointConverterExtensions {
         return result;
     }
 
+    private static PptCore.PowerPointPresentation GetPresentationOrThrow(HtmlToPowerPointResult result) {
+        if (result.Succeeded) {
+            return result.Presentation;
+        }
+
+        result.Presentation.Dispose();
+        throw new HtmlConversionException(result.Diagnostics.Diagnostics);
+    }
+
     private static void ImportSlide(IElement section, PptCore.PowerPointSlide slide, HtmlToPowerPointOptions options, HtmlToPowerPointResult result) {
         result.Slides++;
-        double top = 48D;
-        foreach (IElement paragraph in section.Children.Where(child => IsElement(child, "p"))) {
-            string text = PreserveText(paragraph.TextContent);
-            if (text.Length == 0) {
-                continue;
-            }
-
-            slide.AddTextBoxPoints(text, 64, top, 620, 48);
-            result.TextBoxes++;
-            top += 58D;
-        }
-
-        if (options.ImportTables) {
-            foreach (IElement table in section.Children.Where(child => IsElement(child, "table"))) {
-                top = ImportTable(table, slide, top, result);
-            }
-        }
-
-        if (options.ImportPictures || options.ImportChartInventory) {
-            ImportDrawings(section, slide, options, result);
-        }
+        ImportSemanticShapes(section, slide, options, result);
 
         if (options.ImportNotes) {
             ImportNotes(section, slide, result);
@@ -80,55 +87,6 @@ public static class HtmlPowerPointConverterExtensions {
         string.Equals(value, "true", StringComparison.OrdinalIgnoreCase)
         || string.Equals(value, "1", StringComparison.Ordinal);
 
-    private static double ImportTable(IElement tableElement, PptCore.PowerPointSlide slide, double top, HtmlToPowerPointResult result) {
-        List<IElement> rows = tableElement.QuerySelectorAll("tr").ToList();
-        int rowCount = rows.Count;
-        int columnCount = rows.Count == 0
-            ? 0
-            : rows.Max(row => row.Children.Count(child => IsElement(child, "th") || IsElement(child, "td")));
-        if (rowCount == 0 || columnCount == 0) {
-            return top;
-        }
-
-        PptCore.PowerPointTable table = slide.AddTablePoints(rowCount, columnCount, 64, top, Math.Max(240, columnCount * 150), Math.Max(70, rowCount * 34));
-        for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {
-            IElement row = rows[rowIndex];
-            List<IElement> cells = row.Children.Where(child => IsElement(child, "th") || IsElement(child, "td")).ToList();
-            for (int columnIndex = 0; columnIndex < cells.Count; columnIndex++) {
-                table.GetCell(rowIndex, columnIndex).Text = PreserveText(cells[columnIndex].TextContent);
-            }
-        }
-
-        result.Tables++;
-        return top + Math.Max(90, rowCount * 40);
-    }
-
-    private static void ImportDrawings(IElement section, PptCore.PowerPointSlide slide, HtmlToPowerPointOptions options, HtmlToPowerPointResult result) {
-        var drawings = new List<PowerPointDrawingImportItem>();
-        int fallbackOrder = 0;
-        if (options.ImportPictures) {
-            foreach (IElement item in section.QuerySelectorAll("section.officeimo-images li")) {
-                drawings.Add(new PowerPointDrawingImportItem(item, PowerPointDrawingImportKind.Picture, ReadOptionalIntAttribute(item, "data-officeimo-layer-index"), fallbackOrder++));
-            }
-        }
-
-        if (options.ImportChartInventory) {
-            foreach (IElement item in section.QuerySelectorAll("section.officeimo-charts li")) {
-                drawings.Add(new PowerPointDrawingImportItem(item, PowerPointDrawingImportKind.Chart, ReadOptionalIntAttribute(item, "data-officeimo-layer-index"), fallbackOrder++));
-            }
-        }
-
-        double pictureTop = 140D;
-        double chartTop = 220D;
-        foreach (PowerPointDrawingImportItem drawing in drawings.OrderBy(item => item.LayerIndex ?? item.FallbackOrder).ThenBy(item => item.FallbackOrder)) {
-            if (drawing.Kind == PowerPointDrawingImportKind.Picture) {
-                ImportPicture(drawing.Element, slide, result, ref pictureTop);
-            } else {
-                ImportChart(drawing.Element, slide, result, ref chartTop);
-            }
-        }
-    }
-
     private static void ImportPicture(IElement item, PptCore.PowerPointSlide slide, HtmlToPowerPointResult result, ref double fallbackTop) {
         IElement? image = item.QuerySelector("img[src]");
         if (image == null || !HtmlImageDataUri.TryParse(image.GetAttribute("src"), out HtmlImageDataUri dataUri)) {
@@ -136,12 +94,14 @@ public static class HtmlPowerPointConverterExtensions {
         }
 
         if (!dataUri.TryDecodeBytes(out byte[] bytes)) {
-            result.Diagnostics.Add("Picture inventory item '" + NormalizeText(item.QuerySelector(".officeimo-feature-label")?.TextContent) + "' could not be decoded.");
+            AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ResourceDecodeFailed,
+                "Picture inventory item '" + NormalizeText(item.QuerySelector(".officeimo-feature-label")?.TextContent) + "' could not be decoded.", lossKind: HtmlConversionLossKind.Omission);
             return;
         }
 
         if (!TryGetImagePartType(dataUri.MediaType, out PptCore.ImagePartType imagePartType)) {
-            result.Diagnostics.Add("Picture inventory item '" + NormalizeText(item.QuerySelector(".officeimo-feature-label")?.TextContent) + "' used unsupported media type '" + dataUri.MediaType + "' and was not imported.");
+            AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ResourceTypeUnsupported,
+                "Picture inventory item '" + NormalizeText(item.QuerySelector(".officeimo-feature-label")?.TextContent) + "' used unsupported media type '" + dataUri.MediaType + "' and was not imported.", lossKind: HtmlConversionLossKind.Omission);
             return;
         }
 
@@ -171,7 +131,8 @@ public static class HtmlPowerPointConverterExtensions {
         string chartKind = ReadChartKind(item);
         ReadChartGeometry(item, 500D, fallbackTop, 320D, 180D, out double left, out double chartTop, out double width, out double height);
         if (!TryAddChartByKind(slide, chartKind, data, left, chartTop, width, height, out PptCore.PowerPointChart? chart, out string? fallbackMessage) || chart == null) {
-            result.Diagnostics.Add("Chart inventory item '" + (title.Length == 0 ? "Imported chart" : title) + "' used unsupported chart kind '" + chartKind + "' and was not imported.");
+            AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ContentOmitted,
+                "Chart inventory item '" + (title.Length == 0 ? "Imported chart" : title) + "' used unsupported chart kind '" + chartKind + "' and was not imported.", lossKind: HtmlConversionLossKind.Omission);
             return;
         }
 
@@ -179,11 +140,13 @@ public static class HtmlPowerPointConverterExtensions {
         ApplyShapeTransforms(item, chart);
         result.Charts++;
         if (!string.IsNullOrWhiteSpace(fallbackMessage)) {
-            result.Diagnostics.Add("Chart inventory item '" + (title.Length == 0 ? "Imported chart" : title) + "' " + fallbackMessage);
+            AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ContentApproximated,
+                "Chart inventory item '" + (title.Length == 0 ? "Imported chart" : title) + "' " + fallbackMessage, lossKind: HtmlConversionLossKind.Approximation);
         }
 
         if (!restoredFromSemanticData) {
-            result.Diagnostics.Add("Chart inventory item '" + (title.Length == 0 ? "Imported chart" : title) + "' was restored as a native chart with reconstructed placeholder values; exact source chart data was not present in semantic HTML.");
+            AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ContentApproximated,
+                "Chart inventory item '" + (title.Length == 0 ? "Imported chart" : title) + "' was restored as a native chart with reconstructed placeholder values; exact source chart data was not present in semantic HTML.", lossKind: HtmlConversionLossKind.Approximation);
         }
 
         fallbackTop = Math.Max(fallbackTop + 198D, chartTop + height + 18D);
@@ -325,15 +288,13 @@ public static class HtmlPowerPointConverterExtensions {
         string meta = string.Join("; ", item.QuerySelectorAll(".officeimo-feature-meta").Select(element => element.TextContent));
         const string marker = "Position:";
         int index = meta.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
-        if (index < 0) {
-            return;
-        }
-
-        string text = meta.Substring(index + marker.Length).Split(';')[0].Trim();
-        string[] parts = text.Replace("pt", string.Empty).Split(',');
-        if (parts.Length == 2) {
-            _ = double.TryParse(parts[0].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out left);
-            _ = double.TryParse(parts[1].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out top);
+        if (index >= 0) {
+            string text = meta.Substring(index + marker.Length).Split(';')[0].Trim();
+            string[] parts = text.Replace("pt", string.Empty).Split(',');
+            if (parts.Length == 2) {
+                _ = double.TryParse(parts[0].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out left);
+                _ = double.TryParse(parts[1].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out top);
+            }
         }
 
         if (TryReadDoubleAttribute(item, "data-officeimo-left", out double attributeLeft)) left = attributeLeft;
@@ -363,6 +324,10 @@ public static class HtmlPowerPointConverterExtensions {
 
         if (TryReadBoolAttribute(item, "data-officeimo-flip-vertical", out bool verticalFlip)) {
             shape.VerticalFlip = verticalFlip;
+        }
+
+        if (IsTrueAttribute(item.GetAttribute("data-officeimo-hidden"))) {
+            shape.Hidden = true;
         }
     }
 
@@ -630,25 +595,4 @@ public static class HtmlPowerPointConverterExtensions {
     private static string PreserveText(string? text) =>
         string.IsNullOrWhiteSpace(text) ? string.Empty : text!.Trim();
 
-    private sealed class PowerPointDrawingImportItem {
-        internal PowerPointDrawingImportItem(IElement element, PowerPointDrawingImportKind kind, int? layerIndex, int fallbackOrder) {
-            Element = element;
-            Kind = kind;
-            LayerIndex = layerIndex;
-            FallbackOrder = fallbackOrder;
-        }
-
-        internal IElement Element { get; }
-
-        internal PowerPointDrawingImportKind Kind { get; }
-
-        internal int? LayerIndex { get; }
-
-        internal int FallbackOrder { get; }
-    }
-
-    private enum PowerPointDrawingImportKind {
-        Picture,
-        Chart
-    }
 }

--- a/OfficeIMO.PowerPoint.Html/HtmlToPowerPointOptions.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlToPowerPointOptions.cs
@@ -5,6 +5,11 @@ namespace OfficeIMO.PowerPoint.Html;
 /// </summary>
 public sealed class HtmlToPowerPointOptions {
     /// <summary>
+    /// Maximum rectangular table size imported from one HTML table, including merged spans.
+    /// </summary>
+    public int MaxTableCells { get; set; } = 50_000;
+
+    /// <summary>
     /// Imports semantic slide tables as native PowerPoint tables.
     /// </summary>
     public bool ImportTables { get; set; } = true;

--- a/OfficeIMO.PowerPoint.Html/HtmlToPowerPointResult.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlToPowerPointResult.cs
@@ -1,3 +1,4 @@
+using OfficeIMO.Html;
 using PptCore = OfficeIMO.PowerPoint;
 
 namespace OfficeIMO.PowerPoint.Html;
@@ -5,15 +6,13 @@ namespace OfficeIMO.PowerPoint.Html;
 /// <summary>
 /// Summary of a semantic PowerPoint HTML import.
 /// </summary>
-public sealed class HtmlToPowerPointResult {
-    internal HtmlToPowerPointResult(PptCore.PowerPointPresentation presentation) {
-        Presentation = presentation ?? throw new ArgumentNullException(nameof(presentation));
-    }
+public sealed class HtmlToPowerPointResult : HtmlConversionResult<PptCore.PowerPointPresentation> {
+    internal HtmlToPowerPointResult(PptCore.PowerPointPresentation presentation) : base(presentation) { }
 
     /// <summary>
     /// Imported presentation.
     /// </summary>
-    public PptCore.PowerPointPresentation Presentation { get; }
+    public PptCore.PowerPointPresentation Presentation => Artifact;
 
     /// <summary>
     /// Number of imported slides.
@@ -31,6 +30,11 @@ public sealed class HtmlToPowerPointResult {
     public int Tables { get; internal set; }
 
     /// <summary>
+    /// Number of merged table ranges restored from HTML row and column spans.
+    /// </summary>
+    public int MergedRanges { get; internal set; }
+
+    /// <summary>
     /// Number of imported pictures.
     /// </summary>
     public int Pictures { get; internal set; }
@@ -45,8 +49,4 @@ public sealed class HtmlToPowerPointResult {
     /// </summary>
     public int Notes { get; internal set; }
 
-    /// <summary>
-    /// Import diagnostics for skipped or approximate rich content.
-    /// </summary>
-    public IList<string> Diagnostics { get; } = new List<string>();
 }

--- a/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.IO.cs
+++ b/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.IO.cs
@@ -1,0 +1,28 @@
+using OfficeIMO.Html;
+using System.Threading;
+using System.Threading.Tasks;
+using PptCore = OfficeIMO.PowerPoint;
+
+namespace OfficeIMO.PowerPoint.Html;
+
+public static partial class PowerPointHtmlConverterExtensions {
+    /// <summary>Writes a presentation as UTF-8 HTML to a stream and leaves it open.</summary>
+    public static void SaveAsHtml(this PptCore.PowerPointPresentation presentation, Stream stream, PowerPointHtmlSaveOptions? options = null) {
+        if (presentation == null) throw new ArgumentNullException(nameof(presentation));
+        HtmlTextIO.Write(stream, presentation.ToHtml(options));
+    }
+
+    /// <summary>Asynchronously writes a presentation as UTF-8 HTML.</summary>
+    public static async Task SaveAsHtmlAsync(this PptCore.PowerPointPresentation presentation, string path, PowerPointHtmlSaveOptions? options = null, CancellationToken cancellationToken = default) {
+        if (presentation == null) throw new ArgumentNullException(nameof(presentation));
+        cancellationToken.ThrowIfCancellationRequested();
+        await HtmlTextIO.WriteAsync(path, presentation.ToHtml(options), cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Asynchronously writes a presentation as UTF-8 HTML to a stream and leaves it open.</summary>
+    public static async Task SaveAsHtmlAsync(this PptCore.PowerPointPresentation presentation, Stream stream, PowerPointHtmlSaveOptions? options = null, CancellationToken cancellationToken = default) {
+        if (presentation == null) throw new ArgumentNullException(nameof(presentation));
+        cancellationToken.ThrowIfCancellationRequested();
+        await HtmlTextIO.WriteAsync(stream, presentation.ToHtml(options), cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.SemanticShapes.cs
+++ b/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.SemanticShapes.cs
@@ -33,10 +33,10 @@ public static partial class PowerPointHtmlConverterExtensions {
             .Append("\" data-officeimo-layer-index=\"")
             .Append(shape.DrawingOrder.ToString(CultureInfo.InvariantCulture))
             .Append('"');
-        AppendDataAttribute(body, "data-officeimo-left", shape.LeftPoints);
-        AppendDataAttribute(body, "data-officeimo-top", shape.TopPoints);
-        AppendDataAttribute(body, "data-officeimo-width", shape.WidthPoints);
-        AppendDataAttribute(body, "data-officeimo-height", shape.HeightPoints);
+        AppendDataAttribute(body, "data-officeimo-left", shape.LeftPoints, omitWhenZero: false);
+        AppendDataAttribute(body, "data-officeimo-top", shape.TopPoints, omitWhenZero: false);
+        AppendDataAttribute(body, "data-officeimo-width", shape.WidthPoints, omitWhenZero: false);
+        AppendDataAttribute(body, "data-officeimo-height", shape.HeightPoints, omitWhenZero: false);
         AppendDataAttribute(body, "data-officeimo-rotation", shape.Rotation ?? 0D);
         AppendDataAttribute(body, "data-officeimo-flip-horizontal", shape.HorizontalFlip == true);
         AppendDataAttribute(body, "data-officeimo-flip-vertical", shape.VerticalFlip == true);

--- a/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.SemanticShapes.cs
+++ b/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.SemanticShapes.cs
@@ -1,0 +1,45 @@
+using OfficeIMO.Html;
+using PptCore = OfficeIMO.PowerPoint;
+
+namespace OfficeIMO.PowerPoint.Html;
+
+public static partial class PowerPointHtmlConverterExtensions {
+    private static void AppendSemanticShapes(StringBuilder body, PptCore.PowerPointSlide slide, PowerPointHtmlSaveOptions options) {
+        foreach (PptCore.PowerPointShape shape in slide.Shapes.OrderBy(shape => shape.DrawingOrder)) {
+            if (!options.IncludeHiddenShapes && shape.Hidden) {
+                continue;
+            }
+
+            if (shape is PptCore.PowerPointTextBox textBox) {
+                string text = NormalizeText(textBox.Text);
+                if (text.Length == 0) {
+                    continue;
+                }
+
+                body.Append("<p");
+                AppendSemanticShapeAttributes(body, textBox, "text");
+                body.Append('>')
+                    .Append(OfficeHtmlText.Escape(text))
+                    .Append("</p>");
+            } else if (shape is PptCore.PowerPointTable table && options.IncludeTables) {
+                AppendTable(body, table, includeShapeMetadata: true);
+            }
+        }
+    }
+
+    private static void AppendSemanticShapeAttributes(StringBuilder body, PptCore.PowerPointShape shape, string kind) {
+        body.Append(" data-officeimo-layer-kind=\"")
+            .Append(kind)
+            .Append("\" data-officeimo-layer-index=\"")
+            .Append(shape.DrawingOrder.ToString(CultureInfo.InvariantCulture))
+            .Append('"');
+        AppendDataAttribute(body, "data-officeimo-left", shape.LeftPoints);
+        AppendDataAttribute(body, "data-officeimo-top", shape.TopPoints);
+        AppendDataAttribute(body, "data-officeimo-width", shape.WidthPoints);
+        AppendDataAttribute(body, "data-officeimo-height", shape.HeightPoints);
+        AppendDataAttribute(body, "data-officeimo-rotation", shape.Rotation ?? 0D);
+        AppendDataAttribute(body, "data-officeimo-flip-horizontal", shape.HorizontalFlip == true);
+        AppendDataAttribute(body, "data-officeimo-flip-vertical", shape.VerticalFlip == true);
+        AppendDataAttribute(body, "data-officeimo-hidden", shape.Hidden);
+    }
+}

--- a/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.cs
@@ -7,7 +7,7 @@ namespace OfficeIMO.PowerPoint.Html;
 /// <summary>
 /// Extension methods enabling HTML conversions for OfficeIMO PowerPoint presentations.
 /// </summary>
-public static class PowerPointHtmlConverterExtensions {
+public static partial class PowerPointHtmlConverterExtensions {
     /// <summary>
     /// Converts a presentation to HTML.
     /// </summary>
@@ -25,7 +25,7 @@ public static class PowerPointHtmlConverterExtensions {
     /// </summary>
     public static void SaveAsHtml(this PptCore.PowerPointPresentation presentation, string path, PowerPointHtmlSaveOptions? options = null) {
         if (string.IsNullOrWhiteSpace(path)) throw new ArgumentException("HTML path cannot be empty.", nameof(path));
-        File.WriteAllText(path, presentation.ToHtml(options), Encoding.UTF8);
+        HtmlTextIO.Write(path, presentation.ToHtml(options));
     }
 
     private static string ConvertSemantic(PptCore.PowerPointPresentation presentation, PowerPointHtmlSaveOptions options) {
@@ -80,28 +80,7 @@ public static class PowerPointHtmlConverterExtensions {
         body.Append('>');
         body.Append("<h2>Slide ").Append(visibleIndex.ToString(CultureInfo.InvariantCulture)).Append("</h2>");
 
-        foreach (PptCore.PowerPointTextBox textBox in slide.TextBoxes) {
-            if (!options.IncludeHiddenShapes && textBox.Hidden) {
-                continue;
-            }
-
-            string text = NormalizeText(textBox.Text);
-            if (text.Length == 0) {
-                continue;
-            }
-
-            body.Append("<p>").Append(OfficeHtmlText.Escape(text)).Append("</p>");
-        }
-
-        if (options.IncludeTables) {
-            foreach (PptCore.PowerPointTable table in slide.Tables) {
-                if (!options.IncludeHiddenShapes && table.Hidden) {
-                    continue;
-                }
-
-                AppendTable(body, table);
-            }
-        }
+        AppendSemanticShapes(body, slide, options);
 
         AppendSlideFeatureInventory(body, slide, options);
         AppendExtractionProof(body, extractionProof, options);
@@ -594,12 +573,31 @@ public static class PowerPointHtmlConverterExtensions {
         body.Append("</div>");
     }
 
-    private static void AppendTable(StringBuilder body, PptCore.PowerPointTable table) {
-        body.Append("<table class=\"officeimo-table\"><tbody>");
+    private static void AppendTable(StringBuilder body, PptCore.PowerPointTable table, bool includeShapeMetadata = false) {
+        body.Append("<table class=\"officeimo-table\"");
+        if (includeShapeMetadata) {
+            AppendSemanticShapeAttributes(body, table, "table");
+        }
+
+        body.Append("><tbody>");
         foreach (PptCore.PowerPointTableRow row in table.RowItems) {
             body.Append("<tr>");
             foreach (PptCore.PowerPointTableCell cell in row.Cells) {
-                body.Append("<td>").Append(OfficeHtmlText.Escape(NormalizeText(cell.Text))).Append("</td>");
+                if (cell.IsMergedCell) {
+                    continue;
+                }
+
+                body.Append("<td");
+                (int rows, int columns) = cell.Merge;
+                if (rows > 1) {
+                    body.Append(" rowspan=\"").Append(rows.ToString(CultureInfo.InvariantCulture)).Append('"');
+                }
+
+                if (columns > 1) {
+                    body.Append(" colspan=\"").Append(columns.ToString(CultureInfo.InvariantCulture)).Append('"');
+                }
+
+                body.Append('>').Append(OfficeHtmlText.Escape(NormalizeText(cell.Text))).Append("</td>");
             }
 
             body.Append("</tr>");

--- a/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/PowerPointHtmlConverterExtensions.cs
@@ -258,10 +258,10 @@ public static partial class PowerPointHtmlConverterExtensions {
             body.Append("<li class=\"officeimo-feature-item\" data-officeimo-layer-kind=\"picture\" data-officeimo-layer-index=\"")
                 .Append(picture.DrawingOrder.ToString(CultureInfo.InvariantCulture))
                 .Append('"');
-            AppendDataAttribute(body, "data-officeimo-left", picture.LeftPoints);
-            AppendDataAttribute(body, "data-officeimo-top", picture.TopPoints);
-            AppendDataAttribute(body, "data-officeimo-width", picture.WidthPoints);
-            AppendDataAttribute(body, "data-officeimo-height", picture.HeightPoints);
+            AppendDataAttribute(body, "data-officeimo-left", picture.LeftPoints, omitWhenZero: false);
+            AppendDataAttribute(body, "data-officeimo-top", picture.TopPoints, omitWhenZero: false);
+            AppendDataAttribute(body, "data-officeimo-width", picture.WidthPoints, omitWhenZero: false);
+            AppendDataAttribute(body, "data-officeimo-height", picture.HeightPoints, omitWhenZero: false);
             AppendDataAttribute(body, "data-officeimo-rotation", picture.Rotation ?? 0D);
             AppendDataAttribute(body, "data-officeimo-flip-horizontal", picture.HorizontalFlip == true);
             AppendDataAttribute(body, "data-officeimo-flip-vertical", picture.VerticalFlip == true);
@@ -289,8 +289,8 @@ public static partial class PowerPointHtmlConverterExtensions {
         body.Append("</ul></section>");
     }
 
-    private static void AppendDataAttribute(StringBuilder body, string name, double value) {
-        if (Math.Abs(value) < 0.0000001D) {
+    private static void AppendDataAttribute(StringBuilder body, string name, double value, bool omitWhenZero = true) {
+        if (omitWhenZero && Math.Abs(value) < 0.0000001D) {
             return;
         }
 
@@ -322,10 +322,10 @@ public static partial class PowerPointHtmlConverterExtensions {
             body.Append("<li class=\"officeimo-feature-item\" data-officeimo-layer-kind=\"chart\" data-officeimo-layer-index=\"")
                 .Append(chart.DrawingOrder.ToString(CultureInfo.InvariantCulture))
                 .Append('"');
-            AppendDataAttribute(body, "data-officeimo-left", chart.LeftPoints);
-            AppendDataAttribute(body, "data-officeimo-top", chart.TopPoints);
-            AppendDataAttribute(body, "data-officeimo-width", chart.WidthPoints);
-            AppendDataAttribute(body, "data-officeimo-height", chart.HeightPoints);
+            AppendDataAttribute(body, "data-officeimo-left", chart.LeftPoints, omitWhenZero: false);
+            AppendDataAttribute(body, "data-officeimo-top", chart.TopPoints, omitWhenZero: false);
+            AppendDataAttribute(body, "data-officeimo-width", chart.WidthPoints, omitWhenZero: false);
+            AppendDataAttribute(body, "data-officeimo-height", chart.HeightPoints, omitWhenZero: false);
             AppendDataAttribute(body, "data-officeimo-rotation", chart.Rotation ?? 0D);
             AppendDataAttribute(body, "data-officeimo-flip-horizontal", chart.HorizontalFlip == true);
             AppendDataAttribute(body, "data-officeimo-flip-vertical", chart.VerticalFlip == true);

--- a/OfficeIMO.PowerPoint.Html/README.md
+++ b/OfficeIMO.PowerPoint.Html/README.md
@@ -1,3 +1,32 @@
 # OfficeIMO.PowerPoint.Html
 
 First-party HTML adapter for OfficeIMO.PowerPoint. It exports semantic slide HTML and positioned review HTML using the shared OfficeIMO.Html profile contracts and the public PowerPoint slide model.
+
+## Semantic round trips
+
+```csharp
+using OfficeIMO.PowerPoint;
+using OfficeIMO.PowerPoint.Html;
+
+using PowerPointPresentation presentation = PowerPointPresentation.Open("briefing.pptx");
+string html = presentation.ToHtml();
+
+HtmlToPowerPointResult result = html.ToPowerPointPresentationResult();
+using PowerPointPresentation imported = result.GetArtifactOrThrow();
+using FileStream output = File.Create("briefing-roundtrip.pptx");
+imported.Save(output);
+```
+
+Semantic output keeps slide order and visibility, unified drawing order across text boxes, tables, pictures, and charts, shape geometry and transforms, presenter notes, table merge spans, embedded pictures, and supported chart data. Generic HTML `rowspan` and `colspan` values become native PowerPoint table merges.
+
+`ToPowerPointPresentation()` is the convenience API. It throws `HtmlConversionException` when no semantic `section.officeimo-slide` envelope exists. Use `ToPowerPointPresentationResult()` to inspect diagnostics and loss classification. `HtmlToPowerPointOptions.MaxTableCells` prevents oversized or malicious table spans from causing unbounded allocations.
+
+Path, stream, and async save/import methods use UTF-8 without a byte-order mark. Stream overloads leave caller-owned streams open.
+
+## Positioned review
+
+Set `Profile = OfficeHtmlConversionProfile.PowerPointVisualReview` for a positioned visual representation. Visual-review HTML is intended for inspection, while semantic slide HTML is the importable contract.
+
+## Targets
+
+`netstandard2.0`, `net8.0`, and `net10.0`; `net472` is included when building on Windows.

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Stylesheets.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Stylesheets.cs
@@ -220,7 +220,7 @@ namespace OfficeIMO.Word.Html {
                     break;
                 }
 
-                var args = WordHtmlConverterExtensions.OnStyleMissing(paragraph, cls);
+                var args = WordHtmlConverterExtensions.OnStyleMissing(options, paragraph, cls);
                 if (args.Style.HasValue) {
                     paragraph.Style = args.Style.Value;
                     break;

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.cs
@@ -6,6 +6,7 @@ using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using AngleSharp.Io;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Html;
 using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Http;
@@ -61,6 +62,14 @@ namespace OfficeIMO.Word.Html {
 
         public async Task<WordDocument> ConvertAsync(string html, HtmlToWordOptions options, CancellationToken cancellationToken = default) {
             if (html == null) throw new ArgumentNullException(nameof(html));
+            var config = Configuration.Default.WithDefaultLoader();
+            var context = BrowsingContext.New(config);
+            IDocument parsed = await context.OpenAsync(request => request.Content(html), cancellationToken).ConfigureAwait(false);
+            return await ConvertAsync((IHtmlDocument)parsed, options, cancellationToken).ConfigureAwait(false);
+        }
+
+        internal async Task<WordDocument> ConvertAsync(IHtmlDocument document, HtmlToWordOptions options, CancellationToken cancellationToken = default) {
+            if (document == null) throw new ArgumentNullException(nameof(document));
             options ??= new HtmlToWordOptions();
             cancellationToken.ThrowIfCancellationRequested();
             _cancellationToken = cancellationToken;
@@ -68,10 +77,7 @@ namespace OfficeIMO.Word.Html {
             _resourceTimeout = options.ResourceTimeout;
             _options = options;
 
-            var config = Configuration.Default.WithDefaultLoader();
-            var context = BrowsingContext.New(config);
-            _context = context;
-            var document = await context.OpenAsync(req => req.Content(html), cancellationToken).ConfigureAwait(false);
+            _context = document.Context;
             ValidateDocumentLimits(document, options);
 
             var wordDoc = WordDocument.Create();

--- a/OfficeIMO.Word.Html/HtmlToWordResult.cs
+++ b/OfficeIMO.Word.Html/HtmlToWordResult.cs
@@ -1,0 +1,15 @@
+using OfficeIMO.Html;
+
+namespace OfficeIMO.Word.Html;
+
+/// <summary>
+/// Native Word document plus structured diagnostics from one HTML import operation.
+/// </summary>
+public sealed class HtmlToWordResult : HtmlConversionResult<WordDocument> {
+    internal HtmlToWordResult(WordDocument document, IEnumerable<HtmlDiagnostic> diagnostics) : base(document) {
+        Diagnostics.AddRange(diagnostics);
+    }
+
+    /// <summary>Imported Word document.</summary>
+    public WordDocument Document => Artifact;
+}

--- a/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
+++ b/OfficeIMO.Word.Html/Options/HtmlToWordOptions.cs
@@ -305,6 +305,12 @@ namespace OfficeIMO.Word.Html {
         public Action<HtmlConversionDiagnostic>? DiagnosticHandler { get; set; }
 
         /// <summary>
+        /// Optional conversion-scoped resolver for CSS classes without a built-in Word style mapping.
+        /// This avoids global event state when conversions run concurrently.
+        /// </summary>
+        public Action<StyleMissingEventArgs>? StyleMissingHandler { get; set; }
+
+        /// <summary>
         /// When true, emits advisory accessibility diagnostics for imported HTML patterns that can reduce
         /// document usability, such as missing image alternate text, weak link text, skipped heading levels,
         /// and data tables without header cells.
@@ -405,6 +411,7 @@ namespace OfficeIMO.Word.Html {
                 MaxTotalCssBytes = MaxTotalCssBytes,
                 MaxTableCells = MaxTableCells,
                 DiagnosticHandler = DiagnosticHandler,
+                StyleMissingHandler = StyleMissingHandler,
                 EnableAccessibilityDiagnostics = EnableAccessibilityDiagnostics,
                 ImportHtmlComments = ImportHtmlComments,
                 HtmlCommentAuthor = HtmlCommentAuthor,

--- a/OfficeIMO.Word.Html/README.md
+++ b/OfficeIMO.Word.Html/README.md
@@ -29,6 +29,19 @@ string html = document.ToHtml(new WordToHtmlOptions {
 
 HTML can also be appended to an existing body, header, or footer with `AddHtmlToBody`, `AddHtmlToHeader`, and `AddHtmlToFooter`.
 
+Use the result API when conversion evidence matters:
+
+```csharp
+HtmlToWordResult result = html.ToWordDocumentResult(options);
+using WordDocument document = result.GetArtifactOrThrow();
+
+foreach (HtmlDiagnostic diagnostic in result.Diagnostics) {
+    Console.WriteLine($"{diagnostic.Code}: {diagnostic.LossKind}");
+}
+```
+
+String, stream, async, and prepared `HtmlConversionDocument` overloads expose the same result shape. A prepared document reuses the shared adapter DOM. `HtmlToWordOptions.StyleMissingHandler` scopes custom class mapping to one conversion; the static `StyleMissing` event remains a compatibility fallback.
+
 ## What it maps
 
 - HTML headings, paragraphs, inline formatting, links, images, SVG, lists, tables, captions, form controls, notes, headers, footers, and sections into Word content where supported.

--- a/OfficeIMO.Word.Html/WordHtmlConverterExtensions.Results.cs
+++ b/OfficeIMO.Word.Html/WordHtmlConverterExtensions.Results.cs
@@ -1,0 +1,64 @@
+using OfficeIMO.Html;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Word.Html;
+
+public static partial class WordHtmlConverterExtensions {
+    /// <summary>Imports HTML into Word and returns the document plus structured conversion evidence.</summary>
+    public static HtmlToWordResult ToWordDocumentResult(this string html, HtmlToWordOptions? options = null) =>
+        ToWordDocumentResultAsync(html, options).GetAwaiter().GetResult();
+
+    /// <summary>Imports a prepared shared HTML document into Word and returns structured evidence.</summary>
+    public static HtmlToWordResult ToWordDocumentResult(this HtmlConversionDocument document, HtmlToWordOptions? options = null) =>
+        ToWordDocumentResultAsync(document, options).GetAwaiter().GetResult();
+
+    /// <summary>Reads HTML from a stream, imports it into Word, and returns structured evidence.</summary>
+    public static HtmlToWordResult ToWordDocumentResult(this Stream htmlStream, HtmlToWordOptions? options = null) =>
+        ToWordDocumentResultAsync(htmlStream, options).GetAwaiter().GetResult();
+
+    /// <summary>Asynchronously imports HTML into Word and returns structured evidence.</summary>
+    public static async Task<HtmlToWordResult> ToWordDocumentResultAsync(
+        this string html,
+        HtmlToWordOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        if (html == null) throw new ArgumentNullException(nameof(html));
+        HtmlToWordOptions resolved = options ?? new HtmlToWordOptions();
+        int diagnosticStart = resolved.ConversionReport.Count;
+        var converter = new HtmlToWordConverter();
+        WordDocument document = await converter.ConvertAsync(html, resolved, cancellationToken).ConfigureAwait(false);
+        return CreateResult(document, resolved, diagnosticStart);
+    }
+
+    /// <summary>Asynchronously imports a prepared shared HTML document into Word and returns structured evidence.</summary>
+    public static async Task<HtmlToWordResult> ToWordDocumentResultAsync(
+        this HtmlConversionDocument document,
+        HtmlToWordOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        HtmlToWordOptions resolved = options ?? CreateWordOptionsForSharedDocument(document.ProfileContract.Profile, document.Trust);
+        resolved.ConversionProfile = document.ProfileContract.Profile;
+        int diagnosticStart = resolved.ConversionReport.Count;
+        var converter = new HtmlToWordConverter();
+        WordDocument wordDocument = await converter.ConvertAsync(
+            HtmlDocumentParser.CloneDocument(document.DocumentForConversion),
+            resolved,
+            cancellationToken).ConfigureAwait(false);
+        return CreateResult(wordDocument, resolved, diagnosticStart);
+    }
+
+    /// <summary>Asynchronously reads a stream, imports it into Word, and returns structured evidence.</summary>
+    public static async Task<HtmlToWordResult> ToWordDocumentResultAsync(
+        this Stream htmlStream,
+        HtmlToWordOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        if (htmlStream == null) throw new ArgumentNullException(nameof(htmlStream));
+        string html = await HtmlTextIO.ReadAsync(htmlStream, cancellationToken).ConfigureAwait(false);
+        return await html.ToWordDocumentResultAsync(options, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static HtmlToWordResult CreateResult(WordDocument document, HtmlToWordOptions options, int diagnosticStart) {
+        IEnumerable<HtmlDiagnostic> diagnostics = options.ConversionReport.Skip(diagnosticStart);
+        return new HtmlToWordResult(document, diagnostics);
+    }
+}

--- a/OfficeIMO.Word.Html/WordHtmlConverterExtensions.cs
+++ b/OfficeIMO.Word.Html/WordHtmlConverterExtensions.cs
@@ -7,16 +7,19 @@ namespace OfficeIMO.Word.Html {
     /// <summary>
     /// Extension methods enabling HTML conversions for <see cref="WordDocument"/> instances.
     /// </summary>
-    public static class WordHtmlConverterExtensions {
+    public static partial class WordHtmlConverterExtensions {
         /// <summary>
         /// Raised when an HTML element references a CSS class that has no built-in mapping.
         /// Handlers may supply <see cref="StyleMissingEventArgs.Style"/> or <see cref="StyleMissingEventArgs.StyleId"/>.
         /// </summary>
         public static event EventHandler<StyleMissingEventArgs>? StyleMissing;
 
-        internal static StyleMissingEventArgs OnStyleMissing(WordParagraph paragraph, string className) {
+        internal static StyleMissingEventArgs OnStyleMissing(HtmlToWordOptions options, WordParagraph paragraph, string className) {
             var args = new StyleMissingEventArgs(paragraph, className);
-            StyleMissing?.Invoke(null, args);
+            options.StyleMissingHandler?.Invoke(args);
+            if (!args.Style.HasValue && string.IsNullOrEmpty(args.StyleId)) {
+                StyleMissing?.Invoke(null, args);
+            }
             return args;
         }
 
@@ -94,28 +97,20 @@ namespace OfficeIMO.Word.Html {
         /// <returns>A new <see cref="WordDocument"/> instance.</returns>
         public static Task<WordDocument> ToWordDocumentAsync(this HtmlConversionDocument document, HtmlToWordOptions? options = null, CancellationToken cancellationToken = default) {
             if (document == null) throw new System.ArgumentNullException(nameof(document));
-            options ??= CreateWordOptionsForSharedDocument(document.ProfileContract.Profile);
+            options ??= CreateWordOptionsForSharedDocument(document.ProfileContract.Profile, document.Trust);
             options.ConversionProfile = document.ProfileContract.Profile;
-            return ToWordDocumentAsync(PrepareHtmlForSharedWordConversion(document), options, cancellationToken);
+            var converter = new HtmlToWordConverter();
+            return converter.ConvertAsync(HtmlDocumentParser.CloneDocument(document.DocumentForConversion), options, cancellationToken);
         }
 
-        internal static HtmlToWordOptions CreateWordOptionsForSharedDocument(HtmlConversionProfile profile) {
-            switch (profile) {
-                case HtmlConversionProfile.Document:
-                case HtmlConversionProfile.HighFidelityPrint:
-                    return HtmlToWordOptions.CreateTrustedDocumentProfile();
-                case HtmlConversionProfile.Semantic:
-                    return HtmlToWordOptions.CreateUntrustedHtmlProfile();
-                default:
-                    return HtmlToWordOptions.CreateOfficeIMOProfile();
-            }
-        }
-
-        internal static string PrepareHtmlForSharedWordConversion(HtmlConversionDocument document) {
-            HtmlCssMediaContext mediaContext = document.ProfileContract.Profile == HtmlConversionProfile.HighFidelityPrint
-                ? HtmlCssMediaContext.Print
-                : HtmlCssMediaContext.Screen;
-            return HtmlActiveMediaFilter.Filter(document.HtmlForConversion, mediaContext);
+        internal static HtmlToWordOptions CreateWordOptionsForSharedDocument(
+            HtmlConversionProfile profile,
+            HtmlInputTrust trust = HtmlInputTrust.Untrusted) {
+            HtmlToWordOptions options = trust == HtmlInputTrust.Trusted
+                ? HtmlToWordOptions.CreateTrustedDocumentProfile()
+                : HtmlToWordOptions.CreateUntrustedHtmlProfile();
+            options.ConversionProfile = profile;
+            return options;
         }
 
         /// <summary>
@@ -151,14 +146,7 @@ namespace OfficeIMO.Word.Html {
         /// <returns>A new <see cref="WordDocument"/> instance.</returns>
         public static async Task<WordDocument> ToWordDocumentAsync(this Stream htmlStream, HtmlToWordOptions? options = null, CancellationToken cancellationToken = default) {
             if (htmlStream == null) throw new System.ArgumentNullException(nameof(htmlStream));
-            cancellationToken.ThrowIfCancellationRequested();
-            using var reader = new StreamReader(htmlStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
-#if NET8_0_OR_GREATER
-            string html = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
-#else
-            string html = await reader.ReadToEndAsync().ConfigureAwait(false);
-            cancellationToken.ThrowIfCancellationRequested();
-#endif
+            string html = await HtmlTextIO.ReadAsync(htmlStream, cancellationToken).ConfigureAwait(false);
             return await ToWordDocumentAsync(html, options, cancellationToken).ConfigureAwait(false);
         }
 
@@ -325,13 +313,8 @@ namespace OfficeIMO.Word.Html {
             if (document == null) throw new System.ArgumentNullException(nameof(document));
             if (path == null) throw new System.ArgumentNullException(nameof(path));
             cancellationToken.ThrowIfCancellationRequested();
-            var html = await document.ToHtmlAsync(options, cancellationToken).ConfigureAwait(false);
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
-            await File.WriteAllTextAsync(path, html, Encoding.UTF8, cancellationToken).ConfigureAwait(false);
-#else
-            using var writer = new StreamWriter(path, false, Encoding.UTF8);
-            await writer.WriteAsync(html).ConfigureAwait(false);
-#endif
+            string html = await document.ToHtmlAsync(options, cancellationToken).ConfigureAwait(false);
+            await HtmlTextIO.WriteAsync(path, html, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -345,13 +328,8 @@ namespace OfficeIMO.Word.Html {
             if (document == null) throw new System.ArgumentNullException(nameof(document));
             if (stream == null) throw new System.ArgumentNullException(nameof(stream));
             cancellationToken.ThrowIfCancellationRequested();
-            var html = await document.ToHtmlAsync(options, cancellationToken).ConfigureAwait(false);
-            var bytes = Encoding.UTF8.GetBytes(html);
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
-            await stream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
-#else
-            await stream.WriteAsync(bytes, 0, bytes.Length, cancellationToken).ConfigureAwait(false);
-#endif
+            string html = await document.ToHtmlAsync(options, cancellationToken).ConfigureAwait(false);
+            await HtmlTextIO.WriteAsync(stream, html, cancellationToken).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
## What changed

- adds shared structured HTML conversion results, diagnostics, loss classification, and an input trust boundary without creating another package
- reuses a prepared adapter DOM across Word, Markdown, RTF, PDF, image, Excel, and PowerPoint projections
- fixes Excel merged-cell import/export, typed date-time round trips, explicit header semantics, and bounded table spans
- fixes PowerPoint drawing order, geometry fallbacks, and merged table spans across semantic HTML round trips
- unifies UTF-8 path, stream, and async behavior through one shared HTML text I/O owner
- adds saved-and-reopened DOCX, XLSX, PPTX, RTF, PDF, Markdown, and SVG evidence plus updated package documentation

## Migration notes

- `HtmlToExcelResult.Diagnostics` and `HtmlToPowerPointResult.Diagnostics` are now `HtmlDiagnosticReport` rather than `IList<string>`. Diagnostics expose stable codes, severity, and `LossKind`.
- `ToExcelDocument()` and `ToPowerPointPresentation()` now throw `HtmlConversionException` when the required semantic sheet or slide envelope is absent. Use the corresponding `*Result()` method to retain the artifact and inspect failure diagnostics.
- prepared `HtmlConversionDocument` input defaults to `HtmlInputTrust.Untrusted`; callers must opt into `Trusted` for controlled document resources.
- Word HTML stream output is UTF-8 without a BOM, matching the other HTML adapters.

## Dependency and base

No package references, NuGet dependencies, or package projects were added. This PR is intentionally stacked on #2063 and should be retargeted to `master` after #2063 merges.