### PR TITLE
Preserve list kinds and nesting across converters

### DIFF
--- a/OfficeIMO.Html.Tests/Html.ListNumbering.cs
+++ b/OfficeIMO.Html.Tests/Html.ListNumbering.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Html;
@@ -8,6 +9,114 @@ using Xunit;
 
 namespace OfficeIMO.Tests {
     public partial class Html {
+        [Fact]
+        public void HtmlToWord_UnorderedListWithValueAttributes_RemainsBulletedInValidPackage() {
+            const string html = "<p>Values:</p><ul style=\"list-style-type:disc\"><li value=\"1\">TODAY: Today</li><li value=\"2\">YESTERDAY: Yesterday</li></ul>";
+
+            using var doc = OfficeIMO.Html.HtmlConversionDocument.Parse(html).ToWordDocument(new HtmlToWordOptions());
+
+            var listItems = doc.Paragraphs
+                .Where(paragraph => paragraph.IsListItem)
+                .GroupBy(paragraph => paragraph._paragraph)
+                .Select(group => group.OrderByDescending(paragraph => paragraph.Text.Length).First())
+                .ToList();
+            Assert.Equal(2, listItems.Count);
+            Assert.All(listItems, paragraph => {
+                DocumentTraversal.ListInfo? info = DocumentTraversal.GetListInfo(paragraph);
+                Assert.True(info.HasValue);
+                Assert.False(info.Value.Ordered);
+                Assert.Equal(NumberFormatValues.Bullet, info.Value.NumberFormat);
+            });
+
+            string roundTripHtml = doc.ToHtml(new WordToHtmlOptions { IncludeListStyles = true });
+            Assert.Contains("<ul", roundTripHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("<ol", roundTripHtml, StringComparison.OrdinalIgnoreCase);
+
+            using MemoryStream stream = doc.ToStream();
+            stream.Position = 0;
+            using WordprocessingDocument package = WordprocessingDocument.Open(stream, false);
+            var errors = new OpenXmlValidator().Validate(package).ToList();
+            Assert.True(errors.Count == 0, string.Join(Environment.NewLine, errors.Select(error => error.Description)));
+        }
+
+        [Fact]
+        public void HtmlToWord_AppendedUnorderedList_DoesNotReuseExistingOrderedNumbering() {
+            const string html = "<p>Values:</p><ul style=\"list-style-type:disc\"><li value=\"1\">TODAY: Today</li><li value=\"2\">YESTERDAY: Yesterday</li></ul>";
+            using var doc = WordDocument.Create();
+            WordList existing = doc.AddListNumbered();
+            for (int index = 1; index <= 10; index++) {
+                existing.AddItem("Existing " + index);
+            }
+
+            doc.AddHtmlToBody(
+                OfficeIMO.Html.HtmlConversionDocument.Parse(html),
+                new HtmlToWordOptions { ContinueNumbering = true });
+
+            var imported = doc.Paragraphs
+                .Where(paragraph => paragraph.Text.Contains("TODAY:", StringComparison.OrdinalIgnoreCase)
+                    || paragraph.Text.Contains("YESTERDAY:", StringComparison.OrdinalIgnoreCase))
+                .GroupBy(paragraph => paragraph._paragraph)
+                .Select(group => group.OrderByDescending(paragraph => paragraph.Text.Length).First())
+                .ToArray();
+            Assert.Equal(2, imported.Length);
+            Assert.All(imported, paragraph => {
+                DocumentTraversal.ListInfo info = DocumentTraversal.GetListInfo(paragraph)!.Value;
+                Assert.False(info.Ordered);
+                Assert.Equal(NumberFormatValues.Bullet, info.NumberFormat);
+                Assert.NotEqual(existing.NumberId, paragraph._listNumberId);
+            });
+        }
+
+        [Fact]
+        public void HtmlToWord_MixedNestedListsInsideTable_PreserveKindLevelStartAndOrder() {
+            const string html = """
+                <table><tr><td>
+                  <ul style="list-style-type:square">
+                    <li>Bullet one
+                      <ol start="4" style="list-style-type:lower-alpha">
+                        <li>Number four<ul style="list-style-type:circle"><li>Deep bullet</li></ul></li>
+                        <li>Number five</li>
+                      </ol>
+                    </li>
+                    <li>Bullet two</li>
+                  </ul>
+                </td></tr></table>
+                """;
+
+            using var doc = OfficeIMO.Html.HtmlConversionDocument.Parse(html).ToWordDocument(new HtmlToWordOptions());
+
+            var listItems = doc.Tables.Single().Rows[0].Cells[0].Paragraphs
+                .Where(paragraph => paragraph.IsListItem)
+                .GroupBy(paragraph => paragraph._paragraph)
+                .Select(group => group.OrderByDescending(paragraph => paragraph.Text.Length).First())
+                .ToList();
+            Assert.Equal(
+                new[] { "Bullet one", "Number four", "Deep bullet", "Number five", "Bullet two" },
+                listItems.Select(paragraph => paragraph.Text.Trim()).ToArray());
+            Assert.Equal(new[] { 0, 1, 2, 1, 0 }, listItems.Select(paragraph => paragraph.ListItemLevel!.Value).ToArray());
+
+            var info = listItems.Select(paragraph => DocumentTraversal.GetListInfo(paragraph)!.Value).ToArray();
+            Assert.False(info[0].Ordered);
+            Assert.Equal("■", info[0].LevelText);
+            Assert.True(info[1].Ordered);
+            Assert.Equal(NumberFormatValues.LowerLetter, info[1].NumberFormat);
+            Assert.Equal(4, info[1].Start);
+            Assert.False(info[2].Ordered);
+            Assert.Equal("o", info[2].LevelText);
+            Assert.False(info[4].Ordered);
+
+            string roundTripHtml = doc.ToHtml(new WordToHtmlOptions { IncludeListStyles = true });
+            Assert.Contains("<table", roundTripHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<ul", roundTripHtml, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("<ol", roundTripHtml, StringComparison.OrdinalIgnoreCase);
+
+            using MemoryStream stream = doc.ToStream();
+            stream.Position = 0;
+            using WordprocessingDocument package = WordprocessingDocument.Open(stream, false);
+            var errors = new OpenXmlValidator().Validate(package).ToList();
+            Assert.True(errors.Count == 0, string.Join(Environment.NewLine, errors.Select(error => error.Description)));
+        }
+
         [Fact]
         public void HtmlToWord_ListNumbering_ContiguousLists() {
             string html = "<ol><li>One</li></ol><ol><li>Two</li></ol>";

--- a/OfficeIMO.Html.Tests/Html.WordToHtml.cs
+++ b/OfficeIMO.Html.Tests/Html.WordToHtml.cs
@@ -1,5 +1,7 @@
+using AngleSharp.Dom;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Html;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Html;
 using System;
@@ -132,9 +134,50 @@ namespace OfficeIMO.Tests {
             Assert.Contains("<ul", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("<ol", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Sub 1", html, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(2, html.Split(new[] { "<ul" }, StringSplitOptions.None).Length - 1);
+            Assert.Equal(1, html.Split(new[] { "<ol" }, StringSplitOptions.None).Length - 1);
+            Assert.Contains("Item 1<ul", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("<table>", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains(">A<", html, StringComparison.OrdinalIgnoreCase);
             Assert.Contains(">D<", html, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Test_WordToHtml_ListsInsideTable_PreserveStructureAndNesting() {
+            using var doc = WordDocument.Create();
+            var table = doc.AddTable(1, 2);
+
+            var bulletCell = table.Rows[0].Cells[0];
+            bulletCell.Paragraphs[0].Remove();
+            var bullets = bulletCell.AddList(WordListStyle.Bulleted);
+            bullets.AddItem("Bullet root");
+            bullets.AddItem("Nested bullet", 1);
+            bullets.AddItem("Bullet next");
+
+            var orderedCell = table.Rows[0].Cells[1];
+            orderedCell.Paragraphs[0].Remove();
+            var numbers = orderedCell.AddList(WordListStyle.Numbered);
+            numbers.SetStartNumberingValue(4);
+            numbers.AddItem("Number four");
+            numbers.AddItem("Number five");
+
+            string html = doc.ToHtml();
+            var parsed = HtmlDocumentParser.ParseDocument(html);
+            var cells = parsed.QuerySelectorAll("td");
+            Assert.Equal(2, cells.Length);
+
+            IElement bulletList = Assert.IsAssignableFrom<IElement>(cells[0].QuerySelector("ul"));
+            var bulletItems = bulletList.Children.Where(element => element.LocalName == "li").ToArray();
+            Assert.Equal(2, bulletItems.Length);
+            Assert.Equal("Bullet rootNested bullet", bulletItems[0].TextContent);
+            Assert.Equal("Nested bullet", bulletItems[0].QuerySelector("ul > li")!.TextContent);
+            Assert.Equal("Bullet next", bulletItems[1].TextContent);
+
+            IElement orderedList = Assert.IsAssignableFrom<IElement>(cells[1].QuerySelector("ol"));
+            Assert.Equal("4", orderedList.GetAttribute("start"));
+            Assert.Equal(
+                new[] { "Number four", "Number five" },
+                orderedList.Children.Where(element => element.LocalName == "li").Select(element => element.TextContent).ToArray());
         }
 
         [Fact]

--- a/OfficeIMO.Markdown.Tests/Markdown.NestedLists.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown.NestedLists.cs
@@ -17,6 +17,25 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void MarkdownToWord_NestedOrderedList_PreservesItsOwnStartValue() {
+            const string md = "1. Outer\n   4. Nested four\n   5. Nested five\n2. Next";
+
+            using var doc = OfficeIMO.Markdown.MarkdownReader.Parse(md).ToWordDocument(new MarkdownToWordOptions());
+
+            var paragraphs = doc.Paragraphs
+                .Where(paragraph => paragraph.IsListItem && !string.IsNullOrWhiteSpace(paragraph.Text))
+                .ToArray();
+            Assert.Equal(new[] { "Outer", "Nested four", "Nested five", "Next" }, paragraphs.Select(paragraph => paragraph.Text.Trim()).ToArray());
+
+            DocumentTraversal.ListInfo outer = DocumentTraversal.GetListInfo(paragraphs[0])!.Value;
+            DocumentTraversal.ListInfo nested = DocumentTraversal.GetListInfo(paragraphs[1])!.Value;
+            Assert.Equal(0, outer.Level);
+            Assert.Equal(1, outer.Start);
+            Assert.Equal(1, nested.Level);
+            Assert.Equal(4, nested.Start);
+        }
+
+        [Fact]
         public void MarkdownToWord_TaskLists() {
             string md = "- [ ] Task1\n- [x] Task2\n  - [ ] Subtask";
 

--- a/OfficeIMO.Markup.Excel/OfficeMarkupExcelExporter.cs
+++ b/OfficeIMO.Markup.Excel/OfficeMarkupExcelExporter.cs
@@ -61,8 +61,9 @@ internal sealed class OfficeMarkupExcelExporter {
                 AddWorksheetText(context, paragraph.Text, bold: false);
                 break;
             case OfficeMarkupListBlock list when context.Options.IncludeMarkdownAsWorksheetText:
-                foreach (var item in list.Items) {
-                    AddWorksheetText(context, "- " + item.Text, bold: false);
+                foreach (var entry in OfficeMarkupListTraversal.Enumerate(list)) {
+                    string indent = new string('\u00A0', entry.Depth * 2);
+                    AddWorksheetText(context, indent + entry.Marker + " " + entry.Item.Text, bold: false);
                 }
 
                 break;

--- a/OfficeIMO.Markup.Tests/OfficeMarkupParserTests.cs
+++ b/OfficeIMO.Markup.Tests/OfficeMarkupParserTests.cs
@@ -1,5 +1,6 @@
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
+using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Markup;
 using OfficeIMO.Markup.Excel;
 using OfficeIMO.Markup.PowerPoint;
@@ -2451,6 +2452,73 @@ profile: document
                 File.Delete(path);
             }
         }
+    }
+
+    [Fact]
+    public void ExcelExporter_ProjectsOrderedAndNestedListsWithTheirSemanticMarkers() {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+
+        try {
+            var documentModel = new OfficeMarkupDocument(OfficeMarkupProfile.Workbook);
+            documentModel.Blocks.Add(new OfficeMarkupSheetBlock("Lists"));
+            var list = CreateMixedNestedList();
+            documentModel.Blocks.Add(list);
+
+            documentModel.SaveAsExcel(path, new MarkupToExcelOptions());
+
+            using var spreadsheet = SpreadsheetDocument.Open(path, false);
+            var sheet = Assert.Single(spreadsheet.WorkbookPart!.Workbook.Sheets!.OfType<Sheet>());
+            var worksheetPart = (WorksheetPart)spreadsheet.WorkbookPart.GetPartById(sheet.Id!);
+            Assert.Equal("4. Root four", GetCellValue(spreadsheet, worksheetPart, "A1"));
+            Assert.Equal("\u00A0\u00A0- Nested bullet", GetCellValue(spreadsheet, worksheetPart, "A2"));
+            Assert.Equal("5. Root five", GetCellValue(spreadsheet, worksheetPart, "A3"));
+
+            using var document = OfficeIMO.Excel.ExcelDocument.Load(path, new OfficeIMO.Excel.ExcelLoadOptions { AccessMode = OfficeIMO.Drawing.DocumentAccessMode.ReadOnly });
+            Assert.Empty(document.ValidateOpenXml());
+        } finally {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void WordExporter_PreservesOrderedStartAndNestedListKind() {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".docx");
+
+        try {
+            var documentModel = new OfficeMarkupDocument(OfficeMarkupProfile.Document);
+            documentModel.Blocks.Add(CreateMixedNestedList());
+
+            documentModel.SaveAsWord(path, new MarkupToWordOptions());
+
+            using var document = OfficeIMO.Word.WordDocument.Load(path, new WordLoadOptions { AccessMode = OfficeIMO.Drawing.DocumentAccessMode.ReadOnly });
+            var items = document.Paragraphs.Where(paragraph => paragraph.IsListItem).ToArray();
+            Assert.Equal(new[] { "Root four", "Nested bullet", "Root five" }, items.Select(paragraph => paragraph.Text).ToArray());
+            Assert.Equal(new[] { 0, 1, 0 }, items.Select(paragraph => paragraph.ListItemLevel!.Value).ToArray());
+
+            var rootInfo = DocumentTraversal.GetListInfo(items[0])!.Value;
+            var nestedInfo = DocumentTraversal.GetListInfo(items[1])!.Value;
+            Assert.True(rootInfo.Ordered);
+            Assert.Equal(4, rootInfo.Start);
+            Assert.False(nestedInfo.Ordered);
+            Assert.Equal(NumberFormatValues.Bullet, nestedInfo.NumberFormat);
+        } finally {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        }
+    }
+
+    private static OfficeMarkupListBlock CreateMixedNestedList() {
+        var root = new OfficeMarkupListBlock(ordered: true, start: 4);
+        var first = new OfficeMarkupListItem("Root four");
+        var nested = new OfficeMarkupListBlock(ordered: false);
+        nested.Items.Add(new OfficeMarkupListItem("Nested bullet"));
+        first.Blocks.Add(nested);
+        root.Items.Add(first);
+        root.Items.Add(new OfficeMarkupListItem("Root five"));
+        return root;
     }
 
     private static Cell? GetCell(WorksheetPart worksheetPart, string cellReference) {

--- a/OfficeIMO.Markup.Word/OfficeMarkupWordExporter.cs
+++ b/OfficeIMO.Markup.Word/OfficeMarkupWordExporter.cs
@@ -95,18 +95,27 @@ internal sealed class OfficeMarkupWordExporter {
 
     private static void AddList(WordExportContext context, OfficeMarkupListBlock list) {
         if (context.CurrentSection != null) {
-            for (var index = 0; index < list.Items.Count; index++) {
-                var item = list.Items[index];
-                var prefix = list.Ordered ? $"{list.Start + index}. " : "- ";
-                context.CurrentSection.AddParagraph(prefix + item.Text);
+            foreach (var entry in OfficeMarkupListTraversal.Enumerate(list)) {
+                string indent = new string(' ', entry.Depth * 2);
+                context.CurrentSection.AddParagraph(indent + entry.Marker + " " + entry.Item.Text);
             }
 
             return;
         }
 
-        var wordList = list.Ordered ? context.Document.AddListNumbered() : context.Document.AddListBulleted();
-        foreach (var item in list.Items) {
-            wordList.AddItem(item.Text);
+        var wordLists = new Dictionary<OfficeMarkupListBlock, WordList>();
+        foreach (var entry in OfficeMarkupListTraversal.Enumerate(list)) {
+            if (!wordLists.TryGetValue(entry.SourceList, out var wordList)) {
+                wordList = entry.SourceList.Ordered
+                    ? context.Document.AddListNumbered()
+                    : context.Document.AddListBulleted();
+                if (entry.SourceList.Ordered && entry.SourceList.Start != 1) {
+                    wordList.SetStartNumberingValue(entry.SourceList.Start, entry.Depth);
+                }
+                wordLists.Add(entry.SourceList, wordList);
+            }
+
+            wordList.AddItem(entry.Item.Text, entry.Depth);
         }
     }
 

--- a/OfficeIMO.Markup/OfficeIMO.Markup.csproj
+++ b/OfficeIMO.Markup/OfficeIMO.Markup.csproj
@@ -59,7 +59,9 @@
     <ItemGroup>
         <InternalsVisibleTo Include="OfficeIMO.Markup.Tests" />
         <InternalsVisibleTo Include="OfficeIMO.Markup.Cli" />
+        <InternalsVisibleTo Include="OfficeIMO.Markup.Excel" />
         <InternalsVisibleTo Include="OfficeIMO.Markup.PowerPoint" />
+        <InternalsVisibleTo Include="OfficeIMO.Markup.Word" />
     </ItemGroup>
 
 </Project>

--- a/OfficeIMO.Markup/OfficeMarkupListTraversal.cs
+++ b/OfficeIMO.Markup/OfficeMarkupListTraversal.cs
@@ -1,0 +1,37 @@
+namespace OfficeIMO.Markup;
+
+internal readonly struct OfficeMarkupListEntry {
+    internal OfficeMarkupListEntry(
+        OfficeMarkupListBlock sourceList,
+        OfficeMarkupListItem item,
+        int depth,
+        int ordinal) {
+        SourceList = sourceList;
+        Item = item;
+        Depth = depth;
+        Ordinal = ordinal;
+    }
+
+    internal OfficeMarkupListBlock SourceList { get; }
+    internal OfficeMarkupListItem Item { get; }
+    internal int Depth { get; }
+    internal int Ordinal { get; }
+    internal string Marker => SourceList.Ordered
+        ? Ordinal.ToString(System.Globalization.CultureInfo.InvariantCulture) + "."
+        : "-";
+}
+
+internal static class OfficeMarkupListTraversal {
+    internal static IEnumerable<OfficeMarkupListEntry> Enumerate(OfficeMarkupListBlock list, int depth = 0) {
+        for (int index = 0; index < list.Items.Count; index++) {
+            var item = list.Items[index];
+            yield return new OfficeMarkupListEntry(list, item, depth, list.Start + index);
+
+            foreach (var nestedList in item.Blocks.OfType<OfficeMarkupListBlock>()) {
+                foreach (var nestedItem in Enumerate(nestedList, depth + 1)) {
+                    yield return nestedItem;
+                }
+            }
+        }
+    }
+}

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Lists.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Lists.cs
@@ -40,8 +40,8 @@ namespace OfficeIMO.Word.Html {
             string? typeAttr = element.GetAttribute("type");
 
             WordList list = ordered ? CreateOrderedList() : CreateBulletedList();
-            ApplyListStyle(list, ordered, listStyleType, typeAttr);
-            ApplyListIndentMetadata(list, element);
+            ApplyListStyle(list, parentDepth, ordered, listStyleType, typeAttr);
+            ApplyListIndentMetadata(list, parentDepth, element);
 
             if (ordered) {
                 int? startValue = null;
@@ -55,30 +55,31 @@ namespace OfficeIMO.Word.Html {
                     }
                 }
                 if (startValue.HasValue) {
-                    list.SetStartNumberingValue(startValue.Value);
+                    list.SetStartNumberingValue(startValue.Value, parentDepth);
                 }
             }
 
             listStack.Push(list);
 
             int itemIndex = 0;
+            WordParagraph? insertionAnchor = null;
             foreach (var li in element.Children.OfType<IHtmlListItemElement>()) {
                 if (ordered) {
                     if (TryGetListItemValue(li, out int liValue)) {
                         if (itemIndex == 0) {
-                            list.SetStartNumberingValue(liValue);
+                            list.SetStartNumberingValue(liValue, parentDepth);
                         } else {
                             list = CreateOrderedList(allowContinue: false);
-                            ApplyListStyle(list, ordered, listStyleType, typeAttr);
-                            ApplyListIndentMetadata(list, element);
-                            list.SetStartNumberingValue(liValue);
+                            ApplyListStyle(list, parentDepth, ordered, listStyleType, typeAttr);
+                            ApplyListIndentMetadata(list, parentDepth, element);
+                            list.SetStartNumberingValue(liValue, parentDepth);
                             listStack.Pop();
                             listStack.Push(list);
                         }
                     }
                 }
 
-                ProcessListItem(li, doc, section, options, listStack, formatting, cell, headerFooter);
+                insertionAnchor = ProcessListItem(li, doc, section, options, listStack, formatting, cell, headerFooter, insertionAnchor);
                 itemIndex++;
             }
 
@@ -248,12 +249,12 @@ namespace OfficeIMO.Word.Html {
             return decoded.ToString();
         }
 
-        private static void ApplyListIndentMetadata(WordList list, IElement element) {
-            if (list.Numbering.Levels.Count == 0) {
+        private static void ApplyListIndentMetadata(WordList list, int levelIndex, IElement element) {
+            if (list.Numbering.Levels.Count <= levelIndex) {
                 return;
             }
 
-            var level = list.Numbering.Levels[0];
+            var level = list.Numbering.Levels[levelIndex];
             if (TryGetTwipsAttribute(element, "data-left-indent-twips", out var leftIndentTwips)) {
                 level.IndentationLeft = leftIndentTwips;
             }
@@ -271,12 +272,12 @@ namespace OfficeIMO.Word.Html {
                 && value >= 0;
         }
 
-        private static void ApplyListStyle(WordList list, bool ordered, string? listStyleType, string? typeAttr) {
+        private static void ApplyListStyle(WordList list, int levelIndex, bool ordered, string? listStyleType, string? typeAttr) {
             var levels = list.Numbering.Levels;
-            if (levels.Count == 0) {
+            if (levels.Count <= levelIndex) {
                 return;
             }
-            var level = levels[0];
+            var level = levels[levelIndex];
             string? token = listStyleType;
             if (token != null) {
                 token = token.Trim();
@@ -360,11 +361,14 @@ namespace OfficeIMO.Word.Html {
             }
         }
 
-        private void ProcessListItem(IHtmlListItemElement element, WordDocument doc, WordSection section, HtmlToWordOptions options,
-            Stack<WordList> listStack, TextFormatting formatting, WordTableCell? cell, WordHeaderFooter? headerFooter) {
+        private WordParagraph ProcessListItem(IHtmlListItemElement element, WordDocument doc, WordSection section, HtmlToWordOptions options,
+            Stack<WordList> listStack, TextFormatting formatting, WordTableCell? cell, WordHeaderFooter? headerFooter,
+            WordParagraph? insertionAnchor) {
             var list = listStack.Peek();
             int level = listStack.Count - 1;
-            var paragraph = list.AddItem("", level);
+            var paragraph = insertionAnchor == null
+                ? list.AddItem("", level)
+                : list.AddItemAfter("", level, insertionAnchor);
             WordParagraph? blockAnchor = paragraph;
 
             ApplyParagraphStyleFromCss(paragraph, element);
@@ -389,6 +393,7 @@ namespace OfficeIMO.Word.Html {
                 }
             }
             ApplyPageBreakAfterFromCss(paragraph, element);
+            return blockAnchor ?? paragraph;
         }
 
         private static bool IsListItemTableChild(INode node) =>

--- a/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
+++ b/OfficeIMO.Word.Html/Converters/HtmlToWordConverter.Nodes.cs
@@ -778,7 +778,7 @@ namespace OfficeIMO.Word.Html {
                             break;
                         }
                     case "li": {
-                            ProcessListItem((IHtmlListItemElement)element, doc, section, options, listStack, formatting, cell, headerFooter);
+                            ProcessListItem((IHtmlListItemElement)element, doc, section, options, listStack, formatting, cell, headerFooter, insertionAnchor: null);
                             break;
                         }
                     case "table": {

--- a/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
+++ b/OfficeIMO.Word.Html/Converters/WordToHtmlConverter.cs
@@ -29,6 +29,7 @@ namespace OfficeIMO.Word.Html {
 
             Stack<IElement> listStack = new Stack<IElement>();
             Stack<IElement> itemStack = new Stack<IElement>();
+            Stack<int> listNumberStack = new Stack<int>();
 
             List<(int Number, WordFootNote Note)> footnotes = new();
             List<(int Number, WordEndNote Note)> endnotes = new();
@@ -53,6 +54,9 @@ namespace OfficeIMO.Word.Html {
                 }
                 while (itemStack.Count > 0) {
                     itemStack.Pop();
+                }
+                while (listNumberStack.Count > 0) {
+                    listNumberStack.Pop();
                 }
             }
 
@@ -613,10 +617,19 @@ namespace OfficeIMO.Word.Html {
                         IElement? cellDefinitionList = null;
                         var cellParagraphs = cell.Paragraphs;
                         var processedCellParagraphs = new HashSet<WordParagraph>();
+                        var cellListStack = new Stack<IElement>();
+                        var cellItemStack = new Stack<IElement>();
+                        var cellListNumberStack = new Stack<int>();
                         for (int pIdx = 0; pIdx < cellParagraphs.Count; pIdx++) {
                             var p = cellParagraphs[pIdx];
                             if (processedCellParagraphs.Contains(p)) {
                                 continue;
+                            }
+                            for (int j = pIdx + 1; j < cellParagraphs.Count && cellParagraphs[j].Equals(p); j++) {
+                                var candidate = cellParagraphs[j];
+                                if ((!p.IsBookmark && candidate.IsBookmark) || candidate.Text.Length > p.Text.Length) {
+                                    p = candidate;
+                                }
                             }
                             if (IsDefinitionListParagraph(p) && IsEmptyDefinitionListParagraph(p)) {
                                 for (int j = pIdx + 1; j < cellParagraphs.Count; j++) {
@@ -630,7 +643,12 @@ namespace OfficeIMO.Word.Html {
                                 }
                             }
                             processedCellParagraphs.Add(p);
-                            if (IsCodeParagraph(p)) {
+                            var cellListInfo = DocumentTraversal.GetListInfo(p);
+                            if (cellListInfo != null) {
+                                cellDefinitionList = null;
+                                AppendListParagraph(cellElement, p, cellListInfo.Value, cellListStack, cellItemStack, cellListNumberStack);
+                            } else if (IsCodeParagraph(p)) {
+                                ClearListStacks(cellListStack, cellItemStack, cellListNumberStack);
                                 cellDefinitionList = null;
                                 List<string> lines = new();
                                 lines.Add(p.Text);
@@ -644,6 +662,7 @@ namespace OfficeIMO.Word.Html {
                                 pre.AppendChild(code);
                                 cellElement.AppendChild(pre);
                             } else if (IsDefinitionListParagraph(p)) {
+                                ClearListStacks(cellListStack, cellItemStack, cellListNumberStack);
                                 if (IsEmptyDefinitionListParagraph(p)) {
                                     continue;
                                 }
@@ -653,6 +672,7 @@ namespace OfficeIMO.Word.Html {
                                 }
                                 AppendDefinitionListItem(cellDefinitionList, p);
                             } else {
+                                ClearListStacks(cellListStack, cellItemStack, cellListNumberStack);
                                 cellDefinitionList = null;
                                 AppendParagraph(cellElement, p);
                             }
@@ -761,6 +781,76 @@ namespace OfficeIMO.Word.Html {
 
             var listIndices = DocumentTraversal.BuildListIndices(document);
 
+            void ClearListStacks(Stack<IElement> lists, Stack<IElement> items, Stack<int> numberIds) {
+                lists.Clear();
+                items.Clear();
+                numberIds.Clear();
+            }
+
+            void AppendListParagraph(
+                IElement parent,
+                WordParagraph paragraph,
+                DocumentTraversal.ListInfo listInfo,
+                Stack<IElement> lists,
+                Stack<IElement> items,
+                Stack<int> numberIds) {
+                int level = listInfo.Level;
+                int desiredListDepth = level + 1;
+
+                while (lists.Count > desiredListDepth) {
+                    lists.Pop();
+                    numberIds.Pop();
+                }
+                while (items.Count > level) {
+                    items.Pop();
+                }
+
+                bool ordered = listInfo.Ordered;
+                string listTag = ordered ? "ol" : "ul";
+                int numberId = paragraph._listNumberId.GetValueOrDefault();
+                if (lists.Count == desiredListDepth
+                    && (numberIds.Peek() != numberId
+                        || !string.Equals(lists.Peek().TagName, listTag, StringComparison.OrdinalIgnoreCase))) {
+                    lists.Pop();
+                    numberIds.Pop();
+                }
+
+                while (lists.Count < desiredListDepth) {
+                    var listEl = htmlDoc.CreateElement(listTag);
+                    if (ordered) {
+                        if (listIndices.TryGetValue(paragraph, out var indexInfo)) {
+                            listEl.SetAttribute("start", indexInfo.Index.ToString());
+                        } else {
+                            listEl.SetAttribute("start", listInfo.Start.ToString());
+                        }
+                    }
+                    var typeAttr = GetListType(listInfo);
+                    if (!string.IsNullOrEmpty(typeAttr)) {
+                        listEl.SetAttribute("type", typeAttr);
+                    }
+                    var listStyle = GetListStyle(listInfo);
+                    if (options.IncludeListStyles && !string.IsNullOrEmpty(listStyle)) {
+                        listEl.SetAttribute("style", $"list-style-type:{listStyle}");
+                    }
+                    if (options.IncludeListDefinitions) {
+                        ApplyListDefinition(listEl, listInfo, listStyle, listDefinitions);
+                    }
+                    if (items.Count > 0) {
+                        items.Peek().AppendChild(listEl);
+                    } else {
+                        parent.AppendChild(listEl);
+                    }
+                    lists.Push(listEl);
+                    numberIds.Push(numberId);
+                }
+
+                var li = htmlDoc.CreateElement("li");
+                ApplyBookmarkId(li, paragraph);
+                lists.Peek().AppendChild(li);
+                items.Push(li);
+                AppendRuns(li, paragraph);
+            }
+
             var processedParagraphs = new HashSet<WordParagraph>();
             int sectionIndex = 0;
             foreach (var section in DocumentTraversal.EnumerateSections(document)) {
@@ -810,49 +900,7 @@ namespace OfficeIMO.Word.Html {
                         var listInfo = DocumentTraversal.GetListInfo(paragraph);
                         if (listInfo != null) {
                             activeDefinitionList = null;
-                            int level = listInfo.Value.Level;
-                            while (listStack.Count > level) {
-                                listStack.Pop();
-                                itemStack.Pop();
-                            }
-                            while (listStack.Count <= level) {
-                                bool ordered = listInfo.Value.Ordered;
-                                var listTag = ordered ? "ol" : "ul";
-                                var listEl = htmlDoc.CreateElement(listTag);
-                                if (ordered) {
-                                    // Continue numbering across gaps by using the numeric index of the current item when available
-                                    if (listIndices.TryGetValue(paragraph, out var indexInfo)) {
-                                        listEl.SetAttribute("start", indexInfo.Index.ToString());
-                                    } else {
-                                        listEl.SetAttribute("start", listInfo.Value.Start.ToString());
-                                    }
-                                }
-                                var typeAttr = GetListType(listInfo.Value);
-                                if (!string.IsNullOrEmpty(typeAttr)) {
-                                    listEl.SetAttribute("type", typeAttr);
-                                }
-                                var listStyle = GetListStyle(listInfo.Value);
-                                if (options.IncludeListStyles && !string.IsNullOrEmpty(listStyle)) {
-                                    listEl.SetAttribute("style", $"list-style-type:{listStyle}");
-                                }
-                                if (options.IncludeListDefinitions) {
-                                    ApplyListDefinition(listEl, listInfo.Value, listStyle, listDefinitions);
-                                }
-                                if (itemStack.Count > 0) {
-                                    itemStack.Peek().AppendChild(listEl);
-                                } else {
-                                    sectionParent.AppendChild(listEl);
-                                }
-                                listStack.Push(listEl);
-                            }
-                            while (itemStack.Count > level) {
-                                itemStack.Pop();
-                            }
-                            var li = htmlDoc.CreateElement("li");
-                            ApplyBookmarkId(li, paragraph);
-                            listStack.Peek().AppendChild(li);
-                            itemStack.Push(li);
-                            AppendRuns(li, paragraph);
+                            AppendListParagraph(sectionParent, paragraph, listInfo.Value, listStack, itemStack, listNumberStack);
                         } else {
                             CloseLists();
                             if (IsDefinitionListParagraph(paragraph)) {

--- a/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.BlockRenderer.cs
+++ b/OfficeIMO.Word.Markdown/Converters/MarkdownToWordConverter.BlockRenderer.cs
@@ -361,7 +361,7 @@ namespace OfficeIMO.Word.Markdown {
             private void RenderListBlock(IReadOnlyList<Omd.ListItem> items, WordListStyle style, int? startNumber) {
                 var list = _host.CreateList(style);
                 if (startNumber.HasValue && startNumber.Value != 1) {
-                    list.Numbering.Levels[0].SetStartNumberingValue(startNumber.Value);
+                    list.SetStartNumberingValue(startNumber.Value, _listLevel);
                 }
 
                 foreach (var item in items) {

--- a/OfficeIMO.Word.Tests/Word.EmbeddedDocuments.cs
+++ b/OfficeIMO.Word.Tests/Word.EmbeddedDocuments.cs
@@ -104,8 +104,12 @@ public partial class Word {
             FileInfo info3 = new FileInfo(tempFilePath3);
             FileInfo info4 = new FileInfo(tempFilePath4);
 
-            Assert.True(info3.Length == infoRtf.Length);
-            Assert.True(info4.Length == infoRtf.Length);
+            // Repeated RTF fragments may have their internal list identifiers remapped
+            // so Word does not merge independent numbering definitions during import.
+            Assert.True(info3.Length > 0);
+            Assert.True(info4.Length > 0);
+            Assert.StartsWith(@"{\rtf", File.ReadAllText(tempFilePath3), StringComparison.OrdinalIgnoreCase);
+            Assert.StartsWith(@"{\rtf", File.ReadAllText(tempFilePath4), StringComparison.OrdinalIgnoreCase);
 
             document.Save();
         }

--- a/OfficeIMO.Word.Tests/Word.EmbeddedHtmlLists.cs
+++ b/OfficeIMO.Word.Tests/Word.EmbeddedHtmlLists.cs
@@ -1,0 +1,47 @@
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Word {
+    private const string MixedListHtml = """
+        <html><body>
+        <ul style="list-style-type:disc">
+          <li value="1" class="bullet" data-note="value=8">Bullet</li>
+          <li VALUE='2'>Second<ol start="4"><li value="4">Nested ordered</li></ol></li>
+        </ul>
+        <ol><li value="7">Ordered</li></ol>
+        <script>const template = '<ul><li value="9">raw</li></ul>';</script>
+        </body></html>
+        """;
+
+    [Fact]
+    public void AddEmbeddedFragment_PreservesListKindsWhenUnorderedItemsDeclareValues() {
+        using WordDocument document = WordDocument.Create();
+
+        WordEmbeddedDocument embedded = document.AddEmbeddedFragment(
+            MixedListHtml,
+            WordAlternativeFormatImportPartType.Html);
+
+        string storedHtml = Assert.IsType<string>(embedded.GetHtml());
+        Assert.DoesNotContain("value=\"1\"", storedHtml, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("VALUE='2'", storedHtml, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("data-note=\"value=8\"", storedHtml, StringComparison.Ordinal);
+        Assert.Contains("<ol start=\"4\"><li value=\"4\">Nested ordered", storedHtml, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("<ol><li value=\"7\">Ordered", storedHtml, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("'<ul><li value=\"9\">raw</li></ul>'", storedHtml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AddEmbeddedFragmentAfter_AppliesTheSameListNormalization() {
+        using WordDocument document = WordDocument.Create();
+        WordParagraph anchor = document.AddParagraph("Before");
+
+        WordEmbeddedDocument embedded = document.AddEmbeddedFragmentAfter(anchor, MixedListHtml);
+
+        string storedHtml = Assert.IsType<string>(embedded.GetHtml());
+        Assert.DoesNotContain("value=\"1\"", storedHtml, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("<li value=\"4\">Nested ordered", storedHtml, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("<li value=\"7\">Ordered", storedHtml, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/OfficeIMO.Word.Tests/Word.EmbeddedRtfLists.cs
+++ b/OfficeIMO.Word.Tests/Word.EmbeddedRtfLists.cs
@@ -1,0 +1,122 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Word {
+    private const string NumberedListRtf = """
+        {\rtf1\ansi\deff0{\fonttbl{\f0 Arial;}}{\*\listtable{\list\listtemplateid77{\listlevel\levelnfc0\levelnfcn0\levelstartat1{\leveltext\'02\'00.;}{\levelnumbers\'01;}\fi-360\li720}{\listname Numbered;}\listid100}}{\*\listoverridetable{\listoverride\listid100\listoverridecount0\ls1}}\pard\plain\f0\fs22\ls1\ilvl0 Existing\par}
+        """;
+
+    private const string BulletListRtf = """
+        {\rtf1\ansi\deff0{\fonttbl{\f0 Arial;}}{\*\listtable{\list\listtemplateid77{\listlevel\levelnfc23\levelnfcn23\levelstartat1{\leveltext\'01\u8226 ?;}{\levelnumbers;}\fi-360\li720}{\listname Bullet;}\listid100}}{\*\listoverridetable{\listoverride\listid100\listoverridecount0\ls1}}\pard\plain\f0\fs22\ls1\ilvl0 TODAY: Today\par\pard\plain\f0\fs22\ls1\ilvl0 YESTERDAY: Yesterday\par\pard Literal \\listid100 stays literal.\par}
+        """;
+
+    private const string NestedTableListRtf = """
+        {\rtf1\ansi{\*\listtable{\list\listtemplateid77{\listlevel\levelnfc0\levelnfcn0\levelstartat4{\leveltext\'02\'00.;}{\levelnumbers\'01;}\fi-360\li720}{\listlevel\levelnfc23\levelnfcn23\levelstartat1{\leveltext\'01\u8226 ?;}{\levelnumbers;}\fi-360\li1440}{\listname Mixed;}\listid100}}{\*\listoverridetable{\listoverride\listid100\listoverridecount0\ls1}}{\trowd\cellx5000\pard\intbl\ls1\ilvl0 Outer four\par\pard\intbl\ls1\ilvl1 Nested bullet\cell\row}}
+        """;
+
+    private const string BinaryPayloadListRtf = """
+        {\rtf1\ansi{\*\objdata\bin10 \listid100}{\*\listtable{\list\listtemplateid77{\listlevel\levelnfc23\levelnfcn23\levelstartat1{\leveltext\'01\u8226 ?;}{\levelnumbers;}\fi-360\li720}{\listname Bullet;}\listid100}}{\*\listoverridetable{\listoverride\listid100\listoverridecount0\ls1}}\pard\ls1\ilvl0 Bullet\par}
+        """;
+
+    [Fact]
+    public void AddEmbeddedFragment_IsolatesCollidingRtfListIdentifiers() {
+        using WordDocument document = WordDocument.Create();
+
+        WordEmbeddedDocument numbered = document.AddEmbeddedFragment(
+            NumberedListRtf,
+            WordAlternativeFormatImportPartType.Rtf);
+        WordEmbeddedDocument bullets = document.AddEmbeddedFragment(
+            BulletListRtf,
+            WordAlternativeFormatImportPartType.Rtf);
+
+        string storedNumbered = ReadRtf(numbered);
+        string storedBullets = ReadRtf(bullets);
+        Assert.Equal(NumberedListRtf, storedNumbered);
+
+        AssertIdentifierWasRemapped(storedNumbered, storedBullets, "listid");
+        AssertIdentifierWasRemapped(storedNumbered, storedBullets, "ls");
+        AssertIdentifierWasRemapped(storedNumbered, storedBullets, "listtemplateid");
+        Assert.Contains(@"\levelnfc23", storedBullets, StringComparison.Ordinal);
+        Assert.Contains(@"\\listid100 stays literal", storedBullets, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AddEmbeddedFragmentAfter_AppliesRtfListIsolation() {
+        using WordDocument document = WordDocument.Create();
+        WordParagraph anchor = document.AddParagraph("Anchor");
+        WordEmbeddedDocument numbered = document.AddEmbeddedFragment(
+            NumberedListRtf,
+            WordAlternativeFormatImportPartType.Rtf);
+
+        WordEmbeddedDocument bullets = document.AddEmbeddedFragmentAfter(
+            anchor,
+            BulletListRtf,
+            WordAlternativeFormatImportPartType.Rtf);
+
+        AssertIdentifierWasRemapped(ReadRtf(numbered), ReadRtf(bullets), "listid");
+        AssertIdentifierWasRemapped(ReadRtf(numbered), ReadRtf(bullets), "ls");
+        AssertIdentifierWasRemapped(ReadRtf(numbered), ReadRtf(bullets), "listtemplateid");
+    }
+
+    [Fact]
+    public void AddEmbeddedFragment_RemapKeepsNestedTableListReferencesConsistent() {
+        using WordDocument document = WordDocument.Create();
+        document.AddEmbeddedFragment(NumberedListRtf, WordAlternativeFormatImportPartType.Rtf);
+
+        WordEmbeddedDocument nested = document.AddEmbeddedFragment(
+            NestedTableListRtf,
+            WordAlternativeFormatImportPartType.Rtf);
+        string storedNested = ReadRtf(nested);
+
+        int[] listIds = GetControlValues(storedNested, "listid");
+        Assert.Equal(2, listIds.Length);
+        Assert.Single(listIds.Distinct());
+        Assert.DoesNotContain(100, listIds);
+
+        int[] overrideIds = GetControlValues(storedNested, "ls");
+        Assert.Equal(3, overrideIds.Length);
+        Assert.Single(overrideIds.Distinct());
+        Assert.DoesNotContain(1, overrideIds);
+        Assert.Contains(@"\levelnfc0", storedNested, StringComparison.Ordinal);
+        Assert.Contains(@"\levelnfc23", storedNested, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AddEmbeddedFragment_RtfBinaryPayloadIsNotRewrittenAsControlWords() {
+        using WordDocument document = WordDocument.Create();
+        document.AddEmbeddedFragment(NumberedListRtf, WordAlternativeFormatImportPartType.Rtf);
+
+        WordEmbeddedDocument bullets = document.AddEmbeddedFragment(
+            BinaryPayloadListRtf,
+            WordAlternativeFormatImportPartType.Rtf);
+        string storedBullets = ReadRtf(bullets);
+
+        Assert.Contains(@"\bin10 \listid100", storedBullets, StringComparison.Ordinal);
+        Match listTableId = Regex.Match(
+            storedBullets,
+            @"\\listtable.*?\\listid(-?\d+)",
+            RegexOptions.Singleline);
+        Assert.True(listTableId.Success);
+        Assert.NotEqual(100, int.Parse(listTableId.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    private static string ReadRtf(WordEmbeddedDocument embedded) =>
+        Encoding.UTF8.GetString(embedded.ToBytes());
+
+    private static void AssertIdentifierWasRemapped(string first, string second, string controlWord) {
+        int firstValue = Assert.Single(GetControlValues(first, controlWord).Distinct());
+        int secondValue = Assert.Single(GetControlValues(second, controlWord).Distinct());
+        Assert.NotEqual(firstValue, secondValue);
+    }
+
+    private static int[] GetControlValues(string rtf, string controlWord) {
+        return Regex.Matches(rtf, @"(?<!\\)\\" + Regex.Escape(controlWord) + @"(-?\d+)")
+            .Cast<Match>()
+            .Select(match => int.Parse(match.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture))
+            .ToArray();
+    }
+}

--- a/OfficeIMO.Word.Tests/Word.ListsInEmptyTableCells.cs
+++ b/OfficeIMO.Word.Tests/Word.ListsInEmptyTableCells.cs
@@ -1,0 +1,33 @@
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
+using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Word;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class Word {
+    [Fact]
+    public void TableCell_AddList_WorksAfterItsPlaceholderParagraphIsRemoved() {
+        using WordDocument document = WordDocument.Create();
+        WordTableCell cell = document.AddTable(1, 1).Rows[0].Cells[0];
+        cell.Paragraphs[0].Remove();
+        Assert.Empty(cell.Paragraphs);
+
+        WordList list = cell.AddList(WordListStyle.Bulleted);
+        WordParagraph first = list.AddItem("First");
+        WordParagraph nested = list.AddItem("Nested", 1);
+
+        Assert.Equal(new[] { "First", "Nested" }, cell.Paragraphs.Select(paragraph => paragraph.Text).ToArray());
+        Assert.All(cell.Paragraphs, paragraph => Assert.Same(cell._tableCell, paragraph._paragraph.Parent));
+        Assert.Equal(NumberFormatValues.Bullet, DocumentTraversal.GetListInfo(first)!.Value.NumberFormat);
+        Assert.Equal(1, DocumentTraversal.GetListInfo(nested)!.Value.Level);
+
+        using MemoryStream stream = document.ToStream();
+        stream.Position = 0;
+        using WordprocessingDocument package = WordprocessingDocument.Open(stream, false);
+        var errors = new OpenXmlValidator().Validate(package).ToList();
+        Assert.True(errors.Count == 0, string.Join(Environment.NewLine, errors.Select(error => error.Description)));
+    }
+}

--- a/OfficeIMO.Word/Helpers/EmbeddedFragmentContentNormalizer.cs
+++ b/OfficeIMO.Word/Helpers/EmbeddedFragmentContentNormalizer.cs
@@ -1,0 +1,19 @@
+using DocumentFormat.OpenXml.Packaging;
+
+namespace OfficeIMO.Word;
+
+/// <summary>
+/// Applies format-specific normalization before an alternative-format fragment is embedded.
+/// </summary>
+internal static class EmbeddedFragmentContentNormalizer {
+    internal static string Normalize(
+        MainDocumentPart mainDocumentPart,
+        string content,
+        WordAlternativeFormatImportPartType partType) {
+        return partType switch {
+            WordAlternativeFormatImportPartType.Html => HtmlListSemanticsNormalizer.Normalize(content),
+            WordAlternativeFormatImportPartType.Rtf => RtfListSemanticsNormalizer.Normalize(content, mainDocumentPart),
+            _ => content
+        };
+    }
+}

--- a/OfficeIMO.Word/Helpers/HtmlListSemanticsNormalizer.cs
+++ b/OfficeIMO.Word/Helpers/HtmlListSemanticsNormalizer.cs
@@ -1,0 +1,255 @@
+namespace OfficeIMO.Word;
+
+/// <summary>
+/// Normalizes HTML list markup before it is handed to Word's AltChunk importer.
+/// </summary>
+/// <remarks>
+/// Word interprets a <c>value</c> attribute on an item in an unordered list as
+/// numbering metadata. Browsers ignore that attribute for bullet semantics, so
+/// remove it only when the nearest containing list is a <c>ul</c>. Ordered-list
+/// values remain intact.
+/// </remarks>
+internal static class HtmlListSemanticsNormalizer {
+    internal static string Normalize(string html) {
+        if (string.IsNullOrEmpty(html)
+            || html.IndexOf("<li", StringComparison.OrdinalIgnoreCase) < 0
+            || html.IndexOf("<ul", StringComparison.OrdinalIgnoreCase) < 0) {
+            return html;
+        }
+
+        var output = new StringBuilder(html.Length);
+        var listAncestors = new List<string>();
+        string? rawTextElement = null;
+        int position = 0;
+
+        while (position < html.Length) {
+            if (rawTextElement != null) {
+                int rawEnd = html.IndexOf("</" + rawTextElement, position, StringComparison.OrdinalIgnoreCase);
+                if (rawEnd < 0) {
+                    output.Append(html, position, html.Length - position);
+                    break;
+                }
+
+                output.Append(html, position, rawEnd - position);
+                position = rawEnd;
+                rawTextElement = null;
+            }
+
+            int tagStart = html.IndexOf('<', position);
+            if (tagStart < 0) {
+                output.Append(html, position, html.Length - position);
+                break;
+            }
+
+            output.Append(html, position, tagStart - position);
+
+            if (html.IndexOf("<!--", tagStart, StringComparison.Ordinal) == tagStart) {
+                int commentEnd = html.IndexOf("-->", tagStart + 4, StringComparison.Ordinal);
+                if (commentEnd < 0) {
+                    output.Append(html, tagStart, html.Length - tagStart);
+                    break;
+                }
+
+                int commentLength = commentEnd + 3 - tagStart;
+                output.Append(html, tagStart, commentLength);
+                position = commentEnd + 3;
+                continue;
+            }
+
+            int tagEnd = FindTagEnd(html, tagStart);
+            if (tagEnd < 0) {
+                output.Append(html, tagStart, html.Length - tagStart);
+                break;
+            }
+
+            string tag = html.Substring(tagStart, tagEnd - tagStart + 1);
+            if (TryReadTag(tag, out string tagName, out bool closing, out bool selfClosing)) {
+                if (!closing
+                    && string.Equals(tagName, "li", StringComparison.OrdinalIgnoreCase)
+                    && listAncestors.Count > 0
+                    && string.Equals(listAncestors[listAncestors.Count - 1], "ul", StringComparison.OrdinalIgnoreCase)) {
+                    tag = RemoveValueAttributes(tag);
+                }
+
+                if (string.Equals(tagName, "ul", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(tagName, "ol", StringComparison.OrdinalIgnoreCase)) {
+                    if (closing) {
+                        RemoveClosedList(listAncestors, tagName);
+                    } else if (!selfClosing) {
+                        listAncestors.Add(tagName.ToLowerInvariant());
+                    }
+                } else if (!closing && !selfClosing
+                    && (string.Equals(tagName, "script", StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(tagName, "style", StringComparison.OrdinalIgnoreCase))) {
+                    rawTextElement = tagName;
+                }
+            }
+
+            output.Append(tag);
+            position = tagEnd + 1;
+        }
+
+        return output.ToString();
+    }
+
+    private static int FindTagEnd(string html, int tagStart) {
+        char quote = '\0';
+        for (int i = tagStart + 1; i < html.Length; i++) {
+            char current = html[i];
+            if (quote != '\0') {
+                if (current == quote) {
+                    quote = '\0';
+                }
+                continue;
+            }
+
+            if (current == '\'' || current == '"') {
+                quote = current;
+            } else if (current == '>') {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static bool TryReadTag(string tag, out string name, out bool closing, out bool selfClosing) {
+        name = string.Empty;
+        closing = false;
+        selfClosing = false;
+
+        int position = 1;
+        while (position < tag.Length && char.IsWhiteSpace(tag[position])) {
+            position++;
+        }
+
+        if (position >= tag.Length || tag[position] == '!' || tag[position] == '?') {
+            return false;
+        }
+
+        if (tag[position] == '/') {
+            closing = true;
+            position++;
+            while (position < tag.Length && char.IsWhiteSpace(tag[position])) {
+                position++;
+            }
+        }
+
+        int nameStart = position;
+        while (position < tag.Length && IsNameCharacter(tag[position])) {
+            position++;
+        }
+
+        if (position == nameStart) {
+            return false;
+        }
+
+        name = tag.Substring(nameStart, position - nameStart);
+        int tail = tag.Length - 2;
+        while (tail >= 0 && char.IsWhiteSpace(tag[tail])) {
+            tail--;
+        }
+        selfClosing = tail >= 0 && tag[tail] == '/';
+        return true;
+    }
+
+    private static bool IsNameCharacter(char value) =>
+        char.IsLetterOrDigit(value) || value == '-' || value == ':' || value == '_';
+
+    private static void RemoveClosedList(List<string> listAncestors, string tagName) {
+        for (int i = listAncestors.Count - 1; i >= 0; i--) {
+            if (!string.Equals(listAncestors[i], tagName, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            listAncestors.RemoveRange(i, listAncestors.Count - i);
+            return;
+        }
+    }
+
+    private static string RemoveValueAttributes(string tag) {
+        var ranges = new List<Tuple<int, int>>();
+        int position = 1;
+        while (position < tag.Length && char.IsWhiteSpace(tag[position])) {
+            position++;
+        }
+        while (position < tag.Length && IsNameCharacter(tag[position])) {
+            position++;
+        }
+
+        int tagContentEnd = tag.Length - 1;
+        while (position < tagContentEnd) {
+            int whitespaceStart = position;
+            while (position < tagContentEnd && char.IsWhiteSpace(tag[position])) {
+                position++;
+            }
+
+            if (position >= tagContentEnd || tag[position] == '/') {
+                break;
+            }
+
+            int attributeStart = position;
+            while (position < tagContentEnd
+                && !char.IsWhiteSpace(tag[position])
+                && tag[position] != '='
+                && tag[position] != '/'
+                && tag[position] != '>') {
+                position++;
+            }
+
+            if (position == attributeStart) {
+                position++;
+                continue;
+            }
+
+            string attributeName = tag.Substring(attributeStart, position - attributeStart);
+            int attributeNameEnd = position;
+            while (position < tagContentEnd && char.IsWhiteSpace(tag[position])) {
+                position++;
+            }
+
+            if (position < tagContentEnd && tag[position] == '=') {
+                position++;
+                while (position < tagContentEnd && char.IsWhiteSpace(tag[position])) {
+                    position++;
+                }
+
+                if (position < tagContentEnd && (tag[position] == '\'' || tag[position] == '"')) {
+                    char quote = tag[position++];
+                    while (position < tagContentEnd && tag[position] != quote) {
+                        position++;
+                    }
+                    if (position < tagContentEnd) {
+                        position++;
+                    }
+                } else {
+                    while (position < tagContentEnd
+                        && !char.IsWhiteSpace(tag[position])
+                        && tag[position] != '/'
+                        && tag[position] != '>') {
+                        position++;
+                    }
+                }
+            } else {
+                position = attributeNameEnd;
+            }
+
+            if (string.Equals(attributeName, "value", StringComparison.OrdinalIgnoreCase)) {
+                ranges.Add(Tuple.Create(whitespaceStart, position));
+            }
+        }
+
+        if (ranges.Count == 0) {
+            return tag;
+        }
+
+        var normalized = new StringBuilder(tag.Length);
+        int copiedThrough = 0;
+        foreach (var range in ranges) {
+            normalized.Append(tag, copiedThrough, range.Item1 - copiedThrough);
+            copiedThrough = range.Item2;
+        }
+        normalized.Append(tag, copiedThrough, tag.Length - copiedThrough);
+        return normalized.ToString();
+    }
+}

--- a/OfficeIMO.Word/Helpers/RtfListSemanticsNormalizer.cs
+++ b/OfficeIMO.Word/Helpers/RtfListSemanticsNormalizer.cs
@@ -1,0 +1,289 @@
+using DocumentFormat.OpenXml.Packaging;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+namespace OfficeIMO.Word;
+
+/// <summary>
+/// Isolates RTF list identifiers before Word merges an AltChunk into the document.
+/// </summary>
+/// <remarks>
+/// Independently produced RTF documents commonly reuse the same list, list-override,
+/// and template identifiers. Word can then bind a later fragment to an earlier list
+/// definition, for example rendering bullets as the next values of a numbered list.
+/// This normalizer preserves identifiers when they are unused and remaps only values
+/// that collide with an RTF fragment already embedded in the same document.
+/// </remarks>
+internal static class RtfListSemanticsNormalizer {
+    private const string RtfContentType = "application/rtf";
+    private static readonly ConditionalWeakTable<MainDocumentPart, OccupiedIdentifierState> IdentifierStates =
+        new ConditionalWeakTable<MainDocumentPart, OccupiedIdentifierState>();
+
+    internal static string Normalize(string rtf, MainDocumentPart mainDocumentPart) {
+        if (string.IsNullOrEmpty(rtf)
+            || (rtf.IndexOf("\\list", StringComparison.OrdinalIgnoreCase) < 0
+                && rtf.IndexOf("\\ls", StringComparison.OrdinalIgnoreCase) < 0)) {
+            return rtf;
+        }
+
+        var current = new IdentifierSets();
+        CollectIdentifiers(rtf, current);
+        OccupiedIdentifierState state = IdentifierStates.GetValue(
+            mainDocumentPart,
+            _ => new OccupiedIdentifierState());
+        lock (state.SyncRoot) {
+            if (!state.Initialized) {
+                CollectExistingIdentifiers(mainDocumentPart, state.Identifiers);
+                state.Initialized = true;
+            }
+
+            string normalized = rtf;
+            if (current.Overlaps(state.Identifiers)) {
+                var mappings = IdentifierMappings.Create(current, state.Identifiers);
+                normalized = RewriteIdentifiers(rtf, mappings);
+                current = new IdentifierSets();
+                CollectIdentifiers(normalized, current);
+            }
+
+            state.Identifiers.UnionWith(current);
+            return normalized;
+        }
+    }
+
+    private static void CollectExistingIdentifiers(
+        MainDocumentPart mainDocumentPart,
+        IdentifierSets identifiers) {
+        foreach (AlternativeFormatImportPart part in mainDocumentPart.AlternativeFormatImportParts) {
+            if (!string.Equals(part.ContentType, RtfContentType, StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            using Stream stream = part.GetStream(FileMode.Open, FileAccess.Read);
+            using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+            CollectIdentifiers(reader.ReadToEnd(), identifiers);
+        }
+    }
+
+    private static void CollectIdentifiers(string rtf, IdentifierSets identifiers) {
+        ScanControlWords(rtf, (kind, _, _, value) => identifiers.Get(kind).Add(value));
+    }
+
+    private static string RewriteIdentifiers(string rtf, IdentifierMappings mappings) {
+        var replacements = new List<Replacement>();
+        ScanControlWords(rtf, (kind, start, length, value) => {
+            int replacement = mappings.Get(kind)[value];
+            if (replacement != value) {
+                replacements.Add(new Replacement(start, length, replacement));
+            }
+        });
+
+        if (replacements.Count == 0) {
+            return rtf;
+        }
+
+        var normalized = new StringBuilder(rtf);
+        for (int index = replacements.Count - 1; index >= 0; index--) {
+            Replacement replacement = replacements[index];
+            normalized.Remove(replacement.Start, replacement.Length);
+            normalized.Insert(replacement.Start, replacement.Value.ToString(CultureInfo.InvariantCulture));
+        }
+        return normalized.ToString();
+    }
+
+    private static void ScanControlWords(string rtf, Action<IdentifierKind, int, int, int> visitor) {
+        int position = 0;
+        while (position < rtf.Length) {
+            if (rtf[position] != '\\' || position + 1 >= rtf.Length) {
+                position++;
+                continue;
+            }
+
+            int nameStart = position + 1;
+            if (!char.IsLetter(rtf[nameStart])) {
+                position += 2;
+                continue;
+            }
+
+            int nameEnd = nameStart + 1;
+            while (nameEnd < rtf.Length && char.IsLetter(rtf[nameEnd])) {
+                nameEnd++;
+            }
+
+            int numberStart = nameEnd;
+            int numberEnd = numberStart;
+            if (numberEnd < rtf.Length && rtf[numberEnd] == '-') {
+                numberEnd++;
+            }
+            int digitStart = numberEnd;
+            while (numberEnd < rtf.Length && char.IsDigit(rtf[numberEnd])) {
+                numberEnd++;
+            }
+
+            int value = 0;
+            bool hasParameter = numberEnd > digitStart
+                && int.TryParse(
+                    rtf.Substring(numberStart, numberEnd - numberStart),
+                    NumberStyles.AllowLeadingSign,
+                    CultureInfo.InvariantCulture,
+                    out value);
+
+            if (ControlWordEquals(rtf, nameStart, nameEnd - nameStart, "bin")) {
+                int binaryStart = numberEnd;
+                if (binaryStart < rtf.Length && rtf[binaryStart] == ' ') {
+                    binaryStart++;
+                }
+                if (hasParameter && value >= 0) {
+                    position = (int)Math.Min(rtf.Length, (long)binaryStart + value);
+                } else {
+                    position = binaryStart;
+                }
+                continue;
+            }
+
+            if (hasParameter
+                && TryGetIdentifierKind(rtf, nameStart, nameEnd - nameStart, out IdentifierKind kind)) {
+                visitor(kind, numberStart, numberEnd - numberStart, value);
+            }
+            position = numberEnd;
+        }
+    }
+
+    private static bool ControlWordEquals(
+        string rtf,
+        int start,
+        int length,
+        string expected) {
+        return length == expected.Length
+            && string.Compare(rtf, start, expected, 0, length, StringComparison.OrdinalIgnoreCase) == 0;
+    }
+
+    private static bool TryGetIdentifierKind(
+        string rtf,
+        int start,
+        int length,
+        out IdentifierKind kind) {
+        if (ControlWordEquals(rtf, start, length, "ls")) {
+            kind = IdentifierKind.ListOverride;
+            return true;
+        }
+        if (ControlWordEquals(rtf, start, length, "listid")) {
+            kind = IdentifierKind.List;
+            return true;
+        }
+        if (ControlWordEquals(rtf, start, length, "listtemplateid")) {
+            kind = IdentifierKind.Template;
+            return true;
+        }
+
+        kind = default;
+        return false;
+    }
+
+    private enum IdentifierKind {
+        List,
+        ListOverride,
+        Template
+    }
+
+    private readonly struct Replacement {
+        internal Replacement(int start, int length, int value) {
+            Start = start;
+            Length = length;
+            Value = value;
+        }
+
+        internal int Start { get; }
+        internal int Length { get; }
+        internal int Value { get; }
+    }
+
+    private sealed class IdentifierSets {
+        internal HashSet<int> Lists { get; } = new HashSet<int>();
+        internal HashSet<int> ListOverrides { get; } = new HashSet<int>();
+        internal HashSet<int> Templates { get; } = new HashSet<int>();
+
+        internal HashSet<int> Get(IdentifierKind kind) {
+            return kind switch {
+                IdentifierKind.List => Lists,
+                IdentifierKind.ListOverride => ListOverrides,
+                IdentifierKind.Template => Templates,
+                _ => throw new ArgumentOutOfRangeException(nameof(kind))
+            };
+        }
+
+        internal bool Overlaps(IdentifierSets other) {
+            return Lists.Overlaps(other.Lists)
+                || ListOverrides.Overlaps(other.ListOverrides)
+                || Templates.Overlaps(other.Templates);
+        }
+
+        internal void UnionWith(IdentifierSets other) {
+            Lists.UnionWith(other.Lists);
+            ListOverrides.UnionWith(other.ListOverrides);
+            Templates.UnionWith(other.Templates);
+        }
+    }
+
+    private sealed class OccupiedIdentifierState {
+        internal object SyncRoot { get; } = new object();
+        internal IdentifierSets Identifiers { get; } = new IdentifierSets();
+        internal bool Initialized { get; set; }
+    }
+
+    private sealed class IdentifierMappings {
+        private IdentifierMappings() { }
+
+        internal Dictionary<int, int> Lists { get; } = new Dictionary<int, int>();
+        internal Dictionary<int, int> ListOverrides { get; } = new Dictionary<int, int>();
+        internal Dictionary<int, int> Templates { get; } = new Dictionary<int, int>();
+
+        internal Dictionary<int, int> Get(IdentifierKind kind) {
+            return kind switch {
+                IdentifierKind.List => Lists,
+                IdentifierKind.ListOverride => ListOverrides,
+                IdentifierKind.Template => Templates,
+                _ => throw new ArgumentOutOfRangeException(nameof(kind))
+            };
+        }
+
+        internal static IdentifierMappings Create(IdentifierSets current, IdentifierSets occupied) {
+            var mappings = new IdentifierMappings();
+            CreateMap(current.Lists, occupied.Lists, mappings.Lists);
+            CreateMap(current.ListOverrides, occupied.ListOverrides, mappings.ListOverrides);
+            CreateMap(current.Templates, occupied.Templates, mappings.Templates);
+            return mappings;
+        }
+
+        private static void CreateMap(
+            HashSet<int> current,
+            HashSet<int> occupied,
+            Dictionary<int, int> mappings) {
+            var reserved = new HashSet<int>(occupied);
+            foreach (int value in current.OrderBy(value => value)) {
+                if (!occupied.Contains(value)) {
+                    mappings.Add(value, value);
+                    reserved.Add(value);
+                }
+            }
+
+            foreach (int value in current.OrderBy(value => value)) {
+                if (!occupied.Contains(value)) {
+                    continue;
+                }
+
+                int replacement = FindAvailableIdentifier(reserved);
+                mappings.Add(value, replacement);
+                reserved.Add(replacement);
+            }
+        }
+
+        private static int FindAvailableIdentifier(HashSet<int> reserved) {
+            for (int candidate = 1; candidate < int.MaxValue; candidate++) {
+                if (!reserved.Contains(candidate)) {
+                    return candidate;
+                }
+            }
+            throw new InvalidOperationException("No RTF list identifier is available.");
+        }
+    }
+}

--- a/OfficeIMO.Word/WordDocument.HtmlReplacement.cs
+++ b/OfficeIMO.Word/WordDocument.HtmlReplacement.cs
@@ -77,18 +77,16 @@ namespace OfficeIMO.Word {
                 _ => throw new InvalidOperationException("Unsupported format type")
             };
 
-            AlternativeFormatImportPart chunk = mainDocPart.AddAlternativeFormatImportPart(partTypeInfo);
-            string altChunkId = mainDocPart.GetIdOfPart(chunk);
-            AltChunk altChunk = new AltChunk { Id = altChunkId };
+            htmlContent = EmbeddedFragmentContentNormalizer.Normalize(mainDocPart, htmlContent, type);
 
+            AlternativeFormatImportPart chunk = mainDocPart.AddAlternativeFormatImportPart(partTypeInfo);
             try {
-                if (type == WordAlternativeFormatImportPartType.Html) {
-                    htmlContent = HtmlListSemanticsNormalizer.Normalize(htmlContent);
-                }
                 using (MemoryStream ms = new MemoryStream(Encoding.UTF8.GetBytes(htmlContent))) {
                     chunk.FeedData(ms);
                 }
 
+                string altChunkId = mainDocPart.GetIdOfPart(chunk);
+                AltChunk altChunk = new AltChunk { Id = altChunkId };
                 paragraph._paragraph.InsertAfterSelf(altChunk);
 
                 return new WordEmbeddedDocument(this, altChunk);

--- a/OfficeIMO.Word/WordDocument.HtmlReplacement.cs
+++ b/OfficeIMO.Word/WordDocument.HtmlReplacement.cs
@@ -82,6 +82,9 @@ namespace OfficeIMO.Word {
             AltChunk altChunk = new AltChunk { Id = altChunkId };
 
             try {
+                if (type == WordAlternativeFormatImportPartType.Html) {
+                    htmlContent = HtmlListSemanticsNormalizer.Normalize(htmlContent);
+                }
                 using (MemoryStream ms = new MemoryStream(Encoding.UTF8.GetBytes(htmlContent))) {
                     chunk.FeedData(ms);
                 }

--- a/OfficeIMO.Word/WordEmbeddedDocument.cs
+++ b/OfficeIMO.Word/WordEmbeddedDocument.cs
@@ -170,6 +170,9 @@ namespace OfficeIMO.Word {
                 var documentContent = htmlFragment
                     ? fileNameOrContent
                     : File.ReadAllText(fileNameOrContent, Encoding.UTF8);
+                if (partType == WordAlternativeFormatImportPartType.Html) {
+                    documentContent = HtmlListSemanticsNormalizer.Normalize(documentContent);
+                }
 
                 using (MemoryStream ms = new MemoryStream(Encoding.UTF8.GetBytes(documentContent))) {
                     chunk.FeedData(ms);

--- a/OfficeIMO.Word/WordEmbeddedDocument.cs
+++ b/OfficeIMO.Word/WordEmbeddedDocument.cs
@@ -161,23 +161,20 @@ namespace OfficeIMO.Word {
                 _ => throw new InvalidOperationException("Unsupported format type")
             };
 
+            // If it's a fragment, we don't need to read the file.
+            string documentContent = htmlFragment
+                ? fileNameOrContent
+                : File.ReadAllText(fileNameOrContent, Encoding.UTF8);
+            documentContent = EmbeddedFragmentContentNormalizer.Normalize(mainDocPart, documentContent, partType);
+
             AlternativeFormatImportPart chunk = mainDocPart.AddAlternativeFormatImportPart(partTypeInfo);
-            string altChunkId = mainDocPart.GetIdOfPart(chunk);
-            AltChunk altChunk = new AltChunk { Id = altChunkId };
-
             try {
-                // if it's a fragment, we don't need to read the file
-                var documentContent = htmlFragment
-                    ? fileNameOrContent
-                    : File.ReadAllText(fileNameOrContent, Encoding.UTF8);
-                if (partType == WordAlternativeFormatImportPartType.Html) {
-                    documentContent = HtmlListSemanticsNormalizer.Normalize(documentContent);
-                }
-
                 using (MemoryStream ms = new MemoryStream(Encoding.UTF8.GetBytes(documentContent))) {
                     chunk.FeedData(ms);
                 }
 
+                string altChunkId = mainDocPart.GetIdOfPart(chunk);
+                AltChunk altChunk = new AltChunk { Id = altChunkId };
                 _id = altChunkId;
                 _altChunk = altChunk;
                 _altContent = chunk;

--- a/OfficeIMO.Word/WordList.Private.cs
+++ b/OfficeIMO.Word/WordList.Private.cs
@@ -266,6 +266,8 @@ public partial class WordList : WordElement {
         WordList clonedList;
         if (_headerFooter != null) {
             clonedList = new WordList(_document, _headerFooter);
+        } else if (_tableCell != null) {
+            clonedList = new WordList(_document, _tableCell);
         } else if (_wordParagraph != null) {
             clonedList = new WordList(_document, _wordParagraph, _isToc);
         } else {

--- a/OfficeIMO.Word/WordList.PublicMethods.cs
+++ b/OfficeIMO.Word/WordList.PublicMethods.cs
@@ -26,6 +26,14 @@ namespace OfficeIMO.Word {
         /// <param name="wordParagraph">The paragraph after which the item is inserted. When <c>null</c> the item is appended in the default position.</param>
         /// <returns>The <see cref="WordParagraph"/> representing the created list item.</returns>
         public WordParagraph AddItem(string? text, int level = 0, WordParagraph? wordParagraph = null) {
+            return AddItemCore(text, level, wordParagraph, preferSuppliedReference: false);
+        }
+
+        internal WordParagraph AddItemAfter(string? text, int level, WordParagraph wordParagraph) {
+            return AddItemCore(text, level, wordParagraph, preferSuppliedReference: true);
+        }
+
+        private WordParagraph AddItemCore(string? text, int level, WordParagraph? wordParagraph, bool preferSuppliedReference) {
             var paragraph = new Paragraph();
 
             var levelIndex = level;
@@ -43,7 +51,7 @@ namespace OfficeIMO.Word {
                 ));
             paragraph.Append(paragraphProperties);
 
-            var insertionReference = GetInsertionReference(wordParagraph);
+            var insertionReference = GetInsertionReference(wordParagraph, preferSuppliedReference);
 
             if (insertionReference is not null) {
                 insertionReference.InsertAfterSelf(paragraph);
@@ -54,6 +62,13 @@ namespace OfficeIMO.Word {
                     _headerFooter._header.Append(paragraph);
                 } else if (_headerFooter._footer is not null) {
                     _headerFooter._footer.Append(paragraph);
+                }
+            } else if (_tableCell is not null) {
+                var lastItem = ListItems.LastOrDefault();
+                if (lastItem is not null) {
+                    lastItem._paragraph.InsertAfterSelf(paragraph);
+                } else {
+                    _tableCell.Append(paragraph);
                 }
             } else if (_wordParagraph is not null && _wordParagraph._paragraph.Parent is TableCell parent) {
                 if (this.ListItems.Count > 0) {
@@ -136,11 +151,15 @@ namespace OfficeIMO.Word {
         /// first insertion; subsequent items are chained after the last list item to preserve order.
         /// </summary>
         /// <param name="wordParagraph">Anchor paragraph requested for the insertion.</param>
+        /// <param name="preferSuppliedReference">When <c>true</c>, use the supplied anchor even after the list already has items.</param>
         /// <returns>The <see cref="OpenXmlElement"/> that should be used as the insertion point, if any.</returns>
-        private OpenXmlElement? GetInsertionReference(WordParagraph? wordParagraph) {
+        private OpenXmlElement? GetInsertionReference(WordParagraph? wordParagraph, bool preferSuppliedReference) {
             var lastItem = ListItems.LastOrDefault();
 
             if (wordParagraph is not null) {
+                if (preferSuppliedReference) {
+                    return wordParagraph._paragraph;
+                }
                 return lastItem?._paragraph ?? wordParagraph._paragraph;
             }
 

--- a/OfficeIMO.Word/WordList.cs
+++ b/OfficeIMO.Word/WordList.cs
@@ -25,6 +25,7 @@ public partial class WordList : WordElement {
 
     private WordParagraph? _wordParagraph;
     private readonly WordHeaderFooter? _headerFooter;
+    private readonly TableCell? _tableCell;
 
     private readonly List<WordParagraph> _listItems = new();
 
@@ -319,6 +320,15 @@ public partial class WordList : WordElement {
         _document = wordDocument;
         _wordprocessingDocument = wordDocument._wordprocessingDocument;
         _headerFooter = headerFooter;
+    }
+
+    /// <summary>
+    /// Initializes a list that can append its first item directly to an empty table cell.
+    /// </summary>
+    internal WordList(WordDocument wordDocument, TableCell tableCell) {
+        _document = wordDocument;
+        _wordprocessingDocument = wordDocument._wordprocessingDocument;
+        _tableCell = tableCell;
     }
 
 }

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -910,7 +910,10 @@ namespace OfficeIMO.Word {
         /// <param name="style">List style to apply.</param>
         /// <returns>The created <see cref="WordList"/>.</returns>
         public WordList AddList(WordListStyle style) {
-            WordList wordList = new WordList(this._document, this.Paragraphs.Last());
+            var paragraphs = this.Paragraphs;
+            WordList wordList = paragraphs.Count > 0
+                ? new WordList(this._document, paragraphs[paragraphs.Count - 1])
+                : new WordList(this._document, this._tableCell);
             wordList.AddList(style);
             return wordList;
         }


### PR DESCRIPTION
## Summary

- isolate colliding RTF list-definition, list-override, and template identifiers before Word imports each AltChunk, preventing a later bullet fragment from continuing an earlier numbered fragment
- preserve nested list references inside RTF tables and skip binary payloads while rewriting control words; the identifier state is cached per document for repeated database-fragment imports
- preserve list kind, start value, nesting depth, and document order through HTML, Markdown, Word table cells, and Word-to-HTML conversion
- share semantic list traversal across Office Markup Word and Excel exports so ordered starts and nested markers are retained

## Validation

- reproduced the report in desktop Word: a numbered RTF ending at 10 followed by a bullet RTF with the same IDs rendered as 11/12 before the fix
- verified the same document renders real bullets after the fix
- verified a mixed nested RTF list inside a Word table renders 4. at level 1 and a bullet at level 2
- verified ordered and nested list projection in desktop Excel
- passed full .NET 8 Word (2,300), HTML (945), Markdown (2,881), and Markup (76) suites
- passed focused list and embedded-RTF coverage on .NET 10 and .NET Framework 4.7.2, plus RTF, PDF, and OpenDocument converter checks
- built OfficeIMO.sln in Release with zero warnings and zero errors

Fixes #2071