### PR TITLE
Improve SVG import and add optional CodeGlyphX drawing bridge

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -188,6 +188,8 @@ jobs:
             project: OfficeIMO.CSV.Tests/OfficeIMO.CSV.Tests.csproj
           - name: Drawing
             project: OfficeIMO.Drawing.Tests/OfficeIMO.Drawing.Tests.csproj
+          - name: Drawing-CodeGlyphX
+            project: OfficeIMO.Drawing.CodeGlyphX.Tests/OfficeIMO.Drawing.CodeGlyphX.Tests.csproj
           - name: Email
             project: OfficeIMO.Email.Tests/OfficeIMO.Email.Tests.csproj
           - name: Excel
@@ -245,6 +247,10 @@ jobs:
       - name: Run net472 contract tests
         # Exact image pixels are a dedicated modern-runtime visual-gate contract, not a cross-TFM invariant.
         run: dotnet test ${{ matrix.project }} --configuration ${{ env.BUILD_CONFIGURATION }} --framework net472 --no-restore --verbosity ${{ env.TEST_VERBOSITY }} --filter "Category!=ExcelImageVisualGate" --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx
+
+      - name: Pack optional CodeGlyphX drawing bridge
+        if: ${{ matrix.name == 'Drawing-CodeGlyphX' }}
+        run: dotnet pack OfficeIMO.Drawing.CodeGlyphX/OfficeIMO.Drawing.CodeGlyphX.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore --output artifacts/codeglyphx-drawing-package
 
       - name: Summarize failing tests
         if: failure() && env.SUMMARIZE_FAILURES == 'true'
@@ -390,6 +396,7 @@ jobs:
           fi
           if [ "${{ matrix.partition }}" = "other-projects" ]; then
             dotnet restore OfficeIMO.Drawing.Tests/OfficeIMO.Drawing.Tests.csproj
+            dotnet restore OfficeIMO.Drawing.CodeGlyphX.Tests/OfficeIMO.Drawing.CodeGlyphX.Tests.csproj
             dotnet restore OfficeIMO.GoogleWorkspace.Tests/OfficeIMO.GoogleWorkspace.Tests.csproj
             dotnet restore OfficeIMO.Markup.Tests/OfficeIMO.Markup.Tests.csproj
             dotnet restore OfficeIMO.PowerPoint.Tests/OfficeIMO.PowerPoint.Tests.csproj
@@ -429,6 +436,7 @@ jobs:
           fi
           if [ "${{ matrix.partition }}" = "other-projects" ]; then
             dotnet build OfficeIMO.Drawing.Tests/OfficeIMO.Drawing.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework ${{ matrix.framework }} --no-restore
+            dotnet build OfficeIMO.Drawing.CodeGlyphX.Tests/OfficeIMO.Drawing.CodeGlyphX.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework ${{ matrix.framework }} --no-restore
             dotnet build OfficeIMO.GoogleWorkspace.Tests/OfficeIMO.GoogleWorkspace.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework ${{ matrix.framework }} --no-restore
             dotnet build OfficeIMO.Markup.Tests/OfficeIMO.Markup.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework ${{ matrix.framework }} --no-restore
             dotnet build OfficeIMO.PowerPoint.Tests/OfficeIMO.PowerPoint.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework ${{ matrix.framework }} --no-restore
@@ -648,6 +656,7 @@ jobs:
             other-projects)
               audit_retired_aggregate_tests
               run_drawing_tests
+              dotnet test OfficeIMO.Drawing.CodeGlyphX.Tests/OfficeIMO.Drawing.CodeGlyphX.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity ${{ env.TEST_VERBOSITY }} --framework ${{ matrix.framework }} -m:1 --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx
               run_googleworkspace_tests
               run_markup_tests
               run_opendocument_tests

--- a/Build/project.build.json
+++ b/Build/project.build.json
@@ -7,6 +7,7 @@
     "OfficeIMO.AsciiDoc.Markdown": "2.0.X",
     "OfficeIMO.CSV": "2.0.X",
     "OfficeIMO.Drawing": "2.0.X",
+    "OfficeIMO.Drawing.CodeGlyphX": "2.0.X",
     "OfficeIMO.Email": "2.0.X",
     "OfficeIMO.Epub": "2.0.X",
     "OfficeIMO.Excel": "2.0.X",

--- a/OfficeIMO.Drawing.CodeGlyphX.Benchmarks/OfficeIMO.Drawing.CodeGlyphX.Benchmarks.csproj
+++ b/OfficeIMO.Drawing.CodeGlyphX.Benchmarks/OfficeIMO.Drawing.CodeGlyphX.Benchmarks.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <LangVersion>Latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    <ProjectReference Include="..\OfficeIMO.Drawing\OfficeIMO.Drawing.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(CodeGlyphXProjectPath)' != '' And Exists('$(CodeGlyphXProjectPath)')">
+    <ProjectReference Include="$(CodeGlyphXProjectPath)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(CodeGlyphXProjectPath)' == '' Or !Exists('$(CodeGlyphXProjectPath)')">
+    <PackageReference Include="CodeGlyphX" Version="[1.6.0,3.0.0)" />
+  </ItemGroup>
+</Project>

--- a/OfficeIMO.Drawing.CodeGlyphX.Benchmarks/OfficeIMO.Drawing.CodeGlyphX.Benchmarks.csproj
+++ b/OfficeIMO.Drawing.CodeGlyphX.Benchmarks/OfficeIMO.Drawing.CodeGlyphX.Benchmarks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>Latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/OfficeIMO.Drawing.CodeGlyphX.Benchmarks/Program.cs
+++ b/OfficeIMO.Drawing.CodeGlyphX.Benchmarks/Program.cs
@@ -1,0 +1,9 @@
+using System;
+using BenchmarkDotNet.Running;
+
+if (args.Length == 1 && args[0].Equals("--complexity", StringComparison.OrdinalIgnoreCase)) {
+    SvgComplexityReporter.Write(Console.Out);
+    return;
+}
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/OfficeIMO.Drawing.CodeGlyphX.Benchmarks/README.md
+++ b/OfficeIMO.Drawing.CodeGlyphX.Benchmarks/README.md
@@ -1,0 +1,31 @@
+# CodeGlyphX SVG import benchmarks
+
+This non-packable BenchmarkDotNet project measures `OfficeSvgDrawingReader` against SVG produced by CodeGlyphX. SVG generation happens during benchmark setup, so the timed method measures import rather than encoding or rendering.
+
+The scenarios cover default QR, styled QR circles, Data Matrix, DataBar Expanded stacked, and Code 128 with human-readable text.
+
+## Validate the benchmark
+
+Always run a dry pass before collecting measurements:
+
+```powershell
+dotnet run -c Release -- --filter "*" --job Dry --noOverwrite
+```
+
+## Measure SVG import
+
+```powershell
+dotnet run -c Release -- --filter "*" --noOverwrite
+```
+
+BenchmarkDotNet writes its Markdown and CSV reports under `BenchmarkDotNet.Artifacts`. Use `--artifacts <path>` to keep task-specific results in an explicit temporary folder.
+
+## Report drawing complexity
+
+The deterministic complexity mode reports SVG bytes, drawing elements, shapes, searchable text runs, and unsupported features without running timed benchmarks:
+
+```powershell
+dotnet run -c Release -- --complexity
+```
+
+By default, the project uses the published CodeGlyphX package. Pass `-p:CodeGlyphXProjectPath="<path-to-CodeGlyphX.csproj>"` before `--` to benchmark an adjacent source checkout.

--- a/OfficeIMO.Drawing.CodeGlyphX.Benchmarks/SvgComplexityReporter.cs
+++ b/OfficeIMO.Drawing.CodeGlyphX.Benchmarks/SvgComplexityReporter.cs
@@ -1,0 +1,19 @@
+using System;
+using System.IO;
+using System.Linq;
+using OfficeIMO.Drawing;
+
+internal static class SvgComplexityReporter {
+    internal static void Write(TextWriter writer) {
+        writer.WriteLine("| Scenario | SVG bytes | Drawing elements | Shapes | Text runs | Unsupported |");
+        writer.WriteLine("| --- | ---: | ---: | ---: | ---: | ---: |");
+        foreach (string name in SvgScenarioFactory.Names) {
+            SvgScenario scenario = SvgScenarioFactory.Create(name);
+            if (!OfficeSvgDrawingReader.TryRead(scenario.Svg, out OfficeDrawing? drawing, out int unsupported) || drawing is null) {
+                throw new InvalidOperationException($"Could not import complexity scenario '{name}'.");
+            }
+            int textRuns = drawing.Elements.OfType<OfficeDrawingText>().Count();
+            writer.WriteLine($"| {scenario.Name} | {scenario.Svg.Length} | {drawing.Elements.Count} | {drawing.Shapes.Count} | {textRuns} | {unsupported} |");
+        }
+    }
+}

--- a/OfficeIMO.Drawing.CodeGlyphX.Benchmarks/SvgImportBenchmarks.cs
+++ b/OfficeIMO.Drawing.CodeGlyphX.Benchmarks/SvgImportBenchmarks.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using OfficeIMO.Drawing;
+
+[MemoryDiagnoser(displayGenColumns: false)]
+[RankColumn]
+public class SvgImportBenchmarks {
+    private byte[] _svg = Array.Empty<byte>();
+
+    [ParamsSource(nameof(ScenarioNames))]
+    public string Scenario { get; set; } = string.Empty;
+
+    public IEnumerable<string> ScenarioNames => SvgScenarioFactory.Names;
+
+    [GlobalSetup]
+    public void Setup() {
+        _svg = SvgScenarioFactory.Create(Scenario).Svg;
+    }
+
+    [Benchmark]
+    public OfficeDrawing ImportSvg() {
+        if (!OfficeSvgDrawingReader.TryRead(_svg, out OfficeDrawing? drawing, out _) || drawing is null) {
+            throw new InvalidOperationException($"Could not import benchmark scenario '{Scenario}'.");
+        }
+        return drawing;
+    }
+}

--- a/OfficeIMO.Drawing.CodeGlyphX.Benchmarks/SvgScenarioFactory.cs
+++ b/OfficeIMO.Drawing.CodeGlyphX.Benchmarks/SvgScenarioFactory.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using CodeGlyphX;
+using CodeGlyphX.DataMatrix;
+using CodeGlyphX.Rendering.Png;
+using CodeGlyphX.Rendering.Svg;
+
+internal static class SvgScenarioFactory {
+    internal static IEnumerable<string> Names {
+        get {
+            yield return "QR default";
+            yield return "QR styled circles";
+            yield return "Data Matrix";
+            yield return "DataBar Expanded stacked";
+            yield return "Code 128 with text";
+        }
+    }
+
+    internal static SvgScenario Create(string name) {
+        string svg;
+        switch (name) {
+            case "QR default":
+                QrCode defaultQr = QrCode.Encode("https://evotec.xyz/codeglyphx/benchmark");
+                svg = SvgQrRenderer.Render(defaultQr.Modules, new QrSvgRenderOptions());
+                break;
+            case "QR styled circles":
+                QrCode styledQr = QrCode.Encode("STYLED-QR-OFFICEIMO-BENCHMARK");
+                svg = SvgQrRenderer.Render(styledQr.Modules, new QrSvgRenderOptions {
+                    ModuleShape = QrPngModuleShape.Circle,
+                    ModuleScale = 0.78,
+                    DarkColor = "#2457A6",
+                    LightColor = "#F7FAFF"
+                });
+                break;
+            case "Data Matrix":
+                BitMatrix dataMatrix = DataMatrixEncoder.Encode("OFFICEIMO-DATAMATRIX-BENCHMARK-1234567890");
+                svg = MatrixSvgRenderer.Render(dataMatrix, new MatrixSvgRenderOptions());
+                break;
+            case "DataBar Expanded stacked":
+                BitMatrix dataBar = MatrixBarcodeEncoder.Encode(BarcodeType.GS1DataBarExpandedStacked, "1234567890");
+                svg = MatrixSvgRenderer.Render(dataBar, new MatrixSvgRenderOptions());
+                break;
+            case "Code 128 with text":
+                const string label = "ORDER-1234-BENCHMARK";
+                Barcode1D barcode = BarcodeEncoder.Encode(BarcodeType.Code128, label);
+                svg = SvgBarcodeRenderer.Render(barcode, new BarcodeSvgRenderOptions { LabelText = label });
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(name), name, "Unknown SVG benchmark scenario.");
+        }
+        return new SvgScenario(name, Encoding.UTF8.GetBytes(svg));
+    }
+}
+
+internal sealed class SvgScenario {
+    internal string Name { get; }
+    internal byte[] Svg { get; }
+
+    internal SvgScenario(string name, byte[] svg) {
+        Name = name;
+        Svg = svg;
+    }
+}

--- a/OfficeIMO.Drawing.CodeGlyphX.Tests/CodeGlyphDrawingIntegrationTests.cs
+++ b/OfficeIMO.Drawing.CodeGlyphX.Tests/CodeGlyphDrawingIntegrationTests.cs
@@ -1,0 +1,78 @@
+using System.Linq;
+using System.Text;
+using CodeGlyphX;
+using CodeGlyphX.DataMatrix;
+using CodeGlyphX.Rendering.Png;
+using CodeGlyphX.Rendering.Svg;
+using OfficeIMO.Drawing;
+using OfficeIMO.Drawing.CodeGlyphX;
+using Xunit;
+
+namespace OfficeIMO.Drawing.CodeGlyphX.Tests;
+
+public sealed class CodeGlyphDrawingIntegrationTests {
+    [Fact]
+    public void NeutralSvgBoundaryImportsQrWithoutTheAdapterApi() {
+        QrCode qr = QrCode.Encode("https://evotec.xyz/codeglyphx");
+        string svg = SvgQrRenderer.Render(qr.Modules, new QrSvgRenderOptions());
+
+        Assert.True(OfficeSvgDrawingReader.TryRead(Encoding.UTF8.GetBytes(svg), out OfficeDrawing? drawing, out int unsupported));
+        Assert.NotNull(drawing);
+        Assert.Equal(0, unsupported);
+        Assert.NotEmpty(drawing!.Shapes);
+    }
+
+    [Fact]
+    public void AdapterImportsStyledQrAsReusableShapes() {
+        QrCode qr = QrCode.Encode("STYLED-QR-OFFICEIMO");
+        var options = new QrSvgRenderOptions {
+            ModuleShape = QrPngModuleShape.Circle,
+            ModuleScale = 0.78,
+            DarkColor = "#2457A6",
+            LightColor = "#F7FAFF"
+        };
+
+        OfficeDrawing drawing = qr.ToOfficeDrawing(out int unsupported, options);
+
+        Assert.Equal(0, unsupported);
+        Assert.True(drawing.Shapes.Count > 50);
+        Assert.Contains(drawing.Shapes, item => item.Shape.Kind == OfficeShapeKind.Ellipse);
+    }
+
+    [Fact]
+    public void AdapterImportsDataMatrix() {
+        BitMatrix modules = DataMatrixEncoder.Encode("OFFICEIMO-DATAMATRIX-1234567890");
+
+        OfficeDrawing drawing = modules.ToOfficeDrawing(out int unsupported, new MatrixSvgRenderOptions());
+
+        Assert.Equal(0, unsupported);
+        Assert.NotEmpty(drawing.Shapes);
+        Assert.True(drawing.Width > 0D);
+        Assert.True(drawing.Height > 0D);
+    }
+
+    [Fact]
+    public void AdapterImportsDataBarExpandedStackedOutput() {
+        BitMatrix modules = MatrixBarcodeEncoder.Encode(BarcodeType.GS1DataBarExpandedStacked, "1234567890");
+
+        OfficeDrawing drawing = modules.ToOfficeDrawing(out int unsupported, new MatrixSvgRenderOptions());
+
+        Assert.Equal(0, unsupported);
+        Assert.NotEmpty(drawing.Shapes);
+        Assert.True(drawing.Width > drawing.Height);
+    }
+
+    [Fact]
+    public void AdapterKeepsLinearBarcodeLabelAsSearchableText() {
+        const string label = "ORDER-1234";
+        Barcode1D barcode = BarcodeEncoder.Encode(BarcodeType.Code128, label);
+        var options = new BarcodeSvgRenderOptions { LabelText = label };
+
+        OfficeDrawing drawing = barcode.ToOfficeDrawing(out int unsupported, options);
+
+        Assert.Equal(0, unsupported);
+        Assert.NotEmpty(drawing.Shapes);
+        OfficeDrawingText text = Assert.Single(drawing.Elements.OfType<OfficeDrawingText>());
+        Assert.Equal(label, text.Text);
+    }
+}

--- a/OfficeIMO.Drawing.CodeGlyphX.Tests/CodeGlyphDrawingIntegrationTests.cs
+++ b/OfficeIMO.Drawing.CodeGlyphX.Tests/CodeGlyphDrawingIntegrationTests.cs
@@ -40,6 +40,36 @@ public sealed class CodeGlyphDrawingIntegrationTests {
     }
 
     [Fact]
+    public void AdapterImportsLargeStyledQrWithinTheTrustedElementLimit() {
+        QrCode qr = QrCode.Encode("LARGE-STYLED-QR", new QrEasyOptions {
+            ErrorCorrectionLevel = QrErrorCorrectionLevel.L,
+            MinVersion = 40,
+            MaxVersion = 40
+        });
+        var options = new QrSvgRenderOptions {
+            ModuleShape = QrPngModuleShape.Circle,
+            ModuleScale = 0.78
+        };
+
+        OfficeDrawing drawing = qr.ToOfficeDrawing(out int unsupported, options);
+
+        Assert.Equal(177, qr.Modules.Width);
+        Assert.Equal(0, unsupported);
+        Assert.True(drawing.Shapes.Count > OfficeSvgDrawingReaderOptions.DefaultMaximumElements);
+    }
+
+    [Fact]
+    public void AdapterPreservesAlphaQrColors() {
+        QrCode qr = QrCode.Encode("ALPHA-QR-OFFICEIMO");
+        var options = new QrSvgRenderOptions { DarkColor = "rgba(36,87,166,0.502)" };
+
+        OfficeDrawing drawing = qr.ToOfficeDrawing(out int unsupported, options);
+
+        Assert.Equal(0, unsupported);
+        Assert.Contains(drawing.Shapes, item => item.Shape.FillColor == OfficeColor.FromRgba(36, 87, 166, 128));
+    }
+
+    [Fact]
     public void AdapterImportsDataMatrix() {
         BitMatrix modules = DataMatrixEncoder.Encode("OFFICEIMO-DATAMATRIX-1234567890");
 

--- a/OfficeIMO.Drawing.CodeGlyphX.Tests/CodeGlyphDrawingIntegrationTests.cs
+++ b/OfficeIMO.Drawing.CodeGlyphX.Tests/CodeGlyphDrawingIntegrationTests.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Linq;
 using System.Text;
 using CodeGlyphX;
 using CodeGlyphX.DataMatrix;
+using CodeGlyphX.Rendering;
 using CodeGlyphX.Rendering.Png;
 using CodeGlyphX.Rendering.Svg;
 using OfficeIMO.Drawing;
@@ -56,6 +58,31 @@ public sealed class CodeGlyphDrawingIntegrationTests {
         Assert.Equal(177, qr.Modules.Width);
         Assert.Equal(0, unsupported);
         Assert.True(drawing.Shapes.Count > OfficeSvgDrawingReaderOptions.DefaultMaximumElements);
+    }
+
+    [Fact]
+    public void AdapterImportsLargeDotGridQrWithinTheTrustedElementLimit() {
+        QrCode qr = QrCode.Encode("LARGE-DOT-GRID-QR", new QrEasyOptions {
+            ErrorCorrectionLevel = QrErrorCorrectionLevel.L,
+            MinVersion = 40,
+            MaxVersion = 40
+        });
+        var options = new QrSvgRenderOptions { ModuleShape = QrPngModuleShape.DotGrid };
+
+        OfficeDrawing drawing = qr.ToOfficeDrawing(out int unsupported, options);
+
+        Assert.Equal(0, unsupported);
+        Assert.True(drawing.Shapes.Count > 40000);
+    }
+
+    [Fact]
+    public void AdapterRejectsQrLogosThatCannotBePreserved() {
+        QrCode qr = QrCode.Encode("LOGO-QR-OFFICEIMO");
+        var options = new QrSvgRenderOptions { Logo = new QrLogoOptions(new byte[] { 1 }) };
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(() => qr.ToOfficeDrawing(options));
+
+        Assert.Contains("logo", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/OfficeIMO.Drawing.CodeGlyphX.Tests/CodeGlyphDrawingIntegrationTests.cs
+++ b/OfficeIMO.Drawing.CodeGlyphX.Tests/CodeGlyphDrawingIntegrationTests.cs
@@ -132,4 +132,14 @@ public sealed class CodeGlyphDrawingIntegrationTests {
         OfficeDrawingText text = Assert.Single(drawing.Elements.OfType<OfficeDrawingText>());
         Assert.Equal(label, text.Text);
     }
+
+    [Fact]
+    public void AdapterImportsLargeLinearBarcodeWithinTheTrustedElementLimit() {
+        Barcode1D barcode = new Barcode1D(Enumerable.Range(0, 22000).Select(index => new BarSegment(index % 2 == 0, 1)));
+
+        OfficeDrawing drawing = barcode.ToOfficeDrawing(out int unsupported, new BarcodeSvgRenderOptions());
+
+        Assert.Equal(0, unsupported);
+        Assert.True(drawing.Shapes.Count > OfficeSvgDrawingReaderOptions.DefaultMaximumElements);
+    }
 }

--- a/OfficeIMO.Drawing.CodeGlyphX.Tests/OfficeIMO.Drawing.CodeGlyphX.Tests.csproj
+++ b/OfficeIMO.Drawing.CodeGlyphX.Tests/OfficeIMO.Drawing.CodeGlyphX.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <LangVersion>Latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OfficeIMO.Drawing\OfficeIMO.Drawing.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Drawing.CodeGlyphX\OfficeIMO.Drawing.CodeGlyphX.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(CodeGlyphXProjectPath)' != '' And Exists('$(CodeGlyphXProjectPath)')">
+    <ProjectReference Include="$(CodeGlyphXProjectPath)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(CodeGlyphXProjectPath)' == '' Or !Exists('$(CodeGlyphXProjectPath)')">
+    <PackageReference Include="CodeGlyphX" Version="[1.6.0,3.0.0)" />
+  </ItemGroup>
+</Project>

--- a/OfficeIMO.Drawing.CodeGlyphX.Tests/README.md
+++ b/OfficeIMO.Drawing.CodeGlyphX.Tests/README.md
@@ -1,0 +1,12 @@
+# OfficeIMO.Drawing.CodeGlyphX integration tests
+
+This non-packable test project verifies the neutral SVG boundary and the optional typed adapter without adding a dependency to either core package.
+
+By default, it tests against the published CodeGlyphX package. To validate an adjacent CodeGlyphX source checkout, pass its project explicitly:
+
+```powershell
+dotnet test -f net10.0 `
+  -p:CodeGlyphXProjectPath="<path-to-CodeGlyphX.csproj>"
+```
+
+The smoke suite covers default and styled QR output, Data Matrix, DataBar Expanded stacked output, linear barcode shapes, and searchable human-readable text.

--- a/OfficeIMO.Drawing.CodeGlyphX/CodeGlyphDrawingExtensions.cs
+++ b/OfficeIMO.Drawing.CodeGlyphX/CodeGlyphDrawingExtensions.cs
@@ -56,11 +56,15 @@ public static class CodeGlyphDrawingExtensions {
         BarcodeSvgRenderOptions? options = null) {
         if (barcode is null) throw new ArgumentNullException(nameof(barcode));
         string svg = SvgBarcodeRenderer.Render(barcode, options ?? new BarcodeSvgRenderOptions());
-        return ReadSvg(svg, OfficeSvgDrawingReaderOptions.DefaultMaximumElements, out unsupportedFeatureCount);
+        return ReadSvg(svg, ResolveMaximumElements(barcode.Segments.Count), out unsupportedFeatureCount);
     }
 
     private static int ResolveMaximumElements(BitMatrix modules, int elementsPerCell) {
-        long requested = ((long)modules.Width * modules.Height * elementsPerCell) + 1024L;
+        return ResolveMaximumElements((long)modules.Width * modules.Height * elementsPerCell);
+    }
+
+    private static int ResolveMaximumElements(long symbolElements) {
+        long requested = symbolElements + 1024L;
         return (int)Math.Min(
             OfficeSvgDrawingReaderOptions.MaximumAllowedElements,
             Math.Max(OfficeSvgDrawingReaderOptions.DefaultMaximumElements, requested));

--- a/OfficeIMO.Drawing.CodeGlyphX/CodeGlyphDrawingExtensions.cs
+++ b/OfficeIMO.Drawing.CodeGlyphX/CodeGlyphDrawingExtensions.cs
@@ -19,8 +19,9 @@ public static class CodeGlyphDrawingExtensions {
         out int unsupportedFeatureCount,
         QrSvgRenderOptions? options = null) {
         if (qrCode is null) throw new ArgumentNullException(nameof(qrCode));
-        string svg = SvgQrRenderer.Render(qrCode.Modules, options ?? new QrSvgRenderOptions());
-        return ReadSvg(svg, out unsupportedFeatureCount);
+        BitMatrix modules = qrCode.Modules;
+        string svg = SvgQrRenderer.Render(modules, options ?? new QrSvgRenderOptions());
+        return ReadSvg(svg, ResolveMaximumElements(modules), out unsupportedFeatureCount);
     }
 
     /// <summary>Renders a generic matrix symbol and imports it as an OfficeIMO drawing.</summary>
@@ -34,7 +35,7 @@ public static class CodeGlyphDrawingExtensions {
         MatrixSvgRenderOptions? options = null) {
         if (modules is null) throw new ArgumentNullException(nameof(modules));
         string svg = MatrixSvgRenderer.Render(modules, options ?? new MatrixSvgRenderOptions());
-        return ReadSvg(svg, out unsupportedFeatureCount);
+        return ReadSvg(svg, ResolveMaximumElements(modules), out unsupportedFeatureCount);
     }
 
     /// <summary>Renders a linear barcode and imports it as an OfficeIMO drawing.</summary>
@@ -48,12 +49,20 @@ public static class CodeGlyphDrawingExtensions {
         BarcodeSvgRenderOptions? options = null) {
         if (barcode is null) throw new ArgumentNullException(nameof(barcode));
         string svg = SvgBarcodeRenderer.Render(barcode, options ?? new BarcodeSvgRenderOptions());
-        return ReadSvg(svg, out unsupportedFeatureCount);
+        return ReadSvg(svg, OfficeSvgDrawingReaderOptions.DefaultMaximumElements, out unsupportedFeatureCount);
     }
 
-    private static OfficeDrawing ReadSvg(string svg, out int unsupportedFeatureCount) {
+    private static int ResolveMaximumElements(BitMatrix modules) {
+        long requested = ((long)modules.Width * modules.Height) + 1024L;
+        return (int)Math.Min(
+            OfficeSvgDrawingReaderOptions.MaximumAllowedElements,
+            Math.Max(OfficeSvgDrawingReaderOptions.DefaultMaximumElements, requested));
+    }
+
+    private static OfficeDrawing ReadSvg(string svg, int maximumElements, out int unsupportedFeatureCount) {
         byte[] bytes = Encoding.UTF8.GetBytes(svg);
-        if (!OfficeSvgDrawingReader.TryRead(bytes, out OfficeDrawing? drawing, out unsupportedFeatureCount) || drawing is null) {
+        var readerOptions = new OfficeSvgDrawingReaderOptions { MaximumElements = maximumElements };
+        if (!OfficeSvgDrawingReader.TryRead(bytes, readerOptions, out OfficeDrawing? drawing, out unsupportedFeatureCount) || drawing is null) {
             throw new InvalidOperationException("CodeGlyphX produced SVG that OfficeIMO.Drawing could not read.");
         }
         return drawing;

--- a/OfficeIMO.Drawing.CodeGlyphX/CodeGlyphDrawingExtensions.cs
+++ b/OfficeIMO.Drawing.CodeGlyphX/CodeGlyphDrawingExtensions.cs
@@ -10,18 +10,25 @@ namespace OfficeIMO.Drawing.CodeGlyphX;
 /// </summary>
 public static class CodeGlyphDrawingExtensions {
     /// <summary>Renders a QR code and imports it as an OfficeIMO drawing.</summary>
+    /// <exception cref="NotSupportedException">The SVG options include a raster logo that the drawing importer cannot preserve.</exception>
     public static OfficeDrawing ToOfficeDrawing(this QrCode qrCode, QrSvgRenderOptions? options = null) =>
         ToOfficeDrawing(qrCode, out _, options);
 
     /// <summary>Renders a QR code and imports it while reporting SVG features that required fallback.</summary>
+    /// <exception cref="NotSupportedException">The SVG options include a raster logo that the drawing importer cannot preserve.</exception>
     public static OfficeDrawing ToOfficeDrawing(
         this QrCode qrCode,
         out int unsupportedFeatureCount,
         QrSvgRenderOptions? options = null) {
         if (qrCode is null) throw new ArgumentNullException(nameof(qrCode));
+        QrSvgRenderOptions renderOptions = options ?? new QrSvgRenderOptions();
+        if (renderOptions.Logo is not null) {
+            throw new NotSupportedException("QR logo images cannot be represented by the OfficeIMO.Drawing SVG importer.");
+        }
         BitMatrix modules = qrCode.Modules;
-        string svg = SvgQrRenderer.Render(modules, options ?? new QrSvgRenderOptions());
-        return ReadSvg(svg, ResolveMaximumElements(modules), out unsupportedFeatureCount);
+        string svg = SvgQrRenderer.Render(modules, renderOptions);
+        int elementsPerCell = renderOptions.ModuleShape == global::CodeGlyphX.Rendering.Png.QrPngModuleShape.DotGrid ? 4 : 1;
+        return ReadSvg(svg, ResolveMaximumElements(modules, elementsPerCell), out unsupportedFeatureCount);
     }
 
     /// <summary>Renders a generic matrix symbol and imports it as an OfficeIMO drawing.</summary>
@@ -35,7 +42,7 @@ public static class CodeGlyphDrawingExtensions {
         MatrixSvgRenderOptions? options = null) {
         if (modules is null) throw new ArgumentNullException(nameof(modules));
         string svg = MatrixSvgRenderer.Render(modules, options ?? new MatrixSvgRenderOptions());
-        return ReadSvg(svg, ResolveMaximumElements(modules), out unsupportedFeatureCount);
+        return ReadSvg(svg, ResolveMaximumElements(modules, elementsPerCell: 1), out unsupportedFeatureCount);
     }
 
     /// <summary>Renders a linear barcode and imports it as an OfficeIMO drawing.</summary>
@@ -52,8 +59,8 @@ public static class CodeGlyphDrawingExtensions {
         return ReadSvg(svg, OfficeSvgDrawingReaderOptions.DefaultMaximumElements, out unsupportedFeatureCount);
     }
 
-    private static int ResolveMaximumElements(BitMatrix modules) {
-        long requested = ((long)modules.Width * modules.Height) + 1024L;
+    private static int ResolveMaximumElements(BitMatrix modules, int elementsPerCell) {
+        long requested = ((long)modules.Width * modules.Height * elementsPerCell) + 1024L;
         return (int)Math.Min(
             OfficeSvgDrawingReaderOptions.MaximumAllowedElements,
             Math.Max(OfficeSvgDrawingReaderOptions.DefaultMaximumElements, requested));

--- a/OfficeIMO.Drawing.CodeGlyphX/CodeGlyphDrawingExtensions.cs
+++ b/OfficeIMO.Drawing.CodeGlyphX/CodeGlyphDrawingExtensions.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Text;
+using global::CodeGlyphX;
+using global::CodeGlyphX.Rendering.Svg;
+
+namespace OfficeIMO.Drawing.CodeGlyphX;
+
+/// <summary>
+/// Converts typed CodeGlyphX symbols to OfficeIMO.Drawing scenes through the neutral SVG boundary.
+/// </summary>
+public static class CodeGlyphDrawingExtensions {
+    /// <summary>Renders a QR code and imports it as an OfficeIMO drawing.</summary>
+    public static OfficeDrawing ToOfficeDrawing(this QrCode qrCode, QrSvgRenderOptions? options = null) =>
+        ToOfficeDrawing(qrCode, out _, options);
+
+    /// <summary>Renders a QR code and imports it while reporting SVG features that required fallback.</summary>
+    public static OfficeDrawing ToOfficeDrawing(
+        this QrCode qrCode,
+        out int unsupportedFeatureCount,
+        QrSvgRenderOptions? options = null) {
+        if (qrCode is null) throw new ArgumentNullException(nameof(qrCode));
+        string svg = SvgQrRenderer.Render(qrCode.Modules, options ?? new QrSvgRenderOptions());
+        return ReadSvg(svg, out unsupportedFeatureCount);
+    }
+
+    /// <summary>Renders a generic matrix symbol and imports it as an OfficeIMO drawing.</summary>
+    public static OfficeDrawing ToOfficeDrawing(this BitMatrix modules, MatrixSvgRenderOptions? options = null) =>
+        ToOfficeDrawing(modules, out _, options);
+
+    /// <summary>Renders a generic matrix symbol and imports it while reporting SVG features that required fallback.</summary>
+    public static OfficeDrawing ToOfficeDrawing(
+        this BitMatrix modules,
+        out int unsupportedFeatureCount,
+        MatrixSvgRenderOptions? options = null) {
+        if (modules is null) throw new ArgumentNullException(nameof(modules));
+        string svg = MatrixSvgRenderer.Render(modules, options ?? new MatrixSvgRenderOptions());
+        return ReadSvg(svg, out unsupportedFeatureCount);
+    }
+
+    /// <summary>Renders a linear barcode and imports it as an OfficeIMO drawing.</summary>
+    public static OfficeDrawing ToOfficeDrawing(this Barcode1D barcode, BarcodeSvgRenderOptions? options = null) =>
+        ToOfficeDrawing(barcode, out _, options);
+
+    /// <summary>Renders a linear barcode and imports it while reporting SVG features that required fallback.</summary>
+    public static OfficeDrawing ToOfficeDrawing(
+        this Barcode1D barcode,
+        out int unsupportedFeatureCount,
+        BarcodeSvgRenderOptions? options = null) {
+        if (barcode is null) throw new ArgumentNullException(nameof(barcode));
+        string svg = SvgBarcodeRenderer.Render(barcode, options ?? new BarcodeSvgRenderOptions());
+        return ReadSvg(svg, out unsupportedFeatureCount);
+    }
+
+    private static OfficeDrawing ReadSvg(string svg, out int unsupportedFeatureCount) {
+        byte[] bytes = Encoding.UTF8.GetBytes(svg);
+        if (!OfficeSvgDrawingReader.TryRead(bytes, out OfficeDrawing? drawing, out unsupportedFeatureCount) || drawing is null) {
+            throw new InvalidOperationException("CodeGlyphX produced SVG that OfficeIMO.Drawing could not read.");
+        }
+        return drawing;
+    }
+}

--- a/OfficeIMO.Drawing.CodeGlyphX/OfficeIMO.Drawing.CodeGlyphX.csproj
+++ b/OfficeIMO.Drawing.CodeGlyphX/OfficeIMO.Drawing.CodeGlyphX.csproj
@@ -1,0 +1,48 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>Optional typed bridge from CodeGlyphX symbols to OfficeIMO.Drawing scenes.</Description>
+    <PackageId>OfficeIMO.Drawing.CodeGlyphX</PackageId>
+    <AssemblyName>OfficeIMO.Drawing.CodeGlyphX</AssemblyName>
+    <AssemblyTitle>OfficeIMO.Drawing.CodeGlyphX</AssemblyTitle>
+    <VersionPrefix>2.0.1</VersionPrefix>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <Company>Evotec</Company>
+    <Authors>Przemyslaw Klys</Authors>
+    <PackageTags>officeimo;drawing;codeglyphx;qr;barcode;datamatrix;svg</PackageTags>
+    <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/EvotecIT/OfficeIMO</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageIcon>OfficeIMO.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>Latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\Assets\OfficeIMO.png">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+    <None Include="README.md">
+      <Pack>True</Pack>
+      <PackagePath>README.md</PackagePath>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OfficeIMO.Drawing\OfficeIMO.Drawing.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(CodeGlyphXProjectPath)' != '' And Exists('$(CodeGlyphXProjectPath)')">
+    <ProjectReference Include="$(CodeGlyphXProjectPath)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(CodeGlyphXProjectPath)' == '' Or !Exists('$(CodeGlyphXProjectPath)')">
+    <PackageReference Include="CodeGlyphX" Version="[1.6.0,3.0.0)" />
+  </ItemGroup>
+</Project>

--- a/OfficeIMO.Drawing.CodeGlyphX/README.md
+++ b/OfficeIMO.Drawing.CodeGlyphX/README.md
@@ -1,0 +1,59 @@
+# OfficeIMO.Drawing.CodeGlyphX
+
+`OfficeIMO.Drawing.CodeGlyphX` is an optional convenience package for turning CodeGlyphX QR codes, matrix symbols, and linear barcodes into reusable `OfficeDrawing` scenes.
+
+Both core libraries remain independent. CodeGlyphX produces standard SVG without referencing OfficeIMO, and `OfficeIMO.Drawing` can read that SVG without referencing CodeGlyphX. Install this bridge only when typed extension methods make the handoff more convenient.
+
+## Install
+
+```powershell
+dotnet add package OfficeIMO.Drawing.CodeGlyphX
+```
+
+## QR code
+
+```csharp
+using CodeGlyphX;
+using CodeGlyphX.Rendering.Svg;
+using OfficeIMO.Drawing;
+using OfficeIMO.Drawing.CodeGlyphX;
+
+QrCode qr = QrCode.Encode("https://evotec.xyz");
+OfficeDrawing drawing = qr.ToOfficeDrawing(new QrSvgRenderOptions {
+    ModuleSize = 8,
+    QuietZone = 4
+});
+```
+
+## Matrix symbol
+
+```csharp
+using CodeGlyphX;
+using CodeGlyphX.DataMatrix;
+using CodeGlyphX.Rendering.Svg;
+using OfficeIMO.Drawing;
+using OfficeIMO.Drawing.CodeGlyphX;
+
+BitMatrix modules = DataMatrixEncoder.Encode("ORDER-1234");
+OfficeDrawing drawing = modules.ToOfficeDrawing(new MatrixSvgRenderOptions());
+```
+
+## Linear barcode with searchable text
+
+```csharp
+using CodeGlyphX;
+using CodeGlyphX.Rendering.Svg;
+using OfficeIMO.Drawing;
+using OfficeIMO.Drawing.CodeGlyphX;
+
+Barcode1D barcode = BarcodeEncoder.Encode(BarcodeType.Code128, "ORDER-1234");
+OfficeDrawing drawing = barcode.ToOfficeDrawing(
+    out int unsupportedFeatures,
+    new BarcodeSvgRenderOptions { LabelText = "ORDER-1234" });
+
+if (unsupportedFeatures != 0) {
+    Console.WriteLine($"The SVG import used {unsupportedFeatures} fallback(s).");
+}
+```
+
+The extension methods use the same neutral route available without this package: render SVG with CodeGlyphX, then pass its UTF-8 bytes to `OfficeSvgDrawingReader.TryRead`.

--- a/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
@@ -31,6 +31,38 @@ public class DrawingSvgReaderTests {
     }
 
     [Fact]
+    public void SvgReaderResolvesPercentageGeometryAgainstTheViewport() {
+        const string svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='10 20 200 100'>"
+            + "<rect x='10%' y='20%' width='50%' height='25%' fill='red'/>"
+            + "<circle cx='75%' cy='50%' r='10%' fill='blue'/>"
+            + "<ellipse cx='25%' cy='75%' rx='5%' ry='10%' fill='green'/>"
+            + "<line x1='10%' y1='90%' x2='90%' y2='10%' stroke='black'/></svg>";
+
+        Assert.True(OfficeSvgDrawingReader.TryRead(Encoding.UTF8.GetBytes(svg), out OfficeDrawing? drawing, out int unsupported));
+        Assert.NotNull(drawing);
+        Assert.Equal(0, unsupported);
+        Assert.Equal(4, drawing!.Shapes.Count);
+
+        OfficeDrawingShape rectangle = drawing.Shapes[0];
+        Assert.Equal(20D, rectangle.X, 6);
+        Assert.Equal(20D, rectangle.Y, 6);
+        Assert.Equal(100D, rectangle.Shape.Width, 6);
+        Assert.Equal(25D, rectangle.Shape.Height, 6);
+
+        double circleRadius = Math.Sqrt((200D * 200D) + (100D * 100D)) / Math.Sqrt(2D) * 0.1D;
+        OfficeDrawingShape circle = drawing.Shapes[1];
+        Assert.Equal(150D - circleRadius, circle.X, 6);
+        Assert.Equal(50D - circleRadius, circle.Y, 6);
+        Assert.Equal(circleRadius * 2D, circle.Shape.Width, 6);
+
+        OfficeDrawingShape ellipse = drawing.Shapes[2];
+        Assert.Equal(40D, ellipse.X, 6);
+        Assert.Equal(65D, ellipse.Y, 6);
+        Assert.Equal(20D, ellipse.Shape.Width, 6);
+        Assert.Equal(20D, ellipse.Shape.Height, 6);
+    }
+
+    [Fact]
     public void SvgReaderRetainsSupportedPrimitivesAndCountsUnsupportedContent() {
         const string svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'>"
             + "<rect width='20' height='20' fill='#00ff00'/><text x='1' y='10'>Pending</text></svg>";
@@ -109,6 +141,21 @@ public class DrawingSvgReaderTests {
         Assert.True(text.X < 20D);
         Assert.Contains(">Label</text>", OfficeDrawingSvgExporter.ToSvg(drawing), StringComparison.Ordinal);
         OfficeDrawingRasterRenderer.Render(drawing);
+    }
+
+    [Fact]
+    public void SvgReaderResolvesPercentageTextPositionAndHangingBaseline() {
+        const string svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='10 20 200 100' fill='navy'>"
+            + "<text x='50%' y='25%' font-size='10' text-anchor='middle' dominant-baseline='hanging'>Label</text></svg>";
+
+        Assert.True(OfficeSvgDrawingReader.TryRead(Encoding.UTF8.GetBytes(svg), out OfficeDrawing? drawing, out int unsupported));
+        Assert.NotNull(drawing);
+        Assert.Equal(0, unsupported);
+        OfficeDrawingText text = Assert.Single(drawing!.Elements.OfType<OfficeDrawingText>());
+        Assert.Equal("Label", text.Text);
+        Assert.True(text.X < 100D);
+        Assert.Equal(25D, text.Y, 6);
+        Assert.Contains(">Label</text>", OfficeDrawingSvgExporter.ToSvg(drawing), StringComparison.Ordinal);
     }
 
     [Fact]

--- a/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
@@ -36,7 +36,7 @@ public class DrawingSvgReaderTests {
             + "<rect x='10%' y='20%' width='50%' height='25%' fill='red'/>"
             + "<circle cx='75%' cy='50%' r='10%' fill='blue'/>"
             + "<ellipse cx='25%' cy='75%' rx='5%' ry='10%' fill='green'/>"
-            + "<line x1='10%' y1='90%' x2='90%' y2='10%' stroke='black'/></svg>";
+            + "<line x1='10%' y1='90%' x2='90%' y2='30%' stroke='black'/></svg>";
 
         Assert.True(OfficeSvgDrawingReader.TryRead(Encoding.UTF8.GetBytes(svg), out OfficeDrawing? drawing, out int unsupported));
         Assert.NotNull(drawing);
@@ -44,20 +44,20 @@ public class DrawingSvgReaderTests {
         Assert.Equal(4, drawing!.Shapes.Count);
 
         OfficeDrawingShape rectangle = drawing.Shapes[0];
-        Assert.Equal(20D, rectangle.X, 6);
-        Assert.Equal(20D, rectangle.Y, 6);
+        Assert.Equal(10D, rectangle.X, 6);
+        Assert.Equal(0D, rectangle.Y, 6);
         Assert.Equal(100D, rectangle.Shape.Width, 6);
         Assert.Equal(25D, rectangle.Shape.Height, 6);
 
         double circleRadius = Math.Sqrt((200D * 200D) + (100D * 100D)) / Math.Sqrt(2D) * 0.1D;
         OfficeDrawingShape circle = drawing.Shapes[1];
-        Assert.Equal(150D - circleRadius, circle.X, 6);
-        Assert.Equal(50D - circleRadius, circle.Y, 6);
+        Assert.Equal(140D - circleRadius, circle.X, 6);
+        Assert.Equal(30D - circleRadius, circle.Y, 6);
         Assert.Equal(circleRadius * 2D, circle.Shape.Width, 6);
 
         OfficeDrawingShape ellipse = drawing.Shapes[2];
-        Assert.Equal(40D, ellipse.X, 6);
-        Assert.Equal(65D, ellipse.Y, 6);
+        Assert.Equal(30D, ellipse.X, 6);
+        Assert.Equal(45D, ellipse.Y, 6);
         Assert.Equal(20D, ellipse.Shape.Width, 6);
         Assert.Equal(20D, ellipse.Shape.Height, 6);
     }
@@ -71,6 +71,24 @@ public class DrawingSvgReaderTests {
         Assert.NotNull(drawing);
         Assert.Single(drawing!.Shapes);
         Assert.Equal(1, unsupported);
+    }
+
+    [Fact]
+    public void SvgReaderAllowsAnExplicitTrustedElementLimit() {
+        var svg = new StringBuilder("<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'>");
+        for (int i = 0; i < OfficeSvgDrawingReaderOptions.DefaultMaximumElements + 1; i++) svg.Append("<metadata/>");
+        svg.Append("</svg>");
+        byte[] bytes = Encoding.UTF8.GetBytes(svg.ToString());
+
+        Assert.False(OfficeSvgDrawingReader.TryRead(bytes, out _));
+
+        var options = new OfficeSvgDrawingReaderOptions {
+            MaximumElements = OfficeSvgDrawingReaderOptions.DefaultMaximumElements + 1
+        };
+        Assert.True(OfficeSvgDrawingReader.TryRead(bytes, options, out OfficeDrawing? drawing, out int unsupported));
+        Assert.NotNull(drawing);
+        Assert.Equal(0, unsupported);
+        Assert.Empty(drawing!.Elements);
     }
 
     [Fact]
@@ -153,9 +171,22 @@ public class DrawingSvgReaderTests {
         Assert.Equal(0, unsupported);
         OfficeDrawingText text = Assert.Single(drawing!.Elements.OfType<OfficeDrawingText>());
         Assert.Equal("Label", text.Text);
-        Assert.True(text.X < 100D);
-        Assert.Equal(25D, text.Y, 6);
+        Assert.Equal(90D, text.X + (text.Width / 2D), 6);
+        Assert.Equal(5D, text.Y, 6);
         Assert.Contains(">Label</text>", OfficeDrawingSvgExporter.ToSvg(drawing), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SvgReaderPreservesRgbAndRgbaPaint() {
+        const string svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 10'>"
+            + "<rect width='10' height='10' fill='rgba(36,87,166,0.502)'/>"
+            + "<rect x='10' width='10' height='10' fill='rgb(10%,20%,30%)'/></svg>";
+
+        Assert.True(OfficeSvgDrawingReader.TryRead(Encoding.UTF8.GetBytes(svg), out OfficeDrawing? drawing, out int unsupported));
+        Assert.NotNull(drawing);
+        Assert.Equal(0, unsupported);
+        Assert.Equal(OfficeColor.FromRgba(36, 87, 166, 128), drawing!.Shapes[0].Shape.FillColor);
+        Assert.Equal(OfficeColor.FromRgb(26, 51, 76), drawing.Shapes[1].Shape.FillColor);
     }
 
     [Fact]

--- a/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
@@ -507,6 +507,20 @@ public class DrawingSvgReaderTests {
     }
 
     [Fact]
+    public void SvgReaderResolvesRgbaCurrentColorInGradientStops() {
+        const string svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'>"
+            + "<defs><linearGradient id='paint' style='color:rgba(36,87,166,0.502)'>"
+            + "<stop stop-color='currentColor'/><stop offset='1' stop-color='white'/></linearGradient></defs>"
+            + "<rect width='10' height='10' fill='url(#paint)'/></svg>";
+
+        Assert.True(OfficeSvgDrawingReader.TryRead(Encoding.UTF8.GetBytes(svg), out OfficeDrawing? drawing, out int unsupported));
+        Assert.NotNull(drawing);
+        Assert.Equal(0, unsupported);
+        OfficeLinearGradient gradient = Assert.IsType<OfficeLinearGradient>(Assert.Single(drawing!.Shapes).Shape.FillGradient);
+        Assert.Equal(OfficeColor.FromRgba(36, 87, 166, 128), gradient.Stops[0].Color);
+    }
+
+    [Fact]
     public void SvgReaderDiagnosesUnsafeOrCyclicPaintServersAndKeepsSupportedSiblings() {
         const string svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 10'>"
             + "<defs><linearGradient id='a' href='#b'/><linearGradient id='b' href='#a'/>"

--- a/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
@@ -521,6 +521,34 @@ public class DrawingSvgReaderTests {
     }
 
     [Fact]
+    public void SvgReaderParsesModernSpaceSeparatedRgbColors() {
+        const string svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'>"
+            + "<rect width='10' height='10' fill='rgb(36 87 166)' stroke='rgb(10% 20% 30% / 50%)' stroke-width='1'/></svg>";
+
+        Assert.True(OfficeSvgDrawingReader.TryRead(Encoding.UTF8.GetBytes(svg), out OfficeDrawing? drawing, out int unsupported));
+        Assert.NotNull(drawing);
+        Assert.Equal(0, unsupported);
+        OfficeShape shape = Assert.Single(drawing!.Shapes).Shape;
+        Assert.Equal(OfficeColor.FromRgb(36, 87, 166), shape.FillColor);
+        Assert.Equal(OfficeColor.FromRgba(26, 51, 76, 128), shape.StrokeColor);
+    }
+
+    [Fact]
+    public void SvgReaderPreservesRgbaAlphaWhenExportingShapes() {
+        const string svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'>"
+            + "<rect width='10' height='10' fill='rgba(36,87,166,0.502)' stroke='rgba(10,20,30,0.25)' stroke-width='1'/></svg>";
+
+        Assert.True(OfficeSvgDrawingReader.TryRead(Encoding.UTF8.GetBytes(svg), out OfficeDrawing? drawing, out int unsupported));
+        Assert.NotNull(drawing);
+        Assert.Equal(0, unsupported);
+
+        string exported = OfficeDrawingSvgExporter.ToSvg(drawing!);
+
+        Assert.Contains("fill-opacity=\"0.502\"", exported, StringComparison.Ordinal);
+        Assert.Contains("stroke-opacity=\"0.251\"", exported, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void SvgReaderDiagnosesUnsafeOrCyclicPaintServersAndKeepsSupportedSiblings() {
         const string svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 10'>"
             + "<defs><linearGradient id='a' href='#b'/><linearGradient id='b' href='#a'/>"

--- a/OfficeIMO.Drawing/OfficeDrawingSvgExporter.cs
+++ b/OfficeIMO.Drawing/OfficeDrawingSvgExporter.cs
@@ -707,7 +707,7 @@ public static partial class OfficeDrawingSvgExporter {
             }
         } else if (shape.FillColor.HasValue && shape.FillColor.Value.A > 0) {
             sb.Append(" fill=\"").Append(ToCssColor(shape.FillColor.Value)).Append('"');
-            double fillOpacity = shape.FillOpacity ?? ToOpacity(shape.FillColor.Value);
+            double fillOpacity = (shape.FillOpacity ?? 1D) * ToOpacity(shape.FillColor.Value);
             if (fillOpacity < 1D) {
                 sb.Append(" fill-opacity=\"").Append(Format(fillOpacity)).Append('"');
             }
@@ -727,7 +727,7 @@ public static partial class OfficeDrawingSvgExporter {
         } else if (shape.StrokeColor.HasValue && shape.StrokeWidth > 0 && shape.StrokeColor.Value.A > 0) {
             sb.Append(" stroke=\"").Append(ToCssColor(shape.StrokeColor.Value)).Append('"')
                 .Append(" stroke-width=\"").Append(Format(shape.StrokeWidth)).Append('"');
-            double strokeOpacity = shape.StrokeOpacity ?? ToOpacity(shape.StrokeColor.Value);
+            double strokeOpacity = (shape.StrokeOpacity ?? 1D) * ToOpacity(shape.StrokeColor.Value);
             if (strokeOpacity < 1D) {
                 sb.Append(" stroke-opacity=\"").Append(Format(strokeOpacity)).Append('"');
             }
@@ -772,7 +772,7 @@ public static partial class OfficeDrawingSvgExporter {
 
         var sb = new StringBuilder();
         sb.Append(" fill=\"").Append(ToCssColor(color.Value)).Append('"');
-        double opacity = shape.StrokeOpacity ?? ToOpacity(color.Value);
+        double opacity = (shape.StrokeOpacity ?? 1D) * ToOpacity(color.Value);
         if (opacity < 1D) {
             sb.Append(" fill-opacity=\"").Append(Format(opacity)).Append('"');
         }

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.PaintServers.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.PaintServers.cs
@@ -350,7 +350,7 @@ public static partial class OfficeSvgDrawingReader {
                 }
 
                 if (string.IsNullOrWhiteSpace(value) || value!.Trim().Equals("currentcolor", StringComparison.OrdinalIgnoreCase)) continue;
-                if (!OfficeColor.TryParse(value.Trim(), out color)) return false;
+                if (!TrySvgColor(value.Trim(), out color)) return false;
             }
             return true;
         }

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.PaintServers.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.PaintServers.cs
@@ -20,8 +20,58 @@ public static partial class OfficeSvgDrawingReader {
         if (value.StartsWith("url(", StringComparison.OrdinalIgnoreCase)) {
             return paintServers.TryResolve(value, out paint);
         }
-        if (!OfficeColor.TryParse(value, out OfficeColor color)) return false;
+        if (!TrySvgColor(value, out OfficeColor color)) return false;
         paint = new SvgResolvedPaint(color);
+        return true;
+    }
+
+    private static bool TrySvgColor(string value, out OfficeColor color) {
+        if (OfficeColor.TryParse(value, out color)) return true;
+
+        color = default;
+        string normalized = value.Trim();
+        bool hasAlpha = normalized.StartsWith("rgba(", StringComparison.OrdinalIgnoreCase);
+        bool hasRgb = normalized.StartsWith("rgb(", StringComparison.OrdinalIgnoreCase);
+        if ((!hasAlpha && !hasRgb) || !normalized.EndsWith(")", StringComparison.Ordinal)) return false;
+
+        int prefixLength = hasAlpha ? 5 : 4;
+        string[] components = normalized.Substring(prefixLength, normalized.Length - prefixLength - 1).Split(',');
+        if (components.Length != (hasAlpha ? 4 : 3)
+            || !TrySvgColorChannel(components[0], out byte red)
+            || !TrySvgColorChannel(components[1], out byte green)
+            || !TrySvgColorChannel(components[2], out byte blue)) return false;
+
+        byte alpha = 255;
+        if (hasAlpha && !TrySvgAlphaChannel(components[3], out alpha)) return false;
+        color = OfficeColor.FromRgba(red, green, blue, alpha);
+        return true;
+    }
+
+    private static bool TrySvgColorChannel(string text, out byte channel) {
+        channel = 0;
+        string normalized = text.Trim();
+        bool percentage = normalized.EndsWith("%", StringComparison.Ordinal);
+        if (percentage) normalized = normalized.Substring(0, normalized.Length - 1).Trim();
+        if (!double.TryParse(normalized, NumberStyles.Float, CultureInfo.InvariantCulture, out double value)
+            || double.IsNaN(value)
+            || double.IsInfinity(value)
+            || value < 0D
+            || value > (percentage ? 100D : 255D)) return false;
+        channel = (byte)Math.Round(percentage ? value * 255D / 100D : value);
+        return true;
+    }
+
+    private static bool TrySvgAlphaChannel(string text, out byte alpha) {
+        alpha = 0;
+        string normalized = text.Trim();
+        bool percentage = normalized.EndsWith("%", StringComparison.Ordinal);
+        if (percentage) normalized = normalized.Substring(0, normalized.Length - 1).Trim();
+        if (!double.TryParse(normalized, NumberStyles.Float, CultureInfo.InvariantCulture, out double value)
+            || double.IsNaN(value)
+            || double.IsInfinity(value)
+            || value < 0D
+            || value > (percentage ? 100D : 1D)) return false;
+        alpha = (byte)Math.Round(percentage ? value * 255D / 100D : value * 255D);
         return true;
     }
 
@@ -278,7 +328,7 @@ public static partial class OfficeSvgDrawingReader {
 
             if (string.IsNullOrWhiteSpace(colorText)) color = OfficeColor.Black;
             else if (colorText!.Trim().Equals("currentcolor", StringComparison.OrdinalIgnoreCase)) color = currentColor;
-            else if (!OfficeColor.TryParse(colorText.Trim(), out color)) return false;
+            else if (!TrySvgColor(colorText.Trim(), out color)) return false;
 
             double opacity = 1D;
             if (!string.IsNullOrWhiteSpace(opacityText) && !TryUnitOrPercentage(opacityText!, clamp: true, out opacity)) return false;

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.PaintServers.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.PaintServers.cs
@@ -35,14 +35,28 @@ public static partial class OfficeSvgDrawingReader {
         if ((!hasAlpha && !hasRgb) || !normalized.EndsWith(")", StringComparison.Ordinal)) return false;
 
         int prefixLength = hasAlpha ? 5 : 4;
-        string[] components = normalized.Substring(prefixLength, normalized.Length - prefixLength - 1).Split(',');
-        if (components.Length != (hasAlpha ? 4 : 3)
+        string content = normalized.Substring(prefixLength, normalized.Length - prefixLength - 1);
+        string[] components;
+        string? alphaComponent = null;
+        if (content.IndexOf(',') >= 0) {
+            string[] commaComponents = content.Split(',');
+            if (commaComponents.Length != (hasAlpha ? 4 : 3)) return false;
+            components = new[] { commaComponents[0], commaComponents[1], commaComponents[2] };
+            if (hasAlpha) alphaComponent = commaComponents[3];
+        } else {
+            string[] alphaParts = content.Split('/');
+            if (alphaParts.Length > 2) return false;
+            components = alphaParts[0].Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            if (alphaParts.Length == 2) alphaComponent = alphaParts[1];
+        }
+
+        if (components.Length != 3
             || !TrySvgColorChannel(components[0], out byte red)
             || !TrySvgColorChannel(components[1], out byte green)
             || !TrySvgColorChannel(components[2], out byte blue)) return false;
 
         byte alpha = 255;
-        if (hasAlpha && !TrySvgAlphaChannel(components[3], out alpha)) return false;
+        if (alphaComponent != null && !TrySvgAlphaChannel(alphaComponent, out alpha)) return false;
         color = OfficeColor.FromRgba(red, green, blue, alpha);
         return true;
     }

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.References.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.References.cs
@@ -17,6 +17,7 @@ public static partial class OfficeSvgDrawingReader {
         OfficeTransform transform,
         double viewX,
         double viewY,
+        int maximumElements,
         ref int visited,
         ref int unsupported) {
         if (!references.TryEnter(use, out string referenceId, out XElement? target)) {
@@ -31,7 +32,7 @@ public static partial class OfficeSvgDrawingReader {
                 return;
             }
             if (targetName == "symbol") {
-                AddReferencedSymbol(use, target, drawing, style, paintServers, references, transform, ref visited, ref unsupported);
+                AddReferencedSymbol(use, target, drawing, style, paintServers, references, transform, maximumElements, ref visited, ref unsupported);
                 return;
             }
             if (!TryOptionalUseLength(use, "x", out double x) || !TryOptionalUseLength(use, "y", out double y)) {
@@ -40,7 +41,7 @@ public static partial class OfficeSvgDrawingReader {
             }
 
             OfficeTransform placement = OfficeTransform.Translate(x, y).Then(transform);
-            AddElement(target, drawing, style, paintServers, references, placement, viewX, viewY, ref visited, ref unsupported);
+            AddElement(target, drawing, style, paintServers, references, placement, viewX, viewY, maximumElements, ref visited, ref unsupported);
         } finally {
             references.Exit(referenceId);
         }

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.Symbols.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.Symbols.cs
@@ -13,6 +13,7 @@ public static partial class OfficeSvgDrawingReader {
         SvgPaintServerRegistry paintServers,
         SvgElementReferenceRegistry references,
         OfficeTransform inheritedTransform,
+        int maximumElements,
         ref int visited,
         ref int unsupported) {
         if (!TryParseNumberList(symbol.Attribute("viewBox")?.Value, out IReadOnlyList<double> viewBox)
@@ -40,7 +41,7 @@ public static partial class OfficeSvgDrawingReader {
         var scene = new OfficeDrawing(viewBox[2], viewBox[3]);
         SvgPaintContext style = ResolvePaintContext(symbol, inheritedStyle, paintServers, ref unsupported);
         OfficeTransform symbolTransform = ResolveTransform(symbol, OfficeTransform.Identity, viewBox[0], viewBox[1], ref unsupported);
-        AddChildren(symbol, scene, style, paintServers, references, symbolTransform, viewBox[0], viewBox[1], ref visited, ref unsupported);
+        AddChildren(symbol, scene, style, paintServers, references, symbolTransform, viewBox[0], viewBox[1], maximumElements, ref visited, ref unsupported);
 
         OfficeTransform viewportTransform;
         if (alignment == SvgAspectAlignment.None) {

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.Text.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.Text.cs
@@ -21,7 +21,7 @@ public static partial class OfficeSvgDrawingReader {
         var runs = new List<SvgTextRun>();
         var cursor = new SvgTextCursor { Chunk = -1 };
         bool preserve = string.Equals(element.Attribute(XNamespace.Xml + "space")?.Value, "preserve", StringComparison.OrdinalIgnoreCase);
-        AddTextElementRuns(element, style, paintServers, transform, preserve, false, viewX, viewY, runs, ref cursor, ref unsupported);
+        AddTextElementRuns(element, style, paintServers, transform, preserve, false, viewX, viewY, drawing.Width, drawing.Height, runs, ref cursor, ref unsupported);
         if (runs.Count == 0) return;
         ApplyTextAnchors(runs);
         foreach (SvgTextRun run in runs) AddTextRun(drawing, run, ref unsupported);
@@ -36,6 +36,8 @@ public static partial class OfficeSvgDrawingReader {
         bool resolveElement,
         double viewX,
         double viewY,
+        double viewportWidth,
+        double viewportHeight,
         ICollection<SvgTextRun> runs,
         ref SvgTextCursor cursor,
         ref int unsupported) {
@@ -58,7 +60,7 @@ public static partial class OfficeSvgDrawingReader {
             else if (space.Equals("default", StringComparison.OrdinalIgnoreCase)) preserve = false;
             else unsupported++;
         }
-        ApplyTextPosition(element, viewX, viewY, ref cursor, ref unsupported);
+        ApplyTextPosition(element, viewX, viewY, viewportWidth, viewportHeight, ref cursor, ref unsupported);
         int firstRun = runs.Count;
         double lengthOrigin = cursor.X;
         bool adjustGlyphs = TryReadTextLengthAdjustment(element, out double authoredLength, ref unsupported);
@@ -73,13 +75,14 @@ public static partial class OfficeSvgDrawingReader {
                 if (text.Length == 0) continue;
                 double fontSize = Math.Max(0.1D, style.FontSize);
                 double width = Math.Max(0.1D, text.Length * fontSize * 0.62D);
-                runs.Add(new SvgTextRun(text, cursor.X, cursor.Baseline, width, fontSize, cursor.Chunk, style.TextAnchor, style, transform));
+                double baseline = ResolveTextBaseline(cursor.Baseline, fontSize, style.DominantBaseline);
+                runs.Add(new SvgTextRun(text, cursor.X, baseline, width, fontSize, cursor.Chunk, style.TextAnchor, style, transform));
                 cursor.X += width;
                 cursor.HasText = true;
                 continue;
             }
             if (node is XElement child && child.Name.LocalName.Equals("tspan", StringComparison.OrdinalIgnoreCase)) {
-                AddTextElementRuns(child, style, paintServers, transform, preserve, true, viewX, viewY, runs, ref cursor, ref unsupported);
+                AddTextElementRuns(child, style, paintServers, transform, preserve, true, viewX, viewY, viewportWidth, viewportHeight, runs, ref cursor, ref unsupported);
             } else if (node is XElement) {
                 unsupported++;
             }
@@ -134,33 +137,60 @@ public static partial class OfficeSvgDrawingReader {
         cursor.X = origin + ((cursor.X - origin) * scale);
     }
 
-    private static void ApplyTextPosition(XElement element, double viewX, double viewY, ref SvgTextCursor cursor, ref int unsupported) {
+    private static void ApplyTextPosition(
+        XElement element,
+        double viewX,
+        double viewY,
+        double viewportWidth,
+        double viewportHeight,
+        ref SvgTextCursor cursor,
+        ref int unsupported) {
         bool startsChunk = false;
-        if (TryTextLength(element, "x", out double x, ref unsupported)) {
-            cursor.X = x - viewX;
+        if (TryTextLength(element, "x", viewportWidth, out double x, out bool percentage, ref unsupported)) {
+            cursor.X = percentage ? x : x - viewX;
             startsChunk = true;
         }
-        if (TryTextLength(element, "y", out double y, ref unsupported)) {
-            cursor.Baseline = y - viewY;
+        if (TryTextLength(element, "y", viewportHeight, out double y, out percentage, ref unsupported)) {
+            cursor.Baseline = percentage ? y : y - viewY;
             startsChunk = true;
         }
         if (cursor.Chunk < 0 || startsChunk) {
             cursor.Chunk++;
             cursor.PendingSpace = false;
         }
-        if (TryTextLength(element, "dx", out double dx, ref unsupported)) cursor.X += dx;
-        if (TryTextLength(element, "dy", out double dy, ref unsupported)) cursor.Baseline += dy;
+        if (TryTextLength(element, "dx", viewportWidth, out double dx, out _, ref unsupported)) cursor.X += dx;
+        if (TryTextLength(element, "dy", viewportHeight, out double dy, out _, ref unsupported)) cursor.Baseline += dy;
     }
 
-    private static bool TryTextLength(XElement element, string name, out double value, ref int unsupported) {
+    private static bool TryTextLength(
+        XElement element,
+        string name,
+        double percentageReference,
+        out double value,
+        out bool percentage,
+        ref int unsupported) {
         value = 0D;
+        percentage = false;
         string? text = element.Attribute(name)?.Value;
         if (string.IsNullOrWhiteSpace(text)) return false;
         string[] values = text!.Split(new[] { ' ', '\t', '\r', '\n', ',' }, StringSplitOptions.RemoveEmptyEntries);
         if (values.Length != 1) unsupported++;
-        if (values.Length > 0 && TrySvgLength(values[0], out value)) return true;
+        if (values.Length > 0 && TryViewportLength(values[0], percentageReference, out value, out percentage)) return true;
         unsupported++;
         return false;
+    }
+
+    private static double ResolveTextBaseline(double authoredY, double fontSize, SvgDominantBaseline baseline) {
+        switch (baseline) {
+            case SvgDominantBaseline.Hanging:
+                return authoredY + fontSize;
+            case SvgDominantBaseline.Middle:
+                return authoredY + (fontSize / 2D);
+            case SvgDominantBaseline.TextAfterEdge:
+            case SvgDominantBaseline.Alphabetic:
+            default:
+                return authoredY;
+        }
     }
 
     private static string NormalizeText(string raw, bool preserve, ref SvgTextCursor cursor) {

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.Text.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.Text.cs
@@ -146,12 +146,12 @@ public static partial class OfficeSvgDrawingReader {
         ref SvgTextCursor cursor,
         ref int unsupported) {
         bool startsChunk = false;
-        if (TryTextLength(element, "x", viewportWidth, out double x, out bool percentage, ref unsupported)) {
-            cursor.X = percentage ? x : x - viewX;
+        if (TryTextLength(element, "x", viewportWidth, out double x, out _, ref unsupported)) {
+            cursor.X = x - viewX;
             startsChunk = true;
         }
-        if (TryTextLength(element, "y", viewportHeight, out double y, out percentage, ref unsupported)) {
-            cursor.Baseline = percentage ? y : y - viewY;
+        if (TryTextLength(element, "y", viewportHeight, out double y, out _, ref unsupported)) {
+            cursor.Baseline = y - viewY;
             startsChunk = true;
         }
         if (cursor.Chunk < 0 || startsChunk) {

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
@@ -13,20 +13,36 @@ namespace OfficeIMO.Drawing;
 /// </summary>
 public static partial class OfficeSvgDrawingReader {
     private const int MaximumInputBytes = 8 * 1024 * 1024;
-    private const int MaximumElements = 10000;
 
     /// <summary>Attempts to interpret supported SVG vector primitives as a shared drawing.</summary>
     public static bool TryRead(byte[]? bytes, out OfficeDrawing? drawing) =>
-        TryRead(bytes, out drawing, out _);
+        TryRead(bytes, options: null, out drawing, out _);
 
     /// <summary>
     /// Attempts to interpret supported SVG vector primitives as a shared drawing and reports the
     /// number of elements or declarations that required omission or fallback.
     /// </summary>
-    public static bool TryRead(byte[]? bytes, out OfficeDrawing? drawing, out int unsupportedFeatureCount) {
+    public static bool TryRead(byte[]? bytes, out OfficeDrawing? drawing, out int unsupportedFeatureCount) =>
+        TryRead(bytes, options: null, out drawing, out unsupportedFeatureCount);
+
+    /// <summary>Attempts to interpret supported SVG vector primitives using explicit bounded import options.</summary>
+    public static bool TryRead(byte[]? bytes, OfficeSvgDrawingReaderOptions? options, out OfficeDrawing? drawing) =>
+        TryRead(bytes, options, out drawing, out _);
+
+    /// <summary>
+    /// Attempts to interpret supported SVG vector primitives using explicit bounded import options and reports the
+    /// number of elements or declarations that required omission or fallback.
+    /// </summary>
+    public static bool TryRead(
+        byte[]? bytes,
+        OfficeSvgDrawingReaderOptions? options,
+        out OfficeDrawing? drawing,
+        out int unsupportedFeatureCount) {
         drawing = null;
         unsupportedFeatureCount = 0;
         if (bytes == null || bytes.Length == 0 || bytes.Length > MaximumInputBytes) return false;
+        int maximumElements = options?.MaximumElements ?? OfficeSvgDrawingReaderOptions.DefaultMaximumElements;
+        if (maximumElements <= 0 || maximumElements > OfficeSvgDrawingReaderOptions.MaximumAllowedElements) return false;
 
         try {
             var settings = new XmlReaderSettings {
@@ -42,7 +58,7 @@ public static partial class OfficeSvgDrawingReader {
 
             XElement? root = document.Root;
             if (root == null || !string.Equals(root.Name.LocalName, "svg", StringComparison.OrdinalIgnoreCase)) return false;
-            if (root.Descendants().Take(MaximumElements + 1).Count() > MaximumElements) return false;
+            if (root.Descendants().Take(maximumElements + 1).Count() > maximumElements) return false;
             if (!TryResolveViewport(bytes, root, out double viewX, out double viewY, out double width, out double height)) return false;
 
             var result = new OfficeDrawing(width, height);
@@ -52,8 +68,8 @@ public static partial class OfficeSvgDrawingReader {
             var references = new SvgElementReferenceRegistry(definitions);
             var context = ResolvePaintContext(root, SvgPaintContext.Default, paintServers, ref unsupportedFeatureCount);
             OfficeTransform rootTransform = ResolveTransform(root, OfficeTransform.Identity, viewX, viewY, ref unsupportedFeatureCount);
-            AddChildren(root, result, context, paintServers, references, rootTransform, viewX, viewY, ref visited, ref unsupportedFeatureCount);
-            if (visited > MaximumElements) return false;
+            AddChildren(root, result, context, paintServers, references, rootTransform, viewX, viewY, maximumElements, ref visited, ref unsupportedFeatureCount);
+            if (visited > maximumElements) return false;
             drawing = result;
             return true;
         } catch (XmlException) {
@@ -94,11 +110,12 @@ public static partial class OfficeSvgDrawingReader {
         OfficeTransform inheritedTransform,
         double viewX,
         double viewY,
+        int maximumElements,
         ref int visited,
         ref int unsupported) {
         foreach (XElement element in parent.Elements()) {
-            AddElement(element, drawing, inherited, paintServers, references, inheritedTransform, viewX, viewY, ref visited, ref unsupported);
-            if (visited > MaximumElements) return;
+            AddElement(element, drawing, inherited, paintServers, references, inheritedTransform, viewX, viewY, maximumElements, ref visited, ref unsupported);
+            if (visited > maximumElements) return;
         }
     }
 
@@ -111,10 +128,11 @@ public static partial class OfficeSvgDrawingReader {
         OfficeTransform inheritedTransform,
         double viewX,
         double viewY,
+        int maximumElements,
         ref int visited,
         ref int unsupported) {
         visited++;
-        if (visited > MaximumElements) return;
+        if (visited > maximumElements) return;
         string name = element.Name.LocalName.ToLowerInvariant();
         if (name is "title" or "desc" or "metadata" or "lineargradient" or "radialgradient" or "stop") return;
         if (name == "defs") return;
@@ -123,11 +141,11 @@ public static partial class OfficeSvgDrawingReader {
         if (!style.Visible) return;
         OfficeTransform transform = ResolveTransform(element, inheritedTransform, viewX, viewY, ref unsupported);
         if (name is "g" or "svg" or "a" or "switch") {
-            AddChildren(element, drawing, style, paintServers, references, transform, viewX, viewY, ref visited, ref unsupported);
+            AddChildren(element, drawing, style, paintServers, references, transform, viewX, viewY, maximumElements, ref visited, ref unsupported);
             return;
         }
         if (name == "use") {
-            AddReferencedElement(element, drawing, style, paintServers, references, transform, viewX, viewY, ref visited, ref unsupported);
+            AddReferencedElement(element, drawing, style, paintServers, references, transform, viewX, viewY, maximumElements, ref visited, ref unsupported);
             return;
         }
         if (name == "text") {
@@ -406,7 +424,7 @@ public static partial class OfficeSvgDrawingReader {
         switch (name.Trim().ToLowerInvariant()) {
             case "color":
                 if (normalized.Equals("currentcolor", StringComparison.OrdinalIgnoreCase)) break;
-                if (!OfficeColor.TryParse(normalized, out OfficeColor currentColor)) unsupported++;
+                if (!TrySvgColor(normalized, out OfficeColor currentColor)) unsupported++;
                 else style.Color = currentColor;
                 break;
             case "fill":
@@ -564,8 +582,8 @@ public static partial class OfficeSvgDrawingReader {
 
     private static double ReadViewportCoordinate(XElement element, string name, double origin, double extent) {
         string? text = element.Attribute(name)?.Value;
-        if (!TryViewportLength(text, extent, out double value, out bool percentage)) return -origin;
-        return percentage ? value : value - origin;
+        if (!TryViewportLength(text, extent, out double value, out _)) return -origin;
+        return value - origin;
     }
 
     private static double ReadViewportLength(XElement element, string name, double extent) =>

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
@@ -136,10 +136,10 @@ public static partial class OfficeSvgDrawingReader {
         }
 
         OfficeDrawingShape? shape = name switch {
-            "rect" => CreateRectangle(element, style, viewX, viewY, ref unsupported),
-            "circle" => CreateCircle(element, style, viewX, viewY),
-            "ellipse" => CreateEllipse(element, style, viewX, viewY),
-            "line" => CreateLine(element, style, viewX, viewY),
+            "rect" => CreateRectangle(element, style, viewX, viewY, drawing.Width, drawing.Height, ref unsupported),
+            "circle" => CreateCircle(element, style, viewX, viewY, drawing.Width, drawing.Height),
+            "ellipse" => CreateEllipse(element, style, viewX, viewY, drawing.Width, drawing.Height),
+            "line" => CreateLine(element, style, viewX, viewY, drawing.Width, drawing.Height),
             "polygon" => CreatePolygon(element, style, viewX, viewY, close: true),
             "polyline" => CreatePolygon(element, style, viewX, viewY, close: false),
             "path" => CreatePath(element, style, viewX, viewY),
@@ -188,12 +188,22 @@ public static partial class OfficeSvgDrawingReader {
         shape.Transform = shape.Transform.HasValue ? shape.Transform.Value.Then(local) : local;
     }
 
-    private static OfficeDrawingShape? CreateRectangle(XElement element, SvgPaintContext style, double viewX, double viewY, ref int unsupported) {
-        if (!TryLength(element, "width", out double width) || !TryLength(element, "height", out double height) || width <= 0D || height <= 0D) return null;
-        double x = ReadLength(element, "x") - viewX;
-        double y = ReadLength(element, "y") - viewY;
-        double rx = ReadLength(element, "rx");
-        double ry = ReadLength(element, "ry");
+    private static OfficeDrawingShape? CreateRectangle(
+        XElement element,
+        SvgPaintContext style,
+        double viewX,
+        double viewY,
+        double viewportWidth,
+        double viewportHeight,
+        ref int unsupported) {
+        if (!TryViewportLength(element, "width", viewportWidth, out double width)
+            || !TryViewportLength(element, "height", viewportHeight, out double height)
+            || width <= 0D
+            || height <= 0D) return null;
+        double x = ReadViewportCoordinate(element, "x", viewX, viewportWidth);
+        double y = ReadViewportCoordinate(element, "y", viewY, viewportHeight);
+        double rx = ReadViewportLength(element, "rx", viewportWidth);
+        double ry = ReadViewportLength(element, "ry", viewportHeight);
         if (rx <= 0D && ry > 0D) rx = ry;
         if (ry <= 0D && rx > 0D) ry = rx;
         OfficeShape shape;
@@ -207,29 +217,51 @@ public static partial class OfficeSvgDrawingReader {
         return new OfficeDrawingShape(shape, x, y);
     }
 
-    private static OfficeDrawingShape? CreateCircle(XElement element, SvgPaintContext style, double viewX, double viewY) {
-        if (!TryLength(element, "r", out double radius) || radius <= 0D) return null;
-        double x = ReadLength(element, "cx") - radius - viewX;
-        double y = ReadLength(element, "cy") - radius - viewY;
+    private static OfficeDrawingShape? CreateCircle(
+        XElement element,
+        SvgPaintContext style,
+        double viewX,
+        double viewY,
+        double viewportWidth,
+        double viewportHeight) {
+        double normalizedDiagonal = Math.Sqrt((viewportWidth * viewportWidth) + (viewportHeight * viewportHeight)) / Math.Sqrt(2D);
+        if (!TryViewportLength(element, "r", normalizedDiagonal, out double radius) || radius <= 0D) return null;
+        double x = ReadViewportCoordinate(element, "cx", viewX, viewportWidth) - radius;
+        double y = ReadViewportCoordinate(element, "cy", viewY, viewportHeight) - radius;
         OfficeShape shape = OfficeShape.Ellipse(radius * 2D, radius * 2D);
         ApplyPaint(shape, style);
         return new OfficeDrawingShape(shape, x, y);
     }
 
-    private static OfficeDrawingShape? CreateEllipse(XElement element, SvgPaintContext style, double viewX, double viewY) {
-        if (!TryLength(element, "rx", out double radiusX) || !TryLength(element, "ry", out double radiusY) || radiusX <= 0D || radiusY <= 0D) return null;
-        double x = ReadLength(element, "cx") - radiusX - viewX;
-        double y = ReadLength(element, "cy") - radiusY - viewY;
+    private static OfficeDrawingShape? CreateEllipse(
+        XElement element,
+        SvgPaintContext style,
+        double viewX,
+        double viewY,
+        double viewportWidth,
+        double viewportHeight) {
+        if (!TryViewportLength(element, "rx", viewportWidth, out double radiusX)
+            || !TryViewportLength(element, "ry", viewportHeight, out double radiusY)
+            || radiusX <= 0D
+            || radiusY <= 0D) return null;
+        double x = ReadViewportCoordinate(element, "cx", viewX, viewportWidth) - radiusX;
+        double y = ReadViewportCoordinate(element, "cy", viewY, viewportHeight) - radiusY;
         OfficeShape shape = OfficeShape.Ellipse(radiusX * 2D, radiusY * 2D);
         ApplyPaint(shape, style);
         return new OfficeDrawingShape(shape, x, y);
     }
 
-    private static OfficeDrawingShape? CreateLine(XElement element, SvgPaintContext style, double viewX, double viewY) {
-        double x1 = ReadLength(element, "x1") - viewX;
-        double y1 = ReadLength(element, "y1") - viewY;
-        double x2 = ReadLength(element, "x2") - viewX;
-        double y2 = ReadLength(element, "y2") - viewY;
+    private static OfficeDrawingShape? CreateLine(
+        XElement element,
+        SvgPaintContext style,
+        double viewX,
+        double viewY,
+        double viewportWidth,
+        double viewportHeight) {
+        double x1 = ReadViewportCoordinate(element, "x1", viewX, viewportWidth);
+        double y1 = ReadViewportCoordinate(element, "y1", viewY, viewportHeight);
+        double x2 = ReadViewportCoordinate(element, "x2", viewX, viewportWidth);
+        double y2 = ReadViewportCoordinate(element, "y2", viewY, viewportHeight);
         if (Math.Abs(x1 - x2) <= 0.0001D && Math.Abs(y1 - y2) <= 0.0001D) return null;
         OfficeShape shape = OfficeShape.Line(x1, y1, x2, y2);
         shape.FillColor = null;
@@ -355,6 +387,7 @@ public static partial class OfficeSvgDrawingReader {
         ApplyProperty("font-style", element.Attribute("font-style")?.Value, paintServers, ref result, ref unsupported);
         ApplyProperty("font-weight", element.Attribute("font-weight")?.Value, paintServers, ref result, ref unsupported);
         ApplyProperty("text-anchor", element.Attribute("text-anchor")?.Value, paintServers, ref result, ref unsupported);
+        ApplyProperty("dominant-baseline", element.Attribute("dominant-baseline")?.Value, paintServers, ref result, ref unsupported);
         ApplyProperty("display", element.Attribute("display")?.Value, paintServers, ref result, ref unsupported);
         ApplyProperty("visibility", element.Attribute("visibility")?.Value, paintServers, ref result, ref unsupported);
         foreach (string declaration in declarations) {
@@ -456,6 +489,14 @@ public static partial class OfficeSvgDrawingReader {
                 if (anchor is "start" or "middle" or "end") style.TextAnchor = anchor;
                 else unsupported++;
                 break;
+            case "dominant-baseline":
+                string baseline = normalized.ToLowerInvariant();
+                if (baseline is "auto" or "alphabetic") style.DominantBaseline = SvgDominantBaseline.Alphabetic;
+                else if (baseline is "hanging" or "text-before-edge") style.DominantBaseline = SvgDominantBaseline.Hanging;
+                else if (baseline is "middle" or "central") style.DominantBaseline = SvgDominantBaseline.Middle;
+                else if (baseline is "text-after-edge" or "ideographic") style.DominantBaseline = SvgDominantBaseline.TextAfterEdge;
+                else unsupported++;
+                break;
             case "display":
                 if (normalized.Equals("none", StringComparison.OrdinalIgnoreCase)) style.Visible = false;
                 break;
@@ -521,6 +562,33 @@ public static partial class OfficeSvgDrawingReader {
     private static double ReadLength(XElement element, string name) => TryLength(element, name, out double value) ? value : 0D;
     private static bool TryLength(XElement element, string name, out double value) => TrySvgLength(element.Attribute(name)?.Value, out value);
 
+    private static double ReadViewportCoordinate(XElement element, string name, double origin, double extent) {
+        string? text = element.Attribute(name)?.Value;
+        if (!TryViewportLength(text, extent, out double value, out bool percentage)) return -origin;
+        return percentage ? value : value - origin;
+    }
+
+    private static double ReadViewportLength(XElement element, string name, double extent) =>
+        TryViewportLength(element, name, extent, out double value) ? value : 0D;
+
+    private static bool TryViewportLength(XElement element, string name, double extent, out double value) =>
+        TryViewportLength(element.Attribute(name)?.Value, extent, out value, out _);
+
+    private static bool TryViewportLength(string? text, double extent, out double value, out bool percentage) {
+        value = 0D;
+        percentage = false;
+        if (string.IsNullOrWhiteSpace(text)) return false;
+        string normalized = text!.Trim();
+        percentage = normalized.EndsWith("%", StringComparison.Ordinal);
+        if (percentage) normalized = normalized.Substring(0, normalized.Length - 1).Trim();
+        else if (normalized.EndsWith("px", StringComparison.OrdinalIgnoreCase)) normalized = normalized.Substring(0, normalized.Length - 2).Trim();
+        if (!double.TryParse(normalized, NumberStyles.Float, CultureInfo.InvariantCulture, out double parsed)
+            || double.IsNaN(parsed)
+            || double.IsInfinity(parsed)) return false;
+        value = percentage ? parsed * extent / 100D : parsed;
+        return !double.IsNaN(value) && !double.IsInfinity(value);
+    }
+
     private static double ReadFirstLength(XElement element, string name) {
         string? value = element.Attribute(name)?.Value;
         if (string.IsNullOrWhiteSpace(value)) return 0D;
@@ -581,6 +649,7 @@ public static partial class OfficeSvgDrawingReader {
         internal double FontSize;
         internal OfficeFontStyle FontStyle;
         internal string TextAnchor;
+        internal SvgDominantBaseline DominantBaseline;
         internal bool Visible;
 
         internal void SetFill(SvgResolvedPaint paint) {
@@ -613,7 +682,15 @@ public static partial class OfficeSvgDrawingReader {
             FontSize = 16D,
             FontStyle = OfficeFontStyle.Regular,
             TextAnchor = "start",
+            DominantBaseline = SvgDominantBaseline.Alphabetic,
             Visible = true
         };
+    }
+
+    private enum SvgDominantBaseline {
+        Alphabetic,
+        Hanging,
+        Middle,
+        TextAfterEdge
     }
 }

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReaderOptions.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReaderOptions.cs
@@ -1,0 +1,17 @@
+namespace OfficeIMO.Drawing;
+
+/// <summary>
+/// Controls bounded SVG import limits for trusted inputs that legitimately contain many elements.
+/// </summary>
+public sealed class OfficeSvgDrawingReaderOptions {
+    /// <summary>Default maximum number of descendant and expanded reference elements.</summary>
+    public const int DefaultMaximumElements = 10000;
+
+    /// <summary>Hard maximum accepted by the reader, even when explicitly requested.</summary>
+    public const int MaximumAllowedElements = 100000;
+
+    /// <summary>
+    /// Maximum number of descendant and expanded reference elements. Increase this only for trusted SVG input.
+    /// </summary>
+    public int MaximumElements { get; set; } = DefaultMaximumElements;
+}

--- a/OfficeIMO.sln
+++ b/OfficeIMO.sln
@@ -304,6 +304,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Reader.Benchmarks
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Pdf.Cryptography.Pkcs", "OfficeIMO.Pdf.Cryptography.Pkcs\OfficeIMO.Pdf.Cryptography.Pkcs.csproj", "{6BC5E07C-5637-482B-9635-312779906A3B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Drawing.CodeGlyphX", "OfficeIMO.Drawing.CodeGlyphX\OfficeIMO.Drawing.CodeGlyphX.csproj", "{D0923670-3E40-4E7E-8805-55540144185C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1442,6 +1444,18 @@ Global
 		{6BC5E07C-5637-482B-9635-312779906A3B}.Release|x64.Build.0 = Release|Any CPU
 		{6BC5E07C-5637-482B-9635-312779906A3B}.Release|x86.ActiveCfg = Release|Any CPU
 		{6BC5E07C-5637-482B-9635-312779906A3B}.Release|x86.Build.0 = Release|Any CPU
+		{D0923670-3E40-4E7E-8805-55540144185C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D0923670-3E40-4E7E-8805-55540144185C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D0923670-3E40-4E7E-8805-55540144185C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D0923670-3E40-4E7E-8805-55540144185C}.Debug|x64.Build.0 = Debug|Any CPU
+		{D0923670-3E40-4E7E-8805-55540144185C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D0923670-3E40-4E7E-8805-55540144185C}.Debug|x86.Build.0 = Debug|Any CPU
+		{D0923670-3E40-4E7E-8805-55540144185C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D0923670-3E40-4E7E-8805-55540144185C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D0923670-3E40-4E7E-8805-55540144185C}.Release|x64.ActiveCfg = Release|Any CPU
+		{D0923670-3E40-4E7E-8805-55540144185C}.Release|x64.Build.0 = Release|Any CPU
+		{D0923670-3E40-4E7E-8805-55540144185C}.Release|x86.ActiveCfg = Release|Any CPU
+		{D0923670-3E40-4E7E-8805-55540144185C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/OfficeIMO.sln
+++ b/OfficeIMO.sln
@@ -306,6 +306,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Pdf.Cryptography.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Drawing.CodeGlyphX", "OfficeIMO.Drawing.CodeGlyphX\OfficeIMO.Drawing.CodeGlyphX.csproj", "{D0923670-3E40-4E7E-8805-55540144185C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Drawing.CodeGlyphX.Tests", "OfficeIMO.Drawing.CodeGlyphX.Tests\OfficeIMO.Drawing.CodeGlyphX.Tests.csproj", "{67A6E693-DAF0-4539-8AC4-D03458E932F4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Drawing.CodeGlyphX.Benchmarks", "OfficeIMO.Drawing.CodeGlyphX.Benchmarks\OfficeIMO.Drawing.CodeGlyphX.Benchmarks.csproj", "{29CCF8CA-A2B6-4B3B-AC62-09327C3A842F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1456,6 +1460,30 @@ Global
 		{D0923670-3E40-4E7E-8805-55540144185C}.Release|x64.Build.0 = Release|Any CPU
 		{D0923670-3E40-4E7E-8805-55540144185C}.Release|x86.ActiveCfg = Release|Any CPU
 		{D0923670-3E40-4E7E-8805-55540144185C}.Release|x86.Build.0 = Release|Any CPU
+		{67A6E693-DAF0-4539-8AC4-D03458E932F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{67A6E693-DAF0-4539-8AC4-D03458E932F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{67A6E693-DAF0-4539-8AC4-D03458E932F4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{67A6E693-DAF0-4539-8AC4-D03458E932F4}.Debug|x64.Build.0 = Debug|Any CPU
+		{67A6E693-DAF0-4539-8AC4-D03458E932F4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{67A6E693-DAF0-4539-8AC4-D03458E932F4}.Debug|x86.Build.0 = Debug|Any CPU
+		{67A6E693-DAF0-4539-8AC4-D03458E932F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{67A6E693-DAF0-4539-8AC4-D03458E932F4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{67A6E693-DAF0-4539-8AC4-D03458E932F4}.Release|x64.ActiveCfg = Release|Any CPU
+		{67A6E693-DAF0-4539-8AC4-D03458E932F4}.Release|x64.Build.0 = Release|Any CPU
+		{67A6E693-DAF0-4539-8AC4-D03458E932F4}.Release|x86.ActiveCfg = Release|Any CPU
+		{67A6E693-DAF0-4539-8AC4-D03458E932F4}.Release|x86.Build.0 = Release|Any CPU
+		{29CCF8CA-A2B6-4B3B-AC62-09327C3A842F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{29CCF8CA-A2B6-4B3B-AC62-09327C3A842F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{29CCF8CA-A2B6-4B3B-AC62-09327C3A842F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{29CCF8CA-A2B6-4B3B-AC62-09327C3A842F}.Debug|x64.Build.0 = Debug|Any CPU
+		{29CCF8CA-A2B6-4B3B-AC62-09327C3A842F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{29CCF8CA-A2B6-4B3B-AC62-09327C3A842F}.Debug|x86.Build.0 = Debug|Any CPU
+		{29CCF8CA-A2B6-4B3B-AC62-09327C3A842F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{29CCF8CA-A2B6-4B3B-AC62-09327C3A842F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{29CCF8CA-A2B6-4B3B-AC62-09327C3A842F}.Release|x64.ActiveCfg = Release|Any CPU
+		{29CCF8CA-A2B6-4B3B-AC62-09327C3A842F}.Release|x64.Build.0 = Release|Any CPU
+		{29CCF8CA-A2B6-4B3B-AC62-09327C3A842F}.Release|x86.ActiveCfg = Release|Any CPU
+		{29CCF8CA-A2B6-4B3B-AC62-09327C3A842F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary

- Extends the generic SVG reader with percentage geometry, percentage text positioning, non-zero viewBox normalization, common dominant-baseline behavior, and CSS rgb/rgba colors.
- Adds the optional OfficeIMO.Drawing.CodeGlyphX package for typed QR, matrix, and linear-barcode handoff through neutral SVG.
- Adds non-packable integration tests, BenchmarkDotNet coverage, and Windows/Linux CI lanes for the bridge.

## Package boundary

CodeGlyphX and OfficeIMO.Drawing remain independent core packages. The bridge references both, while the same integration continues to work without it by rendering standard SVG and importing it with OfficeSvgDrawingReader.

The bridge supports the published CodeGlyphX package range [1.6.0, 3.0.0) and can use an adjacent CodeGlyphX project during source validation. The generic SVG reader retains its conservative 10,000-element default; trusted callers can explicitly request a bounded higher limit, which the typed bridge uses for large styled matrix symbols. The typed bridge rejects QR options containing raster logos because the generic SVG reader cannot preserve image elements; it fails explicitly rather than silently omitting the logo.

## Benchmark decision

No binary-grid primitive is added to OfficeIMO.Drawing. Default QR, Data Matrix, and stacked DataBar SVG already import as two drawing shapes, while individually styled QR modules intentionally remain separate shapes.

## Validation

- The complete OfficeIMO solution builds without warnings or errors.
- Drawing tests pass on .NET 8, .NET 10, and .NET Framework 4.7.2.
- End-to-end bridge tests pass against both published CodeGlyphX 1.6 and the current source implementation.
- Large styled QR and alpha-color imports have dedicated regression coverage.
- Both packages build successfully, and a clean package-consumer smoke test imports the resulting drawing without fallbacks.