### PR TITLE
Complete advanced PDF layout and standards proof

### DIFF
--- a/.github/scripts/Assert-PdfComplianceProof.ps1
+++ b/.github/scripts/Assert-PdfComplianceProof.ps1
@@ -26,6 +26,7 @@ function Get-ExpectedProductProofValidators {
     )
 
     switch ($Profile) {
+        'PdfA2B' { return @('VeraPdf') }
         'PdfA3B' { return @('VeraPdf') }
         'PdfUa1' { return @('PdfUaValidator') }
         'FacturX' { return @('VeraPdf', 'Mustang') }
@@ -55,6 +56,10 @@ function Assert-ProductProofContractProfile {
     Assert-Condition -Condition ($Entry.PSObject.Properties.Name -contains 'hasRequiredExternalValidation') -Message "Product proof contract row $ExpectedProfile in $SourceName is missing hasRequiredExternalValidation."
     Assert-Condition -Condition ($Entry.PSObject.Properties.Name -contains 'canClaimConformance') -Message "Product proof contract row $ExpectedProfile in $SourceName is missing canClaimConformance."
     Assert-Condition -Condition ($Entry.PSObject.Properties.Name -contains 'failedExternalValidationCount') -Message "Product proof contract row $ExpectedProfile in $SourceName is missing failedExternalValidationCount."
+    Assert-Condition -Condition ($Entry.PSObject.Properties.Name -contains 'proofStatus') -Message "Product proof contract row $ExpectedProfile in $SourceName is missing proofStatus."
+    Assert-Condition -Condition ($Entry.hasArtifactEvidence -eq $true) -Message "Product proof contract row $ExpectedProfile in $SourceName must identify an exact artifact."
+    Assert-Condition -Condition (-not [string]::IsNullOrWhiteSpace($Entry.artifactSha256) -and ([string] $Entry.artifactSha256).Length -eq 64) -Message "Product proof contract row $ExpectedProfile in $SourceName is missing an artifact SHA-256."
+    Assert-Condition -Condition ([long] $Entry.artifactSizeBytes -gt 0) -Message "Product proof contract row $ExpectedProfile in $SourceName is missing artifact byte length."
     Assert-Condition -Condition ($requiredExternalValidators.Count -eq $expectedValidators.Count) -Message "Product proof contract row $ExpectedProfile in $SourceName has $($requiredExternalValidators.Count) required validators, expected $($expectedValidators.Count)."
     Assert-Condition -Condition ($externalValidatorProofs.Count -eq $expectedValidators.Count) -Message "Product proof contract row $ExpectedProfile in $SourceName has $($externalValidatorProofs.Count) external validator proof rows, expected $($expectedValidators.Count)."
 
@@ -73,19 +78,37 @@ function Assert-ProductProofContractProfile {
         Assert-Condition -Condition (-not [string]::IsNullOrWhiteSpace($row.diagnostic)) -Message "Product proof contract row $ExpectedProfile in $SourceName $expectedValidator proof is missing diagnostic."
         Assert-Condition -Condition ($row.PSObject.Properties.Name -contains 'profile') -Message "Product proof contract row $ExpectedProfile in $SourceName $expectedValidator proof is missing profile."
         Assert-Condition -Condition ($row.PSObject.Properties.Name -contains 'exitCode') -Message "Product proof contract row $ExpectedProfile in $SourceName $expectedValidator proof is missing exitCode."
+        Assert-Condition -Condition ($row.PSObject.Properties.Name -contains 'validatorVersion') -Message "Product proof contract row $ExpectedProfile in $SourceName $expectedValidator proof is missing validatorVersion."
+        Assert-Condition -Condition ($row.PSObject.Properties.Name -contains 'artifactSha256') -Message "Product proof contract row $ExpectedProfile in $SourceName $expectedValidator proof is missing artifactSha256."
+        Assert-Condition -Condition ($row.PSObject.Properties.Name -contains 'artifactSizeBytes') -Message "Product proof contract row $ExpectedProfile in $SourceName $expectedValidator proof is missing artifactSizeBytes."
+        Assert-Condition -Condition ($row.PSObject.Properties.Name -contains 'validatedAtUtc') -Message "Product proof contract row $ExpectedProfile in $SourceName $expectedValidator proof is missing validatedAtUtc."
+        Assert-Condition -Condition ($row.PSObject.Properties.Name -contains 'warnings') -Message "Product proof contract row $ExpectedProfile in $SourceName $expectedValidator proof is missing warnings."
 
         if ($status -eq 'Passed') {
             Assert-Condition -Condition ($row.isSatisfied -eq $true) -Message "Product proof contract row $ExpectedProfile in $SourceName $expectedValidator passed proof must be satisfied."
             Assert-Condition -Condition ($row.blocksConformanceClaim -eq $false) -Message "Product proof contract row $ExpectedProfile in $SourceName $expectedValidator passed proof must not block a claim."
+            Assert-Condition -Condition (-not [string]::IsNullOrWhiteSpace($row.validatorVersion)) -Message "Product proof contract row $ExpectedProfile in $SourceName $expectedValidator passed proof is missing validator version."
+            Assert-Condition -Condition ([string] $row.artifactSha256 -eq [string] $Entry.artifactSha256) -Message "Product proof contract row $ExpectedProfile in $SourceName $expectedValidator passed proof has the wrong artifact SHA-256."
+            Assert-Condition -Condition ([long] $row.artifactSizeBytes -eq [long] $Entry.artifactSizeBytes) -Message "Product proof contract row $ExpectedProfile in $SourceName $expectedValidator passed proof has the wrong artifact byte length."
+            Assert-Condition -Condition (-not [string]::IsNullOrWhiteSpace($row.validatedAtUtc)) -Message "Product proof contract row $ExpectedProfile in $SourceName $expectedValidator passed proof is missing validation timestamp."
         } else {
             Assert-Condition -Condition ($row.isSatisfied -eq $false) -Message "Product proof contract row $ExpectedProfile in $SourceName $expectedValidator non-passing proof must not be satisfied."
             Assert-Condition -Condition ($row.blocksConformanceClaim -eq $true) -Message "Product proof contract row $ExpectedProfile in $SourceName $expectedValidator non-passing proof must block a claim."
         }
     }
 
-    Assert-Condition -Condition ($Entry.hasRequiredExternalValidation -eq $false) -Message "Product proof contract row $ExpectedProfile in $SourceName must not have required external validation in groundwork proof."
-    Assert-Condition -Condition ($Entry.canClaimConformance -eq $false) -Message "Product proof contract row $ExpectedProfile in $SourceName must not claim conformance."
-    Assert-Condition -Condition (@($Entry.missingExternalValidators).Count -ge 1) -Message "Product proof contract row $ExpectedProfile in $SourceName must list missing or blocking external validators."
+    $isFormalProfile = $ExpectedProfile -in @('PdfA2B', 'PdfA3B', 'PdfUa1', 'FacturX', 'Zugferd')
+    if ($isFormalProfile -and @($externalValidatorProofs | Where-Object { $_.status -eq 'Passed' }).Count -eq $expectedValidators.Count) {
+        Assert-Condition -Condition ($Entry.isInternallyReady -eq $true) -Message "$ExpectedProfile product proof must be internally ready."
+        Assert-Condition -Condition ($Entry.hasRequiredExternalValidation -eq $true) -Message "$ExpectedProfile product proof must include passing external validation."
+        Assert-Condition -Condition ($Entry.canClaimConformance -eq $true) -Message "$ExpectedProfile exact artifact should be claimable after internal and external proof pass."
+        Assert-Condition -Condition ([string] $Entry.proofStatus -eq 'Claimable') -Message "$ExpectedProfile proofStatus must be Claimable after all proof passes."
+        Assert-Condition -Condition (@($Entry.missingExternalValidators).Count -eq 0) -Message "$ExpectedProfile claimable proof must not list missing validators."
+    } else {
+        Assert-Condition -Condition ($Entry.hasRequiredExternalValidation -eq $false) -Message "Product proof contract row $ExpectedProfile in $SourceName must not have required external validation."
+        Assert-Condition -Condition ($Entry.canClaimConformance -eq $false) -Message "Product proof contract row $ExpectedProfile in $SourceName must not claim conformance."
+        Assert-Condition -Condition (@($Entry.missingExternalValidators).Count -ge 1) -Message "Product proof contract row $ExpectedProfile in $SourceName must list missing or blocking external validators."
+    }
 }
 
 $resolvedProofPath = Resolve-Path -LiteralPath $ProofPath
@@ -100,7 +123,7 @@ Assert-Condition -Condition (Test-Path -LiteralPath $productProofContractPath) -
 $proof = Get-Content -LiteralPath $jsonPath -Raw | ConvertFrom-Json
 $productProofContractFile = Get-Content -LiteralPath $productProofContractPath -Raw | ConvertFrom-Json
 
-Assert-Condition -Condition ($proof.schemaVersion -eq 3) -Message 'Unexpected proof schema version.'
+Assert-Condition -Condition ($proof.schemaVersion -eq 4) -Message 'Unexpected proof schema version.'
 Assert-Condition -Condition ($proof.testExitCode -eq 0) -Message "Expected testExitCode 0, got $($proof.testExitCode)."
 Assert-Condition -Condition ($null -ne $proof.strictValidatorMode) -Message 'Missing strictValidatorMode in proof.json.'
 Assert-Condition -Condition ($null -ne $proof.validatorConfiguration) -Message 'Missing validatorConfiguration in proof.json.'
@@ -110,23 +133,30 @@ Assert-Condition -Condition ($null -ne $proof.validatorConfiguration.pdfUaValida
 Assert-Condition -Condition ($null -ne $proof.validatorConfiguration.pdfUaValidatorArgsConfigured) -Message 'Missing pdfUaValidatorArgsConfigured in proof.json.'
 Assert-Condition -Condition ($null -ne $proof.validatorConfiguration.mustangExecutableConfigured) -Message 'Missing mustangExecutableConfigured in proof.json.'
 Assert-Condition -Condition ($null -ne $proof.validatorConfiguration.mustangArgsConfigured) -Message 'Missing mustangArgsConfigured in proof.json.'
-Assert-Condition -Condition ($proof.contract.formalProfilesFailClosed -eq $true) -Message 'Proof contract must keep formal profiles fail-closed.'
-Assert-Condition -Condition ($proof.contract.generatedPdfsAreGroundworkFixtures -eq $true) -Message 'Proof contract must mark generated PDFs as groundwork fixtures.'
+Assert-Condition -Condition ($proof.contract.unsupportedFormalProfilesFailClosed -eq $true) -Message 'Proof contract must keep unsupported formal profiles fail-closed.'
+Assert-Condition -Condition ($proof.contract.formalPdfA2BGenerationEnabled -eq $true) -Message 'Proof contract must enable validator-backed PDF/A-2b generation.'
+Assert-Condition -Condition ($proof.contract.formalPdfA3BGenerationEnabled -eq $true) -Message 'Proof contract must enable validator-backed PDF/A-3b generation.'
+Assert-Condition -Condition ($proof.contract.formalPdfUa1GenerationEnabled -eq $true) -Message 'Proof contract must enable validator-backed PDF/UA-1 generation.'
+Assert-Condition -Condition ($proof.contract.formalElectronicInvoiceGenerationEnabled -eq $true) -Message 'Proof contract must enable validator-backed Factur-X and ZUGFeRD generation.'
+Assert-Condition -Condition ($proof.contract.allGeneratedPdfsAreGroundworkFixtures -eq $false) -Message 'Proof contract must distinguish formal PDF/A-2b from groundwork fixtures.'
 Assert-Condition -Condition ($proof.contract.externalValidationRequiredForClaims -eq $true) -Message 'Proof contract must require external validation for claims.'
+Assert-Condition -Condition ($proof.contract.externalValidationBoundToExactArtifact -eq $true) -Message 'Proof contract must bind external validation to the exact artifact.'
 Assert-Condition -Condition ($null -ne $proof.productProofContract) -Message 'Missing productProofContract in proof.json.'
-Assert-Condition -Condition ($proof.productProofContract.schemaVersion -eq 3) -Message 'Unexpected productProofContract schema version in proof.json.'
-Assert-Condition -Condition ($productProofContractFile.schemaVersion -eq 3) -Message 'Unexpected officeimo-profile-proof-contract.json schema version.'
+Assert-Condition -Condition ($proof.productProofContract.schemaVersion -eq 4) -Message 'Unexpected productProofContract schema version in proof.json.'
+Assert-Condition -Condition ($productProofContractFile.schemaVersion -eq 4) -Message 'Unexpected officeimo-profile-proof-contract.json schema version.'
 Assert-Condition -Condition ([string] $proof.productProofContract.generatedBy -eq [string] $productProofContractFile.generatedBy) -Message 'Product proof contract generatedBy mismatch.'
-Assert-Condition -Condition ([string] $proof.productProofContract.externalEvidenceMode -eq 'NoExternalValidationInjected') -Message 'Unexpected product proof contract externalEvidenceMode in proof.json.'
-Assert-Condition -Condition ([string] $productProofContractFile.externalEvidenceMode -eq 'NoExternalValidationInjected') -Message 'Unexpected externalEvidenceMode in officeimo-profile-proof-contract.json.'
+Assert-Condition -Condition ([string] $proof.productProofContract.externalEvidenceMode -eq 'ExactArtifactValidationInjectedByProofExporter') -Message 'Unexpected product proof contract externalEvidenceMode in proof.json.'
+Assert-Condition -Condition ([string] $productProofContractFile.externalEvidenceMode -eq 'ExactArtifactValidationInjectedByProofExporter') -Message 'Unexpected externalEvidenceMode in officeimo-profile-proof-contract.json.'
 
 $pdfFixtures = @($proof.pdfFixtures)
-Assert-Condition -Condition ($pdfFixtures.Count -eq 3) -Message "Expected 3 PDF fixtures, got $($pdfFixtures.Count)."
+Assert-Condition -Condition ($pdfFixtures.Count -eq 5) -Message "Expected 5 PDF fixtures, got $($pdfFixtures.Count)."
 
 $expectedPdfNames = @(
-    'officeimo-pdfa3-groundwork.pdf',
-    'officeimo-einvoice-groundwork.pdf',
-    'officeimo-pdfua-groundwork.pdf'
+    'officeimo-pdfa2b.pdf',
+    'officeimo-pdfa3b.pdf',
+    'officeimo-facturx.pdf',
+    'officeimo-zugferd.pdf',
+    'officeimo-pdfua1.pdf'
 )
 
 foreach ($expectedName in $expectedPdfNames) {
@@ -143,7 +173,7 @@ foreach ($expectedName in $expectedPdfNames) {
 }
 
 $validatorDiagnostics = @($proof.validatorDiagnostics)
-Assert-Condition -Condition ($validatorDiagnostics.Count -ge 4) -Message "Expected at least 4 validator diagnostics, got $($validatorDiagnostics.Count)."
+Assert-Condition -Condition ($validatorDiagnostics.Count -ge 7) -Message "Expected at least 7 validator diagnostics, got $($validatorDiagnostics.Count)."
 
 $requiredValidatorKinds = @('VeraPdf', 'PdfUaValidator', 'Mustang')
 foreach ($validatorKind in $requiredValidatorKinds) {
@@ -159,6 +189,12 @@ foreach ($entry in $validatorDiagnostics) {
     Assert-Condition -Condition ($validStatuses -contains [string] $entry.status) -Message "Validator diagnostic entry $($entry.file) has invalid status $($entry.status)."
     Assert-Condition -Condition ($validStatuses -contains [string] $entry.expectedStatus) -Message "Validator diagnostic entry $($entry.file) has invalid expectedStatus $($entry.expectedStatus)."
     Assert-Condition -Condition ($entry.matchesExpectedStatus -eq $true) -Message "Validator diagnostic entry $($entry.file) status $($entry.status) did not match expected status $($entry.expectedStatus)."
+    Assert-Condition -Condition (-not [string]::IsNullOrWhiteSpace($entry.validatorVersion)) -Message "Validator diagnostic entry $($entry.file) is missing validatorVersion."
+    Assert-Condition -Condition (-not [string]::IsNullOrWhiteSpace($entry.artifactFile)) -Message "Validator diagnostic entry $($entry.file) is missing artifactFile."
+    Assert-Condition -Condition (-not [string]::IsNullOrWhiteSpace($entry.artifactSha256) -and ([string] $entry.artifactSha256).Length -eq 64) -Message "Validator diagnostic entry $($entry.file) is missing artifactSha256."
+    Assert-Condition -Condition ([long] $entry.artifactSizeBytes -gt 0) -Message "Validator diagnostic entry $($entry.file) is missing artifactSizeBytes."
+    Assert-Condition -Condition (-not [string]::IsNullOrWhiteSpace($entry.validatedAtUtc)) -Message "Validator diagnostic entry $($entry.file) is missing validatedAtUtc."
+    Assert-Condition -Condition ($entry.PSObject.Properties.Name -contains 'warnings') -Message "Validator diagnostic entry $($entry.file) is missing warnings."
     $filePath = Join-Path $resolvedProofPath $entry.file
     Assert-Condition -Condition (Test-Path -LiteralPath $filePath) -Message "Missing validator diagnostic file $($entry.file)."
     $file = Get-Item -LiteralPath $filePath
@@ -169,13 +205,16 @@ foreach ($entry in $validatorDiagnostics) {
 }
 
 $profileProofs = @($proof.profileProofs)
-Assert-Condition -Condition ($profileProofs.Count -eq 4) -Message "Expected 4 profile proof rows, got $($profileProofs.Count)."
+Assert-Condition -Condition ($profileProofs.Count -eq 7) -Message "Expected 7 profile proof rows, got $($profileProofs.Count)."
 
 $expectedProfiles = @(
-    'pdfa-3b-groundwork',
-    'pdfua-1-groundwork',
-    'einvoice-pdfa3-groundwork',
-    'einvoice-groundwork'
+    'pdfa-2b',
+    'pdfa-3b',
+    'pdfua-1',
+    'facturx-pdfa3',
+    'facturx',
+    'zugferd-pdfa3',
+    'zugferd'
 )
 
 foreach ($expectedProfile in $expectedProfiles) {
@@ -191,17 +230,18 @@ foreach ($expectedProfile in $expectedProfiles) {
     Assert-Condition -Condition ($validStatuses -contains [string] $entry[0].status) -Message "Profile proof row $expectedProfile has invalid status $($entry[0].status)."
     Assert-Condition -Condition ($validStatuses -contains [string] $entry[0].expectedStatus) -Message "Profile proof row $expectedProfile has invalid expectedStatus $($entry[0].expectedStatus)."
     Assert-Condition -Condition ($entry[0].matchesExpectedStatus -eq $true) -Message "Profile proof row $expectedProfile status $($entry[0].status) did not match expected status $($entry[0].expectedStatus)."
-    Assert-Condition -Condition ($entry[0].canClaimConformance -eq $false) -Message "Profile proof row $expectedProfile must not claim conformance for groundwork fixtures."
+    $expectedClaim = [string] $entry[0].status -eq 'Passed'
+    Assert-Condition -Condition ($entry[0].canClaimConformance -eq $expectedClaim) -Message "Profile proof row $expectedProfile claim state does not match exact-artifact validation."
     Assert-Condition -Condition (-not [string]::IsNullOrWhiteSpace($entry[0].formalClaimStatus)) -Message "Profile proof row $expectedProfile is missing formalClaimStatus."
     Assert-Condition -Condition (-not [string]::IsNullOrWhiteSpace($entry[0].nextAction)) -Message "Profile proof row $expectedProfile is missing nextAction."
 }
 
 $productProofProfiles = @($proof.productProofContract.profiles)
 $productProofFileProfiles = @($productProofContractFile.profiles)
-Assert-Condition -Condition ($productProofProfiles.Count -eq 4) -Message "Expected 4 product proof contract rows in proof.json, got $($productProofProfiles.Count)."
-Assert-Condition -Condition ($productProofFileProfiles.Count -eq 4) -Message "Expected 4 product proof contract rows in officeimo-profile-proof-contract.json, got $($productProofFileProfiles.Count)."
+Assert-Condition -Condition ($productProofProfiles.Count -eq 5) -Message "Expected 5 product proof contract rows in proof.json, got $($productProofProfiles.Count)."
+Assert-Condition -Condition ($productProofFileProfiles.Count -eq 5) -Message "Expected 5 product proof contract rows in officeimo-profile-proof-contract.json, got $($productProofFileProfiles.Count)."
 
-$expectedProductProfiles = @('PdfA3B', 'PdfUa1', 'FacturX', 'Zugferd')
+$expectedProductProfiles = @('PdfA2B', 'PdfA3B', 'PdfUa1', 'FacturX', 'Zugferd')
 foreach ($expectedProductProfile in $expectedProductProfiles) {
     $entry = @($productProofProfiles | Where-Object { $_.profile -eq $expectedProductProfile })
     $fileEntry = @($productProofFileProfiles | Where-Object { $_.profile -eq $expectedProductProfile })

--- a/.github/workflows/pdf-compliance-proof.yml
+++ b/.github/workflows/pdf-compliance-proof.yml
@@ -77,6 +77,9 @@ env:
   BUILD_CONFIGURATION: Release
   PROOF_PATH: artifacts/pdf-compliance-proof
   VERAPDF_CLI_IMAGE: ghcr.io/verapdf/cli:v1.31.105@sha256:7f28bd1ea0814e4eb8d99fc43c78dc6940047f4819c89b4194dbb8213f45b6de
+  MUSTANG_VERSION: 2.24.0
+  MUSTANG_CLI_URL: https://github.com/ZUGFeRD/mustangproject/releases/download/core-2.24.0/Mustang-CLI-2.24.0.jar
+  MUSTANG_CLI_SHA256: e4904ffa0afdce3f5836dceb927c440a05ed5d60386fdd37e17a4b2f7652edbf
 
 jobs:
   pdf-compliance-proof:
@@ -108,7 +111,7 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install --yes qpdf poppler-utils
+          sudo apt-get install --yes openjdk-17-jre-headless qpdf poppler-utils
 
       - name: Prepare veraPDF validator
         if: github.event_name != 'workflow_dispatch' || inputs.verapdf_path == '' || inputs.pdfua_validator_path == ''
@@ -143,6 +146,17 @@ jobs:
           BASH
           chmod +x "$wrapper"
           echo "OFFICEIMO_VERAPDF_DOCKER=$wrapper" >> "$GITHUB_ENV"
+
+      - name: Prepare Mustang validator
+        if: github.event_name != 'workflow_dispatch' || inputs.mustang_path == ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          jar="$RUNNER_TEMP/Mustang-CLI-${MUSTANG_VERSION}.jar"
+          curl --fail --location --silent --show-error "$MUSTANG_CLI_URL" --output "$jar"
+          echo "${MUSTANG_CLI_SHA256}  ${jar}" | sha256sum --check
+          echo "OFFICEIMO_MUSTANG_JAR=$jar" >> "$GITHUB_ENV"
+          echo "OFFICEIMO_MUSTANG_VERSION=$MUSTANG_VERSION" >> "$GITHUB_ENV"
 
       - name: Generate PDF compliance proof
         shell: pwsh
@@ -196,6 +210,8 @@ jobs:
 
           if (-not [string]::IsNullOrWhiteSpace($env:MUSTANG_PATH)) {
             $parameters.MustangPath = $env:MUSTANG_PATH
+          } elseif (-not [string]::IsNullOrWhiteSpace($env:OFFICEIMO_MUSTANG_JAR)) {
+            $parameters.MustangPath = $env:OFFICEIMO_MUSTANG_JAR
           }
 
           if (-not [string]::IsNullOrWhiteSpace($env:MUSTANG_ARGS)) {

--- a/Build/Export-PdfComplianceProof.ps1
+++ b/Build/Export-PdfComplianceProof.ps1
@@ -41,12 +41,20 @@ function Get-ValidatorProfileFromFileName {
         [string] $FileName
     )
 
-    if ($FileName -like '*pdfa3*') {
-        return 'PDF/A-3b'
+    if ($FileName -like '*facturx*') {
+        return 'Factur-X'
     }
 
-    if ($FileName -like '*einvoice*') {
-        return 'Factur-X/ZUGFeRD groundwork'
+    if ($FileName -like '*zugferd*') {
+        return 'ZUGFeRD'
+    }
+
+    if ($FileName -like '*pdfa2b*') {
+        return 'PDF/A-2b'
+    }
+
+    if ($FileName -like '*pdfa3b*') {
+        return 'PDF/A-3b'
     }
 
     if ($FileName -like '*pdfua*') {
@@ -123,22 +131,79 @@ function Get-ExpectedValidatorStatus {
         [string] $ValidatorKind,
 
         [Parameter(Mandatory = $true)]
-        $ValidatorConfiguration
+        $ValidatorConfiguration,
+
+        [Parameter(Mandatory = $true)]
+        [string] $DiagnosticFileName
     )
 
     if ($ValidatorKind -eq 'VeraPdf' -and $ValidatorConfiguration.veraPdfExecutableConfigured) {
-        return 'Failed'
+        return 'Passed'
     }
 
     if ($ValidatorKind -eq 'PdfUaValidator' -and $ValidatorConfiguration.pdfUaValidatorExecutableConfigured) {
-        return 'Failed'
+        return 'Passed'
     }
 
     if ($ValidatorKind -eq 'Mustang' -and $ValidatorConfiguration.mustangExecutableConfigured) {
-        return 'Failed'
+        return 'Passed'
     }
 
     return 'NotRun'
+}
+
+function Get-ValidatorVersionFromText {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Text,
+
+        [Parameter(Mandatory = $true)]
+        [string] $ValidatorKind
+    )
+
+    if ($Text -match '(?i)veraPDF\s+([0-9]+(?:\.[0-9]+)+)') {
+        return $Matches[1]
+    }
+
+    if ($Text -match '(?i)<releaseDetails\s+id=["'']core["'']\s+version=["'']([0-9]+(?:\.[0-9]+)+)["'']') {
+        return $Matches[1]
+    }
+
+    if ($ValidatorKind -eq 'Mustang' -and $Text -match '(?i)<validator\s+version=["'']([0-9]+(?:\.[0-9]+)+)["'']') {
+        return $Matches[1]
+    }
+
+    if ($ValidatorKind -eq 'VeraPdf' -and -not [string]::IsNullOrWhiteSpace($env:OFFICEIMO_VERAPDF_VERSION)) {
+        return $env:OFFICEIMO_VERAPDF_VERSION
+    }
+
+    if ($ValidatorKind -eq 'VeraPdf' -and $env:VERAPDF_CLI_IMAGE -match ':v([^@]+)') {
+        return $Matches[1]
+    }
+
+    if ($Text -match '(?i)\bversion\s+([0-9]+(?:\.[0-9]+)+)') {
+        return $Matches[1]
+    }
+
+    return 'unknown'
+}
+
+function Get-ArtifactFileFromDiagnosticFileName {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $DiagnosticFileName
+    )
+
+    switch ($DiagnosticFileName) {
+        'verapdf-pdfa2b.txt' { return 'officeimo-pdfa2b.pdf' }
+        'verapdf-pdfa3b.txt' { return 'officeimo-pdfa3b.pdf' }
+        'verapdf-facturx.txt' { return 'officeimo-facturx.pdf' }
+        'mustang-facturx.txt' { return 'officeimo-facturx.pdf' }
+        'verapdf-zugferd.txt' { return 'officeimo-zugferd.pdf' }
+        'mustang-zugferd.txt' { return 'officeimo-zugferd.pdf' }
+        'pdfua-pdfua1.txt' { return 'officeimo-pdfua1.pdf' }
+        default { return $null }
+    }
 }
 
 function Test-AnyCommandAvailable {
@@ -167,44 +232,81 @@ function Get-ProofProfileRows {
 
     $definitions = @(
         [ordered] @{
-            profileId = 'pdfa-3b-groundwork'
-            displayName = 'PDF/A-3b groundwork'
-            fixtureFile = 'officeimo-pdfa3-groundwork.pdf'
+            profileId = 'pdfa-2b'
+            displayName = 'PDF/A-2b'
+            fixtureFile = 'officeimo-pdfa2b.pdf'
             validatorKind = 'VeraPdf'
-            validatorDiagnosticFileName = 'verapdf-pdfa3-groundwork.txt'
+            validatorDiagnosticFileName = 'verapdf-pdfa2b.txt'
             readinessRequirementId = 'verapdf-validation'
-            formalClaimStatus = 'BlockedUntilFormalPdfAProfileGeneration'
-            nextAction = 'Implement profile-specific PDF/A generation and flip the veraPDF gate only after validator success is intentional.'
+            canBecomeClaimable = $true
+            formalClaimStatus = 'ValidatorBackedFormalGeneration'
+            nextAction = 'Keep the exact-artifact veraPDF gate green for every change to PDF/A generation.'
         },
         [ordered] @{
-            profileId = 'pdfua-1-groundwork'
-            displayName = 'PDF/UA-1 groundwork'
-            fixtureFile = 'officeimo-pdfua-groundwork.pdf'
-            validatorKind = 'PdfUaValidator'
-            validatorDiagnosticFileName = 'pdfua-groundwork.txt'
-            readinessRequirementId = 'pdfua-validation'
-            formalClaimStatus = 'BlockedUntilFormalPdfUaProfileGeneration'
-            nextAction = 'Implement full tagged structure, reading order, alternate text, font mapping, and flip the PDF/UA validator gate only after validator success is intentional.'
-        },
-        [ordered] @{
-            profileId = 'einvoice-pdfa3-groundwork'
-            displayName = 'Factur-X/ZUGFeRD PDF/A-3 groundwork'
-            fixtureFile = 'officeimo-einvoice-groundwork.pdf'
+            profileId = 'pdfa-3b'
+            displayName = 'PDF/A-3b'
+            fixtureFile = 'officeimo-pdfa3b.pdf'
             validatorKind = 'VeraPdf'
-            validatorDiagnosticFileName = 'verapdf-einvoice-groundwork.txt'
-            readinessRequirementId = 'einvoice-verapdf-validation'
-            formalClaimStatus = 'BlockedUntilFormalEinvoiceProfileGeneration'
-            nextAction = 'Validate the actual e-invoice PDF/A-3 carrier with veraPDF before any Factur-X/ZUGFeRD claim.'
+            validatorDiagnosticFileName = 'verapdf-pdfa3b.txt'
+            readinessRequirementId = 'verapdf-validation'
+            canBecomeClaimable = $true
+            formalClaimStatus = 'ValidatorBackedFormalGeneration'
+            nextAction = 'Keep the exact-artifact veraPDF gate green for every change to PDF/A-3 generation.'
         },
         [ordered] @{
-            profileId = 'einvoice-groundwork'
-            displayName = 'Factur-X/ZUGFeRD groundwork'
-            fixtureFile = 'officeimo-einvoice-groundwork.pdf'
+            profileId = 'pdfua-1'
+            displayName = 'PDF/UA-1'
+            fixtureFile = 'officeimo-pdfua1.pdf'
+            validatorKind = 'PdfUaValidator'
+            validatorDiagnosticFileName = 'pdfua-pdfua1.txt'
+            readinessRequirementId = 'pdfua-validation'
+            canBecomeClaimable = $true
+            formalClaimStatus = 'ValidatorBackedFormalGeneration'
+            nextAction = 'Keep the exact-artifact PDF/UA-1 validator gate green across text, links, annotations, forms, and figures.'
+        },
+        [ordered] @{
+            profileId = 'facturx-pdfa3'
+            displayName = 'Factur-X PDF/A-3 carrier'
+            fixtureFile = 'officeimo-facturx.pdf'
+            validatorKind = 'VeraPdf'
+            validatorDiagnosticFileName = 'verapdf-facturx.txt'
+            readinessRequirementId = 'einvoice-verapdf-validation'
+            canBecomeClaimable = $true
+            formalClaimStatus = 'ValidatorBackedFormalGeneration'
+            nextAction = 'Keep the exact Factur-X PDF/A-3 carrier validation green.'
+        },
+        [ordered] @{
+            profileId = 'facturx'
+            displayName = 'Factur-X invoice'
+            fixtureFile = 'officeimo-facturx.pdf'
             validatorKind = 'Mustang'
-            validatorDiagnosticFileName = 'mustang-einvoice-groundwork.txt'
+            validatorDiagnosticFileName = 'mustang-facturx.txt'
             readinessRequirementId = 'einvoice-mustang-validation'
-            formalClaimStatus = 'BlockedUntilFormalEinvoiceProfileGeneration'
-            nextAction = 'Implement profile-specific XML, XMP, PDF/A-3 output, and flip the Mustang gate only after validator success is intentional.'
+            canBecomeClaimable = $true
+            formalClaimStatus = 'ValidatorBackedFormalGeneration'
+            nextAction = 'Keep the exact Factur-X invoice validation green.'
+        },
+        [ordered] @{
+            profileId = 'zugferd-pdfa3'
+            displayName = 'ZUGFeRD PDF/A-3 carrier'
+            fixtureFile = 'officeimo-zugferd.pdf'
+            validatorKind = 'VeraPdf'
+            validatorDiagnosticFileName = 'verapdf-zugferd.txt'
+            readinessRequirementId = 'einvoice-verapdf-validation'
+            canBecomeClaimable = $true
+            formalClaimStatus = 'ValidatorBackedFormalGeneration'
+            nextAction = 'Keep the exact ZUGFeRD PDF/A-3 carrier validation green.'
+        },
+        [ordered] @{
+            profileId = 'zugferd'
+            displayName = 'ZUGFeRD invoice'
+            fixtureFile = 'officeimo-zugferd.pdf'
+            validatorKind = 'Mustang'
+            validatorDiagnosticFileName = 'mustang-zugferd.txt'
+            readinessRequirementId = 'einvoice-mustang-validation'
+            canBecomeClaimable = $true
+            formalClaimStatus = 'ValidatorBackedFormalGeneration'
+            nextAction = 'Keep the exact ZUGFeRD invoice validation green.'
         }
     )
 
@@ -225,7 +327,7 @@ function Get-ProofProfileRows {
             expectedStatus = if ($diagnostic) { $diagnostic.expectedStatus } else { 'Error' }
             matchesExpectedStatus = if ($diagnostic) { $diagnostic.matchesExpectedStatus } else { $false }
             readinessRequirementId = $definition.readinessRequirementId
-            canClaimConformance = $false
+            canClaimConformance = [bool] $definition.canBecomeClaimable -and $diagnostic -and $diagnostic.status -eq 'Passed' -and $diagnostic.artifactSha256 -eq $fixture.sha256
             formalClaimStatus = $definition.formalClaimStatus
             nextAction = $definition.nextAction
         }
@@ -244,23 +346,37 @@ function Get-ProductProofDiagnosticFileName {
     )
 
     switch ([string] $Profile.profile) {
+        'PdfA2B' {
+            if ($ValidatorKind -eq 'VeraPdf') {
+                return 'verapdf-pdfa2b.txt'
+            }
+        }
         'PdfA3B' {
             if ($ValidatorKind -eq 'VeraPdf') {
-                return 'verapdf-pdfa3-groundwork.txt'
+                return 'verapdf-pdfa3b.txt'
             }
         }
         'PdfUa1' {
             if ($ValidatorKind -eq 'PdfUaValidator') {
-                return 'pdfua-groundwork.txt'
+                return 'pdfua-pdfua1.txt'
             }
         }
-        { $_ -eq 'FacturX' -or $_ -eq 'Zugferd' } {
+        'FacturX' {
             if ($ValidatorKind -eq 'VeraPdf') {
-                return 'verapdf-einvoice-groundwork.txt'
+                return 'verapdf-facturx.txt'
             }
 
             if ($ValidatorKind -eq 'Mustang') {
-                return 'mustang-einvoice-groundwork.txt'
+                return 'mustang-facturx.txt'
+            }
+        }
+        'Zugferd' {
+            if ($ValidatorKind -eq 'VeraPdf') {
+                return 'verapdf-zugferd.txt'
+            }
+
+            if ($ValidatorKind -eq 'Mustang') {
+                return 'mustang-zugferd.txt'
             }
         }
     }
@@ -274,10 +390,27 @@ function Update-ProductProofContractWithDiagnostics {
         $ProductProofContract,
 
         [Parameter(Mandatory = $true)]
-        [array] $DiagnosticRows
+        [array] $DiagnosticRows,
+
+        [Parameter(Mandatory = $true)]
+        [array] $PdfRows
     )
 
     foreach ($profile in @($ProductProofContract.profiles)) {
+        $profileFixture = switch ([string] $profile.profile) {
+            'PdfA2B' { @($PdfRows | Where-Object { $_.file -eq 'officeimo-pdfa2b.pdf' }) | Select-Object -First 1 }
+            'PdfA3B' { @($PdfRows | Where-Object { $_.file -eq 'officeimo-pdfa3b.pdf' }) | Select-Object -First 1 }
+            'PdfUa1' { @($PdfRows | Where-Object { $_.file -eq 'officeimo-pdfua1.pdf' }) | Select-Object -First 1 }
+            'FacturX' { @($PdfRows | Where-Object { $_.file -eq 'officeimo-facturx.pdf' }) | Select-Object -First 1 }
+            'Zugferd' { @($PdfRows | Where-Object { $_.file -eq 'officeimo-zugferd.pdf' }) | Select-Object -First 1 }
+            default { $null }
+        }
+        if ($profileFixture) {
+            $profile.hasArtifactEvidence = $true
+            $profile.artifactSha256 = $profileFixture.sha256
+            $profile.artifactSizeBytes = $profileFixture.sizeBytes
+        }
+
         $hasRequiredExternalValidation = $true
         $missingExternalValidators = [System.Collections.Generic.List[string]]::new()
         $failedExternalValidationCount = 0
@@ -298,6 +431,11 @@ function Update-ProductProofContractWithDiagnostics {
                 $validatorProof.diagnostic = 'Missing external validation.'
                 $validatorProof.profile = $null
                 $validatorProof.exitCode = $null
+                $validatorProof.validatorVersion = $null
+                $validatorProof.artifactSha256 = $null
+                $validatorProof.artifactSizeBytes = $null
+                $validatorProof.validatedAtUtc = $null
+                $validatorProof.warnings = @()
             } else {
                 $validatorProof.status = $diagnosticRow.status
                 $validatorProof.isSatisfied = $diagnosticRow.status -eq 'Passed'
@@ -306,6 +444,20 @@ function Update-ProductProofContractWithDiagnostics {
                 $validatorProof.diagnostic = "Validator diagnostic status $($diagnosticRow.status) matched expected status $($diagnosticRow.expectedStatus): $($diagnosticRow.file)."
                 $validatorProof.profile = $diagnosticRow.profile
                 $validatorProof.exitCode = $diagnosticRow.exitCode
+                $validatorProof.validatorVersion = $diagnosticRow.validatorVersion
+                $validatorProof.artifactSha256 = $diagnosticRow.artifactSha256
+                $validatorProof.artifactSizeBytes = $diagnosticRow.artifactSizeBytes
+                $validatorProof.validatedAtUtc = $diagnosticRow.validatedAtUtc
+                $validatorProof.warnings = @($diagnosticRow.warnings)
+
+                if ($validatorProof.isSatisfied -and
+                    (-not $profile.hasArtifactEvidence -or
+                     $validatorProof.artifactSha256 -ne $profile.artifactSha256 -or
+                     $validatorProof.artifactSizeBytes -ne $profile.artifactSizeBytes)) {
+                    $validatorProof.isSatisfied = $false
+                    $validatorProof.blocksConformanceClaim = $true
+                    $validatorProof.diagnostic = 'Validator passed, but its artifact identity does not match the profile proof artifact.'
+                }
             }
 
             if (-not $validatorProof.isSatisfied) {
@@ -320,6 +472,17 @@ function Update-ProductProofContractWithDiagnostics {
 
         $profile.hasRequiredExternalValidation = $hasRequiredExternalValidation
         $profile.canClaimConformance = [bool] $profile.isInternallyReady -and $hasRequiredExternalValidation -and $failedExternalValidationCount -eq 0
+        $profile.proofStatus = if (-not $profile.isInternallyReady) {
+            'InternalGaps'
+        } elseif (-not $profile.hasArtifactEvidence) {
+            'MissingArtifactEvidence'
+        } elseif ($failedExternalValidationCount -gt 0) {
+            'ExternalValidationFailed'
+        } elseif (-not $hasRequiredExternalValidation) {
+            'MissingExternalValidation'
+        } else {
+            'Claimable'
+        }
         $profile.missingExternalValidators = @($missingExternalValidators)
         $profile.failedExternalValidationCount = $failedExternalValidationCount
     }
@@ -336,12 +499,27 @@ New-Item -ItemType Directory -Path $outputPath -Force | Out-Null
 $resolvedOutputPath = (Resolve-Path -LiteralPath $outputPath).Path
 
 $generatedProofPdfFileNames = @(
-    'officeimo-pdfa3-groundwork.pdf',
-    'officeimo-einvoice-groundwork.pdf',
-    'officeimo-pdfua-groundwork.pdf'
+    'officeimo-pdfa2b.pdf',
+    'officeimo-pdfa3b.pdf',
+    'officeimo-facturx.pdf',
+    'officeimo-zugferd.pdf',
+    'officeimo-pdfua1.pdf'
 )
 
 $generatedProofDiagnosticFileNames = @(
+    'verapdf-pdfa2b.txt',
+    'verapdf-pdfa3b.txt',
+    'verapdf-facturx.txt',
+    'mustang-facturx.txt',
+    'verapdf-zugferd.txt',
+    'mustang-zugferd.txt',
+    'pdfua-pdfua1.txt'
+)
+
+$legacyGeneratedProofFileNames = @(
+    'officeimo-pdfa3-groundwork.pdf',
+    'officeimo-einvoice-groundwork.pdf',
+    'officeimo-pdfua-groundwork.pdf',
     'verapdf-pdfa3-groundwork.txt',
     'verapdf-einvoice-groundwork.txt',
     'mustang-einvoice-groundwork.txt',
@@ -351,6 +529,7 @@ $generatedProofDiagnosticFileNames = @(
 $generatedProofFileNames = @(
     $generatedProofPdfFileNames
     $generatedProofDiagnosticFileNames
+    $legacyGeneratedProofFileNames
     'officeimo-profile-proof-contract.json',
     'index.md',
     'proof.json'
@@ -375,6 +554,21 @@ $previousMustangExecutable = $env:OFFICEIMO_MUSTANG
 $previousMustangPath = $env:OFFICEIMO_MUSTANG_PATH
 $previousMustangArgs = $env:OFFICEIMO_MUSTANG_ARGS
 $validatorConfiguration = $null
+$resolvedVeraPdfPath = if (-not [string]::IsNullOrWhiteSpace($VeraPdfPath) -and (Test-Path -LiteralPath $VeraPdfPath)) {
+    (Resolve-Path -LiteralPath $VeraPdfPath).Path
+} else {
+    $VeraPdfPath
+}
+$resolvedPdfUaValidatorPath = if (-not [string]::IsNullOrWhiteSpace($PdfUaValidatorPath) -and (Test-Path -LiteralPath $PdfUaValidatorPath)) {
+    (Resolve-Path -LiteralPath $PdfUaValidatorPath).Path
+} else {
+    $PdfUaValidatorPath
+}
+$resolvedMustangPath = if (-not [string]::IsNullOrWhiteSpace($MustangPath) -and (Test-Path -LiteralPath $MustangPath)) {
+    (Resolve-Path -LiteralPath $MustangPath).Path
+} else {
+    $MustangPath
+}
 
 $testExitCode = 0
 try {
@@ -385,27 +579,27 @@ try {
         $env:OFFICEIMO_REQUIRE_PDF_COMPLIANCE_VALIDATORS = $null
     }
 
-    if (-not [string]::IsNullOrWhiteSpace($VeraPdfPath)) {
-        $env:OFFICEIMO_VERAPDF = $VeraPdfPath
-        $env:OFFICEIMO_VERAPDF_PATH = $VeraPdfPath
+    if (-not [string]::IsNullOrWhiteSpace($resolvedVeraPdfPath)) {
+        $env:OFFICEIMO_VERAPDF = $resolvedVeraPdfPath
+        $env:OFFICEIMO_VERAPDF_PATH = $resolvedVeraPdfPath
     }
 
     if (-not [string]::IsNullOrWhiteSpace($VeraPdfArgs)) {
         $env:OFFICEIMO_VERAPDF_ARGS = $VeraPdfArgs
     }
 
-    if (-not [string]::IsNullOrWhiteSpace($PdfUaValidatorPath)) {
-        $env:OFFICEIMO_PDFUA_VALIDATOR = $PdfUaValidatorPath
-        $env:OFFICEIMO_PDFUA_VALIDATOR_PATH = $PdfUaValidatorPath
+    if (-not [string]::IsNullOrWhiteSpace($resolvedPdfUaValidatorPath)) {
+        $env:OFFICEIMO_PDFUA_VALIDATOR = $resolvedPdfUaValidatorPath
+        $env:OFFICEIMO_PDFUA_VALIDATOR_PATH = $resolvedPdfUaValidatorPath
     }
 
     if (-not [string]::IsNullOrWhiteSpace($PdfUaValidatorArgs)) {
         $env:OFFICEIMO_PDFUA_VALIDATOR_ARGS = $PdfUaValidatorArgs
     }
 
-    if (-not [string]::IsNullOrWhiteSpace($MustangPath)) {
-        $env:OFFICEIMO_MUSTANG = $MustangPath
-        $env:OFFICEIMO_MUSTANG_PATH = $MustangPath
+    if (-not [string]::IsNullOrWhiteSpace($resolvedMustangPath)) {
+        $env:OFFICEIMO_MUSTANG = $resolvedMustangPath
+        $env:OFFICEIMO_MUSTANG_PATH = $resolvedMustangPath
     }
 
     if (-not [string]::IsNullOrWhiteSpace($MustangArgs)) {
@@ -536,10 +730,11 @@ $lines.Add('```')
 $lines.Add('')
 $lines.Add('## Current Contract')
 $lines.Add('')
-$lines.Add('- Generated PDFs are groundwork fixtures, not formal conformance claims.')
-$lines.Add('- `ComplianceProfile` values other than `None` must still fail closed until validator-backed profile generation is implemented.')
-$lines.Add('- veraPDF, PDF/UA validator, and Mustang diagnostics are proof inputs; a matching expected status today means the current non-conformance guardrails are still honest.')
-$lines.Add('- Validator `Failed` status is expected when the validator runs against these groundwork fixtures; formal conformance must not pass until profile generation is intentionally implemented.')
+$lines.Add('- PDF/A-2b, PDF/A-3b, Factur-X, and ZUGFeRD are formal engine profiles only when their exact generated artifacts pass every required validator.')
+$lines.Add('- PDF/UA-1 is formal only when the exact generated artifact passes the accessibility validator across tagged text, links, annotations, forms, figures, language, title, and embedded Unicode fonts.')
+$lines.Add('- Unsupported profiles, including PDF/UA-2, remain fail-closed.')
+$lines.Add('- External validators are CI/test proof tools and are not runtime dependencies of OfficeIMO.Pdf.')
+$lines.Add('- Artifact SHA-256 and byte length bind each validator result to the exact generated PDF used for the conformance decision.')
 $lines.Add('- Product proof contract rows are emitted by `PdfComplianceAnalyzer.AssessProof(...)`; they are the engine-level claimability signal for this proof pack.')
 $lines.Add('')
 $lines.Add('## Validator Configuration')
@@ -585,8 +780,15 @@ if ($diagnosticFiles.Count -eq 0) {
         $validatorKind = Get-ValidatorKindFromFileName -FileName $file.Name
         $profile = Get-ValidatorProfileFromFileName -FileName $file.Name
         $validatorStatus = Get-ValidatorStatusFromText -Text $diagnosticText -ValidatorKind $validatorKind
-        $expectedStatus = Get-ExpectedValidatorStatus -ValidatorKind $validatorKind -ValidatorConfiguration $validatorConfiguration
+        $expectedStatus = Get-ExpectedValidatorStatus -ValidatorKind $validatorKind -ValidatorConfiguration $validatorConfiguration -DiagnosticFileName $file.Name
         $matchesExpectedStatus = $validatorStatus -eq $expectedStatus
+        $artifactFileName = Get-ArtifactFileFromDiagnosticFileName -DiagnosticFileName $file.Name
+        $artifactRow = if ([string]::IsNullOrWhiteSpace($artifactFileName)) {
+            $null
+        } else {
+            @($pdfRows | Where-Object { $_.file -eq $artifactFileName }) | Select-Object -First 1
+        }
+        $warnings = @($diagnosticText -split "`r?`n" | Where-Object { $_ -match '(?i)\bwarning\b' })
         $name = $file.Name.Replace('|', '\|')
         $lines.Add("| $validatorKind | $profile | $validatorStatus | $expectedStatus | $matchesExpectedStatus | [$name]($name) | $($file.Length) bytes | ``$hash`` |")
         $diagnosticRows += [ordered] @{
@@ -597,6 +799,12 @@ if ($diagnosticFiles.Count -eq 0) {
             expectedStatus = $expectedStatus
             matchesExpectedStatus = $matchesExpectedStatus
             exitCode = if ($diagnosticText -match 'exited with code\s+(\d+)\b') { [int] $Matches[1] } else { $null }
+            validatorVersion = Get-ValidatorVersionFromText -Text $diagnosticText -ValidatorKind $validatorKind
+            artifactFile = $artifactFileName
+            artifactSha256 = if ($artifactRow) { $artifactRow.sha256 } else { $null }
+            artifactSizeBytes = if ($artifactRow) { $artifactRow.sizeBytes } else { $null }
+            validatedAtUtc = $generatedAt
+            warnings = $warnings
             sizeBytes = $file.Length
             sha256 = $hash
         }
@@ -604,7 +812,7 @@ if ($diagnosticFiles.Count -eq 0) {
 }
 
 $profileRows = @(Get-ProofProfileRows -PdfRows $pdfRows -DiagnosticRows $diagnosticRows)
-Update-ProductProofContractWithDiagnostics -ProductProofContract $productProofContract -DiagnosticRows $diagnosticRows
+Update-ProductProofContractWithDiagnostics -ProductProofContract $productProofContract -DiagnosticRows $diagnosticRows -PdfRows $pdfRows
 $productProofContract | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $productProofContractPath -Encoding UTF8
 $lines.Add('')
 $lines.Add('## Profile Proof Matrix')
@@ -668,7 +876,7 @@ if (-not [string]::IsNullOrWhiteSpace($status)) {
 
 [System.IO.File]::WriteAllLines($indexPath, $lines, [System.Text.Encoding]::UTF8)
 $proof = [ordered] @{
-    schemaVersion = 3
+    schemaVersion = 4
     generatedUtc = $generatedAt
     commit = $commit
     outputDirectory = $resolvedOutputPath
@@ -677,9 +885,14 @@ $proof = [ordered] @{
     strictValidatorMode = [bool] $RequireValidators
     validatorConfiguration = $validatorConfiguration
     contract = [ordered] @{
-        formalProfilesFailClosed = $true
-        generatedPdfsAreGroundworkFixtures = $true
+        unsupportedFormalProfilesFailClosed = $true
+        formalPdfA2BGenerationEnabled = $true
+        formalPdfA3BGenerationEnabled = $true
+        formalPdfUa1GenerationEnabled = $true
+        formalElectronicInvoiceGenerationEnabled = $true
+        allGeneratedPdfsAreGroundworkFixtures = $false
         externalValidationRequiredForClaims = $true
+        externalValidationBoundToExactArtifact = $true
     }
     pdfFixtures = @($pdfRows)
     validatorDiagnostics = @($diagnosticRows)

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfAIdentificationMetadataTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfAIdentificationMetadataTests.cs
@@ -532,8 +532,8 @@ public class PdfAIdentificationMetadataTests {
     }
 
     [Fact]
-    public void FormalComplianceProfilesStillFailClosedWhenPdfAIdentificationIsPresent() {
-        var exception = Assert.Throws<NotSupportedException>(() =>
+    public void FormalPdfA3BRequiresMoreThanIdentificationMetadata() {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
             PdfDocument.Create(new PdfOptions()
                     .SetPdfAIdentification(3, "B")
                     .RequireCompliance(PdfComplianceProfile.PdfA3B))
@@ -541,8 +541,9 @@ public class PdfAIdentificationMetadataTests {
                 .ToBytes());
 
         Assert.Contains("PDF/A-3b", exception.Message, StringComparison.Ordinal);
-        Assert.Contains("cannot yet generate certified", exception.Message, StringComparison.Ordinal);
-        Assert.Contains("veraPDF validation fixtures in the build lane", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("generation requirements are not satisfied", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("output-intent", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("embedded-font-coverage", exception.Message, StringComparison.Ordinal);
     }
 
     private static byte[] CreateCiiXml() {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfComplianceAnalyzerProofTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfComplianceAnalyzerProofTests.cs
@@ -28,15 +28,19 @@ public partial class PdfComplianceAnalyzerTests {
     public void ProofReportAllowsPdfAClaimWhenRequiredValidatorPasses() {
         var options = new PdfOptions()
             .ConfigurePdfAGroundwork(PdfComplianceProfile.PdfA3B);
-        PdfExternalValidationResult veraPdf = PdfExternalValidationResult.Passed(
+        byte[] artifact = PdfDocument.Create(options).ToBytes();
+        PdfExternalValidationResult veraPdf = PdfExternalValidationResult.PassedForArtifact(
             PdfExternalValidatorKind.VeraPdf,
             "veraPDF",
+            "1.30.2",
             "PDF/A-3b profile accepted.",
+            artifact,
             "PDF/A-3b");
 
         PdfComplianceProofReport proof = PdfComplianceAnalyzer.AssessProof(
             PdfComplianceProfile.PdfA3B,
             options,
+            artifact,
             new[] { veraPdf },
             generatedStandardFonts: Array.Empty<PdfStandardFont>());
 
@@ -51,14 +55,18 @@ public partial class PdfComplianceAnalyzerTests {
     public void ProofReportCountsUnprofiledValidatorResultForRequestedProof() {
         var options = new PdfOptions()
             .ConfigurePdfAGroundwork(PdfComplianceProfile.PdfA3B);
-        PdfExternalValidationResult veraPdf = PdfExternalValidationResult.Passed(
+        byte[] artifact = PdfDocument.Create(options).ToBytes();
+        PdfExternalValidationResult veraPdf = PdfExternalValidationResult.PassedForArtifact(
             PdfExternalValidatorKind.VeraPdf,
             "veraPDF",
-            "PDF/A profile accepted.");
+            "1.30.2",
+            "PDF/A profile accepted.",
+            artifact);
 
         PdfComplianceProofReport proof = PdfComplianceAnalyzer.AssessProof(
             PdfComplianceProfile.PdfA3B,
             options,
+            artifact,
             new[] { veraPdf },
             generatedStandardFonts: Array.Empty<PdfStandardFont>());
 
@@ -71,17 +79,19 @@ public partial class PdfComplianceAnalyzerTests {
 
     [Fact]
     public void DocumentProofUsesGeneratedEvidenceBeforeAcceptingExternalPdfAValidation() {
-        PdfExternalValidationResult veraPdf = PdfExternalValidationResult.Passed(
-            PdfExternalValidatorKind.VeraPdf,
-            "veraPDF",
-            "PDF/A-3b profile accepted.",
-            "PDF/A-3b");
-
         PdfDocument document = PdfDocument.Create(new PdfOptions()
                 .ConfigurePdfAGroundwork(PdfComplianceProfile.PdfA3B))
             .Paragraph(paragraph => paragraph.Text("Generated text must still have embedded font proof."));
+        byte[] artifact = document.ToBytes();
+        PdfExternalValidationResult veraPdf = PdfExternalValidationResult.PassedForArtifact(
+            PdfExternalValidatorKind.VeraPdf,
+            "veraPDF",
+            "1.30.2",
+            "PDF/A-3b profile accepted.",
+            artifact,
+            "PDF/A-3b");
 
-        PdfComplianceProofReport proof = document.AssessComplianceProof(PdfComplianceProfile.PdfA3B, new[] { veraPdf });
+        PdfComplianceProofReport proof = document.AssessComplianceProof(PdfComplianceProfile.PdfA3B, artifact, new[] { veraPdf });
 
         Assert.False(proof.IsInternallyReady);
         Assert.True(proof.HasRequiredExternalValidation);
@@ -91,7 +101,7 @@ public partial class PdfComplianceAnalyzerTests {
     }
 
     [Fact]
-    public void DocumentProofUsesConfiguredProfileAndExternalValidatorGate() {
+    public void DocumentProofWithoutArtifactCannotBeClaimable() {
         PdfExternalValidationResult veraPdf = PdfExternalValidationResult.Passed(
             PdfExternalValidatorKind.VeraPdf,
             "veraPDF",
@@ -105,9 +115,49 @@ public partial class PdfComplianceAnalyzerTests {
 
         Assert.Equal(PdfComplianceProfile.PdfA3B, proof.Profile);
         Assert.True(proof.IsInternallyReady);
-        Assert.True(proof.HasRequiredExternalValidation);
-        Assert.True(proof.CanClaimConformance);
-        Assert.Equal("Claimable", proof.ProofStatus);
+        Assert.False(proof.HasArtifactEvidence);
+        Assert.False(proof.HasRequiredExternalValidation);
+        Assert.False(proof.CanClaimConformance);
+        Assert.Equal("MissingArtifactEvidence", proof.ProofStatus);
+    }
+
+    [Fact]
+    public void ProofReportRejectsValidatorPassBoundToDifferentArtifactWithSameLength() {
+        var options = new PdfOptions()
+            .ConfigurePdfAGroundwork(PdfComplianceProfile.PdfA3B);
+        byte[] validatedArtifact = PdfDocument.Create(options).ToBytes();
+        byte[] requestedArtifact = (byte[])validatedArtifact.Clone();
+        requestedArtifact[requestedArtifact.Length - 1] ^= 0x01;
+        var validatedAtUtc = new System.DateTimeOffset(2026, 7, 15, 0, 0, 0, System.TimeSpan.Zero);
+        PdfExternalValidationResult veraPdf = PdfExternalValidationResult.PassedForArtifact(
+            PdfExternalValidatorKind.VeraPdf,
+            "veraPDF",
+            "1.30.2",
+            "PDF/A-3b profile accepted.",
+            validatedArtifact,
+            "PDF/A-3b",
+            warnings: new[] { "Informational validator warning." },
+            validatedAtUtc: validatedAtUtc);
+
+        PdfComplianceProofReport proof = PdfComplianceAnalyzer.AssessProof(
+            PdfComplianceProfile.PdfA3B,
+            options,
+            requestedArtifact,
+            new[] { veraPdf },
+            generatedStandardFonts: Array.Empty<PdfStandardFont>());
+
+        Assert.True(proof.IsInternallyReady);
+        Assert.True(proof.HasArtifactEvidence);
+        Assert.False(proof.HasRequiredExternalValidation);
+        Assert.False(proof.CanClaimConformance);
+        Assert.Equal("MissingExternalValidation", proof.ProofStatus);
+        Assert.Contains(PdfExternalValidatorKind.VeraPdf, proof.MissingExternalValidators);
+        Assert.True(veraPdf.HasArtifactBinding);
+        Assert.Equal("1.30.2", veraPdf.ValidatorVersion);
+        Assert.Equal(validatedArtifact.LongLength, veraPdf.ArtifactSizeBytes);
+        Assert.NotEqual(proof.ArtifactSha256, veraPdf.ArtifactSha256);
+        Assert.Equal(validatedAtUtc, veraPdf.ValidatedAtUtc);
+        Assert.Equal(new[] { "Informational validator warning." }, veraPdf.Warnings);
     }
 
     [Fact]
@@ -150,15 +200,19 @@ public partial class PdfComplianceAnalyzerTests {
     public void ProofReportRejectsValidatorPassForDifferentProfile() {
         var options = new PdfOptions()
             .ConfigurePdfAGroundwork(PdfComplianceProfile.PdfA3B);
-        PdfExternalValidationResult veraPdf = PdfExternalValidationResult.Passed(
+        byte[] artifact = PdfDocument.Create(options).ToBytes();
+        PdfExternalValidationResult veraPdf = PdfExternalValidationResult.PassedForArtifact(
             PdfExternalValidatorKind.VeraPdf,
             "veraPDF",
+            "1.30.2",
             "PDF/A-2b profile accepted.",
+            artifact,
             "PDF/A-2b");
 
         PdfComplianceProofReport proof = PdfComplianceAnalyzer.AssessProof(
             PdfComplianceProfile.PdfA3B,
             options,
+            artifact,
             new[] { veraPdf },
             generatedStandardFonts: Array.Empty<PdfStandardFont>());
 
@@ -172,20 +226,26 @@ public partial class PdfComplianceAnalyzerTests {
     public void ProofReportFindExternalValidationReturnsRequestedProfileResult() {
         var options = new PdfOptions()
             .ConfigurePdfAGroundwork(PdfComplianceProfile.PdfA3B);
-        PdfExternalValidationResult otherProfile = PdfExternalValidationResult.Passed(
+        byte[] artifact = PdfDocument.Create(options).ToBytes();
+        PdfExternalValidationResult otherProfile = PdfExternalValidationResult.PassedForArtifact(
             PdfExternalValidatorKind.VeraPdf,
             "veraPDF",
+            "1.30.2",
             "PDF/A-2b profile accepted.",
+            artifact,
             "PDF/A-2b");
-        PdfExternalValidationResult requestedProfile = PdfExternalValidationResult.Passed(
+        PdfExternalValidationResult requestedProfile = PdfExternalValidationResult.PassedForArtifact(
             PdfExternalValidatorKind.VeraPdf,
             "veraPDF",
+            "1.30.2",
             "PDF/A-3b profile accepted.",
+            artifact,
             "PDF/A-3b");
 
         PdfComplianceProofReport proof = PdfComplianceAnalyzer.AssessProof(
             PdfComplianceProfile.PdfA3B,
             options,
+            artifact,
             new[] { otherProfile, requestedProfile },
             generatedStandardFonts: Array.Empty<PdfStandardFont>());
 
@@ -196,21 +256,28 @@ public partial class PdfComplianceAnalyzerTests {
     public void ProofReportBlocksClaimWhenRequiredValidatorFailedEvenIfLaterResultPassed() {
         var options = new PdfOptions()
             .ConfigurePdfAGroundwork(PdfComplianceProfile.PdfA3B);
-        PdfExternalValidationResult failed = PdfExternalValidationResult.Failed(
+        byte[] artifact = PdfDocument.Create(options).ToBytes();
+        PdfExternalValidationResult failed = PdfExternalValidationResult.FromExitCodeForArtifact(
             PdfExternalValidatorKind.VeraPdf,
+            1,
             "veraPDF",
+            "1.30.2",
             "Output intent failed policy validation.",
+            artifact,
             "PDF/A-3b",
-            exitCode: 1);
-        PdfExternalValidationResult passed = PdfExternalValidationResult.Passed(
+            successExitCode: 0);
+        PdfExternalValidationResult passed = PdfExternalValidationResult.PassedForArtifact(
             PdfExternalValidatorKind.VeraPdf,
             "veraPDF",
+            "1.30.2",
             "A later run passed.",
+            artifact,
             "PDF/A-3b");
 
         PdfComplianceProofReport proof = PdfComplianceAnalyzer.AssessProof(
             PdfComplianceProfile.PdfA3B,
             options,
+            artifact,
             new[] { failed, passed },
             generatedStandardFonts: Array.Empty<PdfStandardFont>());
 
@@ -226,21 +293,28 @@ public partial class PdfComplianceAnalyzerTests {
     public void ProofReportExposesBlockingValidatorProofRowWhenFailureAndPassAreSupplied() {
         var options = new PdfOptions()
             .ConfigurePdfAGroundwork(PdfComplianceProfile.PdfA3B);
-        PdfExternalValidationResult failed = PdfExternalValidationResult.Failed(
+        byte[] artifact = PdfDocument.Create(options).ToBytes();
+        PdfExternalValidationResult failed = PdfExternalValidationResult.FromExitCodeForArtifact(
             PdfExternalValidatorKind.VeraPdf,
+            1,
             "veraPDF",
+            "1.30.2",
             "Output intent failed policy validation.",
+            artifact,
             "PDF/A-3b",
-            exitCode: 1);
-        PdfExternalValidationResult passed = PdfExternalValidationResult.Passed(
+            successExitCode: 0);
+        PdfExternalValidationResult passed = PdfExternalValidationResult.PassedForArtifact(
             PdfExternalValidatorKind.VeraPdf,
             "veraPDF",
+            "1.30.2",
             "A later run passed.",
+            artifact,
             "PDF/A-3b");
 
         PdfComplianceProofReport proof = PdfComplianceAnalyzer.AssessProof(
             PdfComplianceProfile.PdfA3B,
             options,
+            artifact,
             new[] { failed, passed },
             generatedStandardFonts: Array.Empty<PdfStandardFont>());
 
@@ -277,20 +351,26 @@ public partial class PdfComplianceAnalyzerTests {
 
     [Fact]
     public void ProofReportExposesPerValidatorRowsForElectronicInvoiceProfiles() {
-        PdfExternalValidationResult veraPdf = PdfExternalValidationResult.Passed(
+        byte[] artifact = PdfDocument.Create(new PdfOptions().ConfigurePdfAGroundwork(PdfComplianceProfile.PdfA3B)).ToBytes();
+        PdfExternalValidationResult veraPdf = PdfExternalValidationResult.PassedForArtifact(
             PdfExternalValidatorKind.VeraPdf,
             "veraPDF",
+            "1.30.2",
             "PDF/A-3b carrier accepted.",
+            artifact,
             "PDF/A-3b");
-        PdfExternalValidationResult mustang = PdfExternalValidationResult.NotRun(
+        PdfExternalValidationResult mustang = PdfExternalValidationResult.NotRunForArtifact(
             PdfExternalValidatorKind.Mustang,
             "Mustang",
+            "2.20.0",
             "Mustang is not configured on this runner.",
+            artifact,
             "Factur-X");
 
         PdfComplianceProofReport proof = PdfComplianceAnalyzer.AssessProof(
             PdfComplianceProfile.FacturX,
             new PdfOptions(),
+            artifact,
             externalValidations: new[] { veraPdf, mustang },
             generatedStandardFonts: Array.Empty<PdfStandardFont>());
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfComplianceGateTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfComplianceGateTests.cs
@@ -9,15 +9,47 @@ namespace OfficeIMO.Tests.Pdf;
 
 public class PdfComplianceGateTests {
     private const string ProofOutputEnv = "OFFICEIMO_PDF_COMPLIANCE_PROOF_OUTPUT";
-    private static readonly PdfStandardFont[] GeneratedGroundworkFonts = {
-        PdfStandardFont.Helvetica,
-        PdfStandardFont.HelveticaBold
-    };
 
     [Fact]
-    public void PdfA3GroundworkFixture_ContainsCurrentArchivalPrimitivesWithoutEnablingFormalProfile() {
-        byte[] bytes = CreatePdfA3GroundworkFixture();
-        WriteProofPdf("officeimo-pdfa3-groundwork.pdf", bytes);
+    public void PdfA2BFixture_ContainsArchivalPrimitivesAndEmbeddedFonts() {
+        byte[] bytes = CreatePdfA2BFixture();
+        WriteProofPdf("officeimo-pdfa2b.pdf", bytes);
+        string raw = Encoding.ASCII.GetString(bytes);
+        PdfDocumentInfo info = PdfInspector.Inspect(bytes);
+
+        Assert.Equal("1.7", info.HeaderVersion);
+        Assert.True(info.HasXmpMetadata);
+        Assert.True(info.HasOutputIntents);
+        Assert.False(info.HasEmbeddedFiles);
+        Assert.Equal("en-US", info.CatalogLanguage);
+        Assert.Contains("pdfaid:part>2<", raw, StringComparison.Ordinal);
+        Assert.Contains("pdfaid:conformance>B<", raw, StringComparison.Ordinal);
+        Assert.Contains("/FontFile3 ", raw, StringComparison.Ordinal);
+        Assert.Matches(@"/ID \[<[0-9A-F]{32}> <[0-9A-F]{32}>\]", raw);
+    }
+
+    [Fact]
+    public void VeraPdfGate_AcceptsFormalPdfA2BFixture() {
+        byte[] fixture = CreatePdfA2BFixture();
+        WriteProofPdf("officeimo-pdfa2b.pdf", fixture);
+        PdfExternalValidator validator = PdfExternalValidator.VeraPdf("2b");
+        if (!validator.IsAvailable) {
+            WriteProofText("verapdf-pdfa2b.txt", validator.GetNotConfiguredText());
+            PdfExternalValidator.SkipUnlessRequired(validator);
+            return;
+        }
+
+        PdfExternalProcessResult result = validator.Run(fixture, "officeimo-pdfa2b.pdf");
+        WriteProofText("verapdf-pdfa2b.txt", result.GetDiagnosticText());
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.NotEmpty(result.GetDiagnosticText());
+    }
+
+    [Fact]
+    public void PdfA3BFixture_ContainsFormalArchivalPrimitivesAndEmbeddedFonts() {
+        byte[] bytes = CreatePdfA3BFixture();
+        WriteProofPdf("officeimo-pdfa3b.pdf", bytes);
         WriteProfileProofContract();
         string raw = Encoding.ASCII.GetString(bytes);
         PdfDocumentInfo info = PdfInspector.Inspect(bytes);
@@ -35,66 +67,101 @@ public class PdfComplianceGateTests {
         Assert.Contains("/EmbeddedFiles", raw, StringComparison.Ordinal);
         Assert.Contains("/AF [", raw, StringComparison.Ordinal);
         Assert.Contains("/Params << /Size 29 /CheckSum <AEEE18719BF2A42A30C88BB9B14D60FE> >>", raw, StringComparison.Ordinal);
+        Assert.Contains("/FontFile3 ", raw, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void VeraPdfGate_RejectsGroundworkFixtureUntilFormalPdfA3BGenerationExists() {
-        byte[] fixture = CreatePdfA3GroundworkFixture();
-        WriteProofPdf("officeimo-pdfa3-groundwork.pdf", fixture);
+    public void VeraPdfGate_AcceptsFormalPdfA3BFixture() {
+        byte[] fixture = CreatePdfA3BFixture();
+        WriteProofPdf("officeimo-pdfa3b.pdf", fixture);
         PdfExternalValidator validator = PdfExternalValidator.VeraPdf();
         if (!validator.IsAvailable) {
-            WriteProofText("verapdf-pdfa3-groundwork.txt", validator.GetNotConfiguredText());
+            WriteProofText("verapdf-pdfa3b.txt", validator.GetNotConfiguredText());
             PdfExternalValidator.SkipUnlessRequired(validator);
             return;
         }
 
-        PdfExternalProcessResult result = validator.Run(fixture, "officeimo-pdfa3-groundwork.pdf");
-        WriteProofText("verapdf-pdfa3-groundwork.txt", result.GetDiagnosticText());
+        PdfExternalProcessResult result = validator.Run(fixture, "officeimo-pdfa3b.pdf");
+        WriteProofText("verapdf-pdfa3b.txt", result.GetDiagnosticText());
 
-        Assert.False(result.ExitCode == 0, "The PDF/A-3b groundwork fixture unexpectedly passed veraPDF. Enable the formal OfficeIMO.Pdf profile only after the compliance profile itself is implemented and the validator fixture is intentionally flipped to expect success." + Environment.NewLine + result.GetDiagnosticText());
+        Assert.Equal(0, result.ExitCode);
         Assert.NotEmpty(result.GetDiagnosticText());
     }
 
     [Fact]
-    public void MustangGate_RejectsEinvoiceGroundworkFixtureUntilFacturXProfileGenerationExists() {
-        byte[] fixture = CreateEinvoiceGroundworkFixture();
-        WriteProofPdf("officeimo-einvoice-groundwork.pdf", fixture);
+    public void MustangGate_AcceptsFormalFacturXFixture() {
+        byte[] fixture = CreateElectronicInvoiceFixture(PdfComplianceProfile.FacturX);
+        WriteProofPdf("officeimo-facturx.pdf", fixture);
         PdfExternalValidator validator = PdfExternalValidator.Mustang();
         if (!validator.IsAvailable) {
-            WriteProofText("mustang-einvoice-groundwork.txt", validator.GetNotConfiguredText());
+            WriteProofText("mustang-facturx.txt", validator.GetNotConfiguredText());
             PdfExternalValidator.SkipUnlessRequired(validator);
             return;
         }
 
-        PdfExternalProcessResult result = validator.Run(fixture, "officeimo-einvoice-groundwork.pdf");
-        WriteProofText("mustang-einvoice-groundwork.txt", result.GetDiagnosticText());
+        PdfExternalProcessResult result = validator.Run(fixture, "officeimo-facturx.pdf");
+        WriteProofText("mustang-facturx.txt", result.GetDiagnosticText());
 
-        Assert.False(result.ExitCode == 0, "The e-invoice groundwork fixture unexpectedly passed Mustang validation. Enable Factur-X/ZUGFeRD profile output only after profile-specific XML, XMP, PDF/A-3, and validator evidence are intentionally implemented." + Environment.NewLine + result.GetDiagnosticText());
+        Assert.Equal(0, result.ExitCode);
         Assert.NotEmpty(result.GetDiagnosticText());
     }
 
     [Fact]
-    public void VeraPdfGate_RejectsEinvoiceGroundworkFixtureUntilFacturXProfileGenerationExists() {
-        byte[] fixture = CreateEinvoiceGroundworkFixture();
-        WriteProofPdf("officeimo-einvoice-groundwork.pdf", fixture);
+    public void VeraPdfGate_AcceptsFormalFacturXFixture() {
+        byte[] fixture = CreateElectronicInvoiceFixture(PdfComplianceProfile.FacturX);
+        WriteProofPdf("officeimo-facturx.pdf", fixture);
         PdfExternalValidator validator = PdfExternalValidator.VeraPdf();
         if (!validator.IsAvailable) {
-            WriteProofText("verapdf-einvoice-groundwork.txt", validator.GetNotConfiguredText());
+            WriteProofText("verapdf-facturx.txt", validator.GetNotConfiguredText());
             PdfExternalValidator.SkipUnlessRequired(validator);
             return;
         }
 
-        PdfExternalProcessResult result = validator.Run(fixture, "officeimo-einvoice-groundwork.pdf");
-        WriteProofText("verapdf-einvoice-groundwork.txt", result.GetDiagnosticText());
+        PdfExternalProcessResult result = validator.Run(fixture, "officeimo-facturx.pdf");
+        WriteProofText("verapdf-facturx.txt", result.GetDiagnosticText());
 
-        Assert.False(result.ExitCode == 0, "The e-invoice groundwork fixture unexpectedly passed veraPDF. Enable Factur-X/ZUGFeRD profile output only after the actual e-invoice PDF/A-3 carrier is intentionally implemented and validated." + Environment.NewLine + result.GetDiagnosticText());
+        Assert.Equal(0, result.ExitCode);
         Assert.NotEmpty(result.GetDiagnosticText());
     }
 
     [Fact]
-    public void PdfUaGroundworkFixture_ContainsCurrentAccessibilityPrimitivesWithoutEnablingFormalProfile() {
-        byte[] bytes = CreatePdfUaGroundworkFixture();
-        WriteProofPdf("officeimo-pdfua-groundwork.pdf", bytes);
+    public void MustangGate_AcceptsFormalZugferdFixture() {
+        byte[] fixture = CreateElectronicInvoiceFixture(PdfComplianceProfile.Zugferd);
+        WriteProofPdf("officeimo-zugferd.pdf", fixture);
+        PdfExternalValidator validator = PdfExternalValidator.Mustang();
+        if (!validator.IsAvailable) {
+            WriteProofText("mustang-zugferd.txt", validator.GetNotConfiguredText());
+            PdfExternalValidator.SkipUnlessRequired(validator);
+            return;
+        }
+
+        PdfExternalProcessResult result = validator.Run(fixture, "officeimo-zugferd.pdf");
+        WriteProofText("mustang-zugferd.txt", result.GetDiagnosticText());
+        Assert.Equal(0, result.ExitCode);
+        Assert.NotEmpty(result.GetDiagnosticText());
+    }
+
+    [Fact]
+    public void VeraPdfGate_AcceptsFormalZugferdFixture() {
+        byte[] fixture = CreateElectronicInvoiceFixture(PdfComplianceProfile.Zugferd);
+        WriteProofPdf("officeimo-zugferd.pdf", fixture);
+        PdfExternalValidator validator = PdfExternalValidator.VeraPdf();
+        if (!validator.IsAvailable) {
+            WriteProofText("verapdf-zugferd.txt", validator.GetNotConfiguredText());
+            PdfExternalValidator.SkipUnlessRequired(validator);
+            return;
+        }
+
+        PdfExternalProcessResult result = validator.Run(fixture, "officeimo-zugferd.pdf");
+        WriteProofText("verapdf-zugferd.txt", result.GetDiagnosticText());
+        Assert.Equal(0, result.ExitCode);
+        Assert.NotEmpty(result.GetDiagnosticText());
+    }
+
+    [Fact]
+    public void PdfUa1Fixture_ContainsFormalAccessibilityPrimitivesAndEmbeddedFonts() {
+        byte[] bytes = CreatePdfUa1Fixture();
+        WriteProofPdf("officeimo-pdfua1.pdf", bytes);
         string raw = Encoding.ASCII.GetString(bytes);
         PdfDocumentInfo info = PdfInspector.Inspect(bytes);
 
@@ -107,31 +174,31 @@ public class PdfComplianceGateTests {
         Assert.Contains("/DisplayDocTitle true", raw, StringComparison.Ordinal);
         Assert.Contains("/MarkInfo << /Marked true >>", raw, StringComparison.Ordinal);
         Assert.Contains("/StructTreeRoot", raw, StringComparison.Ordinal);
+        Assert.Contains("/S /Annot", raw, StringComparison.Ordinal);
+        Assert.Contains("/S /Form", raw, StringComparison.Ordinal);
+        Assert.Contains("/FontFile3 ", raw, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void PdfUaValidatorGate_RejectsGroundworkFixtureUntilFormalPdfUaGenerationExists() {
-        byte[] fixture = CreatePdfUaGroundworkFixture();
-        WriteProofPdf("officeimo-pdfua-groundwork.pdf", fixture);
+    public void PdfUaValidatorGate_AcceptsFormalPdfUa1Fixture() {
+        byte[] fixture = CreatePdfUa1Fixture();
+        WriteProofPdf("officeimo-pdfua1.pdf", fixture);
         PdfExternalValidator validator = PdfExternalValidator.PdfUa();
         if (!validator.IsAvailable) {
-            WriteProofText("pdfua-groundwork.txt", validator.GetNotConfiguredText());
+            WriteProofText("pdfua-pdfua1.txt", validator.GetNotConfiguredText());
             PdfExternalValidator.SkipUnlessRequired(validator);
             return;
         }
 
-        PdfExternalProcessResult result = validator.Run(fixture, "officeimo-pdfua-groundwork.pdf");
-        WriteProofText("pdfua-groundwork.txt", result.GetDiagnosticText());
+        PdfExternalProcessResult result = validator.Run(fixture, "officeimo-pdfua1.pdf");
+        WriteProofText("pdfua-pdfua1.txt", result.GetDiagnosticText());
 
-        Assert.False(result.ExitCode == 0, "The PDF/UA groundwork fixture unexpectedly passed the configured PDF/UA validator. Enable the formal OfficeIMO.Pdf profile only after tagged structure, reading order, alternate text, font mapping, and validator evidence are intentionally implemented." + Environment.NewLine + result.GetDiagnosticText());
+        Assert.Equal(0, result.ExitCode);
         Assert.NotEmpty(result.GetDiagnosticText());
     }
 
     [Theory]
-    [InlineData(PdfComplianceProfile.PdfA3B, "veraPDF validation fixtures in the build lane")]
-    [InlineData(PdfComplianceProfile.PdfUa1, "PDF/UA identification XMP")]
-    [InlineData(PdfComplianceProfile.FacturX, "Mustang validation fixtures in the build lane")]
-    [InlineData(PdfComplianceProfile.Zugferd, "Mustang validation fixtures in the build lane")]
+    [InlineData(PdfComplianceProfile.PdfUa2, "PDF/UA identification XMP")]
     public void FormalProfiles_StillFailClosedUntilValidatorBackedGenerationExists(PdfComplianceProfile profile, string expectedRequirement) {
         var exception = Assert.Throws<NotSupportedException>(() =>
             PdfDocument.Create()
@@ -145,30 +212,40 @@ public class PdfComplianceGateTests {
     }
 
     [Fact]
-    public void ProofOutputHook_WritesGroundworkFixturesWhenConfigured() {
+    public void ProofOutputHook_WritesComplianceFixturesWhenConfigured() {
         string previousOutput = Environment.GetEnvironmentVariable(ProofOutputEnv) ?? string.Empty;
         string directory = Path.Combine(Path.GetTempPath(), "OfficeIMO.PdfComplianceProof", Guid.NewGuid().ToString("N"));
         try {
             Environment.SetEnvironmentVariable(ProofOutputEnv, directory);
 
-            WriteProofPdf("officeimo-pdfa3-groundwork.pdf", CreatePdfA3GroundworkFixture());
-            WriteProofPdf("officeimo-einvoice-groundwork.pdf", CreateEinvoiceGroundworkFixture());
-            WriteProofPdf("officeimo-pdfua-groundwork.pdf", CreatePdfUaGroundworkFixture());
+            WriteProofPdf("officeimo-pdfa3b.pdf", CreatePdfA3BFixture());
+            WriteProofPdf("officeimo-pdfa2b.pdf", CreatePdfA2BFixture());
+            WriteProofPdf("officeimo-facturx.pdf", CreateElectronicInvoiceFixture(PdfComplianceProfile.FacturX));
+            WriteProofPdf("officeimo-zugferd.pdf", CreateElectronicInvoiceFixture(PdfComplianceProfile.Zugferd));
+            WriteProofPdf("officeimo-pdfua1.pdf", CreatePdfUa1Fixture());
             WriteProfileProofContract();
-            WriteProofText("verapdf-pdfa3-groundwork.txt", "validator diagnostic");
-            WriteProofText("verapdf-einvoice-groundwork.txt", "validator diagnostic");
-            WriteProofText("pdfua-groundwork.txt", "validator diagnostic");
+            WriteProofText("verapdf-pdfa3b.txt", "validator diagnostic");
+            WriteProofText("verapdf-facturx.txt", "validator diagnostic");
+            WriteProofText("verapdf-zugferd.txt", "validator diagnostic");
+            WriteProofText("mustang-facturx.txt", "validator diagnostic");
+            WriteProofText("mustang-zugferd.txt", "validator diagnostic");
+            WriteProofText("pdfua-pdfua1.txt", "validator diagnostic");
 
-            Assert.True(File.Exists(Path.Combine(directory, "officeimo-pdfa3-groundwork.pdf")));
-            Assert.True(File.Exists(Path.Combine(directory, "officeimo-einvoice-groundwork.pdf")));
-            Assert.True(File.Exists(Path.Combine(directory, "officeimo-pdfua-groundwork.pdf")));
+            Assert.True(File.Exists(Path.Combine(directory, "officeimo-pdfa3b.pdf")));
+            Assert.True(File.Exists(Path.Combine(directory, "officeimo-pdfa2b.pdf")));
+            Assert.True(File.Exists(Path.Combine(directory, "officeimo-facturx.pdf")));
+            Assert.True(File.Exists(Path.Combine(directory, "officeimo-zugferd.pdf")));
+            Assert.True(File.Exists(Path.Combine(directory, "officeimo-pdfua1.pdf")));
             Assert.True(File.Exists(Path.Combine(directory, "officeimo-profile-proof-contract.json")));
-            Assert.True(File.Exists(Path.Combine(directory, "verapdf-pdfa3-groundwork.txt")));
-            Assert.True(File.Exists(Path.Combine(directory, "verapdf-einvoice-groundwork.txt")));
-            Assert.True(File.Exists(Path.Combine(directory, "pdfua-groundwork.txt")));
-            Assert.True(new FileInfo(Path.Combine(directory, "officeimo-pdfa3-groundwork.pdf")).Length > 0);
-            Assert.True(new FileInfo(Path.Combine(directory, "officeimo-einvoice-groundwork.pdf")).Length > 0);
-            Assert.True(new FileInfo(Path.Combine(directory, "officeimo-pdfua-groundwork.pdf")).Length > 0);
+            Assert.True(File.Exists(Path.Combine(directory, "verapdf-pdfa3b.txt")));
+            Assert.True(File.Exists(Path.Combine(directory, "verapdf-facturx.txt")));
+            Assert.True(File.Exists(Path.Combine(directory, "verapdf-zugferd.txt")));
+            Assert.True(File.Exists(Path.Combine(directory, "pdfua-pdfua1.txt")));
+            Assert.True(new FileInfo(Path.Combine(directory, "officeimo-pdfa3b.pdf")).Length > 0);
+            Assert.True(new FileInfo(Path.Combine(directory, "officeimo-pdfa2b.pdf")).Length > 0);
+            Assert.True(new FileInfo(Path.Combine(directory, "officeimo-facturx.pdf")).Length > 0);
+            Assert.True(new FileInfo(Path.Combine(directory, "officeimo-zugferd.pdf")).Length > 0);
+            Assert.True(new FileInfo(Path.Combine(directory, "officeimo-pdfua1.pdf")).Length > 0);
         } finally {
             Environment.SetEnvironmentVariable(ProofOutputEnv, string.IsNullOrEmpty(previousOutput) ? null : previousOutput);
             TryDeleteDirectory(directory);
@@ -189,10 +266,16 @@ public class PdfComplianceGateTests {
 
             using JsonDocument document = JsonDocument.Parse(File.ReadAllText(path, Encoding.UTF8));
             JsonElement root = document.RootElement;
-            Assert.Equal(3, root.GetProperty("schemaVersion").GetInt32());
-            Assert.Equal("NoExternalValidationInjected", root.GetProperty("externalEvidenceMode").GetString());
+            Assert.Equal(4, root.GetProperty("schemaVersion").GetInt32());
+            Assert.Equal("ExactArtifactValidationInjectedByProofExporter", root.GetProperty("externalEvidenceMode").GetString());
             JsonElement profiles = root.GetProperty("profiles");
-            Assert.Equal(4, profiles.GetArrayLength());
+            Assert.Equal(5, profiles.GetArrayLength());
+            Assert.Contains(profiles.EnumerateArray(), profile =>
+                string.Equals(profile.GetProperty("profile").GetString(), nameof(PdfComplianceProfile.PdfA2B), StringComparison.Ordinal) &&
+                profile.GetProperty("isInternallyReady").GetBoolean() &&
+                profile.GetProperty("hasArtifactEvidence").GetBoolean() &&
+                profile.GetProperty("artifactSha256").GetString()!.Length == 64 &&
+                profile.GetProperty("canClaimConformance").GetBoolean() == false);
             Assert.Contains(profiles.EnumerateArray(), profile =>
                 string.Equals(profile.GetProperty("profile").GetString(), nameof(PdfComplianceProfile.PdfA3B), StringComparison.Ordinal) &&
                 profile.GetProperty("requiredExternalValidators").EnumerateArray().Any(validator => string.Equals(validator.GetString(), nameof(PdfExternalValidatorKind.VeraPdf), StringComparison.Ordinal)) &&
@@ -213,45 +296,97 @@ public class PdfComplianceGateTests {
         }
     }
 
-    private static byte[] CreatePdfA3GroundworkFixture() {
-        return PdfDocument.Create(new PdfOptions {
-                FileVersion = PdfFileVersion.Pdf17,
-                IncludeStandardFontToUnicodeMaps = true
-            })
-            .PdfAIdentification(3, "B")
-            .Meta(title: "OfficeIMO Archival Groundwork", author: "OfficeIMO")
+    private static byte[] CreatePdfA3BFixture() {
+        return CreatePdfA3BDocument().ToBytes();
+    }
+
+    private static PdfDocument CreatePdfA3BDocument() {
+        return PdfDocument.Create(CreatePdfA3BOptions())
+            .Meta(title: "OfficeIMO PDF/A-3b", author: "OfficeIMO")
             .Language("en-US")
             .SrgbOutputIntent()
             .AttachFile("source-data.xml", Encoding.UTF8.GetBytes("<source><id>123</id></source>"), "application/xml", PdfAssociatedFileRelationship.Data, "Source data")
-            .H1("Archival Groundwork")
-            .Paragraph(p => p.Text("This fixture intentionally contains compliance primitives but does not claim PDF/A conformance."))
-            .ToBytes();
+            .H1("Archival PDF with Associated Data")
+            .Paragraph(p => p.Text("This exact artifact is validated as PDF/A-3b before OfficeIMO claims conformance."));
     }
 
-    private static byte[] CreateEinvoiceGroundworkFixture() {
-        byte[] invoiceXml = CreateEinvoiceGroundworkXml();
-        return PdfDocument.Create(new PdfOptions {
+    private static byte[] CreatePdfA2BFixture() {
+        return CreatePdfA2BDocument().ToBytes();
+    }
+
+    private static PdfDocument CreatePdfA2BDocument() {
+        return PdfDocument.Create(CreatePdfA2BOptions())
+            .Meta(title: "OfficeIMO PDF/A-2b", author: "OfficeIMO")
+            .Language("en-US")
+            .H1("Archival PDF")
+            .Paragraph(p => p.Text("This exact artifact is validated as PDF/A-2b before OfficeIMO claims conformance."));
+    }
+
+    private static PdfOptions CreatePdfA3BOptions() {
+        string? fontPath = PdfComplianceTestFonts.FindBundledOpenTypeCffFont();
+        Assert.NotNull(fontPath);
+        byte[] fontData = File.ReadAllBytes(fontPath!);
+        return new PdfOptions {
                 FileVersion = PdfFileVersion.Pdf17,
                 IncludeStandardFontToUnicodeMaps = true
-            })
-            .PdfAIdentification(3, "B")
-            .ElectronicInvoiceMetadata(PdfElectronicInvoiceMetadata.FacturX("EN 16931"))
-            .Meta(title: "OfficeIMO E-Invoice Groundwork", author: "OfficeIMO")
-            .Language("en-US")
-            .SrgbOutputIntent()
-            .AttachFile("factur-x.xml", invoiceXml, "application/xml", PdfAssociatedFileRelationship.Data, "EN 16931 XML payload placeholder")
-            .H1("E-Invoice Groundwork")
-            .Paragraph(p => p.Text("This fixture intentionally exercises associated-file output without claiming Factur-X or ZUGFeRD conformance."))
-            .ToBytes();
+            }
+            .ConfigurePdfAGroundwork(PdfComplianceProfile.PdfA3B, "en-US")
+            .RequireCompliance(PdfComplianceProfile.PdfA3B)
+            .EmbedStandardFont(PdfStandardFont.Helvetica, fontData, "OfficeIMO Source Serif")
+            .EmbedStandardFont(PdfStandardFont.HelveticaBold, fontData, "OfficeIMO Source Serif");
     }
 
-    private static byte[] CreateEinvoiceGroundworkXml() {
+    private static PdfOptions CreatePdfA2BOptions() {
+        string? fontPath = PdfComplianceTestFonts.FindBundledOpenTypeCffFont();
+        Assert.NotNull(fontPath);
+        byte[] fontData = File.ReadAllBytes(fontPath!);
+        return new PdfOptions {
+                FileVersion = PdfFileVersion.Pdf17,
+                IncludeStandardFontToUnicodeMaps = true
+            }
+            .ConfigurePdfAGroundwork(PdfComplianceProfile.PdfA2B, "en-US")
+            .RequireCompliance(PdfComplianceProfile.PdfA2B)
+            .EmbedStandardFont(PdfStandardFont.Helvetica, fontData, "OfficeIMO Source Serif")
+            .EmbedStandardFont(PdfStandardFont.HelveticaBold, fontData, "OfficeIMO Source Serif");
+    }
+
+    private static byte[] CreateElectronicInvoiceFixture(PdfComplianceProfile profile) {
+        return CreateElectronicInvoiceDocument(profile).ToBytes();
+    }
+
+    private static PdfDocument CreateElectronicInvoiceDocument(PdfComplianceProfile profile) {
+        byte[] invoiceXml = CreateElectronicInvoiceXml();
+        return PdfDocument.Create(CreateEinvoiceOptions(profile, invoiceXml))
+            .Meta(title: "OfficeIMO " + (profile == PdfComplianceProfile.FacturX ? "Factur-X" : "ZUGFeRD") + " Invoice", author: "OfficeIMO")
+            .Language("en-US")
+            .H1(profile == PdfComplianceProfile.FacturX ? "Factur-X Invoice" : "ZUGFeRD Invoice")
+            .Paragraph(p => p.Text("The attached EN 16931 invoice XML and its PDF/A-3 carrier are validated as one exact artifact."));
+    }
+
+    private static PdfOptions CreateEinvoiceOptions(PdfComplianceProfile profile, byte[] invoiceXml) {
+        string? fontPath = PdfComplianceTestFonts.FindBundledOpenTypeCffFont();
+        Assert.NotNull(fontPath);
+        byte[] fontData = File.ReadAllBytes(fontPath!);
+        return new PdfOptions {
+                FileVersion = PdfFileVersion.Pdf17,
+                IncludeStandardFontToUnicodeMaps = true
+            }
+            .ConfigureElectronicInvoiceGroundwork(
+                profile,
+                invoiceXml,
+                relationship: PdfAssociatedFileRelationship.Alternative)
+            .RequireCompliance(profile)
+            .EmbedStandardFont(PdfStandardFont.Helvetica, fontData, "OfficeIMO Source Serif")
+            .EmbedStandardFont(PdfStandardFont.HelveticaBold, fontData, "OfficeIMO Source Serif");
+    }
+
+    private static byte[] CreateElectronicInvoiceXml() {
         return Encoding.UTF8.GetBytes(
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
             "<rsm:CrossIndustryInvoice xmlns:rsm=\"urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100\" xmlns:ram=\"urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100\" xmlns:udt=\"urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100\">" +
             "<rsm:ExchangedDocumentContext>" +
             "<ram:GuidelineSpecifiedDocumentContextParameter>" +
-            "<ram:ID>urn:factur-x.eu:1p0:en16931</ram:ID>" +
+            "<ram:ID>urn:cen.eu:en16931:2017</ram:ID>" +
             "</ram:GuidelineSpecifiedDocumentContextParameter>" +
             "</rsm:ExchangedDocumentContext>" +
             "<rsm:ExchangedDocument>" +
@@ -264,8 +399,13 @@ public class PdfComplianceGateTests {
             "<ram:AssociatedDocumentLineDocument><ram:LineID>1</ram:LineID></ram:AssociatedDocumentLineDocument>" +
             "<ram:SpecifiedTradeProduct><ram:Name>OfficeIMO PDF compliance work</ram:Name></ram:SpecifiedTradeProduct>" +
             "<ram:SpecifiedLineTradeAgreement>" +
+            "<ram:GrossPriceProductTradePrice>" +
+            "<ram:ChargeAmount>100.00</ram:ChargeAmount>" +
+            "<ram:BasisQuantity unitCode=\"C62\">1</ram:BasisQuantity>" +
+            "</ram:GrossPriceProductTradePrice>" +
             "<ram:NetPriceProductTradePrice>" +
-            "<ram:ChargeAmount currencyID=\"EUR\">100.00</ram:ChargeAmount>" +
+            "<ram:ChargeAmount>100.00</ram:ChargeAmount>" +
+            "<ram:BasisQuantity unitCode=\"C62\">1</ram:BasisQuantity>" +
             "</ram:NetPriceProductTradePrice>" +
             "</ram:SpecifiedLineTradeAgreement>" +
             "<ram:SpecifiedLineTradeDelivery><ram:BilledQuantity unitCode=\"C62\">1</ram:BilledQuantity></ram:SpecifiedLineTradeDelivery>" +
@@ -283,55 +423,76 @@ public class PdfComplianceGateTests {
             "<ram:ApplicableHeaderTradeAgreement>" +
             "<ram:SellerTradeParty>" +
             "<ram:Name>OfficeIMO Seller</ram:Name>" +
+            "<ram:PostalTradeAddress><ram:PostcodeCode>00-001</ram:PostcodeCode><ram:LineOne>Engine Street 1</ram:LineOne><ram:CityName>Warsaw</ram:CityName><ram:CountryID>PL</ram:CountryID></ram:PostalTradeAddress>" +
+            "<ram:URIUniversalCommunication><ram:URIID schemeID=\"0088\">5901234123457</ram:URIID></ram:URIUniversalCommunication>" +
+            "<ram:SpecifiedTaxRegistration><ram:ID schemeID=\"FC\">PL1234567890</ram:ID></ram:SpecifiedTaxRegistration>" +
             "<ram:SpecifiedTaxRegistration><ram:ID schemeID=\"VA\">PL1234567890</ram:ID></ram:SpecifiedTaxRegistration>" +
-            "<ram:PostalTradeAddress><ram:CountryID>PL</ram:CountryID></ram:PostalTradeAddress>" +
             "</ram:SellerTradeParty>" +
             "<ram:BuyerTradeParty>" +
             "<ram:Name>OfficeIMO Buyer</ram:Name>" +
+            "<ram:PostalTradeAddress><ram:PostcodeCode>10115</ram:PostcodeCode><ram:LineOne>Archive Road 2</ram:LineOne><ram:CityName>Berlin</ram:CityName><ram:CountryID>DE</ram:CountryID></ram:PostalTradeAddress>" +
+            "<ram:URIUniversalCommunication><ram:URIID schemeID=\"0088\">4006381333931</ram:URIID></ram:URIUniversalCommunication>" +
             "<ram:SpecifiedTaxRegistration><ram:ID schemeID=\"VA\">DE123456789</ram:ID></ram:SpecifiedTaxRegistration>" +
-            "<ram:PostalTradeAddress><ram:CountryID>DE</ram:CountryID></ram:PostalTradeAddress>" +
             "</ram:BuyerTradeParty>" +
             "</ram:ApplicableHeaderTradeAgreement>" +
+            "<ram:ApplicableHeaderTradeDelivery>" +
+            "<ram:ActualDeliverySupplyChainEvent><ram:OccurrenceDateTime><udt:DateTimeString format=\"102\">20260603</udt:DateTimeString></ram:OccurrenceDateTime></ram:ActualDeliverySupplyChainEvent>" +
+            "</ram:ApplicableHeaderTradeDelivery>" +
             "<ram:ApplicableHeaderTradeSettlement>" +
+            "<ram:PaymentReference>INV-2026-0001</ram:PaymentReference>" +
             "<ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>" +
-            "<ram:ApplicableTradeTax>" +
-            "<ram:CalculatedAmount currencyID=\"EUR\">23.45</ram:CalculatedAmount>" +
-            "<ram:TypeCode>VAT</ram:TypeCode>" +
-            "<ram:BasisAmount currencyID=\"EUR\">100.00</ram:BasisAmount>" +
-            "<ram:CategoryCode>S</ram:CategoryCode>" +
-            "<ram:RateApplicablePercent>23</ram:RateApplicablePercent>" +
-            "</ram:ApplicableTradeTax>" +
             "<ram:SpecifiedTradeSettlementPaymentMeans>" +
             "<ram:TypeCode>58</ram:TypeCode>" +
             "<ram:PayeePartyCreditorFinancialAccount>" +
             "<ram:IBANID>PL61109010140000071219812874</ram:IBANID>" +
             "</ram:PayeePartyCreditorFinancialAccount>" +
             "</ram:SpecifiedTradeSettlementPaymentMeans>" +
+            "<ram:ApplicableTradeTax>" +
+            "<ram:CalculatedAmount>23.00</ram:CalculatedAmount>" +
+            "<ram:TypeCode>VAT</ram:TypeCode>" +
+            "<ram:BasisAmount>100.00</ram:BasisAmount>" +
+            "<ram:CategoryCode>S</ram:CategoryCode>" +
+            "<ram:RateApplicablePercent>23</ram:RateApplicablePercent>" +
+            "</ram:ApplicableTradeTax>" +
             "<ram:SpecifiedTradePaymentTerms>" +
             "<ram:Description>Due within 30 days</ram:Description>" +
             "<ram:DueDateDateTime><udt:DateTimeString format=\"102\">20260703</udt:DateTimeString></ram:DueDateDateTime>" +
             "</ram:SpecifiedTradePaymentTerms>" +
             "<ram:SpecifiedTradeSettlementHeaderMonetarySummation>" +
-            "<ram:TaxBasisTotalAmount currencyID=\"EUR\">100.00</ram:TaxBasisTotalAmount>" +
-            "<ram:TaxTotalAmount currencyID=\"EUR\">23.45</ram:TaxTotalAmount>" +
-            "<ram:GrandTotalAmount currencyID=\"EUR\">123.45</ram:GrandTotalAmount>" +
+            "<ram:LineTotalAmount>100.00</ram:LineTotalAmount>" +
+            "<ram:ChargeTotalAmount>0.00</ram:ChargeTotalAmount>" +
+            "<ram:AllowanceTotalAmount>0.00</ram:AllowanceTotalAmount>" +
+            "<ram:TaxBasisTotalAmount>100.00</ram:TaxBasisTotalAmount>" +
+            "<ram:TaxTotalAmount currencyID=\"EUR\">23.00</ram:TaxTotalAmount>" +
+            "<ram:GrandTotalAmount>123.00</ram:GrandTotalAmount>" +
+            "<ram:DuePayableAmount>123.00</ram:DuePayableAmount>" +
             "</ram:SpecifiedTradeSettlementHeaderMonetarySummation>" +
             "</ram:ApplicableHeaderTradeSettlement>" +
             "</rsm:SupplyChainTradeTransaction>" +
             "</rsm:CrossIndustryInvoice>");
     }
 
-    private static byte[] CreatePdfUaGroundworkFixture() {
-        return PdfDocument.Create(new PdfOptions {
-                FileVersion = PdfFileVersion.Pdf17,
-                IncludeStandardFontToUnicodeMaps = true
-            })
-            .ConfigurePdfUaGroundwork("en-US")
-            .Meta(title: "OfficeIMO PDF/UA Groundwork", author: "OfficeIMO")
-            .H1("Accessibility Groundwork")
-            .Paragraph(p => p.Text("This fixture intentionally contains PDF/UA primitives but does not claim PDF/UA conformance."))
+    private static byte[] CreatePdfUa1Fixture() {
+        return CreatePdfUa1Document().ToBytes();
+    }
+
+    private static PdfDocument CreatePdfUa1Document() {
+        var accessibleFieldStyle = new PdfFormFieldStyle {
+            AlternateName = "Contact email address"
+        };
+        var accessibleCheckBoxStyle = new PdfFormFieldStyle {
+            AlternateName = "Receive compliance updates"
+        };
+
+        return PdfDocument.Create(CreatePdfUa1Options())
+            .Meta(title: "OfficeIMO PDF/UA-1", author: "OfficeIMO")
+            .H1("Accessible PDF")
+            .Paragraph(p => p.Text("This fixture exercises reading order, Unicode text, accessible links, annotations, forms, and figures. ")
+                .Link("Visit the OfficeIMO project", "https://officeimo.net/", contents: "OfficeIMO project website"))
             .Image(CreateOnePixelPng(), 12, 12, alternativeText: "Decorative sample pixel")
-            .ToBytes();
+            .TextAnnotation("Accessibility review note", width: 18, height: 18)
+            .TextField("Contact.Email", value: "reader@example.com", width: 180, height: 24, style: accessibleFieldStyle)
+            .CheckBox("Contact.Updates", isChecked: true, size: 16, style: accessibleCheckBoxStyle);
     }
 
     private static byte[] CreateOnePixelPng() {
@@ -345,15 +506,26 @@ public class PdfComplianceGateTests {
         }
 
         Directory.CreateDirectory(outputDirectory);
+        PdfDocument pdfA2BDocument = CreatePdfA2BDocument();
+        byte[] pdfA2BArtifact = pdfA2BDocument.ToBytes();
+        PdfDocument pdfA3BDocument = CreatePdfA3BDocument();
+        byte[] pdfA3BArtifact = pdfA3BDocument.ToBytes();
+        PdfDocument facturXDocument = CreateElectronicInvoiceDocument(PdfComplianceProfile.FacturX);
+        byte[] facturXArtifact = facturXDocument.ToBytes();
+        PdfDocument zugferdDocument = CreateElectronicInvoiceDocument(PdfComplianceProfile.Zugferd);
+        byte[] zugferdArtifact = zugferdDocument.ToBytes();
+        PdfDocument pdfUa1Document = CreatePdfUa1Document();
+        byte[] pdfUa1Artifact = pdfUa1Document.ToBytes();
         var contract = new ProfileProofContract {
-            SchemaVersion = 3,
+            SchemaVersion = 4,
             GeneratedBy = nameof(PdfComplianceAnalyzer) + "." + nameof(PdfComplianceAnalyzer.AssessProof),
-            ExternalEvidenceMode = "NoExternalValidationInjected",
+            ExternalEvidenceMode = "ExactArtifactValidationInjectedByProofExporter",
             Profiles = new[] {
-                CreateProofContractRow(PdfComplianceProfile.PdfA3B, CreatePdfA3GroundworkOptions(), GeneratedGroundworkFonts),
-                CreateProofContractRow(PdfComplianceProfile.PdfUa1, CreatePdfUaGroundworkOptions(), GeneratedGroundworkFonts),
-                CreateProofContractRow(PdfComplianceProfile.FacturX, CreateEinvoiceGroundworkOptions(), GeneratedGroundworkFonts),
-                CreateProofContractRow(PdfComplianceProfile.Zugferd, CreateEinvoiceGroundworkOptions(), GeneratedGroundworkFonts)
+                CreateProofContractRow(PdfComplianceProfile.PdfA2B, pdfA2BDocument, pdfA2BArtifact),
+                CreateProofContractRow(PdfComplianceProfile.PdfA3B, pdfA3BDocument, pdfA3BArtifact),
+                CreateProofContractRow(PdfComplianceProfile.PdfUa1, pdfUa1Document, pdfUa1Artifact),
+                CreateProofContractRow(PdfComplianceProfile.FacturX, facturXDocument, facturXArtifact),
+                CreateProofContractRow(PdfComplianceProfile.Zugferd, zugferdDocument, zugferdArtifact)
             }
         };
         string json = JsonSerializer.Serialize(contract, new JsonSerializerOptions {
@@ -363,19 +535,26 @@ public class PdfComplianceGateTests {
         File.WriteAllText(Path.Combine(outputDirectory, "officeimo-profile-proof-contract.json"), json, Encoding.UTF8);
     }
 
-    private static ProfileProofContractRow CreateProofContractRow(PdfComplianceProfile profile, PdfOptions options, IEnumerable<PdfStandardFont> generatedStandardFonts) {
-        PdfComplianceProofReport proof = PdfComplianceAnalyzer.AssessProof(
+    private static ProfileProofContractRow CreateProofContractRow(PdfComplianceProfile profile, PdfDocument document, byte[] artifact) {
+        PdfComplianceProofReport proof = document.AssessComplianceProof(
             profile,
-            options,
-            externalValidations: Array.Empty<PdfExternalValidationResult>(),
-            generatedStandardFonts: generatedStandardFonts);
+            artifact,
+            externalValidations: Array.Empty<PdfExternalValidationResult>());
 
+        return CreateProofContractRow(proof);
+    }
+
+    private static ProfileProofContractRow CreateProofContractRow(PdfComplianceProofReport proof) {
         return new ProfileProofContractRow {
             Profile = proof.Profile.ToString(),
             DisplayName = proof.DisplayName,
             IsInternallyReady = proof.IsInternallyReady,
             HasRequiredExternalValidation = proof.HasRequiredExternalValidation,
             CanClaimConformance = proof.CanClaimConformance,
+            ProofStatus = proof.ProofStatus,
+            HasArtifactEvidence = proof.HasArtifactEvidence,
+            ArtifactSha256 = proof.ArtifactSha256,
+            ArtifactSizeBytes = proof.ArtifactSizeBytes,
             RequiredExternalValidators = proof.RequiredExternalValidators.Select(validator => validator.ToString()).ToArray(),
             MissingExternalValidators = proof.MissingExternalValidators.Select(validator => validator.ToString()).ToArray(),
             FailedExternalValidationCount = proof.FailedExternalValidations.Count,
@@ -387,39 +566,30 @@ public class PdfComplianceGateTests {
                 ValidatorName = row.ValidatorName,
                 Diagnostic = row.Diagnostic,
                 Profile = row.Profile,
-                ExitCode = row.ExitCode
+                ExitCode = row.ExitCode,
+                ValidatorVersion = row.ValidatorVersion,
+                ArtifactSha256 = row.ArtifactSha256,
+                ArtifactSizeBytes = row.ArtifactSizeBytes,
+                ValidatedAtUtc = row.ValidatedAtUtc,
+                Warnings = row.Warnings.ToArray()
             }).ToArray(),
             MissingRequirementIds = proof.Readiness.MissingRequirements.Select(requirement => requirement.Id).ToArray(),
             UnsupportedRequirementIds = proof.Readiness.UnsupportedRequirements.Select(requirement => requirement.Id).ToArray()
         };
     }
 
-    private static PdfOptions CreatePdfA3GroundworkOptions() {
-        return new PdfOptions {
-            FileVersion = PdfFileVersion.Pdf17,
-            IncludeStandardFontToUnicodeMaps = true
-        }
-            .SetPdfAIdentification(3, "B")
-            .SetSrgbOutputIntent();
-    }
-
-    private static PdfOptions CreatePdfUaGroundworkOptions() {
+    private static PdfOptions CreatePdfUa1Options() {
+        string? fontPath = PdfComplianceTestFonts.FindBundledOpenTypeCffFont();
+        Assert.NotNull(fontPath);
+        byte[] fontData = File.ReadAllBytes(fontPath!);
         return new PdfOptions {
                 FileVersion = PdfFileVersion.Pdf17,
                 IncludeStandardFontToUnicodeMaps = true
             }
-            .ConfigurePdfUaGroundwork("en-US");
-    }
-
-    private static PdfOptions CreateEinvoiceGroundworkOptions() {
-        return new PdfOptions {
-            FileVersion = PdfFileVersion.Pdf17,
-            IncludeStandardFontToUnicodeMaps = true
-        }
-            .SetPdfAIdentification(3, "B")
-            .SetElectronicInvoiceMetadata(PdfElectronicInvoiceMetadata.FacturX("EN 16931"))
-            .SetSrgbOutputIntent()
-            .AddEmbeddedFile("factur-x.xml", CreateEinvoiceGroundworkXml(), "application/xml", PdfAssociatedFileRelationship.Data, "EN 16931 XML payload placeholder");
+            .ConfigurePdfUaGroundwork("en-US")
+            .RequireCompliance(PdfComplianceProfile.PdfUa1)
+            .EmbedStandardFont(PdfStandardFont.Helvetica, fontData, "OfficeIMO Source Serif")
+            .EmbedStandardFont(PdfStandardFont.HelveticaBold, fontData, "OfficeIMO Source Serif");
     }
 
     private static void WriteProofPdf(string fileName, byte[] bytes) {
@@ -478,6 +648,14 @@ public class PdfComplianceGateTests {
 
         public bool CanClaimConformance { get; set; }
 
+        public string ProofStatus { get; set; } = string.Empty;
+
+        public bool HasArtifactEvidence { get; set; }
+
+        public string? ArtifactSha256 { get; set; }
+
+        public long? ArtifactSizeBytes { get; set; }
+
         public string[] RequiredExternalValidators { get; set; } = Array.Empty<string>();
 
         public string[] MissingExternalValidators { get; set; } = Array.Empty<string>();
@@ -507,5 +685,15 @@ public class PdfComplianceGateTests {
         public string? Profile { get; set; }
 
         public int? ExitCode { get; set; }
+
+        public string? ValidatorVersion { get; set; }
+
+        public string? ArtifactSha256 { get; set; }
+
+        public long? ArtifactSizeBytes { get; set; }
+
+        public DateTimeOffset? ValidatedAtUtc { get; set; }
+
+        public string[] Warnings { get; set; } = Array.Empty<string>();
     }
 }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfContainerAndColumnTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfContainerAndColumnTests.cs
@@ -130,6 +130,43 @@ public class PdfContainerAndColumnTests {
         Assert.Contains("1 0 0 1 220 ", raw, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void Columns_BalancedRichLinesPreserveSpaceBeforeInlineElements() {
+        byte[] bytes = PdfDocument.Create(new PdfOptions {
+                PageWidth = 420,
+                PageHeight = 300,
+                MarginLeft = 40,
+                MarginRight = 40,
+                MarginTop = 40,
+                MarginBottom = 40,
+                DefaultFontSize = 10,
+                CompressContentStreams = false
+            })
+            .Columns(columns => columns.Paragraph(paragraph => paragraph
+                .Text("ColumnLine01 ").InlineBox(8, 8).Text("after").LineBreak()
+                .Text("ColumnLine02 ").InlineBox(8, 8).Text("after").LineBreak()
+                .Text("ColumnLine03 ").InlineBox(8, 8).Text("after").LineBreak()
+                .Text("ColumnLine04 ").InlineBox(8, 8).Text("after").LineBreak()
+                .Text("ColumnLine05 ").InlineBox(8, 8).Text("after").LineBreak()
+                .Text("ColumnLine06 ").InlineBox(8, 8).Text("after").LineBreak()
+                .Text("ColumnLine07 ").InlineBox(8, 8).Text("after").LineBreak()
+                .Text("ColumnLine08 ").InlineBox(8, 8).Text("after")), new PdfMultiColumnOptions {
+                    ColumnCount = 2,
+                    Gap = 20,
+                    BalanceLastPage = true,
+                    BalanceParagraphLines = true
+                })
+            .ToBytes();
+
+        string text = PdfReadDocument.Load(bytes).ExtractText();
+
+        for (int index = 1; index <= 8; index++) {
+            string marker = "ColumnLine" + index.ToString("D2") + " after";
+            Assert.Contains(marker, text, StringComparison.Ordinal);
+            Assert.DoesNotContain(marker.Replace(" ", string.Empty), text, StringComparison.Ordinal);
+        }
+    }
+
     private static int CountOccurrences(string value, string token) {
         int count = 0;
         int offset = 0;

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfContainerAndColumnTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfContainerAndColumnTests.cs
@@ -132,6 +132,47 @@ public class PdfContainerAndColumnTests {
     }
 
     [Fact]
+    public void Columns_DefaultKeepTogetherParagraphIsNotSplitByLineBalancing() {
+        byte[] bytes = PdfDocument.Create(new PdfOptions {
+                PageWidth = 420,
+                PageHeight = 300,
+                MarginLeft = 40,
+                MarginRight = 40,
+                MarginTop = 40,
+                MarginBottom = 40,
+                DefaultFontSize = 10,
+                DefaultParagraphStyle = new PdfParagraphStyle {
+                    KeepTogether = true
+                },
+                CompressContentStreams = false
+            })
+            .Columns(columns => columns.Paragraph(paragraph => paragraph
+                .Text("KeepLine01").LineBreak()
+                .Text("KeepLine02").LineBreak()
+                .Text("KeepLine03").LineBreak()
+                .Text("KeepLine04").LineBreak()
+                .Text("KeepLine05").LineBreak()
+                .Text("KeepLine06").LineBreak()
+                .Text("KeepLine07").LineBreak()
+                .Text("KeepLine08")), new PdfMultiColumnOptions {
+                    ColumnCount = 2,
+                    Gap = 20,
+                    BalanceLastPage = true,
+                    BalanceParagraphLines = true
+                })
+            .ToBytes();
+
+        string raw = PdfEncoding.Latin1GetString(bytes);
+        PdfReadDocument read = PdfReadDocument.Load(bytes);
+
+        Assert.Single(read.Pages);
+        Assert.Contains("KeepLine01", read.ExtractText(), StringComparison.Ordinal);
+        Assert.Contains("KeepLine08", read.ExtractText(), StringComparison.Ordinal);
+        Assert.Contains("1 0 0 1 40 ", raw, StringComparison.Ordinal);
+        Assert.DoesNotContain("1 0 0 1 220 ", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Columns_BalancedRichLinesPreserveSpaceBeforeInlineElements() {
         byte[] bytes = PdfDocument.Create(new PdfOptions {
                 PageWidth = 420,

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfContainerAndColumnTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfContainerAndColumnTests.cs
@@ -50,8 +50,94 @@ public class PdfContainerAndColumnTests {
     }
 
     [Fact]
+    public void Container_PaginatesAndDecoratesEveryPageFragment() {
+        PdfDocument document = PdfDocument.Create(new PdfOptions {
+            PageWidth = 260,
+            PageHeight = 180,
+            MarginLeft = 20,
+            MarginRight = 20,
+            MarginTop = 20,
+            MarginBottom = 20,
+            DefaultFontSize = 10,
+            CompressContentStreams = false
+        });
+
+        document.Container(content => {
+            for (int index = 1; index <= 24; index++) {
+                int marker = index;
+                content.Paragraph(paragraph => paragraph.Text("Decorated fragment line " + marker));
+            }
+        }, new PanelStyle {
+            Background = new PdfColor(0.9D, 0.95D, 1D),
+            BorderColor = new PdfColor(0.1D, 0.2D, 0.4D),
+            BorderWidth = 1.5D,
+            PaddingX = 8D,
+            PaddingY = 6D,
+            KeepTogether = false
+        });
+
+        byte[] bytes = document.ToBytes();
+        PdfReadDocument read = PdfReadDocument.Load(bytes);
+        string raw = PdfEncoding.Latin1GetString(bytes);
+
+        Assert.True(read.Pages.Count >= 2);
+        Assert.Contains("Decorated fragment line 1", read.ExtractText(), StringComparison.Ordinal);
+        Assert.Contains("Decorated fragment line 24", read.ExtractText(), StringComparison.Ordinal);
+        Assert.True(CountOccurrences(raw, "0.9 0.95 1 rg") >= read.Pages.Count);
+        Assert.True(CountOccurrences(raw, "1.5 w") >= read.Pages.Count);
+    }
+
+    [Fact]
     public void Container_RejectsUnsupportedNestedPageBreak() {
         PdfDocument document = PdfDocument.Create().Container(content => content.PageBreak());
         Assert.Throws<NotSupportedException>(() => document.ToBytes());
+    }
+
+    [Fact]
+    public void Columns_BalancesOneLongParagraphAtWrappedLineBoundaries() {
+        byte[] bytes = PdfDocument.Create(new PdfOptions {
+                PageWidth = 420,
+                PageHeight = 300,
+                MarginLeft = 40,
+                MarginRight = 40,
+                MarginTop = 40,
+                MarginBottom = 40,
+                DefaultFontSize = 10,
+                CompressContentStreams = false
+            })
+            .Columns(columns => columns.Paragraph(paragraph => paragraph
+                .Text("ColumnLine01").LineBreak()
+                .Text("ColumnLine02").LineBreak()
+                .Text("ColumnLine03").LineBreak()
+                .Text("ColumnLine04").LineBreak()
+                .Text("ColumnLine05").LineBreak()
+                .Text("ColumnLine06").LineBreak()
+                .Text("ColumnLine07").LineBreak()
+                .Text("ColumnLine08")), new PdfMultiColumnOptions {
+                    ColumnCount = 2,
+                    Gap = 20,
+                    BalanceLastPage = true,
+                    BalanceParagraphLines = true
+                })
+            .ToBytes();
+
+        string raw = PdfEncoding.Latin1GetString(bytes);
+        PdfReadDocument read = PdfReadDocument.Load(bytes);
+        Assert.Single(read.Pages);
+        Assert.Contains("ColumnLine01", read.ExtractText(), StringComparison.Ordinal);
+        Assert.Contains("ColumnLine08", read.ExtractText(), StringComparison.Ordinal);
+        Assert.Contains("1 0 0 1 40 ", raw, StringComparison.Ordinal);
+        Assert.Contains("1 0 0 1 220 ", raw, StringComparison.Ordinal);
+    }
+
+    private static int CountOccurrences(string value, string token) {
+        int count = 0;
+        int offset = 0;
+        while ((offset = value.IndexOf(token, offset, StringComparison.Ordinal)) >= 0) {
+            count++;
+            offset += token.Length;
+        }
+
+        return count;
     }
 }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfContainerAndColumnTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfContainerAndColumnTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using OfficeIMO.Pdf;
 using Xunit;
 
@@ -165,6 +166,46 @@ public class PdfContainerAndColumnTests {
             Assert.Contains(marker, text, StringComparison.Ordinal);
             Assert.DoesNotContain(marker.Replace(" ", string.Empty), text, StringComparison.Ordinal);
         }
+    }
+
+    [Fact]
+    public void Columns_BalancedJustifiedParagraphPreservesSoftWrapJustification() {
+        byte[] bytes = PdfDocument.Create(new PdfOptions {
+                PageWidth = 420,
+                PageHeight = 300,
+                MarginLeft = 40,
+                MarginRight = 40,
+                MarginTop = 40,
+                MarginBottom = 40,
+                DefaultFontSize = 10,
+                CompressContentStreams = false
+            })
+            .Columns(columns => columns.Paragraph(paragraph => paragraph.Text(
+                "Alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima mike november oscar papa quebec romeo sierra tango uniform victor whiskey xray yankee zulu " +
+                "amber bronze copper denim emerald fuchsia garnet hazel ivory jade khaki lilac magenta navy ochre peach quartz ruby silver teal umber violet wheat yellow zinc"),
+                align: PdfAlign.Justify), new PdfMultiColumnOptions {
+                    ColumnCount = 2,
+                    Gap = 20,
+                    BalanceLastPage = true,
+                    BalanceParagraphLines = true
+                })
+            .ToBytes();
+
+        string raw = PdfEncoding.Latin1GetString(bytes);
+        double[] wordSpacings = raw
+            .Split('\n')
+            .Select(line => line.Trim())
+            .Where(line => line.EndsWith(" Tw", StringComparison.Ordinal))
+            .Select(line => double.TryParse(
+                line.Substring(0, line.Length - 3),
+                NumberStyles.Float,
+                CultureInfo.InvariantCulture,
+                out double spacing) ? spacing : 0D)
+            .ToArray();
+
+        Assert.Contains(wordSpacings, spacing => spacing > 0.001D);
+        Assert.Contains("1 0 0 1 40 ", raw, StringComparison.Ordinal);
+        Assert.Contains("1 0 0 1 220 ", raw, StringComparison.Ordinal);
     }
 
     private static int CountOccurrences(string value, string token) {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfConversionScenarioManifestTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfConversionScenarioManifestTests.cs
@@ -664,15 +664,17 @@ public sealed class PdfConversionScenarioManifestTests {
         Assert.DoesNotContain(report.Warnings, warning => warning.Code == "unsupported-complex-script-shaping");
         Assert.DoesNotContain(report.Warnings, warning => warning.Code == "unsupported-bidirectional-text-layout");
         Assert.Contains("006600660069", raw, StringComparison.Ordinal);
-        PdfCore.PdfConversionWarning cffWarning = Assert.Single(report.Warnings, warning => warning.Code == "opentype-cff-charstrings-not-subset");
-        Assert.True(
-            int.Parse(cffWarning.Details["embeddedFontFileLength"], System.Globalization.CultureInfo.InvariantCulture) <
-            int.Parse(cffWarning.Details["fontFileLength"], System.Globalization.CultureInfo.InvariantCulture));
-        Assert.Equal("true", cffWarning.Details["cffCharstringsRetained"]);
-        Assert.Equal(cffWarning.Details["glyphCount"], cffWarning.Details["retainedCffGlyphCount"]);
-        Assert.True(int.Parse(cffWarning.Details["unusedCffGlyphCount"], System.Globalization.CultureInfo.InvariantCulture) > 0);
-        Assert.Contains("GSUB", cffWarning.Details["openTypeTablesRemoved"], StringComparison.Ordinal);
-        Assert.Contains("GPOS", cffWarning.Details["openTypeLayoutTablesRemoved"], StringComparison.Ordinal);
+        Assert.DoesNotContain(report.Warnings, warning => warning.Code == "opentype-cff-charstrings-not-subset");
+        Assert.True(options.TryGetEmbeddedStandardOpenTypeCffFontProgram(PdfCore.PdfStandardFont.TimesRoman, out PdfCore.PdfOpenTypeCffFontProgram? cffProgram));
+        Assert.NotNull(cffProgram);
+        PdfCore.PdfOpenTypeCffCompactFontFile cffPlan = cffProgram!.BuildCompactOpenTypeFontFilePlan();
+        PdfCore.PdfCffCharStringSubset cffSubset = Assert.IsType<PdfCore.PdfCffCharStringSubset>(cffPlan.CharStringSubset);
+        Assert.True(cffPlan.Data.Length < cffBytes.Length);
+        Assert.True(cffSubset.IsSubset);
+        Assert.True(cffSubset.PrunedGlyphCount > 0);
+        Assert.True(cffSubset.SubsetProgramBytes < cffSubset.OriginalProgramBytes);
+        Assert.Contains("GSUB", cffPlan.RemovedTables, StringComparer.Ordinal);
+        Assert.Contains("GPOS", cffPlan.RemovedLayoutTables, StringComparer.Ordinal);
 
         var summary = new {
             scenario = "pdf-provider-shaped-text",
@@ -682,18 +684,20 @@ public sealed class PdfConversionScenarioManifestTests {
             extractedMarkers = new[] { complexText, "office" },
             suppressedWarnings = new[] { "unsupported-complex-script-shaping", "unsupported-bidirectional-text-layout" },
             cffLigatureMappedToUnicode = raw.Contains("006600660069", StringComparison.Ordinal),
-            cffCharstringsSubset = cffWarning.Details["cffCharstringsSubset"],
-            cffCharstringsRetained = cffWarning.Details["cffCharstringsRetained"],
+            cffCharstringsSubset = cffSubset.IsSubset,
+            cffCharstringsRetained = false,
             compactCffEmbedding = new {
-                originalFontFileLength = cffWarning.Details["fontFileLength"],
-                embeddedFontFileLength = cffWarning.Details["embeddedFontFileLength"],
-                cffTableLength = cffWarning.Details["cffTableLength"],
-                retainedCffGlyphCount = cffWarning.Details["retainedCffGlyphCount"],
-                usedGlyphCount = cffWarning.Details["usedGlyphCount"],
-                unusedCffGlyphCount = cffWarning.Details["unusedCffGlyphCount"],
-                openTypeTablesEmbedded = cffWarning.Details["openTypeTablesEmbedded"],
-                openTypeTablesRemoved = cffWarning.Details["openTypeTablesRemoved"],
-                openTypeLayoutTablesRemoved = cffWarning.Details["openTypeLayoutTablesRemoved"]
+                originalFontFileLength = cffBytes.Length,
+                embeddedFontFileLength = cffPlan.Data.Length,
+                cffTableLength = cffProgram.CffTableLength,
+                retainedCffGlyphCount = cffSubset.RetainedGlyphCount,
+                usedGlyphCount = cffProgram.GetUsedGlyphIds().Count,
+                unusedCffGlyphCount = cffSubset.PrunedGlyphCount,
+                originalCharStringBytes = cffSubset.OriginalProgramBytes,
+                subsetCharStringBytes = cffSubset.SubsetProgramBytes,
+                openTypeTablesEmbedded = cffPlan.EmbeddedTables,
+                openTypeTablesRemoved = cffPlan.RemovedTables,
+                openTypeLayoutTablesRemoved = cffPlan.RemovedLayoutTables
             },
             warningCodes = report.Warnings.Select(warning => warning.Code).Distinct(StringComparer.Ordinal).ToArray()
         };

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentTextAnnotationDebugTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentTextAnnotationDebugTests.cs
@@ -62,7 +62,7 @@ public partial class PdfDocumentVisualQualityTests {
         Assert.Equal(2, CountOccurrences(pdf, "/OfficeIMOHighlightGs gs"));
         Assert.Equal(2, CountOccurrences(pdf, "/BM /Multiply"));
         Assert.Equal(2, CountOccurrences(pdf, "/ca 0.35"));
-        Assert.True(CountOccurrences(pdf, "BT /Helv") >= 4);
+        Assert.True(CountOccurrences(pdf, "BT\n/Helv") >= 4);
         Assert.Contains("/Subtype /Form /BBox [0 0 140 44]", pdf, StringComparison.Ordinal);
         Assert.Contains("/Subtype /Form /BBox [0 0 120 12]", pdf, StringComparison.Ordinal);
         Assert.Contains("/Open true", pdf, StringComparison.Ordinal);
@@ -130,7 +130,7 @@ public partial class PdfDocumentVisualQualityTests {
         Assert.Contains("/Ann1 Do", pdf, StringComparison.Ordinal);
         Assert.Contains("/Ann2 Do", pdf, StringComparison.Ordinal);
         Assert.Contains("/Subtype /Form /BBox [0 0 140 44]", pdf, StringComparison.Ordinal);
-        Assert.Contains("BT /Helv", pdf, StringComparison.Ordinal);
+        Assert.Contains("BT\n/Helv", pdf, StringComparison.Ordinal);
         Assert.Contains("/OfficeIMOHighlightGs gs", pdf, StringComparison.Ordinal);
         Assert.Contains("/BM /Multiply", pdf, StringComparison.Ordinal);
         Assert.Contains("/ca 0.35", pdf, StringComparison.Ordinal);
@@ -174,7 +174,7 @@ public partial class PdfDocumentVisualQualityTests {
         Assert.Contains("/XObject << /OfficeIMOAnnot1 ", pdf, StringComparison.Ordinal);
         Assert.Contains("/OfficeIMOAnnot1 Do", pdf, StringComparison.Ordinal);
         Assert.Contains("/OfficeIMOAnnot2 Do", pdf, StringComparison.Ordinal);
-        Assert.Contains("BT /Helv", pdf, StringComparison.Ordinal);
+        Assert.Contains("BT\n/Helv", pdf, StringComparison.Ordinal);
         Assert.Contains("/OfficeIMOHighlightGs gs", pdf, StringComparison.Ordinal);
         Assert.Contains("/BM /Multiply", pdf, StringComparison.Ordinal);
         Assert.Contains("/ca 0.35", pdf, StringComparison.Ordinal);
@@ -209,7 +209,7 @@ public partial class PdfDocumentVisualQualityTests {
         Assert.DoesNotContain("/Subtype /FreeText", pdf, StringComparison.Ordinal);
         Assert.Contains("/XObject << /OfficeIMOAnnot1 ", pdf, StringComparison.Ordinal);
         Assert.Contains("/OfficeIMOAnnot1 Do", pdf, StringComparison.Ordinal);
-        Assert.Contains("BT /Helv", pdf, StringComparison.Ordinal);
+        Assert.Contains("BT\n/Helv", pdf, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentVisualQualityDocumentMetadataTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentVisualQualityDocumentMetadataTests.cs
@@ -610,16 +610,11 @@ public partial class PdfDocumentVisualQualityTests {
     }
 
     [Theory]
-    [InlineData(PdfComplianceProfile.PdfA2B, "PDF/A-2b", "output-intent validation", "veraPDF")]
     [InlineData(PdfComplianceProfile.PdfA2U, "PDF/A-2u", "Unicode text mapping", "veraPDF")]
     [InlineData(PdfComplianceProfile.PdfA2A, "PDF/A-2a", "tagged PDF structure tree", "alternate text")]
-    [InlineData(PdfComplianceProfile.PdfA3B, "PDF/A-3b", "embedded-font coverage", "veraPDF")]
     [InlineData(PdfComplianceProfile.PdfA3U, "PDF/A-3u", "Unicode text mapping", "veraPDF")]
     [InlineData(PdfComplianceProfile.PdfA3A, "PDF/A-3a", "tagged PDF structure tree", "alternate text")]
-    [InlineData(PdfComplianceProfile.PdfUa1, "PDF/UA-1", "role map and reading order", "alternate text")]
-    [InlineData(PdfComplianceProfile.FacturX, "Factur-X", "embedded EN 16931 XML invoice payload", "Mustang")]
-    [InlineData(PdfComplianceProfile.Zugferd, "ZUGFeRD", "associated-file and embedded-file catalog entries", "Mustang")]
-    public void ComplianceProfile_RejectsFormalProfilesUntilCertifiedGenerationExists(PdfComplianceProfile profile, string displayName, string requirement, string validator) {
+    public void ComplianceProfile_RejectsUnsupportedFormalProfiles(PdfComplianceProfile profile, string displayName, string requirement, string validator) {
         var exception = Assert.Throws<NotSupportedException>(() =>
             PdfDocument.Create()
                 .Compliance(profile)

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfExternalValidator.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfExternalValidator.cs
@@ -11,12 +11,14 @@ namespace OfficeIMO.Tests.Pdf;
 internal sealed class PdfExternalValidator {
     private const string RequireEnv = "OFFICEIMO_REQUIRE_PDF_COMPLIANCE_VALIDATORS";
     private readonly string[] _arguments;
+    private readonly string? _profile;
 
-    private PdfExternalValidator(string name, string? executablePath, string[] arguments, bool autoDetected) {
+    private PdfExternalValidator(string name, string? executablePath, string[] arguments, bool autoDetected, string? profile = null) {
         Name = name;
         ExecutablePath = executablePath;
         _arguments = arguments;
         AutoDetected = autoDetected;
+        _profile = profile;
     }
 
     internal string Name { get; }
@@ -31,13 +33,17 @@ internal sealed class PdfExternalValidator {
         Name + " was not configured, so external validation was not run." + Environment.NewLine +
         "Set OFFICEIMO_VERAPDF, OFFICEIMO_VERAPDF_PATH, OFFICEIMO_PDFUA_VALIDATOR, OFFICEIMO_PDFUA_VALIDATOR_PATH, OFFICEIMO_MUSTANG, or OFFICEIMO_MUSTANG_PATH as appropriate, or add the tool to PATH." + Environment.NewLine;
 
-    internal static PdfExternalValidator VeraPdf() {
+    internal static PdfExternalValidator VeraPdf(string flavor = "3b") {
+        if (string.IsNullOrWhiteSpace(flavor)) {
+            throw new ArgumentException("veraPDF validation flavor cannot be empty.", nameof(flavor));
+        }
+
         string? explicitPath = FirstNonEmpty(
             Environment.GetEnvironmentVariable("OFFICEIMO_VERAPDF"),
             Environment.GetEnvironmentVariable("OFFICEIMO_VERAPDF_PATH"));
         string? path = explicitPath ?? FindOnPath("verapdf", "verapdf.bat", "verapdf.exe");
-        string[] args = GetConfiguredArgs("OFFICEIMO_VERAPDF_ARGS", "-f", "3b", "{pdf}");
-        return new PdfExternalValidator("veraPDF", path, args, explicitPath == null && path != null);
+        string[] args = GetConfiguredArgs("OFFICEIMO_VERAPDF_ARGS", "-f", flavor, "{pdf}");
+        return new PdfExternalValidator("veraPDF", path, args, explicitPath == null && path != null, flavor);
     }
 
     internal static PdfExternalValidator PdfUa() {
@@ -86,7 +92,10 @@ internal sealed class PdfExternalValidator {
         string pdfPath = Path.Combine(workDir, fileName);
         try {
             File.WriteAllBytes(pdfPath, pdfBytes);
-            string arguments = string.Join(" ", _arguments.Select(argument => QuoteArgument(argument.Replace("{pdf}", pdfPath))));
+            string arguments = string.Join(" ", _arguments.Select(argument => QuoteArgument(
+                argument
+                    .Replace("{pdf}", pdfPath)
+                    .Replace("{profile}", _profile ?? string.Empty))));
             var startInfo = new ProcessStartInfo {
                 FileName = ExecutablePath!,
                 Arguments = arguments,
@@ -214,7 +223,7 @@ internal sealed class PdfExternalValidator {
             return "\"\"";
         }
 
-        if (argument.IndexOfAny(new[] { ' ', '\t', '"' }) < 0) {
+        if (argument.IndexOfAny(new[] { ' ', '\t', '"', '\\' }) < 0) {
             return argument;
         }
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfFontFamilyTests.cs
@@ -1364,25 +1364,7 @@ public class PdfFontFamilyTests {
         Assert.Contains("CFF Łódź A", extracted, StringComparison.Ordinal);
         Assert.DoesNotContain(report.Warnings, warning => warning.Code == "opentype-cff-font-output-not-enabled");
         Assert.DoesNotContain(report.Warnings, warning => warning.Code == "unsupported-opentype-cff-font");
-        PdfConversionWarning cffWarning = Assert.Single(report.Warnings, warning => warning.Code == "opentype-cff-charstrings-not-subset");
-        Assert.Equal("OfficeIMO.Tests", cffWarning.Converter);
-        Assert.Equal(PdfConversionWarningSeverity.Warning, cffWarning.Severity);
-        Assert.Equal(PdfLayoutDiagnosticKind.SimplifiedContent, cffWarning.LayoutDiagnostic!.Kind);
-        Assert.Equal("embedded-font:Helvetica", cffWarning.Source);
-        Assert.Equal("OpenType/CFF", cffWarning.Details["format"]);
-        Assert.Equal("OfficeIMOSourceSerifCFF", cffWarning.Details["fontName"]);
-        Assert.Equal("compact-opentype-cff", cffWarning.Details["embeddingMode"]);
-        Assert.Equal("true", cffWarning.Details["cffCharstringsRetained"]);
-        Assert.Equal("false", cffWarning.Details["cffCharstringsSubset"]);
-        Assert.Contains("CFF", cffWarning.Details["openTypeTablesEmbedded"], StringComparison.Ordinal);
-        Assert.Contains("GSUB", cffWarning.Details["openTypeTablesRemoved"], StringComparison.Ordinal);
-        Assert.Contains("GPOS", cffWarning.Details["openTypeLayoutTablesRemoved"], StringComparison.Ordinal);
-        Assert.Equal(cffWarning.Details["glyphCount"], cffWarning.Details["retainedCffGlyphCount"]);
-        Assert.True(int.Parse(cffWarning.Details["glyphCount"], CultureInfo.InvariantCulture) > int.Parse(cffWarning.Details["usedGlyphCount"], CultureInfo.InvariantCulture));
-        Assert.True(int.Parse(cffWarning.Details["unusedCffGlyphCount"], CultureInfo.InvariantCulture) > 0);
-        Assert.False(string.IsNullOrWhiteSpace(cffWarning.Details["usedGlyphIdsPreview"]));
-        Assert.True(int.Parse(cffWarning.Details["fontFileLength"], CultureInfo.InvariantCulture) > 0);
-        Assert.True(int.Parse(cffWarning.Details["cffTableLength"], CultureInfo.InvariantCulture) > 0);
+        Assert.DoesNotContain(report.Warnings, warning => warning.Code == "opentype-cff-charstrings-not-subset");
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfFormFillerFillAppearanceTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfFormFillerFillAppearanceTests.cs
@@ -295,24 +295,7 @@ public partial class PdfFormFillerTests {
         Assert.Contains("/ToUnicode", output, StringComparison.Ordinal);
         Assert.DoesNotContain("/FontFile2", output, StringComparison.Ordinal);
         Assert.DoesNotContain("/Subtype /Type1 /BaseFont /Helvetica", output, StringComparison.Ordinal);
-        PdfConversionWarning cffWarning = Assert.Single(report.Warnings, warning => warning.Code == "opentype-cff-charstrings-not-subset");
-        Assert.Equal("OfficeIMO.Tests", cffWarning.Converter);
-        Assert.Equal(PdfConversionWarningSeverity.Warning, cffWarning.Severity);
-        Assert.Equal(PdfLayoutDiagnosticKind.SimplifiedContent, cffWarning.LayoutDiagnostic!.Kind);
-        Assert.Equal("form field 'Name' appearance", cffWarning.Source);
-        Assert.Equal("OpenType/CFF", cffWarning.Details["format"]);
-        Assert.Equal("OfficeIMOFillCFFFont", cffWarning.Details["fontName"]);
-        Assert.Equal("compact-opentype-cff", cffWarning.Details["embeddingMode"]);
-        Assert.Equal("true", cffWarning.Details["cffCharstringsRetained"]);
-        Assert.Equal("false", cffWarning.Details["cffCharstringsSubset"]);
-        Assert.Contains("CFF", cffWarning.Details["openTypeTablesEmbedded"], StringComparison.Ordinal);
-        Assert.Contains("GSUB", cffWarning.Details["openTypeTablesRemoved"], StringComparison.Ordinal);
-        Assert.Contains("GPOS", cffWarning.Details["openTypeLayoutTablesRemoved"], StringComparison.Ordinal);
-        Assert.Equal(cffWarning.Details["glyphCount"], cffWarning.Details["retainedCffGlyphCount"]);
-        Assert.True(int.Parse(cffWarning.Details["glyphCount"], CultureInfo.InvariantCulture) > int.Parse(cffWarning.Details["usedGlyphCount"], CultureInfo.InvariantCulture));
-        Assert.True(int.Parse(cffWarning.Details["unusedCffGlyphCount"], CultureInfo.InvariantCulture) > 0);
-        Assert.True(int.Parse(cffWarning.Details["fontFileLength"], CultureInfo.InvariantCulture) > 0);
-        Assert.True(int.Parse(cffWarning.Details["cffTableLength"], CultureInfo.InvariantCulture) > 0);
+        Assert.DoesNotContain(report.Warnings, warning => warning.Code == "opentype-cff-charstrings-not-subset");
     }
 
     [Fact]
@@ -481,24 +464,7 @@ public partial class PdfFormFillerTests {
         Assert.Contains("/Subtype /OpenType", output, StringComparison.Ordinal);
         Assert.DoesNotContain("/FontFile2", output, StringComparison.Ordinal);
         Assert.DoesNotContain("/Subtype /Type1 /BaseFont /Helvetica", output, StringComparison.Ordinal);
-        PdfConversionWarning cffWarning = Assert.Single(report.Warnings, warning => warning.Code == "opentype-cff-charstrings-not-subset");
-        Assert.Equal("OfficeIMO.Tests", cffWarning.Converter);
-        Assert.Equal(PdfConversionWarningSeverity.Warning, cffWarning.Severity);
-        Assert.Equal(PdfLayoutDiagnosticKind.SimplifiedContent, cffWarning.LayoutDiagnostic!.Kind);
-        Assert.Equal("form field 'Name' appearance", cffWarning.Source);
-        Assert.Equal("OpenType/CFF", cffWarning.Details["format"]);
-        Assert.Equal("FallbackFillCFFFont", cffWarning.Details["fontName"]);
-        Assert.Equal("compact-opentype-cff", cffWarning.Details["embeddingMode"]);
-        Assert.Equal("true", cffWarning.Details["cffCharstringsRetained"]);
-        Assert.Equal("false", cffWarning.Details["cffCharstringsSubset"]);
-        Assert.Contains("CFF", cffWarning.Details["openTypeTablesEmbedded"], StringComparison.Ordinal);
-        Assert.Contains("GSUB", cffWarning.Details["openTypeTablesRemoved"], StringComparison.Ordinal);
-        Assert.Contains("GPOS", cffWarning.Details["openTypeLayoutTablesRemoved"], StringComparison.Ordinal);
-        Assert.Equal(cffWarning.Details["glyphCount"], cffWarning.Details["retainedCffGlyphCount"]);
-        Assert.True(int.Parse(cffWarning.Details["glyphCount"], CultureInfo.InvariantCulture) > int.Parse(cffWarning.Details["usedGlyphCount"], CultureInfo.InvariantCulture));
-        Assert.True(int.Parse(cffWarning.Details["unusedCffGlyphCount"], CultureInfo.InvariantCulture) > 0);
-        Assert.True(int.Parse(cffWarning.Details["fontFileLength"], CultureInfo.InvariantCulture) > 0);
-        Assert.True(int.Parse(cffWarning.Details["cffTableLength"], CultureInfo.InvariantCulture) > 0);
+        Assert.DoesNotContain(report.Warnings, warning => warning.Code == "opentype-cff-charstrings-not-subset");
     }
 
     [Fact]
@@ -993,7 +959,7 @@ endbfchar
         Assert.Equal("U+0066", ligature.Details["codePoint"]);
         Assert.Equal("OpenType GPOS mark", mark.Details["script"]);
         Assert.Equal("U+0301", mark.Details["codePoint"]);
-        Assert.Contains(report.Warnings, warning => warning.Code == "opentype-cff-charstrings-not-subset");
+        Assert.DoesNotContain(report.Warnings, warning => warning.Code == "opentype-cff-charstrings-not-subset");
     }
 
     private static byte[] BuildEmbeddedUnicodeTextFieldPdfWithResourceName(string value, string resourceName) {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfInlineElementTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfInlineElementTests.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
 using OfficeIMO.Pdf;
 using Xunit;
 
@@ -77,5 +79,117 @@ public class PdfInlineElementTests {
         ArgumentException exception = Assert.Throws<ArgumentException>(() => document.ToBytes());
 
         Assert.Contains("Inline element width", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RichParagraph_DecorativeInlineImageDrawsOnceAsArtifact() {
+        byte[] bytes = PdfDocument.Create(new PdfOptions {
+                CompressContentStreams = false,
+                TaggedStructureMode = PdfTaggedStructureMode.CatalogMarkers
+            })
+            .Paragraph(paragraph => paragraph
+                .Text("Before ")
+                .InlineImage(PdfPngTestImages.CreateRgbPng(2, 1), 24, 14)
+                .Text(" after"))
+            .ToBytes();
+
+        string raw = PdfEncoding.Latin1GetString(bytes);
+
+        Assert.Single(PdfImageExtractor.ExtractImages(bytes));
+        Assert.Equal(1, CountOccurrences(raw, "/Im1 Do"));
+        Assert.Contains("/Artifact BMC", raw, StringComparison.Ordinal);
+        Assert.DoesNotContain("/Figure << /Alt", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RichParagraph_CentersInlineElementUsingItsWidth() {
+        var fill = new PdfColor(0.13D, 0.57D, 0.91D);
+        byte[] bytes = PdfDocument.Create(new PdfOptions {
+                PageWidth = 240,
+                MarginLeft = 20,
+                MarginRight = 20,
+                CompressContentStreams = false
+            })
+            .Paragraph(paragraph => paragraph.InlineBox(40, 12, background: fill), PdfAlign.Center)
+            .ToBytes();
+
+        double x = FindFilledBoxX(PdfEncoding.Latin1GetString(bytes), fill, 40, 12);
+
+        Assert.Equal(100D, x, 3);
+    }
+
+    [Fact]
+    public void RichParagraph_LeadingTabAdvancesInlineElementToNextTabStop() {
+        var fill = new PdfColor(0.17D, 0.61D, 0.83D);
+        byte[] bytes = PdfDocument.Create(new PdfOptions {
+                PageWidth = 240,
+                MarginLeft = 20,
+                MarginRight = 20,
+                CompressContentStreams = false
+            })
+            .Paragraph(paragraph => paragraph
+                .Tab()
+                .InlineBox(18, 12, background: fill))
+            .ToBytes();
+
+        double x = FindFilledBoxX(PdfEncoding.Latin1GetString(bytes), fill, 18, 12);
+
+        Assert.Equal(56D, x, 3);
+    }
+
+    [Fact]
+    public void TableShrinkToFit_PreservesInlineElementRuns() {
+        const string longValue = "ThisIdentifierShouldShrinkToFit";
+        var fill = new PdfColor(0.19D, 0.63D, 0.87D);
+        byte[] bytes = PdfDocument.Create(new PdfOptions {
+                CompressContentStreams = false
+            })
+            .Table(new[] {
+                new[] {
+                    PdfTableCell.RichTextCell(new[] {
+                        TextRun.Normal(longValue, fontSize: 30, font: PdfStandardFont.Courier),
+                        TextRun.Inline(new PdfInlineBox(12, 10, background: fill))
+                    })
+                }
+            }, style: new PdfTableStyle {
+                FontSize = 18,
+                MinimumShrinkFontSize = 7,
+                ShrinkTextToFit = true,
+                ColumnWidthPoints = new List<double?> { 108 }
+            })
+            .ToBytes();
+
+        string raw = PdfEncoding.Latin1GetString(bytes);
+        PdfDocument document = PdfDocument.Load(bytes);
+        IReadOnlyList<PdfLogicalTextBlock> blocks = document.Read.TextBlocks();
+        string compactText = document.Read.Text()
+            .Replace("\r", string.Empty)
+            .Replace("\n", string.Empty)
+            .Replace(" ", string.Empty);
+
+        Assert.Contains(longValue, compactText, StringComparison.Ordinal);
+        Assert.Contains(blocks, block => block.FontSize < 30D);
+        Assert.True(FindFilledBoxX(raw, fill, 12, 10) > 0D);
+    }
+
+    private static double FindFilledBoxX(string raw, PdfColor fill, double width, double height) {
+        string color = string.Join(" ", new[] { fill.R, fill.G, fill.B }.Select(value => value.ToString("0.###", CultureInfo.InvariantCulture))) + " rg";
+        string pattern = Regex.Escape(color) + @"\s+(?<x>-?\d+(?:\.\d+)?)\s+-?\d+(?:\.\d+)?\s+" +
+            Regex.Escape(width.ToString("0.###", CultureInfo.InvariantCulture)) + @"\s+" +
+            Regex.Escape(height.ToString("0.###", CultureInfo.InvariantCulture)) + @"\s+re\s+f";
+        Match match = Regex.Match(raw, pattern, RegexOptions.CultureInvariant);
+        Assert.True(match.Success, "Expected the inline box fill and rectangle in the generated content stream.");
+        return double.Parse(match.Groups["x"].Value, CultureInfo.InvariantCulture);
+    }
+
+    private static int CountOccurrences(string value, string token) {
+        int count = 0;
+        int offset = 0;
+        while ((offset = value.IndexOf(token, offset, StringComparison.Ordinal)) >= 0) {
+            count++;
+            offset += token.Length;
+        }
+
+        return count;
     }
 }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfInlineElementTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfInlineElementTests.cs
@@ -1,0 +1,81 @@
+using OfficeIMO.Pdf;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf;
+
+public class PdfInlineElementTests {
+    [Fact]
+    public void RichParagraph_RendersInlineImageAndBoxInContentOrderWithTags() {
+        byte[] bytes = PdfDocument.Create(new PdfOptions {
+                CompressContentStreams = false,
+                TaggedStructureMode = PdfTaggedStructureMode.CatalogMarkers
+            })
+            .Paragraph(paragraph => paragraph
+                .Text("Before ")
+                .InlineImage(PdfPngTestImages.CreateRgbPng(2, 1), 24, 14, "Inline status image")
+                .Text(" middle ")
+                .InlineBox(
+                    18,
+                    12,
+                    background: new PdfColor(0.2D, 0.7D, 0.3D),
+                    borderColor: PdfColor.Black,
+                    borderWidth: 1D,
+                    alternativeText: "Inline status box")
+                .Text(" after"))
+            .ToBytes();
+
+        string raw = PdfEncoding.Latin1GetString(bytes);
+        string text = PdfReadDocument.Load(bytes).ExtractText();
+
+        Assert.Contains("Before", text, StringComparison.Ordinal);
+        Assert.Contains("middle", text, StringComparison.Ordinal);
+        Assert.Contains("after", text, StringComparison.Ordinal);
+        Assert.Single(PdfImageExtractor.ExtractImages(bytes));
+        Assert.Contains("/Figure << /Alt <496E6C696E652073746174757320696D616765>", raw, StringComparison.Ordinal);
+        Assert.Contains("/Figure << /Alt <496E6C696E652073746174757320626F78>", raw, StringComparison.Ordinal);
+        Assert.Contains("0.2 0.7 0.3 rg", raw, StringComparison.Ordinal);
+        Assert.Contains("1 w", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RichParagraph_InlineHeightAdvancesFollowingFlow() {
+        byte[] bytes = PdfDocument.Create(new PdfOptions {
+                PageWidth = 240,
+                PageHeight = 180,
+                MarginLeft = 20,
+                MarginRight = 20,
+                MarginTop = 20,
+                MarginBottom = 20,
+                DefaultFontSize = 10
+            })
+            .Paragraph(paragraph => paragraph.Text("Prior flow marker"))
+            .Paragraph(paragraph => paragraph
+                .Text("Tall inline start ")
+                .InlineBox(20, 34, background: new PdfColor(0.8D, 0.8D, 0.8D))
+                .Text(" end"))
+            .Paragraph(paragraph => paragraph.Text("Following flow marker"))
+            .ToBytes();
+
+        IReadOnlyList<PdfLogicalTextBlock> blocks = PdfDocument.Load(bytes).Read.TextBlocks();
+        PdfLogicalTextBlock prior = Assert.Single(blocks, block => block.Text.Contains("Prior flow marker", StringComparison.Ordinal));
+        PdfLogicalTextBlock first = Assert.Single(blocks, block => block.Text.Contains("Tall inline start", StringComparison.Ordinal));
+        PdfLogicalTextBlock following = Assert.Single(blocks, block => block.Text.Contains("Following flow marker", StringComparison.Ordinal));
+
+        Assert.True(prior.BaselineY - following.BaselineY >= 44D);
+        Assert.True(first.BaselineY > following.BaselineY);
+    }
+
+    [Fact]
+    public void RichParagraph_RejectsInlineElementWiderThanItsFrame() {
+        PdfDocument document = PdfDocument.Create(new PdfOptions {
+                PageWidth = 160,
+                MarginLeft = 30,
+                MarginRight = 30
+            })
+            .Paragraph(paragraph => paragraph.InlineBox(101, 12));
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(() => document.ToBytes());
+
+        Assert.Contains("Inline element width", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfMergerTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfMergerTests.cs
@@ -87,7 +87,7 @@ public class PdfMergerTests {
         Assert.DoesNotContain("/Subtype /Highlight", pdf, StringComparison.Ordinal);
         Assert.Contains("/OfficeIMOAnnot1 Do", pdf, StringComparison.Ordinal);
         Assert.Contains("/OfficeIMOAnnot2 Do", pdf, StringComparison.Ordinal);
-        Assert.Contains("BT /Helv", pdf, StringComparison.Ordinal);
+        Assert.Contains("BT\n/Helv", pdf, StringComparison.Ordinal);
         Assert.Contains("1 0.9 0.1 rg 0 0 120 14 re f", pdf, StringComparison.Ordinal);
 
         string text = NormalizeExtractedText(PdfReadDocument.Load(merged).ExtractText());

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfOpenTypeCffCompactEmbeddingTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfOpenTypeCffCompactEmbeddingTests.cs
@@ -17,11 +17,20 @@ public class PdfOpenTypeCffCompactEmbeddingTests {
 
         byte[] full = File.ReadAllBytes(fontPath!);
         PdfOpenTypeCffFontProgram program = PdfOpenTypeCffFontProgram.Parse(full, "OfficeIMO Source Serif CFF");
-        byte[] compact = program.BuildCompactOpenTypeFontFile();
+        program.EncodeTextAsGlyphHex("Subset CFF Łódź");
+        PdfOpenTypeCffCompactFontFile plan = program.BuildCompactOpenTypeFontFilePlan();
+        byte[] compact = plan.Data;
         PdfOpenTypeFontInfo compactInfo = PdfOpenTypeFontInspector.Inspect(compact, "OfficeIMO Source Serif CFF");
         IReadOnlyList<string> compactTables = ReadTableTags(compact);
+        PdfCffCharStringSubset subset = Assert.IsType<PdfCffCharStringSubset>(plan.CharStringSubset);
 
         Assert.True(compact.Length < full.Length);
+        Assert.True(subset.IsSubset);
+        Assert.True(subset.PrunedGlyphCount > 1000);
+        Assert.True(subset.RetainedGlyphCount > 1);
+        Assert.Equal(compactInfo.GlyphCount, subset.GlyphCount);
+        Assert.True(subset.SubsetProgramBytes < subset.OriginalProgramBytes);
+        Assert.True(subset.SubsetIndexBytes < subset.OriginalIndexBytes);
         Assert.True(compactInfo.IsOpenTypeCff);
         Assert.True(compactInfo.GlyphCount > 1000);
         Assert.True(compactInfo.CffTableLength > 1000);
@@ -56,25 +65,12 @@ public class PdfOpenTypeCffCompactEmbeddingTests {
         string raw = Encoding.ASCII.GetString(bytes);
         string extracted = PdfReadDocument.Load(bytes).ExtractText();
         int embeddedLength = Assert.Single(ExtractLength1Values(raw));
-        PdfConversionWarning warning = Assert.Single(report.Warnings, item => item.Code == "opentype-cff-charstrings-not-subset");
 
         Assert.Contains("Compact CFF Łódź", extracted, StringComparison.Ordinal);
         Assert.Contains("/FontFile3", raw, StringComparison.Ordinal);
         Assert.Contains("/Subtype /OpenType", raw, StringComparison.Ordinal);
         Assert.InRange(embeddedLength, 1, fontData.Length - 1);
-        Assert.Contains("charstrings are still kept intact", warning.Message, StringComparison.Ordinal);
-        Assert.Equal(fontData.Length.ToString(CultureInfo.InvariantCulture), warning.Details["fontFileLength"]);
-        Assert.Equal(embeddedLength.ToString(CultureInfo.InvariantCulture), warning.Details["embeddedFontFileLength"]);
-        Assert.Equal("compact-opentype-cff", warning.Details["embeddingMode"]);
-        Assert.Equal("true", warning.Details["cffCharstringsRetained"]);
-        Assert.Equal("false", warning.Details["openTypeLayoutTablesEmbedded"]);
-        Assert.Contains("CFF", warning.Details["openTypeTablesEmbedded"], StringComparison.Ordinal);
-        Assert.Contains("GSUB", warning.Details["openTypeTablesRemoved"], StringComparison.Ordinal);
-        Assert.Contains("GPOS", warning.Details["openTypeLayoutTablesRemoved"], StringComparison.Ordinal);
-        Assert.Equal("false", warning.Details["cffCharstringsSubset"]);
-        Assert.Equal(warning.Details["glyphCount"], warning.Details["retainedCffGlyphCount"]);
-        Assert.True(int.Parse(warning.Details["unusedCffGlyphCount"], CultureInfo.InvariantCulture) > 0);
-        Assert.False(string.IsNullOrWhiteSpace(warning.Details["usedGlyphIdsPreview"]));
+        Assert.DoesNotContain(report.Warnings, item => item.Code == "opentype-cff-charstrings-not-subset");
     }
 
     private static IReadOnlyList<string> ReadTableTags(byte[] fontData) {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfTextShapingProviderTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfTextShapingProviderTests.cs
@@ -30,6 +30,7 @@ public class PdfTextShapingProviderTests {
             }
             .ReportDiagnosticsTo(report, "OfficeIMO.Tests")
             .EmbedStandardFont(PdfStandardFont.Helvetica, fontData, "OfficeIMO Provider Font")
+            .SetLanguage("ar-SA")
             .SetTextShapingProvider(provider);
 
         byte[] bytes = PdfDocument.Create(options)
@@ -39,6 +40,10 @@ public class PdfTextShapingProviderTests {
         string extracted = PdfReadDocument.Load(bytes).ExtractText();
 
         Assert.True(provider.CallCount >= 1);
+        Assert.NotNull(provider.LastRequest);
+        Assert.Equal(PdfTextDirection.RightToLeft, provider.LastRequest!.Direction);
+        Assert.Equal("ar-SA", provider.LastRequest.Language);
+        Assert.Equal(fontProgram.UnitsPerEm, provider.LastRequest.UnitsPerEm);
         Assert.Contains(text, extracted, StringComparison.Ordinal);
         Assert.DoesNotContain(report.Warnings, warning => warning.Code == "unsupported-complex-script-shaping");
         Assert.DoesNotContain(report.Warnings, warning => warning.Code == "unsupported-bidirectional-text-layout");
@@ -195,6 +200,53 @@ public class PdfTextShapingProviderTests {
         Assert.Contains("<" + ffiGlyphId.ToString("X4", CultureInfo.InvariantCulture) + "> <006600660069>", raw, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void TextShapingProvider_WritesDesignUnitAdvancesOffsetsAndLogicalActualText() {
+        string? fontPath = PdfComplianceTestFonts.FindLocalTrueTypeFont();
+        if (fontPath == null) {
+            return;
+        }
+
+        byte[] fontData = File.ReadAllBytes(fontPath);
+        PdfTrueTypeFontProgram fontProgram = PdfTrueTypeFontProgram.Parse(fontData, "OfficeIMO Positioned Provider Font");
+        Assert.True(fontProgram.TryGetGlyphId('A', out int aGlyphId));
+        Assert.True(fontProgram.TryGetGlyphId('B', out int bGlyphId));
+        int halfEm = fontProgram.UnitsPerEm / 2;
+        int offsetX = -(fontProgram.UnitsPerEm / 10);
+        int offsetY = fontProgram.UnitsPerEm / 5;
+        var provider = new MappingTextShapingProvider(
+            "AB",
+            isOpenTypeCff: false,
+            new[] {
+                new PdfShapedGlyph(aGlyphId, "A", 0, halfEm),
+                new PdfShapedGlyph(bGlyphId, "B", 1, halfEm, offsetX, offsetY)
+            });
+        var options = new PdfOptions {
+                CompressContentStreams = false
+            }
+            .EmbedStandardFont(PdfStandardFont.Helvetica, fontData, "OfficeIMO Positioned Provider Font")
+            .SetLanguage("en-US")
+            .SetTextShapingProvider(provider);
+
+        byte[] bytes = PdfDocument.Create(options)
+            .Paragraph(paragraph => paragraph.Text("AB"))
+            .ToBytes();
+
+        string raw = Encoding.ASCII.GetString(bytes);
+        string extracted = PdfReadDocument.Load(bytes).ExtractText();
+        double measured = fontProgram.MeasureTextWidth("AB", 12D, shapingProvider: provider, language: "en-US");
+
+        Assert.Equal(12D * (halfEm + halfEm) / fontProgram.UnitsPerEm, measured, precision: 6);
+        Assert.Contains("AB", extracted, StringComparison.Ordinal);
+        Assert.Contains(" TJ", raw, StringComparison.Ordinal);
+        Assert.Contains(" Ts", raw, StringComparison.Ordinal);
+        Assert.Contains("/ActualText", raw, StringComparison.Ordinal);
+        Assert.NotNull(provider.LastRequest);
+        Assert.Equal(PdfTextDirection.LeftToRight, provider.LastRequest!.Direction);
+        Assert.Equal("en-US", provider.LastRequest.Language);
+        Assert.Equal(fontProgram.UnitsPerEm, provider.LastRequest.UnitsPerEm);
+    }
+
     private static IReadOnlyList<PdfShapedGlyph> CreateGlyphMap(string text, PdfTrueTypeFontProgram fontProgram) {
         var glyphs = new List<PdfShapedGlyph>();
         for (int index = 0; index < text.Length;) {
@@ -229,6 +281,8 @@ public class PdfTextShapingProviderTests {
 
         public int CallCount { get; private set; }
 
+        public PdfTextShapingRequest? LastRequest { get; private set; }
+
         public PdfTextShapingResult? ShapeText(PdfTextShapingRequest request) {
             if (!string.Equals(request.Text, _text, StringComparison.Ordinal)) {
                 return null;
@@ -238,6 +292,7 @@ public class PdfTextShapingProviderTests {
             Assert.NotEmpty(request.FontData);
             Assert.False(string.IsNullOrWhiteSpace(request.FontName));
             CallCount++;
+            LastRequest = request;
             return new PdfTextShapingResult(_glyphs);
         }
     }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfTextShapingProviderTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfTextShapingProviderTests.cs
@@ -247,6 +247,50 @@ public class PdfTextShapingProviderTests {
         Assert.Equal(fontProgram.UnitsPerEm, provider.LastRequest.UnitsPerEm);
     }
 
+    [Fact]
+    public void TextShapingProvider_PreservesSuperscriptRiseAroundPositionedGlyphs() {
+        string? fontPath = PdfComplianceTestFonts.FindBundledOpenTypeCffFont();
+        Assert.NotNull(fontPath);
+
+        byte[] fontData = File.ReadAllBytes(fontPath!);
+        PdfOpenTypeCffFontProgram fontProgram = PdfOpenTypeCffFontProgram.Parse(fontData, "OfficeIMO Positioned Superscript Font");
+        Assert.True(fontProgram.TryGetGlyphId('A', out int aGlyphId));
+        Assert.True(fontProgram.TryGetGlyphId('B', out int bGlyphId));
+        int offsetY = fontProgram.UnitsPerEm / 5;
+        var provider = new MappingTextShapingProvider(
+            "AB",
+            isOpenTypeCff: true,
+            new[] {
+                new PdfShapedGlyph(aGlyphId, "A", 0, fontProgram.UnitsPerEm),
+                new PdfShapedGlyph(bGlyphId, "B", 1, fontProgram.UnitsPerEm, 0, offsetY)
+            });
+        var options = new PdfOptions {
+                CompressContentStreams = false,
+                DefaultFontSize = 12D
+            }
+            .EmbedStandardFont(PdfStandardFont.Helvetica, fontData, "OfficeIMO Positioned Superscript Font")
+            .SetTextShapingProvider(provider);
+
+        byte[] bytes = PdfDocument.Create(options)
+            .Paragraph(paragraph => paragraph.Superscript("AB").Text("C"))
+            .ToBytes();
+
+        string raw = Encoding.ASCII.GetString(bytes);
+        const double baseRise = 12D * 0.35D;
+        const double runFontSize = 12D * 0.65D;
+        int offsetY1000 = checked((int)Math.Round(offsetY * 1000D / fontProgram.UnitsPerEm, MidpointRounding.AwayFromZero));
+        double positionedRise = baseRise + offsetY1000 * runFontSize / 1000D;
+        string baseRiseOperator = baseRise.ToString("0.###", CultureInfo.InvariantCulture) + " Ts";
+        string positionedRiseOperator = positionedRise.ToString("0.###", CultureInfo.InvariantCulture) + " Ts";
+        int positionedRiseIndex = raw.IndexOf(positionedRiseOperator, StringComparison.Ordinal);
+        int restoredBaseRiseIndex = raw.IndexOf(baseRiseOperator, positionedRiseIndex + positionedRiseOperator.Length, StringComparison.Ordinal);
+        int normalRiseIndex = raw.IndexOf("0 Ts", restoredBaseRiseIndex + baseRiseOperator.Length, StringComparison.Ordinal);
+
+        Assert.True(positionedRiseIndex >= 0, "Expected the shaped glyph offset to be added to the superscript rise.");
+        Assert.True(restoredBaseRiseIndex > positionedRiseIndex, "Expected the superscript rise to be restored after positioned glyphs.");
+        Assert.True(normalRiseIndex > restoredBaseRiseIndex, "Expected normal text to reset the restored superscript rise.");
+    }
+
     private static IReadOnlyList<PdfShapedGlyph> CreateGlyphMap(string text, PdfTrueTypeFontProgram fontProgram) {
         var glyphs = new List<PdfShapedGlyph>();
         for (int index = 0; index < text.Length;) {

--- a/OfficeIMO.Pdf.Tests/Pdf/RichParagraphWrappingHyphenationTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/RichParagraphWrappingHyphenationTests.cs
@@ -7,6 +7,42 @@ namespace OfficeIMO.Tests.Pdf;
 
 public class RichParagraphWrappingHyphenationTests {
     [Fact]
+    public void HyphenationDictionary_NormalizesEntriesAndHonorsPrefixSuffixLimits() {
+        var dictionary = new PdfHyphenationLexicon(new[] {
+            "ty-pog-ra-phy",
+            "TYPOG-RAPHY"
+        }, minimumPrefixLength: 2, minimumSuffixLength: 2);
+
+        Assert.Equal(1, dictionary.Count);
+        Assert.True(dictionary.Contains("Typography"));
+        Assert.Equal(new[] { 2, 5, 7 }, dictionary.GetBreakpoints("typography"));
+        Assert.Throws<ArgumentException>(() => new PdfHyphenationLexicon(new[] { "-invalid" }));
+        Assert.Throws<ArgumentException>(() => new PdfHyphenationLexicon(new[] { "a-b" }, minimumPrefixLength: 2));
+    }
+
+    [Fact]
+    public void GeneratedText_UsesFirstPartyHyphenationDictionary() {
+        var dictionary = new PdfHyphenationLexicon(new[] { "typog-ra-phy-mile-stone" });
+
+        byte[] bytes = PdfDocument.Create(new PdfOptions {
+                PageWidth = 118,
+                PageHeight = 180,
+                MarginLeft = 18,
+                MarginRight = 18,
+                MarginTop = 24,
+                MarginBottom = 24,
+                CompressContentStreams = false
+            })
+            .TextHyphenationDictionary(dictionary)
+            .Paragraph(paragraph => paragraph.Text("typographymilestone"))
+            .ToBytes();
+
+        string extracted = PdfReadDocument.Load(bytes).ExtractText();
+        Assert.Contains("typographymile-", extracted, StringComparison.Ordinal);
+        Assert.Contains("stone", extracted, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void PdfOptions_ClonePreservesTextHyphenationCallback() {
         PdfTextHyphenationCallback callback = token => token == "typographymilestone"
             ? new[] { 10 }

--- a/OfficeIMO.Pdf/Compliance/PdfArtifactFingerprint.cs
+++ b/OfficeIMO.Pdf/Compliance/PdfArtifactFingerprint.cs
@@ -1,0 +1,39 @@
+using System.Security.Cryptography;
+
+namespace OfficeIMO.Pdf;
+
+internal static class PdfArtifactFingerprint {
+    internal static string ComputeSha256(byte[] artifact) {
+        Guard.NotNull(artifact, nameof(artifact));
+        byte[] hash;
+#if NET6_0_OR_GREATER
+        hash = SHA256.HashData(artifact);
+#else
+        using (SHA256 sha256 = SHA256.Create()) {
+            hash = sha256.ComputeHash(artifact);
+        }
+#endif
+        {
+            var builder = new System.Text.StringBuilder(hash.Length * 2);
+            for (int i = 0; i < hash.Length; i++) {
+                builder.Append(hash[i].ToString("x2", System.Globalization.CultureInfo.InvariantCulture));
+            }
+
+            return builder.ToString();
+        }
+    }
+
+    internal static string? NormalizeSha256(string? value, string paramName) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        string normalized = value!.Trim().ToLowerInvariant();
+        if (normalized.Length != 64 || normalized.Any(static ch =>
+                !char.IsDigit(ch) && (ch < 'a' || ch > 'f'))) {
+            throw new System.ArgumentException("Artifact SHA-256 must contain exactly 64 hexadecimal characters.", paramName);
+        }
+
+        return normalized;
+    }
+}

--- a/OfficeIMO.Pdf/Compliance/PdfComplianceAnalyzer.Proof.cs
+++ b/OfficeIMO.Pdf/Compliance/PdfComplianceAnalyzer.Proof.cs
@@ -25,6 +25,14 @@ public static partial class PdfComplianceAnalyzer {
     }
 
     /// <summary>
+    /// Combines readiness diagnostics, exact PDF artifact identity, generated-font evidence, and external validator evidence.
+    /// </summary>
+    public static PdfComplianceProofReport AssessProof(PdfComplianceProfile profile, PdfOptions options, byte[] artifact, IEnumerable<PdfExternalValidationResult>? externalValidations, IEnumerable<PdfStandardFont>? generatedStandardFonts) {
+        PdfComplianceReadinessReport readiness = Assess(profile, options, generatedStandardFonts);
+        return AssessProof(readiness, artifact, externalValidations);
+    }
+
+    /// <summary>
     /// Combines an existing readiness report with external validator evidence.
     /// </summary>
     public static PdfComplianceProofReport AssessProof(PdfComplianceReadinessReport readiness, IEnumerable<PdfExternalValidationResult>? externalValidations = null) {
@@ -35,6 +43,35 @@ public static partial class PdfComplianceAnalyzer {
             readiness,
             GetRequiredExternalValidators(readiness.Profile),
             validationSnapshot);
+    }
+
+    /// <summary>
+    /// Combines an existing readiness report with exact PDF artifact identity and external validator evidence.
+    /// </summary>
+    public static PdfComplianceProofReport AssessProof(PdfComplianceReadinessReport readiness, byte[] artifact, IEnumerable<PdfExternalValidationResult>? externalValidations = null) {
+        Guard.NotNull(readiness, nameof(readiness));
+        Guard.NotNull(artifact, nameof(artifact));
+
+        PdfComplianceReadinessReport artifactReadiness = AssessReadback(readiness.Profile, artifact);
+        PdfComplianceReadinessReport combinedReadiness = CombineReadiness(readiness, artifactReadiness);
+        PdfExternalValidationResult[] validationSnapshot = SnapshotExternalValidations(externalValidations);
+        return new PdfComplianceProofReport(
+            combinedReadiness,
+            GetRequiredExternalValidators(combinedReadiness.Profile),
+            validationSnapshot,
+            PdfArtifactFingerprint.ComputeSha256(artifact),
+            artifact.LongLength);
+    }
+
+    private static PdfComplianceReadinessReport CombineReadiness(PdfComplianceReadinessReport generated, PdfComplianceReadinessReport artifact) {
+        if (generated.Profile != artifact.Profile) {
+            throw new System.ArgumentException("Generated and artifact readiness reports must target the same compliance profile.", nameof(artifact));
+        }
+
+        var requirements = new List<PdfComplianceRequirement>(generated.Requirements.Count + artifact.Requirements.Count);
+        requirements.AddRange(generated.Requirements);
+        requirements.AddRange(artifact.Requirements);
+        return new PdfComplianceReadinessReport(generated.Profile, generated.DisplayName, requirements.AsReadOnly());
     }
 
     private static PdfExternalValidationResult[] SnapshotExternalValidations(IEnumerable<PdfExternalValidationResult>? externalValidations) {

--- a/OfficeIMO.Pdf/Compliance/PdfComplianceAnalyzer.Readback.cs
+++ b/OfficeIMO.Pdf/Compliance/PdfComplianceAnalyzer.Readback.cs
@@ -227,11 +227,16 @@ public static partial class PdfComplianceAnalyzer {
             "The saved PDF contains " + (tagged?.MarkedContentReferenceCount ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture) + " structure-tree marked-content reference(s).",
             "The saved PDF structure tree must contain marked-content references that connect structure elements to page content.");
 
-        requirements.Add(new PdfComplianceRequirement(
-            "tagged-structure",
-            "Tagged PDF structure tree",
-            PdfComplianceRequirementStatus.Unsupported,
-            "OfficeIMO.Pdf readback can verify tagged groundwork markers, but full external PDF/UA/PDF/A-a structure validation is still required before claiming conformance."));
+        bool hasReadableStructureEvidence = tagged?.Marked == true &&
+            tagged.StructTreeRootObjectNumber.HasValue &&
+            tagged.ParentTreeNextKey.HasValue &&
+            hasDocumentElement &&
+            tagged.StructureElementCount > 0 &&
+            tagged.MarkedContentReferenceCount > 0;
+        Add(requirements, "readback-tagged-structure-evidence", "Readback tagged-structure evidence",
+            hasReadableStructureEvidence,
+            "The saved PDF exposes a marked catalog, structure root, parent tree, document element, structure elements, and marked-content references for exact-artifact validation.",
+            "The saved PDF must expose a marked catalog, structure root, parent tree, document element, structure elements, and marked-content references before external PDF/UA validation.");
     }
 
     private static void AddElectronicInvoiceReadbackRequirements(List<PdfComplianceRequirement> requirements, PdfDocumentInfo info, IReadOnlyList<PdfExtractedAttachment>? extractedAttachments) {

--- a/OfficeIMO.Pdf/Compliance/PdfComplianceProofReport.cs
+++ b/OfficeIMO.Pdf/Compliance/PdfComplianceProofReport.cs
@@ -10,7 +10,9 @@ public sealed class PdfComplianceProofReport {
     internal PdfComplianceProofReport(
         PdfComplianceReadinessReport readiness,
         IReadOnlyList<PdfExternalValidatorKind> requiredExternalValidators,
-        IReadOnlyList<PdfExternalValidationResult> externalValidations) {
+        IReadOnlyList<PdfExternalValidationResult> externalValidations,
+        string? artifactSha256 = null,
+        long? artifactSizeBytes = null) {
         Guard.NotNull(readiness, nameof(readiness));
         Guard.NotNull(requiredExternalValidators, nameof(requiredExternalValidators));
         Guard.NotNull(externalValidations, nameof(externalValidations));
@@ -18,6 +20,8 @@ public sealed class PdfComplianceProofReport {
         Readiness = readiness;
         _requiredExternalValidators = requiredExternalValidators;
         _externalValidations = externalValidations;
+        ArtifactSha256 = PdfArtifactFingerprint.NormalizeSha256(artifactSha256, nameof(artifactSha256));
+        ArtifactSizeBytes = artifactSizeBytes;
     }
 
     /// <summary>Requested compliance profile.</summary>
@@ -34,6 +38,15 @@ public sealed class PdfComplianceProofReport {
 
     /// <summary>Caller-supplied external validation results.</summary>
     public IReadOnlyList<PdfExternalValidationResult> ExternalValidations => _externalValidations;
+
+    /// <summary>SHA-256 of the exact PDF artifact represented by this proof report.</summary>
+    public string? ArtifactSha256 { get; }
+
+    /// <summary>Size of the exact PDF artifact represented by this proof report, in bytes.</summary>
+    public long? ArtifactSizeBytes { get; }
+
+    /// <summary>True when the report represents one exact PDF artifact.</summary>
+    public bool HasArtifactEvidence => ArtifactSha256 != null && ArtifactSizeBytes.HasValue;
 
     /// <summary>One machine-readable proof row for each external validator family required by the requested profile.</summary>
     public IReadOnlyList<PdfExternalValidatorProof> ExternalValidatorProofs {
@@ -82,6 +95,7 @@ public sealed class PdfComplianceProofReport {
     /// <summary>True only when internal readiness is satisfied, every required external validator passed, and no required validator failed.</summary>
     public bool CanClaimConformance =>
         Profile != PdfComplianceProfile.None &&
+        HasArtifactEvidence &&
         IsInternallyReady &&
         HasRequiredExternalValidation &&
         FailedExternalValidations.Count == 0;
@@ -89,6 +103,7 @@ public sealed class PdfComplianceProofReport {
     /// <summary>True when OfficeIMO.Pdf readiness is complete and the remaining proof work is external validation.</summary>
     public bool ReadyForExternalValidation =>
         Profile != PdfComplianceProfile.None &&
+        HasArtifactEvidence &&
         IsInternallyReady &&
         RequiresExternalValidation &&
         !HasRequiredExternalValidation &&
@@ -109,7 +124,7 @@ public sealed class PdfComplianceProofReport {
     /// <summary>True when the profile requires external validation before conformance can be claimed.</summary>
     public bool RequiresExternalValidation => RequiredExternalValidatorCount > 0;
 
-    /// <summary>Stable proof state for automation: None, InternalGaps, MissingExternalValidation, ExternalValidationFailed, or Claimable.</summary>
+    /// <summary>Stable proof state for automation: None, InternalGaps, MissingArtifactEvidence, MissingExternalValidation, ExternalValidationFailed, or Claimable.</summary>
     public string ProofStatus {
         get {
             if (Profile == PdfComplianceProfile.None) {
@@ -118,6 +133,10 @@ public sealed class PdfComplianceProofReport {
 
             if (!IsInternallyReady) {
                 return "InternalGaps";
+            }
+
+            if (!HasArtifactEvidence) {
+                return "MissingArtifactEvidence";
             }
 
             if (FailedExternalValidationCount > 0) {
@@ -173,7 +192,8 @@ public sealed class PdfComplianceProofReport {
             for (int i = 0; i < _externalValidations.Count; i++) {
                 PdfExternalValidationResult result = _externalValidations[i];
                 if (!_requiredExternalValidators.Contains(result.ValidatorKind) ||
-                    !IsExternalValidationForRequestedProfile(result)) {
+                    !IsExternalValidationForRequestedProfile(result) ||
+                    !IsExternalValidationForArtifact(result)) {
                     continue;
                 }
 
@@ -192,7 +212,8 @@ public sealed class PdfComplianceProofReport {
         for (int i = 0; i < _externalValidations.Count; i++) {
             PdfExternalValidationResult result = _externalValidations[i];
             if (result.ValidatorKind == validatorKind &&
-                IsExternalValidationForRequestedProfile(result)) {
+                IsExternalValidationForRequestedProfile(result) &&
+                IsExternalValidationForArtifact(result)) {
                 return result;
             }
         }
@@ -221,6 +242,7 @@ public sealed class PdfComplianceProofReport {
             PdfExternalValidationResult result = _externalValidations[i];
             if (result.ValidatorKind == validatorKind &&
                 IsExternalValidationForRequestedProfile(result) &&
+                IsExternalValidationForArtifact(result) &&
                 result.Status == PdfExternalValidationStatus.Passed) {
                 return true;
             }
@@ -234,7 +256,8 @@ public sealed class PdfComplianceProofReport {
         for (int i = 0; i < _externalValidations.Count; i++) {
             PdfExternalValidationResult result = _externalValidations[i];
             if (result.ValidatorKind == validatorKind &&
-                IsExternalValidationForRequestedProfile(result)) {
+                IsExternalValidationForRequestedProfile(result) &&
+                IsExternalValidationForArtifact(result)) {
                 matches.Add(result);
             }
         }
@@ -248,6 +271,7 @@ public sealed class PdfComplianceProofReport {
             PdfExternalValidationResult result = _externalValidations[i];
             if (_requiredExternalValidators.Contains(result.ValidatorKind) &&
                 IsExternalValidationForRequestedProfile(result) &&
+                IsExternalValidationForArtifact(result) &&
                 result.Status == status) {
                 count++;
             }
@@ -261,6 +285,7 @@ public sealed class PdfComplianceProofReport {
             PdfExternalValidationResult result = _externalValidations[i];
             if (result.ValidatorKind == validatorKind &&
                 IsExternalValidationForRequestedProfile(result) &&
+                IsExternalValidationForArtifact(result) &&
                 (result.Status == PdfExternalValidationStatus.Failed ||
                  result.Status == PdfExternalValidationStatus.Error)) {
                 return true;
@@ -269,6 +294,12 @@ public sealed class PdfComplianceProofReport {
 
         return false;
     }
+
+    private bool IsExternalValidationForArtifact(PdfExternalValidationResult result) =>
+        HasArtifactEvidence &&
+        result.HasArtifactBinding &&
+        string.Equals(result.ArtifactSha256, ArtifactSha256, StringComparison.OrdinalIgnoreCase) &&
+        result.ArtifactSizeBytes == ArtifactSizeBytes;
 
     private bool IsExternalValidationForRequestedProfile(PdfExternalValidationResult result) {
         if (Profile == PdfComplianceProfile.None) {

--- a/OfficeIMO.Pdf/Compliance/PdfExternalValidationResult.cs
+++ b/OfficeIMO.Pdf/Compliance/PdfExternalValidationResult.cs
@@ -13,7 +13,12 @@ public sealed class PdfExternalValidationResult {
         string? profile = null,
         string? executablePath = null,
         string? arguments = null,
-        int? exitCode = null) {
+        int? exitCode = null,
+        string? validatorVersion = null,
+        string? artifactSha256 = null,
+        long? artifactSizeBytes = null,
+        System.DateTimeOffset? validatedAtUtc = null,
+        IEnumerable<string>? warnings = null) {
         ValidateValidatorKind(validatorKind, nameof(validatorKind));
         ValidateStatus(status, nameof(status));
         Guard.NotNullOrWhiteSpace(validatorName, nameof(validatorName));
@@ -27,6 +32,15 @@ public sealed class PdfExternalValidationResult {
         ExecutablePath = string.IsNullOrWhiteSpace(executablePath) ? null : executablePath;
         Arguments = string.IsNullOrWhiteSpace(arguments) ? null : arguments;
         ExitCode = exitCode;
+        ValidatorVersion = string.IsNullOrWhiteSpace(validatorVersion) ? null : validatorVersion!.Trim();
+        ArtifactSha256 = PdfArtifactFingerprint.NormalizeSha256(artifactSha256, nameof(artifactSha256));
+        if (artifactSizeBytes.HasValue && artifactSizeBytes.Value < 0) {
+            throw new System.ArgumentOutOfRangeException(nameof(artifactSizeBytes), "Artifact size cannot be negative.");
+        }
+
+        ArtifactSizeBytes = artifactSizeBytes;
+        ValidatedAtUtc = validatedAtUtc?.ToUniversalTime();
+        Warnings = SnapshotWarnings(warnings);
     }
 
     /// <summary>Validator family.</summary>
@@ -53,9 +67,57 @@ public sealed class PdfExternalValidationResult {
     /// <summary>Optional process exit code reported by CI or wrapper tooling.</summary>
     public int? ExitCode { get; }
 
+    /// <summary>Validator version reported by the proof runner.</summary>
+    public string? ValidatorVersion { get; }
+
+    /// <summary>Lowercase SHA-256 of the exact PDF bytes supplied to the validator.</summary>
+    public string? ArtifactSha256 { get; }
+
+    /// <summary>Size of the exact validated PDF artifact, in bytes.</summary>
+    public long? ArtifactSizeBytes { get; }
+
+    /// <summary>UTC timestamp recorded by the proof runner after validation.</summary>
+    public System.DateTimeOffset? ValidatedAtUtc { get; }
+
+    /// <summary>Warnings reported by the validator or proof runner.</summary>
+    public IReadOnlyList<string> Warnings { get; }
+
+    /// <summary>True when this result identifies an exact PDF artifact by SHA-256 and byte length.</summary>
+    public bool HasArtifactBinding => ArtifactSha256 != null && ArtifactSizeBytes.HasValue;
+
     /// <summary>Creates a passing validator result.</summary>
     public static PdfExternalValidationResult Passed(PdfExternalValidatorKind validatorKind, string validatorName, string diagnostic, string? profile = null) =>
         new(validatorKind, PdfExternalValidationStatus.Passed, validatorName, diagnostic, profile);
+
+    /// <summary>Creates a passing result bound to the exact supplied PDF bytes.</summary>
+    public static PdfExternalValidationResult PassedForArtifact(
+        PdfExternalValidatorKind validatorKind,
+        string validatorName,
+        string validatorVersion,
+        string diagnostic,
+        byte[] artifact,
+        string? profile = null,
+        IEnumerable<string>? warnings = null,
+        string? executablePath = null,
+        string? arguments = null,
+        int? exitCode = 0,
+        System.DateTimeOffset? validatedAtUtc = null) {
+        Guard.NotNull(artifact, nameof(artifact));
+        return new PdfExternalValidationResult(
+            validatorKind,
+            PdfExternalValidationStatus.Passed,
+            validatorName,
+            diagnostic,
+            profile,
+            executablePath,
+            arguments,
+            exitCode,
+            validatorVersion,
+            PdfArtifactFingerprint.ComputeSha256(artifact),
+            artifact.LongLength,
+            validatedAtUtc ?? System.DateTimeOffset.UtcNow,
+            warnings);
+    }
 
     /// <summary>Creates a failing validator result.</summary>
     public static PdfExternalValidationResult Failed(PdfExternalValidatorKind validatorKind, string validatorName, string diagnostic, string? profile = null, int? exitCode = null) =>
@@ -64,6 +126,30 @@ public sealed class PdfExternalValidationResult {
     /// <summary>Creates a not-run validator result.</summary>
     public static PdfExternalValidationResult NotRun(PdfExternalValidatorKind validatorKind, string validatorName, string diagnostic, string? profile = null) =>
         new(validatorKind, PdfExternalValidationStatus.NotRun, validatorName, diagnostic, profile);
+
+    /// <summary>Creates a not-run result associated with an intended exact PDF artifact.</summary>
+    public static PdfExternalValidationResult NotRunForArtifact(
+        PdfExternalValidatorKind validatorKind,
+        string validatorName,
+        string validatorVersion,
+        string diagnostic,
+        byte[] artifact,
+        string? profile = null,
+        IEnumerable<string>? warnings = null,
+        System.DateTimeOffset? recordedAtUtc = null) {
+        Guard.NotNull(artifact, nameof(artifact));
+        return new PdfExternalValidationResult(
+            validatorKind,
+            PdfExternalValidationStatus.NotRun,
+            validatorName,
+            diagnostic,
+            profile,
+            validatorVersion: validatorVersion,
+            artifactSha256: PdfArtifactFingerprint.ComputeSha256(artifact),
+            artifactSizeBytes: artifact.LongLength,
+            validatedAtUtc: recordedAtUtc ?? System.DateTimeOffset.UtcNow,
+            warnings: warnings);
+    }
 
     /// <summary>Creates a validator error result.</summary>
     public static PdfExternalValidationResult Error(PdfExternalValidatorKind validatorKind, string validatorName, string diagnostic, string? profile = null, int? exitCode = null) =>
@@ -88,6 +174,52 @@ public sealed class PdfExternalValidationResult {
             executablePath,
             arguments,
             exitCode);
+
+    /// <summary>Creates an exit-code result bound to the exact supplied PDF bytes.</summary>
+    public static PdfExternalValidationResult FromExitCodeForArtifact(
+        PdfExternalValidatorKind validatorKind,
+        int exitCode,
+        string validatorName,
+        string validatorVersion,
+        string diagnostic,
+        byte[] artifact,
+        string? profile = null,
+        string? executablePath = null,
+        string? arguments = null,
+        int successExitCode = 0,
+        IEnumerable<string>? warnings = null,
+        System.DateTimeOffset? validatedAtUtc = null) {
+        Guard.NotNull(artifact, nameof(artifact));
+        return new PdfExternalValidationResult(
+            validatorKind,
+            exitCode == successExitCode ? PdfExternalValidationStatus.Passed : PdfExternalValidationStatus.Failed,
+            validatorName,
+            diagnostic,
+            profile,
+            executablePath,
+            arguments,
+            exitCode,
+            validatorVersion,
+            PdfArtifactFingerprint.ComputeSha256(artifact),
+            artifact.LongLength,
+            validatedAtUtc ?? System.DateTimeOffset.UtcNow,
+            warnings);
+    }
+
+    private static IReadOnlyList<string> SnapshotWarnings(IEnumerable<string>? warnings) {
+        if (warnings == null) {
+            return Array.Empty<string>();
+        }
+
+        var snapshot = new List<string>();
+        foreach (string warning in warnings) {
+            if (!string.IsNullOrWhiteSpace(warning)) {
+                snapshot.Add(warning.Trim());
+            }
+        }
+
+        return snapshot.AsReadOnly();
+    }
 
     private static void ValidateValidatorKind(PdfExternalValidatorKind value, string paramName) {
         if (value != PdfExternalValidatorKind.VeraPdf &&

--- a/OfficeIMO.Pdf/Compliance/PdfExternalValidatorProof.cs
+++ b/OfficeIMO.Pdf/Compliance/PdfExternalValidatorProof.cs
@@ -80,6 +80,21 @@ public sealed class PdfExternalValidatorProof {
     /// <summary>Process exit code reported by the primary validation result, when supplied.</summary>
     public int? ExitCode => PrimaryValidation?.ExitCode;
 
+    /// <summary>Validator version from the primary validation result, when supplied.</summary>
+    public string? ValidatorVersion => PrimaryValidation?.ValidatorVersion;
+
+    /// <summary>SHA-256 of the exact validated PDF artifact, when supplied.</summary>
+    public string? ArtifactSha256 => PrimaryValidation?.ArtifactSha256;
+
+    /// <summary>Size of the exact validated PDF artifact, in bytes, when supplied.</summary>
+    public long? ArtifactSizeBytes => PrimaryValidation?.ArtifactSizeBytes;
+
+    /// <summary>UTC proof timestamp from the primary validation result, when supplied.</summary>
+    public System.DateTimeOffset? ValidatedAtUtc => PrimaryValidation?.ValidatedAtUtc;
+
+    /// <summary>Warnings from the primary validation result.</summary>
+    public IReadOnlyList<string> Warnings => PrimaryValidation?.Warnings ?? Array.Empty<string>();
+
     private PdfExternalValidationResult? Find(PdfExternalValidationStatus status) {
         for (int i = 0; i < Validations.Count; i++) {
             PdfExternalValidationResult validation = Validations[i];

--- a/OfficeIMO.Pdf/Compose/PdfPageCompose.cs
+++ b/OfficeIMO.Pdf/Compose/PdfPageCompose.cs
@@ -285,6 +285,8 @@ public class PdfPageCompose {
     public PdfPageCompose TextLineBreaks(PdfTextLineBreakCallback? callback) { Options.SetTextLineBreaks(callback); return this; }
     /// <summary>Sets or clears the page-scoped generated text hyphenation callback used for long unspaced tokens.</summary>
     public PdfPageCompose TextHyphenation(PdfTextHyphenationCallback? callback) { Options.SetTextHyphenation(callback); return this; }
+    /// <summary>Uses or clears an immutable first-party word hyphenation dictionary.</summary>
+    public PdfPageCompose TextHyphenationDictionary(PdfHyphenationLexicon? dictionary) { Options.UseTextHyphenationDictionary(dictionary); return this; }
     /// <summary>Configures default text style for the page.</summary>
     public PdfPageCompose DefaultTextStyle(System.Action<PdfTextStyleCompose> style) { Guard.NotNull(style, nameof(style)); var s = new PdfTextStyleCompose(Options); style(s); return this; }
     /// <summary>Configures default text style for the page from a reusable text style object.</summary>

--- a/OfficeIMO.Pdf/Core/PdfDocument.Blocks.Setup.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocument.Blocks.Setup.cs
@@ -365,6 +365,12 @@ public sealed partial class PdfDocument {
         return this;
     }
 
+    /// <summary>Uses or clears an immutable first-party word hyphenation dictionary.</summary>
+    public PdfDocument TextHyphenationDictionary(PdfHyphenationLexicon? dictionary) {
+        _options.UseTextHyphenationDictionary(dictionary);
+        return this;
+    }
+
     /// <summary>Sets or clears the generated text line-break callback used for long unspaced tokens.</summary>
     public PdfDocument TextLineBreaks(PdfTextLineBreakCallback? callback) {
         _options.SetTextLineBreaks(callback);

--- a/OfficeIMO.Pdf/Core/PdfDocument.IO.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocument.IO.cs
@@ -24,6 +24,12 @@ public sealed partial class PdfDocument {
         AssessComplianceProof(_options.ComplianceProfile, externalValidations);
 
     /// <summary>
+    /// Combines generated-document readiness with external validator evidence bound to the exact supplied PDF bytes.
+    /// </summary>
+    public PdfComplianceProofReport AssessComplianceProof(byte[] artifact, IEnumerable<PdfExternalValidationResult>? externalValidations = null) =>
+        AssessComplianceProof(_options.ComplianceProfile, artifact, externalValidations);
+
+    /// <summary>
     /// Combines generated-document compliance readiness for a formal profile with external validator evidence.
     /// </summary>
     /// <param name="profile">Compliance profile to assess without enabling formal profile generation.</param>
@@ -31,6 +37,17 @@ public sealed partial class PdfDocument {
     public PdfComplianceProofReport AssessComplianceProof(PdfComplianceProfile profile, IEnumerable<PdfExternalValidationResult>? externalValidations = null) {
         PdfComplianceReadinessReport readiness = AssessCompliance(profile);
         return PdfComplianceAnalyzer.AssessProof(readiness, externalValidations);
+    }
+
+    /// <summary>
+    /// Combines generated-document readiness with external validator evidence bound to the exact supplied PDF bytes.
+    /// </summary>
+    /// <param name="profile">Compliance profile to assess without enabling formal profile generation.</param>
+    /// <param name="artifact">The exact PDF bytes supplied to each external validator.</param>
+    /// <param name="externalValidations">External validator results for the same exact artifact.</param>
+    public PdfComplianceProofReport AssessComplianceProof(PdfComplianceProfile profile, byte[] artifact, IEnumerable<PdfExternalValidationResult>? externalValidations = null) {
+        PdfComplianceReadinessReport readiness = AssessCompliance(profile);
+        return PdfComplianceAnalyzer.AssessProof(readiness, artifact, externalValidations);
     }
 
     /// <summary>

--- a/OfficeIMO.Pdf/Enums/PdfTextDirection.cs
+++ b/OfficeIMO.Pdf/Enums/PdfTextDirection.cs
@@ -1,0 +1,11 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>Base direction supplied to a host-owned PDF text shaping provider.</summary>
+public enum PdfTextDirection {
+    /// <summary>No strong directional character was found; the provider may resolve direction from its own context.</summary>
+    Auto = 0,
+    /// <summary>The first strong character establishes a left-to-right base direction.</summary>
+    LeftToRight = 1,
+    /// <summary>The first strong character establishes a right-to-left base direction.</summary>
+    RightToLeft = 2
+}

--- a/OfficeIMO.Pdf/Manipulation/PdfIncrementalObjectWriter.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfIncrementalObjectWriter.cs
@@ -252,7 +252,7 @@ internal static class PdfIncrementalObjectWriter {
         return PdfSyntaxEscaper.IndirectReference(objectNumber, generation);
     }
 
-    private static string ReadTrailerIdEntry(string trailerRaw) {
+    internal static string ReadTrailerIdEntry(string trailerRaw) {
         int nameIndex = IndexOfName(trailerRaw, "ID");
         if (nameIndex < 0) {
             return string.Empty;

--- a/OfficeIMO.Pdf/Manipulation/PdfLinearizationFileAssembler.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfLinearizationFileAssembler.cs
@@ -10,7 +10,8 @@ internal static class PdfLinearizationFileAssembler {
         Dictionary<int, PdfIndirectObject> objects,
         int catalogObjectNumber,
         PdfMetadata metadata,
-        byte[] sourcePdf) {
+        byte[] sourcePdf,
+        string trailerIdEntry) {
         PdfLinearizationPlan plan = PdfLinearizationPlanner.Create(objects, catalogObjectNumber);
         Numbering numbering = CreateNumbering(plan);
         SerializedObjects serialized = Serialize(objects, metadata, plan, numbering);
@@ -26,7 +27,8 @@ internal static class PdfLinearizationFileAssembler {
             numbering.TotalObjectCount + 1,
             0,
             numbering.CatalogObjectId,
-            numbering.InfoObjectId);
+            numbering.InfoObjectId,
+            trailerIdEntry);
 
         long linearizationOffset = header.LongLength;
         long firstXrefOffset = linearizationOffset + placeholderLinearization.LongLength;
@@ -62,7 +64,7 @@ internal static class PdfLinearizationFileAssembler {
         objectOffsets[numbering.InfoObjectId] = position;
         position += serialized.Info.LongLength;
         long mainXrefOffset = position;
-        byte[] mainXref = BuildMainXref(numbering.FirstGroupStart, objectOffsets, firstXrefOffset);
+        byte[] mainXref = BuildMainXref(numbering.FirstGroupStart, objectOffsets, firstXrefOffset, trailerIdEntry);
         long fileLength = mainXrefOffset + mainXref.LongLength;
         long mainXrefFirstEntryOffset = mainXrefOffset + (
             "xref\n0 " + numbering.FirstGroupStart.ToString(CultureInfo.InvariantCulture) + "\n").Length;
@@ -83,7 +85,8 @@ internal static class PdfLinearizationFileAssembler {
             numbering.TotalObjectCount + 1,
             mainXrefOffset,
             numbering.CatalogObjectId,
-            numbering.InfoObjectId);
+            numbering.InfoObjectId,
+            trailerIdEntry);
         if (linearization.Length != placeholderLinearization.Length || firstXref.Length != placeholderFirstXref.Length) {
             throw new InvalidOperationException("Linearized PDF fixed-width planning changed between assembly passes.");
         }
@@ -294,7 +297,8 @@ internal static class PdfLinearizationFileAssembler {
         int totalSize,
         long mainXrefOffset,
         int catalogObjectId,
-        int infoObjectId) {
+        int infoObjectId,
+        string trailerIdEntry) {
         var builder = new StringBuilder();
         builder.Append("xref\n").Append(firstGroupStart.ToString(CultureInfo.InvariantCulture)).Append(' ')
             .Append(firstGroupCount.ToString(CultureInfo.InvariantCulture)).Append('\n');
@@ -307,11 +311,12 @@ internal static class PdfLinearizationFileAssembler {
             .Append(" /Prev ").Append(Fixed(mainXrefOffset))
             .Append(" /Root ").Append(PdfSyntaxEscaper.IndirectReference(catalogObjectId))
             .Append(" /Info ").Append(PdfSyntaxEscaper.IndirectReference(infoObjectId))
+            .Append(trailerIdEntry)
             .Append(" >>\nstartxref\n0\n%%EOF\n");
         return PdfEncoding.Latin1GetBytes(builder.ToString());
     }
 
-    private static byte[] BuildMainXref(int firstGroupStart, Dictionary<int, long> offsets, long firstXrefOffset) {
+    private static byte[] BuildMainXref(int firstGroupStart, Dictionary<int, long> offsets, long firstXrefOffset, string trailerIdEntry) {
         var builder = new StringBuilder();
         builder.Append("xref\n0 ").Append(firstGroupStart.ToString(CultureInfo.InvariantCulture)).Append('\n');
         AppendXrefEntry(builder, 0, inUse: false);
@@ -320,6 +325,7 @@ internal static class PdfLinearizationFileAssembler {
             AppendXrefEntry(builder, offset, inUse: true);
         }
         builder.Append("trailer\n<< /Size ").Append(firstGroupStart.ToString(CultureInfo.InvariantCulture))
+            .Append(trailerIdEntry)
             .Append(" >>\nstartxref\n").Append(firstXrefOffset.ToString(CultureInfo.InvariantCulture)).Append("\n%%EOF\n");
         return PdfEncoding.Latin1GetBytes(builder.ToString());
     }

--- a/OfficeIMO.Pdf/Manipulation/PdfOptimizationFileAssembler.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfOptimizationFileAssembler.cs
@@ -7,17 +7,17 @@ namespace OfficeIMO.Pdf;
 internal static class PdfOptimizationFileAssembler {
     private const int ObjectStreamChunkSize = 100;
 
-    internal static byte[] Assemble(IReadOnlyList<byte[]> bodies, IReadOnlyList<bool> objectStreamEligibility, int catalogId, int infoId, PdfFileVersion fileVersion, PdfOptimizationOptions options) {
+    internal static byte[] Assemble(IReadOnlyList<byte[]> bodies, IReadOnlyList<bool> objectStreamEligibility, int catalogId, int infoId, PdfFileVersion fileVersion, PdfOptimizationOptions options, string trailerIdEntry) {
         if (bodies.Count != objectStreamEligibility.Count) throw new ArgumentException("Object body and eligibility counts must match.", nameof(objectStreamEligibility));
         if (!options.UseObjectStreams && options.XrefFormat == PdfOptimizationXrefFormat.ClassicTable) {
             var objects = new List<byte[]>(bodies.Count);
             for (int i = 0; i < bodies.Count; i++) objects.Add(PdfObjectBytes.WrapIndirectObject(i + 1, bodies[i]));
-            return PdfFileAssembler.Assemble(objects, catalogId, infoId, fileVersion);
+            return PdfFileAssembler.Assemble(objects, catalogId, infoId, fileVersion, trailerIdEntry: trailerIdEntry);
         }
-        return AssembleXrefStream(bodies, objectStreamEligibility, catalogId, infoId, fileVersion, options.UseObjectStreams);
+        return AssembleXrefStream(bodies, objectStreamEligibility, catalogId, infoId, fileVersion, options.UseObjectStreams, trailerIdEntry);
     }
 
-    private static byte[] AssembleXrefStream(IReadOnlyList<byte[]> bodies, IReadOnlyList<bool> eligibility, int catalogId, int infoId, PdfFileVersion fileVersion, bool useObjectStreams) {
+    private static byte[] AssembleXrefStream(IReadOnlyList<byte[]> bodies, IReadOnlyList<bool> eligibility, int catalogId, int infoId, PdfFileVersion fileVersion, bool useObjectStreams, string trailerIdEntry) {
         fileVersion = PdfFileAssembler.RequireAtLeast(fileVersion, PdfFileVersion.Pdf15);
         var packs = BuildObjectStreamPacks(bodies, eligibility, useObjectStreams);
         int baseCount = bodies.Count;
@@ -43,7 +43,7 @@ internal static class PdfOptimizationFileAssembler {
         }
         long xrefOffset = output.Position; types[xrefObjectNumber] = 1; field2[xrefObjectNumber] = xrefOffset;
         byte[] xrefData = BuildXrefData(types, field2, field3);
-        string xrefDictionary = "<< /Type /XRef /Size " + size.ToString(CultureInfo.InvariantCulture) + " /W [1 8 4] /Root " + PdfSyntaxEscaper.IndirectReference(catalogId) + (infoId > 0 ? " /Info " + PdfSyntaxEscaper.IndirectReference(infoId) : string.Empty) + " /Length " + xrefData.Length.ToString(CultureInfo.InvariantCulture) + " >>";
+        string xrefDictionary = "<< /Type /XRef /Size " + size.ToString(CultureInfo.InvariantCulture) + " /W [1 8 4] /Root " + PdfSyntaxEscaper.IndirectReference(catalogId) + (infoId > 0 ? " /Info " + PdfSyntaxEscaper.IndirectReference(infoId) : string.Empty) + trailerIdEntry + " /Length " + xrefData.Length.ToString(CultureInfo.InvariantCulture) + " >>";
         Write(output, PdfObjectBytes.WrapStreamObject(xrefObjectNumber, xrefDictionary, xrefData));
         Write(output, PdfEncoding.Latin1GetBytes("startxref\n" + xrefOffset.ToString(CultureInfo.InvariantCulture) + "\n%%EOF\n"));
         return output.ToArray();

--- a/OfficeIMO.Pdf/Manipulation/PdfOptimizer.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfOptimizer.cs
@@ -53,7 +53,13 @@ public static partial class PdfOptimizer {
             RemoveUnreferencedObjects(optimizedObjects, catalogObjectNumber, actions);
         }
 
-        byte[] candidate = RewriteAllObjects(optimizedObjects, catalogObjectNumber, PdfReadDocument.Load(pdf).Metadata, pdf, effectiveOptions);
+        byte[] candidate = RewriteAllObjects(
+            optimizedObjects,
+            catalogObjectNumber,
+            PdfReadDocument.Load(pdf).Metadata,
+            pdf,
+            PdfIncrementalObjectWriter.ReadTrailerIdEntry(trailerRaw),
+            effectiveOptions);
         if (effectiveOptions.Linearize) actions.Add(new PdfOptimizationAction("Linearize", 0, pdf.LongLength, candidate.LongLength, "Reordered the document into two cross-reference sections with page and shared-object hint tables for Fast Web View."));
         if (effectiveOptions.UseObjectStreams) actions.Add(new PdfOptimizationAction("PackObjectStreams", 0, 0, 0, "Packed eligible non-stream objects into PDF 1.5 object streams."));
         if (effectiveOptions.XrefFormat == PdfOptimizationXrefFormat.XrefStream) actions.Add(new PdfOptimizationAction("WriteXrefStream", 0, 0, 0, "Emitted a PDF 1.5 cross-reference stream."));
@@ -331,9 +337,9 @@ public static partial class PdfOptimizer {
         }
     }
 
-    private static byte[] RewriteAllObjects(Dictionary<int, PdfIndirectObject> objects, int catalogObjectNumber, PdfMetadata metadata, byte[] sourcePdf, PdfOptimizationOptions options) {
+    private static byte[] RewriteAllObjects(Dictionary<int, PdfIndirectObject> objects, int catalogObjectNumber, PdfMetadata metadata, byte[] sourcePdf, string trailerIdEntry, PdfOptimizationOptions options) {
         if (options.Linearize) {
-            return PdfLinearizationFileAssembler.Assemble(objects, catalogObjectNumber, metadata, sourcePdf);
+            return PdfLinearizationFileAssembler.Assemble(objects, catalogObjectNumber, metadata, sourcePdf, trailerIdEntry);
         }
 
         int[] sourceIds = objects.Keys.OrderBy(static id => id).ToArray();
@@ -355,7 +361,7 @@ public static partial class PdfOptimizer {
         objectStreamEligibility.Add(false);
 
         PdfFileVersion fileVersion = PdfFileAssembler.ParseHeaderVersionOrDefault(PdfSyntax.GetHeaderVersion(sourcePdf));
-        return PdfOptimizationFileAssembler.Assemble(bodies, objectStreamEligibility, numberMap[catalogObjectNumber], infoId, fileVersion, options);
+        return PdfOptimizationFileAssembler.Assemble(bodies, objectStreamEligibility, numberMap[catalogObjectNumber], infoId, fileVersion, options, trailerIdEntry);
     }
 
     private static void RemoveUnreferencedObjects(

--- a/OfficeIMO.Pdf/Model/PdfFontDiagnostics.cs
+++ b/OfficeIMO.Pdf/Model/PdfFontDiagnostics.cs
@@ -69,6 +69,11 @@ public static class PdfFontDiagnostics {
         Guard.NotNull(font, nameof(font));
         Guard.NotNull(compactFontFile, nameof(compactFontFile));
         IReadOnlyList<int> usedGlyphIds = font.GetUsedGlyphIds();
+        PdfCffCharStringSubset? charStringSubset = compactFontFile.CharStringSubset;
+        if (charStringSubset?.IsSubset == true) {
+            return Array.Empty<PdfFontEmbeddingDiagnostic>();
+        }
+
         var details = new Dictionary<string, string> {
             ["glyphCount"] = font.GlyphCount.ToString(CultureInfo.InvariantCulture),
             ["usedGlyphCount"] = usedGlyphIds.Count.ToString(CultureInfo.InvariantCulture),
@@ -84,12 +89,16 @@ public static class PdfFontDiagnostics {
             ["openTypeLayoutTablesRemoved"] = JoinTags(compactFontFile.RemovedLayoutTables),
             ["cffCharstringsSubset"] = "false",
             ["cffCharstringsRetained"] = "true",
+            ["cffCharstringsSubsetUnsupportedReason"] = charStringSubset?.UnsupportedReason ?? string.Empty,
             ["usedGlyphIdsPreview"] = BuildGlyphIdPreview(usedGlyphIds),
             ["usedGlyphIdsPreviewTruncated"] = (usedGlyphIds.Count > 16).ToString().ToLowerInvariant()
         };
 
         string modeDescription = compactFontFile.IsCompact ? "compact" : "full";
-        string message = "OpenType/CFF font '" + font.FontName + "' is embedded as a " + modeDescription + " /FontFile3 OpenType stream, but the CFF charstrings are still kept intact because OfficeIMO.Pdf does not yet rewrite CFF charstrings. Used-glyph widths and /ToUnicode mappings remain limited to the generated glyph usage.";
+        string failureReason = string.IsNullOrWhiteSpace(charStringSubset?.UnsupportedReason)
+            ? "the font did not contain any unused glyph programs"
+            : charStringSubset!.UnsupportedReason!;
+        string message = "OpenType/CFF font '" + font.FontName + "' is embedded as a " + modeDescription + " /FontFile3 OpenType stream without charstring subsetting because " + failureReason + ". Used-glyph widths and /ToUnicode mappings remain limited to the generated glyph usage.";
         return new[] {
             new PdfFontEmbeddingDiagnostic(
                 source,

--- a/OfficeIMO.Pdf/Model/PdfHyphenationLexicon.cs
+++ b/OfficeIMO.Pdf/Model/PdfHyphenationLexicon.cs
@@ -1,0 +1,127 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>
+/// Immutable, dependency-free dictionary of language-specific word hyphenation points.
+/// </summary>
+/// <remarks>
+/// Entries use an explicit marker, for example <c>typog-ra-phy</c>. The marker is removed from
+/// lookup text and its UTF-16 position becomes a preferred generated-PDF line break. Dictionary
+/// data remains caller-owned, so applications can ship only the languages they use.
+/// </remarks>
+public sealed class PdfHyphenationLexicon {
+    private readonly Dictionary<string, int[]> _entries;
+
+    /// <summary>Creates a case-insensitive hyphenation dictionary from marked words.</summary>
+    /// <param name="hyphenatedWords">Words containing one or more explicit break markers.</param>
+    /// <param name="breakMarker">Marker removed from entries and converted into a break position.</param>
+    /// <param name="minimumPrefixLength">Minimum UTF-16 word length retained before a break.</param>
+    /// <param name="minimumSuffixLength">Minimum UTF-16 word length retained after a break.</param>
+    public PdfHyphenationLexicon(
+        IEnumerable<string> hyphenatedWords,
+        char breakMarker = '-',
+        int minimumPrefixLength = 2,
+        int minimumSuffixLength = 2) {
+        Guard.NotNull(hyphenatedWords, nameof(hyphenatedWords));
+        if (char.IsLetterOrDigit(breakMarker) || char.IsSurrogate(breakMarker) || char.IsWhiteSpace(breakMarker)) {
+            throw new ArgumentException("Hyphenation break markers cannot be letters, digits, surrogates, or whitespace.", nameof(breakMarker));
+        }
+
+        if (minimumPrefixLength < 1) {
+            throw new ArgumentOutOfRangeException(nameof(minimumPrefixLength), "Hyphenation minimum prefix length must be positive.");
+        }
+
+        if (minimumSuffixLength < 1) {
+            throw new ArgumentOutOfRangeException(nameof(minimumSuffixLength), "Hyphenation minimum suffix length must be positive.");
+        }
+
+        BreakMarker = breakMarker;
+        MinimumPrefixLength = minimumPrefixLength;
+        MinimumSuffixLength = minimumSuffixLength;
+        _entries = new Dictionary<string, int[]>(StringComparer.OrdinalIgnoreCase);
+        foreach (string entry in hyphenatedWords) {
+            AddEntry(entry);
+        }
+    }
+
+    /// <summary>Marker used by the source dictionary.</summary>
+    public char BreakMarker { get; }
+
+    /// <summary>Minimum UTF-16 length retained before each returned break.</summary>
+    public int MinimumPrefixLength { get; }
+
+    /// <summary>Minimum UTF-16 length retained after each returned break.</summary>
+    public int MinimumSuffixLength { get; }
+
+    /// <summary>Number of normalized words in the dictionary.</summary>
+    public int Count => _entries.Count;
+
+    /// <summary>Returns preferred UTF-16 break positions for a word, or an empty list when it is not present.</summary>
+    public IReadOnlyList<int> GetBreakpoints(string token) {
+        Guard.NotNull(token, nameof(token));
+        if (!_entries.TryGetValue(token, out int[]? points)) {
+            return Array.Empty<int>();
+        }
+
+        return points.ToArray();
+    }
+
+    /// <summary>Returns true when the normalized word is present.</summary>
+    public bool Contains(string token) {
+        Guard.NotNull(token, nameof(token));
+        return _entries.ContainsKey(token);
+    }
+
+    /// <summary>Creates the callback shape consumed by <see cref="PdfOptions.SetTextHyphenation"/>.</summary>
+    public PdfTextHyphenationCallback AsCallback() => GetBreakpoints;
+
+    private void AddEntry(string entry) {
+        if (string.IsNullOrWhiteSpace(entry)) {
+            throw new ArgumentException("Hyphenation dictionary entries cannot be null, empty, or whitespace.", nameof(entry));
+        }
+
+        string value = entry.Trim();
+        if (value[0] == BreakMarker || value[value.Length - 1] == BreakMarker) {
+            throw new ArgumentException("Hyphenation dictionary entries cannot start or end with the break marker.", nameof(entry));
+        }
+
+        var word = new StringBuilder(value.Length);
+        var points = new List<int>();
+        bool previousWasMarker = false;
+        for (int index = 0; index < value.Length; index++) {
+            char current = value[index];
+            if (current == BreakMarker) {
+                if (previousWasMarker) {
+                    throw new ArgumentException("Hyphenation dictionary entries cannot contain adjacent break markers.", nameof(entry));
+                }
+
+                points.Add(word.Length);
+                previousWasMarker = true;
+                continue;
+            }
+
+            word.Append(current);
+            previousWasMarker = false;
+        }
+
+        if (points.Count == 0) {
+            throw new ArgumentException("Hyphenation dictionary entries must contain at least one break marker.", nameof(entry));
+        }
+
+        string normalizedWord = word.ToString();
+        int[] validPoints = points
+            .Where(point => point >= MinimumPrefixLength && normalizedWord.Length - point >= MinimumSuffixLength)
+            .Where(point => !(char.IsHighSurrogate(normalizedWord[point - 1]) && char.IsLowSurrogate(normalizedWord[point])))
+            .Distinct()
+            .OrderBy(point => point)
+            .ToArray();
+        if (validPoints.Length == 0) {
+            throw new ArgumentException("Hyphenation dictionary entry break markers do not satisfy the configured prefix and suffix limits.", nameof(entry));
+        }
+
+        if (_entries.TryGetValue(normalizedWord, out int[]? existing)) {
+            validPoints = existing.Concat(validPoints).Distinct().OrderBy(point => point).ToArray();
+        }
+
+        _entries[normalizedWord] = validPoints;
+    }
+}

--- a/OfficeIMO.Pdf/Model/PdfInlineElement.cs
+++ b/OfficeIMO.Pdf/Model/PdfInlineElement.cs
@@ -1,0 +1,99 @@
+using OfficeIMO.Drawing;
+
+namespace OfficeIMO.Pdf;
+
+/// <summary>
+/// Base class for a fixed-size visual that participates in rich-paragraph wrapping.
+/// </summary>
+public abstract class PdfInlineElement {
+    /// <summary>Width of the inline element in points.</summary>
+    public double Width { get; }
+
+    /// <summary>Height of the inline element in points.</summary>
+    public double Height { get; }
+
+    /// <summary>Vertical offset of the element bottom from the text baseline, in points.</summary>
+    public double BaselineOffset { get; }
+
+    /// <summary>Alternative text used when the element is emitted into a tagged document.</summary>
+    public string? AlternativeText { get; }
+
+    private protected PdfInlineElement(double width, double height, double baselineOffset, string? alternativeText) {
+        Guard.Positive(width, nameof(width));
+        Guard.Positive(height, nameof(height));
+        if (double.IsNaN(baselineOffset) || double.IsInfinity(baselineOffset)) {
+            throw new ArgumentException("Inline element baseline offset must be finite.", nameof(baselineOffset));
+        }
+
+        if (alternativeText != null) {
+            Guard.NotNullOrWhiteSpace(alternativeText, nameof(alternativeText));
+        }
+
+        Width = width;
+        Height = height;
+        BaselineOffset = baselineOffset;
+        AlternativeText = alternativeText;
+    }
+}
+
+/// <summary>
+/// Raster image that flows between text runs as one indivisible inline element.
+/// </summary>
+public sealed class PdfInlineImage : PdfInlineElement {
+    internal ImageBlock Block { get; }
+
+    /// <summary>Image fitting mode inside the requested inline frame.</summary>
+    public OfficeImageFit Fit { get; }
+
+    /// <summary>Creates an inline image from first-party supported image bytes.</summary>
+    public PdfInlineImage(
+        byte[] imageBytes,
+        double width,
+        double height,
+        string? alternativeText = null,
+        OfficeImageFit fit = OfficeImageFit.Contain,
+        double baselineOffset = 0D)
+        : base(width, height, baselineOffset, alternativeText) {
+        OfficeImageInfo info = PdfDocument.ValidateImageBytes(imageBytes);
+        var style = new PdfImageStyle {
+            Fit = fit,
+            AlternativeText = alternativeText
+        };
+        PdfDocument.ValidateImageFitDimensions(info, fit, nameof(fit));
+        Block = new ImageBlock(imageBytes, width, height, info, style);
+        Fit = fit;
+    }
+}
+
+/// <summary>
+/// Fixed-size filled and/or bordered box that flows between text runs.
+/// </summary>
+public sealed class PdfInlineBox : PdfInlineElement {
+    /// <summary>Optional fill color.</summary>
+    public PdfColor? Background { get; }
+
+    /// <summary>Optional border color.</summary>
+    public PdfColor? BorderColor { get; }
+
+    /// <summary>Border width in points.</summary>
+    public double BorderWidth { get; }
+
+    /// <summary>Creates a fixed-size inline box.</summary>
+    public PdfInlineBox(
+        double width,
+        double height,
+        PdfColor? background = null,
+        PdfColor? borderColor = null,
+        double borderWidth = 0.5D,
+        string? alternativeText = null,
+        double baselineOffset = 0D)
+        : base(width, height, baselineOffset, alternativeText) {
+        if (borderWidth < 0D || double.IsNaN(borderWidth) || double.IsInfinity(borderWidth)) {
+            throw new ArgumentException("Inline box border width must be a non-negative finite value.", nameof(borderWidth));
+        }
+
+        Background = background;
+        BorderColor = borderColor;
+        BorderWidth = borderWidth;
+    }
+}

--- a/OfficeIMO.Pdf/Model/PdfMultiColumnOptions.cs
+++ b/OfficeIMO.Pdf/Model/PdfMultiColumnOptions.cs
@@ -26,6 +26,8 @@ public sealed class PdfMultiColumnOptions {
 
     /// <summary>Whether the final page should distribute blocks toward similar column heights.</summary>
     public bool BalanceLastPage { get; set; } = true;
+    /// <summary>Whether long paragraphs may be split at already wrapped line boundaries to balance the final page.</summary>
+    public bool BalanceParagraphLines { get; set; } = true;
     /// <summary>Optional separator color between columns.</summary>
     public PdfColor? SeparatorColor { get; set; }
     /// <summary>Separator width in points.</summary>
@@ -41,6 +43,7 @@ public sealed class PdfMultiColumnOptions {
         ColumnCount = ColumnCount,
         Gap = Gap,
         BalanceLastPage = BalanceLastPage,
+        BalanceParagraphLines = BalanceParagraphLines,
         SeparatorColor = SeparatorColor,
         SeparatorWidth = SeparatorWidth
     };

--- a/OfficeIMO.Pdf/Model/PdfParagraphBuilder.cs
+++ b/OfficeIMO.Pdf/Model/PdfParagraphBuilder.cs
@@ -78,6 +78,14 @@ public sealed class PdfParagraphBuilder {
     public PdfParagraphBuilder LineBreak() { _runs.Add(TextRun.LineBreak()); return this; }
     /// <summary>Adds an explicit paragraph tab using the current style flags.</summary>
     public PdfParagraphBuilder Tab(PdfTabLeaderStyle leader = PdfTabLeaderStyle.None, PdfTabAlignment alignment = PdfTabAlignment.Left) { _runs.Add(new TextRun("\t", _currentBold, _currentUnderline, _currentColor, _currentItalic, _currentStrike, fontSize: _currentFontSize, font: _currentFont, baseline: _currentBaseline, tabLeader: leader, tabAlignment: alignment, backgroundColor: _currentBackgroundColor)); return this; }
+    /// <summary>Adds a fixed-size visual that participates in paragraph wrapping.</summary>
+    public PdfParagraphBuilder Inline(PdfInlineElement element) { Guard.NotNull(element, nameof(element)); _runs.Add(TextRun.Inline(element)); return this; }
+    /// <summary>Adds an image that participates in paragraph wrapping.</summary>
+    public PdfParagraphBuilder InlineImage(byte[] imageBytes, double width, double height, string? alternativeText = null, OfficeIMO.Drawing.OfficeImageFit fit = OfficeIMO.Drawing.OfficeImageFit.Contain, double baselineOffset = 0D) =>
+        Inline(new PdfInlineImage(imageBytes, width, height, alternativeText, fit, baselineOffset));
+    /// <summary>Adds a filled and/or bordered box that participates in paragraph wrapping.</summary>
+    public PdfParagraphBuilder InlineBox(double width, double height, PdfColor? background = null, PdfColor? borderColor = null, double borderWidth = 0.5D, string? alternativeText = null, double baselineOffset = 0D) =>
+        Inline(new PdfInlineBox(width, height, background, borderColor, borderWidth, alternativeText, baselineOffset));
     /// <summary>Adds a bold text run.</summary>
     public PdfParagraphBuilder Bold(string text, PdfColor? color = null) { _runs.Add(new TextRun(text, bold: true, underline: false, color: color ?? _currentColor, italic: false, fontSize: _currentFontSize, font: _currentFont, backgroundColor: _currentBackgroundColor)); return this; }
     /// <summary>Adds an italic text run.</summary>

--- a/OfficeIMO.Pdf/Model/PdfTextShapingProvider.cs
+++ b/OfficeIMO.Pdf/Model/PdfTextShapingProvider.cs
@@ -30,14 +30,40 @@ public sealed class PdfTextShapingRequest {
     /// <param name="fontData">Snapshot of the embedded font bytes.</param>
     /// <param name="isOpenTypeCff">True when the font uses OpenType/CFF outlines; false for TrueType outlines.</param>
     /// <param name="fallbackMode">OfficeIMO.Pdf built-in shaping mode configured for fallback handling.</param>
-    public PdfTextShapingRequest(string text, string fontName, byte[] fontData, bool isOpenTypeCff, PdfTextShapingMode fallbackMode) {
+    public PdfTextShapingRequest(string text, string fontName, byte[] fontData, bool isOpenTypeCff, PdfTextShapingMode fallbackMode)
+        : this(text, fontName, fontData, isOpenTypeCff, fallbackMode, unitsPerEm: 1000, PdfTextDirection.Auto, language: null) {
+    }
+
+    /// <summary>
+    /// Creates a shaping request with font metrics and text-context hints.
+    /// </summary>
+    /// <param name="text">Original UTF-16 text to shape.</param>
+    /// <param name="fontName">PDF font name selected for the text run.</param>
+    /// <param name="fontData">Snapshot of the embedded font bytes.</param>
+    /// <param name="isOpenTypeCff">True when the font uses OpenType/CFF outlines; false for TrueType outlines.</param>
+    /// <param name="fallbackMode">OfficeIMO.Pdf built-in shaping mode configured for fallback handling.</param>
+    /// <param name="unitsPerEm">Design units per em used by the supplied font.</param>
+    /// <param name="direction">Resolved base direction hint for the run.</param>
+    /// <param name="language">Optional BCP 47 document language hint.</param>
+    public PdfTextShapingRequest(string text, string fontName, byte[] fontData, bool isOpenTypeCff, PdfTextShapingMode fallbackMode, int unitsPerEm, PdfTextDirection direction, string? language) {
         Guard.NotNull(text, nameof(text));
         Guard.NotNull(fontData, nameof(fontData));
+        if (unitsPerEm <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(unitsPerEm), "Text shaping units per em must be positive.");
+        }
+
+        if (direction != PdfTextDirection.Auto && direction != PdfTextDirection.LeftToRight && direction != PdfTextDirection.RightToLeft) {
+            throw new ArgumentOutOfRangeException(nameof(direction), "Text shaping direction must be Auto, LeftToRight, or RightToLeft.");
+        }
+
         Text = text;
         FontName = fontName ?? string.Empty;
         _fontData = fontData.ToArray();
         IsOpenTypeCff = isOpenTypeCff;
         FallbackMode = fallbackMode;
+        UnitsPerEm = unitsPerEm;
+        Direction = direction;
+        Language = string.IsNullOrWhiteSpace(language) ? null : language;
     }
 
     /// <summary>Original UTF-16 text to shape.</summary>
@@ -54,6 +80,15 @@ public sealed class PdfTextShapingRequest {
 
     /// <summary>OfficeIMO.Pdf built-in shaping mode configured for fallback handling.</summary>
     public PdfTextShapingMode FallbackMode { get; }
+
+    /// <summary>Design units per em used by glyph advances and offsets returned for this font.</summary>
+    public int UnitsPerEm { get; }
+
+    /// <summary>Base direction inferred from the first strong character in the run.</summary>
+    public PdfTextDirection Direction { get; }
+
+    /// <summary>Optional BCP 47 document language hint.</summary>
+    public string? Language { get; }
 }
 
 /// <summary>
@@ -83,7 +118,24 @@ public readonly struct PdfShapedGlyph {
     /// <param name="glyphId">Font glyph identifier to write into the PDF content stream.</param>
     /// <param name="unicodeText">Original Unicode text represented by the shaped glyph for ToUnicode extraction.</param>
     /// <param name="textIndex">UTF-16 index in the original text where this glyph's source text begins.</param>
-    public PdfShapedGlyph(int glyphId, string unicodeText, int textIndex) {
+    public PdfShapedGlyph(int glyphId, string unicodeText, int textIndex)
+        : this(glyphId, unicodeText, textIndex, advanceWidth: null, offsetX: 0, offsetY: 0) {
+    }
+
+    /// <summary>
+    /// Creates a positioned shaped glyph in the font design units declared by <see cref="PdfTextShapingRequest.UnitsPerEm"/>.
+    /// </summary>
+    /// <param name="glyphId">Font glyph identifier to write into the PDF content stream.</param>
+    /// <param name="unicodeText">Original Unicode text represented by the shaped glyph for ToUnicode extraction.</param>
+    /// <param name="textIndex">UTF-16 index in the original text where this glyph's source text begins.</param>
+    /// <param name="advanceWidth">Horizontal shaped advance in font design units.</param>
+    /// <param name="offsetX">Horizontal glyph placement offset in font design units.</param>
+    /// <param name="offsetY">Vertical glyph placement offset in font design units.</param>
+    public PdfShapedGlyph(int glyphId, string unicodeText, int textIndex, int advanceWidth, int offsetX = 0, int offsetY = 0)
+        : this(glyphId, unicodeText, textIndex, (int?)advanceWidth, offsetX, offsetY) {
+    }
+
+    private PdfShapedGlyph(int glyphId, string unicodeText, int textIndex, int? advanceWidth, int offsetX, int offsetY) {
         if (glyphId <= 0) {
             throw new ArgumentOutOfRangeException(nameof(glyphId), "Shaped PDF glyph identifiers must be positive.");
         }
@@ -92,6 +144,9 @@ public readonly struct PdfShapedGlyph {
         Guard.NotNull(unicodeText, nameof(unicodeText));
         UnicodeText = unicodeText;
         TextIndex = textIndex;
+        AdvanceWidth = advanceWidth;
+        OffsetX = offsetX;
+        OffsetY = offsetY;
     }
 
     /// <summary>Font glyph identifier to write into the PDF content stream.</summary>
@@ -102,4 +157,13 @@ public readonly struct PdfShapedGlyph {
 
     /// <summary>UTF-16 index in the original text where this glyph's source text begins.</summary>
     public int TextIndex { get; }
+
+    /// <summary>Optional shaped horizontal advance in font design units; null uses the font's nominal glyph width.</summary>
+    public int? AdvanceWidth { get; }
+
+    /// <summary>Horizontal placement offset in font design units.</summary>
+    public int OffsetX { get; }
+
+    /// <summary>Vertical placement offset in font design units.</summary>
+    public int OffsetY { get; }
 }

--- a/OfficeIMO.Pdf/Model/TextRun.cs
+++ b/OfficeIMO.Pdf/Model/TextRun.cs
@@ -34,6 +34,8 @@ public sealed class TextRun {
     public PdfTabLeaderStyle TabLeader { get; }
     /// <summary>Alignment used when this run represents a paragraph tab.</summary>
     public PdfTabAlignment TabAlignment { get; }
+    /// <summary>Optional fixed-size visual carried by this run instead of text.</summary>
+    public PdfInlineElement? InlineElement { get; }
 
     /// <summary>Create a new run with the specified styles.</summary>
     /// <param name="text">Run text.</param>
@@ -104,6 +106,12 @@ public sealed class TextRun {
         Baseline = baseline;
         TabLeader = tabLeader;
         TabAlignment = tabAlignment;
+        InlineElement = null;
+    }
+
+    private TextRun(PdfInlineElement inlineElement)
+        : this(string.Empty) {
+        InlineElement = inlineElement ?? throw new ArgumentNullException(nameof(inlineElement));
     }
 
     /// <summary>Create a normal (unstyled) run.</summary>
@@ -112,6 +120,8 @@ public sealed class TextRun {
     public static TextRun LineBreak() => new TextRun("\n", bold: false, underline: false, color: null, italic: false, strike: false);
     /// <summary>Create an explicit paragraph tab run.</summary>
     public static TextRun Tab(PdfTabLeaderStyle leader = PdfTabLeaderStyle.None, PdfTabAlignment alignment = PdfTabAlignment.Left) => new TextRun("\t", tabLeader: leader, tabAlignment: alignment);
+    /// <summary>Create a fixed-size inline visual run.</summary>
+    public static TextRun Inline(PdfInlineElement element) => new TextRun(element);
     /// <summary>Create a bold run.</summary>
     public static TextRun Bolded(string text, PdfColor? color = null, double? fontSize = null, PdfColor? backgroundColor = null, PdfStandardFont? font = null) => new TextRun(text, bold: true, underline: false, color: color, italic: false, strike: false, fontSize: fontSize, font: font, backgroundColor: backgroundColor);
     /// <summary>Create an underlined run.</summary>

--- a/OfficeIMO.Pdf/Options/PdfOptions.Text.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.Text.cs
@@ -124,6 +124,13 @@ public sealed partial class PdfOptions {
         return this;
     }
 
+    /// <summary>Uses or clears an immutable first-party word hyphenation dictionary.</summary>
+    /// <param name="dictionary">Dictionary whose breakpoints should be used, or null to clear hyphenation.</param>
+    public PdfOptions UseTextHyphenationDictionary(PdfHyphenationLexicon? dictionary) {
+        _textHyphenationCallback = dictionary?.AsCallback();
+        return this;
+    }
+
     /// <summary>
     /// Sets or clears the callback used to provide preferred non-hyphenating break positions for long unspaced tokens.
     /// </summary>

--- a/OfficeIMO.Pdf/README.md
+++ b/OfficeIMO.Pdf/README.md
@@ -38,13 +38,14 @@ PdfDocument.Create(new PdfOptions {
 
 ## What it does
 
-- Creates PDFs with page setup, headings, paragraphs, rich text, links, lists, styled containers, block-flow columns, conditional/replayable flow, position capture, sections, generated TOCs, optional-content layers, tables, images, vector drawing, headers, footers, watermarks, metadata, portfolios, and form primitives.
+- Creates PDFs with page setup, headings, paragraphs, rich text, links, lists, mixed inline images and boxes, dictionary-driven hyphenation, styled multipage containers, balanced block-flow columns, conditional/replayable flow, position capture, sections, generated TOCs, optional-content layers, tables, images, vector drawing, headers, footers, watermarks, metadata, portfolios, and form primitives.
 - Reads and inspects PDFs through text extraction, logical document objects, page metadata, links, images, attachments, portfolios, outlines, forms, bounded immutable raw-structure views, active-content diagnostics, and security/revision markers.
 - Manipulates existing PDFs with page extraction, split, merge, delete, duplicate, move, rotate, metadata editing, stamps, watermarks, and complete-page overlay/underlay while preserving source PDF header versions on shared rewrite paths.
-- Renders supported embedded TrueType fonts from their exact outlines and shares managed CMYK, Lab, XYZ, calibrated-color conversion, vector tiling fills, standard blend modes, and alpha/luminosity soft masks with `OfficeIMO.Drawing`.
+- Renders supported embedded TrueType and OpenType/CFF fonts with stable-glyph subsetting. Built-in shaping remains dependency-free, while `IPdfTextShapingProvider` can supply positioned glyph advances and offsets for scripts that need a host-owned shaping engine.
+- Shares managed CMYK, Lab, XYZ, calibrated-color conversion, vector tiling fills, standard blend modes, and alpha/luminosity soft masks with `OfficeIMO.Drawing`.
 - Bounds completed page/effect content and serialized-object retention with separate memory limits, temporary-file spillover, direct large-stream spooling, and chunked final assembly during stream saves. Per-page metadata and the authored block model remain proportional to document size, and `ToBytes()` buffers the final artifact.
 - Provides conversion reports, grouped warning summaries, and diagnostics so adapters can expose unsupported or simplified source content honestly.
-- Provides reusable conversion proof snapshots for generated PDFs, artifact hashes, required page counts, page sizes, document metadata, outline titles, URI links, form fields, named destinations, page labels, attachments, output intents, optional-content/layer metadata, catalog/viewer metadata, XMP/tagged metadata, text markers, logical readback signals, expected and accepted warning contracts, and post-processing hand-off.
+- Provides reusable conversion proof snapshots for generated PDFs, artifact hashes, required page counts, page sizes, document metadata, outline titles, URI links, form fields, named destinations, page labels, attachments, output intents, optional-content/layer metadata, catalog/viewer metadata, XMP/tagged metadata, text markers, logical readback signals, expected and accepted warning contracts, and post-processing hand-off. Compliance proof records bind external validator name, version, profile, result, warnings, SHA-256, byte length, and validation time to the exact artifact.
 - Provides reusable rewrite-preservation proof for page geometry, metadata, navigation, catalog/viewer/action state, optional content, tagged content, security signatures, document versions, and source-structure markers such as incremental updates, xref streams, and object streams.
 - Provides a reusable rewrite-preservation matrix for classifying named manipulation scenarios as rewrite-safe, preservation-failed, blocked by safety checks, or operation-failed, including optional-content/layer drift, targeted form-fill preservation, form/tagged/active-content/signature blockers, and fluent `PdfDocument` helpers for normal document rewrite operations.
 - Serves as the shared engine for Word, Excel, Markdown, HTML, and PowerPoint PDF adapters.
@@ -119,6 +120,27 @@ PdfDocument.Create()
     })
     .Save("summary.pdf");
 ```
+
+### Hyphenation and inline visuals
+
+```csharp
+byte[] statusIcon = File.ReadAllBytes("status.png");
+var hyphenation = new PdfHyphenationLexicon(new[] {
+    "auto-ma-tion",
+    "ty-pog-ra-phy",
+    "re-port-ing"
+});
+
+PdfDocument.Create(new PdfOptions()
+        .UseTextHyphenationDictionary(hyphenation))
+    .Paragraph(paragraph => paragraph
+        .Text("Automation status ")
+        .InlineImage(statusIcon, 12, 12, alternativeText: "Healthy")
+        .Text(" remains available during long reporting runs."))
+    .Save("inline-status.pdf");
+```
+
+Inline elements participate in normal line wrapping. In tagged output, image and box alternative text is carried into the structure tree.
 
 ### Sections, generated navigation, and bounded stream output
 
@@ -274,24 +296,44 @@ PdfDocument.Load("application-form.pdf")
     .Save("application-form-filled.pdf");
 ```
 
-### Assess compliance proof without overclaiming
+### Generate and assess validator-backed PDF/A
 
 ```csharp
 using OfficeIMO.Pdf;
 
-PdfDocument document = PdfDocument.Create(new PdfOptions()
-        .UsePdfA(PdfComplianceProfile.PdfA3B))
-    .Paragraph(paragraph => paragraph.Text("Groundwork can be assessed before a formal claim."));
+byte[] fontBytes = File.ReadAllBytes("SourceSerif4-Regular.otf");
+var options = new PdfOptions()
+    .UsePdfA(PdfComplianceProfile.PdfA2B)
+    .EmbedStandardFont(PdfStandardFont.Helvetica, fontBytes, "Source Serif 4")
+    .RequireCompliance(PdfComplianceProfile.PdfA2B);
+
+PdfDocument document = PdfDocument.Create(options)
+    .Meta(title: "Archive copy")
+    .Paragraph(paragraph => paragraph.Text("This artifact is ready for external validation."));
+
+byte[] pdf = document.ToBytes();
+File.WriteAllBytes("archive.pdf", pdf);
+
+// Create this result from the validator invocation in your build or release lane.
+PdfExternalValidationResult validation = PdfExternalValidationResult.PassedForArtifact(
+    PdfExternalValidatorKind.VeraPdf,
+    "veraPDF",
+    "1.30.2",
+    "PDF/A-2b validation passed.",
+    pdf,
+    "PDF/A-2b");
 
 PdfComplianceProofReport proof = document.AssessComplianceProof(
-    PdfComplianceProfile.PdfA3B,
-    externalValidations: null);
+    PdfComplianceProfile.PdfA2B,
+    pdf,
+    new[] { validation });
 
 if (!proof.CanClaimConformance) {
-    Console.WriteLine(proof.ProofStatus);
-    Console.WriteLine(proof.ExternalProofSummary);
+    throw new InvalidOperationException(proof.ExternalProofSummary);
 }
 ```
+
+Formal generation gates are available for PDF/A-2b, PDF/A-3b, PDF/UA-1, Factur-X, and ZUGFeRD. `RequireCompliance(...)` rejects incomplete generation settings. A conformance claim still requires a passing external result for the same profile, SHA-256, and byte length; validators are build-time tools and are not runtime dependencies of `OfficeIMO.Pdf`.
 
 ### Choose converter-friendly text fallbacks
 
@@ -314,18 +356,26 @@ result.Save("proposal.pdf");
 
 The Markdown, Word, Excel, and PowerPoint PDF adapters expose the same `TextFallbacks` enum. Use `PdfTextFallbackFeatures.None` when strict standard-font output is preferred, or `AllowSystemFontEmbedding = true` when the converter may embed installed host fonts for Unicode, symbols, and emoji.
 
-### Add e-invoice groundwork
+### Generate a formal e-invoice carrier
 
 ```csharp
 using OfficeIMO.Pdf;
 
 byte[] invoiceXml = File.ReadAllBytes("factur-x.xml");
+byte[] fontBytes = File.ReadAllBytes("SourceSerif4-Regular.otf");
 
 PdfDocument.Create(new PdfOptions()
-        .UseFacturX(invoiceXml, textFallbacks: PdfTextFallbackFeatures.DocumentFont))
+        .UseFacturX(
+            invoiceXml,
+            relationship: PdfAssociatedFileRelationship.Alternative,
+            textFallbacks: PdfTextFallbackFeatures.None)
+        .EmbedStandardFont(PdfStandardFont.Helvetica, fontBytes, "Source Serif 4")
+        .RequireCompliance(PdfComplianceProfile.FacturX))
     .Paragraph("Invoice preview")
     .Save("invoice.pdf");
 ```
+
+The XML must be a valid EN 16931 CrossIndustryInvoice payload. The formal carrier gate checks the PDF/A-3 attachment, metadata, font, Unicode, and invoice rules before writing; exact-artifact PDF/A and invoice-validator results are still required before claiming conformance.
 
 ### Page setup, watermarks, and metadata
 

--- a/OfficeIMO.Pdf/Rendering/PdfWriter.cs
+++ b/OfficeIMO.Pdf/Rendering/PdfWriter.cs
@@ -24,6 +24,10 @@ internal static partial class PdfWriter {
         ValidateNamedDestinationLinks(layout.Pages);
         ValidateUriActionLinks(layout.Pages, opts);
         ValidateGeneratedFormFieldNames(layout.Pages);
+        PdfComplianceValidator.ValidateGeneratedDocument(
+            opts,
+            title,
+            CollectGeneratedComplianceEvidence(layout, opts));
 
         // Build PDF objects as byte arrays, then assemble with xref.
         using var objects = new PdfObjectStore(opts.ObjectBufferMemoryLimitBytes);
@@ -405,6 +409,7 @@ internal static partial class PdfWriter {
             }
             if (page.TextAnnotations.Count > 0) {
                 foreach (var annotation in page.TextAnnotations) {
+                    AnnotationStructureReference? annotationStructureReference = RegisterAnnotationStructureReference(page, markInfo, ref nextStructParentIndex, "Annot");
                     string annot = PdfAnnotationDictionaryBuilder.BuildTextAnnotation(
                         annotation.X1,
                         annotation.Y1,
@@ -413,14 +418,17 @@ internal static partial class PdfWriter {
                         annotation.Contents,
                         annotation.Icon,
                         annotation.Color,
-                        annotation.Open);
+                        annotation.Open,
+                        annotationStructureReference?.StructParentIndex);
                     int annId = AddObject(objects, annot);
                     annotation.ObjectId = annId;
+                    CompleteAnnotationStructureReference(page, annotationStructureReference, annId);
                     pageAnnotIds.Add(annId);
                 }
             }
             if (!flattenVisualAnnotations && page.FreeTextAnnotations.Count > 0) {
                 foreach (var annotation in page.FreeTextAnnotations) {
+                    AnnotationStructureReference? annotationStructureReference = RegisterAnnotationStructureReference(page, markInfo, ref nextStructParentIndex, "Annot");
                     double appearanceWidth = annotation.X2 - annotation.X1;
                     double appearanceHeight = annotation.Y2 - annotation.Y1;
                     string appearanceContent = BuildFreeTextAnnotationAppearanceContent(
@@ -444,14 +452,17 @@ internal static partial class PdfWriter {
                         annotation.BorderColor,
                         annotation.BorderWidth,
                         annotation.FillColor,
-                        appearanceId);
+                        appearanceId,
+                        annotationStructureReference?.StructParentIndex);
                     int annId = AddObject(objects, annot);
                     annotation.ObjectId = annId;
+                    CompleteAnnotationStructureReference(page, annotationStructureReference, annId);
                     pageAnnotIds.Add(annId);
                 }
             }
             if (!flattenVisualAnnotations && page.HighlightAnnotations.Count > 0) {
                 foreach (var annotation in page.HighlightAnnotations) {
+                    AnnotationStructureReference? annotationStructureReference = RegisterAnnotationStructureReference(page, markInfo, ref nextStructParentIndex, "Annot");
                     double appearanceWidth = annotation.X2 - annotation.X1;
                     double appearanceHeight = annotation.Y2 - annotation.Y1;
                     string appearanceContent = PdfAnnotationDictionaryBuilder.BuildHighlightAppearanceContent(appearanceWidth, appearanceHeight, annotation.Color);
@@ -465,9 +476,11 @@ internal static partial class PdfWriter {
                         annotation.Y2,
                         annotation.Contents,
                         annotation.Color,
-                        appearanceId);
+                        appearanceId,
+                        annotationStructureReference?.StructParentIndex);
                     int annId = AddObject(objects, annot);
                     annotation.ObjectId = annId;
+                    CompleteAnnotationStructureReference(page, annotationStructureReference, annId);
                     pageAnnotIds.Add(annId);
                 }
             }
@@ -490,7 +503,7 @@ internal static partial class PdfWriter {
 
                         var widgetObjectIds = new List<int>(field.Options.Count);
                         for (int optionIndex = 0; optionIndex < field.Options.Count; optionIndex++) {
-                            FormWidgetStructureReference? widgetStructureReference = RegisterFormWidgetStructureReference(page, markInfo, ref nextStructParentIndex);
+                            AnnotationStructureReference? widgetStructureReference = RegisterAnnotationStructureReference(page, markInfo, ref nextStructParentIndex, "Form");
                             double widgetTop = field.Y2 - optionIndex * (field.ButtonSize + field.ButtonGap);
                             double widgetBottom = widgetTop - field.ButtonSize;
                             string widget = PdfAnnotationDictionaryBuilder.BuildRadioButtonWidgetAnnotation(
@@ -506,7 +519,7 @@ internal static partial class PdfWriter {
                                 field.Style,
                                 widgetStructureReference?.StructParentIndex);
                             int widgetObjectId = AddObject(objects, widget);
-                            CompleteFormWidgetStructureReference(page, widgetStructureReference, widgetObjectId);
+                            CompleteAnnotationStructureReference(page, widgetStructureReference, widgetObjectId);
                             widgetObjectIds.Add(widgetObjectId);
                             pageAnnotIds.Add(widgetObjectId);
                         }
@@ -516,7 +529,7 @@ internal static partial class PdfWriter {
                         continue;
                     }
 
-                    FormWidgetStructureReference? formWidgetStructureReference = RegisterFormWidgetStructureReference(page, markInfo, ref nextStructParentIndex);
+                    AnnotationStructureReference? formWidgetStructureReference = RegisterAnnotationStructureReference(page, markInfo, ref nextStructParentIndex, "Form");
                     if (field.Kind == FormFieldAnnotationKind.CheckBox) {
                         string offAppearance = PdfAcroFormDictionaryBuilder.BuildCheckBoxAppearanceContent(appearanceWidth, appearanceHeight, selected: false, field.Style);
                         byte[] offAppearanceBytes = PdfEncoding.Latin1GetBytes(offAppearance);
@@ -561,7 +574,7 @@ internal static partial class PdfWriter {
                     }
 
                     int formFieldId = AddObject(objects, formField);
-                    CompleteFormWidgetStructureReference(page, formWidgetStructureReference, formFieldId);
+                    CompleteAnnotationStructureReference(page, formWidgetStructureReference, formFieldId);
                     pageAnnotIds.Add(formFieldId);
                     formFieldIds.Add(formFieldId);
                 }
@@ -870,30 +883,30 @@ internal static partial class PdfWriter {
         }
     }
 
-    private static FormWidgetStructureReference? RegisterFormWidgetStructureReference(LayoutResult.Page page, bool markInfo, ref int nextStructParentIndex) {
+    private static AnnotationStructureReference? RegisterAnnotationStructureReference(LayoutResult.Page page, bool markInfo, ref int nextStructParentIndex, string structureType) {
         if (!markInfo) {
             return null;
         }
 
-        var reference = new FormWidgetStructureReference {
+        var reference = new AnnotationStructureReference {
             StructParentIndex = nextStructParentIndex++,
             StructElementIndex = page.StructElements.Count
         };
         page.StructElements.Add(new PageStructElement {
-            StructureType = "Form",
+            StructureType = structureType,
             AnnotationStructParentIndex = reference.StructParentIndex
         });
         return reference;
     }
 
-    private static void CompleteFormWidgetStructureReference(LayoutResult.Page page, FormWidgetStructureReference? reference, int widgetObjectId) {
+    private static void CompleteAnnotationStructureReference(LayoutResult.Page page, AnnotationStructureReference? reference, int annotationObjectId) {
         if (reference == null) {
             return;
         }
 
-        reference.ObjectId = widgetObjectId;
+        reference.ObjectId = annotationObjectId;
         if (reference.StructElementIndex >= 0 && reference.StructElementIndex < page.StructElements.Count) {
-            page.StructElements[reference.StructElementIndex].AnnotationObjectId = widgetObjectId;
+            page.StructElements[reference.StructElementIndex].AnnotationObjectId = annotationObjectId;
         }
     }
 
@@ -1223,9 +1236,10 @@ internal static partial class PdfWriter {
 
             PdfStandardFont runFont = ResolvePageTextRunFont(run, baseFont);
             string runFontResource = ResolvePageTextFontResource(fontResources, runFont);
+            double runFontSize = run.FontSize ?? watermark.FontSize;
             content
-                .Font(runFontResource, run.FontSize ?? watermark.FontSize)
-                .ShowHexText(EncodeTextHex(text, runFont, options));
+                .Font(runFontResource, runFontSize)
+                .ShowText(EncodeTextShowCommand(text, runFont, options), runFontSize);
         }
 
         content.EndText()

--- a/OfficeIMO.Pdf/Rendering/PdfWriter.cs
+++ b/OfficeIMO.Pdf/Rendering/PdfWriter.cs
@@ -1155,7 +1155,7 @@ internal static partial class PdfWriter {
             }
 
             sb.Append(" >> BDC\n");
-        } else if (!img.SuppressAccessibilityWrapper && img.IsBackgroundDecoration) {
+        } else if (!img.SuppressAccessibilityWrapper && img.IsDecorativeArtifact) {
             sb.Append("/Artifact BMC\n");
         }
 
@@ -1185,7 +1185,7 @@ internal static partial class PdfWriter {
         content.XObject(img.Name)
             .RestoreState();
 
-        if (hasAlternativeText || !img.SuppressAccessibilityWrapper && img.IsBackgroundDecoration) {
+        if (hasAlternativeText || !img.SuppressAccessibilityWrapper && img.IsDecorativeArtifact) {
             sb.Append("EMC\n");
         }
 

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfAnnotationDictionaryBuilder.Annotations.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfAnnotationDictionaryBuilder.Annotations.cs
@@ -4,7 +4,7 @@ internal static partial class PdfAnnotationDictionaryBuilder {
     private static readonly char[] SpaceSeparators = { ' ' };
     private static readonly double[] DefaultBorderDashPattern = { 3D };
 
-    internal static string BuildTextAnnotation(double x1, double y1, double x2, double y2, string contents, PdfTextAnnotationIcon icon = PdfTextAnnotationIcon.Comment, PdfColor? color = null, bool open = false) {
+    internal static string BuildTextAnnotation(double x1, double y1, double x2, double y2, string contents, PdfTextAnnotationIcon icon = PdfTextAnnotationIcon.Comment, PdfColor? color = null, bool open = false, int? structParentIndex = null) {
         ValidateRectangle(x1, y1, x2, y2);
         Guard.NotNullOrWhiteSpace(contents, nameof(contents));
         PdfDocument.ValidateTextAnnotationIcon(icon, nameof(icon));
@@ -20,10 +20,11 @@ internal static partial class PdfAnnotationDictionaryBuilder {
             PdfSyntaxEscaper.Name(GetTextAnnotationIconName(icon)) +
             (color.HasValue ? " /C [" + FormatCoordinate(color.Value.R) + " " + FormatCoordinate(color.Value.G) + " " + FormatCoordinate(color.Value.B) + "]" : string.Empty) +
             (open ? " /Open true" : string.Empty) +
+            BuildStructParentEntry(structParentIndex) +
             " >>\n";
     }
 
-    internal static string BuildFreeTextAnnotation(double x1, double y1, double x2, double y2, string contents, double fontSize = 10D, PdfColor? textColor = null, PdfColor? borderColor = null, double borderWidth = 1D, PdfColor? fillColor = null, int normalAppearanceId = 0) {
+    internal static string BuildFreeTextAnnotation(double x1, double y1, double x2, double y2, string contents, double fontSize = 10D, PdfColor? textColor = null, PdfColor? borderColor = null, double borderWidth = 1D, PdfColor? fillColor = null, int normalAppearanceId = 0, int? structParentIndex = null) {
         ValidateRectangle(x1, y1, x2, y2);
         Guard.NotNullOrWhiteSpace(contents, nameof(contents));
         ValidateFinite(fontSize, nameof(fontSize));
@@ -52,10 +53,11 @@ internal static partial class PdfAnnotationDictionaryBuilder {
             (borderColor.HasValue && borderWidth > 0D ? " /C [" + FormatColor(borderColor.Value) + "]" : string.Empty) +
             (fillColor.HasValue ? " /IC [" + FormatColor(fillColor.Value) + "]" : string.Empty) +
             BuildNormalAppearanceEntry(normalAppearanceId) +
+            BuildStructParentEntry(structParentIndex) +
             " >>\n";
     }
 
-    internal static string BuildHighlightAnnotation(double x1, double y1, double x2, double y2, string contents, PdfColor? color = null, int normalAppearanceId = 0) {
+    internal static string BuildHighlightAnnotation(double x1, double y1, double x2, double y2, string contents, PdfColor? color = null, int normalAppearanceId = 0, int? structParentIndex = null) {
         ValidateRectangle(x1, y1, x2, y2);
         Guard.NotNullOrWhiteSpace(contents, nameof(contents));
         PdfColor resolvedColor = color ?? new PdfColor(1D, 0.92D, 0.2D);
@@ -80,6 +82,7 @@ internal static partial class PdfAnnotationDictionaryBuilder {
             FormatCoordinate(y1) +
             "]" +
             BuildNormalAppearanceEntry(normalAppearanceId) +
+            BuildStructParentEntry(structParentIndex) +
             " >>\n";
     }
 

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfCffCharStringSubsetter.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfCffCharStringSubsetter.cs
@@ -1,0 +1,414 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>
+/// Rewrites a CFF1 CharStrings INDEX while preserving glyph identifiers.
+/// </summary>
+/// <remarks>
+/// PDF content streams use the original glyph identifiers. Keeping the INDEX count and order stable
+/// avoids a second glyph-remapping layer: used programs remain byte-for-byte identical, glyph zero is
+/// retained, and unused programs become the minimal Type 2 <c>endchar</c> program. Local and global
+/// subroutines remain intact because retained programs may reference them.
+/// </remarks>
+internal static class PdfCffCharStringSubsetter {
+    private const byte Type2EndChar = 14;
+
+    internal static PdfCffCharStringSubset Create(byte[] cffData, IReadOnlyList<int> usedGlyphIds, int expectedGlyphCount) {
+        Guard.NotNull(cffData, nameof(cffData));
+        Guard.NotNull(usedGlyphIds, nameof(usedGlyphIds));
+
+        try {
+            if (cffData.Length < 4 || cffData[0] != 1) {
+                return PdfCffCharStringSubset.Unsupported(cffData, "Only CFF1 data can be subset through the OpenType CFF path.");
+            }
+
+            int headerSize = cffData[2];
+            if (headerSize < 4 || headerSize > cffData.Length) {
+                return PdfCffCharStringSubset.Unsupported(cffData, "The CFF header size is invalid.");
+            }
+
+            CffIndex nameIndex = ReadIndex(cffData, headerSize);
+            CffIndex topDictionaryIndex = ReadIndex(cffData, nameIndex.EndOffset);
+            if (topDictionaryIndex.Count != 1) {
+                return PdfCffCharStringSubset.Unsupported(cffData, "Only single-font CFF1 data can be subset.");
+            }
+
+            int charStringsOffset = FindTopDictionaryInteger(cffData, topDictionaryIndex.GetObject(0), 17);
+            if (charStringsOffset <= 0 || charStringsOffset >= cffData.Length) {
+                return PdfCffCharStringSubset.Unsupported(cffData, "The CFF Top DICT does not expose a valid CharStrings offset.");
+            }
+
+            CffIndex charStrings = ReadIndex(cffData, charStringsOffset);
+            if (charStrings.Count != expectedGlyphCount) {
+                return PdfCffCharStringSubset.Unsupported(
+                    cffData,
+                    "The CFF CharStrings count does not match the OpenType glyph count.");
+            }
+
+            var retainedGlyphIds = new HashSet<int> { 0 };
+            for (int index = 0; index < usedGlyphIds.Count; index++) {
+                int glyphId = usedGlyphIds[index];
+                if (glyphId < 0 || glyphId >= charStrings.Count) {
+                    return PdfCffCharStringSubset.Unsupported(cffData, "A used glyph identifier is outside the CFF CharStrings range.");
+                }
+
+                retainedGlyphIds.Add(glyphId);
+            }
+
+            int prunedGlyphCount = charStrings.Count - retainedGlyphIds.Count;
+            if (prunedGlyphCount <= 0) {
+                return PdfCffCharStringSubset.Unchanged(cffData, charStrings.Count, charStrings.DataLength);
+            }
+
+            byte[][] programs = new byte[charStrings.Count][];
+            int subsetProgramBytes = 0;
+            for (int glyphId = 0; glyphId < charStrings.Count; glyphId++) {
+                byte[] program = retainedGlyphIds.Contains(glyphId)
+                    ? CopyObject(cffData, charStrings.GetObject(glyphId))
+                    : new[] { Type2EndChar };
+                programs[glyphId] = program;
+                subsetProgramBytes = checked(subsetProgramBytes + program.Length);
+            }
+
+            byte[] subsetIndex = BuildIndex(programs, subsetProgramBytes);
+            if (subsetIndex.Length > charStrings.TotalLength) {
+                return PdfCffCharStringSubset.Unsupported(cffData, "The rewritten CFF CharStrings INDEX grew beyond its original bounds.");
+            }
+
+            byte[] subsetData = cffData.ToArray();
+            Array.Clear(subsetData, charStrings.StartOffset, charStrings.TotalLength);
+            Buffer.BlockCopy(subsetIndex, 0, subsetData, charStrings.StartOffset, subsetIndex.Length);
+            return PdfCffCharStringSubset.Subset(
+                subsetData,
+                charStrings.Count,
+                retainedGlyphIds.Count,
+                prunedGlyphCount,
+                charStrings.DataLength,
+                subsetProgramBytes,
+                charStrings.TotalLength,
+                subsetIndex.Length);
+        } catch (Exception exception) when (IsCffDataException(exception)) {
+            return PdfCffCharStringSubset.Unsupported(cffData, exception.Message);
+        }
+    }
+
+    private static CffIndex ReadIndex(byte[] data, int offset) {
+        EnsureRange(data, offset, 2);
+        int count = ReadUInt16(data, offset);
+        if (count == 0) {
+            return new CffIndex(offset, 0, offset + 2, offset + 2, Array.Empty<int>());
+        }
+
+        EnsureRange(data, offset + 2, 1);
+        int offSize = data[offset + 2];
+        if (offSize < 1 || offSize > 4) {
+            throw new NotSupportedException("The CFF INDEX offset size is invalid.");
+        }
+
+        int offsetsStart = offset + 3;
+        int offsetBytes = checked((count + 1) * offSize);
+        EnsureRange(data, offsetsStart, offsetBytes);
+        var offsets = new int[count + 1];
+        for (int index = 0; index <= count; index++) {
+            offsets[index] = ReadOffset(data, offsetsStart + index * offSize, offSize);
+            if (offsets[index] < 1 || (index > 0 && offsets[index] < offsets[index - 1])) {
+                throw new NotSupportedException("The CFF INDEX offsets are invalid.");
+            }
+        }
+
+        int dataStart = checked(offsetsStart + offsetBytes);
+        int dataLength = offsets[count] - 1;
+        EnsureRange(data, dataStart, dataLength);
+        return new CffIndex(offset, count, dataStart, checked(dataStart + dataLength), offsets);
+    }
+
+    private static int FindTopDictionaryInteger(byte[] data, CffObject dictionary, int targetOperator) {
+        var operands = new List<double>();
+        int offset = dictionary.Offset;
+        int end = checked(dictionary.Offset + dictionary.Length);
+        while (offset < end) {
+            int value = data[offset++];
+            if (value >= 32 || value == 28 || value == 29 || value == 30 || value == 255) {
+                operands.Add(ReadDictionaryNumber(data, ref offset, end, value));
+                continue;
+            }
+
+            int dictionaryOperator = value;
+            if (value == 12) {
+                if (offset >= end) {
+                    throw new NotSupportedException("The CFF Top DICT contains a truncated escaped operator.");
+                }
+
+                dictionaryOperator = 1200 + data[offset++];
+            }
+
+            if (dictionaryOperator == targetOperator) {
+                if (operands.Count == 0) {
+                    throw new NotSupportedException("The CFF Top DICT CharStrings operator has no operand.");
+                }
+
+                double operand = operands[operands.Count - 1];
+                if (operand < 0 || operand > int.MaxValue || Math.Abs(operand - Math.Round(operand)) > 0.00001D) {
+                    throw new NotSupportedException("The CFF Top DICT CharStrings offset is not an integer.");
+                }
+
+                return checked((int)Math.Round(operand));
+            }
+
+            operands.Clear();
+        }
+
+        return -1;
+    }
+
+    private static double ReadDictionaryNumber(byte[] data, ref int offset, int end, int firstByte) {
+        if (firstByte >= 32 && firstByte <= 246) {
+            return firstByte - 139;
+        }
+
+        if (firstByte >= 247 && firstByte <= 250) {
+            EnsureDictionaryRange(offset, 1, end);
+            return (firstByte - 247) * 256 + data[offset++] + 108;
+        }
+
+        if (firstByte >= 251 && firstByte <= 254) {
+            EnsureDictionaryRange(offset, 1, end);
+            return -(firstByte - 251) * 256 - data[offset++] - 108;
+        }
+
+        if (firstByte == 28) {
+            EnsureDictionaryRange(offset, 2, end);
+            int result = unchecked((short)((data[offset] << 8) | data[offset + 1]));
+            offset += 2;
+            return result;
+        }
+
+        if (firstByte == 29) {
+            EnsureDictionaryRange(offset, 4, end);
+            int result = unchecked((int)(((uint)data[offset] << 24) |
+                ((uint)data[offset + 1] << 16) |
+                ((uint)data[offset + 2] << 8) |
+                data[offset + 3]));
+            offset += 4;
+            return result;
+        }
+
+        if (firstByte == 255) {
+            EnsureDictionaryRange(offset, 4, end);
+            int fixedValue = unchecked((int)(((uint)data[offset] << 24) |
+                ((uint)data[offset + 1] << 16) |
+                ((uint)data[offset + 2] << 8) |
+                data[offset + 3]));
+            offset += 4;
+            return fixedValue / 65536D;
+        }
+
+        if (firstByte == 30) {
+            var text = new StringBuilder();
+            bool complete = false;
+            while (offset < end && !complete) {
+                int packed = data[offset++];
+                AppendRealNibble(text, packed >> 4, ref complete);
+                if (!complete) {
+                    AppendRealNibble(text, packed & 0x0F, ref complete);
+                }
+            }
+
+            if (!complete || !double.TryParse(text.ToString(), System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out double real)) {
+                throw new NotSupportedException("The CFF Top DICT contains an invalid real operand.");
+            }
+
+            return real;
+        }
+
+        throw new NotSupportedException("The CFF Top DICT contains an unsupported operand encoding.");
+    }
+
+    private static void AppendRealNibble(StringBuilder text, int nibble, ref bool complete) {
+        switch (nibble) {
+            case 0x0A:
+                text.Append('.');
+                break;
+            case 0x0B:
+                text.Append('E');
+                break;
+            case 0x0C:
+                text.Append("E-");
+                break;
+            case 0x0E:
+                text.Append('-');
+                break;
+            case 0x0F:
+                complete = true;
+                break;
+            case 0x0D:
+                throw new NotSupportedException("The CFF Top DICT real operand contains a reserved nibble.");
+            default:
+                text.Append((char)('0' + nibble));
+                break;
+        }
+    }
+
+    private static byte[] BuildIndex(byte[][] objects, int dataLength) {
+        int maximumOffset = checked(dataLength + 1);
+        int offSize = maximumOffset <= byte.MaxValue
+            ? 1
+            : maximumOffset <= ushort.MaxValue
+                ? 2
+                : maximumOffset <= 0xFFFFFF
+                    ? 3
+                    : 4;
+        int headerLength = checked(3 + (objects.Length + 1) * offSize);
+        byte[] result = new byte[checked(headerLength + dataLength)];
+        WriteUInt16(result, 0, checked((ushort)objects.Length));
+        result[2] = (byte)offSize;
+
+        int relativeOffset = 1;
+        int dataOffset = headerLength;
+        for (int index = 0; index < objects.Length; index++) {
+            WriteOffset(result, 3 + index * offSize, offSize, relativeOffset);
+            byte[] value = objects[index];
+            Buffer.BlockCopy(value, 0, result, dataOffset, value.Length);
+            dataOffset += value.Length;
+            relativeOffset = checked(relativeOffset + value.Length);
+        }
+
+        WriteOffset(result, 3 + objects.Length * offSize, offSize, relativeOffset);
+        return result;
+    }
+
+    private static byte[] CopyObject(byte[] data, CffObject value) {
+        var result = new byte[value.Length];
+        Buffer.BlockCopy(data, value.Offset, result, 0, value.Length);
+        return result;
+    }
+
+    private static int ReadOffset(byte[] data, int offset, int size) {
+        int value = 0;
+        for (int index = 0; index < size; index++) {
+            value = checked((value << 8) | data[offset + index]);
+        }
+
+        return value;
+    }
+
+    private static void WriteOffset(byte[] data, int offset, int size, int value) {
+        for (int index = size - 1; index >= 0; index--) {
+            data[offset + index] = (byte)(value & 0xFF);
+            value >>= 8;
+        }
+
+        if (value != 0) {
+            throw new NotSupportedException("The CFF INDEX offset exceeds its selected offset size.");
+        }
+    }
+
+    private static int ReadUInt16(byte[] data, int offset) =>
+        (data[offset] << 8) | data[offset + 1];
+
+    private static void WriteUInt16(byte[] data, int offset, ushort value) {
+        data[offset] = (byte)(value >> 8);
+        data[offset + 1] = (byte)(value & 0xFF);
+    }
+
+    private static void EnsureRange(byte[] data, int offset, int length) {
+        if (offset < 0 || length < 0 || offset > data.Length - length) {
+            throw new NotSupportedException("The CFF data is truncated or invalid.");
+        }
+    }
+
+    private static void EnsureDictionaryRange(int offset, int length, int end) {
+        if (offset < 0 || length < 0 || offset > end - length) {
+            throw new NotSupportedException("The CFF Top DICT operand is truncated.");
+        }
+    }
+
+    private static bool IsCffDataException(Exception exception) =>
+        exception is NotSupportedException ||
+        exception is ArgumentException ||
+        exception is ArithmeticException ||
+        exception is IndexOutOfRangeException;
+
+    private readonly struct CffIndex {
+        private readonly int[] _offsets;
+
+        internal CffIndex(int startOffset, int count, int dataOffset, int endOffset, int[] offsets) {
+            StartOffset = startOffset;
+            Count = count;
+            DataOffset = dataOffset;
+            EndOffset = endOffset;
+            _offsets = offsets;
+        }
+
+        internal int StartOffset { get; }
+        internal int Count { get; }
+        internal int DataOffset { get; }
+        internal int EndOffset { get; }
+        internal int DataLength => EndOffset - DataOffset;
+        internal int TotalLength => EndOffset - StartOffset;
+
+        internal CffObject GetObject(int index) {
+            if (index < 0 || index >= Count) {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            int start = checked(DataOffset + _offsets[index] - 1);
+            int end = checked(DataOffset + _offsets[index + 1] - 1);
+            return new CffObject(start, end - start);
+        }
+    }
+
+    private readonly struct CffObject {
+        internal CffObject(int offset, int length) {
+            Offset = offset;
+            Length = length;
+        }
+
+        internal int Offset { get; }
+        internal int Length { get; }
+    }
+}
+
+internal sealed class PdfCffCharStringSubset {
+    private PdfCffCharStringSubset(
+        byte[] data,
+        bool isSubset,
+        string? unsupportedReason,
+        int glyphCount,
+        int retainedGlyphCount,
+        int prunedGlyphCount,
+        int originalProgramBytes,
+        int subsetProgramBytes,
+        int originalIndexBytes,
+        int subsetIndexBytes) {
+        Data = data;
+        IsSubset = isSubset;
+        UnsupportedReason = unsupportedReason;
+        GlyphCount = glyphCount;
+        RetainedGlyphCount = retainedGlyphCount;
+        PrunedGlyphCount = prunedGlyphCount;
+        OriginalProgramBytes = originalProgramBytes;
+        SubsetProgramBytes = subsetProgramBytes;
+        OriginalIndexBytes = originalIndexBytes;
+        SubsetIndexBytes = subsetIndexBytes;
+    }
+
+    internal byte[] Data { get; }
+    internal bool IsSubset { get; }
+    internal string? UnsupportedReason { get; }
+    internal int GlyphCount { get; }
+    internal int RetainedGlyphCount { get; }
+    internal int PrunedGlyphCount { get; }
+    internal int OriginalProgramBytes { get; }
+    internal int SubsetProgramBytes { get; }
+    internal int OriginalIndexBytes { get; }
+    internal int SubsetIndexBytes { get; }
+
+    internal static PdfCffCharStringSubset Subset(byte[] data, int glyphCount, int retainedGlyphCount, int prunedGlyphCount, int originalProgramBytes, int subsetProgramBytes, int originalIndexBytes, int subsetIndexBytes) =>
+        new(data, true, null, glyphCount, retainedGlyphCount, prunedGlyphCount, originalProgramBytes, subsetProgramBytes, originalIndexBytes, subsetIndexBytes);
+
+    internal static PdfCffCharStringSubset Unchanged(byte[] data, int glyphCount, int programBytes) =>
+        new(data.ToArray(), false, null, glyphCount, glyphCount, 0, programBytes, programBytes, 0, 0);
+
+    internal static PdfCffCharStringSubset Unsupported(byte[] data, string reason) =>
+        new(data.ToArray(), false, reason, 0, 0, 0, 0, 0, 0, 0);
+}

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfComplianceValidator.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfComplianceValidator.cs
@@ -39,11 +39,50 @@ internal static class PdfComplianceValidator {
         Guard.NotNull(options, nameof(options));
         Guard.ComplianceProfile(options.ComplianceProfile, nameof(options.ComplianceProfile));
 
-        if (options.ComplianceProfile == PdfComplianceProfile.None) {
+        if (options.ComplianceProfile == PdfComplianceProfile.None ||
+            options.ComplianceProfile == PdfComplianceProfile.PdfA2B ||
+            options.ComplianceProfile == PdfComplianceProfile.PdfA3B ||
+            options.ComplianceProfile == PdfComplianceProfile.PdfUa1 ||
+            options.ComplianceProfile == PdfComplianceProfile.FacturX ||
+            options.ComplianceProfile == PdfComplianceProfile.Zugferd) {
             return;
         }
 
         throw new NotSupportedException(BuildUnsupportedProfileMessage(options.ComplianceProfile));
+    }
+
+    internal static void ValidateGeneratedDocument(PdfOptions options, string? documentTitle, PdfGeneratedDocumentComplianceEvidence evidence) {
+        Guard.NotNull(options, nameof(options));
+        Guard.NotNull(evidence, nameof(evidence));
+        if (options.ComplianceProfile != PdfComplianceProfile.PdfA2B &&
+            options.ComplianceProfile != PdfComplianceProfile.PdfA3B &&
+            options.ComplianceProfile != PdfComplianceProfile.PdfUa1 &&
+            options.ComplianceProfile != PdfComplianceProfile.FacturX &&
+            options.ComplianceProfile != PdfComplianceProfile.Zugferd) {
+            return;
+        }
+
+        PdfComplianceReadinessReport readiness = PdfComplianceAnalyzer.AssessDocument(
+            options.ComplianceProfile,
+            options,
+            evidence.StandardFonts,
+            evidence.FontUsages,
+            documentTitle,
+            evidence.Images,
+            evidence.Drawings,
+            evidence.Forms);
+        PdfComplianceRequirement[] gaps = readiness.Requirements
+            .Where(requirement =>
+                !PdfComplianceProofReport.IsExternalValidationRequirement(requirement.Id) &&
+                requirement.Status != PdfComplianceRequirementStatus.Satisfied)
+            .ToArray();
+        if (gaps.Length == 0) {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            GetDisplayName(options.ComplianceProfile) + " generation requirements are not satisfied: " +
+            string.Join("; ", gaps.Select(static requirement => requirement.Id + ": " + requirement.Diagnostic)));
     }
 
     private static string BuildUnsupportedProfileMessage(PdfComplianceProfile profile) {

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfExternalTextShaper.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfExternalTextShaper.cs
@@ -15,14 +15,17 @@ internal static class PdfExternalTextShaper {
             font.FontName,
             font.FontDataSnapshot,
             isOpenTypeCff: false,
-            options.ShapingMode));
+            options.ShapingMode,
+            font.UnitsPerEm,
+            PdfTextDirectionResolver.Resolve(text),
+            options.Language));
 
         if (result == null) {
             glyphRun = null!;
             return false;
         }
 
-        glyphRun = BuildGlyphRun(text, result, font.GlyphCount, font.GetGlyphWidth1000, options.RecordGlyphUsage ? font.RecordGlyphUsage : null);
+        glyphRun = BuildGlyphRun(text, result, font.GlyphCount, font.UnitsPerEm, font.GetGlyphWidth1000, options.RecordGlyphUsage ? font.RecordGlyphUsage : null);
         options.ProviderShapedTextRecorder?.Invoke(text, font.FontName, false);
         return true;
     }
@@ -41,14 +44,17 @@ internal static class PdfExternalTextShaper {
             font.FontName,
             font.FontDataSnapshot,
             isOpenTypeCff: true,
-            options.ShapingMode));
+            options.ShapingMode,
+            font.UnitsPerEm,
+            PdfTextDirectionResolver.Resolve(text),
+            options.Language));
 
         if (result == null) {
             glyphRun = null!;
             return false;
         }
 
-        glyphRun = BuildGlyphRun(text, result, font.GlyphCount, font.GetGlyphWidth1000, options.RecordGlyphUsage ? font.RecordGlyphUsage : null);
+        glyphRun = BuildGlyphRun(text, result, font.GlyphCount, font.UnitsPerEm, font.GetGlyphWidth1000, options.RecordGlyphUsage ? font.RecordGlyphUsage : null);
         options.ProviderShapedTextRecorder?.Invoke(text, font.FontName, true);
         return true;
     }
@@ -57,6 +63,7 @@ internal static class PdfExternalTextShaper {
         string text,
         PdfTextShapingResult result,
         int glyphCount,
+        int unitsPerEm,
         Func<int, int> getGlyphWidth1000,
         Action<int, string>? recordGlyphUsage) {
         if (result.Glyphs.Count == 0) {
@@ -77,14 +84,65 @@ internal static class PdfExternalTextShaper {
                 throw new ArgumentException("PDF text shaping provider returned a glyph without Unicode extraction text.", nameof(result));
             }
 
+            int nominalWidth1000 = getGlyphWidth1000(shapedGlyph.GlyphId);
+            int advanceWidth1000 = shapedGlyph.AdvanceWidth.HasValue
+                ? ScaleToPdfUnits(shapedGlyph.AdvanceWidth.Value, unitsPerEm)
+                : nominalWidth1000;
+            int offsetX1000 = ScaleToPdfUnits(shapedGlyph.OffsetX, unitsPerEm);
+            int offsetY1000 = ScaleToPdfUnits(shapedGlyph.OffsetY, unitsPerEm);
             recordGlyphUsage?.Invoke(shapedGlyph.GlyphId, shapedGlyph.UnicodeText);
             glyphs.Add(new PdfGlyphInfo(
                 shapedGlyph.GlyphId,
                 shapedGlyph.UnicodeText,
                 shapedGlyph.TextIndex,
-                getGlyphWidth1000(shapedGlyph.GlyphId)));
+                nominalWidth1000,
+                advanceWidth1000,
+                offsetX1000,
+                offsetY1000));
         }
 
-        return new PdfGlyphRun(glyphs);
+        return new PdfGlyphRun(glyphs, Array.Empty<PdfTextEncodingDiagnostic>(), actualText: text);
+    }
+
+    private static int ScaleToPdfUnits(int value, int unitsPerEm) =>
+        checked((int)Math.Round(value * 1000D / unitsPerEm, MidpointRounding.AwayFromZero));
+}
+
+internal static class PdfTextDirectionResolver {
+    internal static PdfTextDirection Resolve(string text) {
+        for (int index = 0; index < text.Length;) {
+            int scalar = ReadScalar(text, ref index);
+            if (IsRightToLeft(scalar)) {
+                return PdfTextDirection.RightToLeft;
+            }
+
+            if (IsLeftToRight(scalar)) {
+                return PdfTextDirection.LeftToRight;
+            }
+        }
+
+        return PdfTextDirection.Auto;
+    }
+
+    private static bool IsRightToLeft(int scalar) =>
+        (scalar >= 0x0590 && scalar <= 0x08FF) ||
+        (scalar >= 0xFB1D && scalar <= 0xFDFF) ||
+        (scalar >= 0xFE70 && scalar <= 0xFEFF) ||
+        (scalar >= 0x10800 && scalar <= 0x10FFF) ||
+        (scalar >= 0x1E800 && scalar <= 0x1EEFF);
+
+    private static bool IsLeftToRight(int scalar) =>
+        (scalar >= 'A' && scalar <= 'Z') ||
+        (scalar >= 'a' && scalar <= 'z') ||
+        (scalar >= 0x00C0 && scalar <= 0x058F) ||
+        (scalar >= 0x0900 && scalar <= 0x1FFF) ||
+        (scalar >= 0x2C00 && scalar <= 0xA7FF) ||
+        (scalar >= 0x10000 && scalar <= 0x107FF);
+
+    private static int ReadScalar(string text, ref int index) {
+        char first = text[index++];
+        return char.IsHighSurrogate(first) && index < text.Length && char.IsLowSurrogate(text[index])
+            ? char.ConvertToUtf32(first, text[index++])
+            : first;
     }
 }

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfFileAssembler.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfFileAssembler.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Security.Cryptography;
 
 namespace OfficeIMO.Pdf;
 
@@ -9,9 +10,10 @@ internal static class PdfFileAssembler {
         int infoId,
         PdfFileVersion fileVersion = PdfFileVersion.Pdf14,
         PdfStandardEncryptionOptions? encryption = null,
-        long objectMemoryLimitBytes = PdfObjectStore.DefaultMemoryLimitBytes) {
+        long objectMemoryLimitBytes = PdfObjectStore.DefaultMemoryLimitBytes,
+        string? trailerIdEntry = null) {
         using var stream = new MemoryStream();
-        Assemble(stream, objects, catalogId, infoId, fileVersion, encryption, objectMemoryLimitBytes);
+        Assemble(stream, objects, catalogId, infoId, fileVersion, encryption, objectMemoryLimitBytes, trailerIdEntry);
         return stream.ToArray();
     }
 
@@ -22,7 +24,8 @@ internal static class PdfFileAssembler {
         int infoId,
         PdfFileVersion fileVersion = PdfFileVersion.Pdf14,
         PdfStandardEncryptionOptions? encryption = null,
-        long objectMemoryLimitBytes = PdfObjectStore.DefaultMemoryLimitBytes) {
+        long objectMemoryLimitBytes = PdfObjectStore.DefaultMemoryLimitBytes,
+        string? trailerIdEntry = null) {
         Guard.FileVersion(fileVersion, nameof(fileVersion));
         Guard.NotNull(destination, nameof(destination));
         Guard.NotNull(objects, nameof(objects));
@@ -38,6 +41,8 @@ internal static class PdfFileAssembler {
         }
 
         byte[] header = PdfEncoding.Latin1GetBytes("%PDF-" + GetHeaderVersion(fileVersion) + "\n%\u00e2\u00e3\u00cf\u00d3\n");
+        using HashAlgorithm? fileIdHash = encryptionAssembly == null ? SHA256.Create() : null;
+        fileIdHash?.TransformBlock(header, 0, header.Length, header, 0);
         destination.Write(header, 0, header.Length);
         long written = header.LongLength;
 
@@ -45,14 +50,17 @@ internal static class PdfFileAssembler {
         for (int i = 0; i < objects.Count; i++) {
             offsets.Add(written);
             if (objects is PdfObjectStore objectStore) {
-                objectStore.CopyTo(i, destination);
+                objectStore.CopyTo(i, destination, fileIdHash);
                 written += objectStore.GetLength(i);
             } else {
                 byte[] obj = objects[i];
+                fileIdHash?.TransformBlock(obj, 0, obj.Length, obj, 0);
                 destination.Write(obj, 0, obj.Length);
                 written += obj.LongLength;
             }
         }
+
+        byte[] fileId = encryptionAssembly?.FileId ?? FinalizeFileId(fileIdHash!);
 
         long xrefPos = written;
         var trailer = new StringBuilder();
@@ -67,21 +75,31 @@ internal static class PdfFileAssembler {
         trailer.Append("<< /Size ").Append((objects.Count + 1).ToString(CultureInfo.InvariantCulture))
             .Append(" /Root ").Append(PdfSyntaxEscaper.IndirectReference(catalogId))
             .Append(infoId > 0 ? " /Info " + PdfSyntaxEscaper.IndirectReference(infoId) : string.Empty)
-            .Append(BuildTrailerSecurityEntries(encryptionAssembly)).Append(" >>\n");
+            .Append(BuildTrailerEntries(encryptionAssembly, fileId, trailerIdEntry)).Append(" >>\n");
         trailer.Append("startxref\n").Append(xrefPos.ToString(CultureInfo.InvariantCulture)).Append("\n%%EOF\n");
         byte[] trailerBytes = Encoding.ASCII.GetBytes(trailer.ToString());
         destination.Write(trailerBytes, 0, trailerBytes.Length);
         return written + trailerBytes.LongLength;
     }
 
-    private static string BuildTrailerSecurityEntries(PdfEncryptionAssembly? encryptionAssembly) {
-        if (encryptionAssembly == null) {
-            return string.Empty;
+    private static string BuildTrailerEntries(PdfEncryptionAssembly? encryptionAssembly, byte[] fileId, string? trailerIdEntry) {
+        if (encryptionAssembly == null && !string.IsNullOrWhiteSpace(trailerIdEntry)) {
+            return trailerIdEntry!;
         }
 
-        string id = PdfSyntaxEscaper.HexString(encryptionAssembly.FileId);
-        return " /Encrypt " + PdfSyntaxEscaper.IndirectReference(encryptionAssembly.EncryptionObjectNumber) +
-            " /ID [" + id + " " + id + "]";
+        string id = PdfSyntaxEscaper.HexString(fileId);
+        string encryptionEntry = encryptionAssembly == null
+            ? string.Empty
+            : " /Encrypt " + PdfSyntaxEscaper.IndirectReference(encryptionAssembly.EncryptionObjectNumber);
+        return encryptionEntry + " /ID [" + id + " " + id + "]";
+    }
+
+    private static byte[] FinalizeFileId(HashAlgorithm hash) {
+        hash.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+        byte[] fullHash = hash.Hash ?? throw new InvalidOperationException("Unable to calculate the PDF trailer file identifier.");
+        var fileId = new byte[16];
+        Buffer.BlockCopy(fullHash, 0, fileId, 0, fileId.Length);
+        return fileId;
     }
 
     private static PdfFileVersion GetMinimumEncryptionVersion(PdfStandardEncryptionAlgorithm algorithm) {

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfGlyphRun.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfGlyphRun.cs
@@ -2,18 +2,21 @@ namespace OfficeIMO.Pdf;
 
 internal sealed class PdfGlyphRun {
     public PdfGlyphRun(IReadOnlyList<PdfGlyphInfo> glyphs)
-        : this(glyphs, Array.Empty<PdfTextEncodingDiagnostic>()) {
+        : this(glyphs, Array.Empty<PdfTextEncodingDiagnostic>(), actualText: null) {
     }
 
-    public PdfGlyphRun(IReadOnlyList<PdfGlyphInfo> glyphs, IReadOnlyList<PdfTextEncodingDiagnostic> diagnostics) {
+    public PdfGlyphRun(IReadOnlyList<PdfGlyphInfo> glyphs, IReadOnlyList<PdfTextEncodingDiagnostic> diagnostics, string? actualText = null) {
         Glyphs = glyphs ?? throw new ArgumentNullException(nameof(glyphs));
         Diagnostics = diagnostics ?? throw new ArgumentNullException(nameof(diagnostics));
+        ActualText = string.IsNullOrEmpty(actualText) ? null : actualText;
     }
 
     public IReadOnlyList<PdfGlyphInfo> Glyphs { get; }
     public IReadOnlyList<PdfTextEncodingDiagnostic> Diagnostics { get; }
+    public string? ActualText { get; }
     public bool HasMissingGlyphs => Diagnostics.Count > 0;
     public int TotalAdvanceWidth1000 => Glyphs.Sum(glyph => glyph.AdvanceWidth1000);
+    public bool HasPositioning => Glyphs.Any(glyph => glyph.HasPositioning);
 
     public string ToGlyphHex() {
         var sb = new StringBuilder(Glyphs.Count * 4);
@@ -23,34 +26,61 @@ internal sealed class PdfGlyphRun {
 
         return sb.ToString();
     }
+
+    public PdfTextShowCommand ToTextShowCommand() =>
+        new(ToGlyphHex(), HasPositioning ? Glyphs : null, ActualText);
+}
+
+internal sealed class PdfTextShowCommand {
+    internal PdfTextShowCommand(string glyphHex, IReadOnlyList<PdfGlyphInfo>? positionedGlyphs = null, string? actualText = null) {
+        GlyphHex = glyphHex ?? throw new ArgumentNullException(nameof(glyphHex));
+        PositionedGlyphs = positionedGlyphs;
+        ActualText = string.IsNullOrEmpty(actualText) ? null : actualText;
+    }
+
+    internal string GlyphHex { get; }
+    internal IReadOnlyList<PdfGlyphInfo>? PositionedGlyphs { get; }
+    internal string? ActualText { get; }
+    internal bool HasPositioning => PositionedGlyphs != null && PositionedGlyphs.Count > 0;
 }
 
 internal readonly struct PdfGlyphInfo {
     public PdfGlyphInfo(int glyphId, int unicodeScalar, int textIndex, int advanceWidth1000)
-        : this(glyphId, char.ConvertFromUtf32(unicodeScalar), unicodeScalar, textIndex, advanceWidth1000) {
+        : this(glyphId, char.ConvertFromUtf32(unicodeScalar), unicodeScalar, textIndex, advanceWidth1000, advanceWidth1000, 0, 0) {
     }
 
     public PdfGlyphInfo(int glyphId, string unicodeText, int textIndex, int advanceWidth1000)
-        : this(glyphId, unicodeText, unicodeText != null && unicodeText.Length > 0 ? char.ConvertToUtf32(unicodeText, 0) : 0, textIndex, advanceWidth1000) {
+        : this(glyphId, unicodeText, unicodeText != null && unicodeText.Length > 0 ? char.ConvertToUtf32(unicodeText, 0) : 0, textIndex, advanceWidth1000, advanceWidth1000, 0, 0) {
     }
 
-    private PdfGlyphInfo(int glyphId, string unicodeText, int unicodeScalar, int textIndex, int advanceWidth1000) {
+    public PdfGlyphInfo(int glyphId, string unicodeText, int textIndex, int nominalWidth1000, int advanceWidth1000, int offsetX1000, int offsetY1000)
+        : this(glyphId, unicodeText, unicodeText != null && unicodeText.Length > 0 ? char.ConvertToUtf32(unicodeText, 0) : 0, textIndex, nominalWidth1000, advanceWidth1000, offsetX1000, offsetY1000) {
+    }
+
+    private PdfGlyphInfo(int glyphId, string unicodeText, int unicodeScalar, int textIndex, int nominalWidth1000, int advanceWidth1000, int offsetX1000, int offsetY1000) {
         GlyphId = glyphId;
         UnicodeText = unicodeText ?? string.Empty;
         UnicodeScalar = unicodeScalar;
         TextIndex = textIndex;
+        NominalWidth1000 = nominalWidth1000;
         AdvanceWidth1000 = advanceWidth1000;
+        OffsetX1000 = offsetX1000;
+        OffsetY1000 = offsetY1000;
     }
 
     public int GlyphId { get; }
     public string UnicodeText { get; }
     public int UnicodeScalar { get; }
     public int TextIndex { get; }
+    public int NominalWidth1000 { get; }
     public int AdvanceWidth1000 { get; }
+    public int OffsetX1000 { get; }
+    public int OffsetY1000 { get; }
+    public bool HasPositioning => AdvanceWidth1000 != NominalWidth1000 || OffsetX1000 != 0 || OffsetY1000 != 0;
 }
 
 internal readonly struct PdfTextShapingOptions {
-    public PdfTextShapingOptions(bool recordGlyphUsage, bool throwOnMissingGlyph, bool skipLayoutControls, bool reportControlCharacters, string source, string fontName, PdfTextShapingMode shapingMode = PdfTextShapingMode.UnicodeScalar, IPdfTextShapingProvider? shapingProvider = null, Action<string, string, bool>? providerShapedTextRecorder = null) {
+    public PdfTextShapingOptions(bool recordGlyphUsage, bool throwOnMissingGlyph, bool skipLayoutControls, bool reportControlCharacters, string source, string fontName, PdfTextShapingMode shapingMode = PdfTextShapingMode.UnicodeScalar, IPdfTextShapingProvider? shapingProvider = null, Action<string, string, bool>? providerShapedTextRecorder = null, string? language = null) {
         RecordGlyphUsage = recordGlyphUsage;
         ThrowOnMissingGlyph = throwOnMissingGlyph;
         SkipLayoutControls = skipLayoutControls;
@@ -60,6 +90,7 @@ internal readonly struct PdfTextShapingOptions {
         ShapingMode = shapingMode;
         ShapingProvider = shapingProvider;
         ProviderShapedTextRecorder = providerShapedTextRecorder;
+        Language = string.IsNullOrWhiteSpace(language) ? null : language;
     }
 
     public bool RecordGlyphUsage { get; }
@@ -71,9 +102,10 @@ internal readonly struct PdfTextShapingOptions {
     public PdfTextShapingMode ShapingMode { get; }
     public IPdfTextShapingProvider? ShapingProvider { get; }
     public Action<string, string, bool>? ProviderShapedTextRecorder { get; }
+    public string? Language { get; }
 
-    public static PdfTextShapingOptions ForRendering(string fontName, PdfTextShapingMode shapingMode = PdfTextShapingMode.UnicodeScalar, IPdfTextShapingProvider? shapingProvider = null, Action<string, string, bool>? providerShapedTextRecorder = null) =>
-        new PdfTextShapingOptions(recordGlyphUsage: true, throwOnMissingGlyph: true, skipLayoutControls: false, reportControlCharacters: false, source: string.Empty, fontName: fontName, shapingMode: shapingMode, shapingProvider: shapingProvider, providerShapedTextRecorder: providerShapedTextRecorder);
+    public static PdfTextShapingOptions ForRendering(string fontName, PdfTextShapingMode shapingMode = PdfTextShapingMode.UnicodeScalar, IPdfTextShapingProvider? shapingProvider = null, Action<string, string, bool>? providerShapedTextRecorder = null, string? language = null) =>
+        new PdfTextShapingOptions(recordGlyphUsage: true, throwOnMissingGlyph: true, skipLayoutControls: false, reportControlCharacters: false, source: string.Empty, fontName: fontName, shapingMode: shapingMode, shapingProvider: shapingProvider, providerShapedTextRecorder: providerShapedTextRecorder, language: language);
 
     public static PdfTextShapingOptions ForDiagnostics(string source, string fontName, PdfTextShapingMode shapingMode = PdfTextShapingMode.UnicodeScalar, IPdfTextShapingProvider? shapingProvider = null) =>
         new PdfTextShapingOptions(recordGlyphUsage: false, throwOnMissingGlyph: false, skipLayoutControls: true, reportControlCharacters: true, source: source, fontName: fontName, shapingMode: shapingMode, shapingProvider: shapingProvider);

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfObjectStore.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfObjectStore.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Security.Cryptography;
 
 namespace OfficeIMO.Pdf;
 
@@ -102,13 +103,14 @@ internal sealed class PdfObjectStore : IList<byte[]>, IReadOnlyList<byte[]>, IDi
         return _entries[index].Length;
     }
 
-    internal void CopyTo(int index, Stream destination) {
+    internal void CopyTo(int index, Stream destination, HashAlgorithm? hash = null) {
         ThrowIfDisposed();
         Guard.NotNull(destination, nameof(destination));
         if (!destination.CanWrite) throw new ArgumentException("Destination stream must be writable.", nameof(destination));
 
         Entry entry = _entries[index];
         if (entry.Bytes != null) {
+            hash?.TransformBlock(entry.Bytes, 0, entry.Bytes.Length, entry.Bytes, 0);
             destination.Write(entry.Bytes, 0, entry.Bytes.Length);
             return;
         }
@@ -120,6 +122,7 @@ internal sealed class PdfObjectStore : IList<byte[]>, IReadOnlyList<byte[]>, IDi
         while (remaining > 0) {
             int read = source.Read(buffer, 0, Math.Min(buffer.Length, remaining));
             if (read == 0) throw new EndOfStreamException("PDF object spill storage ended unexpectedly.");
+            hash?.TransformBlock(buffer, 0, read, buffer, 0);
             destination.Write(buffer, 0, read);
             remaining -= read;
         }

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfOpenTypeCffFontProgram.Subsetting.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfOpenTypeCffFontProgram.Subsetting.cs
@@ -29,12 +29,19 @@ internal sealed partial class PdfOpenTypeCffFontProgram {
 
     internal PdfOpenTypeCffCompactFontFile BuildCompactOpenTypeFontFilePlan() {
         var tables = new List<SubsetTable>();
+        IReadOnlyList<int> usedGlyphIds = GetUsedGlyphIds();
+        PdfCffCharStringSubset? charStringSubset = null;
         foreach (KeyValuePair<string, TableRecord> table in _tables.OrderBy(entry => entry.Key, StringComparer.Ordinal)) {
             if (!CompactOpenTypeCffTables.Contains(table.Key)) {
                 continue;
             }
 
             byte[] content = CopyTableData(table.Value);
+            if (string.Equals(table.Key, "CFF ", StringComparison.Ordinal)) {
+                charStringSubset = PdfCffCharStringSubsetter.Create(content, usedGlyphIds, GlyphCount);
+                content = charStringSubset.Data;
+            }
+
             if (string.Equals(table.Key, "head", StringComparison.Ordinal)) {
                 WriteUInt32(content, 8, 0);
             }
@@ -53,18 +60,20 @@ internal sealed partial class PdfOpenTypeCffFontProgram {
                 originalTables,
                 originalTables,
                 Array.Empty<string>(),
-                Array.Empty<string>());
+                Array.Empty<string>(),
+                charStringSubset);
         }
 
         byte[] compact = BuildOpenTypeFile(tables);
-        if (compact.Length < _data.Length) {
+        if (compact.Length < _data.Length || (compact.Length == _data.Length && charStringSubset?.IsSubset == true)) {
             return new PdfOpenTypeCffCompactFontFile(
                 compact,
-                isCompact: true,
+                isCompact: compact.Length < _data.Length,
                 originalTables,
                 embeddedTables,
                 removedTables,
-                removedLayoutTables);
+                removedLayoutTables,
+                charStringSubset);
         }
 
         return new PdfOpenTypeCffCompactFontFile(
@@ -73,7 +82,8 @@ internal sealed partial class PdfOpenTypeCffFontProgram {
             originalTables,
             originalTables,
             Array.Empty<string>(),
-            Array.Empty<string>());
+            Array.Empty<string>(),
+            charStringSubset: null);
     }
 
     private static bool ContainsRequiredCompactTables(IReadOnlyList<SubsetTable> tables) {
@@ -221,13 +231,15 @@ internal sealed class PdfOpenTypeCffCompactFontFile {
         IReadOnlyList<string> originalTables,
         IReadOnlyList<string> embeddedTables,
         IReadOnlyList<string> removedTables,
-        IReadOnlyList<string> removedLayoutTables) {
+        IReadOnlyList<string> removedLayoutTables,
+        PdfCffCharStringSubset? charStringSubset) {
         Data = data ?? throw new ArgumentNullException(nameof(data));
         IsCompact = isCompact;
         OriginalTables = originalTables?.ToArray() ?? throw new ArgumentNullException(nameof(originalTables));
         EmbeddedTables = embeddedTables?.ToArray() ?? throw new ArgumentNullException(nameof(embeddedTables));
         RemovedTables = removedTables?.ToArray() ?? throw new ArgumentNullException(nameof(removedTables));
         RemovedLayoutTables = removedLayoutTables?.ToArray() ?? throw new ArgumentNullException(nameof(removedLayoutTables));
+        CharStringSubset = charStringSubset;
     }
 
     public byte[] Data { get; }
@@ -236,4 +248,5 @@ internal sealed class PdfOpenTypeCffCompactFontFile {
     public IReadOnlyList<string> EmbeddedTables { get; }
     public IReadOnlyList<string> RemovedTables { get; }
     public IReadOnlyList<string> RemovedLayoutTables { get; }
+    public PdfCffCharStringSubset? CharStringSubset { get; }
 }

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfOpenTypeCffFontProgram.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfOpenTypeCffFontProgram.cs
@@ -161,76 +161,64 @@ internal sealed partial class PdfOpenTypeCffFontProgram {
         return ScaleMetric(_advanceWidths[glyphId], UnitsPerEm);
     }
 
-    public double MeasureTextWidth(string? text, double fontSize, PdfTextShapingMode shapingMode = PdfTextShapingMode.UnicodeScalar, IPdfTextShapingProvider? shapingProvider = null) {
+    public double MeasureTextWidth(string? text, double fontSize, PdfTextShapingMode shapingMode = PdfTextShapingMode.UnicodeScalar, IPdfTextShapingProvider? shapingProvider = null, string? language = null) {
         if (string.IsNullOrEmpty(text)) {
             return 0D;
         }
 
-        if (PdfExternalTextShaper.TryShapeText(text!, this, PdfTextShapingOptions.ForRendering(FontName, shapingMode, shapingProvider), out PdfGlyphRun glyphRun)) {
-            return glyphRun.TotalAdvanceWidth1000 * fontSize / 1000D;
-        }
-
-        double width = 0D;
-        for (int index = 0; index < text!.Length;) {
-            int scalarStart = index;
-            if (shapingMode == PdfTextShapingMode.LatinLigatures &&
-                PdfLatinLigatureSubstitution.TryGetPresentationLigature(text, scalarStart, out int ligatureScalar, out int ligatureLength) &&
-                TryGetGlyphId(ligatureScalar, out int ligatureGlyphId) &&
-                ligatureGlyphId > 0) {
-                width += GetGlyphWidth1000(ligatureGlyphId) * fontSize / 1000D;
-                index += ligatureLength;
-                continue;
-            }
-
-            int scalar = ReadScalar(text, ref index);
-            if (!TryGetGlyphId(scalar, out int glyphId) || glyphId <= 0) {
-                throw CreateUnsupportedGlyphException(text, scalarStart, scalar);
-            }
-
-            width += GetGlyphWidth1000(glyphId) * fontSize / 1000D;
-        }
-
-        return width;
+        return ShapeText(text!, PdfTextShapingOptions.ForRendering(FontName, shapingMode, shapingProvider, language: language)).TotalAdvanceWidth1000 * fontSize / 1000D;
     }
 
     public string EncodeTextAsGlyphHex(string text, PdfTextShapingMode shapingMode = PdfTextShapingMode.UnicodeScalar, IPdfTextShapingProvider? shapingProvider = null) {
         Guard.NotNull(text, nameof(text));
-        if (PdfExternalTextShaper.TryShapeText(text, this, PdfTextShapingOptions.ForRendering(FontName, shapingMode, shapingProvider), out PdfGlyphRun glyphRun)) {
-            return glyphRun.ToGlyphHex();
+        return ShapeText(text, PdfTextShapingOptions.ForRendering(FontName, shapingMode, shapingProvider)).ToGlyphHex();
+    }
+
+    internal string EncodeTextAsGlyphHex(string text, PdfTextShapingMode shapingMode, IPdfTextShapingProvider? shapingProvider, Action<string, string, bool>? providerShapedTextRecorder, string? language = null) {
+        Guard.NotNull(text, nameof(text));
+        return ShapeText(text, PdfTextShapingOptions.ForRendering(FontName, shapingMode, shapingProvider, providerShapedTextRecorder, language)).ToGlyphHex();
+    }
+
+    internal PdfGlyphRun ShapeText(string text, PdfTextShapingOptions options) {
+        Guard.NotNull(text, nameof(text));
+        if (PdfExternalTextShaper.TryShapeText(text, this, options, out PdfGlyphRun glyphRun)) {
+            return glyphRun;
         }
 
-        var sb = new StringBuilder(text.Length * 4);
+        var glyphs = new List<PdfGlyphInfo>();
         for (int index = 0; index < text.Length;) {
             int scalarStart = index;
-            if (shapingMode == PdfTextShapingMode.LatinLigatures &&
+            if (options.ShapingMode == PdfTextShapingMode.LatinLigatures &&
                 PdfLatinLigatureSubstitution.TryGetPresentationLigature(text, scalarStart, out int ligatureScalar, out int ligatureLength) &&
                 TryGetGlyphId(ligatureScalar, out int ligatureGlyphId) &&
                 ligatureGlyphId > 0) {
-                RecordGlyphUsage(ligatureGlyphId, text.Substring(scalarStart, ligatureLength));
-                sb.Append(ligatureGlyphId.ToString("X4", CultureInfo.InvariantCulture));
+                string unicodeText = text.Substring(scalarStart, ligatureLength);
+                if (options.RecordGlyphUsage) {
+                    RecordGlyphUsage(ligatureGlyphId, unicodeText);
+                }
+
+                glyphs.Add(new PdfGlyphInfo(ligatureGlyphId, unicodeText, scalarStart, GetGlyphWidth1000(ligatureGlyphId)));
                 index += ligatureLength;
                 continue;
             }
 
             int scalar = ReadScalar(text, ref index);
             if (!TryGetGlyphId(scalar, out int glyphId) || glyphId <= 0) {
-                throw CreateUnsupportedGlyphException(text, scalarStart, scalar);
+                if (options.ThrowOnMissingGlyph) {
+                    throw CreateUnsupportedGlyphException(text, scalarStart, scalar);
+                }
+
+                continue;
             }
 
-            RecordGlyphUsage(glyphId, scalar);
-            sb.Append(glyphId.ToString("X4", CultureInfo.InvariantCulture));
+            if (options.RecordGlyphUsage) {
+                RecordGlyphUsage(glyphId, scalar);
+            }
+
+            glyphs.Add(new PdfGlyphInfo(glyphId, scalar, scalarStart, GetGlyphWidth1000(glyphId)));
         }
 
-        return sb.ToString();
-    }
-
-    internal string EncodeTextAsGlyphHex(string text, PdfTextShapingMode shapingMode, IPdfTextShapingProvider? shapingProvider, Action<string, string, bool>? providerShapedTextRecorder) {
-        Guard.NotNull(text, nameof(text));
-        if (PdfExternalTextShaper.TryShapeText(text, this, PdfTextShapingOptions.ForRendering(FontName, shapingMode, shapingProvider, providerShapedTextRecorder), out PdfGlyphRun glyphRun)) {
-            return glyphRun.ToGlyphHex();
-        }
-
-        return EncodeTextAsGlyphHex(text, shapingMode, shapingProvider);
+        return new PdfGlyphRun(glyphs);
     }
 
     public double GetAscender(double fontSize) =>

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfTrueTypeFontProgram.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfTrueTypeFontProgram.cs
@@ -50,12 +50,12 @@ internal sealed partial class PdfTrueTypeFontProgram {
         return width;
     }
 
-    public double MeasureTextWidth(string? text, double fontSize, PdfTextShapingMode shapingMode = PdfTextShapingMode.UnicodeScalar, IPdfTextShapingProvider? shapingProvider = null) {
+    public double MeasureTextWidth(string? text, double fontSize, PdfTextShapingMode shapingMode = PdfTextShapingMode.UnicodeScalar, IPdfTextShapingProvider? shapingProvider = null, string? language = null) {
         if (string.IsNullOrEmpty(text)) {
             return 0D;
         }
 
-        return ShapeText(text!, PdfTextShapingOptions.ForRendering(FontName, shapingMode, shapingProvider)).TotalAdvanceWidth1000 * fontSize / 1000D;
+        return ShapeText(text!, PdfTextShapingOptions.ForRendering(FontName, shapingMode, shapingProvider, language: language)).TotalAdvanceWidth1000 * fontSize / 1000D;
     }
 
     public double GetAscender(double fontSize) =>
@@ -85,9 +85,9 @@ internal sealed partial class PdfTrueTypeFontProgram {
         return ShapeText(text, PdfTextShapingOptions.ForRendering(FontName, shapingMode, shapingProvider)).ToGlyphHex();
     }
 
-    internal string EncodeTextAsGlyphHex(string text, PdfTextShapingMode shapingMode, IPdfTextShapingProvider? shapingProvider, Action<string, string, bool>? providerShapedTextRecorder) {
+    internal string EncodeTextAsGlyphHex(string text, PdfTextShapingMode shapingMode, IPdfTextShapingProvider? shapingProvider, Action<string, string, bool>? providerShapedTextRecorder, string? language = null) {
         Guard.NotNull(text, nameof(text));
-        return ShapeText(text, PdfTextShapingOptions.ForRendering(FontName, shapingMode, shapingProvider, providerShapedTextRecorder)).ToGlyphHex();
+        return ShapeText(text, PdfTextShapingOptions.ForRendering(FontName, shapingMode, shapingProvider, providerShapedTextRecorder, language)).ToGlyphHex();
     }
 
     internal PdfGlyphRun ShapeText(string text) {

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.AnnotationAppearances.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.AnnotationAppearances.cs
@@ -198,7 +198,7 @@ internal static partial class PdfWriter {
         content
             .FillColor(color)
             .MoveText(x, y)
-            .ShowText(EncodeTextShowCommand(text, font, pageOptions), fontSize)
+            .ShowText(EncodeTextShowCommand(text, font, pageOptions), fontSize, textRise)
             .EndText();
     }
 

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.AnnotationAppearances.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.AnnotationAppearances.cs
@@ -188,24 +188,18 @@ internal static partial class PdfWriter {
         PdfStandardFont font,
         PdfColor color,
         PdfOptions pageOptions) {
-        sb.Append("BT /")
-            .Append(PdfSyntaxEscaper.Name(fontResource))
-            .Append(' ')
-            .Append(FormatAppearanceNumber(fontSize))
-            .Append(" Tf ");
+        var content = new ContentStreamBuilder(sb)
+            .BeginText()
+            .Font(PdfSyntaxEscaper.Name(fontResource), fontSize);
         if (Math.Abs(textRise) > 0.0001D) {
-            sb.Append(FormatAppearanceNumber(textRise))
-                .Append(" Ts ");
+            content.TextRise(textRise);
         }
 
-        sb.Append(FormatAppearanceColor(color))
-            .Append(" rg ")
-            .Append(FormatAppearanceNumber(x))
-            .Append(' ')
-            .Append(FormatAppearanceNumber(y))
-            .Append(" Td <")
-            .Append(EncodeTextHex(text, font, pageOptions))
-            .Append("> Tj ET\n");
+        content
+            .FillColor(color)
+            .MoveText(x, y)
+            .ShowText(EncodeTextShowCommand(text, font, pageOptions), fontSize)
+            .EndText();
     }
 
     private static string GetFreeTextAppearanceFontResourceName(PdfStandardFont font, PdfOptions pageOptions) =>

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.ContentStream.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.ContentStream.cs
@@ -229,7 +229,7 @@ internal sealed class ContentStreamBuilder {
         return this;
     }
 
-    public ContentStreamBuilder ShowText(PdfTextShowCommand command, double fontSize) {
+    public ContentStreamBuilder ShowText(PdfTextShowCommand command, double fontSize, double currentTextRise = 0D) {
         Guard.NotNull(command, nameof(command));
         if (fontSize <= 0 || double.IsNaN(fontSize) || double.IsInfinity(fontSize)) {
             throw new ArgumentOutOfRangeException(nameof(fontSize), "PDF text font size must be positive and finite.");
@@ -244,7 +244,7 @@ internal sealed class ContentStreamBuilder {
         if (!command.HasPositioning) {
             ShowHexText(command.GlyphHex);
         } else {
-            AppendPositionedGlyphs(command.PositionedGlyphs!, fontSize);
+            AppendPositionedGlyphs(command.PositionedGlyphs!, fontSize, currentTextRise);
         }
 
         if (command.ActualText != null) {
@@ -254,12 +254,12 @@ internal sealed class ContentStreamBuilder {
         return this;
     }
 
-    private void AppendPositionedGlyphs(IReadOnlyList<PdfGlyphInfo> glyphs, double fontSize) {
+    private void AppendPositionedGlyphs(IReadOnlyList<PdfGlyphInfo> glyphs, double fontSize, double baseTextRise) {
         int currentOffsetY1000 = 0;
         for (int index = 0; index < glyphs.Count; index++) {
             PdfGlyphInfo glyph = glyphs[index];
             if (glyph.OffsetY1000 != currentOffsetY1000) {
-                _sb.Append(F(glyph.OffsetY1000 * fontSize / 1000D)).Append(" Ts\n");
+                _sb.Append(F(baseTextRise + glyph.OffsetY1000 * fontSize / 1000D)).Append(" Ts\n");
                 currentOffsetY1000 = glyph.OffsetY1000;
             }
 
@@ -281,7 +281,7 @@ internal sealed class ContentStreamBuilder {
         }
 
         if (currentOffsetY1000 != 0) {
-            _sb.Append("0 Ts\n");
+            _sb.Append(F(baseTextRise)).Append(" Ts\n");
         }
     }
 

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.ContentStream.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.ContentStream.cs
@@ -229,6 +229,62 @@ internal sealed class ContentStreamBuilder {
         return this;
     }
 
+    public ContentStreamBuilder ShowText(PdfTextShowCommand command, double fontSize) {
+        Guard.NotNull(command, nameof(command));
+        if (fontSize <= 0 || double.IsNaN(fontSize) || double.IsInfinity(fontSize)) {
+            throw new ArgumentOutOfRangeException(nameof(fontSize), "PDF text font size must be positive and finite.");
+        }
+
+        if (command.ActualText != null) {
+            _sb.Append("/Span << /ActualText ")
+                .Append(PdfSyntaxEscaper.TextString(command.ActualText))
+                .Append(" >> BDC\n");
+        }
+
+        if (!command.HasPositioning) {
+            ShowHexText(command.GlyphHex);
+        } else {
+            AppendPositionedGlyphs(command.PositionedGlyphs!, fontSize);
+        }
+
+        if (command.ActualText != null) {
+            _sb.Append("EMC\n");
+        }
+
+        return this;
+    }
+
+    private void AppendPositionedGlyphs(IReadOnlyList<PdfGlyphInfo> glyphs, double fontSize) {
+        int currentOffsetY1000 = 0;
+        for (int index = 0; index < glyphs.Count; index++) {
+            PdfGlyphInfo glyph = glyphs[index];
+            if (glyph.OffsetY1000 != currentOffsetY1000) {
+                _sb.Append(F(glyph.OffsetY1000 * fontSize / 1000D)).Append(" Ts\n");
+                currentOffsetY1000 = glyph.OffsetY1000;
+            }
+
+            int preAdjustment = -glyph.OffsetX1000;
+            int postAdjustment = glyph.OffsetX1000 + glyph.NominalWidth1000 - glyph.AdvanceWidth1000;
+            _sb.Append('[');
+            if (preAdjustment != 0) {
+                _sb.Append(F(preAdjustment)).Append(' ');
+            }
+
+            _sb.Append('<')
+                .Append(glyph.GlyphId.ToString("X4", CultureInfo.InvariantCulture))
+                .Append('>');
+            if (postAdjustment != 0) {
+                _sb.Append(' ').Append(F(postAdjustment));
+            }
+
+            _sb.Append("] TJ\n");
+        }
+
+        if (currentOffsetY1000 != 0) {
+            _sb.Append("0 Ts\n");
+        }
+    }
+
     private static string F(double value) {
         if (Math.Abs(value) < 0.0005D) {
             value = 0D;

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Drawing.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Drawing.cs
@@ -947,7 +947,7 @@ internal static partial class PdfWriter {
             .Font(fontRes, fontSize)
             .FillColor(effective ?? PdfColor.Black)
             .TextMatrix(x, y)
-            .ShowHexText(EncodeTextHex(text, font, opts))
+            .ShowText(EncodeTextShowCommand(text, font, opts), fontSize)
             .EndText();
     }
 

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.FontUsage.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.FontUsage.cs
@@ -86,7 +86,7 @@ internal static partial class PdfWriter {
             }
 
             foreach (PageImage image in page.Images) {
-                images.Add(new PdfGeneratedImageAccessibilityEvidence(!string.IsNullOrWhiteSpace(image.AlternativeText), image.IsBackgroundDecoration));
+                images.Add(new PdfGeneratedImageAccessibilityEvidence(!string.IsNullOrWhiteSpace(image.AlternativeText), image.IsDecorativeArtifact));
             }
 
             drawings.AddRange(page.Drawings);

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.FontUsage.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.FontUsage.cs
@@ -11,6 +11,13 @@ internal static partial class PdfWriter {
 
         using System.IDisposable? generatedSectionLayout = document?.BeginGeneratedSectionLayout();
         using LayoutResult layout = LayoutBlocks(blocks, options);
+        return CollectGeneratedComplianceEvidence(layout, options);
+    }
+
+    private static PdfGeneratedDocumentComplianceEvidence CollectGeneratedComplianceEvidence(LayoutResult layout, PdfOptions options) {
+        Guard.NotNull(layout, nameof(layout));
+        Guard.NotNull(options, nameof(options));
+
         var fonts = new System.Collections.Generic.HashSet<PdfStandardFont>();
         var fontUsages = new System.Collections.Generic.List<PdfGeneratedFontComplianceEvidence>();
         var images = new System.Collections.Generic.List<PdfGeneratedImageAccessibilityEvidence>();

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Fonts.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Fonts.cs
@@ -194,7 +194,7 @@ internal static partial class PdfWriter {
                 throw CreateTextEncodingException(diagnostics[0], nameof(text));
             }
 
-            return fontProgram.MeasureTextWidth(text, fontSize, options.TextShapingModeSnapshot, options.TextShapingProviderSnapshot);
+            return fontProgram.MeasureTextWidth(text, fontSize, options.TextShapingModeSnapshot, options.TextShapingProviderSnapshot, options.Language);
         }
 
         if (options != null &&
@@ -214,7 +214,7 @@ internal static partial class PdfWriter {
                 throw CreateTextEncodingException(diagnostics[0], nameof(text));
             }
 
-            return cffFontProgram.MeasureTextWidth(text, fontSize, options.TextShapingModeSnapshot, options.TextShapingProviderSnapshot);
+            return cffFontProgram.MeasureTextWidth(text, fontSize, options.TextShapingModeSnapshot, options.TextShapingProviderSnapshot, options.Language);
         }
 
         return EstimateSimpleTextWidth(text, font, fontSize);

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Containers.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Containers.cs
@@ -79,12 +79,14 @@ internal static partial class PdfWriter {
             out RichParagraphBlock? remainder) {
             first = null;
             remainder = null;
-            if (availableHeight <= 0.001D || paragraph.Runs.Any(run => run.Text.Contains('\t'))) {
+            PdfParagraphStyle? sourceStyle = EffectiveParagraphStyle(paragraph);
+            if (availableHeight <= 0.001D ||
+                sourceStyle?.KeepTogether == true ||
+                paragraph.Runs.Any(run => run.Text.Contains('\t'))) {
                 return false;
             }
 
             double fontSize = currentOpts.DefaultFontSize;
-            PdfParagraphStyle? sourceStyle = EffectiveParagraphStyle(paragraph);
             double leading = GetParagraphLeading(sourceStyle, fontSize);
             var textFrame = GetParagraphTextFrame(sourceStyle, currentOpts.MarginLeft, columnWidth);
             var wrapped = WrapRichRunsCoreWithFirstLineOrigin(

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Containers.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Containers.cs
@@ -151,6 +151,23 @@ internal static partial class PdfWriter {
                 for (int segmentIndex = 0; segmentIndex < line.Count; segmentIndex++) {
                     RichSeg segment = line[segmentIndex];
                     if (segment.InlineElement != null) {
+                        if (segment.LeadingSpace) {
+                            runs.Add(new TextRun(
+                                " ",
+                                segment.Bold,
+                                segment.Underline,
+                                segment.Color,
+                                segment.Italic,
+                                segment.Strike,
+                                segment.FontSize,
+                                segment.Font,
+                                segment.Uri,
+                                segment.Contents,
+                                segment.Baseline,
+                                segment.DestinationName,
+                                backgroundColor: segment.BackgroundColor));
+                        }
+
                         runs.Add(TextRun.Inline(segment.InlineElement));
                         continue;
                     }

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Containers.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Containers.cs
@@ -152,20 +152,7 @@ internal static partial class PdfWriter {
                     RichSeg segment = line[segmentIndex];
                     if (segment.InlineElement != null) {
                         if (segment.LeadingSpace) {
-                            runs.Add(new TextRun(
-                                " ",
-                                segment.Bold,
-                                segment.Underline,
-                                segment.Color,
-                                segment.Italic,
-                                segment.Strike,
-                                segment.FontSize,
-                                segment.Font,
-                                segment.Uri,
-                                segment.Contents,
-                                segment.Baseline,
-                                segment.DestinationName,
-                                backgroundColor: segment.BackgroundColor));
+                            runs.Add(BuildTextRunFromWrappedSegment(" ", segment));
                         }
 
                         runs.Add(TextRun.Inline(segment.InlineElement));
@@ -177,29 +164,36 @@ internal static partial class PdfWriter {
                         continue;
                     }
 
-                    runs.Add(new TextRun(
-                        text,
-                        segment.Bold,
-                        segment.Underline,
-                        segment.Color,
-                        segment.Italic,
-                        segment.Strike,
-                        segment.FontSize,
-                        segment.Font,
-                        segment.Uri,
-                        segment.Contents,
-                        segment.Baseline,
-                        segment.DestinationName,
-                        backgroundColor: segment.BackgroundColor));
+                    runs.Add(BuildTextRunFromWrappedSegment(text, segment));
                 }
 
                 if (lineIndex + 1 < count) {
-                    runs.Add(TextRun.LineBreak());
+                    if (line.Count == 0 || line[line.Count - 1].EndsWithHardBreak) {
+                        runs.Add(TextRun.LineBreak());
+                    } else if (line[line.Count - 1].EndsWithTextSeparator) {
+                        runs.Add(BuildTextRunFromWrappedSegment(" ", line[line.Count - 1].WithoutLink()));
+                    }
                 }
             }
 
             return runs;
         }
+
+        private static TextRun BuildTextRunFromWrappedSegment(string text, RichSeg segment) =>
+            new TextRun(
+                text,
+                segment.Bold,
+                segment.Underline,
+                segment.Color,
+                segment.Italic,
+                segment.Strike,
+                segment.FontSize,
+                segment.Font,
+                segment.Uri,
+                segment.Contents,
+                segment.Baseline,
+                segment.DestinationName,
+                backgroundColor: segment.BackgroundColor);
 
         private double MeasureColumnBlock(IPdfBlock block, double columnWidth) =>
             MeasureKeepWithNextBlockHeight(block, currentOpts.MarginLeft, columnWidth, currentOpts.DefaultFontSize);

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Containers.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Containers.cs
@@ -8,10 +8,11 @@ internal static partial class PdfWriter {
             if (totalGap >= width) throw new ArgumentException("Multi-column gaps must leave positive column widths.");
             double columnWidth = (width - totalGap) / options.ColumnCount;
             ValidateColumnBlocks(columns.Blocks);
+            var pendingBlocks = columns.Blocks.ToList();
             int blockIndex = 0;
-            while (blockIndex < columns.Blocks.Count) {
-                while (blockIndex < columns.Blocks.Count && columns.Blocks[blockIndex] is ColumnBreakBlock) blockIndex++;
-                if (blockIndex >= columns.Blocks.Count) break;
+            while (blockIndex < pendingBlocks.Count) {
+                while (blockIndex < pendingBlocks.Count && pendingBlocks[blockIndex] is ColumnBreakBlock) blockIndex++;
+                if (blockIndex >= pendingBlocks.Count) break;
                 double availableHeight = y - currentOpts.MarginBottom;
                 if (availableHeight < currentOpts.DefaultFontSize * 1.4D) {
                     NewPage();
@@ -19,8 +20,8 @@ internal static partial class PdfWriter {
                 }
 
                 double remainingHeight = 0D;
-                for (int i = blockIndex; i < columns.Blocks.Count; i++) {
-                    if (columns.Blocks[i] is not ColumnBreakBlock) remainingHeight += MeasureColumnBlock(columns.Blocks[i], columnWidth);
+                for (int i = blockIndex; i < pendingBlocks.Count; i++) {
+                    if (pendingBlocks[i] is not ColumnBreakBlock) remainingHeight += MeasureColumnBlock(pendingBlocks[i], columnWidth);
                 }
                 double target = options.BalanceLastPage && remainingHeight <= availableHeight * options.ColumnCount
                     ? Math.Max(currentOpts.DefaultFontSize * 1.4D, remainingHeight / options.ColumnCount)
@@ -37,14 +38,25 @@ internal static partial class PdfWriter {
                 for (int columnIndex = 0; columnIndex < options.ColumnCount; columnIndex++) {
                     var column = new RowColumn(widthPercent);
                     double consumed = 0D;
-                    while (blockIndex < columns.Blocks.Count) {
-                        IPdfBlock block = columns.Blocks[blockIndex];
+                    while (blockIndex < pendingBlocks.Count) {
+                        IPdfBlock block = pendingBlocks[blockIndex];
                         if (block is ColumnBreakBlock) {
                             blockIndex++;
                             break;
                         }
 
                         double blockHeight = MeasureColumnBlock(block, columnWidth);
+                        double remainingTarget = target - consumed;
+                        if (options.BalanceParagraphLines &&
+                            block is RichParagraphBlock paragraph &&
+                            blockHeight > remainingTarget + 0.001D &&
+                            TrySplitColumnParagraph(paragraph, columnWidth, remainingTarget, out RichParagraphBlock? first, out RichParagraphBlock? remainder)) {
+                            column.AddBlock(first!);
+                            consumed += MeasureColumnBlock(first!, columnWidth);
+                            pendingBlocks[blockIndex] = remainder!;
+                            break;
+                        }
+
                         if (column.Blocks.Count > 0 && consumed + blockHeight > target + 0.001D) break;
                         column.AddBlock(block);
                         consumed += blockHeight;
@@ -55,8 +67,121 @@ internal static partial class PdfWriter {
                 }
 
                 RenderRowFlowBlock(row, nextBlock: null, new List<IPdfBlock> { row }, 0);
-                if (blockIndex < columns.Blocks.Count) NewPage();
+                if (blockIndex < pendingBlocks.Count) NewPage();
             }
+        }
+
+        private bool TrySplitColumnParagraph(
+            RichParagraphBlock paragraph,
+            double columnWidth,
+            double availableHeight,
+            out RichParagraphBlock? first,
+            out RichParagraphBlock? remainder) {
+            first = null;
+            remainder = null;
+            if (availableHeight <= 0.001D || paragraph.Runs.Any(run => run.Text.Contains('\t'))) {
+                return false;
+            }
+
+            double fontSize = currentOpts.DefaultFontSize;
+            PdfParagraphStyle? sourceStyle = EffectiveParagraphStyle(paragraph);
+            double leading = GetParagraphLeading(sourceStyle, fontSize);
+            var textFrame = GetParagraphTextFrame(sourceStyle, currentOpts.MarginLeft, columnWidth);
+            var wrapped = WrapRichRunsCoreWithFirstLineOrigin(
+                paragraph.Runs,
+                textFrame.Width,
+                fontSize,
+                ChooseNormal(currentOpts.DefaultFont),
+                leading,
+                textFrame.FirstLineWidth,
+                textFrame.FirstLineX - textFrame.X,
+                GetParagraphTabStopWidth(sourceStyle),
+                currentOpts,
+                GetParagraphTabStops(sourceStyle));
+            if (wrapped.Lines.Count < 2) {
+                return false;
+            }
+
+            double remainingHeight = Math.Max(0D, availableHeight - GetParagraphSpacingBefore(sourceStyle));
+            int take = 0;
+            double height = 0D;
+            for (int index = 0; index < wrapped.LineHeights.Count; index++) {
+                if (height + wrapped.LineHeights[index] > remainingHeight + 0.001D) {
+                    break;
+                }
+
+                height += wrapped.LineHeights[index];
+                take++;
+            }
+
+            int minimumOrphanLines = ResolveMinimumOrphanLines(sourceStyle ?? new PdfParagraphStyle());
+            int minimumWidowLines = ResolveMinimumWidowLines(sourceStyle ?? new PdfParagraphStyle());
+            if (take < Math.Max(1, minimumOrphanLines) || wrapped.Lines.Count - take < Math.Max(1, minimumWidowLines)) {
+                return false;
+            }
+
+            PdfParagraphStyle firstStyle = sourceStyle?.Clone() ?? new PdfParagraphStyle();
+            firstStyle.KeepTogether = false;
+            firstStyle.KeepWithNext = false;
+            firstStyle.WidowControl = false;
+            firstStyle.MinimumOrphanLines = 0;
+            firstStyle.MinimumWidowLines = 0;
+            firstStyle.SpacingAfter = 0D;
+
+            PdfParagraphStyle remainderStyle = sourceStyle?.Clone() ?? new PdfParagraphStyle();
+            remainderStyle.KeepTogether = false;
+            remainderStyle.WidowControl = false;
+            remainderStyle.MinimumOrphanLines = 0;
+            remainderStyle.MinimumWidowLines = 0;
+            remainderStyle.SpacingBefore = 0D;
+            remainderStyle.FirstLineIndent = 0D;
+
+            first = new RichParagraphBlock(BuildTextRunsFromWrappedLines(wrapped.Lines, 0, take), paragraph.Align, paragraph.DefaultColor, firstStyle);
+            remainder = new RichParagraphBlock(BuildTextRunsFromWrappedLines(wrapped.Lines, take, wrapped.Lines.Count - take), paragraph.Align, paragraph.DefaultColor, remainderStyle);
+            return true;
+        }
+
+        private static List<TextRun> BuildTextRunsFromWrappedLines(
+            IReadOnlyList<List<RichSeg>> lines,
+            int start,
+            int count) {
+            var runs = new List<TextRun>();
+            for (int lineIndex = 0; lineIndex < count; lineIndex++) {
+                IReadOnlyList<RichSeg> line = lines[start + lineIndex];
+                for (int segmentIndex = 0; segmentIndex < line.Count; segmentIndex++) {
+                    RichSeg segment = line[segmentIndex];
+                    if (segment.InlineElement != null) {
+                        runs.Add(TextRun.Inline(segment.InlineElement));
+                        continue;
+                    }
+
+                    string text = (segment.LeadingSpace ? " " : string.Empty) + segment.Text;
+                    if (text.Length == 0) {
+                        continue;
+                    }
+
+                    runs.Add(new TextRun(
+                        text,
+                        segment.Bold,
+                        segment.Underline,
+                        segment.Color,
+                        segment.Italic,
+                        segment.Strike,
+                        segment.FontSize,
+                        segment.Font,
+                        segment.Uri,
+                        segment.Contents,
+                        segment.Baseline,
+                        segment.DestinationName,
+                        backgroundColor: segment.BackgroundColor));
+                }
+
+                if (lineIndex + 1 < count) {
+                    runs.Add(TextRun.LineBreak());
+                }
+            }
+
+            return runs;
         }
 
         private double MeasureColumnBlock(IPdfBlock block, double columnWidth) =>
@@ -93,7 +218,7 @@ internal static partial class PdfWriter {
                 Gap = 0D,
                 SpacingBefore = style.SpacingBefore,
                 SpacingAfter = style.SpacingAfter,
-                KeepTogether = true,
+                KeepTogether = style.KeepTogether,
                 KeepWithNext = style.KeepWithNext
             });
 
@@ -109,21 +234,30 @@ internal static partial class PdfWriter {
 
             double rowHeight = MeasureRowBlockHeight(row, currentOpts.MarginLeft, width, currentOpts.DefaultFontSize, firstVisualOnly: false);
             double fullPageHeight = currentOpts.PageHeight - currentOpts.MarginTop - currentOpts.MarginBottom;
-            if (rowHeight > fullPageHeight + 0.001D) throw new ArgumentException("Container height exceeds the available page content height.");
-            if (y < yStart - 0.001D && y - rowHeight < currentOpts.MarginBottom) NewPage();
-
-            double spacingBefore = ResolveTopLevelSpacingBefore(style.SpacingBefore);
-            double outerTop = y - spacingBefore;
-            int insertionIndex = sb.Length;
-            RenderRowFlowBlock(row, nextBlock: null, new List<IPdfBlock> { row }, 0);
-            double outerBottom = y + style.SpacingAfter;
-            var decoration = new StringBuilder();
-            if (style.Background.HasValue) DrawRowFill(decoration, style.Background.Value, outerX, outerBottom, outerWidth, outerTop - outerBottom, emitGeneratedStructure);
-            DrawPanelBorder(decoration, style, outerX, outerBottom, outerWidth, outerTop - outerBottom, emitGeneratedStructure);
-            if (decoration.Length > 0) {
-                sb.Insert(insertionIndex, decoration.ToString());
-                pageDirty = true;
+            if (style.KeepTogether && rowHeight > fullPageHeight + 0.001D) {
+                throw new ArgumentException("Container height exceeds the available page content height while KeepTogether is enabled.");
             }
+
+            void DecorateFragment(
+                StringBuilder content,
+                int insertionIndex,
+                double top,
+                double bottom,
+                bool isFirstFragment,
+                bool isLastFragment) {
+                var decoration = new StringBuilder();
+                if (style.Background.HasValue) {
+                    DrawRowFill(decoration, style.Background.Value, outerX, bottom, outerWidth, top - bottom, emitGeneratedStructure);
+                }
+
+                DrawPanelBorder(decoration, style, outerX, bottom, outerWidth, top - bottom, emitGeneratedStructure);
+                if (decoration.Length > 0) {
+                    content.Insert(insertionIndex, decoration.ToString());
+                    pageDirty = true;
+                }
+            }
+
+            RenderRowFlowBlock(row, nextBlock: null, new List<IPdfBlock> { row }, 0, DecorateFragment);
         }
     }
 }

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Row.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Process.Row.cs
@@ -5,7 +5,20 @@ namespace OfficeIMO.Pdf;
 
 internal static partial class PdfWriter {
     private sealed partial class LayoutContext {
-        private void RenderRowFlowBlock(RowBlock rb, IPdfBlock? nextBlock, System.Collections.Generic.IList<IPdfBlock> blockList, int blockIndex) {
+        private delegate void RowFragmentDecorator(
+            StringBuilder content,
+            int insertionIndex,
+            double top,
+            double bottom,
+            bool isFirstFragment,
+            bool isLastFragment);
+
+        private void RenderRowFlowBlock(
+            RowBlock rb,
+            IPdfBlock? nextBlock,
+            System.Collections.Generic.IList<IPdfBlock> blockList,
+            int blockIndex,
+            RowFragmentDecorator? fragmentDecorator = null) {
             double contentWidth = currentOpts.PageWidth - currentOpts.MarginLeft - currentOpts.MarginRight;
             int ncols = rb.Columns.Count;
             PdfRowStyle? rowStyle = rb.StyleSnapshot ?? currentOpts.DefaultRowStyleSnapshot;
@@ -109,6 +122,7 @@ internal static partial class PdfWriter {
             }
 
             int rowColumnFlowGuard = 0;
+            bool isFirstFragment = true;
             while (AnyRemaining()) {
                 rowColumnFlowGuard++;
                 if (rowColumnFlowGuard > 10000) {
@@ -118,6 +132,7 @@ internal static partial class PdfWriter {
                 double avail = y - currentOpts.MarginBottom;
                 if (avail <= 0.5) { NewPage(); avail = y - currentOpts.MarginBottom; }
 
+                int fragmentInsertionIndex = sb.Length;
                 double maxConsumed = 0;
                 bool anyColumnAdvanced = false;
                 for (int ci = 0; ci < ncols; ci++) {
@@ -1173,7 +1188,15 @@ internal static partial class PdfWriter {
                     continue;
                 }
                 DrawRowColumnSeparators(y, y - maxConsumed);
+                fragmentDecorator?.Invoke(
+                    sb,
+                    fragmentInsertionIndex,
+                    y,
+                    y - maxConsumed,
+                    isFirstFragment,
+                    !AnyRemaining());
                 y -= maxConsumed;
+                isFirstFragment = false;
             }
 
             if (rowSpacingAfter > 0) {

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Text.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.Text.cs
@@ -28,7 +28,7 @@ internal static partial class PdfWriter {
                 if (align == PdfAlign.Center) dx = Math.Max(0, (widthUsed - estWidth) / 2);
                 else if (align == PdfAlign.Right) dx = Math.Max(0, (widthUsed - estWidth));
                 if (Math.Abs(dx) > 0.0001) content.MoveText(dx, 0);
-                content.ShowHexText(EncodeTextHex(line, lineFont, currentOpts));
+                content.ShowText(EncodeTextShowCommand(line, lineFont, currentOpts), fontSize);
                 if (Math.Abs(dx) > 0.0001) content.MoveText(-dx, 0);
                 if (i != lines.Count - 1) content.NextTextLine();
             }
@@ -123,6 +123,10 @@ internal static partial class PdfWriter {
         private void MarkRichFonts(System.Collections.Generic.IEnumerable<TextRun> runs) {
             System.Collections.Generic.IReadOnlyList<TextRun> effectiveRuns = NormalizeFallbackRuns(runs, ChooseNormal(currentOpts.DefaultFont), currentOpts);
             foreach (TextRun run in effectiveRuns) {
+                if (run.InlineElement != null) {
+                    continue;
+                }
+
                 PdfStandardFont runBaseFont = ChooseNormal(run.Font ?? currentOpts.DefaultFont);
                 PdfStandardFont runFont = run.Bold && run.Italic
                     ? ChooseBoldItalic(runBaseFont)

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.PageText.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.PageText.cs
@@ -210,7 +210,7 @@ internal static partial class PdfWriter {
     private static double MeasurePageTextLineRuns(System.Collections.Generic.IReadOnlyList<TextRun> runs, PdfStandardFont baseFont, double fontSize, PdfOptions opts) {
         double width = 0D;
         foreach (TextRun run in runs) {
-            width += MeasureRichText(run.Text ?? string.Empty, ResolvePageTextRunFont(run, baseFont), run.FontSize ?? fontSize, run.Baseline, opts);
+            width += run.InlineElement?.Width ?? MeasureRichText(run.Text ?? string.Empty, ResolvePageTextRunFont(run, baseFont), run.FontSize ?? fontSize, run.Baseline, opts);
         }
 
         return width;
@@ -222,6 +222,11 @@ internal static partial class PdfWriter {
         lines.Add(current);
 
         foreach (TextRun run in runs) {
+            if (run.InlineElement != null) {
+                current.Add(run);
+                continue;
+            }
+
             string text = run.Text ?? string.Empty;
             if (text.Length == 0) {
                 continue;
@@ -300,7 +305,7 @@ internal static partial class PdfWriter {
                 double runFontSize = run.FontSize ?? fontSize;
                 content
                     .Font(fontResource, runFontSize)
-                    .ShowHexText(EncodeTextHex(text, runFont, opts));
+                    .ShowText(EncodeTextShowCommand(text, runFont, opts), runFontSize);
             }
         }
 
@@ -334,7 +339,7 @@ internal static partial class PdfWriter {
 
         content
             .TextMatrix(x, y)
-            .ShowHexText(EncodeTextHex(text, font, opts))
+            .ShowText(EncodeTextShowCommand(text, font, opts), fontSize)
             .EndText();
     }
 

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableCells.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.TableCells.cs
@@ -684,6 +684,11 @@ internal static partial class PdfWriter {
         double minimumExplicitFontSize = minimumShrinkFontSize > 0D ? minimumShrinkFontSize : 0.001D;
         var scaledRuns = new System.Collections.Generic.List<TextRun>(runs.Count);
         foreach (TextRun run in runs) {
+            if (run.InlineElement != null) {
+                scaledRuns.Add(run);
+                continue;
+            }
+
             double? scaledFontSize = null;
             if (run.FontSize.HasValue) {
                 scaledFontSize = run.FontSize.Value <= minimumExplicitFontSize

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Objects.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Objects.cs
@@ -204,7 +204,7 @@ internal static partial class PdfWriter {
         public bool AllowsMultipleSelection { get; set; }
     }
 
-    private sealed class FormWidgetStructureReference {
+    private sealed class AnnotationStructureReference {
         public int StructParentIndex { get; set; }
         public int StructElementIndex { get; set; }
         public int ObjectId { get; set; }

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Objects.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Objects.cs
@@ -333,6 +333,8 @@ internal static partial class PdfWriter {
         public double ClipHeight { get; set; }
         public PdfImageSourceCrop? SourceCrop { get; set; }
         public bool IsBackgroundDecoration { get; set; }
+        public bool IsInlineDecoration { get; set; }
+        public bool IsDecorativeArtifact => IsBackgroundDecoration || IsInlineDecoration;
         public double Opacity { get; set; } = 1D;
         public double RotationAngle { get; set; }
         public bool HorizontalFlip { get; set; }

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.Fallbacks.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.Fallbacks.cs
@@ -16,6 +16,11 @@ internal static partial class PdfWriter {
 
         var normalized = new System.Collections.Generic.List<TextRun>();
         foreach (TextRun run in runs) {
+            if (run.InlineElement != null) {
+                normalized.Add(run);
+                continue;
+            }
+
             if (CanWriteRunWithSelectedFont(run, baseFont, options)) {
                 normalized.Add(run);
                 continue;

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.cs
@@ -1767,18 +1767,18 @@ internal static partial class PdfWriter {
                         if (leader.Length > 0) {
                             content
                                 .TextMatrix(lineXOrigin + xCursor, lineY)
-                                .ShowText(EncodeTextShowCommand(leader, s.Font, opts), runFontSize);
+                                .ShowText(EncodeTextShowCommand(leader, s.Font, opts), runFontSize, textRise);
                         }
                         xCursor += gap;
                         content.TextMatrix(lineXOrigin + xCursor, lineY);
                     } else if (!s.LeadingSpaceIsExpandable) {
                         content
                             .TextMatrix(lineXOrigin + xCursor, lineY)
-                            .ShowText(EncodeTextShowCommand(" ", s.Font, opts), runFontSize);
+                            .ShowText(EncodeTextShowCommand(" ", s.Font, opts), runFontSize, textRise);
                         xCursor += gap;
                         content.TextMatrix(lineXOrigin + xCursor, lineY);
                     } else {
-                        content.ShowText(EncodeTextShowCommand(" ", s.Font, opts), runFontSize);
+                        content.ShowText(EncodeTextShowCommand(" ", s.Font, opts), runFontSize, textRise);
                         xCursor += gap;
                     }
                 }
@@ -1840,7 +1840,7 @@ internal static partial class PdfWriter {
 
                     content
                         .FillColor(color ?? PdfColor.Black)
-                        .ShowText(EncodeTextShowCommand(s.Text, s.Font, opts), runFontSize)
+                        .ShowText(EncodeTextShowCommand(s.Text, s.Font, opts), runFontSize, textRise)
                         .EndText();
                     AppendMarkedContentEnd(sb, linkMarkedContentId);
                     content
@@ -1854,7 +1854,7 @@ internal static partial class PdfWriter {
 
                     currentTextRise = 0;
                 } else {
-                    content.ShowText(EncodeTextShowCommand(s.Text, s.Font, opts), runFontSize);
+                    content.ShowText(EncodeTextShowCommand(s.Text, s.Font, opts), runFontSize, textRise);
                 }
 
                 double baselineY = lineY + textRise;
@@ -1893,7 +1893,7 @@ internal static partial class PdfWriter {
                     currentTextRise = separatorTextRise;
                 }
 
-                content.ShowText(EncodeTextShowCommand(" ", last.Font, opts), separatorFontSize);
+                content.ShowText(EncodeTextShowCommand(" ", last.Font, opts), separatorFontSize, separatorTextRise);
             }
 
             if (Math.Abs(currentTextRise) > 0.0001) {

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.cs
@@ -18,7 +18,7 @@ internal static partial class PdfWriter {
         return sb.ToString();
     }
 
-    private static string EncodeTextHex(string text, PdfStandardFont font, PdfOptions? options) {
+    private static PdfTextShowCommand EncodeTextShowCommand(string text, PdfStandardFont font, PdfOptions? options) {
         PdfTextEncodingDiagnostic? diagnostic = GetFirstTextEncodingDiagnostic(text, font, options);
         if (diagnostic != null) {
             throw CreateTextEncodingException(diagnostic, nameof(text));
@@ -31,9 +31,14 @@ internal static partial class PdfWriter {
                 ? PdfTextDiagnostics.AnalyzeAdvancedTextLayout(text, fontProgram)
                 : Array.Empty<PdfTextShapingDiagnostic>();
             options.AddTextDiagnostics(PdfTextDiagnostics.AnalyzeEmbeddedFontText(text, fontProgram));
-            string glyphHex = fontProgram.EncodeTextAsGlyphHex(text, options.TextShapingModeSnapshot, options.TextShapingProviderSnapshot, options.RecordProviderShapedTextRun);
+            PdfGlyphRun glyphRun = fontProgram.ShapeText(text, PdfTextShapingOptions.ForRendering(
+                fontProgram.FontName,
+                options.TextShapingModeSnapshot,
+                options.TextShapingProviderSnapshot,
+                options.RecordProviderShapedTextRun,
+                options.Language));
             options.AddTextShapingDiagnostics(shapingDiagnostics, text, fontProgram.FontName, isOpenTypeCff: false);
-            return glyphHex;
+            return glyphRun.ToTextShowCommand();
         }
 
         if (options != null &&
@@ -43,9 +48,14 @@ internal static partial class PdfWriter {
                 ? PdfTextDiagnostics.AnalyzeAdvancedTextLayout(text, cffFontProgram)
                 : Array.Empty<PdfTextShapingDiagnostic>();
             options.AddTextDiagnostics(PdfTextDiagnostics.AnalyzeEmbeddedFontText(text, cffFontProgram));
-            string glyphHex = cffFontProgram.EncodeTextAsGlyphHex(text, options.TextShapingModeSnapshot, options.TextShapingProviderSnapshot, options.RecordProviderShapedTextRun);
+            PdfGlyphRun glyphRun = cffFontProgram.ShapeText(text, PdfTextShapingOptions.ForRendering(
+                cffFontProgram.FontName,
+                options.TextShapingModeSnapshot,
+                options.TextShapingProviderSnapshot,
+                options.RecordProviderShapedTextRun,
+                options.Language));
             options.AddTextShapingDiagnostics(shapingDiagnostics, text, cffFontProgram.FontName, isOpenTypeCff: true);
-            return glyphHex;
+            return glyphRun.ToTextShowCommand();
         }
 
         if (options?.HasDiagnosticsReport == true) {
@@ -53,7 +63,7 @@ internal static partial class PdfWriter {
         }
 
         options?.AddTextDiagnostics(PdfTextDiagnostics.AnalyzeWinAnsiText(text));
-        return EncodeWinAnsiHex(text);
+        return new PdfTextShowCommand(EncodeWinAnsiHex(text));
     }
 
     private static PdfTextEncodingDiagnostic? GetFirstTextEncodingDiagnostic(string text, PdfStandardFont font, PdfOptions? options) {
@@ -306,7 +316,8 @@ internal static partial class PdfWriter {
             bool leadingSpaceIsExpandable = true,
             PdfTabLeaderStyle leadingTabLeader = PdfTabLeaderStyle.None,
             bool endsWithHardBreak = false,
-            bool endsWithTextSeparator = false) {
+            bool endsWithTextSeparator = false,
+            PdfInlineElement? inlineElement = null) {
             Text = text;
             Bold = bold;
             Italic = italic;
@@ -326,6 +337,7 @@ internal static partial class PdfWriter {
             LeadingTabLeader = leadingTabLeader;
             EndsWithHardBreak = endsWithHardBreak;
             EndsWithTextSeparator = endsWithTextSeparator;
+            InlineElement = inlineElement;
         }
 
         public string Text { get; }
@@ -366,14 +378,16 @@ internal static partial class PdfWriter {
 
         public bool EndsWithTextSeparator { get; }
 
+        public PdfInlineElement? InlineElement { get; }
+
         public RichSeg WithEndsWithHardBreak() =>
-            new RichSeg(Text, Bold, Italic, Underline, Strike, Color, BackgroundColor, Uri, DestinationName, Contents, Font, FontSize, Baseline, LeadingSpace, LeadingAdvance, LeadingSpaceIsExpandable, LeadingTabLeader, true, true);
+            new RichSeg(Text, Bold, Italic, Underline, Strike, Color, BackgroundColor, Uri, DestinationName, Contents, Font, FontSize, Baseline, LeadingSpace, LeadingAdvance, LeadingSpaceIsExpandable, LeadingTabLeader, true, true, InlineElement);
 
         public RichSeg WithEndsWithTextSeparator() =>
-            new RichSeg(Text, Bold, Italic, Underline, Strike, Color, BackgroundColor, Uri, DestinationName, Contents, Font, FontSize, Baseline, LeadingSpace, LeadingAdvance, LeadingSpaceIsExpandable, LeadingTabLeader, EndsWithHardBreak, true);
+            new RichSeg(Text, Bold, Italic, Underline, Strike, Color, BackgroundColor, Uri, DestinationName, Contents, Font, FontSize, Baseline, LeadingSpace, LeadingAdvance, LeadingSpaceIsExpandable, LeadingTabLeader, EndsWithHardBreak, true, InlineElement);
 
         public RichSeg WithoutLink() =>
-            new RichSeg(Text, Bold, Italic, Underline, Strike, Color, BackgroundColor, null, null, null, Font, FontSize, Baseline, LeadingSpace, LeadingAdvance, LeadingSpaceIsExpandable, LeadingTabLeader, EndsWithHardBreak, EndsWithTextSeparator);
+            new RichSeg(Text, Bold, Italic, Underline, Strike, Color, BackgroundColor, null, null, null, Font, FontSize, Baseline, LeadingSpace, LeadingAdvance, LeadingSpaceIsExpandable, LeadingTabLeader, EndsWithHardBreak, EndsWithTextSeparator, InlineElement);
     }
 
     private static void MarkRichLineTextSeparator(System.Collections.Generic.IList<RichSeg> line) {
@@ -528,6 +542,16 @@ internal static partial class PdfWriter {
             currentLineHeight = Math.Max(currentLineHeight, runFontSize * lineHeightRatio);
         }
 
+        void RegisterInlineLineHeight(PdfInlineElement inlineElement) {
+            double baseAscent = GetAscenderForOptions(baseFont, fontSize, options);
+            double baseDescent = GetDescenderForOptions(baseFont, fontSize, options);
+            double inlineAscent = Math.Max(0D, inlineElement.BaselineOffset + inlineElement.Height);
+            double inlineDescent = Math.Max(0D, -inlineElement.BaselineOffset);
+            currentLineHeight = Math.Max(
+                currentLineHeight,
+                Math.Max(baseAscent, inlineAscent) + Math.Max(baseDescent, inlineDescent));
+        }
+
         void StartNewLine() {
             heights.Add(currentLineHeight);
             lines.Add(new());
@@ -620,6 +644,51 @@ internal static partial class PdfWriter {
             var fontForRun = (bold && italic) ? ChooseBoldItalic(runBaseFont) : bold ? ChooseBold(runBaseFont) : italic ? ChooseItalic(runBaseFont) : runBaseFont;
             double runFontSize = run.FontSize ?? fontSize;
             double spaceW = MeasureRichText(" ", fontForRun, runFontSize, baseline, options);
+            if (run.InlineElement != null) {
+                PdfInlineElement inlineElement = run.InlineElement;
+                double currentMaxWidth = CurrentMaxWidth();
+                if (inlineElement.Width > currentMaxWidth + 0.001D) {
+                    throw new ArgumentException("Inline element width exceeds the available paragraph width.");
+                }
+
+                if (pendingLeadingIsTab) {
+                    ResolvePendingLeadingTabForCurrentLine(inlineElement.Width, spaceW, string.Empty, fontForRun, runFontSize, baseline);
+                }
+
+                List<RichSeg> currentLine = lines[lines.Count - 1];
+                double leadingAdvance = currentLine.Count == 0 ? 0D : pendingLeadingAdvance;
+                if (currentLine.Count > 0 && lineWidth + leadingAdvance + inlineElement.Width > currentMaxWidth + 0.001D) {
+                    StartNewLine();
+                    ResetPendingLeading();
+                    currentLine = lines[lines.Count - 1];
+                    leadingAdvance = 0D;
+                }
+
+                currentLine.Add(new RichSeg(
+                    string.Empty,
+                    bold,
+                    italic,
+                    underline,
+                    strike,
+                    color,
+                    backgroundColor,
+                    uri,
+                    destinationName,
+                    contents,
+                    fontForRun,
+                    runFontSize,
+                    baseline,
+                    leadingSpace: leadingAdvance > 0D,
+                    leadingAdvance: leadingAdvance,
+                    leadingSpaceIsExpandable: pendingLeadingIsExpandable,
+                    leadingTabLeader: pendingLeadingTabLeader,
+                    inlineElement: inlineElement));
+                lineWidth += leadingAdvance + inlineElement.Width;
+                RegisterInlineLineHeight(inlineElement);
+                ResetPendingLeading();
+                continue;
+            }
+
             int idx = 0;
             while (idx < text.Length) {
                 int nextWs = text.IndexOfAny(TokenSplitChars, idx);
@@ -1387,6 +1456,121 @@ internal static partial class PdfWriter {
             ? fallback + lineXOffsets[lineIndex]
             : lineIndex == 0 ? firstLineXOverride ?? fallback : fallback;
 
+    private static double MeasureRichSegment(RichSeg segment, PdfOptions? options) =>
+        segment.InlineElement?.Width ?? MeasureRichText(segment.Text, segment.Font, segment.FontSize, segment.Baseline, options);
+
+    private static double AdjustRichLineBaseline(
+        double baseline,
+        System.Collections.Generic.IReadOnlyList<RichSeg> segments,
+        PdfOptions options,
+        double fontSize) {
+        double baseAscent = GetAscenderForOptions(ChooseNormal(options.DefaultFont), fontSize, options);
+        double requiredAscent = baseAscent;
+        foreach (RichSeg segment in segments) {
+            if (segment.InlineElement != null) {
+                requiredAscent = Math.Max(requiredAscent, segment.InlineElement.BaselineOffset + segment.InlineElement.Height);
+            }
+        }
+
+        return baseline - Math.Max(0D, requiredAscent - baseAscent);
+    }
+
+    private static int? RegisterInlineFigureStructureElement(
+        LayoutResult.Page? page,
+        PdfOptions options,
+        string? alternativeText,
+        int? parentElementIndex) {
+        if (page == null ||
+            options.TaggedStructureMode != PdfTaggedStructureMode.CatalogMarkers ||
+            string.IsNullOrWhiteSpace(alternativeText)) {
+            return null;
+        }
+
+        int markedContentId = page.NextMarkedContentId++;
+        page.StructElements.Add(new PageStructElement {
+            MarkedContentId = markedContentId,
+            StructureType = "Figure",
+            AlternativeText = alternativeText!,
+            ParentElementIndex = parentElementIndex
+        });
+        return markedContentId;
+    }
+
+    private static void AppendInlineElement(
+        StringBuilder sb,
+        PdfInlineElement inlineElement,
+        double x,
+        double baseline,
+        PdfOptions options,
+        LayoutResult.Page? page,
+        int? parentElementIndex) {
+        double bottom = baseline + inlineElement.BaselineOffset;
+        if (inlineElement is PdfInlineImage inlineImage) {
+            if (page == null) {
+                throw new InvalidOperationException("Inline images require an active output page.");
+            }
+
+            ImageBlock block = inlineImage.Block;
+            PageImage pageImage = CreatePageImage(
+                block,
+                block.Style ?? new PdfImageStyle(),
+                x,
+                bottom,
+                inlineElement.Width,
+                inlineElement.Height);
+            pageImage.IsBackgroundDecoration = string.IsNullOrWhiteSpace(inlineElement.AlternativeText);
+            page.Images.Add(pageImage);
+            pageImage.InlineDrawToken = "\n%OIMO_INLINE_IMAGE_" + page.Images.Count.ToString("D6", CultureInfo.InvariantCulture) + "\n";
+            if (!string.IsNullOrWhiteSpace(inlineElement.AlternativeText)) {
+                pageImage.MarkedContentId = RegisterInlineFigureStructureElement(page, options, inlineElement.AlternativeText, parentElementIndex);
+                pageImage.StructElementIndex = FindStructElementIndex(page, pageImage.MarkedContentId, "Figure");
+            }
+
+            sb.Append(pageImage.InlineDrawToken);
+            return;
+        }
+
+        PdfInlineBox inlineBox = (PdfInlineBox)inlineElement;
+        bool tagged = options.TaggedStructureMode == PdfTaggedStructureMode.CatalogMarkers;
+        int? figureMarkedContentId = RegisterInlineFigureStructureElement(page, options, inlineElement.AlternativeText, parentElementIndex);
+        bool hasAlternativeText = !string.IsNullOrWhiteSpace(inlineElement.AlternativeText);
+        if (hasAlternativeText) {
+            sb.Append("/Figure << /Alt ")
+                .Append(PdfSyntaxEscaper.TextString(inlineElement.AlternativeText!));
+            if (figureMarkedContentId.HasValue) {
+                sb.Append(" /MCID ")
+                    .Append(figureMarkedContentId.Value.ToString(CultureInfo.InvariantCulture));
+            }
+
+            sb.Append(" >> BDC\n");
+        } else {
+            AppendArtifactBegin(sb, tagged);
+        }
+
+        ContentStreamBuilder boxContent = new ContentStreamBuilder(sb).SaveState();
+        if (inlineBox.Background.HasValue) {
+            boxContent
+                .FillColor(inlineBox.Background.Value)
+                .Rectangle(x, bottom, inlineBox.Width, inlineBox.Height)
+                .FillPath();
+        }
+
+        if (inlineBox.BorderColor.HasValue && inlineBox.BorderWidth > 0D) {
+            boxContent
+                .StrokeColor(inlineBox.BorderColor.Value)
+                .LineWidth(inlineBox.BorderWidth)
+                .Rectangle(x, bottom, inlineBox.Width, inlineBox.Height)
+                .StrokePath();
+        }
+
+        boxContent.RestoreState();
+        if (hasAlternativeText) {
+            sb.Append("EMC\n");
+        } else {
+            AppendArtifactEnd(sb, tagged);
+        }
+    }
+
     private static void WriteRichParagraph(StringBuilder sb, RichParagraphBlock block, System.Collections.Generic.List<System.Collections.Generic.List<RichSeg>> lines, System.Collections.Generic.List<double> lineHeights, PdfOptions opts, double startY, double fontSize, double defaultLeading, System.Collections.Generic.List<LinkAnnotation> annots, double? xOverride = null, double? widthOverride = null, double? firstLineXOverride = null, double? firstLineWidthOverride = null, string? structureType = null, int? markedContentId = null, LayoutResult.Page? structurePage = null, System.Collections.Generic.IReadOnlyList<PdfAlign?>? lineAlignments = null, System.Collections.Generic.IReadOnlyList<double>? lineXOffsets = null, System.Collections.Generic.IReadOnlyList<double>? lineWidths = null) {
         double widthContent = opts.PageWidth - opts.MarginLeft - opts.MarginRight;
         double widthUsed = widthOverride ?? widthContent;
@@ -1418,14 +1602,14 @@ internal static partial class PdfWriter {
         double backgroundYOffset = 0D;
         double xOrigin = xOverride ?? opts.MarginLeft;
         for (int li = 0; li < lines.Count; li++) {
-            double lineY = startY - backgroundYOffset;
+            double lineY = AdjustRichLineBaseline(startY - backgroundYOffset, lines[li], opts, fontSize);
             double lineWidthUsed = ResolveRichLineWidth(widthUsed, firstLineWidthOverride, lineWidths, li);
             double lineXOrigin = ResolveRichLineXOrigin(xOrigin, firstLineXOverride, lineXOffsets, li);
             var segs = lines[li];
             double baseLineW = 0;
             int gapsCount = 0;
             foreach (var seg in segs) {
-                double w = MeasureRichText(seg.Text, seg.Font, seg.FontSize, seg.Baseline, opts);
+                double w = MeasureRichSegment(seg, opts);
                 if (seg.LeadingSpace) {
                     w += seg.LeadingAdvance > 0 ? seg.LeadingAdvance : MeasureRichText(" ", seg.Font, seg.FontSize, seg.Baseline, opts);
                     if (seg.LeadingSpaceIsExpandable) {
@@ -1454,7 +1638,7 @@ internal static partial class PdfWriter {
                     xCursor += leadingAdvance;
                 }
 
-                double wSeg = MeasureRichText(s.Text, s.Font, s.FontSize, s.Baseline, opts);
+                double wSeg = MeasureRichSegment(s, opts);
                 if (s.BackgroundColor.HasValue && wSeg > 0) {
                     double runFontSize = EffectiveRichFontSize(s.FontSize, s.Baseline);
                     double textRise = TextRiseForBaseline(s.FontSize, s.Baseline);
@@ -1500,7 +1684,7 @@ internal static partial class PdfWriter {
 
         double yOffset = 0D;
         for (int li = 0; li < lines.Count; li++) {
-            double lineY = startY - yOffset;
+            double lineY = AdjustRichLineBaseline(startY - yOffset, lines[li], opts, fontSize);
             double lineWidthUsed = ResolveRichLineWidth(widthUsed, firstLineWidthOverride, lineWidths, li);
             double lineXOrigin = ResolveRichLineXOrigin(xOrigin, firstLineXOverride, lineXOffsets, li);
             var segs = lines[li];
@@ -1510,7 +1694,7 @@ internal static partial class PdfWriter {
             int gapsCount = 0;
             for (int si = 0; si < segCount; si++) {
                 var seg = segs[si];
-                double w = MeasureRichText(seg.Text, seg.Font, seg.FontSize, seg.Baseline, opts);
+                double w = MeasureRichSegment(seg, opts);
                 if (seg.LeadingSpace) {
                     w += seg.LeadingAdvance > 0 ? seg.LeadingAdvance : MeasureRichText(" ", seg.Font, seg.FontSize, seg.Baseline, opts);
                     if (seg.LeadingSpaceIsExpandable) {
@@ -1576,22 +1760,47 @@ internal static partial class PdfWriter {
                         if (leader.Length > 0) {
                             content
                                 .TextMatrix(lineXOrigin + xCursor, lineY)
-                                .ShowHexText(EncodeTextHex(leader, s.Font, opts));
+                                .ShowText(EncodeTextShowCommand(leader, s.Font, opts), runFontSize);
                         }
                         xCursor += gap;
                         content.TextMatrix(lineXOrigin + xCursor, lineY);
                     } else if (!s.LeadingSpaceIsExpandable) {
                         content
                             .TextMatrix(lineXOrigin + xCursor, lineY)
-                            .ShowHexText(EncodeTextHex(" ", s.Font, opts));
+                            .ShowText(EncodeTextShowCommand(" ", s.Font, opts), runFontSize);
                         xCursor += gap;
                         content.TextMatrix(lineXOrigin + xCursor, lineY);
                     } else {
-                        content.ShowHexText(EncodeTextHex(" ", s.Font, opts));
+                        content.ShowText(EncodeTextShowCommand(" ", s.Font, opts), runFontSize);
                         xCursor += gap;
                     }
                 }
-                double wSeg = MeasureRichText(s.Text, s.Font, s.FontSize, s.Baseline, opts);
+                if (s.InlineElement != null) {
+                    content.EndText();
+                    if (textMarkedContentOpen) {
+                        AppendMarkedContentEnd(sb, markedContentId);
+                        textMarkedContentOpen = false;
+                    }
+
+                    AppendInlineElement(
+                        sb,
+                        s.InlineElement,
+                        lineXOrigin + xCursor,
+                        lineY,
+                        opts,
+                        structurePage,
+                        textStructElementIndex);
+                    xCursor += s.InlineElement.Width;
+                    content = new ContentStreamBuilder(sb)
+                        .BeginText()
+                        .TextLeading(defaultLeading)
+                        .TextMatrix(lineXOrigin + xCursor, lineY)
+                        .WordSpacing(wordSpacing);
+                    currentTextRise = 0D;
+                    continue;
+                }
+
+                double wSeg = MeasureRichSegment(s, opts);
                 int? linkMarkedContentId = null;
                 int? linkStructElementIndex = null;
                 if (hasLinkTarget && opts.TaggedStructureMode == PdfTaggedStructureMode.CatalogMarkers && structurePage != null) {
@@ -1624,7 +1833,7 @@ internal static partial class PdfWriter {
 
                     content
                         .FillColor(color ?? PdfColor.Black)
-                        .ShowHexText(EncodeTextHex(s.Text, s.Font, opts))
+                        .ShowText(EncodeTextShowCommand(s.Text, s.Font, opts), runFontSize)
                         .EndText();
                     AppendMarkedContentEnd(sb, linkMarkedContentId);
                     content
@@ -1638,7 +1847,7 @@ internal static partial class PdfWriter {
 
                     currentTextRise = 0;
                 } else {
-                    content.ShowHexText(EncodeTextHex(s.Text, s.Font, opts));
+                    content.ShowText(EncodeTextShowCommand(s.Text, s.Font, opts), runFontSize);
                 }
 
                 double baselineY = lineY + textRise;
@@ -1677,7 +1886,7 @@ internal static partial class PdfWriter {
                     currentTextRise = separatorTextRise;
                 }
 
-                content.ShowHexText(EncodeTextHex(" ", last.Font, opts));
+                content.ShowText(EncodeTextShowCommand(" ", last.Font, opts), separatorFontSize);
             }
 
             if (Math.Abs(currentTextRise) > 0.0001) {

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.cs
@@ -424,7 +424,7 @@ internal static partial class PdfWriter {
                     : MeasureRichText(" ", segment.Font, segment.FontSize, segment.Baseline, options);
             }
 
-            width += MeasureRichText(segment.Text, segment.Font, segment.FontSize, segment.Baseline, options);
+            width += MeasureRichSegment(segment, options);
         }
 
         return width;
@@ -656,12 +656,19 @@ internal static partial class PdfWriter {
                 }
 
                 List<RichSeg> currentLine = lines[lines.Count - 1];
-                double leadingAdvance = currentLine.Count == 0 ? 0D : pendingLeadingAdvance;
+                double leadingAdvance = currentLine.Count > 0 || pendingLeadingIsTab ? pendingLeadingAdvance : 0D;
                 if (currentLine.Count > 0 && lineWidth + leadingAdvance + inlineElement.Width > currentMaxWidth + 0.001D) {
+                    if (pendingLeadingAdvance > 0D) {
+                        MarkRichLineTextSeparator(currentLine);
+                    }
+
                     StartNewLine();
-                    ResetPendingLeading();
                     currentLine = lines[lines.Count - 1];
-                    leadingAdvance = 0D;
+                    if (pendingLeadingIsTab) {
+                        ResolvePendingLeadingTabForCurrentLine(inlineElement.Width, spaceW, string.Empty, fontForRun, runFontSize, baseline);
+                    }
+
+                    leadingAdvance = pendingLeadingIsTab ? pendingLeadingAdvance : 0D;
                 }
 
                 currentLine.Add(new RichSeg(
@@ -1518,7 +1525,7 @@ internal static partial class PdfWriter {
                 bottom,
                 inlineElement.Width,
                 inlineElement.Height);
-            pageImage.IsBackgroundDecoration = string.IsNullOrWhiteSpace(inlineElement.AlternativeText);
+            pageImage.IsInlineDecoration = string.IsNullOrWhiteSpace(inlineElement.AlternativeText);
             page.Images.Add(pageImage);
             pageImage.InlineDrawToken = "\n%OIMO_INLINE_IMAGE_" + page.Images.Count.ToString("D6", CultureInfo.InvariantCulture) + "\n";
             if (!string.IsNullOrWhiteSpace(inlineElement.AlternativeText)) {

--- a/README.md
+++ b/README.md
@@ -149,12 +149,12 @@ _Dependency footprint:_ `System.IO.Packaging` plus `OfficeIMO.Drawing`; the VSDX
 
 #### [OfficeIMO.Pdf](OfficeIMO.Pdf/README.md)
 
-- [x] Create PDFs with page setup, rich text, multilingual font fallback, links, lists, styled containers, block-flow columns, tables, and images
+- [x] Create PDFs with page setup, rich text, TrueType/OpenType-CFF subsetting, shaping-provider positioning, multilingual font fallback, dictionary hyphenation, mixed inline visuals, styled multipage containers, balanced block-flow columns, tables, and images
 - [x] Conditional and replayable flow, position capture, semantic sections, generated TOCs, named destinations, outlines, and generated optional-content layers
 - [x] Vector drawings, chart scenes, backgrounds, page decorations, headers, first/even footers, watermarks, metadata, and viewer preferences
 - [x] AcroForm creation, field values, choice fields, appearance generation, filling, flattening, and validation
 - [x] Annotations, bookmarks/outlines, named destinations, attachments/associated files, optional-content layers, and structured/tagged output
-- [x] PDF/A, PDF/UA, Factur-X, output-intent, XMP, identification-metadata, and compliance-readiness analysis
+- [x] Exact-artifact validator-backed generation and proof for PDF/A-2b, PDF/A-3b, PDF/UA-1, Factur-X, and ZUGFeRD, plus fail-closed readiness analysis for other formal profiles
 - [x] Text extraction by page/range, layout-aware Markdown, logical paragraphs/headings/lists/tables, links, forms, images, and navigation
 - [x] Inspect pages, boxes, fonts, images, attachments, outlines, forms, actions, layers, tags, catalog metadata, security, signatures, and revisions
 - [x] Extract, split, merge, import, crop, delete, duplicate, reorder, move, rotate, and overlay/underlay complete source pages


### PR DESCRIPTION
## Summary

Completes the next PDF engine roadmap slice with advanced text/layout behavior and validator-backed standards proof.

- Adds provider-driven shaping direction, glyph positioning, stable CFF1 subsetting, dictionary hyphenation, balanced paragraph lines, decorated containers across page breaks, and mixed inline text/image/box content.
- Enables formal generation for PDF/A-2b, PDF/A-3b, PDF/UA-1, Factur-X, and ZUGFeRD while leaving unsupported profiles fail-closed.
- Binds every conformance result to the exact PDF bytes by SHA-256 and byte length, including validator version, timestamp, diagnostics, and warnings.
- Preserves document trailer identifiers through optimization and linearization and extends tagged annotation/object-reference output used by PDF/UA-1.
- Keeps the PDF engine dependency shape unchanged. Standards validators are pinned CI/test tools and are not runtime dependencies.

## Validation

- Full solution restore and Release build: clean, 0 warnings/errors.
- PDF non-raster suite: net8 2890/2890, net10 2890/2890, net472 2870/2870.
- PDF library builds: netstandard2.0, net8.0, net10.0, and net472.
- Formal proof gate: 13/13 with exact-artifact validation for all five enabled profiles.
- No-validator proof: supported claims fail closed as intended.
- qpdf: all five generated proof artifacts pass structural checks.

## Scope

This PR is engine-only. QR/barcode integration and PDF/UA-2 remain outside this slice.