### PR TITLE
Improve OfficeIMO.Email format conversion fidelity

### DIFF
--- a/OfficeIMO.Email.Tests/Conversion/EmailConversionMatrixTests.cs
+++ b/OfficeIMO.Email.Tests/Conversion/EmailConversionMatrixTests.cs
@@ -1,0 +1,124 @@
+using MimeKit;
+using OfficeIMO.Email;
+using Xunit;
+
+namespace OfficeIMO.Email.Tests;
+
+public sealed class EmailConversionMatrixTests {
+    [Theory]
+    [InlineData(OutlookItemKind.Message)]
+    [InlineData(OutlookItemKind.Appointment)]
+    [InlineData(OutlookItemKind.Contact)]
+    [InlineData(OutlookItemKind.Task)]
+    public void ConvertsSupportedItemsAcrossEmlMsgTnefAndBack(OutlookItemKind kind) {
+        EmailDocument source = CreateDocument(kind);
+        var writer = new EmailDocumentWriter();
+        var reader = new EmailDocumentReader();
+        EmailDocument current = source;
+
+        foreach (EmailFileFormat target in new[] {
+            EmailFileFormat.Eml, EmailFileFormat.OutlookMsg, EmailFileFormat.Tnef, EmailFileFormat.Eml
+        }) {
+            EmailConversionReport report = writer.AnalyzeConversion(current, target);
+            Assert.True(report.CanWrite, string.Join(Environment.NewLine,
+                report.Diagnostics.Select(diagnostic => diagnostic.Code + ": " + diagnostic.Message)));
+            byte[] artifact = writer.ToBytes(current, target, out EmailWriteResult write);
+            Assert.DoesNotContain(write.Diagnostics,
+                diagnostic => diagnostic.Severity == EmailDiagnosticSeverity.Error);
+            EmailReadResult read = reader.Read(artifact);
+            Assert.DoesNotContain(read.Diagnostics,
+                diagnostic => diagnostic.Severity == EmailDiagnosticSeverity.Error);
+            Assert.Equal(target, read.Document.Format);
+            current = read.Document;
+
+            if (target == EmailFileFormat.Eml) {
+                using var stream = new MemoryStream(artifact);
+                Assert.NotNull(MimeMessage.Load(stream).Body);
+            } else if (target == EmailFileFormat.OutlookMsg) {
+                using var oracle = new global::MsgReader.Outlook.Storage.Message(
+                    new MemoryStream(artifact), FileAccess.Read, true);
+                Assert.False(string.IsNullOrWhiteSpace(oracle.Subject));
+            }
+        }
+
+        Assert.Equal(kind, current.OutlookItemKind);
+        Assert.Equal(source.Subject, current.Subject);
+        if (kind == OutlookItemKind.Message) {
+            Assert.Equal("Matrix body", current.Body.Text);
+            Assert.Equal("matrix.txt", Assert.Single(current.Attachments).FileName);
+        } else if (kind == OutlookItemKind.Appointment) {
+            Assert.Equal("Matrix Room", current.Appointment!.Location);
+            Assert.Equal(source.Appointment!.Start!.Value.UtcDateTime,
+                current.Appointment.Start!.Value.UtcDateTime);
+        } else if (kind == OutlookItemKind.Contact) {
+            Assert.Equal("matrix.contact@example.com", current.Contact!.Email1.Address);
+        } else {
+            Assert.Equal(0.25, current.Task!.PercentComplete);
+        }
+    }
+
+    [Fact]
+    public void UnchangedProtectedContentCannotCrossFormatsWithoutExplicitLossAcceptance() {
+        byte[] source = Encoding.ASCII.GetBytes(
+            "Subject: Signed\r\nMIME-Version: 1.0\r\n" +
+            "Content-Type: multipart/signed; protocol=\"application/pkcs7-signature\"; boundary=\"s\"\r\n\r\n" +
+            "--s\r\nContent-Type: text/plain\r\n\r\nbody\r\n" +
+            "--s\r\nContent-Type: application/pkcs7-signature\r\n\r\nsignature\r\n--s--\r\n");
+        EmailDocument protectedDocument = new EmailDocumentReader().Read(source).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            protectedDocument, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics, diagnostic => diagnostic.Code == "EMAIL_PROTECTED_CONTENT_REWRITE");
+    }
+
+    private static EmailDocument CreateDocument(OutlookItemKind kind) {
+        DateTimeOffset start = new DateTimeOffset(2026, 12, 1, 9, 0, 0, TimeSpan.Zero);
+        var document = new EmailDocument {
+            Format = EmailFileFormat.OutlookMsg,
+            OutlookItemKind = kind,
+            Subject = "Matrix " + kind,
+            MessageId = "matrix-" + kind.ToString().ToLowerInvariant() + "@example.com",
+            Date = start,
+            From = new EmailAddress("sender@example.com", "Sender")
+        };
+        if (kind == OutlookItemKind.Message) {
+            document.Body.Text = "Matrix body";
+            document.Recipients.Add(new EmailRecipient(EmailRecipientKind.To,
+                new EmailAddress("recipient@example.com", "Recipient")));
+            document.Attachments.Add(new EmailAttachment {
+                FileName = "matrix.txt",
+                ContentType = "text/plain",
+                Content = Encoding.UTF8.GetBytes("attachment"),
+                Length = 10
+            });
+        } else if (kind == OutlookItemKind.Appointment) {
+            document.MessageClass = "IPM.Appointment";
+            document.Appointment = new OutlookAppointment {
+                Start = start,
+                End = start.AddHours(1),
+                Location = "Matrix Room",
+                BusyStatus = 2
+            };
+        } else if (kind == OutlookItemKind.Contact) {
+            document.MessageClass = "IPM.Contact";
+            document.Contact = new OutlookContact {
+                DisplayName = "Matrix Contact",
+                GivenName = "Matrix",
+                Surname = "Contact",
+                CompanyName = "Evotec"
+            };
+            document.Contact.Email1.Address = "matrix.contact@example.com";
+        } else {
+            document.MessageClass = "IPM.Task";
+            document.Task = new OutlookTask {
+                Start = start,
+                Due = start.AddDays(1),
+                Status = 1,
+                PercentComplete = 0.25
+            };
+        }
+        return document;
+    }
+}

--- a/OfficeIMO.Email.Tests/Interop/ExternalEmailCorpusHarness.cs
+++ b/OfficeIMO.Email.Tests/Interop/ExternalEmailCorpusHarness.cs
@@ -1,0 +1,358 @@
+using MimeKit;
+using MimeKit.Tnef;
+using OfficeIMO.Email;
+
+namespace OfficeIMO.Email.Tests;
+
+internal sealed class ExternalCorpusResult {
+    private readonly List<string> _failures = new List<string>();
+
+    internal int CandidateArtifacts { get; private set; }
+    internal int ApplicableArtifacts { get; private set; }
+    internal int SkippedArtifacts { get; private set; }
+    internal IReadOnlyList<string> Failures => _failures;
+
+    internal void Run(string category, string path, Func<bool> action) {
+        CandidateArtifacts++;
+        try {
+            if (action()) ApplicableArtifacts++;
+            else SkippedArtifacts++;
+        } catch (Exception exception) {
+            _failures.Add(string.Concat(category, ": ", Path.GetFileName(path), ": ",
+                exception.GetType().Name, ": ", exception.Message, Environment.NewLine, exception.StackTrace));
+        }
+    }
+
+    internal string FormatFailures() => string.Join(Environment.NewLine, _failures);
+}
+
+internal static class ExternalEmailCorpusHarness {
+    private static readonly EmailDocumentReader Reader = new EmailDocumentReader();
+    private static readonly EmailDocumentWriter Writer = new EmailDocumentWriter(new EmailWriterOptions(
+        conversionLossPolicy: EmailConversionLossPolicy.Warn));
+
+    internal static string? FindRepository(string name) {
+        foreach (string? root in new[] {
+            Environment.GetEnvironmentVariable("OFFICEIMO_EMAIL_CORPUS_ROOT"),
+            Environment.GetEnvironmentVariable("EVOTEC_GITHUB_ROOT")
+        }) {
+            if (string.IsNullOrWhiteSpace(root)) continue;
+            string candidate = Path.Combine(root!, name);
+            if (Directory.Exists(candidate)) return candidate;
+        }
+        return null;
+    }
+
+    internal static ExternalCorpusResult RunMsgReader(string repository) {
+        var result = new ExternalCorpusResult();
+        string samples = Path.Combine(repository, "MsgReaderTests", "SampleFiles");
+        if (!Directory.Exists(samples)) return result;
+
+        foreach (string path in Directory.GetFiles(samples, "*.eml", SearchOption.AllDirectories)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)) {
+            result.Run("MsgReader EML", path, () => ValidateMime(path));
+        }
+        foreach (string path in Directory.GetFiles(samples, "*.msg", SearchOption.AllDirectories)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)) {
+            result.Run("MsgReader MSG", path, () => ValidateOutlookMsg(path));
+        }
+        return result;
+    }
+
+    internal static ExternalCorpusResult RunMimeKit(string repository) {
+        var result = new ExternalCorpusResult();
+        string data = Path.Combine(repository, "UnitTests", "TestData");
+        if (!Directory.Exists(data)) return result;
+
+        foreach (string path in FindMimeKitMessages(data)) {
+            result.Run("MimeKit MIME", path, () => ValidateMime(path));
+        }
+        foreach (string path in Directory.GetFiles(Path.Combine(data, "tnef"), "*.tnef",
+            SearchOption.TopDirectoryOnly).OrderBy(path => path, StringComparer.OrdinalIgnoreCase)) {
+            result.Run("MimeKit TNEF", path, () => ValidateTnef(path));
+        }
+        foreach (string path in Directory.GetFiles(Path.Combine(data, "mbox"), "*.mbox.txt",
+            SearchOption.TopDirectoryOnly).OrderBy(path => path, StringComparer.OrdinalIgnoreCase)) {
+            result.Run("MimeKit mbox", path, () => ValidateMbox(path));
+        }
+        return result;
+    }
+
+    private static IEnumerable<string> FindMimeKitMessages(string data) {
+        var paths = new List<string>();
+        AddFiles(paths, Path.Combine(data, "messages"), "*.eml");
+        AddFiles(paths, Path.Combine(data, "messages"), "*.txt", path =>
+            !Path.GetFileName(path).StartsWith("body.", StringComparison.OrdinalIgnoreCase));
+        AddFiles(paths, Path.Combine(data, "dkim"), "*.msg");
+        AddFiles(paths, Path.Combine(data, "yenc"), "*.msg");
+        AddFiles(paths, Path.Combine(data, "openpgp"), "*.eml");
+        AddFiles(paths, Path.Combine(data, "partial"), "*.eml");
+        AddFiles(paths, Path.Combine(data, "tnef"), "*.eml");
+        return paths.Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static void AddFiles(ICollection<string> paths, string directory, string pattern,
+        Func<string, bool>? predicate = null) {
+        if (!Directory.Exists(directory)) return;
+        foreach (string path in Directory.GetFiles(directory, pattern, SearchOption.TopDirectoryOnly)) {
+            if (predicate == null || predicate(path)) paths.Add(path);
+        }
+    }
+
+    private static bool ValidateMime(string path) {
+        using (FileStream formatStream = File.OpenRead(path)) {
+            if (EmailDocumentReader.DetectFormat(formatStream) == EmailFileFormat.Mbox) return ValidateMbox(path);
+        }
+        MimeMessage oracle;
+        try {
+            oracle = MimeMessage.Load(path);
+        } catch (FormatException) {
+            return false;
+        }
+        using (oracle) {
+            EmailReadResult read = Reader.Read(path);
+            EnsureReadable(read, path);
+            Check(read.Document.Format == EmailFileFormat.Eml, "OfficeIMO did not classify the artifact as EML.");
+            Check(EqualText(NormalizeOracleText(oracle.Subject), read.Document.Subject), string.Concat(
+                "The decoded subject differs from MimeKit (OfficeIMO: '", Escape(read.Document.Subject),
+                "'; MimeKit: '", Escape(oracle.Subject), "')."));
+            if (!string.IsNullOrWhiteSpace(oracle.TextBody)) {
+                string? oracleText = NormalizeOracleText(oracle.TextBody);
+                Check(!string.IsNullOrWhiteSpace(read.Document.Body.Text),
+                    "MimeKit found a text body but OfficeIMO did not.");
+                if (IsYEncBody(oracle.TextBody)) {
+                    Check(read.Document.Body.Text!.Contains("=ybegin", StringComparison.Ordinal) &&
+                        read.Document.Body.Text.Contains("=yend", StringComparison.Ordinal),
+                        "OfficeIMO did not preserve the yEnc framing in the non-MIME Usenet body.");
+                } else {
+                    Check(EqualBody(oracleText, read.Document.Body.Text),
+                        DescribeBodyDifference("MimeKit text", oracleText, read.Document.Body.Text));
+                }
+            }
+            if (!string.IsNullOrWhiteSpace(oracle.HtmlBody)) {
+                string? oracleHtml = NormalizeOracleText(oracle.HtmlBody);
+                Check(!string.IsNullOrWhiteSpace(read.Document.Body.Html),
+                    "MimeKit found an HTML body but OfficeIMO did not.");
+                Check(EqualBody(oracleHtml, read.Document.Body.Html),
+                    DescribeBodyDifference("MimeKit HTML", oracleHtml, read.Document.Body.Html));
+            }
+            int oracleAttachments = oracle.Attachments.Count();
+            Check(read.Document.Attachments.Count >= oracleAttachments,
+                "OfficeIMO exposed fewer attachments than MimeKit.");
+            int oracleRecipients = oracle.To.Mailboxes.Count() + oracle.Cc.Mailboxes.Count() +
+                oracle.Bcc.Mailboxes.Count();
+            int officeRecipients = read.Document.Recipients.Count(recipient =>
+                recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc ||
+                recipient.Kind == EmailRecipientKind.Bcc);
+            Check(officeRecipients == oracleRecipients,
+                string.Concat("Recipient count differs from MimeKit (", officeRecipients, " vs ",
+                    oracleRecipients, "). OfficeIMO: ",
+                    string.Join(" | ", read.Document.Recipients.Select(recipient =>
+                        string.Concat(recipient.Kind, ":", recipient.Address.Address, ":", recipient.Address.DisplayName))),
+                    "; MimeKit: ", string.Join(" | ", oracle.To.Mailboxes.Concat(oracle.Cc.Mailboxes)
+                    .Concat(oracle.Bcc.Mailboxes).Select(mailbox => mailbox.ToString())), "."));
+            CheckAddresses("To", oracle.To.Mailboxes.Select(mailbox => mailbox.Address), read.Document,
+                EmailRecipientKind.To);
+            CheckAddresses("Cc", oracle.Cc.Mailboxes.Select(mailbox => mailbox.Address), read.Document,
+                EmailRecipientKind.Cc);
+            CheckAddresses("Bcc", oracle.Bcc.Mailboxes.Select(mailbox => mailbox.Address), read.Document,
+                EmailRecipientKind.Bcc);
+            MailboxAddress? oracleFrom = oracle.From.Mailboxes.FirstOrDefault();
+            if (oracleFrom != null) {
+                Check(string.Equals(oracleFrom.Address, read.Document.From?.Address,
+                        StringComparison.OrdinalIgnoreCase),
+                    string.Concat("From address differs from MimeKit ('", read.Document.From?.Address,
+                        "' vs '", oracleFrom.Address, "')."));
+            }
+
+            ValidateAllOutputFormats(read.Document, path);
+            return true;
+        }
+    }
+
+    private static bool ValidateOutlookMsg(string path) {
+        using var input = File.OpenRead(path);
+        using var oracle = new global::MsgReader.Outlook.Storage.Message(input, FileAccess.Read, true);
+        EmailReadResult read = Reader.Read(path);
+        EnsureReadable(read, path);
+        Check(read.Document.Format == EmailFileFormat.OutlookMsg,
+            "OfficeIMO did not classify the artifact as Outlook MSG.");
+        Check(EqualText(oracle.Subject, read.Document.Subject), "The decoded subject differs from MsgReader.");
+        if (!string.IsNullOrWhiteSpace(oracle.BodyText)) {
+            Check(!string.IsNullOrWhiteSpace(read.Document.Body.Text),
+                "MsgReader found a text body but OfficeIMO did not.");
+            Check(EqualMsgBody(oracle.BodyText, read.Document.Body.Text),
+                DescribeBodyDifference("MsgReader text", NormalizeMsgBody(oracle.BodyText),
+                    NormalizeMsgBody(read.Document.Body.Text)));
+        }
+        Check(read.Document.Attachments.Count == oracle.Attachments.Count,
+            string.Concat("Attachment count differs from MsgReader (", read.Document.Attachments.Count, " vs ",
+                oracle.Attachments.Count, ")."));
+        Check(read.Document.Recipients.Count(recipient => recipient.Kind != EmailRecipientKind.ReplyTo) ==
+            oracle.Recipients.Count,
+            "Recipient count differs from MsgReader.");
+
+        ValidateAllOutputFormats(read.Document, path);
+        return true;
+    }
+
+    private static bool ValidateTnef(string path) {
+        List<MimeEntity> oracleAttachments;
+        try {
+            using var content = File.OpenRead(path);
+            var tnef = new TnefPart { Content = new MimeContent(content) };
+            oracleAttachments = tnef.ExtractAttachments().ToList();
+        } catch (FormatException) {
+            return false;
+        }
+
+        EmailReadResult read = Reader.Read(path);
+        EnsureReadable(read, path);
+        Check(read.Document.Format == EmailFileFormat.Tnef, "OfficeIMO did not classify the artifact as TNEF.");
+        MimePart[] oracleFiles = oracleAttachments.OfType<MimePart>()
+            .Where(part => !(part is TextPart) || !string.IsNullOrWhiteSpace(part.FileName))
+            .GroupBy(part => string.Concat(part.FileName, "\0", part.ContentDisposition?.Size),
+                StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .ToArray();
+        EmailAttachment[] officeAttachments = read.Document.Attachments.ToArray();
+        Check(officeAttachments.Length >= oracleFiles.Length,
+            string.Concat("OfficeIMO exposed fewer TNEF attachments than MimeKit (",
+                officeAttachments.Length, " vs ", oracleFiles.Length, "). OfficeIMO: ",
+                string.Join(" | ", officeAttachments.Select(attachment => string.Concat(
+                    attachment.FileName, ":", attachment.ContentType, ":", attachment.Length))),
+                "; MimeKit: ", string.Join(" | ", oracleAttachments.Select(entity => string.Concat(
+                    entity.ContentType.MimeType, ":", entity.ContentDisposition?.FileName))), "."));
+
+        ValidateAllOutputFormats(read.Document, path);
+        return true;
+    }
+
+    private static bool ValidateMbox(string path) {
+        int oracleCount = CountMimeKitMbox(path);
+        var entries = new EmailMailboxReader().ReadEntries(path).ToArray();
+        Check(entries.All(entry => !entry.HasErrors), string.Concat(
+            "OfficeIMO reported an error while streaming the mailbox: ",
+            string.Join(" | ", entries.SelectMany((entry, index) => entry.Diagnostics
+                .Where(diagnostic => diagnostic.Severity == EmailDiagnosticSeverity.Error)
+                .Select(diagnostic => string.Concat("message[", index, "] ", diagnostic.Code, ": ", diagnostic.Message))))));
+        Check(entries.Length == oracleCount, string.Concat("Mailbox message count differs from MimeKit (",
+            entries.Length, " vs ", oracleCount, ")."));
+
+        var mailbox = new EmailMailbox();
+        foreach (EmailMailboxEntryReadResult entry in entries) mailbox.Messages.Add(entry.Entry);
+        byte[] rewritten = new EmailMailboxWriter().ToBytes(mailbox);
+        using var stream = new MemoryStream(rewritten);
+        int rewrittenCount = CountMimeKitMbox(stream);
+        Check(rewrittenCount == entries.Length, "MimeKit did not reopen every rewritten mailbox entry.");
+        return true;
+    }
+
+    private static void ValidateAllOutputFormats(EmailDocument document, string sourcePath) {
+        byte[] eml = Writer.ToBytes(document, EmailFileFormat.Eml);
+        using (var stream = new MemoryStream(eml)) {
+            using MimeMessage oracle = MimeMessage.Load(stream);
+            Check(EqualText(document.Subject, oracle.Subject), "MimeKit read a different rewritten EML subject.");
+        }
+        EnsureReadable(Reader.Read(eml), string.Concat(sourcePath, " -> EML"));
+
+        byte[] msg = Writer.ToBytes(document, EmailFileFormat.OutlookMsg);
+        EnsureReadable(Reader.Read(msg), string.Concat(sourcePath, " -> MSG"));
+        using (var oracle = new global::MsgReader.Outlook.Storage.Message(
+                   new MemoryStream(msg), FileAccess.Read, true)) {
+            Check(EqualText(document.Subject, oracle.Subject), "MsgReader read a different rewritten MSG subject.");
+        }
+
+        byte[] tnef = Writer.ToBytes(document, EmailFileFormat.Tnef);
+        EnsureReadable(Reader.Read(tnef), string.Concat(sourcePath, " -> TNEF"));
+    }
+
+    private static int CountMimeKitMbox(string path) {
+        using var stream = File.OpenRead(path);
+        return CountMimeKitMbox(stream);
+    }
+
+    private static int CountMimeKitMbox(Stream stream) {
+        var parser = new global::MimeKit.MimeParser(stream, MimeFormat.Mbox);
+        int count = 0;
+        while (!parser.IsEndOfStream) {
+            using MimeMessage message = parser.ParseMessage();
+            count++;
+        }
+        return count;
+    }
+
+    private static void EnsureReadable(EmailReadResult result, string location) {
+        EmailDiagnostic? error = result.Diagnostics.FirstOrDefault(diagnostic =>
+            diagnostic.Severity == EmailDiagnosticSeverity.Error);
+        if (error != null) {
+            throw new InvalidDataException(string.Concat(location, ": ", error.Code, ": ", error.Message));
+        }
+    }
+
+    private static bool EqualText(string? left, string? right) =>
+        string.Equals(left ?? string.Empty, right ?? string.Empty, StringComparison.Ordinal);
+
+    private static bool EqualBody(string? left, string? right) => string.Equals(
+        NormalizeBody(left), NormalizeBody(right), StringComparison.Ordinal);
+
+    private static bool EqualMsgBody(string? left, string? right) => string.Equals(
+        NormalizeMsgBody(left), NormalizeMsgBody(right), StringComparison.Ordinal);
+
+    private static string NormalizeBody(string? value) => (value ?? string.Empty)
+        .Replace("\r\n", "\n").Replace("\r", "\n").TrimEnd('\n');
+
+    private static string NormalizeMsgBody(string? value) {
+        string[] lines = NormalizeBody(value).Split('\n');
+        for (int index = 0; index < lines.Length; index++) lines[index] = lines[index].TrimEnd(' ', '\t');
+        return string.Join("\n", lines).TrimEnd('\n');
+    }
+
+    private static string DescribeBodyDifference(string oracleName, string? oracle, string? office) {
+        string expected = NormalizeBody(oracle);
+        string actual = NormalizeBody(office);
+        int shared = Math.Min(expected.Length, actual.Length);
+        int offset = 0;
+        while (offset < shared && expected[offset] == actual[offset]) offset++;
+        int start = Math.Max(0, offset - 20);
+        return string.Concat("The normalized body differs from ", oracleName,
+            " at character ", offset, " (OfficeIMO length ", actual.Length,
+            ", oracle length ", expected.Length, "). OfficeIMO: '",
+            Escape(actual.Substring(start, Math.Min(100, actual.Length - start))),
+            "'; oracle: '", Escape(expected.Substring(start, Math.Min(100, expected.Length - start))), "'.");
+    }
+
+    private static void CheckAddresses(string label, IEnumerable<string> oracleAddresses,
+        EmailDocument document, EmailRecipientKind kind) {
+        string[] expected = oracleAddresses.Where(address => !string.IsNullOrWhiteSpace(address))
+            .OrderBy(address => address, StringComparer.OrdinalIgnoreCase).ToArray();
+        string[] actual = document.Recipients.Where(recipient => recipient.Kind == kind)
+            .Select(recipient => recipient.Address.Address)
+            .Where(address => !string.IsNullOrWhiteSpace(address)).Select(address => address!)
+            .OrderBy(address => address, StringComparer.OrdinalIgnoreCase).ToArray();
+        Check(expected.SequenceEqual(actual, StringComparer.OrdinalIgnoreCase), string.Concat(
+            label, " addresses differ (OfficeIMO: ", string.Join(", ", actual),
+            "; oracle: ", string.Join(", ", expected), ")."));
+    }
+
+    private static string? NormalizeOracleText(string? value) {
+        if (string.IsNullOrEmpty(value) || value!.IndexOf('\u001b') < 0) return value;
+        try {
+            return Encoding.GetEncoding("iso-2022-jp").GetString(Encoding.ASCII.GetBytes(value));
+        } catch (ArgumentException) {
+            return value;
+        }
+    }
+
+    private static bool IsYEncBody(string? value) => value != null &&
+        value.IndexOf("=ybegin", StringComparison.Ordinal) >= 0 &&
+        value.IndexOf("=yend", StringComparison.Ordinal) >= 0;
+
+    private static string Escape(string? value) => (value ?? string.Empty)
+        .Replace("\r", "\\r").Replace("\n", "\\n").Replace("\0", "\\0");
+
+    private static void Check(bool condition, string message) {
+        if (!condition) throw new InvalidDataException(message);
+    }
+}

--- a/OfficeIMO.Email.Tests/Interop/ExternalEmailCorpusTests.cs
+++ b/OfficeIMO.Email.Tests/Interop/ExternalEmailCorpusTests.cs
@@ -1,0 +1,32 @@
+using OfficeIMO.Email;
+using Xunit;
+
+namespace OfficeIMO.Email.Tests;
+
+public sealed class ExternalEmailCorpusTests {
+    [Fact]
+    public void ProcessesAllMsgReaderSamplesWhenCorpusIsAvailable() {
+        string? repository = ExternalEmailCorpusHarness.FindRepository("MSGReader");
+        if (repository == null) return;
+
+        ExternalCorpusResult result = ExternalEmailCorpusHarness.RunMsgReader(repository);
+
+        Assert.True(result.ApplicableArtifacts > 0, "No applicable MsgReader artifacts were found.");
+        Assert.True(result.Failures.Count == 0, result.FormatFailures());
+        Assert.Equal(result.CandidateArtifacts, result.ApplicableArtifacts);
+        Assert.Equal(0, result.SkippedArtifacts);
+    }
+
+    [Fact]
+    public void ProcessesMimeKitMimeTnefAndMboxCorporaWhenAvailable() {
+        string? repository = ExternalEmailCorpusHarness.FindRepository("MimeKit");
+        if (repository == null) return;
+
+        ExternalCorpusResult result = ExternalEmailCorpusHarness.RunMimeKit(repository);
+
+        Assert.True(result.ApplicableArtifacts > 0, "No applicable MimeKit artifacts were found.");
+        Assert.True(result.Failures.Count == 0, result.FormatFailures());
+        Assert.Equal(result.CandidateArtifacts, result.ApplicableArtifacts);
+        Assert.Equal(0, result.SkippedArtifacts);
+    }
+}

--- a/OfficeIMO.Email.Tests/Interop/MsgKitExampleCompatibilityTests.cs
+++ b/OfficeIMO.Email.Tests/Interop/MsgKitExampleCompatibilityTests.cs
@@ -1,0 +1,124 @@
+using OfficeIMO.Email;
+using Xunit;
+
+namespace OfficeIMO.Email.Tests;
+
+public sealed class MsgKitExampleCompatibilityTests {
+    [Fact]
+    public void ProcessesMsgKitGeneratedMailAppointmentContactAndTaskAcrossEveryFormat() {
+        MsgKitArtifact[] artifacts = {
+            CreateMail(), CreateAppointment(), CreateContact(), CreateTask()
+        };
+        var reader = new EmailDocumentReader();
+        var writer = new EmailDocumentWriter(new EmailWriterOptions(
+            conversionLossPolicy: EmailConversionLossPolicy.Warn));
+
+        foreach (MsgKitArtifact artifact in artifacts) {
+            EmailReadResult source = reader.Read(artifact.Bytes);
+            Assert.DoesNotContain(source.Diagnostics,
+                diagnostic => diagnostic.Severity == EmailDiagnosticSeverity.Error);
+            Assert.Equal(artifact.Kind, source.Document.OutlookItemKind);
+            Assert.Equal(artifact.Subject, source.Document.Subject);
+
+            foreach (EmailFileFormat format in new[] {
+                EmailFileFormat.OutlookMsg, EmailFileFormat.Eml, EmailFileFormat.Tnef
+            }) {
+                byte[] rewritten = writer.ToBytes(source.Document, format);
+                EmailReadResult reopened = reader.Read(rewritten);
+                Assert.DoesNotContain(reopened.Diagnostics,
+                    diagnostic => diagnostic.Severity == EmailDiagnosticSeverity.Error);
+                Assert.Equal(format, reopened.Document.Format);
+                Assert.Equal(artifact.Kind, reopened.Document.OutlookItemKind);
+                Assert.Equal(artifact.Subject, reopened.Document.Subject);
+                if (format == EmailFileFormat.OutlookMsg) {
+                    using var oracle = new global::MsgReader.Outlook.Storage.Message(
+                        new MemoryStream(rewritten), FileAccess.Read, true);
+                    Assert.Equal(artifact.Subject, oracle.Subject);
+                } else if (format == EmailFileFormat.Eml) {
+                    using var stream = new MemoryStream(rewritten);
+                    using MimeKit.MimeMessage oracle = MimeKit.MimeMessage.Load(stream);
+                    Assert.Equal(artifact.Subject, oracle.Subject);
+                }
+            }
+        }
+    }
+
+    private static MsgKitArtifact CreateMail() {
+        using var message = new MsgKit.Email(new MsgKit.Sender("sender@example.com", "Sender"),
+            "MsgKit generated mail", draft: true, readReceipt: true) {
+            BodyText = "MsgKit plain body",
+            BodyHtml = "<html><body><b>MsgKit HTML body</b></body></html>",
+            SentOn = new DateTime(2026, 7, 15, 10, 0, 0, DateTimeKind.Utc)
+        };
+        message.Recipients.AddTo("to@example.com", "To Person");
+        message.Recipients.AddCc("cc@example.com", "Cc Person");
+        message.Attachments.Add(new MemoryStream(Encoding.UTF8.GetBytes("attachment")), "sample.txt");
+        return Save(message, OutlookItemKind.Message, "MsgKit generated mail");
+    }
+
+    private static MsgKitArtifact CreateAppointment() {
+        using var appointment = new MsgKit.Appointment(new MsgKit.Sender("sender@example.com", "Sender"),
+            new MsgKit.Representing("organizer@example.com", "Organizer"), "MsgKit generated appointment") {
+            Location = "Neverland",
+            MeetingStart = new DateTime(2026, 8, 1, 9, 0, 0, DateTimeKind.Utc),
+            MeetingEnd = new DateTime(2026, 8, 1, 10, 30, 0, DateTimeKind.Utc),
+            BodyText = "Appointment body"
+        };
+        appointment.Recipients.AddTo("attendee@example.com", "Attendee");
+        return Save(appointment, OutlookItemKind.Appointment, "MsgKit generated appointment");
+    }
+
+    private static MsgKitArtifact CreateContact() {
+        using var contact = new MsgKit.Contact(new MsgKit.Sender("sender@example.com", "Sender"),
+            "MsgKit generated contact") {
+            FileUnder = "Lovelace, Ada",
+            GivenName = "Ada",
+            SurName = "Lovelace",
+            DepartmentName = "Research",
+            Title = "Mathematician",
+            Email1 = new MsgKit.Address("ada@example.com", "Ada Lovelace"),
+            MobileTelephoneNumber = "+44 7000 000000",
+            Business = new MsgKit.ContactBusiness {
+                City = "London",
+                Country = "United Kingdom",
+                Street = "1 Engine Way"
+            }
+        };
+        return Save(contact, OutlookItemKind.Contact, "MsgKit generated contact");
+    }
+
+    private static MsgKitArtifact CreateTask() {
+        using var task = new MsgKit.Task(new MsgKit.Sender("sender@example.com", "Sender"),
+            new MsgKit.Representing("owner@example.com", "Owner"), "MsgKit generated task") {
+            Status = MsgKit.Enums.TaskStatus.InProgress,
+            PercentageComplete = 0.25,
+            StartDate = new DateTime(2026, 9, 1),
+            DueDate = new DateTime(2026, 9, 3),
+            ReminderDelta = 30,
+            ReminderTime = new DateTime(2026, 9, 1, 8, 30, 0, DateTimeKind.Utc),
+            BodyText = "Task body"
+        };
+        task.Attachments.Add(new MemoryStream(Encoding.UTF8.GetBytes("task attachment")), "task.txt");
+        return Save(task, OutlookItemKind.Task, "MsgKit generated task");
+    }
+
+    private static MsgKitArtifact Save(MsgKit.Email item, OutlookItemKind kind, string subject) {
+        using var stream = new MemoryStream();
+        if (item is MsgKit.Appointment appointment) appointment.Save(stream);
+        else if (item is MsgKit.Contact contact) contact.Save(stream);
+        else if (item is MsgKit.Task task) task.Save(stream);
+        else item.Save(stream);
+        return new MsgKitArtifact(stream.ToArray(), kind, subject);
+    }
+
+    private sealed class MsgKitArtifact {
+        internal MsgKitArtifact(byte[] bytes, OutlookItemKind kind, string subject) {
+            Bytes = bytes;
+            Kind = kind;
+            Subject = subject;
+        }
+        internal byte[] Bytes { get; }
+        internal OutlookItemKind Kind { get; }
+        internal string Subject { get; }
+    }
+}

--- a/OfficeIMO.Email.Tests/Interop/OutlookInteropTests.cs
+++ b/OfficeIMO.Email.Tests/Interop/OutlookInteropTests.cs
@@ -1,0 +1,191 @@
+using OfficeIMO.Email;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace OfficeIMO.Email.Tests;
+
+public sealed class OutlookInteropTests {
+    [Fact]
+    public void ExchangesMailAppointmentContactAndTaskMsgFilesWithInstalledOutlookWhenEnabled() {
+        if (!string.Equals(Environment.GetEnvironmentVariable("OFFICEIMO_EMAIL_OUTLOOK_INTEROP"), "1",
+            StringComparison.Ordinal)) return;
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+        Type? outlookType = Type.GetTypeFromProgID("Outlook.Application");
+        if (outlookType == null) return;
+
+        string directory = Path.Combine(Path.GetTempPath(), "OfficeIMO.Email.Outlook." + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        object? outlookObject = null;
+        object? sessionObject = null;
+        try {
+            outlookObject = Activator.CreateInstance(outlookType);
+            Assert.NotNull(outlookObject);
+            dynamic outlook = outlookObject!;
+            sessionObject = outlook.GetNamespace("MAPI");
+            dynamic session = sessionObject!;
+
+            ValidateOfficeImoFilesInOutlook(directory, session);
+            ValidateOfficeImoStandardsFilesInOutlook(directory, session);
+            ValidateOutlookFilesInOfficeImo(directory, outlook);
+        } finally {
+            ReleaseComObject(sessionObject);
+            ReleaseComObject(outlookObject);
+            try { Directory.Delete(directory, recursive: true); } catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+    }
+
+    private static void ValidateOfficeImoStandardsFilesInOutlook(string directory, dynamic session) {
+        DateTimeOffset start = new DateTimeOffset(2026, 10, 4, 9, 0, 0, TimeSpan.Zero);
+        var appointment = new EmailDocument {
+            Format = EmailFileFormat.OutlookMsg,
+            OutlookItemKind = OutlookItemKind.Appointment,
+            MessageClass = "IPM.Appointment",
+            Subject = "OfficeIMO Outlook iCalendar",
+            Appointment = new OutlookAppointment {
+                Start = start,
+                End = start.AddHours(1),
+                ReminderIsSet = true,
+                ReminderDeltaMinutes = 15
+            }
+        };
+        EmailDocument projectedAppointment = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(appointment, EmailFileFormat.Eml)).Document;
+        EmailAttachment calendar = Assert.Single(projectedAppointment.Attachments,
+            attachment => string.Equals(attachment.ContentType, "text/calendar", StringComparison.OrdinalIgnoreCase));
+        string calendarPath = Path.Combine(directory, "officeimo.ics");
+        File.WriteAllBytes(calendarPath, Assert.IsType<byte[]>(calendar.Content));
+
+        var contact = new EmailDocument {
+            Format = EmailFileFormat.OutlookMsg,
+            OutlookItemKind = OutlookItemKind.Contact,
+            MessageClass = "IPM.Contact",
+            Subject = "OfficeIMO Outlook vCard",
+            Contact = new OutlookContact {
+                DisplayName = "OfficeIMO Outlook vCard",
+                GivenName = "OfficeIMO",
+                Surname = "vCard"
+            }
+        };
+        contact.Contact.Email1.Address = "officeimo.vcard@example.com";
+        EmailDocument projectedContact = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(contact, EmailFileFormat.Eml)).Document;
+        EmailAttachment vcard = Assert.Single(projectedContact.Attachments,
+            attachment => string.Equals(attachment.ContentType, "text/vcard", StringComparison.OrdinalIgnoreCase));
+        string vcardPath = Path.Combine(directory, "officeimo.vcf");
+        File.WriteAllBytes(vcardPath, Assert.IsType<byte[]>(vcard.Content));
+
+        object? appointmentObject = null;
+        object? contactObject = null;
+        try {
+            appointmentObject = session.OpenSharedItem(calendarPath);
+            dynamic outlookAppointment = appointmentObject!;
+            Assert.Equal(appointment.Subject, (string)outlookAppointment.Subject);
+            Assert.True((bool)outlookAppointment.ReminderSet);
+
+            contactObject = session.OpenSharedItem(vcardPath);
+            dynamic outlookContact = contactObject!;
+            Assert.Equal(contact.Contact.DisplayName, (string)outlookContact.FullName);
+            Assert.Equal(contact.Contact.Email1.Address, (string)outlookContact.Email1Address);
+        } finally {
+            ReleaseComObject(contactObject);
+            ReleaseComObject(appointmentObject);
+        }
+    }
+
+    private static void ValidateOfficeImoFilesInOutlook(string directory, dynamic session) {
+        DateTimeOffset start = new DateTimeOffset(2026, 10, 4, 9, 0, 0, TimeSpan.Zero);
+        var documents = new[] {
+            new EmailDocument {
+                Format = EmailFileFormat.OutlookMsg,
+                OutlookItemKind = OutlookItemKind.Message,
+                Subject = "OfficeIMO Outlook mail"
+            },
+            new EmailDocument {
+                Format = EmailFileFormat.OutlookMsg,
+                OutlookItemKind = OutlookItemKind.Appointment,
+                Subject = "OfficeIMO Outlook appointment",
+                Appointment = new OutlookAppointment { Start = start, End = start.AddHours(1), Location = "Room 42" }
+            },
+            new EmailDocument {
+                Format = EmailFileFormat.OutlookMsg,
+                OutlookItemKind = OutlookItemKind.Contact,
+                Subject = "OfficeIMO Outlook contact",
+                Contact = new OutlookContact { DisplayName = "OfficeIMO Contact", GivenName = "OfficeIMO", Surname = "Contact" }
+            },
+            new EmailDocument {
+                Format = EmailFileFormat.OutlookMsg,
+                OutlookItemKind = OutlookItemKind.Task,
+                Subject = "OfficeIMO Outlook task",
+                Task = new OutlookTask { Start = start, Due = start.AddDays(1), PercentComplete = 0.25 }
+            }
+        };
+
+        for (int index = 0; index < documents.Length; index++) {
+            string path = Path.Combine(directory, "officeimo-" + index.ToString(CultureInfo.InvariantCulture) + ".msg");
+            File.WriteAllBytes(path, new EmailDocumentWriter().ToBytes(documents[index], EmailFileFormat.OutlookMsg));
+            object? itemObject = null;
+            try {
+                itemObject = session.OpenSharedItem(path);
+                dynamic item = itemObject!;
+                Assert.Equal(documents[index].Subject, (string)item.Subject);
+                if (documents[index].OutlookItemKind == OutlookItemKind.Appointment) {
+                    Assert.Equal("Room 42", (string)item.Location);
+                }
+            } finally {
+                ReleaseComObject(itemObject);
+            }
+        }
+    }
+
+    private static void ValidateOutlookFilesInOfficeImo(string directory, dynamic outlook) {
+        string[] subjects = {
+            "Outlook OfficeIMO mail", "Outlook OfficeIMO appointment",
+            "Outlook OfficeIMO contact", "Outlook OfficeIMO task"
+        };
+        OutlookItemKind[] kinds = {
+            OutlookItemKind.Message, OutlookItemKind.Appointment, OutlookItemKind.Contact, OutlookItemKind.Task
+        };
+        int[] outlookKinds = { 0, 1, 2, 3 };
+        for (int index = 0; index < outlookKinds.Length; index++) {
+            object? itemObject = null;
+            string path = Path.Combine(directory, "outlook-" + index.ToString(CultureInfo.InvariantCulture) + ".msg");
+            try {
+                itemObject = outlook.CreateItem(outlookKinds[index]);
+                dynamic item = itemObject!;
+                item.Subject = subjects[index];
+                if (kinds[index] == OutlookItemKind.Appointment) {
+                    item.Start = new DateTime(2026, 11, 5, 10, 0, 0, DateTimeKind.Local);
+                    item.End = new DateTime(2026, 11, 5, 11, 30, 0, DateTimeKind.Local);
+                    item.Location = "Outlook Room";
+                } else if (kinds[index] == OutlookItemKind.Contact) {
+                    item.FullName = "Outlook Contact";
+                    item.Email1Address = "outlook.contact@example.com";
+                } else if (kinds[index] == OutlookItemKind.Task) {
+                    item.StartDate = new DateTime(2026, 11, 5);
+                    item.DueDate = new DateTime(2026, 11, 7);
+                    item.PercentComplete = 50;
+                } else {
+                    item.Body = "Created by Outlook for OfficeIMO validation";
+                }
+                item.SaveAs(path, 9);
+                item.Close(1);
+            } finally {
+                ReleaseComObject(itemObject);
+            }
+
+            EmailReadResult read = new EmailDocumentReader().Read(path);
+            Assert.Equal(kinds[index], read.Document.OutlookItemKind);
+            Assert.DoesNotContain(read.Diagnostics, diagnostic => diagnostic.Severity == EmailDiagnosticSeverity.Error);
+            if (kinds[index] == OutlookItemKind.Appointment) Assert.Equal("Outlook Room", read.Document.Appointment!.Location);
+            if (kinds[index] == OutlookItemKind.Contact) Assert.Equal("outlook.contact@example.com", read.Document.Contact!.Email1.Address);
+        }
+    }
+
+    private static void ReleaseComObject(object? value) {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && value != null && Marshal.IsComObject(value)) {
+            Marshal.FinalReleaseComObject(value);
+        }
+    }
+}

--- a/OfficeIMO.Email.Tests/Mbox/EmailMailboxTests.cs
+++ b/OfficeIMO.Email.Tests/Mbox/EmailMailboxTests.cs
@@ -117,4 +117,74 @@ public sealed class EmailMailboxTests {
         Assert.Contains(result.Diagnostics,
             diagnostic => diagnostic.Code == "EMAIL_ATTACHMENT_CONTENT_UNAVAILABLE");
     }
+
+    [Fact]
+    public void EnumeratesAndWritesMailboxEntriesWithoutAggregateMaterialization() {
+        byte[] source = Encoding.ASCII.GetBytes(
+            "From a@example.com Fri Jul 10 12:00:00 2026\nSubject: A\n\nA\n" +
+            "From b@example.com Fri Jul 10 13:00:00 2026\nSubject: B\n\nB\n");
+        using var input = new MemoryStream(source);
+        input.Position = 3;
+        var reader = new EmailMailboxReader();
+
+        EmailMailboxEntryReadResult[] entries = reader.ReadEntries(input).ToArray();
+        using var output = new MemoryStream();
+        EmailWriteResult write = new EmailMailboxWriter().WriteEntries(entries.Select(item => item.Entry), output);
+        EmailMailboxEntryReadResult[] roundTrip = reader.ReadEntries(new MemoryStream(output.ToArray())).ToArray();
+
+        Assert.Equal(3, input.Position);
+        Assert.Equal(new[] { "A", "B" }, entries.Select(item => item.Entry.Document.Subject));
+        Assert.Equal(2, roundTrip.Length);
+        Assert.Equal(output.Length, write.BytesWritten);
+    }
+
+    [Fact]
+    public void StreamingReaderAppliesMailboxAndPerMessageLimitsSeparately() {
+        byte[] source = Encoding.ASCII.GetBytes(
+            "From a@example.com Fri Jul 10 12:00:00 2026\nSubject: A\n\n1234567890\n" +
+            "From b@example.com Fri Jul 10 13:00:00 2026\nSubject: B\n\n1234567890\n");
+        var options = new EmailMailboxReaderOptions(maxMailboxBytes: 200,
+            messageOptions: new EmailReaderOptions(maxInputBytes: 80));
+
+        EmailMailboxEntryReadResult[] entries = new EmailMailboxReader(options)
+            .ReadEntries(new MemoryStream(source)).ToArray();
+
+        Assert.Equal(2, entries.Length);
+    }
+
+    [Fact]
+    public async Task AggregateReadersReportTheAggregateMailboxLimit() {
+        byte[] source = Encoding.ASCII.GetBytes(
+            "From a@example.com Fri Jul 10 12:00:00 2026\nSubject: A\n\n1234567890\n");
+        var options = new EmailMailboxReaderOptions(maxMailboxBytes: 20);
+        var reader = new EmailMailboxReader(options);
+
+        EmailLimitExceededException synchronous = Assert.Throws<EmailLimitExceededException>(() =>
+            reader.Read(new MemoryStream(source)));
+        EmailLimitExceededException asynchronous = await Assert.ThrowsAsync<EmailLimitExceededException>(() =>
+            reader.ReadAsync(new MemoryStream(source)));
+
+        Assert.Equal(nameof(EmailMailboxReaderOptions.MaxMailboxBytes), synchronous.LimitName);
+        Assert.Equal(nameof(EmailMailboxReaderOptions.MaxMailboxBytes), asynchronous.LimitName);
+    }
+
+    [Fact]
+    public void AcceptsUtf8BomAndRecoversUnescapedBodyFromLinesAsEntries() {
+        byte[] source = new byte[] { 0xEF, 0xBB, 0xBF }.Concat(Encoding.ASCII.GetBytes(
+            "From -\r\nSubject: First\r\n\r\nFrom Russia with love\r\n" +
+            "From -\r\nSubject: Second\r\n\r\nbody\r\n")).ToArray();
+        var reader = new EmailMailboxReader();
+
+        EmailMailboxReadResult aggregate = reader.Read(source);
+        EmailMailboxEntryReadResult[] streamed = reader.ReadEntries(new MemoryStream(source)).ToArray();
+
+        Assert.Equal(3, aggregate.Mailbox.Messages.Count);
+        Assert.Equal(3, streamed.Length);
+        Assert.Equal("First", aggregate.Mailbox.Messages[0].Document.Subject);
+        Assert.Equal("Second", aggregate.Mailbox.Messages[2].Document.Subject);
+        Assert.Contains(aggregate.Diagnostics, diagnostic =>
+            diagnostic.Code == "EMAIL_MBOX_MESSAGE_HEADERS_MISSING");
+        Assert.DoesNotContain(streamed.SelectMany(entry => entry.Diagnostics), diagnostic =>
+            diagnostic.Severity == EmailDiagnosticSeverity.Error);
+    }
 }

--- a/OfficeIMO.Email.Tests/Mbox/EmailMailboxTests.cs
+++ b/OfficeIMO.Email.Tests/Mbox/EmailMailboxTests.cs
@@ -187,4 +187,38 @@ public sealed class EmailMailboxTests {
         Assert.DoesNotContain(streamed.SelectMany(entry => entry.Diagnostics), diagnostic =>
             diagnostic.Severity == EmailDiagnosticSeverity.Error);
     }
+
+    [Fact]
+    public void PreservesHeaderlessMboxEntryBody() {
+        byte[] source = Encoding.ASCII.GetBytes(
+            "From sender@example.com Fri Jul 10 12:00:00 2026\nplain body\n");
+        var reader = new EmailMailboxReader();
+
+        EmailMailboxEntry aggregate = Assert.Single(reader.Read(source).Mailbox.Messages);
+        EmailMailboxEntryReadResult streamed = Assert.Single(
+            reader.ReadEntries(new MemoryStream(source)).ToArray());
+
+        Assert.Equal("plain body", aggregate.Document.Body.Text!.Trim());
+        Assert.Equal("plain body", streamed.Entry.Document.Body.Text!.Trim());
+        Assert.Contains(streamed.Diagnostics, diagnostic =>
+            diagnostic.Code == "EMAIL_MBOX_MESSAGE_HEADERS_MISSING");
+    }
+
+    [Fact]
+    public async Task AggregateStreamReadersPreservePerMessageLimitFailures() {
+        byte[] source = Encoding.ASCII.GetBytes(
+            "From sender@example.com Fri Jul 10 12:00:00 2026\nSubject: oversized\n\n" +
+            new string('x', 100) + "\n");
+        var options = new EmailMailboxReaderOptions(maxMailboxBytes: source.Length + 10,
+            messageOptions: new EmailReaderOptions(maxInputBytes: 64));
+        var reader = new EmailMailboxReader(options);
+
+        EmailLimitExceededException synchronous = Assert.Throws<EmailLimitExceededException>(() =>
+            reader.Read(new MemoryStream(source)));
+        EmailLimitExceededException asynchronous = await Assert.ThrowsAsync<EmailLimitExceededException>(() =>
+            reader.ReadAsync(new MemoryStream(source)));
+
+        Assert.Equal(nameof(EmailReaderOptions.MaxInputBytes), synchronous.LimitName);
+        Assert.Equal(nameof(EmailReaderOptions.MaxInputBytes), asynchronous.LimitName);
+    }
 }

--- a/OfficeIMO.Email.Tests/Mbox/EmailMailboxTests.cs
+++ b/OfficeIMO.Email.Tests/Mbox/EmailMailboxTests.cs
@@ -95,6 +95,23 @@ public sealed class EmailMailboxTests {
     }
 
     [Fact]
+    public void StreamsCumulativeMailboxOutputBeyondThePerMessageLimit() {
+        var messageOptions = new EmailWriterOptions(maxOutputBytes: 220);
+        var first = new EmailDocument { Subject = "first" };
+        first.Body.Text = new string('a', 40);
+        var second = new EmailDocument { Subject = "second" };
+        second.Body.Text = new string('b', 40);
+        var entries = new[] { new EmailMailboxEntry(first), new EmailMailboxEntry(second) };
+        using var output = new MemoryStream();
+
+        EmailWriteResult result = new EmailMailboxWriter(new EmailMailboxWriterOptions(messageOptions))
+            .WriteEntries(entries, output);
+
+        Assert.True(result.BytesWritten > messageOptions.MaxOutputBytes);
+        Assert.Equal(output.Length, result.BytesWritten);
+    }
+
+    [Fact]
     public void SingleDocumentReaderDirectsMboxToAggregateApi() {
         byte[] source = Encoding.ASCII.GetBytes("From a@example.com Fri Jul 10 12:00:00 2026\nSubject: A\n\nA\n");
 

--- a/OfficeIMO.Email.Tests/Mbox/EmailMailboxTests.cs
+++ b/OfficeIMO.Email.Tests/Mbox/EmailMailboxTests.cs
@@ -221,4 +221,49 @@ public sealed class EmailMailboxTests {
         Assert.Equal(nameof(EmailReaderOptions.MaxInputBytes), synchronous.LimitName);
         Assert.Equal(nameof(EmailReaderOptions.MaxInputBytes), asynchronous.LimitName);
     }
+
+    [Fact]
+    public void StopsReadingAnOversizedUnterminatedMboxLineAtTheMessageLimit() {
+        byte[] source = Encoding.ASCII.GetBytes(
+            "From sender@example.com Fri Jul 10 12:00:00 2026\n" + new string('x', 10000));
+        var options = new EmailMailboxReaderOptions(maxMailboxBytes: source.Length + 10,
+            messageOptions: new EmailReaderOptions(maxInputBytes: 64));
+        using var stream = new GuardedMemoryStream(source, maximumReads: 200);
+
+        EmailLimitExceededException exception = Assert.Throws<EmailLimitExceededException>(() =>
+            new EmailMailboxReader(options).ReadEntries(stream).ToArray());
+
+        Assert.Equal(nameof(EmailReaderOptions.MaxInputBytes), exception.LimitName);
+        Assert.True(stream.BytesRead < 200);
+    }
+
+    [Fact]
+    public void StopsReadingAnOversizedUnterminatedMboxLineAtTheMailboxLimit() {
+        byte[] source = Encoding.ASCII.GetBytes(new string('x', 10000));
+        var options = new EmailMailboxReaderOptions(maxMailboxBytes: 64);
+        using var stream = new GuardedMemoryStream(source, maximumReads: 200);
+
+        EmailLimitExceededException exception = Assert.Throws<EmailLimitExceededException>(() =>
+            new EmailMailboxReader(options).ReadEntries(stream).ToArray());
+
+        Assert.Equal(nameof(EmailMailboxReaderOptions.MaxMailboxBytes), exception.LimitName);
+        Assert.True(stream.BytesRead < 200);
+    }
+
+    private sealed class GuardedMemoryStream : MemoryStream {
+        private readonly int _maximumReads;
+
+        internal GuardedMemoryStream(byte[] source, int maximumReads) : base(source) {
+            _maximumReads = maximumReads;
+        }
+
+        internal int BytesRead { get; private set; }
+
+        public override int ReadByte() {
+            if (BytesRead >= _maximumReads) throw new InvalidOperationException("The reader did not stop at its limit.");
+            int value = base.ReadByte();
+            if (value >= 0) BytesRead++;
+            return value;
+        }
+    }
 }

--- a/OfficeIMO.Email.Tests/Mbox/EmailMailboxTests.cs
+++ b/OfficeIMO.Email.Tests/Mbox/EmailMailboxTests.cs
@@ -255,6 +255,21 @@ public sealed class EmailMailboxTests {
     }
 
     [Fact]
+    public void StopsReadingAnOversizedFromPrefixedMboxLineAtTheMessageLimit() {
+        byte[] source = Encoding.ASCII.GetBytes(
+            "From sender@example.com Fri Jul 10 12:00:00 2026\nFrom " + new string('x', 10000));
+        var options = new EmailMailboxReaderOptions(maxMailboxBytes: source.Length + 10,
+            messageOptions: new EmailReaderOptions(maxInputBytes: 64));
+        using var stream = new GuardedMemoryStream(source, maximumReads: 200);
+
+        EmailLimitExceededException exception = Assert.Throws<EmailLimitExceededException>(() =>
+            new EmailMailboxReader(options).ReadEntries(stream).ToArray());
+
+        Assert.Equal(nameof(EmailReaderOptions.MaxInputBytes), exception.LimitName);
+        Assert.True(stream.BytesRead < 200);
+    }
+
+    [Fact]
     public void StopsReadingAnOversizedUnterminatedMboxLineAtTheMailboxLimit() {
         byte[] source = Encoding.ASCII.GetBytes(new string('x', 10000));
         var options = new EmailMailboxReaderOptions(maxMailboxBytes: 64);

--- a/OfficeIMO.Email.Tests/Mime/EmailCalendarConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailCalendarConversionTests.cs
@@ -92,8 +92,29 @@ public sealed class EmailCalendarConversionTests {
         }
 
         EmailDocument document = new EmailDocumentReader().Read(prefix.Concat(calendar).ToArray()).Document;
+        EmailDocument roundTrip = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.Eml)).Document;
 
         Assert.Equal("Café", document.Subject);
+        Assert.Equal("Café", roundTrip.Subject);
+        EmailAttachment retained = Assert.Single(roundTrip.Attachments,
+            attachment => string.Equals(attachment.ContentType, "text/calendar", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal("windows-1252", retained.ContentTypeParameters["charset"]);
+    }
+
+    [Fact]
+    public void ParsesWeekFormEventAndReminderDurations() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "BEGIN:VEVENT\r\nUID:weekly@example.com\r\nDTSTART:20260801T100000Z\r\nDURATION:P1W\r\n" +
+            "BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER:-P1W\r\nEND:VALARM\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        OutlookAppointment appointment = new EmailDocumentReader().Read(eml).Document.Appointment!;
+
+        Assert.Equal(new DateTimeOffset(2026, 8, 8, 10, 0, 0, TimeSpan.Zero), appointment.End);
+        Assert.Equal(7 * 24 * 60, appointment.DurationMinutes);
+        Assert.Equal(7 * 24 * 60, appointment.ReminderDeltaMinutes);
     }
 
     [Fact]
@@ -347,6 +368,42 @@ public sealed class EmailCalendarConversionTests {
         Assert.Equal("text/calendar", attachment.ContentType.MimeType);
         Assert.Equal("invite.ics", attachment.FileName);
         Assert.True(attachment.IsAttachment);
+    }
+
+    [Fact]
+    public void KeepsOrdinaryCalendarAttachmentSeparateFromGeneratedAppointmentContent() {
+        DateTimeOffset start = new DateTimeOffset(2026, 8, 1, 10, 0, 0, TimeSpan.Zero);
+        var source = new EmailDocument {
+            Format = EmailFileFormat.OutlookMsg,
+            OutlookItemKind = OutlookItemKind.Appointment,
+            Subject = "Generated appointment",
+            Appointment = new OutlookAppointment { Start = start, End = start.AddHours(1) }
+        };
+        source.Attachments.Add(new EmailAttachment {
+            FileName = "ordinary.ics",
+            ContentType = "text/calendar",
+            Content = Encoding.ASCII.GetBytes(
+                "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:ordinary@example.com\r\n" +
+                "DTSTART:20260901T100000Z\r\nSUMMARY:Ordinary file\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n")
+        });
+        source.Attachments[0].Length = source.Attachments[0].Content!.LongLength;
+
+        byte[] output = new EmailDocumentWriter().ToBytes(source, EmailFileFormat.Eml);
+        using var stream = new MemoryStream(output);
+        MimePart[] calendars = MimeMessage.Load(stream).BodyParts.OfType<MimePart>()
+            .Where(part => part.ContentType.MimeType == "text/calendar").ToArray();
+        MimePart attached = Assert.Single(calendars, part => part.IsAttachment);
+        MimePart generated = Assert.Single(calendars, part => !part.IsAttachment);
+        using var attachedContent = new MemoryStream();
+        attached.Content!.DecodeTo(attachedContent);
+        using var generatedContent = new MemoryStream();
+        generated.Content!.DecodeTo(generatedContent);
+
+        Assert.Equal("ordinary.ics", attached.FileName);
+        Assert.Contains("SUMMARY:Ordinary file", Encoding.ASCII.GetString(attachedContent.ToArray()),
+            StringComparison.Ordinal);
+        Assert.Contains("SUMMARY:Generated appointment", Encoding.UTF8.GetString(generatedContent.ToArray()),
+            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/OfficeIMO.Email.Tests/Mime/EmailCalendarConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailCalendarConversionTests.cs
@@ -436,6 +436,24 @@ public sealed class EmailCalendarConversionTests {
     }
 
     [Fact]
+    public void BlocksAddresslessTaskAssigneesBeforeEmlConversion() {
+        var source = new EmailDocument {
+            Format = EmailFileFormat.OutlookMsg,
+            OutlookItemKind = OutlookItemKind.Task,
+            Task = new OutlookTask(),
+            Subject = "Assigned task"
+        };
+        source.Recipients.Add(new EmailRecipient(EmailRecipientKind.To,
+            new EmailAddress(null, "Assignee without an address")));
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(source, EmailFileFormat.Eml);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_ICALENDAR_ATTENDEE_ADDRESS_REQUIRED");
+    }
+
+    [Fact]
     public void BlocksOpaqueOutlookRecurrenceInsteadOfDroppingIt() {
         var source = new EmailDocument {
             Format = EmailFileFormat.OutlookMsg,

--- a/OfficeIMO.Email.Tests/Mime/EmailCalendarConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailCalendarConversionTests.cs
@@ -248,6 +248,117 @@ public sealed class EmailCalendarConversionTests {
     }
 
     [Fact]
+    public void BlocksUnsupportedCalendarComponentsBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "BEGIN:VEVENT\r\nUID:event@example.com\r\nDTSTART:20260801T100000Z\r\nEND:VEVENT\r\n" +
+            "BEGIN:VJOURNAL\r\nUID:journal@example.com\r\nSUMMARY:Journal\r\nEND:VJOURNAL\r\n" +
+            "END:VCALENDAR\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
+    public void MarksSubMinuteDurationsAndTriggersIncomplete() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "BEGIN:VEVENT\r\nUID:seconds@example.com\r\nDTSTART:20260801T100000Z\r\nDURATION:PT90S\r\n" +
+            "BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER:-PT30S\r\nEND:VALARM\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+        EmailReadResult read = new EmailDocumentReader().Read(eml);
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            read.Document, EmailFileFormat.OutlookMsg);
+
+        Assert.Equal(new DateTimeOffset(2026, 8, 1, 10, 1, 30, TimeSpan.Zero), read.Document.Appointment!.End);
+        Assert.Equal(1, read.Document.Appointment.DurationMinutes);
+        Assert.Equal(0, read.Document.Appointment.ReminderDeltaMinutes);
+        Assert.Contains(read.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_ICALENDAR_DURATION_PRECISION_LOSS");
+        Assert.False(report.CanWrite);
+    }
+
+    [Fact]
+    public void MarksUnresolvedTimeZonesIncompleteForStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "BEGIN:VEVENT\r\nUID:timezone@example.com\r\n" +
+            "DTSTART;TZID=OfficeIMO/Unknown:20260801T100000\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+        EmailReadResult read = new EmailDocumentReader().Read(eml);
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            read.Document, EmailFileFormat.OutlookMsg);
+
+        Assert.Contains(read.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_ICALENDAR_TIMEZONE_UNRESOLVED");
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
+    public void MarksEndRelativeAlarmsIncompleteForStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "BEGIN:VEVENT\r\nUID:end-alarm@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "DTEND:20260801T110000Z\r\nBEGIN:VALARM\r\nACTION:DISPLAY\r\n" +
+            "TRIGGER;RELATED=END:-PT15M\r\nEND:VALARM\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Theory]
+    [InlineData("TRANSPARENT", 0)]
+    [InlineData("OPAQUE", 2)]
+    public void MapsStandardTransparencyToOutlookBusyStatus(string transparency, int busyStatus) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "BEGIN:VEVENT\r\nUID:busy@example.com\r\nDTSTART:20260801T100000Z\r\nTRANSP:" + transparency +
+            "\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        Assert.Equal(busyStatus, document.Appointment!.BusyStatus);
+    }
+
+    [Theory]
+    [InlineData("PRIVATE", 2)]
+    [InlineData("CONFIDENTIAL", 3)]
+    public void PreservesEventPrivacyThroughStoreConversion(string calendarClass, int sensitivity) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "BEGIN:VEVENT\r\nUID:private@example.com\r\nDTSTART:20260801T100000Z\r\nCLASS:" + calendarClass +
+            "\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailDocument storeRoundTrip = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.OutlookMsg)).Document;
+        byte[] regeneratedEml = new EmailDocumentWriter().ToBytes(storeRoundTrip, EmailFileFormat.Eml);
+        using var stream = new MemoryStream(regeneratedEml);
+        MimePart calendar = Assert.Single(MimeMessage.Load(stream).BodyParts.OfType<MimePart>(),
+            part => part.ContentType.MimeType == "text/calendar");
+        using var content = new MemoryStream();
+        calendar.Content!.DecodeTo(content);
+
+        Assert.Equal(sensitivity, document.MessageMetadata.Sensitivity);
+        Assert.Equal(sensitivity, storeRoundTrip.MessageMetadata.Sensitivity);
+        Assert.Contains("CLASS:" + calendarClass, Encoding.UTF8.GetString(content.ToArray()),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ConvertsTaskThroughVtodo() {
         DateTimeOffset start = new DateTimeOffset(2026, 9, 3, 8, 0, 0, TimeSpan.Zero);
         var source = new EmailDocument {

--- a/OfficeIMO.Email.Tests/Mime/EmailCalendarConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailCalendarConversionTests.cs
@@ -133,6 +133,35 @@ public sealed class EmailCalendarConversionTests {
     }
 
     [Fact]
+    public void BlocksAddresslessRecipientRowsAndNeverEmitsEmptyMailtoValues() {
+        var source = new EmailDocument {
+            Format = EmailFileFormat.OutlookMsg,
+            OutlookItemKind = OutlookItemKind.Appointment,
+            Appointment = new OutlookAppointment {
+                Start = new DateTimeOffset(2026, 8, 1, 10, 0, 0, TimeSpan.Zero)
+            }
+        };
+        source.Recipients.Add(new EmailRecipient(EmailRecipientKind.To,
+            new EmailAddress("valid@example.com", "Valid")));
+        source.Recipients.Add(new EmailRecipient(EmailRecipientKind.To,
+            new EmailAddress(null, "No Address")));
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(source, EmailFileFormat.Eml);
+        byte[] warned = new EmailDocumentWriter(new EmailWriterOptions(EmailConversionLossPolicy.Warn))
+            .ToBytes(source, EmailFileFormat.Eml);
+        EmailAttachment calendar = Assert.Single(new EmailDocumentReader().Read(warned).Document.Attachments,
+            attachment => string.Equals(attachment.ContentType, "text/calendar", StringComparison.OrdinalIgnoreCase));
+        string text = Encoding.UTF8.GetString(Assert.IsType<byte[]>(calendar.Content));
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_ICALENDAR_ATTENDEE_ADDRESS_REQUIRED");
+        Assert.Contains("mailto:valid@example.com", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("CN=\"No Address\"", text, StringComparison.Ordinal);
+        Assert.DoesNotContain(":mailto:\r\n", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void KeepsRecurringIcalendarInEmlButBlocksIncompleteStoreProjection() {
         byte[] eml = Encoding.ASCII.GetBytes(
             "Subject: Recurring\r\nMIME-Version: 1.0\r\n" +
@@ -150,6 +179,68 @@ public sealed class EmailCalendarConversionTests {
         Assert.NotEmpty(writer.ToBytes(document, EmailFileFormat.Eml));
         Assert.False(msgReport.CanWrite);
         Assert.Contains(msgReport.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
+    public void KeepsUnchangedCalendarWithoutDtStartInEml() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Subject: Undated\r\nMIME-Version: 1.0\r\n" +
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:undated@example.com\r\n" +
+            "SUMMARY:Undated\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+        var writer = new EmailDocumentWriter();
+
+        EmailConversionReport report = writer.AnalyzeConversion(document, EmailFileFormat.Eml);
+        EmailAttachment calendar = Assert.Single(new EmailDocumentReader().Read(
+            writer.ToBytes(document, EmailFileFormat.Eml)).Document.Attachments,
+            attachment => string.Equals(attachment.ContentType, "text/calendar", StringComparison.OrdinalIgnoreCase));
+        string rewritten = Encoding.ASCII.GetString(Assert.IsType<byte[]>(calendar.Content));
+
+        Assert.True(report.CanWrite);
+        Assert.Contains("UID:undated@example.com", rewritten, StringComparison.Ordinal);
+        Assert.DoesNotContain("DTSTART", rewritten, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RegeneratesEditedCalendarContentWhenLossIsAccepted() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Subject: Original\r\nMIME-Version: 1.0\r\n" +
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:edit@example.com\r\n" +
+            "DTSTART:20260801T100000Z\r\nSUMMARY:Original\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+        document.Subject = "Edited";
+        document.Appointment!.Start = new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero);
+
+        byte[] output = new EmailDocumentWriter(new EmailWriterOptions(EmailConversionLossPolicy.Warn))
+            .ToBytes(document, EmailFileFormat.Eml);
+        EmailAttachment calendar = Assert.Single(new EmailDocumentReader().Read(output).Document.Attachments,
+            attachment => string.Equals(attachment.ContentType, "text/calendar", StringComparison.OrdinalIgnoreCase));
+        string rewritten = Encoding.UTF8.GetString(Assert.IsType<byte[]>(calendar.Content));
+
+        Assert.Contains("DTSTART:20260801T120000Z", rewritten, StringComparison.Ordinal);
+        Assert.Contains("SUMMARY:Edited", rewritten, StringComparison.Ordinal);
+        Assert.DoesNotContain("DTSTART:20260801T100000Z", rewritten, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AccumulatesIncompleteStateAcrossMultipleSemanticParts() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Subject: Multiple\r\nMIME-Version: 1.0\r\nContent-Type: multipart/mixed; boundary=x\r\n\r\n" +
+            "--x\r\nContent-Type: text/vcard\r\n\r\nBEGIN:VCARD\r\nVERSION:4.0\r\n" +
+            "FN:Ada\r\nPHOTO:https://example.com/ada.jpg\r\nEND:VCARD\r\n" +
+            "--x\r\nContent-Type: text/calendar\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "BEGIN:VEVENT\r\nUID:event@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n--x--\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
             diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
     }
 }

--- a/OfficeIMO.Email.Tests/Mime/EmailCalendarConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailCalendarConversionTests.cs
@@ -118,6 +118,136 @@ public sealed class EmailCalendarConversionTests {
     }
 
     [Fact]
+    public void ParsesExplicitlyPositiveEventAndReminderDurations() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "BEGIN:VEVENT\r\nUID:positive@example.com\r\nDTSTART:20260801T100000Z\r\nDURATION:+PT1H\r\n" +
+            "BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER:+PT15M\r\nEND:VALARM\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        OutlookAppointment appointment = new EmailDocumentReader().Read(eml).Document.Appointment!;
+
+        Assert.Equal(new DateTimeOffset(2026, 8, 1, 11, 0, 0, TimeSpan.Zero), appointment.End);
+        Assert.Equal(60, appointment.DurationMinutes);
+        Assert.Equal(-15, appointment.ReminderDeltaMinutes);
+    }
+
+    [Fact]
+    public void PreservesRoomAndResourceRecipientsThroughIcalendar() {
+        DateTimeOffset start = new DateTimeOffset(2026, 8, 1, 10, 0, 0, TimeSpan.Zero);
+        var source = new EmailDocument {
+            OutlookItemKind = OutlookItemKind.Appointment,
+            Subject = "Resource meeting",
+            Appointment = new OutlookAppointment { Start = start, End = start.AddHours(1) }
+        };
+        source.Recipients.Add(new EmailRecipient(EmailRecipientKind.Room,
+            new EmailAddress("room@example.com", "Room 1")));
+        source.Recipients.Add(new EmailRecipient(EmailRecipientKind.Resource,
+            new EmailAddress("projector@example.com", "Projector")));
+
+        byte[] eml = new EmailDocumentWriter().ToBytes(source, EmailFileFormat.Eml);
+        EmailDocument result = new EmailDocumentReader().Read(eml).Document;
+        using var stream = new MemoryStream(eml);
+        MimePart calendar = Assert.Single(MimeMessage.Load(stream).BodyParts.OfType<MimePart>(),
+            part => part.ContentType.MimeType == "text/calendar");
+        using var content = new MemoryStream();
+        calendar.Content!.DecodeTo(content);
+        string calendarText = Encoding.UTF8.GetString(content.ToArray());
+
+        Assert.Contains("CUTYPE=ROOM", calendarText, StringComparison.Ordinal);
+        Assert.Contains("CUTYPE=RESOURCE", calendarText, StringComparison.Ordinal);
+        Assert.Contains(result.Recipients, recipient => recipient.Kind == EmailRecipientKind.Room &&
+            recipient.Address.Address == "room@example.com");
+        Assert.Contains(result.Recipients, recipient => recipient.Kind == EmailRecipientKind.Resource &&
+            recipient.Address.Address == "projector@example.com");
+    }
+
+    [Fact]
+    public void CalendarUserTypeOverridesTheEnvelopeRecipientKind() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "To: Room 1 <room@example.com>\r\nContent-Type: text/calendar; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:room@example.com\r\n" +
+            "DTSTART:20260801T100000Z\r\n" +
+            "ATTENDEE;CUTYPE=ROOM;ROLE=NON-PARTICIPANT:mailto:room@example.com\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        EmailRecipient recipient = Assert.Single(new EmailDocumentReader().Read(eml).Document.Recipients);
+
+        Assert.Equal(EmailRecipientKind.Room, recipient.Kind);
+    }
+
+    [Theory]
+    [InlineData("ACCEPTED", "IPM.Schedule.Meeting.Resp.Pos")]
+    [InlineData("TENTATIVE", "IPM.Schedule.Meeting.Resp.Tent")]
+    [InlineData("DECLINED", "IPM.Schedule.Meeting.Resp.Neg")]
+    public void MapsIcalendarRepliesToOutlookResponseClasses(string participationStatus, string messageClass) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; method=REPLY; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nMETHOD:REPLY\r\nBEGIN:VEVENT\r\n" +
+            "UID:reply@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "ATTENDEE;PARTSTAT=" + participationStatus + ":mailto:person@example.com\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        Assert.Equal(messageClass, document.MessageClass);
+        Assert.Equal("REPLY", IcalendarMethodAfterRoundTrip(document));
+    }
+
+    [Fact]
+    public void MarksAttachedIcalendarPayloadsIncompleteForStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "BEGIN:VEVENT\r\nUID:attach@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "ATTACH:https://example.com/agenda.pdf\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
+    public void ReportsOversizedIcalendarDurationsWithoutThrowing() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "BEGIN:VEVENT\r\nUID:range@example.com\r\nDTSTART:00010101T000000Z\r\n" +
+            "DTEND:99991231T000000Z\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        EmailReadResult read = new EmailDocumentReader().Read(eml);
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            read.Document, EmailFileFormat.OutlookMsg);
+
+        Assert.Null(read.Document.Appointment!.DurationMinutes);
+        Assert.Contains(read.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_ICALENDAR_DURATION_OUT_OF_RANGE");
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
+    public void ReportsOversizedDurationAndReminderValuesWithoutThrowing() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "BEGIN:VEVENT\r\nUID:duration@example.com\r\nDTSTART:20260801T100000Z\r\nDURATION:P2000000D\r\n" +
+            "BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER:-P2000000D\r\nEND:VALARM\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        EmailReadResult read = new EmailDocumentReader().Read(eml);
+
+        Assert.Equal(new DateTimeOffset(2026, 8, 1, 10, 0, 0, TimeSpan.Zero).AddDays(2000000),
+            read.Document.Appointment!.End);
+        Assert.Null(read.Document.Appointment.DurationMinutes);
+        Assert.Null(read.Document.Appointment.ReminderDeltaMinutes);
+        Assert.Contains(read.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_ICALENDAR_DURATION_OUT_OF_RANGE");
+    }
+
+    [Fact]
     public void ConvertsTaskThroughVtodo() {
         DateTimeOffset start = new DateTimeOffset(2026, 9, 3, 8, 0, 0, TimeSpan.Zero);
         var source = new EmailDocument {
@@ -433,5 +563,13 @@ public sealed class EmailCalendarConversionTests {
         string calendarText = Encoding.UTF8.GetString(content.ToArray());
         Assert.Contains("BEGIN:VCALENDAR", calendarText, StringComparison.Ordinal);
         Assert.DoesNotContain("BEGIN:VCARD", calendarText, StringComparison.Ordinal);
+    }
+
+    private static string? IcalendarMethodAfterRoundTrip(EmailDocument document) {
+        byte[] eml = new EmailDocumentWriter().ToBytes(document, EmailFileFormat.Eml);
+        using var stream = new MemoryStream(eml);
+        MimePart calendar = Assert.Single(MimeMessage.Load(stream).BodyParts.OfType<MimePart>(),
+            part => part.ContentType.MimeType == "text/calendar");
+        return calendar.ContentType.Parameters["method"];
     }
 }

--- a/OfficeIMO.Email.Tests/Mime/EmailCalendarConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailCalendarConversionTests.cs
@@ -52,6 +52,51 @@ public sealed class EmailCalendarConversionTests {
     }
 
     [Fact]
+    public void ProjectsEventPropertiesWithoutUsingTimezoneComponentValues() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "BEGIN:VTIMEZONE\r\nTZID:Example\r\nBEGIN:STANDARD\r\nDTSTART:20000101T020000\r\n" +
+            "END:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nUID:event@example.com\r\n" +
+            "DTSTART:20260801T100000Z\r\nDTEND:20260801T110000Z\r\nSUMMARY:Scoped event\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        Assert.Equal("Scoped event", document.Subject);
+        Assert.Equal(new DateTimeOffset(2026, 8, 1, 10, 0, 0, TimeSpan.Zero), document.Appointment!.Start);
+        Assert.Equal(new DateTimeOffset(2026, 8, 1, 11, 0, 0, TimeSpan.Zero), document.Appointment.End);
+    }
+
+    [Fact]
+    public void ParsesQuotedAttendeeParametersContainingDelimiters() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "BEGIN:VEVENT\r\nUID:event@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "ATTENDEE;ROLE=REQ-PARTICIPANT;CN=\"Doe; John: Sr.\":mailto:john@example.com\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        EmailRecipient attendee = Assert.Single(new EmailDocumentReader().Read(eml).Document.Recipients);
+
+        Assert.Equal("john@example.com", attendee.Address.Address);
+        Assert.Equal("Doe; John: Sr.", attendee.Address.DisplayName);
+    }
+
+    [Fact]
+    public void DecodesCalendarProjectionUsingTheDeclaredCharset() {
+        byte[] prefix = Encoding.ASCII.GetBytes("Content-Type: text/calendar; charset=windows-1252\r\n\r\n");
+        byte[] calendar = Encoding.ASCII.GetBytes(
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:event@example.com\r\n" +
+            "DTSTART:20260801T100000Z\r\nSUMMARY:Caf#\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+        for (int index = 0; index < calendar.Length; index++) {
+            if (calendar[index] == (byte)'#') calendar[index] = 0xe9;
+        }
+
+        EmailDocument document = new EmailDocumentReader().Read(prefix.Concat(calendar).ToArray()).Document;
+
+        Assert.Equal("Café", document.Subject);
+    }
+
+    [Fact]
     public void ConvertsTaskThroughVtodo() {
         DateTimeOffset start = new DateTimeOffset(2026, 9, 3, 8, 0, 0, TimeSpan.Zero);
         var source = new EmailDocument {
@@ -94,6 +139,38 @@ public sealed class EmailCalendarConversionTests {
         Assert.Equal("12 km", result.Task.Mileage);
         Assert.Equal("Ada Lovelace", Assert.Single(result.Task.Contacts));
         Assert.Equal("Analytical Engines", Assert.Single(result.Task.Companies));
+    }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(4)]
+    public void PreservesNumericTaskStatusThroughVtodo(int status) {
+        var source = new EmailDocument {
+            Format = EmailFileFormat.OutlookMsg,
+            OutlookItemKind = OutlookItemKind.Task,
+            Subject = "Status",
+            Task = new OutlookTask { Status = status }
+        };
+
+        EmailDocument result = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(source, EmailFileFormat.Eml)).Document;
+
+        Assert.Equal(status, result.Task!.Status);
+    }
+
+    [Fact]
+    public void BlocksRecurringTaskWhenNoPortableRuleIsAvailable() {
+        var source = new EmailDocument {
+            Format = EmailFileFormat.OutlookMsg,
+            OutlookItemKind = OutlookItemKind.Task,
+            Task = new OutlookTask { IsRecurring = true }
+        };
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(source, EmailFileFormat.Eml);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_ICALENDAR_OPAQUE_TASK_RECURRENCE");
     }
 
     [Fact]
@@ -226,6 +303,53 @@ public sealed class EmailCalendarConversionTests {
     }
 
     [Fact]
+    public void RecomputesCalendarMethodWhenRegeneratingEditedContent() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Subject: Published\r\nMIME-Version: 1.0\r\n" +
+            "Content-Type: text/calendar; method=PUBLISH; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nMETHOD:PUBLISH\r\nBEGIN:VEVENT\r\n" +
+            "UID:method@example.com\r\nDTSTART:20260801T100000Z\r\nSUMMARY:Published\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+        document.Subject = "Requested";
+        document.Recipients.Add(new EmailRecipient(EmailRecipientKind.To,
+            new EmailAddress("attendee@example.com")));
+
+        byte[] output = new EmailDocumentWriter(new EmailWriterOptions(EmailConversionLossPolicy.Warn))
+            .ToBytes(document, EmailFileFormat.Eml);
+        EmailAttachment calendar = Assert.Single(new EmailDocumentReader().Read(output).Document.Attachments,
+            attachment => string.Equals(attachment.ContentType, "text/calendar", StringComparison.OrdinalIgnoreCase));
+        string rewritten = Encoding.UTF8.GetString(Assert.IsType<byte[]>(calendar.Content));
+
+        Assert.Equal("REQUEST", calendar.ContentTypeParameters["method"]);
+        Assert.Contains("METHOD:REQUEST", rewritten, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void KeepsAttachedCalendarAsAnAttachment() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Subject: Attached invitation\r\nMIME-Version: 1.0\r\n" +
+            "Content-Type: multipart/mixed; boundary=x\r\n\r\n" +
+            "--x\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nPlease review the attachment.\r\n" +
+            "--x\r\nContent-Type: text/calendar; method=PUBLISH; charset=utf-8\r\n" +
+            "Content-Disposition: attachment; filename=invite.ics\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nMETHOD:PUBLISH\r\nBEGIN:VEVENT\r\n" +
+            "UID:attached@example.com\r\nDTSTART:20260801T100000Z\r\nSUMMARY:Attached\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n--x--\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        byte[] output = new EmailDocumentWriter().ToBytes(document, EmailFileFormat.Eml);
+        using var stream = new MemoryStream(output);
+        MimeMessage message = MimeMessage.Load(stream);
+        MimePart attachment = Assert.IsAssignableFrom<MimePart>(Assert.Single(message.Attachments));
+
+        Assert.Equal("Please review the attachment.", message.TextBody!.Trim());
+        Assert.Equal("text/calendar", attachment.ContentType.MimeType);
+        Assert.Equal("invite.ics", attachment.FileName);
+        Assert.True(attachment.IsAttachment);
+    }
+
+    [Fact]
     public void AccumulatesIncompleteStateAcrossMultipleSemanticParts() {
         byte[] eml = Encoding.ASCII.GetBytes(
             "Subject: Multiple\r\nMIME-Version: 1.0\r\nContent-Type: multipart/mixed; boundary=x\r\n\r\n" +
@@ -242,5 +366,15 @@ public sealed class EmailCalendarConversionTests {
         Assert.False(report.CanWrite);
         Assert.Contains(report.Diagnostics,
             diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+
+        byte[] rewritten = new EmailDocumentWriter().ToBytes(document, EmailFileFormat.Eml);
+        using var stream = new MemoryStream(rewritten);
+        MimePart calendar = Assert.Single(MimeMessage.Load(stream).BodyParts.OfType<MimePart>(),
+            part => part.ContentType.MimeType == "text/calendar");
+        using var content = new MemoryStream();
+        calendar.Content!.DecodeTo(content);
+        string calendarText = Encoding.UTF8.GetString(content.ToArray());
+        Assert.Contains("BEGIN:VCALENDAR", calendarText, StringComparison.Ordinal);
+        Assert.DoesNotContain("BEGIN:VCARD", calendarText, StringComparison.Ordinal);
     }
 }

--- a/OfficeIMO.Email.Tests/Mime/EmailCalendarConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailCalendarConversionTests.cs
@@ -601,14 +601,21 @@ public sealed class EmailCalendarConversionTests {
         EmailDocument document = new EmailDocumentReader().Read(eml).Document;
 
         byte[] output = new EmailDocumentWriter().ToBytes(document, EmailFileFormat.Eml);
+        EmailDocument storeRoundTrip = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.OutlookMsg)).Document;
         using var stream = new MemoryStream(output);
         MimeMessage message = MimeMessage.Load(stream);
         MimePart attachment = Assert.IsAssignableFrom<MimePart>(Assert.Single(message.Attachments));
 
+        Assert.Equal(OutlookItemKind.Message, document.OutlookItemKind);
+        Assert.Null(document.Appointment);
         Assert.Equal("Please review the attachment.", message.TextBody!.Trim());
         Assert.Equal("text/calendar", attachment.ContentType.MimeType);
         Assert.Equal("invite.ics", attachment.FileName);
         Assert.True(attachment.IsAttachment);
+        Assert.Equal(OutlookItemKind.Message, storeRoundTrip.OutlookItemKind);
+        Assert.Null(storeRoundTrip.Appointment);
+        Assert.Equal("invite.ics", Assert.Single(storeRoundTrip.Attachments).FileName);
     }
 
     [Fact]

--- a/OfficeIMO.Email.Tests/Mime/EmailCalendarConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailCalendarConversionTests.cs
@@ -1,0 +1,155 @@
+using MimeKit;
+using OfficeIMO.Email;
+using Xunit;
+
+namespace OfficeIMO.Email.Tests;
+
+public sealed class EmailCalendarConversionTests {
+    [Fact]
+    public void ConvertsAppointmentThroughStandardsBasedEmlWithoutLosingCoreSemantics() {
+        DateTimeOffset start = new DateTimeOffset(2026, 8, 1, 10, 0, 0, TimeSpan.FromHours(2));
+        var source = new EmailDocument {
+            Format = EmailFileFormat.OutlookMsg,
+            OutlookItemKind = OutlookItemKind.Appointment,
+            MessageClass = "IPM.Schedule.Meeting.Request",
+            Subject = "Planning",
+            MessageId = "planning@example.com",
+            From = new EmailAddress("organizer@example.com", "Organizer"),
+            Appointment = new OutlookAppointment {
+                Start = start,
+                End = start.AddHours(2),
+                Location = "Room 1",
+                BusyStatus = 2,
+                Sequence = 3,
+                ReminderIsSet = true,
+                ReminderDeltaMinutes = 20,
+                ReminderTime = start.AddMinutes(-20),
+                ReminderSignalTime = start.AddMinutes(-20)
+            }
+        };
+        source.Body.Text = "Agenda";
+        source.Recipients.Add(new EmailRecipient(EmailRecipientKind.To,
+            new EmailAddress("attendee@example.com", "Attendee")));
+
+        byte[] eml = new EmailDocumentWriter().ToBytes(source, EmailFileFormat.Eml);
+        EmailReadResult read = new EmailDocumentReader().Read(eml);
+        using var oracleStream = new MemoryStream(eml);
+        MimeMessage oracle = MimeMessage.Load(oracleStream);
+
+        Assert.Contains(oracle.BodyParts.OfType<MimePart>(), part => part.ContentType.MimeType == "text/calendar");
+        Assert.Equal(OutlookItemKind.Appointment, read.Document.OutlookItemKind);
+        Assert.Equal("Planning", read.Document.Subject);
+        Assert.Equal(start.UtcDateTime, read.Document.Appointment!.Start!.Value.UtcDateTime);
+        Assert.Equal(start.AddHours(2).UtcDateTime, read.Document.Appointment.End!.Value.UtcDateTime);
+        Assert.Equal("Room 1", read.Document.Appointment.Location);
+        Assert.Equal(3, read.Document.Appointment.Sequence);
+        Assert.True(read.Document.Appointment.ReminderIsSet);
+        Assert.Equal(20, read.Document.Appointment.ReminderDeltaMinutes);
+        Assert.Equal(start.AddMinutes(-20).UtcDateTime,
+            read.Document.Appointment.ReminderSignalTime!.Value.UtcDateTime);
+        Assert.Equal("attendee@example.com", Assert.Single(read.Document.Recipients).Address.Address);
+        Assert.DoesNotContain(read.Diagnostics, diagnostic => diagnostic.Severity == EmailDiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void ConvertsTaskThroughVtodo() {
+        DateTimeOffset start = new DateTimeOffset(2026, 9, 3, 8, 0, 0, TimeSpan.Zero);
+        var source = new EmailDocument {
+            Format = EmailFileFormat.OutlookMsg,
+            OutlookItemKind = OutlookItemKind.Task,
+            MessageClass = "IPM.Task",
+            Subject = "Ship release",
+            Task = new OutlookTask {
+                Start = start,
+                Due = start.AddDays(2),
+                PercentComplete = 0.5,
+                Status = 1,
+                Owner = "Release Manager",
+                EstimatedEffort = TimeSpan.FromHours(6),
+                ActualEffort = TimeSpan.FromHours(2),
+                ReminderIsSet = true,
+                ReminderDeltaMinutes = 30,
+                BillingInformation = "Internal",
+                Mileage = "12 km"
+            }
+        };
+        source.Task.Contacts.Add("Ada Lovelace");
+        source.Task.Companies.Add("Analytical Engines");
+
+        EmailDocument result = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(source, EmailFileFormat.Eml)).Document;
+
+        Assert.Equal(OutlookItemKind.Task, result.OutlookItemKind);
+        Assert.Equal("Ship release", result.Subject);
+        Assert.Equal(start, result.Task!.Start);
+        Assert.Equal(start.AddDays(2), result.Task.Due);
+        Assert.Equal(0.5, result.Task.PercentComplete);
+        Assert.Equal(1, result.Task.Status);
+        Assert.Equal("Release Manager", result.Task.Owner);
+        Assert.Equal(TimeSpan.FromHours(6), result.Task.EstimatedEffort);
+        Assert.Equal(TimeSpan.FromHours(2), result.Task.ActualEffort);
+        Assert.True(result.Task.ReminderIsSet);
+        Assert.Equal(30, result.Task.ReminderDeltaMinutes);
+        Assert.Equal("Internal", result.Task.BillingInformation);
+        Assert.Equal("12 km", result.Task.Mileage);
+        Assert.Equal("Ada Lovelace", Assert.Single(result.Task.Contacts));
+        Assert.Equal("Analytical Engines", Assert.Single(result.Task.Companies));
+    }
+
+    [Fact]
+    public void BlocksOpaqueOutlookRecurrenceInsteadOfDroppingIt() {
+        var source = new EmailDocument {
+            Format = EmailFileFormat.OutlookMsg,
+            OutlookItemKind = OutlookItemKind.Appointment,
+            Appointment = new OutlookAppointment {
+                Start = new DateTimeOffset(2026, 8, 1, 10, 0, 0, TimeSpan.Zero),
+                End = new DateTimeOffset(2026, 8, 1, 11, 0, 0, TimeSpan.Zero),
+                RecurrenceState = new byte[] { 1, 2, 3 }
+            }
+        };
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(source, EmailFileFormat.Eml);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics, diagnostic => diagnostic.Code == "EMAIL_ICALENDAR_OPAQUE_RECURRENCE");
+    }
+
+    [Fact]
+    public void BlocksAttendeeDisplayTextWhenNoCalendarAddressExists() {
+        var source = new EmailDocument {
+            Format = EmailFileFormat.OutlookMsg,
+            OutlookItemKind = OutlookItemKind.Appointment,
+            Appointment = new OutlookAppointment {
+                Start = new DateTimeOffset(2026, 8, 1, 10, 0, 0, TimeSpan.Zero),
+                RequiredAttendees = "Person without an address"
+            }
+        };
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(source, EmailFileFormat.Eml);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_ICALENDAR_ATTENDEE_ADDRESS_REQUIRED");
+    }
+
+    [Fact]
+    public void KeepsRecurringIcalendarInEmlButBlocksIncompleteStoreProjection() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Subject: Recurring\r\nMIME-Version: 1.0\r\n" +
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:r@example.com\r\n" +
+            "DTSTART:20260801T100000Z\r\nDTEND:20260801T110000Z\r\n" +
+            "RRULE:FREQ=WEEKLY;COUNT=4\r\nSUMMARY:Recurring\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+        var writer = new EmailDocumentWriter();
+
+        EmailConversionReport emlReport = writer.AnalyzeConversion(document, EmailFileFormat.Eml);
+        EmailConversionReport msgReport = writer.AnalyzeConversion(document, EmailFileFormat.OutlookMsg);
+
+        Assert.True(emlReport.CanWrite);
+        Assert.NotEmpty(writer.ToBytes(document, EmailFileFormat.Eml));
+        Assert.False(msgReport.CanWrite);
+        Assert.Contains(msgReport.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+}

--- a/OfficeIMO.Email.Tests/Mime/EmailCalendarFidelityRegressionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailCalendarFidelityRegressionTests.cs
@@ -1,0 +1,110 @@
+using MimeKit;
+using OfficeIMO.Email;
+using Xunit;
+
+namespace OfficeIMO.Email.Tests;
+
+public sealed class EmailCalendarFidelityRegressionTests {
+    [Theory]
+    [InlineData("ROOM")]
+    [InlineData("RESOURCE")]
+    public void BlocksRoomAndResourceAttendeesWithoutExplicitNonParticipantRole(string calendarUserType) {
+        byte[] eml = Calendar(
+            "BEGIN:VEVENT\r\nUID:room-role@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "ATTENDEE;CUTYPE=" + calendarUserType + ":mailto:asset@example.com\r\nEND:VEVENT\r\n",
+            "REQUEST");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
+    public void BlocksParameterizedCalendarLocationsBeforeStoreConversion() {
+        byte[] eml = Calendar(
+            "BEGIN:VEVENT\r\nUID:location-parameter@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "LOCATION;ALTREP=\"cid:map\":Room\r\nEND:VEVENT\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.Equal("Room", document.Appointment!.Location);
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
+    public void PreservesVtodoOrganizerDisplayNameThroughStoreConversion() {
+        byte[] eml = Calendar(
+            "BEGIN:VTODO\r\nUID:task-owner@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "ORGANIZER;CN=Owner:mailto:owner@example.com\r\nEND:VTODO\r\n", "PUBLISH");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+        EmailDocument stored = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.OutlookMsg)).Document;
+        string regenerated = CalendarText(new EmailDocumentWriter().ToBytes(stored, EmailFileFormat.Eml));
+
+        Assert.True(report.CanWrite);
+        Assert.Contains("ORGANIZER;CN=\"Owner\":mailto:owner@example.com", regenerated,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CalendarOnlyDescriptionDoesNotBecomeAnExtraMimeBody() {
+        byte[] eml = Calendar(
+            "BEGIN:VEVENT\r\nUID:description-only@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "DESCRIPTION:Calendar description\r\nEND:VEVENT\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        byte[] rewritten = new EmailDocumentWriter().ToBytes(document, EmailFileFormat.Eml);
+        using var stream = new MemoryStream(rewritten);
+        MimeMessage message = MimeMessage.Load(stream);
+
+        MimePart calendar = Assert.IsAssignableFrom<MimePart>(message.Body);
+        Assert.Equal("text/calendar", calendar.ContentType.MimeType);
+        Assert.DoesNotContain(message.BodyParts.OfType<MimePart>(),
+            part => part.ContentType.MimeType == "text/plain");
+    }
+
+    [Fact]
+    public void BlocksPartiallyUnmatchedAppointmentAttendeeDisplays() {
+        var source = new EmailDocument {
+            Format = EmailFileFormat.OutlookMsg,
+            OutlookItemKind = OutlookItemKind.Appointment,
+            Appointment = new OutlookAppointment {
+                Start = new DateTimeOffset(2026, 8, 1, 10, 0, 0, TimeSpan.Zero),
+                RequiredAttendees = "Alice; Bob"
+            }
+        };
+        source.Recipients.Add(new EmailRecipient(EmailRecipientKind.To,
+            new EmailAddress("alice@example.com", "Alice")));
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(source, EmailFileFormat.Eml);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_ICALENDAR_ATTENDEE_ADDRESS_REQUIRED");
+    }
+
+    private static byte[] Calendar(string component, string? method = null) => Encoding.ASCII.GetBytes(
+        "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+        (string.IsNullOrWhiteSpace(method) ? string.Empty : "METHOD:" + method + "\r\n") +
+        component + "END:VCALENDAR\r\n");
+
+    private static string CalendarText(byte[] eml) {
+        using var stream = new MemoryStream(eml);
+        MimePart calendar = Assert.Single(MimeMessage.Load(stream).BodyParts.OfType<MimePart>(),
+            part => part.ContentType.MimeType == "text/calendar");
+        using var content = new MemoryStream();
+        calendar.Content!.DecodeTo(content);
+        return Encoding.UTF8.GetString(content.ToArray());
+    }
+}

--- a/OfficeIMO.Email.Tests/Mime/EmailCalendarProjectionEdgeTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailCalendarProjectionEdgeTests.cs
@@ -76,6 +76,27 @@ public sealed class EmailCalendarProjectionEdgeTests {
     }
 
     [Fact]
+    public void PreservesLiteralPercentSequencesInCalendarMailboxes() {
+        var source = new EmailDocument {
+            Format = EmailFileFormat.OutlookMsg,
+            OutlookItemKind = OutlookItemKind.Appointment,
+            Subject = "Percent mailbox",
+            Appointment = new OutlookAppointment {
+                Start = new DateTimeOffset(2026, 8, 1, 10, 0, 0, TimeSpan.Zero)
+            }
+        };
+        source.Recipients.Add(new EmailRecipient(EmailRecipientKind.To,
+            new EmailAddress("user%2Ctag@example.com")));
+
+        byte[] eml = new EmailDocumentWriter().ToBytes(source, EmailFileFormat.Eml);
+        EmailDocument roundTrip = new EmailDocumentReader().Read(eml).Document;
+
+        Assert.Contains("mailto:user%252Ctag@example.com", CalendarText(eml), StringComparison.Ordinal);
+        Assert.Contains(roundTrip.Recipients,
+            recipient => recipient.Address.Address == "user%2Ctag@example.com");
+    }
+
+    [Fact]
     public void BlocksCalendarPriorityBeforeStoreConversion() {
         byte[] eml = Calendar(
             "BEGIN:VEVENT\r\nUID:priority@example.com\r\nDTSTART:20260801T100000Z\r\n" +
@@ -260,12 +281,45 @@ public sealed class EmailCalendarProjectionEdgeTests {
             diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
     }
 
+    [Theory]
+    [InlineData("PARTSTAT=ACCEPTED")]
+    [InlineData("RSVP=TRUE")]
+    public void BlocksAttendeeParametersThatStoreRecipientsCannotRepresent(string parameter) {
+        byte[] eml = Calendar(
+            "BEGIN:VEVENT\r\nUID:attendee-state@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "ATTENDEE;" + parameter + ":mailto:alice@example.com\r\nEND:VEVENT\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
+    public void BlocksCustomAlarmDescriptionsThatStoreRemindersCannotRepresent() {
+        byte[] eml = Calendar(
+            "BEGIN:VEVENT\r\nUID:alarm-description@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "SUMMARY:Meeting\r\nBEGIN:VALARM\r\nACTION:DISPLAY\r\n" +
+            "DESCRIPTION:Bring the report\r\nTRIGGER:-PT15M\r\nEND:VALARM\r\nEND:VEVENT\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
     [Fact]
     public void PreservesAbsoluteAlarmTriggersThroughStoreConversion() {
         DateTimeOffset signal = new DateTimeOffset(2026, 8, 1, 9, 45, 0, TimeSpan.Zero);
         byte[] eml = Calendar(
             "BEGIN:VEVENT\r\nUID:absolute-alarm@example.com\r\nDTSTART:20260801T100000Z\r\n" +
-            "BEGIN:VALARM\r\nACTION:DISPLAY\r\nDESCRIPTION:Reminder\r\n" +
+            "SUMMARY:Reminder\r\nBEGIN:VALARM\r\nACTION:DISPLAY\r\nDESCRIPTION:Reminder\r\n" +
             "TRIGGER;VALUE=DATE-TIME:20260801T094500Z\r\nEND:VALARM\r\nEND:VEVENT\r\n");
         EmailDocument document = new EmailDocumentReader().Read(eml).Document;
 

--- a/OfficeIMO.Email.Tests/Mime/EmailCalendarProjectionEdgeTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailCalendarProjectionEdgeTests.cs
@@ -146,6 +146,94 @@ public sealed class EmailCalendarProjectionEdgeTests {
             diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
     }
 
+    [Theory]
+    [InlineData("VEVENT")]
+    [InlineData("VTODO")]
+    public void BlocksCalendarTimestampsBeforeStoreConversion(string component) {
+        byte[] eml = Calendar(
+            "BEGIN:" + component + "\r\nUID:timestamp@example.com\r\n" +
+            "DTSTART:20260801T100000Z\r\nDTSTAMP:20260715T080000Z\r\nEND:" + component + "\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Theory]
+    [InlineData("CANCEL")]
+    [InlineData("REPLY")]
+    [InlineData("ADD")]
+    public void BlocksUnsupportedVtodoMethodsBeforeStoreConversion(string method) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; method=" + method + "; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nMETHOD:" + method + "\r\nBEGIN:VTODO\r\n" +
+            "UID:task-method@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "END:VTODO\r\nEND:VCALENDAR\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
+    public void BlocksVtodoSequenceBeforeStoreConversion() {
+        byte[] eml = Calendar(
+            "BEGIN:VTODO\r\nUID:task-sequence@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "SEQUENCE:3\r\nEND:VTODO\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Theory]
+    [InlineData("ORGANIZER:urn:uuid:owner")]
+    [InlineData("ATTENDEE:urn:uuid:attendee")]
+    public void BlocksNonMailtoCalendarAddressesBeforeStoreConversion(string property) {
+        byte[] eml = Calendar(
+            "BEGIN:VEVENT\r\nUID:cal-address@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            property + "\r\nEND:VEVENT\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Null(document.From);
+        Assert.Empty(document.Recipients);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Theory]
+    [InlineData("SENT-BY=mailto:assistant@example.com")]
+    [InlineData("DIR=ldap://directory.example/owner")]
+    public void BlocksUnsupportedOrganizerParametersBeforeStoreConversion(string parameter) {
+        byte[] eml = Calendar(
+            "BEGIN:VEVENT\r\nUID:organizer-parameter@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "ORGANIZER;" + parameter + ":mailto:owner@example.com\r\nEND:VEVENT\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
     [Fact]
     public void CalendarOptionalRoleOverridesEnvelopeRecipientKind() {
         byte[] eml = Encoding.ASCII.GetBytes(

--- a/OfficeIMO.Email.Tests/Mime/EmailCalendarProjectionEdgeTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailCalendarProjectionEdgeTests.cs
@@ -184,6 +184,22 @@ public sealed class EmailCalendarProjectionEdgeTests {
     }
 
     [Fact]
+    public void BlocksUnsupportedCalendarVersionsBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:1.0\r\n" +
+            "BEGIN:VEVENT\r\nUID:version@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
     public void BlocksVtodoSequenceBeforeStoreConversion() {
         byte[] eml = Calendar(
             "BEGIN:VTODO\r\nUID:task-sequence@example.com\r\nDTSTART:20260801T100000Z\r\n" +
@@ -241,6 +257,7 @@ public sealed class EmailCalendarProjectionEdgeTests {
     [InlineData("VTODO", "RESOURCES:Conference room")]
     [InlineData("VEVENT", "GEO:52.2297;21.0122")]
     [InlineData("VEVENT", "CONTACT:calendar@example.com")]
+    [InlineData("VTODO", "LOCATION:Warehouse")]
     public void BlocksUnprojectedCalendarAuditAndDetailFieldsBeforeStoreConversion(
         string component, string property) {
         byte[] eml = Calendar(

--- a/OfficeIMO.Email.Tests/Mime/EmailCalendarProjectionEdgeTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailCalendarProjectionEdgeTests.cs
@@ -111,6 +111,41 @@ public sealed class EmailCalendarProjectionEdgeTests {
             diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
     }
 
+    [Theory]
+    [InlineData("VEVENT")]
+    [InlineData("VTODO")]
+    public void BlocksCalendarUrlsBeforeStoreConversion(string component) {
+        byte[] eml = Calendar(
+            "BEGIN:" + component + "\r\nUID:url@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "URL:https://example.com/item\r\nEND:" + component + "\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Theory]
+    [InlineData("DTSTART")]
+    [InlineData("DUE")]
+    [InlineData("COMPLETED")]
+    public void BlocksDateOnlyTaskDatesBeforeStoreConversion(string property) {
+        byte[] eml = Calendar(
+            "BEGIN:VTODO\r\nUID:date-only@example.com\r\n" + property +
+            ";VALUE=DATE:20260715\r\nEND:VTODO\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
     [Fact]
     public void CalendarOptionalRoleOverridesEnvelopeRecipientKind() {
         byte[] eml = Encoding.ASCII.GetBytes(
@@ -178,6 +213,24 @@ public sealed class EmailCalendarProjectionEdgeTests {
 
         Assert.Equal(expectedMessageClass, document.MessageClass);
         Assert.Equal(expectedMessageClass, roundTrip.MessageClass);
+    }
+
+    [Fact]
+    public void BlocksPublishCalendarsWhoseTransportRecipientsWouldBecomeAttendees() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "To: Distribution <distribution@example.com>\r\n" +
+            "Content-Type: text/calendar; method=PUBLISH; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nMETHOD:PUBLISH\r\nBEGIN:VEVENT\r\n" +
+            "UID:publish@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
     }
 
     [Fact]

--- a/OfficeIMO.Email.Tests/Mime/EmailCalendarProjectionEdgeTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailCalendarProjectionEdgeTests.cs
@@ -139,6 +139,110 @@ public sealed class EmailCalendarProjectionEdgeTests {
     }
 
     [Fact]
+    public void PreservesAbsoluteAlarmTriggersThroughStoreConversion() {
+        DateTimeOffset signal = new DateTimeOffset(2026, 8, 1, 9, 45, 0, TimeSpan.Zero);
+        byte[] eml = Calendar(
+            "BEGIN:VEVENT\r\nUID:absolute-alarm@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "BEGIN:VALARM\r\nACTION:DISPLAY\r\nDESCRIPTION:Reminder\r\n" +
+            "TRIGGER;VALUE=DATE-TIME:20260801T094500Z\r\nEND:VALARM\r\nEND:VEVENT\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+        EmailDocument roundTrip = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.OutlookMsg)).Document;
+
+        Assert.True(report.CanWrite);
+        Assert.Equal(signal, document.Appointment!.ReminderSignalTime);
+        Assert.Equal(signal, roundTrip.Appointment!.ReminderSignalTime);
+    }
+
+    [Fact]
+    public void BlocksDistinctTransportMessageIdAndCalendarUidBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Message-ID: <transport@example.com>\r\nContent-Type: text/calendar; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:event@example.com\r\n" +
+            "DTSTART:20260801T100000Z\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Equal("transport@example.com", document.MessageId);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
+    public void BlocksDistinctTransportFromAndCalendarOrganizerBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "From: Relay <relay@example.com>\r\nContent-Type: text/calendar; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:event@example.com\r\n" +
+            "DTSTART:20260801T100000Z\r\nORGANIZER;CN=Owner:mailto:owner@example.com\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Equal("relay@example.com", document.From!.Address);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
+    public void BlocksDistinctMimeBodyAndCalendarDescriptionBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "MIME-Version: 1.0\r\nContent-Type: multipart/alternative; boundary=x\r\n\r\n" +
+            "--x\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nWrapper text\r\n" +
+            "--x\r\nContent-Type: text/calendar; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:event@example.com\r\n" +
+            "DTSTART:20260801T100000Z\r\nDESCRIPTION:Event notes\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n--x--\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Equal("Wrapper text", document.Body.Text!.Trim());
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
+    public void DecodesEscapedCalendarTextSequentially() {
+        byte[] eml = Calendar(
+            "BEGIN:VEVENT\r\nUID:escape@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "SUMMARY:Literal \\\\n value\r\nEND:VEVENT\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailDocument roundTrip = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.OutlookMsg)).Document;
+
+        Assert.Equal("Literal \\n value", document.Subject);
+        Assert.Equal("Literal \\n value", roundTrip.Subject);
+    }
+
+    [Fact]
+    public void UnescapesQuotedCalendarParameters() {
+        const string parameterName = "Alice \\\"A\\\" \\\\ Team";
+        byte[] eml = Calendar(
+            "BEGIN:VEVENT\r\nUID:parameter@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "ATTENDEE;CN=\"" + parameterName + "\":mailto:alice@example.com\r\n" +
+            "END:VEVENT\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailDocument roundTrip = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.OutlookMsg)).Document;
+
+        Assert.Equal("Alice \"A\" \\ Team", Assert.Single(document.Recipients).Address.DisplayName);
+        Assert.Equal("Alice \"A\" \\ Team", Assert.Single(roundTrip.Recipients).Address.DisplayName);
+    }
+
+    [Fact]
     public void BlocksMultipleSemanticMimeBodyPartsBeforeStoreConversion() {
         byte[] eml = Encoding.ASCII.GetBytes(
             "MIME-Version: 1.0\r\nContent-Type: multipart/alternative; boundary=x\r\n\r\n" +

--- a/OfficeIMO.Email.Tests/Mime/EmailCalendarProjectionEdgeTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailCalendarProjectionEdgeTests.cs
@@ -1,0 +1,120 @@
+using MimeKit;
+using OfficeIMO.Email;
+using Xunit;
+
+namespace OfficeIMO.Email.Tests;
+
+public sealed class EmailCalendarProjectionEdgeTests {
+    [Fact]
+    public void ProjectsVtodoAttendeesThroughStoreRecipients() {
+        byte[] eml = Calendar(
+            "BEGIN:VTODO\r\nUID:assigned@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "ATTENDEE;CN=Assignee:mailto:assignee@example.com\r\nEND:VTODO\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailDocument roundTrip = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.OutlookMsg)).Document;
+
+        Assert.Contains(document.Recipients, recipient => recipient.Address.Address == "assignee@example.com");
+        Assert.Contains(roundTrip.Recipients, recipient => recipient.Address.Address == "assignee@example.com");
+    }
+
+    [Fact]
+    public void PreservesVtodoPrivacyThroughStoreConversion() {
+        byte[] eml = Calendar(
+            "BEGIN:VTODO\r\nUID:private-task@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "CLASS:CONFIDENTIAL\r\nEND:VTODO\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailDocument storeRoundTrip = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.OutlookMsg)).Document;
+        string regenerated = CalendarText(new EmailDocumentWriter().ToBytes(storeRoundTrip, EmailFileFormat.Eml));
+
+        Assert.Equal(3, document.MessageMetadata.Sensitivity);
+        Assert.Equal(3, storeRoundTrip.MessageMetadata.Sensitivity);
+        Assert.Contains("CLASS:CONFIDENTIAL", regenerated, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DerivesVtodoDueDateFromStandardDuration() {
+        DateTimeOffset start = new DateTimeOffset(2026, 8, 1, 10, 0, 0, TimeSpan.Zero);
+        byte[] eml = Calendar(
+            "BEGIN:VTODO\r\nUID:duration-task@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "DURATION:PT2H\r\nEND:VTODO\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailDocument storeRoundTrip = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.OutlookMsg)).Document;
+
+        Assert.Equal(start.AddHours(2), document.Task!.Due);
+        Assert.Null(document.Task.EstimatedEffort);
+        Assert.Equal(start.AddHours(2), storeRoundTrip.Task!.Due);
+    }
+
+    [Theory]
+    [InlineData("VEVENT")]
+    [InlineData("VTODO")]
+    public void PreservesCalendarCategoriesThroughStoreConversion(string component) {
+        byte[] eml = Calendar(
+            "BEGIN:" + component + "\r\nUID:categories@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "CATEGORIES:Blue,Project\\, X\r\nEND:" + component + "\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailDocument storeRoundTrip = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.OutlookMsg)).Document;
+
+        Assert.Equal(new[] { "Blue", "Project, X" }, document.MessageMetadata.Categories);
+        Assert.Equal(new[] { "Blue", "Project, X" }, storeRoundTrip.MessageMetadata.Categories);
+    }
+
+    [Theory]
+    [InlineData("TENTATIVE")]
+    [InlineData("CANCELLED")]
+    public void BlocksVeventStatusWhenTheStoreModelCannotRepresentItExactly(string status) {
+        byte[] eml = Calendar(
+            "BEGIN:VEVENT\r\nUID:status@example.com\r\nDTSTART:20260801T100000Z\r\nSTATUS:" + status +
+            "\r\nEND:VEVENT\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
+    public void BlocksMultipleSemanticMimeBodyPartsBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "MIME-Version: 1.0\r\nContent-Type: multipart/alternative; boundary=x\r\n\r\n" +
+            "--x\r\nContent-Type: text/calendar; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:first@example.com\r\n" +
+            "DTSTART:20260801T100000Z\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n" +
+            "--x\r\nContent-Type: text/calendar; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:second@example.com\r\n" +
+            "DTSTART:20260802T100000Z\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n--x--\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.Equal(2, document.Attachments.Count(attachment => attachment.IsProjectedSemanticContent));
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    private static byte[] Calendar(string component) => Encoding.ASCII.GetBytes(
+        "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+        component + "END:VCALENDAR\r\n");
+
+    private static string CalendarText(byte[] eml) {
+        using var stream = new MemoryStream(eml);
+        MimePart calendar = Assert.Single(MimeMessage.Load(stream).BodyParts.OfType<MimePart>(),
+            part => part.ContentType.MimeType == "text/calendar");
+        using var content = new MemoryStream();
+        calendar.Content!.DecodeTo(content);
+        return Encoding.UTF8.GetString(content.ToArray());
+    }
+}

--- a/OfficeIMO.Email.Tests/Mime/EmailCalendarProjectionEdgeTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailCalendarProjectionEdgeTests.cs
@@ -28,7 +28,7 @@ public sealed class EmailCalendarProjectionEdgeTests {
     public void ProjectsVtodoAttendeesThroughStoreRecipients() {
         byte[] eml = Calendar(
             "BEGIN:VTODO\r\nUID:assigned@example.com\r\nDTSTART:20260801T100000Z\r\n" +
-            "ATTENDEE;CN=Assignee:mailto:assignee@example.com\r\nEND:VTODO\r\n");
+            "ATTENDEE;CN=Assignee:mailto:assignee@example.com\r\nEND:VTODO\r\n", "REQUEST");
         EmailDocument document = new EmailDocumentReader().Read(eml).Document;
 
         EmailDocument roundTrip = new EmailDocumentReader().Read(
@@ -63,7 +63,7 @@ public sealed class EmailCalendarProjectionEdgeTests {
         byte[] eml = Calendar(
             "BEGIN:VEVENT\r\nUID:encoded-address@example.com\r\nDTSTART:20260801T100000Z\r\n" +
             "ORGANIZER:mailto:owner%2Bcalendar@example.com\r\n" +
-            "ATTENDEE:mailto:alice%2Btag@example.com\r\nEND:VEVENT\r\n");
+            "ATTENDEE:mailto:alice%2Btag@example.com\r\nEND:VEVENT\r\n", "REQUEST");
         EmailDocument document = new EmailDocumentReader().Read(eml).Document;
 
         EmailDocument roundTrip = new EmailDocumentReader().Read(
@@ -234,11 +234,53 @@ public sealed class EmailCalendarProjectionEdgeTests {
             diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
     }
 
+    [Theory]
+    [InlineData("VEVENT", "CREATED:20260715T080000Z")]
+    [InlineData("VTODO", "LAST-MODIFIED:20260715T090000Z")]
+    [InlineData("VEVENT", "COMMENT:Bring documents")]
+    [InlineData("VTODO", "RESOURCES:Conference room")]
+    [InlineData("VEVENT", "GEO:52.2297;21.0122")]
+    [InlineData("VEVENT", "CONTACT:calendar@example.com")]
+    public void BlocksUnprojectedCalendarAuditAndDetailFieldsBeforeStoreConversion(
+        string component, string property) {
+        byte[] eml = Calendar(
+            "BEGIN:" + component + "\r\nUID:unprojected@example.com\r\n" +
+            "DTSTART:20260801T100000Z\r\n" + property + "\r\nEND:" + component + "\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Theory]
+    [InlineData("", "ATTENDEE:mailto:attendee@example.com\r\n")]
+    [InlineData("To: recipient@example.com\r\n", "")]
+    public void BlocksMethodlessCalendarsWithRecipientsBeforeStoreConversion(
+        string transportHeaders, string calendarRecipients) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            transportHeaders + "Content-Type: text/calendar; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\n" +
+            "UID:methodless@example.com\r\nDTSTART:20260801T100000Z\r\n" + calendarRecipients +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
     [Fact]
     public void CalendarOptionalRoleOverridesEnvelopeRecipientKind() {
         byte[] eml = Encoding.ASCII.GetBytes(
             "To: Optional <optional@example.com>\r\nContent-Type: text/calendar; charset=utf-8\r\n\r\n" +
-            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:optional@example.com\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\nUID:optional@example.com\r\n" +
             "DTSTART:20260801T100000Z\r\n" +
             "ATTENDEE;ROLE=OPT-PARTICIPANT;CN=Optional:mailto:optional@example.com\r\n" +
             "END:VEVENT\r\nEND:VCALENDAR\r\n");
@@ -255,7 +297,7 @@ public sealed class EmailCalendarProjectionEdgeTests {
     public void UsesCalendarAttendeeNameWhenEnvelopeRecipientHasNoDisplayName() {
         byte[] eml = Encoding.ASCII.GetBytes(
             "To: alice@example.com\r\nContent-Type: text/calendar; charset=utf-8\r\n\r\n" +
-            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:name@example.com\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\nUID:name@example.com\r\n" +
             "DTSTART:20260801T100000Z\r\nATTENDEE;CN=Alice:mailto:alice@example.com\r\n" +
             "END:VEVENT\r\nEND:VCALENDAR\r\n");
         EmailDocument document = new EmailDocumentReader().Read(eml).Document;
@@ -549,7 +591,7 @@ public sealed class EmailCalendarProjectionEdgeTests {
         byte[] eml = Calendar(
             "BEGIN:VEVENT\r\nUID:parameter@example.com\r\nDTSTART:20260801T100000Z\r\n" +
             "ATTENDEE;CN=\"" + parameterName + "\":mailto:alice@example.com\r\n" +
-            "END:VEVENT\r\n");
+            "END:VEVENT\r\n", "REQUEST");
         EmailDocument document = new EmailDocumentReader().Read(eml).Document;
 
         EmailDocument roundTrip = new EmailDocumentReader().Read(
@@ -580,8 +622,9 @@ public sealed class EmailCalendarProjectionEdgeTests {
             diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
     }
 
-    private static byte[] Calendar(string component) => Encoding.ASCII.GetBytes(
+    private static byte[] Calendar(string component, string? method = null) => Encoding.ASCII.GetBytes(
         "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+        (string.IsNullOrWhiteSpace(method) ? string.Empty : "METHOD:" + method + "\r\n") +
         component + "END:VCALENDAR\r\n");
 
     private static string CalendarText(byte[] eml) {

--- a/OfficeIMO.Email.Tests/Mime/EmailCalendarProjectionEdgeTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailCalendarProjectionEdgeTests.cs
@@ -5,6 +5,25 @@ using Xunit;
 namespace OfficeIMO.Email.Tests;
 
 public sealed class EmailCalendarProjectionEdgeTests {
+    [Theory]
+    [InlineData("text/calendar", OutlookItemKind.Appointment,
+        "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:inline@example.com\r\n" +
+        "DTSTART:20260801T100000Z\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n")]
+    [InlineData("text/vcard", OutlookItemKind.Contact,
+        "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Ada Lovelace\r\nEMAIL:ada@example.com\r\nEND:VCARD\r\n")]
+    public void ProjectsInlineSemanticMimeParts(string contentType, OutlookItemKind expectedKind, string content) {
+        byte[] eml = Encoding.ASCII.GetBytes("Content-Type: " + contentType + "; charset=utf-8\r\n" +
+            "Content-Disposition: inline\r\n\r\n" + content);
+
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailAttachment semanticPart = Assert.Single(document.Attachments);
+        Assert.Equal(expectedKind, document.OutlookItemKind);
+        Assert.True(semanticPart.IsInline);
+        Assert.True(semanticPart.IsMimeBodyPart);
+        Assert.True(semanticPart.IsProjectedSemanticContent);
+    }
+
     [Fact]
     public void ProjectsVtodoAttendeesThroughStoreRecipients() {
         byte[] eml = Calendar(
@@ -17,6 +36,23 @@ public sealed class EmailCalendarProjectionEdgeTests {
 
         Assert.Contains(document.Recipients, recipient => recipient.Address.Address == "assignee@example.com");
         Assert.Contains(roundTrip.Recipients, recipient => recipient.Address.Address == "assignee@example.com");
+    }
+
+    [Fact]
+    public void CalendarOptionalRoleOverridesEnvelopeRecipientKind() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "To: Optional <optional@example.com>\r\nContent-Type: text/calendar; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:optional@example.com\r\n" +
+            "DTSTART:20260801T100000Z\r\n" +
+            "ATTENDEE;ROLE=OPT-PARTICIPANT;CN=Optional:mailto:optional@example.com\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailDocument roundTrip = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.OutlookMsg)).Document;
+
+        Assert.Equal(EmailRecipientKind.Cc, Assert.Single(document.Recipients).Kind);
+        Assert.Equal(EmailRecipientKind.Cc, Assert.Single(roundTrip.Recipients).Kind);
     }
 
     [Fact]
@@ -74,6 +110,24 @@ public sealed class EmailCalendarProjectionEdgeTests {
         byte[] eml = Calendar(
             "BEGIN:VEVENT\r\nUID:status@example.com\r\nDTSTART:20260801T100000Z\r\nSTATUS:" + status +
             "\r\nEND:VEVENT\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Theory]
+    [InlineData("ACTION:EMAIL\r\nATTENDEE:mailto:notify@example.com\r\n")]
+    [InlineData("ACTION:DISPLAY\r\nATTACH:https://example.com/reminder.wav\r\n")]
+    public void BlocksAlarmSemanticsThatOutlookReminderPropertiesCannotRepresent(string alarmProperties) {
+        byte[] eml = Calendar(
+            "BEGIN:VEVENT\r\nUID:alarm@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "BEGIN:VALARM\r\n" + alarmProperties + "TRIGGER:-PT15M\r\n" +
+            "END:VALARM\r\nEND:VEVENT\r\n");
         EmailDocument document = new EmailDocumentReader().Read(eml).Document;
 
         EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(

--- a/OfficeIMO.Email.Tests/Mime/EmailCalendarProjectionEdgeTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailCalendarProjectionEdgeTests.cs
@@ -108,6 +108,76 @@ public sealed class EmailCalendarProjectionEdgeTests {
     }
 
     [Fact]
+    public void UsesCalendarAttendeeNameWhenEnvelopeRecipientHasNoDisplayName() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "To: alice@example.com\r\nContent-Type: text/calendar; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:name@example.com\r\n" +
+            "DTSTART:20260801T100000Z\r\nATTENDEE;CN=Alice:mailto:alice@example.com\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailDocument roundTrip = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.OutlookMsg)).Document;
+
+        Assert.Equal("Alice", Assert.Single(document.Recipients).Address.DisplayName);
+        Assert.Equal("Alice", Assert.Single(roundTrip.Recipients).Address.DisplayName);
+    }
+
+    [Fact]
+    public void BlocksConflictingEnvelopeAndCalendarAttendeeNamesBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "To: Relay <alice@example.com>\r\nContent-Type: text/calendar; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:name-conflict@example.com\r\n" +
+            "DTSTART:20260801T100000Z\r\nATTENDEE;CN=Alice:mailto:alice@example.com\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Equal("Relay", Assert.Single(document.Recipients).Address.DisplayName);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Theory]
+    [InlineData("REQUEST", "IPM.Schedule.Meeting.Request")]
+    [InlineData("CANCEL", "IPM.Schedule.Meeting.Canceled")]
+    [InlineData("REPLY", "IPM.Schedule.Meeting.Resp.Pos")]
+    public void UsesMimeCalendarMethodWhenPayloadMethodIsMissing(string method, string expectedMessageClass) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; method=" + method + "; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:method@example.com\r\n" +
+            "DTSTART:20260801T100000Z\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailDocument roundTrip = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.OutlookMsg)).Document;
+
+        Assert.Equal(expectedMessageClass, document.MessageClass);
+        Assert.Equal(expectedMessageClass, roundTrip.MessageClass);
+    }
+
+    [Fact]
+    public void BlocksConflictingMimeAndPayloadCalendarMethodsBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; method=REQUEST; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nMETHOD:CANCEL\r\nBEGIN:VEVENT\r\n" +
+            "UID:method-conflict@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Equal("IPM.Schedule.Meeting.Canceled", document.MessageClass);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
     public void PreservesVtodoPrivacyThroughStoreConversion() {
         byte[] eml = Calendar(
             "BEGIN:VTODO\r\nUID:private-task@example.com\r\nDTSTART:20260801T100000Z\r\n" +

--- a/OfficeIMO.Email.Tests/Mime/EmailCalendarProjectionEdgeTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailCalendarProjectionEdgeTests.cs
@@ -33,9 +33,61 @@ public sealed class EmailCalendarProjectionEdgeTests {
 
         EmailDocument roundTrip = new EmailDocumentReader().Read(
             new EmailDocumentWriter().ToBytes(document, EmailFileFormat.OutlookMsg)).Document;
+        string regenerated = CalendarText(new EmailDocumentWriter().ToBytes(roundTrip, EmailFileFormat.Eml));
 
         Assert.Contains(document.Recipients, recipient => recipient.Address.Address == "assignee@example.com");
         Assert.Contains(roundTrip.Recipients, recipient => recipient.Address.Address == "assignee@example.com");
+        Assert.Contains("ATTENDEE;ROLE=REQ-PARTICIPANT;CN=\"Assignee\":mailto:assignee@example.com",
+            regenerated, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BlocksFloatingCalendarTimesBeforeStoreConversion() {
+        byte[] eml = Calendar(
+            "BEGIN:VEVENT\r\nUID:floating@example.com\r\nDTSTART:20260715T090000\r\nEND:VEVENT\r\n");
+        EmailReadResult read = new EmailDocumentReader().Read(eml);
+        EmailDocument document = read.Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(read.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_ICALENDAR_FLOATING_TIME");
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
+    public void DecodesPercentEncodedCalendarMailboxesBeforeStoreConversion() {
+        byte[] eml = Calendar(
+            "BEGIN:VEVENT\r\nUID:encoded-address@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "ORGANIZER:mailto:owner%2Bcalendar@example.com\r\n" +
+            "ATTENDEE:mailto:alice%2Btag@example.com\r\nEND:VEVENT\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailDocument roundTrip = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.OutlookMsg)).Document;
+
+        Assert.Equal("owner+calendar@example.com", document.From!.Address);
+        Assert.Equal("alice+tag@example.com", Assert.Single(document.Recipients).Address.Address);
+        Assert.Equal("owner+calendar@example.com", roundTrip.From!.Address);
+        Assert.Equal("alice+tag@example.com", Assert.Single(roundTrip.Recipients).Address.Address);
+    }
+
+    [Fact]
+    public void BlocksCalendarPriorityBeforeStoreConversion() {
+        byte[] eml = Calendar(
+            "BEGIN:VEVENT\r\nUID:priority@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "PRIORITY:1\r\nEND:VEVENT\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
     }
 
     [Fact]

--- a/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
@@ -244,6 +244,56 @@ public sealed class EmailContactConversionTests {
     }
 
     [Fact]
+    public void BlocksVcardExtendedAddressComponentsBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN:Ada Lovelace\r\nADR;TYPE=HOME:;Apt 4;123 Main;Warsaw;;;\r\nEND:VCARD\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.Equal("123 Main", document.Contact!.HomeAddress.Street);
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
+    public void BlocksExtraVcardOrganizationUnitsBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN:Ada Lovelace\r\nORG:Example Corp;Sales;West\r\nEND:VCARD\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.Equal("Example Corp", document.Contact!.CompanyName);
+        Assert.Equal("Sales", document.Contact.Department);
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Theory]
+    [InlineData("HOME")]
+    [InlineData("OTHER")]
+    public void BlocksPreferredNonWorkVcardEmailsBeforeStoreConversion(string type) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN:Ada Lovelace\r\nEMAIL;TYPE=" + type + ",PREF:ada@example.com\r\nEND:VCARD\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
     public void BlocksVcardUrlSlotOverflowBeforeStoreConversion() {
         byte[] eml = Encoding.ASCII.GetBytes(
             "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +

--- a/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
@@ -73,4 +73,31 @@ public sealed class EmailContactConversionTests {
         Assert.False(report.CanWrite);
         Assert.Contains(report.Diagnostics, diagnostic => diagnostic.Code == "EMAIL_VCARD_OPAQUE_CONTACT_IDENTITY");
     }
+
+    [Fact]
+    public void AccumulatesRepeatedVcardTypeParameters() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN:Ada Lovelace\r\nTEL;TYPE=HOME;TYPE=VOICE:+44 20 0000 0000\r\nEND:VCARD\r\n");
+
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        Assert.Equal("+44 20 0000 0000", document.Contact!.Phones.Home);
+        Assert.Null(document.Contact.Phones.Primary);
+    }
+
+    [Fact]
+    public void DecodesVcardProjectionUsingTheDeclaredCharset() {
+        byte[] prefix = Encoding.ASCII.GetBytes("Content-Type: text/vcard; charset=windows-1252\r\n\r\n");
+        byte[] vcard = Encoding.ASCII.GetBytes(
+            "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Andr#\r\nN:Example;Andr#;;;\r\nEND:VCARD\r\n");
+        for (int index = 0; index < vcard.Length; index++) {
+            if (vcard[index] == (byte)'#') vcard[index] = 0xe9;
+        }
+
+        EmailDocument document = new EmailDocumentReader().Read(prefix.Concat(vcard).ToArray()).Document;
+
+        Assert.Equal("André", document.Contact!.DisplayName);
+        Assert.Equal("André", document.Contact.GivenName);
+    }
 }

--- a/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
@@ -449,6 +449,27 @@ public sealed class EmailContactConversionTests {
     }
 
     [Theory]
+    [InlineData("EMAIL;TYPE=WORK:ada@example.com")]
+    [InlineData("EMAIL:ada@example.com")]
+    [InlineData("TEL;TYPE=VOICE:+48-123-456-789")]
+    [InlineData("TEL:+48-123-456-789")]
+    [InlineData("URL;TYPE=OTHER:https://example.com")]
+    [InlineData("ADR;TYPE=HOME,POSTAL:;;123 Main;Town;;;")]
+    public void BlocksVcardTypeSemanticsThatOutlookSlotsCannotPreserve(string property) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN:Ada Lovelace\r\n" + property + "\r\nEND:VCARD\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Theory]
     [InlineData("NICKNAME:Bob,Rob")]
     [InlineData("IMPP:xmpp:first@example.com\r\nIMPP:xmpp:second@example.com")]
     public void BlocksUnrepresentableMultiValueVcardPropertiesBeforeStoreConversion(string properties) {
@@ -482,6 +503,29 @@ public sealed class EmailContactConversionTests {
         Assert.Equal("Wrapper text", document.Body.Text!.Trim());
         Assert.Contains(report.Diagnostics,
             diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
+    public void KeepsSemanticVcardAsTheMimeBodyWhenOtherAttachmentsExist() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Subject: Contact\r\nMIME-Version: 1.0\r\nContent-Type: multipart/mixed; boundary=x\r\n\r\n" +
+            "--x\r\nContent-Type: text/vcard; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Ada Lovelace\r\nNOTE:Contact notes\r\nEND:VCARD\r\n" +
+            "--x\r\nContent-Type: text/plain; charset=utf-8; name=notes.txt\r\n" +
+            "Content-Disposition: attachment; filename=notes.txt\r\n\r\nOrdinary attachment\r\n--x--\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        byte[] rewritten = new EmailDocumentWriter().ToBytes(document, EmailFileFormat.Eml);
+        using var stream = new MemoryStream(rewritten);
+        Multipart mixed = Assert.IsAssignableFrom<Multipart>(MimeMessage.Load(stream).Body);
+
+        Assert.Equal(2, mixed.Count);
+        MimePart contactBody = Assert.IsAssignableFrom<MimePart>(mixed[0]);
+        Assert.True(VCardContentType(contactBody.ContentType.MimeType));
+        Assert.False(contactBody.IsAttachment);
+        MimePart attachment = Assert.IsAssignableFrom<MimePart>(mixed[1]);
+        Assert.True(attachment.IsAttachment);
+        Assert.Equal("notes.txt", attachment.FileName);
     }
 
     [Fact]

--- a/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
@@ -359,6 +359,24 @@ public sealed class EmailContactConversionTests {
             diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
     }
 
+    [Theory]
+    [InlineData("REV:20260715T080000Z")]
+    [InlineData("KIND:group")]
+    [InlineData("KIND:org")]
+    public void BlocksUnprojectedVcardIdentityMetadataBeforeStoreConversion(string property) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:4.0\r\n" +
+            "FN:Ada Lovelace\r\n" + property + "\r\nEND:VCARD\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
     [Fact]
     public void BlocksDistinctMimeBodyAndVcardNoteBeforeStoreConversion() {
         byte[] eml = Encoding.ASCII.GetBytes(

--- a/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
@@ -365,13 +365,66 @@ public sealed class EmailContactConversionTests {
     [InlineData("KIND:org")]
     public void BlocksUnprojectedVcardIdentityMetadataBeforeStoreConversion(string property) {
         byte[] eml = Encoding.ASCII.GetBytes(
-            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:4.0\r\n" +
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
             "FN:Ada Lovelace\r\n" + property + "\r\nEND:VCARD\r\n");
         EmailDocument document = new EmailDocumentReader().Read(eml).Document;
 
         EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
             document, EmailFileFormat.OutlookMsg);
 
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Theory]
+    [InlineData("SOURCE:https://example.com/contact.vcf")]
+    [InlineData("FBURL:https://example.com/freebusy")]
+    [InlineData("CALURI:https://example.com/calendar")]
+    [InlineData("CALADRURI:mailto:calendar@example.com")]
+    [InlineData("SOUND:https://example.com/name.wav")]
+    public void BlocksUnprojectedVcardSourceAndLinkFieldsBeforeStoreConversion(string property) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN:Ada Lovelace\r\n" + property + "\r\nEND:VCARD\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Theory]
+    [InlineData("2.1")]
+    [InlineData("4.0")]
+    public void BlocksUnsupportedVcardVersionsBeforeStoreConversion(string version) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:" + version + "\r\n" +
+            "FN:Ada Lovelace\r\nEND:VCARD\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
+    public void BlocksPreferredTypedVcardPhonesBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN:Ada Lovelace\r\nTEL;TYPE=HOME,PREF:+48-123-456-789\r\nEND:VCARD\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.Equal("+48-123-456-789", document.Contact!.Phones.Home);
         Assert.False(report.CanWrite);
         Assert.Contains(report.Diagnostics,
             diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");

--- a/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
@@ -180,6 +180,39 @@ public sealed class EmailContactConversionTests {
     }
 
     [Fact]
+    public void BlocksVcardsWithMoreThanThreeEmailAddressesBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN:Ada Lovelace\r\nEMAIL:first@example.com\r\nEMAIL:second@example.com\r\n" +
+            "EMAIL:third@example.com\r\nEMAIL:fourth@example.com\r\nEND:VCARD\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Theory]
+    [InlineData("BDAY")]
+    [InlineData("ANNIVERSARY")]
+    public void BlocksDateTimeVcardDatesBeforeStoreConversion(string property) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN:Ada Lovelace\r\n" + property + ":19960415T231000Z\r\nEND:VCARD\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
     public void BlocksVcardUidBeforeStoreConversion() {
         byte[] eml = Encoding.ASCII.GetBytes(
             "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +

--- a/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
@@ -1,0 +1,76 @@
+using MimeKit;
+using OfficeIMO.Email;
+using Xunit;
+
+namespace OfficeIMO.Email.Tests;
+
+public sealed class EmailContactConversionTests {
+    [Fact]
+    public void ConvertsContactThroughVcardWithoutLosingCommonFields() {
+        var contact = new OutlookContact {
+            DisplayName = "Ada Lovelace",
+            GivenName = "Ada",
+            Surname = "Lovelace",
+            CompanyName = "Analytical Engines",
+            Department = "Research",
+            JobTitle = "Mathematician",
+            Birthday = new DateTimeOffset(1815, 12, 10, 0, 0, 0, TimeSpan.Zero),
+            BusinessHomePage = "https://example.com/ada"
+        };
+        contact.Email1.Address = "ada@example.com";
+        contact.Phones.Business = "+44 20 0000 0000";
+        contact.Phones.PrimaryFax = "+44 20 0000 0001";
+        contact.Phones.Assistant = "+44 20 0000 0002";
+        contact.BusinessAddress.Street = "1 Engine Way";
+        contact.BusinessAddress.City = "London";
+        contact.BusinessAddress.Formatted = "1 Engine Way, London";
+        contact.BusinessAddress.CountryCode = "GB";
+        contact.HasPicture = true;
+        var source = new EmailDocument {
+            Format = EmailFileFormat.OutlookMsg,
+            OutlookItemKind = OutlookItemKind.Contact,
+            MessageClass = "IPM.Contact",
+            Subject = "Ada Lovelace",
+            Contact = contact
+        };
+
+        byte[] eml = new EmailDocumentWriter().ToBytes(source, EmailFileFormat.Eml);
+        EmailDocument result = new EmailDocumentReader().Read(eml).Document;
+        using var oracleStream = new MemoryStream(eml);
+        MimeMessage oracle = MimeMessage.Load(oracleStream);
+
+        Assert.Contains(oracle.Attachments.OfType<MimePart>(), part => part.ContentType.MimeType == "text/vcard");
+        Assert.Equal(OutlookItemKind.Contact, result.OutlookItemKind);
+        Assert.Equal("Ada Lovelace", result.Contact!.DisplayName);
+        Assert.Equal("Ada", result.Contact.GivenName);
+        Assert.Equal("Lovelace", result.Contact.Surname);
+        Assert.Equal("Analytical Engines", result.Contact.CompanyName);
+        Assert.Equal("Research", result.Contact.Department);
+        Assert.Equal("ada@example.com", result.Contact.Email1.Address);
+        Assert.Equal("+44 20 0000 0000", result.Contact.Phones.Business);
+        Assert.Equal("+44 20 0000 0001", result.Contact.Phones.PrimaryFax);
+        Assert.Equal("+44 20 0000 0002", result.Contact.Phones.Assistant);
+        Assert.Equal("London", result.Contact.BusinessAddress.City);
+        Assert.Equal("1 Engine Way, London", result.Contact.BusinessAddress.Formatted);
+        Assert.Equal("GB", result.Contact.BusinessAddress.CountryCode);
+        Assert.True(result.Contact.HasPicture);
+    }
+
+    [Fact]
+    public void BlocksOpaqueMapiEntryIdentifiersDuringVcardConversion() {
+        var contact = new OutlookContact();
+        contact.Email1.Address = "/o=Example/ou=Exchange Administrative Group/cn=Recipients/cn=person";
+        contact.Email1.AddressType = "EX";
+        contact.Email1.OriginalEntryId = new byte[] { 1, 2, 3 };
+        var source = new EmailDocument {
+            Format = EmailFileFormat.OutlookMsg,
+            OutlookItemKind = OutlookItemKind.Contact,
+            Contact = contact
+        };
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(source, EmailFileFormat.Eml);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics, diagnostic => diagnostic.Code == "EMAIL_VCARD_OPAQUE_CONTACT_IDENTITY");
+    }
+}

--- a/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
@@ -228,6 +228,38 @@ public sealed class EmailContactConversionTests {
     }
 
     [Fact]
+    public void BlocksVcardAddressSlotOverflowBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN:Ada Lovelace\r\nADR;TYPE=HOME:;;First Street;Warsaw;;;\r\n" +
+            "ADR;TYPE=HOME:;;Second Street;London;;;\r\nEND:VCARD\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
+    public void BlocksVcardUrlSlotOverflowBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN:Ada Lovelace\r\nURL;TYPE=WORK:https://first.example\r\n" +
+            "URL;TYPE=WORK:https://second.example\r\nEND:VCARD\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
     public void BlocksVcardPhoneSlotOverflowBeforeStoreConversion() {
         byte[] eml = Encoding.ASCII.GetBytes(
             "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +

--- a/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
@@ -431,6 +431,41 @@ public sealed class EmailContactConversionTests {
     }
 
     [Fact]
+    public void BlocksVcardEmailTypeSlotFallbackBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN:Ada Lovelace\r\nEMAIL;TYPE=WORK:first@example.com\r\n" +
+            "EMAIL;TYPE=WORK:second@example.com\r\nEND:VCARD\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.Equal("first@example.com", document.Contact!.Email1.Address);
+        Assert.Equal("second@example.com", document.Contact.Email2.Address);
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Theory]
+    [InlineData("NICKNAME:Bob,Rob")]
+    [InlineData("IMPP:xmpp:first@example.com\r\nIMPP:xmpp:second@example.com")]
+    public void BlocksUnrepresentableMultiValueVcardPropertiesBeforeStoreConversion(string properties) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN:Robert Example\r\n" + properties + "\r\nEND:VCARD\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
     public void BlocksDistinctMimeBodyAndVcardNoteBeforeStoreConversion() {
         byte[] eml = Encoding.ASCII.GetBytes(
             "MIME-Version: 1.0\r\nContent-Type: multipart/alternative; boundary=x\r\n\r\n" +

--- a/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
@@ -180,6 +180,56 @@ public sealed class EmailContactConversionTests {
     }
 
     [Fact]
+    public void BlocksVcardUidBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "UID:contact-123\r\nFN:Ada Lovelace\r\nEND:VCARD\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
+    public void BlocksDistinctMimeBodyAndVcardNoteBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "MIME-Version: 1.0\r\nContent-Type: multipart/alternative; boundary=x\r\n\r\n" +
+            "--x\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nWrapper text\r\n" +
+            "--x\r\nContent-Type: text/vcard; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Ada Lovelace\r\nNOTE:Contact notes\r\n" +
+            "END:VCARD\r\n--x--\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Equal("Wrapper text", document.Body.Text!.Trim());
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
+    public void DecodesEscapedVcardTextSequentially() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN:Ada Lovelace\r\nNOTE:Literal \\\\n value\r\nEND:VCARD\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailDocument stored = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.OutlookMsg)).Document;
+        EmailDocument roundTrip = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(stored, EmailFileFormat.Eml)).Document;
+
+        Assert.Equal("Literal \\n value", document.Body.Text);
+        Assert.Equal("Literal \\n value", roundTrip.Body.Text);
+    }
+
+    [Fact]
     public void KeepsOrdinaryVcardAttachmentAlongsideGeneratedContact() {
         var source = new EmailDocument {
             Format = EmailFileFormat.OutlookMsg,

--- a/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
@@ -39,7 +39,8 @@ public sealed class EmailContactConversionTests {
         using var oracleStream = new MemoryStream(eml);
         MimeMessage oracle = MimeMessage.Load(oracleStream);
 
-        Assert.Contains(oracle.Attachments.OfType<MimePart>(), part => part.ContentType.MimeType == "text/vcard");
+        Assert.Contains(oracle.BodyParts.OfType<MimePart>(), part => part.ContentType.MimeType == "text/vcard" &&
+            !part.IsAttachment);
         Assert.Equal(OutlookItemKind.Contact, result.OutlookItemKind);
         Assert.Equal("Ada Lovelace", result.Contact!.DisplayName);
         Assert.Equal("Ada", result.Contact.GivenName);
@@ -160,12 +161,52 @@ public sealed class EmailContactConversionTests {
 
         byte[] output = new EmailDocumentWriter().ToBytes(source, EmailFileFormat.Eml);
         using var stream = new MemoryStream(output);
-        MimePart[] vcards = MimeMessage.Load(stream).Attachments.OfType<MimePart>()
+        MimePart[] vcards = MimeMessage.Load(stream).BodyParts.OfType<MimePart>()
             .Where(part => VCardContentType(part.ContentType.MimeType)).ToArray();
 
         Assert.Equal(2, vcards.Length);
-        Assert.Contains(vcards, part => part.FileName == "ordinary.vcf");
-        Assert.Contains(vcards, part => part.FileName == "contact.vcf");
+        Assert.Contains(vcards, part => part.IsAttachment && part.FileName == "ordinary.vcf");
+        Assert.Contains(vcards, part => !part.IsAttachment && part.FileName == null);
+    }
+
+    [Fact]
+    public void KeepsAttachedVcardOnAnOrdinaryMessage() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Subject: Attached contact\r\nMIME-Version: 1.0\r\n" +
+            "Content-Type: multipart/mixed; boundary=x\r\n\r\n" +
+            "--x\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nPlease import this contact.\r\n" +
+            "--x\r\nContent-Type: text/vcard; charset=utf-8\r\n" +
+            "Content-Disposition: attachment; filename=ada.vcf\r\n\r\n" +
+            "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Ada Lovelace\r\nEND:VCARD\r\n--x--\r\n");
+
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+        EmailDocument roundTrip = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.Eml)).Document;
+
+        Assert.Equal(OutlookItemKind.Message, document.OutlookItemKind);
+        Assert.Null(document.Contact);
+        EmailAttachment attachment = Assert.Single(document.Attachments);
+        Assert.Equal("ada.vcf", attachment.FileName);
+        Assert.Equal(OutlookItemKind.Message, roundTrip.OutlookItemKind);
+        Assert.Null(roundTrip.Contact);
+        Assert.Equal("ada.vcf", Assert.Single(roundTrip.Attachments).FileName);
+    }
+
+    [Fact]
+    public void PreservesVcardCategoriesThroughMsgConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN:Ada Lovelace\r\nCATEGORIES:Blue,Project\\, X\r\nEND:VCARD\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        byte[] msg = new EmailDocumentWriter().ToBytes(document, EmailFileFormat.OutlookMsg);
+        EmailDocument roundTrip = new EmailDocumentReader().Read(msg).Document;
+        EmailDocument regeneratedVcard = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(roundTrip, EmailFileFormat.Eml)).Document;
+
+        Assert.Equal(new[] { "Blue", "Project, X" }, document.MessageMetadata.Categories);
+        Assert.Equal(new[] { "Blue", "Project, X" }, roundTrip.MessageMetadata.Categories);
+        Assert.Equal(new[] { "Blue", "Project, X" }, regeneratedVcard.MessageMetadata.Categories);
     }
 
     private static bool VCardContentType(string? contentType) =>

--- a/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
@@ -88,6 +88,39 @@ public sealed class EmailContactConversionTests {
     }
 
     [Fact]
+    public void ParsesQuotedVcardParameterDelimiters() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN:Ada Lovelace\r\n" +
+            "ADR;TYPE=HOME;LABEL=\"12: Main; Apt\":;;Main Street;Warsaw;Mazovia;00-001;Poland\r\n" +
+            "END:VCARD\r\n");
+
+        OutlookPostalAddress address = new EmailDocumentReader().Read(eml).Document.Contact!.HomeAddress;
+
+        Assert.Equal("12: Main; Apt", address.Formatted);
+        Assert.Equal("Main Street", address.Street);
+        Assert.Equal("Warsaw", address.City);
+        Assert.Equal("Mazovia", address.StateOrProvince);
+        Assert.Equal("00-001", address.PostalCode);
+        Assert.Equal("Poland", address.Country);
+    }
+
+    [Fact]
+    public void ProjectsTextDirectoryVcards() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/directory; profile=vCard; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Ada Lovelace\r\n" +
+            "EMAIL;TYPE=WORK:ada@example.com\r\nEND:VCARD\r\n");
+
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        Assert.Equal(OutlookItemKind.Contact, document.OutlookItemKind);
+        Assert.Equal("Ada Lovelace", document.Contact!.DisplayName);
+        Assert.Equal("ada@example.com", document.Contact.Email1.Address);
+        Assert.True(Assert.Single(document.Attachments).IsProjectedSemanticContent);
+    }
+
+    [Fact]
     public void DecodesVcardProjectionUsingTheDeclaredCharset() {
         byte[] prefix = Encoding.ASCII.GetBytes("Content-Type: text/vcard; charset=windows-1252\r\n\r\n");
         byte[] vcard = Encoding.ASCII.GetBytes(

--- a/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
@@ -33,12 +33,15 @@ public sealed class EmailContactConversionTests {
             Subject = "Ada Lovelace",
             Contact = contact
         };
+        source.Body.Text = "Contact notes";
 
         byte[] eml = new EmailDocumentWriter().ToBytes(source, EmailFileFormat.Eml);
         EmailDocument result = new EmailDocumentReader().Read(eml).Document;
         using var oracleStream = new MemoryStream(eml);
         MimeMessage oracle = MimeMessage.Load(oracleStream);
 
+        Assert.Equal("text/vcard", Assert.IsAssignableFrom<MimeEntity>(oracle.Body).ContentType.MimeType);
+        Assert.Null(oracle.TextBody);
         Assert.Contains(oracle.BodyParts.OfType<MimePart>(), part => part.ContentType.MimeType == "text/vcard" &&
             !part.IsAttachment);
         Assert.Equal(OutlookItemKind.Contact, result.OutlookItemKind);
@@ -55,6 +58,7 @@ public sealed class EmailContactConversionTests {
         Assert.Equal("1 Engine Way, London", result.Contact.BusinessAddress.Formatted);
         Assert.Equal("GB", result.Contact.BusinessAddress.CountryCode);
         Assert.True(result.Contact.HasPicture);
+        Assert.Equal("Contact notes", result.Body.Text);
     }
 
     [Fact]
@@ -240,6 +244,29 @@ public sealed class EmailContactConversionTests {
         Assert.Equal(new[] { "Blue", "Project, X" }, document.MessageMetadata.Categories);
         Assert.Equal(new[] { "Blue", "Project, X" }, roundTrip.MessageMetadata.Categories);
         Assert.Equal(new[] { "Blue", "Project, X" }, regeneratedVcard.MessageMetadata.Categories);
+    }
+
+    [Fact]
+    public void PreservesConfidentialVcardClassThroughStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN:Ada Lovelace\r\nCLASS:CONFIDENTIAL\r\nEND:VCARD\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailDocument storeRoundTrip = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.OutlookMsg)).Document;
+        byte[] regenerated = new EmailDocumentWriter().ToBytes(storeRoundTrip, EmailFileFormat.Eml);
+        using var stream = new MemoryStream(regenerated);
+        MimePart vcard = Assert.IsAssignableFrom<MimePart>(MimeMessage.Load(stream).Body);
+        using var content = new MemoryStream();
+        vcard.Content!.DecodeTo(content);
+
+        Assert.True(document.Contact!.IsPrivate);
+        Assert.Equal(3, document.MessageMetadata.Sensitivity);
+        Assert.True(storeRoundTrip.Contact!.IsPrivate);
+        Assert.Equal(3, storeRoundTrip.MessageMetadata.Sensitivity);
+        Assert.Contains("CLASS:CONFIDENTIAL", Encoding.UTF8.GetString(content.ToArray()),
+            StringComparison.Ordinal);
     }
 
     private static bool VCardContentType(string? contentType) =>

--- a/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
@@ -96,8 +96,80 @@ public sealed class EmailContactConversionTests {
         }
 
         EmailDocument document = new EmailDocumentReader().Read(prefix.Concat(vcard).ToArray()).Document;
+        EmailDocument roundTrip = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.Eml)).Document;
 
         Assert.Equal("André", document.Contact!.DisplayName);
         Assert.Equal("André", document.Contact.GivenName);
+        Assert.Equal("André", roundTrip.Contact!.DisplayName);
+        EmailAttachment retained = Assert.Single(roundTrip.Attachments,
+            attachment => VCardContentType(attachment.ContentType));
+        Assert.Equal("windows-1252", retained.ContentTypeParameters["charset"]);
     }
+
+    [Fact]
+    public void MapsHomeAndOtherVcardEmailsToTheirOutlookSlots() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN:Ada Lovelace\r\nEMAIL;TYPE=HOME:ada@home.example\r\n" +
+            "X-OFFICEIMO-EMAIL2-DISPLAY-NAME:Home Ada\r\n" +
+            "X-OFFICEIMO-EMAIL2-ORIGINAL-DISPLAY-NAME:Ada Original\r\n" +
+            "EMAIL;TYPE=OTHER:ada@other.example\r\nEND:VCARD\r\n");
+
+        OutlookContact contact = new EmailDocumentReader().Read(eml).Document.Contact!;
+
+        Assert.Null(contact.Email1.Address);
+        Assert.Equal("ada@home.example", contact.Email2.Address);
+        Assert.Equal("Home Ada", contact.Email2.DisplayName);
+        Assert.Equal("Ada Original", contact.Email2.OriginalDisplayName);
+        Assert.Equal("ada@other.example", contact.Email3.Address);
+    }
+
+    [Fact]
+    public void MarksMultiContactVcardProjectionIncompleteForStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:First\r\nEND:VCARD\r\n" +
+            "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Second\r\nEND:VCARD\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
+    public void KeepsOrdinaryVcardAttachmentAlongsideGeneratedContact() {
+        var source = new EmailDocument {
+            Format = EmailFileFormat.OutlookMsg,
+            OutlookItemKind = OutlookItemKind.Contact,
+            Subject = "Generated contact",
+            Contact = new OutlookContact { DisplayName = "Generated contact" }
+        };
+        byte[] ordinary = Encoding.ASCII.GetBytes(
+            "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Ordinary file\r\nEND:VCARD\r\n");
+        source.Attachments.Add(new EmailAttachment {
+            FileName = "ordinary.vcf",
+            ContentType = "text/vcard",
+            Content = ordinary,
+            Length = ordinary.LongLength
+        });
+
+        byte[] output = new EmailDocumentWriter().ToBytes(source, EmailFileFormat.Eml);
+        using var stream = new MemoryStream(output);
+        MimePart[] vcards = MimeMessage.Load(stream).Attachments.OfType<MimePart>()
+            .Where(part => VCardContentType(part.ContentType.MimeType)).ToArray();
+
+        Assert.Equal(2, vcards.Length);
+        Assert.Contains(vcards, part => part.FileName == "ordinary.vcf");
+        Assert.Contains(vcards, part => part.FileName == "contact.vcf");
+    }
+
+    private static bool VCardContentType(string? contentType) =>
+        string.Equals(contentType, "text/vcard", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(contentType, "text/x-vcard", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(contentType, "application/vcard", StringComparison.OrdinalIgnoreCase);
 }

--- a/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailContactConversionTests.cs
@@ -110,6 +110,38 @@ public sealed class EmailContactConversionTests {
     }
 
     [Fact]
+    public void DecodesQuotedPrintableVcardValuesThroughStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN;CHARSET=UTF-8;ENCODING=QUOTED-PRINTABLE:Jos=C3=\r\n =A9\r\n" +
+            "N;CHARSET=UTF-8;ENCODING=QUOTED-PRINTABLE:Example;Jos=C3=A9;;;\r\nEND:VCARD\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailDocument roundTrip = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.OutlookMsg)).Document;
+
+        Assert.Equal("José", document.Contact!.DisplayName);
+        Assert.Equal("José", document.Contact.GivenName);
+        Assert.Equal("José", roundTrip.Contact!.DisplayName);
+        Assert.Equal("José", roundTrip.Contact.GivenName);
+    }
+
+    [Fact]
+    public void DecodesQuotedVcardParameterEscapesThroughStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN:Ada Lovelace\r\nADR;TYPE=HOME;LABEL=\"12 \\\"Main\\\" \\\\ St\":;;Main Street;;;;\r\n" +
+            "END:VCARD\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailDocument roundTrip = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.OutlookMsg)).Document;
+
+        Assert.Equal("12 \"Main\" \\ St", document.Contact!.HomeAddress.Formatted);
+        Assert.Equal("12 \"Main\" \\ St", roundTrip.Contact!.HomeAddress.Formatted);
+    }
+
+    [Fact]
     public void ProjectsTextDirectoryVcards() {
         byte[] eml = Encoding.ASCII.GetBytes(
             "Content-Type: text/directory; profile=vCard; charset=utf-8\r\n\r\n" +
@@ -191,6 +223,24 @@ public sealed class EmailContactConversionTests {
             document, EmailFileFormat.OutlookMsg);
 
         Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+
+    [Fact]
+    public void BlocksVcardPhoneSlotOverflowBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN:Ada Lovelace\r\nTEL;TYPE=HOME:first\r\nTEL;TYPE=HOME:second\r\n" +
+            "TEL;TYPE=HOME:third\r\nEND:VCARD\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Equal("first", document.Contact!.Phones.Home);
+        Assert.Equal("third", document.Contact.Phones.Home2);
         Assert.Contains(report.Diagnostics,
             diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
     }

--- a/OfficeIMO.Email.Tests/Mime/EmailMimeMetadataTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailMimeMetadataTests.cs
@@ -1,0 +1,49 @@
+using OfficeIMO.Email;
+using Xunit;
+
+namespace OfficeIMO.Email.Tests;
+
+public sealed class EmailMimeMetadataTests {
+    [Fact]
+    public void RoundTripsPortableMessageMetadataThroughStandardMimeHeaders() {
+        var source = new EmailDocument {
+            Format = EmailFileFormat.OutlookMsg,
+            Subject = "Metadata",
+            From = new EmailAddress("sender@example.com")
+        };
+        source.MessageMetadata.Importance = EmailMessageImportance.High;
+        source.MessageMetadata.Priority = EmailMessagePriority.Urgent;
+        source.MessageMetadata.Sensitivity = 2;
+        source.MessageMetadata.ReadReceiptRequested = true;
+        source.MessageMetadata.DeliveryReceiptRequested = true;
+        source.MessageMetadata.IsDraft = true;
+        source.MessageMetadata.IsRead = true;
+        source.MessageMetadata.Categories.Add("Blue");
+        source.MessageMetadata.Categories.Add("Project X");
+
+        EmailDocument result = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(source, EmailFileFormat.Eml)).Document;
+
+        Assert.Equal(EmailMessageImportance.High, result.MessageMetadata.Importance);
+        Assert.Equal(EmailMessagePriority.Urgent, result.MessageMetadata.Priority);
+        Assert.Equal(2, result.MessageMetadata.Sensitivity);
+        Assert.True(result.MessageMetadata.ReadReceiptRequested);
+        Assert.True(result.MessageMetadata.DeliveryReceiptRequested);
+        Assert.True(result.MessageMetadata.IsDraft);
+        Assert.True(result.MessageMetadata.IsRead);
+        Assert.Equal(new[] { "Blue", "Project X" }, result.MessageMetadata.Categories);
+    }
+
+    [Fact]
+    public void ReportsOpaqueMapiMetadataDuringEmlConversionWithoutBlockingCommonContent() {
+        var source = new EmailDocument { Format = EmailFileFormat.OutlookMsg, Subject = "Mapi" };
+        source.MapiProperties.Add(new MapiProperty(0x66aa, MapiPropertyType.Binary, new byte[] { 1 }));
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(source, EmailFileFormat.Eml);
+
+        Assert.True(report.CanWrite);
+        Assert.True(report.HasPotentialDataLoss);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_SOURCE_METADATA_NOT_REPRESENTED_IN_EML");
+    }
+}

--- a/OfficeIMO.Email.Tests/Mime/EmailMimeMetadataTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailMimeMetadataTests.cs
@@ -5,6 +5,38 @@ using Xunit;
 namespace OfficeIMO.Email.Tests;
 
 public sealed class EmailMimeMetadataTests {
+    [Theory]
+    [InlineData(EmailFileFormat.OutlookMsg)]
+    [InlineData(EmailFileFormat.Tnef)]
+    public void PreservesReceiptDestinationsThroughStoreFormats(EmailFileFormat storeFormat) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "From: Sender <sender@example.com>\r\n" +
+            "Disposition-Notification-To: Read Desk <read-receipts@example.com>\r\n" +
+            "Return-Receipt-To: Delivery Desk <delivery-receipts@example.com>\r\n" +
+            "Content-Type: text/plain; charset=utf-8\r\n\r\nBody\r\n");
+        var reader = new EmailDocumentReader();
+        var writer = new EmailDocumentWriter();
+        EmailDocument source = reader.Read(eml).Document;
+
+        EmailDocument stored = reader.Read(writer.ToBytes(source, storeFormat)).Document;
+        byte[] roundTrip = writer.ToBytes(stored, EmailFileFormat.Eml);
+        using var stream = new MemoryStream(roundTrip);
+        MimeMessage message = MimeMessage.Load(stream);
+
+        Assert.Equal("Read Desk <read-receipts@example.com>",
+            stored.MessageMetadata.ReadReceiptDestination);
+        Assert.Equal("Delivery Desk <delivery-receipts@example.com>",
+            stored.MessageMetadata.DeliveryReceiptDestination);
+        Assert.Contains("read-receipts@example.com",
+            message.Headers["Disposition-Notification-To"], StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("delivery-receipts@example.com",
+            message.Headers["Return-Receipt-To"], StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("sender@example.com",
+            message.Headers["Disposition-Notification-To"], StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("sender@example.com",
+            message.Headers["Return-Receipt-To"], StringComparison.OrdinalIgnoreCase);
+    }
+
     [Fact]
     public void RoundTripsPortableMessageMetadataThroughStandardMimeHeaders() {
         var source = new EmailDocument {

--- a/OfficeIMO.Email.Tests/Mime/EmailMimeMetadataTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailMimeMetadataTests.cs
@@ -15,7 +15,9 @@ public sealed class EmailMimeMetadataTests {
         source.MessageMetadata.Priority = EmailMessagePriority.Urgent;
         source.MessageMetadata.Sensitivity = 2;
         source.MessageMetadata.ReadReceiptRequested = true;
+        source.MessageMetadata.ReadReceiptDestination = "read-receipts@example.com";
         source.MessageMetadata.DeliveryReceiptRequested = true;
+        source.MessageMetadata.DeliveryReceiptDestination = "delivery-receipts@example.com";
         source.MessageMetadata.IsDraft = true;
         source.MessageMetadata.IsRead = true;
         source.MessageMetadata.Categories.Add("Blue");
@@ -28,7 +30,9 @@ public sealed class EmailMimeMetadataTests {
         Assert.Equal(EmailMessagePriority.Urgent, result.MessageMetadata.Priority);
         Assert.Equal(2, result.MessageMetadata.Sensitivity);
         Assert.True(result.MessageMetadata.ReadReceiptRequested);
+        Assert.Equal("read-receipts@example.com", result.MessageMetadata.ReadReceiptDestination);
         Assert.True(result.MessageMetadata.DeliveryReceiptRequested);
+        Assert.Equal("delivery-receipts@example.com", result.MessageMetadata.DeliveryReceiptDestination);
         Assert.True(result.MessageMetadata.IsDraft);
         Assert.True(result.MessageMetadata.IsRead);
         Assert.Equal(new[] { "Blue", "Project X" }, result.MessageMetadata.Categories);

--- a/OfficeIMO.Email.Tests/Mime/EmailMimeMetadataTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailMimeMetadataTests.cs
@@ -1,3 +1,4 @@
+using MimeKit;
 using OfficeIMO.Email;
 using Xunit;
 
@@ -49,5 +50,31 @@ public sealed class EmailMimeMetadataTests {
         Assert.True(report.HasPotentialDataLoss);
         Assert.Contains(report.Diagnostics,
             diagnostic => diagnostic.Code == "EMAIL_SOURCE_METADATA_NOT_REPRESENTED_IN_EML");
+    }
+
+    [Fact]
+    public void FormatsReceiptDestinationsAsMailboxHeaders() {
+        var source = new EmailDocument { Format = EmailFileFormat.OutlookMsg, Subject = "Receipts" };
+        source.MessageMetadata.ReadReceiptRequested = true;
+        source.MessageMetadata.ReadReceiptDestination = "Żaneta <read@example.com>";
+        source.MessageMetadata.DeliveryReceiptRequested = true;
+        source.MessageMetadata.DeliveryReceiptDestination = "Łukasz <delivery@example.com>";
+
+        byte[] output = new EmailDocumentWriter().ToBytes(source, EmailFileFormat.Eml);
+        using var stream = new MemoryStream(output);
+        MimeMessage message = MimeMessage.Load(stream);
+        string? readHeader = message.Headers["Disposition-Notification-To"];
+        string? deliveryHeader = message.Headers["Return-Receipt-To"];
+        Assert.NotNull(readHeader);
+        Assert.NotNull(deliveryHeader);
+        MailboxAddress read = Assert.IsType<MailboxAddress>(Assert.Single(
+            InternetAddressList.Parse(readHeader!)));
+        MailboxAddress delivery = Assert.IsType<MailboxAddress>(Assert.Single(
+            InternetAddressList.Parse(deliveryHeader!)));
+
+        Assert.Equal("Żaneta", read.Name);
+        Assert.Equal("read@example.com", read.Address);
+        Assert.Equal("Łukasz", delivery.Name);
+        Assert.Equal("delivery@example.com", delivery.Address);
     }
 }

--- a/OfficeIMO.Email.Tests/Mime/EmailMimeMetadataTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailMimeMetadataTests.cs
@@ -78,4 +78,20 @@ public sealed class EmailMimeMetadataTests {
         Assert.Equal("Łukasz", delivery.Name);
         Assert.Equal("delivery@example.com", delivery.Address);
     }
+
+    [Fact]
+    public void RetainsMetadataHeadersThatCannotBeProjected() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Importance: critical\r\nPriority: immediate\r\nX-Unsent: maybe\r\n" +
+            "Content-Type: text/plain; charset=utf-8\r\n\r\nBody\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        byte[] output = new EmailDocumentWriter().ToBytes(document, EmailFileFormat.Eml);
+        using var stream = new MemoryStream(output);
+        MimeMessage message = MimeMessage.Load(stream);
+
+        Assert.Equal("critical", message.Headers["Importance"]);
+        Assert.Equal("immediate", message.Headers["Priority"]);
+        Assert.Equal("maybe", message.Headers["X-Unsent"]);
+    }
 }

--- a/OfficeIMO.Email.Tests/Mime/EmailMimeMetadataTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailMimeMetadataTests.cs
@@ -23,6 +23,7 @@ public sealed class EmailMimeMetadataTests {
         source.MessageMetadata.IsRead = true;
         source.MessageMetadata.Categories.Add("Blue");
         source.MessageMetadata.Categories.Add("Project X");
+        source.MessageMetadata.Categories.Add("Project, X");
 
         EmailDocument result = new EmailDocumentReader().Read(
             new EmailDocumentWriter().ToBytes(source, EmailFileFormat.Eml)).Document;
@@ -36,7 +37,7 @@ public sealed class EmailMimeMetadataTests {
         Assert.Equal("delivery-receipts@example.com", result.MessageMetadata.DeliveryReceiptDestination);
         Assert.True(result.MessageMetadata.IsDraft);
         Assert.True(result.MessageMetadata.IsRead);
-        Assert.Equal(new[] { "Blue", "Project X" }, result.MessageMetadata.Categories);
+        Assert.Equal(new[] { "Blue", "Project X", "Project, X" }, result.MessageMetadata.Categories);
     }
 
     [Fact]

--- a/OfficeIMO.Email.Tests/Mime/EmailMimeProtectionTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailMimeProtectionTests.cs
@@ -1,0 +1,67 @@
+using OfficeIMO.Email;
+using Xunit;
+
+namespace OfficeIMO.Email.Tests;
+
+public sealed class EmailMimeProtectionTests {
+    [Theory]
+    [InlineData("application/pkcs7-signature", EmailProtectionKind.SmimeClearSigned)]
+    [InlineData("application/pgp-signature", EmailProtectionKind.PgpMimeClearSigned)]
+    public void DetectsAndPassesThroughUnchangedSignedMime(string protocol, EmailProtectionKind expectedKind) {
+        byte[] source = CreateSignedMessage(protocol);
+
+        EmailReadResult read = new EmailDocumentReader().Read(source);
+        byte[] rewritten = new EmailDocumentWriter().ToBytes(read.Document, EmailFileFormat.Eml);
+
+        Assert.Equal(expectedKind, read.Document.Protection.Kind);
+        Assert.NotNull(read.Document.RawSource);
+        Assert.Equal(source, rewritten);
+    }
+
+    [Fact]
+    public void BlocksSignedMimeAfterTheModelChanges() {
+        EmailDocument document = new EmailDocumentReader().Read(
+            CreateSignedMessage("application/pkcs7-signature")).Document;
+        document.Subject = "Changed";
+        var writer = new EmailDocumentWriter();
+
+        EmailConversionReport report = writer.AnalyzeConversion(document, EmailFileFormat.Eml);
+        using var destination = new MemoryStream();
+        EmailWriteResult result = writer.Write(document, destination, EmailFileFormat.Eml);
+
+        Assert.True(report.HasPotentialDataLoss);
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics, diagnostic => diagnostic.Code == "EMAIL_PROTECTED_CONTENT_REWRITE");
+        Assert.True(result.HasErrors);
+        Assert.Equal(0, destination.Length);
+        Assert.Throws<InvalidDataException>(() => writer.ToBytes(document, EmailFileFormat.Eml));
+    }
+
+    [Fact]
+    public void ExplicitWarnPolicyAllowsProtectedConversionAndReportsIt() {
+        EmailDocument document = new EmailDocumentReader().Read(
+            CreateSignedMessage("application/pkcs7-signature")).Document;
+        document.Subject = "Changed";
+        var writer = new EmailDocumentWriter(new EmailWriterOptions(
+            conversionLossPolicy: EmailConversionLossPolicy.Warn));
+
+        byte[] output = writer.ToBytes(document, EmailFileFormat.Eml, out EmailWriteResult result);
+
+        Assert.NotEmpty(output);
+        Assert.False(result.HasErrors);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "EMAIL_PROTECTED_CONTENT_REWRITE" &&
+            diagnostic.Severity == EmailDiagnosticSeverity.Warning);
+    }
+
+    private static byte[] CreateSignedMessage(string protocol) {
+        string source = "From: sender@example.com\r\n" +
+            "To: recipient@example.com\r\n" +
+            "Subject: Signed\r\n" +
+            "MIME-Version: 1.0\r\n" +
+            "Content-Type: multipart/signed; protocol=\"" + protocol + "\"; boundary=\"sig\"\r\n\r\n" +
+            "--sig\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nHello\r\n" +
+            "--sig\r\nContent-Type: " + protocol + "\r\nContent-Transfer-Encoding: base64\r\n\r\nAQID\r\n" +
+            "--sig--\r\n";
+        return Encoding.ASCII.GetBytes(source);
+    }
+}

--- a/OfficeIMO.Email.Tests/Mime/EmailMimeReaderTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailMimeReaderTests.cs
@@ -209,6 +209,17 @@ public sealed class EmailMimeReaderTests {
     }
 
     [Fact]
+    public void ParsesEncodedDisplayNamesThatDecodeToAngleBrackets() {
+        const string eml = "To: =?utf-8?Q?Team_=3CEU=3E?= <team@example.com>\r\n\r\nbody";
+
+        EmailRecipient recipient = Assert.Single(
+            new EmailDocumentReader().Read(Encoding.ASCII.GetBytes(eml)).Document.Recipients);
+
+        Assert.Equal("team@example.com", recipient.Address.Address);
+        Assert.Equal("Team <EU>", recipient.Address.DisplayName);
+    }
+
+    [Fact]
     public void PreservesCidTextPartsAsInlineAttachments() {
         const string eml = "Subject: related\r\nContent-Type: multipart/related; boundary=x\r\n\r\n" +
             "--x\r\nContent-Type: text/html; charset=utf-8\r\n\r\n<p>body</p>\r\n" +
@@ -293,6 +304,23 @@ public sealed class EmailMimeReaderTests {
             Assert.False(attachment.IsProjectedSemanticContent);
             Assert.True(attachment.Length > 0);
         });
+    }
+
+    [Fact]
+    public void PreservesEmptyAddressGroupsThroughStoreTransportHeaders() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "To: undisclosed-recipients:;\r\nSubject: private list\r\n\r\nbody");
+        EmailDocument source = new EmailDocumentReader().Read(eml).Document;
+
+        EmailDocument stored = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(source, EmailFileFormat.OutlookMsg)).Document;
+        string regenerated = Encoding.UTF8.GetString(
+            new EmailDocumentWriter().ToBytes(stored, EmailFileFormat.Eml));
+
+        Assert.Empty(stored.Recipients);
+        Assert.Contains(stored.Headers, header => header.Name == "To" &&
+            (header.RawValue ?? header.Value).Contains("undisclosed-recipients:;", StringComparison.Ordinal));
+        Assert.Contains("To: undisclosed-recipients:;", regenerated, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/OfficeIMO.Email.Tests/Mime/EmailMimeReaderTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailMimeReaderTests.cs
@@ -95,14 +95,19 @@ public sealed class EmailMimeReaderTests {
         Assert.Equal("Child body", attachment.EmbeddedDocument.Body.Text!.Trim());
     }
 
-    [Fact]
-    public void ReportsRecoverableMalformedContent() {
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ReportsUnrecoverableMalformedBase64AsAnError(bool includeAttachmentContent) {
         const string eml = "Subject: malformed\r\nContent-Type: multipart/mixed; boundary=x\r\n\r\n" +
             "--x\r\nContent-Type: application/octet-stream\r\nContent-Transfer-Encoding: base64\r\n\r\n%%%\r\n";
 
-        EmailReadResult result = new EmailDocumentReader().Read(Encoding.ASCII.GetBytes(eml));
+        EmailReadResult result = new EmailDocumentReader(new EmailReaderOptions(
+            includeAttachmentContent: includeAttachmentContent)).Read(Encoding.ASCII.GetBytes(eml));
 
-        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "EMAIL_MIME_BASE64_INVALID");
+        Assert.True(result.HasErrors);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "EMAIL_MIME_BASE64_INVALID" &&
+            diagnostic.Severity == EmailDiagnosticSeverity.Error);
         Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "EMAIL_MIME_BOUNDARY_NOT_CLOSED");
         Assert.Single(result.Document.Attachments);
     }
@@ -336,7 +341,7 @@ public sealed class EmailMimeReaderTests {
     }
 
     [Fact]
-    public void RecoversBrokenMultipartAndBase64AsWarnings() {
+    public void ReportsBrokenMultipartAsWarningButInvalidBase64AsError() {
         const string eml = "Subject: recovery\r\nContent-Type: multipart/mixed; boundary=x\r\n\r\n" +
             "--x\r\nContent-Type: application/octet-stream\r\nContent-Transfer-Encoding: base64\r\n\r\n" +
             "not valid base64!\r\n";
@@ -344,10 +349,10 @@ public sealed class EmailMimeReaderTests {
         EmailReadResult result = new EmailDocumentReader().Read(Encoding.ASCII.GetBytes(eml));
 
         Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "EMAIL_MIME_BASE64_INVALID" &&
-            diagnostic.Severity == EmailDiagnosticSeverity.Warning);
+            diagnostic.Severity == EmailDiagnosticSeverity.Error);
         Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "EMAIL_MIME_BOUNDARY_NOT_CLOSED" &&
             diagnostic.Severity == EmailDiagnosticSeverity.Warning);
-        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Severity == EmailDiagnosticSeverity.Error);
+        Assert.True(result.HasErrors);
     }
 
     [Fact]

--- a/OfficeIMO.Email.Tests/Mime/EmailMimeReaderTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailMimeReaderTests.cs
@@ -275,13 +275,29 @@ public sealed class EmailMimeReaderTests {
 
     [Fact]
     public void ParsesAddressGroupsAndIgnoresEmptyGroups() {
-        const string eml = "To: undisclosed-recipients:;, Team: Alice <alice@example.com>, Bob <bob@example.com>;\r\n\r\nbody";
+        const string eml = "To: undisclosed-recipients:; (no recipients), Team: Alice <alice@example.com>, " +
+            "Bob <bob@example.com>;\r\n\r\nbody";
 
         EmailDocument document = new EmailDocumentReader().Read(Encoding.ASCII.GetBytes(eml)).Document;
 
         Assert.Equal(2, document.Recipients.Count);
         Assert.Equal("alice@example.com", document.Recipients[0].Address.Address);
         Assert.Equal("bob@example.com", document.Recipients[1].Address.Address);
+    }
+
+    [Fact]
+    public void RecoversBrokenMultipartAndBase64AsWarnings() {
+        const string eml = "Subject: recovery\r\nContent-Type: multipart/mixed; boundary=x\r\n\r\n" +
+            "--x\r\nContent-Type: application/octet-stream\r\nContent-Transfer-Encoding: base64\r\n\r\n" +
+            "not valid base64!\r\n";
+
+        EmailReadResult result = new EmailDocumentReader().Read(Encoding.ASCII.GetBytes(eml));
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "EMAIL_MIME_BASE64_INVALID" &&
+            diagnostic.Severity == EmailDiagnosticSeverity.Warning);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "EMAIL_MIME_BOUNDARY_NOT_CLOSED" &&
+            diagnostic.Severity == EmailDiagnosticSeverity.Warning);
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Severity == EmailDiagnosticSeverity.Error);
     }
 
     [Fact]
@@ -386,5 +402,65 @@ public sealed class EmailMimeReaderTests {
         EmailAttachment roundTripAttachment = Assert.Single(roundTrip.Attachments);
         Assert.Equal("caption.txt", roundTripAttachment.ContentLocation);
         Assert.True(roundTripAttachment.IsInline);
+    }
+
+    [Fact]
+    public void DecodesFormatFlowedTextWithDelSpAndSpaceStuffing() {
+        const string eml = "Content-Type: text/plain; charset=utf-8; format=flowed; delsp=yes\r\n\r\n" +
+            "This is flow \r\ned.\r\n From space-stuffed\r\n>quoted \r\n>continuation\r\n-- \r\nsignature";
+
+        EmailDocument document = new EmailDocumentReader().Read(Encoding.ASCII.GetBytes(eml)).Document;
+
+        Assert.Equal("This is flowed.\r\nFrom space-stuffed\r\n>quotedcontinuation\r\n-- \r\nsignature",
+            document.Body.Text);
+    }
+
+    [Fact]
+    public void KeepsFlowedJoinSpaceWhenDelSpIsNotEnabled() {
+        const string eml = "Content-Type: text/plain; charset=utf-8; format=flowed\r\n\r\n" +
+            "This is flow \r\ned.";
+
+        EmailDocument document = new EmailDocumentReader().Read(Encoding.ASCII.GetBytes(eml)).Document;
+
+        Assert.Equal("This is flow ed.", document.Body.Text);
+    }
+
+    [Fact]
+    public void RemovesFinalFlowedSpaceMarkerWhenDelSpIsEnabled() {
+        const string eml = "Content-Type: text/plain; charset=utf-8; format=flowed; delsp=yes\r\n\r\n" +
+            "https://example.com/ ";
+
+        EmailDocument document = new EmailDocumentReader().Read(Encoding.ASCII.GetBytes(eml)).Document;
+
+        Assert.Equal("https://example.com/", document.Body.Text);
+    }
+
+    [Fact]
+    public void RecoversCharsetlessInvalidUtf8AsWindows1252() {
+        byte[] headers = Encoding.ASCII.GetBytes("Content-Type: text/plain\r\n\r\nPrice: ");
+        byte[] eml = new byte[headers.Length + 1];
+        Buffer.BlockCopy(headers, 0, eml, 0, headers.Length);
+        eml[eml.Length - 1] = 0xA3;
+
+        EmailReadResult result = new EmailDocumentReader().Read(eml);
+
+        Assert.Equal("Price: £", result.Document.Body.Text);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "EMAIL_MIME_CHARSET_GUESSED" &&
+            diagnostic.Severity == EmailDiagnosticSeverity.Warning);
+    }
+
+    [Fact]
+    public void KeepsCharsetlessValidUtf8WithoutGuessing() {
+        const string body = "Zażółć gęślą jaźń";
+        byte[] headers = Encoding.ASCII.GetBytes("Content-Type: text/plain\r\n\r\n");
+        byte[] bodyBytes = Encoding.UTF8.GetBytes(body);
+        byte[] eml = new byte[headers.Length + bodyBytes.Length];
+        Buffer.BlockCopy(headers, 0, eml, 0, headers.Length);
+        Buffer.BlockCopy(bodyBytes, 0, eml, headers.Length, bodyBytes.Length);
+
+        EmailReadResult result = new EmailDocumentReader().Read(eml);
+
+        Assert.Equal(body, result.Document.Body.Text);
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Code == "EMAIL_MIME_CHARSET_GUESSED");
     }
 }

--- a/OfficeIMO.Email.Tests/Mime/EmailMimeReaderTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailMimeReaderTests.cs
@@ -274,6 +274,28 @@ public sealed class EmailMimeReaderTests {
     }
 
     [Fact]
+    public void OmitsOrdinaryCalendarAndVcardAttachmentContentWhenRequested() {
+        const string eml = "MIME-Version: 1.0\r\nContent-Type: multipart/mixed; boundary=x\r\n\r\n" +
+            "--x\r\nContent-Type: text/calendar; name=invite.ics\r\n" +
+            "Content-Disposition: attachment; filename=invite.ics\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nEND:VCALENDAR\r\n" +
+            "--x\r\nContent-Type: text/vcard; name=person.vcf\r\n" +
+            "Content-Disposition: attachment; filename=person.vcf\r\n\r\n" +
+            "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Ada Lovelace\r\nEND:VCARD\r\n--x--\r\n";
+
+        EmailDocument document = new EmailDocumentReader(new EmailReaderOptions(includeAttachmentContent: false))
+            .Read(Encoding.ASCII.GetBytes(eml)).Document;
+
+        Assert.Equal(OutlookItemKind.Message, document.OutlookItemKind);
+        Assert.Equal(2, document.Attachments.Count);
+        Assert.All(document.Attachments, attachment => {
+            Assert.Null(attachment.Content);
+            Assert.False(attachment.IsProjectedSemanticContent);
+            Assert.True(attachment.Length > 0);
+        });
+    }
+
+    [Fact]
     public void ParsesAddressGroupsAndIgnoresEmptyGroups() {
         const string eml = "To: undisclosed-recipients:; (no recipients), Team: Alice <alice@example.com>, " +
             "Bob <bob@example.com>;\r\n\r\nbody";

--- a/OfficeIMO.Email.Tests/Mime/EmailMimeReaderTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailMimeReaderTests.cs
@@ -351,6 +351,18 @@ public sealed class EmailMimeReaderTests {
     }
 
     [Fact]
+    public void ReportsMissingMultipartBoundaryAsAnError() {
+        const string eml = "Subject: missing boundary\r\nContent-Type: multipart/mixed; boundary=x\r\n\r\n" +
+            "This body never contains the declared delimiter.\r\n";
+
+        EmailReadResult result = new EmailDocumentReader().Read(Encoding.ASCII.GetBytes(eml));
+
+        Assert.True(result.HasErrors);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "EMAIL_MIME_BOUNDARY_NOT_FOUND" &&
+            diagnostic.Severity == EmailDiagnosticSeverity.Error);
+    }
+
+    [Fact]
     public void DefaultsMultipartDigestChildrenToEmbeddedMessages() {
         const string eml = "Subject: digest\r\nContent-Type: multipart/digest; boundary=d\r\n\r\n" +
             "--d\r\n\r\nFrom: child@example.com\r\nSubject: Digest child\r\n\r\nchild body\r\n" +

--- a/OfficeIMO.Email.Tests/Mime/EmailMimeWriterTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailMimeWriterTests.cs
@@ -444,4 +444,17 @@ public sealed class EmailMimeWriterTests {
 
         Assert.Contains(name + ": " + value + "\r\n", eml, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void RetainsEachUnparsedRecipientHeaderIndependently() {
+        byte[] source = Encoding.ASCII.GetBytes(
+            "To: (undisclosed)\r\nCc: Valid <valid@example.com>\r\nSubject: retained\r\n\r\nbody\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(source).Document;
+
+        string eml = Encoding.ASCII.GetString(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.Eml));
+
+        Assert.Contains("To: (undisclosed)\r\n", eml, StringComparison.Ordinal);
+        Assert.Contains("Cc: Valid <valid@example.com>\r\n", eml, StringComparison.Ordinal);
+    }
 }

--- a/OfficeIMO.Email.Tests/Mime/EmailMimeWriterTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailMimeWriterTests.cs
@@ -457,4 +457,21 @@ public sealed class EmailMimeWriterTests {
         Assert.Contains("To: (undisclosed)\r\n", eml, StringComparison.Ordinal);
         Assert.Contains("Cc: Valid <valid@example.com>\r\n", eml, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void PreservesUnrepresentedRetainedRecipientAlongsideStructuredRecipients() {
+        var document = new EmailDocument { Subject = "retained" };
+        document.Body.Text = "body";
+        document.Headers.Add(new EmailHeader("To", "Header Only <header@example.com>"));
+        document.Recipients.Add(new EmailRecipient(EmailRecipientKind.Cc,
+            new EmailAddress("cc@example.com", "Structured")));
+
+        EmailDocument roundTrip = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.OutlookMsg)).Document;
+
+        Assert.Contains(roundTrip.Recipients, recipient => recipient.Kind == EmailRecipientKind.To &&
+            recipient.Address.Address == "header@example.com");
+        Assert.Contains(roundTrip.Recipients, recipient => recipient.Kind == EmailRecipientKind.Cc &&
+            recipient.Address.Address == "cc@example.com");
+    }
 }

--- a/OfficeIMO.Email.Tests/Mime/EmailMimeWriterTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailMimeWriterTests.cs
@@ -431,4 +431,17 @@ public sealed class EmailMimeWriterTests {
 
         Assert.Equal(displayName, roundTrip.From!.DisplayName);
     }
+
+    [Theory]
+    [InlineData("From", "(undisclosed)")]
+    [InlineData("Sender", "Broken <")]
+    public void RetainsUnparsedScalarAddressHeaders(string name, string value) {
+        byte[] source = Encoding.ASCII.GetBytes(name + ": " + value + "\r\nSubject: retained\r\n\r\nbody\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(source).Document;
+
+        byte[] rewritten = new EmailDocumentWriter().ToBytes(document, EmailFileFormat.Eml);
+        string eml = Encoding.ASCII.GetString(rewritten);
+
+        Assert.Contains(name + ": " + value + "\r\n", eml, StringComparison.Ordinal);
+    }
 }

--- a/OfficeIMO.Email.Tests/Mime/EmailSemanticProjectionLossTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailSemanticProjectionLossTests.cs
@@ -5,6 +5,15 @@ namespace OfficeIMO.Email.Tests;
 
 public sealed class EmailSemanticProjectionLossTests {
     [Fact]
+    public void BlocksGroupedVCardPropertiesBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "item1.FN:Ada Lovelace\r\nEND:VCARD\r\n");
+
+        AssertStoreProjectionBlocked(eml);
+    }
+
+    [Fact]
     public void BlocksCalendarRequestStatusBeforeStoreConversion() {
         byte[] eml = Encoding.ASCII.GetBytes(
             "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +

--- a/OfficeIMO.Email.Tests/Mime/EmailSemanticProjectionLossTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailSemanticProjectionLossTests.cs
@@ -5,6 +5,29 @@ namespace OfficeIMO.Email.Tests;
 
 public sealed class EmailSemanticProjectionLossTests {
     [Fact]
+    public void BlocksEventWithoutStartBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\n" +
+            "VERSION:2.0\r\nBEGIN:VEVENT\r\nUID:undated@example.com\r\n" +
+            "SUMMARY:Undated\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        AssertStoreProjectionBlocked(eml);
+    }
+
+    [Theory]
+    [InlineData("text/directory; profile=vcard")]
+    [InlineData("text/x-vcard")]
+    [InlineData("application/vcard")]
+    [InlineData("text/vcard; profile=vcard")]
+    public void BlocksUnpreservedVCardMediaTypesBeforeStoreConversion(string contentType) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: " + contentType + "; charset=utf-8\r\n\r\nBEGIN:VCARD\r\n" +
+            "VERSION:3.0\r\nFN:Ada Lovelace\r\nEND:VCARD\r\n");
+
+        AssertStoreProjectionBlocked(eml);
+    }
+
+    [Fact]
     public void BlocksNonCanonicalCalendarProducerBeforeStoreConversion() {
         byte[] eml = Encoding.ASCII.GetBytes(
             "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\n" +

--- a/OfficeIMO.Email.Tests/Mime/EmailSemanticProjectionLossTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailSemanticProjectionLossTests.cs
@@ -5,6 +5,38 @@ namespace OfficeIMO.Email.Tests;
 
 public sealed class EmailSemanticProjectionLossTests {
     [Fact]
+    public void BlocksNonCanonicalCalendarProducerBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\n" +
+            "PRODID:-//Example Corp//Calendar 1.0//EN\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\n" +
+            "UID:producer@example.com\r\nDTSTART:20260801T100000Z\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        AssertStoreProjectionBlocked(eml);
+    }
+
+    [Fact]
+    public void BlocksVCardProducerBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "PRODID:-//Example Corp//Contacts 1.0//EN\r\nFN:Ada Lovelace\r\nEND:VCARD\r\n");
+
+        AssertStoreProjectionBlocked(eml);
+    }
+
+    [Fact]
+    public void BlocksUnpreservedCalendarPartHeadersBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "MIME-Version: 1.0\r\nContent-Type: multipart/mixed; boundary=x\r\n\r\n" +
+            "--x\r\nContent-Type: text/calendar; charset=utf-8\r\n" +
+            "Content-Class: urn:content-classes:calendarmessage\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nPRODID:-//Evotec//OfficeIMO.Email//EN\r\nVERSION:2.0\r\n" +
+            "BEGIN:VEVENT\r\nUID:content-class@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n--x--\r\n");
+
+        AssertStoreProjectionBlocked(eml);
+    }
+
+    [Fact]
     public void BlocksGroupedVCardPropertiesBeforeStoreConversion() {
         byte[] eml = Encoding.ASCII.GetBytes(
             "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +

--- a/OfficeIMO.Email.Tests/Mime/EmailSemanticProjectionLossTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailSemanticProjectionLossTests.cs
@@ -65,6 +65,87 @@ public sealed class EmailSemanticProjectionLossTests {
     }
 
     [Theory]
+    [InlineData("METHOD:PUBLISH\r\n", "ORGANIZER:mailto:alice@example.com?subject=Meeting")]
+    [InlineData("METHOD:REQUEST\r\n", "ATTENDEE:mailto:alice@example.com?subject=Meeting")]
+    public void BlocksCalendarMailtoUrisWithHeaderFieldsBeforeStoreConversion(
+        string method, string addressProperty) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            method + "BEGIN:VEVENT\r\nUID:mailto-header@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            addressProperty + "\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        AssertStoreProjectionBlocked(eml);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("VERSION:3.0\r\nVERSION:3.0\r\n")]
+    public void RequiresExactlyOneVcardVersionBeforeStoreConversion(string versions) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\n" + versions +
+            "FN:Ada Lovelace\r\nEND:VCARD\r\n");
+
+        AssertStoreProjectionBlocked(eml);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("SUMMARY:Calendar subject\r\n")]
+    public void BlocksTransportSubjectPromotionOrReplacementBeforeStoreConversion(string summary) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Subject: Transport subject\r\nContent-Type: text/calendar; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nMETHOD:PUBLISH\r\nBEGIN:VEVENT\r\n" +
+            "UID:subject-provenance@example.com\r\nDTSTART:20260801T100000Z\r\n" + summary +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        AssertStoreProjectionBlocked(eml);
+    }
+
+    [Fact]
+    public void BlocksTransportFromPromotionIntoCalendarOrganizer() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "From: Owner <owner@example.com>\r\nContent-Type: text/calendar; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nMETHOD:PUBLISH\r\nBEGIN:VEVENT\r\n" +
+            "UID:organizer-provenance@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        AssertStoreProjectionBlocked(eml);
+    }
+
+    [Fact]
+    public void BlocksUnknownCalendarExtensionsBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "METHOD:PUBLISH\r\nBEGIN:VEVENT\r\nUID:vendor-extension@example.com\r\n" +
+            "DTSTART:20260801T100000Z\r\nX-APPLE-STRUCTURED-LOCATION:geo:52.2,21.0\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        AssertStoreProjectionBlocked(eml);
+    }
+
+    [Fact]
+    public void BlocksDuplicateCalendarAttendeesBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "METHOD:REQUEST\r\nBEGIN:VEVENT\r\nUID:duplicate-attendee@example.com\r\n" +
+            "DTSTART:20260801T100000Z\r\nATTENDEE;ROLE=REQ-PARTICIPANT:mailto:alice@example.com\r\n" +
+            "ATTENDEE;ROLE=OPT-PARTICIPANT:mailto:alice@example.com\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        AssertStoreProjectionBlocked(eml);
+    }
+
+    [Theory]
+    [InlineData("X-SOCIALPROFILE:https://social.example/ada")]
+    [InlineData("item1.X-ABLABEL:Social")]
+    public void BlocksUnknownVcardExtensionsBeforeStoreConversion(string extension) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN:Ada Lovelace\r\n" + extension + "\r\nEND:VCARD\r\n");
+
+        AssertStoreProjectionBlocked(eml);
+    }
+
+    [Theory]
     [InlineData(false)]
     [InlineData(true)]
     public void BlocksNonSmtpCalendarRecipientsAndOmitsInvalidMailtoValues(bool task) {

--- a/OfficeIMO.Email.Tests/Mime/EmailSemanticProjectionLossTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailSemanticProjectionLossTests.cs
@@ -1,0 +1,92 @@
+using OfficeIMO.Email;
+using Xunit;
+
+namespace OfficeIMO.Email.Tests;
+
+public sealed class EmailSemanticProjectionLossTests {
+    [Theory]
+    [InlineData("SUMMARY;LANGUAGE=fr:Reunion")]
+    [InlineData("DESCRIPTION;ALTREP=\"cid:description\":Notes")]
+    public void BlocksParameterizedCalendarTextBeforeStoreConversion(string property) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "BEGIN:VEVENT\r\nUID:parameterized-text@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            property + "\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        AssertStoreProjectionBlocked(eml);
+    }
+
+    [Theory]
+    [InlineData("FN;LANGUAGE=fr:Jean Dupont")]
+    [InlineData("NOTE;ALTID=1:Notes")]
+    public void BlocksParameterizedVcardTextBeforeStoreConversion(string property) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            property + "\r\nEND:VCARD\r\n");
+
+        AssertStoreProjectionBlocked(eml);
+    }
+
+    [Fact]
+    public void BlocksMimeBodyPromotionIntoCalendarDescription() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "MIME-Version: 1.0\r\nContent-Type: multipart/alternative; boundary=x\r\n\r\n" +
+            "--x\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nWrapper text\r\n" +
+            "--x\r\nContent-Type: text/calendar; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:no-description@example.com\r\n" +
+            "DTSTART:20260801T100000Z\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n--x--\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.Equal("Wrapper text", document.Body.Text!.Trim());
+        AssertProjectionBlocked(report);
+    }
+
+    [Fact]
+    public void BlocksMimeBodyPromotionIntoVcardNote() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "MIME-Version: 1.0\r\nContent-Type: multipart/alternative; boundary=x\r\n\r\n" +
+            "--x\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nWrapper text\r\n" +
+            "--x\r\nContent-Type: text/vcard; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Ada Lovelace\r\nEND:VCARD\r\n--x--\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+
+        Assert.Equal("Wrapper text", document.Body.Text!.Trim());
+        AssertProjectionBlocked(report);
+    }
+
+    [Fact]
+    public void BlocksDistributionListConversionToIndividualVcard() {
+        var document = new EmailDocument {
+            Format = EmailFileFormat.OutlookMsg,
+            OutlookItemKind = OutlookItemKind.Contact,
+            MessageClass = "IPM.DistList",
+            Contact = new OutlookContact { DisplayName = "Engineering" }
+        };
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.Eml);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_VCARD_DISTRIBUTION_LIST_UNSUPPORTED");
+    }
+
+    private static void AssertStoreProjectionBlocked(byte[] eml) {
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.OutlookMsg);
+        AssertProjectionBlocked(report);
+    }
+
+    private static void AssertProjectionBlocked(EmailConversionReport report) {
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE");
+    }
+}

--- a/OfficeIMO.Email.Tests/Mime/EmailSemanticProjectionLossTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailSemanticProjectionLossTests.cs
@@ -4,6 +4,21 @@ using Xunit;
 namespace OfficeIMO.Email.Tests;
 
 public sealed class EmailSemanticProjectionLossTests {
+    [Fact]
+    public void PreservesMissingMimeCalendarMethodWhenReusingUnchangedContent() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "BEGIN:VEVENT\r\nUID:methodless-rewrite@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "ATTENDEE:mailto:reader@example.com\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+        EmailDocument document = new EmailDocumentReader().Read(eml).Document;
+
+        string rewritten = Encoding.ASCII.GetString(
+            new EmailDocumentWriter().ToBytes(document, EmailFileFormat.Eml));
+
+        Assert.Contains("Content-Type: text/calendar", rewritten, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("method=", rewritten, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Theory]
     [InlineData("SUMMARY;LANGUAGE=fr:Reunion")]
     [InlineData("DESCRIPTION;ALTREP=\"cid:description\":Notes")]
@@ -12,6 +27,16 @@ public sealed class EmailSemanticProjectionLossTests {
             "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
             "BEGIN:VEVENT\r\nUID:parameterized-text@example.com\r\nDTSTART:20260801T100000Z\r\n" +
             property + "\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        AssertStoreProjectionBlocked(eml);
+    }
+
+    [Fact]
+    public void BlocksCalendarRelationshipsBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "BEGIN:VEVENT\r\nUID:related@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "RELATED-TO;RELTYPE=PARENT:parent@example.com\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
 
         AssertStoreProjectionBlocked(eml);
     }
@@ -25,6 +50,78 @@ public sealed class EmailSemanticProjectionLossTests {
             property + "\r\nEND:VCARD\r\n");
 
         AssertStoreProjectionBlocked(eml);
+    }
+
+    [Theory]
+    [InlineData("AGENT:BEGIN:VCARD\\nFN:Assistant\\nEND:VCARD")]
+    [InlineData("SORT-STRING:Lovelace, Ada")]
+    [InlineData("MAILER:OfficeIMO.Email")]
+    public void BlocksUnprojectedVcardDelegationAndSortFieldsBeforeStoreConversion(string property) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            "FN:Ada Lovelace\r\n" + property + "\r\nEND:VCARD\r\n");
+
+        AssertStoreProjectionBlocked(eml);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void BlocksNonSmtpCalendarRecipientsAndOmitsInvalidMailtoValues(bool task) {
+        var document = new EmailDocument {
+            Format = EmailFileFormat.OutlookMsg,
+            OutlookItemKind = task ? OutlookItemKind.Task : OutlookItemKind.Appointment,
+            Subject = "Portable attendee",
+            Task = task ? new OutlookTask() : null,
+            Appointment = task ? null : new OutlookAppointment {
+                Start = new DateTimeOffset(2026, 8, 1, 10, 0, 0, TimeSpan.Zero)
+            }
+        };
+        document.Recipients.Add(new EmailRecipient(EmailRecipientKind.To,
+            new EmailAddress("/o=Example/ou=Exchange/cn=Recipients/cn=Reader", "Reader") { AddressType = "EX" }));
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.Eml);
+        byte[] warned = new EmailDocumentWriter(new EmailWriterOptions(EmailConversionLossPolicy.Warn))
+            .ToBytes(document, EmailFileFormat.Eml);
+        EmailAttachment calendar = Assert.Single(new EmailDocumentReader().Read(warned).Document.Attachments,
+            attachment => string.Equals(attachment.ContentType, "text/calendar", StringComparison.OrdinalIgnoreCase));
+        string calendarText = Encoding.UTF8.GetString(Assert.IsType<byte[]>(calendar.Content));
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_ICALENDAR_ATTENDEE_ADDRESS_REQUIRED");
+        Assert.DoesNotContain("/o=Example", calendarText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void BlocksNonSmtpCalendarOrganizersAndOmitsInvalidMailtoValues(bool task) {
+        const string organizerAddress = "owner@example.com";
+        var document = new EmailDocument {
+            Format = EmailFileFormat.OutlookMsg,
+            OutlookItemKind = task ? OutlookItemKind.Task : OutlookItemKind.Appointment,
+            Subject = "Portable organizer",
+            From = new EmailAddress(organizerAddress, "Owner") { AddressType = "EX" },
+            Task = task ? new OutlookTask { Owner = organizerAddress } : null,
+            Appointment = task ? null : new OutlookAppointment {
+                Start = new DateTimeOffset(2026, 8, 1, 10, 0, 0, TimeSpan.Zero)
+            }
+        };
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            document, EmailFileFormat.Eml);
+        byte[] warned = new EmailDocumentWriter(new EmailWriterOptions(EmailConversionLossPolicy.Warn))
+            .ToBytes(document, EmailFileFormat.Eml);
+        EmailAttachment calendar = Assert.Single(new EmailDocumentReader().Read(warned).Document.Attachments,
+            attachment => string.Equals(attachment.ContentType, "text/calendar", StringComparison.OrdinalIgnoreCase));
+        string calendarText = Encoding.UTF8.GetString(Assert.IsType<byte[]>(calendar.Content));
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_ICALENDAR_ORGANIZER_ADDRESS_REQUIRED");
+        Assert.DoesNotContain("\r\nORGANIZER", calendarText, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/OfficeIMO.Email.Tests/Mime/EmailSemanticProjectionLossTests.cs
+++ b/OfficeIMO.Email.Tests/Mime/EmailSemanticProjectionLossTests.cs
@@ -5,6 +5,79 @@ namespace OfficeIMO.Email.Tests;
 
 public sealed class EmailSemanticProjectionLossTests {
     [Fact]
+    public void BlocksCalendarRequestStatusBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "METHOD:REPLY\r\nBEGIN:VEVENT\r\nUID:request-status@example.com\r\n" +
+            "DTSTART:20260801T100000Z\r\nREQUEST-STATUS:2.0;Success\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        AssertStoreProjectionBlocked(eml);
+    }
+
+    [Fact]
+    public void BlocksRequestCalendarWithOnlyTransportRecipientsBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "To: Reader <reader@example.com>\r\nContent-Type: text/calendar; charset=utf-8\r\n\r\n" +
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\n" +
+            "UID:transport-only-recipient@example.com\r\nDTSTART:20260801T100000Z\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        AssertStoreProjectionBlocked(eml);
+    }
+
+    [Fact]
+    public void BlocksGroupedCalendarPropertiesBeforeStoreConversion() {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "METHOD:REQUEST\r\nBEGIN:VEVENT\r\nUID:grouped-property@example.com\r\n" +
+            "DTSTART:20260801T100000Z\r\ngrp.ATTENDEE:mailto:reader@example.com\r\n" +
+            "END:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        AssertStoreProjectionBlocked(eml);
+    }
+
+    [Theory]
+    [InlineData("text/calendar", "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:charset@example.com\r\nDTSTART:20260801T100000Z\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n")]
+    [InlineData("text/vcard", "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Ada Lovelace\r\nEND:VCARD\r\n")]
+    public void BlocksSemanticCharsetFallbackBeforeStoreConversion(string contentType, string content) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: " + contentType + "; charset=x-officeimo-unsupported\r\n\r\n" + content);
+        EmailReadResult result = new EmailDocumentReader().Read(eml);
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            result.Document, EmailFileFormat.OutlookMsg);
+
+        Assert.Contains(result.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_MIME_CHARSET_UNSUPPORTED");
+        AssertProjectionBlocked(report);
+    }
+
+    [Theory]
+    [InlineData("SUMMARY:First\r\nSUMMARY:Second")]
+    [InlineData("UID:first@example.com\r\nUID:second@example.com")]
+    [InlineData("DTSTART:20260801T100000Z\r\nDTSTART:20260801T110000Z")]
+    public void BlocksDuplicateCalendarSingletonsBeforeStoreConversion(string duplicateProperties) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +
+            "BEGIN:VEVENT\r\n" + duplicateProperties + "\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+
+        AssertStoreProjectionBlocked(eml);
+    }
+
+    [Theory]
+    [InlineData("FN:First\r\nFN:Second")]
+    [InlineData("N:First;Ada;;;\r\nN:Second;Ada;;;")]
+    [InlineData("TITLE:Engineer\r\nTITLE:Architect")]
+    public void BlocksDuplicateVCardSingletonsBeforeStoreConversion(string duplicateProperties) {
+        byte[] eml = Encoding.ASCII.GetBytes(
+            "Content-Type: text/vcard; charset=utf-8\r\n\r\nBEGIN:VCARD\r\nVERSION:3.0\r\n" +
+            duplicateProperties + "\r\nEND:VCARD\r\n");
+
+        AssertStoreProjectionBlocked(eml);
+    }
+
+    [Fact]
     public void PreservesMissingMimeCalendarMethodWhenReusingUnchangedContent() {
         byte[] eml = Encoding.ASCII.GetBytes(
             "Content-Type: text/calendar; charset=utf-8\r\n\r\nBEGIN:VCALENDAR\r\nVERSION:2.0\r\n" +

--- a/OfficeIMO.Email.Tests/Msg/MsgSerializationRegressionTests.cs
+++ b/OfficeIMO.Email.Tests/Msg/MsgSerializationRegressionTests.cs
@@ -149,6 +149,29 @@ public sealed class MsgSerializationRegressionTests {
         Assert.Equal(2, exception.ActualValue);
     }
 
+    [Fact]
+    public void ProjectedSemanticPartsDoNotSetMsgAttachmentMetadata() {
+        var source = new EmailDocument { Subject = "projected content" };
+        var semanticPart = new EmailAttachment {
+            FileName = "contact.vcf",
+            ContentType = "text/vcard",
+            Content = Encoding.ASCII.GetBytes("BEGIN:VCARD\r\nVERSION:4.0\r\nEND:VCARD\r\n")
+        };
+        semanticPart.Length = semanticPart.Content.Length;
+        semanticPart.IsProjectedSemanticContent = true;
+        source.Attachments.Add(semanticPart);
+
+        EmailDocument result = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(source, EmailFileFormat.OutlookMsg)).Document;
+
+        Assert.Empty(result.Attachments);
+        Assert.False(Assert.IsType<bool>(result.MapiProperties.Single(property =>
+            property.PropertyId == 0x0E1B).Value));
+        int flags = Assert.IsType<int>(result.MapiProperties.Single(property =>
+            property.PropertyId == 0x0E07).Value);
+        Assert.Equal(0, flags & 0x0010);
+    }
+
     private static byte[] CreateMinimalTnef() {
         byte[] subject = Encoding.ASCII.GetBytes("nested\0");
         using var stream = new MemoryStream();

--- a/OfficeIMO.Email.Tests/Msg/MsgSerializationRegressionTests.cs
+++ b/OfficeIMO.Email.Tests/Msg/MsgSerializationRegressionTests.cs
@@ -5,6 +5,22 @@ namespace OfficeIMO.Email.Tests;
 
 public sealed class MsgSerializationRegressionTests {
     [Fact]
+    public void PreservesUnknownMessageFlagBitsWhileUpdatingManagedFlags() {
+        const int unknownFlag = 0x20000000;
+        var source = new EmailDocument { Format = EmailFileFormat.OutlookMsg, Subject = "Flags" };
+        source.MapiProperties.Add(new MapiProperty(0x0E07, MapiPropertyType.Integer32, unknownFlag));
+        source.MessageMetadata.IsDraft = true;
+
+        EmailDocument result = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(source, EmailFileFormat.OutlookMsg)).Document;
+        int flags = Assert.IsType<int>(result.MapiProperties.Single(property =>
+            property.PropertyId == 0x0E07).Value);
+
+        Assert.NotEqual(0, flags & unknownFlag);
+        Assert.True(result.MessageMetadata.IsDraft);
+    }
+
+    [Fact]
     public void ClearingManagedValuesRemovesRetainedMsgProperties() {
         var source = new EmailDocument {
             Subject = "retained subject",

--- a/OfficeIMO.Email.Tests/Packaging/EmailPackagingContractTests.cs
+++ b/OfficeIMO.Email.Tests/Packaging/EmailPackagingContractTests.cs
@@ -46,6 +46,16 @@ public sealed class EmailPackagingContractTests {
         Assert.Contains(references, name => string.Equals(name, "System.Text.Encoding.CodePages", StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public void ExistingOptionsConstructorSignaturesRemainAvailable() {
+        Assert.NotNull(typeof(EmailWriterOptions).GetConstructor(new[] {
+            typeof(bool), typeof(bool), typeof(int), typeof(int), typeof(long)
+        }));
+        Assert.NotNull(typeof(EmailMailboxReaderOptions).GetConstructor(new[] {
+            typeof(EmailReaderOptions), typeof(MboxVariant), typeof(int)
+        }));
+    }
+
     private static string GetRepositoryRoot() {
         DirectoryInfo? directory = new DirectoryInfo(AppContext.BaseDirectory);
         while (directory != null) {

--- a/OfficeIMO.Email.Tests/Tnef/EmailTnefTests.cs
+++ b/OfficeIMO.Email.Tests/Tnef/EmailTnefTests.cs
@@ -50,6 +50,7 @@ public sealed class EmailTnefTests {
         Assert.Equal("child", result.Document.Attachments[1].EmbeddedDocument!.Subject);
         Assert.True(result.Document.Attachments[1].Length > 0);
         Assert.Equal(new byte[] { 9, 8, 7 }, result.Document.Attachments[2].StructuredStorageStreams["Contents"]);
+        Assert.NotNull(result.Document.Attachments[2].Content);
         Assert.Contains(result.Document.TnefAttributes, attribute => attribute.Tag == 0x0006F001);
         Assert.Equal(classId, result.Document.MapiProperties.Single(property => property.PropertyId == 0x66AB).Value);
         Assert.Equal(42, result.Document.MapiProperties.Single(property => property.PropertyId == 0x66AC).Value);
@@ -168,6 +169,41 @@ public sealed class EmailTnefTests {
 
         Assert.Equal(raw, property.RawData);
         Assert.Equal("€", property.Value);
+    }
+
+    [Fact]
+    public void RoundTripsStringNamedMapiPropertyUsingItsByteLength() {
+        Guid propertySet = new Guid("00020329-0000-0000-C000-000000000046");
+        var source = new MapiProperty(0x8001, MapiPropertyType.Unicode, "named value",
+            name: new MapiNamedProperty(propertySet, "UnicodeName"));
+        var diagnostics = new List<EmailDiagnostic>();
+
+        byte[] bytes = TnefMapiCodec.WriteProperties(new[] { source }, 1252, diagnostics, "tnef/mapi");
+        var state = new MsgParserState(EmailReaderOptions.Default, diagnostics, CancellationToken.None);
+        MapiProperty parsed = Assert.Single(TnefMapiCodec.ReadProperties(bytes, 1252, state, "tnef/mapi"));
+
+        Assert.Equal("UnicodeName", parsed.Name!.Name);
+        Assert.Equal("named value", parsed.Value);
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Severity == EmailDiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void IgnoresTrailingBytesAfterCompleteTnefAttributes() {
+        var source = new EmailDocument { Format = EmailFileFormat.Tnef, Subject = "trailing bytes" };
+        byte[] valid = new EmailDocumentWriter().ToBytes(source, EmailFileFormat.Tnef);
+        byte[] withTrailingBytes = valid.Concat(new byte[] { 0x7F, 2, 3, 4 }).ToArray();
+
+        EmailReadResult result = new EmailDocumentReader().Read(withTrailingBytes);
+
+        Assert.Equal("trailing bytes", result.Document.Subject);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "EMAIL_TNEF_TRAILING_DATA_IGNORED" &&
+            diagnostic.Severity == EmailDiagnosticSeverity.Warning);
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Severity == EmailDiagnosticSeverity.Error);
+
+        byte[] truncatedAttribute = valid.Concat(new byte[] { 1, 2, 3, 4 }).ToArray();
+        EmailReadResult truncated = new EmailDocumentReader().Read(truncatedAttribute);
+        Assert.Contains(truncated.Diagnostics, diagnostic => diagnostic.Code == "EMAIL_TNEF_ATTRIBUTE_TRUNCATED" &&
+            diagnostic.Severity == EmailDiagnosticSeverity.Error);
     }
 
     [Fact]

--- a/OfficeIMO.Email.Tests/Tnef/EmailTnefTests.cs
+++ b/OfficeIMO.Email.Tests/Tnef/EmailTnefTests.cs
@@ -6,6 +6,49 @@ using Xunit;
 namespace OfficeIMO.Email.Tests;
 
 public sealed class EmailTnefTests {
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void BlocksUnmanagedRawTnefAttributesBeforeMsgConversion(bool attachmentAttribute) {
+        var source = new EmailDocument { Format = EmailFileFormat.Tnef, Subject = "raw attributes" };
+        source.Body.Text = "body";
+        if (attachmentAttribute) {
+            var attachment = new EmailAttachment {
+                FileName = "data.bin", Content = new byte[] { 1, 2, 3 }, Length = 3
+            };
+            attachment.TnefAttributes.Add(new TnefAttribute(
+                TnefAttributeLevel.Attachment, 0x0006F002, new byte[] { 4, 5 }));
+            source.Attachments.Add(attachment);
+        } else {
+            source.TnefAttributes.Add(new TnefAttribute(
+                TnefAttributeLevel.Message, 0x0006F001, new byte[] { 7, 8 }));
+        }
+        EmailDocument parsed = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(source, EmailFileFormat.Tnef)).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            parsed, EmailFileFormat.OutlookMsg);
+
+        Assert.False(report.CanWrite);
+        Assert.Contains(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_TNEF_ATTRIBUTES_NOT_REPRESENTED_IN_MSG");
+    }
+
+    [Fact]
+    public void AllowsManagedTnefAttributesBeforeMsgConversion() {
+        var source = new EmailDocument { Format = EmailFileFormat.Tnef, Subject = "managed attributes" };
+        source.Body.Text = "body";
+        EmailDocument parsed = new EmailDocumentReader().Read(
+            new EmailDocumentWriter().ToBytes(source, EmailFileFormat.Tnef)).Document;
+
+        EmailConversionReport report = new EmailDocumentWriter().AnalyzeConversion(
+            parsed, EmailFileFormat.OutlookMsg);
+
+        Assert.True(report.CanWrite);
+        Assert.DoesNotContain(report.Diagnostics,
+            diagnostic => diagnostic.Code == "EMAIL_TNEF_ATTRIBUTES_NOT_REPRESENTED_IN_MSG");
+    }
+
     [Fact]
     public void RoundTripsMessageMapiRecipientsAndAttachmentKinds() {
         DateTimeOffset start = new DateTimeOffset(2026, 10, 3, 9, 0, 0, TimeSpan.Zero);

--- a/OfficeIMO.Email.Tests/Writing/EmailContentSourceTests.cs
+++ b/OfficeIMO.Email.Tests/Writing/EmailContentSourceTests.cs
@@ -1,0 +1,61 @@
+using OfficeIMO.Email;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Email.Tests;
+
+public sealed class EmailContentSourceTests {
+    [Theory]
+    [InlineData(EmailFileFormat.Eml)]
+    [InlineData(EmailFileFormat.OutlookMsg)]
+    [InlineData(EmailFileFormat.Tnef)]
+    public void WritersConsumeReopenableAttachmentSources(EmailFileFormat format) {
+        byte[] payload = Encoding.UTF8.GetBytes("lazy attachment");
+        var source = new CountingContentSource(payload);
+        var document = new EmailDocument { Format = format, Subject = "lazy" };
+        document.Attachments.Add(new EmailAttachment {
+            FileName = "lazy.txt",
+            ContentType = "text/plain",
+            ContentSource = source,
+            Length = payload.Length
+        });
+
+        byte[] artifact = new EmailDocumentWriter().ToBytes(document, format);
+        EmailAttachment attachment = Assert.Single(new EmailDocumentReader().Read(artifact).Document.Attachments);
+
+        Assert.Equal(payload, attachment.Content);
+        Assert.Equal(1, source.OpenCount);
+    }
+
+    [Fact]
+    public async Task AttachmentCanOpenSourceSynchronouslyAndAsynchronously() {
+        byte[] payload = new byte[] { 1, 2, 3 };
+        var attachment = new EmailAttachment { ContentSource = new CountingContentSource(payload) };
+
+        using Stream synchronous = attachment.OpenContentStream();
+        using Stream asynchronous = await attachment.OpenContentStreamAsync();
+
+        Assert.Equal(payload, ReadAll(synchronous));
+        Assert.Equal(payload, ReadAll(asynchronous));
+    }
+
+    private static byte[] ReadAll(Stream stream) {
+        using var output = new MemoryStream();
+        stream.CopyTo(output);
+        return output.ToArray();
+    }
+
+    private sealed class CountingContentSource : IEmailContentSource {
+        private readonly byte[] _content;
+        internal CountingContentSource(byte[] content) { _content = content; }
+        public long? Length => _content.LongLength;
+        internal int OpenCount { get; private set; }
+        public Stream OpenRead() { OpenCount++; return new MemoryStream(_content, writable: false); }
+        public Task<Stream> OpenReadAsync(CancellationToken cancellationToken = default) {
+            cancellationToken.ThrowIfCancellationRequested();
+            OpenCount++;
+            return Task.FromResult<Stream>(new MemoryStream(_content, writable: false));
+        }
+    }
+}

--- a/OfficeIMO.Email.Tests/Writing/EmailWriterSafetyTests.cs
+++ b/OfficeIMO.Email.Tests/Writing/EmailWriterSafetyTests.cs
@@ -39,4 +39,30 @@ public sealed class EmailWriterSafetyTests {
         Assert.Equal(nameof(EmailWriterOptions.MaxOutputBytes), exception.LimitName);
         Assert.Equal(4096, exception.ActualValue);
     }
+
+    [Theory]
+    [InlineData(EmailFileFormat.OutlookMsg)]
+    [InlineData(EmailFileFormat.Tnef)]
+    public void IgnoresProjectedSemanticSourcesThatStoreWritersOmit(EmailFileFormat format) {
+        const int maxOutputBytes = 256 * 1024;
+        var document = new EmailDocument {
+            Format = EmailFileFormat.Eml,
+            OutlookItemKind = OutlookItemKind.Appointment,
+            Appointment = new OutlookAppointment {
+                Start = new DateTimeOffset(2026, 8, 1, 10, 0, 0, TimeSpan.Zero)
+            }
+        };
+        document.Attachments.Add(new EmailAttachment {
+            ContentType = "text/calendar",
+            Content = new byte[1024 * 1024],
+            Length = 1024 * 1024,
+            IsProjectedSemanticContent = true,
+            IsMimeBodyPart = true
+        });
+        var writer = new EmailDocumentWriter(new EmailWriterOptions(maxOutputBytes: maxOutputBytes));
+
+        byte[] output = writer.ToBytes(document, format);
+
+        Assert.InRange(output.Length, 1, maxOutputBytes);
+    }
 }

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.Parsing.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.Parsing.cs
@@ -21,11 +21,23 @@ internal static partial class IcsCalendarCodec {
             for (int index = 1; index < tokens.Count; index++) {
                 int equals = FindUnquotedSeparator(tokens[index], '=');
                 if (equals > 0) property.Parameters[tokens[index].Substring(0, equals).Trim()] =
-                    tokens[index].Substring(equals + 1).Trim().Trim('"');
+                    DecodeParameterValue(tokens[index].Substring(equals + 1));
             }
             result.Add(property);
         }
         return result;
+    }
+
+    private static string DecodeParameterValue(string value) {
+        string trimmed = value.Trim();
+        if (trimmed.Length < 2 || trimmed[0] != '"' || trimmed[trimmed.Length - 1] != '"') return trimmed;
+        var result = new StringBuilder(trimmed.Length - 2);
+        for (int index = 1; index < trimmed.Length - 1; index++) {
+            char character = trimmed[index];
+            if (character == '\\' && index + 1 < trimmed.Length - 1) result.Append(trimmed[++index]);
+            else result.Append(character);
+        }
+        return result.ToString();
     }
 
     private static IReadOnlyList<IcsProperty> SelectActiveComponentProperties(

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.Parsing.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.Parsing.cs
@@ -1,0 +1,128 @@
+namespace OfficeIMO.Email;
+
+internal static partial class IcsCalendarCodec {
+    private static List<IcsProperty> ParseProperties(string text) {
+        string normalized = text.Replace("\r\n", "\n").Replace('\r', '\n');
+        var unfolded = new List<string>();
+        foreach (string line in normalized.Split('\n')) {
+            if (line.Length > 0 && (line[0] == ' ' || line[0] == '\t') && unfolded.Count > 0) {
+                unfolded[unfolded.Count - 1] += line.Substring(1);
+            } else {
+                unfolded.Add(line);
+            }
+        }
+
+        var result = new List<IcsProperty>();
+        foreach (string line in unfolded) {
+            int colon = FindUnquotedSeparator(line, ':');
+            if (colon <= 0) continue;
+            IReadOnlyList<string> tokens = SplitUnquoted(line.Substring(0, colon), ';');
+            var property = new IcsProperty(tokens[0].Trim().ToUpperInvariant(), line.Substring(colon + 1));
+            for (int index = 1; index < tokens.Count; index++) {
+                int equals = FindUnquotedSeparator(tokens[index], '=');
+                if (equals > 0) property.Parameters[tokens[index].Substring(0, equals).Trim()] =
+                    tokens[index].Substring(equals + 1).Trim().Trim('"');
+            }
+            result.Add(property);
+        }
+        return result;
+    }
+
+    private static IReadOnlyList<IcsProperty> SelectActiveComponentProperties(
+        IReadOnlyList<IcsProperty> properties, string componentName) {
+        var selected = new List<IcsProperty>();
+        var components = new List<string>();
+        int activeDepth = -1;
+        bool selectedComponent = false;
+        foreach (IcsProperty property in properties) {
+            if (property.Name == "BEGIN") {
+                components.Add(property.Value.Trim().ToUpperInvariant());
+                if (!selectedComponent && property.Value.Equals(componentName, StringComparison.OrdinalIgnoreCase)) {
+                    activeDepth = components.Count;
+                    selectedComponent = true;
+                }
+                continue;
+            }
+            if (property.Name == "END") {
+                if (components.Count == activeDepth &&
+                    property.Value.Equals(componentName, StringComparison.OrdinalIgnoreCase)) activeDepth = -1;
+                if (components.Count > 0) components.RemoveAt(components.Count - 1);
+                continue;
+            }
+
+            bool calendarProperty = components.Count == 1 &&
+                components[0].Equals("VCALENDAR", StringComparison.OrdinalIgnoreCase);
+            bool componentProperty = activeDepth > 0 && components.Count == activeDepth;
+            bool alarmTrigger = activeDepth > 0 && components.Count == activeDepth + 1 &&
+                components[components.Count - 1].Equals("VALARM", StringComparison.OrdinalIgnoreCase) &&
+                property.Name == "TRIGGER";
+            if (calendarProperty || componentProperty || alarmTrigger) selected.Add(property);
+        }
+        return selected;
+    }
+
+    private static int FindUnquotedSeparator(string value, char separator) {
+        bool quoted = false;
+        bool escaped = false;
+        for (int index = 0; index < value.Length; index++) {
+            char character = value[index];
+            if (escaped) escaped = false;
+            else if (character == '\\') escaped = true;
+            else if (character == '"') quoted = !quoted;
+            else if (!quoted && character == separator) return index;
+        }
+        return -1;
+    }
+
+    private static IReadOnlyList<string> SplitUnquoted(string value, char separator) {
+        var result = new List<string>();
+        int start = 0;
+        while (start <= value.Length) {
+            int relative = FindUnquotedSeparator(value.Substring(start), separator);
+            if (relative < 0) {
+                result.Add(value.Substring(start));
+                break;
+            }
+            result.Add(value.Substring(start, relative));
+            start += relative + 1;
+        }
+        return result;
+    }
+
+    private static DateTimeOffset? ParseDate(IcsProperty? property, IList<EmailDiagnostic> diagnostics,
+        string location, out bool isDateOnly) {
+        isDateOnly = property != null && property.Parameters.TryGetValue("VALUE", out string? valueType) &&
+            string.Equals(valueType, "DATE", StringComparison.OrdinalIgnoreCase);
+        if (property == null || string.IsNullOrWhiteSpace(property.Value)) return null;
+        string value = property.Value.Trim();
+        if (isDateOnly && DateTime.TryParseExact(value, "yyyyMMdd", CultureInfo.InvariantCulture,
+            DateTimeStyles.None, out DateTime date)) return new DateTimeOffset(date, TimeSpan.Zero);
+        if (DateTimeOffset.TryParseExact(value, new[] { "yyyyMMdd'T'HHmmss'Z'", "yyyyMMdd'T'HHmm'Z'" },
+            CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out DateTimeOffset utc)) return utc;
+        if (DateTime.TryParseExact(value, new[] { "yyyyMMdd'T'HHmmss", "yyyyMMdd'T'HHmm" },
+            CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime local)) {
+            if (property.Parameters.TryGetValue("TZID", out string? timeZoneId)) {
+                try {
+                    TimeZoneInfo zone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+                    return new DateTimeOffset(local, zone.GetUtcOffset(local));
+                } catch (TimeZoneNotFoundException) {
+                } catch (InvalidTimeZoneException) {
+                }
+                diagnostics.Add(new EmailDiagnostic("EMAIL_ICALENDAR_TIMEZONE_UNRESOLVED",
+                    string.Concat("The iCalendar time zone '", timeZoneId,
+                        "' could not be resolved and the local clock value was interpreted as UTC."),
+                    EmailDiagnosticSeverity.Warning, location));
+                return new DateTimeOffset(local, TimeSpan.Zero);
+            }
+            diagnostics.Add(new EmailDiagnostic("EMAIL_ICALENDAR_FLOATING_TIME",
+                "A floating iCalendar time could not be associated with a known time zone and was interpreted as UTC.",
+                EmailDiagnosticSeverity.Warning, location));
+            return new DateTimeOffset(local, TimeSpan.Zero);
+        }
+        diagnostics.Add(new EmailDiagnostic("EMAIL_ICALENDAR_DATE_INVALID",
+            string.Concat("The iCalendar value '", value, "' could not be parsed."),
+            EmailDiagnosticSeverity.Warning, location));
+        return null;
+    }
+}

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.Parsing.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.Parsing.cs
@@ -61,6 +61,38 @@ internal static partial class IcsCalendarCodec {
         return selected;
     }
 
+    private static IReadOnlyList<IcsProperty> SelectActiveAlarmProperties(
+        IReadOnlyList<IcsProperty> properties, string componentName) {
+        var selected = new List<IcsProperty>();
+        var components = new List<string>();
+        int activeComponentDepth = -1;
+        int activeAlarmDepth = -1;
+        bool selectedComponent = false;
+        foreach (IcsProperty property in properties) {
+            if (property.Name == "BEGIN") {
+                components.Add(property.Value.Trim().ToUpperInvariant());
+                if (!selectedComponent && property.Value.Equals(componentName, StringComparison.OrdinalIgnoreCase)) {
+                    activeComponentDepth = components.Count;
+                    selectedComponent = true;
+                } else if (activeComponentDepth > 0 && components.Count == activeComponentDepth + 1 &&
+                           property.Value.Equals("VALARM", StringComparison.OrdinalIgnoreCase)) {
+                    activeAlarmDepth = components.Count;
+                }
+                continue;
+            }
+            if (property.Name == "END") {
+                if (components.Count == activeAlarmDepth &&
+                    property.Value.Equals("VALARM", StringComparison.OrdinalIgnoreCase)) activeAlarmDepth = -1;
+                if (components.Count == activeComponentDepth &&
+                    property.Value.Equals(componentName, StringComparison.OrdinalIgnoreCase)) activeComponentDepth = -1;
+                if (components.Count > 0) components.RemoveAt(components.Count - 1);
+                continue;
+            }
+            if (activeAlarmDepth > 0 && components.Count == activeAlarmDepth) selected.Add(property);
+        }
+        return selected;
+    }
+
     private static int FindUnquotedSeparator(string value, char separator) {
         bool quoted = false;
         bool escaped = false;

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.Projection.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.Projection.cs
@@ -24,6 +24,7 @@ internal static partial class IcsCalendarCodec {
             : calendarSummary;
         return calendarRoots != 1 || calendarItems > 1 || alarms > 1 || hasTimeZone || hasUnsupportedComponent ||
             hasUnsupportedVersion ||
+            activeProperties.Any(HasUnpreservedPropertyParameters) ||
             HasIncompleteAlarmProjection(alarms, alarmProperties, reminderDescription) ||
             activeProperties.Any(property =>
                 property.Name == "RRULE" || property.Name == "RDATE" ||
@@ -45,6 +46,23 @@ internal static partial class IcsCalendarCodec {
                 property.Parameters.TryGetValue("RELATED", out string? related) &&
                 related.Equals("END", StringComparison.OrdinalIgnoreCase));
     }
+
+    private static bool HasUnpreservedPropertyParameters(IcsProperty property) {
+        if (property.Parameters.Count == 0) return false;
+        if (property.Name == "ATTENDEE") return HasIncompleteAttendeeProjection(property);
+        if (property.Name == "ORGANIZER") return HasIncompleteOrganizerProjection(property);
+        if (property.Name == "TRIGGER") return false;
+        if (!IsCalendarDateProperty(property.Name)) return true;
+        return property.Parameters.Keys.Any(parameter =>
+            !parameter.Equals("VALUE", StringComparison.OrdinalIgnoreCase) &&
+            !parameter.Equals("TZID", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool IsCalendarDateProperty(string name) => name == "DTSTART" || name == "DTEND" ||
+        name == "DUE" || name == "COMPLETED" || name == "DTSTAMP" ||
+        name == "X-OFFICEIMO-COMMON-START" || name == "X-OFFICEIMO-COMMON-END" ||
+        name == "X-OFFICEIMO-TODO-ORDINAL-DATE" || name == "X-OFFICEIMO-REMINDER-TIME" ||
+        name == "X-OFFICEIMO-REMINDER-SIGNAL-TIME";
 
     private static bool HasIncompleteTimestampProjection(IEnumerable<IcsProperty> activeProperties,
         EmailDocument document, bool isEvent, IList<EmailDiagnostic> diagnostics, string location) {

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.Projection.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.Projection.cs
@@ -15,11 +15,15 @@ internal static partial class IcsCalendarCodec {
             property.Value.Equals("VTIMEZONE", StringComparison.OrdinalIgnoreCase));
         bool hasUnsupportedComponent = properties.Any(property => property.Name == "BEGIN" &&
             !IsSupportedComponent(property.Value));
+        IcsProperty[] versions = properties.Where(property => property.Name == "VERSION").ToArray();
+        bool hasUnsupportedVersion = versions.Length != 1 ||
+            !versions[0].Value.Trim().Equals("2.0", StringComparison.OrdinalIgnoreCase);
         string? calendarSummary = Unescape(GetValue(activeProperties, "SUMMARY"));
         string? reminderDescription = string.IsNullOrWhiteSpace(calendarSummary)
             ? envelopeSubject
             : calendarSummary;
         return calendarRoots != 1 || calendarItems > 1 || alarms > 1 || hasTimeZone || hasUnsupportedComponent ||
+            hasUnsupportedVersion ||
             HasIncompleteAlarmProjection(alarms, alarmProperties, reminderDescription) ||
             activeProperties.Any(property =>
                 property.Name == "RRULE" || property.Name == "RDATE" ||
@@ -30,7 +34,7 @@ internal static partial class IcsCalendarCodec {
                 property.Name == "CLASS" && !ParseCalendarSensitivity(property.Value).HasValue ||
                 isEvent && property.Name == "STATUS" ||
                 property.Name == "PRIORITY" || property.Name == "URL" ||
-                property.Name == "LOCATION" && property.Parameters.Count > 0 ||
+                property.Name == "LOCATION" && (!isEvent || property.Parameters.Count > 0) ||
                 !isEvent && property.Name == "SEQUENCE" ||
                 !isEvent && IsDateOnlyTaskProperty(property) ||
                 property.Name == "ATTENDEE" && HasIncompleteAttendeeProjection(property) ||

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.Projection.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.Projection.cs
@@ -1,9 +1,24 @@
 namespace OfficeIMO.Email;
 
 internal static partial class IcsCalendarCodec {
+    private static readonly HashSet<string> ProjectedCalendarExtensions = new HashSet<string>(
+        StringComparer.OrdinalIgnoreCase) {
+            "X-MICROSOFT-CDO-BUSYSTATUS", "X-MICROSOFT-DISALLOW-COUNTER",
+            "X-OFFICEIMO-ACCEPTANCE-STATE", "X-OFFICEIMO-ACTUAL-EFFORT", "X-OFFICEIMO-ASSIGNER",
+            "X-OFFICEIMO-BILLING-INFORMATION", "X-OFFICEIMO-CLIENT-INTENT", "X-OFFICEIMO-COMMON-END",
+            "X-OFFICEIMO-COMMON-START", "X-OFFICEIMO-COMPANY", "X-OFFICEIMO-ESTIMATED-EFFORT",
+            "X-OFFICEIMO-MEETING-STATUS", "X-OFFICEIMO-MILEAGE", "X-OFFICEIMO-ORDINAL",
+            "X-OFFICEIMO-OWNERSHIP", "X-OFFICEIMO-REMINDER-SET", "X-OFFICEIMO-REMINDER-SIGNAL-TIME",
+            "X-OFFICEIMO-REMINDER-TIME", "X-OFFICEIMO-RESPONSE-STATUS",
+            "X-OFFICEIMO-SEND-STATUS-ON-COMPLETE", "X-OFFICEIMO-SEND-UPDATES", "X-OFFICEIMO-TASK-MODE",
+            "X-OFFICEIMO-TASK-OWNER", "X-OFFICEIMO-TASK-STATE", "X-OFFICEIMO-TASK-VERSION",
+            "X-OFFICEIMO-TEAM-TASK", "X-OFFICEIMO-TIMEZONE-DESCRIPTION",
+            "X-OFFICEIMO-TODO-ORDINAL-DATE", "X-OFFICEIMO-TODO-SUBORDINAL"
+        };
+
     private static bool HasIncompleteStoreProjection(IEnumerable<IcsProperty> properties,
         IEnumerable<IcsProperty> activeProperties, IReadOnlyList<IcsProperty> alarmProperties, bool isEvent,
-        string? envelopeSubject) {
+        string? envelopeSubject, EmailAddress? envelopeFrom) {
         int calendarItems = properties.Count(property => property.Name == "BEGIN" &&
             (property.Value.Equals("VEVENT", StringComparison.OrdinalIgnoreCase) ||
              property.Value.Equals("VTODO", StringComparison.OrdinalIgnoreCase)));
@@ -22,9 +37,16 @@ internal static partial class IcsCalendarCodec {
         string? reminderDescription = string.IsNullOrWhiteSpace(calendarSummary)
             ? envelopeSubject
             : calendarSummary;
+        bool hasConflictingEnvelopeSubject = !string.IsNullOrWhiteSpace(envelopeSubject) &&
+            !string.Equals(envelopeSubject, calendarSummary, StringComparison.Ordinal);
+        bool wouldSynthesizeOrganizer = isEvent && !string.IsNullOrWhiteSpace(envelopeFrom?.Address) &&
+            !activeProperties.Any(property => property.Name == "ORGANIZER");
         return calendarRoots != 1 || calendarItems > 1 || alarms > 1 || hasTimeZone || hasUnsupportedComponent ||
-            hasUnsupportedVersion ||
+            hasUnsupportedVersion || hasConflictingEnvelopeSubject || wouldSynthesizeOrganizer ||
+            HasDuplicateAttendeeAddresses(activeProperties) ||
             activeProperties.Any(HasUnpreservedPropertyParameters) ||
+            activeProperties.Any(property => property.Name.StartsWith("X-", StringComparison.OrdinalIgnoreCase) &&
+                !ProjectedCalendarExtensions.Contains(property.Name)) ||
             HasIncompleteAlarmProjection(alarms, alarmProperties, reminderDescription) ||
             activeProperties.Any(property =>
                 property.Name == "RRULE" || property.Name == "RDATE" ||
@@ -42,7 +64,7 @@ internal static partial class IcsCalendarCodec {
                 property.Name == "ATTENDEE" && HasIncompleteAttendeeProjection(property) ||
                 property.Name == "ORGANIZER" && HasIncompleteOrganizerProjection(property) ||
                 (property.Name == "ORGANIZER" || property.Name == "ATTENDEE") &&
-                IsNonMailtoCalendarAddress(property.Value) ||
+                IsUnprojectableCalendarAddress(property.Value) ||
                 property.Name == "ATTACH" || property.Name == "TRIGGER" &&
                 property.Parameters.TryGetValue("RELATED", out string? related) &&
                 related.Equals("END", StringComparison.OrdinalIgnoreCase));
@@ -142,12 +164,21 @@ internal static partial class IcsCalendarCodec {
         organizer.Parameters.Keys.Any(parameter =>
             !parameter.Equals("CN", StringComparison.OrdinalIgnoreCase));
 
-    private static bool IsNonMailtoCalendarAddress(string? value) {
-        if (string.IsNullOrWhiteSpace(value)) return false;
+    private static bool HasDuplicateAttendeeAddresses(IEnumerable<IcsProperty> properties) {
+        var addresses = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (IcsProperty attendee in properties.Where(property => property.Name == "ATTENDEE")) {
+            string? address = StripMailTo(attendee.Value);
+            if (!string.IsNullOrWhiteSpace(address) && !addresses.Add(address!)) return true;
+        }
+        return false;
+    }
+
+    private static bool IsUnprojectableCalendarAddress(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) return true;
         string address = value!.Trim();
-        if (address.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)) return false;
-        return Uri.TryCreate(address, UriKind.Absolute, out Uri? uri) &&
-            !uri.Scheme.Equals("mailto", StringComparison.OrdinalIgnoreCase);
+        if (!address.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)) return true;
+        string mailbox = address.Substring(7);
+        return mailbox.Length == 0 || mailbox.IndexOf('?') >= 0 || mailbox.IndexOf('#') >= 0;
     }
 
     private static bool IsStoreProjectableTaskMethod(string? method) => string.IsNullOrWhiteSpace(method) ||

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.Projection.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.Projection.cs
@@ -1,6 +1,11 @@
 namespace OfficeIMO.Email;
 
 internal static partial class IcsCalendarCodec {
+    private static readonly HashSet<string> RepeatableProjectedCalendarProperties = new HashSet<string>(
+        StringComparer.OrdinalIgnoreCase) {
+            "ATTENDEE", "CATEGORIES", "CONTACT", "X-OFFICEIMO-COMPANY"
+        };
+
     private static readonly HashSet<string> ProjectedCalendarExtensions = new HashSet<string>(
         StringComparer.OrdinalIgnoreCase) {
             "X-MICROSOFT-CDO-BUSYSTATUS", "X-MICROSOFT-DISALLOW-COUNTER",
@@ -44,6 +49,8 @@ internal static partial class IcsCalendarCodec {
         return calendarRoots != 1 || calendarItems > 1 || alarms > 1 || hasTimeZone || hasUnsupportedComponent ||
             hasUnsupportedVersion || hasConflictingEnvelopeSubject || wouldSynthesizeOrganizer ||
             HasDuplicateAttendeeAddresses(activeProperties) ||
+            HasDuplicateCalendarSingletons(activeProperties) ||
+            activeProperties.Any(property => property.Name.IndexOf('.') >= 0) ||
             activeProperties.Any(HasUnpreservedPropertyParameters) ||
             activeProperties.Any(property => property.Name.StartsWith("X-", StringComparison.OrdinalIgnoreCase) &&
                 !ProjectedCalendarExtensions.Contains(property.Name)) ||
@@ -51,7 +58,7 @@ internal static partial class IcsCalendarCodec {
             activeProperties.Any(property =>
                 property.Name == "RRULE" || property.Name == "RDATE" ||
                 property.Name == "EXDATE" || property.Name == "RECURRENCE-ID" ||
-                property.Name == "RELATED-TO" ||
+                property.Name == "RELATED-TO" || property.Name == "REQUEST-STATUS" ||
                 property.Name == "CREATED" || property.Name == "LAST-MODIFIED" ||
                 property.Name == "COMMENT" || property.Name == "RESOURCES" || property.Name == "GEO" ||
                 isEvent && property.Name == "CONTACT" ||
@@ -172,6 +179,11 @@ internal static partial class IcsCalendarCodec {
         }
         return false;
     }
+
+    private static bool HasDuplicateCalendarSingletons(IEnumerable<IcsProperty> properties) =>
+        properties.Where(property => !RepeatableProjectedCalendarProperties.Contains(property.Name))
+            .GroupBy(property => property.Name, StringComparer.OrdinalIgnoreCase)
+            .Any(group => group.Skip(1).Any());
 
     private static bool IsUnprojectableCalendarAddress(string? value) {
         if (string.IsNullOrWhiteSpace(value)) return true;

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.Projection.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.Projection.cs
@@ -27,11 +27,27 @@ internal static partial class IcsCalendarCodec {
                 property.Name == "CLASS" && !ParseCalendarSensitivity(property.Value).HasValue ||
                 isEvent && property.Name == "STATUS" ||
                 property.Name == "PRIORITY" || property.Name == "URL" ||
+                !isEvent && property.Name == "SEQUENCE" ||
                 !isEvent && IsDateOnlyTaskProperty(property) ||
                 property.Name == "ATTENDEE" && HasIncompleteAttendeeProjection(property) ||
+                property.Name == "ORGANIZER" && HasIncompleteOrganizerProjection(property) ||
+                (property.Name == "ORGANIZER" || property.Name == "ATTENDEE") &&
+                IsNonMailtoCalendarAddress(property.Value) ||
                 property.Name == "ATTACH" || property.Name == "TRIGGER" &&
                 property.Parameters.TryGetValue("RELATED", out string? related) &&
                 related.Equals("END", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool HasIncompleteTimestampProjection(IEnumerable<IcsProperty> activeProperties,
+        EmailDocument document, bool isEvent, IList<EmailDiagnostic> diagnostics, string location) {
+        IcsProperty? timestamp = GetProperty(activeProperties, "DTSTAMP");
+        if (timestamp == null) return false;
+        DateTimeOffset? parsed = ParseDate(timestamp, diagnostics, location, out bool isDateOnly);
+        if (!parsed.HasValue || isDateOnly) return true;
+        DateTimeOffset expected = document.Date ?? (isEvent
+            ? document.Appointment?.Start
+            : document.Task?.Start ?? document.Task?.Due) ?? DeterministicEpoch;
+        return !string.Equals(FormatUtc(parsed.Value), FormatUtc(expected), StringComparison.Ordinal);
     }
 
     private static bool IsDateOnlyTaskProperty(IcsProperty property) {
@@ -93,6 +109,22 @@ internal static partial class IcsCalendarCodec {
         }
         return false;
     }
+
+    private static bool HasIncompleteOrganizerProjection(IcsProperty organizer) =>
+        organizer.Parameters.Keys.Any(parameter =>
+            !parameter.Equals("CN", StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsNonMailtoCalendarAddress(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) return false;
+        string address = value!.Trim();
+        if (address.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)) return false;
+        return Uri.TryCreate(address, UriKind.Absolute, out Uri? uri) &&
+            !uri.Scheme.Equals("mailto", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsStoreProjectableTaskMethod(string? method) => string.IsNullOrWhiteSpace(method) ||
+        string.Equals(method, "PUBLISH", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(method, "REQUEST", StringComparison.OrdinalIgnoreCase);
 
     private static bool IsSupportedComponent(string value) =>
         value.Equals("VCALENDAR", StringComparison.OrdinalIgnoreCase) ||

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.Projection.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.Projection.cs
@@ -38,6 +38,7 @@ internal static partial class IcsCalendarCodec {
         IcsProperty[] versions = properties.Where(property => property.Name == "VERSION").ToArray();
         bool hasUnsupportedVersion = versions.Length != 1 ||
             !versions[0].Value.Trim().Equals("2.0", StringComparison.OrdinalIgnoreCase);
+        bool missingEventStart = isEvent && !activeProperties.Any(property => property.Name == "DTSTART");
         string? calendarSummary = Unescape(GetValue(activeProperties, "SUMMARY"));
         string? reminderDescription = string.IsNullOrWhiteSpace(calendarSummary)
             ? envelopeSubject
@@ -47,7 +48,7 @@ internal static partial class IcsCalendarCodec {
         bool wouldSynthesizeOrganizer = isEvent && !string.IsNullOrWhiteSpace(envelopeFrom?.Address) &&
             !activeProperties.Any(property => property.Name == "ORGANIZER");
         return calendarRoots != 1 || calendarItems > 1 || alarms > 1 || hasTimeZone || hasUnsupportedComponent ||
-            hasUnsupportedVersion || hasConflictingEnvelopeSubject || wouldSynthesizeOrganizer ||
+            hasUnsupportedVersion || missingEventStart || hasConflictingEnvelopeSubject || wouldSynthesizeOrganizer ||
             HasDuplicateAttendeeAddresses(activeProperties) ||
             HasDuplicateCalendarSingletons(activeProperties) ||
             activeProperties.Any(property => property.Name.IndexOf('.') >= 0) ||

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.Projection.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.Projection.cs
@@ -30,6 +30,7 @@ internal static partial class IcsCalendarCodec {
                 property.Name == "CLASS" && !ParseCalendarSensitivity(property.Value).HasValue ||
                 isEvent && property.Name == "STATUS" ||
                 property.Name == "PRIORITY" || property.Name == "URL" ||
+                property.Name == "LOCATION" && property.Parameters.Count > 0 ||
                 !isEvent && property.Name == "SEQUENCE" ||
                 !isEvent && IsDateOnlyTaskProperty(property) ||
                 property.Name == "ATTENDEE" && HasIncompleteAttendeeProjection(property) ||
@@ -92,6 +93,9 @@ internal static partial class IcsCalendarCodec {
     }
 
     private static bool HasIncompleteAttendeeProjection(IcsProperty attendee) {
+        bool roomOrResource = attendee.Parameters.TryGetValue("CUTYPE", out string? calendarUserType) &&
+            (calendarUserType.Equals("ROOM", StringComparison.OrdinalIgnoreCase) ||
+             calendarUserType.Equals("RESOURCE", StringComparison.OrdinalIgnoreCase));
         foreach (KeyValuePair<string, string> parameter in attendee.Parameters) {
             if (parameter.Key.Equals("CN", StringComparison.OrdinalIgnoreCase)) continue;
             if (parameter.Key.Equals("CUTYPE", StringComparison.OrdinalIgnoreCase)) {
@@ -101,16 +105,14 @@ internal static partial class IcsCalendarCodec {
                 return true;
             }
             if (!parameter.Key.Equals("ROLE", StringComparison.OrdinalIgnoreCase)) return true;
-            bool roomOrResource = attendee.Parameters.TryGetValue("CUTYPE", out string? calendarUserType) &&
-                (calendarUserType.Equals("ROOM", StringComparison.OrdinalIgnoreCase) ||
-                 calendarUserType.Equals("RESOURCE", StringComparison.OrdinalIgnoreCase));
             if (roomOrResource
                     ? parameter.Value.Equals("NON-PARTICIPANT", StringComparison.OrdinalIgnoreCase)
                     : parameter.Value.Equals("REQ-PARTICIPANT", StringComparison.OrdinalIgnoreCase) ||
                       parameter.Value.Equals("OPT-PARTICIPANT", StringComparison.OrdinalIgnoreCase)) continue;
             return true;
         }
-        return false;
+        return roomOrResource && (!attendee.Parameters.TryGetValue("ROLE", out string? role) ||
+            !role.Equals("NON-PARTICIPANT", StringComparison.OrdinalIgnoreCase));
     }
 
     private static bool HasIncompleteOrganizerProjection(IcsProperty organizer) =>

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.Projection.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.Projection.cs
@@ -1,0 +1,105 @@
+namespace OfficeIMO.Email;
+
+internal static partial class IcsCalendarCodec {
+    private static bool HasIncompleteStoreProjection(IEnumerable<IcsProperty> properties,
+        IEnumerable<IcsProperty> activeProperties, IReadOnlyList<IcsProperty> alarmProperties, bool isEvent,
+        string? envelopeSubject) {
+        int calendarItems = properties.Count(property => property.Name == "BEGIN" &&
+            (property.Value.Equals("VEVENT", StringComparison.OrdinalIgnoreCase) ||
+             property.Value.Equals("VTODO", StringComparison.OrdinalIgnoreCase)));
+        int calendarRoots = properties.Count(property => property.Name == "BEGIN" &&
+            property.Value.Equals("VCALENDAR", StringComparison.OrdinalIgnoreCase));
+        int alarms = properties.Count(property => property.Name == "BEGIN" &&
+            property.Value.Equals("VALARM", StringComparison.OrdinalIgnoreCase));
+        bool hasTimeZone = properties.Any(property => property.Name == "BEGIN" &&
+            property.Value.Equals("VTIMEZONE", StringComparison.OrdinalIgnoreCase));
+        bool hasUnsupportedComponent = properties.Any(property => property.Name == "BEGIN" &&
+            !IsSupportedComponent(property.Value));
+        string? calendarSummary = Unescape(GetValue(activeProperties, "SUMMARY"));
+        string? reminderDescription = string.IsNullOrWhiteSpace(calendarSummary)
+            ? envelopeSubject
+            : calendarSummary;
+        return calendarRoots != 1 || calendarItems > 1 || alarms > 1 || hasTimeZone || hasUnsupportedComponent ||
+            HasIncompleteAlarmProjection(alarms, alarmProperties, reminderDescription) ||
+            activeProperties.Any(property =>
+                property.Name == "RRULE" || property.Name == "RDATE" ||
+                property.Name == "EXDATE" || property.Name == "RECURRENCE-ID" ||
+                property.Name == "CLASS" && !ParseCalendarSensitivity(property.Value).HasValue ||
+                isEvent && property.Name == "STATUS" ||
+                property.Name == "PRIORITY" || property.Name == "URL" ||
+                !isEvent && IsDateOnlyTaskProperty(property) ||
+                property.Name == "ATTENDEE" && HasIncompleteAttendeeProjection(property) ||
+                property.Name == "ATTACH" || property.Name == "TRIGGER" &&
+                property.Parameters.TryGetValue("RELATED", out string? related) &&
+                related.Equals("END", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool IsDateOnlyTaskProperty(IcsProperty property) {
+        if (property.Name != "DTSTART" && property.Name != "DUE" && property.Name != "COMPLETED") return false;
+        if (property.Parameters.TryGetValue("VALUE", out string? valueType) &&
+            valueType.Equals("DATE", StringComparison.OrdinalIgnoreCase)) return true;
+        string value = property.Value.Trim();
+        return value.Length == 8 && value.All(character => character >= '0' && character <= '9');
+    }
+
+    private static bool HasIncompleteAlarmProjection(int alarmCount,
+        IReadOnlyList<IcsProperty> alarmProperties, string? reminderDescription) {
+        if (alarmCount == 0) return false;
+        if (alarmCount != 1) return true;
+        IcsProperty[] actions = alarmProperties.Where(property => property.Name == "ACTION").ToArray();
+        IcsProperty[] triggers = alarmProperties.Where(property => property.Name == "TRIGGER").ToArray();
+        if (actions.Length != 1 || !actions[0].Value.Trim().Equals("DISPLAY", StringComparison.OrdinalIgnoreCase) ||
+            triggers.Length != 1) return true;
+        bool absolute = triggers[0].Parameters.TryGetValue("VALUE", out string? valueType) &&
+            valueType.Equals("DATE-TIME", StringComparison.OrdinalIgnoreCase);
+        if (absolute) {
+            if (string.IsNullOrWhiteSpace(triggers[0].Value) || triggers[0].Parameters.Any(parameter =>
+                    !parameter.Key.Equals("VALUE", StringComparison.OrdinalIgnoreCase))) return true;
+        } else {
+            if (!IcsDurationCodec.Parse(triggers[0].Value).HasValue || triggers[0].Parameters.Any(parameter =>
+                    parameter.Key.Equals("RELATED", StringComparison.OrdinalIgnoreCase)
+                        ? !parameter.Value.Equals("START", StringComparison.OrdinalIgnoreCase)
+                        : !parameter.Key.Equals("VALUE", StringComparison.OrdinalIgnoreCase) ||
+                          !parameter.Value.Equals("DURATION", StringComparison.OrdinalIgnoreCase))) return true;
+        }
+        IcsProperty[] descriptions = alarmProperties.Where(property => property.Name == "DESCRIPTION").ToArray();
+        string expectedDescription = string.IsNullOrWhiteSpace(reminderDescription)
+            ? "Reminder"
+            : reminderDescription!;
+        return descriptions.Length > 1 || descriptions.Length == 1 &&
+                !string.Equals(Unescape(descriptions[0].Value), expectedDescription, StringComparison.Ordinal) ||
+            alarmProperties.Any(property => property.Name != "ACTION" && property.Name != "TRIGGER" &&
+                property.Name != "DESCRIPTION");
+    }
+
+    private static bool HasIncompleteAttendeeProjection(IcsProperty attendee) {
+        foreach (KeyValuePair<string, string> parameter in attendee.Parameters) {
+            if (parameter.Key.Equals("CN", StringComparison.OrdinalIgnoreCase)) continue;
+            if (parameter.Key.Equals("CUTYPE", StringComparison.OrdinalIgnoreCase)) {
+                if (parameter.Value.Equals("INDIVIDUAL", StringComparison.OrdinalIgnoreCase) ||
+                    parameter.Value.Equals("ROOM", StringComparison.OrdinalIgnoreCase) ||
+                    parameter.Value.Equals("RESOURCE", StringComparison.OrdinalIgnoreCase)) continue;
+                return true;
+            }
+            if (!parameter.Key.Equals("ROLE", StringComparison.OrdinalIgnoreCase)) return true;
+            bool roomOrResource = attendee.Parameters.TryGetValue("CUTYPE", out string? calendarUserType) &&
+                (calendarUserType.Equals("ROOM", StringComparison.OrdinalIgnoreCase) ||
+                 calendarUserType.Equals("RESOURCE", StringComparison.OrdinalIgnoreCase));
+            if (roomOrResource
+                    ? parameter.Value.Equals("NON-PARTICIPANT", StringComparison.OrdinalIgnoreCase)
+                    : parameter.Value.Equals("REQ-PARTICIPANT", StringComparison.OrdinalIgnoreCase) ||
+                      parameter.Value.Equals("OPT-PARTICIPANT", StringComparison.OrdinalIgnoreCase)) continue;
+            return true;
+        }
+        return false;
+    }
+
+    private static bool IsSupportedComponent(string value) =>
+        value.Equals("VCALENDAR", StringComparison.OrdinalIgnoreCase) ||
+        value.Equals("VEVENT", StringComparison.OrdinalIgnoreCase) ||
+        value.Equals("VTODO", StringComparison.OrdinalIgnoreCase) ||
+        value.Equals("VTIMEZONE", StringComparison.OrdinalIgnoreCase) ||
+        value.Equals("VALARM", StringComparison.OrdinalIgnoreCase) ||
+        value.Equals("STANDARD", StringComparison.OrdinalIgnoreCase) ||
+        value.Equals("DAYLIGHT", StringComparison.OrdinalIgnoreCase);
+}

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.Projection.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.Projection.cs
@@ -24,6 +24,9 @@ internal static partial class IcsCalendarCodec {
             activeProperties.Any(property =>
                 property.Name == "RRULE" || property.Name == "RDATE" ||
                 property.Name == "EXDATE" || property.Name == "RECURRENCE-ID" ||
+                property.Name == "CREATED" || property.Name == "LAST-MODIFIED" ||
+                property.Name == "COMMENT" || property.Name == "RESOURCES" || property.Name == "GEO" ||
+                isEvent && property.Name == "CONTACT" ||
                 property.Name == "CLASS" && !ParseCalendarSensitivity(property.Value).HasValue ||
                 isEvent && property.Name == "STATUS" ||
                 property.Name == "PRIORITY" || property.Name == "URL" ||

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.Projection.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.Projection.cs
@@ -29,6 +29,7 @@ internal static partial class IcsCalendarCodec {
             activeProperties.Any(property =>
                 property.Name == "RRULE" || property.Name == "RDATE" ||
                 property.Name == "EXDATE" || property.Name == "RECURRENCE-ID" ||
+                property.Name == "RELATED-TO" ||
                 property.Name == "CREATED" || property.Name == "LAST-MODIFIED" ||
                 property.Name == "COMMENT" || property.Name == "RESOURCES" || property.Name == "GEO" ||
                 isEvent && property.Name == "CONTACT" ||

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.Projection.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.Projection.cs
@@ -59,6 +59,8 @@ internal static partial class IcsCalendarCodec {
                 property.Name == "RRULE" || property.Name == "RDATE" ||
                 property.Name == "EXDATE" || property.Name == "RECURRENCE-ID" ||
                 property.Name == "RELATED-TO" || property.Name == "REQUEST-STATUS" ||
+                property.Name == "PRODID" &&
+                !property.Value.Trim().Equals("-//Evotec//OfficeIMO.Email//EN", StringComparison.Ordinal) ||
                 property.Name == "CREATED" || property.Name == "LAST-MODIFIED" ||
                 property.Name == "COMMENT" || property.Name == "RESOURCES" || property.Name == "GEO" ||
                 isEvent && property.Name == "CONTACT" ||

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
@@ -1,0 +1,582 @@
+namespace OfficeIMO.Email;
+
+internal static class IcsCalendarCodec {
+    private static readonly DateTimeOffset DeterministicEpoch =
+        new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    internal static bool TryProject(byte[] content, EmailDocument document, IList<EmailDiagnostic> diagnostics,
+        string location) {
+        string text = Decode(content);
+        List<IcsProperty> properties = ParseProperties(text);
+        bool isEvent = properties.Any(property => property.Name == "BEGIN" &&
+            property.Value.Equals("VEVENT", StringComparison.OrdinalIgnoreCase));
+        bool isTask = properties.Any(property => property.Name == "BEGIN" &&
+            property.Value.Equals("VTODO", StringComparison.OrdinalIgnoreCase));
+        if (!isEvent && !isTask) return false;
+
+        document.MimeSemanticProjectionIsIncomplete = HasStoreSpecificRecurrence(properties);
+
+        if (isEvent) ProjectEvent(properties, document, diagnostics, location);
+        else ProjectTask(properties, document, diagnostics, location);
+        return true;
+    }
+
+    internal static EmailAttachment? FindSemanticAttachment(EmailDocument document) {
+        if (document.OutlookItemKind != OutlookItemKind.Appointment &&
+            document.OutlookItemKind != OutlookItemKind.Task) return null;
+        return document.Attachments.FirstOrDefault(attachment => attachment.IsProjectedSemanticContent) ??
+            document.Attachments.FirstOrDefault(attachment =>
+                string.Equals(attachment.ContentType, "text/calendar", StringComparison.OrdinalIgnoreCase));
+    }
+
+    internal static byte[] Create(EmailDocument document) {
+        var output = new StringBuilder();
+        AppendLine(output, "BEGIN:VCALENDAR");
+        AppendLine(output, "PRODID:-//Evotec//OfficeIMO.Email//EN");
+        AppendLine(output, "VERSION:2.0");
+        AppendLine(output, string.Concat("METHOD:", GetMethod(document)));
+        if (document.OutlookItemKind == OutlookItemKind.Task) WriteTask(output, document);
+        else WriteEvent(output, document);
+        AppendLine(output, "END:VCALENDAR");
+        return Encoding.UTF8.GetBytes(output.ToString());
+    }
+
+    internal static bool HasOpaqueAppointmentState(OutlookAppointment appointment) {
+        return appointment.RecurrenceState != null || appointment.TimeZoneStructure != null ||
+            appointment.StartTimeZoneDefinition != null || appointment.EndTimeZoneDefinition != null ||
+            appointment.RecurrenceTimeZoneDefinition != null || appointment.IsRecurring == true ||
+            appointment.RecurrenceType.HasValue || !string.IsNullOrWhiteSpace(appointment.RecurrencePattern);
+    }
+
+    private static bool HasStoreSpecificRecurrence(IEnumerable<IcsProperty> properties) {
+        int events = properties.Count(property => property.Name == "BEGIN" &&
+            property.Value.Equals("VEVENT", StringComparison.OrdinalIgnoreCase));
+        return events > 1 || properties.Any(property => property.Name == "RRULE" || property.Name == "RDATE" ||
+            property.Name == "EXDATE" || property.Name == "RECURRENCE-ID");
+    }
+
+    private static void ProjectEvent(IReadOnlyList<IcsProperty> properties, EmailDocument document,
+        IList<EmailDiagnostic> diagnostics, string location) {
+        var appointment = document.Appointment ?? new OutlookAppointment();
+        document.OutlookItemKind = OutlookItemKind.Appointment;
+        document.MessageClass = MessageClassForMethod(GetValue(properties, "METHOD"));
+        document.Appointment = appointment;
+        ApplyCommon(properties, document);
+
+        appointment.Start = ParseDate(GetProperty(properties, "DTSTART"), diagnostics, location, out bool allDay);
+        appointment.End = ParseDate(GetProperty(properties, "DTEND"), diagnostics, location, out _);
+        appointment.IsAllDay = allDay;
+        appointment.Location = Unescape(GetValue(properties, "LOCATION"));
+        appointment.Sequence = ParseInt(GetValue(properties, "SEQUENCE"));
+        appointment.IsRecurring = GetProperty(properties, "RRULE") != null;
+        appointment.RecurrencePattern = GetValue(properties, "RRULE");
+        TimeSpan? duration = ParseDuration(GetValue(properties, "DURATION"));
+        appointment.DurationMinutes = appointment.Start.HasValue && appointment.End.HasValue
+            ? checked((int)(appointment.End.Value - appointment.Start.Value).TotalMinutes)
+            : duration.HasValue ? checked((int)duration.Value.TotalMinutes) : (int?)null;
+        if (!appointment.End.HasValue && appointment.Start.HasValue && duration.HasValue) {
+            appointment.End = appointment.Start.Value.Add(duration.Value);
+        }
+        string? busy = GetValue(properties, "X-MICROSOFT-CDO-BUSYSTATUS");
+        appointment.BusyStatus = ParseBusyStatus(busy);
+        appointment.NotAllowPropose = ParseBoolean(GetValue(properties, "X-MICROSOFT-DISALLOW-COUNTER"));
+        appointment.MeetingStatus = ParseInt(GetValue(properties, "X-OFFICEIMO-MEETING-STATUS"));
+        appointment.ResponseStatus = ParseInt(GetValue(properties, "X-OFFICEIMO-RESPONSE-STATUS"));
+        appointment.ClientIntentFlags = ParseInt(GetValue(properties, "X-OFFICEIMO-CLIENT-INTENT"));
+        appointment.TimeZoneDescription = UnescapeOrNull(GetValue(properties, "X-OFFICEIMO-TIMEZONE-DESCRIPTION"));
+        ApplyReminder(properties, appointment, diagnostics, location);
+
+        string[] required = GetAttendees(properties, optional: false).ToArray();
+        string[] optional = GetAttendees(properties, optional: true).ToArray();
+        appointment.RequiredAttendees = required.Length == 0 ? null : string.Join("; ", required);
+        appointment.OptionalAttendees = optional.Length == 0 ? null : string.Join("; ", optional);
+        appointment.AllAttendees = required.Concat(optional).Any()
+            ? string.Join("; ", required.Concat(optional))
+            : null;
+        AddAttendeeRecipients(properties, document);
+    }
+
+    private static void ProjectTask(IReadOnlyList<IcsProperty> properties, EmailDocument document,
+        IList<EmailDiagnostic> diagnostics, string location) {
+        var task = document.Task ?? new OutlookTask();
+        document.OutlookItemKind = OutlookItemKind.Task;
+        document.MessageClass = "IPM.Task";
+        document.Task = task;
+        ApplyCommon(properties, document);
+        task.Start = ParseDate(GetProperty(properties, "DTSTART"), diagnostics, location, out _);
+        task.Due = ParseDate(GetProperty(properties, "DUE"), diagnostics, location, out _);
+        task.CompletedAt = ParseDate(GetProperty(properties, "COMPLETED"), diagnostics, location, out _);
+        if (double.TryParse(GetValue(properties, "PERCENT-COMPLETE"), NumberStyles.Float,
+            CultureInfo.InvariantCulture, out double percent)) task.PercentComplete = percent / 100d;
+        string? status = GetValue(properties, "STATUS");
+        task.IsComplete = string.Equals(status, "COMPLETED", StringComparison.OrdinalIgnoreCase);
+        task.Status = ParseTaskStatus(status);
+        task.Owner = UnescapeOrNull(GetValue(properties, "X-OFFICEIMO-TASK-OWNER")) ?? GetOrganizer(properties);
+        task.IsRecurring = GetProperty(properties, "RRULE") != null;
+        task.EstimatedEffort = ParseDuration(GetValue(properties, "X-OFFICEIMO-ESTIMATED-EFFORT")) ??
+            ParseDuration(GetValue(properties, "DURATION"));
+        task.ActualEffort = ParseDuration(GetValue(properties, "X-OFFICEIMO-ACTUAL-EFFORT"));
+        task.SendUpdates = ParseBoolean(GetValue(properties, "X-OFFICEIMO-SEND-UPDATES"));
+        task.SendStatusOnComplete = ParseBoolean(GetValue(properties, "X-OFFICEIMO-SEND-STATUS-ON-COMPLETE"));
+        task.Ownership = ParseInt(GetValue(properties, "X-OFFICEIMO-OWNERSHIP"));
+        task.AcceptanceState = ParseInt(GetValue(properties, "X-OFFICEIMO-ACCEPTANCE-STATE"));
+        task.Version = ParseInt(GetValue(properties, "X-OFFICEIMO-TASK-VERSION"));
+        task.State = ParseInt(GetValue(properties, "X-OFFICEIMO-TASK-STATE"));
+        task.Assigner = UnescapeOrNull(GetValue(properties, "X-OFFICEIMO-ASSIGNER"));
+        task.IsTeamTask = ParseBoolean(GetValue(properties, "X-OFFICEIMO-TEAM-TASK"));
+        task.Ordinal = ParseInt(GetValue(properties, "X-OFFICEIMO-ORDINAL"));
+        task.CommonStart = ParseDate(GetProperty(properties, "X-OFFICEIMO-COMMON-START"), diagnostics, location, out _);
+        task.CommonEnd = ParseDate(GetProperty(properties, "X-OFFICEIMO-COMMON-END"), diagnostics, location, out _);
+        task.Mode = ParseInt(GetValue(properties, "X-OFFICEIMO-TASK-MODE"));
+        task.ToDoOrdinalDate = ParseDate(GetProperty(properties, "X-OFFICEIMO-TODO-ORDINAL-DATE"),
+            diagnostics, location, out _);
+        task.ToDoSubOrdinal = UnescapeOrNull(GetValue(properties, "X-OFFICEIMO-TODO-SUBORDINAL"));
+        task.BillingInformation = UnescapeOrNull(GetValue(properties, "X-OFFICEIMO-BILLING-INFORMATION"));
+        task.Mileage = UnescapeOrNull(GetValue(properties, "X-OFFICEIMO-MILEAGE"));
+        foreach (IcsProperty property in properties.Where(property => property.Name == "CONTACT")) {
+            task.Contacts.Add(Unescape(property.Value));
+        }
+        foreach (IcsProperty property in properties.Where(property => property.Name == "X-OFFICEIMO-COMPANY")) {
+            task.Companies.Add(Unescape(property.Value));
+        }
+        ApplyReminder(properties, task, diagnostics, location);
+    }
+
+    private static void ApplyCommon(IReadOnlyList<IcsProperty> properties, EmailDocument document) {
+        string? summary = Unescape(GetValue(properties, "SUMMARY"));
+        string? description = Unescape(GetValue(properties, "DESCRIPTION"));
+        string? uid = Unescape(GetValue(properties, "UID"));
+        if (!string.IsNullOrWhiteSpace(summary)) document.Subject = summary;
+        if (!string.IsNullOrWhiteSpace(description) && document.Body.Text == null) document.Body.Text = description;
+        if (!string.IsNullOrWhiteSpace(uid) && document.MessageId == null) document.MessageId = uid;
+        string? organizer = GetOrganizer(properties);
+        if (document.From == null && !string.IsNullOrWhiteSpace(organizer)) document.From = new EmailAddress(organizer!);
+    }
+
+    private static void WriteEvent(StringBuilder output, EmailDocument document) {
+        OutlookAppointment appointment = document.Appointment ?? new OutlookAppointment();
+        AppendLine(output, "BEGIN:VEVENT");
+        WriteCommon(output, document, appointment.Start);
+        if (appointment.Start.HasValue) {
+            if (appointment.IsAllDay == true) {
+                AppendLine(output, string.Concat("DTSTART;VALUE=DATE:", FormatDate(appointment.Start.Value)));
+                DateTimeOffset end = appointment.End ?? appointment.Start.Value.AddDays(1);
+                AppendLine(output, string.Concat("DTEND;VALUE=DATE:", FormatDate(end)));
+            } else {
+                AppendLine(output, string.Concat("DTSTART:", FormatUtc(appointment.Start.Value)));
+                if (appointment.End.HasValue) AppendLine(output, string.Concat("DTEND:", FormatUtc(appointment.End.Value)));
+                else if (appointment.DurationMinutes.HasValue) AppendLine(output,
+                    string.Concat("DURATION:", FormatDuration(TimeSpan.FromMinutes(appointment.DurationMinutes.Value))));
+            }
+        }
+        AppendText(output, "LOCATION", appointment.Location);
+        if (appointment.Sequence.HasValue) AppendLine(output, string.Concat("SEQUENCE:",
+            appointment.Sequence.Value.ToString(CultureInfo.InvariantCulture)));
+        if (appointment.BusyStatus.HasValue) {
+            string busy = FormatBusyStatus(appointment.BusyStatus.Value);
+            AppendLine(output, string.Concat("X-MICROSOFT-CDO-BUSYSTATUS:", busy));
+            AppendLine(output, appointment.BusyStatus.Value == 0 ? "TRANSP:TRANSPARENT" : "TRANSP:OPAQUE");
+        }
+        if (appointment.NotAllowPropose.HasValue) AppendLine(output,
+            string.Concat("X-MICROSOFT-DISALLOW-COUNTER:", appointment.NotAllowPropose.Value ? "TRUE" : "FALSE"));
+        AppendInteger(output, "X-OFFICEIMO-MEETING-STATUS", appointment.MeetingStatus);
+        AppendInteger(output, "X-OFFICEIMO-RESPONSE-STATUS", appointment.ResponseStatus);
+        AppendInteger(output, "X-OFFICEIMO-CLIENT-INTENT", appointment.ClientIntentFlags);
+        AppendText(output, "X-OFFICEIMO-TIMEZONE-DESCRIPTION", appointment.TimeZoneDescription);
+        WriteReminderMetadata(output, appointment.ReminderTime, appointment.ReminderSignalTime);
+        WriteOrganizerAndAttendees(output, document);
+        WriteAlarm(output, appointment.ReminderIsSet, appointment.ReminderDeltaMinutes,
+            appointment.ReminderSignalTime ?? appointment.ReminderTime, document.Subject);
+        AppendLine(output, "END:VEVENT");
+    }
+
+    private static void WriteTask(StringBuilder output, EmailDocument document) {
+        OutlookTask task = document.Task ?? new OutlookTask();
+        AppendLine(output, "BEGIN:VTODO");
+        WriteCommon(output, document, task.Start ?? task.Due);
+        if (task.Start.HasValue) AppendLine(output, string.Concat("DTSTART:", FormatUtc(task.Start.Value)));
+        if (task.Due.HasValue) AppendLine(output, string.Concat("DUE:", FormatUtc(task.Due.Value)));
+        if (task.CompletedAt.HasValue) AppendLine(output, string.Concat("COMPLETED:", FormatUtc(task.CompletedAt.Value)));
+        if (task.PercentComplete.HasValue) AppendLine(output, string.Concat("PERCENT-COMPLETE:",
+            Math.Max(0, Math.Min(100, (int)Math.Round(task.PercentComplete.Value * 100d))).ToString(CultureInfo.InvariantCulture)));
+        if (task.IsComplete == true) AppendLine(output, "STATUS:COMPLETED");
+        else if (task.Status == 1) AppendLine(output, "STATUS:IN-PROCESS");
+        else AppendLine(output, "STATUS:NEEDS-ACTION");
+        if (task.EstimatedEffort.HasValue) AppendLine(output,
+            string.Concat("X-OFFICEIMO-ESTIMATED-EFFORT:", FormatDuration(task.EstimatedEffort.Value)));
+        if (!string.IsNullOrWhiteSpace(task.Owner)) {
+            if (task.Owner!.IndexOf('@') >= 0) AppendLine(output,
+                string.Concat("ORGANIZER:mailto:", EscapeUriValue(task.Owner)));
+            else AppendText(output, "X-OFFICEIMO-TASK-OWNER", task.Owner);
+        }
+        if (task.ActualEffort.HasValue) AppendLine(output,
+            string.Concat("X-OFFICEIMO-ACTUAL-EFFORT:", FormatDuration(task.ActualEffort.Value)));
+        AppendBoolean(output, "X-OFFICEIMO-SEND-UPDATES", task.SendUpdates);
+        AppendBoolean(output, "X-OFFICEIMO-SEND-STATUS-ON-COMPLETE", task.SendStatusOnComplete);
+        AppendInteger(output, "X-OFFICEIMO-OWNERSHIP", task.Ownership);
+        AppendInteger(output, "X-OFFICEIMO-ACCEPTANCE-STATE", task.AcceptanceState);
+        AppendInteger(output, "X-OFFICEIMO-TASK-VERSION", task.Version);
+        AppendInteger(output, "X-OFFICEIMO-TASK-STATE", task.State);
+        AppendText(output, "X-OFFICEIMO-ASSIGNER", task.Assigner);
+        AppendBoolean(output, "X-OFFICEIMO-TEAM-TASK", task.IsTeamTask);
+        AppendInteger(output, "X-OFFICEIMO-ORDINAL", task.Ordinal);
+        AppendDateTime(output, "X-OFFICEIMO-COMMON-START", task.CommonStart);
+        AppendDateTime(output, "X-OFFICEIMO-COMMON-END", task.CommonEnd);
+        AppendInteger(output, "X-OFFICEIMO-TASK-MODE", task.Mode);
+        AppendDateTime(output, "X-OFFICEIMO-TODO-ORDINAL-DATE", task.ToDoOrdinalDate);
+        AppendText(output, "X-OFFICEIMO-TODO-SUBORDINAL", task.ToDoSubOrdinal);
+        AppendText(output, "X-OFFICEIMO-BILLING-INFORMATION", task.BillingInformation);
+        AppendText(output, "X-OFFICEIMO-MILEAGE", task.Mileage);
+        foreach (string contact in task.Contacts) AppendText(output, "CONTACT", contact);
+        foreach (string company in task.Companies) AppendText(output, "X-OFFICEIMO-COMPANY", company);
+        WriteReminderMetadata(output, task.ReminderTime, task.ReminderSignalTime);
+        WriteAlarm(output, task.ReminderIsSet, task.ReminderDeltaMinutes,
+            task.ReminderSignalTime ?? task.ReminderTime, document.Subject);
+        AppendLine(output, "END:VTODO");
+    }
+
+    private static void WriteCommon(StringBuilder output, EmailDocument document, DateTimeOffset? fallbackDate) {
+        string uid = string.IsNullOrWhiteSpace(document.MessageId)
+            ? CreateDeterministicUid(document, fallbackDate)
+            : document.MessageId!.Trim().Trim('<', '>');
+        AppendText(output, "UID", uid);
+        AppendLine(output, string.Concat("DTSTAMP:", FormatUtc(document.Date ?? fallbackDate ?? DeterministicEpoch)));
+        AppendText(output, "SUMMARY", document.Subject);
+        AppendText(output, "DESCRIPTION", document.Body.Text);
+    }
+
+    private static void WriteOrganizerAndAttendees(StringBuilder output, EmailDocument document) {
+        if (!string.IsNullOrWhiteSpace(document.From?.Address)) {
+            string organizer = string.Concat("ORGANIZER");
+            if (!string.IsNullOrWhiteSpace(document.From!.DisplayName)) organizer += string.Concat(";CN=\"",
+                EscapeParameter(document.From.DisplayName!), "\"");
+            AppendLine(output, string.Concat(organizer, ":mailto:", EscapeUriValue(document.From.Address!)));
+        }
+        foreach (EmailRecipient recipient in document.Recipients.Where(recipient =>
+            recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc)) {
+            string role = recipient.Kind == EmailRecipientKind.Cc ? "OPT-PARTICIPANT" : "REQ-PARTICIPANT";
+            string attendee = string.Concat("ATTENDEE;ROLE=", role);
+            if (!string.IsNullOrWhiteSpace(recipient.Address.DisplayName)) attendee += string.Concat(";CN=\"",
+                EscapeParameter(recipient.Address.DisplayName!), "\"");
+            AppendLine(output, string.Concat(attendee, ":mailto:", EscapeUriValue(recipient.Address.Address ?? string.Empty)));
+        }
+    }
+
+    private static string Decode(byte[] content) {
+        int offset = content.Length >= 3 && content[0] == 0xef && content[1] == 0xbb && content[2] == 0xbf ? 3 : 0;
+        return Encoding.UTF8.GetString(content, offset, content.Length - offset);
+    }
+
+    private static List<IcsProperty> ParseProperties(string text) {
+        string normalized = text.Replace("\r\n", "\n").Replace('\r', '\n');
+        var unfolded = new List<string>();
+        foreach (string line in normalized.Split('\n')) {
+            if (line.Length > 0 && (line[0] == ' ' || line[0] == '\t') && unfolded.Count > 0) {
+                unfolded[unfolded.Count - 1] += line.Substring(1);
+            } else {
+                unfolded.Add(line);
+            }
+        }
+
+        var result = new List<IcsProperty>();
+        foreach (string line in unfolded) {
+            int colon = line.IndexOf(':');
+            if (colon <= 0) continue;
+            string[] tokens = line.Substring(0, colon).Split(';');
+            var property = new IcsProperty(tokens[0].Trim().ToUpperInvariant(), line.Substring(colon + 1));
+            for (int index = 1; index < tokens.Length; index++) {
+                int equals = tokens[index].IndexOf('=');
+                if (equals > 0) property.Parameters[tokens[index].Substring(0, equals).Trim()] =
+                    tokens[index].Substring(equals + 1).Trim().Trim('"');
+            }
+            result.Add(property);
+        }
+        return result;
+    }
+
+    private static DateTimeOffset? ParseDate(IcsProperty? property, IList<EmailDiagnostic> diagnostics,
+        string location, out bool isDateOnly) {
+        isDateOnly = property != null && property.Parameters.TryGetValue("VALUE", out string? valueType) &&
+            string.Equals(valueType, "DATE", StringComparison.OrdinalIgnoreCase);
+        if (property == null || string.IsNullOrWhiteSpace(property.Value)) return null;
+        string value = property.Value.Trim();
+        if (isDateOnly && DateTime.TryParseExact(value, "yyyyMMdd", CultureInfo.InvariantCulture,
+            DateTimeStyles.None, out DateTime date)) return new DateTimeOffset(date, TimeSpan.Zero);
+        if (DateTimeOffset.TryParseExact(value, new[] { "yyyyMMdd'T'HHmmss'Z'", "yyyyMMdd'T'HHmm'Z'" },
+            CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out DateTimeOffset utc)) return utc;
+        if (DateTime.TryParseExact(value, new[] { "yyyyMMdd'T'HHmmss", "yyyyMMdd'T'HHmm" },
+            CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime local)) {
+            if (property.Parameters.TryGetValue("TZID", out string? timeZoneId)) {
+                try {
+                    TimeZoneInfo zone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+                    return new DateTimeOffset(local, zone.GetUtcOffset(local));
+                } catch (TimeZoneNotFoundException) {
+                } catch (InvalidTimeZoneException) {
+                }
+            }
+            diagnostics.Add(new EmailDiagnostic("EMAIL_ICALENDAR_FLOATING_TIME",
+                "A floating iCalendar time could not be associated with a known time zone and was interpreted as UTC.",
+                EmailDiagnosticSeverity.Warning, location));
+            return new DateTimeOffset(local, TimeSpan.Zero);
+        }
+        diagnostics.Add(new EmailDiagnostic("EMAIL_ICALENDAR_DATE_INVALID",
+            string.Concat("The iCalendar value '", value, "' could not be parsed."),
+            EmailDiagnosticSeverity.Warning, location));
+        return null;
+    }
+
+    private static IcsProperty? GetProperty(IEnumerable<IcsProperty> properties, string name) =>
+        properties.FirstOrDefault(property => property.Name == name);
+
+    private static string? GetValue(IEnumerable<IcsProperty> properties, string name) => GetProperty(properties, name)?.Value;
+
+    private static string? GetOrganizer(IEnumerable<IcsProperty> properties) {
+        string? value = GetValue(properties, "ORGANIZER");
+        return StripMailTo(value);
+    }
+
+    private static IEnumerable<string> GetAttendees(IEnumerable<IcsProperty> properties, bool optional) {
+        foreach (IcsProperty property in properties.Where(property => property.Name == "ATTENDEE")) {
+            bool isOptional = property.Parameters.TryGetValue("ROLE", out string? role) &&
+                string.Equals(role, "OPT-PARTICIPANT", StringComparison.OrdinalIgnoreCase);
+            if (isOptional != optional) continue;
+            yield return property.Parameters.TryGetValue("CN", out string? name) && !string.IsNullOrWhiteSpace(name)
+                ? name
+                : StripMailTo(property.Value) ?? property.Value;
+        }
+    }
+
+    private static void AddAttendeeRecipients(IEnumerable<IcsProperty> properties, EmailDocument document) {
+        foreach (IcsProperty property in properties.Where(property => property.Name == "ATTENDEE")) {
+            string? address = StripMailTo(property.Value);
+            if (string.IsNullOrWhiteSpace(address)) continue;
+            bool optional = property.Parameters.TryGetValue("ROLE", out string? role) &&
+                string.Equals(role, "OPT-PARTICIPANT", StringComparison.OrdinalIgnoreCase);
+            property.Parameters.TryGetValue("CN", out string? name);
+            if (!document.Recipients.Any(recipient => string.Equals(recipient.Address.Address, address,
+                StringComparison.OrdinalIgnoreCase))) {
+                document.Recipients.Add(new EmailRecipient(optional ? EmailRecipientKind.Cc : EmailRecipientKind.To,
+                    new EmailAddress(address!, name)));
+            }
+        }
+    }
+
+    private static string? StripMailTo(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        string result = value!.Trim();
+        return result.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase) ? result.Substring(7) : result;
+    }
+
+    private static int? ParseInt(string? value) => int.TryParse(value, NumberStyles.Integer,
+        CultureInfo.InvariantCulture, out int result) ? result : (int?)null;
+
+    private static TimeSpan? ParseDuration(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        try {
+            return System.Xml.XmlConvert.ToTimeSpan(value);
+        } catch (FormatException) {
+            return null;
+        } catch (OverflowException) {
+            return null;
+        }
+    }
+
+    private static bool? ParseBoolean(string? value) => string.Equals(value, "TRUE", StringComparison.OrdinalIgnoreCase)
+        ? true : string.Equals(value, "FALSE", StringComparison.OrdinalIgnoreCase) ? false : (bool?)null;
+
+    private static int? ParseBusyStatus(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        if (value!.Equals("FREE", StringComparison.OrdinalIgnoreCase)) return 0;
+        if (value.Equals("TENTATIVE", StringComparison.OrdinalIgnoreCase)) return 1;
+        if (value.Equals("BUSY", StringComparison.OrdinalIgnoreCase)) return 2;
+        if (value.Equals("OOF", StringComparison.OrdinalIgnoreCase)) return 3;
+        if (value.Equals("WORKINGELSEWHERE", StringComparison.OrdinalIgnoreCase)) return 4;
+        return null;
+    }
+
+    private static int? ParseTaskStatus(string? value) {
+        if (string.Equals(value, "NOT-STARTED", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(value, "NEEDS-ACTION", StringComparison.OrdinalIgnoreCase)) return 0;
+        if (string.Equals(value, "IN-PROCESS", StringComparison.OrdinalIgnoreCase)) return 1;
+        if (string.Equals(value, "COMPLETED", StringComparison.OrdinalIgnoreCase)) return 2;
+        if (string.Equals(value, "CANCELLED", StringComparison.OrdinalIgnoreCase)) return 4;
+        return null;
+    }
+
+    private static string FormatBusyStatus(int value) => value == 0 ? "FREE" : value == 1 ? "TENTATIVE" :
+        value == 3 ? "OOF" : value == 4 ? "WORKINGELSEWHERE" : "BUSY";
+
+    private static string MessageClassForMethod(string? method) =>
+        string.Equals(method, "REQUEST", StringComparison.OrdinalIgnoreCase) ? "IPM.Schedule.Meeting.Request" :
+        string.Equals(method, "CANCEL", StringComparison.OrdinalIgnoreCase) ? "IPM.Schedule.Meeting.Canceled" :
+        "IPM.Appointment";
+
+    private static string GetMethod(EmailDocument document) {
+        string messageClass = document.MessageClass ?? string.Empty;
+        if (messageClass.IndexOf("Canceled", StringComparison.OrdinalIgnoreCase) >= 0) return "CANCEL";
+        if (messageClass.IndexOf("Request", StringComparison.OrdinalIgnoreCase) >= 0) return "REQUEST";
+        if (messageClass.IndexOf("Resp", StringComparison.OrdinalIgnoreCase) >= 0) return "REPLY";
+        return document.Recipients.Any(recipient => recipient.Kind == EmailRecipientKind.To ||
+            recipient.Kind == EmailRecipientKind.Cc) ? "REQUEST" : "PUBLISH";
+    }
+
+    private static string FormatUtc(DateTimeOffset value) =>
+        value.UtcDateTime.ToString("yyyyMMdd'T'HHmmss'Z'", CultureInfo.InvariantCulture);
+
+    private static string FormatDate(DateTimeOffset value) =>
+        value.Date.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
+
+    private static string FormatDuration(TimeSpan value) {
+        string sign = value < TimeSpan.Zero ? "-" : string.Empty;
+        TimeSpan absolute = value.Duration();
+        var result = new StringBuilder(sign).Append('P');
+        if (absolute.Days > 0) result.Append(absolute.Days.ToString(CultureInfo.InvariantCulture)).Append('D');
+        if (absolute.Hours > 0 || absolute.Minutes > 0 || absolute.Seconds > 0 || absolute.Days == 0) {
+            result.Append('T');
+            if (absolute.Hours > 0) result.Append(absolute.Hours.ToString(CultureInfo.InvariantCulture)).Append('H');
+            if (absolute.Minutes > 0) result.Append(absolute.Minutes.ToString(CultureInfo.InvariantCulture)).Append('M');
+            if (absolute.Seconds > 0 || absolute == TimeSpan.Zero) {
+                result.Append(absolute.Seconds.ToString(CultureInfo.InvariantCulture)).Append('S');
+            }
+        }
+        return result.ToString();
+    }
+
+    private static void ApplyReminder(IReadOnlyList<IcsProperty> properties, OutlookAppointment appointment,
+        IList<EmailDiagnostic> diagnostics, string location) {
+        IcsProperty? trigger = GetProperty(properties, "TRIGGER");
+        appointment.ReminderIsSet = trigger == null ? ParseBoolean(GetValue(properties, "X-OFFICEIMO-REMINDER-SET")) : true;
+        appointment.ReminderDeltaMinutes = ParseRelativeTriggerMinutes(trigger);
+        appointment.ReminderTime = ParseDate(GetProperty(properties, "X-OFFICEIMO-REMINDER-TIME"),
+            diagnostics, location, out _);
+        appointment.ReminderSignalTime = ParseDate(GetProperty(properties, "X-OFFICEIMO-REMINDER-SIGNAL-TIME"),
+            diagnostics, location, out _);
+        if (!appointment.ReminderSignalTime.HasValue) {
+            appointment.ReminderSignalTime = ParseAbsoluteTrigger(trigger, diagnostics, location);
+        }
+    }
+
+    private static void ApplyReminder(IReadOnlyList<IcsProperty> properties, OutlookTask task,
+        IList<EmailDiagnostic> diagnostics, string location) {
+        IcsProperty? trigger = GetProperty(properties, "TRIGGER");
+        task.ReminderIsSet = trigger == null ? ParseBoolean(GetValue(properties, "X-OFFICEIMO-REMINDER-SET")) : true;
+        task.ReminderDeltaMinutes = ParseRelativeTriggerMinutes(trigger);
+        task.ReminderTime = ParseDate(GetProperty(properties, "X-OFFICEIMO-REMINDER-TIME"),
+            diagnostics, location, out _);
+        task.ReminderSignalTime = ParseDate(GetProperty(properties, "X-OFFICEIMO-REMINDER-SIGNAL-TIME"),
+            diagnostics, location, out _);
+        if (!task.ReminderSignalTime.HasValue) {
+            task.ReminderSignalTime = ParseAbsoluteTrigger(trigger, diagnostics, location);
+        }
+    }
+
+    private static int? ParseRelativeTriggerMinutes(IcsProperty? trigger) {
+        if (trigger == null || trigger.Parameters.TryGetValue("VALUE", out string? valueType) &&
+            valueType.Equals("DATE-TIME", StringComparison.OrdinalIgnoreCase)) return null;
+        TimeSpan? value = ParseDuration(trigger.Value);
+        return value.HasValue ? checked((int)-value.Value.TotalMinutes) : (int?)null;
+    }
+
+    private static DateTimeOffset? ParseAbsoluteTrigger(IcsProperty? trigger,
+        IList<EmailDiagnostic> diagnostics, string location) {
+        if (trigger == null || !trigger.Parameters.TryGetValue("VALUE", out string? valueType) ||
+            !valueType.Equals("DATE-TIME", StringComparison.OrdinalIgnoreCase)) return null;
+        return ParseDate(trigger, diagnostics, location, out _);
+    }
+
+    private static void WriteReminderMetadata(StringBuilder output, DateTimeOffset? reminderTime,
+        DateTimeOffset? reminderSignalTime) {
+        AppendDateTime(output, "X-OFFICEIMO-REMINDER-TIME", reminderTime);
+        AppendDateTime(output, "X-OFFICEIMO-REMINDER-SIGNAL-TIME", reminderSignalTime);
+    }
+
+    private static void WriteAlarm(StringBuilder output, bool? isSet, int? deltaMinutes,
+        DateTimeOffset? absoluteTime, string? subject) {
+        if (isSet != true) {
+            AppendBoolean(output, "X-OFFICEIMO-REMINDER-SET", isSet);
+            return;
+        }
+        AppendLine(output, "BEGIN:VALARM");
+        AppendLine(output, "ACTION:DISPLAY");
+        AppendText(output, "DESCRIPTION", string.IsNullOrWhiteSpace(subject) ? "Reminder" : subject);
+        if (deltaMinutes.HasValue) AppendLine(output, string.Concat("TRIGGER:",
+            FormatDuration(TimeSpan.FromMinutes(-deltaMinutes.Value))));
+        else if (absoluteTime.HasValue) AppendLine(output,
+            string.Concat("TRIGGER;VALUE=DATE-TIME:", FormatUtc(absoluteTime.Value)));
+        else AppendLine(output, "TRIGGER:PT0S");
+        AppendLine(output, "END:VALARM");
+    }
+
+    private static void AppendInteger(StringBuilder output, string name, int? value) {
+        if (value.HasValue) AppendLine(output,
+            string.Concat(name, ":", value.Value.ToString(CultureInfo.InvariantCulture)));
+    }
+
+    private static void AppendBoolean(StringBuilder output, string name, bool? value) {
+        if (value.HasValue) AppendLine(output, string.Concat(name, ":", value.Value ? "TRUE" : "FALSE"));
+    }
+
+    private static void AppendDateTime(StringBuilder output, string name, DateTimeOffset? value) {
+        if (value.HasValue) AppendLine(output, string.Concat(name, ":", FormatUtc(value.Value)));
+    }
+
+    private static string CreateDeterministicUid(EmailDocument document, DateTimeOffset? date) {
+        string input = string.Concat(document.Subject, "|", (date ?? DeterministicEpoch).UtcTicks.ToString(CultureInfo.InvariantCulture));
+        ulong hash = 14695981039346656037UL;
+        foreach (byte value in Encoding.UTF8.GetBytes(input)) {
+            hash ^= value;
+            hash *= 1099511628211UL;
+        }
+        return string.Concat(hash.ToString("x16", CultureInfo.InvariantCulture), "@officeimo.local");
+    }
+
+    private static void AppendText(StringBuilder output, string name, string? value) {
+        if (!string.IsNullOrWhiteSpace(value)) AppendLine(output, string.Concat(name, ":", EscapeText(value!)));
+    }
+
+    private static void AppendLine(StringBuilder output, string line) {
+        const int maximumOctets = 75;
+        var current = new StringBuilder();
+        int octets = 0;
+        for (int index = 0; index < line.Length;) {
+            int length = char.IsHighSurrogate(line[index]) && index + 1 < line.Length &&
+                char.IsLowSurrogate(line[index + 1]) ? 2 : 1;
+            string character = line.Substring(index, length);
+            int bytes = Encoding.UTF8.GetByteCount(character);
+            if (current.Length > 0 && octets + bytes > maximumOctets) {
+                output.Append(current).Append("\r\n ");
+                current.Clear();
+                octets = 1;
+            }
+            current.Append(character);
+            octets += bytes;
+            index += length;
+        }
+        output.Append(current).Append("\r\n");
+    }
+
+    private static string EscapeText(string value) => value.Replace("\\", "\\\\").Replace(";", "\\;")
+        .Replace(",", "\\,").Replace("\r\n", "\\n").Replace("\r", "\\n").Replace("\n", "\\n");
+
+    private static string Unescape(string? value) => (value ?? string.Empty).Replace("\\n", "\n")
+        .Replace("\\N", "\n").Replace("\\,", ",").Replace("\\;", ";").Replace("\\\\", "\\");
+
+    private static string? UnescapeOrNull(string? value) => string.IsNullOrWhiteSpace(value)
+        ? null
+        : Unescape(value);
+
+    private static string EscapeParameter(string value) => value.Replace("\\", "\\\\").Replace("\"", "\\\"")
+        .Replace("\r", string.Empty).Replace("\n", " ");
+
+    private static string EscapeUriValue(string value) => value.Replace("\r", string.Empty).Replace("\n", string.Empty)
+        .Replace(";", "%3B").Replace(",", "%2C");
+
+    private sealed class IcsProperty {
+        internal IcsProperty(string name, string value) { Name = name; Value = value; }
+        internal string Name { get; }
+        internal string Value { get; }
+        internal IDictionary<string, string> Parameters { get; } =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
@@ -24,6 +24,7 @@ internal static partial class IcsCalendarCodec {
         else ProjectTask(activeProperties, document, diagnostics, location);
         document.MimeSemanticProjectionIsIncomplete |= diagnostics.Skip(projectionDiagnosticStart).Any(diagnostic =>
             diagnostic.Code == "EMAIL_ICALENDAR_TIMEZONE_UNRESOLVED" ||
+            diagnostic.Code == "EMAIL_ICALENDAR_FLOATING_TIME" ||
             diagnostic.Code == "EMAIL_ICALENDAR_DATE_INVALID");
         return true;
     }
@@ -102,6 +103,7 @@ internal static partial class IcsCalendarCodec {
             property.Name == "EXDATE" || property.Name == "RECURRENCE-ID" ||
             property.Name == "CLASS" && !ParseCalendarSensitivity(property.Value).HasValue ||
             isEvent && property.Name == "STATUS" ||
+            property.Name == "PRIORITY" ||
             property.Name == "ATTACH" || property.Name == "TRIGGER" &&
             property.Parameters.TryGetValue("RELATED", out string? related) &&
             related.Equals("END", StringComparison.OrdinalIgnoreCase));
@@ -381,6 +383,7 @@ internal static partial class IcsCalendarCodec {
         foreach (string contact in task.Contacts) AppendText(output, "CONTACT", contact);
         foreach (string company in task.Companies) AppendText(output, "X-OFFICEIMO-COMPANY", company);
         WriteReminderMetadata(output, task.ReminderTime, task.ReminderSignalTime);
+        WriteAttendees(output, document);
         WriteAlarm(output, task.ReminderIsSet, task.ReminderDeltaMinutes,
             task.ReminderSignalTime ?? task.ReminderTime, document.Subject);
         AppendLine(output, "END:VTODO");
@@ -413,6 +416,10 @@ internal static partial class IcsCalendarCodec {
                 EscapeParameter(document.From.DisplayName!), "\"");
             AppendLine(output, string.Concat(organizer, ":mailto:", EscapeUriValue(document.From.Address!)));
         }
+        WriteAttendees(output, document);
+    }
+
+    private static void WriteAttendees(StringBuilder output, EmailDocument document) {
         foreach (EmailRecipient recipient in document.Recipients.Where(recipient =>
             (recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc ||
              recipient.Kind == EmailRecipientKind.Room || recipient.Kind == EmailRecipientKind.Resource) &&
@@ -478,7 +485,13 @@ internal static partial class IcsCalendarCodec {
     private static string? StripMailTo(string? value) {
         if (string.IsNullOrWhiteSpace(value)) return null;
         string result = value!.Trim();
-        return result.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase) ? result.Substring(7) : result;
+        if (!result.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)) return result;
+        string address = result.Substring(7);
+        try {
+            return Uri.UnescapeDataString(address);
+        } catch (UriFormatException) {
+            return address;
+        }
     }
 
     private static int? ParseInt(string? value) => int.TryParse(value, NumberStyles.Integer,

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
@@ -225,6 +225,7 @@ internal static partial class IcsCalendarCodec {
         string? summary = Unescape(GetValue(properties, "SUMMARY"));
         string? description = Unescape(GetValue(properties, "DESCRIPTION"));
         string? uid = Unescape(GetValue(properties, "UID"));
+        document.MimeSemanticSourceHasTextBody |= !string.IsNullOrWhiteSpace(description);
         if (!string.IsNullOrWhiteSpace(summary)) document.Subject = summary;
         if (!string.IsNullOrWhiteSpace(description)) {
             if (document.Body.Text == null) document.Body.Text = description;

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
@@ -19,7 +19,7 @@ internal static partial class IcsCalendarCodec {
         IReadOnlyList<IcsProperty> alarmProperties = SelectActiveAlarmProperties(
             properties, activeComponent.Value);
         document.MimeSemanticProjectionIsIncomplete |= HasIncompleteStoreProjection(
-            properties, activeProperties, alarmProperties, isEvent);
+            properties, activeProperties, alarmProperties, isEvent, document.Subject);
         string? calendarMethod = GetValue(activeProperties, "METHOD");
         if (!string.IsNullOrWhiteSpace(calendarMethod) && !string.IsNullOrWhiteSpace(mimeMethod) &&
             !string.Equals(calendarMethod, mimeMethod, StringComparison.OrdinalIgnoreCase) ||
@@ -91,7 +91,8 @@ internal static partial class IcsCalendarCodec {
     }
 
     private static bool HasIncompleteStoreProjection(IEnumerable<IcsProperty> properties,
-        IEnumerable<IcsProperty> activeProperties, IReadOnlyList<IcsProperty> alarmProperties, bool isEvent) {
+        IEnumerable<IcsProperty> activeProperties, IReadOnlyList<IcsProperty> alarmProperties, bool isEvent,
+        string? envelopeSubject) {
         int calendarItems = properties.Count(property => property.Name == "BEGIN" &&
             (property.Value.Equals("VEVENT", StringComparison.OrdinalIgnoreCase) ||
              property.Value.Equals("VTODO", StringComparison.OrdinalIgnoreCase)));
@@ -103,21 +104,26 @@ internal static partial class IcsCalendarCodec {
             property.Value.Equals("VTIMEZONE", StringComparison.OrdinalIgnoreCase));
         bool hasUnsupportedComponent = properties.Any(property => property.Name == "BEGIN" &&
             !IsSupportedComponent(property.Value));
+        string? calendarSummary = Unescape(GetValue(activeProperties, "SUMMARY"));
+        string? reminderDescription = string.IsNullOrWhiteSpace(calendarSummary)
+            ? envelopeSubject
+            : calendarSummary;
         return calendarRoots != 1 || calendarItems > 1 || alarms > 1 || hasTimeZone || hasUnsupportedComponent ||
-            HasIncompleteAlarmProjection(alarms, alarmProperties) ||
+            HasIncompleteAlarmProjection(alarms, alarmProperties, reminderDescription) ||
             activeProperties.Any(property =>
             property.Name == "RRULE" || property.Name == "RDATE" ||
             property.Name == "EXDATE" || property.Name == "RECURRENCE-ID" ||
             property.Name == "CLASS" && !ParseCalendarSensitivity(property.Value).HasValue ||
             isEvent && property.Name == "STATUS" ||
             property.Name == "PRIORITY" ||
+            property.Name == "ATTENDEE" && HasIncompleteAttendeeProjection(property) ||
             property.Name == "ATTACH" || property.Name == "TRIGGER" &&
             property.Parameters.TryGetValue("RELATED", out string? related) &&
             related.Equals("END", StringComparison.OrdinalIgnoreCase));
     }
 
     private static bool HasIncompleteAlarmProjection(int alarmCount,
-        IReadOnlyList<IcsProperty> alarmProperties) {
+        IReadOnlyList<IcsProperty> alarmProperties, string? reminderDescription) {
         if (alarmCount == 0) return false;
         if (alarmCount != 1) return true;
         IcsProperty[] actions = alarmProperties.Where(property => property.Name == "ACTION").ToArray();
@@ -136,8 +142,36 @@ internal static partial class IcsCalendarCodec {
                         : !parameter.Key.Equals("VALUE", StringComparison.OrdinalIgnoreCase) ||
                           !parameter.Value.Equals("DURATION", StringComparison.OrdinalIgnoreCase))) return true;
         }
-        return alarmProperties.Any(property => property.Name != "ACTION" && property.Name != "TRIGGER" &&
-            property.Name != "DESCRIPTION");
+        IcsProperty[] descriptions = alarmProperties.Where(property => property.Name == "DESCRIPTION").ToArray();
+        string expectedDescription = string.IsNullOrWhiteSpace(reminderDescription)
+            ? "Reminder"
+            : reminderDescription!;
+        return descriptions.Length > 1 || descriptions.Length == 1 &&
+                !string.Equals(Unescape(descriptions[0].Value), expectedDescription, StringComparison.Ordinal) ||
+            alarmProperties.Any(property => property.Name != "ACTION" && property.Name != "TRIGGER" &&
+                property.Name != "DESCRIPTION");
+    }
+
+    private static bool HasIncompleteAttendeeProjection(IcsProperty attendee) {
+        foreach (KeyValuePair<string, string> parameter in attendee.Parameters) {
+            if (parameter.Key.Equals("CN", StringComparison.OrdinalIgnoreCase)) continue;
+            if (parameter.Key.Equals("CUTYPE", StringComparison.OrdinalIgnoreCase)) {
+                if (parameter.Value.Equals("INDIVIDUAL", StringComparison.OrdinalIgnoreCase) ||
+                    parameter.Value.Equals("ROOM", StringComparison.OrdinalIgnoreCase) ||
+                    parameter.Value.Equals("RESOURCE", StringComparison.OrdinalIgnoreCase)) continue;
+                return true;
+            }
+            if (!parameter.Key.Equals("ROLE", StringComparison.OrdinalIgnoreCase)) return true;
+            bool roomOrResource = attendee.Parameters.TryGetValue("CUTYPE", out string? calendarUserType) &&
+                (calendarUserType.Equals("ROOM", StringComparison.OrdinalIgnoreCase) ||
+                 calendarUserType.Equals("RESOURCE", StringComparison.OrdinalIgnoreCase));
+            if (roomOrResource
+                    ? parameter.Value.Equals("NON-PARTICIPANT", StringComparison.OrdinalIgnoreCase)
+                    : parameter.Value.Equals("REQ-PARTICIPANT", StringComparison.OrdinalIgnoreCase) ||
+                      parameter.Value.Equals("OPT-PARTICIPANT", StringComparison.OrdinalIgnoreCase)) continue;
+            return true;
+        }
+        return false;
     }
 
     private static bool IsSupportedComponent(string value) =>
@@ -754,7 +788,7 @@ internal static partial class IcsCalendarCodec {
         .Replace("\r", string.Empty).Replace("\n", " ");
 
     private static string EscapeUriValue(string value) => value.Replace("\r", string.Empty).Replace("\n", string.Empty)
-        .Replace(";", "%3B").Replace(",", "%2C");
+        .Replace("%", "%25").Replace(";", "%3B").Replace(",", "%2C");
 
     private sealed class IcsProperty {
         internal IcsProperty(string name, string value) { Name = name; Value = value; }

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
@@ -16,8 +16,10 @@ internal static partial class IcsCalendarCodec {
 
         IReadOnlyList<IcsProperty> activeProperties = SelectActiveComponentProperties(
             properties, activeComponent.Value);
+        IReadOnlyList<IcsProperty> alarmProperties = SelectActiveAlarmProperties(
+            properties, activeComponent.Value);
         document.MimeSemanticProjectionIsIncomplete |= HasIncompleteStoreProjection(
-            properties, activeProperties, isEvent);
+            properties, activeProperties, alarmProperties, isEvent);
         if (isEvent) ProjectEvent(activeProperties, document, diagnostics, location);
         else ProjectTask(activeProperties, document, diagnostics, location);
         document.MimeSemanticProjectionIsIncomplete |= diagnostics.Skip(projectionDiagnosticStart).Any(diagnostic =>
@@ -80,7 +82,7 @@ internal static partial class IcsCalendarCodec {
     }
 
     private static bool HasIncompleteStoreProjection(IEnumerable<IcsProperty> properties,
-        IEnumerable<IcsProperty> activeProperties, bool isEvent) {
+        IEnumerable<IcsProperty> activeProperties, IReadOnlyList<IcsProperty> alarmProperties, bool isEvent) {
         int calendarItems = properties.Count(property => property.Name == "BEGIN" &&
             (property.Value.Equals("VEVENT", StringComparison.OrdinalIgnoreCase) ||
              property.Value.Equals("VTODO", StringComparison.OrdinalIgnoreCase)));
@@ -93,6 +95,7 @@ internal static partial class IcsCalendarCodec {
         bool hasUnsupportedComponent = properties.Any(property => property.Name == "BEGIN" &&
             !IsSupportedComponent(property.Value));
         return calendarRoots != 1 || calendarItems > 1 || alarms > 1 || hasTimeZone || hasUnsupportedComponent ||
+            HasIncompleteAlarmProjection(alarms, alarmProperties) ||
             activeProperties.Any(property =>
             property.Name == "RRULE" || property.Name == "RDATE" ||
             property.Name == "EXDATE" || property.Name == "RECURRENCE-ID" ||
@@ -101,6 +104,23 @@ internal static partial class IcsCalendarCodec {
             property.Name == "ATTACH" || property.Name == "TRIGGER" &&
             property.Parameters.TryGetValue("RELATED", out string? related) &&
             related.Equals("END", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool HasIncompleteAlarmProjection(int alarmCount,
+        IReadOnlyList<IcsProperty> alarmProperties) {
+        if (alarmCount == 0) return false;
+        if (alarmCount != 1) return true;
+        IcsProperty[] actions = alarmProperties.Where(property => property.Name == "ACTION").ToArray();
+        IcsProperty[] triggers = alarmProperties.Where(property => property.Name == "TRIGGER").ToArray();
+        if (actions.Length != 1 || !actions[0].Value.Trim().Equals("DISPLAY", StringComparison.OrdinalIgnoreCase) ||
+            triggers.Length != 1 || !IcsDurationCodec.Parse(triggers[0].Value).HasValue) return true;
+        if (triggers[0].Parameters.Any(parameter =>
+                parameter.Key.Equals("RELATED", StringComparison.OrdinalIgnoreCase)
+                    ? !parameter.Value.Equals("START", StringComparison.OrdinalIgnoreCase)
+                    : !parameter.Key.Equals("VALUE", StringComparison.OrdinalIgnoreCase) ||
+                      !parameter.Value.Equals("DURATION", StringComparison.OrdinalIgnoreCase))) return true;
+        return alarmProperties.Any(property => property.Name != "ACTION" && property.Name != "TRIGGER" &&
+            property.Name != "DESCRIPTION");
     }
 
     private static bool IsSupportedComponent(string value) =>
@@ -419,7 +439,7 @@ internal static partial class IcsCalendarCodec {
                 string.Equals(recipient.Address.Address, address, StringComparison.OrdinalIgnoreCase));
             if (existing == null) {
                 document.Recipients.Add(new EmailRecipient(kind, new EmailAddress(address!, name)));
-            } else if (kind == EmailRecipientKind.Room || kind == EmailRecipientKind.Resource) {
+            } else {
                 existing.Kind = kind;
             }
         }

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
@@ -28,6 +28,7 @@ internal static partial class IcsCalendarCodec {
         bool hasCalendarRecipients = HasCalendarRecipients(document) ||
             activeProperties.Any(property => property.Name == "ATTENDEE");
         bool methodWouldChange =
+            string.IsNullOrWhiteSpace(effectiveMethod) && hasCalendarRecipients ||
             string.Equals(effectiveMethod, "PUBLISH", StringComparison.OrdinalIgnoreCase) &&
             hasCalendarRecipients || !isEvent &&
             string.Equals(effectiveMethod, "REQUEST", StringComparison.OrdinalIgnoreCase) &&

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
@@ -1,6 +1,6 @@
 namespace OfficeIMO.Email;
 
-internal static class IcsCalendarCodec {
+internal static partial class IcsCalendarCodec {
     private static readonly DateTimeOffset DeterministicEpoch =
         new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
@@ -16,7 +16,8 @@ internal static class IcsCalendarCodec {
 
         IReadOnlyList<IcsProperty> activeProperties = SelectActiveComponentProperties(
             properties, activeComponent.Value);
-        document.MimeSemanticProjectionIsIncomplete |= HasIncompleteStoreProjection(properties, activeProperties);
+        document.MimeSemanticProjectionIsIncomplete |= HasIncompleteStoreProjection(
+            properties, activeProperties, isEvent);
         if (isEvent) ProjectEvent(activeProperties, document, diagnostics, location);
         else ProjectTask(activeProperties, document, diagnostics, location);
         document.MimeSemanticProjectionIsIncomplete |= diagnostics.Skip(projectionDiagnosticStart).Any(diagnostic =>
@@ -79,7 +80,7 @@ internal static class IcsCalendarCodec {
     }
 
     private static bool HasIncompleteStoreProjection(IEnumerable<IcsProperty> properties,
-        IEnumerable<IcsProperty> activeProperties) {
+        IEnumerable<IcsProperty> activeProperties, bool isEvent) {
         int calendarItems = properties.Count(property => property.Name == "BEGIN" &&
             (property.Value.Equals("VEVENT", StringComparison.OrdinalIgnoreCase) ||
              property.Value.Equals("VTODO", StringComparison.OrdinalIgnoreCase)));
@@ -96,6 +97,7 @@ internal static class IcsCalendarCodec {
             property.Name == "RRULE" || property.Name == "RDATE" ||
             property.Name == "EXDATE" || property.Name == "RECURRENCE-ID" ||
             property.Name == "CLASS" && !ParseCalendarSensitivity(property.Value).HasValue ||
+            isEvent && property.Name == "STATUS" ||
             property.Name == "ATTACH" || property.Name == "TRIGGER" &&
             property.Parameters.TryGetValue("RELATED", out string? related) &&
             related.Equals("END", StringComparison.OrdinalIgnoreCase));
@@ -143,8 +145,6 @@ internal static class IcsCalendarCodec {
         }
         string? busy = GetValue(properties, "X-MICROSOFT-CDO-BUSYSTATUS");
         appointment.BusyStatus = ParseBusyStatus(busy) ?? ParseTransparency(GetValue(properties, "TRANSP"));
-        int? calendarSensitivity = ParseCalendarSensitivity(GetValue(properties, "CLASS"));
-        if (calendarSensitivity.HasValue) document.MessageMetadata.Sensitivity = calendarSensitivity;
         appointment.NotAllowPropose = ParseBoolean(GetValue(properties, "X-MICROSOFT-DISALLOW-COUNTER"));
         appointment.MeetingStatus = ParseInt(GetValue(properties, "X-OFFICEIMO-MEETING-STATUS"));
         appointment.ResponseStatus = ParseInt(GetValue(properties, "X-OFFICEIMO-RESPONSE-STATUS"));
@@ -180,14 +180,29 @@ internal static class IcsCalendarCodec {
         task.Status = ParseTaskStatus(status);
         task.Owner = UnescapeOrNull(GetValue(properties, "X-OFFICEIMO-TASK-OWNER")) ?? GetOrganizer(properties);
         task.IsRecurring = GetProperty(properties, "RRULE") != null;
-        task.EstimatedEffort = IcsDurationCodec.Parse(GetValue(properties, "X-OFFICEIMO-ESTIMATED-EFFORT")) ??
-            IcsDurationCodec.Parse(GetValue(properties, "DURATION"));
+        TimeSpan? standardDuration = IcsDurationCodec.Parse(GetValue(properties, "DURATION"));
+        task.EstimatedEffort = IcsDurationCodec.Parse(GetValue(properties, "X-OFFICEIMO-ESTIMATED-EFFORT"));
         task.ActualEffort = IcsDurationCodec.Parse(GetValue(properties, "X-OFFICEIMO-ACTUAL-EFFORT"));
         bool incompleteEffort = false;
         if (task.EstimatedEffort.HasValue) IcsDurationCodec.ToWholeMinutes(task.EstimatedEffort.Value,
             diagnostics, location, ref incompleteEffort);
         if (task.ActualEffort.HasValue) IcsDurationCodec.ToWholeMinutes(task.ActualEffort.Value,
             diagnostics, location, ref incompleteEffort);
+        if (!task.Due.HasValue && standardDuration.HasValue) {
+            if (task.Start.HasValue) {
+                try {
+                    task.Due = task.Start.Value.Add(standardDuration.Value);
+                } catch (ArgumentOutOfRangeException) {
+                    IcsDurationCodec.ReportOutOfRange(diagnostics, location);
+                    incompleteEffort = true;
+                }
+            } else {
+                diagnostics.Add(new EmailDiagnostic("EMAIL_ICALENDAR_TASK_DURATION_START_REQUIRED",
+                    "A VTODO duration cannot be projected to a due date without DTSTART.",
+                    EmailDiagnosticSeverity.Warning, location));
+                incompleteEffort = true;
+            }
+        }
         task.SendUpdates = ParseBoolean(GetValue(properties, "X-OFFICEIMO-SEND-UPDATES"));
         task.SendStatusOnComplete = ParseBoolean(GetValue(properties, "X-OFFICEIMO-SEND-STATUS-ON-COMPLETE"));
         task.Ownership = ParseInt(GetValue(properties, "X-OFFICEIMO-OWNERSHIP"));
@@ -211,6 +226,7 @@ internal static class IcsCalendarCodec {
         foreach (IcsProperty property in properties.Where(property => property.Name == "X-OFFICEIMO-COMPANY")) {
             task.Companies.Add(Unescape(property.Value));
         }
+        AddAttendeeRecipients(properties, document);
         document.MimeSemanticProjectionIsIncomplete |= incompleteEffort |
             ApplyReminder(properties, task, diagnostics, location);
     }
@@ -222,6 +238,16 @@ internal static class IcsCalendarCodec {
         if (!string.IsNullOrWhiteSpace(summary)) document.Subject = summary;
         if (!string.IsNullOrWhiteSpace(description) && document.Body.Text == null) document.Body.Text = description;
         if (!string.IsNullOrWhiteSpace(uid) && document.MessageId == null) document.MessageId = uid;
+        int? calendarSensitivity = ParseCalendarSensitivity(GetValue(properties, "CLASS"));
+        if (calendarSensitivity.HasValue) document.MessageMetadata.Sensitivity = calendarSensitivity;
+        foreach (IcsProperty property in properties.Where(property => property.Name == "CATEGORIES")) {
+            foreach (string category in SplitEscapedValues(property.Value, ',')) {
+                if (!string.IsNullOrWhiteSpace(category) && !document.MessageMetadata.Categories.Any(existing =>
+                    string.Equals(existing, category, StringComparison.OrdinalIgnoreCase))) {
+                    document.MessageMetadata.Categories.Add(category);
+                }
+            }
+        }
         string? organizer = GetOrganizer(properties);
         if (document.From == null && !string.IsNullOrWhiteSpace(organizer)) document.From = new EmailAddress(organizer!);
     }
@@ -244,11 +270,6 @@ internal static class IcsCalendarCodec {
             }
         }
         AppendText(output, "LOCATION", appointment.Location);
-        if (document.MessageMetadata.Sensitivity == 0) AppendLine(output, "CLASS:PUBLIC");
-        else if (document.MessageMetadata.Sensitivity == 3) AppendLine(output, "CLASS:CONFIDENTIAL");
-        else if (document.MessageMetadata.Sensitivity == 1 || document.MessageMetadata.Sensitivity == 2) {
-            AppendLine(output, "CLASS:PRIVATE");
-        }
         if (appointment.Sequence.HasValue) AppendLine(output, string.Concat("SEQUENCE:",
             appointment.Sequence.Value.ToString(CultureInfo.InvariantCulture)));
         if (appointment.BusyStatus.HasValue) {
@@ -323,6 +344,16 @@ internal static class IcsCalendarCodec {
         AppendLine(output, string.Concat("DTSTAMP:", FormatUtc(document.Date ?? fallbackDate ?? DeterministicEpoch)));
         AppendText(output, "SUMMARY", document.Subject);
         AppendText(output, "DESCRIPTION", document.Body.Text);
+        WriteCalendarSensitivity(output, document.MessageMetadata.Sensitivity);
+        if (document.MessageMetadata.Categories.Count > 0) AppendLine(output, string.Concat("CATEGORIES:",
+            string.Join(",", document.MessageMetadata.Categories.Where(category =>
+                !string.IsNullOrWhiteSpace(category)).Select(EscapeText))));
+    }
+
+    private static void WriteCalendarSensitivity(StringBuilder output, int? sensitivity) {
+        if (sensitivity == 0) AppendLine(output, "CLASS:PUBLIC");
+        else if (sensitivity == 3) AppendLine(output, "CLASS:CONFIDENTIAL");
+        else if (sensitivity == 1 || sensitivity == 2) AppendLine(output, "CLASS:PRIVATE");
     }
 
     private static void WriteOrganizerAndAttendees(StringBuilder output, EmailDocument document) {
@@ -347,136 +378,6 @@ internal static class IcsCalendarCodec {
                 EscapeParameter(recipient.Address.DisplayName!), "\"");
             AppendLine(output, string.Concat(attendee, ":mailto:", EscapeUriValue(recipient.Address.Address!)));
         }
-    }
-
-    private static List<IcsProperty> ParseProperties(string text) {
-        string normalized = text.Replace("\r\n", "\n").Replace('\r', '\n');
-        var unfolded = new List<string>();
-        foreach (string line in normalized.Split('\n')) {
-            if (line.Length > 0 && (line[0] == ' ' || line[0] == '\t') && unfolded.Count > 0) {
-                unfolded[unfolded.Count - 1] += line.Substring(1);
-            } else {
-                unfolded.Add(line);
-            }
-        }
-
-        var result = new List<IcsProperty>();
-        foreach (string line in unfolded) {
-            int colon = FindUnquotedSeparator(line, ':');
-            if (colon <= 0) continue;
-            IReadOnlyList<string> tokens = SplitUnquoted(line.Substring(0, colon), ';');
-            var property = new IcsProperty(tokens[0].Trim().ToUpperInvariant(), line.Substring(colon + 1));
-            for (int index = 1; index < tokens.Count; index++) {
-                int equals = FindUnquotedSeparator(tokens[index], '=');
-                if (equals > 0) property.Parameters[tokens[index].Substring(0, equals).Trim()] =
-                    tokens[index].Substring(equals + 1).Trim().Trim('"');
-            }
-            result.Add(property);
-        }
-        return result;
-    }
-
-    private static IReadOnlyList<IcsProperty> SelectActiveComponentProperties(
-        IReadOnlyList<IcsProperty> properties, string componentName) {
-        var selected = new List<IcsProperty>();
-        var components = new List<string>();
-        int activeDepth = -1;
-        bool selectedComponent = false;
-        foreach (IcsProperty property in properties) {
-            if (property.Name == "BEGIN") {
-                components.Add(property.Value.Trim().ToUpperInvariant());
-                if (!selectedComponent && property.Value.Equals(componentName, StringComparison.OrdinalIgnoreCase)) {
-                    activeDepth = components.Count;
-                    selectedComponent = true;
-                }
-                continue;
-            }
-            if (property.Name == "END") {
-                if (components.Count == activeDepth &&
-                    property.Value.Equals(componentName, StringComparison.OrdinalIgnoreCase)) activeDepth = -1;
-                if (components.Count > 0) components.RemoveAt(components.Count - 1);
-                continue;
-            }
-
-            bool calendarProperty = components.Count == 1 &&
-                components[0].Equals("VCALENDAR", StringComparison.OrdinalIgnoreCase);
-            bool componentProperty = activeDepth > 0 && components.Count == activeDepth;
-            bool alarmTrigger = activeDepth > 0 && components.Count == activeDepth + 1 &&
-                components[components.Count - 1].Equals("VALARM", StringComparison.OrdinalIgnoreCase) &&
-                property.Name == "TRIGGER";
-            if (calendarProperty || componentProperty || alarmTrigger) selected.Add(property);
-        }
-        return selected;
-    }
-
-    private static int FindUnquotedSeparator(string value, char separator) {
-        bool quoted = false;
-        bool escaped = false;
-        for (int index = 0; index < value.Length; index++) {
-            char character = value[index];
-            if (escaped) {
-                escaped = false;
-            } else if (character == '\\') {
-                escaped = true;
-            } else if (character == '"') {
-                quoted = !quoted;
-            } else if (!quoted && character == separator) {
-                return index;
-            }
-        }
-        return -1;
-    }
-
-    private static IReadOnlyList<string> SplitUnquoted(string value, char separator) {
-        var result = new List<string>();
-        int start = 0;
-        while (start <= value.Length) {
-            int relative = FindUnquotedSeparator(value.Substring(start), separator);
-            if (relative < 0) {
-                result.Add(value.Substring(start));
-                break;
-            }
-            result.Add(value.Substring(start, relative));
-            start += relative + 1;
-        }
-        return result;
-    }
-
-    private static DateTimeOffset? ParseDate(IcsProperty? property, IList<EmailDiagnostic> diagnostics,
-        string location, out bool isDateOnly) {
-        isDateOnly = property != null && property.Parameters.TryGetValue("VALUE", out string? valueType) &&
-            string.Equals(valueType, "DATE", StringComparison.OrdinalIgnoreCase);
-        if (property == null || string.IsNullOrWhiteSpace(property.Value)) return null;
-        string value = property.Value.Trim();
-        if (isDateOnly && DateTime.TryParseExact(value, "yyyyMMdd", CultureInfo.InvariantCulture,
-            DateTimeStyles.None, out DateTime date)) return new DateTimeOffset(date, TimeSpan.Zero);
-        if (DateTimeOffset.TryParseExact(value, new[] { "yyyyMMdd'T'HHmmss'Z'", "yyyyMMdd'T'HHmm'Z'" },
-            CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
-            out DateTimeOffset utc)) return utc;
-        if (DateTime.TryParseExact(value, new[] { "yyyyMMdd'T'HHmmss", "yyyyMMdd'T'HHmm" },
-            CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime local)) {
-            if (property.Parameters.TryGetValue("TZID", out string? timeZoneId)) {
-                try {
-                    TimeZoneInfo zone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
-                    return new DateTimeOffset(local, zone.GetUtcOffset(local));
-                } catch (TimeZoneNotFoundException) {
-                } catch (InvalidTimeZoneException) {
-                }
-                diagnostics.Add(new EmailDiagnostic("EMAIL_ICALENDAR_TIMEZONE_UNRESOLVED",
-                    string.Concat("The iCalendar time zone '", timeZoneId,
-                        "' could not be resolved and the local clock value was interpreted as UTC."),
-                    EmailDiagnosticSeverity.Warning, location));
-                return new DateTimeOffset(local, TimeSpan.Zero);
-            }
-            diagnostics.Add(new EmailDiagnostic("EMAIL_ICALENDAR_FLOATING_TIME",
-                "A floating iCalendar time could not be associated with a known time zone and was interpreted as UTC.",
-                EmailDiagnosticSeverity.Warning, location));
-            return new DateTimeOffset(local, TimeSpan.Zero);
-        }
-        diagnostics.Add(new EmailDiagnostic("EMAIL_ICALENDAR_DATE_INVALID",
-            string.Concat("The iCalendar value '", value, "' could not be parsed."),
-            EmailDiagnosticSeverity.Warning, location));
-        return null;
     }
 
     private static IcsProperty? GetProperty(IEnumerable<IcsProperty> properties, string name) =>
@@ -725,6 +626,26 @@ internal static class IcsCalendarCodec {
 
     private static string EscapeText(string value) => value.Replace("\\", "\\\\").Replace(";", "\\;")
         .Replace(",", "\\,").Replace("\r\n", "\\n").Replace("\r", "\\n").Replace("\n", "\\n");
+
+    private static IEnumerable<string> SplitEscapedValues(string value, char separator) {
+        var current = new StringBuilder();
+        bool escaped = false;
+        foreach (char character in value) {
+            if (escaped) {
+                current.Append('\\').Append(character);
+                escaped = false;
+            } else if (character == '\\') {
+                escaped = true;
+            } else if (character == separator) {
+                yield return Unescape(current.ToString());
+                current.Clear();
+            } else {
+                current.Append(character);
+            }
+        }
+        if (escaped) current.Append('\\');
+        yield return Unescape(current.ToString());
+    }
 
     private static string Unescape(string? value) => (value ?? string.Empty).Replace("\\n", "\n")
         .Replace("\\N", "\n").Replace("\\,", ",").Replace("\\;", ";").Replace("\\\\", "\\");

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
@@ -6,6 +6,7 @@ internal static class IcsCalendarCodec {
 
     internal static bool TryProject(string text, EmailDocument document, IList<EmailDiagnostic> diagnostics,
         string location) {
+        int projectionDiagnosticStart = diagnostics.Count;
         List<IcsProperty> properties = ParseProperties(text.TrimStart('\uFEFF'));
         IcsProperty? activeComponent = properties.FirstOrDefault(property => property.Name == "BEGIN" &&
             (property.Value.Equals("VEVENT", StringComparison.OrdinalIgnoreCase) ||
@@ -18,6 +19,8 @@ internal static class IcsCalendarCodec {
         document.MimeSemanticProjectionIsIncomplete |= HasIncompleteStoreProjection(properties, activeProperties);
         if (isEvent) ProjectEvent(activeProperties, document, diagnostics, location);
         else ProjectTask(activeProperties, document, diagnostics, location);
+        document.MimeSemanticProjectionIsIncomplete |= diagnostics.Skip(projectionDiagnosticStart).Any(diagnostic =>
+            diagnostic.Code == "EMAIL_ICALENDAR_TIMEZONE_UNRESOLVED");
         return true;
     }
 
@@ -80,13 +83,32 @@ internal static class IcsCalendarCodec {
         int calendarItems = properties.Count(property => property.Name == "BEGIN" &&
             (property.Value.Equals("VEVENT", StringComparison.OrdinalIgnoreCase) ||
              property.Value.Equals("VTODO", StringComparison.OrdinalIgnoreCase)));
+        int calendarRoots = properties.Count(property => property.Name == "BEGIN" &&
+            property.Value.Equals("VCALENDAR", StringComparison.OrdinalIgnoreCase));
+        int alarms = properties.Count(property => property.Name == "BEGIN" &&
+            property.Value.Equals("VALARM", StringComparison.OrdinalIgnoreCase));
         bool hasTimeZone = properties.Any(property => property.Name == "BEGIN" &&
             property.Value.Equals("VTIMEZONE", StringComparison.OrdinalIgnoreCase));
-        return calendarItems > 1 || hasTimeZone || activeProperties.Any(property =>
+        bool hasUnsupportedComponent = properties.Any(property => property.Name == "BEGIN" &&
+            !IsSupportedComponent(property.Value));
+        return calendarRoots != 1 || calendarItems > 1 || alarms > 1 || hasTimeZone || hasUnsupportedComponent ||
+            activeProperties.Any(property =>
             property.Name == "RRULE" || property.Name == "RDATE" ||
             property.Name == "EXDATE" || property.Name == "RECURRENCE-ID" ||
-            property.Name == "ATTACH");
+            property.Name == "CLASS" && !ParseCalendarSensitivity(property.Value).HasValue ||
+            property.Name == "ATTACH" || property.Name == "TRIGGER" &&
+            property.Parameters.TryGetValue("RELATED", out string? related) &&
+            related.Equals("END", StringComparison.OrdinalIgnoreCase));
     }
+
+    private static bool IsSupportedComponent(string value) =>
+        value.Equals("VCALENDAR", StringComparison.OrdinalIgnoreCase) ||
+        value.Equals("VEVENT", StringComparison.OrdinalIgnoreCase) ||
+        value.Equals("VTODO", StringComparison.OrdinalIgnoreCase) ||
+        value.Equals("VTIMEZONE", StringComparison.OrdinalIgnoreCase) ||
+        value.Equals("VALARM", StringComparison.OrdinalIgnoreCase) ||
+        value.Equals("STANDARD", StringComparison.OrdinalIgnoreCase) ||
+        value.Equals("DAYLIGHT", StringComparison.OrdinalIgnoreCase);
 
     private static void ProjectEvent(IReadOnlyList<IcsProperty> properties, EmailDocument document,
         IList<EmailDiagnostic> diagnostics, string location) {
@@ -103,24 +125,26 @@ internal static class IcsCalendarCodec {
         appointment.Sequence = ParseInt(GetValue(properties, "SEQUENCE"));
         appointment.IsRecurring = GetProperty(properties, "RRULE") != null;
         appointment.RecurrencePattern = GetValue(properties, "RRULE");
-        TimeSpan? duration = ParseDuration(GetValue(properties, "DURATION"));
+        TimeSpan? duration = IcsDurationCodec.Parse(GetValue(properties, "DURATION"));
         bool incompleteDuration = false;
         TimeSpan? effectiveDuration = appointment.Start.HasValue && appointment.End.HasValue
             ? appointment.End.Value - appointment.Start.Value
             : duration;
         appointment.DurationMinutes = effectiveDuration.HasValue
-            ? ConvertDurationMinutes(effectiveDuration.Value, diagnostics, location, ref incompleteDuration)
+            ? IcsDurationCodec.ToWholeMinutes(effectiveDuration.Value, diagnostics, location, ref incompleteDuration)
             : null;
         if (!appointment.End.HasValue && appointment.Start.HasValue && duration.HasValue) {
             try {
                 appointment.End = appointment.Start.Value.Add(duration.Value);
             } catch (ArgumentOutOfRangeException) {
-                ReportDurationOutOfRange(diagnostics, location);
+                IcsDurationCodec.ReportOutOfRange(diagnostics, location);
                 incompleteDuration = true;
             }
         }
         string? busy = GetValue(properties, "X-MICROSOFT-CDO-BUSYSTATUS");
-        appointment.BusyStatus = ParseBusyStatus(busy);
+        appointment.BusyStatus = ParseBusyStatus(busy) ?? ParseTransparency(GetValue(properties, "TRANSP"));
+        int? calendarSensitivity = ParseCalendarSensitivity(GetValue(properties, "CLASS"));
+        if (calendarSensitivity.HasValue) document.MessageMetadata.Sensitivity = calendarSensitivity;
         appointment.NotAllowPropose = ParseBoolean(GetValue(properties, "X-MICROSOFT-DISALLOW-COUNTER"));
         appointment.MeetingStatus = ParseInt(GetValue(properties, "X-OFFICEIMO-MEETING-STATUS"));
         appointment.ResponseStatus = ParseInt(GetValue(properties, "X-OFFICEIMO-RESPONSE-STATUS"));
@@ -156,9 +180,14 @@ internal static class IcsCalendarCodec {
         task.Status = ParseTaskStatus(status);
         task.Owner = UnescapeOrNull(GetValue(properties, "X-OFFICEIMO-TASK-OWNER")) ?? GetOrganizer(properties);
         task.IsRecurring = GetProperty(properties, "RRULE") != null;
-        task.EstimatedEffort = ParseDuration(GetValue(properties, "X-OFFICEIMO-ESTIMATED-EFFORT")) ??
-            ParseDuration(GetValue(properties, "DURATION"));
-        task.ActualEffort = ParseDuration(GetValue(properties, "X-OFFICEIMO-ACTUAL-EFFORT"));
+        task.EstimatedEffort = IcsDurationCodec.Parse(GetValue(properties, "X-OFFICEIMO-ESTIMATED-EFFORT")) ??
+            IcsDurationCodec.Parse(GetValue(properties, "DURATION"));
+        task.ActualEffort = IcsDurationCodec.Parse(GetValue(properties, "X-OFFICEIMO-ACTUAL-EFFORT"));
+        bool incompleteEffort = false;
+        if (task.EstimatedEffort.HasValue) IcsDurationCodec.ToWholeMinutes(task.EstimatedEffort.Value,
+            diagnostics, location, ref incompleteEffort);
+        if (task.ActualEffort.HasValue) IcsDurationCodec.ToWholeMinutes(task.ActualEffort.Value,
+            diagnostics, location, ref incompleteEffort);
         task.SendUpdates = ParseBoolean(GetValue(properties, "X-OFFICEIMO-SEND-UPDATES"));
         task.SendStatusOnComplete = ParseBoolean(GetValue(properties, "X-OFFICEIMO-SEND-STATUS-ON-COMPLETE"));
         task.Ownership = ParseInt(GetValue(properties, "X-OFFICEIMO-OWNERSHIP"));
@@ -182,7 +211,8 @@ internal static class IcsCalendarCodec {
         foreach (IcsProperty property in properties.Where(property => property.Name == "X-OFFICEIMO-COMPANY")) {
             task.Companies.Add(Unescape(property.Value));
         }
-        document.MimeSemanticProjectionIsIncomplete |= ApplyReminder(properties, task, diagnostics, location);
+        document.MimeSemanticProjectionIsIncomplete |= incompleteEffort |
+            ApplyReminder(properties, task, diagnostics, location);
     }
 
     private static void ApplyCommon(IReadOnlyList<IcsProperty> properties, EmailDocument document) {
@@ -209,10 +239,16 @@ internal static class IcsCalendarCodec {
                 AppendLine(output, string.Concat("DTSTART:", FormatUtc(appointment.Start.Value)));
                 if (appointment.End.HasValue) AppendLine(output, string.Concat("DTEND:", FormatUtc(appointment.End.Value)));
                 else if (appointment.DurationMinutes.HasValue) AppendLine(output,
-                    string.Concat("DURATION:", FormatDuration(TimeSpan.FromMinutes(appointment.DurationMinutes.Value))));
+                    string.Concat("DURATION:", IcsDurationCodec.Format(
+                        TimeSpan.FromMinutes(appointment.DurationMinutes.Value))));
             }
         }
         AppendText(output, "LOCATION", appointment.Location);
+        if (document.MessageMetadata.Sensitivity == 0) AppendLine(output, "CLASS:PUBLIC");
+        else if (document.MessageMetadata.Sensitivity == 3) AppendLine(output, "CLASS:CONFIDENTIAL");
+        else if (document.MessageMetadata.Sensitivity == 1 || document.MessageMetadata.Sensitivity == 2) {
+            AppendLine(output, "CLASS:PRIVATE");
+        }
         if (appointment.Sequence.HasValue) AppendLine(output, string.Concat("SEQUENCE:",
             appointment.Sequence.Value.ToString(CultureInfo.InvariantCulture)));
         if (appointment.BusyStatus.HasValue) {
@@ -247,14 +283,14 @@ internal static class IcsCalendarCodec {
         else if (task.Status == 1) AppendLine(output, "STATUS:IN-PROCESS");
         else AppendLine(output, "STATUS:NEEDS-ACTION");
         if (task.EstimatedEffort.HasValue) AppendLine(output,
-            string.Concat("X-OFFICEIMO-ESTIMATED-EFFORT:", FormatDuration(task.EstimatedEffort.Value)));
+            string.Concat("X-OFFICEIMO-ESTIMATED-EFFORT:", IcsDurationCodec.Format(task.EstimatedEffort.Value)));
         if (!string.IsNullOrWhiteSpace(task.Owner)) {
             if (task.Owner!.IndexOf('@') >= 0) AppendLine(output,
                 string.Concat("ORGANIZER:mailto:", EscapeUriValue(task.Owner)));
             else AppendText(output, "X-OFFICEIMO-TASK-OWNER", task.Owner);
         }
         if (task.ActualEffort.HasValue) AppendLine(output,
-            string.Concat("X-OFFICEIMO-ACTUAL-EFFORT:", FormatDuration(task.ActualEffort.Value)));
+            string.Concat("X-OFFICEIMO-ACTUAL-EFFORT:", IcsDurationCodec.Format(task.ActualEffort.Value)));
         AppendBoolean(output, "X-OFFICEIMO-SEND-UPDATES", task.SendUpdates);
         AppendBoolean(output, "X-OFFICEIMO-SEND-STATUS-ON-COMPLETE", task.SendStatusOnComplete);
         AppendInteger(output, "X-OFFICEIMO-OWNERSHIP", task.Ownership);
@@ -426,6 +462,11 @@ internal static class IcsCalendarCodec {
                 } catch (TimeZoneNotFoundException) {
                 } catch (InvalidTimeZoneException) {
                 }
+                diagnostics.Add(new EmailDiagnostic("EMAIL_ICALENDAR_TIMEZONE_UNRESOLVED",
+                    string.Concat("The iCalendar time zone '", timeZoneId,
+                        "' could not be resolved and the local clock value was interpreted as UTC."),
+                    EmailDiagnosticSeverity.Warning, location));
+                return new DateTimeOffset(local, TimeSpan.Zero);
             }
             diagnostics.Add(new EmailDiagnostic("EMAIL_ICALENDAR_FLOATING_TIME",
                 "A floating iCalendar time could not be associated with a known time zone and was interpreted as UTC.",
@@ -492,31 +533,6 @@ internal static class IcsCalendarCodec {
     private static int? ParseInt(string? value) => int.TryParse(value, NumberStyles.Integer,
         CultureInfo.InvariantCulture, out int result) ? result : (int?)null;
 
-    private static TimeSpan? ParseDuration(string? value) {
-        if (string.IsNullOrWhiteSpace(value)) return null;
-        string normalized = value!.Trim().ToUpperInvariant();
-        bool negative = normalized.StartsWith("-", StringComparison.Ordinal);
-        if (negative || normalized.StartsWith("+", StringComparison.Ordinal)) normalized = normalized.Substring(1);
-        if (normalized.Length > 2 && normalized[0] == 'P' && normalized[normalized.Length - 1] == 'W' &&
-            long.TryParse(normalized.Substring(1, normalized.Length - 2), NumberStyles.None,
-                CultureInfo.InvariantCulture, out long weeks)) {
-            try {
-                long ticks = checked(weeks * 7L * TimeSpan.TicksPerDay);
-                return TimeSpan.FromTicks(negative ? checked(-ticks) : ticks);
-            } catch (OverflowException) {
-                return null;
-            }
-        }
-        try {
-            string xmlValue = negative ? string.Concat("-", normalized) : normalized;
-            return System.Xml.XmlConvert.ToTimeSpan(xmlValue);
-        } catch (FormatException) {
-            return null;
-        } catch (OverflowException) {
-            return null;
-        }
-    }
-
     private static bool? ParseBoolean(string? value) => string.Equals(value, "TRUE", StringComparison.OrdinalIgnoreCase)
         ? true : string.Equals(value, "FALSE", StringComparison.OrdinalIgnoreCase) ? false : (bool?)null;
 
@@ -529,6 +545,15 @@ internal static class IcsCalendarCodec {
         if (value.Equals("WORKINGELSEWHERE", StringComparison.OrdinalIgnoreCase)) return 4;
         return null;
     }
+
+    private static int? ParseTransparency(string? value) =>
+        string.Equals(value, "TRANSPARENT", StringComparison.OrdinalIgnoreCase) ? 0 :
+        string.Equals(value, "OPAQUE", StringComparison.OrdinalIgnoreCase) ? 2 : (int?)null;
+
+    private static int? ParseCalendarSensitivity(string? value) =>
+        string.Equals(value, "PUBLIC", StringComparison.OrdinalIgnoreCase) ? 0 :
+        string.Equals(value, "PRIVATE", StringComparison.OrdinalIgnoreCase) ? 2 :
+        string.Equals(value, "CONFIDENTIAL", StringComparison.OrdinalIgnoreCase) ? 3 : (int?)null;
 
     private static int? ParseTaskStatus(string? value) {
         if (string.Equals(value, "NOT-STARTED", StringComparison.OrdinalIgnoreCase) ||
@@ -578,22 +603,6 @@ internal static class IcsCalendarCodec {
     private static string FormatDate(DateTimeOffset value) =>
         value.Date.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
 
-    private static string FormatDuration(TimeSpan value) {
-        string sign = value < TimeSpan.Zero ? "-" : string.Empty;
-        TimeSpan absolute = value.Duration();
-        var result = new StringBuilder(sign).Append('P');
-        if (absolute.Days > 0) result.Append(absolute.Days.ToString(CultureInfo.InvariantCulture)).Append('D');
-        if (absolute.Hours > 0 || absolute.Minutes > 0 || absolute.Seconds > 0 || absolute.Days == 0) {
-            result.Append('T');
-            if (absolute.Hours > 0) result.Append(absolute.Hours.ToString(CultureInfo.InvariantCulture)).Append('H');
-            if (absolute.Minutes > 0) result.Append(absolute.Minutes.ToString(CultureInfo.InvariantCulture)).Append('M');
-            if (absolute.Seconds > 0 || absolute == TimeSpan.Zero) {
-                result.Append(absolute.Seconds.ToString(CultureInfo.InvariantCulture)).Append('S');
-            }
-        }
-        return result.ToString();
-    }
-
     private static bool ApplyReminder(IReadOnlyList<IcsProperty> properties, OutlookAppointment appointment,
         IList<EmailDiagnostic> diagnostics, string location) {
         IcsProperty? trigger = GetProperty(properties, "TRIGGER");
@@ -630,28 +639,10 @@ internal static class IcsCalendarCodec {
         incomplete = false;
         if (trigger == null || trigger.Parameters.TryGetValue("VALUE", out string? valueType) &&
             valueType.Equals("DATE-TIME", StringComparison.OrdinalIgnoreCase)) return null;
-        TimeSpan? value = ParseDuration(trigger.Value);
+        TimeSpan? value = IcsDurationCodec.Parse(trigger.Value);
         return value.HasValue
-            ? ConvertDurationMinutes(value.Value, diagnostics, location, ref incomplete, invert: true)
+            ? IcsDurationCodec.ToWholeMinutes(value.Value, diagnostics, location, ref incomplete, invert: true)
             : null;
-    }
-
-    private static int? ConvertDurationMinutes(TimeSpan value, IList<EmailDiagnostic> diagnostics,
-        string location, ref bool incomplete, bool invert = false) {
-        double minutes = value.TotalMinutes;
-        if (invert) minutes = -minutes;
-        if (minutes >= int.MinValue && minutes <= int.MaxValue) return (int)minutes;
-        ReportDurationOutOfRange(diagnostics, location);
-        incomplete = true;
-        return null;
-    }
-
-    private static void ReportDurationOutOfRange(IList<EmailDiagnostic> diagnostics, string location) {
-        if (diagnostics.Any(diagnostic => diagnostic.Code == "EMAIL_ICALENDAR_DURATION_OUT_OF_RANGE" &&
-            string.Equals(diagnostic.Location, location, StringComparison.Ordinal))) return;
-        diagnostics.Add(new EmailDiagnostic("EMAIL_ICALENDAR_DURATION_OUT_OF_RANGE",
-            "An iCalendar duration exceeds the supported whole-minute range and was retained only in the semantic source.",
-            EmailDiagnosticSeverity.Warning, location));
     }
 
     private static DateTimeOffset? ParseAbsoluteTrigger(IcsProperty? trigger,
@@ -677,7 +668,7 @@ internal static class IcsCalendarCodec {
         AppendLine(output, "ACTION:DISPLAY");
         AppendText(output, "DESCRIPTION", string.IsNullOrWhiteSpace(subject) ? "Reminder" : subject);
         if (deltaMinutes.HasValue) AppendLine(output, string.Concat("TRIGGER:",
-            FormatDuration(TimeSpan.FromMinutes(-deltaMinutes.Value))));
+            IcsDurationCodec.Format(TimeSpan.FromMinutes(-deltaMinutes.Value))));
         else if (absoluteTime.HasValue) AppendLine(output,
             string.Concat("TRIGGER;VALUE=DATE-TIME:", FormatUtc(absoluteTime.Value)));
         else AppendLine(output, "TRIGGER:PT0S");

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
@@ -23,7 +23,8 @@ internal static partial class IcsCalendarCodec {
         if (isEvent) ProjectEvent(activeProperties, document, diagnostics, location);
         else ProjectTask(activeProperties, document, diagnostics, location);
         document.MimeSemanticProjectionIsIncomplete |= diagnostics.Skip(projectionDiagnosticStart).Any(diagnostic =>
-            diagnostic.Code == "EMAIL_ICALENDAR_TIMEZONE_UNRESOLVED");
+            diagnostic.Code == "EMAIL_ICALENDAR_TIMEZONE_UNRESOLVED" ||
+            diagnostic.Code == "EMAIL_ICALENDAR_DATE_INVALID");
         return true;
     }
 
@@ -113,12 +114,19 @@ internal static partial class IcsCalendarCodec {
         IcsProperty[] actions = alarmProperties.Where(property => property.Name == "ACTION").ToArray();
         IcsProperty[] triggers = alarmProperties.Where(property => property.Name == "TRIGGER").ToArray();
         if (actions.Length != 1 || !actions[0].Value.Trim().Equals("DISPLAY", StringComparison.OrdinalIgnoreCase) ||
-            triggers.Length != 1 || !IcsDurationCodec.Parse(triggers[0].Value).HasValue) return true;
-        if (triggers[0].Parameters.Any(parameter =>
-                parameter.Key.Equals("RELATED", StringComparison.OrdinalIgnoreCase)
-                    ? !parameter.Value.Equals("START", StringComparison.OrdinalIgnoreCase)
-                    : !parameter.Key.Equals("VALUE", StringComparison.OrdinalIgnoreCase) ||
-                      !parameter.Value.Equals("DURATION", StringComparison.OrdinalIgnoreCase))) return true;
+            triggers.Length != 1) return true;
+        bool absolute = triggers[0].Parameters.TryGetValue("VALUE", out string? valueType) &&
+            valueType.Equals("DATE-TIME", StringComparison.OrdinalIgnoreCase);
+        if (absolute) {
+            if (string.IsNullOrWhiteSpace(triggers[0].Value) || triggers[0].Parameters.Any(parameter =>
+                    !parameter.Key.Equals("VALUE", StringComparison.OrdinalIgnoreCase))) return true;
+        } else {
+            if (!IcsDurationCodec.Parse(triggers[0].Value).HasValue || triggers[0].Parameters.Any(parameter =>
+                    parameter.Key.Equals("RELATED", StringComparison.OrdinalIgnoreCase)
+                        ? !parameter.Value.Equals("START", StringComparison.OrdinalIgnoreCase)
+                        : !parameter.Key.Equals("VALUE", StringComparison.OrdinalIgnoreCase) ||
+                          !parameter.Value.Equals("DURATION", StringComparison.OrdinalIgnoreCase))) return true;
+        }
         return alarmProperties.Any(property => property.Name != "ACTION" && property.Name != "TRIGGER" &&
             property.Name != "DESCRIPTION");
     }
@@ -256,8 +264,17 @@ internal static partial class IcsCalendarCodec {
         string? description = Unescape(GetValue(properties, "DESCRIPTION"));
         string? uid = Unescape(GetValue(properties, "UID"));
         if (!string.IsNullOrWhiteSpace(summary)) document.Subject = summary;
-        if (!string.IsNullOrWhiteSpace(description) && document.Body.Text == null) document.Body.Text = description;
-        if (!string.IsNullOrWhiteSpace(uid) && document.MessageId == null) document.MessageId = uid;
+        if (!string.IsNullOrWhiteSpace(description)) {
+            if (document.Body.Text == null) document.Body.Text = description;
+            else if (!string.Equals(document.Body.Text, description, StringComparison.Ordinal)) {
+                document.MimeSemanticProjectionIsIncomplete = true;
+            }
+        }
+        if (!string.IsNullOrWhiteSpace(uid)) {
+            if (document.MessageId == null) document.MessageId = uid;
+            else if (!string.Equals(document.MessageId.Trim().Trim('<', '>'), uid,
+                         StringComparison.Ordinal)) document.MimeSemanticProjectionIsIncomplete = true;
+        }
         int? calendarSensitivity = ParseCalendarSensitivity(GetValue(properties, "CLASS"));
         if (calendarSensitivity.HasValue) document.MessageMetadata.Sensitivity = calendarSensitivity;
         foreach (IcsProperty property in properties.Where(property => property.Name == "CATEGORIES")) {
@@ -269,7 +286,20 @@ internal static partial class IcsCalendarCodec {
             }
         }
         string? organizer = GetOrganizer(properties);
-        if (document.From == null && !string.IsNullOrWhiteSpace(organizer)) document.From = new EmailAddress(organizer!);
+        if (!string.IsNullOrWhiteSpace(organizer)) {
+            IcsProperty? organizerProperty = GetProperty(properties, "ORGANIZER");
+            string? organizerName = null;
+            organizerProperty?.Parameters.TryGetValue("CN", out organizerName);
+            if (document.From == null) document.From = new EmailAddress(organizer!, organizerName);
+            else if (!string.Equals(document.From.Address, organizer, StringComparison.OrdinalIgnoreCase)) {
+                document.MimeSemanticProjectionIsIncomplete = true;
+            } else if (string.IsNullOrWhiteSpace(document.From.DisplayName)) {
+                document.From.DisplayName = organizerName;
+            } else if (!string.IsNullOrWhiteSpace(organizerName) &&
+                       !string.Equals(document.From.DisplayName, organizerName, StringComparison.Ordinal)) {
+                document.MimeSemanticProjectionIsIncomplete = true;
+            }
+        }
     }
 
     private static void WriteEvent(StringBuilder output, EmailDocument document) {
@@ -667,8 +697,22 @@ internal static partial class IcsCalendarCodec {
         yield return Unescape(current.ToString());
     }
 
-    private static string Unescape(string? value) => (value ?? string.Empty).Replace("\\n", "\n")
-        .Replace("\\N", "\n").Replace("\\,", ",").Replace("\\;", ";").Replace("\\\\", "\\");
+    private static string Unescape(string? value) {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        var result = new StringBuilder(value!.Length);
+        for (int index = 0; index < value.Length; index++) {
+            char character = value[index];
+            if (character != '\\' || index + 1 >= value.Length) {
+                result.Append(character);
+                continue;
+            }
+            char escaped = value[++index];
+            if (escaped == 'n' || escaped == 'N') result.Append('\n');
+            else if (escaped == ',' || escaped == ';' || escaped == '\\') result.Append(escaped);
+            else result.Append('\\').Append(escaped);
+        }
+        return result.ToString();
+    }
 
     private static string? UnescapeOrNull(string? value) => string.IsNullOrWhiteSpace(value)
         ? null

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
@@ -21,13 +21,17 @@ internal static partial class IcsCalendarCodec {
         document.MimeSemanticProjectionIsIncomplete |= HasIncompleteStoreProjection(
             properties, activeProperties, alarmProperties, isEvent, document.Subject);
         string? calendarMethod = GetValue(activeProperties, "METHOD");
-        if (!string.IsNullOrWhiteSpace(calendarMethod) && !string.IsNullOrWhiteSpace(mimeMethod) &&
-            !string.Equals(calendarMethod, mimeMethod, StringComparison.OrdinalIgnoreCase) ||
-            isEvent && !IsStoreProjectableMethod(calendarMethod ?? mimeMethod)) {
+        string? effectiveMethod = calendarMethod ?? mimeMethod;
+        bool hasMethodConflict = !string.IsNullOrWhiteSpace(calendarMethod) &&
+            !string.IsNullOrWhiteSpace(mimeMethod) &&
+            !string.Equals(calendarMethod, mimeMethod, StringComparison.OrdinalIgnoreCase);
+        bool publishWouldBecomeRequest = isEvent &&
+            string.Equals(effectiveMethod, "PUBLISH", StringComparison.OrdinalIgnoreCase) &&
+            (HasCalendarRecipients(document) || activeProperties.Any(property => property.Name == "ATTENDEE"));
+        if (hasMethodConflict || isEvent && !IsStoreProjectableMethod(effectiveMethod) || publishWouldBecomeRequest) {
             document.MimeSemanticProjectionIsIncomplete = true;
         }
-        if (isEvent) ProjectEvent(activeProperties, document, diagnostics, location,
-            calendarMethod ?? mimeMethod);
+        if (isEvent) ProjectEvent(activeProperties, document, diagnostics, location, effectiveMethod);
         else ProjectTask(activeProperties, document, diagnostics, location);
         document.MimeSemanticProjectionIsIncomplete |= diagnostics.Skip(projectionDiagnosticStart).Any(diagnostic =>
             diagnostic.Code == "EMAIL_ICALENDAR_TIMEZONE_UNRESOLVED" ||
@@ -89,99 +93,6 @@ internal static partial class IcsCalendarCodec {
             appointment.RecurrenceTimeZoneDefinition != null || appointment.IsRecurring == true ||
             appointment.RecurrenceType.HasValue || !string.IsNullOrWhiteSpace(appointment.RecurrencePattern);
     }
-
-    private static bool HasIncompleteStoreProjection(IEnumerable<IcsProperty> properties,
-        IEnumerable<IcsProperty> activeProperties, IReadOnlyList<IcsProperty> alarmProperties, bool isEvent,
-        string? envelopeSubject) {
-        int calendarItems = properties.Count(property => property.Name == "BEGIN" &&
-            (property.Value.Equals("VEVENT", StringComparison.OrdinalIgnoreCase) ||
-             property.Value.Equals("VTODO", StringComparison.OrdinalIgnoreCase)));
-        int calendarRoots = properties.Count(property => property.Name == "BEGIN" &&
-            property.Value.Equals("VCALENDAR", StringComparison.OrdinalIgnoreCase));
-        int alarms = properties.Count(property => property.Name == "BEGIN" &&
-            property.Value.Equals("VALARM", StringComparison.OrdinalIgnoreCase));
-        bool hasTimeZone = properties.Any(property => property.Name == "BEGIN" &&
-            property.Value.Equals("VTIMEZONE", StringComparison.OrdinalIgnoreCase));
-        bool hasUnsupportedComponent = properties.Any(property => property.Name == "BEGIN" &&
-            !IsSupportedComponent(property.Value));
-        string? calendarSummary = Unescape(GetValue(activeProperties, "SUMMARY"));
-        string? reminderDescription = string.IsNullOrWhiteSpace(calendarSummary)
-            ? envelopeSubject
-            : calendarSummary;
-        return calendarRoots != 1 || calendarItems > 1 || alarms > 1 || hasTimeZone || hasUnsupportedComponent ||
-            HasIncompleteAlarmProjection(alarms, alarmProperties, reminderDescription) ||
-            activeProperties.Any(property =>
-            property.Name == "RRULE" || property.Name == "RDATE" ||
-            property.Name == "EXDATE" || property.Name == "RECURRENCE-ID" ||
-            property.Name == "CLASS" && !ParseCalendarSensitivity(property.Value).HasValue ||
-            isEvent && property.Name == "STATUS" ||
-            property.Name == "PRIORITY" ||
-            property.Name == "ATTENDEE" && HasIncompleteAttendeeProjection(property) ||
-            property.Name == "ATTACH" || property.Name == "TRIGGER" &&
-            property.Parameters.TryGetValue("RELATED", out string? related) &&
-            related.Equals("END", StringComparison.OrdinalIgnoreCase));
-    }
-
-    private static bool HasIncompleteAlarmProjection(int alarmCount,
-        IReadOnlyList<IcsProperty> alarmProperties, string? reminderDescription) {
-        if (alarmCount == 0) return false;
-        if (alarmCount != 1) return true;
-        IcsProperty[] actions = alarmProperties.Where(property => property.Name == "ACTION").ToArray();
-        IcsProperty[] triggers = alarmProperties.Where(property => property.Name == "TRIGGER").ToArray();
-        if (actions.Length != 1 || !actions[0].Value.Trim().Equals("DISPLAY", StringComparison.OrdinalIgnoreCase) ||
-            triggers.Length != 1) return true;
-        bool absolute = triggers[0].Parameters.TryGetValue("VALUE", out string? valueType) &&
-            valueType.Equals("DATE-TIME", StringComparison.OrdinalIgnoreCase);
-        if (absolute) {
-            if (string.IsNullOrWhiteSpace(triggers[0].Value) || triggers[0].Parameters.Any(parameter =>
-                    !parameter.Key.Equals("VALUE", StringComparison.OrdinalIgnoreCase))) return true;
-        } else {
-            if (!IcsDurationCodec.Parse(triggers[0].Value).HasValue || triggers[0].Parameters.Any(parameter =>
-                    parameter.Key.Equals("RELATED", StringComparison.OrdinalIgnoreCase)
-                        ? !parameter.Value.Equals("START", StringComparison.OrdinalIgnoreCase)
-                        : !parameter.Key.Equals("VALUE", StringComparison.OrdinalIgnoreCase) ||
-                          !parameter.Value.Equals("DURATION", StringComparison.OrdinalIgnoreCase))) return true;
-        }
-        IcsProperty[] descriptions = alarmProperties.Where(property => property.Name == "DESCRIPTION").ToArray();
-        string expectedDescription = string.IsNullOrWhiteSpace(reminderDescription)
-            ? "Reminder"
-            : reminderDescription!;
-        return descriptions.Length > 1 || descriptions.Length == 1 &&
-                !string.Equals(Unescape(descriptions[0].Value), expectedDescription, StringComparison.Ordinal) ||
-            alarmProperties.Any(property => property.Name != "ACTION" && property.Name != "TRIGGER" &&
-                property.Name != "DESCRIPTION");
-    }
-
-    private static bool HasIncompleteAttendeeProjection(IcsProperty attendee) {
-        foreach (KeyValuePair<string, string> parameter in attendee.Parameters) {
-            if (parameter.Key.Equals("CN", StringComparison.OrdinalIgnoreCase)) continue;
-            if (parameter.Key.Equals("CUTYPE", StringComparison.OrdinalIgnoreCase)) {
-                if (parameter.Value.Equals("INDIVIDUAL", StringComparison.OrdinalIgnoreCase) ||
-                    parameter.Value.Equals("ROOM", StringComparison.OrdinalIgnoreCase) ||
-                    parameter.Value.Equals("RESOURCE", StringComparison.OrdinalIgnoreCase)) continue;
-                return true;
-            }
-            if (!parameter.Key.Equals("ROLE", StringComparison.OrdinalIgnoreCase)) return true;
-            bool roomOrResource = attendee.Parameters.TryGetValue("CUTYPE", out string? calendarUserType) &&
-                (calendarUserType.Equals("ROOM", StringComparison.OrdinalIgnoreCase) ||
-                 calendarUserType.Equals("RESOURCE", StringComparison.OrdinalIgnoreCase));
-            if (roomOrResource
-                    ? parameter.Value.Equals("NON-PARTICIPANT", StringComparison.OrdinalIgnoreCase)
-                    : parameter.Value.Equals("REQ-PARTICIPANT", StringComparison.OrdinalIgnoreCase) ||
-                      parameter.Value.Equals("OPT-PARTICIPANT", StringComparison.OrdinalIgnoreCase)) continue;
-            return true;
-        }
-        return false;
-    }
-
-    private static bool IsSupportedComponent(string value) =>
-        value.Equals("VCALENDAR", StringComparison.OrdinalIgnoreCase) ||
-        value.Equals("VEVENT", StringComparison.OrdinalIgnoreCase) ||
-        value.Equals("VTODO", StringComparison.OrdinalIgnoreCase) ||
-        value.Equals("VTIMEZONE", StringComparison.OrdinalIgnoreCase) ||
-        value.Equals("VALARM", StringComparison.OrdinalIgnoreCase) ||
-        value.Equals("STANDARD", StringComparison.OrdinalIgnoreCase) ||
-        value.Equals("DAYLIGHT", StringComparison.OrdinalIgnoreCase);
 
     private static void ProjectEvent(IReadOnlyList<IcsProperty> properties, EmailDocument document,
         IList<EmailDiagnostic> diagnostics, string location, string? method) {
@@ -604,14 +515,16 @@ internal static partial class IcsCalendarCodec {
         string.Equals(method, "REPLY", StringComparison.OrdinalIgnoreCase) ||
         string.Equals(method, "CANCEL", StringComparison.OrdinalIgnoreCase);
 
+    private static bool HasCalendarRecipients(EmailDocument document) => document.Recipients.Any(recipient =>
+        recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc ||
+        recipient.Kind == EmailRecipientKind.Room || recipient.Kind == EmailRecipientKind.Resource);
+
     internal static string GetMethod(EmailDocument document) {
         string messageClass = document.MessageClass ?? string.Empty;
         if (messageClass.IndexOf("Canceled", StringComparison.OrdinalIgnoreCase) >= 0) return "CANCEL";
         if (messageClass.IndexOf("Request", StringComparison.OrdinalIgnoreCase) >= 0) return "REQUEST";
         if (messageClass.IndexOf("Resp", StringComparison.OrdinalIgnoreCase) >= 0) return "REPLY";
-        return document.Recipients.Any(recipient => recipient.Kind == EmailRecipientKind.To ||
-            recipient.Kind == EmailRecipientKind.Cc || recipient.Kind == EmailRecipientKind.Room ||
-            recipient.Kind == EmailRecipientKind.Resource) ? "REQUEST" : "PUBLISH";
+        return HasCalendarRecipients(document) ? "REQUEST" : "PUBLISH";
     }
 
     private static string FormatUtc(DateTimeOffset value) =>

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
@@ -25,15 +25,20 @@ internal static partial class IcsCalendarCodec {
         bool hasMethodConflict = !string.IsNullOrWhiteSpace(calendarMethod) &&
             !string.IsNullOrWhiteSpace(mimeMethod) &&
             !string.Equals(calendarMethod, mimeMethod, StringComparison.OrdinalIgnoreCase);
-        bool hasCalendarRecipients = HasCalendarRecipients(document) ||
-            activeProperties.Any(property => property.Name == "ATTENDEE");
+        bool hasTransportRecipients = HasCalendarRecipients(document);
+        bool hasCalendarAttendees = activeProperties.Any(property => property.Name == "ATTENDEE");
+        bool hasCalendarRecipients = hasTransportRecipients || hasCalendarAttendees;
+        bool requestWouldSynthesizeAttendees =
+            string.Equals(effectiveMethod, "REQUEST", StringComparison.OrdinalIgnoreCase) &&
+            hasTransportRecipients && !hasCalendarAttendees;
         bool methodWouldChange =
             string.IsNullOrWhiteSpace(effectiveMethod) && hasCalendarRecipients ||
             string.Equals(effectiveMethod, "PUBLISH", StringComparison.OrdinalIgnoreCase) &&
             hasCalendarRecipients || !isEvent &&
             string.Equals(effectiveMethod, "REQUEST", StringComparison.OrdinalIgnoreCase) &&
             !hasCalendarRecipients;
-        if (hasMethodConflict || isEvent && !IsStoreProjectableMethod(effectiveMethod) ||
+        if (hasMethodConflict || requestWouldSynthesizeAttendees ||
+            isEvent && !IsStoreProjectableMethod(effectiveMethod) ||
             !isEvent && !IsStoreProjectableTaskMethod(effectiveMethod) || methodWouldChange) {
             document.MimeSemanticProjectionIsIncomplete = true;
         }

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
@@ -25,9 +25,7 @@ internal static class IcsCalendarCodec {
         if (document.OutlookItemKind != OutlookItemKind.Appointment &&
             document.OutlookItemKind != OutlookItemKind.Task) return null;
         return document.Attachments.FirstOrDefault(attachment => attachment.IsProjectedSemanticContent &&
-            string.Equals(attachment.ContentType, "text/calendar", StringComparison.OrdinalIgnoreCase)) ??
-            document.Attachments.FirstOrDefault(attachment =>
-                string.Equals(attachment.ContentType, "text/calendar", StringComparison.OrdinalIgnoreCase));
+            string.Equals(attachment.ContentType, "text/calendar", StringComparison.OrdinalIgnoreCase));
     }
 
     internal static bool ShouldWriteAsAttachment(EmailAttachment attachment) => !attachment.IsMimeBodyPart;
@@ -470,6 +468,19 @@ internal static class IcsCalendarCodec {
 
     private static TimeSpan? ParseDuration(string? value) {
         if (string.IsNullOrWhiteSpace(value)) return null;
+        string normalized = value!.Trim().ToUpperInvariant();
+        bool negative = normalized.StartsWith("-", StringComparison.Ordinal);
+        if (negative || normalized.StartsWith("+", StringComparison.Ordinal)) normalized = normalized.Substring(1);
+        if (normalized.Length > 2 && normalized[0] == 'P' && normalized[normalized.Length - 1] == 'W' &&
+            long.TryParse(normalized.Substring(1, normalized.Length - 2), NumberStyles.None,
+                CultureInfo.InvariantCulture, out long weeks)) {
+            try {
+                long ticks = checked(weeks * 7L * TimeSpan.TicksPerDay);
+                return TimeSpan.FromTicks(negative ? checked(-ticks) : ticks);
+            } catch (OverflowException) {
+                return null;
+            }
+        }
         try {
             return System.Xml.XmlConvert.ToTimeSpan(value);
         } catch (FormatException) {

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
@@ -84,14 +84,15 @@ internal static class IcsCalendarCodec {
             property.Value.Equals("VTIMEZONE", StringComparison.OrdinalIgnoreCase));
         return calendarItems > 1 || hasTimeZone || activeProperties.Any(property =>
             property.Name == "RRULE" || property.Name == "RDATE" ||
-            property.Name == "EXDATE" || property.Name == "RECURRENCE-ID");
+            property.Name == "EXDATE" || property.Name == "RECURRENCE-ID" ||
+            property.Name == "ATTACH");
     }
 
     private static void ProjectEvent(IReadOnlyList<IcsProperty> properties, EmailDocument document,
         IList<EmailDiagnostic> diagnostics, string location) {
         var appointment = document.Appointment ?? new OutlookAppointment();
         document.OutlookItemKind = OutlookItemKind.Appointment;
-        document.MessageClass = MessageClassForMethod(GetValue(properties, "METHOD"));
+        document.MessageClass = MessageClassForMethod(GetValue(properties, "METHOD"), properties);
         document.Appointment = appointment;
         ApplyCommon(properties, document);
 
@@ -103,11 +104,20 @@ internal static class IcsCalendarCodec {
         appointment.IsRecurring = GetProperty(properties, "RRULE") != null;
         appointment.RecurrencePattern = GetValue(properties, "RRULE");
         TimeSpan? duration = ParseDuration(GetValue(properties, "DURATION"));
-        appointment.DurationMinutes = appointment.Start.HasValue && appointment.End.HasValue
-            ? checked((int)(appointment.End.Value - appointment.Start.Value).TotalMinutes)
-            : duration.HasValue ? checked((int)duration.Value.TotalMinutes) : (int?)null;
+        bool incompleteDuration = false;
+        TimeSpan? effectiveDuration = appointment.Start.HasValue && appointment.End.HasValue
+            ? appointment.End.Value - appointment.Start.Value
+            : duration;
+        appointment.DurationMinutes = effectiveDuration.HasValue
+            ? ConvertDurationMinutes(effectiveDuration.Value, diagnostics, location, ref incompleteDuration)
+            : null;
         if (!appointment.End.HasValue && appointment.Start.HasValue && duration.HasValue) {
-            appointment.End = appointment.Start.Value.Add(duration.Value);
+            try {
+                appointment.End = appointment.Start.Value.Add(duration.Value);
+            } catch (ArgumentOutOfRangeException) {
+                ReportDurationOutOfRange(diagnostics, location);
+                incompleteDuration = true;
+            }
         }
         string? busy = GetValue(properties, "X-MICROSOFT-CDO-BUSYSTATUS");
         appointment.BusyStatus = ParseBusyStatus(busy);
@@ -116,7 +126,8 @@ internal static class IcsCalendarCodec {
         appointment.ResponseStatus = ParseInt(GetValue(properties, "X-OFFICEIMO-RESPONSE-STATUS"));
         appointment.ClientIntentFlags = ParseInt(GetValue(properties, "X-OFFICEIMO-CLIENT-INTENT"));
         appointment.TimeZoneDescription = UnescapeOrNull(GetValue(properties, "X-OFFICEIMO-TIMEZONE-DESCRIPTION"));
-        ApplyReminder(properties, appointment, diagnostics, location);
+        incompleteDuration |= ApplyReminder(properties, appointment, diagnostics, location);
+        document.MimeSemanticProjectionIsIncomplete |= incompleteDuration;
 
         string[] required = GetAttendees(properties, optional: false).ToArray();
         string[] optional = GetAttendees(properties, optional: true).ToArray();
@@ -171,7 +182,7 @@ internal static class IcsCalendarCodec {
         foreach (IcsProperty property in properties.Where(property => property.Name == "X-OFFICEIMO-COMPANY")) {
             task.Companies.Add(Unescape(property.Value));
         }
-        ApplyReminder(properties, task, diagnostics, location);
+        document.MimeSemanticProjectionIsIncomplete |= ApplyReminder(properties, task, diagnostics, location);
     }
 
     private static void ApplyCommon(IReadOnlyList<IcsProperty> properties, EmailDocument document) {
@@ -286,10 +297,16 @@ internal static class IcsCalendarCodec {
             AppendLine(output, string.Concat(organizer, ":mailto:", EscapeUriValue(document.From.Address!)));
         }
         foreach (EmailRecipient recipient in document.Recipients.Where(recipient =>
-            (recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc) &&
+            (recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc ||
+             recipient.Kind == EmailRecipientKind.Room || recipient.Kind == EmailRecipientKind.Resource) &&
             !string.IsNullOrWhiteSpace(recipient.Address.Address))) {
-            string role = recipient.Kind == EmailRecipientKind.Cc ? "OPT-PARTICIPANT" : "REQ-PARTICIPANT";
+            string role = recipient.Kind == EmailRecipientKind.Cc ? "OPT-PARTICIPANT" :
+                recipient.Kind == EmailRecipientKind.Room || recipient.Kind == EmailRecipientKind.Resource
+                    ? "NON-PARTICIPANT"
+                    : "REQ-PARTICIPANT";
             string attendee = string.Concat("ATTENDEE;ROLE=", role);
+            if (recipient.Kind == EmailRecipientKind.Room) attendee += ";CUTYPE=ROOM";
+            else if (recipient.Kind == EmailRecipientKind.Resource) attendee += ";CUTYPE=RESOURCE";
             if (!string.IsNullOrWhiteSpace(recipient.Address.DisplayName)) attendee += string.Concat(";CN=\"",
                 EscapeParameter(recipient.Address.DisplayName!), "\"");
             AppendLine(output, string.Concat(attendee, ":mailto:", EscapeUriValue(recipient.Address.Address!)));
@@ -448,11 +465,20 @@ internal static class IcsCalendarCodec {
             if (string.IsNullOrWhiteSpace(address)) continue;
             bool optional = property.Parameters.TryGetValue("ROLE", out string? role) &&
                 string.Equals(role, "OPT-PARTICIPANT", StringComparison.OrdinalIgnoreCase);
+            EmailRecipientKind kind = optional ? EmailRecipientKind.Cc : EmailRecipientKind.To;
+            if (property.Parameters.TryGetValue("CUTYPE", out string? calendarUserType)) {
+                if (calendarUserType.Equals("ROOM", StringComparison.OrdinalIgnoreCase)) kind = EmailRecipientKind.Room;
+                else if (calendarUserType.Equals("RESOURCE", StringComparison.OrdinalIgnoreCase)) {
+                    kind = EmailRecipientKind.Resource;
+                }
+            }
             property.Parameters.TryGetValue("CN", out string? name);
-            if (!document.Recipients.Any(recipient => string.Equals(recipient.Address.Address, address,
-                StringComparison.OrdinalIgnoreCase))) {
-                document.Recipients.Add(new EmailRecipient(optional ? EmailRecipientKind.Cc : EmailRecipientKind.To,
-                    new EmailAddress(address!, name)));
+            EmailRecipient? existing = document.Recipients.FirstOrDefault(recipient =>
+                string.Equals(recipient.Address.Address, address, StringComparison.OrdinalIgnoreCase));
+            if (existing == null) {
+                document.Recipients.Add(new EmailRecipient(kind, new EmailAddress(address!, name)));
+            } else if (kind == EmailRecipientKind.Room || kind == EmailRecipientKind.Resource) {
+                existing.Kind = kind;
             }
         }
     }
@@ -482,7 +508,8 @@ internal static class IcsCalendarCodec {
             }
         }
         try {
-            return System.Xml.XmlConvert.ToTimeSpan(value);
+            string xmlValue = negative ? string.Concat("-", normalized) : normalized;
+            return System.Xml.XmlConvert.ToTimeSpan(xmlValue);
         } catch (FormatException) {
             return null;
         } catch (OverflowException) {
@@ -515,10 +542,25 @@ internal static class IcsCalendarCodec {
     private static string FormatBusyStatus(int value) => value == 0 ? "FREE" : value == 1 ? "TENTATIVE" :
         value == 3 ? "OOF" : value == 4 ? "WORKINGELSEWHERE" : "BUSY";
 
-    private static string MessageClassForMethod(string? method) =>
-        string.Equals(method, "REQUEST", StringComparison.OrdinalIgnoreCase) ? "IPM.Schedule.Meeting.Request" :
-        string.Equals(method, "CANCEL", StringComparison.OrdinalIgnoreCase) ? "IPM.Schedule.Meeting.Canceled" :
-        "IPM.Appointment";
+    private static string MessageClassForMethod(string? method, IEnumerable<IcsProperty> properties) {
+        if (string.Equals(method, "REQUEST", StringComparison.OrdinalIgnoreCase)) {
+            return "IPM.Schedule.Meeting.Request";
+        }
+        if (string.Equals(method, "CANCEL", StringComparison.OrdinalIgnoreCase)) {
+            return "IPM.Schedule.Meeting.Canceled";
+        }
+        if (!string.Equals(method, "REPLY", StringComparison.OrdinalIgnoreCase)) return "IPM.Appointment";
+        string? participationStatus = properties.Where(property => property.Name == "ATTENDEE")
+            .Select(property => property.Parameters.TryGetValue("PARTSTAT", out string? value) ? value : null)
+            .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
+        if (string.Equals(participationStatus, "TENTATIVE", StringComparison.OrdinalIgnoreCase)) {
+            return "IPM.Schedule.Meeting.Resp.Tent";
+        }
+        if (string.Equals(participationStatus, "DECLINED", StringComparison.OrdinalIgnoreCase)) {
+            return "IPM.Schedule.Meeting.Resp.Neg";
+        }
+        return "IPM.Schedule.Meeting.Resp.Pos";
+    }
 
     internal static string GetMethod(EmailDocument document) {
         string messageClass = document.MessageClass ?? string.Empty;
@@ -526,7 +568,8 @@ internal static class IcsCalendarCodec {
         if (messageClass.IndexOf("Request", StringComparison.OrdinalIgnoreCase) >= 0) return "REQUEST";
         if (messageClass.IndexOf("Resp", StringComparison.OrdinalIgnoreCase) >= 0) return "REPLY";
         return document.Recipients.Any(recipient => recipient.Kind == EmailRecipientKind.To ||
-            recipient.Kind == EmailRecipientKind.Cc) ? "REQUEST" : "PUBLISH";
+            recipient.Kind == EmailRecipientKind.Cc || recipient.Kind == EmailRecipientKind.Room ||
+            recipient.Kind == EmailRecipientKind.Resource) ? "REQUEST" : "PUBLISH";
     }
 
     private static string FormatUtc(DateTimeOffset value) =>
@@ -551,11 +594,12 @@ internal static class IcsCalendarCodec {
         return result.ToString();
     }
 
-    private static void ApplyReminder(IReadOnlyList<IcsProperty> properties, OutlookAppointment appointment,
+    private static bool ApplyReminder(IReadOnlyList<IcsProperty> properties, OutlookAppointment appointment,
         IList<EmailDiagnostic> diagnostics, string location) {
         IcsProperty? trigger = GetProperty(properties, "TRIGGER");
         appointment.ReminderIsSet = trigger == null ? ParseBoolean(GetValue(properties, "X-OFFICEIMO-REMINDER-SET")) : true;
-        appointment.ReminderDeltaMinutes = ParseRelativeTriggerMinutes(trigger);
+        appointment.ReminderDeltaMinutes = ParseRelativeTriggerMinutes(trigger, diagnostics, location,
+            out bool incomplete);
         appointment.ReminderTime = ParseDate(GetProperty(properties, "X-OFFICEIMO-REMINDER-TIME"),
             diagnostics, location, out _);
         appointment.ReminderSignalTime = ParseDate(GetProperty(properties, "X-OFFICEIMO-REMINDER-SIGNAL-TIME"),
@@ -563,13 +607,14 @@ internal static class IcsCalendarCodec {
         if (!appointment.ReminderSignalTime.HasValue) {
             appointment.ReminderSignalTime = ParseAbsoluteTrigger(trigger, diagnostics, location);
         }
+        return incomplete;
     }
 
-    private static void ApplyReminder(IReadOnlyList<IcsProperty> properties, OutlookTask task,
+    private static bool ApplyReminder(IReadOnlyList<IcsProperty> properties, OutlookTask task,
         IList<EmailDiagnostic> diagnostics, string location) {
         IcsProperty? trigger = GetProperty(properties, "TRIGGER");
         task.ReminderIsSet = trigger == null ? ParseBoolean(GetValue(properties, "X-OFFICEIMO-REMINDER-SET")) : true;
-        task.ReminderDeltaMinutes = ParseRelativeTriggerMinutes(trigger);
+        task.ReminderDeltaMinutes = ParseRelativeTriggerMinutes(trigger, diagnostics, location, out bool incomplete);
         task.ReminderTime = ParseDate(GetProperty(properties, "X-OFFICEIMO-REMINDER-TIME"),
             diagnostics, location, out _);
         task.ReminderSignalTime = ParseDate(GetProperty(properties, "X-OFFICEIMO-REMINDER-SIGNAL-TIME"),
@@ -577,13 +622,36 @@ internal static class IcsCalendarCodec {
         if (!task.ReminderSignalTime.HasValue) {
             task.ReminderSignalTime = ParseAbsoluteTrigger(trigger, diagnostics, location);
         }
+        return incomplete;
     }
 
-    private static int? ParseRelativeTriggerMinutes(IcsProperty? trigger) {
+    private static int? ParseRelativeTriggerMinutes(IcsProperty? trigger, IList<EmailDiagnostic> diagnostics,
+        string location, out bool incomplete) {
+        incomplete = false;
         if (trigger == null || trigger.Parameters.TryGetValue("VALUE", out string? valueType) &&
             valueType.Equals("DATE-TIME", StringComparison.OrdinalIgnoreCase)) return null;
         TimeSpan? value = ParseDuration(trigger.Value);
-        return value.HasValue ? checked((int)-value.Value.TotalMinutes) : (int?)null;
+        return value.HasValue
+            ? ConvertDurationMinutes(value.Value, diagnostics, location, ref incomplete, invert: true)
+            : null;
+    }
+
+    private static int? ConvertDurationMinutes(TimeSpan value, IList<EmailDiagnostic> diagnostics,
+        string location, ref bool incomplete, bool invert = false) {
+        double minutes = value.TotalMinutes;
+        if (invert) minutes = -minutes;
+        if (minutes >= int.MinValue && minutes <= int.MaxValue) return (int)minutes;
+        ReportDurationOutOfRange(diagnostics, location);
+        incomplete = true;
+        return null;
+    }
+
+    private static void ReportDurationOutOfRange(IList<EmailDiagnostic> diagnostics, string location) {
+        if (diagnostics.Any(diagnostic => diagnostic.Code == "EMAIL_ICALENDAR_DURATION_OUT_OF_RANGE" &&
+            string.Equals(diagnostic.Location, location, StringComparison.Ordinal))) return;
+        diagnostics.Add(new EmailDiagnostic("EMAIL_ICALENDAR_DURATION_OUT_OF_RANGE",
+            "An iCalendar duration exceeds the supported whole-minute range and was retained only in the semantic source.",
+            EmailDiagnosticSeverity.Warning, location));
     }
 
     private static DateTimeOffset? ParseAbsoluteTrigger(IcsProperty? trigger,

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
@@ -4,29 +4,58 @@ internal static class IcsCalendarCodec {
     private static readonly DateTimeOffset DeterministicEpoch =
         new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
-    internal static bool TryProject(byte[] content, EmailDocument document, IList<EmailDiagnostic> diagnostics,
+    internal static bool TryProject(string text, EmailDocument document, IList<EmailDiagnostic> diagnostics,
         string location) {
-        string text = Decode(content);
-        List<IcsProperty> properties = ParseProperties(text);
-        bool isEvent = properties.Any(property => property.Name == "BEGIN" &&
-            property.Value.Equals("VEVENT", StringComparison.OrdinalIgnoreCase));
-        bool isTask = properties.Any(property => property.Name == "BEGIN" &&
-            property.Value.Equals("VTODO", StringComparison.OrdinalIgnoreCase));
-        if (!isEvent && !isTask) return false;
+        List<IcsProperty> properties = ParseProperties(text.TrimStart('\uFEFF'));
+        IcsProperty? activeComponent = properties.FirstOrDefault(property => property.Name == "BEGIN" &&
+            (property.Value.Equals("VEVENT", StringComparison.OrdinalIgnoreCase) ||
+             property.Value.Equals("VTODO", StringComparison.OrdinalIgnoreCase)));
+        if (activeComponent == null) return false;
+        bool isEvent = activeComponent.Value.Equals("VEVENT", StringComparison.OrdinalIgnoreCase);
 
-        document.MimeSemanticProjectionIsIncomplete |= HasStoreSpecificRecurrence(properties);
-
-        if (isEvent) ProjectEvent(properties, document, diagnostics, location);
-        else ProjectTask(properties, document, diagnostics, location);
+        IReadOnlyList<IcsProperty> activeProperties = SelectActiveComponentProperties(
+            properties, activeComponent.Value);
+        document.MimeSemanticProjectionIsIncomplete |= HasIncompleteStoreProjection(properties, activeProperties);
+        if (isEvent) ProjectEvent(activeProperties, document, diagnostics, location);
+        else ProjectTask(activeProperties, document, diagnostics, location);
         return true;
     }
 
     internal static EmailAttachment? FindSemanticAttachment(EmailDocument document) {
         if (document.OutlookItemKind != OutlookItemKind.Appointment &&
             document.OutlookItemKind != OutlookItemKind.Task) return null;
-        return document.Attachments.FirstOrDefault(attachment => attachment.IsProjectedSemanticContent) ??
+        return document.Attachments.FirstOrDefault(attachment => attachment.IsProjectedSemanticContent &&
+            string.Equals(attachment.ContentType, "text/calendar", StringComparison.OrdinalIgnoreCase)) ??
             document.Attachments.FirstOrDefault(attachment =>
                 string.Equals(attachment.ContentType, "text/calendar", StringComparison.OrdinalIgnoreCase));
+    }
+
+    internal static bool ShouldWriteAsAttachment(EmailAttachment attachment) => !attachment.IsMimeBodyPart;
+
+    internal static EmailAttachment CreateRegeneratedAttachment(EmailDocument document, EmailAttachment source) {
+        byte[] content = Create(document);
+        var attachment = new EmailAttachment {
+            FileName = source.FileName,
+            ContentType = "text/calendar",
+            ContentId = source.ContentId,
+            ContentLocation = source.ContentLocation,
+            IsInline = source.IsInline,
+            IsHidden = source.IsHidden,
+            RenderingPosition = source.RenderingPosition,
+            CreatedDate = source.CreatedDate,
+            ModifiedDate = source.ModifiedDate,
+            Content = content,
+            Length = content.LongLength,
+            IsProjectedSemanticContent = true,
+            IsMimeAttachment = source.IsMimeAttachment,
+            IsMimeBodyPart = false
+        };
+        foreach (KeyValuePair<string, string> parameter in source.ContentTypeParameters) {
+            attachment.ContentTypeParameters[parameter.Key] = parameter.Value;
+        }
+        attachment.ContentTypeParameters["charset"] = "utf-8";
+        attachment.ContentTypeParameters["method"] = GetMethod(document);
+        return attachment;
     }
 
     internal static byte[] Create(EmailDocument document) {
@@ -48,10 +77,15 @@ internal static class IcsCalendarCodec {
             appointment.RecurrenceType.HasValue || !string.IsNullOrWhiteSpace(appointment.RecurrencePattern);
     }
 
-    private static bool HasStoreSpecificRecurrence(IEnumerable<IcsProperty> properties) {
-        int events = properties.Count(property => property.Name == "BEGIN" &&
-            property.Value.Equals("VEVENT", StringComparison.OrdinalIgnoreCase));
-        return events > 1 || properties.Any(property => property.Name == "RRULE" || property.Name == "RDATE" ||
+    private static bool HasIncompleteStoreProjection(IEnumerable<IcsProperty> properties,
+        IEnumerable<IcsProperty> activeProperties) {
+        int calendarItems = properties.Count(property => property.Name == "BEGIN" &&
+            (property.Value.Equals("VEVENT", StringComparison.OrdinalIgnoreCase) ||
+             property.Value.Equals("VTODO", StringComparison.OrdinalIgnoreCase)));
+        bool hasTimeZone = properties.Any(property => property.Name == "BEGIN" &&
+            property.Value.Equals("VTIMEZONE", StringComparison.OrdinalIgnoreCase));
+        return calendarItems > 1 || hasTimeZone || activeProperties.Any(property =>
+            property.Name == "RRULE" || property.Name == "RDATE" ||
             property.Name == "EXDATE" || property.Name == "RECURRENCE-ID");
     }
 
@@ -199,7 +233,8 @@ internal static class IcsCalendarCodec {
         if (task.CompletedAt.HasValue) AppendLine(output, string.Concat("COMPLETED:", FormatUtc(task.CompletedAt.Value)));
         if (task.PercentComplete.HasValue) AppendLine(output, string.Concat("PERCENT-COMPLETE:",
             Math.Max(0, Math.Min(100, (int)Math.Round(task.PercentComplete.Value * 100d))).ToString(CultureInfo.InvariantCulture)));
-        if (task.IsComplete == true) AppendLine(output, "STATUS:COMPLETED");
+        if (task.IsComplete == true || task.Status == 2) AppendLine(output, "STATUS:COMPLETED");
+        else if (task.Status == 4) AppendLine(output, "STATUS:CANCELLED");
         else if (task.Status == 1) AppendLine(output, "STATUS:IN-PROCESS");
         else AppendLine(output, "STATUS:NEEDS-ACTION");
         if (task.EstimatedEffort.HasValue) AppendLine(output,
@@ -263,11 +298,6 @@ internal static class IcsCalendarCodec {
         }
     }
 
-    private static string Decode(byte[] content) {
-        int offset = content.Length >= 3 && content[0] == 0xef && content[1] == 0xbb && content[2] == 0xbf ? 3 : 0;
-        return Encoding.UTF8.GetString(content, offset, content.Length - offset);
-    }
-
     private static List<IcsProperty> ParseProperties(string text) {
         string normalized = text.Replace("\r\n", "\n").Replace('\r', '\n');
         var unfolded = new List<string>();
@@ -281,16 +311,82 @@ internal static class IcsCalendarCodec {
 
         var result = new List<IcsProperty>();
         foreach (string line in unfolded) {
-            int colon = line.IndexOf(':');
+            int colon = FindUnquotedSeparator(line, ':');
             if (colon <= 0) continue;
-            string[] tokens = line.Substring(0, colon).Split(';');
+            IReadOnlyList<string> tokens = SplitUnquoted(line.Substring(0, colon), ';');
             var property = new IcsProperty(tokens[0].Trim().ToUpperInvariant(), line.Substring(colon + 1));
-            for (int index = 1; index < tokens.Length; index++) {
-                int equals = tokens[index].IndexOf('=');
+            for (int index = 1; index < tokens.Count; index++) {
+                int equals = FindUnquotedSeparator(tokens[index], '=');
                 if (equals > 0) property.Parameters[tokens[index].Substring(0, equals).Trim()] =
                     tokens[index].Substring(equals + 1).Trim().Trim('"');
             }
             result.Add(property);
+        }
+        return result;
+    }
+
+    private static IReadOnlyList<IcsProperty> SelectActiveComponentProperties(
+        IReadOnlyList<IcsProperty> properties, string componentName) {
+        var selected = new List<IcsProperty>();
+        var components = new List<string>();
+        int activeDepth = -1;
+        bool selectedComponent = false;
+        foreach (IcsProperty property in properties) {
+            if (property.Name == "BEGIN") {
+                components.Add(property.Value.Trim().ToUpperInvariant());
+                if (!selectedComponent && property.Value.Equals(componentName, StringComparison.OrdinalIgnoreCase)) {
+                    activeDepth = components.Count;
+                    selectedComponent = true;
+                }
+                continue;
+            }
+            if (property.Name == "END") {
+                if (components.Count == activeDepth &&
+                    property.Value.Equals(componentName, StringComparison.OrdinalIgnoreCase)) activeDepth = -1;
+                if (components.Count > 0) components.RemoveAt(components.Count - 1);
+                continue;
+            }
+
+            bool calendarProperty = components.Count == 1 &&
+                components[0].Equals("VCALENDAR", StringComparison.OrdinalIgnoreCase);
+            bool componentProperty = activeDepth > 0 && components.Count == activeDepth;
+            bool alarmTrigger = activeDepth > 0 && components.Count == activeDepth + 1 &&
+                components[components.Count - 1].Equals("VALARM", StringComparison.OrdinalIgnoreCase) &&
+                property.Name == "TRIGGER";
+            if (calendarProperty || componentProperty || alarmTrigger) selected.Add(property);
+        }
+        return selected;
+    }
+
+    private static int FindUnquotedSeparator(string value, char separator) {
+        bool quoted = false;
+        bool escaped = false;
+        for (int index = 0; index < value.Length; index++) {
+            char character = value[index];
+            if (escaped) {
+                escaped = false;
+            } else if (character == '\\') {
+                escaped = true;
+            } else if (character == '"') {
+                quoted = !quoted;
+            } else if (!quoted && character == separator) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    private static IReadOnlyList<string> SplitUnquoted(string value, char separator) {
+        var result = new List<string>();
+        int start = 0;
+        while (start <= value.Length) {
+            int relative = FindUnquotedSeparator(value.Substring(start), separator);
+            if (relative < 0) {
+                result.Add(value.Substring(start));
+                break;
+            }
+            result.Add(value.Substring(start, relative));
+            start += relative + 1;
         }
         return result;
     }
@@ -413,7 +509,7 @@ internal static class IcsCalendarCodec {
         string.Equals(method, "CANCEL", StringComparison.OrdinalIgnoreCase) ? "IPM.Schedule.Meeting.Canceled" :
         "IPM.Appointment";
 
-    private static string GetMethod(EmailDocument document) {
+    internal static string GetMethod(EmailDocument document) {
         string messageClass = document.MessageClass ?? string.Empty;
         if (messageClass.IndexOf("Canceled", StringComparison.OrdinalIgnoreCase) >= 0) return "CANCEL";
         if (messageClass.IndexOf("Request", StringComparison.OrdinalIgnoreCase) >= 0) return "REQUEST";

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
@@ -318,8 +318,11 @@ internal static partial class IcsCalendarCodec {
         if (task.EstimatedEffort.HasValue) AppendLine(output,
             string.Concat("X-OFFICEIMO-ESTIMATED-EFFORT:", IcsDurationCodec.Format(task.EstimatedEffort.Value)));
         if (!string.IsNullOrWhiteSpace(task.Owner)) {
-            if (task.Owner!.IndexOf('@') >= 0) AppendLine(output,
-                string.Concat("ORGANIZER:mailto:", EscapeUriValue(task.Owner)));
+            if (task.Owner!.IndexOf('@') >= 0) {
+                EmailAddress organizer = document.From != null && string.Equals(document.From.Address, task.Owner,
+                    StringComparison.OrdinalIgnoreCase) ? document.From : new EmailAddress(task.Owner);
+                WriteOrganizer(output, organizer);
+            }
             else AppendText(output, "X-OFFICEIMO-TASK-OWNER", task.Owner);
         }
         if (task.ActualEffort.HasValue) AppendLine(output,
@@ -370,13 +373,16 @@ internal static partial class IcsCalendarCodec {
     }
 
     private static void WriteOrganizerAndAttendees(StringBuilder output, EmailDocument document) {
-        if (!string.IsNullOrWhiteSpace(document.From?.Address)) {
-            string organizer = string.Concat("ORGANIZER");
-            if (!string.IsNullOrWhiteSpace(document.From!.DisplayName)) organizer += string.Concat(";CN=\"",
-                EscapeParameter(document.From.DisplayName!), "\"");
-            AppendLine(output, string.Concat(organizer, ":mailto:", EscapeUriValue(document.From.Address!)));
-        }
+        WriteOrganizer(output, document.From);
         WriteAttendees(output, document);
+    }
+
+    private static void WriteOrganizer(StringBuilder output, EmailAddress? address) {
+        if (string.IsNullOrWhiteSpace(address?.Address)) return;
+        string organizer = string.Concat("ORGANIZER");
+        if (!string.IsNullOrWhiteSpace(address!.DisplayName)) organizer += string.Concat(";CN=\"",
+            EscapeParameter(address.DisplayName!), "\"");
+        AppendLine(output, string.Concat(organizer, ":mailto:", EscapeUriValue(address.Address!)));
     }
 
     private static void WriteAttendees(StringBuilder output, EmailDocument document) {

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
@@ -19,7 +19,7 @@ internal static partial class IcsCalendarCodec {
         IReadOnlyList<IcsProperty> alarmProperties = SelectActiveAlarmProperties(
             properties, activeComponent.Value);
         document.MimeSemanticProjectionIsIncomplete |= HasIncompleteStoreProjection(
-            properties, activeProperties, alarmProperties, isEvent, document.Subject);
+            properties, activeProperties, alarmProperties, isEvent, document.Subject, document.From);
         string? calendarMethod = GetValue(activeProperties, "METHOD");
         string? effectiveMethod = calendarMethod ?? mimeMethod;
         bool hasMethodConflict = !string.IsNullOrWhiteSpace(calendarMethod) &&
@@ -458,7 +458,7 @@ internal static partial class IcsCalendarCodec {
     private static string? StripMailTo(string? value) {
         if (string.IsNullOrWhiteSpace(value)) return null;
         string result = value!.Trim();
-        if (IsNonMailtoCalendarAddress(result)) return null;
+        if (IsUnprojectableCalendarAddress(result)) return null;
         if (!result.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)) return result;
         string address = result.Substring(7);
         try {

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
@@ -379,7 +379,7 @@ internal static partial class IcsCalendarCodec {
     }
 
     private static void WriteOrganizer(StringBuilder output, EmailAddress? address) {
-        if (string.IsNullOrWhiteSpace(address?.Address)) return;
+        if (!HasPortableMailtoAddress(address)) return;
         string organizer = string.Concat("ORGANIZER");
         if (!string.IsNullOrWhiteSpace(address!.DisplayName)) organizer += string.Concat(";CN=\"",
             EscapeParameter(address.DisplayName!), "\"");
@@ -390,7 +390,7 @@ internal static partial class IcsCalendarCodec {
         foreach (EmailRecipient recipient in document.Recipients.Where(recipient =>
             (recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc ||
              recipient.Kind == EmailRecipientKind.Room || recipient.Kind == EmailRecipientKind.Resource) &&
-            !string.IsNullOrWhiteSpace(recipient.Address.Address))) {
+            HasPortableMailtoAddress(recipient.Address))) {
             string role = recipient.Kind == EmailRecipientKind.Cc ? "OPT-PARTICIPANT" :
                 recipient.Kind == EmailRecipientKind.Room || recipient.Kind == EmailRecipientKind.Resource
                     ? "NON-PARTICIPANT"
@@ -534,6 +534,12 @@ internal static partial class IcsCalendarCodec {
     private static bool HasCalendarRecipients(EmailDocument document) => document.Recipients.Any(recipient =>
         recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc ||
         recipient.Kind == EmailRecipientKind.Room || recipient.Kind == EmailRecipientKind.Resource);
+
+    /// <summary>Determines whether an address can be represented safely as an iCalendar mailto URI.</summary>
+    internal static bool HasPortableMailtoAddress(EmailAddress? address) =>
+        !string.IsNullOrWhiteSpace(address?.Address) &&
+        (string.IsNullOrWhiteSpace(address!.AddressType) ||
+         string.Equals(address.AddressType, "SMTP", StringComparison.OrdinalIgnoreCase));
 
     internal static string GetMethod(EmailDocument document) {
         string messageClass = document.MessageClass ?? string.Empty;

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
@@ -14,7 +14,7 @@ internal static class IcsCalendarCodec {
             property.Value.Equals("VTODO", StringComparison.OrdinalIgnoreCase));
         if (!isEvent && !isTask) return false;
 
-        document.MimeSemanticProjectionIsIncomplete = HasStoreSpecificRecurrence(properties);
+        document.MimeSemanticProjectionIsIncomplete |= HasStoreSpecificRecurrence(properties);
 
         if (isEvent) ProjectEvent(properties, document, diagnostics, location);
         else ProjectTask(properties, document, diagnostics, location);
@@ -253,12 +253,13 @@ internal static class IcsCalendarCodec {
             AppendLine(output, string.Concat(organizer, ":mailto:", EscapeUriValue(document.From.Address!)));
         }
         foreach (EmailRecipient recipient in document.Recipients.Where(recipient =>
-            recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc)) {
+            (recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc) &&
+            !string.IsNullOrWhiteSpace(recipient.Address.Address))) {
             string role = recipient.Kind == EmailRecipientKind.Cc ? "OPT-PARTICIPANT" : "REQ-PARTICIPANT";
             string attendee = string.Concat("ATTENDEE;ROLE=", role);
             if (!string.IsNullOrWhiteSpace(recipient.Address.DisplayName)) attendee += string.Concat(";CN=\"",
                 EscapeParameter(recipient.Address.DisplayName!), "\"");
-            AppendLine(output, string.Concat(attendee, ":mailto:", EscapeUriValue(recipient.Address.Address ?? string.Empty)));
+            AppendLine(output, string.Concat(attendee, ":mailto:", EscapeUriValue(recipient.Address.Address!)));
         }
     }
 

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
@@ -5,7 +5,7 @@ internal static partial class IcsCalendarCodec {
         new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
     internal static bool TryProject(string text, EmailDocument document, IList<EmailDiagnostic> diagnostics,
-        string location) {
+        string location, string? mimeMethod = null) {
         int projectionDiagnosticStart = diagnostics.Count;
         List<IcsProperty> properties = ParseProperties(text.TrimStart('\uFEFF'));
         IcsProperty? activeComponent = properties.FirstOrDefault(property => property.Name == "BEGIN" &&
@@ -20,7 +20,14 @@ internal static partial class IcsCalendarCodec {
             properties, activeComponent.Value);
         document.MimeSemanticProjectionIsIncomplete |= HasIncompleteStoreProjection(
             properties, activeProperties, alarmProperties, isEvent);
-        if (isEvent) ProjectEvent(activeProperties, document, diagnostics, location);
+        string? calendarMethod = GetValue(activeProperties, "METHOD");
+        if (!string.IsNullOrWhiteSpace(calendarMethod) && !string.IsNullOrWhiteSpace(mimeMethod) &&
+            !string.Equals(calendarMethod, mimeMethod, StringComparison.OrdinalIgnoreCase) ||
+            isEvent && !IsStoreProjectableMethod(calendarMethod ?? mimeMethod)) {
+            document.MimeSemanticProjectionIsIncomplete = true;
+        }
+        if (isEvent) ProjectEvent(activeProperties, document, diagnostics, location,
+            calendarMethod ?? mimeMethod);
         else ProjectTask(activeProperties, document, diagnostics, location);
         document.MimeSemanticProjectionIsIncomplete |= diagnostics.Skip(projectionDiagnosticStart).Any(diagnostic =>
             diagnostic.Code == "EMAIL_ICALENDAR_TIMEZONE_UNRESOLVED" ||
@@ -143,10 +150,10 @@ internal static partial class IcsCalendarCodec {
         value.Equals("DAYLIGHT", StringComparison.OrdinalIgnoreCase);
 
     private static void ProjectEvent(IReadOnlyList<IcsProperty> properties, EmailDocument document,
-        IList<EmailDiagnostic> diagnostics, string location) {
+        IList<EmailDiagnostic> diagnostics, string location, string? method) {
         var appointment = document.Appointment ?? new OutlookAppointment();
         document.OutlookItemKind = OutlookItemKind.Appointment;
-        document.MessageClass = MessageClassForMethod(GetValue(properties, "METHOD"), properties);
+        document.MessageClass = MessageClassForMethod(method, properties);
         document.Appointment = appointment;
         ApplyCommon(properties, document);
 
@@ -478,6 +485,12 @@ internal static partial class IcsCalendarCodec {
                 document.Recipients.Add(new EmailRecipient(kind, new EmailAddress(address!, name)));
             } else {
                 existing.Kind = kind;
+                if (string.IsNullOrWhiteSpace(existing.Address.DisplayName)) {
+                    existing.Address.DisplayName = name;
+                } else if (!string.IsNullOrWhiteSpace(name) &&
+                           !string.Equals(existing.Address.DisplayName, name, StringComparison.Ordinal)) {
+                    document.MimeSemanticProjectionIsIncomplete = true;
+                }
             }
         }
     }
@@ -550,6 +563,12 @@ internal static partial class IcsCalendarCodec {
         }
         return "IPM.Schedule.Meeting.Resp.Pos";
     }
+
+    private static bool IsStoreProjectableMethod(string? method) => string.IsNullOrWhiteSpace(method) ||
+        string.Equals(method, "PUBLISH", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(method, "REQUEST", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(method, "REPLY", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(method, "CANCEL", StringComparison.OrdinalIgnoreCase);
 
     internal static string GetMethod(EmailDocument document) {
         string messageClass = document.MessageClass ?? string.Empty;

--- a/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
+++ b/OfficeIMO.Email/Calendar/IcsCalendarCodec.cs
@@ -25,14 +25,21 @@ internal static partial class IcsCalendarCodec {
         bool hasMethodConflict = !string.IsNullOrWhiteSpace(calendarMethod) &&
             !string.IsNullOrWhiteSpace(mimeMethod) &&
             !string.Equals(calendarMethod, mimeMethod, StringComparison.OrdinalIgnoreCase);
-        bool publishWouldBecomeRequest = isEvent &&
+        bool hasCalendarRecipients = HasCalendarRecipients(document) ||
+            activeProperties.Any(property => property.Name == "ATTENDEE");
+        bool methodWouldChange =
             string.Equals(effectiveMethod, "PUBLISH", StringComparison.OrdinalIgnoreCase) &&
-            (HasCalendarRecipients(document) || activeProperties.Any(property => property.Name == "ATTENDEE"));
-        if (hasMethodConflict || isEvent && !IsStoreProjectableMethod(effectiveMethod) || publishWouldBecomeRequest) {
+            hasCalendarRecipients || !isEvent &&
+            string.Equals(effectiveMethod, "REQUEST", StringComparison.OrdinalIgnoreCase) &&
+            !hasCalendarRecipients;
+        if (hasMethodConflict || isEvent && !IsStoreProjectableMethod(effectiveMethod) ||
+            !isEvent && !IsStoreProjectableTaskMethod(effectiveMethod) || methodWouldChange) {
             document.MimeSemanticProjectionIsIncomplete = true;
         }
         if (isEvent) ProjectEvent(activeProperties, document, diagnostics, location, effectiveMethod);
         else ProjectTask(activeProperties, document, diagnostics, location);
+        document.MimeSemanticProjectionIsIncomplete |= HasIncompleteTimestampProjection(
+            activeProperties, document, isEvent, diagnostics, location);
         document.MimeSemanticProjectionIsIncomplete |= diagnostics.Skip(projectionDiagnosticStart).Any(diagnostic =>
             diagnostic.Code == "EMAIL_ICALENDAR_TIMEZONE_UNRESOLVED" ||
             diagnostic.Code == "EMAIL_ICALENDAR_FLOATING_TIME" ||
@@ -443,6 +450,7 @@ internal static partial class IcsCalendarCodec {
     private static string? StripMailTo(string? value) {
         if (string.IsNullOrWhiteSpace(value)) return null;
         string result = value!.Trim();
+        if (IsNonMailtoCalendarAddress(result)) return null;
         if (!result.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)) return result;
         string address = result.Substring(7);
         try {

--- a/OfficeIMO.Email/Calendar/IcsDurationCodec.cs
+++ b/OfficeIMO.Email/Calendar/IcsDurationCodec.cs
@@ -1,0 +1,74 @@
+namespace OfficeIMO.Email;
+
+internal static class IcsDurationCodec {
+    internal static TimeSpan? Parse(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        string normalized = value!.Trim().ToUpperInvariant();
+        bool negative = normalized.StartsWith("-", StringComparison.Ordinal);
+        if (negative || normalized.StartsWith("+", StringComparison.Ordinal)) normalized = normalized.Substring(1);
+        if (normalized.Length > 2 && normalized[0] == 'P' && normalized[normalized.Length - 1] == 'W' &&
+            long.TryParse(normalized.Substring(1, normalized.Length - 2), NumberStyles.None,
+                CultureInfo.InvariantCulture, out long weeks)) {
+            try {
+                long ticks = checked(weeks * 7L * TimeSpan.TicksPerDay);
+                return TimeSpan.FromTicks(negative ? checked(-ticks) : ticks);
+            } catch (OverflowException) {
+                return null;
+            }
+        }
+        try {
+            string xmlValue = negative ? string.Concat("-", normalized) : normalized;
+            return System.Xml.XmlConvert.ToTimeSpan(xmlValue);
+        } catch (FormatException) {
+            return null;
+        } catch (OverflowException) {
+            return null;
+        }
+    }
+
+    internal static int? ToWholeMinutes(TimeSpan value, IList<EmailDiagnostic> diagnostics,
+        string location, ref bool incomplete, bool invert = false) {
+        if (value.Ticks % TimeSpan.TicksPerMinute != 0) {
+            AddDiagnosticOnce(diagnostics, "EMAIL_ICALENDAR_DURATION_PRECISION_LOSS",
+                "An iCalendar duration contains sub-minute precision that the Outlook model cannot represent exactly.",
+                location);
+            incomplete = true;
+        }
+        double minutes = value.TotalMinutes;
+        if (invert) minutes = -minutes;
+        if (minutes >= int.MinValue && minutes <= int.MaxValue) return (int)minutes;
+        AddDiagnosticOnce(diagnostics, "EMAIL_ICALENDAR_DURATION_OUT_OF_RANGE",
+            "An iCalendar duration exceeds the supported whole-minute range and was retained only in the semantic source.",
+            location);
+        incomplete = true;
+        return null;
+    }
+
+    internal static void ReportOutOfRange(IList<EmailDiagnostic> diagnostics, string location) =>
+        AddDiagnosticOnce(diagnostics, "EMAIL_ICALENDAR_DURATION_OUT_OF_RANGE",
+            "An iCalendar duration exceeds the supported whole-minute range and was retained only in the semantic source.",
+            location);
+
+    internal static string Format(TimeSpan value) {
+        string sign = value < TimeSpan.Zero ? "-" : string.Empty;
+        TimeSpan absolute = value.Duration();
+        var result = new StringBuilder(sign).Append('P');
+        if (absolute.Days > 0) result.Append(absolute.Days.ToString(CultureInfo.InvariantCulture)).Append('D');
+        if (absolute.Hours > 0 || absolute.Minutes > 0 || absolute.Seconds > 0 || absolute.Days == 0) {
+            result.Append('T');
+            if (absolute.Hours > 0) result.Append(absolute.Hours.ToString(CultureInfo.InvariantCulture)).Append('H');
+            if (absolute.Minutes > 0) result.Append(absolute.Minutes.ToString(CultureInfo.InvariantCulture)).Append('M');
+            if (absolute.Seconds > 0 || absolute == TimeSpan.Zero) {
+                result.Append(absolute.Seconds.ToString(CultureInfo.InvariantCulture)).Append('S');
+            }
+        }
+        return result.ToString();
+    }
+
+    private static void AddDiagnosticOnce(IList<EmailDiagnostic> diagnostics, string code, string message,
+        string location) {
+        if (diagnostics.Any(diagnostic => diagnostic.Code == code &&
+            string.Equals(diagnostic.Location, location, StringComparison.Ordinal))) return;
+        diagnostics.Add(new EmailDiagnostic(code, message, EmailDiagnosticSeverity.Warning, location));
+    }
+}

--- a/OfficeIMO.Email/Contact/VCardCodec.Projection.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.Projection.cs
@@ -1,6 +1,11 @@
 namespace OfficeIMO.Email;
 
 internal static partial class VCardCodec {
+    private static readonly HashSet<string> RepeatableProjectedVCardProperties = new HashSet<string>(
+        StringComparer.OrdinalIgnoreCase) {
+            "ADR", "CATEGORIES", "EMAIL", "LABEL", "TEL", "URL", "X-MS-CHILD"
+        };
+
     private static readonly HashSet<string> ProjectedVCardExtensions = new HashSet<string>(
         StringComparer.OrdinalIgnoreCase) {
             "X-MS-ASSISTANT", "X-MS-CHILD", "X-MS-FILE-AS", "X-MS-HTML", "X-MS-INITIALS",
@@ -20,6 +25,11 @@ internal static partial class VCardCodec {
     private static bool IsExtensionPropertyName(string name) =>
         name.StartsWith("X-", StringComparison.OrdinalIgnoreCase) ||
         name.IndexOf(".X-", StringComparison.OrdinalIgnoreCase) >= 0;
+
+    private static bool HasDuplicateVCardSingletons(IEnumerable<VCardProperty> properties) =>
+        properties.Where(property => !RepeatableProjectedVCardProperties.Contains(property.Name))
+            .GroupBy(property => property.Name, StringComparer.OrdinalIgnoreCase)
+            .Any(group => group.Skip(1).Any());
 
     private static bool HasUnpreservedPropertyParameters(IEnumerable<VCardProperty> properties) =>
         properties.Any(property => {

--- a/OfficeIMO.Email/Contact/VCardCodec.Projection.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.Projection.cs
@@ -1,6 +1,26 @@
 namespace OfficeIMO.Email;
 
 internal static partial class VCardCodec {
+    private static readonly HashSet<string> ProjectedVCardExtensions = new HashSet<string>(
+        StringComparer.OrdinalIgnoreCase) {
+            "X-MS-ASSISTANT", "X-MS-CHILD", "X-MS-FILE-AS", "X-MS-HTML", "X-MS-INITIALS",
+            "X-MS-LOCATION", "X-MS-MANAGER", "X-MS-OFFICE", "X-MS-SPOUSE",
+            "X-OFFICEIMO-HAS-PICTURE",
+            "X-OFFICEIMO-EMAIL1-DISPLAY-NAME", "X-OFFICEIMO-EMAIL1-ORIGINAL-DISPLAY-NAME",
+            "X-OFFICEIMO-EMAIL2-DISPLAY-NAME", "X-OFFICEIMO-EMAIL2-ORIGINAL-DISPLAY-NAME",
+            "X-OFFICEIMO-EMAIL3-DISPLAY-NAME", "X-OFFICEIMO-EMAIL3-ORIGINAL-DISPLAY-NAME",
+            "X-OFFICEIMO-BUSINESS-COUNTRY-CODE", "X-OFFICEIMO-HOME-COUNTRY-CODE",
+            "X-OFFICEIMO-OTHER-COUNTRY-CODE", "X-OFFICEIMO-WORK-COUNTRY-CODE"
+        };
+
+    private static bool HasUnprojectedExtension(IEnumerable<VCardProperty> properties) =>
+        properties.Any(property => IsExtensionPropertyName(property.Name) &&
+            !ProjectedVCardExtensions.Contains(property.Name));
+
+    private static bool IsExtensionPropertyName(string name) =>
+        name.StartsWith("X-", StringComparison.OrdinalIgnoreCase) ||
+        name.IndexOf(".X-", StringComparison.OrdinalIgnoreCase) >= 0;
+
     private static bool HasUnpreservedPropertyParameters(IEnumerable<VCardProperty> properties) =>
         properties.Any(property => {
             if (property.Parameters.Count == 0 || property.Name == "EMAIL" || property.Name == "TEL" ||

--- a/OfficeIMO.Email/Contact/VCardCodec.Projection.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.Projection.cs
@@ -1,0 +1,122 @@
+namespace OfficeIMO.Email;
+
+internal static partial class VCardCodec {
+    private static bool HasUnsupportedEmailSlot(VCardProperty property, int index, string types) {
+        bool preferred = ContainsType(types, "PREF") || property.Parameters.ContainsKey("PREF");
+        bool expectedSlot = index == 0
+            ? ContainsType(types, "WORK") && preferred
+            : index == 1
+                ? ContainsType(types, "HOME") && !preferred
+                : ContainsType(types, "OTHER") && !preferred;
+        string[] allowedTypes = index == 0
+            ? new[] { "WORK", "PREF", "INTERNET" }
+            : index == 1
+                ? new[] { "HOME", "INTERNET" }
+                : new[] { "OTHER", "INTERNET" };
+        return !expectedSlot || HasUnsupportedParameters(property, "TYPE", "PREF") ||
+            HasUnsupportedTypeTokens(types, allowedTypes);
+    }
+
+    private static bool HasUnsupportedPhoneSlot(VCardProperty property, VCardPhoneSlot slot, int count,
+        string types) {
+        if (HasUnsupportedParameters(property, "TYPE", "PREF")) return true;
+        bool preferred = ContainsType(types, "PREF") || property.Parameters.ContainsKey("PREF");
+        string[] allowedTypes;
+        bool requiredTypePresent;
+        switch (slot) {
+            case VCardPhoneSlot.Mobile:
+                allowedTypes = new[] { "CELL", "VOICE" }; requiredTypePresent = ContainsType(types, "CELL"); break;
+            case VCardPhoneSlot.Assistant:
+                allowedTypes = new[] { "X-ASSISTANT" }; requiredTypePresent = ContainsType(types, "X-ASSISTANT"); break;
+            case VCardPhoneSlot.Company:
+                allowedTypes = new[] { "WORK", "X-COMPANY" }; requiredTypePresent = ContainsType(types, "X-COMPANY"); break;
+            case VCardPhoneSlot.Car:
+                allowedTypes = new[] { "CAR" }; requiredTypePresent = ContainsType(types, "CAR"); break;
+            case VCardPhoneSlot.Radio:
+                allowedTypes = new[] { "X-RADIO" }; requiredTypePresent = ContainsType(types, "X-RADIO"); break;
+            case VCardPhoneSlot.Callback:
+                allowedTypes = new[] { "X-CALLBACK" }; requiredTypePresent = ContainsType(types, "X-CALLBACK"); break;
+            case VCardPhoneSlot.Telex:
+                allowedTypes = new[] { "X-TELEX" }; requiredTypePresent = ContainsType(types, "X-TELEX"); break;
+            case VCardPhoneSlot.Text:
+                allowedTypes = new[] { "TEXT" }; requiredTypePresent = ContainsType(types, "TEXT"); break;
+            case VCardPhoneSlot.Isdn:
+                allowedTypes = new[] { "ISDN" }; requiredTypePresent = ContainsType(types, "ISDN"); break;
+            case VCardPhoneSlot.PrimaryFax:
+                allowedTypes = new[] { "PREF", "FAX" }; requiredTypePresent = preferred && ContainsType(types, "FAX"); break;
+            case VCardPhoneSlot.HomeFax:
+                allowedTypes = new[] { "HOME", "FAX" }; requiredTypePresent = ContainsType(types, "HOME") && ContainsType(types, "FAX"); break;
+            case VCardPhoneSlot.BusinessFax:
+                allowedTypes = new[] { "WORK", "FAX" }; requiredTypePresent = ContainsType(types, "WORK") && ContainsType(types, "FAX"); break;
+            case VCardPhoneSlot.Home:
+                allowedTypes = new[] { "HOME", "VOICE" }; requiredTypePresent = ContainsType(types, "HOME") && !preferred; break;
+            case VCardPhoneSlot.Pager:
+                allowedTypes = new[] { "PAGER" }; requiredTypePresent = ContainsType(types, "PAGER"); break;
+            case VCardPhoneSlot.Other:
+                allowedTypes = new[] { "OTHER", "VOICE" }; requiredTypePresent = ContainsType(types, "OTHER") && !preferred; break;
+            case VCardPhoneSlot.Work:
+                allowedTypes = new[] { "WORK", "VOICE" }; requiredTypePresent = ContainsType(types, "WORK") && !preferred; break;
+            default:
+                allowedTypes = new[] { "PREF", "VOICE" }; requiredTypePresent = preferred && count == 1; break;
+        }
+        return !requiredTypePresent || HasUnsupportedTypeTokens(types, allowedTypes);
+    }
+
+    private static bool HasAddressSlotOverflow(IEnumerable<VCardProperty> properties) =>
+        HasAddressSlotOverflow(properties, "ADR") || HasAddressSlotOverflow(properties, "LABEL");
+
+    private static bool HasUnprojectedAddressComponents(IEnumerable<VCardProperty> properties) =>
+        properties.Where(property => property.Name == "ADR").Any(property => {
+            string[] values = SplitEscaped(property.Value, ';');
+            return !string.IsNullOrWhiteSpace(ValueAt(values, 1));
+        });
+
+    private static bool HasUnsupportedAddressTypes(IEnumerable<VCardProperty> properties) =>
+        properties.Where(property => property.Name == "ADR" || property.Name == "LABEL").Any(property => {
+            string types = property.Parameters.TryGetValue("TYPE", out string? type) ? type : string.Empty;
+            int addressTypes = new[] { "HOME", "WORK", "OTHER" }.Count(value => ContainsType(types, value));
+            string[] allowedParameters = property.Name == "ADR" ? new[] { "TYPE", "LABEL" } : new[] { "TYPE" };
+            return addressTypes > 1 || HasUnsupportedParameters(property, allowedParameters) ||
+                HasUnsupportedTypeTokens(types, "HOME", "WORK", "OTHER");
+        });
+
+    private static bool HasAddressSlotOverflow(IEnumerable<VCardProperty> properties, string propertyName) {
+        int homeCount = 0;
+        int workCount = 0;
+        int otherCount = 0;
+        foreach (VCardProperty property in properties.Where(property => property.Name == propertyName)) {
+            string types = property.Parameters.TryGetValue("TYPE", out string? type) ? type : string.Empty;
+            if (ContainsType(types, "HOME")) homeCount++;
+            else if (ContainsType(types, "WORK")) workCount++;
+            else otherCount++;
+        }
+        return homeCount > 1 || workCount > 2 || otherCount > 1;
+    }
+
+    private static bool HasUrlSlotOverflow(IEnumerable<VCardProperty> properties) {
+        int homeCount = 0;
+        int workCount = 0;
+        foreach (VCardProperty property in properties.Where(property => property.Name == "URL")) {
+            string types = property.Parameters.TryGetValue("TYPE", out string? type) ? type : string.Empty;
+            if (ContainsType(types, "HOME")) homeCount++;
+            else workCount++;
+        }
+        return homeCount > 1 || workCount > 1;
+    }
+
+    private static bool HasUnsupportedUrlTypes(IEnumerable<VCardProperty> properties) =>
+        properties.Where(property => property.Name == "URL").Any(property => {
+            string types = property.Parameters.TryGetValue("TYPE", out string? type) ? type : string.Empty;
+            return HasUnsupportedParameters(property, "TYPE") ||
+                HasUnsupportedTypeTokens(types, "HOME", "WORK") ||
+                ContainsType(types, "HOME") && ContainsType(types, "WORK");
+        });
+
+    private static bool HasUnsupportedParameters(VCardProperty property, params string[] allowed) =>
+        property.Parameters.Keys.Any(parameter => !allowed.Any(value =>
+            value.Equals(parameter, StringComparison.OrdinalIgnoreCase)));
+
+    private static bool HasUnsupportedTypeTokens(string types, params string[] allowed) => types.Split(',')
+        .Select(value => value.Trim()).Where(value => value.Length > 0)
+        .Any(value => !allowed.Any(allowedType => allowedType.Equals(value, StringComparison.OrdinalIgnoreCase)));
+}

--- a/OfficeIMO.Email/Contact/VCardCodec.Projection.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.Projection.cs
@@ -1,6 +1,18 @@
 namespace OfficeIMO.Email;
 
 internal static partial class VCardCodec {
+    private static bool HasUnpreservedPropertyParameters(IEnumerable<VCardProperty> properties) =>
+        properties.Any(property => {
+            if (property.Parameters.Count == 0 || property.Name == "EMAIL" || property.Name == "TEL" ||
+                property.Name == "ADR" || property.Name == "LABEL" || property.Name == "URL") return false;
+            bool decodedQuotedPrintable = property.Parameters.TryGetValue("ENCODING", out string? encoding) &&
+                (encoding.Equals("QUOTED-PRINTABLE", StringComparison.OrdinalIgnoreCase) ||
+                 encoding.Equals("QP", StringComparison.OrdinalIgnoreCase));
+            return !decodedQuotedPrintable || property.Parameters.Keys.Any(parameter =>
+                !parameter.Equals("ENCODING", StringComparison.OrdinalIgnoreCase) &&
+                !parameter.Equals("CHARSET", StringComparison.OrdinalIgnoreCase));
+        });
+
     private static bool HasUnsupportedEmailSlot(VCardProperty property, int index, string types) {
         bool preferred = ContainsType(types, "PREF") || property.Parameters.ContainsKey("PREF");
         bool expectedSlot = index == 0

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -11,7 +11,8 @@ internal static class VCardCodec {
         document.MimeSemanticProjectionIsIncomplete |= cardCount > 1 || properties.Any(property =>
             property.Name == "PHOTO" || property.Name == "KEY" || property.Name == "LOGO" ||
             property.Name == "GENDER" || property.Name == "GEO" || property.Name == "TZ" ||
-            property.Name == "RELATED" || property.Name == "MEMBER" || property.Name == "CLASS" &&
+            property.Name == "RELATED" || property.Name == "MEMBER" || property.Name == "UID" ||
+            property.Name == "CLASS" &&
             !ParseVCardSensitivity(property.Value).HasValue);
 
         var contact = document.Contact ?? new OutlookContact();
@@ -56,7 +57,12 @@ internal static class VCardCodec {
             }
         }
         string? note = Unescape(GetValue(properties, "NOTE"));
-        if (document.Body.Text == null && !string.IsNullOrWhiteSpace(note)) document.Body.Text = note;
+        if (!string.IsNullOrWhiteSpace(note)) {
+            if (document.Body.Text == null) document.Body.Text = note;
+            else if (!string.Equals(document.Body.Text, note, StringComparison.Ordinal)) {
+                document.MimeSemanticProjectionIsIncomplete = true;
+            }
+        }
         return true;
     }
 
@@ -456,8 +462,22 @@ internal static class VCardCodec {
     private static string Escape(string? value) => (value ?? string.Empty).Replace("\\", "\\\\")
         .Replace(";", "\\;").Replace(",", "\\,").Replace("\r\n", "\\n").Replace("\r", "\\n").Replace("\n", "\\n");
 
-    private static string Unescape(string? value) => (value ?? string.Empty).Replace("\\n", "\n")
-        .Replace("\\N", "\n").Replace("\\,", ",").Replace("\\;", ";").Replace("\\\\", "\\");
+    private static string Unescape(string? value) {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        var result = new StringBuilder(value!.Length);
+        for (int index = 0; index < value.Length; index++) {
+            char character = value[index];
+            if (character != '\\' || index + 1 >= value.Length) {
+                result.Append(character);
+                continue;
+            }
+            char escaped = value[++index];
+            if (escaped == 'n' || escaped == 'N') result.Append('\n');
+            else if (escaped == ',' || escaped == ';' || escaped == '\\') result.Append(escaped);
+            else result.Append('\\').Append(escaped);
+        }
+        return result.ToString();
+    }
 
     private static string? UnescapeOrNull(string? value) => string.IsNullOrWhiteSpace(value)
         ? null

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -14,6 +14,7 @@ internal static partial class VCardCodec {
         int cardCount = properties.Count(property => property.Name == "BEGIN" &&
             property.Value.Equals("VCARD", StringComparison.OrdinalIgnoreCase));
         document.MimeSemanticProjectionIsIncomplete |= cardCount > 1 ||
+            HasUnpreservedPropertyParameters(properties) ||
             properties.Count(property => property.Name == "EMAIL") > 3 || properties.Any(property =>
             property.Name == "PHOTO" || property.Name == "KEY" || property.Name == "LOGO" ||
             property.Name == "GENDER" || property.Name == "GEO" || property.Name == "TZ" ||
@@ -86,6 +87,7 @@ internal static partial class VCardCodec {
             }
         }
         string? note = Unescape(GetValue(properties, "NOTE"));
+        document.MimeSemanticSourceHasTextBody |= !string.IsNullOrWhiteSpace(note);
         if (!string.IsNullOrWhiteSpace(note)) {
             if (document.Body.Text == null) document.Body.Text = note;
             else if (!string.Equals(document.Body.Text, note, StringComparison.Ordinal)) {

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -44,6 +44,14 @@ internal static class VCardCodec {
         ApplyAddresses(properties, contact);
         ApplyUrls(properties, contact);
         ApplyExtensions(properties, contact);
+        foreach (VCardProperty property in properties.Where(property => property.Name == "CATEGORIES")) {
+            foreach (string category in SplitEscaped(property.Value, ',')) {
+                if (!string.IsNullOrWhiteSpace(category) && !document.MessageMetadata.Categories.Any(existing =>
+                    string.Equals(existing, category, StringComparison.OrdinalIgnoreCase))) {
+                    document.MessageMetadata.Categories.Add(category);
+                }
+            }
+        }
         string? note = Unescape(GetValue(properties, "NOTE"));
         if (document.Body.Text == null && !string.IsNullOrWhiteSpace(note)) document.Body.Text = note;
         return true;
@@ -59,11 +67,11 @@ internal static class VCardCodec {
         if (source != null) return source;
         byte[] content = Create(document);
         var attachment = new EmailAttachment {
-            FileName = "contact.vcf",
             ContentType = "text/vcard",
             Content = content,
             Length = content.LongLength,
-            IsProjectedSemanticContent = true
+            IsProjectedSemanticContent = true,
+            IsMimeBodyPart = true
         };
         attachment.ContentTypeParameters["charset"] = "utf-8";
         return attachment;
@@ -137,6 +145,9 @@ internal static class VCardCodec {
         WriteAddressMetadata(output, contact.HomeAddress, "HOME");
         WriteAddressMetadata(output, contact.OtherAddress, "OTHER");
         WriteAddressMetadata(output, contact.WorkAddress, "WORK");
+        if (document.MessageMetadata.Categories.Count > 0) AppendLine(output, string.Concat("CATEGORIES:",
+            string.Join(",", document.MessageMetadata.Categories.Where(category => !string.IsNullOrWhiteSpace(category))
+                .Select(Escape))));
         AppendText(output, "NOTE", document.Body.Text);
         AppendLine(output, "END:VCARD");
         return Encoding.UTF8.GetBytes(output.ToString());

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -55,7 +55,8 @@ internal static class VCardCodec {
         if (sensitivity.HasValue) document.MessageMetadata.Sensitivity = sensitivity;
 
         ApplyEmails(properties, contact);
-        document.MimeSemanticProjectionIsIncomplete |= ApplyPhones(properties, contact.Phones);
+        document.MimeSemanticProjectionIsIncomplete |= ApplyPhones(properties, contact.Phones) ||
+            HasAddressSlotOverflow(properties) || HasUrlSlotOverflow(properties);
         ApplyAddresses(properties, contact);
         ApplyUrls(properties, contact);
         ApplyExtensions(properties, contact);
@@ -265,6 +266,33 @@ internal static class VCardCodec {
         if (ContainsType(types, "PAGER")) return VCardPhoneSlot.Pager;
         if (ContainsType(types, "WORK")) return VCardPhoneSlot.Work;
         return VCardPhoneSlot.General;
+    }
+
+    private static bool HasAddressSlotOverflow(IEnumerable<VCardProperty> properties) =>
+        HasAddressSlotOverflow(properties, "ADR") || HasAddressSlotOverflow(properties, "LABEL");
+
+    private static bool HasAddressSlotOverflow(IEnumerable<VCardProperty> properties, string propertyName) {
+        int homeCount = 0;
+        int workCount = 0;
+        int otherCount = 0;
+        foreach (VCardProperty property in properties.Where(property => property.Name == propertyName)) {
+            string types = property.Parameters.TryGetValue("TYPE", out string? type) ? type : string.Empty;
+            if (ContainsType(types, "HOME")) homeCount++;
+            else if (ContainsType(types, "WORK")) workCount++;
+            else otherCount++;
+        }
+        return homeCount > 1 || workCount > 2 || otherCount > 1;
+    }
+
+    private static bool HasUrlSlotOverflow(IEnumerable<VCardProperty> properties) {
+        int homeCount = 0;
+        int workCount = 0;
+        foreach (VCardProperty property in properties.Where(property => property.Name == "URL")) {
+            string types = property.Parameters.TryGetValue("TYPE", out string? type) ? type : string.Empty;
+            if (ContainsType(types, "HOME")) homeCount++;
+            else workCount++;
+        }
+        return homeCount > 1 || workCount > 1;
     }
 
     private static void ApplyAddresses(IEnumerable<VCardProperty> properties, OutlookContact contact) {

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -18,7 +18,8 @@ internal static partial class VCardCodec {
             properties.Count(property => property.Name == "EMAIL") > 3 || properties.Any(property =>
             property.Name == "PHOTO" || property.Name == "KEY" || property.Name == "LOGO" ||
             property.Name == "GENDER" || property.Name == "GEO" || property.Name == "TZ" ||
-            property.Name == "RELATED" || property.Name == "MEMBER" || property.Name == "UID" ||
+            property.Name == "RELATED" || property.Name == "MEMBER" || property.Name == "AGENT" ||
+            property.Name == "SORT-STRING" || property.Name == "MAILER" || property.Name == "UID" ||
             property.Name == "SOURCE" || property.Name == "FBURL" || property.Name == "CALURI" ||
             property.Name == "CALADRURI" || property.Name == "SOUND" ||
             property.Name == "VERSION" &&

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -1,6 +1,6 @@
 namespace OfficeIMO.Email;
 
-internal static class VCardCodec {
+internal static partial class VCardCodec {
     internal static bool TryProject(string text, EmailDocument document, IList<EmailDiagnostic> diagnostics,
         string location) {
         int projectionDiagnosticStart = diagnostics.Count;
@@ -71,9 +71,9 @@ internal static class VCardCodec {
 
         document.MimeSemanticProjectionIsIncomplete |= ApplyEmails(properties, contact) ||
             ApplyPhones(properties, contact.Phones) ||
-            HasUnsupportedPhonePreference(properties) ||
             HasAddressSlotOverflow(properties) || HasUnprojectedAddressComponents(properties) ||
-            HasUrlSlotOverflow(properties) || HasUnsupportedEmailPreference(properties);
+            HasUnsupportedAddressTypes(properties) || HasUrlSlotOverflow(properties) ||
+            HasUnsupportedUrlTypes(properties);
         ApplyAddresses(properties, contact);
         ApplyUrls(properties, contact);
         ApplyExtensions(properties, contact);
@@ -203,7 +203,7 @@ internal static class VCardCodec {
         VCardProperty[] emails = properties.Where(property => property.Name == "EMAIL").ToArray();
         OutlookContactEmailAddress[] targets = { contact.Email1, contact.Email2, contact.Email3 };
         var used = new bool[targets.Length];
-        bool typeSlotFallback = false;
+        bool incomplete = false;
         foreach (VCardProperty email in emails) {
             string types = email.Parameters.TryGetValue("TYPE", out string? type) ? type : string.Empty;
             int preferredIndex = ContainsType(types, "HOME") ? 1 : ContainsType(types, "OTHER") ? 2 :
@@ -212,7 +212,8 @@ internal static class VCardCodec {
                 ? preferredIndex
                 : Array.FindIndex(used, value => !value);
             if (index < 0) break;
-            typeSlotFallback |= preferredIndex >= 0 && index != preferredIndex;
+            incomplete |= preferredIndex >= 0 && index != preferredIndex ||
+                HasUnsupportedEmailSlot(email, index, types);
             used[index] = true;
             targets[index].Address = Unescape(email.Value);
             targets[index].AddressType = "SMTP";
@@ -223,12 +224,12 @@ internal static class VCardCodec {
             targets[index].OriginalDisplayName = UnescapeOrNull(GetValue(properties,
                 string.Concat(prefix, "-ORIGINAL-DISPLAY-NAME")));
         }
-        return typeSlotFallback;
+        return incomplete;
     }
 
     private static bool ApplyPhones(IEnumerable<VCardProperty> properties, OutlookContactPhones phones) {
         var counts = new Dictionary<VCardPhoneSlot, int>();
-        bool overflow = false;
+        bool incomplete = false;
         foreach (VCardProperty property in properties.Where(property => property.Name == "TEL")) {
             string types = property.Parameters.TryGetValue("TYPE", out string? type) ? type : string.Empty;
             string value = Unescape(property.Value);
@@ -237,7 +238,7 @@ internal static class VCardCodec {
             counts[slot] = count;
             int capacity = slot == VCardPhoneSlot.Home || slot == VCardPhoneSlot.Work ||
                 slot == VCardPhoneSlot.General ? 2 : 1;
-            overflow |= count > capacity;
+            incomplete |= count > capacity || HasUnsupportedPhoneSlot(property, slot, count, types);
             switch (slot) {
                 case VCardPhoneSlot.Mobile: phones.Mobile = value; break;
                 case VCardPhoneSlot.Assistant: phones.Assistant = value; break;
@@ -256,6 +257,7 @@ internal static class VCardCodec {
                     else phones.Home2 = value;
                     break;
                 case VCardPhoneSlot.Pager: phones.Pager = value; break;
+                case VCardPhoneSlot.Other: phones.Other = value; break;
                 case VCardPhoneSlot.Work:
                     if (count == 1) phones.Business = value;
                     else phones.Business2 = value;
@@ -266,7 +268,7 @@ internal static class VCardCodec {
                     break;
             }
         }
-        return overflow;
+        return incomplete;
     }
 
     private static VCardPhoneSlot GetPhoneSlot(string types) {
@@ -284,57 +286,9 @@ internal static class VCardCodec {
         if (ContainsType(types, "FAX")) return VCardPhoneSlot.BusinessFax;
         if (ContainsType(types, "HOME")) return VCardPhoneSlot.Home;
         if (ContainsType(types, "PAGER")) return VCardPhoneSlot.Pager;
+        if (ContainsType(types, "OTHER")) return VCardPhoneSlot.Other;
         if (ContainsType(types, "WORK")) return VCardPhoneSlot.Work;
         return VCardPhoneSlot.General;
-    }
-
-    private static bool HasAddressSlotOverflow(IEnumerable<VCardProperty> properties) =>
-        HasAddressSlotOverflow(properties, "ADR") || HasAddressSlotOverflow(properties, "LABEL");
-
-    private static bool HasUnprojectedAddressComponents(IEnumerable<VCardProperty> properties) =>
-        properties.Where(property => property.Name == "ADR").Any(property => {
-            string[] values = SplitEscaped(property.Value, ';');
-            return !string.IsNullOrWhiteSpace(ValueAt(values, 1));
-        });
-
-    private static bool HasUnsupportedEmailPreference(IEnumerable<VCardProperty> properties) =>
-        properties.Where(property => property.Name == "EMAIL").Any(property => {
-            string types = property.Parameters.TryGetValue("TYPE", out string? type) ? type : string.Empty;
-            bool preferred = ContainsType(types, "PREF") || property.Parameters.ContainsKey("PREF");
-            return preferred && !ContainsType(types, "WORK");
-        });
-
-    private static bool HasUnsupportedPhonePreference(IEnumerable<VCardProperty> properties) =>
-        properties.Where(property => property.Name == "TEL").Any(property => {
-            string types = property.Parameters.TryGetValue("TYPE", out string? type) ? type : string.Empty;
-            bool preferred = ContainsType(types, "PREF") || property.Parameters.ContainsKey("PREF");
-            if (!preferred) return false;
-            VCardPhoneSlot slot = GetPhoneSlot(types);
-            return slot != VCardPhoneSlot.General && slot != VCardPhoneSlot.PrimaryFax;
-        });
-
-    private static bool HasAddressSlotOverflow(IEnumerable<VCardProperty> properties, string propertyName) {
-        int homeCount = 0;
-        int workCount = 0;
-        int otherCount = 0;
-        foreach (VCardProperty property in properties.Where(property => property.Name == propertyName)) {
-            string types = property.Parameters.TryGetValue("TYPE", out string? type) ? type : string.Empty;
-            if (ContainsType(types, "HOME")) homeCount++;
-            else if (ContainsType(types, "WORK")) workCount++;
-            else otherCount++;
-        }
-        return homeCount > 1 || workCount > 2 || otherCount > 1;
-    }
-
-    private static bool HasUrlSlotOverflow(IEnumerable<VCardProperty> properties) {
-        int homeCount = 0;
-        int workCount = 0;
-        foreach (VCardProperty property in properties.Where(property => property.Name == "URL")) {
-            string types = property.Parameters.TryGetValue("TYPE", out string? type) ? type : string.Empty;
-            if (ContainsType(types, "HOME")) homeCount++;
-            else workCount++;
-        }
-        return homeCount > 1 || workCount > 1;
     }
 
     private static void ApplyAddresses(IEnumerable<VCardProperty> properties, OutlookContact contact) {
@@ -658,6 +612,7 @@ internal static class VCardCodec {
         Car,
         Radio,
         Pager,
+        Other,
         Callback,
         Telex,
         Text,

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -1,10 +1,15 @@
 namespace OfficeIMO.Email;
 
 internal static class VCardCodec {
-    internal static bool TryProject(string text, EmailDocument document) {
-        List<VCardProperty> properties = Parse(text.TrimStart('\uFEFF'));
+    internal static bool TryProject(string text, EmailDocument document, IList<EmailDiagnostic> diagnostics,
+        string location) {
+        int projectionDiagnosticStart = diagnostics.Count;
+        List<VCardProperty> properties = Parse(text.TrimStart('\uFEFF'), diagnostics, location);
         if (!properties.Any(property => property.Name == "BEGIN" &&
             property.Value.Equals("VCARD", StringComparison.OrdinalIgnoreCase))) return false;
+        document.MimeSemanticProjectionIsIncomplete |= diagnostics.Skip(projectionDiagnosticStart).Any(diagnostic =>
+            diagnostic.Code == "EMAIL_MIME_QUOTED_PRINTABLE_INVALID" ||
+            diagnostic.Code == "EMAIL_MIME_CHARSET_UNSUPPORTED");
 
         int cardCount = properties.Count(property => property.Name == "BEGIN" &&
             property.Value.Equals("VCARD", StringComparison.OrdinalIgnoreCase));
@@ -50,7 +55,7 @@ internal static class VCardCodec {
         if (sensitivity.HasValue) document.MessageMetadata.Sensitivity = sensitivity;
 
         ApplyEmails(properties, contact);
-        ApplyPhones(properties, contact.Phones);
+        document.MimeSemanticProjectionIsIncomplete |= ApplyPhones(properties, contact.Phones);
         ApplyAddresses(properties, contact);
         ApplyUrls(properties, contact);
         ApplyExtensions(properties, contact);
@@ -200,30 +205,66 @@ internal static class VCardCodec {
         }
     }
 
-    private static void ApplyPhones(IEnumerable<VCardProperty> properties, OutlookContactPhones phones) {
+    private static bool ApplyPhones(IEnumerable<VCardProperty> properties, OutlookContactPhones phones) {
+        var counts = new Dictionary<VCardPhoneSlot, int>();
+        bool overflow = false;
         foreach (VCardProperty property in properties.Where(property => property.Name == "TEL")) {
             string types = property.Parameters.TryGetValue("TYPE", out string? type) ? type : string.Empty;
             string value = Unescape(property.Value);
-            if (ContainsType(types, "CELL")) phones.Mobile = value;
-            else if (ContainsType(types, "X-ASSISTANT")) phones.Assistant = value;
-            else if (ContainsType(types, "X-COMPANY")) phones.CompanyMain = value;
-            else if (ContainsType(types, "CAR")) phones.Car = value;
-            else if (ContainsType(types, "X-RADIO")) phones.Radio = value;
-            else if (ContainsType(types, "X-CALLBACK")) phones.Callback = value;
-            else if (ContainsType(types, "X-TELEX")) phones.Telex = value;
-            else if (ContainsType(types, "TEXT")) phones.TextTelephone = value;
-            else if (ContainsType(types, "ISDN")) phones.Isdn = value;
-            else if (ContainsType(types, "FAX") && ContainsType(types, "PREF")) phones.PrimaryFax = value;
-            else if (ContainsType(types, "FAX") && ContainsType(types, "HOME")) phones.HomeFax = value;
-            else if (ContainsType(types, "FAX")) phones.BusinessFax = value;
-            else if (ContainsType(types, "HOME") && phones.Home == null) phones.Home = value;
-            else if (ContainsType(types, "HOME")) phones.Home2 = value;
-            else if (ContainsType(types, "PAGER")) phones.Pager = value;
-            else if (ContainsType(types, "WORK") && phones.Business == null) phones.Business = value;
-            else if (ContainsType(types, "WORK")) phones.Business2 = value;
-            else if (phones.Primary == null) phones.Primary = value;
-            else phones.Other = value;
+            VCardPhoneSlot slot = GetPhoneSlot(types);
+            int count = counts.TryGetValue(slot, out int current) ? current + 1 : 1;
+            counts[slot] = count;
+            int capacity = slot == VCardPhoneSlot.Home || slot == VCardPhoneSlot.Work ||
+                slot == VCardPhoneSlot.General ? 2 : 1;
+            overflow |= count > capacity;
+            switch (slot) {
+                case VCardPhoneSlot.Mobile: phones.Mobile = value; break;
+                case VCardPhoneSlot.Assistant: phones.Assistant = value; break;
+                case VCardPhoneSlot.Company: phones.CompanyMain = value; break;
+                case VCardPhoneSlot.Car: phones.Car = value; break;
+                case VCardPhoneSlot.Radio: phones.Radio = value; break;
+                case VCardPhoneSlot.Callback: phones.Callback = value; break;
+                case VCardPhoneSlot.Telex: phones.Telex = value; break;
+                case VCardPhoneSlot.Text: phones.TextTelephone = value; break;
+                case VCardPhoneSlot.Isdn: phones.Isdn = value; break;
+                case VCardPhoneSlot.PrimaryFax: phones.PrimaryFax = value; break;
+                case VCardPhoneSlot.HomeFax: phones.HomeFax = value; break;
+                case VCardPhoneSlot.BusinessFax: phones.BusinessFax = value; break;
+                case VCardPhoneSlot.Home:
+                    if (count == 1) phones.Home = value;
+                    else phones.Home2 = value;
+                    break;
+                case VCardPhoneSlot.Pager: phones.Pager = value; break;
+                case VCardPhoneSlot.Work:
+                    if (count == 1) phones.Business = value;
+                    else phones.Business2 = value;
+                    break;
+                default:
+                    if (count == 1) phones.Primary = value;
+                    else phones.Other = value;
+                    break;
+            }
         }
+        return overflow;
+    }
+
+    private static VCardPhoneSlot GetPhoneSlot(string types) {
+        if (ContainsType(types, "CELL")) return VCardPhoneSlot.Mobile;
+        if (ContainsType(types, "X-ASSISTANT")) return VCardPhoneSlot.Assistant;
+        if (ContainsType(types, "X-COMPANY")) return VCardPhoneSlot.Company;
+        if (ContainsType(types, "CAR")) return VCardPhoneSlot.Car;
+        if (ContainsType(types, "X-RADIO")) return VCardPhoneSlot.Radio;
+        if (ContainsType(types, "X-CALLBACK")) return VCardPhoneSlot.Callback;
+        if (ContainsType(types, "X-TELEX")) return VCardPhoneSlot.Telex;
+        if (ContainsType(types, "TEXT")) return VCardPhoneSlot.Text;
+        if (ContainsType(types, "ISDN")) return VCardPhoneSlot.Isdn;
+        if (ContainsType(types, "FAX") && ContainsType(types, "PREF")) return VCardPhoneSlot.PrimaryFax;
+        if (ContainsType(types, "FAX") && ContainsType(types, "HOME")) return VCardPhoneSlot.HomeFax;
+        if (ContainsType(types, "FAX")) return VCardPhoneSlot.BusinessFax;
+        if (ContainsType(types, "HOME")) return VCardPhoneSlot.Home;
+        if (ContainsType(types, "PAGER")) return VCardPhoneSlot.Pager;
+        if (ContainsType(types, "WORK")) return VCardPhoneSlot.Work;
+        return VCardPhoneSlot.General;
     }
 
     private static void ApplyAddresses(IEnumerable<VCardProperty> properties, OutlookContact contact) {
@@ -333,11 +374,17 @@ internal static class VCardCodec {
         address.CountryCode }
         .All(string.IsNullOrWhiteSpace);
 
-    private static List<VCardProperty> Parse(string text) {
+    private static List<VCardProperty> Parse(string text, IList<EmailDiagnostic> diagnostics, string location) {
         string normalized = text.Replace("\r\n", "\n").Replace('\r', '\n');
         var unfolded = new List<string>();
         foreach (string line in normalized.Split('\n')) {
-            if (line.Length > 0 && (line[0] == ' ' || line[0] == '\t') && unfolded.Count > 0) {
+            if (unfolded.Count > 0 && unfolded[unfolded.Count - 1].EndsWith("=", StringComparison.Ordinal) &&
+                IsQuotedPrintableProperty(unfolded[unfolded.Count - 1])) {
+                string continuation = line.Length > 0 && (line[0] == ' ' || line[0] == '\t')
+                    ? line.Substring(1)
+                    : line;
+                unfolded[unfolded.Count - 1] += string.Concat("\r\n", continuation);
+            } else if (line.Length > 0 && (line[0] == ' ' || line[0] == '\t') && unfolded.Count > 0) {
                 unfolded[unfolded.Count - 1] += line.Substring(1);
             } else unfolded.Add(line);
         }
@@ -354,7 +401,7 @@ internal static class VCardCodec {
                 int equals = FindUnquotedSeparator(tokens[index], '=');
                 if (equals > 0) {
                     string parameterName = tokens[index].Substring(0, equals).Trim();
-                    string parameterValue = tokens[index].Substring(equals + 1).Trim().Trim('"');
+                    string parameterValue = DecodeParameterValue(tokens[index].Substring(equals + 1));
                     if (parameterName.Equals("TYPE", StringComparison.OrdinalIgnoreCase) &&
                         property.Parameters.TryGetValue(parameterName, out string? priorType)) {
                         property.Parameters[parameterName] = string.Concat(priorType, ",", parameterValue);
@@ -365,9 +412,38 @@ internal static class VCardCodec {
                 else property.Parameters["TYPE"] = property.Parameters.TryGetValue("TYPE", out string? prior)
                     ? string.Concat(prior, ",", tokens[index]) : tokens[index];
             }
+            DecodePropertyValue(property, diagnostics, location);
             result.Add(property);
         }
         return result;
+    }
+
+    private static bool IsQuotedPrintableProperty(string line) =>
+        line.IndexOf("ENCODING=QUOTED-PRINTABLE", StringComparison.OrdinalIgnoreCase) >= 0 ||
+        line.IndexOf("ENCODING=QP", StringComparison.OrdinalIgnoreCase) >= 0;
+
+    private static string DecodeParameterValue(string value) {
+        string trimmed = value.Trim();
+        if (trimmed.Length < 2 || trimmed[0] != '"' || trimmed[trimmed.Length - 1] != '"') return trimmed;
+        var result = new StringBuilder(trimmed.Length - 2);
+        for (int index = 1; index < trimmed.Length - 1; index++) {
+            char character = trimmed[index];
+            if (character == '\\' && index + 1 < trimmed.Length - 1) result.Append(trimmed[++index]);
+            else result.Append(character);
+        }
+        return result.ToString();
+    }
+
+    private static void DecodePropertyValue(VCardProperty property, IList<EmailDiagnostic> diagnostics,
+        string location) {
+        if (!property.Parameters.TryGetValue("ENCODING", out string? encoding) ||
+            !(encoding.Equals("QUOTED-PRINTABLE", StringComparison.OrdinalIgnoreCase) ||
+              encoding.Equals("QP", StringComparison.OrdinalIgnoreCase))) return;
+        byte[] decoded = MimeTextCodec.DecodeQuotedPrintable(Encoding.ASCII.GetBytes(property.Value), false,
+            diagnostics, string.Concat(location, "/", property.Name));
+        property.Parameters.TryGetValue("CHARSET", out string? charset);
+        property.Value = MimeTextCodec.DecodeText(decoded, charset, diagnostics,
+            string.Concat(location, "/", property.Name));
     }
 
     private static int FindUnquotedSeparator(string value, char separator) {
@@ -494,8 +570,27 @@ internal static class VCardCodec {
     private sealed class VCardProperty {
         internal VCardProperty(string name, string value) { Name = name; Value = value; }
         internal string Name { get; }
-        internal string Value { get; }
+        internal string Value { get; set; }
         internal IDictionary<string, string> Parameters { get; } =
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private enum VCardPhoneSlot {
+        General,
+        Work,
+        Home,
+        Mobile,
+        PrimaryFax,
+        HomeFax,
+        BusinessFax,
+        Assistant,
+        Company,
+        Car,
+        Radio,
+        Pager,
+        Callback,
+        Telex,
+        Text,
+        Isdn
     }
 }

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -11,7 +11,8 @@ internal static class VCardCodec {
         document.MimeSemanticProjectionIsIncomplete |= cardCount > 1 || properties.Any(property =>
             property.Name == "PHOTO" || property.Name == "KEY" || property.Name == "LOGO" ||
             property.Name == "GENDER" || property.Name == "GEO" || property.Name == "TZ" ||
-            property.Name == "RELATED" || property.Name == "MEMBER");
+            property.Name == "RELATED" || property.Name == "MEMBER" || property.Name == "CLASS" &&
+            !ParseVCardSensitivity(property.Value).HasValue);
 
         var contact = document.Contact ?? new OutlookContact();
         document.Contact = contact;
@@ -37,7 +38,9 @@ internal static class VCardCodec {
         contact.InstantMessagingAddress = Unescape(GetValue(properties, "IMPP"));
         contact.Birthday = ParseDate(GetValue(properties, "BDAY"));
         contact.WeddingAnniversary = ParseDate(GetValue(properties, "ANNIVERSARY"));
-        contact.IsPrivate = string.Equals(GetValue(properties, "CLASS"), "PRIVATE", StringComparison.OrdinalIgnoreCase);
+        int? sensitivity = ParseVCardSensitivity(GetValue(properties, "CLASS"));
+        contact.IsPrivate = sensitivity.HasValue ? sensitivity.Value != 0 : (bool?)null;
+        if (sensitivity.HasValue) document.MessageMetadata.Sensitivity = sensitivity;
 
         ApplyEmails(properties, contact);
         ApplyPhones(properties, contact.Phones);
@@ -113,7 +116,12 @@ internal static class VCardCodec {
         if (contact.Birthday.HasValue) AppendLine(output, string.Concat("BDAY:", FormatDate(contact.Birthday.Value)));
         if (contact.WeddingAnniversary.HasValue) AppendLine(output,
             string.Concat("ANNIVERSARY:", FormatDate(contact.WeddingAnniversary.Value)));
-        if (contact.IsPrivate.HasValue) AppendLine(output, contact.IsPrivate.Value ? "CLASS:PRIVATE" : "CLASS:PUBLIC");
+        if (document.MessageMetadata.Sensitivity == 3) AppendLine(output, "CLASS:CONFIDENTIAL");
+        else if (document.MessageMetadata.Sensitivity == 1 || document.MessageMetadata.Sensitivity == 2 ||
+            contact.IsPrivate == true) AppendLine(output, "CLASS:PRIVATE");
+        else if (document.MessageMetadata.Sensitivity == 0 || contact.IsPrivate == false) {
+            AppendLine(output, "CLASS:PUBLIC");
+        }
 
         WriteEmail(output, contact.Email1, "WORK", true);
         WriteEmail(output, contact.Email2, "HOME", false);
@@ -390,6 +398,11 @@ internal static class VCardCodec {
     private static bool? ParseBoolean(string? value) =>
         string.Equals(value, "TRUE", StringComparison.OrdinalIgnoreCase) ? true :
         string.Equals(value, "FALSE", StringComparison.OrdinalIgnoreCase) ? false : (bool?)null;
+
+    private static int? ParseVCardSensitivity(string? value) =>
+        string.Equals(value, "PUBLIC", StringComparison.OrdinalIgnoreCase) ? 0 :
+        string.Equals(value, "PRIVATE", StringComparison.OrdinalIgnoreCase) ? 2 :
+        string.Equals(value, "CONFIDENTIAL", StringComparison.OrdinalIgnoreCase) ? 3 : (int?)null;
 
     private static string FormatDate(DateTimeOffset value) => value.Date.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
 

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -39,7 +39,10 @@ internal static class VCardCodec {
         contact.Prefix = ValueAt(name, 3);
         contact.Generation = ValueAt(name, 4);
         contact.DisplayName = Unescape(GetValue(properties, "FN"));
-        contact.NickName = Unescape(GetValue(properties, "NICKNAME"));
+        string[] nickNames = SplitEscaped(GetValue(properties, "NICKNAME"), ',');
+        contact.NickName = ValueAt(nickNames, 0);
+        document.MimeSemanticProjectionIsIncomplete |= nickNames.Skip(1)
+            .Any(value => !string.IsNullOrWhiteSpace(value));
         if (string.IsNullOrWhiteSpace(document.Subject)) document.Subject = contact.DisplayName;
 
         string[] organization = SplitEscaped(GetValue(properties, "ORG"), ';');
@@ -50,7 +53,11 @@ internal static class VCardCodec {
         contact.JobTitle = Unescape(GetValue(properties, "TITLE"));
         contact.Profession = Unescape(GetValue(properties, "ROLE"));
         contact.Language = Unescape(GetValue(properties, "LANG"));
-        contact.InstantMessagingAddress = Unescape(GetValue(properties, "IMPP"));
+        VCardProperty[] instantMessagingAddresses = properties.Where(property => property.Name == "IMPP").ToArray();
+        contact.InstantMessagingAddress = instantMessagingAddresses.Length == 0
+            ? null
+            : Unescape(instantMessagingAddresses[0].Value);
+        document.MimeSemanticProjectionIsIncomplete |= instantMessagingAddresses.Length > 1;
         string? birthday = GetValue(properties, "BDAY");
         string? anniversary = GetValue(properties, "ANNIVERSARY");
         contact.Birthday = ParseDate(birthday);
@@ -62,8 +69,8 @@ internal static class VCardCodec {
         contact.IsPrivate = sensitivity.HasValue ? sensitivity.Value != 0 : (bool?)null;
         if (sensitivity.HasValue) document.MessageMetadata.Sensitivity = sensitivity;
 
-        ApplyEmails(properties, contact);
-        document.MimeSemanticProjectionIsIncomplete |= ApplyPhones(properties, contact.Phones) ||
+        document.MimeSemanticProjectionIsIncomplete |= ApplyEmails(properties, contact) ||
+            ApplyPhones(properties, contact.Phones) ||
             HasUnsupportedPhonePreference(properties) ||
             HasAddressSlotOverflow(properties) || HasUnprojectedAddressComponents(properties) ||
             HasUrlSlotOverflow(properties) || HasUnsupportedEmailPreference(properties);
@@ -192,10 +199,11 @@ internal static class VCardCodec {
         return Encoding.UTF8.GetBytes(output.ToString());
     }
 
-    private static void ApplyEmails(IEnumerable<VCardProperty> properties, OutlookContact contact) {
+    private static bool ApplyEmails(IEnumerable<VCardProperty> properties, OutlookContact contact) {
         VCardProperty[] emails = properties.Where(property => property.Name == "EMAIL").ToArray();
         OutlookContactEmailAddress[] targets = { contact.Email1, contact.Email2, contact.Email3 };
         var used = new bool[targets.Length];
+        bool typeSlotFallback = false;
         foreach (VCardProperty email in emails) {
             string types = email.Parameters.TryGetValue("TYPE", out string? type) ? type : string.Empty;
             int preferredIndex = ContainsType(types, "HOME") ? 1 : ContainsType(types, "OTHER") ? 2 :
@@ -204,6 +212,7 @@ internal static class VCardCodec {
                 ? preferredIndex
                 : Array.FindIndex(used, value => !value);
             if (index < 0) break;
+            typeSlotFallback |= preferredIndex >= 0 && index != preferredIndex;
             used[index] = true;
             targets[index].Address = Unescape(email.Value);
             targets[index].AddressType = "SMTP";
@@ -214,6 +223,7 @@ internal static class VCardCodec {
             targets[index].OriginalDisplayName = UnescapeOrNull(GetValue(properties,
                 string.Concat(prefix, "-ORIGINAL-DISPLAY-NAME")));
         }
+        return typeSlotFallback;
     }
 
     private static bool ApplyPhones(IEnumerable<VCardProperty> properties, OutlookContactPhones phones) {

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -18,6 +18,8 @@ internal static class VCardCodec {
             property.Name == "PHOTO" || property.Name == "KEY" || property.Name == "LOGO" ||
             property.Name == "GENDER" || property.Name == "GEO" || property.Name == "TZ" ||
             property.Name == "RELATED" || property.Name == "MEMBER" || property.Name == "UID" ||
+            property.Name == "REV" || property.Name == "KIND" &&
+            !property.Value.Trim().Equals("individual", StringComparison.OrdinalIgnoreCase) ||
             property.Name == "CLASS" &&
             !ParseVCardSensitivity(property.Value).HasValue);
 

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -1,0 +1,408 @@
+namespace OfficeIMO.Email;
+
+internal static class VCardCodec {
+    internal static bool TryProject(byte[] content, EmailDocument document) {
+        List<VCardProperty> properties = Parse(Decode(content));
+        if (!properties.Any(property => property.Name == "BEGIN" &&
+            property.Value.Equals("VCARD", StringComparison.OrdinalIgnoreCase))) return false;
+
+        document.MimeSemanticProjectionIsIncomplete = properties.Any(property =>
+            property.Name == "PHOTO" || property.Name == "KEY" || property.Name == "LOGO" ||
+            property.Name == "GENDER" || property.Name == "GEO" || property.Name == "TZ" ||
+            property.Name == "RELATED" || property.Name == "MEMBER");
+
+        var contact = document.Contact ?? new OutlookContact();
+        document.Contact = contact;
+        document.OutlookItemKind = OutlookItemKind.Contact;
+        document.MessageClass = "IPM.Contact";
+
+        string[] name = SplitEscaped(GetValue(properties, "N"), ';');
+        contact.Surname = ValueAt(name, 0);
+        contact.GivenName = ValueAt(name, 1);
+        contact.MiddleName = ValueAt(name, 2);
+        contact.Prefix = ValueAt(name, 3);
+        contact.Generation = ValueAt(name, 4);
+        contact.DisplayName = Unescape(GetValue(properties, "FN"));
+        contact.NickName = Unescape(GetValue(properties, "NICKNAME"));
+        if (string.IsNullOrWhiteSpace(document.Subject)) document.Subject = contact.DisplayName;
+
+        string[] organization = SplitEscaped(GetValue(properties, "ORG"), ';');
+        contact.CompanyName = ValueAt(organization, 0);
+        contact.Department = ValueAt(organization, 1);
+        contact.JobTitle = Unescape(GetValue(properties, "TITLE"));
+        contact.Profession = Unescape(GetValue(properties, "ROLE"));
+        contact.Language = Unescape(GetValue(properties, "LANG"));
+        contact.InstantMessagingAddress = Unescape(GetValue(properties, "IMPP"));
+        contact.Birthday = ParseDate(GetValue(properties, "BDAY"));
+        contact.WeddingAnniversary = ParseDate(GetValue(properties, "ANNIVERSARY"));
+        contact.IsPrivate = string.Equals(GetValue(properties, "CLASS"), "PRIVATE", StringComparison.OrdinalIgnoreCase);
+
+        ApplyEmails(properties, contact);
+        ApplyPhones(properties, contact.Phones);
+        ApplyAddresses(properties, contact);
+        ApplyUrls(properties, contact);
+        ApplyExtensions(properties, contact);
+        string? note = Unescape(GetValue(properties, "NOTE"));
+        if (document.Body.Text == null && !string.IsNullOrWhiteSpace(note)) document.Body.Text = note;
+        return true;
+    }
+
+    internal static EmailAttachment? FindSemanticAttachment(EmailDocument document) {
+        if (document.OutlookItemKind != OutlookItemKind.Contact) return null;
+        return document.Attachments.FirstOrDefault(attachment => attachment.IsProjectedSemanticContent &&
+            IsVCardContentType(attachment.ContentType)) ?? document.Attachments.FirstOrDefault(attachment =>
+            IsVCardContentType(attachment.ContentType));
+    }
+
+    internal static EmailAttachment CreateAttachment(EmailDocument document, long maximumBytes,
+        EmailAttachment? source = null) {
+        byte[] content = source == null
+            ? Create(document)
+            : EmailAttachmentContent.ReadOrNull(source, maximumBytes) ?? Create(document);
+        var attachment = new EmailAttachment {
+            FileName = source?.FileName ?? "contact.vcf",
+            ContentType = "text/vcard",
+            Content = content,
+            Length = content.LongLength,
+            IsProjectedSemanticContent = true
+        };
+        attachment.ContentTypeParameters["charset"] = "utf-8";
+        return attachment;
+    }
+
+    internal static bool HasOpaqueContactState(OutlookContact contact) =>
+        HasOpaqueAddress(contact.Email1) || HasOpaqueAddress(contact.Email2) || HasOpaqueAddress(contact.Email3);
+
+    private static bool HasOpaqueAddress(OutlookContactEmailAddress address) =>
+        address.OriginalEntryId != null && string.IsNullOrWhiteSpace(address.Address) ||
+        !string.IsNullOrWhiteSpace(address.Address) && !string.IsNullOrWhiteSpace(address.AddressType) &&
+        !string.Equals(address.AddressType, "SMTP", StringComparison.OrdinalIgnoreCase);
+
+    internal static bool IsVCardContentType(string? contentType) =>
+        string.Equals(contentType, "text/vcard", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(contentType, "text/x-vcard", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(contentType, "application/vcard", StringComparison.OrdinalIgnoreCase);
+
+    private static byte[] Create(EmailDocument document) {
+        OutlookContact contact = document.Contact ?? new OutlookContact();
+        var output = new StringBuilder();
+        AppendLine(output, "BEGIN:VCARD");
+        AppendLine(output, "VERSION:3.0");
+        AppendLine(output, string.Concat("N:", Escape(contact.Surname), ";", Escape(contact.GivenName), ";",
+            Escape(contact.MiddleName), ";", Escape(contact.Prefix), ";", Escape(contact.Generation)));
+        string displayName = contact.DisplayName ?? document.Subject ?? string.Join(" ",
+            new[] { contact.GivenName, contact.Surname }.Where(value => !string.IsNullOrWhiteSpace(value)));
+        AppendText(output, "FN", displayName);
+        AppendText(output, "NICKNAME", contact.NickName);
+        if (!string.IsNullOrWhiteSpace(contact.CompanyName) || !string.IsNullOrWhiteSpace(contact.Department)) {
+            AppendLine(output, string.Concat("ORG:", Escape(contact.CompanyName), ";", Escape(contact.Department)));
+        }
+        AppendText(output, "TITLE", contact.JobTitle);
+        AppendText(output, "ROLE", contact.Profession);
+        AppendText(output, "LANG", contact.Language);
+        if (contact.Birthday.HasValue) AppendLine(output, string.Concat("BDAY:", FormatDate(contact.Birthday.Value)));
+        if (contact.WeddingAnniversary.HasValue) AppendLine(output,
+            string.Concat("ANNIVERSARY:", FormatDate(contact.WeddingAnniversary.Value)));
+        if (contact.IsPrivate.HasValue) AppendLine(output, contact.IsPrivate.Value ? "CLASS:PRIVATE" : "CLASS:PUBLIC");
+
+        WriteEmail(output, contact.Email1, "WORK", true);
+        WriteEmail(output, contact.Email2, "HOME", false);
+        WriteEmail(output, contact.Email3, "OTHER", false);
+        WritePhones(output, contact.Phones);
+        WriteAddress(output, contact.BusinessAddress, "WORK");
+        WriteAddress(output, contact.HomeAddress, "HOME");
+        WriteAddress(output, contact.OtherAddress, "OTHER");
+        WriteAddress(output, contact.WorkAddress, "WORK");
+        if (!string.IsNullOrWhiteSpace(contact.BusinessHomePage)) AppendLine(output,
+            string.Concat("URL;TYPE=WORK:", EscapeUri(contact.BusinessHomePage!)));
+        if (!string.IsNullOrWhiteSpace(contact.PersonalHomePage)) AppendLine(output,
+            string.Concat("URL;TYPE=HOME:", EscapeUri(contact.PersonalHomePage!)));
+        if (!string.IsNullOrWhiteSpace(contact.InstantMessagingAddress)) AppendLine(output,
+            string.Concat("IMPP:", EscapeUri(contact.InstantMessagingAddress!)));
+
+        AppendText(output, "X-MS-MANAGER", contact.ManagerName);
+        AppendText(output, "X-MS-ASSISTANT", contact.AssistantName);
+        AppendText(output, "X-MS-SPOUSE", contact.SpouseName);
+        foreach (string child in contact.Children) AppendText(output, "X-MS-CHILD", child);
+        AppendText(output, "X-MS-LOCATION", contact.Location);
+        AppendText(output, "X-MS-OFFICE", contact.OfficeLocation);
+        AppendText(output, "X-MS-FILE-AS", contact.FileAs);
+        AppendText(output, "X-MS-INITIALS", contact.Initials);
+        AppendText(output, "X-MS-HTML", contact.Html);
+        if (contact.HasPicture.HasValue) AppendLine(output,
+            string.Concat("X-OFFICEIMO-HAS-PICTURE:", contact.HasPicture.Value ? "TRUE" : "FALSE"));
+        WriteEmailMetadata(output, contact.Email1, 1);
+        WriteEmailMetadata(output, contact.Email2, 2);
+        WriteEmailMetadata(output, contact.Email3, 3);
+        WriteAddressMetadata(output, contact.BusinessAddress, "BUSINESS");
+        WriteAddressMetadata(output, contact.HomeAddress, "HOME");
+        WriteAddressMetadata(output, contact.OtherAddress, "OTHER");
+        WriteAddressMetadata(output, contact.WorkAddress, "WORK");
+        AppendText(output, "NOTE", document.Body.Text);
+        AppendLine(output, "END:VCARD");
+        return Encoding.UTF8.GetBytes(output.ToString());
+    }
+
+    private static void ApplyEmails(IEnumerable<VCardProperty> properties, OutlookContact contact) {
+        VCardProperty[] emails = properties.Where(property => property.Name == "EMAIL").ToArray();
+        OutlookContactEmailAddress[] targets = { contact.Email1, contact.Email2, contact.Email3 };
+        for (int index = 0; index < Math.Min(emails.Length, targets.Length); index++) {
+            targets[index].Address = Unescape(emails[index].Value);
+            targets[index].AddressType = "SMTP";
+            string prefix = string.Concat("X-OFFICEIMO-EMAIL",
+                (index + 1).ToString(CultureInfo.InvariantCulture));
+            targets[index].DisplayName = UnescapeOrNull(GetValue(properties,
+                string.Concat(prefix, "-DISPLAY-NAME"))) ?? contact.DisplayName;
+            targets[index].OriginalDisplayName = UnescapeOrNull(GetValue(properties,
+                string.Concat(prefix, "-ORIGINAL-DISPLAY-NAME")));
+        }
+    }
+
+    private static void ApplyPhones(IEnumerable<VCardProperty> properties, OutlookContactPhones phones) {
+        foreach (VCardProperty property in properties.Where(property => property.Name == "TEL")) {
+            string types = property.Parameters.TryGetValue("TYPE", out string? type) ? type : string.Empty;
+            string value = Unescape(property.Value);
+            if (ContainsType(types, "CELL")) phones.Mobile = value;
+            else if (ContainsType(types, "X-ASSISTANT")) phones.Assistant = value;
+            else if (ContainsType(types, "X-COMPANY")) phones.CompanyMain = value;
+            else if (ContainsType(types, "CAR")) phones.Car = value;
+            else if (ContainsType(types, "X-RADIO")) phones.Radio = value;
+            else if (ContainsType(types, "X-CALLBACK")) phones.Callback = value;
+            else if (ContainsType(types, "X-TELEX")) phones.Telex = value;
+            else if (ContainsType(types, "TEXT")) phones.TextTelephone = value;
+            else if (ContainsType(types, "ISDN")) phones.Isdn = value;
+            else if (ContainsType(types, "FAX") && ContainsType(types, "PREF")) phones.PrimaryFax = value;
+            else if (ContainsType(types, "FAX") && ContainsType(types, "HOME")) phones.HomeFax = value;
+            else if (ContainsType(types, "FAX")) phones.BusinessFax = value;
+            else if (ContainsType(types, "HOME") && phones.Home == null) phones.Home = value;
+            else if (ContainsType(types, "HOME")) phones.Home2 = value;
+            else if (ContainsType(types, "PAGER")) phones.Pager = value;
+            else if (ContainsType(types, "WORK") && phones.Business == null) phones.Business = value;
+            else if (ContainsType(types, "WORK")) phones.Business2 = value;
+            else if (phones.Primary == null) phones.Primary = value;
+            else phones.Other = value;
+        }
+    }
+
+    private static void ApplyAddresses(IEnumerable<VCardProperty> properties, OutlookContact contact) {
+        int workIndex = 0;
+        foreach (VCardProperty property in properties.Where(property => property.Name == "ADR")) {
+            string types = property.Parameters.TryGetValue("TYPE", out string? type) ? type : string.Empty;
+            OutlookPostalAddress target = ContainsType(types, "HOME") ? contact.HomeAddress :
+                ContainsType(types, "WORK") && workIndex++ > 0 ? contact.WorkAddress :
+                ContainsType(types, "WORK") ? contact.BusinessAddress : contact.OtherAddress;
+            string[] values = SplitEscaped(property.Value, ';');
+            target.PostOfficeBox = ValueAt(values, 0);
+            target.Street = ValueAt(values, 2);
+            target.City = ValueAt(values, 3);
+            target.StateOrProvince = ValueAt(values, 4);
+            target.PostalCode = ValueAt(values, 5);
+            target.Country = ValueAt(values, 6);
+        }
+        int labelWorkIndex = 0;
+        foreach (VCardProperty property in properties.Where(property => property.Name == "LABEL")) {
+            string types = property.Parameters.TryGetValue("TYPE", out string? type) ? type : string.Empty;
+            OutlookPostalAddress target = ContainsType(types, "HOME") ? contact.HomeAddress :
+                ContainsType(types, "WORK") && labelWorkIndex++ > 0 ? contact.WorkAddress :
+                ContainsType(types, "WORK") ? contact.BusinessAddress : contact.OtherAddress;
+            target.Formatted = Unescape(property.Value);
+        }
+        contact.BusinessAddress.CountryCode = Unescape(GetValue(properties, "X-OFFICEIMO-BUSINESS-COUNTRY-CODE"));
+        contact.HomeAddress.CountryCode = Unescape(GetValue(properties, "X-OFFICEIMO-HOME-COUNTRY-CODE"));
+        contact.OtherAddress.CountryCode = Unescape(GetValue(properties, "X-OFFICEIMO-OTHER-COUNTRY-CODE"));
+        contact.WorkAddress.CountryCode = Unescape(GetValue(properties, "X-OFFICEIMO-WORK-COUNTRY-CODE"));
+    }
+
+    private static void ApplyUrls(IEnumerable<VCardProperty> properties, OutlookContact contact) {
+        foreach (VCardProperty property in properties.Where(property => property.Name == "URL")) {
+            string types = property.Parameters.TryGetValue("TYPE", out string? type) ? type : string.Empty;
+            if (ContainsType(types, "HOME")) contact.PersonalHomePage = Unescape(property.Value);
+            else contact.BusinessHomePage = Unescape(property.Value);
+        }
+    }
+
+    private static void ApplyExtensions(IEnumerable<VCardProperty> properties, OutlookContact contact) {
+        contact.ManagerName = Unescape(GetValue(properties, "X-MS-MANAGER"));
+        contact.AssistantName = Unescape(GetValue(properties, "X-MS-ASSISTANT"));
+        contact.SpouseName = Unescape(GetValue(properties, "X-MS-SPOUSE"));
+        contact.Location = Unescape(GetValue(properties, "X-MS-LOCATION"));
+        contact.OfficeLocation = Unescape(GetValue(properties, "X-MS-OFFICE"));
+        contact.FileAs = Unescape(GetValue(properties, "X-MS-FILE-AS"));
+        contact.Initials = Unescape(GetValue(properties, "X-MS-INITIALS"));
+        contact.Html = Unescape(GetValue(properties, "X-MS-HTML"));
+        contact.HasPicture = ParseBoolean(GetValue(properties, "X-OFFICEIMO-HAS-PICTURE"));
+        foreach (VCardProperty child in properties.Where(property => property.Name == "X-MS-CHILD")) {
+            contact.Children.Add(Unescape(child.Value));
+        }
+    }
+
+    private static void WriteEmail(StringBuilder output, OutlookContactEmailAddress email, string type, bool preferred) {
+        if (string.IsNullOrWhiteSpace(email.Address)) return;
+        AppendLine(output, string.Concat("EMAIL;TYPE=", type, preferred ? ",PREF:" : ":", Escape(email.Address)));
+    }
+
+    private static void WriteEmailMetadata(StringBuilder output, OutlookContactEmailAddress email, int index) {
+        string prefix = string.Concat("X-OFFICEIMO-EMAIL", index.ToString(CultureInfo.InvariantCulture));
+        AppendText(output, string.Concat(prefix, "-DISPLAY-NAME"), email.DisplayName);
+        AppendText(output, string.Concat(prefix, "-ORIGINAL-DISPLAY-NAME"), email.OriginalDisplayName);
+    }
+
+    private static void WritePhones(StringBuilder output, OutlookContactPhones phones) {
+        WritePhone(output, phones.Business, "WORK,VOICE");
+        WritePhone(output, phones.Business2, "WORK,VOICE");
+        WritePhone(output, phones.Home, "HOME,VOICE");
+        WritePhone(output, phones.Home2, "HOME,VOICE");
+        WritePhone(output, phones.Mobile, "CELL,VOICE");
+        WritePhone(output, phones.Other, "OTHER,VOICE");
+        WritePhone(output, phones.Primary, "PREF,VOICE");
+        WritePhone(output, phones.BusinessFax, "WORK,FAX");
+        WritePhone(output, phones.HomeFax, "HOME,FAX");
+        WritePhone(output, phones.PrimaryFax, "PREF,FAX");
+        WritePhone(output, phones.Assistant, "X-ASSISTANT");
+        WritePhone(output, phones.CompanyMain, "WORK,X-COMPANY");
+        WritePhone(output, phones.Car, "CAR");
+        WritePhone(output, phones.Radio, "X-RADIO");
+        WritePhone(output, phones.Pager, "PAGER");
+        WritePhone(output, phones.Callback, "X-CALLBACK");
+        WritePhone(output, phones.Telex, "X-TELEX");
+        WritePhone(output, phones.TextTelephone, "TEXT");
+        WritePhone(output, phones.Isdn, "ISDN");
+    }
+
+    private static void WritePhone(StringBuilder output, string? value, string type) {
+        if (!string.IsNullOrWhiteSpace(value)) AppendLine(output,
+            string.Concat("TEL;TYPE=", type, ":", Escape(value)));
+    }
+
+    private static void WriteAddress(StringBuilder output, OutlookPostalAddress address, string type) {
+        if (IsEmpty(address)) return;
+        AppendLine(output, string.Concat("ADR;TYPE=", type, ":", Escape(address.PostOfficeBox), ";;",
+            Escape(address.Street), ";", Escape(address.City), ";", Escape(address.StateOrProvince), ";",
+            Escape(address.PostalCode), ";", Escape(address.Country)));
+        if (!string.IsNullOrWhiteSpace(address.Formatted)) AppendText(output, string.Concat("LABEL;TYPE=", type), address.Formatted);
+    }
+
+    private static void WriteAddressMetadata(StringBuilder output, OutlookPostalAddress address, string type) =>
+        AppendText(output, string.Concat("X-OFFICEIMO-", type, "-COUNTRY-CODE"), address.CountryCode);
+
+    private static bool IsEmpty(OutlookPostalAddress address) => new[] { address.Formatted, address.Street,
+        address.City, address.StateOrProvince, address.PostalCode, address.Country, address.PostOfficeBox,
+        address.CountryCode }
+        .All(string.IsNullOrWhiteSpace);
+
+    private static List<VCardProperty> Parse(string text) {
+        string normalized = text.Replace("\r\n", "\n").Replace('\r', '\n');
+        var unfolded = new List<string>();
+        foreach (string line in normalized.Split('\n')) {
+            if (line.Length > 0 && (line[0] == ' ' || line[0] == '\t') && unfolded.Count > 0) {
+                unfolded[unfolded.Count - 1] += line.Substring(1);
+            } else unfolded.Add(line);
+        }
+        var result = new List<VCardProperty>();
+        foreach (string line in unfolded) {
+            int colon = line.IndexOf(':');
+            if (colon <= 0) continue;
+            string[] tokens = line.Substring(0, colon).Split(';');
+            string name = tokens[0];
+            int dot = name.LastIndexOf('.');
+            if (dot >= 0) name = name.Substring(dot + 1);
+            var property = new VCardProperty(name.Trim().ToUpperInvariant(), line.Substring(colon + 1));
+            for (int index = 1; index < tokens.Length; index++) {
+                int equals = tokens[index].IndexOf('=');
+                if (equals > 0) property.Parameters[tokens[index].Substring(0, equals).Trim()] =
+                    tokens[index].Substring(equals + 1).Trim().Trim('"');
+                else property.Parameters["TYPE"] = property.Parameters.TryGetValue("TYPE", out string? prior)
+                    ? string.Concat(prior, ",", tokens[index]) : tokens[index];
+            }
+            result.Add(property);
+        }
+        return result;
+    }
+
+    private static string Decode(byte[] content) {
+        int offset = content.Length >= 3 && content[0] == 0xef && content[1] == 0xbb && content[2] == 0xbf ? 3 : 0;
+        return Encoding.UTF8.GetString(content, offset, content.Length - offset);
+    }
+
+    private static string? GetValue(IEnumerable<VCardProperty> properties, string name) =>
+        properties.FirstOrDefault(property => property.Name == name)?.Value;
+
+    private static DateTimeOffset? ParseDate(string? value) {
+        if (DateTime.TryParseExact(value, new[] { "yyyyMMdd", "yyyy-MM-dd" }, CultureInfo.InvariantCulture,
+            DateTimeStyles.None, out DateTime date)) return new DateTimeOffset(date, TimeSpan.Zero);
+        return null;
+    }
+
+    private static bool? ParseBoolean(string? value) =>
+        string.Equals(value, "TRUE", StringComparison.OrdinalIgnoreCase) ? true :
+        string.Equals(value, "FALSE", StringComparison.OrdinalIgnoreCase) ? false : (bool?)null;
+
+    private static string FormatDate(DateTimeOffset value) => value.Date.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
+
+    private static bool ContainsType(string types, string type) => types.Split(',')
+        .Any(value => value.Trim().Equals(type, StringComparison.OrdinalIgnoreCase));
+
+    private static string[] SplitEscaped(string? value, char separator) {
+        if (value == null) return Array.Empty<string>();
+        var result = new List<string>();
+        var current = new StringBuilder();
+        bool escaped = false;
+        foreach (char character in value) {
+            if (escaped) {
+                current.Append('\\').Append(character);
+                escaped = false;
+            } else if (character == '\\') escaped = true;
+            else if (character == separator) {
+                result.Add(Unescape(current.ToString()));
+                current.Clear();
+            } else current.Append(character);
+        }
+        if (escaped) current.Append('\\');
+        result.Add(Unescape(current.ToString()));
+        return result.ToArray();
+    }
+
+    private static string? ValueAt(string[] values, int index) => index < values.Length &&
+        !string.IsNullOrWhiteSpace(values[index]) ? values[index] : null;
+
+    private static void AppendText(StringBuilder output, string name, string? value) {
+        if (!string.IsNullOrWhiteSpace(value)) AppendLine(output, string.Concat(name, ":", Escape(value)));
+    }
+
+    private static void AppendLine(StringBuilder output, string line) {
+        const int maximumOctets = 75;
+        var current = new StringBuilder();
+        int octets = 0;
+        for (int index = 0; index < line.Length;) {
+            int length = char.IsHighSurrogate(line[index]) && index + 1 < line.Length &&
+                char.IsLowSurrogate(line[index + 1]) ? 2 : 1;
+            string character = line.Substring(index, length);
+            int bytes = Encoding.UTF8.GetByteCount(character);
+            if (current.Length > 0 && octets + bytes > maximumOctets) {
+                output.Append(current).Append("\r\n "); current.Clear(); octets = 1;
+            }
+            current.Append(character); octets += bytes; index += length;
+        }
+        output.Append(current).Append("\r\n");
+    }
+
+    private static string Escape(string? value) => (value ?? string.Empty).Replace("\\", "\\\\")
+        .Replace(";", "\\;").Replace(",", "\\,").Replace("\r\n", "\\n").Replace("\r", "\\n").Replace("\n", "\\n");
+
+    private static string Unescape(string? value) => (value ?? string.Empty).Replace("\\n", "\n")
+        .Replace("\\N", "\n").Replace("\\,", ",").Replace("\\;", ";").Replace("\\\\", "\\");
+
+    private static string? UnescapeOrNull(string? value) => string.IsNullOrWhiteSpace(value)
+        ? null
+        : Unescape(value);
+
+    private static string EscapeUri(string value) => value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+
+    private sealed class VCardProperty {
+        internal VCardProperty(string name, string value) { Name = name; Value = value; }
+        internal string Name { get; }
+        internal string Value { get; }
+        internal IDictionary<string, string> Parameters { get; } =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -8,7 +8,8 @@ internal static class VCardCodec {
 
         int cardCount = properties.Count(property => property.Name == "BEGIN" &&
             property.Value.Equals("VCARD", StringComparison.OrdinalIgnoreCase));
-        document.MimeSemanticProjectionIsIncomplete |= cardCount > 1 || properties.Any(property =>
+        document.MimeSemanticProjectionIsIncomplete |= cardCount > 1 ||
+            properties.Count(property => property.Name == "EMAIL") > 3 || properties.Any(property =>
             property.Name == "PHOTO" || property.Name == "KEY" || property.Name == "LOGO" ||
             property.Name == "GENDER" || property.Name == "GEO" || property.Name == "TZ" ||
             property.Name == "RELATED" || property.Name == "MEMBER" || property.Name == "UID" ||
@@ -37,8 +38,13 @@ internal static class VCardCodec {
         contact.Profession = Unescape(GetValue(properties, "ROLE"));
         contact.Language = Unescape(GetValue(properties, "LANG"));
         contact.InstantMessagingAddress = Unescape(GetValue(properties, "IMPP"));
-        contact.Birthday = ParseDate(GetValue(properties, "BDAY"));
-        contact.WeddingAnniversary = ParseDate(GetValue(properties, "ANNIVERSARY"));
+        string? birthday = GetValue(properties, "BDAY");
+        string? anniversary = GetValue(properties, "ANNIVERSARY");
+        contact.Birthday = ParseDate(birthday);
+        contact.WeddingAnniversary = ParseDate(anniversary);
+        document.MimeSemanticProjectionIsIncomplete |=
+            !string.IsNullOrWhiteSpace(birthday) && !contact.Birthday.HasValue ||
+            !string.IsNullOrWhiteSpace(anniversary) && !contact.WeddingAnniversary.HasValue;
         int? sensitivity = ParseVCardSensitivity(GetValue(properties, "CLASS"));
         contact.IsPrivate = sensitivity.HasValue ? sensitivity.Value != 0 : (bool?)null;
         if (sensitivity.HasValue) document.MessageMetadata.Sensitivity = sensitivity;

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -16,6 +16,7 @@ internal static partial class VCardCodec {
         VCardProperty[] versions = properties.Where(property => property.Name == "VERSION").ToArray();
         document.MimeSemanticProjectionIsIncomplete |= cardCount > 1 ||
             versions.Length != 1 || !versions[0].Value.Trim().Equals("3.0", StringComparison.OrdinalIgnoreCase) ||
+            HasDuplicateVCardSingletons(properties) ||
             HasUnprojectedExtension(properties) ||
             HasUnpreservedPropertyParameters(properties) ||
             properties.Count(property => property.Name == "EMAIL") > 3 || properties.Any(property =>

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -26,7 +26,7 @@ internal static partial class VCardCodec {
             property.Name == "RELATED" || property.Name == "MEMBER" || property.Name == "AGENT" ||
             property.Name == "SORT-STRING" || property.Name == "MAILER" || property.Name == "UID" ||
             property.Name == "SOURCE" || property.Name == "FBURL" || property.Name == "CALURI" ||
-            property.Name == "CALADRURI" || property.Name == "SOUND" ||
+            property.Name == "CALADRURI" || property.Name == "SOUND" || property.Name == "PRODID" ||
             property.Name == "REV" || property.Name == "KIND" &&
             !property.Value.Trim().Equals("individual", StringComparison.OrdinalIgnoreCase) ||
             property.Name == "CLASS" &&

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -16,6 +16,7 @@ internal static partial class VCardCodec {
         VCardProperty[] versions = properties.Where(property => property.Name == "VERSION").ToArray();
         document.MimeSemanticProjectionIsIncomplete |= cardCount > 1 ||
             versions.Length != 1 || !versions[0].Value.Trim().Equals("3.0", StringComparison.OrdinalIgnoreCase) ||
+            properties.Any(property => property.Group != null) ||
             HasDuplicateVCardSingletons(properties) ||
             HasUnprojectedExtension(properties) ||
             HasUnpreservedPropertyParameters(properties) ||
@@ -424,8 +425,9 @@ internal static partial class VCardCodec {
             IReadOnlyList<string> tokens = SplitUnquoted(line.Substring(0, colon), ';');
             string name = tokens[0];
             int dot = name.LastIndexOf('.');
-            if (dot >= 0) name = name.Substring(dot + 1);
-            var property = new VCardProperty(name.Trim().ToUpperInvariant(), line.Substring(colon + 1));
+            string? group = dot >= 0 ? name.Substring(0, dot) : null;
+            if (group != null) name = name.Substring(dot + 1);
+            var property = new VCardProperty(name.Trim().ToUpperInvariant(), line.Substring(colon + 1), group);
             for (int index = 1; index < tokens.Count; index++) {
                 int equals = FindUnquotedSeparator(tokens[index], '=');
                 if (equals > 0) {
@@ -597,9 +599,14 @@ internal static partial class VCardCodec {
     private static string EscapeUri(string value) => value.Replace("\r", string.Empty).Replace("\n", string.Empty);
 
     private sealed class VCardProperty {
-        internal VCardProperty(string name, string value) { Name = name; Value = value; }
+        internal VCardProperty(string name, string value, string? group) {
+            Name = name;
+            Value = value;
+            Group = group;
+        }
         internal string Name { get; }
         internal string Value { get; set; }
+        internal string? Group { get; }
         internal IDictionary<string, string> Parameters { get; } =
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
     }

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -60,7 +60,8 @@ internal static class VCardCodec {
     internal static EmailAttachment? FindSemanticAttachment(EmailDocument document) {
         if (document.OutlookItemKind != OutlookItemKind.Contact) return null;
         return document.Attachments.FirstOrDefault(attachment => attachment.IsProjectedSemanticContent &&
-            IsVCardContentType(attachment.ContentType));
+            IsVCardContentType(attachment.ContentType,
+                attachment.ContentTypeParameters.TryGetValue("profile", out string? profile) ? profile : null));
     }
 
     internal static EmailAttachment CreateAttachment(EmailDocument document, EmailAttachment? source = null) {
@@ -85,10 +86,12 @@ internal static class VCardCodec {
         !string.IsNullOrWhiteSpace(address.Address) && !string.IsNullOrWhiteSpace(address.AddressType) &&
         !string.Equals(address.AddressType, "SMTP", StringComparison.OrdinalIgnoreCase);
 
-    internal static bool IsVCardContentType(string? contentType) =>
+    internal static bool IsVCardContentType(string? contentType, string? profile = null) =>
         string.Equals(contentType, "text/vcard", StringComparison.OrdinalIgnoreCase) ||
         string.Equals(contentType, "text/x-vcard", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(contentType, "application/vcard", StringComparison.OrdinalIgnoreCase);
+        string.Equals(contentType, "application/vcard", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(contentType, "text/directory", StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(profile, "vcard", StringComparison.OrdinalIgnoreCase);
 
     private static byte[] Create(EmailDocument document) {
         OutlookContact contact = document.Contact ?? new OutlookContact();
@@ -217,6 +220,7 @@ internal static class VCardCodec {
             target.StateOrProvince = ValueAt(values, 4);
             target.PostalCode = ValueAt(values, 5);
             target.Country = ValueAt(values, 6);
+            if (property.Parameters.TryGetValue("LABEL", out string? label)) target.Formatted = Unescape(label);
         }
         int labelWorkIndex = 0;
         foreach (VCardProperty property in properties.Where(property => property.Name == "LABEL")) {
@@ -319,15 +323,15 @@ internal static class VCardCodec {
         }
         var result = new List<VCardProperty>();
         foreach (string line in unfolded) {
-            int colon = line.IndexOf(':');
+            int colon = FindUnquotedSeparator(line, ':');
             if (colon <= 0) continue;
-            string[] tokens = line.Substring(0, colon).Split(';');
+            IReadOnlyList<string> tokens = SplitUnquoted(line.Substring(0, colon), ';');
             string name = tokens[0];
             int dot = name.LastIndexOf('.');
             if (dot >= 0) name = name.Substring(dot + 1);
             var property = new VCardProperty(name.Trim().ToUpperInvariant(), line.Substring(colon + 1));
-            for (int index = 1; index < tokens.Length; index++) {
-                int equals = tokens[index].IndexOf('=');
+            for (int index = 1; index < tokens.Count; index++) {
+                int equals = FindUnquotedSeparator(tokens[index], '=');
                 if (equals > 0) {
                     string parameterName = tokens[index].Substring(0, equals).Trim();
                     string parameterValue = tokens[index].Substring(equals + 1).Trim().Trim('"');
@@ -342,6 +346,34 @@ internal static class VCardCodec {
                     ? string.Concat(prior, ",", tokens[index]) : tokens[index];
             }
             result.Add(property);
+        }
+        return result;
+    }
+
+    private static int FindUnquotedSeparator(string value, char separator) {
+        bool quoted = false;
+        bool escaped = false;
+        for (int index = 0; index < value.Length; index++) {
+            char character = value[index];
+            if (escaped) escaped = false;
+            else if (character == '\\') escaped = true;
+            else if (character == '"') quoted = !quoted;
+            else if (!quoted && character == separator) return index;
+        }
+        return -1;
+    }
+
+    private static IReadOnlyList<string> SplitUnquoted(string value, char separator) {
+        var result = new List<string>();
+        int start = 0;
+        while (start <= value.Length) {
+            int relative = FindUnquotedSeparator(value.Substring(start), separator);
+            if (relative < 0) {
+                result.Add(value.Substring(start));
+                break;
+            }
+            result.Add(value.Substring(start, relative));
+            start += relative + 1;
         }
         return result;
     }

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -13,7 +13,10 @@ internal static partial class VCardCodec {
 
         int cardCount = properties.Count(property => property.Name == "BEGIN" &&
             property.Value.Equals("VCARD", StringComparison.OrdinalIgnoreCase));
+        VCardProperty[] versions = properties.Where(property => property.Name == "VERSION").ToArray();
         document.MimeSemanticProjectionIsIncomplete |= cardCount > 1 ||
+            versions.Length != 1 || !versions[0].Value.Trim().Equals("3.0", StringComparison.OrdinalIgnoreCase) ||
+            HasUnprojectedExtension(properties) ||
             HasUnpreservedPropertyParameters(properties) ||
             properties.Count(property => property.Name == "EMAIL") > 3 || properties.Any(property =>
             property.Name == "PHOTO" || property.Name == "KEY" || property.Name == "LOGO" ||
@@ -22,8 +25,6 @@ internal static partial class VCardCodec {
             property.Name == "SORT-STRING" || property.Name == "MAILER" || property.Name == "UID" ||
             property.Name == "SOURCE" || property.Name == "FBURL" || property.Name == "CALURI" ||
             property.Name == "CALADRURI" || property.Name == "SOUND" ||
-            property.Name == "VERSION" &&
-            !property.Value.Trim().Equals("3.0", StringComparison.OrdinalIgnoreCase) ||
             property.Name == "REV" || property.Name == "KIND" &&
             !property.Value.Trim().Equals("individual", StringComparison.OrdinalIgnoreCase) ||
             property.Name == "CLASS" &&

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -39,6 +39,8 @@ internal static class VCardCodec {
         string[] organization = SplitEscaped(GetValue(properties, "ORG"), ';');
         contact.CompanyName = ValueAt(organization, 0);
         contact.Department = ValueAt(organization, 1);
+        document.MimeSemanticProjectionIsIncomplete |= organization.Skip(2)
+            .Any(value => !string.IsNullOrWhiteSpace(value));
         contact.JobTitle = Unescape(GetValue(properties, "TITLE"));
         contact.Profession = Unescape(GetValue(properties, "ROLE"));
         contact.Language = Unescape(GetValue(properties, "LANG"));
@@ -56,7 +58,8 @@ internal static class VCardCodec {
 
         ApplyEmails(properties, contact);
         document.MimeSemanticProjectionIsIncomplete |= ApplyPhones(properties, contact.Phones) ||
-            HasAddressSlotOverflow(properties) || HasUrlSlotOverflow(properties);
+            HasAddressSlotOverflow(properties) || HasUnprojectedAddressComponents(properties) ||
+            HasUrlSlotOverflow(properties) || HasUnsupportedEmailPreference(properties);
         ApplyAddresses(properties, contact);
         ApplyUrls(properties, contact);
         ApplyExtensions(properties, contact);
@@ -270,6 +273,19 @@ internal static class VCardCodec {
 
     private static bool HasAddressSlotOverflow(IEnumerable<VCardProperty> properties) =>
         HasAddressSlotOverflow(properties, "ADR") || HasAddressSlotOverflow(properties, "LABEL");
+
+    private static bool HasUnprojectedAddressComponents(IEnumerable<VCardProperty> properties) =>
+        properties.Where(property => property.Name == "ADR").Any(property => {
+            string[] values = SplitEscaped(property.Value, ';');
+            return !string.IsNullOrWhiteSpace(ValueAt(values, 1));
+        });
+
+    private static bool HasUnsupportedEmailPreference(IEnumerable<VCardProperty> properties) =>
+        properties.Where(property => property.Name == "EMAIL").Any(property => {
+            string types = property.Parameters.TryGetValue("TYPE", out string? type) ? type : string.Empty;
+            bool preferred = ContainsType(types, "PREF") || property.Parameters.ContainsKey("PREF");
+            return preferred && !ContainsType(types, "WORK");
+        });
 
     private static bool HasAddressSlotOverflow(IEnumerable<VCardProperty> properties, string propertyName) {
         int homeCount = 0;

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -6,7 +6,9 @@ internal static class VCardCodec {
         if (!properties.Any(property => property.Name == "BEGIN" &&
             property.Value.Equals("VCARD", StringComparison.OrdinalIgnoreCase))) return false;
 
-        document.MimeSemanticProjectionIsIncomplete |= properties.Any(property =>
+        int cardCount = properties.Count(property => property.Name == "BEGIN" &&
+            property.Value.Equals("VCARD", StringComparison.OrdinalIgnoreCase));
+        document.MimeSemanticProjectionIsIncomplete |= cardCount > 1 || properties.Any(property =>
             property.Name == "PHOTO" || property.Name == "KEY" || property.Name == "LOGO" ||
             property.Name == "GENDER" || property.Name == "GEO" || property.Name == "TZ" ||
             property.Name == "RELATED" || property.Name == "MEMBER");
@@ -50,17 +52,14 @@ internal static class VCardCodec {
     internal static EmailAttachment? FindSemanticAttachment(EmailDocument document) {
         if (document.OutlookItemKind != OutlookItemKind.Contact) return null;
         return document.Attachments.FirstOrDefault(attachment => attachment.IsProjectedSemanticContent &&
-            IsVCardContentType(attachment.ContentType)) ?? document.Attachments.FirstOrDefault(attachment =>
             IsVCardContentType(attachment.ContentType));
     }
 
-    internal static EmailAttachment CreateAttachment(EmailDocument document, long maximumBytes,
-        EmailAttachment? source = null) {
-        byte[] content = source == null
-            ? Create(document)
-            : EmailAttachmentContent.ReadOrNull(source, maximumBytes) ?? Create(document);
+    internal static EmailAttachment CreateAttachment(EmailDocument document, EmailAttachment? source = null) {
+        if (source != null) return source;
+        byte[] content = Create(document);
         var attachment = new EmailAttachment {
-            FileName = source?.FileName ?? "contact.vcf",
+            FileName = "contact.vcf",
             ContentType = "text/vcard",
             Content = content,
             Length = content.LongLength,
@@ -146,8 +145,17 @@ internal static class VCardCodec {
     private static void ApplyEmails(IEnumerable<VCardProperty> properties, OutlookContact contact) {
         VCardProperty[] emails = properties.Where(property => property.Name == "EMAIL").ToArray();
         OutlookContactEmailAddress[] targets = { contact.Email1, contact.Email2, contact.Email3 };
-        for (int index = 0; index < Math.Min(emails.Length, targets.Length); index++) {
-            targets[index].Address = Unescape(emails[index].Value);
+        var used = new bool[targets.Length];
+        foreach (VCardProperty email in emails) {
+            string types = email.Parameters.TryGetValue("TYPE", out string? type) ? type : string.Empty;
+            int preferredIndex = ContainsType(types, "HOME") ? 1 : ContainsType(types, "OTHER") ? 2 :
+                ContainsType(types, "WORK") ? 0 : -1;
+            int index = preferredIndex >= 0 && !used[preferredIndex]
+                ? preferredIndex
+                : Array.FindIndex(used, value => !value);
+            if (index < 0) break;
+            used[index] = true;
+            targets[index].Address = Unescape(email.Value);
             targets[index].AddressType = "SMTP";
             string prefix = string.Concat("X-OFFICEIMO-EMAIL",
                 (index + 1).ToString(CultureInfo.InvariantCulture));

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -18,6 +18,10 @@ internal static class VCardCodec {
             property.Name == "PHOTO" || property.Name == "KEY" || property.Name == "LOGO" ||
             property.Name == "GENDER" || property.Name == "GEO" || property.Name == "TZ" ||
             property.Name == "RELATED" || property.Name == "MEMBER" || property.Name == "UID" ||
+            property.Name == "SOURCE" || property.Name == "FBURL" || property.Name == "CALURI" ||
+            property.Name == "CALADRURI" || property.Name == "SOUND" ||
+            property.Name == "VERSION" &&
+            !property.Value.Trim().Equals("3.0", StringComparison.OrdinalIgnoreCase) ||
             property.Name == "REV" || property.Name == "KIND" &&
             !property.Value.Trim().Equals("individual", StringComparison.OrdinalIgnoreCase) ||
             property.Name == "CLASS" &&
@@ -60,6 +64,7 @@ internal static class VCardCodec {
 
         ApplyEmails(properties, contact);
         document.MimeSemanticProjectionIsIncomplete |= ApplyPhones(properties, contact.Phones) ||
+            HasUnsupportedPhonePreference(properties) ||
             HasAddressSlotOverflow(properties) || HasUnprojectedAddressComponents(properties) ||
             HasUrlSlotOverflow(properties) || HasUnsupportedEmailPreference(properties);
         ApplyAddresses(properties, contact);
@@ -287,6 +292,15 @@ internal static class VCardCodec {
             string types = property.Parameters.TryGetValue("TYPE", out string? type) ? type : string.Empty;
             bool preferred = ContainsType(types, "PREF") || property.Parameters.ContainsKey("PREF");
             return preferred && !ContainsType(types, "WORK");
+        });
+
+    private static bool HasUnsupportedPhonePreference(IEnumerable<VCardProperty> properties) =>
+        properties.Where(property => property.Name == "TEL").Any(property => {
+            string types = property.Parameters.TryGetValue("TYPE", out string? type) ? type : string.Empty;
+            bool preferred = ContainsType(types, "PREF") || property.Parameters.ContainsKey("PREF");
+            if (!preferred) return false;
+            VCardPhoneSlot slot = GetPhoneSlot(types);
+            return slot != VCardPhoneSlot.General && slot != VCardPhoneSlot.PrimaryFax;
         });
 
     private static bool HasAddressSlotOverflow(IEnumerable<VCardProperty> properties, string propertyName) {

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -6,7 +6,7 @@ internal static class VCardCodec {
         if (!properties.Any(property => property.Name == "BEGIN" &&
             property.Value.Equals("VCARD", StringComparison.OrdinalIgnoreCase))) return false;
 
-        document.MimeSemanticProjectionIsIncomplete = properties.Any(property =>
+        document.MimeSemanticProjectionIsIncomplete |= properties.Any(property =>
             property.Name == "PHOTO" || property.Name == "KEY" || property.Name == "LOGO" ||
             property.Name == "GENDER" || property.Name == "GEO" || property.Name == "TZ" ||
             property.Name == "RELATED" || property.Name == "MEMBER");

--- a/OfficeIMO.Email/Contact/VCardCodec.cs
+++ b/OfficeIMO.Email/Contact/VCardCodec.cs
@@ -1,8 +1,8 @@
 namespace OfficeIMO.Email;
 
 internal static class VCardCodec {
-    internal static bool TryProject(byte[] content, EmailDocument document) {
-        List<VCardProperty> properties = Parse(Decode(content));
+    internal static bool TryProject(string text, EmailDocument document) {
+        List<VCardProperty> properties = Parse(text.TrimStart('\uFEFF'));
         if (!properties.Any(property => property.Name == "BEGIN" &&
             property.Value.Equals("VCARD", StringComparison.OrdinalIgnoreCase))) return false;
 
@@ -309,19 +309,22 @@ internal static class VCardCodec {
             var property = new VCardProperty(name.Trim().ToUpperInvariant(), line.Substring(colon + 1));
             for (int index = 1; index < tokens.Length; index++) {
                 int equals = tokens[index].IndexOf('=');
-                if (equals > 0) property.Parameters[tokens[index].Substring(0, equals).Trim()] =
-                    tokens[index].Substring(equals + 1).Trim().Trim('"');
+                if (equals > 0) {
+                    string parameterName = tokens[index].Substring(0, equals).Trim();
+                    string parameterValue = tokens[index].Substring(equals + 1).Trim().Trim('"');
+                    if (parameterName.Equals("TYPE", StringComparison.OrdinalIgnoreCase) &&
+                        property.Parameters.TryGetValue(parameterName, out string? priorType)) {
+                        property.Parameters[parameterName] = string.Concat(priorType, ",", parameterValue);
+                    } else {
+                        property.Parameters[parameterName] = parameterValue;
+                    }
+                }
                 else property.Parameters["TYPE"] = property.Parameters.TryGetValue("TYPE", out string? prior)
                     ? string.Concat(prior, ",", tokens[index]) : tokens[index];
             }
             result.Add(property);
         }
         return result;
-    }
-
-    private static string Decode(byte[] content) {
-        int offset = content.Length >= 3 && content[0] == 0xef && content[1] == 0xbb && content[2] == 0xbf ? 3 : 0;
-        return Encoding.UTF8.GetString(content, offset, content.Length - offset);
     }
 
     private static string? GetValue(IEnumerable<VCardProperty> properties, string name) =>

--- a/OfficeIMO.Email/Conversion/EmailConversionAnalyzer.cs
+++ b/OfficeIMO.Email/Conversion/EmailConversionAnalyzer.cs
@@ -40,8 +40,16 @@ internal static class EmailConversionAnalyzer {
                     hasPotentialDataLoss = true;
                     diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,
                         "EMAIL_ICALENDAR_ATTENDEE_ADDRESS_REQUIRED",
-                        "The appointment has attendee display text but no recipient addresses from which valid iCalendar ATTENDEE values can be created.",
+                        "The appointment has attendee state without portable SMTP recipient addresses from which valid iCalendar ATTENDEE values can be created.",
                         "appointment/attendees"));
+                }
+                if (HasNonPortableCalendarOrganizer(document) &&
+                    !HasUnchangedMimeSemanticSource(document)) {
+                    hasPotentialDataLoss = true;
+                    diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,
+                        "EMAIL_ICALENDAR_ORGANIZER_ADDRESS_REQUIRED",
+                        "The appointment organizer does not have a portable SMTP address from which a valid iCalendar ORGANIZER value can be created.",
+                        "appointment/organizer"));
                 }
             } else if (document.OutlookItemKind == OutlookItemKind.Task) {
                 if (document.Task?.IsRecurring == true && !HasUnchangedMimeSemanticSource(document)) {
@@ -51,12 +59,20 @@ internal static class EmailConversionAnalyzer {
                         "The task is recurring, but its recurrence rule is not available for a safe iCalendar VTODO representation.",
                         "task/recurrence"));
                 }
-                if (HasAddresslessCalendarRecipient(document) && !HasUnchangedMimeSemanticSource(document)) {
+                if (HasNonPortableCalendarRecipient(document) && !HasUnchangedMimeSemanticSource(document)) {
                     hasPotentialDataLoss = true;
                     diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,
                         "EMAIL_ICALENDAR_ATTENDEE_ADDRESS_REQUIRED",
-                        "The task has an assignee recipient without an address from which a valid iCalendar ATTENDEE value can be created.",
+                        "The task has an assignee recipient without a portable SMTP address from which a valid iCalendar ATTENDEE value can be created.",
                         "task/attendees"));
+                }
+                if (HasNonPortableCalendarOrganizer(document, document.Task?.Owner) &&
+                    !HasUnchangedMimeSemanticSource(document)) {
+                    hasPotentialDataLoss = true;
+                    diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,
+                        "EMAIL_ICALENDAR_ORGANIZER_ADDRESS_REQUIRED",
+                        "The task owner does not have a portable SMTP address from which a valid iCalendar ORGANIZER value can be created.",
+                        "task/organizer"));
                 }
             } else if (document.OutlookItemKind == OutlookItemKind.Contact &&
                 document.MessageClass != null &&
@@ -142,7 +158,7 @@ internal static class EmailConversionAnalyzer {
 
     private static bool HasAddresslessAttendeeDisplayState(EmailDocument document) {
         OutlookAppointment appointment = document.Appointment!;
-        if (HasAddresslessCalendarRecipient(document)) return true;
+        if (HasNonPortableCalendarRecipient(document)) return true;
 
         EmailRecipient[] requiredRecipients = document.Recipients.Where(recipient =>
             recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Room ||
@@ -188,8 +204,17 @@ internal static class EmailConversionAnalyzer {
             displayValue.EndsWith(string.Concat("<", address.Address, ">"), StringComparison.OrdinalIgnoreCase);
     }
 
-    private static bool HasAddresslessCalendarRecipient(EmailDocument document) => document.Recipients.Any(recipient =>
+    private static bool HasNonPortableCalendarRecipient(EmailDocument document) => document.Recipients.Any(recipient =>
         (recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc ||
          recipient.Kind == EmailRecipientKind.Room || recipient.Kind == EmailRecipientKind.Resource) &&
-        string.IsNullOrWhiteSpace(recipient.Address.Address));
+        !IcsCalendarCodec.HasPortableMailtoAddress(recipient.Address));
+
+    private static bool HasNonPortableCalendarOrganizer(EmailDocument document, string? taskOwner = null) {
+        EmailAddress? from = document.From;
+        string? fromAddress = from?.Address;
+        if (string.IsNullOrWhiteSpace(fromAddress) ||
+            document.OutlookItemKind == OutlookItemKind.Task &&
+            !string.Equals(fromAddress, taskOwner, StringComparison.OrdinalIgnoreCase)) return false;
+        return !IcsCalendarCodec.HasPortableMailtoAddress(from);
+    }
 }

--- a/OfficeIMO.Email/Conversion/EmailConversionAnalyzer.cs
+++ b/OfficeIMO.Email/Conversion/EmailConversionAnalyzer.cs
@@ -127,13 +127,15 @@ internal static class EmailConversionAnalyzer {
     private static bool HasAddresslessAttendeeDisplayState(EmailDocument document) {
         OutlookAppointment appointment = document.Appointment!;
         bool hasAddresslessRecipient = document.Recipients.Any(recipient =>
-            (recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc) &&
+            (recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc ||
+             recipient.Kind == EmailRecipientKind.Room || recipient.Kind == EmailRecipientKind.Resource) &&
             string.IsNullOrWhiteSpace(recipient.Address.Address));
         bool hasDisplayText = !string.IsNullOrWhiteSpace(appointment.AllAttendees) ||
             !string.IsNullOrWhiteSpace(appointment.RequiredAttendees) ||
             !string.IsNullOrWhiteSpace(appointment.OptionalAttendees);
         return hasAddresslessRecipient || hasDisplayText && !document.Recipients.Any(recipient =>
-            (recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc) &&
+            (recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc ||
+             recipient.Kind == EmailRecipientKind.Room || recipient.Kind == EmailRecipientKind.Resource) &&
             !string.IsNullOrWhiteSpace(recipient.Address.Address));
     }
 }

--- a/OfficeIMO.Email/Conversion/EmailConversionAnalyzer.cs
+++ b/OfficeIMO.Email/Conversion/EmailConversionAnalyzer.cs
@@ -81,7 +81,7 @@ internal static class EmailConversionAnalyzer {
             hasPotentialDataLoss = true;
             diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,
                 "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE",
-                "The calendar or vCard contains recurrence, exception, time-zone, photo, key, or relationship semantics that cannot be projected completely into MSG/TNEF properties.",
+                "The calendar or vCard contains semantics that cannot be projected completely into MSG/TNEF properties.",
                 "semantic-content"));
         }
 

--- a/OfficeIMO.Email/Conversion/EmailConversionAnalyzer.cs
+++ b/OfficeIMO.Email/Conversion/EmailConversionAnalyzer.cs
@@ -117,6 +117,14 @@ internal static class EmailConversionAnalyzer {
                 "semantic-content"));
         }
 
+        if (targetFormat == EmailFileFormat.OutlookMsg && TnefWriter.HasUnmanagedRawAttributes(document)) {
+            hasPotentialDataLoss = true;
+            diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,
+                "EMAIL_TNEF_ATTRIBUTES_NOT_REPRESENTED_IN_MSG",
+                "Raw TNEF message or attachment attributes cannot be represented in an Outlook MSG artifact.",
+                "source-metadata/tnef"));
+        }
+
         if (targetFormat == EmailFileFormat.Eml && HasSourceSpecificMetadata(document)) {
             hasPotentialDataLoss = true;
             diagnostics.Add(new EmailDiagnostic("EMAIL_SOURCE_METADATA_NOT_REPRESENTED_IN_EML",

--- a/OfficeIMO.Email/Conversion/EmailConversionAnalyzer.cs
+++ b/OfficeIMO.Email/Conversion/EmailConversionAnalyzer.cs
@@ -59,6 +59,14 @@ internal static class EmailConversionAnalyzer {
                         "task/attendees"));
                 }
             } else if (document.OutlookItemKind == OutlookItemKind.Contact &&
+                document.MessageClass != null &&
+                document.MessageClass.StartsWith("IPM.DistList", StringComparison.OrdinalIgnoreCase)) {
+                hasPotentialDataLoss = true;
+                diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,
+                    "EMAIL_VCARD_DISTRIBUTION_LIST_UNSUPPORTED",
+                    "An Outlook distribution list cannot be represented as an individual vCard without losing its membership.",
+                    "contact/distribution-list"));
+            } else if (document.OutlookItemKind == OutlookItemKind.Contact &&
                 (document.Contact == null || VCardCodec.HasOpaqueContactState(document.Contact))) {
                 hasPotentialDataLoss = true;
                 diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,

--- a/OfficeIMO.Email/Conversion/EmailConversionAnalyzer.cs
+++ b/OfficeIMO.Email/Conversion/EmailConversionAnalyzer.cs
@@ -43,13 +43,21 @@ internal static class EmailConversionAnalyzer {
                         "The appointment has attendee display text but no recipient addresses from which valid iCalendar ATTENDEE values can be created.",
                         "appointment/attendees"));
                 }
-            } else if (document.OutlookItemKind == OutlookItemKind.Task && document.Task?.IsRecurring == true &&
-                !HasUnchangedMimeSemanticSource(document)) {
-                hasPotentialDataLoss = true;
-                diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,
-                    "EMAIL_ICALENDAR_OPAQUE_TASK_RECURRENCE",
-                    "The task is recurring, but its recurrence rule is not available for a safe iCalendar VTODO representation.",
-                    "task/recurrence"));
+            } else if (document.OutlookItemKind == OutlookItemKind.Task) {
+                if (document.Task?.IsRecurring == true && !HasUnchangedMimeSemanticSource(document)) {
+                    hasPotentialDataLoss = true;
+                    diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,
+                        "EMAIL_ICALENDAR_OPAQUE_TASK_RECURRENCE",
+                        "The task is recurring, but its recurrence rule is not available for a safe iCalendar VTODO representation.",
+                        "task/recurrence"));
+                }
+                if (HasAddresslessCalendarRecipient(document) && !HasUnchangedMimeSemanticSource(document)) {
+                    hasPotentialDataLoss = true;
+                    diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,
+                        "EMAIL_ICALENDAR_ATTENDEE_ADDRESS_REQUIRED",
+                        "The task has an assignee recipient without an address from which a valid iCalendar ATTENDEE value can be created.",
+                        "task/attendees"));
+                }
             } else if (document.OutlookItemKind == OutlookItemKind.Contact &&
                 (document.Contact == null || VCardCodec.HasOpaqueContactState(document.Contact))) {
                 hasPotentialDataLoss = true;
@@ -126,16 +134,17 @@ internal static class EmailConversionAnalyzer {
 
     private static bool HasAddresslessAttendeeDisplayState(EmailDocument document) {
         OutlookAppointment appointment = document.Appointment!;
-        bool hasAddresslessRecipient = document.Recipients.Any(recipient =>
-            (recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc ||
-             recipient.Kind == EmailRecipientKind.Room || recipient.Kind == EmailRecipientKind.Resource) &&
-            string.IsNullOrWhiteSpace(recipient.Address.Address));
         bool hasDisplayText = !string.IsNullOrWhiteSpace(appointment.AllAttendees) ||
             !string.IsNullOrWhiteSpace(appointment.RequiredAttendees) ||
             !string.IsNullOrWhiteSpace(appointment.OptionalAttendees);
-        return hasAddresslessRecipient || hasDisplayText && !document.Recipients.Any(recipient =>
+        return HasAddresslessCalendarRecipient(document) || hasDisplayText && !document.Recipients.Any(recipient =>
             (recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc ||
              recipient.Kind == EmailRecipientKind.Room || recipient.Kind == EmailRecipientKind.Resource) &&
             !string.IsNullOrWhiteSpace(recipient.Address.Address));
     }
+
+    private static bool HasAddresslessCalendarRecipient(EmailDocument document) => document.Recipients.Any(recipient =>
+        (recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc ||
+         recipient.Kind == EmailRecipientKind.Room || recipient.Kind == EmailRecipientKind.Resource) &&
+        string.IsNullOrWhiteSpace(recipient.Address.Address));
 }

--- a/OfficeIMO.Email/Conversion/EmailConversionAnalyzer.cs
+++ b/OfficeIMO.Email/Conversion/EmailConversionAnalyzer.cs
@@ -1,0 +1,128 @@
+namespace OfficeIMO.Email;
+
+internal static class EmailConversionAnalyzer {
+    internal static EmailConversionReport Analyze(EmailDocument document, EmailFileFormat targetFormat,
+        EmailWriterOptions options) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        if (options == null) throw new ArgumentNullException(nameof(options));
+
+        var diagnostics = new List<EmailDiagnostic>();
+        bool hasPotentialDataLoss = false;
+
+        if (document.Protection.IsProtected && !CanPassThroughProtectedSource(document, targetFormat)) {
+            hasPotentialDataLoss = true;
+            diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,
+                "EMAIL_PROTECTED_CONTENT_REWRITE",
+                "The protected MIME or Outlook wrapper cannot be regenerated without invalidating its signature or encrypted payload. " +
+                "Write the unchanged artifact in its source format, or explicitly choose a non-blocking conversion loss policy.",
+                "protection"));
+        }
+
+        if (targetFormat == EmailFileFormat.Eml) {
+            if (document.OutlookItemKind == OutlookItemKind.Appointment) {
+                if (document.Appointment == null || !document.Appointment.Start.HasValue) {
+                    hasPotentialDataLoss = true;
+                    diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,
+                        "EMAIL_ICALENDAR_START_REQUIRED",
+                        "An appointment needs a start time before it can be represented as an iCalendar VEVENT.",
+                        "appointment/start"));
+                } else if (IcsCalendarCodec.HasOpaqueAppointmentState(document.Appointment) &&
+                    !HasUnchangedMimeSemanticSource(document)) {
+                    hasPotentialDataLoss = true;
+                    diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,
+                        "EMAIL_ICALENDAR_OPAQUE_RECURRENCE",
+                        "The appointment contains Outlook recurrence or time-zone blobs that cannot be translated safely to iCalendar without changing their meaning.",
+                        "appointment/recurrence"));
+                }
+                if (document.Appointment != null && HasAddresslessAttendeeDisplayState(document) &&
+                    !HasUnchangedMimeSemanticSource(document)) {
+                    hasPotentialDataLoss = true;
+                    diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,
+                        "EMAIL_ICALENDAR_ATTENDEE_ADDRESS_REQUIRED",
+                        "The appointment has attendee display text but no recipient addresses from which valid iCalendar ATTENDEE values can be created.",
+                        "appointment/attendees"));
+                }
+            } else if (document.OutlookItemKind == OutlookItemKind.Contact &&
+                (document.Contact == null || VCardCodec.HasOpaqueContactState(document.Contact))) {
+                hasPotentialDataLoss = true;
+                diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,
+                    "EMAIL_VCARD_OPAQUE_CONTACT_IDENTITY",
+                    "The contact contains opaque Outlook entry identifiers that cannot be represented in vCard.",
+                    "contact/email-address"));
+            } else if (document.OutlookItemKind == OutlookItemKind.Journal ||
+                document.OutlookItemKind == OutlookItemKind.Note) {
+                hasPotentialDataLoss = true;
+                diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,
+                    "EMAIL_OUTLOOK_ITEM_EML_REPRESENTATION_MISSING",
+                    string.Concat(document.OutlookItemKind.ToString(),
+                        " does not yet have a standards-based EML representation."),
+                    "outlook-item"));
+            }
+        }
+
+        if (document.MimeSemanticSourceModelFingerprint != null &&
+            !EmailDocumentStateFingerprint.Matches(document, document.MimeSemanticSourceModelFingerprint)) {
+            hasPotentialDataLoss = true;
+            diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,
+                "EMAIL_MIME_SEMANTIC_CONTENT_CHANGED",
+                "The message model changed after calendar or vCard content was projected. Regenerating that content can omit unmodeled source properties.",
+                "semantic-content"));
+        }
+
+        if (targetFormat != EmailFileFormat.Eml && document.MimeSemanticProjectionIsIncomplete) {
+            hasPotentialDataLoss = true;
+            diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,
+                "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE",
+                "The calendar or vCard contains recurrence, exception, photo, key, or relationship semantics that cannot be projected completely into MSG/TNEF properties.",
+                "semantic-content"));
+        }
+
+        if (targetFormat == EmailFileFormat.Eml && HasSourceSpecificMetadata(document)) {
+            hasPotentialDataLoss = true;
+            diagnostics.Add(new EmailDiagnostic("EMAIL_SOURCE_METADATA_NOT_REPRESENTED_IN_EML",
+                "The common message content is representable, but opaque MAPI, TNEF, compound-storage, conversation, reaction, or editor metadata has no portable EML equivalent.",
+                EmailDiagnosticSeverity.Warning, "source-metadata"));
+        }
+
+        return new EmailConversionReport(document.Format, targetFormat, diagnostics.AsReadOnly(), hasPotentialDataLoss);
+    }
+
+    internal static bool CanPassThroughProtectedSource(EmailDocument document, EmailFileFormat targetFormat) {
+        return document.Protection.IsProtected && document.Format == targetFormat && document.RawSource != null &&
+            document.RawSourceModelFingerprint != null &&
+            EmailDocumentStateFingerprint.Matches(document, document.RawSourceModelFingerprint);
+    }
+
+    internal static EmailDiagnostic CreateLossDiagnostic(EmailConversionLossPolicy policy, string code,
+        string message, string? location = null) {
+        EmailDiagnosticSeverity severity = policy == EmailConversionLossPolicy.Block
+            ? EmailDiagnosticSeverity.Error
+            : policy == EmailConversionLossPolicy.Warn
+                ? EmailDiagnosticSeverity.Warning
+                : EmailDiagnosticSeverity.Information;
+        return new EmailDiagnostic(code, message, severity, location);
+    }
+
+    private static bool HasSourceSpecificMetadata(EmailDocument document) {
+        EmailMessageMetadata metadata = document.MessageMetadata;
+        return document.MapiProperties.Count > 0 || document.TnefAttributes.Count > 0 ||
+            document.Attachments.Any(attachment => attachment.MapiProperties.Count > 0 ||
+                attachment.TnefAttributes.Count > 0 || attachment.StructuredStorageStreams.Count > 0) ||
+            metadata.ConversationIndex != null || metadata.ConversationId != null || metadata.ReactionsSummary != null ||
+            metadata.OwnerReactionHistory != null || metadata.IconIndex.HasValue || metadata.EditorFormat.HasValue;
+    }
+
+    private static bool HasUnchangedMimeSemanticSource(EmailDocument document) =>
+        document.Format == EmailFileFormat.Eml && document.MimeSemanticSourceModelFingerprint != null &&
+        EmailDocumentStateFingerprint.Matches(document, document.MimeSemanticSourceModelFingerprint);
+
+    private static bool HasAddresslessAttendeeDisplayState(EmailDocument document) {
+        OutlookAppointment appointment = document.Appointment!;
+        bool hasDisplayText = !string.IsNullOrWhiteSpace(appointment.AllAttendees) ||
+            !string.IsNullOrWhiteSpace(appointment.RequiredAttendees) ||
+            !string.IsNullOrWhiteSpace(appointment.OptionalAttendees);
+        return hasDisplayText && !document.Recipients.Any(recipient =>
+            (recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc) &&
+            !string.IsNullOrWhiteSpace(recipient.Address.Address));
+    }
+}

--- a/OfficeIMO.Email/Conversion/EmailConversionAnalyzer.cs
+++ b/OfficeIMO.Email/Conversion/EmailConversionAnalyzer.cs
@@ -20,13 +20,14 @@ internal static class EmailConversionAnalyzer {
 
         if (targetFormat == EmailFileFormat.Eml) {
             if (document.OutlookItemKind == OutlookItemKind.Appointment) {
-                if (document.Appointment == null || !document.Appointment.Start.HasValue) {
+                if ((document.Appointment == null || !document.Appointment.Start.HasValue) &&
+                    !HasUnchangedMimeSemanticSource(document)) {
                     hasPotentialDataLoss = true;
                     diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,
                         "EMAIL_ICALENDAR_START_REQUIRED",
                         "An appointment needs a start time before it can be represented as an iCalendar VEVENT.",
                         "appointment/start"));
-                } else if (IcsCalendarCodec.HasOpaqueAppointmentState(document.Appointment) &&
+                } else if (document.Appointment != null && IcsCalendarCodec.HasOpaqueAppointmentState(document.Appointment) &&
                     !HasUnchangedMimeSemanticSource(document)) {
                     hasPotentialDataLoss = true;
                     diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,
@@ -118,10 +119,13 @@ internal static class EmailConversionAnalyzer {
 
     private static bool HasAddresslessAttendeeDisplayState(EmailDocument document) {
         OutlookAppointment appointment = document.Appointment!;
+        bool hasAddresslessRecipient = document.Recipients.Any(recipient =>
+            (recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc) &&
+            string.IsNullOrWhiteSpace(recipient.Address.Address));
         bool hasDisplayText = !string.IsNullOrWhiteSpace(appointment.AllAttendees) ||
             !string.IsNullOrWhiteSpace(appointment.RequiredAttendees) ||
             !string.IsNullOrWhiteSpace(appointment.OptionalAttendees);
-        return hasDisplayText && !document.Recipients.Any(recipient =>
+        return hasAddresslessRecipient || hasDisplayText && !document.Recipients.Any(recipient =>
             (recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc) &&
             !string.IsNullOrWhiteSpace(recipient.Address.Address));
     }

--- a/OfficeIMO.Email/Conversion/EmailConversionAnalyzer.cs
+++ b/OfficeIMO.Email/Conversion/EmailConversionAnalyzer.cs
@@ -43,6 +43,13 @@ internal static class EmailConversionAnalyzer {
                         "The appointment has attendee display text but no recipient addresses from which valid iCalendar ATTENDEE values can be created.",
                         "appointment/attendees"));
                 }
+            } else if (document.OutlookItemKind == OutlookItemKind.Task && document.Task?.IsRecurring == true &&
+                !HasUnchangedMimeSemanticSource(document)) {
+                hasPotentialDataLoss = true;
+                diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,
+                    "EMAIL_ICALENDAR_OPAQUE_TASK_RECURRENCE",
+                    "The task is recurring, but its recurrence rule is not available for a safe iCalendar VTODO representation.",
+                    "task/recurrence"));
             } else if (document.OutlookItemKind == OutlookItemKind.Contact &&
                 (document.Contact == null || VCardCodec.HasOpaqueContactState(document.Contact))) {
                 hasPotentialDataLoss = true;
@@ -74,7 +81,7 @@ internal static class EmailConversionAnalyzer {
             hasPotentialDataLoss = true;
             diagnostics.Add(CreateLossDiagnostic(options.ConversionLossPolicy,
                 "EMAIL_STORE_SEMANTIC_PROJECTION_INCOMPLETE",
-                "The calendar or vCard contains recurrence, exception, photo, key, or relationship semantics that cannot be projected completely into MSG/TNEF properties.",
+                "The calendar or vCard contains recurrence, exception, time-zone, photo, key, or relationship semantics that cannot be projected completely into MSG/TNEF properties.",
                 "semantic-content"));
         }
 

--- a/OfficeIMO.Email/Conversion/EmailConversionAnalyzer.cs
+++ b/OfficeIMO.Email/Conversion/EmailConversionAnalyzer.cs
@@ -134,13 +134,50 @@ internal static class EmailConversionAnalyzer {
 
     private static bool HasAddresslessAttendeeDisplayState(EmailDocument document) {
         OutlookAppointment appointment = document.Appointment!;
-        bool hasDisplayText = !string.IsNullOrWhiteSpace(appointment.AllAttendees) ||
-            !string.IsNullOrWhiteSpace(appointment.RequiredAttendees) ||
+        if (HasAddresslessCalendarRecipient(document)) return true;
+
+        EmailRecipient[] requiredRecipients = document.Recipients.Where(recipient =>
+            recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Room ||
+            recipient.Kind == EmailRecipientKind.Resource).ToArray();
+        EmailRecipient[] optionalRecipients = document.Recipients.Where(recipient =>
+            recipient.Kind == EmailRecipientKind.Cc).ToArray();
+        bool hasRoleSpecificDisplays = !string.IsNullOrWhiteSpace(appointment.RequiredAttendees) ||
             !string.IsNullOrWhiteSpace(appointment.OptionalAttendees);
-        return HasAddresslessCalendarRecipient(document) || hasDisplayText && !document.Recipients.Any(recipient =>
-            (recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc ||
-             recipient.Kind == EmailRecipientKind.Room || recipient.Kind == EmailRecipientKind.Resource) &&
-            !string.IsNullOrWhiteSpace(recipient.Address.Address));
+        if (hasRoleSpecificDisplays) {
+            return HasUnmatchedAttendeeDisplay(appointment.RequiredAttendees, requiredRecipients) ||
+                HasUnmatchedAttendeeDisplay(appointment.OptionalAttendees, optionalRecipients);
+        }
+
+        return HasUnmatchedAttendeeDisplay(appointment.AllAttendees,
+            requiredRecipients.Concat(optionalRecipients).ToArray());
+    }
+
+    private static bool HasUnmatchedAttendeeDisplay(string? displayState,
+        IReadOnlyList<EmailRecipient> recipients) {
+        string[] displayValues = (displayState ?? string.Empty).Split(';')
+            .Select(value => value.Trim()).Where(value => value.Length > 0).ToArray();
+        if (displayValues.Length == 0) return false;
+        if (displayValues.Length > recipients.Count) return true;
+
+        var used = new bool[recipients.Count];
+        foreach (string displayValue in displayValues) {
+            int match = -1;
+            for (int index = 0; index < recipients.Count; index++) {
+                if (used[index] || !AttendeeDisplayMatches(displayValue, recipients[index].Address)) continue;
+                match = index;
+                break;
+            }
+            if (match < 0) return true;
+            used[match] = true;
+        }
+        return false;
+    }
+
+    private static bool AttendeeDisplayMatches(string displayValue, EmailAddress address) {
+        if (string.Equals(displayValue, address.DisplayName, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(displayValue, address.Address, StringComparison.OrdinalIgnoreCase)) return true;
+        return !string.IsNullOrWhiteSpace(address.Address) &&
+            displayValue.EndsWith(string.Concat("<", address.Address, ">"), StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool HasAddresslessCalendarRecipient(EmailDocument document) => document.Recipients.Any(recipient =>

--- a/OfficeIMO.Email/Conversion/EmailConversionLossPolicy.cs
+++ b/OfficeIMO.Email/Conversion/EmailConversionLossPolicy.cs
@@ -1,0 +1,11 @@
+namespace OfficeIMO.Email;
+
+/// <summary>Controls whether a conversion may continue when message semantics cannot be preserved.</summary>
+public enum EmailConversionLossPolicy {
+    /// <summary>Stop before producing output when a known semantic loss would occur.</summary>
+    Block = 0,
+    /// <summary>Produce output and report each known semantic loss as a warning.</summary>
+    Warn = 1,
+    /// <summary>Produce output and report each accepted semantic loss as information.</summary>
+    Allow = 2
+}

--- a/OfficeIMO.Email/Conversion/EmailConversionReport.cs
+++ b/OfficeIMO.Email/Conversion/EmailConversionReport.cs
@@ -1,0 +1,27 @@
+namespace OfficeIMO.Email;
+
+/// <summary>Describes known fidelity implications before an email artifact is serialized.</summary>
+public sealed class EmailConversionReport {
+    internal EmailConversionReport(EmailFileFormat sourceFormat, EmailFileFormat targetFormat,
+        IReadOnlyList<EmailDiagnostic> diagnostics, bool hasPotentialDataLoss) {
+        SourceFormat = sourceFormat;
+        TargetFormat = targetFormat;
+        Diagnostics = diagnostics;
+        HasPotentialDataLoss = hasPotentialDataLoss;
+    }
+
+    /// <summary>Format from which the in-memory document was read or created.</summary>
+    public EmailFileFormat SourceFormat { get; }
+
+    /// <summary>Requested output format.</summary>
+    public EmailFileFormat TargetFormat { get; }
+
+    /// <summary>Known fidelity and safety diagnostics for the requested conversion.</summary>
+    public IReadOnlyList<EmailDiagnostic> Diagnostics { get; }
+
+    /// <summary>True when the conversion is known to normalize or omit source semantics.</summary>
+    public bool HasPotentialDataLoss { get; }
+
+    /// <summary>True when the active conversion policy permits serialization.</summary>
+    public bool CanWrite => !Diagnostics.Any(diagnostic => diagnostic.Severity == EmailDiagnosticSeverity.Error);
+}

--- a/OfficeIMO.Email/Mbox/EmailMailboxEntryReadResult.cs
+++ b/OfficeIMO.Email/Mbox/EmailMailboxEntryReadResult.cs
@@ -1,0 +1,23 @@
+namespace OfficeIMO.Email;
+
+/// <summary>One streamed mbox entry together with message-scoped diagnostics and source byte count.</summary>
+public sealed class EmailMailboxEntryReadResult {
+    internal EmailMailboxEntryReadResult(EmailMailboxEntry entry, IReadOnlyList<EmailDiagnostic> diagnostics,
+        long bytesRead) {
+        Entry = entry;
+        Diagnostics = diagnostics;
+        BytesRead = bytesRead;
+    }
+
+    /// <summary>Parsed mailbox entry.</summary>
+    public EmailMailboxEntry Entry { get; }
+
+    /// <summary>Diagnostics produced while reading this message.</summary>
+    public IReadOnlyList<EmailDiagnostic> Diagnostics { get; }
+
+    /// <summary>Envelope and message bytes consumed for this entry.</summary>
+    public long BytesRead { get; }
+
+    /// <summary>True when this message produced at least one error diagnostic.</summary>
+    public bool HasErrors => Diagnostics.Any(diagnostic => diagnostic.Severity == EmailDiagnosticSeverity.Error);
+}

--- a/OfficeIMO.Email/Mbox/EmailMailboxReader.cs
+++ b/OfficeIMO.Email/Mbox/EmailMailboxReader.cs
@@ -37,12 +37,14 @@ public sealed class EmailMailboxReader {
     /// original position; non-seekable streams are read forward from their current position.
     /// </summary>
     public EmailMailboxReadResult Read(Stream stream, CancellationToken cancellationToken = default) {
+        byte[] data;
         try {
-            return Parse(EmailByteReader.ReadAll(stream, _options.MaxMailboxBytes, cancellationToken), cancellationToken);
+            data = EmailByteReader.ReadAll(stream, _options.MaxMailboxBytes, cancellationToken);
         } catch (EmailLimitExceededException exception) when
             (exception.LimitName == nameof(EmailReaderOptions.MaxInputBytes)) {
             throw CreateMailboxLimitException(exception);
         }
+        return Parse(data, cancellationToken);
     }
 
     /// <summary>Asynchronously reads a mailbox file.</summary>
@@ -59,13 +61,15 @@ public sealed class EmailMailboxReader {
     /// to their original position; non-seekable streams are read forward.
     /// </summary>
     public async Task<EmailMailboxReadResult> ReadAsync(Stream stream, CancellationToken cancellationToken = default) {
+        byte[] data;
         try {
-            byte[] data = await EmailByteReader.ReadAllAsync(stream, _options.MaxMailboxBytes, cancellationToken).ConfigureAwait(false);
-            return Parse(data, cancellationToken);
+            data = await EmailByteReader.ReadAllAsync(stream, _options.MaxMailboxBytes, cancellationToken)
+                .ConfigureAwait(false);
         } catch (EmailLimitExceededException exception) when
             (exception.LimitName == nameof(EmailReaderOptions.MaxInputBytes)) {
             throw CreateMailboxLimitException(exception);
         }
+        return Parse(data, cancellationToken);
     }
 
     /// <summary>Enumerates a mailbox file while retaining at most one decoded message in memory.</summary>
@@ -215,7 +219,11 @@ public sealed class EmailMailboxReader {
         diagnostics.Add(new EmailDiagnostic("EMAIL_MBOX_MESSAGE_HEADERS_MISSING",
             "An mbox entry without recognizable message headers was retained as a plain MIME body.",
             EmailDiagnosticSeverity.Warning));
-        EmailDocument document = MimeParser.Parse(messageBytes, options, diagnostics, cancellationToken);
+        byte[] mimeBody = new byte[messageBytes.Length + 2];
+        mimeBody[0] = (byte)'\r';
+        mimeBody[1] = (byte)'\n';
+        Buffer.BlockCopy(messageBytes, 0, mimeBody, 2, messageBytes.Length);
+        EmailDocument document = MimeParser.Parse(mimeBody, options, diagnostics, cancellationToken);
         return new EmailReadResult(document, diagnostics.AsReadOnly(), messageBytes.LongLength);
     }
 

--- a/OfficeIMO.Email/Mbox/EmailMailboxReader.cs
+++ b/OfficeIMO.Email/Mbox/EmailMailboxReader.cs
@@ -25,9 +25,9 @@ public sealed class EmailMailboxReader {
     public EmailMailboxReadResult Read(byte[] data, CancellationToken cancellationToken = default) {
         if (data == null) throw new ArgumentNullException(nameof(data));
         cancellationToken.ThrowIfCancellationRequested();
-        if (data.LongLength > _options.MessageOptions.MaxInputBytes) {
-            throw new EmailLimitExceededException(nameof(EmailReaderOptions.MaxInputBytes), data.LongLength,
-                _options.MessageOptions.MaxInputBytes);
+        if (data.LongLength > _options.MaxMailboxBytes) {
+            throw new EmailLimitExceededException(nameof(EmailMailboxReaderOptions.MaxMailboxBytes), data.LongLength,
+                _options.MaxMailboxBytes);
         }
         return Parse(data, cancellationToken);
     }
@@ -37,7 +37,12 @@ public sealed class EmailMailboxReader {
     /// original position; non-seekable streams are read forward from their current position.
     /// </summary>
     public EmailMailboxReadResult Read(Stream stream, CancellationToken cancellationToken = default) {
-        return Parse(EmailByteReader.ReadAll(stream, _options.MessageOptions.MaxInputBytes, cancellationToken), cancellationToken);
+        try {
+            return Parse(EmailByteReader.ReadAll(stream, _options.MaxMailboxBytes, cancellationToken), cancellationToken);
+        } catch (EmailLimitExceededException exception) when
+            (exception.LimitName == nameof(EmailReaderOptions.MaxInputBytes)) {
+            throw CreateMailboxLimitException(exception);
+        }
     }
 
     /// <summary>Asynchronously reads a mailbox file.</summary>
@@ -54,9 +59,39 @@ public sealed class EmailMailboxReader {
     /// to their original position; non-seekable streams are read forward.
     /// </summary>
     public async Task<EmailMailboxReadResult> ReadAsync(Stream stream, CancellationToken cancellationToken = default) {
-        byte[] data = await EmailByteReader.ReadAllAsync(stream, _options.MessageOptions.MaxInputBytes, cancellationToken).ConfigureAwait(false);
-        return Parse(data, cancellationToken);
+        try {
+            byte[] data = await EmailByteReader.ReadAllAsync(stream, _options.MaxMailboxBytes, cancellationToken).ConfigureAwait(false);
+            return Parse(data, cancellationToken);
+        } catch (EmailLimitExceededException exception) when
+            (exception.LimitName == nameof(EmailReaderOptions.MaxInputBytes)) {
+            throw CreateMailboxLimitException(exception);
+        }
     }
+
+    /// <summary>Enumerates a mailbox file while retaining at most one decoded message in memory.</summary>
+    public IEnumerable<EmailMailboxEntryReadResult> ReadEntries(string filePath,
+        CancellationToken cancellationToken = default) {
+        if (filePath == null) throw new ArgumentNullException(nameof(filePath));
+        return EnumerateFile(filePath, cancellationToken);
+    }
+
+    /// <summary>
+    /// Enumerates a caller-owned mailbox stream while retaining at most one decoded message in memory.
+    /// Seekable streams are restored to their original position when enumeration ends or is disposed.
+    /// </summary>
+    public IEnumerable<EmailMailboxEntryReadResult> ReadEntries(Stream stream,
+        CancellationToken cancellationToken = default) => MboxStreamReader.Read(stream, _options, cancellationToken);
+
+    private IEnumerable<EmailMailboxEntryReadResult> EnumerateFile(string filePath,
+        CancellationToken cancellationToken) {
+        using (FileStream stream = File.OpenRead(filePath)) {
+            foreach (EmailMailboxEntryReadResult entry in ReadEntries(stream, cancellationToken)) yield return entry;
+        }
+    }
+
+    private static EmailLimitExceededException CreateMailboxLimitException(EmailLimitExceededException exception) =>
+        new EmailLimitExceededException(nameof(EmailMailboxReaderOptions.MaxMailboxBytes),
+            exception.ActualValue, exception.MaximumValue);
 
     private EmailMailboxReadResult Parse(byte[] data, CancellationToken cancellationToken) {
         var diagnostics = new List<EmailDiagnostic>();
@@ -75,7 +110,7 @@ public sealed class EmailMailboxReader {
             byte[] messageBytes = MsgBinary.Slice(data, envelope.MessageStart, end - envelope.MessageStart);
             MboxVariant variant = _options.Variant == MboxVariant.Auto ? DetectVariant(messageBytes, cancellationToken) : _options.Variant;
             messageBytes = Unescape(messageBytes, variant, cancellationToken);
-            EmailReadResult message = reader.Read(messageBytes, cancellationToken);
+            EmailReadResult message = ReadEntryMessage(reader, messageBytes, _options.MessageOptions, cancellationToken);
             var entry = new EmailMailboxEntry(message.Document) {
                 EnvelopeSender = envelope.Sender,
                 EnvelopeDate = envelope.Date,
@@ -94,7 +129,8 @@ public sealed class EmailMailboxReader {
     private static List<Envelope> FindEnvelopes(byte[] data, int maximumMessages,
         CancellationToken cancellationToken) {
         var result = new List<Envelope>();
-        int lineStart = 0;
+        int lineStart = HasUtf8Bom(data) ? 3 : 0;
+        bool firstLine = true;
         while (lineStart < data.Length) {
             cancellationToken.ThrowIfCancellationRequested();
             int lineEnd = lineStart;
@@ -102,18 +138,20 @@ public sealed class EmailMailboxReader {
             if (lineEnd - lineStart >= 5 && StartsWith(data, lineStart, "From ")) {
                 string raw = Encoding.ASCII.GetString(data, lineStart, lineEnd - lineStart);
                 ParseEnvelope(raw, out string? sender, out DateTimeOffset? date);
-                result.Add(new Envelope(lineStart, SkipLineEnding(data, lineEnd), raw, sender, date));
+                result.Add(new Envelope(firstLine && lineStart == 3 ? 0 : lineStart,
+                    SkipLineEnding(data, lineEnd), raw, sender, date));
                 if (result.Count > maximumMessages) {
                     throw new EmailLimitExceededException(nameof(EmailMailboxReaderOptions.MaxMessageCount),
                         result.Count, maximumMessages);
                 }
             }
             lineStart = SkipLineEnding(data, lineEnd);
+            firstLine = false;
         }
         return result;
     }
 
-    private static void ParseEnvelope(string raw, out string? sender, out DateTimeOffset? date) {
+    internal static void ParseEnvelope(string raw, out string? sender, out DateTimeOffset? date) {
         string remainder = raw.Substring(5).Trim();
         int separator = remainder.IndexOf(' ');
         sender = separator < 0 ? remainder : remainder.Substring(0, separator);
@@ -122,7 +160,7 @@ public sealed class EmailMailboxReader {
             DateTimeStyles.AllowWhiteSpaces | DateTimeStyles.AssumeUniversal, out DateTimeOffset parsed) ? parsed : (DateTimeOffset?)null;
     }
 
-    private static MboxVariant DetectVariant(byte[] message, CancellationToken cancellationToken) {
+    internal static MboxVariant DetectVariant(byte[] message, CancellationToken cancellationToken) {
         int lineStart = 0;
         while (lineStart < message.Length) {
             cancellationToken.ThrowIfCancellationRequested();
@@ -137,7 +175,7 @@ public sealed class EmailMailboxReader {
         return MboxVariant.Mboxo;
     }
 
-    private static byte[] Unescape(byte[] message, MboxVariant variant, CancellationToken cancellationToken) {
+    internal static byte[] Unescape(byte[] message, MboxVariant variant, CancellationToken cancellationToken) {
         using (MemoryStream output = new MemoryStream(message.Length)) {
             int lineStart = 0;
             while (lineStart < message.Length) {
@@ -164,6 +202,25 @@ public sealed class EmailMailboxReader {
         for (int index = 0; index < value.Length; index++) if (data[offset + index] != value[index]) return false;
         return true;
     }
+
+    internal static EmailReadResult ReadEntryMessage(EmailDocumentReader reader, byte[] messageBytes,
+        EmailReaderOptions options, CancellationToken cancellationToken) {
+        EmailReadResult result = reader.Read(messageBytes, cancellationToken);
+        if (result.Document.Format != EmailFileFormat.Unknown ||
+            !result.Diagnostics.Any(diagnostic => diagnostic.Code == "EMAIL_FORMAT_UNKNOWN")) return result;
+
+        var diagnostics = result.Diagnostics
+            .Where(diagnostic => diagnostic.Code != "EMAIL_FORMAT_UNKNOWN")
+            .ToList();
+        diagnostics.Add(new EmailDiagnostic("EMAIL_MBOX_MESSAGE_HEADERS_MISSING",
+            "An mbox entry without recognizable message headers was retained as a plain MIME body.",
+            EmailDiagnosticSeverity.Warning));
+        EmailDocument document = MimeParser.Parse(messageBytes, options, diagnostics, cancellationToken);
+        return new EmailReadResult(document, diagnostics.AsReadOnly(), messageBytes.LongLength);
+    }
+
+    private static bool HasUtf8Bom(byte[] data) => data.Length >= 3 &&
+        data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF;
 
     private static int SkipLineEnding(byte[] data, int position) {
         if (position < data.Length && data[position] == '\r') position++;

--- a/OfficeIMO.Email/Mbox/EmailMailboxReaderOptions.cs
+++ b/OfficeIMO.Email/Mbox/EmailMailboxReaderOptions.cs
@@ -7,17 +7,26 @@ public sealed class EmailMailboxReaderOptions {
 
     /// <summary>Creates mailbox reader options.</summary>
     public EmailMailboxReaderOptions(EmailReaderOptions? messageOptions = null, MboxVariant variant = MboxVariant.Auto,
-        int maxMessageCount = 100000) {
+        int maxMessageCount = 100000)
+        : this(512L * 1024L * 1024L, messageOptions, variant, maxMessageCount) { }
+
+    /// <summary>Creates mailbox reader options with an explicit aggregate byte limit.</summary>
+    public EmailMailboxReaderOptions(long maxMailboxBytes, EmailReaderOptions? messageOptions = null,
+        MboxVariant variant = MboxVariant.Auto, int maxMessageCount = 100000) {
         if (maxMessageCount <= 0) throw new ArgumentOutOfRangeException(nameof(maxMessageCount));
+        if (maxMailboxBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maxMailboxBytes));
         MessageOptions = messageOptions ?? EmailReaderOptions.Default;
         Variant = variant;
         MaxMessageCount = maxMessageCount;
+        MaxMailboxBytes = maxMailboxBytes;
     }
 
-    /// <summary>Bounded policy applied to each message and the aggregate input.</summary>
+    /// <summary>Bounded policy applied independently to each message.</summary>
     public EmailReaderOptions MessageOptions { get; }
     /// <summary>Escaping convention to decode.</summary>
     public MboxVariant Variant { get; }
     /// <summary>Maximum messages in one mailbox.</summary>
     public int MaxMessageCount { get; }
+    /// <summary>Maximum aggregate source bytes consumed from one mailbox.</summary>
+    public long MaxMailboxBytes { get; }
 }

--- a/OfficeIMO.Email/Mbox/EmailMailboxWriter.cs
+++ b/OfficeIMO.Email/Mbox/EmailMailboxWriter.cs
@@ -20,6 +20,7 @@ public sealed class EmailMailboxWriter {
     public EmailWriteResult Write(EmailMailbox mailbox, string filePath) {
         if (filePath == null) throw new ArgumentNullException(nameof(filePath));
         byte[] bytes = ToBytes(mailbox, out EmailWriteResult result, CancellationToken.None);
+        if (result.HasErrors && bytes.Length == 0) return result;
         OfficeFileCommit.WriteAllBytes(filePath, bytes);
         return result;
     }
@@ -29,12 +30,53 @@ public sealed class EmailMailboxWriter {
         if (stream == null) throw new ArgumentNullException(nameof(stream));
         if (!stream.CanWrite) throw new ArgumentException("The stream must be writable.", nameof(stream));
         byte[] bytes = ToBytes(mailbox, out EmailWriteResult result, CancellationToken.None);
+        if (result.HasErrors && bytes.Length == 0) return result;
         OfficeStreamWriter.WriteAllBytes(stream, bytes);
         return result;
     }
 
     /// <summary>Writes a mailbox to memory.</summary>
-    public byte[] ToBytes(EmailMailbox mailbox) => ToBytes(mailbox, out _, CancellationToken.None);
+    public byte[] ToBytes(EmailMailbox mailbox) {
+        byte[] bytes = ToBytes(mailbox, out EmailWriteResult result, CancellationToken.None);
+        if (result.HasErrors) {
+            EmailDiagnostic error = result.Diagnostics.First(diagnostic =>
+                diagnostic.Severity == EmailDiagnosticSeverity.Error);
+            throw new InvalidDataException(string.Concat("The mailbox could not be serialized: ", error.Code,
+                ": ", error.Message));
+        }
+        return bytes;
+    }
+
+    /// <summary>
+    /// Writes an entry sequence directly to a caller-owned stream while retaining at most one serialized message.
+    /// A limit or enumeration failure can leave already completed entries in the destination.
+    /// </summary>
+    public EmailWriteResult WriteEntries(IEnumerable<EmailMailboxEntry> entries, Stream stream,
+        CancellationToken cancellationToken = default) {
+        if (entries == null) throw new ArgumentNullException(nameof(entries));
+        if (stream == null) throw new ArgumentNullException(nameof(stream));
+        if (!stream.CanWrite) throw new ArgumentException("The stream must be writable.", nameof(stream));
+        var diagnostics = new List<EmailDiagnostic>();
+        long bytesWritten = 0;
+        int index = 0;
+        foreach (EmailMailboxEntry entry in entries) {
+            cancellationToken.ThrowIfCancellationRequested();
+            byte[] bytes = SerializeEntry(entry, index, diagnostics, cancellationToken);
+            if (bytes.Length == 0 && diagnostics.Any(diagnostic =>
+                diagnostic.Severity == EmailDiagnosticSeverity.Error)) {
+                return new EmailWriteResult(bytesWritten, diagnostics.AsReadOnly(), false);
+            }
+            long next = checked(bytesWritten + bytes.LongLength);
+            if (next > _options.MessageOptions.MaxOutputBytes) {
+                throw new EmailLimitExceededException(nameof(EmailWriterOptions.MaxOutputBytes), next,
+                    _options.MessageOptions.MaxOutputBytes);
+            }
+            stream.Write(bytes, 0, bytes.Length);
+            bytesWritten = next;
+            index++;
+        }
+        return new EmailWriteResult(bytesWritten, diagnostics.AsReadOnly(), false);
+    }
 
     /// <summary>Asynchronously writes a mailbox file.</summary>
     public async Task<EmailWriteResult> WriteAsync(EmailMailbox mailbox, string filePath,
@@ -42,6 +84,7 @@ public sealed class EmailMailboxWriter {
         if (filePath == null) throw new ArgumentNullException(nameof(filePath));
         cancellationToken.ThrowIfCancellationRequested();
         byte[] bytes = ToBytes(mailbox, out EmailWriteResult result, cancellationToken);
+        if (result.HasErrors && bytes.Length == 0) return result;
         await OfficeFileCommit.WriteAllBytesAsync(filePath, bytes, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
         return result;
@@ -54,6 +97,7 @@ public sealed class EmailMailboxWriter {
         if (!stream.CanWrite) throw new ArgumentException("The stream must be writable.", nameof(stream));
         cancellationToken.ThrowIfCancellationRequested();
         byte[] bytes = ToBytes(mailbox, out EmailWriteResult result, cancellationToken);
+        if (result.HasErrors && bytes.Length == 0) return result;
         cancellationToken.ThrowIfCancellationRequested();
         await OfficeStreamWriter.WriteAllBytesAsync(stream, bytes, cancellationToken).ConfigureAwait(false);
         return result;
@@ -68,29 +112,50 @@ public sealed class EmailMailboxWriter {
                    _options.MessageOptions.MaxOutputBytes)) {
             for (int index = 0; index < mailbox.Messages.Count; index++) {
                 cancellationToken.ThrowIfCancellationRequested();
-                EmailMailboxEntry entry = mailbox.Messages[index];
-                string sender = entry.EnvelopeSender ?? entry.Document.From?.Address ?? "MAILER-DAEMON";
-                DateTimeOffset date = entry.EnvelopeDate ?? entry.Document.Date ??
-                    new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
-                string fromLine = string.Concat("From ", SanitizeSender(sender), " ",
-                    date.UtcDateTime.ToString("ddd MMM dd HH:mm:ss yyyy", CultureInfo.InvariantCulture), "\n");
-                byte[] fromBytes = Encoding.ASCII.GetBytes(fromLine);
-                output.Write(fromBytes, 0, fromBytes.Length);
-                byte[] eml;
-                using (MemoryStream messageOutput = new MemoryStream()) {
-                    EmailWriteResult messageResult = messageWriter.Write(entry.Document, messageOutput, EmailFileFormat.Eml);
-                    diagnostics.AddRange(messageResult.Diagnostics);
-                    eml = messageOutput.ToArray();
+                byte[] entry = SerializeEntry(mailbox.Messages[index], index, diagnostics, cancellationToken,
+                    messageWriter);
+                if (entry.Length == 0 && diagnostics.Any(diagnostic =>
+                    diagnostic.Severity == EmailDiagnosticSeverity.Error)) {
+                    result = new EmailWriteResult(0, diagnostics.AsReadOnly(), false);
+                    return Array.Empty<byte>();
                 }
-                byte[] normalized = NormalizeLineEndings(eml);
-                byte[] escaped = Escape(normalized, _options.Variant);
-                output.Write(escaped, 0, escaped.Length);
-                if (escaped.Length == 0 || escaped[escaped.Length - 1] != '\n') output.WriteByte((byte)'\n');
+                output.Write(entry, 0, entry.Length);
             }
             byte[] bytes = output.ToArray();
             cancellationToken.ThrowIfCancellationRequested();
             result = new EmailWriteResult(bytes.LongLength, diagnostics.AsReadOnly(), false);
             return bytes;
+        }
+    }
+
+    private byte[] SerializeEntry(EmailMailboxEntry entry, int index, IList<EmailDiagnostic> diagnostics,
+        CancellationToken cancellationToken, EmailDocumentWriter? existingWriter = null) {
+        var messageWriter = existingWriter ?? new EmailDocumentWriter(_options.MessageOptions);
+        byte[] eml;
+        EmailWriteResult messageResult;
+        using (var messageOutput = new MemoryStream()) {
+            messageResult = messageWriter.Write(entry.Document, messageOutput, EmailFileFormat.Eml);
+            eml = messageOutput.ToArray();
+        }
+        foreach (EmailDiagnostic diagnostic in messageResult.Diagnostics) {
+            diagnostics.Add(new EmailDiagnostic(diagnostic.Code, diagnostic.Message, diagnostic.Severity,
+                string.Concat("message[", index.ToString(CultureInfo.InvariantCulture), "]",
+                    diagnostic.Location == null ? string.Empty : string.Concat("/", diagnostic.Location))));
+        }
+        if (messageResult.HasErrors && eml.Length == 0) return Array.Empty<byte>();
+
+        string sender = entry.EnvelopeSender ?? entry.Document.From?.Address ?? "MAILER-DAEMON";
+        DateTimeOffset date = entry.EnvelopeDate ?? entry.Document.Date ??
+            new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        byte[] fromBytes = Encoding.ASCII.GetBytes(string.Concat("From ", SanitizeSender(sender), " ",
+            date.UtcDateTime.ToString("ddd MMM dd HH:mm:ss yyyy", CultureInfo.InvariantCulture), "\n"));
+        byte[] escaped = Escape(NormalizeLineEndings(eml), _options.Variant);
+        using (var output = new MemoryStream(checked(fromBytes.Length + escaped.Length + 1))) {
+            output.Write(fromBytes, 0, fromBytes.Length);
+            output.Write(escaped, 0, escaped.Length);
+            if (escaped.Length == 0 || escaped[escaped.Length - 1] != '\n') output.WriteByte((byte)'\n');
+            cancellationToken.ThrowIfCancellationRequested();
+            return output.ToArray();
         }
     }
 

--- a/OfficeIMO.Email/Mbox/EmailMailboxWriter.cs
+++ b/OfficeIMO.Email/Mbox/EmailMailboxWriter.cs
@@ -67,10 +67,6 @@ public sealed class EmailMailboxWriter {
                 return new EmailWriteResult(bytesWritten, diagnostics.AsReadOnly(), false);
             }
             long next = checked(bytesWritten + bytes.LongLength);
-            if (next > _options.MessageOptions.MaxOutputBytes) {
-                throw new EmailLimitExceededException(nameof(EmailWriterOptions.MaxOutputBytes), next,
-                    _options.MessageOptions.MaxOutputBytes);
-            }
             stream.Write(bytes, 0, bytes.Length);
             bytesWritten = next;
             index++;

--- a/OfficeIMO.Email/Mbox/MboxStreamReader.cs
+++ b/OfficeIMO.Email/Mbox/MboxStreamReader.cs
@@ -19,7 +19,8 @@ internal static class MboxStreamReader {
         long entryBytes = 0;
         int pendingByte = -1;
         try {
-            while (TryReadLine(stream, cancellationToken, ref pendingByte, out byte[] line, out byte[] ending)) {
+            while (TryReadLine(stream, cancellationToken, ref pendingByte, totalBytes, message.Length,
+                       envelope != null, options, out byte[] line, out byte[] ending)) {
                 long lineBytes = checked(line.LongLength + ending.LongLength);
                 totalBytes = checked(totalBytes + lineBytes);
                 if (totalBytes > options.MaxMailboxBytes) {
@@ -95,13 +96,18 @@ internal static class MboxStreamReader {
     }
 
     private static bool TryReadLine(Stream stream, CancellationToken cancellationToken, ref int pendingByte,
+        long totalBytes, long messageBytes, bool hasEnvelope, EmailMailboxReaderOptions options,
         out byte[] line, out byte[] ending) {
         using (var content = new MemoryStream()) {
             int current = pendingByte;
             pendingByte = -1;
+            bool couldBeEnvelope = hasEnvelope;
             while (current >= 0 || (current = stream.ReadByte()) >= 0) {
                 cancellationToken.ThrowIfCancellationRequested();
                 if (current == '\n') {
+                    bool envelopeCandidate = couldBeEnvelope && content.Length >= 5;
+                    EnsureLineWithinLimits(content.Length + 1, envelopeCandidate, totalBytes, messageBytes,
+                        hasEnvelope, options);
                     line = content.ToArray();
                     if (line.Length > 0 && line[line.Length - 1] == '\r') {
                         Array.Resize(ref line, line.Length - 1);
@@ -112,15 +118,25 @@ internal static class MboxStreamReader {
                 if (current == '\r') {
                     int next = stream.ReadByte();
                     if (next == '\n') {
+                        bool envelopeCandidate = couldBeEnvelope && content.Length >= 5;
+                        EnsureLineWithinLimits(content.Length + 2, envelopeCandidate, totalBytes, messageBytes,
+                            hasEnvelope, options);
                         line = content.ToArray();
                         ending = new byte[] { (byte)'\r', (byte)'\n' };
                         return true;
                     }
+                    bool bareEnvelopeCandidate = couldBeEnvelope && content.Length >= 5;
+                    EnsureLineWithinLimits(content.Length + 1, bareEnvelopeCandidate, totalBytes, messageBytes,
+                        hasEnvelope, options);
                     line = content.ToArray();
                     ending = new byte[] { (byte)'\r' };
                     pendingByte = next;
                     return true;
                 }
+                if (couldBeEnvelope && content.Length < 5 &&
+                    current != "From "[(int)content.Length]) couldBeEnvelope = false;
+                EnsureLineWithinLimits(content.Length + 1, couldBeEnvelope, totalBytes, messageBytes,
+                    hasEnvelope, options);
                 content.WriteByte((byte)current);
                 current = -1;
             }
@@ -129,9 +145,26 @@ internal static class MboxStreamReader {
                 ending = Array.Empty<byte>();
                 return false;
             }
+            EnsureLineWithinLimits(content.Length, couldBeEnvelope && content.Length >= 5, totalBytes,
+                messageBytes, hasEnvelope, options);
             line = content.ToArray();
             ending = Array.Empty<byte>();
             return true;
+        }
+    }
+
+    private static void EnsureLineWithinLimits(long lineBytes, bool couldBeEnvelope, long totalBytes,
+        long messageBytes, bool hasEnvelope, EmailMailboxReaderOptions options) {
+        long aggregateLength = checked(totalBytes + lineBytes);
+        if (aggregateLength > options.MaxMailboxBytes) {
+            throw new EmailLimitExceededException(nameof(EmailMailboxReaderOptions.MaxMailboxBytes),
+                aggregateLength, options.MaxMailboxBytes);
+        }
+        if (!hasEnvelope || couldBeEnvelope) return;
+        long messageLength = checked(messageBytes + lineBytes);
+        if (messageLength > options.MessageOptions.MaxInputBytes) {
+            throw new EmailLimitExceededException(nameof(EmailReaderOptions.MaxInputBytes), messageLength,
+                options.MessageOptions.MaxInputBytes);
         }
     }
 

--- a/OfficeIMO.Email/Mbox/MboxStreamReader.cs
+++ b/OfficeIMO.Email/Mbox/MboxStreamReader.cs
@@ -1,0 +1,161 @@
+namespace OfficeIMO.Email;
+
+internal static class MboxStreamReader {
+    internal static IEnumerable<EmailMailboxEntryReadResult> Read(Stream stream, EmailMailboxReaderOptions options,
+        CancellationToken cancellationToken) {
+        if (stream == null) throw new ArgumentNullException(nameof(stream));
+        if (!stream.CanRead) throw new ArgumentException("The stream must be readable.", nameof(stream));
+        return Enumerate(stream, options, cancellationToken);
+    }
+
+    private static IEnumerable<EmailMailboxEntryReadResult> Enumerate(Stream stream,
+        EmailMailboxReaderOptions options, CancellationToken cancellationToken) {
+        long originalPosition = stream.CanSeek ? stream.Position : 0;
+        if (stream.CanSeek) stream.Position = 0;
+        long totalBytes = 0;
+        int messageCount = 0;
+        Envelope? envelope = null;
+        var message = new MemoryStream();
+        long entryBytes = 0;
+        int pendingByte = -1;
+        try {
+            while (TryReadLine(stream, cancellationToken, ref pendingByte, out byte[] line, out byte[] ending)) {
+                long lineBytes = checked(line.LongLength + ending.LongLength);
+                totalBytes = checked(totalBytes + lineBytes);
+                if (totalBytes > options.MaxMailboxBytes) {
+                    throw new EmailLimitExceededException(nameof(EmailMailboxReaderOptions.MaxMailboxBytes),
+                        totalBytes, options.MaxMailboxBytes);
+                }
+
+                byte[] envelopeLine = envelope == null && messageCount == 0 && totalBytes == lineBytes && HasUtf8Bom(line)
+                    ? Slice(line, 3)
+                    : line;
+                if (StartsWith(envelopeLine, "From ")) {
+                    if (envelope != null) {
+                        yield return ParseEntry(message.ToArray(), envelope, entryBytes, options, cancellationToken);
+                        message.Dispose();
+                        message = new MemoryStream();
+                    } else if (totalBytes != lineBytes) {
+                        throw new InvalidDataException(
+                            "EMAIL_MBOX_ENVELOPE_MISSING: The mailbox does not begin with an mbox From separator.");
+                    }
+
+                    messageCount++;
+                    if (messageCount > options.MaxMessageCount) {
+                        throw new EmailLimitExceededException(nameof(EmailMailboxReaderOptions.MaxMessageCount),
+                            messageCount, options.MaxMessageCount);
+                    }
+                    string rawLine = Encoding.ASCII.GetString(envelopeLine);
+                    EmailMailboxReader.ParseEnvelope(rawLine, out string? sender, out DateTimeOffset? date);
+                    envelope = new Envelope(rawLine, sender, date);
+                    entryBytes = lineBytes;
+                    continue;
+                }
+
+                if (envelope == null) {
+                    throw new InvalidDataException(
+                        "EMAIL_MBOX_ENVELOPE_MISSING: The mailbox does not begin with an mbox From separator.");
+                }
+                long messageLength = checked(message.Length + lineBytes);
+                if (messageLength > options.MessageOptions.MaxInputBytes) {
+                    throw new EmailLimitExceededException(nameof(EmailReaderOptions.MaxInputBytes), messageLength,
+                        options.MessageOptions.MaxInputBytes);
+                }
+                message.Write(line, 0, line.Length);
+                message.Write(ending, 0, ending.Length);
+                entryBytes = checked(entryBytes + lineBytes);
+            }
+
+            if (envelope == null) {
+                throw new InvalidDataException(
+                    "EMAIL_MBOX_ENVELOPE_MISSING: The mailbox does not begin with an mbox From separator.");
+            }
+            yield return ParseEntry(message.ToArray(), envelope, entryBytes, options, cancellationToken);
+        } finally {
+            message.Dispose();
+            if (stream.CanSeek) stream.Position = originalPosition;
+        }
+    }
+
+    private static EmailMailboxEntryReadResult ParseEntry(byte[] messageBytes, Envelope envelope, long bytesRead,
+        EmailMailboxReaderOptions options, CancellationToken cancellationToken) {
+        MboxVariant variant = options.Variant == MboxVariant.Auto
+            ? EmailMailboxReader.DetectVariant(messageBytes, cancellationToken)
+            : options.Variant;
+        byte[] unescaped = EmailMailboxReader.Unescape(messageBytes, variant, cancellationToken);
+        var reader = new EmailDocumentReader(options.MessageOptions);
+        EmailReadResult message = EmailMailboxReader.ReadEntryMessage(
+            reader, unescaped, options.MessageOptions, cancellationToken);
+        var entry = new EmailMailboxEntry(message.Document) {
+            EnvelopeSender = envelope.Sender,
+            EnvelopeDate = envelope.Date,
+            RawFromLine = envelope.RawLine
+        };
+        return new EmailMailboxEntryReadResult(entry, message.Diagnostics, bytesRead);
+    }
+
+    private static bool TryReadLine(Stream stream, CancellationToken cancellationToken, ref int pendingByte,
+        out byte[] line, out byte[] ending) {
+        using (var content = new MemoryStream()) {
+            int current = pendingByte;
+            pendingByte = -1;
+            while (current >= 0 || (current = stream.ReadByte()) >= 0) {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (current == '\n') {
+                    line = content.ToArray();
+                    if (line.Length > 0 && line[line.Length - 1] == '\r') {
+                        Array.Resize(ref line, line.Length - 1);
+                        ending = new byte[] { (byte)'\r', (byte)'\n' };
+                    } else ending = new byte[] { (byte)'\n' };
+                    return true;
+                }
+                if (current == '\r') {
+                    int next = stream.ReadByte();
+                    if (next == '\n') {
+                        line = content.ToArray();
+                        ending = new byte[] { (byte)'\r', (byte)'\n' };
+                        return true;
+                    }
+                    line = content.ToArray();
+                    ending = new byte[] { (byte)'\r' };
+                    pendingByte = next;
+                    return true;
+                }
+                content.WriteByte((byte)current);
+                current = -1;
+            }
+            if (content.Length == 0) {
+                line = Array.Empty<byte>();
+                ending = Array.Empty<byte>();
+                return false;
+            }
+            line = content.ToArray();
+            ending = Array.Empty<byte>();
+            return true;
+        }
+    }
+
+    private static bool StartsWith(byte[] data, string value) {
+        if (data.Length < value.Length) return false;
+        for (int index = 0; index < value.Length; index++) if (data[index] != value[index]) return false;
+        return true;
+    }
+
+    private static bool HasUtf8Bom(byte[] data) => data.Length >= 3 &&
+        data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF;
+
+    private static byte[] Slice(byte[] data, int offset) {
+        var result = new byte[data.Length - offset];
+        Buffer.BlockCopy(data, offset, result, 0, result.Length);
+        return result;
+    }
+
+    private sealed class Envelope {
+        internal Envelope(string rawLine, string? sender, DateTimeOffset? date) {
+            RawLine = rawLine; Sender = sender; Date = date;
+        }
+        internal string RawLine { get; }
+        internal string? Sender { get; }
+        internal DateTimeOffset? Date { get; }
+    }
+}

--- a/OfficeIMO.Email/Mbox/MboxStreamReader.cs
+++ b/OfficeIMO.Email/Mbox/MboxStreamReader.cs
@@ -101,7 +101,7 @@ internal static class MboxStreamReader {
         using (var content = new MemoryStream()) {
             int current = pendingByte;
             pendingByte = -1;
-            bool couldBeEnvelope = hasEnvelope;
+            bool couldBeEnvelope = true;
             while (current >= 0 || (current = stream.ReadByte()) >= 0) {
                 cancellationToken.ThrowIfCancellationRequested();
                 if (current == '\n') {
@@ -160,7 +160,14 @@ internal static class MboxStreamReader {
             throw new EmailLimitExceededException(nameof(EmailMailboxReaderOptions.MaxMailboxBytes),
                 aggregateLength, options.MaxMailboxBytes);
         }
-        if (!hasEnvelope || couldBeEnvelope) return;
+        if (couldBeEnvelope) {
+            if (lineBytes > options.MessageOptions.MaxInputBytes) {
+                throw new EmailLimitExceededException(nameof(EmailReaderOptions.MaxInputBytes), lineBytes,
+                    options.MessageOptions.MaxInputBytes);
+            }
+            return;
+        }
+        if (!hasEnvelope) return;
         long messageLength = checked(messageBytes + lineBytes);
         if (messageLength > options.MessageOptions.MaxInputBytes) {
             throw new EmailLimitExceededException(nameof(EmailReaderOptions.MaxInputBytes), messageLength,

--- a/OfficeIMO.Email/Mime/MimeAddressParser.cs
+++ b/OfficeIMO.Email/Mime/MimeAddressParser.cs
@@ -10,6 +10,10 @@ internal static class MimeAddressParser {
     }
 
     internal static EmailAddress? ParseOne(string? input) {
+        return ParseOne(input, DecodeDisplayName);
+    }
+
+    private static EmailAddress? ParseOne(string? input, Func<string, string> decodeDisplayName) {
         if (string.IsNullOrWhiteSpace(input)) return null;
         string raw = input!.Trim();
         if (IsCommentOnly(raw)) return null;
@@ -17,18 +21,18 @@ internal static class MimeAddressParser {
         int greater = less >= 0 ? raw.IndexOf('>', less + 1) : -1;
         if (less >= 0 && greater > less) {
             if (!HasOnlyCommentsAfter(raw, greater + 1)) return null;
-            string display = DecodeDisplayName(raw.Substring(0, less));
+            string display = decodeDisplayName(raw.Substring(0, less));
             string address = raw.Substring(less + 1, greater - less - 1).Trim();
             return new EmailAddress(address.Length == 0 ? null : address, display.Length == 0 ? null : display, raw);
         }
         if (less >= 0 || raw.IndexOf('>') >= 0) return null;
-        if (TryParseAddressWithTrailingComment(raw, out EmailAddress? commented)) return commented;
+        if (TryParseAddressWithTrailingComment(raw, decodeDisplayName, out EmailAddress? commented)) return commented;
         return new EmailAddress(raw, null, raw);
     }
 
     internal static EmailAddress? ParseOne(string? input, IList<EmailDiagnostic> diagnostics, string location) {
         if (string.IsNullOrWhiteSpace(input)) return null;
-        return ParseOne(MimeTextCodec.DecodeHeader(input!, diagnostics, location));
+        return ParseOne(input, value => DecodeDisplayName(MimeTextCodec.DecodeHeader(value, diagnostics, location)));
     }
 
     internal static IEnumerable<EmailAddress> ParseMany(string? input, IList<EmailDiagnostic> diagnostics,
@@ -184,7 +188,8 @@ internal static class MimeAddressParser {
         return sawComment && depth == 0;
     }
 
-    private static bool TryParseAddressWithTrailingComment(string value, out EmailAddress? address) {
+    private static bool TryParseAddressWithTrailingComment(string value, Func<string, string> decodeDisplayName,
+        out EmailAddress? address) {
         address = null;
         int open = value.IndexOf('(');
         if (open <= 0) return false;
@@ -192,7 +197,7 @@ internal static class MimeAddressParser {
         if (close <= open || value.Substring(close + 1).Trim().Length != 0) return false;
         string addressText = value.Substring(0, open).Trim();
         if (addressText.Length == 0 || addressText.IndexOfAny(new[] { ' ', '\t', '<', '>' }) >= 0) return false;
-        string displayName = DecodeDisplayName(value.Substring(open + 1, close - open - 1));
+        string displayName = decodeDisplayName(value.Substring(open + 1, close - open - 1));
         address = new EmailAddress(addressText, displayName.Length == 0 ? null : displayName, value);
         return true;
     }

--- a/OfficeIMO.Email/Mime/MimeAddressParser.cs
+++ b/OfficeIMO.Email/Mime/MimeAddressParser.cs
@@ -12,13 +12,17 @@ internal static class MimeAddressParser {
     internal static EmailAddress? ParseOne(string? input) {
         if (string.IsNullOrWhiteSpace(input)) return null;
         string raw = input!.Trim();
-        int less = raw.LastIndexOf('<');
+        if (IsCommentOnly(raw)) return null;
+        int less = FindAngleAddressStart(raw);
         int greater = less >= 0 ? raw.IndexOf('>', less + 1) : -1;
         if (less >= 0 && greater > less) {
+            if (!HasOnlyCommentsAfter(raw, greater + 1)) return null;
             string display = DecodeDisplayName(raw.Substring(0, less));
             string address = raw.Substring(less + 1, greater - less - 1).Trim();
             return new EmailAddress(address.Length == 0 ? null : address, display.Length == 0 ? null : display, raw);
         }
+        if (less >= 0 || raw.IndexOf('>') >= 0) return null;
+        if (TryParseAddressWithTrailingComment(raw, out EmailAddress? commented)) return commented;
         return new EmailAddress(raw, null, raw);
     }
 
@@ -96,6 +100,101 @@ internal static class MimeAddressParser {
     private static bool IsGroupLabel(StringBuilder value) {
         string candidate = value.ToString().Trim();
         return candidate.Length > 0 && candidate.IndexOf('@') < 0;
+    }
+
+    private static int FindAngleAddressStart(string value) {
+        bool quoted = false;
+        bool escaped = false;
+        int commentDepth = 0;
+        for (int index = 0; index < value.Length; index++) {
+            char character = value[index];
+            if (escaped) {
+                escaped = false;
+                continue;
+            }
+            if (character == '\\' && (quoted || commentDepth > 0)) {
+                escaped = true;
+                continue;
+            }
+            if (character == '"' && commentDepth == 0) {
+                quoted = !quoted;
+                continue;
+            }
+            if (quoted) continue;
+            if (character == '(') {
+                commentDepth++;
+                continue;
+            }
+            if (character == ')' && commentDepth > 0) {
+                commentDepth--;
+                continue;
+            }
+            if (character == '<' && commentDepth == 0) return index;
+        }
+        return -1;
+    }
+
+    private static bool HasOnlyCommentsAfter(string value, int offset) {
+        int commentDepth = 0;
+        bool escaped = false;
+        for (int index = offset; index < value.Length; index++) {
+            char character = value[index];
+            if (escaped) {
+                escaped = false;
+                continue;
+            }
+            if (character == '\\' && commentDepth > 0) {
+                escaped = true;
+                continue;
+            }
+            if (character == '(') {
+                commentDepth++;
+            } else if (character == ')' && commentDepth > 0) {
+                commentDepth--;
+            } else if (commentDepth == 0 && !char.IsWhiteSpace(character) && character != '"') {
+                return false;
+            }
+        }
+        return commentDepth == 0;
+    }
+
+    private static bool IsCommentOnly(string value) {
+        int depth = 0;
+        bool escaped = false;
+        bool sawComment = false;
+        for (int index = 0; index < value.Length; index++) {
+            char character = value[index];
+            if (escaped) {
+                escaped = false;
+                continue;
+            }
+            if (character == '\\' && depth > 0) {
+                escaped = true;
+                continue;
+            }
+            if (character == '(') {
+                depth++;
+                sawComment = true;
+            } else if (character == ')' && depth > 0) {
+                depth--;
+            } else if (depth == 0 && !char.IsWhiteSpace(character)) {
+                return false;
+            }
+        }
+        return sawComment && depth == 0;
+    }
+
+    private static bool TryParseAddressWithTrailingComment(string value, out EmailAddress? address) {
+        address = null;
+        int open = value.IndexOf('(');
+        if (open <= 0) return false;
+        int close = value.LastIndexOf(')');
+        if (close <= open || value.Substring(close + 1).Trim().Length != 0) return false;
+        string addressText = value.Substring(0, open).Trim();
+        if (addressText.Length == 0 || addressText.IndexOfAny(new[] { ' ', '\t', '<', '>' }) >= 0) return false;
+        string displayName = DecodeDisplayName(value.Substring(open + 1, close - open - 1));
+        address = new EmailAddress(addressText, displayName.Length == 0 ? null : displayName, value);
+        return true;
     }
 
     private static string DecodeDisplayName(string value) {

--- a/OfficeIMO.Email/Mime/MimeFlowedTextCodec.cs
+++ b/OfficeIMO.Email/Mime/MimeFlowedTextCodec.cs
@@ -1,0 +1,70 @@
+namespace OfficeIMO.Email;
+
+/// <summary>
+/// Decodes RFC 3676 format=flowed plain text into the message model's logical text representation.
+/// </summary>
+internal static class MimeFlowedTextCodec {
+    internal static string Decode(string value, bool deleteSpace) {
+        if (string.IsNullOrEmpty(value)) return value;
+
+        string newline = DetectNewline(value);
+        string normalized = value.Replace("\r\n", "\n").Replace('\r', '\n');
+        string[] lines = normalized.Split('\n');
+        StringBuilder output = new StringBuilder(value.Length);
+
+        for (int index = 0; index < lines.Length; index++) {
+            FlowedLine current = Parse(lines[index]);
+            output.Append(current.QuotePrefix);
+
+            while (IsFlowed(current) && index + 1 < lines.Length) {
+                FlowedLine next = Parse(lines[index + 1]);
+                if (next.QuoteDepth != current.QuoteDepth) break;
+
+                output.Append(deleteSpace
+                    ? current.Content.Substring(0, current.Content.Length - 1)
+                    : current.Content);
+                current = next;
+                index++;
+            }
+
+            if (deleteSpace && IsFlowed(current) && index + 1 == lines.Length) {
+                output.Append(current.Content.Substring(0, current.Content.Length - 1));
+            } else {
+                output.Append(current.Content);
+            }
+            if (index + 1 < lines.Length) output.Append(newline);
+        }
+
+        return output.ToString();
+    }
+
+    private static FlowedLine Parse(string physicalLine) {
+        string line = physicalLine.Length > 0 && physicalLine[0] == ' '
+            ? physicalLine.Substring(1)
+            : physicalLine;
+        int quoteDepth = 0;
+        while (quoteDepth < line.Length && line[quoteDepth] == '>') quoteDepth++;
+        return new FlowedLine(line.Substring(0, quoteDepth), line.Substring(quoteDepth), quoteDepth);
+    }
+
+    private static bool IsFlowed(FlowedLine line) => line.Content.EndsWith(" ", StringComparison.Ordinal) &&
+        !string.Equals(line.Content, "-- ", StringComparison.Ordinal);
+
+    private static string DetectNewline(string value) {
+        if (value.IndexOf("\r\n", StringComparison.Ordinal) >= 0) return "\r\n";
+        if (value.IndexOf('\r') >= 0) return "\r";
+        return "\n";
+    }
+
+    private readonly struct FlowedLine {
+        internal FlowedLine(string quotePrefix, string content, int quoteDepth) {
+            QuotePrefix = quotePrefix;
+            Content = content;
+            QuoteDepth = quoteDepth;
+        }
+
+        internal string QuotePrefix { get; }
+        internal string Content { get; }
+        internal int QuoteDepth { get; }
+    }
+}

--- a/OfficeIMO.Email/Mime/MimeMessageMetadataProjection.cs
+++ b/OfficeIMO.Email/Mime/MimeMessageMetadataProjection.cs
@@ -1,0 +1,92 @@
+namespace OfficeIMO.Email;
+
+internal static class MimeMessageMetadataProjection {
+    internal static void Apply(EmailDocument document, IReadOnlyList<EmailHeader> headers) {
+        string? importance = MimeHeaderParser.GetValue(headers, "Importance");
+        document.MessageMetadata.Importance = ParseImportance(importance) ??
+            ParseXPriority(MimeHeaderParser.GetValue(headers, "X-Priority"));
+        document.MessageMetadata.Priority = ParsePriority(MimeHeaderParser.GetValue(headers, "Priority"));
+        document.MessageMetadata.Sensitivity = ParseSensitivity(MimeHeaderParser.GetValue(headers, "Sensitivity"));
+        document.MessageMetadata.ReadReceiptRequested =
+            !string.IsNullOrWhiteSpace(MimeHeaderParser.GetValue(headers, "Disposition-Notification-To"));
+        document.MessageMetadata.DeliveryReceiptRequested =
+            !string.IsNullOrWhiteSpace(MimeHeaderParser.GetValue(headers, "Return-Receipt-To"));
+        document.MessageMetadata.IsDraft = IsTrue(MimeHeaderParser.GetValue(headers, "X-Unsent"));
+        string? status = MimeHeaderParser.GetValue(headers, "Status");
+        if (!string.IsNullOrWhiteSpace(status)) {
+            document.MessageMetadata.IsRead = status!.IndexOf('R') >= 0;
+        }
+        foreach (string value in MimeHeaderParser.GetValues(headers, "Keywords")) {
+            foreach (string category in value.Split(',')) {
+                string trimmed = category.Trim();
+                if (trimmed.Length > 0 && !document.MessageMetadata.Categories.Contains(trimmed)) {
+                    document.MessageMetadata.Categories.Add(trimmed);
+                }
+            }
+        }
+    }
+
+    internal static IEnumerable<EmailHeader> CreateHeaders(EmailDocument document) {
+        EmailMessageMetadata metadata = document.MessageMetadata;
+        if (metadata.Importance.HasValue) {
+            string value = metadata.Importance.Value == EmailMessageImportance.High ? "high" :
+                metadata.Importance.Value == EmailMessageImportance.Low ? "low" : "normal";
+            yield return new EmailHeader("Importance", value);
+            yield return new EmailHeader("X-Priority", metadata.Importance.Value == EmailMessageImportance.High
+                ? "1 (Highest)" : metadata.Importance.Value == EmailMessageImportance.Low ? "5 (Lowest)" : "3 (Normal)");
+        }
+        if (metadata.Priority.HasValue) {
+            yield return new EmailHeader("Priority", metadata.Priority.Value == EmailMessagePriority.Urgent
+                ? "urgent" : metadata.Priority.Value == EmailMessagePriority.NonUrgent ? "non-urgent" : "normal");
+        }
+        if (metadata.Sensitivity.HasValue && metadata.Sensitivity.Value > 0) {
+            string value = metadata.Sensitivity.Value == 1 ? "Personal" : metadata.Sensitivity.Value == 2
+                ? "Private" : "Company-Confidential";
+            yield return new EmailHeader("Sensitivity", value);
+        }
+        string? receiptAddress = document.Sender?.Address ?? document.From?.Address;
+        if (!string.IsNullOrWhiteSpace(receiptAddress) && metadata.ReadReceiptRequested) {
+            yield return new EmailHeader("Disposition-Notification-To", receiptAddress!);
+        }
+        if (!string.IsNullOrWhiteSpace(receiptAddress) && metadata.DeliveryReceiptRequested) {
+            yield return new EmailHeader("Return-Receipt-To", receiptAddress!);
+        }
+        if (metadata.IsDraft) yield return new EmailHeader("X-Unsent", "1");
+        if (metadata.IsRead.HasValue) yield return new EmailHeader("Status", metadata.IsRead.Value ? "RO" : "O");
+        if (metadata.Categories.Count > 0) {
+            yield return new EmailHeader("Keywords", string.Join(", ", metadata.Categories));
+        }
+    }
+
+    private static EmailMessageImportance? ParseImportance(string? value) {
+        if (string.Equals(value, "high", StringComparison.OrdinalIgnoreCase)) return EmailMessageImportance.High;
+        if (string.Equals(value, "low", StringComparison.OrdinalIgnoreCase)) return EmailMessageImportance.Low;
+        if (string.Equals(value, "normal", StringComparison.OrdinalIgnoreCase)) return EmailMessageImportance.Normal;
+        return null;
+    }
+
+    private static EmailMessageImportance? ParseXPriority(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        char first = value!.Trim()[0];
+        return first == '1' || first == '2' ? EmailMessageImportance.High : first == '4' || first == '5'
+            ? EmailMessageImportance.Low : first == '3' ? EmailMessageImportance.Normal : (EmailMessageImportance?)null;
+    }
+
+    private static EmailMessagePriority? ParsePriority(string? value) {
+        if (string.Equals(value, "urgent", StringComparison.OrdinalIgnoreCase)) return EmailMessagePriority.Urgent;
+        if (string.Equals(value, "non-urgent", StringComparison.OrdinalIgnoreCase)) return EmailMessagePriority.NonUrgent;
+        if (string.Equals(value, "normal", StringComparison.OrdinalIgnoreCase)) return EmailMessagePriority.Normal;
+        return null;
+    }
+
+    private static int? ParseSensitivity(string? value) {
+        if (string.Equals(value, "Personal", StringComparison.OrdinalIgnoreCase)) return 1;
+        if (string.Equals(value, "Private", StringComparison.OrdinalIgnoreCase)) return 2;
+        if (string.Equals(value, "Company-Confidential", StringComparison.OrdinalIgnoreCase)) return 3;
+        return null;
+    }
+
+    private static bool IsTrue(string? value) => string.Equals(value, "1", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase);
+}

--- a/OfficeIMO.Email/Mime/MimeMessageMetadataProjection.cs
+++ b/OfficeIMO.Email/Mime/MimeMessageMetadataProjection.cs
@@ -7,10 +7,12 @@ internal static class MimeMessageMetadataProjection {
             ParseXPriority(MimeHeaderParser.GetValue(headers, "X-Priority"));
         document.MessageMetadata.Priority = ParsePriority(MimeHeaderParser.GetValue(headers, "Priority"));
         document.MessageMetadata.Sensitivity = ParseSensitivity(MimeHeaderParser.GetValue(headers, "Sensitivity"));
-        document.MessageMetadata.ReadReceiptRequested =
-            !string.IsNullOrWhiteSpace(MimeHeaderParser.GetValue(headers, "Disposition-Notification-To"));
-        document.MessageMetadata.DeliveryReceiptRequested =
-            !string.IsNullOrWhiteSpace(MimeHeaderParser.GetValue(headers, "Return-Receipt-To"));
+        string? readReceiptDestination = MimeHeaderParser.GetValue(headers, "Disposition-Notification-To");
+        document.MessageMetadata.ReadReceiptDestination = readReceiptDestination;
+        document.MessageMetadata.ReadReceiptRequested = !string.IsNullOrWhiteSpace(readReceiptDestination);
+        string? deliveryReceiptDestination = MimeHeaderParser.GetValue(headers, "Return-Receipt-To");
+        document.MessageMetadata.DeliveryReceiptDestination = deliveryReceiptDestination;
+        document.MessageMetadata.DeliveryReceiptRequested = !string.IsNullOrWhiteSpace(deliveryReceiptDestination);
         document.MessageMetadata.IsDraft = IsTrue(MimeHeaderParser.GetValue(headers, "X-Unsent"));
         string? status = MimeHeaderParser.GetValue(headers, "Status");
         if (!string.IsNullOrWhiteSpace(status)) {
@@ -44,12 +46,14 @@ internal static class MimeMessageMetadataProjection {
                 ? "Private" : "Company-Confidential";
             yield return new EmailHeader("Sensitivity", value);
         }
-        string? receiptAddress = document.Sender?.Address ?? document.From?.Address;
-        if (!string.IsNullOrWhiteSpace(receiptAddress) && metadata.ReadReceiptRequested) {
-            yield return new EmailHeader("Disposition-Notification-To", receiptAddress!);
+        string? fallbackReceiptDestination = document.Sender?.Address ?? document.From?.Address;
+        string? readReceiptDestination = metadata.ReadReceiptDestination ?? fallbackReceiptDestination;
+        if (!string.IsNullOrWhiteSpace(readReceiptDestination) && metadata.ReadReceiptRequested) {
+            yield return new EmailHeader("Disposition-Notification-To", readReceiptDestination!);
         }
-        if (!string.IsNullOrWhiteSpace(receiptAddress) && metadata.DeliveryReceiptRequested) {
-            yield return new EmailHeader("Return-Receipt-To", receiptAddress!);
+        string? deliveryReceiptDestination = metadata.DeliveryReceiptDestination ?? fallbackReceiptDestination;
+        if (!string.IsNullOrWhiteSpace(deliveryReceiptDestination) && metadata.DeliveryReceiptRequested) {
+            yield return new EmailHeader("Return-Receipt-To", deliveryReceiptDestination!);
         }
         if (metadata.IsDraft) yield return new EmailHeader("X-Unsent", "1");
         if (metadata.IsRead.HasValue) yield return new EmailHeader("Status", metadata.IsRead.Value ? "RO" : "O");

--- a/OfficeIMO.Email/Mime/MimeMessageMetadataProjection.cs
+++ b/OfficeIMO.Email/Mime/MimeMessageMetadataProjection.cs
@@ -19,7 +19,7 @@ internal static class MimeMessageMetadataProjection {
             document.MessageMetadata.IsRead = status!.IndexOf('R') >= 0;
         }
         foreach (string value in MimeHeaderParser.GetValues(headers, "Keywords")) {
-            foreach (string category in value.Split(',')) {
+            foreach (string category in SplitKeywords(value)) {
                 string trimmed = category.Trim();
                 if (trimmed.Length > 0 && !document.MessageMetadata.Categories.Contains(trimmed)) {
                     document.MessageMetadata.Categories.Add(trimmed);
@@ -58,8 +58,38 @@ internal static class MimeMessageMetadataProjection {
         if (metadata.IsDraft) yield return new EmailHeader("X-Unsent", "1");
         if (metadata.IsRead.HasValue) yield return new EmailHeader("Status", metadata.IsRead.Value ? "RO" : "O");
         if (metadata.Categories.Count > 0) {
-            yield return new EmailHeader("Keywords", string.Join(", ", metadata.Categories));
+            yield return new EmailHeader("Keywords", string.Join(", ", metadata.Categories.Select(FormatKeyword)));
         }
+    }
+
+    private static IEnumerable<string> SplitKeywords(string value) {
+        var current = new StringBuilder();
+        bool quoted = false;
+        bool escaped = false;
+        foreach (char character in value) {
+            if (escaped) {
+                current.Append(character);
+                escaped = false;
+            } else if (character == '\\' && quoted) {
+                escaped = true;
+            } else if (character == '"') {
+                quoted = !quoted;
+            } else if (character == ',' && !quoted) {
+                yield return current.ToString();
+                current.Clear();
+            } else {
+                current.Append(character);
+            }
+        }
+        if (escaped) current.Append('\\');
+        yield return current.ToString();
+    }
+
+    private static string FormatKeyword(string value) {
+        string sanitized = value.Replace("\r", string.Empty).Replace("\n", string.Empty).Trim();
+        return sanitized.IndexOfAny(new[] { ',', '"', '\\' }) < 0
+            ? sanitized
+            : string.Concat("\"", sanitized.Replace("\\", "\\\\").Replace("\"", "\\\""), "\"");
     }
 
     private static EmailMessageImportance? ParseImportance(string? value) {

--- a/OfficeIMO.Email/Mime/MimeMessageMetadataProjection.cs
+++ b/OfficeIMO.Email/Mime/MimeMessageMetadataProjection.cs
@@ -7,12 +7,7 @@ internal static class MimeMessageMetadataProjection {
             ParseXPriority(MimeHeaderParser.GetValue(headers, "X-Priority"));
         document.MessageMetadata.Priority = ParsePriority(MimeHeaderParser.GetValue(headers, "Priority"));
         document.MessageMetadata.Sensitivity = ParseSensitivity(MimeHeaderParser.GetValue(headers, "Sensitivity"));
-        string? readReceiptDestination = MimeHeaderParser.GetValue(headers, "Disposition-Notification-To");
-        document.MessageMetadata.ReadReceiptDestination = readReceiptDestination;
-        document.MessageMetadata.ReadReceiptRequested = !string.IsNullOrWhiteSpace(readReceiptDestination);
-        string? deliveryReceiptDestination = MimeHeaderParser.GetValue(headers, "Return-Receipt-To");
-        document.MessageMetadata.DeliveryReceiptDestination = deliveryReceiptDestination;
-        document.MessageMetadata.DeliveryReceiptRequested = !string.IsNullOrWhiteSpace(deliveryReceiptDestination);
+        ApplyReceiptDestinations(document, headers);
         document.MessageMetadata.IsDraft = IsTrue(MimeHeaderParser.GetValue(headers, "X-Unsent"));
         string? status = MimeHeaderParser.GetValue(headers, "Status");
         if (!string.IsNullOrWhiteSpace(status)) {
@@ -25,6 +20,19 @@ internal static class MimeMessageMetadataProjection {
                     document.MessageMetadata.Categories.Add(trimmed);
                 }
             }
+        }
+    }
+
+    internal static void ApplyReceiptDestinations(EmailDocument document, IReadOnlyList<EmailHeader> headers) {
+        string? readReceiptDestination = MimeHeaderParser.GetValue(headers, "Disposition-Notification-To");
+        if (!string.IsNullOrWhiteSpace(readReceiptDestination)) {
+            document.MessageMetadata.ReadReceiptDestination = readReceiptDestination;
+            document.MessageMetadata.ReadReceiptRequested = true;
+        }
+        string? deliveryReceiptDestination = MimeHeaderParser.GetValue(headers, "Return-Receipt-To");
+        if (!string.IsNullOrWhiteSpace(deliveryReceiptDestination)) {
+            document.MessageMetadata.DeliveryReceiptDestination = deliveryReceiptDestination;
+            document.MessageMetadata.DeliveryReceiptRequested = true;
         }
     }
 

--- a/OfficeIMO.Email/Mime/MimeParser.cs
+++ b/OfficeIMO.Email/Mime/MimeParser.cs
@@ -187,14 +187,22 @@ internal static class MimeParser {
             state.Options.IncludeAttachmentContent || semanticBodyPart ? decoded : null, decoded.LongLength);
         if (semanticBodyPart) attachment.IsMimeBodyPart = true;
         string? semanticCharset = contentType.GetParameter("charset");
+        int semanticDiagnosticStart = state.Diagnostics.Count;
+        bool shouldProjectSemantic = attachment.IsMimeBodyPart && (calendarContent || vcardContent);
+        string? semanticText = shouldProjectSemantic
+            ? MimeTextCodec.DecodeText(decoded, semanticCharset, state.Diagnostics, location)
+            : null;
+        bool semanticCharsetFallback = state.Diagnostics.Skip(semanticDiagnosticStart).Any(diagnostic =>
+            diagnostic.Code == "EMAIL_MIME_CHARSET_UNSUPPORTED");
         if (calendarContent && attachment.IsMimeBodyPart && IcsCalendarCodec.TryProject(
-                MimeTextCodec.DecodeText(decoded, semanticCharset, state.Diagnostics, location),
-                document, state.Diagnostics, location, contentType.GetParameter("method"))) {
+                semanticText!, document, state.Diagnostics, location, contentType.GetParameter("method"))) {
             attachment.IsProjectedSemanticContent = true;
         } else if (vcardContent && attachment.IsMimeBodyPart && VCardCodec.TryProject(
-                       MimeTextCodec.DecodeText(decoded, semanticCharset, state.Diagnostics, location),
-                       document, state.Diagnostics, location)) {
+                       semanticText!, document, state.Diagnostics, location)) {
             attachment.IsProjectedSemanticContent = true;
+        }
+        if (attachment.IsProjectedSemanticContent && semanticCharsetFallback) {
+            document.MimeSemanticProjectionIsIncomplete = true;
         }
         if (attachment.IsProjectedSemanticContent && document.Attachments.Any(existing =>
             existing.IsProjectedSemanticContent)) document.MimeSemanticProjectionIsIncomplete = true;

--- a/OfficeIMO.Email/Mime/MimeParser.cs
+++ b/OfficeIMO.Email/Mime/MimeParser.cs
@@ -15,10 +15,15 @@ internal static class MimeParser {
         int bodyOffset = MimeHeaderParser.Parse(data, offset, count, state.Options, headers, state.Diagnostics, location);
         foreach (EmailHeader header in headers) document.Headers.Add(header);
         PopulateEnvelope(document, headers, state.Diagnostics, location);
+        MimeMessageMetadataProjection.Apply(document, headers);
 
         int end = offset + count;
         int bodyCount = Math.Max(0, end - bodyOffset);
         ParseEntity(headers, data, bodyOffset, bodyCount, document, state, 0, nestedMessageDepth, location);
+        MimeProtectionProjection.Apply(document, headers, state.Diagnostics, location);
+        if (document.Attachments.Any(attachment => attachment.IsProjectedSemanticContent)) {
+            document.MimeSemanticSourceModelFingerprint = EmailDocumentStateFingerprint.TryCompute(document);
+        }
         return document;
     }
 
@@ -52,11 +57,17 @@ internal static class MimeParser {
             !attachmentDisposition && string.IsNullOrWhiteSpace(fileName) &&
             (!isRelatedSibling || !hasRelatedIdentity || isPreferredRelatedBody)) {
             string? boundary = contentType.GetParameter("boundary");
-            if (string.IsNullOrEmpty(boundary)) {
+            if (boundary == null) {
                 state.Diagnostics.Add(new EmailDiagnostic("EMAIL_MIME_BOUNDARY_MISSING",
                     string.Concat("Multipart entity '", contentType.Value, "' has no boundary."),
-                    EmailDiagnosticSeverity.Error, location));
+                    EmailDiagnosticSeverity.Warning, location));
                 return;
+            }
+            if (boundary.Length == 0) {
+                state.Diagnostics.Add(new EmailDiagnostic("EMAIL_MIME_BOUNDARY_EMPTY",
+                    string.Concat("Multipart entity '", contentType.Value,
+                        "' declares an empty boundary; compatible recovery was attempted."),
+                    EmailDiagnosticSeverity.Warning, location));
             }
 
             List<ArraySegment<byte>> parts = SplitMultipart(data, offset, count, boundary!, state, location);
@@ -102,7 +113,10 @@ internal static class MimeParser {
         bool additionalInlineBody = isBodyCandidate && !bodySlotAvailable;
         bool embeddedMessage = string.Equals(contentType.Value, "message/rfc822", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(contentType.Value, "message/global", StringComparison.OrdinalIgnoreCase);
-        bool skipAttachmentDecoding = !isBody && !state.Options.IncludeAttachmentContent && !embeddedMessage;
+        bool calendarContent = string.Equals(contentType.Value, "text/calendar", StringComparison.OrdinalIgnoreCase);
+        bool vcardContent = VCardCodec.IsVCardContentType(contentType.Value);
+        bool skipAttachmentDecoding = !isBody && !state.Options.IncludeAttachmentContent && !embeddedMessage &&
+            !calendarContent && !vcardContent;
         long decodedLength = isBody ? 0 : MimeTextCodec.GetDecodedLength(data, offset, count, transferEncoding,
             skipAttachmentDecoding ? state.Diagnostics : null, skipAttachmentDecoding ? location : null);
         if (!isBody) {
@@ -121,6 +135,12 @@ internal static class MimeParser {
         if (isBody) {
             string? charset = contentType.GetParameter("charset");
             string text = MimeTextCodec.DecodeText(decoded, charset, state.Diagnostics, location);
+            if (string.Equals(contentType.Value, "text/plain", StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(contentType.GetParameter("format"), "flowed", StringComparison.OrdinalIgnoreCase)) {
+                bool deleteSpace = string.Equals(contentType.GetParameter("delsp"), "yes",
+                    StringComparison.OrdinalIgnoreCase);
+                text = MimeFlowedTextCodec.Decode(text, deleteSpace);
+            }
             if (string.Equals(contentType.Value, "text/rtf", StringComparison.OrdinalIgnoreCase)) {
                 if (document.Body.Rtf == null) document.Body.Rtf = text;
             } else if (string.Equals(contentType.Value, "text/html", StringComparison.OrdinalIgnoreCase)) {
@@ -152,8 +172,15 @@ internal static class MimeParser {
         }
 
         state.CountAttachment(decoded.LongLength);
-        document.Attachments.Add(CreateAttachment(headers, contentType, disposition, fileName,
-            inlineDisposition || additionalInlineBody, decoded, decoded.LongLength));
+        EmailAttachment attachment = CreateAttachment(headers, contentType, disposition, fileName,
+            inlineDisposition || additionalInlineBody,
+            state.Options.IncludeAttachmentContent || calendarContent || vcardContent ? decoded : null, decoded.LongLength);
+        if (calendarContent && IcsCalendarCodec.TryProject(decoded, document, state.Diagnostics, location)) {
+            attachment.IsProjectedSemanticContent = true;
+        } else if (vcardContent && VCardCodec.TryProject(decoded, document)) {
+            attachment.IsProjectedSemanticContent = true;
+        }
+        document.Attachments.Add(attachment);
     }
 
     private static EmailAttachment CreateAttachment(IReadOnlyList<EmailHeader> headers, MimeValue contentType,
@@ -266,7 +293,7 @@ internal static class MimeParser {
         if (partStart < 0) {
             state.Diagnostics.Add(new EmailDiagnostic("EMAIL_MIME_BOUNDARY_NOT_FOUND",
                 string.Concat("Multipart boundary '", boundary, "' was not found."),
-                EmailDiagnosticSeverity.Error, location));
+                EmailDiagnosticSeverity.Warning, location));
         }
         return parts;
     }

--- a/OfficeIMO.Email/Mime/MimeParser.cs
+++ b/OfficeIMO.Email/Mime/MimeParser.cs
@@ -317,7 +317,7 @@ internal static class MimeParser {
         if (partStart < 0) {
             state.Diagnostics.Add(new EmailDiagnostic("EMAIL_MIME_BOUNDARY_NOT_FOUND",
                 string.Concat("Multipart boundary '", boundary, "' was not found."),
-                EmailDiagnosticSeverity.Warning, location));
+                EmailDiagnosticSeverity.Error, location));
         }
         return parts;
     }

--- a/OfficeIMO.Email/Mime/MimeParser.cs
+++ b/OfficeIMO.Email/Mime/MimeParser.cs
@@ -124,7 +124,7 @@ internal static class MimeParser {
             if (skipAttachmentDecoding) {
                 state.CountAttachment(decodedLength);
                 document.Attachments.Add(CreateAttachment(headers, contentType, disposition, fileName,
-                    inlineDisposition || additionalInlineBody, null, decodedLength));
+                    inlineDisposition || additionalInlineBody, attachmentDisposition, null, decodedLength));
                 return;
             }
         }
@@ -158,7 +158,8 @@ internal static class MimeParser {
         if (embeddedMessage) {
             state.CountAttachment(decoded.LongLength);
             EmailAttachment embedded = CreateAttachment(headers, contentType, disposition, fileName,
-                inlineDisposition, state.Options.IncludeAttachmentContent ? decoded : null, decoded.LongLength);
+                inlineDisposition, attachmentDisposition, state.Options.IncludeAttachmentContent ? decoded : null,
+                decoded.LongLength);
             if (nestedMessageDepth >= state.Options.MaxNestedMessageDepth) {
                 state.Diagnostics.Add(new EmailDiagnostic("EMAIL_MIME_NESTED_MESSAGE_LIMIT",
                     "The embedded message was retained but not parsed because the nested-message limit was reached.",
@@ -173,18 +174,23 @@ internal static class MimeParser {
 
         state.CountAttachment(decoded.LongLength);
         EmailAttachment attachment = CreateAttachment(headers, contentType, disposition, fileName,
-            inlineDisposition || additionalInlineBody,
+            inlineDisposition || additionalInlineBody, attachmentDisposition,
             state.Options.IncludeAttachmentContent || calendarContent || vcardContent ? decoded : null, decoded.LongLength);
-        if (calendarContent && IcsCalendarCodec.TryProject(decoded, document, state.Diagnostics, location)) {
+        string? semanticCharset = contentType.GetParameter("charset");
+        if (calendarContent && IcsCalendarCodec.TryProject(
+                MimeTextCodec.DecodeText(decoded, semanticCharset, state.Diagnostics, location),
+                document, state.Diagnostics, location)) {
             attachment.IsProjectedSemanticContent = true;
-        } else if (vcardContent && VCardCodec.TryProject(decoded, document)) {
+        } else if (vcardContent && VCardCodec.TryProject(
+                       MimeTextCodec.DecodeText(decoded, semanticCharset, state.Diagnostics, location), document)) {
             attachment.IsProjectedSemanticContent = true;
         }
         document.Attachments.Add(attachment);
     }
 
     private static EmailAttachment CreateAttachment(IReadOnlyList<EmailHeader> headers, MimeValue contentType,
-        MimeValue disposition, string? fileName, bool inlineDisposition, byte[]? content, long length) {
+        MimeValue disposition, string? fileName, bool inlineDisposition, bool attachmentDisposition,
+        byte[]? content, long length) {
         var attachment = new EmailAttachment {
             FileName = fileName,
             ContentType = contentType.Value,
@@ -194,7 +200,12 @@ internal static class MimeParser {
                 !string.IsNullOrWhiteSpace(MimeHeaderParser.GetValue(headers, "Content-ID")) ||
                 !string.IsNullOrWhiteSpace(MimeHeaderParser.GetValue(headers, "Content-Location")),
             Length = length,
-            Content = content
+            Content = content,
+            IsMimeAttachment = attachmentDisposition,
+            IsMimeBodyPart = !attachmentDisposition && !inlineDisposition &&
+                string.IsNullOrWhiteSpace(fileName) &&
+                string.IsNullOrWhiteSpace(MimeHeaderParser.GetValue(headers, "Content-ID")) &&
+                string.IsNullOrWhiteSpace(MimeHeaderParser.GetValue(headers, "Content-Location"))
         };
         foreach (KeyValuePair<string, string> parameter in contentType.Parameters) {
             if (!string.Equals(parameter.Key, "name", StringComparison.OrdinalIgnoreCase)) {

--- a/OfficeIMO.Email/Mime/MimeParser.cs
+++ b/OfficeIMO.Email/Mime/MimeParser.cs
@@ -181,7 +181,7 @@ internal static class MimeParser {
                 MimeTextCodec.DecodeText(decoded, semanticCharset, state.Diagnostics, location),
                 document, state.Diagnostics, location)) {
             attachment.IsProjectedSemanticContent = true;
-        } else if (vcardContent && VCardCodec.TryProject(
+        } else if (vcardContent && attachment.IsMimeBodyPart && VCardCodec.TryProject(
                        MimeTextCodec.DecodeText(decoded, semanticCharset, state.Diagnostics, location), document)) {
             attachment.IsProjectedSemanticContent = true;
         }

--- a/OfficeIMO.Email/Mime/MimeParser.cs
+++ b/OfficeIMO.Email/Mime/MimeParser.cs
@@ -184,10 +184,11 @@ internal static class MimeParser {
         string? semanticCharset = contentType.GetParameter("charset");
         if (calendarContent && attachment.IsMimeBodyPart && IcsCalendarCodec.TryProject(
                 MimeTextCodec.DecodeText(decoded, semanticCharset, state.Diagnostics, location),
-                document, state.Diagnostics, location)) {
+                document, state.Diagnostics, location, contentType.GetParameter("method"))) {
             attachment.IsProjectedSemanticContent = true;
         } else if (vcardContent && attachment.IsMimeBodyPart && VCardCodec.TryProject(
-                       MimeTextCodec.DecodeText(decoded, semanticCharset, state.Diagnostics, location), document)) {
+                       MimeTextCodec.DecodeText(decoded, semanticCharset, state.Diagnostics, location),
+                       document, state.Diagnostics, location)) {
             attachment.IsProjectedSemanticContent = true;
         }
         if (attachment.IsProjectedSemanticContent && document.Attachments.Any(existing =>

--- a/OfficeIMO.Email/Mime/MimeParser.cs
+++ b/OfficeIMO.Email/Mime/MimeParser.cs
@@ -204,6 +204,10 @@ internal static class MimeParser {
         if (attachment.IsProjectedSemanticContent && semanticCharsetFallback) {
             document.MimeSemanticProjectionIsIncomplete = true;
         }
+        if (attachment.IsProjectedSemanticContent && vcardContent &&
+            HasUnpreservedVCardContentType(contentType)) {
+            document.MimeSemanticProjectionIsIncomplete = true;
+        }
         if (attachment.IsProjectedSemanticContent && mimeDepth > 0 &&
             HasUnpreservedSemanticPartHeaders(headers)) {
             document.MimeSemanticProjectionIsIncomplete = true;
@@ -217,6 +221,11 @@ internal static class MimeParser {
         headers.Any(header =>
             !header.Name.Equals("Content-Type", StringComparison.OrdinalIgnoreCase) &&
             !header.Name.Equals("Content-Transfer-Encoding", StringComparison.OrdinalIgnoreCase));
+
+    private static bool HasUnpreservedVCardContentType(MimeValue contentType) =>
+        !contentType.Value.Equals("text/vcard", StringComparison.OrdinalIgnoreCase) ||
+        contentType.Parameters.Keys.Any(parameter =>
+            !parameter.Equals("charset", StringComparison.OrdinalIgnoreCase));
 
     private static EmailAttachment CreateAttachment(IReadOnlyList<EmailHeader> headers, MimeValue contentType,
         MimeValue disposition, string? fileName, bool inlineDisposition, bool attachmentDisposition,

--- a/OfficeIMO.Email/Mime/MimeParser.cs
+++ b/OfficeIMO.Email/Mime/MimeParser.cs
@@ -114,7 +114,7 @@ internal static class MimeParser {
         bool embeddedMessage = string.Equals(contentType.Value, "message/rfc822", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(contentType.Value, "message/global", StringComparison.OrdinalIgnoreCase);
         bool calendarContent = string.Equals(contentType.Value, "text/calendar", StringComparison.OrdinalIgnoreCase);
-        bool vcardContent = VCardCodec.IsVCardContentType(contentType.Value);
+        bool vcardContent = VCardCodec.IsVCardContentType(contentType.Value, contentType.GetParameter("profile"));
         bool skipAttachmentDecoding = !isBody && !state.Options.IncludeAttachmentContent && !embeddedMessage &&
             !calendarContent && !vcardContent;
         long decodedLength = isBody ? 0 : MimeTextCodec.GetDecodedLength(data, offset, count, transferEncoding,

--- a/OfficeIMO.Email/Mime/MimeParser.cs
+++ b/OfficeIMO.Email/Mime/MimeParser.cs
@@ -21,7 +21,12 @@ internal static class MimeParser {
         int bodyCount = Math.Max(0, end - bodyOffset);
         ParseEntity(headers, data, bodyOffset, bodyCount, document, state, 0, nestedMessageDepth, location);
         MimeProtectionProjection.Apply(document, headers, state.Diagnostics, location);
-        if (document.Attachments.Any(attachment => attachment.IsProjectedSemanticContent)) {
+        bool hasSemanticContent = document.Attachments.Any(attachment => attachment.IsProjectedSemanticContent);
+        if (hasSemanticContent && document.MimeHasMessageBody && !document.MimeSemanticSourceHasTextBody &&
+            !string.IsNullOrWhiteSpace(document.Body.Text)) {
+            document.MimeSemanticProjectionIsIncomplete = true;
+        }
+        if (hasSemanticContent) {
             document.MimeSemanticSourceModelFingerprint = EmailDocumentStateFingerprint.TryCompute(document);
         }
         return document;

--- a/OfficeIMO.Email/Mime/MimeParser.cs
+++ b/OfficeIMO.Email/Mime/MimeParser.cs
@@ -133,6 +133,7 @@ internal static class MimeParser {
         byte[] decoded = MimeTextCodec.DecodeTransfer(source, transferEncoding, state.Diagnostics, location);
 
         if (isBody) {
+            document.MimeHasMessageBody = true;
             string? charset = contentType.GetParameter("charset");
             string text = MimeTextCodec.DecodeText(decoded, charset, state.Diagnostics, location);
             if (string.Equals(contentType.Value, "text/plain", StringComparison.OrdinalIgnoreCase) &&
@@ -177,7 +178,7 @@ internal static class MimeParser {
             inlineDisposition || additionalInlineBody, attachmentDisposition,
             state.Options.IncludeAttachmentContent || calendarContent || vcardContent ? decoded : null, decoded.LongLength);
         string? semanticCharset = contentType.GetParameter("charset");
-        if (calendarContent && IcsCalendarCodec.TryProject(
+        if (calendarContent && attachment.IsMimeBodyPart && IcsCalendarCodec.TryProject(
                 MimeTextCodec.DecodeText(decoded, semanticCharset, state.Diagnostics, location),
                 document, state.Diagnostics, location)) {
             attachment.IsProjectedSemanticContent = true;
@@ -185,6 +186,8 @@ internal static class MimeParser {
                        MimeTextCodec.DecodeText(decoded, semanticCharset, state.Diagnostics, location), document)) {
             attachment.IsProjectedSemanticContent = true;
         }
+        if (attachment.IsProjectedSemanticContent && document.Attachments.Any(existing =>
+            existing.IsProjectedSemanticContent)) document.MimeSemanticProjectionIsIncomplete = true;
         document.Attachments.Add(attachment);
     }
 

--- a/OfficeIMO.Email/Mime/MimeParser.cs
+++ b/OfficeIMO.Email/Mime/MimeParser.cs
@@ -115,8 +115,11 @@ internal static class MimeParser {
             string.Equals(contentType.Value, "message/global", StringComparison.OrdinalIgnoreCase);
         bool calendarContent = string.Equals(contentType.Value, "text/calendar", StringComparison.OrdinalIgnoreCase);
         bool vcardContent = VCardCodec.IsVCardContentType(contentType.Value, contentType.GetParameter("profile"));
+        bool semanticBodyPart = (calendarContent || vcardContent) && !attachmentDisposition &&
+            string.IsNullOrWhiteSpace(fileName) && string.IsNullOrWhiteSpace(contentId) &&
+            string.IsNullOrWhiteSpace(contentLocation);
         bool skipAttachmentDecoding = !isBody && !state.Options.IncludeAttachmentContent && !embeddedMessage &&
-            !calendarContent && !vcardContent;
+            !semanticBodyPart;
         long decodedLength = isBody ? 0 : MimeTextCodec.GetDecodedLength(data, offset, count, transferEncoding,
             skipAttachmentDecoding ? state.Diagnostics : null, skipAttachmentDecoding ? location : null);
         if (!isBody) {
@@ -176,7 +179,8 @@ internal static class MimeParser {
         state.CountAttachment(decoded.LongLength);
         EmailAttachment attachment = CreateAttachment(headers, contentType, disposition, fileName,
             inlineDisposition || additionalInlineBody, attachmentDisposition,
-            state.Options.IncludeAttachmentContent || calendarContent || vcardContent ? decoded : null, decoded.LongLength);
+            state.Options.IncludeAttachmentContent || semanticBodyPart ? decoded : null, decoded.LongLength);
+        if (semanticBodyPart) attachment.IsMimeBodyPart = true;
         string? semanticCharset = contentType.GetParameter("charset");
         if (calendarContent && attachment.IsMimeBodyPart && IcsCalendarCodec.TryProject(
                 MimeTextCodec.DecodeText(decoded, semanticCharset, state.Diagnostics, location),

--- a/OfficeIMO.Email/Mime/MimeParser.cs
+++ b/OfficeIMO.Email/Mime/MimeParser.cs
@@ -204,10 +204,19 @@ internal static class MimeParser {
         if (attachment.IsProjectedSemanticContent && semanticCharsetFallback) {
             document.MimeSemanticProjectionIsIncomplete = true;
         }
+        if (attachment.IsProjectedSemanticContent && mimeDepth > 0 &&
+            HasUnpreservedSemanticPartHeaders(headers)) {
+            document.MimeSemanticProjectionIsIncomplete = true;
+        }
         if (attachment.IsProjectedSemanticContent && document.Attachments.Any(existing =>
             existing.IsProjectedSemanticContent)) document.MimeSemanticProjectionIsIncomplete = true;
         document.Attachments.Add(attachment);
     }
+
+    private static bool HasUnpreservedSemanticPartHeaders(IEnumerable<EmailHeader> headers) =>
+        headers.Any(header =>
+            !header.Name.Equals("Content-Type", StringComparison.OrdinalIgnoreCase) &&
+            !header.Name.Equals("Content-Transfer-Encoding", StringComparison.OrdinalIgnoreCase));
 
     private static EmailAttachment CreateAttachment(IReadOnlyList<EmailHeader> headers, MimeValue contentType,
         MimeValue disposition, string? fileName, bool inlineDisposition, bool attachmentDisposition,

--- a/OfficeIMO.Email/Mime/MimeProtectionProjection.cs
+++ b/OfficeIMO.Email/Mime/MimeProtectionProjection.cs
@@ -1,0 +1,60 @@
+namespace OfficeIMO.Email;
+
+internal static class MimeProtectionProjection {
+    internal static void Apply(EmailDocument document, IReadOnlyList<EmailHeader> headers,
+        IList<EmailDiagnostic> diagnostics, string location) {
+        MimeValue contentType = MimeValueParser.Parse(MimeHeaderParser.GetValue(headers, "Content-Type"),
+            "text/plain", diagnostics, location);
+        string protocol = contentType.GetParameter("protocol") ?? string.Empty;
+        EmailProtectionKind kind = Classify(contentType.Value, protocol);
+        if (kind == EmailProtectionKind.None) return;
+
+        document.Protection.Kind = kind;
+        document.Protection.MessageClass = document.MessageClass;
+        document.Protection.PayloadAttachment = kind == EmailProtectionKind.PgpMimeEncrypted ||
+            kind == EmailProtectionKind.MimeEncrypted
+            ? document.Attachments.LastOrDefault(attachment => !IsEncryptionControlPart(attachment))
+            : document.Attachments.FirstOrDefault(IsProtectedPayload);
+        if (document.Protection.PayloadAttachment == null &&
+            !contentType.Value.StartsWith("multipart/", StringComparison.OrdinalIgnoreCase)) {
+            document.Protection.PayloadAttachment = document.Attachments.FirstOrDefault();
+        }
+    }
+
+    private static EmailProtectionKind Classify(string contentType, string protocol) {
+        if (string.Equals(contentType, "application/pkcs7-mime", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(contentType, "application/x-pkcs7-mime", StringComparison.OrdinalIgnoreCase)) {
+            return EmailProtectionKind.SmimeOpaque;
+        }
+        if (string.Equals(contentType, "multipart/signed", StringComparison.OrdinalIgnoreCase)) {
+            if (protocol.IndexOf("pkcs7-signature", StringComparison.OrdinalIgnoreCase) >= 0) {
+                return EmailProtectionKind.SmimeClearSigned;
+            }
+            if (protocol.IndexOf("pgp-signature", StringComparison.OrdinalIgnoreCase) >= 0) {
+                return EmailProtectionKind.PgpMimeClearSigned;
+            }
+            return EmailProtectionKind.MimeClearSigned;
+        }
+        if (string.Equals(contentType, "multipart/encrypted", StringComparison.OrdinalIgnoreCase)) {
+            return protocol.IndexOf("pgp-encrypted", StringComparison.OrdinalIgnoreCase) >= 0
+                ? EmailProtectionKind.PgpMimeEncrypted
+                : EmailProtectionKind.MimeEncrypted;
+        }
+        return EmailProtectionKind.None;
+    }
+
+    private static bool IsProtectedPayload(EmailAttachment attachment) {
+        string contentType = attachment.ContentType ?? string.Empty;
+        string fileName = attachment.FileName ?? string.Empty;
+        return contentType.IndexOf("pkcs7", StringComparison.OrdinalIgnoreCase) >= 0 ||
+            contentType.IndexOf("pgp-signature", StringComparison.OrdinalIgnoreCase) >= 0 ||
+            contentType.IndexOf("pgp-encrypted", StringComparison.OrdinalIgnoreCase) >= 0 ||
+            fileName.EndsWith(".p7m", StringComparison.OrdinalIgnoreCase) ||
+            fileName.EndsWith(".p7s", StringComparison.OrdinalIgnoreCase) ||
+            fileName.EndsWith(".asc", StringComparison.OrdinalIgnoreCase) ||
+            fileName.EndsWith(".pgp", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsEncryptionControlPart(EmailAttachment attachment) =>
+        string.Equals(attachment.ContentType, "application/pgp-encrypted", StringComparison.OrdinalIgnoreCase);
+}

--- a/OfficeIMO.Email/Mime/MimeTextCodec.cs
+++ b/OfficeIMO.Email/Mime/MimeTextCodec.cs
@@ -35,7 +35,18 @@ internal static class MimeTextCodec {
     }
 
     internal static string DecodeText(byte[] bytes, string? charset, IList<EmailDiagnostic> diagnostics, string location) {
-        string normalized = (charset ?? "utf-8").Trim().Trim('"').ToLowerInvariant();
+        if (string.IsNullOrWhiteSpace(charset)) {
+            try {
+                return new UTF8Encoding(false, true).GetString(bytes);
+            } catch (DecoderFallbackException) {
+                diagnostics.Add(new EmailDiagnostic("EMAIL_MIME_CHARSET_GUESSED",
+                    "The charsetless text was not valid UTF-8; Windows-1252 recovery was used.",
+                    EmailDiagnosticSeverity.Warning, location));
+                return DecodeWindows1252(bytes);
+            }
+        }
+
+        string normalized = charset!.Trim().Trim('"').ToLowerInvariant();
         try {
             switch (normalized) {
                 case "us-ascii":
@@ -110,7 +121,7 @@ internal static class MimeTextCodec {
                 if (diagnostics != null && !validBase64) {
                     diagnostics.Add(new EmailDiagnostic("EMAIL_MIME_BASE64_INVALID",
                         "The invalid Base64 payload was preserved without decoding.",
-                        EmailDiagnosticSeverity.Error, location));
+                        EmailDiagnosticSeverity.Warning, location));
                 } else if (diagnostics != null && recoveredPadding) {
                     diagnostics.Add(new EmailDiagnostic("EMAIL_MIME_BASE64_PADDING_RECOVERED",
                         "Missing Base64 padding was recovered.", EmailDiagnosticSeverity.Warning, location));
@@ -212,7 +223,8 @@ internal static class MimeTextCodec {
                     "Missing Base64 padding was recovered.", EmailDiagnosticSeverity.Warning, location));
                 return recovered;
             } catch (FormatException ex) {
-                diagnostics.Add(new EmailDiagnostic("EMAIL_MIME_BASE64_INVALID", ex.Message, EmailDiagnosticSeverity.Error, location));
+                diagnostics.Add(new EmailDiagnostic("EMAIL_MIME_BASE64_INVALID", ex.Message,
+                    EmailDiagnosticSeverity.Warning, location));
                 return Encoding.ASCII.GetBytes(value);
             }
         }

--- a/OfficeIMO.Email/Mime/MimeTextCodec.cs
+++ b/OfficeIMO.Email/Mime/MimeTextCodec.cs
@@ -121,7 +121,7 @@ internal static class MimeTextCodec {
                 if (diagnostics != null && !validBase64) {
                     diagnostics.Add(new EmailDiagnostic("EMAIL_MIME_BASE64_INVALID",
                         "The invalid Base64 payload was preserved without decoding.",
-                        EmailDiagnosticSeverity.Warning, location));
+                        EmailDiagnosticSeverity.Error, location));
                 } else if (diagnostics != null && recoveredPadding) {
                     diagnostics.Add(new EmailDiagnostic("EMAIL_MIME_BASE64_PADDING_RECOVERED",
                         "Missing Base64 padding was recovered.", EmailDiagnosticSeverity.Warning, location));
@@ -224,7 +224,7 @@ internal static class MimeTextCodec {
                 return recovered;
             } catch (FormatException ex) {
                 diagnostics.Add(new EmailDiagnostic("EMAIL_MIME_BASE64_INVALID", ex.Message,
-                    EmailDiagnosticSeverity.Warning, location));
+                    EmailDiagnosticSeverity.Error, location));
                 return Encoding.ASCII.GetBytes(value);
             }
         }

--- a/OfficeIMO.Email/Mime/MimeWriter.cs
+++ b/OfficeIMO.Email/Mime/MimeWriter.cs
@@ -176,8 +176,14 @@ internal static class MimeWriter {
                 : IcsCalendarCodec.CreateRegeneratedAttachment(document, calendarAttachment));
         }
         if (document.OutlookItemKind == OutlookItemKind.Contact && document.Contact != null) {
-            regularAttachmentList.Add(VCardCodec.CreateAttachment(document,
-                semanticSourceUnchanged ? vcardAttachment : null));
+            EmailAttachment contactPart = VCardCodec.CreateAttachment(document,
+                semanticSourceUnchanged ? vcardAttachment : null);
+            if (!document.MimeHasMessageBody && document.Body.Html == null && document.Body.Rtf == null &&
+                calendarContent == null && regularAttachmentList.Count == 0) {
+                WriteAttachment(output, contactPart, state, depth + 1, 0);
+                return;
+            }
+            regularAttachmentList.Add(contactPart);
         } else if (vcardAttachment != null) {
             regularAttachmentList.Add(vcardAttachment);
         }

--- a/OfficeIMO.Email/Mime/MimeWriter.cs
+++ b/OfficeIMO.Email/Mime/MimeWriter.cs
@@ -4,8 +4,7 @@ internal static class MimeWriter {
     private static readonly HashSet<string> ManagedHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
         "Subject", "From", "Sender", "To", "Cc", "Bcc", "Reply-To", "Date", "Message-ID",
         "References", "In-Reply-To", "MIME-Version", "Content-Type", "Content-Transfer-Encoding",
-        "Content-Disposition", "Importance", "X-Priority", "Priority", "Sensitivity",
-        "Disposition-Notification-To", "Return-Receipt-To", "X-Unsent", "Status", "Keywords"
+        "Content-Disposition"
     };
 
     internal static byte[] Write(EmailDocument document, EmailWriterOptions options, IList<EmailDiagnostic> diagnostics) {
@@ -45,11 +44,14 @@ internal static class MimeWriter {
         }
         WriteThreadingHeader(output, document, "References", document.MessageMetadata.InternetReferences);
         WriteThreadingHeader(output, document, "In-Reply-To", document.MessageMetadata.InReplyToId);
-        foreach (EmailHeader header in MimeMessageMetadataProjection.CreateHeaders(document)) {
+        EmailHeader[] projectedMetadataHeaders = MimeMessageMetadataProjection.CreateHeaders(document).ToArray();
+        foreach (EmailHeader header in projectedMetadataHeaders) {
             WriteProjectedMetadataHeader(output, header);
         }
+        var projectedMetadataNames = new HashSet<string>(
+            projectedMetadataHeaders.Select(header => header.Name), StringComparer.OrdinalIgnoreCase);
         foreach (EmailHeader header in document.Headers) {
-            if (ManagedHeaders.Contains(header.Name)) continue;
+            if (ManagedHeaders.Contains(header.Name) || projectedMetadataNames.Contains(header.Name)) continue;
             WriteRetainedHeader(output, header);
         }
     }

--- a/OfficeIMO.Email/Mime/MimeWriter.cs
+++ b/OfficeIMO.Email/Mime/MimeWriter.cs
@@ -46,7 +46,7 @@ internal static class MimeWriter {
         WriteThreadingHeader(output, document, "References", document.MessageMetadata.InternetReferences);
         WriteThreadingHeader(output, document, "In-Reply-To", document.MessageMetadata.InReplyToId);
         foreach (EmailHeader header in MimeMessageMetadataProjection.CreateHeaders(document)) {
-            WriteLine(output, string.Concat(header.Name, ": ", EncodeHeaderText(header.Value)));
+            WriteProjectedMetadataHeader(output, header);
         }
         foreach (EmailHeader header in document.Headers) {
             if (ManagedHeaders.Contains(header.Name)) continue;
@@ -63,6 +63,20 @@ internal static class MimeWriter {
         }
 
         WriteLine(output, string.Concat(name, ": ", EncodeHeaderText(header.Value)));
+    }
+
+    private static void WriteProjectedMetadataHeader(Stream output, EmailHeader header) {
+        if (!string.Equals(header.Name, "Disposition-Notification-To", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(header.Name, "Return-Receipt-To", StringComparison.OrdinalIgnoreCase)) {
+            WriteLine(output, string.Concat(header.Name, ": ", EncodeHeaderText(header.Value)));
+            return;
+        }
+
+        var diagnostics = new List<EmailDiagnostic>();
+        string[] addresses = MimeAddressParser.ParseMany(header.Value, diagnostics,
+            string.Concat("transport/", header.Name)).Select(FormatAddress).ToArray();
+        string value = addresses.Length == 0 ? EncodeHeaderText(header.Value) : string.Join(",\r\n ", addresses);
+        WriteLine(output, string.Concat(header.Name, ": ", value));
     }
 
     private static void WriteFoldedRawHeader(Stream output, string name, string value) {
@@ -162,7 +176,7 @@ internal static class MimeWriter {
                 : IcsCalendarCodec.CreateRegeneratedAttachment(document, calendarAttachment));
         }
         if (document.OutlookItemKind == OutlookItemKind.Contact && document.Contact != null) {
-            regularAttachmentList.Add(VCardCodec.CreateAttachment(document, state.Options.MaxOutputBytes,
+            regularAttachmentList.Add(VCardCodec.CreateAttachment(document,
                 semanticSourceUnchanged ? vcardAttachment : null));
         } else if (vcardAttachment != null) {
             regularAttachmentList.Add(vcardAttachment);
@@ -308,7 +322,10 @@ internal static class MimeWriter {
         string method = source != null && source.ContentTypeParameters.TryGetValue("method", out string? retainedMethod)
             ? retainedMethod
             : IcsCalendarCodec.GetMethod(document);
-        WriteLine(output, string.Concat("Content-Type: text/calendar; method=", SanitizeToken(method), "; charset=utf-8"));
+        string charset = source != null && source.ContentTypeParameters.TryGetValue("charset", out string? retainedCharset)
+            ? string.Concat("; charset=", SanitizeToken(retainedCharset))
+            : source == null ? "; charset=utf-8" : string.Empty;
+        WriteLine(output, string.Concat("Content-Type: text/calendar; method=", SanitizeToken(method), charset));
         WriteLine(output, "Content-Transfer-Encoding: base64");
         WriteLine(output, string.Empty);
         WriteBase64(output, content, base64LineLength);

--- a/OfficeIMO.Email/Mime/MimeWriter.cs
+++ b/OfficeIMO.Email/Mime/MimeWriter.cs
@@ -139,9 +139,11 @@ internal static class MimeWriter {
 
     private static void WriteContent(Stream output, EmailDocument document, MimeWriterState state, int depth, bool includeLeadingHeaders) {
         EmailAttachment? calendarAttachment = IcsCalendarCodec.FindSemanticAttachment(document);
+        bool semanticSourceUnchanged = document.MimeSemanticSourceModelFingerprint != null &&
+            EmailDocumentStateFingerprint.Matches(document, document.MimeSemanticSourceModelFingerprint);
         byte[]? calendarContent = document.OutlookItemKind == OutlookItemKind.Appointment ||
             document.OutlookItemKind == OutlookItemKind.Task
-            ? calendarAttachment == null
+            ? calendarAttachment == null || !semanticSourceUnchanged
                 ? IcsCalendarCodec.Create(document)
                 : EmailAttachmentContent.ReadOrNull(calendarAttachment, state.Options.MaxOutputBytes) ??
                   IcsCalendarCodec.Create(document)
@@ -150,10 +152,8 @@ internal static class MimeWriter {
         var regularAttachmentList = document.Attachments.Where(attachment =>
             !ReferenceEquals(attachment, calendarAttachment) && !ReferenceEquals(attachment, vcardAttachment)).ToList();
         if (document.OutlookItemKind == OutlookItemKind.Contact && document.Contact != null) {
-            bool unchanged = vcardAttachment != null && document.MimeSemanticSourceModelFingerprint != null &&
-                EmailDocumentStateFingerprint.Matches(document, document.MimeSemanticSourceModelFingerprint);
             regularAttachmentList.Add(VCardCodec.CreateAttachment(document, state.Options.MaxOutputBytes,
-                unchanged ? vcardAttachment : null));
+                semanticSourceUnchanged ? vcardAttachment : null));
         } else if (vcardAttachment != null) {
             regularAttachmentList.Add(vcardAttachment);
         }

--- a/OfficeIMO.Email/Mime/MimeWriter.cs
+++ b/OfficeIMO.Email/Mime/MimeWriter.cs
@@ -116,7 +116,14 @@ internal static class MimeWriter {
             }
             addresses = parsed.ToArray();
         }
-        if (addresses.Length > 0) WriteLine(output, string.Concat(name, ": ", string.Join(",\r\n ", addresses)));
+        if (addresses.Length > 0) {
+            WriteLine(output, string.Concat(name, ": ", string.Join(",\r\n ", addresses)));
+        } else if (!hasProjectedRecipients) {
+            foreach (EmailHeader header in document.Headers.Where(header =>
+                         string.Equals(header.Name, name, StringComparison.OrdinalIgnoreCase))) {
+                WriteRetainedHeader(output, header);
+            }
+        }
     }
 
     private static void WriteAddressHeader(Stream output, EmailDocument document, EmailAddress? address, string name) {
@@ -311,8 +318,19 @@ internal static class MimeWriter {
         bool structured = scalarAddress != null || recipientKind.HasValue &&
             document.Recipients.Any(recipient => recipient.Kind == recipientKind.Value);
         if (!retained && !structured) return;
+        bool hasProjectedRecipients = document.Recipients.Any(recipient =>
+            recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc ||
+            recipient.Kind == EmailRecipientKind.Bcc || recipient.Kind == EmailRecipientKind.ReplyTo);
+        long initialPosition = output.Position;
         if (recipientKind.HasValue) WriteRecipientHeader(output, document, recipientKind.Value, name);
         else WriteAddressHeader(output, document, scalarAddress, name);
+        if (retained && output.Position == initialPosition &&
+            (!recipientKind.HasValue || !hasProjectedRecipients)) {
+            foreach (EmailHeader header in document.Headers.Where(header =>
+                         string.Equals(header.Name, name, StringComparison.OrdinalIgnoreCase))) {
+                WriteRetainedHeader(output, header);
+            }
+        }
     }
 
     private static bool HasHeader(EmailDocument document, string name) => document.Headers.Any(header =>

--- a/OfficeIMO.Email/Mime/MimeWriter.cs
+++ b/OfficeIMO.Email/Mime/MimeWriter.cs
@@ -371,9 +371,11 @@ internal static class MimeWriter {
         string? fileName = attachment.FileName;
         WriteLine(output, string.Concat("Content-Type: ", SanitizeToken(contentType),
             FormatContentTypeParameters(attachment.ContentTypeParameters), FormatFileNameParameter("name", fileName)));
-        WriteLine(output, string.Concat("Content-Disposition: ",
-            attachment.IsMimeAttachment ? "attachment" : attachment.IsInline ? "inline" : "attachment",
-            FormatFileNameParameter("filename", fileName)));
+        if (!attachment.IsMimeBodyPart) {
+            WriteLine(output, string.Concat("Content-Disposition: ",
+                attachment.IsMimeAttachment ? "attachment" : attachment.IsInline ? "inline" : "attachment",
+                FormatFileNameParameter("filename", fileName)));
+        }
         if (!string.IsNullOrWhiteSpace(attachment.ContentId)) {
             WriteLine(output, string.Concat("Content-ID: <", SanitizeMessageId(attachment.ContentId!), ">"));
         }

--- a/OfficeIMO.Email/Mime/MimeWriter.cs
+++ b/OfficeIMO.Email/Mime/MimeWriter.cs
@@ -106,20 +106,18 @@ internal static class MimeWriter {
         string[] addresses = document.Recipients.Where(item => item.Kind == kind)
             .Select(item => FormatAddress(item.Address)).ToArray();
         bool hasProjectedRecipients = document.Recipients.Any(item => item.Kind == kind);
-        bool hasAnyProjectedRecipients = document.Recipients.Any(item =>
-            item.Kind == EmailRecipientKind.To || item.Kind == EmailRecipientKind.Cc ||
-            item.Kind == EmailRecipientKind.Bcc || item.Kind == EmailRecipientKind.ReplyTo);
         bool retainedHeaderIsParseable = false;
         if (addresses.Length == 0 && !hasProjectedRecipients) {
-            var parsed = new List<string>();
+            var parsed = new List<EmailAddress>();
             var diagnostics = new List<EmailDiagnostic>();
             foreach (EmailHeader header in document.Headers.Where(header =>
                          string.Equals(header.Name, name, StringComparison.OrdinalIgnoreCase))) {
                 parsed.AddRange(MimeAddressParser.ParseMany(header.RawValue ?? header.Value, diagnostics,
-                    string.Concat("transport/", name)).Select(FormatAddress));
+                    string.Concat("transport/", name)));
             }
             retainedHeaderIsParseable = parsed.Count > 0;
-            if (!hasAnyProjectedRecipients) addresses = parsed.ToArray();
+            addresses = parsed.Where(address => !HasProjectedRecipientAddress(document, address))
+                .Select(FormatAddress).ToArray();
         }
         if (addresses.Length > 0) {
             WriteLine(output, string.Concat(name, ": ", string.Join(",\r\n ", addresses)));
@@ -129,6 +127,12 @@ internal static class MimeWriter {
                 WriteRetainedHeader(output, header);
             }
         }
+    }
+
+    private static bool HasProjectedRecipientAddress(EmailDocument document, EmailAddress address) {
+        string? candidate = address.Address?.Trim();
+        return !string.IsNullOrWhiteSpace(candidate) && document.Recipients.Any(recipient =>
+            string.Equals(recipient.Address.Address?.Trim(), candidate, StringComparison.OrdinalIgnoreCase));
     }
 
     private static void WriteAddressHeader(Stream output, EmailDocument document, EmailAddress? address, string name) {

--- a/OfficeIMO.Email/Mime/MimeWriter.cs
+++ b/OfficeIMO.Email/Mime/MimeWriter.cs
@@ -356,13 +356,10 @@ internal static class MimeWriter {
 
     private static void WriteCalendarPart(Stream output, EmailDocument document, byte[] content,
         EmailAttachment? source, int base64LineLength) {
-        string method = source != null && source.ContentTypeParameters.TryGetValue("method", out string? retainedMethod)
-            ? retainedMethod
-            : IcsCalendarCodec.GetMethod(document);
-        string charset = source != null && source.ContentTypeParameters.TryGetValue("charset", out string? retainedCharset)
-            ? string.Concat("; charset=", SanitizeToken(retainedCharset))
-            : source == null ? "; charset=utf-8" : string.Empty;
-        WriteLine(output, string.Concat("Content-Type: text/calendar; method=", SanitizeToken(method), charset));
+        string parameters = source == null
+            ? string.Concat("; method=", SanitizeToken(IcsCalendarCodec.GetMethod(document)), "; charset=utf-8")
+            : FormatContentTypeParameters(source.ContentTypeParameters);
+        WriteLine(output, string.Concat("Content-Type: text/calendar", parameters));
         WriteLine(output, "Content-Transfer-Encoding: base64");
         WriteLine(output, string.Empty);
         WriteBase64(output, content, base64LineLength);

--- a/OfficeIMO.Email/Mime/MimeWriter.cs
+++ b/OfficeIMO.Email/Mime/MimeWriter.cs
@@ -139,6 +139,7 @@ internal static class MimeWriter {
         EmailAddress? parsed = MimeAddressParser.ParseOne(retained?.RawValue ?? retained?.Value,
             diagnostics, string.Concat("transport/", name));
         if (parsed != null) WriteLine(output, string.Concat(name, ": ", FormatAddress(parsed)));
+        else if (retained != null) WriteRetainedHeader(output, retained);
     }
 
     private static void WriteThreadingHeader(Stream output, EmailDocument document, string name, string? fallbackValue) {
@@ -200,7 +201,10 @@ internal static class MimeWriter {
             regularAttachmentList.Add(vcardAttachment);
         }
         EmailAttachment[] regularAttachments = regularAttachmentList.ToArray();
-        bool hasAlternative = CountBodyAlternatives(document.Body) + (calendarContent == null ? 0 : 1) > 1;
+        bool includeTextBody = document.Body.Text != null &&
+            (document.MimeHasMessageBody || calendarAttachment == null);
+        bool hasAlternative = CountBodyAlternatives(document.Body, includeTextBody) +
+            (calendarContent == null ? 0 : 1) > 1;
         bool hasRelatedResources = regularAttachments.Any(attachment => IsRelatedResource(document, attachment));
         bool hasUnrelatedAttachments = regularAttachments.Any(attachment => !IsRelatedResource(document, attachment));
         if (hasUnrelatedAttachments) {
@@ -209,10 +213,10 @@ internal static class MimeWriter {
             WriteLine(output, string.Empty);
             WriteLine(output, string.Concat("--", boundary));
             if (hasRelatedResources) {
-                WriteRelatedBodyEntity(output, document, state, depth, hasAlternative, calendarContent,
+                WriteRelatedBodyEntity(output, document, state, depth, hasAlternative, includeTextBody, calendarContent,
                     calendarSourceReused ? calendarAttachment : null, regularAttachments);
             } else {
-                WriteBodyEntity(output, document, state, depth, hasAlternative, calendarContent,
+                WriteBodyEntity(output, document, state, depth, hasAlternative, includeTextBody, calendarContent,
                     calendarSourceReused ? calendarAttachment : null);
             }
             for (int i = 0; i < regularAttachments.Length; i++) {
@@ -225,22 +229,24 @@ internal static class MimeWriter {
         }
 
         if (hasRelatedResources) {
-            WriteRelatedBodyEntity(output, document, state, depth, hasAlternative, calendarContent,
+            WriteRelatedBodyEntity(output, document, state, depth, hasAlternative, includeTextBody, calendarContent,
                 calendarSourceReused ? calendarAttachment : null, regularAttachments);
         } else {
-            WriteBodyEntity(output, document, state, depth, hasAlternative, calendarContent,
+            WriteBodyEntity(output, document, state, depth, hasAlternative, includeTextBody, calendarContent,
                 calendarSourceReused ? calendarAttachment : null);
         }
     }
 
     private static void WriteRelatedBodyEntity(Stream output, EmailDocument document, MimeWriterState state,
-        int depth, bool hasAlternative, byte[]? calendarContent, EmailAttachment? calendarAttachment,
+        int depth, bool hasAlternative, bool includeTextBody, byte[]? calendarContent,
+        EmailAttachment? calendarAttachment,
         IReadOnlyList<EmailAttachment> attachments) {
         string boundary = CreateBoundary(document, depth, "related");
         WriteLine(output, string.Concat("Content-Type: multipart/related; boundary=\"", boundary, "\""));
         WriteLine(output, string.Empty);
         WriteLine(output, string.Concat("--", boundary));
-        WriteBodyEntity(output, document, state, depth, hasAlternative, calendarContent, calendarAttachment);
+        WriteBodyEntity(output, document, state, depth, hasAlternative, includeTextBody, calendarContent,
+            calendarAttachment);
         for (int i = 0; i < attachments.Count; i++) {
             if (!IsRelatedResource(document, attachments[i])) continue;
             WriteLine(output, string.Concat("--", boundary));
@@ -260,14 +266,14 @@ internal static class MimeWriter {
     }
 
     private static void WriteBodyEntity(Stream output, EmailDocument document, MimeWriterState state, int depth,
-        bool hasAlternative, byte[]? calendarContent, EmailAttachment? calendarAttachment) {
+        bool hasAlternative, bool includeTextBody, byte[]? calendarContent, EmailAttachment? calendarAttachment) {
         if (hasAlternative) {
             string boundary = CreateBoundary(document, depth, "alternative");
             WriteLine(output, string.Concat("Content-Type: multipart/alternative; boundary=\"", boundary, "\""));
             WriteLine(output, string.Empty);
-            if (document.Body.Text != null) {
+            if (includeTextBody) {
                 WriteLine(output, string.Concat("--", boundary));
-                WriteTextPart(output, "text/plain", document.Body.Text, state.Options.Base64LineLength);
+                WriteTextPart(output, "text/plain", document.Body.Text!, state.Options.Base64LineLength);
             }
             if (document.Body.Html != null) {
                 WriteLine(output, string.Concat("--", boundary));
@@ -360,8 +366,8 @@ internal static class MimeWriter {
         WriteBase64(output, content, base64LineLength);
     }
 
-    private static int CountBodyAlternatives(EmailBody body) {
-        return (body.Text == null ? 0 : 1) + (body.Html == null ? 0 : 1) + (body.Rtf == null ? 0 : 1);
+    private static int CountBodyAlternatives(EmailBody body, bool includeTextBody) {
+        return (includeTextBody ? 1 : 0) + (body.Html == null ? 0 : 1) + (body.Rtf == null ? 0 : 1);
     }
 
     private static void WriteTextPart(Stream output, string mediaType, string text, int base64LineLength) {

--- a/OfficeIMO.Email/Mime/MimeWriter.cs
+++ b/OfficeIMO.Email/Mime/MimeWriter.cs
@@ -103,7 +103,10 @@ internal static class MimeWriter {
     private static void WriteRecipientHeader(Stream output, EmailDocument document, EmailRecipientKind kind, string name) {
         string[] addresses = document.Recipients.Where(item => item.Kind == kind)
             .Select(item => FormatAddress(item.Address)).ToArray();
-        if (addresses.Length == 0) {
+        bool hasProjectedRecipients = document.Recipients.Any(item =>
+            item.Kind == EmailRecipientKind.To || item.Kind == EmailRecipientKind.Cc ||
+            item.Kind == EmailRecipientKind.Bcc || item.Kind == EmailRecipientKind.ReplyTo);
+        if (addresses.Length == 0 && !hasProjectedRecipients) {
             var parsed = new List<string>();
             var diagnostics = new List<EmailDiagnostic>();
             foreach (EmailHeader header in document.Headers.Where(header =>

--- a/OfficeIMO.Email/Mime/MimeWriter.cs
+++ b/OfficeIMO.Email/Mime/MimeWriter.cs
@@ -105,9 +105,11 @@ internal static class MimeWriter {
     private static void WriteRecipientHeader(Stream output, EmailDocument document, EmailRecipientKind kind, string name) {
         string[] addresses = document.Recipients.Where(item => item.Kind == kind)
             .Select(item => FormatAddress(item.Address)).ToArray();
-        bool hasProjectedRecipients = document.Recipients.Any(item =>
+        bool hasProjectedRecipients = document.Recipients.Any(item => item.Kind == kind);
+        bool hasAnyProjectedRecipients = document.Recipients.Any(item =>
             item.Kind == EmailRecipientKind.To || item.Kind == EmailRecipientKind.Cc ||
             item.Kind == EmailRecipientKind.Bcc || item.Kind == EmailRecipientKind.ReplyTo);
+        bool retainedHeaderIsParseable = false;
         if (addresses.Length == 0 && !hasProjectedRecipients) {
             var parsed = new List<string>();
             var diagnostics = new List<EmailDiagnostic>();
@@ -116,11 +118,12 @@ internal static class MimeWriter {
                 parsed.AddRange(MimeAddressParser.ParseMany(header.RawValue ?? header.Value, diagnostics,
                     string.Concat("transport/", name)).Select(FormatAddress));
             }
-            addresses = parsed.ToArray();
+            retainedHeaderIsParseable = parsed.Count > 0;
+            if (!hasAnyProjectedRecipients) addresses = parsed.ToArray();
         }
         if (addresses.Length > 0) {
             WriteLine(output, string.Concat(name, ": ", string.Join(",\r\n ", addresses)));
-        } else if (!hasProjectedRecipients) {
+        } else if (!hasProjectedRecipients && !retainedHeaderIsParseable) {
             foreach (EmailHeader header in document.Headers.Where(header =>
                          string.Equals(header.Name, name, StringComparison.OrdinalIgnoreCase))) {
                 WriteRetainedHeader(output, header);
@@ -188,21 +191,23 @@ internal static class MimeWriter {
                 ? calendarAttachment
                 : IcsCalendarCodec.CreateRegeneratedAttachment(document, calendarAttachment));
         }
+        EmailAttachment? contactBodyPart = null;
         if (document.OutlookItemKind == OutlookItemKind.Contact && document.Contact != null) {
             EmailAttachment contactPart = VCardCodec.CreateAttachment(document,
                 semanticSourceUnchanged ? vcardAttachment : null);
             if (!document.MimeHasMessageBody && document.Body.Html == null && document.Body.Rtf == null &&
-                calendarContent == null && regularAttachmentList.Count == 0) {
-                WriteAttachment(output, contactPart, state, depth + 1, 0);
-                return;
+                calendarContent == null) {
+                contactBodyPart = contactPart;
+            } else {
+                regularAttachmentList.Add(contactPart);
             }
-            regularAttachmentList.Add(contactPart);
         } else if (vcardAttachment != null) {
             regularAttachmentList.Add(vcardAttachment);
         }
         EmailAttachment[] regularAttachments = regularAttachmentList.ToArray();
         bool includeTextBody = document.Body.Text != null &&
-            (document.MimeHasMessageBody || calendarAttachment == null);
+            (document.MimeHasMessageBody || calendarAttachment == null && contactBodyPart == null &&
+             document.OutlookItemKind != OutlookItemKind.Contact);
         bool hasAlternative = CountBodyAlternatives(document.Body, includeTextBody) +
             (calendarContent == null ? 0 : 1) > 1;
         bool hasRelatedResources = regularAttachments.Any(attachment => IsRelatedResource(document, attachment));
@@ -214,10 +219,10 @@ internal static class MimeWriter {
             WriteLine(output, string.Concat("--", boundary));
             if (hasRelatedResources) {
                 WriteRelatedBodyEntity(output, document, state, depth, hasAlternative, includeTextBody, calendarContent,
-                    calendarSourceReused ? calendarAttachment : null, regularAttachments);
+                    calendarSourceReused ? calendarAttachment : null, contactBodyPart, regularAttachments);
             } else {
                 WriteBodyEntity(output, document, state, depth, hasAlternative, includeTextBody, calendarContent,
-                    calendarSourceReused ? calendarAttachment : null);
+                    calendarSourceReused ? calendarAttachment : null, contactBodyPart);
             }
             for (int i = 0; i < regularAttachments.Length; i++) {
                 if (IsRelatedResource(document, regularAttachments[i])) continue;
@@ -230,23 +235,24 @@ internal static class MimeWriter {
 
         if (hasRelatedResources) {
             WriteRelatedBodyEntity(output, document, state, depth, hasAlternative, includeTextBody, calendarContent,
-                calendarSourceReused ? calendarAttachment : null, regularAttachments);
+                calendarSourceReused ? calendarAttachment : null, contactBodyPart, regularAttachments);
         } else {
             WriteBodyEntity(output, document, state, depth, hasAlternative, includeTextBody, calendarContent,
-                calendarSourceReused ? calendarAttachment : null);
+                calendarSourceReused ? calendarAttachment : null, contactBodyPart);
         }
     }
 
     private static void WriteRelatedBodyEntity(Stream output, EmailDocument document, MimeWriterState state,
         int depth, bool hasAlternative, bool includeTextBody, byte[]? calendarContent,
         EmailAttachment? calendarAttachment,
+        EmailAttachment? contactBodyPart,
         IReadOnlyList<EmailAttachment> attachments) {
         string boundary = CreateBoundary(document, depth, "related");
         WriteLine(output, string.Concat("Content-Type: multipart/related; boundary=\"", boundary, "\""));
         WriteLine(output, string.Empty);
         WriteLine(output, string.Concat("--", boundary));
         WriteBodyEntity(output, document, state, depth, hasAlternative, includeTextBody, calendarContent,
-            calendarAttachment);
+            calendarAttachment, contactBodyPart);
         for (int i = 0; i < attachments.Count; i++) {
             if (!IsRelatedResource(document, attachments[i])) continue;
             WriteLine(output, string.Concat("--", boundary));
@@ -266,7 +272,8 @@ internal static class MimeWriter {
     }
 
     private static void WriteBodyEntity(Stream output, EmailDocument document, MimeWriterState state, int depth,
-        bool hasAlternative, bool includeTextBody, byte[]? calendarContent, EmailAttachment? calendarAttachment) {
+        bool hasAlternative, bool includeTextBody, byte[]? calendarContent, EmailAttachment? calendarAttachment,
+        EmailAttachment? contactBodyPart) {
         if (hasAlternative) {
             string boundary = CreateBoundary(document, depth, "alternative");
             WriteLine(output, string.Concat("Content-Type: multipart/alternative; boundary=\"", boundary, "\""));
@@ -290,6 +297,8 @@ internal static class MimeWriter {
             WriteLine(output, string.Concat("--", boundary, "--"));
         } else if (calendarContent != null) {
             WriteCalendarPart(output, document, calendarContent, calendarAttachment, state.Options.Base64LineLength);
+        } else if (contactBodyPart != null) {
+            WriteAttachment(output, contactBodyPart, state, depth + 1, 0);
         } else if (document.Body.Html != null) {
             WriteTextPart(output, "text/html", document.Body.Html, state.Options.Base64LineLength);
         } else if (document.Body.Rtf != null) {
@@ -326,19 +335,8 @@ internal static class MimeWriter {
         bool structured = scalarAddress != null || recipientKind.HasValue &&
             document.Recipients.Any(recipient => recipient.Kind == recipientKind.Value);
         if (!retained && !structured) return;
-        bool hasProjectedRecipients = document.Recipients.Any(recipient =>
-            recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc ||
-            recipient.Kind == EmailRecipientKind.Bcc || recipient.Kind == EmailRecipientKind.ReplyTo);
-        long initialPosition = output.Position;
         if (recipientKind.HasValue) WriteRecipientHeader(output, document, recipientKind.Value, name);
         else WriteAddressHeader(output, document, scalarAddress, name);
-        if (retained && output.Position == initialPosition &&
-            (!recipientKind.HasValue || !hasProjectedRecipients)) {
-            foreach (EmailHeader header in document.Headers.Where(header =>
-                         string.Equals(header.Name, name, StringComparison.OrdinalIgnoreCase))) {
-                WriteRetainedHeader(output, header);
-            }
-        }
     }
 
     private static bool HasHeader(EmailDocument document, string name) => document.Headers.Any(header =>

--- a/OfficeIMO.Email/Mime/MimeWriter.cs
+++ b/OfficeIMO.Email/Mime/MimeWriter.cs
@@ -141,16 +141,26 @@ internal static class MimeWriter {
         EmailAttachment? calendarAttachment = IcsCalendarCodec.FindSemanticAttachment(document);
         bool semanticSourceUnchanged = document.MimeSemanticSourceModelFingerprint != null &&
             EmailDocumentStateFingerprint.Matches(document, document.MimeSemanticSourceModelFingerprint);
+        bool calendarIsAttachment = calendarAttachment != null &&
+            IcsCalendarCodec.ShouldWriteAsAttachment(calendarAttachment);
+        byte[]? retainedCalendarContent = calendarAttachment != null && semanticSourceUnchanged
+            ? EmailAttachmentContent.ReadOrNull(calendarAttachment, state.Options.MaxOutputBytes)
+            : null;
+        bool calendarSourceReused = retainedCalendarContent != null;
         byte[]? calendarContent = document.OutlookItemKind == OutlookItemKind.Appointment ||
             document.OutlookItemKind == OutlookItemKind.Task
-            ? calendarAttachment == null || !semanticSourceUnchanged
-                ? IcsCalendarCodec.Create(document)
-                : EmailAttachmentContent.ReadOrNull(calendarAttachment, state.Options.MaxOutputBytes) ??
-                  IcsCalendarCodec.Create(document)
+            ? calendarIsAttachment
+                ? null
+                : retainedCalendarContent ?? IcsCalendarCodec.Create(document)
             : null;
         EmailAttachment? vcardAttachment = VCardCodec.FindSemanticAttachment(document);
         var regularAttachmentList = document.Attachments.Where(attachment =>
             !ReferenceEquals(attachment, calendarAttachment) && !ReferenceEquals(attachment, vcardAttachment)).ToList();
+        if (calendarIsAttachment && calendarAttachment != null) {
+            regularAttachmentList.Add(calendarSourceReused
+                ? calendarAttachment
+                : IcsCalendarCodec.CreateRegeneratedAttachment(document, calendarAttachment));
+        }
         if (document.OutlookItemKind == OutlookItemKind.Contact && document.Contact != null) {
             regularAttachmentList.Add(VCardCodec.CreateAttachment(document, state.Options.MaxOutputBytes,
                 semanticSourceUnchanged ? vcardAttachment : null));
@@ -168,9 +178,10 @@ internal static class MimeWriter {
             WriteLine(output, string.Concat("--", boundary));
             if (hasRelatedResources) {
                 WriteRelatedBodyEntity(output, document, state, depth, hasAlternative, calendarContent,
-                    calendarAttachment, regularAttachments);
+                    calendarSourceReused ? calendarAttachment : null, regularAttachments);
             } else {
-                WriteBodyEntity(output, document, state, depth, hasAlternative, calendarContent, calendarAttachment);
+                WriteBodyEntity(output, document, state, depth, hasAlternative, calendarContent,
+                    calendarSourceReused ? calendarAttachment : null);
             }
             for (int i = 0; i < regularAttachments.Length; i++) {
                 if (IsRelatedResource(document, regularAttachments[i])) continue;
@@ -183,9 +194,10 @@ internal static class MimeWriter {
 
         if (hasRelatedResources) {
             WriteRelatedBodyEntity(output, document, state, depth, hasAlternative, calendarContent,
-                calendarAttachment, regularAttachments);
+                calendarSourceReused ? calendarAttachment : null, regularAttachments);
         } else {
-            WriteBodyEntity(output, document, state, depth, hasAlternative, calendarContent, calendarAttachment);
+            WriteBodyEntity(output, document, state, depth, hasAlternative, calendarContent,
+                calendarSourceReused ? calendarAttachment : null);
         }
     }
 
@@ -295,11 +307,7 @@ internal static class MimeWriter {
         EmailAttachment? source, int base64LineLength) {
         string method = source != null && source.ContentTypeParameters.TryGetValue("method", out string? retainedMethod)
             ? retainedMethod
-            : document.MessageClass != null && document.MessageClass.IndexOf("Canceled", StringComparison.OrdinalIgnoreCase) >= 0
-                ? "CANCEL"
-                : document.Recipients.Any(recipient => recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc)
-                    ? "REQUEST"
-                    : "PUBLISH";
+            : IcsCalendarCodec.GetMethod(document);
         WriteLine(output, string.Concat("Content-Type: text/calendar; method=", SanitizeToken(method), "; charset=utf-8"));
         WriteLine(output, "Content-Transfer-Encoding: base64");
         WriteLine(output, string.Empty);
@@ -346,7 +354,8 @@ internal static class MimeWriter {
         string? fileName = attachment.FileName;
         WriteLine(output, string.Concat("Content-Type: ", SanitizeToken(contentType),
             FormatContentTypeParameters(attachment.ContentTypeParameters), FormatFileNameParameter("name", fileName)));
-        WriteLine(output, string.Concat("Content-Disposition: ", attachment.IsInline ? "inline" : "attachment",
+        WriteLine(output, string.Concat("Content-Disposition: ",
+            attachment.IsMimeAttachment ? "attachment" : attachment.IsInline ? "inline" : "attachment",
             FormatFileNameParameter("filename", fileName)));
         if (!string.IsNullOrWhiteSpace(attachment.ContentId)) {
             WriteLine(output, string.Concat("Content-ID: <", SanitizeMessageId(attachment.ContentId!), ">"));

--- a/OfficeIMO.Email/Mime/MimeWriter.cs
+++ b/OfficeIMO.Email/Mime/MimeWriter.cs
@@ -4,7 +4,8 @@ internal static class MimeWriter {
     private static readonly HashSet<string> ManagedHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
         "Subject", "From", "Sender", "To", "Cc", "Bcc", "Reply-To", "Date", "Message-ID",
         "References", "In-Reply-To", "MIME-Version", "Content-Type", "Content-Transfer-Encoding",
-        "Content-Disposition"
+        "Content-Disposition", "Importance", "X-Priority", "Priority", "Sensitivity",
+        "Disposition-Notification-To", "Return-Receipt-To", "X-Unsent", "Status", "Keywords"
     };
 
     internal static byte[] Write(EmailDocument document, EmailWriterOptions options, IList<EmailDiagnostic> diagnostics) {
@@ -28,8 +29,8 @@ internal static class MimeWriter {
 
     private static void WriteEnvelopeHeaders(Stream output, EmailDocument document, EmailWriterOptions options) {
         if (!string.IsNullOrWhiteSpace(document.Subject)) WriteLine(output, string.Concat("Subject: ", EncodeHeaderText(document.Subject!)));
-        if (document.From != null) WriteLine(output, string.Concat("From: ", FormatAddress(document.From)));
-        if (document.Sender != null) WriteLine(output, string.Concat("Sender: ", FormatAddress(document.Sender)));
+        WriteAddressHeader(output, document, document.From, "From");
+        WriteAddressHeader(output, document, document.Sender, "Sender");
         WriteRecipientHeader(output, document, EmailRecipientKind.To, "To");
         WriteRecipientHeader(output, document, EmailRecipientKind.Cc, "Cc");
         if (options.IncludeBccHeader) WriteRecipientHeader(output, document, EmailRecipientKind.Bcc, "Bcc");
@@ -44,6 +45,9 @@ internal static class MimeWriter {
         }
         WriteThreadingHeader(output, document, "References", document.MessageMetadata.InternetReferences);
         WriteThreadingHeader(output, document, "In-Reply-To", document.MessageMetadata.InReplyToId);
+        foreach (EmailHeader header in MimeMessageMetadataProjection.CreateHeaders(document)) {
+            WriteLine(output, string.Concat(header.Name, ": ", EncodeHeaderText(header.Value)));
+        }
         foreach (EmailHeader header in document.Headers) {
             if (ManagedHeaders.Contains(header.Name)) continue;
             WriteRetainedHeader(output, header);
@@ -83,8 +87,32 @@ internal static class MimeWriter {
     }
 
     private static void WriteRecipientHeader(Stream output, EmailDocument document, EmailRecipientKind kind, string name) {
-        string[] addresses = document.Recipients.Where(item => item.Kind == kind).Select(item => FormatAddress(item.Address)).ToArray();
+        string[] addresses = document.Recipients.Where(item => item.Kind == kind)
+            .Select(item => FormatAddress(item.Address)).ToArray();
+        if (addresses.Length == 0) {
+            var parsed = new List<string>();
+            var diagnostics = new List<EmailDiagnostic>();
+            foreach (EmailHeader header in document.Headers.Where(header =>
+                         string.Equals(header.Name, name, StringComparison.OrdinalIgnoreCase))) {
+                parsed.AddRange(MimeAddressParser.ParseMany(header.RawValue ?? header.Value, diagnostics,
+                    string.Concat("transport/", name)).Select(FormatAddress));
+            }
+            addresses = parsed.ToArray();
+        }
         if (addresses.Length > 0) WriteLine(output, string.Concat(name, ": ", string.Join(",\r\n ", addresses)));
+    }
+
+    private static void WriteAddressHeader(Stream output, EmailDocument document, EmailAddress? address, string name) {
+        if (address != null) {
+            WriteLine(output, string.Concat(name, ": ", FormatAddress(address)));
+            return;
+        }
+        var diagnostics = new List<EmailDiagnostic>();
+        EmailHeader? retained = document.Headers.FirstOrDefault(header =>
+            string.Equals(header.Name, name, StringComparison.OrdinalIgnoreCase));
+        EmailAddress? parsed = MimeAddressParser.ParseOne(retained?.RawValue ?? retained?.Value,
+            diagnostics, string.Concat("transport/", name));
+        if (parsed != null) WriteLine(output, string.Concat(name, ": ", FormatAddress(parsed)));
     }
 
     private static void WriteThreadingHeader(Stream output, EmailDocument document, string name, string? fallbackValue) {
@@ -110,46 +138,69 @@ internal static class MimeWriter {
     }
 
     private static void WriteContent(Stream output, EmailDocument document, MimeWriterState state, int depth, bool includeLeadingHeaders) {
-        bool hasAlternative = CountBodyAlternatives(document.Body) > 1;
-        bool hasRelatedResources = document.Attachments.Any(attachment => IsRelatedResource(document, attachment));
-        bool hasUnrelatedAttachments = document.Attachments.Any(attachment => !IsRelatedResource(document, attachment));
+        EmailAttachment? calendarAttachment = IcsCalendarCodec.FindSemanticAttachment(document);
+        byte[]? calendarContent = document.OutlookItemKind == OutlookItemKind.Appointment ||
+            document.OutlookItemKind == OutlookItemKind.Task
+            ? calendarAttachment == null
+                ? IcsCalendarCodec.Create(document)
+                : EmailAttachmentContent.ReadOrNull(calendarAttachment, state.Options.MaxOutputBytes) ??
+                  IcsCalendarCodec.Create(document)
+            : null;
+        EmailAttachment? vcardAttachment = VCardCodec.FindSemanticAttachment(document);
+        var regularAttachmentList = document.Attachments.Where(attachment =>
+            !ReferenceEquals(attachment, calendarAttachment) && !ReferenceEquals(attachment, vcardAttachment)).ToList();
+        if (document.OutlookItemKind == OutlookItemKind.Contact && document.Contact != null) {
+            bool unchanged = vcardAttachment != null && document.MimeSemanticSourceModelFingerprint != null &&
+                EmailDocumentStateFingerprint.Matches(document, document.MimeSemanticSourceModelFingerprint);
+            regularAttachmentList.Add(VCardCodec.CreateAttachment(document, state.Options.MaxOutputBytes,
+                unchanged ? vcardAttachment : null));
+        } else if (vcardAttachment != null) {
+            regularAttachmentList.Add(vcardAttachment);
+        }
+        EmailAttachment[] regularAttachments = regularAttachmentList.ToArray();
+        bool hasAlternative = CountBodyAlternatives(document.Body) + (calendarContent == null ? 0 : 1) > 1;
+        bool hasRelatedResources = regularAttachments.Any(attachment => IsRelatedResource(document, attachment));
+        bool hasUnrelatedAttachments = regularAttachments.Any(attachment => !IsRelatedResource(document, attachment));
         if (hasUnrelatedAttachments) {
             string boundary = CreateBoundary(document, depth, "mixed");
             WriteLine(output, string.Concat("Content-Type: multipart/mixed; boundary=\"", boundary, "\""));
             WriteLine(output, string.Empty);
             WriteLine(output, string.Concat("--", boundary));
             if (hasRelatedResources) {
-                WriteRelatedBodyEntity(output, document, state, depth, hasAlternative);
+                WriteRelatedBodyEntity(output, document, state, depth, hasAlternative, calendarContent,
+                    calendarAttachment, regularAttachments);
             } else {
-                WriteBodyEntity(output, document, state, depth, hasAlternative);
+                WriteBodyEntity(output, document, state, depth, hasAlternative, calendarContent, calendarAttachment);
             }
-            for (int i = 0; i < document.Attachments.Count; i++) {
-                if (IsRelatedResource(document, document.Attachments[i])) continue;
+            for (int i = 0; i < regularAttachments.Length; i++) {
+                if (IsRelatedResource(document, regularAttachments[i])) continue;
                 WriteLine(output, string.Concat("--", boundary));
-                WriteAttachment(output, document.Attachments[i], state, depth + 1, i);
+                WriteAttachment(output, regularAttachments[i], state, depth + 1, i);
             }
             WriteLine(output, string.Concat("--", boundary, "--"));
             return;
         }
 
         if (hasRelatedResources) {
-            WriteRelatedBodyEntity(output, document, state, depth, hasAlternative);
+            WriteRelatedBodyEntity(output, document, state, depth, hasAlternative, calendarContent,
+                calendarAttachment, regularAttachments);
         } else {
-            WriteBodyEntity(output, document, state, depth, hasAlternative);
+            WriteBodyEntity(output, document, state, depth, hasAlternative, calendarContent, calendarAttachment);
         }
     }
 
     private static void WriteRelatedBodyEntity(Stream output, EmailDocument document, MimeWriterState state,
-        int depth, bool hasAlternative) {
+        int depth, bool hasAlternative, byte[]? calendarContent, EmailAttachment? calendarAttachment,
+        IReadOnlyList<EmailAttachment> attachments) {
         string boundary = CreateBoundary(document, depth, "related");
         WriteLine(output, string.Concat("Content-Type: multipart/related; boundary=\"", boundary, "\""));
         WriteLine(output, string.Empty);
         WriteLine(output, string.Concat("--", boundary));
-        WriteBodyEntity(output, document, state, depth, hasAlternative);
-        for (int i = 0; i < document.Attachments.Count; i++) {
-            if (!IsRelatedResource(document, document.Attachments[i])) continue;
+        WriteBodyEntity(output, document, state, depth, hasAlternative, calendarContent, calendarAttachment);
+        for (int i = 0; i < attachments.Count; i++) {
+            if (!IsRelatedResource(document, attachments[i])) continue;
             WriteLine(output, string.Concat("--", boundary));
-            WriteAttachment(output, document.Attachments[i], state, depth + 1, i);
+            WriteAttachment(output, attachments[i], state, depth + 1, i);
         }
         WriteLine(output, string.Concat("--", boundary, "--"));
     }
@@ -164,7 +215,8 @@ internal static class MimeWriter {
             MimeRelatedResourceReference.ContainsContentLocation(document.Body.Html!, attachment.ContentLocation!);
     }
 
-    private static void WriteBodyEntity(Stream output, EmailDocument document, MimeWriterState state, int depth, bool hasAlternative) {
+    private static void WriteBodyEntity(Stream output, EmailDocument document, MimeWriterState state, int depth,
+        bool hasAlternative, byte[]? calendarContent, EmailAttachment? calendarAttachment) {
         if (hasAlternative) {
             string boundary = CreateBoundary(document, depth, "alternative");
             WriteLine(output, string.Concat("Content-Type: multipart/alternative; boundary=\"", boundary, "\""));
@@ -181,7 +233,13 @@ internal static class MimeWriter {
                 WriteLine(output, string.Concat("--", boundary));
                 WriteRtfPart(output, document.Body.Rtf, state, "body/rtf");
             }
+            if (calendarContent != null) {
+                WriteLine(output, string.Concat("--", boundary));
+                WriteCalendarPart(output, document, calendarContent, calendarAttachment, state.Options.Base64LineLength);
+            }
             WriteLine(output, string.Concat("--", boundary, "--"));
+        } else if (calendarContent != null) {
+            WriteCalendarPart(output, document, calendarContent, calendarAttachment, state.Options.Base64LineLength);
         } else if (document.Body.Html != null) {
             WriteTextPart(output, "text/html", document.Body.Html, state.Options.Base64LineLength);
         } else if (document.Body.Rtf != null) {
@@ -189,6 +247,63 @@ internal static class MimeWriter {
         } else {
             WriteTextPart(output, "text/plain", document.Body.Text ?? string.Empty, state.Options.Base64LineLength);
         }
+    }
+
+    internal static string? CreateTransportHeaders(EmailDocument document, EmailWriterOptions options) {
+        if (document.Headers.Count == 0) return null;
+        using (var output = new MemoryStream()) {
+            WriteTransportAddressHeader(output, document, "From", document.From, null);
+            WriteTransportAddressHeader(output, document, "Sender", document.Sender, null);
+            WriteTransportAddressHeader(output, document, "To", null, EmailRecipientKind.To);
+            WriteTransportAddressHeader(output, document, "Cc", null, EmailRecipientKind.Cc);
+            if (options.IncludeBccHeader || HasHeader(document, "Bcc")) {
+                WriteTransportAddressHeader(output, document, "Bcc", null, EmailRecipientKind.Bcc);
+            }
+            WriteTransportAddressHeader(output, document, "Reply-To", null, EmailRecipientKind.ReplyTo);
+            foreach (EmailHeader header in document.Headers) {
+                if (IsAddressHeader(header.Name)) continue;
+                WriteLine(output, string.Concat(MimeHeaderSafety.SanitizeName(header.Name), ": ",
+                    MimeHeaderSafety.SanitizeValue(header.RawValue ?? header.Value)));
+            }
+            if (output.Length == 0) return null;
+            return Encoding.UTF8.GetString(output.ToArray()).TrimEnd('\r', '\n');
+        }
+    }
+
+    private static void WriteTransportAddressHeader(Stream output, EmailDocument document, string name,
+        EmailAddress? scalarAddress, EmailRecipientKind? recipientKind) {
+        bool retained = HasHeader(document, name);
+        bool structured = scalarAddress != null || recipientKind.HasValue &&
+            document.Recipients.Any(recipient => recipient.Kind == recipientKind.Value);
+        if (!retained && !structured) return;
+        if (recipientKind.HasValue) WriteRecipientHeader(output, document, recipientKind.Value, name);
+        else WriteAddressHeader(output, document, scalarAddress, name);
+    }
+
+    private static bool HasHeader(EmailDocument document, string name) => document.Headers.Any(header =>
+        string.Equals(header.Name, name, StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsAddressHeader(string name) =>
+        string.Equals(name, "From", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(name, "Sender", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(name, "To", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(name, "Cc", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(name, "Bcc", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(name, "Reply-To", StringComparison.OrdinalIgnoreCase);
+
+    private static void WriteCalendarPart(Stream output, EmailDocument document, byte[] content,
+        EmailAttachment? source, int base64LineLength) {
+        string method = source != null && source.ContentTypeParameters.TryGetValue("method", out string? retainedMethod)
+            ? retainedMethod
+            : document.MessageClass != null && document.MessageClass.IndexOf("Canceled", StringComparison.OrdinalIgnoreCase) >= 0
+                ? "CANCEL"
+                : document.Recipients.Any(recipient => recipient.Kind == EmailRecipientKind.To || recipient.Kind == EmailRecipientKind.Cc)
+                    ? "REQUEST"
+                    : "PUBLISH";
+        WriteLine(output, string.Concat("Content-Type: text/calendar; method=", SanitizeToken(method), "; charset=utf-8"));
+        WriteLine(output, "Content-Transfer-Encoding: base64");
+        WriteLine(output, string.Empty);
+        WriteBase64(output, content, base64LineLength);
     }
 
     private static int CountBodyAlternatives(EmailBody body) {
@@ -247,8 +362,9 @@ internal static class MimeWriter {
             return;
         }
 
-        byte[] content = attachment.Content ?? Array.Empty<byte>();
-        if (attachment.Content == null && attachment.Length > 0) {
+        byte[]? retainedContent = EmailAttachmentContent.ReadOrNull(attachment, state.Options.MaxOutputBytes);
+        byte[] content = retainedContent ?? Array.Empty<byte>();
+        if (retainedContent == null && attachment.Length > 0) {
             state.Diagnostics.Add(new EmailDiagnostic("EMAIL_ATTACHMENT_CONTENT_UNAVAILABLE",
                 string.Concat("Attachment ", index.ToString(CultureInfo.InvariantCulture),
                     " has a declared length but no retained content; an empty payload was written."),

--- a/OfficeIMO.Email/Model/EmailContent.cs
+++ b/OfficeIMO.Email/Model/EmailContent.cs
@@ -24,6 +24,7 @@ public sealed class EmailAttachment {
     private readonly Dictionary<string, string> _contentTypeParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, byte[]> _structuredStorageStreams = new Dictionary<string, byte[]>(StringComparer.OrdinalIgnoreCase);
     private readonly List<TnefAttribute> _tnefAttributes = new List<TnefAttribute>();
+    internal bool IsProjectedSemanticContent { get; set; }
     /// <summary>Attachment filename.</summary>
     public string? FileName { get; set; }
 
@@ -65,6 +66,41 @@ public sealed class EmailAttachment {
 
     /// <summary>Decoded content when requested by reader options.</summary>
     public byte[]? Content { get; set; }
+
+    /// <summary>
+    /// Reopenable decoded content used when retaining a byte array is undesirable. Writers prefer
+    /// <see cref="Content"/> when both representations are present.
+    /// </summary>
+    public IEmailContentSource? ContentSource { get; set; }
+
+    /// <summary>Opens decoded attachment content without transferring ownership of the attachment.</summary>
+    public Stream OpenContentStream() {
+        if (Content != null) return new MemoryStream(Content, writable: false);
+        if (ContentSource != null) {
+            Stream stream = ContentSource.OpenRead();
+            if (stream == null || !stream.CanRead) {
+                stream?.Dispose();
+                throw new InvalidDataException("The attachment content source did not return a readable stream.");
+            }
+            return stream;
+        }
+        return new MemoryStream(Array.Empty<byte>(), writable: false);
+    }
+
+    /// <summary>Asynchronously opens decoded attachment content.</summary>
+    public async Task<Stream> OpenContentStreamAsync(CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (Content != null) return new MemoryStream(Content, writable: false);
+        if (ContentSource != null) {
+            Stream stream = await ContentSource.OpenReadAsync(cancellationToken).ConfigureAwait(false);
+            if (stream == null || !stream.CanRead) {
+                stream?.Dispose();
+                throw new InvalidDataException("The attachment content source did not return a readable stream.");
+            }
+            return stream;
+        }
+        return new MemoryStream(Array.Empty<byte>(), writable: false);
+    }
 
     /// <summary>Embedded message or Outlook item when the attachment is structured.</summary>
     public EmailDocument? EmbeddedDocument { get; set; }

--- a/OfficeIMO.Email/Model/EmailContent.cs
+++ b/OfficeIMO.Email/Model/EmailContent.cs
@@ -25,6 +25,8 @@ public sealed class EmailAttachment {
     private readonly Dictionary<string, byte[]> _structuredStorageStreams = new Dictionary<string, byte[]>(StringComparer.OrdinalIgnoreCase);
     private readonly List<TnefAttribute> _tnefAttributes = new List<TnefAttribute>();
     internal bool IsProjectedSemanticContent { get; set; }
+    internal bool IsMimeAttachment { get; set; }
+    internal bool IsMimeBodyPart { get; set; }
     /// <summary>Attachment filename.</summary>
     public string? FileName { get; set; }
 

--- a/OfficeIMO.Email/Model/EmailDocument.cs
+++ b/OfficeIMO.Email/Model/EmailDocument.cs
@@ -95,4 +95,6 @@ public sealed partial class EmailDocument {
     internal byte[]? MimeSemanticSourceModelFingerprint { get; set; }
 
     internal bool MimeSemanticProjectionIsIncomplete { get; set; }
+
+    internal bool MimeHasMessageBody { get; set; }
 }

--- a/OfficeIMO.Email/Model/EmailDocument.cs
+++ b/OfficeIMO.Email/Model/EmailDocument.cs
@@ -97,4 +97,6 @@ public sealed partial class EmailDocument {
     internal bool MimeSemanticProjectionIsIncomplete { get; set; }
 
     internal bool MimeHasMessageBody { get; set; }
+
+    internal bool MimeSemanticSourceHasTextBody { get; set; }
 }

--- a/OfficeIMO.Email/Model/EmailDocument.cs
+++ b/OfficeIMO.Email/Model/EmailDocument.cs
@@ -91,4 +91,8 @@ public sealed partial class EmailDocument {
     public byte[]? RawSource { get; internal set; }
 
     internal byte[]? RawSourceModelFingerprint { get; set; }
+
+    internal byte[]? MimeSemanticSourceModelFingerprint { get; set; }
+
+    internal bool MimeSemanticProjectionIsIncomplete { get; set; }
 }

--- a/OfficeIMO.Email/Model/EmailMessageMetadata.cs
+++ b/OfficeIMO.Email/Model/EmailMessageMetadata.cs
@@ -40,8 +40,14 @@ public sealed class EmailMessageMetadata {
     /// <summary>Whether a read receipt was requested.</summary>
     public bool ReadReceiptRequested { get; set; }
 
+    /// <summary>MIME destination for a requested read receipt.</summary>
+    public string? ReadReceiptDestination { get; set; }
+
     /// <summary>Whether a delivery receipt was requested.</summary>
     public bool DeliveryReceiptRequested { get; set; }
+
+    /// <summary>MIME destination for a requested delivery receipt.</summary>
+    public string? DeliveryReceiptDestination { get; set; }
 
     /// <summary>MAPI sensitivity value.</summary>
     public int? Sensitivity { get; set; }

--- a/OfficeIMO.Email/Model/EmailProtectionInfo.cs
+++ b/OfficeIMO.Email/Model/EmailProtectionInfo.cs
@@ -7,22 +7,29 @@ public enum EmailProtectionKind {
     /// <summary>An opaque S/MIME CMS payload was detected; it can be signed, encrypted, or both.</summary>
     SmimeOpaque = 1,
     /// <summary>A clear-signed S/MIME MIME entity was detected.</summary>
-    SmimeClearSigned = 2
+    SmimeClearSigned = 2,
+    /// <summary>An OpenPGP/MIME encrypted multipart entity was detected.</summary>
+    PgpMimeEncrypted = 3,
+    /// <summary>An OpenPGP/MIME clear-signed multipart entity was detected.</summary>
+    PgpMimeClearSigned = 4,
+    /// <summary>A clear-signed MIME entity with an unrecognized signature protocol was detected.</summary>
+    MimeClearSigned = 5,
+    /// <summary>An encrypted MIME entity with an unrecognized encryption protocol was detected.</summary>
+    MimeEncrypted = 6
 }
 
 /// <summary>
-/// Describes a protected Outlook message and points to the original payload that a cryptographic owner can process.
+/// Describes a protected message and points to the original payload that a cryptographic owner can process.
 /// </summary>
 public sealed class EmailProtectionInfo {
     /// <summary>Detected protection wrapper.</summary>
     public EmailProtectionKind Kind { get; internal set; }
 
-    /// <summary>Original Outlook message class used for classification.</summary>
+    /// <summary>Original Outlook message class used for classification, when one exists.</summary>
     public string? MessageClass { get; internal set; }
 
     /// <summary>
-    /// Attachment containing the CMS or signed MIME payload. Its content can be handed to MimeKit or another
-    /// cryptographic provider when attachment content was retained by the reader.
+    /// Attachment containing the CMS, signature, or encrypted MIME payload when it can be projected independently.
     /// </summary>
     public EmailAttachment? PayloadAttachment { get; internal set; }
 

--- a/OfficeIMO.Email/Model/IEmailContentSource.cs
+++ b/OfficeIMO.Email/Model/IEmailContentSource.cs
@@ -1,0 +1,16 @@
+namespace OfficeIMO.Email;
+
+/// <summary>
+/// Supplies a fresh readable stream for content that should not be retained as a resident byte array.
+/// Future mailbox stores can implement this contract without leaking store-specific handles into the email model.
+/// </summary>
+public interface IEmailContentSource {
+    /// <summary>Known decoded content length, or null when the source cannot determine it cheaply.</summary>
+    long? Length { get; }
+
+    /// <summary>Opens a new readable stream. The caller owns and disposes the returned stream.</summary>
+    Stream OpenRead();
+
+    /// <summary>Asynchronously opens a new readable stream. The caller owns and disposes the returned stream.</summary>
+    Task<Stream> OpenReadAsync(CancellationToken cancellationToken = default);
+}

--- a/OfficeIMO.Email/Msg/MsgProjection.cs
+++ b/OfficeIMO.Email/Msg/MsgProjection.cs
@@ -49,6 +49,7 @@ internal static class MsgProjection {
             MimeHeaderParser.Parse(bytes, 0, bytes.Length, state.Options, parsedHeaders, state.Diagnostics,
                 string.Concat(location, "/transport-headers"));
             foreach (EmailHeader header in parsedHeaders) document.Headers.Add(header);
+            MimeMessageMetadataProjection.ApplyReceiptDestinations(document, parsedHeaders);
             document.From = document.From ?? MimeAddressParser.ParseOne(
                 MimeHeaderParser.GetRawValue(parsedHeaders, "From"), state.Diagnostics,
                 string.Concat(location, "/transport-headers/From"));

--- a/OfficeIMO.Email/Msg/MsgWriter.cs
+++ b/OfficeIMO.Email/Msg/MsgWriter.cs
@@ -28,10 +28,12 @@ internal static class MsgWriter {
         EmailRecipient[] storageRecipients = document.Recipients
             .Where(recipient => recipient.Kind != EmailRecipientKind.ReplyTo)
             .ToArray();
+        EmailAttachment[] writableAttachments = document.Attachments.Where(attachment =>
+            !attachment.IsProjectedSemanticContent).ToArray();
         int codePage = MapiStringEncodingContext.FromCodePage(document.OutlookCodePage ?? 65001).PrimaryCodePage;
-        MsgPropertyBuilder messageProperties = CreateMessageProperties(document, diagnostics, prefix);
+        MsgPropertyBuilder messageProperties = CreateMessageProperties(document, diagnostics, prefix, options);
         MsgPropertyWriter.Write(prefix, kind, messageProperties.Properties, storageRecipients.Length,
-            document.Attachments.Count, names, streams, diagnostics, codePage);
+            writableAttachments.Length, names, streams, diagnostics, codePage);
 
         for (int index = 0; index < storageRecipients.Length; index++) {
             EmailRecipient recipient = storageRecipients[index];
@@ -42,16 +44,17 @@ internal static class MsgWriter {
                 0, 0, names, streams, diagnostics, codePage);
         }
 
-        for (int index = 0; index < document.Attachments.Count; index++) {
-            EmailAttachment attachment = document.Attachments[index];
+        for (int index = 0; index < writableAttachments.Length; index++) {
+            EmailAttachment attachment = writableAttachments[index];
+            byte[]? content = EmailAttachmentContent.ReadOrNull(attachment, options.MaxOutputBytes);
             string storage = MsgBinary.CombinePath(prefix,
                 string.Concat("__attach_version1.0_#", index.ToString("X8", CultureInfo.InvariantCulture)));
             int method = attachment.MapiAttachMethod ?? (attachment.EmbeddedDocument != null ? 5 :
                 attachment.StructuredStorageStreams.Count > 0 ? 6 : 1);
             EmailDocument? embeddedDocument = attachment.EmbeddedDocument ??
-                TryReadOpaqueEmbeddedTnef(attachment, diagnostics, storage);
+                TryReadOpaqueEmbeddedTnef(attachment, content, diagnostics, storage);
             MsgPropertyBuilder properties = CreateAttachmentProperties(attachment, index, method, diagnostics, storage,
-                embeddedDocument != null || attachment.StructuredStorageStreams.Count > 0 || attachment.Content != null);
+                embeddedDocument != null || attachment.StructuredStorageStreams.Count > 0 || content != null, content);
             MsgPropertyWriter.Write(storage, MsgPropertyStreamKind.ChildObject, properties.Properties,
                 0, 0, names, streams, diagnostics, codePage,
                 method == 5 ? 1U : method == 6 ? 4U : 0U);
@@ -65,19 +68,19 @@ internal static class MsgWriter {
                     .OrderBy(item => item.Key, StringComparer.OrdinalIgnoreCase)) {
                     streams.Add(new OfficeCompoundStream(MsgBinary.CombinePath(objectStorage, stream.Key), stream.Value));
                 }
-            } else if (method == 5 && attachment.Content != null) {
+            } else if (method == 5 && content != null) {
                 streams.Add(new OfficeCompoundStream(
-                    MsgBinary.CombinePath(objectStorage, "CONTENTS"), attachment.Content));
+                    MsgBinary.CombinePath(objectStorage, "CONTENTS"), content));
                 diagnostics.Add(new EmailDiagnostic("EMAIL_MSG_OPAQUE_EMBEDDED_CONTENT_WRAPPED",
                     "Opaque embedded attachment bytes were retained in the MSG object storage because the payload could not be projected as a nested message.",
                     EmailDiagnosticSeverity.Warning, objectStorage));
             } else if (method == 6) {
-                WriteStructuredAttachment(attachment, objectStorage, streams, diagnostics);
+                WriteStructuredAttachment(attachment, content, objectStorage, streams, diagnostics);
             }
         }
     }
 
-    private static void WriteStructuredAttachment(EmailAttachment attachment, string objectStorage,
+    private static void WriteStructuredAttachment(EmailAttachment attachment, byte[]? content, string objectStorage,
         IList<OfficeCompoundStream> streams, IList<EmailDiagnostic> diagnostics) {
         if (attachment.StructuredStorageStreams.Count > 0) {
             foreach (KeyValuePair<string, byte[]> stream in attachment.StructuredStorageStreams
@@ -87,8 +90,8 @@ internal static class MsgWriter {
             return;
         }
 
-        if (attachment.Content == null) return;
-        byte[] retained = attachment.Content;
+        if (content == null) return;
+        byte[] retained = content;
         byte[] compoundCandidate = retained.Length > 16 &&
             new Guid(MsgBinary.Slice(retained, 0, 16)) == StorageInterfaceId
                 ? MsgBinary.Slice(retained, 16, retained.Length - 16)
@@ -109,7 +112,7 @@ internal static class MsgWriter {
     }
 
     internal static MsgPropertyBuilder CreateMessageProperties(EmailDocument document,
-        IList<EmailDiagnostic> diagnostics, string location) {
+        IList<EmailDiagnostic> diagnostics, string location, EmailWriterOptions? options = null) {
         var properties = new MsgPropertyBuilder(document.MapiProperties);
         int codePage = MapiStringEncodingContext.FromCodePage(document.OutlookCodePage ?? 65001).PrimaryCodePage;
         EmailMessageMetadata metadata = document.MessageMetadata;
@@ -120,8 +123,10 @@ internal static class MsgWriter {
             MapiPropertyType.Unicode, ResolveAcceptLanguage(document));
         properties.Set(0x340D, MapiPropertyType.Integer32, 0x00040E79);
         properties.Set(0x0002, MapiPropertyType.Boolean, true);
-        int messageFlags = 0x0002;
-        if (document.Attachments.Count > 0) messageFlags |= 0x0010;
+        const int managedMessageFlags = 0x0001 | 0x0002 | 0x0008 | 0x0010 | 0x0400;
+        int messageFlags = (MsgProjection.GetInt(document.MapiProperties, 0x0E07) ?? 0) & ~managedMessageFlags;
+        messageFlags |= 0x0002;
+        if (document.Attachments.Any(attachment => !attachment.IsProjectedSemanticContent)) messageFlags |= 0x0010;
         if (metadata.IsDraft) messageFlags |= 0x0008;
         if (metadata.IsRead == true) messageFlags |= 0x0001 | 0x0400;
         properties.Set(0x0E07, MapiPropertyType.Integer32, messageFlags);
@@ -208,10 +213,7 @@ internal static class MsgWriter {
         properties.Set(0x0050, MapiPropertyType.Unicode, JoinRecipients(document, EmailRecipientKind.ReplyTo));
         properties.SetNamed(MsgProjection.PsPublicStrings, "Keywords", MapiPropertyType.MultipleUnicode,
             metadata.Categories.Count == 0 ? null : metadata.Categories.Cast<object>().ToArray());
-        string? headers = document.Headers.Count == 0 ? null : string.Join("\r\n",
-            document.Headers.Select(header => string.Concat(
-                MimeHeaderSafety.SanitizeName(header.Name), ": ",
-                MimeHeaderSafety.SanitizeValue(header.RawValue ?? header.Value))));
+        string? headers = MimeWriter.CreateTransportHeaders(document, options ?? EmailWriterOptions.Default);
         properties.Set(0x007D, MapiPropertyType.Unicode, headers);
         AddTypedProperties(properties, document);
         return properties;
@@ -263,7 +265,8 @@ internal static class MsgWriter {
     }
 
     internal static MsgPropertyBuilder CreateAttachmentProperties(EmailAttachment attachment, int index, int method,
-        IList<EmailDiagnostic> diagnostics, string location, bool hasRetainedObjectContent = false) {
+        IList<EmailDiagnostic> diagnostics, string location, bool hasRetainedObjectContent = false,
+        byte[]? materializedContent = null) {
         var properties = new MsgPropertyBuilder(attachment.MapiProperties);
         properties.Set(0x0FFE, MapiPropertyType.Integer32, 7);
         properties.Set(0x3705, MapiPropertyType.Integer32, method);
@@ -295,9 +298,10 @@ internal static class MsgWriter {
                     "A structured MSG attachment has a declared length but no retained storage streams.",
                     EmailDiagnosticSeverity.Error, location));
             }
-        } else if (attachment.Content != null) {
-            properties.Set(0x3701, MapiPropertyType.Binary, attachment.Content);
-            properties.Set(0x0E20, MapiPropertyType.Integer32, attachment.Content.Length);
+        } else if (materializedContent != null || attachment.Content != null) {
+            byte[] content = materializedContent ?? attachment.Content!;
+            properties.Set(0x3701, MapiPropertyType.Binary, content);
+            properties.Set(0x0E20, MapiPropertyType.Integer32, content.Length);
         } else {
             properties.Set(0x3701, MapiPropertyType.Binary, null);
             properties.Set(0x0E20, MapiPropertyType.Integer32, checked((int)Math.Min(attachment.Length, int.MaxValue)));
@@ -310,9 +314,8 @@ internal static class MsgWriter {
         return properties;
     }
 
-    private static EmailDocument? TryReadOpaqueEmbeddedTnef(EmailAttachment attachment,
+    private static EmailDocument? TryReadOpaqueEmbeddedTnef(EmailAttachment attachment, byte[]? content,
         IList<EmailDiagnostic> diagnostics, string location) {
-        byte[]? content = attachment.Content;
         if (attachment.MapiAttachMethod != 5 || content == null || content.Length < 20 ||
             new Guid(MsgBinary.Slice(content, 0, 16)) != new Guid("00020307-0000-0000-C000-000000000046")) {
             return null;

--- a/OfficeIMO.Email/Msg/MsgWriter.cs
+++ b/OfficeIMO.Email/Msg/MsgWriter.cs
@@ -565,7 +565,8 @@ internal static class MsgWriter {
 
     private static int? GetDurationMinutes(DateTimeOffset? start, DateTimeOffset? end) {
         if (!start.HasValue || !end.HasValue) return null;
-        return checked((int)Math.Round((end.Value - start.Value).TotalMinutes));
+        double minutes = Math.Round((end.Value - start.Value).TotalMinutes);
+        return minutes >= int.MinValue && minutes <= int.MaxValue ? (int)minutes : (int?)null;
     }
 
     private static string? JoinAppointmentAttendees(EmailDocument document, EmailRecipientKind? kind) {
@@ -581,7 +582,8 @@ internal static class MsgWriter {
 
     private static int? ToMinutes(TimeSpan? value) {
         if (!value.HasValue) return null;
-        return checked((int)Math.Round(value.Value.TotalMinutes));
+        double minutes = Math.Round(value.Value.TotalMinutes);
+        return minutes >= int.MinValue && minutes <= int.MaxValue ? (int)minutes : (int?)null;
     }
 
     private static object[]? ToObjectArray(IList<string> values) =>

--- a/OfficeIMO.Email/Msg/MsgWriter.cs
+++ b/OfficeIMO.Email/Msg/MsgWriter.cs
@@ -125,12 +125,13 @@ internal static class MsgWriter {
         properties.Set(0x0002, MapiPropertyType.Boolean, true);
         const int managedMessageFlags = 0x0001 | 0x0002 | 0x0008 | 0x0010 | 0x0400;
         int messageFlags = (MsgProjection.GetInt(document.MapiProperties, 0x0E07) ?? 0) & ~managedMessageFlags;
+        bool hasAttachments = document.Attachments.Any(attachment => !attachment.IsProjectedSemanticContent);
         messageFlags |= 0x0002;
-        if (document.Attachments.Any(attachment => !attachment.IsProjectedSemanticContent)) messageFlags |= 0x0010;
+        if (hasAttachments) messageFlags |= 0x0010;
         if (metadata.IsDraft) messageFlags |= 0x0008;
         if (metadata.IsRead == true) messageFlags |= 0x0001 | 0x0400;
         properties.Set(0x0E07, MapiPropertyType.Integer32, messageFlags);
-        properties.Set(0x0E1B, MapiPropertyType.Boolean, document.Attachments.Count > 0);
+        properties.Set(0x0E1B, MapiPropertyType.Boolean, hasAttachments);
         properties.Set(0x0037, MapiPropertyType.Unicode, document.Subject);
         ResolveSubject(document.Subject, metadata, out string? subjectPrefix, out string? normalizedSubject);
         properties.Set(0x003D, MapiPropertyType.Unicode, subjectPrefix);

--- a/OfficeIMO.Email/README.md
+++ b/OfficeIMO.Email/README.md
@@ -8,10 +8,12 @@ The package supports:
 - Outlook MSG files with standard and named MAPI properties, legacy code pages, recipients, embedded messages, linked attachments, and OLE/custom-storage attachments
 - MS-OXRTFCP compressed and uncompressed RTF bodies, including bounded expansion and checksum validation
 - Outlook messages, appointments, contacts, tasks, journals, and sticky notes with typed read/write models
+- standards-based iCalendar (`VEVENT`/`VTODO`) and vCard projection when appointments, tasks, or contacts cross the EML boundary
 - TNEF payloads such as `winmail.dat`
 - mboxo and mboxrd mailbox archives
+- reopenable attachment content and per-message mbox streaming for large or store-backed workflows
 - bounded synchronous and asynchronous reads, immutable reader configuration, cancellation, and structured diagnostics
-- deterministic EML, MSG, TNEF, and mbox writing
+- deterministic EML, MSG, TNEF, and mbox writing with explicit conversion-loss policy
 
 MSG output includes the root storage identity, complete named-property forward and reverse mappings, and the compatibility metadata required by native Outlook. A document without an explicit date receives a deterministic creation-time fallback; set `Date` or `MessageMetadata.CreatedDate` when the real timestamp matters.
 
@@ -68,6 +70,28 @@ The same model can be written as EML, MSG, or TNEF. Conversion is a load followe
 EmailDocument.Load("source.eml").Save("converted.msg");
 ```
 
+Known semantic loss is blocked by default. This includes changing or cross-converting a signed/encrypted artifact,
+dropping Outlook recurrence or time-zone blobs into iCalendar, converting an Exchange contact whose address depends
+on an opaque entry identifier, and writing journal or sticky-note semantics as EML. Analyze the conversion before
+opening a destination when the host needs to present those choices:
+
+```csharp
+var writer = new EmailDocumentWriter();
+EmailConversionReport report = writer.AnalyzeConversion(message, EmailFileFormat.Eml);
+
+foreach (EmailDiagnostic diagnostic in report.Diagnostics) {
+    Console.WriteLine($"{diagnostic.Severity}: {diagnostic.Code}: {diagnostic.Message}");
+}
+
+if (report.CanWrite) {
+    writer.Write(message, "converted.eml");
+}
+```
+
+Use `EmailConversionLossPolicy.Warn` only when the application has made an explicit decision to accept a documented
+loss. Opaque MAPI/TNEF metadata that has no portable EML equivalent is reported as a warning while common message
+content remains writable.
+
 ## Read an mbox archive
 
 An mbox file is an aggregate, so it has a dedicated reader rather than pretending to be one message:
@@ -82,6 +106,23 @@ foreach (EmailMailboxEntry entry in result.Mailbox.Messages) {
 ```
 
 `EmailMailboxWriter` writes mboxo or mboxrd with deterministic envelope and escaping behavior.
+
+For a large mailbox, enumerate or write one entry at a time:
+
+```csharp
+var reader = new EmailMailboxReader();
+
+foreach (EmailMailboxEntryReadResult item in reader.ReadEntries("archive.mbox")) {
+    Console.WriteLine(item.Entry.Document.Subject);
+}
+
+using Stream destination = File.Create("export.mbox");
+new EmailMailboxWriter().WriteEntries(entries, destination);
+```
+
+`ReadEntries` retains at most one decoded message and restores a seekable caller-owned stream when enumeration ends.
+`WriteEntries` writes completed entries directly, so a later enumeration or size failure can leave earlier entries in
+the destination; use the aggregate `EmailMailbox.Save` API when atomic file replacement is required.
 
 ## Outlook item projections
 
@@ -99,6 +140,15 @@ if (item.OutlookItemKind == OutlookItemKind.Appointment && item.Appointment is n
 
 Equivalent projections are available through `Contact`, `Task`, `Journal`, and `Note`.
 
+When an appointment or task is written as EML, it becomes a `text/calendar` iCalendar part. Contacts become vCard
+attachments. Reminders become `VALARM`; task fields without a direct iCalendar property use valid `X-OFFICEIMO-*`
+extensions so they survive an OfficeIMO EML/MSG/TNEF cycle while remaining ignorable to other calendar readers.
+Reading those parts restores the corresponding typed model. Source calendar/vCard bytes are retained
+while the projected model is unchanged; editing a projected item is blocked by default when regeneration could omit
+unmodeled source properties. Meetings whose only attendee data is display text are also blocked because a valid
+iCalendar `ATTENDEE` requires an address. Journal and sticky-note models remain lossless across MSG/TNEF, but have no
+standard EML representation and therefore require an explicit non-blocking loss policy for EML output.
+
 Properties that do not have a convenience field remain available through `MapiProperties`. Standard, numeric named, and string named properties have public lookup helpers:
 
 ```csharp
@@ -114,24 +164,45 @@ MapiProperty? custom = item.MapiProperties.GetMapiProperty(
 
 RTF syntax editing and semantic conversion belong to `OfficeIMO.Rtf`. Generate RTF through that package when the source contains characters that need RTF escapes. `OfficeIMO.Reader` will route an RTF-only email body through the registered `OfficeIMO.Reader.Rtf` handler; without that optional adapter, it preserves the RTF source and reports the fallback explicitly.
 
-## Protected Outlook messages
+## Protected messages
 
-`EmailDocument.Protection` detects opaque and clear-signed S/MIME Outlook message classes and points to the original `.p7m` or `.p7s` attachment. It does not validate or decrypt that payload. Applications can pass `Protection.PayloadAttachment.Content` to MimeKit or another cryptographic owner when attachment content was retained.
+`EmailDocument.Protection` detects opaque and clear-signed S/MIME plus signed or encrypted OpenPGP/MIME wrappers. It
+does not validate signatures or decrypt payloads. Protected input retains its original artifact bytes automatically.
+Writing an unchanged protected document in its source format emits those bytes verbatim; an edited or cross-format
+write is blocked by default because regenerating the wrapper would invalidate its cryptographic meaning.
 
 ```csharp
 EmailDocument protectedMessage = EmailDocument.Load("signed.msg");
 
 if (protectedMessage.Protection.IsProtected) {
     byte[]? cms = protectedMessage.Protection.PayloadAttachment?.Content;
-    // Mailozaurr or another host can process cms with its configured MimeKit context.
+    // A cryptographic owner can validate or decrypt the retained payload.
 }
 ```
+
+## Store-backed attachment content
+
+`EmailAttachment.Content` remains the simple in-memory representation. A mailbox or archive provider can instead set
+`ContentSource` to an `IEmailContentSource` that opens a fresh decoded stream on demand:
+
+```csharp
+EmailAttachment attachment = item.Attachments[0];
+
+using Stream content = await attachment.OpenContentStreamAsync(cancellationToken);
+await content.CopyToAsync(destination, 81920, cancellationToken);
+```
+
+EML, MSG, and TNEF writers consume either representation through the same bounded path. The interface deliberately
+contains no PST, OST, MAPI, or Outlook types, so a future mailbox-store package can yield ordinary `EmailDocument`
+instances while keeping store lifetime and property-stream access in the store owner.
 
 ## Resource limits
 
 `EmailReaderOptions` is immutable and applies limits before retaining decoded content. It controls source size, header size and count, MIME part count and depth, per-attachment and aggregate attachment bytes, embedded-message depth, CFB directory entries, MAPI properties and decoded property bytes, and TNEF attributes.
 
-Use `includeAttachmentContent: false` when only attachment metadata is needed. Parsing still validates the source structure, but decoded attachment payloads are not retained in the result model.
+Use `includeAttachmentContent: false` when only attachment metadata is needed. Parsing still validates the source
+structure, but ordinary decoded attachment payloads are not retained in the result model. Calendar and vCard parts
+that define the typed item are retained because they are semantic message content, not optional file payloads.
 
 ## Reader integration
 
@@ -152,9 +223,14 @@ foreach (OfficeDocumentAsset attachment in result.Assets) {
 
 `OfficeIMO.Email` owns offline artifact parsing, serialization, and format-neutral Outlook data. It does not connect to mail servers, authenticate users, resolve certificates or keys, verify DKIM/ARC/PGP/S/MIME signatures, or decrypt protected messages. MailKit, MimeKit, and applications such as Mailozaurr remain the owners for those operations.
 
-The package does not expose general-purpose CFB transactions and does not read PST or OST mailbox stores. Its compound implementation serves MSG and structured attachments only. Use `EmailMailboxReader` for mbox aggregates and a dedicated store API for PST/OST workflows.
+The package does not expose general-purpose CFB transactions and does not yet read or modify PST/OST mailbox stores.
+Its compound implementation serves MSG and structured attachments only. `IEmailContentSource`, the format-neutral
+`EmailDocument`, and streaming mbox APIs are the compatibility boundary for a future dedicated PST/OST package; store
+folder traversal, named-property mapping, item mutation, allocation tables, and transactional commits still belong in
+that separate owner.
 
-For an exact pass-through of a signed or encrypted artifact, read with `preserveRawSource: true` and write with `usePreservedRawSource: true`. A structured rewrite can change MIME canonicalization and must not be treated as signature-preserving.
+For exact pass-through of an ordinary unprotected artifact, read with `preserveRawSource: true` and write with
+`usePreservedRawSource: true`. Protected artifacts use safe unchanged pass-through automatically.
 
 ## Dependency footprint
 

--- a/OfficeIMO.Email/Reading/EmailDocumentReader.cs
+++ b/OfficeIMO.Email/Reading/EmailDocumentReader.cs
@@ -122,7 +122,7 @@ public sealed class EmailDocumentReader {
                     "The compound artifact is not an Outlook MSG item.", EmailDiagnosticSeverity.Error));
             }
             cancellationToken.ThrowIfCancellationRequested();
-            if (_options.PreserveRawSource) PreserveRawSource(document, data);
+            if (_options.PreserveRawSource || document.Protection.IsProtected) PreserveRawSource(document, data);
             return new EmailReadResult(document, diagnostics.AsReadOnly(), data.LongLength);
         }
 
@@ -153,7 +153,7 @@ public sealed class EmailDocumentReader {
                 break;
         }
         cancellationToken.ThrowIfCancellationRequested();
-        if (_options.PreserveRawSource) PreserveRawSource(document, data);
+        if (_options.PreserveRawSource || document.Protection.IsProtected) PreserveRawSource(document, data);
         return new EmailReadResult(document, diagnostics.AsReadOnly(), data.LongLength);
     }
 

--- a/OfficeIMO.Email/Tnef/TnefMapiCodec.cs
+++ b/OfficeIMO.Email/Tnef/TnefMapiCodec.cs
@@ -236,11 +236,12 @@ internal static class TnefMapiCodec {
         uint kind = cursor.ReadUInt32();
         if (kind == 0) return new MapiNamedProperty(propertySet, cursor.ReadUInt32());
         if (kind != 1) throw new InvalidDataException("Unknown TNEF named-property kind.");
-        uint characters = cursor.ReadUInt32();
-        if (characters > int.MaxValue / 2) throw new InvalidDataException("TNEF named-property string is too large.");
-        byte[] bytes = cursor.ReadBytes(checked((int)characters * 2));
+        uint byteCount = cursor.ReadUInt32();
+        if (byteCount > int.MaxValue) throw new InvalidDataException("TNEF named-property string is too large.");
+        byte[] bytes = cursor.ReadBytes((int)byteCount);
         cursor.Align4();
-        return new MapiNamedProperty(propertySet, Encoding.Unicode.GetString(bytes).TrimEnd('\0'));
+        return new MapiNamedProperty(propertySet,
+            Encoding.Unicode.GetString(bytes, 0, bytes.Length - bytes.Length % 2).TrimEnd('\0'));
     }
 
     private static object? DecodeValue(MapiPropertyType type, byte[] bytes, int codePage,
@@ -330,8 +331,8 @@ internal static class TnefMapiCodec {
             WriteUInt32(output, name.LocalId.GetValueOrDefault());
         } else {
             string text = string.Concat(name.Name, "\0");
-            WriteUInt32(output, unchecked((uint)text.Length));
             byte[] bytes = Encoding.Unicode.GetBytes(text);
+            WriteUInt32(output, unchecked((uint)bytes.Length));
             output.Write(bytes, 0, bytes.Length);
             Pad4(output);
         }
@@ -356,8 +357,10 @@ internal static class TnefMapiCodec {
 
     private static int GetFixedSize(MapiPropertyType type) {
         switch (type) {
+            case MapiPropertyType.Unspecified:
+            case MapiPropertyType.Null: return 0;
             case MapiPropertyType.Integer16:
-            case MapiPropertyType.Boolean: return 2;
+            case MapiPropertyType.Boolean: return 4;
             case MapiPropertyType.Integer32:
             case MapiPropertyType.ErrorCode:
             case MapiPropertyType.Floating32: return 4;
@@ -388,9 +391,9 @@ internal static class TnefMapiCodec {
             return;
         }
         if (kind != 1) throw new InvalidDataException("Unknown TNEF named-property kind.");
-        uint characters = cursor.ReadUInt32();
-        if (characters > int.MaxValue / 2) throw new InvalidDataException("TNEF named-property string is too large.");
-        cursor.Skip(checked((int)characters * 2));
+        uint byteCount = cursor.ReadUInt32();
+        if (byteCount > int.MaxValue) throw new InvalidDataException("TNEF named-property string is too large.");
+        cursor.Skip((int)byteCount);
         cursor.Align4();
     }
 

--- a/OfficeIMO.Email/Tnef/TnefReader.cs
+++ b/OfficeIMO.Email/Tnef/TnefReader.cs
@@ -105,8 +105,13 @@ internal static class TnefReader {
         while (offset < data.Length) {
             state.CountTnefAttribute();
             if (offset + 9 > data.Length) {
-                state.Diagnostics.Add(new EmailDiagnostic("EMAIL_TNEF_ATTRIBUTE_TRUNCATED",
-                    "A TNEF attribute header is truncated.", EmailDiagnosticSeverity.Error, location));
+                bool trailingGarbage = result.Count > 0 && data[offset] != 1 && data[offset] != 2;
+                state.Diagnostics.Add(new EmailDiagnostic(
+                    trailingGarbage ? "EMAIL_TNEF_TRAILING_DATA_IGNORED" : "EMAIL_TNEF_ATTRIBUTE_TRUNCATED",
+                    trailingGarbage
+                        ? "Trailing data after the final complete TNEF attribute was ignored."
+                        : "A TNEF attribute header is truncated.",
+                    trailingGarbage ? EmailDiagnosticSeverity.Warning : EmailDiagnosticSeverity.Error, location));
                 break;
             }
             byte rawLevel = data[offset++];
@@ -115,8 +120,13 @@ internal static class TnefReader {
             uint rawLength = MsgBinary.ReadUInt32(data, offset);
             offset += 4;
             if (rawLength > int.MaxValue || offset > data.Length - (int)rawLength - 2) {
-                state.Diagnostics.Add(new EmailDiagnostic("EMAIL_TNEF_ATTRIBUTE_LENGTH_INVALID",
-                    "A TNEF attribute length exceeds the remaining input.", EmailDiagnosticSeverity.Error, location));
+                bool trailingGarbage = result.Count > 0 && rawLevel != 1 && rawLevel != 2;
+                state.Diagnostics.Add(new EmailDiagnostic(
+                    trailingGarbage ? "EMAIL_TNEF_TRAILING_DATA_IGNORED" : "EMAIL_TNEF_ATTRIBUTE_LENGTH_INVALID",
+                    trailingGarbage
+                        ? "Trailing data after the final complete TNEF attribute was ignored."
+                        : "A TNEF attribute length exceeds the remaining input.",
+                    trailingGarbage ? EmailDiagnosticSeverity.Warning : EmailDiagnosticSeverity.Error, location));
                 break;
             }
             long attachmentMapiPayloadLength = 0;
@@ -248,16 +258,15 @@ internal static class TnefReader {
                     exception.LimitName, exception.ActualValue, exception.MaximumValue);
             }
             if (compoundRead && compound != null) {
-                long total = 0;
                 foreach (KeyValuePair<string, byte[]> stream in compound.Streams) {
                     state.ThrowIfCancellationRequested();
                     if (state.Options.IncludeAttachmentContent) {
                         attachment.StructuredStorageStreams[stream.Key] = stream.Value;
                     }
-                    total = checked(total + stream.Value.LongLength);
                 }
-                attachment.Length = total;
-                state.CountAttachment(total);
+                attachment.Length = compoundBytes.LongLength;
+                if (state.Options.IncludeAttachmentContent) attachment.Content = (byte[])compoundBytes.Clone();
+                state.CountAttachment(compoundBytes.LongLength);
             } else {
                 state.Diagnostics.Add(new EmailDiagnostic("EMAIL_TNEF_COMPOUND_ATTACHMENT_INVALID",
                     compoundError ?? "The TNEF compound attachment could not be read.",

--- a/OfficeIMO.Email/Tnef/TnefWriter.cs
+++ b/OfficeIMO.Email/Tnef/TnefWriter.cs
@@ -19,6 +19,12 @@ internal static class TnefWriter {
         return WriteMessage(document, options, diagnostics, 0);
     }
 
+    /// <summary>Returns whether raw TNEF attributes exist that only the TNEF writer can reproduce.</summary>
+    internal static bool HasUnmanagedRawAttributes(EmailDocument document) =>
+        document.TnefAttributes.Any(attribute => !ManagedMessageAttributes.Contains(attribute.Tag)) ||
+        document.Attachments.Any(attachment => attachment.TnefAttributes.Any(attribute =>
+            !ManagedAttachmentAttributes.Contains(attribute.Tag)));
+
     private static byte[] WriteMessage(EmailDocument document, EmailWriterOptions options,
         IList<EmailDiagnostic> diagnostics, int depth) {
         if (depth > options.MaxNestedMessageDepth) throw new InvalidOperationException("The embedded-message write depth exceeds the configured maximum.");

--- a/OfficeIMO.Email/Tnef/TnefWriter.cs
+++ b/OfficeIMO.Email/Tnef/TnefWriter.cs
@@ -50,7 +50,7 @@ internal static class TnefWriter {
                     TnefMapiCodec.WriteRecipientTable(rows, codePage, diagnostics, "tnef/recipients"));
             }
 
-            MapiProperty[] messageProperties = MsgWriter.CreateMessageProperties(document, diagnostics, "tnef").Properties
+            MapiProperty[] messageProperties = MsgWriter.CreateMessageProperties(document, diagnostics, "tnef", options).Properties
                 .Where(property => !IsMessageAttributeProperty(property.PropertyId)).ToArray();
             if (messageProperties.Length > 0) {
                 WriteAttribute(output, TnefAttributeLevel.Message, TnefConstants.MessageProperties,
@@ -60,8 +60,10 @@ internal static class TnefWriter {
                 WriteAttribute(output, TnefAttributeLevel.Message, attribute.Tag, attribute.Data);
             }
 
-            for (int index = 0; index < document.Attachments.Count; index++) {
-                WriteAttachment(output, document.Attachments[index], index, codePage, options, diagnostics, depth);
+            EmailAttachment[] writableAttachments = document.Attachments.Where(attachment =>
+                !attachment.IsProjectedSemanticContent).ToArray();
+            for (int index = 0; index < writableAttachments.Length; index++) {
+                WriteAttachment(output, writableAttachments[index], index, codePage, options, diagnostics, depth);
             }
             return output.ToArray();
         }
@@ -69,6 +71,7 @@ internal static class TnefWriter {
 
     private static void WriteAttachment(Stream output, EmailAttachment attachment, int index, int codePage,
         EmailWriterOptions options, IList<EmailDiagnostic> diagnostics, int depth) {
+        byte[]? content = EmailAttachmentContent.ReadOrNull(attachment, options.MaxOutputBytes);
         int method = attachment.MapiAttachMethod ?? (attachment.EmbeddedDocument != null ? 5 :
             attachment.StructuredStorageStreams.Count > 0 ? 6 : 1);
         byte[] rendition = new byte[14];
@@ -80,23 +83,23 @@ internal static class TnefWriter {
             attachment.FileName, diagnostics, string.Concat(attachmentLocation, "/title"));
         WriteStringAttribute(output, TnefAttributeLevel.Attachment, TnefConstants.AttachTransportFilename, codePage,
             attachment.FileName, diagnostics, string.Concat(attachmentLocation, "/transport-filename"));
-        if (method == 1 && attachment.Content != null) {
-            WriteAttribute(output, TnefAttributeLevel.Attachment, TnefConstants.AttachData, attachment.Content);
+        if (method == 1 && content != null) {
+            WriteAttribute(output, TnefAttributeLevel.Attachment, TnefConstants.AttachData, content);
         }
 
         MsgPropertyBuilder builder = MsgWriter.CreateAttachmentProperties(attachment, index, method, diagnostics,
-            attachmentLocation, attachment.EmbeddedDocument != null || attachment.Content != null);
+            attachmentLocation, attachment.EmbeddedDocument != null || content != null, content);
         var properties = builder.Properties.Where(property => !IsAttachmentAttributeProperty(property.PropertyId)).
             Select(Clone).ToList();
         if (method == 5 && attachment.EmbeddedDocument != null) {
             byte[] nested = WriteMessage(attachment.EmbeddedDocument, options, diagnostics, depth + 1);
             properties.RemoveAll(property => property.PropertyId == 0x3701);
             properties.Add(new MapiProperty(0x3701, MapiPropertyType.Object, Combine(IidMessage.ToByteArray(), nested)));
-        } else if (method == 5 && attachment.Content != null) {
-            byte[] opaque = attachment.Content.Length >= 16 &&
-                new Guid(MsgBinary.Slice(attachment.Content, 0, 16)) == IidMessage
-                    ? (byte[])attachment.Content.Clone()
-                    : Combine(IidMessage.ToByteArray(), attachment.Content);
+        } else if (method == 5 && content != null) {
+            byte[] opaque = content.Length >= 16 &&
+                new Guid(MsgBinary.Slice(content, 0, 16)) == IidMessage
+                    ? (byte[])content.Clone()
+                    : Combine(IidMessage.ToByteArray(), content);
             properties.RemoveAll(property => property.PropertyId == 0x3701);
             properties.Add(new MapiProperty(0x3701, MapiPropertyType.Object, opaque));
         } else if (method == 6 && attachment.StructuredStorageStreams.Count > 0) {
@@ -105,11 +108,11 @@ internal static class TnefWriter {
             byte[] compound = OfficeCompoundFileWriter.Write(compoundStreams);
             properties.RemoveAll(property => property.PropertyId == 0x3701);
             properties.Add(new MapiProperty(0x3701, MapiPropertyType.Object, Combine(IidStorage.ToByteArray(), compound)));
-        } else if (method == 6 && attachment.Content != null) {
-            byte[] opaque = attachment.Content.Length >= 16 &&
-                new Guid(MsgBinary.Slice(attachment.Content, 0, 16)) == IidStorage
-                    ? (byte[])attachment.Content.Clone()
-                    : Combine(IidStorage.ToByteArray(), attachment.Content);
+        } else if (method == 6 && content != null) {
+            byte[] opaque = content.Length >= 16 &&
+                new Guid(MsgBinary.Slice(content, 0, 16)) == IidStorage
+                    ? (byte[])content.Clone()
+                    : Combine(IidStorage.ToByteArray(), content);
             properties.RemoveAll(property => property.PropertyId == 0x3701);
             properties.Add(new MapiProperty(0x3701, MapiPropertyType.Object, opaque));
         }

--- a/OfficeIMO.Email/Writing/EmailAttachmentContent.cs
+++ b/OfficeIMO.Email/Writing/EmailAttachmentContent.cs
@@ -1,0 +1,27 @@
+namespace OfficeIMO.Email;
+
+internal static class EmailAttachmentContent {
+    internal static byte[]? ReadOrNull(EmailAttachment attachment, long maximumBytes) {
+        if (attachment.Content != null) return attachment.Content;
+        if (attachment.ContentSource == null) return null;
+        if (attachment.ContentSource.Length.HasValue && attachment.ContentSource.Length.Value > maximumBytes) {
+            throw new EmailLimitExceededException(nameof(EmailWriterOptions.MaxOutputBytes),
+                attachment.ContentSource.Length.Value, maximumBytes);
+        }
+
+        using (Stream input = attachment.ContentSource.OpenRead()) {
+            if (input == null || !input.CanRead) {
+                throw new InvalidDataException("The attachment content source did not return a readable stream.");
+            }
+            using (var output = new EmailBoundedMemoryStream(maximumBytes)) {
+                byte[] buffer = new byte[81920];
+                while (true) {
+                    int read = input.Read(buffer, 0, buffer.Length);
+                    if (read == 0) break;
+                    output.Write(buffer, 0, read);
+                }
+                return output.ToArray();
+            }
+        }
+    }
+}

--- a/OfficeIMO.Email/Writing/EmailDocumentWriter.cs
+++ b/OfficeIMO.Email/Writing/EmailDocumentWriter.cs
@@ -96,7 +96,7 @@ public sealed class EmailDocumentWriter {
             return Array.Empty<byte>();
         }
 
-        EmailOutputPreflight.EnsurePayloadsFit(document, _options.MaxOutputBytes);
+        EmailOutputPreflight.EnsurePayloadsFit(document, format, _options.MaxOutputBytes);
         byte[] data = format == EmailFileFormat.Eml
             ? MimeWriter.Write(document, _options, diagnostics)
             : format == EmailFileFormat.OutlookMsg

--- a/OfficeIMO.Email/Writing/EmailDocumentWriter.cs
+++ b/OfficeIMO.Email/Writing/EmailDocumentWriter.cs
@@ -20,6 +20,7 @@ public sealed class EmailDocumentWriter {
     public EmailWriteResult Write(EmailDocument document, string filePath, EmailFileFormat format = EmailFileFormat.Eml) {
         if (filePath == null) throw new ArgumentNullException(nameof(filePath));
         byte[] data = ToBytes(document, format, out EmailWriteResult result);
+        if (result.HasErrors && data.Length == 0) return result;
         OfficeFileCommit.WriteAllBytes(filePath, data);
         return result;
     }
@@ -29,13 +30,16 @@ public sealed class EmailDocumentWriter {
         if (stream == null) throw new ArgumentNullException(nameof(stream));
         if (!stream.CanWrite) throw new ArgumentException("The stream must be writable.", nameof(stream));
         byte[] data = ToBytes(document, format, out EmailWriteResult result);
+        if (result.HasErrors && data.Length == 0) return result;
         OfficeStreamWriter.WriteAllBytes(stream, data);
         return result;
     }
 
     /// <summary>Writes an artifact to memory.</summary>
     public byte[] ToBytes(EmailDocument document, EmailFileFormat format = EmailFileFormat.Eml) {
-        return ToBytes(document, format, out _);
+        byte[] data = ToBytes(document, format, out EmailWriteResult result);
+        ThrowIfBlocked(result);
+        return data;
     }
 
     /// <summary>Asynchronously writes an artifact to a file.</summary>
@@ -44,6 +48,7 @@ public sealed class EmailDocumentWriter {
         if (filePath == null) throw new ArgumentNullException(nameof(filePath));
         cancellationToken.ThrowIfCancellationRequested();
         byte[] data = ToBytes(document, format, out EmailWriteResult result);
+        if (result.HasErrors && data.Length == 0) return result;
         cancellationToken.ThrowIfCancellationRequested();
         await OfficeFileCommit.WriteAllBytesAsync(filePath, data, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
@@ -57,6 +62,7 @@ public sealed class EmailDocumentWriter {
         if (!stream.CanWrite) throw new ArgumentException("The stream must be writable.", nameof(stream));
         cancellationToken.ThrowIfCancellationRequested();
         byte[] data = ToBytes(document, format, out EmailWriteResult result);
+        if (result.HasErrors && data.Length == 0) return result;
         cancellationToken.ThrowIfCancellationRequested();
         await OfficeStreamWriter.WriteAllBytesAsync(stream, data, cancellationToken).ConfigureAwait(false);
         return result;
@@ -69,7 +75,8 @@ public sealed class EmailDocumentWriter {
         }
 
         List<EmailDiagnostic> diagnostics = new List<EmailDiagnostic>();
-        if (_options.UsePreservedRawSource && document.Format == format && document.RawSource != null) {
+        bool protectedPassThrough = EmailConversionAnalyzer.CanPassThroughProtectedSource(document, format);
+        if ((_options.UsePreservedRawSource || protectedPassThrough) && document.Format == format && document.RawSource != null) {
             byte[]? baseline = document.RawSourceModelFingerprint;
             if (baseline != null && EmailDocumentStateFingerprint.Matches(document, baseline)) {
                 EnsureOutputLimit(document.RawSource.LongLength);
@@ -80,6 +87,13 @@ public sealed class EmailDocumentWriter {
             diagnostics.Add(new EmailDiagnostic("EMAIL_RAW_SOURCE_SKIPPED_MODEL_CHANGED",
                 "The preserved source was not reused because the email model changed after reading or could not be verified as unchanged.",
                 EmailDiagnosticSeverity.Warning));
+        }
+
+        EmailConversionReport conversion = EmailConversionAnalyzer.Analyze(document, format, _options);
+        diagnostics.AddRange(conversion.Diagnostics);
+        if (!conversion.CanWrite) {
+            result = new EmailWriteResult(0, diagnostics.AsReadOnly(), false);
+            return Array.Empty<byte>();
         }
 
         EmailOutputPreflight.EnsurePayloadsFit(document, _options.MaxOutputBytes);
@@ -97,5 +111,21 @@ public sealed class EmailDocumentWriter {
         if (length > _options.MaxOutputBytes) {
             throw new EmailLimitExceededException(nameof(EmailWriterOptions.MaxOutputBytes), length, _options.MaxOutputBytes);
         }
+    }
+
+    /// <summary>Analyzes known fidelity implications without producing output.</summary>
+    public EmailConversionReport AnalyzeConversion(EmailDocument document,
+        EmailFileFormat format = EmailFileFormat.Eml) {
+        if (format != EmailFileFormat.Eml && format != EmailFileFormat.OutlookMsg && format != EmailFileFormat.Tnef) {
+            throw new NotSupportedException("The requested email artifact format cannot be serialized.");
+        }
+        return EmailConversionAnalyzer.Analyze(document, format, _options);
+    }
+
+    private static void ThrowIfBlocked(EmailWriteResult result) {
+        if (!result.HasErrors) return;
+        EmailDiagnostic diagnostic = result.Diagnostics.First(item => item.Severity == EmailDiagnosticSeverity.Error);
+        throw new InvalidDataException(string.Concat("The email artifact could not be serialized: ",
+            diagnostic.Code, ": ", diagnostic.Message));
     }
 }

--- a/OfficeIMO.Email/Writing/EmailOutputPreflight.cs
+++ b/OfficeIMO.Email/Writing/EmailOutputPreflight.cs
@@ -2,23 +2,24 @@ namespace OfficeIMO.Email;
 
 /// <summary>Rejects retained payloads that cannot fit before a format writer materializes encoded output.</summary>
 internal static class EmailOutputPreflight {
-    internal static void EnsurePayloadsFit(EmailDocument document, long maxOutputBytes) {
+    internal static void EnsurePayloadsFit(EmailDocument document, EmailFileFormat format, long maxOutputBytes) {
         var visited = new HashSet<EmailDocument>(ReferenceEqualityComparer<EmailDocument>.Instance);
-        long retainedBytes = CountRetainedPayloadBytes(document, visited, maxOutputBytes);
+        long retainedBytes = CountRetainedPayloadBytes(document, format, visited, maxOutputBytes);
         if (retainedBytes > maxOutputBytes) {
             throw new EmailLimitExceededException(nameof(EmailWriterOptions.MaxOutputBytes), retainedBytes, maxOutputBytes);
         }
     }
 
-    private static long CountRetainedPayloadBytes(EmailDocument document, ISet<EmailDocument> visited,
-        long maxOutputBytes) {
+    private static long CountRetainedPayloadBytes(EmailDocument document, EmailFileFormat format,
+        ISet<EmailDocument> visited, long maxOutputBytes) {
         if (!visited.Add(document)) return 0;
         long total = 0;
         if (document.Body.Text != null) total = Add(total, document.Body.Text.Length, maxOutputBytes);
         if (document.Body.Html != null) total = Add(total, document.Body.Html.Length, maxOutputBytes);
         foreach (EmailAttachment attachment in document.Attachments) {
+            if (format != EmailFileFormat.Eml && attachment.IsProjectedSemanticContent) continue;
             if (attachment.EmbeddedDocument != null) {
-                total = Add(total, CountRetainedPayloadBytes(attachment.EmbeddedDocument, visited, maxOutputBytes),
+                total = Add(total, CountRetainedPayloadBytes(attachment.EmbeddedDocument, format, visited, maxOutputBytes),
                     maxOutputBytes);
             } else if (attachment.StructuredStorageStreams.Count > 0) {
                 foreach (byte[] stream in attachment.StructuredStorageStreams.Values) {

--- a/OfficeIMO.Email/Writing/EmailOutputPreflight.cs
+++ b/OfficeIMO.Email/Writing/EmailOutputPreflight.cs
@@ -26,6 +26,8 @@ internal static class EmailOutputPreflight {
                 }
             } else if (attachment.Content != null) {
                 total = Add(total, attachment.Content.LongLength, maxOutputBytes);
+            } else if (attachment.ContentSource?.Length is long sourceLength) {
+                total = Add(total, sourceLength, maxOutputBytes);
             }
         }
         return total;

--- a/OfficeIMO.Email/Writing/EmailWriterOptions.cs
+++ b/OfficeIMO.Email/Writing/EmailWriterOptions.cs
@@ -8,6 +8,14 @@ public sealed class EmailWriterOptions {
     /// <summary>Creates writer options.</summary>
     public EmailWriterOptions(bool usePreservedRawSource = false, bool includeBccHeader = false,
         int base64LineLength = 76, int maxNestedMessageDepth = 16,
+        long maxOutputBytes = 512L * 1024L * 1024L)
+        : this(EmailConversionLossPolicy.Block, usePreservedRawSource, includeBccHeader, base64LineLength,
+            maxNestedMessageDepth, maxOutputBytes) { }
+
+    /// <summary>Creates writer options with an explicit semantic-loss policy.</summary>
+    public EmailWriterOptions(EmailConversionLossPolicy conversionLossPolicy,
+        bool usePreservedRawSource = false, bool includeBccHeader = false,
+        int base64LineLength = 76, int maxNestedMessageDepth = 16,
         long maxOutputBytes = 512L * 1024L * 1024L) {
         if (base64LineLength < 4 || base64LineLength > 998 || base64LineLength % 4 != 0) {
             throw new ArgumentOutOfRangeException(nameof(base64LineLength), "Base64 line length must be a multiple of four from 4 through 996.");
@@ -19,6 +27,7 @@ public sealed class EmailWriterOptions {
         Base64LineLength = base64LineLength;
         MaxNestedMessageDepth = maxNestedMessageDepth;
         MaxOutputBytes = maxOutputBytes;
+        ConversionLossPolicy = conversionLossPolicy;
     }
 
     /// <summary>Whether an unchanged preserved source should be emitted instead of regenerating EML.</summary>
@@ -35,4 +44,7 @@ public sealed class EmailWriterOptions {
 
     /// <summary>Maximum serialized artifact size.</summary>
     public long MaxOutputBytes { get; }
+
+    /// <summary>Policy applied when the requested format cannot preserve known message semantics.</summary>
+    public EmailConversionLossPolicy ConversionLossPolicy { get; }
 }


### PR DESCRIPTION
## Summary

- add conversion preflight and explicit loss policies for EML, MSG, and TNEF writes
- project appointments, tasks, contacts, reminders, and common metadata through iCalendar and vCard when crossing the MIME boundary
- preserve protected S/MIME and OpenPGP/MIME artifacts safely, including unchanged raw-source pass-through
- add streaming mbox enumeration/writing and reopenable attachment content for future store-backed providers
- harden MIME, MSG, TNEF, and mbox parsing against malformed and real-world inputs found in upstream compatibility corpora
- add opt-in MsgKit, MSGReader, MimeKit, and installed-Outlook interoperability coverage without adding format-library runtime dependencies

## Compatibility notes

Known semantic loss is now blocked by default. Callers that intentionally accept a reported loss can use `EmailConversionLossPolicy.Warn`.

PST/OST stores are not implemented in this change. The format-neutral `EmailDocument`, `IEmailContentSource`, and streaming mailbox APIs provide the boundary for a future dedicated store package without introducing Outlook, MAPI, MsgKit, MSGReader, MimeKit, or Aspose types into the core engine.

## Validation

- complete test matrix on .NET Framework 4.7.2, .NET 8, and .NET 10
- clean library builds for netstandard2.0, net472, net8.0, and net10.0
- 88 MsgReader/MimeKit corpus artifacts plus MsgKit-generated mail, appointment, contact, and task samples
- installed Outlook exchange for MSG, ICS, and VCF artifacts
- packaged `OfficeIMO.Email` artifact inspected for its runtime dependency surface