### PR TITLE
Add Reader all-handlers composition preset

### DIFF
--- a/Build/project.build.json
+++ b/Build/project.build.json
@@ -35,6 +35,7 @@
     "OfficeIMO.PowerPoint.Html": "2.0.X",
     "OfficeIMO.PowerPoint.Pdf": "2.0.X",
     "OfficeIMO.Reader": "2.0.X",
+    "OfficeIMO.Reader.All": "2.0.X",
     "OfficeIMO.Reader.AsciiDoc": "2.0.X",
     "OfficeIMO.Reader.Csv": "2.0.X",
     "OfficeIMO.Reader.Epub": "2.0.X",

--- a/OfficeIMO.Reader.All/OfficeDocumentReaderBuilderAllExtensions.cs
+++ b/OfficeIMO.Reader.All/OfficeDocumentReaderBuilderAllExtensions.cs
@@ -1,0 +1,50 @@
+using OfficeIMO.Reader.AsciiDoc;
+using OfficeIMO.Reader.Csv;
+using OfficeIMO.Reader.Epub;
+using OfficeIMO.Reader.Html;
+using OfficeIMO.Reader.Json;
+using OfficeIMO.Reader.Latex;
+using OfficeIMO.Reader.OpenDocument;
+using OfficeIMO.Reader.Pdf;
+using OfficeIMO.Reader.Rtf;
+using OfficeIMO.Reader.Visio;
+using OfficeIMO.Reader.Xml;
+using OfficeIMO.Reader.Yaml;
+using OfficeIMO.Reader.Zip;
+
+namespace OfficeIMO.Reader.All;
+
+/// <summary>Adds the local OfficeIMO format adapters to an isolated reader builder.</summary>
+public static class OfficeDocumentReaderBuilderAllExtensions {
+    /// <summary>
+    /// Adds all local, in-process OfficeIMO handlers included by this package.
+    /// </summary>
+    /// <param name="builder">The isolated reader builder to configure.</param>
+    /// <param name="options">Optional format-specific settings. Defaults are bounded and deterministic.</param>
+    /// <returns>The same builder for fluent composition.</returns>
+    /// <remarks>
+    /// This preset intentionally excludes OCR engines, process adapters, network clients, and hosted providers.
+    /// It only composes the handler packages referenced by <c>OfficeIMO.Reader.All</c>.
+    /// </remarks>
+    public static OfficeDocumentReaderBuilder AddAllOfficeIMOHandlers(
+        this OfficeDocumentReaderBuilder builder,
+        ReaderAllOptions? options = null) {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+
+        ReaderAllOptions configured = options ?? new ReaderAllOptions();
+        return builder
+            .AddAsciiDocHandler(configured.AsciiDoc)
+            .AddCsvHandler(configured.Csv)
+            .AddEpubHandler(configured.Epub)
+            .AddHtmlHandler(configured.Html)
+            .AddJsonHandler(configured.Json)
+            .AddLatexHandler(configured.Latex)
+            .AddOpenDocumentHandler()
+            .AddPdfHandler(configured.Pdf)
+            .AddRtfHandler(configured.Rtf)
+            .AddVisioHandler(configured.Visio)
+            .AddXmlHandler(configured.Xml)
+            .AddYamlHandler(configured.Yaml)
+            .AddZipHandler(configured.ZipTraversal, configured.Zip);
+    }
+}

--- a/OfficeIMO.Reader.All/OfficeIMO.Reader.All.csproj
+++ b/OfficeIMO.Reader.All/OfficeIMO.Reader.All.csproj
@@ -1,0 +1,55 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Composition-only preset for registering OfficeIMO.Reader's local format adapters.</Description>
+    <AssemblyName>OfficeIMO.Reader.All</AssemblyName>
+    <AssemblyTitle>OfficeIMO.Reader.All</AssemblyTitle>
+    <VersionPrefix>2.0.1</VersionPrefix>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <Company>Evotec</Company>
+    <Authors>Przemyslaw Klys</Authors>
+    <PackageId>OfficeIMO.Reader.All</PackageId>
+    <PackageTags>reader;ingestion;composition;officeimo</PackageTags>
+    <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/EvotecIT/OfficeIMO</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageIcon>OfficeIMO.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <IsPackable>true</IsPackable>
+    <IsPublishable>true</IsPublishable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <LangVersion>Latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OfficeIMO.Reader\OfficeIMO.Reader.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Reader.AsciiDoc\OfficeIMO.Reader.AsciiDoc.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Reader.Csv\OfficeIMO.Reader.Csv.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Reader.Epub\OfficeIMO.Reader.Epub.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Reader.Html\OfficeIMO.Reader.Html.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Reader.Json\OfficeIMO.Reader.Json.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Reader.Latex\OfficeIMO.Reader.Latex.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Reader.OpenDocument\OfficeIMO.Reader.OpenDocument.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Reader.Pdf\OfficeIMO.Reader.Pdf.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Reader.Rtf\OfficeIMO.Reader.Rtf.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Reader.Visio\OfficeIMO.Reader.Visio.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Reader.Xml\OfficeIMO.Reader.Xml.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Reader.Yaml\OfficeIMO.Reader.Yaml.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Reader.Zip\OfficeIMO.Reader.Zip.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\Assets\OfficeIMO.png" Pack="true" PackagePath="\" Link="OfficeIMO.png" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="OfficeIMO.Reader" />
+  </ItemGroup>
+</Project>

--- a/OfficeIMO.Reader.All/README.md
+++ b/OfficeIMO.Reader.All/README.md
@@ -1,0 +1,47 @@
+# OfficeIMO.Reader.All
+
+`OfficeIMO.Reader.All` is a thin composition package for applications that want OfficeIMO's local format handlers without registering every adapter separately.
+
+## Install
+
+```powershell
+dotnet add package OfficeIMO.Reader.All
+```
+
+## Use the preset
+
+```csharp
+using OfficeIMO.Reader;
+using OfficeIMO.Reader.All;
+
+OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+    .AddAllOfficeIMOHandlers()
+    .WithMaxConcurrentReads(4)
+    .Build();
+
+OfficeDocumentReadResult document = reader.ReadDocument("input.epub");
+```
+
+The preset adds AsciiDoc, CSV/TSV, EPUB, HTML, JSON, LaTeX, OpenDocument, PDF, RTF, Visio, XML, YAML, and ZIP handlers. Word, Excel, PowerPoint, Markdown, email, and plain text remain built into `OfficeIMO.Reader`.
+
+Configure a format through one options object:
+
+```csharp
+OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+    .AddAllOfficeIMOHandlers(new ReaderAllOptions {
+        Csv = new OfficeIMO.Reader.Csv.CsvReadOptions {
+            ChunkRows = 100
+        },
+        ZipTraversal = new OfficeIMO.Zip.ZipTraversalOptions {
+            MaxEntries = 500,
+            MaxTotalUncompressedBytes = 64L * 1024 * 1024
+        }
+    })
+    .Build();
+```
+
+Registrations are copied into the builder's immutable snapshot. The preset does not mutate `DocumentReader` global state.
+
+## Dependency boundary
+
+This package contains no parser, provider, model, native binary, process launcher, or network client. It references OfficeIMO's existing local adapter packages and therefore carries their established managed dependency graph. OCR packages are deliberately excluded because they require an engine or executable; add one explicitly only when the host chooses it.

--- a/OfficeIMO.Reader.All/ReaderAllOptions.cs
+++ b/OfficeIMO.Reader.All/ReaderAllOptions.cs
@@ -1,0 +1,49 @@
+namespace OfficeIMO.Reader.All;
+
+/// <summary>
+/// Optional format-specific settings used by <see cref="OfficeDocumentReaderBuilderAllExtensions.AddAllOfficeIMOHandlers"/>.
+/// </summary>
+/// <remarks>
+/// Each adapter captures a defensive copy during registration. Changing this object after the preset is applied
+/// does not change a built reader.
+/// </remarks>
+public sealed class ReaderAllOptions {
+    /// <summary>Gets or sets AsciiDoc adapter options.</summary>
+    public AsciiDoc.ReaderAsciiDocOptions? AsciiDoc { get; set; }
+
+    /// <summary>Gets or sets CSV and TSV adapter options.</summary>
+    public Csv.CsvReadOptions? Csv { get; set; }
+
+    /// <summary>Gets or sets EPUB adapter options.</summary>
+    public OfficeIMO.Epub.EpubReadOptions? Epub { get; set; }
+
+    /// <summary>Gets or sets HTML adapter options.</summary>
+    public Html.ReaderHtmlOptions? Html { get; set; }
+
+    /// <summary>Gets or sets JSON adapter options.</summary>
+    public Json.JsonReadOptions? Json { get; set; }
+
+    /// <summary>Gets or sets LaTeX adapter options.</summary>
+    public Latex.ReaderLatexOptions? Latex { get; set; }
+
+    /// <summary>Gets or sets PDF adapter options.</summary>
+    public Pdf.ReaderPdfOptions? Pdf { get; set; }
+
+    /// <summary>Gets or sets RTF adapter options.</summary>
+    public Rtf.ReaderRtfOptions? Rtf { get; set; }
+
+    /// <summary>Gets or sets Visio adapter options.</summary>
+    public Visio.ReaderVisioOptions? Visio { get; set; }
+
+    /// <summary>Gets or sets XML adapter options.</summary>
+    public Xml.XmlReadOptions? Xml { get; set; }
+
+    /// <summary>Gets or sets YAML adapter options.</summary>
+    public Yaml.YamlReadOptions? Yaml { get; set; }
+
+    /// <summary>Gets or sets ZIP archive traversal limits.</summary>
+    public OfficeIMO.Zip.ZipTraversalOptions? ZipTraversal { get; set; }
+
+    /// <summary>Gets or sets Reader-specific nested ZIP behavior.</summary>
+    public Zip.ReaderZipOptions? Zip { get; set; }
+}

--- a/OfficeIMO.Reader.Tests/OfficeIMO.Reader.Tests.csproj
+++ b/OfficeIMO.Reader.Tests/OfficeIMO.Reader.Tests.csproj
@@ -36,6 +36,7 @@
     <ProjectReference Include="..\OfficeIMO.Pdf\OfficeIMO.Pdf.csproj" />
     <ProjectReference Include="..\OfficeIMO.PowerPoint\OfficeIMO.PowerPoint.csproj" />
     <ProjectReference Include="..\OfficeIMO.Reader\OfficeIMO.Reader.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Reader.All\OfficeIMO.Reader.All.csproj" />
     <ProjectReference Include="..\OfficeIMO.Reader.AsciiDoc\OfficeIMO.Reader.AsciiDoc.csproj" />
     <ProjectReference Include="..\OfficeIMO.Reader.Latex\OfficeIMO.Reader.Latex.csproj" />
     <ProjectReference Include="..\OfficeIMO.Reader.Ocr.Process\OfficeIMO.Reader.Ocr.Process.csproj" />

--- a/OfficeIMO.Reader.Tests/Reader.AllPreset.cs
+++ b/OfficeIMO.Reader.Tests/Reader.AllPreset.cs
@@ -66,16 +66,19 @@ public sealed class ReaderAllPresetTests {
         var cases = new[] {
             (
                 Name: "document.odt",
+                CrossLabeledName: "document.ods",
                 Bytes: text.ToBytes(),
                 Marker: "ODT semantic marker",
                 MediaType: "application/vnd.oasis.opendocument.text"),
             (
                 Name: "document.ods",
+                CrossLabeledName: "document.odp",
                 Bytes: spreadsheet.ToBytes(),
                 Marker: "ODS semantic marker",
                 MediaType: "application/vnd.oasis.opendocument.spreadsheet"),
             (
                 Name: "document.odp",
+                CrossLabeledName: "document.odt",
                 Bytes: presentation.ToBytes(),
                 Marker: "ODP semantic marker",
                 MediaType: "application/vnd.oasis.opendocument.presentation")
@@ -84,7 +87,7 @@ public sealed class ReaderAllPresetTests {
             .AddAllOfficeIMOHandlers()
             .Build();
 
-        foreach ((string name, byte[] bytes, string marker, string mediaType) in cases) {
+        foreach ((string name, string crossLabeledName, byte[] bytes, string marker, string mediaType) in cases) {
             ReaderDetectionResult detection = reader.Detect(bytes, name);
 
             Assert.Equal(ReaderInputKind.OpenDocument, detection.ExtensionKind);
@@ -92,6 +95,16 @@ public sealed class ReaderAllPresetTests {
             Assert.Equal(ReaderInputKind.OpenDocument, detection.Kind);
             Assert.Equal(mediaType, detection.MediaType);
             Assert.Equal(ReaderDetectionConfidence.High, detection.Confidence);
+
+            ReaderDetectionResult crossLabeled = reader.Detect(
+                bytes,
+                crossLabeledName,
+                new ReaderDetectionOptions { Mode = ReaderDetectionMode.PreferContent });
+            Assert.Equal(ReaderInputKind.OpenDocument, crossLabeled.ExtensionKind);
+            Assert.Equal(ReaderInputKind.OpenDocument, crossLabeled.ContentKind);
+            Assert.Equal(ReaderInputKind.OpenDocument, crossLabeled.Kind);
+            Assert.Equal(mediaType, crossLabeled.MediaType);
+            Assert.Contains("container:opendocument-mimetype", crossLabeled.Evidence);
 
             OfficeDocumentReadResult result = reader.ReadDocument(
                 bytes,

--- a/OfficeIMO.Reader.Tests/Reader.AllPreset.cs
+++ b/OfficeIMO.Reader.Tests/Reader.AllPreset.cs
@@ -1,5 +1,6 @@
 using OfficeIMO.OpenDocument;
 using OfficeIMO.Reader.All;
+using OfficeIMO.Reader.Zip;
 using Xunit;
 
 namespace OfficeIMO.Reader.Tests;
@@ -118,6 +119,50 @@ public sealed class ReaderAllPresetTests {
                     .SelectMany(chunk => chunk.Tables ?? Array.Empty<ReaderTable>())
                     .SelectMany(table => table.Columns.Concat(table.Rows.SelectMany(row => row))));
             Assert.Contains(marker, string.Join("\n", extractedValues), StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("document.odt", ReaderDetectionMode.ContentWhenUnknown)]
+    [InlineData("document.blob", ReaderDetectionMode.ContentWhenUnknown)]
+    [InlineData("document.zip", ReaderDetectionMode.PreferContent)]
+    public void ZipOnlyRegistrationFallsBackForOpenDocumentStreams(
+        string sourceName,
+        ReaderDetectionMode detectionMode) {
+        OdtDocument document = OdtDocument.Create();
+        document.AddParagraph("ZIP fallback marker");
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+            .AddZipHandler()
+            .Build();
+
+        OfficeDocumentReadResult result = reader.ReadDocument(
+            document.ToBytes(),
+            sourceName,
+            new ReaderOptions { DetectionMode = detectionMode });
+
+        Assert.NotEmpty(result.Chunks);
+        Assert.Contains(result.Chunks, chunk =>
+            chunk.Location.Path?.Contains("::", StringComparison.Ordinal) == true);
+    }
+
+    [Fact]
+    public void ZipOnlyRegistrationFallsBackForOpenDocumentPaths() {
+        string path = Path.Combine(Path.GetTempPath(), $"officeimo-zip-fallback-{Guid.NewGuid():N}.odt");
+        try {
+            OdtDocument document = OdtDocument.Create();
+            document.AddParagraph("ZIP path fallback marker");
+            File.WriteAllBytes(path, document.ToBytes());
+            OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+                .AddZipHandler()
+                .Build();
+
+            OfficeDocumentReadResult result = reader.ReadDocument(path);
+
+            Assert.NotEmpty(result.Chunks);
+            Assert.Contains(result.Chunks, chunk =>
+                chunk.Location.Path?.Contains("::", StringComparison.Ordinal) == true);
+        } finally {
+            if (File.Exists(path)) File.Delete(path);
         }
     }
 }

--- a/OfficeIMO.Reader.Tests/Reader.AllPreset.cs
+++ b/OfficeIMO.Reader.Tests/Reader.AllPreset.cs
@@ -1,3 +1,4 @@
+using OfficeIMO.OpenDocument;
 using OfficeIMO.Reader.All;
 using Xunit;
 
@@ -51,5 +52,39 @@ public sealed class ReaderAllPresetTests {
             Encoding.UTF8.GetBytes("name,value\nalpha,1\nbeta,2"),
             "data.csv");
         Assert.Equal(2, document.Chunks.Count);
+    }
+
+    [Fact]
+    public void PresetPreservesOpenDocumentRoutingWhenContentIsPreferred() {
+        OdtDocument text = OdtDocument.Create();
+        text.AddParagraph("ODT semantic marker");
+        OdsDocument spreadsheet = OdsDocument.Create();
+        spreadsheet.AddSheet("Data").Cell(0, 0).SetString("ODS semantic marker");
+        OdpPresentation presentation = OdpPresentation.Create();
+        presentation.AddSlide("Summary")
+            .AddTextBox(OdfRect.FromCentimeters(1, 1, 12, 3), "ODP semantic marker");
+        var cases = new[] {
+            (Name: "document.odt", Bytes: text.ToBytes(), Marker: "ODT semantic marker"),
+            (Name: "document.ods", Bytes: spreadsheet.ToBytes(), Marker: "ODS semantic marker"),
+            (Name: "document.odp", Bytes: presentation.ToBytes(), Marker: "ODP semantic marker")
+        };
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+            .AddAllOfficeIMOHandlers()
+            .Build();
+
+        foreach ((string name, byte[] bytes, string marker) in cases) {
+            OfficeDocumentReadResult result = reader.ReadDocument(
+                bytes,
+                name,
+                new ReaderOptions { DetectionMode = ReaderDetectionMode.PreferContent });
+
+            Assert.Equal(ReaderInputKind.OpenDocument, result.Kind);
+            Assert.Contains("officeimo.reader.opendocument", result.CapabilitiesUsed);
+            IEnumerable<string> extractedValues = result.Chunks.Select(chunk => chunk.Text)
+                .Concat(result.Chunks
+                    .SelectMany(chunk => chunk.Tables ?? Array.Empty<ReaderTable>())
+                    .SelectMany(table => table.Columns.Concat(table.Rows.SelectMany(row => row))));
+            Assert.Contains(marker, string.Join("\n", extractedValues), StringComparison.Ordinal);
+        }
     }
 }

--- a/OfficeIMO.Reader.Tests/Reader.AllPreset.cs
+++ b/OfficeIMO.Reader.Tests/Reader.AllPreset.cs
@@ -64,15 +64,35 @@ public sealed class ReaderAllPresetTests {
         presentation.AddSlide("Summary")
             .AddTextBox(OdfRect.FromCentimeters(1, 1, 12, 3), "ODP semantic marker");
         var cases = new[] {
-            (Name: "document.odt", Bytes: text.ToBytes(), Marker: "ODT semantic marker"),
-            (Name: "document.ods", Bytes: spreadsheet.ToBytes(), Marker: "ODS semantic marker"),
-            (Name: "document.odp", Bytes: presentation.ToBytes(), Marker: "ODP semantic marker")
+            (
+                Name: "document.odt",
+                Bytes: text.ToBytes(),
+                Marker: "ODT semantic marker",
+                MediaType: "application/vnd.oasis.opendocument.text"),
+            (
+                Name: "document.ods",
+                Bytes: spreadsheet.ToBytes(),
+                Marker: "ODS semantic marker",
+                MediaType: "application/vnd.oasis.opendocument.spreadsheet"),
+            (
+                Name: "document.odp",
+                Bytes: presentation.ToBytes(),
+                Marker: "ODP semantic marker",
+                MediaType: "application/vnd.oasis.opendocument.presentation")
         };
         OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
             .AddAllOfficeIMOHandlers()
             .Build();
 
-        foreach ((string name, byte[] bytes, string marker) in cases) {
+        foreach ((string name, byte[] bytes, string marker, string mediaType) in cases) {
+            ReaderDetectionResult detection = reader.Detect(bytes, name);
+
+            Assert.Equal(ReaderInputKind.OpenDocument, detection.ExtensionKind);
+            Assert.Equal(ReaderInputKind.OpenDocument, detection.ContentKind);
+            Assert.Equal(ReaderInputKind.OpenDocument, detection.Kind);
+            Assert.Equal(mediaType, detection.MediaType);
+            Assert.Equal(ReaderDetectionConfidence.High, detection.Confidence);
+
             OfficeDocumentReadResult result = reader.ReadDocument(
                 bytes,
                 name,

--- a/OfficeIMO.Reader.Tests/Reader.AllPreset.cs
+++ b/OfficeIMO.Reader.Tests/Reader.AllPreset.cs
@@ -1,0 +1,55 @@
+using OfficeIMO.Reader.All;
+using Xunit;
+
+namespace OfficeIMO.Reader.Tests;
+
+public sealed class ReaderAllPresetTests {
+    private static readonly string[] ExpectedModularHandlerIds = {
+        "officeimo.reader.asciidoc",
+        "officeimo.reader.csv",
+        "officeimo.reader.epub",
+        "officeimo.reader.html",
+        "officeimo.reader.json",
+        "officeimo.reader.latex",
+        "officeimo.reader.opendocument",
+        "officeimo.reader.pdf",
+        "officeimo.reader.rtf",
+        "officeimo.reader.visio",
+        "officeimo.reader.xml",
+        "officeimo.reader.yaml",
+        "officeimo.reader.zip"
+    };
+
+    [Fact]
+    public void PresetRegistersEveryLocalAdapterAndExcludesProviders() {
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+            .AddAllOfficeIMOHandlers()
+            .Build();
+
+        ReaderHandlerCapability[] modular = reader.GetCapabilities()
+            .Where(capability => !capability.IsBuiltIn)
+            .ToArray();
+
+        Assert.Equal(ExpectedModularHandlerIds, modular.Select(capability => capability.Id).ToArray());
+        Assert.DoesNotContain(modular, capability => capability.Id.Contains("ocr", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(modular, capability => capability.Id.Contains("provider", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void PresetConfigurationRemainsInstanceScoped() {
+        OfficeDocumentReader configured = new OfficeDocumentReaderBuilder()
+            .AddAllOfficeIMOHandlers(new ReaderAllOptions {
+                Csv = new Csv.CsvReadOptions { ChunkRows = 1 }
+            })
+            .Build();
+        OfficeDocumentReader unconfigured = new OfficeDocumentReaderBuilder().Build();
+
+        Assert.Contains(configured.GetCapabilities(), capability => capability.Id == "officeimo.reader.csv" && !capability.IsBuiltIn);
+        Assert.DoesNotContain(unconfigured.GetCapabilities(), capability => capability.Id == "officeimo.reader.csv" && !capability.IsBuiltIn);
+
+        OfficeDocumentReadResult document = configured.ReadDocument(
+            Encoding.UTF8.GetBytes("name,value\nalpha,1\nbeta,2"),
+            "data.csv");
+        Assert.Equal(2, document.Chunks.Count);
+    }
+}

--- a/OfficeIMO.Reader.Tests/Reader.Detection.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Detection.cs
@@ -115,6 +115,36 @@ public sealed class ReaderDetectionTests {
         Assert.Contains("container:word/document.xml", detection.Evidence);
     }
 
+    [Theory]
+    [InlineData("application/vnd.oasis.opendocument.text")]
+    [InlineData("application/vnd.oasis.opendocument.spreadsheet")]
+    [InlineData("application/vnd.oasis.opendocument.presentation")]
+    public void DocumentReader_Detect_IdentifiesOpenDocumentMimeTypes(string mediaType) {
+        byte[] package = CreateStreamingZip(
+            ("mimetype", mediaType),
+            ("content.xml", "<document />"));
+
+        ReaderDetectionResult detection = OfficeDocumentReader.Default.Detect(package, "document.blob");
+
+        Assert.Equal(ReaderInputKind.OpenDocument, detection.Kind);
+        Assert.Equal(mediaType, detection.MediaType);
+        Assert.Contains("container:opendocument-mimetype", detection.Evidence);
+    }
+
+    [Fact]
+    public async Task DocumentReader_DetectAsync_IdentifiesOpenDocumentMimeType() {
+        const string mediaType = "application/vnd.oasis.opendocument.text";
+        byte[] package = CreateStreamingZip(
+            ("mimetype", mediaType),
+            ("content.xml", "<document />"));
+
+        ReaderDetectionResult detection = await OfficeDocumentReader.Default.DetectAsync(package, "document.blob");
+
+        Assert.Equal(ReaderInputKind.OpenDocument, detection.Kind);
+        Assert.Equal(mediaType, detection.MediaType);
+        Assert.Contains("container:opendocument-mimetype", detection.Evidence);
+    }
+
     [Fact]
     public void DocumentReader_Detect_InspectsEntriesAfterDataDescriptors() {
         byte[] package = CreateStreamingZip(

--- a/OfficeIMO.Reader/DocumentReader.Detection.Zip.cs
+++ b/OfficeIMO.Reader/DocumentReader.Detection.Zip.cs
@@ -303,13 +303,18 @@ internal static partial class DocumentReaderEngine {
     }
 
     private static DetectionCandidate EpubCandidate() {
-        return DetectionCandidate.High(ReaderInputKind.Epub, "application/epub+zip", "container:epub-mimetype");
+        return DetectionCandidate.High(
+            ReaderInputKind.Epub,
+            "application/epub+zip",
+            "container:epub-mimetype",
+            mediaTypeIsDeclared: true);
     }
 
     private static DetectionCandidate OpenDocumentCandidate(string mediaType) {
         return DetectionCandidate.High(
             ReaderInputKind.OpenDocument,
             mediaType,
-            "container:opendocument-mimetype");
+            "container:opendocument-mimetype",
+            mediaTypeIsDeclared: true);
     }
 }

--- a/OfficeIMO.Reader/DocumentReader.Detection.Zip.cs
+++ b/OfficeIMO.Reader/DocumentReader.Detection.Zip.cs
@@ -44,9 +44,15 @@ internal static partial class DocumentReaderEngine {
 
             DetectionCandidate? match = MatchContainerEntry(name);
             if (match != null) return match;
-            if (name == "mimetype" &&
-                TryReadEpubMimeType(stream, start, localHeaderOffset, compression, compressedSize, nextEntryOffset)) {
-                return EpubCandidate();
+            if (name == "mimetype") {
+                DetectionCandidate? mimeType = TryReadContainerMimeType(
+                    stream,
+                    start,
+                    localHeaderOffset,
+                    compression,
+                    compressedSize,
+                    nextEntryOffset);
+                if (mimeType != null) return mimeType;
             }
 
             stream.Position = nextEntryOffset;
@@ -92,15 +98,17 @@ internal static partial class DocumentReaderEngine {
 
             DetectionCandidate? match = MatchContainerEntry(name);
             if (match != null) return match;
-            if (name == "mimetype" && await TryReadEpubMimeTypeAsync(
-                    stream,
-                    start,
-                    localHeaderOffset,
-                    compression,
-                    compressedSize,
-                    nextEntryOffset,
-                    cancellationToken).ConfigureAwait(false)) {
-                return EpubCandidate();
+            if (name == "mimetype") {
+                DetectionCandidate? mimeType = await TryReadContainerMimeTypeAsync(
+                        stream,
+                        start,
+                        localHeaderOffset,
+                        compression,
+                        compressedSize,
+                        nextEntryOffset,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                if (mimeType != null) return mimeType;
             }
 
             stream.Position = nextEntryOffset;
@@ -200,22 +208,22 @@ internal static partial class DocumentReaderEngine {
         return false;
     }
 
-    private static bool TryReadEpubMimeType(
+    private static DetectionCandidate? TryReadContainerMimeType(
         Stream stream,
         long start,
         uint localHeaderOffset,
         ushort compression,
         uint compressedSize,
         long returnPosition) {
-        if (compression != 0 || compressedSize == 0 || compressedSize > 128) return false;
+        if (compression != 0 || compressedSize == 0 || compressedSize > 128) return null;
 
         var header = new byte[30];
         long headerPosition = start + localHeaderOffset;
-        if (headerPosition < start || headerPosition > stream.Length - header.Length) return false;
+        if (headerPosition < start || headerPosition > stream.Length - header.Length) return null;
         stream.Position = headerPosition;
         if (!ReadExact(stream, header, 0, header.Length) || ReadUInt32(header, 0) != ZipLocalHeaderSignature) {
             stream.Position = returnPosition;
-            return false;
+            return null;
         }
 
         ushort nameLength = ReadUInt16(header, 26);
@@ -223,17 +231,19 @@ internal static partial class DocumentReaderEngine {
         long dataPosition = stream.Position + nameLength + extraLength;
         if (dataPosition < stream.Position || dataPosition > stream.Length - compressedSize) {
             stream.Position = returnPosition;
-            return false;
+            return null;
         }
 
         stream.Position = dataPosition;
         var mimeBytes = new byte[(int)compressedSize];
-        bool isEpub = ReadExact(stream, mimeBytes, 0, mimeBytes.Length) && IsEpubMimeType(mimeBytes);
+        DetectionCandidate? candidate = ReadExact(stream, mimeBytes, 0, mimeBytes.Length)
+            ? MatchContainerMimeType(mimeBytes)
+            : null;
         stream.Position = returnPosition;
-        return isEpub;
+        return candidate;
     }
 
-    private static async Task<bool> TryReadEpubMimeTypeAsync(
+    private static async Task<DetectionCandidate?> TryReadContainerMimeTypeAsync(
         Stream stream,
         long start,
         uint localHeaderOffset,
@@ -241,16 +251,16 @@ internal static partial class DocumentReaderEngine {
         uint compressedSize,
         long returnPosition,
         CancellationToken cancellationToken) {
-        if (compression != 0 || compressedSize == 0 || compressedSize > 128) return false;
+        if (compression != 0 || compressedSize == 0 || compressedSize > 128) return null;
 
         var header = new byte[30];
         long headerPosition = start + localHeaderOffset;
-        if (headerPosition < start || headerPosition > stream.Length - header.Length) return false;
+        if (headerPosition < start || headerPosition > stream.Length - header.Length) return null;
         stream.Position = headerPosition;
         if (!await ReadExactAsync(stream, header, 0, header.Length, cancellationToken).ConfigureAwait(false) ||
             ReadUInt32(header, 0) != ZipLocalHeaderSignature) {
             stream.Position = returnPosition;
-            return false;
+            return null;
         }
 
         ushort nameLength = ReadUInt16(header, 26);
@@ -258,26 +268,34 @@ internal static partial class DocumentReaderEngine {
         long dataPosition = stream.Position + nameLength + extraLength;
         if (dataPosition < stream.Position || dataPosition > stream.Length - compressedSize) {
             stream.Position = returnPosition;
-            return false;
+            return null;
         }
 
         stream.Position = dataPosition;
         var mimeBytes = new byte[(int)compressedSize];
-        bool isEpub = await ReadExactAsync(stream, mimeBytes, 0, mimeBytes.Length, cancellationToken).ConfigureAwait(false) &&
-                      IsEpubMimeType(mimeBytes);
+        DetectionCandidate? candidate = await ReadExactAsync(stream, mimeBytes, 0, mimeBytes.Length, cancellationToken)
+                .ConfigureAwait(false)
+            ? MatchContainerMimeType(mimeBytes)
+            : null;
         stream.Position = returnPosition;
-        return isEpub;
+        return candidate;
     }
 
     private static string NormalizeZipEntryName(byte[] nameBytes) {
         return Encoding.UTF8.GetString(nameBytes).Replace('\\', '/').ToLowerInvariant();
     }
 
-    private static bool IsEpubMimeType(byte[] mimeBytes) {
-        return string.Equals(
-            Encoding.ASCII.GetString(mimeBytes).Trim(),
-            "application/epub+zip",
-            StringComparison.Ordinal);
+    private static DetectionCandidate? MatchContainerMimeType(byte[] mimeBytes) {
+        string mediaType = Encoding.ASCII.GetString(mimeBytes).Trim();
+        if (string.Equals(mediaType, "application/epub+zip", StringComparison.Ordinal)) {
+            return EpubCandidate();
+        }
+        if (string.Equals(mediaType, "application/vnd.oasis.opendocument.text", StringComparison.Ordinal) ||
+            string.Equals(mediaType, "application/vnd.oasis.opendocument.spreadsheet", StringComparison.Ordinal) ||
+            string.Equals(mediaType, "application/vnd.oasis.opendocument.presentation", StringComparison.Ordinal)) {
+            return OpenDocumentCandidate(mediaType);
+        }
+        return null;
     }
 
     private static DetectionCandidate GenericZipCandidate() {
@@ -286,5 +304,12 @@ internal static partial class DocumentReaderEngine {
 
     private static DetectionCandidate EpubCandidate() {
         return DetectionCandidate.High(ReaderInputKind.Epub, "application/epub+zip", "container:epub-mimetype");
+    }
+
+    private static DetectionCandidate OpenDocumentCandidate(string mediaType) {
+        return DetectionCandidate.High(
+            ReaderInputKind.OpenDocument,
+            mediaType,
+            "container:opendocument-mimetype");
     }
 }

--- a/OfficeIMO.Reader/DocumentReader.Detection.cs
+++ b/OfficeIMO.Reader/DocumentReader.Detection.cs
@@ -144,13 +144,13 @@ internal static partial class DocumentReaderEngine {
         bool contentOverridesExtension = options.DetectionMode == ReaderDetectionMode.PreferContent &&
                                          detection.IsMismatch;
         if (contentOverridesExtension) {
-            return TryResolveCustomHandlerByKind(detection.Kind, pathInput: true, out handler);
+            return TryResolveDetectedHandler(detection, pathInput: true, out handler);
         }
         if (hasExtensionHandler) {
             handler = extensionHandler;
             return true;
         }
-        return TryResolveCustomHandlerByKind(detection.Kind, pathInput: true, out handler);
+        return TryResolveDetectedHandler(detection, pathInput: true, out handler);
     }
 
     private static bool TryResolveStreamHandler(
@@ -173,13 +173,32 @@ internal static partial class DocumentReaderEngine {
         bool contentOverridesExtension = options.DetectionMode == ReaderDetectionMode.PreferContent &&
                                          detection.IsMismatch;
         if (contentOverridesExtension) {
-            return TryResolveCustomHandlerByKind(detection.Kind, pathInput: false, out handler);
+            return TryResolveDetectedHandler(detection, pathInput: false, out handler);
         }
         if (hasExtensionHandler) {
             handler = extensionHandler;
             return true;
         }
-        return TryResolveCustomHandlerByKind(detection.Kind, pathInput: false, out handler);
+        return TryResolveDetectedHandler(detection, pathInput: false, out handler);
+    }
+
+    private static bool TryResolveDetectedHandler(
+        ReaderDetectionResult detection,
+        bool pathInput,
+        out ReaderHandlerDescriptor handler) {
+        if (TryResolveCustomHandlerByKind(detection.Kind, pathInput, out handler)) {
+            return true;
+        }
+
+        if (!CanUseZipContainerFallback(detection)) {
+            return false;
+        }
+
+        return TryResolveCustomHandlerByKind(ReaderInputKind.Zip, pathInput, out handler);
+    }
+
+    private static bool CanUseZipContainerFallback(ReaderDetectionResult detection) {
+        return detection.Kind == ReaderInputKind.OpenDocument;
     }
 
     private static async Task<HandlerDetectionResolution> ResolvePathHandlerAsync(

--- a/OfficeIMO.Reader/DocumentReader.Detection.cs
+++ b/OfficeIMO.Reader/DocumentReader.Detection.cs
@@ -345,6 +345,16 @@ internal static partial class DocumentReaderEngine {
             effectiveConfidence = content.Confidence;
         }
 
+        bool useContentMediaType = content.Kind == effectiveKind &&
+            content.MediaType != null &&
+            (effectiveKind != extensionResult.ExtensionKind ||
+             (mode == ReaderDetectionMode.PreferContent && content.MediaTypeIsDeclared));
+        string? effectiveMediaType = useContentMediaType
+            ? content.MediaType
+            : effectiveKind == extensionResult.ExtensionKind
+                ? extensionResult.MediaType ?? GetMediaType(effectiveKind)
+                : GetMediaType(effectiveKind);
+
         return new ReaderDetectionResult {
             SourceName = extensionResult.SourceName,
             Extension = extensionResult.Extension,
@@ -354,11 +364,7 @@ internal static partial class DocumentReaderEngine {
             ContentConfidence = content.Confidence,
             Kind = effectiveKind,
             Confidence = effectiveConfidence,
-            MediaType = effectiveKind == extensionResult.ExtensionKind
-                ? extensionResult.MediaType ?? GetMediaType(effectiveKind)
-                : content.Kind == effectiveKind && content.MediaType != null
-                    ? content.MediaType
-                    : GetMediaType(effectiveKind),
+            MediaType = effectiveMediaType,
             ContentInspected = true,
             ContainerInspected = containerInspected,
             InspectedBytes = inspectedBytes,
@@ -675,17 +681,20 @@ internal static partial class DocumentReaderEngine {
             ReaderInputKind kind,
             ReaderDetectionConfidence confidence,
             string? mediaType,
-            IReadOnlyList<string> evidence) {
+            IReadOnlyList<string> evidence,
+            bool mediaTypeIsDeclared = false) {
             Kind = kind;
             Confidence = confidence;
             MediaType = mediaType;
             Evidence = evidence;
+            MediaTypeIsDeclared = mediaTypeIsDeclared;
         }
 
         public ReaderInputKind Kind { get; }
         public ReaderDetectionConfidence Confidence { get; }
         public string? MediaType { get; }
         public IReadOnlyList<string> Evidence { get; }
+        public bool MediaTypeIsDeclared { get; }
 
         public static DetectionCandidate Unknown(string evidence) =>
             new DetectionCandidate(ReaderInputKind.Unknown, ReaderDetectionConfidence.None, null, new[] { evidence });
@@ -696,8 +705,17 @@ internal static partial class DocumentReaderEngine {
         public static DetectionCandidate Medium(ReaderInputKind kind, string mediaType, string evidence) =>
             new DetectionCandidate(kind, ReaderDetectionConfidence.Medium, mediaType, new[] { evidence });
 
-        public static DetectionCandidate High(ReaderInputKind kind, string mediaType, string evidence) =>
-            new DetectionCandidate(kind, ReaderDetectionConfidence.High, mediaType, new[] { evidence });
+        public static DetectionCandidate High(
+            ReaderInputKind kind,
+            string mediaType,
+            string evidence,
+            bool mediaTypeIsDeclared = false) =>
+            new DetectionCandidate(
+                kind,
+                ReaderDetectionConfidence.High,
+                mediaType,
+                new[] { evidence },
+                mediaTypeIsDeclared);
     }
 
     private sealed class HandlerDetectionResolution {

--- a/OfficeIMO.Reader/DocumentReader.Detection.cs
+++ b/OfficeIMO.Reader/DocumentReader.Detection.cs
@@ -644,6 +644,9 @@ internal static partial class DocumentReaderEngine {
             ".json" => "application/json",
             ".xml" => "application/xml",
             ".yml" or ".yaml" => "application/yaml",
+            ".odt" => "application/vnd.oasis.opendocument.text",
+            ".ods" => "application/vnd.oasis.opendocument.spreadsheet",
+            ".odp" => "application/vnd.oasis.opendocument.presentation",
             _ => GetMediaType(kind)
         };
     }

--- a/OfficeIMO.Reader/README.md
+++ b/OfficeIMO.Reader/README.md
@@ -92,6 +92,22 @@ var chunks = reader.Read(@"C:\Docs\data.json").ToList();
 
 `Build()` freezes the handler configuration. The resulting `OfficeDocumentReader` is safe to reuse across concurrent reads and is unaffected by later builder changes. `DocumentReader` remains the simple built-in-only facade; modular formats are configured explicitly on `OfficeDocumentReaderBuilder`, so one reader cannot change another reader or process-wide state.
 
+When the application wants every local adapter, `OfficeIMO.Reader.All` provides the same explicit, instance-scoped composition in one call:
+
+```powershell
+dotnet add package OfficeIMO.Reader.All
+```
+
+```csharp
+using OfficeIMO.Reader.All;
+
+OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+    .AddAllOfficeIMOHandlers()
+    .Build();
+```
+
+The preset contains no parser or provider logic. It excludes OCR engines, process adapters, network clients, and hosted providers; those remain explicit host choices.
+
 ## Async and bounded batches
 
 Configure the instance-wide async limit once, then use the same reader for individual or batched work:

--- a/OfficeIMO.sln
+++ b/OfficeIMO.sln
@@ -146,6 +146,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.MarkdownRenderer"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OfficeIMO.Reader", "OfficeIMO.Reader\OfficeIMO.Reader.csproj", "{3731577E-0CFF-4089-9A55-94CF0527A8E5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Reader.All", "OfficeIMO.Reader.All\OfficeIMO.Reader.All.csproj", "{D97FD999-4C8F-4EC0-A975-6364D9404462}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Reader.Ocr.Process", "OfficeIMO.Reader.Ocr.Process\OfficeIMO.Reader.Ocr.Process.csproj", "{A8F9B0C1-D2E3-4F50-9123-456789ABCDEF}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Reader.Ocr.Tesseract", "OfficeIMO.Reader.Ocr.Tesseract\OfficeIMO.Reader.Ocr.Tesseract.csproj", "{B9C0D1E2-F3A4-5061-A234-56789ABCDEF0}"
@@ -524,6 +526,18 @@ Global
 		{3731577E-0CFF-4089-9A55-94CF0527A8E5}.Release|x64.Build.0 = Release|Any CPU
 		{3731577E-0CFF-4089-9A55-94CF0527A8E5}.Release|x86.ActiveCfg = Release|Any CPU
 		{3731577E-0CFF-4089-9A55-94CF0527A8E5}.Release|x86.Build.0 = Release|Any CPU
+		{D97FD999-4C8F-4EC0-A975-6364D9404462}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D97FD999-4C8F-4EC0-A975-6364D9404462}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D97FD999-4C8F-4EC0-A975-6364D9404462}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D97FD999-4C8F-4EC0-A975-6364D9404462}.Debug|x64.Build.0 = Debug|Any CPU
+		{D97FD999-4C8F-4EC0-A975-6364D9404462}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D97FD999-4C8F-4EC0-A975-6364D9404462}.Debug|x86.Build.0 = Debug|Any CPU
+		{D97FD999-4C8F-4EC0-A975-6364D9404462}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D97FD999-4C8F-4EC0-A975-6364D9404462}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D97FD999-4C8F-4EC0-A975-6364D9404462}.Release|x64.ActiveCfg = Release|Any CPU
+		{D97FD999-4C8F-4EC0-A975-6364D9404462}.Release|x64.Build.0 = Release|Any CPU
+		{D97FD999-4C8F-4EC0-A975-6364D9404462}.Release|x86.ActiveCfg = Release|Any CPU
+		{D97FD999-4C8F-4EC0-A975-6364D9404462}.Release|x86.Build.0 = Release|Any CPU
 		{485EC640-7670-441B-81DD-BE927EC43429}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{485EC640-7670-441B-81DD-BE927EC43429}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{485EC640-7670-441B-81DD-BE927EC43429}.Debug|x64.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
## Summary

- add the OfficeIMO.Reader.All composition package
- provide one AddAllOfficeIMOHandlers API with typed per-format options
- preserve standard ODT, ODS, and ODP routing with exact OpenDocument media types, including the package-declared subtype when `PreferContent` receives a cross-labeled file
- retain ZIP traversal as the fallback when OpenDocument packages are detected but only the ZIP adapter is registered
- register the existing local Reader adapters while preserving immutable, instance-scoped reader configuration
- keep parser and provider behavior in the owning packages

## Boundary

The preset contains no parser or global registration logic. It excludes OCR engines, process adapters, network clients, models, and hosted providers. Later local image, notebook, and subtitle adapters join the same OfficeIMO-only graph in PR5; explicit web retrieval remains outside this preset.

## Validation

- final stacked Reader suite: 636/636 on net8.0 and 636/636 on net10.0
- All package builds and packs for .NET Standard 2.0, .NET 8, and .NET 10
- packed manifest contains only OfficeIMO.Reader and modular OfficeIMO.Reader adapter packages

## Stack

This PR is intentionally based on #2083 and its diff contains only the all-handlers preset work.



