### PR TITLE
Add dependency-bounded Reader command-line tool

### DIFF
--- a/Build/project.build.json
+++ b/Build/project.build.json
@@ -47,6 +47,7 @@
     "OfficeIMO.Reader.Ocr.Tesseract": "2.0.X",
     "OfficeIMO.Reader.Pdf": "2.0.X",
     "OfficeIMO.Reader.Rtf": "2.0.X",
+    "OfficeIMO.Reader.Tool": "2.0.X",
     "OfficeIMO.Reader.Visio": "2.0.X",
     "OfficeIMO.Reader.Xml": "2.0.X",
     "OfficeIMO.Reader.Yaml": "2.0.X",

--- a/OfficeIMO.Reader.Tests/OfficeIMO.Reader.Tests.csproj
+++ b/OfficeIMO.Reader.Tests/OfficeIMO.Reader.Tests.csproj
@@ -59,12 +59,14 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
+    <ProjectReference Include="..\OfficeIMO.Reader.Tool\OfficeIMO.Reader.Tool.csproj" />
     <Compile Include="..\OfficeIMO.Reader.Benchmarks\Comparison\*.cs"
              Link="ReaderComparison\%(Filename)%(Extension)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Compile Remove="Reader.ComparisonEvidence.cs" />
+    <Compile Remove="Reader.Tool.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OfficeIMO.Reader.Tests/Reader.Tool.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Tool.cs
@@ -90,6 +90,78 @@ public sealed class ReaderToolTests {
     }
 
     [Fact]
+    public async Task FolderUsesABoundedPerFileDefaultAndSupportsAnExplicitLimit() {
+        using var temporary = new ReaderToolTemporaryDirectory();
+        string inputRoot = Path.Combine(temporary.Path, "input");
+        string outputRoot = Path.Combine(temporary.Path, "output");
+        Directory.CreateDirectory(inputRoot);
+        await File.WriteAllTextAsync(Path.Combine(inputRoot, "large.txt"), "0123456789abcdefg");
+        ReaderToolArguments defaults = ReaderToolArguments.Parse(new[] {
+            "folder", inputRoot, "--output", outputRoot
+        });
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        int exitCode = await ReaderToolApp.RunAsync(
+            new[] {
+                "folder", inputRoot,
+                "--output", outputRoot,
+                "--max-input-bytes", "16"
+            },
+            Stream.Null,
+            output,
+            error);
+
+        Assert.Equal(ReaderToolArguments.DefaultMaxInputBytes, defaults.MaxInputBytes);
+        Assert.Equal((int)ReaderToolExitCode.ReadFailed, exitCode);
+        Assert.Contains("MaxInputBytes", error.ToString(), StringComparison.Ordinal);
+        Assert.False(Directory.Exists(outputRoot));
+    }
+
+    [Fact]
+    public async Task ReadRejectsAnOutputThatAliasesTheInput() {
+        using var temporary = new ReaderToolTemporaryDirectory();
+        string inputPath = Path.Combine(temporary.Path, "input.md");
+        const string original = "# Original";
+        await File.WriteAllTextAsync(inputPath, original);
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        int exitCode = await ReaderToolApp.RunAsync(
+            new[] { "read", inputPath, "--output", inputPath },
+            Stream.Null,
+            output,
+            error);
+
+        Assert.Equal((int)ReaderToolExitCode.OutputFailed, exitCode);
+        Assert.Contains("different from the input", error.ToString(), StringComparison.Ordinal);
+        Assert.Equal(original, await File.ReadAllTextAsync(inputPath));
+    }
+
+    [Fact]
+    public async Task ReadRejectsASymbolicOutputThatTargetsTheInput() {
+        if (OperatingSystem.IsWindows()) return;
+        using var temporary = new ReaderToolTemporaryDirectory();
+        string inputPath = Path.Combine(temporary.Path, "input.md");
+        string outputPath = Path.Combine(temporary.Path, "output.md");
+        const string original = "# Original";
+        await File.WriteAllTextAsync(inputPath, original);
+        File.CreateSymbolicLink(outputPath, inputPath);
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        int exitCode = await ReaderToolApp.RunAsync(
+            new[] { "read", inputPath, "--output", outputPath },
+            Stream.Null,
+            output,
+            error);
+
+        Assert.Equal((int)ReaderToolExitCode.OutputFailed, exitCode);
+        Assert.Contains("different from the input", error.ToString(), StringComparison.Ordinal);
+        Assert.Equal(original, await File.ReadAllTextAsync(inputPath));
+    }
+
+    [Fact]
     public async Task CapabilityListExcludesDependencyBackedProviders() {
         using var output = new StringWriter();
         using var error = new StringWriter();

--- a/OfficeIMO.Reader.Tests/Reader.Tool.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Tool.cs
@@ -214,9 +214,9 @@ public sealed class ReaderToolTests {
     }
 
     [Fact]
-    public void FolderDiscoveryStopsAtMaxFilesAndSortsBoundedResults() {
+    public void FolderDiscoverySelectsTheSameBoundedLexicographicSubset() {
         using var temporary = new ReaderToolTemporaryDirectory();
-        for (int index = 0; index < 100; index++) {
+        for (int index = 99; index >= 0; index--) {
             File.WriteAllText(Path.Combine(temporary.Path, index.ToString("D3") + ".md"), "# Document");
         }
         OfficeDocumentReader reader = new OfficeDocumentReaderBuilder().Build();
@@ -230,7 +230,21 @@ public sealed class ReaderToolTests {
             CancellationToken.None);
 
         Assert.Equal(3, paths.Count);
-        Assert.Equal(paths.OrderBy(path => path, StringComparer.Ordinal), paths);
+        Assert.Equal(new[] { "000.md", "001.md", "002.md" }, paths.Select(Path.GetFileName));
+    }
+
+    [Fact]
+    public void MacPathSafetyTreatsCasingAliasesAsTheSameInputTree() {
+        if (!OperatingSystem.IsMacOS()) return;
+        using var temporary = new ReaderToolTemporaryDirectory();
+        string input = Path.Combine(temporary.Path, "Input");
+        Directory.CreateDirectory(input);
+        string casingAlias = Path.Combine(temporary.Path, "input", "converted");
+
+        ReaderToolOutputException exception = Assert.Throws<ReaderToolOutputException>(() =>
+            ReaderToolPathSafety.EnsureOutsideInput(input, casingAlias));
+
+        Assert.Contains("outside the input folder", exception.Message, StringComparison.Ordinal);
     }
 }
 

--- a/OfficeIMO.Reader.Tests/Reader.Tool.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Tool.cs
@@ -24,6 +24,25 @@ public sealed class ReaderToolTests {
     }
 
     [Fact]
+    public async Task StandardInputUsesABoundedDefaultAndSupportsAnExplicitLimit() {
+        ReaderToolArguments defaults = ReaderToolArguments.Parse(new[] { "read", "-" });
+        Assert.Equal(ReaderToolArguments.DefaultMaxInputBytes, defaults.MaxInputBytes);
+
+        await using var input = new ReaderToolNonSeekableStream(Encoding.UTF8.GetBytes("0123456789abcdefg"));
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        int exitCode = await ReaderToolApp.RunAsync(
+            new[] { "read", "-", "--name", "input.txt", "--max-input-bytes", "16" },
+            input,
+            output,
+            error);
+
+        Assert.Equal((int)ReaderToolExitCode.ReadFailed, exitCode);
+        Assert.Contains("MaxInputBytes", error.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task EmitsStableV5Json() {
         await using var input = new MemoryStream(Encoding.UTF8.GetBytes("plain text"));
         using var output = new StringWriter();
@@ -281,4 +300,32 @@ internal sealed class ReaderToolUnsupportedStream : Stream {
     public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
     public override void SetLength(long value) => throw new NotSupportedException();
     public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+}
+
+internal sealed class ReaderToolNonSeekableStream : Stream {
+    private readonly MemoryStream _stream;
+
+    internal ReaderToolNonSeekableStream(byte[] bytes) {
+        _stream = new MemoryStream(bytes, writable: false);
+    }
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotSupportedException();
+    public override long Position {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override void Flush() { }
+    public override int Read(byte[] buffer, int offset, int count) => _stream.Read(buffer, offset, count);
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing) {
+        if (disposing) _stream.Dispose();
+        base.Dispose(disposing);
+    }
 }

--- a/OfficeIMO.Reader.Tests/Reader.Tool.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Tool.cs
@@ -1,0 +1,201 @@
+using OfficeIMO.Reader.Tool;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Reader.Tests;
+
+public sealed class ReaderToolTests {
+    [Fact]
+    public async Task ReadsStandardInputAsMarkdown() {
+        await using var input = new MemoryStream(Encoding.UTF8.GetBytes("# Tool heading\n\nBody"));
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        int exitCode = await ReaderToolApp.RunAsync(
+            new[] { "read", "-", "--name", "input.md" },
+            input,
+            output,
+            error);
+
+        Assert.Equal((int)ReaderToolExitCode.Success, exitCode);
+        Assert.Contains("# Tool heading", output.ToString(), StringComparison.Ordinal);
+        Assert.Equal(string.Empty, error.ToString());
+    }
+
+    [Fact]
+    public async Task EmitsStableV5Json() {
+        await using var input = new MemoryStream(Encoding.UTF8.GetBytes("plain text"));
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        int exitCode = await ReaderToolApp.RunAsync(
+            new[] { "read", "-", "--name", "input.txt", "--format", "json" },
+            input,
+            output,
+            error);
+        OfficeDocumentReadResult document = OfficeDocumentReadResultJson.Deserialize(output.ToString());
+
+        Assert.Equal((int)ReaderToolExitCode.Success, exitCode);
+        Assert.Equal(OfficeDocumentReadResultSchema.CurrentVersion, document.SchemaVersion);
+        Assert.Equal(OfficeDocumentReadResultSchema.Id, document.SchemaId);
+    }
+
+    [Fact]
+    public async Task ConvertsFolderWithDeterministicRelativeOutputs() {
+        using var temporary = new ReaderToolTemporaryDirectory();
+        string inputRoot = Path.Combine(temporary.Path, "input");
+        string nestedRoot = Path.Combine(inputRoot, "nested");
+        string outputRoot = Path.Combine(temporary.Path, "output");
+        Directory.CreateDirectory(nestedRoot);
+        await File.WriteAllTextAsync(Path.Combine(inputRoot, "alpha.md"), "# Alpha");
+        await File.WriteAllTextAsync(Path.Combine(nestedRoot, "data.csv"), "name,value\none,1");
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        int exitCode = await ReaderToolApp.RunAsync(
+            new[] {
+                "folder", inputRoot,
+                "--output", outputRoot,
+                "--format", "json",
+                "--concurrency", "2"
+            },
+            Stream.Null,
+            output,
+            error);
+
+        Assert.Equal((int)ReaderToolExitCode.Success, exitCode);
+        Assert.True(File.Exists(Path.Combine(outputRoot, "alpha.md.reader.json")));
+        Assert.True(File.Exists(Path.Combine(outputRoot, "nested", "data.csv.reader.json")));
+        Assert.Equal("Converted 2 document(s)." + Environment.NewLine, error.ToString());
+    }
+
+    [Fact]
+    public async Task CapabilityListExcludesDependencyBackedProviders() {
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        int exitCode = await ReaderToolApp.RunAsync(
+            new[] { "capabilities" },
+            Stream.Null,
+            output,
+            error);
+
+        Assert.Equal((int)ReaderToolExitCode.Success, exitCode);
+        Assert.Contains("officeimo.reader.epub", output.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("ocr", output.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("provider", output.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task InvalidArgumentsReturnDocumentedUsageCode() {
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        int exitCode = await ReaderToolApp.RunAsync(
+            new[] { "folder", "missing-output" },
+            Stream.Null,
+            output,
+            error);
+
+        Assert.Equal((int)ReaderToolExitCode.Usage, exitCode);
+        Assert.Contains("requires --output", error.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MissingInputReturnsDocumentedNotFoundCode() {
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        int exitCode = await ReaderToolApp.RunAsync(
+            new[] { "read", Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "missing.md") },
+            Stream.Null,
+            output,
+            error);
+
+        Assert.Equal((int)ReaderToolExitCode.InputNotFound, exitCode);
+    }
+
+    [Fact]
+    public async Task CorruptInputReturnsDocumentedReadFailureCode() {
+        using var temporary = new ReaderToolTemporaryDirectory();
+        string path = Path.Combine(temporary.Path, "legacy.doc");
+        await File.WriteAllBytesAsync(path, new byte[] { 1, 2, 3 });
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        int exitCode = await ReaderToolApp.RunAsync(
+            new[] { "read", path },
+            Stream.Null,
+            output,
+            error);
+
+        Assert.Equal((int)ReaderToolExitCode.ReadFailed, exitCode);
+    }
+
+    [Fact]
+    public async Task UnsupportedInputReturnsDocumentedFormatCode() {
+        await using var input = new ReaderToolUnsupportedStream();
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        int exitCode = await ReaderToolApp.RunAsync(
+            new[] { "read", "-", "--name", "input.txt" },
+            input,
+            output,
+            error);
+
+        Assert.Equal((int)ReaderToolExitCode.UnsupportedInput, exitCode);
+    }
+
+    [Fact]
+    public async Task FolderRejectsOutputInsideInputTree() {
+        using var temporary = new ReaderToolTemporaryDirectory();
+        string outputPath = Path.Combine(temporary.Path, "converted");
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        int exitCode = await ReaderToolApp.RunAsync(
+            new[] { "folder", temporary.Path, "--output", outputPath },
+            Stream.Null,
+            output,
+            error);
+
+        Assert.Equal((int)ReaderToolExitCode.OutputFailed, exitCode);
+        Assert.Contains("outside the input folder", error.ToString(), StringComparison.Ordinal);
+    }
+}
+
+internal sealed class ReaderToolTemporaryDirectory : IDisposable {
+    internal ReaderToolTemporaryDirectory() {
+        Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "OfficeIMO.Reader.Tool.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path);
+    }
+
+    internal string Path { get; }
+
+    public void Dispose() {
+        try {
+            Directory.Delete(Path, recursive: true);
+        } catch (DirectoryNotFoundException) {
+        } catch (IOException) {
+        } catch (UnauthorizedAccessException) {
+        }
+    }
+}
+
+internal sealed class ReaderToolUnsupportedStream : Stream {
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotSupportedException();
+    public override long Position {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override void Flush() { }
+    public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException("Unsupported input stream.");
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+}

--- a/OfficeIMO.Reader.Tests/Reader.Tool.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Tool.cs
@@ -1,4 +1,5 @@
 using OfficeIMO.Reader.Tool;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -162,6 +163,74 @@ public sealed class ReaderToolTests {
 
         Assert.Equal((int)ReaderToolExitCode.OutputFailed, exitCode);
         Assert.Contains("outside the input folder", error.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task FolderRejectsLinkedOutputThatTargetsInputTree() {
+        if (OperatingSystem.IsWindows()) return;
+        using var temporary = new ReaderToolTemporaryDirectory();
+        string inputRoot = Path.Combine(temporary.Path, "input");
+        string convertedRoot = Path.Combine(inputRoot, "converted");
+        string linkedOutput = Path.Combine(temporary.Path, "linked-output");
+        Directory.CreateDirectory(convertedRoot);
+        Directory.CreateSymbolicLink(linkedOutput, convertedRoot);
+        await File.WriteAllTextAsync(Path.Combine(inputRoot, "document.md"), "# Input");
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        int exitCode = await ReaderToolApp.RunAsync(
+            new[] { "folder", inputRoot, "--output", linkedOutput },
+            Stream.Null,
+            output,
+            error);
+
+        Assert.Equal((int)ReaderToolExitCode.OutputFailed, exitCode);
+        Assert.Contains("outside the input folder", error.ToString(), StringComparison.Ordinal);
+        Assert.Empty(Directory.EnumerateFiles(convertedRoot));
+    }
+
+    [Fact]
+    public async Task FolderRejectsRealOutputInsideLinkedInputTree() {
+        if (OperatingSystem.IsWindows()) return;
+        using var temporary = new ReaderToolTemporaryDirectory();
+        string inputRoot = Path.Combine(temporary.Path, "input");
+        string linkedInput = Path.Combine(temporary.Path, "linked-input");
+        string outputRoot = Path.Combine(inputRoot, "converted");
+        Directory.CreateDirectory(inputRoot);
+        Directory.CreateSymbolicLink(linkedInput, inputRoot);
+        await File.WriteAllTextAsync(Path.Combine(inputRoot, "document.md"), "# Input");
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        int exitCode = await ReaderToolApp.RunAsync(
+            new[] { "folder", linkedInput, "--output", outputRoot },
+            Stream.Null,
+            output,
+            error);
+
+        Assert.Equal((int)ReaderToolExitCode.OutputFailed, exitCode);
+        Assert.Contains("outside the input folder", error.ToString(), StringComparison.Ordinal);
+        Assert.False(Directory.Exists(outputRoot));
+    }
+
+    [Fact]
+    public void FolderDiscoveryStopsAtMaxFilesAndSortsBoundedResults() {
+        using var temporary = new ReaderToolTemporaryDirectory();
+        for (int index = 0; index < 100; index++) {
+            File.WriteAllText(Path.Combine(temporary.Path, index.ToString("D3") + ".md"), "# Document");
+        }
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder().Build();
+
+        IReadOnlyList<string> paths = ReaderToolFileDiscovery.FindSupportedFiles(
+            temporary.Path,
+            reader,
+            recurse: true,
+            maxFiles: 3,
+            maxTotalBytes: null,
+            CancellationToken.None);
+
+        Assert.Equal(3, paths.Count);
+        Assert.Equal(paths.OrderBy(path => path, StringComparer.Ordinal), paths);
     }
 }
 

--- a/OfficeIMO.Reader.Tool/OfficeIMO.Reader.Tool.csproj
+++ b/OfficeIMO.Reader.Tool/OfficeIMO.Reader.Tool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <Description>Dependency-bounded command-line tool for OfficeIMO.Reader document extraction.</Description>
     <AssemblyName>OfficeIMO.Reader.Tool</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Tool</AssemblyTitle>

--- a/OfficeIMO.Reader.Tool/OfficeIMO.Reader.Tool.csproj
+++ b/OfficeIMO.Reader.Tool/OfficeIMO.Reader.Tool.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Description>Dependency-bounded command-line tool for OfficeIMO.Reader document extraction.</Description>
+    <AssemblyName>OfficeIMO.Reader.Tool</AssemblyName>
+    <AssemblyTitle>OfficeIMO.Reader.Tool</AssemblyTitle>
+    <VersionPrefix>2.0.1</VersionPrefix>
+    <Company>Evotec</Company>
+    <Authors>Przemyslaw Klys</Authors>
+    <PackageId>OfficeIMO.Reader.Tool</PackageId>
+    <PackageTags>reader;ingestion;markdown;json;cli;dotnet-tool;officeimo</PackageTags>
+    <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/EvotecIT/OfficeIMO</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageIcon>OfficeIMO.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>officeimo-reader</ToolCommandName>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <IsPackable>true</IsPackable>
+    <IsPublishable>true</IsPublishable>
+    <LangVersion>Latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OfficeIMO.Reader.All\OfficeIMO.Reader.All.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\Assets\OfficeIMO.png" Pack="true" PackagePath="\" Link="OfficeIMO.png" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="OfficeIMO.Reader.Tests" />
+  </ItemGroup>
+</Project>

--- a/OfficeIMO.Reader.Tool/Program.cs
+++ b/OfficeIMO.Reader.Tool/Program.cs
@@ -1,0 +1,14 @@
+using OfficeIMO.Reader.Tool;
+
+using var cancellation = new CancellationTokenSource();
+Console.CancelKeyPress += (_, eventArgs) => {
+    eventArgs.Cancel = true;
+    cancellation.Cancel();
+};
+
+return await ReaderToolApp.RunAsync(
+    args,
+    Console.OpenStandardInput(),
+    Console.Out,
+    Console.Error,
+    cancellation.Token).ConfigureAwait(false);

--- a/OfficeIMO.Reader.Tool/README.md
+++ b/OfficeIMO.Reader.Tool/README.md
@@ -27,10 +27,11 @@ officeimo-reader folder ./documents `
     --format json `
     --assets ./converted-assets `
     --concurrency 4 `
-    --max-files 500
+    --max-files 500 `
+    --max-input-bytes 67108864
 ```
 
-Folder output preserves relative source paths and adds `.md` or `.reader.json`. Discovery streams filesystem entries, stops at `--max-files`, skips reparse points, and sorts the selected paths before conversion; `--max-total-bytes` provides an optional aggregate input ceiling. Use `--no-recursive` for the top directory only. Output and asset paths are resolved through existing symbolic links or junctions and must remain outside the input tree.
+Folder output preserves relative source paths and adds `.md` or `.reader.json`. Each document has the same 64 MiB default input ceiling as `read`; use `--max-input-bytes` to override it. Discovery streams filesystem entries, stops at `--max-files`, skips reparse points, and sorts the selected paths before conversion; `--max-total-bytes` provides an optional aggregate input ceiling. Use `--no-recursive` for the top directory only. Output and asset paths are resolved through existing symbolic links or junctions and must remain outside the input tree.
 
 ## Inspect capabilities
 

--- a/OfficeIMO.Reader.Tool/README.md
+++ b/OfficeIMO.Reader.Tool/README.md
@@ -29,7 +29,7 @@ officeimo-reader folder ./documents `
     --max-files 500
 ```
 
-Folder output preserves relative source paths and adds `.md` or `.reader.json`. Traversal is deterministic, skips directory reparse points, and is bounded by `--max-files`; `--max-total-bytes` provides an optional aggregate input ceiling. Use `--no-recursive` for the top directory only.
+Folder output preserves relative source paths and adds `.md` or `.reader.json`. Discovery streams filesystem entries, stops at `--max-files`, skips reparse points, and sorts the selected paths before conversion; `--max-total-bytes` provides an optional aggregate input ceiling. Use `--no-recursive` for the top directory only. Output and asset paths are resolved through existing symbolic links or junctions and must remain outside the input tree.
 
 ## Inspect capabilities
 

--- a/OfficeIMO.Reader.Tool/README.md
+++ b/OfficeIMO.Reader.Tool/README.md
@@ -14,9 +14,10 @@ dotnet tool install --global OfficeIMO.Reader.Tool
 officeimo-reader read policy.docx --format markdown --output policy.md
 officeimo-reader read report.pdf --format json --output report.reader.json --assets report-assets
 Get-Content notes.md -Raw | officeimo-reader read - --name notes.md
+Get-Content archive.json -Raw | officeimo-reader read - --name archive.json --max-input-bytes 134217728
 ```
 
-`--output -` or an omitted output path writes to standard output. `--name` gives piped bytes an extension so Reader can choose the intended handler; its default is `stdin.txt`.
+`--output -` or an omitted output path writes to standard output. `--name` gives piped bytes an extension so Reader can choose the intended handler; its default is `stdin.txt`. The `read` command bounds files and standard input to 64 MiB by default; use `--max-input-bytes` for an explicit positive-byte override.
 
 ## Convert a folder
 

--- a/OfficeIMO.Reader.Tool/README.md
+++ b/OfficeIMO.Reader.Tool/README.md
@@ -1,0 +1,55 @@
+# OfficeIMO.Reader.Tool
+
+`OfficeIMO.Reader.Tool` exposes OfficeIMO's local document readers as a .NET global tool. It reads files or standard input, converts bounded folders concurrently, emits Markdown or the stable v5 JSON envelope, and materializes embedded assets.
+
+## Install
+
+```powershell
+dotnet tool install --global OfficeIMO.Reader.Tool
+```
+
+## Read a file or standard input
+
+```powershell
+officeimo-reader read policy.docx --format markdown --output policy.md
+officeimo-reader read report.pdf --format json --output report.reader.json --assets report-assets
+Get-Content notes.md -Raw | officeimo-reader read - --name notes.md
+```
+
+`--output -` or an omitted output path writes to standard output. `--name` gives piped bytes an extension so Reader can choose the intended handler; its default is `stdin.txt`.
+
+## Convert a folder
+
+```powershell
+officeimo-reader folder ./documents `
+    --output ./converted `
+    --format json `
+    --assets ./converted-assets `
+    --concurrency 4 `
+    --max-files 500
+```
+
+Folder output preserves relative source paths and adds `.md` or `.reader.json`. Traversal is deterministic, skips directory reparse points, and is bounded by `--max-files`; `--max-total-bytes` provides an optional aggregate input ceiling. Use `--no-recursive` for the top directory only.
+
+## Inspect capabilities
+
+```powershell
+officeimo-reader capabilities
+officeimo-reader capabilities --format json
+```
+
+## Exit codes
+
+| Code | Meaning |
+| ---: | --- |
+| 0 | Success |
+| 2 | Invalid command or arguments |
+| 3 | Input file or directory not found |
+| 4 | Unsupported input format |
+| 5 | Document discovery or reading failed |
+| 6 | Output or asset materialization failed |
+| 130 | Cancelled |
+
+## Dependency boundary
+
+The tool uses `OfficeIMO.Reader.All` and the existing local adapter graph. It has no third-party command parser, process launcher, native binary, model, network client, or hosted provider. OCR is not configured because an OCR engine is an explicit host dependency.

--- a/OfficeIMO.Reader.Tool/ReaderToolApp.cs
+++ b/OfficeIMO.Reader.Tool/ReaderToolApp.cs
@@ -1,0 +1,183 @@
+using OfficeIMO.Reader.All;
+
+namespace OfficeIMO.Reader.Tool;
+
+internal static class ReaderToolApp {
+    internal const string Usage = """
+OfficeIMO.Reader.Tool
+
+Usage:
+  officeimo-reader read <path|-> [--name <source-name>] [--format markdown|json] [--output <file|->] [--assets <directory>]
+  officeimo-reader folder <path> --output <directory> [--format markdown|json] [--assets <directory>] [--concurrency <1-64>]
+                          [--max-files <count>] [--max-total-bytes <bytes>] [--no-recursive]
+  officeimo-reader capabilities [--format text|json]
+
+The dependency-bounded tool does not configure OCR or hosted providers.
+""";
+
+    internal static async Task<int> RunAsync(
+        string[] args,
+        Stream standardInput,
+        TextWriter standardOutput,
+        TextWriter standardError,
+        CancellationToken cancellationToken = default) {
+        if (standardInput == null) throw new ArgumentNullException(nameof(standardInput));
+        if (standardOutput == null) throw new ArgumentNullException(nameof(standardOutput));
+        if (standardError == null) throw new ArgumentNullException(nameof(standardError));
+
+        ReaderToolArguments parsed;
+        try {
+            parsed = ReaderToolArguments.Parse(args);
+        } catch (ReaderToolUsageException exception) {
+            await standardError.WriteLineAsync(exception.Message).ConfigureAwait(false);
+            await standardError.WriteLineAsync(Usage).ConfigureAwait(false);
+            return (int)ReaderToolExitCode.Usage;
+        }
+
+        if (parsed.Command == ReaderToolCommand.Help) {
+            await standardOutput.WriteLineAsync(Usage).ConfigureAwait(false);
+            return (int)ReaderToolExitCode.Success;
+        }
+
+        try {
+            OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+                .AddAllOfficeIMOHandlers()
+                .WithMaxConcurrentReads(parsed.Concurrency)
+                .Build();
+
+            return parsed.Command switch {
+                ReaderToolCommand.Read => await RunReadAsync(
+                    parsed, reader, standardInput, standardOutput, cancellationToken).ConfigureAwait(false),
+                ReaderToolCommand.Folder => await RunFolderAsync(
+                    parsed, reader, standardError, cancellationToken).ConfigureAwait(false),
+                ReaderToolCommand.Capabilities => await RunCapabilitiesAsync(
+                    parsed, reader, standardOutput).ConfigureAwait(false),
+                _ => (int)ReaderToolExitCode.Usage
+            };
+        } catch (OperationCanceledException) {
+            await standardError.WriteLineAsync("Operation cancelled.").ConfigureAwait(false);
+            return (int)ReaderToolExitCode.Cancelled;
+        } catch (ReaderToolOutputException exception) {
+            await standardError.WriteLineAsync(exception.Message).ConfigureAwait(false);
+            return (int)ReaderToolExitCode.OutputFailed;
+        } catch (FileNotFoundException exception) {
+            await standardError.WriteLineAsync(exception.Message).ConfigureAwait(false);
+            return (int)ReaderToolExitCode.InputNotFound;
+        } catch (DirectoryNotFoundException exception) {
+            await standardError.WriteLineAsync(exception.Message).ConfigureAwait(false);
+            return (int)ReaderToolExitCode.InputNotFound;
+        } catch (NotSupportedException exception) {
+            await standardError.WriteLineAsync(exception.Message).ConfigureAwait(false);
+            return (int)ReaderToolExitCode.UnsupportedInput;
+        } catch (Exception exception) {
+            await standardError.WriteLineAsync(
+                "Document read failed: " + exception.GetType().Name + ": " + exception.Message).ConfigureAwait(false);
+            return (int)ReaderToolExitCode.ReadFailed;
+        }
+    }
+
+    private static async Task<int> RunReadAsync(
+        ReaderToolArguments options,
+        OfficeDocumentReader reader,
+        Stream standardInput,
+        TextWriter standardOutput,
+        CancellationToken cancellationToken) {
+        OfficeDocumentReadResult document;
+        if (options.InputPath == "-") {
+            document = await reader.ReadDocumentAsync(
+                standardInput,
+                options.SourceName,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+        } else {
+            string inputPath = Path.GetFullPath(options.InputPath!);
+            if (!File.Exists(inputPath)) {
+                throw new FileNotFoundException("Input file '" + inputPath + "' does not exist.", inputPath);
+            }
+            document = await reader.ReadDocumentAsync(inputPath, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        await ReaderToolOutput.WriteSingleAsync(
+            ReaderToolOutput.FormatDocument(document, options.Format),
+            options.OutputPath,
+            standardOutput,
+            cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(options.AssetsPath)) {
+            ReaderToolOutput.WriteAssets(document, options.AssetsPath!, cancellationToken);
+        }
+        return (int)ReaderToolExitCode.Success;
+    }
+
+    private static async Task<int> RunFolderAsync(
+        ReaderToolArguments options,
+        OfficeDocumentReader reader,
+        TextWriter standardError,
+        CancellationToken cancellationToken) {
+        string inputPath = Path.GetFullPath(options.InputPath!);
+        if (!Directory.Exists(inputPath)) {
+            throw new DirectoryNotFoundException("Input folder '" + inputPath + "' does not exist.");
+        }
+
+        string outputPath = Path.GetFullPath(options.OutputPath!);
+        string? assetsPath = string.IsNullOrWhiteSpace(options.AssetsPath)
+            ? null
+            : Path.GetFullPath(options.AssetsPath!);
+        if (IsSameOrChildPath(inputPath, outputPath) ||
+            (assetsPath != null && IsSameOrChildPath(inputPath, assetsPath))) {
+            throw new ReaderToolOutputException("Folder output and asset directories must be outside the input folder.");
+        }
+
+        IReadOnlyList<string> paths = ReaderToolFileDiscovery.FindSupportedFiles(
+            inputPath,
+            reader,
+            options.Recurse,
+            options.MaxFiles,
+            options.MaxTotalBytes,
+            cancellationToken);
+        IReadOnlyList<OfficeDocumentReadResult> documents = await reader.ReadDocumentsAsync(
+            paths,
+            batchOptions: new ReaderBatchOptions {
+                MaxDegreeOfParallelism = options.Concurrency,
+                MaxDocuments = options.MaxFiles
+            },
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        await ReaderToolOutput.WriteFolderAsync(
+            inputPath,
+            outputPath,
+            assetsPath,
+            paths,
+            documents,
+            options.Format,
+            cancellationToken).ConfigureAwait(false);
+        await standardError.WriteLineAsync("Converted " + paths.Count + " document(s).").ConfigureAwait(false);
+        return (int)ReaderToolExitCode.Success;
+    }
+
+    private static bool IsSameOrChildPath(string parentPath, string candidatePath) {
+        string parent = Path.TrimEndingDirectorySeparator(Path.GetFullPath(parentPath));
+        string candidate = Path.TrimEndingDirectorySeparator(Path.GetFullPath(candidatePath));
+        StringComparison comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        if (string.Equals(parent, candidate, comparison)) return true;
+        return candidate.StartsWith(parent + Path.DirectorySeparatorChar, comparison);
+    }
+
+    private static async Task<int> RunCapabilitiesAsync(
+        ReaderToolArguments options,
+        OfficeDocumentReader reader,
+        TextWriter standardOutput) {
+        if (options.Format == ReaderToolOutputFormat.Json) {
+            await standardOutput.WriteLineAsync(reader.GetCapabilityManifestJson(indented: true)).ConfigureAwait(false);
+            return (int)ReaderToolExitCode.Success;
+        }
+
+        foreach (ReaderHandlerCapability capability in reader.GetCapabilities()) {
+            string scope = capability.IsBuiltIn ? "built-in" : "adapter";
+            await standardOutput.WriteLineAsync(
+                capability.Id + "\t" + scope + "\t" + string.Join(",", capability.Extensions)).ConfigureAwait(false);
+        }
+        return (int)ReaderToolExitCode.Success;
+    }
+}

--- a/OfficeIMO.Reader.Tool/ReaderToolApp.cs
+++ b/OfficeIMO.Reader.Tool/ReaderToolApp.cs
@@ -10,7 +10,7 @@ Usage:
   officeimo-reader read <path|-> [--name <source-name>] [--format markdown|json] [--output <file|->] [--assets <directory>]
                                 [--max-input-bytes <bytes>]
   officeimo-reader folder <path> --output <directory> [--format markdown|json] [--assets <directory>] [--concurrency <1-64>]
-                          [--max-files <count>] [--max-total-bytes <bytes>] [--no-recursive]
+                          [--max-files <count>] [--max-total-bytes <bytes>] [--max-input-bytes <bytes>] [--no-recursive]
   officeimo-reader capabilities [--format text|json]
 
 The dependency-bounded tool does not configure OCR or hosted providers.
@@ -96,6 +96,9 @@ The dependency-bounded tool does not configure OCR or hosted providers.
             if (!File.Exists(inputPath)) {
                 throw new FileNotFoundException("Input file '" + inputPath + "' does not exist.", inputPath);
             }
+            if (!string.IsNullOrWhiteSpace(options.OutputPath) && options.OutputPath != "-") {
+                ReaderToolPathSafety.EnsureDistinctFile(inputPath, options.OutputPath!);
+            }
             document = await reader.ReadDocumentAsync(inputPath, readerOptions, cancellationToken)
                 .ConfigureAwait(false);
         }
@@ -136,6 +139,7 @@ The dependency-bounded tool does not configure OCR or hosted providers.
             cancellationToken);
         IReadOnlyList<OfficeDocumentReadResult> documents = await reader.ReadDocumentsAsync(
             paths,
+            options: new ReaderOptions { MaxInputBytes = options.MaxInputBytes },
             batchOptions: new ReaderBatchOptions {
                 MaxDegreeOfParallelism = options.Concurrency,
                 MaxDocuments = options.MaxFiles

--- a/OfficeIMO.Reader.Tool/ReaderToolApp.cs
+++ b/OfficeIMO.Reader.Tool/ReaderToolApp.cs
@@ -122,10 +122,7 @@ The dependency-bounded tool does not configure OCR or hosted providers.
         string? assetsPath = string.IsNullOrWhiteSpace(options.AssetsPath)
             ? null
             : Path.GetFullPath(options.AssetsPath!);
-        if (IsSameOrChildPath(inputPath, outputPath) ||
-            (assetsPath != null && IsSameOrChildPath(inputPath, assetsPath))) {
-            throw new ReaderToolOutputException("Folder output and asset directories must be outside the input folder.");
-        }
+        ReaderToolPathSafety.EnsureOutsideInput(inputPath, outputPath, assetsPath);
 
         IReadOnlyList<string> paths = ReaderToolFileDiscovery.FindSupportedFiles(
             inputPath,
@@ -152,16 +149,6 @@ The dependency-bounded tool does not configure OCR or hosted providers.
             cancellationToken).ConfigureAwait(false);
         await standardError.WriteLineAsync("Converted " + paths.Count + " document(s).").ConfigureAwait(false);
         return (int)ReaderToolExitCode.Success;
-    }
-
-    private static bool IsSameOrChildPath(string parentPath, string candidatePath) {
-        string parent = Path.TrimEndingDirectorySeparator(Path.GetFullPath(parentPath));
-        string candidate = Path.TrimEndingDirectorySeparator(Path.GetFullPath(candidatePath));
-        StringComparison comparison = OperatingSystem.IsWindows()
-            ? StringComparison.OrdinalIgnoreCase
-            : StringComparison.Ordinal;
-        if (string.Equals(parent, candidate, comparison)) return true;
-        return candidate.StartsWith(parent + Path.DirectorySeparatorChar, comparison);
     }
 
     private static async Task<int> RunCapabilitiesAsync(

--- a/OfficeIMO.Reader.Tool/ReaderToolApp.cs
+++ b/OfficeIMO.Reader.Tool/ReaderToolApp.cs
@@ -8,6 +8,7 @@ OfficeIMO.Reader.Tool
 
 Usage:
   officeimo-reader read <path|-> [--name <source-name>] [--format markdown|json] [--output <file|->] [--assets <directory>]
+                                [--max-input-bytes <bytes>]
   officeimo-reader folder <path> --output <directory> [--format markdown|json] [--assets <directory>] [--concurrency <1-64>]
                           [--max-files <count>] [--max-total-bytes <bytes>] [--no-recursive]
   officeimo-reader capabilities [--format text|json]
@@ -82,18 +83,20 @@ The dependency-bounded tool does not configure OCR or hosted providers.
         Stream standardInput,
         TextWriter standardOutput,
         CancellationToken cancellationToken) {
+        var readerOptions = new ReaderOptions { MaxInputBytes = options.MaxInputBytes };
         OfficeDocumentReadResult document;
         if (options.InputPath == "-") {
             document = await reader.ReadDocumentAsync(
                 standardInput,
                 options.SourceName,
+                readerOptions,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
         } else {
             string inputPath = Path.GetFullPath(options.InputPath!);
             if (!File.Exists(inputPath)) {
                 throw new FileNotFoundException("Input file '" + inputPath + "' does not exist.", inputPath);
             }
-            document = await reader.ReadDocumentAsync(inputPath, cancellationToken: cancellationToken)
+            document = await reader.ReadDocumentAsync(inputPath, readerOptions, cancellationToken)
                 .ConfigureAwait(false);
         }
 

--- a/OfficeIMO.Reader.Tool/ReaderToolArguments.cs
+++ b/OfficeIMO.Reader.Tool/ReaderToolArguments.cs
@@ -31,7 +31,7 @@ internal sealed class ReaderToolArguments {
     internal bool Recurse { get; private set; } = true;
     private bool ConcurrencySpecified { get; set; }
     private bool FolderLimitSpecified { get; set; }
-    private bool ReadLimitSpecified { get; set; }
+    private bool InputLimitSpecified { get; set; }
     private bool RecursionSpecified { get; set; }
 
     internal static ReaderToolArguments Parse(string[] args) {
@@ -82,7 +82,7 @@ internal sealed class ReaderToolArguments {
                     break;
                 case "--max-input-bytes":
                     parsed.MaxInputBytes = ParsePositiveLong(NextValue(args, ref index, token), token);
-                    parsed.ReadLimitSpecified = true;
+                    parsed.InputLimitSpecified = true;
                     break;
                 case "--recursive":
                     parsed.Recurse = true;
@@ -111,7 +111,7 @@ internal sealed class ReaderToolArguments {
     private void Validate() {
         if (Command == ReaderToolCommand.Capabilities) {
             if (InputPath != null || SourceName != null || AssetsPath != null || OutputPath != null ||
-                ConcurrencySpecified || FolderLimitSpecified || ReadLimitSpecified || RecursionSpecified) {
+                ConcurrencySpecified || FolderLimitSpecified || InputLimitSpecified || RecursionSpecified) {
                 throw new ReaderToolUsageException("The capabilities command does not accept input or output paths.");
             }
             if (Format == ReaderToolOutputFormat.Markdown) {
@@ -147,9 +147,6 @@ internal sealed class ReaderToolArguments {
         }
         if (SourceName != null) {
             throw new ReaderToolUsageException("--name is only valid when reading standard input.");
-        }
-        if (ReadLimitSpecified) {
-            throw new ReaderToolUsageException("--max-input-bytes is only valid with the read command.");
         }
     }
 

--- a/OfficeIMO.Reader.Tool/ReaderToolArguments.cs
+++ b/OfficeIMO.Reader.Tool/ReaderToolArguments.cs
@@ -16,6 +16,8 @@ internal enum ReaderToolOutputFormat {
 }
 
 internal sealed class ReaderToolArguments {
+    internal const long DefaultMaxInputBytes = 64L * 1024L * 1024L;
+
     internal ReaderToolCommand Command { get; private set; }
     internal ReaderToolOutputFormat Format { get; private set; }
     internal string? InputPath { get; private set; }
@@ -25,9 +27,11 @@ internal sealed class ReaderToolArguments {
     internal int Concurrency { get; private set; } = 4;
     internal int MaxFiles { get; private set; } = 500;
     internal long? MaxTotalBytes { get; private set; }
+    internal long MaxInputBytes { get; private set; } = DefaultMaxInputBytes;
     internal bool Recurse { get; private set; } = true;
     private bool ConcurrencySpecified { get; set; }
     private bool FolderLimitSpecified { get; set; }
+    private bool ReadLimitSpecified { get; set; }
     private bool RecursionSpecified { get; set; }
 
     internal static ReaderToolArguments Parse(string[] args) {
@@ -76,6 +80,10 @@ internal sealed class ReaderToolArguments {
                     parsed.MaxTotalBytes = ParsePositiveLong(NextValue(args, ref index, token), token);
                     parsed.FolderLimitSpecified = true;
                     break;
+                case "--max-input-bytes":
+                    parsed.MaxInputBytes = ParsePositiveLong(NextValue(args, ref index, token), token);
+                    parsed.ReadLimitSpecified = true;
+                    break;
                 case "--recursive":
                     parsed.Recurse = true;
                     parsed.RecursionSpecified = true;
@@ -103,7 +111,7 @@ internal sealed class ReaderToolArguments {
     private void Validate() {
         if (Command == ReaderToolCommand.Capabilities) {
             if (InputPath != null || SourceName != null || AssetsPath != null || OutputPath != null ||
-                ConcurrencySpecified || FolderLimitSpecified || RecursionSpecified) {
+                ConcurrencySpecified || FolderLimitSpecified || ReadLimitSpecified || RecursionSpecified) {
                 throw new ReaderToolUsageException("The capabilities command does not accept input or output paths.");
             }
             if (Format == ReaderToolOutputFormat.Markdown) {
@@ -139,6 +147,9 @@ internal sealed class ReaderToolArguments {
         }
         if (SourceName != null) {
             throw new ReaderToolUsageException("--name is only valid when reading standard input.");
+        }
+        if (ReadLimitSpecified) {
+            throw new ReaderToolUsageException("--max-input-bytes is only valid with the read command.");
         }
     }
 

--- a/OfficeIMO.Reader.Tool/ReaderToolArguments.cs
+++ b/OfficeIMO.Reader.Tool/ReaderToolArguments.cs
@@ -1,0 +1,192 @@
+using System.Globalization;
+
+namespace OfficeIMO.Reader.Tool;
+
+internal enum ReaderToolCommand {
+    Help,
+    Read,
+    Folder,
+    Capabilities
+}
+
+internal enum ReaderToolOutputFormat {
+    Markdown,
+    Json,
+    Text
+}
+
+internal sealed class ReaderToolArguments {
+    internal ReaderToolCommand Command { get; private set; }
+    internal ReaderToolOutputFormat Format { get; private set; }
+    internal string? InputPath { get; private set; }
+    internal string? SourceName { get; private set; }
+    internal string? OutputPath { get; private set; }
+    internal string? AssetsPath { get; private set; }
+    internal int Concurrency { get; private set; } = 4;
+    internal int MaxFiles { get; private set; } = 500;
+    internal long? MaxTotalBytes { get; private set; }
+    internal bool Recurse { get; private set; } = true;
+    private bool ConcurrencySpecified { get; set; }
+    private bool FolderLimitSpecified { get; set; }
+    private bool RecursionSpecified { get; set; }
+
+    internal static ReaderToolArguments Parse(string[] args) {
+        if (args == null) throw new ArgumentNullException(nameof(args));
+        if (args.Length == 0 || IsHelp(args[0])) {
+            return new ReaderToolArguments { Command = ReaderToolCommand.Help };
+        }
+
+        var parsed = new ReaderToolArguments {
+            Command = ParseCommand(args[0])
+        };
+        parsed.Format = parsed.Command == ReaderToolCommand.Capabilities
+            ? ReaderToolOutputFormat.Text
+            : ReaderToolOutputFormat.Markdown;
+
+        for (int index = 1; index < args.Length; index++) {
+            string token = args[index];
+            if (IsHelp(token)) {
+                parsed.Command = ReaderToolCommand.Help;
+                return parsed;
+            }
+
+            switch (token) {
+                case "--format":
+                    parsed.Format = ParseFormat(NextValue(args, ref index, token));
+                    break;
+                case "--output":
+                case "-o":
+                    parsed.OutputPath = NextValue(args, ref index, token);
+                    break;
+                case "--assets":
+                    parsed.AssetsPath = NextValue(args, ref index, token);
+                    break;
+                case "--name":
+                    parsed.SourceName = NextValue(args, ref index, token);
+                    break;
+                case "--concurrency":
+                    parsed.Concurrency = ParseBoundedInt(NextValue(args, ref index, token), token, 1, 64);
+                    parsed.ConcurrencySpecified = true;
+                    break;
+                case "--max-files":
+                    parsed.MaxFiles = ParseBoundedInt(NextValue(args, ref index, token), token, 1, 100_000);
+                    parsed.FolderLimitSpecified = true;
+                    break;
+                case "--max-total-bytes":
+                    parsed.MaxTotalBytes = ParsePositiveLong(NextValue(args, ref index, token), token);
+                    parsed.FolderLimitSpecified = true;
+                    break;
+                case "--recursive":
+                    parsed.Recurse = true;
+                    parsed.RecursionSpecified = true;
+                    break;
+                case "--no-recursive":
+                    parsed.Recurse = false;
+                    parsed.RecursionSpecified = true;
+                    break;
+                default:
+                    if (token.StartsWith("-", StringComparison.Ordinal) && token != "-") {
+                        throw new ReaderToolUsageException("Unknown option '" + token + "'.");
+                    }
+                    if (parsed.InputPath != null) {
+                        throw new ReaderToolUsageException("Only one input path may be specified.");
+                    }
+                    parsed.InputPath = token;
+                    break;
+            }
+        }
+
+        parsed.Validate();
+        return parsed;
+    }
+
+    private void Validate() {
+        if (Command == ReaderToolCommand.Capabilities) {
+            if (InputPath != null || SourceName != null || AssetsPath != null || OutputPath != null ||
+                ConcurrencySpecified || FolderLimitSpecified || RecursionSpecified) {
+                throw new ReaderToolUsageException("The capabilities command does not accept input or output paths.");
+            }
+            if (Format == ReaderToolOutputFormat.Markdown) {
+                throw new ReaderToolUsageException("Capabilities format must be 'text' or 'json'.");
+            }
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(InputPath)) {
+            throw new ReaderToolUsageException("The " + Command.ToString().ToLowerInvariant() + " command requires an input path.");
+        }
+        if (Format == ReaderToolOutputFormat.Text) {
+            throw new ReaderToolUsageException("Document format must be 'markdown' or 'json'.");
+        }
+
+        if (Command == ReaderToolCommand.Read) {
+            if (InputPath == "-" && string.IsNullOrWhiteSpace(SourceName)) {
+                SourceName = "stdin.txt";
+            } else if (InputPath != "-" && SourceName != null) {
+                throw new ReaderToolUsageException("--name is only valid when reading standard input.");
+            }
+            if (ConcurrencySpecified || FolderLimitSpecified || RecursionSpecified) {
+                throw new ReaderToolUsageException("Folder traversal options are only valid with the folder command.");
+            }
+            return;
+        }
+
+        if (InputPath == "-") {
+            throw new ReaderToolUsageException("The folder command does not read from standard input.");
+        }
+        if (string.IsNullOrWhiteSpace(OutputPath) || OutputPath == "-") {
+            throw new ReaderToolUsageException("The folder command requires --output <directory>.");
+        }
+        if (SourceName != null) {
+            throw new ReaderToolUsageException("--name is only valid when reading standard input.");
+        }
+    }
+
+    private static ReaderToolCommand ParseCommand(string value) {
+        return value.ToLowerInvariant() switch {
+            "read" => ReaderToolCommand.Read,
+            "folder" => ReaderToolCommand.Folder,
+            "capabilities" => ReaderToolCommand.Capabilities,
+            _ => throw new ReaderToolUsageException("Unknown command '" + value + "'.")
+        };
+    }
+
+    private static ReaderToolOutputFormat ParseFormat(string value) {
+        return value.ToLowerInvariant() switch {
+            "markdown" or "md" => ReaderToolOutputFormat.Markdown,
+            "json" => ReaderToolOutputFormat.Json,
+            "text" => ReaderToolOutputFormat.Text,
+            _ => throw new ReaderToolUsageException("Unknown format '" + value + "'.")
+        };
+    }
+
+    private static string NextValue(string[] args, ref int index, string option) {
+        if (++index >= args.Length || string.IsNullOrWhiteSpace(args[index])) {
+            throw new ReaderToolUsageException(option + " requires a value.");
+        }
+        return args[index];
+    }
+
+    private static int ParseBoundedInt(string value, string option, int minimum, int maximum) {
+        if (!int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out int parsed) ||
+            parsed < minimum || parsed > maximum) {
+            throw new ReaderToolUsageException(option + " must be between " + minimum + " and " + maximum + ".");
+        }
+        return parsed;
+    }
+
+    private static long ParsePositiveLong(string value, string option) {
+        if (!long.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out long parsed) || parsed < 1) {
+            throw new ReaderToolUsageException(option + " must be a positive integer.");
+        }
+        return parsed;
+    }
+
+    private static bool IsHelp(string value) {
+        return value is "--help" or "-h" or "help";
+    }
+}
+
+internal sealed class ReaderToolUsageException : Exception {
+    internal ReaderToolUsageException(string message) : base(message) { }
+}

--- a/OfficeIMO.Reader.Tool/ReaderToolExitCode.cs
+++ b/OfficeIMO.Reader.Tool/ReaderToolExitCode.cs
@@ -1,0 +1,11 @@
+namespace OfficeIMO.Reader.Tool;
+
+internal enum ReaderToolExitCode {
+    Success = 0,
+    Usage = 2,
+    InputNotFound = 3,
+    UnsupportedInput = 4,
+    ReadFailed = 5,
+    OutputFailed = 6,
+    Cancelled = 130
+}

--- a/OfficeIMO.Reader.Tool/ReaderToolFileDiscovery.cs
+++ b/OfficeIMO.Reader.Tool/ReaderToolFileDiscovery.cs
@@ -12,44 +12,34 @@ internal static class ReaderToolFileDiscovery {
             reader.GetCapabilities().SelectMany(capability => capability.Extensions),
             StringComparer.OrdinalIgnoreCase);
         var results = new List<string>(Math.Min(maxFiles, 256));
-        var pending = new Stack<string>();
         long totalBytes = 0;
-        pending.Push(Path.GetFullPath(rootPath));
+        var enumerationOptions = new EnumerationOptions {
+            RecurseSubdirectories = recurse,
+            AttributesToSkip = FileAttributes.ReparsePoint,
+            ReturnSpecialDirectories = false
+        };
 
-        while (pending.Count > 0 && results.Count < maxFiles) {
+        foreach (string file in Directory.EnumerateFiles(
+            Path.GetFullPath(rootPath),
+            "*",
+            enumerationOptions)) {
             cancellationToken.ThrowIfCancellationRequested();
-            string directory = pending.Pop();
-
-            string[] files = Directory.GetFiles(directory, "*", SearchOption.TopDirectoryOnly);
-            Array.Sort(files, StringComparer.Ordinal);
-            foreach (string file in files) {
-                cancellationToken.ThrowIfCancellationRequested();
-                if (results.Count >= maxFiles) break;
-                if (!extensions.Contains(Path.GetExtension(file)) &&
-                    !string.Equals(Path.GetFileName(file), "winmail.dat", StringComparison.OrdinalIgnoreCase)) {
-                    continue;
-                }
-
-                long length = new FileInfo(file).Length;
-                if (maxTotalBytes.HasValue && totalBytes + length > maxTotalBytes.Value) {
-                    return results;
-                }
-
-                totalBytes += length;
-                results.Add(file);
+            if (!extensions.Contains(Path.GetExtension(file)) &&
+                !string.Equals(Path.GetFileName(file), "winmail.dat", StringComparison.OrdinalIgnoreCase)) {
+                continue;
             }
 
-            if (!recurse) continue;
-            string[] directories = Directory.GetDirectories(directory, "*", SearchOption.TopDirectoryOnly);
-            Array.Sort(directories, StringComparer.Ordinal);
-            for (int index = directories.Length - 1; index >= 0; index--) {
-                FileAttributes attributes = File.GetAttributes(directories[index]);
-                if ((attributes & FileAttributes.ReparsePoint) == 0) {
-                    pending.Push(directories[index]);
-                }
+            long length = new FileInfo(file).Length;
+            if (maxTotalBytes.HasValue && length > maxTotalBytes.Value - totalBytes) {
+                break;
             }
+
+            totalBytes += length;
+            results.Add(file);
+            if (results.Count >= maxFiles) break;
         }
 
+        results.Sort(StringComparer.Ordinal);
         return results;
     }
 }

--- a/OfficeIMO.Reader.Tool/ReaderToolFileDiscovery.cs
+++ b/OfficeIMO.Reader.Tool/ReaderToolFileDiscovery.cs
@@ -11,8 +11,7 @@ internal static class ReaderToolFileDiscovery {
         var extensions = new HashSet<string>(
             reader.GetCapabilities().SelectMany(capability => capability.Extensions),
             StringComparer.OrdinalIgnoreCase);
-        var results = new List<string>(Math.Min(maxFiles, 256));
-        long totalBytes = 0;
+        var selected = new SortedSet<string>(StringComparer.Ordinal);
         var enumerationOptions = new EnumerationOptions {
             RecurseSubdirectories = recurse,
             AttributesToSkip = FileAttributes.ReparsePoint,
@@ -29,17 +28,20 @@ internal static class ReaderToolFileDiscovery {
                 continue;
             }
 
-            long length = new FileInfo(file).Length;
-            if (maxTotalBytes.HasValue && length > maxTotalBytes.Value - totalBytes) {
-                break;
+            selected.Add(file);
+            if (selected.Count > maxFiles) {
+                selected.Remove(selected.Max!);
             }
-
-            totalBytes += length;
-            results.Add(file);
-            if (results.Count >= maxFiles) break;
         }
 
-        results.Sort(StringComparer.Ordinal);
+        var results = new List<string>(selected.Count);
+        long totalBytes = 0;
+        foreach (string file in selected) {
+            long length = new FileInfo(file).Length;
+            if (maxTotalBytes.HasValue && length > maxTotalBytes.Value - totalBytes) break;
+            totalBytes += length;
+            results.Add(file);
+        }
         return results;
     }
 }

--- a/OfficeIMO.Reader.Tool/ReaderToolFileDiscovery.cs
+++ b/OfficeIMO.Reader.Tool/ReaderToolFileDiscovery.cs
@@ -1,0 +1,55 @@
+namespace OfficeIMO.Reader.Tool;
+
+internal static class ReaderToolFileDiscovery {
+    internal static IReadOnlyList<string> FindSupportedFiles(
+        string rootPath,
+        OfficeDocumentReader reader,
+        bool recurse,
+        int maxFiles,
+        long? maxTotalBytes,
+        CancellationToken cancellationToken) {
+        var extensions = new HashSet<string>(
+            reader.GetCapabilities().SelectMany(capability => capability.Extensions),
+            StringComparer.OrdinalIgnoreCase);
+        var results = new List<string>(Math.Min(maxFiles, 256));
+        var pending = new Stack<string>();
+        long totalBytes = 0;
+        pending.Push(Path.GetFullPath(rootPath));
+
+        while (pending.Count > 0 && results.Count < maxFiles) {
+            cancellationToken.ThrowIfCancellationRequested();
+            string directory = pending.Pop();
+
+            string[] files = Directory.GetFiles(directory, "*", SearchOption.TopDirectoryOnly);
+            Array.Sort(files, StringComparer.Ordinal);
+            foreach (string file in files) {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (results.Count >= maxFiles) break;
+                if (!extensions.Contains(Path.GetExtension(file)) &&
+                    !string.Equals(Path.GetFileName(file), "winmail.dat", StringComparison.OrdinalIgnoreCase)) {
+                    continue;
+                }
+
+                long length = new FileInfo(file).Length;
+                if (maxTotalBytes.HasValue && totalBytes + length > maxTotalBytes.Value) {
+                    return results;
+                }
+
+                totalBytes += length;
+                results.Add(file);
+            }
+
+            if (!recurse) continue;
+            string[] directories = Directory.GetDirectories(directory, "*", SearchOption.TopDirectoryOnly);
+            Array.Sort(directories, StringComparer.Ordinal);
+            for (int index = directories.Length - 1; index >= 0; index--) {
+                FileAttributes attributes = File.GetAttributes(directories[index]);
+                if ((attributes & FileAttributes.ReparsePoint) == 0) {
+                    pending.Push(directories[index]);
+                }
+            }
+        }
+
+        return results;
+    }
+}

--- a/OfficeIMO.Reader.Tool/ReaderToolOutput.cs
+++ b/OfficeIMO.Reader.Tool/ReaderToolOutput.cs
@@ -63,11 +63,13 @@ internal static class ReaderToolOutput {
             string relativePath = Path.GetRelativePath(sourceRoot, paths[index]);
             string suffix = format == ReaderToolOutputFormat.Json ? ".reader.json" : ".md";
             string outputPath = Path.Combine(outputRoot, relativePath + suffix);
+            ReaderToolPathSafety.EnsureOutsideInput(sourceRoot, outputPath);
             await WriteFileAsync(outputPath, FormatDocument(documents[index], format), cancellationToken)
                 .ConfigureAwait(false);
 
             if (!string.IsNullOrWhiteSpace(assetsRoot) && documents[index].Assets.Count > 0) {
                 string assetDirectory = Path.Combine(assetsRoot!, relativePath + ".assets");
+                ReaderToolPathSafety.EnsureOutsideInput(sourceRoot, assetDirectory);
                 WriteAssets(documents[index], assetDirectory, cancellationToken);
             }
         }

--- a/OfficeIMO.Reader.Tool/ReaderToolOutput.cs
+++ b/OfficeIMO.Reader.Tool/ReaderToolOutput.cs
@@ -94,14 +94,30 @@ internal static class ReaderToolOutput {
     }
 
     private static async Task WriteFileAsync(string path, string content, CancellationToken cancellationToken) {
+        string? temporaryPath = null;
         try {
-            string? directory = Path.GetDirectoryName(Path.GetFullPath(path));
+            string fullPath = Path.GetFullPath(path);
+            string? directory = Path.GetDirectoryName(fullPath);
             if (!string.IsNullOrEmpty(directory)) {
                 Directory.CreateDirectory(directory);
             }
-            await File.WriteAllTextAsync(path, content, Utf8WithoutBom, cancellationToken).ConfigureAwait(false);
+            string outputDirectory = string.IsNullOrEmpty(directory) ? Directory.GetCurrentDirectory() : directory!;
+            temporaryPath = Path.Combine(
+                outputDirectory,
+                "." + Path.GetFileName(fullPath) + "." + Guid.NewGuid().ToString("N") + ".tmp");
+            await File.WriteAllTextAsync(temporaryPath, content, Utf8WithoutBom, cancellationToken).ConfigureAwait(false);
+            File.Move(temporaryPath, fullPath, overwrite: true);
+            temporaryPath = null;
         } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
             throw new ReaderToolOutputException("Could not write output file '" + path + "'.", exception);
+        } finally {
+            if (temporaryPath != null) {
+                try {
+                    File.Delete(temporaryPath);
+                } catch (IOException) {
+                } catch (UnauthorizedAccessException) {
+                }
+            }
         }
     }
 }

--- a/OfficeIMO.Reader.Tool/ReaderToolOutput.cs
+++ b/OfficeIMO.Reader.Tool/ReaderToolOutput.cs
@@ -1,0 +1,110 @@
+using System.Text;
+
+namespace OfficeIMO.Reader.Tool;
+
+internal static class ReaderToolOutput {
+    private static readonly Encoding Utf8WithoutBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+    internal static string FormatDocument(OfficeDocumentReadResult document, ReaderToolOutputFormat format) {
+        if (format == ReaderToolOutputFormat.Json) {
+            return OfficeDocumentReadResultJson.Serialize(document, indented: true);
+        }
+
+        if (!string.IsNullOrEmpty(document.Markdown)) {
+            return document.Markdown!;
+        }
+
+        return string.Join(
+            Environment.NewLine + Environment.NewLine,
+            (document.Chunks ?? Array.Empty<ReaderChunk>())
+                .Select(chunk => chunk.Markdown ?? chunk.Text)
+                .Where(value => !string.IsNullOrWhiteSpace(value)));
+    }
+
+    internal static async Task WriteSingleAsync(
+        string content,
+        string? outputPath,
+        TextWriter standardOutput,
+        CancellationToken cancellationToken) {
+        if (string.IsNullOrWhiteSpace(outputPath) || outputPath == "-") {
+            await standardOutput.WriteAsync(content.AsMemory(), cancellationToken).ConfigureAwait(false);
+            if (!content.EndsWith("\n", StringComparison.Ordinal)) {
+                await standardOutput.WriteLineAsync().ConfigureAwait(false);
+            }
+            return;
+        }
+
+        await WriteFileAsync(outputPath!, content, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static async Task WriteFolderAsync(
+        string sourceRoot,
+        string outputRoot,
+        string? assetsRoot,
+        IReadOnlyList<string> paths,
+        IReadOnlyList<OfficeDocumentReadResult> documents,
+        ReaderToolOutputFormat format,
+        CancellationToken cancellationToken) {
+        if (File.Exists(outputRoot)) {
+            throw new ReaderToolOutputException("Output path '" + outputRoot + "' is a file.");
+        }
+
+        try {
+            Directory.CreateDirectory(outputRoot);
+            if (!string.IsNullOrWhiteSpace(assetsRoot)) {
+                Directory.CreateDirectory(assetsRoot!);
+            }
+        } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+            throw new ReaderToolOutputException("Could not create an output directory.", exception);
+        }
+
+        for (int index = 0; index < paths.Count; index++) {
+            cancellationToken.ThrowIfCancellationRequested();
+            string relativePath = Path.GetRelativePath(sourceRoot, paths[index]);
+            string suffix = format == ReaderToolOutputFormat.Json ? ".reader.json" : ".md";
+            string outputPath = Path.Combine(outputRoot, relativePath + suffix);
+            await WriteFileAsync(outputPath, FormatDocument(documents[index], format), cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!string.IsNullOrWhiteSpace(assetsRoot) && documents[index].Assets.Count > 0) {
+                string assetDirectory = Path.Combine(assetsRoot!, relativePath + ".assets");
+                WriteAssets(documents[index], assetDirectory, cancellationToken);
+            }
+        }
+    }
+
+    internal static void WriteAssets(
+        OfficeDocumentReadResult document,
+        string assetsPath,
+        CancellationToken cancellationToken) {
+        try {
+            document.WriteAssetsToDirectory(
+                assetsPath,
+                new OfficeDocumentAssetMaterializationOptions {
+                    CreateDirectory = true,
+                    Overwrite = true,
+                    ValidatePayloadHash = true
+                },
+                cancellationToken);
+        } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+            throw new ReaderToolOutputException("Could not materialize document assets.", exception);
+        }
+    }
+
+    private static async Task WriteFileAsync(string path, string content, CancellationToken cancellationToken) {
+        try {
+            string? directory = Path.GetDirectoryName(Path.GetFullPath(path));
+            if (!string.IsNullOrEmpty(directory)) {
+                Directory.CreateDirectory(directory);
+            }
+            await File.WriteAllTextAsync(path, content, Utf8WithoutBom, cancellationToken).ConfigureAwait(false);
+        } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+            throw new ReaderToolOutputException("Could not write output file '" + path + "'.", exception);
+        }
+    }
+}
+
+internal sealed class ReaderToolOutputException : Exception {
+    internal ReaderToolOutputException(string message) : base(message) { }
+    internal ReaderToolOutputException(string message, Exception innerException) : base(message, innerException) { }
+}

--- a/OfficeIMO.Reader.Tool/ReaderToolPathSafety.cs
+++ b/OfficeIMO.Reader.Tool/ReaderToolPathSafety.cs
@@ -15,9 +15,7 @@ internal static class ReaderToolPathSafety {
 
     private static string ResolveExistingLinks(string path) {
         string current = Path.GetFullPath(path);
-        StringComparison comparison = OperatingSystem.IsWindows()
-            ? StringComparison.OrdinalIgnoreCase
-            : StringComparison.Ordinal;
+        StringComparison comparison = PathComparison;
         for (int pass = 0; pass < 40; pass++) {
             string resolved = ResolveLinkPass(current);
             if (string.Equals(current, resolved, comparison)) return resolved;
@@ -72,13 +70,16 @@ internal static class ReaderToolPathSafety {
     }
 
     private static bool IsSameOrChildPath(string parentPath, string candidatePath) {
-        StringComparison comparison = OperatingSystem.IsWindows()
-            ? StringComparison.OrdinalIgnoreCase
-            : StringComparison.Ordinal;
+        StringComparison comparison = PathComparison;
         if (string.Equals(parentPath, candidatePath, comparison)) return true;
         string parentPrefix = Path.EndsInDirectorySeparator(parentPath)
             ? parentPath
             : parentPath + Path.DirectorySeparatorChar;
         return candidatePath.StartsWith(parentPrefix, comparison);
     }
+
+    private static StringComparison PathComparison =>
+        OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
 }

--- a/OfficeIMO.Reader.Tool/ReaderToolPathSafety.cs
+++ b/OfficeIMO.Reader.Tool/ReaderToolPathSafety.cs
@@ -1,6 +1,14 @@
 namespace OfficeIMO.Reader.Tool;
 
 internal static class ReaderToolPathSafety {
+    internal static void EnsureDistinctFile(string inputPath, string outputPath) {
+        string resolvedInput = ResolveExistingLinks(inputPath);
+        string resolvedOutput = ResolveExistingLinks(outputPath);
+        if (string.Equals(resolvedInput, resolvedOutput, PathComparison)) {
+            throw new ReaderToolOutputException("Output file must be different from the input file.");
+        }
+    }
+
     internal static void EnsureOutsideInput(string inputPath, params string?[] candidatePaths) {
         string resolvedInput = ResolveExistingLinks(inputPath);
         foreach (string? candidatePath in candidatePaths) {

--- a/OfficeIMO.Reader.Tool/ReaderToolPathSafety.cs
+++ b/OfficeIMO.Reader.Tool/ReaderToolPathSafety.cs
@@ -1,0 +1,84 @@
+namespace OfficeIMO.Reader.Tool;
+
+internal static class ReaderToolPathSafety {
+    internal static void EnsureOutsideInput(string inputPath, params string?[] candidatePaths) {
+        string resolvedInput = ResolveExistingLinks(inputPath);
+        foreach (string? candidatePath in candidatePaths) {
+            if (string.IsNullOrWhiteSpace(candidatePath)) continue;
+            string resolvedCandidate = ResolveExistingLinks(candidatePath!);
+            if (IsSameOrChildPath(resolvedInput, resolvedCandidate)) {
+                throw new ReaderToolOutputException(
+                    "Folder output and asset directories must be outside the input folder.");
+            }
+        }
+    }
+
+    private static string ResolveExistingLinks(string path) {
+        string current = Path.GetFullPath(path);
+        StringComparison comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        for (int pass = 0; pass < 40; pass++) {
+            string resolved = ResolveLinkPass(current);
+            if (string.Equals(current, resolved, comparison)) return resolved;
+            current = resolved;
+        }
+
+        throw new ReaderToolOutputException("Linked path resolution exceeded the supported depth.");
+    }
+
+    private static string ResolveLinkPass(string path) {
+        string fullPath = Path.GetFullPath(path);
+        string? root = Path.GetPathRoot(fullPath);
+        if (string.IsNullOrEmpty(root)) return fullPath;
+
+        string current = root;
+        string relative = fullPath.Substring(root.Length);
+        string[] segments = relative.Split(
+            new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
+            StringSplitOptions.RemoveEmptyEntries);
+        for (int index = 0; index < segments.Length; index++) {
+            current = Path.Combine(current, segments[index]);
+            bool isDirectory = Directory.Exists(current);
+            bool isFile = File.Exists(current);
+            if (!isDirectory && !isFile) {
+                for (int remainder = index + 1; remainder < segments.Length; remainder++) {
+                    current = Path.Combine(current, segments[remainder]);
+                }
+                break;
+            }
+
+            FileSystemInfo link = isDirectory
+                ? new DirectoryInfo(current)
+                : new FileInfo(current);
+            try {
+                if (link.LinkTarget == null) continue;
+                FileSystemInfo? target = link.ResolveLinkTarget(returnFinalTarget: true);
+                if (target == null) {
+                    throw new ReaderToolOutputException(
+                        "Could not resolve linked path '" + current + "'.");
+                }
+                current = Path.GetFullPath(target.FullName);
+            } catch (ReaderToolOutputException) {
+                throw;
+            } catch (Exception exception) when (exception is IOException or UnauthorizedAccessException) {
+                throw new ReaderToolOutputException(
+                    "Could not resolve linked path '" + current + "'.",
+                    exception);
+            }
+        }
+
+        return Path.TrimEndingDirectorySeparator(Path.GetFullPath(current));
+    }
+
+    private static bool IsSameOrChildPath(string parentPath, string candidatePath) {
+        StringComparison comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        if (string.Equals(parentPath, candidatePath, comparison)) return true;
+        string parentPrefix = Path.EndsInDirectorySeparator(parentPath)
+            ? parentPath
+            : parentPath + Path.DirectorySeparatorChar;
+        return candidatePath.StartsWith(parentPrefix, comparison);
+    }
+}

--- a/OfficeIMO.Reader/README.md
+++ b/OfficeIMO.Reader/README.md
@@ -108,6 +108,16 @@ OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
 
 The preset contains no parser or provider logic. It excludes OCR engines, process adapters, network clients, and hosted providers; those remain explicit host choices.
 
+For scripts and shell pipelines, install the dependency-bounded global tool:
+
+```powershell
+dotnet tool install --global OfficeIMO.Reader.Tool
+officeimo-reader read policy.docx --format markdown --output policy.md
+officeimo-reader capabilities --format json
+```
+
+`officeimo-reader folder` provides deterministic, bounded folder conversion with configurable concurrency and optional asset directories. The tool emits Markdown or the stable Reader v5 JSON envelope and does not configure OCR or hosted providers.
+
 ## Async and bounded batches
 
 Configure the instance-wide async limit once, then use the same reader for individual or batched work:

--- a/OfficeIMO.sln
+++ b/OfficeIMO.sln
@@ -148,6 +148,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OfficeIMO.Reader", "OfficeI
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Reader.All", "OfficeIMO.Reader.All\OfficeIMO.Reader.All.csproj", "{D97FD999-4C8F-4EC0-A975-6364D9404462}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Reader.Tool", "OfficeIMO.Reader.Tool\OfficeIMO.Reader.Tool.csproj", "{2D7D2717-97D4-42F1-B402-B94D73212E02}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Reader.Ocr.Process", "OfficeIMO.Reader.Ocr.Process\OfficeIMO.Reader.Ocr.Process.csproj", "{A8F9B0C1-D2E3-4F50-9123-456789ABCDEF}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Reader.Ocr.Tesseract", "OfficeIMO.Reader.Ocr.Tesseract\OfficeIMO.Reader.Ocr.Tesseract.csproj", "{B9C0D1E2-F3A4-5061-A234-56789ABCDEF0}"
@@ -538,6 +540,18 @@ Global
 		{D97FD999-4C8F-4EC0-A975-6364D9404462}.Release|x64.Build.0 = Release|Any CPU
 		{D97FD999-4C8F-4EC0-A975-6364D9404462}.Release|x86.ActiveCfg = Release|Any CPU
 		{D97FD999-4C8F-4EC0-A975-6364D9404462}.Release|x86.Build.0 = Release|Any CPU
+		{2D7D2717-97D4-42F1-B402-B94D73212E02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2D7D2717-97D4-42F1-B402-B94D73212E02}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2D7D2717-97D4-42F1-B402-B94D73212E02}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2D7D2717-97D4-42F1-B402-B94D73212E02}.Debug|x64.Build.0 = Debug|Any CPU
+		{2D7D2717-97D4-42F1-B402-B94D73212E02}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2D7D2717-97D4-42F1-B402-B94D73212E02}.Debug|x86.Build.0 = Debug|Any CPU
+		{2D7D2717-97D4-42F1-B402-B94D73212E02}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2D7D2717-97D4-42F1-B402-B94D73212E02}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2D7D2717-97D4-42F1-B402-B94D73212E02}.Release|x64.ActiveCfg = Release|Any CPU
+		{2D7D2717-97D4-42F1-B402-B94D73212E02}.Release|x64.Build.0 = Release|Any CPU
+		{2D7D2717-97D4-42F1-B402-B94D73212E02}.Release|x86.ActiveCfg = Release|Any CPU
+		{2D7D2717-97D4-42F1-B402-B94D73212E02}.Release|x86.Build.0 = Release|Any CPU
 		{485EC640-7670-441B-81DD-BE927EC43429}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{485EC640-7670-441B-81DD-BE927EC43429}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{485EC640-7670-441B-81DD-BE927EC43429}.Debug|x64.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
## Summary

- Add the `officeimo-reader` .NET global tool as a thin host over `OfficeIMO.Reader.All`.
- Read files or standard input as Markdown or the stable v5 JSON envelope.
- Bound file, standard-input, and folder reads to 64 MiB per input by default, with an explicit `--max-input-bytes` override.
- Convert bounded folders concurrently with deterministic relative output paths and lexicographically stable file selection.
- Materialize document assets and expose text or JSON capability listings.
- Publish stable exit codes for usage, input, format, read, output, and cancellation failures.
- Reject output paths that alias an input through exact paths or symbolic links, and use same-directory atomic replacement to avoid partial or hard-link truncation.
- Package compatible .NET 8 and .NET 10 tool assets so repository analyzer builds use the same supported target frameworks.

## Boundaries

The tool has no command-parser package, network client, process launcher, native binary, model, hosted provider, OCR engine, or implicit web retrieval. Folder output and asset roots must stay outside the input tree.

## Validation

- Reader CLI contracts: 17 of 17 on .NET 8 and .NET 10
- CI-equivalent solution AOT and trim analyzer builds: .NET 8 and .NET 10, zero warnings
- Release tool package contains both `tools/net8.0` and `tools/net10.0`
- Release tool package contains no OCR or Tesseract assembly
- Installed-tool capability, standard-input JSON, and deterministic folder flows exercised