### PR TITLE
Add thin Reader Markdown conversion helpers

### DIFF
--- a/OfficeIMO.Reader.Tests/Reader.MarkdownConversion.cs
+++ b/OfficeIMO.Reader.Tests/Reader.MarkdownConversion.cs
@@ -1,0 +1,120 @@
+using OfficeIMO.Reader;
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class ReaderMarkdownConversionTests {
+    [Fact]
+    public void ConvertToMarkdown_PathProjectsRichResultMarkdown() {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".md");
+        try {
+            File.WriteAllText(path, "# Policy\n\nPortable content.\n");
+
+            OfficeDocumentReadResult document = OfficeDocumentReader.Default.ReadDocument(path);
+            string markdown = OfficeDocumentReader.Default.ConvertToMarkdown(path);
+
+            Assert.Equal(document.Markdown ?? string.Empty, markdown);
+        } finally {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void ConvertToMarkdown_StreamAndBytesProjectRichResultMarkdown() {
+        byte[] bytes = Encoding.UTF8.GetBytes("# Stream\n\nContent.\n");
+        using var expectedStream = new MemoryStream(bytes, writable: false);
+        using var conversionStream = new MemoryStream(bytes, writable: false);
+        OfficeDocumentReadResult document = OfficeDocumentReader.Default.ReadDocument(expectedStream, "sample.md");
+
+        string streamMarkdown = OfficeDocumentReader.Default.ConvertToMarkdown(conversionStream, "sample.md");
+        string bytesMarkdown = OfficeDocumentReader.Default.ConvertToMarkdown(bytes, "sample.md");
+
+        Assert.Equal(document.Markdown ?? string.Empty, streamMarkdown);
+        Assert.Equal(document.Markdown ?? string.Empty, bytesMarkdown);
+        Assert.True(conversionStream.CanRead);
+    }
+
+    [Fact]
+    public async Task ConvertToMarkdownAsync_PathStreamAndBytesProjectRichResultMarkdown() {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".md");
+        byte[] bytes = Encoding.UTF8.GetBytes("# Async\n\nContent.\n");
+        try {
+            File.WriteAllBytes(path, bytes);
+            OfficeDocumentReadResult document = await OfficeDocumentReader.Default.ReadDocumentAsync(path);
+            using var stream = new MemoryStream(bytes, writable: false);
+
+            string pathMarkdown = await OfficeDocumentReader.Default.ConvertToMarkdownAsync(path);
+            string streamMarkdown = await OfficeDocumentReader.Default.ConvertToMarkdownAsync(stream, "sample.md");
+            string bytesMarkdown = await OfficeDocumentReader.Default.ConvertToMarkdownAsync(bytes, "sample.md");
+
+            string expected = document.Markdown ?? string.Empty;
+            Assert.Equal(expected, pathMarkdown);
+            Assert.Equal(expected, streamMarkdown);
+            Assert.Equal(expected, bytesMarkdown);
+            Assert.True(stream.CanRead);
+        } finally {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void ConvertToMarkdown_UsesConfiguredRichHandler() {
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+            .AddHandler(new ReaderHandlerRegistration {
+                Id = "officeimo.tests.markdown-conversion",
+                Kind = ReaderInputKind.Text,
+                Extensions = new[] { ".convertix" },
+                ReadDocumentStream = (stream, sourceName, options, cancellationToken) => new OfficeDocumentReadResult {
+                    Kind = ReaderInputKind.Text,
+                    Markdown = "# Configured handler"
+                }
+            })
+            .Build();
+
+        string markdown = reader.ConvertToMarkdown(new byte[] { 1 }, "sample.convertix");
+
+        Assert.Equal("# Configured handler", markdown);
+    }
+
+    [Fact]
+    public async Task ConvertToMarkdownAsync_UsesNativeAsyncRichHandler() {
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+            .AddHandler(new ReaderHandlerRegistration {
+                Id = "officeimo.tests.markdown-conversion-async",
+                Kind = ReaderInputKind.Text,
+                Extensions = new[] { ".asyncconvertix" },
+                ReadDocumentStreamAsync = (stream, sourceName, options, cancellationToken) => Task.FromResult(
+                    new OfficeDocumentReadResult {
+                        Kind = ReaderInputKind.Text,
+                        Markdown = "# Native async handler"
+                    })
+            })
+            .Build();
+
+        string markdown = await reader.ConvertToMarkdownAsync(new byte[] { 1 }, "sample.asyncconvertix");
+
+        Assert.Equal("# Native async handler", markdown);
+    }
+
+    [Fact]
+    public void ConvertToMarkdown_ReturnsEmptyStringWhenRichResultHasNoMarkdown() {
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+            .AddHandler(new ReaderHandlerRegistration {
+                Id = "officeimo.tests.markdown-conversion-empty",
+                Kind = ReaderInputKind.Text,
+                Extensions = new[] { ".emptyconvertix" },
+                ReadDocumentStream = (stream, sourceName, options, cancellationToken) => new OfficeDocumentReadResult {
+                    Kind = ReaderInputKind.Text
+                }
+            })
+            .Build();
+
+        string markdown = reader.ConvertToMarkdown(new byte[] { 1 }, "sample.emptyconvertix");
+
+        Assert.Equal(string.Empty, markdown);
+    }
+}

--- a/OfficeIMO.Reader/OfficeDocumentReader.MarkdownConversion.cs
+++ b/OfficeIMO.Reader/OfficeDocumentReader.MarkdownConversion.cs
@@ -1,0 +1,112 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Reader;
+
+public sealed partial class OfficeDocumentReader {
+    /// <summary>
+    /// Converts a supported file to its portable Markdown representation.
+    /// </summary>
+    /// <remarks>
+    /// This is a thin projection over <see cref="ReadDocument(string, ReaderOptions?, CancellationToken)"/>.
+    /// Use <c>ReadDocument(...)</c> when source metadata, blocks, tables, assets, or diagnostics are required.
+    /// </remarks>
+    /// <returns>The emitted Markdown, or an empty string when the reader produced no Markdown.</returns>
+    public string ConvertToMarkdown(
+        string path,
+        ReaderOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        return ReadDocument(path, options, cancellationToken).Markdown ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Converts a supported stream to its portable Markdown representation. The caller retains ownership of the stream.
+    /// </summary>
+    /// <remarks>
+    /// This is a thin projection over <see cref="ReadDocument(Stream, string?, ReaderOptions?, CancellationToken)"/>.
+    /// Use <c>ReadDocument(...)</c> when source metadata, blocks, tables, assets, or diagnostics are required.
+    /// </remarks>
+    /// <returns>The emitted Markdown, or an empty string when the reader produced no Markdown.</returns>
+    public string ConvertToMarkdown(
+        Stream stream,
+        string? sourceName = null,
+        ReaderOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        return ReadDocument(stream, sourceName, options, cancellationToken).Markdown ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Converts supported bytes to their portable Markdown representation.
+    /// </summary>
+    /// <remarks>
+    /// This is a thin projection over <see cref="ReadDocument(byte[], string?, ReaderOptions?, CancellationToken)"/>.
+    /// Use <c>ReadDocument(...)</c> when source metadata, blocks, tables, assets, or diagnostics are required.
+    /// </remarks>
+    /// <returns>The emitted Markdown, or an empty string when the reader produced no Markdown.</returns>
+    public string ConvertToMarkdown(
+        byte[] bytes,
+        string? sourceName = null,
+        ReaderOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        return ReadDocument(bytes, sourceName, options, cancellationToken).Markdown ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Asynchronously converts a supported file to its portable Markdown representation.
+    /// </summary>
+    /// <remarks>
+    /// This is a thin projection over <see cref="ReadDocumentAsync(string, ReaderOptions?, CancellationToken)"/>.
+    /// Use <c>ReadDocumentAsync(...)</c> when source metadata, blocks, tables, assets, or diagnostics are required.
+    /// </remarks>
+    /// <returns>The emitted Markdown, or an empty string when the reader produced no Markdown.</returns>
+    public async Task<string> ConvertToMarkdownAsync(
+        string path,
+        ReaderOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        OfficeDocumentReadResult document = await ReadDocumentAsync(path, options, cancellationToken).ConfigureAwait(false);
+        return document.Markdown ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Asynchronously converts a supported stream to its portable Markdown representation. The caller retains ownership of the stream.
+    /// </summary>
+    /// <remarks>
+    /// This is a thin projection over <see cref="ReadDocumentAsync(Stream, string?, ReaderOptions?, CancellationToken)"/>.
+    /// Use <c>ReadDocumentAsync(...)</c> when source metadata, blocks, tables, assets, or diagnostics are required.
+    /// </remarks>
+    /// <returns>The emitted Markdown, or an empty string when the reader produced no Markdown.</returns>
+    public async Task<string> ConvertToMarkdownAsync(
+        Stream stream,
+        string? sourceName = null,
+        ReaderOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        OfficeDocumentReadResult document = await ReadDocumentAsync(
+            stream,
+            sourceName,
+            options,
+            cancellationToken).ConfigureAwait(false);
+        return document.Markdown ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Asynchronously converts supported bytes to their portable Markdown representation.
+    /// </summary>
+    /// <remarks>
+    /// This is a thin projection over <see cref="ReadDocumentAsync(byte[], string?, ReaderOptions?, CancellationToken)"/>.
+    /// Use <c>ReadDocumentAsync(...)</c> when source metadata, blocks, tables, assets, or diagnostics are required.
+    /// </remarks>
+    /// <returns>The emitted Markdown, or an empty string when the reader produced no Markdown.</returns>
+    public async Task<string> ConvertToMarkdownAsync(
+        byte[] bytes,
+        string? sourceName = null,
+        ReaderOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        OfficeDocumentReadResult document = await ReadDocumentAsync(
+            bytes,
+            sourceName,
+            options,
+            cancellationToken).ConfigureAwait(false);
+        return document.Markdown ?? string.Empty;
+    }
+}

--- a/OfficeIMO.Reader/README.md
+++ b/OfficeIMO.Reader/README.md
@@ -16,12 +16,22 @@ dotnet add package OfficeIMO.Reader
 ```csharp
 using OfficeIMO.Reader;
 
-foreach (var chunk in DocumentReader.Read(@"C:\Docs\Policy.docx")) {
+foreach (var chunk in OfficeDocumentReader.Default.Read(@"C:\Docs\Policy.docx")) {
     Console.WriteLine(chunk.Id);
     Console.WriteLine(chunk.Location.HeadingPath);
     Console.WriteLine(chunk.Markdown ?? chunk.Text);
 }
 ```
+
+When the caller only needs the portable Markdown projection, use the thin conversion helper:
+
+```csharp
+string markdown = await OfficeDocumentReader.Default.ConvertToMarkdownAsync(
+    @"C:\Docs\Policy.docx",
+    cancellationToken: cancellationToken);
+```
+
+`ConvertToMarkdown(...)` and `ConvertToMarkdownAsync(...)` support file paths, streams, and byte arrays. They return the `Markdown` emitted by the same rich `ReadDocument(...)` pipeline, or an empty string when a handler emits no Markdown. Use the rich read APIs when metadata, blocks, tables, assets, or diagnostics are needed.
 
 ## Streams and folders
 
@@ -29,9 +39,9 @@ foreach (var chunk in DocumentReader.Read(@"C:\Docs\Policy.docx")) {
 using OfficeIMO.Reader;
 
 using var stream = File.OpenRead(@"C:\Docs\Policy.docx");
-var chunksFromStream = DocumentReader.Read(stream, "Policy.docx").ToList();
+var chunksFromStream = OfficeDocumentReader.Default.Read(stream, "Policy.docx").ToList();
 
-var folderChunks = DocumentReader.ReadFolder(
+var folderChunks = OfficeDocumentReader.Default.ReadFolder(
     folderPath: @"C:\Docs",
     folderOptions: new ReaderFolderOptions {
         Recurse = true,
@@ -90,7 +100,7 @@ OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
 var chunks = reader.Read(@"C:\Docs\data.json").ToList();
 ```
 
-`Build()` freezes the handler configuration. The resulting `OfficeDocumentReader` is safe to reuse across concurrent reads and is unaffected by later builder changes. `DocumentReader` remains the simple built-in-only facade; modular formats are configured explicitly on `OfficeDocumentReaderBuilder`, so one reader cannot change another reader or process-wide state.
+`Build()` freezes the handler configuration. The resulting `OfficeDocumentReader` is safe to reuse across concurrent reads and is unaffected by later builder changes. `OfficeDocumentReader.Default` is the simple built-in-only instance; modular formats are configured explicitly on `OfficeDocumentReaderBuilder`, so one reader cannot change another reader or process-wide state.
 
 When the application wants every local adapter, `OfficeIMO.Reader.All` provides the same explicit, instance-scoped composition in one call:
 
@@ -268,9 +278,9 @@ Seekable stream probes restore the original position. Prefix probing is capped a
 Word, Excel, and PowerPoint rich reads use the format packages' public inspection models instead of reparsing Open XML in the Reader facade:
 
 ```csharp
-OfficeDocumentReadResult word = DocumentReader.ReadDocument("policy.docx");
-OfficeDocumentReadResult workbook = DocumentReader.ReadDocument("forecast.xlsx");
-OfficeDocumentReadResult deck = DocumentReader.ReadDocument("briefing.pptx");
+OfficeDocumentReadResult word = OfficeDocumentReader.Default.ReadDocument("policy.docx");
+OfficeDocumentReadResult workbook = OfficeDocumentReader.Default.ReadDocument("forecast.xlsx");
+OfficeDocumentReadResult deck = OfficeDocumentReader.Default.ReadDocument("briefing.pptx");
 
 Console.WriteLine($"{word.Blocks.Count} semantic Word blocks");
 Console.WriteLine($"{workbook.Tables.Count} named Excel tables");
@@ -300,7 +310,7 @@ var engine = new DelegateOfficeOcrEngine(
         };
     });
 
-OfficeDocumentReadResult source = DocumentReader.ReadDocument("scanned.pdf");
+OfficeDocumentReadResult source = OfficeDocumentReader.Default.ReadDocument("scanned.pdf");
 OfficeDocumentOcrExecutionResult execution = await source.ApplyOcrAsync(
     engine,
     new OfficeDocumentOcrExecutionOptions {
@@ -374,7 +384,7 @@ OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
 
 `reader.ReadDocument(...)` dispatches directly to these delegates. Existing `reader.Read(...)` calls remain usable by projecting the returned result's `Chunks` collection. A handler may continue to register `ReadPath` and `ReadStream` when chunk production is its native contract.
 
-Adapter authors can call `DocumentReader.CreateDocumentResult(...)` to create the common v5 source, chunks, assets, diagnostics, and baseline collections, then replace or enrich format-owned blocks, pages, tables, links, forms, visuals, and metadata.
+Rich handlers return `OfficeDocumentReadResult` directly and can populate the common v5 source, chunks, assets, diagnostics, and baseline collections before adding format-owned blocks, pages, tables, links, forms, visuals, and metadata.
 
 ## Host contracts
 
@@ -383,14 +393,14 @@ Adapter authors can call `DocumentReader.CreateDocumentResult(...)` to create th
 - `OfficeDocumentReader.GetCapabilities()` and `GetCapabilityManifestJson()` expose the frozen configuration of that reader instance.
 - Capability records distinguish basic path/stream support from native rich-result support through `SupportsDocumentPath` and `SupportsDocumentStream`.
 - `SupportsAsyncPath` and `SupportsAsyncStream` identify handlers with native asynchronous delegates; false means the async facade uses the bounded synchronous fallback.
-- `DocumentReader.Detect(...)` / `DetectAsync(...)` and `OfficeDocumentReader.Detect(...)` / `DetectAsync(...)` expose bounded extension/content evidence, confidence, media type, and mismatch state.
+- `OfficeDocumentReader.Detect(...)` / `DetectAsync(...)` expose bounded extension/content evidence, confidence, media type, and mismatch state.
 - `OfficeDocumentDiagnostic` carries stable categories, codes, sources, recoverability, and attributes so hosts do not need to parse warning text.
 - `OfficeDocumentReadResultJson` reads and writes stable schema version 5 envelopes; `OfficeDocumentReadResultSchema.GetJsonSchema()` exposes the packaged schema artifact.
 - `OfficeDocumentProcessorPipeline` freezes ordered processors and reports each completed, failed, or skipped step.
 - `OfficeDocumentStructuredExtractor` produces bounded non-generic records, sections, named tables, forms, and diagnostics without AI dependencies.
 - `ReaderHierarchicalChunker` produces token-bounded `ReaderChunk` leaves, exact overlap spans, and document/container/heading hierarchy nodes.
 - `OfficeDocumentReaderBuilder.AddHandler(...)` is the recommended custom-handler path for services and concurrent hosts.
-- Static `DocumentReader` registration is retained as a process-wide compatibility surface.
+- Reader configuration and custom handler registration stay instance-scoped and are frozen by `OfficeDocumentReaderBuilder.Build()`.
 
 ## Boundaries
 


### PR DESCRIPTION
## Summary

- Add `ConvertToMarkdown` and `ConvertToMarkdownAsync` overloads for paths, streams, and byte arrays.
- Keep conversion as a thin projection over the existing rich `ReadDocument` pipeline.
- Preserve configured handlers, processors, cancellation, input bounds, and caller-owned stream lifetime.
- Document the simple built-in instance and correct the stale static-facade examples.

## API behavior

The helpers return the Markdown emitted by the rich document result, or an empty string when a handler emits no Markdown. Use `ReadDocument` when metadata, blocks, tables, assets, or diagnostics are needed.

## Boundaries

- No new package, native, model, cloud, process, or network dependency.
- No alternate parsing or Markdown projection engine.
- Instance-scoped Reader configuration remains the public surface.

## Validation

- `OfficeIMO.Reader.Tests`: 608/608 on .NET 8 and 608/608 on .NET 10.
- `OfficeIMO.Reader` packs for `netstandard2.0`, `net8.0`, and `net10.0` with zero warnings.
- Dependency and project-reference files are unchanged.