### PR TITLE
Add explicit bounded web ingestion

### DIFF
--- a/Build/project.build.json
+++ b/Build/project.build.json
@@ -60,6 +60,7 @@
     "OfficeIMO.Reader.Subtitles": "2.0.X",
     "OfficeIMO.Reader.Tool": "2.0.X",
     "OfficeIMO.Reader.Visio": "2.0.X",
+    "OfficeIMO.Reader.Web": "2.0.X",
     "OfficeIMO.Reader.Xml": "2.0.X",
     "OfficeIMO.Reader.Yaml": "2.0.X",
     "OfficeIMO.Reader.Zip": "2.0.X",

--- a/Docs/officeimo.reader.md
+++ b/Docs/officeimo.reader.md
@@ -10,6 +10,8 @@
 
 It is designed for deterministic ingestion. Format-specific parsing stays in the owning OfficeIMO package, the facade remains thin, and optional adapters do not force unrelated dependencies into the core package.
 
+Remote HTTP(S) retrieval is available only through the separate `OfficeIMO.Reader.Web` transport. It requires a caller-owned `HttpClient`, remains outside `OfficeIMO.Reader.All`, and passes bounded response bytes into the same configured local handlers.
+
 ## Install / Reference
 
 Reference the `OfficeIMO.Reader` NuGet package or add a project reference. Install only the modular adapter packages required by the host.
@@ -26,6 +28,7 @@ The package README at `OfficeIMO.Reader/README.md` is the detailed API guide. Th
 - `ReadStructured(...)` emits bounded scalar records, sections, named tables, forms, and readiness diagnostics without an AI dependency.
 - `ReadHierarchical(...)` creates token-bounded RAG leaves with overlap, exact source spans, and document/container/heading ancestry.
 - `IOfficeOcrEngine` keeps OCR execution in a dependency-free core contract; process and Tesseract implementations are separate optional packages.
+- `OfficeDocumentWebReader` adds explicit bounded HTTP(S) retrieval without adding network behavior to the core Reader, all-adapters preset, or global tool.
 
 For format adapters, prefer instance-scoped registration:
 

--- a/Docs/officeimo.reader.modular-roadmap.md
+++ b/Docs/officeimo.reader.modular-roadmap.md
@@ -9,6 +9,7 @@ This document records the current Reader package boundaries and the remaining mo
 | `OfficeIMO.Reader` | Shared chunks and rich result, built-in default instance, isolated reader instances, bounded sync/async execution, detection, diagnostics, processors, structured extraction, hierarchical chunking, and OCR execution contracts. |
 | Format packages | Parse and inspect their own formats. Reader must not duplicate Word, Excel, PowerPoint, Markdown, PDF, RTF, HTML, EPUB, Visio, CSV, ZIP, or other format logic. Small transport formats without an owning package may use a narrow, isolated adapter. |
 | `OfficeIMO.Reader.*` adapters | Register path/stream handlers and project owning format models into the shared Reader contracts. |
+| `OfficeIMO.Reader.Web` | Explicit caller-injected HTTP transport that bounds retrieval and routes bytes through an existing Reader instance. |
 | `OfficeIMO.Reader.Ocr.Process` | Optional versioned external-process OCR bridge. |
 | `OfficeIMO.Reader.Ocr.Tesseract` | Optional Tesseract CLI provider with line and word geometry. |
 
@@ -24,6 +25,7 @@ The modular adapters are working packages in the publishing pipeline, not placeh
 - `OfficeIMO.Reader.Rtf`
 - `OfficeIMO.Reader.Subtitles`
 - `OfficeIMO.Reader.Visio`
+- `OfficeIMO.Reader.Web`
 - `OfficeIMO.Reader.Xml`
 - `OfficeIMO.Reader.Yaml`
 - `OfficeIMO.Reader.Zip`
@@ -41,6 +43,7 @@ The modular adapters are working packages in the publishing pipeline, not placeh
 - The stable rich transport is `OfficeDocumentReadResult` schema version 5.
 - Ordered processors, bounded structured extraction, token-aware hierarchical chunking, and optional OCR build on the shared result instead of adding format-specific host pipelines.
 - OCR providers remain opt-in and do not change the core package dependency graph.
+- Web retrieval remains opt-in, uses a caller-owned `HttpClient`, and is not composed by `OfficeIMO.Reader.All` or the global tool.
 
 ## Ownership rules for new adapters
 
@@ -66,5 +69,5 @@ Before publishing a new or changed adapter:
 
 - Continue increasing format fidelity in the owning packages and project that evidence through the adapters.
 - Add optional providers only when their dependency and runtime boundaries are clear.
-- Keep audio, video, URL, and transcription ingestion in separate packages if downstream products require them.
+- Keep audio, video, and transcription ingestion in separate packages if downstream products require them; URL retrieval remains isolated in `OfficeIMO.Reader.Web`.
 - Keep email and attachment ingestion in the existing Mailozaurr owner; it is outside the current OfficeIMO Reader stack.

--- a/OfficeIMO.Reader.Tests/OfficeIMO.Reader.Tests.csproj
+++ b/OfficeIMO.Reader.Tests/OfficeIMO.Reader.Tests.csproj
@@ -54,6 +54,7 @@
     <ProjectReference Include="..\OfficeIMO.Reader.Rtf\OfficeIMO.Reader.Rtf.csproj" />
     <ProjectReference Include="..\OfficeIMO.Reader.Subtitles\OfficeIMO.Reader.Subtitles.csproj" />
     <ProjectReference Include="..\OfficeIMO.Reader.Visio\OfficeIMO.Reader.Visio.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Reader.Web\OfficeIMO.Reader.Web.csproj" />
     <ProjectReference Include="..\OfficeIMO.Reader.Xml\OfficeIMO.Reader.Xml.csproj" />
     <ProjectReference Include="..\OfficeIMO.Reader.Yaml\OfficeIMO.Reader.Yaml.csproj" />
     <ProjectReference Include="..\OfficeIMO.Reader.Zip\OfficeIMO.Reader.Zip.csproj" />

--- a/OfficeIMO.Reader.Tests/Reader.Registry.RichDocuments.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Registry.RichDocuments.cs
@@ -5,6 +5,37 @@ namespace OfficeIMO.Tests;
 
 public sealed partial class ReaderRegistryTests {
     [Fact]
+    public void OfficeDocumentReader_HandlerDefaultLimit_IgnoresPathOnlyOverridesForStreamInput() {
+        long? builtInLimit = OfficeDocumentReader.Default.GetHandlerDefaultMaxInputBytes("message.eml");
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+            .AddHandler(new ReaderHandlerRegistration {
+                Id = "officeimo.tests.path-only-email",
+                Kind = ReaderInputKind.Email,
+                Extensions = new[] { ".eml" },
+                DefaultMaxInputBytes = 16,
+                ReadPath = (path, options, cancellationToken) => Array.Empty<ReaderChunk>()
+            }, replaceExisting: true)
+            .Build();
+
+        Assert.NotNull(builtInLimit);
+        Assert.Equal(builtInLimit, reader.GetHandlerDefaultMaxInputBytes("message.eml"));
+    }
+
+    [Fact]
+    public void OfficeDocumentReader_HandlerDefaultLimit_HonorsNullableStreamOverride() {
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+            .AddHandler(new ReaderHandlerRegistration {
+                Id = "officeimo.tests.unbounded-email-stream",
+                Kind = ReaderInputKind.Email,
+                Extensions = new[] { ".eml" },
+                ReadStream = (stream, sourceName, options, cancellationToken) => Array.Empty<ReaderChunk>()
+            }, replaceExisting: true)
+            .Build();
+
+        Assert.Null(reader.GetHandlerDefaultMaxInputBytes("message.eml"));
+    }
+
+    [Fact]
     public void OfficeDocumentReader_RichDocumentHandler_ProjectsChunksAndPreservesEnvelope() {
         const string handlerId = "officeimo.tests.custom.rich";
         const string extension = ".richix";

--- a/OfficeIMO.Reader.Tests/Reader.Web.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Web.cs
@@ -41,7 +41,40 @@ public sealed class ReaderWebTests {
             item => item.Id == "reader-web-request-uri");
         Assert.DoesNotContain("token", requestUri.Value, StringComparison.Ordinal);
         Assert.Equal(lastModified.UtcDateTime, result.Source.LastWriteUtc);
+        Assert.All(result.Chunks, chunk => {
+            Assert.Equal(result.Source.SourceId, chunk.SourceId);
+            Assert.Equal(lastModified.UtcDateTime, chunk.SourceLastWriteUtc);
+        });
         Assert.Equal(1, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task WebReader_DerivesSourceIdentityFromTheFinalUriInsteadOfTheFileName() {
+        int responseIndex = 0;
+        var handler = new DelegateHttpHandler((request, cancellationToken) => {
+            int current = Interlocked.Increment(ref responseIndex);
+            HttpResponseMessage response = TextResponse("same body", "text/plain");
+            response.Content.Headers.ContentDisposition = new ContentDispositionHeaderValue("attachment") {
+                FileName = "\"report.txt\""
+            };
+            response.RequestMessage = new HttpRequestMessage(
+                HttpMethod.Get,
+                "https://cdn.example/tenant-" + current.ToString(CultureInfo.InvariantCulture) + "/report.txt?token=secret");
+            return Task.FromResult(response);
+        });
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(httpClient);
+
+        OfficeDocumentReadResult first = await webReader.ReadDocumentAsync(new Uri("https://example.test/report"));
+        OfficeDocumentReadResult second = await webReader.ReadDocumentAsync(new Uri("https://example.test/report"));
+
+        Assert.Equal("report.txt", first.Source.Path);
+        Assert.Equal(first.Source.Path, second.Source.Path);
+        Assert.NotEqual(first.Source.SourceId, second.Source.SourceId);
+        Assert.DoesNotContain("cdn.example", first.Source.SourceId, StringComparison.Ordinal);
+        Assert.All(first.Chunks, chunk => Assert.Equal(first.Source.SourceId, chunk.SourceId));
+        Assert.All(second.Chunks, chunk => Assert.Equal(second.Source.SourceId, chunk.SourceId));
+        Assert.NotEqual(Assert.Single(first.Chunks).ChunkHash, Assert.Single(second.Chunks).ChunkHash);
     }
 
     [Fact]
@@ -68,6 +101,39 @@ public sealed class ReaderWebTests {
             webReader.ReadDocumentAsync(new Uri("http://127.0.0.1/private.txt")));
 
         Assert.Equal(0, handler.CallCount);
+    }
+
+    [Theory]
+    [InlineData("192.0.0.8")]
+    [InlineData("192.0.0.170")]
+    [InlineData("192.0.0.171")]
+    public async Task WebReader_RejectsNonGlobalIanaProtocolAssignmentTargets(string host) {
+        var handler = new DelegateHttpHandler((request, cancellationToken) =>
+            Task.FromResult(TextResponse("not reached", "text/plain")));
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(httpClient);
+
+        await Assert.ThrowsAsync<ReaderWebPolicyException>(() =>
+            webReader.ReadDocumentAsync(new Uri("http://" + host + "/special.txt")));
+
+        Assert.Equal(0, handler.CallCount);
+    }
+
+    [Theory]
+    [InlineData("192.0.0.9")]
+    [InlineData("192.0.0.10")]
+    [InlineData("192.0.1.1")]
+    public async Task WebReader_DoesNotOverblockGloballyReachableOrOrdinaryTargets(string host) {
+        var handler = new DelegateHttpHandler((request, cancellationToken) =>
+            Task.FromResult(TextResponse("public fixture", "text/plain")));
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(httpClient);
+
+        OfficeDocumentReadResult result = await webReader.ReadDocumentAsync(
+            new Uri("http://" + host + "/public.txt"));
+
+        Assert.Contains("public fixture", result.Markdown, StringComparison.Ordinal);
+        Assert.Equal(1, handler.CallCount);
     }
 
     [Fact]

--- a/OfficeIMO.Reader.Tests/Reader.Web.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Web.cs
@@ -107,6 +107,7 @@ public sealed class ReaderWebTests {
     [InlineData("192.0.0.8")]
     [InlineData("192.0.0.170")]
     [InlineData("192.0.0.171")]
+    [InlineData("192.88.99.1")]
     public async Task WebReader_RejectsNonGlobalIanaProtocolAssignmentTargets(string host) {
         var handler = new DelegateHttpHandler((request, cancellationToken) =>
             Task.FromResult(TextResponse("not reached", "text/plain")));
@@ -358,6 +359,63 @@ public sealed class ReaderWebTests {
     }
 
     [Fact]
+    public async Task WebReader_TimesOutANonCooperativeStreamOpenAndDisposesALateStream() {
+        var stalledContent = new CancellationIgnoringOpenContent();
+        int responseIndex = 0;
+        var handler = new DelegateHttpHandler((request, cancellationToken) => {
+            if (Interlocked.Increment(ref responseIndex) == 1) {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = stalledContent });
+            }
+            return Task.FromResult(TextResponse("recovered", "text/plain"));
+        });
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(
+            httpClient,
+            new ReaderWebOptions {
+                MaxConcurrentRequests = 1,
+                RequestTimeout = TimeSpan.FromMilliseconds(100)
+            });
+
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            webReader.ReadDocumentAsync(new Uri("https://example.test/stalled-open.txt")));
+        OfficeDocumentReadResult recovered = await webReader.ReadDocumentAsync(
+            new Uri("https://example.test/recovered.txt"));
+        var lateStream = new TrackingMemoryStream(Encoding.UTF8.GetBytes("late"));
+        stalledContent.CompleteOpen(lateStream);
+
+        Assert.Contains("recovered", recovered.Markdown, StringComparison.Ordinal);
+        Assert.True(stalledContent.IsDisposed);
+        Assert.True(SpinWait.SpinUntil(() => lateStream.IsDisposed, TimeSpan.FromSeconds(2)));
+        Assert.Equal(2, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task WebTransport_HandsReaderItsPreparedSnapshotWithoutCopying() {
+        byte[] payload = Encoding.UTF8.GetBytes("prepared snapshot");
+        var handler = new DelegateHttpHandler((request, cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new ByteArrayContent(payload)
+            }));
+        using var httpClient = new HttpClient(handler);
+        using ReaderWebDownload download = await ReaderWebTransport.DownloadAsync(
+            httpClient,
+            new Uri("https://example.test/prepared.txt"),
+            sourceName: null,
+            maxResponseBytes: 1024,
+            new ReaderWebOptions(),
+            CancellationToken.None);
+
+        Stream prepared = await ReaderInputLimits.EnsureSeekableReadStreamAsync(
+            download.Content,
+            maxInputBytes: 1024);
+
+        Assert.Same(download.Content, prepared);
+        Assert.True(ReaderInputLimits.IsSnapshotStream(prepared));
+        Assert.Equal(payload.Length, prepared.Length);
+        Assert.Equal(0, prepared.Position);
+    }
+
+    [Fact]
     public async Task WebReader_BoundsConcurrentOperationsPerInstance() {
         var handler = new BlockingFirstRequestHandler();
         using var httpClient = new HttpClient(handler);
@@ -483,6 +541,49 @@ public sealed class ReaderWebTests {
         public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
         public override void SetLength(long value) => throw new NotSupportedException();
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing) {
+            if (disposing) Interlocked.Exchange(ref _isDisposed, 1);
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class CancellationIgnoringOpenContent : HttpContent {
+        private readonly TaskCompletionSource<Stream> _pendingOpen =
+            new TaskCompletionSource<Stream>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _isDisposed;
+
+        internal bool IsDisposed => Volatile.Read(ref _isDisposed) != 0;
+
+        internal void CompleteOpen(Stream stream) => _pendingOpen.TrySetResult(stream);
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) {
+            return Task.CompletedTask;
+        }
+
+        protected override bool TryComputeLength(out long length) {
+            length = 0;
+            return false;
+        }
+
+        protected override Task<Stream> CreateContentReadStreamAsync() => _pendingOpen.Task;
+
+        protected override Task<Stream> CreateContentReadStreamAsync(CancellationToken cancellationToken) =>
+            _pendingOpen.Task;
+
+        protected override void Dispose(bool disposing) {
+            if (disposing) Interlocked.Exchange(ref _isDisposed, 1);
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class TrackingMemoryStream : MemoryStream {
+        private int _isDisposed;
+
+        internal TrackingMemoryStream(byte[] bytes) : base(bytes, writable: false) {
+        }
+
+        internal bool IsDisposed => Volatile.Read(ref _isDisposed) != 0;
 
         protected override void Dispose(bool disposing) {
             if (disposing) Interlocked.Exchange(ref _isDisposed, 1);

--- a/OfficeIMO.Reader.Tests/Reader.Web.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Web.cs
@@ -178,6 +178,33 @@ public sealed class ReaderWebTests {
     }
 
     [Fact]
+    public async Task WebReader_RejectsPrivateIpv4EmbeddedInTheIpv4TranslatedPrefix() {
+        var handler = new DelegateHttpHandler((request, cancellationToken) =>
+            Task.FromResult(TextResponse("not reached", "text/plain")));
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(httpClient);
+
+        await Assert.ThrowsAsync<ReaderWebPolicyException>(() =>
+            webReader.ReadDocumentAsync(new Uri("http://[::ffff:0:10.0.0.1]/private.txt")));
+
+        Assert.Equal(0, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task WebReader_AllowsPublicIpv4EmbeddedInTheIpv4TranslatedPrefix() {
+        var handler = new DelegateHttpHandler((request, cancellationToken) =>
+            Task.FromResult(TextResponse("public fixture", "text/plain")));
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(httpClient);
+
+        OfficeDocumentReadResult result = await webReader.ReadDocumentAsync(
+            new Uri("http://[::ffff:0:8.8.8.8]/public.txt"));
+
+        Assert.Contains("public fixture", result.Markdown, StringComparison.Ordinal);
+        Assert.Equal(1, handler.CallCount);
+    }
+
+    [Fact]
     public async Task WebReader_RejectsPrivateIpv4EmbeddedInA6To4Target() {
         var handler = new DelegateHttpHandler((request, cancellationToken) =>
             Task.FromResult(TextResponse("not reached", "text/plain")));
@@ -284,6 +311,41 @@ public sealed class ReaderWebTests {
             webReader.ReadDocumentAsync(new Uri("https://example.test/file.bin")));
 
         Assert.Contains("effective web input byte limit", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WebReader_AppliesTheSelectedHandlersDefaultBeforeReadingTheBody() {
+        bool readerInvoked = false;
+        var handler = new DelegateHttpHandler((request, cancellationToken) => {
+            var content = new ByteArrayContent(new byte[32]);
+            content.Headers.ContentLength = 32;
+            content.Headers.ContentDisposition = new ContentDispositionHeaderValue("attachment") {
+                FileName = "\"fixture.bounded\""
+            };
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
+        });
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+            .AddHandler(new ReaderHandlerRegistration {
+                Id = "test.bounded",
+                Extensions = new[] { ".bounded" },
+                DefaultMaxInputBytes = 16,
+                ReadDocumentStream = (stream, sourceName, options, cancellationToken) => {
+                    readerInvoked = true;
+                    return new OfficeDocumentReadResult();
+                }
+            })
+            .Build();
+        OfficeDocumentWebReader webReader = reader.CreateWebReader(
+            httpClient,
+            new ReaderWebOptions { MaxResponseBytes = 64 });
+
+        IOException exception = await Assert.ThrowsAsync<IOException>(() =>
+            webReader.ReadDocumentAsync(new Uri("https://example.test/download")));
+
+        Assert.Contains("effective web input byte limit", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("32 > 16", exception.Message, StringComparison.Ordinal);
+        Assert.False(readerInvoked);
     }
 
     [Fact]
@@ -434,7 +496,7 @@ public sealed class ReaderWebTests {
             httpClient,
             new Uri("https://example.test/prepared.txt"),
             sourceName: null,
-            maxResponseBytes: 1024,
+            resolveMaxResponseBytes: _ => 1024,
             new ReaderWebOptions(),
             CancellationToken.None);
 

--- a/OfficeIMO.Reader.Tests/Reader.Web.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Web.cs
@@ -1,0 +1,287 @@
+using OfficeIMO.Reader;
+using OfficeIMO.Reader.Html;
+using OfficeIMO.Reader.Web;
+using System.Globalization;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class ReaderWebTests {
+    [Fact]
+    public async Task WebReader_RoutesBytesThroughConfiguredReaderAndAddsSafeMetadata() {
+        DateTimeOffset lastModified = new DateTimeOffset(2026, 7, 15, 12, 0, 0, TimeSpan.Zero);
+        var handler = new DelegateHttpHandler((request, cancellationToken) => {
+            HttpResponseMessage response = TextResponse("<h1>Remote guide</h1><p>Body</p>", "text/html");
+            response.Content.Headers.ContentDisposition = new ContentDispositionHeaderValue("attachment") {
+                FileName = "\"remote.html\""
+            };
+            response.Content.Headers.LastModified = lastModified;
+            return Task.FromResult(response);
+        });
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentReader reader = new OfficeDocumentReaderBuilder().AddHtmlHandler().Build();
+        OfficeDocumentWebReader webReader = reader.CreateWebReader(httpClient, new ReaderWebOptions {
+            AllowedHosts = new[] { "example.test" }
+        });
+
+        OfficeDocumentReadResult result = await webReader.ReadDocumentAsync(
+            new Uri("https://example.test/files/download?token=secret"));
+
+        Assert.Equal(ReaderInputKind.Html, result.Kind);
+        Assert.Equal("remote.html", result.Source.Path);
+        Assert.Contains("Remote guide", result.Markdown, StringComparison.Ordinal);
+        Assert.Contains("officeimo.reader.web", result.CapabilitiesUsed);
+        OfficeDocumentMetadataEntry requestUri = Assert.Single(
+            result.Metadata,
+            item => item.Id == "reader-web-request-uri");
+        Assert.DoesNotContain("token", requestUri.Value, StringComparison.Ordinal);
+        Assert.Equal(lastModified.UtcDateTime, result.Source.LastWriteUtc);
+        Assert.Equal(1, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task WebReader_UsesTheRichPipelineForMarkdownConvenience() {
+        var handler = new DelegateHttpHandler((request, cancellationToken) =>
+            Task.FromResult(TextResponse("# Remote note\n\nBody", "text/markdown")));
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(httpClient);
+
+        string markdown = await webReader.ConvertToMarkdownAsync(
+            new Uri("https://example.test/note.md"));
+
+        Assert.Contains("# Remote note", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WebReader_RejectsPrivateTargetsBeforeSending() {
+        var handler = new DelegateHttpHandler((request, cancellationToken) =>
+            Task.FromResult(TextResponse("not reached", "text/plain")));
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(httpClient);
+
+        await Assert.ThrowsAsync<ReaderWebPolicyException>(() =>
+            webReader.ReadDocumentAsync(new Uri("http://127.0.0.1/private.txt")));
+
+        Assert.Equal(0, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task WebReader_RejectsAnInvalidSourceNameBeforeSending() {
+        var handler = new DelegateHttpHandler((request, cancellationToken) =>
+            Task.FromResult(TextResponse("not reached", "text/plain")));
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(httpClient);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => webReader.ReadDocumentAsync(
+            new Uri("https://example.test/file.txt"),
+            sourceName: "bad\nname.txt"));
+
+        Assert.Equal(0, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task WebReader_CanExplicitlyAllowAPrivateTarget() {
+        var handler = new DelegateHttpHandler((request, cancellationToken) =>
+            Task.FromResult(TextResponse("local fixture", "text/plain")));
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(
+            httpClient,
+            new ReaderWebOptions {
+                AllowedHosts = new[] { "localhost" },
+                AllowPrivateNetworkTargets = true
+            });
+
+        OfficeDocumentReadResult result = await webReader.ReadDocumentAsync(
+            new Uri("http://localhost/fixture.txt"));
+
+        Assert.Contains("local fixture", result.Markdown, StringComparison.Ordinal);
+        Assert.Equal(1, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task WebReader_RejectsAHostOutsideTheAllowlistBeforeSending() {
+        var handler = new DelegateHttpHandler((request, cancellationToken) =>
+            Task.FromResult(TextResponse("not reached", "text/plain")));
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(
+            httpClient,
+            new ReaderWebOptions { AllowedHosts = new[] { "allowed.example" } });
+
+        await Assert.ThrowsAsync<ReaderWebPolicyException>(() =>
+            webReader.ReadDocumentAsync(new Uri("https://other.example/file.txt")));
+
+        Assert.Equal(0, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task WebReader_RejectsADisallowedFinalUriReportedByTheResponse() {
+        var handler = new DelegateHttpHandler((request, cancellationToken) => {
+            HttpResponseMessage response = TextResponse("not parsed", "text/plain");
+            response.RequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://127.0.0.1/final.txt");
+            return Task.FromResult(response);
+        });
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(httpClient);
+
+        await Assert.ThrowsAsync<ReaderWebPolicyException>(() =>
+            webReader.ReadDocumentAsync(new Uri("https://example.test/start.txt")));
+
+        Assert.Equal(1, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task WebReader_RejectsDeclaredContentLengthAboveTheBound() {
+        var handler = new DelegateHttpHandler((request, cancellationToken) => {
+            var content = new ByteArrayContent(new byte[32]);
+            content.Headers.ContentLength = 32;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
+        });
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(
+            httpClient,
+            new ReaderWebOptions { MaxResponseBytes = 16 });
+
+        IOException exception = await Assert.ThrowsAsync<IOException>(() =>
+            webReader.ReadDocumentAsync(new Uri("https://example.test/file.bin")));
+
+        Assert.Contains("effective web input byte limit", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WebReader_RejectsAStreamingBodyWhenActualBytesCrossTheBound() {
+        var handler = new DelegateHttpHandler((request, cancellationToken) => {
+            var content = new StreamContent(new NonSeekableReadStream(new byte[32]));
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
+        });
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(
+            httpClient,
+            new ReaderWebOptions { MaxResponseBytes = 16 });
+
+        IOException exception = await Assert.ThrowsAsync<IOException>(() =>
+            webReader.ReadDocumentAsync(new Uri("https://example.test/file.bin")));
+
+        Assert.Contains("effective web input byte limit", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WebReader_ReportsItsOwnRequestTimeout() {
+        var handler = new DelegateHttpHandler(async (request, cancellationToken) => {
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+            return TextResponse("not reached", "text/plain");
+        });
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(
+            httpClient,
+            new ReaderWebOptions { RequestTimeout = TimeSpan.FromMilliseconds(100) });
+
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            webReader.ReadDocumentAsync(new Uri("https://example.test/slow.txt")));
+    }
+
+    [Fact]
+    public async Task WebReader_BoundsConcurrentOperationsPerInstance() {
+        var handler = new BlockingFirstRequestHandler();
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(
+            httpClient,
+            new ReaderWebOptions { MaxConcurrentRequests = 1 });
+
+        Task<OfficeDocumentReadResult> first = webReader.ReadDocumentAsync(
+            new Uri("https://example.test/first.txt"));
+        Task firstArrival = await Task.WhenAny(handler.FirstRequestArrived, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(handler.FirstRequestArrived, firstArrival);
+
+        Task<OfficeDocumentReadResult> second = webReader.ReadDocumentAsync(
+            new Uri("https://example.test/second.txt"));
+        await Task.Delay(100);
+        Assert.Equal(1, handler.CallCount);
+
+        handler.ReleaseFirstRequest();
+        await Task.WhenAll(first, second);
+        Assert.Equal(2, handler.CallCount);
+    }
+
+    private static HttpResponseMessage TextResponse(string value, string mediaType) {
+        return new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = new StringContent(value, Encoding.UTF8, mediaType)
+        };
+    }
+
+    private sealed class DelegateHttpHandler : HttpMessageHandler {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _send;
+        private int _callCount;
+
+        internal DelegateHttpHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> send) {
+            _send = send;
+        }
+
+        internal int CallCount => Volatile.Read(ref _callCount);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) {
+            Interlocked.Increment(ref _callCount);
+            return _send(request, cancellationToken);
+        }
+    }
+
+    private sealed class BlockingFirstRequestHandler : HttpMessageHandler {
+        private readonly TaskCompletionSource<bool> _firstRequestArrived =
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> _releaseFirstRequest =
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _callCount;
+
+        internal Task FirstRequestArrived => _firstRequestArrived.Task;
+        internal int CallCount => Volatile.Read(ref _callCount);
+
+        internal void ReleaseFirstRequest() => _releaseFirstRequest.TrySetResult(true);
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) {
+            int call = Interlocked.Increment(ref _callCount);
+            if (call == 1) {
+                _firstRequestArrived.TrySetResult(true);
+                Task cancellation = Task.Delay(Timeout.Infinite, cancellationToken);
+                Task completed = await Task.WhenAny(_releaseFirstRequest.Task, cancellation);
+                cancellationToken.ThrowIfCancellationRequested();
+                await completed;
+            }
+            return TextResponse("request " + call.ToString(CultureInfo.InvariantCulture), "text/plain");
+        }
+    }
+
+    private sealed class NonSeekableReadStream : Stream {
+        private readonly MemoryStream _inner;
+
+        internal NonSeekableReadStream(byte[] bytes) {
+            _inner = new MemoryStream(bytes, writable: false);
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing) {
+            if (disposing) _inner.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/OfficeIMO.Reader.Tests/Reader.Web.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Web.cs
@@ -690,8 +690,10 @@ public sealed class ReaderWebTests {
 
         protected override Task<Stream> CreateContentReadStreamAsync() => _pendingOpen.Task;
 
+#if !NET472
         protected override Task<Stream> CreateContentReadStreamAsync(CancellationToken cancellationToken) =>
             _pendingOpen.Task;
+#endif
 
         protected override void Dispose(bool disposing) {
             if (disposing) Interlocked.Exchange(ref _isDisposed, 1);

--- a/OfficeIMO.Reader.Tests/Reader.Web.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Web.cs
@@ -205,6 +205,33 @@ public sealed class ReaderWebTests {
     }
 
     [Fact]
+    public async Task WebReader_RejectsTheIpv6DiscardOnlyPrefix() {
+        var handler = new DelegateHttpHandler((request, cancellationToken) =>
+            Task.FromResult(TextResponse("not reached", "text/plain")));
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(httpClient);
+
+        await Assert.ThrowsAsync<ReaderWebPolicyException>(() =>
+            webReader.ReadDocumentAsync(new Uri("http://[100::1]/discard.txt")));
+
+        Assert.Equal(0, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task WebReader_DoesNotOverblockOutsideTheIpv6DiscardOnlyPrefix() {
+        var handler = new DelegateHttpHandler((request, cancellationToken) =>
+            Task.FromResult(TextResponse("public fixture", "text/plain")));
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(httpClient);
+
+        OfficeDocumentReadResult result = await webReader.ReadDocumentAsync(
+            new Uri("http://[100:0:0:1::1]/public.txt"));
+
+        Assert.Contains("public fixture", result.Markdown, StringComparison.Ordinal);
+        Assert.Equal(1, handler.CallCount);
+    }
+
+    [Fact]
     public async Task WebReader_RejectsPrivateIpv4EmbeddedInA6To4Target() {
         var handler = new DelegateHttpHandler((request, cancellationToken) =>
             Task.FromResult(TextResponse("not reached", "text/plain")));

--- a/OfficeIMO.Reader.Tests/Reader.Web.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Web.cs
@@ -330,6 +330,39 @@ public sealed class ReaderWebTests {
     }
 
     [Fact]
+    public async Task WebReader_TimesOutANonCooperativeSendAndReleasesItsRequestSlot() {
+        var pendingSend = new TaskCompletionSource<HttpResponseMessage>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        int responseIndex = 0;
+        var handler = new DelegateHttpHandler((request, cancellationToken) => {
+            if (Interlocked.Increment(ref responseIndex) == 1) {
+                return pendingSend.Task;
+            }
+            return Task.FromResult(TextResponse("recovered", "text/plain"));
+        });
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(
+            httpClient,
+            new ReaderWebOptions {
+                MaxConcurrentRequests = 1,
+                RequestTimeout = TimeSpan.FromMilliseconds(100)
+            });
+
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            webReader.ReadDocumentAsync(new Uri("https://example.test/stalled-send.txt")));
+        OfficeDocumentReadResult recovered = await webReader.ReadDocumentAsync(
+            new Uri("https://example.test/recovered.txt"));
+        var lateStream = new TrackingMemoryStream(Encoding.UTF8.GetBytes("late"));
+        pendingSend.TrySetResult(new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = new StreamContent(lateStream)
+        });
+
+        Assert.Contains("recovered", recovered.Markdown, StringComparison.Ordinal);
+        Assert.True(SpinWait.SpinUntil(() => lateStream.IsDisposed, TimeSpan.FromSeconds(2)));
+        Assert.Equal(2, handler.CallCount);
+    }
+
+    [Fact]
     public async Task WebReader_TimesOutANonCooperativeBodyAndReleasesItsRequestSlot() {
         var blockingStream = new CancellationIgnoringReadStream();
         int responseIndex = 0;

--- a/OfficeIMO.Reader.Tests/Reader.Web.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Web.cs
@@ -71,6 +71,19 @@ public sealed class ReaderWebTests {
     }
 
     [Fact]
+    public async Task WebReader_RejectsLocalUseNat64TargetsBeforeSending() {
+        var handler = new DelegateHttpHandler((request, cancellationToken) =>
+            Task.FromResult(TextResponse("not reached", "text/plain")));
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(httpClient);
+
+        await Assert.ThrowsAsync<ReaderWebPolicyException>(() =>
+            webReader.ReadDocumentAsync(new Uri("http://[64:ff9b:1::a00:1]/private.txt")));
+
+        Assert.Equal(0, handler.CallCount);
+    }
+
+    [Fact]
     public async Task WebReader_RejectsAnInvalidSourceNameBeforeSending() {
         var handler = new DelegateHttpHandler((request, cancellationToken) =>
             Task.FromResult(TextResponse("not reached", "text/plain")));

--- a/OfficeIMO.Reader.Tests/Reader.Web.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Web.cs
@@ -84,6 +84,33 @@ public sealed class ReaderWebTests {
     }
 
     [Fact]
+    public async Task WebReader_RejectsPrivateIpv4EmbeddedInTheWellKnownNat64Prefix() {
+        var handler = new DelegateHttpHandler((request, cancellationToken) =>
+            Task.FromResult(TextResponse("not reached", "text/plain")));
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(httpClient);
+
+        await Assert.ThrowsAsync<ReaderWebPolicyException>(() =>
+            webReader.ReadDocumentAsync(new Uri("http://[64:ff9b::a00:1]/private.txt")));
+
+        Assert.Equal(0, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task WebReader_AllowsPublicIpv4EmbeddedInTheWellKnownNat64Prefix() {
+        var handler = new DelegateHttpHandler((request, cancellationToken) =>
+            Task.FromResult(TextResponse("public fixture", "text/plain")));
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(httpClient);
+
+        OfficeDocumentReadResult result = await webReader.ReadDocumentAsync(
+            new Uri("http://[64:ff9b::808:808]/public.txt"));
+
+        Assert.Contains("public fixture", result.Markdown, StringComparison.Ordinal);
+        Assert.Equal(1, handler.CallCount);
+    }
+
+    [Fact]
     public async Task WebReader_RejectsAnInvalidSourceNameBeforeSending() {
         var handler = new DelegateHttpHandler((request, cancellationToken) =>
             Task.FromResult(TextResponse("not reached", "text/plain")));

--- a/OfficeIMO.Reader.Tests/Reader.Web.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Web.cs
@@ -177,6 +177,33 @@ public sealed class ReaderWebTests {
     }
 
     [Fact]
+    public async Task WebReader_RejectsPrivateIpv4EmbeddedInA6To4Target() {
+        var handler = new DelegateHttpHandler((request, cancellationToken) =>
+            Task.FromResult(TextResponse("not reached", "text/plain")));
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(httpClient);
+
+        await Assert.ThrowsAsync<ReaderWebPolicyException>(() =>
+            webReader.ReadDocumentAsync(new Uri("http://[2002:a00:1::]/private.txt")));
+
+        Assert.Equal(0, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task WebReader_AllowsPublicIpv4EmbeddedInA6To4Target() {
+        var handler = new DelegateHttpHandler((request, cancellationToken) =>
+            Task.FromResult(TextResponse("public fixture", "text/plain")));
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(httpClient);
+
+        OfficeDocumentReadResult result = await webReader.ReadDocumentAsync(
+            new Uri("http://[2002:808:808::]/public.txt"));
+
+        Assert.Contains("public fixture", result.Markdown, StringComparison.Ordinal);
+        Assert.Equal(1, handler.CallCount);
+    }
+
+    [Fact]
     public async Task WebReader_RejectsAnInvalidSourceNameBeforeSending() {
         var handler = new DelegateHttpHandler((request, cancellationToken) =>
             Task.FromResult(TextResponse("not reached", "text/plain")));
@@ -302,6 +329,35 @@ public sealed class ReaderWebTests {
     }
 
     [Fact]
+    public async Task WebReader_TimesOutANonCooperativeBodyAndReleasesItsRequestSlot() {
+        var blockingStream = new CancellationIgnoringReadStream();
+        int responseIndex = 0;
+        var handler = new DelegateHttpHandler((request, cancellationToken) => {
+            if (Interlocked.Increment(ref responseIndex) == 1) {
+                var content = new StreamContent(blockingStream);
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
+            }
+            return Task.FromResult(TextResponse("recovered", "text/plain"));
+        });
+        using var httpClient = new HttpClient(handler);
+        OfficeDocumentWebReader webReader = OfficeDocumentReader.Default.CreateWebReader(
+            httpClient,
+            new ReaderWebOptions {
+                MaxConcurrentRequests = 1,
+                RequestTimeout = TimeSpan.FromMilliseconds(100)
+            });
+
+        await Assert.ThrowsAsync<TimeoutException>(() =>
+            webReader.ReadDocumentAsync(new Uri("https://example.test/stalled.txt")));
+        OfficeDocumentReadResult recovered = await webReader.ReadDocumentAsync(
+            new Uri("https://example.test/recovered.txt"));
+
+        Assert.Contains("recovered", recovered.Markdown, StringComparison.Ordinal);
+        Assert.True(blockingStream.IsDisposed);
+        Assert.Equal(2, handler.CallCount);
+    }
+
+    [Fact]
     public async Task WebReader_BoundsConcurrentOperationsPerInstance() {
         var handler = new BlockingFirstRequestHandler();
         using var httpClient = new HttpClient(handler);
@@ -398,6 +454,38 @@ public sealed class ReaderWebTests {
 
         protected override void Dispose(bool disposing) {
             if (disposing) _inner.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class CancellationIgnoringReadStream : Stream {
+        private readonly TaskCompletionSource<int> _pendingRead =
+            new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _isDisposed;
+
+        internal bool IsDisposed => Volatile.Read(ref _isDisposed) != 0;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override Task<int> ReadAsync(
+            byte[] buffer,
+            int offset,
+            int count,
+            CancellationToken cancellationToken) => _pendingRead.Task;
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing) {
+            if (disposing) Interlocked.Exchange(ref _isDisposed, 1);
             base.Dispose(disposing);
         }
     }

--- a/OfficeIMO.Reader.Tests/Reader.Web.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Web.cs
@@ -182,6 +182,17 @@ public sealed class ReaderWebTests {
         Assert.Contains("effective web input byte limit", exception.Message, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData(null, 0)]
+    [InlineData(1024L, 1024)]
+    [InlineData(65536L, 65536)]
+    [InlineData(1073741824L, 65536)]
+    public void WebReader_CapsInitialBufferCapacityIndependentOfTheResponseLimit(
+        long? declaredLength,
+        int expectedCapacity) {
+        Assert.Equal(expectedCapacity, ReaderWebTransport.GetInitialBufferCapacity(declaredLength));
+    }
+
     [Fact]
     public async Task WebReader_ReportsItsOwnRequestTimeout() {
         var handler = new DelegateHttpHandler(async (request, cancellationToken) => {

--- a/OfficeIMO.Reader.Tests/Reader.Web.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Web.cs
@@ -91,7 +91,7 @@ public sealed class ReaderWebTests {
     }
 
     [Fact]
-    public async Task WebReader_RejectsPrivateTargetsBeforeSending() {
+    public async Task WebReader_RejectsPrivateIpLiteralsBeforeSending() {
         var handler = new DelegateHttpHandler((request, cancellationToken) =>
             Task.FromResult(TextResponse("not reached", "text/plain")));
         using var httpClient = new HttpClient(handler);
@@ -219,7 +219,7 @@ public sealed class ReaderWebTests {
     }
 
     [Fact]
-    public async Task WebReader_CanExplicitlyAllowAPrivateTarget() {
+    public async Task WebReader_CanExplicitlyAllowLocalhost() {
         var handler = new DelegateHttpHandler((request, cancellationToken) =>
             Task.FromResult(TextResponse("local fixture", "text/plain")));
         using var httpClient = new HttpClient(handler);
@@ -227,7 +227,7 @@ public sealed class ReaderWebTests {
             httpClient,
             new ReaderWebOptions {
                 AllowedHosts = new[] { "localhost" },
-                AllowPrivateNetworkTargets = true
+                AllowLocalhostAndNonPublicIpLiterals = true
             });
 
         OfficeDocumentReadResult result = await webReader.ReadDocumentAsync(

--- a/OfficeIMO.Reader.Web/OfficeDocumentReaderWebExtensions.cs
+++ b/OfficeIMO.Reader.Web/OfficeDocumentReaderWebExtensions.cs
@@ -5,6 +5,10 @@ public static class OfficeDocumentReaderWebExtensions {
     /// <summary>
     /// Creates a bounded web reader without mutating the source Reader or taking ownership of the HTTP client.
     /// </summary>
+    /// <remarks>
+    /// For untrusted URIs, the supplied client handler must validate resolved addresses at connection time and
+    /// validate every redirect destination before sending the redirected request.
+    /// </remarks>
     public static OfficeDocumentWebReader CreateWebReader(
         this OfficeDocumentReader reader,
         HttpClient httpClient,

--- a/OfficeIMO.Reader.Web/OfficeDocumentReaderWebExtensions.cs
+++ b/OfficeIMO.Reader.Web/OfficeDocumentReaderWebExtensions.cs
@@ -1,0 +1,14 @@
+namespace OfficeIMO.Reader.Web;
+
+/// <summary>Creates explicit web transports for existing Reader instances.</summary>
+public static class OfficeDocumentReaderWebExtensions {
+    /// <summary>
+    /// Creates a bounded web reader without mutating the source Reader or taking ownership of the HTTP client.
+    /// </summary>
+    public static OfficeDocumentWebReader CreateWebReader(
+        this OfficeDocumentReader reader,
+        HttpClient httpClient,
+        ReaderWebOptions? options = null) {
+        return new OfficeDocumentWebReader(reader, httpClient, options);
+    }
+}

--- a/OfficeIMO.Reader.Web/OfficeDocumentWebReader.cs
+++ b/OfficeIMO.Reader.Web/OfficeDocumentWebReader.cs
@@ -24,7 +24,7 @@ public sealed class OfficeDocumentWebReader {
     }
 
     /// <summary>
-    /// Downloads one bounded HTTP(S) response and routes its bytes through the configured Reader instance.
+    /// Downloads one bounded HTTP(S) response and routes its body through the configured Reader instance.
     /// </summary>
     public async Task<OfficeDocumentReadResult> ReadDocumentAsync(
         Uri uri,
@@ -40,7 +40,7 @@ public sealed class OfficeDocumentWebReader {
             if (readerOptions?.MaxInputBytes is long readerLimit && readerLimit >= 0) {
                 maxResponseBytes = Math.Min(maxResponseBytes, readerLimit);
             }
-            ReaderWebDownload download = await ReaderWebTransport.DownloadAsync(
+            using ReaderWebDownload download = await ReaderWebTransport.DownloadAsync(
                 _httpClient,
                 uri,
                 normalizedSourceName,
@@ -48,7 +48,7 @@ public sealed class OfficeDocumentWebReader {
                 _options,
                 cancellationToken).ConfigureAwait(false);
             OfficeDocumentReadResult result = await _reader.ReadDocumentAsync(
-                download.Bytes,
+                download.Content,
                 download.SourceName,
                 readerOptions,
                 cancellationToken).ConfigureAwait(false);

--- a/OfficeIMO.Reader.Web/OfficeDocumentWebReader.cs
+++ b/OfficeIMO.Reader.Web/OfficeDocumentWebReader.cs
@@ -1,0 +1,77 @@
+namespace OfficeIMO.Reader.Web;
+
+/// <summary>
+/// Bounded, thread-safe HTTP transport over a caller-configured <see cref="OfficeDocumentReader"/>.
+/// </summary>
+/// <remarks>
+/// The caller owns the Reader and <see cref="HttpClient"/> lifetimes. This type does not mutate or dispose either.
+/// </remarks>
+public sealed class OfficeDocumentWebReader {
+    private readonly OfficeDocumentReader _reader;
+    private readonly HttpClient _httpClient;
+    private readonly ReaderWebOptions _options;
+    private readonly SemaphoreSlim _requestGate;
+
+    /// <summary>Creates a bounded web reader over existing Reader and HTTP client instances.</summary>
+    public OfficeDocumentWebReader(
+        OfficeDocumentReader reader,
+        HttpClient httpClient,
+        ReaderWebOptions? options = null) {
+        _reader = reader ?? throw new ArgumentNullException(nameof(reader));
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _options = (options ?? new ReaderWebOptions()).CloneValidated();
+        _requestGate = new SemaphoreSlim(_options.MaxConcurrentRequests, _options.MaxConcurrentRequests);
+    }
+
+    /// <summary>
+    /// Downloads one bounded HTTP(S) response and routes its bytes through the configured Reader instance.
+    /// </summary>
+    public async Task<OfficeDocumentReadResult> ReadDocumentAsync(
+        Uri uri,
+        string? sourceName = null,
+        ReaderOptions? readerOptions = null,
+        CancellationToken cancellationToken = default) {
+        if (uri == null) throw new ArgumentNullException(nameof(uri));
+        ReaderWebUriPolicy.Validate(uri, _options);
+        string? normalizedSourceName = ReaderWebTransport.NormalizeExplicitSourceName(sourceName);
+        await _requestGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            long maxResponseBytes = _options.MaxResponseBytes;
+            if (readerOptions?.MaxInputBytes is long readerLimit && readerLimit >= 0) {
+                maxResponseBytes = Math.Min(maxResponseBytes, readerLimit);
+            }
+            ReaderWebDownload download = await ReaderWebTransport.DownloadAsync(
+                _httpClient,
+                uri,
+                normalizedSourceName,
+                maxResponseBytes,
+                _options,
+                cancellationToken).ConfigureAwait(false);
+            OfficeDocumentReadResult result = await _reader.ReadDocumentAsync(
+                download.Bytes,
+                download.SourceName,
+                readerOptions,
+                cancellationToken).ConfigureAwait(false);
+            download.ApplyTransportMetadata(result, _options);
+            return result;
+        } finally {
+            _requestGate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Downloads one bounded HTTP(S) response and returns the Markdown emitted by the same rich Reader pipeline.
+    /// </summary>
+    public async Task<string> ConvertToMarkdownAsync(
+        Uri uri,
+        string? sourceName = null,
+        ReaderOptions? readerOptions = null,
+        CancellationToken cancellationToken = default) {
+        OfficeDocumentReadResult result = await ReadDocumentAsync(
+            uri,
+            sourceName,
+            readerOptions,
+            cancellationToken).ConfigureAwait(false);
+        return result.Markdown ?? string.Empty;
+    }
+}

--- a/OfficeIMO.Reader.Web/OfficeDocumentWebReader.cs
+++ b/OfficeIMO.Reader.Web/OfficeDocumentWebReader.cs
@@ -52,7 +52,10 @@ public sealed class OfficeDocumentWebReader {
                 download.SourceName,
                 readerOptions,
                 cancellationToken).ConfigureAwait(false);
-            download.ApplyTransportMetadata(result, _options);
+            download.ApplyTransportMetadata(
+                result,
+                _options,
+                readerOptions?.ComputeHashes ?? true);
             return result;
         } finally {
             _requestGate.Release();

--- a/OfficeIMO.Reader.Web/OfficeDocumentWebReader.cs
+++ b/OfficeIMO.Reader.Web/OfficeDocumentWebReader.cs
@@ -43,15 +43,11 @@ public sealed class OfficeDocumentWebReader {
         string? normalizedSourceName = ReaderWebTransport.NormalizeExplicitSourceName(sourceName);
         await _requestGate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try {
-            long maxResponseBytes = _options.MaxResponseBytes;
-            if (readerOptions?.MaxInputBytes is long readerLimit && readerLimit >= 0) {
-                maxResponseBytes = Math.Min(maxResponseBytes, readerLimit);
-            }
             using ReaderWebDownload download = await ReaderWebTransport.DownloadAsync(
                 _httpClient,
                 uri,
                 normalizedSourceName,
-                maxResponseBytes,
+                logicalSourceName => GetEffectiveMaxInputBytes(logicalSourceName, readerOptions),
                 _options,
                 cancellationToken).ConfigureAwait(false);
             OfficeDocumentReadResult result = await _reader.ReadDocumentAsync(
@@ -67,6 +63,17 @@ public sealed class OfficeDocumentWebReader {
         } finally {
             _requestGate.Release();
         }
+    }
+
+    private long GetEffectiveMaxInputBytes(string sourceName, ReaderOptions? readerOptions) {
+        long maxInputBytes = _options.MaxResponseBytes;
+        if (readerOptions?.MaxInputBytes is long readerLimit && readerLimit >= 0) {
+            maxInputBytes = Math.Min(maxInputBytes, readerLimit);
+        }
+        if (_reader.GetHandlerDefaultMaxInputBytes(sourceName) is long handlerLimit) {
+            maxInputBytes = Math.Min(maxInputBytes, handlerLimit);
+        }
+        return maxInputBytes;
     }
 
     /// <summary>

--- a/OfficeIMO.Reader.Web/OfficeDocumentWebReader.cs
+++ b/OfficeIMO.Reader.Web/OfficeDocumentWebReader.cs
@@ -5,6 +5,9 @@ namespace OfficeIMO.Reader.Web;
 /// </summary>
 /// <remarks>
 /// The caller owns the Reader and <see cref="HttpClient"/> lifetimes. This type does not mutate or dispose either.
+/// URI validation provides defense in depth for schemes, allowlists, credentials, and non-public IP literals;
+/// it is not an SSRF isolation boundary. When reading an untrusted URI, configure the caller-owned HTTP handler
+/// to validate resolved addresses at connection time and validate each redirect before sending it.
 /// </remarks>
 public sealed class OfficeDocumentWebReader {
     private readonly OfficeDocumentReader _reader;
@@ -26,6 +29,10 @@ public sealed class OfficeDocumentWebReader {
     /// <summary>
     /// Downloads one bounded HTTP(S) response and routes its body through the configured Reader instance.
     /// </summary>
+    /// <remarks>
+    /// The URI must be trusted unless the caller-owned HTTP handler enforces connection-time address and
+    /// pre-request redirect policy. Reader Web cannot inspect or override those behaviors on an existing client.
+    /// </remarks>
     public async Task<OfficeDocumentReadResult> ReadDocumentAsync(
         Uri uri,
         string? sourceName = null,

--- a/OfficeIMO.Reader.Web/OfficeIMO.Reader.Web.csproj
+++ b/OfficeIMO.Reader.Web/OfficeIMO.Reader.Web.csproj
@@ -1,0 +1,49 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>Bounded caller-injected HTTP transport for OfficeIMO.Reader.</Description>
+    <AssemblyName>OfficeIMO.Reader.Web</AssemblyName>
+    <AssemblyTitle>OfficeIMO.Reader.Web</AssemblyTitle>
+    <VersionPrefix>2.0.1</VersionPrefix>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(\`Windows\`))' ">$(TargetFrameworks);net472</TargetFrameworks>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <IsPackable>true</IsPackable>
+    <IsPublishable>true</IsPublishable>
+    <Company>Evotec</Company>
+    <Authors>Przemyslaw Klys</Authors>
+    <PackageId>OfficeIMO.Reader.Web</PackageId>
+    <PackageTags>reader;web;http;url;ingestion;officeimo</PackageTags>
+    <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/EvotecIT/OfficeIMO</RepositoryUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <LangVersion>Latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OfficeIMO.Reader\OfficeIMO.Reader.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="README.md" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.Globalization" />
+    <Using Include="System.IO" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Net" />
+    <Using Include="System.Net.Http" />
+    <Using Include="System.Net.Http.Headers" />
+    <Using Include="System.Net.Sockets" />
+    <Using Include="System.Text" />
+    <Using Include="System.Threading" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="OfficeIMO.Reader" />
+  </ItemGroup>
+</Project>

--- a/OfficeIMO.Reader.Web/OfficeIMO.Reader.Web.csproj
+++ b/OfficeIMO.Reader.Web/OfficeIMO.Reader.Web.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>OfficeIMO.Reader.Web</AssemblyTitle>
     <VersionPrefix>2.0.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(\`Windows\`))' ">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <IsPackable>true</IsPackable>
     <IsPublishable>true</IsPublishable>

--- a/OfficeIMO.Reader.Web/OfficeIMO.Reader.Web.csproj
+++ b/OfficeIMO.Reader.Web/OfficeIMO.Reader.Web.csproj
@@ -27,6 +27,10 @@
     <ProjectReference Include="..\OfficeIMO.Reader\OfficeIMO.Reader.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>

--- a/OfficeIMO.Reader.Web/OfficeIMO.Reader.Web.csproj
+++ b/OfficeIMO.Reader.Web/OfficeIMO.Reader.Web.csproj
@@ -27,6 +27,10 @@
     <ProjectReference Include="..\OfficeIMO.Reader\OfficeIMO.Reader.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="OfficeIMO.Reader.Tests" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/OfficeIMO.Reader.Web/README.md
+++ b/OfficeIMO.Reader.Web/README.md
@@ -22,10 +22,13 @@ OfficeDocumentReadResult result = await webReader.ReadDocumentAsync(
     new Uri("https://docs.example.com/guide.html"));
 ```
 
-The transport accepts absolute HTTP(S) GET targets only, rejects URI-embedded credentials, checks an optional exact host allowlist, blocks obvious loopback/private/non-routable literal targets by default, caps response bytes, applies a request timeout, and bounds concurrent operations per web-reader instance. Query strings are omitted from result metadata unless explicitly enabled.
+The transport accepts absolute HTTP(S) GET targets only, rejects URI-embedded credentials, checks an optional exact host allowlist, blocks loopback/private/non-routable IP literals by default, caps response bytes, applies a request timeout, and bounds concurrent operations per web-reader instance. Query strings are omitted from result metadata unless explicitly enabled.
 
 Format selection stays with Reader. The logical source name comes from an explicit `sourceName`, the response `Content-Disposition` filename, or the final URI path, in that order. Supply `sourceName` when a download URL has no usable extension and content detection cannot identify the intended modular handler.
 
-The injected `HttpClient` owns authentication, proxies, certificates, DNS resolution, automatic redirects, decompression, retries, and connection policy. Because an already-configured handler can follow redirects before returning a response, server hosts must enforce DNS and redirect destinations in that handler when SSRF isolation matters. Reader Web validates the requested URI and the final URI reported by the response, but does not claim to intercept intermediate redirects.
+> [!IMPORTANT]
+> Reader Web is not an SSRF isolation boundary. The injected `HttpClient` owns DNS resolution, connection establishment, and automatic redirects. When a URI is untrusted, its handler must validate resolved addresses at connection time and validate every redirect destination before sending the redirected request. A preflight DNS lookup would remain vulnerable to rebinding, and Reader Web cannot intercept a redirect that an existing handler has already followed.
+
+The injected client also owns authentication, proxies, certificates, decompression, retries, and other connection policy. Reader Web validates the requested URI and the final URI reported by the response as defense in depth, but IP-literal screening does not make arbitrary hostnames safe.
 
 This package is not registered by `OfficeIMO.Reader.All` and performs no implicit network access. It adds no HTTP SDK, HTML parser, browser, process, native binary, model, or cloud provider; `System.Net.Http` comes from the target framework.

--- a/OfficeIMO.Reader.Web/README.md
+++ b/OfficeIMO.Reader.Web/README.md
@@ -22,7 +22,7 @@ OfficeDocumentReadResult result = await webReader.ReadDocumentAsync(
     new Uri("https://docs.example.com/guide.html"));
 ```
 
-The transport accepts absolute HTTP(S) GET targets only, rejects URI-embedded credentials, checks an optional exact host allowlist, blocks loopback/private/non-routable IP literals by default, caps response bytes, applies a request timeout, and bounds concurrent operations per web-reader instance. Query strings are omitted from result metadata unless explicitly enabled.
+The transport accepts absolute HTTP(S) GET targets only, rejects URI-embedded credentials, checks an optional exact host allowlist, blocks loopback/private/non-routable IP literals by default, caps response bytes at the strictest Web, Reader, or selected-handler limit, applies a request timeout, and bounds concurrent operations per web-reader instance. Query strings are omitted from result metadata unless explicitly enabled.
 
 Format selection stays with Reader. The logical source name comes from an explicit `sourceName`, the response `Content-Disposition` filename, or the final URI path, in that order. Supply `sourceName` when a download URL has no usable extension and content detection cannot identify the intended modular handler.
 

--- a/OfficeIMO.Reader.Web/README.md
+++ b/OfficeIMO.Reader.Web/README.md
@@ -1,0 +1,31 @@
+# OfficeIMO.Reader.Web
+
+`OfficeIMO.Reader.Web` is an explicit, bounded HTTP transport for an existing `OfficeDocumentReader`. It downloads bytes with a caller-owned `HttpClient`, then passes those bytes to the same configured handlers and processors used for local files.
+
+```csharp
+using OfficeIMO.Reader;
+using OfficeIMO.Reader.Html;
+using OfficeIMO.Reader.Web;
+
+OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+    .AddHtmlHandler()
+    .Build();
+
+var webReader = reader.CreateWebReader(
+    httpClient,
+    new ReaderWebOptions {
+        AllowedHosts = new[] { "docs.example.com" },
+        MaxResponseBytes = 16L * 1024L * 1024L
+    });
+
+OfficeDocumentReadResult result = await webReader.ReadDocumentAsync(
+    new Uri("https://docs.example.com/guide.html"));
+```
+
+The transport accepts absolute HTTP(S) GET targets only, rejects URI-embedded credentials, checks an optional exact host allowlist, blocks obvious loopback/private/non-routable literal targets by default, caps response bytes, applies a request timeout, and bounds concurrent operations per web-reader instance. Query strings are omitted from result metadata unless explicitly enabled.
+
+Format selection stays with Reader. The logical source name comes from an explicit `sourceName`, the response `Content-Disposition` filename, or the final URI path, in that order. Supply `sourceName` when a download URL has no usable extension and content detection cannot identify the intended modular handler.
+
+The injected `HttpClient` owns authentication, proxies, certificates, DNS resolution, automatic redirects, decompression, retries, and connection policy. Because an already-configured handler can follow redirects before returning a response, server hosts must enforce DNS and redirect destinations in that handler when SSRF isolation matters. Reader Web validates the requested URI and the final URI reported by the response, but does not claim to intercept intermediate redirects.
+
+This package is not registered by `OfficeIMO.Reader.All` and performs no implicit network access. It adds no HTTP SDK, HTML parser, browser, process, native binary, model, or cloud provider; `System.Net.Http` comes from the target framework.

--- a/OfficeIMO.Reader.Web/ReaderWebOptions.cs
+++ b/OfficeIMO.Reader.Web/ReaderWebOptions.cs
@@ -1,0 +1,96 @@
+namespace OfficeIMO.Reader.Web;
+
+/// <summary>Controls bounded HTTP retrieval before content enters an existing Reader pipeline.</summary>
+public sealed class ReaderWebOptions {
+    /// <summary>Default maximum downloaded response size: 64 MiB.</summary>
+    public const long DefaultMaxResponseBytes = 64L * 1024L * 1024L;
+
+    /// <summary>Maximum supported response bound: 1 GiB.</summary>
+    public const long MaximumResponseBytes = 1024L * 1024L * 1024L;
+
+    /// <summary>Gets or sets the maximum downloaded response bytes. Default: 64 MiB.</summary>
+    public long MaxResponseBytes { get; set; } = DefaultMaxResponseBytes;
+
+    /// <summary>Gets or sets the timeout covering response headers and body download. Default: two minutes.</summary>
+    public TimeSpan RequestTimeout { get; set; } = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// Gets or sets the maximum concurrent web read operations on one
+    /// <see cref="OfficeDocumentWebReader"/>. Default: 4.
+    /// </summary>
+    public int MaxConcurrentRequests { get; set; } = 4;
+
+    /// <summary>
+    /// Gets or sets an optional exact host allowlist. An empty list permits any host that passes the
+    /// scheme and private-target checks.
+    /// </summary>
+    public IReadOnlyList<string> AllowedHosts { get; set; } = Array.Empty<string>();
+
+    /// <summary>Gets or sets whether subdomains of entries in <see cref="AllowedHosts"/> are permitted.</summary>
+    public bool AllowSubdomains { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether loopback, private, link-local, and non-routable literal IP targets are permitted.
+    /// Default: false.
+    /// </summary>
+    public bool AllowPrivateNetworkTargets { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether query strings are retained in transport metadata. Default: false.
+    /// Keep disabled when URLs may contain signed tokens or other secrets.
+    /// </summary>
+    public bool IncludeQueryInMetadata { get; set; }
+
+    internal ReaderWebOptions CloneValidated() {
+        if (MaxResponseBytes < 1 || MaxResponseBytes > MaximumResponseBytes) {
+            throw new ArgumentOutOfRangeException(nameof(MaxResponseBytes));
+        }
+        if (RequestTimeout <= TimeSpan.Zero || RequestTimeout > TimeSpan.FromDays(1)) {
+            throw new ArgumentOutOfRangeException(nameof(RequestTimeout));
+        }
+        if (MaxConcurrentRequests < 1 || MaxConcurrentRequests > 64) {
+            throw new ArgumentOutOfRangeException(nameof(MaxConcurrentRequests));
+        }
+        if (AllowedHosts == null) throw new ArgumentNullException(nameof(AllowedHosts));
+
+        string[] allowedHosts = AllowedHosts
+            .Select(NormalizeAllowedHost)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        return new ReaderWebOptions {
+            MaxResponseBytes = MaxResponseBytes,
+            RequestTimeout = RequestTimeout,
+            MaxConcurrentRequests = MaxConcurrentRequests,
+            AllowedHosts = allowedHosts,
+            AllowSubdomains = AllowSubdomains,
+            AllowPrivateNetworkTargets = AllowPrivateNetworkTargets,
+            IncludeQueryInMetadata = IncludeQueryInMetadata
+        };
+    }
+
+    private static string NormalizeAllowedHost(string host) {
+        if (string.IsNullOrWhiteSpace(host)) {
+            throw new ArgumentException("Allowed host values cannot be empty.", nameof(AllowedHosts));
+        }
+        string normalized = host.Trim().TrimEnd('.');
+        if (normalized.Length > 253 ||
+            normalized.IndexOf("://", StringComparison.Ordinal) >= 0 ||
+            normalized.IndexOfAny(new[] { '/', '\\', '*', '?', '#', '@' }) >= 0) {
+            throw new ArgumentException("Allowed host values must be host names or IP literals without schemes or wildcards.", nameof(AllowedHosts));
+        }
+        if (normalized.Length > 1 && normalized[0] == '[' && normalized[normalized.Length - 1] == ']') {
+            normalized = normalized.Substring(1, normalized.Length - 2);
+        }
+        if (IPAddress.TryParse(normalized, out IPAddress? address)) {
+            return address.ToString().ToLowerInvariant();
+        }
+        if (Uri.CheckHostName(normalized) == UriHostNameType.Unknown) {
+            throw new ArgumentException("Allowed host value is not a valid host name or IP literal: " + host, nameof(AllowedHosts));
+        }
+        try {
+            return new Uri(Uri.UriSchemeHttp + "://" + normalized).IdnHost.TrimEnd('.').ToLowerInvariant();
+        } catch (UriFormatException exception) {
+            throw new ArgumentException("Allowed host value is not a valid host name: " + host, nameof(AllowedHosts), exception);
+        }
+    }
+}

--- a/OfficeIMO.Reader.Web/ReaderWebOptions.cs
+++ b/OfficeIMO.Reader.Web/ReaderWebOptions.cs
@@ -22,7 +22,7 @@ public sealed class ReaderWebOptions {
 
     /// <summary>
     /// Gets or sets an optional exact host allowlist. An empty list permits any host that passes the
-    /// scheme and private-target checks.
+    /// scheme and non-public IP-literal checks.
     /// </summary>
     public IReadOnlyList<string> AllowedHosts { get; set; } = Array.Empty<string>();
 
@@ -30,10 +30,15 @@ public sealed class ReaderWebOptions {
     public bool AllowSubdomains { get; set; }
 
     /// <summary>
-    /// Gets or sets whether loopback, private, link-local, and non-routable literal IP targets are permitted.
+    /// Gets or sets whether localhost names and loopback, private, link-local, or non-routable IP literals are permitted.
     /// Default: false.
     /// </summary>
-    public bool AllowPrivateNetworkTargets { get; set; }
+    /// <remarks>
+    /// This option screens URI literals only. It does not resolve hostnames or intercept redirects.
+    /// When a URI is not trusted, the caller-provided HTTP handler must validate resolved addresses at
+    /// connection time and validate every redirect destination before sending the redirected request.
+    /// </remarks>
+    public bool AllowLocalhostAndNonPublicIpLiterals { get; set; }
 
     /// <summary>
     /// Gets or sets whether query strings are retained in transport metadata. Default: false.
@@ -63,7 +68,7 @@ public sealed class ReaderWebOptions {
             MaxConcurrentRequests = MaxConcurrentRequests,
             AllowedHosts = allowedHosts,
             AllowSubdomains = AllowSubdomains,
-            AllowPrivateNetworkTargets = AllowPrivateNetworkTargets,
+            AllowLocalhostAndNonPublicIpLiterals = AllowLocalhostAndNonPublicIpLiterals,
             IncludeQueryInMetadata = IncludeQueryInMetadata
         };
     }

--- a/OfficeIMO.Reader.Web/ReaderWebPolicyException.cs
+++ b/OfficeIMO.Reader.Web/ReaderWebPolicyException.cs
@@ -1,0 +1,12 @@
+namespace OfficeIMO.Reader.Web;
+
+/// <summary>Thrown when a requested or reported response URI violates Reader Web policy.</summary>
+public sealed class ReaderWebPolicyException : InvalidOperationException {
+    internal ReaderWebPolicyException(Uri targetUri, string message)
+        : base(message) {
+        TargetUri = targetUri;
+    }
+
+    /// <summary>Gets the URI rejected by policy.</summary>
+    public Uri TargetUri { get; }
+}

--- a/OfficeIMO.Reader.Web/ReaderWebTransport.cs
+++ b/OfficeIMO.Reader.Web/ReaderWebTransport.cs
@@ -1,0 +1,207 @@
+namespace OfficeIMO.Reader.Web;
+
+internal static class ReaderWebTransport {
+    internal const string CapabilityId = "officeimo.reader.web";
+
+    internal static async Task<ReaderWebDownload> DownloadAsync(
+        HttpClient httpClient,
+        Uri uri,
+        string? sourceName,
+        long maxResponseBytes,
+        ReaderWebOptions options,
+        CancellationToken cancellationToken) {
+        ReaderWebUriPolicy.Validate(uri, options);
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(options.RequestTimeout);
+        try {
+            using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+            using HttpResponseMessage response = await httpClient.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                timeout.Token).ConfigureAwait(false);
+            Uri finalUri = response.RequestMessage?.RequestUri ?? uri;
+            ReaderWebUriPolicy.Validate(finalUri, options);
+            response.EnsureSuccessStatusCode();
+
+            long? declaredLength = response.Content.Headers.ContentLength;
+            if (declaredLength.HasValue && declaredLength.Value > maxResponseBytes) {
+                throw new IOException(
+                    "HTTP response exceeds the effective web input byte limit (" +
+                    declaredLength.Value.ToString(CultureInfo.InvariantCulture) + " > " +
+                    maxResponseBytes.ToString(CultureInfo.InvariantCulture) + ").");
+            }
+
+            byte[] bytes = await ReadBoundedContentAsync(
+                response.Content,
+                declaredLength,
+                maxResponseBytes,
+                timeout.Token).ConfigureAwait(false);
+            string logicalSourceName = ResolveSourceName(
+                sourceName,
+                finalUri,
+                response.Content.Headers.ContentDisposition);
+            return new ReaderWebDownload(
+                bytes,
+                logicalSourceName,
+                uri,
+                finalUri,
+                (int)response.StatusCode,
+                response.Content.Headers.ContentType?.ToString(),
+                response.Content.Headers.LastModified?.UtcDateTime);
+        } catch (OperationCanceledException exception)
+            when (!cancellationToken.IsCancellationRequested && timeout.IsCancellationRequested) {
+            throw new TimeoutException("Reader Web request exceeded RequestTimeout.", exception);
+        }
+    }
+
+    private static async Task<byte[]> ReadBoundedContentAsync(
+        HttpContent content,
+        long? declaredLength,
+        long maxResponseBytes,
+        CancellationToken cancellationToken) {
+        int capacity = declaredLength.HasValue
+            ? (int)Math.Min(declaredLength.Value, maxResponseBytes)
+            : 0;
+        using var output = capacity > 0 ? new MemoryStream(capacity) : new MemoryStream();
+        using Stream input = await content.ReadAsStreamAsync().ConfigureAwait(false);
+        byte[] buffer = new byte[64 * 1024];
+        long total = 0;
+        while (true) {
+            int read = await input.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+            if (read == 0) break;
+            if (total > maxResponseBytes - read) {
+                throw new IOException(
+                    "HTTP response exceeds the effective web input byte limit (" +
+                    (total + read).ToString(CultureInfo.InvariantCulture) + " > " +
+                    maxResponseBytes.ToString(CultureInfo.InvariantCulture) + ").");
+            }
+            output.Write(buffer, 0, read);
+            total += read;
+        }
+        return output.ToArray();
+    }
+
+    private static string ResolveSourceName(
+        string? sourceName,
+        Uri finalUri,
+        ContentDispositionHeaderValue? contentDisposition) {
+        if (sourceName != null) {
+            return sourceName;
+        }
+
+        string? candidate = contentDisposition?.FileNameStar ?? contentDisposition?.FileName;
+        if (string.IsNullOrWhiteSpace(candidate)) {
+            try {
+                candidate = Uri.UnescapeDataString(finalUri.AbsolutePath);
+            } catch (UriFormatException) {
+                candidate = finalUri.AbsolutePath;
+            }
+        }
+        string derived = SanitizeDerivedSourceName(candidate);
+        return derived.Length == 0 ? "download" : derived;
+    }
+
+    private static string SanitizeDerivedSourceName(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) return string.Empty;
+        string normalized = value!.Trim().Trim('"').Replace('\\', '/');
+        int separator = normalized.LastIndexOf('/');
+        if (separator >= 0) normalized = normalized.Substring(separator + 1);
+        var safe = new StringBuilder(Math.Min(normalized.Length, 512));
+        for (int index = 0; index < normalized.Length; index++) {
+            char character = normalized[index];
+            if (!char.IsControl(character)) safe.Append(character);
+        }
+        string result = safe.ToString().Trim();
+        if (result == "." || result == "..") return string.Empty;
+        if (result.Length > 512) result = result.Substring(result.Length - 512);
+        return result;
+    }
+
+    internal static string? NormalizeExplicitSourceName(string? sourceName) {
+        if (sourceName == null) return null;
+        string normalized = sourceName.Trim();
+        if (normalized.Length == 0) {
+            throw new ArgumentException("Source name cannot be empty when supplied.", nameof(sourceName));
+        }
+        if (normalized.Length > 2048) {
+            throw new ArgumentException("Source name cannot exceed 2,048 characters.", nameof(sourceName));
+        }
+        for (int index = 0; index < normalized.Length; index++) {
+            if (char.IsControl(normalized[index])) {
+                throw new ArgumentException("Source name cannot contain control characters.", nameof(sourceName));
+            }
+        }
+        return normalized;
+    }
+}
+
+internal sealed class ReaderWebDownload {
+    internal ReaderWebDownload(
+        byte[] bytes,
+        string sourceName,
+        Uri requestUri,
+        Uri responseUri,
+        int statusCode,
+        string? contentType,
+        DateTime? lastModifiedUtc) {
+        Bytes = bytes;
+        SourceName = sourceName;
+        RequestUri = requestUri;
+        ResponseUri = responseUri;
+        StatusCode = statusCode;
+        ContentType = contentType;
+        LastModifiedUtc = lastModifiedUtc;
+    }
+
+    internal byte[] Bytes { get; }
+    internal string SourceName { get; }
+    internal Uri RequestUri { get; }
+    internal Uri ResponseUri { get; }
+    internal int StatusCode { get; }
+    internal string? ContentType { get; }
+    internal DateTime? LastModifiedUtc { get; }
+
+    internal void ApplyTransportMetadata(OfficeDocumentReadResult result, ReaderWebOptions options) {
+        result.CapabilitiesUsed = result.CapabilitiesUsed
+            .Concat(new[] { ReaderWebTransport.CapabilityId })
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        result.Source.LengthBytes = Bytes.LongLength;
+        if (!result.Source.LastWriteUtc.HasValue && LastModifiedUtc.HasValue) {
+            result.Source.LastWriteUtc = LastModifiedUtc;
+        }
+        var metadata = new List<OfficeDocumentMetadataEntry> {
+            Metadata("reader-web-request-uri", "RequestUri", FormatUri(RequestUri, options.IncludeQueryInMetadata), "uri"),
+            Metadata("reader-web-response-uri", "ResponseUri", FormatUri(ResponseUri, options.IncludeQueryInMetadata), "uri"),
+            Metadata("reader-web-status-code", "StatusCode", StatusCode.ToString(CultureInfo.InvariantCulture), "number"),
+            Metadata("reader-web-length", "LengthBytes", Bytes.LongLength.ToString(CultureInfo.InvariantCulture), "number")
+        };
+        if (!string.IsNullOrWhiteSpace(ContentType)) {
+            metadata.Add(Metadata("reader-web-content-type", "ContentType", ContentType!, "string"));
+        }
+        if (LastModifiedUtc.HasValue) {
+            metadata.Add(Metadata(
+                "reader-web-last-modified",
+                "LastModifiedUtc",
+                LastModifiedUtc.Value.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture),
+                "timestamp"));
+        }
+        result.Metadata = result.Metadata.Concat(metadata).ToArray();
+    }
+
+    private static OfficeDocumentMetadataEntry Metadata(string id, string name, string value, string valueType) {
+        return new OfficeDocumentMetadataEntry {
+            Id = id,
+            Category = "web.transport",
+            Name = name,
+            Value = value,
+            ValueType = valueType
+        };
+    }
+
+    private static string FormatUri(Uri uri, bool includeQuery) {
+        var builder = new UriBuilder(uri) { Fragment = string.Empty };
+        if (!includeQuery) builder.Query = string.Empty;
+        return builder.Uri.AbsoluteUri;
+    }
+}

--- a/OfficeIMO.Reader.Web/ReaderWebTransport.cs
+++ b/OfficeIMO.Reader.Web/ReaderWebTransport.cs
@@ -32,59 +32,75 @@ internal static class ReaderWebTransport {
                     maxResponseBytes.ToString(CultureInfo.InvariantCulture) + ").");
             }
 
-            byte[] bytes = await ReadBoundedContentAsync(
+            MemoryStream content = await ReadBoundedContentAsync(
                 response.Content,
                 declaredLength,
                 maxResponseBytes,
                 timeout.Token).ConfigureAwait(false);
-            string logicalSourceName = ResolveSourceName(
-                sourceName,
-                finalUri,
-                response.Content.Headers.ContentDisposition);
-            return new ReaderWebDownload(
-                bytes,
-                logicalSourceName,
-                uri,
-                finalUri,
-                (int)response.StatusCode,
-                response.Content.Headers.ContentType?.ToString(),
-                response.Content.Headers.LastModified?.UtcDateTime);
+            try {
+                string logicalSourceName = ResolveSourceName(
+                    sourceName,
+                    finalUri,
+                    response.Content.Headers.ContentDisposition);
+                return new ReaderWebDownload(
+                    content,
+                    logicalSourceName,
+                    uri,
+                    finalUri,
+                    (int)response.StatusCode,
+                    response.Content.Headers.ContentType?.ToString(),
+                    response.Content.Headers.LastModified?.UtcDateTime);
+            } catch {
+                content.Dispose();
+                throw;
+            }
         } catch (OperationCanceledException exception)
             when (!cancellationToken.IsCancellationRequested && timeout.IsCancellationRequested) {
             throw new TimeoutException("Reader Web request exceeded RequestTimeout.", exception);
         }
     }
 
-    private static async Task<byte[]> ReadBoundedContentAsync(
+    private static async Task<MemoryStream> ReadBoundedContentAsync(
         HttpContent content,
         long? declaredLength,
         long maxResponseBytes,
         CancellationToken cancellationToken) {
         int capacity = GetInitialBufferCapacity(declaredLength);
-        using var output = capacity > 0 ? new MemoryStream(capacity) : new MemoryStream();
-        using Stream input = await content.ReadAsStreamAsync().ConfigureAwait(false);
-        byte[] buffer = new byte[64 * 1024];
-        long total = 0;
-        while (true) {
-            cancellationToken.ThrowIfCancellationRequested();
-            Task<int> readOperation = input.ReadAsync(buffer, 0, buffer.Length, cancellationToken);
-            int read = await WaitForOperationAsync(readOperation, cancellationToken).ConfigureAwait(false);
-            if (read == 0) break;
-            if (total > maxResponseBytes - read) {
-                throw new IOException(
-                    "HTTP response exceeds the effective web input byte limit (" +
-                    (total + read).ToString(CultureInfo.InvariantCulture) + " > " +
-                    maxResponseBytes.ToString(CultureInfo.InvariantCulture) + ").");
+        MemoryStream output = ReaderInputLimits.CreateSnapshotStream(capacity);
+        try {
+            Task<Stream> openOperation = content.ReadAsStreamAsync();
+            using Stream input = await WaitForOperationAsync(
+                openOperation,
+                cancellationToken,
+                stream => stream.Dispose()).ConfigureAwait(false);
+            byte[] buffer = new byte[64 * 1024];
+            long total = 0;
+            while (true) {
+                cancellationToken.ThrowIfCancellationRequested();
+                Task<int> readOperation = input.ReadAsync(buffer, 0, buffer.Length, cancellationToken);
+                int read = await WaitForOperationAsync(readOperation, cancellationToken).ConfigureAwait(false);
+                if (read == 0) break;
+                if (total > maxResponseBytes - read) {
+                    throw new IOException(
+                        "HTTP response exceeds the effective web input byte limit (" +
+                        (total + read).ToString(CultureInfo.InvariantCulture) + " > " +
+                        maxResponseBytes.ToString(CultureInfo.InvariantCulture) + ").");
+                }
+                output.Write(buffer, 0, read);
+                total += read;
             }
-            output.Write(buffer, 0, read);
-            total += read;
+            output.Position = 0;
+            return output;
+        } catch {
+            output.Dispose();
+            throw;
         }
-        return output.ToArray();
     }
 
     private static async Task<T> WaitForOperationAsync<T>(
         Task<T> operation,
-        CancellationToken cancellationToken) {
+        CancellationToken cancellationToken,
+        Action<T>? disposeAbandonedResult = null) {
         if (operation.IsCompleted) {
             return await operation.ConfigureAwait(false);
         }
@@ -100,15 +116,25 @@ internal static class ReaderWebTransport {
             }
         }
 
-        ObserveFault(operation);
+        ObserveAbandonedOperation(operation, disposeAbandonedResult);
         throw new OperationCanceledException(cancellationToken);
     }
 
-    private static void ObserveFault(Task operation) {
+    private static void ObserveAbandonedOperation<T>(Task<T> operation, Action<T>? disposeResult) {
         _ = operation.ContinueWith(
-            completed => { _ = completed.Exception; },
+            completed => {
+                if (completed.IsFaulted) {
+                    _ = completed.Exception;
+                } else if (completed.Status == TaskStatus.RanToCompletion && disposeResult != null) {
+                    try {
+                        disposeResult(completed.Result);
+                    } catch {
+                        // Cleanup must not surface on the continuation scheduler.
+                    }
+                }
+            },
             CancellationToken.None,
-            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskContinuationOptions.ExecuteSynchronously,
             TaskScheduler.Default);
     }
 
@@ -171,16 +197,17 @@ internal static class ReaderWebTransport {
     }
 }
 
-internal sealed class ReaderWebDownload {
+internal sealed class ReaderWebDownload : IDisposable {
     internal ReaderWebDownload(
-        byte[] bytes,
+        MemoryStream content,
         string sourceName,
         Uri requestUri,
         Uri responseUri,
         int statusCode,
         string? contentType,
         DateTime? lastModifiedUtc) {
-        Bytes = bytes;
+        Content = content;
+        LengthBytes = content.Length;
         SourceName = sourceName;
         RequestUri = requestUri;
         ResponseUri = responseUri;
@@ -189,7 +216,8 @@ internal sealed class ReaderWebDownload {
         LastModifiedUtc = lastModifiedUtc;
     }
 
-    internal byte[] Bytes { get; }
+    internal MemoryStream Content { get; }
+    internal long LengthBytes { get; }
     internal string SourceName { get; }
     internal Uri RequestUri { get; }
     internal Uri ResponseUri { get; }
@@ -207,7 +235,7 @@ internal sealed class ReaderWebDownload {
             result,
             sourceId,
             LastModifiedUtc,
-            Bytes.LongLength,
+            LengthBytes,
             computeHashes);
         result.CapabilitiesUsed = result.CapabilitiesUsed
             .Concat(new[] { ReaderWebTransport.CapabilityId })
@@ -217,7 +245,7 @@ internal sealed class ReaderWebDownload {
             Metadata("reader-web-request-uri", "RequestUri", FormatUri(RequestUri, options.IncludeQueryInMetadata), "uri"),
             Metadata("reader-web-response-uri", "ResponseUri", FormatUri(ResponseUri, options.IncludeQueryInMetadata), "uri"),
             Metadata("reader-web-status-code", "StatusCode", StatusCode.ToString(CultureInfo.InvariantCulture), "number"),
-            Metadata("reader-web-length", "LengthBytes", Bytes.LongLength.ToString(CultureInfo.InvariantCulture), "number")
+            Metadata("reader-web-length", "LengthBytes", LengthBytes.ToString(CultureInfo.InvariantCulture), "number")
         };
         if (!string.IsNullOrWhiteSpace(ContentType)) {
             metadata.Add(Metadata("reader-web-content-type", "ContentType", ContentType!, "string"));
@@ -230,6 +258,10 @@ internal sealed class ReaderWebDownload {
                 "timestamp"));
         }
         result.Metadata = result.Metadata.Concat(metadata).ToArray();
+    }
+
+    public void Dispose() {
+        Content.Dispose();
     }
 
     private static OfficeDocumentMetadataEntry Metadata(string id, string name, string value, string valueType) {

--- a/OfficeIMO.Reader.Web/ReaderWebTransport.cs
+++ b/OfficeIMO.Reader.Web/ReaderWebTransport.cs
@@ -165,15 +165,22 @@ internal sealed class ReaderWebDownload {
     internal string? ContentType { get; }
     internal DateTime? LastModifiedUtc { get; }
 
-    internal void ApplyTransportMetadata(OfficeDocumentReadResult result, ReaderWebOptions options) {
+    internal void ApplyTransportMetadata(
+        OfficeDocumentReadResult result,
+        ReaderWebOptions options,
+        bool computeHashes) {
+        string sourceId = DocumentReaderEngine.BuildPortableSourceId(
+            "web:" + FormatUri(ResponseUri, includeQuery: true));
+        DocumentReaderEngine.ApplyExternalSourceMetadata(
+            result,
+            sourceId,
+            LastModifiedUtc,
+            Bytes.LongLength,
+            computeHashes);
         result.CapabilitiesUsed = result.CapabilitiesUsed
             .Concat(new[] { ReaderWebTransport.CapabilityId })
             .Distinct(StringComparer.Ordinal)
             .ToArray();
-        result.Source.LengthBytes = Bytes.LongLength;
-        if (!result.Source.LastWriteUtc.HasValue && LastModifiedUtc.HasValue) {
-            result.Source.LastWriteUtc = LastModifiedUtc;
-        }
         var metadata = new List<OfficeDocumentMetadataEntry> {
             Metadata("reader-web-request-uri", "RequestUri", FormatUri(RequestUri, options.IncludeQueryInMetadata), "uri"),
             Metadata("reader-web-response-uri", "ResponseUri", FormatUri(ResponseUri, options.IncludeQueryInMetadata), "uri"),

--- a/OfficeIMO.Reader.Web/ReaderWebTransport.cs
+++ b/OfficeIMO.Reader.Web/ReaderWebTransport.cs
@@ -8,9 +8,10 @@ internal static class ReaderWebTransport {
         HttpClient httpClient,
         Uri uri,
         string? sourceName,
-        long maxResponseBytes,
+        Func<string, long> resolveMaxResponseBytes,
         ReaderWebOptions options,
         CancellationToken cancellationToken) {
+        if (resolveMaxResponseBytes == null) throw new ArgumentNullException(nameof(resolveMaxResponseBytes));
         ReaderWebUriPolicy.Validate(uri, options);
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeout.CancelAfter(options.RequestTimeout);
@@ -38,6 +39,11 @@ internal static class ReaderWebTransport {
                     ReaderWebUriPolicy.Validate(finalUri, options);
                     response.EnsureSuccessStatusCode();
 
+                    string logicalSourceName = ResolveSourceName(
+                        sourceName,
+                        finalUri,
+                        response.Content.Headers.ContentDisposition);
+                    long maxResponseBytes = resolveMaxResponseBytes(logicalSourceName);
                     long? declaredLength = response.Content.Headers.ContentLength;
                     if (declaredLength.HasValue && declaredLength.Value > maxResponseBytes) {
                         throw new IOException(
@@ -52,10 +58,6 @@ internal static class ReaderWebTransport {
                         maxResponseBytes,
                         timeout.Token).ConfigureAwait(false);
                     try {
-                        string logicalSourceName = ResolveSourceName(
-                            sourceName,
-                            finalUri,
-                            response.Content.Headers.ContentDisposition);
                         return new ReaderWebDownload(
                             content,
                             logicalSourceName,

--- a/OfficeIMO.Reader.Web/ReaderWebTransport.cs
+++ b/OfficeIMO.Reader.Web/ReaderWebTransport.cs
@@ -66,7 +66,9 @@ internal static class ReaderWebTransport {
         byte[] buffer = new byte[64 * 1024];
         long total = 0;
         while (true) {
-            int read = await input.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            Task<int> readOperation = input.ReadAsync(buffer, 0, buffer.Length, cancellationToken);
+            int read = await WaitForOperationAsync(readOperation, cancellationToken).ConfigureAwait(false);
             if (read == 0) break;
             if (total > maxResponseBytes - read) {
                 throw new IOException(
@@ -78,6 +80,36 @@ internal static class ReaderWebTransport {
             total += read;
         }
         return output.ToArray();
+    }
+
+    private static async Task<T> WaitForOperationAsync<T>(
+        Task<T> operation,
+        CancellationToken cancellationToken) {
+        if (operation.IsCompleted) {
+            return await operation.ConfigureAwait(false);
+        }
+
+        var cancellationSignal = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using (cancellationToken.Register(
+            state => ((TaskCompletionSource<bool>)state!).TrySetResult(true),
+            cancellationSignal)) {
+            Task completed = await Task.WhenAny(operation, cancellationSignal.Task).ConfigureAwait(false);
+            if (completed == operation) {
+                return await operation.ConfigureAwait(false);
+            }
+        }
+
+        ObserveFault(operation);
+        throw new OperationCanceledException(cancellationToken);
+    }
+
+    private static void ObserveFault(Task operation) {
+        _ = operation.ContinueWith(
+            completed => { _ = completed.Exception; },
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
     internal static int GetInitialBufferCapacity(long? declaredLength) {

--- a/OfficeIMO.Reader.Web/ReaderWebTransport.cs
+++ b/OfficeIMO.Reader.Web/ReaderWebTransport.cs
@@ -15,44 +15,62 @@ internal static class ReaderWebTransport {
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeout.CancelAfter(options.RequestTimeout);
         try {
-            using var request = new HttpRequestMessage(HttpMethod.Get, uri);
-            using HttpResponseMessage response = await httpClient.SendAsync(
-                request,
-                HttpCompletionOption.ResponseHeadersRead,
-                timeout.Token).ConfigureAwait(false);
-            Uri finalUri = response.RequestMessage?.RequestUri ?? uri;
-            ReaderWebUriPolicy.Validate(finalUri, options);
-            response.EnsureSuccessStatusCode();
-
-            long? declaredLength = response.Content.Headers.ContentLength;
-            if (declaredLength.HasValue && declaredLength.Value > maxResponseBytes) {
-                throw new IOException(
-                    "HTTP response exceeds the effective web input byte limit (" +
-                    declaredLength.Value.ToString(CultureInfo.InvariantCulture) + " > " +
-                    maxResponseBytes.ToString(CultureInfo.InvariantCulture) + ").");
-            }
-
-            MemoryStream content = await ReadBoundedContentAsync(
-                response.Content,
-                declaredLength,
-                maxResponseBytes,
-                timeout.Token).ConfigureAwait(false);
+            HttpRequestMessage? request = new HttpRequestMessage(HttpMethod.Get, uri);
             try {
-                string logicalSourceName = ResolveSourceName(
-                    sourceName,
-                    finalUri,
-                    response.Content.Headers.ContentDisposition);
-                return new ReaderWebDownload(
-                    content,
-                    logicalSourceName,
-                    uri,
-                    finalUri,
-                    (int)response.StatusCode,
-                    response.Content.Headers.ContentType?.ToString(),
-                    response.Content.Headers.LastModified?.UtcDateTime);
-            } catch {
-                content.Dispose();
-                throw;
+                Task<HttpResponseMessage> sendOperation = httpClient.SendAsync(
+                    request,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    timeout.Token);
+                HttpResponseMessage response;
+                try {
+                    response = await WaitForOperationAsync(
+                        sendOperation,
+                        timeout.Token,
+                        lateResponse => lateResponse.Dispose()).ConfigureAwait(false);
+                } catch (OperationCanceledException) when (!sendOperation.IsCompleted) {
+                    DisposeAfterCompletion(sendOperation, request);
+                    request = null;
+                    throw;
+                }
+
+                using (response) {
+                    Uri finalUri = response.RequestMessage?.RequestUri ?? uri;
+                    ReaderWebUriPolicy.Validate(finalUri, options);
+                    response.EnsureSuccessStatusCode();
+
+                    long? declaredLength = response.Content.Headers.ContentLength;
+                    if (declaredLength.HasValue && declaredLength.Value > maxResponseBytes) {
+                        throw new IOException(
+                            "HTTP response exceeds the effective web input byte limit (" +
+                            declaredLength.Value.ToString(CultureInfo.InvariantCulture) + " > " +
+                            maxResponseBytes.ToString(CultureInfo.InvariantCulture) + ").");
+                    }
+
+                    MemoryStream content = await ReadBoundedContentAsync(
+                        response.Content,
+                        declaredLength,
+                        maxResponseBytes,
+                        timeout.Token).ConfigureAwait(false);
+                    try {
+                        string logicalSourceName = ResolveSourceName(
+                            sourceName,
+                            finalUri,
+                            response.Content.Headers.ContentDisposition);
+                        return new ReaderWebDownload(
+                            content,
+                            logicalSourceName,
+                            uri,
+                            finalUri,
+                            (int)response.StatusCode,
+                            response.Content.Headers.ContentType?.ToString(),
+                            response.Content.Headers.LastModified?.UtcDateTime);
+                    } catch {
+                        content.Dispose();
+                        throw;
+                    }
+                }
+            } finally {
+                request?.Dispose();
             }
         } catch (OperationCanceledException exception)
             when (!cancellationToken.IsCancellationRequested && timeout.IsCancellationRequested) {
@@ -133,6 +151,21 @@ internal static class ReaderWebTransport {
                     }
                 }
             },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    private static void DisposeAfterCompletion(Task operation, IDisposable resource) {
+        _ = operation.ContinueWith(
+            (completed, state) => {
+                try {
+                    ((IDisposable)state!).Dispose();
+                } catch {
+                    // Cleanup must not surface on the continuation scheduler.
+                }
+            },
+            resource,
             CancellationToken.None,
             TaskContinuationOptions.ExecuteSynchronously,
             TaskScheduler.Default);

--- a/OfficeIMO.Reader.Web/ReaderWebTransport.cs
+++ b/OfficeIMO.Reader.Web/ReaderWebTransport.cs
@@ -2,6 +2,7 @@ namespace OfficeIMO.Reader.Web;
 
 internal static class ReaderWebTransport {
     internal const string CapabilityId = "officeimo.reader.web";
+    internal const int MaximumInitialBufferCapacity = 64 * 1024;
 
     internal static async Task<ReaderWebDownload> DownloadAsync(
         HttpClient httpClient,
@@ -59,9 +60,7 @@ internal static class ReaderWebTransport {
         long? declaredLength,
         long maxResponseBytes,
         CancellationToken cancellationToken) {
-        int capacity = declaredLength.HasValue
-            ? (int)Math.Min(declaredLength.Value, maxResponseBytes)
-            : 0;
+        int capacity = GetInitialBufferCapacity(declaredLength);
         using var output = capacity > 0 ? new MemoryStream(capacity) : new MemoryStream();
         using Stream input = await content.ReadAsStreamAsync().ConfigureAwait(false);
         byte[] buffer = new byte[64 * 1024];
@@ -79,6 +78,11 @@ internal static class ReaderWebTransport {
             total += read;
         }
         return output.ToArray();
+    }
+
+    internal static int GetInitialBufferCapacity(long? declaredLength) {
+        if (!declaredLength.HasValue || declaredLength.Value <= 0) return 0;
+        return (int)Math.Min(declaredLength.Value, MaximumInitialBufferCapacity);
     }
 
     private static string ResolveSourceName(

--- a/OfficeIMO.Reader.Web/ReaderWebUriPolicy.cs
+++ b/OfficeIMO.Reader.Web/ReaderWebUriPolicy.cs
@@ -63,6 +63,7 @@ internal static class ReaderWebUriPolicy {
                 (bytes[0] & 0xFE) == 0xFC ||
                 IsLocalUseNat64(bytes) ||
                 IsWellKnownNat64WithPrivateIpv4(bytes) ||
+                IsIpv4TranslatedWithPrivateIpv4(bytes) ||
                 IsSixToFourWithPrivateIpv4(bytes) ||
                 (bytes[0] == 0x20 && bytes[1] == 0x01 && bytes[2] == 0x0D && bytes[3] == 0xB8);
         }
@@ -104,6 +105,19 @@ internal static class ReaderWebUriPolicy {
         }
         for (int index = 4; index < 12; index++) {
             if (bytes[index] != 0x00) return false;
+        }
+        return IsPrivateOrNonRoutableIpv4(new[] { bytes[12], bytes[13], bytes[14], bytes[15] });
+    }
+
+    private static bool IsIpv4TranslatedWithPrivateIpv4(byte[] bytes) {
+        if (bytes.Length != 16 ||
+            bytes[0] != 0x00 || bytes[1] != 0x00 ||
+            bytes[2] != 0x00 || bytes[3] != 0x00 ||
+            bytes[4] != 0x00 || bytes[5] != 0x00 ||
+            bytes[6] != 0x00 || bytes[7] != 0x00 ||
+            bytes[8] != 0xFF || bytes[9] != 0xFF ||
+            bytes[10] != 0x00 || bytes[11] != 0x00) {
+            return false;
         }
         return IsPrivateOrNonRoutableIpv4(new[] { bytes[12], bytes[13], bytes[14], bytes[15] });
     }

--- a/OfficeIMO.Reader.Web/ReaderWebUriPolicy.cs
+++ b/OfficeIMO.Reader.Web/ReaderWebUriPolicy.cs
@@ -77,7 +77,11 @@ internal static class ReaderWebUriPolicy {
         if (first == 169 && second == 254) return true;
         if (first == 172 && second >= 16 && second <= 31) return true;
         if (first == 192 && second == 168) return true;
-        if (first == 192 && second == 0 && third <= 2) return true;
+        if (first == 192 && second == 0 && third == 0) {
+            byte fourth = bytes[3];
+            return fourth != 9 && fourth != 10;
+        }
+        if (first == 192 && second == 0 && third == 2) return true;
         if (first == 192 && second == 88 && third == 99) return true;
         if (first == 198 && (second == 18 || second == 19 || (second == 51 && third == 100))) return true;
         if (first == 203 && second == 0 && third == 113) return true;

--- a/OfficeIMO.Reader.Web/ReaderWebUriPolicy.cs
+++ b/OfficeIMO.Reader.Web/ReaderWebUriPolicy.cs
@@ -62,6 +62,7 @@ internal static class ReaderWebUriPolicy {
                 address.IsIPv6Multicast ||
                 (bytes[0] & 0xFE) == 0xFC ||
                 IsLocalUseNat64(bytes) ||
+                IsWellKnownNat64WithPrivateIpv4(bytes) ||
                 (bytes[0] == 0x20 && bytes[1] == 0x01 && bytes[2] == 0x0D && bytes[3] == 0xB8);
         }
         return true;
@@ -88,5 +89,17 @@ internal static class ReaderWebUriPolicy {
             bytes[0] == 0x00 && bytes[1] == 0x64 &&
             bytes[2] == 0xFF && bytes[3] == 0x9B &&
             bytes[4] == 0x00 && bytes[5] == 0x01;
+    }
+
+    private static bool IsWellKnownNat64WithPrivateIpv4(byte[] bytes) {
+        if (bytes.Length != 16 ||
+            bytes[0] != 0x00 || bytes[1] != 0x64 ||
+            bytes[2] != 0xFF || bytes[3] != 0x9B) {
+            return false;
+        }
+        for (int index = 4; index < 12; index++) {
+            if (bytes[index] != 0x00) return false;
+        }
+        return IsPrivateOrNonRoutableIpv4(new[] { bytes[12], bytes[13], bytes[14], bytes[15] });
     }
 }

--- a/OfficeIMO.Reader.Web/ReaderWebUriPolicy.cs
+++ b/OfficeIMO.Reader.Web/ReaderWebUriPolicy.cs
@@ -61,6 +61,7 @@ internal static class ReaderWebUriPolicy {
                 address.IsIPv6SiteLocal ||
                 address.IsIPv6Multicast ||
                 (bytes[0] & 0xFE) == 0xFC ||
+                IsDiscardOnlyIpv6(bytes) ||
                 IsLocalUseNat64(bytes) ||
                 IsWellKnownNat64WithPrivateIpv4(bytes) ||
                 IsIpv4TranslatedWithPrivateIpv4(bytes) ||
@@ -88,6 +89,14 @@ internal static class ReaderWebUriPolicy {
         if (first == 198 && (second == 18 || second == 19 || (second == 51 && third == 100))) return true;
         if (first == 203 && second == 0 && third == 113) return true;
         return false;
+    }
+
+    private static bool IsDiscardOnlyIpv6(byte[] bytes) {
+        if (bytes.Length != 16 || bytes[0] != 0x01) return false;
+        for (int index = 1; index < 8; index++) {
+            if (bytes[index] != 0x00) return false;
+        }
+        return true;
     }
 
     private static bool IsLocalUseNat64(byte[] bytes) {

--- a/OfficeIMO.Reader.Web/ReaderWebUriPolicy.cs
+++ b/OfficeIMO.Reader.Web/ReaderWebUriPolicy.cs
@@ -63,6 +63,7 @@ internal static class ReaderWebUriPolicy {
                 (bytes[0] & 0xFE) == 0xFC ||
                 IsLocalUseNat64(bytes) ||
                 IsWellKnownNat64WithPrivateIpv4(bytes) ||
+                IsSixToFourWithPrivateIpv4(bytes) ||
                 (bytes[0] == 0x20 && bytes[1] == 0x01 && bytes[2] == 0x0D && bytes[3] == 0xB8);
         }
         return true;
@@ -105,5 +106,11 @@ internal static class ReaderWebUriPolicy {
             if (bytes[index] != 0x00) return false;
         }
         return IsPrivateOrNonRoutableIpv4(new[] { bytes[12], bytes[13], bytes[14], bytes[15] });
+    }
+
+    private static bool IsSixToFourWithPrivateIpv4(byte[] bytes) {
+        return bytes.Length == 16 &&
+            bytes[0] == 0x20 && bytes[1] == 0x02 &&
+            IsPrivateOrNonRoutableIpv4(new[] { bytes[2], bytes[3], bytes[4], bytes[5] });
     }
 }

--- a/OfficeIMO.Reader.Web/ReaderWebUriPolicy.cs
+++ b/OfficeIMO.Reader.Web/ReaderWebUriPolicy.cs
@@ -1,0 +1,84 @@
+namespace OfficeIMO.Reader.Web;
+
+internal static class ReaderWebUriPolicy {
+    internal static void Validate(Uri uri, ReaderWebOptions options) {
+        if (uri == null) throw new ArgumentNullException(nameof(uri));
+        if (!uri.IsAbsoluteUri) {
+            throw new ReaderWebPolicyException(uri, "Reader Web requires an absolute URI.");
+        }
+        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)) {
+            throw new ReaderWebPolicyException(uri, "Reader Web permits only HTTP and HTTPS URIs.");
+        }
+        if (!string.IsNullOrEmpty(uri.UserInfo)) {
+            throw new ReaderWebPolicyException(uri, "Reader Web rejects credentials embedded in a URI.");
+        }
+
+        string host = uri.IdnHost.TrimEnd('.').ToLowerInvariant();
+        if (options.AllowedHosts.Count > 0 && !IsAllowedHost(host, options)) {
+            throw new ReaderWebPolicyException(uri, "Reader Web rejected a host outside the configured allowlist.");
+        }
+        if (!options.AllowPrivateNetworkTargets && IsPrivateOrNonRoutableTarget(uri, host)) {
+            throw new ReaderWebPolicyException(uri, "Reader Web rejected a loopback, private, link-local, or non-routable target.");
+        }
+    }
+
+    private static bool IsAllowedHost(string host, ReaderWebOptions options) {
+        for (int index = 0; index < options.AllowedHosts.Count; index++) {
+            string allowed = options.AllowedHosts[index];
+            if (string.Equals(host, allowed, StringComparison.OrdinalIgnoreCase)) return true;
+            if (options.AllowSubdomains &&
+                host.Length > allowed.Length &&
+                host.EndsWith("." + allowed, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static bool IsPrivateOrNonRoutableTarget(Uri uri, string host) {
+        if (uri.IsLoopback ||
+            string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase) ||
+            host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase)) {
+            return true;
+        }
+        if (!IPAddress.TryParse(host, out IPAddress? address)) return false;
+        if (address.IsIPv4MappedToIPv6) address = address.MapToIPv4();
+        if (IPAddress.IsLoopback(address) ||
+            address.Equals(IPAddress.Any) ||
+            address.Equals(IPAddress.IPv6Any) ||
+            address.Equals(IPAddress.None) ||
+            address.Equals(IPAddress.IPv6None)) {
+            return true;
+        }
+
+        byte[] bytes = address.GetAddressBytes();
+        if (address.AddressFamily == AddressFamily.InterNetwork) {
+            return IsPrivateOrNonRoutableIpv4(bytes);
+        }
+        if (address.AddressFamily == AddressFamily.InterNetworkV6) {
+            return address.IsIPv6LinkLocal ||
+                address.IsIPv6SiteLocal ||
+                address.IsIPv6Multicast ||
+                (bytes[0] & 0xFE) == 0xFC ||
+                (bytes[0] == 0x20 && bytes[1] == 0x01 && bytes[2] == 0x0D && bytes[3] == 0xB8);
+        }
+        return true;
+    }
+
+    private static bool IsPrivateOrNonRoutableIpv4(byte[] bytes) {
+        byte first = bytes[0];
+        byte second = bytes[1];
+        byte third = bytes[2];
+        if (first == 0 || first == 10 || first == 127 || first >= 224) return true;
+        if (first == 100 && second >= 64 && second <= 127) return true;
+        if (first == 169 && second == 254) return true;
+        if (first == 172 && second >= 16 && second <= 31) return true;
+        if (first == 192 && second == 168) return true;
+        if (first == 192 && second == 0 && third <= 2) return true;
+        if (first == 192 && second == 88 && third == 99) return true;
+        if (first == 198 && (second == 18 || second == 19 || (second == 51 && third == 100))) return true;
+        if (first == 203 && second == 0 && third == 113) return true;
+        return false;
+    }
+}

--- a/OfficeIMO.Reader.Web/ReaderWebUriPolicy.cs
+++ b/OfficeIMO.Reader.Web/ReaderWebUriPolicy.cs
@@ -18,8 +18,8 @@ internal static class ReaderWebUriPolicy {
         if (options.AllowedHosts.Count > 0 && !IsAllowedHost(host, options)) {
             throw new ReaderWebPolicyException(uri, "Reader Web rejected a host outside the configured allowlist.");
         }
-        if (!options.AllowPrivateNetworkTargets && IsPrivateOrNonRoutableTarget(uri, host)) {
-            throw new ReaderWebPolicyException(uri, "Reader Web rejected a loopback, private, link-local, or non-routable target.");
+        if (!options.AllowLocalhostAndNonPublicIpLiterals && IsLocalhostOrNonPublicIpLiteral(uri, host)) {
+            throw new ReaderWebPolicyException(uri, "Reader Web rejected a localhost name or a loopback, private, link-local, or non-routable IP literal.");
         }
     }
 
@@ -36,7 +36,7 @@ internal static class ReaderWebUriPolicy {
         return false;
     }
 
-    private static bool IsPrivateOrNonRoutableTarget(Uri uri, string host) {
+    private static bool IsLocalhostOrNonPublicIpLiteral(Uri uri, string host) {
         if (uri.IsLoopback ||
             string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase) ||
             host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase)) {

--- a/OfficeIMO.Reader.Web/ReaderWebUriPolicy.cs
+++ b/OfficeIMO.Reader.Web/ReaderWebUriPolicy.cs
@@ -61,6 +61,7 @@ internal static class ReaderWebUriPolicy {
                 address.IsIPv6SiteLocal ||
                 address.IsIPv6Multicast ||
                 (bytes[0] & 0xFE) == 0xFC ||
+                IsLocalUseNat64(bytes) ||
                 (bytes[0] == 0x20 && bytes[1] == 0x01 && bytes[2] == 0x0D && bytes[3] == 0xB8);
         }
         return true;
@@ -80,5 +81,12 @@ internal static class ReaderWebUriPolicy {
         if (first == 198 && (second == 18 || second == 19 || (second == 51 && third == 100))) return true;
         if (first == 203 && second == 0 && third == 113) return true;
         return false;
+    }
+
+    private static bool IsLocalUseNat64(byte[] bytes) {
+        return bytes.Length == 16 &&
+            bytes[0] == 0x00 && bytes[1] == 0x64 &&
+            bytes[2] == 0xFF && bytes[3] == 0x9B &&
+            bytes[4] == 0x00 && bytes[5] == 0x01;
     }
 }

--- a/OfficeIMO.Reader/DocumentReader.Document.cs
+++ b/OfficeIMO.Reader/DocumentReader.Document.cs
@@ -99,30 +99,39 @@ internal static partial class DocumentReaderEngine {
                     detection);
             }
 
-            using MemoryStream snapshot = ownsReadStream && readStream is MemoryStream bufferedInput
-                ? bufferedInput
-                : CopyToMemory(readStream, cancellationToken, opt.MaxInputBytes);
-            snapshot.Position = 0;
-            ReaderChunk[] chunks = Read(snapshot, logicalSourceName, opt, cancellationToken).ToArray();
-            snapshot.Position = 0;
-            bool customStreamReaderOwnsExtension = hasCustomStreamHandler && customStreamHandler.ReadStream != null;
-            IReadOnlyList<OfficeDocumentAsset> assets = customStreamReaderOwnsExtension
-                ? Array.Empty<OfficeDocumentAsset>()
-                : ReadOpenXmlImageAssets(snapshot, logicalSourceName, kind, opt, cancellationToken);
-            ReaderInputKind fallbackKind = customStreamReaderOwnsExtension ? customStreamHandler.Kind : kind;
-            OfficeDocumentReadResult result = BuildChunkDocumentResult(
-                chunks,
-                logicalSourceName,
-                fallbackKind,
-                BuildStreamDocumentSource(snapshot, logicalSourceName, chunks),
-                assets,
-                detection);
-            if (customStreamReaderOwnsExtension) {
-                return result;
+            MemoryStream? ownedSnapshot = null;
+            MemoryStream snapshot;
+            if (ReaderInputLimits.IsSnapshotStream(readStream)) {
+                snapshot = (MemoryStream)readStream;
+            } else {
+                ownedSnapshot = CopyToMemory(readStream, cancellationToken, opt.MaxInputBytes);
+                snapshot = ownedSnapshot;
             }
+            try {
+                snapshot.Position = 0;
+                ReaderChunk[] chunks = Read(snapshot, logicalSourceName, opt, cancellationToken).ToArray();
+                snapshot.Position = 0;
+                bool customStreamReaderOwnsExtension = hasCustomStreamHandler && customStreamHandler.ReadStream != null;
+                IReadOnlyList<OfficeDocumentAsset> assets = customStreamReaderOwnsExtension
+                    ? Array.Empty<OfficeDocumentAsset>()
+                    : ReadOpenXmlImageAssets(snapshot, logicalSourceName, kind, opt, cancellationToken);
+                ReaderInputKind fallbackKind = customStreamReaderOwnsExtension ? customStreamHandler.Kind : kind;
+                OfficeDocumentReadResult result = BuildChunkDocumentResult(
+                    chunks,
+                    logicalSourceName,
+                    fallbackKind,
+                    BuildStreamDocumentSource(snapshot, logicalSourceName, chunks),
+                    assets,
+                    detection);
+                if (customStreamReaderOwnsExtension) {
+                    return result;
+                }
 
-            snapshot.Position = 0;
-            return EnrichBuiltInDocumentResult(snapshot, logicalSourceName, kind, opt, result, cancellationToken);
+                snapshot.Position = 0;
+                return EnrichBuiltInDocumentResult(snapshot, logicalSourceName, kind, opt, result, cancellationToken);
+            } finally {
+                ownedSnapshot?.Dispose();
+            }
         } finally {
             if (ownsReadStream) {
                 readStream.Dispose();

--- a/OfficeIMO.Reader/DocumentReader.Registry.cs
+++ b/OfficeIMO.Reader/DocumentReader.Registry.cs
@@ -160,6 +160,10 @@ internal static partial class DocumentReaderEngine {
             return options.MaxInputBytes;
         }
 
+        return ResolveHandlerDefaultMaxInputBytes(sourceName);
+    }
+
+    internal static long? ResolveHandlerDefaultMaxInputBytes(string? sourceName) {
         if (TryResolveCustomHandlerBySourceName(sourceName, out ReaderHandlerDescriptor customHandler)
             && customHandler.DefaultMaxInputBytes.HasValue) {
             return customHandler.DefaultMaxInputBytes;

--- a/OfficeIMO.Reader/DocumentReader.Registry.cs
+++ b/OfficeIMO.Reader/DocumentReader.Registry.cs
@@ -165,7 +165,7 @@ internal static partial class DocumentReaderEngine {
 
     internal static long? ResolveHandlerDefaultMaxInputBytes(string? sourceName) {
         if (TryResolveCustomHandlerBySourceName(sourceName, out ReaderHandlerDescriptor customHandler)
-            && customHandler.DefaultMaxInputBytes.HasValue) {
+            && customHandler.SupportsStreamInput) {
             return customHandler.DefaultMaxInputBytes;
         }
 

--- a/OfficeIMO.Reader/DocumentReader.SourceIdentity.cs
+++ b/OfficeIMO.Reader/DocumentReader.SourceIdentity.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+
+namespace OfficeIMO.Reader;
+
+internal static partial class DocumentReaderEngine {
+    internal static string BuildPortableSourceId(string sourceKey) {
+        if (sourceKey == null) throw new ArgumentNullException(nameof(sourceKey));
+        // External identities are not filesystem paths, so their case must not vary by host OS.
+        return "src:" + ComputeSha256Hex(sourceKey);
+    }
+
+    internal static void ApplyExternalSourceMetadata(
+        OfficeDocumentReadResult result,
+        string sourceId,
+        DateTime? lastWriteUtc,
+        long? lengthBytes,
+        bool computeHashes) {
+        if (result == null) throw new ArgumentNullException(nameof(result));
+        if (string.IsNullOrWhiteSpace(sourceId)) throw new ArgumentException("Source ID cannot be empty.", nameof(sourceId));
+
+        result.Source ??= new OfficeDocumentSource();
+        result.Source.SourceId = sourceId;
+        if (lastWriteUtc.HasValue) result.Source.LastWriteUtc = lastWriteUtc.Value.ToUniversalTime();
+        if (lengthBytes.HasValue) result.Source.LengthBytes = lengthBytes;
+
+        // Source identity participates in chunk hashes; update both together as one core operation.
+        IReadOnlyList<ReaderChunk> chunks = result.Chunks ?? Array.Empty<ReaderChunk>();
+        for (int index = 0; index < chunks.Count; index++) {
+            ReaderChunk chunk = chunks[index];
+            chunk.SourceId = sourceId;
+            if (lastWriteUtc.HasValue) chunk.SourceLastWriteUtc = lastWriteUtc.Value.ToUniversalTime();
+            if (lengthBytes.HasValue) chunk.SourceLengthBytes = lengthBytes;
+            chunk.ChunkHash = computeHashes ? ComputeChunkHash(chunk) : null;
+        }
+    }
+}

--- a/OfficeIMO.Reader/OfficeDocumentReader.cs
+++ b/OfficeIMO.Reader/OfficeDocumentReader.cs
@@ -64,6 +64,12 @@ public sealed partial class OfficeDocumentReader {
         return ReaderCapabilityManifestJson.Serialize(GetCapabilityManifest(), indented);
     }
 
+    internal long? GetHandlerDefaultMaxInputBytes(string? sourceName) {
+        using (DocumentReaderEngine.UseHandlerRegistry(_handlers)) {
+            return DocumentReaderEngine.ResolveHandlerDefaultMaxInputBytes(sourceName);
+        }
+    }
+
     /// <summary>
     /// Reads a supported file using this reader's frozen handler configuration.
     /// </summary>

--- a/OfficeIMO.Reader/OfficeIMO.Reader.csproj
+++ b/OfficeIMO.Reader/OfficeIMO.Reader.csproj
@@ -75,6 +75,7 @@
     <InternalsVisibleTo Include="OfficeIMO.Reader.Rtf" />
     <InternalsVisibleTo Include="OfficeIMO.Reader.Subtitles" />
     <InternalsVisibleTo Include="OfficeIMO.Reader.Visio" />
+    <InternalsVisibleTo Include="OfficeIMO.Reader.Web" />
     <InternalsVisibleTo Include="OfficeIMO.Reader.Xml" />
     <InternalsVisibleTo Include="OfficeIMO.Reader.Yaml" />
     <InternalsVisibleTo Include="OfficeIMO.Reader.Zip" />

--- a/OfficeIMO.Reader/README.md
+++ b/OfficeIMO.Reader/README.md
@@ -124,6 +124,31 @@ OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
 
 The preset contains no parser or provider logic. It excludes OCR engines, process adapters, network clients, and hosted providers; those remain explicit host choices. Standalone images expose header metadata, source assets, and optional OCR candidates without running OCR. Notebook cells are never executed, and subtitle support reads local SRT/WebVTT text only.
 
+### Explicit bounded web transport
+
+Install `OfficeIMO.Reader.Web` only in hosts that intentionally allow network retrieval:
+
+```powershell
+dotnet add package OfficeIMO.Reader.Web
+```
+
+```csharp
+using OfficeIMO.Reader.Web;
+
+OfficeDocumentWebReader webReader = reader.CreateWebReader(
+    httpClient,
+    new ReaderWebOptions {
+        AllowedHosts = new[] { "docs.example.com" },
+        MaxResponseBytes = 16L * 1024 * 1024
+    });
+
+OfficeDocumentReadResult remote = await webReader.ReadDocumentAsync(
+    new Uri("https://docs.example.com/guide.html"),
+    cancellationToken: cancellationToken);
+```
+
+The web package performs bounded HTTP(S) GET retrieval and routes the bytes through the same configured Reader handlers and processors. It captures its options, bounds bytes, time, and concurrent operations, blocks obvious private literal targets by default, and omits query strings from metadata by default. The caller owns the `HttpClient` and its authentication, DNS, redirect, proxy, certificate, retry, and connection policy. It is deliberately absent from `OfficeIMO.Reader.All` and the global tool, so neither surface gains implicit network access.
+
 For scripts and shell pipelines, install the dependency-bounded global tool:
 
 ```powershell

--- a/OfficeIMO.Reader/ReaderInputLimits.cs
+++ b/OfficeIMO.Reader/ReaderInputLimits.cs
@@ -8,6 +8,14 @@ namespace OfficeIMO.Reader;
 /// Shared input-size guard helpers for reader adapters.
 /// </summary>
 public static class ReaderInputLimits {
+    internal static MemoryStream CreateSnapshotStream(int initialCapacity = 0) {
+        return new ReaderSnapshotStream(initialCapacity);
+    }
+
+    internal static bool IsSnapshotStream(Stream stream) {
+        return stream is ReaderSnapshotStream;
+    }
+
     /// <summary>
     /// Enforces <paramref name="maxBytes"/> against file length when available.
     /// </summary>
@@ -70,7 +78,7 @@ public static class ReaderInputLimits {
             stream.Position = 0;
         }
 
-        var buffer = new ReaderSnapshotStream();
+        var buffer = new ReaderSnapshotStream(0);
         try {
             var chunk = new byte[64 * 1024];
             long totalBytes = 0;
@@ -125,7 +133,7 @@ public static class ReaderInputLimits {
             stream.Position = 0;
         }
 
-        var buffer = new ReaderSnapshotStream();
+        var buffer = new ReaderSnapshotStream(0);
         try {
             var chunk = new byte[64 * 1024];
             long totalBytes = 0;
@@ -153,5 +161,7 @@ public static class ReaderInputLimits {
     }
 
     private sealed class ReaderSnapshotStream : MemoryStream {
+        internal ReaderSnapshotStream(int initialCapacity) : base(initialCapacity) {
+        }
     }
 }

--- a/OfficeIMO.sln
+++ b/OfficeIMO.sln
@@ -340,6 +340,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Reader.Notebook",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Reader.Subtitles", "OfficeIMO.Reader.Subtitles\OfficeIMO.Reader.Subtitles.csproj", "{7F73CF50-42FA-4B0F-AE09-6634D039193B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Reader.Web", "OfficeIMO.Reader.Web\OfficeIMO.Reader.Web.csproj", "{ECDA1010-F716-480A-B611-1E5474D181D2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1694,6 +1696,18 @@ Global
 		{7F73CF50-42FA-4B0F-AE09-6634D039193B}.Release|x64.Build.0 = Release|Any CPU
 		{7F73CF50-42FA-4B0F-AE09-6634D039193B}.Release|x86.ActiveCfg = Release|Any CPU
 		{7F73CF50-42FA-4B0F-AE09-6634D039193B}.Release|x86.Build.0 = Release|Any CPU
+		{ECDA1010-F716-480A-B611-1E5474D181D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ECDA1010-F716-480A-B611-1E5474D181D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ECDA1010-F716-480A-B611-1E5474D181D2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{ECDA1010-F716-480A-B611-1E5474D181D2}.Debug|x64.Build.0 = Debug|Any CPU
+		{ECDA1010-F716-480A-B611-1E5474D181D2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ECDA1010-F716-480A-B611-1E5474D181D2}.Debug|x86.Build.0 = Debug|Any CPU
+		{ECDA1010-F716-480A-B611-1E5474D181D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ECDA1010-F716-480A-B611-1E5474D181D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ECDA1010-F716-480A-B611-1E5474D181D2}.Release|x64.ActiveCfg = Release|Any CPU
+		{ECDA1010-F716-480A-B611-1E5474D181D2}.Release|x64.Build.0 = Release|Any CPU
+		{ECDA1010-F716-480A-B611-1E5474D181D2}.Release|x86.ActiveCfg = Release|Any CPU
+		{ECDA1010-F716-480A-B611-1E5474D181D2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -670,6 +670,14 @@ _Dependency footprint:_ only OfficeIMO Reader and platform APIs; no audio codec,
 
 _Dependency footprint:_ only OfficeIMO Reader and Visio.
 
+#### [OfficeIMO.Reader.Web](OfficeIMO.Reader.Web/README.md)
+
+- [x] Explicit caller-injected HTTP(S) transport over an existing Reader instance
+- [x] Response-byte, timeout, host, private-target, metadata-privacy, and concurrency bounds
+- [x] Existing handler and processor reuse without implicit network registration
+
+_Dependency footprint:_ only OfficeIMO Reader and framework `System.Net.Http`; no HTTP SDK, browser, process, model, or provider.
+
 #### [OfficeIMO.Reader.Xml](OfficeIMO.Reader.Xml/README.md)
 
 - [x] Element/attribute tree traversal into path rows


### PR DESCRIPTION
## Summary

- add `OfficeIMO.Reader.Web` as an explicit transport over an existing `OfficeDocumentReader`
- require a caller-owned `HttpClient` and enforce response-size, timeout, concurrency, host, IP-literal, and metadata-privacy policy
- route bounded response bodies through the configured Reader handlers and processors
- apply the strictest Web, explicit Reader, and selected stream-handler input limit after the final logical source name is known
- enforce response-header send, response-stream creation, and body-download timeout even when an operation ignores cancellation
- release request slots promptly and dispose resources that complete after timeout
- cap `Content-Length`-based initial buffer allocation at 64 KiB while streaming under the effective byte ceiling
- hand the bounded Reader-owned snapshot stream directly to Reader without a full-response byte-array rewrap
- reject local and non-public IP literals, including private IPv4 embedded in NAT64, IPv4-translated, and 6to4 forms, plus the IPv6 discard-only prefix
- derive privacy-safe source identity from the canonical final response URI and apply it consistently to chunks and chunk hashes
- propagate `Last-Modified` and response length for incremental processing
- keep network behavior out of `OfficeIMO.Reader.All` and the global tool

## Caller-owned network boundary

Reader Web is not an SSRF isolation boundary. Its scheme, allowlist, credential, requested-URI, final-URI, and IP-literal checks are defense in depth around an injected client.

The caller-owned `HttpClient` remains responsible for DNS resolution, connection establishment, and automatic redirects. When a URI is untrusted, its handler must validate resolved addresses at connection time and validate every redirect destination before sending the redirected request. Reader does not perform a preflight DNS lookup because that would remain vulnerable to rebinding, and it cannot intercept a redirect that an existing handler has already followed.

The option is named `AllowLocalhostAndNonPublicIpLiterals` so the API describes exactly what Reader itself can enforce.

## Dependency boundary

The package depends only on `OfficeIMO.Reader` and framework `System.Net.Http`. It adds no HTTP SDK, HTML parser, browser, process, native binary, runtime payload, model, cloud provider, audio transcription, Whisper, or YouTube integration.

Across the dependency-free Reader roadmap, no external `PackageReference` was added. The exact-head package contains `netstandard2.0`, `net8.0`, and `net10.0` assets and only the intended `OfficeIMO.Reader` dependency groups.

## Validation

- focused Web contracts: 37/37 passed on .NET 8 and .NET 10
- focused Web/registry boundary contracts: 45/45 passed on .NET 8 and .NET 10
- full Reader suite: 730/730 passed on .NET 8 and .NET 10
- `OfficeIMO.Reader.Web` `netstandard2.0` owner build: zero warnings
- exact-head package: all three target assets, with only `OfficeIMO.Reader` dependencies and no runtime/native payloads

This is the dependency-free bounded Web-ingestion step of the Reader roadmap and is based directly on current `master`.
