### PR TITLE
Strengthen EPUB package parsing and diagnostics

### DIFF
--- a/OfficeIMO.Epub/EpubChapter.cs
+++ b/OfficeIMO.Epub/EpubChapter.cs
@@ -34,6 +34,15 @@ public sealed class EpubChapter {
     /// </summary>
     public bool? IsLinear { get; internal set; }
 
+    /// <summary>Effective declared layout for this spine item, when specified.</summary>
+    public EpubRenditionLayout? RenditionLayout { get; internal set; }
+
+    /// <summary>Whether this chapter is declared as pre-paginated fixed-layout content.</summary>
+    public bool IsFixedLayout => RenditionLayout == EpubRenditionLayout.PrePaginated;
+
+    /// <summary>Encryption declaration for this chapter resource, when present.</summary>
+    public EpubEncryptionInfo? Encryption { get; internal set; }
+
     /// <summary>
     /// Best-effort chapter title.
     /// </summary>

--- a/OfficeIMO.Epub/EpubDiagnostic.cs
+++ b/OfficeIMO.Epub/EpubDiagnostic.cs
@@ -1,0 +1,16 @@
+namespace OfficeIMO.Epub;
+
+/// <summary>Describes a deterministic EPUB package or extraction diagnostic.</summary>
+public sealed class EpubDiagnostic {
+    /// <summary>Stable machine-readable diagnostic code.</summary>
+    public string Code { get; internal set; } = string.Empty;
+
+    /// <summary>Diagnostic severity.</summary>
+    public EpubDiagnosticSeverity Severity { get; internal set; }
+
+    /// <summary>Human-readable diagnostic message.</summary>
+    public string Message { get; internal set; } = string.Empty;
+
+    /// <summary>Normalized archive path associated with the diagnostic, when known.</summary>
+    public string? Path { get; internal set; }
+}

--- a/OfficeIMO.Epub/EpubDiagnosticSeverity.cs
+++ b/OfficeIMO.Epub/EpubDiagnosticSeverity.cs
@@ -1,0 +1,13 @@
+namespace OfficeIMO.Epub;
+
+/// <summary>Severity of an EPUB diagnostic.</summary>
+public enum EpubDiagnosticSeverity {
+    /// <summary>Informational package characteristic.</summary>
+    Info,
+
+    /// <summary>Recoverable package or extraction problem.</summary>
+    Warning,
+
+    /// <summary>Fatal package or extraction problem.</summary>
+    Error
+}

--- a/OfficeIMO.Epub/EpubDocument.cs
+++ b/OfficeIMO.Epub/EpubDocument.cs
@@ -1,6 +1,5 @@
 namespace OfficeIMO.Epub;
 
-using OfficeIMO.Drawing.Internal;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -35,9 +34,7 @@ public sealed class EpubDocument {
         Stream stream,
         EpubReadOptions? options = null,
         CancellationToken cancellationToken = default) {
-        byte[] bytes = await OfficeStreamReader.ReadAllBytesAsync(stream, cancellationToken).ConfigureAwait(false);
-        cancellationToken.ThrowIfCancellationRequested();
-        return EpubReader.ReadBytes(bytes, options);
+        return await EpubReader.ReadAsync(stream, options, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -65,6 +62,18 @@ public sealed class EpubDocument {
     /// </summary>
     public string? OpfPath { get; internal set; }
 
+    /// <summary>Version declared by the OPF package element.</summary>
+    public string? PackageVersion { get; internal set; }
+
+    /// <summary>ID of the dc:identifier selected by the package unique-identifier attribute.</summary>
+    public string? UniqueIdentifierId { get; internal set; }
+
+    /// <summary>Globally declared rendition layout, or null when the package uses the default.</summary>
+    public EpubRenditionLayout? RenditionLayout { get; internal set; }
+
+    /// <summary>Whether the package globally declares a pre-paginated fixed layout.</summary>
+    public bool IsFixedLayout => RenditionLayout == EpubRenditionLayout.PrePaginated;
+
     /// <summary>
     /// Extracted chapters.
     /// </summary>
@@ -74,6 +83,18 @@ public sealed class EpubDocument {
     /// OPF manifest resources in deterministic package order.
     /// </summary>
     public IReadOnlyList<EpubResource> Resources { get; internal set; } = Array.Empty<EpubResource>();
+
+    /// <summary>Encrypted or obfuscated resources declared by META-INF/encryption.xml.</summary>
+    public IReadOnlyList<EpubEncryptionInfo> Encryption { get; internal set; } = Array.Empty<EpubEncryptionInfo>();
+
+    /// <summary>Whether the container declares any encrypted or obfuscated resources.</summary>
+    public bool HasEncryptedResources => Encryption.Count > 0;
+
+    /// <summary>Whether one or more resources require unsupported decryption.</summary>
+    public bool RequiresDecryption => Encryption.Any(static item => item.RequiresDecryption);
+
+    /// <summary>Structured non-fatal diagnostics encountered during extraction.</summary>
+    public IReadOnlyList<EpubDiagnostic> Diagnostics { get; internal set; } = Array.Empty<EpubDiagnostic>();
 
     /// <summary>
     /// Non-fatal warnings encountered during extraction.

--- a/OfficeIMO.Epub/EpubEncryptionInfo.cs
+++ b/OfficeIMO.Epub/EpubEncryptionInfo.cs
@@ -1,0 +1,21 @@
+namespace OfficeIMO.Epub;
+
+/// <summary>Describes an encrypted or obfuscated resource declared by META-INF/encryption.xml.</summary>
+public sealed class EpubEncryptionInfo {
+    /// <summary>Normalized archive path of the affected resource.</summary>
+    public string Path { get; internal set; } = string.Empty;
+
+    /// <summary>Declared XML Encryption algorithm URI.</summary>
+    public string? Algorithm { get; internal set; }
+
+    /// <summary>Classified encryption or obfuscation kind.</summary>
+    public EpubEncryptionKind Kind { get; internal set; }
+
+    /// <summary>Whether the declaration is a recognized EPUB font-obfuscation algorithm.</summary>
+    public bool IsFontObfuscation =>
+        Kind == EpubEncryptionKind.IdpfFontObfuscation ||
+        Kind == EpubEncryptionKind.AdobeFontObfuscation;
+
+    /// <summary>Whether the resource requires a decryption capability not provided by OfficeIMO.Epub.</summary>
+    public bool RequiresDecryption => Kind == EpubEncryptionKind.Encryption || Kind == EpubEncryptionKind.Unknown;
+}

--- a/OfficeIMO.Epub/EpubEncryptionKind.cs
+++ b/OfficeIMO.Epub/EpubEncryptionKind.cs
@@ -1,0 +1,16 @@
+namespace OfficeIMO.Epub;
+
+/// <summary>Classifies encryption declarations used by EPUB containers.</summary>
+public enum EpubEncryptionKind {
+    /// <summary>The declaration does not provide a recognized algorithm.</summary>
+    Unknown,
+
+    /// <summary>IDPF EPUB font obfuscation.</summary>
+    IdpfFontObfuscation,
+
+    /// <summary>Legacy Adobe font obfuscation.</summary>
+    AdobeFontObfuscation,
+
+    /// <summary>Encryption that requires an external decryption or DRM capability.</summary>
+    Encryption
+}

--- a/OfficeIMO.Epub/EpubReadException.cs
+++ b/OfficeIMO.Epub/EpubReadException.cs
@@ -1,0 +1,12 @@
+namespace OfficeIMO.Epub;
+
+/// <summary>Represents a fatal EPUB package read failure with structured diagnostics.</summary>
+public sealed class EpubReadException : IOException {
+    internal EpubReadException(string message, IReadOnlyList<EpubDiagnostic> diagnostics, Exception? innerException = null)
+        : base(message, innerException) {
+        Diagnostics = diagnostics ?? Array.Empty<EpubDiagnostic>();
+    }
+
+    /// <summary>Structured diagnostics associated with the fatal read failure.</summary>
+    public IReadOnlyList<EpubDiagnostic> Diagnostics { get; }
+}

--- a/OfficeIMO.Epub/EpubReadOptions.cs
+++ b/OfficeIMO.Epub/EpubReadOptions.cs
@@ -4,6 +4,18 @@ namespace OfficeIMO.Epub;
 /// Controls EPUB extraction behavior.
 /// </summary>
 public sealed class EpubReadOptions {
+    /// <summary>Maximum compressed EPUB package size read from a file or stream.</summary>
+    public long MaxPackageBytes { get; set; } = 512L * 1024 * 1024;
+
+    /// <summary>Maximum number of ZIP entries indexed from the container.</summary>
+    public int MaxArchiveEntries { get; set; } = 10_000;
+
+    /// <summary>Maximum combined uncompressed size declared by ZIP entries.</summary>
+    public long MaxTotalUncompressedBytes { get; set; } = 4L * 1024 * 1024 * 1024;
+
+    /// <summary>Maximum size of container, OPF, navigation, NCX, or encryption XML read into memory.</summary>
+    public long MaxPackageMetadataBytes { get; set; } = 4L * 1024 * 1024;
+
     /// <summary>
     /// Maximum number of chapter entries to emit.
     /// </summary>

--- a/OfficeIMO.Epub/EpubReader.Chapters.cs
+++ b/OfficeIMO.Epub/EpubReader.Chapters.cs
@@ -1,0 +1,214 @@
+namespace OfficeIMO.Epub;
+
+using OfficeIMO.Drawing.Internal;
+
+internal static partial class EpubReader {
+    private static List<ChapterCandidate> BuildChapterCandidates(
+        Dictionary<string, ZipArchiveEntry> entryIndex,
+        EpubPackage? package,
+        EpubReadOptions options,
+        EpubDiagnosticCollector diagnostics) {
+        var candidates = new List<ChapterCandidate>();
+        var seenPaths = new HashSet<string>(StringComparer.Ordinal);
+
+        if (package != null && options.PreferSpineOrder && package.Spine.Count > 0) {
+            foreach (var spineItem in package.Spine.OrderBy(s => s.SpineIndex)) {
+                if (!options.IncludeNonLinearSpineItems && !spineItem.IsLinear) {
+                    continue;
+                }
+
+                if (!package.Manifest.TryGetValue(spineItem.IdRef, out var manifestItem)) {
+                    diagnostics.Warning(
+                        "epub.spine.manifest-id-missing",
+                        $"EPUB spine idref '{spineItem.IdRef}' does not exist in manifest.",
+                        package.OpfPath);
+                    continue;
+                }
+
+                if (!IsChapterManifestItem(manifestItem)) {
+                    continue;
+                }
+
+                if (!entryIndex.TryGetValue(manifestItem.FullPath, out var chapterEntry)) {
+                    diagnostics.Warning(
+                        "epub.spine.resource-missing",
+                        $"EPUB manifest item '{manifestItem.FullPath}' referenced by spine was not found in archive.",
+                        manifestItem.FullPath);
+                    continue;
+                }
+
+                var chapterPath = NormalizePath(chapterEntry.FullName);
+                if (seenPaths.Contains(chapterPath)) {
+                    continue;
+                }
+
+                seenPaths.Add(chapterPath);
+                candidates.Add(new ChapterCandidate {
+                    Entry = chapterEntry,
+                    ManifestId = manifestItem.Id,
+                    MediaType = manifestItem.MediaType,
+                    SpineIndex = spineItem.SpineIndex,
+                    IsLinear = spineItem.IsLinear,
+                    RenditionLayout = spineItem.RenditionLayout
+                });
+            }
+        }
+
+        var shouldFallbackScan = candidates.Count == 0 && options.FallbackToHtmlScan;
+        if (!options.PreferSpineOrder) {
+            shouldFallbackScan = true;
+        }
+
+        if (shouldFallbackScan) {
+            IEnumerable<ZipArchiveEntry> scanEntries = entryIndex.Values.Where(e => IsChapterEntry(e.FullName));
+            if (options.DeterministicOrder) {
+                scanEntries = scanEntries.OrderBy(e => e.FullName, StringComparer.Ordinal);
+            }
+
+            var manifestByPath = BuildManifestByPath(package);
+            foreach (var entry in scanEntries) {
+                var chapterPath = NormalizePath(entry.FullName);
+                if (seenPaths.Contains(chapterPath)) continue;
+
+                manifestByPath.TryGetValue(chapterPath, out var manifestItem);
+                seenPaths.Add(chapterPath);
+                candidates.Add(new ChapterCandidate {
+                    Entry = entry,
+                    ManifestId = manifestItem?.Id,
+                    MediaType = manifestItem?.MediaType,
+                    SpineIndex = null,
+                    IsLinear = null,
+                    RenditionLayout = package?.RenditionLayout
+                });
+            }
+        }
+
+        return candidates;
+    }
+
+    private static Dictionary<string, ManifestItem> BuildManifestByPath(EpubPackage? package) {
+        var map = new Dictionary<string, ManifestItem>(StringComparer.Ordinal);
+        if (package == null) return map;
+
+        foreach (var item in package.Manifest.Values) {
+            if (!map.ContainsKey(item.FullPath)) {
+                map[item.FullPath] = item;
+            }
+        }
+
+        return map;
+    }
+
+    private static bool IsChapterManifestItem(ManifestItem item) {
+        if (!string.IsNullOrWhiteSpace(item.MediaType) &&
+            (item.MediaType.IndexOf("xhtml", StringComparison.OrdinalIgnoreCase) >= 0 ||
+             item.MediaType.IndexOf("html", StringComparison.OrdinalIgnoreCase) >= 0)) {
+            return true;
+        }
+
+        return IsChapterEntry(item.FullPath);
+    }
+
+    private static bool IsChapterEntry(string? fullName) {
+        if (string.IsNullOrWhiteSpace(fullName)) return false;
+        var normalized = NormalizePath(fullName!);
+        if (normalized.EndsWith("/", StringComparison.Ordinal)) return false;
+
+        var ext = Path.GetExtension(normalized).ToLowerInvariant();
+        return ext == ".xhtml" || ext == ".html" || ext == ".htm";
+    }
+
+    private static string ReadEntryText(ZipArchiveEntry entry, long? maxBytes) {
+        byte[] data;
+        using (Stream entryStream = entry.Open()) {
+            data = OfficeStreamReader.ReadAllBytes(entryStream, maxBytes);
+        }
+        using var memory = new MemoryStream(data, writable: false);
+        using var reader = new StreamReader(memory, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 16 * 1024, leaveOpen: false);
+        return reader.ReadToEnd();
+    }
+
+    private static byte[] ReadEntryBytes(ZipArchiveEntry entry, long maxBytes) {
+        using Stream entryStream = entry.Open();
+        return OfficeStreamReader.ReadAllBytes(entryStream, maxBytes);
+    }
+
+    private static bool TryParseXml(string content, out XDocument? document) {
+        document = null;
+        if (string.IsNullOrWhiteSpace(content)) return false;
+
+        try {
+            var settings = new XmlReaderSettings {
+                DtdProcessing = DtdProcessing.Ignore,
+                XmlResolver = null
+            };
+
+            using var stringReader = new StringReader(content);
+            using var xmlReader = XmlReader.Create(stringReader, settings);
+            document = XDocument.Load(xmlReader, LoadOptions.PreserveWhitespace);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    private static string ExtractVisibleText(XDocument chapterDocument) {
+        var root = chapterDocument.Root;
+        if (root == null) return string.Empty;
+
+        var body = root.Descendants().FirstOrDefault(e => IsName(e, "body"));
+        var scope = (XContainer?)body ?? root;
+
+        var sb = new StringBuilder();
+        foreach (var textNode in scope.DescendantNodes().OfType<XText>()) {
+            if (textNode.Parent != null && (IsName(textNode.Parent, "script") || IsName(textNode.Parent, "style"))) {
+                continue;
+            }
+
+            var value = textNode.Value;
+            if (string.IsNullOrWhiteSpace(value)) continue;
+
+            sb.Append(value);
+            sb.Append(' ');
+        }
+
+        return NormalizeWhitespace(sb.ToString());
+    }
+
+    private static string? ResolveChapterTitle(XDocument chapterDocument, Dictionary<string, string> navTitleMap, string chapterPath) {
+        if (navTitleMap.TryGetValue(chapterPath, out var navTitle) && !string.IsNullOrWhiteSpace(navTitle)) {
+            return navTitle;
+        }
+
+        var title = chapterDocument.Descendants()
+            .FirstOrDefault(e => IsName(e, "title"));
+        if (title != null) {
+            var normalized = NormalizeWhitespace(title.Value);
+            if (normalized.Length > 0) return normalized;
+        }
+
+        var heading = chapterDocument.Descendants()
+            .FirstOrDefault(e => IsName(e, "h1") || IsName(e, "h2"));
+        if (heading != null) {
+            var normalized = NormalizeWhitespace(heading.Value);
+            if (normalized.Length > 0) return normalized;
+        }
+
+        return null;
+    }
+
+    private static string? ResolveDocumentTitle(EpubPackage? package, IReadOnlyList<EpubChapter> chapters) {
+        if (!string.IsNullOrWhiteSpace(package?.Title)) {
+            return package!.Title;
+        }
+
+        foreach (var chapter in chapters) {
+            if (!string.IsNullOrWhiteSpace(chapter.Title)) {
+                return chapter.Title;
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/OfficeIMO.Epub/EpubReader.Chapters.cs
+++ b/OfficeIMO.Epub/EpubReader.Chapters.cs
@@ -37,7 +37,7 @@ internal static partial class EpubReader {
                     continue;
                 }
 
-                var chapterPath = NormalizePath(chapterEntry.FullName);
+                string chapterPath = manifestItem.FullPath;
                 if (seenPaths.Contains(chapterPath)) {
                     continue;
                 }
@@ -45,6 +45,7 @@ internal static partial class EpubReader {
                 seenPaths.Add(chapterPath);
                 candidates.Add(new ChapterCandidate {
                     Entry = chapterEntry,
+                    Path = chapterPath,
                     ManifestId = manifestItem.Id,
                     MediaType = manifestItem.MediaType,
                     SpineIndex = spineItem.SpineIndex,
@@ -60,20 +61,22 @@ internal static partial class EpubReader {
         }
 
         if (shouldFallbackScan) {
-            IEnumerable<ZipArchiveEntry> scanEntries = entryIndex.Values.Where(e => IsChapterEntry(e.FullName));
+            IEnumerable<KeyValuePair<string, ZipArchiveEntry>> scanEntries = entryIndex
+                .Where(entry => IsChapterEntry(entry.Key));
             if (options.DeterministicOrder) {
-                scanEntries = scanEntries.OrderBy(e => e.FullName, StringComparer.Ordinal);
+                scanEntries = scanEntries.OrderBy(entry => entry.Key, StringComparer.Ordinal);
             }
 
             var manifestByPath = BuildManifestByPath(package);
-            foreach (var entry in scanEntries) {
-                var chapterPath = NormalizePath(entry.FullName);
+            foreach (KeyValuePair<string, ZipArchiveEntry> indexedEntry in scanEntries) {
+                string chapterPath = indexedEntry.Key;
                 if (seenPaths.Contains(chapterPath)) continue;
 
                 manifestByPath.TryGetValue(chapterPath, out var manifestItem);
                 seenPaths.Add(chapterPath);
                 candidates.Add(new ChapterCandidate {
-                    Entry = entry,
+                    Entry = indexedEntry.Value,
+                    Path = chapterPath,
                     ManifestId = manifestItem?.Id,
                     MediaType = manifestItem?.MediaType,
                     SpineIndex = null,

--- a/OfficeIMO.Epub/EpubReader.Models.cs
+++ b/OfficeIMO.Epub/EpubReader.Models.cs
@@ -1,0 +1,43 @@
+namespace OfficeIMO.Epub;
+
+internal static partial class EpubReader {
+    private sealed class EpubPackage {
+        public string OpfPath { get; set; } = string.Empty;
+        public string? PackageVersion { get; set; }
+        public string? UniqueIdentifierId { get; set; }
+        public string? Title { get; set; }
+        public string? Identifier { get; set; }
+        public string? Language { get; set; }
+        public string? Creator { get; set; }
+        public EpubRenditionLayout? RenditionLayout { get; set; }
+        public Dictionary<string, ManifestItem> Manifest { get; } = new Dictionary<string, ManifestItem>(StringComparer.Ordinal);
+        public List<SpineItem> Spine { get; } = new List<SpineItem>();
+        public string? NavDocumentPath { get; set; }
+        public string? NcxPath { get; set; }
+    }
+
+    private sealed class ManifestItem {
+        public string Id { get; set; } = string.Empty;
+        public string Href { get; set; } = string.Empty;
+        public string FullPath { get; set; } = string.Empty;
+        public string MediaType { get; set; } = string.Empty;
+        public string Properties { get; set; } = string.Empty;
+    }
+
+    private sealed class SpineItem {
+        public string IdRef { get; set; } = string.Empty;
+        public int SpineIndex { get; set; }
+        public bool IsLinear { get; set; }
+        public string? Properties { get; set; }
+        public EpubRenditionLayout? RenditionLayout { get; set; }
+    }
+
+    private sealed class ChapterCandidate {
+        public ZipArchiveEntry Entry { get; set; } = null!;
+        public string? ManifestId { get; set; }
+        public string? MediaType { get; set; }
+        public int? SpineIndex { get; set; }
+        public bool? IsLinear { get; set; }
+        public EpubRenditionLayout? RenditionLayout { get; set; }
+    }
+}

--- a/OfficeIMO.Epub/EpubReader.Models.cs
+++ b/OfficeIMO.Epub/EpubReader.Models.cs
@@ -34,6 +34,7 @@ internal static partial class EpubReader {
 
     private sealed class ChapterCandidate {
         public ZipArchiveEntry Entry { get; set; } = null!;
+        public string Path { get; set; } = string.Empty;
         public string? ManifestId { get; set; }
         public string? MediaType { get; set; }
         public int? SpineIndex { get; set; }

--- a/OfficeIMO.Epub/EpubReader.Navigation.cs
+++ b/OfficeIMO.Epub/EpubReader.Navigation.cs
@@ -1,0 +1,121 @@
+namespace OfficeIMO.Epub;
+
+internal static partial class EpubReader {
+    private static Dictionary<string, string> BuildNavigationTitleMap(
+        Dictionary<string, ZipArchiveEntry> entryIndex,
+        EpubPackage? package,
+        EpubReadOptions options,
+        EpubDiagnosticCollector diagnostics) {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (package == null) return map;
+
+        if (!string.IsNullOrWhiteSpace(package.NavDocumentPath)) {
+            TryReadNavigationDocument(entryIndex, package.NavDocumentPath!, map, options, diagnostics);
+        }
+        if (!string.IsNullOrWhiteSpace(package.NcxPath)) {
+            TryReadNcxDocument(entryIndex, package.NcxPath!, map, options, diagnostics);
+        }
+
+        return map;
+    }
+
+    private static void TryReadNavigationDocument(
+        Dictionary<string, ZipArchiveEntry> entryIndex,
+        string navPath,
+        Dictionary<string, string> map,
+        EpubReadOptions options,
+        EpubDiagnosticCollector diagnostics) {
+        if (!entryIndex.TryGetValue(navPath, out var navEntry)) {
+            diagnostics.Warning(
+                "epub.navigation.missing",
+                $"EPUB navigation document '{navPath}' was not found in archive.",
+                navPath);
+            return;
+        }
+
+        if (navEntry.Length > options.MaxPackageMetadataBytes) {
+            diagnostics.Warning(
+                "epub.navigation.metadata-size-limit",
+                $"EPUB navigation document '{navPath}' exceeds MaxPackageMetadataBytes ({options.MaxPackageMetadataBytes}).",
+                navPath);
+            return;
+        }
+
+        var navContent = ReadEntryText(navEntry, options.MaxPackageMetadataBytes);
+        if (!TryParseXml(navContent, out var navDocument) || navDocument == null) {
+            diagnostics.Warning(
+                "epub.navigation.invalid-xml",
+                $"EPUB navigation document '{navPath}' could not be parsed.",
+                navPath);
+            return;
+        }
+
+        foreach (var anchor in navDocument.Descendants().Where(e => IsName(e, "a"))) {
+            var href = GetAttribute(anchor, "href");
+            if (string.IsNullOrWhiteSpace(href)) continue;
+
+            var targetPath = ResolveRelativePath(navPath, href);
+            if (targetPath.Length == 0) continue;
+
+            var title = NormalizeWhitespace(anchor.Value);
+            if (title.Length == 0) continue;
+
+            if (!map.ContainsKey(targetPath)) {
+                map[targetPath] = title;
+            }
+        }
+    }
+
+    private static void TryReadNcxDocument(
+        Dictionary<string, ZipArchiveEntry> entryIndex,
+        string ncxPath,
+        Dictionary<string, string> map,
+        EpubReadOptions options,
+        EpubDiagnosticCollector diagnostics) {
+        if (!entryIndex.TryGetValue(ncxPath, out var ncxEntry)) {
+            diagnostics.Warning(
+                "epub.ncx.missing",
+                $"EPUB NCX document '{ncxPath}' was not found in archive.",
+                ncxPath);
+            return;
+        }
+
+        if (ncxEntry.Length > options.MaxPackageMetadataBytes) {
+            diagnostics.Warning(
+                "epub.ncx.metadata-size-limit",
+                $"EPUB NCX document '{ncxPath}' exceeds MaxPackageMetadataBytes ({options.MaxPackageMetadataBytes}).",
+                ncxPath);
+            return;
+        }
+
+        var ncxContent = ReadEntryText(ncxEntry, options.MaxPackageMetadataBytes);
+        if (!TryParseXml(ncxContent, out var ncxDocument) || ncxDocument == null) {
+            diagnostics.Warning(
+                "epub.ncx.invalid-xml",
+                $"EPUB NCX document '{ncxPath}' could not be parsed.",
+                ncxPath);
+            return;
+        }
+
+        foreach (var navPoint in ncxDocument.Descendants().Where(e => IsName(e, "navPoint"))) {
+            var content = navPoint.Descendants().FirstOrDefault(e => IsName(e, "content"));
+            if (content == null) continue;
+
+            var src = GetAttribute(content, "src");
+            if (string.IsNullOrWhiteSpace(src)) continue;
+
+            var targetPath = ResolveRelativePath(ncxPath, src);
+            if (targetPath.Length == 0) continue;
+
+            var textElement = navPoint.Descendants().FirstOrDefault(e => IsName(e, "text"));
+            if (textElement == null) continue;
+
+            var title = NormalizeWhitespace(textElement.Value);
+            if (title.Length == 0) continue;
+
+            if (!map.ContainsKey(targetPath)) {
+                map[targetPath] = title;
+            }
+        }
+    }
+}

--- a/OfficeIMO.Epub/EpubReader.Package.cs
+++ b/OfficeIMO.Epub/EpubReader.Package.cs
@@ -158,21 +158,26 @@ internal static partial class EpubReader {
             UniqueIdentifierId = packageElement == null ? null : NullIfWhiteSpace(GetAttribute(packageElement, "unique-identifier"))
         };
 
+        bool declaredUniqueIdentifierResolved = false;
         var metadata = opfDocument.Descendants().FirstOrDefault(e => IsName(e, "metadata"));
         if (metadata != null) {
             package.Title = TryGetFirstElementValue(metadata, "title");
             package.Creator = TryGetFirstElementValue(metadata, "creator");
             package.Language = TryGetFirstElementValue(metadata, "language");
-            XElement? primaryIdentifier = null;
+            string? declaredIdentifier = null;
             if (!string.IsNullOrWhiteSpace(package.UniqueIdentifierId)) {
-                primaryIdentifier = metadata.Elements().FirstOrDefault(element =>
+                XElement? declaredIdentifierElement = metadata.Elements().FirstOrDefault(element =>
                     IsName(element, "identifier") &&
                     string.Equals(GetAttribute(element, "id"), package.UniqueIdentifierId, StringComparison.Ordinal));
+                if (declaredIdentifierElement != null) {
+                    declaredIdentifier = NullIfWhiteSpace(NormalizeWhitespace(declaredIdentifierElement.Value));
+                    declaredUniqueIdentifierResolved = declaredIdentifier != null;
+                }
             }
-            primaryIdentifier ??= metadata.Elements().FirstOrDefault(element => IsName(element, "identifier"));
-            package.Identifier = primaryIdentifier == null
-                ? null
-                : NullIfWhiteSpace(NormalizeWhitespace(primaryIdentifier.Value));
+            package.Identifier = declaredIdentifier ?? metadata.Elements()
+                .Where(element => IsName(element, "identifier"))
+                .Select(element => NullIfWhiteSpace(NormalizeWhitespace(element.Value)))
+                .FirstOrDefault(identifier => identifier != null);
 
             package.RenditionLayout = ReadPackageRenditionLayout(metadata, diagnostics, opfPath);
         }
@@ -183,7 +188,7 @@ internal static partial class EpubReader {
                 "EPUB package does not declare a version.",
                 opfPath);
         }
-        if (!string.IsNullOrWhiteSpace(package.UniqueIdentifierId) && string.IsNullOrWhiteSpace(package.Identifier)) {
+        if (!string.IsNullOrWhiteSpace(package.UniqueIdentifierId) && !declaredUniqueIdentifierResolved) {
             diagnostics.Warning(
                 "epub.package.unique-identifier-missing",
                 $"EPUB package unique-identifier '{package.UniqueIdentifierId}' does not reference a dc:identifier.",

--- a/OfficeIMO.Epub/EpubReader.Package.cs
+++ b/OfficeIMO.Epub/EpubReader.Package.cs
@@ -1,0 +1,264 @@
+namespace OfficeIMO.Epub;
+
+internal static partial class EpubReader {
+    private static Dictionary<string, ZipArchiveEntry> BuildEntryIndex(
+        ZipArchive archive,
+        EpubReadOptions options,
+        EpubDiagnosticCollector diagnostics) {
+        var map = new Dictionary<string, ZipArchiveEntry>(StringComparer.Ordinal);
+        long totalUncompressedBytes = 0;
+        int entryCount = 0;
+        foreach (var entry in archive.Entries) {
+            entryCount++;
+            if (entryCount > options.MaxArchiveEntries) {
+                throw CreateFatalReadException(
+                    "epub.archive.entry-count-limit",
+                    $"EPUB archive contains more than MaxArchiveEntries ({options.MaxArchiveEntries}) entries.");
+            }
+
+            try {
+                totalUncompressedBytes = checked(totalUncompressedBytes + entry.Length);
+            } catch (OverflowException exception) {
+                throw CreateFatalReadException(
+                    "epub.archive.total-size-limit",
+                    "EPUB archive uncompressed size exceeds the supported range.",
+                    null,
+                    exception);
+            }
+            if (totalUncompressedBytes > options.MaxTotalUncompressedBytes) {
+                throw CreateFatalReadException(
+                    "epub.archive.total-size-limit",
+                    $"EPUB archive uncompressed size exceeds MaxTotalUncompressedBytes ({options.MaxTotalUncompressedBytes}).");
+            }
+
+            if (entry.FullName.EndsWith("/", StringComparison.Ordinal)) continue;
+
+            if (!TryNormalizeArchiveEntryPath(entry.FullName, out string key)) {
+                diagnostics.Warning(
+                    "epub.archive.unsafe-path",
+                    $"Ignored archive entry '{NormalizePath(entry.FullName)}' because its path is not safe.",
+                    NormalizePath(entry.FullName));
+                continue;
+            }
+            if (key.Length == 0) continue;
+            if (map.ContainsKey(key)) {
+                diagnostics.Warning(
+                    "epub.archive.duplicate-path",
+                    $"Ignored duplicate archive entry '{key}'.",
+                    key);
+                continue;
+            }
+            map[key] = entry;
+        }
+
+        return map;
+    }
+
+    private static EpubPackage? TryReadPackage(
+        Dictionary<string, ZipArchiveEntry> entryIndex,
+        EpubReadOptions options,
+        EpubDiagnosticCollector diagnostics) {
+        var opfPath = TryReadOpfPathFromContainer(entryIndex, options, diagnostics);
+        if (opfPath == null) {
+            opfPath = entryIndex.Keys
+                .Where(k => k.EndsWith(".opf", StringComparison.OrdinalIgnoreCase))
+                .OrderBy(k => k, StringComparer.Ordinal)
+                .FirstOrDefault();
+
+            if (opfPath != null) {
+                diagnostics.Warning(
+                    "epub.container.rootfile-fallback",
+                    "EPUB container.xml rootfile was not found. Falling back to first discovered OPF.",
+                    opfPath);
+            }
+        }
+
+        if (opfPath == null) {
+            diagnostics.Warning(
+                "epub.package.missing",
+                "EPUB OPF package document was not found.");
+            return null;
+        }
+
+        if (!entryIndex.TryGetValue(opfPath, out var opfEntry)) {
+            diagnostics.Warning(
+                "epub.package.missing",
+                $"EPUB OPF package '{opfPath}' was referenced but not found in archive.",
+                opfPath);
+            return null;
+        }
+
+        if (opfEntry.Length > options.MaxPackageMetadataBytes) {
+            diagnostics.Warning(
+                "epub.package.metadata-size-limit",
+                $"EPUB OPF package '{opfPath}' exceeds MaxPackageMetadataBytes ({options.MaxPackageMetadataBytes}).",
+                opfPath);
+            return null;
+        }
+
+        var opfContent = ReadEntryText(opfEntry, options.MaxPackageMetadataBytes);
+        if (!TryParseXml(opfContent, out var opfDocument) || opfDocument == null) {
+            diagnostics.Warning(
+                "epub.package.invalid-xml",
+                $"EPUB OPF package '{opfPath}' could not be parsed as XML.",
+                opfPath);
+            return null;
+        }
+
+        return ParseOpf(opfDocument, opfPath, diagnostics);
+    }
+
+    private static string? TryReadOpfPathFromContainer(
+        Dictionary<string, ZipArchiveEntry> entryIndex,
+        EpubReadOptions options,
+        EpubDiagnosticCollector diagnostics) {
+        if (!entryIndex.TryGetValue("META-INF/container.xml", out var containerEntry)) {
+            return null;
+        }
+
+        if (containerEntry.Length > options.MaxPackageMetadataBytes) {
+            diagnostics.Warning(
+                "epub.container.metadata-size-limit",
+                $"EPUB container.xml exceeds MaxPackageMetadataBytes ({options.MaxPackageMetadataBytes}).",
+                "META-INF/container.xml");
+            return null;
+        }
+
+        var containerContent = ReadEntryText(containerEntry, options.MaxPackageMetadataBytes);
+        if (!TryParseXml(containerContent, out var containerDocument) || containerDocument == null) {
+            diagnostics.Warning(
+                "epub.container.invalid-xml",
+                "EPUB container.xml could not be parsed as XML.",
+                "META-INF/container.xml");
+            return null;
+        }
+
+        foreach (var rootfile in containerDocument.Descendants().Where(e => IsName(e, "rootfile"))) {
+            var fullPath = GetAttribute(rootfile, "full-path");
+            if (!string.IsNullOrWhiteSpace(fullPath)) {
+                return NormalizePath(fullPath);
+            }
+        }
+
+        diagnostics.Warning(
+            "epub.container.rootfile-missing",
+            "EPUB container.xml did not define a rootfile path.",
+            "META-INF/container.xml");
+        return null;
+    }
+
+    private static EpubPackage ParseOpf(
+        XDocument opfDocument,
+        string opfPath,
+        EpubDiagnosticCollector diagnostics) {
+        XElement? packageElement = opfDocument.Root;
+        var package = new EpubPackage {
+            OpfPath = opfPath,
+            PackageVersion = packageElement == null ? null : NullIfWhiteSpace(GetAttribute(packageElement, "version")),
+            UniqueIdentifierId = packageElement == null ? null : NullIfWhiteSpace(GetAttribute(packageElement, "unique-identifier"))
+        };
+
+        var metadata = opfDocument.Descendants().FirstOrDefault(e => IsName(e, "metadata"));
+        if (metadata != null) {
+            package.Title = TryGetFirstElementValue(metadata, "title");
+            package.Creator = TryGetFirstElementValue(metadata, "creator");
+            package.Language = TryGetFirstElementValue(metadata, "language");
+            XElement? primaryIdentifier = null;
+            if (!string.IsNullOrWhiteSpace(package.UniqueIdentifierId)) {
+                primaryIdentifier = metadata.Elements().FirstOrDefault(element =>
+                    IsName(element, "identifier") &&
+                    string.Equals(GetAttribute(element, "id"), package.UniqueIdentifierId, StringComparison.Ordinal));
+            }
+            primaryIdentifier ??= metadata.Elements().FirstOrDefault(element => IsName(element, "identifier"));
+            package.Identifier = primaryIdentifier == null
+                ? null
+                : NullIfWhiteSpace(NormalizeWhitespace(primaryIdentifier.Value));
+
+            package.RenditionLayout = ReadPackageRenditionLayout(metadata, diagnostics, opfPath);
+        }
+
+        if (string.IsNullOrWhiteSpace(package.PackageVersion)) {
+            diagnostics.Warning(
+                "epub.package.version-missing",
+                "EPUB package does not declare a version.",
+                opfPath);
+        }
+        if (!string.IsNullOrWhiteSpace(package.UniqueIdentifierId) && string.IsNullOrWhiteSpace(package.Identifier)) {
+            diagnostics.Warning(
+                "epub.package.unique-identifier-missing",
+                $"EPUB package unique-identifier '{package.UniqueIdentifierId}' does not reference a dc:identifier.",
+                opfPath);
+        }
+
+        var manifestItems = opfDocument.Descendants().Where(e => IsName(e, "item"));
+        foreach (var item in manifestItems) {
+            var id = GetAttribute(item, "id");
+            var href = GetAttribute(item, "href");
+            if (string.IsNullOrWhiteSpace(id) || string.IsNullOrWhiteSpace(href)) continue;
+
+            string fullPath = ResolveRelativePath(opfPath, href);
+            if (fullPath.Length == 0) {
+                diagnostics.Warning(
+                    "epub.manifest.invalid-path",
+                    $"Ignored manifest item '{id}' because href '{href}' does not resolve to a safe archive path.",
+                    opfPath);
+                continue;
+            }
+            var model = new ManifestItem {
+                Id = id,
+                Href = href,
+                FullPath = fullPath,
+                MediaType = GetAttribute(item, "media-type"),
+                Properties = GetAttribute(item, "properties")
+            };
+            if (package.Manifest.ContainsKey(id)) {
+                diagnostics.Warning(
+                    "epub.manifest.duplicate-id",
+                    $"EPUB manifest contains duplicate id '{id}'. The last declaration is used.",
+                    opfPath);
+            }
+            package.Manifest[id] = model;
+
+            if (ContainsSpaceSeparatedToken(model.Properties, "nav")) {
+                package.NavDocumentPath = model.FullPath;
+            }
+            if (!string.IsNullOrWhiteSpace(model.MediaType) &&
+                model.MediaType.IndexOf("ncx", StringComparison.OrdinalIgnoreCase) >= 0 &&
+                string.IsNullOrWhiteSpace(package.NcxPath)) {
+                package.NcxPath = model.FullPath;
+            }
+        }
+
+        var spine = opfDocument.Descendants().FirstOrDefault(e => IsName(e, "spine"));
+        if (spine != null) {
+            var tocId = GetAttribute(spine, "toc");
+            if (!string.IsNullOrWhiteSpace(tocId) &&
+                package.Manifest.TryGetValue(tocId, out var tocManifest) &&
+                string.IsNullOrWhiteSpace(package.NcxPath)) {
+                package.NcxPath = tocManifest.FullPath;
+            }
+
+            int index = 0;
+            foreach (var itemRef in spine.Elements().Where(e => IsName(e, "itemref"))) {
+                index++;
+                var idRef = GetAttribute(itemRef, "idref");
+                if (string.IsNullOrWhiteSpace(idRef)) continue;
+
+                var linear = GetAttribute(itemRef, "linear");
+                var isLinear = !string.Equals(linear, "no", StringComparison.OrdinalIgnoreCase);
+                string properties = GetAttribute(itemRef, "properties");
+
+                package.Spine.Add(new SpineItem {
+                    IdRef = idRef,
+                    SpineIndex = index,
+                    IsLinear = isLinear,
+                    Properties = properties,
+                    RenditionLayout = ResolveRenditionLayout(package.RenditionLayout, properties)
+                });
+            }
+        }
+
+        return package;
+    }
+
+}

--- a/OfficeIMO.Epub/EpubReader.PackageDiagnostics.cs
+++ b/OfficeIMO.Epub/EpubReader.PackageDiagnostics.cs
@@ -1,0 +1,205 @@
+namespace OfficeIMO.Epub;
+
+internal static partial class EpubReader {
+    private const string IdpfFontObfuscationAlgorithm = "http://www.idpf.org/2008/embedding";
+    private const string AdobeFontObfuscationAlgorithm = "http://ns.adobe.com/pdf/enc#RC";
+
+    private static IReadOnlyList<EpubEncryptionInfo> ReadEncryption(
+        IReadOnlyDictionary<string, ZipArchiveEntry> entryIndex,
+        EpubReadOptions options,
+        EpubDiagnosticCollector diagnostics) {
+        const string encryptionPath = "META-INF/encryption.xml";
+        if (!entryIndex.TryGetValue(encryptionPath, out ZipArchiveEntry? entry)) {
+            return Array.Empty<EpubEncryptionInfo>();
+        }
+        if (entry.Length > options.MaxPackageMetadataBytes) {
+            diagnostics.Warning(
+                "epub.encryption.metadata-size-limit",
+                $"EPUB encryption.xml exceeds MaxPackageMetadataBytes ({options.MaxPackageMetadataBytes}).",
+                encryptionPath);
+            return Array.Empty<EpubEncryptionInfo>();
+        }
+
+        string content = ReadEntryText(entry, options.MaxPackageMetadataBytes);
+        if (!TryParseXml(content, out XDocument? document) || document == null) {
+            diagnostics.Warning(
+                "epub.encryption.invalid-xml",
+                "EPUB encryption.xml could not be parsed as XML.",
+                encryptionPath);
+            return Array.Empty<EpubEncryptionInfo>();
+        }
+
+        var results = new List<EpubEncryptionInfo>();
+        var seenPaths = new HashSet<string>(StringComparer.Ordinal);
+        foreach (XElement encryptedData in document.Descendants().Where(element => IsName(element, "EncryptedData"))) {
+            XElement? method = encryptedData.Descendants().FirstOrDefault(element => IsName(element, "EncryptionMethod"));
+            XElement? reference = encryptedData.Descendants().FirstOrDefault(element => IsName(element, "CipherReference"));
+            string? algorithm = method == null ? null : NullIfWhiteSpace(GetAttribute(method, "Algorithm"));
+            string uri = reference == null ? string.Empty : GetAttribute(reference, "URI");
+            string resourcePath = ResolveContainerRootPath(uri);
+            if (resourcePath.Length == 0) {
+                diagnostics.Warning(
+                    "epub.encryption.resource-path-invalid",
+                    $"Ignored encryption declaration with invalid resource URI '{uri}'.",
+                    encryptionPath);
+                continue;
+            }
+            if (!seenPaths.Add(resourcePath)) {
+                diagnostics.Warning(
+                    "epub.encryption.duplicate-resource",
+                    $"Ignored duplicate encryption declaration for '{resourcePath}'.",
+                    resourcePath);
+                continue;
+            }
+
+            EpubEncryptionKind kind = ClassifyEncryption(algorithm);
+            var info = new EpubEncryptionInfo {
+                Path = resourcePath,
+                Algorithm = algorithm,
+                Kind = kind
+            };
+            results.Add(info);
+
+            if (!entryIndex.ContainsKey(resourcePath)) {
+                diagnostics.Warning(
+                    "epub.encryption.resource-missing",
+                    $"Encryption declaration references missing resource '{resourcePath}'.",
+                    resourcePath);
+            } else if (info.RequiresDecryption) {
+                diagnostics.Warning(
+                    "epub.encryption.unsupported",
+                    $"Resource '{resourcePath}' uses unsupported encryption algorithm '{algorithm ?? "(missing)"}'.",
+                    resourcePath);
+            } else {
+                diagnostics.Info(
+                    "epub.encryption.font-obfuscation",
+                    $"Resource '{resourcePath}' uses recognized EPUB font obfuscation.",
+                    resourcePath);
+            }
+        }
+        return results;
+    }
+
+    private static EpubEncryptionKind ClassifyEncryption(string? algorithm) {
+        if (string.Equals(algorithm, IdpfFontObfuscationAlgorithm, StringComparison.Ordinal)) {
+            return EpubEncryptionKind.IdpfFontObfuscation;
+        }
+        if (string.Equals(algorithm, AdobeFontObfuscationAlgorithm, StringComparison.Ordinal)) {
+            return EpubEncryptionKind.AdobeFontObfuscation;
+        }
+        return string.IsNullOrWhiteSpace(algorithm)
+            ? EpubEncryptionKind.Unknown
+            : EpubEncryptionKind.Encryption;
+    }
+
+    private static string ResolveContainerRootPath(string value) {
+        string reference = RemoveFragmentAndQuery(value);
+        if (reference.Length == 0 || reference.StartsWith("//", StringComparison.Ordinal)) return string.Empty;
+        if (Uri.TryCreate(reference, UriKind.Absolute, out _)) return string.Empty;
+        return CollapsePathSegments(NormalizePath(reference).TrimStart('/'));
+    }
+
+    private static EpubRenditionLayout? ReadPackageRenditionLayout(
+        XElement metadata,
+        EpubDiagnosticCollector diagnostics,
+        string opfPath) {
+        XElement[] declarations = metadata.Elements()
+            .Where(element => IsName(element, "meta") &&
+                string.Equals(GetAttribute(element, "property"), "rendition:layout", StringComparison.Ordinal))
+            .ToArray();
+        if (declarations.Length > 1) {
+            diagnostics.Warning(
+                "epub.layout.multiple-declarations",
+                "EPUB package declares rendition:layout more than once. The first valid declaration is used.",
+                opfPath);
+        }
+
+        foreach (XElement declaration in declarations) {
+            if (TryParseRenditionLayout(declaration.Value, out EpubRenditionLayout layout)) return layout;
+            diagnostics.Warning(
+                "epub.layout.invalid",
+                $"EPUB package declares unsupported rendition:layout value '{NormalizeWhitespace(declaration.Value)}'.",
+                opfPath);
+        }
+
+        XElement? legacy = metadata.Elements().FirstOrDefault(element =>
+            IsName(element, "meta") &&
+            string.Equals(GetAttribute(element, "name"), "fixed-layout", StringComparison.OrdinalIgnoreCase));
+        if (legacy != null) {
+            string content = GetAttribute(legacy, "content");
+            if (string.Equals(content, "true", StringComparison.OrdinalIgnoreCase)) return EpubRenditionLayout.PrePaginated;
+            if (string.Equals(content, "false", StringComparison.OrdinalIgnoreCase)) return EpubRenditionLayout.Reflowable;
+        }
+        return null;
+    }
+
+    private static EpubRenditionLayout? ResolveRenditionLayout(
+        EpubRenditionLayout? packageLayout,
+        string? spineProperties) {
+        if (ContainsSpaceSeparatedToken(spineProperties, "rendition:layout-pre-paginated")) {
+            return EpubRenditionLayout.PrePaginated;
+        }
+        if (ContainsSpaceSeparatedToken(spineProperties, "rendition:layout-reflowable")) {
+            return EpubRenditionLayout.Reflowable;
+        }
+        return packageLayout;
+    }
+
+    private static bool TryParseRenditionLayout(string? value, out EpubRenditionLayout layout) {
+        string normalized = NormalizeWhitespace(value ?? string.Empty);
+        if (string.Equals(normalized, "pre-paginated", StringComparison.OrdinalIgnoreCase)) {
+            layout = EpubRenditionLayout.PrePaginated;
+            return true;
+        }
+        if (string.Equals(normalized, "reflowable", StringComparison.OrdinalIgnoreCase)) {
+            layout = EpubRenditionLayout.Reflowable;
+            return true;
+        }
+        layout = default;
+        return false;
+    }
+
+    private static EpubReadException CreateFatalReadException(
+        string code,
+        string message,
+        string? path = null,
+        Exception? innerException = null) {
+        return new EpubReadException(
+            message,
+            new[] {
+                new EpubDiagnostic {
+                    Code = code,
+                    Severity = EpubDiagnosticSeverity.Error,
+                    Message = message,
+                    Path = path
+                }
+            },
+            innerException);
+    }
+
+    private sealed class EpubDiagnosticCollector {
+        private readonly List<EpubDiagnostic> _items = new List<EpubDiagnostic>();
+
+        public IReadOnlyList<EpubDiagnostic> Items => _items.ToArray();
+
+        public IReadOnlyList<string> WarningMessages => _items
+            .Where(static item => item.Severity != EpubDiagnosticSeverity.Info)
+            .Select(static item => item.Message)
+            .ToArray();
+
+        public void Info(string code, string message, string? path = null) =>
+            Add(code, EpubDiagnosticSeverity.Info, message, path);
+
+        public void Warning(string code, string message, string? path = null) =>
+            Add(code, EpubDiagnosticSeverity.Warning, message, path);
+
+        private void Add(string code, EpubDiagnosticSeverity severity, string message, string? path) {
+            _items.Add(new EpubDiagnostic {
+                Code = code,
+                Severity = severity,
+                Message = message,
+                Path = path
+            });
+        }
+    }
+}

--- a/OfficeIMO.Epub/EpubReader.Utilities.cs
+++ b/OfficeIMO.Epub/EpubReader.Utilities.cs
@@ -1,0 +1,186 @@
+namespace OfficeIMO.Epub;
+
+internal static partial class EpubReader {
+    private static bool IsName(XElement element, string expectedLocalName) {
+        return string.Equals(element.Name.LocalName, expectedLocalName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string GetAttribute(XElement element, string attributeName) {
+        var attr = element.Attributes().FirstOrDefault(a => string.Equals(a.Name.LocalName, attributeName, StringComparison.OrdinalIgnoreCase));
+        return attr?.Value ?? string.Empty;
+    }
+
+    private static string? TryGetFirstElementValue(XElement container, string localName) {
+        foreach (var element in container.Elements()) {
+            if (!string.Equals(element.Name.LocalName, localName, StringComparison.OrdinalIgnoreCase)) continue;
+
+            var normalized = NormalizeWhitespace(element.Value);
+            return normalized.Length == 0 ? null : normalized;
+        }
+
+        return null;
+    }
+
+    private static bool ContainsSpaceSeparatedToken(string? value, string token) {
+        var source = value ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(source)) return false;
+        var parts = source.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var part in parts) {
+            if (string.Equals(part, token, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string ResolveRelativePath(string basePath, string relativeOrAbsolute) {
+        var normalizedBase = NormalizePath(basePath);
+        string reference = RemoveFragmentAndQuery(relativeOrAbsolute);
+        if (reference.StartsWith("//", StringComparison.Ordinal) || Uri.TryCreate(reference, UriKind.Absolute, out _)) {
+            return string.Empty;
+        }
+        var normalizedRelative = NormalizePath(reference);
+        if (normalizedRelative.Length == 0) return string.Empty;
+
+        if (normalizedRelative.Length >= 2 && normalizedRelative[1] == ':') {
+            return normalizedRelative;
+        }
+
+        if (normalizedRelative.StartsWith("/", StringComparison.Ordinal)) {
+            return CollapsePathSegments(normalizedRelative.TrimStart('/'));
+        }
+
+        var baseDirectory = string.Empty;
+        var lastSlash = normalizedBase.LastIndexOf('/');
+        if (lastSlash >= 0) {
+            baseDirectory = normalizedBase.Substring(0, lastSlash);
+        }
+
+        var combined = baseDirectory.Length == 0
+            ? normalizedRelative
+            : baseDirectory + "/" + normalizedRelative;
+        return CollapsePathSegments(combined);
+    }
+
+    private static string RemoveFragmentAndQuery(string value) {
+        if (string.IsNullOrWhiteSpace(value)) return string.Empty;
+
+        var trimmed = value.Trim();
+        var hash = trimmed.IndexOf('#');
+        if (hash >= 0) {
+            trimmed = trimmed.Substring(0, hash);
+        }
+
+        var question = trimmed.IndexOf('?');
+        if (question >= 0) {
+            trimmed = trimmed.Substring(0, question);
+        }
+
+        if (trimmed.Length == 0) return string.Empty;
+
+        try {
+            return Uri.UnescapeDataString(trimmed);
+        } catch {
+            return trimmed;
+        }
+    }
+
+    private static string CollapsePathSegments(string path) {
+        var segments = path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+        var stack = new List<string>(segments.Length);
+
+        foreach (var segment in segments) {
+            if (segment == ".") continue;
+            if (segment == "..") {
+                if (stack.Count == 0) return string.Empty;
+                stack.RemoveAt(stack.Count - 1);
+                continue;
+            }
+
+            stack.Add(segment);
+        }
+
+        return string.Join("/", stack);
+    }
+
+    private static string NormalizePath(string path) {
+        if (string.IsNullOrWhiteSpace(path)) return string.Empty;
+        return path.Replace('\\', '/').Trim();
+    }
+
+    private static bool TryNormalizeArchiveEntryPath(string path, out string normalizedPath) {
+        normalizedPath = NormalizePath(path);
+        if (normalizedPath.Length == 0 || normalizedPath.StartsWith("/", StringComparison.Ordinal)) return false;
+        if (normalizedPath.Length >= 2 && normalizedPath[1] == ':') return false;
+        if (Uri.TryCreate(normalizedPath, UriKind.Absolute, out _)) return false;
+
+        string[] segments = normalizedPath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Any(static segment => segment == "..")) return false;
+
+        normalizedPath = CollapsePathSegments(normalizedPath);
+        return normalizedPath.Length > 0;
+    }
+
+    private static string? NullIfWhiteSpace(string? value) {
+        return string.IsNullOrWhiteSpace(value) ? null : value!.Trim();
+    }
+
+    private static string NormalizeWhitespace(string value) {
+        if (string.IsNullOrWhiteSpace(value)) return string.Empty;
+
+        var sb = new StringBuilder(value.Length);
+        bool previousWasWhitespace = false;
+        foreach (var ch in value) {
+            if (char.IsWhiteSpace(ch)) {
+                if (!previousWasWhitespace) {
+                    sb.Append(' ');
+                    previousWasWhitespace = true;
+                }
+            } else {
+                sb.Append(ch);
+                previousWasWhitespace = false;
+            }
+        }
+
+        return sb.ToString().Trim();
+    }
+
+    private static EpubReadOptions Normalize(EpubReadOptions? options) {
+        var source = options ?? new EpubReadOptions();
+        var normalized = new EpubReadOptions {
+            MaxPackageBytes = source.MaxPackageBytes,
+            MaxArchiveEntries = source.MaxArchiveEntries,
+            MaxTotalUncompressedBytes = source.MaxTotalUncompressedBytes,
+            MaxPackageMetadataBytes = source.MaxPackageMetadataBytes,
+            MaxChapters = source.MaxChapters,
+            MaxChapterBytes = source.MaxChapterBytes,
+            MaxTotalRawHtmlBytes = source.MaxTotalRawHtmlBytes,
+            IncludeRawHtml = source.IncludeRawHtml,
+            IncludeResourceData = source.IncludeResourceData,
+            MaxResources = source.MaxResources,
+            MaxResourceBytes = source.MaxResourceBytes,
+            MaxTotalResourceBytes = source.MaxTotalResourceBytes,
+            DeterministicOrder = source.DeterministicOrder,
+            PreferSpineOrder = source.PreferSpineOrder,
+            IncludeNonLinearSpineItems = source.IncludeNonLinearSpineItems,
+            FallbackToHtmlScan = source.FallbackToHtmlScan
+        };
+
+        if (normalized.MaxPackageBytes < 1) normalized.MaxPackageBytes = 1;
+        if (normalized.MaxArchiveEntries < 1) normalized.MaxArchiveEntries = 1;
+        if (normalized.MaxTotalUncompressedBytes < 1) normalized.MaxTotalUncompressedBytes = 1;
+        if (normalized.MaxPackageMetadataBytes < 1) normalized.MaxPackageMetadataBytes = 1;
+        if (normalized.MaxChapters < 1) normalized.MaxChapters = 1;
+        if (normalized.MaxChapterBytes.HasValue && normalized.MaxChapterBytes.Value < 1) {
+            normalized.MaxChapterBytes = 1;
+        }
+        if (normalized.MaxTotalRawHtmlBytes < 1) normalized.MaxTotalRawHtmlBytes = 1;
+        if (normalized.MaxResources < 1) normalized.MaxResources = 1;
+        if (normalized.MaxResourceBytes < 1) normalized.MaxResourceBytes = 1;
+        if (normalized.MaxTotalResourceBytes < 1) normalized.MaxTotalResourceBytes = 1;
+
+        return normalized;
+    }
+
+}

--- a/OfficeIMO.Epub/EpubReader.cs
+++ b/OfficeIMO.Epub/EpubReader.cs
@@ -110,7 +110,7 @@ internal static partial class EpubReader {
         foreach (var candidate in candidates) {
             if (emitted >= effective.MaxChapters) break;
             if (effective.MaxChapterBytes.HasValue && candidate.Entry.Length > effective.MaxChapterBytes.Value) {
-                string path = NormalizePath(candidate.Entry.FullName);
+                string path = candidate.Path;
                 diagnostics.Warning(
                     "epub.chapter.size-limit",
                     $"Skipped chapter '{path}' because size {candidate.Entry.Length} exceeds MaxChapterBytes ({effective.MaxChapterBytes.Value}).",
@@ -118,7 +118,7 @@ internal static partial class EpubReader {
                 continue;
             }
 
-            string normalizedPath = NormalizePath(candidate.Entry.FullName);
+            string normalizedPath = candidate.Path;
             encryptionByPath.TryGetValue(normalizedPath, out EpubEncryptionInfo? chapterEncryption);
             if (chapterEncryption?.RequiresDecryption == true) {
                 diagnostics.Warning(

--- a/OfficeIMO.Epub/EpubReader.cs
+++ b/OfficeIMO.Epub/EpubReader.cs
@@ -1,11 +1,13 @@
 namespace OfficeIMO.Epub;
 
 using OfficeIMO.Drawing.Internal;
+using System.Threading;
+using System.Threading.Tasks;
 
 /// <summary>
 /// Standards-based EPUB extractor using container/OPF/spine/navigation metadata.
 /// </summary>
-internal static class EpubReader {
+internal static partial class EpubReader {
     /// <summary>
     /// Reads an EPUB document from disk.
     /// </summary>
@@ -25,21 +27,81 @@ internal static class EpubReader {
         if (epubStream == null) throw new ArgumentNullException(nameof(epubStream));
         if (!epubStream.CanRead) throw new IOException("EPUB stream must be readable.");
 
-        return ReadBytes(OfficeStreamReader.ReadAllBytes(epubStream), options);
+        EpubReadOptions effective = Normalize(options);
+        try {
+            return ReadBytes(OfficeStreamReader.ReadAllBytes(epubStream, effective.MaxPackageBytes), effective);
+        } catch (EpubReadException) {
+            throw;
+        } catch (InvalidDataException exception) {
+            throw CreateFatalReadException(
+                "epub.package.size-limit",
+                exception.Message,
+                null,
+                exception);
+        }
+    }
+
+    internal static async Task<EpubDocument> ReadAsync(
+        Stream epubStream,
+        EpubReadOptions? options,
+        CancellationToken cancellationToken) {
+        if (epubStream == null) throw new ArgumentNullException(nameof(epubStream));
+        if (!epubStream.CanRead) throw new IOException("EPUB stream must be readable.");
+
+        EpubReadOptions effective = Normalize(options);
+        try {
+            byte[] bytes = await OfficeStreamReader.ReadAllBytesAsync(
+                epubStream,
+                cancellationToken,
+                effective.MaxPackageBytes).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            return ReadBytes(bytes, effective);
+        } catch (EpubReadException) {
+            throw;
+        } catch (InvalidDataException exception) {
+            throw CreateFatalReadException(
+                "epub.package.size-limit",
+                exception.Message,
+                null,
+                exception);
+        }
     }
 
     internal static EpubDocument ReadBytes(byte[] bytes, EpubReadOptions? options = null) {
         if (bytes == null) throw new ArgumentNullException(nameof(bytes));
-        using var epubStream = new MemoryStream(bytes, writable: false);
+        EpubReadOptions effective = Normalize(options);
+        if (bytes.LongLength > effective.MaxPackageBytes) {
+            throw CreateFatalReadException(
+                "epub.package.size-limit",
+                $"EPUB package size {bytes.LongLength} exceeds MaxPackageBytes ({effective.MaxPackageBytes}).");
+        }
 
-        var effective = Normalize(options);
-        var warnings = new List<string>();
+        try {
+            return ReadArchive(bytes, effective);
+        } catch (EpubReadException) {
+            throw;
+        } catch (InvalidDataException exception) {
+            throw CreateFatalReadException(
+                "epub.archive.invalid",
+                "EPUB container is not a readable ZIP archive.",
+                null,
+                exception);
+        }
+    }
+
+    private static EpubDocument ReadArchive(byte[] bytes, EpubReadOptions effective) {
+        using var epubStream = new MemoryStream(bytes, writable: false);
+        var diagnostics = new EpubDiagnosticCollector();
 
         using var archive = new ZipArchive(epubStream, ZipArchiveMode.Read, leaveOpen: true);
-        var entryIndex = BuildEntryIndex(archive);
-        var package = TryReadPackage(entryIndex, warnings);
-        var navTitleMap = BuildNavigationTitleMap(entryIndex, package, warnings);
-        var candidates = BuildChapterCandidates(archive, entryIndex, package, effective, warnings);
+        Dictionary<string, ZipArchiveEntry> entryIndex = BuildEntryIndex(archive, effective, diagnostics);
+        EpubPackage? package = TryReadPackage(entryIndex, effective, diagnostics);
+        IReadOnlyList<EpubEncryptionInfo> encryption = ReadEncryption(entryIndex, effective, diagnostics);
+        Dictionary<string, EpubEncryptionInfo> encryptionByPath = encryption
+            .GroupBy(static item => item.Path, StringComparer.Ordinal)
+            .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.Ordinal);
+        Dictionary<string, string> navTitleMap = BuildNavigationTitleMap(entryIndex, package, effective, diagnostics);
+        List<ChapterCandidate> candidates = BuildChapterCandidates(entryIndex, package, effective, diagnostics);
 
         var chapters = new List<EpubChapter>();
         int emitted = 0;
@@ -48,13 +110,30 @@ internal static class EpubReader {
         foreach (var candidate in candidates) {
             if (emitted >= effective.MaxChapters) break;
             if (effective.MaxChapterBytes.HasValue && candidate.Entry.Length > effective.MaxChapterBytes.Value) {
-                warnings.Add($"Skipped chapter '{NormalizePath(candidate.Entry.FullName)}' because size {candidate.Entry.Length} exceeds MaxChapterBytes ({effective.MaxChapterBytes.Value}).");
+                string path = NormalizePath(candidate.Entry.FullName);
+                diagnostics.Warning(
+                    "epub.chapter.size-limit",
+                    $"Skipped chapter '{path}' because size {candidate.Entry.Length} exceeds MaxChapterBytes ({effective.MaxChapterBytes.Value}).",
+                    path);
                 continue;
             }
 
-            var markup = ReadEntryText(candidate.Entry);
+            string normalizedPath = NormalizePath(candidate.Entry.FullName);
+            encryptionByPath.TryGetValue(normalizedPath, out EpubEncryptionInfo? chapterEncryption);
+            if (chapterEncryption?.RequiresDecryption == true) {
+                diagnostics.Warning(
+                    "epub.chapter.encrypted",
+                    $"Skipped encrypted chapter '{normalizedPath}' because its algorithm is not supported.",
+                    normalizedPath);
+                continue;
+            }
+
+            string markup = ReadEntryText(candidate.Entry, effective.MaxChapterBytes);
             if (!TryParseXml(markup, out var chapterDocument) || chapterDocument == null) {
-                warnings.Add($"Skipped chapter '{NormalizePath(candidate.Entry.FullName)}' because chapter markup is not valid XML/XHTML.");
+                diagnostics.Warning(
+                    "epub.chapter.invalid-xhtml",
+                    $"Skipped chapter '{normalizedPath}' because chapter markup is not valid XML/XHTML.",
+                    normalizedPath);
                 continue;
             }
 
@@ -63,7 +142,10 @@ internal static class EpubReader {
             string? retainedHtml = null;
             if (effective.IncludeRawHtml) {
                 if (candidate.Entry.Length > effective.MaxTotalRawHtmlBytes - totalRawHtmlBytes) {
-                    warnings.Add($"Did not retain raw HTML for chapter '{NormalizePath(candidate.Entry.FullName)}' because MaxTotalRawHtmlBytes ({effective.MaxTotalRawHtmlBytes}) was reached.");
+                    diagnostics.Warning(
+                        "epub.chapter.raw-html-total-limit",
+                        $"Did not retain raw HTML for chapter '{normalizedPath}' because MaxTotalRawHtmlBytes ({effective.MaxTotalRawHtmlBytes}) was reached.",
+                        normalizedPath);
                 } else {
                     retainedHtml = markup;
                     totalRawHtmlBytes += candidate.Entry.Length;
@@ -74,7 +156,6 @@ internal static class EpubReader {
             }
 
             emitted++;
-            var normalizedPath = NormalizePath(candidate.Entry.FullName);
             var title = ResolveChapterTitle(chapterDocument, navTitleMap, normalizedPath);
 
             chapters.Add(new EpubChapter {
@@ -84,6 +165,8 @@ internal static class EpubReader {
                 MediaType = candidate.MediaType,
                 SpineIndex = candidate.SpineIndex,
                 IsLinear = candidate.IsLinear,
+                RenditionLayout = candidate.RenditionLayout,
+                Encryption = chapterEncryption,
                 Title = title,
                 Text = text,
                 HasStructuredContent = hasStructuredContent,
@@ -91,7 +174,19 @@ internal static class EpubReader {
             });
         }
 
-        IReadOnlyList<EpubResource> resources = BuildResources(entryIndex, package, effective, warnings);
+        IReadOnlyList<EpubResource> resources = BuildResources(
+            entryIndex,
+            package,
+            encryptionByPath,
+            effective,
+            diagnostics);
+
+        if (package?.RenditionLayout == EpubRenditionLayout.PrePaginated || chapters.Any(static chapter => chapter.IsFixedLayout)) {
+            diagnostics.Warning(
+                "epub.layout.fixed",
+                "Fixed-layout EPUB content was detected. Text and structure are extracted, but page geometry is not reproduced.",
+                package?.OpfPath);
+        }
 
         return new EpubDocument {
             Title = ResolveDocumentTitle(package, chapters),
@@ -99,9 +194,14 @@ internal static class EpubReader {
             Language = package?.Language,
             Creator = package?.Creator,
             OpfPath = package?.OpfPath,
+            PackageVersion = package?.PackageVersion,
+            UniqueIdentifierId = package?.UniqueIdentifierId,
+            RenditionLayout = package?.RenditionLayout,
             Chapters = chapters.ToArray(),
             Resources = resources.ToArray(),
-            Warnings = warnings.ToArray()
+            Encryption = encryption.ToArray(),
+            Diagnostics = diagnostics.Items,
+            Warnings = diagnostics.WarningMessages
         };
     }
 
@@ -126,8 +226,9 @@ internal static class EpubReader {
     private static IReadOnlyList<EpubResource> BuildResources(
         IReadOnlyDictionary<string, ZipArchiveEntry> entryIndex,
         EpubPackage? package,
+        IReadOnlyDictionary<string, EpubEncryptionInfo> encryptionByPath,
         EpubReadOptions options,
-        List<string> warnings) {
+        EpubDiagnosticCollector diagnostics) {
         if (package == null || package.Manifest.Count == 0) return Array.Empty<EpubResource>();
         var resources = new List<EpubResource>(Math.Min(package.Manifest.Count, options.MaxResources));
         long totalPayloadBytes = 0;
@@ -135,22 +236,40 @@ internal static class EpubReader {
         if (options.DeterministicOrder) items = items.OrderBy(static item => item.FullPath, StringComparer.Ordinal);
         foreach (ManifestItem item in items) {
             if (resources.Count >= options.MaxResources) {
-                warnings.Add($"EPUB manifest resources were truncated at MaxResources ({options.MaxResources}).");
+                diagnostics.Warning(
+                    "epub.resource.count-limit",
+                    $"EPUB manifest resources were truncated at MaxResources ({options.MaxResources}).",
+                    package.OpfPath);
                 break;
             }
             if (!entryIndex.TryGetValue(item.FullPath, out ZipArchiveEntry? entry)) {
-                warnings.Add($"EPUB manifest resource '{item.FullPath}' was not found in archive.");
+                diagnostics.Warning(
+                    "epub.resource.missing",
+                    $"EPUB manifest resource '{item.FullPath}' was not found in archive.",
+                    item.FullPath);
                 continue;
             }
 
+            encryptionByPath.TryGetValue(item.FullPath, out EpubEncryptionInfo? resourceEncryption);
             byte[]? data = null;
             if (options.IncludeResourceData) {
-                if (entry.Length > options.MaxResourceBytes) {
-                    warnings.Add($"Skipped payload for EPUB resource '{item.FullPath}' because size {entry.Length} exceeds MaxResourceBytes ({options.MaxResourceBytes}).");
+                if (resourceEncryption?.RequiresDecryption == true) {
+                    diagnostics.Warning(
+                        "epub.resource.encrypted",
+                        $"Skipped encrypted payload for EPUB resource '{item.FullPath}' because its algorithm is not supported.",
+                        item.FullPath);
+                } else if (entry.Length > options.MaxResourceBytes) {
+                    diagnostics.Warning(
+                        "epub.resource.size-limit",
+                        $"Skipped payload for EPUB resource '{item.FullPath}' because size {entry.Length} exceeds MaxResourceBytes ({options.MaxResourceBytes}).",
+                        item.FullPath);
                 } else if (entry.Length > options.MaxTotalResourceBytes - totalPayloadBytes) {
-                    warnings.Add($"Skipped payload for EPUB resource '{item.FullPath}' because MaxTotalResourceBytes ({options.MaxTotalResourceBytes}) was reached.");
+                    diagnostics.Warning(
+                        "epub.resource.total-size-limit",
+                        $"Skipped payload for EPUB resource '{item.FullPath}' because MaxTotalResourceBytes ({options.MaxTotalResourceBytes}) was reached.",
+                        item.FullPath);
                 } else {
-                    data = ReadEntryBytes(entry);
+                    data = ReadEntryBytes(entry, options.MaxResourceBytes);
                     totalPayloadBytes += data.LongLength;
                 }
             }
@@ -160,610 +279,11 @@ internal static class EpubReader {
                 MediaType = item.MediaType,
                 Properties = item.Properties,
                 LengthBytes = entry.Length,
+                Encryption = resourceEncryption,
                 Data = data
             });
         }
         return resources;
     }
 
-    private static Dictionary<string, ZipArchiveEntry> BuildEntryIndex(ZipArchive archive) {
-        var map = new Dictionary<string, ZipArchiveEntry>(StringComparer.OrdinalIgnoreCase);
-        foreach (var entry in archive.Entries) {
-            var key = NormalizePath(entry.FullName);
-            if (key.Length == 0) continue;
-            if (!map.ContainsKey(key)) {
-                map[key] = entry;
-            }
-        }
-
-        return map;
-    }
-
-    private static EpubPackage? TryReadPackage(Dictionary<string, ZipArchiveEntry> entryIndex, List<string> warnings) {
-        var opfPath = TryReadOpfPathFromContainer(entryIndex, warnings);
-        if (opfPath == null) {
-            opfPath = entryIndex.Keys
-                .Where(k => k.EndsWith(".opf", StringComparison.OrdinalIgnoreCase))
-                .OrderBy(k => k, StringComparer.Ordinal)
-                .FirstOrDefault();
-
-            if (opfPath != null) {
-                warnings.Add("EPUB container.xml rootfile was not found. Falling back to first discovered OPF.");
-            }
-        }
-
-        if (opfPath == null) {
-            warnings.Add("EPUB OPF package document was not found.");
-            return null;
-        }
-
-        if (!entryIndex.TryGetValue(opfPath, out var opfEntry)) {
-            warnings.Add($"EPUB OPF package '{opfPath}' was referenced but not found in archive.");
-            return null;
-        }
-
-        var opfContent = ReadEntryText(opfEntry);
-        if (!TryParseXml(opfContent, out var opfDocument) || opfDocument == null) {
-            warnings.Add($"EPUB OPF package '{opfPath}' could not be parsed as XML.");
-            return null;
-        }
-
-        return ParseOpf(opfDocument, opfPath);
-    }
-
-    private static string? TryReadOpfPathFromContainer(Dictionary<string, ZipArchiveEntry> entryIndex, List<string> warnings) {
-        if (!entryIndex.TryGetValue("META-INF/container.xml", out var containerEntry)) {
-            return null;
-        }
-
-        var containerContent = ReadEntryText(containerEntry);
-        if (!TryParseXml(containerContent, out var containerDocument) || containerDocument == null) {
-            warnings.Add("EPUB container.xml could not be parsed as XML.");
-            return null;
-        }
-
-        foreach (var rootfile in containerDocument.Descendants().Where(e => IsName(e, "rootfile"))) {
-            var fullPath = GetAttribute(rootfile, "full-path");
-            if (!string.IsNullOrWhiteSpace(fullPath)) {
-                return NormalizePath(fullPath);
-            }
-        }
-
-        warnings.Add("EPUB container.xml did not define a rootfile path.");
-        return null;
-    }
-
-    private static EpubPackage ParseOpf(XDocument opfDocument, string opfPath) {
-        var package = new EpubPackage {
-            OpfPath = opfPath
-        };
-
-        var metadata = opfDocument.Descendants().FirstOrDefault(e => IsName(e, "metadata"));
-        if (metadata != null) {
-            package.Title = TryGetFirstElementValue(metadata, "title");
-            package.Creator = TryGetFirstElementValue(metadata, "creator");
-            package.Language = TryGetFirstElementValue(metadata, "language");
-            package.Identifier = TryGetFirstElementValue(metadata, "identifier");
-        }
-
-        var manifestItems = opfDocument.Descendants().Where(e => IsName(e, "item"));
-        foreach (var item in manifestItems) {
-            var id = GetAttribute(item, "id");
-            var href = GetAttribute(item, "href");
-            if (string.IsNullOrWhiteSpace(id) || string.IsNullOrWhiteSpace(href)) continue;
-
-            var model = new ManifestItem {
-                Id = id,
-                Href = href,
-                FullPath = ResolveRelativePath(opfPath, href),
-                MediaType = GetAttribute(item, "media-type"),
-                Properties = GetAttribute(item, "properties")
-            };
-            package.Manifest[id] = model;
-
-            if (ContainsSpaceSeparatedToken(model.Properties, "nav")) {
-                package.NavDocumentPath = model.FullPath;
-            }
-            if (!string.IsNullOrWhiteSpace(model.MediaType) &&
-                model.MediaType.IndexOf("ncx", StringComparison.OrdinalIgnoreCase) >= 0 &&
-                string.IsNullOrWhiteSpace(package.NcxPath)) {
-                package.NcxPath = model.FullPath;
-            }
-        }
-
-        var spine = opfDocument.Descendants().FirstOrDefault(e => IsName(e, "spine"));
-        if (spine != null) {
-            var tocId = GetAttribute(spine, "toc");
-            if (!string.IsNullOrWhiteSpace(tocId) &&
-                package.Manifest.TryGetValue(tocId, out var tocManifest) &&
-                string.IsNullOrWhiteSpace(package.NcxPath)) {
-                package.NcxPath = tocManifest.FullPath;
-            }
-
-            int index = 0;
-            foreach (var itemRef in spine.Elements().Where(e => IsName(e, "itemref"))) {
-                index++;
-                var idRef = GetAttribute(itemRef, "idref");
-                if (string.IsNullOrWhiteSpace(idRef)) continue;
-
-                var linear = GetAttribute(itemRef, "linear");
-                var isLinear = !string.Equals(linear, "no", StringComparison.OrdinalIgnoreCase);
-
-                package.Spine.Add(new SpineItem {
-                    IdRef = idRef,
-                    SpineIndex = index,
-                    IsLinear = isLinear
-                });
-            }
-        }
-
-        return package;
-    }
-
-    private static Dictionary<string, string> BuildNavigationTitleMap(Dictionary<string, ZipArchiveEntry> entryIndex, EpubPackage? package, List<string> warnings) {
-        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        if (package == null) return map;
-
-        if (!string.IsNullOrWhiteSpace(package.NavDocumentPath)) {
-            TryReadNavigationDocument(entryIndex, package.NavDocumentPath!, map, warnings);
-        }
-        if (!string.IsNullOrWhiteSpace(package.NcxPath)) {
-            TryReadNcxDocument(entryIndex, package.NcxPath!, map, warnings);
-        }
-
-        return map;
-    }
-
-    private static void TryReadNavigationDocument(
-        Dictionary<string, ZipArchiveEntry> entryIndex,
-        string navPath,
-        Dictionary<string, string> map,
-        List<string> warnings) {
-        if (!entryIndex.TryGetValue(navPath, out var navEntry)) return;
-
-        var navContent = ReadEntryText(navEntry);
-        if (!TryParseXml(navContent, out var navDocument) || navDocument == null) {
-            warnings.Add($"EPUB navigation document '{navPath}' could not be parsed.");
-            return;
-        }
-
-        foreach (var anchor in navDocument.Descendants().Where(e => IsName(e, "a"))) {
-            var href = GetAttribute(anchor, "href");
-            if (string.IsNullOrWhiteSpace(href)) continue;
-
-            var targetPath = ResolveRelativePath(navPath, href);
-            if (targetPath.Length == 0) continue;
-
-            var title = NormalizeWhitespace(anchor.Value);
-            if (title.Length == 0) continue;
-
-            if (!map.ContainsKey(targetPath)) {
-                map[targetPath] = title;
-            }
-        }
-    }
-
-    private static void TryReadNcxDocument(
-        Dictionary<string, ZipArchiveEntry> entryIndex,
-        string ncxPath,
-        Dictionary<string, string> map,
-        List<string> warnings) {
-        if (!entryIndex.TryGetValue(ncxPath, out var ncxEntry)) return;
-
-        var ncxContent = ReadEntryText(ncxEntry);
-        if (!TryParseXml(ncxContent, out var ncxDocument) || ncxDocument == null) {
-            warnings.Add($"EPUB NCX document '{ncxPath}' could not be parsed.");
-            return;
-        }
-
-        foreach (var navPoint in ncxDocument.Descendants().Where(e => IsName(e, "navPoint"))) {
-            var content = navPoint.Descendants().FirstOrDefault(e => IsName(e, "content"));
-            if (content == null) continue;
-
-            var src = GetAttribute(content, "src");
-            if (string.IsNullOrWhiteSpace(src)) continue;
-
-            var targetPath = ResolveRelativePath(ncxPath, src);
-            if (targetPath.Length == 0) continue;
-
-            var textElement = navPoint.Descendants().FirstOrDefault(e => IsName(e, "text"));
-            if (textElement == null) continue;
-
-            var title = NormalizeWhitespace(textElement.Value);
-            if (title.Length == 0) continue;
-
-            if (!map.ContainsKey(targetPath)) {
-                map[targetPath] = title;
-            }
-        }
-    }
-
-    private static List<ChapterCandidate> BuildChapterCandidates(
-        ZipArchive archive,
-        Dictionary<string, ZipArchiveEntry> entryIndex,
-        EpubPackage? package,
-        EpubReadOptions options,
-        List<string> warnings) {
-        var candidates = new List<ChapterCandidate>();
-        var seenPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        if (package != null && options.PreferSpineOrder && package.Spine.Count > 0) {
-            foreach (var spineItem in package.Spine.OrderBy(s => s.SpineIndex)) {
-                if (!options.IncludeNonLinearSpineItems && !spineItem.IsLinear) {
-                    continue;
-                }
-
-                if (!package.Manifest.TryGetValue(spineItem.IdRef, out var manifestItem)) {
-                    warnings.Add($"EPUB spine idref '{spineItem.IdRef}' does not exist in manifest.");
-                    continue;
-                }
-
-                if (!IsChapterManifestItem(manifestItem)) {
-                    continue;
-                }
-
-                if (!entryIndex.TryGetValue(manifestItem.FullPath, out var chapterEntry)) {
-                    warnings.Add($"EPUB manifest item '{manifestItem.FullPath}' referenced by spine was not found in archive.");
-                    continue;
-                }
-
-                var chapterPath = NormalizePath(chapterEntry.FullName);
-                if (seenPaths.Contains(chapterPath)) {
-                    continue;
-                }
-
-                seenPaths.Add(chapterPath);
-                candidates.Add(new ChapterCandidate {
-                    Entry = chapterEntry,
-                    ManifestId = manifestItem.Id,
-                    MediaType = manifestItem.MediaType,
-                    SpineIndex = spineItem.SpineIndex,
-                    IsLinear = spineItem.IsLinear
-                });
-            }
-        }
-
-        var shouldFallbackScan = candidates.Count == 0 && options.FallbackToHtmlScan;
-        if (!options.PreferSpineOrder) {
-            shouldFallbackScan = true;
-        }
-
-        if (shouldFallbackScan) {
-            IEnumerable<ZipArchiveEntry> scanEntries = archive.Entries.Where(e => IsChapterEntry(e.FullName));
-            if (options.DeterministicOrder) {
-                scanEntries = scanEntries.OrderBy(e => e.FullName, StringComparer.Ordinal);
-            }
-
-            var manifestByPath = BuildManifestByPath(package);
-            foreach (var entry in scanEntries) {
-                var chapterPath = NormalizePath(entry.FullName);
-                if (seenPaths.Contains(chapterPath)) continue;
-
-                manifestByPath.TryGetValue(chapterPath, out var manifestItem);
-                seenPaths.Add(chapterPath);
-                candidates.Add(new ChapterCandidate {
-                    Entry = entry,
-                    ManifestId = manifestItem?.Id,
-                    MediaType = manifestItem?.MediaType,
-                    SpineIndex = null,
-                    IsLinear = null
-                });
-            }
-        }
-
-        return candidates;
-    }
-
-    private static Dictionary<string, ManifestItem> BuildManifestByPath(EpubPackage? package) {
-        var map = new Dictionary<string, ManifestItem>(StringComparer.OrdinalIgnoreCase);
-        if (package == null) return map;
-
-        foreach (var item in package.Manifest.Values) {
-            if (!map.ContainsKey(item.FullPath)) {
-                map[item.FullPath] = item;
-            }
-        }
-
-        return map;
-    }
-
-    private static bool IsChapterManifestItem(ManifestItem item) {
-        if (!string.IsNullOrWhiteSpace(item.MediaType) &&
-            (item.MediaType.IndexOf("xhtml", StringComparison.OrdinalIgnoreCase) >= 0 ||
-             item.MediaType.IndexOf("html", StringComparison.OrdinalIgnoreCase) >= 0)) {
-            return true;
-        }
-
-        return IsChapterEntry(item.FullPath);
-    }
-
-    private static bool IsChapterEntry(string? fullName) {
-        if (string.IsNullOrWhiteSpace(fullName)) return false;
-        var normalized = NormalizePath(fullName!);
-        if (normalized.EndsWith("/", StringComparison.Ordinal)) return false;
-
-        var ext = Path.GetExtension(normalized).ToLowerInvariant();
-        return ext == ".xhtml" || ext == ".html" || ext == ".htm";
-    }
-
-    private static string ReadEntryText(ZipArchiveEntry entry) {
-        using var entryStream = entry.Open();
-        using var reader = new StreamReader(entryStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 16 * 1024, leaveOpen: false);
-        return reader.ReadToEnd();
-    }
-
-    private static byte[] ReadEntryBytes(ZipArchiveEntry entry) {
-        using Stream entryStream = entry.Open();
-        using var memory = entry.Length > 0 && entry.Length <= int.MaxValue
-            ? new MemoryStream((int)entry.Length)
-            : new MemoryStream();
-        entryStream.CopyTo(memory);
-        return memory.ToArray();
-    }
-
-    private static bool TryParseXml(string content, out XDocument? document) {
-        document = null;
-        if (string.IsNullOrWhiteSpace(content)) return false;
-
-        try {
-            var settings = new XmlReaderSettings {
-                DtdProcessing = DtdProcessing.Ignore,
-                XmlResolver = null
-            };
-
-            using var stringReader = new StringReader(content);
-            using var xmlReader = XmlReader.Create(stringReader, settings);
-            document = XDocument.Load(xmlReader, LoadOptions.PreserveWhitespace);
-            return true;
-        } catch {
-            return false;
-        }
-    }
-
-    private static string ExtractVisibleText(XDocument chapterDocument) {
-        var root = chapterDocument.Root;
-        if (root == null) return string.Empty;
-
-        var body = root.Descendants().FirstOrDefault(e => IsName(e, "body"));
-        var scope = (XContainer?)body ?? root;
-
-        var sb = new StringBuilder();
-        foreach (var textNode in scope.DescendantNodes().OfType<XText>()) {
-            if (textNode.Parent != null && (IsName(textNode.Parent, "script") || IsName(textNode.Parent, "style"))) {
-                continue;
-            }
-
-            var value = textNode.Value;
-            if (string.IsNullOrWhiteSpace(value)) continue;
-
-            sb.Append(value);
-            sb.Append(' ');
-        }
-
-        return NormalizeWhitespace(sb.ToString());
-    }
-
-    private static string? ResolveChapterTitle(XDocument chapterDocument, Dictionary<string, string> navTitleMap, string chapterPath) {
-        if (navTitleMap.TryGetValue(chapterPath, out var navTitle) && !string.IsNullOrWhiteSpace(navTitle)) {
-            return navTitle;
-        }
-
-        var title = chapterDocument.Descendants()
-            .FirstOrDefault(e => IsName(e, "title"));
-        if (title != null) {
-            var normalized = NormalizeWhitespace(title.Value);
-            if (normalized.Length > 0) return normalized;
-        }
-
-        var heading = chapterDocument.Descendants()
-            .FirstOrDefault(e => IsName(e, "h1") || IsName(e, "h2"));
-        if (heading != null) {
-            var normalized = NormalizeWhitespace(heading.Value);
-            if (normalized.Length > 0) return normalized;
-        }
-
-        return null;
-    }
-
-    private static string? ResolveDocumentTitle(EpubPackage? package, IReadOnlyList<EpubChapter> chapters) {
-        if (!string.IsNullOrWhiteSpace(package?.Title)) {
-            return package!.Title;
-        }
-
-        foreach (var chapter in chapters) {
-            if (!string.IsNullOrWhiteSpace(chapter.Title)) {
-                return chapter.Title;
-            }
-        }
-
-        return null;
-    }
-
-    private static bool IsName(XElement element, string expectedLocalName) {
-        return string.Equals(element.Name.LocalName, expectedLocalName, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static string GetAttribute(XElement element, string attributeName) {
-        var attr = element.Attributes().FirstOrDefault(a => string.Equals(a.Name.LocalName, attributeName, StringComparison.OrdinalIgnoreCase));
-        return attr?.Value ?? string.Empty;
-    }
-
-    private static string? TryGetFirstElementValue(XElement container, string localName) {
-        foreach (var element in container.Elements()) {
-            if (!string.Equals(element.Name.LocalName, localName, StringComparison.OrdinalIgnoreCase)) continue;
-
-            var normalized = NormalizeWhitespace(element.Value);
-            return normalized.Length == 0 ? null : normalized;
-        }
-
-        return null;
-    }
-
-    private static bool ContainsSpaceSeparatedToken(string? value, string token) {
-        var source = value ?? string.Empty;
-        if (string.IsNullOrWhiteSpace(source)) return false;
-        var parts = source.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-        foreach (var part in parts) {
-            if (string.Equals(part, token, StringComparison.OrdinalIgnoreCase)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static string ResolveRelativePath(string basePath, string relativeOrAbsolute) {
-        var normalizedBase = NormalizePath(basePath);
-        var normalizedRelative = NormalizePath(RemoveFragmentAndQuery(relativeOrAbsolute));
-        if (normalizedRelative.Length == 0) return string.Empty;
-
-        if (normalizedRelative.Length >= 2 && normalizedRelative[1] == ':') {
-            return normalizedRelative;
-        }
-
-        if (normalizedRelative.StartsWith("/", StringComparison.Ordinal)) {
-            return CollapsePathSegments(normalizedRelative.TrimStart('/'));
-        }
-
-        var baseDirectory = string.Empty;
-        var lastSlash = normalizedBase.LastIndexOf('/');
-        if (lastSlash >= 0) {
-            baseDirectory = normalizedBase.Substring(0, lastSlash);
-        }
-
-        var combined = baseDirectory.Length == 0
-            ? normalizedRelative
-            : baseDirectory + "/" + normalizedRelative;
-        return CollapsePathSegments(combined);
-    }
-
-    private static string RemoveFragmentAndQuery(string value) {
-        if (string.IsNullOrWhiteSpace(value)) return string.Empty;
-
-        var trimmed = value.Trim();
-        var hash = trimmed.IndexOf('#');
-        if (hash >= 0) {
-            trimmed = trimmed.Substring(0, hash);
-        }
-
-        var question = trimmed.IndexOf('?');
-        if (question >= 0) {
-            trimmed = trimmed.Substring(0, question);
-        }
-
-        if (trimmed.Length == 0) return string.Empty;
-
-        try {
-            return Uri.UnescapeDataString(trimmed);
-        } catch {
-            return trimmed;
-        }
-    }
-
-    private static string CollapsePathSegments(string path) {
-        var segments = path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
-        var stack = new List<string>(segments.Length);
-
-        foreach (var segment in segments) {
-            if (segment == ".") continue;
-            if (segment == "..") {
-                if (stack.Count > 0) {
-                    stack.RemoveAt(stack.Count - 1);
-                }
-                continue;
-            }
-
-            stack.Add(segment);
-        }
-
-        return string.Join("/", stack);
-    }
-
-    private static string NormalizePath(string path) {
-        if (string.IsNullOrWhiteSpace(path)) return string.Empty;
-        return path.Replace('\\', '/').Trim();
-    }
-
-    private static string NormalizeWhitespace(string value) {
-        if (string.IsNullOrWhiteSpace(value)) return string.Empty;
-
-        var sb = new StringBuilder(value.Length);
-        bool previousWasWhitespace = false;
-        foreach (var ch in value) {
-            if (char.IsWhiteSpace(ch)) {
-                if (!previousWasWhitespace) {
-                    sb.Append(' ');
-                    previousWasWhitespace = true;
-                }
-            } else {
-                sb.Append(ch);
-                previousWasWhitespace = false;
-            }
-        }
-
-        return sb.ToString().Trim();
-    }
-
-    private static EpubReadOptions Normalize(EpubReadOptions? options) {
-        var source = options ?? new EpubReadOptions();
-        var normalized = new EpubReadOptions {
-            MaxChapters = source.MaxChapters,
-            MaxChapterBytes = source.MaxChapterBytes,
-            MaxTotalRawHtmlBytes = source.MaxTotalRawHtmlBytes,
-            IncludeRawHtml = source.IncludeRawHtml,
-            IncludeResourceData = source.IncludeResourceData,
-            MaxResources = source.MaxResources,
-            MaxResourceBytes = source.MaxResourceBytes,
-            MaxTotalResourceBytes = source.MaxTotalResourceBytes,
-            DeterministicOrder = source.DeterministicOrder,
-            PreferSpineOrder = source.PreferSpineOrder,
-            IncludeNonLinearSpineItems = source.IncludeNonLinearSpineItems,
-            FallbackToHtmlScan = source.FallbackToHtmlScan
-        };
-
-        if (normalized.MaxChapters < 1) normalized.MaxChapters = 1;
-        if (normalized.MaxChapterBytes.HasValue && normalized.MaxChapterBytes.Value < 1) {
-            normalized.MaxChapterBytes = 1;
-        }
-        if (normalized.MaxTotalRawHtmlBytes < 1) normalized.MaxTotalRawHtmlBytes = 1;
-        if (normalized.MaxResources < 1) normalized.MaxResources = 1;
-        if (normalized.MaxResourceBytes < 1) normalized.MaxResourceBytes = 1;
-        if (normalized.MaxTotalResourceBytes < 1) normalized.MaxTotalResourceBytes = 1;
-
-        return normalized;
-    }
-
-    private sealed class EpubPackage {
-        public string OpfPath { get; set; } = string.Empty;
-        public string? Title { get; set; }
-        public string? Identifier { get; set; }
-        public string? Language { get; set; }
-        public string? Creator { get; set; }
-        public Dictionary<string, ManifestItem> Manifest { get; } = new Dictionary<string, ManifestItem>(StringComparer.OrdinalIgnoreCase);
-        public List<SpineItem> Spine { get; } = new List<SpineItem>();
-        public string? NavDocumentPath { get; set; }
-        public string? NcxPath { get; set; }
-    }
-
-    private sealed class ManifestItem {
-        public string Id { get; set; } = string.Empty;
-        public string Href { get; set; } = string.Empty;
-        public string FullPath { get; set; } = string.Empty;
-        public string MediaType { get; set; } = string.Empty;
-        public string Properties { get; set; } = string.Empty;
-    }
-
-    private sealed class SpineItem {
-        public string IdRef { get; set; } = string.Empty;
-        public int SpineIndex { get; set; }
-        public bool IsLinear { get; set; }
-    }
-
-    private sealed class ChapterCandidate {
-        public ZipArchiveEntry Entry { get; set; } = null!;
-        public string? ManifestId { get; set; }
-        public string? MediaType { get; set; }
-        public int? SpineIndex { get; set; }
-        public bool? IsLinear { get; set; }
-    }
 }

--- a/OfficeIMO.Epub/EpubRenditionLayout.cs
+++ b/OfficeIMO.Epub/EpubRenditionLayout.cs
@@ -1,0 +1,10 @@
+namespace OfficeIMO.Epub;
+
+/// <summary>EPUB rendition layout declared globally or for a spine item.</summary>
+public enum EpubRenditionLayout {
+    /// <summary>Content is dynamically paginated by the reading system.</summary>
+    Reflowable,
+
+    /// <summary>Content is pre-paginated and has fixed page geometry.</summary>
+    PrePaginated
+}

--- a/OfficeIMO.Epub/EpubResource.cs
+++ b/OfficeIMO.Epub/EpubResource.cs
@@ -19,6 +19,9 @@ public sealed class EpubResource {
     /// <summary>Uncompressed resource length.</summary>
     public long LengthBytes { get; internal set; }
 
+    /// <summary>Encryption declaration for this resource, when present.</summary>
+    public EpubEncryptionInfo? Encryption { get; internal set; }
+
     /// <summary>Optional bounded resource payload requested by the caller.</summary>
     public byte[]? Data {
         get => _data == null ? null : (byte[])_data.Clone();

--- a/OfficeIMO.Reader.Epub/EpubReaderAdapter.Diagnostics.cs
+++ b/OfficeIMO.Reader.Epub/EpubReaderAdapter.Diagnostics.cs
@@ -1,0 +1,51 @@
+using OfficeIMO.Epub;
+using OfficeIMO.Reader;
+
+namespace OfficeIMO.Reader.Epub;
+
+internal static partial class EpubReaderAdapter {
+    private static IReadOnlyList<OfficeDocumentDiagnostic> BuildEpubDiagnostics(
+        EpubDocument document,
+        string sourcePath) {
+        if (document.Diagnostics.Count == 0) return Array.Empty<OfficeDocumentDiagnostic>();
+
+        var diagnostics = new List<OfficeDocumentDiagnostic>(document.Diagnostics.Count);
+        foreach (EpubDiagnostic diagnostic in document.Diagnostics) {
+            diagnostics.Add(new OfficeDocumentDiagnostic {
+                Severity = MapEpubDiagnosticSeverity(diagnostic.Severity),
+                Category = MapEpubDiagnosticCategory(diagnostic.Code),
+                Code = diagnostic.Code,
+                Message = diagnostic.Message,
+                Source = "OfficeIMO.Epub",
+                IsRecoverable = diagnostic.Severity != EpubDiagnosticSeverity.Error,
+                Location = new ReaderLocation {
+                    Path = string.IsNullOrWhiteSpace(diagnostic.Path)
+                        ? sourcePath
+                        : BuildVirtualPath(sourcePath, diagnostic.Path!)
+                }
+            });
+        }
+        return diagnostics;
+    }
+
+    private static OfficeDocumentDiagnosticSeverity MapEpubDiagnosticSeverity(EpubDiagnosticSeverity severity) {
+        return severity switch {
+            EpubDiagnosticSeverity.Info => OfficeDocumentDiagnosticSeverity.Information,
+            EpubDiagnosticSeverity.Error => OfficeDocumentDiagnosticSeverity.Error,
+            _ => OfficeDocumentDiagnosticSeverity.Warning
+        };
+    }
+
+    private static OfficeDocumentDiagnosticCategory MapEpubDiagnosticCategory(string code) {
+        if (code.IndexOf("encryption", StringComparison.Ordinal) >= 0) {
+            return OfficeDocumentDiagnosticCategory.Security;
+        }
+        if (code.IndexOf("limit", StringComparison.Ordinal) >= 0) {
+            return OfficeDocumentDiagnosticCategory.Limit;
+        }
+        if (code.IndexOf("layout", StringComparison.Ordinal) >= 0) {
+            return OfficeDocumentDiagnosticCategory.Content;
+        }
+        return OfficeDocumentDiagnosticCategory.Parsing;
+    }
+}

--- a/OfficeIMO.Reader.Epub/EpubReaderAdapter.Diagnostics.cs
+++ b/OfficeIMO.Reader.Epub/EpubReaderAdapter.Diagnostics.cs
@@ -37,7 +37,7 @@ internal static partial class EpubReaderAdapter {
     }
 
     private static OfficeDocumentDiagnosticCategory MapEpubDiagnosticCategory(string code) {
-        if (code.IndexOf("encryption", StringComparison.Ordinal) >= 0) {
+        if (code.IndexOf("encrypt", StringComparison.Ordinal) >= 0) {
             return OfficeDocumentDiagnosticCategory.Security;
         }
         if (code.IndexOf("limit", StringComparison.Ordinal) >= 0) {

--- a/OfficeIMO.Reader.Epub/EpubReaderAdapter.Document.cs
+++ b/OfficeIMO.Reader.Epub/EpubReaderAdapter.Document.cs
@@ -53,7 +53,7 @@ internal static partial class EpubReaderAdapter {
         var links = new List<OfficeDocumentLink>();
         var forms = new List<OfficeDocumentFormField>();
         var visuals = new List<ReaderVisual>();
-        var diagnostics = new List<OfficeDocumentDiagnostic>();
+        var diagnostics = new List<OfficeDocumentDiagnostic>(BuildEpubDiagnostics(document, source.Path));
         var pages = new List<OfficeDocumentPage>();
         int tableIndex = 0;
         for (int chapterIndex = 0; chapterIndex < document.Chapters.Count; chapterIndex++) {
@@ -130,7 +130,17 @@ internal static partial class EpubReaderAdapter {
         result.Forms = forms;
         result.Visuals = visuals;
         result.Pages = AttachEpubOcrCandidates(pages, result.OcrCandidates);
-        result.Diagnostics = result.Diagnostics.Concat(diagnostics).ToArray();
+        var packageWarningMessages = new HashSet<string>(
+            document.Diagnostics
+                .Where(static diagnostic => diagnostic.Severity != EpubDiagnosticSeverity.Info)
+                .Select(static diagnostic => diagnostic.Message),
+            StringComparer.Ordinal);
+        result.Diagnostics = result.Diagnostics
+            .Where(diagnostic =>
+                !string.Equals(diagnostic.Code, "reader-warning", StringComparison.Ordinal) ||
+                !packageWarningMessages.Contains(diagnostic.Message))
+            .Concat(diagnostics)
+            .ToArray();
         result.Metadata = BuildEpubMetadata(document, blocks.Count, tables.Count, links.Count, assets.Count);
         return result;
     }
@@ -296,8 +306,15 @@ internal static partial class EpubReaderAdapter {
             EpubMetadata("epub-asset-count", "AssetCount", assetCount, "count")
         };
         if (!string.IsNullOrWhiteSpace(document.Identifier)) metadata.Add(EpubMetadata("epub-identifier", "Identifier", document.Identifier!, "string"));
+        if (!string.IsNullOrWhiteSpace(document.UniqueIdentifierId)) metadata.Add(EpubMetadata("epub-unique-identifier-id", "UniqueIdentifierId", document.UniqueIdentifierId!, "string"));
         if (!string.IsNullOrWhiteSpace(document.Language)) metadata.Add(EpubMetadata("epub-language", "Language", document.Language!, "string"));
         if (!string.IsNullOrWhiteSpace(document.OpfPath)) metadata.Add(EpubMetadata("epub-package-path", "PackagePath", document.OpfPath!, "string"));
+        if (!string.IsNullOrWhiteSpace(document.PackageVersion)) metadata.Add(EpubMetadata("epub-package-version", "PackageVersion", document.PackageVersion!, "string"));
+        if (document.RenditionLayout.HasValue) metadata.Add(EpubMetadata("epub-rendition-layout", "RenditionLayout", document.RenditionLayout.Value.ToString(), "string"));
+        metadata.Add(EpubMetadata("epub-fixed-layout", "IsFixedLayout", document.IsFixedLayout, "boolean"));
+        metadata.Add(EpubMetadata("epub-encryption-count", "EncryptionCount", document.Encryption.Count, "count"));
+        metadata.Add(EpubMetadata("epub-requires-decryption", "RequiresDecryption", document.RequiresDecryption, "boolean"));
+        metadata.Add(EpubMetadata("epub-diagnostic-count", "DiagnosticCount", document.Diagnostics.Count, "count"));
         return metadata;
     }
 

--- a/OfficeIMO.Reader.Epub/EpubReaderAdapter.Options.cs
+++ b/OfficeIMO.Reader.Epub/EpubReaderAdapter.Options.cs
@@ -31,6 +31,10 @@ internal static partial class EpubReaderAdapter {
         bool includeRawHtml,
         bool includeResourceData) {
         return new EpubReadOptions {
+            MaxPackageBytes = source.MaxPackageBytes,
+            MaxArchiveEntries = source.MaxArchiveEntries,
+            MaxTotalUncompressedBytes = source.MaxTotalUncompressedBytes,
+            MaxPackageMetadataBytes = source.MaxPackageMetadataBytes,
             MaxChapters = source.MaxChapters,
             MaxChapterBytes = source.MaxChapterBytes,
             MaxTotalRawHtmlBytes = source.MaxTotalRawHtmlBytes,

--- a/OfficeIMO.Reader.Epub/OfficeDocumentReaderBuilderEpubExtensions.cs
+++ b/OfficeIMO.Reader.Epub/OfficeDocumentReaderBuilderEpubExtensions.cs
@@ -59,6 +59,10 @@ public static class OfficeDocumentReaderBuilderEpubExtensions {
     private static EpubReadOptions? Clone(EpubReadOptions? options) {
         if (options == null) return null;
         return new EpubReadOptions {
+            MaxPackageBytes = options.MaxPackageBytes,
+            MaxArchiveEntries = options.MaxArchiveEntries,
+            MaxTotalUncompressedBytes = options.MaxTotalUncompressedBytes,
+            MaxPackageMetadataBytes = options.MaxPackageMetadataBytes,
             MaxChapters = options.MaxChapters,
             MaxChapterBytes = options.MaxChapterBytes,
             MaxTotalRawHtmlBytes = options.MaxTotalRawHtmlBytes,

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Modular.Fixtures.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Modular.Fixtures.cs
@@ -102,6 +102,39 @@ public sealed partial class ReaderEpubModularTests {
         WriteBinaryEntry(archive, "OEBPS/images/cover.png", new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 });
     }
 
+    private static void BuildEpubWithEncryptedChapter(string epubPath) {
+        using var fs = new FileStream(epubPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+        using var archive = new ZipArchive(fs, ZipArchiveMode.Create, leaveOpen: false);
+
+        WriteTextEntry(
+            archive,
+            "META-INF/container.xml",
+            "<container version=\"1.0\" xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\">" +
+            "<rootfiles><rootfile full-path=\"OEBPS/content.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles>" +
+            "</container>");
+        WriteTextEntry(
+            archive,
+            "META-INF/encryption.xml",
+            "<encryption xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\" xmlns:enc=\"http://www.w3.org/2001/04/xmlenc#\">" +
+            "<enc:EncryptedData><enc:EncryptionMethod Algorithm=\"urn:unsupported\"/><enc:CipherData>" +
+            "<enc:CipherReference URI=\"OEBPS/locked.xhtml\"/></enc:CipherData></enc:EncryptedData></encryption>");
+        WriteTextEntry(
+            archive,
+            "OEBPS/content.opf",
+            "<package version=\"3.0\" xmlns=\"http://www.idpf.org/2007/opf\"><manifest>" +
+            "<item id=\"locked\" href=\"locked.xhtml\" media-type=\"application/xhtml+xml\"/>" +
+            "<item id=\"open\" href=\"open.xhtml\" media-type=\"application/xhtml+xml\"/>" +
+            "</manifest><spine><itemref idref=\"locked\"/><itemref idref=\"open\"/></spine></package>");
+        WriteTextEntry(
+            archive,
+            "OEBPS/./locked.xhtml",
+            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><body><p>Locked body.</p></body></html>");
+        WriteTextEntry(
+            archive,
+            "OEBPS/open.xhtml",
+            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><body><p>Open body.</p></body></html>");
+    }
+
     private static void BuildEpubWithMalformedChapter(string epubPath) {
         using var fs = new FileStream(epubPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
         using var archive = new ZipArchive(fs, ZipArchiveMode.Create, leaveOpen: false);

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Modular.Fixtures.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Modular.Fixtures.cs
@@ -1,0 +1,156 @@
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace OfficeIMO.Tests;
+
+public sealed partial class ReaderEpubModularTests {
+    private static void BuildEpubWithSpine(
+        string epubPath,
+        string secondTitleXml = "Second",
+        bool includePackageDiagnostics = false) {
+        using var fs = new FileStream(epubPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+        using var archive = new ZipArchive(fs, ZipArchiveMode.Create, leaveOpen: false);
+
+        WriteTextEntry(archive, "mimetype", "application/epub+zip", CompressionLevel.NoCompression);
+        WriteTextEntry(archive, "META-INF/container.xml",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<container version=\"1.0\" xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\">" +
+            "<rootfiles><rootfile full-path=\"OEBPS/content.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles>" +
+            "</container>");
+        if (includePackageDiagnostics) {
+            WriteTextEntry(
+                archive,
+                "META-INF/encryption.xml",
+                "<encryption xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\" xmlns:enc=\"http://www.w3.org/2001/04/xmlenc#\">" +
+                "<enc:EncryptedData><enc:EncryptionMethod Algorithm=\"urn:unsupported\"/><enc:CipherData>" +
+                "<enc:CipherReference URI=\"OEBPS/protected.bin\"/></enc:CipherData></enc:EncryptedData></encryption>");
+        }
+
+        WriteTextEntry(archive, "OEBPS/content.opf",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<package version=\"3.0\" unique-identifier=\"bookid\" xmlns=\"http://www.idpf.org/2007/opf\">" +
+            "<metadata xmlns:dc=\"http://purl.org/dc/elements/1.1/\">" +
+            "<dc:title>Demo Book</dc:title><dc:creator>OfficeIMO Team</dc:creator><dc:language>en</dc:language><dc:identifier id=\"bookid\">author-1</dc:identifier>" +
+            (includePackageDiagnostics ? "<meta property=\"rendition:layout\">pre-paginated</meta>" : string.Empty) +
+            "</metadata>" +
+            "<manifest>" +
+            "<item id=\"nav\" href=\"nav.xhtml\" media-type=\"application/xhtml+xml\" properties=\"nav\"/>" +
+            "<item id=\"ncx\" href=\"toc.ncx\" media-type=\"application/x-dtbncx+xml\"/>" +
+            "<item id=\"ch1\" href=\"chapter1.xhtml\" media-type=\"application/xhtml+xml\"/>" +
+            "<item id=\"ch2\" href=\"chapter2.xhtml\" media-type=\"application/xhtml+xml\"/>" +
+            "<item id=\"cover\" href=\"images/cover.png\" media-type=\"image/png\" properties=\"cover-image\"/>" +
+            (includePackageDiagnostics ? "<item id=\"protected\" href=\"protected.bin\" media-type=\"application/octet-stream\"/>" : string.Empty) +
+            "</manifest>" +
+            "<spine toc=\"ncx\"><itemref idref=\"ch2\"/><itemref idref=\"ch1\"/></spine>" +
+            "</package>");
+
+        WriteTextEntry(archive, "OEBPS/nav.xhtml",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><body><nav epub:type=\"toc\" xmlns:epub=\"http://www.idpf.org/2007/ops\"><ol>" +
+            "<li><a href=\"chapter2.xhtml\">" + secondTitleXml + "</a></li>" +
+            "<li><a href=\"chapter1.xhtml\">First</a></li>" +
+            "</ol></nav></body></html>");
+
+        WriteTextEntry(archive, "OEBPS/toc.ncx",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<ncx xmlns=\"http://www.daisy.org/z3986/2005/ncx/\" version=\"2005-1\"><navMap>" +
+            "<navPoint id=\"n1\"><navLabel><text>" + secondTitleXml + "</text></navLabel><content src=\"chapter2.xhtml\"/></navPoint>" +
+            "<navPoint id=\"n2\"><navLabel><text>First</text></navLabel><content src=\"chapter1.xhtml\"/></navPoint>" +
+            "</navMap></ncx>");
+
+        WriteTextEntry(archive, "OEBPS/chapter1.xhtml",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>Local One</title></head><body><h1>One</h1><p>First chapter text.</p>" +
+            "<p><a href=\"chapter2.xhtml#details\">next chapter</a></p>" +
+            "<img src=\"data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==\" alt=\"Inline\"/></body></html>");
+
+        WriteTextEntry(archive, "OEBPS/chapter2.xhtml",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>Local Two</title></head><body><h1>Two</h1><p>Second chapter text. <a href=\"https://example.test/chapter-two\">details</a></p>" +
+            "<ul><li>EPUB list item</li></ul>" +
+            "<table><tr><th>Name</th><th>Qty</th></tr><tr><td>Chapter</td><td>2</td></tr></table>" +
+            "<img src=\"data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==\" alt=\"Inline\"/>" +
+            "<img src=\"images/cover.png\" alt=\"Cover\"/></body></html>");
+
+        WriteBinaryEntry(archive, "OEBPS/images/cover.png", new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 });
+        if (includePackageDiagnostics) {
+            WriteBinaryEntry(archive, "OEBPS/protected.bin", new byte[] { 1, 2, 3, 4 });
+        }
+    }
+
+    private static void BuildImageOnlyEpub(string epubPath) {
+        using var fs = new FileStream(epubPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+        using var archive = new ZipArchive(fs, ZipArchiveMode.Create, leaveOpen: false);
+
+        WriteTextEntry(archive, "mimetype", "application/epub+zip", CompressionLevel.NoCompression);
+        WriteTextEntry(archive, "META-INF/container.xml",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<container version=\"1.0\" xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\">" +
+            "<rootfiles><rootfile full-path=\"OEBPS/content.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles>" +
+            "</container>");
+        WriteTextEntry(archive, "OEBPS/content.opf",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<package version=\"3.0\" xmlns=\"http://www.idpf.org/2007/opf\">" +
+            "<manifest><item id=\"cover-page\" href=\"cover.xhtml\" media-type=\"application/xhtml+xml\"/>" +
+            "<item id=\"cover\" href=\"images/cover.png\" media-type=\"image/png\" properties=\"cover-image\"/></manifest>" +
+            "<spine><itemref idref=\"cover-page\"/></spine></package>");
+        WriteTextEntry(archive, "OEBPS/cover.xhtml",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>Cover</title></head>" +
+            "<body><img src=\"images/cover.png\" alt=\"Cover\"/></body></html>");
+        WriteBinaryEntry(archive, "OEBPS/images/cover.png", new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 });
+    }
+
+    private static void BuildEpubWithMalformedChapter(string epubPath) {
+        using var fs = new FileStream(epubPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+        using var archive = new ZipArchive(fs, ZipArchiveMode.Create, leaveOpen: false);
+
+        WriteTextEntry(archive, "META-INF/container.xml",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<container version=\"1.0\" xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\">" +
+            "<rootfiles><rootfile full-path=\"OEBPS/content.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles>" +
+            "</container>");
+
+        WriteTextEntry(archive, "OEBPS/content.opf",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<package version=\"3.0\" xmlns=\"http://www.idpf.org/2007/opf\">" +
+            "<manifest>" +
+            "<item id=\"good\" href=\"good.xhtml\" media-type=\"application/xhtml+xml\"/>" +
+            "<item id=\"bad\" href=\"bad.xhtml\" media-type=\"application/xhtml+xml\"/>" +
+            "</manifest>" +
+            "<spine><itemref idref=\"bad\"/><itemref idref=\"good\"/></spine>" +
+            "</package>");
+
+        WriteTextEntry(archive, "OEBPS/bad.xhtml", "<html><body><p>broken");
+        WriteTextEntry(archive, "OEBPS/good.xhtml",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><body><p>Good chapter body text.</p></body></html>");
+    }
+
+    private static void WriteTextEntry(ZipArchive archive, string path, string content, CompressionLevel compressionLevel = CompressionLevel.Optimal) {
+        var entry = archive.CreateEntry(path, compressionLevel);
+        using var stream = entry.Open();
+        using var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), 4096, leaveOpen: false);
+        writer.Write(content);
+    }
+
+    private static void WriteBinaryEntry(ZipArchive archive, string path, byte[] content) {
+        ZipArchiveEntry entry = archive.CreateEntry(path, CompressionLevel.Optimal);
+        using Stream stream = entry.Open();
+        stream.Write(content, 0, content.Length);
+    }
+
+    private static string ComputeSha256Hex(byte[] content) {
+        byte[] hash;
+        using (SHA256 sha = SHA256.Create()) {
+            hash = sha.ComputeHash(content);
+        }
+
+        var result = new StringBuilder(hash.Length * 2);
+        foreach (byte value in hash) {
+            result.Append(value.ToString("x2"));
+        }
+        return result.ToString();
+    }
+}

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Modular.cs
@@ -1,9 +1,6 @@
 using OfficeIMO.Epub;
 using OfficeIMO.Reader;
 using OfficeIMO.Reader.Epub;
-using System.IO.Compression;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -133,6 +130,32 @@ public sealed partial class ReaderEpubModularTests {
                 new[] { "Second", "Two" },
                 ReaderHeadingPath.Split(secondChapter.Location.HierarchyHeadingPath));
             Assert.False(epubOptions.IncludeRawHtml);
+        } finally {
+            if (File.Exists(epubPath)) File.Delete(epubPath);
+        }
+    }
+
+    [Fact]
+    public void DocumentReaderEpub_RichDispatch_ProjectsPackageLayoutEncryptionAndDiagnostics() {
+        var epubPath = Path.Combine(Path.GetTempPath(), "officeimo-epub-" + Guid.NewGuid().ToString("N") + ".epub");
+        try {
+            BuildEpubWithSpine(epubPath, includePackageDiagnostics: true);
+
+            OfficeDocumentReadResult result = EpubReaderAdapter.ReadDocument(epubPath);
+
+            Assert.Equal("3.0", Assert.Single(result.Metadata, item => item.Id == "epub-package-version").Value);
+            Assert.Equal("PrePaginated", Assert.Single(result.Metadata, item => item.Id == "epub-rendition-layout").Value);
+            Assert.Equal("True", Assert.Single(result.Metadata, item => item.Id == "epub-fixed-layout").Value);
+            Assert.Equal("1", Assert.Single(result.Metadata, item => item.Id == "epub-encryption-count").Value);
+            Assert.Equal("True", Assert.Single(result.Metadata, item => item.Id == "epub-requires-decryption").Value);
+            OfficeDocumentDiagnostic encryption = Assert.Single(result.Diagnostics, item => item.Code == "epub.encryption.unsupported");
+            Assert.Equal(OfficeDocumentDiagnosticCategory.Security, encryption.Category);
+            Assert.EndsWith("::OEBPS/protected.bin", encryption.Location!.Path, StringComparison.Ordinal);
+            Assert.DoesNotContain(result.Diagnostics, item =>
+                item.Code == "reader-warning" &&
+                string.Equals(item.Message, encryption.Message, StringComparison.Ordinal));
+            OfficeDocumentDiagnostic layout = Assert.Single(result.Diagnostics, item => item.Code == "epub.layout.fixed");
+            Assert.Equal(OfficeDocumentDiagnosticCategory.Content, layout.Category);
         } finally {
             if (File.Exists(epubPath)) File.Delete(epubPath);
         }
@@ -269,7 +292,9 @@ public sealed partial class ReaderEpubModularTests {
             Assert.Equal(2, document.Chapters.Count);
             Assert.All(document.Chapters, chapter => Assert.Null(chapter.Html));
             Assert.All(document.Chapters, chapter => Assert.False(string.IsNullOrWhiteSpace(chapter.Text)));
-            Assert.Contains(document.Warnings, warning => warning.Contains("MaxTotalRawHtmlBytes", StringComparison.Ordinal));
+            Assert.Contains(document.Diagnostics, diagnostic =>
+                diagnostic.Code == "epub.chapter.raw-html-total-limit" &&
+                diagnostic.Severity == EpubDiagnosticSeverity.Warning);
         } finally {
             if (File.Exists(epubPath)) File.Delete(epubPath);
         }
@@ -568,136 +593,4 @@ public sealed partial class ReaderEpubModularTests {
         }
     }
 
-    private static void BuildEpubWithSpine(string epubPath, string secondTitleXml = "Second") {
-        using var fs = new FileStream(epubPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
-        using var archive = new ZipArchive(fs, ZipArchiveMode.Create, leaveOpen: false);
-
-        WriteTextEntry(archive, "mimetype", "application/epub+zip", CompressionLevel.NoCompression);
-        WriteTextEntry(archive, "META-INF/container.xml",
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-            "<container version=\"1.0\" xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\">" +
-            "<rootfiles><rootfile full-path=\"OEBPS/content.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles>" +
-            "</container>");
-
-        WriteTextEntry(archive, "OEBPS/content.opf",
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-            "<package version=\"3.0\" unique-identifier=\"bookid\" xmlns=\"http://www.idpf.org/2007/opf\">" +
-            "<metadata xmlns:dc=\"http://purl.org/dc/elements/1.1/\">" +
-            "<dc:title>Demo Book</dc:title><dc:creator>OfficeIMO Team</dc:creator><dc:language>en</dc:language><dc:identifier id=\"bookid\">author-1</dc:identifier>" +
-            "</metadata>" +
-            "<manifest>" +
-            "<item id=\"nav\" href=\"nav.xhtml\" media-type=\"application/xhtml+xml\" properties=\"nav\"/>" +
-            "<item id=\"ncx\" href=\"toc.ncx\" media-type=\"application/x-dtbncx+xml\"/>" +
-            "<item id=\"ch1\" href=\"chapter1.xhtml\" media-type=\"application/xhtml+xml\"/>" +
-            "<item id=\"ch2\" href=\"chapter2.xhtml\" media-type=\"application/xhtml+xml\"/>" +
-            "<item id=\"cover\" href=\"images/cover.png\" media-type=\"image/png\" properties=\"cover-image\"/>" +
-            "</manifest>" +
-            "<spine toc=\"ncx\"><itemref idref=\"ch2\"/><itemref idref=\"ch1\"/></spine>" +
-            "</package>");
-
-        WriteTextEntry(archive, "OEBPS/nav.xhtml",
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><body><nav epub:type=\"toc\" xmlns:epub=\"http://www.idpf.org/2007/ops\"><ol>" +
-            "<li><a href=\"chapter2.xhtml\">" + secondTitleXml + "</a></li>" +
-            "<li><a href=\"chapter1.xhtml\">First</a></li>" +
-            "</ol></nav></body></html>");
-
-        WriteTextEntry(archive, "OEBPS/toc.ncx",
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-            "<ncx xmlns=\"http://www.daisy.org/z3986/2005/ncx/\" version=\"2005-1\"><navMap>" +
-            "<navPoint id=\"n1\"><navLabel><text>" + secondTitleXml + "</text></navLabel><content src=\"chapter2.xhtml\"/></navPoint>" +
-            "<navPoint id=\"n2\"><navLabel><text>First</text></navLabel><content src=\"chapter1.xhtml\"/></navPoint>" +
-            "</navMap></ncx>");
-
-        WriteTextEntry(archive, "OEBPS/chapter1.xhtml",
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>Local One</title></head><body><h1>One</h1><p>First chapter text.</p>" +
-            "<p><a href=\"chapter2.xhtml#details\">next chapter</a></p>" +
-            "<img src=\"data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==\" alt=\"Inline\"/></body></html>");
-
-        WriteTextEntry(archive, "OEBPS/chapter2.xhtml",
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>Local Two</title></head><body><h1>Two</h1><p>Second chapter text. <a href=\"https://example.test/chapter-two\">details</a></p>" +
-            "<ul><li>EPUB list item</li></ul>" +
-            "<table><tr><th>Name</th><th>Qty</th></tr><tr><td>Chapter</td><td>2</td></tr></table>" +
-            "<img src=\"data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==\" alt=\"Inline\"/>" +
-            "<img src=\"images/cover.png\" alt=\"Cover\"/></body></html>");
-
-        WriteBinaryEntry(archive, "OEBPS/images/cover.png", new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 });
-    }
-
-    private static void BuildImageOnlyEpub(string epubPath) {
-        using var fs = new FileStream(epubPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
-        using var archive = new ZipArchive(fs, ZipArchiveMode.Create, leaveOpen: false);
-
-        WriteTextEntry(archive, "mimetype", "application/epub+zip", CompressionLevel.NoCompression);
-        WriteTextEntry(archive, "META-INF/container.xml",
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-            "<container version=\"1.0\" xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\">" +
-            "<rootfiles><rootfile full-path=\"OEBPS/content.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles>" +
-            "</container>");
-        WriteTextEntry(archive, "OEBPS/content.opf",
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-            "<package version=\"3.0\" xmlns=\"http://www.idpf.org/2007/opf\">" +
-            "<manifest><item id=\"cover-page\" href=\"cover.xhtml\" media-type=\"application/xhtml+xml\"/>" +
-            "<item id=\"cover\" href=\"images/cover.png\" media-type=\"image/png\" properties=\"cover-image\"/></manifest>" +
-            "<spine><itemref idref=\"cover-page\"/></spine></package>");
-        WriteTextEntry(archive, "OEBPS/cover.xhtml",
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>Cover</title></head>" +
-            "<body><img src=\"images/cover.png\" alt=\"Cover\"/></body></html>");
-        WriteBinaryEntry(archive, "OEBPS/images/cover.png", new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 });
-    }
-
-    private static void BuildEpubWithMalformedChapter(string epubPath) {
-        using var fs = new FileStream(epubPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
-        using var archive = new ZipArchive(fs, ZipArchiveMode.Create, leaveOpen: false);
-
-        WriteTextEntry(archive, "META-INF/container.xml",
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-            "<container version=\"1.0\" xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\">" +
-            "<rootfiles><rootfile full-path=\"OEBPS/content.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles>" +
-            "</container>");
-
-        WriteTextEntry(archive, "OEBPS/content.opf",
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-            "<package version=\"3.0\" xmlns=\"http://www.idpf.org/2007/opf\">" +
-            "<manifest>" +
-            "<item id=\"good\" href=\"good.xhtml\" media-type=\"application/xhtml+xml\"/>" +
-            "<item id=\"bad\" href=\"bad.xhtml\" media-type=\"application/xhtml+xml\"/>" +
-            "</manifest>" +
-            "<spine><itemref idref=\"bad\"/><itemref idref=\"good\"/></spine>" +
-            "</package>");
-
-        WriteTextEntry(archive, "OEBPS/bad.xhtml", "<html><body><p>broken");
-        WriteTextEntry(archive, "OEBPS/good.xhtml",
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><body><p>Good chapter body text.</p></body></html>");
-    }
-
-    private static void WriteTextEntry(ZipArchive archive, string path, string content, CompressionLevel compressionLevel = CompressionLevel.Optimal) {
-        var entry = archive.CreateEntry(path, compressionLevel);
-        using var stream = entry.Open();
-        using var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), 4096, leaveOpen: false);
-        writer.Write(content);
-    }
-
-    private static void WriteBinaryEntry(ZipArchive archive, string path, byte[] content) {
-        ZipArchiveEntry entry = archive.CreateEntry(path, CompressionLevel.Optimal);
-        using Stream stream = entry.Open();
-        stream.Write(content, 0, content.Length);
-    }
-
-    private static string ComputeSha256Hex(byte[] content) {
-        byte[] hash;
-        using (SHA256 sha = SHA256.Create()) {
-            hash = sha.ComputeHash(content);
-        }
-
-        var result = new StringBuilder(hash.Length * 2);
-        foreach (byte value in hash) {
-            result.Append(value.ToString("x2"));
-        }
-        return result.ToString();
-    }
 }

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Modular.cs
@@ -162,6 +162,26 @@ public sealed partial class ReaderEpubModularTests {
     }
 
     [Fact]
+    public void DocumentReaderEpub_RichDispatch_MapsEncryptedChapterDiagnosticsToSecurity() {
+        var epubPath = Path.Combine(Path.GetTempPath(), "officeimo-epub-encrypted-chapter-" + Guid.NewGuid().ToString("N") + ".epub");
+        try {
+            BuildEpubWithEncryptedChapter(epubPath);
+
+            OfficeDocumentReadResult result = EpubReaderAdapter.ReadDocument(epubPath);
+
+            OfficeDocumentDiagnostic diagnostic = Assert.Single(
+                result.Diagnostics,
+                item => item.Code == "epub.chapter.encrypted");
+            Assert.Equal(OfficeDocumentDiagnosticCategory.Security, diagnostic.Category);
+            Assert.EndsWith("::OEBPS/locked.xhtml", diagnostic.Location!.Path, StringComparison.Ordinal);
+            OfficeDocumentPage page = Assert.Single(result.Pages);
+            Assert.EndsWith("::OEBPS/open.xhtml", page.Location.Path, StringComparison.Ordinal);
+        } finally {
+            if (File.Exists(epubPath)) File.Delete(epubPath);
+        }
+    }
+
+    [Fact]
     public void DocumentReaderEpub_RichDispatch_HonorsDisabledResourcePayloadsAndKeepsPageAssets() {
         var epubPath = Path.Combine(Path.GetTempPath(), "officeimo-epub-" + Guid.NewGuid().ToString("N") + ".epub");
         try {

--- a/OfficeIMO.Shared.Tests/EpubPackageContracts.cs
+++ b/OfficeIMO.Shared.Tests/EpubPackageContracts.cs
@@ -149,6 +149,38 @@ public sealed class EpubPackageContractTests {
     }
 
     [Fact]
+    public void Load_UsesFallbackIdentifierButReportsInvalidDeclaredUniqueIdentifier() {
+        byte[] package = BuildInvalidUniqueIdentifierPackage();
+
+        EpubDocument document = EpubDocument.Load(new MemoryStream(package, writable: false));
+
+        Assert.Equal("missing-primary", document.UniqueIdentifierId);
+        Assert.Equal("urn:book:fallback", document.Identifier);
+        EpubDiagnostic diagnostic = Assert.Single(
+            document.Diagnostics,
+            item => item.Code == "epub.package.unique-identifier-missing");
+        Assert.Equal("EPUB/package.opf", diagnostic.Path);
+        Assert.Contains("missing-primary", diagnostic.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Load_UsesCanonicalArchiveIdentityForNavigationAndEncryptedChapters() {
+        byte[] package = BuildCanonicalPathPackage();
+
+        EpubDocument document = EpubDocument.Load(new MemoryStream(package, writable: false));
+
+        EpubChapter chapter = Assert.Single(document.Chapters);
+        Assert.Equal("EPUB/visible.xhtml", chapter.Path);
+        Assert.Equal("Canonical Navigation Title", chapter.Title);
+        Assert.Contains("Visible body", chapter.Text, StringComparison.Ordinal);
+        EpubDiagnostic diagnostic = Assert.Single(
+            document.Diagnostics,
+            item => item.Code == "epub.chapter.encrypted");
+        Assert.Equal("EPUB/locked.xhtml", diagnostic.Path);
+        Assert.DoesNotContain(document.Chapters, item => item.Path.Contains("locked", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Load_InvalidZipThrowsStructuredFatalDiagnostic() {
         EpubReadException exception = Assert.Throws<EpubReadException>(() =>
             EpubDocument.Load(new MemoryStream(new byte[] { 1, 2, 3, 4 }, writable: false)));
@@ -156,6 +188,73 @@ public sealed class EpubPackageContractTests {
         EpubDiagnostic diagnostic = Assert.Single(exception.Diagnostics);
         Assert.Equal("epub.archive.invalid", diagnostic.Code);
         Assert.Equal(EpubDiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    private static byte[] BuildInvalidUniqueIdentifierPackage() {
+        using var output = new MemoryStream();
+        using (var archive = new ZipArchive(output, ZipArchiveMode.Create, leaveOpen: true)) {
+            WriteTextEntry(
+                archive,
+                "META-INF/container.xml",
+                "<container version=\"1.0\" xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\">" +
+                "<rootfiles><rootfile full-path=\"EPUB/package.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles>" +
+                "</container>");
+            WriteTextEntry(
+                archive,
+                "EPUB/package.opf",
+                "<package version=\"3.0\" unique-identifier=\"missing-primary\" xmlns=\"http://www.idpf.org/2007/opf\">" +
+                "<metadata xmlns:dc=\"http://purl.org/dc/elements/1.1/\">" +
+                "<dc:identifier id=\"fallback\">urn:book:fallback</dc:identifier>" +
+                "</metadata><manifest><item id=\"chapter\" href=\"chapter.xhtml\" media-type=\"application/xhtml+xml\"/>" +
+                "</manifest><spine><itemref idref=\"chapter\"/></spine></package>");
+            WriteTextEntry(
+                archive,
+                "EPUB/chapter.xhtml",
+                "<html xmlns=\"http://www.w3.org/1999/xhtml\"><body><p>Fallback identity.</p></body></html>");
+        }
+        return output.ToArray();
+    }
+
+    private static byte[] BuildCanonicalPathPackage() {
+        using var output = new MemoryStream();
+        using (var archive = new ZipArchive(output, ZipArchiveMode.Create, leaveOpen: true)) {
+            WriteTextEntry(
+                archive,
+                "META-INF/container.xml",
+                "<container version=\"1.0\" xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\">" +
+                "<rootfiles><rootfile full-path=\"EPUB/package.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles>" +
+                "</container>");
+            WriteTextEntry(
+                archive,
+                "META-INF/encryption.xml",
+                "<encryption xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\" xmlns:enc=\"http://www.w3.org/2001/04/xmlenc#\">" +
+                "<enc:EncryptedData><enc:EncryptionMethod Algorithm=\"urn:unsupported\"/><enc:CipherData>" +
+                "<enc:CipherReference URI=\"EPUB/locked.xhtml\"/></enc:CipherData></enc:EncryptedData></encryption>");
+            WriteTextEntry(
+                archive,
+                "EPUB/package.opf",
+                "<package version=\"3.0\" xmlns=\"http://www.idpf.org/2007/opf\"><manifest>" +
+                "<item id=\"nav\" href=\"nav.xhtml\" media-type=\"application/xhtml+xml\" properties=\"nav\"/>" +
+                "<item id=\"locked\" href=\"locked.xhtml\" media-type=\"application/xhtml+xml\"/>" +
+                "<item id=\"visible\" href=\"visible.xhtml\" media-type=\"application/xhtml+xml\"/>" +
+                "</manifest><spine><itemref idref=\"locked\"/><itemref idref=\"visible\"/></spine></package>");
+            WriteTextEntry(
+                archive,
+                "EPUB/nav.xhtml",
+                "<html xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:epub=\"http://www.idpf.org/2007/ops\"><body>" +
+                "<nav epub:type=\"toc\"><ol><li><a href=\"visible.xhtml\">Canonical Navigation Title</a></li></ol></nav>" +
+                "</body></html>");
+            WriteTextEntry(
+                archive,
+                "EPUB/./locked.xhtml",
+                "<html xmlns=\"http://www.w3.org/1999/xhtml\"><body><p>Locked body.</p></body></html>");
+            WriteTextEntry(
+                archive,
+                "EPUB//visible.xhtml",
+                "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>Local title</title></head>" +
+                "<body><p>Visible body.</p></body></html>");
+        }
+        return output.ToArray();
     }
 
     private static byte[] BuildPackage(bool includeUnsafeEntry) {

--- a/OfficeIMO.Shared.Tests/EpubPackageContracts.cs
+++ b/OfficeIMO.Shared.Tests/EpubPackageContracts.cs
@@ -1,0 +1,290 @@
+using OfficeIMO.Epub;
+using System.IO.Compression;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Shared.Tests;
+
+public sealed class EpubPackageContractTests {
+    [Fact]
+    public void Load_ExposesIdentityLayoutEncryptionAndStructuredDiagnostics() {
+        byte[] package = BuildPackage(includeUnsafeEntry: false);
+
+        EpubDocument document = EpubDocument.Load(
+            new MemoryStream(package, writable: false),
+            new EpubReadOptions {
+                IncludeRawHtml = true,
+                IncludeResourceData = true
+            });
+
+        Assert.Equal("3.0", document.PackageVersion);
+        Assert.Equal("primary-id", document.UniqueIdentifierId);
+        Assert.Equal("urn:book:primary", document.Identifier);
+        Assert.Equal(EpubRenditionLayout.PrePaginated, document.RenditionLayout);
+        Assert.True(document.IsFixedLayout);
+
+        EpubChapter chapter = Assert.Single(document.Chapters);
+        Assert.Equal(EpubRenditionLayout.Reflowable, chapter.RenditionLayout);
+        Assert.False(chapter.IsFixedLayout);
+
+        Assert.True(document.HasEncryptedResources);
+        Assert.True(document.RequiresDecryption);
+        Assert.Equal(2, document.Encryption.Count);
+        EpubEncryptionInfo fontEncryption = Assert.Single(
+            document.Encryption,
+            item => item.Path == "EPUB/fonts/book.otf");
+        Assert.Equal(EpubEncryptionKind.IdpfFontObfuscation, fontEncryption.Kind);
+        Assert.True(fontEncryption.IsFontObfuscation);
+        Assert.False(fontEncryption.RequiresDecryption);
+        EpubEncryptionInfo protectedEncryption = Assert.Single(
+            document.Encryption,
+            item => item.Path == "EPUB/protected.bin");
+        Assert.Equal(EpubEncryptionKind.Encryption, protectedEncryption.Kind);
+        Assert.True(protectedEncryption.RequiresDecryption);
+
+        EpubResource font = Assert.Single(document.Resources, item => item.Id == "font");
+        Assert.NotNull(font.Data);
+        Assert.Same(fontEncryption, font.Encryption);
+        EpubResource protectedResource = Assert.Single(document.Resources, item => item.Id == "protected");
+        Assert.Null(protectedResource.Data);
+        Assert.Same(protectedEncryption, protectedResource.Encryption);
+
+        Assert.Contains(document.Diagnostics, item =>
+            item.Code == "epub.encryption.font-obfuscation" &&
+            item.Severity == EpubDiagnosticSeverity.Info &&
+            item.Path == "EPUB/fonts/book.otf");
+        Assert.Contains(document.Diagnostics, item =>
+            item.Code == "epub.encryption.unsupported" &&
+            item.Severity == EpubDiagnosticSeverity.Warning &&
+            item.Path == "EPUB/protected.bin");
+        Assert.Contains(document.Diagnostics, item => item.Code == "epub.layout.fixed");
+        Assert.DoesNotContain(document.Warnings, warning => warning.Contains("font obfuscation", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(document.Warnings, warning => warning.Contains("unsupported encryption", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task LoadAndLoadAsync_EnforcePackageSizeWithFatalDiagnostics() {
+        byte[] package = BuildPackage(includeUnsafeEntry: false);
+        var options = new EpubReadOptions { MaxPackageBytes = package.Length - 1L };
+
+        EpubReadException syncException = Assert.Throws<EpubReadException>(() =>
+            EpubDocument.Load(new MemoryStream(package, writable: false), options));
+        EpubDiagnostic syncDiagnostic = Assert.Single(syncException.Diagnostics);
+        Assert.Equal("epub.package.size-limit", syncDiagnostic.Code);
+        Assert.Equal(EpubDiagnosticSeverity.Error, syncDiagnostic.Severity);
+
+        EpubReadException asyncException = await Assert.ThrowsAsync<EpubReadException>(() =>
+            EpubDocument.LoadAsync(new MemoryStream(package, writable: false), options));
+        Assert.Equal("epub.package.size-limit", Assert.Single(asyncException.Diagnostics).Code);
+    }
+
+    [Fact]
+    public void Load_EnforcesArchiveEntryAndDeclaredUncompressedLimits() {
+        byte[] package = BuildPackage(includeUnsafeEntry: false);
+
+        EpubReadException entryException = Assert.Throws<EpubReadException>(() =>
+            EpubDocument.Load(
+                new MemoryStream(package, writable: false),
+                new EpubReadOptions { MaxArchiveEntries = 2 }));
+        Assert.Equal("epub.archive.entry-count-limit", Assert.Single(entryException.Diagnostics).Code);
+
+        EpubReadException sizeException = Assert.Throws<EpubReadException>(() =>
+            EpubDocument.Load(
+                new MemoryStream(package, writable: false),
+                new EpubReadOptions { MaxTotalUncompressedBytes = 32 }));
+        Assert.Equal("epub.archive.total-size-limit", Assert.Single(sizeException.Diagnostics).Code);
+    }
+
+    [Fact]
+    public void Load_IgnoresUnsafeArchivePathsAndReportsStableDiagnostic() {
+        byte[] package = BuildPackage(includeUnsafeEntry: true);
+
+        EpubDocument document = EpubDocument.Load(new MemoryStream(package, writable: false));
+
+        EpubDiagnostic[] diagnostics = document.Diagnostics
+            .Where(item => item.Code == "epub.archive.unsafe-path")
+            .ToArray();
+        Assert.Equal(2, diagnostics.Length);
+        Assert.Contains(diagnostics, item => item.Path == "../outside.xhtml");
+        Assert.Contains(diagnostics, item => item.Path == "EPUB/../also-outside.xhtml");
+        Assert.DoesNotContain(diagnostics, item => item.Path == "EPUB/");
+        Assert.DoesNotContain(document.Chapters, chapter => chapter.Path.Contains("outside", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Load_PreservesCaseDistinctManifestIdsAndArchivePaths() {
+        byte[] package = BuildCaseSensitivePackage();
+
+        EpubDocument document = EpubDocument.Load(new MemoryStream(package, writable: false));
+
+        Assert.Collection(
+            document.Chapters,
+            chapter => {
+                Assert.Equal("EPUB/Chapter.xhtml", chapter.Path);
+                Assert.Equal("Chapter", chapter.ManifestId);
+                Assert.Contains("Upper body", chapter.Text, StringComparison.Ordinal);
+            },
+            chapter => {
+                Assert.Equal("EPUB/chapter.xhtml", chapter.Path);
+                Assert.Equal("chapter", chapter.ManifestId);
+                Assert.Contains("Lower body", chapter.Text, StringComparison.Ordinal);
+            });
+    }
+
+    [Fact]
+    public void Load_ParsesEpub2NcxIdentityAndLegacyFixedLayout() {
+        byte[] package = BuildEpub2Package();
+
+        EpubDocument document = EpubDocument.Load(new MemoryStream(package, writable: false));
+
+        Assert.Equal("2.0", document.PackageVersion);
+        Assert.Equal("book-id", document.UniqueIdentifierId);
+        Assert.Equal("urn:epub2:book", document.Identifier);
+        Assert.Equal(EpubRenditionLayout.PrePaginated, document.RenditionLayout);
+        Assert.True(document.IsFixedLayout);
+        EpubChapter chapter = Assert.Single(document.Chapters);
+        Assert.Equal("NCX Chapter", chapter.Title);
+        Assert.True(chapter.IsFixedLayout);
+    }
+
+    [Fact]
+    public void Load_InvalidZipThrowsStructuredFatalDiagnostic() {
+        EpubReadException exception = Assert.Throws<EpubReadException>(() =>
+            EpubDocument.Load(new MemoryStream(new byte[] { 1, 2, 3, 4 }, writable: false)));
+
+        EpubDiagnostic diagnostic = Assert.Single(exception.Diagnostics);
+        Assert.Equal("epub.archive.invalid", diagnostic.Code);
+        Assert.Equal(EpubDiagnosticSeverity.Error, diagnostic.Severity);
+    }
+
+    private static byte[] BuildPackage(bool includeUnsafeEntry) {
+        using var output = new MemoryStream();
+        using (var archive = new ZipArchive(output, ZipArchiveMode.Create, leaveOpen: true)) {
+            WriteTextEntry(archive, "mimetype", "application/epub+zip", CompressionLevel.NoCompression);
+            WriteTextEntry(
+                archive,
+                "META-INF/container.xml",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<container version=\"1.0\" xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\">" +
+                "<rootfiles><rootfile full-path=\"EPUB/package.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles>" +
+                "</container>");
+            WriteTextEntry(
+                archive,
+                "META-INF/encryption.xml",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<encryption xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\" xmlns:enc=\"http://www.w3.org/2001/04/xmlenc#\">" +
+                "<enc:EncryptedData><enc:EncryptionMethod Algorithm=\"http://www.idpf.org/2008/embedding\"/>" +
+                "<enc:CipherData><enc:CipherReference URI=\"EPUB/fonts/book.otf\"/></enc:CipherData></enc:EncryptedData>" +
+                "<enc:EncryptedData><enc:EncryptionMethod Algorithm=\"http://www.w3.org/2001/04/xmlenc#aes256-cbc\"/>" +
+                "<enc:CipherData><enc:CipherReference URI=\"EPUB/protected.bin\"/></enc:CipherData></enc:EncryptedData>" +
+                "</encryption>");
+            WriteTextEntry(
+                archive,
+                "EPUB/package.opf",
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<package version=\"3.0\" unique-identifier=\"primary-id\" xmlns=\"http://www.idpf.org/2007/opf\">" +
+                "<metadata xmlns:dc=\"http://purl.org/dc/elements/1.1/\">" +
+                "<dc:identifier id=\"secondary-id\">urn:book:secondary</dc:identifier>" +
+                "<dc:identifier id=\"primary-id\">urn:book:primary</dc:identifier>" +
+                "<dc:title>Package contracts</dc:title><dc:language>en</dc:language>" +
+                "<meta property=\"rendition:layout\">pre-paginated</meta>" +
+                "</metadata>" +
+                "<manifest>" +
+                "<item id=\"chapter\" href=\"chapter.xhtml\" media-type=\"application/xhtml+xml\"/>" +
+                "<item id=\"font\" href=\"fonts/book.otf\" media-type=\"font/otf\"/>" +
+                "<item id=\"protected\" href=\"protected.bin\" media-type=\"application/octet-stream\"/>" +
+                "</manifest>" +
+                "<spine><itemref idref=\"chapter\" properties=\"rendition:layout-reflowable\"/></spine>" +
+                "</package>");
+            WriteTextEntry(
+                archive,
+                "EPUB/chapter.xhtml",
+                "<html xmlns=\"http://www.w3.org/1999/xhtml\"><body><h1>Chapter</h1><p>Body.</p></body></html>");
+            WriteBytesEntry(archive, "EPUB/fonts/book.otf", new byte[] { 1, 2, 3, 4 });
+            WriteBytesEntry(archive, "EPUB/protected.bin", new byte[] { 5, 6, 7, 8 });
+            if (includeUnsafeEntry) {
+                archive.CreateEntry("EPUB/");
+                WriteTextEntry(archive, "../outside.xhtml", "<html><body>Outside</body></html>");
+                WriteTextEntry(archive, "EPUB/../also-outside.xhtml", "<html><body>Also outside</body></html>");
+            }
+        }
+        return output.ToArray();
+    }
+
+    private static byte[] BuildCaseSensitivePackage() {
+        using var output = new MemoryStream();
+        using (var archive = new ZipArchive(output, ZipArchiveMode.Create, leaveOpen: true)) {
+            WriteTextEntry(
+                archive,
+                "META-INF/container.xml",
+                "<container version=\"1.0\" xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\">" +
+                "<rootfiles><rootfile full-path=\"EPUB/package.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles>" +
+                "</container>");
+            WriteTextEntry(
+                archive,
+                "EPUB/package.opf",
+                "<package version=\"3.0\" xmlns=\"http://www.idpf.org/2007/opf\">" +
+                "<manifest>" +
+                "<item id=\"Chapter\" href=\"Chapter.xhtml\" media-type=\"application/xhtml+xml\"/>" +
+                "<item id=\"chapter\" href=\"chapter.xhtml\" media-type=\"application/xhtml+xml\"/>" +
+                "</manifest><spine><itemref idref=\"Chapter\"/><itemref idref=\"chapter\"/></spine></package>");
+            WriteTextEntry(archive, "EPUB/Chapter.xhtml", "<html><body><p>Upper body</p></body></html>");
+            WriteTextEntry(archive, "EPUB/chapter.xhtml", "<html><body><p>Lower body</p></body></html>");
+        }
+        return output.ToArray();
+    }
+
+    private static byte[] BuildEpub2Package() {
+        using var output = new MemoryStream();
+        using (var archive = new ZipArchive(output, ZipArchiveMode.Create, leaveOpen: true)) {
+            WriteTextEntry(
+                archive,
+                "META-INF/container.xml",
+                "<container version=\"1.0\" xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\">" +
+                "<rootfiles><rootfile full-path=\"OPS/content.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles>" +
+                "</container>");
+            WriteTextEntry(
+                archive,
+                "OPS/content.opf",
+                "<package version=\"2.0\" unique-identifier=\"book-id\" xmlns=\"http://www.idpf.org/2007/opf\">" +
+                "<metadata xmlns:dc=\"http://purl.org/dc/elements/1.1/\">" +
+                "<dc:identifier id=\"book-id\">urn:epub2:book</dc:identifier>" +
+                "<dc:title>EPUB 2 contracts</dc:title><meta name=\"fixed-layout\" content=\"true\"/>" +
+                "</metadata><manifest>" +
+                "<item id=\"ncx\" href=\"toc.ncx\" media-type=\"application/x-dtbncx+xml\"/>" +
+                "<item id=\"chapter\" href=\"chapter.xhtml\" media-type=\"application/xhtml+xml\"/>" +
+                "</manifest><spine toc=\"ncx\"><itemref idref=\"chapter\"/></spine></package>");
+            WriteTextEntry(
+                archive,
+                "OPS/toc.ncx",
+                "<ncx xmlns=\"http://www.daisy.org/z3986/2005/ncx/\" version=\"2005-1\"><navMap>" +
+                "<navPoint id=\"chapter\"><navLabel><text>NCX Chapter</text></navLabel>" +
+                "<content src=\"chapter.xhtml\"/></navPoint></navMap></ncx>");
+            WriteTextEntry(
+                archive,
+                "OPS/chapter.xhtml",
+                "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>Local title</title></head>" +
+                "<body><p>EPUB 2 body</p></body></html>");
+        }
+        return output.ToArray();
+    }
+
+    private static void WriteTextEntry(
+        ZipArchive archive,
+        string path,
+        string content,
+        CompressionLevel compressionLevel = CompressionLevel.Optimal) {
+        WriteBytesEntry(archive, path, Encoding.UTF8.GetBytes(content), compressionLevel);
+    }
+
+    private static void WriteBytesEntry(
+        ZipArchive archive,
+        string path,
+        byte[] data,
+        CompressionLevel compressionLevel = CompressionLevel.Optimal) {
+        ZipArchiveEntry entry = archive.CreateEntry(path, compressionLevel);
+        using Stream stream = entry.Open();
+        stream.Write(data, 0, data.Length);
+    }
+}


### PR DESCRIPTION
## Summary

OfficeIMO.Epub now exposes package-level state and deterministic diagnostics instead of reducing every problem to an unstructured warning. It reads EPUB 2 and EPUB 3 identity data more faithfully, recognizes NCX navigation, reports fixed-layout content, classifies encryption and font obfuscation, and carries that information into the rich Reader result.

Package processing is bounded by configurable compressed size, ZIP entry count, declared uncompressed size, metadata size, per-chapter size, aggregate retained XHTML, and resource payload limits. Archive paths are validated before fallback discovery, remain case-sensitive, and reject traversal entries. Fatal package failures use EpubReadException with stable diagnostic codes; the existing Warnings projection remains available for compatibility.

Reader clones every EPUB limit, maps typed diagnostics into the shared envelope, and avoids emitting a second generic diagnostic for the same package warning. No external runtime dependency is added.

## Current limits

- Unsupported encryption and DRM are reported; encrypted content is not decrypted.
- Recognized IDPF and Adobe font obfuscation is classified but not decoded in this change.
- Fixed-layout declarations are exposed and diagnosed, but page geometry is not reproduced.
- Remote manifest resources, full navigation trees, page lists, landmarks, and broader metadata refinements remain follow-up work.

This PR is stacked on #2090, which provides structure-preserving XHTML-to-Markdown projection.

## Validation

- OfficeIMO.Shared.Tests: 134/134 on net8.0 and net10.0
- OfficeIMO.Reader.Tests: 530/530 on net8.0 and net10.0
- OfficeIMO.Epub and OfficeIMO.Reader.Epub: netstandard2.0 and net10.0 builds with zero warnings
- Focused corpus covers EPUB 2 NCX, EPUB 3 identity/layout/encryption, case-distinct paths, invalid ZIPs, unsafe entries, and size/count limits