### PR TITLE
Resolve EPUB resource references end to end

### DIFF
--- a/OfficeIMO.Epub/EpubChapter.cs
+++ b/OfficeIMO.Epub/EpubChapter.cs
@@ -49,6 +49,12 @@ public sealed class EpubChapter {
     public string? Title { get; internal set; }
 
     /// <summary>
+    /// First HTML <c>base</c> element href declared by this chapter, when present.
+    /// Relative content references are resolved through this value.
+    /// </summary>
+    public string? BaseHref { get; internal set; }
+
+    /// <summary>
     /// Plain-text content extracted from chapter HTML.
     /// </summary>
     public string Text { get; internal set; } = string.Empty;

--- a/OfficeIMO.Epub/EpubNavigationItem.cs
+++ b/OfficeIMO.Epub/EpubNavigationItem.cs
@@ -11,7 +11,7 @@ public sealed class EpubNavigationItem {
     /// <summary>Original href or NCX src value.</summary>
     public string? Href { get; internal set; }
 
-    /// <summary>Normalized archive path or absolute remote URI targeted by this item.</summary>
+    /// <summary>Normalized archive path or external URL targeted by this item.</summary>
     public string? Target { get; internal set; }
 
     /// <summary>Decoded fragment identifier without the leading hash.</summary>
@@ -23,7 +23,7 @@ public sealed class EpubNavigationItem {
     /// <summary>NCX playOrder value when declared.</summary>
     public int? PlayOrder { get; internal set; }
 
-    /// <summary>Whether the target is an absolute remote URI.</summary>
+    /// <summary>Whether the target is external to the EPUB container.</summary>
     public bool IsRemote { get; internal set; }
 
     /// <summary>Ordered child navigation items.</summary>

--- a/OfficeIMO.Epub/EpubReader.Navigation.cs
+++ b/OfficeIMO.Epub/EpubReader.Navigation.cs
@@ -84,6 +84,12 @@ internal static partial class EpubReader {
             return;
         }
 
+        string? baseHref = navDocument
+            .Descendants()
+            .Where(static element => IsName(element, "base"))
+            .Select(element => NullIfWhiteSpace(GetAttribute(element, "href")))
+            .FirstOrDefault(static value => value != null);
+
         foreach (XElement nav in navDocument.Descendants().Where(element => IsName(element, "nav"))) {
             string type = GetAttribute(nav, "type");
             List<EpubNavigationItem>? destination = ContainsSpaceSeparatedToken(type, "toc")
@@ -98,13 +104,14 @@ internal static partial class EpubReader {
             XElement? list = nav.Elements().FirstOrDefault(element => IsName(element, "ol"))
                 ?? nav.Descendants().FirstOrDefault(element => IsName(element, "ol"));
             if (list == null) continue;
-            destination.AddRange(ParseHtmlNavigationList(list, navPath, 1, options, limits, diagnostics));
+            destination.AddRange(ParseHtmlNavigationList(list, navPath, baseHref, 1, options, limits, diagnostics));
         }
     }
 
     private static IReadOnlyList<EpubNavigationItem> ParseHtmlNavigationList(
         XElement list,
         string navPath,
+        string? baseHref,
         int depth,
         EpubReadOptions options,
         NavigationLimitState limits,
@@ -122,7 +129,7 @@ internal static partial class EpubReader {
             string? target = null;
             string? fragment = null;
             bool isRemote = false;
-            if (href != null && !TryResolveNavigationTarget(navPath, href, out target, out fragment, out isRemote)) {
+            if (href != null && !TryResolveNavigationTarget(navPath, baseHref, href, out target, out fragment, out isRemote)) {
                 diagnostics.Warning(
                     "epub.navigation.target-invalid",
                     $"Navigation item '{label}' has invalid href '{href}'.",
@@ -132,7 +139,7 @@ internal static partial class EpubReader {
             XElement? childList = listItem.Elements().FirstOrDefault(element => IsName(element, "ol"));
             IReadOnlyList<EpubNavigationItem> children = childList == null
                 ? Array.Empty<EpubNavigationItem>()
-                : ParseHtmlNavigationList(childList, navPath, depth + 1, options, limits, diagnostics);
+                : ParseHtmlNavigationList(childList, navPath, baseHref, depth + 1, options, limits, diagnostics);
             if (label.Length == 0) label = target ?? string.Empty;
             items.Add(new EpubNavigationItem {
                 Source = EpubNavigationSource.Epub3Navigation,
@@ -240,7 +247,7 @@ internal static partial class EpubReader {
             string? target = null;
             string? fragment = null;
             bool isRemote = false;
-            if (href != null && !TryResolveNavigationTarget(ncxPath, href, out target, out fragment, out isRemote)) {
+            if (href != null && !TryResolveNavigationTarget(ncxPath, null, href, out target, out fragment, out isRemote)) {
                 diagnostics.Warning(
                     "epub.ncx.target-invalid",
                     $"NCX item '{label}' has invalid src '{href}'.",
@@ -276,6 +283,7 @@ internal static partial class EpubReader {
 
     private static bool TryResolveNavigationTarget(
         string basePath,
+        string? baseHref,
         string href,
         out string? target,
         out string? fragment,
@@ -285,30 +293,14 @@ internal static partial class EpubReader {
         isRemote = false;
         if (string.IsNullOrWhiteSpace(href)) return false;
 
-        string candidate = href.Trim();
-        int fragmentIndex = candidate.IndexOf('#');
-        string reference = fragmentIndex < 0 ? candidate : candidate.Substring(0, fragmentIndex);
-        if (fragmentIndex >= 0 && fragmentIndex + 1 < candidate.Length) {
-            string encodedFragment = candidate.Substring(fragmentIndex + 1);
-            try {
-                fragment = Uri.UnescapeDataString(encodedFragment);
-            } catch {
-                fragment = encodedFragment;
-            }
-        }
-
-        if (reference.Length == 0) {
-            target = NormalizePath(basePath);
-            return target.Length > 0;
-        }
-        if (TryGetRemoteResourceUri(reference, out string? remoteUri)) {
-            target = remoteUri;
-            isRemote = true;
-            return true;
-        }
-
-        target = ResolveRelativePath(basePath, reference);
-        return target.Length > 0;
+        EpubReference resolved = EpubReference.Resolve(basePath, baseHref, href);
+        if (!resolved.IsValid || resolved.Kind == EpubReferenceKind.Data) return false;
+        target = resolved.Kind == EpubReferenceKind.Container
+            ? resolved.ContainerPath
+            : resolved.Target;
+        fragment = resolved.Fragment;
+        isRemote = resolved.Kind == EpubReferenceKind.External;
+        return !string.IsNullOrWhiteSpace(target);
     }
 
     private static bool TryReserveNavigationItem(

--- a/OfficeIMO.Epub/EpubReader.Package.cs
+++ b/OfficeIMO.Epub/EpubReader.Package.cs
@@ -246,14 +246,26 @@ internal static partial class EpubReader {
             var href = GetAttribute(item, "href");
             if (string.IsNullOrWhiteSpace(id) || string.IsNullOrWhiteSpace(href)) continue;
 
-            bool isRemote = TryGetRemoteResourceUri(href, out string? remoteUri);
-            string fullPath = isRemote ? remoteUri! : ResolveRelativePath(opfPath, href);
+            EpubReference resolvedReference = EpubReference.Resolve(opfPath, href);
+            bool isRemote = resolvedReference.Kind == EpubReferenceKind.External;
+            string? remoteUri = isRemote ? resolvedReference.ResolvedValue : null;
+            string fullPath = isRemote
+                ? remoteUri ?? string.Empty
+                : resolvedReference.Kind == EpubReferenceKind.Container
+                    ? resolvedReference.ContainerPath ?? string.Empty
+                    : string.Empty;
             if (fullPath.Length == 0) {
                 diagnostics.Warning(
                     "epub.manifest.invalid-path",
                     $"Ignored manifest item '{id}' because href '{href}' does not resolve to a safe archive path.",
                     opfPath);
                 continue;
+            }
+            if (!resolvedReference.IsConforming) {
+                diagnostics.Warning(
+                    "epub.manifest.reference-non-conforming",
+                    $"Manifest item '{id}' uses non-conforming root-relative href '{href}'. The safe container target is retained.",
+                    fullPath);
             }
             var model = new ManifestItem {
                 Id = id,
@@ -322,7 +334,7 @@ internal static partial class EpubReader {
                     break;
                 }
                 string href = GetAttribute(reference, "href");
-                if (!TryResolveNavigationTarget(opfPath, href, out string? target, out string? fragment, out bool isRemote)) {
+                if (!TryResolveNavigationTarget(opfPath, null, href, out string? target, out string? fragment, out bool isRemote)) {
                     diagnostics.Warning(
                         "epub.guide.invalid-target",
                         $"Ignored EPUB 2 guide reference with invalid href '{href}'.",
@@ -395,18 +407,6 @@ internal static partial class EpubReader {
                 MediaType = NullIfWhiteSpace(GetAttribute(element, "media-type"))
             });
         }
-    }
-
-    private static bool TryGetRemoteResourceUri(string href, out string? remoteUri) {
-        remoteUri = null;
-        string candidate = href.Trim();
-        if (!Uri.TryCreate(candidate, UriKind.Absolute, out Uri? uri)) return false;
-        if (string.Equals(uri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(uri.Scheme, "data", StringComparison.OrdinalIgnoreCase)) {
-            return false;
-        }
-        remoteUri = candidate;
-        return true;
     }
 
 }

--- a/OfficeIMO.Epub/EpubReader.Utilities.cs
+++ b/OfficeIMO.Epub/EpubReader.Utilities.cs
@@ -34,35 +34,6 @@ internal static partial class EpubReader {
         return false;
     }
 
-    private static string ResolveRelativePath(string basePath, string relativeOrAbsolute) {
-        var normalizedBase = NormalizePath(basePath);
-        string reference = RemoveFragmentAndQuery(relativeOrAbsolute);
-        if (reference.StartsWith("//", StringComparison.Ordinal) || Uri.TryCreate(reference, UriKind.Absolute, out _)) {
-            return string.Empty;
-        }
-        var normalizedRelative = NormalizePath(reference);
-        if (normalizedRelative.Length == 0) return string.Empty;
-
-        if (normalizedRelative.Length >= 2 && normalizedRelative[1] == ':') {
-            return normalizedRelative;
-        }
-
-        if (normalizedRelative.StartsWith("/", StringComparison.Ordinal)) {
-            return CollapsePathSegments(normalizedRelative.TrimStart('/'));
-        }
-
-        var baseDirectory = string.Empty;
-        var lastSlash = normalizedBase.LastIndexOf('/');
-        if (lastSlash >= 0) {
-            baseDirectory = normalizedBase.Substring(0, lastSlash);
-        }
-
-        var combined = baseDirectory.Length == 0
-            ? normalizedRelative
-            : baseDirectory + "/" + normalizedRelative;
-        return CollapsePathSegments(combined);
-    }
-
     private static string RemoveFragmentAndQuery(string value) {
         if (string.IsNullOrWhiteSpace(value)) return string.Empty;
 

--- a/OfficeIMO.Epub/EpubReader.cs
+++ b/OfficeIMO.Epub/EpubReader.cs
@@ -157,6 +157,11 @@ internal static partial class EpubReader {
 
             emitted++;
             var title = ResolveChapterTitle(chapterDocument, navigation.TitleMap, normalizedPath);
+            string? baseHref = chapterDocument
+                .Descendants()
+                .Where(static element => element.Name.LocalName.Equals("base", StringComparison.OrdinalIgnoreCase))
+                .Select(element => NullIfWhiteSpace(GetAttribute(element, "href")))
+                .FirstOrDefault(static value => value != null);
 
             chapters.Add(new EpubChapter {
                 Order = emitted,
@@ -168,6 +173,7 @@ internal static partial class EpubReader {
                 RenditionLayout = candidate.RenditionLayout,
                 Encryption = chapterEncryption,
                 Title = title,
+                BaseHref = baseHref,
                 Text = text,
                 HasStructuredContent = hasStructuredContent,
                 Html = retainedHtml

--- a/OfficeIMO.Epub/EpubReference.cs
+++ b/OfficeIMO.Epub/EpubReference.cs
@@ -1,0 +1,389 @@
+namespace OfficeIMO.Epub;
+
+/// <summary>
+/// Represents an EPUB URL reference resolved against a container document path.
+/// </summary>
+public sealed class EpubReference {
+    private readonly string? _encodedFragment;
+
+    private EpubReference(
+        string original,
+        EpubReferenceKind kind,
+        EpubReferenceError error,
+        string? containerPath,
+        string? externalUri,
+        string? query,
+        string? fragment,
+        string? encodedFragment,
+        bool isContainerRootRelative,
+        bool isConforming) {
+        Original = original;
+        Kind = kind;
+        Error = error;
+        ContainerPath = containerPath;
+        ExternalUri = externalUri;
+        Query = query;
+        Fragment = fragment;
+        _encodedFragment = encodedFragment;
+        IsContainerRootRelative = isContainerRootRelative;
+        IsConforming = isConforming;
+    }
+
+    /// <summary>The original trimmed reference value.</summary>
+    public string Original { get; }
+
+    /// <summary>The resolved reference kind.</summary>
+    public EpubReferenceKind Kind { get; }
+
+    /// <summary>The resolution error, or <see cref="EpubReferenceError.None"/> on success.</summary>
+    public EpubReferenceError Error { get; }
+
+    /// <summary>Case-sensitive normalized archive path for a container reference.</summary>
+    public string? ContainerPath { get; }
+
+    /// <summary>External or data URL, including its query and fragment when present.</summary>
+    public string? ExternalUri { get; }
+
+    /// <summary>Raw query value without the leading question mark.</summary>
+    public string? Query { get; }
+
+    /// <summary>Decoded fragment value without the leading number sign.</summary>
+    public string? Fragment { get; }
+
+    /// <summary>Whether a container reference began at the virtual container root.</summary>
+    public bool IsContainerRootRelative { get; }
+
+    /// <summary>
+    /// Whether the reference conforms to EPUB OCF URL restrictions. A safely resolved
+    /// root-relative container reference is exposed with this value set to <see langword="false"/>.
+    /// </summary>
+    public bool IsConforming { get; }
+
+    /// <summary>Whether the reference resolved successfully.</summary>
+    public bool IsValid => Kind != EpubReferenceKind.Invalid;
+
+    /// <summary>
+    /// Resolved target without a fragment. Container targets include any original query.
+    /// </summary>
+    public string? Target {
+        get {
+            if (Kind == EpubReferenceKind.Container) {
+                return AppendQuery(ContainerPath, Query);
+            }
+            if (Kind == EpubReferenceKind.External || Kind == EpubReferenceKind.Data) {
+                return RemoveFragment(ExternalUri);
+            }
+            return null;
+        }
+    }
+
+    /// <summary>Fully resolved container path or preserved external/data URL.</summary>
+    public string? ResolvedValue {
+        get {
+            if (Kind == EpubReferenceKind.Container) {
+                return AppendFragment(AppendQuery(ContainerPath, Query), _encodedFragment);
+            }
+            return ExternalUri;
+        }
+    }
+
+    /// <summary>Resolves a reference against an EPUB container document path.</summary>
+    /// <param name="basePath">Case-sensitive archive path of the containing document.</param>
+    /// <param name="reference">URL reference to resolve.</param>
+    /// <returns>A typed result. Invalid and unsafe values do not throw.</returns>
+    public static EpubReference Resolve(string basePath, string reference) {
+        string original = reference?.Trim() ?? string.Empty;
+        if (original.Length == 0) return Invalid(original, EpubReferenceError.Empty);
+        if (ContainsControlCharacter(original)) return Invalid(original, EpubReferenceError.ControlCharacter);
+        if (!TryNormalizeBasePath(basePath, out string normalizedBase)) {
+            return Invalid(original, EpubReferenceError.InvalidBasePath);
+        }
+
+        SplitReference(original, out string path, out string? query, out string? encodedFragment);
+        string? fragment = DecodeFragment(encodedFragment);
+        string pathAndQuery = AppendQuery(path, query) ?? string.Empty;
+        string completeValue = AppendFragment(pathAndQuery, encodedFragment) ?? string.Empty;
+
+        if (path.StartsWith("data:", StringComparison.OrdinalIgnoreCase)) {
+            return Valid(
+                original,
+                EpubReferenceKind.Data,
+                null,
+                completeValue,
+                query,
+                fragment,
+                encodedFragment,
+                false,
+                true);
+        }
+        if (path.StartsWith("file:", StringComparison.OrdinalIgnoreCase) || LooksLikeWindowsDrivePath(path)) {
+            return Invalid(original, EpubReferenceError.FileUrl);
+        }
+        if (path.StartsWith("//", StringComparison.Ordinal)) {
+            return Valid(
+                original,
+                EpubReferenceKind.External,
+                null,
+                completeValue,
+                query,
+                fragment,
+                encodedFragment,
+                false,
+                true);
+        }
+        if (!path.StartsWith("/", StringComparison.Ordinal) &&
+            Uri.TryCreate(pathAndQuery, UriKind.Absolute, out Uri? absoluteUri)) {
+            if (absoluteUri.IsFile) return Invalid(original, EpubReferenceError.FileUrl);
+            return Valid(
+                original,
+                EpubReferenceKind.External,
+                null,
+                completeValue,
+                query,
+                fragment,
+                encodedFragment,
+                false,
+                true);
+        }
+
+        bool isRootRelative = path.StartsWith("/", StringComparison.Ordinal);
+        string relativePath = isRootRelative ? path.TrimStart('/') : path;
+        var segments = new List<string>();
+        if (!isRootRelative) {
+            int lastSlash = normalizedBase.LastIndexOf('/');
+            string baseDirectory = lastSlash < 0 ? string.Empty : normalizedBase.Substring(0, lastSlash);
+            if (baseDirectory.Length > 0) segments.AddRange(baseDirectory.Split('/'));
+        }
+
+        if (relativePath.Length == 0) {
+            if (isRootRelative) return Invalid(original, EpubReferenceError.InvalidPath);
+            if (!TryNormalizeBasePath(normalizedBase, out string currentPath)) {
+                return Invalid(original, EpubReferenceError.InvalidBasePath);
+            }
+            return Valid(
+                original,
+                EpubReferenceKind.Container,
+                currentPath,
+                null,
+                query,
+                fragment,
+                encodedFragment,
+                false,
+                true);
+        }
+
+        string[] sourceSegments = relativePath.Split(new[] { '/' }, StringSplitOptions.None);
+        foreach (string sourceSegment in sourceSegments) {
+            if (sourceSegment.Length == 0 || IsSingleDotSegment(sourceSegment)) continue;
+            if (IsDoubleDotSegment(sourceSegment)) {
+                if (segments.Count == 0) return Invalid(original, EpubReferenceError.EscapesContainer);
+                segments.RemoveAt(segments.Count - 1);
+                continue;
+            }
+            if (!TryDecodePathSegment(sourceSegment, out string decodedSegment)) {
+                return Invalid(original, EpubReferenceError.InvalidPath);
+            }
+            segments.Add(decodedSegment);
+        }
+
+        if (segments.Count == 0) return Invalid(original, EpubReferenceError.InvalidPath);
+        return Valid(
+            original,
+            EpubReferenceKind.Container,
+            string.Join("/", segments),
+            null,
+            query,
+            fragment,
+            encodedFragment,
+            isRootRelative,
+            !isRootRelative);
+    }
+
+    /// <summary>
+    /// Resolves a content reference using an optional HTML <c>base</c> element value.
+    /// </summary>
+    /// <param name="documentPath">Case-sensitive archive path of the content document.</param>
+    /// <param name="baseHref">Optional HTML base URL.</param>
+    /// <param name="reference">URL reference to resolve.</param>
+    /// <returns>A typed result. Invalid and unsafe values do not throw.</returns>
+    public static EpubReference Resolve(string documentPath, string? baseHref, string reference) {
+        if (string.IsNullOrWhiteSpace(baseHref)) return Resolve(documentPath, reference);
+
+        string original = reference?.Trim() ?? string.Empty;
+        if (original.Length == 0) return Invalid(original, EpubReferenceError.Empty);
+        if (ContainsControlCharacter(original)) return Invalid(original, EpubReferenceError.ControlCharacter);
+
+        EpubReference resolvedBase = Resolve(documentPath, baseHref!);
+        if (!resolvedBase.IsValid) return Invalid(original, EpubReferenceError.InvalidBasePath);
+        if (resolvedBase.Kind == EpubReferenceKind.Data) {
+            return Invalid(original, EpubReferenceError.InvalidBasePath);
+        }
+        if (resolvedBase.Kind == EpubReferenceKind.External) {
+            string externalBase = resolvedBase.ResolvedValue ?? string.Empty;
+            if (externalBase.StartsWith("//", StringComparison.Ordinal)) externalBase = "https:" + externalBase;
+            if (!Uri.TryCreate(externalBase, UriKind.Absolute, out Uri? baseUri) ||
+                !Uri.TryCreate(baseUri, original, out Uri? resolvedExternal)) {
+                return Invalid(original, EpubReferenceError.InvalidPath);
+            }
+            return Resolve(documentPath, resolvedExternal.AbsoluteUri);
+        }
+
+        string effectiveBase = resolvedBase.ContainerPath ?? documentPath;
+        SplitReference(baseHref!.Trim(), out string basePathPart, out _, out _);
+        SplitReference(original, out string referencePathPart, out string? query, out string? encodedFragment);
+        if (referencePathPart.Length == 0) {
+            string containerPath = basePathPart.EndsWith("/", StringComparison.Ordinal)
+                ? effectiveBase.TrimEnd('/') + "/"
+                : effectiveBase;
+            return Valid(
+                original,
+                EpubReferenceKind.Container,
+                containerPath,
+                null,
+                query ?? resolvedBase.Query,
+                DecodeFragment(encodedFragment),
+                encodedFragment,
+                false,
+                resolvedBase.IsConforming);
+        }
+        if (basePathPart.EndsWith("/", StringComparison.Ordinal)) {
+            effectiveBase = effectiveBase.TrimEnd('/') + "/__officeimo_epub_base__";
+        }
+        EpubReference result = Resolve(effectiveBase, original);
+        return resolvedBase.IsConforming || !result.IsValid
+            ? result
+            : result.WithConformance(false);
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => ResolvedValue ?? Original;
+
+    private EpubReference WithConformance(bool isConforming) => new EpubReference(
+        Original,
+        Kind,
+        Error,
+        ContainerPath,
+        ExternalUri,
+        Query,
+        Fragment,
+        _encodedFragment,
+        IsContainerRootRelative,
+        isConforming);
+
+    private static EpubReference Valid(
+        string original,
+        EpubReferenceKind kind,
+        string? containerPath,
+        string? externalUri,
+        string? query,
+        string? fragment,
+        string? encodedFragment,
+        bool isContainerRootRelative,
+        bool isConforming) => new EpubReference(
+            original,
+            kind,
+            EpubReferenceError.None,
+            containerPath,
+            externalUri,
+            query,
+            fragment,
+            encodedFragment,
+            isContainerRootRelative,
+            isConforming);
+
+    private static EpubReference Invalid(string original, EpubReferenceError error) => new EpubReference(
+        original,
+        EpubReferenceKind.Invalid,
+        error,
+        null,
+        null,
+        null,
+        null,
+        null,
+        false,
+        false);
+
+    private static void SplitReference(string value, out string path, out string? query, out string? fragment) {
+        int hash = value.IndexOf('#');
+        string withoutFragment = hash < 0 ? value : value.Substring(0, hash);
+        fragment = hash < 0 ? null : value.Substring(hash + 1);
+        int question = withoutFragment.IndexOf('?');
+        path = question < 0 ? withoutFragment : withoutFragment.Substring(0, question);
+        query = question < 0 ? null : withoutFragment.Substring(question + 1);
+    }
+
+    private static string? AppendQuery(string? value, string? query) => value == null
+        ? null
+        : query == null ? value : value + "?" + query;
+
+    private static string? AppendFragment(string? value, string? fragment) => value == null
+        ? null
+        : fragment == null ? value : value + "#" + fragment;
+
+    private static string? RemoveFragment(string? value) {
+        if (value == null) return null;
+        int hash = value.IndexOf('#');
+        return hash < 0 ? value : value.Substring(0, hash);
+    }
+
+    private static string? DecodeFragment(string? value) {
+        if (value == null) return null;
+        try {
+            return Uri.UnescapeDataString(value);
+        } catch {
+            return value;
+        }
+    }
+
+    private static bool TryNormalizeBasePath(string? value, out string normalized) {
+        normalized = value?.Replace('\\', '/').Trim() ?? string.Empty;
+        if (normalized.Length == 0 || normalized.StartsWith("/", StringComparison.Ordinal)) return false;
+        if (LooksLikeWindowsDrivePath(normalized) || Uri.TryCreate(normalized, UriKind.Absolute, out _)) return false;
+        string[] segments = normalized.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0 || segments.Any(static segment => segment == "." || segment == ".." || ContainsControlCharacter(segment))) {
+            return false;
+        }
+        normalized = string.Join("/", segments);
+        return true;
+    }
+
+    private static bool TryDecodePathSegment(string value, out string decoded) {
+        decoded = string.Empty;
+        for (int index = 0; index < value.Length; index++) {
+            if (value[index] != '%') continue;
+            if (index + 2 >= value.Length || !Uri.IsHexDigit(value[index + 1]) || !Uri.IsHexDigit(value[index + 2])) {
+                return false;
+            }
+            index += 2;
+        }
+        try {
+            decoded = Uri.UnescapeDataString(value);
+        } catch {
+            return false;
+        }
+        if (decoded.Length == 0 || decoded.IndexOf('/') >= 0 || decoded.IndexOf('\\') >= 0 || ContainsControlCharacter(decoded)) {
+            return false;
+        }
+        return true;
+    }
+
+    private static bool IsSingleDotSegment(string value) => string.Equals(value, ".", StringComparison.Ordinal)
+        || string.Equals(value, "%2e", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsDoubleDotSegment(string value) => string.Equals(value, "..", StringComparison.Ordinal)
+        || string.Equals(value, ".%2e", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(value, "%2e.", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(value, "%2e%2e", StringComparison.OrdinalIgnoreCase);
+
+    private static bool LooksLikeWindowsDrivePath(string value) => value.Length >= 2
+        && char.IsLetter(value[0])
+        && value[1] == ':';
+
+    private static bool ContainsControlCharacter(string value) {
+        for (int index = 0; index < value.Length; index++) {
+            char character = value[index];
+            if (character <= '\u001F' || character == '\u007F') return true;
+        }
+        return false;
+    }
+}

--- a/OfficeIMO.Epub/EpubReference.cs
+++ b/OfficeIMO.Epub/EpubReference.cs
@@ -21,6 +21,9 @@ public sealed class EpubReference {
         Kind = kind;
         Error = error;
         ContainerPath = containerPath;
+        ContainerUrlPath = kind == EpubReferenceKind.Container && containerPath != null
+            ? EncodeContainerPath(containerPath)
+            : null;
         ExternalUri = externalUri;
         Query = query;
         Fragment = fragment;
@@ -40,6 +43,11 @@ public sealed class EpubReference {
 
     /// <summary>Case-sensitive normalized archive path for a container reference.</summary>
     public string? ContainerPath { get; }
+
+    /// <summary>
+    /// URL-encoded form of <see cref="ContainerPath"/> for serialization in links and media references.
+    /// </summary>
+    public string? ContainerUrlPath { get; }
 
     /// <summary>External or data URL, including its query and fragment when present.</summary>
     public string? ExternalUri { get; }
@@ -68,7 +76,7 @@ public sealed class EpubReference {
     public string? Target {
         get {
             if (Kind == EpubReferenceKind.Container) {
-                return AppendQuery(ContainerPath, Query);
+                return AppendQuery(ContainerUrlPath, Query);
             }
             if (Kind == EpubReferenceKind.External || Kind == EpubReferenceKind.Data) {
                 return RemoveFragment(ExternalUri);
@@ -81,7 +89,7 @@ public sealed class EpubReference {
     public string? ResolvedValue {
         get {
             if (Kind == EpubReferenceKind.Container) {
-                return AppendFragment(AppendQuery(ContainerPath, Query), _encodedFragment);
+                return AppendFragment(AppendQuery(ContainerUrlPath, Query), _encodedFragment);
             }
             return ExternalUri;
         }
@@ -334,6 +342,10 @@ public sealed class EpubReference {
             return value;
         }
     }
+
+    private static string EncodeContainerPath(string value) => string.Join(
+        "/",
+        value.Split(new[] { '/' }, StringSplitOptions.None).Select(Uri.EscapeDataString));
 
     private static bool TryNormalizeBasePath(string? value, out string normalized) {
         normalized = value?.Replace('\\', '/').Trim() ?? string.Empty;

--- a/OfficeIMO.Epub/EpubReference.cs
+++ b/OfficeIMO.Epub/EpubReference.cs
@@ -62,8 +62,9 @@ public sealed class EpubReference {
     public bool IsContainerRootRelative { get; }
 
     /// <summary>
-    /// Whether the reference conforms to EPUB OCF URL restrictions. A safely resolved
-    /// root-relative container reference is exposed with this value set to <see langword="false"/>.
+    /// Whether the reference conforms to EPUB OCF URL restrictions. Safely resolved
+    /// root-relative or backslash-separated container references are exposed with this
+    /// value set to <see langword="false"/>.
     /// </summary>
     public bool IsConforming { get; }
 
@@ -154,6 +155,8 @@ public sealed class EpubReference {
                 true);
         }
 
+        bool hasRawBackslash = path.IndexOf('\\') >= 0;
+        if (hasRawBackslash) path = path.Replace('\\', '/');
         bool isRootRelative = path.StartsWith("/", StringComparison.Ordinal);
         string relativePath = isRootRelative ? path.TrimStart('/') : path;
         var segments = new List<string>();
@@ -215,7 +218,7 @@ public sealed class EpubReference {
                 fragment,
                 encodedFragment,
                 isRootRelative,
-                !isRootRelative);
+                !isRootRelative && !hasRawBackslash);
         }
         return Valid(
             original,
@@ -226,7 +229,7 @@ public sealed class EpubReference {
             fragment,
             encodedFragment,
             isRootRelative,
-            !isRootRelative);
+            !isRootRelative && !hasRawBackslash);
     }
 
     /// <summary>

--- a/OfficeIMO.Epub/EpubReference.cs
+++ b/OfficeIMO.Epub/EpubReference.cs
@@ -164,7 +164,18 @@ public sealed class EpubReference {
         }
 
         if (relativePath.Length == 0) {
-            if (isRootRelative) return Invalid(original, EpubReferenceError.InvalidPath);
+            if (isRootRelative) {
+                return Valid(
+                    original,
+                    EpubReferenceKind.Container,
+                    string.Empty,
+                    null,
+                    query,
+                    fragment,
+                    encodedFragment,
+                    true,
+                    false);
+            }
             if (!TryNormalizeBasePath(normalizedBase, out string currentPath)) {
                 return Invalid(original, EpubReferenceError.InvalidBasePath);
             }
@@ -194,7 +205,18 @@ public sealed class EpubReference {
             segments.Add(decodedSegment);
         }
 
-        if (segments.Count == 0) return Invalid(original, EpubReferenceError.InvalidPath);
+        if (segments.Count == 0) {
+            return Valid(
+                original,
+                EpubReferenceKind.Container,
+                string.Empty,
+                null,
+                query,
+                fragment,
+                encodedFragment,
+                isRootRelative,
+                !isRootRelative);
+        }
         return Valid(
             original,
             EpubReferenceKind.Container,
@@ -255,7 +277,9 @@ public sealed class EpubReference {
                 resolvedBase.IsConforming);
         }
         if (basePathPart.EndsWith("/", StringComparison.Ordinal)) {
-            effectiveBase = effectiveBase.TrimEnd('/') + "/__officeimo_epub_base__";
+            effectiveBase = effectiveBase.Length == 0
+                ? "__officeimo_epub_base__"
+                : effectiveBase.TrimEnd('/') + "/__officeimo_epub_base__";
         }
         EpubReference result = Resolve(effectiveBase, original);
         return resolvedBase.IsConforming || !result.IsValid

--- a/OfficeIMO.Epub/EpubReferenceError.cs
+++ b/OfficeIMO.Epub/EpubReferenceError.cs
@@ -1,0 +1,25 @@
+namespace OfficeIMO.Epub;
+
+/// <summary>Describes why an EPUB URL reference could not be resolved.</summary>
+public enum EpubReferenceError {
+    /// <summary>The reference resolved successfully.</summary>
+    None,
+
+    /// <summary>The reference value was empty.</summary>
+    Empty,
+
+    /// <summary>The container base path was not a safe archive path.</summary>
+    InvalidBasePath,
+
+    /// <summary>The reference contains a control character.</summary>
+    ControlCharacter,
+
+    /// <summary>The reference uses the prohibited <c>file:</c> URL scheme.</summary>
+    FileUrl,
+
+    /// <summary>The reference contains an invalid or ambiguous path encoding.</summary>
+    InvalidPath,
+
+    /// <summary>The reference attempts to traverse above the EPUB container root.</summary>
+    EscapesContainer
+}

--- a/OfficeIMO.Epub/EpubReferenceKind.cs
+++ b/OfficeIMO.Epub/EpubReferenceKind.cs
@@ -1,0 +1,16 @@
+namespace OfficeIMO.Epub;
+
+/// <summary>Identifies how an EPUB URL reference resolves.</summary>
+public enum EpubReferenceKind {
+    /// <summary>The reference could not be resolved safely.</summary>
+    Invalid,
+
+    /// <summary>The reference resolves to a case-sensitive path in the EPUB container.</summary>
+    Container,
+
+    /// <summary>The reference resolves outside the EPUB container.</summary>
+    External,
+
+    /// <summary>The reference is an embedded <c>data:</c> URL.</summary>
+    Data
+}

--- a/OfficeIMO.Epub/EpubResource.cs
+++ b/OfficeIMO.Epub/EpubResource.cs
@@ -7,16 +7,16 @@ public sealed class EpubResource {
     /// <summary>OPF manifest item identifier.</summary>
     public string Id { get; internal set; } = string.Empty;
 
-    /// <summary>Normalized archive path or absolute remote URI.</summary>
+    /// <summary>Normalized archive path or external URL.</summary>
     public string Path { get; internal set; } = string.Empty;
 
     /// <summary>Original manifest href.</summary>
     public string? Href { get; internal set; }
 
-    /// <summary>Whether this manifest item references an absolute remote resource.</summary>
+    /// <summary>Whether this manifest item references an external resource.</summary>
     public bool IsRemote { get; internal set; }
 
-    /// <summary>Absolute remote URI when <see cref="IsRemote"/> is true.</summary>
+    /// <summary>External URL, including a scheme-relative URL, when <see cref="IsRemote"/> is true.</summary>
     public string? RemoteUri { get; internal set; }
 
     /// <summary>Declared media type.</summary>

--- a/OfficeIMO.Epub/README.md
+++ b/OfficeIMO.Epub/README.md
@@ -59,12 +59,13 @@ EpubReference reference = EpubReference.Resolve(
     "../images/cover%20art.png?size=large#front");
 
 if (reference.Kind == EpubReferenceKind.Container) {
-    Console.WriteLine(reference.ContainerPath);  // EPUB/images/cover art.png
-    Console.WriteLine(reference.ResolvedValue);  // path plus query and fragment
+    Console.WriteLine(reference.ContainerPath);     // decoded ZIP lookup path
+    Console.WriteLine(reference.ContainerUrlPath);  // URL-encoded link path
+    Console.WriteLine(reference.ResolvedValue);     // encoded path plus query and fragment
 }
 ```
 
-Use the three-argument overload with `chapter.BaseHref` when resolving URLs found in chapter markup. Results distinguish container, external, embedded data, and invalid references without performing network or file-system access. Container paths remain case-sensitive. Root-relative references are resolved safely but marked non-conforming; `file:` URLs, ambiguous encoded separators, and paths that escape the container are rejected.
+Use the three-argument overload with `chapter.BaseHref` when resolving URLs found in chapter markup. Results distinguish container, external, embedded data, and invalid references without performing network or file-system access. `ContainerPath` remains case-sensitive and decoded for ZIP lookup, while `ContainerUrlPath`, `Target`, and `ResolvedValue` preserve a safe URL serialization. Root-relative references are resolved safely but marked non-conforming; `file:` URLs, ambiguous encoded separators, and paths that escape the container are rejected.
 
 ## What it does
 

--- a/OfficeIMO.Epub/README.md
+++ b/OfficeIMO.Epub/README.md
@@ -51,15 +51,31 @@ foreach (EpubResource resource in book.Resources) {
 
 Manifest metadata is returned even when payload loading is disabled. Payload inclusion is opt-in and bounded per resource, in total, and by resource count; skipped payloads produce warnings.
 
+### Resolve chapter-relative references
+
+```csharp
+EpubReference reference = EpubReference.Resolve(
+    "EPUB/text/chapter.xhtml",
+    "../images/cover%20art.png?size=large#front");
+
+if (reference.Kind == EpubReferenceKind.Container) {
+    Console.WriteLine(reference.ContainerPath);  // EPUB/images/cover art.png
+    Console.WriteLine(reference.ResolvedValue);  // path plus query and fragment
+}
+```
+
+Use the three-argument overload with `chapter.BaseHref` when resolving URLs found in chapter markup. Results distinguish container, external, embedded data, and invalid references without performing network or file-system access. Container paths remain case-sensitive. Root-relative references are resolved safely but marked non-conforming; `file:` URLs, ambiguous encoded separators, and paths that escape the container are rejected.
+
 ## What it does
 
 - Opens EPUB files as ZIP containers.
 - Parses `META-INF/container.xml` and OPF package metadata.
 - Follows OPF manifest and spine ordering.
-- Reads nav/NCX labels for chapter titles when available.
+- Reads hierarchical EPUB 3 navigation and EPUB 2 NCX labels when available.
 - Extracts chapter text from XHTML/XML ASTs.
 - Returns deterministic OPF manifest resources with optional bounded payloads.
-- Emits extraction warnings for malformed or unreadable content.
+- Resolves package, navigation, and content references through a shared typed URL contract.
+- Emits structured diagnostics and warning messages for malformed, unsafe, encrypted, fixed-layout, or unreadable content.
 
 ## Examples
 

--- a/OfficeIMO.Html.Tests/Html.Core.cs
+++ b/OfficeIMO.Html.Tests/Html.Core.cs
@@ -371,6 +371,27 @@ public sealed class HtmlCoreTests {
     }
 
     [Fact]
+    public void HtmlUrlPolicyEvaluator_TransformsResolvedUrlsAndRevalidatesTransformOutput() {
+        var policy = HtmlUrlPolicy.CreateWebOnlyProfile();
+        policy.ResolvedUrlTransform = value => value.Replace(
+            "https://example.test/book/",
+            "/library/book::");
+
+        string resolved = HtmlUrlPolicyEvaluator.ResolveUrl(
+            "images/cover.png",
+            new Uri("https://example.test/book/"),
+            policy);
+
+        Assert.Equal("/library/book::images/cover.png", resolved);
+        Assert.NotNull(policy.Clone().ResolvedUrlTransform);
+
+        policy.ResolvedUrlTransform = static _ => "javascript:alert(1)";
+        Assert.Equal(
+            string.Empty,
+            HtmlUrlPolicyEvaluator.ResolveUrl("images/cover.png", new Uri("https://example.test/book/"), policy));
+    }
+
+    [Fact]
     public void HtmlUrlPolicyEvaluator_ResolvesProtocolRelativeUrlsAgainstWebSchemeWhenBaseIsFile() {
         var policy = HtmlUrlPolicy.CreateWebOnlyProfile();
 

--- a/OfficeIMO.Html/Policies/HtmlUrlPolicy.cs
+++ b/OfficeIMO.Html/Policies/HtmlUrlPolicy.cs
@@ -58,6 +58,13 @@ public sealed class HtmlUrlPolicy {
     public bool RestrictUrlSchemes { get; set; }
 
     /// <summary>
+    /// Optional trusted transform applied after a URL passes policy checks and base-URI resolution.
+    /// Return <see langword="null"/> or an empty string to reject the resolved URL. Transformed
+    /// values are checked against this policy again before use.
+    /// </summary>
+    public Func<string, string?>? ResolvedUrlTransform { get; set; }
+
+    /// <summary>
     /// URL schemes allowed when <see cref="RestrictUrlSchemes"/> is enabled.
     /// </summary>
     public HashSet<string> AllowedUrlSchemes { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
@@ -76,7 +83,8 @@ public sealed class HtmlUrlPolicy {
             AllowMailtoUrls = AllowMailtoUrls,
             AllowDataUrls = AllowDataUrls,
             AllowProtocolRelativeUrls = AllowProtocolRelativeUrls,
-            RestrictUrlSchemes = RestrictUrlSchemes
+            RestrictUrlSchemes = RestrictUrlSchemes,
+            ResolvedUrlTransform = ResolvedUrlTransform
         };
 
         clone.AllowedUrlSchemes.Clear();

--- a/OfficeIMO.Html/Policies/HtmlUrlPolicyEvaluator.cs
+++ b/OfficeIMO.Html/Policies/HtmlUrlPolicyEvaluator.cs
@@ -14,27 +14,40 @@ public static class HtmlUrlPolicyEvaluator {
     /// Resolves a raw URL against an optional base URI and returns an empty string when policy rejects it.
     /// </summary>
     public static string ResolveUrl(string? rawUrl, Uri? baseUri, HtmlUrlPolicy? policy, bool allowEmptyFragment = true) {
-        var evaluation = Evaluate(rawUrl, policy, allowEmptyFragment);
+        var effectivePolicy = policy ?? HtmlUrlPolicy.CreateOfficeIMOProfile();
+        var evaluation = Evaluate(rawUrl, effectivePolicy, allowEmptyFragment);
         if (!evaluation.IsAllowed) {
             return string.Empty;
         }
 
         string candidate = evaluation.NormalizedUrl;
         if (candidate.StartsWith("//", StringComparison.Ordinal)) {
-            return ResolveProtocolRelativeUrl(candidate, baseUri, policy ?? HtmlUrlPolicy.CreateOfficeIMOProfile());
+            return ApplyResolvedUrlTransform(
+                ResolveProtocolRelativeUrl(candidate, baseUri, effectivePolicy),
+                effectivePolicy,
+                allowEmptyFragment);
         }
 
         if (!evaluation.AllowBaseUriResolution || baseUri == null) {
-            return candidate;
+            return ApplyResolvedUrlTransform(candidate, effectivePolicy, allowEmptyFragment);
         }
 
         if (!Uri.TryCreate(baseUri, candidate, out var resolved)) {
-            return candidate;
+            return ApplyResolvedUrlTransform(candidate, effectivePolicy, allowEmptyFragment);
         }
 
-        return IsAllowedResolvedUri(resolved, policy ?? HtmlUrlPolicy.CreateOfficeIMOProfile())
+        string resolvedValue = IsAllowedResolvedUri(resolved, effectivePolicy)
             ? resolved.AbsoluteUri
             : string.Empty;
+        return ApplyResolvedUrlTransform(resolvedValue, effectivePolicy, allowEmptyFragment);
+    }
+
+    private static string ApplyResolvedUrlTransform(string value, HtmlUrlPolicy policy, bool allowEmptyFragment) {
+        if (value.Length == 0 || policy.ResolvedUrlTransform == null) return value;
+        string? transformed = policy.ResolvedUrlTransform(value);
+        if (string.IsNullOrWhiteSpace(transformed)) return string.Empty;
+        HtmlUrlEvaluation evaluation = Evaluate(transformed, policy, allowEmptyFragment);
+        return evaluation.IsAllowed ? evaluation.NormalizedUrl : string.Empty;
     }
 
     private static string ResolveProtocolRelativeUrl(string candidate, Uri? baseUri, HtmlUrlPolicy policy) {

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.Media.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.Media.cs
@@ -5,6 +5,31 @@ using OfficeIMO.Markdown;
 namespace OfficeIMO.Markdown.Html;
 
 internal sealed partial class HtmlToMarkdownConverter {
+    private static IEnumerable<IMarkdownBlock> ConvertMediaElement(IElement element, ConversionContext context) {
+        if (!context.Options.PreserveUnsupportedBlocks) {
+            return ConvertUnknownElementChildrenToBlocks(element, context);
+        }
+
+        IElement clone = (IElement)element.Clone(deep: true);
+        ResolveMediaUrlAttribute(clone, "src", context);
+        ResolveMediaUrlAttribute(clone, "poster", context);
+        foreach (IElement child in clone.QuerySelectorAll("source[src], track[src]")) {
+            ResolveMediaUrlAttribute(child, "src", context);
+        }
+        return new IMarkdownBlock[] { new HtmlRawBlock(clone.OuterHtml) };
+    }
+
+    private static void ResolveMediaUrlAttribute(IElement element, string attributeName, ConversionContext context) {
+        string? value = element.GetAttribute(attributeName);
+        if (string.IsNullOrWhiteSpace(value)) return;
+        string resolved = ResolveUrl(value, context);
+        if (resolved.Length == 0) {
+            element.RemoveAttribute(attributeName);
+        } else {
+            element.SetAttribute(attributeName, resolved);
+        }
+    }
+
     private static IEnumerable<IMarkdownBlock> ConvertImageElement(IElement element, ConversionContext context) {
         if (!TryCreateImageBlock(element, context, out var image)) {
             return Array.Empty<IMarkdownBlock>();

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.cs
@@ -224,6 +224,9 @@ internal sealed partial class HtmlToMarkdownConverter {
                 return ConvertPictureElement(element, context);
             case "FIGURE":
                 return ConvertFigureElement(element, context);
+            case "AUDIO":
+            case "VIDEO":
+                return ConvertMediaElement(element, context);
             case "A":
                 if (TryCreateLinkedImageBlockFromAnchor(element, context, out var linkedImage)) {
                     return new IMarkdownBlock[] { linkedImage };

--- a/OfficeIMO.Reader.Epub/EpubReaderAdapter.Document.cs
+++ b/OfficeIMO.Reader.Epub/EpubReaderAdapter.Document.cs
@@ -71,15 +71,26 @@ internal static partial class EpubReaderAdapter {
                     virtualPath,
                     readerOptions,
                     cancellationToken: cancellationToken);
-                ResolveEpubChapterLinks(source.Path, chapter.Path, htmlResult.Links);
+                IReadOnlyList<OfficeDocumentLink> resolvedLinks = ResolveEpubChapterLinks(
+                    source.Path,
+                    chapter,
+                    htmlResult.Links,
+                    diagnostics);
                 string prefix = "epub-chapter-" + (chapterIndex + 1).ToString("D4", CultureInfo.InvariantCulture) + "-";
                 PrefixHtmlProjection(prefix, htmlResult, ref tableIndex);
                 chapterBlocks.AddRange(htmlResult.Blocks);
                 chapterTables.AddRange(htmlResult.Tables);
-                chapterLinks.AddRange(htmlResult.Links);
+                chapterLinks.AddRange(resolvedLinks);
                 chapterForms.AddRange(htmlResult.Forms);
-                visuals.AddRange(htmlResult.Visuals);
-                AddEpubChapterAssets(source.Path, chapter.Path, htmlResult.Assets, assets, chapterAssets);
+                AddEpubChapterAssets(source.Path, chapter, htmlResult.Assets, assets, chapterAssets, diagnostics);
+                IReadOnlyList<ReaderVisual> resolvedVisuals = ResolveEpubChapterVisuals(
+                    source.Path,
+                    chapter,
+                    htmlResult.Visuals,
+                    assets,
+                    chapterAssets,
+                    diagnostics);
+                visuals.AddRange(resolvedVisuals);
                 diagnostics.AddRange(htmlResult.Diagnostics.Where(static diagnostic =>
                     !string.Equals(diagnostic.Code, "ocr-needed", StringComparison.Ordinal)));
             }
@@ -159,128 +170,6 @@ internal static partial class EpubReaderAdapter {
         return pages;
     }
 
-    private static IEnumerable<OfficeDocumentAsset> BuildEpubAssets(EpubDocument document, string sourcePath) {
-        int assetIndex = 0;
-        foreach (EpubResource resource in document.Resources) {
-            if (string.IsNullOrWhiteSpace(resource.MediaType) || !resource.MediaType!.StartsWith("image/", StringComparison.OrdinalIgnoreCase)) continue;
-            string id = "epub-image-" + assetIndex.ToString("D4", CultureInfo.InvariantCulture);
-            string resourceLocation = resource.IsRemote && !string.IsNullOrWhiteSpace(resource.RemoteUri)
-                ? resource.RemoteUri!
-                : BuildVirtualPath(sourcePath, resource.Path);
-            string extensionSource = resource.Path;
-            if (resource.IsRemote && Uri.TryCreate(resource.RemoteUri, UriKind.Absolute, out Uri? remoteUri)) {
-                extensionSource = remoteUri.AbsolutePath;
-            }
-            string extension = Path.GetExtension(extensionSource);
-            yield return new OfficeDocumentAsset {
-                Id = id,
-                Kind = "image",
-                MediaType = resource.MediaType,
-                Extension = string.IsNullOrWhiteSpace(extension) ? null : extension,
-                FileName = OfficeDocumentAssetNaming.BuildFileName(id, extension),
-                LengthBytes = resource.LengthBytes,
-                PayloadHash = resource.Data == null ? null : ComputeEpubPayloadHash(resource.Data),
-                PayloadBytes = resource.Data,
-                SourceObjectId = resource.Id,
-                Location = new ReaderLocation {
-                    Path = resourceLocation,
-                    SourceBlockKind = "image",
-                    BlockAnchor = id
-                }
-            };
-            assetIndex++;
-        }
-    }
-
-    private static void AddEpubChapterAssets(
-        string sourcePath,
-        string chapterPath,
-        IReadOnlyList<OfficeDocumentAsset> htmlAssets,
-        List<OfficeDocumentAsset> documentAssets,
-        List<OfficeDocumentAsset> chapterAssets) {
-        foreach (OfficeDocumentAsset htmlAsset in htmlAssets) {
-            OfficeDocumentAsset? mappedAsset = null;
-            if (htmlAsset.PayloadBytes == null) {
-                string? resourceLocation = ResolveEpubResourceLocation(sourcePath, chapterPath, htmlAsset.SourceObjectId);
-                if (!string.IsNullOrWhiteSpace(resourceLocation)) {
-                    mappedAsset = documentAssets.FirstOrDefault(asset => string.Equals(asset.Location.Path, resourceLocation, StringComparison.Ordinal));
-                }
-            }
-
-            if (mappedAsset == null) {
-                mappedAsset = htmlAsset;
-                documentAssets.Add(mappedAsset);
-            }
-            if (!chapterAssets.Contains(mappedAsset)) chapterAssets.Add(mappedAsset);
-        }
-    }
-
-    private static string? ResolveEpubResourceLocation(string sourcePath, string chapterPath, string? sourceObjectId) {
-        if (string.IsNullOrWhiteSpace(sourceObjectId)) return null;
-        string candidate = sourceObjectId!.Trim();
-        if (candidate.StartsWith("data:", StringComparison.OrdinalIgnoreCase)) return null;
-        if (Uri.TryCreate(candidate, UriKind.Absolute, out Uri? absoluteUri) && !absoluteUri.IsFile) {
-            return candidate;
-        }
-        string? resourcePath = ResolveEpubResourcePath(chapterPath, candidate);
-        return string.IsNullOrWhiteSpace(resourcePath) ? null : BuildVirtualPath(sourcePath, resourcePath!);
-    }
-
-    private static string? ResolveEpubResourcePath(string chapterPath, string? sourceObjectId) {
-        if (string.IsNullOrWhiteSpace(sourceObjectId)) return null;
-        string candidate = sourceObjectId!.Trim();
-        int fragmentIndex = candidate.IndexOfAny(new[] { '#', '?' });
-        if (fragmentIndex >= 0) candidate = candidate.Substring(0, fragmentIndex);
-        if (candidate.Length == 0
-            || candidate.StartsWith("data:", StringComparison.OrdinalIgnoreCase)
-            || candidate.StartsWith("//", StringComparison.Ordinal)
-            || Uri.TryCreate(candidate, UriKind.Absolute, out _)) {
-            return null;
-        }
-
-        try {
-            candidate = Uri.UnescapeDataString(candidate).Replace('\\', '/');
-        } catch {
-            candidate = candidate.Replace('\\', '/');
-        }
-
-        string combined;
-        if (candidate.StartsWith("/", StringComparison.Ordinal)) {
-            combined = candidate.TrimStart('/');
-        } else {
-            int lastSlash = chapterPath.LastIndexOf('/');
-            string chapterDirectory = lastSlash < 0 ? string.Empty : chapterPath.Substring(0, lastSlash + 1);
-            combined = chapterDirectory + candidate;
-        }
-
-        var segments = new List<string>();
-        foreach (string segment in combined.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries)) {
-            if (segment == ".") continue;
-            if (segment == "..") {
-                if (segments.Count == 0) return null;
-                segments.RemoveAt(segments.Count - 1);
-            } else {
-                segments.Add(segment);
-            }
-        }
-        return segments.Count == 0 ? null : string.Join("/", segments);
-    }
-
-    private static void ResolveEpubChapterLinks(
-        string sourcePath,
-        string chapterPath,
-        IReadOnlyList<OfficeDocumentLink> links) {
-        foreach (OfficeDocumentLink link in links) {
-            if (string.IsNullOrWhiteSpace(link.Uri)) continue;
-            string rawUri = link.Uri!.Trim();
-            string? resourcePath = ResolveEpubResourcePath(chapterPath, rawUri);
-            if (resourcePath == null) continue;
-            int suffixIndex = rawUri.IndexOfAny(new[] { '?', '#' });
-            string suffix = suffixIndex < 0 ? string.Empty : rawUri.Substring(suffixIndex);
-            link.Uri = BuildVirtualPath(sourcePath, resourcePath) + suffix;
-        }
-    }
-
     private static void PrefixHtmlProjection(string prefix, OfficeDocumentReadResult result, ref int tableIndex) {
         foreach (OfficeDocumentBlock block in result.Blocks) {
             block.Id = prefix + block.Id;
@@ -313,8 +202,4 @@ internal static partial class EpubReaderAdapter {
         }
     }
 
-    private static string ComputeEpubPayloadHash(byte[] bytes) {
-        using var stream = new MemoryStream(bytes, writable: false);
-        return ComputeSha256Hex(stream);
-    }
 }

--- a/OfficeIMO.Reader.Epub/EpubReaderAdapter.PackageProjection.cs
+++ b/OfficeIMO.Reader.Epub/EpubReaderAdapter.PackageProjection.cs
@@ -173,6 +173,7 @@ internal static partial class EpubReaderAdapter {
     };
 
     private static string BuildEpubLocationPath(string sourcePath, string path) {
+        if (path.StartsWith("//", StringComparison.Ordinal)) return path;
         if (Uri.TryCreate(path, UriKind.Absolute, out Uri? uri) && !uri.IsFile) return path;
         return BuildVirtualPath(sourcePath, path);
     }

--- a/OfficeIMO.Reader.Epub/EpubReaderAdapter.References.cs
+++ b/OfficeIMO.Reader.Epub/EpubReaderAdapter.References.cs
@@ -110,12 +110,13 @@ internal static partial class EpubReaderAdapter {
         if (reference.Kind == EpubReferenceKind.External) {
             return includeFragment ? reference.ResolvedValue : reference.Target;
         }
-        if (string.IsNullOrWhiteSpace(reference.ContainerPath)) return null;
+        if (string.IsNullOrWhiteSpace(reference.ContainerPath)
+            || string.IsNullOrWhiteSpace(reference.ContainerUrlPath)) return null;
 
-        string location = BuildVirtualPath(sourcePath, reference.ContainerPath!);
+        string location = BuildVirtualPath(sourcePath, reference.ContainerUrlPath!);
         string? resolved = includeFragment ? reference.ResolvedValue : reference.Target;
-        if (!string.IsNullOrWhiteSpace(resolved) && resolved!.Length > reference.ContainerPath!.Length) {
-            location += resolved.Substring(reference.ContainerPath.Length);
+        if (!string.IsNullOrWhiteSpace(resolved) && resolved!.Length > reference.ContainerUrlPath!.Length) {
+            location += resolved.Substring(reference.ContainerUrlPath.Length);
         }
         return location;
     }

--- a/OfficeIMO.Reader.Epub/EpubReaderAdapter.References.cs
+++ b/OfficeIMO.Reader.Epub/EpubReaderAdapter.References.cs
@@ -64,6 +64,10 @@ internal static partial class EpubReaderAdapter {
                 resolvedVisuals.Add(visual);
                 continue;
             }
+            if (string.Equals(visual.SourceName, "data-uri", StringComparison.Ordinal)) {
+                resolvedVisuals.Add(visual);
+                continue;
+            }
             EpubReference reference = EpubReference.Resolve(chapter.Path, chapter.BaseHref, visual.SourceName!);
             AddEpubReferenceDiagnostic(sourcePath, chapter, reference, diagnostics);
             if (!reference.IsValid) continue;

--- a/OfficeIMO.Reader.Epub/EpubReaderAdapter.References.cs
+++ b/OfficeIMO.Reader.Epub/EpubReaderAdapter.References.cs
@@ -1,0 +1,167 @@
+using OfficeIMO.Epub;
+using OfficeIMO.Reader;
+using System.Linq;
+
+namespace OfficeIMO.Reader.Epub;
+
+internal static partial class EpubReaderAdapter {
+    private static string? ResolveEpubMarkdownReference(
+        string sourcePath,
+        EpubChapter chapter,
+        string value) {
+        EpubReference reference = EpubReference.Resolve(chapter.Path, chapter.BaseHref, value);
+        if (!reference.IsValid) return null;
+        if (reference.Kind == EpubReferenceKind.Data) return reference.ResolvedValue;
+        string? location = BuildEpubResolvedLocation(sourcePath, reference, includeFragment: true);
+        return location?
+            .Replace(" ", "%20")
+            .Replace("(", "%28")
+            .Replace(")", "%29");
+    }
+
+    private static IReadOnlyList<OfficeDocumentLink> ResolveEpubChapterLinks(
+        string sourcePath,
+        EpubChapter chapter,
+        IReadOnlyList<OfficeDocumentLink> links,
+        List<OfficeDocumentDiagnostic> diagnostics) {
+        var resolvedLinks = new List<OfficeDocumentLink>(links.Count);
+        foreach (OfficeDocumentLink link in links) {
+            string? rawReference = !string.IsNullOrWhiteSpace(link.Uri)
+                ? link.Uri
+                : !string.IsNullOrWhiteSpace(link.DestinationName)
+                    ? "#" + link.DestinationName
+                    : null;
+            if (rawReference == null) {
+                resolvedLinks.Add(link);
+                continue;
+            }
+
+            EpubReference reference = EpubReference.Resolve(chapter.Path, chapter.BaseHref, rawReference);
+            AddEpubReferenceDiagnostic(sourcePath, chapter, reference, diagnostics);
+            if (!reference.IsValid) continue;
+            if (reference.Kind == EpubReferenceKind.Data) {
+                resolvedLinks.Add(link);
+                continue;
+            }
+
+            string? location = BuildEpubResolvedLocation(sourcePath, reference, includeFragment: true);
+            if (!string.IsNullOrWhiteSpace(location)) link.Uri = location;
+            resolvedLinks.Add(link);
+        }
+        return resolvedLinks;
+    }
+
+    private static IReadOnlyList<ReaderVisual> ResolveEpubChapterVisuals(
+        string sourcePath,
+        EpubChapter chapter,
+        IReadOnlyList<ReaderVisual> visuals,
+        List<OfficeDocumentAsset> documentAssets,
+        List<OfficeDocumentAsset> chapterAssets,
+        List<OfficeDocumentDiagnostic> diagnostics) {
+        var resolvedVisuals = new List<ReaderVisual>(visuals.Count);
+        foreach (ReaderVisual visual in visuals) {
+            if (string.IsNullOrWhiteSpace(visual.SourceName)) {
+                resolvedVisuals.Add(visual);
+                continue;
+            }
+            EpubReference reference = EpubReference.Resolve(chapter.Path, chapter.BaseHref, visual.SourceName!);
+            AddEpubReferenceDiagnostic(sourcePath, chapter, reference, diagnostics);
+            if (!reference.IsValid) continue;
+            if (reference.Kind == EpubReferenceKind.Data) {
+                resolvedVisuals.Add(visual);
+                continue;
+            }
+
+            string? location = BuildEpubResolvedLocation(sourcePath, reference, includeFragment: true);
+            if (!string.IsNullOrWhiteSpace(location)) visual.SourceName = location;
+            OfficeDocumentAsset? asset = FindEpubAsset(sourcePath, reference, documentAssets);
+            if (asset != null && !chapterAssets.Contains(asset)) chapterAssets.Add(asset);
+            resolvedVisuals.Add(visual);
+        }
+        return resolvedVisuals;
+    }
+
+    private static OfficeDocumentAsset? FindEpubAsset(
+        string sourcePath,
+        EpubReference reference,
+        IReadOnlyList<OfficeDocumentAsset> assets) {
+        string? targetLocation = BuildEpubResolvedLocation(sourcePath, reference, includeFragment: false);
+        if (string.IsNullOrWhiteSpace(targetLocation)) return null;
+
+        OfficeDocumentAsset? exact = assets.FirstOrDefault(asset =>
+            string.Equals(asset.Location.Path, targetLocation, StringComparison.Ordinal));
+        if (exact != null || reference.Kind != EpubReferenceKind.Container || string.IsNullOrWhiteSpace(reference.ContainerPath)) {
+            return exact;
+        }
+
+        string packageLocation = BuildVirtualPath(sourcePath, reference.ContainerPath!);
+        return assets.FirstOrDefault(asset => string.Equals(asset.Location.Path, packageLocation, StringComparison.Ordinal));
+    }
+
+    private static string? BuildEpubResolvedLocation(
+        string sourcePath,
+        EpubReference reference,
+        bool includeFragment) {
+        if (!reference.IsValid || reference.Kind == EpubReferenceKind.Data) return null;
+        if (reference.Kind == EpubReferenceKind.External) {
+            return includeFragment ? reference.ResolvedValue : reference.Target;
+        }
+        if (string.IsNullOrWhiteSpace(reference.ContainerPath)) return null;
+
+        string location = BuildVirtualPath(sourcePath, reference.ContainerPath!);
+        string? resolved = includeFragment ? reference.ResolvedValue : reference.Target;
+        if (!string.IsNullOrWhiteSpace(resolved) && resolved!.Length > reference.ContainerPath!.Length) {
+            location += resolved.Substring(reference.ContainerPath.Length);
+        }
+        return location;
+    }
+
+    private static void AddEpubReferenceDiagnostic(
+        string sourcePath,
+        EpubChapter chapter,
+        EpubReference reference,
+        List<OfficeDocumentDiagnostic> diagnostics) {
+        string? code = null;
+        string? message = null;
+        OfficeDocumentDiagnosticCategory category = OfficeDocumentDiagnosticCategory.Parsing;
+        var attributes = new Dictionary<string, string>(StringComparer.Ordinal) {
+            ["reference"] = reference.Original,
+            ["referenceKind"] = reference.Kind.ToString(),
+            ["referenceError"] = reference.Error.ToString()
+        };
+
+        if (!reference.IsValid && reference.Error != EpubReferenceError.Empty) {
+            bool unsafeReference = reference.Error == EpubReferenceError.EscapesContainer
+                || reference.Error == EpubReferenceError.FileUrl
+                || reference.Error == EpubReferenceError.ControlCharacter
+                || reference.Error == EpubReferenceError.InvalidPath;
+            code = unsafeReference ? "epub.reference.unsafe" : "epub.reference.invalid";
+            category = unsafeReference ? OfficeDocumentDiagnosticCategory.Security : OfficeDocumentDiagnosticCategory.Parsing;
+            message = $"Ignored EPUB reference '{reference.Original}' because it could not be resolved safely ({reference.Error}).";
+        } else if (reference.IsValid && !reference.IsConforming) {
+            code = "epub.reference.non-conforming";
+            message = $"Resolved non-conforming EPUB reference '{reference.Original}' within the container.";
+            if (!string.IsNullOrWhiteSpace(reference.ResolvedValue)) attributes["resolvedValue"] = reference.ResolvedValue!;
+        }
+        if (code == null || message == null) return;
+
+        string chapterLocation = BuildVirtualPath(sourcePath, chapter.Path);
+        bool duplicate = diagnostics.Any(diagnostic =>
+            string.Equals(diagnostic.Code, code, StringComparison.Ordinal)
+            && string.Equals(diagnostic.Location?.Path, chapterLocation, StringComparison.Ordinal)
+            && diagnostic.Attributes.TryGetValue("reference", out string? existing)
+            && string.Equals(existing, reference.Original, StringComparison.Ordinal));
+        if (duplicate) return;
+
+        diagnostics.Add(new OfficeDocumentDiagnostic {
+            Severity = OfficeDocumentDiagnosticSeverity.Warning,
+            Category = category,
+            Code = code,
+            Message = message,
+            Source = "OfficeIMO.Reader.Epub",
+            IsRecoverable = true,
+            Location = new ReaderLocation { Path = chapterLocation, SourceBlockKind = "chapter-reference" },
+            Attributes = attributes
+        });
+    }
+}

--- a/OfficeIMO.Reader.Epub/EpubReaderAdapter.Resources.cs
+++ b/OfficeIMO.Reader.Epub/EpubReaderAdapter.Resources.cs
@@ -13,7 +13,7 @@ internal static partial class EpubReaderAdapter {
 
             string id = "epub-" + kind + "-" + assetIndex.ToString("D4", CultureInfo.InvariantCulture);
             string resourceLocation = resource.IsRemote && !string.IsNullOrWhiteSpace(resource.RemoteUri)
-                ? resource.RemoteUri!
+                ? RemoveEpubUrlFragment(resource.RemoteUri!)
                 : BuildVirtualPath(sourcePath, resource.Path);
             string extensionSource = GetEpubExtensionSource(resource);
             string extension = Path.GetExtension(extensionSource);
@@ -105,6 +105,11 @@ internal static partial class EpubReaderAdapter {
         if (query >= 0) value = value.Substring(0, query);
         if (value.StartsWith("//", StringComparison.Ordinal)) value = "https:" + value;
         return Uri.TryCreate(value, UriKind.Absolute, out Uri? uri) ? uri.AbsolutePath : value;
+    }
+
+    private static string RemoveEpubUrlFragment(string value) {
+        int fragment = value.IndexOf('#');
+        return fragment < 0 ? value : value.Substring(0, fragment);
     }
 
     private static string ComputeEpubPayloadHash(byte[] bytes) {

--- a/OfficeIMO.Reader.Epub/EpubReaderAdapter.Resources.cs
+++ b/OfficeIMO.Reader.Epub/EpubReaderAdapter.Resources.cs
@@ -1,0 +1,114 @@
+using OfficeIMO.Epub;
+using OfficeIMO.Reader;
+using System.Linq;
+
+namespace OfficeIMO.Reader.Epub;
+
+internal static partial class EpubReaderAdapter {
+    private static IEnumerable<OfficeDocumentAsset> BuildEpubAssets(EpubDocument document, string sourcePath) {
+        int assetIndex = 0;
+        foreach (EpubResource resource in document.Resources) {
+            string? kind = GetEpubAssetKind(resource.MediaType);
+            if (kind == null) continue;
+
+            string id = "epub-" + kind + "-" + assetIndex.ToString("D4", CultureInfo.InvariantCulture);
+            string resourceLocation = resource.IsRemote && !string.IsNullOrWhiteSpace(resource.RemoteUri)
+                ? resource.RemoteUri!
+                : BuildVirtualPath(sourcePath, resource.Path);
+            string extensionSource = GetEpubExtensionSource(resource);
+            string extension = Path.GetExtension(extensionSource);
+            yield return new OfficeDocumentAsset {
+                Id = id,
+                Kind = kind,
+                MediaType = resource.MediaType,
+                Extension = string.IsNullOrWhiteSpace(extension) ? null : extension,
+                FileName = OfficeDocumentAssetNaming.BuildFileName(id, extension),
+                LengthBytes = resource.LengthBytes,
+                PayloadHash = resource.Data == null ? null : ComputeEpubPayloadHash(resource.Data),
+                PayloadBytes = resource.Data,
+                SourceObjectId = resource.Id,
+                Location = new ReaderLocation {
+                    Path = resourceLocation,
+                    SourceBlockKind = kind,
+                    BlockAnchor = id
+                }
+            };
+            assetIndex++;
+        }
+    }
+
+    private static void AddEpubChapterAssets(
+        string sourcePath,
+        EpubChapter chapter,
+        IReadOnlyList<OfficeDocumentAsset> htmlAssets,
+        List<OfficeDocumentAsset> documentAssets,
+        List<OfficeDocumentAsset> chapterAssets,
+        List<OfficeDocumentDiagnostic> diagnostics) {
+        foreach (OfficeDocumentAsset htmlAsset in htmlAssets) {
+            OfficeDocumentAsset? mappedAsset = null;
+            if (htmlAsset.PayloadBytes == null) {
+                EpubReference reference = EpubReference.Resolve(chapter.Path, chapter.BaseHref, htmlAsset.SourceObjectId ?? string.Empty);
+                if (!reference.IsValid) {
+                    AddEpubReferenceDiagnostic(sourcePath, chapter, reference, diagnostics);
+                    continue;
+                }
+                if (reference.Kind == EpubReferenceKind.Data) continue;
+
+                AddEpubReferenceDiagnostic(sourcePath, chapter, reference, diagnostics);
+                string? resourceLocation = BuildEpubResolvedLocation(sourcePath, reference, includeFragment: true);
+                if (!string.IsNullOrWhiteSpace(resourceLocation)) {
+                    mappedAsset = FindEpubAsset(sourcePath, reference, documentAssets);
+                    if (mappedAsset == null) htmlAsset.Location.Path = resourceLocation;
+                }
+            }
+
+            if (mappedAsset == null) {
+                mappedAsset = htmlAsset;
+                documentAssets.Add(mappedAsset);
+            }
+            if (!chapterAssets.Contains(mappedAsset)) chapterAssets.Add(mappedAsset);
+        }
+    }
+
+    private static string? GetEpubAssetKind(string? mediaType) {
+        if (string.IsNullOrWhiteSpace(mediaType)) return "resource";
+        string value = mediaType!.Trim();
+        if (value.Equals("application/xhtml+xml", StringComparison.OrdinalIgnoreCase)
+            || value.Equals("text/html", StringComparison.OrdinalIgnoreCase)
+            || value.Equals("application/x-dtbncx+xml", StringComparison.OrdinalIgnoreCase)) {
+            return null;
+        }
+        if (value.StartsWith("image/", StringComparison.OrdinalIgnoreCase)) return "image";
+        if (value.StartsWith("audio/", StringComparison.OrdinalIgnoreCase)) return "audio";
+        if (value.StartsWith("video/", StringComparison.OrdinalIgnoreCase)) return "video";
+        if (value.StartsWith("font/", StringComparison.OrdinalIgnoreCase)
+            || value.IndexOf("font", StringComparison.OrdinalIgnoreCase) >= 0
+            || value.Equals("application/vnd.ms-opentype", StringComparison.OrdinalIgnoreCase)) {
+            return "font";
+        }
+        if (value.Equals("text/css", StringComparison.OrdinalIgnoreCase)) return "stylesheet";
+        if (value.IndexOf("javascript", StringComparison.OrdinalIgnoreCase) >= 0
+            || value.Equals("application/ecmascript", StringComparison.OrdinalIgnoreCase)) {
+            return "script";
+        }
+        if (value.Equals("application/smil+xml", StringComparison.OrdinalIgnoreCase)) return "media-overlay";
+        return "resource";
+    }
+
+    private static string GetEpubExtensionSource(EpubResource resource) {
+        string value = resource.IsRemote && !string.IsNullOrWhiteSpace(resource.RemoteUri)
+            ? resource.RemoteUri!
+            : resource.Path;
+        int fragment = value.IndexOf('#');
+        if (fragment >= 0) value = value.Substring(0, fragment);
+        int query = value.IndexOf('?');
+        if (query >= 0) value = value.Substring(0, query);
+        if (value.StartsWith("//", StringComparison.Ordinal)) value = "https:" + value;
+        return Uri.TryCreate(value, UriKind.Absolute, out Uri? uri) ? uri.AbsolutePath : value;
+    }
+
+    private static string ComputeEpubPayloadHash(byte[] bytes) {
+        using var stream = new MemoryStream(bytes, writable: false);
+        return ComputeSha256Hex(stream);
+    }
+}

--- a/OfficeIMO.Reader.Epub/EpubReaderAdapter.StructuredChunks.cs
+++ b/OfficeIMO.Reader.Epub/EpubReaderAdapter.StructuredChunks.cs
@@ -21,10 +21,16 @@ internal static partial class EpubReaderAdapter {
         string fileName = Path.GetFileName(source.Path);
         var chunks = new List<ReaderChunk>();
         var nonContentWarnings = new List<string>();
+        ReaderHtmlOptions htmlOptions = ReaderHtmlOptions.CreateOfficeIMOProfile();
+        if (htmlOptions.HtmlToMarkdownOptions != null) {
+            htmlOptions.HtmlToMarkdownOptions.UrlPolicy.ResolvedUrlTransform = value =>
+                ResolveEpubMarkdownReference(source.Path, chapter, value);
+        }
         foreach (ReaderChunk htmlChunk in HtmlReaderAdapter.ReadContent(
                      chapter.Html!,
                      virtualPath,
                      options,
+                     htmlOptions,
                      cancellationToken: cancellationToken)) {
             cancellationToken.ThrowIfCancellationRequested();
             if (IsHtmlNoMarkdownWarningChunk(htmlChunk)) {

--- a/OfficeIMO.Reader.Epub/README.md
+++ b/OfficeIMO.Reader.Epub/README.md
@@ -70,7 +70,7 @@ foreach (string warning in chunks.SelectMany(chunk => chunk.Warnings ?? Array.Em
 }
 ```
 
-### Read chapters and packaged images as one rich result
+### Read chapters and packaged resources as one rich result
 
 ```csharp
 OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
@@ -86,12 +86,12 @@ foreach (OfficeDocumentPage chapter in document.Pages) {
     Console.WriteLine($"{chapter.Number}. {chapter.Name}");
 }
 
-foreach (OfficeDocumentAsset image in document.Assets) {
-    Console.WriteLine($"{image.FileName}: {image.LengthBytes} bytes");
+foreach (OfficeDocumentAsset asset in document.Assets) {
+    Console.WriteLine($"{asset.Kind}: {asset.FileName} ({asset.LengthBytes} bytes)");
 }
 ```
 
-The rich reader requests bounded chapter HTML and manifest payloads from `OfficeIMO.Epub` so it can reuse the HTML semantic mapping. `reader.ReadDocument("book.epub")` uses this native result path.
+The rich reader requests bounded chapter HTML and manifest payloads from `OfficeIMO.Epub` so it can reuse the HTML semantic mapping. Images, audio, video, fonts, stylesheets, scripts, media overlays, and other manifest resources are projected as assets; content documents and navigation files are not duplicated as assets. Remote resources retain metadata but are never fetched. Audio and video are exposed for downstream processing, not played or transcribed.
 
 ## What it emits
 
@@ -101,7 +101,9 @@ The rich reader requests bounded chapter HTML and manifest payloads from `Office
 - Warning chunks propagated from EPUB parser warnings.
 - Virtual source paths such as `.epub::chapter.xhtml` for traceability.
 - Path and stream dispatch, including non-seekable stream support.
-- A schema-v5 rich result with chapter pages, HTML blocks, tables, links, forms, manifest image assets, metadata, and structured parser diagnostics.
+- A schema-v5 rich result with chapter pages, HTML blocks, tables, links, forms, bounded manifest assets, metadata, and structured parser diagnostics.
+- Chapter-relative, query-only, fragment-only, encoded, root-relative, external, and HTML-base URL projection through the shared EPUB reference contract.
+- Recoverable diagnostics for unsafe or non-conforming chapter references.
 
 ## Boundaries
 

--- a/OfficeIMO.Reader.Html/HtmlReaderAdapter.Document.cs
+++ b/OfficeIMO.Reader.Html/HtmlReaderAdapter.Document.cs
@@ -186,7 +186,8 @@ internal static partial class HtmlReaderAdapter {
                 projection.Assets.Add(asset);
                 projection.Visuals.Add(MapHtmlVisual(node, asset.Location, asset.PayloadHash, asset.MediaType, asset.SourceObjectId));
             }
-        } else if (node.Kind == HtmlLogicalNodeKind.Media) {
+        } else if (node.Kind == HtmlLogicalNodeKind.Media &&
+            !string.Equals(node.Name, "source", StringComparison.OrdinalIgnoreCase)) {
             string anchor = "html-media-" + projection.Visuals.Count.ToString("D4", CultureInfo.InvariantCulture);
             projection.Visuals.Add(MapHtmlVisual(node, BuildHtmlLocation(path, null, "media", anchor), null, null));
         }

--- a/OfficeIMO.Reader.Html/HtmlReaderAdapter.Document.cs
+++ b/OfficeIMO.Reader.Html/HtmlReaderAdapter.Document.cs
@@ -340,10 +340,18 @@ internal static partial class HtmlReaderAdapter {
         string? mediaType,
         string? sourceOverride = null) {
         node.Attributes.TryGetValue("src", out string? source);
+        HtmlLogicalNode? mediaSource = null;
+        if (string.IsNullOrWhiteSpace(source) && node.Kind == HtmlLogicalNodeKind.Media) {
+            mediaSource = FindHtmlMediaSource(node);
+            mediaSource?.Attributes.TryGetValue("src", out source);
+        }
         if (!string.IsNullOrWhiteSpace(sourceOverride)) source = sourceOverride;
         node.Attributes.TryGetValue("alt", out string? altText);
         node.Attributes.TryGetValue("title", out string? title);
         if (mediaType == null && node.Attributes.TryGetValue("type", out string? declaredType)) mediaType = declaredType;
+        if (mediaType == null && mediaSource != null && mediaSource.Attributes.TryGetValue("type", out string? sourceType)) {
+            mediaType = sourceType;
+        }
         string content = altText ?? title ?? GetHtmlNodeText(node);
         if (string.IsNullOrWhiteSpace(content)) content = source ?? node.Name;
         return new ReaderVisual {
@@ -361,6 +369,20 @@ internal static partial class HtmlReaderAdapter {
                 BlockAnchor = location.BlockAnchor
             }
         };
+    }
+
+    private static HtmlLogicalNode? FindHtmlMediaSource(HtmlLogicalNode node) {
+        foreach (HtmlLogicalNode child in node.Children) {
+            if (child.Kind == HtmlLogicalNodeKind.Media
+                && string.Equals(child.Name, "source", StringComparison.OrdinalIgnoreCase)
+                && child.Attributes.TryGetValue("src", out string? source)
+                && !string.IsNullOrWhiteSpace(source)) {
+                return child;
+            }
+            HtmlLogicalNode? descendant = FindHtmlMediaSource(child);
+            if (descendant != null) return descendant;
+        }
+        return null;
     }
 
     private static IReadOnlyList<OfficeDocumentMetadataEntry> BuildHtmlMetadata(HtmlLogicalDocument logical, HtmlProjection projection) {

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Modular.cs
@@ -65,7 +65,9 @@ public sealed partial class ReaderEpubModularTests {
             Assert.Equal(2, inlineImages.Length);
             Assert.Equal(2, inlineImages.Select(item => item.FileName).Distinct(StringComparer.Ordinal).Count());
             Assert.All(result.Pages, page => Assert.Contains(page.Assets, pageAsset => pageAsset.MediaType == "image/gif"));
-            ReaderVisual visual = Assert.Single(result.Visuals, item => item.Kind == "image" && item.SourceName == "images/cover.png");
+            ReaderVisual visual = Assert.Single(result.Visuals, item =>
+                item.Kind == "image" &&
+                item.SourceName == result.Source.Path + "::OEBPS/images/cover.png");
             Assert.StartsWith("epub-chapter-0001-html-image-", visual.Location!.BlockAnchor!, StringComparison.Ordinal);
             using (FileStream stream = File.OpenRead(epubPath)) {
                 OfficeDocumentReadResult jsonResult = OfficeDocumentReadResultJson.Deserialize(

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Resources.Fixtures.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Resources.Fixtures.cs
@@ -1,0 +1,72 @@
+using System.IO.Compression;
+using System.Text;
+
+namespace OfficeIMO.Tests;
+
+public sealed partial class ReaderEpubModularTests {
+    private static void BuildEpubWithResolvedResources(string epubPath) {
+        using var file = new FileStream(epubPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+        using var archive = new ZipArchive(file, ZipArchiveMode.Create, leaveOpen: false);
+
+        WriteResolvedResourceEntry(
+            archive,
+            "META-INF/container.xml",
+            "<container version=\"1.0\" xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\"><rootfiles>" +
+            "<rootfile full-path=\"EPUB/package.opf\" media-type=\"application/oebps-package+xml\"/>" +
+            "</rootfiles></container>");
+        WriteResolvedResourceEntry(
+            archive,
+            "EPUB/package.opf",
+            "<package version=\"3.0\" xmlns=\"http://www.idpf.org/2007/opf\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\">" +
+            "<metadata><dc:title>Resolved resources</dc:title></metadata><manifest>" +
+            "<item id=\"chapter\" href=\"text/chapter.xhtml\" media-type=\"application/xhtml+xml\"/>" +
+            "<item id=\"second\" href=\"text/second.xhtml\" media-type=\"application/xhtml+xml\"/>" +
+            "<item id=\"cover\" href=\"shared/images/cover%20art.png\" media-type=\"image/png\"/>" +
+            "<item id=\"root-image\" href=\"shared/images/root.png\" media-type=\"image/png\"/>" +
+            "<item id=\"audio\" href=\"shared/audio/chapter.mp3\" media-type=\"audio/mpeg\"/>" +
+            "<item id=\"video\" href=\"shared/video/clip.mp4\" media-type=\"video/mp4\"/>" +
+            "<item id=\"styles\" href=\"shared/styles/book.css\" media-type=\"text/css\"/>" +
+            "<item id=\"font\" href=\"shared/fonts/book.woff2\" media-type=\"font/woff2\"/>" +
+            "<item id=\"remote-image\" href=\"https://cdn.example/remote.png\" media-type=\"image/png\"/>" +
+            "</manifest><spine><itemref idref=\"chapter\"/><itemref idref=\"second\"/></spine></package>");
+        WriteResolvedResourceEntry(
+            archive,
+            "EPUB/text/chapter.xhtml",
+            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><base href=\"../shared/\"/></head><body>" +
+            "<h1 id=\"local\">Chapter</h1>" +
+            "<a href=\"../text/chapter.xhtml?mode=print#local\">base link</a>" +
+            "<img src=\"images/cover%20art.png?display=1#front\" alt=\"Cover\"/>" +
+            "<img src=\"/EPUB/shared/images/root.png\" alt=\"Root image\"/>" +
+            "<img src=\"https://cdn.example/remote.png\" alt=\"Remote image\"/>" +
+            "<audio src=\"audio/chapter.mp3\">Audio fallback</audio>" +
+            "<video src=\"video/clip.mp4#clip\">Video fallback</video>" +
+            "</body></html>");
+        WriteResolvedResourceEntry(
+            archive,
+            "EPUB/text/second.xhtml",
+            "<html xmlns=\"http://www.w3.org/1999/xhtml\"><body>" +
+            "<h1 id=\"second\">Second</h1>" +
+            "<a href=\"#second\">same fragment</a>" +
+            "<a href=\"?view=print\">same query</a>" +
+            "<a href=\"/EPUB/text/chapter.xhtml#local\">root link</a>" +
+            "<a href=\"../../../outside.xhtml\">unsafe link</a>" +
+            "<img src=\"../../../outside.png\" alt=\"Unsafe\"/>" +
+            "</body></html>");
+
+        WriteResolvedResourceBytes(archive, "EPUB/shared/images/cover art.png", new byte[] { 137, 80, 78, 71 });
+        WriteResolvedResourceBytes(archive, "EPUB/shared/images/root.png", new byte[] { 137, 80, 78, 71, 1 });
+        WriteResolvedResourceBytes(archive, "EPUB/shared/audio/chapter.mp3", new byte[] { 73, 68, 51, 4 });
+        WriteResolvedResourceBytes(archive, "EPUB/shared/video/clip.mp4", new byte[] { 0, 0, 0, 20, 102, 116, 121, 112 });
+        WriteResolvedResourceEntry(archive, "EPUB/shared/styles/book.css", "body { font-family: Book; }");
+        WriteResolvedResourceBytes(archive, "EPUB/shared/fonts/book.woff2", new byte[] { 119, 79, 70, 50 });
+    }
+
+    private static void WriteResolvedResourceEntry(ZipArchive archive, string path, string content) =>
+        WriteResolvedResourceBytes(archive, path, Encoding.UTF8.GetBytes(content));
+
+    private static void WriteResolvedResourceBytes(ZipArchive archive, string path, byte[] content) {
+        ZipArchiveEntry entry = archive.CreateEntry(path, CompressionLevel.Optimal);
+        using Stream stream = entry.Open();
+        stream.Write(content, 0, content.Length);
+    }
+}

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Resources.Fixtures.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Resources.Fixtures.cs
@@ -28,7 +28,7 @@ public sealed partial class ReaderEpubModularTests {
             "<item id=\"video\" href=\"shared/video/clip.mp4\" media-type=\"video/mp4\"/>" +
             "<item id=\"styles\" href=\"shared/styles/book.css\" media-type=\"text/css\"/>" +
             "<item id=\"font\" href=\"shared/fonts/book.woff2\" media-type=\"font/woff2\"/>" +
-            "<item id=\"remote-image\" href=\"https://cdn.example/remote.png\" media-type=\"image/png\"/>" +
+            "<item id=\"remote-image\" href=\"https://cdn.example/remote.png#v2\" media-type=\"image/png\"/>" +
             "</manifest><spine><itemref idref=\"chapter\"/><itemref idref=\"second\"/></spine></package>");
         WriteResolvedResourceEntry(
             archive,
@@ -39,7 +39,7 @@ public sealed partial class ReaderEpubModularTests {
             "<img src=\"images/cover%20art.png?display=1#front\" alt=\"Cover\"/>" +
             "<img src=\"images/cover%23v2.png\" alt=\"Reserved name\"/>" +
             "<img src=\"/EPUB/shared/images/root.png\" alt=\"Root image\"/>" +
-            "<img src=\"https://cdn.example/remote.png\" alt=\"Remote image\"/>" +
+            "<img src=\"https://cdn.example/remote.png#v2\" alt=\"Remote image\"/>" +
             "<img src=\"data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==\" alt=\"Inline\"/>" +
             "<audio><source src=\"audio/chapter.mp3\" type=\"audio/mpeg\"/>Audio fallback</audio>" +
             "<video src=\"video/clip.mp4#clip\">Video fallback</video>" +

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Resources.Fixtures.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Resources.Fixtures.cs
@@ -22,6 +22,7 @@ public sealed partial class ReaderEpubModularTests {
             "<item id=\"chapter\" href=\"text/chapter.xhtml\" media-type=\"application/xhtml+xml\"/>" +
             "<item id=\"second\" href=\"text/second.xhtml\" media-type=\"application/xhtml+xml\"/>" +
             "<item id=\"cover\" href=\"shared/images/cover%20art.png\" media-type=\"image/png\"/>" +
+            "<item id=\"reserved-image\" href=\"shared/images/cover%23v2.png\" media-type=\"image/png\"/>" +
             "<item id=\"root-image\" href=\"shared/images/root.png\" media-type=\"image/png\"/>" +
             "<item id=\"audio\" href=\"shared/audio/chapter.mp3\" media-type=\"audio/mpeg\"/>" +
             "<item id=\"video\" href=\"shared/video/clip.mp4\" media-type=\"video/mp4\"/>" +
@@ -36,6 +37,7 @@ public sealed partial class ReaderEpubModularTests {
             "<h1 id=\"local\">Chapter</h1>" +
             "<a href=\"../text/chapter.xhtml?mode=print#local\">base link</a>" +
             "<img src=\"images/cover%20art.png?display=1#front\" alt=\"Cover\"/>" +
+            "<img src=\"images/cover%23v2.png\" alt=\"Reserved name\"/>" +
             "<img src=\"/EPUB/shared/images/root.png\" alt=\"Root image\"/>" +
             "<img src=\"https://cdn.example/remote.png\" alt=\"Remote image\"/>" +
             "<img src=\"data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==\" alt=\"Inline\"/>" +
@@ -55,6 +57,7 @@ public sealed partial class ReaderEpubModularTests {
             "</body></html>");
 
         WriteResolvedResourceBytes(archive, "EPUB/shared/images/cover art.png", new byte[] { 137, 80, 78, 71 });
+        WriteResolvedResourceBytes(archive, "EPUB/shared/images/cover#v2.png", new byte[] { 137, 80, 78, 71, 2 });
         WriteResolvedResourceBytes(archive, "EPUB/shared/images/root.png", new byte[] { 137, 80, 78, 71, 1 });
         WriteResolvedResourceBytes(archive, "EPUB/shared/audio/chapter.mp3", new byte[] { 73, 68, 51, 4 });
         WriteResolvedResourceBytes(archive, "EPUB/shared/video/clip.mp4", new byte[] { 0, 0, 0, 20, 102, 116, 121, 112 });

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Resources.Fixtures.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Resources.Fixtures.cs
@@ -38,6 +38,7 @@ public sealed partial class ReaderEpubModularTests {
             "<img src=\"images/cover%20art.png?display=1#front\" alt=\"Cover\"/>" +
             "<img src=\"/EPUB/shared/images/root.png\" alt=\"Root image\"/>" +
             "<img src=\"https://cdn.example/remote.png\" alt=\"Remote image\"/>" +
+            "<img src=\"data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==\" alt=\"Inline\"/>" +
             "<audio src=\"audio/chapter.mp3\">Audio fallback</audio>" +
             "<video src=\"video/clip.mp4#clip\">Video fallback</video>" +
             "</body></html>");

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Resources.Fixtures.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Resources.Fixtures.cs
@@ -41,7 +41,7 @@ public sealed partial class ReaderEpubModularTests {
             "<img src=\"/EPUB/shared/images/root.png\" alt=\"Root image\"/>" +
             "<img src=\"https://cdn.example/remote.png\" alt=\"Remote image\"/>" +
             "<img src=\"data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==\" alt=\"Inline\"/>" +
-            "<audio src=\"audio/chapter.mp3\">Audio fallback</audio>" +
+            "<audio><source src=\"audio/chapter.mp3\" type=\"audio/mpeg\"/>Audio fallback</audio>" +
             "<video src=\"video/clip.mp4#clip\">Video fallback</video>" +
             "</body></html>");
         WriteResolvedResourceEntry(

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Resources.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Resources.cs
@@ -57,9 +57,10 @@ public sealed partial class ReaderEpubModularTests {
             Assert.Equal("audio", audio.Kind);
             Assert.Equal("audio/mpeg", audio.MediaType);
             Assert.Contains(result.Pages[0].Assets, asset => ReferenceEquals(asset, audio));
-            Assert.Contains(result.Visuals, visual =>
+            ReaderVisual audioVisual = Assert.Single(result.Visuals, visual =>
                 visual.Language == "audio" &&
                 visual.SourceName == prefix + "EPUB/shared/audio/chapter.mp3");
+            Assert.Equal("audio/mpeg", audioVisual.MimeType);
 
             OfficeDocumentAsset video = Assert.Single(result.Assets, asset => asset.SourceObjectId == "video");
             Assert.Equal("video", video.Kind);

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Resources.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Resources.cs
@@ -76,9 +76,11 @@ public sealed partial class ReaderEpubModularTests {
             Assert.Equal("stylesheet", Assert.Single(result.Assets, asset => asset.SourceObjectId == "styles").Kind);
             Assert.Equal("font", Assert.Single(result.Assets, asset => asset.SourceObjectId == "font").Kind);
             Assert.DoesNotContain(result.Assets, asset => asset.SourceObjectId == "chapter" || asset.SourceObjectId == "second");
-            Assert.Contains(result.Assets, asset =>
-                asset.Location.Path == "https://cdn.example/remote.png" &&
-                asset.PayloadBytes == null);
+            OfficeDocumentAsset remoteImage = Assert.Single(result.Assets, asset => asset.SourceObjectId == "remote-image");
+            Assert.Equal("https://cdn.example/remote.png", remoteImage.Location.Path);
+            Assert.Null(remoteImage.PayloadBytes);
+            Assert.Contains(result.Pages[0].Assets, asset => ReferenceEquals(asset, remoteImage));
+            Assert.DoesNotContain(result.Assets, asset => asset.SourceObjectId == "https://cdn.example/remote.png#v2");
 
             OfficeDocumentDiagnostic[] nonConforming = result.Diagnostics
                 .Where(item => item.Code == "epub.reference.non-conforming")

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Resources.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Resources.cs
@@ -1,0 +1,95 @@
+using OfficeIMO.Reader;
+using OfficeIMO.Reader.Epub;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed partial class ReaderEpubModularTests {
+    [Fact]
+    public void DocumentReaderEpub_ResolvesChapterReferencesAndProjectsBoundedManifestAssets() {
+        string epubPath = Path.Combine(Path.GetTempPath(), "officeimo-epub-resources-" + Guid.NewGuid().ToString("N") + ".epub");
+        try {
+            BuildEpubWithResolvedResources(epubPath);
+
+            OfficeDocumentReadResult result = EpubReaderAdapter.ReadDocument(epubPath);
+
+            string prefix = result.Source.Path + "::";
+            Assert.Contains(result.Links, link =>
+                link.Text == "base link" &&
+                link.Uri == prefix + "EPUB/text/chapter.xhtml?mode=print#local");
+            Assert.Contains(result.Links, link =>
+                link.Text == "same fragment" &&
+                link.Uri == prefix + "EPUB/text/second.xhtml#second");
+            Assert.Contains(result.Links, link =>
+                link.Text == "same query" &&
+                link.Uri == prefix + "EPUB/text/second.xhtml?view=print");
+            Assert.Contains(result.Links, link =>
+                link.Text == "root link" &&
+                link.Uri == prefix + "EPUB/text/chapter.xhtml#local");
+            Assert.DoesNotContain(result.Links, link => link.Text == "unsafe link");
+            string markdown = Assert.IsType<string>(result.Markdown);
+            Assert.Contains("::EPUB/text/chapter.xhtml?mode=print#local", markdown, StringComparison.Ordinal);
+            Assert.Contains("::EPUB/text/second.xhtml#second", markdown, StringComparison.Ordinal);
+            Assert.Contains("::EPUB/shared/images/cover%20art.png?display=1#front", markdown, StringComparison.Ordinal);
+            Assert.Contains("::EPUB/shared/audio/chapter.mp3", markdown, StringComparison.Ordinal);
+            Assert.Contains("::EPUB/shared/video/clip.mp4#clip", markdown, StringComparison.Ordinal);
+            Assert.DoesNotContain("../../../outside.png", markdown, StringComparison.Ordinal);
+
+            OfficeDocumentAsset cover = Assert.Single(result.Assets, asset => asset.SourceObjectId == "cover");
+            Assert.Equal("image", cover.Kind);
+            Assert.Equal(prefix + "EPUB/shared/images/cover art.png", cover.Location.Path);
+            Assert.NotNull(cover.PayloadBytes);
+            Assert.Contains(result.Pages[0].Assets, asset => ReferenceEquals(asset, cover));
+
+            OfficeDocumentAsset rootImage = Assert.Single(result.Assets, asset => asset.SourceObjectId == "root-image");
+            Assert.Contains(result.Pages[0].Assets, asset => ReferenceEquals(asset, rootImage));
+            Assert.Equal(prefix + "EPUB/shared/images/root.png", rootImage.Location.Path);
+
+            OfficeDocumentAsset audio = Assert.Single(result.Assets, asset => asset.SourceObjectId == "audio");
+            Assert.Equal("audio", audio.Kind);
+            Assert.Equal("audio/mpeg", audio.MediaType);
+            Assert.Contains(result.Pages[0].Assets, asset => ReferenceEquals(asset, audio));
+            Assert.Contains(result.Visuals, visual =>
+                visual.Language == "audio" &&
+                visual.SourceName == prefix + "EPUB/shared/audio/chapter.mp3");
+
+            OfficeDocumentAsset video = Assert.Single(result.Assets, asset => asset.SourceObjectId == "video");
+            Assert.Equal("video", video.Kind);
+            Assert.Contains(result.Pages[0].Assets, asset => ReferenceEquals(asset, video));
+            Assert.Contains(result.Visuals, visual =>
+                visual.Language == "video" &&
+                visual.SourceName == prefix + "EPUB/shared/video/clip.mp4#clip");
+            Assert.DoesNotContain(result.Visuals, visual => visual.SourceName == "../../../outside.png");
+
+            Assert.Equal("stylesheet", Assert.Single(result.Assets, asset => asset.SourceObjectId == "styles").Kind);
+            Assert.Equal("font", Assert.Single(result.Assets, asset => asset.SourceObjectId == "font").Kind);
+            Assert.DoesNotContain(result.Assets, asset => asset.SourceObjectId == "chapter" || asset.SourceObjectId == "second");
+            Assert.Contains(result.Assets, asset =>
+                asset.Location.Path == "https://cdn.example/remote.png" &&
+                asset.PayloadBytes == null);
+
+            OfficeDocumentDiagnostic[] nonConforming = result.Diagnostics
+                .Where(item => item.Code == "epub.reference.non-conforming")
+                .ToArray();
+            Assert.Equal(2, nonConforming.Length);
+            Assert.Contains(nonConforming, item => item.Attributes["reference"] == "/EPUB/shared/images/root.png");
+            Assert.Contains(nonConforming, item => item.Attributes["reference"] == "/EPUB/text/chapter.xhtml#local");
+            OfficeDocumentDiagnostic unsafeReference = Assert.Single(
+                result.Diagnostics,
+                item => item.Code == "epub.reference.unsafe" && item.Attributes["reference"] == "../../../outside.png");
+            Assert.Equal(OfficeDocumentDiagnosticCategory.Security, unsafeReference.Category);
+            Assert.DoesNotContain(result.Assets, asset => asset.SourceObjectId == "../../../outside.png");
+            Assert.Contains(result.Diagnostics, item =>
+                item.Code == "epub.reference.unsafe" &&
+                item.Attributes["reference"] == "../../../outside.xhtml");
+
+            OfficeDocumentReadResult roundTrip = OfficeDocumentReadResultJson.Deserialize(
+                OfficeDocumentReadResultJson.Serialize(result, indented: false));
+            Assert.Contains(roundTrip.Assets, asset => asset.SourceObjectId == "audio" && asset.Kind == "audio");
+            Assert.Contains(roundTrip.Links, link => link.Text == "same fragment" && link.Uri == prefix + "EPUB/text/second.xhtml#second");
+            Assert.Contains(roundTrip.Diagnostics, item => item.Code == "epub.reference.unsafe");
+        } finally {
+            if (File.Exists(epubPath)) File.Delete(epubPath);
+        }
+    }
+}

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Resources.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Resources.cs
@@ -59,6 +59,9 @@ public sealed partial class ReaderEpubModularTests {
             Assert.Contains(result.Visuals, visual =>
                 visual.Language == "video" &&
                 visual.SourceName == prefix + "EPUB/shared/video/clip.mp4#clip");
+            Assert.Contains(result.Visuals, visual =>
+                visual.Language == "img" &&
+                visual.SourceName == "data-uri");
             Assert.DoesNotContain(result.Visuals, visual => visual.SourceName == "../../../outside.png");
 
             Assert.Equal("stylesheet", Assert.Single(result.Assets, asset => asset.SourceObjectId == "styles").Kind);
@@ -88,6 +91,31 @@ public sealed partial class ReaderEpubModularTests {
             Assert.Contains(roundTrip.Assets, asset => asset.SourceObjectId == "audio" && asset.Kind == "audio");
             Assert.Contains(roundTrip.Links, link => link.Text == "same fragment" && link.Uri == prefix + "EPUB/text/second.xhtml#second");
             Assert.Contains(roundTrip.Diagnostics, item => item.Code == "epub.reference.unsafe");
+        } finally {
+            if (File.Exists(epubPath)) File.Delete(epubPath);
+        }
+    }
+
+    [Fact]
+    public void DocumentReaderEpub_PreservesWindowsVirtualReferencesInMarkdown() {
+        string epubPath = Path.Combine(Path.GetTempPath(), "officeimo-epub-resources-" + Guid.NewGuid().ToString("N") + ".epub");
+        try {
+            BuildEpubWithResolvedResources(epubPath);
+            using FileStream stream = File.OpenRead(epubPath);
+
+            OfficeDocumentReadResult result = EpubReaderAdapter.ReadDocument(
+                stream,
+                @"C:\books\novel.epub");
+
+            string markdown = Assert.IsType<string>(result.Markdown);
+            Assert.Contains("[base link](", markdown, StringComparison.Ordinal);
+            Assert.Contains(@"C:\books\novel.epub::", markdown, StringComparison.Ordinal);
+            Assert.Contains("::EPUB/text/chapter.xhtml?mode=print#local", markdown, StringComparison.Ordinal);
+            Assert.Contains("![Cover](", markdown, StringComparison.Ordinal);
+            Assert.Contains("::EPUB/shared/images/cover%20art.png?display=1#front", markdown, StringComparison.Ordinal);
+            Assert.Contains(result.Links, link =>
+                link.Text == "base link" &&
+                link.Uri == @"C:\books\novel.epub::EPUB/text/chapter.xhtml?mode=print#local");
         } finally {
             if (File.Exists(epubPath)) File.Delete(epubPath);
         }

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Resources.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Resources.cs
@@ -31,6 +31,7 @@ public sealed partial class ReaderEpubModularTests {
             Assert.Contains("::EPUB/text/chapter.xhtml?mode=print#local", markdown, StringComparison.Ordinal);
             Assert.Contains("::EPUB/text/second.xhtml#second", markdown, StringComparison.Ordinal);
             Assert.Contains("::EPUB/shared/images/cover%20art.png?display=1#front", markdown, StringComparison.Ordinal);
+            Assert.Contains("::EPUB/shared/images/cover%23v2.png", markdown, StringComparison.Ordinal);
             Assert.Contains("::EPUB/shared/audio/chapter.mp3", markdown, StringComparison.Ordinal);
             Assert.Contains("::EPUB/shared/video/clip.mp4#clip", markdown, StringComparison.Ordinal);
             Assert.DoesNotContain("../../../outside.png", markdown, StringComparison.Ordinal);
@@ -40,6 +41,13 @@ public sealed partial class ReaderEpubModularTests {
             Assert.Equal(prefix + "EPUB/shared/images/cover art.png", cover.Location.Path);
             Assert.NotNull(cover.PayloadBytes);
             Assert.Contains(result.Pages[0].Assets, asset => ReferenceEquals(asset, cover));
+
+            OfficeDocumentAsset reservedImage = Assert.Single(result.Assets, asset => asset.SourceObjectId == "reserved-image");
+            Assert.Equal(prefix + "EPUB/shared/images/cover#v2.png", reservedImage.Location.Path);
+            Assert.Contains(result.Pages[0].Assets, asset => ReferenceEquals(asset, reservedImage));
+            Assert.Contains(result.Visuals, visual =>
+                visual.Language == "img" &&
+                visual.SourceName == prefix + "EPUB/shared/images/cover%23v2.png");
 
             OfficeDocumentAsset rootImage = Assert.Single(result.Assets, asset => asset.SourceObjectId == "root-image");
             Assert.Contains(result.Pages[0].Assets, asset => ReferenceEquals(asset, rootImage));

--- a/OfficeIMO.Reader.Tests/Reader.Html.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Html.Modular.cs
@@ -64,6 +64,24 @@ public sealed class ReaderHtmlModularTests {
     }
 
     [Fact]
+    public void DocumentReaderHtml_RichProjection_ProjectsNestedMediaSourcesOnce() {
+        const string html = "<audio><source src=\"chapter.mp3\" type=\"audio/mpeg\"/>Audio fallback</audio>"
+            + "<video><source src=\"clip.webm\" type=\"video/webm\"/>"
+            + "<source src=\"clip.mp4\" type=\"video/mp4\"/>Video fallback</video>";
+
+        OfficeDocumentReadResult result = HtmlReaderAdapter.ReadContentDocument(html, "media.html");
+
+        Assert.Equal(2, result.Visuals.Count);
+        ReaderVisual audio = Assert.Single(result.Visuals, visual => visual.Language == "audio");
+        Assert.Equal("chapter.mp3", audio.SourceName);
+        Assert.Equal("audio/mpeg", audio.MimeType);
+        ReaderVisual video = Assert.Single(result.Visuals, visual => visual.Language == "video");
+        Assert.Equal("clip.webm", video.SourceName);
+        Assert.Equal("video/webm", video.MimeType);
+        Assert.DoesNotContain(result.Visuals, visual => visual.Language == "source");
+    }
+
+    [Fact]
     public void DocumentReaderHtml_RichProjection_RejectsOversizedInputBeforeLogicalProjection() {
         const string html = "<p>This input exceeds its configured bound.</p>";
 

--- a/OfficeIMO.Shared.Tests/EpubReferenceContracts.cs
+++ b/OfficeIMO.Shared.Tests/EpubReferenceContracts.cs
@@ -1,0 +1,115 @@
+using OfficeIMO.Epub;
+using Xunit;
+
+namespace OfficeIMO.Shared.Tests;
+
+public sealed class EpubReferenceContractTests {
+    [Fact]
+    public void Resolve_PreservesQueryAndFragmentWhileResolvingEncodedContainerPath() {
+        EpubReference reference = EpubReference.Resolve(
+            "EPUB/text/chapter.xhtml",
+            "../images/cover%20art.png?size=large#hero%20image");
+
+        Assert.True(reference.IsValid);
+        Assert.Equal(EpubReferenceKind.Container, reference.Kind);
+        Assert.Equal(EpubReferenceError.None, reference.Error);
+        Assert.Equal("EPUB/images/cover art.png", reference.ContainerPath);
+        Assert.Equal("size=large", reference.Query);
+        Assert.Equal("hero image", reference.Fragment);
+        Assert.Equal("EPUB/images/cover art.png?size=large", reference.Target);
+        Assert.Equal("EPUB/images/cover art.png?size=large#hero%20image", reference.ResolvedValue);
+        Assert.True(reference.IsConforming);
+    }
+
+    [Theory]
+    [InlineData("#section", "EPUB/text/chapter.xhtml#section")]
+    [InlineData("?mode=print", "EPUB/text/chapter.xhtml?mode=print")]
+    [InlineData("?mode=print#section", "EPUB/text/chapter.xhtml?mode=print#section")]
+    public void Resolve_BindsFragmentAndQueryOnlyReferencesToCurrentDocument(string value, string expected) {
+        EpubReference reference = EpubReference.Resolve("EPUB/text/chapter.xhtml", value);
+
+        Assert.Equal(EpubReferenceKind.Container, reference.Kind);
+        Assert.Equal("EPUB/text/chapter.xhtml", reference.ContainerPath);
+        Assert.Equal(expected, reference.ResolvedValue);
+    }
+
+    [Fact]
+    public void Resolve_ToleratesButMarksContainerRootRelativeReferenceNonConforming() {
+        EpubReference reference = EpubReference.Resolve(
+            "EPUB/text/chapter.xhtml",
+            "/EPUB/images/cover.png#front");
+
+        Assert.Equal(EpubReferenceKind.Container, reference.Kind);
+        Assert.Equal("EPUB/images/cover.png", reference.ContainerPath);
+        Assert.True(reference.IsContainerRootRelative);
+        Assert.False(reference.IsConforming);
+    }
+
+    [Theory]
+    [InlineData("../../../outside.xhtml", EpubReferenceError.EscapesContainer)]
+    [InlineData("../images/a%2Fb.png", EpubReferenceError.InvalidPath)]
+    [InlineData("../images/a%5Cb.png", EpubReferenceError.InvalidPath)]
+    [InlineData("../images/bad%2.png", EpubReferenceError.InvalidPath)]
+    [InlineData("file:///tmp/outside.xhtml", EpubReferenceError.FileUrl)]
+    public void Resolve_RejectsUnsafeOrAmbiguousContainerReferences(string value, EpubReferenceError error) {
+        EpubReference reference = EpubReference.Resolve("EPUB/text/chapter.xhtml", value);
+
+        Assert.False(reference.IsValid);
+        Assert.Equal(EpubReferenceKind.Invalid, reference.Kind);
+        Assert.Equal(error, reference.Error);
+        Assert.Null(reference.ResolvedValue);
+    }
+
+    [Fact]
+    public void Resolve_AppliesUrlDotSegmentsBeforeDecodingArchiveNames() {
+        EpubReference reference = EpubReference.Resolve(
+            "EPUB/text/chapter.xhtml",
+            "%2e%2e/images/cover.png");
+
+        Assert.Equal(EpubReferenceKind.Container, reference.Kind);
+        Assert.Equal("EPUB/images/cover.png", reference.ContainerPath);
+    }
+
+    [Theory]
+    [InlineData("https://cdn.example/book/audio.mp3?token=1#clip", EpubReferenceKind.External)]
+    [InlineData("//cdn.example/book/audio.mp3", EpubReferenceKind.External)]
+    [InlineData("data:image/svg+xml,%3Csvg%2F%3E", EpubReferenceKind.Data)]
+    public void Resolve_ClassifiesNonContainerReferencesWithoutFetching(string value, EpubReferenceKind kind) {
+        EpubReference reference = EpubReference.Resolve("EPUB/text/chapter.xhtml", value);
+
+        Assert.Equal(kind, reference.Kind);
+        Assert.Equal(value, reference.ResolvedValue);
+        Assert.Null(reference.ContainerPath);
+    }
+
+    [Fact]
+    public void Resolve_AppliesRelativeAndExternalHtmlBaseHref() {
+        EpubReference local = EpubReference.Resolve(
+            "EPUB/text/chapter.xhtml",
+            "../shared/",
+            "images/cover.png#front");
+        EpubReference external = EpubReference.Resolve(
+            "EPUB/text/chapter.xhtml",
+            "https://cdn.example/book/",
+            "audio/chapter.mp3");
+
+        Assert.Equal("EPUB/shared/images/cover.png#front", local.ResolvedValue);
+        Assert.Equal(EpubReferenceKind.External, external.Kind);
+        Assert.Equal("https://cdn.example/book/audio/chapter.mp3", external.ResolvedValue);
+    }
+
+    [Fact]
+    public void Resolve_BindsFragmentOnlyReferenceToDirectoryBaseAndPreservesBaseQuery() {
+        EpubReference directory = EpubReference.Resolve(
+            "EPUB/text/chapter.xhtml",
+            "../shared/?edition=2",
+            "#notes");
+        EpubReference document = EpubReference.Resolve(
+            "EPUB/text/chapter.xhtml",
+            "appendix.xhtml?edition=2",
+            "?edition=3#notes");
+
+        Assert.Equal("EPUB/shared/?edition=2#notes", directory.ResolvedValue);
+        Assert.Equal("EPUB/text/appendix.xhtml?edition=3#notes", document.ResolvedValue);
+    }
+}

--- a/OfficeIMO.Shared.Tests/EpubReferenceContracts.cs
+++ b/OfficeIMO.Shared.Tests/EpubReferenceContracts.cs
@@ -61,6 +61,19 @@ public sealed class EpubReferenceContractTests {
         Assert.False(reference.IsConforming);
     }
 
+    [Fact]
+    public void Resolve_NormalizesRawBackslashesButMarksReferenceNonConforming() {
+        EpubReference reference = EpubReference.Resolve(
+            "EPUB/package.opf",
+            @"images\cover.png");
+
+        Assert.Equal(EpubReferenceKind.Container, reference.Kind);
+        Assert.Equal(EpubReferenceError.None, reference.Error);
+        Assert.Equal("EPUB/images/cover.png", reference.ContainerPath);
+        Assert.Equal("EPUB/images/cover.png", reference.ResolvedValue);
+        Assert.False(reference.IsConforming);
+    }
+
     [Theory]
     [InlineData("../../../outside.xhtml", EpubReferenceError.EscapesContainer)]
     [InlineData("../images/a%2Fb.png", EpubReferenceError.InvalidPath)]

--- a/OfficeIMO.Shared.Tests/EpubReferenceContracts.cs
+++ b/OfficeIMO.Shared.Tests/EpubReferenceContracts.cs
@@ -14,11 +14,27 @@ public sealed class EpubReferenceContractTests {
         Assert.Equal(EpubReferenceKind.Container, reference.Kind);
         Assert.Equal(EpubReferenceError.None, reference.Error);
         Assert.Equal("EPUB/images/cover art.png", reference.ContainerPath);
+        Assert.Equal("EPUB/images/cover%20art.png", reference.ContainerUrlPath);
         Assert.Equal("size=large", reference.Query);
         Assert.Equal("hero image", reference.Fragment);
-        Assert.Equal("EPUB/images/cover art.png?size=large", reference.Target);
-        Assert.Equal("EPUB/images/cover art.png?size=large#hero%20image", reference.ResolvedValue);
+        Assert.Equal("EPUB/images/cover%20art.png?size=large", reference.Target);
+        Assert.Equal("EPUB/images/cover%20art.png?size=large#hero%20image", reference.ResolvedValue);
         Assert.True(reference.IsConforming);
+    }
+
+    [Theory]
+    [InlineData("../images/cover%23v2.png", "EPUB/images/cover#v2.png", "EPUB/images/cover%23v2.png")]
+    [InlineData("../images/cover%3Fv2.png", "EPUB/images/cover?v2.png", "EPUB/images/cover%3Fv2.png")]
+    public void Resolve_SeparatesArchiveLookupPathFromUrlSerialization(
+        string value,
+        string expectedContainerPath,
+        string expectedResolvedValue) {
+        EpubReference reference = EpubReference.Resolve("EPUB/text/chapter.xhtml", value);
+
+        Assert.Equal(EpubReferenceKind.Container, reference.Kind);
+        Assert.Equal(expectedContainerPath, reference.ContainerPath);
+        Assert.Equal(expectedResolvedValue, reference.ContainerUrlPath);
+        Assert.Equal(expectedResolvedValue, reference.ResolvedValue);
     }
 
     [Theory]

--- a/OfficeIMO.Shared.Tests/EpubReferenceContracts.cs
+++ b/OfficeIMO.Shared.Tests/EpubReferenceContracts.cs
@@ -114,6 +114,22 @@ public sealed class EpubReferenceContractTests {
         Assert.Equal("https://cdn.example/book/audio/chapter.mp3", external.ResolvedValue);
     }
 
+    [Theory]
+    [InlineData("/", false)]
+    [InlineData("./", true)]
+    public void Resolve_AppliesContainerRootHtmlBaseHref(string baseHref, bool isConforming) {
+        EpubReference reference = EpubReference.Resolve(
+            "chapter.xhtml",
+            baseHref,
+            "images/cover.png");
+
+        Assert.Equal(EpubReferenceKind.Container, reference.Kind);
+        Assert.Equal(EpubReferenceError.None, reference.Error);
+        Assert.Equal("images/cover.png", reference.ContainerPath);
+        Assert.Equal("images/cover.png", reference.ResolvedValue);
+        Assert.Equal(isConforming, reference.IsConforming);
+    }
+
     [Fact]
     public void Resolve_BindsFragmentOnlyReferenceToDirectoryBaseAndPreservesBaseQuery() {
         EpubReference directory = EpubReference.Resolve(


### PR DESCRIPTION
## Summary

- Add a typed, dependency-free EPUB URL resolver for encoded container paths, query and fragment references, HTML base URLs, archive-root directory bases, external and data URLs, raw backslash compatibility, and container-root safety.
- Keep decoded, case-sensitive `ContainerPath` identity for ZIP lookup while exposing `ContainerUrlPath`, `Target`, and `ResolvedValue` for safe URL serialization.
- Use the shared resolver for OPF manifests, EPUB 2 and 3 navigation, Reader links, Markdown, images, audio, video, and packaged asset identity.
- Project bounded manifest images, media, fonts, stylesheets, scripts, overlays, and generic resources without fetching remote content.
- Resolve parent audio and video visuals from nested `source` elements, including declared media type and chapter asset association, without projecting the consumed source as a duplicate visual.
- Canonicalize external packaged assets to fragment-free identity so chapter references reuse and attach the manifest asset without duplicates.
- Reject traversal, file URLs, and ambiguous encoded separators across Markdown and rich projections, with recoverable diagnostics.
- Reuse the HTML owner for post-resolution URL transformation so links, images, srcset, audio, video, sources, and tracks follow one policy.

## Boundaries

This remains dependency-free and does not fetch remote resources, play or transcribe media, or decrypt protected payloads.

## Validation

- EPUB reference contracts: 21 of 21 on .NET 8 and .NET 10
- Reader suite: 577 of 577 on .NET 8 and .NET 10
- Reader EPUB resource contracts cover nested media sources, archive-root bases, fragmented external asset identity, raw backslash compatibility, and Windows virtual references
- Real ZIP-entry coverage for encoded spaces and reserved `#` and `?` path characters
- `OfficeIMO.Reader.Html` and `OfficeIMO.Reader.Epub` builds: `netstandard2.0`, zero warnings