### PR TITLE
Project ChartForgeX fences into the native Markdown AST

### DIFF
--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_IntelligenceXTranscript_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_IntelligenceXTranscript_Tests.cs
@@ -270,6 +270,21 @@ flowchart LR
         }
 
         [Fact]
+        public void IntelligenceXMarkdownRenderer_ApplyVisuals_After_CoreAdapter_Still_Projects_ChartForgeX_Fences() {
+            var options = MarkdownRendererPresets.CreateStrictMinimal();
+            MarkdownRendererIntelligenceXAdapter.Apply(options);
+
+            IntelligenceXMarkdownRenderer.ApplyVisuals(options);
+
+            var native = OfficeIMO.MarkdownRenderer.MarkdownRenderer.ParseNativeDocument(
+                "```chartforgex flow v1\nvisual payload\n```",
+                options);
+            var visual = Assert.IsType<MarkdownNativeVisualBlock>(Assert.Single(native.Blocks));
+            Assert.Equal("chartforgex flow v1", visual.InfoString);
+            Assert.Equal("visual payload", visual.Content);
+        }
+
+        [Fact]
         public void MarkdownRendererPresets_CreateIntelligenceXTranscript_Reuses_Shared_Transcript_Reader_Contract() {
             var expected = MarkdownTranscriptPreparation.CreateIntelligenceXTranscriptReaderOptions(
                 preservesGroupedDefinitionLikeParagraphs: false,

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_IntelligenceXTranscript_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_IntelligenceXTranscript_Tests.cs
@@ -249,6 +249,26 @@ flowchart LR
             Assert.Equal("mermaid", visual.Language);
         }
 
+        [Theory]
+        [InlineData("topology")]
+        [InlineData("flow")]
+        [InlineData("table")]
+        [InlineData("chart")]
+        [InlineData("timeline")]
+        [InlineData("sequence")]
+        public void IntelligenceXMarkdownRenderer_ParseTranscriptNativeDesktopShell_Projects_ChartForgeX_Fences(string kind) {
+            var infoString = "chartforgex " + kind + " v1";
+            var markdown = "```" + infoString + "\nvisual payload\n```";
+
+            var native = IntelligenceXMarkdownRenderer.ParseTranscriptNativeDesktopShell(markdown);
+
+            var visual = Assert.IsType<MarkdownNativeVisualBlock>(Assert.Single(native.Blocks));
+            Assert.Equal("chartforgex", visual.SemanticKind);
+            Assert.Equal("chartforgex", visual.Language);
+            Assert.Equal(infoString, visual.InfoString);
+            Assert.Equal("visual payload", visual.Content);
+        }
+
         [Fact]
         public void MarkdownRendererPresets_CreateIntelligenceXTranscript_Reuses_Shared_Transcript_Reader_Contract() {
             var expected = MarkdownTranscriptPreparation.CreateIntelligenceXTranscriptReaderOptions(

--- a/OfficeIMO.MarkdownRenderer.IntelligenceX/IntelligenceXMarkdownRenderer.cs
+++ b/OfficeIMO.MarkdownRenderer.IntelligenceX/IntelligenceXMarkdownRenderer.cs
@@ -22,7 +22,7 @@ public static class IntelligenceXMarkdownRenderer {
     /// fences into the shared native visual AST.
     /// </summary>
     public static MarkdownRendererPlugin VisualsPlugin { get; } = new MarkdownRendererPlugin(
-        "IntelligenceX Visuals",
+        "IntelligenceX ChartForgeX Visuals",
         new[] { MarkdownRendererPlugins.IntelligenceXVisuals },
         fenceOptionSchemas: new[] { IntelligenceXVisualFenceSchemas.Visuals },
         applyReader: options => options.FencedBlockExtensions.Add(ChartForgeXVisualFenceExtension));

--- a/OfficeIMO.MarkdownRenderer.IntelligenceX/IntelligenceXMarkdownRenderer.cs
+++ b/OfficeIMO.MarkdownRenderer.IntelligenceX/IntelligenceXMarkdownRenderer.cs
@@ -7,13 +7,25 @@ namespace OfficeIMO.MarkdownRenderer.IntelligenceX;
 /// First-party IntelligenceX plugin entrypoint layered on top of <see cref="OfficeIMO.MarkdownRenderer"/>.
 /// </summary>
 public static class IntelligenceXMarkdownRenderer {
+    private const string ChartForgeXSemanticKind = "chartforgex";
+    private static readonly MarkdownFencedBlockExtension ChartForgeXVisualFenceExtension = new(
+        "ChartForgeX visual AST",
+        new[] { ChartForgeXSemanticKind },
+        context => new SemanticFencedBlock(
+            ChartForgeXSemanticKind,
+            context.InfoString,
+            context.Content,
+            context.Caption));
+
     /// <summary>
-    /// IntelligenceX visual alias plugin that adds <c>ix-chart</c>, <c>ix-network</c>, and <c>ix-dataview</c>.
+    /// IntelligenceX visual plugin that adds IX aliases and projects canonical <c>chartforgex ...</c>
+    /// fences into the shared native visual AST.
     /// </summary>
     public static MarkdownRendererPlugin VisualsPlugin { get; } = new MarkdownRendererPlugin(
         "IntelligenceX Visuals",
         new[] { MarkdownRendererPlugins.IntelligenceXVisuals },
-        new[] { IntelligenceXVisualFenceSchemas.Visuals });
+        fenceOptionSchemas: new[] { IntelligenceXVisualFenceSchemas.Visuals },
+        applyReader: options => options.FencedBlockExtensions.Add(ChartForgeXVisualFenceExtension));
 
     /// <summary>
     /// IntelligenceX transcript plugin that carries the IX visual aliases, fence-option schema,

--- a/OfficeIMO.MarkdownRenderer.IntelligenceX/OfficeIMO.MarkdownRenderer.IntelligenceX.csproj
+++ b/OfficeIMO.MarkdownRenderer.IntelligenceX/OfficeIMO.MarkdownRenderer.IntelligenceX.csproj
@@ -4,7 +4,7 @@
     <Description>IntelligenceX renderer plugin pack for OfficeIMO.MarkdownRenderer with transcript-oriented preset helpers and IX visual aliases.</Description>
     <AssemblyName>OfficeIMO.MarkdownRenderer.IntelligenceX</AssemblyName>
     <AssemblyTitle>OfficeIMO.MarkdownRenderer.IntelligenceX</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
       $(TargetFrameworks);net472
@@ -19,7 +19,7 @@
     <RepositoryUrl>https://github.com/EvotecIT/OfficeIMO</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>0.1.0: first-party IntelligenceX plugin pack for OfficeIMO.MarkdownRenderer with IX visual aliases and transcript preset helpers.</PackageReleaseNotes>
+    <PackageReleaseNotes>2.0.2: project canonical ChartForgeX fences into the native visual AST for desktop consumers.</PackageReleaseNotes>
     <DebugType>portable</DebugType>
     <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
     <IsPublishable>True</IsPublishable>

--- a/OfficeIMO.MarkdownRenderer.IntelligenceX/OfficeIMO.MarkdownRenderer.IntelligenceX.csproj
+++ b/OfficeIMO.MarkdownRenderer.IntelligenceX/OfficeIMO.MarkdownRenderer.IntelligenceX.csproj
@@ -4,7 +4,7 @@
     <Description>IntelligenceX renderer plugin pack for OfficeIMO.MarkdownRenderer with transcript-oriented preset helpers and IX visual aliases.</Description>
     <AssemblyName>OfficeIMO.MarkdownRenderer.IntelligenceX</AssemblyName>
     <AssemblyTitle>OfficeIMO.MarkdownRenderer.IntelligenceX</AssemblyTitle>
-    <VersionPrefix>2.0.2</VersionPrefix>
+    <VersionPrefix>2.0.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
       $(TargetFrameworks);net472
@@ -19,7 +19,7 @@
     <RepositoryUrl>https://github.com/EvotecIT/OfficeIMO</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>2.0.2: project canonical ChartForgeX fences into the native visual AST for desktop consumers.</PackageReleaseNotes>
+    <PackageReleaseNotes>0.1.0: first-party IntelligenceX plugin pack for OfficeIMO.MarkdownRenderer with IX visual aliases and transcript preset helpers.</PackageReleaseNotes>
     <DebugType>portable</DebugType>
     <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
     <IsPublishable>True</IsPublishable>


### PR DESCRIPTION
## Summary

- recognize canonical ChartForgeX fenced blocks in the IntelligenceX renderer adapter
- preserve the complete fence info and payload in OfficeIMO's native visual AST
- cover topology, flow, table, chart, timeline, and sequence fences across supported target frameworks
- keep package versioning out of this focused parser change

## Why

Native desktop consumers previously received canonical ChartForgeX fences as ordinary code blocks. This keeps semantic fence ownership in the renderer adapter so consumers can pass the typed native block to ChartForgeX without inventing another fence classifier.

## Validation

- 21 focused IntelligenceX renderer tests on net472, net8.0, and net10.0
- release packaging guard passes on net472, net8.0, and net10.0
- regression coverage verifies the ChartForgeX extension remains active when the core IntelligenceX adapter is applied first

Package publication will follow as a repository-wide version change so OfficeIMO's single-version release contract remains intact.
