### PR TITLE
Preserve EPUB accessibility, list, and footnote semantics

### DIFF
--- a/OfficeIMO.Html.Tests/Html.AccessibleNames.cs
+++ b/OfficeIMO.Html.Tests/Html.AccessibleNames.cs
@@ -15,10 +15,12 @@ public sealed class HtmlAccessibleNameTests {
     [Fact]
     public void AccessibilitySemantics_ResolvesAriaAndHostLanguageNamesInPriorityOrder() {
         var document = HtmlDocumentParser.ParseDocument("""
-<span id="chapter">Chapter</span><span id="number">four</span>
+<span id="chapter" aria-label="Chapter">ignored</span><span id="number">four</span>
 <a id="link" href="#target" aria-labelledby="chapter number"></a>
 <img id="aria-image" src="cover.png" alt="Cover" aria-label="Accessible cover">
 <img id="decorative" src="rule.png" alt="" title="Decorative rule">
+<span id="cycle-a" aria-labelledby="cycle-b"></span>
+<span id="cycle-b" aria-labelledby="cycle-a" aria-label="Cycle safe"></span>
 """);
 
         Assert.Equal(
@@ -30,6 +32,9 @@ public sealed class HtmlAccessibleNameTests {
         Assert.Equal(
             string.Empty,
             HtmlAccessibilitySemantics.GetAccessibleName(document.GetElementById("decorative")!));
+        Assert.Equal(
+            "Cycle safe",
+            HtmlAccessibilitySemantics.GetAccessibleName(document.GetElementById("cycle-a")!, includeTextFallback: true));
 
         var customImage = HtmlDocumentParser.ParseDocument("<media-image alt=\"Aliased image\"></media-image>");
         Assert.Equal(

--- a/OfficeIMO.Html.Tests/Html.AccessibleNames.cs
+++ b/OfficeIMO.Html.Tests/Html.AccessibleNames.cs
@@ -1,0 +1,103 @@
+using OfficeIMO.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class HtmlAccessibleNameTests {
+    [Fact]
+    public void LogicalNodeKind_AppendsSemanticKindsWithoutRenumberingExistingValues() {
+        Assert.Equal(19, (int)HtmlLogicalNodeKind.TableCaption);
+        Assert.Equal(20, (int)HtmlLogicalNodeKind.Code);
+        Assert.Equal(21, (int)HtmlLogicalNodeKind.Quote);
+        Assert.Equal(22, (int)HtmlLogicalNodeKind.Footnote);
+    }
+
+    [Fact]
+    public void AccessibilitySemantics_ResolvesAriaAndHostLanguageNamesInPriorityOrder() {
+        var document = HtmlDocumentParser.ParseDocument("""
+<span id="chapter">Chapter</span><span id="number">four</span>
+<a id="link" href="#target" aria-labelledby="chapter number"></a>
+<img id="aria-image" src="cover.png" alt="Cover" aria-label="Accessible cover">
+<img id="decorative" src="rule.png" alt="" title="Decorative rule">
+""");
+
+        Assert.Equal(
+            "Chapter four",
+            HtmlAccessibilitySemantics.GetAccessibleName(document.GetElementById("link")!, includeTextFallback: true));
+        Assert.Equal(
+            "Accessible cover",
+            HtmlAccessibilitySemantics.GetAccessibleName(document.GetElementById("aria-image")!));
+        Assert.Equal(
+            string.Empty,
+            HtmlAccessibilitySemantics.GetAccessibleName(document.GetElementById("decorative")!));
+
+        var customImage = HtmlDocumentParser.ParseDocument("<media-image alt=\"Aliased image\"></media-image>");
+        Assert.Equal(
+            "Aliased image",
+            HtmlAccessibilitySemantics.GetImageAccessibleName(customImage.Body!.FirstElementChild!));
+
+        var svgImage = HtmlDocumentParser.ParseDocument("<svg><title>Vector diagram</title></svg>");
+        Assert.Equal(
+            "Vector diagram",
+            HtmlAccessibilitySemantics.GetImageAccessibleName(svgImage.Body!.FirstElementChild!));
+    }
+
+    [Theory]
+    [InlineData("<div role=\"heading\" aria-level=\"4\">Heading</div>", 4)]
+    [InlineData("<span role=\"heading\">Heading</span>", 2)]
+    [InlineData("<div role=\"heading\" aria-level=\"12\">Heading</div>", 6)]
+    [InlineData("<h3>Heading</h3>", 3)]
+    public void AccessibilitySemantics_ResolvesNativeAndAriaHeadingLevels(string html, int expectedLevel) {
+        var document = HtmlDocumentParser.ParseDocument(html);
+
+        Assert.True(HtmlAccessibilitySemantics.TryGetHeadingLevel(document.Body!.FirstElementChild!, out int level));
+        Assert.Equal(expectedLevel, level);
+    }
+
+    [Fact]
+    public void LogicalDocument_ProjectsAccessibleNamesRolesAndCapabilities() {
+        HtmlLogicalDocument logical = HtmlLogicalDocumentBuilder.FromHtml("""
+<main>
+  <div role="heading" aria-level="3">Accessible section</div>
+  <a href="#target" aria-label="Read the note"></a>
+  <blockquote><p>Quoted text</p></blockquote>
+  <pre data-language="csharp">Console.WriteLine(1);</pre>
+  <aside id="note" epub:type="footnote" role="doc-footnote"><p>Note text</p><a epub:type="backlink" href="#target">return</a></aside>
+</main>
+""");
+
+        HtmlLogicalNode heading = Find(logical.Root, HtmlLogicalNodeKind.Heading);
+        HtmlLogicalNode link = Find(logical.Root, HtmlLogicalNodeKind.Link);
+        HtmlLogicalNode quote = Find(logical.Root, HtmlLogicalNodeKind.Quote);
+        HtmlLogicalNode code = Find(logical.Root, HtmlLogicalNodeKind.Code);
+        HtmlLogicalNode footnote = Find(logical.Root, HtmlLogicalNodeKind.Footnote);
+
+        Assert.Equal("Accessible section", heading.Text);
+        Assert.Equal("Read the note", link.AccessibleName);
+        Assert.Equal("Quoted text", quote.Text);
+        Assert.Equal("Console.WriteLine(1);", code.Text);
+        Assert.Equal("Note text", footnote.Text);
+        Assert.Contains("accessibility", logical.Capabilities);
+        Assert.Contains("footnotes", logical.Capabilities);
+        Assert.Contains("quotes", logical.Capabilities);
+        Assert.Contains("code", logical.Capabilities);
+    }
+
+    private static HtmlLogicalNode Find(HtmlLogicalNode node, HtmlLogicalNodeKind kind) {
+        if (node.Kind == kind) return node;
+        foreach (HtmlLogicalNode child in node.Children) {
+            HtmlLogicalNode? found = FindOrNull(child, kind);
+            if (found != null) return found;
+        }
+        throw new InvalidOperationException("Logical node was not found: " + kind);
+    }
+
+    private static HtmlLogicalNode? FindOrNull(HtmlLogicalNode node, HtmlLogicalNodeKind kind) {
+        if (node.Kind == kind) return node;
+        foreach (HtmlLogicalNode child in node.Children) {
+            HtmlLogicalNode? found = FindOrNull(child, kind);
+            if (found != null) return found;
+        }
+        return null;
+    }
+}

--- a/OfficeIMO.Html.Tests/Html.AccessibleNames.cs
+++ b/OfficeIMO.Html.Tests/Html.AccessibleNames.cs
@@ -83,6 +83,17 @@ public sealed class HtmlAccessibleNameTests {
         Assert.Contains("code", logical.Capabilities);
     }
 
+    [Fact]
+    public void LogicalDocument_LinkNamesPreferAriaThenVisibleTextBeforeTitle() {
+        HtmlLogicalDocument visible = HtmlLogicalDocumentBuilder.FromHtml(
+            "<a href=\"guide\" title=\"Open guide\">Read more</a>");
+        HtmlLogicalDocument aria = HtmlLogicalDocumentBuilder.FromHtml(
+            "<a href=\"report\" aria-label=\"Download annual report\">Download</a>");
+
+        Assert.Equal("Read more", Find(visible.Root, HtmlLogicalNodeKind.Link).AccessibleName);
+        Assert.Equal("Download annual report", Find(aria.Root, HtmlLogicalNodeKind.Link).AccessibleName);
+    }
+
     private static HtmlLogicalNode Find(HtmlLogicalNode node, HtmlLogicalNodeKind kind) {
         if (node.Kind == kind) return node;
         foreach (HtmlLogicalNode child in node.Children) {

--- a/OfficeIMO.Html/Accessibility/HtmlAccessibilitySemantics.cs
+++ b/OfficeIMO.Html/Accessibility/HtmlAccessibilitySemantics.cs
@@ -66,49 +66,58 @@ public static class HtmlAccessibilitySemantics {
     /// <param name="element">Element to name.</param>
     /// <param name="includeTextFallback">Whether normalized descendant text may supply the name.</param>
     public static string GetAccessibleName(IElement element, bool includeTextFallback = false) =>
-        GetAccessibleName(element, includeTextFallback, treatAsImage: false);
+        GetAccessibleName(element, includeTextFallback, treatAsImage: false, new HashSet<IElement>());
 
     /// <summary>
     /// Resolves an accessible image name, including image <c>alt</c> semantics for custom
     /// elements that a converter explicitly aliases to an image.
     /// </summary>
     public static string GetImageAccessibleName(IElement element) =>
-        GetAccessibleName(element, includeTextFallback: false, treatAsImage: true);
+        GetAccessibleName(element, includeTextFallback: false, treatAsImage: true, new HashSet<IElement>());
 
-    private static string GetAccessibleName(IElement element, bool includeTextFallback, bool treatAsImage) {
+    private static string GetAccessibleName(
+        IElement element,
+        bool includeTextFallback,
+        bool treatAsImage,
+        ISet<IElement> resolutionPath) {
         if (element == null) return string.Empty;
+        if (!resolutionPath.Add(element)) return string.Empty;
 
-        string labelledBy = ResolveLabelledBy(element);
-        if (labelledBy.Length > 0) return labelledBy;
+        try {
+            string labelledBy = ResolveLabelledBy(element, resolutionPath);
+            if (labelledBy.Length > 0) return labelledBy;
 
-        string ariaLabel = NormalizeText(element.GetAttribute("aria-label"));
-        if (ariaLabel.Length > 0) return ariaLabel;
+            string ariaLabel = NormalizeText(element.GetAttribute("aria-label"));
+            if (ariaLabel.Length > 0) return ariaLabel;
 
-        string tagName = element.TagName;
-        if ((treatAsImage
-             || tagName.Equals("IMG", StringComparison.OrdinalIgnoreCase)
-             || tagName.Equals("AREA", StringComparison.OrdinalIgnoreCase))
-            && element.HasAttribute("alt")) {
-            return NormalizeText(element.GetAttribute("alt"));
+            string tagName = element.TagName;
+            if ((treatAsImage
+                 || tagName.Equals("IMG", StringComparison.OrdinalIgnoreCase)
+                 || tagName.Equals("AREA", StringComparison.OrdinalIgnoreCase))
+                && element.HasAttribute("alt")) {
+                return NormalizeText(element.GetAttribute("alt"));
+            }
+            if (tagName.Equals("INPUT", StringComparison.OrdinalIgnoreCase)
+                && string.Equals(element.GetAttribute("type"), "image", StringComparison.OrdinalIgnoreCase)
+                && element.HasAttribute("alt")) {
+                return NormalizeText(element.GetAttribute("alt"));
+            }
+            if (tagName.Equals("SVG", StringComparison.OrdinalIgnoreCase)) {
+                IElement? titleElement = element.Children.FirstOrDefault(static child =>
+                    child.TagName.Equals("TITLE", StringComparison.OrdinalIgnoreCase));
+                string svgTitle = NormalizeText(titleElement?.TextContent);
+                if (svgTitle.Length > 0) return svgTitle;
+            }
+
+            if (includeTextFallback) {
+                string text = NormalizeText(element.TextContent);
+                if (text.Length > 0) return text;
+            }
+
+            return NormalizeText(element.GetAttribute("title"));
+        } finally {
+            resolutionPath.Remove(element);
         }
-        if (tagName.Equals("INPUT", StringComparison.OrdinalIgnoreCase)
-            && string.Equals(element.GetAttribute("type"), "image", StringComparison.OrdinalIgnoreCase)
-            && element.HasAttribute("alt")) {
-            return NormalizeText(element.GetAttribute("alt"));
-        }
-        if (tagName.Equals("SVG", StringComparison.OrdinalIgnoreCase)) {
-            IElement? titleElement = element.Children.FirstOrDefault(static child =>
-                child.TagName.Equals("TITLE", StringComparison.OrdinalIgnoreCase));
-            string svgTitle = NormalizeText(titleElement?.TextContent);
-            if (svgTitle.Length > 0) return svgTitle;
-        }
-
-        if (includeTextFallback) {
-            string text = NormalizeText(element.TextContent);
-            if (text.Length > 0) return text;
-        }
-
-        return NormalizeText(element.GetAttribute("title"));
     }
 
     /// <summary>Returns whether an element is explicitly hidden from the accessibility tree.</summary>
@@ -124,7 +133,7 @@ public static class HtmlAccessibilitySemantics {
         return false;
     }
 
-    private static string ResolveLabelledBy(IElement element) {
+    private static string ResolveLabelledBy(IElement element, ISet<IElement> resolutionPath) {
         string? value = element.GetAttribute("aria-labelledby");
         if (string.IsNullOrWhiteSpace(value) || element.Owner == null) return string.Empty;
 
@@ -134,7 +143,7 @@ public static class HtmlAccessibilitySemantics {
             if (!seen.Add(id)) continue;
             IElement? label = element.Owner.GetElementById(id);
             if (label == null || ReferenceEquals(label, element)) continue;
-            string text = NormalizeText(label.TextContent);
+            string text = GetAccessibleName(label, includeTextFallback: true, treatAsImage: false, resolutionPath);
             if (text.Length > 0) labels.Add(text);
         }
         return string.Join(" ", labels);

--- a/OfficeIMO.Html/Accessibility/HtmlAccessibilitySemantics.cs
+++ b/OfficeIMO.Html/Accessibility/HtmlAccessibilitySemantics.cs
@@ -1,0 +1,147 @@
+using AngleSharp.Dom;
+
+namespace OfficeIMO.Html;
+
+/// <summary>
+/// Resolves the small, deterministic subset of HTML and ARIA accessibility semantics
+/// used by OfficeIMO document conversion pipelines.
+/// </summary>
+public static class HtmlAccessibilitySemantics {
+    private static readonly char[] TokenSeparators = { ' ', '\t', '\r', '\n', '\f' };
+
+    /// <summary>Returns whether an element declares the requested ARIA role.</summary>
+    public static bool HasRole(IElement element, string role) =>
+        element != null && ContainsToken(element.GetAttribute("role"), role);
+
+    /// <summary>Returns whether an element declares the requested EPUB structural semantic.</summary>
+    public static bool HasEpubType(IElement element, string semanticType) {
+        if (element == null || string.IsNullOrWhiteSpace(semanticType)) return false;
+
+        string? value = element.GetAttribute("epub:type");
+        if (string.IsNullOrWhiteSpace(value)) {
+            foreach (IAttr attribute in element.Attributes) {
+                if (attribute.Name.Equals("epub:type", StringComparison.OrdinalIgnoreCase)) {
+                    value = attribute.Value;
+                    break;
+                }
+            }
+        }
+        return ContainsToken(value, semanticType);
+    }
+
+    /// <summary>
+    /// Resolves a heading level from a native heading element or an ARIA heading role.
+    /// ARIA levels outside the Markdown heading range are clamped to levels 1 through 6.
+    /// </summary>
+    public static bool TryGetHeadingLevel(IElement element, out int level) {
+        level = 0;
+        if (element == null) return false;
+
+        string tagName = element.TagName;
+        if (tagName.Length == 2
+            && (tagName[0] == 'h' || tagName[0] == 'H')
+            && tagName[1] >= '1'
+            && tagName[1] <= '6') {
+            level = tagName[1] - '0';
+            return true;
+        }
+
+        if (!HasRole(element, "heading")) return false;
+        if (!int.TryParse(
+                element.GetAttribute("aria-level"),
+                System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out level)) {
+            level = 2;
+        }
+        if (level < 1) level = 1;
+        if (level > 6) level = 6;
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves an accessible name using ARIA labelling, host-language alternatives,
+    /// optional element text, and title fallback. This does not mutate the DOM.
+    /// </summary>
+    /// <param name="element">Element to name.</param>
+    /// <param name="includeTextFallback">Whether normalized descendant text may supply the name.</param>
+    public static string GetAccessibleName(IElement element, bool includeTextFallback = false) =>
+        GetAccessibleName(element, includeTextFallback, treatAsImage: false);
+
+    /// <summary>
+    /// Resolves an accessible image name, including image <c>alt</c> semantics for custom
+    /// elements that a converter explicitly aliases to an image.
+    /// </summary>
+    public static string GetImageAccessibleName(IElement element) =>
+        GetAccessibleName(element, includeTextFallback: false, treatAsImage: true);
+
+    private static string GetAccessibleName(IElement element, bool includeTextFallback, bool treatAsImage) {
+        if (element == null) return string.Empty;
+
+        string labelledBy = ResolveLabelledBy(element);
+        if (labelledBy.Length > 0) return labelledBy;
+
+        string ariaLabel = NormalizeText(element.GetAttribute("aria-label"));
+        if (ariaLabel.Length > 0) return ariaLabel;
+
+        string tagName = element.TagName;
+        if ((treatAsImage
+             || tagName.Equals("IMG", StringComparison.OrdinalIgnoreCase)
+             || tagName.Equals("AREA", StringComparison.OrdinalIgnoreCase))
+            && element.HasAttribute("alt")) {
+            return NormalizeText(element.GetAttribute("alt"));
+        }
+        if (tagName.Equals("INPUT", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(element.GetAttribute("type"), "image", StringComparison.OrdinalIgnoreCase)
+            && element.HasAttribute("alt")) {
+            return NormalizeText(element.GetAttribute("alt"));
+        }
+        if (tagName.Equals("SVG", StringComparison.OrdinalIgnoreCase)) {
+            IElement? titleElement = element.Children.FirstOrDefault(static child =>
+                child.TagName.Equals("TITLE", StringComparison.OrdinalIgnoreCase));
+            string svgTitle = NormalizeText(titleElement?.TextContent);
+            if (svgTitle.Length > 0) return svgTitle;
+        }
+
+        if (includeTextFallback) {
+            string text = NormalizeText(element.TextContent);
+            if (text.Length > 0) return text;
+        }
+
+        return NormalizeText(element.GetAttribute("title"));
+    }
+
+    /// <summary>Returns whether an element is explicitly hidden from the accessibility tree.</summary>
+    public static bool IsAriaHidden(IElement element) =>
+        element != null
+        && string.Equals(element.GetAttribute("aria-hidden")?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
+
+    internal static bool ContainsToken(string? value, string token) {
+        if (string.IsNullOrWhiteSpace(value) || string.IsNullOrWhiteSpace(token)) return false;
+        foreach (string candidate in value!.Split(TokenSeparators, StringSplitOptions.RemoveEmptyEntries)) {
+            if (candidate.Equals(token, StringComparison.OrdinalIgnoreCase)) return true;
+        }
+        return false;
+    }
+
+    private static string ResolveLabelledBy(IElement element) {
+        string? value = element.GetAttribute("aria-labelledby");
+        if (string.IsNullOrWhiteSpace(value) || element.Owner == null) return string.Empty;
+
+        var labels = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (string id in value!.Split(TokenSeparators, StringSplitOptions.RemoveEmptyEntries)) {
+            if (!seen.Add(id)) continue;
+            IElement? label = element.Owner.GetElementById(id);
+            if (label == null || ReferenceEquals(label, element)) continue;
+            string text = NormalizeText(label.TextContent);
+            if (text.Length > 0) labels.Add(text);
+        }
+        return string.Join(" ", labels);
+    }
+
+    private static string NormalizeText(string? value) {
+        if (string.IsNullOrWhiteSpace(value)) return string.Empty;
+        return string.Join(" ", value!.Split(TokenSeparators, StringSplitOptions.RemoveEmptyEntries));
+    }
+}

--- a/OfficeIMO.Html/Model/HtmlLogicalDocumentBuilder.cs
+++ b/OfficeIMO.Html/Model/HtmlLogicalDocumentBuilder.cs
@@ -40,6 +40,8 @@ internal static class HtmlLogicalDocumentBuilder {
         HtmlLogicalNode node = CreateNode(source);
 
         if (source is IElement element) {
+            string accessibleName = HtmlAccessibilitySemantics.GetAccessibleName(element);
+            node.AccessibleName = accessibleName.Length == 0 ? null : accessibleName;
             foreach (IAttr attribute in element.Attributes) {
                 node.AddAttribute(attribute.Name, attribute.Value);
             }
@@ -102,11 +104,29 @@ internal static class HtmlLogicalDocumentBuilder {
 
         string name = element.TagName.ToLowerInvariant();
         HtmlLogicalNodeKind kind = MapKind(name, element);
-        string capturedText = kind == HtmlLogicalNodeKind.Text ? NormalizeText(element.TextContent) : CaptureText(name, element);
+        string capturedText = kind == HtmlLogicalNodeKind.Text
+            ? NormalizeText(element.TextContent)
+            : CaptureText(name, element, kind);
         return new HtmlLogicalNode(kind, name, capturedText);
     }
 
     private static HtmlLogicalNodeKind MapKind(string name, IElement element) {
+        if (HtmlAccessibilitySemantics.TryGetHeadingLevel(element, out _)) {
+            return HtmlLogicalNodeKind.Heading;
+        }
+        if (IsFootnoteDefinition(element)) return HtmlLogicalNodeKind.Footnote;
+        if (HtmlAccessibilitySemantics.HasRole(element, "list")) return HtmlLogicalNodeKind.List;
+        if (HtmlAccessibilitySemantics.HasRole(element, "listitem")) return HtmlLogicalNodeKind.ListItem;
+        if (HtmlAccessibilitySemantics.HasRole(element, "table")) return HtmlLogicalNodeKind.Table;
+        if (HtmlAccessibilitySemantics.HasRole(element, "row")) return HtmlLogicalNodeKind.TableRow;
+        if (HtmlAccessibilitySemantics.HasRole(element, "cell")
+            || HtmlAccessibilitySemantics.HasRole(element, "columnheader")
+            || HtmlAccessibilitySemantics.HasRole(element, "rowheader")) {
+            return HtmlLogicalNodeKind.TableCell;
+        }
+        if (HtmlAccessibilitySemantics.HasRole(element, "img")) return HtmlLogicalNodeKind.Image;
+        if (HtmlAccessibilitySemantics.HasRole(element, "link")) return HtmlLogicalNodeKind.Link;
+
         if (name == "body" || name == "main" || name == "article" || name == "section" || name == "aside" || name == "header" || name == "footer") {
             return HtmlLogicalNodeKind.Section;
         }
@@ -117,9 +137,11 @@ internal static class HtmlLogicalDocumentBuilder {
 
         switch (name) {
             case "p":
-            case "blockquote":
-            case "pre":
                 return HtmlLogicalNodeKind.Paragraph;
+            case "pre":
+                return HtmlLogicalNodeKind.Code;
+            case "blockquote":
+                return HtmlLogicalNodeKind.Quote;
             case "ul":
             case "ol":
             case "dl":
@@ -190,7 +212,11 @@ internal static class HtmlLogicalDocumentBuilder {
         }
     }
 
-    private static string CaptureText(string name, IElement element) {
+    private static string CaptureText(string name, IElement element, HtmlLogicalNodeKind kind) {
+        if (kind == HtmlLogicalNodeKind.Heading) return NormalizeText(element.TextContent);
+        if (kind == HtmlLogicalNodeKind.Code) return NormalizePreformattedText(element.TextContent);
+        if (kind == HtmlLogicalNodeKind.Quote) return NormalizeText(element.TextContent);
+        if (kind == HtmlLogicalNodeKind.Footnote) return CaptureFootnoteText(element);
         switch (name) {
             case "h1":
             case "h2":
@@ -210,9 +236,25 @@ internal static class HtmlLogicalDocumentBuilder {
     }
 
     private static IEnumerable<string> InferCapabilities(HtmlLogicalNode node) {
+        if (!string.IsNullOrWhiteSpace(node.AccessibleName)
+            || node.Attributes.ContainsKey("role")
+            || node.Attributes.Keys.Any(static key => key.StartsWith("aria-", StringComparison.OrdinalIgnoreCase))) {
+            yield return "accessibility";
+        }
+        if (HasFootnoteSemantic(node)) yield return "footnotes";
+
         switch (node.Kind) {
             case HtmlLogicalNodeKind.Heading:
                 yield return "headings";
+                break;
+            case HtmlLogicalNodeKind.Code:
+                yield return "code";
+                break;
+            case HtmlLogicalNodeKind.Quote:
+                yield return "quotes";
+                break;
+            case HtmlLogicalNodeKind.Footnote:
+                yield return "footnotes";
                 break;
             case HtmlLogicalNodeKind.Table:
             case HtmlLogicalNodeKind.TableCell:
@@ -240,6 +282,55 @@ internal static class HtmlLogicalDocumentBuilder {
                 yield return "figures";
                 break;
         }
+    }
+
+    private static bool HasFootnoteSemantic(HtmlLogicalNode node) {
+        if (node.Attributes.TryGetValue("role", out string? role)
+            && (HtmlAccessibilitySemantics.ContainsToken(role, "doc-noteref")
+                || HtmlAccessibilitySemantics.ContainsToken(role, "doc-footnote")
+                || HtmlAccessibilitySemantics.ContainsToken(role, "doc-endnote")
+                || HtmlAccessibilitySemantics.ContainsToken(role, "doc-endnotes")
+                || HtmlAccessibilitySemantics.ContainsToken(role, "doc-backlink"))) {
+            return true;
+        }
+        return node.Attributes.TryGetValue("epub:type", out string? epubType)
+               && new[] { "noteref", "footnote", "footnotes", "endnote", "endnotes", "rearnote", "rearnotes", "backlink" }
+                   .Any(token => HtmlAccessibilitySemantics.ContainsToken(epubType, token));
+    }
+
+    private static bool IsFootnoteDefinition(IElement element) =>
+        HtmlAccessibilitySemantics.HasRole(element, "doc-footnote")
+        || HtmlAccessibilitySemantics.HasRole(element, "doc-endnote")
+        || HtmlAccessibilitySemantics.HasEpubType(element, "footnote")
+        || HtmlAccessibilitySemantics.HasEpubType(element, "endnote")
+        || HtmlAccessibilitySemantics.HasEpubType(element, "rearnote")
+        || HtmlAccessibilitySemantics.HasEpubType(element, "note");
+
+    private static string CaptureFootnoteText(IElement element) {
+        var builder = new StringBuilder();
+        AppendFootnoteText(element, builder);
+        return NormalizeText(builder.ToString());
+    }
+
+    private static void AppendFootnoteText(INode node, StringBuilder builder) {
+        foreach (INode child in node.ChildNodes) {
+            if (child is IElement element) {
+                if (HtmlAccessibilitySemantics.HasRole(element, "doc-backlink")
+                    || HtmlAccessibilitySemantics.HasEpubType(element, "backlink")
+                    || element.HasAttribute("data-footnote-backref")
+                    || element.ClassList.Contains("footnote-backref")) {
+                    continue;
+                }
+                AppendFootnoteText(element, builder);
+            } else if (child is IText text) {
+                builder.Append(text.Data);
+            }
+        }
+    }
+
+    private static string NormalizePreformattedText(string? text) {
+        if (string.IsNullOrEmpty(text)) return string.Empty;
+        return text!.Replace("\r\n", "\n").Replace('\r', '\n').Trim('\n');
     }
 
     private static void Count(IDictionary<HtmlLogicalNodeKind, int> counts, HtmlLogicalNodeKind kind) {

--- a/OfficeIMO.Html/Model/HtmlLogicalDocumentBuilder.cs
+++ b/OfficeIMO.Html/Model/HtmlLogicalDocumentBuilder.cs
@@ -40,7 +40,9 @@ internal static class HtmlLogicalDocumentBuilder {
         HtmlLogicalNode node = CreateNode(source);
 
         if (source is IElement element) {
-            string accessibleName = HtmlAccessibilitySemantics.GetAccessibleName(element);
+            string accessibleName = HtmlAccessibilitySemantics.GetAccessibleName(
+                element,
+                includeTextFallback: node.Kind == HtmlLogicalNodeKind.Link);
             node.AccessibleName = accessibleName.Length == 0 ? null : accessibleName;
             foreach (IAttr attribute in element.Attributes) {
                 node.AddAttribute(attribute.Name, attribute.Value);
@@ -303,7 +305,35 @@ internal static class HtmlLogicalDocumentBuilder {
         || HtmlAccessibilitySemantics.HasRole(element, "doc-endnote")
         || HtmlAccessibilitySemantics.HasEpubType(element, "footnote")
         || HtmlAccessibilitySemantics.HasEpubType(element, "endnote")
-        || HtmlAccessibilitySemantics.HasEpubType(element, "rearnote");
+        || HtmlAccessibilitySemantics.HasEpubType(element, "rearnote")
+        || IsFootnoteCollectionMember(element);
+
+    private static bool IsFootnoteCollectionMember(IElement element) {
+        if (!element.TagName.Equals("LI", StringComparison.OrdinalIgnoreCase)) return false;
+
+        string? id = element.Id;
+        if (string.IsNullOrWhiteSpace(id)) return false;
+
+        string footnoteId = id!;
+        if (!footnoteId.StartsWith("fn:", StringComparison.OrdinalIgnoreCase)
+            && !footnoteId.StartsWith("fn-", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
+
+        for (IElement? current = element.ParentElement; current != null; current = current.ParentElement) {
+            if (IsFootnoteCollection(current)) return true;
+        }
+        return false;
+    }
+
+    private static bool IsFootnoteCollection(IElement element) =>
+        element.HasAttribute("data-footnotes")
+        || element.ClassList.Contains("footnotes")
+        || element.ClassList.Contains("endnotes")
+        || HtmlAccessibilitySemantics.HasEpubType(element, "footnotes")
+        || HtmlAccessibilitySemantics.HasEpubType(element, "endnotes")
+        || HtmlAccessibilitySemantics.HasEpubType(element, "rearnotes")
+        || HtmlAccessibilitySemantics.HasRole(element, "doc-endnotes");
 
     private static string CaptureFootnoteText(IElement element) {
         var builder = new StringBuilder();

--- a/OfficeIMO.Html/Model/HtmlLogicalDocumentBuilder.cs
+++ b/OfficeIMO.Html/Model/HtmlLogicalDocumentBuilder.cs
@@ -303,8 +303,7 @@ internal static class HtmlLogicalDocumentBuilder {
         || HtmlAccessibilitySemantics.HasRole(element, "doc-endnote")
         || HtmlAccessibilitySemantics.HasEpubType(element, "footnote")
         || HtmlAccessibilitySemantics.HasEpubType(element, "endnote")
-        || HtmlAccessibilitySemantics.HasEpubType(element, "rearnote")
-        || HtmlAccessibilitySemantics.HasEpubType(element, "note");
+        || HtmlAccessibilitySemantics.HasEpubType(element, "rearnote");
 
     private static string CaptureFootnoteText(IElement element) {
         var builder = new StringBuilder();

--- a/OfficeIMO.Html/Model/HtmlLogicalNode.cs
+++ b/OfficeIMO.Html/Model/HtmlLogicalNode.cs
@@ -20,8 +20,11 @@ public sealed class HtmlLogicalNode {
     /// <summary>Original element name, or <c>#text</c> for text nodes.</summary>
     public string Name { get; }
 
-    /// <summary>Trimmed node text for text and small semantic nodes.</summary>
+    /// <summary>Normalized node text, or preserved preformatted text for code nodes.</summary>
     public string Text { get; }
+
+    /// <summary>ARIA or host-language accessible name resolved from the source element.</summary>
+    public string? AccessibleName { get; internal set; }
 
     /// <summary>Attributes captured from the source element.</summary>
     public IReadOnlyDictionary<string, string> Attributes => _attributes;

--- a/OfficeIMO.Html/Model/HtmlLogicalNodeKind.cs
+++ b/OfficeIMO.Html/Model/HtmlLogicalNodeKind.cs
@@ -43,5 +43,11 @@ public enum HtmlLogicalNodeKind {
     /// <summary>Node that does not map to a known logical kind.</summary>
     Unknown,
     /// <summary>Table caption.</summary>
-    TableCaption
+    TableCaption,
+    /// <summary>Preformatted or source-code block.</summary>
+    Code,
+    /// <summary>Quoted block content.</summary>
+    Quote,
+    /// <summary>EPUB, DPUB-ARIA, or compatible footnote definition.</summary>
+    Footnote
 }

--- a/OfficeIMO.Html/README.md
+++ b/OfficeIMO.Html/README.md
@@ -9,6 +9,7 @@ It owns the reusable parts that should behave consistently across HTML-to-Markdo
 - DOM traversal facts and node/depth limit tracking
 - image source discovery for `img`, lazy-loading attributes, `srcset`, and `picture/source`
 - image data URI parsing and media-type extension mapping
+- deterministic accessible-name, ARIA heading, EPUB structural-semantic, and logical quote/code/footnote projection
 - dependency-free HTML layout for continuous and paged output
 - direct PNG and SVG export over `OfficeIMO.Drawing`
 - semantic HTML to/from RTF conversion over the dependency-free `OfficeIMO.Rtf` model

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.Flow.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.Flow.cs
@@ -74,6 +74,7 @@ internal sealed partial class HtmlToMarkdownConverter {
                 .Where(child => HasEffectiveTagName(child, context, "LI"))
                 .ToArray();
             bool reversed = element.HasAttribute("reversed");
+            list.Reversed = reversed;
             int currentValue = reversed ? itemElements.Length : 1;
             if (int.TryParse(
                     element.GetAttribute("start"),

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.Flow.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.Flow.cs
@@ -94,7 +94,7 @@ internal sealed partial class HtmlToMarkdownConverter {
                     currentValue = itemValue;
                 }
                 ListItem item = ConvertListItem(itemElement, context);
-                item.MarkerText = FormatOrderedListMarker(currentValue, list.MarkerStyle);
+                item.MarkerText = currentValue.ToString(System.Globalization.CultureInfo.InvariantCulture) + ".";
                 list.Items.Add(item);
                 currentValue += step;
             }
@@ -280,56 +280,6 @@ internal sealed partial class HtmlToMarkdownConverter {
             case "I": return MarkdownOrderedListMarkerStyle.UpperRoman;
             default: return MarkdownOrderedListMarkerStyle.Decimal;
         }
-    }
-
-    private static string FormatOrderedListMarker(int value, MarkdownOrderedListMarkerStyle style) {
-        string marker;
-        switch (style) {
-            case MarkdownOrderedListMarkerStyle.LowerAlpha:
-                marker = FormatOrderedListAlpha(value, uppercase: false);
-                break;
-            case MarkdownOrderedListMarkerStyle.UpperAlpha:
-                marker = FormatOrderedListAlpha(value, uppercase: true);
-                break;
-            case MarkdownOrderedListMarkerStyle.LowerRoman:
-                marker = FormatOrderedListRoman(value, uppercase: false);
-                break;
-            case MarkdownOrderedListMarkerStyle.UpperRoman:
-                marker = FormatOrderedListRoman(value, uppercase: true);
-                break;
-            default:
-                marker = value.ToString(System.Globalization.CultureInfo.InvariantCulture);
-                break;
-        }
-        return marker + ".";
-    }
-
-    private static string FormatOrderedListAlpha(int value, bool uppercase) {
-        if (value <= 0) return value.ToString(System.Globalization.CultureInfo.InvariantCulture);
-        var builder = new StringBuilder();
-        int remaining = value;
-        while (remaining > 0) {
-            remaining--;
-            builder.Insert(0, (char)((uppercase ? 'A' : 'a') + remaining % 26));
-            remaining /= 26;
-        }
-        return builder.ToString();
-    }
-
-    private static string FormatOrderedListRoman(int value, bool uppercase) {
-        if (value <= 0 || value > 3999) return value.ToString(System.Globalization.CultureInfo.InvariantCulture);
-        int[] values = { 1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1 };
-        string[] symbols = { "m", "cm", "d", "cd", "c", "xc", "l", "xl", "x", "ix", "v", "iv", "i" };
-        var builder = new StringBuilder();
-        int remaining = value;
-        for (int index = 0; index < values.Length; index++) {
-            while (remaining >= values[index]) {
-                builder.Append(symbols[index]);
-                remaining -= values[index];
-            }
-        }
-        string marker = builder.ToString();
-        return uppercase ? marker.ToUpperInvariant() : marker;
     }
 
     private static string ReadCodeLanguageAttribute(IElement? element) {

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.Flow.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.Flow.cs
@@ -69,12 +69,34 @@ internal sealed partial class HtmlToMarkdownConverter {
     private static IMarkdownBlock ConvertListElement(IElement element, bool ordered, ConversionContext context) {
         if (ordered) {
             var list = new OrderedListBlock();
-            if (int.TryParse(element.GetAttribute("start"), out int start) && start > 0) {
-                list.Start = start;
+            list.MarkerStyle = ParseOrderedListMarkerStyle(element.GetAttribute("type"));
+            IElement[] itemElements = element.Children
+                .Where(child => HasEffectiveTagName(child, context, "LI"))
+                .ToArray();
+            bool reversed = element.HasAttribute("reversed");
+            int currentValue = reversed ? itemElements.Length : 1;
+            if (int.TryParse(
+                    element.GetAttribute("start"),
+                    System.Globalization.NumberStyles.Integer,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out int start)) {
+                currentValue = start;
             }
+            list.Start = currentValue;
+            int step = reversed ? -1 : 1;
 
-            foreach (var item in element.Children.Where(child => HasEffectiveTagName(child, context, "LI"))) {
-                list.Items.Add(ConvertListItem(item, context));
+            foreach (IElement itemElement in itemElements) {
+                if (int.TryParse(
+                        itemElement.GetAttribute("value"),
+                        System.Globalization.NumberStyles.Integer,
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        out int itemValue)) {
+                    currentValue = itemValue;
+                }
+                ListItem item = ConvertListItem(itemElement, context);
+                item.MarkerText = FormatOrderedListMarker(currentValue, list.MarkerStyle);
+                list.Items.Add(item);
+                currentValue += step;
             }
 
             return list;
@@ -240,14 +262,83 @@ internal sealed partial class HtmlToMarkdownConverter {
 
     private static CodeBlock ConvertPreElement(IElement element) {
         var codeElement = element.QuerySelector("code");
-        string language = string.Empty;
-        if (codeElement != null) {
-            language = ExtractCodeLanguage(codeElement.GetAttribute("class"));
-        }
+        string language = ExtractCodeLanguage(codeElement?.GetAttribute("class"));
+        if (language.Length == 0) language = ReadCodeLanguageAttribute(codeElement);
+        if (language.Length == 0) language = ExtractCodeLanguage(element.GetAttribute("class"));
+        if (language.Length == 0) language = ReadCodeLanguageAttribute(element);
 
         string content = codeElement?.TextContent ?? element.TextContent ?? string.Empty;
         content = content.Replace("\r\n", "\n").Replace('\r', '\n').TrimEnd('\n');
         return new CodeBlock(language, content);
+    }
+
+    private static MarkdownOrderedListMarkerStyle ParseOrderedListMarkerStyle(string? value) {
+        switch (value?.Trim()) {
+            case "a": return MarkdownOrderedListMarkerStyle.LowerAlpha;
+            case "A": return MarkdownOrderedListMarkerStyle.UpperAlpha;
+            case "i": return MarkdownOrderedListMarkerStyle.LowerRoman;
+            case "I": return MarkdownOrderedListMarkerStyle.UpperRoman;
+            default: return MarkdownOrderedListMarkerStyle.Decimal;
+        }
+    }
+
+    private static string FormatOrderedListMarker(int value, MarkdownOrderedListMarkerStyle style) {
+        string marker;
+        switch (style) {
+            case MarkdownOrderedListMarkerStyle.LowerAlpha:
+                marker = FormatOrderedListAlpha(value, uppercase: false);
+                break;
+            case MarkdownOrderedListMarkerStyle.UpperAlpha:
+                marker = FormatOrderedListAlpha(value, uppercase: true);
+                break;
+            case MarkdownOrderedListMarkerStyle.LowerRoman:
+                marker = FormatOrderedListRoman(value, uppercase: false);
+                break;
+            case MarkdownOrderedListMarkerStyle.UpperRoman:
+                marker = FormatOrderedListRoman(value, uppercase: true);
+                break;
+            default:
+                marker = value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                break;
+        }
+        return marker + ".";
+    }
+
+    private static string FormatOrderedListAlpha(int value, bool uppercase) {
+        if (value <= 0) return value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var builder = new StringBuilder();
+        int remaining = value;
+        while (remaining > 0) {
+            remaining--;
+            builder.Insert(0, (char)((uppercase ? 'A' : 'a') + remaining % 26));
+            remaining /= 26;
+        }
+        return builder.ToString();
+    }
+
+    private static string FormatOrderedListRoman(int value, bool uppercase) {
+        if (value <= 0 || value > 3999) return value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        int[] values = { 1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1 };
+        string[] symbols = { "m", "cm", "d", "cd", "c", "xc", "l", "xl", "x", "ix", "v", "iv", "i" };
+        var builder = new StringBuilder();
+        int remaining = value;
+        for (int index = 0; index < values.Length; index++) {
+            while (remaining >= values[index]) {
+                builder.Append(symbols[index]);
+                remaining -= values[index];
+            }
+        }
+        string marker = builder.ToString();
+        return uppercase ? marker.ToUpperInvariant() : marker;
+    }
+
+    private static string ReadCodeLanguageAttribute(IElement? element) {
+        if (element == null) return string.Empty;
+        foreach (string name in new[] { "data-language", "data-lang", "lang" }) {
+            string? value = element.GetAttribute(name);
+            if (!string.IsNullOrWhiteSpace(value)) return value!.Trim();
+        }
+        return string.Empty;
     }
 
     private static string ExtractCodeLanguage(string? classValue) {

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.ImageSources.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.ImageSources.cs
@@ -229,7 +229,7 @@ internal sealed partial class HtmlToMarkdownConverter {
     private static ImageBlock CreateImageBlock(string src, IElement metadataElement, IElement? pictureElement = null, ConversionContext? context = null) {
         var image = new ImageBlock(
             src,
-            metadataElement.GetAttribute("alt"),
+            GetAccessibleImageName(metadataElement),
             metadataElement.GetAttribute("title"));
         ApplyImageDimensions(metadataElement, image);
         if (pictureElement != null && context != null) {
@@ -265,7 +265,9 @@ internal sealed partial class HtmlToMarkdownConverter {
     private static ImageBlock MergeImageMetadata(IElement preferredElement, ImageBlock fallbackImage, IElement? fallbackMetadataElement) {
         var merged = new ImageBlock(
             fallbackImage.Path,
-            !string.IsNullOrWhiteSpace(preferredElement.GetAttribute("alt")) ? preferredElement.GetAttribute("alt") : fallbackImage.Alt,
+            HasAccessibleNameDeclaration(preferredElement)
+                ? GetAccessibleImageName(preferredElement)
+                : fallbackImage.Alt,
             !string.IsNullOrWhiteSpace(preferredElement.GetAttribute("title")) ? preferredElement.GetAttribute("title") : fallbackImage.Title,
             fallbackImage.Width,
             fallbackImage.Height,
@@ -289,12 +291,27 @@ internal sealed partial class HtmlToMarkdownConverter {
     private static ImageBlock CreateMergedImageBlock(string src, IElement preferredMetadataElement, IElement fallbackMetadataElement) {
         var image = new ImageBlock(
             src,
-            !string.IsNullOrWhiteSpace(preferredMetadataElement.GetAttribute("alt")) ? preferredMetadataElement.GetAttribute("alt") : fallbackMetadataElement.GetAttribute("alt"),
+            HasAccessibleNameDeclaration(preferredMetadataElement)
+                ? GetAccessibleImageName(preferredMetadataElement)
+                : GetAccessibleImageName(fallbackMetadataElement),
             !string.IsNullOrWhiteSpace(preferredMetadataElement.GetAttribute("title")) ? preferredMetadataElement.GetAttribute("title") : fallbackMetadataElement.GetAttribute("title"));
         ApplyImageDimensions(preferredMetadataElement, image);
         ApplyMissingImageDimensions(fallbackMetadataElement, image);
         return image;
     }
+
+    private static bool HasAccessibleNameDeclaration(IElement element) =>
+        element.HasAttribute("aria-labelledby")
+        || element.HasAttribute("aria-label")
+        || element.HasAttribute("alt")
+        || element.HasAttribute("title")
+        || element.TagName.Equals("SVG", StringComparison.OrdinalIgnoreCase)
+           && element.Children.Any(static child => child.TagName.Equals("TITLE", StringComparison.OrdinalIgnoreCase));
+
+    private static string? GetAccessibleImageName(IElement element) =>
+        HasAccessibleNameDeclaration(element)
+            ? HtmlAccessibilitySemantics.GetImageAccessibleName(element)
+            : null;
 
     private static void ApplyPictureMetadata(IElement pictureElement, ImageBlock image, IElement? fallbackImageElement, ConversionContext context) {
         if (pictureElement == null || image == null || context == null) {

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Blocks.cs
@@ -1,4 +1,5 @@
 using AngleSharp.Dom;
+using OfficeIMO.Html;
 using OfficeIMO.Markdown;
 
 namespace OfficeIMO.Markdown.Html;
@@ -65,6 +66,12 @@ internal sealed partial class HtmlToMarkdownConverter {
     }
 
     private static bool ShouldTreatAsBlockElement(IElement element, ConversionContext context) {
+        if (context.Footnotes.TryGetDefinitionLabel(element, out _)
+            || context.Footnotes.ShouldConvertContainer(element)
+            || HtmlAccessibilitySemantics.TryGetHeadingLevel(element, out _)) {
+            return true;
+        }
+
         if (IsBlockElement(element, context)) {
             return true;
         }
@@ -193,6 +200,14 @@ internal sealed partial class HtmlToMarkdownConverter {
 
         if (TryConvertConfiguredElementConverters(element, context, out var customBlocks)) {
             return customBlocks;
+        }
+
+        if (TryConvertFootnoteElement(element, context, out IReadOnlyList<IMarkdownBlock> footnoteBlocks)) {
+            return footnoteBlocks;
+        }
+
+        if (HtmlAccessibilitySemantics.TryGetHeadingLevel(element, out int accessibleHeadingLevel)) {
+            return new IMarkdownBlock[] { ConvertHeadingElement(element, accessibleHeadingLevel, context) };
         }
 
         string tag = GetEffectiveTagName(element, context);

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Footnotes.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Footnotes.cs
@@ -142,7 +142,7 @@ internal sealed partial class HtmlToMarkdownConverter {
         }
 
         private static bool IsSemanticFootnoteDefinition(IElement element) =>
-            HasAnyEpubType(element, "footnote", "endnote", "rearnote", "note")
+            HasAnyEpubType(element, "footnote", "endnote", "rearnote")
             || HasAnyRole(element, "doc-footnote", "doc-endnote");
 
         private static bool IsRecognizedIdDefinition(IElement element, ISet<string> referencedIds) {

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Footnotes.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Footnotes.cs
@@ -1,0 +1,295 @@
+using AngleSharp.Dom;
+using OfficeIMO.Html;
+using OfficeIMO.Markdown;
+
+namespace OfficeIMO.Markdown.Html;
+
+internal sealed partial class HtmlToMarkdownConverter {
+    internal sealed class HtmlFootnoteConversionState {
+        private readonly IReadOnlyList<IElement> _orderedDefinitions;
+        private readonly Dictionary<IElement, string> _labelsByDefinition;
+        private readonly Dictionary<string, string> _labelsByTargetId;
+
+        private HtmlFootnoteConversionState(
+            IReadOnlyList<IElement> orderedDefinitions,
+            Dictionary<IElement, string> labelsByDefinition,
+            Dictionary<string, string> labelsByTargetId) {
+            _orderedDefinitions = orderedDefinitions;
+            _labelsByDefinition = labelsByDefinition;
+            _labelsByTargetId = labelsByTargetId;
+        }
+
+        internal static HtmlFootnoteConversionState Empty { get; } = new HtmlFootnoteConversionState(
+            Array.Empty<IElement>(),
+            new Dictionary<IElement, string>(),
+            new Dictionary<string, string>(StringComparer.Ordinal));
+
+        internal static HtmlFootnoteConversionState Create(INode root) {
+            if (root == null) return Empty;
+
+            List<IElement> elements = EnumerateElements(root).ToList();
+            var referencedIds = new HashSet<string>(StringComparer.Ordinal);
+            foreach (IElement element in elements) {
+                if (!LooksLikeFootnoteReference(element)) continue;
+                string? targetId = GetLocalFragmentId(element.GetAttribute("href"));
+                if (!string.IsNullOrWhiteSpace(targetId)) referencedIds.Add(targetId!);
+            }
+
+            var definitions = new List<IElement>();
+            foreach (IElement element in elements) {
+                if (IsSemanticFootnoteDefinition(element)
+                    || IsRecognizedIdDefinition(element, referencedIds)) {
+                    definitions.Add(element);
+                }
+            }
+            if (definitions.Count == 0) return Empty;
+
+            var labelsByDefinition = new Dictionary<IElement, string>();
+            var labelsByTargetId = new Dictionary<string, string>(StringComparer.Ordinal);
+            var usedLabels = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (int index = 0; index < definitions.Count; index++) {
+                IElement definition = definitions[index];
+                string? definitionId = definition.Id;
+                string label = CreateUniqueLabel(definitionId, index + 1, usedLabels);
+                labelsByDefinition[definition] = label;
+                if (!string.IsNullOrWhiteSpace(definitionId) && !labelsByTargetId.ContainsKey(definitionId!)) {
+                    labelsByTargetId[definitionId!] = label;
+                }
+            }
+
+            return new HtmlFootnoteConversionState(definitions, labelsByDefinition, labelsByTargetId);
+        }
+
+        internal bool TryGetDefinitionLabel(IElement element, out string label) =>
+            _labelsByDefinition.TryGetValue(element, out label!);
+
+        internal bool TryGetReferenceLabel(IElement element, out string label) {
+            label = string.Empty;
+            if (!LooksLikeFootnoteReference(element)) return false;
+            string? targetId = GetLocalFragmentId(element.GetAttribute("href"));
+            return targetId != null && _labelsByTargetId.TryGetValue(targetId, out label!);
+        }
+
+        internal bool TryGetWrappedReferenceLabel(IElement element, out string label) {
+            label = string.Empty;
+            if (element == null || !element.TagName.Equals("SUP", StringComparison.OrdinalIgnoreCase)) return false;
+
+            IElement[] references = element.QuerySelectorAll("a")
+                .Where(reference => TryGetReferenceLabel(reference, out _))
+                .ToArray();
+            if (references.Length != 1 || !TryGetReferenceLabel(references[0], out label)) return false;
+
+            return string.Equals(
+                NormalizeComparisonText(element.TextContent),
+                NormalizeComparisonText(references[0].TextContent),
+                StringComparison.Ordinal);
+        }
+
+        internal bool IsBacklink(IElement element) {
+            if (element == null || !element.TagName.Equals("A", StringComparison.OrdinalIgnoreCase)) return false;
+            if (HtmlAccessibilitySemantics.HasEpubType(element, "backlink")
+                || HtmlAccessibilitySemantics.HasRole(element, "doc-backlink")
+                || element.HasAttribute("data-footnote-backref")
+                || element.ClassList.Contains("footnote-backref")) {
+                return true;
+            }
+
+            string? href = element.GetAttribute("href");
+            if (string.IsNullOrWhiteSpace(href)
+                || (!href!.StartsWith("#fnref:", StringComparison.OrdinalIgnoreCase)
+                    && !href.StartsWith("#fnref-", StringComparison.OrdinalIgnoreCase))) {
+                return false;
+            }
+            for (IElement? current = element.ParentElement; current != null; current = current.ParentElement) {
+                if (_labelsByDefinition.ContainsKey(current)) return true;
+            }
+            return false;
+        }
+
+        internal bool ShouldConvertContainer(IElement element) {
+            if (element == null || _orderedDefinitions.Count == 0) return false;
+            if (IsFootnoteContainer(element)) return _orderedDefinitions.Any(definition => IsDescendantOf(definition, element));
+
+            string tagName = element.TagName;
+            if (!tagName.Equals("OL", StringComparison.OrdinalIgnoreCase)
+                && !tagName.Equals("UL", StringComparison.OrdinalIgnoreCase)) {
+                return false;
+            }
+
+            IElement[] items = element.Children
+                .Where(static child => child.TagName.Equals("LI", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+            return items.Length > 0 && items.All(item => _labelsByDefinition.ContainsKey(item));
+        }
+
+        internal IEnumerable<IElement> GetContainedDefinitions(IElement container) {
+            foreach (IElement definition in _orderedDefinitions) {
+                if (IsDescendantOf(definition, container)) yield return definition;
+            }
+        }
+
+        internal string GetDefinitionFallbackText(IElement definition) {
+            var builder = new StringBuilder();
+            AppendDefinitionFallbackText(definition, builder);
+            return NormalizeBlockText(builder.ToString());
+        }
+
+        private static IEnumerable<IElement> EnumerateElements(INode root) {
+            foreach (INode child in root.ChildNodes) {
+                if (child is IElement element) yield return element;
+                foreach (IElement descendant in EnumerateElements(child)) yield return descendant;
+            }
+        }
+
+        private static bool IsSemanticFootnoteDefinition(IElement element) =>
+            HasAnyEpubType(element, "footnote", "endnote", "rearnote", "note")
+            || HasAnyRole(element, "doc-footnote", "doc-endnote");
+
+        private static bool IsRecognizedIdDefinition(IElement element, ISet<string> referencedIds) {
+            string? id = element.Id;
+            if (string.IsNullOrWhiteSpace(id)
+                || (!id!.StartsWith("fn:", StringComparison.OrdinalIgnoreCase)
+                    && !id.StartsWith("fn-", StringComparison.OrdinalIgnoreCase))) {
+                return false;
+            }
+            if (referencedIds.Contains(id)) return true;
+            for (IElement? current = element.ParentElement; current != null; current = current.ParentElement) {
+                if (IsFootnoteContainer(current)) return true;
+            }
+            return false;
+        }
+
+        private static bool IsFootnoteContainer(IElement element) =>
+            element.HasAttribute("data-footnotes")
+            || element.ClassList.Contains("footnotes")
+            || element.ClassList.Contains("endnotes")
+            || HasAnyEpubType(element, "footnotes", "endnotes", "rearnotes")
+            || HasAnyRole(element, "doc-endnotes");
+
+        private static bool LooksLikeFootnoteReference(IElement element) {
+            if (element == null || !element.TagName.Equals("A", StringComparison.OrdinalIgnoreCase)) return false;
+            if (HasAnyEpubType(element, "noteref")
+                || HasAnyRole(element, "doc-noteref")
+                || element.HasAttribute("data-footnote-ref")
+                || element.ClassList.Contains("noteref")
+                || element.ClassList.Contains("footnote-ref")) {
+                return true;
+            }
+
+            IElement? parent = element.ParentElement;
+            string? parentId = parent?.Id;
+            return parent != null
+                   && parent.TagName.Equals("SUP", StringComparison.OrdinalIgnoreCase)
+                   && (!string.IsNullOrWhiteSpace(parentId)
+                       && (parentId!.StartsWith("fnref:", StringComparison.OrdinalIgnoreCase)
+                           || parentId.StartsWith("fnref-", StringComparison.OrdinalIgnoreCase)));
+        }
+
+        private static string? GetLocalFragmentId(string? href) {
+            if (string.IsNullOrWhiteSpace(href)) return null;
+            string candidate = href!.Trim();
+            if (!candidate.StartsWith("#", StringComparison.Ordinal) || candidate.Length == 1) return null;
+            try {
+                return Uri.UnescapeDataString(candidate.Substring(1));
+            } catch {
+                return candidate.Substring(1);
+            }
+        }
+
+        private static string CreateUniqueLabel(string? id, int index, ISet<string> usedLabels) {
+            string candidate = id?.Trim() ?? string.Empty;
+            if (candidate.StartsWith("fn:", StringComparison.OrdinalIgnoreCase)
+                || candidate.StartsWith("fn-", StringComparison.OrdinalIgnoreCase)) {
+                candidate = candidate.Substring(3);
+            }
+            candidate = SanitizeLabel(candidate);
+            if (candidate.Length == 0) candidate = "note-" + index.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+            string unique = candidate;
+            int suffix = 2;
+            while (!usedLabels.Add(unique)) {
+                unique = candidate + "-" + suffix.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                suffix++;
+            }
+            return unique;
+        }
+
+        private static string SanitizeLabel(string value) {
+            if (string.IsNullOrWhiteSpace(value)) return string.Empty;
+            var builder = new StringBuilder(value.Length);
+            bool previousSeparator = false;
+            foreach (char character in value) {
+                bool invalid = char.IsWhiteSpace(character)
+                    || char.IsControl(character)
+                    || character == '['
+                    || character == ']'
+                    || character == '^';
+                if (invalid) {
+                    if (!previousSeparator && builder.Length > 0) builder.Append('-');
+                    previousSeparator = true;
+                    continue;
+                }
+                builder.Append(character);
+                previousSeparator = false;
+            }
+            return builder.ToString().Trim('-');
+        }
+
+        private static string NormalizeComparisonText(string? value) {
+            if (string.IsNullOrWhiteSpace(value)) return string.Empty;
+            return string.Join(" ", value!.Split(new[] { ' ', '\t', '\r', '\n', '\f' }, StringSplitOptions.RemoveEmptyEntries));
+        }
+
+        private void AppendDefinitionFallbackText(INode node, StringBuilder builder) {
+            foreach (INode child in node.ChildNodes) {
+                if (child is IElement element) {
+                    if (IsBacklink(element)) continue;
+                    AppendDefinitionFallbackText(element, builder);
+                } else if (child is IText text) {
+                    builder.Append(text.Data);
+                }
+            }
+        }
+
+        private static bool IsDescendantOf(IElement element, IElement ancestor) {
+            for (IElement? current = element.ParentElement; current != null; current = current.ParentElement) {
+                if (ReferenceEquals(current, ancestor)) return true;
+            }
+            return false;
+        }
+
+        private static bool HasAnyEpubType(IElement element, params string[] values) =>
+            values.Any(value => HtmlAccessibilitySemantics.HasEpubType(element, value));
+
+        private static bool HasAnyRole(IElement element, params string[] values) =>
+            values.Any(value => HtmlAccessibilitySemantics.HasRole(element, value));
+    }
+
+    private static bool TryConvertFootnoteElement(
+        IElement element,
+        ConversionContext context,
+        out IReadOnlyList<IMarkdownBlock> blocks) {
+        blocks = Array.Empty<IMarkdownBlock>();
+        if (context.Footnotes.TryGetDefinitionLabel(element, out string label)) {
+            IReadOnlyList<IMarkdownBlock> body = ConvertNodesToBlocks(element.ChildNodes, context);
+            blocks = new IMarkdownBlock[] {
+                body.Count == 0
+                    ? new FootnoteDefinitionBlock(label, context.Footnotes.GetDefinitionFallbackText(element))
+                    : new FootnoteDefinitionBlock(label, body)
+            };
+            return true;
+        }
+
+        if (!context.Footnotes.ShouldConvertContainer(element)) return false;
+        var definitions = new List<IMarkdownBlock>();
+        foreach (IElement definition in context.Footnotes.GetContainedDefinitions(element)) {
+            if (!context.Footnotes.TryGetDefinitionLabel(definition, out label)) continue;
+            IReadOnlyList<IMarkdownBlock> body = ConvertNodesToBlocks(definition.ChildNodes, context);
+            definitions.Add(body.Count == 0
+                ? new FootnoteDefinitionBlock(label, context.Footnotes.GetDefinitionFallbackText(definition))
+                : new FootnoteDefinitionBlock(label, body));
+        }
+        blocks = definitions;
+        return definitions.Count > 0;
+    }
+}

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Inlines.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.Inlines.cs
@@ -1,4 +1,5 @@
 using AngleSharp.Dom;
+using OfficeIMO.Html;
 
 namespace OfficeIMO.Markdown.Html;
 
@@ -45,6 +46,18 @@ internal sealed partial class HtmlToMarkdownConverter {
         }
 
         if (TryConvertConfiguredInlineElementConverters(sequence, element, context)) {
+            return;
+        }
+
+        if (context != null && element.TagName.Equals("A", StringComparison.OrdinalIgnoreCase)) {
+            if (context.Footnotes.IsBacklink(element)) return;
+            if (context.Footnotes.TryGetReferenceLabel(element, out string footnoteLabel)) {
+                sequence.FootnoteRef(footnoteLabel);
+                return;
+            }
+        }
+        if (context != null && context.Footnotes.TryGetWrappedReferenceLabel(element, out string wrappedFootnoteLabel)) {
+            sequence.FootnoteRef(wrappedFootnoteLabel);
             return;
         }
 
@@ -156,6 +169,16 @@ internal sealed partial class HtmlToMarkdownConverter {
     }
 
     private static string ConvertInlineElementToMarkdown(IElement element, ConversionContext? context) {
+        if (context != null && element.TagName.Equals("A", StringComparison.OrdinalIgnoreCase)) {
+            if (context.Footnotes.IsBacklink(element)) return string.Empty;
+            if (context.Footnotes.TryGetReferenceLabel(element, out string footnoteLabel)) {
+                return "[^" + footnoteLabel + "]";
+            }
+        }
+        if (context != null && context.Footnotes.TryGetWrappedReferenceLabel(element, out string wrappedFootnoteLabel)) {
+            return "[^" + wrappedFootnoteLabel + "]";
+        }
+
         string tag = GetEffectiveTagName(element, context);
         switch (tag) {
             case "BR":
@@ -233,7 +256,8 @@ internal sealed partial class HtmlToMarkdownConverter {
             : ResolveUrl(element.GetAttribute("href"), context);
         string label = ConvertInlineNodesToMarkdown(element.ChildNodes, context).Trim();
         if (label.Length == 0) {
-            return string.Empty;
+            label = EscapeInlineText(HtmlAccessibilitySemantics.GetAccessibleName(element, includeTextFallback: true));
+            if (label.Length == 0) return string.Empty;
         }
         if (href.Length == 0) {
             return label;
@@ -256,7 +280,9 @@ internal sealed partial class HtmlToMarkdownConverter {
             : ResolveUrl(element.GetAttribute("href"), context);
         var label = ConvertInlineNodesToInlineSequence(element.ChildNodes, context);
         if (label.Nodes.Count == 0) {
-            return;
+            string accessibleName = HtmlAccessibilitySemantics.GetAccessibleName(element, includeTextFallback: true);
+            if (accessibleName.Length == 0) return;
+            label.Text(accessibleName);
         }
 
         if (href.Length == 0) {
@@ -361,13 +387,14 @@ internal sealed partial class HtmlToMarkdownConverter {
         if (context != null
             && context.Options.Base64Images != HtmlBase64ImageHandling.Include
             && ResolveImageSourceCandidates(element, context).Any(IsBase64ImageDataUri)) {
-            return (string.Empty, element.GetAttribute("alt"), element.GetAttribute("title"), element.GetAttribute("alt"));
+            string? accessibleName = GetAccessibleImageName(element);
+            return (string.Empty, accessibleName, element.GetAttribute("title"), accessibleName);
         }
 
         string src = context == null
             ? element.GetAttribute("src") ?? string.Empty
             : ResolveUrl(element.GetAttribute("src"), context);
-        string? alt = element.GetAttribute("alt");
+        string? alt = GetAccessibleImageName(element);
         return (src, alt, element.GetAttribute("title"), alt);
     }
 

--- a/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.cs
+++ b/OfficeIMO.Markdown.Html/Converters/HtmlToMarkdownConverter.cs
@@ -17,6 +17,7 @@ internal sealed partial class HtmlToMarkdownConverter {
         public HtmlToMarkdownOptions Options { get; }
         public int SavedBase64ImageCount { get; set; }
         public Dictionary<string, string> SavedBase64ImagesBySource { get; } = new(StringComparer.Ordinal);
+        internal HtmlFootnoteConversionState Footnotes { get; set; } = HtmlFootnoteConversionState.Empty;
     }
 
     /// <summary>
@@ -56,6 +57,7 @@ internal sealed partial class HtmlToMarkdownConverter {
         var context = new ConversionContext(effectiveOptions);
 
         INode root = HtmlDocumentParser.GetConversionRoot(document, effectiveOptions.UseBodyContentsOnly);
+        context.Footnotes = HtmlFootnoteConversionState.Create(root);
 
         var markdown = MarkdownDoc.Create();
         foreach (var block in ConvertNodesToBlocks(root.ChildNodes, context)) {

--- a/OfficeIMO.Markdown.Html/README.md
+++ b/OfficeIMO.Markdown.Html/README.md
@@ -75,13 +75,13 @@ string markdown = html.ToMarkdown(options);
 
 - Headings, paragraphs, ordered and unordered lists, block quotes, code blocks, horizontal rules, tables, images, figures, details/summary, definition lists, and raw HTML fallback blocks.
 - Emphasis, strong emphasis, strike-through, code spans, links, images, line breaks, and selected inline HTML wrappers.
-- Native and ARIA headings, accessible link/image names, ordered-list marker families, reversed lists, item value resets, and code-language hints.
+- Native and ARIA headings, accessible link/image names, ordered-list marker families, reversed lists, item value resets, and code-language hints. Generated Markdown uses decimal CommonMark markers while the typed list retains the original HTML marker family for HTML projection.
 - Local EPUB/DPUB-ARIA footnotes and GitHub-style footnote sections as typed `FootnoteRefInline` and `FootnoteDefinitionBlock` nodes, including structured definition bodies.
 - Relative links and image targets when a base URI is supplied.
 - Shared `data-omd-*` visual host elements back into semantic fenced blocks when host hints are registered.
 - Custom block and inline converters for host or plug-in packages.
 
-EPUB footnote references are converted only when their target is a definition in the same HTML document. Cross-document note links remain ordinary links so the converter does not invent a local definition. Footnote backlinks are omitted from Markdown. Accessible names use a deterministic conversion subset: `aria-labelledby`, `aria-label`, host-language alternatives such as image `alt`, optional visible text, and `title` fallback.
+EPUB footnote references are converted only when their target is an actual footnote, endnote, or rearnote definition in the same HTML document. Generic `epub:type="note"` content stays ordinary content. Cross-document note links remain ordinary links so the converter does not invent a local definition. Footnote backlinks are omitted from Markdown. Accessible names use a deterministic conversion subset: `aria-labelledby`, `aria-label`, host-language alternatives such as image `alt`, optional visible text, and `title` fallback.
 
 ## Profiles
 

--- a/OfficeIMO.Markdown.Html/README.md
+++ b/OfficeIMO.Markdown.Html/README.md
@@ -75,9 +75,13 @@ string markdown = html.ToMarkdown(options);
 
 - Headings, paragraphs, ordered and unordered lists, block quotes, code blocks, horizontal rules, tables, images, figures, details/summary, definition lists, and raw HTML fallback blocks.
 - Emphasis, strong emphasis, strike-through, code spans, links, images, line breaks, and selected inline HTML wrappers.
+- Native and ARIA headings, accessible link/image names, ordered-list marker families, reversed lists, item value resets, and code-language hints.
+- Local EPUB/DPUB-ARIA footnotes and GitHub-style footnote sections as typed `FootnoteRefInline` and `FootnoteDefinitionBlock` nodes, including structured definition bodies.
 - Relative links and image targets when a base URI is supplied.
 - Shared `data-omd-*` visual host elements back into semantic fenced blocks when host hints are registered.
 - Custom block and inline converters for host or plug-in packages.
+
+EPUB footnote references are converted only when their target is a definition in the same HTML document. Cross-document note links remain ordinary links so the converter does not invent a local definition. Footnote backlinks are omitted from Markdown. Accessible names use a deterministic conversion subset: `aria-labelledby`, `aria-label`, host-language alternatives such as image `alt`, optional visible text, and `title` fallback.
 
 ## Profiles
 

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_EpubSemantics_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_EpubSemantics_Tests.cs
@@ -1,0 +1,113 @@
+using OfficeIMO.Html;
+using OfficeIMO.Markdown;
+using OfficeIMO.Markdown.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class MarkdownHtmlToMarkdownEpubSemanticsTests {
+    [Fact]
+    public void HtmlToMarkdown_ConvertsEpubFootnotesToTypedMarkdown() {
+        const string html = """
+<p id="ref-alpha">Text<a epub:type="noteref" role="doc-noteref" href="#note-alpha">1</a>.</p>
+<aside epub:type="footnote" role="doc-footnote" id="note-alpha">
+  <p>First <strong>note</strong>.</p>
+  <pre><code class="language-csharp">Console.WriteLine(1);</code></pre>
+  <a epub:type="backlink" role="doc-backlink" href="#ref-alpha">back</a>
+</aside>
+""";
+
+        MarkdownDoc document = HtmlConversionDocument.Parse(html).ToMarkdownDocument();
+
+        ParagraphBlock paragraph = Assert.IsType<ParagraphBlock>(document.Blocks[0]);
+        FootnoteRefInline reference = Assert.Single(paragraph.Inlines.Nodes.OfType<FootnoteRefInline>());
+        FootnoteDefinitionBlock definition = Assert.Single(document.Blocks.OfType<FootnoteDefinitionBlock>());
+
+        Assert.Equal("note-alpha", reference.Label);
+        Assert.Equal("note-alpha", definition.Label);
+        Assert.Contains(definition.ChildBlocks, block => block is ParagraphBlock);
+        CodeBlock code = Assert.Single(definition.ChildBlocks.OfType<CodeBlock>());
+        Assert.Equal("csharp", code.Language);
+        Assert.Contains("Console.WriteLine(1);", code.Content, StringComparison.Ordinal);
+
+        string markdown = document.ToMarkdown();
+        Assert.Contains("Text[^note-alpha].", markdown, StringComparison.Ordinal);
+        Assert.Contains("[^note-alpha]: First **note**.", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("back", markdown, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void HtmlToMarkdown_ConvertsGitHubFootnoteSectionWithoutListScaffolding() {
+        const string html = """
+<p>Shape<sup id="fnref-shape"><a href="#fn-shape" data-footnote-ref>1</a></sup>.</p>
+<section class="footnotes" data-footnotes>
+  <ol>
+    <li id="fn-shape"><p>Footnote body <a href="#fnref-shape" class="footnote-backref" data-footnote-backref>return</a></p></li>
+  </ol>
+</section>
+""";
+
+        MarkdownDoc document = HtmlConversionDocument.Parse(html).ToMarkdownDocument();
+
+        FootnoteDefinitionBlock definition = Assert.Single(document.Blocks.OfType<FootnoteDefinitionBlock>());
+        FootnoteRefInline reference = Assert.Single(
+            document.Blocks.OfType<ParagraphBlock>().SelectMany(block => block.Inlines.Nodes).OfType<FootnoteRefInline>());
+
+        Assert.Equal("shape", reference.Label);
+        Assert.Equal("shape", definition.Label);
+        Assert.DoesNotContain(document.Blocks, block => block is OrderedListBlock);
+        Assert.DoesNotContain("return", document.ToMarkdown(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void HtmlToMarkdown_ProjectsAriaNamesHeadingsListMarkersAndCodeLanguage() {
+        const string html = """
+<div role="heading" aria-level="4">Accessible heading</div>
+<p><a href="note.xhtml" aria-label="Open note"></a></p>
+<figure><span id="cover-label">Cover chart</span><img src="images/cover.png" aria-labelledby="cover-label"></figure>
+<ol type="A" start="3"><li>Third</li></ol>
+<pre data-language="csharp">Console.WriteLine(3);</pre>
+""";
+        var options = new HtmlToMarkdownOptions { BaseUri = new Uri("https://example.test/book/chapter.xhtml") };
+
+        MarkdownDoc document = HtmlConversionDocument.Parse(html).ToMarkdownDocument(options);
+
+        HeadingBlock heading = Assert.Single(document.Blocks.OfType<HeadingBlock>());
+        LinkInline link = Assert.Single(
+            document.Blocks.OfType<ParagraphBlock>().SelectMany(block => block.Inlines.Nodes).OfType<LinkInline>());
+        ImageBlock image = Assert.Single(document.Blocks.OfType<ImageBlock>());
+        OrderedListBlock list = Assert.Single(document.Blocks.OfType<OrderedListBlock>());
+        CodeBlock code = Assert.Single(document.Blocks.OfType<CodeBlock>());
+
+        Assert.Equal(4, heading.Level);
+        Assert.Equal("Accessible heading", heading.Text);
+        Assert.Equal("Open note", link.Text);
+        Assert.Equal("https://example.test/book/note.xhtml", link.Url);
+        Assert.Equal("Cover chart", image.Alt);
+        Assert.Equal("https://example.test/book/images/cover.png", image.Path);
+        Assert.Equal(3, list.Start);
+        Assert.Equal(MarkdownOrderedListMarkerStyle.UpperAlpha, list.MarkerStyle);
+        Assert.Equal("csharp", code.Language);
+    }
+
+    [Fact]
+    public void HtmlToMarkdown_PreservesReversedAndValueResetOrderedListMarkers() {
+        const string html = """
+<ol reversed><li>Three</li><li value="7">Seven</li><li>Six</li></ol>
+<ol type="A" start="27"><li>Twenty seven</li><li>Twenty eight</li></ol>
+""";
+
+        MarkdownDoc document = HtmlConversionDocument.Parse(html).ToMarkdownDocument();
+        OrderedListBlock[] lists = document.Blocks.OfType<OrderedListBlock>().ToArray();
+
+        Assert.Equal(2, lists.Length);
+        Assert.Equal(new[] { "3.", "7.", "6." }, lists[0].Items.Select(item => item.MarkerText));
+        Assert.Equal(new[] { "AA.", "AB." }, lists[1].Items.Select(item => item.MarkerText));
+        string markdown = document.ToMarkdown();
+        Assert.Contains("3. Three", markdown, StringComparison.Ordinal);
+        Assert.Contains("7. Seven", markdown, StringComparison.Ordinal);
+        Assert.Contains("6. Six", markdown, StringComparison.Ordinal);
+        Assert.Contains("AA. Twenty seven", markdown, StringComparison.Ordinal);
+        Assert.Contains("AB. Twenty eight", markdown, StringComparison.Ordinal);
+    }
+}

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_EpubSemantics_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_EpubSemantics_Tests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace OfficeIMO.Tests;
 
-public sealed class MarkdownHtmlToMarkdownEpubSemanticsTests {
+public sealed class MarkdownHtmlToMarkdownTestsEpubSemantics {
     [Fact]
     public void HtmlToMarkdown_ConvertsEpubFootnotesToTypedMarkdown() {
         const string html = """
@@ -76,7 +76,7 @@ public sealed class MarkdownHtmlToMarkdownEpubSemanticsTests {
         const string html = """
 <div role="heading" aria-level="4">Accessible heading</div>
 <p><a href="note.xhtml" aria-label="Open note"></a></p>
-<figure><span id="cover-label">Cover chart</span><img src="images/cover.png" aria-labelledby="cover-label"></figure>
+<figure><span id="cover-label" aria-label="Accessible cover chart">ignored</span><img src="images/cover.png" aria-labelledby="cover-label"></figure>
 <ol type="A" start="3"><li>Third</li></ol>
 <pre data-language="csharp">Console.WriteLine(3);</pre>
 """;
@@ -95,7 +95,7 @@ public sealed class MarkdownHtmlToMarkdownEpubSemanticsTests {
         Assert.Equal("Accessible heading", heading.Text);
         Assert.Equal("Open note", link.Text);
         Assert.Equal("https://example.test/book/note.xhtml", link.Url);
-        Assert.Equal("Cover chart", image.Alt);
+        Assert.Equal("Accessible cover chart", image.Alt);
         Assert.Equal("https://example.test/book/images/cover.png", image.Path);
         Assert.Equal(3, list.Start);
         Assert.Equal(MarkdownOrderedListMarkerStyle.UpperAlpha, list.MarkerStyle);

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_EpubSemantics_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_EpubSemantics_Tests.cs
@@ -60,6 +60,18 @@ public sealed class MarkdownHtmlToMarkdownEpubSemanticsTests {
     }
 
     [Fact]
+    public void HtmlToMarkdown_KeepsGenericEpubNotesAsOrdinaryContent() {
+        const string html = "<aside epub:type=\"note\" id=\"editorial\"><p>Editorial context.</p></aside>";
+
+        MarkdownDoc document = HtmlConversionDocument.Parse(html).ToMarkdownDocument();
+        string markdown = document.ToMarkdown();
+
+        Assert.Empty(document.Blocks.OfType<FootnoteDefinitionBlock>());
+        Assert.DoesNotContain("[^", markdown, StringComparison.Ordinal);
+        Assert.Contains("Editorial context.", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void HtmlToMarkdown_ProjectsAriaNamesHeadingsListMarkersAndCodeLanguage() {
         const string html = """
 <div role="heading" aria-level="4">Accessible heading</div>
@@ -102,12 +114,16 @@ public sealed class MarkdownHtmlToMarkdownEpubSemanticsTests {
 
         Assert.Equal(2, lists.Length);
         Assert.Equal(new[] { "3.", "7.", "6." }, lists[0].Items.Select(item => item.MarkerText));
-        Assert.Equal(new[] { "AA.", "AB." }, lists[1].Items.Select(item => item.MarkerText));
+        Assert.Equal(MarkdownOrderedListMarkerStyle.UpperAlpha, lists[1].MarkerStyle);
+        Assert.Equal(new[] { "27.", "28." }, lists[1].Items.Select(item => item.MarkerText));
         string markdown = document.ToMarkdown();
         Assert.Contains("3. Three", markdown, StringComparison.Ordinal);
         Assert.Contains("7. Seven", markdown, StringComparison.Ordinal);
         Assert.Contains("6. Six", markdown, StringComparison.Ordinal);
-        Assert.Contains("AA. Twenty seven", markdown, StringComparison.Ordinal);
-        Assert.Contains("AB. Twenty eight", markdown, StringComparison.Ordinal);
+        Assert.Contains("27. Twenty seven", markdown, StringComparison.Ordinal);
+        Assert.Contains("28. Twenty eight", markdown, StringComparison.Ordinal);
+        MarkdownDoc parsed = MarkdownReader.Parse(markdown);
+        OrderedListBlock parsedList = Assert.Single(parsed.Blocks.OfType<OrderedListBlock>());
+        Assert.Equal(5, parsedList.Items.Count);
     }
 }

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_EpubSemantics_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_HtmlToMarkdown_EpubSemantics_Tests.cs
@@ -113,6 +113,7 @@ public sealed class MarkdownHtmlToMarkdownEpubSemanticsTests {
         OrderedListBlock[] lists = document.Blocks.OfType<OrderedListBlock>().ToArray();
 
         Assert.Equal(2, lists.Length);
+        Assert.True(lists[0].Reversed);
         Assert.Equal(new[] { "3.", "7.", "6." }, lists[0].Items.Select(item => item.MarkerText));
         Assert.Equal(MarkdownOrderedListMarkerStyle.UpperAlpha, lists[1].MarkerStyle);
         Assert.Equal(new[] { "27.", "28." }, lists[1].Items.Select(item => item.MarkerText));
@@ -122,6 +123,7 @@ public sealed class MarkdownHtmlToMarkdownEpubSemanticsTests {
         Assert.Contains("6. Six", markdown, StringComparison.Ordinal);
         Assert.Contains("27. Twenty seven", markdown, StringComparison.Ordinal);
         Assert.Contains("28. Twenty eight", markdown, StringComparison.Ordinal);
+        Assert.Contains("<ol start=\"3\" reversed>", ((IMarkdownBlock)lists[0]).RenderHtml(), StringComparison.Ordinal);
         MarkdownDoc parsed = MarkdownReader.Parse(markdown);
         OrderedListBlock parsedList = Assert.Single(parsed.Blocks.OfType<OrderedListBlock>());
         Assert.Equal(5, parsedList.Items.Count);

--- a/OfficeIMO.Markdown/Blocks/OrderedListBlock.cs
+++ b/OfficeIMO.Markdown/Blocks/OrderedListBlock.cs
@@ -24,6 +24,8 @@ public sealed class OrderedListBlock : MarkdownBlock, IMarkdownListBlock, ISynta
     public List<ListItem> Items { get; } = new List<ListItem>();
     /// <summary>Starting number (default 1).</summary>
     public int Start { get; set; } = 1;
+    /// <summary>Whether top-level item numbering descends from <see cref="Start"/>.</summary>
+    public bool Reversed { get; set; }
     /// <summary>Ordered list marker family.</summary>
     public MarkdownOrderedListMarkerStyle MarkerStyle { get; set; } = MarkdownOrderedListMarkerStyle.Decimal;
     /// <summary>Marker delimiter used when writing generated list markers.</summary>
@@ -36,7 +38,7 @@ public sealed class OrderedListBlock : MarkdownBlock, IMarkdownListBlock, ISynta
             Items,
             (item, topLevelIndex) => {
                 string markerText = item.MarkerText ?? (item.Level == 0
-                    ? FormatMarker(Start + topLevelIndex, MarkerStyle, MarkerDelimiter)
+                    ? FormatMarker(Reversed ? Start - topLevelIndex : Start + topLevelIndex, MarkerStyle, MarkerDelimiter)
                     : FormatMarker(1, MarkerStyle, MarkerDelimiter));
                 string baseMarker = markerText + " ";
                 return item.IsTask
@@ -75,8 +77,12 @@ public sealed class OrderedListBlock : MarkdownBlock, IMarkdownListBlock, ISynta
             attributes.Append(" type=\"").Append(type).Append('"');
         }
 
-        if (Start != 1) {
+        if (Start != 1 || Reversed) {
             attributes.Append(" start=\"").Append(Start.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append('"');
+        }
+
+        if (Reversed) {
+            attributes.Append(" reversed");
         }
 
         return attributes.ToString();

--- a/OfficeIMO.Reader.Epub/EpubReaderAdapter.Document.cs
+++ b/OfficeIMO.Reader.Epub/EpubReaderAdapter.Document.cs
@@ -55,6 +55,12 @@ internal static partial class EpubReaderAdapter {
         var visuals = new List<ReaderVisual>();
         var diagnostics = new List<OfficeDocumentDiagnostic>(BuildEpubDiagnostics(document, source.Path));
         var pages = new List<OfficeDocumentPage>();
+        var capabilities = new List<string> {
+            "officeimo.reader.epub.rich-v5",
+            "officeimo.epub.package-model",
+            "officeimo.html.logical-document"
+        };
+        var seenCapabilities = new HashSet<string>(capabilities, StringComparer.Ordinal);
         int tableIndex = 0;
         for (int chapterIndex = 0; chapterIndex < document.Chapters.Count; chapterIndex++) {
             cancellationToken.ThrowIfCancellationRequested();
@@ -71,6 +77,12 @@ internal static partial class EpubReaderAdapter {
                     virtualPath,
                     readerOptions,
                     cancellationToken: cancellationToken);
+                foreach (string capability in htmlResult.CapabilitiesUsed) {
+                    if (capability.StartsWith("officeimo.html.", StringComparison.Ordinal)
+                        && seenCapabilities.Add(capability)) {
+                        capabilities.Add(capability);
+                    }
+                }
                 IReadOnlyList<OfficeDocumentLink> resolvedLinks = ResolveEpubChapterLinks(
                     source.Path,
                     chapter,
@@ -133,7 +145,7 @@ internal static partial class EpubReaderAdapter {
             chunks,
             ReaderInputKind.Epub,
             documentSource,
-            new[] { "officeimo.reader.epub.rich-v5", "officeimo.epub.package-model", "officeimo.html.logical-document" },
+            capabilities,
             assets);
         result.Blocks = blocks;
         result.Tables = tables;

--- a/OfficeIMO.Reader.Epub/EpubReaderAdapter.Resources.cs
+++ b/OfficeIMO.Reader.Epub/EpubReaderAdapter.Resources.cs
@@ -58,7 +58,11 @@ internal static partial class EpubReaderAdapter {
                 string? resourceLocation = BuildEpubResolvedLocation(sourcePath, reference, includeFragment: true);
                 if (!string.IsNullOrWhiteSpace(resourceLocation)) {
                     mappedAsset = FindEpubAsset(sourcePath, reference, documentAssets);
-                    if (mappedAsset == null) htmlAsset.Location.Path = resourceLocation;
+                    if (mappedAsset == null) {
+                        htmlAsset.Location.Path = resourceLocation;
+                    } else {
+                        ApplyEpubOccurrenceMetadata(mappedAsset, htmlAsset);
+                    }
                 }
             }
 
@@ -68,6 +72,13 @@ internal static partial class EpubReaderAdapter {
             }
             if (!chapterAssets.Contains(mappedAsset)) chapterAssets.Add(mappedAsset);
         }
+    }
+
+    private static void ApplyEpubOccurrenceMetadata(OfficeDocumentAsset packageAsset, OfficeDocumentAsset occurrenceAsset) {
+        if (packageAsset.AltText == null && occurrenceAsset.AltText != null) packageAsset.AltText = occurrenceAsset.AltText;
+        if (packageAsset.Title == null && occurrenceAsset.Title != null) packageAsset.Title = occurrenceAsset.Title;
+        if (!packageAsset.Width.HasValue && occurrenceAsset.Width.HasValue) packageAsset.Width = occurrenceAsset.Width;
+        if (!packageAsset.Height.HasValue && occurrenceAsset.Height.HasValue) packageAsset.Height = occurrenceAsset.Height;
     }
 
     private static string? GetEpubAssetKind(string? mediaType) {

--- a/OfficeIMO.Reader.Epub/EpubReaderAdapter.Resources.cs
+++ b/OfficeIMO.Reader.Epub/EpubReaderAdapter.Resources.cs
@@ -75,7 +75,10 @@ internal static partial class EpubReaderAdapter {
     }
 
     private static void ApplyEpubOccurrenceMetadata(OfficeDocumentAsset packageAsset, OfficeDocumentAsset occurrenceAsset) {
-        if (packageAsset.AltText == null && occurrenceAsset.AltText != null) packageAsset.AltText = occurrenceAsset.AltText;
+        if (string.IsNullOrWhiteSpace(packageAsset.AltText)
+            && !string.IsNullOrWhiteSpace(occurrenceAsset.AltText)) {
+            packageAsset.AltText = occurrenceAsset.AltText;
+        }
         if (packageAsset.Title == null && occurrenceAsset.Title != null) packageAsset.Title = occurrenceAsset.Title;
         if (!packageAsset.Width.HasValue && occurrenceAsset.Width.HasValue) packageAsset.Width = occurrenceAsset.Width;
         if (!packageAsset.Height.HasValue && occurrenceAsset.Height.HasValue) packageAsset.Height = occurrenceAsset.Height;

--- a/OfficeIMO.Reader.Epub/README.md
+++ b/OfficeIMO.Reader.Epub/README.md
@@ -93,6 +93,8 @@ foreach (OfficeDocumentAsset asset in document.Assets) {
 
 The rich reader requests bounded chapter HTML and manifest payloads from `OfficeIMO.Epub` so it can reuse the HTML semantic mapping. Images, audio, video, fonts, stylesheets, scripts, media overlays, and other manifest resources are projected as assets; content documents and navigation files are not duplicated as assets. Remote resources retain metadata but are never fetched. Audio and video are exposed for downstream processing, not played or transcribed.
 
+Manifest assets keep their package identity and payload while inheriting useful metadata from chapter placements, such as accessible image names, titles, and dimensions. The first available placement supplies missing metadata; each visual still retains its own placement content and source path.
+
 ## What it emits
 
 - Chapter-to-chunk projection.
@@ -103,6 +105,8 @@ The rich reader requests bounded chapter HTML and manifest payloads from `Office
 - Path and stream dispatch, including non-seekable stream support.
 - A schema-v5 rich result with chapter pages, HTML blocks, tables, links, forms, bounded manifest assets, metadata, and structured parser diagnostics.
 - Chapter-relative, query-only, fragment-only, encoded, root-relative, external, and HTML-base URL projection through the shared EPUB reference contract.
+- Structured chapter Markdown for native and ARIA headings, quotes, ordered-list markers, code-language hints, tables, and local EPUB/DPUB-ARIA footnotes.
+- Rich `quote`, `code`, and `footnote` blocks, accessible link/image names, exact ordered-list markers, and propagated `officeimo.html.*` capabilities.
 - Recoverable diagnostics for unsafe or non-conforming chapter references.
 
 ## Boundaries
@@ -110,6 +114,9 @@ The rich reader requests bounded chapter HTML and manifest payloads from `Office
 - Reader adapter configuration belongs here.
 - EPUB parsing belongs in `OfficeIMO.Epub`.
 - Shared extraction contracts belong in `OfficeIMO.Reader`.
+- Local footnotes become typed Markdown footnotes. Cross-document note targets remain resolved EPUB links.
+- Fixed-layout publications are identified and diagnosed; this reader extracts their content and resources but does not emulate a reading-system viewport.
+- Unsupported encryption is reported as a security diagnostic and is not decrypted.
 
 ## Targets and license
 
@@ -120,5 +127,6 @@ The rich reader requests bounded chapter HTML and manifest payloads from `Office
 
 - **External:** None beyond the dependencies of its OfficeIMO format packages.
 - **OfficeIMO:** `OfficeIMO.Reader`, `OfficeIMO.Reader.Html`, and `OfficeIMO.Epub`; EPUB parsing stays in the native package.
+- The EPUB semantics and resource projection layer adds no new package or process dependency.
 
 See the [complete OfficeIMO package map](../README.md) for related formats and conversion paths.

--- a/OfficeIMO.Reader.Epub/README.md
+++ b/OfficeIMO.Reader.Epub/README.md
@@ -105,7 +105,7 @@ Manifest assets keep their package identity and payload while inheriting useful 
 - Path and stream dispatch, including non-seekable stream support.
 - A schema-v5 rich result with chapter pages, HTML blocks, tables, links, forms, bounded manifest assets, metadata, and structured parser diagnostics.
 - Chapter-relative, query-only, fragment-only, encoded, root-relative, external, and HTML-base URL projection through the shared EPUB reference contract.
-- Structured chapter Markdown for native and ARIA headings, quotes, ordered-list markers, code-language hints, tables, and local EPUB/DPUB-ARIA footnotes.
+- Structured chapter Markdown for native and ARIA headings, quotes, portable decimal ordered-list markers with preserved starts and value resets, code-language hints, tables, and local EPUB/DPUB-ARIA footnotes.
 - Rich `quote`, `code`, and `footnote` blocks, accessible link/image names, exact ordered-list markers, and propagated `officeimo.html.*` capabilities.
 - Recoverable diagnostics for unsafe or non-conforming chapter references.
 

--- a/OfficeIMO.Reader.Html/HtmlReaderAdapter.Document.cs
+++ b/OfficeIMO.Reader.Html/HtmlReaderAdapter.Document.cs
@@ -152,11 +152,11 @@ internal static partial class HtmlReaderAdapter {
             ? HtmlListProjectionContext.Create(node)
             : listContext;
         int nextListLevel = node.Kind == HtmlLogicalNodeKind.List ? listLevel + 1 : listLevel;
-        ReaderTable? mappedTable = node.Kind == HtmlLogicalNodeKind.Table
+        ReaderTable? mappedTable = !suppressBlockEmission && node.Kind == HtmlLogicalNodeKind.Table
             ? MapHtmlTable(node, path, tableIndex++, maxTableRows)
             : null;
         if (IsHtmlBlock(node.Kind)
-            && (!suppressBlockEmission || node.Kind != HtmlLogicalNodeKind.Paragraph)) {
+            && !suppressBlockEmission) {
             string kind = NormalizeHtmlBlockKind(node.Kind);
             string anchor = "html-" + kind + "-" + blockIndex.ToString("D4", CultureInfo.InvariantCulture);
             projection.Blocks.Add(new OfficeDocumentBlock {
@@ -214,7 +214,7 @@ internal static partial class HtmlReaderAdapter {
         List<HtmlLogicalNode> rows = GetHtmlTableRows(table).ToList();
         int columnCount = rows.Count == 0 ? 0 : rows.Max(row => row.Children.Count(child => child.Kind == HtmlLogicalNodeKind.TableCell));
         bool hasHeaderRow = rows.Count > 0 && rows[0].Children.Any(child =>
-            child.Kind == HtmlLogicalNodeKind.TableCell && string.Equals(child.Name, "th", StringComparison.OrdinalIgnoreCase));
+            child.Kind == HtmlLogicalNodeKind.TableCell && IsHtmlColumnHeaderCell(child));
         IReadOnlyList<string> columns = hasHeaderRow
             ? BuildHtmlTableRow(rows[0], columnCount, true)
             : Enumerable.Range(1, columnCount)
@@ -243,6 +243,10 @@ internal static partial class HtmlReaderAdapter {
             return string.IsNullOrWhiteSpace(value) && fallbacks ? "Column " + (index + 1).ToString(CultureInfo.InvariantCulture) : value;
         }).ToArray();
     }
+
+    private static bool IsHtmlColumnHeaderCell(HtmlLogicalNode cell) =>
+        string.Equals(cell.Name, "th", StringComparison.OrdinalIgnoreCase)
+        || (cell.Attributes.TryGetValue("role", out string? role) && ContainsHtmlToken(role, "columnheader"));
 
     private static OfficeDocumentAsset? MapHtmlImage(HtmlLogicalNode node, string? path, int index, HtmlToMarkdownOptions htmlOptions) {
         node.Attributes.TryGetValue("alt", out string? altText);

--- a/OfficeIMO.Reader.Html/HtmlReaderAdapter.Document.cs
+++ b/OfficeIMO.Reader.Html/HtmlReaderAdapter.Document.cs
@@ -192,6 +192,10 @@ internal static partial class HtmlReaderAdapter {
                 assetIndex++;
                 projection.Assets.Add(asset);
                 projection.Visuals.Add(MapHtmlVisual(node, asset.Location, asset.PayloadHash, asset.MediaType, asset.SourceObjectId));
+            } else if (!HasHtmlImageSourceCandidate(node)
+                && !string.IsNullOrWhiteSpace(node.AccessibleName)) {
+                string anchor = "html-image-visual-" + projection.Visuals.Count.ToString("D4", CultureInfo.InvariantCulture);
+                projection.Visuals.Add(MapHtmlVisual(node, BuildHtmlLocation(path, null, "image", anchor), null, null));
             }
         } else if (node.Kind == HtmlLogicalNodeKind.Media &&
             !string.Equals(node.Name, "source", StringComparison.OrdinalIgnoreCase)) {
@@ -347,6 +351,19 @@ internal static partial class HtmlReaderAdapter {
         return node.Attributes.TryGetValue("src", out string? source)
             ? HtmlUrlPolicyEvaluator.ResolveUrl(source, options.BaseUri, options.UrlPolicy)
             : string.Empty;
+    }
+
+    private static bool HasHtmlImageSourceCandidate(HtmlLogicalNode node) {
+        foreach (string attribute in new[] {
+            "src", "data-src", "data-original", "data-original-src", "data-lazy-src",
+            "srcset", "data-srcset", "data-original-srcset", "data-lazy-srcset"
+        }) {
+            if (node.Attributes.TryGetValue(attribute, out string? value)
+                && !string.IsNullOrWhiteSpace(value)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static ReaderVisual MapHtmlVisual(

--- a/OfficeIMO.Reader.Html/HtmlReaderAdapter.Document.cs
+++ b/OfficeIMO.Reader.Html/HtmlReaderAdapter.Document.cs
@@ -180,7 +180,7 @@ internal static partial class HtmlReaderAdapter {
                     Kind = resolvedHref.StartsWith("#", StringComparison.Ordinal) ? "internal" : "uri",
                     Uri = resolvedHref.StartsWith("#", StringComparison.Ordinal) ? null : resolvedHref,
                     DestinationName = resolvedHref.StartsWith("#", StringComparison.Ordinal) ? resolvedHref.Substring(1) : null,
-                    Text = GetHtmlNodeAccessibleText(node),
+                    Text = GetHtmlLinkText(node),
                     Location = BuildHtmlLocation(path, null, "hyperlink", "html-link-" + linkIndex.ToString("D4", CultureInfo.InvariantCulture))
                 });
                 linkIndex++;
@@ -455,6 +455,11 @@ internal static partial class HtmlReaderAdapter {
         string text = GetHtmlNodeText(node);
         return text.Length > 0 ? text : node.AccessibleName ?? string.Empty;
     }
+
+    private static string GetHtmlLinkText(HtmlLogicalNode node) =>
+        !string.IsNullOrWhiteSpace(node.AccessibleName)
+            ? node.AccessibleName!
+            : GetHtmlNodeText(node);
 
     private static bool IsHtmlFootnoteBacklink(HtmlLogicalNode node) {
         if (node.Attributes.ContainsKey("data-footnote-backref")) return true;

--- a/OfficeIMO.Reader.Html/HtmlReaderAdapter.Document.cs
+++ b/OfficeIMO.Reader.Html/HtmlReaderAdapter.Document.cs
@@ -3,6 +3,7 @@ using OfficeIMO.Markdown.Html;
 using OfficeIMO.Reader;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Text;
 
 namespace OfficeIMO.Reader.Html;
 
@@ -127,14 +128,15 @@ internal static partial class HtmlReaderAdapter {
         int linkIndex = 0;
         int assetIndex = 0;
         int formIndex = 0;
-        TraverseHtml(document.Root, null, 0, path, maxTableRows, htmlOptions, projection, ref blockIndex, ref tableIndex, ref linkIndex, ref assetIndex, ref formIndex, cancellationToken);
+        TraverseHtml(document.Root, null, 0, false, path, maxTableRows, htmlOptions, projection, ref blockIndex, ref tableIndex, ref linkIndex, ref assetIndex, ref formIndex, cancellationToken);
         return projection;
     }
 
     private static void TraverseHtml(
         HtmlLogicalNode node,
-        string? listName,
+        HtmlListProjectionContext? listContext,
         int listLevel,
+        bool suppressBlockEmission,
         string? path,
         int maxTableRows,
         HtmlToMarkdownOptions htmlOptions,
@@ -146,26 +148,31 @@ internal static partial class HtmlReaderAdapter {
         ref int formIndex,
         CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
-        string? nextListName = node.Kind == HtmlLogicalNodeKind.List ? node.Name : listName;
+        HtmlListProjectionContext? nextListContext = node.Kind == HtmlLogicalNodeKind.List
+            ? HtmlListProjectionContext.Create(node)
+            : listContext;
         int nextListLevel = node.Kind == HtmlLogicalNodeKind.List ? listLevel + 1 : listLevel;
         ReaderTable? mappedTable = node.Kind == HtmlLogicalNodeKind.Table
             ? MapHtmlTable(node, path, tableIndex++, maxTableRows)
             : null;
-        if (IsHtmlBlock(node.Kind)) {
+        if (IsHtmlBlock(node.Kind)
+            && (!suppressBlockEmission || node.Kind != HtmlLogicalNodeKind.Paragraph)) {
             string kind = NormalizeHtmlBlockKind(node.Kind);
             string anchor = "html-" + kind + "-" + blockIndex.ToString("D4", CultureInfo.InvariantCulture);
             projection.Blocks.Add(new OfficeDocumentBlock {
                 Id = anchor,
                 Kind = kind,
-                Text = mappedTable == null ? GetHtmlNodeText(node) : BuildHtmlTableBlockText(mappedTable),
-                Level = node.Kind == HtmlLogicalNodeKind.Heading ? ParseHtmlHeadingLevel(node.Name) : node.Kind == HtmlLogicalNodeKind.ListItem ? nextListLevel : null,
-                Marker = node.Kind == HtmlLogicalNodeKind.ListItem ? (string.Equals(nextListName, "ol", StringComparison.OrdinalIgnoreCase) ? "1." : "-") : null,
+                Text = mappedTable == null ? GetHtmlNodeAccessibleText(node) : BuildHtmlTableBlockText(mappedTable),
+                Level = node.Kind == HtmlLogicalNodeKind.Heading ? ParseHtmlHeadingLevel(node) : node.Kind == HtmlLogicalNodeKind.ListItem ? nextListLevel : null,
+                Marker = node.Kind == HtmlLogicalNodeKind.ListItem ? nextListContext?.GetMarker(node) ?? "-" : null,
                 Location = BuildHtmlLocation(path, blockIndex, kind, anchor)
             });
             blockIndex++;
         }
         if (mappedTable != null) projection.Tables.Add(mappedTable);
-        if (node.Kind == HtmlLogicalNodeKind.Link && node.Attributes.TryGetValue("href", out string? href)) {
+        if (node.Kind == HtmlLogicalNodeKind.Link
+            && !IsHtmlFootnoteBacklink(node)
+            && node.Attributes.TryGetValue("href", out string? href)) {
             string resolvedHref = HtmlUrlPolicyEvaluator.ResolveUrl(href, htmlOptions.BaseUri, htmlOptions.UrlPolicy);
             if (!string.IsNullOrWhiteSpace(resolvedHref)) {
                 projection.Links.Add(new OfficeDocumentLink {
@@ -173,7 +180,7 @@ internal static partial class HtmlReaderAdapter {
                     Kind = resolvedHref.StartsWith("#", StringComparison.Ordinal) ? "internal" : "uri",
                     Uri = resolvedHref.StartsWith("#", StringComparison.Ordinal) ? null : resolvedHref,
                     DestinationName = resolvedHref.StartsWith("#", StringComparison.Ordinal) ? resolvedHref.Substring(1) : null,
-                    Text = GetHtmlNodeText(node),
+                    Text = GetHtmlNodeAccessibleText(node),
                     Location = BuildHtmlLocation(path, null, "hyperlink", "html-link-" + linkIndex.ToString("D4", CultureInfo.InvariantCulture))
                 });
                 linkIndex++;
@@ -195,8 +202,11 @@ internal static partial class HtmlReaderAdapter {
             !string.Equals(node.Name, "option", StringComparison.OrdinalIgnoreCase)) {
             projection.Forms.Add(MapHtmlFormControl(node, path, formIndex++));
         }
+        bool suppressChildBlocks = suppressBlockEmission
+            || node.Kind == HtmlLogicalNodeKind.Quote
+            || node.Kind == HtmlLogicalNodeKind.Footnote;
         foreach (HtmlLogicalNode child in node.Children) {
-            TraverseHtml(child, nextListName, nextListLevel, path, maxTableRows, htmlOptions, projection, ref blockIndex, ref tableIndex, ref linkIndex, ref assetIndex, ref formIndex, cancellationToken);
+            TraverseHtml(child, nextListContext, nextListLevel, suppressChildBlocks, path, maxTableRows, htmlOptions, projection, ref blockIndex, ref tableIndex, ref linkIndex, ref assetIndex, ref formIndex, cancellationToken);
         }
     }
 
@@ -236,6 +246,7 @@ internal static partial class HtmlReaderAdapter {
 
     private static OfficeDocumentAsset? MapHtmlImage(HtmlLogicalNode node, string? path, int index, HtmlToMarkdownOptions htmlOptions) {
         node.Attributes.TryGetValue("alt", out string? altText);
+        if (!string.IsNullOrWhiteSpace(node.AccessibleName)) altText = node.AccessibleName;
         node.Attributes.TryGetValue("title", out string? title);
         string resolvedSource = ResolveHtmlImageSource(node, htmlOptions);
         if (string.IsNullOrWhiteSpace(resolvedSource)) return null;
@@ -348,6 +359,7 @@ internal static partial class HtmlReaderAdapter {
         }
         if (!string.IsNullOrWhiteSpace(sourceOverride)) source = sourceOverride;
         node.Attributes.TryGetValue("alt", out string? altText);
+        if (!string.IsNullOrWhiteSpace(node.AccessibleName)) altText = node.AccessibleName;
         node.Attributes.TryGetValue("title", out string? title);
         if (mediaType == null && node.Attributes.TryGetValue("type", out string? declaredType)) mediaType = declaredType;
         if (mediaType == null && mediaSource != null && mediaSource.Attributes.TryGetValue("type", out string? sourceType)) {
@@ -435,7 +447,26 @@ internal static partial class HtmlReaderAdapter {
         return string.Join(" ", Descendants(node, HtmlLogicalNodeKind.Text).Select(static child => child.Text).Where(static text => !string.IsNullOrWhiteSpace(text)));
     }
 
+    private static string GetHtmlNodeAccessibleText(HtmlLogicalNode node) {
+        string text = GetHtmlNodeText(node);
+        return text.Length > 0 ? text : node.AccessibleName ?? string.Empty;
+    }
+
+    private static bool IsHtmlFootnoteBacklink(HtmlLogicalNode node) {
+        if (node.Attributes.ContainsKey("data-footnote-backref")) return true;
+        return (node.Attributes.TryGetValue("role", out string? role) && ContainsHtmlToken(role, "doc-backlink"))
+            || (node.Attributes.TryGetValue("epub:type", out string? epubType) && ContainsHtmlToken(epubType, "backlink"))
+            || (node.Attributes.TryGetValue("class", out string? className) && ContainsHtmlToken(className, "footnote-backref"));
+    }
+
+    private static bool ContainsHtmlToken(string? value, string token) {
+        if (string.IsNullOrWhiteSpace(value)) return false;
+        return value!.Split(new[] { ' ', '\t', '\r', '\n', '\f' }, StringSplitOptions.RemoveEmptyEntries)
+            .Any(candidate => candidate.Equals(token, StringComparison.OrdinalIgnoreCase));
+    }
+
     private static bool IsHtmlBlock(HtmlLogicalNodeKind kind) => kind == HtmlLogicalNodeKind.Heading || kind == HtmlLogicalNodeKind.Paragraph
+        || kind == HtmlLogicalNodeKind.Code || kind == HtmlLogicalNodeKind.Quote || kind == HtmlLogicalNodeKind.Footnote
         || kind == HtmlLogicalNodeKind.ListItem || kind == HtmlLogicalNodeKind.Table || kind == HtmlLogicalNodeKind.Figure
         || kind == HtmlLogicalNodeKind.Image || kind == HtmlLogicalNodeKind.Media || kind == HtmlLogicalNodeKind.Form;
 
@@ -444,7 +475,13 @@ internal static partial class HtmlReaderAdapter {
         _ => kind.ToString().ToLowerInvariant()
     };
 
-    private static int? ParseHtmlHeadingLevel(string name) => name.Length == 2 && name[0] == 'h' && name[1] >= '1' && name[1] <= '6' ? name[1] - '0' : null;
+    private static int? ParseHtmlHeadingLevel(HtmlLogicalNode node) {
+        string name = node.Name;
+        if (name.Length == 2 && name[0] == 'h' && name[1] >= '1' && name[1] <= '6') return name[1] - '0';
+        if (!node.Attributes.TryGetValue("aria-level", out string? value) || !int.TryParse(value, out int level)) return 2;
+        if (level < 1) return 1;
+        return level > 6 ? 6 : level;
+    }
 
     private static ReaderLocation BuildHtmlLocation(string? path, int? blockIndex, string kind, string anchor, int? tableIndex = null) => new ReaderLocation {
         Path = path, SourceBlockIndex = blockIndex, SourceBlockKind = kind, BlockAnchor = anchor, TableIndex = tableIndex
@@ -462,5 +499,82 @@ internal static partial class HtmlReaderAdapter {
         internal List<OfficeDocumentAsset> Assets { get; } = new List<OfficeDocumentAsset>();
         internal List<OfficeDocumentFormField> Forms { get; } = new List<OfficeDocumentFormField>();
         internal List<ReaderVisual> Visuals { get; } = new List<ReaderVisual>();
+    }
+
+    private sealed class HtmlListProjectionContext {
+        private readonly Dictionary<HtmlLogicalNode, string> _markers;
+
+        private HtmlListProjectionContext(Dictionary<HtmlLogicalNode, string> markers) {
+            _markers = markers;
+        }
+
+        internal static HtmlListProjectionContext Create(HtmlLogicalNode list) {
+            HtmlLogicalNode[] items = list.Children.Where(static child => child.Kind == HtmlLogicalNodeKind.ListItem).ToArray();
+            var markers = new Dictionary<HtmlLogicalNode, string>();
+            if (!string.Equals(list.Name, "ol", StringComparison.OrdinalIgnoreCase)) {
+                foreach (HtmlLogicalNode item in items) markers[item] = "-";
+                return new HtmlListProjectionContext(markers);
+            }
+
+            bool reversed = list.Attributes.ContainsKey("reversed");
+            int value = reversed ? items.Length : 1;
+            if (list.Attributes.TryGetValue("start", out string? startValue)
+                && int.TryParse(startValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsedStart)) {
+                value = parsedStart;
+            }
+            list.Attributes.TryGetValue("type", out string? markerType);
+            int step = reversed ? -1 : 1;
+            foreach (HtmlLogicalNode item in items) {
+                if (item.Attributes.TryGetValue("value", out string? itemValue)
+                    && int.TryParse(itemValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsedValue)) {
+                    value = parsedValue;
+                }
+                markers[item] = FormatOrderedMarker(value, markerType) + ".";
+                value += step;
+            }
+            return new HtmlListProjectionContext(markers);
+        }
+
+        internal string? GetMarker(HtmlLogicalNode item) =>
+            _markers.TryGetValue(item, out string? marker) ? marker : null;
+
+        private static string FormatOrderedMarker(int value, string? markerType) {
+            switch (markerType?.Trim()) {
+                case "a": return FormatAlpha(value, uppercase: false);
+                case "A": return FormatAlpha(value, uppercase: true);
+                case "i": return FormatRoman(value, uppercase: false);
+                case "I": return FormatRoman(value, uppercase: true);
+                default: return value.ToString(CultureInfo.InvariantCulture);
+            }
+        }
+
+        private static string FormatAlpha(int value, bool uppercase) {
+            if (value <= 0) return value.ToString(CultureInfo.InvariantCulture);
+            var builder = new StringBuilder();
+            int remaining = value;
+            while (remaining > 0) {
+                remaining--;
+                char character = (char)((uppercase ? 'A' : 'a') + remaining % 26);
+                builder.Insert(0, character);
+                remaining /= 26;
+            }
+            return builder.ToString();
+        }
+
+        private static string FormatRoman(int value, bool uppercase) {
+            if (value <= 0 || value > 3999) return value.ToString(CultureInfo.InvariantCulture);
+            int[] values = { 1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1 };
+            string[] symbols = { "m", "cm", "d", "cd", "c", "xc", "l", "xl", "x", "ix", "v", "iv", "i" };
+            var builder = new StringBuilder();
+            int remaining = value;
+            for (int index = 0; index < values.Length; index++) {
+                while (remaining >= values[index]) {
+                    builder.Append(symbols[index]);
+                    remaining -= values[index];
+                }
+            }
+            string marker = builder.ToString();
+            return uppercase ? marker.ToUpperInvariant() : marker;
+        }
     }
 }

--- a/OfficeIMO.Reader.Html/README.md
+++ b/OfficeIMO.Reader.Html/README.md
@@ -97,7 +97,8 @@ foreach (OfficeDocumentLink link in document.Links) {
 - Table extraction with `ReaderTable.ColumnProfiles`.
 - Heading-aware chunk metadata when `ReaderOptions.MarkdownChunkByHeadings` is enabled.
 - HTML-to-Markdown profile, transform, converter, and visual round-trip option pass-through.
-- A schema-v5 rich result containing semantic blocks, figures, tables, links, form controls, media visuals, metadata, and bounded data-URI image assets.
+- A schema-v5 rich result containing semantic headings, quotes, code, footnotes, list markers, figures, tables, links, form controls, media visuals, metadata, and bounded data-URI image assets.
+- ARIA heading levels and accessible link/image names in rich blocks, links, assets, visuals, JSON, and `officeimo.html.*` capability identifiers.
 
 ## Boundaries
 

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Semantics.Fixtures.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Semantics.Fixtures.cs
@@ -1,0 +1,45 @@
+using System.IO.Compression;
+
+namespace OfficeIMO.Tests;
+
+public sealed partial class ReaderEpubModularTests {
+    private static void BuildEpubWithStructuredSemantics(string epubPath) {
+        using var file = new FileStream(epubPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+        using var archive = new ZipArchive(file, ZipArchiveMode.Create, leaveOpen: false);
+
+        WriteTextEntry(archive, "mimetype", "application/epub+zip", CompressionLevel.NoCompression);
+        WriteTextEntry(
+            archive,
+            "META-INF/container.xml",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<container version=\"1.0\" xmlns=\"urn:oasis:names:tc:opendocument:xmlns:container\">" +
+            "<rootfiles><rootfile full-path=\"OEBPS/package.opf\" media-type=\"application/oebps-package+xml\"/></rootfiles>" +
+            "</container>");
+        WriteTextEntry(
+            archive,
+            "OEBPS/package.opf",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<package version=\"3.0\" unique-identifier=\"bookid\" xmlns=\"http://www.idpf.org/2007/opf\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\">" +
+            "<metadata><dc:identifier id=\"bookid\">semantics-book</dc:identifier><dc:title>Structured semantics</dc:title><dc:language>en</dc:language></metadata>" +
+            "<manifest><item id=\"chapter\" href=\"chapter.xhtml\" media-type=\"application/xhtml+xml\"/>" +
+            "<item id=\"cover\" href=\"images/cover.png\" media-type=\"image/png\"/></manifest>" +
+            "<spine><itemref idref=\"chapter\"/></spine></package>");
+        WriteTextEntry(
+            archive,
+            "OEBPS/chapter.xhtml",
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<html xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:epub=\"http://www.idpf.org/2007/ops\"><head><title>Semantics</title></head><body>" +
+            "<div id=\"detail\" role=\"heading\" aria-level=\"4\">Accessible section</div>" +
+            "<blockquote><p>Quoted wisdom.</p></blockquote>" +
+            "<ol type=\"A\" start=\"3\"><li>Third choice</li></ol>" +
+            "<table><caption>Coverage</caption><tr><th>Measure</th><th>Value</th></tr><tr><td>Footnotes</td><td>Typed</td></tr></table>" +
+            "<pre data-language=\"csharp\">Console.WriteLine(3);</pre>" +
+            "<p id=\"ref-alpha\">Evidence<a epub:type=\"noteref\" role=\"doc-noteref\" href=\"#note-alpha\">1</a>.</p>" +
+            "<aside epub:type=\"footnote\" role=\"doc-footnote\" id=\"note-alpha\"><p>Source <strong>detail</strong>.</p>" +
+            "<a epub:type=\"backlink\" role=\"doc-backlink\" href=\"#ref-alpha\">return</a></aside>" +
+            "<p><a href=\"#detail\" aria-label=\"Read details\"></a></p>" +
+            "<figure><span id=\"cover-label\">Accessible cover</span><img src=\"images/cover.png\" aria-labelledby=\"cover-label\"/></figure>" +
+            "</body></html>");
+        WriteBinaryEntry(archive, "OEBPS/images/cover.png", new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 });
+    }
+}

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Semantics.Fixtures.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Semantics.Fixtures.cs
@@ -38,6 +38,7 @@ public sealed partial class ReaderEpubModularTests {
             "<aside epub:type=\"footnote\" role=\"doc-footnote\" id=\"note-alpha\"><p>Source <strong>detail</strong>.</p>" +
             "<a epub:type=\"backlink\" role=\"doc-backlink\" href=\"#ref-alpha\">return</a></aside>" +
             "<p><a href=\"#detail\" aria-label=\"Read details\"></a></p>" +
+            "<img src=\"images/cover.png\" alt=\"\"/>" +
             "<figure><span id=\"cover-label\">Accessible cover</span><img src=\"images/cover.png\" aria-labelledby=\"cover-label\"/></figure>" +
             "</body></html>");
         WriteBinaryEntry(archive, "OEBPS/images/cover.png", new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 });

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Semantics.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Semantics.cs
@@ -16,7 +16,7 @@ public sealed partial class ReaderEpubModularTests {
             string markdown = Assert.IsType<string>(result.Markdown).Replace("\r\n", "\n");
             Assert.Contains("#### Accessible section", markdown, StringComparison.Ordinal);
             Assert.Contains("> Quoted wisdom.", markdown, StringComparison.Ordinal);
-            Assert.Contains("C. Third choice", markdown, StringComparison.Ordinal);
+            Assert.Contains("3. Third choice", markdown, StringComparison.Ordinal);
             Assert.Contains("| Measure | Value |", markdown, StringComparison.Ordinal);
             Assert.Contains("```csharp", markdown, StringComparison.Ordinal);
             Assert.Contains("Evidence[^note-alpha].", markdown, StringComparison.Ordinal);

--- a/OfficeIMO.Reader.Tests/Reader.Epub.Semantics.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Epub.Semantics.cs
@@ -1,0 +1,57 @@
+using OfficeIMO.Reader;
+using OfficeIMO.Reader.Epub;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed partial class ReaderEpubModularTests {
+    [Fact]
+    public void DocumentReaderEpub_ProjectsStructuredSemanticsEndToEnd() {
+        string epubPath = Path.Combine(Path.GetTempPath(), "officeimo-epub-semantics-" + Guid.NewGuid().ToString("N") + ".epub");
+        try {
+            BuildEpubWithStructuredSemantics(epubPath);
+
+            OfficeDocumentReadResult result = EpubReaderAdapter.ReadDocument(epubPath);
+
+            string markdown = Assert.IsType<string>(result.Markdown).Replace("\r\n", "\n");
+            Assert.Contains("#### Accessible section", markdown, StringComparison.Ordinal);
+            Assert.Contains("> Quoted wisdom.", markdown, StringComparison.Ordinal);
+            Assert.Contains("C. Third choice", markdown, StringComparison.Ordinal);
+            Assert.Contains("| Measure | Value |", markdown, StringComparison.Ordinal);
+            Assert.Contains("```csharp", markdown, StringComparison.Ordinal);
+            Assert.Contains("Evidence[^note-alpha].", markdown, StringComparison.Ordinal);
+            Assert.Contains("[^note-alpha]: Source **detail**.", markdown, StringComparison.Ordinal);
+            Assert.DoesNotContain("return", markdown, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("[Read details]", markdown, StringComparison.Ordinal);
+
+            OfficeDocumentBlock heading = Assert.Single(
+                result.Blocks,
+                block => block.Kind == "heading" && block.Text == "Accessible section");
+            Assert.Equal(4, heading.Level);
+            Assert.Equal("Quoted wisdom.", Assert.Single(result.Blocks, block => block.Kind == "quote").Text);
+            Assert.Equal("Console.WriteLine(3);", Assert.Single(result.Blocks, block => block.Kind == "code").Text);
+            Assert.Equal("Source detail.", Assert.Single(result.Blocks, block => block.Kind == "footnote").Text);
+            Assert.Equal("C.", Assert.Single(result.Blocks, block => block.Kind == "list-item").Marker);
+            OfficeDocumentLink accessibleLink = Assert.Single(result.Links, link => link.Text == "Read details");
+            Assert.Equal(result.Source.Path + "::OEBPS/chapter.xhtml#detail", accessibleLink.Uri);
+            OfficeDocumentAsset cover = Assert.Single(result.Assets, asset => asset.SourceObjectId == "cover");
+            Assert.Equal("Accessible cover", cover.AltText);
+            Assert.Contains(Assert.Single(result.Pages).Assets, asset => ReferenceEquals(asset, cover));
+            Assert.Contains(result.Visuals, visual => visual.Kind == "image" && visual.Content == "Accessible cover");
+            Assert.Contains("officeimo.html.accessibility", result.CapabilitiesUsed);
+            Assert.Contains("officeimo.html.footnotes", result.CapabilitiesUsed);
+            Assert.Contains("officeimo.html.tables", result.CapabilitiesUsed);
+            Assert.Contains("officeimo.html.lists", result.CapabilitiesUsed);
+            Assert.Contains("officeimo.html.quotes", result.CapabilitiesUsed);
+            Assert.Contains("officeimo.html.code", result.CapabilitiesUsed);
+
+            OfficeDocumentReadResult roundTrip = OfficeDocumentReadResultJson.Deserialize(
+                EpubReaderAdapter.ReadDocumentJson(epubPath));
+            Assert.Equal("Accessible cover", Assert.Single(roundTrip.Assets, asset => asset.SourceObjectId == "cover").AltText);
+            Assert.Contains("officeimo.html.footnotes", roundTrip.CapabilitiesUsed);
+            Assert.Contains("[^note-alpha]: Source **detail**.", Assert.IsType<string>(roundTrip.Markdown), StringComparison.Ordinal);
+        } finally {
+            if (File.Exists(epubPath)) File.Delete(epubPath);
+        }
+    }
+}

--- a/OfficeIMO.Reader.Tests/Reader.Html.AccessibilityAndFootnotes.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Html.AccessibilityAndFootnotes.cs
@@ -1,0 +1,40 @@
+using OfficeIMO.Reader;
+using OfficeIMO.Reader.Html;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+[Collection("ReaderRegistryNonParallel")]
+public sealed class ReaderHtmlAccessibilityAndFootnotesTests {
+    [Fact]
+    public void DocumentReaderHtml_LinkNamesPreferAriaThenVisibleTextBeforeTitle() {
+        const string html = """
+<p><a href="report" aria-label="Download annual report">Download</a></p>
+<p><a href="guide" title="Open guide">Read more</a></p>
+""";
+
+        OfficeDocumentReadResult result = HtmlReaderAdapter.ReadContentDocument(html, "links.html");
+
+        Assert.Equal(new[] { "Download annual report", "Read more" }, result.Links.Select(link => link.Text));
+    }
+
+    [Fact]
+    public void DocumentReaderHtml_ProjectsGroupedEpubFootnotesAsFootnoteBlocks() {
+        const string html = """
+<p>Text<a epub:type="noteref" role="doc-noteref" href="#fn:1">1</a>.</p>
+<ol epub:type="footnotes">
+  <li id="fn:1">
+    <p>Grouped <strong>footnote</strong>.</p>
+    <a epub:type="backlink" role="doc-backlink" href="#ref:1">back</a>
+  </li>
+</ol>
+""";
+
+        OfficeDocumentReadResult result = HtmlReaderAdapter.ReadContentDocument(html, "grouped-footnotes.xhtml");
+        OfficeDocumentBlock footnote = Assert.Single(result.Blocks, block => block.Kind == "footnote");
+
+        Assert.Equal("Grouped footnote.", footnote.Text);
+        Assert.DoesNotContain(result.Blocks, block => block.Kind == "list-item" && block.Text.Contains("Grouped", StringComparison.Ordinal));
+        Assert.Contains("officeimo.html.footnotes", result.CapabilitiesUsed);
+    }
+}

--- a/OfficeIMO.Reader.Tests/Reader.Html.AccessibilityAndFootnotes.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Html.AccessibilityAndFootnotes.cs
@@ -11,11 +11,28 @@ public sealed class ReaderHtmlAccessibilityAndFootnotesTests {
         const string html = """
 <p><a href="report" aria-label="Download annual report">Download</a></p>
 <p><a href="guide" title="Open guide">Read more</a></p>
+<span id="label" aria-label="Download labelled report">ignored</span>
+<p><a href="labelled" aria-labelledby="label"></a></p>
 """;
 
         OfficeDocumentReadResult result = HtmlReaderAdapter.ReadContentDocument(html, "links.html");
 
-        Assert.Equal(new[] { "Download annual report", "Read more" }, result.Links.Select(link => link.Text));
+        Assert.Equal(new[] { "Download annual report", "Read more", "Download labelled report" }, result.Links.Select(link => link.Text));
+    }
+
+    [Fact]
+    public void DocumentReaderHtml_ProjectsSourceLessAriaImageAsVisualWithoutAsset() {
+        const string html = "<div role=\"img\" aria-label=\"Sales chart\"></div>";
+
+        OfficeDocumentReadResult result = HtmlReaderAdapter.ReadContentDocument(html, "aria-image.html");
+        ReaderVisual visual = Assert.Single(result.Visuals);
+
+        Assert.Empty(result.Assets);
+        Assert.Equal("image", visual.Kind);
+        Assert.Equal("div", visual.Language);
+        Assert.Equal("Sales chart", visual.Content);
+        Assert.Null(visual.SourceName);
+        Assert.Equal("image", visual.Location!.SourceBlockKind);
     }
 
     [Fact]

--- a/OfficeIMO.Reader.Tests/Reader.Html.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Html.Modular.cs
@@ -702,4 +702,57 @@ public sealed class ReaderHtmlModularTests {
         Assert.Contains("officeimo.html.accessibility", roundTrip.CapabilitiesUsed);
         Assert.Contains("officeimo.html.footnotes", roundTrip.CapabilitiesUsed);
     }
+
+    [Fact]
+    public void DocumentReaderHtml_UsesAriaColumnHeadersForTableColumns() {
+        const string html = """
+<div role="table">
+  <div role="row"><div role="columnheader">Name</div><div role="columnheader">Value</div></div>
+  <div role="row"><div role="cell">EPUB</div><div role="cell">Structured</div></div>
+</div>
+""";
+
+        OfficeDocumentReadResult result = HtmlReaderAdapter.ReadContentDocument(html, "aria-table.html");
+        ReaderTable table = Assert.Single(result.Tables);
+
+        Assert.Equal(new[] { "Name", "Value" }, table.Columns);
+        Assert.Equal(new[] { "EPUB", "Structured" }, Assert.Single(table.Rows));
+    }
+
+    [Fact]
+    public void DocumentReaderHtml_DoesNotDuplicateNestedQuoteOrFootnoteBlocks() {
+        const string html = """
+<blockquote>
+  <h2>Quoted heading</h2>
+  <pre>quoted code</pre>
+  <ul><li>quoted item</li></ul>
+  <table><tr><th>Quoted column</th></tr><tr><td>quoted value</td></tr></table>
+</blockquote>
+<aside epub:type="footnote" id="source-note">
+  <p>Footnote text</p>
+  <pre>footnote code</pre>
+</aside>
+""";
+
+        OfficeDocumentReadResult result = HtmlReaderAdapter.ReadContentDocument(html, "nested-blocks.html");
+        OfficeDocumentBlock quote = Assert.Single(result.Blocks, block => block.Kind == "quote");
+        OfficeDocumentBlock footnote = Assert.Single(result.Blocks, block => block.Kind == "footnote");
+
+        Assert.Contains("Quoted heading", quote.Text, StringComparison.Ordinal);
+        Assert.Contains("quoted code", quote.Text, StringComparison.Ordinal);
+        Assert.Contains("Footnote text", footnote.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain(result.Blocks, block => block.Kind == "code" || block.Kind == "list-item" || block.Kind == "table");
+        Assert.Empty(result.Tables);
+    }
+
+    [Fact]
+    public void DocumentReaderHtml_DoesNotPromoteGenericEpubNotesToFootnotes() {
+        const string html = "<aside epub:type=\"note\" id=\"editorial\"><p>Editorial context.</p></aside>";
+
+        OfficeDocumentReadResult result = HtmlReaderAdapter.ReadContentDocument(html, "generic-note.html");
+
+        Assert.DoesNotContain(result.Blocks, block => block.Kind == "footnote");
+        Assert.DoesNotContain("officeimo.html.footnotes", result.CapabilitiesUsed);
+        Assert.Contains(result.Blocks, block => block.Kind == "paragraph" && block.Text == "Editorial context.");
+    }
 }

--- a/OfficeIMO.Reader.Tests/Reader.Html.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Html.Modular.cs
@@ -658,7 +658,7 @@ public sealed class ReaderHtmlModularTests {
   <head><base href="https://example.test/book/"></head>
   <body>
     <div role="heading" aria-level="4">Accessible section</div>
-    <p><a href="note.xhtml" aria-label="Open note"></a></p>
+    <p><a href="note.xhtml" aria-label="Open note">Visible note</a></p>
     <blockquote><p>Quoted text</p></blockquote>
     <pre data-language="csharp">Console.WriteLine(1);</pre>
     <ol type="A" start="3"><li>Third choice</li></ol>

--- a/OfficeIMO.Reader.Tests/Reader.Html.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Html.Modular.cs
@@ -650,4 +650,56 @@ public sealed class ReaderHtmlModularTests {
         Assert.Contains(chunks, c =>
             ((c.Markdown ?? c.Text).Contains("https://example.com/docs/guide/getting-started", StringComparison.OrdinalIgnoreCase)));
     }
+
+    [Fact]
+    public void DocumentReaderHtml_ProjectsAccessibilityAndFootnoteCapabilitiesThroughJson() {
+        const string html = """
+<html>
+  <head><base href="https://example.test/book/"></head>
+  <body>
+    <div role="heading" aria-level="4">Accessible section</div>
+    <p><a href="note.xhtml" aria-label="Open note"></a></p>
+    <blockquote><p>Quoted text</p></blockquote>
+    <pre data-language="csharp">Console.WriteLine(1);</pre>
+    <ol type="A" start="3"><li>Third choice</li></ol>
+    <span id="cover-label">Cover chart</span>
+    <img src="images/cover.png" aria-labelledby="cover-label">
+    <aside id="note" epub:type="footnote" role="doc-footnote"><p>Footnote body</p></aside>
+  </body>
+</html>
+""";
+
+        OfficeDocumentReadResult result = HtmlReaderAdapter.ReadContentDocument(html, "chapter.xhtml");
+
+        OfficeDocumentBlock heading = Assert.Single(result.Blocks, block => block.Kind == "heading");
+        OfficeDocumentLink link = Assert.Single(result.Links);
+        OfficeDocumentAsset image = Assert.Single(result.Assets);
+        ReaderVisual visual = Assert.Single(result.Visuals, item => item.Kind == "image");
+        OfficeDocumentBlock quote = Assert.Single(result.Blocks, block => block.Kind == "quote");
+        OfficeDocumentBlock code = Assert.Single(result.Blocks, block => block.Kind == "code");
+        OfficeDocumentBlock footnote = Assert.Single(result.Blocks, block => block.Kind == "footnote");
+        OfficeDocumentBlock listItem = Assert.Single(result.Blocks, block => block.Kind == "list-item");
+
+        Assert.Equal(4, heading.Level);
+        Assert.Equal("Accessible section", heading.Text);
+        Assert.Equal("Open note", link.Text);
+        Assert.Equal("https://example.test/book/note.xhtml", link.Uri);
+        Assert.Equal("Cover chart", image.AltText);
+        Assert.Equal("https://example.test/book/images/cover.png", image.SourceObjectId);
+        Assert.Equal("Cover chart", visual.Content);
+        Assert.Equal("Quoted text", quote.Text);
+        Assert.Equal("Console.WriteLine(1);", code.Text);
+        Assert.Equal("Footnote body", footnote.Text);
+        Assert.Equal("C.", listItem.Marker);
+        Assert.Contains("officeimo.html.accessibility", result.CapabilitiesUsed);
+        Assert.Contains("officeimo.html.footnotes", result.CapabilitiesUsed);
+        Assert.Contains("officeimo.html.quotes", result.CapabilitiesUsed);
+        Assert.Contains("officeimo.html.code", result.CapabilitiesUsed);
+
+        OfficeDocumentReadResult roundTrip = OfficeDocumentReadResultJson.Deserialize(
+            HtmlReaderAdapter.ReadContentDocumentJson(html, "chapter.xhtml"));
+        Assert.Equal("Cover chart", Assert.Single(roundTrip.Assets).AltText);
+        Assert.Contains("officeimo.html.accessibility", roundTrip.CapabilitiesUsed);
+        Assert.Contains("officeimo.html.footnotes", roundTrip.CapabilitiesUsed);
+    }
 }


### PR DESCRIPTION
## Summary

- Preserve EPUB code blocks, quotations, footnotes, accessibility semantics, and ordered-list metadata through the shared HTML and Markdown models.
- Retain ordered-list marker family, start value, reversal, and item value resets in the typed model while emitting portable decimal CommonMark markers.
- Resolve accessible names in ARIA order, including nested `aria-labelledby` targets with deterministic cycle protection.
- Project genuinely source-less accessible graphics as Reader visuals without manufacturing assets or bypassing image-source policy.
- Project ID-backed entries inside EPUB footnote, endnote, and rearnote collections as footnote blocks.
- Avoid duplicate nested rich blocks and keep package-level accessible image naming separate from per-placement decorative semantics.
- Keep conversion local, deterministic, bounded, and dependency-free.

## Reader behavior

EPUB continues to use `OfficeIMO.Epub` for package and resource ownership, `OfficeIMO.Reader.Html` for reusable HTML structure, and a thin `OfficeIMO.Reader.Epub` projection layer. EPUB 3 fixtures cover headings, lists, code, quotes, grouped and individual footnotes, accessible names, semantic visuals, and resource projection end to end.

## API

`OrderedListBlock.Reversed` records descending ordered-list semantics and emits the matching HTML `reversed` attribute. Existing Markdown output remains portable for default CommonMark readers.

## Validation

- `OfficeIMO.Html.Tests`: 974 tests on .NET 8 and .NET 10
- `OfficeIMO.Markdown.Tests`: 2,905 tests on .NET 8 and .NET 10
- `OfficeIMO.Reader.Tests`: 602 tests on .NET 8 and .NET 10
- `OfficeIMO.Reader.Epub` owner graph: `netstandard2.0`, zero warnings
- Dependency files unchanged

## Standards

The semantic mapping follows [EPUB 3 Structural Semantics Vocabulary](https://www.w3.org/TR/epub-ssv-11/) and [EPUB Accessibility Techniques](https://www.w3.org/TR/epub-a11y-tech-11/).