### PR TITLE
Align all OfficeIMO NuGet package versions

### DIFF
--- a/Build/project.build.json
+++ b/Build/project.build.json
@@ -65,6 +65,7 @@
   },
   "ExpectedVersionMapAsInclude": true,
   "ExpectedVersionMapUseWildcards": false,
+  "AlignPackageVersions": true,
   "ExcludeProjects": [],
   "NugetSource": [],
   "IncludePrerelease": false,


### PR DESCRIPTION
## Summary

- enable PSPublishModule package-version alignment for the OfficeIMO project build
- resolve every included `2.0.X` package from the highest current package version, then apply one shared next patch version

For example, if the highest package is `2.0.5`, all included packages plan `2.0.6`, including packages currently below that version or packages being published for the first time.

## Validation

- public PSPublishModule 3.0.64 dry-run planned all 60 OfficeIMO packages at `2.0.2`
- focused PowerForge version-alignment tests passed (13/13), including the `2.0.5` to `2.0.6` scenario
- `Build/project.build.json` passes the PSPublishModule project-build schema