### PR TITLE
Release OfficeIMO packages 2.0.2

### DIFF
--- a/OfficeIMO.AsciiDoc.Markdown/OfficeIMO.AsciiDoc.Markdown.csproj
+++ b/OfficeIMO.AsciiDoc.Markdown/OfficeIMO.AsciiDoc.Markdown.csproj
@@ -4,7 +4,7 @@
     <Description>Loss-aware AsciiDoc and Markdown conversion bridge for OfficeIMO.</Description>
     <AssemblyName>OfficeIMO.AsciiDoc.Markdown</AssemblyName>
     <AssemblyTitle>OfficeIMO.AsciiDoc.Markdown</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.AsciiDoc/OfficeIMO.AsciiDoc.csproj
+++ b/OfficeIMO.AsciiDoc/OfficeIMO.AsciiDoc.csproj
@@ -4,7 +4,7 @@
     <Description>Source-preserving AsciiDoc parser, semantic model, and writer for .NET.</Description>
     <AssemblyName>OfficeIMO.AsciiDoc</AssemblyName>
     <AssemblyTitle>OfficeIMO.AsciiDoc</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.CSV/OfficeIMO.CSV.csproj
+++ b/OfficeIMO.CSV/OfficeIMO.CSV.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>OfficeIMO.CSV</AssemblyName>
     <AssemblyTitle>OfficeIMO.CSV</AssemblyTitle>
 
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0;net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Company>Evotec</Company>

--- a/OfficeIMO.Drawing.CodeGlyphX/OfficeIMO.Drawing.CodeGlyphX.csproj
+++ b/OfficeIMO.Drawing.CodeGlyphX/OfficeIMO.Drawing.CodeGlyphX.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.Drawing.CodeGlyphX</PackageId>
     <AssemblyName>OfficeIMO.Drawing.CodeGlyphX</AssemblyName>
     <AssemblyTitle>OfficeIMO.Drawing.CodeGlyphX</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Drawing/OfficeIMO.Drawing.csproj
+++ b/OfficeIMO.Drawing/OfficeIMO.Drawing.csproj
@@ -4,7 +4,7 @@
     <Description>Shared zero-dependency document, drawing, color, image, and font primitives for OfficeIMO projects.</Description>
     <AssemblyName>OfficeIMO.Drawing</AssemblyName>
     <AssemblyTitle>OfficeIMO.Drawing</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Email/OfficeIMO.Email.csproj
+++ b/OfficeIMO.Email/OfficeIMO.Email.csproj
@@ -4,7 +4,7 @@
     <Description>Managed EML, Outlook MSG, TNEF, and mailbox artifact engine with no third-party runtime dependency forest.</Description>
     <AssemblyName>OfficeIMO.Email</AssemblyName>
     <AssemblyTitle>OfficeIMO.Email</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Epub/OfficeIMO.Epub.csproj
+++ b/OfficeIMO.Epub/OfficeIMO.Epub.csproj
@@ -3,7 +3,7 @@
     <Description>EPUB extraction primitives for modular OfficeIMO ingestion pipelines.</Description>
     <AssemblyName>OfficeIMO.Epub</AssemblyName>
     <AssemblyTitle>OfficeIMO.Epub</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Excel.GoogleSheets/OfficeIMO.Excel.GoogleSheets.csproj
+++ b/OfficeIMO.Excel.GoogleSheets/OfficeIMO.Excel.GoogleSheets.csproj
@@ -4,7 +4,7 @@
         <Description>Google Sheets planning and export scaffolding for OfficeIMO.Excel.</Description>
         <AssemblyName>OfficeIMO.Excel.GoogleSheets</AssemblyName>
         <AssemblyTitle>OfficeIMO.Excel.GoogleSheets</AssemblyTitle>
-        <VersionPrefix>2.0.1</VersionPrefix>
+        <VersionPrefix>2.0.2</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             $(TargetFrameworks);net472</TargetFrameworks>

--- a/OfficeIMO.Excel.Html/OfficeIMO.Excel.Html.csproj
+++ b/OfficeIMO.Excel.Html/OfficeIMO.Excel.Html.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.Excel.Html</PackageId>
     <AssemblyName>OfficeIMO.Excel.Html</AssemblyName>
     <AssemblyTitle>OfficeIMO.Excel.Html</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Excel.OpenDocument/OfficeIMO.Excel.OpenDocument.csproj
+++ b/OfficeIMO.Excel.OpenDocument/OfficeIMO.Excel.OpenDocument.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.Excel.OpenDocument</PackageId>
     <AssemblyName>OfficeIMO.Excel.OpenDocument</AssemblyName>
     <AssemblyTitle>OfficeIMO.Excel.OpenDocument</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Excel.Pdf/OfficeIMO.Excel.Pdf.csproj
+++ b/OfficeIMO.Excel.Pdf/OfficeIMO.Excel.Pdf.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.Excel.Pdf</PackageId>
     <AssemblyName>OfficeIMO.Excel.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Excel.Pdf</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Excel/OfficeIMO.Excel.csproj
+++ b/OfficeIMO.Excel/OfficeIMO.Excel.csproj
@@ -6,7 +6,7 @@
         <AssemblyName>OfficeIMO.Excel</AssemblyName>
         <AssemblyTitle>OfficeIMO.Excel</AssemblyTitle>
 
-        <VersionPrefix>2.0.1</VersionPrefix>
+        <VersionPrefix>2.0.2</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             $(TargetFrameworks);net472</TargetFrameworks>

--- a/OfficeIMO.GoogleWorkspace/OfficeIMO.GoogleWorkspace.csproj
+++ b/OfficeIMO.GoogleWorkspace/OfficeIMO.GoogleWorkspace.csproj
@@ -4,7 +4,7 @@
         <Description>Shared Google Workspace abstractions for OfficeIMO extension packages.</Description>
         <AssemblyName>OfficeIMO.GoogleWorkspace</AssemblyName>
         <AssemblyTitle>OfficeIMO.GoogleWorkspace</AssemblyTitle>
-        <VersionPrefix>2.0.1</VersionPrefix>
+        <VersionPrefix>2.0.2</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             $(TargetFrameworks);net472</TargetFrameworks>

--- a/OfficeIMO.Html.Pdf/OfficeIMO.Html.Pdf.csproj
+++ b/OfficeIMO.Html.Pdf/OfficeIMO.Html.Pdf.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.Html.Pdf</PackageId>
     <AssemblyName>OfficeIMO.Html.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Html.Pdf</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Html/OfficeIMO.Html.csproj
+++ b/OfficeIMO.Html/OfficeIMO.Html.csproj
@@ -4,7 +4,7 @@
     <Description>Shared HTML parsing, resource policy, layout, diagnostics, and direct PNG/SVG rendering for OfficeIMO converters.</Description>
     <AssemblyName>OfficeIMO.Html</AssemblyName>
     <AssemblyTitle>OfficeIMO.Html</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Latex.Markdown/OfficeIMO.Latex.Markdown.csproj
+++ b/OfficeIMO.Latex.Markdown/OfficeIMO.Latex.Markdown.csproj
@@ -4,7 +4,7 @@
     <Description>Loss-aware LaTeX and Markdown conversion bridge for OfficeIMO.</Description>
     <AssemblyName>OfficeIMO.Latex.Markdown</AssemblyName>
     <AssemblyTitle>OfficeIMO.Latex.Markdown</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Latex/OfficeIMO.Latex.csproj
+++ b/OfficeIMO.Latex/OfficeIMO.Latex.csproj
@@ -4,7 +4,7 @@
     <Description>Source-preserving LaTeX interoperability profile for .NET.</Description>
     <AssemblyName>OfficeIMO.Latex</AssemblyName>
     <AssemblyTitle>OfficeIMO.Latex</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Markdown.Html/OfficeIMO.Markdown.Html.csproj
+++ b/OfficeIMO.Markdown.Html/OfficeIMO.Markdown.Html.csproj
@@ -4,7 +4,7 @@
         <Description>HTML converter for OfficeIMO.Markdown - Convert HTML fragments or documents into OfficeIMO.Markdown documents and Markdown text.</Description>
         <AssemblyName>OfficeIMO.Markdown.Html</AssemblyName>
         <AssemblyTitle>OfficeIMO.Markdown.Html</AssemblyTitle>
-        <VersionPrefix>2.0.1</VersionPrefix>
+        <VersionPrefix>2.0.2</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             $(TargetFrameworks);net472

--- a/OfficeIMO.Markdown.Pdf/OfficeIMO.Markdown.Pdf.csproj
+++ b/OfficeIMO.Markdown.Pdf/OfficeIMO.Markdown.Pdf.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.Markdown.Pdf</PackageId>
     <AssemblyName>OfficeIMO.Markdown.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Markdown.Pdf</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Markdown/OfficeIMO.Markdown.csproj
+++ b/OfficeIMO.Markdown/OfficeIMO.Markdown.csproj
@@ -4,7 +4,7 @@
         <Description>Markdown builder, typed reader/AST, and HTML renderer for .NET with GitHub-like output and an optional portable reader profile.</Description>
         <AssemblyName>OfficeIMO.Markdown</AssemblyName>
         <AssemblyTitle>OfficeIMO.Markdown</AssemblyTitle>
-        <VersionPrefix>2.0.1</VersionPrefix>
+        <VersionPrefix>2.0.2</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             $(TargetFrameworks);net472</TargetFrameworks>

--- a/OfficeIMO.MarkdownRenderer.IntelligenceX/OfficeIMO.MarkdownRenderer.IntelligenceX.csproj
+++ b/OfficeIMO.MarkdownRenderer.IntelligenceX/OfficeIMO.MarkdownRenderer.IntelligenceX.csproj
@@ -4,7 +4,7 @@
     <Description>IntelligenceX renderer plugin pack for OfficeIMO.MarkdownRenderer with transcript-oriented preset helpers and IX visual aliases.</Description>
     <AssemblyName>OfficeIMO.MarkdownRenderer.IntelligenceX</AssemblyName>
     <AssemblyTitle>OfficeIMO.MarkdownRenderer.IntelligenceX</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
       $(TargetFrameworks);net472

--- a/OfficeIMO.MarkdownRenderer.Wpf/OfficeIMO.MarkdownRenderer.Wpf.csproj
+++ b/OfficeIMO.MarkdownRenderer.Wpf/OfficeIMO.MarkdownRenderer.Wpf.csproj
@@ -4,7 +4,7 @@
     <Description>Reusable WPF/WebView2 host control for OfficeIMO.MarkdownRenderer.</Description>
     <AssemblyName>OfficeIMO.MarkdownRenderer.Wpf</AssemblyName>
     <AssemblyTitle>OfficeIMO.MarkdownRenderer.Wpf</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Company>Evotec</Company>

--- a/OfficeIMO.MarkdownRenderer/OfficeIMO.MarkdownRenderer.csproj
+++ b/OfficeIMO.MarkdownRenderer/OfficeIMO.MarkdownRenderer.csproj
@@ -4,7 +4,7 @@
     <Description>WebView-friendly Markdown rendering helpers (shell + incremental updates) built on OfficeIMO.Markdown.</Description>
     <AssemblyName>OfficeIMO.MarkdownRenderer</AssemblyName>
     <AssemblyTitle>OfficeIMO.MarkdownRenderer</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
       $(TargetFrameworks);net472

--- a/OfficeIMO.OpenDocument/OfficeIMO.OpenDocument.csproj
+++ b/OfficeIMO.OpenDocument/OfficeIMO.OpenDocument.csproj
@@ -3,7 +3,7 @@
     <Description>Native OpenDocument ODT, ODS, and ODP reader, writer, and preservation-aware document model for .NET.</Description>
     <AssemblyName>OfficeIMO.OpenDocument</AssemblyName>
     <AssemblyTitle>OfficeIMO.OpenDocument</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Pdf.Cryptography.Pkcs/OfficeIMO.Pdf.Cryptography.Pkcs.csproj
+++ b/OfficeIMO.Pdf.Cryptography.Pkcs/OfficeIMO.Pdf.Cryptography.Pkcs.csproj
@@ -4,7 +4,7 @@
     <Description>Optional first-party managed CMS signing and X.509 signature-validation provider for OfficeIMO.Pdf.</Description>
     <AssemblyName>OfficeIMO.Pdf.Cryptography.Pkcs</AssemblyName>
     <AssemblyTitle>OfficeIMO.Pdf.Cryptography.Pkcs</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Pdf/OfficeIMO.Pdf.csproj
+++ b/OfficeIMO.Pdf/OfficeIMO.Pdf.csproj
@@ -4,7 +4,7 @@
     <Description>Dependency-free PDF builder and reader for .NET with fluent document composition, standard PDF fonts, basic layout primitives, and no runtime package dependencies.</Description>
     <AssemblyName>OfficeIMO.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Pdf</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.PowerPoint.Html/OfficeIMO.PowerPoint.Html.csproj
+++ b/OfficeIMO.PowerPoint.Html/OfficeIMO.PowerPoint.Html.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.PowerPoint.Html</PackageId>
     <AssemblyName>OfficeIMO.PowerPoint.Html</AssemblyName>
     <AssemblyTitle>OfficeIMO.PowerPoint.Html</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.PowerPoint.OpenDocument/OfficeIMO.PowerPoint.OpenDocument.csproj
+++ b/OfficeIMO.PowerPoint.OpenDocument/OfficeIMO.PowerPoint.OpenDocument.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.PowerPoint.OpenDocument</PackageId>
     <AssemblyName>OfficeIMO.PowerPoint.OpenDocument</AssemblyName>
     <AssemblyTitle>OfficeIMO.PowerPoint.OpenDocument</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.PowerPoint.Pdf/OfficeIMO.PowerPoint.Pdf.csproj
+++ b/OfficeIMO.PowerPoint.Pdf/OfficeIMO.PowerPoint.Pdf.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.PowerPoint.Pdf</PackageId>
     <AssemblyName>OfficeIMO.PowerPoint.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.PowerPoint.Pdf</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.PowerPoint/OfficeIMO.PowerPoint.csproj
+++ b/OfficeIMO.PowerPoint/OfficeIMO.PowerPoint.csproj
@@ -6,7 +6,7 @@
         <AssemblyName>OfficeIMO.PowerPoint</AssemblyName>
         <AssemblyTitle>OfficeIMO.PowerPoint</AssemblyTitle>
 
-        <VersionPrefix>2.0.1</VersionPrefix>
+        <VersionPrefix>2.0.2</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             $(TargetFrameworks);net472

--- a/OfficeIMO.Reader.All/OfficeIMO.Reader.All.csproj
+++ b/OfficeIMO.Reader.All/OfficeIMO.Reader.All.csproj
@@ -4,7 +4,7 @@
     <Description>Composition-only preset for registering OfficeIMO.Reader's local format adapters.</Description>
     <AssemblyName>OfficeIMO.Reader.All</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.All</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.AsciiDoc/OfficeIMO.Reader.AsciiDoc.csproj
+++ b/OfficeIMO.Reader.AsciiDoc/OfficeIMO.Reader.AsciiDoc.csproj
@@ -4,7 +4,7 @@
     <Description>Modular OfficeIMO.Reader adapter for dependency-free AsciiDoc ingestion.</Description>
     <AssemblyName>OfficeIMO.Reader.AsciiDoc</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.AsciiDoc</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Csv/OfficeIMO.Reader.Csv.csproj
+++ b/OfficeIMO.Reader.Csv/OfficeIMO.Reader.Csv.csproj
@@ -3,7 +3,7 @@
     <Description>CSV/TSV adapters for OfficeIMO.Reader and OfficeIMO.Excel.</Description>
     <AssemblyName>OfficeIMO.Reader.Csv</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Csv</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Epub/OfficeIMO.Reader.Epub.csproj
+++ b/OfficeIMO.Reader.Epub/OfficeIMO.Reader.Epub.csproj
@@ -3,7 +3,7 @@
     <Description>EPUB adapter for OfficeIMO.Reader modular ingestion.</Description>
     <AssemblyName>OfficeIMO.Reader.Epub</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Epub</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Html/OfficeIMO.Reader.Html.csproj
+++ b/OfficeIMO.Reader.Html/OfficeIMO.Reader.Html.csproj
@@ -3,7 +3,7 @@
     <Description>HTML adapter for OfficeIMO.Reader using OfficeIMO.Markdown.Html.</Description>
     <AssemblyName>OfficeIMO.Reader.Html</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Html</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Json/OfficeIMO.Reader.Json.csproj
+++ b/OfficeIMO.Reader.Json/OfficeIMO.Reader.Json.csproj
@@ -3,7 +3,7 @@
     <Description>JSON adapter extensions for OfficeIMO.Reader.</Description>
     <AssemblyName>OfficeIMO.Reader.Json</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Json</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Latex/OfficeIMO.Reader.Latex.csproj
+++ b/OfficeIMO.Reader.Latex/OfficeIMO.Reader.Latex.csproj
@@ -4,7 +4,7 @@
     <Description>Modular OfficeIMO.Reader adapter for bounded-profile LaTeX ingestion.</Description>
     <AssemblyName>OfficeIMO.Reader.Latex</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Latex</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Ocr.Process/OfficeIMO.Reader.Ocr.Process.csproj
+++ b/OfficeIMO.Reader.Ocr.Process/OfficeIMO.Reader.Ocr.Process.csproj
@@ -3,7 +3,7 @@
     <Description>Optional process-protocol OCR engine for OfficeIMO.Reader.</Description>
     <AssemblyName>OfficeIMO.Reader.Ocr.Process</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Ocr.Process</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Ocr.Tesseract/OfficeIMO.Reader.Ocr.Tesseract.csproj
+++ b/OfficeIMO.Reader.Ocr.Tesseract/OfficeIMO.Reader.Ocr.Tesseract.csproj
@@ -3,7 +3,7 @@
     <Description>Optional Tesseract CLI OCR engine for OfficeIMO.Reader.</Description>
     <AssemblyName>OfficeIMO.Reader.Ocr.Tesseract</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Ocr.Tesseract</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.OpenDocument/OfficeIMO.Reader.OpenDocument.csproj
+++ b/OfficeIMO.Reader.OpenDocument/OfficeIMO.Reader.OpenDocument.csproj
@@ -3,7 +3,7 @@
     <Description>Native ODT, ODS, and ODP adapter for OfficeIMO.Reader modular ingestion.</Description>
     <AssemblyName>OfficeIMO.Reader.OpenDocument</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.OpenDocument</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Pdf/OfficeIMO.Reader.Pdf.csproj
+++ b/OfficeIMO.Reader.Pdf/OfficeIMO.Reader.Pdf.csproj
@@ -3,7 +3,7 @@
     <Description>PDF adapter for OfficeIMO.Reader using OfficeIMO.Pdf logical read model.</Description>
     <AssemblyName>OfficeIMO.Reader.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Pdf</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Rtf/OfficeIMO.Reader.Rtf.csproj
+++ b/OfficeIMO.Reader.Rtf/OfficeIMO.Reader.Rtf.csproj
@@ -3,7 +3,7 @@
     <Description>Bounded RTF chunk, table, visual, warning, and provenance adapter for OfficeIMO.Reader.</Description>
     <AssemblyName>OfficeIMO.Reader.Rtf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Rtf</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Visio/OfficeIMO.Reader.Visio.csproj
+++ b/OfficeIMO.Reader.Visio/OfficeIMO.Reader.Visio.csproj
@@ -3,7 +3,7 @@
     <Description>Visio adapter for OfficeIMO.Reader using OfficeIMO.Visio inspection snapshots.</Description>
     <AssemblyName>OfficeIMO.Reader.Visio</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Visio</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Xml/OfficeIMO.Reader.Xml.csproj
+++ b/OfficeIMO.Reader.Xml/OfficeIMO.Reader.Xml.csproj
@@ -3,7 +3,7 @@
     <Description>XML adapter extensions for OfficeIMO.Reader.</Description>
     <AssemblyName>OfficeIMO.Reader.Xml</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Xml</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Yaml/OfficeIMO.Reader.Yaml.csproj
+++ b/OfficeIMO.Reader.Yaml/OfficeIMO.Reader.Yaml.csproj
@@ -3,7 +3,7 @@
     <Description>YAML adapter extensions for OfficeIMO.Reader.</Description>
     <AssemblyName>OfficeIMO.Reader.Yaml</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Yaml</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader.Zip/OfficeIMO.Reader.Zip.csproj
+++ b/OfficeIMO.Reader.Zip/OfficeIMO.Reader.Zip.csproj
@@ -3,7 +3,7 @@
     <Description>ZIP adapter for OfficeIMO.Reader modular ingestion.</Description>
     <AssemblyName>OfficeIMO.Reader.Zip</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader.Zip</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Reader/OfficeIMO.Reader.csproj
+++ b/OfficeIMO.Reader/OfficeIMO.Reader.csproj
@@ -3,7 +3,7 @@
     <Description>Unified, read-only document extraction facade for OfficeIMO (Word/Excel/PowerPoint/Markdown/PDF) intended for AI ingestion.</Description>
     <AssemblyName>OfficeIMO.Reader</AssemblyName>
     <AssemblyTitle>OfficeIMO.Reader</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Rtf.Markdown/OfficeIMO.Rtf.Markdown.csproj
+++ b/OfficeIMO.Rtf.Markdown/OfficeIMO.Rtf.Markdown.csproj
@@ -10,7 +10,7 @@
     <Company>Evotec</Company>
     <Description>Semantic Rich Text Format and Markdown conversion bridge for OfficeIMO.</Description>
     <PackageTags>RTF;Markdown;OfficeIMO;document-conversion</PackageTags>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>Latest</LangVersion>

--- a/OfficeIMO.Rtf.Pdf/OfficeIMO.Rtf.Pdf.csproj
+++ b/OfficeIMO.Rtf.Pdf/OfficeIMO.Rtf.Pdf.csproj
@@ -3,7 +3,7 @@
     <Description>Bidirectional semantic RTF/PDF converter with shared fidelity diagnostics and managed image handling.</Description>
     <AssemblyName>OfficeIMO.Rtf.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Rtf.Pdf</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Rtf/OfficeIMO.Rtf.csproj
+++ b/OfficeIMO.Rtf/OfficeIMO.Rtf.csproj
@@ -4,7 +4,7 @@
     <Description>Managed Rich Text Format (RTF) reader, writer, lossless syntax tree, bounded parser, and editable document model for .NET.</Description>
     <AssemblyName>OfficeIMO.Rtf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Rtf</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Visio/OfficeIMO.Visio.csproj
+++ b/OfficeIMO.Visio/OfficeIMO.Visio.csproj
@@ -6,7 +6,7 @@
         <AssemblyName>OfficeIMO.Visio</AssemblyName>
         <AssemblyTitle>OfficeIMO.Visio</AssemblyTitle>
 
-        <VersionPrefix>2.0.1</VersionPrefix>
+        <VersionPrefix>2.0.2</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             $(TargetFrameworks);net472</TargetFrameworks>

--- a/OfficeIMO.Word.GoogleDocs/OfficeIMO.Word.GoogleDocs.csproj
+++ b/OfficeIMO.Word.GoogleDocs/OfficeIMO.Word.GoogleDocs.csproj
@@ -4,7 +4,7 @@
         <Description>Google Docs planning and export scaffolding for OfficeIMO.Word.</Description>
         <AssemblyName>OfficeIMO.Word.GoogleDocs</AssemblyName>
         <AssemblyTitle>OfficeIMO.Word.GoogleDocs</AssemblyTitle>
-        <VersionPrefix>2.0.1</VersionPrefix>
+        <VersionPrefix>2.0.2</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             $(TargetFrameworks);net472</TargetFrameworks>

--- a/OfficeIMO.Word.Html/OfficeIMO.Word.Html.csproj
+++ b/OfficeIMO.Word.Html/OfficeIMO.Word.Html.csproj
@@ -5,7 +5,7 @@
         <AssemblyName>OfficeIMO.Word.Html</AssemblyName>
         <AssemblyTitle>OfficeIMO.Word.Html</AssemblyTitle>
 
-        <VersionPrefix>2.0.1</VersionPrefix>
+        <VersionPrefix>2.0.2</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             $(TargetFrameworks);net472

--- a/OfficeIMO.Word.Markdown/OfficeIMO.Word.Markdown.csproj
+++ b/OfficeIMO.Word.Markdown/OfficeIMO.Word.Markdown.csproj
@@ -3,7 +3,7 @@
     <Description>Markdown converter for OfficeIMO.Word - Convert Word documents to/from Markdown using OfficeIMO.Markdown</Description>
     <AssemblyName>OfficeIMO.Word.Markdown</AssemblyName>
     <AssemblyTitle>OfficeIMO.Word.Markdown</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Word.OpenDocument/OfficeIMO.Word.OpenDocument.csproj
+++ b/OfficeIMO.Word.OpenDocument/OfficeIMO.Word.OpenDocument.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.Word.OpenDocument</PackageId>
     <AssemblyName>OfficeIMO.Word.OpenDocument</AssemblyName>
     <AssemblyTitle>OfficeIMO.Word.OpenDocument</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Word.Pdf/OfficeIMO.Word.Pdf.csproj
+++ b/OfficeIMO.Word.Pdf/OfficeIMO.Word.Pdf.csproj
@@ -4,7 +4,7 @@
     <PackageId>OfficeIMO.Word.Pdf</PackageId>
     <AssemblyName>OfficeIMO.Word.Pdf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Word.Pdf</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/OfficeIMO.Word.Rtf/OfficeIMO.Word.Rtf.csproj
+++ b/OfficeIMO.Word.Rtf/OfficeIMO.Word.Rtf.csproj
@@ -3,7 +3,7 @@
     <Description>Result-bearing RTF converter and document workflow bridge for OfficeIMO.Word.</Description>
     <AssemblyName>OfficeIMO.Word.Rtf</AssemblyName>
     <AssemblyTitle>OfficeIMO.Word.Rtf</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/OfficeIMO.Word/OfficeIMO.Word.csproj
+++ b/OfficeIMO.Word/OfficeIMO.Word.csproj
@@ -6,7 +6,7 @@
         <AssemblyName>OfficeIMO.Word</AssemblyName>
         <AssemblyTitle>OfficeIMO.Word</AssemblyTitle>
 
-        <VersionPrefix>2.0.1</VersionPrefix>
+        <VersionPrefix>2.0.2</VersionPrefix>
         <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
             $(TargetFrameworks);net472</TargetFrameworks>

--- a/OfficeIMO.Zip/OfficeIMO.Zip.csproj
+++ b/OfficeIMO.Zip/OfficeIMO.Zip.csproj
@@ -3,7 +3,7 @@
     <Description>Safe ZIP traversal primitives for modular OfficeIMO ingestion pipelines.</Description>
     <AssemblyName>OfficeIMO.Zip</AssemblyName>
     <AssemblyTitle>OfficeIMO.Zip</AssemblyTitle>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.0.2</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>


### PR DESCRIPTION
## Summary

- align all 59 published OfficeIMO packages on version 2.0.2
- make the merged typed ChartForgeX fence integration available through OfficeIMO.MarkdownRenderer.IntelligenceX 2.0.2
- keep the OfficeIMO package graph on a single compatible patch version

## Validation

- PowerForge release plan resolved all 59 included projects from 2.0.1 to 2.0.2
- OfficeIMO.MarkdownRenderer.IntelligenceX builds for net472, netstandard2.0, net8.0, and net10.0 with no warnings
- Markdown IntelligenceX transcript suite passes 59/59 on net8.0