### PR TITLE
Add managed PST writing and safe store conversion

### DIFF
--- a/Docs/officeimo.email-support-matrix.md
+++ b/Docs/officeimo.email-support-matrix.md
@@ -17,10 +17,10 @@ This matrix describes the current public contract for persisted email and Outloo
 | RTF bodies | Broad | MS-OXRTFCP `LZFu` and `MELA`, bounded decompression, CRC diagnostics, encapsulated HTML projection, and deterministic writing | RTF syntax and semantic conversion are owned by `OfficeIMO.Rtf` |
 | TNEF / `winmail.dat` | Broad | Message attributes, MAPI properties, recipient rows, attachments, embedded items, checksums, limits, and deterministic writing | Transport generation policy remains with the mail client |
 | mboxo and mboxrd | Supported | Aggregate read/write, envelope metadata, escaping, message-count and source limits | No mailbox indexing or concurrent store engine |
-| PST and OST stores | Read-only, selective | ANSI/Unicode PST and supported PST-compatible OST NDB variants; bounded folder catalogs, item references, summaries, selective item parts, deferred attachment streams, associated items, and orphan discovery | No mutation, PST writer, Exchange synchronization, or recovery of content never cached in an OST |
+| PST and OST stores | Selective read; new Unicode PST write | ANSI/Unicode PST and supported PST-compatible OST NDB variants; bounded folder catalogs, item references, summaries, selective item parts, deferred attachment streams, associated items, and orphan discovery. New PST output covers folders, typed items, recipients, attachments, embedded messages, named properties, and multi-valued MAPI properties | Existing-store mutation, append, repair, password/encryption authoring, Exchange synchronization, and recovery of content never cached in an OST are outside the contract |
 | OLM and EMLX stores | Read-only | Bounded Outlook for Mac ZIP/XML archives, individual Apple Mail EMLX items, partial-content metadata, Apple Mail trees, Maildir, and EML/MIME directory sessions | OLM opens into a bounded materialized model; mailbox directories remain lazy |
 | Store search and validation | Supported | Metadata queries, resumable semantic body/recipient/attachment-name search, snippets, progress, special-folder roles, content-availability reporting, and bounded PST/OST CRC/signature/layout validation | Search is an offline scan, not an Outlook or Exchange index query; structural validation does not repair the source |
-| Store export | Supported | Selected items to EML, MSG, OFT, or TNEF with a manifest, plus atomically committed streaming mbox | True OST-to-PST conversion requires a new PST writer and is not advertised |
+| Store export and conversion | Supported | Selected items to EML, MSG, OFT, or TNEF with a manifest, atomically committed streaming mbox, and read-only conversion of any supported store into a separate new Unicode PST | Search folders become static folders; unavailable OST/server content and unsupported attachment payloads are reported rather than invented |
 | Outlook OAB address books | Read-only, selective | Bounded component discovery; dynamic-schema v4 Full Details entries and distribution lists; shared address/contact/MAPI projections; raw property retention; resumable search; seeded CRC, framing, and full-decode validation | Display templates and v2/v3 components are inspection-only; compressed Exchange downloads, patches, directory synchronization, and mutation are outside the expanded-cache reader |
 | Protected Outlook messages | Handoff | Detects opaque and clear-signed S/MIME classes and exposes the original `.p7m`/`.p7s` payload attachment | Verification, trust, certificate/key lookup, and decryption belong to MimeKit or another host provider |
 | Lossless pass-through | Supported | Preserved raw source can be emitted unchanged when explicitly requested | Structured edits regenerate the artifact and cannot preserve an existing cryptographic signature |
@@ -53,13 +53,14 @@ This matrix describes the current public contract for persisted email and Outloo
 | Local packed-package consumer | A clean net8 consumer restored local `OfficeIMO.Email 0.1.0` and `OfficeIMO.Rtf 0.1.10`, wrote an MSG, and read it asynchronously |
 | Performance contracts | Release tests cover 1 MiB MIME, 1 MiB MSG attachment, and 500-message mbox workloads; see [performance evidence](officeimo.email-performance.md) |
 | Large-store contracts | A virtual 64 GiB PST contract covers selective reads, deferred attachment I/O, content search, and structural validation under fixed source-read ceilings; an aggregate-only 22.4 GB OST run exercises extraction, search, calendar items, Reader projection, and bounded structural checks |
+| Unicode PST writer | Synthetic round trips cover multi-block heaps and tables, typed MAPI properties, recipients, large attachments, embedded and associated items, named properties, and OST-to-new-PST conversion. An independent libpff reader opens the generated store and exports its synthetic folder and message. |
 | Outlook OAB cache | Generated v4 fixtures cover every supported property encoding, corruption and limits; aggregate-only validation of 18 private cache components decoded and fully validated all 8,049 declared entries with no retained directory data |
 
 ## Explicit non-goals
 
 - SMTP, IMAP, POP3, Graph, authentication, and account synchronization
 - DKIM, ARC, PGP, certificate trust, S/MIME verification, and decryption
-- PST/OST writing, mutation, compaction, repair, or OST-to-PST conversion
+- Existing PST/OST mutation, append, compaction, repair, password/encryption authoring, or OST output
 - Outlook profile settings, autocomplete caches, search indexes, and other profile/cache formats outside the dedicated OAB owner
 - a public arbitrary-CFB editing or transaction package
 - Outlook UI automation or identical editors across platforms; Outlook for Mac uses its generic item viewer for non-mail MSG classes

--- a/OfficeIMO.Email.Store.Tests/Interop/ExternalEmailStoreCorpusTests.cs
+++ b/OfficeIMO.Email.Store.Tests/Interop/ExternalEmailStoreCorpusTests.cs
@@ -1,0 +1,140 @@
+using System.Globalization;
+
+namespace OfficeIMO.Email.Store.Tests;
+
+public sealed class ExternalEmailStoreCorpusTests {
+    [EnvironmentFact("OFFICEIMO_EMAIL_STORE_CORPUS", requireDirectory: true)]
+    public void ReadsBoundedPrivatePstAndOstCorpusWithoutTableTraversalFailures() {
+        string root = Environment.GetEnvironmentVariable("OFFICEIMO_EMAIL_STORE_CORPUS")!;
+        int maximumItems = ReadPositiveEnvironmentInteger(
+            "OFFICEIMO_EMAIL_STORE_CORPUS_MAX_ITEMS", defaultValue: 10_000);
+
+        string[] paths = Directory.GetFiles(root, "*.*", SearchOption.TopDirectoryOnly)
+            .Where(path => path.EndsWith(".pst", StringComparison.OrdinalIgnoreCase) ||
+                           path.EndsWith(".ost", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        Assert.NotEmpty(paths);
+
+        var failures = new List<string>();
+        long totalItems = 0;
+        for (int storeIndex = 0; storeIndex < paths.Length; storeIndex++) {
+            string path = paths[storeIndex];
+            var before = new FileInfo(path);
+            long beforeLength = before.Length;
+            DateTime beforeWriteTimeUtc = before.LastWriteTimeUtc;
+            using EmailStoreSession session = EmailStoreSession.Open(path,
+                new EmailStoreReaderOptions(includeAssociatedItems: true, includeOrphanedItems: true));
+            var references = new List<EmailStoreItemReference>();
+            foreach (EmailStoreItemReference reference in session.EnumerateItems(new EmailStoreEnumerationOptions(
+                maxItems: maximumItems,
+                includeAssociatedItems: true,
+                includeOrphanedItems: true))) {
+                references.Add(reference);
+            }
+            int itemCount = references.Count;
+            totalItems = checked(totalItems + itemCount);
+
+            var safeProjection = new EmailStoreItemReadOptions(
+                EmailStoreItemReadParts.Metadata | EmailStoreItemReadParts.Bodies |
+                EmailStoreItemReadParts.Recipients | EmailStoreItemReadParts.AttachmentMetadata,
+                maxDecodedPropertyBytes: 32L * 1024 * 1024,
+                preferStreamingAttachmentContent: true);
+            foreach (EmailStoreItemReference reference in references.Take(8)) {
+                _ = session.ReadItem(reference, safeProjection);
+            }
+
+            EmailStoreDiagnostic[] tableFailures = session.Diagnostics.Where(diagnostic =>
+                diagnostic.Code == "EMAIL_STORE_PST_TABLE_CONTEXT").ToArray();
+            if (tableFailures.Length > 0) {
+                failures.Add(string.Concat(
+                    "store-", (storeIndex + 1).ToString(CultureInfo.InvariantCulture),
+                    " format=", session.Format,
+                    " bytes=", beforeLength.ToString(CultureInfo.InvariantCulture),
+                    " items=", itemCount.ToString(CultureInfo.InvariantCulture),
+                    " table-errors=", tableFailures.Length.ToString(CultureInfo.InvariantCulture),
+                    Environment.NewLine,
+                    string.Join(Environment.NewLine, tableFailures
+                        .Select(diagnostic => string.Concat(diagnostic.Location, ": ", diagnostic.Message))
+                        .Distinct(StringComparer.Ordinal))));
+            }
+
+            before.Refresh();
+            Assert.Equal(beforeLength, before.Length);
+            Assert.Equal(beforeWriteTimeUtc, before.LastWriteTimeUtc);
+        }
+
+        Assert.True(totalItems > 0, "The external PST/OST corpus contained no enumerable items.");
+        Assert.True(failures.Count == 0, string.Join(Environment.NewLine, failures));
+    }
+
+    [EnvironmentFact("OFFICEIMO_EMAIL_STORE_CORPUS_CONVERT", "1")]
+    public void ConvertsBoundedPrivateStoresToTemporaryPstWithoutRetainingCorpusContent() {
+        string? root = Environment.GetEnvironmentVariable("OFFICEIMO_EMAIL_STORE_CORPUS");
+        Assert.True(!string.IsNullOrWhiteSpace(root) && Directory.Exists(root),
+            "OFFICEIMO_EMAIL_STORE_CORPUS must name a private local PST/OST directory.");
+        int maximumItems = ReadPositiveEnvironmentInteger(
+            "OFFICEIMO_EMAIL_STORE_CORPUS_CONVERT_MAX_ITEMS", defaultValue: 8);
+        int maximumStores = ReadPositiveEnvironmentInteger(
+            "OFFICEIMO_EMAIL_STORE_CORPUS_MAX_STORES", defaultValue: 1);
+        string[] paths = Directory.GetFiles(root!, "*.*", SearchOption.TopDirectoryOnly)
+            .Where(path => path.EndsWith(".pst", StringComparison.OrdinalIgnoreCase) ||
+                           path.EndsWith(".ost", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .Take(maximumStores)
+            .ToArray();
+        Assert.NotEmpty(paths);
+
+        int convertedItems = 0;
+        foreach (string sourcePath in paths) {
+            var source = new FileInfo(sourcePath);
+            long sourceLength = source.Length;
+            DateTime sourceWriteTimeUtc = source.LastWriteTimeUtc;
+            string destinationPath = Path.Combine(Path.GetTempPath(),
+                string.Concat("officeimo-private-conversion-", Guid.NewGuid().ToString("N"), ".pst"));
+            try {
+                var readerOptions = new EmailStoreReaderOptions(
+                    maxItemCount: maximumItems,
+                    maxAttachmentBytes: 64L * 1024 * 1024,
+                    maxTotalAttachmentBytes: 256L * 1024 * 1024,
+                    retainAttachmentContent: false,
+                    includeAssociatedItems: true,
+                    includeOrphanedItems: true);
+                EmailStorePstConversionReport report = EmailStoreConverter.ConvertToPst(
+                    sourcePath, destinationPath, readerOptions,
+                    new EmailStorePstConversionOptions(
+                        continueOnItemError: true,
+                        includeAssociatedItems: true,
+                        includeOrphanedItems: true,
+                        maxItems: maximumItems));
+                convertedItems = checked(convertedItems + report.ConvertedItems);
+                Assert.Equal(report.ConvertedItems, report.WriteReport.ItemCount);
+                using EmailStoreSession converted = EmailStoreSession.Open(destinationPath,
+                    new EmailStoreReaderOptions(includeAssociatedItems: true,
+                        includeOrphanedItems: true));
+                Assert.Equal(report.ConvertedItems, converted.EnumerateItems(
+                    new EmailStoreEnumerationOptions(
+                        maxItems: maximumItems,
+                        includeAssociatedItems: true,
+                        includeOrphanedItems: true)).Count());
+
+                source.Refresh();
+                Assert.Equal(sourceLength, source.Length);
+                Assert.Equal(sourceWriteTimeUtc, source.LastWriteTimeUtc);
+            } finally {
+                try { if (File.Exists(destinationPath)) File.Delete(destinationPath); }
+                catch (IOException) { }
+                catch (UnauthorizedAccessException) { }
+            }
+        }
+        Assert.True(convertedItems > 0,
+            "The bounded private-corpus conversion did not produce an item.");
+    }
+
+    private static int ReadPositiveEnvironmentInteger(string name, int defaultValue) {
+        string? value = Environment.GetEnvironmentVariable(name);
+        return int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out int parsed) && parsed > 0
+            ? parsed
+            : defaultValue;
+    }
+}

--- a/OfficeIMO.Email.Store.Tests/Interop/OptInFactAttributes.cs
+++ b/OfficeIMO.Email.Store.Tests/Interop/OptInFactAttributes.cs
@@ -1,0 +1,37 @@
+using System.Runtime.InteropServices;
+
+namespace OfficeIMO.Email.Store.Tests;
+
+public sealed class EnvironmentFactAttribute : FactAttribute {
+    public EnvironmentFactAttribute(string variableName, string? expectedValue = null,
+        bool requireDirectory = false) {
+        string? value = Environment.GetEnvironmentVariable(variableName);
+        bool available = expectedValue == null
+            ? !string.IsNullOrWhiteSpace(value)
+            : string.Equals(value, expectedValue, StringComparison.Ordinal);
+        if (available && requireDirectory) available = Directory.Exists(value);
+        if (!available) {
+            Skip = expectedValue == null
+                ? string.Concat("Set ", variableName, " to run this opt-in test.")
+                : string.Concat("Set ", variableName, "=", expectedValue,
+                    " to run this opt-in test.");
+        }
+    }
+}
+
+public sealed class OutlookInteropFactAttribute : FactAttribute {
+    public OutlookInteropFactAttribute() {
+        if (!string.Equals(Environment.GetEnvironmentVariable(
+            "OFFICEIMO_EMAIL_STORE_OUTLOOK_INTEROP"), "1", StringComparison.Ordinal)) {
+            Skip = "Set OFFICEIMO_EMAIL_STORE_OUTLOOK_INTEROP=1 to run classic Outlook interoperability.";
+        } else if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Skip = "Classic Outlook interoperability requires Windows.";
+        } else {
+#pragma warning disable CA1416
+            if (Type.GetTypeFromProgID("Outlook.Application") == null) {
+                Skip = "Classic Outlook is not registered on this machine.";
+            }
+#pragma warning restore CA1416
+        }
+    }
+}

--- a/OfficeIMO.Email.Store.Tests/Interop/OutlookPstWriterInteropTests.cs
+++ b/OfficeIMO.Email.Store.Tests/Interop/OutlookPstWriterInteropTests.cs
@@ -1,0 +1,92 @@
+using OfficeIMO.Email;
+using System.Runtime.InteropServices;
+
+namespace OfficeIMO.Email.Store.Tests;
+
+public sealed class OutlookPstWriterInteropTests {
+    [OutlookInteropFact]
+    public void Generated_unicode_pst_can_be_mounted_read_and_removed_by_classic_outlook() {
+#pragma warning disable CA1416
+        Type? outlookType = Type.GetTypeFromProgID("Outlook.Application");
+#pragma warning restore CA1416
+        Assert.NotNull(outlookType);
+
+        string? retainedPath = Environment.GetEnvironmentVariable(
+            "OFFICEIMO_EMAIL_STORE_OUTLOOK_INTEROP_OUTPUT");
+        string path = string.IsNullOrWhiteSpace(retainedPath)
+            ? Path.Combine(Path.GetTempPath(),
+                string.Concat("officeimo-outlook-interop-", Guid.NewGuid().ToString("N"), ".pst"))
+            : Path.GetFullPath(retainedPath!);
+        object? application = null;
+        object? nameSpace = null;
+        object? store = null;
+        object? root = null;
+        try {
+            using (EmailStorePstWriter writer = EmailStorePstWriter.Create(path,
+                new EmailStorePstWriterOptions("OfficeIMO Interop"))) {
+                if (!string.Equals(Environment.GetEnvironmentVariable(
+                    "OFFICEIMO_EMAIL_STORE_OUTLOOK_INTEROP_EMPTY"), "1", StringComparison.Ordinal)) {
+                    string folder = writer.AddFolder("OfficeIMO Synthetic");
+                    writer.AddItem(folder, new EmailDocument {
+                        Subject = "OfficeIMO synthetic interoperability item",
+                        MessageClass = "IPM.Note"
+                    });
+                }
+                writer.Complete();
+            }
+            if (!string.IsNullOrWhiteSpace(retainedPath)) {
+                File.Copy(path, string.Concat(path, ".before-outlook"), overwrite: true);
+            }
+            application = Activator.CreateInstance(outlookType);
+            Assert.NotNull(application);
+            dynamic outlook = application!;
+            nameSpace = outlook.GetNamespace("MAPI");
+            dynamic mapi = nameSpace!;
+            mapi.AddStoreEx(path, 2); // OlStoreType.olStoreUnicode
+            dynamic stores = mapi.Stores;
+            for (int index = 1; index <= stores.Count; index++) {
+                dynamic candidate = stores.Item(index);
+                if (string.Equals(Convert.ToString(candidate.FilePath), path,
+                    StringComparison.OrdinalIgnoreCase)) {
+                    store = candidate;
+                    break;
+                }
+                Release(candidate);
+            }
+            Assert.NotNull(store);
+            dynamic mountedStore = store!;
+            root = mountedStore.GetRootFolder();
+            dynamic mountedRoot = root!;
+            if (!string.Equals(Environment.GetEnvironmentVariable(
+                "OFFICEIMO_EMAIL_STORE_OUTLOOK_INTEROP_EMPTY"), "1", StringComparison.Ordinal)) {
+                dynamic folderObject = mountedRoot.Folders.Item("OfficeIMO Synthetic");
+                Assert.Equal(1, (int)folderObject.Items.Count);
+                dynamic item = folderObject.Items.Item(1);
+                Assert.Equal("OfficeIMO synthetic interoperability item",
+                    Convert.ToString(item.Subject));
+                Release(item);
+                Release(folderObject);
+            }
+            mapi.RemoveStore(mountedRoot);
+            root = null;
+        } finally {
+            Release(root);
+            Release(store);
+            Release(nameSpace);
+            Release(application);
+            if (string.IsNullOrWhiteSpace(retainedPath)) {
+                try { if (File.Exists(path)) File.Delete(path); }
+                catch (IOException) { }
+                catch (UnauthorizedAccessException) { }
+            }
+        }
+    }
+
+    private static void Release(object? value) {
+        if (value == null || !Marshal.IsComObject(value)) return;
+#pragma warning disable CA1416
+        try { Marshal.FinalReleaseComObject(value); }
+#pragma warning restore CA1416
+        catch (InvalidComObjectException) { }
+    }
+}

--- a/OfficeIMO.Email.Store.Tests/Pst/PstHeapTests.cs
+++ b/OfficeIMO.Email.Store.Tests/Pst/PstHeapTests.cs
@@ -1,0 +1,87 @@
+using System.Threading;
+
+namespace OfficeIMO.Email.Store.Tests;
+
+public sealed class PstHeapTests {
+    [Fact]
+    public void ResolvesVersion36ThirteenBitHeapBlockIndexes() {
+        using var stream = new MemoryStream(PstTestFileBuilder.Create(ost: true, fourK: true));
+        PstHeader header = PstHeader.Read(stream, EmailStoreFormat.Ost);
+        var ndb = new PstNdbReader(stream, header, EmailStoreReaderOptions.Default,
+            CancellationToken.None);
+        byte[] expected = new byte[] { 1, 3, 5, 7, 9 };
+        var dataTree = new PstDataTree(new[] {
+            CreateHeapPage(Array.Empty<byte>(), firstPage: true),
+            CreateHeapPage(expected, firstPage: false)
+        }, expected.LongLength);
+        var heap = new PstHeap(dataTree, new Dictionary<uint, PstSubnodeReference>(), ndb,
+            EmailStoreReaderOptions.Default, CancellationToken.None);
+
+        byte[] actual = heap.GetAllocation(0x00080020);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ResolvesVersion36FourteenBitHeapAllocationIndexes() {
+        using var stream = new MemoryStream(PstTestFileBuilder.Create(ost: true, fourK: true));
+        PstHeader header = PstHeader.Read(stream, EmailStoreFormat.Ost);
+        var ndb = new PstNdbReader(stream, header, EmailStoreReaderOptions.Default,
+            CancellationToken.None);
+        byte[] expected = new byte[] { 2, 4, 6, 8 };
+        var dataTree = new PstDataTree(new[] {
+            CreateHeapPageWithAllocations(2049, 2048, expected)
+        }, expected.LongLength);
+        var heap = new PstHeap(dataTree, new Dictionary<uint, PstSubnodeReference>(), ndb,
+            EmailStoreReaderOptions.Default, CancellationToken.None);
+
+        byte[] actual = heap.GetAllocation(0x00010020);
+
+        Assert.Equal(expected, actual);
+    }
+
+    private static byte[] CreateHeapPage(byte[] allocation, bool firstPage, int minimumLength = 0) {
+        int headerSize = firstPage ? 12 : 8;
+        int mapOffset = (headerSize + allocation.Length + 1) & ~1;
+        var block = new byte[Math.Max(mapOffset + 8, minimumLength)];
+        WriteUInt16(block, 0, mapOffset);
+        if (firstPage) {
+            block[2] = 0xEC;
+            block[3] = 0xBC;
+        }
+        Buffer.BlockCopy(allocation, 0, block, headerSize, allocation.Length);
+        WriteUInt16(block, mapOffset, 1);
+        WriteUInt16(block, mapOffset + 4, headerSize);
+        WriteUInt16(block, mapOffset + 6, headerSize + allocation.Length);
+        return block;
+    }
+
+    private static byte[] CreateHeapPageWithAllocations(
+        int allocationCount, int targetIndex, byte[] target) {
+        const int headerSize = 12;
+        int dataLength = allocationCount - 1 + target.Length;
+        int mapOffset = (headerSize + dataLength + 1) & ~1;
+        var block = new byte[mapOffset + 4 + (allocationCount + 1) * 2];
+        WriteUInt16(block, 0, mapOffset);
+        block[2] = 0xEC;
+        block[3] = 0xBC;
+        int cursor = headerSize;
+        WriteUInt16(block, mapOffset, allocationCount);
+        for (int index = 0; index < allocationCount; index++) {
+            WriteUInt16(block, mapOffset + 4 + index * 2, cursor);
+            if (index == targetIndex) {
+                Buffer.BlockCopy(target, 0, block, cursor, target.Length);
+                cursor += target.Length;
+            } else {
+                block[cursor++] = 0xCC;
+            }
+        }
+        WriteUInt16(block, mapOffset + 4 + allocationCount * 2, cursor);
+        return block;
+    }
+
+    private static void WriteUInt16(byte[] bytes, int offset, int value) {
+        bytes[offset] = (byte)value;
+        bytes[offset + 1] = (byte)(value >> 8);
+    }
+}

--- a/OfficeIMO.Email.Store.Tests/Pst/PstPropertyContextReaderTests.cs
+++ b/OfficeIMO.Email.Store.Tests/Pst/PstPropertyContextReaderTests.cs
@@ -1,0 +1,73 @@
+using OfficeIMO.Email;
+
+namespace OfficeIMO.Email.Store.Tests;
+
+public sealed class PstPropertyContextReaderTests {
+    [Fact]
+    public void DecodesVariableMultiValuedProperties() {
+        byte[] unicode = CreateVariableValues(
+            Encoding.Unicode.GetBytes("alpha\0"),
+            Encoding.Unicode.GetBytes("beta\0"));
+        byte[] binary = CreateVariableValues(
+            new byte[] { 1, 2, 3 },
+            Array.Empty<byte>(),
+            new byte[] { 4, 5 });
+
+        Assert.Equal(new[] { "alpha", "beta" },
+            Assert.IsType<string[]>(PstPropertyContextReader.DecodeVariable(
+                MapiPropertyType.MultipleUnicode, unicode)));
+        byte[][] values = Assert.IsType<byte[][]>(PstPropertyContextReader.DecodeVariable(
+            MapiPropertyType.MultipleBinary, binary));
+        Assert.Equal(3, values.Length);
+        Assert.Equal(new byte[] { 1, 2, 3 }, values[0]);
+        Assert.Empty(values[1]);
+        Assert.Equal(new byte[] { 4, 5 }, values[2]);
+    }
+
+    [Fact]
+    public void DecodesEveryFixedMultiValuedPropertyFamily() {
+        var guid1 = new Guid("8e14d68e-2598-43ec-9bf9-135d878b78d7");
+        var guid2 = new Guid("c4e255f8-e880-43fc-b26c-b35540fa07dc");
+        var guidBytes = guid1.ToByteArray().Concat(guid2.ToByteArray()).ToArray();
+        var doubles = new[] { 1.25, -8.5 };
+        byte[] doubleBytes = doubles.SelectMany(BitConverter.GetBytes).ToArray();
+        var singles = new[] { 2.5f, -3.75f };
+        byte[] singleBytes = singles.SelectMany(BitConverter.GetBytes).ToArray();
+
+        Assert.Equal(singles, Assert.IsType<float[]>(PstPropertyContextReader.DecodeVariable(
+            MapiPropertyType.MultipleFloating32, singleBytes)));
+        Assert.Equal(doubles, Assert.IsType<double[]>(PstPropertyContextReader.DecodeVariable(
+            MapiPropertyType.MultipleFloating64, doubleBytes)));
+        Assert.Equal(new[] { guid1, guid2 }, Assert.IsType<Guid[]>(PstPropertyContextReader.DecodeVariable(
+            MapiPropertyType.MultipleGuid, guidBytes)));
+    }
+
+    [Fact]
+    public void RejectsMalformedMultiValuedPropertyLayouts() {
+        Assert.Throws<InvalidDataException>(() => PstPropertyContextReader.DecodeVariable(
+            MapiPropertyType.MultipleInteger32, new byte[] { 1, 2, 3 }));
+        Assert.Throws<InvalidDataException>(() => PstPropertyContextReader.DecodeVariable(
+            MapiPropertyType.MultipleUnicode,
+            new byte[] { 1, 0, 0, 0, 3, 0, 0, 0 }));
+    }
+
+    private static byte[] CreateVariableValues(params byte[][] values) {
+        int headerLength = checked(4 + values.Length * 4);
+        var result = new byte[checked(headerLength + values.Sum(value => value.Length))];
+        WriteUInt32(result, 0, (uint)values.Length);
+        int cursor = headerLength;
+        for (int index = 0; index < values.Length; index++) {
+            WriteUInt32(result, 4 + index * 4, (uint)cursor);
+            Buffer.BlockCopy(values[index], 0, result, cursor, values[index].Length);
+            cursor += values[index].Length;
+        }
+        return result;
+    }
+
+    private static void WriteUInt32(byte[] bytes, int offset, uint value) {
+        bytes[offset] = (byte)value;
+        bytes[offset + 1] = (byte)(value >> 8);
+        bytes[offset + 2] = (byte)(value >> 16);
+        bytes[offset + 3] = (byte)(value >> 24);
+    }
+}

--- a/OfficeIMO.Email.Store.Tests/Pst/PstWriterTableTests.cs
+++ b/OfficeIMO.Email.Store.Tests/Pst/PstWriterTableTests.cs
@@ -1,0 +1,54 @@
+using OfficeIMO.Email;
+using System.Globalization;
+using System.Threading;
+
+namespace OfficeIMO.Email.Store.Tests;
+
+public sealed class PstWriterTableTests {
+    [Fact]
+    public void Multi_block_heap_and_row_index_round_trip_more_than_one_thousand_rows() {
+        string path = Path.Combine(Path.GetTempPath(),
+            string.Concat("officeimo-pst-table-", Guid.NewGuid().ToString("N"), ".pst"));
+        try {
+            var rows = Enumerable.Range(0, 1_500).Select(index =>
+                new PstWriterTableRow(checked((uint)(0x2004 + index * 0x20)), new[] {
+                    new MapiProperty(0x0037, MapiPropertyType.Unicode,
+                        string.Concat("Subject ", index.ToString(CultureInfo.InvariantCulture)))
+                })).ToArray();
+            using (var writer = new PstWriterFile(path)) {
+                PstWriterContextResult table = PstTableContextWriter.Write(writer,
+                    rows, 65001,
+                    new[] { new MapiProperty(0x0037, MapiPropertyType.Unicode) },
+                    null, "large-table");
+                var nodes = new[] { new PstWriterNode(0x60E, 0, table.DataBid, table.SubnodeBid) };
+                PstWriterTreeRoot nbt = writer.WriteNodeTree(nodes);
+                PstWriterTreeRoot bbt = writer.WriteBlockTree();
+                writer.FinalizeFile(nbt, bbt, nodes);
+            }
+
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            PstHeader header = PstHeader.Read(stream, EmailStoreFormat.Pst);
+            var ndb = new PstNdbReader(stream, header, EmailStoreReaderOptions.Default,
+                CancellationToken.None);
+            ndb.LoadIndexes();
+            PstNodeReference node = ndb.Nodes[0x60E];
+            PstDataTree data = ndb.ReadDataTree(node.DataBid,
+                64 * 1024 * 1024, CancellationToken.None);
+            IReadOnlyDictionary<uint, PstSubnodeReference> subnodes =
+                ndb.ReadSubnodes(node.SubnodeBid, CancellationToken.None);
+            var heap = new PstHeap(data, subnodes, ndb,
+                EmailStoreReaderOptions.Default, CancellationToken.None);
+            IReadOnlyList<IReadOnlyList<MapiProperty>> decoded =
+                new PstTableContextReader(heap, true,
+                    EmailStoreReaderOptions.Default, CancellationToken.None).ReadRows();
+
+            Assert.Equal(rows.Length, decoded.Count);
+            Assert.Equal("Subject 1499", decoded[1499]
+                .Single(item => item.PropertyId == 0x0037).Value);
+        } finally {
+            try { if (File.Exists(path)) File.Delete(path); }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+    }
+}

--- a/OfficeIMO.Email.Store.Tests/Pst/PstWriterTests.cs
+++ b/OfficeIMO.Email.Store.Tests/Pst/PstWriterTests.cs
@@ -1,0 +1,238 @@
+using OfficeIMO.Email;
+
+namespace OfficeIMO.Email.Store.Tests;
+
+public sealed class PstWriterTests {
+    [Fact]
+    public void Empty_unicode_pst_reopens_with_mandatory_store_and_folder_structure() {
+        string path = TemporaryPstPath();
+        try {
+            EmailStorePstWriteReport report;
+            using (EmailStorePstWriter writer = EmailStorePstWriter.Create(path,
+                new EmailStorePstWriterOptions("Synthetic Store"))) {
+                report = writer.Complete();
+            }
+
+            Assert.True(File.Exists(path));
+            Assert.True(report.BytesWritten >= 0x4800);
+            Assert.Equal(0, report.ItemCount);
+            AssertMaterializedNameToIdStreams(path);
+            using EmailStoreSession session = EmailStoreSession.Open(path);
+            Assert.Equal(EmailStoreFormat.Pst, session.Format);
+            Assert.Equal("Synthetic Store", session.DisplayName);
+            Assert.Contains(session.Folders, item => item.Name == "Top of Personal Folders");
+            Assert.Contains(session.Folders, item => item.Name == "Deleted Items");
+            Assert.Empty(session.EnumerateItems());
+            Assert.DoesNotContain(session.Diagnostics,
+                item => item.Severity == EmailStoreDiagnosticSeverity.Error);
+            EmailStoreValidationReport validation = session.Validate(
+                new EmailStoreValidationOptions(
+                    mode: EmailStoreValidationMode.Shallow,
+                    verifyStructuralIntegrity: true,
+                    maxStructuralPages: 10_000,
+                    maxStructuralBlocks: 10_000,
+                    maxStructuralBytes: 128 * 1024 * 1024));
+            Assert.True(validation.StructuralFailures == 0,
+                string.Join(" | ", validation.Diagnostics.Select(item => item.Code + ":" + item.Message)));
+        } finally {
+            TryDelete(path);
+        }
+    }
+
+    [Fact]
+    public void Unmapped_named_property_is_preserved_under_a_diagnostic_placeholder_mapping() {
+        string path = TemporaryPstPath();
+        try {
+            var document = new EmailDocument { Subject = "Unknown named property" };
+            document.MapiProperties.Add(new MapiProperty(0x8000,
+                MapiPropertyType.Unicode, "preserved-value"));
+            EmailStorePstWriteReport report;
+            using (EmailStorePstWriter writer = EmailStorePstWriter.Create(path)) {
+                string folder = writer.AddFolder("Mailbox");
+                writer.AddItem(folder, document);
+                report = writer.Complete();
+            }
+
+            Assert.Contains(report.Diagnostics, diagnostic =>
+                diagnostic.Code == "EMAIL_STORE_PST_WRITE_NAMED_PROPERTY_PLACEHOLDER" &&
+                diagnostic.Severity == EmailStoreDiagnosticSeverity.Warning);
+            using EmailStoreSession session = EmailStoreSession.Open(path);
+            EmailStoreItem item = session.ReadItem(Assert.Single(session.EnumerateItems()));
+            MapiProperty property = Assert.Single(item.Document.MapiProperties,
+                candidate => candidate.Name?.PropertySet ==
+                    new Guid("E962B602-9F1E-4F76-BC29-4795CD1752F7") &&
+                    candidate.Name.LocalId == 0x8000);
+            Assert.Equal("preserved-value", property.Value);
+        } finally {
+            TryDelete(path);
+        }
+    }
+
+    [Fact]
+    public void Message_recipient_attachment_named_and_multi_value_properties_round_trip() {
+        string path = TemporaryPstPath();
+        try {
+            var document = new EmailDocument {
+                Subject = "Round-trip subject",
+                MessageClass = "IPM.Note",
+                From = new EmailAddress("sender@example.test", "Sender"),
+                Date = new DateTimeOffset(2025, 1, 2, 3, 4, 5, TimeSpan.Zero)
+            };
+            document.Body.Text = "Plain body";
+            document.Body.Html = "<p>HTML body</p>";
+            document.Recipients.Add(new EmailRecipient(EmailRecipientKind.To,
+                new EmailAddress("recipient@example.test", "Recipient")));
+            document.Attachments.Add(new EmailAttachment {
+                FileName = "payload.bin",
+                ContentType = "application/octet-stream",
+                Content = new byte[] { 1, 2, 3, 4, 5 },
+                Length = 5
+            });
+            var named = new MapiNamedProperty(
+                new Guid("00020329-0000-0000-C000-000000000046"), "OfficeIMO-Test");
+            document.MapiProperties.Add(new MapiProperty(0x8000,
+                MapiPropertyType.Unicode, "named-value", name: named));
+            document.MapiProperties.Add(new MapiProperty(0x7001,
+                MapiPropertyType.MultipleUnicode, new[] { "one", "two" }));
+
+            string folderId;
+            using (EmailStorePstWriter writer = EmailStorePstWriter.Create(path)) {
+                folderId = writer.AddFolder("Inbox", containerClass: "IPF.Note");
+                writer.AddItem(folderId, document);
+                writer.Complete();
+            }
+
+            using EmailStoreSession session = EmailStoreSession.Open(path);
+            EmailStoreFolderInfo folder = Assert.Single(session.Folders, item => item.Name == "Inbox");
+            EmailStoreItemReference reference = Assert.Single(session.EnumerateItems(
+                new EmailStoreEnumerationOptions(folderId: folder.Id)));
+            EmailStoreItem item = session.ReadItem(reference);
+            Assert.Equal(document.Subject, item.Document.Subject);
+            Assert.Equal(document.Body.Text, item.Document.Body.Text);
+            Assert.Equal(document.Body.Html, item.Document.Body.Html);
+            Assert.Equal("recipient@example.test", Assert.Single(item.Document.Recipients).Address.Address);
+            EmailAttachment attachment = Assert.Single(item.Document.Attachments);
+            Assert.Equal("payload.bin", attachment.FileName);
+            Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, attachment.Content);
+            MapiProperty mapped = Assert.Single(item.Document.MapiProperties,
+                property => property.Name?.Name == "OfficeIMO-Test");
+            Assert.Equal("named-value", mapped.Value);
+            Assert.Equal(new[] { "one", "two" }, Assert.IsType<string[]>(
+                Assert.Single(item.Document.MapiProperties,
+                    property => property.PropertyId == 0x7001).Value));
+            Assert.DoesNotContain(session.Diagnostics,
+                diagnostic => diagnostic.Severity == EmailStoreDiagnosticSeverity.Error);
+        } finally {
+            TryDelete(path);
+        }
+    }
+
+    [Fact]
+    public void Ost_session_converts_to_a_different_new_pst_without_mutating_source() {
+        byte[] sourceBytes = PstTestFileBuilder.Create(ost: true,
+            attachmentContent: new byte[] { 9, 8, 7 });
+        using var source = new MemoryStream(sourceBytes, writable: false);
+        string path = TemporaryPstPath();
+        try {
+            using (EmailStoreSession sourceSession = EmailStoreSession.Open(
+                source, "mailbox.ost", leaveOpen: true)) {
+                EmailStorePstConversionReport report = sourceSession.ExportToPst(path);
+                Assert.Equal(EmailStoreFormat.Ost, report.SourceFormat);
+                Assert.Equal(1, report.ConvertedItems);
+                Assert.Equal(0, report.SkippedItems);
+            }
+            Assert.Equal(sourceBytes, source.ToArray());
+
+            using EmailStoreSession converted = EmailStoreSession.Open(path);
+            EmailStoreItemReference reference = Assert.Single(converted.EnumerateItems());
+            EmailStoreItem item = converted.ReadItem(reference);
+            Assert.Equal("Synthetic PST message", item.Document.Subject);
+            Assert.Equal(new byte[] { 9, 8, 7 }, Assert.Single(item.Document.Attachments).Content);
+        } finally {
+            TryDelete(path);
+        }
+    }
+
+    [Fact]
+    public void Large_data_tree_rtf_embedded_message_and_associated_item_round_trip() {
+        string path = TemporaryPstPath();
+        try {
+            byte[] payload = Enumerable.Range(0, 100_000)
+                .Select(index => unchecked((byte)index)).ToArray();
+            var embedded = new EmailDocument {
+                Subject = "Embedded subject",
+                MessageClass = "IPM.Note"
+            };
+            embedded.Body.Text = "Embedded body";
+            var document = new EmailDocument {
+                Subject = "Parent subject",
+                MessageClass = "IPM.Note"
+            };
+            document.Body.Rtf = "{\\rtf1\\ansi Parent RTF body}";
+            document.Attachments.Add(new EmailAttachment {
+                FileName = "large.bin",
+                Content = payload,
+                Length = payload.Length
+            });
+            document.Attachments.Add(new EmailAttachment {
+                FileName = "embedded.msg",
+                EmbeddedDocument = embedded,
+                MapiAttachMethod = 5
+            });
+
+            string folderId;
+            using (EmailStorePstWriter writer = EmailStorePstWriter.Create(path)) {
+                folderId = writer.AddFolder("Mailbox");
+                writer.AddItem(folderId, document);
+                writer.AddItem(folderId, new EmailDocument {
+                    Subject = "Associated configuration",
+                    MessageClass = "IPM.Configuration.Test"
+                }, isAssociated: true);
+                writer.Complete();
+            }
+
+            using EmailStoreSession session = EmailStoreSession.Open(path);
+            EmailStoreFolderInfo folder = Assert.Single(session.Folders, item => item.Name == "Mailbox");
+            EmailStoreItemReference visible = Assert.Single(session.EnumerateItems(
+                new EmailStoreEnumerationOptions(folderId: folder.Id)));
+            EmailStoreItem item = session.ReadItem(visible);
+            Assert.Equal(document.Body.Rtf, item.Document.Body.Rtf);
+            Assert.Equal(payload, item.Document.Attachments.Single(
+                attachment => attachment.FileName == "large.bin").Content);
+            Assert.Equal("Embedded subject", item.Document.Attachments.Single(
+                attachment => attachment.FileName == "embedded.msg").EmbeddedDocument?.Subject);
+            EmailStoreItemReference[] all = session.EnumerateItems(
+                new EmailStoreEnumerationOptions(folderId: folder.Id,
+                    includeAssociatedItems: true)).ToArray();
+            Assert.Equal(2, all.Length);
+            Assert.Single(all, reference => reference.IsAssociated);
+        } finally {
+            TryDelete(path);
+        }
+    }
+
+    private static string TemporaryPstPath() => Path.Combine(Path.GetTempPath(),
+        string.Concat("officeimo-email-store-", Guid.NewGuid().ToString("N"), ".pst"));
+
+    private static void AssertMaterializedNameToIdStreams(string path) {
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        PstHeader header = PstHeader.Read(stream, EmailStoreFormat.Pst);
+        var ndb = new PstNdbReader(stream, header, EmailStoreReaderOptions.Default, default);
+        Assert.True(ndb.TryGetNode(0x61, out PstNodeReference? node));
+        Assert.NotNull(node);
+        var heap = new PstHeap(ndb.OpenDataTree(node!.DataBid, 16 * 1024 * 1024),
+            ndb.ReadSubnodes(node.SubnodeBid), ndb, EmailStoreReaderOptions.Default, default);
+        MapiProperty[] properties = new PstPropertyContextReader(heap,
+            EmailStoreReaderOptions.Default, default).ReadProperties().ToArray();
+        foreach (ushort propertyId in new ushort[] { 0x0002, 0x0003, 0x0004 }) {
+            Assert.NotEmpty(Assert.IsType<byte[]>(Assert.Single(properties,
+                property => property.PropertyId == propertyId).Value));
+        }
+    }
+
+    private static void TryDelete(string path) {
+        try { if (File.Exists(path)) File.Delete(path); }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+}

--- a/OfficeIMO.Email.Store/ARCHITECTURE.md
+++ b/OfficeIMO.Email.Store/ARCHITECTURE.md
@@ -52,10 +52,10 @@ Mailbox-directory sessions index bounded file metadata and open only selected EM
 skipped. OLM is bounded but currently materialized during open because one XML archive entry can contain multiple
 logical items; making OLM item payloads lazy would require a durable XML item-location index.
 
-## OST to PST decision
+## Managed PST writer and conversion
 
-OST-to-PST output is feasible, but it is a separate major writer project. It is not safe to copy an OST and change
-its client signature. A valid PST creator must implement and validate all three format layers:
+OST-to-PST conversion never copies a store and changes its client signature. `EmailStorePstWriter` creates a new
+Unicode PST through three internal layers:
 
 1. NDB: Unicode header state and checksums, allocation maps, BBT/NBT construction, block/page allocation, BID/NID
    counters, data trees, subnode trees, and an atomic commit strategy.
@@ -64,25 +64,34 @@ its client signature. A valid PST creator must implement and validate all three 
 3. Messaging: mandatory store/folder/message properties, hierarchy and contents tables, recipients, attachments,
    embedded messages, named-property maps, search/deleted folders, and entry identifiers.
 
-Microsoft's current PST specification explicitly describes the format as a read/write contract and defines minimum
-objects required for a mountable file. It also requires allocation metadata and header state to be maintained. See
+Microsoft's PST specification describes the format as a read/write contract and defines the minimum objects
+required for a mountable file. It also requires allocation metadata and header state to be maintained. See
 the official [MS-PST overview](https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-pst/141923d5-15ab-4ef1-a524-6dce75aae546),
 [NDB layer requirements](https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-pst/9d2083cf-fd37-4a0d-b61a-d2ef10a89a04),
 [LTP layer](https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-pst/77007716-7993-44fe-9b40-9526157cfc6d),
 and [minimum object requirements](https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-pst/7af54176-5108-4ac7-973f-8252ad223acb).
 
-A future writer should be append-oriented and Unicode-only, write to a new destination, never mutate the OST, and
-remain internal until it passes:
+The public writer is incremental at the item boundary and new-file-only. It allocates data blocks, subnode trees,
+BBT/NBT pages, allocation maps, property contexts, table contexts, and the mandatory store and folder objects,
+then commits a same-directory temporary file. `EmailStoreSession.ExportToPst` remains a thin orchestration surface:
+it enumerates the source, maps its folder tree, streams selected attachments, and reports source items that cannot
+be represented. All message and typed-item property projection stays in `OfficeIMO.Email` and is shared with MSG.
 
-- reopen and deep-validation tests through an independent read path;
-- Outlook mount/import interoperability on supported Windows test hosts;
-- named-property, typed-item, recipient, attachment, and embedded-message round trips;
-- corruption/fault-injection tests around allocation and commit boundaries;
-- multi-gigabyte and multi-million-item stress tests with bounded memory;
-- conversion manifests that distinguish preserved, normalized, omitted, and server-only data.
+Current validation covers:
 
-Until those gates exist, supported migration outputs are EML/MSG/OFT/TNEF directories and streaming mbox. MSG is
-the closest current first-party output when retaining Outlook/MAPI item semantics matters.
+- reopen and structural CRC/signature validation through the OfficeIMO reader;
+- multi-block heaps, multi-leaf table indexes, large attachment data trees, embedded messages, associated items,
+  recipients, named properties, and fixed and variable multi-valued properties;
+- synthetic OST-to-new-PST conversion with a byte-for-byte unchanged source;
+- independent libpff open and synthetic message export;
+- an opt-in classic Outlook mount/read/remove test for Windows interoperability hosts;
+- an opt-in private-corpus lane that reports only aggregate structure and diagnostic counts.
+
+This is a projection conversion, not an Exchange recovery service. Search results are materialized as static
+folders; a source Name-to-ID entry that is unavailable receives a diagnostic placeholder mapping; and attachment
+or OST content absent from the local source is reported rather than fabricated. The writer does not append to,
+repair, compact, password-protect, encrypt, or otherwise mutate existing PST/OST files. ANSI PST and OST output are
+also outside the current contract.
 
 ## Source and output safety
 

--- a/OfficeIMO.Email.Store/OfficeIMO.Email.Store.csproj
+++ b/OfficeIMO.Email.Store/OfficeIMO.Email.Store.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Fully managed, large-store PST, OST, OLM, and EMLX access for OfficeIMO.Email items with no third-party store parser.</Description>
+    <Description>Fully managed PST, OST, OLM, and EMLX access plus Unicode PST creation and safe store-to-PST conversion for OfficeIMO.Email items, with no third-party store parser.</Description>
     <AssemblyName>OfficeIMO.Email.Store</AssemblyName>
     <AssemblyTitle>OfficeIMO.Email.Store</AssemblyTitle>
     <VersionPrefix>2.0.1</VersionPrefix>
@@ -11,7 +11,7 @@
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>
     <PackageId>OfficeIMO.Email.Store</PackageId>
-    <PackageTags>email;store;pst;ost;olm;emlx;outlook;apple-mail;maildir;reader;managed</PackageTags>
+    <PackageTags>email;store;pst;ost;olm;emlx;outlook;apple-mail;maildir;reader;writer;converter;managed</PackageTags>
     <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/EvotecIT/OfficeIMO</RepositoryUrl>

--- a/OfficeIMO.Email.Store/Pst/PstBinary.cs
+++ b/OfficeIMO.Email.Store/Pst/PstBinary.cs
@@ -24,6 +24,25 @@ internal static class PstBinary {
 
     internal static long Int64(byte[] bytes, int offset) => unchecked((long)UInt64(bytes, offset));
 
+    internal static void WriteUInt16(byte[] bytes, int offset, int value) {
+        EnsureWrite(bytes, offset, 2);
+        bytes[offset] = (byte)value;
+        bytes[offset + 1] = (byte)(value >> 8);
+    }
+
+    internal static void WriteUInt32(byte[] bytes, int offset, uint value) {
+        EnsureWrite(bytes, offset, 4);
+        bytes[offset] = (byte)value;
+        bytes[offset + 1] = (byte)(value >> 8);
+        bytes[offset + 2] = (byte)(value >> 16);
+        bytes[offset + 3] = (byte)(value >> 24);
+    }
+
+    internal static void WriteUInt64(byte[] bytes, int offset, ulong value) {
+        WriteUInt32(bytes, offset, (uint)value);
+        WriteUInt32(bytes, offset + 4, (uint)(value >> 32));
+    }
+
     internal static byte[] ReadAt(Stream stream, long offset, int count) {
         if (offset < 0 || count < 0 || offset > stream.Length - count) {
             throw new InvalidDataException("A PST structure points outside the source stream.");
@@ -42,6 +61,13 @@ internal static class PstBinary {
     internal static void Ensure(byte[] bytes, int offset, int count) {
         if (offset < 0 || count < 0 || offset > bytes.Length - count) {
             throw new InvalidDataException("A PST structure is truncated.");
+        }
+    }
+
+    private static void EnsureWrite(byte[] bytes, int offset, int count) {
+        if (bytes == null) throw new ArgumentNullException(nameof(bytes));
+        if (offset < 0 || count < 0 || offset > bytes.Length - count) {
+            throw new ArgumentOutOfRangeException(nameof(offset));
         }
     }
 

--- a/OfficeIMO.Email.Store/Pst/PstHeap.cs
+++ b/OfficeIMO.Email.Store/Pst/PstHeap.cs
@@ -30,20 +30,39 @@ internal sealed class PstHeap {
     internal byte[] GetAllocation(uint hid) {
         _cancellationToken.ThrowIfCancellationRequested();
         if (hid == 0) return Array.Empty<byte>();
-        if ((hid & 0x1F) != 0) throw new InvalidDataException("A heap allocation identifier has an invalid type.");
+        if ((hid & 0x1F) != 0) {
+            throw new InvalidDataException(string.Concat(
+                "Heap allocation identifier 0x", hid.ToString("X8", CultureInfo.InvariantCulture),
+                " has non-HID type 0x", (hid & 0x1F).ToString("X2", CultureInfo.InvariantCulture), "."));
+        }
 
-        int blockIndex = checked((int)(hid >> 16));
-        int allocationIndex = checked((int)((hid >> 5) & 0x7FF)) - 1;
-        if (blockIndex < 0 || allocationIndex < 0) {
+        int allocationIndexBits = _ndb.HeapAllocationIndexBits;
+        uint allocationIndexMask = (1U << allocationIndexBits) - 1U;
+        int allocationIndex = checked((int)((hid >> 5) & allocationIndexMask)) - 1;
+        int blockIndex = checked((int)(hid >> (5 + allocationIndexBits)));
+        if (allocationIndex < 0) {
             throw new InvalidDataException("A heap allocation identifier is out of range.");
         }
 
-        byte[] block = _dataTree.GetBlock(blockIndex);
+        byte[] block;
+        try {
+            block = _dataTree.GetBlock(blockIndex);
+        } catch (InvalidDataException exception) {
+            throw new InvalidDataException(string.Concat(
+                "Heap allocation identifier 0x", hid.ToString("X8", CultureInfo.InvariantCulture),
+                " references an unavailable HN data block."), exception);
+        }
         int mapOffset = PstBinary.UInt16(block, 0);
         PstBinary.Ensure(block, mapOffset, 4);
         int allocationCount = PstBinary.UInt16(block, mapOffset);
         if (allocationIndex >= allocationCount) {
-            throw new InvalidDataException("A heap allocation index is out of range.");
+            throw new InvalidDataException(string.Concat(
+                "Heap allocation identifier 0x", hid.ToString("X8", CultureInfo.InvariantCulture),
+                " requests allocation ", (allocationIndex + 1).ToString(CultureInfo.InvariantCulture),
+                " from a page containing ", allocationCount.ToString(CultureInfo.InvariantCulture),
+                " allocations (block-bytes=", block.Length.ToString(CultureInfo.InvariantCulture),
+                ", map-offset=", mapOffset.ToString(CultureInfo.InvariantCulture),
+                ")."));
         }
         int offsetsStart = mapOffset + 4;
         PstBinary.Ensure(block, offsetsStart, checked((allocationCount + 1) * 2));
@@ -101,21 +120,36 @@ internal sealed class PstHeap {
         int indexLevels) {
         var visited = new HashSet<uint>();
         foreach (byte[] record in EnumerateBthLeafRecordsCore(rootHid, keySize, valueSize,
-            indexLevels, 0, visited)) yield return record;
+            indexLevels, 0, visited, parentHid: 0, parentRecordIndex: -1)) yield return record;
     }
 
     private IEnumerable<byte[]> EnumerateBthLeafRecordsCore(uint hid, int keySize, int valueSize,
-        int remainingIndexLevels, int depth, HashSet<uint> visited) {
+        int remainingIndexLevels, int depth, HashSet<uint> visited,
+        uint parentHid, int parentRecordIndex) {
         _cancellationToken.ThrowIfCancellationRequested();
         if (depth > _options.MaxBTreeDepth) {
             throw new EmailStoreLimitExceededException(nameof(EmailStoreReaderOptions.MaxBTreeDepth),
                 depth, _options.MaxBTreeDepth);
         }
         if (!visited.Add(hid)) throw new InvalidDataException("The PST BTree-on-Heap contains a cycle.");
-        byte[] allocation = GetAllocation(hid);
+        byte[] allocation;
+        try {
+            allocation = GetAllocation(hid);
+        } catch (InvalidDataException exception) when (parentRecordIndex >= 0) {
+            throw new InvalidDataException(string.Concat(
+                "BTree-on-Heap allocation 0x", parentHid.ToString("X8", CultureInfo.InvariantCulture),
+                " record ", parentRecordIndex.ToString(CultureInfo.InvariantCulture),
+                " references invalid child 0x", hid.ToString("X8", CultureInfo.InvariantCulture),
+                ": ", exception.Message), exception);
+        }
         int recordSize = keySize + (remainingIndexLevels > 0 ? 4 : valueSize);
         if (recordSize <= 0 || allocation.Length % recordSize != 0) {
-            throw new InvalidDataException("A PST BTree-on-Heap allocation has an invalid record layout.");
+            throw new InvalidDataException(string.Concat(
+                "BTree-on-Heap allocation 0x", hid.ToString("X8", CultureInfo.InvariantCulture),
+                " has ", allocation.Length.ToString(CultureInfo.InvariantCulture),
+                " bytes, which is not divisible by its ",
+                recordSize.ToString(CultureInfo.InvariantCulture), "-byte record size at index level ",
+                remainingIndexLevels.ToString(CultureInfo.InvariantCulture), "."));
         }
         int count = allocation.Length / recordSize;
         for (int index = 0; index < count; index++) {
@@ -123,7 +157,7 @@ internal sealed class PstHeap {
             if (remainingIndexLevels > 0) {
                 uint child = PstBinary.UInt32(allocation, offset + keySize);
                 foreach (byte[] record in EnumerateBthLeafRecordsCore(child, keySize, valueSize,
-                    remainingIndexLevels - 1, depth + 1, visited)) yield return record;
+                    remainingIndexLevels - 1, depth + 1, visited, hid, index)) yield return record;
             } else {
                 var record = new byte[recordSize];
                 Buffer.BlockCopy(allocation, offset, record, 0, recordSize);

--- a/OfficeIMO.Email.Store/Pst/PstNdbReader.cs
+++ b/OfficeIMO.Email.Store/Pst/PstNdbReader.cs
@@ -24,6 +24,7 @@ internal sealed partial class PstNdbReader {
         : throw new InvalidOperationException("The complete PST indexes have not been loaded.");
 
     internal bool IsUnicode => _header.IsUnicode;
+    internal int HeapAllocationIndexBits => _header.Variant == PstVariant.Unicode4K ? 14 : 11;
 
     /// <summary>Loads complete BBT and NBT dictionaries for the legacy materializing reader.</summary>
     internal void LoadIndexes() {

--- a/OfficeIMO.Email.Store/Pst/PstNdbStructures.cs
+++ b/OfficeIMO.Email.Store/Pst/PstNdbStructures.cs
@@ -80,8 +80,8 @@ internal sealed class PstDataTree {
         EnsureCursor();
         while (_cursorIndex < index && _cursor!.MoveNext()) {
             _cursorIndex++;
-            AddCached(_cursorIndex,
-                _cursor.Current ?? throw new InvalidDataException("A PST data-tree block was null."));
+            AddCached(_cursorIndex, _cursor.Current ??
+                throw new InvalidDataException("A PST data-tree block was null."));
         }
         if (_cache.TryGetValue(index, out cached)) return cached.Value.Bytes;
         throw new InvalidDataException("A PST data-tree block index is out of range.");
@@ -115,6 +115,9 @@ internal sealed class PstDataTree {
     }
 
     private void AddCached(int index, byte[] bytes) {
+        if (_cache.TryGetValue(index, out LinkedListNode<CachedBlock>? existing)) {
+            _lru.Remove(existing);
+        }
         var entry = new CachedBlock(index, bytes);
         LinkedListNode<CachedBlock> node = _lru.AddFirst(entry);
         _cache[index] = node;

--- a/OfficeIMO.Email.Store/Pst/PstPropertyContextReader.cs
+++ b/OfficeIMO.Email.Store/Pst/PstPropertyContextReader.cs
@@ -48,8 +48,20 @@ internal sealed class PstPropertyContextReader {
                 var type = (MapiPropertyType)PstBinary.UInt16(record, 2);
                 uint rawValue = PstBinary.UInt32(record, 4);
                 if (deferredPropertyIds != null && deferredPropertyIds.Contains(id)) {
-                    if (sourceHnids != null) sourceHnids[id] = rawValue;
-                    properties.Add(new MapiProperty(id, type, null));
+                    uint sourceHnid = rawValue;
+                    byte[]? deferredRawData = null;
+                    if (type == MapiPropertyType.Object && rawValue != 0 &&
+                        (rawValue & 0x1F) == 0) {
+                        // PtypObject stores an eight-byte (NID, size) descriptor in
+                        // the heap. Resolving only that descriptor keeps the actual
+                        // embedded object deferred while exposing its subnode NID.
+                        deferredRawData = _heap.ResolveHnid(rawValue, 8);
+                        if (deferredRawData.Length >= 8) {
+                            sourceHnid = PstBinary.UInt32(deferredRawData, 0);
+                        }
+                    }
+                    if (sourceHnids != null) sourceHnids[id] = sourceHnid;
+                    properties.Add(new MapiProperty(id, type, null) { RawData = deferredRawData });
                     continue;
                 }
                 MapiProperty property = DecodeProperty(
@@ -62,6 +74,10 @@ internal sealed class PstPropertyContextReader {
         foreach (MapiProperty property in properties) {
             if (property.PropertyType == MapiPropertyType.String8 && property.RawData != null) {
                 property.Value = DecodeString8(property.RawData, codePage);
+            } else if (property.PropertyType == MapiPropertyType.MultipleString8 && property.RawData != null) {
+                property.Value = DecodeVariableElements(property.RawData)
+                    .Select(value => DecodeString8(value, codePage))
+                    .ToArray();
             }
         }
         return properties;
@@ -90,13 +106,22 @@ internal sealed class PstPropertyContextReader {
                 value = (rawValue & 0xFF) != 0;
                 break;
             default:
-                if (sourceHnids != null) sourceHnids[id] = rawValue;
                 rawData = _heap.ResolveHnid(rawValue, maximumDecodedBytes);
                 decodedBytes = checked(decodedBytes + rawData.Length);
                 if (decodedBytes > maximumDecodedBytes) {
                     throw new EmailStoreLimitExceededException(
                         nameof(EmailStoreItemReadOptions.MaxDecodedPropertyBytes), decodedBytes,
                         maximumDecodedBytes);
+                }
+                if (sourceHnids != null) {
+                    uint sourceHnid = rawValue;
+                    // A PC PtypObject value is an HNID whose allocation contains the
+                    // referenced subnode NID followed by its declared size. Retain the
+                    // historical direct-NID shape for compact third-party fixtures.
+                    if (type == MapiPropertyType.Object && (rawValue & 0x1F) == 0 && rawData.Length >= 8) {
+                        sourceHnid = PstBinary.UInt32(rawData, 0);
+                    }
+                    sourceHnids[id] = sourceHnid;
                 }
                 value = DecodeVariable(type, rawData);
                 break;
@@ -129,30 +154,133 @@ internal sealed class PstPropertyContextReader {
                 return ReadInt16Array(bytes);
             case MapiPropertyType.MultipleInteger32:
                 return ReadInt32Array(bytes);
+            case MapiPropertyType.MultipleFloating32:
+                return ReadSingleArray(bytes);
+            case MapiPropertyType.MultipleFloating64:
+            case MapiPropertyType.MultipleFloatingTime:
+                return ReadDoubleArray(bytes);
+            case MapiPropertyType.MultipleCurrency:
             case MapiPropertyType.MultipleInteger64:
-            case MapiPropertyType.MultipleTime:
                 return ReadInt64Array(bytes);
+            case MapiPropertyType.MultipleTime:
+                return ReadTimeArray(bytes);
+            case MapiPropertyType.MultipleGuid:
+                return ReadGuidArray(bytes);
+            case MapiPropertyType.MultipleUnicode:
+                return DecodeVariableElements(bytes)
+                    .Select(value => Encoding.Unicode.GetString(value).TrimEnd('\0'))
+                    .ToArray();
+            case MapiPropertyType.MultipleString8:
+                return DecodeVariableElements(bytes)
+                    .Select(value => DecodeString8(value, 1252))
+                    .ToArray();
+            case MapiPropertyType.MultipleBinary:
+                return DecodeVariableElements(bytes);
             default:
                 return bytes;
         }
     }
 
     private static short[] ReadInt16Array(byte[] bytes) {
+        EnsurePackedElementSize(bytes, 2);
         var values = new short[bytes.Length / 2];
         for (int index = 0; index < values.Length; index++) values[index] = PstBinary.Int16(bytes, index * 2);
         return values;
     }
 
     private static int[] ReadInt32Array(byte[] bytes) {
+        EnsurePackedElementSize(bytes, 4);
         var values = new int[bytes.Length / 4];
         for (int index = 0; index < values.Length; index++) values[index] = PstBinary.Int32(bytes, index * 4);
         return values;
     }
 
     private static long[] ReadInt64Array(byte[] bytes) {
+        EnsurePackedElementSize(bytes, 8);
         var values = new long[bytes.Length / 8];
         for (int index = 0; index < values.Length; index++) values[index] = PstBinary.Int64(bytes, index * 8);
         return values;
+    }
+
+    private static float[] ReadSingleArray(byte[] bytes) {
+        EnsurePackedElementSize(bytes, 4);
+        var values = new float[bytes.Length / 4];
+        for (int index = 0; index < values.Length; index++) values[index] = BitConverter.ToSingle(bytes, index * 4);
+        return values;
+    }
+
+    private static double[] ReadDoubleArray(byte[] bytes) {
+        EnsurePackedElementSize(bytes, 8);
+        var values = new double[bytes.Length / 8];
+        for (int index = 0; index < values.Length; index++) values[index] = BitConverter.ToDouble(bytes, index * 8);
+        return values;
+    }
+
+    private static DateTimeOffset?[] ReadTimeArray(byte[] bytes) {
+        EnsurePackedElementSize(bytes, 8);
+        var values = new DateTimeOffset?[bytes.Length / 8];
+        for (int index = 0; index < values.Length; index++) {
+            try {
+                values[index] = new DateTimeOffset(DateTime.FromFileTimeUtc(PstBinary.Int64(bytes, index * 8)));
+            } catch (ArgumentOutOfRangeException) {
+                values[index] = null;
+            }
+        }
+        return values;
+    }
+
+    private static Guid[] ReadGuidArray(byte[] bytes) {
+        EnsurePackedElementSize(bytes, 16);
+        var values = new Guid[bytes.Length / 16];
+        for (int index = 0; index < values.Length; index++) {
+            var value = new byte[16];
+            Buffer.BlockCopy(bytes, index * 16, value, 0, value.Length);
+            values[index] = new Guid(value);
+        }
+        return values;
+    }
+
+    private static byte[][] DecodeVariableElements(byte[] bytes) {
+        if (bytes.Length < 4) throw new InvalidDataException("A variable multi-valued PST property is truncated.");
+        uint rawCount = PstBinary.UInt32(bytes, 0);
+        if (rawCount > int.MaxValue) {
+            throw new InvalidDataException("A variable multi-valued PST property declares too many elements.");
+        }
+        int count = (int)rawCount;
+        int dataStart = checked(4 + count * 4);
+        if (dataStart > bytes.Length) {
+            throw new InvalidDataException("A variable multi-valued PST property offset table is truncated.");
+        }
+        var values = new byte[count][];
+        int previous = dataStart;
+        for (int index = 0; index < count; index++) {
+            int start = ReadBoundedOffset(bytes, 4 + index * 4);
+            int end = index + 1 < count
+                ? ReadBoundedOffset(bytes, 4 + (index + 1) * 4)
+                : bytes.Length;
+            if (start < dataStart || start < previous || end < start || end > bytes.Length) {
+                throw new InvalidDataException("A variable multi-valued PST property contains an invalid element offset.");
+            }
+            var value = new byte[end - start];
+            Buffer.BlockCopy(bytes, start, value, 0, value.Length);
+            values[index] = value;
+            previous = start;
+        }
+        return values;
+    }
+
+    private static int ReadBoundedOffset(byte[] bytes, int offset) {
+        uint value = PstBinary.UInt32(bytes, offset);
+        if (value > int.MaxValue) {
+            throw new InvalidDataException("A variable multi-valued PST property offset is out of range.");
+        }
+        return (int)value;
+    }
+
+    private static void EnsurePackedElementSize(byte[] bytes, int elementSize) {
+        if (bytes.Length % elementSize != 0) {
+            throw new InvalidDataException("A fixed multi-valued PST property has a partial trailing element.");
+        }
     }
 
     private static int ResolveCodePage(IEnumerable<MapiProperty> properties) {

--- a/OfficeIMO.Email.Store/Pst/PstStoreReader.Messages.cs
+++ b/OfficeIMO.Email.Store/Pst/PstStoreReader.Messages.cs
@@ -69,7 +69,9 @@ internal sealed partial class PstStoreReader {
             .Where(item => item.Type == 0x12).OrderBy(item => item.Nid)) {
             string recipientLocation = string.Concat(location, "/recipients/", FormatId(recipientTable.Nid));
             try {
-                foreach (EmailRecipient recipient in ReadRecipients(recipientTable)) document.Recipients.Add(recipient);
+                foreach (EmailRecipient recipient in ReadRecipients(recipientTable, recipientLocation)) {
+                    document.Recipients.Add(recipient);
+                }
             } catch (EmailStoreLimitExceededException) {
                 throw;
             } catch (InvalidDataException exception) {
@@ -201,14 +203,15 @@ internal sealed partial class PstStoreReader {
         }
     }
 
-    private IReadOnlyList<EmailRecipient> ReadRecipients(PstSubnodeReference table) {
+    private IReadOnlyList<EmailRecipient> ReadRecipients(PstSubnodeReference table, string location) {
         PstDataTree data = Ndb.ReadDataTree(
             table.DataBid, _options.MaxDecodedPropertyBytesPerItem, _cancellationToken);
         IReadOnlyDictionary<uint, PstSubnodeReference> subnodes =
             Ndb.ReadSubnodes(table.SubnodeBid, _cancellationToken);
         var heap = new PstHeap(data, subnodes, Ndb, _options, _cancellationToken);
         IReadOnlyList<IReadOnlyList<MapiProperty>> rows = new PstTableContextReader(
-            heap, Ndb.IsUnicode, _options, _cancellationToken).ReadRows();
+            heap, Ndb.IsUnicode, _options, _cancellationToken,
+            message => AddTableCellDiagnostic(message, location)).ReadRows();
         var recipients = new List<EmailRecipient>(rows.Count);
         foreach (IReadOnlyList<MapiProperty> row in rows) {
             _namedProperties.Apply(row);

--- a/OfficeIMO.Email.Store/Pst/PstStoreReader.cs
+++ b/OfficeIMO.Email.Store/Pst/PstStoreReader.cs
@@ -348,12 +348,13 @@ internal sealed partial class PstStoreReader {
         IEnumerator<IReadOnlyList<MapiProperty>>? rows = null;
         try {
             PstDataTree data = Ndb.OpenDataTree(
-                dataBid, _options.MaxDecodedPropertyBytesPerItem, _cancellationToken);
+                dataBid, _options.MaxDecodedTableBytes, _cancellationToken);
             IReadOnlyDictionary<uint, PstSubnodeReference> subnodes =
                 Ndb.ReadSubnodes(subnodeBid, _cancellationToken);
             var heap = new PstHeap(data, subnodes, Ndb, _options, _cancellationToken);
             rows = new PstTableContextReader(
-                heap, Ndb.IsUnicode, _options, _cancellationToken).EnumerateRows().GetEnumerator();
+                heap, Ndb.IsUnicode, _options, _cancellationToken,
+                message => AddTableCellDiagnostic(message, location)).EnumerateRows().GetEnumerator();
         } catch (EmailStoreLimitExceededException) {
             throw;
         } catch (Exception exception) when (exception is InvalidDataException || exception is NotSupportedException) {
@@ -391,6 +392,14 @@ internal sealed partial class PstStoreReader {
             "EMAIL_STORE_PST_TABLE_CONTEXT",
             exception.Message,
             EmailStoreDiagnosticSeverity.Error,
+            location));
+    }
+
+    private void AddTableCellDiagnostic(string message, string location) {
+        _diagnostics.Add(new EmailStoreDiagnostic(
+            "EMAIL_STORE_PST_TABLE_CELL",
+            message,
+            EmailStoreDiagnosticSeverity.Warning,
             location));
     }
 

--- a/OfficeIMO.Email.Store/Pst/PstTableContextReader.cs
+++ b/OfficeIMO.Email.Store/Pst/PstTableContextReader.cs
@@ -7,13 +7,15 @@ internal sealed class PstTableContextReader {
     private readonly bool _isUnicode;
     private readonly EmailStoreReaderOptions _options;
     private readonly CancellationToken _cancellationToken;
+    private readonly Action<string>? _reportCellWarning;
 
     internal PstTableContextReader(PstHeap heap, bool isUnicode, EmailStoreReaderOptions options,
-        CancellationToken cancellationToken) {
+        CancellationToken cancellationToken, Action<string>? reportCellWarning = null) {
         _heap = heap;
         _isUnicode = isUnicode;
         _options = options;
         _cancellationToken = cancellationToken;
+        _reportCellWarning = reportCellWarning;
     }
 
     internal IReadOnlyList<IReadOnlyList<MapiProperty>> ReadRows() => EnumerateRows().ToArray();
@@ -26,7 +28,8 @@ internal sealed class PstTableContextReader {
 
         int columnCount = info[1];
         int rowSize = PstBinary.UInt16(info, 8);
-        int existenceOffset = PstBinary.UInt16(info, 6);
+        int existenceBytes = checked((columnCount + 7) / 8);
+        int existenceOffset = rowSize - existenceBytes;
         uint rowIndexHid = PstBinary.UInt32(info, 10);
         uint rowsHnid = PstBinary.UInt32(info, 14);
         if (rowSize <= 0 || existenceOffset < 0 || existenceOffset > rowSize ||
@@ -41,32 +44,58 @@ internal sealed class PstTableContextReader {
             int dataOffset = PstBinary.UInt16(info, offset + 4);
             int dataSize = info[offset + 6];
             int bitIndex = info[offset + 7];
-            if (dataOffset < 0 || dataSize < 0 || dataOffset > rowSize - dataSize) {
+            if (bitIndex >= columnCount || dataOffset < 0 || dataSize < 0 ||
+                dataOffset > existenceOffset - dataSize) {
                 throw new InvalidDataException("A PST table column points outside its row.");
             }
             columns.Add(new PstTableColumn(tag, dataOffset, dataSize, bitIndex));
         }
 
-        IReadOnlyList<int> rowIndexes = ReadRowIndexes(rowIndexHid);
+        IReadOnlyList<int> rowIndexes;
+        try {
+            rowIndexes = ReadRowIndexes(rowIndexHid);
+        } catch (InvalidDataException exception) {
+            throw CreateTableInfoException(info, columnCount, rowSize, existenceOffset,
+                rowIndexHid, rowsHnid, "row-index", exception);
+        }
         IEnumerable<byte[]> rowBlocks = _heap.EnumerateHnidBlocks(
-            rowsHnid, _options.MaxDecodedPropertyBytesPerItem);
+            rowsHnid, _options.MaxDecodedTableBytes);
         using (var cursor = new PstTableRowCursor(rowBlocks, rowSize)) {
             foreach (int rowIndex in rowIndexes.OrderBy(index => index)) {
                 _cancellationToken.ThrowIfCancellationRequested();
-                PstTableRow row = cursor.GetRow(rowIndex);
+                PstTableRow row;
+                try {
+                    row = cursor.GetRow(rowIndex);
+                } catch (InvalidDataException exception) {
+                    throw CreateTableInfoException(info, columnCount, rowSize, existenceOffset,
+                        rowIndexHid, rowsHnid, "row-matrix", exception);
+                }
                 var properties = new List<MapiProperty>(columns.Count);
                 long decodedBytes = 0;
                 foreach (PstTableColumn column in columns) {
                     int existenceByte = row.Offset + existenceOffset + column.BitIndex / 8;
                     if (existenceByte >= row.Offset + row.Length ||
                         (row.Bytes[existenceByte] & (1 << (7 - column.BitIndex % 8))) == 0) continue;
-                    MapiProperty property = DecodeColumn(row, column, ref decodedBytes);
-                    properties.Add(property);
+                    MapiProperty? property = DecodeColumn(row, rowIndex, column, ref decodedBytes);
+                    if (property != null) properties.Add(property);
                 }
                 yield return properties;
             }
         }
     }
+
+    private static InvalidDataException CreateTableInfoException(
+        byte[] info, int columnCount, int rowSize, int existenceOffset,
+        uint rowIndexHid, uint rowsHnid, string component, InvalidDataException exception) =>
+        new InvalidDataException(string.Concat(
+            "TCINFO ", component,
+            " bytes=", info.Length.ToString(CultureInfo.InvariantCulture),
+            " columns=", columnCount.ToString(CultureInfo.InvariantCulture),
+            " row-size=", rowSize.ToString(CultureInfo.InvariantCulture),
+            " existence-offset=", existenceOffset.ToString(CultureInfo.InvariantCulture),
+            " row-index=0x", rowIndexHid.ToString("X8", CultureInfo.InvariantCulture),
+            " rows=0x", rowsHnid.ToString("X8", CultureInfo.InvariantCulture),
+            ": ", exception.Message), exception);
 
     private IReadOnlyList<int> ReadRowIndexes(uint headerHid) {
         if (headerHid == 0) return Array.Empty<int>();
@@ -86,7 +115,8 @@ internal sealed class PstTableContextReader {
         return indexes;
     }
 
-    private MapiProperty DecodeColumn(PstTableRow row, PstTableColumn column, ref long decodedBytes) {
+    private MapiProperty? DecodeColumn(
+        PstTableRow row, int rowIndex, PstTableColumn column, ref long decodedBytes) {
         ushort id = (ushort)(column.Tag >> 16);
         var type = (MapiPropertyType)(ushort)column.Tag;
         object? value;
@@ -123,7 +153,18 @@ internal sealed class PstTableContextReader {
                 break;
             default:
                 uint hnid = PstBinary.UInt32(row.Bytes, offset);
-                rawData = _heap.ResolveHnid(hnid, _options.MaxDecodedPropertyBytesPerItem);
+                try {
+                    rawData = _heap.ResolveHnid(hnid, _options.MaxDecodedPropertyBytesPerItem);
+                } catch (InvalidDataException exception) {
+                    _reportCellWarning?.Invoke(string.Concat(
+                        "Table row ", rowIndex.ToString(CultureInfo.InvariantCulture),
+                        " column tag 0x", column.Tag.ToString("X8", CultureInfo.InvariantCulture),
+                        " type 0x", ((ushort)type).ToString("X4", CultureInfo.InvariantCulture),
+                        " width ", column.DataSize.ToString(CultureInfo.InvariantCulture),
+                        " contains invalid HNID 0x", hnid.ToString("X8", CultureInfo.InvariantCulture),
+                        ": ", exception.Message));
+                    return null;
+                }
                 decodedBytes = checked(decodedBytes + rawData.Length);
                 if (decodedBytes > _options.MaxDecodedPropertyBytesPerItem) {
                     throw new EmailStoreLimitExceededException(

--- a/OfficeIMO.Email.Store/Pst/Writing/PstNamedPropertyWriter.cs
+++ b/OfficeIMO.Email.Store/Pst/Writing/PstNamedPropertyWriter.cs
@@ -1,0 +1,147 @@
+using OfficeIMO.Email;
+
+namespace OfficeIMO.Email.Store;
+
+internal sealed class PstNamedPropertyWriter {
+    private static readonly Guid PsMapi = new Guid("00020328-0000-0000-C000-000000000046");
+    private static readonly Guid PsPublicStrings = new Guid("00020329-0000-0000-C000-000000000046");
+    private static readonly Guid OfficeImoUnknownPropertySet =
+        new Guid("E962B602-9F1E-4F76-BC29-4795CD1752F7");
+    private const int BucketCount = 251;
+    private readonly Dictionary<string, NamedEntry> _byIdentity =
+        new Dictionary<string, NamedEntry>(StringComparer.Ordinal);
+    private readonly List<NamedEntry> _entries = new List<NamedEntry>();
+
+    internal PstNamedPropertyWriter() {
+        // An empty binary entry stream is treated as a missing Name-to-ID map by
+        // Outlook-compatible readers. Seed one harmless, standard public-string
+        // mapping and one PS_COMMON mapping so every required map stream is
+        // materialized even before the caller writes a named property.
+        GetOrAdd(new MapiNamedProperty(PsPublicStrings, "Keywords"));
+        GetOrAdd(new MapiNamedProperty(
+            new Guid("00062008-0000-0000-C000-000000000046"), 0x8501));
+    }
+
+    internal IReadOnlyList<MapiProperty> Map(IEnumerable<MapiProperty> properties,
+        Action<EmailStoreDiagnostic>? reportDiagnostic, string location) {
+        var result = new List<MapiProperty>();
+        foreach (MapiProperty property in properties) {
+            ushort propertyId = property.PropertyId;
+            MapiNamedProperty? name = property.Name;
+            if (name == null && propertyId >= 0x8000) {
+                name = new MapiNamedProperty(OfficeImoUnknownPropertySet, propertyId);
+                reportDiagnostic?.Invoke(new EmailStoreDiagnostic(
+                    "EMAIL_STORE_PST_WRITE_NAMED_PROPERTY_PLACEHOLDER",
+                    string.Concat("Named property 0x", propertyId.ToString("X4",
+                        CultureInfo.InvariantCulture),
+                        " had no source Name-to-ID mapping and was preserved under an OfficeIMO placeholder property set."),
+                    EmailStoreDiagnosticSeverity.Warning, location));
+            }
+            if (name != null) propertyId = GetOrAdd(name).PropertyId;
+            result.Add(new MapiProperty(propertyId, property.PropertyType,
+                property.Value, property.Flags, name) {
+                RawData = property.RawData == null ? null : (byte[])property.RawData.Clone()
+            });
+        }
+        return result;
+    }
+
+    internal IReadOnlyList<MapiProperty> BuildProperties() {
+        var guidIndexes = new Dictionary<Guid, int>();
+        var guidStream = new List<byte>();
+        var stringStream = new List<byte>();
+        var entryStream = new byte[_entries.Count * 8];
+        var buckets = Enumerable.Range(0, BucketCount).Select(_ => new List<byte>()).ToArray();
+
+        for (int index = 0; index < _entries.Count; index++) {
+            NamedEntry entry = _entries[index];
+            int guidIndex = GetGuidIndex(entry.Name.PropertySet, entry.Name.IsStringNamed,
+                guidIndexes, guidStream);
+            uint identifier;
+            uint bucketIdentifier;
+            if (entry.Name.IsStringNamed) {
+                byte[] nameBytes = Encoding.Unicode.GetBytes(entry.Name.Name!);
+                identifier = checked((uint)stringStream.Count);
+                AddUInt32(stringStream, checked((uint)nameBytes.Length));
+                stringStream.AddRange(nameBytes);
+                while ((stringStream.Count & 3) != 0) stringStream.Add(0);
+                bucketIdentifier = PstCrc32.Compute(nameBytes);
+            } else {
+                identifier = entry.Name.LocalId.GetValueOrDefault();
+                bucketIdentifier = identifier;
+            }
+            ushort guidAndKind = checked((ushort)((guidIndex << 1) |
+                (entry.Name.IsStringNamed ? 1 : 0)));
+            ushort propertyIndex = checked((ushort)(entry.PropertyId - 0x8000));
+            WriteNameId(entryStream, index * 8, identifier, guidAndKind, propertyIndex);
+
+            uint firstDword = bucketIdentifier;
+            uint secondDword = (uint)guidAndKind | ((uint)propertyIndex << 16);
+            int bucket = checked((int)((firstDword ^ (secondDword & 0xFFFFU)) % BucketCount));
+            byte[] bucketEntry = new byte[8];
+            WriteNameId(bucketEntry, 0, bucketIdentifier, guidAndKind, propertyIndex);
+            buckets[bucket].AddRange(bucketEntry);
+        }
+
+        var properties = new List<MapiProperty> {
+            new MapiProperty(0x0001, MapiPropertyType.Integer32, BucketCount),
+            new MapiProperty(0x0002, MapiPropertyType.Binary, guidStream.ToArray()),
+            new MapiProperty(0x0003, MapiPropertyType.Binary, entryStream),
+            new MapiProperty(0x0004, MapiPropertyType.Binary, stringStream.ToArray())
+        };
+        for (int index = 0; index < buckets.Length; index++) {
+            if (buckets[index].Count == 0) continue;
+            properties.Add(new MapiProperty(checked((ushort)(0x1000 + index)),
+                MapiPropertyType.Binary, buckets[index].ToArray()));
+        }
+        return properties;
+    }
+
+    private NamedEntry GetOrAdd(MapiNamedProperty name) {
+        string identity = name.IsStringNamed
+            ? string.Concat(name.PropertySet.ToString("D"), ":S:", name.Name)
+            : string.Concat(name.PropertySet.ToString("D"), ":N:",
+                name.LocalId.GetValueOrDefault().ToString("X8", CultureInfo.InvariantCulture));
+        if (_byIdentity.TryGetValue(identity, out NamedEntry? existing)) return existing;
+        if (_entries.Count >= 0x8000) throw new NotSupportedException("The PST named-property map is full.");
+        var created = new NamedEntry(checked((ushort)(0x8000 + _entries.Count)), name);
+        _entries.Add(created);
+        _byIdentity.Add(identity, created);
+        return created;
+    }
+
+    private static int GetGuidIndex(Guid guid, bool stringNamed,
+        IDictionary<Guid, int> indexes, ICollection<byte> stream) {
+        if (stringNamed && guid == Guid.Empty) return 0;
+        if (guid == PsMapi) return 1;
+        if (guid == PsPublicStrings) return 2;
+        if (indexes.TryGetValue(guid, out int existing)) return existing;
+        int index = checked(3 + indexes.Count);
+        indexes.Add(guid, index);
+        foreach (byte value in guid.ToByteArray()) stream.Add(value);
+        return index;
+    }
+
+    private static void WriteNameId(byte[] bytes, int offset, uint identifier,
+        ushort guidAndKind, ushort propertyIndex) {
+        PstBinary.WriteUInt32(bytes, offset, identifier);
+        PstBinary.WriteUInt16(bytes, offset + 4, guidAndKind);
+        PstBinary.WriteUInt16(bytes, offset + 6, propertyIndex);
+    }
+
+    private static void AddUInt32(ICollection<byte> bytes, uint value) {
+        bytes.Add((byte)value);
+        bytes.Add((byte)(value >> 8));
+        bytes.Add((byte)(value >> 16));
+        bytes.Add((byte)(value >> 24));
+    }
+
+    private sealed class NamedEntry {
+        internal NamedEntry(ushort propertyId, MapiNamedProperty name) {
+            PropertyId = propertyId;
+            Name = name;
+        }
+        internal ushort PropertyId { get; }
+        internal MapiNamedProperty Name { get; }
+    }
+}

--- a/OfficeIMO.Email.Store/Pst/Writing/PstPropertyContextWriter.cs
+++ b/OfficeIMO.Email.Store/Pst/Writing/PstPropertyContextWriter.cs
@@ -1,0 +1,175 @@
+using OfficeIMO.Email;
+
+namespace OfficeIMO.Email.Store;
+
+internal sealed class PstWriterObjectReference {
+    internal PstWriterObjectReference(uint nid, long size) {
+        Nid = nid;
+        Size = size;
+    }
+
+    internal uint Nid { get; }
+    internal long Size { get; }
+}
+
+internal sealed class PstWriterValueReference {
+    internal PstWriterValueReference(uint nid, ulong dataBid, ulong subnodeBid = 0) {
+        Nid = nid;
+        DataBid = dataBid;
+        SubnodeBid = subnodeBid;
+    }
+
+    internal uint Nid { get; }
+    internal ulong DataBid { get; }
+    internal ulong SubnodeBid { get; }
+}
+
+internal readonly struct PstWriterContextResult {
+    internal PstWriterContextResult(ulong dataBid, ulong subnodeBid) {
+        DataBid = dataBid;
+        SubnodeBid = subnodeBid;
+    }
+
+    internal ulong DataBid { get; }
+    internal ulong SubnodeBid { get; }
+}
+
+internal static class PstPropertyContextWriter {
+    private const int MaximumHeapPayload = 8176;
+    private const int PreferredHeapValueLimit = 3580;
+
+    internal static PstWriterContextResult Write(PstWriterFile file,
+        IEnumerable<MapiProperty> properties, int codePage,
+        IEnumerable<PstWriterSubnode>? additionalSubnodes,
+        IReadOnlyDictionary<ushort, PstWriterValueReference>? valueReferences,
+        IReadOnlyDictionary<ushort, PstWriterObjectReference>? objectReferences,
+        Action<EmailStoreDiagnostic>? reportDiagnostic, string location) {
+        if (file == null) throw new ArgumentNullException(nameof(file));
+        if (properties == null) throw new ArgumentNullException(nameof(properties));
+
+        var candidates = new List<EncodedProperty>();
+        foreach (MapiProperty property in properties
+            .Where(item => item != null)
+            .GroupBy(item => item.PropertyId)
+            .Select(group => group.Last())
+            .OrderBy(item => item.PropertyId)) {
+            try {
+                if (valueReferences != null && valueReferences.TryGetValue(
+                    property.PropertyId, out PstWriterValueReference? valueReference)) {
+                    candidates.Add(new EncodedProperty(property.PropertyId,
+                        property.PropertyType, valueReference.Nid, isExternalReference: true));
+                } else if (property.PropertyType == MapiPropertyType.Object) {
+                    if (objectReferences != null && objectReferences.TryGetValue(
+                        property.PropertyId, out PstWriterObjectReference? reference)) {
+                        var descriptor = new byte[8];
+                        PstBinary.WriteUInt32(descriptor, 0, reference.Nid);
+                        PstBinary.WriteUInt32(descriptor, 4, checked((uint)Math.Min(reference.Size, uint.MaxValue)));
+                        candidates.Add(new EncodedProperty(property.PropertyId,
+                            property.PropertyType, descriptor, isObjectDescriptor: true));
+                    } else {
+                        Report(reportDiagnostic, "EMAIL_STORE_PST_WRITE_OBJECT_OMITTED",
+                            "An object property without a corresponding embedded subnode was omitted.",
+                            EmailStoreDiagnosticSeverity.Warning, location);
+                    }
+                } else if (PstPropertyValueWriter.IsInline(property.PropertyType)) {
+                    candidates.Add(new EncodedProperty(property.PropertyId,
+                        property.PropertyType, PstPropertyValueWriter.EncodeInline(property)));
+                } else {
+                    candidates.Add(new EncodedProperty(property.PropertyId,
+                        property.PropertyType,
+                        PstPropertyValueWriter.EncodeVariable(property, codePage)));
+                }
+            } catch (Exception exception) when (exception is ArgumentException ||
+                exception is InvalidCastException || exception is FormatException ||
+                exception is OverflowException || exception is NotSupportedException) {
+                Report(reportDiagnostic, "EMAIL_STORE_PST_WRITE_PROPERTY_OMITTED",
+                    string.Concat("Property 0x", property.PropertyTag.ToString("X8", CultureInfo.InvariantCulture),
+                        " was omitted: ", exception.Message),
+                    EmailStoreDiagnosticSeverity.Warning, location);
+            }
+        }
+
+        foreach (EncodedProperty candidate in candidates.Where(item =>
+            item.Bytes != null && !item.IsObjectDescriptor && item.Bytes.Length > PreferredHeapValueLimit)) {
+            candidate.UseSubnode = true;
+        }
+        var heap = new PstWriterHeap(0xBC);
+        var bthHeader = new byte[8];
+        uint headerHid = heap.Add(bthHeader);
+        var records = new byte[candidates.Count * 8];
+
+        var subnodes = additionalSubnodes == null
+            ? new List<PstWriterSubnode>()
+            : new List<PstWriterSubnode>(additionalSubnodes);
+        if (valueReferences != null) {
+            foreach (PstWriterValueReference reference in valueReferences.Values) {
+                subnodes.Add(new PstWriterSubnode(reference.Nid, reference.DataBid, reference.SubnodeBid));
+            }
+        }
+        uint localIndex = NextLocalIndex(subnodes);
+        for (int index = 0; index < candidates.Count; index++) {
+            EncodedProperty candidate = candidates[index];
+            uint rawValue;
+            if (candidate.IsExternalReference) {
+                rawValue = candidate.InlineValue;
+            } else if (candidate.IsInline) {
+                rawValue = candidate.InlineValue;
+            } else if (candidate.Bytes == null || candidate.Bytes.Length == 0) {
+                rawValue = 0;
+            } else if (candidate.UseSubnode) {
+                uint nid = checked((localIndex++ << 5) | 0x1FU);
+                subnodes.Add(new PstWriterSubnode(nid, file.WriteDataTree(candidate.Bytes)));
+                rawValue = nid;
+            } else {
+                rawValue = heap.Add(candidate.Bytes);
+            }
+            int recordOffset = index * 8;
+            PstBinary.WriteUInt16(records, recordOffset, candidate.PropertyId);
+            PstBinary.WriteUInt16(records, recordOffset + 2, (ushort)candidate.PropertyType);
+            PstBinary.WriteUInt32(records, recordOffset + 4, rawValue);
+        }
+
+        PstWriterBth.Complete(heap, bthHeader, 2, 6, records);
+        ulong dataBid = file.WriteDataTreeBlocks(heap.Build(headerHid));
+        ulong subnodeBid = PstWriterSubnodeTree.Write(file, subnodes);
+        return new PstWriterContextResult(dataBid, subnodeBid);
+    }
+
+    private static uint NextLocalIndex(IEnumerable<PstWriterSubnode> subnodes) {
+        uint maximum = 0x10;
+        foreach (PstWriterSubnode subnode in subnodes) maximum = Math.Max(maximum, subnode.Nid >> 5);
+        return checked(maximum + 1);
+    }
+
+    private static void Report(Action<EmailStoreDiagnostic>? callback, string code,
+        string message, EmailStoreDiagnosticSeverity severity, string location) =>
+        callback?.Invoke(new EmailStoreDiagnostic(code, message, severity, location));
+
+    private sealed class EncodedProperty {
+        internal EncodedProperty(ushort propertyId, MapiPropertyType propertyType, uint inlineValue,
+            bool isExternalReference = false) {
+            PropertyId = propertyId;
+            PropertyType = propertyType;
+            InlineValue = inlineValue;
+            IsInline = !isExternalReference;
+            IsExternalReference = isExternalReference;
+        }
+
+        internal EncodedProperty(ushort propertyId, MapiPropertyType propertyType, byte[] bytes,
+            bool isObjectDescriptor = false) {
+            PropertyId = propertyId;
+            PropertyType = propertyType;
+            Bytes = bytes;
+            IsObjectDescriptor = isObjectDescriptor;
+        }
+
+        internal ushort PropertyId { get; }
+        internal MapiPropertyType PropertyType { get; }
+        internal uint InlineValue { get; }
+        internal bool IsInline { get; }
+        internal bool IsExternalReference { get; }
+        internal byte[]? Bytes { get; }
+        internal bool IsObjectDescriptor { get; }
+        internal bool UseSubnode { get; set; }
+    }
+}

--- a/OfficeIMO.Email.Store/Pst/Writing/PstPropertyValueWriter.cs
+++ b/OfficeIMO.Email.Store/Pst/Writing/PstPropertyValueWriter.cs
@@ -1,0 +1,141 @@
+using OfficeIMO.Email;
+
+namespace OfficeIMO.Email.Store;
+
+internal static class PstPropertyValueWriter {
+    static PstPropertyValueWriter() {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+    }
+
+    internal static bool IsInline(MapiPropertyType type) =>
+        type == MapiPropertyType.Null ||
+        type == MapiPropertyType.Integer16 ||
+        type == MapiPropertyType.Integer32 ||
+        type == MapiPropertyType.ErrorCode ||
+        type == MapiPropertyType.Floating32 ||
+        type == MapiPropertyType.Boolean;
+
+    internal static uint EncodeInline(MapiProperty property) {
+        object? value = property.Value;
+        switch (property.PropertyType) {
+            case MapiPropertyType.Null:
+                return 0;
+            case MapiPropertyType.Integer16:
+                return unchecked((ushort)Convert.ToInt16(value ?? 0, CultureInfo.InvariantCulture));
+            case MapiPropertyType.Integer32:
+            case MapiPropertyType.ErrorCode:
+                return unchecked((uint)Convert.ToInt32(value ?? 0, CultureInfo.InvariantCulture));
+            case MapiPropertyType.Floating32:
+                return BitConverter.ToUInt32(BitConverter.GetBytes(
+                    Convert.ToSingle(value ?? 0F, CultureInfo.InvariantCulture)), 0);
+            case MapiPropertyType.Boolean:
+                return Convert.ToBoolean(value ?? false, CultureInfo.InvariantCulture) ? 1U : 0U;
+            default:
+                throw new NotSupportedException("The MAPI property type is not a four-byte inline value.");
+        }
+    }
+
+    internal static byte[] EncodeVariable(MapiProperty property, int codePage) {
+        if (property.RawData != null) return (byte[])property.RawData.Clone();
+        object? value = property.Value;
+        switch (property.PropertyType) {
+            case MapiPropertyType.Floating64:
+            case MapiPropertyType.FloatingTime:
+                return BitConverter.GetBytes(Convert.ToDouble(value ?? 0D, CultureInfo.InvariantCulture));
+            case MapiPropertyType.Currency:
+            case MapiPropertyType.Integer64:
+                return BitConverter.GetBytes(Convert.ToInt64(value ?? 0L, CultureInfo.InvariantCulture));
+            case MapiPropertyType.Time:
+                return BitConverter.GetBytes(ToFileTime(value));
+            case MapiPropertyType.Guid:
+                return value is Guid guid ? guid.ToByteArray() : Guid.Empty.ToByteArray();
+            case MapiPropertyType.Unicode:
+                return Encoding.Unicode.GetBytes(string.Concat(Convert.ToString(value, CultureInfo.InvariantCulture), "\0"));
+            case MapiPropertyType.String8:
+                return GetEncoding(codePage).GetBytes(string.Concat(Convert.ToString(value, CultureInfo.InvariantCulture), "\0"));
+            case MapiPropertyType.Binary:
+            case MapiPropertyType.Object:
+            case MapiPropertyType.Unspecified:
+                return value as byte[] ?? Array.Empty<byte>();
+            case MapiPropertyType.MultipleInteger16:
+                return EncodeFixedValues(value, 2, item => BitConverter.GetBytes(Convert.ToInt16(item, CultureInfo.InvariantCulture)));
+            case MapiPropertyType.MultipleInteger32:
+                return EncodeFixedValues(value, 4, item => BitConverter.GetBytes(Convert.ToInt32(item, CultureInfo.InvariantCulture)));
+            case MapiPropertyType.MultipleFloating32:
+                return EncodeFixedValues(value, 4, item => BitConverter.GetBytes(Convert.ToSingle(item, CultureInfo.InvariantCulture)));
+            case MapiPropertyType.MultipleFloating64:
+            case MapiPropertyType.MultipleFloatingTime:
+                return EncodeFixedValues(value, 8, item => BitConverter.GetBytes(Convert.ToDouble(item, CultureInfo.InvariantCulture)));
+            case MapiPropertyType.MultipleCurrency:
+            case MapiPropertyType.MultipleInteger64:
+                return EncodeFixedValues(value, 8, item => BitConverter.GetBytes(Convert.ToInt64(item, CultureInfo.InvariantCulture)));
+            case MapiPropertyType.MultipleTime:
+                return EncodeFixedValues(value, 8, item => BitConverter.GetBytes(ToFileTime(item)));
+            case MapiPropertyType.MultipleGuid:
+                return EncodeFixedValues(value, 16, item => item is Guid itemGuid ? itemGuid.ToByteArray() : Guid.Empty.ToByteArray());
+            case MapiPropertyType.MultipleUnicode:
+                return EncodeVariableValues(value, item => Encoding.Unicode.GetBytes(
+                    string.Concat(Convert.ToString(item, CultureInfo.InvariantCulture), "\0")));
+            case MapiPropertyType.MultipleString8:
+                Encoding encoding = GetEncoding(codePage);
+                return EncodeVariableValues(value, item => encoding.GetBytes(
+                    string.Concat(Convert.ToString(item, CultureInfo.InvariantCulture), "\0")));
+            case MapiPropertyType.MultipleBinary:
+                return EncodeVariableValues(value, item => item as byte[] ?? Array.Empty<byte>());
+            default:
+                throw new NotSupportedException(string.Concat("Unsupported MAPI property type 0x",
+                    ((ushort)property.PropertyType).ToString("X4", CultureInfo.InvariantCulture), "."));
+        }
+    }
+
+    private static byte[] EncodeFixedValues(object? source, int elementSize,
+        Func<object?, byte[]> encode) {
+        object?[] values = Enumerate(source);
+        var result = new byte[checked(values.Length * elementSize)];
+        for (int index = 0; index < values.Length; index++) {
+            byte[] encoded = encode(values[index]);
+            if (encoded.Length != elementSize) throw new InvalidDataException("A fixed MAPI value has an invalid size.");
+            Buffer.BlockCopy(encoded, 0, result, index * elementSize, elementSize);
+        }
+        return result;
+    }
+
+    private static byte[] EncodeVariableValues(object? source, Func<object?, byte[]> encode) {
+        object?[] values = Enumerate(source);
+        byte[][] encoded = values.Select(encode).ToArray();
+        int headerLength = checked(4 + encoded.Length * 4);
+        int length = encoded.Aggregate(headerLength, (current, item) => checked(current + item.Length));
+        var result = new byte[length];
+        PstBinary.WriteUInt32(result, 0, checked((uint)encoded.Length));
+        int cursor = headerLength;
+        for (int index = 0; index < encoded.Length; index++) {
+            PstBinary.WriteUInt32(result, 4 + index * 4, checked((uint)cursor));
+            Buffer.BlockCopy(encoded[index], 0, result, cursor, encoded[index].Length);
+            cursor += encoded[index].Length;
+        }
+        return result;
+    }
+
+    private static object?[] Enumerate(object? source) {
+        if (source == null) return Array.Empty<object?>();
+        if (source is string || source is byte[]) return new[] { source };
+        if (source is System.Collections.IEnumerable enumerable) {
+            var result = new List<object?>();
+            foreach (object? item in enumerable) result.Add(item);
+            return result.ToArray();
+        }
+        return new[] { source };
+    }
+
+    private static long ToFileTime(object? value) {
+        if (value is DateTimeOffset offset) return offset.UtcDateTime.ToFileTimeUtc();
+        if (value is DateTime dateTime) return dateTime.ToUniversalTime().ToFileTimeUtc();
+        if (value == null) return 0;
+        return Convert.ToInt64(value, CultureInfo.InvariantCulture);
+    }
+
+    private static Encoding GetEncoding(int codePage) {
+        try { return Encoding.GetEncoding(codePage > 0 ? codePage : 1252); }
+        catch (ArgumentException) { return Encoding.GetEncoding(1252); }
+    }
+}

--- a/OfficeIMO.Email.Store/Pst/Writing/PstStoreWriterCore.Items.cs
+++ b/OfficeIMO.Email.Store/Pst/Writing/PstStoreWriterCore.Items.cs
@@ -1,0 +1,241 @@
+using OfficeIMO.Email;
+
+namespace OfficeIMO.Email.Store;
+
+internal sealed partial class PstStoreWriterCore {
+    private WrittenMessage WriteMessage(EmailDocument document, uint messageNid,
+        int depth, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (depth > _options.MaxNestedMessageDepth) {
+            throw new InvalidOperationException("The embedded-message depth exceeds the configured PST limit.");
+        }
+
+        var emailDiagnostics = new List<EmailDiagnostic>();
+        MsgPropertyBuilder messageBuilder = MsgWriter.CreateMessageProperties(
+            document, emailDiagnostics, string.Concat("message/", FormatId(messageNid)),
+            new EmailWriterOptions(EmailConversionLossPolicy.Allow,
+                maxNestedMessageDepth: _options.MaxNestedMessageDepth,
+                maxOutputBytes: uint.MaxValue));
+        messageBuilder.Set(0x0E08, MapiPropertyType.Integer32, EstimateMessageSize(document));
+        messageBuilder.Set(0x0E17, MapiPropertyType.Integer32,
+            GetInt(document.MapiProperties, 0x0E17) ?? 0);
+        messageBuilder.Set(0x300B, MapiPropertyType.Binary,
+            GetBytes(document.MapiProperties, 0x300B) ?? CreateObjectKey(messageNid));
+        TranslateDiagnostics(emailDiagnostics);
+
+        IReadOnlyList<MapiProperty> messageProperties =
+            _namedProperties.Map(messageBuilder.Properties, Report,
+                string.Concat("message/", FormatId(messageNid)));
+        int codePage = ResolveCodePage(document);
+        var messageSubnodes = new List<PstWriterSubnode>();
+
+        EmailRecipient[] recipients = document.Recipients
+            .Where(item => item.Kind != EmailRecipientKind.ReplyTo).ToArray();
+        var recipientRows = new List<PstWriterTableRow>(recipients.Length);
+        for (int index = 0; index < recipients.Length; index++) {
+            MsgPropertyBuilder recipientBuilder = MsgWriter.CreateRecipientProperties(recipients[index], index);
+            recipientBuilder.Set(0x0E0F, MapiPropertyType.Boolean, false);
+            recipientBuilder.Set(0x0FF9, MapiPropertyType.Binary,
+                GetBytes(recipients[index].MapiProperties, 0x0FF9) ?? CreateObjectKey(checked((uint)index + 1)));
+            recipientBuilder.Set(0x39FF, MapiPropertyType.String8,
+                recipients[index].Address.DisplayName ?? recipients[index].Address.Address);
+            recipientBuilder.Set(0x3A40, MapiPropertyType.Boolean,
+                GetBool(recipients[index].MapiProperties, 0x3A40) ?? false);
+            recipientRows.Add(new PstWriterTableRow(checked((uint)index + 1),
+                _namedProperties.Map(recipientBuilder.Properties, Report,
+                    string.Concat("message/", FormatId(messageNid), "/recipient/",
+                        index.ToString(CultureInfo.InvariantCulture)))));
+        }
+        PstWriterContextResult recipientTable = PstTableContextWriter.Write(_file,
+            recipientRows, codePage, RecipientColumns, Report,
+            string.Concat("message/", FormatId(messageNid), "/recipients"));
+        messageSubnodes.Add(new PstWriterSubnode(0x692,
+            recipientTable.DataBid, recipientTable.SubnodeBid));
+
+        EmailAttachment[] attachments = document.Attachments
+            .Where(item => !item.IsProjectedSemanticContent).ToArray();
+        var attachmentRows = new List<PstWriterTableRow>(attachments.Length);
+        for (int index = 0; index < attachments.Length; index++) {
+            cancellationToken.ThrowIfCancellationRequested();
+            uint attachmentNid = checked(((uint)(index + 0x10) << 5) | 0x05U);
+            WrittenAttachment written = WriteAttachment(attachments[index], attachmentNid,
+                codePage, depth, cancellationToken);
+            messageSubnodes.Add(new PstWriterSubnode(attachmentNid,
+                written.Context.DataBid, written.Context.SubnodeBid));
+            attachmentRows.Add(new PstWriterTableRow(attachmentNid,
+                SelectTableProperties(written.TableProperties, AttachmentColumns)));
+        }
+        if (attachmentRows.Count > 0) {
+            PstWriterContextResult attachmentTable = PstTableContextWriter.Write(_file,
+                attachmentRows, codePage, AttachmentColumns, Report,
+                string.Concat("message/", FormatId(messageNid), "/attachments"));
+            messageSubnodes.Add(new PstWriterSubnode(0x671,
+                attachmentTable.DataBid, attachmentTable.SubnodeBid));
+        }
+
+        PstWriterContextResult context = PstPropertyContextWriter.Write(_file,
+            messageProperties, codePage, messageSubnodes, null, null,
+            Report, string.Concat("message/", FormatId(messageNid)));
+        return new WrittenMessage(context,
+            SelectTableProperties(messageProperties, ContentsColumns.Concat(AssociatedColumns).ToArray()));
+    }
+
+    private WrittenAttachment WriteAttachment(EmailAttachment attachment, uint attachmentNid,
+        int codePage, int parentDepth, CancellationToken cancellationToken) {
+        var diagnostics = new List<EmailDiagnostic>();
+        int method = attachment.MapiAttachMethod ??
+            (attachment.EmbeddedDocument != null ? 5 :
+                attachment.StructuredStorageStreams.Count > 0 ? 6 : 1);
+        bool hasSource = attachment.Content != null || attachment.ContentSource != null ||
+            attachment.EmbeddedDocument != null || attachment.StructuredStorageStreams.Count > 0;
+        MsgPropertyBuilder builder = MsgWriter.CreateAttachmentProperties(
+            attachment, checked((int)(attachmentNid >> 5)), method, diagnostics,
+            string.Concat("attachment/0x", attachmentNid.ToString("X8", CultureInfo.InvariantCulture)),
+            hasRetainedObjectContent: hasSource, materializedContent: null);
+        var subnodes = new List<PstWriterSubnode>();
+        var valueReferences = new Dictionary<ushort, PstWriterValueReference>();
+        var objectReferences = new Dictionary<ushort, PstWriterObjectReference>();
+        long contentLength = Math.Max(0, attachment.Length);
+
+        if (method == 5 && attachment.EmbeddedDocument != null) {
+            if (parentDepth >= _options.MaxNestedMessageDepth) {
+                Report(new EmailStoreDiagnostic(
+                    "EMAIL_STORE_PST_WRITE_EMBEDDED_DEPTH_LIMIT",
+                    "An embedded item could not be written because the configured nesting limit was reached.",
+                    EmailStoreDiagnosticSeverity.Error,
+                    string.Concat("attachment/0x", attachmentNid.ToString("X8", CultureInfo.InvariantCulture))));
+            } else {
+                const uint embeddedNid = 0x224;
+                WrittenMessage embedded = WriteMessage(attachment.EmbeddedDocument,
+                    embeddedNid, parentDepth + 1, cancellationToken);
+                subnodes.Add(new PstWriterSubnode(embeddedNid,
+                    embedded.Context.DataBid, embedded.Context.SubnodeBid));
+                objectReferences[0x3701] = new PstWriterObjectReference(embeddedNid, 0);
+                builder.Set(0x3701, MapiPropertyType.Object, null);
+            }
+        } else if (method == 5) {
+            Report(new EmailStoreDiagnostic(
+                "EMAIL_STORE_PST_WRITE_EMBEDDED_CONTENT_UNAVAILABLE",
+                "An embedded attachment has no projected embedded item and was retained as metadata only.",
+                EmailStoreDiagnosticSeverity.Error,
+                string.Concat("attachment/0x", attachmentNid.ToString("X8", CultureInfo.InvariantCulture))));
+        } else if (method == 6) {
+            if (TryWriteAttachmentPayload(attachment, out ulong contentBid,
+                out contentLength, cancellationToken)) {
+                const uint contentNid = 0x3F;
+                subnodes.Add(new PstWriterSubnode(contentNid, contentBid));
+                objectReferences[0x3701] = new PstWriterObjectReference(contentNid, contentLength);
+                builder.Set(0x3701, MapiPropertyType.Object, null);
+            } else if (attachment.StructuredStorageStreams.Count > 0) {
+                Report(new EmailStoreDiagnostic(
+                    "EMAIL_STORE_PST_WRITE_STRUCTURED_STORAGE_OMITTED",
+                    "Structured-storage attachment streams require an original compound payload and were retained as metadata only.",
+                    EmailStoreDiagnosticSeverity.Error,
+                    string.Concat("attachment/0x", attachmentNid.ToString("X8", CultureInfo.InvariantCulture))));
+            }
+        } else if (TryWriteAttachmentPayload(attachment, out ulong contentBid,
+            out contentLength, cancellationToken)) {
+            const uint contentNid = 0x3F;
+            valueReferences[0x3701] = new PstWriterValueReference(contentNid, contentBid);
+            builder.Set(0x3701, MapiPropertyType.Binary, Array.Empty<byte>());
+        } else if (attachment.Length > 0) {
+            Report(new EmailStoreDiagnostic(
+                "EMAIL_STORE_PST_WRITE_ATTACHMENT_CONTENT_UNAVAILABLE",
+                "Attachment content was unavailable and only its metadata could be written.",
+                EmailStoreDiagnosticSeverity.Error,
+                string.Concat("attachment/0x", attachmentNid.ToString("X8", CultureInfo.InvariantCulture))));
+        }
+        builder.Set(0x0E20, MapiPropertyType.Integer32,
+            checked((int)Math.Min(contentLength, int.MaxValue)));
+        TranslateDiagnostics(diagnostics);
+        string location = string.Concat("attachment/0x",
+            attachmentNid.ToString("X8", CultureInfo.InvariantCulture));
+        IReadOnlyList<MapiProperty> properties = _namedProperties.Map(
+            builder.Properties, Report, location);
+        PstWriterContextResult context = PstPropertyContextWriter.Write(_file,
+            properties, codePage, subnodes, valueReferences, objectReferences,
+            Report, string.Concat("attachment/0x", attachmentNid.ToString("X8", CultureInfo.InvariantCulture)));
+        return new WrittenAttachment(context, properties);
+    }
+
+    private bool TryWriteAttachmentPayload(EmailAttachment attachment,
+        out ulong dataBid, out long length, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (attachment.Content != null) {
+            length = attachment.Content.LongLength;
+            dataBid = _file.WriteDataTree(attachment.Content);
+            return true;
+        }
+        if (attachment.ContentSource != null) {
+            using (Stream stream = attachment.OpenContentStream()) {
+                cancellationToken.ThrowIfCancellationRequested();
+                dataBid = _file.WriteDataTree(stream, out length);
+                return true;
+            }
+        }
+        dataBid = 0;
+        length = 0;
+        return false;
+    }
+
+    private void TranslateDiagnostics(IEnumerable<EmailDiagnostic> diagnostics) {
+        foreach (EmailDiagnostic diagnostic in diagnostics) {
+            Report(new EmailStoreDiagnostic(diagnostic.Code, diagnostic.Message,
+                diagnostic.Severity == EmailDiagnosticSeverity.Error
+                    ? EmailStoreDiagnosticSeverity.Error
+                    : diagnostic.Severity == EmailDiagnosticSeverity.Information
+                        ? EmailStoreDiagnosticSeverity.Information
+                        : EmailStoreDiagnosticSeverity.Warning,
+                diagnostic.Location));
+        }
+    }
+
+    private static int ResolveCodePage(EmailDocument document) =>
+        document.OutlookCodePage.GetValueOrDefault(65001) > 0
+            ? document.OutlookCodePage.GetValueOrDefault(65001)
+            : 65001;
+
+    private static int EstimateMessageSize(EmailDocument document) {
+        long length = 0;
+        if (document.Body.Text != null) length += Encoding.Unicode.GetByteCount(document.Body.Text);
+        if (document.Body.Html != null) length += Encoding.UTF8.GetByteCount(document.Body.Html);
+        if (document.Body.Rtf != null) length += Encoding.UTF8.GetByteCount(document.Body.Rtf);
+        foreach (EmailAttachment attachment in document.Attachments) {
+            length = checked(length + Math.Max(0, attachment.Content?.LongLength ?? attachment.Length));
+        }
+        return checked((int)Math.Min(length, int.MaxValue));
+    }
+
+    private byte[] CreateObjectKey(uint value) {
+        byte[] bytes = _providerUid.ToByteArray();
+        PstBinary.WriteUInt32(bytes, 0, PstBinary.UInt32(bytes, 0) ^ value);
+        return bytes;
+    }
+
+    private static int? GetInt(IEnumerable<MapiProperty> properties, ushort propertyId) {
+        object? value = properties.LastOrDefault(item => item.PropertyId == propertyId)?.Value;
+        if (value is int number) return number;
+        if (value is short shortNumber) return shortNumber;
+        return null;
+    }
+
+    private static bool? GetBool(IEnumerable<MapiProperty> properties, ushort propertyId) {
+        object? value = properties.LastOrDefault(item => item.PropertyId == propertyId)?.Value;
+        if (value is bool boolean) return boolean;
+        if (value is int number) return number != 0;
+        return null;
+    }
+
+    private static byte[]? GetBytes(IEnumerable<MapiProperty> properties, ushort propertyId) =>
+        properties.LastOrDefault(item => item.PropertyId == propertyId)?.Value as byte[];
+
+    private readonly struct WrittenAttachment {
+        internal WrittenAttachment(PstWriterContextResult context,
+            IReadOnlyList<MapiProperty> tableProperties) {
+            Context = context;
+            TableProperties = tableProperties;
+        }
+        internal PstWriterContextResult Context { get; }
+        internal IReadOnlyList<MapiProperty> TableProperties { get; }
+    }
+}

--- a/OfficeIMO.Email.Store/Pst/Writing/PstStoreWriterCore.Structure.cs
+++ b/OfficeIMO.Email.Store/Pst/Writing/PstStoreWriterCore.Structure.cs
@@ -1,0 +1,180 @@
+using OfficeIMO.Email;
+
+namespace OfficeIMO.Email.Store;
+
+internal sealed partial class PstStoreWriterCore {
+    private static readonly MapiProperty[] HierarchyColumns = {
+        Column(0x0E30, MapiPropertyType.Integer32), Column(0x0E33, MapiPropertyType.Integer64),
+        Column(0x0E34, MapiPropertyType.Binary), Column(0x0E38, MapiPropertyType.Integer32),
+        Column(0x3001, MapiPropertyType.Unicode), Column(0x3602, MapiPropertyType.Integer32),
+        Column(0x3603, MapiPropertyType.Integer32), Column(0x360A, MapiPropertyType.Boolean),
+        Column(0x3613, MapiPropertyType.Unicode), Column(0x6635, MapiPropertyType.Integer32),
+        Column(0x6636, MapiPropertyType.Integer32)
+    };
+    private static readonly MapiProperty[] ContentsColumns = {
+        Column(0x0017, MapiPropertyType.Integer32), Column(0x001A, MapiPropertyType.Unicode),
+        Column(0x0036, MapiPropertyType.Integer32), Column(0x0037, MapiPropertyType.Unicode),
+        Column(0x0039, MapiPropertyType.Time), Column(0x0042, MapiPropertyType.Unicode),
+        Column(0x0057, MapiPropertyType.Boolean), Column(0x0058, MapiPropertyType.Boolean),
+        Column(0x0070, MapiPropertyType.Unicode), Column(0x0071, MapiPropertyType.Binary),
+        Column(0x0E03, MapiPropertyType.Unicode), Column(0x0E04, MapiPropertyType.Unicode),
+        Column(0x0E06, MapiPropertyType.Time), Column(0x0E07, MapiPropertyType.Integer32),
+        Column(0x0E08, MapiPropertyType.Integer32), Column(0x0E17, MapiPropertyType.Integer32),
+        Column(0x0E30, MapiPropertyType.Integer32), Column(0x0E33, MapiPropertyType.Integer64),
+        Column(0x0E34, MapiPropertyType.Binary), Column(0x0E38, MapiPropertyType.Integer32),
+        Column(0x0E3C, MapiPropertyType.Binary), Column(0x0E3D, MapiPropertyType.Binary),
+        Column(0x1097, MapiPropertyType.Integer32), Column(0x3008, MapiPropertyType.Time),
+        Column(0x65C6, MapiPropertyType.Integer32)
+    };
+    private static readonly MapiProperty[] AssociatedColumns = {
+        Column(0x001A, MapiPropertyType.Unicode), Column(0x0E07, MapiPropertyType.Integer32),
+        Column(0x0E17, MapiPropertyType.Integer32), Column(0x3001, MapiPropertyType.Unicode),
+        Column(0x6800, MapiPropertyType.Unicode), Column(0x6803, MapiPropertyType.Boolean),
+        Column(0x6805, MapiPropertyType.MultipleInteger32), Column(0x7003, MapiPropertyType.Integer32),
+        Column(0x7004, MapiPropertyType.Binary), Column(0x7005, MapiPropertyType.Binary)
+    };
+    private static readonly MapiProperty[] RecipientColumns = {
+        Column(0x0C15, MapiPropertyType.Integer32), Column(0x0E0F, MapiPropertyType.Boolean),
+        Column(0x0FF9, MapiPropertyType.Binary), Column(0x0FFE, MapiPropertyType.Integer32),
+        Column(0x0FFF, MapiPropertyType.Binary), Column(0x3001, MapiPropertyType.Unicode),
+        Column(0x3002, MapiPropertyType.Unicode), Column(0x3003, MapiPropertyType.Unicode),
+        Column(0x300B, MapiPropertyType.Binary), Column(0x3900, MapiPropertyType.Integer32),
+        Column(0x39FF, MapiPropertyType.String8), Column(0x3A40, MapiPropertyType.Boolean)
+    };
+    private static readonly MapiProperty[] AttachmentColumns = {
+        Column(0x0E20, MapiPropertyType.Integer32), Column(0x3704, MapiPropertyType.Unicode),
+        Column(0x3705, MapiPropertyType.Integer32), Column(0x370B, MapiPropertyType.Integer32)
+    };
+
+    private void WriteStoreStructure(CancellationToken cancellationToken) {
+        WriteTemplateTable(0x60D, HierarchyColumns, "template/hierarchy");
+        WriteTemplateTable(0x60E, ContentsColumns, "template/contents");
+        WriteTemplateTable(0x60F, AssociatedColumns, "template/associated");
+        WriteTemplateTable(0x610, ContentsColumns, "template/search");
+        WriteTemplateTable(0x692, RecipientColumns, "template/recipients");
+        WriteTemplateTable(0x671, AttachmentColumns, "template/attachments");
+
+        foreach (FolderState folder in _folders.Values.OrderBy(item => item.Nid)) {
+            cancellationToken.ThrowIfCancellationRequested();
+            WriteFolder(folder);
+        }
+
+        PstWriterContextResult nameMap = PstPropertyContextWriter.Write(_file,
+            _namedProperties.BuildProperties(), 65001, null, null, null,
+            Report, "named-properties");
+        _nodes.Add(new PstWriterNode(0x61, 0, nameMap.DataBid, nameMap.SubnodeBid));
+
+        byte[] uid = _providerUid.ToByteArray();
+        IReadOnlyList<MapiProperty> storeProperties = new[] {
+            new MapiProperty(0x0FF9, MapiPropertyType.Binary, uid),
+            new MapiProperty(0x3001, MapiPropertyType.Unicode, _options.DisplayName),
+            new MapiProperty(0x35DF, MapiPropertyType.Integer32, 0x89),
+            new MapiProperty(0x35E0, MapiPropertyType.Binary, CreateEntryId(IpmSubtreeNid)),
+            new MapiProperty(0x35E3, MapiPropertyType.Binary, CreateEntryId(DeletedItemsNid)),
+            new MapiProperty(0x35E7, MapiPropertyType.Binary, CreateEntryId(SearchRootNid)),
+            new MapiProperty(0x67FF, MapiPropertyType.Integer32, 0)
+        };
+        PstWriterContextResult store = PstPropertyContextWriter.Write(_file,
+            storeProperties, 65001, null, null, null, Report, "store");
+        _nodes.Add(new PstWriterNode(0x21, 0, store.DataBid, store.SubnodeBid));
+
+        ulong emptyQueue = _file.WriteDataTree(Array.Empty<byte>());
+        _nodes.Add(new PstWriterNode(0x1E1, 0, emptyQueue));
+        _nodes.Add(new PstWriterNode(0x201, 0, emptyQueue));
+    }
+
+    private void WriteFolder(FolderState folder) {
+        FolderState[] children = _folders.Values.Where(item => item.ParentNid == folder.Nid &&
+            item.Nid != folder.Nid).OrderBy(item => item.Nid).ToArray();
+        ItemState[] normalItems = folder.Items.Where(item => !item.IsAssociated).ToArray();
+        ItemState[] associatedItems = folder.Items.Where(item => item.IsAssociated).ToArray();
+        int unread = normalItems.Count(item => IsUnread(item.TableProperties));
+        var folderProperties = new List<MapiProperty> {
+            new MapiProperty(0x0FF9, MapiPropertyType.Binary, CreateEntryId(folder.Nid)),
+            new MapiProperty(0x3001, MapiPropertyType.Unicode, folder.Name),
+            new MapiProperty(0x3602, MapiPropertyType.Integer32, normalItems.Length),
+            new MapiProperty(0x3603, MapiPropertyType.Integer32, unread),
+            new MapiProperty(0x360A, MapiPropertyType.Boolean, children.Length > 0),
+            new MapiProperty(0x3617, MapiPropertyType.Integer32, associatedItems.Length)
+        };
+        if (!string.IsNullOrWhiteSpace(folder.ContainerClass)) {
+            folderProperties.Add(new MapiProperty(0x3613, MapiPropertyType.Unicode, folder.ContainerClass));
+        }
+        PstWriterContextResult pc = PstPropertyContextWriter.Write(_file,
+            folderProperties, 65001, null, null, null, Report,
+            string.Concat("folder/", FormatId(folder.Nid)));
+        _nodes.Add(new PstWriterNode(folder.Nid, folder.ParentNid, pc.DataBid, pc.SubnodeBid));
+
+        if (folder.IsSearchFolder) {
+            _nodes.Add(new PstWriterNode((folder.Nid & ~0x1FU) | 0x06, 0, 0));
+            PstWriterContextResult criteria = PstPropertyContextWriter.Write(_file,
+                new[] { new MapiProperty(0x660B, MapiPropertyType.Integer32, 0) },
+                65001, null, null, null, Report,
+                string.Concat("folder/", FormatId(folder.Nid), "/search-criteria"));
+            _nodes.Add(new PstWriterNode((folder.Nid & ~0x1FU) | 0x07, 0,
+                criteria.DataBid, criteria.SubnodeBid));
+            WriteFolderTable((folder.Nid & ~0x1FU) | 0x10, folder.Nid,
+                Array.Empty<PstWriterTableRow>(), ContentsColumns, "search-contents");
+            return;
+        }
+
+        var hierarchyRows = children.Select(child => new PstWriterTableRow(child.Nid,
+            new[] {
+                new MapiProperty(0x3001, MapiPropertyType.Unicode, child.Name),
+                new MapiProperty(0x3602, MapiPropertyType.Integer32,
+                    child.Items.Count(item => !item.IsAssociated)),
+                new MapiProperty(0x3603, MapiPropertyType.Integer32,
+                    child.Items.Count(item => !item.IsAssociated && IsUnread(item.TableProperties))),
+                new MapiProperty(0x360A, MapiPropertyType.Boolean,
+                    _folders.Values.Any(item => item.ParentNid == child.Nid && item.Nid != child.Nid)),
+                new MapiProperty(0x3613, MapiPropertyType.Unicode, child.ContainerClass)
+            })).ToArray();
+        WriteFolderTable((folder.Nid & ~0x1FU) | 0x0D, folder.Nid,
+            hierarchyRows, HierarchyColumns, "hierarchy");
+        WriteFolderTable((folder.Nid & ~0x1FU) | 0x0E, folder.Nid,
+            normalItems.Select(item => new PstWriterTableRow(item.Nid,
+                SelectTableProperties(item.TableProperties, ContentsColumns))),
+            ContentsColumns, "contents");
+        WriteFolderTable((folder.Nid & ~0x1FU) | 0x0F, folder.Nid,
+            associatedItems.Select(item => new PstWriterTableRow(item.Nid,
+                SelectTableProperties(item.TableProperties, AssociatedColumns))),
+            AssociatedColumns, "associated");
+    }
+
+    private void WriteFolderTable(uint nid, uint parentNid,
+        IEnumerable<PstWriterTableRow> rows, IReadOnlyList<MapiProperty> columns, string kind) {
+        PstWriterContextResult table = PstTableContextWriter.Write(_file, rows, 65001,
+            columns, Report, string.Concat("folder/", FormatId(parentNid), "/", kind));
+        // The owning folder relationship is represented by the folder PC and
+        // hierarchy table. Outlook writes top-level table-context NBT entries
+        // with a zero parent NID.
+        _nodes.Add(new PstWriterNode(nid, 0, table.DataBid, table.SubnodeBid));
+    }
+
+    private void WriteTemplateTable(uint nid, IReadOnlyList<MapiProperty> columns, string location) {
+        PstWriterContextResult table = PstTableContextWriter.Write(_file,
+            Array.Empty<PstWriterTableRow>(), 65001, columns, Report, location);
+        _nodes.Add(new PstWriterNode(nid, 0, table.DataBid, table.SubnodeBid));
+    }
+
+    private byte[] CreateEntryId(uint nid) {
+        var bytes = new byte[24];
+        Buffer.BlockCopy(_providerUid.ToByteArray(), 0, bytes, 4, 16);
+        PstBinary.WriteUInt32(bytes, 20, nid);
+        return bytes;
+    }
+
+    private static IReadOnlyList<MapiProperty> SelectTableProperties(
+        IEnumerable<MapiProperty> properties, IReadOnlyList<MapiProperty> columns) {
+        var ids = new HashSet<ushort>(columns.Select(item => item.PropertyId));
+        return properties.Where(item => ids.Contains(item.PropertyId)).ToArray();
+    }
+
+    private static bool IsUnread(IEnumerable<MapiProperty> properties) {
+        MapiProperty? flags = properties.LastOrDefault(item => item.PropertyId == 0x0E07);
+        return !(flags?.Value is int value) || (value & 1) == 0;
+    }
+
+    private static MapiProperty Column(ushort id, MapiPropertyType type) =>
+        new MapiProperty(id, type, null);
+}

--- a/OfficeIMO.Email.Store/Pst/Writing/PstStoreWriterCore.cs
+++ b/OfficeIMO.Email.Store/Pst/Writing/PstStoreWriterCore.cs
@@ -1,0 +1,192 @@
+using OfficeIMO.Email;
+
+namespace OfficeIMO.Email.Store;
+
+internal sealed partial class PstStoreWriterCore : IDisposable {
+    private const uint RootFolderNid = 0x122;
+    private const uint IpmSubtreeNid = 0x8022;
+    private const uint SearchRootNid = 0x8042;
+    private const uint DeletedItemsNid = 0x8062;
+    private const uint SpamSearchFolderNid = 0x2223;
+
+    private readonly string _destinationPath;
+    private readonly string _temporaryPath;
+    private readonly EmailStorePstWriterOptions _options;
+    private readonly PstWriterFile _file;
+    private readonly Guid _providerUid = Guid.NewGuid();
+    private readonly PstNamedPropertyWriter _namedProperties = new PstNamedPropertyWriter();
+    private readonly List<PstWriterNode> _nodes = new List<PstWriterNode>();
+    private readonly Dictionary<uint, FolderState> _folders = new Dictionary<uint, FolderState>();
+    private readonly List<EmailStoreDiagnostic> _diagnostics = new List<EmailStoreDiagnostic>();
+    private uint _nextFolderIndex = 0x10000;
+    private uint _nextMessageIndex = 0x200000;
+    private int _userFolderCount;
+    private int _itemCount;
+    private bool _completed;
+    private bool _disposed;
+
+    internal PstStoreWriterCore(string destinationPath, EmailStorePstWriterOptions options) {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _destinationPath = Path.GetFullPath(destinationPath);
+        string? directory = Path.GetDirectoryName(_destinationPath);
+        if (string.IsNullOrEmpty(directory)) directory = Directory.GetCurrentDirectory();
+        Directory.CreateDirectory(directory);
+        if (File.Exists(_destinationPath) && !options.OverwriteExisting) {
+            throw new IOException("The destination PST already exists. Enable overwrite to replace it.");
+        }
+        _temporaryPath = Path.Combine(directory,
+            string.Concat(".", Path.GetFileName(_destinationPath), ".",
+                Guid.NewGuid().ToString("N"), ".tmp"));
+        _file = new PstWriterFile(_temporaryPath);
+        AddSystemFolder(RootFolderNid, RootFolderNid, "Root - Mailbox", null, false);
+        AddSystemFolder(IpmSubtreeNid, RootFolderNid, "Top of Personal Folders", "IPF.Note", false);
+        AddSystemFolder(SearchRootNid, RootFolderNid, "Finder", null, false);
+        AddSystemFolder(DeletedItemsNid, IpmSubtreeNid, "Deleted Items", "IPF.Note", false);
+        AddSystemFolder(SpamSearchFolderNid, RootFolderNid, "SPAM Search Folder 2", "IPF.Note", true);
+    }
+
+    internal string RootFolderId => FormatId(IpmSubtreeNid);
+    internal string DeletedItemsFolderId => FormatId(DeletedItemsNid);
+    internal string SearchRootFolderId => FormatId(SearchRootNid);
+
+    internal string AddFolder(string name, string? parentFolderId, string? containerClass) {
+        ThrowIfUnavailable();
+        if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("A folder name is required.", nameof(name));
+        if (_userFolderCount >= _options.MaxFolderCount) {
+            throw new InvalidOperationException("The configured PST folder limit has been reached.");
+        }
+        uint parentNid = parentFolderId == null ? IpmSubtreeNid : ParseFolderId(parentFolderId);
+        uint nid = AllocateNid(ref _nextFolderIndex, 0x02);
+        _folders.Add(nid, new FolderState(nid, parentNid, name.Trim(), containerClass, false));
+        _userFolderCount++;
+        return FormatId(nid);
+    }
+
+    internal string AddItem(string folderId, EmailDocument document, bool isAssociated,
+        CancellationToken cancellationToken) {
+        ThrowIfUnavailable();
+        cancellationToken.ThrowIfCancellationRequested();
+        if (_itemCount >= _options.MaxItemCount) {
+            throw new InvalidOperationException("The configured PST item limit has been reached.");
+        }
+        uint folderNid = ParseFolderId(folderId);
+        uint itemNid = AllocateNid(ref _nextMessageIndex, isAssociated ? 0x08U : 0x04U);
+        WrittenMessage message = WriteMessage(document, itemNid, depth: 0, cancellationToken);
+        _nodes.Add(new PstWriterNode(itemNid, folderNid, message.Context.DataBid,
+            message.Context.SubnodeBid));
+        _folders[folderNid].Items.Add(new ItemState(itemNid, isAssociated, message.TableProperties));
+        _itemCount++;
+        return FormatId(itemNid);
+    }
+
+    internal EmailStorePstWriteReport Complete(CancellationToken cancellationToken) {
+        ThrowIfUnavailable();
+        cancellationToken.ThrowIfCancellationRequested();
+        WriteStoreStructure(cancellationToken);
+        if (_options.FailOnDataLoss && _diagnostics.Any(item =>
+            item.Severity != EmailStoreDiagnosticSeverity.Information)) {
+            throw new InvalidOperationException(
+                "PST creation produced fidelity diagnostics and FailOnDataLoss is enabled.");
+        }
+        PstWriterTreeRoot nbt = _file.WriteNodeTree(_nodes);
+        PstWriterTreeRoot bbt = _file.WriteBlockTree();
+        _file.FinalizeFile(nbt, bbt, _nodes);
+        _file.Dispose();
+        CommitTemporaryFile();
+        _completed = true;
+        long bytes = new FileInfo(_destinationPath).Length;
+        return new EmailStorePstWriteReport(_destinationPath, _userFolderCount,
+            _itemCount, bytes, _diagnostics.ToArray());
+    }
+
+    public void Dispose() {
+        if (_disposed) return;
+        _disposed = true;
+        _file.Dispose();
+        if (!_completed) TryDelete(_temporaryPath);
+    }
+
+    private void AddSystemFolder(uint nid, uint parentNid, string name,
+        string? containerClass, bool search) =>
+        _folders.Add(nid, new FolderState(nid, parentNid, name, containerClass, search));
+
+    private uint ParseFolderId(string value) {
+        if (value == null || value.Length != 12 ||
+            !value.StartsWith("pst:", StringComparison.OrdinalIgnoreCase) ||
+            !uint.TryParse(value.Substring(4), NumberStyles.HexNumber,
+                CultureInfo.InvariantCulture, out uint nid) || !_folders.ContainsKey(nid)) {
+            throw new ArgumentException("The folder identifier does not belong to this PST writer.", nameof(value));
+        }
+        return nid;
+    }
+
+    private void CommitTemporaryFile() {
+        if (File.Exists(_destinationPath)) {
+            if (!_options.OverwriteExisting) throw new IOException("The destination PST already exists.");
+            File.Replace(_temporaryPath, _destinationPath, null);
+        } else {
+            File.Move(_temporaryPath, _destinationPath);
+        }
+    }
+
+    private void ThrowIfUnavailable() {
+        if (_disposed) throw new ObjectDisposedException(nameof(PstStoreWriterCore));
+        if (_completed) throw new InvalidOperationException("The PST writer has already completed.");
+    }
+
+    private void Report(EmailStoreDiagnostic diagnostic) => _diagnostics.Add(diagnostic);
+
+    private static uint AllocateNid(ref uint nextIndex, uint type) {
+        uint value = checked(nextIndex | type);
+        nextIndex = checked(nextIndex + 0x20);
+        return value;
+    }
+
+    private static string FormatId(uint nid) =>
+        string.Concat("pst:", nid.ToString("X8", CultureInfo.InvariantCulture));
+
+    private static void TryDelete(string path) {
+        try { if (File.Exists(path)) File.Delete(path); }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+
+    private sealed class FolderState {
+        internal FolderState(uint nid, uint parentNid, string name,
+            string? containerClass, bool isSearchFolder) {
+            Nid = nid;
+            ParentNid = parentNid;
+            Name = name;
+            ContainerClass = containerClass;
+            IsSearchFolder = isSearchFolder;
+        }
+        internal uint Nid { get; }
+        internal uint ParentNid { get; }
+        internal string Name { get; }
+        internal string? ContainerClass { get; }
+        internal bool IsSearchFolder { get; }
+        internal List<ItemState> Items { get; } = new List<ItemState>();
+    }
+
+    private sealed class ItemState {
+        internal ItemState(uint nid, bool isAssociated,
+            IReadOnlyList<MapiProperty> tableProperties) {
+            Nid = nid;
+            IsAssociated = isAssociated;
+            TableProperties = tableProperties;
+        }
+        internal uint Nid { get; }
+        internal bool IsAssociated { get; }
+        internal IReadOnlyList<MapiProperty> TableProperties { get; }
+    }
+
+    private readonly struct WrittenMessage {
+        internal WrittenMessage(PstWriterContextResult context,
+            IReadOnlyList<MapiProperty> tableProperties) {
+            Context = context;
+            TableProperties = tableProperties;
+        }
+        internal PstWriterContextResult Context { get; }
+        internal IReadOnlyList<MapiProperty> TableProperties { get; }
+    }
+}

--- a/OfficeIMO.Email.Store/Pst/Writing/PstTableContextWriter.cs
+++ b/OfficeIMO.Email.Store/Pst/Writing/PstTableContextWriter.cs
@@ -1,0 +1,297 @@
+using OfficeIMO.Email;
+
+namespace OfficeIMO.Email.Store;
+
+internal sealed class PstWriterTableRow {
+    internal PstWriterTableRow(uint rowId, IEnumerable<MapiProperty> properties) {
+        RowId = rowId;
+        Properties = properties == null
+            ? Array.Empty<MapiProperty>()
+            : properties.Where(item => item != null).ToArray();
+    }
+
+    internal uint RowId { get; }
+    internal IReadOnlyList<MapiProperty> Properties { get; }
+}
+
+internal static class PstTableContextWriter {
+    private const int MaximumBlockPayload = 8176;
+    private const int PreferredHeapValueLimit = 3580;
+
+    internal static PstWriterContextResult Write(PstWriterFile file,
+        IEnumerable<PstWriterTableRow> sourceRows, int codePage,
+        IEnumerable<MapiProperty>? requiredColumns,
+        Action<EmailStoreDiagnostic>? reportDiagnostic, string location) {
+        PstWriterTableRow[] rows = sourceRows == null
+            ? Array.Empty<PstWriterTableRow>()
+            : sourceRows.GroupBy(item => item.RowId)
+                .Select(group => group.Last())
+                .OrderBy(item => item.RowId)
+                .ToArray();
+        Column[] columns = CreateColumns(rows, requiredColumns);
+        if (columns.Length > byte.MaxValue) {
+            throw new NotSupportedException("A PST Table Context cannot contain more than 255 columns.");
+        }
+
+        AssignLayout(columns, out int dataEnd, out int twoByteEnd, out int oneByteEnd);
+        int bitmapBytes = (columns.Length + 7) / 8;
+        int rowSize = checked(oneByteEnd + bitmapBytes);
+        if (rowSize <= 0 || rowSize > MaximumBlockPayload) {
+            throw new NotSupportedException("A PST table row exceeds the supported Unicode block size.");
+        }
+
+        var heap = new PstWriterHeap(0x7C);
+        var info = new byte[22 + columns.Length * 8];
+        uint infoHid = heap.Add(info);
+        var rowIndexHeader = new byte[8];
+        uint rowIndexHeaderHid = heap.Add(rowIndexHeader);
+        var rowIndexRecords = new byte[rows.Length * 8];
+
+        var subnodes = new List<PstWriterSubnode>();
+        const uint rowMatrixNid = 0x3F;
+        uint nextLocalIndex = 2;
+        var encodedRows = new List<EncodedRow>(rows.Length);
+        for (int rowIndex = 0; rowIndex < rows.Length; rowIndex++) {
+            PstWriterTableRow row = rows[rowIndex];
+            var values = row.Properties
+                .GroupBy(item => item.PropertyId)
+                .ToDictionary(group => group.Key, group => group.Last());
+            values[0x67F2] = new MapiProperty(0x67F2, MapiPropertyType.Integer32,
+                unchecked((int)row.RowId));
+            if (!values.ContainsKey(0x67F3)) {
+                values[0x67F3] = new MapiProperty(0x67F3, MapiPropertyType.Integer32, 0);
+            }
+            var encoded = new EncodedRow(row.RowId, columns.Length);
+            foreach (Column column in columns) {
+                if (!values.TryGetValue(column.PropertyId, out MapiProperty? property)) continue;
+                try {
+                    encoded.Values[column.BitIndex] = EncodeCell(property, column, codePage);
+                } catch (Exception exception) when (exception is ArgumentException ||
+                    exception is InvalidCastException || exception is FormatException ||
+                    exception is OverflowException || exception is NotSupportedException) {
+                    reportDiagnostic?.Invoke(new EmailStoreDiagnostic(
+                        "EMAIL_STORE_PST_WRITE_TABLE_CELL_OMITTED",
+                        string.Concat("Table property 0x", property.PropertyTag.ToString("X8", CultureInfo.InvariantCulture),
+                            " was omitted: ", exception.Message),
+                        EmailStoreDiagnosticSeverity.Warning, location));
+                }
+            }
+            encodedRows.Add(encoded);
+            PstBinary.WriteUInt32(rowIndexRecords, rowIndex * 8, row.RowId);
+            PstBinary.WriteUInt32(rowIndexRecords, rowIndex * 8 + 4, checked((uint)rowIndex));
+        }
+
+        List<EncodedCell> variableCells = encodedRows.SelectMany(item => item.Values)
+            .Where(item => item != null && item.Bytes != null && item.Bytes.Length > 0)
+            .Select(item => item!)
+            .ToList();
+        foreach (EncodedCell cell in variableCells.Where(item => item.Bytes!.Length > PreferredHeapValueLimit)) {
+            cell.UseSubnode = true;
+        }
+        var matrix = new byte[checked(rows.Length * rowSize)];
+        for (int rowIndex = 0; rowIndex < encodedRows.Count; rowIndex++) {
+            int rowOffset = rowIndex * rowSize;
+            EncodedRow row = encodedRows[rowIndex];
+            foreach (Column column in columns) {
+                EncodedCell? cell = row.Values[column.BitIndex];
+                if (cell == null) continue;
+                int destination = rowOffset + column.DataOffset;
+                if (cell.Bytes != null) {
+                    uint hnid;
+                    if (cell.Bytes.Length == 0) {
+                        hnid = 0;
+                    } else if (cell.UseSubnode) {
+                        uint nid = checked((nextLocalIndex++ << 5) | 0x1FU);
+                        subnodes.Add(new PstWriterSubnode(nid, file.WriteDataTree(cell.Bytes)));
+                        hnid = nid;
+                    } else {
+                        hnid = heap.Add(cell.Bytes);
+                    }
+                    PstBinary.WriteUInt32(matrix, destination, hnid);
+                } else {
+                    Buffer.BlockCopy(cell.InlineBytes!, 0, matrix, destination, cell.InlineBytes!.Length);
+                }
+                int bitmapOffset = rowOffset + oneByteEnd + column.BitIndex / 8;
+                matrix[bitmapOffset] |= checked((byte)(1 << (7 - column.BitIndex % 8)));
+            }
+        }
+
+        ulong rowMatrixBid = 0;
+        if (rows.Length > 0) {
+            IReadOnlyList<byte[]> blocks = PartitionRows(matrix, rowSize, rows.Length);
+            rowMatrixBid = file.WriteDataTreeBlocks(blocks);
+            subnodes.Add(new PstWriterSubnode(rowMatrixNid, rowMatrixBid));
+        }
+
+        info[0] = 0x7C;
+        info[1] = checked((byte)columns.Length);
+        PstBinary.WriteUInt16(info, 2, dataEnd);
+        PstBinary.WriteUInt16(info, 4, twoByteEnd);
+        PstBinary.WriteUInt16(info, 6, oneByteEnd);
+        PstBinary.WriteUInt16(info, 8, rowSize);
+        PstBinary.WriteUInt32(info, 10, rowIndexHeaderHid);
+        PstBinary.WriteUInt32(info, 14, rows.Length == 0 ? 0 : rowMatrixNid);
+        PstBinary.WriteUInt32(info, 18, 0);
+        for (int index = 0; index < columns.Length; index++) {
+            Column column = columns[index];
+            int offset = 22 + index * 8;
+            PstBinary.WriteUInt32(info, offset,
+                ((uint)column.PropertyId << 16) | (ushort)column.PropertyType);
+            PstBinary.WriteUInt16(info, offset + 4, column.DataOffset);
+            info[offset + 6] = checked((byte)column.Size);
+            info[offset + 7] = checked((byte)column.BitIndex);
+        }
+
+        PstWriterBth.Complete(heap, rowIndexHeader, 4, 4, rowIndexRecords);
+        ulong dataBid = file.WriteDataTreeBlocks(heap.Build(infoHid));
+        ulong subnodeBid = PstWriterSubnodeTree.Write(file, subnodes);
+        return new PstWriterContextResult(dataBid, subnodeBid);
+    }
+
+    private static Column[] CreateColumns(IReadOnlyList<PstWriterTableRow> rows,
+        IEnumerable<MapiProperty>? requiredColumns) {
+        var types = new Dictionary<ushort, MapiPropertyType> {
+            [0x67F2] = MapiPropertyType.Integer32,
+            [0x67F3] = MapiPropertyType.Integer32
+        };
+        if (requiredColumns != null) {
+            foreach (MapiProperty property in requiredColumns) types[property.PropertyId] = property.PropertyType;
+        }
+        foreach (PstWriterTableRow row in rows) {
+            foreach (MapiProperty property in row.Properties) {
+                if (!types.ContainsKey(property.PropertyId)) types.Add(property.PropertyId, property.PropertyType);
+            }
+        }
+        Column[] columns = types.OrderBy(item => ((uint)item.Key << 16) | (ushort)item.Value)
+            .Select(item => new Column(item.Key, item.Value, GetTableWidth(item.Value))).ToArray();
+        int nextBit = 2;
+        foreach (Column column in columns) {
+            column.BitIndex = column.PropertyId == 0x67F2 ? 0 : column.PropertyId == 0x67F3 ? 1 : nextBit++;
+        }
+        return columns;
+    }
+
+    private static void AssignLayout(Column[] columns, out int dataEnd,
+        out int twoByteEnd, out int oneByteEnd) {
+        Column rowId = columns.Single(item => item.PropertyId == 0x67F2);
+        Column rowVersion = columns.Single(item => item.PropertyId == 0x67F3);
+        rowId.DataOffset = 0;
+        rowVersion.DataOffset = 4;
+        int cursor = 8;
+        foreach (Column column in columns.Where(item => item != rowId && item != rowVersion && item.Size >= 4)
+            .OrderByDescending(item => item.Size).ThenBy(item => item.PropertyId)) {
+            int alignment = column.Size >= 8 ? 8 : 4;
+            cursor = (cursor + alignment - 1) & ~(alignment - 1);
+            column.DataOffset = cursor;
+            cursor += column.Size;
+        }
+        dataEnd = cursor;
+        foreach (Column column in columns.Where(item => item.Size == 2).OrderBy(item => item.PropertyId)) {
+            cursor = (cursor + 1) & ~1;
+            column.DataOffset = cursor;
+            cursor += 2;
+        }
+        twoByteEnd = cursor;
+        foreach (Column column in columns.Where(item => item.Size == 1).OrderBy(item => item.PropertyId)) {
+            column.DataOffset = cursor++;
+        }
+        oneByteEnd = cursor;
+    }
+
+    private static EncodedCell EncodeCell(MapiProperty property, Column column, int codePage) {
+        switch (column.PropertyType) {
+            case MapiPropertyType.Integer16:
+                return EncodedCell.Inline(BitConverter.GetBytes(
+                    Convert.ToInt16(property.Value ?? 0, CultureInfo.InvariantCulture)));
+            case MapiPropertyType.Integer32:
+            case MapiPropertyType.ErrorCode:
+                return EncodedCell.Inline(BitConverter.GetBytes(
+                    Convert.ToInt32(property.Value ?? 0, CultureInfo.InvariantCulture)));
+            case MapiPropertyType.Floating32:
+                return EncodedCell.Inline(BitConverter.GetBytes(
+                    Convert.ToSingle(property.Value ?? 0F, CultureInfo.InvariantCulture)));
+            case MapiPropertyType.Boolean:
+                return EncodedCell.Inline(new[] {
+                    Convert.ToBoolean(property.Value ?? false, CultureInfo.InvariantCulture) ? (byte)1 : (byte)0 });
+            case MapiPropertyType.Integer64:
+            case MapiPropertyType.Currency:
+                return EncodedCell.Inline(BitConverter.GetBytes(
+                    Convert.ToInt64(property.Value ?? 0L, CultureInfo.InvariantCulture)));
+            case MapiPropertyType.Floating64:
+            case MapiPropertyType.FloatingTime:
+                return EncodedCell.Inline(BitConverter.GetBytes(
+                    Convert.ToDouble(property.Value ?? 0D, CultureInfo.InvariantCulture)));
+            case MapiPropertyType.Time:
+                return EncodedCell.Inline(PstPropertyValueWriter.EncodeVariable(property, codePage));
+            default:
+                return EncodedCell.Variable(PstPropertyValueWriter.EncodeVariable(property, codePage));
+        }
+    }
+
+    private static int GetTableWidth(MapiPropertyType type) {
+        switch (type) {
+            case MapiPropertyType.Boolean: return 1;
+            case MapiPropertyType.Integer16: return 2;
+            case MapiPropertyType.Integer32:
+            case MapiPropertyType.ErrorCode:
+            case MapiPropertyType.Floating32: return 4;
+            case MapiPropertyType.Integer64:
+            case MapiPropertyType.Currency:
+            case MapiPropertyType.Floating64:
+            case MapiPropertyType.FloatingTime:
+            case MapiPropertyType.Time: return 8;
+            default: return 4;
+        }
+    }
+
+    private static IReadOnlyList<byte[]> PartitionRows(byte[] matrix, int rowSize, int rowCount) {
+        int rowsPerFullBlock = MaximumBlockPayload / rowSize;
+        if (rowsPerFullBlock <= 0) throw new NotSupportedException("A PST row is larger than one data block.");
+        var blocks = new List<byte[]>();
+        int rowIndex = 0;
+        while (rowIndex < rowCount) {
+            int count = Math.Min(rowsPerFullBlock, rowCount - rowIndex);
+            bool isLast = rowIndex + count == rowCount;
+            int used = count * rowSize;
+            var block = new byte[isLast ? used : MaximumBlockPayload];
+            Buffer.BlockCopy(matrix, rowIndex * rowSize, block, 0, used);
+            blocks.Add(block);
+            rowIndex += count;
+        }
+        return blocks;
+    }
+
+    private sealed class Column {
+        internal Column(ushort propertyId, MapiPropertyType propertyType, int size) {
+            PropertyId = propertyId;
+            PropertyType = propertyType;
+            Size = size;
+        }
+        internal ushort PropertyId { get; }
+        internal MapiPropertyType PropertyType { get; }
+        internal int Size { get; }
+        internal int DataOffset { get; set; }
+        internal int BitIndex { get; set; }
+    }
+
+    private sealed class EncodedRow {
+        internal EncodedRow(uint rowId, int columns) {
+            RowId = rowId;
+            Values = new EncodedCell?[columns];
+        }
+        internal uint RowId { get; }
+        internal EncodedCell?[] Values { get; }
+    }
+
+    private sealed class EncodedCell {
+        private EncodedCell(byte[]? inlineBytes, byte[]? bytes) {
+            InlineBytes = inlineBytes;
+            Bytes = bytes;
+        }
+        internal byte[]? InlineBytes { get; }
+        internal byte[]? Bytes { get; }
+        internal bool UseSubnode { get; set; }
+        internal static EncodedCell Inline(byte[] bytes) => new EncodedCell(bytes, null);
+        internal static EncodedCell Variable(byte[] bytes) => new EncodedCell(null, bytes);
+    }
+}

--- a/OfficeIMO.Email.Store/Pst/Writing/PstWriterBth.cs
+++ b/OfficeIMO.Email.Store/Pst/Writing/PstWriterBth.cs
@@ -1,0 +1,70 @@
+namespace OfficeIMO.Email.Store;
+
+internal static class PstWriterBth {
+    private const int MaximumAllocationBytes = 8000;
+
+    internal static void Complete(PstWriterHeap heap, byte[] header,
+        int keySize, int valueSize, byte[] leafRecords) {
+        if (heap == null) throw new ArgumentNullException(nameof(heap));
+        if (header == null || header.Length < 8) throw new ArgumentException("A BTH header requires eight bytes.", nameof(header));
+        int recordSize = checked(keySize + valueSize);
+        if (recordSize <= 0 || leafRecords.Length % recordSize != 0) {
+            throw new ArgumentException("BTH leaf records are not aligned to their declared size.", nameof(leafRecords));
+        }
+        header[0] = 0xB5;
+        header[1] = checked((byte)keySize);
+        header[2] = checked((byte)valueSize);
+        if (leafRecords.Length == 0) {
+            header[3] = 0;
+            PstBinary.WriteUInt32(header, 4, 0);
+            return;
+        }
+
+        int recordsPerLeaf = Math.Max(1, MaximumAllocationBytes / recordSize);
+        var level = new List<BthReference>();
+        int recordCount = leafRecords.Length / recordSize;
+        for (int recordIndex = 0; recordIndex < recordCount; recordIndex += recordsPerLeaf) {
+            int count = Math.Min(recordsPerLeaf, recordCount - recordIndex);
+            var allocation = new byte[count * recordSize];
+            Buffer.BlockCopy(leafRecords, recordIndex * recordSize,
+                allocation, 0, allocation.Length);
+            uint hid = heap.Add(allocation);
+            var firstKey = new byte[keySize];
+            Buffer.BlockCopy(allocation, 0, firstKey, 0, keySize);
+            level.Add(new BthReference(firstKey, hid));
+        }
+
+        int indexLevels = 0;
+        int indexRecordSize = checked(keySize + 4);
+        int recordsPerIndex = Math.Max(1, MaximumAllocationBytes / indexRecordSize);
+        while (level.Count > 1) {
+            var parent = new List<BthReference>();
+            for (int offset = 0; offset < level.Count; offset += recordsPerIndex) {
+                int count = Math.Min(recordsPerIndex, level.Count - offset);
+                var allocation = new byte[count * indexRecordSize];
+                for (int index = 0; index < count; index++) {
+                    BthReference child = level[offset + index];
+                    int target = index * indexRecordSize;
+                    Buffer.BlockCopy(child.FirstKey, 0, allocation, target, keySize);
+                    PstBinary.WriteUInt32(allocation, target + keySize, child.Hid);
+                }
+                uint hid = heap.Add(allocation);
+                parent.Add(new BthReference(level[offset].FirstKey, hid));
+            }
+            level = parent;
+            indexLevels++;
+            if (indexLevels > byte.MaxValue) throw new NotSupportedException("The PST BTH is too deep.");
+        }
+        header[3] = checked((byte)indexLevels);
+        PstBinary.WriteUInt32(header, 4, level[0].Hid);
+    }
+
+    private sealed class BthReference {
+        internal BthReference(byte[] firstKey, uint hid) {
+            FirstKey = firstKey;
+            Hid = hid;
+        }
+        internal byte[] FirstKey { get; }
+        internal uint Hid { get; }
+    }
+}

--- a/OfficeIMO.Email.Store/Pst/Writing/PstWriterFile.cs
+++ b/OfficeIMO.Email.Store/Pst/Writing/PstWriterFile.cs
@@ -1,0 +1,446 @@
+namespace OfficeIMO.Email.Store;
+
+internal sealed class PstWriterFile : IDisposable {
+    private const int HeaderLength = 564;
+    private const int PageSize = 512;
+    private const int PageDataLength = 496;
+    private const int BlockTrailerLength = 16;
+    private const int MaximumBlockPayload = 8176;
+    private const long FirstAmapOffset = 0x4400;
+    private const long FirstPmapOffset = 0x4600;
+    private const long FirstDataOffset = 0x4800;
+    private const long AmapInterval = 0x3E000;
+    private const long PmapInterval = AmapInterval * 8;
+
+    private readonly FileStream _stream;
+    private readonly List<PstWriterBlock> _blocks = new List<PstWriterBlock>();
+    private readonly List<PstWriterAllocation> _allocations = new List<PstWriterAllocation>();
+    private long _nextOffset = FirstDataOffset;
+    private ulong _nextBlockBid = 0x100;
+    private ulong _nextPageBid = 0x100;
+    private bool _finalized;
+
+    internal PstWriterFile(string path) {
+        _stream = new FileStream(path, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.Read,
+            128 * 1024, FileOptions.SequentialScan);
+        _stream.SetLength(FirstDataOffset);
+        RegisterMapPagesThrough(FirstDataOffset);
+    }
+
+    internal IReadOnlyList<PstWriterBlock> Blocks => _blocks;
+
+    internal ulong NextBlockBid => _nextBlockBid;
+
+    internal ulong NextPageBid => _nextPageBid;
+
+    internal long Length => _stream.Length;
+
+    internal ulong WriteDataTree(byte[] bytes) {
+        if (bytes == null) throw new ArgumentNullException(nameof(bytes));
+        using (var input = new MemoryStream(bytes, writable: false)) return WriteDataTree(input, bytes.LongLength);
+    }
+
+    internal ulong WriteDataTree(Stream input, long length) {
+        if (input == null) throw new ArgumentNullException(nameof(input));
+        if (!input.CanRead) throw new ArgumentException("The PST data source must be readable.", nameof(input));
+        if (length < 0 || length > uint.MaxValue) {
+            throw new NotSupportedException("One PST data tree cannot exceed 4 GiB.");
+        }
+        var leaves = new List<DataTreeBlockReference>();
+        long remaining = length;
+        if (remaining == 0) return WriteBlock(Array.Empty<byte>(), isInternal: false).Bid;
+        var buffer = new byte[MaximumBlockPayload];
+        while (remaining > 0) {
+            int required = checked((int)Math.Min(buffer.Length, remaining));
+            int total = 0;
+            while (total < required) {
+                int read = input.Read(buffer, total, required - total);
+                if (read == 0) throw new EndOfStreamException("The PST data source ended before its declared length.");
+                total += read;
+            }
+            var payload = new byte[total];
+            Buffer.BlockCopy(buffer, 0, payload, 0, total);
+            leaves.Add(new DataTreeBlockReference(
+                WriteBlock(payload, isInternal: false).Bid, checked((uint)payload.Length)));
+            remaining -= total;
+        }
+        return WriteDataTreeIndex(leaves);
+    }
+
+    internal ulong WriteDataTree(Stream input, out long length) {
+        if (input == null) throw new ArgumentNullException(nameof(input));
+        if (!input.CanRead) throw new ArgumentException("The PST data source must be readable.", nameof(input));
+        var leaves = new List<DataTreeBlockReference>();
+        var buffer = new byte[MaximumBlockPayload];
+        long totalLength = 0;
+        while (true) {
+            int total = 0;
+            while (total < buffer.Length) {
+                int read = input.Read(buffer, total, buffer.Length - total);
+                if (read == 0) break;
+                total += read;
+            }
+            if (total == 0) break;
+            totalLength = checked(totalLength + total);
+            if (totalLength > uint.MaxValue) {
+                throw new NotSupportedException("One PST data tree cannot exceed 4 GiB.");
+            }
+            var payload = new byte[total];
+            Buffer.BlockCopy(buffer, 0, payload, 0, total);
+            leaves.Add(new DataTreeBlockReference(
+                WriteBlock(payload, isInternal: false).Bid, checked((uint)total)));
+            if (total < buffer.Length) break;
+        }
+        length = totalLength;
+        if (leaves.Count == 0) return WriteBlock(Array.Empty<byte>(), isInternal: false).Bid;
+        return WriteDataTreeIndex(leaves);
+    }
+
+    internal ulong WriteDataTreeBlocks(IReadOnlyList<byte[]> blocks) {
+        if (blocks == null) throw new ArgumentNullException(nameof(blocks));
+        if (blocks.Count == 0) return WriteBlock(Array.Empty<byte>(), isInternal: false).Bid;
+        var leaves = new List<DataTreeBlockReference>(blocks.Count);
+        ulong total = 0;
+        foreach (byte[] payload in blocks) {
+            if (payload == null) throw new ArgumentException("A PST data-tree block cannot be null.", nameof(blocks));
+            if (payload.Length > MaximumBlockPayload) {
+                throw new ArgumentOutOfRangeException(nameof(blocks), "A PST data-tree block exceeds 8176 bytes.");
+            }
+            total = checked(total + (uint)payload.Length);
+            if (total > uint.MaxValue) throw new NotSupportedException("One PST data tree cannot exceed 4 GiB.");
+            leaves.Add(new DataTreeBlockReference(
+                WriteBlock(payload, isInternal: false).Bid, checked((uint)payload.Length)));
+        }
+        return WriteDataTreeIndex(leaves);
+    }
+
+    private ulong WriteDataTreeIndex(IReadOnlyList<DataTreeBlockReference> leaves) {
+        if (leaves.Count == 1) return leaves[0].Bid;
+
+        const int childrenPerBlock = (MaximumBlockPayload - 8) / 8;
+        IReadOnlyList<DataTreeBlockReference> current = leaves;
+        int level = 1;
+        while (current.Count > 1) {
+            if (level > 2) throw new NotSupportedException("The PST data tree exceeds the Unicode XBLOCK depth.");
+            var parents = new List<DataTreeBlockReference>((current.Count + childrenPerBlock - 1) / childrenPerBlock);
+            for (int offset = 0; offset < current.Count; offset += childrenPerBlock) {
+                int count = Math.Min(childrenPerBlock, current.Count - offset);
+                var payload = new byte[8 + count * 8];
+                payload[0] = 0x01;
+                payload[1] = checked((byte)level);
+                PstBinary.WriteUInt16(payload, 2, count);
+                uint childLength = 0;
+                for (int index = 0; index < count; index++) {
+                    childLength = checked(childLength + current[offset + index].Length);
+                }
+                PstBinary.WriteUInt32(payload, 4, childLength);
+                for (int index = 0; index < count; index++) {
+                    PstBinary.WriteUInt64(payload, 8 + index * 8, current[offset + index].Bid);
+                }
+                parents.Add(new DataTreeBlockReference(
+                    WriteBlock(payload, isInternal: true).Bid, childLength));
+            }
+            current = parents;
+            level++;
+        }
+        return current[0].Bid;
+    }
+
+    internal ulong WriteInternalBlock(byte[] payload) => WriteBlock(payload, isInternal: true).Bid;
+
+    internal PstWriterTreeRoot WriteNodeTree(IReadOnlyList<PstWriterNode> nodes) {
+        var ordered = nodes.OrderBy(item => item.Nid).ToArray();
+        return WriteBTree(ordered.Length, leafEntrySize: 32, pageType: 0x81,
+            (page, pageOffset, itemIndex) => {
+                PstWriterNode node = ordered[itemIndex];
+                int offset = pageOffset;
+                PstBinary.WriteUInt32(page, offset, node.Nid);
+                PstBinary.WriteUInt64(page, offset + 8, node.DataBid);
+                PstBinary.WriteUInt64(page, offset + 16, node.SubnodeBid);
+                PstBinary.WriteUInt32(page, offset + 24, node.ParentNid);
+                return node.Nid;
+            });
+    }
+
+    internal PstWriterTreeRoot WriteBlockTree() {
+        PstWriterBlock[] ordered = _blocks.OrderBy(item => PstBinary.NormalizeBid(item.Bid)).ToArray();
+        return WriteBTree(ordered.Length, leafEntrySize: 24, pageType: 0x80,
+            (page, pageOffset, itemIndex) => {
+                PstWriterBlock block = ordered[itemIndex];
+                PstBinary.WriteUInt64(page, pageOffset, block.Bid);
+                PstBinary.WriteUInt64(page, pageOffset + 8, checked((ulong)block.Offset));
+                PstBinary.WriteUInt16(page, pageOffset + 16, block.Length);
+                PstBinary.WriteUInt16(page, pageOffset + 18, 1);
+                return PstBinary.NormalizeBid(block.Bid);
+            });
+    }
+
+    internal void FinalizeFile(PstWriterTreeRoot nbt, PstWriterTreeRoot bbt,
+        IReadOnlyCollection<PstWriterNode> nodes) {
+        if (_finalized) throw new InvalidOperationException("The PST file has already been finalized.");
+        long dataPosition = Math.Max(_nextOffset, FirstDataOffset);
+        long coverageIndex = (dataPosition - 1 - FirstAmapOffset) / AmapInterval;
+        long finalLength = checked(FirstAmapOffset + (coverageIndex + 1) * AmapInterval);
+        _stream.SetLength(finalLength);
+        RegisterMapPagesThrough(finalLength);
+        long freeBytes = WriteAllocationMaps(finalLength);
+        WriteDensityListPage();
+        WriteHeader(finalLength, freeBytes, nbt, bbt, nodes);
+        _stream.Flush(flushToDisk: true);
+        _finalized = true;
+    }
+
+    public void Dispose() => _stream.Dispose();
+
+    private PstWriterBlock WriteBlock(byte[] payload, bool isInternal) {
+        if (payload.Length > MaximumBlockPayload) {
+            throw new ArgumentOutOfRangeException(nameof(payload), "A PST block payload exceeds 8176 bytes.");
+        }
+        int allocationLength = PstBinary.Align(payload.Length + BlockTrailerLength, 64);
+        long offset = Allocate(allocationLength, alignment: 64);
+        ulong bid = _nextBlockBid | (isInternal ? 0x02UL : 0UL);
+        _nextBlockBid = checked(_nextBlockBid + 4);
+        var allocation = new byte[allocationLength];
+        Buffer.BlockCopy(payload, 0, allocation, 0, payload.Length);
+        int trailerOffset = allocationLength - BlockTrailerLength;
+        PstBinary.WriteUInt16(allocation, trailerOffset, payload.Length);
+        PstBinary.WriteUInt16(allocation, trailerOffset + 2, PstSignature.Compute(offset, bid));
+        PstBinary.WriteUInt32(allocation, trailerOffset + 4, PstCrc32.Compute(payload));
+        PstBinary.WriteUInt64(allocation, trailerOffset + 8, bid);
+        WriteAt(offset, allocation);
+        var block = new PstWriterBlock(bid, offset, payload.Length);
+        _blocks.Add(block);
+        return block;
+    }
+
+    private PstWriterTreeRoot WriteBTree(int itemCount, int leafEntrySize, byte pageType,
+        Func<byte[], int, int, ulong> writeLeafEntry) {
+        int leafCapacity = PageDataLength / leafEntrySize;
+        var level = new List<PstWriterPageReference>();
+        if (itemCount == 0) {
+            level.Add(WriteBTreePage(Array.Empty<PstWriterPageReference>(), 0, leafEntrySize,
+                pageType, null, 0, writeLeafEntry));
+        } else {
+            for (int itemOffset = 0; itemOffset < itemCount; itemOffset += leafCapacity) {
+                int count = Math.Min(leafCapacity, itemCount - itemOffset);
+                level.Add(WriteBTreePage(Array.Empty<PstWriterPageReference>(), 0, leafEntrySize,
+                    pageType, null, count, (page, offset, localIndex) =>
+                        writeLeafEntry(page, offset, itemOffset + localIndex)));
+            }
+        }
+
+        int pageLevel = 1;
+        const int indexEntrySize = 24;
+        int indexCapacity = PageDataLength / indexEntrySize;
+        while (level.Count > 1) {
+            var parent = new List<PstWriterPageReference>();
+            for (int offset = 0; offset < level.Count; offset += indexCapacity) {
+                PstWriterPageReference[] children = level.Skip(offset).Take(indexCapacity).ToArray();
+                parent.Add(WriteBTreePage(children, pageLevel, indexEntrySize, pageType,
+                    children, children.Length, null));
+            }
+            level = parent;
+            pageLevel++;
+        }
+        PstWriterPageReference root = level[0];
+        return new PstWriterTreeRoot(root.Bid, root.Offset);
+    }
+
+    private PstWriterPageReference WriteBTreePage(IReadOnlyList<PstWriterPageReference> keySource,
+        int level, int entrySize, byte pageType, IReadOnlyList<PstWriterPageReference>? children,
+        int count, Func<byte[], int, int, ulong>? writeLeafEntry) {
+        var page = new byte[PageSize];
+        ulong firstKey = 0;
+        for (int index = 0; index < count; index++) {
+            int offset = index * entrySize;
+            ulong key;
+            if (level == 0) {
+                key = writeLeafEntry!(page, offset, index);
+            } else {
+                PstWriterPageReference child = children![index];
+                key = child.Key;
+                PstBinary.WriteUInt64(page, offset, key);
+                PstBinary.WriteUInt64(page, offset + 8, child.Bid);
+                PstBinary.WriteUInt64(page, offset + 16, checked((ulong)child.Offset));
+            }
+            if (index == 0) firstKey = key;
+        }
+        page[488] = checked((byte)count);
+        page[489] = checked((byte)(PageDataLength / entrySize));
+        page[490] = checked((byte)entrySize);
+        page[491] = checked((byte)level);
+        long pageOffset = Allocate(PageSize, PageSize);
+        ulong pageBid = _nextPageBid;
+        _nextPageBid = checked(_nextPageBid + 1);
+        WritePageTrailer(page, pageType, pageOffset, pageBid, PstSignature.Compute(pageOffset, pageBid));
+        WriteAt(pageOffset, page);
+        return new PstWriterPageReference(firstKey, pageBid, pageOffset);
+    }
+
+    private long Allocate(int length, int alignment) {
+        long candidate = (_nextOffset + alignment - 1) & ~(alignment - 1L);
+        while (true) {
+            long? reserved = FindReservedPageOverlap(candidate, length);
+            if (!reserved.HasValue) break;
+            candidate = (reserved.Value + PageSize + alignment - 1) & ~(alignment - 1L);
+        }
+        _nextOffset = checked(candidate + length);
+        if (_stream.Length < _nextOffset) _stream.SetLength(_nextOffset);
+        _allocations.Add(new PstWriterAllocation(candidate, length));
+        RegisterMapPagesThrough(_nextOffset);
+        return candidate;
+    }
+
+    private static long? FindReservedPageOverlap(long offset, int length) {
+        long end = checked(offset + length);
+        long firstMapIndex = Math.Max(0, (offset - FirstAmapOffset) / AmapInterval);
+        for (long index = firstMapIndex; ; index++) {
+            long amap = FirstAmapOffset + index * AmapInterval;
+            if (amap >= end) break;
+            if (offset < amap + PageSize && end > amap) return amap;
+        }
+        long firstPmapIndex = Math.Max(0, (offset - FirstPmapOffset) / PmapInterval);
+        for (long index = firstPmapIndex; ; index++) {
+            long pmap = FirstPmapOffset + index * PmapInterval;
+            if (pmap >= end) break;
+            if (offset < pmap + PageSize && end > pmap) return pmap;
+        }
+        return null;
+    }
+
+    private void RegisterMapPagesThrough(long end) {
+        for (long amap = FirstAmapOffset; amap < end; amap += AmapInterval) {
+            RegisterAllocation(amap, PageSize);
+        }
+        for (long pmap = FirstPmapOffset; pmap < end; pmap += PmapInterval) {
+            RegisterAllocation(pmap, PageSize);
+        }
+    }
+
+    private void RegisterAllocation(long offset, int length) {
+        if (_allocations.Any(item => item.Offset == offset && item.Length == length)) return;
+        _allocations.Add(new PstWriterAllocation(offset, length));
+    }
+
+    private long WriteAllocationMaps(long finalLength) {
+        long freeBytes = 0;
+        for (long amap = FirstAmapOffset; amap < finalLength; amap += AmapInterval) {
+            var page = new byte[PageSize];
+            foreach (PstWriterAllocation allocation in _allocations) {
+                MarkRange(page, amap, AmapInterval, allocation.Offset, allocation.Length, 64);
+            }
+            int allocated = CountBits(page, PageDataLength);
+            freeBytes = checked(freeBytes + (PageDataLength * 8L - allocated) * 64L);
+            WritePageTrailer(page, 0x84, amap, checked((ulong)amap), 0);
+            WriteAt(amap, page);
+        }
+        for (long pmap = FirstPmapOffset; pmap < finalLength; pmap += PmapInterval) {
+            var page = new byte[PageSize];
+            for (int index = 0; index < PageDataLength; index++) page[index] = 0xFF;
+            WritePageTrailer(page, 0x83, pmap, checked((ulong)pmap), 0);
+            WriteAt(pmap, page);
+        }
+        return freeBytes;
+    }
+
+    private void WriteDensityListPage() {
+        const long densityListOffset = 0x4200;
+        var page = new byte[PageSize];
+        ulong bid = _nextPageBid;
+        _nextPageBid = checked(_nextPageBid + 1);
+        WritePageTrailer(page, 0x86, densityListOffset, bid,
+            PstSignature.Compute(densityListOffset, bid));
+        WriteAt(densityListOffset, page);
+    }
+
+    private static void MarkRange(byte[] map, long coverageStart, long coverageLength,
+        long allocationOffset, int allocationLength, int unit) {
+        long coverageEnd = coverageStart + coverageLength;
+        long start = Math.Max(coverageStart, allocationOffset);
+        long end = Math.Min(coverageEnd, allocationOffset + allocationLength);
+        if (start >= end) return;
+        int first = checked((int)((start - coverageStart) / unit));
+        int last = checked((int)((end - 1 - coverageStart) / unit));
+        for (int index = first; index <= last && index < PageDataLength * 8; index++) {
+            map[index / 8] |= checked((byte)(1 << (7 - index % 8)));
+        }
+    }
+
+    private static int CountBits(byte[] bytes, int count) {
+        int result = 0;
+        for (int index = 0; index < count; index++) {
+            byte value = bytes[index];
+            while (value != 0) { result += value & 1; value >>= 1; }
+        }
+        return result;
+    }
+
+    private void WriteHeader(long fileLength, long freeBytes, PstWriterTreeRoot nbt,
+        PstWriterTreeRoot bbt, IReadOnlyCollection<PstWriterNode> nodes) {
+        var header = new byte[HeaderLength];
+        PstBinary.WriteUInt32(header, 0, 0x4E444221);
+        PstBinary.WriteUInt16(header, 8, 0x4D53);
+        PstBinary.WriteUInt16(header, 10, 23);
+        PstBinary.WriteUInt16(header, 12, 19);
+        header[14] = 1;
+        header[15] = 1;
+        PstBinary.WriteUInt64(header, 32, _nextPageBid);
+        PstBinary.WriteUInt32(header, 40, 1);
+        WriteNidCounters(header, nodes);
+        PstBinary.WriteUInt64(header, 184, checked((ulong)fileLength));
+        long lastAmap = FirstAmapOffset + ((Math.Max(fileLength - 1, FirstAmapOffset) - FirstAmapOffset) / AmapInterval) * AmapInterval;
+        PstBinary.WriteUInt64(header, 192, checked((ulong)lastAmap));
+        PstBinary.WriteUInt64(header, 200, checked((ulong)freeBytes));
+        PstBinary.WriteUInt64(header, 216, nbt.Bid);
+        PstBinary.WriteUInt64(header, 224, checked((ulong)nbt.Offset));
+        PstBinary.WriteUInt64(header, 232, bbt.Bid);
+        PstBinary.WriteUInt64(header, 240, checked((ulong)bbt.Offset));
+        header[248] = 0x02;
+        for (int index = 256; index < 512; index++) header[index] = 0xFF;
+        header[512] = 0x80;
+        header[513] = 0x00;
+        PstBinary.WriteUInt64(header, 516, _nextBlockBid);
+        PstBinary.WriteUInt32(header, 524, PstCrc32.Compute(header, 8, 516));
+        PstBinary.WriteUInt32(header, 4, PstCrc32.Compute(header, 8, 471));
+        WriteAt(0, header);
+    }
+
+    private static void WriteNidCounters(byte[] header, IReadOnlyCollection<PstWriterNode> nodes) {
+        var starts = Enumerable.Repeat(0x400U, 32).ToArray();
+        starts[2] = 0x400;
+        starts[3] = 0x4000;
+        starts[4] = 0x10000;
+        starts[8] = 0x8000;
+        foreach (PstWriterNode node in nodes) {
+            int type = checked((int)(node.Nid & 0x1F));
+            uint index = node.Nid >> 5;
+            if (index > starts[type]) starts[type] = index;
+        }
+        for (int index = 0; index < starts.Length; index++) {
+            PstBinary.WriteUInt32(header, 44 + index * 4, starts[index]);
+        }
+    }
+
+    private static void WritePageTrailer(byte[] page, byte pageType, long offset, ulong bid, ushort signature) {
+        page[496] = pageType;
+        page[497] = pageType;
+        PstBinary.WriteUInt16(page, 498, signature);
+        PstBinary.WriteUInt32(page, 500, PstCrc32.Compute(page, 0, PageDataLength));
+        PstBinary.WriteUInt64(page, 504, bid);
+    }
+
+    private void WriteAt(long offset, byte[] bytes) {
+        _stream.Position = offset;
+        _stream.Write(bytes, 0, bytes.Length);
+    }
+
+    private readonly struct DataTreeBlockReference {
+        internal DataTreeBlockReference(ulong bid, uint length) {
+            Bid = bid;
+            Length = length;
+        }
+
+        internal ulong Bid { get; }
+        internal uint Length { get; }
+    }
+}

--- a/OfficeIMO.Email.Store/Pst/Writing/PstWriterHeap.cs
+++ b/OfficeIMO.Email.Store/Pst/Writing/PstWriterHeap.cs
@@ -1,0 +1,158 @@
+namespace OfficeIMO.Email.Store;
+
+internal sealed class PstWriterHeap {
+    private const int MaximumBlockPayload = 8176;
+    private const int AllocationIndexBits = 11;
+    private readonly byte _clientSignature;
+    private readonly List<HeapBlock> _blocks = new List<HeapBlock>();
+
+    internal PstWriterHeap(byte clientSignature) {
+        _clientSignature = clientSignature;
+        _blocks.Add(new HeapBlock(0, HeaderSize(0)));
+    }
+
+    internal uint Add(byte[] value) {
+        if (value == null) throw new ArgumentNullException(nameof(value));
+        HeapBlock block = _blocks[_blocks.Count - 1];
+        if (!block.CanAdd(value.Length)) {
+            int index = _blocks.Count;
+            if (index > ushort.MaxValue) throw new NotSupportedException("The PST heap exceeds 65,536 blocks.");
+            block = new HeapBlock(index, HeaderSize(index));
+            _blocks.Add(block);
+            if (!block.CanAdd(value.Length)) {
+                throw new InvalidOperationException(string.Concat(
+                    "A PST heap allocation requires ", value.Length.ToString(CultureInfo.InvariantCulture),
+                    " bytes and cannot fit in one heap block."));
+            }
+        }
+        int allocationIndex = block.Add(value);
+        if (allocationIndex >= (1 << AllocationIndexBits)) {
+            throw new InvalidOperationException("A PST heap block contains too many allocations.");
+        }
+        return checked(((uint)block.Index << (5 + AllocationIndexBits)) |
+            ((uint)(allocationIndex + 1) << 5));
+    }
+
+    internal IReadOnlyList<byte[]> Build(uint userRoot) {
+        var result = new byte[_blocks.Count][];
+        for (int index = 0; index < _blocks.Count; index++) {
+            result[index] = BuildBlock(_blocks[index], index + 1 < _blocks.Count, userRoot);
+        }
+        SetFillLevels(result);
+        return result;
+    }
+
+    private byte[] BuildBlock(HeapBlock block, bool padToFullBlock, uint userRoot) {
+        var allocations = new List<byte[]>(block.Allocations);
+        int dataLength = block.HeaderSize + allocations.Sum(item => item.Length);
+        if (padToFullBlock) {
+            int filler = FindFillerLength(dataLength, allocations.Count);
+            if (filler > 0) {
+                allocations.Add(new byte[filler]);
+                dataLength += filler;
+            }
+        }
+        int mapOffset = (dataLength + 1) & ~1;
+        int mapLength = checked(4 + (allocations.Count + 1) * 2);
+        int usedLength = checked(mapOffset + mapLength);
+        int outputLength = padToFullBlock ? MaximumBlockPayload : usedLength;
+        if (usedLength > outputLength || outputLength > MaximumBlockPayload) {
+            throw new InvalidOperationException("A PST heap block exceeds its data-block capacity.");
+        }
+        var bytes = new byte[outputLength];
+        PstBinary.WriteUInt16(bytes, 0, mapOffset);
+        if (block.Index == 0) {
+            bytes[2] = 0xEC;
+            bytes[3] = _clientSignature;
+            PstBinary.WriteUInt32(bytes, 4, userRoot);
+        }
+        int cursor = block.HeaderSize;
+        PstBinary.WriteUInt16(bytes, mapOffset, allocations.Count);
+        PstBinary.WriteUInt16(bytes, mapOffset + 2, 0);
+        PstBinary.WriteUInt16(bytes, mapOffset + 4, cursor);
+        for (int index = 0; index < allocations.Count; index++) {
+            byte[] allocation = allocations[index];
+            Buffer.BlockCopy(allocation, 0, bytes, cursor, allocation.Length);
+            cursor += allocation.Length;
+            PstBinary.WriteUInt16(bytes, mapOffset + 6 + index * 2, cursor);
+        }
+        return bytes;
+    }
+
+    private static int FindFillerLength(int dataLength, int allocationCount) {
+        int mapLengthWithFiller = checked(4 + (allocationCount + 2) * 2);
+        int maximum = Math.Max(0, MaximumBlockPayload - dataLength - mapLengthWithFiller);
+        for (int filler = maximum; filler >= 0; filler--) {
+            int used = (((dataLength + filler) + 1) & ~1) + mapLengthWithFiller;
+            if (used <= MaximumBlockPayload && MaximumBlockPayload - used <= 63) return filler;
+        }
+        return 0;
+    }
+
+    private static void SetFillLevels(IReadOnlyList<byte[]> blocks) {
+        int firstCount = Math.Min(8, blocks.Count);
+        for (int index = 0; index < firstCount; index++) {
+            SetNibble(blocks[0], 8, index, FillLevel(blocks[index]));
+        }
+        for (int blockIndex = 8; blockIndex < blocks.Count; blockIndex += 128) {
+            int count = Math.Min(128, blocks.Count - blockIndex);
+            for (int index = 0; index < count; index++) {
+                SetNibble(blocks[blockIndex], 2, index, FillLevel(blocks[blockIndex + index]));
+            }
+        }
+    }
+
+    private static int FillLevel(byte[] block) {
+        int free = MaximumBlockPayload - block.Length;
+        if (free < 8) return 0xF;
+        if (free < 16) return 0xE;
+        if (free < 32) return 0xD;
+        if (free < 64) return 0xC;
+        if (free < 128) return 0xB;
+        if (free < 256) return 0xA;
+        if (free < 512) return 0x9;
+        if (free < 768) return 0x8;
+        if (free < 1024) return 0x7;
+        if (free < 1280) return 0x6;
+        if (free < 1536) return 0x5;
+        if (free < 1792) return 0x4;
+        if (free < 2048) return 0x3;
+        if (free < 2560) return 0x2;
+        if (free < 3584) return 0x1;
+        return 0x0;
+    }
+
+    private static void SetNibble(byte[] bytes, int offset, int index, int value) {
+        int byteOffset = offset + index / 2;
+        if ((index & 1) == 0) bytes[byteOffset] = checked((byte)((bytes[byteOffset] & 0xF0) | value));
+        else bytes[byteOffset] = checked((byte)((bytes[byteOffset] & 0x0F) | (value << 4)));
+    }
+
+    private static int HeaderSize(int blockIndex) => blockIndex == 0
+        ? 12
+        : blockIndex >= 8 && (blockIndex - 8) % 128 == 0 ? 66 : 2;
+
+    private sealed class HeapBlock {
+        internal HeapBlock(int index, int headerSize) {
+            Index = index;
+            HeaderSize = headerSize;
+        }
+        internal int Index { get; }
+        internal int HeaderSize { get; }
+        internal List<byte[]> Allocations { get; } = new List<byte[]>();
+
+        internal bool CanAdd(int length) {
+            if (Allocations.Count >= (1 << AllocationIndexBits) - 1) return false;
+            int dataLength = checked(HeaderSize + Allocations.Sum(item => item.Length) + length);
+            int mapOffset = (dataLength + 1) & ~1;
+            int mapLength = checked(4 + (Allocations.Count + 2) * 2);
+            return mapOffset + mapLength <= MaximumBlockPayload;
+        }
+
+        internal int Add(byte[] value) {
+            int index = Allocations.Count;
+            Allocations.Add(value);
+            return index;
+        }
+    }
+}

--- a/OfficeIMO.Email.Store/Pst/Writing/PstWriterStructures.cs
+++ b/OfficeIMO.Email.Store/Pst/Writing/PstWriterStructures.cs
@@ -1,0 +1,59 @@
+namespace OfficeIMO.Email.Store;
+
+internal sealed class PstWriterNode {
+    internal PstWriterNode(uint nid, uint parentNid, ulong dataBid, ulong subnodeBid = 0) {
+        Nid = nid;
+        ParentNid = parentNid;
+        DataBid = dataBid;
+        SubnodeBid = subnodeBid;
+    }
+
+    internal uint Nid { get; }
+    internal uint ParentNid { get; }
+    internal ulong DataBid { get; }
+    internal ulong SubnodeBid { get; }
+}
+
+internal sealed class PstWriterBlock {
+    internal PstWriterBlock(ulong bid, long offset, int length) {
+        Bid = bid;
+        Offset = offset;
+        Length = length;
+    }
+
+    internal ulong Bid { get; }
+    internal long Offset { get; }
+    internal int Length { get; }
+}
+
+internal readonly struct PstWriterPageReference {
+    internal PstWriterPageReference(ulong key, ulong bid, long offset) {
+        Key = key;
+        Bid = bid;
+        Offset = offset;
+    }
+
+    internal ulong Key { get; }
+    internal ulong Bid { get; }
+    internal long Offset { get; }
+}
+
+internal readonly struct PstWriterAllocation {
+    internal PstWriterAllocation(long offset, int length) {
+        Offset = offset;
+        Length = length;
+    }
+
+    internal long Offset { get; }
+    internal int Length { get; }
+}
+
+internal readonly struct PstWriterTreeRoot {
+    internal PstWriterTreeRoot(ulong bid, long offset) {
+        Bid = bid;
+        Offset = offset;
+    }
+
+    internal ulong Bid { get; }
+    internal long Offset { get; }
+}

--- a/OfficeIMO.Email.Store/Pst/Writing/PstWriterSubnodeTree.cs
+++ b/OfficeIMO.Email.Store/Pst/Writing/PstWriterSubnodeTree.cs
@@ -1,0 +1,81 @@
+namespace OfficeIMO.Email.Store;
+
+internal sealed class PstWriterSubnode {
+    internal PstWriterSubnode(uint nid, ulong dataBid, ulong subnodeBid = 0) {
+        Nid = nid;
+        DataBid = dataBid;
+        SubnodeBid = subnodeBid;
+    }
+
+    internal uint Nid { get; }
+    internal ulong DataBid { get; }
+    internal ulong SubnodeBid { get; }
+}
+
+internal static class PstWriterSubnodeTree {
+    private const int MaximumBlockPayload = 8176;
+    private const int HeaderSize = 8;
+    private const int LeafEntrySize = 24;
+    private const int IndexEntrySize = 16;
+
+    internal static ulong Write(PstWriterFile file, IEnumerable<PstWriterSubnode> subnodes) {
+        if (file == null) throw new ArgumentNullException(nameof(file));
+        PstWriterSubnode[] ordered = subnodes
+            .GroupBy(item => item.Nid)
+            .Select(group => group.Last())
+            .OrderBy(item => item.Nid)
+            .ToArray();
+        if (ordered.Length == 0) return 0;
+
+        int leafCapacity = (MaximumBlockPayload - HeaderSize) / LeafEntrySize;
+        var level = new List<SubnodeBlockReference>();
+        for (int offset = 0; offset < ordered.Length; offset += leafCapacity) {
+            int count = Math.Min(leafCapacity, ordered.Length - offset);
+            var payload = new byte[HeaderSize + count * LeafEntrySize];
+            payload[0] = 0x02;
+            payload[1] = 0x00;
+            PstBinary.WriteUInt16(payload, 2, count);
+            for (int index = 0; index < count; index++) {
+                PstWriterSubnode subnode = ordered[offset + index];
+                int entryOffset = HeaderSize + index * LeafEntrySize;
+                PstBinary.WriteUInt32(payload, entryOffset, subnode.Nid);
+                PstBinary.WriteUInt64(payload, entryOffset + 8, subnode.DataBid);
+                PstBinary.WriteUInt64(payload, entryOffset + 16, subnode.SubnodeBid);
+            }
+            level.Add(new SubnodeBlockReference(
+                ordered[offset].Nid, file.WriteInternalBlock(payload)));
+        }
+
+        int indexCapacity = (MaximumBlockPayload - HeaderSize) / IndexEntrySize;
+        while (level.Count > 1) {
+            var parent = new List<SubnodeBlockReference>();
+            for (int offset = 0; offset < level.Count; offset += indexCapacity) {
+                int count = Math.Min(indexCapacity, level.Count - offset);
+                var payload = new byte[HeaderSize + count * IndexEntrySize];
+                payload[0] = 0x02;
+                payload[1] = 0x01;
+                PstBinary.WriteUInt16(payload, 2, count);
+                for (int index = 0; index < count; index++) {
+                    SubnodeBlockReference child = level[offset + index];
+                    int entryOffset = HeaderSize + index * IndexEntrySize;
+                    PstBinary.WriteUInt32(payload, entryOffset, child.FirstNid);
+                    PstBinary.WriteUInt64(payload, entryOffset + 8, child.Bid);
+                }
+                parent.Add(new SubnodeBlockReference(
+                    level[offset].FirstNid, file.WriteInternalBlock(payload)));
+            }
+            level = parent;
+        }
+        return level[0].Bid;
+    }
+
+    private readonly struct SubnodeBlockReference {
+        internal SubnodeBlockReference(uint firstNid, ulong bid) {
+            FirstNid = firstNid;
+            Bid = bid;
+        }
+
+        internal uint FirstNid { get; }
+        internal ulong Bid { get; }
+    }
+}

--- a/OfficeIMO.Email.Store/README.md
+++ b/OfficeIMO.Email.Store/README.md
@@ -1,6 +1,6 @@
 # OfficeIMO.Email.Store
 
-`OfficeIMO.Email.Store` is the fully managed mailbox-store package for PST, OST, OLM, EMLX, Apple Mail, and Maildir sources. Sources remain read-only. Selected items project into the common `OfficeIMO.Email.EmailDocument` model and can be exported through `OfficeIMO.Email` without Outlook, native libraries, or third-party parser packages.
+`OfficeIMO.Email.Store` is the fully managed mailbox-store package for PST, OST, OLM, EMLX, Apple Mail, and Maildir sources. Source stores remain read-only. Selected items project into the common `OfficeIMO.Email.EmailDocument` model, and applications can create a new Unicode PST or convert a supported source into a separate PST without Outlook, native libraries, or third-party parser packages.
 
 ## Install
 
@@ -210,8 +210,56 @@ EmailStoreMboxExportReport mailbox = session.ExportToMbox(
 Output conversion uses `OfficeIMO.Email` and its explicit semantic-loss policy. Existing destinations are not
 replaced by default. Per-item failures and fidelity warnings remain visible in the export report.
 
-True OST-to-PST conversion is not advertised. It requires a complete new PST writer rather than changing an OST
-signature. The separate writer scope and validation gates are documented in [ARCHITECTURE.md](ARCHITECTURE.md).
+## Create a Unicode PST
+
+`EmailStorePstWriter` creates a new PST incrementally and commits it through a same-directory temporary file. It
+does not append to or edit an existing PST:
+
+```csharp
+using OfficeIMO.Email;
+using OfficeIMO.Email.Store;
+
+using EmailStorePstWriter writer = EmailStorePstWriter.Create(
+    "created.pst",
+    new EmailStorePstWriterOptions(displayName: "Project archive"));
+
+string inbox = writer.AddFolder("Inbox", containerClass: "IPF.Note");
+writer.AddItem(inbox, new EmailDocument {
+    Subject = "Created without Outlook",
+    MessageClass = "IPM.Note"
+});
+
+EmailStorePstWriteReport report = writer.Complete();
+```
+
+The writer owns Unicode NDB allocation and indexes, Heap-on-Node property and table contexts, folders, ordinary
+and associated items, recipients, attachments, embedded messages, named properties, and fixed or variable
+multi-valued MAPI properties. It reuses `OfficeIMO.Email` item projection so appointments, contacts, tasks,
+journals, notes, and messages do not acquire a PST-only property model.
+
+Set `failOnDataLoss: true` when a warning should prevent the final commit. Examples include an attachment whose
+payload was not retained, structured-storage metadata without its original compound payload, or a named property
+whose source Name-to-ID mapping was unavailable. `Diagnostics` identifies the affected item or property without
+including message or attachment content.
+
+## Convert OST or another store to a new PST
+
+Conversion opens the source read-only and always writes a different destination:
+
+```csharp
+EmailStorePstConversionReport report = EmailStoreConverter.ConvertToPst(
+    "mailbox.ost",
+    "mailbox-converted.pst",
+    conversionOptions: new EmailStorePstConversionOptions(
+        includeAssociatedItems: true,
+        includeOrphanedItems: true,
+        failOnDataLoss: false));
+```
+
+The same API accepts every format supported by `EmailStoreSession`. Search-folder results can be copied as static
+folders, but their dynamic query definitions are not regenerated. Content that was never cached in an OST cannot
+be recovered from the offline file. The conversion report separates converted and skipped items and combines
+reader, conversion, and writer diagnostics.
 
 ## Limits and attachment retention
 
@@ -236,15 +284,16 @@ Set `PstPassword` only when a protected PST requires checksum validation. Passwo
 
 ## Boundaries
 
-- This package owns store/container traversal, bounded selection, validation/recovery discovery, and export orchestration.
+- This package owns store/container traversal, bounded selection, validation/recovery discovery, new Unicode PST creation, and export/conversion orchestration.
 - `OfficeIMO.Email` owns EML/MIME, MSG/OFT, TNEF, mbox, MAPI models, and item serialization.
 - `OfficeIMO.Reader.EmailStore` owns optional Reader registration and rich-result projection.
-- PST/OST writing or mutation, Outlook profiles, Exchange synchronization, cloud download, and server-side recovery are outside this offline reader.
+- Existing PST/OST mutation, append, compaction, repair, password/encryption authoring, Outlook profiles, Exchange synchronization, cloud download, and server-side recovery remain outside this package.
+- The writer currently emits Unicode PST files. It does not emit ANSI PST or OST files, and one data tree is limited to 4 GiB.
 
 ## Targets and dependencies
 
 - Targets: `netstandard2.0`, `net8.0`, `net10.0`; `net472` is included when building on Windows.
-- External parser dependencies: none.
+- External runtime parser/writer dependencies: none.
 - Direct first-party dependencies: `OfficeIMO.Email` and `OfficeIMO.Rtf`.
 - `OfficeIMO.Email` carries Microsoft's `System.Text.Encoding.CodePages` compatibility package for legacy message
   encodings; no Outlook installation, native component, or third-party PST/OST/OLM parser is used.

--- a/OfficeIMO.Email.Store/Reading/EmailStoreReaderOptions.cs
+++ b/OfficeIMO.Email.Store/Reading/EmailStoreReaderOptions.cs
@@ -27,7 +27,8 @@ public sealed class EmailStoreReaderOptions {
         long maxXmlCharactersPerItem = 64L * 1024 * 1024,
         long maxMessageBytes = 256L * 1024 * 1024,
         int maxDirectoryDepth = 64,
-        int maxDirectoryFileCount = 1_000_000) {
+        int maxDirectoryFileCount = 1_000_000,
+        long maxDecodedTableBytes = 8L * 1024 * 1024 * 1024) {
         MaxInputBytes = Positive(maxInputBytes, nameof(maxInputBytes));
         MaxNodeCount = Positive(maxNodeCount, nameof(maxNodeCount));
         MaxBTreeDepth = Positive(maxBTreeDepth, nameof(maxBTreeDepth));
@@ -53,6 +54,7 @@ public sealed class EmailStoreReaderOptions {
         MaxMessageBytes = Positive(maxMessageBytes, nameof(maxMessageBytes));
         MaxDirectoryDepth = Positive(maxDirectoryDepth, nameof(maxDirectoryDepth));
         MaxDirectoryFileCount = Positive(maxDirectoryFileCount, nameof(maxDirectoryFileCount));
+        MaxDecodedTableBytes = Positive(maxDecodedTableBytes, nameof(maxDecodedTableBytes));
     }
 
     /// <summary>Default bounded options.</summary>
@@ -106,6 +108,8 @@ public sealed class EmailStoreReaderOptions {
     public int MaxDirectoryDepth { get; }
     /// <summary>Maximum EML, EMLX, and Maildir files indexed by one mailbox-directory session.</summary>
     public int MaxDirectoryFileCount { get; }
+    /// <summary>Maximum decoded bytes traversed from one PST/OST table data tree.</summary>
+    public long MaxDecodedTableBytes { get; }
 
     private static int Positive(int value, string name) {
         if (value <= 0) throw new ArgumentOutOfRangeException(name);

--- a/OfficeIMO.Email.Store/Reading/EmailStoreSession.PstExport.cs
+++ b/OfficeIMO.Email.Store/Reading/EmailStoreSession.PstExport.cs
@@ -1,0 +1,141 @@
+namespace OfficeIMO.Email.Store;
+
+public sealed partial class EmailStoreSession {
+    /// <summary>
+    /// Streams this open store into a newly created Unicode PST. The source is read-only and is never mutated.
+    /// </summary>
+    public EmailStorePstConversionReport ExportToPst(string destinationPath,
+        EmailStorePstConversionOptions? options = null,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(destinationPath)) {
+            throw new ArgumentException("A destination path is required.", nameof(destinationPath));
+        }
+        ThrowIfDisposed();
+        var effective = options ?? new EmailStorePstConversionOptions();
+        string destination = Path.GetFullPath(destinationPath);
+        if (_stream is FileStream sourceFile && string.Equals(
+            Path.GetFullPath(sourceFile.Name), destination, StringComparison.OrdinalIgnoreCase)) {
+            throw new InvalidOperationException(
+                "Store conversion always writes a different destination file; in-place PST/OST mutation is not supported.");
+        }
+
+        var diagnostics = new List<EmailStoreDiagnostic>();
+        var writerOptions = new EmailStorePstWriterOptions(
+            effective.DisplayName ?? DisplayName,
+            effective.OverwriteExisting,
+            effective.FailOnDataLoss,
+            maxFolderCount: Math.Max(1, Folders.Count + 8),
+            maxItemCount: effective.MaxItems,
+            maxNestedMessageDepth: effective.MaxNestedMessageDepth);
+        using EmailStorePstWriter writer = EmailStorePstWriter.Create(destination, writerOptions);
+        Dictionary<string, string> folderMap = CreatePstFolderMap(writer, effective, diagnostics);
+        int converted = 0;
+        int skipped = 0;
+        var enumeration = new EmailStoreEnumerationOptions(
+            includeAssociatedItems: effective.IncludeAssociatedItems,
+            includeOrphanedItems: effective.IncludeOrphanedItems,
+            maxItems: effective.MaxItems);
+        var readOptions = new EmailStoreItemReadOptions(
+            EmailStoreItemReadParts.All, preferStreamingAttachmentContent: true);
+        foreach (EmailStoreItemReference reference in EnumerateItems(enumeration, cancellationToken)) {
+            cancellationToken.ThrowIfCancellationRequested();
+            EmailStoreFolderInfo? sourceFolder = Folders.FirstOrDefault(item => item.Id == reference.FolderId);
+            if (sourceFolder?.IsSearchFolder == true && !effective.IncludeSearchFolders) {
+                skipped++;
+                continue;
+            }
+            if (!folderMap.TryGetValue(reference.FolderId, out string? destinationFolder)) {
+                skipped++;
+                diagnostics.Add(new EmailStoreDiagnostic(
+                    "EMAIL_STORE_PST_CONVERT_FOLDER_UNMAPPED",
+                    "An item was skipped because its source folder could not be mapped.",
+                    EmailStoreDiagnosticSeverity.Error, reference.Id));
+                if (!effective.ContinueOnItemError) {
+                    throw new InvalidDataException("A source item folder could not be mapped.");
+                }
+                continue;
+            }
+            try {
+                EmailStoreItem item = ReadItem(reference, readOptions, cancellationToken);
+                writer.AddItem(destinationFolder, item.Document, reference.IsAssociated,
+                    cancellationToken);
+                converted++;
+                if (reference.IsOrphaned) {
+                    diagnostics.Add(new EmailStoreDiagnostic(
+                        "EMAIL_STORE_PST_CONVERT_ORPHAN_RECOVERED",
+                        "An item absent from its source contents table was recovered from the source index and copied.",
+                        EmailStoreDiagnosticSeverity.Information, reference.Id));
+                }
+            } catch (Exception exception) when (effective.ContinueOnItemError &&
+                (exception is InvalidDataException || exception is NotSupportedException ||
+                 exception is IOException || exception is EmailStoreLimitExceededException)) {
+                skipped++;
+                diagnostics.Add(new EmailStoreDiagnostic(
+                    "EMAIL_STORE_PST_CONVERT_ITEM_SKIPPED",
+                    string.Concat("A source item could not be copied: ", exception.Message),
+                    EmailStoreDiagnosticSeverity.Error, reference.Id));
+            }
+        }
+
+        if (effective.FailOnDataLoss && diagnostics.Any(item =>
+            item.Severity != EmailStoreDiagnosticSeverity.Information)) {
+            throw new InvalidOperationException(
+                "Store conversion produced fidelity diagnostics and FailOnDataLoss is enabled.");
+        }
+        EmailStorePstWriteReport writeReport = writer.Complete(cancellationToken);
+        diagnostics.AddRange(writeReport.Diagnostics);
+        return new EmailStorePstConversionReport(Format, writeReport,
+            Folders.Count, converted, skipped, diagnostics.ToArray());
+    }
+
+    private Dictionary<string, string> CreatePstFolderMap(EmailStorePstWriter writer,
+        EmailStorePstConversionOptions options, IList<EmailStoreDiagnostic> diagnostics) {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (EmailStoreFolderInfo folder in Folders) {
+            if (folder.SpecialFolderKind == EmailStoreSpecialFolderKind.Root ||
+                folder.SpecialFolderKind == EmailStoreSpecialFolderKind.IpmSubtree) {
+                map[folder.Id] = writer.RootFolderId;
+            } else if (folder.SpecialFolderKind == EmailStoreSpecialFolderKind.DeletedItems) {
+                map[folder.Id] = writer.DeletedItemsFolderId;
+            } else if (folder.SpecialFolderKind == EmailStoreSpecialFolderKind.SearchRoot) {
+                map[folder.Id] = writer.SearchRootFolderId;
+            }
+        }
+
+        var pending = Folders.Where(item => !map.ContainsKey(item.Id)).ToList();
+        bool progress;
+        do {
+            progress = false;
+            for (int index = pending.Count - 1; index >= 0; index--) {
+                EmailStoreFolderInfo folder = pending[index];
+                if (folder.IsSearchFolder && !options.IncludeSearchFolders) {
+                    pending.RemoveAt(index);
+                    progress = true;
+                    continue;
+                }
+                string? parent;
+                if (folder.ParentId == null) parent = writer.RootFolderId;
+                else if (!map.TryGetValue(folder.ParentId, out parent)) continue;
+                map[folder.Id] = writer.AddFolder(folder.Name, parent, folder.ContainerClass);
+                if (folder.IsSearchFolder) {
+                    diagnostics.Add(new EmailStoreDiagnostic(
+                        "EMAIL_STORE_PST_CONVERT_SEARCH_FOLDER_STATIC",
+                        "A search folder was copied as a static folder; its dynamic search definition is not regenerated.",
+                        EmailStoreDiagnosticSeverity.Warning, folder.Id));
+                }
+                pending.RemoveAt(index);
+                progress = true;
+            }
+        } while (progress && pending.Count > 0);
+
+        foreach (EmailStoreFolderInfo folder in pending) {
+            map[folder.Id] = writer.AddFolder(folder.Name, writer.RootFolderId,
+                folder.ContainerClass);
+            diagnostics.Add(new EmailStoreDiagnostic(
+                "EMAIL_STORE_PST_CONVERT_FOLDER_PARENT_RECOVERED",
+                "A folder with an unavailable or cyclic parent was attached to the destination root.",
+                EmailStoreDiagnosticSeverity.Warning, folder.Id));
+        }
+        return map;
+    }
+}

--- a/OfficeIMO.Email.Store/Writing/EmailStoreConverter.cs
+++ b/OfficeIMO.Email.Store/Writing/EmailStoreConverter.cs
@@ -1,0 +1,21 @@
+namespace OfficeIMO.Email.Store;
+
+/// <summary>Dependency-free mailbox-store conversion entry points.</summary>
+public static class EmailStoreConverter {
+    /// <summary>Opens a PST, OST, OLM, MBOX, EML, or mailbox directory and writes a new Unicode PST.</summary>
+    public static EmailStorePstConversionReport ConvertToPst(string sourcePath,
+        string destinationPath, EmailStoreReaderOptions? readerOptions = null,
+        EmailStorePstConversionOptions? conversionOptions = null,
+        CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(sourcePath)) throw new ArgumentException("A source path is required.", nameof(sourcePath));
+        if (string.IsNullOrWhiteSpace(destinationPath)) throw new ArgumentException("A destination path is required.", nameof(destinationPath));
+        string source = Path.GetFullPath(sourcePath);
+        string destination = Path.GetFullPath(destinationPath);
+        if (string.Equals(source, destination, StringComparison.OrdinalIgnoreCase)) {
+            throw new InvalidOperationException("Store conversion always writes a different destination file; in-place PST/OST mutation is not supported.");
+        }
+        using EmailStoreSession session = EmailStoreSession.Open(source,
+            readerOptions, cancellationToken);
+        return session.ExportToPst(destination, conversionOptions, cancellationToken);
+    }
+}

--- a/OfficeIMO.Email.Store/Writing/EmailStorePstConversionOptions.cs
+++ b/OfficeIMO.Email.Store/Writing/EmailStorePstConversionOptions.cs
@@ -1,0 +1,47 @@
+namespace OfficeIMO.Email.Store;
+
+/// <summary>Controls safe conversion of a supported mailbox store into a newly created Unicode PST.</summary>
+public sealed class EmailStorePstConversionOptions {
+    /// <summary>Creates conversion options.</summary>
+    public EmailStorePstConversionOptions(
+        bool overwriteExisting = false,
+        bool failOnDataLoss = false,
+        bool continueOnItemError = true,
+        bool includeAssociatedItems = true,
+        bool includeOrphanedItems = true,
+        bool includeSearchFolders = true,
+        int maxItems = int.MaxValue,
+        int maxNestedMessageDepth = 32,
+        string? displayName = null) {
+        if (maxItems <= 0) throw new ArgumentOutOfRangeException(nameof(maxItems));
+        if (maxNestedMessageDepth < 0) throw new ArgumentOutOfRangeException(nameof(maxNestedMessageDepth));
+        OverwriteExisting = overwriteExisting;
+        FailOnDataLoss = failOnDataLoss;
+        ContinueOnItemError = continueOnItemError;
+        IncludeAssociatedItems = includeAssociatedItems;
+        IncludeOrphanedItems = includeOrphanedItems;
+        IncludeSearchFolders = includeSearchFolders;
+        MaxItems = maxItems;
+        MaxNestedMessageDepth = maxNestedMessageDepth;
+        DisplayName = string.IsNullOrWhiteSpace(displayName) ? null : displayName;
+    }
+
+    /// <summary>Whether an existing destination may be atomically replaced.</summary>
+    public bool OverwriteExisting { get; }
+    /// <summary>Whether any fidelity warning or error blocks completion.</summary>
+    public bool FailOnDataLoss { get; }
+    /// <summary>Whether unreadable individual items are reported and skipped instead of aborting immediately.</summary>
+    public bool ContinueOnItemError { get; }
+    /// <summary>Whether folder-associated information items are copied.</summary>
+    public bool IncludeAssociatedItems { get; }
+    /// <summary>Whether items recovered from source indexes but absent from contents tables are copied.</summary>
+    public bool IncludeOrphanedItems { get; }
+    /// <summary>Whether search-folder results are copied as static folders and items.</summary>
+    public bool IncludeSearchFolders { get; }
+    /// <summary>Maximum source items inspected by one conversion.</summary>
+    public int MaxItems { get; }
+    /// <summary>Maximum embedded-message nesting depth written.</summary>
+    public int MaxNestedMessageDepth { get; }
+    /// <summary>Optional destination display name. The source display name is used when null.</summary>
+    public string? DisplayName { get; }
+}

--- a/OfficeIMO.Email.Store/Writing/EmailStorePstConversionReport.cs
+++ b/OfficeIMO.Email.Store/Writing/EmailStorePstConversionReport.cs
@@ -1,0 +1,31 @@
+namespace OfficeIMO.Email.Store;
+
+/// <summary>Outcome of converting a supported store into a new Unicode PST.</summary>
+public sealed class EmailStorePstConversionReport {
+    internal EmailStorePstConversionReport(EmailStoreFormat sourceFormat,
+        EmailStorePstWriteReport writeReport, int sourceFolders, int convertedItems,
+        int skippedItems, IReadOnlyList<EmailStoreDiagnostic> diagnostics) {
+        SourceFormat = sourceFormat;
+        WriteReport = writeReport;
+        SourceFolders = sourceFolders;
+        ConvertedItems = convertedItems;
+        SkippedItems = skippedItems;
+        Diagnostics = diagnostics;
+    }
+
+    /// <summary>Detected source format.</summary>
+    public EmailStoreFormat SourceFormat { get; }
+    /// <summary>Final PST creation report.</summary>
+    public EmailStorePstWriteReport WriteReport { get; }
+    /// <summary>Number of source folders considered.</summary>
+    public int SourceFolders { get; }
+    /// <summary>Number of items written.</summary>
+    public int ConvertedItems { get; }
+    /// <summary>Number of items skipped after a reported read or fidelity failure.</summary>
+    public int SkippedItems { get; }
+    /// <summary>Combined conversion and PST writer diagnostics.</summary>
+    public IReadOnlyList<EmailStoreDiagnostic> Diagnostics { get; }
+    /// <summary>True when the conversion emitted a warning or error.</summary>
+    public bool HasDataLoss => Diagnostics.Any(item =>
+        item.Severity != EmailStoreDiagnosticSeverity.Information);
+}

--- a/OfficeIMO.Email.Store/Writing/EmailStorePstWriteReport.cs
+++ b/OfficeIMO.Email.Store/Writing/EmailStorePstWriteReport.cs
@@ -1,0 +1,36 @@
+namespace OfficeIMO.Email.Store;
+
+/// <summary>Result of creating a new Unicode PST.</summary>
+public sealed class EmailStorePstWriteReport {
+    internal EmailStorePstWriteReport(string destinationPath, int folderCount, int itemCount,
+        long bytesWritten, IReadOnlyList<EmailStoreDiagnostic> diagnostics) {
+        DestinationPath = destinationPath;
+        FolderCount = folderCount;
+        ItemCount = itemCount;
+        BytesWritten = bytesWritten;
+        Diagnostics = diagnostics;
+    }
+
+    /// <summary>Committed destination path.</summary>
+    public string DestinationPath { get; }
+
+    /// <summary>Number of user-visible folders written, excluding mandatory PST system folders.</summary>
+    public int FolderCount { get; }
+
+    /// <summary>Number of top-level items written.</summary>
+    public int ItemCount { get; }
+
+    /// <summary>Committed file length.</summary>
+    public long BytesWritten { get; }
+
+    /// <summary>Preservation and compatibility diagnostics.</summary>
+    public IReadOnlyList<EmailStoreDiagnostic> Diagnostics { get; }
+
+    /// <summary>True when at least one error diagnostic was emitted.</summary>
+    public bool HasErrors => Diagnostics.Any(item => item.Severity == EmailStoreDiagnosticSeverity.Error);
+
+    /// <summary>True when at least one fidelity warning or error was emitted.</summary>
+    public bool HasDataLoss => Diagnostics.Any(item =>
+        item.Severity == EmailStoreDiagnosticSeverity.Warning ||
+        item.Severity == EmailStoreDiagnosticSeverity.Error);
+}

--- a/OfficeIMO.Email.Store/Writing/EmailStorePstWriter.cs
+++ b/OfficeIMO.Email.Store/Writing/EmailStorePstWriter.cs
@@ -1,0 +1,73 @@
+using OfficeIMO.Email;
+
+namespace OfficeIMO.Email.Store;
+
+/// <summary>
+/// Incrementally creates a new dependency-free Unicode PST. Source PST/OST files are never modified.
+/// </summary>
+public sealed class EmailStorePstWriter : IDisposable {
+    private readonly PstStoreWriterCore _core;
+    private bool _completed;
+    private bool _disposed;
+
+    private EmailStorePstWriter(string destinationPath, EmailStorePstWriterOptions options) {
+        _core = new PstStoreWriterCore(destinationPath, options);
+    }
+
+    /// <summary>Creates a writer targeting a new PST path.</summary>
+    public static EmailStorePstWriter Create(string destinationPath,
+        EmailStorePstWriterOptions? options = null) {
+        if (string.IsNullOrWhiteSpace(destinationPath)) {
+            throw new ArgumentException("A destination path is required.", nameof(destinationPath));
+        }
+        return new EmailStorePstWriter(destinationPath, options ?? new EmailStorePstWriterOptions());
+    }
+
+    /// <summary>Identifier of the mandatory Top of Personal Folders container.</summary>
+    public string RootFolderId {
+        get { ThrowIfUnavailable(); return _core.RootFolderId; }
+    }
+
+    internal string DeletedItemsFolderId {
+        get { ThrowIfUnavailable(); return _core.DeletedItemsFolderId; }
+    }
+
+    internal string SearchRootFolderId {
+        get { ThrowIfUnavailable(); return _core.SearchRootFolderId; }
+    }
+
+    /// <summary>Adds a folder. A null parent places it under <see cref="RootFolderId"/>.</summary>
+    public string AddFolder(string name, string? parentFolderId = null,
+        string? containerClass = null) {
+        ThrowIfUnavailable();
+        return _core.AddFolder(name, parentFolderId, containerClass);
+    }
+
+    /// <summary>Writes one message or typed Outlook item into a folder.</summary>
+    public string AddItem(string folderId, EmailDocument document, bool isAssociated = false,
+        CancellationToken cancellationToken = default) {
+        ThrowIfUnavailable();
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        return _core.AddItem(folderId, document, isAssociated, cancellationToken);
+    }
+
+    /// <summary>Finalizes indexes and allocation maps, then atomically commits the PST.</summary>
+    public EmailStorePstWriteReport Complete(CancellationToken cancellationToken = default) {
+        ThrowIfUnavailable();
+        EmailStorePstWriteReport report = _core.Complete(cancellationToken);
+        _completed = true;
+        return report;
+    }
+
+    /// <inheritdoc />
+    public void Dispose() {
+        if (_disposed) return;
+        _disposed = true;
+        _core.Dispose();
+    }
+
+    private void ThrowIfUnavailable() {
+        if (_disposed) throw new ObjectDisposedException(nameof(EmailStorePstWriter));
+        if (_completed) throw new InvalidOperationException("The PST writer has already completed.");
+    }
+}

--- a/OfficeIMO.Email.Store/Writing/EmailStorePstWriterOptions.cs
+++ b/OfficeIMO.Email.Store/Writing/EmailStorePstWriterOptions.cs
@@ -1,0 +1,41 @@
+namespace OfficeIMO.Email.Store;
+
+/// <summary>Controls creation of a new managed Unicode PST file.</summary>
+public sealed class EmailStorePstWriterOptions {
+    /// <summary>Creates PST writer options.</summary>
+    public EmailStorePstWriterOptions(
+        string? displayName = null,
+        bool overwriteExisting = false,
+        bool failOnDataLoss = false,
+        int maxFolderCount = 100_000,
+        int maxItemCount = int.MaxValue,
+        int maxNestedMessageDepth = 32) {
+        if (maxFolderCount <= 0) throw new ArgumentOutOfRangeException(nameof(maxFolderCount));
+        if (maxItemCount <= 0) throw new ArgumentOutOfRangeException(nameof(maxItemCount));
+        if (maxNestedMessageDepth < 0) throw new ArgumentOutOfRangeException(nameof(maxNestedMessageDepth));
+        DisplayName = string.IsNullOrWhiteSpace(displayName) ? "OfficeIMO Personal Folders" : displayName!;
+        OverwriteExisting = overwriteExisting;
+        FailOnDataLoss = failOnDataLoss;
+        MaxFolderCount = maxFolderCount;
+        MaxItemCount = maxItemCount;
+        MaxNestedMessageDepth = maxNestedMessageDepth;
+    }
+
+    /// <summary>Display name stored in the message-store object.</summary>
+    public string DisplayName { get; }
+
+    /// <summary>Whether an existing destination may be atomically replaced.</summary>
+    public bool OverwriteExisting { get; }
+
+    /// <summary>Whether a fidelity warning prevents completion.</summary>
+    public bool FailOnDataLoss { get; }
+
+    /// <summary>Maximum folders accepted by one writer.</summary>
+    public int MaxFolderCount { get; }
+
+    /// <summary>Maximum top-level items accepted by one writer.</summary>
+    public int MaxItemCount { get; }
+
+    /// <summary>Maximum embedded-message nesting depth written.</summary>
+    public int MaxNestedMessageDepth { get; }
+}

--- a/OfficeIMO.Email/OfficeIMO.Email.csproj
+++ b/OfficeIMO.Email/OfficeIMO.Email.csproj
@@ -60,6 +60,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="OfficeIMO.Email.Tests" />
+    <InternalsVisibleTo Include="OfficeIMO.Email.Store" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ _Dependency footprint:_ `System.Text.Encoding.CodePages` plus first-party Office
 - [x] Common `OfficeIMO.Email.EmailDocument` projection instead of a second message or Outlook-item model
 - [x] Resumable semantic content search, special-folder roles, offline-content availability, and deferred attachment streams
 - [x] Inspection, bounded PST/OST structural validation, orphan discovery, EML/MSG/OFT/TNEF directory export, and streaming mbox export
+- [x] Managed Unicode PST creation with folders, typed items, recipients, attachments, embedded messages, named properties, and multi-valued MAPI properties
+- [x] Read-only OST/PST/OLM/EMLX/mailbox-directory conversion into a separate new PST with explicit fidelity diagnostics
 - [x] Configurable source, cache, tree, item, attachment, archive, XML, directory, and recursion limits with structured diagnostics
 
 _Dependency footprint:_ first-party `OfficeIMO.Email` and `OfficeIMO.Rtf`; no Outlook installation, native library, or third-party store parser.


### PR DESCRIPTION
## Summary

- Improve PST/OST heap, table, property-context, and multi-valued MAPI decoding, including safer per-cell diagnostics and bounded large-table traversal.
- Add a fully managed Unicode PST writer plus read-only store-to-new-PST conversion for PST, OST, OLM, EMLX, and mailbox-directory sessions.
- Preserve folders, ordinary and associated items, typed Outlook items, recipients, bodies, attachments, embedded messages, named properties, and multi-valued MAPI properties through the shared `OfficeIMO.Email` projection.
- Add privacy-safe opt-in corpus and classic Outlook interoperability lanes, synthetic structural/round-trip coverage, package metadata, and current capability documentation.

## Usage

```csharp
EmailStorePstConversionReport report = EmailStoreConverter.ConvertToPst(
    "mailbox.ost",
    "mailbox-converted.pst");
```

The source is always opened read-only and the destination is committed atomically as a separate file.

## Compatibility and limits

The writer creates new Unicode PST files only. Existing PST/OST append, mutation, repair, compaction, password/encryption authoring, ANSI PST output, and OST output remain out of scope. Search folders are copied as static folders, and content absent from an offline OST is reported rather than fabricated.

Independent `libpff` validation opened the generated PST and exported its synthetic folder/message. A content-free classic Outlook mount/read/remove test is included as an opt-in lane; the final rerun on the current host remained pending because that Outlook installation is at its crash-recovery prompt.

## Validation

- `OfficeIMO.Email.Store.Tests`: 92 passed and 3 explicitly skipped opt-in lanes on each target (`net472`, `net8.0`, `net10.0`).
- Private local corpus: three PST/OST stores traversed up to 10,000 items each and converted a bounded sample without modifying the sources or retaining mail data.
- Full Release solution build: 0 warnings and 0 errors.
- Packed `OfficeIMO.Email.Store` contents and a clean package-only consumer round trip were verified.