### PR TITLE
Recognize current and past GitHub sponsors

### DIFF
--- a/.github/workflows/update-sponsors.yml
+++ b/.github/workflows/update-sponsors.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   sponsors:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-content.yml@a2c7efbf2e0217527d711544d79e0f62ed5d6c11
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-content.yml@35080238eeaf3e8bc86cf64fcedc8881fb97fea3
     with:
       config_path: .powerforge/github-content.json
     secrets:

--- a/.github/workflows/update-sponsors.yml
+++ b/.github/workflows/update-sponsors.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   sponsors:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-content.yml@04f7c12883fa0fd19e9ddf85badbdc79ddcd9434
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-content.yml@d97af0c810582ecddaeee767eba06b1a0d116395
     with:
       config_path: .powerforge/github-content.json
     secrets:

--- a/.github/workflows/update-sponsors.yml
+++ b/.github/workflows/update-sponsors.yml
@@ -1,0 +1,21 @@
+name: Update Sponsors
+
+on:
+  schedule:
+    - cron: "37 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-sponsors-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  sponsors:
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-content.yml@a2c7efbf2e0217527d711544d79e0f62ed5d6c11
+    with:
+      config_path: .powerforge/github-content.json
+    secrets:
+      github_token: ${{ secrets.SPONSORS_TOKEN }}

--- a/.github/workflows/update-sponsors.yml
+++ b/.github/workflows/update-sponsors.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   sponsors:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-content.yml@28482d9acfe79a9c9da85153474a81d898987f41
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-content.yml@04f7c12883fa0fd19e9ddf85badbdc79ddcd9434
     with:
       config_path: .powerforge/github-content.json
     secrets:

--- a/.github/workflows/update-sponsors.yml
+++ b/.github/workflows/update-sponsors.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   sponsors:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-content.yml@d97af0c810582ecddaeee767eba06b1a0d116395
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-content.yml@0102eccbaff79c31285501a9264e4bf189ddb5cf
     with:
       config_path: .powerforge/github-content.json
     secrets:

--- a/.github/workflows/update-sponsors.yml
+++ b/.github/workflows/update-sponsors.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   sponsors:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-content.yml@c7ffdd4e947b3c0d6736fe2f5cc47d34f309d68e
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-content.yml@459a49d8215c6f5ed8b8097ed8b029b251aa7ae1
     with:
       config_path: .powerforge/github-content.json
     secrets:

--- a/.github/workflows/update-sponsors.yml
+++ b/.github/workflows/update-sponsors.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   sponsors:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-content.yml@459a49d8215c6f5ed8b8097ed8b029b251aa7ae1
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-content.yml@3660eec007084d755cd286c1af622d5d1814db96
     with:
       config_path: .powerforge/github-content.json
     secrets:

--- a/.github/workflows/update-sponsors.yml
+++ b/.github/workflows/update-sponsors.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   sponsors:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-content.yml@35080238eeaf3e8bc86cf64fcedc8881fb97fea3
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-content.yml@28482d9acfe79a9c9da85153474a81d898987f41
     with:
       config_path: .powerforge/github-content.json
     secrets:

--- a/.github/workflows/update-sponsors.yml
+++ b/.github/workflows/update-sponsors.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   sponsors:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-content.yml@0102eccbaff79c31285501a9264e4bf189ddb5cf
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-github-content.yml@c7ffdd4e947b3c0d6736fe2f5cc47d34f309d68e
     with:
       config_path: .powerforge/github-content.json
     secrets:

--- a/.powerforge/github-content.json
+++ b/.powerforge/github-content.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://raw.githubusercontent.com/EvotecIT/PSPublishModule/main/Schemas/github.content.schema.json",
+  "tokenEnvName": "GITHUB_TOKEN",
+  "sponsors": {
+    "enabled": true,
+    "sponsorableLogin": "PrzemyslawKlys",
+    "includeFormer": true,
+    "failOnEmpty": true,
+    "requireFundingTierData": true,
+    "tierRecognition": {
+      "enabled": true,
+      "useDefaultTiers": true,
+      "unmappedTierKey": "Sponsors"
+    },
+    "outputs": [
+      {
+        "path": "SPONSORS.md",
+        "blockId": "sponsors",
+        "layout": "Full",
+        "title": "OfficeIMO Sponsors",
+        "introduction": "OfficeIMO is MIT-licensed and available without feature gates. These people and organizations support or have helped fund its development, testing, and documentation.",
+        "closing": "You can support OfficeIMO through [GitHub Sponsors](https://github.com/sponsors/PrzemyslawKlys). Companies that need a VAT invoice can contact [contact@evotec.pl](mailto:contact@evotec.pl).",
+        "includeFormer": true,
+        "createIfMissing": true
+      },
+      {
+        "path": "README.md",
+        "blockId": "sponsors-readme",
+        "layout": "Compact",
+        "includeFormer": false,
+        "createIfMissing": false,
+        "missingBlockBehavior": "Fail",
+        "avatarSize": 48,
+        "maxEntries": 12,
+        "moreLink": "SPONSORS.md"
+      }
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,21 @@ The current coordinated package line is `2.0.x`. Applications should upgrade Off
 
 If OfficeIMO saves you time, please consider supporting the work through [GitHub Sponsors](https://github.com/sponsors/PrzemyslawKlys) or [PayPal](https://paypal.me/PrzemyslawKlys). PowerShell users should start with [PSWriteOffice](https://github.com/EvotecIT/PSWriteOffice).
 
+## Sponsors
+
+<!-- POWERFORGE:sponsors-readme:START -->
+<p>
+  <a href="https://github.com/KelvinTegelaar" title="KelvinTegelaar"><img src="https://avatars.githubusercontent.com/u/49186168?u=49610dcd84d6c868d9e47c1a64ac137f3da24808&amp;v=4" width="48" height="48" alt="KelvinTegelaar" /></a>
+  <a href="https://github.com/apbirch67" title="Andrew Birch"><img src="https://avatars.githubusercontent.com/u/12010032?u=79082c6c1f026e3ab39dae7a4aff8e8fadeeeeea&amp;v=4" width="48" height="48" alt="Andrew Birch" /></a>
+  <a href="https://github.com/thomas-moeller" title="Thomas M&#248;ller"><img src="https://avatars.githubusercontent.com/u/37923349?u=e5b9b9d52dc33256937ace98623e3b7c6aead98a&amp;v=4" width="48" height="48" alt="Thomas M&#248;ller" /></a>
+  <a href="https://github.com/jakehildreth" title="Jake Hildreth"><img src="https://avatars.githubusercontent.com/u/93942157?u=e1e8d3f460d775c44f5491711ad1c47a5005fb5c&amp;v=4" width="48" height="48" alt="Jake Hildreth" /></a>
+  <a href="https://github.com/complea" title="Complea"><img src="https://avatars.githubusercontent.com/u/144781871?v=4" width="48" height="48" alt="Complea" /></a>
+  <a href="https://github.com/DarthPanda12" title="DarthPanda12"><img src="https://avatars.githubusercontent.com/u/294241377?v=4" width="48" height="48" alt="DarthPanda12" /></a>
+</p>
+
+[See all sponsors](SPONSORS.md)
+<!-- POWERFORGE:sponsors-readme:END -->
+
 ## Dependency model
 
 OfficeIMO keeps document engines first-party and optional integrations isolated. The table calls out direct non-OfficeIMO runtime dependencies that matter to package selection; Microsoft/BCL compatibility packages are still used where older target frameworks need platform APIs.

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,0 +1,64 @@
+# OfficeIMO Sponsors
+
+<!-- POWERFORGE:sponsors:START -->
+OfficeIMO is MIT-licensed and available without feature gates. These people and organizations support or have helped fund its development, testing, and documentation.
+
+## Platinum Sponsors
+
+<p>
+  <a href="https://github.com/KelvinTegelaar" title="KelvinTegelaar"><img src="https://avatars.githubusercontent.com/u/49186168?u=49610dcd84d6c868d9e47c1a64ac137f3da24808&amp;v=4" width="96" height="96" alt="KelvinTegelaar" /></a>
+</p>
+
+## Gold Sponsors
+
+<p>
+  <a href="https://github.com/apbirch67" title="Andrew Birch"><img src="https://avatars.githubusercontent.com/u/12010032?u=79082c6c1f026e3ab39dae7a4aff8e8fadeeeeea&amp;v=4" width="80" height="80" alt="Andrew Birch" /></a>
+</p>
+
+## Silver Sponsors
+
+<p>
+  <a href="https://github.com/thomas-moeller" title="Thomas M&#248;ller"><img src="https://avatars.githubusercontent.com/u/37923349?u=e5b9b9d52dc33256937ace98623e3b7c6aead98a&amp;v=4" width="72" height="72" alt="Thomas M&#248;ller" /></a>
+</p>
+
+## Bronze Sponsors
+
+<p>
+  <a href="https://github.com/jakehildreth" title="Jake Hildreth"><img src="https://avatars.githubusercontent.com/u/93942157?u=e1e8d3f460d775c44f5491711ad1c47a5005fb5c&amp;v=4" width="64" height="64" alt="Jake Hildreth" /></a>
+</p>
+
+## Sponsors
+
+<p>
+  <a href="https://github.com/complea" title="Complea"><img src="https://avatars.githubusercontent.com/u/144781871?v=4" width="64" height="64" alt="Complea" /></a>
+  <a href="https://github.com/DarthPanda12" title="DarthPanda12"><img src="https://avatars.githubusercontent.com/u/294241377?v=4" width="64" height="64" alt="DarthPanda12" /></a>
+</p>
+
+## Past Sponsors
+
+We are grateful to everyone who has supported this work.
+
+<ul>
+  <li><a href="https://github.com/bastienperez">Bastien Perez</a></li>
+  <li><a href="https://github.com/ChimeraArmadillo">ChimeraArmadillo</a></li>
+  <li><a href="https://github.com/mavericksevmont">E3k</a></li>
+  <li><a href="https://github.com/khofesh">Fahmi Ahmad</a></li>
+  <li><a href="https://github.com/user8446">Glenn Fowler</a></li>
+  <li><a href="https://github.com/StartAutomating">James Brundage</a></li>
+  <li><a href="https://github.com/joejsullivan">joejsullivan</a></li>
+  <li><a href="https://github.com/keenanbuck">keenanbuck</a></li>
+  <li><a href="https://github.com/Relkci">Kent Ickler</a></li>
+  <li><a href="https://github.com/kieranwalsh">Kieran Walsh</a></li>
+  <li><a href="https://github.com/mattcargile">Matthew A Cargile</a></li>
+  <li><a href="https://github.com/pminnebach">pminnebach</a></li>
+  <li><a href="https://github.com/PSingletary">PSingletary</a></li>
+  <li><a href="https://github.com/rvdwegen">Roel van der Wegen</a></li>
+  <li><a href="https://github.com/scott1138">scott1138</a></li>
+  <li><a href="https://github.com/Stephanevg">St&#233;phane</a></li>
+  <li><a href="https://github.com/sureshkrishnan83">SureshKrishnan</a></li>
+  <li><a href="https://github.com/thetechgy">Travis McDade</a></li>
+  <li><a href="https://github.com/whitTech">whitTech</a></li>
+</ul>
+
+You can support OfficeIMO through [GitHub Sponsors](https://github.com/sponsors/PrzemyslawKlys). Companies that need a VAT invoice can contact [contact@evotec.pl](mailto:contact@evotec.pl).
+<!-- POWERFORGE:sponsors:END -->


### PR DESCRIPTION
## Summary

- add a generated `SPONSORS.md` with tiered recognition for six current public sponsors and an untiered thank-you list for 19 former public sponsors
- add a compact sponsor avatar block near the top of the README, linked to the full roster
- add `.powerforge/github-content.json` so recognition tiers, manual companies/people, exclusions, presentation details, and per-sponsor tier overrides remain easy to customize
- add a weekly/on-demand update workflow pinned to immutable PowerForge commit `3660eec007084d755cd286c1af622d5d1814db96`

## Automation requirement

Tier recognition is intentionally configured with `requireFundingTierData: true`. Before enabling or manually running the workflow, add a repository or organization secret named `SPONSORS_TOKEN` containing a maintainer-authorized token that can read the sponsorable account's selected tiers. The normal repository token may retrieve the public roster but not tier prices; in that case the workflow fails before modifying files instead of silently moving everyone into the fallback tier.

## Dependency

The reusable engine and workflow are introduced by EvotecIT/PSPublishModule#593. This PR pins its exact reviewed commit rather than following a mutable branch.
