### PR TITLE
Clarify OfficeIMO 3.0 release state

### DIFF
--- a/Docs/officeimo-3.0-migration.md
+++ b/Docs/officeimo-3.0-migration.md
@@ -92,10 +92,16 @@ OfficeIMO.Epub.Html  ->  OfficeIMO.Epub.Image
 
 Update both the package reference and namespace imports. The adapter still retains EPUB chapter HTML and package resources internally and renders through the shared HTML image pipeline; the rename does not introduce another HTML renderer.
 
+## Compatibility shim visibility
+
+`OfficeIMO.Drawing` no longer exports `System.Runtime.CompilerServices.IsExternalInit` from its `netstandard2.0` and `net472` assets. That type was a compiler compatibility shim, not an OfficeIMO API. OfficeIMO still supplies an internal shim where the target framework needs one, so record and `init` usage in applications is unaffected. Remove any direct reference to the OfficeIMO-provided shim.
+
 ## Package and dependency ownership
 
 OfficeIMO 3.0 keeps format ownership in the existing document, renderer, and adapter projects. There is no new catch-all core package. Small adapter packages such as PDF or image exporters remain thin surfaces over the owning parser and renderer, which avoids duplicating conversion logic or forcing unrelated dependencies into document packages.
 
 After upgrading, perform a clean restore so lock files and cached transitive packages no longer retain 2.x OfficeIMO versions.
+
+The [3.0 public API review](officeimo-3.0-public-api-review.md) records the complete assembly-level comparison used to confirm that these are the only changed coordinated public surfaces.
 
 For the older 1.x to 2.0 API removals, see the [2.0 breaking API migration guide](officeimo.breaking-api-migration.md).

--- a/Docs/officeimo-3.0-public-api-review.md
+++ b/Docs/officeimo-3.0-public-api-review.md
@@ -1,0 +1,83 @@
+# OfficeIMO 3.0 public API review
+
+This review records the complete public-surface comparison used for the coordinated 3.0 release. It is separate from package validation: package validation checks the assets inside each newly built package, while this review identifies the intentional changes from the audited 2.x source line.
+
+## Compared release states
+
+| Side | Git commit | Package metadata |
+|---|---|---|
+| Audited 2.x baseline | `955ce7b589512499aa42ba1da654b4a7742817f4` | 81 coordinated projects at `2.0.1` |
+| Reviewed 3.0 tree | `584bff01202c7a1da2f8fc51b1d2b9636cc66821` | 81 coordinated projects at `3.0.0` |
+
+The framework inventory is identical on both sides:
+
+| Target | Compared assembly pairs |
+|---|---:|
+| `netstandard2.0` | 79 |
+| `net8.0` | 81 |
+| `net10.0` | 81 |
+| `net472` | 80 |
+| `net8.0-windows` and `net10.0-windows` WPF assets | 2 |
+| **Total** | **323** |
+
+Both trees were built in Release for every declared target. The .NET Framework assets were cross-targeted with Microsoft's reference assemblies; the WPF assets were cross-targeted with Windows targeting enabled. Windows CI remains the authoritative runtime check for those assets.
+
+`Meziantou.Framework.PublicApiGenerator.Tool` 2.0.2 generated one deterministic public API stub for each of the 323 assembly/target pairs. Each pair was compared by package identity, with `OfficeIMO.Epub.Html` paired to its 3.0 replacement, `OfficeIMO.Epub.Image`.
+
+## Complete result
+
+Two hundred ninety-seven of the 323 assembly/target pairs are byte-for-byte identical. Seventy-four of the 81 package identities are unchanged on every target. Seven packages changed:
+
+| 2.x identity | 3.0 identity | Changed targets | Added public declarations | Removed public declarations |
+|---|---|---|---:|---:|
+| `OfficeIMO.Drawing` | `OfficeIMO.Drawing` | `netstandard2.0`, `net472` | 0 | 1 |
+| `OfficeIMO.Epub.Html` | `OfficeIMO.Epub.Image` | `netstandard2.0`, `net8.0`, `net10.0`, `net472` | 11 | 11 |
+| `OfficeIMO.Excel` | `OfficeIMO.Excel` | `netstandard2.0`, `net8.0`, `net10.0`, `net472` | 1 | 735 |
+| `OfficeIMO.Excel.Pdf` | `OfficeIMO.Excel.Pdf` | `netstandard2.0`, `net8.0`, `net10.0`, `net472` | 19 | 16 |
+| `OfficeIMO.Pdf` | `OfficeIMO.Pdf` | `netstandard2.0`, `net8.0`, `net10.0`, `net472` | 34 | 0 |
+| `OfficeIMO.PowerPoint.Pdf` | `OfficeIMO.PowerPoint.Pdf` | `netstandard2.0`, `net8.0`, `net10.0`, `net472` | 19 | 16 |
+| `OfficeIMO.Word` | `OfficeIMO.Word` | `netstandard2.0`, `net8.0`, `net10.0`, `net472` | 14 | 25 |
+
+The counts include declarations beginning with `public`; namespace, brace, and blank lines are excluded. The two WPF-only Windows pairs are unchanged.
+
+## Breaking changes reviewed
+
+### Compatibility shim visibility
+
+The one older-target-only removal is `System.Runtime.CompilerServices.IsExternalInit`:
+
+```csharp
+namespace System.Runtime.CompilerServices {
+    public static class IsExternalInit { }
+}
+```
+
+The type was emitted by `OfficeIMO.Drawing` only for `netstandard2.0` and `net472`. It is a compiler compatibility shim rather than an OfficeIMO contract. The 3.0 assemblies still compile record and `init` syntax through an internal shim, but applications must not reference the OfficeIMO-provided type directly.
+
+### PDF table adapters
+
+The Excel and PowerPoint adapters now say “tables” in method and result names. Their reports add `SourceScope` and `HasOmittedPageContent`, so non-table PDF content can no longer be silently described as lossless. The exact old-to-new names are in the [3.0 migration guide](officeimo-3.0-migration.md#pdf-table-imports).
+
+### Legacy XLS
+
+`LegacyXlsLoadResult.Workbook`, `LegacyXlsLoadResult.ImportReport`, and `LegacyXlsLoadResult.CreateAdvancedImportReport()` are removed. `LegacyXlsLoadResult.CreateImportReport()` is added as the supported report entry point.
+
+`LegacyXlsImportReport` retains exactly these 23 public declarations:
+
+`WorksheetCount`, `ChartSheetCount`, `UnsupportedSheetCount`, `CellCount`, `FormulaCellCount`, `CommentCount`, `HyperlinkCount`, `DataValidationCount`, `ConditionalFormattingCount`, `AutoFilterCriteriaCount`, `DefinedNameCount`, `ExternalReferenceCount`, `PivotTableRecordCount`, `ChartRecordCount`, `DrawingRecordCount`, `UnsupportedFeatureCount`, `UnsupportedProjectionGapCount`, `PreservedFeatureRecordCount`, `ErrorCount`, `WarningCount`, `HasImportErrors`, `HasUnsupportedFeatures`, and `ToMarkdown()`.
+
+The other 732 former `LegacyXlsImportReport` telemetry declarations are removed from the public contract. Structured diagnostics, unsupported and preserved feature collections, `HasImportErrors`, `HasUnsupportedFeatures`, `HasConversionLoss`, and the stable summary remain public through the owning result/report APIs. Exhaustive BIFF corpus counters remain internal for OfficeIMO tests and compatibility analysis.
+
+### Word
+
+`FormattingHelper`, `HorizontalAlignmentHelper`, `ImageShapeStyleHelper`, `InlineRunHelper`, `WordHelpers.GetNextSdtId`, and the mutable `WordListLevel._level` field are not 3.0 contracts. Their supported replacements are `WordParagraph.GetFormattedRuns()`, `WordFormattedRun`, owner alignment/image/content-control APIs, and the read-only `WordListLevel.OpenXmlElement`. `WordHelpers` is now static.
+
+### EPUB image export
+
+`OfficeIMO.Epub.Html` and its namespace become `OfficeIMO.Epub.Image`. The adapter exports images through the shared HTML image pipeline; it does not claim EPUB-to-HTML conversion.
+
+## Additive PDF facade
+
+`OfficeIMO.Pdf` has no removals in this comparison. The added surface covers document preflight, merge and resize conveniences, external-signature completion, image export, table-extraction scope, and text preflight. These additions keep the fluent consumer path on the owning PDF document rather than creating another facade package.
+
+No other coordinated package or target-specific asset changed its generated public API between the compared states. The migration guide covers every intentional breaking category above; current generated API reference pages remain the source of truth for the complete 3.0 member inventory.

--- a/OfficeIMO.Shared.Tests/ReleasePackagingGuardrails.cs
+++ b/OfficeIMO.Shared.Tests/ReleasePackagingGuardrails.cs
@@ -12,10 +12,12 @@ public sealed class ReleasePackagingGuardrails {
         string readme = File.ReadAllText(Path.Combine(repositoryRoot, "README.md"));
         using JsonDocument buildDocument = JsonDocument.Parse(
             File.ReadAllText(Path.Combine(repositoryRoot, "Build", "project.build.json")));
-        int releasePackageCount = buildDocument.RootElement
+        HashSet<string> releasePackageIds = buildDocument.RootElement
             .GetProperty("ExpectedVersionMap")
             .EnumerateObject()
-            .Count();
+            .Select(static property => property.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        int releasePackageCount = releasePackageIds.Count;
 
         MatchCollection projectHeadings = Regex.Matches(
             readme,
@@ -46,6 +48,13 @@ public sealed class ReleasePackagingGuardrails {
         Assert.Contains("| Conversion and cloud bridge packages | 26 |", readme, StringComparison.Ordinal);
         Assert.Contains("| Unified Reader packages and tool | 28 |", readme, StringComparison.Ordinal);
         Assert.Contains("| Markdown renderer and OfficeIMO Markup surfaces | 11 |", readme, StringComparison.Ordinal);
+        Assert.Contains("NuGet publication is a separate release step.", readme, StringComparison.Ordinal);
+        Assert.DoesNotContain("All OfficeIMO .NET packages are published", readme, StringComparison.Ordinal);
+        AssertDotNetInstallCommands(
+            readme,
+            releasePackageIds,
+            expectedCount: 15,
+            toolPackageId: "OfficeIMO.Reader.Tool");
     }
 
     [Fact]
@@ -206,6 +215,22 @@ public sealed class ReleasePackagingGuardrails {
                 "Installation guide references an unknown package: " + packageId);
             Assert.Equal(project!.Version, match.Groups["version"].Value);
         });
+        Assert.Contains("NuGet publication is a separate release step", installation, StringComparison.Ordinal);
+        Assert.DoesNotContain("All OfficeIMO .NET packages are published", installation, StringComparison.Ordinal);
+        HashSet<string> releasePackageIds = packageProjects.Keys.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        string[] installationCommandIds = AssertDotNetInstallCommands(
+            installation,
+            releasePackageIds,
+            expectedCount: 9);
+        string[] packageReferenceIds = documentedPackages
+            .Cast<Match>()
+            .Select(static match => match.Groups["id"].Value)
+            .OrderBy(static packageId => packageId, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        Assert.Equal(
+            packageReferenceIds,
+            installationCommandIds.OrderBy(static packageId => packageId, StringComparer.OrdinalIgnoreCase).ToArray());
+        AssertPackageManagerInstallCommands(installation, releasePackageIds, expectedCount: 4);
 
         string openXmlVersion = ReadPackageReferenceVersion(
             repositoryRoot,
@@ -274,6 +299,88 @@ public sealed class ReleasePackagingGuardrails {
         Assert.Contains("`new WordHelpers()`", migration, StringComparison.Ordinal);
         Assert.Contains("using OfficeIMO.Word;", migration, StringComparison.Ordinal);
         Assert.Contains("vector graphics", migration, StringComparison.Ordinal);
+        Assert.Contains("System.Runtime.CompilerServices.IsExternalInit", migration, StringComparison.Ordinal);
+
+        string apiReview = File.ReadAllText(Path.Combine(
+            repositoryRoot,
+            "Docs",
+            "officeimo-3.0-public-api-review.md"));
+        Assert.Contains("323 assembly/target pairs", apiReview, StringComparison.Ordinal);
+        Assert.Contains("Seventy-four of the 81", apiReview, StringComparison.Ordinal);
+        Assert.Contains("Seven packages changed", apiReview, StringComparison.Ordinal);
+        Assert.Contains("955ce7b589512499aa42ba1da654b4a7742817f4", apiReview, StringComparison.Ordinal);
+        Assert.Contains("584bff01202c7a1da2f8fc51b1d2b9636cc66821", apiReview, StringComparison.Ordinal);
+        Assert.Contains("OfficeIMO.Drawing", apiReview, StringComparison.Ordinal);
+        Assert.Contains("System.Runtime.CompilerServices.IsExternalInit", apiReview, StringComparison.Ordinal);
+        Assert.Contains("`netstandard2.0`", apiReview, StringComparison.Ordinal);
+        Assert.Contains("`net472`", apiReview, StringComparison.Ordinal);
+        Assert.Contains("OfficeIMO.Epub.Html", apiReview, StringComparison.Ordinal);
+        Assert.Contains("OfficeIMO.Epub.Image", apiReview, StringComparison.Ordinal);
+        Assert.Contains("OfficeIMO.Excel.Pdf", apiReview, StringComparison.Ordinal);
+        Assert.Contains("OfficeIMO.PowerPoint.Pdf", apiReview, StringComparison.Ordinal);
+        Assert.Contains("OfficeIMO.Word", apiReview, StringComparison.Ordinal);
+    }
+
+    private static string[] AssertDotNetInstallCommands(
+        string content,
+        ISet<string> releasePackageIds,
+        int expectedCount,
+        string? toolPackageId = null) {
+        MatchCollection commands = Regex.Matches(
+            content,
+            @"^dotnet (?<verb>add package|tool install --global) (?<id>OfficeIMO\.[^\s]+)(?<arguments>[^\r\n]*)\r?$",
+            RegexOptions.Multiline | RegexOptions.CultureInvariant);
+
+        Assert.Equal(expectedCount, commands.Count);
+        string[] packageIds = commands
+            .Cast<Match>()
+            .Select(match => {
+                string packageId = match.Groups["id"].Value;
+                Assert.True(
+                    releasePackageIds.Contains(packageId),
+                    "Install command references an unknown package: " + match.Value);
+                Assert.Equal(" --version 3.0.0", match.Groups["arguments"].Value);
+
+                bool isTool = !string.IsNullOrWhiteSpace(toolPackageId) &&
+                    string.Equals(packageId, toolPackageId, StringComparison.OrdinalIgnoreCase);
+                Assert.Equal(
+                    isTool ? "tool install --global" : "add package",
+                    match.Groups["verb"].Value);
+                return packageId;
+            })
+            .ToArray();
+
+        Assert.Equal(
+            expectedCount,
+            packageIds.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        return packageIds;
+    }
+
+    private static void AssertPackageManagerInstallCommands(
+        string content,
+        ISet<string> releasePackageIds,
+        int expectedCount) {
+        MatchCollection commands = Regex.Matches(
+            content,
+            @"^Install-Package (?<id>OfficeIMO\.[^\s]+)(?<arguments>[^\r\n]*)\r?$",
+            RegexOptions.Multiline | RegexOptions.CultureInvariant);
+
+        Assert.Equal(expectedCount, commands.Count);
+        string[] packageIds = commands
+            .Cast<Match>()
+            .Select(match => {
+                string packageId = match.Groups["id"].Value;
+                Assert.True(
+                    releasePackageIds.Contains(packageId),
+                    "Package Manager command references an unknown package: " + match.Value);
+                Assert.Equal(" -Version 3.0.0", match.Groups["arguments"].Value);
+                return packageId;
+            })
+            .ToArray();
+
+        Assert.Equal(
+            expectedCount,
+            packageIds.Distinct(StringComparer.OrdinalIgnoreCase).Count());
     }
 
     private static PackageProject? ReadPackageProject(string projectPath) {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ OfficeIMO is a family of COM-free .NET libraries for creating, reading, editing,
 
 This is not one facade over a collection of unrelated document libraries. OfficeIMO owns its OneNote, PDF, Markdown, RTF, OpenDocument, AsciiDoc, LaTeX, CSV, EPUB, ZIP, drawing, legacy Word `.doc`, legacy Excel `.xls`, and legacy PowerPoint `.ppt`/`.pot`/`.pps` implementations. Word, Excel, and PowerPoint use the Open XML SDK for package mechanics; HTML uses AngleSharp for DOM and CSS parsing. Converters compose the same first-party object models used by the native packages and return diagnostics when a target format cannot carry everything from the source.
 
-The current coordinated package line is `3.0.x`. Applications should upgrade OfficeIMO packages together: 3.0 tightens public boundaries, makes table-only PDF recovery explicit, and aligns the complete release set on one version. See the [2.x to 3.0 migration guide](Docs/officeimo-3.0-migration.md).
+The current source and packaging line is `3.0.x`. Applications should upgrade OfficeIMO packages together: 3.0 tightens public boundaries, makes table-only PDF recovery explicit, and aligns the complete release set on one version. See the [2.x to 3.0 migration guide](Docs/officeimo-3.0-migration.md).
+
+NuGet publication is a separate release step. The repository, project files, and locally packed artifacts target `3.0.0`; a package ID is installable from NuGet.org only after that exact artifact has been published there. Until then, use the clean local feed produced by the release build or remain on the current public stable version.
 
 If OfficeIMO saves you time, please consider supporting the work through [GitHub Sponsors](https://github.com/sponsors/PrzemyslawKlys) or [PayPal](https://paypal.me/PrzemyslawKlys). PowerShell users should start with [PSWriteOffice](https://github.com/EvotecIT/PSWriteOffice).
 
@@ -940,35 +942,35 @@ Fixed-layout PDF import is necessarily semantic rather than visually lossless. R
 
 ## Install
 
-Install only the native packages and adapters an application needs:
+Install only the native packages and adapters an application needs. The commands below deliberately request `3.0.0`; they work against NuGet.org after each package ID is published, or against the clean local feed produced by `Build/Build-Project.ps1` before publication.
 
 ```powershell
-dotnet add package OfficeIMO.Word
-dotnet add package OfficeIMO.Word.Pdf
+dotnet add package OfficeIMO.Word --version 3.0.0
+dotnet add package OfficeIMO.Word.Pdf --version 3.0.0
 
-dotnet add package OfficeIMO.Excel
-dotnet add package OfficeIMO.Excel.Html
-dotnet add package OfficeIMO.Excel.Pdf
+dotnet add package OfficeIMO.Excel --version 3.0.0
+dotnet add package OfficeIMO.Excel.Html --version 3.0.0
+dotnet add package OfficeIMO.Excel.Pdf --version 3.0.0
 
-dotnet add package OfficeIMO.Epub
-dotnet add package OfficeIMO.Epub.Image
+dotnet add package OfficeIMO.Epub --version 3.0.0
+dotnet add package OfficeIMO.Epub.Image --version 3.0.0
 
-dotnet add package OfficeIMO.Reader.Pdf
+dotnet add package OfficeIMO.Reader.Pdf --version 3.0.0
 
 # Add every Reader adapter only when a broad ingestion host genuinely needs all formats.
-dotnet add package OfficeIMO.Reader.All
+dotnet add package OfficeIMO.Reader.All --version 3.0.0
 
-dotnet add package OfficeIMO.OneNote
-dotnet add package OfficeIMO.OneNote.Markdown
-dotnet add package OfficeIMO.OneNote.Html
-dotnet add package OfficeIMO.OneNote.Pdf
-dotnet add package OfficeIMO.Reader.OneNote
+dotnet add package OfficeIMO.OneNote --version 3.0.0
+dotnet add package OfficeIMO.OneNote.Markdown --version 3.0.0
+dotnet add package OfficeIMO.OneNote.Html --version 3.0.0
+dotnet add package OfficeIMO.OneNote.Pdf --version 3.0.0
+dotnet add package OfficeIMO.Reader.OneNote --version 3.0.0
 
 # Install the broad local-reader command only when a CLI is the desired surface.
-dotnet tool install --global OfficeIMO.Reader.Tool
+dotnet tool install --global OfficeIMO.Reader.Tool --version 3.0.0
 ```
 
-All coordinated packages use the same `3.0.x` compatibility line. Avoid mixing OfficeIMO `2.x` and `3.x` packages in one application.
+All coordinated source packages use the same `3.0.x` compatibility line. Avoid mixing OfficeIMO `2.x` and `3.x` packages in one application.
 
 ## Common workflows
 
@@ -1125,6 +1127,7 @@ Most shipping libraries target `netstandard2.0`, `net8.0`, and `net10.0`. Many a
 
 - [Examples](OfficeIMO.Examples/README.md)
 - [2.x to 3.0 migration](Docs/officeimo-3.0-migration.md)
+- [2.x to 3.0 public API review](Docs/officeimo-3.0-public-api-review.md)
 - [2.0 breaking API migration](Docs/officeimo.breaking-api-migration.md)
 - [Image export capability matrix](Docs/officeimo.image-export-capability-matrix.md)
 - [PDF current state](Docs/officeimo.pdf.current-state.md)

--- a/Website/content/docs/getting-started/installation/index.md
+++ b/Website/content/docs/getting-started/installation/index.md
@@ -6,9 +6,9 @@ order: 1
 
 # Installation
 
-All OfficeIMO .NET packages are published to [NuGet.org](https://www.nuget.org/profiles/EvotecIT). The PowerShell module is published to the [PowerShell Gallery](https://www.powershellgallery.com/packages/PSWriteOffice).
+Released OfficeIMO .NET packages are distributed through [NuGet.org](https://www.nuget.org/profiles/EvotecIT). The PowerShell module is distributed through the [PowerShell Gallery](https://www.powershellgallery.com/packages/PSWriteOffice).
 
-The explicit references below target the coordinated `3.0.0` release. Upgrade OfficeIMO packages together rather than mixing release lines. Until NuGet lists `3.0.0`, versionless install commands resolve the current public stable version instead.
+This source tree and its locally packed artifacts target the coordinated `3.0.0` release. NuGet publication is a separate release step: the examples below will restore from NuGet.org only after each exact `3.0.0` package ID is live. Before publication, point NuGet at the clean local feed produced by `Build/Build-Project.ps1`; otherwise remain on the current public stable version. Upgrade OfficeIMO packages together rather than mixing release lines.
 
 ## .NET Packages
 
@@ -19,13 +19,13 @@ The core Word document library. Create, read, and modify `.docx` files.
 **.NET CLI**
 
 ```bash
-dotnet add package OfficeIMO.Word
+dotnet add package OfficeIMO.Word --version 3.0.0
 ```
 
 **Package Manager Console**
 
 ```powershell
-Install-Package OfficeIMO.Word
+Install-Package OfficeIMO.Word -Version 3.0.0
 ```
 
 **PackageReference (csproj)**
@@ -41,13 +41,13 @@ Create and manipulate Excel `.xlsx` workbooks.
 **.NET CLI**
 
 ```bash
-dotnet add package OfficeIMO.Excel
+dotnet add package OfficeIMO.Excel --version 3.0.0
 ```
 
 **Package Manager Console**
 
 ```powershell
-Install-Package OfficeIMO.Excel
+Install-Package OfficeIMO.Excel -Version 3.0.0
 ```
 
 **PackageReference**
@@ -63,13 +63,13 @@ Fluent Markdown builder, typed reader/AST, and HTML renderer. Zero external depe
 **.NET CLI**
 
 ```bash
-dotnet add package OfficeIMO.Markdown
+dotnet add package OfficeIMO.Markdown --version 3.0.0
 ```
 
 **Package Manager Console**
 
 ```powershell
-Install-Package OfficeIMO.Markdown
+Install-Package OfficeIMO.Markdown -Version 3.0.0
 ```
 
 **PackageReference**
@@ -85,13 +85,13 @@ Strongly-typed CSV document model with validation and streaming.
 **.NET CLI**
 
 ```bash
-dotnet add package OfficeIMO.CSV
+dotnet add package OfficeIMO.CSV --version 3.0.0
 ```
 
 **Package Manager Console**
 
 ```powershell
-Install-Package OfficeIMO.CSV
+Install-Package OfficeIMO.CSV -Version 3.0.0
 ```
 
 **PackageReference**
@@ -107,7 +107,7 @@ Bidirectional Word-to-HTML conversion powered by AngleSharp.
 **.NET CLI**
 
 ```bash
-dotnet add package OfficeIMO.Word.Html
+dotnet add package OfficeIMO.Word.Html --version 3.0.0
 ```
 
 **PackageReference**
@@ -123,7 +123,7 @@ Bidirectional Word-to-Markdown conversion built on OfficeIMO.Markdown.
 **.NET CLI**
 
 ```bash
-dotnet add package OfficeIMO.Word.Markdown
+dotnet add package OfficeIMO.Word.Markdown --version 3.0.0
 ```
 
 **PackageReference**
@@ -139,7 +139,7 @@ Word-to-PDF conversion built on the first-party OfficeIMO.Pdf engine.
 **.NET CLI**
 
 ```bash
-dotnet add package OfficeIMO.Word.Pdf
+dotnet add package OfficeIMO.Word.Pdf --version 3.0.0
 ```
 
 **PackageReference**
@@ -155,7 +155,7 @@ Excel workbook-to-PDF conversion built on the first-party OfficeIMO.Pdf engine.
 **.NET CLI**
 
 ```bash
-dotnet add package OfficeIMO.Excel.Pdf
+dotnet add package OfficeIMO.Excel.Pdf --version 3.0.0
 ```
 
 **PackageReference**
@@ -171,7 +171,7 @@ Direct PDF generation, reading, editing, rendering, and signature workflows.
 **.NET CLI**
 
 ```bash
-dotnet add package OfficeIMO.Pdf
+dotnet add package OfficeIMO.Pdf --version 3.0.0
 ```
 
 **PackageReference**


### PR DESCRIPTION
## Summary

- distinguish the 3.0 source and packaging state from the separate NuGet publication step
- pin README and website install examples to exact 3.0.0 package versions
- record the complete 2.x-to-3.0 public API review across all 323 declared assembly and target-framework pairs
- document the older-target IsExternalInit shim removal and every intentional breaking category
- enforce valid package IDs, exact command versions, command forms, PackageReferences, and Package Manager examples with release guardrails

## Migration notes

The API review found 297 unchanged assembly/target pairs and 26 changed pairs across seven package identities. OfficeIMO.Drawing no longer exposes System.Runtime.CompilerServices.IsExternalInit from netstandard2.0 and net472; the compiler shim remains internal, so normal record and init usage is unaffected.

## Validation

- ReleasePackagingGuardrails: 5/5 on net8.0 and net10.0
- complete net472 test dependency graph: zero warnings and zero errors
- baseline/current public API generation: 323/323 pairs on each side
- website CI pipeline: 36 stages, 2,309 pages, 944,181 links, zero SEO errors or new issues, final audit passed

No packages are published by this change.