### PR TITLE
Add mixed-format Reader corpus search and streaming batches

### DIFF
--- a/OfficeIMO.Email/OfficeIMO.Email.csproj
+++ b/OfficeIMO.Email/OfficeIMO.Email.csproj
@@ -65,6 +65,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="OfficeIMO.Email.Tests" />
+    <InternalsVisibleTo Include="OfficeIMO.Reader.Tests" />
   </ItemGroup>
 
 </Project>

--- a/OfficeIMO.Reader.Core/DocumentReader.Async.cs
+++ b/OfficeIMO.Reader.Core/DocumentReader.Async.cs
@@ -197,7 +197,8 @@ internal static partial class DocumentReaderEngine {
             batchOptions,
             DefaultMaxConcurrentReads,
             MaximumConcurrentReads,
-            (path, token) => ReadDocumentAsync(path, options, token),
+            (index, path, token) => ReadDocumentAsync(path, options, token),
+            onCompleted: null,
             cancellationToken);
     }
 

--- a/OfficeIMO.Reader.Core/DocumentReader.PathEnumeration.cs
+++ b/OfficeIMO.Reader.Core/DocumentReader.PathEnumeration.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+
+namespace OfficeIMO.Reader;
+
+internal static partial class DocumentReaderEngine {
+    internal static IEnumerable<string> EnumerateDocumentPaths(
+        IEnumerable<string> paths,
+        ReaderFolderOptions? folderOptions,
+        CancellationToken cancellationToken) {
+        if (paths == null) throw new ArgumentNullException(nameof(paths));
+
+        ReaderFolderOptions effectiveFolder = NormalizeFolderOptions(folderOptions);
+        HashSet<string> allowedExtensions = NormalizeExtensions(effectiveFolder.Extensions);
+        foreach (string path in paths) {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (string.IsNullOrWhiteSpace(path)) {
+                throw new ArgumentException("Paths cannot contain null or empty values.", nameof(paths));
+            }
+
+            if (!Directory.Exists(path)) {
+                yield return path;
+                continue;
+            }
+
+            int filesEnumerated = 0;
+            foreach (string file in EnumerateFilesSafeDeterministic(path, effectiveFolder, cancellationToken)) {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (filesEnumerated >= effectiveFolder.MaxFiles) break;
+
+                string extension = NormalizeExtension(TryGetExtension(file));
+                if (!allowedExtensions.Contains(extension) &&
+                    !string.Equals(Path.GetFileName(file), "winmail.dat", StringComparison.OrdinalIgnoreCase)) {
+                    continue;
+                }
+
+                filesEnumerated++;
+                yield return file;
+            }
+        }
+    }
+}

--- a/OfficeIMO.Reader.Core/OfficeDocumentReader.Batch.cs
+++ b/OfficeIMO.Reader.Core/OfficeDocumentReader.Batch.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OfficeIMO.Reader;
+
+public sealed partial class OfficeDocumentReader {
+    /// <summary>
+    /// Asynchronously reads a bounded set of files and captures a success or error outcome for every path.
+    /// </summary>
+    /// <remarks>
+    /// Results retain input order. <paramref name="onCompleted"/> is invoked as individual reads finish and
+    /// may run concurrently on worker threads. Cancellation is never converted into a failed outcome.
+    /// </remarks>
+    public Task<IReadOnlyList<ReaderDocumentReadOutcome>> ReadDocumentsDetailedAsync(
+        IEnumerable<string> paths,
+        ReaderOptions? options = null,
+        ReaderBatchOptions? batchOptions = null,
+        Action<ReaderDocumentReadOutcome>? onCompleted = null,
+        CancellationToken cancellationToken = default) {
+        return ReaderBatchExecutor.ExecuteAsync(
+            paths,
+            batchOptions,
+            MaxConcurrentReads,
+            MaxConcurrentReads,
+            (index, path, token) => ReadDocumentOutcomeAsync(index, path, options, token),
+            onCompleted,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Asynchronously reads a bounded set of files and reports each resilient outcome without retaining completed
+    /// document results for the lifetime of the whole batch.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="onCompleted"/> is invoked as individual reads finish and may run concurrently on worker
+    /// threads. Callers that need an input-ordered materialized result should use
+    /// <see cref="ReadDocumentsDetailedAsync"/> instead. Cancellation is never converted into a failed outcome.
+    /// </remarks>
+    public Task ReadDocumentsAsCompletedAsync(
+        IEnumerable<string> paths,
+        Action<ReaderDocumentReadOutcome> onCompleted,
+        ReaderOptions? options = null,
+        ReaderBatchOptions? batchOptions = null,
+        CancellationToken cancellationToken = default) {
+        return ReaderBatchExecutor.ExecuteAsCompletedAsync(
+            paths,
+            batchOptions,
+            MaxConcurrentReads,
+            MaxConcurrentReads,
+            (index, path, token) => ReadDocumentOutcomeAsync(index, path, options, token),
+            onCompleted,
+            cancellationToken);
+    }
+
+    private async Task<ReaderDocumentReadOutcome> ReadDocumentOutcomeAsync(
+        int index,
+        string path,
+        ReaderOptions? options,
+        CancellationToken cancellationToken) {
+        try {
+            OfficeDocumentReadResult document = await ReadDocumentAsync(path, options, cancellationToken)
+                .ConfigureAwait(false);
+            return new ReaderDocumentReadOutcome(index, path, document, error: null);
+        } catch (OperationCanceledException) {
+            throw;
+        } catch (Exception exception) {
+            return new ReaderDocumentReadOutcome(index, path, document: null, exception);
+        }
+    }
+}

--- a/OfficeIMO.Reader.Core/OfficeDocumentReader.PathEnumeration.cs
+++ b/OfficeIMO.Reader.Core/OfficeDocumentReader.PathEnumeration.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Threading;
+
+namespace OfficeIMO.Reader;
+
+public sealed partial class OfficeDocumentReader {
+    /// <summary>
+    /// Expands files and folders using this reader's registered extensions.
+    /// </summary>
+    /// <remarks>
+    /// Explicit file paths are returned as supplied so callers receive a normal read error for missing or unsupported
+    /// files. Folder contents are filtered to registered or explicitly requested extensions. Directory traversal uses
+    /// <see cref="ReaderFolderOptions"/> for recursion, ordering, reparse-point handling, and per-folder limits.
+    /// </remarks>
+    public IEnumerable<string> EnumerateDocumentPaths(
+        IEnumerable<string> paths,
+        ReaderFolderOptions? folderOptions = null,
+        CancellationToken cancellationToken = default) {
+        return Scope(DocumentReaderEngine.EnumerateDocumentPaths(paths, folderOptions, cancellationToken));
+    }
+}

--- a/OfficeIMO.Reader.Core/OfficeDocumentReader.cs
+++ b/OfficeIMO.Reader.Core/OfficeDocumentReader.cs
@@ -268,7 +268,8 @@ public sealed partial class OfficeDocumentReader {
             batchOptions,
             MaxConcurrentReads,
             MaxConcurrentReads,
-            (path, token) => ReadDocumentAsync(path, options, token),
+            (index, path, token) => ReadDocumentAsync(path, options, token),
+            onCompleted: null,
             cancellationToken);
     }
 

--- a/OfficeIMO.Reader.Core/OfficeDocumentSearch.cs
+++ b/OfficeIMO.Reader.Core/OfficeDocumentSearch.cs
@@ -45,12 +45,16 @@ public sealed class OfficeDocumentSearchHit {
 /// <summary>Search results with aggregated page citation information.</summary>
 public sealed class OfficeDocumentSearchResult {
     internal OfficeDocumentSearchResult(
+        OfficeDocumentSource source,
         string query,
         int totalPageCount,
-        IReadOnlyList<OfficeDocumentSearchHit> hits) {
+        IReadOnlyList<OfficeDocumentSearchHit> hits,
+        bool maximumResultsReached) {
+        Source = source;
         Query = query;
         TotalPageCount = totalPageCount;
         Hits = hits;
+        MaximumResultsReached = maximumResultsReached;
         PageNumbers = hits
             .SelectMany(static hit => hit.Pages)
             .Where(static location => location.Number.HasValue)
@@ -59,6 +63,9 @@ public sealed class OfficeDocumentSearchResult {
             .OrderBy(static number => number)
             .ToArray();
     }
+
+    /// <summary>Source document that was searched.</summary>
+    public OfficeDocumentSource Source { get; }
 
     /// <summary>Original query text.</summary>
     public string Query { get; }
@@ -71,6 +78,11 @@ public sealed class OfficeDocumentSearchResult {
 
     /// <summary>Distinct one-based physical pages containing matches.</summary>
     public IReadOnlyList<int> PageNumbers { get; }
+
+    /// <summary>
+    /// True when the configured maximum result count was reached and the search stopped at that ceiling.
+    /// </summary>
+    public bool MaximumResultsReached { get; }
 }
 
 public static partial class OfficeDocumentReadResultExtensions {
@@ -151,12 +163,22 @@ public static partial class OfficeDocumentReadResultExtensions {
                         ? occurrencePages[occurrenceIndex]
                         : pageFallback));
                 if (hits.Count >= effective.MaximumResults) {
-                    return new OfficeDocumentSearchResult(query, document.GetTotalPageCount(), hits.AsReadOnly());
+                    return new OfficeDocumentSearchResult(
+                        document.Source ?? new OfficeDocumentSource(),
+                        query,
+                        document.GetTotalPageCount(),
+                        hits.AsReadOnly(),
+                        maximumResultsReached: true);
                 }
             }
         }
 
-        return new OfficeDocumentSearchResult(query, document.GetTotalPageCount(), hits.AsReadOnly());
+        return new OfficeDocumentSearchResult(
+            document.Source ?? new OfficeDocumentSource(),
+            query,
+            document.GetTotalPageCount(),
+            hits.AsReadOnly(),
+            maximumResultsReached: false);
     }
 
     private static IReadOnlyList<IReadOnlyList<OfficeDocumentPageLocation>>? CorrelateOccurrencesToPages(

--- a/OfficeIMO.Reader.Core/ReaderBatchOptions.cs
+++ b/OfficeIMO.Reader.Core/ReaderBatchOptions.cs
@@ -26,7 +26,48 @@ internal static class ReaderBatchExecutor {
         ReaderBatchOptions? options,
         int defaultMaxDegreeOfParallelism,
         int maxDegreeOfParallelismLimit,
-        Func<string, CancellationToken, Task<T>> readAsync,
+        Func<int, string, CancellationToken, Task<T>> readAsync,
+        Action<T>? onCompleted,
+        CancellationToken cancellationToken) {
+        return await ExecuteCoreAsync(
+            paths,
+            options,
+            defaultMaxDegreeOfParallelism,
+            maxDegreeOfParallelismLimit,
+            readAsync,
+            onCompleted,
+            retainResults: true,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public static async Task ExecuteAsCompletedAsync<T>(
+        IEnumerable<string> paths,
+        ReaderBatchOptions? options,
+        int defaultMaxDegreeOfParallelism,
+        int maxDegreeOfParallelismLimit,
+        Func<int, string, CancellationToken, Task<T>> readAsync,
+        Action<T> onCompleted,
+        CancellationToken cancellationToken) {
+        if (onCompleted == null) throw new ArgumentNullException(nameof(onCompleted));
+        await ExecuteCoreAsync(
+            paths,
+            options,
+            defaultMaxDegreeOfParallelism,
+            maxDegreeOfParallelismLimit,
+            readAsync,
+            onCompleted,
+            retainResults: false,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<IReadOnlyList<T>> ExecuteCoreAsync<T>(
+        IEnumerable<string> paths,
+        ReaderBatchOptions? options,
+        int defaultMaxDegreeOfParallelism,
+        int maxDegreeOfParallelismLimit,
+        Func<int, string, CancellationToken, Task<T>> readAsync,
+        Action<T>? onCompleted,
+        bool retainResults,
         CancellationToken cancellationToken) {
         if (paths == null) throw new ArgumentNullException(nameof(paths));
         if (readAsync == null) throw new ArgumentNullException(nameof(readAsync));
@@ -61,7 +102,7 @@ internal static class ReaderBatchExecutor {
             return Array.Empty<T>();
         }
 
-        var results = new T[inputs.Count];
+        T[]? results = retainResults ? new T[inputs.Count] : null;
         int nextIndex = -1;
         int workerCount = Math.Min(degree, inputs.Count);
         using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -72,7 +113,7 @@ internal static class ReaderBatchExecutor {
         }
 
         await Task.WhenAll(workers).ConfigureAwait(false);
-        return results;
+        return results ?? Array.Empty<T>();
 
         async Task RunWorkerAsync() {
             try {
@@ -83,7 +124,9 @@ internal static class ReaderBatchExecutor {
                         return;
                     }
 
-                    results[index] = await readAsync(inputs[index], linkedCancellation.Token).ConfigureAwait(false);
+                    T result = await readAsync(index, inputs[index], linkedCancellation.Token).ConfigureAwait(false);
+                    if (results != null) results[index] = result;
+                    onCompleted?.Invoke(result);
                 }
             } catch {
                 linkedCancellation.Cancel();

--- a/OfficeIMO.Reader.Core/ReaderDocumentReadOutcome.cs
+++ b/OfficeIMO.Reader.Core/ReaderDocumentReadOutcome.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace OfficeIMO.Reader;
+
+/// <summary>
+/// Describes the success or failure of one path in a resilient multi-document read.
+/// </summary>
+public sealed class ReaderDocumentReadOutcome {
+    internal ReaderDocumentReadOutcome(
+        int index,
+        string path,
+        OfficeDocumentReadResult? document,
+        Exception? error) {
+        Index = index;
+        Path = path;
+        Document = document;
+        Error = error;
+    }
+
+    /// <summary>Zero-based input position assigned after path expansion.</summary>
+    public int Index { get; }
+
+    /// <summary>Resolved source path.</summary>
+    public string Path { get; }
+
+    /// <summary>Document result when reading succeeded.</summary>
+    public OfficeDocumentReadResult? Document { get; }
+
+    /// <summary>Original read exception when reading failed.</summary>
+    public Exception? Error { get; }
+
+    /// <summary>True when the document was read successfully.</summary>
+    public bool Succeeded => Document != null && Error == null;
+}

--- a/OfficeIMO.Reader.Tests/OfficeIMO.Reader.Tests.csproj
+++ b/OfficeIMO.Reader.Tests/OfficeIMO.Reader.Tests.csproj
@@ -81,6 +81,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\OfficeIMO.Email.Tests\Store\Pst\PstTestFileBuilder.cs" Link="EmailStore\PstTestFileBuilder.cs" />
     <Compile Include="..\OfficeIMO.Pdf.Tests\Pdf\PdfPngTestImages.cs" Link="Pdf\PdfPngTestImages.cs" />
     <Compile Include="..\OfficeIMO.TestAssets\TestStreams\NonSeekableReadStream.cs" Link="TestStreams\NonSeekableReadStream.cs" />
     <Compile Include="..\TestSupport\OpenDocument\OdfTestPackageRewriter.cs" Link="TestSupport\OdfTestPackageRewriter.cs" />

--- a/OfficeIMO.Reader.Tests/Reader.BatchDetailed.cs
+++ b/OfficeIMO.Reader.Tests/Reader.BatchDetailed.cs
@@ -1,0 +1,170 @@
+using OfficeIMO.Reader;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class ReaderBatchDetailedTests {
+    [Fact]
+    public async Task DetailedBatchCapturesPerPathFailuresAndStreamsCompletedOutcomes() {
+        const string extension = ".readerbatchdetail";
+        string root = Path.Combine(Path.GetTempPath(), "officeimo-reader-batch-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        string[] paths = {
+            Path.Combine(root, "01-good" + extension),
+            Path.Combine(root, "02-bad" + extension),
+            Path.Combine(root, "03-good" + extension)
+        };
+        foreach (string path in paths) File.WriteAllText(path, "input");
+
+        try {
+            OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+                .WithMaxConcurrentReads(2)
+                .AddHandler(new ReaderHandlerRegistration {
+                    Id = "officeimo.tests.batch.detailed",
+                    Kind = ReaderInputKind.Text,
+                    Extensions = new[] { extension },
+                    ReadDocumentPathAsync = (path, options, cancellationToken) => {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        if (Path.GetFileName(path).Contains("bad", StringComparison.Ordinal)) {
+                            throw new InvalidDataException("Synthetic per-path failure.");
+                        }
+
+                        return Task.FromResult(CreateResult(path));
+                    }
+                })
+                .Build();
+            var completed = new ConcurrentBag<ReaderDocumentReadOutcome>();
+
+            IReadOnlyList<ReaderDocumentReadOutcome> outcomes = await reader.ReadDocumentsDetailedAsync(
+                paths,
+                batchOptions: new ReaderBatchOptions {
+                    MaxDocuments = 3,
+                    MaxDegreeOfParallelism = 2
+                },
+                onCompleted: completed.Add);
+
+            Assert.Equal(paths, outcomes.Select(outcome => outcome.Path).ToArray());
+            Assert.Equal(new[] { 0, 1, 2 }, outcomes.Select(outcome => outcome.Index).ToArray());
+            Assert.Equal(2, outcomes.Count(outcome => outcome.Succeeded));
+            ReaderDocumentReadOutcome failed = Assert.Single(outcomes, outcome => !outcome.Succeeded);
+            Assert.IsType<InvalidDataException>(failed.Error);
+            Assert.Null(failed.Document);
+            Assert.Equal(3, completed.Count);
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void PathEnumerationUsesRegisteredFormatsAndCallerControlledFolderLimits() {
+        const string extension = ".readerpathexpand";
+        string root = Path.Combine(Path.GetTempPath(), "officeimo-reader-paths-" + Guid.NewGuid().ToString("N"));
+        string nested = Path.Combine(root, "nested");
+        Directory.CreateDirectory(nested);
+        string first = Path.Combine(root, "01-first" + extension);
+        string second = Path.Combine(nested, "02-second" + extension);
+        string ignored = Path.Combine(root, "ignored.unsupported");
+        File.WriteAllText(first, "first");
+        File.WriteAllText(second, "second");
+        File.WriteAllText(ignored, "ignored");
+
+        try {
+            OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+                .AddHandler(new ReaderHandlerRegistration {
+                    Id = "officeimo.tests.path.enumeration",
+                    Kind = ReaderInputKind.Text,
+                    Extensions = new[] { extension },
+                    ReadDocumentPath = (path, options, cancellationToken) => CreateResult(path)
+                })
+                .Build();
+
+            string[] topLevel = reader.EnumerateDocumentPaths(
+                new[] { root },
+                new ReaderFolderOptions { Recurse = false, MaxFiles = 10 }).ToArray();
+            string[] recursive = reader.EnumerateDocumentPaths(
+                new[] { root },
+                new ReaderFolderOptions { Recurse = true, MaxFiles = int.MaxValue }).ToArray();
+            string[] explicitUnsupported = reader.EnumerateDocumentPaths(new[] { ignored }).ToArray();
+
+            Assert.Equal(new[] { first }, topLevel);
+            Assert.Equal(new[] { first, second }, recursive);
+            Assert.Equal(new[] { ignored }, explicitUnsupported);
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task AsCompletedBatchReportsOutcomesWithoutReturningAMaterializedCollection() {
+        const string extension = ".readerbatchstream";
+        string root = Path.Combine(Path.GetTempPath(), "officeimo-reader-stream-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        string[] paths = Enumerable.Range(1, 8)
+            .Select(index => Path.Combine(root, index.ToString("00") + extension))
+            .ToArray();
+        foreach (string path in paths) File.WriteAllText(path, "input");
+
+        try {
+            int activeReads = 0;
+            int peakReads = 0;
+            OfficeDocumentReader reader = new OfficeDocumentReaderBuilder()
+                .WithMaxConcurrentReads(6)
+                .AddHandler(new ReaderHandlerRegistration {
+                    Id = "officeimo.tests.batch.as-completed",
+                    Kind = ReaderInputKind.Text,
+                    Extensions = new[] { extension },
+                    ReadDocumentPathAsync = async (path, options, cancellationToken) => {
+                        int active = Interlocked.Increment(ref activeReads);
+                        UpdateMaximum(ref peakReads, active);
+                        try {
+                            await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+                            return CreateResult(path);
+                        } finally {
+                            Interlocked.Decrement(ref activeReads);
+                        }
+                    }
+                })
+                .Build();
+            var completed = new ConcurrentBag<ReaderDocumentReadOutcome>();
+
+            await reader.ReadDocumentsAsCompletedAsync(
+                paths,
+                completed.Add,
+                batchOptions: new ReaderBatchOptions {
+                    MaxDocuments = paths.Length,
+                    MaxDegreeOfParallelism = 6
+                });
+
+            Assert.Equal(paths.Length, completed.Count);
+            Assert.All(completed, outcome => Assert.True(outcome.Succeeded));
+            Assert.Equal(paths, completed.OrderBy(outcome => outcome.Index).Select(outcome => outcome.Path).ToArray());
+            Assert.True(peakReads >= 5, $"Expected at least five concurrent reads but observed {peakReads}.");
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static void UpdateMaximum(ref int target, int value) {
+        int current;
+        do {
+            current = Volatile.Read(ref target);
+            if (value <= current) return;
+        } while (Interlocked.CompareExchange(ref target, value, current) != current);
+    }
+
+    private static OfficeDocumentReadResult CreateResult(string path) => new OfficeDocumentReadResult {
+        Kind = ReaderInputKind.Text,
+        Source = new OfficeDocumentSource { Path = path },
+        Blocks = new[] {
+            new OfficeDocumentBlock {
+                Id = "block:0001",
+                Kind = "paragraph",
+                Text = "searchable text",
+                Location = new ReaderLocation { Path = path }
+            }
+        }
+    };
+}

--- a/OfficeIMO.Reader.Tests/Reader.MixedCorpus.cs
+++ b/OfficeIMO.Reader.Tests/Reader.MixedCorpus.cs
@@ -1,0 +1,84 @@
+using OfficeIMO.Email.Store.Tests;
+using OfficeIMO.Excel;
+using OfficeIMO.Reader;
+using OfficeIMO.Word;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public sealed class ReaderMixedCorpusTests {
+    [Fact]
+    public async Task OneReaderCanDiscoverReadAndSearchWordExcelMarkdownPstAndOst() {
+        const string query = "Synthetic";
+        string root = Path.Combine(Path.GetTempPath(), "officeimo-reader-mixed-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        string wordPath = Path.Combine(root, "01-word.docx");
+        string excelPath = Path.Combine(root, "02-excel.xlsx");
+        string markdownPath = Path.Combine(root, "03-notes.md");
+        string pstPath = Path.Combine(root, "04-mail.pst");
+        string ostPath = Path.Combine(root, "05-offline.ost");
+        string ignoredPath = Path.Combine(root, "ignored.bin");
+
+        try {
+            using (WordDocument document = WordDocument.Create(wordPath)) {
+                document.AddParagraph("Synthetic contract in Word");
+                document.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Create(excelPath)) {
+                ExcelSheet sheet = document.AddWorksheet("Data");
+                sheet.Cell(1, 1, "Synthetic contract in Excel");
+                document.Save();
+            }
+
+            File.WriteAllText(markdownPath, "# Synthetic contract in Markdown");
+            File.WriteAllBytes(pstPath, PstTestFileBuilder.Create());
+            File.WriteAllBytes(ostPath, PstTestFileBuilder.Create(ost: true));
+            File.WriteAllText(ignoredPath, "Synthetic unsupported input");
+
+            OfficeDocumentReader reader = OfficeIMO.Reader.Tests.ReaderTestReaders.All;
+            string[] paths = reader.EnumerateDocumentPaths(
+                new[] { root },
+                new ReaderFolderOptions {
+                    Recurse = true,
+                    MaxFiles = int.MaxValue
+                }).ToArray();
+
+            Assert.Equal(
+                new[] { wordPath, excelPath, markdownPath, pstPath, ostPath },
+                paths);
+
+            IReadOnlyList<ReaderDocumentReadOutcome> outcomes = await reader.ReadDocumentsDetailedAsync(
+                paths,
+                batchOptions: new ReaderBatchOptions {
+                    MaxDocuments = int.MaxValue,
+                    MaxDegreeOfParallelism = 4
+                });
+
+            Assert.All(outcomes, outcome => Assert.True(outcome.Succeeded, outcome.Error?.ToString()));
+            Assert.Equal(
+                new[] {
+                    ReaderInputKind.Word,
+                    ReaderInputKind.Excel,
+                    ReaderInputKind.Markdown,
+                    ReaderInputKind.Email,
+                    ReaderInputKind.Email
+                },
+                outcomes.Select(outcome => outcome.Document!.Kind).ToArray());
+
+            OfficeDocumentSearchResult[] searches = outcomes
+                .Select(outcome => outcome.Document!.Search(query, new OfficeDocumentSearchOptions {
+                    MaximumResults = int.MaxValue
+                }))
+                .ToArray();
+
+            Assert.All(searches, result => Assert.NotEmpty(result.Hits));
+            Assert.Equal(paths, searches.Select(result => result.Source.Path).ToArray());
+            Assert.All(searches, result => Assert.False(result.MaximumResultsReached));
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/OfficeIMO.Reader.Tests/Reader.PageLocations.cs
+++ b/OfficeIMO.Reader.Tests/Reader.PageLocations.cs
@@ -88,6 +88,7 @@ public sealed class ReaderPageLocationTests {
         };
         OfficeDocumentReadResult document = new OfficeDocumentReadResult {
             Kind = ReaderInputKind.Word,
+            Source = new OfficeDocumentSource { Path = "repeated-pages.docx" },
             Blocks = new[] { sourceBlock },
             Pages = new[] {
                 Page(1, PageBlock(sourceBlock, 1, "First needle before the page boundary. ")),
@@ -101,6 +102,9 @@ public sealed class ReaderPageLocationTests {
             new OfficeDocumentSearchOptions { MaximumResults = 1 });
 
         Assert.Equal(2, result.Hits.Count);
+        Assert.Equal("repeated-pages.docx", result.Source.Path);
+        Assert.False(result.MaximumResultsReached);
+        Assert.True(limited.MaximumResultsReached);
         Assert.Equal(new[] { 1 }, result.Hits[0].Pages.Select(page => page.Number!.Value).ToArray());
         Assert.Equal(new[] { 2 }, result.Hits[1].Pages.Select(page => page.Number!.Value).ToArray());
         Assert.Equal(new[] { 1, 2 }, result.PageNumbers);


### PR DESCRIPTION
## Summary

- add Reader-native file and folder discovery across all registered document formats
- add ordered resilient batch outcomes plus a non-retaining as-completed callback path
- preserve source provenance and expose search/result-limit state
- prove one mixed corpus containing Word, Excel, Markdown, PST, and OST files

This is the reusable engine layer for a PowerShell-native mixed-document search surface in PSWriteOffice.

## Validation

- full OfficeIMO.Reader.Tests net8.0 suite: 834 passed
- focused batch/streaming tests: net8.0, net10.0, and net472 passed
- mixed corpus test uses generated Word, Excel, PST, and OST files in one run

## Release note

PSWriteOffice consumes this through the normal OfficeIMO 3.0.1 package line. Merge and publish OfficeIMO 3.0.1 before expecting the dependent PSWriteOffice package-based build to restore.