### PR TITLE
Unify PDF and image conversion engines

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -15,6 +15,7 @@ paths:
   - OfficeIMO.MarkdownRenderer.SamplePlugin
   - OfficeIMO.MarkdownRenderer.Wpf
   - OfficeIMO.OpenDocument
+  - OfficeIMO.OpenDocument.Pdf
   - OfficeIMO.Pdf
   - OfficeIMO.PowerPoint
   - OfficeIMO.PowerPoint.OpenDocument

--- a/.github/workflows/pdf-visual-review-gallery.yml
+++ b/.github/workflows/pdf-visual-review-gallery.yml
@@ -39,6 +39,8 @@ on:
       - 'OfficeIMO.OneNote.Markdown/**'
       - 'OfficeIMO.OneNote.Pdf/**'
       - 'OfficeIMO.OneNote.Tests/**'
+      - 'OfficeIMO.OpenDocument.Pdf/**'
+      - 'OfficeIMO.OpenDocument.Converters.Tests/**'
       - 'OfficeIMO.Reader.Core/**'
       - 'OfficeIMO.Reader.Pdf/**'
       - 'OfficeIMO.Pdf.Tests/Pdf/**'
@@ -46,7 +48,9 @@ on:
       - 'OfficeIMO.Html.Tests/Html.Pdf.cs'
       - 'OfficeIMO.Reader.Tests/Reader.Pdf.Modular.cs'
       - 'Build/Export-PdfVisualReviewGallery.ps1'
+      - 'Build/Export-PdfConversionSupportMatrix.ps1'
       - 'Docs/officeimo.pdf.current-state.md'
+      - 'Docs/officeimo.pdf-conversion-support-matrix.md'
       - 'Docs/pdf-conversion-scenarios.json'
       - '.github/workflows/pdf-visual-review-gallery.yml'
   push:
@@ -87,6 +91,8 @@ on:
       - 'OfficeIMO.OneNote.Markdown/**'
       - 'OfficeIMO.OneNote.Pdf/**'
       - 'OfficeIMO.OneNote.Tests/**'
+      - 'OfficeIMO.OpenDocument.Pdf/**'
+      - 'OfficeIMO.OpenDocument.Converters.Tests/**'
       - 'OfficeIMO.Reader.Core/**'
       - 'OfficeIMO.Reader.Pdf/**'
       - 'OfficeIMO.Pdf.Tests/Pdf/**'
@@ -94,7 +100,9 @@ on:
       - 'OfficeIMO.Html.Tests/Html.Pdf.cs'
       - 'OfficeIMO.Reader.Tests/Reader.Pdf.Modular.cs'
       - 'Build/Export-PdfVisualReviewGallery.ps1'
+      - 'Build/Export-PdfConversionSupportMatrix.ps1'
       - 'Docs/officeimo.pdf.current-state.md'
+      - 'Docs/officeimo.pdf-conversion-support-matrix.md'
       - 'Docs/pdf-conversion-scenarios.json'
       - '.github/workflows/pdf-visual-review-gallery.yml'
   workflow_dispatch:
@@ -128,6 +136,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Verify generated PDF conversion support matrix
+        shell: pwsh
+        run: ./Build/Export-PdfConversionSupportMatrix.ps1 -Check
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/Build/Export-PdfConversionSupportMatrix.ps1
+++ b/Build/Export-PdfConversionSupportMatrix.ps1
@@ -1,0 +1,105 @@
+[CmdletBinding()]
+param(
+    [string] $ManifestPath,
+    [string] $OutputPath,
+    [switch] $Check
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+if ([string]::IsNullOrWhiteSpace($ManifestPath)) {
+    $ManifestPath = Join-Path $repoRoot 'Docs/pdf-conversion-scenarios.json'
+}
+if ([string]::IsNullOrWhiteSpace($OutputPath)) {
+    $OutputPath = Join-Path $repoRoot 'Docs/officeimo.pdf-conversion-support-matrix.md'
+}
+
+$resolvedManifestPath = [System.IO.Path]::GetFullPath($ManifestPath)
+$resolvedOutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $resolvedManifestPath -PathType Leaf)) {
+    throw "PDF conversion scenario manifest was not found: $resolvedManifestPath"
+}
+
+$scenarioManifest = Get-Content -LiteralPath $resolvedManifestPath -Raw | ConvertFrom-Json
+$qualityContract = $scenarioManifest.qualityContract
+$supportLines = [System.Collections.Generic.List[string]]::new()
+$supportLines.Add('# OfficeIMO PDF Conversion Support Matrix')
+$supportLines.Add('')
+$supportLines.Add('This matrix is generated from `Docs/pdf-conversion-scenarios.json`. Fidelity status describes the current evidence, not the intended destination.')
+$supportLines.Add('')
+$supportLines.Add("Premium claim rule: $($qualityContract.premiumClaimRule)")
+$supportLines.Add('')
+$supportLines.Add('| Source | Formats | Mode | Evidence status | Reference policy |')
+$supportLines.Add('| --- | --- | --- | --- | --- |')
+foreach ($converter in @($scenarioManifest.converterCatalog)) {
+    $source = ([string]$converter.id).Replace('|', '\|')
+    $formats = (@($converter.sourceFormats) -join ', ').Replace('|', '\|')
+    $mode = ([string]$converter.conversionMode).Replace('|', '\|')
+    $fidelityStatus = ([string]$converter.fidelityStatus).Replace('|', '\|')
+    $referencePolicy = ([string]$converter.referencePolicy).Replace('|', '\|')
+    $supportLines.Add("| $source | $formats | $mode | $fidelityStatus | $referencePolicy |")
+}
+$supportLines.Add('')
+$supportLines.Add('## Capability Claims')
+$supportLines.Add('')
+$supportLines.Add('| Source | Capability | Fidelity level | Evidence scenarios |')
+$supportLines.Add('| --- | --- | --- | --- |')
+foreach ($converter in @($scenarioManifest.converterCatalog)) {
+    if ($null -eq $converter.capabilityClaims) {
+        continue
+    }
+    foreach ($claim in @($converter.capabilityClaims)) {
+        $source = ([string]$converter.id).Replace('|', '\|')
+        $capability = ([string]$claim.capability).Replace('|', '\|')
+        $level = ([string]$claim.level).Replace('|', '\|')
+        $evidence = (@($claim.evidenceScenarioIds) -join ', ').Replace('|', '\|')
+        $supportLines.Add("| $source | $capability | $level | $evidence |")
+    }
+}
+$supportLines.Add('')
+$supportLines.Add('## Direct, Composed, And Planned Routes')
+$supportLines.Add('')
+$supportLines.Add('| Route | Formats | Status | Implementation owner | Contract evidence | Diagnostic contract |')
+$supportLines.Add('| --- | --- | --- | --- | --- | --- |')
+foreach ($route in @($scenarioManifest.compositionRoutes)) {
+    $routeId = ([string]$route.id).Replace('|', '\|')
+    $formats = (@($route.sourceFormats) -join ', ').Replace('|', '\|')
+    $routeStatus = ([string]$route.status).Replace('|', '\|')
+    $implementationProject = if ([string]::IsNullOrWhiteSpace([string]$route.implementationProject)) {
+        '—'
+    } else {
+        ('`' + ([string]$route.implementationProject).Replace('|', '\|') + '`')
+    }
+    $evidenceTest = if ([string]::IsNullOrWhiteSpace([string]$route.evidenceTest)) {
+        '—'
+    } else {
+        ('`' + ([string]$route.evidenceTest).Replace('|', '\|') + '`')
+    }
+    $diagnosticContract = ([string]$route.diagnosticContract).Replace('|', '\|')
+    $supportLines.Add("| $routeId | $formats | $routeStatus | $implementationProject | $evidenceTest | $diagnosticContract |")
+}
+
+$expected = ($supportLines -join "`n") + "`n"
+if ($Check) {
+    if (-not (Test-Path -LiteralPath $resolvedOutputPath -PathType Leaf)) {
+        throw "Generated PDF conversion support matrix is missing: $resolvedOutputPath"
+    }
+
+    $actual = [System.IO.File]::ReadAllText($resolvedOutputPath).Replace("`r`n", "`n")
+    if ($actual -ne $expected) {
+        throw "Generated PDF conversion support matrix is out of date. Run Build/Export-PdfConversionSupportMatrix.ps1."
+    }
+
+    Write-Host "PDF conversion support matrix is current: $resolvedOutputPath"
+    return
+}
+
+$outputDirectory = Split-Path -Parent $resolvedOutputPath
+if (-not [string]::IsNullOrWhiteSpace($outputDirectory)) {
+    [System.IO.Directory]::CreateDirectory($outputDirectory) | Out-Null
+}
+[System.IO.File]::WriteAllText(
+    $resolvedOutputPath,
+    $expected,
+    [System.Text.UTF8Encoding]::new($false))
+Write-Host "Generated PDF conversion support matrix: $resolvedOutputPath"

--- a/Build/Export-PdfVisualReviewGallery.ps1
+++ b/Build/Export-PdfVisualReviewGallery.ps1
@@ -260,53 +260,9 @@ $proofSummary = [pscustomobject]@{
 $proofSummaryPath = Join-Path $resolvedOutputPath 'conversion-proof-summary.json'
 $proofSummary | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $proofSummaryPath -Encoding UTF8
 
-$supportLines = [System.Collections.Generic.List[string]]::new()
-$supportLines.Add('# OfficeIMO PDF Conversion Support Matrix')
-$supportLines.Add('')
-$supportLines.Add('This matrix is generated from `Docs/pdf-conversion-scenarios.json`. Fidelity status describes the current evidence, not the intended destination.')
-$supportLines.Add('')
-$supportLines.Add("Premium claim rule: $($qualityContract.premiumClaimRule)")
-$supportLines.Add('')
-$supportLines.Add('| Source | Formats | Mode | Evidence status | Reference policy |')
-$supportLines.Add('| --- | --- | --- | --- | --- |')
-foreach ($converter in @($scenarioManifest.converterCatalog)) {
-    $source = ([string]$converter.id).Replace('|', '\|')
-    $formats = (@($converter.sourceFormats) -join ', ').Replace('|', '\|')
-    $mode = ([string]$converter.conversionMode).Replace('|', '\|')
-    $fidelityStatus = ([string]$converter.fidelityStatus).Replace('|', '\|')
-    $referencePolicy = ([string]$converter.referencePolicy).Replace('|', '\|')
-    $supportLines.Add("| $source | $formats | $mode | $fidelityStatus | $referencePolicy |")
-}
-$supportLines.Add('')
-$supportLines.Add('## Capability Claims')
-$supportLines.Add('')
-$supportLines.Add('| Source | Capability | Fidelity level | Evidence scenarios |')
-$supportLines.Add('| --- | --- | --- | --- |')
-foreach ($converter in @($scenarioManifest.converterCatalog)) {
-    if ($null -eq $converter.capabilityClaims) {
-        continue
-    }
-    foreach ($claim in @($converter.capabilityClaims)) {
-        $source = ([string]$converter.id).Replace('|', '\|')
-        $capability = ([string]$claim.capability).Replace('|', '\|')
-        $level = ([string]$claim.level).Replace('|', '\|')
-        $evidence = (@($claim.evidenceScenarioIds) -join ', ').Replace('|', '\|')
-        $supportLines.Add("| $source | $capability | $level | $evidence |")
-    }
-}
-$supportLines.Add('')
-$supportLines.Add('## Composed And Planned Routes')
-$supportLines.Add('')
-$supportLines.Add('| Route | Formats | Status | Diagnostic contract |')
-$supportLines.Add('| --- | --- | --- | --- |')
-foreach ($route in @($scenarioManifest.compositionRoutes)) {
-    $routeId = ([string]$route.id).Replace('|', '\|')
-    $formats = (@($route.sourceFormats) -join ', ').Replace('|', '\|')
-    $routeStatus = ([string]$route.status).Replace('|', '\|')
-    $diagnosticContract = ([string]$route.diagnosticContract).Replace('|', '\|')
-    $supportLines.Add("| $routeId | $formats | $routeStatus | $diagnosticContract |")
-}
-[System.IO.File]::WriteAllLines($supportMatrixPath, $supportLines, [System.Text.Encoding]::UTF8)
+& (Join-Path $PSScriptRoot 'Export-PdfConversionSupportMatrix.ps1') `
+    -ManifestPath $scenarioManifestPath `
+    -OutputPath $supportMatrixPath
 
 $lines = [System.Collections.Generic.List[string]]::new()
 $lines.Add('# OfficeIMO PDF Visual Review Gallery')

--- a/Build/project.build.json
+++ b/Build/project.build.json
@@ -34,6 +34,7 @@
     "OfficeIMO.MarkdownRenderer.IntelligenceX": "3.0.X",
     "OfficeIMO.MarkdownRenderer.Wpf": "3.0.X",
     "OfficeIMO.OpenDocument": "3.0.X",
+    "OfficeIMO.OpenDocument.Pdf": "3.0.X",
     "OfficeIMO.OneNote": "3.0.X",
     "OfficeIMO.OneNote.Html": "3.0.X",
     "OfficeIMO.OneNote.Markdown": "3.0.X",

--- a/Docs/officeimo.image-export-capability-matrix.md
+++ b/Docs/officeimo.image-export-capability-matrix.md
@@ -15,7 +15,7 @@ This matrix tracks dependency-free image export across OfficeIMO document packag
 | `OfficeIMO.Epub.Image` | EPUB chapter selection and retained package-resource mapping into HTML | Another EPUB parser, CSS layout engine, or image encoder |
 | `OfficeIMO.OneNote` | Page hierarchy, positioned content, ink/math/image projection, page selection | Private image encoders |
 | `OfficeIMO.Visio` | Page geometry, shapes, connectors, stencil artwork, labels, native Visio text/layout decisions, and the richer Visio embedded-SVG interpreter needed for linked images, clipping, nested opacity, and CSS | Private output encoders or duplicate shared format mechanics |
-| `OfficeIMO.Pdf` | PDF parsing/content semantics, page-to-Drawing projection, page selection, PDF render capability diagnostics, and source-to-PDF diagnostic bridging | Private raster encoders, allocation policy, or source-adapter-specific image APIs |
+| `OfficeIMO.Pdf` | PDF parsing/content semantics, page-to-Drawing projection, page selection, Drawing-owned raster normalization for authored/stamped images, PDF render capability diagnostics, and source-to-PDF diagnostic bridging | Private raster encoders, allocation policy, or source-adapter-specific image APIs |
 | OpenDocument adapters | Attach ODT/ODS/ODP conversion evidence while delegating visuals to Word/Excel/PowerPoint | Another ODF parser or renderer |
 
 ## Shared Drawing Foundation
@@ -113,8 +113,9 @@ This matrix tracks dependency-free image export across OfficeIMO document packag
 | Surface | Status | Evidence | Key gaps |
 | --- | --- | --- | --- |
 | Loaded PDF page | Five formats supported | `PdfReadPage.ExportImage`, `ToImage()`, format identity tests, DPI and thumbnail tests; supported missing annotation appearances are synthesized through the annotation appearance owner and reported as `render.annotation.appearance-synthesized` | Coverage follows the first-party PDF page-to-Drawing capability manifest; Type 3 fonts, unsupported content-paint color spaces, and arbitrary producer edge cases remain diagnostic-driven |
-| Loaded PDF document | Selected batch supported | `PdfReadDocument.ExportImages`, `ToImages().Pages("2,1")`, shared pixel budget and cancellation | Continue extending PDF operator/font/form/transparency fidelity in the existing page projection |
-| Source-to-PDF conversion result | Shared paged-image bridge | `PdfDocumentConversionResult.ExportImages` / `ToImages()` retain source conversion diagnostics for Markdown, AsciiDoc, LaTeX, RTF, OneNote, Word, Excel, PowerPoint, and HTML adapters | A source package should add a direct image API only when PDF pagination is not the right visual contract |
+| Authored or loaded PDF document | Selected batch supported | `PdfDocument.ExportImages` / `ToImages()` and `PdfReadDocument.ExportImages` / `ToImages().Pages("2,1")` share the page renderer, pixel budget, and cancellation contract | Continue extending PDF operator/font/form/transparency fidelity in the existing page projection |
+| Authored and stamped raster input | Drawing-supported source set normalized once | JPEG and writer-safe PNG embed directly; baseline TIFF, uncompressed BMP, first-frame GIF, and OfficeIMO literal-lossless WebP normalize through `OfficeImagePngConverter` with density preservation before every flow, table, inline, header/footer, background, watermark, canvas, and stamp placement | Broader source codecs remain explicit Drawing or caller-codec work; malformed PNGs retain precise fail-closed writer diagnostics |
+| Source-to-PDF conversion result | Shared paged-image bridge | `PdfDocumentConversionResult.ExportImages` / `ToImages()` retain source conversion diagnostics for Markdown, AsciiDoc, LaTeX, RTF, OneNote, OpenDocument, Word, Excel, PowerPoint, and HTML adapters | A source package should add a direct image API only when PDF pagination is not the right visual contract |
 
 ## OpenDocument Bridges
 

--- a/Docs/officeimo.pdf-conversion-support-matrix.md
+++ b/Docs/officeimo.pdf-conversion-support-matrix.md
@@ -1,0 +1,42 @@
+# OfficeIMO PDF Conversion Support Matrix
+
+This matrix is generated from `Docs/pdf-conversion-scenarios.json`. Fidelity status describes the current evidence, not the intended destination.
+
+Premium claim rule: A converter can be marked externally-verified only when its declared reference policy has stable source artifacts, producer/version metadata, page geometry, visual comparison results, text/link/structure proof, and no unexpected conversion warnings.
+
+| Source | Formats | Mode | Evidence status | Reference policy |
+| --- | --- | --- | --- | --- |
+| word | doc, docx, docm, dotx, dotm | native-paged | candidate | microsoft-office-plus-officeimo-regression |
+| excel | xlsx, xlsm, xltx, xltm, xls, xlsb | native-paged | candidate | microsoft-excel-plus-officeimo-regression |
+| powerpoint | pptx, pptm | native-slide-canvas | candidate | microsoft-powerpoint-plus-officeimo-regression |
+| markdown | md, markdown | semantic-document | regression-proven | officeimo-regression |
+| html | html, htm, mhtml, mht | native-static-paged | candidate | standards-corpus-plus-officeimo-regression |
+| rtf | rtf | semantic-document | regression-proven | officeimo-regression |
+| onenote | one, onetoc2, onepkg | explicit-semantic-document | accepted-degradation | semantic-contract |
+| asciidoc | adoc, asciidoc, asc | loss-aware-semantic-document | accepted-degradation | semantic-contract |
+| latex | tex, latex | loss-aware-semantic-document | accepted-degradation | semantic-contract |
+
+## Capability Claims
+
+| Source | Capability | Fidelity level | Evidence scenarios |
+| --- | --- | --- | --- |
+| word | semantic-text-headings-lists-and-tables | exact | word-native-report |
+| word | advanced-word-layout-and-drawing-objects | supported-with-approximation | word-native-report |
+| excel | worksheet-values-formats-links-and-basic-pagination | exact | excel-native-daily-workbook |
+| excel | worksheet-canvas-drawings-charts-and-dashboard-layout | supported-with-approximation | excel-native-daily-workbook, excel-dashboard-report |
+| powerpoint | slide-geometry-basic-text-images-and-tables | exact | powerpoint-native-dense-layout |
+| powerpoint | advanced-theme-drawingml-smartart-and-chart-layout | supported-with-approximation | powerpoint-layout-theme-groups |
+| html | static-business-html-shared-png-svg-and-searchable-pdf-scene | exact | html-static-market-corpus |
+| html | advanced-css-fragmentation-typography-and-svg-effects | supported-with-approximation | html-static-market-corpus, html-css-resource-policy |
+| html | javascript-and-interactive-browser-state | unsupported | html-css-resource-policy |
+
+## Direct, Composed, And Planned Routes
+
+| Route | Formats | Status | Implementation owner | Contract evidence | Diagnostic contract |
+| --- | --- | --- | --- | --- | --- |
+| opendocument-text-via-word | odt, ott | direct-loss-aware-adapter | `OfficeIMO.OpenDocument.Pdf/OfficeIMO.OpenDocument.Pdf.csproj` | `OfficeIMO.OpenDocument.Converters.Tests/OpenDocumentPdfConversionContracts.cs#OdtFacadePreservesProjectionLossAndProducesReadablePdf` | The direct adapter merges ODT-to-Word feature mappings with Word-to-PDF diagnostics in PdfDocumentConversionResult. |
+| opendocument-spreadsheet-via-excel | ods, ots | direct-loss-aware-adapter | `OfficeIMO.OpenDocument.Pdf/OfficeIMO.OpenDocument.Pdf.csproj` | `OfficeIMO.OpenDocument.Converters.Tests/OpenDocumentPdfConversionContracts.cs#OdsFacadeUsesExcelPdfEngineAndExposesInformationEvidence` | The direct adapter merges ODS-to-Excel feature mappings with Excel-to-PDF diagnostics in PdfDocumentConversionResult. |
+| opendocument-presentation-via-powerpoint | odp, otp | direct-loss-aware-adapter | `OfficeIMO.OpenDocument.Pdf/OfficeIMO.OpenDocument.Pdf.csproj` | `OfficeIMO.OpenDocument.Converters.Tests/OpenDocumentPdfConversionContracts.cs#OdpFacadeUsesPowerPointPdfEngineAndKeepsAnimationLoss` | The direct adapter merges ODP-to-PowerPoint feature mappings with PowerPoint-to-PDF diagnostics in PdfDocumentConversionResult. |
+| email-document | eml, msg, tnef | not-yet-direct | — | — | A premium route still needs deterministic body selection, inline-resource resolution, attachment policy, and combined source/PDF diagnostics. |
+| epub-book | epub | not-yet-direct | — | — | A premium route still needs book-level chapter order, stylesheet/font/image resolution, navigation, pagination, and combined diagnostics. |
+| visio-diagram | vsdx, vssx, vstx | not-yet-direct | — | — | A premium route should preserve vector page output and hyperlinks; raster-only composition is not advertised as a direct Visio PDF converter. |

--- a/Docs/officeimo.pdf.current-state.md
+++ b/Docs/officeimo.pdf.current-state.md
@@ -22,7 +22,7 @@ explicit:
 - `OfficeIMO.Pdf` should not gain a runtime dependency on another PDF engine,
   browser, JavaScript runtime, or native renderer.
 
-Word, Excel, PowerPoint, Markdown, HTML, RTF, OneNote, AsciiDoc, and LaTeX
+Word, Excel, PowerPoint, OpenDocument, Markdown, HTML, RTF, OneNote, AsciiDoc, and LaTeX
 packages remain thin adapters. AsciiDoc and LaTeX reuse their existing
 loss-aware Markdown projections and the Markdown PDF renderer; they do not add
 format-specific layout engines. Shared PDF parsing, writing, layout, rendering,
@@ -30,7 +30,14 @@ security, signatures, forms, annotations, resource trust, and manipulation belon
 Reusable vector and raster primitives belong in `OfficeIMO.Drawing`. The
 machine-readable direct-adapter and composition-route inventory is
 [`pdf-conversion-scenarios.json`](pdf-conversion-scenarios.json); it is the
-source of truth for supported routes and visual proof ownership.
+source of truth for supported routes and visual proof ownership. The checked-in
+[`PDF conversion support matrix`](officeimo.pdf-conversion-support-matrix.md) is
+generated from that manifest and verified for drift in CI.
+
+OpenDocument text, spreadsheet, and presentation callers use one direct
+loss-aware façade over the existing semantic and PDF adapters. It combines
+projection-stage and PDF-stage diagnostics without adding another layout or
+rendering engine.
 
 Direct conversion uses one balanced resource default: installed fonts plus
 bounded data URI and embedded-package resources are available for Unicode and
@@ -96,8 +103,52 @@ PDF primitive exists somewhere in the codebase.
 | Serialize generated PDFs | Bounded payload streaming | `PdfOptions.PageContentMemoryLimitBytes` bounds completed page/effect content retained during layout, and `PdfOptions.ObjectBufferMemoryLimitBytes` bounds completed indirect-object bytes during serialization. Both stores spill excess payloads to indexed temporary files; large stream objects are spooled without a duplicate combined buffer, and final stream assembly copies spilled objects in bounded chunks for plain and encrypted saves. Spill files are removed on disposal. | Per-page metadata and the authored block model remain proportional to document size, the active page is materialized while it is processed, and `ToBytes()` necessarily buffers the final artifact. Fully forward-only layout/output needs a deeper writer contract and representative memory gates. |
 | Text and layout extraction | Broad, strategy-driven | The fast heuristic remains the default. A pluggable six-stage understanding pipeline provides confidence/evidence and stable JSON, Markdown, ALTO, hOCR, and PAGE XML. The built-in advanced profile adds rotation/arbitrary-baseline grouping, spatial and non-rectangular regions, multi-column/spanning-band order, tables, captions, headers/footers, and footnotes. | Refine advanced heuristics from real mixed-layout corpora and use provider stages for domain-specific reconstruction rather than hard-coding every document family. |
 | PDF to Office/HTML/data | Partial by design | PDF-to-HTML review output, table export, Reader chunks, and limited PowerPoint table import use the shared logical model. | Improve the logical model and confidence/proof first. Do not promise general editable reconstruction from a presentation format. |
-| Office/HTML/Markdown/RTF/OneNote/AsciiDoc/LaTeX to PDF | Broad but evolving | Thin adapters use the shared PDF and Drawing engines. Word and PowerPoint preserve source font families and richer table/list/header/footer geometry; Excel uses a worksheet scene with authored row/column geometry, print areas, titles, breaks, charts, images, and conditional formatting; static HTML uses the shared paged render scene with market-corpus raster gates, tables, forms, word breaking, and searchable text. OneNote, AsciiDoc, and LaTeX use explicit loss-aware semantic projections with combined diagnostics. | Browser-executed HTML is outside the current scope. Continue converter-specific fidelity only when the missing primitive is truly source-specific; otherwise improve the shared PDF, Drawing, HTML, or semantic-projection owner. |
+| Office/OpenDocument/HTML/Markdown/RTF/OneNote/AsciiDoc/LaTeX to PDF | Broad but evolving | Thin adapters use the shared PDF and Drawing engines. Word and PowerPoint preserve source font families and richer table/list/header/footer geometry; Excel uses a worksheet scene with authored row/column geometry, print areas, titles, breaks, charts, images, and conditional formatting; OpenDocument text, spreadsheet, and presentation formats expose one direct loss-aware façade over their existing semantic and PDF engines; static HTML uses the shared paged render scene with market-corpus raster gates, tables, forms, word breaking, and searchable text. OneNote, AsciiDoc, and LaTeX use explicit loss-aware semantic projections with combined diagnostics. | Browser-executed HTML is outside the current scope. Continue converter-specific fidelity only when the missing primitive is truly source-specific; otherwise improve the shared PDF, Drawing, HTML, or semantic-projection owner. |
 | PDF/A, PDF/UA, and e-invoices | Exact-artifact proof available for declared profiles | PDF/A-2b, PDF/A-3b, PDF/UA-1, Factur-X, and ZUGFeRD generation gates combine internal readiness with external validator evidence bound to validator name/version/profile, SHA-256, byte length, result, and validation time. A report cannot be claimable while an effective requirement remains missing or unsupported. | Keep validator versions and profile fixtures current; do not broaden claims beyond exact artifacts that pass both internal and external proof. |
+
+## Conversion Direction And Fidelity Assessment
+
+| Direction | Assessment | Quality contract |
+| --- | --- | --- |
+| Office, OpenDocument, HTML, Markdown, RTF, OneNote, AsciiDoc, and LaTeX to PDF | Broad, with source-specific approximations | Every direct adapter uses the shared PDF/Drawing owners and returns stable conversion evidence. The generated support matrix distinguishes regression-proven, candidate, externally verified, and accepted-degradation routes instead of treating every feature as exact. |
+| PDF to editable Word | Useful semantic recovery, not fixed-layout reconstruction | Metadata, page breaks, headings, paragraphs, lists, logical tables, links, supported images, and form placeholders are recovered when represented by the logical model. Unsupported image streams and interactive or unresolved navigation remain diagnostic-driven. |
+| PDF to editable Excel or PowerPoint | Intentionally narrow | Logical tables can be recovered into worksheets or table slides with page/range limits and loss reports. Unrelated page text, drawings, images, and fixed layout are not advertised as editable reconstruction. |
+| PDF to HTML | Good for semantic access and positioned visual review | Semantic and positioned-review profiles share the PDF logical/read model. Output is a review projection, not a browser-based reverse authoring guarantee. |
+| Authored/loaded PDF to PNG, JPEG, TIFF, WebP, or SVG | Broad managed rendering with explicit gaps | One page-to-Drawing projection serves authored documents, loaded pages, batches, and source-conversion results with budgets, cancellation, selection, and diagnostics. Unsupported Type 3/CFF, ICC, pattern, and layer cases remain visible in page reports. |
+| JPEG, PNG, GIF, BMP, TIFF, or supported WebP into authored/stamped PDF | Consistent shared ingestion | JPEG and writer-safe PNG embed directly. Other Drawing-decoded raster payloads normalize once to density-preserving PNG before all flow, table, inline, header/footer, background, watermark, canvas, and stamp paths. Malformed PNGs retain precise fail-closed diagnostics. |
+
+## Remaining Engine Work, Easiest To Most Complex
+
+The core is already broad enough for common business-document authoring,
+inspection, conversion, rendering, and controlled mutation. Premium claims
+remain capability-scoped and evidence-backed. The remaining engine work is
+ordered by expected implementation and proof complexity:
+
+1. Add a small set of tested report, invoice, label, and ticket recipes as
+   `IPdfComponent` implementations after their contracts are stable. They must
+   remain examples over the existing flow engine, not a template subsystem.
+2. Broaden Drawing-owned raster ingestion where real fixtures require it,
+   including explicit frame-selection and animation-loss policy. PDF surfaces
+   should continue to consume one normalized payload contract.
+3. Promote email, EPUB, and Visio routes only after body/attachment,
+   book-resource/pagination, and vector-page policies are explicit. Each route
+   should merge source and PDF evidence through the existing result contract.
+4. Deepen generated and existing-document annotations, navigation, form-field
+   kinds, and appearance editing through the current mutation and incremental
+   update engines.
+5. Add a dependency-light built-in complex-script shaping implementation, or a
+   narrowly packaged provider, while retaining Drawing as the single shaping
+   contract owner and preserving font fallback/subsetting proof.
+6. Extend stateful and page-dependent composition for workflows whose content
+   changes after pagination, without creating a second measurement or layout
+   path for components.
+7. Expand producer interoperability for Type 3/CFF rendering, ICC and pattern
+   edge cases, layers, encrypted incremental updates, and complex structure
+   preservation from corpus failures with explicit diagnostics.
+8. Redesign layout and serialization for genuinely forward-only output with
+   bounded memory, replay rules, deterministic object allocation, and artifact
+   proof. This is architectural work; asynchronous save alone is not a
+   streaming-layout guarantee.
 
 ## Current Architecture To Keep
 
@@ -359,9 +410,12 @@ any repair is explicit, reproducible, and validated before save.
   distance results, and runtime-independent comparison gates.
 - [ ] Keep HTML/CSS fidelity work in the canonical HTML/PDF/image plan. The PDF
   package should only add missing PDF-native primitives or writer support.
-- [ ] Add reusable typed report components and recipes only after repeated real
-  examples identify a stable abstraction. Do not introduce a second template
-  language or dependency-injection requirement into the PDF core speculatively.
+- [x] Add a reusable typed component contract that composes through the
+  canonical flow engine, including existing layout constraints and position
+  capture, without introducing another layout language.
+- [ ] Add built-in report recipes only after repeated real examples identify a
+  stable abstraction. Do not introduce a second template language or
+  dependency-injection requirement into the PDF core speculatively.
 - [ ] If real invoice, label, ticket, or logistics workflows require barcodes or
   QR codes, implement the encoding and drawing once in the smallest reusable
   `OfficeIMO.Drawing` owner (or a narrow optional adapter). PDF, Word, Excel,
@@ -376,11 +430,11 @@ any repair is explicit, reproducible, and validated before save.
 - [x] Promote AsciiDoc and LaTeX compositions to direct adapters whose native
   parser and semantic-projection diagnostics flow automatically into the final
   `PdfDocumentConversionResult` while reusing `OfficeIMO.Markdown.Pdf`.
-- [ ] Promote OpenDocument text, spreadsheet, and presentation compositions to
-  direct adapters only when their existing `OdfConversionResult` diagnostics
-  flow automatically into the final PDF result. Do not advertise email, EPUB,
-  or Visio as direct PDF conversion until body/asset/book/vector-page policies
-  are explicit and visually proven.
+- [x] Promote OpenDocument text, spreadsheet, and presentation compositions to
+  one direct adapter whose existing `OdfConversionResult` diagnostics flow
+  automatically into the final PDF result without duplicating the Word, Excel,
+  or PowerPoint PDF engines. Email, EPUB, and Visio remain planned until their
+  body/asset/book/vector-page policies are explicit and visually proven.
 
 Exit criterion: new fidelity work improves the shared engine or has a documented
 source-format reason to remain in a thin adapter.
@@ -417,8 +471,10 @@ external validator both pass the exact generated artifact.
 - [ ] Add fully forward-only layout and serialization before describing async
   APIs as fully streaming. Per-page metadata and the authored block model remain
   proportional to document size, while `ToBytes()` buffers the final artifact.
-- [ ] Generate the public support matrix and README examples from tested
-  capability records so documentation cannot drift from the implementation.
+- [x] Generate and CI-check the public PDF conversion support matrix from the
+  tested capability manifest so route and diagnostic claims cannot drift.
+- [ ] Generate README examples from tested capability records where doing so
+  improves user guidance without making prose less readable.
 - [x] Keep a public-surface/dependency contract plus dependency-free mixed
   60-page cold/cached analysis, SVG, and PNG performance budgets in CI; verify
   output integrity as well as time and allocation ceilings, and keep bounded

--- a/Docs/pdf-conversion-scenarios.json
+++ b/Docs/pdf-conversion-scenarios.json
@@ -212,23 +212,29 @@
     {
       "id": "opendocument-text-via-word",
       "sourceFormats": [ "odt", "ott" ],
-      "status": "manual-loss-aware-composition",
-      "stages": [ "OfficeIMO.OpenDocument", "OfficeIMO.Word.OpenDocument", "OfficeIMO.Word.Pdf" ],
-      "diagnosticContract": "Preserve OdfConversionResult diagnostics before PDF save; there is no direct OpenDocument PDF adapter yet."
+      "status": "direct-loss-aware-adapter",
+      "stages": [ "OfficeIMO.OpenDocument.Pdf", "OfficeIMO.Word.OpenDocument", "OfficeIMO.Word.Pdf" ],
+      "implementationProject": "OfficeIMO.OpenDocument.Pdf/OfficeIMO.OpenDocument.Pdf.csproj",
+      "evidenceTest": "OfficeIMO.OpenDocument.Converters.Tests/OpenDocumentPdfConversionContracts.cs#OdtFacadePreservesProjectionLossAndProducesReadablePdf",
+      "diagnosticContract": "The direct adapter merges ODT-to-Word feature mappings with Word-to-PDF diagnostics in PdfDocumentConversionResult."
     },
     {
       "id": "opendocument-spreadsheet-via-excel",
       "sourceFormats": [ "ods", "ots" ],
-      "status": "manual-loss-aware-composition",
-      "stages": [ "OfficeIMO.OpenDocument", "OfficeIMO.Excel.OpenDocument", "OfficeIMO.Excel.Pdf" ],
-      "diagnosticContract": "Preserve OdfConversionResult diagnostics before PDF save; there is no direct OpenDocument PDF adapter yet."
+      "status": "direct-loss-aware-adapter",
+      "stages": [ "OfficeIMO.OpenDocument.Pdf", "OfficeIMO.Excel.OpenDocument", "OfficeIMO.Excel.Pdf" ],
+      "implementationProject": "OfficeIMO.OpenDocument.Pdf/OfficeIMO.OpenDocument.Pdf.csproj",
+      "evidenceTest": "OfficeIMO.OpenDocument.Converters.Tests/OpenDocumentPdfConversionContracts.cs#OdsFacadeUsesExcelPdfEngineAndExposesInformationEvidence",
+      "diagnosticContract": "The direct adapter merges ODS-to-Excel feature mappings with Excel-to-PDF diagnostics in PdfDocumentConversionResult."
     },
     {
       "id": "opendocument-presentation-via-powerpoint",
       "sourceFormats": [ "odp", "otp" ],
-      "status": "manual-loss-aware-composition",
-      "stages": [ "OfficeIMO.OpenDocument", "OfficeIMO.PowerPoint.OpenDocument", "OfficeIMO.PowerPoint.Pdf" ],
-      "diagnosticContract": "Preserve OdfConversionResult diagnostics before PDF save; there is no direct OpenDocument PDF adapter yet."
+      "status": "direct-loss-aware-adapter",
+      "stages": [ "OfficeIMO.OpenDocument.Pdf", "OfficeIMO.PowerPoint.OpenDocument", "OfficeIMO.PowerPoint.Pdf" ],
+      "implementationProject": "OfficeIMO.OpenDocument.Pdf/OfficeIMO.OpenDocument.Pdf.csproj",
+      "evidenceTest": "OfficeIMO.OpenDocument.Converters.Tests/OpenDocumentPdfConversionContracts.cs#OdpFacadeUsesPowerPointPdfEngineAndKeepsAnimationLoss",
+      "diagnosticContract": "The direct adapter merges ODP-to-PowerPoint feature mappings with PowerPoint-to-PDF diagnostics in PdfDocumentConversionResult."
     },
     {
       "id": "email-document",

--- a/OfficeIMO.Drawing.Tests/Drawing.Tests.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.Tests.cs
@@ -3488,7 +3488,10 @@ public partial class DrawingTests {
     [InlineData("image/png", OfficeImageFormat.Png, true)]
     [InlineData("image/jpg", OfficeImageFormat.Jpeg, true)]
     [InlineData("image/jpeg; charset=binary", OfficeImageFormat.Jpeg, true)]
-    [InlineData("image/webp", OfficeImageFormat.Webp, false)]
+    [InlineData("image/gif", OfficeImageFormat.Gif, true)]
+    [InlineData("image/bmp", OfficeImageFormat.Bmp, true)]
+    [InlineData("image/tiff", OfficeImageFormat.Tiff, true)]
+    [InlineData("image/webp", OfficeImageFormat.Webp, true)]
     [InlineData("application/octet-stream", OfficeImageFormat.Unknown, false)]
     public void OfficeImagePdfCompatibilityMapsSupportedContentTypes(string contentType, OfficeImageFormat expectedFormat, bool expectedSupported) {
         bool supported = OfficeImagePdfCompatibility.TryGetSupportedContentTypeFormat(contentType, out OfficeImageFormat format);
@@ -3496,6 +3499,24 @@ public partial class DrawingTests {
         Assert.Equal(expectedSupported, supported);
         Assert.Equal(expectedFormat, format);
         Assert.Equal(expectedSupported, OfficeImagePdfCompatibility.IsSupportedContentType(contentType));
+    }
+
+    [Theory]
+    [InlineData(OfficeImageExportFormat.Tiff, OfficeImageFormat.Tiff)]
+    [InlineData(OfficeImageExportFormat.Webp, OfficeImageFormat.Webp)]
+    public void OfficeImagePdfCompatibilityAcceptsDrawingNormalizedRaster(
+        OfficeImageExportFormat format,
+        OfficeImageFormat expectedFormat) {
+        byte[] source = OfficeRasterImageEncoder.Encode(
+            new OfficeRasterImage(2, 1, OfficeColor.Red),
+            format);
+
+        Assert.True(OfficeImagePdfCompatibility.TryValidate(
+            source,
+            out OfficeImageInfo? imageInfo,
+            out string? unsupportedReason), unsupportedReason);
+        Assert.NotNull(imageInfo);
+        Assert.Equal(expectedFormat, imageInfo!.Format);
     }
 
     [Fact]

--- a/OfficeIMO.Drawing/Internal/OfficeFileCommit.cs
+++ b/OfficeIMO.Drawing/Internal/OfficeFileCommit.cs
@@ -392,6 +392,12 @@ namespace OfficeIMO.Drawing.Internal {
                     if (!waitForClaim) return false;
                     if (attempt >= 9) throw;
                     Thread.Sleep(Math.Min(50 * (attempt + 1), 500));
+                } catch (UnauthorizedAccessException) when (attempt < 9) {
+                    // Windows can report a sharing violation as access denied while
+                    // another writer owns the claim, and File.Exists may transiently
+                    // return false for that locked path. Retry so the owner can release
+                    // the claim; a persistent permission failure is rethrown below.
+                    Thread.Sleep(Math.Min(50 * (attempt + 1), 500));
                 } catch (IOException) when (attempt < 9) {
                     Thread.Sleep(Math.Min(50 * (attempt + 1), 500));
                 }

--- a/OfficeIMO.Drawing/OfficeImagePdfCompatibility.cs
+++ b/OfficeIMO.Drawing/OfficeImagePdfCompatibility.cs
@@ -1,12 +1,12 @@
 namespace OfficeIMO.Drawing {
     /// <summary>
-    /// Validates image bytes against the lightweight image constraints used by first-party PDF export preflight checks.
+    /// Validates image bytes against the shared Drawing raster contract used by first-party PDF export preflight checks.
     /// </summary>
     public static class OfficeImagePdfCompatibility {
         private static readonly byte[] PngSignature = { 137, 80, 78, 71, 13, 10, 26, 10 };
 
         /// <summary>
-        /// Returns true when the image bytes are JPEG or structurally valid PNG bytes suitable for first-party PDF export.
+        /// Returns true when the image bytes can be embedded directly or normalized by the shared Drawing raster engine.
         /// </summary>
         public static bool TryValidate(byte[] bytes, out OfficeImageInfo? imageInfo, out string? unsupportedReason) {
             imageInfo = null;
@@ -28,19 +28,29 @@ namespace OfficeIMO.Drawing {
                 case OfficeImageFormat.Png:
                     return TryValidatePngContainer(bytes, out unsupportedReason);
                 default:
-                    unsupportedReason = $"Detected {detected.Format} ({detected.MimeType}); first-party PDF export supports JPEG and PNG image bytes.";
-                    return false;
+                    if (!IsSupportedFormat(detected.Format)) {
+                        unsupportedReason = $"Detected {detected.Format} ({detected.MimeType}); the format is not part of the shared PDF raster contract.";
+                        return false;
+                    }
+
+                    if (!OfficeImagePngConverter.TryConvertToPng(bytes, out byte[] normalizedPng) ||
+                        !TryValidatePngContainer(normalizedPng, out unsupportedReason)) {
+                        unsupportedReason ??= $"Detected {detected.Format} ({detected.MimeType}), but the payload could not be normalized by OfficeIMO.Drawing.";
+                        return false;
+                    }
+
+                    return true;
             }
         }
 
         /// <summary>
-        /// Returns true when the MIME content type is accepted by first-party PDF image export.
+        /// Returns true when the MIME content type belongs to the shared PDF raster source set.
         /// </summary>
         public static bool IsSupportedContentType(string? contentType) =>
             TryGetSupportedContentTypeFormat(contentType, out _);
 
         /// <summary>
-        /// Resolves a MIME content type accepted by first-party PDF image export to its shared image format.
+        /// Resolves a MIME content type accepted by the shared PDF raster source set to its image format.
         /// </summary>
         public static bool TryGetSupportedContentTypeFormat(string? contentType, out OfficeImageFormat format) {
             format = OfficeImageInfo.FromMimeType(contentType);
@@ -87,10 +97,15 @@ namespace OfficeIMO.Drawing {
         }
 
         /// <summary>
-        /// Returns true when the shared image format is accepted by first-party PDF image export.
+        /// Returns true when the shared image format can be embedded directly or normalized by OfficeIMO.Drawing.
         /// </summary>
         public static bool IsSupportedFormat(OfficeImageFormat format) =>
-            format == OfficeImageFormat.Png || format == OfficeImageFormat.Jpeg;
+            format == OfficeImageFormat.Png ||
+            format == OfficeImageFormat.Jpeg ||
+            format == OfficeImageFormat.Gif ||
+            format == OfficeImageFormat.Bmp ||
+            format == OfficeImageFormat.Tiff ||
+            format == OfficeImageFormat.Webp;
 
         private static string GetPdfImageFormatDisplayName(OfficeImageFormat format) =>
             format == OfficeImageFormat.Jpeg ? "JPEG" : format.ToString().ToUpperInvariant();

--- a/OfficeIMO.Drawing/Raster/OfficeImagePngConverter.cs
+++ b/OfficeIMO.Drawing/Raster/OfficeImagePngConverter.cs
@@ -2,7 +2,7 @@ namespace OfficeIMO.Drawing;
 
 /// <summary>Shared dependency-free conversion helpers for raster formats supported by OfficeIMO.Drawing.</summary>
 public static class OfficeImagePngConverter {
-    /// <summary>Attempts to convert a BMP, DIB, GIF, JPEG, or PNG payload to PNG bytes.</summary>
+    /// <summary>Attempts to convert a Drawing-supported raster payload to PNG bytes.</summary>
     public static bool TryConvertToPng(byte[]? imageBytes, out byte[] pngBytes) {
         pngBytes = System.Array.Empty<byte>();
         if (!OfficeRasterImageDecoder.TryDecode(imageBytes, out OfficeRasterImage? image) &&
@@ -10,7 +10,17 @@ public static class OfficeImagePngConverter {
             return false;
         }
 
-        pngBytes = OfficePngWriter.Encode(image!);
+        OfficeImageInfo? sourceInfo = null;
+        if (imageBytes != null && OfficeImageReader.TryIdentify(imageBytes, null, out OfficeImageInfo identified)) {
+            sourceInfo = identified;
+        }
+
+        pngBytes = sourceInfo == null
+            ? OfficePngWriter.Encode(image!)
+            : OfficePngWriter.Encode(image!, new OfficePngEncodeOptions {
+                DpiX = sourceInfo.DpiX,
+                DpiY = sourceInfo.DpiY
+            });
         return true;
     }
 

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.HeaderFooter.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.HeaderFooter.cs
@@ -8,7 +8,7 @@ namespace OfficeIMO.Excel.Pdf {
                 return;
             }
 
-            WarnUnsupportedHeaderFooterImages(headerFooter, sheetName, options);
+            PreparedHeaderFooterImages preparedImages = PrepareHeaderFooterImages(headerFooter, sheetName, options);
 
             HeaderFooterZones? headerZones = options.UseWorksheetHeadersAndFooters ? ConvertHeaderFooterZones(headerFooter.HeaderLeft, headerFooter.HeaderCenter, headerFooter.HeaderRight, sheetName, workbookPath, options, "header") : null;
             var firstHeaderZones = options.UseWorksheetHeadersAndFooters && headerFooter.DifferentFirstPage
@@ -19,7 +19,7 @@ namespace OfficeIMO.Excel.Pdf {
                 : null;
             bool hasFirstHeaderVariant = options.UseWorksheetHeadersAndFooters && headerFooter.DifferentFirstPage;
             bool hasEvenHeaderVariant = options.UseWorksheetHeadersAndFooters && headerFooter.DifferentOddEven;
-            if (HasAnyText(headerZones) || hasFirstHeaderVariant || hasEvenHeaderVariant || HasAnyHeaderImage(headerFooter, options)) {
+            if (HasAnyText(headerZones) || hasFirstHeaderVariant || hasEvenHeaderVariant || preparedImages.HasHeaderImages) {
                 page.Header(header => {
                     ApplyHeaderFooterStyle(header, ResolveSharedHeaderFooterStyle(new[] { headerZones, firstHeaderZones, evenHeaderZones }, sheetName, options, "header"));
 
@@ -39,9 +39,9 @@ namespace OfficeIMO.Excel.Pdf {
                         header.EvenPagesText(string.Empty);
                     }
 
-                    AddHeaderImage(header, headerFooter.HeaderLeftImage, options, PdfCore.PdfAlign.Left, headerFooter.HeaderLeft, headerFooter.FirstHeaderLeft, headerFooter.EvenHeaderLeft);
-                    AddHeaderImage(header, headerFooter.HeaderCenterImage, options, PdfCore.PdfAlign.Center, headerFooter.HeaderCenter, headerFooter.FirstHeaderCenter, headerFooter.EvenHeaderCenter);
-                    AddHeaderImage(header, headerFooter.HeaderRightImage, options, PdfCore.PdfAlign.Right, headerFooter.HeaderRight, headerFooter.FirstHeaderRight, headerFooter.EvenHeaderRight);
+                    AddHeaderImage(header, preparedImages.HeaderLeft, PdfCore.PdfAlign.Left, headerFooter.HeaderLeft, headerFooter.FirstHeaderLeft, headerFooter.EvenHeaderLeft);
+                    AddHeaderImage(header, preparedImages.HeaderCenter, PdfCore.PdfAlign.Center, headerFooter.HeaderCenter, headerFooter.FirstHeaderCenter, headerFooter.EvenHeaderCenter);
+                    AddHeaderImage(header, preparedImages.HeaderRight, PdfCore.PdfAlign.Right, headerFooter.HeaderRight, headerFooter.FirstHeaderRight, headerFooter.EvenHeaderRight);
                 });
             }
 
@@ -54,7 +54,7 @@ namespace OfficeIMO.Excel.Pdf {
                 : null;
             bool hasFirstFooterVariant = options.UseWorksheetHeadersAndFooters && headerFooter.DifferentFirstPage;
             bool hasEvenFooterVariant = options.UseWorksheetHeadersAndFooters && headerFooter.DifferentOddEven;
-            if (HasAnyText(footerZones) || hasFirstFooterVariant || hasEvenFooterVariant || HasAnyFooterImage(headerFooter, options)) {
+            if (HasAnyText(footerZones) || hasFirstFooterVariant || hasEvenFooterVariant || preparedImages.HasFooterImages) {
                 page.Footer(footer => {
                     ApplyHeaderFooterStyle(footer, ResolveSharedHeaderFooterStyle(new[] { footerZones, firstFooterZones, evenFooterZones }, sheetName, options, "footer"));
 
@@ -74,63 +74,49 @@ namespace OfficeIMO.Excel.Pdf {
                         footer.EvenPagesText(string.Empty);
                     }
 
-                    AddFooterImage(footer, headerFooter.FooterLeftImage, options, PdfCore.PdfAlign.Left, headerFooter.FooterLeft, headerFooter.FirstFooterLeft, headerFooter.EvenFooterLeft);
-                    AddFooterImage(footer, headerFooter.FooterCenterImage, options, PdfCore.PdfAlign.Center, headerFooter.FooterCenter, headerFooter.FirstFooterCenter, headerFooter.EvenFooterCenter);
-                    AddFooterImage(footer, headerFooter.FooterRightImage, options, PdfCore.PdfAlign.Right, headerFooter.FooterRight, headerFooter.FirstFooterRight, headerFooter.EvenFooterRight);
+                    AddFooterImage(footer, preparedImages.FooterLeft, PdfCore.PdfAlign.Left, headerFooter.FooterLeft, headerFooter.FirstFooterLeft, headerFooter.EvenFooterLeft);
+                    AddFooterImage(footer, preparedImages.FooterCenter, PdfCore.PdfAlign.Center, headerFooter.FooterCenter, headerFooter.FirstFooterCenter, headerFooter.EvenFooterCenter);
+                    AddFooterImage(footer, preparedImages.FooterRight, PdfCore.PdfAlign.Right, headerFooter.FooterRight, headerFooter.FirstFooterRight, headerFooter.EvenFooterRight);
                 });
             }
         }
 
-        private static bool HasAnyHeaderImage(ExcelSheet.HeaderFooterSnapshot headerFooter, ExcelPdfSaveOptions options) {
-            return options.UseWorksheetHeaderFooterImages
-                   && (IsPdfSupportedImage(headerFooter.HeaderLeftImage)
-                       || IsPdfSupportedImage(headerFooter.HeaderCenterImage)
-                       || IsPdfSupportedImage(headerFooter.HeaderRightImage));
-        }
-
-        private static bool HasAnyFooterImage(ExcelSheet.HeaderFooterSnapshot headerFooter, ExcelPdfSaveOptions options) {
-            return options.UseWorksheetHeaderFooterImages
-                   && (IsPdfSupportedImage(headerFooter.FooterLeftImage)
-                       || IsPdfSupportedImage(headerFooter.FooterCenterImage)
-                       || IsPdfSupportedImage(headerFooter.FooterRightImage));
-        }
-
-        private static void AddHeaderImage(PdfCore.PdfHeaderCompose header, ExcelSheet.HeaderFooterImageSnapshot? image, ExcelPdfSaveOptions options, PdfCore.PdfAlign align, string defaultZone, string firstZone, string evenZone) {
-            if (options.UseWorksheetHeaderFooterImages && IsPdfSupportedImage(image)) {
+        private static void AddHeaderImage(PdfCore.PdfHeaderCompose header, PreparedHeaderFooterImage? image, PdfCore.PdfAlign align, string defaultZone, string firstZone, string evenZone) {
+            if (image != null) {
                 bool defaultHasImage = HasPicturePlaceholder(defaultZone);
                 bool firstHasImage = HasPicturePlaceholder(firstZone);
                 bool evenHasImage = HasPicturePlaceholder(evenZone);
                 bool hasSpecificPlaceholder = defaultHasImage || firstHasImage || evenHasImage;
                 if (!hasSpecificPlaceholder || defaultHasImage) {
-                    header.Image(image!.Bytes, image.WidthPoints, image.HeightPoints, align);
+                    header.Image(image.Bytes, image.WidthPoints, image.HeightPoints, align);
                 }
 
                 if (firstHasImage) {
-                    header.FirstPageImage(image!.Bytes, image.WidthPoints, image.HeightPoints, align);
+                    header.FirstPageImage(image.Bytes, image.WidthPoints, image.HeightPoints, align);
                 }
 
                 if (evenHasImage) {
-                    header.EvenPagesImage(image!.Bytes, image.WidthPoints, image.HeightPoints, align);
+                    header.EvenPagesImage(image.Bytes, image.WidthPoints, image.HeightPoints, align);
                 }
             }
         }
 
-        private static void AddFooterImage(PdfCore.PdfFooterCompose footer, ExcelSheet.HeaderFooterImageSnapshot? image, ExcelPdfSaveOptions options, PdfCore.PdfAlign align, string defaultZone, string firstZone, string evenZone) {
-            if (options.UseWorksheetHeaderFooterImages && IsPdfSupportedImage(image)) {
+        private static void AddFooterImage(PdfCore.PdfFooterCompose footer, PreparedHeaderFooterImage? image, PdfCore.PdfAlign align, string defaultZone, string firstZone, string evenZone) {
+            if (image != null) {
                 bool defaultHasImage = HasPicturePlaceholder(defaultZone);
                 bool firstHasImage = HasPicturePlaceholder(firstZone);
                 bool evenHasImage = HasPicturePlaceholder(evenZone);
                 bool hasSpecificPlaceholder = defaultHasImage || firstHasImage || evenHasImage;
                 if (!hasSpecificPlaceholder || defaultHasImage) {
-                    footer.Image(image!.Bytes, image.WidthPoints, image.HeightPoints, align);
+                    footer.Image(image.Bytes, image.WidthPoints, image.HeightPoints, align);
                 }
 
                 if (firstHasImage) {
-                    footer.FirstPageImage(image!.Bytes, image.WidthPoints, image.HeightPoints, align);
+                    footer.FirstPageImage(image.Bytes, image.WidthPoints, image.HeightPoints, align);
                 }
 
                 if (evenHasImage) {
-                    footer.EvenPagesImage(image!.Bytes, image.WidthPoints, image.HeightPoints, align);
+                    footer.EvenPagesImage(image.Bytes, image.WidthPoints, image.HeightPoints, align);
                 }
             }
         }
@@ -138,13 +124,43 @@ namespace OfficeIMO.Excel.Pdf {
         private static bool HasPicturePlaceholder(string? text) =>
             text?.IndexOf("&G", StringComparison.Ordinal) >= 0;
 
-        private static bool IsPdfSupportedImage(ExcelSheet.HeaderFooterImageSnapshot? image) {
-            return image != null
-                   && image.Bytes.Length > 0
-                   && image.WidthPoints > 0D
-                   && image.HeightPoints > 0D
-                   && IsPdfSupportedImageContentType(image.ContentType)
-                   && TryValidatePdfImageBytes(image.Bytes, image.ContentType, out _);
+        private static PreparedHeaderFooterImages PrepareHeaderFooterImages(
+            ExcelSheet.HeaderFooterSnapshot headerFooter,
+            string sheetName,
+            ExcelPdfSaveOptions options) {
+            if (!options.UseWorksheetHeaderFooterImages) return new PreparedHeaderFooterImages();
+
+            return new PreparedHeaderFooterImages {
+                HeaderLeft = PrepareHeaderFooterImage(headerFooter.HeaderLeftImage, sheetName, "header left", options),
+                HeaderCenter = PrepareHeaderFooterImage(headerFooter.HeaderCenterImage, sheetName, "header center", options),
+                HeaderRight = PrepareHeaderFooterImage(headerFooter.HeaderRightImage, sheetName, "header right", options),
+                FooterLeft = PrepareHeaderFooterImage(headerFooter.FooterLeftImage, sheetName, "footer left", options),
+                FooterCenter = PrepareHeaderFooterImage(headerFooter.FooterCenterImage, sheetName, "footer center", options),
+                FooterRight = PrepareHeaderFooterImage(headerFooter.FooterRightImage, sheetName, "footer right", options)
+            };
+        }
+
+        private static PreparedHeaderFooterImage? PrepareHeaderFooterImage(
+            ExcelSheet.HeaderFooterImageSnapshot? image,
+            string sheetName,
+            string location,
+            ExcelPdfSaveOptions options) {
+            if (image == null) return null;
+
+            if (image.Bytes.Length > 0 &&
+                image.WidthPoints > 0D &&
+                image.HeightPoints > 0D &&
+                IsPdfSupportedImageContentType(image.ContentType) &&
+                TryPreparePdfImageBytes(image.Bytes, image.ContentType, out byte[] preparedBytes, out _)) {
+                return new PreparedHeaderFooterImage(preparedBytes, image.WidthPoints, image.HeightPoints);
+            }
+
+            AddWarning(
+                options,
+                sheetName,
+                "WorksheetHeaderFooterImage",
+                $"The {location} image was not exported because it is not a supported PDF image payload. ContentType='{image.ContentType}', WidthPoints={image.WidthPoints.ToString(CultureInfo.InvariantCulture)}, HeightPoints={image.HeightPoints.ToString(CultureInfo.InvariantCulture)}, Bytes={image.Bytes.Length.ToString(CultureInfo.InvariantCulture)}.");
+            return null;
         }
 
         private static bool HasAnyText(params string?[] values) {
@@ -165,30 +181,6 @@ namespace OfficeIMO.Excel.Pdf {
             return HasAnyText(zones.Left, zones.Center, zones.Right);
         }
 
-        private static void WarnUnsupportedHeaderFooterImages(ExcelSheet.HeaderFooterSnapshot headerFooter, string sheetName, ExcelPdfSaveOptions options) {
-            if (!options.UseWorksheetHeaderFooterImages) {
-                return;
-            }
-
-            WarnUnsupportedHeaderFooterImage(headerFooter.HeaderLeftImage, sheetName, "header left", options);
-            WarnUnsupportedHeaderFooterImage(headerFooter.HeaderCenterImage, sheetName, "header center", options);
-            WarnUnsupportedHeaderFooterImage(headerFooter.HeaderRightImage, sheetName, "header right", options);
-            WarnUnsupportedHeaderFooterImage(headerFooter.FooterLeftImage, sheetName, "footer left", options);
-            WarnUnsupportedHeaderFooterImage(headerFooter.FooterCenterImage, sheetName, "footer center", options);
-            WarnUnsupportedHeaderFooterImage(headerFooter.FooterRightImage, sheetName, "footer right", options);
-        }
-
-        private static void WarnUnsupportedHeaderFooterImage(ExcelSheet.HeaderFooterImageSnapshot? image, string sheetName, string location, ExcelPdfSaveOptions options) {
-            if (image == null || IsPdfSupportedImage(image)) {
-                return;
-            }
-
-            AddWarning(
-                options,
-                sheetName,
-                "WorksheetHeaderFooterImage",
-                $"The {location} image was not exported because it is not a supported PDF image payload. ContentType='{image.ContentType}', WidthPoints={image.WidthPoints.ToString(CultureInfo.InvariantCulture)}, HeightPoints={image.HeightPoints.ToString(CultureInfo.InvariantCulture)}, Bytes={image.Bytes.Length.ToString(CultureInfo.InvariantCulture)}.");
-        }
 
         private static HeaderFooterZones ConvertHeaderFooterZones(string? left, string? center, string? right, string sheetName, string? workbookPath, ExcelPdfSaveOptions options, string scope) {
             HeaderFooterZone leftZone = ConvertHeaderFooterText(left, sheetName, workbookPath, options, scope, "left");
@@ -605,6 +597,30 @@ namespace OfficeIMO.Excel.Pdf {
             return (value >= '0' && value <= '9') ||
                    (value >= 'a' && value <= 'f') ||
                    (value >= 'A' && value <= 'F');
+        }
+
+        private sealed class PreparedHeaderFooterImages {
+            internal PreparedHeaderFooterImage? HeaderLeft { get; set; }
+            internal PreparedHeaderFooterImage? HeaderCenter { get; set; }
+            internal PreparedHeaderFooterImage? HeaderRight { get; set; }
+            internal PreparedHeaderFooterImage? FooterLeft { get; set; }
+            internal PreparedHeaderFooterImage? FooterCenter { get; set; }
+            internal PreparedHeaderFooterImage? FooterRight { get; set; }
+
+            internal bool HasHeaderImages => HeaderLeft != null || HeaderCenter != null || HeaderRight != null;
+            internal bool HasFooterImages => FooterLeft != null || FooterCenter != null || FooterRight != null;
+        }
+
+        private sealed class PreparedHeaderFooterImage {
+            internal PreparedHeaderFooterImage(byte[] bytes, double widthPoints, double heightPoints) {
+                Bytes = bytes;
+                WidthPoints = widthPoints;
+                HeightPoints = heightPoints;
+            }
+
+            internal byte[] Bytes { get; }
+            internal double WidthPoints { get; }
+            internal double HeightPoints { get; }
         }
 
     }

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.WorksheetContent.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.WorksheetContent.cs
@@ -86,7 +86,7 @@ namespace OfficeIMO.Excel.Pdf {
                     continue;
                 }
 
-                if (!TryValidatePdfImageBytes(bytes, image.ContentType, out string? unsupportedReason)) {
+                if (!TryPreparePdfImageBytes(bytes, image.ContentType, out byte[] preparedBytes, out string? unsupportedReason)) {
                     AddWarning(
                         options,
                         sheetName,
@@ -99,7 +99,7 @@ namespace OfficeIMO.Excel.Pdf {
                     ? string.IsNullOrWhiteSpace(image.Title) ? null : image.Title
                     : image.Description;
                 images.Add(new WorksheetImageExportData(
-                    bytes,
+                    preparedBytes,
                     PixelsToPoints(image.WidthPixels),
                     PixelsToPoints(image.HeightPixels),
                     A1.CellReference(image.RowIndex, image.ColumnIndex),
@@ -187,25 +187,23 @@ namespace OfficeIMO.Excel.Pdf {
             return OfficeImagePdfCompatibility.IsSupportedContentType(contentType);
         }
 
-        private static bool TryValidatePdfImageBytes(byte[] bytes, string contentType, out string? unsupportedReason) {
+        private static bool TryPreparePdfImageBytes(
+            byte[] bytes,
+            string contentType,
+            out byte[] preparedBytes,
+            out string? unsupportedReason) {
+            preparedBytes = Array.Empty<byte>();
             unsupportedReason = null;
             if (!OfficeImagePdfCompatibility.TryValidateDeclaredContentType(bytes, contentType, out _, out unsupportedReason)) {
                 return false;
             }
 
-            try {
-                _ = new PdfCore.PdfTableCellImage(bytes, 1D, 1D);
-                return true;
-            } catch (ArgumentException ex) {
-                unsupportedReason = ex.Message;
-                return false;
-            } catch (InvalidDataException ex) {
-                unsupportedReason = ex.Message;
-                return false;
-            } catch (NotSupportedException ex) {
-                unsupportedReason = ex.Message;
-                return false;
-            }
+            return PdfCore.PdfDocument.TryPrepareImageBytes(
+                bytes,
+                out preparedBytes,
+                out _,
+                out _,
+                out unsupportedReason);
         }
 
         private static double PixelsToPoints(int pixels) {

--- a/OfficeIMO.Excel.Tests/Excel.FeatureReport.Preflight.cs
+++ b/OfficeIMO.Excel.Tests/Excel.FeatureReport.Preflight.cs
@@ -633,13 +633,13 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void FeatureReport_Preflight_BlocksPdfExportForUnsupportedWorksheetImages() {
-            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.UnsupportedImage.xlsx");
+        public void FeatureReport_Preflight_AllowsPdfExportForSupportedWorksheetGif() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.SupportedGifImage.xlsx");
 
             using (ExcelDocument document = ExcelDocument.Create(filePath)) {
                 ExcelSheet sheet = document.AddWorksheet("Images");
                 sheet.CellValue(1, 1, "Image");
-                sheet.AddImage(2, 1, new byte[] { 0x47, 0x49, 0x46, 0x38, 0x39, 0x61 }, "image/gif",
+                sheet.AddImage(2, 1, CreateFeatureReportGif(), "image/gif",
                     widthPixels: 12, heightPixels: 12, name: "GifLogo");
                 document.Save();
             }
@@ -647,23 +647,19 @@ namespace OfficeIMO.Tests {
             using (ExcelDocument document = ExcelDocument.Load(filePath, new OfficeIMO.Excel.ExcelLoadOptions { AccessMode = OfficeIMO.Drawing.DocumentAccessMode.ReadOnly })) {
                 ExcelFeatureReport report = document.InspectFeatures();
 
-                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
-
-                string diagnostics = string.Join(Environment.NewLine,
-                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
-                Assert.Contains("PDF-unsupported images", diagnostics);
-                Assert.Contains("image/gif", diagnostics);
+                Assert.True(report.Can(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Empty(report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
             }
         }
 
         [Fact]
-        public void FeatureReport_Preflight_BlocksPdfExportForUnsupportedHeaderFooterImages() {
-            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.UnsupportedHeaderImage.xlsx");
+        public void FeatureReport_Preflight_AllowsPdfExportForSupportedHeaderFooterGif() {
+            string filePath = Path.Combine(_directoryWithFiles, "FeatureReport.Preflight.SupportedHeaderGif.xlsx");
 
             using (ExcelDocument document = ExcelDocument.Create(filePath)) {
                 ExcelSheet sheet = document.AddWorksheet("Images");
                 sheet.CellValue(1, 1, "Image");
-                sheet.SetHeaderImage(HeaderFooterPosition.Center, new byte[] { 0x47, 0x49, 0x46, 0x38, 0x39, 0x61 }, "image/gif",
+                sheet.SetHeaderImage(HeaderFooterPosition.Center, CreateFeatureReportGif(), "image/gif",
                     widthPoints: 24, heightPoints: 24);
                 document.Save();
             }
@@ -671,15 +667,13 @@ namespace OfficeIMO.Tests {
             using (ExcelDocument document = ExcelDocument.Load(filePath, new OfficeIMO.Excel.ExcelLoadOptions { AccessMode = OfficeIMO.Drawing.DocumentAccessMode.ReadOnly })) {
                 ExcelFeatureReport report = document.InspectFeatures();
 
-                Assert.False(report.Can(ExcelPreflightCapability.ExportPdfReport));
-
-                string diagnostics = string.Join(Environment.NewLine,
-                    report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
-                Assert.Contains("PDF-unsupported images", diagnostics);
-                Assert.Contains("header center", diagnostics);
-                Assert.Contains("image/gif", diagnostics);
+                Assert.True(report.Can(ExcelPreflightCapability.ExportPdfReport));
+                Assert.Empty(report.GetCapabilityDiagnostics(ExcelPreflightCapability.ExportPdfReport));
             }
         }
+
+        private static byte[] CreateFeatureReportGif() =>
+            Convert.FromBase64String("R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==");
 
         [Fact]
         public void FeatureReport_Preflight_BlocksPdfExportForUnsupportedHeaderFooterFormatting() {

--- a/OfficeIMO.Markdown.Pdf/MarkdownPdfConverterExtensions.Images.cs
+++ b/OfficeIMO.Markdown.Pdf/MarkdownPdfConverterExtensions.Images.cs
@@ -88,7 +88,12 @@ public static partial class MarkdownPdfConverterExtensions {
         string? linkContents,
         MarkdownPdfSaveOptions options,
         MarkdownPdfStyle visualTheme) {
-        if (!PdfCore.PdfDocument.TryValidateImageBytes(bytes, out OfficeImageInfo? info, out string? unsupportedReason)) {
+        if (!PdfCore.PdfDocument.TryPrepareImageBytes(
+                bytes,
+                out byte[] preparedBytes,
+                out OfficeImageInfo? info,
+                out _,
+                out string? unsupportedReason)) {
             AddWarning(options, "UnsupportedImage", sourceName, "The Markdown image bytes are not supported by the PDF image renderer. " + unsupportedReason);
             RenderImagePlaceholder(pdf, altText ?? sourceName, visualTheme);
             return;
@@ -100,7 +105,7 @@ public static partial class MarkdownPdfConverterExtensions {
         PdfCore.PdfImageStyle imageStyle = CreateConverterImageStyle(figureStyle, altText);
         string? normalizedLinkContents = linkUri == null || string.IsNullOrWhiteSpace(linkContents) ? null : linkContents;
 
-        pdf.Image(bytes, width, height, align: null, clipPath: null, fit: null, spacingBefore: null, spacingAfter: null, style: imageStyle, linkUri: linkUri, linkContents: normalizedLinkContents);
+        pdf.Image(preparedBytes, width, height, align: null, clipPath: null, fit: null, spacingBefore: null, spacingAfter: null, style: imageStyle, linkUri: linkUri, linkContents: normalizedLinkContents);
         RenderFigureCaption(pdf, caption, figureStyle);
     }
 

--- a/OfficeIMO.OpenDocument.Converters.Tests/OfficeIMO.OpenDocument.Converters.Tests.csproj
+++ b/OfficeIMO.OpenDocument.Converters.Tests/OfficeIMO.OpenDocument.Converters.Tests.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\OfficeIMO.OpenDocument.Pdf\OfficeIMO.OpenDocument.Pdf.csproj" />
     <ProjectReference Include="..\OfficeIMO.Word.OpenDocument\OfficeIMO.Word.OpenDocument.csproj" />
     <ProjectReference Include="..\OfficeIMO.Excel.OpenDocument\OfficeIMO.Excel.OpenDocument.csproj" />
     <ProjectReference Include="..\OfficeIMO.PowerPoint.OpenDocument\OfficeIMO.PowerPoint.OpenDocument.csproj" />

--- a/OfficeIMO.OpenDocument.Converters.Tests/OpenDocumentPdfConversionContracts.cs
+++ b/OfficeIMO.OpenDocument.Converters.Tests/OpenDocumentPdfConversionContracts.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using OfficeIMO.OpenDocument.Pdf;
+using OfficeIMO.Pdf;
+using Xunit;
+
+namespace OfficeIMO.OpenDocument.Converters.Tests;
+
+public sealed class OpenDocumentPdfConversionContracts {
+    public static IEnumerable<object[]> DirectAdapterTypes() {
+        yield return new object[] { typeof(OdtPdfConversionExtensions) };
+        yield return new object[] { typeof(OdsPdfConversionExtensions) };
+        yield return new object[] { typeof(OdpPdfConversionExtensions) };
+    }
+
+    [Theory]
+    [MemberData(nameof(DirectAdapterTypes))]
+    public void OpenDocumentFacadesExposeTheCanonicalPdfLifecycle(Type adapterType) {
+        MethodInfo[] methods = adapterType.GetMethods(BindingFlags.Public | BindingFlags.Static);
+
+        Assert.Single(methods, method => method.Name == "ToPdf");
+        Assert.Single(methods, method => method.Name == "ToPdfDocument");
+        Assert.Single(methods, method => method.Name == "ToPdfDocumentResult");
+        Assert.Equal(2, methods.Count(method => method.Name == "SaveAsPdf" && method.ReturnType == typeof(PdfSaveResult)));
+        Assert.Equal(2, methods.Count(method => method.Name == "TrySaveAsPdf" && method.ReturnType == typeof(PdfSaveResult)));
+        Assert.Equal(2, methods.Count(method => method.Name == "SaveAsPdfAsync" && method.ReturnType == typeof(Task<PdfSaveResult>)));
+        Assert.Equal(2, methods.Count(method => method.Name == "TrySaveAsPdfAsync" && method.ReturnType == typeof(Task<PdfSaveResult>)));
+    }
+
+    [Fact]
+    public void OdtFacadePreservesProjectionLossAndProducesReadablePdf() {
+        OdtDocument source = OdtDocument.Create();
+        source.AddParagraph("Direct ODT PDF");
+        source.AddTrackedParagraphInsertion("Tracked source", "Reviewer");
+
+        PdfDocumentConversionResult result = source.ToPdfDocumentResult();
+        byte[] bytes = result.ToBytes();
+
+        Assert.Contains("Direct ODT PDF", PdfReadDocument.Open(bytes).ExtractText(), StringComparison.Ordinal);
+        Assert.Contains(result.Warnings, warning =>
+            warning.Code == "ODF_UNSUPPORTED" &&
+            warning.Source.EndsWith(":source-tracked-changes", StringComparison.Ordinal) &&
+            warning.Severity == PdfConversionWarningSeverity.Warning &&
+            warning.Details["stage"] == "open-document-projection");
+    }
+
+    [Fact]
+    public void OdsFacadeUsesExcelPdfEngineAndExposesInformationEvidence() {
+        OdsDocument source = OdsDocument.Create();
+        source.AddSheet("Revenue").Cell(0, 0).SetString("Quarter total");
+
+        PdfDocumentConversionResult result = source.ToPdfDocumentResult();
+        string text = PdfReadDocument.Open(result.ToBytes()).ExtractText();
+
+        Assert.Contains("Quarter total", text, StringComparison.Ordinal);
+        Assert.Single(PdfReadDocument.Open(result.ToBytes()).Pages);
+        Assert.Contains(result.Warnings, warning =>
+            warning.Code == "ODF_CONVERTED" &&
+            warning.Severity == PdfConversionWarningSeverity.Information);
+    }
+
+    [Fact]
+    public void OdpFacadeUsesPowerPointPdfEngineAndKeepsAnimationLoss() {
+        OdpPresentation source = OdpPresentation.Create();
+        OdpSlide slide = source.AddSlide("Overview");
+        slide.AddTextBox(OdfRect.FromCentimeters(1, 1, 8, 2), "Direct ODP PDF");
+        OdpRectangle animated = slide.AddRectangle(OdfRect.FromCentimeters(1, 4, 2, 2));
+        slide.AddFadeInAnimation(animated, TimeSpan.FromSeconds(1));
+
+        PdfDocumentConversionResult result = source.ToPdfDocumentResult();
+        string text = PdfReadDocument.Open(result.ToBytes()).ExtractText();
+
+        Assert.Contains("Direct ODP PDF", text, StringComparison.Ordinal);
+        Assert.Contains(result.Warnings, warning =>
+            warning.Code == "ODF_UNSUPPORTED" &&
+            warning.Source.EndsWith(":source-presentation-animations", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task DirectFacadeSupportsStreamAndAsyncSaveContracts() {
+        OdtDocument source = OdtDocument.Create();
+        source.AddParagraph("Stream contract");
+        using var stream = new MemoryStream();
+
+        PdfSaveResult save = await source.SaveAsPdfAsync(stream);
+
+        Assert.True(save.Succeeded, save.Exception?.Message);
+        Assert.True(stream.Length > 0);
+    }
+}

--- a/OfficeIMO.OpenDocument.Pdf/OdfPdfConversionDiagnostics.cs
+++ b/OfficeIMO.OpenDocument.Pdf/OdfPdfConversionDiagnostics.cs
@@ -1,0 +1,70 @@
+using System.Globalization;
+using System.Text;
+using PdfCore = OfficeIMO.Pdf;
+
+namespace OfficeIMO.OpenDocument.Pdf;
+
+internal static class OdfPdfConversionDiagnostics {
+    internal static PdfCore.PdfDocumentConversionResult Attach(
+        PdfCore.PdfDocumentConversionResult result,
+        OdfConversionReport report) {
+        if (result == null) throw new ArgumentNullException(nameof(result));
+        if (report == null) throw new ArgumentNullException(nameof(report));
+
+        var warnings = new List<PdfCore.PdfConversionWarning>(report.Mappings.Count);
+        foreach (OdfConversionMapping mapping in report.Mappings) {
+            warnings.Add(ToWarning(report, mapping));
+        }
+
+        return result.WithAdditionalWarnings(warnings);
+    }
+
+    private static PdfCore.PdfConversionWarning ToWarning(
+        OdfConversionReport report,
+        OdfConversionMapping mapping) {
+        PdfCore.PdfConversionWarningSeverity severity =
+            mapping.Status == OdfConversionMappingStatus.Converted
+                ? PdfCore.PdfConversionWarningSeverity.Information
+                : PdfCore.PdfConversionWarningSeverity.Warning;
+        string message = string.IsNullOrWhiteSpace(mapping.Message)
+            ? string.Format(
+                CultureInfo.InvariantCulture,
+                "{0} {1} item(s) were {2} while projecting {3} to {4} before PDF layout.",
+                mapping.Count,
+                mapping.Feature,
+                mapping.Status.ToString().ToLowerInvariant(),
+                report.SourceFormat,
+                report.TargetFormat)
+            : mapping.Message!;
+        var details = new Dictionary<string, string> {
+            ["stage"] = "open-document-projection",
+            ["sourceFormat"] = report.SourceFormat,
+            ["targetFormat"] = report.TargetFormat,
+            ["feature"] = mapping.Feature,
+            ["status"] = mapping.Status.ToString(),
+            ["count"] = mapping.Count.ToString(CultureInfo.InvariantCulture)
+        };
+        return new PdfCore.PdfConversionWarning(
+            "OfficeIMO.OpenDocument.Pdf",
+            "ODF_" + NormalizeToken(mapping.Status.ToString()),
+            report.SourceFormat + "->" + report.TargetFormat + ":" + mapping.Feature,
+            message,
+            severity,
+            details: details);
+    }
+
+    private static string NormalizeToken(string value) {
+        var builder = new StringBuilder(value.Length);
+        bool previousUnderscore = false;
+        foreach (char character in value) {
+            char normalized = char.IsLetterOrDigit(character)
+                ? char.ToUpperInvariant(character)
+                : '_';
+            if (normalized == '_' && previousUnderscore) continue;
+            builder.Append(normalized);
+            previousUnderscore = normalized == '_';
+        }
+
+        return builder.ToString().Trim('_');
+    }
+}

--- a/OfficeIMO.OpenDocument.Pdf/OdpPdfConversionExtensions.cs
+++ b/OfficeIMO.OpenDocument.Pdf/OdpPdfConversionExtensions.cs
@@ -1,0 +1,74 @@
+using OfficeIMO.PowerPoint.OpenDocument;
+using PowerPointPdf = OfficeIMO.PowerPoint.Pdf;
+using PdfCore = OfficeIMO.Pdf;
+
+namespace OfficeIMO.OpenDocument.Pdf;
+
+/// <summary>Direct, loss-aware ODP to PDF conversion through the PowerPoint semantic and PDF engines.</summary>
+public static class OdpPdfConversionExtensions {
+    /// <summary>Converts an ODP presentation to the first-party PDF document model.</summary>
+    public static PdfCore.PdfDocument ToPdfDocument(this OdpPresentation source, PowerPointOpenDocumentConversionOptions? conversionOptions = null, PowerPointPdf.PowerPointPdfSaveOptions? pdfOptions = null) =>
+        source.ToPdfDocumentResult(conversionOptions, pdfOptions).Value;
+
+    /// <summary>Converts an ODP presentation to PDF and preserves diagnostics from both conversion stages.</summary>
+    public static PdfCore.PdfDocumentConversionResult ToPdfDocumentResult(this OdpPresentation source, PowerPointOpenDocumentConversionOptions? conversionOptions = null, PowerPointPdf.PowerPointPdfSaveOptions? pdfOptions = null) {
+        if (source == null) throw new ArgumentNullException(nameof(source));
+        OdfConversionResult<OfficeIMO.PowerPoint.PowerPointPresentation> conversion = source.ToPowerPointPresentationResult(conversionOptions);
+        using (conversion.Value) {
+            PdfCore.PdfDocumentConversionResult result = PowerPointPdf.PowerPointPdfConverterExtensions.ToPdfDocumentResult(conversion.Value, pdfOptions);
+            return OdfPdfConversionDiagnostics.Attach(result, conversion.Report);
+        }
+    }
+
+    /// <summary>Converts an ODP presentation to PDF bytes.</summary>
+    public static byte[] ToPdf(this OdpPresentation source, PowerPointOpenDocumentConversionOptions? conversionOptions = null, PowerPointPdf.PowerPointPdfSaveOptions? pdfOptions = null) =>
+        source.ToPdfDocumentResult(conversionOptions, pdfOptions).ToBytes();
+
+    /// <summary>Saves an ODP presentation as PDF.</summary>
+    public static PdfCore.PdfSaveResult SaveAsPdf(this OdpPresentation source, string path, PowerPointOpenDocumentConversionOptions? conversionOptions = null, PowerPointPdf.PowerPointPdfSaveOptions? pdfOptions = null) =>
+        source.ToPdfDocumentResult(conversionOptions, pdfOptions).Save(path);
+
+    /// <summary>Writes an ODP presentation as PDF to a caller-owned stream.</summary>
+    public static PdfCore.PdfSaveResult SaveAsPdf(this OdpPresentation source, Stream stream, PowerPointOpenDocumentConversionOptions? conversionOptions = null, PowerPointPdf.PowerPointPdfSaveOptions? pdfOptions = null) =>
+        source.ToPdfDocumentResult(conversionOptions, pdfOptions).Save(stream);
+
+    /// <summary>Attempts to save an ODP presentation as PDF and returns structured failure evidence.</summary>
+    public static PdfCore.PdfSaveResult TrySaveAsPdf(this OdpPresentation source, string path, PowerPointOpenDocumentConversionOptions? conversionOptions = null, PowerPointPdf.PowerPointPdfSaveOptions? pdfOptions = null) {
+        try { return source.ToPdfDocumentResult(conversionOptions, pdfOptions).TrySave(path); }
+        catch (Exception ex) { return PdfCore.PdfSaveResult.FromFailure(path, ex); }
+    }
+
+    /// <summary>Attempts to write an ODP presentation as PDF and returns structured failure evidence.</summary>
+    public static PdfCore.PdfSaveResult TrySaveAsPdf(this OdpPresentation source, Stream stream, PowerPointOpenDocumentConversionOptions? conversionOptions = null, PowerPointPdf.PowerPointPdfSaveOptions? pdfOptions = null) {
+        try { return source.ToPdfDocumentResult(conversionOptions, pdfOptions).TrySave(stream); }
+        catch (Exception ex) { return PdfCore.PdfSaveResult.FromFailure(outputPath: null, ex); }
+    }
+
+    /// <summary>Converts synchronously, then asynchronously saves an ODP presentation as PDF.</summary>
+    public static Task<PdfCore.PdfSaveResult> SaveAsPdfAsync(this OdpPresentation source, string path, PowerPointOpenDocumentConversionOptions? conversionOptions = null, PowerPointPdf.PowerPointPdfSaveOptions? pdfOptions = null, CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
+        return source.ToPdfDocumentResult(conversionOptions, pdfOptions).SaveAsync(path, cancellationToken);
+    }
+
+    /// <summary>Converts synchronously, then asynchronously writes an ODP presentation as PDF.</summary>
+    public static Task<PdfCore.PdfSaveResult> SaveAsPdfAsync(this OdpPresentation source, Stream stream, PowerPointOpenDocumentConversionOptions? conversionOptions = null, PowerPointPdf.PowerPointPdfSaveOptions? pdfOptions = null, CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
+        return source.ToPdfDocumentResult(conversionOptions, pdfOptions).SaveAsync(stream, cancellationToken);
+    }
+
+    /// <summary>Attempts to asynchronously save an ODP presentation as PDF and returns structured failure evidence.</summary>
+    public static async Task<PdfCore.PdfSaveResult> TrySaveAsPdfAsync(this OdpPresentation source, string path, PowerPointOpenDocumentConversionOptions? conversionOptions = null, PowerPointPdf.PowerPointPdfSaveOptions? pdfOptions = null, CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
+        try { return await source.ToPdfDocumentResult(conversionOptions, pdfOptions).TrySaveAsync(path, cancellationToken).ConfigureAwait(false); }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
+        catch (Exception ex) { return PdfCore.PdfSaveResult.FromFailure(path, ex); }
+    }
+
+    /// <summary>Attempts to asynchronously write an ODP presentation as PDF and returns structured failure evidence.</summary>
+    public static async Task<PdfCore.PdfSaveResult> TrySaveAsPdfAsync(this OdpPresentation source, Stream stream, PowerPointOpenDocumentConversionOptions? conversionOptions = null, PowerPointPdf.PowerPointPdfSaveOptions? pdfOptions = null, CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
+        try { return await source.ToPdfDocumentResult(conversionOptions, pdfOptions).TrySaveAsync(stream, cancellationToken).ConfigureAwait(false); }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
+        catch (Exception ex) { return PdfCore.PdfSaveResult.FromFailure(outputPath: null, ex); }
+    }
+}

--- a/OfficeIMO.OpenDocument.Pdf/OdsPdfConversionExtensions.cs
+++ b/OfficeIMO.OpenDocument.Pdf/OdsPdfConversionExtensions.cs
@@ -1,0 +1,74 @@
+using OfficeIMO.Excel.OpenDocument;
+using ExcelPdf = OfficeIMO.Excel.Pdf;
+using PdfCore = OfficeIMO.Pdf;
+
+namespace OfficeIMO.OpenDocument.Pdf;
+
+/// <summary>Direct, loss-aware ODS to PDF conversion through the Excel semantic and PDF engines.</summary>
+public static class OdsPdfConversionExtensions {
+    /// <summary>Converts an ODS workbook to the first-party PDF document model.</summary>
+    public static PdfCore.PdfDocument ToPdfDocument(this OdsDocument source, ExcelOpenDocumentConversionOptions? conversionOptions = null, ExcelPdf.ExcelPdfSaveOptions? pdfOptions = null) =>
+        source.ToPdfDocumentResult(conversionOptions, pdfOptions).Value;
+
+    /// <summary>Converts an ODS workbook to PDF and preserves diagnostics from both conversion stages.</summary>
+    public static PdfCore.PdfDocumentConversionResult ToPdfDocumentResult(this OdsDocument source, ExcelOpenDocumentConversionOptions? conversionOptions = null, ExcelPdf.ExcelPdfSaveOptions? pdfOptions = null) {
+        if (source == null) throw new ArgumentNullException(nameof(source));
+        OdfConversionResult<OfficeIMO.Excel.ExcelDocument> conversion = source.ToExcelDocumentResult(conversionOptions);
+        using (conversion.Value) {
+            PdfCore.PdfDocumentConversionResult result = ExcelPdf.ExcelPdfConverterExtensions.ToPdfDocumentResult(conversion.Value, pdfOptions);
+            return OdfPdfConversionDiagnostics.Attach(result, conversion.Report);
+        }
+    }
+
+    /// <summary>Converts an ODS workbook to PDF bytes.</summary>
+    public static byte[] ToPdf(this OdsDocument source, ExcelOpenDocumentConversionOptions? conversionOptions = null, ExcelPdf.ExcelPdfSaveOptions? pdfOptions = null) =>
+        source.ToPdfDocumentResult(conversionOptions, pdfOptions).ToBytes();
+
+    /// <summary>Saves an ODS workbook as PDF.</summary>
+    public static PdfCore.PdfSaveResult SaveAsPdf(this OdsDocument source, string path, ExcelOpenDocumentConversionOptions? conversionOptions = null, ExcelPdf.ExcelPdfSaveOptions? pdfOptions = null) =>
+        source.ToPdfDocumentResult(conversionOptions, pdfOptions).Save(path);
+
+    /// <summary>Writes an ODS workbook as PDF to a caller-owned stream.</summary>
+    public static PdfCore.PdfSaveResult SaveAsPdf(this OdsDocument source, Stream stream, ExcelOpenDocumentConversionOptions? conversionOptions = null, ExcelPdf.ExcelPdfSaveOptions? pdfOptions = null) =>
+        source.ToPdfDocumentResult(conversionOptions, pdfOptions).Save(stream);
+
+    /// <summary>Attempts to save an ODS workbook as PDF and returns structured failure evidence.</summary>
+    public static PdfCore.PdfSaveResult TrySaveAsPdf(this OdsDocument source, string path, ExcelOpenDocumentConversionOptions? conversionOptions = null, ExcelPdf.ExcelPdfSaveOptions? pdfOptions = null) {
+        try { return source.ToPdfDocumentResult(conversionOptions, pdfOptions).TrySave(path); }
+        catch (Exception ex) { return PdfCore.PdfSaveResult.FromFailure(path, ex); }
+    }
+
+    /// <summary>Attempts to write an ODS workbook as PDF and returns structured failure evidence.</summary>
+    public static PdfCore.PdfSaveResult TrySaveAsPdf(this OdsDocument source, Stream stream, ExcelOpenDocumentConversionOptions? conversionOptions = null, ExcelPdf.ExcelPdfSaveOptions? pdfOptions = null) {
+        try { return source.ToPdfDocumentResult(conversionOptions, pdfOptions).TrySave(stream); }
+        catch (Exception ex) { return PdfCore.PdfSaveResult.FromFailure(outputPath: null, ex); }
+    }
+
+    /// <summary>Converts synchronously, then asynchronously saves an ODS workbook as PDF.</summary>
+    public static Task<PdfCore.PdfSaveResult> SaveAsPdfAsync(this OdsDocument source, string path, ExcelOpenDocumentConversionOptions? conversionOptions = null, ExcelPdf.ExcelPdfSaveOptions? pdfOptions = null, CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
+        return source.ToPdfDocumentResult(conversionOptions, pdfOptions).SaveAsync(path, cancellationToken);
+    }
+
+    /// <summary>Converts synchronously, then asynchronously writes an ODS workbook as PDF.</summary>
+    public static Task<PdfCore.PdfSaveResult> SaveAsPdfAsync(this OdsDocument source, Stream stream, ExcelOpenDocumentConversionOptions? conversionOptions = null, ExcelPdf.ExcelPdfSaveOptions? pdfOptions = null, CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
+        return source.ToPdfDocumentResult(conversionOptions, pdfOptions).SaveAsync(stream, cancellationToken);
+    }
+
+    /// <summary>Attempts to asynchronously save an ODS workbook as PDF and returns structured failure evidence.</summary>
+    public static async Task<PdfCore.PdfSaveResult> TrySaveAsPdfAsync(this OdsDocument source, string path, ExcelOpenDocumentConversionOptions? conversionOptions = null, ExcelPdf.ExcelPdfSaveOptions? pdfOptions = null, CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
+        try { return await source.ToPdfDocumentResult(conversionOptions, pdfOptions).TrySaveAsync(path, cancellationToken).ConfigureAwait(false); }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
+        catch (Exception ex) { return PdfCore.PdfSaveResult.FromFailure(path, ex); }
+    }
+
+    /// <summary>Attempts to asynchronously write an ODS workbook as PDF and returns structured failure evidence.</summary>
+    public static async Task<PdfCore.PdfSaveResult> TrySaveAsPdfAsync(this OdsDocument source, Stream stream, ExcelOpenDocumentConversionOptions? conversionOptions = null, ExcelPdf.ExcelPdfSaveOptions? pdfOptions = null, CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
+        try { return await source.ToPdfDocumentResult(conversionOptions, pdfOptions).TrySaveAsync(stream, cancellationToken).ConfigureAwait(false); }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
+        catch (Exception ex) { return PdfCore.PdfSaveResult.FromFailure(outputPath: null, ex); }
+    }
+}

--- a/OfficeIMO.OpenDocument.Pdf/OdtPdfConversionExtensions.cs
+++ b/OfficeIMO.OpenDocument.Pdf/OdtPdfConversionExtensions.cs
@@ -1,0 +1,82 @@
+using OfficeIMO.Word.OpenDocument;
+using WordPdf = OfficeIMO.Word.Pdf;
+using PdfCore = OfficeIMO.Pdf;
+
+namespace OfficeIMO.OpenDocument.Pdf;
+
+/// <summary>Direct, loss-aware ODT to PDF conversion through the Word semantic and PDF engines.</summary>
+public static class OdtPdfConversionExtensions {
+    /// <summary>Converts an ODT document to the first-party PDF document model.</summary>
+    public static PdfCore.PdfDocument ToPdfDocument(
+        this OdtDocument source,
+        WordOpenDocumentConversionOptions? conversionOptions = null,
+        WordPdf.PdfSaveOptions? pdfOptions = null) =>
+        source.ToPdfDocumentResult(conversionOptions, pdfOptions).Value;
+
+    /// <summary>Converts an ODT document to PDF and preserves diagnostics from both conversion stages.</summary>
+    public static PdfCore.PdfDocumentConversionResult ToPdfDocumentResult(
+        this OdtDocument source,
+        WordOpenDocumentConversionOptions? conversionOptions = null,
+        WordPdf.PdfSaveOptions? pdfOptions = null) {
+        if (source == null) throw new ArgumentNullException(nameof(source));
+        OdfConversionResult<OfficeIMO.Word.WordDocument> conversion =
+            source.ToWordDocumentResult(conversionOptions);
+        using (conversion.Value) {
+            PdfCore.PdfDocumentConversionResult result =
+                WordPdf.WordPdfConverterExtensions.ToPdfDocumentResult(conversion.Value, pdfOptions);
+            return OdfPdfConversionDiagnostics.Attach(result, conversion.Report);
+        }
+    }
+
+    /// <summary>Converts an ODT document to PDF bytes.</summary>
+    public static byte[] ToPdf(this OdtDocument source, WordOpenDocumentConversionOptions? conversionOptions = null, WordPdf.PdfSaveOptions? pdfOptions = null) =>
+        source.ToPdfDocumentResult(conversionOptions, pdfOptions).ToBytes();
+
+    /// <summary>Saves an ODT document as PDF.</summary>
+    public static PdfCore.PdfSaveResult SaveAsPdf(this OdtDocument source, string path, WordOpenDocumentConversionOptions? conversionOptions = null, WordPdf.PdfSaveOptions? pdfOptions = null) =>
+        source.ToPdfDocumentResult(conversionOptions, pdfOptions).Save(path);
+
+    /// <summary>Writes an ODT document as PDF to a caller-owned stream.</summary>
+    public static PdfCore.PdfSaveResult SaveAsPdf(this OdtDocument source, Stream stream, WordOpenDocumentConversionOptions? conversionOptions = null, WordPdf.PdfSaveOptions? pdfOptions = null) =>
+        source.ToPdfDocumentResult(conversionOptions, pdfOptions).Save(stream);
+
+    /// <summary>Attempts to save an ODT document as PDF and returns structured failure evidence.</summary>
+    public static PdfCore.PdfSaveResult TrySaveAsPdf(this OdtDocument source, string path, WordOpenDocumentConversionOptions? conversionOptions = null, WordPdf.PdfSaveOptions? pdfOptions = null) {
+        try { return source.ToPdfDocumentResult(conversionOptions, pdfOptions).TrySave(path); }
+        catch (Exception ex) { return PdfCore.PdfSaveResult.FromFailure(path, ex); }
+    }
+
+    /// <summary>Attempts to write an ODT document as PDF and returns structured failure evidence.</summary>
+    public static PdfCore.PdfSaveResult TrySaveAsPdf(this OdtDocument source, Stream stream, WordOpenDocumentConversionOptions? conversionOptions = null, WordPdf.PdfSaveOptions? pdfOptions = null) {
+        try { return source.ToPdfDocumentResult(conversionOptions, pdfOptions).TrySave(stream); }
+        catch (Exception ex) { return PdfCore.PdfSaveResult.FromFailure(outputPath: null, ex); }
+    }
+
+    /// <summary>Converts synchronously, then asynchronously saves an ODT document as PDF.</summary>
+    public static Task<PdfCore.PdfSaveResult> SaveAsPdfAsync(this OdtDocument source, string path, WordOpenDocumentConversionOptions? conversionOptions = null, WordPdf.PdfSaveOptions? pdfOptions = null, CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
+        return source.ToPdfDocumentResult(conversionOptions, pdfOptions).SaveAsync(path, cancellationToken);
+    }
+
+    /// <summary>Converts synchronously, then asynchronously writes an ODT document as PDF.</summary>
+    public static Task<PdfCore.PdfSaveResult> SaveAsPdfAsync(this OdtDocument source, Stream stream, WordOpenDocumentConversionOptions? conversionOptions = null, WordPdf.PdfSaveOptions? pdfOptions = null, CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
+        return source.ToPdfDocumentResult(conversionOptions, pdfOptions).SaveAsync(stream, cancellationToken);
+    }
+
+    /// <summary>Attempts to asynchronously save an ODT document as PDF and returns structured failure evidence.</summary>
+    public static async Task<PdfCore.PdfSaveResult> TrySaveAsPdfAsync(this OdtDocument source, string path, WordOpenDocumentConversionOptions? conversionOptions = null, WordPdf.PdfSaveOptions? pdfOptions = null, CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
+        try { return await source.ToPdfDocumentResult(conversionOptions, pdfOptions).TrySaveAsync(path, cancellationToken).ConfigureAwait(false); }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
+        catch (Exception ex) { return PdfCore.PdfSaveResult.FromFailure(path, ex); }
+    }
+
+    /// <summary>Attempts to asynchronously write an ODT document as PDF and returns structured failure evidence.</summary>
+    public static async Task<PdfCore.PdfSaveResult> TrySaveAsPdfAsync(this OdtDocument source, Stream stream, WordOpenDocumentConversionOptions? conversionOptions = null, WordPdf.PdfSaveOptions? pdfOptions = null, CancellationToken cancellationToken = default) {
+        cancellationToken.ThrowIfCancellationRequested();
+        try { return await source.ToPdfDocumentResult(conversionOptions, pdfOptions).TrySaveAsync(stream, cancellationToken).ConfigureAwait(false); }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
+        catch (Exception ex) { return PdfCore.PdfSaveResult.FromFailure(outputPath: null, ex); }
+    }
+}

--- a/OfficeIMO.OpenDocument.Pdf/OfficeIMO.OpenDocument.Pdf.csproj
+++ b/OfficeIMO.OpenDocument.Pdf/OfficeIMO.OpenDocument.Pdf.csproj
@@ -1,0 +1,47 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>Direct loss-aware OpenDocument text, spreadsheet, and presentation to PDF adapters.</Description>
+    <PackageId>OfficeIMO.OpenDocument.Pdf</PackageId>
+    <AssemblyName>OfficeIMO.OpenDocument.Pdf</AssemblyName>
+    <AssemblyTitle>OfficeIMO.OpenDocument.Pdf</AssemblyTitle>
+    <VersionPrefix>3.0.0</VersionPrefix>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <Company>Evotec</Company>
+    <Authors>Przemyslaw Klys</Authors>
+    <PackageTags>odf;odt;ods;odp;pdf;conversion;officeimo</PackageTags>
+    <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/EvotecIT/OfficeIMO</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageIcon>OfficeIMO.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>Latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\Assets\OfficeIMO.png"><Pack>True</Pack><PackagePath>\</PackagePath></None>
+    <None Include="README.md"><Pack>True</Pack><PackagePath>README.md</PackagePath></None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OfficeIMO.OpenDocument\OfficeIMO.OpenDocument.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Word.OpenDocument\OfficeIMO.Word.OpenDocument.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Word.Pdf\OfficeIMO.Word.Pdf.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Excel.OpenDocument\OfficeIMO.Excel.OpenDocument.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Excel.Pdf\OfficeIMO.Excel.Pdf.csproj" />
+    <ProjectReference Include="..\OfficeIMO.PowerPoint.OpenDocument\OfficeIMO.PowerPoint.OpenDocument.csproj" />
+    <ProjectReference Include="..\OfficeIMO.PowerPoint.Pdf\OfficeIMO.PowerPoint.Pdf.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.IO" />
+    <Using Include="System.Threading" />
+    <Using Include="System.Threading.Tasks" />
+  </ItemGroup>
+</Project>

--- a/OfficeIMO.OpenDocument.Pdf/README.md
+++ b/OfficeIMO.OpenDocument.Pdf/README.md
@@ -1,0 +1,19 @@
+# OfficeIMO.OpenDocument.Pdf
+
+`OfficeIMO.OpenDocument.Pdf` provides direct, loss-aware PDF conversion for OpenDocument text documents, spreadsheets, and presentations.
+
+The adapter does not introduce another renderer. It projects each OpenDocument model through its existing Office semantic adapter and then through the corresponding first-party PDF engine. The returned `PdfDocumentConversionResult` combines diagnostics from both stages, so callers can inspect approximations or omissions before saving.
+
+```csharp
+using OfficeIMO.OpenDocument;
+using OfficeIMO.OpenDocument.Pdf;
+using OfficeIMO.Pdf;
+
+OdtDocument document = OdtDocument.Load("proposal.odt");
+PdfDocumentConversionResult result = document.ToPdfDocumentResult();
+
+result.Report.RequireNoLoss();
+result.Save("proposal.pdf");
+```
+
+The same façade is available on `OdsDocument` and `OdpPresentation`, including byte-array, path, stream, and asynchronous save entry points.

--- a/OfficeIMO.Pdf.Tests/Pdf/Markdown.SaveAsPdf.Visuals.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/Markdown.SaveAsPdf.Visuals.cs
@@ -214,7 +214,7 @@ public class MarkdownSaveAsPdfVisualTests {
     }
 
     [Fact]
-    public void ToPdfDocument_MarkdownImageOnlyParagraph_WarnsAndFallsBackWhenBytesAreUnsupportedByPdfRenderer() {
+    public void ToPdfDocument_MarkdownGifImage_NormalizesThroughSharedRasterEngine() {
         const string imageUrl = "https://example.test/badge.gif";
         MarkdownDoc document = MarkdownDoc
             .Create()
@@ -227,8 +227,9 @@ public class MarkdownSaveAsPdfVisualTests {
         byte[] bytes = result.ToBytes();
         string text = PdfCore.PdfReadDocument.Open(bytes).ExtractText();
 
-        Assert.Contains(result.Warnings, warning => warning.Code == "UnsupportedImage" && warning.Source == imageUrl);
-        Assert.Contains("[Image unavailable: Remote badge]", text, StringComparison.Ordinal);
+        Assert.DoesNotContain(result.Warnings, warning => warning.Code == "UnsupportedImage" && warning.Source == imageUrl);
+        Assert.Contains(PdfCore.PdfImageExtractor.ExtractImages(bytes), image => image.IsImageFile && image.MimeType == "image/png");
+        Assert.DoesNotContain("[Image unavailable: Remote badge]", text, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfConversionScenarioManifestTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfConversionScenarioManifestTests.cs
@@ -2063,6 +2063,7 @@ public sealed class PdfConversionScenarioManifestTests {
     }
 
     private static void AssertCompositionRoutes(JsonElement compositionRoutes) {
+        string repositoryRoot = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(GetManifestPath())!, ".."));
         JsonElement[] routes = compositionRoutes.EnumerateArray().ToArray();
         Assert.NotEmpty(routes);
 
@@ -2085,8 +2086,22 @@ public sealed class PdfConversionScenarioManifestTests {
             Assert.False(string.IsNullOrWhiteSpace(RequireString(route, "diagnosticContract")));
             string status = RequireString(route, "status");
             Assert.True(
-                status == "manual-loss-aware-composition" || status == "not-yet-direct",
+                status == "direct-loss-aware-adapter" || status == "manual-loss-aware-composition" || status == "not-yet-direct",
                 "Unknown composition-route status: " + status);
+
+            if (status == "direct-loss-aware-adapter") {
+                string projectPath = RequireString(route, "implementationProject");
+                Assert.True(
+                    File.Exists(Path.Combine(repositoryRoot, projectPath.Replace('/', Path.DirectorySeparatorChar))),
+                    "Direct route implementation project does not exist: " + projectPath);
+
+                string evidenceReference = RequireString(route, "evidenceTest");
+                string[] evidenceParts = evidenceReference.Split(new[] { '#' }, 2);
+                Assert.Equal(2, evidenceParts.Length);
+                string evidencePath = Path.Combine(repositoryRoot, evidenceParts[0].Replace('/', Path.DirectorySeparatorChar));
+                Assert.True(File.Exists(evidencePath), "Direct route evidence test does not exist: " + evidenceParts[0]);
+                Assert.Contains(evidenceParts[1], File.ReadAllText(evidencePath), StringComparison.Ordinal);
+            }
         }
     }
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentImageValidationTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentImageValidationTests.cs
@@ -2,7 +2,11 @@ using System;
 using System.IO;
 using System.Linq;
 using OfficeIMO.Drawing;
+using OfficeIMO.Excel;
+using OfficeIMO.Excel.Pdf;
 using OfficeIMO.Pdf;
+using OfficeIMO.Word;
+using OfficeIMO.Word.Pdf;
 using PdfPigDocument = UglyToad.PdfPig.PdfDocument;
 using Xunit;
 
@@ -422,15 +426,29 @@ public class PdfDocumentImageValidationTests {
             new ImageBlock(new byte[] { 1 }, 24, 24, PdfAlign.Left, imageInfo, fit: (OfficeImageFit)42));
     }
 
-    [Fact]
-    public void Image_WithRecognizedUnsupportedFormat_ThrowsNotSupportedException() {
-        var doc = PdfDocument.Create();
+    [Theory]
+    [MemberData(nameof(NormalizedRasterPayloads))]
+    public void Image_WithDrawingSupportedRaster_NormalizesAndEmbeds(
+        byte[] source,
+        OfficeImageFormat sourceFormat) {
+        Assert.True(PdfDocument.TryPrepareImageBytes(
+            source,
+            out byte[] prepared,
+            out OfficeImageInfo? imageInfo,
+            out bool wasTranscoded,
+            out string? unsupportedReason), unsupportedReason);
+        Assert.True(wasTranscoded);
+        Assert.NotNull(imageInfo);
+        Assert.Equal(OfficeImageFormat.Png, imageInfo!.Format);
+        Assert.Equal(sourceFormat, OfficeImageReader.Identify(source).Format);
+        Assert.True(OfficeImageReader.TryIdentify(prepared, null, out OfficeImageInfo preparedInfo));
+        Assert.Equal(OfficeImageFormat.Png, preparedInfo.Format);
 
-        var exception = Assert.Throws<NotSupportedException>(() => doc.Image(CreateMinimalGif(), 24, 24));
+        byte[] pdf = PdfDocument.Create()
+            .Image(source, 24, 24)
+            .ToBytes();
 
-        Assert.Contains("JPEG and grayscale/grayscale-alpha/indexed-color/RGB/RGBA PNG", exception.Message, StringComparison.Ordinal);
-        Assert.Contains("Adam7-interlaced PNGs", exception.Message, StringComparison.Ordinal);
-        Assert.Contains(nameof(OfficeImageFormat.Gif), exception.Message, StringComparison.Ordinal);
+        Assert.Single(PdfImageExtractor.ExtractImages(pdf));
     }
 
     [Fact]
@@ -499,18 +517,74 @@ public class PdfDocumentImageValidationTests {
     }
 
     [Fact]
-    public void RowColumnImage_WithRecognizedUnsupportedFormat_ThrowsNotSupportedException() {
+    public void RowColumnImage_WithDrawingSupportedRaster_NormalizesAndEmbeds() {
         var doc = PdfDocument.Create();
 
-        var exception = Assert.Throws<NotSupportedException>(() =>
-            doc.Compose(compose =>
-                compose.Page(page =>
-                    page.Content(content =>
-                        content.Row(row =>
-                            row.Column(100, column =>
-                                column.Image(CreateMinimalGif(), 24, 24)))))));
+        doc.Compose(compose =>
+            compose.Page(page =>
+                page.Content(content =>
+                    content.Row(row =>
+                        row.Column(100, column =>
+                            column.Image(CreateMinimalGif(), 24, 24))))));
 
-        Assert.Contains(nameof(OfficeImageFormat.Gif), exception.Message, StringComparison.Ordinal);
+        Assert.Single(PdfImageExtractor.ExtractImages(doc.ToBytes()));
+    }
+
+    [Fact]
+    public void WordPdfAdapterUsesCanonicalRasterPreparation() {
+        using WordDocument document = WordDocument.Create();
+        using var image = new MemoryStream(CreateMinimalGif());
+        document.AddParagraph().AddImage(image, "pixel.gif", 24, 24);
+
+        byte[] pdf = document.ToPdf();
+
+        PdfExtractedImage embedded = Assert.Single(PdfImageExtractor.ExtractImages(pdf));
+        Assert.Equal("image/png", embedded.MimeType);
+    }
+
+    [Fact]
+    public void ExcelPdfAdapterUsesCanonicalRasterPreparation() {
+        using ExcelDocument workbook = ExcelDocument.Create();
+        ExcelSheet sheet = workbook.AddWorksheet("Raster");
+        sheet.AddImage(1, 1, CreateMinimalGif(), "image/gif", 24, 24);
+
+        byte[] pdf = workbook.ToPdf();
+
+        PdfExtractedImage embedded = Assert.Single(PdfImageExtractor.ExtractImages(pdf));
+        Assert.Equal("image/png", embedded.MimeType);
+    }
+
+    [Fact]
+    public void Image_WithUnrecognizedPayload_ReportsTheSharedContract() {
+        var exception = Assert.Throws<NotSupportedException>(() =>
+            PdfDocument.Create().Image(new byte[] { 1, 2, 3, 4 }, 24, 24));
+
+        Assert.Contains("raster formats decoded by OfficeIMO.Drawing", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("not recognized", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RasterNormalizationPreservesPhysicalResolution() {
+        var image = new OfficeRasterImage(2, 1, OfficeColor.Red);
+        byte[] tiff = OfficeRasterImageEncoder.Encode(
+            image,
+            OfficeImageExportFormat.Tiff,
+            new OfficeRasterEncodingOptions { DpiX = 144, DpiY = 120 });
+
+        Assert.True(PdfDocument.TryPrepareImageBytes(
+            tiff,
+            out byte[] prepared,
+            out OfficeImageInfo? info,
+            out bool wasTranscoded,
+            out string? unsupportedReason), unsupportedReason);
+
+        Assert.True(wasTranscoded);
+        Assert.NotNull(info);
+        Assert.InRange(info!.DpiX, 143.98D, 144.02D);
+        Assert.InRange(info.DpiY, 119.98D, 120.02D);
+        OfficeImageInfo preparedInfo = OfficeImageReader.Identify(prepared);
+        Assert.Equal(info.DpiX, preparedInfo.DpiX);
+        Assert.Equal(info.DpiY, preparedInfo.DpiY);
     }
 
     [Fact]
@@ -1210,6 +1284,52 @@ public class PdfDocumentImageValidationTests {
 
     private static byte[] CreateMinimalGif() =>
         Convert.FromBase64String("R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==");
+
+    public static System.Collections.Generic.IEnumerable<object[]> NormalizedRasterPayloads() {
+        var image = new OfficeRasterImage(2, 1, OfficeColor.Transparent);
+        image.SetPixel(0, 0, OfficeColor.Red);
+        image.SetPixel(1, 0, OfficeColor.Blue);
+        yield return new object[] { CreateMinimalGif(), OfficeImageFormat.Gif };
+        yield return new object[] { CreateMinimalBmp(), OfficeImageFormat.Bmp };
+        yield return new object[] {
+            OfficeRasterImageEncoder.Encode(image, OfficeImageExportFormat.Tiff),
+            OfficeImageFormat.Tiff
+        };
+        yield return new object[] {
+            OfficeRasterImageEncoder.Encode(image, OfficeImageExportFormat.Webp),
+            OfficeImageFormat.Webp
+        };
+    }
+
+    private static byte[] CreateMinimalBmp() {
+        byte[] bytes = new byte[58];
+        bytes[0] = (byte)'B';
+        bytes[1] = (byte)'M';
+        WriteInt32LittleEndian(bytes, 2, bytes.Length);
+        WriteInt32LittleEndian(bytes, 10, 54);
+        WriteInt32LittleEndian(bytes, 14, 40);
+        WriteInt32LittleEndian(bytes, 18, 1);
+        WriteInt32LittleEndian(bytes, 22, 1);
+        WriteUInt16LittleEndian(bytes, 26, 1);
+        WriteUInt16LittleEndian(bytes, 28, 24);
+        WriteInt32LittleEndian(bytes, 34, 4);
+        bytes[54] = 0x33;
+        bytes[55] = 0x22;
+        bytes[56] = 0x11;
+        return bytes;
+    }
+
+    private static void WriteInt32LittleEndian(byte[] bytes, int offset, int value) {
+        bytes[offset] = (byte)value;
+        bytes[offset + 1] = (byte)(value >> 8);
+        bytes[offset + 2] = (byte)(value >> 16);
+        bytes[offset + 3] = (byte)(value >> 24);
+    }
+
+    private static void WriteUInt16LittleEndian(byte[] bytes, int offset, int value) {
+        bytes[offset] = (byte)value;
+        bytes[offset + 1] = (byte)(value >> 8);
+    }
 
     private static byte[] CreateMinimalJpeg(int width, int height) {
         return new byte[] {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfFlowGroupTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfFlowGroupTests.cs
@@ -5,6 +5,22 @@ namespace OfficeIMO.Tests.Pdf;
 
 public class PdfFlowGroupTests {
     [Fact]
+    public void TypedComponentReusesCanonicalFlowAndLayoutCapture() {
+        var capture = new PdfLayoutPositionCapture();
+        var component = new SummaryComponent("Reusable component");
+
+        byte[] bytes = CreateShortPageDocument()
+            .Component(component, new PdfFlowOptions { KeepTogether = true }, capture)
+            .Component(component)
+            .ToBytes();
+
+        string text = PdfReadDocument.Open(bytes).ExtractText();
+        Assert.Equal(2, CountOccurrences(text, "Reusable component"));
+        Assert.NotNull(capture.Last);
+        Assert.False(capture.WasSkipped);
+    }
+
+    [Fact]
     public void KeepTogether_MovesMeasuredGroupAndCapturesFinalRegion() {
         var capture = new PdfLayoutPositionCapture();
         byte[] bytes = CreateShortPageDocument()
@@ -97,5 +113,29 @@ public class PdfFlowGroupTests {
             MarginBottom = 20,
             CompressContentStreams = false
         });
+    }
+
+    private static int CountOccurrences(string value, string expected) {
+        int count = 0;
+        int index = 0;
+        while ((index = value.IndexOf(expected, index, System.StringComparison.Ordinal)) >= 0) {
+            count++;
+            index += expected.Length;
+        }
+
+        return count;
+    }
+
+    private sealed class SummaryComponent : IPdfComponent {
+        private readonly string _title;
+
+        internal SummaryComponent(string title) {
+            _title = title;
+        }
+
+        public void Compose(PdfItemCompose content) {
+            content.Paragraph(paragraph => paragraph.Text(_title))
+                .Paragraph(paragraph => paragraph.Text("The same engine owns component layout."));
+        }
     }
 }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfImageExportContractTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfImageExportContractTests.cs
@@ -1,6 +1,8 @@
 using OfficeIMO.Drawing;
 using OfficeIMO.Pdf;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace OfficeIMO.Tests.Pdf;
@@ -108,6 +110,40 @@ public sealed class PdfImageExportContractTests {
         Assert.Equal(OfficeImageExportFormat.Svg, result.Format);
         Assert.Equal(result.Width, OfficeImageReader.Identify(result.Bytes).Width);
         Assert.Equal(result.Height, OfficeImageReader.Identify(result.Bytes).Height);
+    }
+
+    [Fact]
+    public void AuthoredDocumentExportsImagesWithoutAReadFacade() {
+        PdfDocument document = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("Authored page"));
+
+        OfficeImageExportResult direct = Assert.Single(document.ExportImages(OfficeImageExportFormat.Webp));
+        OfficeImageExportResult fluent = Assert.Single(document.ToImages().AsPng().Export());
+
+        Assert.Equal(OfficeImageExportFormat.Webp, direct.Format);
+        Assert.Equal("image/webp", OfficeImageReader.Identify(direct.Bytes).MimeType);
+        Assert.Equal(OfficeImageExportFormat.Png, fluent.Format);
+        Assert.Equal("image/png", OfficeImageReader.Identify(fluent.Bytes).MimeType);
+    }
+
+    [Fact]
+    public async Task AuthoredDocumentExportDefersSnapshotAndHonorsPreCanceledToken() {
+        bool materialized = false;
+        PdfDocument document = PdfDocument.Create()
+            .Deferred(_ => {
+                materialized = true;
+                return item => item.Paragraph(paragraph => paragraph.Text("Deferred page"));
+            });
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        PdfDocumentImageExportBuilder builder = document.ToImages();
+
+        Assert.False(materialized);
+        Assert.ThrowsAny<OperationCanceledException>(() =>
+            document.ExportImages(OfficeImageExportFormat.Png, cancellationToken: cancellation.Token));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => builder.ExportAsync(cancellation.Token));
+        Assert.False(materialized);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf/Compose/IPdfComponent.cs
+++ b/OfficeIMO.Pdf/Compose/IPdfComponent.cs
@@ -1,0 +1,10 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>
+/// Reusable typed PDF content that composes through the canonical <see cref="PdfItemCompose"/> surface.
+/// Components own structure and data binding while the document engine continues to own layout and rendering.
+/// </summary>
+public interface IPdfComponent {
+    /// <summary>Composes this component into the supplied document content.</summary>
+    void Compose(PdfItemCompose content);
+}

--- a/OfficeIMO.Pdf/Compose/PdfElementCompose.cs
+++ b/OfficeIMO.Pdf/Compose/PdfElementCompose.cs
@@ -135,7 +135,7 @@ public class PdfElementCompose {
     public PdfElementCompose Polygon(System.Collections.Generic.IEnumerable<OfficePoint> points, PdfColor? strokeColor = null, double strokeWidth = 1, PdfColor? fillColor = null, PdfAlign? align = null, double? spacingBefore = null, double? spacingAfter = null, OfficeStrokeDashStyle strokeDashStyle = OfficeStrokeDashStyle.Solid, OfficeStrokeLineCap? strokeLineCap = null, OfficeStrokeLineJoin? strokeLineJoin = null, PdfDrawingStyle? style = null, string? linkUri = null, string? linkContents = null) { _doc.Polygon(points, strokeColor, strokeWidth, fillColor, align, spacingBefore, spacingAfter, strokeDashStyle, strokeLineCap, strokeLineJoin, style, linkUri, linkContents); return this; }
     /// <summary>Adds a freeform path vector shape.</summary>
     public PdfElementCompose Path(System.Collections.Generic.IEnumerable<OfficePathCommand> commands, PdfColor? strokeColor = null, double strokeWidth = 1, PdfColor? fillColor = null, PdfAlign? align = null, double? spacingBefore = null, double? spacingAfter = null, OfficeStrokeDashStyle strokeDashStyle = OfficeStrokeDashStyle.Solid, OfficeStrokeLineCap? strokeLineCap = null, OfficeStrokeLineJoin? strokeLineJoin = null, PdfDrawingStyle? style = null, string? linkUri = null, string? linkContents = null) { _doc.Path(commands, strokeColor, strokeWidth, fillColor, align, spacingBefore, spacingAfter, strokeDashStyle, strokeLineCap, strokeLineJoin, style, linkUri, linkContents); return this; }
-    /// <summary>Adds an image from supported image bytes at the current nested element flow position. JPEG and simple PNG images, including Adam7 interlace, indexed-color palettes, and alpha soft masks, are currently supported.</summary>
+    /// <summary>Adds a raster image supported by OfficeIMO.Drawing at the current nested element flow position.</summary>
     /// <param name="jpegBytes">Supported image bytes.</param>
     /// <param name="width">Target width in points.</param>
     /// <param name="height">Target height in points.</param>
@@ -154,7 +154,7 @@ public class PdfElementCompose {
     public PdfElementCompose Image(byte[] jpegBytes, double width, double height, string? alternativeText) =>
         Image(jpegBytes, width, height, align: null, clipPath: null, fit: null, spacingBefore: null, spacingAfter: null, style: null, linkUri: null, linkContents: null, alternativeText: alternativeText);
 
-    /// <summary>Adds an image from supported image bytes. JPEG and simple PNG images, including Adam7 interlace, indexed-color palettes, and alpha soft masks, are currently supported.</summary>
+    /// <summary>Adds a raster image supported by OfficeIMO.Drawing.</summary>
     /// <param name="jpegBytes">Supported image bytes.</param>
     /// <param name="width">Target width in points.</param>
     /// <param name="height">Target height in points.</param>

--- a/OfficeIMO.Pdf/Compose/PdfItemCompose.cs
+++ b/OfficeIMO.Pdf/Compose/PdfItemCompose.cs
@@ -6,6 +6,8 @@ namespace OfficeIMO.Pdf;
 public class PdfItemCompose {
     private readonly PdfDocument _doc;
     internal PdfItemCompose(PdfDocument doc) { _doc = doc; }
+    /// <summary>Adds a reusable typed component through the canonical flow engine.</summary>
+    public PdfItemCompose Component(IPdfComponent component, PdfFlowOptions? options = null, PdfLayoutPositionCapture? capture = null) { _doc.Component(component, options, capture); return this; }
     /// <summary>Adds a nested flow group with optional constraints and position capture.</summary>
     public PdfItemCompose Flow(System.Action<PdfItemCompose> build, PdfFlowOptions? options = null, PdfLayoutPositionCapture? capture = null) { _doc.Flow(build, options, capture); return this; }
     /// <summary>Adds replayable content materialized from the live page context during layout.</summary>
@@ -124,7 +126,7 @@ public class PdfItemCompose {
     /// <param name="align">Panel text alignment.</param>
     /// <param name="defaultColor">Optional default text color.</param>
     public PdfItemCompose Panel(System.Action<PdfItemCompose> build, PanelStyle? style = null, PdfAlign align = PdfAlign.Left, PdfColor? defaultColor = null) { _doc.Panel(build, style, align, defaultColor); return this; }
-    /// <summary>Adds an image from supported image bytes. JPEG and simple PNG images, including Adam7 interlace, indexed-color palettes, and alpha soft masks, are currently supported.</summary>
+    /// <summary>Adds a raster image supported by OfficeIMO.Drawing.</summary>
     /// <param name="jpegBytes">Supported image bytes.</param>
     /// <param name="width">Target width in points.</param>
     /// <param name="height">Target height in points.</param>
@@ -143,7 +145,7 @@ public class PdfItemCompose {
     public PdfItemCompose Image(byte[] jpegBytes, double width, double height, string? alternativeText) =>
         Image(jpegBytes, width, height, align: null, clipPath: null, fit: null, spacingBefore: null, spacingAfter: null, style: null, linkUri: null, linkContents: null, alternativeText: alternativeText);
 
-    /// <summary>Adds an image from supported image bytes. JPEG and simple PNG images, including Adam7 interlace, indexed-color palettes, and alpha soft masks, are currently supported.</summary>
+    /// <summary>Adds a raster image supported by OfficeIMO.Drawing.</summary>
     /// <param name="jpegBytes">Supported image bytes.</param>
     /// <param name="width">Target width in points.</param>
     /// <param name="height">Target height in points.</param>

--- a/OfficeIMO.Pdf/Compose/PdfRowColumnCompose.cs
+++ b/OfficeIMO.Pdf/Compose/PdfRowColumnCompose.cs
@@ -214,7 +214,7 @@ public class PdfRowColumnCompose {
         _col.AddBlock(PdfDocument.CreateShapeBlock(shape, align, spacingBefore, spacingAfter, style, linkUri, linkContents));
         return this;
     }
-    /// <summary>Adds a supported image in the column. JPEG and simple PNG images, including Adam7 interlace, indexed-color palettes, and alpha soft masks, are currently supported.</summary>
+    /// <summary>Adds a raster image supported by OfficeIMO.Drawing in the column.</summary>
     public PdfRowColumnCompose Image(byte[] jpegBytes, double width, double height, PdfAlign? align = null, OfficeClipPath? clipPath = null, OfficeImageFit? fit = null, double? spacingBefore = null, double? spacingAfter = null, PdfImageStyle? style = null, string? linkUri = null, string? linkContents = null) =>
         Image(jpegBytes, width, height, align, clipPath, fit, spacingBefore, spacingAfter, style, linkUri, linkContents, alternativeText: null);
 
@@ -222,7 +222,7 @@ public class PdfRowColumnCompose {
     public PdfRowColumnCompose Image(byte[] jpegBytes, double width, double height, string? alternativeText) =>
         Image(jpegBytes, width, height, align: null, clipPath: null, fit: null, spacingBefore: null, spacingAfter: null, style: null, linkUri: null, linkContents: null, alternativeText: alternativeText);
 
-    /// <summary>Adds a supported image in the column. JPEG and simple PNG images, including Adam7 interlace, indexed-color palettes, and alpha soft masks, are currently supported.</summary>
+    /// <summary>Adds a raster image supported by OfficeIMO.Drawing in the column.</summary>
     public PdfRowColumnCompose Image(byte[] jpegBytes, double width, double height, PdfAlign? align, OfficeClipPath? clipPath, OfficeImageFit? fit, double? spacingBefore, double? spacingAfter, PdfImageStyle? style, string? linkUri, string? linkContents, string? alternativeText) {
         Guard.NotNullOrEmpty(jpegBytes, nameof(jpegBytes));
         Guard.Positive(width, nameof(width));
@@ -233,12 +233,12 @@ public class PdfRowColumnCompose {
             PdfDocument.ValidateImageStyleForBox(imageStyle, width, height, nameof(clipPath));
         }
 
-        var imageInfo = PdfDocument.ValidateImageBytes(jpegBytes);
+        PdfDocument.PreparedImage prepared = PdfDocument.PrepareImageBytes(jpegBytes);
         if (imageStyle != null) {
-            PdfDocument.ValidateImageFitDimensions(imageInfo, imageStyle.Fit, nameof(fit));
+            PdfDocument.ValidateImageFitDimensions(prepared.Info, imageStyle.Fit, nameof(fit));
         }
 
-        _col.AddBlock(new ImageBlock(jpegBytes, width, height, imageInfo, imageStyle, linkUri, linkContents));
+        _col.AddBlock(new ImageBlock(prepared.Data, width, height, prepared.Info, imageStyle, linkUri, linkContents, useDataSnapshot: true));
         return this;
     }
 }

--- a/OfficeIMO.Pdf/Core/PdfDocument.Blocks.FlowGroups.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocument.Blocks.FlowGroups.cs
@@ -1,6 +1,17 @@
 namespace OfficeIMO.Pdf;
 
 public sealed partial class PdfDocument {
+    /// <summary>
+    /// Adds a reusable typed component through the canonical flow engine, with optional layout constraints and position capture.
+    /// </summary>
+    public PdfDocument Component(
+        IPdfComponent component,
+        PdfFlowOptions? options = null,
+        PdfLayoutPositionCapture? capture = null) {
+        Guard.NotNull(component, nameof(component));
+        return Flow(component.Compose, options, capture);
+    }
+
     /// <summary>Adds a nested flow group with optional constraints and position capture.</summary>
     public PdfDocument Flow(
         Action<PdfItemCompose> compose,

--- a/OfficeIMO.Pdf/Core/PdfDocument.Blocks.ImageValidation.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocument.Blocks.ImageValidation.cs
@@ -4,16 +4,49 @@ namespace OfficeIMO.Pdf;
 
 public sealed partial class PdfDocument {
     private const string SupportedImageMessage =
-        "PdfDocument.Image currently supports JPEG and grayscale/grayscale-alpha/indexed-color/RGB/RGBA PNG image bytes only, including Adam7-interlaced PNGs and supported 16-bit grayscale/grayscale-alpha/RGB/RGBA PNG payloads.";
+        "PdfDocument.Image accepts JPEG and the raster formats decoded by OfficeIMO.Drawing. JPEG and writer-safe PNG payloads are embedded directly; other supported raster payloads are normalized to PNG once before PDF serialization.";
+
+    internal readonly struct PreparedImage {
+        internal PreparedImage(byte[] data, OfficeImageInfo info, OfficeImageFormat sourceFormat, bool wasTranscoded) {
+            Data = data;
+            Info = info;
+            SourceFormat = sourceFormat;
+            WasTranscoded = wasTranscoded;
+        }
+
+        internal byte[] Data { get; }
+        internal OfficeImageInfo Info { get; }
+        internal OfficeImageFormat SourceFormat { get; }
+        internal bool WasTranscoded { get; }
+    }
 
     /// <summary>
     /// Checks whether image bytes can be embedded by the first-party PDF writer.
     /// </summary>
     public static bool TryValidateImageBytes(byte[] data, out OfficeImageInfo? imageInfo, out string? unsupportedReason) {
+        bool prepared = TryPrepareImageBytes(data, out _, out imageInfo, out _, out unsupportedReason);
+        return prepared;
+    }
+
+    /// <summary>
+    /// Prepares source image bytes for first-party PDF embedding. Writer-safe JPEG and PNG data is retained;
+    /// other raster formats supported by <see cref="OfficeRasterImageDecoder"/> are normalized to PNG.
+    /// </summary>
+    public static bool TryPrepareImageBytes(
+        byte[] data,
+        out byte[] preparedBytes,
+        out OfficeImageInfo? imageInfo,
+        out bool wasTranscoded,
+        out string? unsupportedReason) {
+        preparedBytes = System.Array.Empty<byte>();
         imageInfo = null;
+        wasTranscoded = false;
         unsupportedReason = null;
         try {
-            imageInfo = ValidateImageBytes(data);
+            PreparedImage prepared = PrepareImageBytes(data);
+            preparedBytes = (byte[])prepared.Data.Clone();
+            imageInfo = prepared.Info;
+            wasTranscoded = prepared.WasTranscoded;
             return true;
         } catch (NotSupportedException ex) {
             unsupportedReason = ex.Message;
@@ -24,56 +57,67 @@ public sealed partial class PdfDocument {
         }
     }
 
-    internal static OfficeImageInfo ValidateImageBytes(byte[] data) {
-        if (OfficeImageReader.TryIdentify(data, null, out var info)) {
-            if (info.Format == OfficeImageFormat.Jpeg) {
-                return info;
+    internal static OfficeImageInfo ValidateImageBytes(byte[] data) => PrepareImageBytes(data).Info;
+
+    internal static PreparedImage PrepareImageBytes(byte[] data) {
+        Guard.NotNullOrEmpty(data, nameof(data));
+        if (!OfficeImageReader.TryIdentify(data, null, out OfficeImageInfo sourceInfo)) {
+            // Keep the established pass-through contract for JPEG streams whose dimensions are not
+            // understood by the managed header reader. The PDF writer embeds JPEG data without
+            // decoding it, and layout deliberately falls back to the requested/page box in this case.
+            if (LooksLikeJpeg(data)) {
+                return new PreparedImage(
+                    (byte[])data.Clone(),
+                    new OfficeImageInfo(OfficeImageFormat.Unknown, 0, 0),
+                    OfficeImageFormat.Jpeg,
+                    wasTranscoded: false);
             }
 
-            if (info.Format == OfficeImageFormat.Png) {
-                string? unsupportedReason;
-                if (PdfWriter.TryGetPngImageData(data, out _, out unsupportedReason)) {
-                    return info;
-                }
-
-                throw new NotSupportedException(SupportedImageMessage + " " + unsupportedReason);
-            } else {
-                throw new NotSupportedException(
-                    $"{SupportedImageMessage} Detected {info.Format} ({info.MimeType}).");
-            }
+            throw new NotSupportedException(SupportedImageMessage + " The source image header is not recognized.");
         }
 
-        if (LooksLikePng(data)) {
-            string? unsupportedReason;
-            if (PdfWriter.TryGetPngImageData(data, out var image, out unsupportedReason)) {
-                return new OfficeImageInfo(OfficeImageFormat.Png, image.PixelWidth, image.PixelHeight);
+        if (sourceInfo.Format == OfficeImageFormat.Jpeg) {
+            return new PreparedImage((byte[])data.Clone(), sourceInfo, sourceInfo.Format, wasTranscoded: false);
+        }
+
+        if (sourceInfo.Format == OfficeImageFormat.Png) {
+            if (PdfWriter.TryGetPngImageData(data, out _, out string? sourcePngReason)) {
+                return new PreparedImage((byte[])data.Clone(), sourceInfo, sourceInfo.Format, wasTranscoded: false);
             }
 
-            throw new NotSupportedException(SupportedImageMessage + " " + unsupportedReason);
+            string suffix = string.IsNullOrWhiteSpace(sourcePngReason) ? string.Empty : " " + sourcePngReason;
+            throw new NotSupportedException(SupportedImageMessage + suffix);
         }
 
-        if (!LooksLikeJpeg(data)) {
-            System.Diagnostics.Trace.TraceWarning("PdfDocument.Image: Provided bytes do not appear to be JPEG encoded.");
+        if (!OfficeImagePngConverter.TryConvertToPng(data, out byte[] normalizedPng)) {
+            throw new NotSupportedException(
+                $"{SupportedImageMessage} Detected {sourceInfo.Format} ({sourceInfo.MimeType}), but it could not be normalized.");
         }
 
-        return new OfficeImageInfo(OfficeImageFormat.Unknown, 0, 0);
+        if (!PdfWriter.TryGetPngImageData(normalizedPng, out PdfWriter.PdfImageStream normalizedImage, out string? normalizedReason)) {
+            string suffix = string.IsNullOrWhiteSpace(normalizedReason) ? string.Empty : " " + normalizedReason;
+            throw new NotSupportedException(
+                $"{SupportedImageMessage} Detected {sourceInfo.Format} ({sourceInfo.MimeType}), but it could not be normalized.{suffix}");
+        }
+
+        OfficeImageInfo normalizedInfo = OfficeImageReader.TryIdentify(
+            normalizedPng,
+            null,
+            out OfficeImageInfo identifiedNormalized)
+                ? identifiedNormalized
+                : new OfficeImageInfo(
+                    OfficeImageFormat.Png,
+                    normalizedImage.PixelWidth,
+                    normalizedImage.PixelHeight,
+                    sourceInfo.DpiX,
+                    sourceInfo.DpiY);
+        return new PreparedImage(normalizedPng, normalizedInfo, sourceInfo.Format, wasTranscoded: true);
     }
 
-    private static bool LooksLikePng(byte[] data) =>
-        data.Length >= 8 &&
-        data[0] == 137 &&
-        data[1] == 80 &&
-        data[2] == 78 &&
-        data[3] == 71 &&
-        data[4] == 13 &&
-        data[5] == 10 &&
-        data[6] == 26 &&
-        data[7] == 10;
-
-    private static bool LooksLikeJpeg(byte[] data) {
-        if (data.Length < 4)
-            return false;
-
-        return data[0] == 0xFF && data[1] == 0xD8 && data[data.Length - 2] == 0xFF && data[data.Length - 1] == 0xD9;
-    }
+    private static bool LooksLikeJpeg(byte[] data) =>
+        data.Length >= 4 &&
+        data[0] == 0xFF &&
+        data[1] == 0xD8 &&
+        data[data.Length - 2] == 0xFF &&
+        data[data.Length - 1] == 0xD9;
 }

--- a/OfficeIMO.Pdf/Core/PdfDocument.Blocks.Media.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocument.Blocks.Media.cs
@@ -95,7 +95,7 @@ public sealed partial class PdfDocument {
         return Shape(shape, align, spacingBefore, spacingAfter, style, linkUri, linkContents);
     }
 
-    /// <summary>Adds a supported image at the current flow position. JPEG and simple PNG images, including Adam7 interlace, indexed-color palettes, and alpha soft masks, are currently supported.</summary>
+    /// <summary>Adds a raster image supported by OfficeIMO.Drawing at the current flow position.</summary>
     public PdfDocument Image(byte[] jpegBytes, double width, double height, PdfAlign? align = null, OfficeClipPath? clipPath = null, OfficeImageFit? fit = null, double? spacingBefore = null, double? spacingAfter = null, PdfImageStyle? style = null, string? linkUri = null, string? linkContents = null) =>
         Image(jpegBytes, width, height, align, clipPath, fit, spacingBefore, spacingAfter, style, linkUri, linkContents, alternativeText: null);
 
@@ -103,7 +103,7 @@ public sealed partial class PdfDocument {
     public PdfDocument Image(byte[] jpegBytes, double width, double height, string? alternativeText) =>
         Image(jpegBytes, width, height, align: null, clipPath: null, fit: null, spacingBefore: null, spacingAfter: null, style: null, linkUri: null, linkContents: null, alternativeText: alternativeText);
 
-    /// <summary>Adds a supported image at the current flow position. JPEG and simple PNG images, including Adam7 interlace, indexed-color palettes, and alpha soft masks, are currently supported.</summary>
+    /// <summary>Adds a raster image supported by OfficeIMO.Drawing at the current flow position.</summary>
     public PdfDocument Image(byte[] jpegBytes, double width, double height, PdfAlign? align, OfficeClipPath? clipPath, OfficeImageFit? fit, double? spacingBefore, double? spacingAfter, PdfImageStyle? style, string? linkUri, string? linkContents, string? alternativeText) {
         Guard.NotNullOrEmpty(jpegBytes, nameof(jpegBytes));
         Guard.Positive(width, nameof(width));
@@ -114,12 +114,12 @@ public sealed partial class PdfDocument {
             ValidateImageStyleForBox(imageStyle, width, height, nameof(clipPath));
         }
 
-        var imageInfo = ValidateImageBytes(jpegBytes);
+        PreparedImage prepared = PrepareImageBytes(jpegBytes);
         if (imageStyle != null) {
-            ValidateImageFitDimensions(imageInfo, imageStyle.Fit, nameof(fit));
+            ValidateImageFitDimensions(prepared.Info, imageStyle.Fit, nameof(fit));
         }
 
-        AddBlock(new ImageBlock(jpegBytes, width, height, imageInfo, imageStyle, linkUri, linkContents));
+        AddBlock(new ImageBlock(prepared.Data, width, height, prepared.Info, imageStyle, linkUri, linkContents, useDataSnapshot: true));
         return this;
     }
 

--- a/OfficeIMO.Pdf/Manipulation/PdfStamper.Images.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfStamper.Images.cs
@@ -67,13 +67,13 @@ internal static partial class PdfStamper {
 
         var effectiveOptions = options ?? new PdfImageStampOptions();
         ValidateImageOptions(effectiveOptions);
-        var imageInfo = PdfDocument.ValidateImageBytes(imageBytes);
+        PdfDocument.PreparedImage prepared = PdfDocument.PrepareImageBytes(imageBytes);
 
         if (!PdfWriter.TryBuildImageStream(
-                imageBytes,
-                imageInfo,
-                effectiveOptions.Width ?? Math.Max(1, imageInfo.Width),
-                effectiveOptions.Height ?? Math.Max(1, imageInfo.Height),
+                prepared.Data,
+                prepared.Info,
+                effectiveOptions.Width ?? Math.Max(1, prepared.Info.Width),
+                effectiveOptions.Height ?? Math.Max(1, prepared.Info.Height),
                 out var imageStream,
                 out string? unsupportedReason)) {
             throw new NotSupportedException(unsupportedReason ?? "Image format is not supported.");

--- a/OfficeIMO.Pdf/Model/PdfHeaderFooterImage.cs
+++ b/OfficeIMO.Pdf/Model/PdfHeaderFooterImage.cs
@@ -29,15 +29,15 @@ public sealed class PdfHeaderFooterImage {
             Guard.NotNullOrWhiteSpace(alternativeText, nameof(alternativeText));
         }
 
-        OfficeImageInfo imageInfo = PdfDocument.ValidateImageBytes(data);
-        PdfDocument.ValidateImageFitDimensions(imageInfo, fit, nameof(fit));
+        PdfDocument.PreparedImage prepared = PdfDocument.PrepareImageBytes(data);
+        PdfDocument.ValidateImageFitDimensions(prepared.Info, fit, nameof(fit));
 
-        _data = (byte[])data.Clone();
+        _data = prepared.Data;
         Width = width;
         Height = height;
         Align = align;
         Fit = fit;
-        Info = imageInfo;
+        Info = prepared.Info;
         AlternativeText = alternativeText;
     }
 
@@ -68,5 +68,5 @@ public sealed class PdfHeaderFooterImage {
         Align = Align,
         Fit = Fit,
         AlternativeText = AlternativeText
-    });
+    }, useDataSnapshot: true);
 }

--- a/OfficeIMO.Pdf/Model/PdfImageWatermark.cs
+++ b/OfficeIMO.Pdf/Model/PdfImageWatermark.cs
@@ -13,11 +13,12 @@ public sealed class PdfImageWatermark {
     private double _opacity = 0.16D;
     private double _rotationAngle;
 
-    /// <summary>Creates an image watermark from supported JPEG or PNG bytes.</summary>
+    /// <summary>Creates an image watermark from raster bytes supported by OfficeIMO.Drawing.</summary>
     public PdfImageWatermark(byte[] data, double width, double height) {
         Guard.NotNullOrEmpty(data, nameof(data));
-        _info = PdfDocument.ValidateImageBytes(data);
-        _data = (byte[])data.Clone();
+        PdfDocument.PreparedImage prepared = PdfDocument.PrepareImageBytes(data);
+        _info = prepared.Info;
+        _data = prepared.Data;
         Width = width;
         Height = height;
     }

--- a/OfficeIMO.Pdf/Model/PdfInlineElement.cs
+++ b/OfficeIMO.Pdf/Model/PdfInlineElement.cs
@@ -54,13 +54,13 @@ public sealed class PdfInlineImage : PdfInlineElement {
         OfficeImageFit fit = OfficeImageFit.Contain,
         double baselineOffset = 0D)
         : base(width, height, baselineOffset, alternativeText) {
-        OfficeImageInfo info = PdfDocument.ValidateImageBytes(imageBytes);
+        PdfDocument.PreparedImage prepared = PdfDocument.PrepareImageBytes(imageBytes);
         var style = new PdfImageStyle {
             Fit = fit,
             AlternativeText = alternativeText
         };
-        PdfDocument.ValidateImageFitDimensions(info, fit, nameof(fit));
-        Block = new ImageBlock(imageBytes, width, height, info, style);
+        PdfDocument.ValidateImageFitDimensions(prepared.Info, fit, nameof(fit));
+        Block = new ImageBlock(prepared.Data, width, height, prepared.Info, style, useDataSnapshot: true);
         Fit = fit;
     }
 }

--- a/OfficeIMO.Pdf/Model/PdfPageBackgroundImage.cs
+++ b/OfficeIMO.Pdf/Model/PdfPageBackgroundImage.cs
@@ -11,11 +11,12 @@ public sealed class PdfPageBackgroundImage {
     private double _opacity = 1D;
     private OfficeImageFit _fit = OfficeImageFit.Cover;
 
-    /// <summary>Creates a page background image from supported JPEG or PNG bytes.</summary>
+    /// <summary>Creates a page background image from raster bytes supported by OfficeIMO.Drawing.</summary>
     public PdfPageBackgroundImage(byte[] data) {
         Guard.NotNullOrEmpty(data, nameof(data));
-        _info = PdfDocument.ValidateImageBytes(data);
-        _data = (byte[])data.Clone();
+        PdfDocument.PreparedImage prepared = PdfDocument.PrepareImageBytes(data);
+        _info = prepared.Info;
+        _data = prepared.Data;
     }
 
     /// <summary>How the image is fitted into the page box.</summary>

--- a/OfficeIMO.Pdf/Model/PdfPageCanvas.cs
+++ b/OfficeIMO.Pdf/Model/PdfPageCanvas.cs
@@ -448,8 +448,8 @@ internal sealed class PdfCanvasImageResource {
 
     internal static PdfCanvasImageResource Create(byte[] bytes) {
         Guard.NotNullOrEmpty(bytes, nameof(bytes));
-        byte[] snapshot = (byte[])bytes.Clone();
-        return new PdfCanvasImageResource(snapshot, PdfDocument.ValidateImageBytes(snapshot));
+        PdfDocument.PreparedImage prepared = PdfDocument.PrepareImageBytes(bytes);
+        return new PdfCanvasImageResource(prepared.Data, prepared.Info);
     }
 }
 

--- a/OfficeIMO.Pdf/Model/PdfTableCellImage.cs
+++ b/OfficeIMO.Pdf/Model/PdfTableCellImage.cs
@@ -8,7 +8,7 @@ namespace OfficeIMO.Pdf;
 public sealed class PdfTableCellImage {
     private readonly byte[] _data;
 
-    /// <summary>Creates a supported table-cell image. JPEG and simple PNG images, including Adam7 interlace, indexed-color palettes, and alpha soft masks, are supported.</summary>
+    /// <summary>Creates a table-cell image from raster bytes supported by OfficeIMO.Drawing.</summary>
     public PdfTableCellImage(byte[] data, double width, double height, PdfImageStyle? style = null, string? linkUri = null, string? linkContents = null) {
         Guard.NotNullOrEmpty(data, nameof(data));
         Guard.Positive(width, nameof(width));
@@ -27,15 +27,15 @@ public sealed class PdfTableCellImage {
             PdfDocument.ValidateImageStyleForBox(imageStyle, width, height, nameof(style));
         }
 
-        OfficeImageInfo info = PdfDocument.ValidateImageBytes(data);
+        PdfDocument.PreparedImage prepared = PdfDocument.PrepareImageBytes(data);
         if (imageStyle != null) {
-            PdfDocument.ValidateImageFitDimensions(info, imageStyle.Fit, nameof(style));
+            PdfDocument.ValidateImageFitDimensions(prepared.Info, imageStyle.Fit, nameof(style));
         }
 
-        _data = (byte[])data.Clone();
+        _data = prepared.Data;
         Width = width;
         Height = height;
-        Info = info;
+        Info = prepared.Info;
         Style = imageStyle;
         LinkUri = linkUri;
         LinkContents = linkUri == null ? null : linkContents ?? "Table cell image";
@@ -68,6 +68,6 @@ public sealed class PdfTableCellImage {
         PdfImageStyle style = Style?.Clone() ?? new PdfImageStyle {
             Align = fallbackAlign
         };
-        return new ImageBlock(_data, Width, Height, Info, style, LinkUri, LinkContents);
+        return new ImageBlock(_data, Width, Height, Info, style, LinkUri, LinkContents, useDataSnapshot: true);
     }
 }

--- a/OfficeIMO.Pdf/README.md
+++ b/OfficeIMO.Pdf/README.md
@@ -38,7 +38,7 @@ PdfDocument.Create(new PdfOptions {
 
 ## What it does
 
-- Creates PDFs with page setup, headings, paragraphs, rich text, links, lists, mixed inline images and boxes, dictionary-driven hyphenation, styled multipage containers, balanced block-flow columns, conditional/replayable flow, position capture, sections, generated TOCs, optional-content layers, tables, images, vector drawing, headers, footers, watermarks, metadata, portfolios, and form primitives.
+- Creates PDFs with page setup, headings, paragraphs, rich text, links, lists, reusable typed components, mixed inline images and boxes, dictionary-driven hyphenation, styled multipage containers, balanced block-flow columns, conditional/replayable flow, position capture, sections, generated TOCs, optional-content layers, tables, images, vector drawing, headers, footers, watermarks, metadata, portfolios, and form primitives. Raster inputs accepted by `OfficeIMO.Drawing` normalize once through the shared image owner before PDF embedding.
 - Reads and inspects PDFs through text extraction, logical document objects, page metadata, links, images, attachments, portfolios, outlines, forms, bounded immutable raw-structure views, active-content diagnostics, and security/revision markers.
 - Manipulates existing PDFs with page extraction, split, merge, delete, duplicate, move, rotate, metadata editing, stamps, watermarks, and complete-page overlay/underlay while preserving source PDF header versions on shared rewrite paths.
 - Renders supported embedded TrueType and OpenType/CFF fonts with stable-glyph subsetting. Built-in shaping remains dependency-free, while the shared `OfficeIMO.Drawing.IOfficeTextShapingProvider` contract can supply positioned glyph advances and offsets for scripts that need a host-owned shaping engine.
@@ -49,7 +49,7 @@ PdfDocument.Create(new PdfOptions {
 - Provides reusable conversion proof snapshots for generated PDFs, artifact hashes, required page counts, page sizes, document metadata, outline titles, URI links, form fields, named destinations, page labels, attachments, output intents, optional-content/layer metadata, catalog/viewer metadata, XMP/tagged metadata, text markers, logical readback signals, expected and accepted warning contracts, and post-processing hand-off. Compliance proof records bind external validator name, version, profile, result, warnings, SHA-256, byte length, and validation time to the exact artifact.
 - Provides reusable rewrite-preservation proof for page geometry, metadata, navigation, catalog/viewer/action state, optional content, tagged content, security signatures, document versions, and source-structure markers such as incremental updates, xref streams, and object streams.
 - Provides a reusable rewrite-preservation matrix for classifying named manipulation scenarios as rewrite-safe, preservation-failed, blocked by safety checks, or operation-failed, including optional-content/layer drift, targeted form-fill preservation, form/tagged/active-content/signature blockers, and fluent `PdfDocument` helpers for normal document rewrite operations.
-- Serves as the shared engine for Word, Excel, PowerPoint, Markdown, HTML, RTF, OneNote, AsciiDoc, and LaTeX PDF adapters.
+- Serves as the shared engine for Word, Excel, PowerPoint, OpenDocument, Markdown, HTML, RTF, OneNote, AsciiDoc, and LaTeX PDF adapters.
 
 ## Existing PDF workflows
 
@@ -143,6 +143,13 @@ pdf.ToImages()
     .WithMaximumRasterPixels(20_000_000)
     .AsWebp()
     .Save("page-images");
+
+PdfDocument.Create()
+    .H1("Authored PDF")
+    .Paragraph(paragraph => paragraph.Text("The authored model uses the same page renderer."))
+    .ToImages()
+    .AsPng()
+    .Save("authored-page-images");
 ```
 
 PNG, JPEG, TIFF, SVG, and WebP use the same `OfficeImageExportResult` contract and Drawing-owned encoders. Allocation limits are resolved before a raster buffer is created. Unsupported or simplified PDF operators and resources remain visible as typed image diagnostics.
@@ -564,8 +571,9 @@ PdfHtmlConverterExtensions.SaveAsHtml(
 | [OfficeIMO.OneNote.Pdf](../OfficeIMO.OneNote.Pdf/README.md) | Explicitly projects offline OneNote hierarchy into a semantic PDF document with loss diagnostics. |
 | [OfficeIMO.AsciiDoc.Pdf](../OfficeIMO.AsciiDoc.Pdf/README.md) | Projects native AsciiDoc through the loss-aware Markdown bridge and combines parser, projection, and PDF diagnostics. |
 | [OfficeIMO.Latex.Pdf](../OfficeIMO.Latex.Pdf/README.md) | Projects the bounded LaTeX profile through the loss-aware Markdown bridge without executing TeX. |
+| [OfficeIMO.OpenDocument.Pdf](../OfficeIMO.OpenDocument.Pdf/README.md) | Provides direct ODT, ODS, and ODP façades while retaining both OpenDocument projection and PDF conversion diagnostics. |
 
-The canonical catalog records OpenDocument as manual loss-aware composition and formats that are intentionally not advertised as direct conversion yet: email, EPUB, and Visio. See [`Docs/pdf-conversion-scenarios.json`](../Docs/pdf-conversion-scenarios.json).
+The generated [PDF conversion support matrix](../Docs/officeimo.pdf-conversion-support-matrix.md) records direct, composed, and planned routes from the canonical [`Docs/pdf-conversion-scenarios.json`](../Docs/pdf-conversion-scenarios.json) manifest. Email, EPUB, and Visio are intentionally not advertised as direct conversion yet.
 
 ## Boundaries
 

--- a/OfficeIMO.Pdf/Rendering/PdfImageExportBuilder.cs
+++ b/OfficeIMO.Pdf/Rendering/PdfImageExportBuilder.cs
@@ -29,52 +29,66 @@ public sealed class PdfDocumentImageExportBuilder : OfficeImageExportBatchBuilde
         PdfImageExportOptions? options = null,
         IReadOnlyList<OfficeImageExportDiagnostic>? initialDiagnostics = null)
         : this(
-            document,
+            PdfImageExportDocumentSource.FromLoaded(document),
             options?.Clone() ?? new PdfImageExportOptions(),
-            CreateSelectionState(document),
+            new PageSelectionState(),
+            initialDiagnostics) {
+    }
+
+    internal PdfDocumentImageExportBuilder(
+        PdfDocument document,
+        PdfImageExportOptions? options = null,
+        IReadOnlyList<OfficeImageExportDiagnostic>? initialDiagnostics = null)
+        : this(
+            PdfImageExportDocumentSource.FromDeferred(() => document.GetReadSnapshot().Document),
+            options?.Clone() ?? new PdfImageExportOptions(),
+            new PageSelectionState(),
+            initialDiagnostics) {
+    }
+
+    internal PdfDocumentImageExportBuilder(
+        PdfDocumentConversionResult conversion,
+        PdfImageExportOptions? options = null,
+        IReadOnlyList<OfficeImageExportDiagnostic>? initialDiagnostics = null)
+        : this(
+            PdfImageExportDocumentSource.FromDeferred(() => PdfReadDocument.Open(conversion.ToBytes())),
+            options?.Clone() ?? new PdfImageExportOptions(),
+            new PageSelectionState(),
             initialDiagnostics) {
     }
 
     private PdfDocumentImageExportBuilder(
-        PdfReadDocument document,
+        PdfImageExportDocumentSource source,
         PdfImageExportOptions options,
         PageSelectionState selection,
         IReadOnlyList<OfficeImageExportDiagnostic>? initialDiagnostics)
         : base(
             options,
-            (format, effective) => PdfImageExportEngine.Export(
-                document,
-                format,
-                effective,
-                selection.Selection,
-                initialDiagnostics),
-            (format, effective, consumer, cancellationToken) => PdfImageExportEngine.ExportEach(
-                document,
-                format,
-                effective,
-                selection.Selection,
-                consumer,
-                initialDiagnostics,
-                cancellationToken)) {
+            (format, effective) => Export(source, selection, format, effective, initialDiagnostics),
+            (format, effective, consumer, cancellationToken) =>
+                ExportEach(source, selection, format, effective, consumer, initialDiagnostics, cancellationToken)) {
         _selection = selection;
     }
 
     /// <summary>Selects caller-ordered one-based PDF pages.</summary>
     public PdfDocumentImageExportBuilder Pages(PdfPageSelection selection) {
         _selection.Selection = selection ?? throw new ArgumentNullException(nameof(selection));
+        _selection.Selector = null;
         return this;
     }
 
     /// <summary>Selects document-relative pages such as <c>1-3,last</c>.</summary>
     public PdfDocumentImageExportBuilder Pages(string selector) {
         if (string.IsNullOrWhiteSpace(selector)) throw new ArgumentException("A page selector is required.", nameof(selector));
-        _selection.Selection = PdfPageSelector.Parse(selector).ResolveSelection(_selection.PageCount);
+        _selection.Selector = PdfPageSelector.Parse(selector);
+        _selection.Selection = null;
         return this;
     }
 
     /// <summary>Exports all document pages in source order.</summary>
     public PdfDocumentImageExportBuilder AllPages() {
         _selection.Selection = null;
+        _selection.Selector = null;
         return this;
     }
 
@@ -94,17 +108,102 @@ public sealed class PdfDocumentImageExportBuilder : OfficeImageExportBatchBuilde
 
     private sealed class PageSelectionState {
         internal PdfPageSelection? Selection { get; set; }
-        internal int PageCount { get; set; }
+        internal PdfPageSelector? Selector { get; set; }
+
+        internal PdfPageSelection? Resolve(PdfReadDocument document) =>
+            Selector?.ResolveSelection(document.Pages.Count) ?? Selection;
     }
 
-    private static PageSelectionState CreateSelectionState(PdfReadDocument document) {
-        Guard.NotNull(document, nameof(document));
-        return new PageSelectionState { PageCount = document.Pages.Count };
+    private static IReadOnlyList<OfficeImageExportResult> Export(
+        PdfImageExportDocumentSource source,
+        PageSelectionState selection,
+        OfficeImageExportFormat format,
+        PdfImageExportOptions options,
+        IReadOnlyList<OfficeImageExportDiagnostic>? initialDiagnostics) {
+        PdfReadDocument document = source.Get(CancellationToken.None);
+        return PdfImageExportEngine.Export(
+            document,
+            format,
+            options,
+            selection.Resolve(document),
+            initialDiagnostics);
+    }
+
+    private static void ExportEach(
+        PdfImageExportDocumentSource source,
+        PageSelectionState selection,
+        OfficeImageExportFormat format,
+        PdfImageExportOptions options,
+        OfficeImageExportConsumer consumer,
+        IReadOnlyList<OfficeImageExportDiagnostic>? initialDiagnostics,
+        CancellationToken cancellationToken) {
+        PdfReadDocument document = source.Get(cancellationToken);
+        PdfImageExportEngine.ExportEach(
+            document,
+            format,
+            options,
+            selection.Resolve(document),
+            consumer,
+            initialDiagnostics,
+            cancellationToken);
+    }
+
+    private sealed class PdfImageExportDocumentSource {
+        private readonly Func<PdfReadDocument>? _factory;
+        private readonly object _sync = new();
+        private PdfReadDocument? _document;
+
+        private PdfImageExportDocumentSource(PdfReadDocument document) {
+            _document = document;
+        }
+
+        private PdfImageExportDocumentSource(Func<PdfReadDocument> factory) {
+            _factory = factory;
+        }
+
+        internal static PdfImageExportDocumentSource FromLoaded(PdfReadDocument document) {
+            Guard.NotNull(document, nameof(document));
+            return new PdfImageExportDocumentSource(document);
+        }
+
+        internal static PdfImageExportDocumentSource FromDeferred(Func<PdfReadDocument> factory) {
+            Guard.NotNull(factory, nameof(factory));
+            return new PdfImageExportDocumentSource(factory);
+        }
+
+        internal PdfReadDocument Get(CancellationToken cancellationToken) {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (_document != null) return _document;
+
+            lock (_sync) {
+                cancellationToken.ThrowIfCancellationRequested();
+                return _document ??= _factory!();
+            }
+        }
     }
 }
 
 /// <summary>Canonical PDF page image-export entry points.</summary>
 public static class PdfImageExportExtensions {
+    /// <summary>Exports pages from an authored or opened PDF document using the shared five-format result contract.</summary>
+    public static IReadOnlyList<OfficeImageExportResult> ExportImages(
+        this PdfDocument document,
+        OfficeImageExportFormat format,
+        PdfImageExportOptions? options = null,
+        PdfPageSelection? selection = null,
+        CancellationToken cancellationToken = default) {
+        Guard.NotNull(document, nameof(document));
+        cancellationToken.ThrowIfCancellationRequested();
+        var snapshot = document.GetReadSnapshot();
+        return PdfImageExportEngine.Export(
+            snapshot.Document,
+            format,
+            options?.Clone() ?? new PdfImageExportOptions(),
+            selection,
+            initialDiagnostics: null,
+            cancellationToken);
+    }
+
     /// <summary>Exports one loaded PDF page using the shared five-format result contract.</summary>
     public static OfficeImageExportResult ExportImage(
         this PdfReadPage page,
@@ -138,6 +237,7 @@ public static class PdfImageExportExtensions {
         PdfPageSelection? selection = null,
         CancellationToken cancellationToken = default) {
         Guard.NotNull(conversion, nameof(conversion));
+        cancellationToken.ThrowIfCancellationRequested();
         return PdfImageExportEngine.Export(
             PdfReadDocument.Open(conversion.ToBytes()),
             format,
@@ -164,6 +264,20 @@ public static class PdfImageExportExtensions {
         CreateDocumentBuilder(document, options ?? throw new ArgumentNullException(nameof(options)));
 
     /// <summary>
+    /// Starts fluent image export for all pages in an authored or opened PDF document.
+    /// The read snapshot is captured on first export so a pre-canceled operation does not materialize the document.
+    /// </summary>
+    public static PdfDocumentImageExportBuilder ToImages(this PdfDocument document) =>
+        CreateDocumentBuilder(document, options: null);
+
+    /// <summary>
+    /// Starts fluent image export for an authored or opened PDF document using a cloned options snapshot.
+    /// The read snapshot is captured on first export.
+    /// </summary>
+    public static PdfDocumentImageExportBuilder ToImages(this PdfDocument document, PdfImageExportOptions options) =>
+        CreateDocumentBuilder(document, options ?? throw new ArgumentNullException(nameof(options)));
+
+    /// <summary>
     /// Starts fluent paged-image export from a source-to-PDF conversion and carries its diagnostics into every page result.
     /// </summary>
     public static PdfDocumentImageExportBuilder ToImages(this PdfDocumentConversionResult conversion) =>
@@ -183,11 +297,18 @@ public static class PdfImageExportExtensions {
     }
 
     private static PdfDocumentImageExportBuilder CreateDocumentBuilder(
+        PdfDocument document,
+        PdfImageExportOptions? options) {
+        Guard.NotNull(document, nameof(document));
+        return new PdfDocumentImageExportBuilder(document, options);
+    }
+
+    private static PdfDocumentImageExportBuilder CreateDocumentBuilder(
         PdfDocumentConversionResult conversion,
         PdfImageExportOptions? options) {
         Guard.NotNull(conversion, nameof(conversion));
         return new PdfDocumentImageExportBuilder(
-            PdfReadDocument.Open(conversion.ToBytes()),
+            conversion,
             options,
             PdfImageExportEngine.MapConversionDiagnostics(conversion));
     }

--- a/OfficeIMO.Rtf.Pdf/RtfPdfConverter.TablesAndImages.cs
+++ b/OfficeIMO.Rtf.Pdf/RtfPdfConverter.TablesAndImages.cs
@@ -171,9 +171,13 @@ internal static partial class RtfPdfConverter {
         if (options.ImageConverter != null) {
             byte[]? converted = options.ImageConverter(image);
             string? reason = null;
-            if (converted != null && OfficeImagePdfCompatibility.TryValidate(converted, out _, out reason)) {
-                imageBytes = converted;
-                ReportImageSubstitution(options, source, image.Format, "PNG/JPEG", "The RTF image was converted by the configured image converter.");
+            if (converted != null && PdfCore.PdfDocument.TryPrepareImageBytes(
+                    converted,
+                    out imageBytes,
+                    out _,
+                    out _,
+                    out reason)) {
+                ReportImageSubstitution(options, source, image.Format, "PDF raster", "The RTF image was converted by the configured image converter and prepared through OfficeIMO.Drawing.");
                 return true;
             }
 
@@ -181,7 +185,7 @@ internal static partial class RtfPdfConverter {
                 options,
                 "ImageConversionFailed",
                 source,
-                reason ?? "The configured image converter did not return PNG or JPEG bytes.",
+                reason ?? "The configured image converter did not return a raster payload supported by OfficeIMO.Drawing.",
                 new Dictionary<string, string> {
                     ["Format"] = image.Format.ToString()
                 });

--- a/OfficeIMO.Rtf.Pdf/RtfPdfSaveOptions.cs
+++ b/OfficeIMO.Rtf.Pdf/RtfPdfSaveOptions.cs
@@ -30,7 +30,7 @@ public sealed class RtfPdfSaveOptions {
 
     /// <summary>
     /// Optional converter for image formats that the managed drawing layer cannot rasterize, such as WMF and EMF.
-    /// The callback must return structurally valid PNG or JPEG bytes, or null when it cannot convert the image.
+    /// The callback must return a raster payload supported by the shared Drawing-to-PDF pipeline, or null when it cannot convert the image.
     /// </summary>
     public Func<RtfImage, byte[]?>? ImageConverter { get; set; }
 

--- a/OfficeIMO.Rtf.Tests/Rtf/RtfPdfConverterTests.cs
+++ b/OfficeIMO.Rtf.Tests/Rtf/RtfPdfConverterTests.cs
@@ -261,6 +261,24 @@ public class RtfPdfConverterTests {
     }
 
     [Fact]
+    public void RtfDocument_ToPdfDocument_Normalizes_Configured_Gif_Through_Shared_Drawing() {
+        RtfDocument document = RtfDocument.Create();
+        document.AddImage(RtfImageFormat.Emf, new byte[] { 1, 2, 3 });
+        var options = new RtfPdfSaveOptions {
+            ImageConverter = _ => Convert.FromBase64String("R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==")
+        };
+
+        PdfCore.PdfDocumentConversionResult result = document.ToPdfDocumentResult(options);
+        byte[] pdf = result.ToBytes();
+
+        Assert.NotEmpty(pdf);
+        Assert.Contains(result.Warnings, warning =>
+            warning.Code == "ImageConverted" &&
+            warning.Details["TargetFormat"] == "PDF raster");
+        Assert.DoesNotContain(result.Warnings, warning => warning.Code == "ImageConversionFailed");
+    }
+
+    [Fact]
     public void RtfDocument_ToPdfDocument_Renders_Tables() {
         RtfDocument document = RtfDocument.Create();
         RtfTable table = document.AddTable(2, 2);

--- a/OfficeIMO.Shared.Tests/ReleasePackagingGuardrails.cs
+++ b/OfficeIMO.Shared.Tests/ReleasePackagingGuardrails.cs
@@ -37,15 +37,15 @@ public sealed class ReleasePackagingGuardrails {
                 File.Exists(Path.Combine(repositoryRoot, match.Groups["path"].Value)),
                 "README project link is missing: " + match.Value));
         Assert.Equal(24, CountProjectHeadings(readme, "Native formats and shared foundations"));
-        Assert.Equal(26, CountProjectHeadings(readme, "Conversion and cloud bridges"));
+        Assert.Equal(27, CountProjectHeadings(readme, "Conversion and cloud bridges"));
         Assert.Equal(28, CountProjectHeadings(readme, "Unified Reader family"));
         Assert.Equal(11, CountProjectHeadings(readme, "Markdown rendering and OfficeIMO Markup"));
-        Assert.Equal(89, projectHeadings.Count);
+        Assert.Equal(90, projectHeadings.Count);
 
         Assert.Contains($"| Coordinated `3.0.x` release packages | {releasePackageCount} |", readme, StringComparison.Ordinal);
         Assert.Contains($"| Documented package, tool, and example projects below | {projectHeadings.Count} |", readme, StringComparison.Ordinal);
         Assert.Contains("| Native format, foundation, and shared-service packages | 24 |", readme, StringComparison.Ordinal);
-        Assert.Contains("| Conversion and cloud bridge packages | 26 |", readme, StringComparison.Ordinal);
+        Assert.Contains("| Conversion and cloud bridge packages | 27 |", readme, StringComparison.Ordinal);
         Assert.Contains("| Unified Reader packages and tool | 28 |", readme, StringComparison.Ordinal);
         Assert.Contains("| Markdown renderer and OfficeIMO Markup surfaces | 11 |", readme, StringComparison.Ordinal);
         Assert.Contains("NuGet publication is a separate release step.", readme, StringComparison.Ordinal);

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.CoverPages.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.CoverPages.cs
@@ -198,7 +198,7 @@ namespace OfficeIMO.Word.Pdf {
                 !IsNativeVmlBoxVisibleOnPage(box, pageWidth, pageHeight) ||
                 !TryGetNativeVmlImageBytes(document, element, imageData, out byte[]? imageBytes) ||
                 imageBytes == null ||
-                !IsNativePdfSupportedImageBytes(imageBytes, out _)) {
+                !TryPrepareNativePdfImageBytes(imageBytes, out byte[] preparedBytes, out _)) {
                 return false;
             }
 
@@ -212,7 +212,7 @@ namespace OfficeIMO.Word.Pdf {
             }
 
             RenderNativeVmlVisible(canvas, box, pageWidth, pageHeight, target => target.Image(
-                imageBytes,
+                preparedBytes,
                 box.X,
                 box.Y,
                 box.Width,

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.FootnotesImages.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.FootnotesImages.cs
@@ -220,13 +220,13 @@ namespace OfficeIMO.Word.Pdf {
                 return;
             }
 
-            if (!IsNativePdfSupportedImageBytes(bytes, out string? unsupportedReason)) {
+            if (!TryPrepareNativePdfImageBytes(bytes, out byte[] preparedBytes, out string? unsupportedReason)) {
                 if (options != null) {
                     AddNativeExportWarning(
                         options,
                         "NativeBodyImageUnsupported",
                         source,
-                        "Word image was not exported because the first-party PDF image writer supports JPEG and simple PNG images only. " + unsupportedReason);
+                        "Word image was not exported because the shared PDF raster pipeline could not prepare it. " + unsupportedReason);
                 }
 
                 return;
@@ -234,7 +234,7 @@ namespace OfficeIMO.Word.Pdf {
 
             double width = image.Width.HasValue ? image.Width.Value * 72D / 96D : 144D;
             double height = image.Height.HasValue ? image.Height.Value * 72D / 96D : 144D;
-            pdf.Image(bytes, width, height, align);
+            pdf.Image(preparedBytes, width, height, align);
         }
 
         private static bool TryGetNativeBodyImageBytes(WordImage image, PdfSaveOptions? options, string source, out byte[] bytes) {
@@ -255,25 +255,16 @@ namespace OfficeIMO.Word.Pdf {
             }
         }
 
-        private static bool IsNativePdfSupportedImageBytes(byte[] bytes, out string? unsupportedReason) {
-            unsupportedReason = null;
-            if (!OfficeImageReader.TryIdentify(bytes, null, out OfficeImageInfo info)) {
-                unsupportedReason = "The image format could not be identified.";
-                return false;
-            }
-
-            if (info.Format == OfficeImageFormat.Jpeg) {
-                return true;
-            }
-
-            if (info.Format == OfficeImageFormat.Png &&
-                PdfCore.PdfDocument.TryValidateImageBytes(bytes, out _, out unsupportedReason)) {
-                return true;
-            }
-
-            unsupportedReason ??= "Detected " + info.Format + " (" + info.MimeType + ").";
-            return false;
-        }
+        private static bool TryPrepareNativePdfImageBytes(
+            byte[] bytes,
+            out byte[] preparedBytes,
+            out string? unsupportedReason) =>
+            PdfCore.PdfDocument.TryPrepareImageBytes(
+                bytes,
+                out preparedBytes,
+                out _,
+                out _,
+                out unsupportedReason);
 
     }
 }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.HeaderFooter.Content.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.HeaderFooter.Content.cs
@@ -576,13 +576,13 @@ namespace OfficeIMO.Word.Pdf {
 
         private static void AddNativeHeaderFooterImage(List<NativeHeaderFooterImage> images, WordImage image, PdfCore.PdfAlign align, PdfSaveOptions? options, string source) {
             byte[] bytes = ImageEmbedder.GetImageBytes(image);
-            if (!IsNativePdfSupportedImageBytes(bytes, out string? unsupportedReason)) {
+            if (!TryPrepareNativePdfImageBytes(bytes, out byte[] preparedBytes, out string? unsupportedReason)) {
                 if (options != null) {
                     AddNativeExportWarning(
                         options,
                         "NativeHeaderFooterImageUnsupported",
                         source,
-                        "Word header/footer image was not exported because the first-party PDF image writer supports JPEG and simple PNG images only. " + unsupportedReason);
+                        "Word header/footer image was not exported because the shared PDF raster pipeline could not prepare it. " + unsupportedReason);
                 }
 
                 return;
@@ -590,7 +590,7 @@ namespace OfficeIMO.Word.Pdf {
 
             double width = image.Width.HasValue ? image.Width.Value * 72D / 96D : 144D;
             double height = image.Height.HasValue ? image.Height.Value * 72D / 96D : 144D;
-            images.Add(new NativeHeaderFooterImage(bytes, width, height, align));
+            images.Add(new NativeHeaderFooterImage(preparedBytes, width, height, align));
         }
 
         private static void AddNativeHeaderFooterTableShapes(List<NativeHeaderFooterShape> shapes, WordTable table) {

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Rendering.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.Rendering.cs
@@ -436,13 +436,13 @@ namespace OfficeIMO.Word.Pdf {
 
         private static void AddNativeTableCellImage(List<PdfCore.PdfTableCellImage> images, WordImage image) {
             byte[] bytes = ImageEmbedder.GetImageBytes(image);
-            if (!IsNativePdfSupportedImageBytes(bytes, out _)) {
+            if (!TryPrepareNativePdfImageBytes(bytes, out byte[] preparedBytes, out _)) {
                 return;
             }
 
             double width = image.Width.HasValue ? image.Width.Value * 72D / 96D : 144D;
             double height = image.Height.HasValue ? image.Height.Value * 72D / 96D : 144D;
-            images.Add(new PdfCore.PdfTableCellImage(bytes, width, height, CreateNativeImageStyle()));
+            images.Add(new PdfCore.PdfTableCellImage(preparedBytes, width, height, CreateNativeImageStyle()));
         }
 
         private static void AddNativeParagraphContent(

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.StructuredBlocks.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.StructuredBlocks.cs
@@ -377,13 +377,13 @@ namespace OfficeIMO.Word.Pdf {
                 return null;
             }
 
-            if (!IsNativePdfSupportedImageBytes(bytes, out unsupportedReason)) {
+            if (!TryPrepareNativePdfImageBytes(bytes, out byte[] preparedBytes, out unsupportedReason)) {
                 if (options != null) {
                     AddNativeExportWarning(
                         options,
                         "NativeWatermarkImageUnsupported",
                         source,
-                        "Word image watermark was not exported because the first-party PDF image writer supports JPEG and simple PNG images only. " + unsupportedReason);
+                        "Word image watermark was not exported because the shared PDF raster pipeline could not prepare it. " + unsupportedReason);
                 }
 
                 return null;
@@ -391,7 +391,7 @@ namespace OfficeIMO.Word.Pdf {
 
             double width = watermark.Width is > 0D ? watermark.Width.Value : 144D;
             double height = watermark.Height is > 0D ? watermark.Height.Value : 144D;
-            var pdfWatermark = new PdfCore.PdfImageWatermark(bytes, width, height);
+            var pdfWatermark = new PdfCore.PdfImageWatermark(preparedBytes, width, height);
             if (watermark.Rotation.HasValue) {
                 pdfWatermark.RotationAngle = watermark.Rotation.Value;
             }

--- a/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.HeaderFooterContent.cs
+++ b/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.HeaderFooterContent.cs
@@ -122,9 +122,9 @@ public partial class Word {
     }
 
     [Fact]
-    public void SaveAsPdf_OfficeIMOEngine_Skips_Unsupported_HeaderFooter_Images() {
-        string docPath = Path.Combine(_directoryWithFiles, "PdfNativeUnsupportedHeaderImage.docx");
-        string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeUnsupportedHeaderImage.pdf");
+    public void SaveAsPdf_OfficeIMOEngine_Normalizes_Gif_HeaderFooter_Images() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfNativeGifHeaderImage.docx");
+        string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeGifHeaderImage.pdf");
         string imagePath = Path.Combine(_directoryWithImages, "EvotecLogo.png");
         var options = new PdfSaveOptions {
             IncludePageNumbers = false
@@ -133,7 +133,7 @@ public partial class Word {
         using (WordDocument document = WordDocument.Create(docPath)) {
             document.AddHeadersAndFooters();
             RequireSectionHeader(document, 0, HeaderFooterValues.Default).AddParagraph().AddImage(imagePath, 32, 32);
-            document.AddParagraph("Native unsupported header image body");
+            document.AddParagraph("Native GIF header image body");
             document.Save();
         }
 
@@ -142,13 +142,12 @@ public partial class Word {
         using (WordDocument document = WordDocument.Load(docPath)) {
             PdfCore.PdfDocumentConversionResult result = document.ToPdfDocumentResult(options);
             result.Save(pdfPath);
-            Assert.Contains(result.Warnings, warning =>
-                warning.Code == "NativeHeaderFooterImageUnsupported" &&
-                warning.Source == "default header image");
+            Assert.DoesNotContain(result.Warnings, warning => warning.Code == "NativeHeaderFooterImageUnsupported");
         }
         Assert.True(File.Exists(pdfPath));
         using PdfPigDocument pdf = PdfPigDocument.Open(pdfPath);
-        Assert.Contains("Native unsupported header image body", pdf.GetPage(1).Text);
+        Assert.Contains("Native GIF header image body", pdf.GetPage(1).Text);
+        Assert.NotEmpty(PdfCore.PdfDocument.Open(pdfPath).Read.ImagePlacements());
     }
 
     [Fact]

--- a/OfficeIMO.sln
+++ b/OfficeIMO.sln
@@ -364,6 +364,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Security", "Offic
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Security.Tests", "OfficeIMO.Security.Tests\OfficeIMO.Security.Tests.csproj", "{C39332DB-E102-4263-983F-FA0702A71AB0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.OpenDocument.Pdf", "OfficeIMO.OpenDocument.Pdf\OfficeIMO.OpenDocument.Pdf.csproj", "{7D51C2EE-0FA6-4DC7-9E63-BC98BFAAA5CF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1862,6 +1864,18 @@ Global
 		{C39332DB-E102-4263-983F-FA0702A71AB0}.Release|x64.Build.0 = Release|Any CPU
 		{C39332DB-E102-4263-983F-FA0702A71AB0}.Release|x86.ActiveCfg = Release|Any CPU
 		{C39332DB-E102-4263-983F-FA0702A71AB0}.Release|x86.Build.0 = Release|Any CPU
+		{7D51C2EE-0FA6-4DC7-9E63-BC98BFAAA5CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7D51C2EE-0FA6-4DC7-9E63-BC98BFAAA5CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7D51C2EE-0FA6-4DC7-9E63-BC98BFAAA5CF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7D51C2EE-0FA6-4DC7-9E63-BC98BFAAA5CF}.Debug|x64.Build.0 = Debug|Any CPU
+		{7D51C2EE-0FA6-4DC7-9E63-BC98BFAAA5CF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7D51C2EE-0FA6-4DC7-9E63-BC98BFAAA5CF}.Debug|x86.Build.0 = Debug|Any CPU
+		{7D51C2EE-0FA6-4DC7-9E63-BC98BFAAA5CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7D51C2EE-0FA6-4DC7-9E63-BC98BFAAA5CF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7D51C2EE-0FA6-4DC7-9E63-BC98BFAAA5CF}.Release|x64.ActiveCfg = Release|Any CPU
+		{7D51C2EE-0FA6-4DC7-9E63-BC98BFAAA5CF}.Release|x64.Build.0 = Release|Any CPU
+		{7D51C2EE-0FA6-4DC7-9E63-BC98BFAAA5CF}.Release|x86.ActiveCfg = Release|Any CPU
+		{7D51C2EE-0FA6-4DC7-9E63-BC98BFAAA5CF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ OfficeIMO keeps document engines first-party and optional integrations isolated.
 
 | Surface | Current repository coverage |
 | --- | ---: |
-| Coordinated `3.0.x` release packages | 81 |
-| Documented package, tool, and example projects below | 89 |
+| Coordinated `3.0.x` release packages | 82 |
+| Documented package, tool, and example projects below | 90 |
 | Native format, foundation, and shared-service packages | 24 |
-| Conversion and cloud bridge packages | 26 |
+| Conversion and cloud bridge packages | 27 |
 | Unified Reader packages and tool | 28 |
 | Markdown renderer and OfficeIMO Markup surfaces | 11 |
 | Runnable example projects | 1 |
@@ -479,6 +479,14 @@ _Dependency footprint:_ only OfficeIMO PowerPoint, PDF, and Drawing packages.
 - [x] Feature reports for advanced geometry, charts, SmartArt, media, animations, masters, and unsupported transitions
 
 _Dependency footprint:_ only OfficeIMO PowerPoint and OpenDocument packages.
+
+#### [OfficeIMO.OpenDocument.Pdf](OfficeIMO.OpenDocument.Pdf/README.md)
+
+- [x] Direct ODT, ODS, and ODP to PDF workflows with path, stream, synchronous, asynchronous, and result-bearing APIs
+- [x] One thin façade over the existing OpenDocument-to-Office adapters and canonical Word, Excel, and PowerPoint PDF engines
+- [x] Combined feature-mapping and PDF conversion diagnostics so approximated, skipped, and unsupported content remains visible
+
+_Dependency footprint:_ only first-party OfficeIMO OpenDocument, Office, and PDF adapter packages; no second document or PDF rendering engine.
 
 #### [OfficeIMO.Markdown.Html](OfficeIMO.Markdown.Html/README.md)
 
@@ -1131,6 +1139,7 @@ Most shipping libraries target `netstandard2.0`, `net8.0`, and `net10.0`. Many a
 - [2.0 breaking API migration](Docs/officeimo.breaking-api-migration.md)
 - [Image export capability matrix](Docs/officeimo.image-export-capability-matrix.md)
 - [PDF current state](Docs/officeimo.pdf.current-state.md)
+- [PDF conversion support matrix](Docs/officeimo.pdf-conversion-support-matrix.md)
 - [Word/HTML support matrix](Docs/officeimo.word-html-support-matrix.md)
 - [RTF support matrix](Docs/officeimo.rtf-support-matrix.md)
 - [Email support matrix](Docs/officeimo.email-support-matrix.md)


### PR DESCRIPTION
## Summary

- route PDF image placement through one shared raster preparation path so authored/stamped PDFs and Word, Excel, Markdown, and RTF adapters consistently accept JPEG, PNG, GIF, BMP, TIFF, and supported WebP payloads without duplicate normalization
- add lazy, cancellation-safe five-format image export directly from authored PDF documents and a typed component contract that reuses the existing flow/layout engine
- add a direct loss-aware OpenDocument-to-PDF package for text, spreadsheet, and presentation documents, preserving source-projection and PDF-stage diagnostics
- generate a public conversion support matrix from the scenario manifest, require implementation/test evidence for direct routes, and document current fidelity plus the remaining engine work in easiest-to-most-complex order
- harden the shared atomic image-export commit path against transient Windows sharing violations so create-unique saves remain deterministic under concurrent writers

## Validation

- `dotnet build OfficeIMO.sln -c Release --no-restore` — 0 warnings, 0 errors
- PDF tests — 3,068 passed on .NET 8 and 3,068 on .NET 10
- Drawing tests — 916 passed on .NET 8 and 916 on .NET 10
- concurrent image-export contracts — 25 repeated passes on .NET 8 and .NET 10; .NET Framework 4.7.2 compile passed with 0 warnings and 0 errors
- RTF tests — 696 passed on .NET 8 and 696 on .NET 10
- OpenDocument converter tests — 45 passed on .NET 8 and 45 on .NET 10
- release packaging guardrails — 5 passed on each target
- generated support-matrix drift check passed
- `OfficeIMO.OpenDocument.Pdf` packed successfully with .NET Standard 2.0, .NET 8, and .NET 10 assets
- independent read-only review completed, followed by one targeted confirmation of all accepted fixes with no unresolved actionable findings
