### PR TITLE
Update js-yaml to 4.3.0

### DIFF
--- a/OfficeIMO.Markup.VSCode/package-lock.json
+++ b/OfficeIMO.Markup.VSCode/package-lock.json
@@ -3515,9 +3515,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Updates the VS Code extension lockfile so its transitive `js-yaml` dependency resolves to 4.3.0, which contains the fix for GHSA-52cp-r559-cp3m.

The extension builds successfully with the refreshed lockfile.