### PR TITLE
Add authenticated PDF automation and rich headers

### DIFF
--- a/OfficeIMO.Pdf.Tests/Pdf/PdfCanvasStampTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfCanvasStampTests.cs
@@ -136,6 +136,26 @@ public class PdfCanvasStampTests {
     }
 
     [Fact]
+    public void ContentRejectsTaggedStructureThatVisualImportCannotPreserve() {
+        PdfDocument target = PdfDocument.Create().Paragraph(paragraph => paragraph.Text("Existing page"));
+        var taggedOptions = new PdfCanvasStampOptions().UseRenderingOptions(
+            new PdfOptions().SetTaggedStructureMode(PdfTaggedStructureMode.CatalogMarkers));
+
+        NotSupportedException renderingException = Assert.Throws<NotSupportedException>(() =>
+            target.Stamp.Content(canvas => canvas.Text("Tagged text", 10D, 10D, 120D, 30D), taggedOptions));
+        NotSupportedException figureException = Assert.Throws<NotSupportedException>(() =>
+            target.Stamp.Content(canvas => canvas.Figure("Tagged figure", nested =>
+                nested.Text("Figure", 10D, 10D, 120D, 30D))));
+        NotSupportedException structureException = Assert.Throws<NotSupportedException>(() =>
+            target.Stamp.Content(canvas => canvas.Structure(PdfCanvasStructureRole.Paragraph, nested =>
+                nested.Text("Structured paragraph", 10D, 10D, 180D, 30D))));
+
+        Assert.Contains("structure", renderingException.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("structure", figureException.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("structure", structureException.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void OverlayPageReadsEncryptedSourceWithItsOwnPasswordPolicy() {
         byte[] target = PdfDocument.Create().Paragraph(paragraph => paragraph.Text("Target page")).ToBytes();
         byte[] source = CreateRestrictedPdf("source-open", "source-owner", "Encrypted overlay source");

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfCanvasStampTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfCanvasStampTests.cs
@@ -53,6 +53,32 @@ public class PdfCanvasStampTests {
     }
 
     [Fact]
+    public void ContentStampsManyPagesWithPageSpecificCanvasContent() {
+        byte[] target = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("Body one"))
+            .PageBreak()
+            .Paragraph(paragraph => paragraph.Text("Body two"))
+            .PageBreak()
+            .Paragraph(paragraph => paragraph.Text("Body three"))
+            .ToBytes();
+        int callbackCount = 0;
+
+        byte[] stamped = PdfDocument.Open(target).Stamp.Content((canvas, context) => {
+            callbackCount++;
+            canvas.Text("Stamp page " + context.PageNumber, 30D, 30D, 180D, 24D);
+        }).ToBytes();
+
+        PdfReadDocument readback = PdfReadDocument.Open(stamped);
+        Assert.Equal(3, callbackCount);
+        Assert.Equal(3, readback.Pages.Count);
+        for (int pageIndex = 0; pageIndex < readback.Pages.Count; pageIndex++) {
+            string pageText = readback.Pages[pageIndex].ExtractText();
+            Assert.Contains("Body " + new[] { "one", "two", "three" }[pageIndex], pageText, StringComparison.Ordinal);
+            Assert.Contains("Stamp page " + (pageIndex + 1), pageText, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
     public void ContentRejectsInteractiveAnnotationsBecauseItIsVisualOnly() {
         PdfDocument target = PdfDocument.Create().Paragraph(paragraph => paragraph.Text("Existing page"));
 
@@ -61,6 +87,29 @@ public class PdfCanvasStampTests {
                 nested.TextAnnotation("Interactive note", 10D, 10D))));
 
         Assert.Contains("visual content only", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ContentRejectsInteractiveMetadataThatWouldNotSurviveVisualImport() {
+        PdfDocument target = PdfDocument.Create().Paragraph(paragraph => paragraph.Text("Existing page"));
+
+        NotSupportedException linkException = Assert.Throws<NotSupportedException>(() =>
+            target.Stamp.Content(canvas => canvas.Text(
+                new[] { TextRun.Link("Link", "https://example.com") },
+                10D,
+                10D,
+                120D,
+                30D)));
+        NotSupportedException formException = Assert.Throws<NotSupportedException>(() =>
+            target.Stamp.Content(canvas => canvas.Table(
+                new[] { new[] { PdfTableCell.WithFormFields("Field", new[] { PdfTableCellFormField.TextField("Entry") }) } },
+                10D,
+                50D,
+                160D,
+                50D)));
+
+        Assert.Contains("visual content only", linkException.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("visual content only", formException.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfCanvasStampTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfCanvasStampTests.cs
@@ -156,6 +156,30 @@ public class PdfCanvasStampTests {
     }
 
     [Fact]
+    public void ContentIgnoresDocumentChromeFromRenderingOptions() {
+        var renderingOptions = new PdfOptions {
+            ShowHeader = true,
+            HeaderFormat = "Rendering-options header",
+            ShowPageNumbers = true,
+            FooterFormat = "Rendering-options footer",
+            BackgroundColor = PdfColor.FromRgb(240, 240, 240)
+        };
+        var stampOptions = new PdfCanvasStampOptions().UseRenderingOptions(renderingOptions);
+        PdfDocument target = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("Existing body"));
+
+        PdfDocument stamped = target.Stamp.Content(
+            canvas => canvas.Text("Callback content", 36D, 36D, 220D, 30D),
+            stampOptions);
+
+        string text = stamped.Read.Text();
+        Assert.Contains("Existing body", text, StringComparison.Ordinal);
+        Assert.Contains("Callback content", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("Rendering-options header", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("Rendering-options footer", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void OverlayPageReadsEncryptedSourceWithItsOwnPasswordPolicy() {
         byte[] target = PdfDocument.Create().Paragraph(paragraph => paragraph.Text("Target page")).ToBytes();
         byte[] source = CreateRestrictedPdf("source-open", "source-owner", "Encrypted overlay source");

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfCanvasStampTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfCanvasStampTests.cs
@@ -79,6 +79,29 @@ public class PdfCanvasStampTests {
     }
 
     [Fact]
+    public void ContentPreservesRepeatedPageSelectorLayersInOneRewrite() {
+        byte[] target = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("Existing body"))
+            .ToBytes();
+        int callbackCount = 0;
+
+        byte[] stamped = PdfDocument.Open(target).Stamp.Content(
+            (canvas, _) => {
+                callbackCount++;
+                canvas.Text("Layer " + callbackCount, 30D, 30D + (callbackCount * 30D), 140D, 24D);
+            },
+            new PdfCanvasStampOptions {
+                TargetPages = PdfPageSelector.Parse("1,1")
+            }).ToBytes();
+
+        string text = PdfReadDocument.Open(stamped).Pages[0].ExtractText();
+        Assert.Equal(2, callbackCount);
+        Assert.Contains("Existing body", text, StringComparison.Ordinal);
+        Assert.Contains("Layer 1", text, StringComparison.Ordinal);
+        Assert.Contains("Layer 2", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ContentRejectsInteractiveAnnotationsBecauseItIsVisualOnly() {
         PdfDocument target = PdfDocument.Create().Paragraph(paragraph => paragraph.Text("Existing page"));
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfCanvasStampTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfCanvasStampTests.cs
@@ -1,0 +1,93 @@
+using OfficeIMO.Pdf;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf;
+
+public class PdfCanvasStampTests {
+    [Fact]
+    public void ContentStampsGeneralVisualCanvasWithPageContext() {
+        byte[] target = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("Existing page body"))
+            .ToBytes();
+        int callbackCount = 0;
+
+        PdfDocument stamped = PdfDocument.Open(target).Stamp.Content((canvas, context) => {
+            callbackCount++;
+            canvas.Text("Canvas page " + context.PageNumber, 36D, 36D, 220D, 30D, fontSize: 14D)
+                .Table(new[] {
+                    new[] { PdfTableCell.TextCell("Name"), PdfTableCell.TextCell("Value") },
+                    new[] { PdfTableCell.TextCell("Mode"), PdfTableCell.RichTextCell(new[] { TextRun.Bolded("General visual canvas") }) }
+                }, 36D, 90D, Math.Min(420D, context.Width - 72D), 100D)
+                .Image(PdfPngTestImages.CreateRgbPng(20, 80, 180), 36D, 210D, 24D, 24D, alternativeText: "Blue marker");
+        });
+
+        string text = stamped.Read.Text();
+        Assert.Equal(1, callbackCount);
+        Assert.Contains("Existing page body", text, StringComparison.Ordinal);
+        Assert.Contains("Canvas page 1", text, StringComparison.Ordinal);
+        Assert.Contains("General visual canvas", text, StringComparison.Ordinal);
+        Assert.False(PdfInspector.Probe(stamped.ToBytes()).HasEncryption);
+    }
+
+    [Fact]
+    public void ContentSupportsAuthenticatedEncryptedTargetsAndReportsIgnoredRestrictions() {
+        byte[] encrypted = CreateRestrictedPdf("open", "owner", "Encrypted existing body");
+        var options = new PdfReadOptions {
+            Password = "open",
+            PermissionPolicy = PdfPermissionPolicy.IgnoreRestrictions
+        };
+        PdfDocument target = PdfDocument.Open(encrypted, options);
+
+        PdfOperationResult<PdfDocument> result = target.Stamp.TryContent(
+            (canvas, _) => canvas.Text("Authorized canvas stamp", 30D, 30D, 260D, 30D),
+            options: options);
+
+        Assert.True(result.Succeeded, string.Join(Environment.NewLine, result.Diagnostics));
+        PdfMutationPlan plan = Assert.IsType<PdfMutationPlan>(result.MutationPlan);
+        Assert.True(plan.PermissionRestrictionsIgnored);
+        Assert.Contains("Input.PermissionRestrictionsIgnored", plan.Warnings);
+        PdfDocument output = result.RequireValue();
+        Assert.False(PdfInspector.Probe(output.ToBytes()).HasEncryption);
+        Assert.Contains("Encrypted existing body", output.Read.Text(), StringComparison.Ordinal);
+        Assert.Contains("Authorized canvas stamp", output.Read.Text(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ContentRejectsInteractiveAnnotationsBecauseItIsVisualOnly() {
+        PdfDocument target = PdfDocument.Create().Paragraph(paragraph => paragraph.Text("Existing page"));
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(() =>
+            target.Stamp.Content(canvas => canvas.Clip(0D, 0D, 100D, 100D, nested =>
+                nested.TextAnnotation("Interactive note", 10D, 10D))));
+
+        Assert.Contains("visual content only", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void OverlayPageReadsEncryptedSourceWithItsOwnPasswordPolicy() {
+        byte[] target = PdfDocument.Create().Paragraph(paragraph => paragraph.Text("Target page")).ToBytes();
+        byte[] source = CreateRestrictedPdf("source-open", "source-owner", "Encrypted overlay source");
+        var overlayOptions = new PdfPageOverlayOptions {
+            SourceReadOptions = new PdfReadOptions {
+                Password = "source-open",
+                PermissionPolicy = PdfPermissionPolicy.IgnoreRestrictions
+            }
+        };
+
+        PdfDocument stamped = PdfDocument.Open(target).Stamp.OverlayPage(source, overlayOptions);
+
+        Assert.Contains("Target", stamped.Read.Text(), StringComparison.Ordinal);
+        Assert.Contains("Encrypted", stamped.Read.Text(), StringComparison.Ordinal);
+        Assert.Contains("overlay source", stamped.Read.Text(), StringComparison.Ordinal);
+    }
+
+    private static byte[] CreateRestrictedPdf(string userPassword, string ownerPassword, string text) {
+        var encryption = new PdfStandardEncryptionOptions(userPassword) {
+            OwnerPassword = ownerPassword,
+            AllowedPermissions = PdfStandardPermissions.None
+        };
+        return PdfDocument.Create(new PdfOptions().SetEncryption(encryption))
+            .Paragraph(paragraph => paragraph.Text(text))
+            .ToBytes();
+    }
+}

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfCanvasStampTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfCanvasStampTests.cs
@@ -153,6 +153,38 @@ public class PdfCanvasStampTests {
         Assert.Contains("overlay source", stamped.Read.Text(), StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void ContentCarriesRegisteredNamedFontsThroughRenderingOptions() {
+        string? fontPath = PdfComplianceTestFonts.FindLocalTrueTypeFont();
+        if (fontPath == null) {
+            return;
+        }
+
+        const string familyName = "Canvas Stamp Family";
+        var renderingOptions = new PdfOptions()
+            .RegisterNamedFontFamily(new PdfEmbeddedFontFamily(familyName, File.ReadAllBytes(fontPath)));
+        var stampOptions = new PdfCanvasStampOptions()
+            .UseRenderingOptions(renderingOptions);
+        byte[] target = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("Existing body"))
+            .ToBytes();
+
+        PdfDocument stamped = PdfDocument.Open(target).Stamp.Content(
+            canvas => canvas.Text(
+                new[] { TextRun.Normal("Named font stamp", fontFamily: familyName) },
+                36D,
+                36D,
+                220D,
+                30D),
+            stampOptions);
+
+        using var pdf = UglyToad.PdfPig.PdfDocument.Open(new MemoryStream(stamped.ToBytes()));
+        Assert.Contains(
+            pdf.GetPage(1).Letters,
+            letter => letter.Value == "N" &&
+                      letter.FontName.Contains("CanvasStampFamily", StringComparison.OrdinalIgnoreCase));
+    }
+
     private static byte[] CreateRestrictedPdf(string userPassword, string ownerPassword, string text) {
         var encryption = new PdfStandardEncryptionOptions(userPassword) {
             OwnerPassword = ownerPassword,

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfComposePageHeaderFooterRichTextTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfComposePageHeaderFooterRichTextTests.cs
@@ -109,6 +109,25 @@ namespace OfficeIMO.Tests.Pdf {
         }
 
         [Fact]
+        public void HeaderFooterRichText_ResetsBaselineShiftAcrossLines() {
+            byte[] bytes = PdfDocument.Create()
+                .Header(header => header.Text(text => text
+                    .Text("NormalOne\nNormalTwo")
+                    .Run(TextRun.Superscript("Raised\n"))
+                    .Text("NormalThree")))
+                .Paragraph(paragraph => paragraph.Text("Body"))
+                .ToBytes();
+
+            using var pdf = PdfPigDocument.Open(new MemoryStream(bytes));
+            var letters = pdf.GetPage(1).Letters;
+            double firstBaseline = letters.First(letter => letter.Value == "N").StartBaseLine.Y;
+            double secondBaseline = letters.Where(letter => letter.Value == "N").Skip(1).First().StartBaseLine.Y;
+            double thirdBaseline = letters.Where(letter => letter.Value == "N").Skip(2).First().StartBaseLine.Y;
+
+            Assert.InRange(Math.Abs((firstBaseline - secondBaseline) - (secondBaseline - thirdBaseline)), 0D, 0.05D);
+        }
+
+        [Fact]
         public void HeaderFooterRichText_RejectsInteractiveAndInlineRuns() {
             var link = TextRun.Link("Link", "https://example.com");
             var inline = TextRun.Inline(new PdfInlineBox(12, 8));

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfComposePageHeaderFooterRichTextTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfComposePageHeaderFooterRichTextTests.cs
@@ -73,6 +73,42 @@ namespace OfficeIMO.Tests.Pdf {
         }
 
         [Fact]
+        public void HeaderFooterRichText_InheritsConfiguredFontFamily() {
+            string? fontPath = PdfComplianceTestFonts.FindLocalTrueTypeFont();
+            if (fontPath == null) {
+                return;
+            }
+
+            const string familyName = "Rich Header Family";
+            var options = new PdfOptions {
+                CompressContentStreams = false
+            }.RegisterNamedFontFamily(new PdfEmbeddedFontFamily(familyName, File.ReadAllBytes(fontPath)));
+
+            byte[] bytes = PdfDocument.Create(options)
+                .Header(header => header
+                    .FontFamily(familyName)
+                    .Text(text => text
+                        .Run(new TextRun("Header "))
+                        .CurrentPage(new TextRun(string.Empty))))
+                .Footer(footer => footer
+                    .FontFamily(familyName)
+                    .Text(text => text
+                        .Run(new TextRun("Footer "))
+                        .TotalPages(new TextRun(string.Empty))))
+                .Paragraph(paragraph => paragraph.Text("Body"))
+                .ToBytes();
+
+            using var pdf = PdfPigDocument.Open(new MemoryStream(bytes));
+            var page = pdf.GetPage(1);
+            foreach (string glyph in new[] { "H", "F", "1" }) {
+                Assert.Contains(
+                    page.Letters,
+                    letter => letter.Value == glyph &&
+                              letter.FontName.Contains("RichHeaderFamily", StringComparison.OrdinalIgnoreCase));
+            }
+        }
+
+        [Fact]
         public void HeaderFooterRichText_RejectsInteractiveAndInlineRuns() {
             var link = TextRun.Link("Link", "https://example.com");
             var inline = TextRun.Inline(new PdfInlineBox(12, 8));

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfComposePageHeaderFooterRichTextTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfComposePageHeaderFooterRichTextTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using OfficeIMO.Pdf;
+using PdfPigDocument = UglyToad.PdfPig.PdfDocument;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf {
+    public partial class PdfComposePageOptionsTests {
+        [Fact]
+        public void HeaderFooterRichText_RendersStylesAndStyledPageTokens() {
+            var options = new PdfOptions {
+                CompressContentStreams = false,
+                HeaderFont = PdfStandardFont.Helvetica,
+                FooterFont = PdfStandardFont.Helvetica
+            };
+            var doc = PdfDocument.Create(options)
+                .Header(header => header.Text(text => text
+                    .Run(TextRun.Bolded("Rich header ", PdfColor.FromRgb(255, 0, 0), fontSize: 14, backgroundColor: PdfColor.FromRgb(255, 255, 0)))
+                    .CurrentPage(TextRun.Italicized(string.Empty, PdfColor.FromRgb(0, 0, 255), fontSize: 11))
+                    .Text("/")
+                    .TotalPages(TextRun.Underlined(string.Empty, PdfColor.FromRgb(0, 128, 0), fontSize: 11))))
+                .Footer(footer => footer.Text(text => text
+                    .Run(TextRun.Strikethrough("Rich footer ", PdfColor.FromRgb(128, 0, 128), fontSize: 9))
+                    .CurrentPage(TextRun.Superscript(string.Empty, fontSize: 9))))
+                .Paragraph(p => p.Text("Body content."));
+
+            byte[] bytes = doc.ToBytes();
+            string rawPdf = Encoding.ASCII.GetString(bytes);
+            using var pdf = PdfPigDocument.Open(new MemoryStream(bytes));
+            var page = pdf.GetPage(1);
+            string text = Normalize(page.Text);
+
+            Assert.Contains("Richheader1/1", text, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Richfooter1", text, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(page.Letters, letter => letter.Value == "R" && letter.FontName != null && letter.FontName.Contains("Bold", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.Letters, letter => letter.Value == "1" && letter.FontName != null && letter.FontName.Contains("Oblique", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(page.Letters, letter => letter.Value == "R" && letter.PointSize > 13D);
+            Assert.Contains("1 0 0 rg", rawPdf, StringComparison.Ordinal);
+            Assert.Contains("0 0 1 rg", rawPdf, StringComparison.Ordinal);
+            Assert.Contains("1 1 0 rg", rawPdf, StringComparison.Ordinal);
+            Assert.Contains("0 0.502 0 RG", rawPdf, StringComparison.Ordinal);
+            Assert.Contains("0.502 0 0.502 RG", rawPdf, StringComparison.Ordinal);
+            Assert.Contains(" Ts", rawPdf, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void HeaderFooterRichText_UsesFirstEvenAndDefaultVariants() {
+            byte[] bytes = PdfDocument.Create()
+                .Header(header => header
+                    .Text(text => text.Run(TextRun.Bolded("Odd rich")))
+                    .FirstPageText(text => text.Run(TextRun.Italicized("First rich")))
+                    .EvenPagesText(text => text.Run(TextRun.Underlined("Even rich"))))
+                .Footer(footer => footer
+                    .Text(text => text.Run(TextRun.Bolded("Odd footer")))
+                    .FirstPageText(text => text.Run(TextRun.Italicized("First footer")))
+                    .EvenPagesText(text => text.Run(TextRun.Underlined("Even footer"))))
+                .Paragraph(p => p.Text("Page one"))
+                .PageBreak()
+                .Paragraph(p => p.Text("Page two"))
+                .PageBreak()
+                .Paragraph(p => p.Text("Page three"))
+                .ToBytes();
+
+            using var pdf = PdfPigDocument.Open(new MemoryStream(bytes));
+            Assert.Contains("Firstrich", Normalize(pdf.GetPage(1).Text), StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Firstfooter", Normalize(pdf.GetPage(1).Text), StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Evenrich", Normalize(pdf.GetPage(2).Text), StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Evenfooter", Normalize(pdf.GetPage(2).Text), StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Oddrich", Normalize(pdf.GetPage(3).Text), StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Oddfooter", Normalize(pdf.GetPage(3).Text), StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void HeaderFooterRichText_RejectsInteractiveAndInlineRuns() {
+            var link = TextRun.Link("Link", "https://example.com");
+            var inline = TextRun.Inline(new PdfInlineBox(12, 8));
+
+            Assert.Throws<ArgumentException>(() =>
+                PdfDocument.Create().Header(header => header.Text(text => text.Run(link))));
+            Assert.Throws<ArgumentException>(() =>
+                PdfDocument.Create().Footer(footer => footer.Text(text => text.Run(inline))));
+            Assert.Throws<ArgumentException>(() =>
+                FooterSegment.PageNumber(TextRun.Tab()));
+        }
+    }
+}

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfEncryptedReadTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfEncryptedReadTests.cs
@@ -156,7 +156,7 @@ public class PdfEncryptedReadTests {
         Assert.False(preflight.Can(PdfPreflightCapability.FillSimpleFormFields));
         Assert.Contains(preflight.RewriteBlockers, blocker => blocker.Kind == PdfRewriteBlockerKind.Encryption);
         Assert.Contains(
-            "General encrypted-document rewrites remain blocked; the dedicated owner-authorized security editor can decrypt or re-encrypt supported unsigned PDFs.",
+            "Encrypted input requires operation-specific planning. Authenticated unsigned PDFs support proven page extraction, merge, page-tree, and page-content rewrites; other rewrites remain blocked, and security changes require owner authorization.",
             preflight.GetCapabilityDiagnostics(PdfPreflightCapability.FillSimpleFormFields));
     }
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfEncryptedReadTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfEncryptedReadTests.cs
@@ -145,19 +145,22 @@ public class PdfEncryptedReadTests {
 
 
     [Fact]
-    public void StandardPasswordEncryptedFormPdf_BlocksFormFillEvenWithValidPassword() {
+    public void StandardPasswordEncryptedFormPdf_FillsWithValidPassword() {
         byte[] pdf = EncryptedPdfFixture.CreateRevision2WithTextField("open", "owner", "Secret PDF Text");
 
-        PdfDocumentPreflight preflight = PdfInspector.Preflight(pdf, new PdfReadOptions { Password = "open" });
+        var readOptions = new PdfReadOptions { Password = "open" };
+        PdfDocumentPreflight preflight = PdfInspector.Preflight(pdf, readOptions);
+        PdfDocument filled = PdfDocument.Open(pdf, readOptions).Forms.Fill(new Dictionary<string, string> {
+            ["Name"] = "Grace"
+        });
 
         Assert.True(preflight.CanRead);
         Assert.False(preflight.CanRewrite);
-        Assert.False(preflight.CanFillSimpleFormFields);
-        Assert.False(preflight.Can(PdfPreflightCapability.FillSimpleFormFields));
+        Assert.True(preflight.CanFillSimpleFormFields);
+        Assert.True(preflight.Can(PdfPreflightCapability.FillSimpleFormFields));
         Assert.Contains(preflight.RewriteBlockers, blocker => blocker.Kind == PdfRewriteBlockerKind.Encryption);
-        Assert.Contains(
-            "Encrypted input requires operation-specific planning. Authenticated unsigned PDFs support proven page extraction, merge, page-tree, and page-content rewrites; other rewrites remain blocked, and security changes require owner authorization.",
-            preflight.GetCapabilityDiagnostics(PdfPreflightCapability.FillSimpleFormFields));
+        Assert.False(PdfInspector.Probe(filled.ToBytes()).HasEncryption);
+        Assert.Equal("Grace", Assert.Single(filled.Inspect().FormFields).Value);
     }
 
     private static class EncryptedPdfFixture {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfEncryptedWriteTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfEncryptedWriteTests.cs
@@ -128,24 +128,23 @@ public class PdfEncryptedWriteTests {
     }
 
     [Fact]
-    public void GeneratedEncryptedFormPdfBlocksFormMutationEvenWithPassword() {
+    public void GeneratedEncryptedFormPdfSupportsFormMutationWithPassword() {
         byte[] pdf = PdfDocument.Create(new PdfOptions().SetEncryption("open", "owner"))
             .TextField("Name", width: 180, height: 24, value: "Ada")
             .ToBytes();
 
-        PdfDocumentPreflight preflight = PdfInspector.Preflight(pdf, new PdfReadOptions { Password = "open" });
+        var readOptions = new PdfReadOptions { Password = "open" };
+        PdfDocumentPreflight preflight = PdfInspector.Preflight(pdf, readOptions);
+        PdfDocument filled = PdfDocument.Open(pdf, readOptions).Forms.Fill(new Dictionary<string, string> {
+            ["Name"] = "Grace"
+        });
 
         Assert.True(preflight.CanRead);
-        Assert.False(preflight.CanFillSimpleFormFields);
-        Assert.False(preflight.CanFlattenSimpleFormFields);
-        Assert.False(preflight.Can(PdfPreflightCapability.FillSimpleFormFields));
-        Assert.Contains(
-            "Encrypted PDF files are not supported for form filling or flattening by OfficeIMO.Pdf yet.",
-            preflight.GetCapabilityDiagnostics(PdfPreflightCapability.FillSimpleFormFields));
-        PdfMutationBlockedException exception = Assert.Throws<PdfMutationBlockedException>(() => PdfFormFiller.FillFields(pdf, new Dictionary<string, string> {
-            ["Name"] = "Grace"
-        }));
-        Assert.Contains("FullRewrite.Encryption", exception.Plan.BlockerCodes);
+        Assert.True(preflight.CanFillSimpleFormFields);
+        Assert.True(preflight.CanFlattenSimpleFormFields);
+        Assert.True(preflight.Can(PdfPreflightCapability.FillSimpleFormFields));
+        Assert.False(PdfInspector.Probe(filled.ToBytes()).HasEncryption);
+        Assert.Equal("Grace", Assert.Single(filled.Inspect().FormFields).Value);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfInspectorSecurityFormPreflightTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfInspectorSecurityFormPreflightTests.cs
@@ -29,13 +29,13 @@ public partial class PdfInspectorTests {
         Assert.Contains("PDF encryption dictionary could not be read.", report.GetCapabilityDiagnostics(PdfPreflightCapability.ExtractText));
         Assert.Contains("PDF encryption dictionary could not be read.", report.GetCapabilityDiagnostics(PdfPreflightCapability.ExtractImages));
         Assert.Contains("PDF encryption dictionary could not be read.", report.GetCapabilityDiagnostics(PdfPreflightCapability.ReadLogicalObjects));
-        Assert.Contains("General encrypted-document rewrites remain blocked; the dedicated owner-authorized security editor can decrypt or re-encrypt supported unsigned PDFs.", report.GetCapabilityDiagnostics(PdfPreflightCapability.ManipulatePages));
+        Assert.Contains("Encrypted input requires operation-specific planning. Authenticated unsigned PDFs support proven page extraction, merge, page-tree, and page-content rewrites; other rewrites remain blocked, and security changes require owner authorization.", report.GetCapabilityDiagnostics(PdfPreflightCapability.ManipulatePages));
         Assert.Contains("PDF encryption dictionary could not be read.", report.GetCapabilityDiagnostics(PdfPreflightCapability.FillSimpleFormFields));
         Assert.Null(report.DocumentInfo);
         Assert.True(report.Probe.HasEncryption);
         Assert.Contains("PDF encryption dictionary could not be read.", report.Diagnostics);
         AssertReadBlocker(report, PdfReadBlockerKind.Encryption, "PDF encryption dictionary could not be read.");
-        AssertRewriteBlocker(report, PdfRewriteBlockerKind.Encryption, "General encrypted-document rewrites remain blocked; the dedicated owner-authorized security editor can decrypt or re-encrypt supported unsigned PDFs.");
+        AssertRewriteBlocker(report, PdfRewriteBlockerKind.Encryption, "Encrypted input requires operation-specific planning. Authenticated unsigned PDFs support proven page extraction, merge, page-tree, and page-content rewrites; other rewrites remain blocked, and security changes require owner authorization.");
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfInspectorSecurityFormPreflightTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfInspectorSecurityFormPreflightTests.cs
@@ -29,13 +29,13 @@ public partial class PdfInspectorTests {
         Assert.Contains("PDF encryption dictionary could not be read.", report.GetCapabilityDiagnostics(PdfPreflightCapability.ExtractText));
         Assert.Contains("PDF encryption dictionary could not be read.", report.GetCapabilityDiagnostics(PdfPreflightCapability.ExtractImages));
         Assert.Contains("PDF encryption dictionary could not be read.", report.GetCapabilityDiagnostics(PdfPreflightCapability.ReadLogicalObjects));
-        Assert.Contains("Encrypted input requires operation-specific planning. Authenticated unsigned PDFs support proven page extraction, merge, page-tree, and page-content rewrites; other rewrites remain blocked, and security changes require owner authorization.", report.GetCapabilityDiagnostics(PdfPreflightCapability.ManipulatePages));
+        Assert.Contains("Encrypted input requires operation-specific planning. Authenticated unsigned PDFs support proven page, metadata, sanitization, and simple form rewrites when the required permissions are authorized; security changes require owner authorization.", report.GetCapabilityDiagnostics(PdfPreflightCapability.ManipulatePages));
         Assert.Contains("PDF encryption dictionary could not be read.", report.GetCapabilityDiagnostics(PdfPreflightCapability.FillSimpleFormFields));
         Assert.Null(report.DocumentInfo);
         Assert.True(report.Probe.HasEncryption);
         Assert.Contains("PDF encryption dictionary could not be read.", report.Diagnostics);
         AssertReadBlocker(report, PdfReadBlockerKind.Encryption, "PDF encryption dictionary could not be read.");
-        AssertRewriteBlocker(report, PdfRewriteBlockerKind.Encryption, "Encrypted input requires operation-specific planning. Authenticated unsigned PDFs support proven page extraction, merge, page-tree, and page-content rewrites; other rewrites remain blocked, and security changes require owner authorization.");
+        AssertRewriteBlocker(report, PdfRewriteBlockerKind.Encryption, "Encrypted input requires operation-specific planning. Authenticated unsigned PDFs support proven page, metadata, sanitization, and simple form rewrites when the required permissions are authorized; security changes require owner authorization.");
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfInspectorSecurityStateTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfInspectorSecurityStateTests.cs
@@ -15,7 +15,7 @@ public partial class PdfInspectorTests {
         Assert.Null(report.DocumentInfo);
         Assert.True(report.HasSecurityDiagnostics);
         AssertReadBlocker(report, PdfReadBlockerKind.Encryption, "PDF encryption dictionary is missing /O.");
-        AssertRewriteBlocker(report, PdfRewriteBlockerKind.Encryption, "General encrypted-document rewrites remain blocked; the dedicated owner-authorized security editor can decrypt or re-encrypt supported unsigned PDFs.");
+        AssertRewriteBlocker(report, PdfRewriteBlockerKind.Encryption, "Encrypted input requires operation-specific planning. Authenticated unsigned PDFs support proven page extraction, merge, page-tree, and page-content rewrites; other rewrites remain blocked, and security changes require owner authorization.");
 
         PdfDocumentSecurityInfo security = report.Probe.Security;
         Assert.True(security.HasEncryption);
@@ -51,10 +51,10 @@ public partial class PdfInspectorTests {
         Assert.False(report.RequiresAppendOnlyMutation);
         Assert.False(report.CanAppendOnlyMutate);
         Assert.Empty(report.AppendOnlyMutationDiagnostics);
-        Assert.Contains("PDF encryption was detected using /Filter /Standard and /SubFilter /adbe.pkcs7.s5 (R=3, 128-bit). OfficeIMO.Pdf can report lightweight markers, but cannot decrypt encrypted PDFs yet.", report.SecurityDiagnostics);
-        Assert.Contains("Raw encryption permissions /P=3900 were detected; permission helpers are informational until decryption support exists.", report.SecurityDiagnostics);
-        Assert.Contains("PDF encryption was detected using /Filter /Standard and /SubFilter /adbe.pkcs7.s5 (R=3, 128-bit). OfficeIMO.Pdf can report lightweight markers, but cannot decrypt encrypted PDFs yet.", report.GetCapabilityDiagnostics(PdfPreflightCapability.ExtractText));
-        Assert.Contains("Raw encryption permissions /P=3900 were detected; permission helpers are informational until decryption support exists.", report.GetCapabilityDiagnostics(PdfPreflightCapability.ManipulatePages));
+        Assert.Contains("PDF encryption was detected using /Filter /Standard and /SubFilter /adbe.pkcs7.s5 (R=3, 128-bit). No password authorization was established.", report.SecurityDiagnostics);
+        Assert.Contains("Raw encryption permissions /P=3900 were detected and are enforced for user-password operations unless the caller explicitly ignores restrictions.", report.SecurityDiagnostics);
+        Assert.Contains("PDF encryption was detected using /Filter /Standard and /SubFilter /adbe.pkcs7.s5 (R=3, 128-bit). No password authorization was established.", report.GetCapabilityDiagnostics(PdfPreflightCapability.ExtractText));
+        Assert.Contains("Raw encryption permissions /P=3900 were detected and are enforced for user-password operations unless the caller explicitly ignores restrictions.", report.GetCapabilityDiagnostics(PdfPreflightCapability.ManipulatePages));
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfInspectorSecurityStateTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfInspectorSecurityStateTests.cs
@@ -15,7 +15,7 @@ public partial class PdfInspectorTests {
         Assert.Null(report.DocumentInfo);
         Assert.True(report.HasSecurityDiagnostics);
         AssertReadBlocker(report, PdfReadBlockerKind.Encryption, "PDF encryption dictionary is missing /O.");
-        AssertRewriteBlocker(report, PdfRewriteBlockerKind.Encryption, "Encrypted input requires operation-specific planning. Authenticated unsigned PDFs support proven page extraction, merge, page-tree, and page-content rewrites; other rewrites remain blocked, and security changes require owner authorization.");
+        AssertRewriteBlocker(report, PdfRewriteBlockerKind.Encryption, "Encrypted input requires operation-specific planning. Authenticated unsigned PDFs support proven page, metadata, sanitization, and simple form rewrites when the required permissions are authorized; security changes require owner authorization.");
 
         PdfDocumentSecurityInfo security = report.Probe.Security;
         Assert.True(security.HasEncryption);

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfInteroperabilityCorpusSupport.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfInteroperabilityCorpusSupport.cs
@@ -77,7 +77,7 @@ internal static class PdfInteroperabilityCorpusSupport {
             new PdfInteroperabilityCorpusCase(
                 "password-encrypted",
                 encrypted,
-                PdfMutationExecutionMode.Blocked,
+                PdfMutationExecutionMode.FullRewrite,
                 new PdfReadOptions { Password = "open" },
                 "encrypted", "standard-security", "password"),
             new PdfInteroperabilityCorpusCase(

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfInteroperabilityCorpusTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfInteroperabilityCorpusTests.cs
@@ -53,7 +53,10 @@ public class PdfInteroperabilityCorpusTests {
                 ExpectedClassification = item.ExpectedMetadataMode == PdfMutationExecutionMode.Blocked
                     ? PdfRewritePreservationMatrixClassification.Blocked
                     : PdfRewritePreservationMatrixClassification.RewriteSafe,
-                PreservationOptions = new PdfRewritePreservationOptions().AllowMetadataChanges("Title")
+                PreservationOptions = new PdfRewritePreservationOptions {
+                    OriginalReadOptions = item.ReadOptions,
+                    PreserveSecurityState = !item.Features.Contains("encrypted", StringComparer.Ordinal)
+                }.AllowMetadataChanges("Title")
             }
             .WithSourceFeatures(item.Features.ToArray());
     }
@@ -62,9 +65,9 @@ public class PdfInteroperabilityCorpusTests {
         PdfMutationPlan plan = PdfMutationPlanner.Plan(pdf, PdfMutationOperation.UpdateMetadata, readOptions);
         switch (plan.ExecutionMode) {
             case PdfMutationExecutionMode.FullRewrite:
-                return PdfMetadataEditor.UpdateMetadata(pdf, title: "Corpus metadata update");
+                return PdfMetadataEditor.UpdateMetadata(pdf, "Corpus metadata update", author: null, subject: null, keywords: null, readOptions: readOptions);
             case PdfMutationExecutionMode.AppendOnly:
-                return PdfIncrementalUpdater.UpdateMetadata(pdf, title: "Corpus metadata update");
+                return PdfIncrementalUpdater.UpdateMetadata(pdf, title: "Corpus metadata update", readOptions: readOptions);
             default:
                 throw new NotSupportedException(plan.Summary);
         }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfMutationPlannerTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfMutationPlannerTests.cs
@@ -127,7 +127,7 @@ public class PdfMutationPlannerTests {
     }
 
     [Fact]
-    public void Plan_BlocksEncryptedMutationEvenWithValidPassword() {
+    public void Plan_ChoosesFullRewriteForAuthorizedEncryptedMutation() {
         byte[] source = PdfDocument.Create(new PdfOptions().SetEncryption("open", "owner"))
             .Paragraph(paragraph => paragraph.Text("Encrypted planner source"))
             .ToBytes();
@@ -135,11 +135,13 @@ public class PdfMutationPlannerTests {
 
         PdfMutationPlan plan = PdfMutationPlanner.Plan(source, PdfMutationOperation.UpdateMetadata, readOptions);
 
-        Assert.False(plan.CanExecute);
+        Assert.True(plan.CanExecute);
         Assert.True(plan.Preflight.CanRead);
-        Assert.Equal(PdfMutationExecutionMode.Blocked, plan.ExecutionMode);
-        Assert.Contains("FullRewrite.Encryption", plan.BlockerCodes);
-        Assert.Contains("AppendOnly.Encrypted", plan.BlockerCodes);
+        Assert.Equal(PdfMutationExecutionMode.FullRewrite, plan.ExecutionMode);
+        Assert.True(plan.FullRewriteAvailable);
+        Assert.False(plan.AppendOnlyAvailable);
+        Assert.Empty(plan.BlockerCodes);
+        Assert.Contains("Output.EncryptionWillBeRemoved", plan.Warnings);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfMutationPlannerTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfMutationPlannerTests.cs
@@ -213,6 +213,51 @@ public class PdfMutationPlannerTests {
     }
 
     [Fact]
+    public void TryPageImports_PropagateExplicitTargetAuthenticationThroughExecution() {
+        var encryption = new PdfStandardEncryptionOptions("open") {
+            OwnerPassword = "owner",
+            AllowedPermissions = PdfStandardPermissions.None
+        };
+        byte[] target = PdfDocument.Create(new PdfOptions().SetEncryption(encryption))
+            .Paragraph(paragraph => paragraph.Text("Target one"))
+            .PageBreak()
+            .Paragraph(paragraph => paragraph.Text("Target two"))
+            .ToBytes();
+        byte[] incoming = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("Incoming one"))
+            .PageBreak()
+            .Paragraph(paragraph => paragraph.Text("Incoming two"))
+            .ToBytes();
+        var targetReadOptions = new PdfReadOptions {
+            Password = "open",
+            PermissionPolicy = PdfPermissionPolicy.IgnoreRestrictions
+        };
+
+        PdfOperationResult<PdfDocument> appended = PdfDocument.Open(target).Pages.TryAppend(
+            incoming,
+            options: targetReadOptions);
+        PdfOperationResult<PdfDocument> prepended = PdfDocument.Open(target).Pages.TryPrepend(
+            incoming,
+            PdfPageSelection.From(2),
+            options: targetReadOptions);
+        PdfOperationResult<PdfDocument> inserted = PdfDocument.Open(target).Pages.TryInsert(
+            2,
+            incoming,
+            PdfPageSelection.From(1),
+            options: targetReadOptions);
+
+        Assert.All(new[] { appended, prepended, inserted }, result => {
+            Assert.True(result.Succeeded, string.Join(" ", result.Diagnostics));
+            Assert.Equal(PdfMutationOperation.MergeDocuments, result.MutationPlan!.Operation);
+            Assert.Contains("Output.EncryptionWillBeRemoved", result.MutationPlan.Warnings);
+            Assert.False(PdfInspector.Probe(result.RequireValue().ToBytes()).HasEncryption);
+        });
+        Assert.Equal(4, appended.RequireValue().Inspect().PageCount);
+        Assert.Equal(3, prepended.RequireValue().Inspect().PageCount);
+        Assert.Equal(3, inserted.RequireValue().Inspect().PageCount);
+    }
+
+    [Fact]
     public void Plan_StreamStopsBufferingAtConfiguredInputLimit() {
         byte[] source = PdfDocument.Create().Paragraph(paragraph => paragraph.Text("Bounded planner stream")).ToBytes();
         byte[] padded = new byte[1024 * 1024];

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfMutationPlannerTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfMutationPlannerTests.cs
@@ -5,6 +5,21 @@ namespace OfficeIMO.Tests.Pdf;
 
 public class PdfMutationPlannerTests {
     [Fact]
+    public void PermissionCheckEnumPreservesPublishedNumericValues() {
+        Assert.Equal(0, (int)PdfMutationPermissionCheck.ReadDocument);
+        Assert.Equal(1, (int)PdfMutationPermissionCheck.ModifyDocument);
+        Assert.Equal(2, (int)PdfMutationPermissionCheck.AssembleDocument);
+        Assert.Equal(3, (int)PdfMutationPermissionCheck.ModifyAnnotations);
+        Assert.Equal(4, (int)PdfMutationPermissionCheck.FillForms);
+        Assert.Equal(5, (int)PdfMutationPermissionCheck.DocMdp);
+        Assert.Equal(6, (int)PdfMutationPermissionCheck.FieldMdp);
+        Assert.Equal(7, (int)PdfMutationPermissionCheck.AppendRevision);
+        Assert.Equal(8, (int)PdfMutationPermissionCheck.FillSignatureContentsReservation);
+        Assert.Equal(9, (int)PdfMutationPermissionCheck.OwnerAuthorization);
+        Assert.Equal(10, (int)PdfMutationPermissionCheck.CopyContents);
+    }
+
+    [Fact]
     public void Plan_ChoosesFullRewriteForOrdinaryMetadataMutation() {
         byte[] source = PdfDocument.Create()
             .Paragraph(paragraph => paragraph.Text("Planner metadata source"))

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPageOverlayTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPageOverlayTests.cs
@@ -6,6 +6,20 @@ namespace OfficeIMO.Tests.Pdf;
 
 public class PdfPageOverlayTests {
     [Fact]
+    public void RepeatedTargetPageSelectorIsDeduplicatedForOneOverlayRequest() {
+        byte[] target = PdfDocument.Create().Paragraph(paragraph => paragraph.Text("Target")).ToBytes();
+        byte[] source = PdfDocument.Create().Paragraph(paragraph => paragraph.Text("Overlay once")).ToBytes();
+
+        byte[] result = PdfStamper.StampPage(target, source, new PdfPageOverlayOptions {
+            TargetPages = PdfPageSelector.Parse("1,1")
+        });
+
+        string text = PdfReadDocument.Open(result).Pages[0].ExtractText();
+        Assert.Contains("Overlay once", text, StringComparison.Ordinal);
+        Assert.Equal(text.IndexOf("Overlay once", StringComparison.Ordinal), text.LastIndexOf("Overlay once", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void OverlayPage_ImportsSelectedSourcePageAsFormOnSelectedTargetPages() {
         byte[] source = PdfDocument.Create()
             .Paragraph(paragraph => paragraph.Text("Source page one"))

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPermissionPolicyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPermissionPolicyTests.cs
@@ -132,7 +132,12 @@ public class PdfPermissionPolicyTests {
         Assert.Throws<PdfPermissionDeniedException>(() => restricted.Pages[0].GetLinkAnnotations());
         Assert.Throws<PdfPermissionDeniedException>(() => restricted.Pages[0].GetAnnotations());
         Assert.Throws<PdfPermissionDeniedException>(() => restricted.Pages[0].GetPageActions());
-        Assert.Throws<PdfPermissionDeniedException>(() => PdfDocument.Open(pdf, enforced).Inspect());
+        PdfDocument restrictedDocument = PdfDocument.Open(pdf, enforced);
+        Assert.Throws<PdfPermissionDeniedException>(() => restrictedDocument.Inspect());
+        Assert.Throws<PdfPermissionDeniedException>(() => restrictedDocument.Analyze());
+        Assert.Throws<PdfPermissionDeniedException>(() => restrictedDocument.Diagnostics());
+        Assert.Throws<PdfPermissionDeniedException>(() => restrictedDocument.AnalyzeOptimization());
+        Assert.Throws<PdfPermissionDeniedException>(() => restrictedDocument.Debug());
 
         var ignored = new PdfReadOptions {
             Password = "direct-open",
@@ -148,7 +153,12 @@ public class PdfPermissionPolicyTests {
         Assert.NotEmpty(authorized.Pages[0].GetLinkAnnotations());
         Assert.NotEmpty(authorized.Pages[0].GetAnnotations());
         Assert.Empty(authorized.Pages[0].GetPageActions());
-        Assert.Equal("Ada", Assert.Single(PdfDocument.Open(pdf, ignored).Inspect().FormFields).Value);
+        PdfDocument authorizedDocument = PdfDocument.Open(pdf, ignored);
+        Assert.Equal("Ada", Assert.Single(authorizedDocument.Inspect().FormFields).Value);
+        Assert.Equal("Ada", Assert.Single(authorizedDocument.Analyze().Info.FormFields).Value);
+        Assert.Equal("Direct title", authorizedDocument.Diagnostics().Info?.Metadata.Title);
+        Assert.Equal("Direct title", authorizedDocument.AnalyzeOptimization().Diagnostics.Info?.Metadata.Title);
+        Assert.NotEmpty(authorizedDocument.Debug().Objects);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPermissionPolicyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPermissionPolicyTests.cs
@@ -1,0 +1,130 @@
+using OfficeIMO.Pdf;
+using Xunit;
+
+namespace OfficeIMO.Tests.Pdf;
+
+public class PdfPermissionPolicyTests {
+    [Fact]
+    public void RestrictedUserPasswordBlocksTextUntilCallerExplicitlyIgnoresRestrictions() {
+        byte[] pdf = CreateRestrictedPdf("open-one", "owner-one", "Restricted text");
+        var enforced = new PdfReadOptions { Password = "open-one" };
+        var ignored = new PdfReadOptions {
+            Password = "open-one",
+            PermissionPolicy = PdfPermissionPolicy.IgnoreRestrictions
+        };
+
+        PdfDocumentPreflight enforcedPreflight = PdfInspector.Preflight(pdf, enforced);
+        PdfPermissionDeniedException exception = Assert.Throws<PdfPermissionDeniedException>(() =>
+            PdfTextExtractor.ExtractAllText(pdf, (PdfTextLayoutOptions?)null, enforced));
+        PdfDocumentPreflight ignoredPreflight = PdfInspector.Preflight(pdf, ignored);
+        string text = PdfTextExtractor.ExtractAllText(pdf, (PdfTextLayoutOptions?)null, ignored);
+
+        Assert.True(enforcedPreflight.CanRead, string.Join(Environment.NewLine, enforcedPreflight.Diagnostics));
+        Assert.False(enforcedPreflight.CanExtractText);
+        Assert.Equal(PdfStandardPermissions.CopyContents, exception.Permission);
+        Assert.Equal(PdfPasswordAuthenticationRole.User, exception.AuthenticationRole);
+        Assert.True(ignoredPreflight.CanExtractText);
+        Assert.True(ignoredPreflight.PermissionRestrictionsIgnored);
+        Assert.True(ignoredPreflight.CanManipulatePages);
+        Assert.Contains("Restricted text", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void IgnoreRestrictionsStillRequiresAValidDecryptionPassword() {
+        byte[] pdf = CreateRestrictedPdf("open-two", "owner-two", "No password bypass");
+        var options = new PdfReadOptions {
+            Password = "wrong",
+            PermissionPolicy = PdfPermissionPolicy.IgnoreRestrictions
+        };
+
+        Assert.Throws<PdfInvalidPasswordException>(() => PdfReadDocument.Open(pdf, options));
+        Assert.Throws<PdfInvalidPasswordException>(() =>
+            PdfTextExtractor.ExtractAllText(pdf, (PdfTextLayoutOptions?)null, options));
+    }
+
+    [Fact]
+    public void OwnerPasswordDoesNotNeedPermissionOverride() {
+        byte[] pdf = CreateRestrictedPdf("open-three", "owner-three", "Owner authorized text");
+        var options = new PdfReadOptions { Password = "owner-three" };
+
+        PdfDocumentPreflight preflight = PdfInspector.Preflight(pdf, options);
+        string text = PdfDocument.Open(pdf, options).Read.Text();
+
+        Assert.Equal(PdfPasswordAuthenticationRole.Owner, preflight.Probe.Security.PasswordAuthenticationRole);
+        Assert.True(preflight.CanExtractText);
+        Assert.False(preflight.PermissionRestrictionsIgnored);
+        Assert.Contains("Owner authorized text", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MergeUsesPerSourcePasswordsAndReportsSecurityDecisions() {
+        byte[] first = CreateRestrictedPdf("open-first", "owner-first", "First encrypted page");
+        byte[] second = CreateRestrictedPdf("open-second", "owner-second", "Second encrypted page");
+        var firstOptions = new PdfReadOptions { Password = "owner-first" };
+        var secondOptions = new PdfReadOptions {
+            Password = "open-second",
+            PermissionPolicy = PdfPermissionPolicy.IgnoreRestrictions
+        };
+
+        PdfMergeResult result = PdfDocument.MergeWithReport(
+            new PdfMergeOptions(),
+            PdfDocument.Open(first, firstOptions),
+            PdfDocument.Open(second, secondOptions));
+
+        Assert.Equal(2, result.Report.OutputPageCount);
+        Assert.False(result.Report.OutputHasEncryption);
+        Assert.False(result.Report.OutputHasSignatures);
+        Assert.Equal(PdfPasswordAuthenticationRole.Owner, result.Report.Sources[0].PasswordAuthenticationRole);
+        Assert.False(result.Report.Sources[0].PermissionRestrictionsIgnored);
+        Assert.Equal(PdfPasswordAuthenticationRole.User, result.Report.Sources[1].PasswordAuthenticationRole);
+        Assert.True(result.Report.Sources[1].PermissionRestrictionsIgnored);
+        Assert.Equal(PdfStandardPermissions.None, result.Report.Sources[1].Security.AllowedStandardPermissions);
+        PdfMergeDecision security = Assert.Single(result.Report.Decisions, decision => decision.Structure == "Security");
+        Assert.Contains("unencrypted", security.Action, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("explicitly ignored", security.Action, StringComparison.OrdinalIgnoreCase);
+        string mergedText = result.ToDocument().Read.Text();
+        Assert.Contains("First encrypted page", mergedText, StringComparison.Ordinal);
+        Assert.Contains("Second encrypted page", mergedText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RestrictedUserMergeIsBlockedUnlessCopyAndAssemblyAreAllowed() {
+        byte[] restricted = CreateRestrictedPdf("open-blocked", "owner-blocked", "Blocked merge");
+        var restrictedOptions = new PdfReadOptions { Password = "open-blocked" };
+        PdfDocument plain = PdfDocument.Create().Paragraph(paragraph => paragraph.Text("Plain page"));
+
+        PdfMutationBlockedException exception = Assert.Throws<PdfMutationBlockedException>(() =>
+            PdfDocument.Merge(plain, PdfDocument.Open(restricted, restrictedOptions)));
+
+        Assert.Contains("FullRewrite.Encryption", exception.Plan.BlockerCodes);
+
+        byte[] allowed = CreateEncryptedPdf(
+            "open-allowed",
+            "owner-allowed",
+            PdfStandardPermissions.CopyContents | PdfStandardPermissions.AssembleDocument,
+            "Allowed merge");
+        PdfDocument merged = PdfDocument.Merge(
+            plain,
+            PdfDocument.Open(allowed, new PdfReadOptions { Password = "open-allowed" }));
+
+        Assert.Equal(2, PdfInspector.Inspect(merged.ToBytes()).PageCount);
+        Assert.Contains("Allowed merge", merged.Read.Text(), StringComparison.Ordinal);
+    }
+
+    private static byte[] CreateRestrictedPdf(string userPassword, string ownerPassword, string text) =>
+        CreateEncryptedPdf(userPassword, ownerPassword, PdfStandardPermissions.None, text);
+
+    private static byte[] CreateEncryptedPdf(
+        string userPassword,
+        string ownerPassword,
+        PdfStandardPermissions permissions,
+        string text) {
+        var encryption = new PdfStandardEncryptionOptions(userPassword) {
+            OwnerPassword = ownerPassword,
+            AllowedPermissions = permissions
+        };
+        return PdfDocument.Create(new PdfOptions().SetEncryption(encryption))
+            .Paragraph(paragraph => paragraph.Text(text))
+            .ToBytes();
+    }
+}

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPermissionPolicyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPermissionPolicyTests.cs
@@ -240,16 +240,24 @@ public class PdfPermissionPolicyTests {
         PdfDocument moved = PdfDocument.Open(source, options).Pages.Move(1, 3);
         PdfDocument rotated = PdfDocument.Open(source, options).Pages.Rotate(90, 1);
         PdfDocument boxed = PdfDocument.Open(source, options).Pages.SetCropBox(10, 10, 300, 500, 1);
+        PdfDocument reordered = PdfDocument.Open(source, options).Pages.Reorder(3, 2, 1);
+        PdfDocument duplicated = PdfDocument.Open(source, options).Pages.Duplicate(2);
 
         Assert.Equal(2, deleted.Inspect().PageCount);
         Assert.Equal(3, moved.Inspect().PageCount);
         Assert.StartsWith("Page three", moved.Read.Text(), StringComparison.Ordinal);
         Assert.Equal(90, rotated.Inspect().Pages[0].RotationDegrees);
         Assert.Equal(290D, boxed.Inspect().Pages[0].CropBox!.Width, 3);
+        Assert.StartsWith("Page three", reordered.Read.Text(), StringComparison.Ordinal);
+        Assert.Equal(4, duplicated.Inspect().PageCount);
 
         PdfOperationResult<PdfDocument> explicitOptions = PdfDocument.Open(source).Pages.TryRotate(180, PdfPageSelection.From(2), options);
         Assert.True(explicitOptions.Succeeded, string.Join(Environment.NewLine, explicitOptions.Diagnostics));
         Assert.Equal(180, explicitOptions.RequireValue().Inspect().Pages[1].RotationDegrees);
+
+        PdfOperationResult<PdfDocument> explicitDuplicateOptions = PdfDocument.Open(source).Pages.TryDuplicate(PdfPageSelection.From(1), options);
+        Assert.True(explicitDuplicateOptions.Succeeded, string.Join(Environment.NewLine, explicitDuplicateOptions.Diagnostics));
+        Assert.Equal(4, explicitDuplicateOptions.RequireValue().Inspect().PageCount);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPermissionPolicyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPermissionPolicyTests.cs
@@ -57,6 +57,54 @@ public class PdfPermissionPolicyTests {
     }
 
     [Fact]
+    public void RestrictedPageLevelVisualExtractionRequiresCopyPermission() {
+        var encryption = new PdfStandardEncryptionOptions("visual-open") {
+            OwnerPassword = "visual-owner",
+            AllowedPermissions = PdfStandardPermissions.None
+        };
+        byte[] pdf = PdfDocument.Create(new PdfOptions().SetEncryption(encryption))
+            .Canvas(canvas => canvas.Image(PdfPngTestImages.CreateRgbPng(30, 90, 180), 20D, 20D, 40D, 40D))
+            .ToBytes();
+        var enforced = new PdfReadOptions { Password = "visual-open" };
+        PdfReadDocument document = PdfReadDocument.Open(pdf, enforced);
+
+        Assert.Throws<PdfPermissionDeniedException>(() => document.Pages[0].GetImages());
+        Assert.Throws<PdfPermissionDeniedException>(() => document.Pages[0].GetImagePlacements());
+        Assert.Throws<PdfPermissionDeniedException>(() => document.Pages[0].ToDrawing());
+        Assert.Throws<PdfPermissionDeniedException>(() => PdfImageExtractor.ExtractImages(document));
+        Assert.Throws<PdfPermissionDeniedException>(() => PdfImageExtractor.ExtractImagePlacements(document));
+
+        var ignored = new PdfReadOptions {
+            Password = "visual-open",
+            PermissionPolicy = PdfPermissionPolicy.IgnoreRestrictions
+        };
+        PdfReadDocument authorized = PdfReadDocument.Open(pdf, ignored);
+        Assert.NotEmpty(authorized.Pages[0].GetImages());
+        Assert.NotEmpty(authorized.Pages[0].GetImagePlacements());
+        Assert.NotEmpty(authorized.Pages[0].ToDrawing().Elements);
+    }
+
+    [Fact]
+    public void AccessibilityPermissionAllowsTextButNotTheFullLogicalObjectModel() {
+        byte[] pdf = CreateEncryptedPdf(
+            "accessible-open",
+            "accessible-owner",
+            PdfStandardPermissions.Accessibility,
+            "Accessible text");
+        var options = new PdfReadOptions { Password = "accessible-open" };
+
+        PdfDocumentPreflight preflight = PdfInspector.Preflight(pdf, options);
+        string text = PdfTextExtractor.ExtractAllText(pdf, (PdfTextLayoutOptions?)null, options);
+        PdfPermissionDeniedException exception = Assert.Throws<PdfPermissionDeniedException>(() =>
+            PdfLogicalDocument.Load(pdf, null, options));
+
+        Assert.True(preflight.CanExtractText);
+        Assert.False(preflight.CanReadLogicalObjects);
+        Assert.Contains("Accessible text", text, StringComparison.Ordinal);
+        Assert.Equal(PdfStandardPermissions.CopyContents, exception.Permission);
+    }
+
+    [Fact]
     public void MergeUsesPerSourcePasswordsAndReportsSecurityDecisions() {
         byte[] first = CreateRestrictedPdf("open-first", "owner-first", "First encrypted page");
         byte[] second = CreateRestrictedPdf("open-second", "owner-second", "Second encrypted page");
@@ -88,6 +136,33 @@ public class PdfPermissionPolicyTests {
     }
 
     [Fact]
+    public void MergePreservesOriginalSecurityEvidenceAfterSourcePreprocessing() {
+        byte[] encrypted = CreateRestrictedPdf("resize-open", "resize-owner", "Encrypted resized page");
+        var sourceOptions = new PdfReadOptions {
+            Password = "resize-open",
+            PermissionPolicy = PdfPermissionPolicy.IgnoreRestrictions
+        };
+        PdfDocument plain = PdfDocument.Create().Paragraph(paragraph => paragraph.Text("Plain page"));
+        var mergeOptions = new PdfMergeOptions {
+            ResizePages = new PdfPageResizeOptions(PageSizes.A4)
+        };
+
+        PdfMergeResult result = PdfDocument.MergeWithReport(
+            mergeOptions,
+            PdfDocument.Open(encrypted, sourceOptions),
+            plain);
+
+        PdfMergeSourceInventory inventory = result.Report.Sources[0];
+        Assert.True(inventory.HasEncryption);
+        Assert.Equal(PdfPasswordAuthenticationRole.User, inventory.PasswordAuthenticationRole);
+        Assert.True(inventory.PermissionRestrictionsIgnored);
+        Assert.Equal(PdfStandardPermissions.None, inventory.Security.AllowedStandardPermissions);
+        PdfMergeDecision security = Assert.Single(result.Report.Decisions, decision => decision.Structure == "Security");
+        Assert.Contains("unencrypted", security.Action, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("explicitly ignored", security.Action, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void RestrictedUserMergeIsBlockedUnlessCopyAndAssemblyAreAllowed() {
         byte[] restricted = CreateRestrictedPdf("open-blocked", "owner-blocked", "Blocked merge");
         var restrictedOptions = new PdfReadOptions { Password = "open-blocked" };
@@ -107,8 +182,16 @@ public class PdfPermissionPolicyTests {
             plain,
             PdfDocument.Open(allowed, new PdfReadOptions { Password = "open-allowed" }));
 
+        PdfMutationPlan allowedPlan = PdfMutationPlanner.Plan(
+            allowed,
+            PdfMutationOperation.MergeDocuments,
+            new PdfReadOptions { Password = "open-allowed" });
+
         Assert.Equal(2, PdfInspector.Inspect(merged.ToBytes()).PageCount);
         Assert.Contains("Allowed merge", merged.Read.Text(), StringComparison.Ordinal);
+        Assert.Contains(PdfMutationPermissionCheck.CopyContents, allowedPlan.PermissionChecks);
+        Assert.Contains(PdfMutationPermissionCheck.AssembleDocument, allowedPlan.PermissionChecks);
+        Assert.DoesNotContain(PdfMutationPermissionCheck.ModifyDocument, allowedPlan.PermissionChecks);
     }
 
     private static byte[] CreateRestrictedPdf(string userPassword, string ownerPassword, string text) =>

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPermissionPolicyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPermissionPolicyTests.cs
@@ -315,6 +315,21 @@ public class PdfPermissionPolicyTests {
         PdfOperationResult<PdfDocument> explicitDuplicateOptions = PdfDocument.Open(source).Pages.TryDuplicate(PdfPageSelection.From(1), options);
         Assert.True(explicitDuplicateOptions.Succeeded, string.Join(Environment.NewLine, explicitDuplicateOptions.Diagnostics));
         Assert.Equal(4, explicitDuplicateOptions.RequireValue().Inspect().PageCount);
+
+        PdfOperationResult<PdfDocument>[] selectorResults = {
+            PdfDocument.Open(source).Pages.TryDelete(PdfPageSelector.Parse("last"), options),
+            PdfDocument.Open(source).Pages.TryReorder(PdfPageSelector.Parse("last..1"), options),
+            PdfDocument.Open(source).Pages.TryDuplicate(PdfPageSelector.Parse("1"), options),
+            PdfDocument.Open(source).Pages.TryMove(1, PdfPageSelector.Parse("last"), options),
+            PdfDocument.Open(source).Pages.TryRotate(270, PdfPageSelector.Parse("2"), options)
+        };
+
+        Assert.All(selectorResults, result => Assert.True(result.Succeeded, string.Join(Environment.NewLine, result.Diagnostics)));
+        Assert.Equal(2, selectorResults[0].RequireValue().Inspect().PageCount);
+        Assert.StartsWith("Page three", selectorResults[1].RequireValue().Read.Text(), StringComparison.Ordinal);
+        Assert.Equal(4, selectorResults[2].RequireValue().Inspect().PageCount);
+        Assert.StartsWith("Page three", selectorResults[3].RequireValue().Read.Text(), StringComparison.Ordinal);
+        Assert.Equal(270, selectorResults[4].RequireValue().Inspect().Pages[1].RotationDegrees);
     }
 
     [Fact]
@@ -368,6 +383,15 @@ public class PdfPermissionPolicyTests {
 
         Assert.True(report.Original.Security.HasEncryption);
         Assert.True(report.Rewritten.Security.HasEncryption);
+
+        var enforcedSourceOptions = new PdfReadOptions { Password = "owner-open" };
+        var enforcedRewrittenOptions = new PdfReadOptions { Password = "rewrite-open" };
+        Assert.Throws<PdfPermissionDeniedException>(() =>
+            PdfDocument.Open(source, enforcedSourceOptions).AssessRewritePreservation(
+                PdfDocument.Open(rewrittenBytes, rewrittenOptions)));
+        Assert.Throws<PdfPermissionDeniedException>(() =>
+            PdfDocument.Open(source, options).AssessRewritePreservation(
+                PdfDocument.Open(rewrittenBytes, enforcedRewrittenOptions)));
     }
 
     private static byte[] CreateRestrictedPdf(string userPassword, string ownerPassword, string text) =>

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPermissionPolicyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPermissionPolicyTests.cs
@@ -105,6 +105,47 @@ public class PdfPermissionPolicyTests {
     }
 
     [Fact]
+    public void RestrictedDirectReadModelRequiresCopyPermissionForLogicalContent() {
+        var encryption = new PdfStandardEncryptionOptions("direct-open") {
+            OwnerPassword = "direct-owner",
+            AllowedPermissions = PdfStandardPermissions.None
+        };
+        byte[] pdf = PdfDocument.Create(new PdfOptions {
+                CreateOutlineFromHeadings = true
+            }.SetEncryption(encryption))
+            .Bookmark("DirectAnchor")
+            .H1("Direct logical heading")
+            .Paragraph(paragraph => paragraph.LinkToBookmark("Jump", "DirectAnchor"))
+            .TextField("Direct.Name", value: "Ada")
+            .ToBytes();
+        var enforced = new PdfReadOptions { Password = "direct-open" };
+        PdfReadDocument restricted = PdfReadDocument.Open(pdf, enforced);
+
+        Assert.Throws<PdfPermissionDeniedException>(() => restricted.Outlines);
+        Assert.Throws<PdfPermissionDeniedException>(() => restricted.NamedDestinations);
+        Assert.Throws<PdfPermissionDeniedException>(() => restricted.FormFields);
+        Assert.Throws<PdfPermissionDeniedException>(() => restricted.RawStructure());
+        Assert.Throws<PdfPermissionDeniedException>(() => restricted.Pages[0].GetLinkAnnotations());
+        Assert.Throws<PdfPermissionDeniedException>(() => restricted.Pages[0].GetAnnotations());
+        Assert.Throws<PdfPermissionDeniedException>(() => restricted.Pages[0].GetPageActions());
+        Assert.Throws<PdfPermissionDeniedException>(() => PdfDocument.Open(pdf, enforced).Inspect());
+
+        var ignored = new PdfReadOptions {
+            Password = "direct-open",
+            PermissionPolicy = PdfPermissionPolicy.IgnoreRestrictions
+        };
+        PdfReadDocument authorized = PdfReadDocument.Open(pdf, ignored);
+        Assert.NotEmpty(authorized.Outlines);
+        Assert.Contains(authorized.NamedDestinations, destination => destination.Name == "DirectAnchor");
+        Assert.Equal("Ada", Assert.Single(authorized.FormFields).Value);
+        Assert.NotEmpty(authorized.RawStructure().Objects);
+        Assert.NotEmpty(authorized.Pages[0].GetLinkAnnotations());
+        Assert.NotEmpty(authorized.Pages[0].GetAnnotations());
+        Assert.Empty(authorized.Pages[0].GetPageActions());
+        Assert.Equal("Ada", Assert.Single(PdfDocument.Open(pdf, ignored).Inspect().FormFields).Value);
+    }
+
+    [Fact]
     public void MergeUsesPerSourcePasswordsAndReportsSecurityDecisions() {
         byte[] first = CreateRestrictedPdf("open-first", "owner-first", "First encrypted page");
         byte[] second = CreateRestrictedPdf("open-second", "owner-second", "Second encrypted page");

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPermissionPolicyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPermissionPolicyTests.cs
@@ -113,7 +113,7 @@ public class PdfPermissionPolicyTests {
         byte[] pdf = PdfDocument.Create(new PdfOptions {
                 CreateOutlineFromHeadings = true,
                 IncludeXmpMetadata = true
-            }.SetEncryption(encryption))
+            }.SetSrgbOutputIntent().SetEncryption(encryption))
             .Meta(title: "Direct title", author: "OfficeIMO")
             .Bookmark("DirectAnchor")
             .H1("Direct logical heading")
@@ -128,6 +128,7 @@ public class PdfPermissionPolicyTests {
         Assert.Throws<PdfPermissionDeniedException>(() => restricted.Outlines);
         Assert.Throws<PdfPermissionDeniedException>(() => restricted.NamedDestinations);
         Assert.Throws<PdfPermissionDeniedException>(() => restricted.FormFields);
+        Assert.Throws<PdfPermissionDeniedException>(() => restricted.OutputIntents);
         Assert.Throws<PdfPermissionDeniedException>(() => restricted.RawStructure());
         Assert.Throws<PdfPermissionDeniedException>(() => restricted.Pages[0].GetLinkAnnotations());
         Assert.Throws<PdfPermissionDeniedException>(() => restricted.Pages[0].GetAnnotations());
@@ -149,6 +150,7 @@ public class PdfPermissionPolicyTests {
         Assert.NotEmpty(authorized.Outlines);
         Assert.Contains(authorized.NamedDestinations, destination => destination.Name == "DirectAnchor");
         Assert.Equal("Ada", Assert.Single(authorized.FormFields).Value);
+        Assert.NotEmpty(authorized.OutputIntents);
         Assert.NotEmpty(authorized.RawStructure().Objects);
         Assert.NotEmpty(authorized.Pages[0].GetLinkAnnotations());
         Assert.NotEmpty(authorized.Pages[0].GetAnnotations());
@@ -283,6 +285,41 @@ public class PdfPermissionPolicyTests {
         } finally {
             File.Delete(path);
         }
+    }
+
+    [Fact]
+    public void PageImportsUseIndependentSourceReadOptionsAcrossPlacements() {
+        byte[] target = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("Target page"))
+            .ToBytes();
+        byte[] source = CreateRestrictedThreePagePdf("import-open", "import-owner");
+        var sourceReadOptions = new PdfReadOptions {
+            Password = "import-open",
+            PermissionPolicy = PdfPermissionPolicy.IgnoreRestrictions
+        };
+        var importOptions = new PdfPageImportOptions {
+            SourceReadOptions = sourceReadOptions
+        };
+
+        PdfDocument appended = PdfDocument.Open(target).Pages.Append(
+            source,
+            PdfPageSelection.From(2),
+            importOptions);
+        PdfDocument prepended = PdfDocument.Open(target).Pages.Prepend(source, importOptions);
+        PdfDocument encryptedSourceDocument = PdfDocument.Open(source, sourceReadOptions);
+        PdfOperationResult<PdfDocument> inserted = PdfDocument.Open(target).Pages.TryInsert(
+            1,
+            encryptedSourceDocument,
+            PdfPageSelection.From(3),
+            new PdfPageImportOptions());
+
+        Assert.Equal(2, appended.Inspect().PageCount);
+        Assert.Contains("Page two", appended.Read.Text(), StringComparison.Ordinal);
+        Assert.Equal(4, prepended.Inspect().PageCount);
+        Assert.StartsWith("Page one", prepended.Read.Text(), StringComparison.Ordinal);
+        Assert.True(inserted.Succeeded, string.Join(Environment.NewLine, inserted.Diagnostics));
+        Assert.Equal(2, inserted.RequireValue().Inspect().PageCount);
+        Assert.StartsWith("Page three", inserted.RequireValue().Read.Text(), StringComparison.Ordinal);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPermissionPolicyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPermissionPolicyTests.cs
@@ -111,8 +111,10 @@ public class PdfPermissionPolicyTests {
             AllowedPermissions = PdfStandardPermissions.None
         };
         byte[] pdf = PdfDocument.Create(new PdfOptions {
-                CreateOutlineFromHeadings = true
+                CreateOutlineFromHeadings = true,
+                IncludeXmpMetadata = true
             }.SetEncryption(encryption))
+            .Meta(title: "Direct title", author: "OfficeIMO")
             .Bookmark("DirectAnchor")
             .H1("Direct logical heading")
             .Paragraph(paragraph => paragraph.LinkToBookmark("Jump", "DirectAnchor"))
@@ -121,6 +123,8 @@ public class PdfPermissionPolicyTests {
         var enforced = new PdfReadOptions { Password = "direct-open" };
         PdfReadDocument restricted = PdfReadDocument.Open(pdf, enforced);
 
+        Assert.Throws<PdfPermissionDeniedException>(() => restricted.Metadata);
+        Assert.Throws<PdfPermissionDeniedException>(() => restricted.XmpMetadata);
         Assert.Throws<PdfPermissionDeniedException>(() => restricted.Outlines);
         Assert.Throws<PdfPermissionDeniedException>(() => restricted.NamedDestinations);
         Assert.Throws<PdfPermissionDeniedException>(() => restricted.FormFields);
@@ -135,6 +139,8 @@ public class PdfPermissionPolicyTests {
             PermissionPolicy = PdfPermissionPolicy.IgnoreRestrictions
         };
         PdfReadDocument authorized = PdfReadDocument.Open(pdf, ignored);
+        Assert.Equal("Direct title", authorized.Metadata.Title);
+        Assert.Equal("Direct title", authorized.XmpMetadata?.Title);
         Assert.NotEmpty(authorized.Outlines);
         Assert.Contains(authorized.NamedDestinations, destination => destination.Name == "DirectAnchor");
         Assert.Equal("Ada", Assert.Single(authorized.FormFields).Value);

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPermissionPolicyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPermissionPolicyTests.cs
@@ -121,8 +121,12 @@ public class PdfPermissionPolicyTests {
             .TextField("Direct.Name", value: "Ada")
             .ToBytes();
         var enforced = new PdfReadOptions { Password = "direct-open" };
+        PdfDocumentPreflight restrictedPreflight = PdfInspector.Preflight(pdf, enforced);
         PdfReadDocument restricted = PdfReadDocument.Open(pdf, enforced);
 
+        Assert.True(restrictedPreflight.CanRead);
+        Assert.False(restrictedPreflight.CanReadLogicalObjects);
+        Assert.Null(restrictedPreflight.DocumentInfo);
         Assert.Throws<PdfPermissionDeniedException>(() => restricted.Metadata);
         Assert.Throws<PdfPermissionDeniedException>(() => restricted.XmpMetadata);
         Assert.Throws<PdfPermissionDeniedException>(() => restricted.Outlines);
@@ -144,7 +148,10 @@ public class PdfPermissionPolicyTests {
             Password = "direct-open",
             PermissionPolicy = PdfPermissionPolicy.IgnoreRestrictions
         };
+        PdfDocumentPreflight authorizedPreflight = PdfInspector.Preflight(pdf, ignored);
         PdfReadDocument authorized = PdfReadDocument.Open(pdf, ignored);
+        Assert.True(authorizedPreflight.CanReadLogicalObjects);
+        Assert.Equal("Ada", Assert.Single(authorizedPreflight.DocumentInfo!.FormFields).Value);
         Assert.Equal("Direct title", authorized.Metadata.Title);
         Assert.Equal("Direct title", authorized.XmpMetadata?.Title);
         Assert.NotEmpty(authorized.Outlines);

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPermissionPolicyTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPermissionPolicyTests.cs
@@ -194,8 +194,143 @@ public class PdfPermissionPolicyTests {
         Assert.DoesNotContain(PdfMutationPermissionCheck.ModifyDocument, allowedPlan.PermissionChecks);
     }
 
+    [Fact]
+    public void TryMergeWithUsesExplicitReadOptionsForEncryptedTargetAcrossOverloads() {
+        byte[] target = CreateRestrictedPdf("merge-open", "merge-owner", "Encrypted target");
+        byte[] incoming = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("Incoming page"))
+            .ToBytes();
+        var options = new PdfReadOptions {
+            Password = "merge-open",
+            PermissionPolicy = PdfPermissionPolicy.IgnoreRestrictions
+        };
+        string path = Path.Combine(Path.GetTempPath(), $"officeimo-merge-{Guid.NewGuid():N}.pdf");
+
+        try {
+            File.WriteAllBytes(path, incoming);
+            using var stream = new MemoryStream(incoming, writable: false);
+            PdfOperationResult<PdfDocument>[] results = {
+                PdfDocument.Open(target).TryMergeWith(PdfDocument.Open(incoming), options),
+                PdfDocument.Open(target).TryMergeWith(incoming, options),
+                PdfDocument.Open(target).TryMergeWith(path, options),
+                PdfDocument.Open(target).TryMergeWith(stream, options)
+            };
+
+            Assert.All(results, result => {
+                Assert.True(result.Succeeded, string.Join(Environment.NewLine, result.Diagnostics));
+                Assert.Equal(2, result.RequireValue().Inspect().PageCount);
+                string text = result.RequireValue().Read.Text();
+                Assert.Contains("Encrypted target", text, StringComparison.Ordinal);
+                Assert.Contains("Incoming page", text, StringComparison.Ordinal);
+            });
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void AuthenticatedFluentPageMutationsPreserveStoredReadOptions() {
+        byte[] source = CreateRestrictedThreePagePdf("pages-open", "pages-owner");
+        var options = new PdfReadOptions {
+            Password = "pages-open",
+            PermissionPolicy = PdfPermissionPolicy.IgnoreRestrictions
+        };
+
+        PdfDocument deleted = PdfDocument.Open(source, options).Pages.Delete(3);
+        PdfDocument moved = PdfDocument.Open(source, options).Pages.Move(1, 3);
+        PdfDocument rotated = PdfDocument.Open(source, options).Pages.Rotate(90, 1);
+        PdfDocument boxed = PdfDocument.Open(source, options).Pages.SetCropBox(10, 10, 300, 500, 1);
+
+        Assert.Equal(2, deleted.Inspect().PageCount);
+        Assert.Equal(3, moved.Inspect().PageCount);
+        Assert.StartsWith("Page three", moved.Read.Text(), StringComparison.Ordinal);
+        Assert.Equal(90, rotated.Inspect().Pages[0].RotationDegrees);
+        Assert.Equal(290D, boxed.Inspect().Pages[0].CropBox!.Width, 3);
+
+        PdfOperationResult<PdfDocument> explicitOptions = PdfDocument.Open(source).Pages.TryRotate(180, PdfPageSelection.From(2), options);
+        Assert.True(explicitOptions.Succeeded, string.Join(Environment.NewLine, explicitOptions.Diagnostics));
+        Assert.Equal(180, explicitOptions.RequireValue().Inspect().Pages[1].RotationDegrees);
+    }
+
+    [Fact]
+    public void AuthenticatedFluentFormMutationsPreserveStoredReadOptions() {
+        byte[] source = CreateRestrictedFormPdf("forms-open", "forms-owner", "Before");
+        var options = new PdfReadOptions {
+            Password = "forms-open",
+            PermissionPolicy = PdfPermissionPolicy.IgnoreRestrictions
+        };
+        var ownerOptions = new PdfReadOptions { Password = "forms-owner" };
+        var values = new Dictionary<string, string> { ["Name"] = "After" };
+        var data = new PdfFormDataSet(new[] { new PdfFormDataField("Name", new[] { "Imported" }) });
+
+        PdfDocument filled = PdfDocument.Open(source, options).Forms.Fill(values);
+        PdfDocument appended = PdfDocument.Open(source, ownerOptions).Forms.AppendRevision(values);
+        PdfDocument flattened = PdfDocument.Open(source, options).Forms.Flatten();
+        PdfDocument filledAndFlattened = PdfDocument.Open(source, options).Forms.FillAndFlatten(values);
+        PdfDocument imported = PdfDocument.Open(source, options).Forms.ImportXfdf(data.ToXfdf());
+
+        Assert.Equal("After", Assert.Single(filled.Inspect().FormFields).Value);
+        Assert.Equal("After", Assert.Single(appended.Inspect().FormFields).Value);
+        Assert.False(flattened.Inspect().HasForms);
+        Assert.False(filledAndFlattened.Inspect().HasForms);
+        Assert.Equal("Imported", Assert.Single(imported.Inspect().FormFields).Value);
+
+        PdfOperationResult<PdfDocument> explicitOptions = PdfDocument.Open(source).Forms.TryFlatten(options);
+        Assert.True(explicitOptions.Succeeded, string.Join(Environment.NewLine, explicitOptions.Diagnostics));
+        Assert.False(explicitOptions.RequireValue().Inspect().HasForms);
+    }
+
+    [Fact]
+    public void AuthenticatedSanitizationMetadataAndRewriteProofUseDocumentReadOptions() {
+        byte[] source = CreateRestrictedPdf("owner-open", "owner-password", "Protected content");
+        var options = new PdfReadOptions {
+            Password = "owner-open",
+            PermissionPolicy = PdfPermissionPolicy.IgnoreRestrictions
+        };
+
+        PdfSanitizationResult sanitized = PdfDocument.Open(source, options).Sanitize();
+        PdfDocument updated = PdfDocument.Open(source, options).UpdateMetadata(title: "Authenticated title");
+        Assert.True(sanitized.IsSanitized);
+        Assert.Equal("Authenticated title", updated.Read.Metadata().Title);
+
+        byte[] rewrittenBytes = CreateRestrictedPdf("rewrite-open", "rewrite-owner", "Protected content");
+        var rewrittenOptions = new PdfReadOptions {
+            Password = "rewrite-open",
+            PermissionPolicy = PdfPermissionPolicy.IgnoreRestrictions
+        };
+        PdfRewritePreservationReport report = PdfDocument.Open(source, options).AssessRewritePreservation(
+            PdfDocument.Open(rewrittenBytes, rewrittenOptions));
+
+        Assert.True(report.Original.Security.HasEncryption);
+        Assert.True(report.Rewritten.Security.HasEncryption);
+    }
+
     private static byte[] CreateRestrictedPdf(string userPassword, string ownerPassword, string text) =>
         CreateEncryptedPdf(userPassword, ownerPassword, PdfStandardPermissions.None, text);
+
+    private static byte[] CreateRestrictedThreePagePdf(string userPassword, string ownerPassword) {
+        var encryption = new PdfStandardEncryptionOptions(userPassword) {
+            OwnerPassword = ownerPassword,
+            AllowedPermissions = PdfStandardPermissions.None
+        };
+        return PdfDocument.Create(new PdfOptions().SetEncryption(encryption))
+            .Paragraph(paragraph => paragraph.Text("Page one"))
+            .PageBreak()
+            .Paragraph(paragraph => paragraph.Text("Page two"))
+            .PageBreak()
+            .Paragraph(paragraph => paragraph.Text("Page three"))
+            .ToBytes();
+    }
+
+    private static byte[] CreateRestrictedFormPdf(string userPassword, string ownerPassword, string value) {
+        var encryption = new PdfStandardEncryptionOptions(userPassword) {
+            OwnerPassword = ownerPassword,
+            AllowedPermissions = PdfStandardPermissions.None
+        };
+        return PdfDocument.Create(new PdfOptions().SetEncryption(encryption))
+            .TextField("Name", width: 180, height: 24, value: value)
+            .ToBytes();
+    }
 
     private static byte[] CreateEncryptedPdf(
         string userPassword,

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPublicApiContractTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPublicApiContractTests.cs
@@ -129,7 +129,7 @@ public sealed class PdfPublicApiContractTests {
                 BindingFlags.DeclaredOnly).Length);
 
         Assert.InRange(exportedTypes.Length, 1, 500);
-        Assert.InRange(publicMemberCount, 1, 9700);
+        Assert.InRange(publicMemberCount, 1, 9750);
 
         string[] officeReferences = assembly.GetReferencedAssemblies()
             .Select(reference => reference.Name)

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfSecurityEditorTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfSecurityEditorTests.cs
@@ -76,7 +76,12 @@ public class PdfSecurityEditorTests {
         Assert.Equal(PdfPasswordAuthenticationRole.User, userInfo.Security.PasswordAuthenticationRole);
         Assert.Equal(PdfPasswordAuthenticationRole.Owner, ownerInfo.Security.PasswordAuthenticationRole);
         Assert.Throws<PdfInvalidPasswordException>(() => PdfInspector.Inspect(result.Pdf, new PdfReadOptions { Password = "old-open" }));
-        Assert.Contains("Re-encryption proof", PdfTextExtractor.ExtractAllText(result.Pdf, (PdfTextLayoutOptions?)null, new PdfReadOptions { Password = "new-open" }), StringComparison.Ordinal);
+        Assert.Throws<PdfPermissionDeniedException>(() =>
+            PdfTextExtractor.ExtractAllText(result.Pdf, (PdfTextLayoutOptions?)null, new PdfReadOptions { Password = "new-open" }));
+        Assert.Contains(
+            "Re-encryption proof",
+            PdfTextExtractor.ExtractAllText(result.Pdf, (PdfTextLayoutOptions?)null, new PdfReadOptions { Password = "new-owner" }),
+            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf/Compose/FooterTextBuilder.cs
+++ b/OfficeIMO.Pdf/Compose/FooterTextBuilder.cs
@@ -9,11 +9,26 @@ public class FooterTextBuilder {
     /// <returns>The same builder for chaining.</returns>
     public FooterTextBuilder Text(string s) { Guard.NotNull(s, nameof(s)); _segments.Add(new FooterSegment(FooterSegmentKind.Text, s)); return this; }
 
+    /// <summary>Adds a visually styled text run to the footer.</summary>
+    /// <param name="run">Styled text to render. Interactive links, inline visuals, and paragraph tabs are not supported.</param>
+    /// <returns>The same builder for chaining.</returns>
+    public FooterTextBuilder Run(TextRun run) { Guard.NotNull(run, nameof(run)); _segments.Add(FooterSegment.RichText(run)); return this; }
+
     /// <summary>Adds a token that renders the current page number.</summary>
     /// <returns>The same builder for chaining.</returns>
     public FooterTextBuilder CurrentPage() { _segments.Add(new FooterSegment(FooterSegmentKind.PageNumber)); return this; }
 
+    /// <summary>Adds a current-page token with the supplied visual text style.</summary>
+    /// <param name="style">Text run whose visual styling is applied; its text is ignored.</param>
+    /// <returns>The same builder for chaining.</returns>
+    public FooterTextBuilder CurrentPage(TextRun style) { Guard.NotNull(style, nameof(style)); _segments.Add(FooterSegment.PageNumber(style)); return this; }
+
     /// <summary>Adds a token that renders the total number of pages.</summary>
     /// <returns>The same builder for chaining.</returns>
     public FooterTextBuilder TotalPages() { _segments.Add(new FooterSegment(FooterSegmentKind.TotalPages)); return this; }
+
+    /// <summary>Adds a total-pages token with the supplied visual text style.</summary>
+    /// <param name="style">Text run whose visual styling is applied; its text is ignored.</param>
+    /// <returns>The same builder for chaining.</returns>
+    public FooterTextBuilder TotalPages(TextRun style) { Guard.NotNull(style, nameof(style)); _segments.Add(FooterSegment.TotalPages(style)); return this; }
 }

--- a/OfficeIMO.Pdf/Compose/HeaderTextBuilder.cs
+++ b/OfficeIMO.Pdf/Compose/HeaderTextBuilder.cs
@@ -14,6 +14,15 @@ public class HeaderTextBuilder {
         return this;
     }
 
+    /// <summary>Adds a visually styled text run to the header.</summary>
+    /// <param name="run">Styled text to render. Interactive links, inline visuals, and paragraph tabs are not supported.</param>
+    /// <returns>The same builder for chaining.</returns>
+    public HeaderTextBuilder Run(TextRun run) {
+        Guard.NotNull(run, nameof(run));
+        _segments.Add(FooterSegment.RichText(run));
+        return this;
+    }
+
     /// <summary>Adds a token that renders the current page number.</summary>
     /// <returns>The same builder for chaining.</returns>
     public HeaderTextBuilder CurrentPage() {
@@ -21,10 +30,28 @@ public class HeaderTextBuilder {
         return this;
     }
 
+    /// <summary>Adds a current-page token with the supplied visual text style.</summary>
+    /// <param name="style">Text run whose visual styling is applied; its text is ignored.</param>
+    /// <returns>The same builder for chaining.</returns>
+    public HeaderTextBuilder CurrentPage(TextRun style) {
+        Guard.NotNull(style, nameof(style));
+        _segments.Add(FooterSegment.PageNumber(style));
+        return this;
+    }
+
     /// <summary>Adds a token that renders the total number of pages.</summary>
     /// <returns>The same builder for chaining.</returns>
     public HeaderTextBuilder TotalPages() {
         _segments.Add(new FooterSegment(FooterSegmentKind.TotalPages));
+        return this;
+    }
+
+    /// <summary>Adds a total-pages token with the supplied visual text style.</summary>
+    /// <param name="style">Text run whose visual styling is applied; its text is ignored.</param>
+    /// <returns>The same builder for chaining.</returns>
+    public HeaderTextBuilder TotalPages(TextRun style) {
+        Guard.NotNull(style, nameof(style));
+        _segments.Add(FooterSegment.TotalPages(style));
         return this;
     }
 }

--- a/OfficeIMO.Pdf/Core/PdfDocument.Merge.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocument.Merge.cs
@@ -1,0 +1,32 @@
+namespace OfficeIMO.Pdf;
+
+public sealed partial class PdfDocument {
+    /// <summary>Merges loaded or generated documents with an explicit structure policy and returns readback evidence.</summary>
+    public static PdfMergeResult MergeWithReport(PdfMergeOptions options, params PdfDocument[] documents) =>
+        MergeWithReport(options, (IEnumerable<PdfDocument>)documents);
+
+    /// <summary>Merges loaded or generated documents with an explicit structure policy and returns readback evidence.</summary>
+    public static PdfMergeResult MergeWithReport(PdfMergeOptions options, IEnumerable<PdfDocument> documents) {
+        Guard.NotNull(options, nameof(options));
+        Guard.NotNull(documents, nameof(documents));
+        PdfDocument[] sources = documents.ToArray();
+        if (sources.Length == 0) {
+            throw new ArgumentException("At least one PDF document must be supplied.", nameof(documents));
+        }
+
+        if (sources.Any(static document => document is null)) {
+            throw new ArgumentException("PDF documents cannot contain null entries.", nameof(documents));
+        }
+
+        byte[][] bytes = sources.Select(static document => document.GetBytesForOperation()).ToArray();
+        PdfReadOptions[] readOptions = sources.Select(static document => document.ReadOptions).ToArray();
+        return PdfMerger.MergeWithReport(options, bytes, readOptions);
+    }
+
+    /// <summary>Merges this PDF with another loaded or generated PDF using an explicit structure policy.</summary>
+    public PdfDocument MergeWith(PdfDocument document, PdfMergeOptions options) {
+        Guard.NotNull(document, nameof(document));
+        Guard.NotNull(options, nameof(options));
+        return MergeWithReport(options, this, document).ToDocument();
+    }
+}

--- a/OfficeIMO.Pdf/Core/PdfDocument.Operations.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocument.Operations.cs
@@ -63,6 +63,7 @@ public sealed partial class PdfDocument {
     /// </summary>
     public PdfDocumentInfo Inspect(PdfReadOptions? options = null) {
         var snapshot = GetReadSnapshot(options);
+        snapshot.Document.DemandContentExtraction("logical object");
         return PdfInspector.Inspect(snapshot.Bytes, snapshot.Document);
     }
 

--- a/OfficeIMO.Pdf/Core/PdfDocument.Operations.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocument.Operations.cs
@@ -313,9 +313,14 @@ public sealed partial class PdfDocument {
     /// </summary>
     public PdfDocument MergeWith(PdfDocument document) {
         Guard.NotNull(document, nameof(document));
+        return MergeWith(document, ReadOptions);
+    }
+
+    private PdfDocument MergeWith(PdfDocument document, PdfReadOptions targetReadOptions) {
         return ApplyMutation(input => PdfMerger.Merge(
             new[] { input, document.GetBytesForOperation() },
-            new[] { ReadOptions, document.ReadOptions }));
+            new[] { targetReadOptions, document.ReadOptions }),
+            targetReadOptions);
     }
 
     /// <summary>
@@ -323,7 +328,7 @@ public sealed partial class PdfDocument {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryMergeWith(PdfDocument document, PdfReadOptions? options = null) {
         Guard.NotNull(document, nameof(document));
-        return TryMutationOperation("Merge documents", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, _ => MergeWith(document), options: options);
+        return TryMutationOperation("Merge documents", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, _ => MergeWith(document, options ?? ReadOptions), options: options);
     }
 
     /// <summary>
@@ -331,7 +336,14 @@ public sealed partial class PdfDocument {
     /// </summary>
     public PdfDocument MergeWith(byte[] pdf) {
         Guard.NotNull(pdf, nameof(pdf));
-        return ApplyMutation(input => PdfMerger.Merge(input, pdf));
+        return MergeWith(pdf, ReadOptions);
+    }
+
+    private PdfDocument MergeWith(byte[] pdf, PdfReadOptions targetReadOptions) {
+        return ApplyMutation(input => PdfMerger.Merge(
+            new[] { input, pdf },
+            new[] { targetReadOptions, PdfReadOptions.Default }),
+            targetReadOptions);
     }
 
     /// <summary>
@@ -339,7 +351,7 @@ public sealed partial class PdfDocument {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryMergeWith(byte[] pdf, PdfReadOptions? options = null) {
         Guard.NotNull(pdf, nameof(pdf));
-        return TryMutationOperation("Merge documents", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, _ => MergeWith(pdf), options: options);
+        return TryMutationOperation("Merge documents", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, _ => MergeWith(pdf, options ?? ReadOptions), options: options);
     }
 
     /// <summary>
@@ -347,7 +359,11 @@ public sealed partial class PdfDocument {
     /// </summary>
     public PdfDocument MergeWith(string path) {
         Guard.NotNullOrWhiteSpace(path, nameof(path));
-        return MergeWith(File.ReadAllBytes(path));
+        return MergeWith(path, ReadOptions);
+    }
+
+    private PdfDocument MergeWith(string path, PdfReadOptions targetReadOptions) {
+        return MergeWith(File.ReadAllBytes(path), targetReadOptions);
     }
 
     /// <summary>
@@ -355,7 +371,7 @@ public sealed partial class PdfDocument {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryMergeWith(string path, PdfReadOptions? options = null) {
         Guard.NotNullOrWhiteSpace(path, nameof(path));
-        return TryMutationOperation("Merge documents", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, _ => MergeWith(path), options: options);
+        return TryMutationOperation("Merge documents", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, _ => MergeWith(path, options ?? ReadOptions), options: options);
     }
 
     /// <summary>
@@ -363,13 +379,17 @@ public sealed partial class PdfDocument {
     /// </summary>
     public PdfDocument MergeWith(Stream stream) {
         Guard.NotNull(stream, nameof(stream));
+        return MergeWith(stream, ReadOptions);
+    }
+
+    private PdfDocument MergeWith(Stream stream, PdfReadOptions targetReadOptions) {
         if (!stream.CanRead) {
             throw new ArgumentException("Stream must be readable.", nameof(stream));
         }
 
         using var buffer = new MemoryStream();
         stream.CopyTo(buffer);
-        return MergeWith(buffer.ToArray());
+        return MergeWith(buffer.ToArray(), targetReadOptions);
     }
 
     /// <summary>
@@ -377,7 +397,7 @@ public sealed partial class PdfDocument {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryMergeWith(Stream stream, PdfReadOptions? options = null) {
         Guard.NotNull(stream, nameof(stream));
-        return TryMutationOperation("Merge documents", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, _ => MergeWith(stream), options: options);
+        return TryMutationOperation("Merge documents", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, _ => MergeWith(stream, options ?? ReadOptions), options: options);
     }
 
     /// <summary>
@@ -483,8 +503,11 @@ public sealed partial class PdfDocument {
     /// Creates a new PDF with updated metadata. Null values preserve existing fields; empty strings clear fields.
     /// </summary>
     public PdfDocument UpdateMetadata(string? title = null, string? author = null, string? subject = null, string? keywords = null) {
-        return ApplyMutation(input => PdfMetadataEditor.UpdateMetadata(input, title, author, subject, keywords));
+        return UpdateMetadata(title, author, subject, keywords, ReadOptions);
     }
+
+    private PdfDocument UpdateMetadata(string? title, string? author, string? subject, string? keywords, PdfReadOptions? readOptions) =>
+        ApplyMutation(input => PdfMetadataEditor.UpdateMetadata(input, title, author, subject, keywords, readOptions), readOptions);
 
     /// <summary>
     /// Creates a normalized full-rewrite PDF whose Info dictionary and XMP packet share the supplied common fields.
@@ -496,9 +519,17 @@ public sealed partial class PdfDocument {
         string? subject = null,
         string? keywords = null,
         bool createXmpMetadata = true) {
-        return ApplyMutation(input => PdfMetadataEditor.SynchronizeMetadata(
-            input, title, author, subject, keywords, createXmpMetadata));
+        return SynchronizeMetadata(title, author, subject, keywords, createXmpMetadata, ReadOptions);
     }
+
+    private PdfDocument SynchronizeMetadata(
+        string? title,
+        string? author,
+        string? subject,
+        string? keywords,
+        bool createXmpMetadata,
+        PdfReadOptions? readOptions) => ApplyMutation(input => PdfMetadataEditor.SynchronizeMetadata(
+            input, title, author, subject, keywords, createXmpMetadata, readOptions), readOptions);
 
     /// <summary>Attempts a full-rewrite Info/XMP synchronization and returns planner diagnostics when blocked.</summary>
     public PdfOperationResult<PdfDocument> TrySynchronizeMetadata(
@@ -512,14 +543,14 @@ public sealed partial class PdfDocument {
             "Synchronize Info and XMP metadata",
             PdfPreflightCapability.ManipulatePages,
             PdfMutationOperation.SynchronizeMetadata,
-            _ => SynchronizeMetadata(title, author, subject, keywords, createXmpMetadata),
+            _ => SynchronizeMetadata(title, author, subject, keywords, createXmpMetadata, options ?? ReadOptions),
             options: options,
             executionPreference: PdfMutationExecutionPreference.RequireFullRewrite);
     }
 
     /// <summary>Removes or quarantines active content and embedded payloads through a proven full rewrite.</summary>
     public PdfSanitizationResult Sanitize(PdfSanitizationOptions? options = null) {
-        return PdfSanitizer.Sanitize(GetBytesForOperation(), options);
+        return PdfSanitizer.Sanitize(GetBytesForOperation(), options, ReadOptions);
     }
 
     /// <summary>
@@ -532,7 +563,7 @@ public sealed partial class PdfDocument {
             PdfMutationOperation.UpdateMetadata,
             mode => mode == PdfMutationExecutionMode.AppendOnly
                 ? AppendMetadataRevision(title, author, subject, keywords, options ?? ReadOptions)
-                : UpdateMetadata(title, author, subject, keywords),
+                : UpdateMetadata(title, author, subject, keywords, options ?? ReadOptions),
             options: options);
     }
 
@@ -541,8 +572,11 @@ public sealed partial class PdfDocument {
     /// </summary>
     public PdfDocument ReplaceMetadata(PdfMetadata metadata) {
         Guard.NotNull(metadata, nameof(metadata));
-        return ApplyMutation(input => PdfMetadataEditor.ReplaceMetadata(input, metadata));
+        return ReplaceMetadata(metadata, ReadOptions);
     }
+
+    private PdfDocument ReplaceMetadata(PdfMetadata metadata, PdfReadOptions? readOptions) =>
+        ApplyMutation(input => PdfMetadataEditor.ReplaceMetadata(input, metadata, readOptions), readOptions);
 
     /// <summary>
     /// Attempts to create a new PDF with exactly the supplied metadata, returning diagnostics when blocked or failed.
@@ -553,7 +587,7 @@ public sealed partial class PdfDocument {
             "Replace metadata",
             PdfPreflightCapability.ManipulatePages,
             PdfMutationOperation.UpdateMetadata,
-            _ => ReplaceMetadata(metadata),
+            _ => ReplaceMetadata(metadata, options ?? ReadOptions),
             options: options,
             executionPreference: PdfMutationExecutionPreference.RequireFullRewrite);
     }

--- a/OfficeIMO.Pdf/Core/PdfDocument.Operations.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocument.Operations.cs
@@ -28,6 +28,7 @@ public sealed partial class PdfDocument {
     /// </summary>
     public PdfAnalysisReport Analyze(PdfComplianceProfile complianceProfile = PdfComplianceProfile.None) {
         var snapshot = GetReadSnapshot();
+        snapshot.Document.DemandContentExtraction("analysis report");
         PdfDocumentInfo info = PdfInspector.Inspect(snapshot.Bytes, snapshot.Document);
         PdfDocumentPreflight preflight = PdfInspector.Preflight(
             snapshot.Bytes,
@@ -164,6 +165,7 @@ public sealed partial class PdfDocument {
     /// </summary>
     public PdfDiagnosticReport Diagnostics(PdfReadOptions? options = null) {
         var snapshot = GetReadSnapshot(options);
+        snapshot.Document.DemandContentExtraction("diagnostic report");
         PdfDocumentInfo info = PdfInspector.Inspect(snapshot.Bytes, snapshot.Document);
         PdfDocumentPreflight preflight = PdfInspector.Preflight(
             snapshot.Bytes,

--- a/OfficeIMO.Pdf/Core/PdfDocument.Proof.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocument.Proof.cs
@@ -23,14 +23,19 @@ public sealed partial class PdfDocument {
     /// </summary>
     public PdfRewritePreservationReport AssessRewritePreservation(PdfDocument rewrittenDocument, PdfRewritePreservationOptions? options = null) {
         Guard.NotNull(rewrittenDocument, nameof(rewrittenDocument));
-        return AssessRewritePreservation(rewrittenDocument.GetBytesForOperation(), options);
+        return PdfRewritePreservation.Assess(
+            GetBytesForOperation(),
+            rewrittenDocument.GetBytesForOperation(),
+            options,
+            ReadOptions,
+            rewrittenDocument.ReadOptions);
     }
 
     /// <summary>
     /// Compares this PDF with rewritten PDF bytes and reports whether important document signals were preserved.
     /// </summary>
     public PdfRewritePreservationReport AssessRewritePreservation(byte[] rewrittenPdf, PdfRewritePreservationOptions? options = null) {
-        return PdfRewritePreservation.Assess(GetBytesForOperation(), rewrittenPdf, options);
+        return PdfRewritePreservation.Assess(GetBytesForOperation(), rewrittenPdf, options, ReadOptions, rewrittenReadOptions: null);
     }
 
     /// <summary>
@@ -53,14 +58,19 @@ public sealed partial class PdfDocument {
     /// </summary>
     public PdfRewritePreservationReport AssertRewritePreserved(PdfDocument rewrittenDocument, PdfRewritePreservationOptions? options = null) {
         Guard.NotNull(rewrittenDocument, nameof(rewrittenDocument));
-        return AssertRewritePreserved(rewrittenDocument.GetBytesForOperation(), options);
+        return PdfRewritePreservation.AssertPreserved(
+            GetBytesForOperation(),
+            rewrittenDocument.GetBytesForOperation(),
+            options,
+            ReadOptions,
+            rewrittenDocument.ReadOptions);
     }
 
     /// <summary>
     /// Compares this PDF with rewritten PDF bytes and throws when important document signals were not preserved.
     /// </summary>
     public PdfRewritePreservationReport AssertRewritePreserved(byte[] rewrittenPdf, PdfRewritePreservationOptions? options = null) {
-        return PdfRewritePreservation.AssertPreserved(GetBytesForOperation(), rewrittenPdf, options);
+        return PdfRewritePreservation.AssertPreserved(GetBytesForOperation(), rewrittenPdf, options, ReadOptions, rewrittenReadOptions: null);
     }
 
     /// <summary>

--- a/OfficeIMO.Pdf/Core/PdfDocumentForms.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocumentForms.cs
@@ -14,14 +14,14 @@ public sealed class PdfDocumentForms {
     /// Creates a new PDF with simple form fields filled.
     /// </summary>
     public PdfDocument Fill(IReadOnlyDictionary<string, string> fieldValues) {
-        return _document.ApplyMutation(input => PdfFormFiller.FillFields(input, fieldValues));
+        return FillWithReadOptions(fieldValues, formOptions: null, _document.ReadOptions);
     }
 
     /// <summary>
     /// Creates a new PDF with simple form fields filled.
     /// </summary>
     public PdfDocument Fill(IReadOnlyDictionary<string, string> fieldValues, PdfFormFillerOptions formOptions) {
-        return _document.ApplyMutation(input => PdfFormFiller.FillFields(input, fieldValues, formOptions));
+        return FillWithReadOptions(fieldValues, formOptions, _document.ReadOptions);
     }
 
     /// <summary>
@@ -35,7 +35,7 @@ public sealed class PdfDocumentForms {
             PdfMutationOperation.FillFormFields,
             mode => mode == PdfMutationExecutionMode.AppendOnly
                 ? AppendRevisionWithReadOptions(fieldValues, CreateIncrementalOptions(formOptions: null), options ?? _document.ReadOptions)
-                : Fill(fieldValues),
+                : FillWithReadOptions(fieldValues, formOptions: null, options ?? _document.ReadOptions),
             fieldValues.Keys,
             options);
     }
@@ -52,7 +52,7 @@ public sealed class PdfDocumentForms {
             PdfMutationOperation.FillFormFields,
             mode => mode == PdfMutationExecutionMode.AppendOnly
                 ? AppendRevisionWithReadOptions(fieldValues, CreateIncrementalOptions(formOptions), readOptions ?? _document.ReadOptions)
-                : Fill(fieldValues, formOptions),
+                : FillWithReadOptions(fieldValues, formOptions, readOptions ?? _document.ReadOptions),
             fieldValues.Keys,
             readOptions);
     }
@@ -61,14 +61,14 @@ public sealed class PdfDocumentForms {
     /// Creates a new PDF with simple form fields filled, including multi-value fields.
     /// </summary>
     public PdfDocument Fill(IReadOnlyDictionary<string, PdfFormFieldValue> fieldValues) {
-        return _document.ApplyMutation(input => PdfFormFiller.FillFields(input, fieldValues));
+        return FillWithReadOptions(fieldValues, formOptions: null, _document.ReadOptions);
     }
 
     /// <summary>
     /// Creates a new PDF with simple form fields filled, including multi-value fields.
     /// </summary>
     public PdfDocument Fill(IReadOnlyDictionary<string, PdfFormFieldValue> fieldValues, PdfFormFillerOptions formOptions) {
-        return _document.ApplyMutation(input => PdfFormFiller.FillFields(input, fieldValues, formOptions));
+        return FillWithReadOptions(fieldValues, formOptions, _document.ReadOptions);
     }
 
     /// <summary>
@@ -82,7 +82,7 @@ public sealed class PdfDocumentForms {
             PdfMutationOperation.FillFormFields,
             mode => mode == PdfMutationExecutionMode.AppendOnly
                 ? AppendRevisionWithReadOptions(fieldValues, CreateIncrementalOptions(formOptions: null), options ?? _document.ReadOptions)
-                : Fill(fieldValues),
+                : FillWithReadOptions(fieldValues, formOptions: null, options ?? _document.ReadOptions),
             fieldValues.Keys,
             options);
     }
@@ -99,7 +99,7 @@ public sealed class PdfDocumentForms {
             PdfMutationOperation.FillFormFields,
             mode => mode == PdfMutationExecutionMode.AppendOnly
                 ? AppendRevisionWithReadOptions(fieldValues, CreateIncrementalOptions(formOptions), readOptions ?? _document.ReadOptions)
-                : Fill(fieldValues, formOptions),
+                : FillWithReadOptions(fieldValues, formOptions, readOptions ?? _document.ReadOptions),
             fieldValues.Keys,
             readOptions);
     }
@@ -108,14 +108,14 @@ public sealed class PdfDocumentForms {
     /// Appends a simple AcroForm field-value revision without rewriting the existing PDF bytes.
     /// </summary>
     public PdfDocument AppendRevision(IReadOnlyDictionary<string, string> fieldValues, bool keepNeedAppearances = true) {
-        return _document.ApplyMutation(input => PdfIncrementalUpdater.UpdateFormFields(input, fieldValues, keepNeedAppearances));
+        return AppendRevisionWithReadOptions(fieldValues, CreateIncrementalOptions(keepNeedAppearances), _document.ReadOptions);
     }
 
     /// <summary>
     /// Appends a simple AcroForm field-value revision without rewriting the existing PDF bytes.
     /// </summary>
     public PdfDocument AppendRevision(IReadOnlyDictionary<string, string> fieldValues, PdfIncrementalFormFieldUpdateOptions? formOptions) {
-        return _document.ApplyMutation(input => PdfIncrementalUpdater.UpdateFormFields(input, fieldValues, formOptions));
+        return AppendRevisionWithReadOptions(fieldValues, formOptions, _document.ReadOptions);
     }
 
     /// <summary>
@@ -152,14 +152,14 @@ public sealed class PdfDocumentForms {
     /// Appends a simple AcroForm field-value revision, including multi-value fields, without rewriting the existing PDF bytes.
     /// </summary>
     public PdfDocument AppendRevision(IReadOnlyDictionary<string, PdfFormFieldValue> fieldValues, bool keepNeedAppearances = true) {
-        return _document.ApplyMutation(input => PdfIncrementalUpdater.UpdateFormFields(input, fieldValues, keepNeedAppearances));
+        return AppendRevisionWithReadOptions(fieldValues, CreateIncrementalOptions(keepNeedAppearances), _document.ReadOptions);
     }
 
     /// <summary>
     /// Appends a simple AcroForm field-value revision, including multi-value fields, without rewriting the existing PDF bytes.
     /// </summary>
     public PdfDocument AppendRevision(IReadOnlyDictionary<string, PdfFormFieldValue> fieldValues, PdfIncrementalFormFieldUpdateOptions? formOptions) {
-        return _document.ApplyMutation(input => PdfIncrementalUpdater.UpdateFormFields(input, fieldValues, formOptions));
+        return AppendRevisionWithReadOptions(fieldValues, formOptions, _document.ReadOptions);
     }
 
     /// <summary>
@@ -196,94 +196,94 @@ public sealed class PdfDocumentForms {
     /// Creates a new PDF with simple form fields flattened.
     /// </summary>
     public PdfDocument Flatten() {
-        return _document.ApplyMutation(input => PdfFormFiller.FlattenFields(input));
+        return FlattenWithReadOptions(formOptions: null, _document.ReadOptions);
     }
 
     /// <summary>
     /// Creates a new PDF with simple form fields flattened.
     /// </summary>
     public PdfDocument Flatten(PdfFormFillerOptions formOptions) {
-        return _document.ApplyMutation(input => PdfFormFiller.FlattenFields(input, formOptions));
+        return FlattenWithReadOptions(formOptions, _document.ReadOptions);
     }
 
     /// <summary>Creates a new PDF with only the named simple form fields flattened.</summary>
     public PdfDocument Flatten(params string[] fieldNames) {
-        return _document.ApplyMutation(input => PdfFormFiller.FlattenFields(input, fieldNames));
+        return FlattenWithReadOptions(fieldNames, formOptions: null, _document.ReadOptions);
     }
 
     /// <summary>Creates a new PDF with only the named simple form fields flattened.</summary>
     public PdfDocument Flatten(IReadOnlyCollection<string> fieldNames, PdfFormFillerOptions formOptions) {
-        return _document.ApplyMutation(input => PdfFormFiller.FlattenFields(input, fieldNames, formOptions));
+        return FlattenWithReadOptions(fieldNames, formOptions, _document.ReadOptions);
     }
 
     /// <summary>
     /// Attempts to create a new PDF with simple form fields flattened, returning diagnostics when blocked or failed.
     /// </summary>
     public PdfOperationResult<PdfDocument> TryFlatten(PdfReadOptions? options = null) {
-        return _document.TryMutationOperation("Flatten form fields", PdfPreflightCapability.FlattenSimpleFormFields, PdfMutationOperation.FlattenFormFields, Flatten, options);
+        return _document.TryMutationOperation("Flatten form fields", PdfPreflightCapability.FlattenSimpleFormFields, PdfMutationOperation.FlattenFormFields, () => FlattenWithReadOptions(formOptions: null, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
     /// Attempts to create a new PDF with simple form fields flattened, returning diagnostics when blocked or failed.
     /// </summary>
     public PdfOperationResult<PdfDocument> TryFlatten(PdfFormFillerOptions formOptions, PdfReadOptions? readOptions) {
-        return _document.TryMutationOperation("Flatten form fields", PdfPreflightCapability.FlattenSimpleFormFields, PdfMutationOperation.FlattenFormFields, () => Flatten(formOptions), readOptions);
+        return _document.TryMutationOperation("Flatten form fields", PdfPreflightCapability.FlattenSimpleFormFields, PdfMutationOperation.FlattenFormFields, () => FlattenWithReadOptions(formOptions, readOptions ?? _document.ReadOptions), readOptions);
     }
 
     /// <summary>
     /// Creates a new PDF with simple form fields filled and flattened.
     /// </summary>
     public PdfDocument FillAndFlatten(IReadOnlyDictionary<string, string> fieldValues) {
-        return _document.ApplyMutation(input => PdfFormFiller.FillAndFlattenFields(input, fieldValues));
+        return FillAndFlattenWithReadOptions(fieldValues, formOptions: null, _document.ReadOptions);
     }
 
     /// <summary>
     /// Creates a new PDF with simple form fields filled and flattened.
     /// </summary>
     public PdfDocument FillAndFlatten(IReadOnlyDictionary<string, string> fieldValues, PdfFormFillerOptions formOptions) {
-        return _document.ApplyMutation(input => PdfFormFiller.FillAndFlattenFields(input, fieldValues, formOptions));
+        return FillAndFlattenWithReadOptions(fieldValues, formOptions, _document.ReadOptions);
     }
 
     /// <summary>
     /// Attempts to create a new PDF with simple form fields filled and flattened, returning diagnostics when blocked or failed.
     /// </summary>
     public PdfOperationResult<PdfDocument> TryFillAndFlatten(IReadOnlyDictionary<string, string> fieldValues, PdfReadOptions? options = null) {
-        return _document.TryMutationOperation("Fill and flatten form fields", PdfPreflightCapability.FillAndFlattenSimpleFormFields, PdfMutationOperation.FillAndFlattenFormFields, () => FillAndFlatten(fieldValues), options);
+        return _document.TryMutationOperation("Fill and flatten form fields", PdfPreflightCapability.FillAndFlattenSimpleFormFields, PdfMutationOperation.FillAndFlattenFormFields, () => FillAndFlattenWithReadOptions(fieldValues, formOptions: null, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
     /// Attempts to create a new PDF with simple form fields filled and flattened, returning diagnostics when blocked or failed.
     /// </summary>
     public PdfOperationResult<PdfDocument> TryFillAndFlatten(IReadOnlyDictionary<string, string> fieldValues, PdfFormFillerOptions formOptions, PdfReadOptions? readOptions) {
-        return _document.TryMutationOperation("Fill and flatten form fields", PdfPreflightCapability.FillAndFlattenSimpleFormFields, PdfMutationOperation.FillAndFlattenFormFields, () => FillAndFlatten(fieldValues, formOptions), readOptions);
+        return _document.TryMutationOperation("Fill and flatten form fields", PdfPreflightCapability.FillAndFlattenSimpleFormFields, PdfMutationOperation.FillAndFlattenFormFields, () => FillAndFlattenWithReadOptions(fieldValues, formOptions, readOptions ?? _document.ReadOptions), readOptions);
     }
 
     /// <summary>
     /// Creates a new PDF with simple form fields filled and flattened, including multi-value fields.
     /// </summary>
     public PdfDocument FillAndFlatten(IReadOnlyDictionary<string, PdfFormFieldValue> fieldValues) {
-        return _document.ApplyMutation(input => PdfFormFiller.FillAndFlattenFields(input, fieldValues));
+        return FillAndFlattenWithReadOptions(fieldValues, formOptions: null, _document.ReadOptions);
     }
 
     /// <summary>
     /// Creates a new PDF with simple form fields filled and flattened, including multi-value fields.
     /// </summary>
     public PdfDocument FillAndFlatten(IReadOnlyDictionary<string, PdfFormFieldValue> fieldValues, PdfFormFillerOptions formOptions) {
-        return _document.ApplyMutation(input => PdfFormFiller.FillAndFlattenFields(input, fieldValues, formOptions));
+        return FillAndFlattenWithReadOptions(fieldValues, formOptions, _document.ReadOptions);
     }
 
     /// <summary>
     /// Attempts to create a new PDF with simple form fields filled and flattened, including multi-value fields, returning diagnostics when blocked or failed.
     /// </summary>
     public PdfOperationResult<PdfDocument> TryFillAndFlatten(IReadOnlyDictionary<string, PdfFormFieldValue> fieldValues, PdfReadOptions? options = null) {
-        return _document.TryMutationOperation("Fill and flatten form fields", PdfPreflightCapability.FillAndFlattenSimpleFormFields, PdfMutationOperation.FillAndFlattenFormFields, () => FillAndFlatten(fieldValues), options);
+        return _document.TryMutationOperation("Fill and flatten form fields", PdfPreflightCapability.FillAndFlattenSimpleFormFields, PdfMutationOperation.FillAndFlattenFormFields, () => FillAndFlattenWithReadOptions(fieldValues, formOptions: null, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
     /// Attempts to create a new PDF with simple form fields filled and flattened, including multi-value fields, returning diagnostics when blocked or failed.
     /// </summary>
     public PdfOperationResult<PdfDocument> TryFillAndFlatten(IReadOnlyDictionary<string, PdfFormFieldValue> fieldValues, PdfFormFillerOptions formOptions, PdfReadOptions? readOptions) {
-        return _document.TryMutationOperation("Fill and flatten form fields", PdfPreflightCapability.FillAndFlattenSimpleFormFields, PdfMutationOperation.FillAndFlattenFormFields, () => FillAndFlatten(fieldValues, formOptions), readOptions);
+        return _document.TryMutationOperation("Fill and flatten form fields", PdfPreflightCapability.FillAndFlattenSimpleFormFields, PdfMutationOperation.FillAndFlattenFormFields, () => FillAndFlattenWithReadOptions(fieldValues, formOptions, readOptions ?? _document.ReadOptions), readOptions);
     }
 
     /// <summary>Exports readable field values as a typed data set.</summary>
@@ -293,10 +293,10 @@ public sealed class PdfDocumentForms {
     public string ExportXfdf() => ExportData().ToXfdf();
 
     /// <summary>Imports a typed data set through the validated form filler.</summary>
-    public PdfDocument ImportData(PdfFormDataSet data, PdfFormFillerOptions? options = null) => _document.ApplyMutation(input => PdfFormData.Import(input, data, options));
+    public PdfDocument ImportData(PdfFormDataSet data, PdfFormFillerOptions? options = null) => _document.ApplyMutation(input => PdfFormData.Import(input, data, options, _document.ReadOptions));
 
     /// <summary>Imports XFDF through the validated form filler.</summary>
-    public PdfDocument ImportXfdf(string xfdf, PdfFormFillerOptions? options = null) => _document.ApplyMutation(input => PdfFormData.ImportXfdf(input, xfdf, options));
+    public PdfDocument ImportXfdf(string xfdf, PdfFormFillerOptions? options = null) => _document.ApplyMutation(input => PdfFormData.ImportXfdf(input, xfdf, options, _document.ReadOptions));
 
     /// <summary>Transactionally creates or edits fields, widgets, ordering, and selective flattening.</summary>
     public PdfAcroFormEditResult Edit(Action<PdfAcroFormEditSession> edit) => PdfAcroFormEditor.Edit(_document.GetBytesForOperation(), edit, _document.ReadOptions);
@@ -317,11 +317,59 @@ public sealed class PdfDocumentForms {
         GenerateAppearanceStreams = !keepNeedAppearances
     };
 
+    private PdfDocument FillWithReadOptions(
+        IReadOnlyDictionary<string, string> fieldValues,
+        PdfFormFillerOptions? formOptions,
+        PdfReadOptions? readOptions) => _document.ApplyMutation(
+            input => PdfFormFiller.FillFields(input, fieldValues, formOptions, readOptions),
+            readOptions,
+            operationName: "Fill");
+
+    private PdfDocument FillWithReadOptions(
+        IReadOnlyDictionary<string, PdfFormFieldValue> fieldValues,
+        PdfFormFillerOptions? formOptions,
+        PdfReadOptions? readOptions) => _document.ApplyMutation(
+            input => PdfFormFiller.FillFields(input, fieldValues, formOptions, readOptions),
+            readOptions,
+            operationName: "Fill");
+
+    private PdfDocument FlattenWithReadOptions(
+        PdfFormFillerOptions? formOptions,
+        PdfReadOptions? readOptions) => _document.ApplyMutation(
+            input => PdfFormFiller.FlattenFields(input, formOptions, readOptions),
+            readOptions,
+            operationName: "Flatten");
+
+    private PdfDocument FlattenWithReadOptions(
+        IReadOnlyCollection<string> fieldNames,
+        PdfFormFillerOptions? formOptions,
+        PdfReadOptions? readOptions) => _document.ApplyMutation(
+            input => PdfFormFiller.FlattenFields(input, fieldNames, formOptions, readOptions),
+            readOptions,
+            operationName: "Flatten");
+
+    private PdfDocument FillAndFlattenWithReadOptions(
+        IReadOnlyDictionary<string, string> fieldValues,
+        PdfFormFillerOptions? formOptions,
+        PdfReadOptions? readOptions) => _document.ApplyMutation(
+            input => PdfFormFiller.FillAndFlattenFields(input, fieldValues, formOptions, readOptions),
+            readOptions,
+            operationName: "FillAndFlatten");
+
+    private PdfDocument FillAndFlattenWithReadOptions(
+        IReadOnlyDictionary<string, PdfFormFieldValue> fieldValues,
+        PdfFormFillerOptions? formOptions,
+        PdfReadOptions? readOptions) => _document.ApplyMutation(
+            input => PdfFormFiller.FillAndFlattenFields(input, fieldValues, formOptions, readOptions),
+            readOptions,
+            operationName: "FillAndFlatten");
+
     private PdfDocument AppendRevisionWithReadOptions(
         IReadOnlyDictionary<string, string> fieldValues,
         PdfIncrementalFormFieldUpdateOptions? formOptions,
         PdfReadOptions? readOptions) => _document.ApplyMutation(
             input => PdfIncrementalUpdater.UpdateFormFields(input, fieldValues, formOptions, readOptions),
+            readOptions,
             operationName: "AppendRevision");
 
     private PdfDocument AppendRevisionWithReadOptions(
@@ -329,5 +377,6 @@ public sealed class PdfDocumentForms {
         PdfIncrementalFormFieldUpdateOptions? formOptions,
         PdfReadOptions? readOptions) => _document.ApplyMutation(
             input => PdfIncrementalUpdater.UpdateFormFields(input, fieldValues, formOptions, readOptions),
+            readOptions,
             operationName: "AppendRevision");
 }

--- a/OfficeIMO.Pdf/Core/PdfDocumentPages.Import.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocumentPages.Import.cs
@@ -6,7 +6,9 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfDocument Append(PdfDocument sourceDocument, PdfPageImportOptions? importOptions = null) {
         Guard.NotNull(sourceDocument, nameof(sourceDocument));
-        return Append(sourceDocument.GetBytesForOperation(), importOptions);
+        return Append(
+            sourceDocument.GetBytesForOperation(),
+            ResolveSourceImportOptions(importOptions, sourceDocument.ReadOptions));
     }
 
     /// <summary>
@@ -14,7 +16,10 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfDocument Append(PdfDocument sourceDocument, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions = null) {
         Guard.NotNull(sourceDocument, nameof(sourceDocument));
-        return Append(sourceDocument.GetBytesForOperation(), sourceSelection, importOptions);
+        return Append(
+            sourceDocument.GetBytesForOperation(),
+            sourceSelection,
+            ResolveSourceImportOptions(importOptions, sourceDocument.ReadOptions));
     }
 
     /// <summary>
@@ -36,7 +41,7 @@ public sealed partial class PdfDocumentPages {
 
     private PdfDocument Append(byte[] sourcePdf, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions, PdfReadOptions targetReadOptions) {
         Guard.NotNull(sourceSelection, nameof(sourceSelection));
-        return Import(sourcePdf, ImportPlacement.Append, insertBeforePageNumber: null, GetSelectedSourcePages(sourcePdf, sourceSelection), importOptions, targetReadOptions);
+        return Import(sourcePdf, ImportPlacement.Append, insertBeforePageNumber: null, GetSelectedSourcePages(sourcePdf, sourceSelection, importOptions?.SourceReadOptions), importOptions, targetReadOptions);
     }
 
     /// <summary>
@@ -74,7 +79,8 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryAppend(PdfDocument sourceDocument, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourceDocument, nameof(sourceDocument));
-        return _document.TryMutationOperation("Append pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Append(sourceDocument.GetBytesForOperation(), importOptions, options ?? _document.ReadOptions), options);
+        PdfPageImportOptions effectiveImportOptions = ResolveSourceImportOptions(importOptions, sourceDocument.ReadOptions);
+        return _document.TryMutationOperation("Append pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Append(sourceDocument.GetBytesForOperation(), effectiveImportOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -83,7 +89,8 @@ public sealed partial class PdfDocumentPages {
     public PdfOperationResult<PdfDocument> TryAppend(PdfDocument sourceDocument, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourceDocument, nameof(sourceDocument));
         Guard.NotNull(sourceSelection, nameof(sourceSelection));
-        return _document.TryMutationOperation("Append pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Append(sourceDocument.GetBytesForOperation(), sourceSelection, importOptions, options ?? _document.ReadOptions), options);
+        PdfPageImportOptions effectiveImportOptions = ResolveSourceImportOptions(importOptions, sourceDocument.ReadOptions);
+        return _document.TryMutationOperation("Append pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Append(sourceDocument.GetBytesForOperation(), sourceSelection, effectiveImportOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -142,7 +149,9 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfDocument Prepend(PdfDocument sourceDocument, PdfPageImportOptions? importOptions = null) {
         Guard.NotNull(sourceDocument, nameof(sourceDocument));
-        return Prepend(sourceDocument.GetBytesForOperation(), importOptions);
+        return Prepend(
+            sourceDocument.GetBytesForOperation(),
+            ResolveSourceImportOptions(importOptions, sourceDocument.ReadOptions));
     }
 
     /// <summary>
@@ -150,7 +159,10 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfDocument Prepend(PdfDocument sourceDocument, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions = null) {
         Guard.NotNull(sourceDocument, nameof(sourceDocument));
-        return Prepend(sourceDocument.GetBytesForOperation(), sourceSelection, importOptions);
+        return Prepend(
+            sourceDocument.GetBytesForOperation(),
+            sourceSelection,
+            ResolveSourceImportOptions(importOptions, sourceDocument.ReadOptions));
     }
 
     /// <summary>
@@ -172,7 +184,7 @@ public sealed partial class PdfDocumentPages {
 
     private PdfDocument Prepend(byte[] sourcePdf, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions, PdfReadOptions targetReadOptions) {
         Guard.NotNull(sourceSelection, nameof(sourceSelection));
-        return Import(sourcePdf, ImportPlacement.Prepend, insertBeforePageNumber: null, GetSelectedSourcePages(sourcePdf, sourceSelection), importOptions, targetReadOptions);
+        return Import(sourcePdf, ImportPlacement.Prepend, insertBeforePageNumber: null, GetSelectedSourcePages(sourcePdf, sourceSelection, importOptions?.SourceReadOptions), importOptions, targetReadOptions);
     }
 
     /// <summary>
@@ -210,7 +222,8 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryPrepend(PdfDocument sourceDocument, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourceDocument, nameof(sourceDocument));
-        return _document.TryMutationOperation("Prepend pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Prepend(sourceDocument.GetBytesForOperation(), importOptions, options ?? _document.ReadOptions), options);
+        PdfPageImportOptions effectiveImportOptions = ResolveSourceImportOptions(importOptions, sourceDocument.ReadOptions);
+        return _document.TryMutationOperation("Prepend pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Prepend(sourceDocument.GetBytesForOperation(), effectiveImportOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -219,7 +232,8 @@ public sealed partial class PdfDocumentPages {
     public PdfOperationResult<PdfDocument> TryPrepend(PdfDocument sourceDocument, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourceDocument, nameof(sourceDocument));
         Guard.NotNull(sourceSelection, nameof(sourceSelection));
-        return _document.TryMutationOperation("Prepend pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Prepend(sourceDocument.GetBytesForOperation(), sourceSelection, importOptions, options ?? _document.ReadOptions), options);
+        PdfPageImportOptions effectiveImportOptions = ResolveSourceImportOptions(importOptions, sourceDocument.ReadOptions);
+        return _document.TryMutationOperation("Prepend pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Prepend(sourceDocument.GetBytesForOperation(), sourceSelection, effectiveImportOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -279,7 +293,10 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfDocument Insert(int insertBeforePageNumber, PdfDocument sourceDocument, PdfPageImportOptions? importOptions = null) {
         Guard.NotNull(sourceDocument, nameof(sourceDocument));
-        return Insert(insertBeforePageNumber, sourceDocument.GetBytesForOperation(), importOptions);
+        return Insert(
+            insertBeforePageNumber,
+            sourceDocument.GetBytesForOperation(),
+            ResolveSourceImportOptions(importOptions, sourceDocument.ReadOptions));
     }
 
     /// <summary>
@@ -288,7 +305,11 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfDocument Insert(int insertBeforePageNumber, PdfDocument sourceDocument, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions = null) {
         Guard.NotNull(sourceDocument, nameof(sourceDocument));
-        return Insert(insertBeforePageNumber, sourceDocument.GetBytesForOperation(), sourceSelection, importOptions);
+        return Insert(
+            insertBeforePageNumber,
+            sourceDocument.GetBytesForOperation(),
+            sourceSelection,
+            ResolveSourceImportOptions(importOptions, sourceDocument.ReadOptions));
     }
 
     /// <summary>
@@ -312,7 +333,7 @@ public sealed partial class PdfDocumentPages {
 
     private PdfDocument Insert(int insertBeforePageNumber, byte[] sourcePdf, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions, PdfReadOptions targetReadOptions) {
         Guard.NotNull(sourceSelection, nameof(sourceSelection));
-        return Import(sourcePdf, ImportPlacement.Insert, insertBeforePageNumber, GetSelectedSourcePages(sourcePdf, sourceSelection), importOptions, targetReadOptions);
+        return Import(sourcePdf, ImportPlacement.Insert, insertBeforePageNumber, GetSelectedSourcePages(sourcePdf, sourceSelection, importOptions?.SourceReadOptions), importOptions, targetReadOptions);
     }
 
     /// <summary>
@@ -354,7 +375,8 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryInsert(int insertBeforePageNumber, PdfDocument sourceDocument, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourceDocument, nameof(sourceDocument));
-        return _document.TryMutationOperation("Insert pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Insert(insertBeforePageNumber, sourceDocument.GetBytesForOperation(), importOptions, options ?? _document.ReadOptions), options);
+        PdfPageImportOptions effectiveImportOptions = ResolveSourceImportOptions(importOptions, sourceDocument.ReadOptions);
+        return _document.TryMutationOperation("Insert pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Insert(insertBeforePageNumber, sourceDocument.GetBytesForOperation(), effectiveImportOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -363,7 +385,8 @@ public sealed partial class PdfDocumentPages {
     public PdfOperationResult<PdfDocument> TryInsert(int insertBeforePageNumber, PdfDocument sourceDocument, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourceDocument, nameof(sourceDocument));
         Guard.NotNull(sourceSelection, nameof(sourceSelection));
-        return _document.TryMutationOperation("Insert pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Insert(insertBeforePageNumber, sourceDocument.GetBytesForOperation(), sourceSelection, importOptions, options ?? _document.ReadOptions), options);
+        PdfPageImportOptions effectiveImportOptions = ResolveSourceImportOptions(importOptions, sourceDocument.ReadOptions);
+        return _document.TryMutationOperation("Insert pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Insert(insertBeforePageNumber, sourceDocument.GetBytesForOperation(), sourceSelection, effectiveImportOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -437,11 +460,19 @@ public sealed partial class PdfDocumentPages {
             operationName: placement.ToString());
     }
 
-    private static int[] GetSelectedSourcePages(byte[] sourcePdf, PdfPageSelection sourceSelection) {
+    private static int[] GetSelectedSourcePages(byte[] sourcePdf, PdfPageSelection sourceSelection, PdfReadOptions? sourceReadOptions) {
         Guard.NotNull(sourcePdf, nameof(sourcePdf));
         Guard.NotNull(sourceSelection, nameof(sourceSelection));
-        int pageCount = PdfInspector.Inspect(sourcePdf).PageCount;
+        int pageCount = PdfInspector.Inspect(sourcePdf, sourceReadOptions).PageCount;
         return sourceSelection.ToPageNumbers(pageCount, nameof(sourceSelection));
+    }
+
+    private static PdfPageImportOptions ResolveSourceImportOptions(PdfPageImportOptions? importOptions, PdfReadOptions sourceReadOptions) {
+        Guard.NotNull(sourceReadOptions, nameof(sourceReadOptions));
+        return new PdfPageImportOptions {
+            FlattenVisualAnnotations = importOptions?.FlattenVisualAnnotations ?? false,
+            SourceReadOptions = importOptions?.SourceReadOptions ?? sourceReadOptions
+        };
     }
 
     private static byte[] ReadSourceStream(Stream sourceStream) {

--- a/OfficeIMO.Pdf/Core/PdfDocumentPages.Import.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocumentPages.Import.cs
@@ -21,15 +21,22 @@ public sealed partial class PdfDocumentPages {
     /// Appends all pages from source PDF bytes to this document.
     /// </summary>
     public PdfDocument Append(byte[] sourcePdf, PdfPageImportOptions? importOptions = null) {
-        return Import(sourcePdf, ImportPlacement.Append, insertBeforePageNumber: null, sourcePageNumbers: Array.Empty<int>(), importOptions);
+        return Append(sourcePdf, importOptions, _document.ReadOptions);
     }
+
+    private PdfDocument Append(byte[] sourcePdf, PdfPageImportOptions? importOptions, PdfReadOptions targetReadOptions) =>
+        Import(sourcePdf, ImportPlacement.Append, insertBeforePageNumber: null, sourcePageNumbers: Array.Empty<int>(), importOptions, targetReadOptions);
 
     /// <summary>
     /// Appends selected one-based pages from source PDF bytes to this document.
     /// </summary>
     public PdfDocument Append(byte[] sourcePdf, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions = null) {
+        return Append(sourcePdf, sourceSelection, importOptions, _document.ReadOptions);
+    }
+
+    private PdfDocument Append(byte[] sourcePdf, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions, PdfReadOptions targetReadOptions) {
         Guard.NotNull(sourceSelection, nameof(sourceSelection));
-        return Import(sourcePdf, ImportPlacement.Append, insertBeforePageNumber: null, GetSelectedSourcePages(sourcePdf, sourceSelection), importOptions);
+        return Import(sourcePdf, ImportPlacement.Append, insertBeforePageNumber: null, GetSelectedSourcePages(sourcePdf, sourceSelection), importOptions, targetReadOptions);
     }
 
     /// <summary>
@@ -67,7 +74,7 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryAppend(PdfDocument sourceDocument, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourceDocument, nameof(sourceDocument));
-        return _document.TryMutationOperation("Append pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Append(sourceDocument, importOptions), options);
+        return _document.TryMutationOperation("Append pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Append(sourceDocument.GetBytesForOperation(), importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -76,7 +83,7 @@ public sealed partial class PdfDocumentPages {
     public PdfOperationResult<PdfDocument> TryAppend(PdfDocument sourceDocument, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourceDocument, nameof(sourceDocument));
         Guard.NotNull(sourceSelection, nameof(sourceSelection));
-        return _document.TryMutationOperation("Append pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Append(sourceDocument, sourceSelection, importOptions), options);
+        return _document.TryMutationOperation("Append pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Append(sourceDocument.GetBytesForOperation(), sourceSelection, importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -84,7 +91,7 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryAppend(byte[] sourcePdf, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourcePdf, nameof(sourcePdf));
-        return _document.TryMutationOperation("Append pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Append(sourcePdf, importOptions), options);
+        return _document.TryMutationOperation("Append pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Append(sourcePdf, importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -93,7 +100,7 @@ public sealed partial class PdfDocumentPages {
     public PdfOperationResult<PdfDocument> TryAppend(byte[] sourcePdf, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourcePdf, nameof(sourcePdf));
         Guard.NotNull(sourceSelection, nameof(sourceSelection));
-        return _document.TryMutationOperation("Append pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Append(sourcePdf, sourceSelection, importOptions), options);
+        return _document.TryMutationOperation("Append pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Append(sourcePdf, sourceSelection, importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -101,7 +108,7 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryAppend(Stream sourceStream, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourceStream, nameof(sourceStream));
-        return _document.TryMutationOperation("Append pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Append(sourceStream, importOptions), options);
+        return _document.TryMutationOperation("Append pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Append(ReadSourceStream(sourceStream), importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -110,7 +117,7 @@ public sealed partial class PdfDocumentPages {
     public PdfOperationResult<PdfDocument> TryAppend(Stream sourceStream, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourceStream, nameof(sourceStream));
         Guard.NotNull(sourceSelection, nameof(sourceSelection));
-        return _document.TryMutationOperation("Append pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Append(sourceStream, sourceSelection, importOptions), options);
+        return _document.TryMutationOperation("Append pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Append(ReadSourceStream(sourceStream), sourceSelection, importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -118,7 +125,7 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryAppend(string sourcePath, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNullOrWhiteSpace(sourcePath, nameof(sourcePath));
-        return _document.TryMutationOperation("Append pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Append(sourcePath, importOptions), options);
+        return _document.TryMutationOperation("Append pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Append(File.ReadAllBytes(sourcePath), importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -127,7 +134,7 @@ public sealed partial class PdfDocumentPages {
     public PdfOperationResult<PdfDocument> TryAppend(string sourcePath, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNullOrWhiteSpace(sourcePath, nameof(sourcePath));
         Guard.NotNull(sourceSelection, nameof(sourceSelection));
-        return _document.TryMutationOperation("Append pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Append(sourcePath, sourceSelection, importOptions), options);
+        return _document.TryMutationOperation("Append pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Append(File.ReadAllBytes(sourcePath), sourceSelection, importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -150,15 +157,22 @@ public sealed partial class PdfDocumentPages {
     /// Prepends all pages from source PDF bytes before this document.
     /// </summary>
     public PdfDocument Prepend(byte[] sourcePdf, PdfPageImportOptions? importOptions = null) {
-        return Import(sourcePdf, ImportPlacement.Prepend, insertBeforePageNumber: null, sourcePageNumbers: Array.Empty<int>(), importOptions);
+        return Prepend(sourcePdf, importOptions, _document.ReadOptions);
     }
+
+    private PdfDocument Prepend(byte[] sourcePdf, PdfPageImportOptions? importOptions, PdfReadOptions targetReadOptions) =>
+        Import(sourcePdf, ImportPlacement.Prepend, insertBeforePageNumber: null, sourcePageNumbers: Array.Empty<int>(), importOptions, targetReadOptions);
 
     /// <summary>
     /// Prepends selected one-based pages from source PDF bytes before this document.
     /// </summary>
     public PdfDocument Prepend(byte[] sourcePdf, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions = null) {
+        return Prepend(sourcePdf, sourceSelection, importOptions, _document.ReadOptions);
+    }
+
+    private PdfDocument Prepend(byte[] sourcePdf, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions, PdfReadOptions targetReadOptions) {
         Guard.NotNull(sourceSelection, nameof(sourceSelection));
-        return Import(sourcePdf, ImportPlacement.Prepend, insertBeforePageNumber: null, GetSelectedSourcePages(sourcePdf, sourceSelection), importOptions);
+        return Import(sourcePdf, ImportPlacement.Prepend, insertBeforePageNumber: null, GetSelectedSourcePages(sourcePdf, sourceSelection), importOptions, targetReadOptions);
     }
 
     /// <summary>
@@ -196,7 +210,7 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryPrepend(PdfDocument sourceDocument, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourceDocument, nameof(sourceDocument));
-        return _document.TryMutationOperation("Prepend pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Prepend(sourceDocument, importOptions), options);
+        return _document.TryMutationOperation("Prepend pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Prepend(sourceDocument.GetBytesForOperation(), importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -205,7 +219,7 @@ public sealed partial class PdfDocumentPages {
     public PdfOperationResult<PdfDocument> TryPrepend(PdfDocument sourceDocument, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourceDocument, nameof(sourceDocument));
         Guard.NotNull(sourceSelection, nameof(sourceSelection));
-        return _document.TryMutationOperation("Prepend pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Prepend(sourceDocument, sourceSelection, importOptions), options);
+        return _document.TryMutationOperation("Prepend pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Prepend(sourceDocument.GetBytesForOperation(), sourceSelection, importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -213,7 +227,7 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryPrepend(byte[] sourcePdf, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourcePdf, nameof(sourcePdf));
-        return _document.TryMutationOperation("Prepend pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Prepend(sourcePdf, importOptions), options);
+        return _document.TryMutationOperation("Prepend pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Prepend(sourcePdf, importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -222,7 +236,7 @@ public sealed partial class PdfDocumentPages {
     public PdfOperationResult<PdfDocument> TryPrepend(byte[] sourcePdf, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourcePdf, nameof(sourcePdf));
         Guard.NotNull(sourceSelection, nameof(sourceSelection));
-        return _document.TryMutationOperation("Prepend pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Prepend(sourcePdf, sourceSelection, importOptions), options);
+        return _document.TryMutationOperation("Prepend pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Prepend(sourcePdf, sourceSelection, importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -230,7 +244,7 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryPrepend(Stream sourceStream, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourceStream, nameof(sourceStream));
-        return _document.TryMutationOperation("Prepend pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Prepend(sourceStream, importOptions), options);
+        return _document.TryMutationOperation("Prepend pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Prepend(ReadSourceStream(sourceStream), importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -239,7 +253,7 @@ public sealed partial class PdfDocumentPages {
     public PdfOperationResult<PdfDocument> TryPrepend(Stream sourceStream, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourceStream, nameof(sourceStream));
         Guard.NotNull(sourceSelection, nameof(sourceSelection));
-        return _document.TryMutationOperation("Prepend pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Prepend(sourceStream, sourceSelection, importOptions), options);
+        return _document.TryMutationOperation("Prepend pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Prepend(ReadSourceStream(sourceStream), sourceSelection, importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -247,7 +261,7 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryPrepend(string sourcePath, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNullOrWhiteSpace(sourcePath, nameof(sourcePath));
-        return _document.TryMutationOperation("Prepend pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Prepend(sourcePath, importOptions), options);
+        return _document.TryMutationOperation("Prepend pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Prepend(File.ReadAllBytes(sourcePath), importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -256,7 +270,7 @@ public sealed partial class PdfDocumentPages {
     public PdfOperationResult<PdfDocument> TryPrepend(string sourcePath, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNullOrWhiteSpace(sourcePath, nameof(sourcePath));
         Guard.NotNull(sourceSelection, nameof(sourceSelection));
-        return _document.TryMutationOperation("Prepend pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Prepend(sourcePath, sourceSelection, importOptions), options);
+        return _document.TryMutationOperation("Prepend pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Prepend(File.ReadAllBytes(sourcePath), sourceSelection, importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -282,16 +296,23 @@ public sealed partial class PdfDocumentPages {
     /// Use target page count + 1 to insert at the end.
     /// </summary>
     public PdfDocument Insert(int insertBeforePageNumber, byte[] sourcePdf, PdfPageImportOptions? importOptions = null) {
-        return Import(sourcePdf, ImportPlacement.Insert, insertBeforePageNumber, Array.Empty<int>(), importOptions);
+        return Insert(insertBeforePageNumber, sourcePdf, importOptions, _document.ReadOptions);
     }
+
+    private PdfDocument Insert(int insertBeforePageNumber, byte[] sourcePdf, PdfPageImportOptions? importOptions, PdfReadOptions targetReadOptions) =>
+        Import(sourcePdf, ImportPlacement.Insert, insertBeforePageNumber, Array.Empty<int>(), importOptions, targetReadOptions);
 
     /// <summary>
     /// Inserts selected one-based pages from source PDF bytes before the supplied one-based page number.
     /// Use target page count + 1 to insert at the end.
     /// </summary>
     public PdfDocument Insert(int insertBeforePageNumber, byte[] sourcePdf, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions = null) {
+        return Insert(insertBeforePageNumber, sourcePdf, sourceSelection, importOptions, _document.ReadOptions);
+    }
+
+    private PdfDocument Insert(int insertBeforePageNumber, byte[] sourcePdf, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions, PdfReadOptions targetReadOptions) {
         Guard.NotNull(sourceSelection, nameof(sourceSelection));
-        return Import(sourcePdf, ImportPlacement.Insert, insertBeforePageNumber, GetSelectedSourcePages(sourcePdf, sourceSelection), importOptions);
+        return Import(sourcePdf, ImportPlacement.Insert, insertBeforePageNumber, GetSelectedSourcePages(sourcePdf, sourceSelection), importOptions, targetReadOptions);
     }
 
     /// <summary>
@@ -333,7 +354,7 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryInsert(int insertBeforePageNumber, PdfDocument sourceDocument, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourceDocument, nameof(sourceDocument));
-        return _document.TryMutationOperation("Insert pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Insert(insertBeforePageNumber, sourceDocument, importOptions), options);
+        return _document.TryMutationOperation("Insert pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Insert(insertBeforePageNumber, sourceDocument.GetBytesForOperation(), importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -342,7 +363,7 @@ public sealed partial class PdfDocumentPages {
     public PdfOperationResult<PdfDocument> TryInsert(int insertBeforePageNumber, PdfDocument sourceDocument, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourceDocument, nameof(sourceDocument));
         Guard.NotNull(sourceSelection, nameof(sourceSelection));
-        return _document.TryMutationOperation("Insert pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Insert(insertBeforePageNumber, sourceDocument, sourceSelection, importOptions), options);
+        return _document.TryMutationOperation("Insert pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Insert(insertBeforePageNumber, sourceDocument.GetBytesForOperation(), sourceSelection, importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -350,7 +371,7 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryInsert(int insertBeforePageNumber, byte[] sourcePdf, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourcePdf, nameof(sourcePdf));
-        return _document.TryMutationOperation("Insert pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Insert(insertBeforePageNumber, sourcePdf, importOptions), options);
+        return _document.TryMutationOperation("Insert pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Insert(insertBeforePageNumber, sourcePdf, importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -359,7 +380,7 @@ public sealed partial class PdfDocumentPages {
     public PdfOperationResult<PdfDocument> TryInsert(int insertBeforePageNumber, byte[] sourcePdf, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourcePdf, nameof(sourcePdf));
         Guard.NotNull(sourceSelection, nameof(sourceSelection));
-        return _document.TryMutationOperation("Insert pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Insert(insertBeforePageNumber, sourcePdf, sourceSelection, importOptions), options);
+        return _document.TryMutationOperation("Insert pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Insert(insertBeforePageNumber, sourcePdf, sourceSelection, importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -367,7 +388,7 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryInsert(int insertBeforePageNumber, Stream sourceStream, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourceStream, nameof(sourceStream));
-        return _document.TryMutationOperation("Insert pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Insert(insertBeforePageNumber, sourceStream, importOptions), options);
+        return _document.TryMutationOperation("Insert pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Insert(insertBeforePageNumber, ReadSourceStream(sourceStream), importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -376,7 +397,7 @@ public sealed partial class PdfDocumentPages {
     public PdfOperationResult<PdfDocument> TryInsert(int insertBeforePageNumber, Stream sourceStream, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourceStream, nameof(sourceStream));
         Guard.NotNull(sourceSelection, nameof(sourceSelection));
-        return _document.TryMutationOperation("Insert pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Insert(insertBeforePageNumber, sourceStream, sourceSelection, importOptions), options);
+        return _document.TryMutationOperation("Insert pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Insert(insertBeforePageNumber, ReadSourceStream(sourceStream), sourceSelection, importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -384,7 +405,7 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryInsert(int insertBeforePageNumber, string sourcePath, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNullOrWhiteSpace(sourcePath, nameof(sourcePath));
-        return _document.TryMutationOperation("Insert pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Insert(insertBeforePageNumber, sourcePath, importOptions), options);
+        return _document.TryMutationOperation("Insert pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Insert(insertBeforePageNumber, File.ReadAllBytes(sourcePath), importOptions, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -393,25 +414,26 @@ public sealed partial class PdfDocumentPages {
     public PdfOperationResult<PdfDocument> TryInsert(int insertBeforePageNumber, string sourcePath, PdfPageSelection sourceSelection, PdfPageImportOptions? importOptions = null, PdfReadOptions? options = null) {
         Guard.NotNullOrWhiteSpace(sourcePath, nameof(sourcePath));
         Guard.NotNull(sourceSelection, nameof(sourceSelection));
-        return _document.TryMutationOperation("Insert pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Insert(insertBeforePageNumber, sourcePath, sourceSelection, importOptions), options);
+        return _document.TryMutationOperation("Insert pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.MergeDocuments, () => Insert(insertBeforePageNumber, File.ReadAllBytes(sourcePath), sourceSelection, importOptions, options ?? _document.ReadOptions), options);
     }
 
-    private PdfDocument Import(byte[] sourcePdf, ImportPlacement placement, int? insertBeforePageNumber, int[] sourcePageNumbers, PdfPageImportOptions? importOptions) {
+    private PdfDocument Import(byte[] sourcePdf, ImportPlacement placement, int? insertBeforePageNumber, int[] sourcePageNumbers, PdfPageImportOptions? importOptions, PdfReadOptions targetReadOptions) {
         Guard.NotNull(sourcePdf, nameof(sourcePdf));
         Guard.NotNull(sourcePageNumbers, nameof(sourcePageNumbers));
 
         PdfPageImportOptions effectiveOptions = importOptions ?? new PdfPageImportOptions();
         byte[] targetPdf = _document.GetBytesForOperation();
         byte[] imported = placement switch {
-            ImportPlacement.Append => PdfPageImporter.AppendPages(effectiveOptions, targetPdf, sourcePdf, sourcePageNumbers),
-            ImportPlacement.Prepend => PdfPageImporter.PrependPages(effectiveOptions, targetPdf, sourcePdf, sourcePageNumbers),
-            ImportPlacement.Insert => PdfPageImporter.InsertPages(effectiveOptions, targetPdf, sourcePdf, insertBeforePageNumber!.Value, sourcePageNumbers),
+            ImportPlacement.Append => PdfPageImporter.AppendPages(effectiveOptions, targetPdf, sourcePdf, targetReadOptions, sourcePageNumbers),
+            ImportPlacement.Prepend => PdfPageImporter.PrependPages(effectiveOptions, targetPdf, sourcePdf, targetReadOptions, sourcePageNumbers),
+            ImportPlacement.Insert => PdfPageImporter.InsertPages(effectiveOptions, targetPdf, sourcePdf, insertBeforePageNumber!.Value, targetReadOptions, sourcePageNumbers),
             _ => throw new ArgumentOutOfRangeException(nameof(placement), placement, "Unsupported page import placement.")
         };
 
         return _document.WithBytes(
             targetPdf,
             imported,
+            readOptions: targetReadOptions,
             operationName: placement.ToString());
     }
 

--- a/OfficeIMO.Pdf/Core/PdfDocumentPages.Selectors.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocumentPages.Selectors.cs
@@ -20,11 +20,12 @@ public sealed partial class PdfDocumentPages {
     /// <summary>Attempts to delete pages resolved from a document-relative selector.</summary>
     public PdfOperationResult<PdfDocument> TryDelete(PdfPageSelector selector, PdfReadOptions? options = null) {
         Guard.NotNull(selector, nameof(selector));
+        PdfReadOptions? effectiveOptions = options ?? _document.ReadOptions;
         return _document.TryMutationOperation(
             "Delete pages",
             PdfPreflightCapability.ManipulatePages,
             PdfMutationOperation.ModifyPageTree,
-            () => Delete(ResolveSelector(selector, options)),
+            () => Delete(ResolveSelector(selector, effectiveOptions), effectiveOptions),
             options);
     }
 
@@ -36,11 +37,12 @@ public sealed partial class PdfDocumentPages {
     /// <summary>Attempts to reorder pages resolved from a document-relative selector.</summary>
     public PdfOperationResult<PdfDocument> TryReorder(PdfPageSelector selector, PdfReadOptions? options = null) {
         Guard.NotNull(selector, nameof(selector));
+        PdfReadOptions? effectiveOptions = options ?? _document.ReadOptions;
         return _document.TryMutationOperation(
             "Reorder pages",
             PdfPreflightCapability.ManipulatePages,
             PdfMutationOperation.ModifyPageTree,
-            () => Reorder(ResolveSelector(selector, options)),
+            () => Reorder(ResolveSelector(selector, effectiveOptions), effectiveOptions),
             options);
     }
 
@@ -52,11 +54,12 @@ public sealed partial class PdfDocumentPages {
     /// <summary>Attempts to duplicate pages resolved from a document-relative selector.</summary>
     public PdfOperationResult<PdfDocument> TryDuplicate(PdfPageSelector selector, PdfReadOptions? options = null) {
         Guard.NotNull(selector, nameof(selector));
+        PdfReadOptions? effectiveOptions = options ?? _document.ReadOptions;
         return _document.TryMutationOperation(
             "Duplicate pages",
             PdfPreflightCapability.ManipulatePages,
             PdfMutationOperation.ModifyPageTree,
-            () => Duplicate(ResolveSelector(selector, options)),
+            () => Duplicate(ResolveSelector(selector, effectiveOptions), effectiveOptions),
             options);
     }
 
@@ -68,11 +71,12 @@ public sealed partial class PdfDocumentPages {
     /// <summary>Attempts to move pages resolved from a document-relative selector.</summary>
     public PdfOperationResult<PdfDocument> TryMove(int insertBeforePageNumber, PdfPageSelector selector, PdfReadOptions? options = null) {
         Guard.NotNull(selector, nameof(selector));
+        PdfReadOptions? effectiveOptions = options ?? _document.ReadOptions;
         return _document.TryMutationOperation(
             "Move pages",
             PdfPreflightCapability.ManipulatePages,
             PdfMutationOperation.ModifyPageTree,
-            () => Move(insertBeforePageNumber, ResolveSelector(selector, options)),
+            () => Move(insertBeforePageNumber, ResolveSelector(selector, effectiveOptions), effectiveOptions),
             options);
     }
 
@@ -84,11 +88,12 @@ public sealed partial class PdfDocumentPages {
     /// <summary>Attempts to rotate pages resolved from a document-relative selector.</summary>
     public PdfOperationResult<PdfDocument> TryRotate(int rotationDegrees, PdfPageSelector selector, PdfReadOptions? options = null) {
         Guard.NotNull(selector, nameof(selector));
+        PdfReadOptions? effectiveOptions = options ?? _document.ReadOptions;
         return _document.TryMutationOperation(
             "Rotate pages",
             PdfPreflightCapability.ManipulatePages,
             PdfMutationOperation.ModifyPageTree,
-            () => Rotate(rotationDegrees, ResolveSelector(selector, options)),
+            () => Rotate(rotationDegrees, ResolveSelector(selector, effectiveOptions), effectiveOptions),
             options);
     }
 

--- a/OfficeIMO.Pdf/Core/PdfDocumentPages.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocumentPages.cs
@@ -274,14 +274,14 @@ public sealed partial class PdfDocumentPages {
     /// Creates a new PDF with selected pages deleted.
     /// </summary>
     public PdfDocument Delete(params int[] pageNumbers) {
-        return _document.ApplyMutation(input => PdfPageEditor.DeletePages(input, pageNumbers));
+        return _document.ApplyMutation(input => PdfPageEditor.DeletePagesWithReadOptions(input, _document.ReadOptions, pageNumbers));
     }
 
     /// <summary>
     /// Creates a new PDF with one inclusive page range deleted.
     /// </summary>
     public PdfDocument Delete(PdfPageRange pageRange) {
-        return _document.ApplyMutation(input => PdfPageEditor.DeletePageRange(input, pageRange));
+        return _document.ApplyMutation(input => PdfPageEditor.DeletePagesWithReadOptions(input, _document.ReadOptions, pageRange.ToPageNumbers()));
     }
 
     /// <summary>
@@ -289,15 +289,18 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfDocument Delete(PdfPageSelection selection) {
         Guard.NotNull(selection, nameof(selection));
-        return _document.ApplyMutation(input => PdfPageEditor.DeletePageRanges(input, selection.ToRanges()));
+        return Delete(selection, _document.ReadOptions);
     }
+
+    private PdfDocument Delete(PdfPageSelection selection, PdfReadOptions? readOptions) =>
+        _document.ApplyMutation(input => PdfPageEditor.DeletePagesWithReadOptions(input, readOptions, selection.ToPageNumbers(_document.Inspect(readOptions).PageCount, nameof(selection))), readOptions);
 
     /// <summary>
     /// Attempts to create a new PDF with selected pages deleted, returning diagnostics when blocked or failed.
     /// </summary>
     public PdfOperationResult<PdfDocument> TryDelete(PdfPageSelection selection, PdfReadOptions? options = null) {
         Guard.NotNull(selection, nameof(selection));
-        return _document.TryMutationOperation("Delete pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageTree, () => Delete(selection), options);
+        return _document.TryMutationOperation("Delete pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageTree, () => Delete(selection, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -311,7 +314,7 @@ public sealed partial class PdfDocumentPages {
     /// Attempts to create a new PDF with pages described by page ranges deleted, returning diagnostics when blocked or failed.
     /// </summary>
     public PdfOperationResult<PdfDocument> TryDelete(string pageRanges, PdfReadOptions? options = null) {
-        return _document.TryMutationOperation("Delete pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageTree, () => Delete(PdfPageSelection.Parse(pageRanges)), options);
+        return _document.TryMutationOperation("Delete pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageTree, () => Delete(PdfPageSelection.Parse(pageRanges), options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -400,7 +403,7 @@ public sealed partial class PdfDocumentPages {
     /// Use page count + 1 to move pages to the end.
     /// </summary>
     public PdfDocument Move(int insertBeforePageNumber, params int[] pageNumbers) {
-        return _document.ApplyMutation(input => PdfPageEditor.MovePages(input, insertBeforePageNumber, pageNumbers));
+        return _document.ApplyMutation(input => PdfPageEditor.MovePagesWithReadOptions(input, insertBeforePageNumber, _document.ReadOptions, pageNumbers));
     }
 
     /// <summary>
@@ -408,7 +411,7 @@ public sealed partial class PdfDocumentPages {
     /// Use page count + 1 to move pages to the end.
     /// </summary>
     public PdfDocument Move(int insertBeforePageNumber, PdfPageRange pageRange) {
-        return _document.ApplyMutation(input => PdfPageEditor.MovePageRange(input, insertBeforePageNumber, pageRange));
+        return _document.ApplyMutation(input => PdfPageEditor.MovePagesWithReadOptions(input, insertBeforePageNumber, _document.ReadOptions, pageRange.ToPageNumbers()));
     }
 
     /// <summary>
@@ -417,15 +420,18 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfDocument Move(int insertBeforePageNumber, PdfPageSelection selection) {
         Guard.NotNull(selection, nameof(selection));
-        return _document.ApplyMutation(input => PdfPageEditor.MovePageRanges(input, insertBeforePageNumber, selection.ToRanges()));
+        return Move(insertBeforePageNumber, selection, _document.ReadOptions);
     }
+
+    private PdfDocument Move(int insertBeforePageNumber, PdfPageSelection selection, PdfReadOptions? readOptions) =>
+        _document.ApplyMutation(input => PdfPageEditor.MovePagesWithReadOptions(input, insertBeforePageNumber, readOptions, selection.ToPageNumbers(_document.Inspect(readOptions).PageCount, nameof(selection))), readOptions);
 
     /// <summary>
     /// Attempts to create a new PDF with selected pages moved before the supplied one-based page number, returning diagnostics when blocked or failed.
     /// </summary>
     public PdfOperationResult<PdfDocument> TryMove(int insertBeforePageNumber, PdfPageSelection selection, PdfReadOptions? options = null) {
         Guard.NotNull(selection, nameof(selection));
-        return _document.TryMutationOperation("Move pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageTree, () => Move(insertBeforePageNumber, selection), options);
+        return _document.TryMutationOperation("Move pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageTree, () => Move(insertBeforePageNumber, selection, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -440,21 +446,21 @@ public sealed partial class PdfDocumentPages {
     /// Attempts to create a new PDF with parsed page ranges moved before the supplied one-based page number, returning diagnostics when blocked or failed.
     /// </summary>
     public PdfOperationResult<PdfDocument> TryMove(int insertBeforePageNumber, string pageRanges, PdfReadOptions? options = null) {
-        return _document.TryMutationOperation("Move pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageTree, () => Move(insertBeforePageNumber, PdfPageSelection.Parse(pageRanges)), options);
+        return _document.TryMutationOperation("Move pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageTree, () => Move(insertBeforePageNumber, PdfPageSelection.Parse(pageRanges), options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
     /// Creates a new PDF with selected pages rotated. Supplying no page numbers rotates every page.
     /// </summary>
     public PdfDocument Rotate(int rotationDegrees, params int[] pageNumbers) {
-        return _document.ApplyMutation(input => PdfPageEditor.RotatePages(input, rotationDegrees, pageNumbers));
+        return _document.ApplyMutation(input => PdfPageEditor.RotatePagesWithReadOptions(input, rotationDegrees, _document.ReadOptions, pageNumbers));
     }
 
     /// <summary>
     /// Creates a new PDF with one inclusive page range rotated.
     /// </summary>
     public PdfDocument Rotate(int rotationDegrees, PdfPageRange pageRange) {
-        return _document.ApplyMutation(input => PdfPageEditor.RotatePageRange(input, rotationDegrees, pageRange));
+        return _document.ApplyMutation(input => PdfPageEditor.RotatePagesWithReadOptions(input, rotationDegrees, _document.ReadOptions, pageRange.ToPageNumbers()));
     }
 
     /// <summary>
@@ -462,15 +468,18 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfDocument Rotate(int rotationDegrees, PdfPageSelection selection) {
         Guard.NotNull(selection, nameof(selection));
-        return _document.ApplyMutation(input => PdfPageEditor.RotatePageRanges(input, rotationDegrees, selection.ToRanges()));
+        return Rotate(rotationDegrees, selection, _document.ReadOptions);
     }
+
+    private PdfDocument Rotate(int rotationDegrees, PdfPageSelection selection, PdfReadOptions? readOptions) =>
+        _document.ApplyMutation(input => PdfPageEditor.RotatePagesWithReadOptions(input, rotationDegrees, readOptions, selection.ToPageNumbers(_document.Inspect(readOptions).PageCount, nameof(selection))), readOptions);
 
     /// <summary>
     /// Attempts to create a new PDF with selected pages rotated, returning diagnostics when blocked or failed.
     /// </summary>
     public PdfOperationResult<PdfDocument> TryRotate(int rotationDegrees, PdfPageSelection selection, PdfReadOptions? options = null) {
         Guard.NotNull(selection, nameof(selection));
-        return _document.TryMutationOperation("Rotate pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageTree, () => Rotate(rotationDegrees, selection), options);
+        return _document.TryMutationOperation("Rotate pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageTree, () => Rotate(rotationDegrees, selection, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -484,12 +493,12 @@ public sealed partial class PdfDocumentPages {
     /// Attempts to create a new PDF with parsed page ranges rotated, returning diagnostics when blocked or failed.
     /// </summary>
     public PdfOperationResult<PdfDocument> TryRotate(int rotationDegrees, string pageRanges, PdfReadOptions? options = null) {
-        return _document.TryMutationOperation("Rotate pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageTree, () => Rotate(rotationDegrees, PdfPageSelection.Parse(pageRanges)), options);
+        return _document.TryMutationOperation("Rotate pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageTree, () => Rotate(rotationDegrees, PdfPageSelection.Parse(pageRanges), options ?? _document.ReadOptions), options);
     }
 
     /// <summary>Sets a typed boundary box for selected pages, or every page when no page numbers are supplied.</summary>
     public PdfDocument SetPageBox(PdfPageBoundaryBox box, double left, double bottom, double right, double top, params int[] pageNumbers) {
-        return _document.ApplyMutation(input => PdfPageEditor.SetPageBox(input, box, left, bottom, right, top, pageNumbers));
+        return _document.ApplyMutation(input => PdfPageEditor.SetPageBoxWithReadOptions(input, box, left, bottom, right, top, _document.ReadOptions, pageNumbers));
     }
 
     /// <summary>Resizes selected pages to the supplied page size.</summary>

--- a/OfficeIMO.Pdf/Core/PdfDocumentPages.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocumentPages.cs
@@ -321,7 +321,7 @@ public sealed partial class PdfDocumentPages {
     /// Creates a new PDF with every page copied in the specified one-based order.
     /// </summary>
     public PdfDocument Reorder(params int[] pageNumbers) {
-        return _document.ApplyMutation(input => PdfPageEditor.ReorderPages(input, pageNumbers));
+        return _document.ApplyMutation(input => PdfPageEditor.ReorderPagesWithReadOptions(input, _document.ReadOptions, pageNumbers));
     }
 
     /// <summary>
@@ -336,36 +336,39 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfDocument Reorder(PdfPageSelection selection) {
         Guard.NotNull(selection, nameof(selection));
-        return _document.ApplyMutation(input => PdfPageEditor.ReorderPageRanges(input, selection.ToRanges()));
+        return Reorder(selection, _document.ReadOptions);
     }
+
+    private PdfDocument Reorder(PdfPageSelection selection, PdfReadOptions? readOptions) =>
+        _document.ApplyMutation(input => PdfPageEditor.ReorderPagesWithReadOptions(input, readOptions, selection.ToPageNumbers(_document.Inspect(readOptions).PageCount, nameof(selection))), readOptions);
 
     /// <summary>
     /// Attempts to create a new PDF with every page copied in the selected one-based order, returning diagnostics when blocked or failed.
     /// </summary>
     public PdfOperationResult<PdfDocument> TryReorder(PdfPageSelection selection, PdfReadOptions? options = null) {
         Guard.NotNull(selection, nameof(selection));
-        return _document.TryMutationOperation("Reorder pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageTree, () => Reorder(selection), options);
+        return _document.TryMutationOperation("Reorder pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageTree, () => Reorder(selection, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
     /// Attempts to create a new PDF with pages copied in parsed page-range order, returning diagnostics when blocked or failed.
     /// </summary>
     public PdfOperationResult<PdfDocument> TryReorder(string pageRanges, PdfReadOptions? options = null) {
-        return _document.TryMutationOperation("Reorder pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageTree, () => Reorder(PdfPageSelection.Parse(pageRanges)), options);
+        return _document.TryMutationOperation("Reorder pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageTree, () => Reorder(PdfPageSelection.Parse(pageRanges), options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
     /// Creates a new PDF with selected pages duplicated immediately after each source page.
     /// </summary>
     public PdfDocument Duplicate(params int[] pageNumbers) {
-        return _document.ApplyMutation(input => PdfPageEditor.DuplicatePages(input, pageNumbers));
+        return _document.ApplyMutation(input => PdfPageEditor.DuplicatePagesWithReadOptions(input, _document.ReadOptions, pageNumbers));
     }
 
     /// <summary>
     /// Creates a new PDF with one inclusive page range duplicated.
     /// </summary>
     public PdfDocument Duplicate(PdfPageRange pageRange) {
-        return _document.ApplyMutation(input => PdfPageEditor.DuplicatePageRange(input, pageRange));
+        return _document.ApplyMutation(input => PdfPageEditor.DuplicatePagesWithReadOptions(input, _document.ReadOptions, pageRange.ToPageNumbers()));
     }
 
     /// <summary>
@@ -373,15 +376,18 @@ public sealed partial class PdfDocumentPages {
     /// </summary>
     public PdfDocument Duplicate(PdfPageSelection selection) {
         Guard.NotNull(selection, nameof(selection));
-        return _document.ApplyMutation(input => PdfPageEditor.DuplicatePageRanges(input, selection.ToRanges()));
+        return Duplicate(selection, _document.ReadOptions);
     }
+
+    private PdfDocument Duplicate(PdfPageSelection selection, PdfReadOptions? readOptions) =>
+        _document.ApplyMutation(input => PdfPageEditor.DuplicatePagesWithReadOptions(input, readOptions, selection.ToPageNumbers(_document.Inspect(readOptions).PageCount, nameof(selection))), readOptions);
 
     /// <summary>
     /// Attempts to create a new PDF with selected pages duplicated, returning diagnostics when blocked or failed.
     /// </summary>
     public PdfOperationResult<PdfDocument> TryDuplicate(PdfPageSelection selection, PdfReadOptions? options = null) {
         Guard.NotNull(selection, nameof(selection));
-        return _document.TryMutationOperation("Duplicate pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageTree, () => Duplicate(selection), options);
+        return _document.TryMutationOperation("Duplicate pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageTree, () => Duplicate(selection, options ?? _document.ReadOptions), options);
     }
 
     /// <summary>
@@ -395,7 +401,7 @@ public sealed partial class PdfDocumentPages {
     /// Attempts to create a new PDF with parsed page ranges duplicated, returning diagnostics when blocked or failed.
     /// </summary>
     public PdfOperationResult<PdfDocument> TryDuplicate(string pageRanges, PdfReadOptions? options = null) {
-        return _document.TryMutationOperation("Duplicate pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageTree, () => Duplicate(PdfPageSelection.Parse(pageRanges)), options);
+        return _document.TryMutationOperation("Duplicate pages", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageTree, () => Duplicate(PdfPageSelection.Parse(pageRanges), options ?? _document.ReadOptions), options);
     }
 
     /// <summary>

--- a/OfficeIMO.Pdf/Core/PdfDocumentStamper.Content.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocumentStamper.Content.cs
@@ -1,0 +1,38 @@
+namespace OfficeIMO.Pdf;
+
+public sealed partial class PdfDocumentStamper {
+    /// <summary>
+    /// Stamps arbitrary visual <see cref="PdfPageCanvas"/> content onto selected existing pages.
+    /// Annotations and form fields remain separate editor concerns and are rejected by this visual-only operation.
+    /// </summary>
+    public PdfDocument Content(
+        Action<PdfPageCanvas, PdfStampPageContext> build,
+        PdfCanvasStampOptions? options = null,
+        PdfReadOptions? readOptions = null) {
+        Guard.NotNull(build, nameof(build));
+        return _document.ApplyMutation(input => PdfStamper.StampCanvas(input, build, options, readOptions ?? _document.ReadOptions));
+    }
+
+    /// <summary>Stamps the same arbitrary visual canvas content onto selected existing pages.</summary>
+    public PdfDocument Content(
+        Action<PdfPageCanvas> build,
+        PdfCanvasStampOptions? options = null,
+        PdfReadOptions? readOptions = null) {
+        Guard.NotNull(build, nameof(build));
+        return Content((canvas, _) => build(canvas), options, readOptions);
+    }
+
+    /// <summary>Attempts to stamp arbitrary visual canvas content and returns diagnostics when blocked or failed.</summary>
+    public PdfOperationResult<PdfDocument> TryContent(
+        Action<PdfPageCanvas, PdfStampPageContext> build,
+        PdfCanvasStampOptions? stampOptions = null,
+        PdfReadOptions? options = null) {
+        Guard.NotNull(build, nameof(build));
+        return _document.TryMutationOperation(
+            "Stamp visual canvas content",
+            PdfPreflightCapability.ManipulatePages,
+            PdfMutationOperation.ModifyPageContent,
+            _ => Content(build, stampOptions, options),
+            options: options);
+    }
+}

--- a/OfficeIMO.Pdf/Core/PdfDocumentStamper.Content.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocumentStamper.Content.cs
@@ -3,7 +3,8 @@ namespace OfficeIMO.Pdf;
 public sealed partial class PdfDocumentStamper {
     /// <summary>
     /// Stamps arbitrary visual <see cref="PdfPageCanvas"/> content onto selected existing pages.
-    /// Annotations and form fields remain separate editor concerns and are rejected by this visual-only operation.
+    /// Annotations, form fields, interactive metadata, outlines, and tagged structure remain separate editor concerns
+    /// and are rejected by this visual-only operation.
     /// </summary>
     public PdfDocument Content(
         Action<PdfPageCanvas, PdfStampPageContext> build,

--- a/OfficeIMO.Pdf/Core/PdfDocumentStamper.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocumentStamper.cs
@@ -3,7 +3,7 @@ namespace OfficeIMO.Pdf;
 /// <summary>
 /// Fluent stamping and watermarking operations for a <see cref="PdfDocument"/>.
 /// </summary>
-public sealed class PdfDocumentStamper {
+public sealed partial class PdfDocumentStamper {
     private readonly PdfDocument _document;
 
     internal PdfDocumentStamper(PdfDocument document) {
@@ -13,37 +13,46 @@ public sealed class PdfDocumentStamper {
     /// <summary>
     /// Creates a new PDF with text stamped above existing content unless options request otherwise.
     /// </summary>
-    public PdfDocument Text(string text, PdfTextStampOptions? options = null) {
-        return _document.ApplyMutation(input => PdfStamper.StampText(input, text, options));
+    public PdfDocument Text(string text, PdfTextStampOptions? options = null) => Text(text, options, _document.ReadOptions);
+
+    /// <summary>Creates a new PDF with text stamped above existing content using explicit target read options.</summary>
+    public PdfDocument Text(string text, PdfTextStampOptions? options, PdfReadOptions? readOptions) {
+        return _document.ApplyMutation(input => PdfStamper.StampText(input, text, options, readOptions ?? _document.ReadOptions));
     }
 
     /// <summary>
     /// Attempts to create a new PDF with text stamped above existing content, returning diagnostics when blocked or failed.
     /// </summary>
     public PdfOperationResult<PdfDocument> TryText(string text, PdfTextStampOptions? stampOptions = null, PdfReadOptions? options = null) {
-        return _document.TryMutationOperation("Stamp text", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => Text(text, stampOptions), options: options);
+        return _document.TryMutationOperation("Stamp text", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => Text(text, stampOptions, options), options: options);
     }
 
     /// <summary>
     /// Creates a new PDF with text watermarked behind existing content.
     /// </summary>
-    public PdfDocument TextWatermark(string text, PdfTextStampOptions? options = null) {
-        return _document.ApplyMutation(input => PdfStamper.WatermarkText(input, text, options));
+    public PdfDocument TextWatermark(string text, PdfTextStampOptions? options = null) => TextWatermark(text, options, _document.ReadOptions);
+
+    /// <summary>Creates a text watermark behind existing content using explicit target read options.</summary>
+    public PdfDocument TextWatermark(string text, PdfTextStampOptions? options, PdfReadOptions? readOptions) {
+        return _document.ApplyMutation(input => PdfStamper.WatermarkText(input, text, options, readOptions ?? _document.ReadOptions));
     }
 
     /// <summary>
     /// Attempts to create a new PDF with text watermarked behind existing content, returning diagnostics when blocked or failed.
     /// </summary>
     public PdfOperationResult<PdfDocument> TryTextWatermark(string text, PdfTextStampOptions? stampOptions = null, PdfReadOptions? options = null) {
-        return _document.TryMutationOperation("Watermark text", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => TextWatermark(text, stampOptions), options: options);
+        return _document.TryMutationOperation("Watermark text", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => TextWatermark(text, stampOptions, options), options: options);
     }
 
     /// <summary>
     /// Creates a new PDF with an image stamped above existing content unless options request otherwise.
     /// </summary>
-    public PdfDocument Image(byte[] imageBytes, PdfImageStampOptions? options = null) {
+    public PdfDocument Image(byte[] imageBytes, PdfImageStampOptions? options = null) => Image(imageBytes, options, _document.ReadOptions);
+
+    /// <summary>Creates a new PDF with an image stamped above existing content using explicit target read options.</summary>
+    public PdfDocument Image(byte[] imageBytes, PdfImageStampOptions? options, PdfReadOptions? readOptions) {
         Guard.NotNull(imageBytes, nameof(imageBytes));
-        return _document.ApplyMutation(input => PdfStamper.StampImage(input, imageBytes, options));
+        return _document.ApplyMutation(input => PdfStamper.StampImage(input, imageBytes, options, readOptions ?? _document.ReadOptions));
     }
 
     /// <summary>
@@ -51,15 +60,20 @@ public sealed class PdfDocumentStamper {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryImage(byte[] imageBytes, PdfImageStampOptions? stampOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(imageBytes, nameof(imageBytes));
-        return _document.TryMutationOperation("Stamp image", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => Image(imageBytes, stampOptions), options: options);
+        return _document.TryMutationOperation("Stamp image", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => Image(imageBytes, stampOptions, options), options: options);
     }
 
     /// <summary>
     /// Creates a new PDF with an image stamped from a readable image stream.
     /// </summary>
-    public PdfDocument Image(Stream imageStream, PdfImageStampOptions? options = null) {
+    public PdfDocument Image(Stream imageStream, PdfImageStampOptions? options = null) => Image(imageStream, options, _document.ReadOptions);
+
+    /// <summary>Creates a new PDF with an image stream stamped using explicit target read options.</summary>
+    public PdfDocument Image(Stream imageStream, PdfImageStampOptions? options, PdfReadOptions? readOptions) {
         Guard.NotNull(imageStream, nameof(imageStream));
-        return _document.ApplyMutation(input => PdfStamper.StampImage(input, imageStream, options));
+        using var buffer = new MemoryStream();
+        imageStream.CopyTo(buffer);
+        return Image(buffer.ToArray(), options, readOptions);
     }
 
     /// <summary>
@@ -67,15 +81,18 @@ public sealed class PdfDocumentStamper {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryImage(Stream imageStream, PdfImageStampOptions? stampOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(imageStream, nameof(imageStream));
-        return _document.TryMutationOperation("Stamp image", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => Image(imageStream, stampOptions), options: options);
+        return _document.TryMutationOperation("Stamp image", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => Image(imageStream, stampOptions, options), options: options);
     }
 
     /// <summary>
     /// Creates a new PDF with an image watermarked behind existing content.
     /// </summary>
-    public PdfDocument ImageWatermark(byte[] imageBytes, PdfImageStampOptions? options = null) {
+    public PdfDocument ImageWatermark(byte[] imageBytes, PdfImageStampOptions? options = null) => ImageWatermark(imageBytes, options, _document.ReadOptions);
+
+    /// <summary>Creates an image watermark behind existing content using explicit target read options.</summary>
+    public PdfDocument ImageWatermark(byte[] imageBytes, PdfImageStampOptions? options, PdfReadOptions? readOptions) {
         Guard.NotNull(imageBytes, nameof(imageBytes));
-        return _document.ApplyMutation(input => PdfStamper.WatermarkImage(input, imageBytes, options));
+        return _document.ApplyMutation(input => PdfStamper.WatermarkImage(input, imageBytes, options, readOptions ?? _document.ReadOptions));
     }
 
     /// <summary>
@@ -83,15 +100,20 @@ public sealed class PdfDocumentStamper {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryImageWatermark(byte[] imageBytes, PdfImageStampOptions? stampOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(imageBytes, nameof(imageBytes));
-        return _document.TryMutationOperation("Watermark image", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => ImageWatermark(imageBytes, stampOptions), options: options);
+        return _document.TryMutationOperation("Watermark image", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => ImageWatermark(imageBytes, stampOptions, options), options: options);
     }
 
     /// <summary>
     /// Creates a new PDF with an image watermark from a readable image stream.
     /// </summary>
-    public PdfDocument ImageWatermark(Stream imageStream, PdfImageStampOptions? options = null) {
+    public PdfDocument ImageWatermark(Stream imageStream, PdfImageStampOptions? options = null) => ImageWatermark(imageStream, options, _document.ReadOptions);
+
+    /// <summary>Creates an image-stream watermark using explicit target read options.</summary>
+    public PdfDocument ImageWatermark(Stream imageStream, PdfImageStampOptions? options, PdfReadOptions? readOptions) {
         Guard.NotNull(imageStream, nameof(imageStream));
-        return _document.ApplyMutation(input => PdfStamper.WatermarkImage(input, imageStream, options));
+        using var buffer = new MemoryStream();
+        imageStream.CopyTo(buffer);
+        return ImageWatermark(buffer.ToArray(), options, readOptions);
     }
 
     /// <summary>
@@ -99,84 +121,108 @@ public sealed class PdfDocumentStamper {
     /// </summary>
     public PdfOperationResult<PdfDocument> TryImageWatermark(Stream imageStream, PdfImageStampOptions? stampOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(imageStream, nameof(imageStream));
-        return _document.TryMutationOperation("Watermark image", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => ImageWatermark(imageStream, stampOptions), options: options);
+        return _document.TryMutationOperation("Watermark image", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => ImageWatermark(imageStream, stampOptions, options), options: options);
     }
 
     /// <summary>Imports one page from another PDF above selected pages.</summary>
-    public PdfDocument OverlayPage(byte[] sourcePdf, PdfPageOverlayOptions? options = null) {
+    public PdfDocument OverlayPage(byte[] sourcePdf, PdfPageOverlayOptions? options = null) => OverlayPage(sourcePdf, options, _document.ReadOptions);
+
+    /// <summary>Imports one page from another PDF above selected pages using explicit target read options.</summary>
+    public PdfDocument OverlayPage(byte[] sourcePdf, PdfPageOverlayOptions? options, PdfReadOptions? targetReadOptions) {
         Guard.NotNull(sourcePdf, nameof(sourcePdf));
-        return _document.ApplyMutation(input => PdfStamper.OverlayPage(input, sourcePdf, options));
+        return _document.ApplyMutation(input => PdfStamper.OverlayPage(input, sourcePdf, options, targetReadOptions ?? _document.ReadOptions));
     }
 
     /// <summary>Imports one page from a readable PDF stream above selected pages.</summary>
     public PdfDocument OverlayPage(Stream sourceStream, PdfPageOverlayOptions? options = null) {
+        return OverlayPage(sourceStream, options, _document.ReadOptions);
+    }
+
+    /// <summary>Imports one page from a readable PDF stream using explicit target read options.</summary>
+    public PdfDocument OverlayPage(Stream sourceStream, PdfPageOverlayOptions? options, PdfReadOptions? targetReadOptions) {
         Guard.NotNull(sourceStream, nameof(sourceStream));
-        return _document.ApplyMutation(input => {
-            using var targetStream = new MemoryStream(input, writable: false);
-            return PdfStamper.OverlayPage(targetStream, sourceStream, options);
-        });
+        using var buffer = new MemoryStream();
+        sourceStream.CopyTo(buffer);
+        return OverlayPage(buffer.ToArray(), options, targetReadOptions);
     }
 
     /// <summary>Imports one page from a PDF file above selected pages.</summary>
     public PdfDocument OverlayPage(string sourcePath, PdfPageOverlayOptions? options = null) {
+        return OverlayPage(sourcePath, options, _document.ReadOptions);
+    }
+
+    /// <summary>Imports one page from a PDF file using explicit target read options.</summary>
+    public PdfDocument OverlayPage(string sourcePath, PdfPageOverlayOptions? options, PdfReadOptions? targetReadOptions) {
         Guard.NotNullOrWhiteSpace(sourcePath, nameof(sourcePath));
-        return OverlayPage(File.ReadAllBytes(sourcePath), options);
+        return OverlayPage(File.ReadAllBytes(sourcePath), options, targetReadOptions);
     }
 
     /// <summary>Attempts to import one page from another PDF above selected pages.</summary>
     public PdfOperationResult<PdfDocument> TryOverlayPage(byte[] sourcePdf, PdfPageOverlayOptions? overlayOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourcePdf, nameof(sourcePdf));
-        return _document.TryMutationOperation("Overlay PDF page", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => OverlayPage(sourcePdf, overlayOptions), options: options);
+        return _document.TryMutationOperation("Overlay PDF page", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => OverlayPage(sourcePdf, overlayOptions, options), options: options);
     }
 
     /// <summary>Attempts to import one page from a readable PDF stream above selected pages.</summary>
     public PdfOperationResult<PdfDocument> TryOverlayPage(Stream sourceStream, PdfPageOverlayOptions? overlayOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourceStream, nameof(sourceStream));
-        return _document.TryMutationOperation("Overlay PDF page", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => OverlayPage(sourceStream, overlayOptions), options: options);
+        return _document.TryMutationOperation("Overlay PDF page", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => OverlayPage(sourceStream, overlayOptions, options), options: options);
     }
 
     /// <summary>Attempts to import one page from a PDF file above selected pages.</summary>
     public PdfOperationResult<PdfDocument> TryOverlayPage(string sourcePath, PdfPageOverlayOptions? overlayOptions = null, PdfReadOptions? options = null) {
         Guard.NotNullOrWhiteSpace(sourcePath, nameof(sourcePath));
-        return _document.TryMutationOperation("Overlay PDF page", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => OverlayPage(sourcePath, overlayOptions), options: options);
+        return _document.TryMutationOperation("Overlay PDF page", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => OverlayPage(sourcePath, overlayOptions, options), options: options);
     }
 
     /// <summary>Imports one page from another PDF below selected pages.</summary>
-    public PdfDocument UnderlayPage(byte[] sourcePdf, PdfPageOverlayOptions? options = null) {
+    public PdfDocument UnderlayPage(byte[] sourcePdf, PdfPageOverlayOptions? options = null) => UnderlayPage(sourcePdf, options, _document.ReadOptions);
+
+    /// <summary>Imports one page from another PDF below selected pages using explicit target read options.</summary>
+    public PdfDocument UnderlayPage(byte[] sourcePdf, PdfPageOverlayOptions? options, PdfReadOptions? targetReadOptions) {
         Guard.NotNull(sourcePdf, nameof(sourcePdf));
-        return _document.ApplyMutation(input => PdfStamper.UnderlayPage(input, sourcePdf, options));
+        return _document.ApplyMutation(input => PdfStamper.UnderlayPage(input, sourcePdf, options, targetReadOptions ?? _document.ReadOptions));
     }
 
     /// <summary>Imports one page from a readable PDF stream below selected pages.</summary>
     public PdfDocument UnderlayPage(Stream sourceStream, PdfPageOverlayOptions? options = null) {
+        return UnderlayPage(sourceStream, options, _document.ReadOptions);
+    }
+
+    /// <summary>Imports one page from a readable PDF stream below selected pages using explicit target read options.</summary>
+    public PdfDocument UnderlayPage(Stream sourceStream, PdfPageOverlayOptions? options, PdfReadOptions? targetReadOptions) {
         Guard.NotNull(sourceStream, nameof(sourceStream));
-        return _document.ApplyMutation(input => {
-            using var targetStream = new MemoryStream(input, writable: false);
-            return PdfStamper.UnderlayPage(targetStream, sourceStream, options);
-        });
+        using var buffer = new MemoryStream();
+        sourceStream.CopyTo(buffer);
+        return UnderlayPage(buffer.ToArray(), options, targetReadOptions);
     }
 
     /// <summary>Imports one page from a PDF file below selected pages.</summary>
     public PdfDocument UnderlayPage(string sourcePath, PdfPageOverlayOptions? options = null) {
+        return UnderlayPage(sourcePath, options, _document.ReadOptions);
+    }
+
+    /// <summary>Imports one page from a PDF file below selected pages using explicit target read options.</summary>
+    public PdfDocument UnderlayPage(string sourcePath, PdfPageOverlayOptions? options, PdfReadOptions? targetReadOptions) {
         Guard.NotNullOrWhiteSpace(sourcePath, nameof(sourcePath));
-        return UnderlayPage(File.ReadAllBytes(sourcePath), options);
+        return UnderlayPage(File.ReadAllBytes(sourcePath), options, targetReadOptions);
     }
 
     /// <summary>Attempts to import one page from another PDF below selected pages.</summary>
     public PdfOperationResult<PdfDocument> TryUnderlayPage(byte[] sourcePdf, PdfPageOverlayOptions? overlayOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourcePdf, nameof(sourcePdf));
-        return _document.TryMutationOperation("Underlay PDF page", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => UnderlayPage(sourcePdf, overlayOptions), options: options);
+        return _document.TryMutationOperation("Underlay PDF page", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => UnderlayPage(sourcePdf, overlayOptions, options), options: options);
     }
 
     /// <summary>Attempts to import one page from a readable PDF stream below selected pages.</summary>
     public PdfOperationResult<PdfDocument> TryUnderlayPage(Stream sourceStream, PdfPageOverlayOptions? overlayOptions = null, PdfReadOptions? options = null) {
         Guard.NotNull(sourceStream, nameof(sourceStream));
-        return _document.TryMutationOperation("Underlay PDF page", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => UnderlayPage(sourceStream, overlayOptions), options: options);
+        return _document.TryMutationOperation("Underlay PDF page", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => UnderlayPage(sourceStream, overlayOptions, options), options: options);
     }
 
     /// <summary>Attempts to import one page from a PDF file below selected pages.</summary>
     public PdfOperationResult<PdfDocument> TryUnderlayPage(string sourcePath, PdfPageOverlayOptions? overlayOptions = null, PdfReadOptions? options = null) {
         Guard.NotNullOrWhiteSpace(sourcePath, nameof(sourcePath));
-        return _document.TryMutationOperation("Underlay PDF page", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => UnderlayPage(sourcePath, overlayOptions), options: options);
+        return _document.TryMutationOperation("Underlay PDF page", PdfPreflightCapability.ManipulatePages, PdfMutationOperation.ModifyPageContent, _ => UnderlayPage(sourcePath, overlayOptions, options), options: options);
     }
 }

--- a/OfficeIMO.Pdf/Diagnostics/PdfDebugger.cs
+++ b/OfficeIMO.Pdf/Diagnostics/PdfDebugger.cs
@@ -11,6 +11,7 @@ internal static class PdfDebugger {
         effectiveOptions.Validate();
         PdfReadOptions effectiveReadOptions = PdfReadOptions.Resolve(readOptions);
         PdfReadDocument document = PdfReadDocument.Open(pdf, effectiveReadOptions);
+        document.DemandContentExtraction("debug object");
         var (objects, _) = PdfSyntax.ParseObjects(pdf, effectiveReadOptions);
         HashSet<int> reachable = GetReachableObjectNumbers(objects, document.Security);
         var objectReports = objects.Values

--- a/OfficeIMO.Pdf/Diagnostics/PdfDiagnostics.cs
+++ b/OfficeIMO.Pdf/Diagnostics/PdfDiagnostics.cs
@@ -209,7 +209,7 @@ internal static class PdfDiagnostics {
             findings.Add(new PdfDiagnosticFinding(
                 PdfDiagnosticSeverity.Warning,
                 "EncryptionDetected",
-                "Encryption markers were detected. OfficeIMO.Pdf can read Standard password-encrypted PDFs with a valid password; general rewrites remain blocked while the dedicated owner-authorized security editor supports unsigned decrypt/re-encrypt workflows."));
+                "Encryption markers were detected. OfficeIMO.Pdf can read Standard password-encrypted PDFs with a valid password and can perform selected authenticated page rewrites on unsigned inputs; other rewrites remain blocked, while security changes require owner authorization."));
         }
 
         if (probe.HasActiveContent) {

--- a/OfficeIMO.Pdf/Diagnostics/PdfDiagnostics.cs
+++ b/OfficeIMO.Pdf/Diagnostics/PdfDiagnostics.cs
@@ -209,7 +209,7 @@ internal static class PdfDiagnostics {
             findings.Add(new PdfDiagnosticFinding(
                 PdfDiagnosticSeverity.Warning,
                 "EncryptionDetected",
-                "Encryption markers were detected. OfficeIMO.Pdf can read Standard password-encrypted PDFs with a valid password and can perform selected authenticated page rewrites on unsigned inputs; other rewrites remain blocked, while security changes require owner authorization."));
+                "Encryption markers were detected. OfficeIMO.Pdf can read Standard password-encrypted PDFs with a valid password and can perform proven authenticated page, metadata, sanitization, and simple form rewrites on unsigned inputs when the required permissions are authorized; security changes require owner authorization."));
         }
 
         if (probe.HasActiveContent) {

--- a/OfficeIMO.Pdf/Manipulation/PdfAnnotationEditor.Create.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfAnnotationEditor.Create.cs
@@ -42,7 +42,7 @@ internal static partial class PdfAnnotationEditor {
             output = PdfIncrementalObjectWriter.Append(pdf, objects, plan.Preflight.Probe.Security, trailerRaw, changed, encryptionHandler: GetAppendEncryptionHandler(objects, trailerRaw, readOptions, plan.Preflight.Probe.Security));
             PdfSignatureMutationReport proof = BuildAppendOnlyProof(pdf, output, plan, readOptions); ValidateCreatedAnnotation(output, options, annotationObjectNumber, PdfReadOptions.WithMinimumInputBytes(readOptions, output.LongLength)); return new PdfAnnotationEditResult(output, 1, plan, proof, readOptions: readOptions);
         }
-        PdfObjectGraphPruner.PruneUnreachableObjects(objects, catalog); output = RewriteAllObjects(objects, catalog, PdfReadDocument.Open(pdf, readOptions).Metadata, pdf);
+        PdfObjectGraphPruner.PruneUnreachableObjects(objects, catalog); output = RewriteAllObjects(objects, catalog, PdfReadDocument.Open(pdf, readOptions).UncheckedMetadata, pdf);
         ValidateCreatedAnnotation(output, options, null, PdfReadOptions.WithMinimumInputBytes(readOptions, output.LongLength)); return CreateFullRewriteResult(pdf, output, 1, plan, annotationsChanged: true, readOptions: readOptions);
     }
 

--- a/OfficeIMO.Pdf/Manipulation/PdfAnnotationEditor.Stamps.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfAnnotationEditor.Stamps.cs
@@ -70,7 +70,7 @@ internal static partial class PdfAnnotationEditor {
         }
 
         PdfObjectGraphPruner.PruneUnreachableObjects(objects, catalogObjectNumber);
-        byte[] rewritten = RewriteAllObjects(objects, catalogObjectNumber, PdfReadDocument.Open(pdf, readOptions).Metadata, pdf);
+        byte[] rewritten = RewriteAllObjects(objects, catalogObjectNumber, PdfReadDocument.Open(pdf, readOptions).UncheckedMetadata, pdf);
         return CreateFullRewriteResult(pdf, rewritten, 1, mutationPlan, annotationsChanged: true, readOptions: readOptions);
     }
 

--- a/OfficeIMO.Pdf/Manipulation/PdfAnnotationEditor.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfAnnotationEditor.cs
@@ -120,7 +120,7 @@ internal static partial class PdfAnnotationEditor {
         }
 
         PdfObjectGraphPruner.PruneUnreachableObjects(objects, catalogObjectNumber);
-        byte[] rewritten = RewriteAllObjects(objects, catalogObjectNumber, PdfReadDocument.Open(pdf, readOptions).Metadata, pdf);
+        byte[] rewritten = RewriteAllObjects(objects, catalogObjectNumber, PdfReadDocument.Open(pdf, readOptions).UncheckedMetadata, pdf);
         return CreateFullRewriteResult(pdf, rewritten, Math.Max(removed.Count, 1), mutationPlan, annotationsChanged: true, readOptions: readOptions);
     }
 
@@ -159,7 +159,7 @@ internal static partial class PdfAnnotationEditor {
 
         IReadOnlyList<int> changedObjects = ApplyUpdates(objects, annotation, options);
         PdfObjectGraphPruner.PruneUnreachableObjects(objects, catalogObjectNumber);
-        byte[] rewritten = RewriteAllObjects(objects, catalogObjectNumber, PdfReadDocument.Open(pdf, readOptions).Metadata, pdf);
+        byte[] rewritten = RewriteAllObjects(objects, catalogObjectNumber, PdfReadDocument.Open(pdf, readOptions).UncheckedMetadata, pdf);
         return CreateFullRewriteResult(pdf, rewritten, 1, mutationPlan, annotationsChanged: false, readOptions: readOptions);
     }
 

--- a/OfficeIMO.Pdf/Manipulation/PdfAnnotationFlattener.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfAnnotationFlattener.cs
@@ -39,7 +39,7 @@ internal static partial class PdfAnnotationFlattener {
             return pdf.ToArray();
         }
 
-        return RewriteAllObjects(objects, catalogObjectNumber, read.Metadata);
+        return RewriteAllObjects(objects, catalogObjectNumber, read.UncheckedMetadata);
     }
 
     private static void ValidateFlattenOptions(PdfAnnotationFlattenOptions? options) {

--- a/OfficeIMO.Pdf/Manipulation/PdfCanvasStampOptions.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfCanvasStampOptions.cs
@@ -1,0 +1,30 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>Controls arbitrary visual canvas content stamped onto existing PDF pages.</summary>
+public sealed class PdfCanvasStampOptions {
+    private double _opacity = 1D;
+
+    /// <summary>Optional target-page selector. Null applies the canvas callback to every page.</summary>
+    public PdfPageSelector? TargetPages { get; set; }
+
+    /// <summary>Places generated visual content before the existing page content streams.</summary>
+    public bool BehindContent { get; set; }
+
+    /// <summary>Canvas opacity from zero through one.</summary>
+    public double Opacity {
+        get => _opacity;
+        set {
+            if (value < 0D || value > 1D || double.IsNaN(value) || double.IsInfinity(value)) {
+                throw new ArgumentOutOfRangeException(nameof(Opacity), value, "Canvas stamp opacity must be finite and between zero and one.");
+            }
+
+            _opacity = value;
+        }
+    }
+
+    /// <summary>Sets target pages from a rich page-selector expression.</summary>
+    public PdfCanvasStampOptions UseTargetPages(string selector) {
+        TargetPages = PdfPageSelector.Parse(selector);
+        return this;
+    }
+}

--- a/OfficeIMO.Pdf/Manipulation/PdfCanvasStampOptions.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfCanvasStampOptions.cs
@@ -3,6 +3,7 @@ namespace OfficeIMO.Pdf;
 /// <summary>Controls arbitrary visual canvas content stamped onto existing PDF pages.</summary>
 public sealed class PdfCanvasStampOptions {
     private double _opacity = 1D;
+    private PdfOptions? _renderingOptions;
 
     /// <summary>Optional target-page selector. Null applies the canvas callback to every page.</summary>
     public PdfPageSelector? TargetPages { get; set; }
@@ -22,9 +23,28 @@ public sealed class PdfCanvasStampOptions {
         }
     }
 
+    /// <summary>
+    /// Generated-PDF rendering options used for the temporary visual overlay.
+    /// The value is cloned on assignment and retrieval. Page geometry, margins, and encryption are controlled by the stamping operation.
+    /// Use this to carry registered embedded fonts, text shaping, image handling, and other visual rendering configuration into canvas content.
+    /// </summary>
+    public PdfOptions? RenderingOptions {
+        get => _renderingOptions?.Clone();
+        set => _renderingOptions = value?.Clone();
+    }
+
+    internal PdfOptions? RenderingOptionsSnapshot => _renderingOptions?.Clone();
+
     /// <summary>Sets target pages from a rich page-selector expression.</summary>
     public PdfCanvasStampOptions UseTargetPages(string selector) {
         TargetPages = PdfPageSelector.Parse(selector);
+        return this;
+    }
+
+    /// <summary>Uses cloned generated-PDF rendering options for visual canvas content.</summary>
+    public PdfCanvasStampOptions UseRenderingOptions(PdfOptions options) {
+        Guard.NotNull(options, nameof(options));
+        RenderingOptions = options;
         return this;
     }
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfCanvasStampOptions.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfCanvasStampOptions.cs
@@ -27,6 +27,7 @@ public sealed class PdfCanvasStampOptions {
     /// Generated-PDF rendering options used for the temporary visual overlay.
     /// The value is cloned on assignment and retrieval. Page geometry, margins, and encryption are controlled by the stamping operation.
     /// Use this to carry registered embedded fonts, text shaping, image handling, and other visual rendering configuration into canvas content.
+    /// Tagged structure mode must remain disabled because a visual page import cannot merge the temporary document's structure tree into the target.
     /// </summary>
     public PdfOptions? RenderingOptions {
         get => _renderingOptions?.Clone();

--- a/OfficeIMO.Pdf/Manipulation/PdfCanvasStampOptions.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfCanvasStampOptions.cs
@@ -25,7 +25,7 @@ public sealed class PdfCanvasStampOptions {
 
     /// <summary>
     /// Generated-PDF rendering options used for the temporary visual overlay.
-    /// The value is cloned on assignment and retrieval. Page geometry, margins, and encryption are controlled by the stamping operation.
+    /// The value is cloned on assignment and retrieval. Page geometry, margins, encryption, page chrome, and page decorations are controlled by the stamping operation.
     /// Use this to carry registered embedded fonts, text shaping, image handling, and other visual rendering configuration into canvas content.
     /// Tagged structure mode must remain disabled because a visual page import cannot merge the temporary document's structure tree into the target.
     /// </summary>

--- a/OfficeIMO.Pdf/Manipulation/PdfFormData.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfFormData.cs
@@ -15,7 +15,9 @@ internal static class PdfFormData {
     /// <summary>Exports readable fields as XFDF.</summary>
     public static string ExportXfdf(byte[] pdf, PdfReadOptions? options = null) => Export(pdf, options).ToXfdf();
     /// <summary>Imports typed form data through the validated full-rewrite filler.</summary>
-    public static byte[] Import(byte[] pdf, PdfFormDataSet data, PdfFormFillerOptions? options = null) { Guard.NotNull(data, nameof(data)); return PdfFormFiller.FillFields(pdf, data.ToFieldValues(), options); }
+    public static byte[] Import(byte[] pdf, PdfFormDataSet data, PdfFormFillerOptions? options = null) => Import(pdf, data, options, readOptions: null);
+    internal static byte[] Import(byte[] pdf, PdfFormDataSet data, PdfFormFillerOptions? options, PdfReadOptions? readOptions) { Guard.NotNull(data, nameof(data)); return PdfFormFiller.FillFields(pdf, data.ToFieldValues(), options, readOptions); }
     /// <summary>Imports XFDF through the validated full-rewrite filler.</summary>
-    public static byte[] ImportXfdf(byte[] pdf, string xfdf, PdfFormFillerOptions? options = null) => Import(pdf, PdfFormDataSet.ParseXfdf(xfdf), options);
+    public static byte[] ImportXfdf(byte[] pdf, string xfdf, PdfFormFillerOptions? options = null) => ImportXfdf(pdf, xfdf, options, readOptions: null);
+    internal static byte[] ImportXfdf(byte[] pdf, string xfdf, PdfFormFillerOptions? options, PdfReadOptions? readOptions) => Import(pdf, PdfFormDataSet.ParseXfdf(xfdf), options, readOptions);
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfFormFiller.Api.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfFormFiller.Api.cs
@@ -70,7 +70,7 @@ internal static partial class PdfFormFiller {
         }
 
         acroForm.Items["NeedAppearances"] = new PdfBoolean(options?.KeepNeedAppearances == true);
-        return RewriteAllObjects(objects, catalogObjectNumber, PdfReadDocument.Open(pdf, readOptions).Metadata, pdf);
+        return RewriteAllObjects(objects, catalogObjectNumber, PdfReadDocument.Open(pdf, readOptions).UncheckedMetadata, pdf);
     }
 
     /// <summary>
@@ -317,7 +317,7 @@ internal static partial class PdfFormFiller {
             objects.Remove(objectNumber);
         }
 
-        return RewriteAllObjects(objects, catalogObjectNumber, PdfReadDocument.Open(pdf, readOptions).Metadata, pdf);
+        return RewriteAllObjects(objects, catalogObjectNumber, PdfReadDocument.Open(pdf, readOptions).UncheckedMetadata, pdf);
     }
 
     /// <summary>
@@ -393,7 +393,7 @@ internal static partial class PdfFormFiller {
         }
 
         foreach (int objectNumber in removableObjects) objects.Remove(objectNumber);
-        return RewriteAllObjects(objects, catalogObjectNumber, PdfReadDocument.Open(pdf, readOptions).Metadata, pdf);
+        return RewriteAllObjects(objects, catalogObjectNumber, PdfReadDocument.Open(pdf, readOptions).UncheckedMetadata, pdf);
     }
 
     /// <summary>

--- a/OfficeIMO.Pdf/Manipulation/PdfFormFiller.Api.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfFormFiller.Api.cs
@@ -6,40 +6,46 @@ internal static partial class PdfFormFiller {
     /// Returns a new PDF with simple AcroForm field values updated by fully qualified field name.
     /// </summary>
     public static byte[] FillFields(byte[] pdf, IReadOnlyDictionary<string, string> fieldValues) {
-        return FillFields(pdf, ToFormFieldValues(fieldValues), options: null);
+        return FillFields(pdf, ToFormFieldValues(fieldValues), options: null, readOptions: null);
     }
 
     /// <summary>
     /// Returns a new PDF with simple AcroForm field values updated by fully qualified field name.
     /// </summary>
     public static byte[] FillFields(byte[] pdf, IReadOnlyDictionary<string, string> fieldValues, PdfFormFillerOptions? options) {
-        return FillFields(pdf, ToFormFieldValues(fieldValues), options);
+        return FillFields(pdf, ToFormFieldValues(fieldValues), options, readOptions: null);
     }
+
+    internal static byte[] FillFields(byte[] pdf, IReadOnlyDictionary<string, string> fieldValues, PdfFormFillerOptions? options, PdfReadOptions? readOptions) =>
+        FillFields(pdf, ToFormFieldValues(fieldValues), options, readOptions);
 
     /// <summary>
     /// Returns a new PDF with simple AcroForm field values updated by fully qualified field name.
     /// </summary>
     public static byte[] FillFields(byte[] pdf, IReadOnlyDictionary<string, PdfFormFieldValue> fieldValues) {
-        return FillFields(pdf, fieldValues, options: null);
+        return FillFields(pdf, fieldValues, options: null, readOptions: null);
     }
 
     /// <summary>
     /// Returns a new PDF with simple AcroForm field values updated by fully qualified field name.
     /// </summary>
     public static byte[] FillFields(byte[] pdf, IReadOnlyDictionary<string, PdfFormFieldValue> fieldValues, PdfFormFillerOptions? options) {
-        return FillFieldsCore(pdf, fieldValues, options, requireMutationPlan: true);
+        return FillFields(pdf, fieldValues, options, readOptions: null);
     }
+
+    internal static byte[] FillFields(byte[] pdf, IReadOnlyDictionary<string, PdfFormFieldValue> fieldValues, PdfFormFillerOptions? options, PdfReadOptions? readOptions) =>
+        FillFieldsCore(pdf, fieldValues, options, readOptions, requireMutationPlan: true);
 
     internal static byte[] FillFieldsWithinPlannedRewrite(byte[] pdf, IReadOnlyDictionary<string, PdfFormFieldValue> fieldValues, PdfFormFillerOptions? options = null) {
-        return FillFieldsCore(pdf, fieldValues, options, requireMutationPlan: false);
+        return FillFieldsCore(pdf, fieldValues, options, readOptions: null, requireMutationPlan: false);
     }
 
-    private static byte[] FillFieldsCore(byte[] pdf, IReadOnlyDictionary<string, PdfFormFieldValue> fieldValues, PdfFormFillerOptions? options, bool requireMutationPlan) {
+    private static byte[] FillFieldsCore(byte[] pdf, IReadOnlyDictionary<string, PdfFormFieldValue> fieldValues, PdfFormFillerOptions? options, PdfReadOptions? readOptions, bool requireMutationPlan) {
         Guard.NotNull(pdf, nameof(pdf));
         ValidateFieldValues(fieldValues);
-        if (requireMutationPlan) _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.FillFormFields, fieldNames: fieldValues.Keys);
+        if (requireMutationPlan) _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.FillFormFields, readOptions, fieldNames: fieldValues.Keys);
 
-        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf);
+        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf, readOptions);
         int catalogObjectNumber = FindCatalogObjectNumber(objects, trailerRaw);
         if (catalogObjectNumber == 0 ||
             objects[catalogObjectNumber].Value is not PdfDictionary catalog ||
@@ -64,7 +70,7 @@ internal static partial class PdfFormFiller {
         }
 
         acroForm.Items["NeedAppearances"] = new PdfBoolean(options?.KeepNeedAppearances == true);
-        return RewriteAllObjects(objects, catalogObjectNumber, PdfReadDocument.Open(pdf).Metadata, pdf);
+        return RewriteAllObjects(objects, catalogObjectNumber, PdfReadDocument.Open(pdf, readOptions).Metadata, pdf);
     }
 
     /// <summary>
@@ -259,17 +265,21 @@ internal static partial class PdfFormFiller {
     /// Returns a new PDF with simple text, choice, and button AcroForm widgets painted into page content and removed from the form tree.
     /// </summary>
     public static byte[] FlattenFields(byte[] pdf) {
-        return FlattenFields(pdf, options: null);
+        return FlattenFields(pdf, options: null, readOptions: null);
     }
 
     /// <summary>
     /// Returns a new PDF with simple text, choice, and button AcroForm widgets painted into page content and removed from the form tree.
     /// </summary>
     public static byte[] FlattenFields(byte[] pdf, PdfFormFillerOptions? options) {
-        Guard.NotNull(pdf, nameof(pdf));
-        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.FlattenFormFields);
+        return FlattenFields(pdf, options, readOptions: null);
+    }
 
-        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf);
+    internal static byte[] FlattenFields(byte[] pdf, PdfFormFillerOptions? options, PdfReadOptions? readOptions) {
+        Guard.NotNull(pdf, nameof(pdf));
+        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.FlattenFormFields, readOptions);
+
+        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf, readOptions);
         int catalogObjectNumber = FindCatalogObjectNumber(objects, trailerRaw);
         if (catalogObjectNumber == 0 ||
             objects[catalogObjectNumber].Value is not PdfDictionary catalog ||
@@ -307,26 +317,29 @@ internal static partial class PdfFormFiller {
             objects.Remove(objectNumber);
         }
 
-        return RewriteAllObjects(objects, catalogObjectNumber, PdfReadDocument.Open(pdf).Metadata, pdf);
+        return RewriteAllObjects(objects, catalogObjectNumber, PdfReadDocument.Open(pdf, readOptions).Metadata, pdf);
     }
 
     /// <summary>
     /// Returns a new PDF with only the named simple text, choice, and button AcroForm fields painted into page content and removed from the form tree.
     /// </summary>
     public static byte[] FlattenFields(byte[] pdf, IReadOnlyCollection<string> fieldNames, PdfFormFillerOptions? options = null) {
-        return FlattenFieldsCore(pdf, fieldNames, options, requireMutationPlan: true);
+        return FlattenFieldsCore(pdf, fieldNames, options, readOptions: null, requireMutationPlan: true);
     }
+
+    internal static byte[] FlattenFields(byte[] pdf, IReadOnlyCollection<string> fieldNames, PdfFormFillerOptions? options, PdfReadOptions? readOptions) =>
+        FlattenFieldsCore(pdf, fieldNames, options, readOptions, requireMutationPlan: true);
 
     internal static byte[] FlattenFieldsWithinPlannedRewrite(byte[] pdf, IReadOnlyCollection<string> fieldNames, PdfFormFillerOptions? options = null) {
-        return FlattenFieldsCore(pdf, fieldNames, options, requireMutationPlan: false);
+        return FlattenFieldsCore(pdf, fieldNames, options, readOptions: null, requireMutationPlan: false);
     }
 
-    private static byte[] FlattenFieldsCore(byte[] pdf, IReadOnlyCollection<string> fieldNames, PdfFormFillerOptions? options, bool requireMutationPlan) {
+    private static byte[] FlattenFieldsCore(byte[] pdf, IReadOnlyCollection<string> fieldNames, PdfFormFillerOptions? options, PdfReadOptions? readOptions, bool requireMutationPlan) {
         Guard.NotNull(pdf, nameof(pdf));
         ValidateFlattenFieldNames(fieldNames);
-        if (requireMutationPlan) _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.FlattenFormFields, fieldNames: fieldNames);
+        if (requireMutationPlan) _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.FlattenFormFields, readOptions, fieldNames: fieldNames);
 
-        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf);
+        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf, readOptions);
         int catalogObjectNumber = FindCatalogObjectNumber(objects, trailerRaw);
         if (catalogObjectNumber == 0 ||
             objects[catalogObjectNumber].Value is not PdfDictionary catalog ||
@@ -380,7 +393,7 @@ internal static partial class PdfFormFiller {
         }
 
         foreach (int objectNumber in removableObjects) objects.Remove(objectNumber);
-        return RewriteAllObjects(objects, catalogObjectNumber, PdfReadDocument.Open(pdf).Metadata, pdf);
+        return RewriteAllObjects(objects, catalogObjectNumber, PdfReadDocument.Open(pdf, readOptions).Metadata, pdf);
     }
 
     /// <summary>
@@ -491,6 +504,9 @@ internal static partial class PdfFormFiller {
         return FlattenFields(FillFields(pdf, fieldValues, options), options);
     }
 
+    internal static byte[] FillAndFlattenFields(byte[] pdf, IReadOnlyDictionary<string, string> fieldValues, PdfFormFillerOptions? options, PdfReadOptions? readOptions) =>
+        FlattenFields(FillFields(pdf, fieldValues, options, readOptions), options);
+
     /// <summary>
     /// Returns a new PDF with simple AcroForm field values updated and then flattened into page content.
     /// </summary>
@@ -504,6 +520,9 @@ internal static partial class PdfFormFiller {
     public static byte[] FillAndFlattenFields(byte[] pdf, IReadOnlyDictionary<string, PdfFormFieldValue> fieldValues, PdfFormFillerOptions? options) {
         return FlattenFields(FillFields(pdf, fieldValues, options), options);
     }
+
+    internal static byte[] FillAndFlattenFields(byte[] pdf, IReadOnlyDictionary<string, PdfFormFieldValue> fieldValues, PdfFormFillerOptions? options, PdfReadOptions? readOptions) =>
+        FlattenFields(FillFields(pdf, fieldValues, options, readOptions), options);
 
     /// <summary>
     /// Returns a new PDF with simple AcroForm field values updated and flattened from the current position of a readable stream.

--- a/OfficeIMO.Pdf/Manipulation/PdfMergeResult.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMergeResult.cs
@@ -2,9 +2,13 @@ namespace OfficeIMO.Pdf;
 
 /// <summary>Observable inventory for one source supplied to a PDF merge.</summary>
 public sealed class PdfMergeSourceInventory {
-    internal PdfMergeSourceInventory(int sourceIndex, int pageCount, int outlineCount, int namedDestinationCount, int pageLabelCount, int formFieldCount, int attachmentCount) {
+    internal PdfMergeSourceInventory(int sourceIndex, int pageCount, int outlineCount, int namedDestinationCount, int pageLabelCount, int formFieldCount, int attachmentCount, PdfDocumentSecurityInfo security, PdfPermissionPolicy permissionPolicy) {
         SourceIndex = sourceIndex; PageCount = pageCount; OutlineCount = outlineCount; NamedDestinationCount = namedDestinationCount;
         PageLabelCount = pageLabelCount; FormFieldCount = formFieldCount; AttachmentCount = attachmentCount;
+        Security = security;
+        HasEncryption = security.HasEncryption; PasswordAuthenticationRole = security.PasswordAuthenticationRole;
+        PermissionRestrictionsIgnored = PdfPermissionAuthorization.RestrictionsIgnored(security, permissionPolicy);
+        HasSignatures = security.HasSignatures;
     }
     /// <summary>Zero-based source index.</summary>
     public int SourceIndex { get; }
@@ -20,6 +24,16 @@ public sealed class PdfMergeSourceInventory {
     public int FormFieldCount { get; }
     /// <summary>Readable embedded or associated files.</summary>
     public int AttachmentCount { get; }
+    /// <summary>Complete security state detected for this source.</summary>
+    public PdfDocumentSecurityInfo Security { get; }
+    /// <summary>True when this source was encrypted.</summary>
+    public bool HasEncryption { get; }
+    /// <summary>Password role established for this source.</summary>
+    public PdfPasswordAuthenticationRole PasswordAuthenticationRole { get; }
+    /// <summary>True when authenticated user-password restrictions were explicitly ignored for this source.</summary>
+    public bool PermissionRestrictionsIgnored { get; }
+    /// <summary>True when signature evidence was detected in this source.</summary>
+    public bool HasSignatures { get; }
 }
 
 /// <summary>One applied merge-policy decision.</summary>
@@ -44,8 +58,8 @@ public sealed class PdfMergeDecision {
 
 /// <summary>Policy and readback evidence returned by a first-party PDF merge.</summary>
 public sealed class PdfMergeReport {
-    internal PdfMergeReport(IReadOnlyList<PdfMergeSourceInventory> sources, IReadOnlyList<PdfMergeDecision> decisions, int outputPageCount) {
-        Sources = sources; Decisions = decisions; OutputPageCount = outputPageCount;
+    internal PdfMergeReport(IReadOnlyList<PdfMergeSourceInventory> sources, IReadOnlyList<PdfMergeDecision> decisions, int outputPageCount, PdfDocumentSecurityInfo outputSecurity) {
+        Sources = sources; Decisions = decisions; OutputPageCount = outputPageCount; OutputSecurity = outputSecurity;
     }
     /// <summary>Per-source structure inventory captured before mutation.</summary>
     public IReadOnlyList<PdfMergeSourceInventory> Sources { get; }
@@ -53,6 +67,12 @@ public sealed class PdfMergeReport {
     public IReadOnlyList<PdfMergeDecision> Decisions { get; }
     /// <summary>Page count read back from the saved artifact.</summary>
     public int OutputPageCount { get; }
+    /// <summary>Complete security state read back from the merged output.</summary>
+    public PdfDocumentSecurityInfo OutputSecurity { get; }
+    /// <summary>True when the merged output remains encrypted.</summary>
+    public bool OutputHasEncryption => OutputSecurity.HasEncryption;
+    /// <summary>True when signature evidence is present in the merged output.</summary>
+    public bool OutputHasSignatures => OutputSecurity.HasSignatures;
 }
 
 /// <summary>Merged PDF bytes plus the policy decisions and readback evidence.</summary>

--- a/OfficeIMO.Pdf/Manipulation/PdfMerger.Policy.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMerger.Policy.cs
@@ -16,8 +16,20 @@ internal static partial class PdfMerger {
             source.Document.NamedDestinations.Count,
             source.Document.PageLabels.Count,
             source.Document.FormFields.Count,
-            PdfAttachmentExtractor.ExtractAttachments(source.Document).Count)).ToArray();
+            PdfAttachmentExtractor.ExtractAttachments(source.Document).Count,
+            source.Document.Security,
+            source.Document.ReadOptions.PermissionPolicy)).ToArray();
         var decisions = new List<PdfMergeDecision>();
+        int encryptedSourceCount = inventories.Count(static source => source.HasEncryption);
+        int ignoredRestrictionCount = inventories.Count(static source => source.PermissionRestrictionsIgnored);
+        if (encryptedSourceCount > 0) {
+            string action = "Decrypted " + encryptedSourceCount.ToString(System.Globalization.CultureInfo.InvariantCulture) +
+                " authenticated source(s) and produced an unencrypted merged output.";
+            if (ignoredRestrictionCount > 0) {
+                action += " Permission restrictions were explicitly ignored for " + ignoredRestrictionCount.ToString(System.Globalization.CultureInfo.InvariantCulture) + " source(s).";
+            }
+            decisions.Add(new PdfMergeDecision("Security", PdfMergeStructureMode.Combine, action, encryptedSourceCount));
+        }
         if (options?.FlattenVisualAnnotations == true) decisions.Add(new PdfMergeDecision("SourceAnnotations", PdfMergeStructureMode.Combine, "Flattened supported visual annotations before import; links, forms, and unsupported shapes remained live."));
         if (options?.ResizePages != null) decisions.Add(new PdfMergeDecision("PageSizeNormalization", PdfMergeStructureMode.Combine, "Normalized every source page through the requested resize mode before import."));
 
@@ -38,7 +50,7 @@ internal static partial class PdfMerger {
             throw new InvalidOperationException("PDF merge post-save validation failed: output page count did not match the imported page count.");
         }
 
-        return new PdfMergeResult(merged, new PdfMergeReport(inventories, decisions.AsReadOnly(), readback.Pages.Count));
+        return new PdfMergeResult(merged, new PdfMergeReport(inventories, decisions.AsReadOnly(), readback.Pages.Count, readback.Security));
     }
 
     private static byte[] ApplyMetadataPolicy(

--- a/OfficeIMO.Pdf/Manipulation/PdfMerger.Policy.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMerger.Policy.cs
@@ -17,8 +17,8 @@ internal static partial class PdfMerger {
             source.Document.PageLabels.Count,
             source.Document.FormFields.Count,
             PdfAttachmentExtractor.ExtractAttachments(source.Document).Count,
-            source.Document.Security,
-            source.Document.ReadOptions.PermissionPolicy)).ToArray();
+            source.SourceSecurity,
+            source.SourcePermissionPolicy)).ToArray();
         var decisions = new List<PdfMergeDecision>();
         int encryptedSourceCount = inventories.Count(static source => source.HasEncryption);
         int ignoredRestrictionCount = inventories.Count(static source => source.PermissionRestrictionsIgnored);

--- a/OfficeIMO.Pdf/Manipulation/PdfMerger.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMerger.cs
@@ -40,6 +40,12 @@ internal static partial class PdfMerger {
         return MergeCore(pdfs, primarySourceIndex: 0, options: null, readOptions).ToBytes();
     }
 
+    internal static PdfMergeResult MergeWithReport(PdfMergeOptions options, IReadOnlyList<byte[]> pdfs, IReadOnlyList<PdfReadOptions> readOptions) {
+        Guard.NotNull(options, nameof(options));
+        Guard.NotNull(readOptions, nameof(readOptions));
+        return MergeCore(pdfs, primarySourceIndex: 0, options, readOptions);
+    }
+
     /// <summary>
     /// Merges all pages from the supplied PDFs into one new PDF, applying optional source preparation first.
     /// </summary>

--- a/OfficeIMO.Pdf/Manipulation/PdfMerger.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMerger.cs
@@ -145,8 +145,23 @@ internal static partial class PdfMerger {
             }
 
             PdfReadOptions? sourceReadOptions = readOptions?[i];
+            PdfMutationPlan sourceMergePlan = PdfMutationPlanner.RequireFullRewrite(
+                source,
+                PdfMutationOperation.MergeDocuments,
+                sourceReadOptions);
+            PdfDocumentSecurityInfo sourceSecurity = sourceMergePlan.Preflight.Probe.Security;
+            PdfPermissionPolicy sourcePermissionPolicy = sourceMergePlan.Preflight.PermissionPolicy;
             source = PrepareMergeSource(source, options, sourceReadOptions);
-            importedSources.Add(ImportSource(source, i, null, mergedPageOffset, null, PdfMutationOperation.MergeDocuments, sourceReadOptions));
+            importedSources.Add(ImportSource(
+                source,
+                i,
+                null,
+                mergedPageOffset,
+                null,
+                PdfMutationOperation.MergeDocuments,
+                sourceReadOptions,
+                sourceSecurity,
+                sourcePermissionPolicy));
             mergedPageOffset += importedSources[importedSources.Count - 1].PageObjectNumbers.Length;
         }
 
@@ -422,7 +437,9 @@ internal static partial class PdfMerger {
         int mergedPageOffset,
         IReadOnlyDictionary<int, int>? outputPageIndexByPageObjectNumber,
         PdfMutationOperation mutationOperation = PdfMutationOperation.ExtractPages,
-        PdfReadOptions? readOptions = null) {
+        PdfReadOptions? readOptions = null,
+        PdfDocumentSecurityInfo? sourceSecurity = null,
+        PdfPermissionPolicy? sourcePermissionPolicy = null) {
         _ = PdfMutationPlanner.RequireFullRewrite(source, mutationOperation, readOptions);
 
         var (objects, trailerRaw) = PdfSyntax.ParseObjects(source, readOptions);
@@ -455,7 +472,15 @@ internal static partial class PdfMerger {
         collector.CollectObjectGraph(catalogState.AssociatedFiles);
         collector.CollectObjectGraph(catalogState.OptionalContent);
         int[] formFieldRootObjectNumbers = CollectAcroFormFieldRoots(objects, document, collector);
-        return new ImportedSource(objects, document, pageObjectNumbers, collector, catalogState, formFieldRootObjectNumbers);
+        return new ImportedSource(
+            objects,
+            document,
+            pageObjectNumbers,
+            collector,
+            catalogState,
+            formFieldRootObjectNumbers,
+            sourceSecurity ?? document.Security,
+            sourcePermissionPolicy ?? document.ReadOptions.PermissionPolicy);
     }
 
     private static byte[] WriteMerged(
@@ -536,13 +561,17 @@ internal static partial class PdfMerger {
             int[] pageObjectNumbers,
             PdfPageExtractor.ObjectCollector collector,
             PdfPageExtractor.CatalogRewriteState catalogState,
-            int[] formFieldRootObjectNumbers) {
+            int[] formFieldRootObjectNumbers,
+            PdfDocumentSecurityInfo sourceSecurity,
+            PdfPermissionPolicy sourcePermissionPolicy) {
             Objects = objects;
             Document = document;
             PageObjectNumbers = pageObjectNumbers;
             Collector = collector;
             CatalogState = catalogState;
             FormFieldRootObjectNumbers = formFieldRootObjectNumbers;
+            SourceSecurity = sourceSecurity;
+            SourcePermissionPolicy = sourcePermissionPolicy;
         }
 
         public Dictionary<int, PdfIndirectObject> Objects { get; }
@@ -558,6 +587,10 @@ internal static partial class PdfMerger {
         public PdfPageExtractor.CatalogRewriteState CatalogState { get; }
 
         public int[] FormFieldRootObjectNumbers { get; }
+
+        public PdfDocumentSecurityInfo SourceSecurity { get; }
+
+        public PdfPermissionPolicy SourcePermissionPolicy { get; }
 
         public IReadOnlyDictionary<int, int>? OutputNumberMap { get; set; }
     }

--- a/OfficeIMO.Pdf/Manipulation/PdfMerger.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMerger.cs
@@ -69,14 +69,30 @@ internal static partial class PdfMerger {
         return MergeCore(pdfs, primarySourceIndex, options: null).ToBytes();
     }
 
+    internal static byte[] MergeWithPrimarySource(
+        int primarySourceIndex,
+        IReadOnlyList<byte[]> pdfs,
+        IReadOnlyList<PdfReadOptions> readOptions) {
+        Guard.NotNull(readOptions, nameof(readOptions));
+        return MergeCore(pdfs, primarySourceIndex, options: null, readOptions).ToBytes();
+    }
+
     internal static byte[] MergePrimaryWithInsertedPages(byte[] primaryPdf, byte[] insertedPdf, int insertBeforePageNumber) {
+        return MergePrimaryWithInsertedPages(primaryPdf, insertedPdf, insertBeforePageNumber, primaryReadOptions: null);
+    }
+
+    internal static byte[] MergePrimaryWithInsertedPages(
+        byte[] primaryPdf,
+        byte[] insertedPdf,
+        int insertBeforePageNumber,
+        PdfReadOptions? primaryReadOptions) {
         Guard.NotNull(primaryPdf, nameof(primaryPdf));
         Guard.NotNull(insertedPdf, nameof(insertedPdf));
 
-        _ = PdfMutationPlanner.RequireFullRewrite(primaryPdf, PdfMutationOperation.ModifyPageTree);
+        _ = PdfMutationPlanner.RequireFullRewrite(primaryPdf, PdfMutationOperation.ModifyPageTree, primaryReadOptions);
         _ = PdfMutationPlanner.RequireFullRewrite(insertedPdf, PdfMutationOperation.ExtractPages);
 
-        var primaryDocument = PdfReadDocument.Open(primaryPdf);
+        var primaryDocument = PdfReadDocument.Open(primaryPdf, primaryReadOptions);
         if (primaryDocument.Pages.Count == 0) {
             throw new ArgumentException("Primary PDF does not contain any pages.", nameof(primaryPdf));
         }
@@ -110,7 +126,7 @@ internal static partial class PdfMerger {
         }
 
         var importedSources = new[] {
-            ImportSource(primaryPdf, 0, primaryPageObjectNumbers, 0, primaryPageIndexMap),
+            ImportSource(primaryPdf, 0, primaryPageObjectNumbers, 0, primaryPageIndexMap, PdfMutationOperation.ModifyPageTree, primaryReadOptions),
             ImportSource(insertedPdf, 1, insertedPageObjectNumbers, insertBeforePageNumber - 1, null)
         };
         return WriteMerged(importedSources, primarySourceIndex: 0, outputOrder);

--- a/OfficeIMO.Pdf/Manipulation/PdfMerger.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMerger.cs
@@ -594,7 +594,7 @@ internal static partial class PdfMerger {
 
         public PdfReadDocument Document { get; }
 
-        public PdfMetadata Metadata => Document.Metadata;
+        public PdfMetadata Metadata => Document.UncheckedMetadata;
 
         public int[] PageObjectNumbers { get; }
 

--- a/OfficeIMO.Pdf/Manipulation/PdfMetadataEditor.Xmp.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMetadataEditor.Xmp.cs
@@ -12,10 +12,21 @@ internal static partial class PdfMetadataEditor {
         string? subject = null,
         string? keywords = null,
         bool createXmpMetadata = true) {
-        Guard.NotNull(pdf, nameof(pdf));
-        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.SynchronizeMetadata);
+        return SynchronizeMetadata(pdf, title, author, subject, keywords, createXmpMetadata, readOptions: null);
+    }
 
-        PdfDocumentInfo documentInfo = PdfInspector.Inspect(pdf);
+    internal static byte[] SynchronizeMetadata(
+        byte[] pdf,
+        string? title,
+        string? author,
+        string? subject,
+        string? keywords,
+        bool createXmpMetadata,
+        PdfReadOptions? readOptions) {
+        Guard.NotNull(pdf, nameof(pdf));
+        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.SynchronizeMetadata, readOptions);
+
+        PdfDocumentInfo documentInfo = PdfInspector.Inspect(pdf, readOptions);
         PdfMetadata existing = documentInfo.Metadata;
         PdfXmpMetadataInfo? existingXmp = documentInfo.XmpMetadata;
         var updated = new PdfMetadata {
@@ -27,7 +38,7 @@ internal static partial class PdfMetadataEditor {
 
         return PdfDocumentObjectGraphRewriter.Rewrite(
             pdf,
-            sourceReadOptions: null,
+            sourceReadOptions: readOptions,
             outputEncryption: null,
             (objects, security) => SynchronizeObjectGraph(objects, security, existingXmp, updated, createXmpMetadata));
     }

--- a/OfficeIMO.Pdf/Manipulation/PdfMetadataEditor.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMetadataEditor.cs
@@ -29,10 +29,10 @@ internal static partial class PdfMetadataEditor {
 
         var document = PdfReadDocument.Open(pdf, readOptions);
         var metadata = new PdfMetadata {
-            Title = title ?? document.Metadata.Title,
-            Author = author ?? document.Metadata.Author,
-            Subject = subject ?? document.Metadata.Subject,
-            Keywords = keywords ?? document.Metadata.Keywords
+            Title = title ?? document.UncheckedMetadata.Title,
+            Author = author ?? document.UncheckedMetadata.Author,
+            Subject = subject ?? document.UncheckedMetadata.Subject,
+            Keywords = keywords ?? document.UncheckedMetadata.Keywords
         };
 
         return RewriteWithMetadata(pdf, metadata, readOptions);

--- a/OfficeIMO.Pdf/Manipulation/PdfMetadataEditor.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMetadataEditor.cs
@@ -14,10 +14,20 @@ internal static partial class PdfMetadataEditor {
         string? author = null,
         string? subject = null,
         string? keywords = null) {
-        Guard.NotNull(pdf, nameof(pdf));
-        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.UpdateMetadata);
+        return UpdateMetadata(pdf, title, author, subject, keywords, readOptions: null);
+    }
 
-        var document = PdfReadDocument.Open(pdf);
+    internal static byte[] UpdateMetadata(
+        byte[] pdf,
+        string? title,
+        string? author,
+        string? subject,
+        string? keywords,
+        PdfReadOptions? readOptions) {
+        Guard.NotNull(pdf, nameof(pdf));
+        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.UpdateMetadata, readOptions);
+
+        var document = PdfReadDocument.Open(pdf, readOptions);
         var metadata = new PdfMetadata {
             Title = title ?? document.Metadata.Title,
             Author = author ?? document.Metadata.Author,
@@ -25,7 +35,7 @@ internal static partial class PdfMetadataEditor {
             Keywords = keywords ?? document.Metadata.Keywords
         };
 
-        return RewriteWithMetadata(pdf, metadata);
+        return RewriteWithMetadata(pdf, metadata, readOptions);
     }
 
     /// <summary>
@@ -118,11 +128,15 @@ internal static partial class PdfMetadataEditor {
     /// Creates a new PDF with exactly the supplied document metadata.
     /// </summary>
     public static byte[] ReplaceMetadata(byte[] pdf, PdfMetadata metadata) {
+        return ReplaceMetadata(pdf, metadata, readOptions: null);
+    }
+
+    internal static byte[] ReplaceMetadata(byte[] pdf, PdfMetadata metadata, PdfReadOptions? readOptions) {
         Guard.NotNull(pdf, nameof(pdf));
         Guard.NotNull(metadata, nameof(metadata));
-        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.UpdateMetadata);
+        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.UpdateMetadata, readOptions);
 
-        return RewriteWithMetadata(pdf, metadata);
+        return RewriteWithMetadata(pdf, metadata, readOptions);
     }
 
     /// <summary>
@@ -181,9 +195,9 @@ internal static partial class PdfMetadataEditor {
         return ReplaceMetadata(File.ReadAllBytes(inputPath), metadata);
     }
 
-    private static byte[] RewriteWithMetadata(byte[] pdf, PdfMetadata metadata) {
-        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf);
-        var document = PdfReadDocument.Open(pdf);
+    private static byte[] RewriteWithMetadata(byte[] pdf, PdfMetadata metadata, PdfReadOptions? readOptions) {
+        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf, readOptions);
+        var document = PdfReadDocument.Open(pdf, readOptions);
         if (document.Pages.Count == 0) {
             throw new ArgumentException("PDF does not contain any pages.", nameof(pdf));
         }

--- a/OfficeIMO.Pdf/Manipulation/PdfMutationPermissionCheck.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMutationPermissionCheck.cs
@@ -8,6 +8,9 @@ public enum PdfMutationPermissionCheck {
     /// <summary>The document security permissions must allow general modification.</summary>
     ModifyDocument,
 
+    /// <summary>The document security permissions must allow content copying or extraction.</summary>
+    CopyContents,
+
     /// <summary>The document security permissions must allow document assembly.</summary>
     AssembleDocument,
 

--- a/OfficeIMO.Pdf/Manipulation/PdfMutationPermissionCheck.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMutationPermissionCheck.cs
@@ -8,9 +8,6 @@ public enum PdfMutationPermissionCheck {
     /// <summary>The document security permissions must allow general modification.</summary>
     ModifyDocument,
 
-    /// <summary>The document security permissions must allow content copying or extraction.</summary>
-    CopyContents,
-
     /// <summary>The document security permissions must allow document assembly.</summary>
     AssembleDocument,
 
@@ -33,5 +30,8 @@ public enum PdfMutationPermissionCheck {
     FillSignatureContentsReservation,
 
     /// <summary>The operation requires owner-level authorization for encryption changes.</summary>
-    OwnerAuthorization
+    OwnerAuthorization,
+
+    /// <summary>The document security permissions must allow content copying or extraction.</summary>
+    CopyContents
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfMutationPlan.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMutationPlan.cs
@@ -78,6 +78,9 @@ public sealed class PdfMutationPlan {
     /// <summary>Human-readable explanation of the selected or blocked plan.</summary>
     public IReadOnlyList<string> Diagnostics { get; }
 
+    /// <summary>True when this executable plan explicitly ignores authenticated user-password permission restrictions.</summary>
+    public bool PermissionRestrictionsIgnored => CanExecute && Preflight.PermissionRestrictionsIgnored;
+
     /// <summary>Short plan summary suitable for logs and command surfaces.</summary>
     public string Summary => CanExecute
         ? Operation + " will use " + ExecutionMode + " and requires " + RequiredProofs.Count + " proof check(s)."

--- a/OfficeIMO.Pdf/Manipulation/PdfMutationPlanner.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMutationPlanner.cs
@@ -314,9 +314,12 @@ internal static class PdfMutationPlanner {
                 Add(permissions, PdfMutationPermissionCheck.FieldMdp);
                 break;
             case PdfMutationOperation.ModifyPageTree:
+                Add(permissions, PdfMutationPermissionCheck.AssembleDocument);
+                Add(permissions, PdfMutationPermissionCheck.DocMdp);
+                break;
             case PdfMutationOperation.ExtractPages:
             case PdfMutationOperation.MergeDocuments:
-                Add(permissions, PdfMutationPermissionCheck.ModifyDocument);
+                Add(permissions, PdfMutationPermissionCheck.CopyContents);
                 Add(permissions, PdfMutationPermissionCheck.AssembleDocument);
                 Add(permissions, PdfMutationPermissionCheck.DocMdp);
                 break;

--- a/OfficeIMO.Pdf/Manipulation/PdfMutationPlanner.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMutationPlanner.cs
@@ -540,7 +540,7 @@ internal static class PdfMutationPlanner {
             }
         }
 
-        if (preflight.Probe.HasActiveContent || preflight.DocumentInfo?.HasActiveContent == true) {
+        if (preflight.Probe.HasActiveContent || preflight.UncheckedDocumentInfo?.HasActiveContent == true) {
             Add(warnings, "Input.ActiveContentPreserved");
         }
 

--- a/OfficeIMO.Pdf/Manipulation/PdfMutationPlanner.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMutationPlanner.cs
@@ -110,13 +110,14 @@ internal static class PdfMutationPlanner {
         bool securityRewrite = operation == PdfMutationOperation.ChangeEncryption && fullRewriteCapability;
         bool requiresAppendOnly = RequiresAppendOnlyForOperation(security, operation);
         bool unsignedSignatureFieldRewrite = operation == PdfMutationOperation.ModifyAcroForm && CanFullRewriteUnsignedSignatureFields(security);
-        bool normalizedObjectGraphRewrite = (operation == PdfMutationOperation.MergeDocuments || operation == PdfMutationOperation.Optimize) && CanNormalizeObjectGraphSource(security);
+        bool normalizedObjectGraphRewrite = (operation == PdfMutationOperation.MergeDocuments || operation == PdfMutationOperation.Optimize) && CanNormalizeObjectGraphSource(preflight, operation);
+        bool authorizedEncryptedRewrite = security.HasEncryption && CanUseAuthenticatedEncryptedRewrite(preflight, operation);
         bool fullRewriteAvailable =
             fullRewriteImplemented &&
             fullRewriteCapability &&
             (securityRewrite ||
                 (!requiresAppendOnly &&
-                (!security.BlocksOfficeIMOFullRewriteMutation || unsignedSignatureFieldRewrite || normalizedObjectGraphRewrite || CanExtractPagesViaNormalization(preflight, operation))));
+                (!security.BlocksOfficeIMOFullRewriteMutation || unsignedSignatureFieldRewrite || normalizedObjectGraphRewrite || authorizedEncryptedRewrite || CanExtractPagesViaNormalization(preflight, operation))));
         bool appendOnlyAvailable = appendOnlyImplemented && CanAppend(appendOnly, operation);
 
         PdfMutationExecutionMode mode;
@@ -194,6 +195,9 @@ internal static class PdfMutationPlanner {
                 return preflight.CanRewrite || CanExtractPagesViaNormalization(preflight, operation);
             case PdfMutationOperation.MergeDocuments:
                 return CanMergeDocuments(preflight);
+            case PdfMutationOperation.ModifyPageContent:
+            case PdfMutationOperation.ModifyPageTree:
+                return CanRewriteAllowingAuthorizedEncryption(preflight, operation);
             case PdfMutationOperation.Optimize:
                 return CanOptimize(preflight);
             case PdfMutationOperation.Redact:
@@ -535,6 +539,10 @@ internal static class PdfMutationPlanner {
             Add(warnings, "Input.RevisionHistoryWillBeNormalized");
         }
 
+        if (mode != PdfMutationExecutionMode.Blocked && preflight.PermissionRestrictionsIgnored) {
+            Add(warnings, "Input.PermissionRestrictionsIgnored");
+        }
+
         return warnings.Count == 0 ? Array.Empty<string>() : warnings.AsReadOnly();
     }
 
@@ -629,9 +637,7 @@ internal static class PdfMutationPlanner {
         }
 
         PdfDocumentSecurityInfo security = preflight.Probe.Security;
-        return !security.HasEncryption ||
-            security.HasOwnerAuthorization ||
-            (security.AllowsCopying == true && security.AllowsDocumentAssembly == true);
+        return PdfPermissionAuthorization.CanMutate(security, preflight.PermissionPolicy, operation);
     }
 
     private static bool CanChangeEncryption(PdfDocumentPreflight preflight) {
@@ -650,7 +656,13 @@ internal static class PdfMutationPlanner {
     private static bool CanMergeDocuments(PdfDocumentPreflight preflight) {
         if (!preflight.CanRead) return false;
         for (int i = 0; i < preflight.RewriteBlockers.Count; i++) {
-            if (IsFullRewriteBlockerForOperation(preflight.RewriteBlockers[i].Kind, PdfMutationOperation.MergeDocuments)) return false;
+            PdfRewriteBlockerKind blocker = preflight.RewriteBlockers[i].Kind;
+            if (blocker == PdfRewriteBlockerKind.Encryption &&
+                PdfPermissionAuthorization.CanMutate(preflight.Probe.Security, preflight.PermissionPolicy, PdfMutationOperation.MergeDocuments)) {
+                continue;
+            }
+
+            if (IsFullRewriteBlockerForOperation(blocker, PdfMutationOperation.MergeDocuments)) return false;
         }
         return true;
     }
@@ -697,11 +709,46 @@ internal static class PdfMutationPlanner {
         !security.HasXrefStreams &&
         !security.HasObjectStreams;
 
-    private static bool CanNormalizeObjectGraphSource(PdfDocumentSecurityInfo security) =>
-        !security.HasEncryption &&
+    private static bool CanNormalizeObjectGraphSource(PdfDocumentPreflight preflight, PdfMutationOperation operation) {
+        PdfDocumentSecurityInfo security = preflight.Probe.Security;
+        return (!security.HasEncryption || PdfPermissionAuthorization.CanMutate(security, preflight.PermissionPolicy, operation)) &&
         !security.HasSignatures &&
         !security.HasDocMDPPermissions &&
         !security.HasUsageRights;
+    }
+
+    private static bool CanUseAuthenticatedEncryptedRewrite(PdfDocumentPreflight preflight, PdfMutationOperation operation) {
+        PdfDocumentSecurityInfo security = preflight.Probe.Security;
+        if (!security.HasEncryption || security.HasSignatures || security.HasDocMDPPermissions || security.HasUsageRights) {
+            return false;
+        }
+
+        if (operation != PdfMutationOperation.MergeDocuments &&
+            operation != PdfMutationOperation.ExtractPages &&
+            operation != PdfMutationOperation.ModifyPageContent &&
+            operation != PdfMutationOperation.ModifyPageTree) {
+            return false;
+        }
+
+        return PdfPermissionAuthorization.CanMutate(security, preflight.PermissionPolicy, operation);
+    }
+
+    private static bool CanRewriteAllowingAuthorizedEncryption(PdfDocumentPreflight preflight, PdfMutationOperation operation) {
+        if (!preflight.CanRead) {
+            return false;
+        }
+
+        for (int i = 0; i < preflight.RewriteBlockers.Count; i++) {
+            PdfRewriteBlockerKind blocker = preflight.RewriteBlockers[i].Kind;
+            if (blocker == PdfRewriteBlockerKind.Encryption && CanUseAuthenticatedEncryptedRewrite(preflight, operation)) {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
 
     private static bool CanSynchronizeMetadata(PdfDocumentPreflight preflight) {
         if (!preflight.CanRead) {

--- a/OfficeIMO.Pdf/Manipulation/PdfMutationPlanner.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfMutationPlanner.cs
@@ -125,6 +125,8 @@ internal static class PdfMutationPlanner {
             mode = fullRewriteAvailable ? PdfMutationExecutionMode.FullRewrite : PdfMutationExecutionMode.Blocked;
         } else if (executionPreference == PdfMutationExecutionPreference.RequireAppendOnly || RequiresAppendOnlyByDefinition(operation)) {
             mode = appendOnlyAvailable ? PdfMutationExecutionMode.AppendOnly : PdfMutationExecutionMode.Blocked;
+        } else if (security.HasEncryption && appendOnlyAvailable) {
+            mode = PdfMutationExecutionMode.AppendOnly;
         } else if (fullRewriteAvailable) {
             mode = PdfMutationExecutionMode.FullRewrite;
         } else if (appendOnlyAvailable) {
@@ -149,7 +151,7 @@ internal static class PdfMutationPlanner {
             permissions,
             proofs,
             blockers);
-        IReadOnlyList<string> warnings = GetWarnings(preflight, appendOnly, mode, security);
+        IReadOnlyList<string> warnings = GetWarnings(preflight, appendOnly, operation, mode, security);
         IReadOnlyList<string> diagnostics = GetDiagnostics(preflight, appendOnly, operation, mode, blockers, fullRewriteCapability, appendOnlyAvailable, security);
 
         return new PdfMutationPlan(
@@ -171,6 +173,8 @@ internal static class PdfMutationPlanner {
 
     private static bool CanFullRewrite(PdfDocumentPreflight preflight, PdfMutationOperation operation) {
         switch (operation) {
+            case PdfMutationOperation.UpdateMetadata:
+                return CanRewriteAllowingAuthorizedEncryption(preflight, operation);
             case PdfMutationOperation.SynchronizeMetadata:
                 return CanSynchronizeMetadata(preflight);
             case PdfMutationOperation.Sanitize:
@@ -472,6 +476,11 @@ internal static class PdfMutationPlanner {
             }
         } else {
             for (int i = 0; i < preflight.RewriteBlockers.Count; i++) {
+                if (preflight.RewriteBlockers[i].Kind == PdfRewriteBlockerKind.Encryption &&
+                    CanUseAuthenticatedEncryptedRewrite(preflight, operation)) {
+                    continue;
+                }
+
                 if (IsFullRewriteBlockerForOperation(preflight.RewriteBlockers[i].Kind, operation)) {
                     Add(blockers, "FullRewrite." + preflight.RewriteBlockers[i].Kind);
                 }
@@ -521,6 +530,7 @@ internal static class PdfMutationPlanner {
     private static IReadOnlyList<string> GetWarnings(
         PdfDocumentPreflight preflight,
         PdfAppendOnlyMutationReport appendOnly,
+        PdfMutationOperation operation,
         PdfMutationExecutionMode mode,
         PdfDocumentSecurityInfo security) {
         var warnings = new List<string>();
@@ -540,6 +550,12 @@ internal static class PdfMutationPlanner {
 
         if (mode == PdfMutationExecutionMode.FullRewrite && security.HasIncrementalUpdates) {
             Add(warnings, "Input.RevisionHistoryWillBeNormalized");
+        }
+
+        if (mode == PdfMutationExecutionMode.FullRewrite &&
+            security.HasEncryption &&
+            operation != PdfMutationOperation.ChangeEncryption) {
+            Add(warnings, "Output.EncryptionWillBeRemoved");
         }
 
         if (mode != PdfMutationExecutionMode.Blocked && preflight.PermissionRestrictionsIgnored) {
@@ -729,7 +745,13 @@ internal static class PdfMutationPlanner {
         if (operation != PdfMutationOperation.MergeDocuments &&
             operation != PdfMutationOperation.ExtractPages &&
             operation != PdfMutationOperation.ModifyPageContent &&
-            operation != PdfMutationOperation.ModifyPageTree) {
+            operation != PdfMutationOperation.ModifyPageTree &&
+            operation != PdfMutationOperation.UpdateMetadata &&
+            operation != PdfMutationOperation.SynchronizeMetadata &&
+            operation != PdfMutationOperation.Sanitize &&
+            operation != PdfMutationOperation.FillFormFields &&
+            operation != PdfMutationOperation.FlattenFormFields &&
+            operation != PdfMutationOperation.FillAndFlattenFormFields) {
             return false;
         }
 
@@ -759,7 +781,13 @@ internal static class PdfMutationPlanner {
         }
 
         for (int i = 0; i < preflight.RewriteBlockers.Count; i++) {
-            if (IsFullRewriteBlockerForOperation(preflight.RewriteBlockers[i].Kind, PdfMutationOperation.SynchronizeMetadata)) {
+            PdfRewriteBlockerKind blocker = preflight.RewriteBlockers[i].Kind;
+            if (blocker == PdfRewriteBlockerKind.Encryption &&
+                CanUseAuthenticatedEncryptedRewrite(preflight, PdfMutationOperation.SynchronizeMetadata)) {
+                continue;
+            }
+
+            if (IsFullRewriteBlockerForOperation(blocker, PdfMutationOperation.SynchronizeMetadata)) {
                 return false;
             }
         }
@@ -792,6 +820,12 @@ internal static class PdfMutationPlanner {
             return blocker != PdfRewriteBlockerKind.Forms;
         }
 
+        if (operation == PdfMutationOperation.FillFormFields ||
+            operation == PdfMutationOperation.FlattenFormFields ||
+            operation == PdfMutationOperation.FillAndFlattenFormFields) {
+            return blocker != PdfRewriteBlockerKind.Forms;
+        }
+
         return true;
     }
 
@@ -801,7 +835,13 @@ internal static class PdfMutationPlanner {
         }
 
         for (int i = 0; i < preflight.RewriteBlockers.Count; i++) {
-            if (IsFullRewriteBlockerForOperation(preflight.RewriteBlockers[i].Kind, PdfMutationOperation.Sanitize)) {
+            PdfRewriteBlockerKind blocker = preflight.RewriteBlockers[i].Kind;
+            if (blocker == PdfRewriteBlockerKind.Encryption &&
+                CanUseAuthenticatedEncryptedRewrite(preflight, PdfMutationOperation.Sanitize)) {
+                continue;
+            }
+
+            if (IsFullRewriteBlockerForOperation(blocker, PdfMutationOperation.Sanitize)) {
                 return false;
             }
         }

--- a/OfficeIMO.Pdf/Manipulation/PdfOptimizer.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfOptimizer.cs
@@ -42,7 +42,7 @@ internal static partial class PdfOptimizer {
         var actions = new List<PdfOptimizationAction>();
         var skippedActions = new List<PdfOptimizationSkippedAction>();
         var optimizedObjects = new Dictionary<int, PdfIndirectObject>(objects);
-        PdfMetadata metadata = PdfReadDocument.Open(pdf, readOptions).Metadata;
+        PdfMetadata metadata = PdfReadDocument.Open(pdf, readOptions).UncheckedMetadata;
         if (effectiveOptions.CompressUnfilteredStreams) {
             CompressUnfilteredStreams(optimizedObjects, effectiveOptions, actions, skippedActions);
         }

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Compose.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Compose.cs
@@ -22,7 +22,7 @@ internal static partial class PdfPageEditor {
         PdfFileVersion fileVersion = PdfPageExtractor.GetSourceFileVersion(pdf);
         return PdfPageExtractor.ExtractPages(
             objects,
-            document.Metadata,
+            document.UncheckedMetadata,
             orderedObjectNumbers,
             catalogState: PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw),
             fileVersion: fileVersion);

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Crop.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Crop.cs
@@ -93,7 +93,7 @@ internal static partial class PdfPageEditor {
             transformedArrays);
         return PdfPageExtractor.ExtractPages(
             objects,
-            document.Metadata,
+            document.UncheckedMetadata,
             pageObjectNumbers,
             overrides,
             additionalObjects,

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Delete.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Delete.cs
@@ -35,7 +35,7 @@ internal static partial class PdfPageEditor {
         }
 
         PdfFileVersion fileVersion = PdfPageExtractor.GetSourceFileVersion(pdf);
-        return PdfPageExtractor.ExtractPages(objects, document.Metadata, remaining.ToArray(), catalogState: PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw), fileVersion: fileVersion);
+        return PdfPageExtractor.ExtractPages(objects, document.UncheckedMetadata, remaining.ToArray(), catalogState: PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw), fileVersion: fileVersion);
     }
 
     /// <summary>

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Delete.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Delete.cs
@@ -5,16 +5,20 @@ internal static partial class PdfPageEditor {
     /// Creates a new PDF with the specified one-based pages removed.
     /// </summary>
     public static byte[] DeletePages(byte[] pdf, params int[] pageNumbers) {
+        return DeletePagesWithReadOptions(pdf, readOptions: null, pageNumbers);
+    }
+
+    internal static byte[] DeletePagesWithReadOptions(byte[] pdf, PdfReadOptions? readOptions, params int[] pageNumbers) {
         Guard.NotNull(pdf, nameof(pdf));
         Guard.NotNull(pageNumbers, nameof(pageNumbers));
-        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyPageTree);
+        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyPageTree, readOptions);
 
         if (pageNumbers.Length == 0) {
             throw new ArgumentException("At least one page number must be specified.", nameof(pageNumbers));
         }
 
-        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf);
-        var document = PdfReadDocument.Open(pdf);
+        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf, readOptions);
+        var document = PdfReadDocument.Open(pdf, readOptions);
         ValidatePageNumbers(pageNumbers, document.Pages.Count, nameof(pageNumbers));
 
         var deleted = new HashSet<int>(pageNumbers);

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Duplicate.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Duplicate.cs
@@ -6,16 +6,20 @@ internal static partial class PdfPageEditor {
     /// Repeated selections create repeated page copies.
     /// </summary>
     public static byte[] DuplicatePages(byte[] pdf, params int[] pageNumbers) {
+        return DuplicatePagesWithReadOptions(pdf, null, pageNumbers);
+    }
+
+    internal static byte[] DuplicatePagesWithReadOptions(byte[] pdf, PdfReadOptions? readOptions, params int[] pageNumbers) {
         Guard.NotNull(pdf, nameof(pdf));
         Guard.NotNull(pageNumbers, nameof(pageNumbers));
-        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyPageTree);
+        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyPageTree, readOptions);
 
         if (pageNumbers.Length == 0) {
             throw new ArgumentException("At least one page number must be specified.", nameof(pageNumbers));
         }
 
-        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf);
-        var document = PdfReadDocument.Open(pdf);
+        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf, readOptions);
+        var document = PdfReadDocument.Open(pdf, readOptions);
         ValidatePageNumbers(pageNumbers, document.Pages.Count, nameof(pageNumbers), allowDuplicates: true);
 
         var duplicateCounts = new Dictionary<int, int>();

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Duplicate.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Duplicate.cs
@@ -44,7 +44,7 @@ internal static partial class PdfPageEditor {
         }
 
         PdfFileVersion fileVersion = PdfPageExtractor.GetSourceFileVersion(pdf);
-        return PdfPageExtractor.ExtractPages(objects, document.Metadata, ordered.ToArray(), catalogState: PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw), fileVersion: fileVersion);
+        return PdfPageExtractor.ExtractPages(objects, document.UncheckedMetadata, ordered.ToArray(), catalogState: PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw), fileVersion: fileVersion);
     }
 
     /// <summary>

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Move.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Move.cs
@@ -57,7 +57,7 @@ internal static partial class PdfPageEditor {
         }
 
         PdfFileVersion fileVersion = PdfPageExtractor.GetSourceFileVersion(pdf);
-        return PdfPageExtractor.ExtractPages(objects, document.Metadata, ordered.ToArray(), catalogState: PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw), fileVersion: fileVersion);
+        return PdfPageExtractor.ExtractPages(objects, document.UncheckedMetadata, ordered.ToArray(), catalogState: PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw), fileVersion: fileVersion);
     }
 
     /// <summary>

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Move.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Move.cs
@@ -6,16 +6,20 @@ internal static partial class PdfPageEditor {
     /// The moved pages keep their original relative order. Use page count + 1 to move pages to the end.
     /// </summary>
     public static byte[] MovePages(byte[] pdf, int insertBeforePageNumber, params int[] pageNumbers) {
+        return MovePagesWithReadOptions(pdf, insertBeforePageNumber, readOptions: null, pageNumbers);
+    }
+
+    internal static byte[] MovePagesWithReadOptions(byte[] pdf, int insertBeforePageNumber, PdfReadOptions? readOptions, params int[] pageNumbers) {
         Guard.NotNull(pdf, nameof(pdf));
         Guard.NotNull(pageNumbers, nameof(pageNumbers));
-        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyPageTree);
+        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyPageTree, readOptions);
 
         if (pageNumbers.Length == 0) {
             throw new ArgumentException("At least one page number must be specified.", nameof(pageNumbers));
         }
 
-        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf);
-        var document = PdfReadDocument.Open(pdf);
+        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf, readOptions);
+        var document = PdfReadDocument.Open(pdf, readOptions);
         ValidateMoveInsertBeforePageNumber(insertBeforePageNumber, document.Pages.Count);
         ValidatePageNumbers(pageNumbers, document.Pages.Count, nameof(pageNumbers));
 

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.PageBoxes.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.PageBoxes.cs
@@ -65,7 +65,7 @@ internal static partial class PdfPageEditor {
         }
 
         PdfFileVersion fileVersion = PdfPageExtractor.GetSourceFileVersion(pdf);
-        return PdfPageExtractor.ExtractPages(objects, document.Metadata, pageObjectNumbers, overrides, catalogState: PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw), fileVersion: fileVersion);
+        return PdfPageExtractor.ExtractPages(objects, document.UncheckedMetadata, pageObjectNumbers, overrides, catalogState: PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw), fileVersion: fileVersion);
     }
 
     /// <summary>Creates a new PDF with the selected pages updated to the supplied production boundary box from a readable stream.</summary>

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.PageBoxes.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.PageBoxes.cs
@@ -3,8 +3,11 @@ namespace OfficeIMO.Pdf;
 internal static partial class PdfPageEditor {
     /// <summary>Creates a new PDF with the selected pages updated to the supplied typed boundary box.</summary>
     public static byte[] SetPageBox(byte[] pdf, PdfPageBoundaryBox box, double left, double bottom, double right, double top, params int[] pageNumbers) {
-        return SetPageBox(pdf, GetPageBoxName(box), left, bottom, right, top, pageNumbers);
+        return SetPageBoxWithReadOptions(pdf, box, left, bottom, right, top, readOptions: null, pageNumbers);
     }
+
+    internal static byte[] SetPageBoxWithReadOptions(byte[] pdf, PdfPageBoundaryBox box, double left, double bottom, double right, double top, PdfReadOptions? readOptions, params int[] pageNumbers) =>
+        SetPageBoxWithReadOptions(pdf, GetPageBoxName(box), left, bottom, right, top, readOptions, pageNumbers);
 
     /// <summary>Sets the media box for selected pages, or every page when no page numbers are supplied.</summary>
     public static byte[] SetMediaBox(byte[] pdf, double left, double bottom, double right, double top, params int[] pageNumbers) =>
@@ -30,14 +33,18 @@ internal static partial class PdfPageEditor {
     /// Creates a new PDF with the selected pages updated to the supplied production boundary box.
     /// </summary>
     public static byte[] SetPageBox(byte[] pdf, string boxName, double left, double bottom, double right, double top, params int[] pageNumbers) {
+        return SetPageBoxWithReadOptions(pdf, boxName, left, bottom, right, top, readOptions: null, pageNumbers);
+    }
+
+    internal static byte[] SetPageBoxWithReadOptions(byte[] pdf, string boxName, double left, double bottom, double right, double top, PdfReadOptions? readOptions, params int[] pageNumbers) {
         Guard.NotNull(pdf, nameof(pdf));
         Guard.NotNull(pageNumbers, nameof(pageNumbers));
         string normalizedBoxName = NormalizePageBoxName(boxName);
         ValidatePageBoxCoordinates(left, bottom, right, top);
-        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyPageTree);
+        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyPageTree, readOptions);
 
-        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf);
-        var document = PdfReadDocument.Open(pdf);
+        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf, readOptions);
+        var document = PdfReadDocument.Open(pdf, readOptions);
         var selectedPages = pageNumbers.Length == 0
             ? Enumerable.Range(1, document.Pages.Count).ToArray()
             : pageNumbers;

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Reorder.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Reorder.cs
@@ -23,7 +23,7 @@ internal static partial class PdfPageEditor {
         }
 
         PdfFileVersion fileVersion = PdfPageExtractor.GetSourceFileVersion(pdf);
-        return PdfPageExtractor.ExtractPages(objects, document.Metadata, ordered, catalogState: PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw), fileVersion: fileVersion);
+        return PdfPageExtractor.ExtractPages(objects, document.UncheckedMetadata, ordered, catalogState: PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw), fileVersion: fileVersion);
     }
 
     /// <summary>

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Reorder.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Reorder.cs
@@ -5,12 +5,16 @@ internal static partial class PdfPageEditor {
     /// Creates a new PDF with every page copied in the specified one-based order.
     /// </summary>
     public static byte[] ReorderPages(byte[] pdf, params int[] pageNumbers) {
+        return ReorderPagesWithReadOptions(pdf, null, pageNumbers);
+    }
+
+    internal static byte[] ReorderPagesWithReadOptions(byte[] pdf, PdfReadOptions? readOptions, params int[] pageNumbers) {
         Guard.NotNull(pdf, nameof(pdf));
         Guard.NotNull(pageNumbers, nameof(pageNumbers));
-        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyPageTree);
+        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyPageTree, readOptions);
 
-        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf);
-        var document = PdfReadDocument.Open(pdf);
+        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf, readOptions);
+        var document = PdfReadDocument.Open(pdf, readOptions);
         ValidateReorderPageNumbers(pageNumbers, document.Pages.Count, nameof(pageNumbers));
 
         var ordered = new int[pageNumbers.Length];

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Resize.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Resize.cs
@@ -95,7 +95,7 @@ internal static partial class PdfPageEditor {
         TransformPageAnnotationsForResize(objects, document, selected, transformsByPageObjectNumber, overrides, additionalObjects, ref nextPseudoObjectNumber, destinationVisitedReferences, transformedDestinationArrays);
         return PdfPageExtractor.ExtractPages(
             objects,
-            document.Metadata,
+            document.UncheckedMetadata,
             pageObjectNumbers,
             overrides,
             additionalObjects,

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Rotate.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Rotate.cs
@@ -35,7 +35,7 @@ internal static partial class PdfPageEditor {
         }
 
         PdfFileVersion fileVersion = PdfPageExtractor.GetSourceFileVersion(pdf);
-        return PdfPageExtractor.ExtractPages(objects, document.Metadata, pageObjectNumbers, overrides, catalogState: PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw), fileVersion: fileVersion);
+        return PdfPageExtractor.ExtractPages(objects, document.UncheckedMetadata, pageObjectNumbers, overrides, catalogState: PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw), fileVersion: fileVersion);
     }
 
     /// <summary>

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Rotate.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.Rotate.cs
@@ -5,13 +5,17 @@ internal static partial class PdfPageEditor {
     /// Creates a new PDF with the selected pages rotated to the specified degrees. If no page numbers are supplied, all pages are rotated.
     /// </summary>
     public static byte[] RotatePages(byte[] pdf, int rotationDegrees, params int[] pageNumbers) {
+        return RotatePagesWithReadOptions(pdf, rotationDegrees, readOptions: null, pageNumbers);
+    }
+
+    internal static byte[] RotatePagesWithReadOptions(byte[] pdf, int rotationDegrees, PdfReadOptions? readOptions, params int[] pageNumbers) {
         Guard.NotNull(pdf, nameof(pdf));
         Guard.NotNull(pageNumbers, nameof(pageNumbers));
-        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyPageTree);
+        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyPageTree, readOptions);
 
         int normalizedRotation = NormalizeRotation(rotationDegrees);
-        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf);
-        var document = PdfReadDocument.Open(pdf);
+        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf, readOptions);
+        var document = PdfReadDocument.Open(pdf, readOptions);
         var selectedPages = pageNumbers.Length == 0
             ? Enumerable.Range(1, document.Pages.Count).ToArray()
             : pageNumbers;

--- a/OfficeIMO.Pdf/Manipulation/PdfPageExtractor.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageExtractor.cs
@@ -53,7 +53,7 @@ internal static partial class PdfPageExtractor {
 
         var pageObjectNumbers = selected.Select(pageNumber => document.Pages[pageNumber - 1].ObjectNumber).ToArray();
         PdfFileVersion fileVersion = GetSourceFileVersion(pdf);
-        return ExtractPages(objects, document.Metadata, pageObjectNumbers, catalogState: ExtractCatalogRewriteState(objects, trailerRaw), fileVersion: fileVersion);
+        return ExtractPages(objects, document.UncheckedMetadata, pageObjectNumbers, catalogState: ExtractCatalogRewriteState(objects, trailerRaw), fileVersion: fileVersion);
     }
 
     /// <summary>
@@ -246,7 +246,7 @@ internal static partial class PdfPageExtractor {
         }
 
         PdfFileVersion fileVersion = GetSourceFileVersion(pdf);
-        return ExtractPages(objects, document.Metadata, pageObjectNumbers.ToArray(), catalogState: ExtractCatalogRewriteState(objects, trailerRaw), fileVersion: fileVersion);
+        return ExtractPages(objects, document.UncheckedMetadata, pageObjectNumbers.ToArray(), catalogState: ExtractCatalogRewriteState(objects, trailerRaw), fileVersion: fileVersion);
     }
 
     /// <summary>
@@ -330,7 +330,7 @@ internal static partial class PdfPageExtractor {
         var result = new List<byte[]>(document.Pages.Count);
 
         foreach (var page in document.Pages) {
-            result.Add(ExtractPages(objects, document.Metadata, new[] { page.ObjectNumber }, catalogState: catalogState, fileVersion: fileVersion));
+            result.Add(ExtractPages(objects, document.UncheckedMetadata, new[] { page.ObjectNumber }, catalogState: catalogState, fileVersion: fileVersion));
         }
 
         return result;
@@ -389,7 +389,7 @@ internal static partial class PdfPageExtractor {
                 .Range(range.FirstPage, range.PageCount)
                 .Select(pageNumber => document.Pages[pageNumber - 1].ObjectNumber)
                 .ToArray();
-            result.Add(ExtractPages(objects, document.Metadata, pageObjectNumbers, catalogState: catalogState, fileVersion: fileVersion));
+            result.Add(ExtractPages(objects, document.UncheckedMetadata, pageObjectNumbers, catalogState: catalogState, fileVersion: fileVersion));
         }
 
         return result;

--- a/OfficeIMO.Pdf/Manipulation/PdfPageImportOptions.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageImportOptions.cs
@@ -5,6 +5,12 @@ namespace OfficeIMO.Pdf;
 /// </summary>
 public sealed class PdfPageImportOptions {
     /// <summary>
+    /// Gets or sets read options used for the imported source PDF, including its password and permission policy.
+    /// Target-document credentials remain controlled by the document or the corresponding <c>Try*</c> operation.
+    /// </summary>
+    public PdfReadOptions? SourceReadOptions { get; set; }
+
+    /// <summary>
     /// Gets or sets whether supported visual annotations from imported source pages should be painted into page content.
     /// Existing target-document annotations are not flattened by this option.
     /// </summary>

--- a/OfficeIMO.Pdf/Manipulation/PdfPageImporter.Options.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageImporter.Options.cs
@@ -42,12 +42,17 @@ internal static partial class PdfPageImporter {
         int targetPageCount = PdfInspector.Inspect(targetPdf, targetReadOptions).PageCount;
         ValidateInsertBeforePageNumber(insertBeforePageNumber, targetPageCount);
 
-        byte[] preparedSource = PrepareImportSource(sourcePdf, options);
+        PdfReadOptions? sourceReadOptions = options.SourceReadOptions;
+        byte[] preparedSource = PrepareImportSource(sourcePdf, options, sourceReadOptions);
+        PdfReadOptions? preparedSourceReadOptions = options.FlattenVisualAnnotations ? null : sourceReadOptions;
         if (insertBeforePageNumber == targetPageCount + 1) {
-            return ImportPreparedPages(targetPdf, preparedSource, append: true, targetReadOptions, sourcePageNumbers);
+            return ImportPreparedPages(targetPdf, preparedSource, append: true, targetReadOptions, preparedSourceReadOptions, sourcePageNumbers);
         }
 
-        byte[] inserted = PdfPageExtractor.ExtractPages(preparedSource, NormalizeSourcePageNumbers(preparedSource, sourcePageNumbers));
+        byte[] inserted = PdfPageExtractor.ExtractPages(
+            preparedSource,
+            preparedSourceReadOptions,
+            NormalizeSourcePageNumbers(preparedSource, sourcePageNumbers, preparedSourceReadOptions));
         if (insertBeforePageNumber == 1) {
             return PdfMerger.MergeWithPrimarySource(
                 1,
@@ -64,12 +69,21 @@ internal static partial class PdfPageImporter {
         Guard.NotNull(sourcePdf, nameof(sourcePdf));
         Guard.NotNull(sourcePageNumbers, nameof(sourcePageNumbers));
 
-        return ImportPreparedPages(targetPdf, PrepareImportSource(sourcePdf, options), append, targetReadOptions, sourcePageNumbers!);
+        PdfReadOptions? sourceReadOptions = options.SourceReadOptions;
+        byte[] preparedSource = PrepareImportSource(sourcePdf, options, sourceReadOptions);
+        PdfReadOptions? preparedSourceReadOptions = options.FlattenVisualAnnotations ? null : sourceReadOptions;
+        return ImportPreparedPages(targetPdf, preparedSource, append, targetReadOptions, preparedSourceReadOptions, sourcePageNumbers!);
     }
 
-    private static byte[] ImportPreparedPages(byte[] targetPdf, byte[] preparedSourcePdf, bool append, PdfReadOptions? targetReadOptions, int[] sourcePageNumbers) {
-        int[] selectedPages = NormalizeSourcePageNumbers(preparedSourcePdf, sourcePageNumbers);
-        byte[] importedPages = PdfPageExtractor.ExtractPages(preparedSourcePdf, selectedPages);
+    private static byte[] ImportPreparedPages(
+        byte[] targetPdf,
+        byte[] preparedSourcePdf,
+        bool append,
+        PdfReadOptions? targetReadOptions,
+        PdfReadOptions? sourceReadOptions,
+        int[] sourcePageNumbers) {
+        int[] selectedPages = NormalizeSourcePageNumbers(preparedSourcePdf, sourcePageNumbers, sourceReadOptions);
+        byte[] importedPages = PdfPageExtractor.ExtractPages(preparedSourcePdf, sourceReadOptions, selectedPages);
         return append
             ? PdfMerger.Merge(
                 new[] { targetPdf, importedPages },
@@ -80,9 +94,9 @@ internal static partial class PdfPageImporter {
                 new[] { PdfReadOptions.Default, PdfReadOptions.Resolve(targetReadOptions) });
     }
 
-    private static byte[] PrepareImportSource(byte[] sourcePdf, PdfPageImportOptions options) {
+    private static byte[] PrepareImportSource(byte[] sourcePdf, PdfPageImportOptions options, PdfReadOptions? sourceReadOptions) {
         return options.FlattenVisualAnnotations
-            ? PdfAnnotationFlattener.FlattenVisualAnnotations(sourcePdf)
+            ? PdfAnnotationFlattener.FlattenVisualAnnotations(sourcePdf, options: null, readOptions: sourceReadOptions)
             : sourcePdf;
     }
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfPageImporter.Options.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageImporter.Options.cs
@@ -6,7 +6,11 @@ internal static partial class PdfPageImporter {
     /// When no page numbers are supplied, all source pages are appended.
     /// </summary>
     public static byte[] AppendPages(PdfPageImportOptions options, byte[] targetPdf, byte[] sourcePdf, params int[] sourcePageNumbers) {
-        return ImportPages(options, targetPdf, sourcePdf, append: true, sourcePageNumbers);
+        return AppendPages(options, targetPdf, sourcePdf, targetReadOptions: null, sourcePageNumbers);
+    }
+
+    internal static byte[] AppendPages(PdfPageImportOptions options, byte[] targetPdf, byte[] sourcePdf, PdfReadOptions? targetReadOptions, params int[] sourcePageNumbers) {
+        return ImportPages(options, targetPdf, sourcePdf, append: true, targetReadOptions, sourcePageNumbers);
     }
 
     /// <summary>
@@ -14,7 +18,11 @@ internal static partial class PdfPageImporter {
     /// When no page numbers are supplied, all source pages are prepended.
     /// </summary>
     public static byte[] PrependPages(PdfPageImportOptions options, byte[] targetPdf, byte[] sourcePdf, params int[] sourcePageNumbers) {
-        return ImportPages(options, targetPdf, sourcePdf, append: false, sourcePageNumbers);
+        return PrependPages(options, targetPdf, sourcePdf, targetReadOptions: null, sourcePageNumbers);
+    }
+
+    internal static byte[] PrependPages(PdfPageImportOptions options, byte[] targetPdf, byte[] sourcePdf, PdfReadOptions? targetReadOptions, params int[] sourcePageNumbers) {
+        return ImportPages(options, targetPdf, sourcePdf, append: false, targetReadOptions, sourcePageNumbers);
     }
 
     /// <summary>
@@ -22,42 +30,54 @@ internal static partial class PdfPageImporter {
     /// Use target page count + 1 to insert at the end. When no page numbers are supplied, all source pages are inserted.
     /// </summary>
     public static byte[] InsertPages(PdfPageImportOptions options, byte[] targetPdf, byte[] sourcePdf, int insertBeforePageNumber, params int[] sourcePageNumbers) {
+        return InsertPages(options, targetPdf, sourcePdf, insertBeforePageNumber, targetReadOptions: null, sourcePageNumbers);
+    }
+
+    internal static byte[] InsertPages(PdfPageImportOptions options, byte[] targetPdf, byte[] sourcePdf, int insertBeforePageNumber, PdfReadOptions? targetReadOptions, params int[] sourcePageNumbers) {
         Guard.NotNull(options, nameof(options));
         Guard.NotNull(targetPdf, nameof(targetPdf));
         Guard.NotNull(sourcePdf, nameof(sourcePdf));
         Guard.NotNull(sourcePageNumbers, nameof(sourcePageNumbers));
 
-        int targetPageCount = PdfInspector.Inspect(targetPdf).PageCount;
+        int targetPageCount = PdfInspector.Inspect(targetPdf, targetReadOptions).PageCount;
         ValidateInsertBeforePageNumber(insertBeforePageNumber, targetPageCount);
 
         byte[] preparedSource = PrepareImportSource(sourcePdf, options);
         if (insertBeforePageNumber == targetPageCount + 1) {
-            return ImportPreparedPages(targetPdf, preparedSource, append: true, sourcePageNumbers);
+            return ImportPreparedPages(targetPdf, preparedSource, append: true, targetReadOptions, sourcePageNumbers);
         }
 
         byte[] inserted = PdfPageExtractor.ExtractPages(preparedSource, NormalizeSourcePageNumbers(preparedSource, sourcePageNumbers));
         if (insertBeforePageNumber == 1) {
-            return PdfMerger.MergeWithPrimarySource(1, inserted, targetPdf);
+            return PdfMerger.MergeWithPrimarySource(
+                1,
+                new[] { inserted, targetPdf },
+                new[] { PdfReadOptions.Default, PdfReadOptions.Resolve(targetReadOptions) });
         }
 
-        return PdfMerger.MergePrimaryWithInsertedPages(targetPdf, inserted, insertBeforePageNumber);
+        return PdfMerger.MergePrimaryWithInsertedPages(targetPdf, inserted, insertBeforePageNumber, targetReadOptions);
     }
 
-    private static byte[] ImportPages(PdfPageImportOptions options, byte[] targetPdf, byte[] sourcePdf, bool append, int[]? sourcePageNumbers) {
+    private static byte[] ImportPages(PdfPageImportOptions options, byte[] targetPdf, byte[] sourcePdf, bool append, PdfReadOptions? targetReadOptions, int[]? sourcePageNumbers) {
         Guard.NotNull(options, nameof(options));
         Guard.NotNull(targetPdf, nameof(targetPdf));
         Guard.NotNull(sourcePdf, nameof(sourcePdf));
         Guard.NotNull(sourcePageNumbers, nameof(sourcePageNumbers));
 
-        return ImportPreparedPages(targetPdf, PrepareImportSource(sourcePdf, options), append, sourcePageNumbers!);
+        return ImportPreparedPages(targetPdf, PrepareImportSource(sourcePdf, options), append, targetReadOptions, sourcePageNumbers!);
     }
 
-    private static byte[] ImportPreparedPages(byte[] targetPdf, byte[] preparedSourcePdf, bool append, int[] sourcePageNumbers) {
+    private static byte[] ImportPreparedPages(byte[] targetPdf, byte[] preparedSourcePdf, bool append, PdfReadOptions? targetReadOptions, int[] sourcePageNumbers) {
         int[] selectedPages = NormalizeSourcePageNumbers(preparedSourcePdf, sourcePageNumbers);
         byte[] importedPages = PdfPageExtractor.ExtractPages(preparedSourcePdf, selectedPages);
         return append
-            ? PdfMerger.Merge(targetPdf, importedPages)
-            : PdfMerger.MergeWithPrimarySource(1, importedPages, targetPdf);
+            ? PdfMerger.Merge(
+                new[] { targetPdf, importedPages },
+                new[] { PdfReadOptions.Resolve(targetReadOptions), PdfReadOptions.Default })
+            : PdfMerger.MergeWithPrimarySource(
+                1,
+                new[] { importedPages, targetPdf },
+                new[] { PdfReadOptions.Default, PdfReadOptions.Resolve(targetReadOptions) });
     }
 
     private static byte[] PrepareImportSource(byte[] sourcePdf, PdfPageImportOptions options) {

--- a/OfficeIMO.Pdf/Manipulation/PdfPageImporter.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageImporter.cs
@@ -571,12 +571,12 @@ internal static partial class PdfPageImporter {
             : PdfMerger.MergeWithPrimarySource(1, importedPages, targetPdf);
     }
 
-    private static int[] NormalizeSourcePageNumbers(byte[] sourcePdf, int[] sourcePageNumbers) {
+    private static int[] NormalizeSourcePageNumbers(byte[] sourcePdf, int[] sourcePageNumbers, PdfReadOptions? sourceReadOptions = null) {
         if (sourcePageNumbers.Length > 0) {
             return sourcePageNumbers;
         }
 
-        PdfDocumentInfo info = PdfInspector.Inspect(sourcePdf);
+        PdfDocumentInfo info = PdfInspector.Inspect(sourcePdf, sourceReadOptions);
         if (info.PageCount == 0) {
             throw new ArgumentException("Source PDF does not contain any pages.", nameof(sourcePdf));
         }

--- a/OfficeIMO.Pdf/Manipulation/PdfPageOverlayOptions.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageOverlayOptions.cs
@@ -68,6 +68,9 @@ public sealed class PdfPageOverlayOptions {
     /// <summary>Places the imported page before existing page content.</summary>
     public bool BehindContent { get; set; }
 
+    /// <summary>Read options used for the imported source PDF, including its password and permission policy.</summary>
+    public PdfReadOptions? SourceReadOptions { get; set; }
+
     /// <summary>Sets the target pages from a rich page-selector expression.</summary>
     public PdfPageOverlayOptions UseTargetPages(string selector) {
         TargetPages = PdfPageSelector.Parse(selector);
@@ -85,7 +88,8 @@ public sealed class PdfPageOverlayOptions {
         Width = Width,
         Height = Height,
         Opacity = Opacity,
-        BehindContent = behindContent ?? BehindContent
+        BehindContent = behindContent ?? BehindContent,
+        SourceReadOptions = SourceReadOptions
     };
 
     private static void ValidateOptionalFinite(double? value, string paramName) {

--- a/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.cs
@@ -67,7 +67,7 @@ internal static partial class PdfRedactionApplier {
         }
 
         PdfObjectGraphPruner.PruneUnreachableObjects(objects, catalogObjectNumber);
-        PdfMetadata metadata = (effectiveOptions.CleanupScope & PdfRedactionCleanupScope.Metadata) != 0 ? new PdfMetadata() : document.Metadata;
+        PdfMetadata metadata = (effectiveOptions.CleanupScope & PdfRedactionCleanupScope.Metadata) != 0 ? new PdfMetadata() : document.UncheckedMetadata;
         return RewriteAllObjects(objects, catalogObjectNumber, metadata, pdf);
     }
 

--- a/OfficeIMO.Pdf/Manipulation/PdfRedactionPlanner.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfRedactionPlanner.cs
@@ -25,7 +25,7 @@ internal static partial class PdfRedactionPlanner {
         }
 
         PdfLogicalDocument logical = PdfLogicalDocument.From(PdfReadDocument.Open(pdf, options), layoutOptions);
-        PdfDocumentInfo info = preflight.DocumentInfo ?? PdfInspector.Inspect(pdf, options);
+        PdfDocumentInfo info = preflight.UncheckedDocumentInfo ?? PdfInspector.Inspect(pdf, options);
         var matches = new List<PdfRedactionMatch>();
 
         foreach (PdfRedactionArea area in areaArray) {

--- a/OfficeIMO.Pdf/Manipulation/PdfRewritePreservation.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfRewritePreservation.cs
@@ -17,12 +17,23 @@ public static partial class PdfRewritePreservation {
     /// Compares an original PDF and a rewritten PDF using the supplied preservation profile.
     /// </summary>
     public static PdfRewritePreservationReport Assess(byte[] originalPdf, byte[] rewrittenPdf, PdfRewritePreservationOptions? options) {
+        return Assess(originalPdf, rewrittenPdf, options, originalReadOptions: null, rewrittenReadOptions: null);
+    }
+
+    internal static PdfRewritePreservationReport Assess(
+        byte[] originalPdf,
+        byte[] rewrittenPdf,
+        PdfRewritePreservationOptions? options,
+        PdfReadOptions? originalReadOptions,
+        PdfReadOptions? rewrittenReadOptions) {
         Guard.NotNull(originalPdf, nameof(originalPdf));
         Guard.NotNull(rewrittenPdf, nameof(rewrittenPdf));
 
         options ??= new PdfRewritePreservationOptions();
-        PdfDocumentInfo original = PdfInspector.Inspect(originalPdf, options.OriginalReadOptions);
-        PdfDocumentInfo rewritten = PdfInspector.Inspect(rewrittenPdf, options.RewrittenReadOptions);
+        PdfReadOptions? effectiveOriginalReadOptions = options.OriginalReadOptions ?? originalReadOptions;
+        PdfReadOptions? effectiveRewrittenReadOptions = options.RewrittenReadOptions ?? rewrittenReadOptions;
+        PdfDocumentInfo original = PdfInspector.Inspect(originalPdf, effectiveOriginalReadOptions);
+        PdfDocumentInfo rewritten = PdfInspector.Inspect(rewrittenPdf, effectiveRewrittenReadOptions);
         var issues = new List<PdfRewritePreservationIssue>();
 
         CompareCounts(issues, "PageCount", original.PageCount, rewritten.PageCount, options.PreservePageCount);
@@ -52,7 +63,7 @@ public static partial class PdfRewritePreservation {
         CompareSourceStructure(issues, original, rewritten, options);
         CompareSecurityState(issues, original.Security, rewritten.Security, options);
         CompareCatalogViewSettings(issues, original, rewritten, options);
-        CompareTextMarkers(issues, rewrittenPdf, options.RequiredTextMarkers, options.RewrittenReadOptions);
+        CompareTextMarkers(issues, rewrittenPdf, options.RequiredTextMarkers, effectiveRewrittenReadOptions);
 
         return new PdfRewritePreservationReport(original, rewritten, issues.AsReadOnly());
     }
@@ -69,6 +80,17 @@ public static partial class PdfRewritePreservation {
     /// </summary>
     public static PdfRewritePreservationReport AssertPreserved(byte[] originalPdf, byte[] rewrittenPdf, PdfRewritePreservationOptions? options) {
         PdfRewritePreservationReport report = Assess(originalPdf, rewrittenPdf, options);
+        report.ThrowIfFailed();
+        return report;
+    }
+
+    internal static PdfRewritePreservationReport AssertPreserved(
+        byte[] originalPdf,
+        byte[] rewrittenPdf,
+        PdfRewritePreservationOptions? options,
+        PdfReadOptions? originalReadOptions,
+        PdfReadOptions? rewrittenReadOptions) {
+        PdfRewritePreservationReport report = Assess(originalPdf, rewrittenPdf, options, originalReadOptions, rewrittenReadOptions);
         report.ThrowIfFailed();
         return report;
     }

--- a/OfficeIMO.Pdf/Manipulation/PdfRewritePreservation.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfRewritePreservation.cs
@@ -32,8 +32,8 @@ public static partial class PdfRewritePreservation {
         options ??= new PdfRewritePreservationOptions();
         PdfReadOptions? effectiveOriginalReadOptions = options.OriginalReadOptions ?? originalReadOptions;
         PdfReadOptions? effectiveRewrittenReadOptions = options.RewrittenReadOptions ?? rewrittenReadOptions;
-        PdfDocumentInfo original = PdfInspector.Inspect(originalPdf, effectiveOriginalReadOptions);
-        PdfDocumentInfo rewritten = PdfInspector.Inspect(rewrittenPdf, effectiveRewrittenReadOptions);
+        PdfDocumentInfo original = InspectReportInput(originalPdf, effectiveOriginalReadOptions, "original");
+        PdfDocumentInfo rewritten = InspectReportInput(rewrittenPdf, effectiveRewrittenReadOptions, "rewritten");
         var issues = new List<PdfRewritePreservationIssue>();
 
         CompareCounts(issues, "PageCount", original.PageCount, rewritten.PageCount, options.PreservePageCount);
@@ -66,6 +66,12 @@ public static partial class PdfRewritePreservation {
         CompareTextMarkers(issues, rewrittenPdf, options.RequiredTextMarkers, effectiveRewrittenReadOptions);
 
         return new PdfRewritePreservationReport(original, rewritten, issues.AsReadOnly());
+    }
+
+    private static PdfDocumentInfo InspectReportInput(byte[] pdf, PdfReadOptions? readOptions, string inputName) {
+        PdfReadDocument document = PdfReadDocument.Open(pdf, readOptions);
+        document.DemandContentExtraction(inputName + " rewrite-preservation report");
+        return PdfInspector.Inspect(pdf, document);
     }
 
     /// <summary>

--- a/OfficeIMO.Pdf/Manipulation/PdfSanitizer.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSanitizer.cs
@@ -4,8 +4,12 @@ namespace OfficeIMO.Pdf;
 internal static partial class PdfSanitizer {
     /// <summary>Returns the forbidden-content inventory that the supplied policy would remove.</summary>
     public static IReadOnlyList<PdfSanitizationFinding> Analyze(byte[] pdf, PdfSanitizationOptions? options = null) {
+        return Analyze(pdf, options, readOptions: null);
+    }
+
+    internal static IReadOnlyList<PdfSanitizationFinding> Analyze(byte[] pdf, PdfSanitizationOptions? options, PdfReadOptions? readOptions) {
         Guard.NotNull(pdf, nameof(pdf));
-        var parsed = PdfSyntax.ParseObjects(pdf);
+        var parsed = PdfSyntax.ParseObjects(pdf, readOptions);
         return Scan(parsed.Map, options ?? new PdfSanitizationOptions());
     }
 
@@ -14,17 +18,21 @@ internal static partial class PdfSanitizer {
     /// Quarantine mode returns decoded attachments to the caller but never writes them to disk.
     /// </summary>
     public static PdfSanitizationResult Sanitize(byte[] pdf, PdfSanitizationOptions? options = null) {
+        return Sanitize(pdf, options, readOptions: null);
+    }
+
+    internal static PdfSanitizationResult Sanitize(byte[] pdf, PdfSanitizationOptions? options, PdfReadOptions? readOptions) {
         Guard.NotNull(pdf, nameof(pdf));
         PdfSanitizationOptions policy = options ?? new PdfSanitizationOptions();
-        PdfMutationPlan plan = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.Sanitize);
-        IReadOnlyList<PdfSanitizationFinding> before = Analyze(pdf, policy);
+        PdfMutationPlan plan = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.Sanitize, readOptions);
+        IReadOnlyList<PdfSanitizationFinding> before = Analyze(pdf, policy, readOptions);
         IReadOnlyList<PdfExtractedAttachment> quarantined = policy.EmbeddedFiles == PdfEmbeddedFileSanitizationMode.Quarantine
-            ? PdfAttachmentExtractor.ExtractAttachments(pdf)
+            ? PdfAttachmentExtractor.ExtractAttachments(PdfReadDocument.Open(pdf, readOptions))
             : Array.Empty<PdfExtractedAttachment>();
 
         byte[] sanitized = PdfDocumentObjectGraphRewriter.Rewrite(
             pdf,
-            sourceReadOptions: null,
+            sourceReadOptions: readOptions,
             outputEncryption: null,
             (objects, security) => {
                 SanitizeObjectGraph(objects, policy);
@@ -32,7 +40,7 @@ internal static partial class PdfSanitizer {
                     ? security.InfoObjectNumber
                     : null;
             });
-        IReadOnlyList<PdfSanitizationFinding> remaining = Analyze(sanitized, policy);
+        IReadOnlyList<PdfSanitizationFinding> remaining = Analyze(sanitized, policy, readOptions: null);
         if (remaining.Count > 0) {
             throw new InvalidOperationException(
                 "PDF sanitization post-save validation found " + remaining.Count.ToString(System.Globalization.CultureInfo.InvariantCulture) +

--- a/OfficeIMO.Pdf/Manipulation/PdfSecurityEditor.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfSecurityEditor.cs
@@ -77,7 +77,7 @@ internal static class PdfSecurityEditor {
         byte[] rewrittenPdf = PdfDocumentObjectGraphRewriter.Rewrite(sourcePdf, sourceReadOptions, outputEncryption);
         PdfReadOptions? outputReadOptions = outputEncryption is null
             ? null
-            : new PdfReadOptions { Password = outputEncryption.UserPassword };
+            : new PdfReadOptions { Password = outputEncryption.OwnerPassword ?? outputEncryption.UserPassword };
 
         var preservationOptions = new PdfRewritePreservationOptions {
             OriginalReadOptions = sourceReadOptions,

--- a/OfficeIMO.Pdf/Manipulation/PdfStampPageContext.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfStampPageContext.cs
@@ -1,0 +1,27 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>Existing-page geometry supplied while building visual canvas stamp content.</summary>
+public sealed class PdfStampPageContext {
+    internal PdfStampPageContext(int pageNumber, int pageCount, double width, double height, int rotationDegrees) {
+        PageNumber = pageNumber;
+        PageCount = pageCount;
+        Width = width;
+        Height = height;
+        RotationDegrees = rotationDegrees;
+    }
+
+    /// <summary>One-based target page number.</summary>
+    public int PageNumber { get; }
+
+    /// <summary>Total page count in the target PDF before stamping.</summary>
+    public int PageCount { get; }
+
+    /// <summary>Visual target-page width in points after crop and rotation are applied.</summary>
+    public double Width { get; }
+
+    /// <summary>Visual target-page height in points after crop and rotation are applied.</summary>
+    public double Height { get; }
+
+    /// <summary>Inherited target-page rotation normalized to 0, 90, 180, or 270 degrees.</summary>
+    public int RotationDegrees { get; }
+}

--- a/OfficeIMO.Pdf/Manipulation/PdfStamper.Canvas.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfStamper.Canvas.cs
@@ -18,7 +18,7 @@ internal static partial class PdfStamper {
 
         IReadOnlyList<int> selectedPages = effective.TargetPages?.Resolve(target.Pages.Count) ??
             Enumerable.Range(1, target.Pages.Count).ToArray();
-        byte[] output = pdf;
+        var requests = new List<PageStampRequest>(selectedPages.Count);
         for (int selectedIndex = 0; selectedIndex < selectedPages.Count; selectedIndex++) {
             int pageNumber = selectedPages[selectedIndex];
             PdfReadPage page = target.Pages[pageNumber - 1];
@@ -49,10 +49,10 @@ internal static partial class PdfStamper {
                 Opacity = effective.Opacity,
                 BehindContent = effective.BehindContent
             };
-            output = StampPage(output, overlay, pageOptions, readOptions);
+            requests.Add(new PageStampRequest(overlay, pageOptions));
         }
 
-        return output;
+        return StampPageSetCore(pdf, requests, readOptions);
     }
 
     private static void CopyCanvasItems(PdfPageCanvas source, PdfPageCanvas target) {
@@ -70,6 +70,10 @@ internal static partial class PdfStamper {
                 throw new NotSupportedException("Existing-page canvas stamping accepts visual content only. Use the bookmark editor for document outlines.");
             }
 
+            if (HasInteractiveMetadata(item)) {
+                throw new NotSupportedException("Existing-page canvas stamping accepts visual content only. Links, named destinations, and form controls require their dedicated document editors.");
+            }
+
             if (item is PdfCanvasClipItem clip) {
                 RejectNonVisualCanvasItems(clip.Items);
             } else if (item is PdfCanvasEffectItem effect) {
@@ -82,5 +86,39 @@ internal static partial class PdfStamper {
                 RejectNonVisualCanvasItems(actualText.Items);
             }
         }
+    }
+
+    private static bool HasInteractiveMetadata(PdfCanvasItem item) {
+        if (item is PdfCanvasTextItem text) return HasInteractiveTextRuns(text.Runs);
+        if (item is PdfCanvasTextBoxItem textBox) return HasInteractiveTextRuns(textBox.Runs);
+        if (item is PdfCanvasShapeItem shape) return shape.Block.LinkUri != null;
+        if (item is PdfCanvasDrawingItem drawing) return drawing.Block.LinkUri != null;
+        if (item is PdfCanvasImageItem image) return image.Block.LinkUri != null;
+        if (item is not PdfCanvasTableItem table) return false;
+
+        if (table.Block.Links.Count > 0) return true;
+        for (int rowIndex = 0; rowIndex < table.Block.Cells.Count; rowIndex++) {
+            IReadOnlyList<PdfTableCell> row = table.Block.Cells[rowIndex];
+            for (int cellIndex = 0; cellIndex < row.Count; cellIndex++) {
+                PdfTableCell cell = row[cellIndex];
+                if (cell.LinkUri != null || cell.LinkDestinationName != null || cell.NamedDestinationName != null ||
+                    cell.CheckBoxes.Count > 0 || cell.FormFields.Count > 0 ||
+                    HasInteractiveTextRuns(cell.Runs) ||
+                    cell.Images.Any(static cellImage => cellImage.LinkUri != null) ||
+                    cell.Paragraphs.Any(static paragraph => HasInteractiveTextRuns(paragraph.Runs))) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasInteractiveTextRuns(IReadOnlyList<TextRun> runs) {
+        for (int i = 0; i < runs.Count; i++) {
+            if (runs[i].LinkUri != null || runs[i].LinkDestinationName != null) return true;
+        }
+
+        return false;
     }
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfStamper.Canvas.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfStamper.Canvas.cs
@@ -9,6 +9,10 @@ internal static partial class PdfStamper {
         Guard.NotNull(pdf, nameof(pdf));
         Guard.NotNull(build, nameof(build));
         PdfCanvasStampOptions effective = options ?? new PdfCanvasStampOptions();
+        PdfOptions? renderingOptions = effective.RenderingOptionsSnapshot;
+        if (renderingOptions is not null && renderingOptions.TaggedStructureMode != PdfTaggedStructureMode.None) {
+            throw new NotSupportedException("Existing-page canvas stamping is visual-only and cannot preserve a generated tagged structure tree. Use untagged rendering options or a document authoring path that owns the target structure tree.");
+        }
         _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyPageContent, readOptions);
 
         PdfReadDocument target = PdfReadDocument.Open(pdf, readOptions);
@@ -28,7 +32,7 @@ internal static partial class PdfStamper {
             build(canvas, context);
             RejectNonVisualCanvasItems(canvas.Items);
 
-            PdfOptions overlayOptions = effective.RenderingOptionsSnapshot ?? new PdfOptions();
+            PdfOptions overlayOptions = renderingOptions?.Clone() ?? new PdfOptions();
             overlayOptions.PageWidth = width;
             overlayOptions.PageHeight = height;
             overlayOptions.MarginLeft = 0D;
@@ -74,14 +78,14 @@ internal static partial class PdfStamper {
                 throw new NotSupportedException("Existing-page canvas stamping accepts visual content only. Links, named destinations, and form controls require their dedicated document editors.");
             }
 
+            if (item is PdfCanvasFigureItem || item is PdfCanvasStructureItem) {
+                throw new NotSupportedException("Existing-page canvas stamping is visual-only and cannot preserve canvas figure or structure-tree semantics. Use ordinary visual canvas items or a document authoring path that owns the target structure tree.");
+            }
+
             if (item is PdfCanvasClipItem clip) {
                 RejectNonVisualCanvasItems(clip.Items);
             } else if (item is PdfCanvasEffectItem effect) {
                 RejectNonVisualCanvasItems(effect.Items);
-            } else if (item is PdfCanvasFigureItem figure) {
-                RejectNonVisualCanvasItems(figure.Items);
-            } else if (item is PdfCanvasStructureItem structure) {
-                RejectNonVisualCanvasItems(structure.Items);
             } else if (item is PdfCanvasActualTextItem actualText) {
                 RejectNonVisualCanvasItems(actualText.Items);
             }

--- a/OfficeIMO.Pdf/Manipulation/PdfStamper.Canvas.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfStamper.Canvas.cs
@@ -28,14 +28,14 @@ internal static partial class PdfStamper {
             build(canvas, context);
             RejectNonVisualCanvasItems(canvas.Items);
 
-            var overlayOptions = new PdfOptions {
-                PageWidth = width,
-                PageHeight = height,
-                MarginLeft = 0D,
-                MarginTop = 0D,
-                MarginRight = 0D,
-                MarginBottom = 0D
-            };
+            PdfOptions overlayOptions = effective.RenderingOptionsSnapshot ?? new PdfOptions();
+            overlayOptions.PageWidth = width;
+            overlayOptions.PageHeight = height;
+            overlayOptions.MarginLeft = 0D;
+            overlayOptions.MarginTop = 0D;
+            overlayOptions.MarginRight = 0D;
+            overlayOptions.MarginBottom = 0D;
+            overlayOptions.Encryption = null;
             byte[] overlay = PdfDocument.Create(overlayOptions)
                 .Canvas(generatedCanvas => CopyCanvasItems(canvas, generatedCanvas))
                 .ToBytes();

--- a/OfficeIMO.Pdf/Manipulation/PdfStamper.Canvas.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfStamper.Canvas.cs
@@ -13,6 +13,7 @@ internal static partial class PdfStamper {
         if (renderingOptions is not null && renderingOptions.TaggedStructureMode != PdfTaggedStructureMode.None) {
             throw new NotSupportedException("Existing-page canvas stamping is visual-only and cannot preserve a generated tagged structure tree. Use untagged rendering options or a document authoring path that owns the target structure tree.");
         }
+        PdfOptions? canvasRenderingOptions = renderingOptions?.CloneForCanvasStampRendering();
         _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyPageContent, readOptions);
 
         PdfReadDocument target = PdfReadDocument.Open(pdf, readOptions);
@@ -32,7 +33,7 @@ internal static partial class PdfStamper {
             build(canvas, context);
             RejectNonVisualCanvasItems(canvas.Items);
 
-            PdfOptions overlayOptions = renderingOptions?.Clone() ?? new PdfOptions();
+            PdfOptions overlayOptions = canvasRenderingOptions?.Clone() ?? new PdfOptions();
             overlayOptions.PageWidth = width;
             overlayOptions.PageHeight = height;
             overlayOptions.MarginLeft = 0D;

--- a/OfficeIMO.Pdf/Manipulation/PdfStamper.Canvas.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfStamper.Canvas.cs
@@ -1,0 +1,86 @@
+namespace OfficeIMO.Pdf;
+
+internal static partial class PdfStamper {
+    internal static byte[] StampCanvas(
+        byte[] pdf,
+        Action<PdfPageCanvas, PdfStampPageContext> build,
+        PdfCanvasStampOptions? options = null,
+        PdfReadOptions? readOptions = null) {
+        Guard.NotNull(pdf, nameof(pdf));
+        Guard.NotNull(build, nameof(build));
+        PdfCanvasStampOptions effective = options ?? new PdfCanvasStampOptions();
+        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyPageContent, readOptions);
+
+        PdfReadDocument target = PdfReadDocument.Open(pdf, readOptions);
+        if (target.Pages.Count == 0) {
+            throw new ArgumentException("PDF does not contain any pages.", nameof(pdf));
+        }
+
+        IReadOnlyList<int> selectedPages = effective.TargetPages?.Resolve(target.Pages.Count) ??
+            Enumerable.Range(1, target.Pages.Count).ToArray();
+        byte[] output = pdf;
+        for (int selectedIndex = 0; selectedIndex < selectedPages.Count; selectedIndex++) {
+            int pageNumber = selectedPages[selectedIndex];
+            PdfReadPage page = target.Pages[pageNumber - 1];
+            (double width, double height, _) = page.GetImportGeometry();
+            var context = new PdfStampPageContext(pageNumber, target.Pages.Count, width, height, page.GetRotationDegrees());
+            var canvas = new PdfPageCanvas();
+            build(canvas, context);
+            RejectNonVisualCanvasItems(canvas.Items);
+
+            var overlayOptions = new PdfOptions {
+                PageWidth = width,
+                PageHeight = height,
+                MarginLeft = 0D,
+                MarginTop = 0D,
+                MarginRight = 0D,
+                MarginBottom = 0D
+            };
+            byte[] overlay = PdfDocument.Create(overlayOptions)
+                .Canvas(generatedCanvas => CopyCanvasItems(canvas, generatedCanvas))
+                .ToBytes();
+            var pageOptions = new PdfPageOverlayOptions {
+                TargetPages = PdfPageSelector.Parse(pageNumber.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                Fit = PdfPageOverlayFit.Stretch,
+                X = 0D,
+                Y = 0D,
+                Width = width,
+                Height = height,
+                Opacity = effective.Opacity,
+                BehindContent = effective.BehindContent
+            };
+            output = StampPage(output, overlay, pageOptions, readOptions);
+        }
+
+        return output;
+    }
+
+    private static void CopyCanvasItems(PdfPageCanvas source, PdfPageCanvas target) {
+        target.AddItems(source.Items);
+    }
+
+    private static void RejectNonVisualCanvasItems(IReadOnlyList<PdfCanvasItem> items) {
+        for (int i = 0; i < items.Count; i++) {
+            PdfCanvasItem item = items[i];
+            if (item is PdfCanvasTextAnnotationItem || item is PdfCanvasFreeTextAnnotationItem || item is PdfCanvasHighlightAnnotationItem) {
+                throw new NotSupportedException("Existing-page canvas stamping accepts visual content only. Use the annotation editor for interactive annotations.");
+            }
+
+            if (item is PdfCanvasOutlineItem) {
+                throw new NotSupportedException("Existing-page canvas stamping accepts visual content only. Use the bookmark editor for document outlines.");
+            }
+
+            if (item is PdfCanvasClipItem clip) {
+                RejectNonVisualCanvasItems(clip.Items);
+            } else if (item is PdfCanvasEffectItem effect) {
+                RejectNonVisualCanvasItems(effect.Items);
+            } else if (item is PdfCanvasFigureItem figure) {
+                RejectNonVisualCanvasItems(figure.Items);
+            } else if (item is PdfCanvasStructureItem structure) {
+                RejectNonVisualCanvasItems(structure.Items);
+            } else if (item is PdfCanvasActualTextItem actualText) {
+                RejectNonVisualCanvasItems(actualText.Items);
+            }
+        }
+    }
+}

--- a/OfficeIMO.Pdf/Manipulation/PdfStamper.Images.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfStamper.Images.cs
@@ -121,7 +121,7 @@ internal static partial class PdfStamper {
         }
 
         PdfFileVersion fileVersion = PdfPageExtractor.GetSourceFileVersion(pdf);
-        return PdfPageExtractor.ExtractPages(objects, document.Metadata, pageObjectNumbers, overrides, additionalObjects, PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw), fileVersion);
+        return PdfPageExtractor.ExtractPages(objects, document.UncheckedMetadata, pageObjectNumbers, overrides, additionalObjects, PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw), fileVersion);
     }
 
     /// <summary>

--- a/OfficeIMO.Pdf/Manipulation/PdfStamper.Images.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfStamper.Images.cs
@@ -4,8 +4,8 @@ internal static partial class PdfStamper {
     /// <summary>
     /// Adds an image stamp to selected pages, or every page when no page selection is supplied.
     /// </summary>
-    public static byte[] StampImage(byte[] pdf, byte[] imageBytes, PdfImageStampOptions? options = null) {
-        return StampImageCore(pdf, imageBytes, options, watermarkDefaults: false);
+    public static byte[] StampImage(byte[] pdf, byte[] imageBytes, PdfImageStampOptions? options = null, PdfReadOptions? readOptions = null) {
+        return StampImageCore(pdf, imageBytes, options, watermarkDefaults: false, readOptions);
     }
 
     /// <summary>
@@ -57,10 +57,10 @@ internal static partial class PdfStamper {
         WriteOutput(outputStream, StampImage(stream, imageStream, options));
     }
 
-    private static byte[] StampImageCore(byte[] pdf, byte[] imageBytes, PdfImageStampOptions? options, bool watermarkDefaults) {
+    private static byte[] StampImageCore(byte[] pdf, byte[] imageBytes, PdfImageStampOptions? options, bool watermarkDefaults, PdfReadOptions? readOptions = null) {
         Guard.NotNull(pdf, nameof(pdf));
         Guard.NotNull(imageBytes, nameof(imageBytes));
-        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyPageContent);
+        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyPageContent, readOptions);
         if (imageBytes.Length == 0) {
             throw new ArgumentException("Image bytes cannot be empty.", nameof(imageBytes));
         }
@@ -79,8 +79,8 @@ internal static partial class PdfStamper {
             throw new NotSupportedException(unsupportedReason ?? "Image format is not supported.");
         }
 
-        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf);
-        var document = PdfReadDocument.Open(pdf);
+        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf, readOptions);
+        var document = PdfReadDocument.Open(pdf, readOptions);
         if (document.Pages.Count == 0) {
             throw new ArgumentException("PDF does not contain any pages.", nameof(pdf));
         }
@@ -208,9 +208,9 @@ internal static partial class PdfStamper {
     /// Adds a centered image watermark to selected pages, or every page when no page selection is supplied.
     /// Simple PNG alpha and transparency soft masks are supported for compatible PNG inputs.
     /// </summary>
-    public static byte[] WatermarkImage(byte[] pdf, byte[] imageBytes, PdfImageStampOptions? options = null) {
+    public static byte[] WatermarkImage(byte[] pdf, byte[] imageBytes, PdfImageStampOptions? options = null, PdfReadOptions? readOptions = null) {
         var effectiveOptions = BuildImageWatermarkOptions(options);
-        return StampImageCore(pdf, imageBytes, effectiveOptions, watermarkDefaults: true);
+        return StampImageCore(pdf, imageBytes, effectiveOptions, watermarkDefaults: true, readOptions);
     }
 
     /// <summary>

--- a/OfficeIMO.Pdf/Manipulation/PdfStamper.PageResources.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfStamper.PageResources.cs
@@ -162,7 +162,10 @@ internal static partial class PdfStamper {
         throw new InvalidOperationException("Unable to find an available PDF font resource name for the stamp.");
     }
 
-    private static string GetAvailableXObjectResourceName(Dictionary<int, PdfIndirectObject> objects, int[] pageObjectNumbers) {
+    private static string GetAvailableXObjectResourceName(
+        Dictionary<int, PdfIndirectObject> objects,
+        int[] pageObjectNumbers,
+        HashSet<string>? additionallyUsed = null) {
         var usedNames = new HashSet<string>(StringComparer.Ordinal);
         for (int i = 0; i < pageObjectNumbers.Length; i++) {
             if (!objects.TryGetValue(pageObjectNumbers[i], out var indirect) || indirect.Value is not PdfDictionary pageDictionary) {
@@ -183,7 +186,7 @@ internal static partial class PdfStamper {
         const string baseName = "OIMOStampIm";
         for (int i = 1; i < 1000; i++) {
             string candidate = baseName + i.ToString(CultureInfo.InvariantCulture);
-            if (!usedNames.Contains(candidate)) {
+            if (!usedNames.Contains(candidate) && (additionallyUsed is null || !additionallyUsed.Contains(candidate))) {
                 return candidate;
             }
         }

--- a/OfficeIMO.Pdf/Manipulation/PdfStamper.Pages.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfStamper.Pages.cs
@@ -161,7 +161,7 @@ internal static partial class PdfStamper {
 
         return PdfPageExtractor.ExtractPages(
             targetObjects,
-            target.Metadata,
+            target.UncheckedMetadata,
             pageObjectNumbers,
             overrides,
             catalogState: PdfPageExtractor.ExtractCatalogRewriteState(targetObjects, targetTrailer),

--- a/OfficeIMO.Pdf/Manipulation/PdfStamper.Pages.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfStamper.Pages.cs
@@ -5,18 +5,18 @@ namespace OfficeIMO.Pdf;
 
 internal static partial class PdfStamper {
     /// <summary>Imports one source PDF page as a Form XObject above selected target pages.</summary>
-    public static byte[] OverlayPage(byte[] targetPdf, byte[] sourcePdf, PdfPageOverlayOptions? options = null) {
-        return StampPageCore(targetPdf, sourcePdf, (options ?? new PdfPageOverlayOptions()).Clone(behindContent: false));
+    public static byte[] OverlayPage(byte[] targetPdf, byte[] sourcePdf, PdfPageOverlayOptions? options = null, PdfReadOptions? targetReadOptions = null) {
+        return StampPageCore(targetPdf, sourcePdf, (options ?? new PdfPageOverlayOptions()).Clone(behindContent: false), targetReadOptions);
     }
 
     /// <summary>Imports one source PDF page as a Form XObject below selected target pages.</summary>
-    public static byte[] UnderlayPage(byte[] targetPdf, byte[] sourcePdf, PdfPageOverlayOptions? options = null) {
-        return StampPageCore(targetPdf, sourcePdf, (options ?? new PdfPageOverlayOptions()).Clone(behindContent: true));
+    public static byte[] UnderlayPage(byte[] targetPdf, byte[] sourcePdf, PdfPageOverlayOptions? options = null, PdfReadOptions? targetReadOptions = null) {
+        return StampPageCore(targetPdf, sourcePdf, (options ?? new PdfPageOverlayOptions()).Clone(behindContent: true), targetReadOptions);
     }
 
     /// <summary>Imports one source PDF page as a Form XObject using the requested content order.</summary>
-    public static byte[] StampPage(byte[] targetPdf, byte[] sourcePdf, PdfPageOverlayOptions? options = null) {
-        return StampPageCore(targetPdf, sourcePdf, options?.Clone() ?? new PdfPageOverlayOptions());
+    public static byte[] StampPage(byte[] targetPdf, byte[] sourcePdf, PdfPageOverlayOptions? options = null, PdfReadOptions? targetReadOptions = null) {
+        return StampPageCore(targetPdf, sourcePdf, options?.Clone() ?? new PdfPageOverlayOptions(), targetReadOptions);
     }
 
     /// <summary>Imports a source PDF page onto target pages read from streams.</summary>
@@ -34,17 +34,18 @@ internal static partial class PdfStamper {
         return UnderlayPage(ReadStream(targetPdf, nameof(targetPdf)), ReadStream(sourcePdf, nameof(sourcePdf)), options);
     }
 
-    private static byte[] StampPageCore(byte[] targetPdf, byte[] sourcePdf, PdfPageOverlayOptions options) {
+    private static byte[] StampPageCore(byte[] targetPdf, byte[] sourcePdf, PdfPageOverlayOptions options, PdfReadOptions? targetReadOptions = null) {
         Guard.NotNull(targetPdf, nameof(targetPdf));
         Guard.NotNull(sourcePdf, nameof(sourcePdf));
         Guard.NotNull(options, nameof(options));
-        _ = PdfMutationPlanner.RequireFullRewrite(targetPdf, PdfMutationOperation.ModifyPageContent);
-        _ = PdfMutationPlanner.RequireFullRewrite(sourcePdf, PdfMutationOperation.ExtractPages);
+        PdfReadOptions? sourceReadOptions = options.SourceReadOptions;
+        _ = PdfMutationPlanner.RequireFullRewrite(targetPdf, PdfMutationOperation.ModifyPageContent, targetReadOptions);
+        _ = PdfMutationPlanner.RequireFullRewrite(sourcePdf, PdfMutationOperation.ExtractPages, sourceReadOptions);
 
-        var (targetObjects, targetTrailer) = PdfSyntax.ParseObjects(targetPdf);
-        var (sourceObjects, _) = PdfSyntax.ParseObjects(sourcePdf);
-        PdfReadDocument target = PdfReadDocument.Open(targetPdf);
-        PdfReadDocument source = PdfReadDocument.Open(sourcePdf);
+        var (targetObjects, targetTrailer) = PdfSyntax.ParseObjects(targetPdf, targetReadOptions);
+        var (sourceObjects, _) = PdfSyntax.ParseObjects(sourcePdf, sourceReadOptions);
+        PdfReadDocument target = PdfReadDocument.Open(targetPdf, targetReadOptions);
+        PdfReadDocument source = PdfReadDocument.Open(sourcePdf, sourceReadOptions);
         if (target.Pages.Count == 0) throw new ArgumentException("Target PDF does not contain any pages.", nameof(targetPdf));
         if (options.SourcePageNumber > source.Pages.Count) throw new ArgumentOutOfRangeException(nameof(options), options.SourcePageNumber, "Source page number exceeds the source PDF page count.");
 

--- a/OfficeIMO.Pdf/Manipulation/PdfStamper.Pages.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfStamper.Pages.cs
@@ -35,96 +35,129 @@ internal static partial class PdfStamper {
     }
 
     private static byte[] StampPageCore(byte[] targetPdf, byte[] sourcePdf, PdfPageOverlayOptions options, PdfReadOptions? targetReadOptions = null) {
+        return StampPageSetCore(
+            targetPdf,
+            new[] { new PageStampRequest(sourcePdf, options) },
+            targetReadOptions);
+    }
+
+    private static byte[] StampPageSetCore(
+        byte[] targetPdf,
+        IReadOnlyList<PageStampRequest> requests,
+        PdfReadOptions? targetReadOptions = null) {
         Guard.NotNull(targetPdf, nameof(targetPdf));
-        Guard.NotNull(sourcePdf, nameof(sourcePdf));
-        Guard.NotNull(options, nameof(options));
-        PdfReadOptions? sourceReadOptions = options.SourceReadOptions;
+        Guard.NotNull(requests, nameof(requests));
+        if (requests.Count == 0) {
+            return targetPdf;
+        }
+
         _ = PdfMutationPlanner.RequireFullRewrite(targetPdf, PdfMutationOperation.ModifyPageContent, targetReadOptions);
-        _ = PdfMutationPlanner.RequireFullRewrite(sourcePdf, PdfMutationOperation.ExtractPages, sourceReadOptions);
 
         var (targetObjects, targetTrailer) = PdfSyntax.ParseObjects(targetPdf, targetReadOptions);
-        var (sourceObjects, _) = PdfSyntax.ParseObjects(sourcePdf, sourceReadOptions);
         PdfReadDocument target = PdfReadDocument.Open(targetPdf, targetReadOptions);
-        PdfReadDocument source = PdfReadDocument.Open(sourcePdf, sourceReadOptions);
         if (target.Pages.Count == 0) throw new ArgumentException("Target PDF does not contain any pages.", nameof(targetPdf));
-        if (options.SourcePageNumber > source.Pages.Count) throw new ArgumentOutOfRangeException(nameof(options), options.SourcePageNumber, "Source page number exceeds the source PDF page count.");
-
-        PdfReadPage sourcePage = source.Pages[options.SourcePageNumber - 1];
-        if (!sourceObjects.TryGetValue(sourcePage.ObjectNumber, out PdfIndirectObject? sourcePageObject) || sourcePageObject.Value is not PdfDictionary sourcePageDictionary) {
-            throw new InvalidOperationException("Source PDF page dictionary was not found.");
-        }
-
-        PdfObject? sourceResources = GetInheritedPageValue(sourceObjects, sourcePageDictionary, "Resources");
-        PdfObject? sourceGroup = sourcePageDictionary.Items.TryGetValue("Group", out PdfObject? groupValue)
-            ? groupValue
-            : null;
-        var sourceCollector = new PdfPageExtractor.ObjectCollector(sourceObjects);
-        sourceCollector.CollectObjectGraph(sourceResources);
-        sourceCollector.CollectObjectGraph(sourceGroup);
         int nextObjectNumber = targetObjects.Count == 0 ? 1 : targetObjects.Keys.Max() + 1;
-        var importedObjectNumbers = new Dictionary<int, int>();
-        foreach (int sourceObjectNumber in sourceCollector.ObjectIds) importedObjectNumbers[sourceObjectNumber] = nextObjectNumber++;
-        foreach (int sourceObjectNumber in sourceCollector.ObjectIds) {
-            PdfIndirectObject sourceObject = sourceObjects[sourceObjectNumber];
-            int importedNumber = importedObjectNumbers[sourceObjectNumber];
-            targetObjects[importedNumber] = new PdfIndirectObject(importedNumber, 0, CloneImportedObject(sourceObject.Value, importedObjectNumbers));
-        }
-
-        (double sourceWidth, double sourceHeight, Matrix2D normalization) = sourcePage.GetImportGeometry();
-        byte[] formContent = BuildImportedPageContent(sourceObjects, sourcePageDictionary, sourceWidth, sourceHeight, normalization);
-        var formDictionary = new PdfDictionary();
-        formDictionary.Items["Type"] = new PdfName("XObject");
-        formDictionary.Items["Subtype"] = new PdfName("Form");
-        formDictionary.Items["FormType"] = new PdfNumber(1D);
-        formDictionary.Items["BBox"] = NumberArray(0D, 0D, sourceWidth, sourceHeight);
-        formDictionary.Items["Resources"] = sourceResources == null
-            ? new PdfDictionary()
-            : CloneImportedObject(sourceResources, importedObjectNumbers);
-        if (sourceGroup != null) formDictionary.Items["Group"] = CloneImportedObject(sourceGroup, importedObjectNumbers);
-        int formObjectNumber = nextObjectNumber++;
-        targetObjects[formObjectNumber] = new PdfIndirectObject(formObjectNumber, 0, new PdfStream(formDictionary, formContent));
-
-        int graphicsStateObjectNumber = 0;
-        if (options.Opacity < 1D) {
-            var graphicsState = new PdfDictionary();
-            graphicsState.Items["Type"] = new PdfName("ExtGState");
-            graphicsState.Items["ca"] = new PdfNumber(options.Opacity);
-            graphicsState.Items["CA"] = new PdfNumber(options.Opacity);
-            graphicsStateObjectNumber = nextObjectNumber++;
-            targetObjects[graphicsStateObjectNumber] = new PdfIndirectObject(graphicsStateObjectNumber, 0, graphicsState);
-        }
-
-        IReadOnlyList<int> selectedPages = options.TargetPages?.Resolve(target.Pages.Count) ?? Enumerable.Range(1, target.Pages.Count).ToArray();
-        var selectedSet = new HashSet<int>(selectedPages);
         int[] pageObjectNumbers = target.Pages.Select(page => page.ObjectNumber).ToArray();
-        string formResourceName = GetAvailableXObjectResourceName(targetObjects, pageObjectNumbers);
-        string? graphicsStateResourceName = graphicsStateObjectNumber == 0
-            ? null
-            : GetAvailableGraphicsStateResourceName(targetObjects, pageObjectNumbers);
         var overrides = new Dictionary<int, Dictionary<string, PdfObject>>();
-        for (int pageIndex = 0; pageIndex < target.Pages.Count; pageIndex++) {
-            int pageNumber = pageIndex + 1;
-            if (!selectedSet.Contains(pageNumber)) continue;
-            PdfReadPage targetPage = target.Pages[pageIndex];
-            (double targetWidth, double targetHeight, Matrix2D targetUserToVisual) = targetPage.GetImportGeometry();
-            Matrix2D targetVisualToUser = Invert(targetUserToVisual);
-            PdfStream stamp = BuildImportedPageStampStream(formResourceName, graphicsStateResourceName, sourceWidth, sourceHeight, targetWidth, targetHeight, targetVisualToUser, options);
-            int stampObjectNumber = nextObjectNumber++;
-            targetObjects[stampObjectNumber] = new PdfIndirectObject(stampObjectNumber, 0, stamp);
-            overrides[targetPage.ObjectNumber] = BuildImportedPageOverrides(
-                targetObjects,
-                targetPage.ObjectNumber,
-                formResourceName,
-                formObjectNumber,
-                graphicsStateResourceName,
-                graphicsStateObjectNumber,
-                stampObjectNumber,
-                options.BehindContent);
+        var reservedFormResourceNames = new HashSet<string>(StringComparer.Ordinal);
+        var reservedGraphicsStateResourceNames = new HashSet<string>(StringComparer.Ordinal);
+        var stampedPageNumbers = new HashSet<int>();
+        PdfFileVersion outputVersion = PdfPageExtractor.GetSourceFileVersion(targetPdf);
+
+        for (int requestIndex = 0; requestIndex < requests.Count; requestIndex++) {
+            PageStampRequest request = requests[requestIndex];
+            byte[] sourcePdf = request.SourcePdf;
+            PdfPageOverlayOptions options = request.Options;
+            Guard.NotNull(sourcePdf, nameof(requests));
+            Guard.NotNull(options, nameof(requests));
+            PdfReadOptions? sourceReadOptions = options.SourceReadOptions;
+            _ = PdfMutationPlanner.RequireFullRewrite(sourcePdf, PdfMutationOperation.ExtractPages, sourceReadOptions);
+
+            var (sourceObjects, _) = PdfSyntax.ParseObjects(sourcePdf, sourceReadOptions);
+            PdfReadDocument source = PdfReadDocument.Open(sourcePdf, sourceReadOptions);
+            if (options.SourcePageNumber > source.Pages.Count) {
+                throw new ArgumentOutOfRangeException(nameof(requests), options.SourcePageNumber, "Source page number exceeds the source PDF page count.");
+            }
+
+            PdfReadPage sourcePage = source.Pages[options.SourcePageNumber - 1];
+            if (!sourceObjects.TryGetValue(sourcePage.ObjectNumber, out PdfIndirectObject? sourcePageObject) || sourcePageObject.Value is not PdfDictionary sourcePageDictionary) {
+                throw new InvalidOperationException("Source PDF page dictionary was not found.");
+            }
+
+            PdfObject? sourceResources = GetInheritedPageValue(sourceObjects, sourcePageDictionary, "Resources");
+            PdfObject? sourceGroup = sourcePageDictionary.Items.TryGetValue("Group", out PdfObject? groupValue)
+                ? groupValue
+                : null;
+            var sourceCollector = new PdfPageExtractor.ObjectCollector(sourceObjects);
+            sourceCollector.CollectObjectGraph(sourceResources);
+            sourceCollector.CollectObjectGraph(sourceGroup);
+            var importedObjectNumbers = new Dictionary<int, int>();
+            foreach (int sourceObjectNumber in sourceCollector.ObjectIds) importedObjectNumbers[sourceObjectNumber] = nextObjectNumber++;
+            foreach (int sourceObjectNumber in sourceCollector.ObjectIds) {
+                PdfIndirectObject sourceObject = sourceObjects[sourceObjectNumber];
+                int importedNumber = importedObjectNumbers[sourceObjectNumber];
+                targetObjects[importedNumber] = new PdfIndirectObject(importedNumber, 0, CloneImportedObject(sourceObject.Value, importedObjectNumbers));
+            }
+
+            (double sourceWidth, double sourceHeight, Matrix2D normalization) = sourcePage.GetImportGeometry();
+            byte[] formContent = BuildImportedPageContent(sourceObjects, sourcePageDictionary, sourceWidth, sourceHeight, normalization);
+            var formDictionary = new PdfDictionary();
+            formDictionary.Items["Type"] = new PdfName("XObject");
+            formDictionary.Items["Subtype"] = new PdfName("Form");
+            formDictionary.Items["FormType"] = new PdfNumber(1D);
+            formDictionary.Items["BBox"] = NumberArray(0D, 0D, sourceWidth, sourceHeight);
+            formDictionary.Items["Resources"] = sourceResources == null
+                ? new PdfDictionary()
+                : CloneImportedObject(sourceResources, importedObjectNumbers);
+            if (sourceGroup != null) formDictionary.Items["Group"] = CloneImportedObject(sourceGroup, importedObjectNumbers);
+            int formObjectNumber = nextObjectNumber++;
+            targetObjects[formObjectNumber] = new PdfIndirectObject(formObjectNumber, 0, new PdfStream(formDictionary, formContent));
+
+            int graphicsStateObjectNumber = 0;
+            if (options.Opacity < 1D) {
+                var graphicsState = new PdfDictionary();
+                graphicsState.Items["Type"] = new PdfName("ExtGState");
+                graphicsState.Items["ca"] = new PdfNumber(options.Opacity);
+                graphicsState.Items["CA"] = new PdfNumber(options.Opacity);
+                graphicsStateObjectNumber = nextObjectNumber++;
+                targetObjects[graphicsStateObjectNumber] = new PdfIndirectObject(graphicsStateObjectNumber, 0, graphicsState);
+            }
+
+            string formResourceName = GetAvailableXObjectResourceName(targetObjects, pageObjectNumbers, reservedFormResourceNames);
+            reservedFormResourceNames.Add(formResourceName);
+            string? graphicsStateResourceName = graphicsStateObjectNumber == 0
+                ? null
+                : GetAvailableGraphicsStateResourceName(targetObjects, pageObjectNumbers, reservedGraphicsStateResourceNames);
+            if (graphicsStateResourceName != null) reservedGraphicsStateResourceNames.Add(graphicsStateResourceName);
+
+            IReadOnlyList<int> selectedPages = options.TargetPages?.Resolve(target.Pages.Count) ?? Enumerable.Range(1, target.Pages.Count).ToArray();
+            for (int selectedIndex = 0; selectedIndex < selectedPages.Count; selectedIndex++) {
+                int pageNumber = selectedPages[selectedIndex];
+                if (!stampedPageNumbers.Add(pageNumber)) {
+                    throw new InvalidOperationException("A page can only receive one generated canvas stamp in a single rewrite.");
+                }
+
+                PdfReadPage targetPage = target.Pages[pageNumber - 1];
+                (double targetWidth, double targetHeight, Matrix2D targetUserToVisual) = targetPage.GetImportGeometry();
+                Matrix2D targetVisualToUser = Invert(targetUserToVisual);
+                PdfStream stamp = BuildImportedPageStampStream(formResourceName, graphicsStateResourceName, sourceWidth, sourceHeight, targetWidth, targetHeight, targetVisualToUser, options);
+                int stampObjectNumber = nextObjectNumber++;
+                targetObjects[stampObjectNumber] = new PdfIndirectObject(stampObjectNumber, 0, stamp);
+                overrides[targetPage.ObjectNumber] = BuildImportedPageOverrides(
+                    targetObjects,
+                    targetPage.ObjectNumber,
+                    formResourceName,
+                    formObjectNumber,
+                    graphicsStateResourceName,
+                    graphicsStateObjectNumber,
+                    stampObjectNumber,
+                    options.BehindContent);
+            }
+
+            PdfFileVersion sourceVersion = PdfPageExtractor.GetSourceFileVersion(sourcePdf);
+            if (sourceVersion > outputVersion) outputVersion = sourceVersion;
         }
 
-        PdfFileVersion targetVersion = PdfPageExtractor.GetSourceFileVersion(targetPdf);
-        PdfFileVersion sourceVersion = PdfPageExtractor.GetSourceFileVersion(sourcePdf);
-        PdfFileVersion outputVersion = sourceVersion > targetVersion ? sourceVersion : targetVersion;
         return PdfPageExtractor.ExtractPages(
             targetObjects,
             target.Metadata,
@@ -132,6 +165,17 @@ internal static partial class PdfStamper {
             overrides,
             catalogState: PdfPageExtractor.ExtractCatalogRewriteState(targetObjects, targetTrailer),
             fileVersion: outputVersion);
+    }
+
+    private sealed class PageStampRequest {
+        internal PageStampRequest(byte[] sourcePdf, PdfPageOverlayOptions options) {
+            SourcePdf = sourcePdf;
+            Options = options;
+        }
+
+        internal byte[] SourcePdf { get; }
+
+        internal PdfPageOverlayOptions Options { get; }
     }
 
     private static byte[] BuildImportedPageContent(
@@ -314,7 +358,10 @@ internal static partial class PdfStamper {
         _ => y
     };
 
-    private static string GetAvailableGraphicsStateResourceName(Dictionary<int, PdfIndirectObject> objects, int[] pageObjectNumbers) {
+    private static string GetAvailableGraphicsStateResourceName(
+        Dictionary<int, PdfIndirectObject> objects,
+        int[] pageObjectNumbers,
+        HashSet<string>? additionallyUsed = null) {
         var used = new HashSet<string>(StringComparer.Ordinal);
         foreach (int pageObjectNumber in pageObjectNumbers) {
             if (!objects.TryGetValue(pageObjectNumber, out PdfIndirectObject? indirect) || indirect.Value is not PdfDictionary page) continue;
@@ -324,7 +371,7 @@ internal static partial class PdfStamper {
         }
         for (int i = 1; i < 1000; i++) {
             string candidate = "OIMOStampGS" + i.ToString(CultureInfo.InvariantCulture);
-            if (!used.Contains(candidate)) return candidate;
+            if (!used.Contains(candidate) && (additionallyUsed is null || !additionallyUsed.Contains(candidate))) return candidate;
         }
         throw new InvalidOperationException("Unable to find an available PDF graphics-state resource name for the imported page.");
     }

--- a/OfficeIMO.Pdf/Manipulation/PdfStamper.Pages.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfStamper.Pages.cs
@@ -61,7 +61,6 @@ internal static partial class PdfStamper {
         var overrides = new Dictionary<int, Dictionary<string, PdfObject>>();
         var reservedFormResourceNames = new HashSet<string>(StringComparer.Ordinal);
         var reservedGraphicsStateResourceNames = new HashSet<string>(StringComparer.Ordinal);
-        var stampedPageNumbers = new HashSet<int>();
         PdfFileVersion outputVersion = PdfPageExtractor.GetSourceFileVersion(targetPdf);
 
         for (int requestIndex = 0; requestIndex < requests.Count; requestIndex++) {
@@ -131,11 +130,10 @@ internal static partial class PdfStamper {
             if (graphicsStateResourceName != null) reservedGraphicsStateResourceNames.Add(graphicsStateResourceName);
 
             IReadOnlyList<int> selectedPages = options.TargetPages?.Resolve(target.Pages.Count) ?? Enumerable.Range(1, target.Pages.Count).ToArray();
+            var selectedPageNumbers = new HashSet<int>();
             for (int selectedIndex = 0; selectedIndex < selectedPages.Count; selectedIndex++) {
                 int pageNumber = selectedPages[selectedIndex];
-                if (!stampedPageNumbers.Add(pageNumber)) {
-                    throw new InvalidOperationException("A page can only receive one generated canvas stamp in a single rewrite.");
-                }
+                if (!selectedPageNumbers.Add(pageNumber)) continue;
 
                 PdfReadPage targetPage = target.Pages[pageNumber - 1];
                 (double targetWidth, double targetHeight, Matrix2D targetUserToVisual) = targetPage.GetImportGeometry();
@@ -151,7 +149,10 @@ internal static partial class PdfStamper {
                     graphicsStateResourceName,
                     graphicsStateObjectNumber,
                     stampObjectNumber,
-                    options.BehindContent);
+                    options.BehindContent,
+                    overrides.TryGetValue(targetPage.ObjectNumber, out Dictionary<string, PdfObject>? existingOverride)
+                        ? existingOverride
+                        : null);
             }
 
             PdfFileVersion sourceVersion = PdfPageExtractor.GetSourceFileVersion(sourcePdf);
@@ -275,10 +276,17 @@ internal static partial class PdfStamper {
         string? graphicsStateResourceName,
         int graphicsStateObjectNumber,
         int stampObjectNumber,
-        bool behindContent) {
+        bool behindContent,
+        Dictionary<string, PdfObject>? existingOverride = null) {
         PdfDictionary page = (PdfDictionary)objects[pageObjectNumber].Value;
-        PdfArray contents = BuildContentsArray(objects, page.Items.TryGetValue("Contents", out PdfObject? existing) ? existing : null, stampObjectNumber, behindContent);
-        PdfDictionary resources = CloneDictionary(ResolveDictionary(objects, GetInheritedPageValue(objects, page, "Resources")));
+        PdfObject? existingContents = existingOverride != null && existingOverride.TryGetValue("Contents", out PdfObject? overriddenContents)
+            ? overriddenContents
+            : page.Items.TryGetValue("Contents", out PdfObject? pageContents) ? pageContents : null;
+        PdfArray contents = BuildContentsArray(objects, existingContents, stampObjectNumber, behindContent);
+        PdfObject? existingResources = existingOverride != null && existingOverride.TryGetValue("Resources", out PdfObject? overriddenResources)
+            ? overriddenResources
+            : GetInheritedPageValue(objects, page, "Resources");
+        PdfDictionary resources = CloneDictionary(ResolveDictionary(objects, existingResources));
         PdfDictionary xObjects = CloneDictionary(ResolveDictionary(objects, resources.Items.TryGetValue("XObject", out PdfObject? xObject) ? xObject : null));
         xObjects.Items[formResourceName] = new PdfReference(formObjectNumber, 0);
         resources.Items["XObject"] = xObjects;

--- a/OfficeIMO.Pdf/Manipulation/PdfStamper.Text.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfStamper.Text.cs
@@ -51,7 +51,7 @@ internal static partial class PdfStamper {
         }
 
         PdfFileVersion fileVersion = PdfPageExtractor.GetSourceFileVersion(pdf);
-        return PdfPageExtractor.ExtractPages(objects, document.Metadata, pageObjectNumbers, overrides, additionalObjects, PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw), fileVersion);
+        return PdfPageExtractor.ExtractPages(objects, document.UncheckedMetadata, pageObjectNumbers, overrides, additionalObjects, PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw), fileVersion);
     }
 
     /// <summary>
@@ -164,7 +164,7 @@ internal static partial class PdfStamper {
         }
 
         PdfFileVersion fileVersion = PdfPageExtractor.GetSourceFileVersion(pdf);
-        return PdfPageExtractor.ExtractPages(objects, document.Metadata, pageObjectNumbers, overrides, additionalObjects, PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw), fileVersion);
+        return PdfPageExtractor.ExtractPages(objects, document.UncheckedMetadata, pageObjectNumbers, overrides, additionalObjects, PdfPageExtractor.ExtractCatalogRewriteState(objects, trailerRaw), fileVersion);
     }
 
     /// <summary>

--- a/OfficeIMO.Pdf/Manipulation/PdfStamper.Text.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfStamper.Text.cs
@@ -4,10 +4,10 @@ internal static partial class PdfStamper {
     /// <summary>
     /// Adds a simple text stamp to selected pages, or every page when no page selection is supplied.
     /// </summary>
-    public static byte[] StampText(byte[] pdf, string text, PdfTextStampOptions? options = null) {
+    public static byte[] StampText(byte[] pdf, string text, PdfTextStampOptions? options = null, PdfReadOptions? readOptions = null) {
         Guard.NotNull(pdf, nameof(pdf));
         Guard.NotNull(text, nameof(text));
-        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyPageContent);
+        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyPageContent, readOptions);
         if (text.Length == 0) {
             throw new ArgumentException("Stamp text cannot be empty.", nameof(text));
         }
@@ -15,8 +15,8 @@ internal static partial class PdfStamper {
         var effectiveOptions = options ?? new PdfTextStampOptions();
         ValidateOptions(effectiveOptions);
 
-        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf);
-        var document = PdfReadDocument.Open(pdf);
+        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf, readOptions);
+        var document = PdfReadDocument.Open(pdf, readOptions);
         if (document.Pages.Count == 0) {
             throw new ArgumentException("PDF does not contain any pages.", nameof(pdf));
         }
@@ -118,17 +118,17 @@ internal static partial class PdfStamper {
     /// <summary>
     /// Adds a large diagonal text watermark to selected pages, or every page when no page selection is supplied.
     /// </summary>
-    public static byte[] WatermarkText(byte[] pdf, string text, PdfTextStampOptions? options = null) {
+    public static byte[] WatermarkText(byte[] pdf, string text, PdfTextStampOptions? options = null, PdfReadOptions? readOptions = null) {
         Guard.NotNull(pdf, nameof(pdf));
         Guard.NotNull(text, nameof(text));
-        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyPageContent);
+        _ = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyPageContent, readOptions);
         if (text.Length == 0) {
             throw new ArgumentException("Watermark text cannot be empty.", nameof(text));
         }
 
         var effectiveOptions = BuildWatermarkOptions(options);
-        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf);
-        var document = PdfReadDocument.Open(pdf);
+        var (objects, trailerRaw) = PdfSyntax.ParseObjects(pdf, readOptions);
+        var document = PdfReadDocument.Open(pdf, readOptions);
         if (document.Pages.Count == 0) {
             throw new ArgumentException("PDF does not contain any pages.", nameof(pdf));
         }

--- a/OfficeIMO.Pdf/Model/PdfPageCanvas.cs
+++ b/OfficeIMO.Pdf/Model/PdfPageCanvas.cs
@@ -19,6 +19,13 @@ public sealed class PdfPageCanvas {
 
     internal IReadOnlyList<PdfCanvasItem> Items => _items;
 
+    internal void AddItems(IReadOnlyList<PdfCanvasItem> items) {
+        Guard.NotNull(items, nameof(items));
+        for (int i = 0; i < items.Count; i++) {
+            _items.Add(items[i]);
+        }
+    }
+
     /// <summary>Adds a document outline entry targeting an absolute top-left page coordinate.</summary>
     /// <param name="title">Visible outline title.</param>
     /// <param name="level">One-based outline hierarchy level.</param>

--- a/OfficeIMO.Pdf/Options/FooterSegment.cs
+++ b/OfficeIMO.Pdf/Options/FooterSegment.cs
@@ -1,11 +1,15 @@
 namespace OfficeIMO.Pdf;
 
-/// <summary>A segment of footer content, either literal text or a token.</summary>
+/// <summary>A segment of header or footer content, either literal text, styled text, or a page token.</summary>
 public sealed class FooterSegment {
     /// <summary>Segment kind (text or token).</summary>
     public FooterSegmentKind Kind { get; }
     /// <summary>Literal text used when <see cref="Kind"/> is <see cref="FooterSegmentKind.Text"/>.</summary>
     public string? Text { get; }
+    /// <summary>Optional visual styling for this segment.</summary>
+    /// <remarks>Header/footer rich text supports text styling only. Links, inline visuals, and paragraph tabs are not accepted.</remarks>
+    public TextRun? StyledRun { get; }
+
     /// <summary>Creates a new footer segment.</summary>
     public FooterSegment(FooterSegmentKind kind, string? text = null) {
         if (kind != FooterSegmentKind.Text &&
@@ -20,6 +24,47 @@ public sealed class FooterSegment {
 
         Kind = kind;
         Text = text;
+    }
+
+    private FooterSegment(FooterSegmentKind kind, string? text, TextRun styledRun) {
+        ValidateStyledRun(styledRun, nameof(styledRun));
+        Kind = kind;
+        Text = text;
+        StyledRun = styledRun;
+    }
+
+    /// <summary>Creates a styled literal text segment.</summary>
+    /// <param name="run">Visual text run to render.</param>
+    public static FooterSegment RichText(TextRun run) {
+        Guard.NotNull(run, nameof(run));
+        return new FooterSegment(FooterSegmentKind.Text, run.Text, run);
+    }
+
+    /// <summary>Creates a current-page token using the supplied visual text style.</summary>
+    /// <param name="style">Text run whose visual styling is applied; its text is ignored.</param>
+    public static FooterSegment PageNumber(TextRun style) {
+        Guard.NotNull(style, nameof(style));
+        return new FooterSegment(FooterSegmentKind.PageNumber, null, style);
+    }
+
+    /// <summary>Creates a total-pages token using the supplied visual text style.</summary>
+    /// <param name="style">Text run whose visual styling is applied; its text is ignored.</param>
+    public static FooterSegment TotalPages(TextRun style) {
+        Guard.NotNull(style, nameof(style));
+        return new FooterSegment(FooterSegmentKind.TotalPages, null, style);
+    }
+
+    internal static void ValidateStyledRun(TextRun run, string paramName) {
+        Guard.NotNull(run, paramName);
+        if (run.InlineElement != null) {
+            throw new System.ArgumentException("PDF header/footer rich text cannot contain inline visuals. Use the header/footer image or shape APIs instead.", paramName);
+        }
+        if (run.LinkUri != null || run.LinkDestinationName != null) {
+            throw new System.ArgumentException("PDF header/footer rich text cannot contain interactive links.", paramName);
+        }
+        if (run.TabLeader != PdfTabLeaderStyle.None || run.TabAlignment != PdfTabAlignment.Left || run.Text.Contains('\t')) {
+            throw new System.ArgumentException("PDF header/footer rich text cannot contain paragraph tabs.", paramName);
+        }
     }
 }
 

--- a/OfficeIMO.Pdf/Options/PdfOptions.CanvasStamp.cs
+++ b/OfficeIMO.Pdf/Options/PdfOptions.CanvasStamp.cs
@@ -1,0 +1,75 @@
+namespace OfficeIMO.Pdf;
+
+public sealed partial class PdfOptions {
+    /// <summary>
+    /// Clones reusable rendering configuration while removing document-level content that must not leak into a canvas stamp.
+    /// </summary>
+    internal PdfOptions CloneForCanvasStampRendering() {
+        PdfOptions clone = Clone();
+
+        clone.ShowHeader = false;
+        clone.ShowPageNumbers = false;
+        clone.DifferentFirstPageHeaderFooter = false;
+        clone.DifferentOddAndEvenPagesHeaderFooter = false;
+        clone.HeaderFormat = string.Empty;
+        clone.FirstPageHeaderFormat = string.Empty;
+        clone.EvenPageHeaderFormat = string.Empty;
+        clone.FooterFormat = string.Empty;
+        clone.FirstPageFooterFormat = string.Empty;
+        clone.EvenPageFooterFormat = string.Empty;
+        clone._headerSegments = null;
+        clone._firstPageHeaderSegments = null;
+        clone._evenPageHeaderSegments = null;
+        clone._footerSegments = null;
+        clone._firstPageFooterSegments = null;
+        clone._evenPageFooterSegments = null;
+        clone._headerLeftFormat = null;
+        clone._headerCenterFormat = null;
+        clone._headerRightFormat = null;
+        clone._firstPageHeaderLeftFormat = null;
+        clone._firstPageHeaderCenterFormat = null;
+        clone._firstPageHeaderRightFormat = null;
+        clone._evenPageHeaderLeftFormat = null;
+        clone._evenPageHeaderCenterFormat = null;
+        clone._evenPageHeaderRightFormat = null;
+        clone._footerLeftFormat = null;
+        clone._footerCenterFormat = null;
+        clone._footerRightFormat = null;
+        clone._firstPageFooterLeftFormat = null;
+        clone._firstPageFooterCenterFormat = null;
+        clone._firstPageFooterRightFormat = null;
+        clone._evenPageFooterLeftFormat = null;
+        clone._evenPageFooterCenterFormat = null;
+        clone._evenPageFooterRightFormat = null;
+        clone._headerImages = null;
+        clone._firstPageHeaderImages = null;
+        clone._evenPageHeaderImages = null;
+        clone._footerImages = null;
+        clone._firstPageFooterImages = null;
+        clone._evenPageFooterImages = null;
+        clone._headerShapes = null;
+        clone._firstPageHeaderShapes = null;
+        clone._evenPageHeaderShapes = null;
+        clone._footerShapes = null;
+        clone._firstPageFooterShapes = null;
+        clone._evenPageFooterShapes = null;
+
+        clone.BackgroundColor = null;
+        clone._textWatermark = null;
+        clone._firstPageTextWatermark = null;
+        clone._evenPageTextWatermark = null;
+        clone._suppressFirstPageTextWatermark = false;
+        clone._suppressEvenPageTextWatermark = false;
+        clone._imageWatermark = null;
+        clone._firstPageImageWatermark = null;
+        clone._evenPageImageWatermark = null;
+        clone._suppressFirstPageImageWatermark = false;
+        clone._suppressEvenPageImageWatermark = false;
+        clone._pageBorder = null;
+        clone._pageBackgroundImage = null;
+        clone._pageBackgroundShapes = null;
+        clone._encryption = null;
+
+        return clone;
+    }
+}

--- a/OfficeIMO.Pdf/README.md
+++ b/OfficeIMO.Pdf/README.md
@@ -196,6 +196,25 @@ PdfDocument.Create(new PdfOptions {
     .Save("service-report.pdf");
 ```
 
+Generated headers and footers can combine literal text, visually styled runs, and styled page tokens. The same builder is available for the default, first-page, and even-page variants:
+
+```csharp
+PdfDocument.Create()
+    .Header(header => header
+        .Text(text => text
+            .Run(TextRun.Bolded("Confidential ", PdfColor.FromRgb(180, 0, 0)))
+            .Text("- page ")
+            .CurrentPage(TextRun.Italicized(string.Empty))
+            .Text(" of ")
+            .TotalPages(TextRun.Italicized(string.Empty)))
+        .FirstPageText(text => text.Run(TextRun.Bolded("Confidential cover")))
+        .EvenPagesText(text => text.Run(TextRun.Underlined("Confidential even page"))))
+    .Paragraph(p => p.Text("Generated report body."))
+    .Save("styled-header.pdf");
+```
+
+Styled header/footer runs support fonts, size, color, highlighting, underline, strike, and baseline changes. Use the existing header/footer image and shape methods for visuals; interactive links and inline elements are intentionally kept out of text runs.
+
 ### Rich report layout
 
 ```csharp

--- a/OfficeIMO.Pdf/README.md
+++ b/OfficeIMO.Pdf/README.md
@@ -371,6 +371,35 @@ PdfDocument.Open("packet.pdf")
     .Save("packet-clean.pdf");
 ```
 
+Encrypted merge inputs keep independent authentication settings. Owner
+authorization is honored automatically. A user password follows the PDF
+permission bits unless the caller explicitly opts into ignoring those
+restrictions:
+
+```csharp
+PdfDocument first = PdfDocument.Open("first.pdf", new PdfReadOptions {
+    Password = "first-owner-password"
+});
+PdfDocument second = PdfDocument.Open("second.pdf", new PdfReadOptions {
+    Password = "second-user-password",
+    PermissionPolicy = PdfPermissionPolicy.IgnoreRestrictions
+});
+
+PdfMergeResult merged = PdfDocument.MergeWithReport(
+    new PdfMergeOptions(),
+    first,
+    second);
+
+File.WriteAllBytes("merged.pdf", merged.ToBytes());
+Console.WriteLine(merged.Report.OutputHasEncryption); // False
+Console.WriteLine(merged.Report.Sources[1].PermissionRestrictionsIgnored); // True
+```
+
+`IgnoreRestrictions` is an authenticated permission override, not password
+recovery. The document must still decrypt with the supplied password; an
+unknown or incorrect password remains an error. Full rewrites of signed PDFs
+remain blocked because they would invalidate existing signatures.
+
 ### Stamp and watermark an existing PDF
 
 ```csharp
@@ -404,6 +433,29 @@ PdfDocument.Open("contract.pdf")
     })
     .Save("contract-with-letterhead.pdf");
 ```
+
+For richer existing-page automation, stamp a general visual canvas instead of
+using separate table-, text-, and image-only operations:
+
+```csharp
+PdfDocument.Open("contract.pdf")
+    .Stamp.Content((canvas, page) => {
+        canvas.Text($"Page {page.PageNumber} of {page.PageCount}", 36, 24, 220, 24)
+            .Table(new[] {
+                new[] { PdfTableCell.TextCell("Status"), PdfTableCell.TextCell("Reviewed") },
+                new[] { PdfTableCell.TextCell("Owner"), PdfTableCell.RichTextCell(new[] { TextRun.Bolded("Legal") }) }
+            }, 36, 620, page.Width - 72, 90);
+    }, new PdfCanvasStampOptions {
+        TargetPages = PdfPageSelector.Parse("1,last"),
+        Opacity = 0.95
+    })
+    .Save("contract-with-review-panel.pdf");
+```
+
+Canvas stamping is intentionally visual-only. Text, rich tables, images,
+shapes, drawings, clipping, and effects are supported; interactive annotations,
+forms, and document outlines use their dedicated editors so their behavior is
+not silently flattened or discarded.
 
 ### Fill and flatten a PDF form
 

--- a/OfficeIMO.Pdf/README.md
+++ b/OfficeIMO.Pdf/README.md
@@ -453,9 +453,9 @@ PdfDocument.Open("contract.pdf")
 ```
 
 Canvas stamping is intentionally visual-only. Text, rich tables, images,
-shapes, drawings, clipping, and effects are supported; interactive annotations,
-forms, and document outlines use their dedicated editors so their behavior is
-not silently flattened or discarded.
+shapes, drawings, clipping, and effects are supported. Interactive links and
+annotations, named destinations, forms, and document outlines use their
+dedicated editors so their behavior is not silently flattened or discarded.
 
 ### Fill and flatten a PDF form
 

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Attachments.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Attachments.cs
@@ -2,7 +2,7 @@ namespace OfficeIMO.Pdf;
 
 public sealed partial class PdfReadDocument {
     /// <summary>Embedded and associated file attachment metadata discovered from the document catalog.</summary>
-    public IReadOnlyList<PdfAttachmentInfo> Attachments { get; }
+    public IReadOnlyList<PdfAttachmentInfo> Attachments => ReadLogicalContent(_attachments);
 
     private IReadOnlyList<PdfAttachmentInfo> ExtractAttachmentInfos() {
         // Catalog inspection must remain available for preflight even when payload extraction is restricted.

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Attachments.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Attachments.cs
@@ -5,7 +5,8 @@ public sealed partial class PdfReadDocument {
     public IReadOnlyList<PdfAttachmentInfo> Attachments { get; }
 
     private IReadOnlyList<PdfAttachmentInfo> ExtractAttachmentInfos() {
-        IReadOnlyList<PdfExtractedAttachment> attachments = ExtractAttachments();
+        // Catalog inspection must remain available for preflight even when payload extraction is restricted.
+        IReadOnlyList<PdfExtractedAttachment> attachments = PdfAttachmentExtractor.ExtractAttachments(_objects, _trailerRaw, _options.Limits);
         if (attachments.Count == 0) {
             return Array.Empty<PdfAttachmentInfo>();
         }

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Forms.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Forms.cs
@@ -12,7 +12,7 @@ public sealed partial class PdfReadDocument {
         var result = new List<PdfFormField>();
         var visited = new HashSet<int>();
         var widgetPageNumbers = BuildWidgetPageNumberLookup();
-        PdfFormFieldInheritedState inherited = PdfFormFieldInheritedState.FromAcroForm(AcroFormDefaultAppearance, AcroFormQuadding);
+        PdfFormFieldInheritedState inherited = PdfFormFieldInheritedState.FromAcroForm(_acroFormDefaultAppearance, _acroFormQuadding);
         if (fields.Items.Count > _options.Limits.MaxFormFields) {
             throw PdfReadLimitException.Create(PdfReadLimitKind.FormFields, _options.Limits.MaxFormFields, fields.Items.Count);
         }

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Loading.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Loading.cs
@@ -33,8 +33,18 @@ public sealed partial class PdfReadDocument {
     }
 
     /// <summary>Extracts image XObjects from all pages in page order.</summary>
-    public IReadOnlyList<PdfExtractedImage> ExtractImages() => PdfImageExtractor.ExtractImages(this);
+    public IReadOnlyList<PdfExtractedImage> ExtractImages() {
+        DemandContentExtraction("image");
+        return PdfImageExtractor.ExtractImages(this);
+    }
 
     /// <summary>Extracts embedded file attachments from the document catalog.</summary>
-    public IReadOnlyList<PdfExtractedAttachment> ExtractAttachments() => PdfAttachmentExtractor.ExtractAttachments(_objects, _trailerRaw, _options.Limits);
+    public IReadOnlyList<PdfExtractedAttachment> ExtractAttachments() {
+        DemandContentExtraction("attachment");
+        return PdfAttachmentExtractor.ExtractAttachments(_objects, _trailerRaw, _options.Limits);
+    }
+
+    internal void DemandTextExtraction() => PdfPermissionAuthorization.DemandTextExtraction(Security, _options.PermissionPolicy);
+
+    internal void DemandContentExtraction(string contentName) => PdfPermissionAuthorization.DemandContentExtraction(Security, _options.PermissionPolicy, contentName);
 }

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.OptionalContent.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.OptionalContent.cs
@@ -2,7 +2,7 @@ namespace OfficeIMO.Pdf;
 
 public sealed partial class PdfReadDocument {
     /// <summary>Catalog optional-content/layer metadata discovered from /OCProperties.</summary>
-    public PdfOptionalContentProperties? OptionalContent { get; }
+    public PdfOptionalContentProperties? OptionalContent => ReadLogicalContent(_optionalContent);
 
     private PdfOptionalContentProperties? ExtractOptionalContent() {
         PdfDictionary? catalog = FindCatalog();

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.OutputIntents.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.OutputIntents.cs
@@ -4,7 +4,7 @@ namespace OfficeIMO.Pdf;
 
 public sealed partial class PdfReadDocument {
     /// <summary>Catalog output intent metadata discovered from /OutputIntents.</summary>
-    public IReadOnlyList<PdfOutputIntentInfo> OutputIntents { get; }
+    public IReadOnlyList<PdfOutputIntentInfo> OutputIntents => ReadLogicalContent(_outputIntents);
 
     private IReadOnlyList<PdfOutputIntentInfo> ExtractOutputIntents() {
         PdfDictionary? catalog = FindCatalog();

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Pages.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Pages.cs
@@ -18,7 +18,7 @@ public sealed partial class PdfReadDocument {
                     var reachable = CollectReachableLeafCandidates(pagesNode);
                     foreach (var id in reachable) {
                         if (_objects.TryGetValue(id, out var ind) && ind.Value is PdfDictionary dict) {
-                            AddPageWithinBudget(result, new PdfReadPage(id, dict, _objects, _options.Limits, DemandTextExtraction));
+                            AddPageWithinBudget(result, CreateReadPage(id, dict));
                         }
                     }
                 }
@@ -29,7 +29,7 @@ public sealed partial class PdfReadDocument {
         // Fallback: scan all dictionaries; accept leaf candidates whose Parent chain leads to a /Pages node
         foreach (var kv in _objects) {
             if (kv.Value.Value is PdfDictionary dict) {
-                if (IsLeafPageByParent(dict)) AddPageWithinBudget(result, new PdfReadPage(kv.Key, dict, _objects, _options.Limits, DemandTextExtraction));
+                if (IsLeafPageByParent(dict)) AddPageWithinBudget(result, CreateReadPage(kv.Key, dict));
             }
         }
         result.Sort((a, b) => a.ObjectNumber.CompareTo(b.ObjectNumber));
@@ -62,7 +62,7 @@ public sealed partial class PdfReadDocument {
             int objNum = FindObjectNumberFor(node);
             if (objNum > 0 && visitedPages.Add(objNum)) {
                 if (type == "Page" || HasMedia(node) || HasInheritedValue(node, "MediaBox") || HasInheritedValue(node, "CropBox")) {
-                    AddPageWithinBudget(outList, new PdfReadPage(objNum, node, _objects, _options.Limits, DemandTextExtraction));
+                    AddPageWithinBudget(outList, CreateReadPage(objNum, node));
                 }
             }
             return;
@@ -79,12 +79,15 @@ public sealed partial class PdfReadDocument {
                      (t == "Page" || HasMedia(d) || HasInheritedValue(d, "MediaBox") || HasInheritedValue(d, "CropBox"))) {
                 int on = FindObjectNumberFor(d);
                 if (on > 0 && visitedPages.Add(on)) {
-                    AddPageWithinBudget(outList, new PdfReadPage(on, d, _objects, _options.Limits, DemandTextExtraction));
+                    AddPageWithinBudget(outList, CreateReadPage(on, d));
                     if (limit.HasValue && outList.Count >= limit.Value) return;
                 }
             }
         }
     }
+
+    private PdfReadPage CreateReadPage(int objectNumber, PdfDictionary pageDictionary) =>
+        new PdfReadPage(objectNumber, pageDictionary, _objects, _options.Limits, DemandTextExtraction, DemandContentExtraction);
 
     private HashSet<int> CollectReachableLeafCandidates(PdfDictionary pagesRoot) {
         var set = new HashSet<int>();

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Pages.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Pages.cs
@@ -18,7 +18,7 @@ public sealed partial class PdfReadDocument {
                     var reachable = CollectReachableLeafCandidates(pagesNode);
                     foreach (var id in reachable) {
                         if (_objects.TryGetValue(id, out var ind) && ind.Value is PdfDictionary dict) {
-                            AddPageWithinBudget(result, new PdfReadPage(id, dict, _objects, _options.Limits));
+                            AddPageWithinBudget(result, new PdfReadPage(id, dict, _objects, _options.Limits, DemandTextExtraction));
                         }
                     }
                 }
@@ -29,7 +29,7 @@ public sealed partial class PdfReadDocument {
         // Fallback: scan all dictionaries; accept leaf candidates whose Parent chain leads to a /Pages node
         foreach (var kv in _objects) {
             if (kv.Value.Value is PdfDictionary dict) {
-                if (IsLeafPageByParent(dict)) AddPageWithinBudget(result, new PdfReadPage(kv.Key, dict, _objects, _options.Limits));
+                if (IsLeafPageByParent(dict)) AddPageWithinBudget(result, new PdfReadPage(kv.Key, dict, _objects, _options.Limits, DemandTextExtraction));
             }
         }
         result.Sort((a, b) => a.ObjectNumber.CompareTo(b.ObjectNumber));
@@ -62,7 +62,7 @@ public sealed partial class PdfReadDocument {
             int objNum = FindObjectNumberFor(node);
             if (objNum > 0 && visitedPages.Add(objNum)) {
                 if (type == "Page" || HasMedia(node) || HasInheritedValue(node, "MediaBox") || HasInheritedValue(node, "CropBox")) {
-                    AddPageWithinBudget(outList, new PdfReadPage(objNum, node, _objects, _options.Limits));
+                    AddPageWithinBudget(outList, new PdfReadPage(objNum, node, _objects, _options.Limits, DemandTextExtraction));
                 }
             }
             return;
@@ -79,7 +79,7 @@ public sealed partial class PdfReadDocument {
                      (t == "Page" || HasMedia(d) || HasInheritedValue(d, "MediaBox") || HasInheritedValue(d, "CropBox"))) {
                 int on = FindObjectNumberFor(d);
                 if (on > 0 && visitedPages.Add(on)) {
-                    AddPageWithinBudget(outList, new PdfReadPage(on, d, _objects, _options.Limits));
+                    AddPageWithinBudget(outList, new PdfReadPage(on, d, _objects, _options.Limits, DemandTextExtraction));
                     if (limit.HasValue && outList.Count >= limit.Value) return;
                 }
             }

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.RawStructure.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.RawStructure.cs
@@ -3,6 +3,7 @@ namespace OfficeIMO.Pdf;
 public sealed partial class PdfReadDocument {
     /// <summary>Builds a safe, immutable, bounded projection of the active raw object graph.</summary>
     public PdfRawDocumentView RawStructure(PdfRawStructureOptions? options = null) {
+        DemandContentExtraction("raw object");
         PdfRawStructureOptions effective = options ?? new PdfRawStructureOptions();
         int take = Math.Min(_objects.Count, effective.MaxObjects);
         var projected = new List<PdfRawObjectView>(take);

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.TaggedContent.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.TaggedContent.cs
@@ -2,7 +2,7 @@ namespace OfficeIMO.Pdf;
 
 public sealed partial class PdfReadDocument {
     /// <summary>Tagged PDF structure metadata discovered from /MarkInfo and /StructTreeRoot.</summary>
-    public PdfTaggedContentInfo? TaggedContent { get; }
+    public PdfTaggedContentInfo? TaggedContent => ReadLogicalContent(_taggedContent);
 
     private PdfTaggedContentInfo? ExtractTaggedContent() {
         PdfDictionary? catalog = FindCatalog();

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.XmpMetadata.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.XmpMetadata.cs
@@ -11,7 +11,7 @@ public sealed partial class PdfReadDocument {
     public const int MaxXmpMetadataBytes = 4_000_000;
 
     /// <summary>Catalog XMP metadata stream discovered from /Metadata.</summary>
-    public PdfXmpMetadataInfo? XmpMetadata { get; }
+    public PdfXmpMetadataInfo? XmpMetadata => ReadLogicalContent(_xmpMetadata);
 
     private PdfXmpMetadataInfo? ExtractXmpMetadata() {
         PdfDictionary? catalog = FindCatalog();

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.cs
@@ -12,6 +12,7 @@ public sealed partial class PdfReadDocument {
     private readonly Dictionary<string, PdfNamedDestination> _stringDestinations = new(StringComparer.Ordinal);
     private readonly PdfMetadata _metadata;
     private readonly PdfXmpMetadataInfo? _xmpMetadata;
+    private readonly IReadOnlyList<PdfOutputIntentInfo> _outputIntents;
     private readonly IReadOnlyList<PdfOutlineItem> _outlines;
     private readonly IReadOnlyList<PdfPageLabel> _pageLabels;
     private readonly IReadOnlyList<PdfNamedDestination> _namedDestinations;
@@ -47,7 +48,7 @@ public sealed partial class PdfReadDocument {
         _namedDestinations = ExtractNamedDestinations();
         _catalogActions = ExtractCatalogActions();
         _attachments = ExtractAttachmentInfos();
-        OutputIntents = ExtractOutputIntents();
+        _outputIntents = ExtractOutputIntents();
         _xmpMetadata = ExtractXmpMetadata();
         _taggedContent = ExtractTaggedContent();
         _optionalContent = ExtractOptionalContent();
@@ -133,6 +134,7 @@ public sealed partial class PdfReadDocument {
     internal IReadOnlyList<PdfOutlineItem> UncheckedOutlines => _outlines;
     internal PdfMetadata UncheckedMetadata => _metadata;
     internal PdfXmpMetadataInfo? UncheckedXmpMetadata => _xmpMetadata;
+    internal IReadOnlyList<PdfOutputIntentInfo> UncheckedOutputIntents => _outputIntents;
     internal IReadOnlyList<PdfPageLabel> UncheckedPageLabels => _pageLabels;
     internal IReadOnlyList<PdfNamedDestination> UncheckedNamedDestinations => _namedDestinations;
     internal IReadOnlyList<PdfCatalogAction> UncheckedCatalogActions => _catalogActions;

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.cs
@@ -10,6 +10,8 @@ public sealed partial class PdfReadDocument {
     private readonly PdfReadOptions _options;
     private readonly Dictionary<string, PdfNamedDestination> _nameDestinations = new(StringComparer.Ordinal);
     private readonly Dictionary<string, PdfNamedDestination> _stringDestinations = new(StringComparer.Ordinal);
+    private readonly PdfMetadata _metadata;
+    private readonly PdfXmpMetadataInfo? _xmpMetadata;
     private readonly IReadOnlyList<PdfOutlineItem> _outlines;
     private readonly IReadOnlyList<PdfPageLabel> _pageLabels;
     private readonly IReadOnlyList<PdfNamedDestination> _namedDestinations;
@@ -40,13 +42,13 @@ public sealed partial class PdfReadDocument {
         Security = security;
         Pages = CollectPages();
         RepairReport = repairReport.Append(PdfSemanticRepairDiagnostics.AnalyzeAndRepair(_objects, FindCatalog(), Pages, _options));
-        Metadata = ExtractMetadata();
+        _metadata = ExtractMetadata();
         _pageLabels = ExtractPageLabels();
         _namedDestinations = ExtractNamedDestinations();
         _catalogActions = ExtractCatalogActions();
         _attachments = ExtractAttachmentInfos();
         OutputIntents = ExtractOutputIntents();
-        XmpMetadata = ExtractXmpMetadata();
+        _xmpMetadata = ExtractXmpMetadata();
         _taggedContent = ExtractTaggedContent();
         _optionalContent = ExtractOptionalContent();
         _outlines = ExtractOutlines();
@@ -69,7 +71,7 @@ public sealed partial class PdfReadDocument {
     public IReadOnlyList<PdfReadPage> Pages { get; }
 
     /// <summary>Document metadata (when present).</summary>
-    public PdfMetadata Metadata { get; }
+    public PdfMetadata Metadata => ReadLogicalContent(_metadata);
 
     /// <summary>Top-level document outline/bookmark entries.</summary>
     public IReadOnlyList<PdfOutlineItem> Outlines => ReadLogicalContent(_outlines);
@@ -129,6 +131,8 @@ public sealed partial class PdfReadDocument {
     public PdfRepairReport RepairReport { get; }
 
     internal IReadOnlyList<PdfOutlineItem> UncheckedOutlines => _outlines;
+    internal PdfMetadata UncheckedMetadata => _metadata;
+    internal PdfXmpMetadataInfo? UncheckedXmpMetadata => _xmpMetadata;
     internal IReadOnlyList<PdfPageLabel> UncheckedPageLabels => _pageLabels;
     internal IReadOnlyList<PdfNamedDestination> UncheckedNamedDestinations => _namedDestinations;
     internal IReadOnlyList<PdfCatalogAction> UncheckedCatalogActions => _catalogActions;

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.cs
@@ -10,6 +10,21 @@ public sealed partial class PdfReadDocument {
     private readonly PdfReadOptions _options;
     private readonly Dictionary<string, PdfNamedDestination> _nameDestinations = new(StringComparer.Ordinal);
     private readonly Dictionary<string, PdfNamedDestination> _stringDestinations = new(StringComparer.Ordinal);
+    private readonly IReadOnlyList<PdfOutlineItem> _outlines;
+    private readonly IReadOnlyList<PdfPageLabel> _pageLabels;
+    private readonly IReadOnlyList<PdfNamedDestination> _namedDestinations;
+    private readonly IReadOnlyList<PdfCatalogAction> _catalogActions;
+    private readonly IReadOnlyList<PdfAttachmentInfo> _attachments;
+    private readonly PdfTaggedContentInfo? _taggedContent;
+    private readonly PdfOptionalContentProperties? _optionalContent;
+    private readonly PdfDocumentOpenAction? _openAction;
+    private readonly PdfPortfolioInfo? _portfolio;
+    private readonly IReadOnlyList<PdfFormField> _formFields;
+    private readonly string? _acroFormDefaultAppearance;
+    private readonly int? _acroFormQuadding;
+    private readonly bool? _acroFormNeedAppearances;
+    private readonly int? _acroFormSignatureFlags;
+    private readonly PdfAcroFormXfaInfo? _acroFormXfa;
 
     internal Dictionary<int, PdfIndirectObject> Objects => _objects;
     internal string TrailerRaw => _trailerRaw;
@@ -26,24 +41,24 @@ public sealed partial class PdfReadDocument {
         Pages = CollectPages();
         RepairReport = repairReport.Append(PdfSemanticRepairDiagnostics.AnalyzeAndRepair(_objects, FindCatalog(), Pages, _options));
         Metadata = ExtractMetadata();
-        PageLabels = ExtractPageLabels();
-        NamedDestinations = ExtractNamedDestinations();
-        CatalogActions = ExtractCatalogActions();
-        Attachments = ExtractAttachmentInfos();
+        _pageLabels = ExtractPageLabels();
+        _namedDestinations = ExtractNamedDestinations();
+        _catalogActions = ExtractCatalogActions();
+        _attachments = ExtractAttachmentInfos();
         OutputIntents = ExtractOutputIntents();
         XmpMetadata = ExtractXmpMetadata();
-        TaggedContent = ExtractTaggedContent();
-        OptionalContent = ExtractOptionalContent();
-        Outlines = ExtractOutlines();
-        OpenAction = ExtractOpenAction();
+        _taggedContent = ExtractTaggedContent();
+        _optionalContent = ExtractOptionalContent();
+        _outlines = ExtractOutlines();
+        _openAction = ExtractOpenAction();
         ViewerPreferences = ExtractViewerPreferences();
-        Portfolio = ExtractPortfolio();
-        AcroFormDefaultAppearance = ExtractAcroFormText("DA");
-        AcroFormQuadding = ExtractAcroFormInteger("Q");
-        AcroFormXfa = ExtractAcroFormXfaInfo();
-        FormFields = ExtractFormFields();
-        AcroFormNeedAppearances = ExtractAcroFormBoolean("NeedAppearances");
-        AcroFormSignatureFlags = ExtractAcroFormInteger("SigFlags");
+        _portfolio = ExtractPortfolio();
+        _acroFormDefaultAppearance = ExtractAcroFormText("DA");
+        _acroFormQuadding = ExtractAcroFormInteger("Q");
+        _acroFormXfa = ExtractAcroFormXfaInfo();
+        _formFields = ExtractFormFields();
+        _acroFormNeedAppearances = ExtractAcroFormBoolean("NeedAppearances");
+        _acroFormSignatureFlags = ExtractAcroFormInteger("SigFlags");
         CatalogPageMode = ExtractCatalogName("PageMode");
         CatalogPageLayout = ExtractCatalogName("PageLayout");
         CatalogVersion = ExtractCatalogName("Version");
@@ -57,43 +72,43 @@ public sealed partial class PdfReadDocument {
     public PdfMetadata Metadata { get; }
 
     /// <summary>Top-level document outline/bookmark entries.</summary>
-    public IReadOnlyList<PdfOutlineItem> Outlines { get; }
+    public IReadOnlyList<PdfOutlineItem> Outlines => ReadLogicalContent(_outlines);
 
     /// <summary>Page-label rules discovered from the document catalog.</summary>
-    public IReadOnlyList<PdfPageLabel> PageLabels { get; }
+    public IReadOnlyList<PdfPageLabel> PageLabels => ReadLogicalContent(_pageLabels);
 
     /// <summary>Named destinations discovered from the document catalog.</summary>
-    public IReadOnlyList<PdfNamedDestination> NamedDestinations { get; }
+    public IReadOnlyList<PdfNamedDestination> NamedDestinations => ReadLogicalContent(_namedDestinations);
 
     /// <summary>Catalog-level actions discovered from supported name trees.</summary>
-    public IReadOnlyList<PdfCatalogAction> CatalogActions { get; }
+    public IReadOnlyList<PdfCatalogAction> CatalogActions => ReadLogicalContent(_catalogActions);
 
     /// <summary>Simple document open action discovered from the document catalog, when supported.</summary>
-    public PdfDocumentOpenAction? OpenAction { get; }
+    public PdfDocumentOpenAction? OpenAction => ReadLogicalContent(_openAction);
 
     /// <summary>Simple viewer preference entries discovered from the document catalog, when supported.</summary>
     public PdfViewerPreferences? ViewerPreferences { get; }
 
     /// <summary>Document portfolio metadata discovered from the catalog, when present.</summary>
-    public PdfPortfolioInfo? Portfolio { get; }
+    public PdfPortfolioInfo? Portfolio => ReadLogicalContent(_portfolio);
 
     /// <summary>Simple AcroForm fields discovered from the document catalog.</summary>
-    public IReadOnlyList<PdfFormField> FormFields { get; }
+    public IReadOnlyList<PdfFormField> FormFields => ReadLogicalContent(_formFields);
 
     /// <summary>AcroForm default appearance string from /DA, when present.</summary>
-    public string? AcroFormDefaultAppearance { get; }
+    public string? AcroFormDefaultAppearance => ReadLogicalContent(_acroFormDefaultAppearance);
 
     /// <summary>Raw AcroForm default /Q quadding value, when present.</summary>
-    public int? AcroFormQuadding { get; }
+    public int? AcroFormQuadding => ReadLogicalContent(_acroFormQuadding);
 
     /// <summary>AcroForm NeedAppearances flag, when present.</summary>
-    public bool? AcroFormNeedAppearances { get; }
+    public bool? AcroFormNeedAppearances => ReadLogicalContent(_acroFormNeedAppearances);
 
     /// <summary>Raw AcroForm signature flags from /SigFlags, when present.</summary>
-    public int? AcroFormSignatureFlags { get; }
+    public int? AcroFormSignatureFlags => ReadLogicalContent(_acroFormSignatureFlags);
 
     /// <summary>AcroForm XFA packet metadata when the document catalog exposes /AcroForm /XFA.</summary>
-    public PdfAcroFormXfaInfo? AcroFormXfa { get; }
+    public PdfAcroFormXfaInfo? AcroFormXfa => ReadLogicalContent(_acroFormXfa);
 
     /// <summary>Catalog page mode, for example UseOutlines or FullScreen, when present.</summary>
     public string? CatalogPageMode { get; }
@@ -112,4 +127,24 @@ public sealed partial class PdfReadDocument {
 
     /// <summary>Structural recoveries applied while loading this document.</summary>
     public PdfRepairReport RepairReport { get; }
+
+    internal IReadOnlyList<PdfOutlineItem> UncheckedOutlines => _outlines;
+    internal IReadOnlyList<PdfPageLabel> UncheckedPageLabels => _pageLabels;
+    internal IReadOnlyList<PdfNamedDestination> UncheckedNamedDestinations => _namedDestinations;
+    internal IReadOnlyList<PdfCatalogAction> UncheckedCatalogActions => _catalogActions;
+    internal IReadOnlyList<PdfAttachmentInfo> UncheckedAttachments => _attachments;
+    internal PdfTaggedContentInfo? UncheckedTaggedContent => _taggedContent;
+    internal PdfOptionalContentProperties? UncheckedOptionalContent => _optionalContent;
+    internal PdfDocumentOpenAction? UncheckedOpenAction => _openAction;
+    internal IReadOnlyList<PdfFormField> UncheckedFormFields => _formFields;
+    internal string? UncheckedAcroFormDefaultAppearance => _acroFormDefaultAppearance;
+    internal int? UncheckedAcroFormQuadding => _acroFormQuadding;
+    internal bool? UncheckedAcroFormNeedAppearances => _acroFormNeedAppearances;
+    internal int? UncheckedAcroFormSignatureFlags => _acroFormSignatureFlags;
+    internal PdfAcroFormXfaInfo? UncheckedAcroFormXfa => _acroFormXfa;
+
+    private T ReadLogicalContent<T>(T value) {
+        DemandContentExtraction("logical object");
+        return value;
+    }
 }

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.PageActions.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.PageActions.cs
@@ -3,6 +3,11 @@ namespace OfficeIMO.Pdf;
 public sealed partial class PdfReadPage {
     /// <summary>Reads page-level additional action metadata from this page dictionary.</summary>
     public IReadOnlyList<PdfPageAction> GetPageActions() {
+        _demandContentExtraction?.Invoke("page action");
+        return GetPageActionsUnchecked();
+    }
+
+    internal IReadOnlyList<PdfPageAction> GetPageActionsUnchecked() {
         return _pageDict.Items.TryGetValue("AA", out var additionalActionsObject)
             ? ReadPageActions(additionalActionsObject)
             : Array.Empty<PdfPageAction>();

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.Visual.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.Visual.cs
@@ -42,6 +42,7 @@ public sealed partial class PdfReadPage {
     /// Projects supported page drawing operators, text spans, and image placements into a dependency-free drawing scene.
     /// </summary>
     public OfficeDrawing ToDrawing() {
+        _demandContentExtraction?.Invoke("visual content");
         (double Width, double Height) size = GetVisualPageSize();
         Matrix2D pageTransform = GetVisualPageTransform();
         var drawing = new OfficeDrawing(size.Width, size.Height);

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
@@ -12,6 +12,7 @@ public sealed partial class PdfReadPage {
     private readonly int _maxDecodedStreamBytes;
     private readonly PdfReadLimits _limits;
     private readonly Action? _demandTextExtraction;
+    private readonly Action<string>? _demandContentExtraction;
 
     internal PdfReadPage(int objectNumber, PdfDictionary pageDict, Dictionary<int, PdfIndirectObject> objects)
         : this(objectNumber, pageDict, objects, new PdfReadLimits()) { }
@@ -21,13 +22,15 @@ public sealed partial class PdfReadPage {
         PdfDictionary pageDict,
         Dictionary<int, PdfIndirectObject> objects,
         PdfReadLimits limits,
-        Action? demandTextExtraction = null) {
+        Action? demandTextExtraction = null,
+        Action<string>? demandContentExtraction = null) {
         ObjectNumber = objectNumber;
         _pageDict = pageDict;
         _objects = objects;
         _limits = limits;
         _maxDecodedStreamBytes = limits.MaxDecodedStreamBytes;
         _demandTextExtraction = demandTextExtraction;
+        _demandContentExtraction = demandContentExtraction;
     }
 
     /// <summary>Underlying object number for the page.</summary>
@@ -306,7 +309,10 @@ public sealed partial class PdfReadPage {
     }
 
     /// <summary>Extracts image XObjects referenced by this page.</summary>
-    public IReadOnlyList<PdfExtractedImage> GetImages() => GetImages(0);
+    public IReadOnlyList<PdfExtractedImage> GetImages() {
+        _demandContentExtraction?.Invoke("image");
+        return GetImages(0);
+    }
 
     internal IReadOnlyList<PdfExtractedImage> GetImages(int pageNumber) {
         return GetImages(pageNumber, GetImagePlacements(pageNumber));
@@ -348,7 +354,10 @@ public sealed partial class PdfReadPage {
     }
 
     /// <summary>Extracts image XObject placement invocations from this page.</summary>
-    public IReadOnlyList<PdfImagePlacement> GetImagePlacements() => GetImagePlacements(0);
+    public IReadOnlyList<PdfImagePlacement> GetImagePlacements() {
+        _demandContentExtraction?.Invoke("image placement");
+        return GetImagePlacements(0);
+    }
 
     internal IReadOnlyList<PdfImagePlacement> GetImagePlacements(int pageNumber) {
         var placements = new List<PdfImagePlacement>();

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
@@ -139,6 +139,11 @@ public sealed partial class PdfReadPage {
 
     /// <summary>Reads simple URI, named-destination, direct-destination, named-action, and remote GoTo link annotations from this page.</summary>
     public IReadOnlyList<PdfLinkAnnotation> GetLinkAnnotations() {
+        _demandContentExtraction?.Invoke("link annotation");
+        return GetLinkAnnotationsUnchecked();
+    }
+
+    internal IReadOnlyList<PdfLinkAnnotation> GetLinkAnnotationsUnchecked() {
         if (!_pageDict.Items.TryGetValue("Annots", out var annotsObject)) {
             return Array.Empty<PdfLinkAnnotation>();
         }
@@ -201,6 +206,11 @@ public sealed partial class PdfReadPage {
 
     /// <summary>Reads generic annotation metadata from this page.</summary>
     public IReadOnlyList<PdfAnnotation> GetAnnotations() {
+        _demandContentExtraction?.Invoke("annotation");
+        return GetAnnotationsUnchecked();
+    }
+
+    internal IReadOnlyList<PdfAnnotation> GetAnnotationsUnchecked() {
         if (!_pageDict.Items.TryGetValue("Annots", out var annotsObject)) {
             return Array.Empty<PdfAnnotation>();
         }

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
@@ -11,6 +11,7 @@ public sealed partial class PdfReadPage {
     private readonly Dictionary<int, PdfIndirectObject> _objects;
     private readonly int _maxDecodedStreamBytes;
     private readonly PdfReadLimits _limits;
+    private readonly Action? _demandTextExtraction;
 
     internal PdfReadPage(int objectNumber, PdfDictionary pageDict, Dictionary<int, PdfIndirectObject> objects)
         : this(objectNumber, pageDict, objects, new PdfReadLimits()) { }
@@ -19,12 +20,14 @@ public sealed partial class PdfReadPage {
         int objectNumber,
         PdfDictionary pageDict,
         Dictionary<int, PdfIndirectObject> objects,
-        PdfReadLimits limits) {
+        PdfReadLimits limits,
+        Action? demandTextExtraction = null) {
         ObjectNumber = objectNumber;
         _pageDict = pageDict;
         _objects = objects;
         _limits = limits;
         _maxDecodedStreamBytes = limits.MaxDecodedStreamBytes;
+        _demandTextExtraction = demandTextExtraction;
     }
 
     /// <summary>Underlying object number for the page.</summary>
@@ -106,6 +109,7 @@ public sealed partial class PdfReadPage {
 
     /// <summary>Gets text spans (text with position and font info) from this page.</summary>
     public IReadOnlyList<PdfTextSpan> GetTextSpans() {
+        _demandTextExtraction?.Invoke();
         var spans = new List<PdfTextSpan>();
         var pageResources = ResolveDictionary(GetInheritedValue("Resources"));
         var pageDecoders = ResourceResolver.GetFontDecoders(_pageDict, _objects);

--- a/OfficeIMO.Pdf/Reading/Logical/PdfLogicalDocument.cs
+++ b/OfficeIMO.Pdf/Reading/Logical/PdfLogicalDocument.cs
@@ -943,6 +943,7 @@ public sealed partial class PdfLogicalDocument {
     }
 
     private static PdfLogicalDocument FromPageNumbers(PdfReadDocument document, PdfTextLayoutOptions? options, int[] pageNumbers) {
+        document.DemandContentExtraction("logical object");
         bool useDocumentWideObjects = PdfPageRangeObjectFilter.ShouldUseDocumentWideObjects(document.Pages.Count, pageNumbers);
         IReadOnlyList<PdfFormField> formFields = useDocumentWideObjects
             ? document.FormFields

--- a/OfficeIMO.Pdf/Reading/Model/PdfDocumentPreflight.Security.cs
+++ b/OfficeIMO.Pdf/Reading/Model/PdfDocumentPreflight.Security.cs
@@ -39,11 +39,17 @@ public sealed partial class PdfDocumentPreflight {
                     encryption += string.Join(", ", parts) + ")";
                 }
 
-                encryption += ". OfficeIMO.Pdf can report lightweight markers, but cannot decrypt encrypted PDFs yet.";
+                encryption += security.PasswordAuthenticationRole == PdfPasswordAuthenticationRole.None
+                    ? ". No password authorization was established."
+                    : ". The supplied password authenticated as " + security.PasswordAuthenticationRole + ".";
                 AddDistinct(messages, encryption);
 
                 if (security.EncryptionPermissions.HasValue) {
-                    AddDistinct(messages, "Raw encryption permissions /P=" + security.EncryptionPermissions.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) + " were detected; permission helpers are informational until decryption support exists.");
+                    AddDistinct(messages, "Raw encryption permissions /P=" + security.EncryptionPermissions.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) + " were detected and are enforced for user-password operations unless the caller explicitly ignores restrictions.");
+                }
+
+                if (PermissionRestrictionsIgnored) {
+                    AddDistinct(messages, "Authenticated user-password permission restrictions are being explicitly ignored for this operation.");
                 }
             }
 

--- a/OfficeIMO.Pdf/Reading/Model/PdfDocumentPreflight.cs
+++ b/OfficeIMO.Pdf/Reading/Model/PdfDocumentPreflight.cs
@@ -4,6 +4,8 @@ namespace OfficeIMO.Pdf;
 /// Wrapper-friendly PDF capability report for OfficeIMO.Pdf read and rewrite operations.
 /// </summary>
 public sealed partial class PdfDocumentPreflight {
+    private readonly PdfDocumentInfo? _documentInfo;
+
     internal PdfDocumentPreflight(
         PdfDocumentProbe probe,
         PdfDocumentInfo? documentInfo,
@@ -14,7 +16,7 @@ public sealed partial class PdfDocumentPreflight {
         IReadOnlyList<PdfRewriteBlocker> rewriteBlockers,
         PdfPermissionPolicy permissionPolicy) {
         Probe = probe;
-        DocumentInfo = documentInfo;
+        _documentInfo = documentInfo;
         CanRead = canRead;
         CanRewrite = canRewrite;
         Diagnostics = diagnostics;
@@ -26,8 +28,13 @@ public sealed partial class PdfDocumentPreflight {
     /// <summary>Lightweight PDF markers read before full parsing.</summary>
     public PdfDocumentProbe Probe { get; }
 
-    /// <summary>Parsed document information when the document can be inspected.</summary>
-    public PdfDocumentInfo? DocumentInfo { get; }
+    /// <summary>Parsed document information when content extraction is authorized; otherwise <see langword="null"/>.</summary>
+    public PdfDocumentInfo? DocumentInfo => PdfPermissionAuthorization.CanExtractContent(Probe.Security, PermissionPolicy)
+        ? _documentInfo
+        : null;
+
+    /// <summary>Parsed document information retained for internal capability and mutation planning.</summary>
+    internal PdfDocumentInfo? UncheckedDocumentInfo => _documentInfo;
 
     /// <summary>True when OfficeIMO.Pdf can parse enough of the document for read-oriented operations.</summary>
     public bool CanRead { get; }
@@ -39,10 +46,10 @@ public sealed partial class PdfDocumentPreflight {
     public bool CanExtractText => CanRead && PdfPermissionAuthorization.CanExtractText(Probe.Security, PermissionPolicy);
 
     /// <summary>True when OfficeIMO.Pdf can attempt image XObject extraction for this PDF.</summary>
-    public bool CanExtractImages => DocumentInfo is not null && !HasImageExtractionBlocker() && PdfPermissionAuthorization.CanExtractContent(Probe.Security, PermissionPolicy);
+    public bool CanExtractImages => _documentInfo is not null && !HasImageExtractionBlocker() && PdfPermissionAuthorization.CanExtractContent(Probe.Security, PermissionPolicy);
 
     /// <summary>True when OfficeIMO.Pdf can attempt embedded-file and associated-file attachment extraction for this PDF.</summary>
-    public bool CanExtractAttachments => DocumentInfo is not null && !HasAttachmentExtractionBlocker() && PdfPermissionAuthorization.CanExtractContent(Probe.Security, PermissionPolicy);
+    public bool CanExtractAttachments => _documentInfo is not null && !HasAttachmentExtractionBlocker() && PdfPermissionAuthorization.CanExtractContent(Probe.Security, PermissionPolicy);
 
     /// <summary>True when OfficeIMO.Pdf can attempt logical object readback through PdfLogicalDocument for this PDF.</summary>
     public bool CanReadLogicalObjects => CanRead && PdfPermissionAuthorization.CanExtractContent(Probe.Security, PermissionPolicy);
@@ -179,8 +186,8 @@ public sealed partial class PdfDocumentPreflight {
     private bool HasFormMutationBlocker(PdfMutationOperation operation) {
         return Probe.HasSignatures ||
             Probe.HasActiveContent ||
-            DocumentInfo?.AcroFormSignaturesExist == true ||
-            DocumentInfo?.HasActiveContent == true ||
+            _documentInfo?.AcroFormSignaturesExist == true ||
+            _documentInfo?.HasActiveContent == true ||
             (Probe.HasEncryption && !PdfPermissionAuthorization.CanMutate(Probe.Security, PermissionPolicy, operation));
     }
 
@@ -198,12 +205,12 @@ public sealed partial class PdfDocumentPreflight {
     }
 
     private bool HasSimpleFillableFormFields() {
-        if (DocumentInfo is null || DocumentInfo.FormFields.Count == 0) {
+        if (_documentInfo is null || _documentInfo.FormFields.Count == 0) {
             return false;
         }
 
-        for (int i = 0; i < DocumentInfo.FormFields.Count; i++) {
-            PdfFormField field = DocumentInfo.FormFields[i];
+        for (int i = 0; i < _documentInfo.FormFields.Count; i++) {
+            PdfFormField field = _documentInfo.FormFields[i];
             if (IsNamedSimpleFillField(field)) {
                 return true;
             }
@@ -213,13 +220,13 @@ public sealed partial class PdfDocumentPreflight {
     }
 
     private bool HasSimpleFlattenableFormFields() {
-        if (DocumentInfo is null || DocumentInfo.FormFields.Count == 0) {
+        if (_documentInfo is null || _documentInfo.FormFields.Count == 0) {
             return false;
         }
 
         bool hasFlattenableWidget = false;
-        for (int i = 0; i < DocumentInfo.FormFields.Count; i++) {
-            PdfFormField field = DocumentInfo.FormFields[i];
+        for (int i = 0; i < _documentInfo.FormFields.Count; i++) {
+            PdfFormField field = _documentInfo.FormFields[i];
             if (!IsNamedSimpleFlattenField(field) || field.Widgets.Count == 0) {
                 return false;
             }
@@ -383,12 +390,12 @@ public sealed partial class PdfDocumentPreflight {
             AddRange(messages, SecurityDiagnostics);
         }
 
-        if (Probe.HasSignatures || DocumentInfo?.AcroFormSignaturesExist == true) {
+        if (Probe.HasSignatures || _documentInfo?.AcroFormSignaturesExist == true) {
             AddDistinct(messages, "Signed PDF files are not supported for form filling or flattening by OfficeIMO.Pdf yet.");
             AddRange(messages, SignatureMutationDiagnostics);
         }
 
-        if (Probe.HasActiveContent || DocumentInfo?.HasActiveContent == true) {
+        if (Probe.HasActiveContent || _documentInfo?.HasActiveContent == true) {
             AddDistinct(messages, "PDF active content is not supported for form filling or flattening by OfficeIMO.Pdf yet.");
         }
 

--- a/OfficeIMO.Pdf/Reading/Model/PdfDocumentPreflight.cs
+++ b/OfficeIMO.Pdf/Reading/Model/PdfDocumentPreflight.cs
@@ -45,7 +45,7 @@ public sealed partial class PdfDocumentPreflight {
     public bool CanExtractAttachments => DocumentInfo is not null && !HasAttachmentExtractionBlocker() && PdfPermissionAuthorization.CanExtractContent(Probe.Security, PermissionPolicy);
 
     /// <summary>True when OfficeIMO.Pdf can attempt logical object readback through PdfLogicalDocument for this PDF.</summary>
-    public bool CanReadLogicalObjects => CanExtractText;
+    public bool CanReadLogicalObjects => CanRead && PdfPermissionAuthorization.CanExtractContent(Probe.Security, PermissionPolicy);
 
     /// <summary>Permission policy used while evaluating extraction and mutation capabilities.</summary>
     public PdfPermissionPolicy PermissionPolicy { get; }

--- a/OfficeIMO.Pdf/Reading/Model/PdfDocumentPreflight.cs
+++ b/OfficeIMO.Pdf/Reading/Model/PdfDocumentPreflight.cs
@@ -57,10 +57,10 @@ public sealed partial class PdfDocumentPreflight {
     public bool CanManipulatePages => CanRewrite || CanUseAuthenticatedEncryptedPageMutation();
 
     /// <summary>True when OfficeIMO.Pdf can attempt simple AcroForm value updates for named text, choice, or button fields.</summary>
-    public bool CanFillSimpleFormFields => CanRead && !HasFormMutationBlocker() && !HasRewriteBlocker(PdfRewriteBlockerKind.Encryption) && HasSimpleFillableFormFields();
+    public bool CanFillSimpleFormFields => CanRead && !HasFormMutationBlocker(PdfMutationOperation.FillFormFields) && HasSimpleFillableFormFields();
 
     /// <summary>True when OfficeIMO.Pdf can attempt simple AcroForm flattening for text, choice, or button widgets with page-backed rectangles.</summary>
-    public bool CanFlattenSimpleFormFields => CanRead && !HasFormMutationBlocker() && !HasRewriteBlocker(PdfRewriteBlockerKind.Encryption) && HasSimpleFlattenableFormFields();
+    public bool CanFlattenSimpleFormFields => CanRead && !HasFormMutationBlocker(PdfMutationOperation.FlattenFormFields) && HasSimpleFlattenableFormFields();
 
     /// <summary>True when OfficeIMO.Pdf can attempt simple AcroForm value updates followed by simple widget flattening.</summary>
     public bool CanFillAndFlattenSimpleFormFields => CanFillSimpleFormFields && CanFlattenSimpleFormFields;
@@ -176,12 +176,12 @@ public sealed partial class PdfDocumentPreflight {
         }
     }
 
-    private bool HasFormMutationBlocker() {
-        return Probe.HasEncryption ||
-            Probe.HasSignatures ||
+    private bool HasFormMutationBlocker(PdfMutationOperation operation) {
+        return Probe.HasSignatures ||
             Probe.HasActiveContent ||
             DocumentInfo?.AcroFormSignaturesExist == true ||
-            DocumentInfo?.HasActiveContent == true;
+            DocumentInfo?.HasActiveContent == true ||
+            (Probe.HasEncryption && !PdfPermissionAuthorization.CanMutate(Probe.Security, PermissionPolicy, operation));
     }
 
     private bool HasImageExtractionBlocker() {

--- a/OfficeIMO.Pdf/Reading/Model/PdfDocumentPreflight.cs
+++ b/OfficeIMO.Pdf/Reading/Model/PdfDocumentPreflight.cs
@@ -11,7 +11,8 @@ public sealed partial class PdfDocumentPreflight {
         bool canRewrite,
         IReadOnlyList<string> diagnostics,
         IReadOnlyList<PdfReadBlocker> readBlockers,
-        IReadOnlyList<PdfRewriteBlocker> rewriteBlockers) {
+        IReadOnlyList<PdfRewriteBlocker> rewriteBlockers,
+        PdfPermissionPolicy permissionPolicy) {
         Probe = probe;
         DocumentInfo = documentInfo;
         CanRead = canRead;
@@ -19,6 +20,7 @@ public sealed partial class PdfDocumentPreflight {
         Diagnostics = diagnostics;
         ReadBlockers = readBlockers;
         RewriteBlockers = rewriteBlockers;
+        PermissionPolicy = permissionPolicy;
     }
 
     /// <summary>Lightweight PDF markers read before full parsing.</summary>
@@ -34,19 +36,25 @@ public sealed partial class PdfDocumentPreflight {
     public bool CanRewrite { get; }
 
     /// <summary>True when OfficeIMO.Pdf can attempt text and structured text readback operations for this PDF.</summary>
-    public bool CanExtractText => CanRead;
+    public bool CanExtractText => CanRead && PdfPermissionAuthorization.CanExtractText(Probe.Security, PermissionPolicy);
 
     /// <summary>True when OfficeIMO.Pdf can attempt image XObject extraction for this PDF.</summary>
-    public bool CanExtractImages => DocumentInfo is not null && !HasImageExtractionBlocker();
+    public bool CanExtractImages => DocumentInfo is not null && !HasImageExtractionBlocker() && PdfPermissionAuthorization.CanExtractContent(Probe.Security, PermissionPolicy);
 
     /// <summary>True when OfficeIMO.Pdf can attempt embedded-file and associated-file attachment extraction for this PDF.</summary>
-    public bool CanExtractAttachments => DocumentInfo is not null && !HasAttachmentExtractionBlocker();
+    public bool CanExtractAttachments => DocumentInfo is not null && !HasAttachmentExtractionBlocker() && PdfPermissionAuthorization.CanExtractContent(Probe.Security, PermissionPolicy);
 
     /// <summary>True when OfficeIMO.Pdf can attempt logical object readback through PdfLogicalDocument for this PDF.</summary>
-    public bool CanReadLogicalObjects => CanRead;
+    public bool CanReadLogicalObjects => CanExtractText;
 
-    /// <summary>True when OfficeIMO.Pdf can attempt page-level rewrite operations such as extract, split, merge, import, edit, stamp, and metadata updates.</summary>
-    public bool CanManipulatePages => CanRewrite;
+    /// <summary>Permission policy used while evaluating extraction and mutation capabilities.</summary>
+    public PdfPermissionPolicy PermissionPolicy { get; }
+
+    /// <summary>True when authenticated user-password restrictions are being explicitly ignored.</summary>
+    public bool PermissionRestrictionsIgnored => PdfPermissionAuthorization.RestrictionsIgnored(Probe.Security, PermissionPolicy);
+
+    /// <summary>True when OfficeIMO.Pdf can attempt at least one page-level rewrite operation.</summary>
+    public bool CanManipulatePages => CanRewrite || CanUseAuthenticatedEncryptedPageMutation();
 
     /// <summary>True when OfficeIMO.Pdf can attempt simple AcroForm value updates for named text, choice, or button fields.</summary>
     public bool CanFillSimpleFormFields => CanRead && !HasFormMutationBlocker() && !HasRewriteBlocker(PdfRewriteBlockerKind.Encryption) && HasSimpleFillableFormFields();
@@ -88,6 +96,22 @@ public sealed partial class PdfDocumentPreflight {
         return false;
     }
 
+    private bool CanUseAuthenticatedEncryptedPageMutation() {
+        if (!CanRead || !Probe.Security.HasEncryption) {
+            return false;
+        }
+
+        for (int i = 0; i < RewriteBlockers.Count; i++) {
+            if (RewriteBlockers[i].Kind != PdfRewriteBlockerKind.Encryption) {
+                return false;
+            }
+        }
+
+        return PdfPermissionAuthorization.CanMutate(Probe.Security, PermissionPolicy, PdfMutationOperation.ModifyPageContent) ||
+            PdfPermissionAuthorization.CanMutate(Probe.Security, PermissionPolicy, PdfMutationOperation.ModifyPageTree) ||
+            PdfPermissionAuthorization.CanMutate(Probe.Security, PermissionPolicy, PdfMutationOperation.MergeDocuments);
+    }
+
     /// <summary>Returns true when the requested wrapper-facing capability can be attempted for this PDF.</summary>
     public bool Can(PdfPreflightCapability capability) {
         switch (capability) {
@@ -126,7 +150,7 @@ public sealed partial class PdfDocumentPreflight {
 
         switch (capability) {
             case PdfPreflightCapability.ExtractText:
-                return GetReadCapabilityDiagnostics("PDF text extraction is not available because OfficeIMO.Pdf cannot read this PDF.");
+                return GetTextExtractionDiagnostics();
             case PdfPreflightCapability.ExtractImages:
                 return GetImageExtractionDiagnostics();
             case PdfPreflightCapability.ExtractAttachments:
@@ -244,7 +268,19 @@ public sealed partial class PdfDocumentPreflight {
         return messages.AsReadOnly();
     }
 
+    private IReadOnlyList<string> GetTextExtractionDiagnostics() {
+        if (CanRead && !PdfPermissionAuthorization.CanExtractText(Probe.Security, PermissionPolicy)) {
+            return new[] { "PDF text extraction is restricted by the authenticated user-password permissions. Supply owner authorization or explicitly ignore permission restrictions." };
+        }
+
+        return GetReadCapabilityDiagnostics("PDF text extraction is not available because OfficeIMO.Pdf cannot read this PDF.");
+    }
+
     private IReadOnlyList<string> GetImageExtractionDiagnostics() {
+        if (CanRead && !PdfPermissionAuthorization.CanExtractContent(Probe.Security, PermissionPolicy)) {
+            return new[] { "PDF image extraction is restricted by the authenticated user-password permissions. Supply owner authorization or explicitly ignore permission restrictions." };
+        }
+
         if (ReadBlockers.Count == 0) {
             return new[] { "PDF image extraction is not available because OfficeIMO.Pdf cannot inspect this PDF." };
         }
@@ -265,6 +301,10 @@ public sealed partial class PdfDocumentPreflight {
     }
 
     private IReadOnlyList<string> GetAttachmentExtractionDiagnostics() {
+        if (CanRead && !PdfPermissionAuthorization.CanExtractContent(Probe.Security, PermissionPolicy)) {
+            return new[] { "PDF attachment extraction is restricted by the authenticated user-password permissions. Supply owner authorization or explicitly ignore permission restrictions." };
+        }
+
         if (ReadBlockers.Count == 0) {
             return new[] { "PDF attachment extraction is not available because OfficeIMO.Pdf cannot inspect this PDF." };
         }

--- a/OfficeIMO.Pdf/Reading/Options/PdfPermissionPolicy.cs
+++ b/OfficeIMO.Pdf/Reading/Options/PdfPermissionPolicy.cs
@@ -1,0 +1,13 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>Controls how authenticated PDF Standard-security permission restrictions are handled.</summary>
+public enum PdfPermissionPolicy {
+    /// <summary>Enforces the permission bits associated with user-password authorization.</summary>
+    Enforce,
+
+    /// <summary>
+    /// Ignores authenticated user-password permission restrictions after the PDF has been successfully decrypted.
+    /// This does not discover, bypass, or crack an unknown document-open password.
+    /// </summary>
+    IgnoreRestrictions
+}

--- a/OfficeIMO.Pdf/Reading/Options/PdfReadOptions.cs
+++ b/OfficeIMO.Pdf/Reading/Options/PdfReadOptions.cs
@@ -15,6 +15,12 @@ public sealed class PdfReadOptions {
 
     /// <summary>Password used to open encrypted PDFs. The same value is tried as user and owner password for Standard security handler files.</summary>
     public string? Password { get; init; }
+
+    /// <summary>
+    /// Controls whether authenticated user-password permission restrictions are enforced.
+    /// Ignoring restrictions still requires the PDF to be successfully decrypted with a valid password.
+    /// </summary>
+    public PdfPermissionPolicy PermissionPolicy { get; init; } = PdfPermissionPolicy.Enforce;
     /// <summary>Prefer decoding via ToUnicode CMap when available. Default: true.</summary>
     public bool PreferToUnicode { get; init; } = true;
     /// <summary>Fallback to WinAnsi (Windows-1252) when no ToUnicode is present. Default: true.</summary>
@@ -35,6 +41,7 @@ public sealed class PdfReadOptions {
             ParsingMode = effective.ParsingMode,
             Limits = effective.Limits.WithMinimumInputBytes(minimumInputBytes),
             Password = effective.Password,
+            PermissionPolicy = effective.PermissionPolicy,
             PreferToUnicode = effective.PreferToUnicode,
             UseWinAnsiFallback = effective.UseWinAnsiFallback,
             AdjustKerningFromTJ = effective.AdjustKerningFromTJ

--- a/OfficeIMO.Pdf/Reading/PdfImageExtractor.cs
+++ b/OfficeIMO.Pdf/Reading/PdfImageExtractor.cs
@@ -233,6 +233,7 @@ internal static class PdfImageExtractor {
     /// </summary>
     public static IReadOnlyList<PdfExtractedImage> ExtractImages(PdfReadDocument document) {
         Guard.NotNull(document, nameof(document));
+        document.DemandContentExtraction("image");
 
         var images = new List<PdfExtractedImage>();
         for (int i = 0; i < document.Pages.Count; i++) {
@@ -247,6 +248,7 @@ internal static class PdfImageExtractor {
     /// </summary>
     public static IReadOnlyList<PdfImagePlacement> ExtractImagePlacements(PdfReadDocument document) {
         Guard.NotNull(document, nameof(document));
+        document.DemandContentExtraction("image placement");
 
         var placements = new List<PdfImagePlacement>();
         for (int i = 0; i < document.Pages.Count; i++) {
@@ -277,6 +279,7 @@ internal static class PdfImageExtractor {
     /// </summary>
     public static IReadOnlyList<PdfExtractedImage> ExtractImagesByPageRanges(PdfReadDocument document, params PdfPageRange[] pageRanges) {
         Guard.NotNull(document, nameof(document));
+        document.DemandContentExtraction("image");
         int[] pageNumbers = PdfPageRange.ExpandMany(pageRanges, document.Pages.Count, nameof(pageRanges));
         var images = new List<PdfExtractedImage>();
         for (int i = 0; i < pageNumbers.Length; i++) {
@@ -292,6 +295,7 @@ internal static class PdfImageExtractor {
     /// </summary>
     public static IReadOnlyList<PdfImagePlacement> ExtractImagePlacementsByPageRanges(PdfReadDocument document, params PdfPageRange[] pageRanges) {
         Guard.NotNull(document, nameof(document));
+        document.DemandContentExtraction("image placement");
         int[] pageNumbers = PdfPageRange.ExpandMany(pageRanges, document.Pages.Count, nameof(pageRanges));
         var placements = new List<PdfImagePlacement>();
         for (int i = 0; i < pageNumbers.Length; i++) {

--- a/OfficeIMO.Pdf/Reading/PdfInspector.cs
+++ b/OfficeIMO.Pdf/Reading/PdfInspector.cs
@@ -456,7 +456,7 @@ internal static class PdfInspector {
             ? document.OutputIntents
             : Array.Empty<PdfOutputIntentInfo>();
         PdfXmpMetadataInfo? xmpMetadata = useDocumentWideObjects
-            ? document.XmpMetadata
+            ? document.UncheckedXmpMetadata
             : null;
         PdfTaggedContentInfo? taggedContent = useDocumentWideObjects
             ? document.UncheckedTaggedContent
@@ -503,7 +503,7 @@ internal static class PdfInspector {
             pages.Add(new PdfPageInfo(pageNumber, width, height, rotation, geometry, links, formWidgets, annotations, actions));
         }
 
-        return new PdfDocumentInfo(pages.AsReadOnly(), document.Metadata, outlines, pageLabels, namedDestinations, catalogActions, attachments, outputIntents, xmpMetadata, taggedContent, optionalContent, openAction, document.ViewerPreferences, formFields, document.UncheckedAcroFormDefaultAppearance, document.UncheckedAcroFormQuadding, document.UncheckedAcroFormXfa, document.UncheckedAcroFormNeedAppearances, document.UncheckedAcroFormSignatureFlags, document.Security, probe.HeaderVersion, document.CatalogPageMode, document.CatalogPageLayout, document.CatalogVersion, document.CatalogLanguage, document.Security.HasSignatures || probe.HasSignatures, probe.HasForms || document.UncheckedAcroFormXfa is not null, probe.HasAnnotations, probe.HasOutlines, probe.HasCatalogViewSettings, probe.HasPageLabels, probe.HasCatalogNameTrees, probe.HasNamedDestinations, probe.HasOpenActions, probe.HasViewerPreferences, probe.HasTaggedContent, probe.HasXmpMetadata, probe.HasCatalogUri, probe.HasOutputIntents, probe.HasEmbeddedFiles, probe.HasOptionalContent, probe.HasActiveContent);
+        return new PdfDocumentInfo(pages.AsReadOnly(), document.UncheckedMetadata, outlines, pageLabels, namedDestinations, catalogActions, attachments, outputIntents, xmpMetadata, taggedContent, optionalContent, openAction, document.ViewerPreferences, formFields, document.UncheckedAcroFormDefaultAppearance, document.UncheckedAcroFormQuadding, document.UncheckedAcroFormXfa, document.UncheckedAcroFormNeedAppearances, document.UncheckedAcroFormSignatureFlags, document.Security, probe.HeaderVersion, document.CatalogPageMode, document.CatalogPageLayout, document.CatalogVersion, document.CatalogLanguage, document.Security.HasSignatures || probe.HasSignatures, probe.HasForms || document.UncheckedAcroFormXfa is not null, probe.HasAnnotations, probe.HasOutlines, probe.HasCatalogViewSettings, probe.HasPageLabels, probe.HasCatalogNameTrees, probe.HasNamedDestinations, probe.HasOpenActions, probe.HasViewerPreferences, probe.HasTaggedContent, probe.HasXmpMetadata, probe.HasCatalogUri, probe.HasOutputIntents, probe.HasEmbeddedFiles, probe.HasOptionalContent, probe.HasActiveContent);
     }
 
     private static Dictionary<int, IReadOnlyList<PdfFormWidget>> BuildFormWidgetsByPage(IReadOnlyList<PdfFormField> fields) {

--- a/OfficeIMO.Pdf/Reading/PdfInspector.cs
+++ b/OfficeIMO.Pdf/Reading/PdfInspector.cs
@@ -435,22 +435,22 @@ internal static class PdfInspector {
         pageNumbers ??= PdfPageRangeObjectFilter.GetAllPageNumbers(document.Pages.Count);
         bool useDocumentWideObjects = PdfPageRangeObjectFilter.ShouldUseDocumentWideObjects(document.Pages.Count, pageNumbers);
         IReadOnlyList<PdfFormField> formFields = useDocumentWideObjects
-            ? document.FormFields
-            : PdfPageRangeObjectFilter.FilterFormFieldsByPageNumbers(document.FormFields, pageNumbers, preservePageDuplicates: true);
+            ? document.UncheckedFormFields
+            : PdfPageRangeObjectFilter.FilterFormFieldsByPageNumbers(document.UncheckedFormFields, pageNumbers, preservePageDuplicates: true);
         IReadOnlyList<PdfOutlineItem> outlines = useDocumentWideObjects
-            ? document.Outlines
-            : PdfPageRangeObjectFilter.FilterOutlinesByPageNumbers(document.Outlines, pageNumbers);
+            ? document.UncheckedOutlines
+            : PdfPageRangeObjectFilter.FilterOutlinesByPageNumbers(document.UncheckedOutlines, pageNumbers);
         IReadOnlyList<PdfPageLabel> pageLabels = useDocumentWideObjects
-            ? document.PageLabels
-            : PdfPageRangeObjectFilter.FilterPageLabelsByPageNumbers(document.PageLabels, pageNumbers);
+            ? document.UncheckedPageLabels
+            : PdfPageRangeObjectFilter.FilterPageLabelsByPageNumbers(document.UncheckedPageLabels, pageNumbers);
         IReadOnlyList<PdfNamedDestination> namedDestinations = useDocumentWideObjects
-            ? document.NamedDestinations
-            : PdfPageRangeObjectFilter.FilterNamedDestinationsByPageNumbers(document.NamedDestinations, pageNumbers);
+            ? document.UncheckedNamedDestinations
+            : PdfPageRangeObjectFilter.FilterNamedDestinationsByPageNumbers(document.UncheckedNamedDestinations, pageNumbers);
         IReadOnlyList<PdfCatalogAction> catalogActions = useDocumentWideObjects
-            ? document.CatalogActions
+            ? document.UncheckedCatalogActions
             : Array.Empty<PdfCatalogAction>();
         IReadOnlyList<PdfAttachmentInfo> attachments = useDocumentWideObjects
-            ? document.Attachments
+            ? document.UncheckedAttachments
             : Array.Empty<PdfAttachmentInfo>();
         IReadOnlyList<PdfOutputIntentInfo> outputIntents = useDocumentWideObjects
             ? document.OutputIntents
@@ -459,24 +459,24 @@ internal static class PdfInspector {
             ? document.XmpMetadata
             : null;
         PdfTaggedContentInfo? taggedContent = useDocumentWideObjects
-            ? document.TaggedContent
+            ? document.UncheckedTaggedContent
             : null;
         PdfOptionalContentProperties? optionalContent = useDocumentWideObjects
-            ? document.OptionalContent
+            ? document.UncheckedOptionalContent
             : null;
         PdfDocumentOpenAction? openAction = useDocumentWideObjects
-            ? document.OpenAction
-            : PdfPageRangeObjectFilter.FilterOpenActionByPageNumbers(document.OpenAction, pageNumbers);
+            ? document.UncheckedOpenAction
+            : PdfPageRangeObjectFilter.FilterOpenActionByPageNumbers(document.UncheckedOpenAction, pageNumbers);
 
         var pages = new List<PdfPageInfo>(pageNumbers.Length);
-        var widgetsByPage = BuildFormWidgetsByPage(document.FormFields);
+        var widgetsByPage = BuildFormWidgetsByPage(document.UncheckedFormFields);
         for (int i = 0; i < pageNumbers.Length; i++) {
             int pageNumber = pageNumbers[i];
             PdfReadPage page = document.Pages[pageNumber - 1];
             PdfPageGeometry geometry = page.GetGeometry();
             var (width, height) = page.GetPageSize();
             int rotation = page.GetRotationDegrees();
-            var pageLinks = page.GetLinkAnnotations();
+            var pageLinks = page.GetLinkAnnotationsUnchecked();
             var links = new List<PdfLinkAnnotation>(pageLinks.Count);
             for (int j = 0; j < pageLinks.Count; j++) {
                 PdfLinkAnnotation link = pageLinks[j].WithPageNumber(pageNumber);
@@ -487,13 +487,13 @@ internal static class PdfInspector {
                 links.Add(link);
             }
 
-            var pageAnnotations = page.GetAnnotations();
+            var pageAnnotations = page.GetAnnotationsUnchecked();
             var annotations = new List<PdfAnnotation>(pageAnnotations.Count);
             for (int j = 0; j < pageAnnotations.Count; j++) {
                 annotations.Add(pageAnnotations[j].WithPageNumber(pageNumber));
             }
 
-            var pageActions = page.GetPageActions();
+            var pageActions = page.GetPageActionsUnchecked();
             var actions = new List<PdfPageAction>(pageActions.Count);
             for (int j = 0; j < pageActions.Count; j++) {
                 actions.Add(pageActions[j].WithPageNumber(pageNumber));
@@ -503,7 +503,7 @@ internal static class PdfInspector {
             pages.Add(new PdfPageInfo(pageNumber, width, height, rotation, geometry, links, formWidgets, annotations, actions));
         }
 
-        return new PdfDocumentInfo(pages.AsReadOnly(), document.Metadata, outlines, pageLabels, namedDestinations, catalogActions, attachments, outputIntents, xmpMetadata, taggedContent, optionalContent, openAction, document.ViewerPreferences, formFields, document.AcroFormDefaultAppearance, document.AcroFormQuadding, document.AcroFormXfa, document.AcroFormNeedAppearances, document.AcroFormSignatureFlags, document.Security, probe.HeaderVersion, document.CatalogPageMode, document.CatalogPageLayout, document.CatalogVersion, document.CatalogLanguage, document.Security.HasSignatures || probe.HasSignatures, probe.HasForms || document.AcroFormXfa is not null, probe.HasAnnotations, probe.HasOutlines, probe.HasCatalogViewSettings, probe.HasPageLabels, probe.HasCatalogNameTrees, probe.HasNamedDestinations, probe.HasOpenActions, probe.HasViewerPreferences, probe.HasTaggedContent, probe.HasXmpMetadata, probe.HasCatalogUri, probe.HasOutputIntents, probe.HasEmbeddedFiles, probe.HasOptionalContent, probe.HasActiveContent);
+        return new PdfDocumentInfo(pages.AsReadOnly(), document.Metadata, outlines, pageLabels, namedDestinations, catalogActions, attachments, outputIntents, xmpMetadata, taggedContent, optionalContent, openAction, document.ViewerPreferences, formFields, document.UncheckedAcroFormDefaultAppearance, document.UncheckedAcroFormQuadding, document.UncheckedAcroFormXfa, document.UncheckedAcroFormNeedAppearances, document.UncheckedAcroFormSignatureFlags, document.Security, probe.HeaderVersion, document.CatalogPageMode, document.CatalogPageLayout, document.CatalogVersion, document.CatalogLanguage, document.Security.HasSignatures || probe.HasSignatures, probe.HasForms || document.UncheckedAcroFormXfa is not null, probe.HasAnnotations, probe.HasOutlines, probe.HasCatalogViewSettings, probe.HasPageLabels, probe.HasCatalogNameTrees, probe.HasNamedDestinations, probe.HasOpenActions, probe.HasViewerPreferences, probe.HasTaggedContent, probe.HasXmpMetadata, probe.HasCatalogUri, probe.HasOutputIntents, probe.HasEmbeddedFiles, probe.HasOptionalContent, probe.HasActiveContent);
     }
 
     private static Dictionary<int, IReadOnlyList<PdfFormWidget>> BuildFormWidgetsByPage(IReadOnlyList<PdfFormField> fields) {

--- a/OfficeIMO.Pdf/Reading/PdfInspector.cs
+++ b/OfficeIMO.Pdf/Reading/PdfInspector.cs
@@ -107,7 +107,8 @@ internal static class PdfInspector {
         byte[] pdf,
         PdfReadOptions? options,
         Func<PdfReadDocument>? readDocumentFactory) {
-        PdfDocumentProbe probe = Probe(pdf, options);
+        PdfReadOptions effectiveOptions = PdfReadOptions.Resolve(options);
+        PdfDocumentProbe probe = Probe(pdf, effectiveOptions);
         var diagnostics = new List<string>();
         var readBlockers = new List<PdfReadBlocker>();
         var rewriteBlockers = new List<PdfRewriteBlocker>();
@@ -119,13 +120,13 @@ internal static class PdfInspector {
         }
 
         if (probe.HasEncryption) {
-            AddRewriteBlocker(PdfRewriteBlockerKind.Encryption, "General encrypted-document rewrites remain blocked; the dedicated owner-authorized security editor can decrypt or re-encrypt supported unsigned PDFs.");
+            AddRewriteBlocker(PdfRewriteBlockerKind.Encryption, "Encrypted input requires operation-specific planning. Authenticated unsigned PDFs support proven page extraction, merge, page-tree, and page-content rewrites; other rewrites remain blocked, and security changes require owner authorization.");
         }
 
         bool canRead = readBlockers.Count == 0;
         if (canRead) {
             try {
-                readDocument = readDocumentFactory?.Invoke() ?? PdfReadDocument.Open(pdf, options);
+                readDocument = readDocumentFactory?.Invoke() ?? PdfReadDocument.Open(pdf, effectiveOptions);
                 probe = Probe(pdf, readDocument);
                 info = FromReadDocument(readDocument, probe);
                 if (info.PageCount == 0) {
@@ -224,7 +225,7 @@ internal static class PdfInspector {
         }
 
         bool canRewrite = canRead && rewriteBlockers.Count == 0;
-        return new PdfDocumentPreflight(probe, info, canRead, canRewrite, diagnostics.AsReadOnly(), readBlockers.AsReadOnly(), rewriteBlockers.AsReadOnly());
+        return new PdfDocumentPreflight(probe, info, canRead, canRewrite, diagnostics.AsReadOnly(), readBlockers.AsReadOnly(), rewriteBlockers.AsReadOnly(), effectiveOptions.PermissionPolicy);
 
         void AddReadBlocker(PdfReadBlockerKind kind, string message) {
             AddDiagnostic(message);

--- a/OfficeIMO.Pdf/Reading/PdfInspector.cs
+++ b/OfficeIMO.Pdf/Reading/PdfInspector.cs
@@ -453,7 +453,7 @@ internal static class PdfInspector {
             ? document.UncheckedAttachments
             : Array.Empty<PdfAttachmentInfo>();
         IReadOnlyList<PdfOutputIntentInfo> outputIntents = useDocumentWideObjects
-            ? document.OutputIntents
+            ? document.UncheckedOutputIntents
             : Array.Empty<PdfOutputIntentInfo>();
         PdfXmpMetadataInfo? xmpMetadata = useDocumentWideObjects
             ? document.UncheckedXmpMetadata

--- a/OfficeIMO.Pdf/Reading/PdfInspector.cs
+++ b/OfficeIMO.Pdf/Reading/PdfInspector.cs
@@ -120,7 +120,7 @@ internal static class PdfInspector {
         }
 
         if (probe.HasEncryption) {
-            AddRewriteBlocker(PdfRewriteBlockerKind.Encryption, "Encrypted input requires operation-specific planning. Authenticated unsigned PDFs support proven page extraction, merge, page-tree, and page-content rewrites; other rewrites remain blocked, and security changes require owner authorization.");
+            AddRewriteBlocker(PdfRewriteBlockerKind.Encryption, "Encrypted input requires operation-specific planning. Authenticated unsigned PDFs support proven page, metadata, sanitization, and simple form rewrites when the required permissions are authorized; security changes require owner authorization.");
         }
 
         bool canRead = readBlockers.Count == 0;

--- a/OfficeIMO.Pdf/Reading/Security/PdfPermissionAuthorization.cs
+++ b/OfficeIMO.Pdf/Reading/Security/PdfPermissionAuthorization.cs
@@ -1,0 +1,77 @@
+namespace OfficeIMO.Pdf;
+
+internal static class PdfPermissionAuthorization {
+    internal static bool CanExtractText(PdfDocumentSecurityInfo security, PdfPermissionPolicy policy) =>
+        IsAllowed(security, policy, PdfStandardPermissions.CopyContents) ||
+        IsAllowed(security, policy, PdfStandardPermissions.Accessibility);
+
+    internal static bool CanExtractContent(PdfDocumentSecurityInfo security, PdfPermissionPolicy policy) =>
+        IsAllowed(security, policy, PdfStandardPermissions.CopyContents);
+
+    internal static bool CanMutate(PdfDocumentSecurityInfo security, PdfPermissionPolicy policy, PdfMutationOperation operation) {
+        if (!security.HasEncryption || security.HasOwnerAuthorization) {
+            return true;
+        }
+
+        if (operation == PdfMutationOperation.ChangeEncryption) {
+            return false;
+        }
+
+        if (policy == PdfPermissionPolicy.IgnoreRestrictions) {
+            return true;
+        }
+
+        switch (operation) {
+            case PdfMutationOperation.ExtractPages:
+            case PdfMutationOperation.MergeDocuments:
+                return security.AllowsCopying == true && security.AllowsDocumentAssembly == true;
+            case PdfMutationOperation.ModifyPageTree:
+                return security.AllowsDocumentAssembly == true;
+            case PdfMutationOperation.ModifyAnnotations:
+                return security.AllowsAnnotationChanges == true || security.AllowsModification == true;
+            case PdfMutationOperation.FillFormFields:
+            case PdfMutationOperation.FlattenFormFields:
+            case PdfMutationOperation.FillAndFlattenFormFields:
+            case PdfMutationOperation.ModifyAcroForm:
+                return security.AllowsFormFilling == true || security.AllowsModification == true;
+            default:
+                return security.AllowsModification == true;
+        }
+    }
+
+    internal static void DemandTextExtraction(PdfDocumentSecurityInfo security, PdfPermissionPolicy policy) {
+        if (CanExtractText(security, policy)) {
+            return;
+        }
+
+        throw new PdfPermissionDeniedException(
+            PdfStandardPermissions.CopyContents,
+            security.PasswordAuthenticationRole,
+            "PDF text extraction is restricted by the authenticated user-password permissions. Supply owner authorization or set PermissionPolicy to IgnoreRestrictions after confirming that the operation is authorized.");
+    }
+
+    internal static void DemandContentExtraction(PdfDocumentSecurityInfo security, PdfPermissionPolicy policy, string contentName) {
+        if (CanExtractContent(security, policy)) {
+            return;
+        }
+
+        throw new PdfPermissionDeniedException(
+            PdfStandardPermissions.CopyContents,
+            security.PasswordAuthenticationRole,
+            "PDF " + contentName + " extraction is restricted by the authenticated user-password permissions. Supply owner authorization or set PermissionPolicy to IgnoreRestrictions after confirming that the operation is authorized.");
+    }
+
+    internal static bool RestrictionsIgnored(PdfDocumentSecurityInfo security, PdfPermissionPolicy policy) =>
+        security.HasEncryption &&
+        !security.HasOwnerAuthorization &&
+        policy == PdfPermissionPolicy.IgnoreRestrictions;
+
+    private static bool IsAllowed(PdfDocumentSecurityInfo security, PdfPermissionPolicy policy, PdfStandardPermissions permission) {
+        if (!security.HasEncryption || security.HasOwnerAuthorization || policy == PdfPermissionPolicy.IgnoreRestrictions) {
+            return true;
+        }
+
+        PdfStandardPermissions? allowed = security.AllowedStandardPermissions;
+        return allowed.HasValue && (allowed.Value & permission) == permission;
+    }
+}

--- a/OfficeIMO.Pdf/Reading/Security/PdfPermissionDeniedException.cs
+++ b/OfficeIMO.Pdf/Reading/Security/PdfPermissionDeniedException.cs
@@ -1,0 +1,16 @@
+namespace OfficeIMO.Pdf;
+
+/// <summary>Raised when an authenticated PDF permission restriction blocks an extraction or mutation.</summary>
+public sealed class PdfPermissionDeniedException : InvalidOperationException {
+    internal PdfPermissionDeniedException(PdfStandardPermissions permission, PdfPasswordAuthenticationRole authenticationRole, string message)
+        : base(message) {
+        Permission = permission;
+        AuthenticationRole = authenticationRole;
+    }
+
+    /// <summary>Permission required by the blocked operation.</summary>
+    public PdfStandardPermissions Permission { get; }
+
+    /// <summary>Password role established while opening the PDF.</summary>
+    public PdfPasswordAuthenticationRole AuthenticationRole { get; }
+}

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.PageText.Rich.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.PageText.Rich.cs
@@ -1,0 +1,104 @@
+namespace OfficeIMO.Pdf;
+
+internal static partial class PdfWriter {
+    private static double[] BuildPageTextLineBaselines(
+        System.Collections.Generic.List<System.Collections.Generic.IReadOnlyList<TextRun>> lines,
+        double firstBaseline,
+        double defaultFontSize) {
+        var baselines = new double[lines.Count];
+        double baseline = firstBaseline;
+        for (int index = 0; index < lines.Count; index++) {
+            baselines[index] = baseline;
+            baseline -= GetPageTextLineLeading(lines[index], defaultFontSize);
+        }
+
+        return baselines;
+    }
+
+    private static double GetPageTextLineLeading(System.Collections.Generic.IReadOnlyList<TextRun> line, double defaultFontSize) {
+        double leading = defaultFontSize * 1.2D;
+        foreach (TextRun run in line) {
+            double requestedFontSize = run.FontSize ?? defaultFontSize;
+            leading = Math.Max(leading, EffectiveRichFontSize(requestedFontSize, run.Baseline) * 1.2D);
+        }
+
+        return leading;
+    }
+
+    private static void AppendPageTextRunDecorations(
+        StringBuilder sb,
+        System.Collections.Generic.List<System.Collections.Generic.IReadOnlyList<TextRun>> lines,
+        double[] baselines,
+        PdfStandardFont baseFont,
+        double defaultFontSize,
+        PdfColor? defaultColor,
+        double x,
+        PdfOptions options,
+        double? lineBoxWidth,
+        PdfAlign align) {
+        for (int lineIndex = 0; lineIndex < lines.Count; lineIndex++) {
+            System.Collections.Generic.IReadOnlyList<TextRun> line = lines[lineIndex];
+            double lineWidth = MeasurePageTextLineRuns(line, baseFont, defaultFontSize, options);
+            double dx = lineBoxWidth.HasValue
+                ? align == PdfAlign.Center
+                    ? Math.Max(0D, (lineBoxWidth.Value - lineWidth) / 2D)
+                    : align == PdfAlign.Right
+                        ? Math.Max(0D, lineBoxWidth.Value - lineWidth)
+                        : 0D
+                : 0D;
+            double cursorX = x + dx;
+
+            foreach (TextRun run in line) {
+                string text = run.Text ?? string.Empty;
+                if (text.Length == 0) {
+                    continue;
+                }
+
+                PdfStandardFont runFont = ResolvePageTextRunFont(run, baseFont);
+                PdfNamedFontFace? namedFont = options.TryResolveNamedFontFace(run.FontFamily, run.Bold, run.Italic, out PdfNamedFontFace resolvedNamedFont)
+                    ? resolvedNamedFont
+                    : null;
+                double requestedFontSize = run.FontSize ?? defaultFontSize;
+                double effectiveFontSize = EffectiveRichFontSize(requestedFontSize, run.Baseline);
+                double textRise = TextRiseForBaseline(requestedFontSize, run.Baseline);
+                double width = MeasureRichText(text, runFont, namedFont, requestedFontSize, run.Baseline, options);
+                PdfColor runColor = ResolvePageTextColor(run.Color ?? defaultColor, options);
+
+                if (run.BackgroundColor.HasValue && width > 0D) {
+                    double ascender = GetAscenderForOptions(runFont, namedFont, effectiveFontSize, options);
+                    double descender = GetDescenderForOptions(runFont, namedFont, effectiveFontSize, options);
+                    double paddingY = Math.Max(0.35D, effectiveFontSize * 0.04D);
+                    new ContentStreamBuilder(sb)
+                        .SaveState()
+                        .FillColor(run.BackgroundColor.Value)
+                        .Rectangle(cursorX, baselines[lineIndex] + textRise - descender - paddingY, width, ascender + descender + (paddingY * 2D))
+                        .FillPath()
+                        .RestoreState();
+                }
+
+                if (width > 0D && (run.Underline || run.Strike)) {
+                    double decorationWidth = Math.Max(0.45D, effectiveFontSize * 0.055D);
+                    if (run.Underline) {
+                        AppendPageTextDecorationLine(sb, cursorX, cursorX + width, baselines[lineIndex] + textRise - Math.Max(0.8D, effectiveFontSize * 0.1D), decorationWidth, runColor);
+                    }
+                    if (run.Strike) {
+                        AppendPageTextDecorationLine(sb, cursorX, cursorX + width, baselines[lineIndex] + textRise + (effectiveFontSize * 0.28D), decorationWidth, runColor);
+                    }
+                }
+
+                cursorX += width;
+            }
+        }
+    }
+
+    private static void AppendPageTextDecorationLine(StringBuilder sb, double x1, double x2, double y, double width, PdfColor color) {
+        new ContentStreamBuilder(sb)
+            .SaveState()
+            .StrokeColor(color)
+            .LineWidth(width)
+            .MoveTo(x1, y)
+            .LineTo(x2, y)
+            .StrokePath()
+            .RestoreState();
+    }
+}

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.PageText.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.PageText.cs
@@ -451,6 +451,7 @@ internal static partial class PdfWriter {
             .FillColor(ResolvePageTextColor(color, opts))
             .TextLeading(fontSize * 1.2D);
 
+        double currentTextRise = 0D;
         for (int lineIndex = 0; lineIndex < lines.Count; lineIndex++) {
             System.Collections.Generic.IReadOnlyList<TextRun> line = lines[lineIndex];
             double dx = 0D;
@@ -463,8 +464,11 @@ internal static partial class PdfWriter {
                 }
             }
 
+            if (lineIndex > 0 && Math.Abs(currentTextRise) > 0.0001D) {
+                content.TextRise(0D);
+                currentTextRise = 0D;
+            }
             content.TextMatrix(x + dx, baselines[lineIndex]);
-            double currentTextRise = 0D;
             foreach (TextRun run in line) {
                 string text = run.Text ?? string.Empty;
                 if (text.Length == 0) {
@@ -488,6 +492,10 @@ internal static partial class PdfWriter {
                     .FillColor(ResolvePageTextColor(run.Color ?? color, opts))
                     .ShowText(EncodeTextShowCommand(text, runFont, namedFont, opts), runFontSize);
             }
+        }
+
+        if (Math.Abs(currentTextRise) > 0.0001D) {
+            content.TextRise(0D);
         }
 
         content.EndText();

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.PageText.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.PageText.cs
@@ -5,17 +5,17 @@ namespace OfficeIMO.Pdf;
 
 internal static partial class PdfWriter {
     private static string BuildFooter(PdfOptions opts, int variantPage, int page, int pages, int documentPages, PdfStandardFont footerFont, string footerFontResource, System.Collections.Generic.IReadOnlyDictionary<PdfStandardFont, string> fontResources, System.Collections.Generic.IReadOnlyDictionary<PdfNamedFontFace, string> namedFontResources) {
-        string text;
+        System.Collections.Generic.IReadOnlyList<TextRun> runs;
         var footerSegments = opts.GetFooterSegmentsForPage(variantPage);
         var footerZones = opts.GetFooterZonesForPage(variantPage);
         if (HasPageTextZones(footerZones)) {
             return BuildPageTextZones(opts, footerZones, variantPage, page, pages, documentPages, footerFont, fontResources, namedFontResources, opts.FooterFontSize, opts.FooterTextColor, opts.FooterOffsetY, isHeader: false);
         } else if (footerSegments != null && footerSegments.Count > 0) {
-            text = BuildPageTextFromSegments(footerSegments, page, pages, opts.PageNumberStyle);
+            runs = BuildPageTextRunsFromSegments(footerSegments, page, pages, footerFont, opts.FooterFontSize, opts.FooterTextColor, opts, opts.FooterFontFamily);
         } else {
-            text = FormatPageText(opts.GetFooterFormatForPage(variantPage), page, pages, documentPages, opts.PageNumberStyle);
+            string text = FormatPageText(opts.GetFooterFormatForPage(variantPage), page, pages, documentPages, opts.PageNumberStyle);
+            runs = BuildPageTextRuns(text, footerFont, opts.FooterFontSize, opts.FooterTextColor, opts, opts.FooterFontFamily);
         }
-        System.Collections.Generic.IReadOnlyList<TextRun> runs = BuildPageTextRuns(text, footerFont, opts.FooterFontSize, opts.FooterTextColor, opts, opts.FooterFontFamily);
         double textWidth = MeasurePageTextRuns(runs, footerFont, opts.FooterFontSize, opts);
         double imagesWidth = MeasureHeaderFooterImagesWidth(opts.GetFooterImagesForPage(variantPage), opts.FooterAlign);
         double shapesWidth = MeasureHeaderFooterShapesWidth(opts.GetFooterShapesForPage(variantPage), opts.FooterAlign);
@@ -29,18 +29,18 @@ internal static partial class PdfWriter {
     }
 
     private static string BuildHeader(PdfOptions opts, int variantPage, int page, int pages, int documentPages, PdfStandardFont headerFont, string headerFontResource, System.Collections.Generic.IReadOnlyDictionary<PdfStandardFont, string> fontResources, System.Collections.Generic.IReadOnlyDictionary<PdfNamedFontFace, string> namedFontResources) {
-        string text;
+        System.Collections.Generic.IReadOnlyList<TextRun> runs;
         var headerSegments = opts.GetHeaderSegmentsForPage(variantPage);
         var headerZones = opts.GetHeaderZonesForPage(variantPage);
         if (HasPageTextZones(headerZones)) {
             return BuildPageTextZones(opts, headerZones, variantPage, page, pages, documentPages, headerFont, fontResources, namedFontResources, opts.HeaderFontSize, opts.HeaderTextColor, opts.HeaderOffsetY, isHeader: true);
         } else if (headerSegments != null && headerSegments.Count > 0) {
-            text = BuildPageTextFromSegments(headerSegments, page, pages, opts.PageNumberStyle);
+            runs = BuildPageTextRunsFromSegments(headerSegments, page, pages, headerFont, opts.HeaderFontSize, opts.HeaderTextColor, opts, opts.HeaderFontFamily);
         } else {
-            text = FormatPageText(opts.GetHeaderFormatForPage(variantPage), page, pages, documentPages, opts.PageNumberStyle);
+            string text = FormatPageText(opts.GetHeaderFormatForPage(variantPage), page, pages, documentPages, opts.PageNumberStyle);
+            runs = BuildPageTextRuns(text, headerFont, opts.HeaderFontSize, opts.HeaderTextColor, opts, opts.HeaderFontFamily);
         }
 
-        System.Collections.Generic.IReadOnlyList<TextRun> runs = BuildPageTextRuns(text, headerFont, opts.HeaderFontSize, opts.HeaderTextColor, opts, opts.HeaderFontFamily);
         double textWidth = MeasurePageTextRuns(runs, headerFont, opts.HeaderFontSize, opts);
         double imagesWidth = MeasureHeaderFooterImagesWidth(opts.GetHeaderImagesForPage(variantPage), opts.HeaderAlign);
         double shapesWidth = MeasureHeaderFooterShapesWidth(opts.GetHeaderShapesForPage(variantPage), opts.HeaderAlign);
@@ -72,15 +72,16 @@ internal static partial class PdfWriter {
             return;
         }
 
-        string text;
+        System.Collections.Generic.IReadOnlyList<TextRun> runs;
         var segments = isHeader ? opts.GetHeaderSegmentsForPage(variantPage) : opts.GetFooterSegmentsForPage(variantPage);
         if (segments != null && segments.Count > 0) {
-            text = BuildPageTextFromSegments(segments, page, pages, opts.PageNumberStyle);
+            runs = BuildPageTextRunsFromSegments(segments, page, pages, font, fontSize, color: null, opts, fontFamily);
         } else {
-            text = FormatPageText(isHeader ? opts.GetHeaderFormatForPage(variantPage) : opts.GetFooterFormatForPage(variantPage), page, pages, documentPages, opts.PageNumberStyle);
+            string text = FormatPageText(isHeader ? opts.GetHeaderFormatForPage(variantPage) : opts.GetFooterFormatForPage(variantPage), page, pages, documentPages, opts.PageNumberStyle);
+            runs = BuildPageTextRuns(text, font, fontSize, color: null, opts, fontFamily);
         }
 
-        EnsurePageTextRunFontResources(BuildPageTextRuns(text, font, fontSize, color: null, opts, fontFamily), font, opts, ensureFontResource, ensureNamedFontResource);
+        EnsurePageTextRunFontResources(runs, font, opts, ensureFontResource, ensureNamedFontResource);
     }
 
     private static void EnsurePageTextZoneFontResources(
@@ -244,6 +245,7 @@ internal static partial class PdfWriter {
             PdfAlign.Right => zones.Right,
             _ => zones.Left
         };
+        System.Collections.Generic.IReadOnlyList<TextRun>? runs = null;
 
         if (!string.IsNullOrEmpty(text)) {
             text = FormatPageText(text!, page, pages, documentPages, opts.PageNumberStyle);
@@ -251,19 +253,31 @@ internal static partial class PdfWriter {
                    !HasPageTextZones(zones) &&
                    align == (isHeader ? opts.HeaderAlign : opts.FooterAlign)) {
             var segments = isHeader ? opts.GetHeaderSegmentsForPage(variantPage) : opts.GetFooterSegmentsForPage(variantPage);
-            text = segments != null && segments.Count > 0
-                ? BuildPageTextFromSegments(segments, page, pages, opts.PageNumberStyle)
-                : FormatPageText(
+            if (segments != null && segments.Count > 0) {
+                runs = BuildPageTextRunsFromSegments(
+                    segments,
+                    page,
+                    pages,
+                    font,
+                    fontSize,
+                    color: null,
+                    opts,
+                    isHeader ? opts.HeaderFontFamily : opts.FooterFontFamily);
+            } else {
+                text = FormatPageText(
                     isHeader ? opts.GetHeaderFormatForPage(variantPage) : opts.GetFooterFormatForPage(variantPage),
                     page,
                     pages,
                     documentPages,
                     opts.PageNumberStyle);
+            }
         }
 
-        return string.IsNullOrEmpty(text)
-            ? 0D
-            : MeasurePageTextRuns(BuildPageTextRuns(text!, font, fontSize, color: null, opts, isHeader ? opts.HeaderFontFamily : opts.FooterFontFamily), font, fontSize, opts);
+        if (runs == null && !string.IsNullOrEmpty(text)) {
+            runs = BuildPageTextRuns(text!, font, fontSize, color: null, opts, isHeader ? opts.HeaderFontFamily : opts.FooterFontFamily);
+        }
+
+        return runs == null ? 0D : MeasurePageTextRuns(runs, font, fontSize, opts);
     }
 
     private readonly record struct PageTextZoneLayout(
@@ -287,6 +301,44 @@ internal static partial class PdfWriter {
             font: ChooseNormal(font),
             fontFamily: fontFamily);
         return NormalizeFallbackRuns(new[] { run }, ChooseNormal(font), opts);
+    }
+
+    private static System.Collections.Generic.IReadOnlyList<TextRun> BuildPageTextRunsFromSegments(
+        System.Collections.Generic.IReadOnlyList<FooterSegment> segments,
+        int page,
+        int pages,
+        PdfStandardFont font,
+        double fontSize,
+        PdfColor? color,
+        PdfOptions opts,
+        string? fontFamily) {
+        (bool bold, bool italic) = GetPageTextFontStyle(font);
+        var runs = new System.Collections.Generic.List<TextRun>(segments.Count);
+        foreach (FooterSegment segment in segments) {
+            string text = segment.Kind switch {
+                FooterSegmentKind.Text => segment.Text ?? string.Empty,
+                FooterSegmentKind.PageNumber => FormatPageNumber(page, opts.PageNumberStyle),
+                FooterSegmentKind.TotalPages => FormatPageNumber(pages, opts.PageNumberStyle),
+                _ => throw new System.ArgumentOutOfRangeException(nameof(segments), segment.Kind, "PDF header/footer segment kind is not supported.")
+            };
+
+            if (segment.StyledRun != null) {
+                runs.Add(CreateStyledTextRun(text, segment.StyledRun, segment.StyledRun.Font));
+            } else {
+                runs.Add(new TextRun(
+                    text,
+                    bold: bold,
+                    underline: false,
+                    color: color,
+                    italic: italic,
+                    strike: false,
+                    fontSize: fontSize,
+                    font: ChooseNormal(font),
+                    fontFamily: fontFamily));
+            }
+        }
+
+        return NormalizeFallbackRuns(runs, ChooseNormal(font), opts);
     }
 
     private static bool TryResolvePageTextNamedFont(PdfOptions options, string? fontFamily, PdfStandardFont font, out PdfNamedFontFace namedFont) {
@@ -389,14 +441,16 @@ internal static partial class PdfWriter {
         PdfOptions opts,
         double? lineBoxWidth = null,
         PdfAlign align = PdfAlign.Left) {
+        var lines = BuildPageTextLineRuns(runs);
+        double[] baselines = BuildPageTextLineBaselines(lines, y, fontSize);
+        AppendPageTextRunDecorations(sb, lines, baselines, baseFont, fontSize, color, x, opts, lineBoxWidth, align);
+
         var content = new ContentStreamBuilder(sb)
             .BeginText()
             .Font(baseFontResource, fontSize)
             .FillColor(ResolvePageTextColor(color, opts))
             .TextLeading(fontSize * 1.2D);
 
-        var lines = BuildPageTextLineRuns(runs);
-        double leading = fontSize * 1.2D;
         for (int lineIndex = 0; lineIndex < lines.Count; lineIndex++) {
             System.Collections.Generic.IReadOnlyList<TextRun> line = lines[lineIndex];
             double dx = 0D;
@@ -409,7 +463,8 @@ internal static partial class PdfWriter {
                 }
             }
 
-            content.TextMatrix(x + dx, y - (lineIndex * leading));
+            content.TextMatrix(x + dx, baselines[lineIndex]);
+            double currentTextRise = 0D;
             foreach (TextRun run in line) {
                 string text = run.Text ?? string.Empty;
                 if (text.Length == 0) {
@@ -421,9 +476,16 @@ internal static partial class PdfWriter {
                     ? resolvedNamedFont
                     : null;
                 string fontResource = ResolvePageTextFontResource(fontResources, namedFontResources, runFont, namedFont);
-                double runFontSize = run.FontSize ?? fontSize;
+                double requestedFontSize = run.FontSize ?? fontSize;
+                double runFontSize = EffectiveRichFontSize(requestedFontSize, run.Baseline);
+                double textRise = TextRiseForBaseline(requestedFontSize, run.Baseline);
+                content.Font(fontResource, runFontSize);
+                if (Math.Abs(textRise - currentTextRise) > 0.0001D) {
+                    content.TextRise(textRise);
+                    currentTextRise = textRise;
+                }
                 content
-                    .Font(fontResource, runFontSize)
+                    .FillColor(ResolvePageTextColor(run.Color ?? color, opts))
                     .ShowText(EncodeTextShowCommand(text, runFont, namedFont, opts), runFontSize);
             }
         }

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.PageText.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.PageText.cs
@@ -323,7 +323,7 @@ internal static partial class PdfWriter {
             };
 
             if (segment.StyledRun != null) {
-                runs.Add(CreateStyledTextRun(text, segment.StyledRun, segment.StyledRun.Font));
+                runs.Add(CreateStyledTextRun(text, segment.StyledRun, segment.StyledRun.Font, fontFamily));
             } else {
                 runs.Add(new TextRun(
                     text,

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.cs
@@ -1372,7 +1372,7 @@ internal static partial class PdfWriter {
     private static bool IsLongTokenDelimiterBreakChar(char value) =>
         Array.IndexOf(LongTokenDelimiterBreakChars, value) >= 0;
 
-    private static TextRun CreateStyledTextRun(string text, TextRun styleTemplate, PdfStandardFont? font) {
+    private static TextRun CreateStyledTextRun(string text, TextRun styleTemplate, PdfStandardFont? font, string? fallbackFontFamily = null) {
         bool keepLink = !string.IsNullOrWhiteSpace(text) &&
             (styleTemplate.LinkUri != null || styleTemplate.LinkDestinationName != null);
 
@@ -1390,7 +1390,7 @@ internal static partial class PdfWriter {
             styleTemplate.Baseline,
             keepLink ? styleTemplate.LinkDestinationName : null,
             backgroundColor: styleTemplate.BackgroundColor,
-            fontFamily: styleTemplate.FontFamily);
+            fontFamily: styleTemplate.FontFamily ?? fallbackFontFamily);
     }
 
     private static bool CanWriteRunWithSelectedFont(TextRun run, PdfStandardFont baseFont, PdfOptions? options) {


### PR DESCRIPTION
## Summary

- add an explicit PDF permission policy that enforces authenticated user-password restrictions by default and permits an authorized override only after successful decryption
- support independent per-source credentials for PDF merges, page imports, and source-page overlays while keeping target authentication separate
- return source/output security evidence, authentication roles, ignored-restriction state, and merge decisions
- add general existing-page canvas overlays and underlays for text, rich tables, images, shapes, drawings, clipping, and effects, with page context and one batched target rewrite
- keep canvas rendering options callback-scoped: reusable fonts, shaping, and image handling are retained, while document headers, footers, page numbers, backgrounds, watermarks, borders, and encryption cannot leak into the stamp
- support visually rich generated header/footer runs and styled page tokens across default, first-page, and even-page variants
- preserve authenticated read options across selector-based page-tree edits, forms, sanitization, metadata, rewrite-preservation reports, and merge retries
- carry independent target and source authentication through append, prepend, insert, and selected-page import execution
- make preflight, extraction, mutation-plan permission reporting, and encryption-removal warnings match the operation actually performed
- enforce copy restrictions across direct logical readback, public preflight/validation reports, and aggregate analysis/debug reports, including Info, XMP, and output-intent metadata, while retaining truthful internal preflight inspection and operation-specific mutation paths
- preserve registered named fonts and rendering configuration in visual canvas stamps
- reset superscript/subscript text rise between rich header/footer lines

## Security and behavior

This does not discover, recover, or crack passwords. A valid user or owner password is still required. The override is the PDF-standard equivalent of ignoring owner permission flags after authenticated decryption; changing encryption still requires owner authorization.

Authenticated encrypted sources are intentionally written to an unencrypted full-rewrite merge/stamp/edit output, and that decision is exposed in reports or planner warnings. Owner-authorized append-only metadata and form updates continue to preserve encryption. Signed, certified, usage-rights, and other unsupported rewrite cases remain blocked.

Canvas stamping is visual-only. Interactive links and annotations, named destinations, forms, outlines, and tagged structure remain on their dedicated editors so they are not silently discarded; tagged rendering and structure items are rejected because the temporary structure tree cannot be merged safely into an existing target. Rendering options contribute only reusable callback rendering configuration, not document-owned page chrome or decorations. Header/footer rich text supports visual styles; images and shapes remain on their dedicated header/footer APIs.

## Validation

- full OfficeIMO.Pdf suite on .NET 10: 3,113 tests
- affected permission, planner, page import, canvas stamp, header/footer, and public API contracts on .NET Framework 4.7.2
- public API contract on .NET 10 and .NET Framework 4.7.2
- independent read-only review, repository-triggered review, and regression findings addressed