### PR TITLE
Add ADF and Confluence integration

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,7 +1,9 @@
 name: "OfficeIMO production CodeQL config"
 
 paths:
+  - OfficeIMO.Adf
   - OfficeIMO.CSV
+  - OfficeIMO.Confluence
   - OfficeIMO.Epub
   - OfficeIMO.Excel
   - OfficeIMO.Excel.OpenDocument

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -419,12 +419,16 @@ jobs:
       max-parallel: 6
       matrix:
         include:
+          - name: Adf
+            project: OfficeIMO.Adf.Tests/OfficeIMO.Adf.Tests.csproj
           - name: AsciiDoc
             project: OfficeIMO.AsciiDoc.Tests/OfficeIMO.AsciiDoc.Tests.csproj
           - name: AsciiDoc-Markdown
             project: OfficeIMO.AsciiDoc.Markdown.Tests/OfficeIMO.AsciiDoc.Markdown.Tests.csproj
           - name: CSV
             project: OfficeIMO.CSV.Tests/OfficeIMO.CSV.Tests.csproj
+          - name: Confluence
+            project: OfficeIMO.Confluence.Tests/OfficeIMO.Confluence.Tests.csproj
           - name: Drawing
             project: OfficeIMO.Drawing.Tests/OfficeIMO.Drawing.Tests.csproj
           - name: Drawing-CodeGlyphX
@@ -720,6 +724,8 @@ jobs:
             fi
           fi
           if [ "${{ matrix.partition }}" = "other-projects" ]; then
+            dotnet restore OfficeIMO.Adf.Tests/OfficeIMO.Adf.Tests.csproj
+            dotnet restore OfficeIMO.Confluence.Tests/OfficeIMO.Confluence.Tests.csproj
             dotnet restore OfficeIMO.Drawing.Tests/OfficeIMO.Drawing.Tests.csproj
             dotnet restore OfficeIMO.Drawing.CodeGlyphX.Tests/OfficeIMO.Drawing.CodeGlyphX.Tests.csproj
             dotnet restore OfficeIMO.GoogleWorkspace.Tests/OfficeIMO.GoogleWorkspace.Tests.csproj
@@ -767,6 +773,8 @@ jobs:
             fi
           fi
           if [ "${{ matrix.partition }}" = "other-projects" ]; then
+            dotnet build OfficeIMO.Adf.Tests/OfficeIMO.Adf.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework ${{ matrix.framework }} --no-restore
+            dotnet build OfficeIMO.Confluence.Tests/OfficeIMO.Confluence.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework ${{ matrix.framework }} --no-restore
             dotnet build OfficeIMO.Drawing.Tests/OfficeIMO.Drawing.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework ${{ matrix.framework }} --no-restore
             dotnet build OfficeIMO.Drawing.CodeGlyphX.Tests/OfficeIMO.Drawing.CodeGlyphX.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework ${{ matrix.framework }} --no-restore
             dotnet build OfficeIMO.GoogleWorkspace.Tests/OfficeIMO.GoogleWorkspace.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework ${{ matrix.framework }} --no-restore
@@ -1005,6 +1013,8 @@ jobs:
               ;;
             other-projects)
               audit_retired_aggregate_tests
+              dotnet test OfficeIMO.Adf.Tests/OfficeIMO.Adf.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity ${{ env.TEST_VERBOSITY }} --framework ${{ matrix.framework }} --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx
+              dotnet test OfficeIMO.Confluence.Tests/OfficeIMO.Confluence.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity ${{ env.TEST_VERBOSITY }} --framework ${{ matrix.framework }} --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx
               run_drawing_tests
               dotnet test OfficeIMO.Drawing.CodeGlyphX.Tests/OfficeIMO.Drawing.CodeGlyphX.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity ${{ env.TEST_VERBOSITY }} --framework ${{ matrix.framework }} -m:1 --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx
               run_googleworkspace_tests

--- a/Build/project.build.json
+++ b/Build/project.build.json
@@ -3,10 +3,12 @@
   "RootPath": "..",
   "ExpectedVersion": "3.0.X",
   "ExpectedVersionMap": {
+    "OfficeIMO.Adf": "3.0.X",
     "OfficeIMO.AsciiDoc": "3.0.X",
     "OfficeIMO.AsciiDoc.Markdown": "3.0.X",
     "OfficeIMO.AsciiDoc.Pdf": "3.0.X",
     "OfficeIMO.CSV": "3.0.X",
+    "OfficeIMO.Confluence": "3.0.X",
     "OfficeIMO.Drawing": "3.0.X",
     "OfficeIMO.Drawing.CodeGlyphX": "3.0.X",
     "OfficeIMO.Email": "3.0.X",

--- a/OfficeIMO.Adf.Tests/AdfContractTests.cs
+++ b/OfficeIMO.Adf.Tests/AdfContractTests.cs
@@ -163,6 +163,29 @@ public sealed class AdfContractTests {
         Assert.Equal("$.content[0].content[0].marks[0].attrs.href", issue.Path);
     }
 
+    [Theory]
+    [InlineData("{}", false)]
+    [InlineData("{\"level\":0}", false)]
+    [InlineData("{\"level\":1}", true)]
+    [InlineData("{\"level\":6}", true)]
+    [InlineData("{\"level\":7}", false)]
+    [InlineData("{\"level\":\"2\"}", false)]
+    [InlineData("{\"level\":1.5}", false)]
+    public void Validation_RequiresIntegerHeadingLevelFromOneThroughSix(string attributesJson, bool expectedValid) {
+        AdfDocument document = AdfDocument.Parse(
+            "{\"version\":1,\"type\":\"doc\",\"content\":[{\"type\":\"heading\",\"attrs\":" + attributesJson + ",\"content\":[{\"type\":\"text\",\"text\":\"Title\"}]}]}");
+
+        AdfValidationResult result = document.Validate();
+
+        Assert.Equal(expectedValid, result.IsValid);
+        if (expectedValid) {
+            Assert.DoesNotContain(result.Issues, item => item.Code == "ADF_HEADING_LEVEL");
+        } else {
+            AdfValidationIssue issue = Assert.Single(result.Issues, item => item.Code == "ADF_HEADING_LEVEL");
+            Assert.Equal("$.content[0].attrs.level", issue.Path);
+        }
+    }
+
     [Fact]
     public void LinkProjection_PreservesTitleAndReportsUnsupportedAttributes() {
         var link = new AdfMark("link")
@@ -298,6 +321,20 @@ public sealed class AdfContractTests {
     }
 
     [Fact]
+    public void HeadingProjection_ReportsMultilineTextAsLossy() {
+        var document = new AdfDocument();
+        document.Content.Add(new AdfNode("heading") {
+            Content = { AdfNode.TextNode("first\nsecond") }
+        }.SetAttribute("level", 2));
+
+        AdfConversionResult<string> result = AdfConverter.ToMarkdown(document);
+
+        Assert.False(result.Report.IsLossless);
+        AdfConversionDiagnostic diagnostic = Assert.Single(result.Report.Diagnostics, item => item.Code == "ADF_HEADING_LINE_BREAK_NORMALIZED");
+        Assert.Equal("$.content[0].content[0]", diagnostic.Path);
+    }
+
+    [Fact]
     public void TableProjection_PreservesLiteralPipesAndHardBreaks() {
         var document = new AdfDocument();
         document.Content.Add(new AdfNode("table") {
@@ -372,6 +409,26 @@ public sealed class AdfContractTests {
         Assert.Equal("$.content[0].content[0].content[0]", diagnostic.Path);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void TableProjection_ReportsHeaderLayoutsMarkdownCannotRepresent(bool mixedFirstRow) {
+        var firstRow = new AdfNode("tableRow");
+        firstRow.Content.Add(TableCell("tableHeader", "First"));
+        firstRow.Content.Add(TableCell(mixedFirstRow ? "tableCell" : "tableHeader", "Second"));
+        var secondRow = new AdfNode("tableRow");
+        secondRow.Content.Add(TableCell("tableCell", "Third"));
+        secondRow.Content.Add(TableCell(mixedFirstRow ? "tableCell" : "tableHeader", "Fourth"));
+        var document = new AdfDocument();
+        document.Content.Add(new AdfNode("table") { Content = { firstRow, secondRow } });
+
+        AdfConversionResult<string> result = AdfConverter.ToMarkdown(document);
+
+        Assert.False(result.Report.IsLossless);
+        AdfConversionDiagnostic diagnostic = Assert.Single(result.Report.Diagnostics, item => item.Code == "ADF_TABLE_HEADER_LAYOUT_NORMALIZED");
+        Assert.Equal("$.content[0]", diagnostic.Path);
+    }
+
     [Fact]
     public void InlineCodeProjection_PreservesBackticksAndCombinedMarksRegardlessOfOrder() {
         const string content = "value`tick";
@@ -408,4 +465,8 @@ public sealed class AdfContractTests {
         Assert.Equal("first second", text.Text);
         Assert.Contains(text.Marks, mark => mark.Type == "code");
     }
+
+    private static AdfNode TableCell(string type, string text) => new AdfNode(type) {
+        Content = { new AdfNode("paragraph") { Content = { AdfNode.TextNode(text) } } }
+    };
 }

--- a/OfficeIMO.Adf.Tests/AdfContractTests.cs
+++ b/OfficeIMO.Adf.Tests/AdfContractTests.cs
@@ -114,6 +114,25 @@ public sealed class AdfContractTests {
         Assert.Equal(content, Assert.Single(codeBlock.Content).Text);
     }
 
+    [Fact]
+    public void CodeBlockProjection_NormalizesExternalLanguageToOneSafeToken() {
+        const string content = "Get-Date";
+        var document = new AdfDocument();
+        document.Content.Add(new AdfNode("codeBlock") {
+            Content = { AdfNode.TextNode(content) }
+        }.SetAttribute("language", "powershell\n```\n# Heading"));
+
+        AdfConversionResult<string> markdown = AdfConverter.ToMarkdown(document);
+        AdfConversionResult<AdfDocument> roundTrip = AdfConverter.FromMarkdown(markdown.Value);
+
+        Assert.StartsWith("```powershell\n", markdown.Value.Replace("\r\n", "\n"));
+        Assert.Contains(markdown.Report.Diagnostics, item => item.Code == "ADF_CODE_LANGUAGE_NORMALIZED");
+        AdfNode codeBlock = Assert.Single(roundTrip.Value.Content);
+        Assert.Equal("codeBlock", codeBlock.Type);
+        Assert.Equal("powershell", codeBlock.GetStringAttribute("language"));
+        Assert.Equal(content, Assert.Single(codeBlock.Content).Text);
+    }
+
     [Theory]
     [InlineData("# Heading")]
     [InlineData("> quote")]
@@ -129,6 +148,38 @@ public sealed class AdfContractTests {
         AdfNode paragraph = Assert.Single(roundTrip.Value.Content);
         Assert.Equal("paragraph", paragraph.Type);
         Assert.Equal(text, string.Concat(paragraph.Content.Select(node => node.Text)));
+    }
+
+    [Fact]
+    public void ParagraphProjection_PreservesLiteralHtmlLikeAndEntityLikeText() {
+        const string content = "before <u>value</u> &copy; after";
+        var document = new AdfDocument();
+        document.Content.Add(new AdfNode("paragraph") { Content = { AdfNode.TextNode(content) } });
+
+        AdfConversionResult<string> markdown = AdfConverter.ToMarkdown(document);
+        AdfConversionResult<AdfDocument> roundTrip = AdfConverter.FromMarkdown(markdown.Value);
+
+        AdfNode paragraph = Assert.Single(roundTrip.Value.Content);
+        Assert.Equal("paragraph", paragraph.Type);
+        Assert.Equal(content, string.Concat(paragraph.Content.Select(node => node.Text)));
+    }
+
+    [Fact]
+    public void ParagraphProjection_PreservesTerminalHardBreak() {
+        var document = new AdfDocument();
+        document.Content.Add(new AdfNode("paragraph") {
+            Content = { AdfNode.TextNode("ready"), new AdfNode("hardBreak") }
+        });
+
+        AdfConversionResult<string> markdown = AdfConverter.ToMarkdown(document);
+        AdfConversionResult<AdfDocument> roundTrip = AdfConverter.FromMarkdown(markdown.Value);
+
+        Assert.EndsWith("<br />", markdown.Value);
+        AdfNode paragraph = Assert.Single(roundTrip.Value.Content);
+        Assert.Collection(
+            paragraph.Content,
+            text => Assert.Equal("ready", text.Text),
+            hardBreak => Assert.Equal("hardBreak", hardBreak.Type));
     }
 
     [Fact]
@@ -149,5 +200,22 @@ public sealed class AdfContractTests {
             Assert.Contains(text.Marks, mark => mark.Type == "strong");
             Assert.Contains(text.Marks, mark => mark.Type == "code");
         }
+    }
+
+    [Fact]
+    public void InlineCodeProjection_ReportsMarkdownLineBreakNormalization() {
+        const string content = "first\nsecond";
+        var document = new AdfDocument();
+        document.Content.Add(new AdfNode("paragraph") {
+            Content = { AdfNode.TextNode(content, new[] { new AdfMark("code") }) }
+        });
+
+        AdfConversionResult<string> markdown = AdfConverter.ToMarkdown(document);
+        AdfConversionResult<AdfDocument> roundTrip = AdfConverter.FromMarkdown(markdown.Value);
+
+        Assert.Contains(markdown.Report.Diagnostics, item => item.Code == "ADF_CODE_MARK_LINE_BREAK_NORMALIZED");
+        AdfNode text = Assert.Single(Assert.Single(roundTrip.Value.Content).Content);
+        Assert.Equal("first second", text.Text);
+        Assert.Contains(text.Marks, mark => mark.Type == "code");
     }
 }

--- a/OfficeIMO.Adf.Tests/AdfContractTests.cs
+++ b/OfficeIMO.Adf.Tests/AdfContractTests.cs
@@ -400,6 +400,54 @@ public sealed class AdfContractTests {
         Assert.Equal(content, Assert.Single(codeBlock.Content).Text);
     }
 
+    [Fact]
+    public void CodeBlockProjection_PreventsLanguageFromExtendingTildeFence() {
+        const string content = "````\n~";
+        var document = new AdfDocument();
+        document.Content.Add(new AdfNode("codeBlock") {
+            Content = { AdfNode.TextNode(content) }
+        }.SetAttribute("language", "~~~"));
+        document.Content.Add(new AdfNode("paragraph") { Content = { AdfNode.TextNode("After") } });
+
+        AdfConversionResult<string> markdown = AdfConverter.ToMarkdown(document);
+        AdfConversionResult<AdfDocument> roundTrip = AdfConverter.FromMarkdown(markdown.Value);
+
+        Assert.StartsWith("~~~\n", markdown.Value.Replace("\r\n", "\n"));
+        Assert.Contains(markdown.Report.Diagnostics, item => item.Code == "ADF_CODE_LANGUAGE_NORMALIZED");
+        Assert.Collection(
+            roundTrip.Value.Content,
+            codeBlock => Assert.Equal(content, Assert.Single(codeBlock.Content).Text),
+            paragraph => Assert.Equal("After", Assert.Single(paragraph.Content).Text));
+    }
+
+    [Fact]
+    public void CodeBlockProjection_ReportsDroppedAttributesAndExtensionProperties() {
+        var codeBlock = new AdfNode("codeBlock") { Content = { AdfNode.TextNode("Get-Date") } };
+        codeBlock.SetAttribute("uniqueId", "code-1");
+        codeBlock.ExtensionData["vendorCodeOption"] = JsonSerializer.SerializeToElement(true);
+        var document = new AdfDocument(new[] { codeBlock });
+
+        AdfConversionResult<string> result = AdfConverter.ToMarkdown(document);
+
+        Assert.False(result.Report.IsLossless);
+        AdfConversionDiagnostic diagnostic = Assert.Single(result.Report.Diagnostics, item => item.Code == "ADF_CODE_PROPERTIES_DROPPED");
+        Assert.Equal("$.content[0]", diagnostic.Path);
+    }
+
+    [Fact]
+    public void Validation_RejectsMarksInsideCodeBlockText() {
+        var codeBlock = new AdfNode("codeBlock") {
+            Content = { AdfNode.TextNode("Get-Date", new[] { new AdfMark("strong") }) }
+        };
+        var document = new AdfDocument(new[] { codeBlock });
+
+        AdfValidationResult result = document.Validate();
+
+        Assert.False(result.IsValid);
+        AdfValidationIssue issue = Assert.Single(result.Issues, item => item.Code == "ADF_CODE_MARKS_NOT_ALLOWED");
+        Assert.Equal("$.content[0].content[0].marks", issue.Path);
+    }
+
     [Theory]
     [InlineData("first\r\nsecond")]
     [InlineData("first\rsecond")]

--- a/OfficeIMO.Adf.Tests/AdfContractTests.cs
+++ b/OfficeIMO.Adf.Tests/AdfContractTests.cs
@@ -154,6 +154,19 @@ public sealed class AdfContractTests {
         Assert.Contains(result.Issues, item => item.Code == "ADF_TEXT_REQUIRED" && item.Path == "$.content[0].content[0].text");
     }
 
+    [Fact]
+    public void Validation_ReportsNullNestedNodesWithoutThrowing() {
+        var paragraph = new AdfNode("paragraph");
+        paragraph.Content.Add(null!);
+        var document = new AdfDocument(new[] { paragraph });
+
+        AdfValidationResult result = document.Validate();
+
+        Assert.False(result.IsValid);
+        AdfValidationIssue issue = Assert.Single(result.Issues, item => item.Code == "ADF_NULL_NODE");
+        Assert.Equal("$.content[0].content[0]", issue.Path);
+    }
+
     [Theory]
     [InlineData("taskList", "{}", "ADF_TASK_LOCAL_ID")]
     [InlineData("taskItem", "{\"state\":\"DONE\"}", "ADF_TASK_LOCAL_ID")]
@@ -325,6 +338,19 @@ public sealed class AdfContractTests {
     }
 
     [Fact]
+    public void MarkdownEmptyCodeFence_ProducesValidEmptyAdfCodeBlock() {
+        AdfConversionResult<AdfDocument> adf = AdfConverter.FromMarkdown("```\n```");
+
+        AdfNode codeBlock = Assert.Single(adf.Value.Content);
+        Assert.Equal("codeBlock", codeBlock.Type);
+        Assert.Empty(codeBlock.Content);
+        Assert.True(adf.Value.Validate().IsValid);
+
+        AdfConversionResult<string> roundTrip = AdfConverter.ToMarkdown(adf.Value);
+        Assert.Equal("```\n```", roundTrip.Value.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
     public void CodeBlockProjection_NormalizesExternalLanguageToOneSafeToken() {
         const string content = "Get-Date";
         var document = new AdfDocument();
@@ -479,6 +505,20 @@ public sealed class AdfContractTests {
         Assert.False(result.Report.IsLossless);
         AdfConversionDiagnostic diagnostic = Assert.Single(result.Report.Diagnostics, item => item.Code == "ADF_TABLE_CELL_ATTRIBUTES_DROPPED");
         Assert.Equal("$.content[0].content[0].content[0]", diagnostic.Path);
+    }
+
+    [Fact]
+    public void TableProjection_ReportsDroppedTableAttributesAndProperties() {
+        var table = new AdfNode("table").SetAttribute("layout", "wide");
+        table.ExtensionData["vendorTableProperty"] = JsonSerializer.SerializeToElement(true);
+        table.Content.Add(new AdfNode("tableRow") { Content = { TableCell("tableHeader", "Header") } });
+        var document = new AdfDocument(new[] { table });
+
+        AdfConversionResult<string> result = AdfConverter.ToMarkdown(document);
+
+        Assert.False(result.Report.IsLossless);
+        AdfConversionDiagnostic diagnostic = Assert.Single(result.Report.Diagnostics, item => item.Code == "ADF_TABLE_ATTRIBUTES_DROPPED");
+        Assert.Equal("$.content[0]", diagnostic.Path);
     }
 
     [Fact]

--- a/OfficeIMO.Adf.Tests/AdfContractTests.cs
+++ b/OfficeIMO.Adf.Tests/AdfContractTests.cs
@@ -40,6 +40,32 @@ public sealed class AdfContractTests {
     }
 
     [Fact]
+    public void MarkdownProjection_ReportsExplicitEmptyParagraphLoss() {
+        var document = new AdfDocument(new[] { new AdfNode("paragraph") });
+
+        AdfConversionResult<string> result = AdfConverter.ToMarkdown(document);
+
+        Assert.Empty(result.Value);
+        Assert.False(result.Report.IsLossless);
+        AdfConversionDiagnostic diagnostic = Assert.Single(result.Report.Diagnostics, item => item.Code == "ADF_EMPTY_PARAGRAPH_DROPPED");
+        Assert.Equal("$.content[0]", diagnostic.Path);
+    }
+
+    [Fact]
+    public void HeadingProjection_ReportsDroppedProperties() {
+        var heading = new AdfNode("heading") { Content = { AdfNode.TextNode("Status") } };
+        heading.SetAttribute("level", 2).SetAttribute("localId", "heading-1");
+        heading.ExtensionData["vendorHeadingOption"] = JsonSerializer.SerializeToElement(true);
+        var document = new AdfDocument(new[] { heading });
+
+        AdfConversionResult<string> result = AdfConverter.ToMarkdown(document);
+
+        Assert.False(result.Report.IsLossless);
+        AdfConversionDiagnostic diagnostic = Assert.Single(result.Report.Diagnostics, item => item.Code == "ADF_HEADING_PROPERTIES_DROPPED");
+        Assert.Equal("$.content[0]", diagnostic.Path);
+    }
+
+    [Fact]
     public void HtmlConversion_UsesOfficeimoPipelines() {
         AdfConversionResult<AdfDocument> adf = AdfConverter.FromHtml("<h2>Report</h2><p><strong>Ready</strong></p>");
         AdfConversionResult<string> html = AdfConverter.ToHtml(adf.Value);
@@ -683,6 +709,31 @@ public sealed class AdfContractTests {
             Assert.Contains(text.Marks, mark => mark.Type == "strong");
             Assert.Contains(text.Marks, mark => mark.Type == "code");
         }
+    }
+
+    [Theory]
+    [InlineData("strong", "**ready**")]
+    [InlineData("em", "*ready*")]
+    [InlineData("strike", "~~ready~~")]
+    public void DelimiterMarkProjection_MovesBoundaryWhitespaceOutsideMarkup(string markType, string renderedCore) {
+        var document = new AdfDocument();
+        document.Content.Add(new AdfNode("paragraph") {
+            Content = {
+                AdfNode.TextNode("before"),
+                AdfNode.TextNode(" ready ", new[] { new AdfMark(markType) }),
+                AdfNode.TextNode("after"),
+            }
+        });
+
+        AdfConversionResult<string> markdown = AdfConverter.ToMarkdown(document);
+        AdfConversionResult<AdfDocument> roundTrip = AdfConverter.FromMarkdown(markdown.Value);
+
+        Assert.Contains(" " + renderedCore + " ", markdown.Value);
+        Assert.False(markdown.Report.IsLossless);
+        Assert.Contains(markdown.Report.Diagnostics, item => item.Code == "ADF_MARK_BOUNDARY_WHITESPACE_NORMALIZED");
+        AdfNode paragraph = Assert.Single(roundTrip.Value.Content);
+        Assert.Equal("before ready after", string.Concat(paragraph.Content.Select(item => item.Text)));
+        Assert.Contains(paragraph.Content, item => item.Text == "ready" && item.Marks.Any(mark => mark.Type == markType));
     }
 
     [Fact]

--- a/OfficeIMO.Adf.Tests/AdfContractTests.cs
+++ b/OfficeIMO.Adf.Tests/AdfContractTests.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using OfficeIMO.Adf;
+using Xunit;
+
+namespace OfficeIMO.Adf.Tests;
+
+public sealed class AdfContractTests {
+    [Fact]
+    public void ParseWrite_PreservesUnknownNodesMarksAttributesAndProperties() {
+        const string json = "{\"version\":1,\"type\":\"doc\",\"vendorRoot\":{\"enabled\":true},\"content\":[{\"type\":\"vendorPanel\",\"attrs\":{\"tone\":\"blue\"},\"vendorNode\":17,\"content\":[{\"type\":\"text\",\"text\":\"Hello\",\"marks\":[{\"type\":\"vendorMark\",\"attrs\":{\"x\":1},\"vendorMarkProperty\":\"kept\"}]}]}]}";
+
+        AdfDocument document = AdfDocument.Parse(json);
+        string output = document.ToJson();
+
+        using JsonDocument parsed = JsonDocument.Parse(output);
+        JsonElement root = parsed.RootElement;
+        Assert.True(root.GetProperty("vendorRoot").GetProperty("enabled").GetBoolean());
+        JsonElement node = root.GetProperty("content")[0];
+        Assert.Equal("vendorPanel", node.GetProperty("type").GetString());
+        Assert.Equal(17, node.GetProperty("vendorNode").GetInt32());
+        Assert.Equal("blue", node.GetProperty("attrs").GetProperty("tone").GetString());
+        Assert.Equal("kept", node.GetProperty("content")[0].GetProperty("marks")[0].GetProperty("vendorMarkProperty").GetString());
+    }
+
+    [Fact]
+    public void MarkdownRoundTrip_PreservesCommonDocumentStructure() {
+        const string markdown = "# Status\n\nThis is **ready** with [details](https://example.com).\n\n- First\n- Second\n\n```powershell\nGet-Date\n```";
+
+        AdfConversionResult<AdfDocument> adf = AdfConverter.FromMarkdown(markdown);
+        AdfConversionResult<string> roundTrip = AdfConverter.ToMarkdown(adf.Value);
+
+        Assert.Contains("# Status", roundTrip.Value);
+        Assert.Contains("**ready**", roundTrip.Value);
+        Assert.Contains("[details](https://example.com)", roundTrip.Value);
+        Assert.Contains("- First", roundTrip.Value);
+        Assert.Contains("```powershell", roundTrip.Value);
+        Assert.False(adf.Report.HasErrors);
+    }
+
+    [Fact]
+    public void HtmlConversion_UsesOfficeimoPipelines() {
+        AdfConversionResult<AdfDocument> adf = AdfConverter.FromHtml("<h2>Report</h2><p><strong>Ready</strong></p>");
+        AdfConversionResult<string> html = AdfConverter.ToHtml(adf.Value);
+
+        Assert.Contains("<h2", html.Value);
+        Assert.Contains("Report", html.Value);
+        Assert.Contains("<strong>Ready</strong>", html.Value);
+    }
+
+    [Fact]
+    public void Validation_WarnsForUnknownNodesWithoutRejectingRoundTrip() {
+        AdfDocument document = AdfDocument.Parse("{\"version\":1,\"type\":\"doc\",\"content\":[{\"type\":\"futureNode\",\"attrs\":{\"a\":1}}]}");
+
+        AdfValidationResult result = document.Validate();
+
+        Assert.True(result.IsValid);
+        Assert.Contains(result.Issues, item => item.Code == "ADF_UNKNOWN_NODE");
+    }
+}

--- a/OfficeIMO.Adf.Tests/AdfContractTests.cs
+++ b/OfficeIMO.Adf.Tests/AdfContractTests.cs
@@ -215,11 +215,14 @@ public sealed class AdfContractTests {
     }
 
     [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public void Validation_RequiresStringHrefOnLinkMarks(bool addNonStringHref) {
+    [InlineData(false, null)]
+    [InlineData(true, null)]
+    [InlineData(false, "")]
+    [InlineData(false, " ")]
+    public void Validation_RequiresNonEmptyStringHrefOnLinkMarks(bool addNonStringHref, string? href) {
         var link = new AdfMark("link");
         if (addNonStringHref) link.SetAttribute("href", 42);
+        else if (href != null) link.SetAttribute("href", href);
         var document = new AdfDocument();
         document.Content.Add(new AdfNode("paragraph") {
             Content = { AdfNode.TextNode("broken", new[] { link }) }

--- a/OfficeIMO.Adf.Tests/AdfContractTests.cs
+++ b/OfficeIMO.Adf.Tests/AdfContractTests.cs
@@ -100,6 +100,42 @@ public sealed class AdfContractTests {
     }
 
     [Fact]
+    public void LinkProjection_EscapesAndRoundTripsDestinationDelimiters() {
+        const string href = "https://example.test/a(b)/docs\\[one]|two";
+        var link = new AdfMark("link").SetAttribute("href", href);
+        var document = new AdfDocument();
+        document.Content.Add(new AdfNode("paragraph") {
+            Content = { AdfNode.TextNode("details", new[] { link }) }
+        });
+
+        AdfConversionResult<string> markdown = AdfConverter.ToMarkdown(document);
+        AdfConversionResult<AdfDocument> roundTrip = AdfConverter.FromMarkdown(markdown.Value);
+
+        AdfNode text = Assert.Single(Assert.Single(roundTrip.Value.Content).Content);
+        AdfMark roundTripLink = Assert.Single(text.Marks, mark => mark.Type == "link");
+        Assert.Equal(href, roundTripLink.GetStringAttribute("href"));
+    }
+
+    [Fact]
+    public void MarkdownDocumentSoftBreak_StaysTextInsteadOfBecomingHardBreak() {
+        var markdown = MarkdownDoc.Create()
+            .Add(new ParagraphBlock(new InlineSequence().Text("first").SoftBreak().Text("second")));
+
+        AdfConversionResult<AdfDocument> adf = AdfConverter.FromMarkdown(markdown);
+        AdfConversionResult<string> roundTrip = AdfConverter.ToMarkdown(adf.Value);
+
+        AdfNode paragraph = Assert.Single(adf.Value.Content);
+        Assert.Collection(
+            paragraph.Content,
+            first => Assert.Equal("first", first.Text),
+            newline => Assert.Equal("\n", newline.Text),
+            second => Assert.Equal("second", second.Text));
+        Assert.True(adf.Value.Validate().IsValid);
+        Assert.DoesNotContain(paragraph.Content, node => node.Type == "hardBreak");
+        Assert.Equal("first\nsecond", roundTrip.Value.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
     public void CodeBlockProjection_UsesFenceThatCannotCollideWithContent() {
         const string content = "before\n```\n# still code\nafter";
         var document = new AdfDocument();

--- a/OfficeIMO.Adf.Tests/AdfContractTests.cs
+++ b/OfficeIMO.Adf.Tests/AdfContractTests.cs
@@ -61,6 +61,22 @@ public sealed class AdfContractTests {
         Assert.Contains(result.Issues, item => item.Code == "ADF_UNKNOWN_NODE");
     }
 
+    [Theory]
+    [InlineData("text")]
+    [InlineData("hardBreak")]
+    [InlineData("mention")]
+    [InlineData("tableCell")]
+    public void Validation_RejectsKnownNonBlockNodesAtDocumentRoot(string nodeType) {
+        var document = new AdfDocument();
+        document.Content.Add(nodeType == "text" ? AdfNode.TextNode("invalid") : new AdfNode(nodeType));
+
+        AdfValidationResult result = document.Validate();
+
+        Assert.False(result.IsValid);
+        AdfValidationIssue issue = Assert.Single(result.Issues, item => item.Code == "ADF_ROOT_CHILD");
+        Assert.Equal("$.content[0]", issue.Path);
+    }
+
     [Fact]
     public void MarkdownTaskList_UsesValidListItemFallbackAndReportsFidelity() {
         AdfConversionResult<AdfDocument> result = AdfConverter.FromMarkdown("- [x] Ready\n- [ ] Pending");
@@ -216,6 +232,59 @@ public sealed class AdfContractTests {
             paragraph.Content,
             text => Assert.Equal("ready", text.Text),
             hardBreak => Assert.Equal("hardBreak", hardBreak.Type));
+    }
+
+    [Fact]
+    public void TableProjection_PreservesLiteralPipesAndHardBreaks() {
+        var document = new AdfDocument();
+        document.Content.Add(new AdfNode("table") {
+            Content = {
+                new AdfNode("tableRow") {
+                    Content = {
+                        new AdfNode("tableHeader") {
+                            Content = { new AdfNode("paragraph") { Content = { AdfNode.TextNode("Header") } } }
+                        },
+                        new AdfNode("tableHeader") {
+                            Content = { new AdfNode("paragraph") { Content = { AdfNode.TextNode("Other") } } }
+                        }
+                    }
+                },
+                new AdfNode("tableRow") {
+                    Content = {
+                        new AdfNode("tableCell") {
+                            Content = {
+                                new AdfNode("paragraph") {
+                                    Content = {
+                                        AdfNode.TextNode("left|right"),
+                                        new AdfNode("hardBreak"),
+                                        AdfNode.TextNode("next")
+                                    }
+                                }
+                            }
+                        },
+                        new AdfNode("tableCell") {
+                            Content = { new AdfNode("paragraph") { Content = { AdfNode.TextNode("stable") } } }
+                        }
+                    }
+                }
+            }
+        });
+
+        AdfConversionResult<string> markdown = AdfConverter.ToMarkdown(document);
+        AdfConversionResult<AdfDocument> roundTrip = AdfConverter.FromMarkdown(markdown.Value);
+
+        Assert.Contains("left\\|right<br />next", markdown.Value);
+        AdfNode table = Assert.Single(roundTrip.Value.Content);
+        Assert.Equal(2, table.Content.Count);
+        Assert.All(table.Content, row => Assert.Equal(2, row.Content.Count));
+        AdfNode paragraph = Assert.Single(table.Content[1].Content[0].Content);
+        Assert.Collection(
+            paragraph.Content,
+            text => Assert.Equal("left", text.Text),
+            pipe => Assert.Equal("|", pipe.Text),
+            text => Assert.Equal("right", text.Text),
+            hardBreak => Assert.Equal("hardBreak", hardBreak.Type),
+            text => Assert.Equal("next", text.Text));
     }
 
     [Fact]

--- a/OfficeIMO.Adf.Tests/AdfContractTests.cs
+++ b/OfficeIMO.Adf.Tests/AdfContractTests.cs
@@ -45,6 +45,8 @@ public sealed class AdfContractTests {
         Assert.Contains("<h2", html.Value);
         Assert.Contains("Report", html.Value);
         Assert.Contains("<strong>Ready</strong>", html.Value);
+        Assert.Contains(adf.Report.Diagnostics, item => item.Code == "ADF_HTML_VIA_MARKDOWN");
+        Assert.Contains(html.Report.Diagnostics, item => item.Code == "ADF_TO_HTML_VIA_MARKDOWN");
     }
 
     [Fact]
@@ -55,5 +57,43 @@ public sealed class AdfContractTests {
 
         Assert.True(result.IsValid);
         Assert.Contains(result.Issues, item => item.Code == "ADF_UNKNOWN_NODE");
+    }
+
+    [Fact]
+    public void MarkdownTaskList_UsesValidListItemFallbackAndReportsFidelity() {
+        AdfConversionResult<AdfDocument> result = AdfConverter.FromMarkdown("- [x] Ready\n- [ ] Pending");
+
+        AdfNode list = Assert.Single(result.Value.Content);
+        Assert.Equal("bulletList", list.Type);
+        Assert.All(list.Content, item => Assert.Equal("listItem", item.Type));
+        Assert.True(result.Value.Validate().IsValid);
+        Assert.Contains(result.Report.Diagnostics, item => item.Code == "MARKDOWN_TASK_LIST_FALLBACK");
+        Assert.Contains("\\[x\\] Ready", AdfConverter.ToMarkdown(result.Value).Value);
+    }
+
+    [Fact]
+    public void Validation_RejectsTaskItemUnderBulletList() {
+        AdfDocument document = AdfDocument.Parse("{\"version\":1,\"type\":\"doc\",\"content\":[{\"type\":\"bulletList\",\"content\":[{\"type\":\"taskItem\",\"attrs\":{\"state\":\"DONE\"},\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"Ready\"}]}]}]}]}");
+
+        AdfValidationResult result = document.Validate();
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, item => item.Code == "ADF_LIST_CHILD");
+        Assert.Contains(result.Issues, item => item.Code == "ADF_TASK_ITEM_PARENT");
+    }
+
+    [Fact]
+    public void LinkProjection_PreservesTitleAndReportsUnsupportedAttributes() {
+        var link = new AdfMark("link")
+            .SetAttribute("href", "https://example.com/details")
+            .SetAttribute("title", "Ready \"now\"")
+            .SetAttribute("collection", "other");
+        var document = new AdfDocument();
+        document.Content.Add(new AdfNode("paragraph") { Content = { AdfNode.TextNode("details", new[] { link }) } });
+
+        AdfConversionResult<string> result = AdfConverter.ToMarkdown(document);
+
+        Assert.Contains("[details](https://example.com/details 'Ready \"now\"')", result.Value);
+        Assert.Contains(result.Report.Diagnostics, item => item.Code == "ADF_LINK_ATTRIBUTES_DROPPED");
     }
 }

--- a/OfficeIMO.Adf.Tests/AdfContractTests.cs
+++ b/OfficeIMO.Adf.Tests/AdfContractTests.cs
@@ -100,6 +100,69 @@ public sealed class AdfContractTests {
         Assert.Contains(result.Issues, item => item.Code == "ADF_TASK_ITEM_PARENT");
     }
 
+    [Theory]
+    [InlineData("paragraph", "paragraph")]
+    [InlineData("table", "paragraph")]
+    [InlineData("codeBlock", "hardBreak")]
+    [InlineData("mediaGroup", "paragraph")]
+    [InlineData("rule", "text")]
+    public void Validation_RejectsKnownInvalidParentChildPairs(string parentType, string childType) {
+        var parent = new AdfNode(parentType);
+        parent.Content.Add(childType == "text" ? AdfNode.TextNode("invalid") : new AdfNode(childType));
+        var document = new AdfDocument(new[] { parent });
+
+        AdfValidationResult result = document.Validate();
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, item => item.Code == "ADF_NODE_CHILD" && item.Path == "$.content[0].content[0]");
+    }
+
+    [Theory]
+    [InlineData("paragraph", "text")]
+    [InlineData("heading", "hardBreak")]
+    [InlineData("codeBlock", "text")]
+    [InlineData("blockquote", "paragraph")]
+    [InlineData("bulletList", "listItem")]
+    [InlineData("listItem", "paragraph")]
+    [InlineData("taskList", "taskItem")]
+    [InlineData("taskItem", "text")]
+    [InlineData("table", "tableRow")]
+    [InlineData("tableRow", "tableCell")]
+    [InlineData("tableCell", "paragraph")]
+    [InlineData("mediaSingle", "media")]
+    [InlineData("mediaGroup", "media")]
+    [InlineData("panel", "paragraph")]
+    [InlineData("bodiedExtension", "paragraph")]
+    public void Validation_AcceptsKnownParentChildPairs(string parentType, string childType) {
+        var parent = new AdfNode(parentType);
+        parent.Content.Add(childType == "text" ? AdfNode.TextNode("valid") : new AdfNode(childType));
+        var document = new AdfDocument(new[] { parent });
+
+        AdfValidationResult result = document.Validate();
+
+        Assert.DoesNotContain(result.Issues, item => item.Code == "ADF_NODE_CHILD" && item.Path == "$.content[0].content[0]");
+        Assert.DoesNotContain(result.Issues, item => item.Code == "ADF_LIST_CHILD" && item.Path == "$.content[0].content[0]");
+        Assert.DoesNotContain(result.Issues, item => item.Code == "ADF_TASK_LIST_CHILD" && item.Path == "$.content[0].content[0]");
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Validation_RequiresStringHrefOnLinkMarks(bool addNonStringHref) {
+        var link = new AdfMark("link");
+        if (addNonStringHref) link.SetAttribute("href", 42);
+        var document = new AdfDocument();
+        document.Content.Add(new AdfNode("paragraph") {
+            Content = { AdfNode.TextNode("broken", new[] { link }) }
+        });
+
+        AdfValidationResult result = document.Validate();
+
+        Assert.False(result.IsValid);
+        AdfValidationIssue issue = Assert.Single(result.Issues, item => item.Code == "ADF_LINK_HREF_REQUIRED");
+        Assert.Equal("$.content[0].content[0].marks[0].attrs.href", issue.Path);
+    }
+
     [Fact]
     public void LinkProjection_PreservesTitleAndReportsUnsupportedAttributes() {
         var link = new AdfMark("link")
@@ -285,6 +348,28 @@ public sealed class AdfContractTests {
             text => Assert.Equal("right", text.Text),
             hardBreak => Assert.Equal("hardBreak", hardBreak.Type),
             text => Assert.Equal("next", text.Text));
+    }
+
+    [Fact]
+    public void TableProjection_ReportsDroppedCellAttributes() {
+        var document = new AdfDocument();
+        document.Content.Add(new AdfNode("table") {
+            Content = {
+                new AdfNode("tableRow") {
+                    Content = {
+                        new AdfNode("tableHeader") {
+                            Content = { new AdfNode("paragraph") { Content = { AdfNode.TextNode("Header") } } }
+                        }.SetAttribute("colspan", 2).SetAttribute("colwidth", new[] { 120, 120 })
+                    }
+                }
+            }
+        });
+
+        AdfConversionResult<string> result = AdfConverter.ToMarkdown(document);
+
+        Assert.False(result.Report.IsLossless);
+        AdfConversionDiagnostic diagnostic = Assert.Single(result.Report.Diagnostics, item => item.Code == "ADF_TABLE_CELL_ATTRIBUTES_DROPPED");
+        Assert.Equal("$.content[0].content[0].content[0]", diagnostic.Path);
     }
 
     [Fact]

--- a/OfficeIMO.Adf.Tests/AdfContractTests.cs
+++ b/OfficeIMO.Adf.Tests/AdfContractTests.cs
@@ -62,6 +62,37 @@ public sealed class AdfContractTests {
     }
 
     [Theory]
+    [InlineData("{\"type\":\"file\",\"collection\":\"files\"}", "ADF_MEDIA_ID")]
+    [InlineData("{\"type\":\"file\",\"id\":17,\"collection\":\"files\"}", "ADF_MEDIA_ID")]
+    [InlineData("{\"type\":\"link\",\"id\":\"media-1\"}", "ADF_MEDIA_COLLECTION")]
+    [InlineData("{\"type\":\"link\",\"id\":\"media-1\",\"collection\":42}", "ADF_MEDIA_COLLECTION")]
+    [InlineData("{\"type\":\"external\"}", "ADF_MEDIA_URL")]
+    [InlineData("{\"type\":\"external\",\"url\":42}", "ADF_MEDIA_URL")]
+    [InlineData("{\"type\":\"unknown\"}", "ADF_MEDIA_TYPE")]
+    [InlineData("{\"type\":42}", "ADF_MEDIA_TYPE")]
+    public void Validation_RequiresSchemaDefinedMediaSourceAttributes(string attributesJson, string expectedCode) {
+        AdfDocument document = AdfDocument.Parse(
+            "{\"version\":1,\"type\":\"doc\",\"content\":[{\"type\":\"mediaSingle\",\"content\":[{\"type\":\"media\",\"attrs\":" + attributesJson + "}]}]}");
+
+        AdfValidationResult result = document.Validate();
+
+        Assert.False(result.IsValid);
+        AdfValidationIssue issue = Assert.Single(result.Issues, item => item.Code == expectedCode);
+        Assert.StartsWith("$.content[0].content[0].attrs.", issue.Path);
+    }
+
+    [Theory]
+    [InlineData("{\"type\":\"file\",\"id\":\"media-1\",\"collection\":\"files\"}")]
+    [InlineData("{\"type\":\"link\",\"id\":\"media-1\",\"collection\":\"\"}")]
+    [InlineData("{\"type\":\"external\",\"url\":\"\"}")]
+    public void Validation_AcceptsSchemaDefinedMediaSourceAttributes(string attributesJson) {
+        AdfDocument document = AdfDocument.Parse(
+            "{\"version\":1,\"type\":\"doc\",\"content\":[{\"type\":\"mediaSingle\",\"content\":[{\"type\":\"media\",\"attrs\":" + attributesJson + "}]}]}");
+
+        Assert.True(document.Validate().IsValid);
+    }
+
+    [Theory]
     [InlineData("text")]
     [InlineData("hardBreak")]
     [InlineData("mention")]
@@ -370,6 +401,22 @@ public sealed class AdfContractTests {
     }
 
     [Theory]
+    [InlineData("first\r\nsecond")]
+    [InlineData("first\rsecond")]
+    public void CodeBlockProjection_ReportsCarriageReturnLineEndingNormalization(string content) {
+        var document = new AdfDocument();
+        document.Content.Add(new AdfNode("codeBlock") { Content = { AdfNode.TextNode(content) } });
+
+        AdfConversionResult<string> markdown = AdfConverter.ToMarkdown(document);
+        AdfConversionResult<AdfDocument> roundTrip = AdfConverter.FromMarkdown(markdown.Value);
+
+        Assert.False(markdown.Report.IsLossless);
+        AdfConversionDiagnostic diagnostic = Assert.Single(markdown.Report.Diagnostics, item => item.Code == "ADF_CODE_LINE_ENDINGS_NORMALIZED");
+        Assert.Equal("$.content[0]", diagnostic.Path);
+        Assert.Equal("first\nsecond", Assert.Single(Assert.Single(roundTrip.Value.Content).Content).Text);
+    }
+
+    [Theory]
     [InlineData("# Heading")]
     [InlineData("> quote")]
     [InlineData("- item")]
@@ -519,6 +566,19 @@ public sealed class AdfContractTests {
         Assert.False(result.Report.IsLossless);
         AdfConversionDiagnostic diagnostic = Assert.Single(result.Report.Diagnostics, item => item.Code == "ADF_TABLE_ATTRIBUTES_DROPPED");
         Assert.Equal("$.content[0]", diagnostic.Path);
+    }
+
+    [Fact]
+    public void MarkdownProjection_ReportsDroppedRootExtensionProperties() {
+        var document = new AdfDocument();
+        document.ExtensionData["vendorRoot"] = JsonSerializer.SerializeToElement(true);
+        document.Content.Add(new AdfNode("paragraph") { Content = { AdfNode.TextNode("Ready") } });
+
+        AdfConversionResult<string> result = AdfConverter.ToMarkdown(document);
+
+        Assert.False(result.Report.IsLossless);
+        AdfConversionDiagnostic diagnostic = Assert.Single(result.Report.Diagnostics, item => item.Code == "ADF_ROOT_PROPERTIES_DROPPED");
+        Assert.Equal("$", diagnostic.Path);
     }
 
     [Fact]

--- a/OfficeIMO.Adf.Tests/AdfContractTests.cs
+++ b/OfficeIMO.Adf.Tests/AdfContractTests.cs
@@ -1,5 +1,7 @@
+using System.Linq;
 using System.Text.Json;
 using OfficeIMO.Adf;
+using OfficeIMO.Markdown;
 using Xunit;
 
 namespace OfficeIMO.Adf.Tests;
@@ -95,5 +97,57 @@ public sealed class AdfContractTests {
 
         Assert.Contains("[details](https://example.com/details 'Ready \"now\"')", result.Value);
         Assert.Contains(result.Report.Diagnostics, item => item.Code == "ADF_LINK_ATTRIBUTES_DROPPED");
+    }
+
+    [Fact]
+    public void CodeBlockProjection_UsesFenceThatCannotCollideWithContent() {
+        const string content = "before\n```\n# still code\nafter";
+        var document = new AdfDocument();
+        document.Content.Add(new AdfNode("codeBlock") { Content = { AdfNode.TextNode(content) } });
+
+        AdfConversionResult<string> markdown = AdfConverter.ToMarkdown(document);
+        AdfConversionResult<AdfDocument> roundTrip = AdfConverter.FromMarkdown(markdown.Value);
+
+        Assert.StartsWith(MarkdownFence.BuildSafeFence(content), markdown.Value);
+        AdfNode codeBlock = Assert.Single(roundTrip.Value.Content);
+        Assert.Equal("codeBlock", codeBlock.Type);
+        Assert.Equal(content, Assert.Single(codeBlock.Content).Text);
+    }
+
+    [Theory]
+    [InlineData("# Heading")]
+    [InlineData("> quote")]
+    [InlineData("- item")]
+    [InlineData("1. item")]
+    public void ParagraphProjection_EscapesLineLeadingBlockSyntax(string text) {
+        var document = new AdfDocument();
+        document.Content.Add(new AdfNode("paragraph") { Content = { AdfNode.TextNode(text) } });
+
+        AdfConversionResult<string> markdown = AdfConverter.ToMarkdown(document);
+        AdfConversionResult<AdfDocument> roundTrip = AdfConverter.FromMarkdown(markdown.Value);
+
+        AdfNode paragraph = Assert.Single(roundTrip.Value.Content);
+        Assert.Equal("paragraph", paragraph.Type);
+        Assert.Equal(text, string.Concat(paragraph.Content.Select(node => node.Text)));
+    }
+
+    [Fact]
+    public void InlineCodeProjection_PreservesBackticksAndCombinedMarksRegardlessOfOrder() {
+        const string content = "value`tick";
+        foreach (AdfMark[] marks in new[] {
+                     new[] { new AdfMark("strong"), new AdfMark("code") },
+                     new[] { new AdfMark("code"), new AdfMark("strong") },
+                 }) {
+            var document = new AdfDocument();
+            document.Content.Add(new AdfNode("paragraph") { Content = { AdfNode.TextNode(content, marks) } });
+
+            AdfConversionResult<string> markdown = AdfConverter.ToMarkdown(document);
+            AdfConversionResult<AdfDocument> roundTrip = AdfConverter.FromMarkdown(markdown.Value);
+
+            AdfNode text = Assert.Single(Assert.Single(roundTrip.Value.Content).Content);
+            Assert.Equal(content, text.Text);
+            Assert.Contains(text.Marks, mark => mark.Type == "strong");
+            Assert.Contains(text.Marks, mark => mark.Type == "code");
+        }
     }
 }

--- a/OfficeIMO.Adf.Tests/AdfContractTests.cs
+++ b/OfficeIMO.Adf.Tests/AdfContractTests.cs
@@ -78,15 +78,45 @@ public sealed class AdfContractTests {
     }
 
     [Fact]
-    public void MarkdownTaskList_UsesValidListItemFallbackAndReportsFidelity() {
+    public void MarkdownTaskList_UsesNativeAdfTaskNodesAndRoundTrips() {
         AdfConversionResult<AdfDocument> result = AdfConverter.FromMarkdown("- [x] Ready\n- [ ] Pending");
 
         AdfNode list = Assert.Single(result.Value.Content);
-        Assert.Equal("bulletList", list.Type);
-        Assert.All(list.Content, item => Assert.Equal("listItem", item.Type));
+        Assert.Equal("taskList", list.Type);
+        Assert.False(string.IsNullOrWhiteSpace(list.GetStringAttribute("localId")));
+        Assert.Collection(
+            list.Content,
+            item => {
+                Assert.Equal("taskItem", item.Type);
+                Assert.Equal("DONE", item.GetStringAttribute("state"));
+                Assert.False(string.IsNullOrWhiteSpace(item.GetStringAttribute("localId")));
+                Assert.Equal("Ready", Assert.Single(item.Content).Text);
+            },
+            item => {
+                Assert.Equal("taskItem", item.Type);
+                Assert.Equal("TODO", item.GetStringAttribute("state"));
+                Assert.False(string.IsNullOrWhiteSpace(item.GetStringAttribute("localId")));
+                Assert.Equal("Pending", Assert.Single(item.Content).Text);
+            });
         Assert.True(result.Value.Validate().IsValid);
+        Assert.DoesNotContain(result.Report.Diagnostics, item => item.Code == "MARKDOWN_TASK_LIST_FALLBACK");
+
+        AdfConversionResult<string> roundTrip = AdfConverter.ToMarkdown(result.Value);
+        Assert.Equal("- [x] Ready\n- [ ] Pending", roundTrip.Value.Replace("\r\n", "\n"));
+        Assert.DoesNotContain(roundTrip.Report.Diagnostics, item => item.Code == "ADF_UNSUPPORTED_NODE");
+    }
+
+    [Fact]
+    public void MarkdownComplexTaskList_UsesVisibleMarkerFallback() {
+        var task = ListItem.Task("Ready", done: true);
+        task.AdditionalParagraphs.Add(new InlineSequence().Text("Details"));
+        var list = new UnorderedListBlock();
+        list.Items.Add(task);
+
+        AdfConversionResult<AdfDocument> result = AdfConverter.FromMarkdown(MarkdownDoc.Create().Add(list));
+
+        Assert.Equal("bulletList", Assert.Single(result.Value.Content).Type);
         Assert.Contains(result.Report.Diagnostics, item => item.Code == "MARKDOWN_TASK_LIST_FALLBACK");
-        Assert.Contains("\\[x\\] Ready", AdfConverter.ToMarkdown(result.Value).Value);
     }
 
     [Fact]
@@ -98,6 +128,45 @@ public sealed class AdfContractTests {
         Assert.False(result.IsValid);
         Assert.Contains(result.Issues, item => item.Code == "ADF_LIST_CHILD");
         Assert.Contains(result.Issues, item => item.Code == "ADF_TASK_ITEM_PARENT");
+    }
+
+    [Fact]
+    public void Validation_RejectsKnownNonTextPayloadsAndMarks() {
+        var paragraph = new AdfNode("paragraph") { Text = "invalid" };
+        paragraph.Marks.Add(new AdfMark("strong"));
+        var document = new AdfDocument(new[] { paragraph });
+
+        AdfValidationResult result = document.Validate();
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, item => item.Code == "ADF_TEXT_NOT_ALLOWED" && item.Path == "$.content[0].text");
+        Assert.Contains(result.Issues, item => item.Code == "ADF_MARKS_NOT_ALLOWED" && item.Path == "$.content[0].marks");
+    }
+
+    [Fact]
+    public void Validation_RejectsEmptyTextNodes() {
+        var document = new AdfDocument();
+        document.Content.Add(new AdfNode("paragraph") { Content = { AdfNode.TextNode(string.Empty) } });
+
+        AdfValidationResult result = document.Validate();
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, item => item.Code == "ADF_TEXT_REQUIRED" && item.Path == "$.content[0].content[0].text");
+    }
+
+    [Theory]
+    [InlineData("taskList", "{}", "ADF_TASK_LOCAL_ID")]
+    [InlineData("taskItem", "{\"state\":\"DONE\"}", "ADF_TASK_LOCAL_ID")]
+    [InlineData("taskItem", "{\"localId\":\"item-1\"}", "ADF_TASK_STATE")]
+    [InlineData("taskItem", "{\"localId\":\"item-1\",\"state\":\"done\"}", "ADF_TASK_STATE")]
+    public void Validation_RequiresTaskIdentityAndState(string nodeType, string attributesJson, string expectedCode) {
+        AdfDocument document = AdfDocument.Parse(
+            "{\"version\":1,\"type\":\"doc\",\"content\":[{\"type\":\"" + nodeType + "\",\"attrs\":" + attributesJson + "}]}");
+
+        AdfValidationResult result = document.Validate();
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, item => item.Code == expectedCode);
     }
 
     [Theory]
@@ -406,6 +475,22 @@ public sealed class AdfContractTests {
 
         Assert.False(result.Report.IsLossless);
         AdfConversionDiagnostic diagnostic = Assert.Single(result.Report.Diagnostics, item => item.Code == "ADF_TABLE_CELL_ATTRIBUTES_DROPPED");
+        Assert.Equal("$.content[0].content[0].content[0]", diagnostic.Path);
+    }
+
+    [Fact]
+    public void TableProjection_ReportsFlattenedCellBlockStructure() {
+        var header = TableCell("tableHeader", "First");
+        header.Content.Add(new AdfNode("paragraph") { Content = { AdfNode.TextNode("Second") } });
+        var document = new AdfDocument();
+        document.Content.Add(new AdfNode("table") {
+            Content = { new AdfNode("tableRow") { Content = { header } } }
+        });
+
+        AdfConversionResult<string> result = AdfConverter.ToMarkdown(document);
+
+        Assert.False(result.Report.IsLossless);
+        AdfConversionDiagnostic diagnostic = Assert.Single(result.Report.Diagnostics, item => item.Code == "ADF_TABLE_CELL_BLOCKS_FLATTENED");
         Assert.Equal("$.content[0].content[0].content[0]", diagnostic.Path);
     }
 

--- a/OfficeIMO.Adf.Tests/AdfSchemaValidationTests.cs
+++ b/OfficeIMO.Adf.Tests/AdfSchemaValidationTests.cs
@@ -1,0 +1,61 @@
+using OfficeIMO.Adf;
+using Xunit;
+
+namespace OfficeIMO.Adf.Tests;
+
+public sealed class AdfSchemaValidationTests {
+    [Fact]
+    public void Validation_RejectsEmptyListItems() {
+        var listItem = new AdfNode("listItem");
+        var list = new AdfNode("bulletList") { Content = { listItem } };
+        var document = new AdfDocument(new[] { list });
+
+        AdfValidationResult result = document.Validate();
+
+        Assert.False(result.IsValid);
+        AdfValidationIssue issue = Assert.Single(result.Issues, item => item.Code == "ADF_LIST_ITEM_CONTENT_REQUIRED");
+        Assert.Equal("$.content[0].content[0].content", issue.Path);
+    }
+
+    [Fact]
+    public void Validation_AllowsSchemaDefinedListItemWithoutLeadingParagraph() {
+        var codeBlock = new AdfNode("codeBlock") { Content = { AdfNode.TextNode("Get-Date") } };
+        var listItem = new AdfNode("listItem") { Content = { codeBlock } };
+        var list = new AdfNode("bulletList") { Content = { listItem } };
+        var document = new AdfDocument(new[] { list });
+
+        AdfValidationResult result = document.Validate();
+
+        Assert.True(result.IsValid);
+    }
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("{\"url\":42}")]
+    [InlineData("{\"url\":\" \"}")]
+    [InlineData("{\"data\":null}")]
+    [InlineData("{\"url\":\"https://example.test\",\"data\":{}}")]
+    public void Validation_RejectsInlineCardsWithoutExactlyOneValidTarget(string attributesJson) {
+        AdfDocument document = InlineCardDocument(attributesJson);
+
+        AdfValidationResult result = document.Validate();
+
+        Assert.False(result.IsValid);
+        AdfValidationIssue issue = Assert.Single(result.Issues, item => item.Code == "ADF_INLINE_CARD_TARGET");
+        Assert.Equal("$.content[0].content[0].attrs", issue.Path);
+    }
+
+    [Theory]
+    [InlineData("{\"url\":\"https://example.test/card\"}")]
+    [InlineData("{\"data\":{\"@type\":\"Link\",\"url\":\"https://example.test/card\"}}")]
+    public void Validation_AcceptsInlineCardUrlOrDataTarget(string attributesJson) {
+        AdfDocument document = InlineCardDocument(attributesJson);
+
+        AdfValidationResult result = document.Validate();
+
+        Assert.True(result.IsValid);
+    }
+
+    private static AdfDocument InlineCardDocument(string attributesJson) => AdfDocument.Parse(
+        "{\"version\":1,\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"inlineCard\",\"attrs\":" + attributesJson + "}]}]}");
+}

--- a/OfficeIMO.Adf.Tests/AdfTaskProjectionTests.cs
+++ b/OfficeIMO.Adf.Tests/AdfTaskProjectionTests.cs
@@ -1,0 +1,33 @@
+using OfficeIMO.Adf;
+using Xunit;
+
+namespace OfficeIMO.Adf.Tests;
+
+public sealed class AdfTaskProjectionTests {
+    [Fact]
+    public void TaskProjection_ReportsRegeneratedLocalIds() {
+        var item = new AdfNode("taskItem") {
+            Content = { AdfNode.TextNode("Ready") }
+        }.SetAttribute("localId", "item-1").SetAttribute("state", "DONE");
+        var list = new AdfNode("taskList") {
+            Content = { item }
+        }.SetAttribute("localId", "list-1");
+        var document = new AdfDocument(new[] { list });
+
+        Assert.True(document.Validate().IsValid);
+
+        AdfConversionResult<string> markdown = AdfConverter.ToMarkdown(document);
+        AdfConversionResult<AdfDocument> roundTrip = AdfConverter.FromMarkdown(markdown.Value);
+
+        Assert.Equal("- [x] Ready", markdown.Value.Replace("\r\n", "\n"));
+        Assert.False(markdown.Report.IsLossless);
+        AdfConversionDiagnostic diagnostic = Assert.Single(
+            markdown.Report.Diagnostics,
+            item => item.Code == "ADF_TASK_LOCAL_IDS_REGENERATED");
+        Assert.Equal("$.content[0]", diagnostic.Path);
+        AdfNode projectedList = Assert.Single(roundTrip.Value.Content);
+        AdfNode projectedItem = Assert.Single(projectedList.Content);
+        Assert.NotEqual("list-1", projectedList.GetStringAttribute("localId"));
+        Assert.NotEqual("item-1", projectedItem.GetStringAttribute("localId"));
+    }
+}

--- a/OfficeIMO.Adf.Tests/OfficeIMO.Adf.Tests.csproj
+++ b/OfficeIMO.Adf.Tests/OfficeIMO.Adf.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <LangVersion>Latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1"><PrivateAssets>all</PrivateAssets></PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5"><PrivateAssets>all</PrivateAssets></PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OfficeIMO.Adf\OfficeIMO.Adf.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/OfficeIMO.Adf/AdfConversionModels.cs
+++ b/OfficeIMO.Adf/AdfConversionModels.cs
@@ -1,0 +1,50 @@
+namespace OfficeIMO.Adf;
+
+/// <summary>Severity of a lossy or noteworthy conversion decision.</summary>
+public enum AdfConversionSeverity {
+    Information,
+    Warning,
+    Error,
+}
+
+/// <summary>A conversion decision recorded for fidelity review.</summary>
+public sealed class AdfConversionDiagnostic {
+    internal AdfConversionDiagnostic(string code, string path, string message, AdfConversionSeverity severity) {
+        Code = code;
+        Path = path;
+        Message = message;
+        Severity = severity;
+    }
+
+    public string Code { get; }
+    public string Path { get; }
+    public string Message { get; }
+    public AdfConversionSeverity Severity { get; }
+}
+
+/// <summary>Operation-scoped conversion evidence.</summary>
+public sealed class AdfConversionReport {
+    /// <summary>Creates a report from operation-scoped diagnostics.</summary>
+    public AdfConversionReport(IEnumerable<AdfConversionDiagnostic> diagnostics) =>
+        Diagnostics = diagnostics?.ToArray() ?? throw new ArgumentNullException(nameof(diagnostics));
+    public IReadOnlyList<AdfConversionDiagnostic> Diagnostics { get; }
+    public bool IsLossless => Diagnostics.All(item => item.Severity == AdfConversionSeverity.Information);
+    public bool HasErrors => Diagnostics.Any(item => item.Severity == AdfConversionSeverity.Error);
+}
+
+/// <summary>A converted value and its fidelity report.</summary>
+public sealed class AdfConversionResult<T> {
+    internal AdfConversionResult(T value, IReadOnlyList<AdfConversionDiagnostic> diagnostics) {
+        Value = value;
+        Report = new AdfConversionReport(diagnostics);
+    }
+
+    public T Value { get; }
+    public AdfConversionReport Report { get; }
+}
+
+/// <summary>Options for ADF projections.</summary>
+public sealed class AdfConversionOptions {
+    /// <summary>When true, visible placeholders are emitted for unsupported nodes with no projectable text.</summary>
+    public bool EmitUnsupportedPlaceholders { get; set; }
+}

--- a/OfficeIMO.Adf/AdfConversionModels.cs
+++ b/OfficeIMO.Adf/AdfConversionModels.cs
@@ -9,7 +9,11 @@ public enum AdfConversionSeverity {
 
 /// <summary>A conversion decision recorded for fidelity review.</summary>
 public sealed class AdfConversionDiagnostic {
-    internal AdfConversionDiagnostic(string code, string path, string message, AdfConversionSeverity severity) {
+    /// <summary>Creates an operation-scoped conversion diagnostic.</summary>
+    public AdfConversionDiagnostic(string code, string path, string message, AdfConversionSeverity severity) {
+        if (string.IsNullOrWhiteSpace(code)) throw new ArgumentException("A diagnostic code is required.", nameof(code));
+        if (path == null) throw new ArgumentNullException(nameof(path));
+        if (string.IsNullOrWhiteSpace(message)) throw new ArgumentException("A diagnostic message is required.", nameof(message));
         Code = code;
         Path = path;
         Message = message;
@@ -27,6 +31,8 @@ public sealed class AdfConversionReport {
     /// <summary>Creates a report from operation-scoped diagnostics.</summary>
     public AdfConversionReport(IEnumerable<AdfConversionDiagnostic> diagnostics) =>
         Diagnostics = diagnostics?.ToArray() ?? throw new ArgumentNullException(nameof(diagnostics));
+    /// <summary>An empty report for identity conversions that do not project content.</summary>
+    public static AdfConversionReport Empty { get; } = new AdfConversionReport(Array.Empty<AdfConversionDiagnostic>());
     public IReadOnlyList<AdfConversionDiagnostic> Diagnostics { get; }
     public bool IsLossless => Diagnostics.All(item => item.Severity == AdfConversionSeverity.Information);
     public bool HasErrors => Diagnostics.Any(item => item.Severity == AdfConversionSeverity.Error);

--- a/OfficeIMO.Adf/AdfConverter.cs
+++ b/OfficeIMO.Adf/AdfConverter.cs
@@ -10,18 +10,18 @@ public static class AdfConverter {
     public static AdfConversionResult<MarkdownDoc> ToMarkdownDocument(
         AdfDocument document,
         AdfConversionOptions? options = null) {
-        if (document == null) throw new ArgumentNullException(nameof(document));
-        var diagnostics = new List<AdfConversionDiagnostic>();
-        string markdown = AdfToMarkdownConverter.Convert(document, options ?? new AdfConversionOptions(), diagnostics);
-        return new AdfConversionResult<MarkdownDoc>(MarkdownReader.Parse(markdown), diagnostics);
+        AdfConversionResult<string> result = ToMarkdown(document, options);
+        return new AdfConversionResult<MarkdownDoc>(MarkdownReader.Parse(result.Value), result.Report.Diagnostics);
     }
 
     /// <summary>Converts an ADF document to Markdown text.</summary>
     public static AdfConversionResult<string> ToMarkdown(
         AdfDocument document,
         AdfConversionOptions? options = null) {
-        AdfConversionResult<MarkdownDoc> result = ToMarkdownDocument(document, options);
-        return new AdfConversionResult<string>(result.Value.ToMarkdown(), result.Report.Diagnostics);
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        var diagnostics = new List<AdfConversionDiagnostic>();
+        string markdown = AdfToMarkdownConverter.Convert(document, options ?? new AdfConversionOptions(), diagnostics);
+        return new AdfConversionResult<string>(markdown, diagnostics);
     }
 
     /// <summary>Converts an ADF document to an HTML fragment through OfficeIMO.Markdown.</summary>

--- a/OfficeIMO.Adf/AdfConverter.cs
+++ b/OfficeIMO.Adf/AdfConverter.cs
@@ -30,7 +30,13 @@ public static class AdfConverter {
         HtmlOptions? htmlOptions = null,
         AdfConversionOptions? options = null) {
         AdfConversionResult<MarkdownDoc> result = ToMarkdownDocument(document, options);
-        return new AdfConversionResult<string>(result.Value.ToHtmlFragment(htmlOptions), result.Report.Diagnostics);
+        var diagnostics = result.Report.Diagnostics.ToList();
+        diagnostics.Add(new AdfConversionDiagnostic(
+            "ADF_TO_HTML_VIA_MARKDOWN",
+            "$",
+            "ADF is projected through the OfficeIMO Markdown model before HTML rendering.",
+            AdfConversionSeverity.Warning));
+        return new AdfConversionResult<string>(result.Value.ToHtmlFragment(htmlOptions), diagnostics);
     }
 
     /// <summary>Converts Markdown text to ADF.</summary>
@@ -51,6 +57,13 @@ public static class AdfConverter {
     public static AdfConversionResult<AdfDocument> FromHtml(string html, HtmlToMarkdownOptions? options = null) {
         if (html == null) throw new ArgumentNullException(nameof(html));
         MarkdownDoc markdown = HtmlConversionDocument.Parse(html).ToMarkdownDocument(options);
-        return FromMarkdown(markdown);
+        AdfConversionResult<AdfDocument> result = FromMarkdown(markdown);
+        var diagnostics = result.Report.Diagnostics.ToList();
+        diagnostics.Insert(0, new AdfConversionDiagnostic(
+            "ADF_HTML_VIA_MARKDOWN",
+            "$",
+            "HTML is projected through the OfficeIMO Markdown model before ADF generation.",
+            AdfConversionSeverity.Warning));
+        return new AdfConversionResult<AdfDocument>(result.Value, diagnostics);
     }
 }

--- a/OfficeIMO.Adf/AdfConverter.cs
+++ b/OfficeIMO.Adf/AdfConverter.cs
@@ -1,0 +1,56 @@
+using OfficeIMO.Html;
+using OfficeIMO.Markdown;
+using OfficeIMO.Markdown.Html;
+
+namespace OfficeIMO.Adf;
+
+/// <summary>Converts ADF through OfficeIMO's canonical Markdown and HTML models.</summary>
+public static class AdfConverter {
+    /// <summary>Converts an ADF document to the OfficeIMO Markdown object model.</summary>
+    public static AdfConversionResult<MarkdownDoc> ToMarkdownDocument(
+        AdfDocument document,
+        AdfConversionOptions? options = null) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        var diagnostics = new List<AdfConversionDiagnostic>();
+        string markdown = AdfToMarkdownConverter.Convert(document, options ?? new AdfConversionOptions(), diagnostics);
+        return new AdfConversionResult<MarkdownDoc>(MarkdownReader.Parse(markdown), diagnostics);
+    }
+
+    /// <summary>Converts an ADF document to Markdown text.</summary>
+    public static AdfConversionResult<string> ToMarkdown(
+        AdfDocument document,
+        AdfConversionOptions? options = null) {
+        AdfConversionResult<MarkdownDoc> result = ToMarkdownDocument(document, options);
+        return new AdfConversionResult<string>(result.Value.ToMarkdown(), result.Report.Diagnostics);
+    }
+
+    /// <summary>Converts an ADF document to an HTML fragment through OfficeIMO.Markdown.</summary>
+    public static AdfConversionResult<string> ToHtml(
+        AdfDocument document,
+        HtmlOptions? htmlOptions = null,
+        AdfConversionOptions? options = null) {
+        AdfConversionResult<MarkdownDoc> result = ToMarkdownDocument(document, options);
+        return new AdfConversionResult<string>(result.Value.ToHtmlFragment(htmlOptions), result.Report.Diagnostics);
+    }
+
+    /// <summary>Converts Markdown text to ADF.</summary>
+    public static AdfConversionResult<AdfDocument> FromMarkdown(string markdown) {
+        if (markdown == null) throw new ArgumentNullException(nameof(markdown));
+        return FromMarkdown(MarkdownReader.Parse(markdown));
+    }
+
+    /// <summary>Converts an OfficeIMO Markdown document to ADF.</summary>
+    public static AdfConversionResult<AdfDocument> FromMarkdown(MarkdownDoc markdown) {
+        if (markdown == null) throw new ArgumentNullException(nameof(markdown));
+        var diagnostics = new List<AdfConversionDiagnostic>();
+        AdfDocument value = MarkdownToAdfConverter.Convert(markdown, diagnostics);
+        return new AdfConversionResult<AdfDocument>(value, diagnostics);
+    }
+
+    /// <summary>Converts HTML to ADF through OfficeIMO.Html and OfficeIMO.Markdown.Html.</summary>
+    public static AdfConversionResult<AdfDocument> FromHtml(string html, HtmlToMarkdownOptions? options = null) {
+        if (html == null) throw new ArgumentNullException(nameof(html));
+        MarkdownDoc markdown = HtmlConversionDocument.Parse(html).ToMarkdownDocument(options);
+        return FromMarkdown(markdown);
+    }
+}

--- a/OfficeIMO.Adf/AdfDocument.cs
+++ b/OfficeIMO.Adf/AdfDocument.cs
@@ -1,0 +1,124 @@
+using System.Text.Json;
+
+namespace OfficeIMO.Adf;
+
+/// <summary>
+/// Represents an Atlas Document Format document while retaining fields that OfficeIMO does not yet understand.
+/// </summary>
+public sealed class AdfDocument {
+    /// <summary>Creates an empty ADF document.</summary>
+    public AdfDocument() {
+    }
+
+    /// <summary>Creates an ADF document with the supplied top-level nodes.</summary>
+    public AdfDocument(IEnumerable<AdfNode>? content) {
+        if (content != null) {
+            Content.AddRange(content);
+        }
+    }
+
+    /// <summary>ADF schema version.</summary>
+    public int Version { get; set; } = 1;
+
+    /// <summary>Root node type. A normal ADF document uses <c>doc</c>.</summary>
+    public string Type { get; set; } = "doc";
+
+    /// <summary>Top-level document nodes.</summary>
+    public List<AdfNode> Content { get; } = new List<AdfNode>();
+
+    /// <summary>Unknown root properties retained during parse/write round trips.</summary>
+    public IDictionary<string, JsonElement> ExtensionData { get; } = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+
+    /// <summary>Parses an ADF JSON document.</summary>
+    public static AdfDocument Parse(string json) => AdfJsonSerializer.Parse(json);
+
+    /// <summary>Serializes this document to ADF JSON.</summary>
+    public string ToJson(bool indented = false) => AdfJsonSerializer.Serialize(this, indented);
+
+    /// <summary>Validates the structural ADF contract without rejecting unknown node or mark types.</summary>
+    public AdfValidationResult Validate() => AdfValidator.Validate(this);
+}
+
+/// <summary>An ADF content node.</summary>
+public sealed class AdfNode {
+    /// <summary>Creates an ADF node.</summary>
+    public AdfNode(string type) {
+        if (string.IsNullOrWhiteSpace(type)) throw new ArgumentException("ADF node type is required.", nameof(type));
+        Type = type;
+    }
+
+    /// <summary>Node type such as <c>paragraph</c>, <c>heading</c>, or <c>text</c>.</summary>
+    public string Type { get; set; }
+
+    /// <summary>Text payload for text nodes.</summary>
+    public string? Text { get; set; }
+
+    /// <summary>Child nodes.</summary>
+    public List<AdfNode> Content { get; } = new List<AdfNode>();
+
+    /// <summary>Marks applied to a text node.</summary>
+    public List<AdfMark> Marks { get; } = new List<AdfMark>();
+
+    /// <summary>Node attributes retained as arbitrary JSON values.</summary>
+    public IDictionary<string, JsonElement> Attributes { get; } = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+
+    /// <summary>Unknown node properties retained during parse/write round trips.</summary>
+    public IDictionary<string, JsonElement> ExtensionData { get; } = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+
+    /// <summary>Creates a text node.</summary>
+    public static AdfNode TextNode(string text, IEnumerable<AdfMark>? marks = null) {
+        var node = new AdfNode("text") { Text = text ?? string.Empty };
+        if (marks != null) node.Marks.AddRange(marks);
+        return node;
+    }
+
+    /// <summary>Sets a JSON-compatible attribute value.</summary>
+    public AdfNode SetAttribute<T>(string name, T value) {
+        if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Attribute name is required.", nameof(name));
+        Attributes[name] = JsonSerializer.SerializeToElement(value).Clone();
+        return this;
+    }
+
+    /// <summary>Gets a string attribute when present.</summary>
+    public string? GetStringAttribute(string name) =>
+        Attributes.TryGetValue(name, out JsonElement value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    /// <summary>Gets an integer attribute when present.</summary>
+    public int? GetInt32Attribute(string name) =>
+        Attributes.TryGetValue(name, out JsonElement value) && value.ValueKind == JsonValueKind.Number && value.TryGetInt32(out int result)
+            ? result
+            : null;
+}
+
+/// <summary>An ADF text mark such as strong, emphasis, code, or link.</summary>
+public sealed class AdfMark {
+    /// <summary>Creates an ADF mark.</summary>
+    public AdfMark(string type) {
+        if (string.IsNullOrWhiteSpace(type)) throw new ArgumentException("ADF mark type is required.", nameof(type));
+        Type = type;
+    }
+
+    /// <summary>Mark type.</summary>
+    public string Type { get; set; }
+
+    /// <summary>Mark attributes retained as arbitrary JSON values.</summary>
+    public IDictionary<string, JsonElement> Attributes { get; } = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+
+    /// <summary>Unknown mark properties retained during parse/write round trips.</summary>
+    public IDictionary<string, JsonElement> ExtensionData { get; } = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+
+    /// <summary>Sets a JSON-compatible mark attribute.</summary>
+    public AdfMark SetAttribute<T>(string name, T value) {
+        if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Attribute name is required.", nameof(name));
+        Attributes[name] = JsonSerializer.SerializeToElement(value).Clone();
+        return this;
+    }
+
+    /// <summary>Gets a string attribute when present.</summary>
+    public string? GetStringAttribute(string name) =>
+        Attributes.TryGetValue(name, out JsonElement value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+}

--- a/OfficeIMO.Adf/AdfJsonSerializer.cs
+++ b/OfficeIMO.Adf/AdfJsonSerializer.cs
@@ -1,0 +1,174 @@
+using System.IO;
+using System.Text;
+using System.Text.Json;
+
+namespace OfficeIMO.Adf;
+
+internal static class AdfJsonSerializer {
+    internal static AdfDocument Parse(string json) {
+        if (string.IsNullOrWhiteSpace(json)) throw new ArgumentException("ADF JSON is required.", nameof(json));
+
+        using JsonDocument source = JsonDocument.Parse(json);
+        if (source.RootElement.ValueKind != JsonValueKind.Object) {
+            throw new FormatException("An ADF document must be a JSON object.");
+        }
+
+        JsonElement root = source.RootElement;
+        var document = new AdfDocument {
+            Version = ReadRequiredInt32(root, "version", "$"),
+            Type = ReadRequiredString(root, "type", "$"),
+        };
+
+        if (!root.TryGetProperty("content", out JsonElement content) || content.ValueKind != JsonValueKind.Array) {
+            throw new FormatException("ADF root property 'content' must be an array.");
+        }
+
+        int index = 0;
+        foreach (JsonElement element in content.EnumerateArray()) {
+            document.Content.Add(ReadNode(element, "$.content[" + index + "]"));
+            index++;
+        }
+
+        CopyExtensionProperties(root, document.ExtensionData, "version", "type", "content");
+        return document;
+    }
+
+    internal static string Serialize(AdfDocument document, bool indented) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = indented })) {
+            writer.WriteStartObject();
+            writer.WriteNumber("version", document.Version);
+            writer.WriteString("type", document.Type);
+            writer.WritePropertyName("content");
+            writer.WriteStartArray();
+            foreach (AdfNode node in document.Content) WriteNode(writer, node);
+            writer.WriteEndArray();
+            WriteExtensionProperties(writer, document.ExtensionData, "version", "type", "content");
+            writer.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static AdfNode ReadNode(JsonElement element, string path) {
+        if (element.ValueKind != JsonValueKind.Object) throw new FormatException(path + " must be an object.");
+        var node = new AdfNode(ReadRequiredString(element, "type", path));
+
+        if (element.TryGetProperty("text", out JsonElement text)) {
+            if (text.ValueKind != JsonValueKind.String) throw new FormatException(path + ".text must be a string.");
+            node.Text = text.GetString();
+        }
+
+        if (element.TryGetProperty("attrs", out JsonElement attributes)) {
+            ReadObjectProperties(attributes, node.Attributes, path + ".attrs");
+        }
+
+        if (element.TryGetProperty("content", out JsonElement content)) {
+            if (content.ValueKind != JsonValueKind.Array) throw new FormatException(path + ".content must be an array.");
+            int index = 0;
+            foreach (JsonElement child in content.EnumerateArray()) {
+                node.Content.Add(ReadNode(child, path + ".content[" + index + "]"));
+                index++;
+            }
+        }
+
+        if (element.TryGetProperty("marks", out JsonElement marks)) {
+            if (marks.ValueKind != JsonValueKind.Array) throw new FormatException(path + ".marks must be an array.");
+            int index = 0;
+            foreach (JsonElement mark in marks.EnumerateArray()) {
+                node.Marks.Add(ReadMark(mark, path + ".marks[" + index + "]"));
+                index++;
+            }
+        }
+
+        CopyExtensionProperties(element, node.ExtensionData, "type", "text", "attrs", "content", "marks");
+        return node;
+    }
+
+    private static AdfMark ReadMark(JsonElement element, string path) {
+        if (element.ValueKind != JsonValueKind.Object) throw new FormatException(path + " must be an object.");
+        var mark = new AdfMark(ReadRequiredString(element, "type", path));
+        if (element.TryGetProperty("attrs", out JsonElement attributes)) {
+            ReadObjectProperties(attributes, mark.Attributes, path + ".attrs");
+        }
+        CopyExtensionProperties(element, mark.ExtensionData, "type", "attrs");
+        return mark;
+    }
+
+    private static void WriteNode(Utf8JsonWriter writer, AdfNode node) {
+        if (node == null) throw new InvalidOperationException("ADF content cannot contain null nodes.");
+        writer.WriteStartObject();
+        writer.WriteString("type", node.Type);
+        if (node.Attributes.Count > 0) WriteObject(writer, "attrs", node.Attributes);
+        if (node.Text != null) writer.WriteString("text", node.Text);
+        if (node.Marks.Count > 0) {
+            writer.WritePropertyName("marks");
+            writer.WriteStartArray();
+            foreach (AdfMark mark in node.Marks) WriteMark(writer, mark);
+            writer.WriteEndArray();
+        }
+        if (node.Content.Count > 0) {
+            writer.WritePropertyName("content");
+            writer.WriteStartArray();
+            foreach (AdfNode child in node.Content) WriteNode(writer, child);
+            writer.WriteEndArray();
+        }
+        WriteExtensionProperties(writer, node.ExtensionData, "type", "text", "attrs", "content", "marks");
+        writer.WriteEndObject();
+    }
+
+    private static void WriteMark(Utf8JsonWriter writer, AdfMark mark) {
+        writer.WriteStartObject();
+        writer.WriteString("type", mark.Type);
+        if (mark.Attributes.Count > 0) WriteObject(writer, "attrs", mark.Attributes);
+        WriteExtensionProperties(writer, mark.ExtensionData, "type", "attrs");
+        writer.WriteEndObject();
+    }
+
+    private static void ReadObjectProperties(JsonElement element, IDictionary<string, JsonElement> target, string path) {
+        if (element.ValueKind != JsonValueKind.Object) throw new FormatException(path + " must be an object.");
+        foreach (JsonProperty property in element.EnumerateObject()) target[property.Name] = property.Value.Clone();
+    }
+
+    private static void WriteObject(Utf8JsonWriter writer, string name, IDictionary<string, JsonElement> values) {
+        writer.WritePropertyName(name);
+        writer.WriteStartObject();
+        foreach (KeyValuePair<string, JsonElement> value in values) {
+            writer.WritePropertyName(value.Key);
+            value.Value.WriteTo(writer);
+        }
+        writer.WriteEndObject();
+    }
+
+    private static void CopyExtensionProperties(JsonElement source, IDictionary<string, JsonElement> target, params string[] knownNames) {
+        var known = new HashSet<string>(knownNames, StringComparer.Ordinal);
+        foreach (JsonProperty property in source.EnumerateObject()) {
+            if (!known.Contains(property.Name)) target[property.Name] = property.Value.Clone();
+        }
+    }
+
+    private static void WriteExtensionProperties(Utf8JsonWriter writer, IDictionary<string, JsonElement> values, params string[] knownNames) {
+        var known = new HashSet<string>(knownNames, StringComparer.Ordinal);
+        foreach (KeyValuePair<string, JsonElement> value in values) {
+            if (known.Contains(value.Key)) continue;
+            writer.WritePropertyName(value.Key);
+            value.Value.WriteTo(writer);
+        }
+    }
+
+    private static string ReadRequiredString(JsonElement element, string name, string path) {
+        if (!element.TryGetProperty(name, out JsonElement value) || value.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(value.GetString())) {
+            throw new FormatException(path + "." + name + " must be a non-empty string.");
+        }
+        return value.GetString()!;
+    }
+
+    private static int ReadRequiredInt32(JsonElement element, string name, string path) {
+        if (!element.TryGetProperty(name, out JsonElement value) || value.ValueKind != JsonValueKind.Number || !value.TryGetInt32(out int result)) {
+            throw new FormatException(path + "." + name + " must be an integer.");
+        }
+        return result;
+    }
+}

--- a/OfficeIMO.Adf/AdfToMarkdownConverter.cs
+++ b/OfficeIMO.Adf/AdfToMarkdownConverter.cs
@@ -129,7 +129,7 @@ internal static class AdfToMarkdownConverter {
         builder.Append('|');
         for (int column = 0; column < columns; column++) {
             string value = column < row.Content.Count ? RenderCell(row.Content[column], path + ".content[" + column + "]", diagnostics) : string.Empty;
-            builder.Append(' ').Append(value.Replace("|", "\\|").Replace("\r", " ").Replace("\n", "<br/>")).Append(" |");
+            builder.Append(' ').Append(value.Replace("\r", " ").Replace("\n", "<br/>")).Append(" |");
         }
     }
 

--- a/OfficeIMO.Adf/AdfToMarkdownConverter.cs
+++ b/OfficeIMO.Adf/AdfToMarkdownConverter.cs
@@ -99,7 +99,11 @@ internal static class AdfToMarkdownConverter {
             }
             builder.Append(new string(' ', depth * 2)).Append(marker);
             var itemBody = new StringBuilder();
-            AppendChildrenAsBlocks(itemBody, item, path + ".content[" + i + "]", options, diagnostics, depth + 1);
+            if (item.Type == "taskItem") {
+                itemBody.Append(RenderInlineContent(item, path + ".content[" + i + "]", diagnostics));
+            } else {
+                AppendChildrenAsBlocks(itemBody, item, path + ".content[" + i + "]", options, diagnostics, depth + 1);
+            }
             string[] lines = itemBody.ToString().Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
             if (lines.Length > 0) builder.Append(lines[0]);
             for (int lineIndex = 1; lineIndex < lines.Length; lineIndex++) {
@@ -142,6 +146,9 @@ internal static class AdfToMarkdownConverter {
     private static string RenderCell(AdfNode cell, string path, List<AdfConversionDiagnostic> diagnostics) {
         if (cell.Attributes.Count > 0 || cell.ExtensionData.Count > 0) {
             diagnostics.Add(Warning("ADF_TABLE_CELL_ATTRIBUTES_DROPPED", path, "ADF table-cell attributes cannot be represented in Markdown and were omitted."));
+        }
+        if (cell.Content.Count != 1 || cell.Content[0].Type != "paragraph") {
+            diagnostics.Add(Warning("ADF_TABLE_CELL_BLOCKS_FLATTENED", path, "Markdown table cells reconstruct as one paragraph; the source cell block structure was flattened."));
         }
         var builder = new StringBuilder();
         for (int i = 0; i < cell.Content.Count; i++) {

--- a/OfficeIMO.Adf/AdfToMarkdownConverter.cs
+++ b/OfficeIMO.Adf/AdfToMarkdownConverter.cs
@@ -7,6 +7,9 @@ namespace OfficeIMO.Adf;
 internal static class AdfToMarkdownConverter {
     internal static string Convert(AdfDocument document, AdfConversionOptions options, List<AdfConversionDiagnostic> diagnostics) {
         var builder = new StringBuilder();
+        if (document.ExtensionData.Count > 0) {
+            diagnostics.Add(Warning("ADF_ROOT_PROPERTIES_DROPPED", "$", "ADF root extension properties cannot be represented in Markdown and were omitted."));
+        }
         for (int i = 0; i < document.Content.Count; i++) {
             AppendBlock(builder, document.Content[i], "$.content[" + i + "]", options, diagnostics, 0);
             if (i < document.Content.Count - 1 && !EndsWithBlankLine(builder)) builder.AppendLine().AppendLine();
@@ -32,6 +35,9 @@ internal static class AdfToMarkdownConverter {
                     diagnostics.Add(Warning("ADF_CODE_LANGUAGE_NORMALIZED", path, "ADF code-block language was normalized to one safe Markdown language token."));
                 }
                 string code = ExtractPlainText(node);
+                if (code.IndexOf('\r') >= 0) {
+                    diagnostics.Add(Warning("ADF_CODE_LINE_ENDINGS_NORMALIZED", path, "ADF code-block carriage-return line endings are normalized by Markdown round trips."));
+                }
                 string fence = MarkdownFence.BuildSafeFence(code);
                 builder.Append(fence).Append(language).AppendLine();
                 builder.Append(code);

--- a/OfficeIMO.Adf/AdfToMarkdownConverter.cs
+++ b/OfficeIMO.Adf/AdfToMarkdownConverter.cs
@@ -113,6 +113,9 @@ internal static class AdfToMarkdownConverter {
     }
 
     private static void AppendTable(StringBuilder builder, AdfNode table, string path, List<AdfConversionDiagnostic> diagnostics) {
+        if (table.Attributes.Count > 0 || table.ExtensionData.Count > 0) {
+            diagnostics.Add(Warning("ADF_TABLE_ATTRIBUTES_DROPPED", path, "ADF table attributes cannot be represented in Markdown and were omitted."));
+        }
         var rows = table.Content.Where(node => node.Type == "tableRow").ToList();
         if (rows.Count == 0) return;
         int columns = rows.Max(row => row.Content.Count);

--- a/OfficeIMO.Adf/AdfToMarkdownConverter.cs
+++ b/OfficeIMO.Adf/AdfToMarkdownConverter.cs
@@ -20,11 +20,17 @@ internal static class AdfToMarkdownConverter {
     private static void AppendBlock(StringBuilder builder, AdfNode node, string path, AdfConversionOptions options, List<AdfConversionDiagnostic> diagnostics, int listDepth) {
         switch (node.Type) {
             case "paragraph":
+                if (node.Content.Count == 0) {
+                    diagnostics.Add(Warning("ADF_EMPTY_PARAGRAPH_DROPPED", path, "Markdown cannot preserve an explicit empty ADF paragraph, so the paragraph was omitted."));
+                }
                 builder.Append(RenderInlineContent(node, path, diagnostics));
                 break;
             case "heading":
                 int level = node.GetInt32Attribute("level") ?? 1;
                 level = Math.Max(1, Math.Min(6, level));
+                if (node.ExtensionData.Count > 0 || node.Attributes.Keys.Any(key => !string.Equals(key, "level", StringComparison.Ordinal))) {
+                    diagnostics.Add(Warning("ADF_HEADING_PROPERTIES_DROPPED", path, "ADF heading properties other than level cannot be represented in Markdown and were omitted."));
+                }
                 ReportMultilineHeadingText(node, path, diagnostics);
                 builder.Append(new string('#', level)).Append(' ').Append(RenderInlineContent(node, path, diagnostics));
                 break;
@@ -204,10 +210,32 @@ internal static class AdfToMarkdownConverter {
         if (hasCode && (rawText.IndexOf('\r') >= 0 || rawText.IndexOf('\n') >= 0)) {
             diagnostics.Add(Warning("ADF_CODE_MARK_LINE_BREAK_NORMALIZED", path, "Markdown code spans normalize line breaks to spaces; the original ADF code-mark text cannot be represented exactly."));
         }
+        bool hasDelimiterMark = node.Marks.Any(mark =>
+            string.Equals(mark.Type, "strong", StringComparison.Ordinal) ||
+            string.Equals(mark.Type, "em", StringComparison.Ordinal) ||
+            string.Equals(mark.Type, "strike", StringComparison.Ordinal));
+        int leadingWhitespace = 0;
+        while (leadingWhitespace < rawText.Length && char.IsWhiteSpace(rawText[leadingWhitespace])) leadingWhitespace++;
+        int trailingWhitespace = rawText.Length;
+        while (trailingWhitespace > leadingWhitespace && char.IsWhiteSpace(rawText[trailingWhitespace - 1])) trailingWhitespace--;
+        if (hasDelimiterMark && (leadingWhitespace > 0 || trailingWhitespace < rawText.Length)) {
+            diagnostics.Add(Warning("ADF_MARK_BOUNDARY_WHITESPACE_NORMALIZED", path, "Markdown delimiters cannot preserve boundary whitespace inside an ADF strong, emphasis, or strike mark; the whitespace was moved outside the marked span."));
+            builder.Append(MarkdownEscaper.EscapeLiteralText(rawText.Substring(0, leadingWhitespace)));
+            if (trailingWhitespace > leadingWhitespace) {
+                builder.Append(RenderMarkedText(rawText.Substring(leadingWhitespace, trailingWhitespace - leadingWhitespace), node.Marks, path, diagnostics));
+            }
+            builder.Append(MarkdownEscaper.EscapeLiteralText(rawText.Substring(trailingWhitespace)));
+            return;
+        }
+        builder.Append(RenderMarkedText(rawText, node.Marks, path, diagnostics));
+    }
+
+    private static string RenderMarkedText(string rawText, IEnumerable<AdfMark> marks, string path, List<AdfConversionDiagnostic> diagnostics) {
+        bool hasCode = marks.Any(mark => string.Equals(mark.Type, "code", StringComparison.Ordinal));
         string value = hasCode
             ? MarkdownFence.BuildSafeCodeSpan(rawText)
             : MarkdownEscaper.EscapeLiteralText(rawText);
-        foreach (AdfMark mark in node.Marks.Where(mark => !string.Equals(mark.Type, "code", StringComparison.Ordinal))) {
+        foreach (AdfMark mark in marks.Where(mark => !string.Equals(mark.Type, "code", StringComparison.Ordinal))) {
             switch (mark.Type) {
                 case "strong": value = "**" + value + "**"; break;
                 case "em": value = "*" + value + "*"; break;
@@ -228,7 +256,7 @@ internal static class AdfToMarkdownConverter {
                     break;
             }
         }
-        builder.Append(value);
+        return value;
     }
 
     private static string ExtractPlainText(AdfNode node) {

--- a/OfficeIMO.Adf/AdfToMarkdownConverter.cs
+++ b/OfficeIMO.Adf/AdfToMarkdownConverter.cs
@@ -1,0 +1,186 @@
+using System.IO;
+using System.Text;
+
+namespace OfficeIMO.Adf;
+
+internal static class AdfToMarkdownConverter {
+    internal static string Convert(AdfDocument document, AdfConversionOptions options, List<AdfConversionDiagnostic> diagnostics) {
+        var builder = new StringBuilder();
+        for (int i = 0; i < document.Content.Count; i++) {
+            AppendBlock(builder, document.Content[i], "$.content[" + i + "]", options, diagnostics, 0);
+            if (i < document.Content.Count - 1 && !EndsWithBlankLine(builder)) builder.AppendLine().AppendLine();
+        }
+        return builder.ToString().TrimEnd();
+    }
+
+    private static void AppendBlock(StringBuilder builder, AdfNode node, string path, AdfConversionOptions options, List<AdfConversionDiagnostic> diagnostics, int listDepth) {
+        switch (node.Type) {
+            case "paragraph":
+                builder.Append(RenderInlineContent(node, path, diagnostics));
+                break;
+            case "heading":
+                int level = node.GetInt32Attribute("level") ?? 1;
+                level = Math.Max(1, Math.Min(6, level));
+                builder.Append(new string('#', level)).Append(' ').Append(RenderInlineContent(node, path, diagnostics));
+                break;
+            case "codeBlock":
+                string language = node.GetStringAttribute("language") ?? string.Empty;
+                builder.Append("```").Append(language).AppendLine();
+                builder.Append(ExtractPlainText(node));
+                if (builder.Length > 0 && builder[builder.Length - 1] != '\n') builder.AppendLine();
+                builder.Append("```");
+                break;
+            case "blockquote":
+                var quote = new StringBuilder();
+                AppendChildrenAsBlocks(quote, node, path, options, diagnostics, listDepth);
+                using (var reader = new StringReader(quote.ToString())) {
+                    string? line;
+                    bool first = true;
+                    while ((line = reader.ReadLine()) != null) {
+                        if (!first) builder.AppendLine();
+                        builder.Append("> ").Append(line);
+                        first = false;
+                    }
+                }
+                break;
+            case "bulletList":
+            case "orderedList":
+            case "taskList":
+                AppendList(builder, node, path, options, diagnostics, listDepth);
+                break;
+            case "rule":
+                builder.Append("---");
+                break;
+            case "table":
+                AppendTable(builder, node, path, diagnostics);
+                break;
+            case "panel":
+                diagnostics.Add(Warning("ADF_PANEL_PROJECTED", path, "ADF panel styling is projected as a blockquote."));
+                var panel = new StringBuilder();
+                AppendChildrenAsBlocks(panel, node, path, options, diagnostics, listDepth);
+                foreach (string line in panel.ToString().Split(new[] { "\r\n", "\n" }, StringSplitOptions.None)) {
+                    if (builder.Length > 0 && builder[builder.Length - 1] != '\n') builder.AppendLine();
+                    builder.Append("> ").Append(line);
+                }
+                break;
+            default:
+                diagnostics.Add(Warning("ADF_UNSUPPORTED_NODE", path, "ADF node '" + node.Type + "' is retained in the ADF model but has no exact Markdown projection."));
+                if (node.Content.Count > 0) AppendChildrenAsBlocks(builder, node, path, options, diagnostics, listDepth);
+                else if (!string.IsNullOrEmpty(node.Text)) builder.Append(EscapeText(node.Text!));
+                else if (options.EmitUnsupportedPlaceholders) builder.Append("[Unsupported ADF node: ").Append(node.Type).Append(']');
+                break;
+        }
+    }
+
+    private static void AppendChildrenAsBlocks(StringBuilder builder, AdfNode node, string path, AdfConversionOptions options, List<AdfConversionDiagnostic> diagnostics, int listDepth) {
+        for (int i = 0; i < node.Content.Count; i++) {
+            if (i > 0) builder.AppendLine().AppendLine();
+            AppendBlock(builder, node.Content[i], path + ".content[" + i + "]", options, diagnostics, listDepth);
+        }
+    }
+
+    private static void AppendList(StringBuilder builder, AdfNode list, string path, AdfConversionOptions options, List<AdfConversionDiagnostic> diagnostics, int depth) {
+        int order = list.GetInt32Attribute("order") ?? 1;
+        for (int i = 0; i < list.Content.Count; i++) {
+            AdfNode item = list.Content[i];
+            if (i > 0) builder.AppendLine();
+            string marker = list.Type == "orderedList" ? (order + i).ToString(System.Globalization.CultureInfo.InvariantCulture) + ". " : "- ";
+            if (item.Type == "taskItem") {
+                bool done = item.Attributes.TryGetValue("state", out var state) && string.Equals(state.GetString(), "DONE", StringComparison.OrdinalIgnoreCase);
+                marker += done ? "[x] " : "[ ] ";
+            }
+            builder.Append(new string(' ', depth * 2)).Append(marker);
+            var itemBody = new StringBuilder();
+            AppendChildrenAsBlocks(itemBody, item, path + ".content[" + i + "]", options, diagnostics, depth + 1);
+            string[] lines = itemBody.ToString().Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+            if (lines.Length > 0) builder.Append(lines[0]);
+            for (int lineIndex = 1; lineIndex < lines.Length; lineIndex++) {
+                builder.AppendLine().Append(new string(' ', depth * 2 + marker.Length)).Append(lines[lineIndex]);
+            }
+        }
+    }
+
+    private static void AppendTable(StringBuilder builder, AdfNode table, string path, List<AdfConversionDiagnostic> diagnostics) {
+        var rows = table.Content.Where(node => node.Type == "tableRow").ToList();
+        if (rows.Count == 0) return;
+        int columns = rows.Max(row => row.Content.Count);
+        if (columns == 0) return;
+
+        bool hasHeader = rows[0].Content.Any(cell => cell.Type == "tableHeader");
+        if (!hasHeader) diagnostics.Add(Warning("ADF_TABLE_HEADER_SYNTHESIZED", path, "Markdown requires a header row; the first ADF row was used as the header."));
+        AppendTableRow(builder, rows[0], columns, path + ".content[0]", diagnostics);
+        builder.AppendLine();
+        builder.Append('|');
+        for (int column = 0; column < columns; column++) builder.Append(" --- |");
+        for (int row = 1; row < rows.Count; row++) {
+            builder.AppendLine();
+            AppendTableRow(builder, rows[row], columns, path + ".content[" + row + "]", diagnostics);
+        }
+    }
+
+    private static void AppendTableRow(StringBuilder builder, AdfNode row, int columns, string path, List<AdfConversionDiagnostic> diagnostics) {
+        builder.Append('|');
+        for (int column = 0; column < columns; column++) {
+            string value = column < row.Content.Count ? RenderCell(row.Content[column], path + ".content[" + column + "]", diagnostics) : string.Empty;
+            builder.Append(' ').Append(value.Replace("|", "\\|").Replace("\r", " ").Replace("\n", "<br/>")).Append(" |");
+        }
+    }
+
+    private static string RenderCell(AdfNode cell, string path, List<AdfConversionDiagnostic> diagnostics) {
+        var builder = new StringBuilder();
+        for (int i = 0; i < cell.Content.Count; i++) {
+            if (i > 0) builder.Append("<br/>");
+            builder.Append(RenderInlineContent(cell.Content[i], path + ".content[" + i + "]", diagnostics));
+        }
+        return builder.ToString();
+    }
+
+    private static string RenderInlineContent(AdfNode node, string path, List<AdfConversionDiagnostic> diagnostics) {
+        var builder = new StringBuilder();
+        for (int i = 0; i < node.Content.Count; i++) AppendInline(builder, node.Content[i], path + ".content[" + i + "]", diagnostics);
+        return builder.ToString();
+    }
+
+    private static void AppendInline(StringBuilder builder, AdfNode node, string path, List<AdfConversionDiagnostic> diagnostics) {
+        if (node.Type == "hardBreak") {
+            builder.Append("  \n");
+            return;
+        }
+        if (node.Type != "text") {
+            diagnostics.Add(Warning("ADF_UNSUPPORTED_INLINE", path, "ADF inline node '" + node.Type + "' was flattened to text."));
+            builder.Append(EscapeText(ExtractPlainText(node)));
+            return;
+        }
+
+        string value = EscapeText(node.Text ?? string.Empty);
+        foreach (AdfMark mark in node.Marks) {
+            switch (mark.Type) {
+                case "strong": value = "**" + value + "**"; break;
+                case "em": value = "*" + value + "*"; break;
+                case "strike": value = "~~" + value + "~~"; break;
+                case "code": value = "`" + (node.Text ?? string.Empty).Replace("`", "\\`") + "`"; break;
+                case "link":
+                    string? href = mark.GetStringAttribute("href");
+                    value = string.IsNullOrWhiteSpace(href) ? value : "[" + value + "](" + href!.Replace(")", "\\)") + ")";
+                    break;
+                default:
+                    diagnostics.Add(Warning("ADF_UNSUPPORTED_MARK", path, "ADF mark '" + mark.Type + "' was flattened."));
+                    break;
+            }
+        }
+        builder.Append(value);
+    }
+
+    private static string ExtractPlainText(AdfNode node) {
+        if (node.Type == "text") return node.Text ?? string.Empty;
+        var builder = new StringBuilder();
+        foreach (AdfNode child in node.Content) builder.Append(ExtractPlainText(child));
+        return builder.ToString();
+    }
+
+    private static string EscapeText(string value) => (value ?? string.Empty)
+        .Replace("\\", "\\\\").Replace("*", "\\*").Replace("_", "\\_").Replace("[", "\\[").Replace("]", "\\]");
+
+    private static bool EndsWithBlankLine(StringBuilder builder) => builder.Length >= 2 && builder[builder.Length - 1] == '\n' && builder[builder.Length - 2] == '\n';
+    private static AdfConversionDiagnostic Warning(string code, string path, string message) => new AdfConversionDiagnostic(code, path, message, AdfConversionSeverity.Warning);
+}

--- a/OfficeIMO.Adf/AdfToMarkdownConverter.cs
+++ b/OfficeIMO.Adf/AdfToMarkdownConverter.cs
@@ -134,6 +134,9 @@ internal static class AdfToMarkdownConverter {
     }
 
     private static string RenderCell(AdfNode cell, string path, List<AdfConversionDiagnostic> diagnostics) {
+        if (cell.Attributes.Count > 0 || cell.ExtensionData.Count > 0) {
+            diagnostics.Add(Warning("ADF_TABLE_CELL_ATTRIBUTES_DROPPED", path, "ADF table-cell attributes cannot be represented in Markdown and were omitted."));
+        }
         var builder = new StringBuilder();
         for (int i = 0; i < cell.Content.Count; i++) {
             if (i > 0) builder.Append("<br/>");

--- a/OfficeIMO.Adf/AdfToMarkdownConverter.cs
+++ b/OfficeIMO.Adf/AdfToMarkdownConverter.cs
@@ -104,6 +104,14 @@ internal static class AdfToMarkdownConverter {
 
     private static void AppendList(StringBuilder builder, AdfNode list, string path, AdfConversionOptions options, List<AdfConversionDiagnostic> diagnostics, int depth) {
         int order = list.GetInt32Attribute("order") ?? 1;
+        if (list.Type == "taskList" &&
+            (!string.IsNullOrWhiteSpace(list.GetStringAttribute("localId")) ||
+             list.Content.Any(item => item.Type == "taskItem" && !string.IsNullOrWhiteSpace(item.GetStringAttribute("localId"))))) {
+            diagnostics.Add(Warning(
+                "ADF_TASK_LOCAL_IDS_REGENERATED",
+                path,
+                "Markdown has no task identity syntax; taskList and taskItem localId attributes were omitted and will be regenerated when Markdown is imported."));
+        }
         for (int i = 0; i < list.Content.Count; i++) {
             AdfNode item = list.Content[i];
             if (i > 0) builder.AppendLine();

--- a/OfficeIMO.Adf/AdfToMarkdownConverter.cs
+++ b/OfficeIMO.Adf/AdfToMarkdownConverter.cs
@@ -161,7 +161,16 @@ internal static class AdfToMarkdownConverter {
                 case "code": value = "`" + (node.Text ?? string.Empty).Replace("`", "\\`") + "`"; break;
                 case "link":
                     string? href = mark.GetStringAttribute("href");
-                    value = string.IsNullOrWhiteSpace(href) ? value : "[" + value + "](" + href!.Replace(")", "\\)") + ")";
+                    string? title = mark.GetStringAttribute("title");
+                    if (mark.Attributes.Keys.Any(key => !string.Equals(key, "href", StringComparison.Ordinal) && !string.Equals(key, "title", StringComparison.Ordinal)) || mark.ExtensionData.Count > 0) {
+                        diagnostics.Add(Warning("ADF_LINK_ATTRIBUTES_DROPPED", path, "ADF link attributes other than href and title cannot be represented in Markdown."));
+                    }
+                    if (!string.IsNullOrWhiteSpace(href)) {
+                        string renderedTitle = string.IsNullOrEmpty(title)
+                            ? string.Empty
+                            : " \"" + title!.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
+                        value = "[" + value + "](" + href!.Replace(")", "\\)") + renderedTitle + ")";
+                    }
                     break;
                 default:
                     diagnostics.Add(Warning("ADF_UNSUPPORTED_MARK", path, "ADF mark '" + mark.Type + "' was flattened."));

--- a/OfficeIMO.Adf/AdfToMarkdownConverter.cs
+++ b/OfficeIMO.Adf/AdfToMarkdownConverter.cs
@@ -31,6 +31,9 @@ internal static class AdfToMarkdownConverter {
             case "codeBlock":
                 string rawLanguage = node.GetStringAttribute("language") ?? string.Empty;
                 string language = MarkdownFence.NormalizeLanguageToken(rawLanguage);
+                if (node.ExtensionData.Count > 0 || node.Attributes.Keys.Any(key => !string.Equals(key, "language", StringComparison.Ordinal))) {
+                    diagnostics.Add(Warning("ADF_CODE_PROPERTIES_DROPPED", path, "ADF code-block properties other than language cannot be represented in Markdown and were omitted."));
+                }
                 if (!string.Equals(language, rawLanguage, StringComparison.Ordinal)) {
                     diagnostics.Add(Warning("ADF_CODE_LANGUAGE_NORMALIZED", path, "ADF code-block language was normalized to one safe Markdown language token."));
                 }

--- a/OfficeIMO.Adf/AdfToMarkdownConverter.cs
+++ b/OfficeIMO.Adf/AdfToMarkdownConverter.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Text;
+using OfficeIMO.Markdown;
 
 namespace OfficeIMO.Adf;
 
@@ -25,10 +26,12 @@ internal static class AdfToMarkdownConverter {
                 break;
             case "codeBlock":
                 string language = node.GetStringAttribute("language") ?? string.Empty;
-                builder.Append("```").Append(language).AppendLine();
-                builder.Append(ExtractPlainText(node));
+                string code = ExtractPlainText(node);
+                string fence = MarkdownFence.BuildSafeFence(code);
+                builder.Append(fence).Append(language).AppendLine();
+                builder.Append(code);
                 if (builder.Length > 0 && builder[builder.Length - 1] != '\n') builder.AppendLine();
-                builder.Append("```");
+                builder.Append(fence);
                 break;
             case "blockquote":
                 var quote = new StringBuilder();
@@ -66,7 +69,7 @@ internal static class AdfToMarkdownConverter {
             default:
                 diagnostics.Add(Warning("ADF_UNSUPPORTED_NODE", path, "ADF node '" + node.Type + "' is retained in the ADF model but has no exact Markdown projection."));
                 if (node.Content.Count > 0) AppendChildrenAsBlocks(builder, node, path, options, diagnostics, listDepth);
-                else if (!string.IsNullOrEmpty(node.Text)) builder.Append(EscapeText(node.Text!));
+                else if (!string.IsNullOrEmpty(node.Text)) builder.Append(MarkdownEscaper.EscapeTextAndLineStarts(node.Text!));
                 else if (options.EmitUnsupportedPlaceholders) builder.Append("[Unsupported ADF node: ").Append(node.Type).Append(']');
                 break;
         }
@@ -148,17 +151,20 @@ internal static class AdfToMarkdownConverter {
         }
         if (node.Type != "text") {
             diagnostics.Add(Warning("ADF_UNSUPPORTED_INLINE", path, "ADF inline node '" + node.Type + "' was flattened to text."));
-            builder.Append(EscapeText(ExtractPlainText(node)));
+            builder.Append(MarkdownEscaper.EscapeTextAndLineStarts(ExtractPlainText(node)));
             return;
         }
 
-        string value = EscapeText(node.Text ?? string.Empty);
-        foreach (AdfMark mark in node.Marks) {
+        string rawText = node.Text ?? string.Empty;
+        bool hasCode = node.Marks.Any(mark => string.Equals(mark.Type, "code", StringComparison.Ordinal));
+        string value = hasCode
+            ? MarkdownFence.BuildSafeCodeSpan(rawText)
+            : MarkdownEscaper.EscapeTextAndLineStarts(rawText);
+        foreach (AdfMark mark in node.Marks.Where(mark => !string.Equals(mark.Type, "code", StringComparison.Ordinal))) {
             switch (mark.Type) {
                 case "strong": value = "**" + value + "**"; break;
                 case "em": value = "*" + value + "*"; break;
                 case "strike": value = "~~" + value + "~~"; break;
-                case "code": value = "`" + (node.Text ?? string.Empty).Replace("`", "\\`") + "`"; break;
                 case "link":
                     string? href = mark.GetStringAttribute("href");
                     string? title = mark.GetStringAttribute("title");
@@ -166,9 +172,7 @@ internal static class AdfToMarkdownConverter {
                         diagnostics.Add(Warning("ADF_LINK_ATTRIBUTES_DROPPED", path, "ADF link attributes other than href and title cannot be represented in Markdown."));
                     }
                     if (!string.IsNullOrWhiteSpace(href)) {
-                        string renderedTitle = string.IsNullOrEmpty(title)
-                            ? string.Empty
-                            : " \"" + title!.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
+                        string renderedTitle = MarkdownEscaper.FormatOptionalTitle(title);
                         value = "[" + value + "](" + href!.Replace(")", "\\)") + renderedTitle + ")";
                     }
                     break;
@@ -186,9 +190,6 @@ internal static class AdfToMarkdownConverter {
         foreach (AdfNode child in node.Content) builder.Append(ExtractPlainText(child));
         return builder.ToString();
     }
-
-    private static string EscapeText(string value) => (value ?? string.Empty)
-        .Replace("\\", "\\\\").Replace("*", "\\*").Replace("_", "\\_").Replace("[", "\\[").Replace("]", "\\]");
 
     private static bool EndsWithBlankLine(StringBuilder builder) => builder.Length >= 2 && builder[builder.Length - 1] == '\n' && builder[builder.Length - 2] == '\n';
     private static AdfConversionDiagnostic Warning(string code, string path, string message) => new AdfConversionDiagnostic(code, path, message, AdfConversionSeverity.Warning);

--- a/OfficeIMO.Adf/AdfToMarkdownConverter.cs
+++ b/OfficeIMO.Adf/AdfToMarkdownConverter.cs
@@ -22,6 +22,7 @@ internal static class AdfToMarkdownConverter {
             case "heading":
                 int level = node.GetInt32Attribute("level") ?? 1;
                 level = Math.Max(1, Math.Min(6, level));
+                ReportMultilineHeadingText(node, path, diagnostics);
                 builder.Append(new string('#', level)).Append(' ').Append(RenderInlineContent(node, path, diagnostics));
                 break;
             case "codeBlock":
@@ -114,7 +115,12 @@ internal static class AdfToMarkdownConverter {
         if (columns == 0) return;
 
         bool hasHeader = rows[0].Content.Any(cell => cell.Type == "tableHeader");
+        bool hasMixedFirstRow = hasHeader && rows[0].Content.Any(cell => cell.Type != "tableHeader");
+        bool hasHeaderAfterFirstRow = rows.Skip(1).Any(row => row.Content.Any(cell => cell.Type == "tableHeader"));
         if (!hasHeader) diagnostics.Add(Warning("ADF_TABLE_HEADER_SYNTHESIZED", path, "Markdown requires a header row; the first ADF row was used as the header."));
+        if (hasMixedFirstRow || hasHeaderAfterFirstRow) {
+            diagnostics.Add(Warning("ADF_TABLE_HEADER_LAYOUT_NORMALIZED", path, "Markdown supports only one all-header first row; source table header cell types were normalized."));
+        }
         AppendTableRow(builder, rows[0], columns, path + ".content[0]", diagnostics);
         builder.AppendLine();
         builder.Append('|');
@@ -149,6 +155,18 @@ internal static class AdfToMarkdownConverter {
         var builder = new StringBuilder();
         for (int i = 0; i < node.Content.Count; i++) AppendInline(builder, node.Content[i], path + ".content[" + i + "]", diagnostics);
         return builder.ToString();
+    }
+
+    private static void ReportMultilineHeadingText(AdfNode heading, string path, List<AdfConversionDiagnostic> diagnostics) {
+        for (int i = 0; i < heading.Content.Count; i++) {
+            AdfNode child = heading.Content[i];
+            if (child.Type == "text" && child.Text != null && (child.Text.IndexOf('\r') >= 0 || child.Text.IndexOf('\n') >= 0)) {
+                diagnostics.Add(Warning(
+                    "ADF_HEADING_LINE_BREAK_NORMALIZED",
+                    path + ".content[" + i + "]",
+                    "Markdown headings cannot preserve line endings inside one ADF text node; the projected heading structure is lossy."));
+            }
+        }
     }
 
     private static void AppendInline(StringBuilder builder, AdfNode node, string path, List<AdfConversionDiagnostic> diagnostics) {

--- a/OfficeIMO.Adf/AdfToMarkdownConverter.cs
+++ b/OfficeIMO.Adf/AdfToMarkdownConverter.cs
@@ -11,7 +11,7 @@ internal static class AdfToMarkdownConverter {
             AppendBlock(builder, document.Content[i], "$.content[" + i + "]", options, diagnostics, 0);
             if (i < document.Content.Count - 1 && !EndsWithBlankLine(builder)) builder.AppendLine().AppendLine();
         }
-        return builder.ToString().TrimEnd();
+        return builder.ToString();
     }
 
     private static void AppendBlock(StringBuilder builder, AdfNode node, string path, AdfConversionOptions options, List<AdfConversionDiagnostic> diagnostics, int listDepth) {
@@ -25,7 +25,11 @@ internal static class AdfToMarkdownConverter {
                 builder.Append(new string('#', level)).Append(' ').Append(RenderInlineContent(node, path, diagnostics));
                 break;
             case "codeBlock":
-                string language = node.GetStringAttribute("language") ?? string.Empty;
+                string rawLanguage = node.GetStringAttribute("language") ?? string.Empty;
+                string language = MarkdownFence.NormalizeLanguageToken(rawLanguage);
+                if (!string.Equals(language, rawLanguage, StringComparison.Ordinal)) {
+                    diagnostics.Add(Warning("ADF_CODE_LANGUAGE_NORMALIZED", path, "ADF code-block language was normalized to one safe Markdown language token."));
+                }
                 string code = ExtractPlainText(node);
                 string fence = MarkdownFence.BuildSafeFence(code);
                 builder.Append(fence).Append(language).AppendLine();
@@ -69,7 +73,7 @@ internal static class AdfToMarkdownConverter {
             default:
                 diagnostics.Add(Warning("ADF_UNSUPPORTED_NODE", path, "ADF node '" + node.Type + "' is retained in the ADF model but has no exact Markdown projection."));
                 if (node.Content.Count > 0) AppendChildrenAsBlocks(builder, node, path, options, diagnostics, listDepth);
-                else if (!string.IsNullOrEmpty(node.Text)) builder.Append(MarkdownEscaper.EscapeTextAndLineStarts(node.Text!));
+                else if (!string.IsNullOrEmpty(node.Text)) builder.Append(MarkdownEscaper.EscapeLiteralText(node.Text!));
                 else if (options.EmitUnsupportedPlaceholders) builder.Append("[Unsupported ADF node: ").Append(node.Type).Append(']');
                 break;
         }
@@ -146,20 +150,23 @@ internal static class AdfToMarkdownConverter {
 
     private static void AppendInline(StringBuilder builder, AdfNode node, string path, List<AdfConversionDiagnostic> diagnostics) {
         if (node.Type == "hardBreak") {
-            builder.Append("  \n");
+            builder.Append("<br />");
             return;
         }
         if (node.Type != "text") {
             diagnostics.Add(Warning("ADF_UNSUPPORTED_INLINE", path, "ADF inline node '" + node.Type + "' was flattened to text."));
-            builder.Append(MarkdownEscaper.EscapeTextAndLineStarts(ExtractPlainText(node)));
+            builder.Append(MarkdownEscaper.EscapeLiteralText(ExtractPlainText(node)));
             return;
         }
 
         string rawText = node.Text ?? string.Empty;
         bool hasCode = node.Marks.Any(mark => string.Equals(mark.Type, "code", StringComparison.Ordinal));
+        if (hasCode && (rawText.IndexOf('\r') >= 0 || rawText.IndexOf('\n') >= 0)) {
+            diagnostics.Add(Warning("ADF_CODE_MARK_LINE_BREAK_NORMALIZED", path, "Markdown code spans normalize line breaks to spaces; the original ADF code-mark text cannot be represented exactly."));
+        }
         string value = hasCode
             ? MarkdownFence.BuildSafeCodeSpan(rawText)
-            : MarkdownEscaper.EscapeTextAndLineStarts(rawText);
+            : MarkdownEscaper.EscapeLiteralText(rawText);
         foreach (AdfMark mark in node.Marks.Where(mark => !string.Equals(mark.Type, "code", StringComparison.Ordinal))) {
             switch (mark.Type) {
                 case "strong": value = "**" + value + "**"; break;

--- a/OfficeIMO.Adf/AdfToMarkdownConverter.cs
+++ b/OfficeIMO.Adf/AdfToMarkdownConverter.cs
@@ -180,7 +180,7 @@ internal static class AdfToMarkdownConverter {
                     }
                     if (!string.IsNullOrWhiteSpace(href)) {
                         string renderedTitle = MarkdownEscaper.FormatOptionalTitle(title);
-                        value = "[" + value + "](" + href!.Replace(")", "\\)") + renderedTitle + ")";
+                        value = "[" + value + "](" + MarkdownEscaper.EscapeLinkUrl(href) + renderedTitle + ")";
                     }
                     break;
                 default:

--- a/OfficeIMO.Adf/AdfValidation.cs
+++ b/OfficeIMO.Adf/AdfValidation.cs
@@ -37,6 +37,12 @@ internal static class AdfValidator {
         "inlineCard", "blockCard", "extension", "inlineExtension", "bodiedExtension", "panel",
     };
 
+    private static readonly HashSet<string> RootBlockNodes = new HashSet<string>(StringComparer.Ordinal) {
+        "paragraph", "heading", "rule", "blockquote", "codeBlock", "bulletList", "orderedList",
+        "taskList", "table", "mediaSingle", "mediaGroup", "blockCard", "extension",
+        "bodiedExtension", "panel",
+    };
+
     private static readonly HashSet<string> KnownMarks = new HashSet<string>(StringComparer.Ordinal) {
         "strong", "em", "code", "strike", "link", "subsup", "textColor", "backgroundColor", "annotation",
     };
@@ -46,7 +52,14 @@ internal static class AdfValidator {
         var issues = new List<AdfValidationIssue>();
         if (document.Version != 1) issues.Add(Error("ADF_VERSION", "$.version", "Only ADF version 1 is supported."));
         if (!string.Equals(document.Type, "doc", StringComparison.Ordinal)) issues.Add(Error("ADF_ROOT_TYPE", "$.type", "ADF root type must be 'doc'."));
-        for (int i = 0; i < document.Content.Count; i++) ValidateNode(document.Content[i], "$.content[" + i + "]", null, issues);
+        for (int i = 0; i < document.Content.Count; i++) {
+            AdfNode node = document.Content[i];
+            string path = "$.content[" + i + "]";
+            if (node != null && KnownNodes.Contains(node.Type) && !RootBlockNodes.Contains(node.Type)) {
+                issues.Add(Error("ADF_ROOT_CHILD", path, "ADF document content may contain only block nodes."));
+            }
+            ValidateNode(node, path, null, issues);
+        }
         return new AdfValidationResult(issues);
     }
 

--- a/OfficeIMO.Adf/AdfValidation.cs
+++ b/OfficeIMO.Adf/AdfValidation.cs
@@ -113,6 +113,12 @@ internal static class AdfValidator {
         if (string.Equals(node.Type, "taskItem", StringComparison.Ordinal) && !string.Equals(parentType, "taskList", StringComparison.Ordinal)) {
             issues.Add(Error("ADF_TASK_ITEM_PARENT", path, "ADF taskItem nodes require a taskList parent."));
         }
+        if (string.Equals(node.Type, "heading", StringComparison.Ordinal)) {
+            int? level = node.GetInt32Attribute("level");
+            if (!level.HasValue || level.Value < 1 || level.Value > 6) {
+                issues.Add(Error("ADF_HEADING_LEVEL", path + ".attrs.level", "ADF heading nodes require an integer level from 1 through 6."));
+            }
+        }
         for (int i = 0; i < node.Marks.Count; i++) {
             AdfMark mark = node.Marks[i];
             if (mark == null || string.IsNullOrWhiteSpace(mark.Type)) issues.Add(Error("ADF_MARK_TYPE", path + ".marks[" + i + "]", "ADF mark type is required."));

--- a/OfficeIMO.Adf/AdfValidation.cs
+++ b/OfficeIMO.Adf/AdfValidation.cs
@@ -104,7 +104,16 @@ internal static class AdfValidator {
         }
         if (string.IsNullOrWhiteSpace(node.Type)) issues.Add(Error("ADF_NODE_TYPE", path + ".type", "ADF node type is required."));
         else if (!KnownNodes.Contains(node.Type)) issues.Add(Warning("ADF_UNKNOWN_NODE", path, "Unknown ADF node '" + node.Type + "' is retained but may be projected with reduced fidelity."));
-        if (string.Equals(node.Type, "text", StringComparison.Ordinal) && node.Text == null) issues.Add(Error("ADF_TEXT_REQUIRED", path + ".text", "ADF text nodes require a text value."));
+        bool isKnownNode = KnownNodes.Contains(node.Type);
+        bool isTextNode = string.Equals(node.Type, "text", StringComparison.Ordinal);
+        if (isTextNode && string.IsNullOrEmpty(node.Text)) {
+            issues.Add(Error("ADF_TEXT_REQUIRED", path + ".text", "ADF text nodes require a non-empty text value."));
+        } else if (isKnownNode && !isTextNode && node.Text != null) {
+            issues.Add(Error("ADF_TEXT_NOT_ALLOWED", path + ".text", "ADF text payloads are allowed only on text nodes."));
+        }
+        if (isKnownNode && !isTextNode && node.Marks.Count > 0) {
+            issues.Add(Error("ADF_MARKS_NOT_ALLOWED", path + ".marks", "ADF marks are allowed only on text nodes."));
+        }
         if (string.Equals(node.Type, "listItem", StringComparison.Ordinal) &&
             !string.Equals(parentType, "bulletList", StringComparison.Ordinal) &&
             !string.Equals(parentType, "orderedList", StringComparison.Ordinal)) {
@@ -117,6 +126,17 @@ internal static class AdfValidator {
             int? level = node.GetInt32Attribute("level");
             if (!level.HasValue || level.Value < 1 || level.Value > 6) {
                 issues.Add(Error("ADF_HEADING_LEVEL", path + ".attrs.level", "ADF heading nodes require an integer level from 1 through 6."));
+            }
+        }
+        if (string.Equals(node.Type, "taskList", StringComparison.Ordinal) || string.Equals(node.Type, "taskItem", StringComparison.Ordinal)) {
+            if (string.IsNullOrWhiteSpace(node.GetStringAttribute("localId"))) {
+                issues.Add(Error("ADF_TASK_LOCAL_ID", path + ".attrs.localId", "ADF taskList and taskItem nodes require a non-empty string localId attribute."));
+            }
+        }
+        if (string.Equals(node.Type, "taskItem", StringComparison.Ordinal)) {
+            string? state = node.GetStringAttribute("state");
+            if (!string.Equals(state, "TODO", StringComparison.Ordinal) && !string.Equals(state, "DONE", StringComparison.Ordinal)) {
+                issues.Add(Error("ADF_TASK_STATE", path + ".attrs.state", "ADF taskItem state must be 'TODO' or 'DONE'."));
             }
         }
         for (int i = 0; i < node.Marks.Count; i++) {

--- a/OfficeIMO.Adf/AdfValidation.cs
+++ b/OfficeIMO.Adf/AdfValidation.cs
@@ -114,6 +114,9 @@ internal static class AdfValidator {
         if (isKnownNode && !isTextNode && node.Marks.Count > 0) {
             issues.Add(Error("ADF_MARKS_NOT_ALLOWED", path + ".marks", "ADF marks are allowed only on text nodes."));
         }
+        if (isTextNode && string.Equals(parentType, "codeBlock", StringComparison.Ordinal) && node.Marks.Count > 0) {
+            issues.Add(Error("ADF_CODE_MARKS_NOT_ALLOWED", path + ".marks", "ADF code-block text cannot contain marks."));
+        }
         if (string.Equals(node.Type, "listItem", StringComparison.Ordinal) &&
             !string.Equals(parentType, "bulletList", StringComparison.Ordinal) &&
             !string.Equals(parentType, "orderedList", StringComparison.Ordinal)) {

--- a/OfficeIMO.Adf/AdfValidation.cs
+++ b/OfficeIMO.Adf/AdfValidation.cs
@@ -43,6 +43,40 @@ internal static class AdfValidator {
         "bodiedExtension", "panel",
     };
 
+    private static readonly HashSet<string> InlineNodes = Nodes(
+        "text", "hardBreak", "mention", "emoji", "inlineCard", "inlineExtension");
+
+    // Relationships for node types this library recognizes follow Atlassian's full ADF schema.
+    // Unknown node types stay warning-only so newer vendor nodes can still round-trip.
+    private static readonly IReadOnlyDictionary<string, HashSet<string>> AllowedKnownChildren =
+        new Dictionary<string, HashSet<string>>(StringComparer.Ordinal) {
+            ["paragraph"] = InlineNodes,
+            ["heading"] = InlineNodes,
+            ["codeBlock"] = Nodes("text"),
+            ["blockquote"] = Nodes("paragraph", "orderedList", "bulletList", "codeBlock", "mediaSingle", "mediaGroup", "extension"),
+            ["bulletList"] = Nodes("listItem"),
+            ["orderedList"] = Nodes("listItem"),
+            ["listItem"] = Nodes("paragraph", "bulletList", "orderedList", "taskList", "mediaSingle", "codeBlock", "extension"),
+            ["taskList"] = Nodes("taskItem", "taskList"),
+            ["taskItem"] = InlineNodes,
+            ["table"] = Nodes("tableRow"),
+            ["tableRow"] = Nodes("tableCell", "tableHeader"),
+            ["tableCell"] = Nodes(
+                "paragraph", "panel", "blockquote", "orderedList", "bulletList", "rule", "heading",
+                "codeBlock", "mediaSingle", "mediaGroup", "taskList", "blockCard", "extension"),
+            ["tableHeader"] = Nodes(
+                "paragraph", "panel", "blockquote", "orderedList", "bulletList", "rule", "heading",
+                "codeBlock", "mediaSingle", "mediaGroup", "taskList", "blockCard", "extension"),
+            ["mediaSingle"] = Nodes("media"),
+            ["mediaGroup"] = Nodes("media"),
+            ["panel"] = Nodes(
+                "paragraph", "heading", "bulletList", "orderedList", "blockCard", "mediaGroup",
+                "mediaSingle", "codeBlock", "taskList", "rule", "extension"),
+            ["bodiedExtension"] = Nodes(
+                "paragraph", "panel", "blockquote", "orderedList", "bulletList", "rule", "heading",
+                "codeBlock", "mediaGroup", "mediaSingle", "taskList", "table", "blockCard", "extension"),
+        };
+
     private static readonly HashSet<string> KnownMarks = new HashSet<string>(StringComparer.Ordinal) {
         "strong", "em", "code", "strike", "link", "subsup", "textColor", "backgroundColor", "annotation",
     };
@@ -83,19 +117,32 @@ internal static class AdfValidator {
             AdfMark mark = node.Marks[i];
             if (mark == null || string.IsNullOrWhiteSpace(mark.Type)) issues.Add(Error("ADF_MARK_TYPE", path + ".marks[" + i + "]", "ADF mark type is required."));
             else if (!KnownMarks.Contains(mark.Type)) issues.Add(Warning("ADF_UNKNOWN_MARK", path + ".marks[" + i + "]", "Unknown ADF mark '" + mark.Type + "' is retained but may be projected with reduced fidelity."));
+            if (mark != null && string.Equals(mark.Type, "link", StringComparison.Ordinal) && mark.GetStringAttribute("href") == null) {
+                issues.Add(Error("ADF_LINK_HREF_REQUIRED", path + ".marks[" + i + "].attrs.href", "ADF link marks require a string href attribute."));
+            }
         }
         for (int i = 0; i < node.Content.Count; i++) {
             AdfNode child = node.Content[i];
-            if ((string.Equals(node.Type, "bulletList", StringComparison.Ordinal) || string.Equals(node.Type, "orderedList", StringComparison.Ordinal)) &&
-                !string.Equals(child.Type, "listItem", StringComparison.Ordinal)) {
-                issues.Add(Error("ADF_LIST_CHILD", path + ".content[" + i + "]", "ADF bulletList and orderedList nodes may contain only listItem nodes."));
-            }
-            if (string.Equals(node.Type, "taskList", StringComparison.Ordinal) && !string.Equals(child.Type, "taskItem", StringComparison.Ordinal)) {
-                issues.Add(Error("ADF_TASK_LIST_CHILD", path + ".content[" + i + "]", "ADF taskList nodes may contain only taskItem nodes."));
-            }
-            ValidateNode(child, path + ".content[" + i + "]", node.Type, issues);
+            string childPath = path + ".content[" + i + "]";
+            ValidateKnownChild(node, child, childPath, issues);
+            ValidateNode(child, childPath, node.Type, issues);
         }
     }
+
+    private static void ValidateKnownChild(AdfNode parent, AdfNode child, string path, List<AdfValidationIssue> issues) {
+        if (!KnownNodes.Contains(parent.Type) || !KnownNodes.Contains(child.Type)) return;
+        if (AllowedKnownChildren.TryGetValue(parent.Type, out HashSet<string>? allowed) && allowed.Contains(child.Type)) return;
+
+        if (string.Equals(parent.Type, "bulletList", StringComparison.Ordinal) || string.Equals(parent.Type, "orderedList", StringComparison.Ordinal)) {
+            issues.Add(Error("ADF_LIST_CHILD", path, "ADF bulletList and orderedList nodes may contain only listItem nodes."));
+        } else if (string.Equals(parent.Type, "taskList", StringComparison.Ordinal)) {
+            issues.Add(Error("ADF_TASK_LIST_CHILD", path, "ADF taskList nodes may contain only taskItem or nested taskList nodes."));
+        } else {
+            issues.Add(Error("ADF_NODE_CHILD", path, "ADF node '" + parent.Type + "' cannot contain known child node '" + child.Type + "'."));
+        }
+    }
+
+    private static HashSet<string> Nodes(params string[] nodeTypes) => new HashSet<string>(nodeTypes, StringComparer.Ordinal);
 
     private static AdfValidationIssue Error(string code, string path, string message) => new AdfValidationIssue(code, path, message, AdfValidationSeverity.Error);
     private static AdfValidationIssue Warning(string code, string path, string message) => new AdfValidationIssue(code, path, message, AdfValidationSeverity.Warning);

--- a/OfficeIMO.Adf/AdfValidation.cs
+++ b/OfficeIMO.Adf/AdfValidation.cs
@@ -46,11 +46,11 @@ internal static class AdfValidator {
         var issues = new List<AdfValidationIssue>();
         if (document.Version != 1) issues.Add(Error("ADF_VERSION", "$.version", "Only ADF version 1 is supported."));
         if (!string.Equals(document.Type, "doc", StringComparison.Ordinal)) issues.Add(Error("ADF_ROOT_TYPE", "$.type", "ADF root type must be 'doc'."));
-        for (int i = 0; i < document.Content.Count; i++) ValidateNode(document.Content[i], "$.content[" + i + "]", issues);
+        for (int i = 0; i < document.Content.Count; i++) ValidateNode(document.Content[i], "$.content[" + i + "]", null, issues);
         return new AdfValidationResult(issues);
     }
 
-    private static void ValidateNode(AdfNode? node, string path, List<AdfValidationIssue> issues) {
+    private static void ValidateNode(AdfNode? node, string path, string? parentType, List<AdfValidationIssue> issues) {
         if (node == null) {
             issues.Add(Error("ADF_NULL_NODE", path, "ADF content cannot contain null nodes."));
             return;
@@ -58,12 +58,30 @@ internal static class AdfValidator {
         if (string.IsNullOrWhiteSpace(node.Type)) issues.Add(Error("ADF_NODE_TYPE", path + ".type", "ADF node type is required."));
         else if (!KnownNodes.Contains(node.Type)) issues.Add(Warning("ADF_UNKNOWN_NODE", path, "Unknown ADF node '" + node.Type + "' is retained but may be projected with reduced fidelity."));
         if (string.Equals(node.Type, "text", StringComparison.Ordinal) && node.Text == null) issues.Add(Error("ADF_TEXT_REQUIRED", path + ".text", "ADF text nodes require a text value."));
+        if (string.Equals(node.Type, "listItem", StringComparison.Ordinal) &&
+            !string.Equals(parentType, "bulletList", StringComparison.Ordinal) &&
+            !string.Equals(parentType, "orderedList", StringComparison.Ordinal)) {
+            issues.Add(Error("ADF_LIST_ITEM_PARENT", path, "ADF listItem nodes require a bulletList or orderedList parent."));
+        }
+        if (string.Equals(node.Type, "taskItem", StringComparison.Ordinal) && !string.Equals(parentType, "taskList", StringComparison.Ordinal)) {
+            issues.Add(Error("ADF_TASK_ITEM_PARENT", path, "ADF taskItem nodes require a taskList parent."));
+        }
         for (int i = 0; i < node.Marks.Count; i++) {
             AdfMark mark = node.Marks[i];
             if (mark == null || string.IsNullOrWhiteSpace(mark.Type)) issues.Add(Error("ADF_MARK_TYPE", path + ".marks[" + i + "]", "ADF mark type is required."));
             else if (!KnownMarks.Contains(mark.Type)) issues.Add(Warning("ADF_UNKNOWN_MARK", path + ".marks[" + i + "]", "Unknown ADF mark '" + mark.Type + "' is retained but may be projected with reduced fidelity."));
         }
-        for (int i = 0; i < node.Content.Count; i++) ValidateNode(node.Content[i], path + ".content[" + i + "]", issues);
+        for (int i = 0; i < node.Content.Count; i++) {
+            AdfNode child = node.Content[i];
+            if ((string.Equals(node.Type, "bulletList", StringComparison.Ordinal) || string.Equals(node.Type, "orderedList", StringComparison.Ordinal)) &&
+                !string.Equals(child.Type, "listItem", StringComparison.Ordinal)) {
+                issues.Add(Error("ADF_LIST_CHILD", path + ".content[" + i + "]", "ADF bulletList and orderedList nodes may contain only listItem nodes."));
+            }
+            if (string.Equals(node.Type, "taskList", StringComparison.Ordinal) && !string.Equals(child.Type, "taskItem", StringComparison.Ordinal)) {
+                issues.Add(Error("ADF_TASK_LIST_CHILD", path + ".content[" + i + "]", "ADF taskList nodes may contain only taskItem nodes."));
+            }
+            ValidateNode(child, path + ".content[" + i + "]", node.Type, issues);
+        }
     }
 
     private static AdfValidationIssue Error(string code, string path, string message) => new AdfValidationIssue(code, path, message, AdfValidationSeverity.Error);

--- a/OfficeIMO.Adf/AdfValidation.cs
+++ b/OfficeIMO.Adf/AdfValidation.cs
@@ -122,6 +122,9 @@ internal static class AdfValidator {
             !string.Equals(parentType, "orderedList", StringComparison.Ordinal)) {
             issues.Add(Error("ADF_LIST_ITEM_PARENT", path, "ADF listItem nodes require a bulletList or orderedList parent."));
         }
+        if (string.Equals(node.Type, "listItem", StringComparison.Ordinal) && node.Content.Count == 0) {
+            issues.Add(Error("ADF_LIST_ITEM_CONTENT_REQUIRED", path + ".content", "ADF listItem nodes require at least one content node."));
+        }
         if (string.Equals(node.Type, "taskItem", StringComparison.Ordinal) && !string.Equals(parentType, "taskList", StringComparison.Ordinal)) {
             issues.Add(Error("ADF_TASK_ITEM_PARENT", path, "ADF taskItem nodes require a taskList parent."));
         }
@@ -144,6 +147,9 @@ internal static class AdfValidator {
         }
         if (string.Equals(node.Type, "media", StringComparison.Ordinal)) {
             ValidateMediaAttributes(node, path, issues);
+        }
+        if (string.Equals(node.Type, "inlineCard", StringComparison.Ordinal)) {
+            ValidateInlineCardAttributes(node, path, issues);
         }
         for (int i = 0; i < node.Marks.Count; i++) {
             AdfMark mark = node.Marks[i];
@@ -195,6 +201,20 @@ internal static class AdfValidator {
         }
         if (node.GetStringAttribute("collection") == null) {
             issues.Add(Error("ADF_MEDIA_COLLECTION", path + ".attrs.collection", "File and link ADF media require a string collection attribute."));
+        }
+    }
+
+    private static void ValidateInlineCardAttributes(AdfNode node, string path, List<AdfValidationIssue> issues) {
+        bool hasUrl = node.Attributes.TryGetValue("url", out System.Text.Json.JsonElement url);
+        bool hasData = node.Attributes.TryGetValue("data", out System.Text.Json.JsonElement data);
+        bool hasValidUrl = hasUrl && url.ValueKind == System.Text.Json.JsonValueKind.String && !string.IsNullOrWhiteSpace(url.GetString());
+        bool hasValidData = hasData && data.ValueKind == System.Text.Json.JsonValueKind.Object;
+
+        if ((hasValidUrl == hasValidData) || (hasUrl && hasData)) {
+            issues.Add(Error(
+                "ADF_INLINE_CARD_TARGET",
+                path + ".attrs",
+                "ADF inlineCard nodes require exactly one target: a non-empty string url or an object data attribute."));
         }
     }
 

--- a/OfficeIMO.Adf/AdfValidation.cs
+++ b/OfficeIMO.Adf/AdfValidation.cs
@@ -148,9 +148,9 @@ internal static class AdfValidator {
             }
         }
         for (int i = 0; i < node.Content.Count; i++) {
-            AdfNode child = node.Content[i];
+            AdfNode? child = node.Content[i];
             string childPath = path + ".content[" + i + "]";
-            ValidateKnownChild(node, child, childPath, issues);
+            if (child != null) ValidateKnownChild(node, child, childPath, issues);
             ValidateNode(child, childPath, node.Type, issues);
         }
     }

--- a/OfficeIMO.Adf/AdfValidation.cs
+++ b/OfficeIMO.Adf/AdfValidation.cs
@@ -1,0 +1,71 @@
+namespace OfficeIMO.Adf;
+
+/// <summary>Severity of an ADF validation issue.</summary>
+public enum AdfValidationSeverity {
+    Information,
+    Warning,
+    Error,
+}
+
+/// <summary>A structural ADF validation issue.</summary>
+public sealed class AdfValidationIssue {
+    internal AdfValidationIssue(string code, string path, string message, AdfValidationSeverity severity) {
+        Code = code;
+        Path = path;
+        Message = message;
+        Severity = severity;
+    }
+
+    public string Code { get; }
+    public string Path { get; }
+    public string Message { get; }
+    public AdfValidationSeverity Severity { get; }
+}
+
+/// <summary>Result of validating an ADF document.</summary>
+public sealed class AdfValidationResult {
+    internal AdfValidationResult(IReadOnlyList<AdfValidationIssue> issues) => Issues = issues;
+    public IReadOnlyList<AdfValidationIssue> Issues { get; }
+    public bool IsValid => !Issues.Any(issue => issue.Severity == AdfValidationSeverity.Error);
+}
+
+internal static class AdfValidator {
+    private static readonly HashSet<string> KnownNodes = new HashSet<string>(StringComparer.Ordinal) {
+        "doc", "paragraph", "heading", "text", "hardBreak", "rule", "blockquote", "codeBlock",
+        "bulletList", "orderedList", "listItem", "taskList", "taskItem", "table", "tableRow",
+        "tableHeader", "tableCell", "media", "mediaSingle", "mediaGroup", "mention", "emoji",
+        "inlineCard", "blockCard", "extension", "inlineExtension", "bodiedExtension", "panel",
+    };
+
+    private static readonly HashSet<string> KnownMarks = new HashSet<string>(StringComparer.Ordinal) {
+        "strong", "em", "code", "strike", "link", "subsup", "textColor", "backgroundColor", "annotation",
+    };
+
+    internal static AdfValidationResult Validate(AdfDocument document) {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+        var issues = new List<AdfValidationIssue>();
+        if (document.Version != 1) issues.Add(Error("ADF_VERSION", "$.version", "Only ADF version 1 is supported."));
+        if (!string.Equals(document.Type, "doc", StringComparison.Ordinal)) issues.Add(Error("ADF_ROOT_TYPE", "$.type", "ADF root type must be 'doc'."));
+        for (int i = 0; i < document.Content.Count; i++) ValidateNode(document.Content[i], "$.content[" + i + "]", issues);
+        return new AdfValidationResult(issues);
+    }
+
+    private static void ValidateNode(AdfNode? node, string path, List<AdfValidationIssue> issues) {
+        if (node == null) {
+            issues.Add(Error("ADF_NULL_NODE", path, "ADF content cannot contain null nodes."));
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(node.Type)) issues.Add(Error("ADF_NODE_TYPE", path + ".type", "ADF node type is required."));
+        else if (!KnownNodes.Contains(node.Type)) issues.Add(Warning("ADF_UNKNOWN_NODE", path, "Unknown ADF node '" + node.Type + "' is retained but may be projected with reduced fidelity."));
+        if (string.Equals(node.Type, "text", StringComparison.Ordinal) && node.Text == null) issues.Add(Error("ADF_TEXT_REQUIRED", path + ".text", "ADF text nodes require a text value."));
+        for (int i = 0; i < node.Marks.Count; i++) {
+            AdfMark mark = node.Marks[i];
+            if (mark == null || string.IsNullOrWhiteSpace(mark.Type)) issues.Add(Error("ADF_MARK_TYPE", path + ".marks[" + i + "]", "ADF mark type is required."));
+            else if (!KnownMarks.Contains(mark.Type)) issues.Add(Warning("ADF_UNKNOWN_MARK", path + ".marks[" + i + "]", "Unknown ADF mark '" + mark.Type + "' is retained but may be projected with reduced fidelity."));
+        }
+        for (int i = 0; i < node.Content.Count; i++) ValidateNode(node.Content[i], path + ".content[" + i + "]", issues);
+    }
+
+    private static AdfValidationIssue Error(string code, string path, string message) => new AdfValidationIssue(code, path, message, AdfValidationSeverity.Error);
+    private static AdfValidationIssue Warning(string code, string path, string message) => new AdfValidationIssue(code, path, message, AdfValidationSeverity.Warning);
+}

--- a/OfficeIMO.Adf/AdfValidation.cs
+++ b/OfficeIMO.Adf/AdfValidation.cs
@@ -143,8 +143,8 @@ internal static class AdfValidator {
             AdfMark mark = node.Marks[i];
             if (mark == null || string.IsNullOrWhiteSpace(mark.Type)) issues.Add(Error("ADF_MARK_TYPE", path + ".marks[" + i + "]", "ADF mark type is required."));
             else if (!KnownMarks.Contains(mark.Type)) issues.Add(Warning("ADF_UNKNOWN_MARK", path + ".marks[" + i + "]", "Unknown ADF mark '" + mark.Type + "' is retained but may be projected with reduced fidelity."));
-            if (mark != null && string.Equals(mark.Type, "link", StringComparison.Ordinal) && mark.GetStringAttribute("href") == null) {
-                issues.Add(Error("ADF_LINK_HREF_REQUIRED", path + ".marks[" + i + "].attrs.href", "ADF link marks require a string href attribute."));
+            if (mark != null && string.Equals(mark.Type, "link", StringComparison.Ordinal) && string.IsNullOrWhiteSpace(mark.GetStringAttribute("href"))) {
+                issues.Add(Error("ADF_LINK_HREF_REQUIRED", path + ".marks[" + i + "].attrs.href", "ADF link marks require a non-empty string href attribute."));
             }
         }
         for (int i = 0; i < node.Content.Count; i++) {

--- a/OfficeIMO.Adf/AdfValidation.cs
+++ b/OfficeIMO.Adf/AdfValidation.cs
@@ -139,6 +139,9 @@ internal static class AdfValidator {
                 issues.Add(Error("ADF_TASK_STATE", path + ".attrs.state", "ADF taskItem state must be 'TODO' or 'DONE'."));
             }
         }
+        if (string.Equals(node.Type, "media", StringComparison.Ordinal)) {
+            ValidateMediaAttributes(node, path, issues);
+        }
         for (int i = 0; i < node.Marks.Count; i++) {
             AdfMark mark = node.Marks[i];
             if (mark == null || string.IsNullOrWhiteSpace(mark.Type)) issues.Add(Error("ADF_MARK_TYPE", path + ".marks[" + i + "]", "ADF mark type is required."));
@@ -165,6 +168,30 @@ internal static class AdfValidator {
             issues.Add(Error("ADF_TASK_LIST_CHILD", path, "ADF taskList nodes may contain only taskItem or nested taskList nodes."));
         } else {
             issues.Add(Error("ADF_NODE_CHILD", path, "ADF node '" + parent.Type + "' cannot contain known child node '" + child.Type + "'."));
+        }
+    }
+
+    private static void ValidateMediaAttributes(AdfNode node, string path, List<AdfValidationIssue> issues) {
+        string? mediaType = node.GetStringAttribute("type");
+        if (!string.Equals(mediaType, "file", StringComparison.Ordinal) &&
+            !string.Equals(mediaType, "link", StringComparison.Ordinal) &&
+            !string.Equals(mediaType, "external", StringComparison.Ordinal)) {
+            issues.Add(Error("ADF_MEDIA_TYPE", path + ".attrs.type", "ADF media type must be 'file', 'link', or 'external'."));
+            return;
+        }
+
+        if (string.Equals(mediaType, "external", StringComparison.Ordinal)) {
+            if (node.GetStringAttribute("url") == null) {
+                issues.Add(Error("ADF_MEDIA_URL", path + ".attrs.url", "External ADF media requires a string url attribute."));
+            }
+            return;
+        }
+
+        if (string.IsNullOrEmpty(node.GetStringAttribute("id"))) {
+            issues.Add(Error("ADF_MEDIA_ID", path + ".attrs.id", "File and link ADF media require a non-empty string id attribute."));
+        }
+        if (node.GetStringAttribute("collection") == null) {
+            issues.Add(Error("ADF_MEDIA_COLLECTION", path + ".attrs.collection", "File and link ADF media require a string collection attribute."));
         }
     }
 

--- a/OfficeIMO.Adf/MarkdownToAdfConverter.cs
+++ b/OfficeIMO.Adf/MarkdownToAdfConverter.cs
@@ -32,6 +32,7 @@ internal static class MarkdownToAdfConverter {
                 }
                 return quoteNode;
             case UnorderedListBlock unordered:
+                if (CanConvertTaskList(unordered.Items)) return ConvertTaskList(unordered.Items, path, diagnostics);
                 return ConvertList("bulletList", unordered.Items, path, diagnostics, 1);
             case OrderedListBlock ordered:
                 return ConvertList("orderedList", ordered.Items, path, diagnostics, ordered.Start);
@@ -70,6 +71,22 @@ internal static class MarkdownToAdfConverter {
                 item.Content.Add(WithInlines(new AdfNode("paragraph"), paragraph, path + ".items[" + i + "]", diagnostics));
             }
             AddBlocks(item, sourceItem.NestedBlocks, path + ".items[" + i + "].nested", diagnostics);
+            list.Content.Add(item);
+        }
+        return list;
+    }
+
+    private static bool CanConvertTaskList(IReadOnlyList<ListItem> items) =>
+        items.Count > 0 && items.All(item => item.IsTask && item.AdditionalParagraphs.Count == 0 && item.NestedBlocks.Count == 0);
+
+    private static AdfNode ConvertTaskList(IReadOnlyList<ListItem> items, string path, List<AdfConversionDiagnostic> diagnostics) {
+        var list = new AdfNode("taskList").SetAttribute("localId", Guid.NewGuid().ToString("D"));
+        for (int i = 0; i < items.Count; i++) {
+            ListItem sourceItem = items[i];
+            var item = new AdfNode("taskItem")
+                .SetAttribute("localId", Guid.NewGuid().ToString("D"))
+                .SetAttribute("state", sourceItem.Checked ? "DONE" : "TODO");
+            WithInlines(item, sourceItem.Content, path + ".items[" + i + "]", diagnostics);
             list.Content.Add(item);
         }
         return list;

--- a/OfficeIMO.Adf/MarkdownToAdfConverter.cs
+++ b/OfficeIMO.Adf/MarkdownToAdfConverter.cs
@@ -56,9 +56,16 @@ internal static class MarkdownToAdfConverter {
         if (type == "orderedList" && order != 1) list.SetAttribute("order", order);
         for (int i = 0; i < items.Count; i++) {
             ListItem sourceItem = items[i];
-            var item = new AdfNode(sourceItem.IsTask ? "taskItem" : "listItem");
-            if (sourceItem.IsTask) item.SetAttribute("state", sourceItem.Checked ? "DONE" : "TODO");
-            item.Content.Add(WithInlines(new AdfNode("paragraph"), sourceItem.Content, path + ".items[" + i + "]", diagnostics));
+            var item = new AdfNode("listItem");
+            AdfNode listParagraph = WithInlines(new AdfNode("paragraph"), sourceItem.Content, path + ".items[" + i + "]", diagnostics);
+            if (sourceItem.IsTask) {
+                listParagraph.Content.Insert(0, AdfNode.TextNode(sourceItem.Checked ? "[x] " : "[ ] "));
+                diagnostics.Add(Warning(
+                    "MARKDOWN_TASK_LIST_FALLBACK",
+                    path + ".items[" + i + "]",
+                    "Markdown task state is preserved as a visible marker because ADF taskItem nodes require a taskList parent."));
+            }
+            item.Content.Add(listParagraph);
             foreach (InlineSequence paragraph in sourceItem.AdditionalParagraphs) {
                 item.Content.Add(WithInlines(new AdfNode("paragraph"), paragraph, path + ".items[" + i + "]", diagnostics));
             }

--- a/OfficeIMO.Adf/MarkdownToAdfConverter.cs
+++ b/OfficeIMO.Adf/MarkdownToAdfConverter.cs
@@ -112,6 +112,9 @@ internal static class MarkdownToAdfConverter {
                 case TextRun text:
                     target.Add(AdfNode.TextNode(text.Text, CloneMarks(inheritedMarks)));
                     break;
+                case ILiteralTextMarkdownInline literalText:
+                    target.Add(AdfNode.TextNode(literalText.Text, CloneMarks(inheritedMarks)));
+                    break;
                 case BoldInline bold:
                     target.Add(AdfNode.TextNode(bold.Text, AddMark(inheritedMarks, new AdfMark("strong"))));
                     break;

--- a/OfficeIMO.Adf/MarkdownToAdfConverter.cs
+++ b/OfficeIMO.Adf/MarkdownToAdfConverter.cs
@@ -149,8 +149,10 @@ internal static class MarkdownToAdfConverter {
                     else target.Add(AdfNode.TextNode(link.Text, AddMark(inheritedMarks, linkMark)));
                     break;
                 case HardBreakInline:
-                case SoftBreakInline:
                     target.Add(new AdfNode("hardBreak"));
+                    break;
+                case SoftBreakInline:
+                    target.Add(AdfNode.TextNode("\n"));
                     break;
                 default:
                     diagnostics.Add(Warning("MARKDOWN_UNSUPPORTED_INLINE", inlinePath, "Markdown inline '" + inline.GetType().Name + "' has no exact ADF mapping and was omitted."));

--- a/OfficeIMO.Adf/MarkdownToAdfConverter.cs
+++ b/OfficeIMO.Adf/MarkdownToAdfConverter.cs
@@ -1,0 +1,177 @@
+using OfficeIMO.Markdown;
+
+namespace OfficeIMO.Adf;
+
+internal static class MarkdownToAdfConverter {
+    internal static AdfDocument Convert(MarkdownDoc source, List<AdfConversionDiagnostic> diagnostics) {
+        var document = new AdfDocument();
+        for (int i = 0; i < source.Blocks.Count; i++) {
+            AdfNode? node = ConvertBlock(source.Blocks[i], "$.blocks[" + i + "]", diagnostics);
+            if (node != null) document.Content.Add(node);
+        }
+        return document;
+    }
+
+    private static AdfNode? ConvertBlock(IMarkdownBlock block, string path, List<AdfConversionDiagnostic> diagnostics) {
+        switch (block) {
+            case ParagraphBlock paragraph:
+                return WithInlines(new AdfNode("paragraph"), paragraph.Inlines, path, diagnostics);
+            case HeadingBlock heading:
+                return WithInlines(new AdfNode("heading").SetAttribute("level", heading.Level), heading.Inlines, path, diagnostics);
+            case CodeBlock code:
+                var codeNode = new AdfNode("codeBlock");
+                if (!string.IsNullOrWhiteSpace(code.Language)) codeNode.SetAttribute("language", code.Language);
+                codeNode.Content.Add(AdfNode.TextNode(code.Content));
+                return codeNode;
+            case QuoteBlock quote:
+                var quoteNode = new AdfNode("blockquote");
+                if (quote.ChildBlocks.Count > 0) {
+                    AddBlocks(quoteNode, quote.ChildBlocks, path + ".children", diagnostics);
+                } else {
+                    foreach (string line in quote.Lines) quoteNode.Content.Add(new AdfNode("paragraph") { Content = { AdfNode.TextNode(line) } });
+                }
+                return quoteNode;
+            case UnorderedListBlock unordered:
+                return ConvertList("bulletList", unordered.Items, path, diagnostics, 1);
+            case OrderedListBlock ordered:
+                return ConvertList("orderedList", ordered.Items, path, diagnostics, ordered.Start);
+            case HorizontalRuleBlock:
+                return new AdfNode("rule");
+            case TableBlock table:
+                return ConvertTable(table, path, diagnostics);
+            case HtmlRawBlock raw:
+                diagnostics.Add(Warning("MARKDOWN_RAW_HTML", path, "Raw HTML has no exact ADF mapping and was retained as an extension node."));
+                return new AdfNode("extension")
+                    .SetAttribute("extensionType", "com.officeimo.raw-html")
+                    .SetAttribute("extensionKey", "raw-html")
+                    .SetAttribute("parameters", new { html = raw.Html });
+            default:
+                diagnostics.Add(Warning("MARKDOWN_UNSUPPORTED_BLOCK", path, "Markdown block '" + block.GetType().Name + "' has no exact ADF mapping and was omitted."));
+                return null;
+        }
+    }
+
+    private static AdfNode ConvertList(string type, IReadOnlyList<ListItem> items, string path, List<AdfConversionDiagnostic> diagnostics, int order) {
+        var list = new AdfNode(type);
+        if (type == "orderedList" && order != 1) list.SetAttribute("order", order);
+        for (int i = 0; i < items.Count; i++) {
+            ListItem sourceItem = items[i];
+            var item = new AdfNode(sourceItem.IsTask ? "taskItem" : "listItem");
+            if (sourceItem.IsTask) item.SetAttribute("state", sourceItem.Checked ? "DONE" : "TODO");
+            item.Content.Add(WithInlines(new AdfNode("paragraph"), sourceItem.Content, path + ".items[" + i + "]", diagnostics));
+            foreach (InlineSequence paragraph in sourceItem.AdditionalParagraphs) {
+                item.Content.Add(WithInlines(new AdfNode("paragraph"), paragraph, path + ".items[" + i + "]", diagnostics));
+            }
+            AddBlocks(item, sourceItem.NestedBlocks, path + ".items[" + i + "].nested", diagnostics);
+            list.Content.Add(item);
+        }
+        return list;
+    }
+
+    private static AdfNode ConvertTable(TableBlock table, string path, List<AdfConversionDiagnostic> diagnostics) {
+        var result = new AdfNode("table");
+        if (table.HeaderInlines.Count > 0) {
+            var header = new AdfNode("tableRow");
+            for (int column = 0; column < table.HeaderInlines.Count; column++) {
+                var cell = new AdfNode("tableHeader");
+                cell.Content.Add(WithInlines(new AdfNode("paragraph"), table.HeaderInlines[column], path + ".header[" + column + "]", diagnostics));
+                header.Content.Add(cell);
+            }
+            result.Content.Add(header);
+        }
+
+        for (int row = 0; row < table.RowInlines.Count; row++) {
+            var rowNode = new AdfNode("tableRow");
+            for (int column = 0; column < table.RowInlines[row].Count; column++) {
+                var cell = new AdfNode("tableCell");
+                cell.Content.Add(WithInlines(new AdfNode("paragraph"), table.RowInlines[row][column], path + ".rows[" + row + "][" + column + "]", diagnostics));
+                rowNode.Content.Add(cell);
+            }
+            result.Content.Add(rowNode);
+        }
+        return result;
+    }
+
+    private static AdfNode WithInlines(AdfNode target, InlineSequence sequence, string path, List<AdfConversionDiagnostic> diagnostics) {
+        AppendInlines(target.Content, sequence, Array.Empty<AdfMark>(), path, diagnostics);
+        return target;
+    }
+
+    private static void AppendInlines(List<AdfNode> target, InlineSequence sequence, IReadOnlyList<AdfMark> inheritedMarks, string path, List<AdfConversionDiagnostic> diagnostics) {
+        for (int i = 0; i < sequence.Nodes.Count; i++) {
+            IMarkdownInline inline = sequence.Nodes[i];
+            string inlinePath = path + ".inlines[" + i + "]";
+            switch (inline) {
+                case TextRun text:
+                    target.Add(AdfNode.TextNode(text.Text, CloneMarks(inheritedMarks)));
+                    break;
+                case BoldInline bold:
+                    target.Add(AdfNode.TextNode(bold.Text, AddMark(inheritedMarks, new AdfMark("strong"))));
+                    break;
+                case ItalicInline italic:
+                    target.Add(AdfNode.TextNode(italic.Text, AddMark(inheritedMarks, new AdfMark("em"))));
+                    break;
+                case BoldItalicInline boldItalic:
+                    target.Add(AdfNode.TextNode(boldItalic.Text, AddMark(AddMark(inheritedMarks, new AdfMark("strong")), new AdfMark("em"))));
+                    break;
+                case StrikethroughInline strike:
+                    target.Add(AdfNode.TextNode(strike.Text, AddMark(inheritedMarks, new AdfMark("strike"))));
+                    break;
+                case CodeSpanInline code:
+                    target.Add(AdfNode.TextNode(code.Text, AddMark(inheritedMarks, new AdfMark("code"))));
+                    break;
+                case BoldSequenceInline boldSequence:
+                    AppendInlines(target, boldSequence.Inlines, AddMark(inheritedMarks, new AdfMark("strong")), inlinePath, diagnostics);
+                    break;
+                case ItalicSequenceInline italicSequence:
+                    AppendInlines(target, italicSequence.Inlines, AddMark(inheritedMarks, new AdfMark("em")), inlinePath, diagnostics);
+                    break;
+                case BoldItalicSequenceInline boldItalicSequence:
+                    AppendInlines(target, boldItalicSequence.Inlines, AddMark(AddMark(inheritedMarks, new AdfMark("strong")), new AdfMark("em")), inlinePath, diagnostics);
+                    break;
+                case StrikethroughSequenceInline strikeSequence:
+                    AppendInlines(target, strikeSequence.Inlines, AddMark(inheritedMarks, new AdfMark("strike")), inlinePath, diagnostics);
+                    break;
+                case LinkInline link:
+                    var linkMark = new AdfMark("link").SetAttribute("href", link.Url);
+                    if (!string.IsNullOrWhiteSpace(link.Title)) linkMark.SetAttribute("title", link.Title);
+                    if (link.LabelInlines != null) AppendInlines(target, link.LabelInlines, AddMark(inheritedMarks, linkMark), inlinePath, diagnostics);
+                    else target.Add(AdfNode.TextNode(link.Text, AddMark(inheritedMarks, linkMark)));
+                    break;
+                case HardBreakInline:
+                case SoftBreakInline:
+                    target.Add(new AdfNode("hardBreak"));
+                    break;
+                default:
+                    diagnostics.Add(Warning("MARKDOWN_UNSUPPORTED_INLINE", inlinePath, "Markdown inline '" + inline.GetType().Name + "' has no exact ADF mapping and was omitted."));
+                    break;
+            }
+        }
+    }
+
+    private static IReadOnlyList<AdfMark> AddMark(IReadOnlyList<AdfMark> marks, AdfMark added) {
+        var result = CloneMarks(marks).ToList();
+        result.Add(added);
+        return result;
+    }
+
+    private static IReadOnlyList<AdfMark> CloneMarks(IReadOnlyList<AdfMark> marks) {
+        var result = new List<AdfMark>(marks.Count);
+        foreach (AdfMark source in marks) {
+            var copy = new AdfMark(source.Type);
+            foreach (var attribute in source.Attributes) copy.Attributes[attribute.Key] = attribute.Value.Clone();
+            foreach (var extension in source.ExtensionData) copy.ExtensionData[extension.Key] = extension.Value.Clone();
+            result.Add(copy);
+        }
+        return result;
+    }
+
+    private static void AddBlocks(AdfNode target, IReadOnlyList<IMarkdownBlock> blocks, string path, List<AdfConversionDiagnostic> diagnostics) {
+        for (int i = 0; i < blocks.Count; i++) {
+            AdfNode? converted = ConvertBlock(blocks[i], path + "[" + i + "]", diagnostics);
+            if (converted != null) target.Content.Add(converted);
+        }
+    }
+
+    private static AdfConversionDiagnostic Warning(string code, string path, string message) => new AdfConversionDiagnostic(code, path, message, AdfConversionSeverity.Warning);
+}

--- a/OfficeIMO.Adf/MarkdownToAdfConverter.cs
+++ b/OfficeIMO.Adf/MarkdownToAdfConverter.cs
@@ -21,7 +21,7 @@ internal static class MarkdownToAdfConverter {
             case CodeBlock code:
                 var codeNode = new AdfNode("codeBlock");
                 if (!string.IsNullOrWhiteSpace(code.Language)) codeNode.SetAttribute("language", code.Language);
-                codeNode.Content.Add(AdfNode.TextNode(code.Content));
+                if (!string.IsNullOrEmpty(code.Content)) codeNode.Content.Add(AdfNode.TextNode(code.Content));
                 return codeNode;
             case QuoteBlock quote:
                 var quoteNode = new AdfNode("blockquote");

--- a/OfficeIMO.Adf/OfficeIMO.Adf.csproj
+++ b/OfficeIMO.Adf/OfficeIMO.Adf.csproj
@@ -1,0 +1,48 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Atlas Document Format model and OfficeIMO conversion support.</Description>
+    <AssemblyName>OfficeIMO.Adf</AssemblyName>
+    <AssemblyTitle>OfficeIMO.Adf</AssemblyTitle>
+    <VersionPrefix>3.0.0</VersionPrefix>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <Company>Evotec</Company>
+    <Authors>Przemyslaw Klys</Authors>
+    <PackageId>OfficeIMO.Adf</PackageId>
+    <PackageTags>atlassian;adf;confluence;markdown;html;officeimo;net472;net8.0;net10.0</PackageTags>
+    <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <IsPublishable>True</IsPublishable>
+    <PackageIcon>OfficeIMO.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryUrl>https://github.com/EvotecIT/OfficeIMO</RepositoryUrl>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <LangVersion>Latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="True" PackagePath="\" />
+    <None Include="..\Assets\OfficeIMO.png" Pack="True" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OfficeIMO.Html\OfficeIMO.Html.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Markdown\OfficeIMO.Markdown.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Markdown.Html\OfficeIMO.Markdown.Html.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472'">
+    <PackageReference Include="System.Text.Json" Version="[10.0.7,11.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.Linq" />
+  </ItemGroup>
+
+</Project>

--- a/OfficeIMO.Adf/README.md
+++ b/OfficeIMO.Adf/README.md
@@ -11,3 +11,5 @@ AdfConversionResult<AdfDocument> fromMarkdown = AdfConverter.FromMarkdown("# Sta
 ```
 
 Unknown ADF nodes, marks, attributes, and extension properties remain in the parsed model and survive JSON round trips. A projection to Markdown or HTML reports unsupported constructs through `AdfConversionReport` instead of silently claiming full fidelity.
+
+Structural validation enforces list and task-list parent/child contracts. Markdown task markers inside ordinary bullet or ordered lists remain visible text and produce a fidelity warning rather than generating invalid ADF hierarchy.

--- a/OfficeIMO.Adf/README.md
+++ b/OfficeIMO.Adf/README.md
@@ -1,0 +1,13 @@
+# OfficeIMO.Adf
+
+`OfficeIMO.Adf` provides a dependency-light Atlas Document Format model plus conversions through OfficeIMO's Markdown and HTML engines.
+
+```csharp
+AdfDocument document = AdfDocument.Parse(adfJson);
+AdfConversionResult<string> markdown = AdfConverter.ToMarkdown(document);
+AdfConversionResult<string> html = AdfConverter.ToHtml(document);
+
+AdfConversionResult<AdfDocument> fromMarkdown = AdfConverter.FromMarkdown("# Status\n\nReady.");
+```
+
+Unknown ADF nodes, marks, attributes, and extension properties remain in the parsed model and survive JSON round trips. A projection to Markdown or HTML reports unsupported constructs through `AdfConversionReport` instead of silently claiming full fidelity.

--- a/OfficeIMO.Confluence.Tests/ConfluenceContractTests.cs
+++ b/OfficeIMO.Confluence.Tests/ConfluenceContractTests.cs
@@ -184,7 +184,7 @@ public sealed class ConfluenceContractTests {
     [Fact]
     public async Task AttachmentUpload_UsesMultipartAndXsrfHeader() {
         var handler = new RecordingHandler(request => {
-            Assert.Equal(HttpMethod.Put, request.Method);
+            Assert.Equal(HttpMethod.Post, request.Method);
             Assert.True(request.Headers.Contains("X-Atlassian-Token"));
             Assert.NotNull(request.Content);
             Assert.StartsWith("multipart/form-data", request.Content!.Headers.ContentType!.MediaType);
@@ -239,6 +239,28 @@ public sealed class ConfluenceContractTests {
         Assert.Equal("download-ready", Encoding.UTF8.GetString(destination.ToArray()));
     }
 
+    [Fact]
+    public async Task AttachmentDownload_RetryDoesNotAppendToPartialDestination() {
+        int attempt = 0;
+        var handler = new RecordingHandler(_ => ++attempt == 1
+            ? new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new StreamContent(new PartialReadFailureStream(Encoding.UTF8.GetBytes("partial"))),
+            }
+            : new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new ByteArrayContent(Encoding.UTF8.GetBytes("complete")),
+            });
+        using ConfluenceClient client = CreateClient(handler, configure: options => {
+            options.RetryBaseDelay = TimeSpan.Zero;
+            options.RetryMaxDelay = TimeSpan.Zero;
+        });
+        using var destination = new MemoryStream();
+
+        await client.DownloadAttachmentAsync("123", "a1", destination);
+
+        Assert.Equal(2, attempt);
+        Assert.Equal("complete", Encoding.UTF8.GetString(destination.ToArray()));
+    }
+
     private static ConfluenceClient CreateClient(RecordingHandler handler, IConfluenceCredentialSource? credential = null, Action<ConfluenceSessionOptions>? configure = null) {
         var options = new ConfluenceSessionOptions {
             SiteUri = new Uri("https://example.atlassian.net/"),
@@ -260,6 +282,41 @@ public sealed class ConfluenceContractTests {
             length = 0;
             return false;
         }
+    }
+
+    private sealed class PartialReadFailureStream : Stream {
+        private readonly byte[] _prefix;
+        private int _position;
+
+        internal PartialReadFailureStream(byte[] prefix) => _prefix = prefix;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => _position; set => throw new NotSupportedException(); }
+        public override void Flush() { }
+
+        public override int Read(byte[] buffer, int offset, int count) {
+            if (_position >= _prefix.Length) throw new HttpRequestException("transient partial response body failure");
+            int copied = Math.Min(count, _prefix.Length - _position);
+            Array.Copy(_prefix, _position, buffer, offset, copied);
+            _position += copied;
+            return copied;
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) {
+            try {
+                cancellationToken.ThrowIfCancellationRequested();
+                return Task.FromResult(Read(buffer, offset, count));
+            } catch (Exception exception) {
+                return Task.FromException<int>(exception);
+            }
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 
     private sealed class RecordingHandler : HttpMessageHandler {

--- a/OfficeIMO.Confluence.Tests/ConfluenceContractTests.cs
+++ b/OfficeIMO.Confluence.Tests/ConfluenceContractTests.cs
@@ -22,6 +22,18 @@ public sealed class ConfluenceContractTests {
     }
 
     [Fact]
+    public async Task DirectSession_NormalizesSitePathBeforeResolvingApiRequests() {
+        string fixture = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "page-adf.json"));
+        var handler = new RecordingHandler(_ => Response(HttpStatusCode.OK, fixture));
+        using ConfluenceClient client = CreateClient(handler, configure: options => options.SiteUri = new Uri("https://example.atlassian.net/wiki/"));
+
+        await client.GetPageAsync("123");
+
+        Uri requestUri = handler.Requests.Single().RequestUri!;
+        Assert.Equal("https://example.atlassian.net/wiki/api/v2/pages/123?body-format=atlas_doc_format", requestUri.AbsoluteUri);
+    }
+
+    [Fact]
     public async Task PageBatch_ExposesDecodedNextCursor() {
         var handler = new RecordingHandler(_ => Response(HttpStatusCode.OK, "{\"results\":[],\"_links\":{\"next\":\"/wiki/api/v2/pages?limit=25&cursor=abc%2B123\"}}"));
         using ConfluenceClient client = CreateClient(handler);

--- a/OfficeIMO.Confluence.Tests/ConfluenceContractTests.cs
+++ b/OfficeIMO.Confluence.Tests/ConfluenceContractTests.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using OfficeIMO.Confluence;
+using Xunit;
+
+namespace OfficeIMO.Confluence.Tests;
+
+public sealed class ConfluenceContractTests {
+    [Fact]
+    public void Session_RejectsCredentialsEmbeddedInSiteUri() {
+        var options = new ConfluenceSessionOptions { SiteUri = new Uri("https://user:secret@example.atlassian.net/") };
+
+        Assert.Throws<ArgumentException>(() => new ConfluenceSession(new ConfluenceBearerCredentialSource("token"), options));
+    }
+
+    [Fact]
+    public async Task PageBatch_ExposesDecodedNextCursor() {
+        var handler = new RecordingHandler(_ => Response(HttpStatusCode.OK, "{\"results\":[],\"_links\":{\"next\":\"/wiki/api/v2/pages?limit=25&cursor=abc%2B123\"}}"));
+        using ConfluenceClient client = CreateClient(handler);
+
+        ConfluencePageBatch batch = await client.GetPagesAsync();
+
+        Assert.Equal("abc+123", batch.NextCursor);
+    }
+
+    [Fact]
+    public async Task GetPage_UsesV2BodyFormatAndCallerCredentialSource() {
+        string fixture = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "page-adf.json"));
+        var handler = new RecordingHandler(_ => Response(HttpStatusCode.OK, fixture));
+        using ConfluenceClient client = CreateClient(handler, new ConfluenceBasicCredentialSource("person@example.com", "token"));
+
+        ConfluencePage page = await client.GetPageAsync("123", ConfluenceBodyFormat.AtlasDocFormat);
+
+        Assert.Equal("Status", page.Title);
+        Assert.Equal("/wiki/api/v2/pages/123?body-format=atlas_doc_format", handler.Requests.Single().RequestUri!.PathAndQuery);
+        Assert.Equal("Basic", handler.Requests.Single().Headers.Authorization!.Scheme);
+    }
+
+    [Fact]
+    public void UpdatePlan_IsDryAndCarriesOptimisticVersion() {
+        ConfluencePageBody body = ConfluenceContentConverter.FromMarkdown("# Ready").Value;
+
+        ConfluencePageWritePlan plan = ConfluenceClient.PlanUpdatePage(new ConfluencePageUpdateRequest {
+            PageId = "123",
+            Title = "Ready",
+            VersionNumber = 8,
+            VersionMessage = "generated",
+            Body = body,
+        });
+
+        Assert.Equal("PUT", plan.Method);
+        Assert.Equal("/wiki/api/v2/pages/123", plan.RelativeUri);
+        Assert.Contains("\"number\":8", plan.Payload);
+        Assert.Contains("atlas_doc_format", plan.Payload);
+    }
+
+    [Fact]
+    public async Task NonIdempotentWrite_IsNotRetriedAfterServiceFailure() {
+        var handler = new RecordingHandler(_ => Response(HttpStatusCode.ServiceUnavailable, "{\"message\":\"later\"}"));
+        using ConfluenceClient client = CreateClient(handler);
+        var request = new ConfluencePageCreateRequest {
+            SpaceId = "42",
+            Title = "Status",
+            Body = ConfluenceContentConverter.FromMarkdown("Ready").Value,
+        };
+
+        await Assert.ThrowsAsync<ConfluenceApiException>(() => client.CreatePageAsync(request));
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task SafeRead_RetriesRateLimit() {
+        int attempt = 0;
+        string fixture = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "page-adf.json"));
+        var handler = new RecordingHandler(_ => ++attempt == 1 ? Response((HttpStatusCode)429, "{}") : Response(HttpStatusCode.OK, fixture));
+        using ConfluenceClient client = CreateClient(handler, configure: options => { options.RetryBaseDelay = TimeSpan.Zero; options.RetryMaxDelay = TimeSpan.Zero; });
+
+        ConfluencePage page = await client.GetPageAsync("123");
+
+        Assert.Equal("123", page.Id);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public void ManagedSection_ReplacesOnlyMarkedContentAndProducesHashes() {
+        string original = "<p>Owner content</p>\n<!-- officeimo:section:report:start -->\nold\n<!-- officeimo:section:report:end -->\n<p>Tail</p>";
+
+        ConfluenceManagedSectionResult result = ConfluenceManagedSection.Apply(original, "report", "<p>new</p>");
+
+        Assert.Contains("<p>Owner content</p>", result.UpdatedBody);
+        Assert.Contains("<p>new</p>", result.UpdatedBody);
+        Assert.Contains("<p>Tail</p>", result.UpdatedBody);
+        Assert.True(result.Changed);
+        Assert.NotEqual(result.OriginalSha256, result.UpdatedSha256);
+    }
+
+    [Fact]
+    public async Task AttachmentUpload_UsesMultipartAndXsrfHeader() {
+        var handler = new RecordingHandler(request => {
+            Assert.Equal(HttpMethod.Put, request.Method);
+            Assert.True(request.Headers.Contains("X-Atlassian-Token"));
+            Assert.NotNull(request.Content);
+            Assert.StartsWith("multipart/form-data", request.Content!.Headers.ContentType!.MediaType);
+            return Response(HttpStatusCode.OK, "{\"results\":[{\"id\":\"a1\",\"title\":\"report.txt\",\"extensions\":{\"mediaType\":\"text/plain\",\"fileSize\":5},\"_links\":{\"download\":\"/download/attachments/123/report.txt\"}}]}" );
+        });
+        using ConfluenceClient client = CreateClient(handler);
+
+        IReadOnlyList<ConfluenceAttachment> result = await client.UploadAttachmentAsync("123", new ConfluenceAttachmentUpload {
+            FileName = "report.txt",
+            ContentType = "text/plain",
+            Content = Encoding.UTF8.GetBytes("ready"),
+        });
+
+        ConfluenceAttachment attachment = Assert.Single(result);
+        Assert.Equal("a1", attachment.Id);
+        Assert.Equal("123", attachment.PageId);
+        Assert.Equal("text/plain", attachment.MediaType);
+        Assert.Equal(5, attachment.FileSize);
+        Assert.Equal("/download/attachments/123/report.txt", attachment.DownloadLink);
+    }
+
+    private static ConfluenceClient CreateClient(RecordingHandler handler, IConfluenceCredentialSource? credential = null, Action<ConfluenceSessionOptions>? configure = null) {
+        var options = new ConfluenceSessionOptions {
+            SiteUri = new Uri("https://example.atlassian.net/"),
+            HttpClient = new HttpClient(handler),
+        };
+        configure?.Invoke(options);
+        return new ConfluenceSession(credential ?? new ConfluenceBearerCredentialSource("token"), options).CreateClient();
+    }
+
+    private static HttpResponseMessage Response(HttpStatusCode status, string body) => new HttpResponseMessage(status) {
+        Content = new StringContent(body, Encoding.UTF8, "application/json"),
+    };
+
+    private sealed class RecordingHandler : HttpMessageHandler {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _respond;
+        internal RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) => _respond = respond;
+        internal List<HttpRequestMessage> Requests { get; } = new List<HttpRequestMessage>();
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            var snapshot = new HttpRequestMessage(request.Method, request.RequestUri);
+            snapshot.Headers.Authorization = request.Headers.Authorization == null ? null : new AuthenticationHeaderValue(request.Headers.Authorization.Scheme, request.Headers.Authorization.Parameter);
+            foreach (var header in request.Headers.Where(header => !string.Equals(header.Key, "Authorization", StringComparison.OrdinalIgnoreCase))) snapshot.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            snapshot.Content = request.Content;
+            Requests.Add(snapshot);
+            return Task.FromResult(_respond(request));
+        }
+    }
+}

--- a/OfficeIMO.Confluence.Tests/ConfluenceContractTests.cs
+++ b/OfficeIMO.Confluence.Tests/ConfluenceContractTests.cs
@@ -32,6 +32,20 @@ public sealed class ConfluenceContractTests {
     }
 
     [Fact]
+    public async Task PageBatch_UsesLinkHeaderWhenBodyDoesNotContainNextLink() {
+        var handler = new RecordingHandler(_ => {
+            HttpResponseMessage response = Response(HttpStatusCode.OK, "{\"results\":[]}");
+            response.Headers.TryAddWithoutValidation("Link", "<https://example.atlassian.net/wiki/api/v2/pages?limit=25&cursor=header%2Bcursor>; rel=\"next\"");
+            return response;
+        });
+        using ConfluenceClient client = CreateClient(handler);
+
+        ConfluencePageBatch batch = await client.GetPagesAsync();
+
+        Assert.Equal("header+cursor", batch.NextCursor);
+    }
+
+    [Fact]
     public async Task GetPage_UsesV2BodyFormatAndCallerCredentialSource() {
         string fixture = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "page-adf.json"));
         var handler = new RecordingHandler(_ => Response(HttpStatusCode.OK, fixture));
@@ -42,6 +56,29 @@ public sealed class ConfluenceContractTests {
         Assert.Equal("Status", page.Title);
         Assert.Equal("/wiki/api/v2/pages/123?body-format=atlas_doc_format", handler.Requests.Single().RequestUri!.PathAndQuery);
         Assert.Equal("Basic", handler.Requests.Single().Headers.Authorization!.Scheme);
+    }
+
+    [Fact]
+    public async Task OAuthSession_UsesCloudGatewayAndDefensiveOptionsSnapshot() {
+        string fixture = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "page-adf.json"));
+        var handler = new RecordingHandler(_ => Response(HttpStatusCode.OK, fixture));
+        var options = new ConfluenceSessionOptions {
+            SiteUri = new Uri("https://example.atlassian.net/"),
+            CloudId = "cloud-123",
+            HttpClient = new HttpClient(handler),
+        };
+        var session = new ConfluenceSession(new ConfluenceBearerCredentialSource("token"), options);
+        options.SiteUri = new Uri("https://attacker.invalid/");
+        ConfluenceSessionOptions exposed = session.Options;
+        exposed.CloudId = "changed";
+        using ConfluenceClient client = session.CreateClient();
+
+        await client.GetPageAsync("123");
+
+        Uri requestUri = handler.Requests.Single().RequestUri!;
+        Assert.Equal("api.atlassian.com", requestUri.Host);
+        Assert.Equal("/ex/confluence/cloud-123/wiki/api/v2/pages/123?body-format=atlas_doc_format", requestUri.PathAndQuery);
+        Assert.Equal("Bearer", handler.Requests.Single().Headers.Authorization!.Scheme);
     }
 
     [Fact]
@@ -90,6 +127,33 @@ public sealed class ConfluenceContractTests {
     }
 
     [Fact]
+    public async Task SafeRead_RetriesTransportFailure() {
+        int attempt = 0;
+        string fixture = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "page-adf.json"));
+        var handler = new RecordingHandler(_ => ++attempt == 1 ? throw new HttpRequestException("transient") : Response(HttpStatusCode.OK, fixture));
+        using ConfluenceClient client = CreateClient(handler, configure: options => { options.RetryBaseDelay = TimeSpan.Zero; options.RetryMaxDelay = TimeSpan.Zero; });
+
+        ConfluencePage page = await client.GetPageAsync("123");
+
+        Assert.Equal("123", page.Id);
+        Assert.Equal(2, attempt);
+    }
+
+    [Fact]
+    public async Task DeletePage_IsPlannableAndNotRetried() {
+        var handler = new RecordingHandler(_ => Response(HttpStatusCode.ServiceUnavailable, "{\"message\":\"later\"}"));
+        using ConfluenceClient client = CreateClient(handler);
+
+        ConfluencePageWritePlan plan = ConfluenceClient.PlanDeletePage("123", purge: true, draft: true);
+        await Assert.ThrowsAsync<ConfluenceApiException>(() => client.DeletePageAsync("123", purge: true, draft: true));
+
+        Assert.Equal("DELETE", plan.Method);
+        Assert.Equal("/wiki/api/v2/pages/123?purge=true&draft=true", plan.RelativeUri);
+        Assert.Empty(plan.Payload);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
     public void ManagedSection_ReplacesOnlyMarkedContentAndProducesHashes() {
         string original = "<p>Owner content</p>\n<!-- officeimo:section:report:start -->\nold\n<!-- officeimo:section:report:end -->\n<p>Tail</p>";
 
@@ -125,6 +189,39 @@ public sealed class ConfluenceContractTests {
         Assert.Equal("text/plain", attachment.MediaType);
         Assert.Equal(5, attachment.FileSize);
         Assert.Equal("/download/attachments/123/report.txt", attachment.DownloadLink);
+    }
+
+    [Fact]
+    public async Task AttachmentStreamingUpload_LeavesCallerStreamOpen() {
+        string? uploaded = null;
+        var handler = new RecordingHandler(request => {
+            uploaded = request.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+            return Response(HttpStatusCode.OK, "{\"results\":[]}");
+        });
+        using ConfluenceClient client = CreateClient(handler);
+        using var content = new MemoryStream(Encoding.UTF8.GetBytes("stream-ready"));
+
+        await client.UploadAttachmentAsync("123", new ConfluenceAttachmentStreamUpload {
+            FileName = "report.txt",
+            ContentType = "text/plain",
+            Content = content,
+        });
+
+        Assert.True(content.CanRead);
+        Assert.Contains("stream-ready", uploaded);
+    }
+
+    [Fact]
+    public async Task AttachmentDownload_StreamsToCallerDestination() {
+        var handler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = new ByteArrayContent(Encoding.UTF8.GetBytes("download-ready")),
+        });
+        using ConfluenceClient client = CreateClient(handler);
+        using var destination = new MemoryStream();
+
+        await client.DownloadAttachmentAsync("123", "a1", destination);
+
+        Assert.Equal("download-ready", Encoding.UTF8.GetString(destination.ToArray()));
     }
 
     private static ConfluenceClient CreateClient(RecordingHandler handler, IConfluenceCredentialSource? credential = null, Action<ConfluenceSessionOptions>? configure = null) {

--- a/OfficeIMO.Confluence.Tests/ConfluenceContractTests.cs
+++ b/OfficeIMO.Confluence.Tests/ConfluenceContractTests.cs
@@ -140,6 +140,21 @@ public sealed class ConfluenceContractTests {
     }
 
     [Fact]
+    public async Task SafeRead_RetriesTransientResponseBodyFailure() {
+        int attempt = 0;
+        string fixture = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "page-adf.json"));
+        var handler = new RecordingHandler(_ => ++attempt == 1
+            ? new HttpResponseMessage(HttpStatusCode.OK) { Content = new ThrowingReadContent() }
+            : Response(HttpStatusCode.OK, fixture));
+        using ConfluenceClient client = CreateClient(handler, configure: options => { options.RetryBaseDelay = TimeSpan.Zero; options.RetryMaxDelay = TimeSpan.Zero; });
+
+        ConfluencePage page = await client.GetPageAsync("123");
+
+        Assert.Equal("123", page.Id);
+        Assert.Equal(2, attempt);
+    }
+
+    [Fact]
     public async Task DeletePage_IsPlannableAndNotRetried() {
         var handler = new RecordingHandler(_ => Response(HttpStatusCode.ServiceUnavailable, "{\"message\":\"later\"}"));
         using ConfluenceClient client = CreateClient(handler);
@@ -236,6 +251,16 @@ public sealed class ConfluenceContractTests {
     private static HttpResponseMessage Response(HttpStatusCode status, string body) => new HttpResponseMessage(status) {
         Content = new StringContent(body, Encoding.UTF8, "application/json"),
     };
+
+    private sealed class ThrowingReadContent : HttpContent {
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+            Task.FromException(new HttpRequestException("transient response body failure"));
+
+        protected override bool TryComputeLength(out long length) {
+            length = 0;
+            return false;
+        }
+    }
 
     private sealed class RecordingHandler : HttpMessageHandler {
         private readonly Func<HttpRequestMessage, HttpResponseMessage> _respond;

--- a/OfficeIMO.Confluence.Tests/Fixtures/page-adf.json
+++ b/OfficeIMO.Confluence.Tests/Fixtures/page-adf.json
@@ -1,0 +1,14 @@
+{
+  "id": "123",
+  "status": "current",
+  "title": "Status",
+  "spaceId": "42",
+  "parentId": "100",
+  "version": { "number": 7, "message": "fixture", "minorEdit": false },
+  "body": {
+    "atlas_doc_format": {
+      "representation": "atlas_doc_format",
+      "value": "{\"version\":1,\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"Ready\"}]}]}"
+    }
+  }
+}

--- a/OfficeIMO.Confluence.Tests/OfficeIMO.Confluence.Tests.csproj
+++ b/OfficeIMO.Confluence.Tests/OfficeIMO.Confluence.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <LangVersion>Latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1"><PrivateAssets>all</PrivateAssets></PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5"><PrivateAssets>all</PrivateAssets></PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OfficeIMO.Confluence\OfficeIMO.Confluence.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Fixtures\**\*" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/OfficeIMO.Confluence/ConfluenceAttachments.cs
+++ b/OfficeIMO.Confluence/ConfluenceAttachments.cs
@@ -1,0 +1,42 @@
+using System.Text.Json.Serialization;
+
+namespace OfficeIMO.Confluence;
+
+/// <summary>Confluence attachment metadata.</summary>
+public sealed class ConfluenceAttachment {
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+    [JsonPropertyName("title")]
+    public string FileName { get; set; } = string.Empty;
+    [JsonPropertyName("mediaType")]
+    public string? MediaType { get; set; }
+    [JsonPropertyName("fileSize")]
+    public long FileSize { get; set; }
+    [JsonPropertyName("pageId")]
+    public string? PageId { get; set; }
+    [JsonPropertyName("downloadLink")]
+    public string? DownloadLink { get; set; }
+    [JsonPropertyName("version")]
+    public ConfluencePageVersion Version { get; set; } = new ConfluencePageVersion();
+}
+
+/// <summary>A cursor-addressable attachment batch.</summary>
+public sealed class ConfluenceAttachmentBatch {
+    internal ConfluenceAttachmentBatch(IReadOnlyList<ConfluenceAttachment> attachments, string? nextRelativeUri) {
+        Attachments = attachments;
+        NextRelativeUri = nextRelativeUri;
+    }
+    public IReadOnlyList<ConfluenceAttachment> Attachments { get; }
+    public string? NextRelativeUri { get; }
+    /// <summary>Decoded cursor for requesting the next batch, or null when enumeration is complete.</summary>
+    public string? NextCursor => ConfluenceCursor.Extract(NextRelativeUri);
+}
+
+/// <summary>Attachment data for Confluence's multipart upload endpoint.</summary>
+public sealed class ConfluenceAttachmentUpload {
+    public string FileName { get; set; } = string.Empty;
+    public string ContentType { get; set; } = "application/octet-stream";
+    public byte[] Content { get; set; } = Array.Empty<byte>();
+    public string? Comment { get; set; }
+    public bool MinorEdit { get; set; } = true;
+}

--- a/OfficeIMO.Confluence/ConfluenceAttachments.cs
+++ b/OfficeIMO.Confluence/ConfluenceAttachments.cs
@@ -40,3 +40,13 @@ public sealed class ConfluenceAttachmentUpload {
     public string? Comment { get; set; }
     public bool MinorEdit { get; set; } = true;
 }
+
+/// <summary>Streaming attachment data for Confluence's multipart upload endpoint.</summary>
+public sealed class ConfluenceAttachmentStreamUpload {
+    public string FileName { get; set; } = string.Empty;
+    public string ContentType { get; set; } = "application/octet-stream";
+    /// <summary>Readable content stream. Ownership remains with the caller.</summary>
+    public Stream Content { get; set; } = Stream.Null;
+    public string? Comment { get; set; }
+    public bool MinorEdit { get; set; } = true;
+}

--- a/OfficeIMO.Confluence/ConfluenceClient.Attachments.cs
+++ b/OfficeIMO.Confluence/ConfluenceClient.Attachments.cs
@@ -1,0 +1,97 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace OfficeIMO.Confluence;
+
+public sealed partial class ConfluenceClient {
+    /// <summary>Lists one cursor-addressable batch of attachments for a page.</summary>
+    public async Task<ConfluenceAttachmentBatch> GetAttachmentsAsync(string pageId, string? cursor = null, int limit = 50, CancellationToken cancellationToken = default) {
+        ValidateId(pageId, nameof(pageId));
+        if (limit < 1 || limit > 250) throw new ArgumentOutOfRangeException(nameof(limit), "Limit must be between 1 and 250.");
+        string uri = "/wiki/api/v2/pages/" + Encode(pageId) + "/attachments?limit=" + limit.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        if (!string.IsNullOrWhiteSpace(cursor)) uri += "&cursor=" + Encode(cursor!);
+        CollectionResponse<ConfluenceAttachment> response = await _transport.SendJsonAsync<CollectionResponse<ConfluenceAttachment>>(HttpMethod.Get, uri, null, ConfluenceRequestSafety.SafeToRetry, cancellationToken).ConfigureAwait(false);
+        return new ConfluenceAttachmentBatch(response.Results, response.Links?.Next);
+    }
+
+    /// <summary>Downloads an attachment through Confluence's authenticated redirect endpoint.</summary>
+    public async Task<byte[]> DownloadAttachmentAsync(string pageId, string attachmentId, CancellationToken cancellationToken = default) {
+        ValidateId(pageId, nameof(pageId));
+        ValidateId(attachmentId, nameof(attachmentId));
+        string uri = "/wiki/rest/api/content/" + Encode(pageId) + "/child/attachment/" + Encode(attachmentId) + "/download";
+        ConfluenceHttpResponse response = await _transport.SendRawAsync(HttpMethod.Get, uri, cancellationToken).ConfigureAwait(false);
+        return response.Body;
+    }
+
+    /// <summary>Creates or versions an attachment through Confluence's multipart v1 endpoint.</summary>
+    public async Task<IReadOnlyList<ConfluenceAttachment>> UploadAttachmentAsync(string pageId, ConfluenceAttachmentUpload upload, CancellationToken cancellationToken = default) {
+        ValidateId(pageId, nameof(pageId));
+        if (upload == null) throw new ArgumentNullException(nameof(upload));
+        if (string.IsNullOrWhiteSpace(upload.FileName)) throw new ArgumentException("Attachment file name is required.", nameof(upload));
+        if (upload.Content == null) throw new ArgumentException("Attachment content is required.", nameof(upload));
+        string uri = "/wiki/rest/api/content/" + Encode(pageId) + "/child/attachment";
+        ConfluenceHttpResponse response = await _transport.SendMultipartAsync(uri, () => CreateMultipart(upload), cancellationToken).ConfigureAwait(false);
+        V1AttachmentResponse? parsed = JsonSerializer.Deserialize<V1AttachmentResponse>(response.Body, ConfluenceHttpTransport.JsonOptions);
+        return parsed == null
+            ? Array.Empty<ConfluenceAttachment>()
+            : parsed.Results.Select(item => new ConfluenceAttachment {
+                Id = item.Id,
+                FileName = item.Title,
+                MediaType = item.Extensions?.MediaType ?? item.Metadata?.MediaType,
+                FileSize = item.Extensions?.FileSize ?? item.FileSize,
+                PageId = pageId,
+                DownloadLink = item.Links?.Download,
+                Version = item.Version ?? new ConfluencePageVersion(),
+            }).ToArray();
+    }
+
+    private static HttpContent CreateMultipart(ConfluenceAttachmentUpload upload) {
+        var multipart = new MultipartFormDataContent();
+        var file = new ByteArrayContent(upload.Content);
+        file.Headers.ContentType = new MediaTypeHeaderValue(string.IsNullOrWhiteSpace(upload.ContentType) ? "application/octet-stream" : upload.ContentType);
+        multipart.Add(file, "file", upload.FileName);
+        multipart.Add(new StringContent(upload.MinorEdit ? "true" : "false", Encoding.UTF8, "text/plain"), "minorEdit");
+        if (!string.IsNullOrWhiteSpace(upload.Comment)) multipart.Add(new StringContent(upload.Comment!, Encoding.UTF8, "text/plain"), "comment");
+        return multipart;
+    }
+
+    private sealed class V1AttachmentResponse {
+        [System.Text.Json.Serialization.JsonPropertyName("results")]
+        public List<V1Attachment> Results { get; set; } = new List<V1Attachment>();
+    }
+
+    private sealed class V1Attachment {
+        [System.Text.Json.Serialization.JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+        [System.Text.Json.Serialization.JsonPropertyName("title")]
+        public string Title { get; set; } = string.Empty;
+        [System.Text.Json.Serialization.JsonPropertyName("fileSize")]
+        public long FileSize { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("metadata")]
+        public V1AttachmentMetadata? Metadata { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("extensions")]
+        public V1AttachmentExtensions? Extensions { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("_links")]
+        public V1AttachmentLinks? Links { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("version")]
+        public ConfluencePageVersion? Version { get; set; }
+    }
+
+    private sealed class V1AttachmentMetadata {
+        [System.Text.Json.Serialization.JsonPropertyName("mediaType")]
+        public string? MediaType { get; set; }
+    }
+
+    private sealed class V1AttachmentExtensions {
+        [System.Text.Json.Serialization.JsonPropertyName("mediaType")]
+        public string? MediaType { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("fileSize")]
+        public long FileSize { get; set; }
+    }
+
+    private sealed class V1AttachmentLinks {
+        [System.Text.Json.Serialization.JsonPropertyName("download")]
+        public string? Download { get; set; }
+    }
+}

--- a/OfficeIMO.Confluence/ConfluenceClient.Attachments.cs
+++ b/OfficeIMO.Confluence/ConfluenceClient.Attachments.cs
@@ -11,8 +11,8 @@ public sealed partial class ConfluenceClient {
         if (limit < 1 || limit > 250) throw new ArgumentOutOfRangeException(nameof(limit), "Limit must be between 1 and 250.");
         string uri = "/wiki/api/v2/pages/" + Encode(pageId) + "/attachments?limit=" + limit.ToString(System.Globalization.CultureInfo.InvariantCulture);
         if (!string.IsNullOrWhiteSpace(cursor)) uri += "&cursor=" + Encode(cursor!);
-        CollectionResponse<ConfluenceAttachment> response = await _transport.SendJsonAsync<CollectionResponse<ConfluenceAttachment>>(HttpMethod.Get, uri, null, ConfluenceRequestSafety.SafeToRetry, cancellationToken).ConfigureAwait(false);
-        return new ConfluenceAttachmentBatch(response.Results, response.Links?.Next);
+        ConfluenceJsonResponse<CollectionResponse<ConfluenceAttachment>> response = await _transport.SendJsonWithHeadersAsync<CollectionResponse<ConfluenceAttachment>>(HttpMethod.Get, uri, null, ConfluenceRequestSafety.SafeToRetry, cancellationToken).ConfigureAwait(false);
+        return new ConfluenceAttachmentBatch(response.Value.Results, ConfluencePagination.Next(response.Value.Links?.Next, response.Headers));
     }
 
     /// <summary>Downloads an attachment through Confluence's authenticated redirect endpoint.</summary>
@@ -20,8 +20,18 @@ public sealed partial class ConfluenceClient {
         ValidateId(pageId, nameof(pageId));
         ValidateId(attachmentId, nameof(attachmentId));
         string uri = "/wiki/rest/api/content/" + Encode(pageId) + "/child/attachment/" + Encode(attachmentId) + "/download";
-        ConfluenceHttpResponse response = await _transport.SendRawAsync(HttpMethod.Get, uri, cancellationToken).ConfigureAwait(false);
-        return response.Body;
+        using var destination = new MemoryStream();
+        await DownloadAttachmentAsync(pageId, attachmentId, destination, cancellationToken).ConfigureAwait(false);
+        return destination.ToArray();
+    }
+
+    /// <summary>Streams an attachment through Confluence's authenticated redirect endpoint.</summary>
+    public Task DownloadAttachmentAsync(string pageId, string attachmentId, Stream destination, CancellationToken cancellationToken = default) {
+        ValidateId(pageId, nameof(pageId));
+        ValidateId(attachmentId, nameof(attachmentId));
+        if (destination == null) throw new ArgumentNullException(nameof(destination));
+        string uri = "/wiki/rest/api/content/" + Encode(pageId) + "/child/attachment/" + Encode(attachmentId) + "/download";
+        return _transport.SendToStreamAsync(HttpMethod.Get, uri, destination, cancellationToken);
     }
 
     /// <summary>Creates or versions an attachment through Confluence's multipart v1 endpoint.</summary>
@@ -30,6 +40,22 @@ public sealed partial class ConfluenceClient {
         if (upload == null) throw new ArgumentNullException(nameof(upload));
         if (string.IsNullOrWhiteSpace(upload.FileName)) throw new ArgumentException("Attachment file name is required.", nameof(upload));
         if (upload.Content == null) throw new ArgumentException("Attachment content is required.", nameof(upload));
+        using var content = new MemoryStream(upload.Content, writable: false);
+        return await UploadAttachmentAsync(pageId, new ConfluenceAttachmentStreamUpload {
+            FileName = upload.FileName,
+            ContentType = upload.ContentType,
+            Content = content,
+            Comment = upload.Comment,
+            MinorEdit = upload.MinorEdit,
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Creates or versions an attachment from a caller-owned stream.</summary>
+    public async Task<IReadOnlyList<ConfluenceAttachment>> UploadAttachmentAsync(string pageId, ConfluenceAttachmentStreamUpload upload, CancellationToken cancellationToken = default) {
+        ValidateId(pageId, nameof(pageId));
+        if (upload == null) throw new ArgumentNullException(nameof(upload));
+        if (string.IsNullOrWhiteSpace(upload.FileName)) throw new ArgumentException("Attachment file name is required.", nameof(upload));
+        if (upload.Content == null || !upload.Content.CanRead) throw new ArgumentException("A readable attachment content stream is required.", nameof(upload));
         string uri = "/wiki/rest/api/content/" + Encode(pageId) + "/child/attachment";
         ConfluenceHttpResponse response = await _transport.SendMultipartAsync(uri, () => CreateMultipart(upload), cancellationToken).ConfigureAwait(false);
         V1AttachmentResponse? parsed = JsonSerializer.Deserialize<V1AttachmentResponse>(response.Body, ConfluenceHttpTransport.JsonOptions);
@@ -46,14 +72,30 @@ public sealed partial class ConfluenceClient {
             }).ToArray();
     }
 
-    private static HttpContent CreateMultipart(ConfluenceAttachmentUpload upload) {
+    private static HttpContent CreateMultipart(ConfluenceAttachmentStreamUpload upload) {
         var multipart = new MultipartFormDataContent();
-        var file = new ByteArrayContent(upload.Content);
+        var file = new StreamContent(new NonDisposingReadStream(upload.Content));
         file.Headers.ContentType = new MediaTypeHeaderValue(string.IsNullOrWhiteSpace(upload.ContentType) ? "application/octet-stream" : upload.ContentType);
         multipart.Add(file, "file", upload.FileName);
         multipart.Add(new StringContent(upload.MinorEdit ? "true" : "false", Encoding.UTF8, "text/plain"), "minorEdit");
         if (!string.IsNullOrWhiteSpace(upload.Comment)) multipart.Add(new StringContent(upload.Comment!, Encoding.UTF8, "text/plain"), "comment");
         return multipart;
+    }
+
+    private sealed class NonDisposingReadStream : Stream {
+        private readonly Stream _inner;
+        internal NonDisposingReadStream(Stream inner) => _inner = inner;
+        public override bool CanRead => _inner.CanRead;
+        public override bool CanSeek => _inner.CanSeek;
+        public override bool CanWrite => false;
+        public override long Length => _inner.Length;
+        public override long Position { get => _inner.Position; set => _inner.Position = value; }
+        public override void Flush() => _inner.Flush();
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+        public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        protected override void Dispose(bool disposing) { }
     }
 
     private sealed class V1AttachmentResponse {

--- a/OfficeIMO.Confluence/ConfluenceClient.Pages.cs
+++ b/OfficeIMO.Confluence/ConfluenceClient.Pages.cs
@@ -26,8 +26,8 @@ public sealed partial class ConfluenceClient : IDisposable {
         query ??= new ConfluencePageQuery();
         if (query.Limit < 1 || query.Limit > 250) throw new ArgumentOutOfRangeException(nameof(query), "Limit must be between 1 and 250.");
         string relativeUri = BuildPageQuery(query);
-        CollectionResponse<ConfluencePage> response = await _transport.SendJsonAsync<CollectionResponse<ConfluencePage>>(HttpMethod.Get, relativeUri, null, ConfluenceRequestSafety.SafeToRetry, cancellationToken).ConfigureAwait(false);
-        return new ConfluencePageBatch(response.Results, response.Links?.Next);
+        ConfluenceJsonResponse<CollectionResponse<ConfluencePage>> response = await _transport.SendJsonWithHeadersAsync<CollectionResponse<ConfluencePage>>(HttpMethod.Get, relativeUri, null, ConfluenceRequestSafety.SafeToRetry, cancellationToken).ConfigureAwait(false);
+        return new ConfluencePageBatch(response.Value.Results, ConfluencePagination.Next(response.Value.Links?.Next, response.Headers));
     }
 
     /// <summary>Creates a page. Non-idempotent writes are never retried automatically.</summary>
@@ -42,6 +42,12 @@ public sealed partial class ConfluenceClient : IDisposable {
         ConfluencePageWritePlan plan = PlanUpdatePage(request);
         using JsonDocument payload = JsonDocument.Parse(plan.Payload);
         return _transport.SendJsonAsync<ConfluencePage>(HttpMethod.Put, plan.RelativeUri, payload.RootElement.Clone(), ConfluenceRequestSafety.NonIdempotent, cancellationToken);
+    }
+
+    /// <summary>Deletes a page. This non-idempotent operation is never retried automatically.</summary>
+    public async Task DeletePageAsync(string pageId, bool purge = false, bool draft = false, CancellationToken cancellationToken = default) {
+        ConfluencePageWritePlan plan = PlanDeletePage(pageId, purge, draft);
+        await _transport.SendRawAsync(HttpMethod.Delete, plan.RelativeUri, ConfluenceRequestSafety.NonIdempotent, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Builds the exact create request without contacting Confluence.</summary>
@@ -75,6 +81,16 @@ public sealed partial class ConfluenceClient : IDisposable {
             version = new { number = request.VersionNumber, message = request.VersionMessage },
         };
         return new ConfluencePageWritePlan("PUT", "/wiki/api/v2/pages/" + Encode(request.PageId), JsonSerializer.Serialize(payload, ConfluenceHttpTransport.JsonOptions));
+    }
+
+    /// <summary>Builds the exact delete request without contacting Confluence.</summary>
+    public static ConfluencePageWritePlan PlanDeletePage(string pageId, bool purge = false, bool draft = false) {
+        ValidateId(pageId, nameof(pageId));
+        var query = new List<string>();
+        if (purge) query.Add("purge=true");
+        if (draft) query.Add("draft=true");
+        string relativeUri = "/wiki/api/v2/pages/" + Encode(pageId) + (query.Count == 0 ? string.Empty : "?" + string.Join("&", query));
+        return new ConfluencePageWritePlan("DELETE", relativeUri, string.Empty);
     }
 
     public void Dispose() => _transport.Dispose();

--- a/OfficeIMO.Confluence/ConfluenceClient.Pages.cs
+++ b/OfficeIMO.Confluence/ConfluenceClient.Pages.cs
@@ -1,0 +1,114 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OfficeIMO.Confluence;
+
+/// <summary>Dependency-light Confluence Cloud page and attachment client.</summary>
+public sealed partial class ConfluenceClient : IDisposable {
+    private readonly ConfluenceHttpTransport _transport;
+
+    public ConfluenceClient(ConfluenceSession session) {
+        Session = session ?? throw new ArgumentNullException(nameof(session));
+        _transport = new ConfluenceHttpTransport(session);
+    }
+
+    public ConfluenceSession Session { get; }
+
+    /// <summary>Reads a page with the requested body representation.</summary>
+    public Task<ConfluencePage> GetPageAsync(string pageId, ConfluenceBodyFormat bodyFormat = ConfluenceBodyFormat.AtlasDocFormat, CancellationToken cancellationToken = default) {
+        ValidateId(pageId, nameof(pageId));
+        return _transport.SendJsonAsync<ConfluencePage>(HttpMethod.Get, "/wiki/api/v2/pages/" + Encode(pageId) + "?body-format=" + Format(bodyFormat), null, ConfluenceRequestSafety.SafeToRetry, cancellationToken);
+    }
+
+    /// <summary>Lists one cursor-addressable batch of pages.</summary>
+    public async Task<ConfluencePageBatch> GetPagesAsync(ConfluencePageQuery? query = null, CancellationToken cancellationToken = default) {
+        query ??= new ConfluencePageQuery();
+        if (query.Limit < 1 || query.Limit > 250) throw new ArgumentOutOfRangeException(nameof(query), "Limit must be between 1 and 250.");
+        string relativeUri = BuildPageQuery(query);
+        CollectionResponse<ConfluencePage> response = await _transport.SendJsonAsync<CollectionResponse<ConfluencePage>>(HttpMethod.Get, relativeUri, null, ConfluenceRequestSafety.SafeToRetry, cancellationToken).ConfigureAwait(false);
+        return new ConfluencePageBatch(response.Results, response.Links?.Next);
+    }
+
+    /// <summary>Creates a page. Non-idempotent writes are never retried automatically.</summary>
+    public Task<ConfluencePage> CreatePageAsync(ConfluencePageCreateRequest request, CancellationToken cancellationToken = default) {
+        ConfluencePageWritePlan plan = PlanCreatePage(request);
+        using JsonDocument payload = JsonDocument.Parse(plan.Payload);
+        return _transport.SendJsonAsync<ConfluencePage>(HttpMethod.Post, plan.RelativeUri, payload.RootElement.Clone(), ConfluenceRequestSafety.NonIdempotent, cancellationToken);
+    }
+
+    /// <summary>Updates a page using the caller-supplied next version number. Writes are never retried automatically.</summary>
+    public Task<ConfluencePage> UpdatePageAsync(ConfluencePageUpdateRequest request, CancellationToken cancellationToken = default) {
+        ConfluencePageWritePlan plan = PlanUpdatePage(request);
+        using JsonDocument payload = JsonDocument.Parse(plan.Payload);
+        return _transport.SendJsonAsync<ConfluencePage>(HttpMethod.Put, plan.RelativeUri, payload.RootElement.Clone(), ConfluenceRequestSafety.NonIdempotent, cancellationToken);
+    }
+
+    /// <summary>Builds the exact create request without contacting Confluence.</summary>
+    public static ConfluencePageWritePlan PlanCreatePage(ConfluencePageCreateRequest request) {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+        ValidateId(request.SpaceId, nameof(request.SpaceId));
+        ValidateTitle(request.Title);
+        ValidateBody(request.Body);
+        var payload = new {
+            spaceId = request.SpaceId,
+            status = string.IsNullOrWhiteSpace(request.Status) ? "current" : request.Status,
+            title = request.Title,
+            parentId = string.IsNullOrWhiteSpace(request.ParentId) ? null : request.ParentId,
+            body = request.Body,
+        };
+        return new ConfluencePageWritePlan("POST", "/wiki/api/v2/pages", JsonSerializer.Serialize(payload, ConfluenceHttpTransport.JsonOptions));
+    }
+
+    /// <summary>Builds the exact update request without contacting Confluence.</summary>
+    public static ConfluencePageWritePlan PlanUpdatePage(ConfluencePageUpdateRequest request) {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+        ValidateId(request.PageId, nameof(request.PageId));
+        ValidateTitle(request.Title);
+        ValidateBody(request.Body);
+        if (request.VersionNumber < 1) throw new ArgumentOutOfRangeException(nameof(request.VersionNumber), "Version number must be the next positive page version.");
+        var payload = new {
+            id = request.PageId,
+            status = string.IsNullOrWhiteSpace(request.Status) ? "current" : request.Status,
+            title = request.Title,
+            body = request.Body,
+            version = new { number = request.VersionNumber, message = request.VersionMessage },
+        };
+        return new ConfluencePageWritePlan("PUT", "/wiki/api/v2/pages/" + Encode(request.PageId), JsonSerializer.Serialize(payload, ConfluenceHttpTransport.JsonOptions));
+    }
+
+    public void Dispose() => _transport.Dispose();
+
+    private static string BuildPageQuery(ConfluencePageQuery query) {
+        var values = new List<string> {
+            "limit=" + query.Limit.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            "body-format=" + Format(query.BodyFormat),
+        };
+        if (!string.IsNullOrWhiteSpace(query.SpaceId)) values.Add("space-id=" + Encode(query.SpaceId!));
+        if (!string.IsNullOrWhiteSpace(query.Title)) values.Add("title=" + Encode(query.Title!));
+        if (!string.IsNullOrWhiteSpace(query.Cursor)) values.Add("cursor=" + Encode(query.Cursor!));
+        return "/wiki/api/v2/pages?" + string.Join("&", values);
+    }
+
+    private static string Format(ConfluenceBodyFormat format) => format == ConfluenceBodyFormat.Storage ? "storage" : "atlas_doc_format";
+    private static string Encode(string value) => Uri.EscapeDataString(value);
+    private static void ValidateId(string value, string parameterName) { if (string.IsNullOrWhiteSpace(value)) throw new ArgumentException("Confluence identifier is required.", parameterName); }
+    private static void ValidateTitle(string value) { if (string.IsNullOrWhiteSpace(value)) throw new ArgumentException("Page title is required.", nameof(value)); }
+    private static void ValidateBody(ConfluencePageBody body) {
+        if (body == null) throw new ArgumentNullException(nameof(body));
+        if (string.IsNullOrWhiteSpace(body.Representation)) throw new ArgumentException("Page body representation is required.", nameof(body));
+        if (body.Value == null) throw new ArgumentException("Page body value is required.", nameof(body));
+    }
+
+    private sealed class CollectionResponse<T> {
+        [JsonPropertyName("results")]
+        public List<T> Results { get; set; } = new List<T>();
+        [JsonPropertyName("_links")]
+        public CollectionLinks? Links { get; set; }
+    }
+
+    private sealed class CollectionLinks {
+        [JsonPropertyName("next")]
+        public string? Next { get; set; }
+    }
+}

--- a/OfficeIMO.Confluence/ConfluenceContentConverter.cs
+++ b/OfficeIMO.Confluence/ConfluenceContentConverter.cs
@@ -19,23 +19,30 @@ public static class ConfluenceContentConverter {
     public static ConfluenceContentConversionResult<ConfluencePageBody> FromMarkdown(string markdown, ConfluenceBodyFormat format = ConfluenceBodyFormat.AtlasDocFormat) {
         if (markdown == null) throw new ArgumentNullException(nameof(markdown));
         AdfConversionResult<AdfDocument> adf = AdfConverter.FromMarkdown(markdown);
-        string value = format == ConfluenceBodyFormat.AtlasDocFormat
-            ? adf.Value.ToJson()
-            : MarkdownReader.Parse(markdown).ToHtmlFragment();
+        string value = format == ConfluenceBodyFormat.AtlasDocFormat ? adf.Value.ToJson() : MarkdownReader.Parse(markdown).ToHtmlFragment();
+        AdfConversionReport report = format == ConfluenceBodyFormat.AtlasDocFormat
+            ? adf.Report
+            : new AdfConversionReport(new[] {
+                new AdfConversionDiagnostic(
+                    "CONFLUENCE_MARKDOWN_STORAGE_PIPELINE",
+                    "$",
+                    "Markdown is rendered directly to Confluence storage HTML; no ADF conversion is performed.",
+                    AdfConversionSeverity.Information),
+            });
         return new ConfluenceContentConversionResult<ConfluencePageBody>(new ConfluencePageBody {
             Representation = format == ConfluenceBodyFormat.AtlasDocFormat ? "atlas_doc_format" : "storage",
             Value = value,
-        }, adf.Report);
+        }, report);
     }
 
     /// <summary>Creates a Confluence body from HTML. ADF output passes through OfficeIMO.Html and Markdown.</summary>
     public static ConfluenceContentConversionResult<ConfluencePageBody> FromHtml(string html, ConfluenceBodyFormat format = ConfluenceBodyFormat.Storage) {
         if (html == null) throw new ArgumentNullException(nameof(html));
-        AdfConversionResult<AdfDocument> adf = AdfConverter.FromHtml(html);
+        AdfConversionResult<AdfDocument>? adf = format == ConfluenceBodyFormat.AtlasDocFormat ? AdfConverter.FromHtml(html) : null;
         return new ConfluenceContentConversionResult<ConfluencePageBody>(new ConfluencePageBody {
             Representation = format == ConfluenceBodyFormat.AtlasDocFormat ? "atlas_doc_format" : "storage",
-            Value = format == ConfluenceBodyFormat.AtlasDocFormat ? adf.Value.ToJson() : html,
-        }, adf.Report);
+            Value = format == ConfluenceBodyFormat.AtlasDocFormat ? adf!.Value.ToJson() : html,
+        }, adf?.Report ?? AdfConversionReport.Empty);
     }
 
     /// <summary>Projects a page body to Markdown with an explicit fidelity report.</summary>
@@ -56,12 +63,13 @@ public static class ConfluenceContentConverter {
     /// <summary>Projects a page body to HTML with an explicit fidelity report.</summary>
     public static ConfluenceContentConversionResult<string> ToHtml(ConfluencePage page) {
         if (page == null) throw new ArgumentNullException(nameof(page));
-        if (!string.IsNullOrWhiteSpace(page.Body.Storage?.Value)) {
-            AdfConversionResult<AdfDocument> reportSource = AdfConverter.FromHtml(page.Body.Storage!.Value!);
-            return new ConfluenceContentConversionResult<string>(page.Body.Storage.Value!, reportSource.Report);
+        string? storage = page.Body?.Storage?.Value;
+        if (!string.IsNullOrWhiteSpace(storage)) {
+            return new ConfluenceContentConversionResult<string>(storage!, AdfConversionReport.Empty);
         }
-        if (!string.IsNullOrWhiteSpace(page.Body.AtlasDocFormat?.Value)) {
-            AdfConversionResult<string> result = AdfConverter.ToHtml(AdfDocument.Parse(page.Body.AtlasDocFormat!.Value!));
+        string? atlasDocFormat = page.Body?.AtlasDocFormat?.Value;
+        if (!string.IsNullOrWhiteSpace(atlasDocFormat)) {
+            AdfConversionResult<string> result = AdfConverter.ToHtml(AdfDocument.Parse(atlasDocFormat!));
             return new ConfluenceContentConversionResult<string>(result.Value, result.Report);
         }
         throw new InvalidOperationException("The Confluence page does not contain an ADF or storage body.");

--- a/OfficeIMO.Confluence/ConfluenceContentConverter.cs
+++ b/OfficeIMO.Confluence/ConfluenceContentConverter.cs
@@ -1,0 +1,73 @@
+using OfficeIMO.Adf;
+using OfficeIMO.Markdown;
+
+namespace OfficeIMO.Confluence;
+
+/// <summary>A converted Confluence body and its ADF fidelity evidence.</summary>
+public sealed class ConfluenceContentConversionResult<T> {
+    internal ConfluenceContentConversionResult(T value, AdfConversionReport report) {
+        Value = value;
+        Report = report;
+    }
+    public T Value { get; }
+    public AdfConversionReport Report { get; }
+}
+
+/// <summary>Creates and projects Confluence page bodies using OfficeIMO's ADF, Markdown, and HTML engines.</summary>
+public static class ConfluenceContentConverter {
+    /// <summary>Creates a Confluence ADF body from Markdown.</summary>
+    public static ConfluenceContentConversionResult<ConfluencePageBody> FromMarkdown(string markdown, ConfluenceBodyFormat format = ConfluenceBodyFormat.AtlasDocFormat) {
+        if (markdown == null) throw new ArgumentNullException(nameof(markdown));
+        AdfConversionResult<AdfDocument> adf = AdfConverter.FromMarkdown(markdown);
+        string value = format == ConfluenceBodyFormat.AtlasDocFormat
+            ? adf.Value.ToJson()
+            : MarkdownReader.Parse(markdown).ToHtmlFragment();
+        return new ConfluenceContentConversionResult<ConfluencePageBody>(new ConfluencePageBody {
+            Representation = format == ConfluenceBodyFormat.AtlasDocFormat ? "atlas_doc_format" : "storage",
+            Value = value,
+        }, adf.Report);
+    }
+
+    /// <summary>Creates a Confluence body from HTML. ADF output passes through OfficeIMO.Html and Markdown.</summary>
+    public static ConfluenceContentConversionResult<ConfluencePageBody> FromHtml(string html, ConfluenceBodyFormat format = ConfluenceBodyFormat.Storage) {
+        if (html == null) throw new ArgumentNullException(nameof(html));
+        AdfConversionResult<AdfDocument> adf = AdfConverter.FromHtml(html);
+        return new ConfluenceContentConversionResult<ConfluencePageBody>(new ConfluencePageBody {
+            Representation = format == ConfluenceBodyFormat.AtlasDocFormat ? "atlas_doc_format" : "storage",
+            Value = format == ConfluenceBodyFormat.AtlasDocFormat ? adf.Value.ToJson() : html,
+        }, adf.Report);
+    }
+
+    /// <summary>Projects a page body to Markdown with an explicit fidelity report.</summary>
+    public static ConfluenceContentConversionResult<string> ToMarkdown(ConfluencePage page) {
+        if (page == null) throw new ArgumentNullException(nameof(page));
+        if (!string.IsNullOrWhiteSpace(page.Body.AtlasDocFormat?.Value)) {
+            AdfConversionResult<string> result = AdfConverter.ToMarkdown(AdfDocument.Parse(page.Body.AtlasDocFormat!.Value!));
+            return new ConfluenceContentConversionResult<string>(result.Value, result.Report);
+        }
+        if (!string.IsNullOrWhiteSpace(page.Body.Storage?.Value)) {
+            AdfConversionResult<AdfDocument> adf = AdfConverter.FromHtml(page.Body.Storage!.Value!);
+            AdfConversionResult<string> result = AdfConverter.ToMarkdown(adf.Value);
+            return new ConfluenceContentConversionResult<string>(result.Value, Combine(adf.Report, result.Report));
+        }
+        throw new InvalidOperationException("The Confluence page does not contain an ADF or storage body.");
+    }
+
+    /// <summary>Projects a page body to HTML with an explicit fidelity report.</summary>
+    public static ConfluenceContentConversionResult<string> ToHtml(ConfluencePage page) {
+        if (page == null) throw new ArgumentNullException(nameof(page));
+        if (!string.IsNullOrWhiteSpace(page.Body.Storage?.Value)) {
+            AdfConversionResult<AdfDocument> reportSource = AdfConverter.FromHtml(page.Body.Storage!.Value!);
+            return new ConfluenceContentConversionResult<string>(page.Body.Storage.Value!, reportSource.Report);
+        }
+        if (!string.IsNullOrWhiteSpace(page.Body.AtlasDocFormat?.Value)) {
+            AdfConversionResult<string> result = AdfConverter.ToHtml(AdfDocument.Parse(page.Body.AtlasDocFormat!.Value!));
+            return new ConfluenceContentConversionResult<string>(result.Value, result.Report);
+        }
+        throw new InvalidOperationException("The Confluence page does not contain an ADF or storage body.");
+    }
+
+    private static AdfConversionReport Combine(AdfConversionReport first, AdfConversionReport second) {
+        return new AdfConversionReport(first.Diagnostics.Concat(second.Diagnostics));
+    }
+}

--- a/OfficeIMO.Confluence/ConfluenceCredentials.cs
+++ b/OfficeIMO.Confluence/ConfluenceCredentials.cs
@@ -1,0 +1,52 @@
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace OfficeIMO.Confluence;
+
+/// <summary>Applies caller-owned authentication to an outgoing Confluence request.</summary>
+public interface IConfluenceCredentialSource {
+    Task ApplyAsync(HttpRequestMessage request, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Applies Atlassian email/API-token basic authentication.</summary>
+public sealed class ConfluenceBasicCredentialSource : IConfluenceCredentialSource {
+    private readonly string _encodedCredential;
+
+    public ConfluenceBasicCredentialSource(string email, string apiToken) {
+        if (string.IsNullOrWhiteSpace(email)) throw new ArgumentException("Atlassian account email is required.", nameof(email));
+        if (string.IsNullOrWhiteSpace(apiToken)) throw new ArgumentException("Atlassian API token is required.", nameof(apiToken));
+        _encodedCredential = Convert.ToBase64String(Encoding.UTF8.GetBytes(email + ":" + apiToken));
+    }
+
+    public Task ApplyAsync(HttpRequestMessage request, CancellationToken cancellationToken = default) {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+        request.Headers.Authorization = new AuthenticationHeaderValue("Basic", _encodedCredential);
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>Applies a caller-supplied OAuth bearer token.</summary>
+public sealed class ConfluenceBearerCredentialSource : IConfluenceCredentialSource {
+    private readonly string _accessToken;
+
+    public ConfluenceBearerCredentialSource(string accessToken) {
+        if (string.IsNullOrWhiteSpace(accessToken)) throw new ArgumentException("Access token is required.", nameof(accessToken));
+        _accessToken = accessToken;
+    }
+
+    public Task ApplyAsync(HttpRequestMessage request, CancellationToken cancellationToken = default) {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>Delegates authentication to a caller-owned token or signing workflow.</summary>
+public sealed class ConfluenceDelegateCredentialSource : IConfluenceCredentialSource {
+    private readonly Func<HttpRequestMessage, CancellationToken, Task> _apply;
+
+    public ConfluenceDelegateCredentialSource(Func<HttpRequestMessage, CancellationToken, Task> apply) =>
+        _apply = apply ?? throw new ArgumentNullException(nameof(apply));
+
+    public Task ApplyAsync(HttpRequestMessage request, CancellationToken cancellationToken = default) => _apply(request, cancellationToken);
+}

--- a/OfficeIMO.Confluence/ConfluenceHttpTransport.cs
+++ b/OfficeIMO.Confluence/ConfluenceHttpTransport.cs
@@ -167,22 +167,10 @@ internal sealed class ConfluenceHttpTransport : IDisposable {
 
             using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             timeout.CancelAfter(_session.RuntimeOptions.RequestTimeout);
-            HttpResponseMessage response;
             try {
-                response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeout.Token).ConfigureAwait(false);
-            } catch (HttpRequestException) when (CanRetry(safety, attempt)) {
-                TimeSpan delay = GetRetryDelay(attempt);
-                attempt++;
-                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
-                continue;
-            } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && CanRetry(safety, attempt)) {
-                TimeSpan delay = GetRetryDelay(attempt);
-                attempt++;
-                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
-                continue;
-            }
-
-            using (response) {
+                using HttpResponseMessage response = await _client
+                    .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeout.Token)
+                    .ConfigureAwait(false);
                 if (ShouldRetry(response.StatusCode, safety, attempt)) {
                     TimeSpan delay = GetRetryDelay(response, attempt);
                     attempt++;
@@ -194,6 +182,16 @@ internal sealed class ConfluenceHttpTransport : IDisposable {
                     throw new ConfluenceApiException(response.StatusCode, method.Method, uri, Encoding.UTF8.GetString(body));
                 }
                 return await readSuccess(response, timeout.Token).ConfigureAwait(false);
+            } catch (HttpRequestException) when (CanRetry(safety, attempt)) {
+                TimeSpan delay = GetRetryDelay(attempt);
+                attempt++;
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                continue;
+            } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && CanRetry(safety, attempt)) {
+                TimeSpan delay = GetRetryDelay(attempt);
+                attempt++;
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                continue;
             }
         }
     }

--- a/OfficeIMO.Confluence/ConfluenceHttpTransport.cs
+++ b/OfficeIMO.Confluence/ConfluenceHttpTransport.cs
@@ -43,6 +43,15 @@ internal sealed class ConfluenceHttpResponse {
     internal IReadOnlyDictionary<string, IReadOnlyList<string>> Headers { get; }
 }
 
+internal sealed class ConfluenceJsonResponse<T> {
+    internal ConfluenceJsonResponse(T value, IReadOnlyDictionary<string, IReadOnlyList<string>> headers) {
+        Value = value;
+        Headers = headers;
+    }
+    internal T Value { get; }
+    internal IReadOnlyDictionary<string, IReadOnlyList<string>> Headers { get; }
+}
+
 internal sealed class ConfluenceHttpTransport : IDisposable {
     internal static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions {
         PropertyNameCaseInsensitive = true,
@@ -56,12 +65,17 @@ internal sealed class ConfluenceHttpTransport : IDisposable {
 
     internal ConfluenceHttpTransport(ConfluenceSession session) {
         _session = session ?? throw new ArgumentNullException(nameof(session));
-        _ownsClient = session.Options.HttpClient == null;
-        _client = session.Options.HttpClient ?? new HttpClient();
+        _ownsClient = session.RuntimeOptions.HttpClient == null;
+        _client = session.RuntimeOptions.HttpClient ?? new HttpClient();
         if (_ownsClient) _client.Timeout = Timeout.InfiniteTimeSpan;
     }
 
     internal async Task<T> SendJsonAsync<T>(HttpMethod method, string relativeUri, object? payload, ConfluenceRequestSafety safety, CancellationToken cancellationToken) {
+        ConfluenceJsonResponse<T> response = await SendJsonWithHeadersAsync<T>(method, relativeUri, payload, safety, cancellationToken).ConfigureAwait(false);
+        return response.Value;
+    }
+
+    internal async Task<ConfluenceJsonResponse<T>> SendJsonWithHeadersAsync<T>(HttpMethod method, string relativeUri, object? payload, ConfluenceRequestSafety safety, CancellationToken cancellationToken) {
         ConfluenceHttpResponse response = await SendAsync(
             method,
             relativeUri,
@@ -69,13 +83,24 @@ internal sealed class ConfluenceHttpTransport : IDisposable {
             null,
             safety,
             cancellationToken).ConfigureAwait(false);
-        if (response.Body.Length == 0) return default!;
+        if (response.Body.Length == 0) return new ConfluenceJsonResponse<T>(default!, response.Headers);
         T? value = JsonSerializer.Deserialize<T>(response.Body, JsonOptions);
-        return value == null ? throw new InvalidOperationException("Confluence returned an empty or invalid JSON response.") : value;
+        return value == null
+            ? throw new InvalidOperationException("Confluence returned an empty or invalid JSON response.")
+            : new ConfluenceJsonResponse<T>(value, response.Headers);
     }
 
     internal Task<ConfluenceHttpResponse> SendRawAsync(HttpMethod method, string relativeUri, CancellationToken cancellationToken) =>
         SendAsync(method, relativeUri, null, null, ConfluenceRequestSafety.SafeToRetry, cancellationToken);
+
+    internal Task<ConfluenceHttpResponse> SendRawAsync(HttpMethod method, string relativeUri, ConfluenceRequestSafety safety, CancellationToken cancellationToken) =>
+        SendAsync(method, relativeUri, null, null, safety, cancellationToken);
+
+    internal Task SendToStreamAsync(HttpMethod method, string relativeUri, Stream destination, CancellationToken cancellationToken) {
+        if (destination == null) throw new ArgumentNullException(nameof(destination));
+        if (!destination.CanWrite) throw new ArgumentException("Attachment destination stream must be writable.", nameof(destination));
+        return SendToStreamCoreAsync(method, relativeUri, destination, cancellationToken);
+    }
 
     internal Task<ConfluenceHttpResponse> SendMultipartAsync(string relativeUri, Func<HttpContent> contentFactory, CancellationToken cancellationToken) =>
         SendAsync(HttpMethod.Put, relativeUri, contentFactory, request => request.Headers.TryAddWithoutValidation("X-Atlassian-Token", "nocheck"), ConfluenceRequestSafety.NonIdempotent, cancellationToken);
@@ -86,53 +111,101 @@ internal sealed class ConfluenceHttpTransport : IDisposable {
         _disposed = true;
     }
 
+    private async Task SendToStreamCoreAsync(HttpMethod method, string relativeUri, Stream destination, CancellationToken cancellationToken) {
+        await SendAsync(
+                method,
+                relativeUri,
+                null,
+                null,
+                ConfluenceRequestSafety.SafeToRetry,
+                cancellationToken,
+                async (response, token) => {
+                    using Stream source = await ReadAsStreamAsync(response.Content, token).ConfigureAwait(false);
+                    await source.CopyToAsync(destination, 81920, token).ConfigureAwait(false);
+                    return true;
+                })
+            .ConfigureAwait(false);
+    }
+
     private async Task<ConfluenceHttpResponse> SendAsync(
         HttpMethod method,
         string relativeUri,
         Func<HttpContent>? contentFactory,
         Action<HttpRequestMessage>? configure,
         ConfluenceRequestSafety safety,
-        CancellationToken cancellationToken) {
+        CancellationToken cancellationToken) => await SendAsync(
+            method,
+            relativeUri,
+            contentFactory,
+            configure,
+            safety,
+            cancellationToken,
+            async (response, token) => new ConfluenceHttpResponse(
+                response.StatusCode,
+                await ReadBodyAsync(response.Content, token).ConfigureAwait(false),
+                CaptureHeaders(response)))
+        .ConfigureAwait(false);
+
+    private async Task<T> SendAsync<T>(
+        HttpMethod method,
+        string relativeUri,
+        Func<HttpContent>? contentFactory,
+        Action<HttpRequestMessage>? configure,
+        ConfluenceRequestSafety safety,
+        CancellationToken cancellationToken,
+        Func<HttpResponseMessage, CancellationToken, Task<T>> readSuccess) {
         ThrowIfDisposed();
         Uri uri = ResolveUri(relativeUri);
         int attempt = 0;
         while (true) {
             using var request = new HttpRequestMessage(method, uri);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            request.Headers.UserAgent.ParseAdd(BuildUserAgent(_session.Options.ApplicationName));
+            request.Headers.UserAgent.ParseAdd(BuildUserAgent(_session.RuntimeOptions.ApplicationName));
             request.Content = contentFactory?.Invoke();
             configure?.Invoke(request);
             await _session.CredentialSource.ApplyAsync(request, cancellationToken).ConfigureAwait(false);
 
             using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            timeout.CancelAfter(_session.Options.RequestTimeout);
-            HttpResponseMessage response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeout.Token).ConfigureAwait(false);
-            if (ShouldRetry(response.StatusCode, safety, attempt)) {
-                TimeSpan delay = GetRetryDelay(response, attempt);
-                response.Dispose();
+            timeout.CancelAfter(_session.RuntimeOptions.RequestTimeout);
+            HttpResponseMessage response;
+            try {
+                response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeout.Token).ConfigureAwait(false);
+            } catch (HttpRequestException) when (CanRetry(safety, attempt)) {
+                TimeSpan delay = GetRetryDelay(attempt);
+                attempt++;
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                continue;
+            } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && CanRetry(safety, attempt)) {
+                TimeSpan delay = GetRetryDelay(attempt);
                 attempt++;
                 await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
                 continue;
             }
 
             using (response) {
-                byte[] body = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                if (ShouldRetry(response.StatusCode, safety, attempt)) {
+                    TimeSpan delay = GetRetryDelay(response, attempt);
+                    attempt++;
+                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
                 if (!response.IsSuccessStatusCode) {
+                    byte[] body = await ReadBodyAsync(response.Content, timeout.Token).ConfigureAwait(false);
                     throw new ConfluenceApiException(response.StatusCode, method.Method, uri, Encoding.UTF8.GetString(body));
                 }
-                var headers = response.Headers.Concat(response.Content.Headers)
-                    .GroupBy(item => item.Key, StringComparer.OrdinalIgnoreCase)
-                    .ToDictionary(group => group.Key, group => (IReadOnlyList<string>)group.SelectMany(item => item.Value).ToArray(), StringComparer.OrdinalIgnoreCase);
-                return new ConfluenceHttpResponse(response.StatusCode, body, headers);
+                return await readSuccess(response, timeout.Token).ConfigureAwait(false);
             }
         }
     }
 
     private bool ShouldRetry(HttpStatusCode statusCode, ConfluenceRequestSafety safety, int attempt) {
-        if (safety != ConfluenceRequestSafety.SafeToRetry || attempt >= _session.Options.MaxRetryCount) return false;
+        if (!CanRetry(safety, attempt)) return false;
         int code = (int)statusCode;
         return code == 429 || code == 500 || code == 502 || code == 503 || code == 504;
     }
+
+    private bool CanRetry(ConfluenceRequestSafety safety, int attempt) =>
+        safety == ConfluenceRequestSafety.SafeToRetry && attempt < _session.RuntimeOptions.MaxRetryCount;
 
     private TimeSpan GetRetryDelay(HttpResponseMessage response, int attempt) {
         if (response.Headers.RetryAfter?.Delta is TimeSpan delta && delta > TimeSpan.Zero) return Clamp(delta);
@@ -141,18 +214,59 @@ internal sealed class ConfluenceHttpTransport : IDisposable {
             if (until > TimeSpan.Zero) return Clamp(until);
         }
         double multiplier = Math.Pow(2, attempt);
-        return Clamp(TimeSpan.FromMilliseconds(_session.Options.RetryBaseDelay.TotalMilliseconds * multiplier));
+        return Clamp(TimeSpan.FromMilliseconds(_session.RuntimeOptions.RetryBaseDelay.TotalMilliseconds * multiplier));
     }
 
-    private TimeSpan Clamp(TimeSpan delay) => delay > _session.Options.RetryMaxDelay ? _session.Options.RetryMaxDelay : delay;
+    private TimeSpan GetRetryDelay(int attempt) {
+        double multiplier = Math.Pow(2, attempt);
+        return Clamp(TimeSpan.FromMilliseconds(_session.RuntimeOptions.RetryBaseDelay.TotalMilliseconds * multiplier));
+    }
+
+    private TimeSpan Clamp(TimeSpan delay) => delay > _session.RuntimeOptions.RetryMaxDelay ? _session.RuntimeOptions.RetryMaxDelay : delay;
 
     private Uri ResolveUri(string relativeUri) {
         if (string.IsNullOrWhiteSpace(relativeUri)) throw new ArgumentException("Confluence request URI is required.", nameof(relativeUri));
-        if (Uri.TryCreate(relativeUri, UriKind.Absolute, out Uri? absolute)) {
-            if (!string.Equals(absolute.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)) throw new InvalidOperationException("Confluence requests must use HTTPS.");
-            return absolute;
+        Uri resolved = Uri.TryCreate(relativeUri, UriKind.Absolute, out Uri? absolute)
+            ? absolute
+            : new Uri(_session.ApiBaseUri, relativeUri.TrimStart('/'));
+        ValidateResolvedUri(resolved);
+        return resolved;
+    }
+
+    private void ValidateResolvedUri(Uri uri) {
+        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)) throw new InvalidOperationException("Confluence requests must use HTTPS.");
+        if (!string.IsNullOrEmpty(uri.UserInfo)) throw new InvalidOperationException("Confluence request URIs cannot contain embedded credentials.");
+        Uri expected = _session.ApiBaseUri;
+        if (!string.Equals(uri.Scheme, expected.Scheme, StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(uri.Host, expected.Host, StringComparison.OrdinalIgnoreCase) ||
+            uri.Port != expected.Port) {
+            throw new InvalidOperationException("Confluence requests cannot leave the configured API origin.");
         }
-        return new Uri(_session.Options.SiteUri, relativeUri.StartsWith("/", StringComparison.Ordinal) ? relativeUri : "/" + relativeUri);
+        string expectedPath = expected.AbsolutePath.EndsWith("/", StringComparison.Ordinal) ? expected.AbsolutePath : expected.AbsolutePath + "/";
+        if (!uri.AbsolutePath.StartsWith(expectedPath, StringComparison.Ordinal)) {
+            throw new InvalidOperationException("Confluence requests cannot leave the configured API path.");
+        }
+    }
+
+    private static IReadOnlyDictionary<string, IReadOnlyList<string>> CaptureHeaders(HttpResponseMessage response) =>
+        response.Headers.Concat(response.Content.Headers)
+            .GroupBy(item => item.Key, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => (IReadOnlyList<string>)group.SelectMany(item => item.Value).ToArray(), StringComparer.OrdinalIgnoreCase);
+
+    private static async Task<byte[]> ReadBodyAsync(HttpContent content, CancellationToken cancellationToken) {
+        using Stream source = await ReadAsStreamAsync(content, cancellationToken).ConfigureAwait(false);
+        using var buffer = new MemoryStream();
+        await source.CopyToAsync(buffer, 81920, cancellationToken).ConfigureAwait(false);
+        return buffer.ToArray();
+    }
+
+    private static Task<Stream> ReadAsStreamAsync(HttpContent content, CancellationToken cancellationToken) {
+#if NET8_0_OR_GREATER
+        return content.ReadAsStreamAsync(cancellationToken);
+#else
+        cancellationToken.ThrowIfCancellationRequested();
+        return content.ReadAsStreamAsync();
+#endif
     }
 
     private static string BuildUserAgent(string? applicationName) {

--- a/OfficeIMO.Confluence/ConfluenceHttpTransport.cs
+++ b/OfficeIMO.Confluence/ConfluenceHttpTransport.cs
@@ -1,0 +1,166 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace OfficeIMO.Confluence;
+
+internal enum ConfluenceRequestSafety {
+    SafeToRetry,
+    NonIdempotent,
+}
+
+/// <summary>An error returned by Confluence Cloud.</summary>
+public sealed class ConfluenceApiException : Exception {
+    internal ConfluenceApiException(HttpStatusCode statusCode, string method, Uri requestUri, string responseBody)
+        : base(BuildMessage(statusCode, method, requestUri, responseBody)) {
+        StatusCode = statusCode;
+        RequestMethod = method;
+        RequestUri = requestUri;
+        ResponseBody = responseBody;
+    }
+
+    public HttpStatusCode StatusCode { get; }
+    public string RequestMethod { get; }
+    public Uri RequestUri { get; }
+    public string ResponseBody { get; }
+
+    private static string BuildMessage(HttpStatusCode statusCode, string method, Uri requestUri, string responseBody) {
+        string compact = string.IsNullOrWhiteSpace(responseBody) ? "No response body." : responseBody.Trim();
+        if (compact.Length > 2048) compact = compact.Substring(0, 2048) + "...";
+        return "Confluence " + method + " " + requestUri.PathAndQuery + " failed with HTTP " + (int)statusCode + ": " + compact;
+    }
+}
+
+internal sealed class ConfluenceHttpResponse {
+    internal ConfluenceHttpResponse(HttpStatusCode statusCode, byte[] body, IReadOnlyDictionary<string, IReadOnlyList<string>> headers) {
+        StatusCode = statusCode;
+        Body = body;
+        Headers = headers;
+    }
+    internal HttpStatusCode StatusCode { get; }
+    internal byte[] Body { get; }
+    internal IReadOnlyDictionary<string, IReadOnlyList<string>> Headers { get; }
+}
+
+internal sealed class ConfluenceHttpTransport : IDisposable {
+    internal static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions {
+        PropertyNameCaseInsensitive = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly ConfluenceSession _session;
+    private readonly HttpClient _client;
+    private readonly bool _ownsClient;
+    private bool _disposed;
+
+    internal ConfluenceHttpTransport(ConfluenceSession session) {
+        _session = session ?? throw new ArgumentNullException(nameof(session));
+        _ownsClient = session.Options.HttpClient == null;
+        _client = session.Options.HttpClient ?? new HttpClient();
+        if (_ownsClient) _client.Timeout = Timeout.InfiniteTimeSpan;
+    }
+
+    internal async Task<T> SendJsonAsync<T>(HttpMethod method, string relativeUri, object? payload, ConfluenceRequestSafety safety, CancellationToken cancellationToken) {
+        ConfluenceHttpResponse response = await SendAsync(
+            method,
+            relativeUri,
+            payload == null ? null : (() => new StringContent(JsonSerializer.Serialize(payload, JsonOptions), Encoding.UTF8, "application/json")),
+            null,
+            safety,
+            cancellationToken).ConfigureAwait(false);
+        if (response.Body.Length == 0) return default!;
+        T? value = JsonSerializer.Deserialize<T>(response.Body, JsonOptions);
+        return value == null ? throw new InvalidOperationException("Confluence returned an empty or invalid JSON response.") : value;
+    }
+
+    internal Task<ConfluenceHttpResponse> SendRawAsync(HttpMethod method, string relativeUri, CancellationToken cancellationToken) =>
+        SendAsync(method, relativeUri, null, null, ConfluenceRequestSafety.SafeToRetry, cancellationToken);
+
+    internal Task<ConfluenceHttpResponse> SendMultipartAsync(string relativeUri, Func<HttpContent> contentFactory, CancellationToken cancellationToken) =>
+        SendAsync(HttpMethod.Put, relativeUri, contentFactory, request => request.Headers.TryAddWithoutValidation("X-Atlassian-Token", "nocheck"), ConfluenceRequestSafety.NonIdempotent, cancellationToken);
+
+    public void Dispose() {
+        if (_disposed) return;
+        if (_ownsClient) _client.Dispose();
+        _disposed = true;
+    }
+
+    private async Task<ConfluenceHttpResponse> SendAsync(
+        HttpMethod method,
+        string relativeUri,
+        Func<HttpContent>? contentFactory,
+        Action<HttpRequestMessage>? configure,
+        ConfluenceRequestSafety safety,
+        CancellationToken cancellationToken) {
+        ThrowIfDisposed();
+        Uri uri = ResolveUri(relativeUri);
+        int attempt = 0;
+        while (true) {
+            using var request = new HttpRequestMessage(method, uri);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            request.Headers.UserAgent.ParseAdd(BuildUserAgent(_session.Options.ApplicationName));
+            request.Content = contentFactory?.Invoke();
+            configure?.Invoke(request);
+            await _session.CredentialSource.ApplyAsync(request, cancellationToken).ConfigureAwait(false);
+
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(_session.Options.RequestTimeout);
+            HttpResponseMessage response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeout.Token).ConfigureAwait(false);
+            if (ShouldRetry(response.StatusCode, safety, attempt)) {
+                TimeSpan delay = GetRetryDelay(response, attempt);
+                response.Dispose();
+                attempt++;
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                continue;
+            }
+
+            using (response) {
+                byte[] body = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                if (!response.IsSuccessStatusCode) {
+                    throw new ConfluenceApiException(response.StatusCode, method.Method, uri, Encoding.UTF8.GetString(body));
+                }
+                var headers = response.Headers.Concat(response.Content.Headers)
+                    .GroupBy(item => item.Key, StringComparer.OrdinalIgnoreCase)
+                    .ToDictionary(group => group.Key, group => (IReadOnlyList<string>)group.SelectMany(item => item.Value).ToArray(), StringComparer.OrdinalIgnoreCase);
+                return new ConfluenceHttpResponse(response.StatusCode, body, headers);
+            }
+        }
+    }
+
+    private bool ShouldRetry(HttpStatusCode statusCode, ConfluenceRequestSafety safety, int attempt) {
+        if (safety != ConfluenceRequestSafety.SafeToRetry || attempt >= _session.Options.MaxRetryCount) return false;
+        int code = (int)statusCode;
+        return code == 429 || code == 500 || code == 502 || code == 503 || code == 504;
+    }
+
+    private TimeSpan GetRetryDelay(HttpResponseMessage response, int attempt) {
+        if (response.Headers.RetryAfter?.Delta is TimeSpan delta && delta > TimeSpan.Zero) return Clamp(delta);
+        if (response.Headers.RetryAfter?.Date is DateTimeOffset date) {
+            TimeSpan until = date - DateTimeOffset.UtcNow;
+            if (until > TimeSpan.Zero) return Clamp(until);
+        }
+        double multiplier = Math.Pow(2, attempt);
+        return Clamp(TimeSpan.FromMilliseconds(_session.Options.RetryBaseDelay.TotalMilliseconds * multiplier));
+    }
+
+    private TimeSpan Clamp(TimeSpan delay) => delay > _session.Options.RetryMaxDelay ? _session.Options.RetryMaxDelay : delay;
+
+    private Uri ResolveUri(string relativeUri) {
+        if (string.IsNullOrWhiteSpace(relativeUri)) throw new ArgumentException("Confluence request URI is required.", nameof(relativeUri));
+        if (Uri.TryCreate(relativeUri, UriKind.Absolute, out Uri? absolute)) {
+            if (!string.Equals(absolute.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)) throw new InvalidOperationException("Confluence requests must use HTTPS.");
+            return absolute;
+        }
+        return new Uri(_session.Options.SiteUri, relativeUri.StartsWith("/", StringComparison.Ordinal) ? relativeUri : "/" + relativeUri);
+    }
+
+    private static string BuildUserAgent(string? applicationName) {
+        string value = string.IsNullOrWhiteSpace(applicationName) ? "OfficeIMO" : applicationName!.Trim();
+        return value.Replace(' ', '-') + "/3.0";
+    }
+
+    private void ThrowIfDisposed() {
+        if (_disposed) throw new ObjectDisposedException(nameof(ConfluenceHttpTransport));
+    }
+}

--- a/OfficeIMO.Confluence/ConfluenceHttpTransport.cs
+++ b/OfficeIMO.Confluence/ConfluenceHttpTransport.cs
@@ -103,7 +103,7 @@ internal sealed class ConfluenceHttpTransport : IDisposable {
     }
 
     internal Task<ConfluenceHttpResponse> SendMultipartAsync(string relativeUri, Func<HttpContent> contentFactory, CancellationToken cancellationToken) =>
-        SendAsync(HttpMethod.Put, relativeUri, contentFactory, request => request.Headers.TryAddWithoutValidation("X-Atlassian-Token", "nocheck"), ConfluenceRequestSafety.NonIdempotent, cancellationToken);
+        SendAsync(HttpMethod.Post, relativeUri, contentFactory, request => request.Headers.TryAddWithoutValidation("X-Atlassian-Token", "nocheck"), ConfluenceRequestSafety.NonIdempotent, cancellationToken);
 
     public void Dispose() {
         if (_disposed) return;
@@ -112,19 +112,43 @@ internal sealed class ConfluenceHttpTransport : IDisposable {
     }
 
     private async Task SendToStreamCoreAsync(HttpMethod method, string relativeUri, Stream destination, CancellationToken cancellationToken) {
-        await SendAsync(
-                method,
-                relativeUri,
-                null,
-                null,
-                ConfluenceRequestSafety.SafeToRetry,
-                cancellationToken,
-                async (response, token) => {
-                    using Stream source = await ReadAsStreamAsync(response.Content, token).ConfigureAwait(false);
-                    await source.CopyToAsync(destination, 81920, token).ConfigureAwait(false);
-                    return true;
-                })
-            .ConfigureAwait(false);
+        string bufferPath = Path.Combine(Path.GetTempPath(), "officeimo-confluence-" + Guid.NewGuid().ToString("N") + ".tmp");
+        try {
+            using (var buffer = new FileStream(
+                       bufferPath,
+                       FileMode.CreateNew,
+                       FileAccess.ReadWrite,
+                       FileShare.None,
+                       81920,
+                       FileOptions.Asynchronous | FileOptions.SequentialScan)) {
+                await SendAsync(
+                        method,
+                        relativeUri,
+                        null,
+                        null,
+                        ConfluenceRequestSafety.SafeToRetry,
+                        cancellationToken,
+                        async (response, token) => {
+                            buffer.Position = 0;
+                            buffer.SetLength(0);
+                            using Stream source = await ReadAsStreamAsync(response.Content, token).ConfigureAwait(false);
+                            await source.CopyToAsync(buffer, 81920, token).ConfigureAwait(false);
+                            return true;
+                        })
+                    .ConfigureAwait(false);
+
+                buffer.Position = 0;
+                await buffer.CopyToAsync(destination, 81920, cancellationToken).ConfigureAwait(false);
+            }
+        } finally {
+            try {
+                File.Delete(bufferPath);
+            } catch (IOException) {
+                // The completed operation is more useful than surfacing best-effort temp cleanup.
+            } catch (UnauthorizedAccessException) {
+                // The completed operation is more useful than surfacing best-effort temp cleanup.
+            }
+        }
     }
 
     private async Task<ConfluenceHttpResponse> SendAsync(
@@ -224,9 +248,11 @@ internal sealed class ConfluenceHttpTransport : IDisposable {
 
     private Uri ResolveUri(string relativeUri) {
         if (string.IsNullOrWhiteSpace(relativeUri)) throw new ArgumentException("Confluence request URI is required.", nameof(relativeUri));
-        Uri resolved = Uri.TryCreate(relativeUri, UriKind.Absolute, out Uri? absolute)
-            ? absolute
-            : new Uri(_session.ApiBaseUri, relativeUri.TrimStart('/'));
+        Uri resolved = relativeUri.StartsWith("/", StringComparison.Ordinal)
+            ? new Uri(_session.ApiBaseUri, relativeUri.TrimStart('/'))
+            : Uri.TryCreate(relativeUri, UriKind.Absolute, out Uri? absolute)
+                ? absolute
+                : new Uri(_session.ApiBaseUri, relativeUri);
         ValidateResolvedUri(resolved);
         return resolved;
     }

--- a/OfficeIMO.Confluence/ConfluenceManagedSection.cs
+++ b/OfficeIMO.Confluence/ConfluenceManagedSection.cs
@@ -1,0 +1,84 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace OfficeIMO.Confluence;
+
+/// <summary>Behavior when a managed section marker pair does not exist.</summary>
+public enum ConfluenceMissingSectionBehavior {
+    Fail,
+    Append,
+}
+
+/// <summary>Pure result of replacing one OfficeIMO-managed page-body section.</summary>
+public sealed class ConfluenceManagedSectionResult {
+    internal ConfluenceManagedSectionResult(string sectionId, string originalBody, string updatedBody, bool created) {
+        SectionId = sectionId;
+        OriginalBody = originalBody;
+        UpdatedBody = updatedBody;
+        WasCreated = created;
+        OriginalSha256 = ComputeHash(originalBody);
+        UpdatedSha256 = ComputeHash(updatedBody);
+    }
+
+    public string SectionId { get; }
+    public string OriginalBody { get; }
+    public string UpdatedBody { get; }
+    public bool WasCreated { get; }
+    public bool Changed => !string.Equals(OriginalBody, UpdatedBody, StringComparison.Ordinal);
+    public string OriginalSha256 { get; }
+    public string UpdatedSha256 { get; }
+
+    private static string ComputeHash(string value) {
+        using SHA256 sha = SHA256.Create();
+        byte[] hash = sha.ComputeHash(Encoding.UTF8.GetBytes(value ?? string.Empty));
+        var builder = new StringBuilder(hash.Length * 2);
+        foreach (byte item in hash) builder.Append(item.ToString("x2", System.Globalization.CultureInfo.InvariantCulture));
+        return builder.ToString();
+    }
+}
+
+/// <summary>Safely replaces content between stable OfficeIMO markers while preserving the rest of the page.</summary>
+public static class ConfluenceManagedSection {
+    private static readonly Regex SectionIdPattern = new Regex("^[A-Za-z0-9._-]{1,100}$", RegexOptions.CultureInvariant);
+    private const string MarkerPrefix = "<!-- officeimo:section:";
+
+    public static ConfluenceManagedSectionResult Apply(
+        string existingBody,
+        string sectionId,
+        string replacement,
+        ConfluenceMissingSectionBehavior missingBehavior = ConfluenceMissingSectionBehavior.Fail) {
+        existingBody ??= string.Empty;
+        replacement ??= string.Empty;
+        ValidateSectionId(sectionId);
+        if (replacement.IndexOf(MarkerPrefix, StringComparison.OrdinalIgnoreCase) >= 0) throw new ArgumentException("Replacement content cannot contain OfficeIMO section markers.", nameof(replacement));
+
+        string start = StartMarker(sectionId);
+        string end = EndMarker(sectionId);
+        int startIndex = existingBody.IndexOf(start, StringComparison.Ordinal);
+        int endIndex = existingBody.IndexOf(end, StringComparison.Ordinal);
+
+        if (startIndex < 0 && endIndex < 0) {
+            if (missingBehavior == ConfluenceMissingSectionBehavior.Fail) throw new InvalidOperationException("Managed section '" + sectionId + "' does not exist.");
+            string separator = existingBody.Length == 0 ? string.Empty : existingBody.EndsWith("\n", StringComparison.Ordinal) ? "\n" : "\n\n";
+            string appended = existingBody + separator + start + "\n" + replacement + "\n" + end;
+            return new ConfluenceManagedSectionResult(sectionId, existingBody, appended, created: true);
+        }
+
+        if (startIndex < 0 || endIndex < 0 || endIndex < startIndex) throw new InvalidOperationException("Managed section '" + sectionId + "' has unmatched or reversed markers.");
+        if (existingBody.IndexOf(start, startIndex + start.Length, StringComparison.Ordinal) >= 0 || existingBody.IndexOf(end, endIndex + end.Length, StringComparison.Ordinal) >= 0) {
+            throw new InvalidOperationException("Managed section '" + sectionId + "' appears more than once.");
+        }
+
+        int contentStart = startIndex + start.Length;
+        string updated = existingBody.Substring(0, contentStart) + "\n" + replacement + "\n" + existingBody.Substring(endIndex);
+        return new ConfluenceManagedSectionResult(sectionId, existingBody, updated, created: false);
+    }
+
+    public static string StartMarker(string sectionId) { ValidateSectionId(sectionId); return MarkerPrefix + sectionId + ":start -->"; }
+    public static string EndMarker(string sectionId) { ValidateSectionId(sectionId); return MarkerPrefix + sectionId + ":end -->"; }
+
+    private static void ValidateSectionId(string sectionId) {
+        if (string.IsNullOrWhiteSpace(sectionId) || !SectionIdPattern.IsMatch(sectionId)) throw new ArgumentException("Section id must contain 1-100 letters, digits, dots, underscores, or hyphens.", nameof(sectionId));
+    }
+}

--- a/OfficeIMO.Confluence/ConfluenceModels.cs
+++ b/OfficeIMO.Confluence/ConfluenceModels.cs
@@ -1,0 +1,123 @@
+using System.Text.Json.Serialization;
+
+namespace OfficeIMO.Confluence;
+
+/// <summary>Confluence page body representation.</summary>
+public enum ConfluenceBodyFormat {
+    Storage,
+    AtlasDocFormat,
+}
+
+/// <summary>A Confluence page version.</summary>
+public sealed class ConfluencePageVersion {
+    [JsonPropertyName("number")]
+    public int Number { get; set; }
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
+    [JsonPropertyName("minorEdit")]
+    public bool MinorEdit { get; set; }
+}
+
+/// <summary>A represented Confluence page body.</summary>
+public sealed class ConfluencePageBody {
+    [JsonPropertyName("representation")]
+    public string? Representation { get; set; }
+    [JsonPropertyName("value")]
+    public string? Value { get; set; }
+}
+
+/// <summary>Body representations returned for a page.</summary>
+public sealed class ConfluencePageBodies {
+    [JsonPropertyName("storage")]
+    public ConfluencePageBody? Storage { get; set; }
+    [JsonPropertyName("atlas_doc_format")]
+    public ConfluencePageBody? AtlasDocFormat { get; set; }
+    [JsonPropertyName("view")]
+    public ConfluencePageBody? View { get; set; }
+}
+
+/// <summary>A Confluence Cloud page.</summary>
+public sealed class ConfluencePage {
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = string.Empty;
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = string.Empty;
+    [JsonPropertyName("spaceId")]
+    public string SpaceId { get; set; } = string.Empty;
+    [JsonPropertyName("parentId")]
+    public string? ParentId { get; set; }
+    [JsonPropertyName("version")]
+    public ConfluencePageVersion Version { get; set; } = new ConfluencePageVersion();
+    [JsonPropertyName("body")]
+    public ConfluencePageBodies Body { get; set; } = new ConfluencePageBodies();
+}
+
+/// <summary>A cursor-addressable page batch.</summary>
+public sealed class ConfluencePageBatch {
+    internal ConfluencePageBatch(IReadOnlyList<ConfluencePage> pages, string? nextRelativeUri) {
+        Pages = pages;
+        NextRelativeUri = nextRelativeUri;
+    }
+    public IReadOnlyList<ConfluencePage> Pages { get; }
+    public string? NextRelativeUri { get; }
+    /// <summary>Decoded cursor for requesting the next batch, or null when enumeration is complete.</summary>
+    public string? NextCursor => ConfluenceCursor.Extract(NextRelativeUri);
+}
+
+internal static class ConfluenceCursor {
+    public static string? Extract(string? relativeUri) {
+        if (string.IsNullOrWhiteSpace(relativeUri)) return null;
+        int question = relativeUri!.IndexOf('?');
+        if (question < 0 || question == relativeUri.Length - 1) return null;
+        foreach (string item in relativeUri.Substring(question + 1).Split('&')) {
+            string[] parts = item.Split(new[] { '=' }, 2);
+            if (parts.Length == 2 && string.Equals(Uri.UnescapeDataString(parts[0]), "cursor", StringComparison.OrdinalIgnoreCase)) {
+                string value = Uri.UnescapeDataString(parts[1]);
+                return value.Length == 0 ? null : value;
+            }
+        }
+        return null;
+    }
+}
+
+/// <summary>Options for listing Confluence pages.</summary>
+public sealed class ConfluencePageQuery {
+    public string? SpaceId { get; set; }
+    public string? Title { get; set; }
+    public string? Cursor { get; set; }
+    public int Limit { get; set; } = 25;
+    public ConfluenceBodyFormat BodyFormat { get; set; } = ConfluenceBodyFormat.AtlasDocFormat;
+}
+
+/// <summary>Input for creating a Confluence page.</summary>
+public sealed class ConfluencePageCreateRequest {
+    public string SpaceId { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string? ParentId { get; set; }
+    public string Status { get; set; } = "current";
+    public ConfluencePageBody Body { get; set; } = new ConfluencePageBody();
+}
+
+/// <summary>Input for updating a Confluence page.</summary>
+public sealed class ConfluencePageUpdateRequest {
+    public string PageId { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Status { get; set; } = "current";
+    public int VersionNumber { get; set; }
+    public string? VersionMessage { get; set; }
+    public ConfluencePageBody Body { get; set; } = new ConfluencePageBody();
+}
+
+/// <summary>A serializable, non-executing representation of a pending page write.</summary>
+public sealed class ConfluencePageWritePlan {
+    internal ConfluencePageWritePlan(string method, string relativeUri, string payload) {
+        Method = method;
+        RelativeUri = relativeUri;
+        Payload = payload;
+    }
+    public string Method { get; }
+    public string RelativeUri { get; }
+    public string Payload { get; }
+}

--- a/OfficeIMO.Confluence/ConfluenceModels.cs
+++ b/OfficeIMO.Confluence/ConfluenceModels.cs
@@ -82,6 +82,27 @@ internal static class ConfluenceCursor {
     }
 }
 
+internal static class ConfluencePagination {
+    internal static string? Next(string? responseLink, IReadOnlyDictionary<string, IReadOnlyList<string>> headers) {
+        if (!string.IsNullOrWhiteSpace(responseLink)) return responseLink;
+        if (!headers.TryGetValue("Link", out IReadOnlyList<string>? values)) return null;
+        foreach (string value in values) {
+            foreach (string segment in value.Split(',')) {
+                string candidate = segment.Trim();
+                int close = candidate.IndexOf('>');
+                if (!candidate.StartsWith("<", StringComparison.Ordinal) || close <= 1) continue;
+                string parameters = candidate.Substring(close + 1);
+                bool isNext = parameters.Split(';')
+                    .Select(item => item.Trim())
+                    .Any(item => string.Equals(item, "rel=next", StringComparison.OrdinalIgnoreCase) ||
+                                 string.Equals(item, "rel=\"next\"", StringComparison.OrdinalIgnoreCase));
+                if (isNext) return candidate.Substring(1, close - 1);
+            }
+        }
+        return null;
+    }
+}
+
 /// <summary>Options for listing Confluence pages.</summary>
 public sealed class ConfluencePageQuery {
     public string? SpaceId { get; set; }

--- a/OfficeIMO.Confluence/ConfluenceSession.cs
+++ b/OfficeIMO.Confluence/ConfluenceSession.cs
@@ -2,7 +2,7 @@ namespace OfficeIMO.Confluence;
 
 /// <summary>Options shared by Confluence Cloud requests.</summary>
 public sealed class ConfluenceSessionOptions {
-    /// <summary>Confluence site root, for example <c>https://example.atlassian.net/</c>.</summary>
+    /// <summary>Confluence site URL, for example <c>https://example.atlassian.net/wiki/</c>. Direct API requests use its origin.</summary>
     public Uri SiteUri { get; set; } = null!;
     /// <summary>
     /// Atlassian Cloud identifier used by OAuth 2.0 (3LO). When supplied, requests are routed through
@@ -35,7 +35,7 @@ public sealed class ConfluenceSession {
 
         _options = Clone(options);
         ApiBaseUri = string.IsNullOrWhiteSpace(_options.CloudId)
-            ? EnsureTrailingSlash(_options.SiteUri)
+            ? GetOriginRoot(_options.SiteUri)
             : new Uri("https://api.atlassian.com/ex/confluence/" + Uri.EscapeDataString(_options.CloudId!) + "/", UriKind.Absolute);
     }
 
@@ -60,7 +60,5 @@ public sealed class ConfluenceSession {
         RetryMaxDelay = source.RetryMaxDelay,
     };
 
-    private static Uri EnsureTrailingSlash(Uri uri) => uri.AbsoluteUri.EndsWith("/", StringComparison.Ordinal)
-        ? uri
-        : new Uri(uri.AbsoluteUri + "/", UriKind.Absolute);
+    private static Uri GetOriginRoot(Uri uri) => new Uri(uri.GetLeftPart(UriPartial.Authority) + "/", UriKind.Absolute);
 }

--- a/OfficeIMO.Confluence/ConfluenceSession.cs
+++ b/OfficeIMO.Confluence/ConfluenceSession.cs
@@ -4,6 +4,11 @@ namespace OfficeIMO.Confluence;
 public sealed class ConfluenceSessionOptions {
     /// <summary>Confluence site root, for example <c>https://example.atlassian.net/</c>.</summary>
     public Uri SiteUri { get; set; } = null!;
+    /// <summary>
+    /// Atlassian Cloud identifier used by OAuth 2.0 (3LO). When supplied, requests are routed through
+    /// <c>https://api.atlassian.com/ex/confluence/{cloudId}/</c> while <see cref="SiteUri"/> remains the human-facing site.
+    /// </summary>
+    public string? CloudId { get; set; }
     public string ApplicationName { get; set; } = "OfficeIMO";
     public HttpClient? HttpClient { get; set; }
     public TimeSpan RequestTimeout { get; set; } = TimeSpan.FromSeconds(100);
@@ -14,21 +19,48 @@ public sealed class ConfluenceSessionOptions {
 
 /// <summary>A configured Confluence Cloud session.</summary>
 public sealed class ConfluenceSession {
+    private readonly ConfluenceSessionOptions _options;
+
     public ConfluenceSession(IConfluenceCredentialSource credentialSource, ConfluenceSessionOptions options) {
         CredentialSource = credentialSource ?? throw new ArgumentNullException(nameof(credentialSource));
-        Options = options ?? throw new ArgumentNullException(nameof(options));
+        if (options == null) throw new ArgumentNullException(nameof(options));
         if (options.SiteUri == null || !options.SiteUri.IsAbsoluteUri) throw new ArgumentException("An absolute Confluence site URI is required.", nameof(options));
         if (!string.Equals(options.SiteUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)) throw new ArgumentException("Confluence Cloud site URI must use HTTPS.", nameof(options));
         if (!string.IsNullOrEmpty(options.SiteUri.UserInfo)) throw new ArgumentException("Confluence site URI cannot contain embedded credentials.", nameof(options));
+        if (options.CloudId != null && string.IsNullOrWhiteSpace(options.CloudId)) throw new ArgumentException("Confluence Cloud ID cannot be empty.", nameof(options));
         if (options.MaxRetryCount < 0) throw new ArgumentOutOfRangeException(nameof(options), "Max retry count cannot be negative.");
         if (options.RequestTimeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(options), "Request timeout must be greater than zero.");
         if (options.RetryBaseDelay < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(options), "Retry base delay cannot be negative.");
         if (options.RetryMaxDelay < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(options), "Retry maximum delay cannot be negative.");
+
+        _options = Clone(options);
+        ApiBaseUri = string.IsNullOrWhiteSpace(_options.CloudId)
+            ? EnsureTrailingSlash(_options.SiteUri)
+            : new Uri("https://api.atlassian.com/ex/confluence/" + Uri.EscapeDataString(_options.CloudId!) + "/", UriKind.Absolute);
     }
 
     public IConfluenceCredentialSource CredentialSource { get; }
-    public ConfluenceSessionOptions Options { get; }
+    /// <summary>Returns a defensive copy of the validated session options.</summary>
+    public ConfluenceSessionOptions Options => Clone(_options);
+    /// <summary>Resolved API base used for direct-site or OAuth cloud-ID requests.</summary>
+    public Uri ApiBaseUri { get; }
+    internal ConfluenceSessionOptions RuntimeOptions => _options;
 
     /// <summary>Creates a client for this session.</summary>
     public ConfluenceClient CreateClient() => new ConfluenceClient(this);
+
+    private static ConfluenceSessionOptions Clone(ConfluenceSessionOptions source) => new ConfluenceSessionOptions {
+        SiteUri = source.SiteUri,
+        CloudId = source.CloudId?.Trim(),
+        ApplicationName = source.ApplicationName,
+        HttpClient = source.HttpClient,
+        RequestTimeout = source.RequestTimeout,
+        MaxRetryCount = source.MaxRetryCount,
+        RetryBaseDelay = source.RetryBaseDelay,
+        RetryMaxDelay = source.RetryMaxDelay,
+    };
+
+    private static Uri EnsureTrailingSlash(Uri uri) => uri.AbsoluteUri.EndsWith("/", StringComparison.Ordinal)
+        ? uri
+        : new Uri(uri.AbsoluteUri + "/", UriKind.Absolute);
 }

--- a/OfficeIMO.Confluence/ConfluenceSession.cs
+++ b/OfficeIMO.Confluence/ConfluenceSession.cs
@@ -1,0 +1,34 @@
+namespace OfficeIMO.Confluence;
+
+/// <summary>Options shared by Confluence Cloud requests.</summary>
+public sealed class ConfluenceSessionOptions {
+    /// <summary>Confluence site root, for example <c>https://example.atlassian.net/</c>.</summary>
+    public Uri SiteUri { get; set; } = null!;
+    public string ApplicationName { get; set; } = "OfficeIMO";
+    public HttpClient? HttpClient { get; set; }
+    public TimeSpan RequestTimeout { get; set; } = TimeSpan.FromSeconds(100);
+    public int MaxRetryCount { get; set; } = 3;
+    public TimeSpan RetryBaseDelay { get; set; } = TimeSpan.FromMilliseconds(250);
+    public TimeSpan RetryMaxDelay { get; set; } = TimeSpan.FromSeconds(8);
+}
+
+/// <summary>A configured Confluence Cloud session.</summary>
+public sealed class ConfluenceSession {
+    public ConfluenceSession(IConfluenceCredentialSource credentialSource, ConfluenceSessionOptions options) {
+        CredentialSource = credentialSource ?? throw new ArgumentNullException(nameof(credentialSource));
+        Options = options ?? throw new ArgumentNullException(nameof(options));
+        if (options.SiteUri == null || !options.SiteUri.IsAbsoluteUri) throw new ArgumentException("An absolute Confluence site URI is required.", nameof(options));
+        if (!string.Equals(options.SiteUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)) throw new ArgumentException("Confluence Cloud site URI must use HTTPS.", nameof(options));
+        if (!string.IsNullOrEmpty(options.SiteUri.UserInfo)) throw new ArgumentException("Confluence site URI cannot contain embedded credentials.", nameof(options));
+        if (options.MaxRetryCount < 0) throw new ArgumentOutOfRangeException(nameof(options), "Max retry count cannot be negative.");
+        if (options.RequestTimeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(options), "Request timeout must be greater than zero.");
+        if (options.RetryBaseDelay < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(options), "Retry base delay cannot be negative.");
+        if (options.RetryMaxDelay < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(options), "Retry maximum delay cannot be negative.");
+    }
+
+    public IConfluenceCredentialSource CredentialSource { get; }
+    public ConfluenceSessionOptions Options { get; }
+
+    /// <summary>Creates a client for this session.</summary>
+    public ConfluenceClient CreateClient() => new ConfluenceClient(this);
+}

--- a/OfficeIMO.Confluence/OfficeIMO.Confluence.csproj
+++ b/OfficeIMO.Confluence/OfficeIMO.Confluence.csproj
@@ -1,0 +1,54 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Dependency-light Confluence Cloud client and OfficeIMO content conversion support.</Description>
+    <AssemblyName>OfficeIMO.Confluence</AssemblyName>
+    <AssemblyTitle>OfficeIMO.Confluence</AssemblyTitle>
+    <VersionPrefix>3.0.0</VersionPrefix>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">$(TargetFrameworks);net472</TargetFrameworks>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <Company>Evotec</Company>
+    <Authors>Przemyslaw Klys</Authors>
+    <PackageId>OfficeIMO.Confluence</PackageId>
+    <PackageTags>atlassian;confluence;cloud;adf;markdown;officeimo;net472;net8.0;net10.0</PackageTags>
+    <PackageProjectUrl>https://github.com/EvotecIT/OfficeIMO</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <IsPublishable>True</IsPublishable>
+    <PackageIcon>OfficeIMO.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryUrl>https://github.com/EvotecIT/OfficeIMO</RepositoryUrl>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <LangVersion>Latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="True" PackagePath="\" />
+    <None Include="..\Assets\OfficeIMO.png" Pack="True" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OfficeIMO.Adf\OfficeIMO.Adf.csproj" />
+    <ProjectReference Include="..\OfficeIMO.Markdown\OfficeIMO.Markdown.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472'">
+    <PackageReference Include="System.Text.Json" Version="[10.0.7,11.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Net.Http" />
+    <Using Include="System.Threading" />
+    <Using Include="System.Threading.Tasks" />
+  </ItemGroup>
+
+</Project>

--- a/OfficeIMO.Confluence/OfficeIMO.Confluence.csproj
+++ b/OfficeIMO.Confluence/OfficeIMO.Confluence.csproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <Using Include="System" />
     <Using Include="System.Collections.Generic" />
+    <Using Include="System.IO" />
     <Using Include="System.Linq" />
     <Using Include="System.Net.Http" />
     <Using Include="System.Threading" />

--- a/OfficeIMO.Confluence/README.md
+++ b/OfficeIMO.Confluence/README.md
@@ -14,4 +14,17 @@ ConfluenceContentConversionResult<string> markdown = ConfluenceContentConverter.
 
 Use `ConfluenceClient.PlanCreatePage` and `PlanUpdatePage` for non-executing write previews. `ConfluenceManagedSection.Apply` updates only a stable marker pair and returns before/after SHA-256 hashes. Safe reads retry transient failures; creates, updates, and attachment uploads are not automatically retried after an ambiguous write.
 
+OAuth 2.0 bearer sessions set `ConfluenceSessionOptions.CloudId`; the client then retains the Atlassian gateway prefix for every request:
+
+```csharp
+var oauthSession = new ConfluenceSession(
+    new ConfluenceBearerCredentialSource(accessToken),
+    new ConfluenceSessionOptions {
+        SiteUri = new Uri("https://example.atlassian.net/"),
+        CloudId = cloudId,
+    });
+```
+
+Use `PlanDeletePage` before `DeletePageAsync` when a caller needs a reviewable destructive-operation plan. Attachment overloads accepting `Stream` avoid buffering file-sized payloads; caller-owned streams remain open.
+
 Credentials remain caller-owned through `IConfluenceCredentialSource`. The library does not provide a secret store or persist tokens.

--- a/OfficeIMO.Confluence/README.md
+++ b/OfficeIMO.Confluence/README.md
@@ -1,0 +1,17 @@
+# OfficeIMO.Confluence
+
+`OfficeIMO.Confluence` is a dependency-light Confluence Cloud client with ADF, Markdown, HTML, attachment, dry-run, and managed-section support.
+
+```csharp
+var session = new ConfluenceSession(
+    new ConfluenceBasicCredentialSource(email, apiToken),
+    new ConfluenceSessionOptions { SiteUri = new Uri("https://example.atlassian.net/") });
+
+using ConfluenceClient client = session.CreateClient();
+ConfluencePage page = await client.GetPageAsync("123", ConfluenceBodyFormat.AtlasDocFormat);
+ConfluenceContentConversionResult<string> markdown = ConfluenceContentConverter.ToMarkdown(page);
+```
+
+Use `ConfluenceClient.PlanCreatePage` and `PlanUpdatePage` for non-executing write previews. `ConfluenceManagedSection.Apply` updates only a stable marker pair and returns before/after SHA-256 hashes. Safe reads retry transient failures; creates, updates, and attachment uploads are not automatically retried after an ambiguous write.
+
+Credentials remain caller-owned through `IConfluenceCredentialSource`. The library does not provide a secret store or persist tokens.

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_Fence_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_Fence_Tests.cs
@@ -68,6 +68,25 @@ public class Markdown_Fence_Tests {
         Assert.Equal("````", fence);
     }
 
+    [Theory]
+    [InlineData("a`b", "``a`b``")]
+    [InlineData("`edge`", "`` `edge` ``")]
+    [InlineData("`edge", "`` `edge ``")]
+    [InlineData("edge`", "`` edge` ``")]
+    [InlineData(" edge ", "`  edge  `")]
+    [InlineData(" edge", "` edge`")]
+    [InlineData("edge ", "`edge `")]
+    [InlineData("   ", "`   `")]
+    public void BuildSafeCodeSpan_PreservesDelimiterContent(string content, string expected) {
+        var span = MarkdownFence.BuildSafeCodeSpan(content);
+
+        Assert.Equal(expected, span);
+        var document = MarkdownReader.Parse(span, MarkdownReaderOptions.CreateCommonMarkProfile());
+        var paragraph = Assert.IsType<ParagraphBlock>(Assert.Single(document.Blocks));
+        var code = Assert.IsType<CodeSpanInline>(Assert.Single(paragraph.Inlines.Nodes));
+        Assert.Equal(content, code.Text);
+    }
+
     [Fact]
     public void ApplyTransformOutsideFencedCodeBlocks_PreservesQuotedFenceBodies() {
         var markdown = """

--- a/OfficeIMO.Markdown.Tests/Markdown/Markdown_Fence_Tests.cs
+++ b/OfficeIMO.Markdown.Tests/Markdown/Markdown_Fence_Tests.cs
@@ -69,6 +69,16 @@ public class Markdown_Fence_Tests {
     }
 
     [Theory]
+    [InlineData("powershell", "powershell")]
+    [InlineData("powershell options", "powershell")]
+    [InlineData("csharp`unsafe", "csharp")]
+    [InlineData("powershell~unsafe", "powershell")]
+    [InlineData("~~~", "")]
+    public void NormalizeLanguageToken_StopsBeforeFenceMarkers(string language, string expected) {
+        Assert.Equal(expected, MarkdownFence.NormalizeLanguageToken(language));
+    }
+
+    [Theory]
     [InlineData("a`b", "``a`b``")]
     [InlineData("`edge`", "`` `edge` ``")]
     [InlineData("`edge", "`` `edge ``")]

--- a/OfficeIMO.Markdown/Abstractions/ILiteralTextMarkdownInline.cs
+++ b/OfficeIMO.Markdown/Abstractions/ILiteralTextMarkdownInline.cs
@@ -1,0 +1,9 @@
+namespace OfficeIMO.Markdown;
+
+/// <summary>
+/// Identifies an inline node whose complete semantic value is literal text.
+/// </summary>
+public interface ILiteralTextMarkdownInline : IMarkdownInline {
+    /// <summary>Literal semantic text represented by the inline node.</summary>
+    string Text { get; }
+}

--- a/OfficeIMO.Markdown/Inlines/CodeSpanInline.cs
+++ b/OfficeIMO.Markdown/Inlines/CodeSpanInline.cs
@@ -16,14 +16,7 @@ public sealed class CodeSpanInline : MarkdownInline, IRenderableMarkdownInline, 
     }
 
     internal string RenderMarkdown() {
-        // Choose a fence with length > any run of backticks in the text.
-        int maxRun = 0; int run = 0;
-        foreach (char c in Text) { if (c == '`') { run++; if (run > maxRun) maxRun = run; } else run = 0; }
-        string fence = new string('`', maxRun + 1);
-        // Per CommonMark, add a space inside when the text starts/ends with a backtick or space
-        string leftPad = (Text.StartsWith("`") || Text.StartsWith(" ")) ? " " : string.Empty;
-        string rightPad = (Text.EndsWith("`") || Text.EndsWith(" ")) ? " " : string.Empty;
-        return fence + leftPad + Text + rightPad + fence;
+        return MarkdownFence.BuildSafeCodeSpan(Text);
     }
     internal string RenderHtml() => "<code>" + HtmlTextEncoder.Encode(Text, HtmlRenderContext.Options) + "</code>";
     string IRenderableMarkdownInline.RenderMarkdown() => RenderMarkdown();

--- a/OfficeIMO.Markdown/Inlines/DecodedHtmlEntityTextRun.cs
+++ b/OfficeIMO.Markdown/Inlines/DecodedHtmlEntityTextRun.cs
@@ -5,12 +5,12 @@ namespace OfficeIMO.Markdown;
 /// Keeps the decoded text in the AST while re-encoding angle brackets during Markdown rendering
 /// so literal tag text does not become active HTML on roundtrip.
 /// </summary>
-internal sealed class DecodedHtmlEntityTextRun : MarkdownInline, IRenderableMarkdownInline, IPlainTextMarkdownInline {
+internal sealed class DecodedHtmlEntityTextRun : MarkdownInline, IRenderableMarkdownInline, IPlainTextMarkdownInline, ILiteralTextMarkdownInline {
     internal DecodedHtmlEntityTextRun(string text) {
         Text = text ?? string.Empty;
     }
 
-    internal string Text { get; }
+    public string Text { get; }
     internal string? SourceText { get; private set; }
     internal MarkdownSourceSpan? SourceTextSourceSpan { get; private set; }
 

--- a/OfficeIMO.Markdown/Inlines/TextRun.cs
+++ b/OfficeIMO.Markdown/Inlines/TextRun.cs
@@ -3,7 +3,7 @@ namespace OfficeIMO.Markdown;
 /// <summary>
 /// Plain text run.
 /// </summary>
-public sealed class TextRun : MarkdownInline, IRenderableMarkdownInline, IPlainTextMarkdownInline {
+public sealed class TextRun : MarkdownInline, IRenderableMarkdownInline, IPlainTextMarkdownInline, ILiteralTextMarkdownInline {
     /// <summary>Text content.</summary>
     public string Text { get; }
     /// <summary>Backslash escape marker text when this run was parsed from an escaped character.</summary>

--- a/OfficeIMO.Markdown/Utilities/MarkdownEscaper.cs
+++ b/OfficeIMO.Markdown/Utilities/MarkdownEscaper.cs
@@ -39,7 +39,8 @@ public static class MarkdownEscaper {
     internal static string EscapeSuperscriptText(string? text) => Escape(text, ['\\', '[', ']', '(', ')', '|', '*', '_', '^']);
     internal static string EscapeSubscriptText(string? text) => Escape(text, ['\\', '[', ']', '(', ')', '|', '*', '_', '~']);
     internal static string EscapeLinkText(string? text) => Escape(text, GeneralReserved);
-    internal static string EscapeLinkUrl(string? text) => Escape(text, UrlReserved);
+    /// <summary>Escapes Markdown-reserved delimiters in a link destination.</summary>
+    public static string EscapeLinkUrl(string? text) => Escape(text, UrlReserved);
     internal static string EscapeImageAlt(string? text) => Escape(text, GeneralReserved);
     internal static string EscapeImageSrc(string? text) => Escape(text, UrlReserved);
 

--- a/OfficeIMO.Markdown/Utilities/MarkdownEscaper.cs
+++ b/OfficeIMO.Markdown/Utilities/MarkdownEscaper.cs
@@ -23,9 +23,15 @@ public static class MarkdownEscaper {
     /// as a heading, quote, list, fence, thematic break, definition, or HTML block.
     /// </summary>
     public static string EscapeTextAndLineStarts(string? text) => EscapeMarkdownLineStarts(EscapeText(text));
+
+    /// <summary>
+    /// Escapes literal text so Markdown punctuation, HTML-like text, and character-reference-like
+    /// text are preserved as text when parsed again.
+    /// </summary>
+    public static string EscapeLiteralText(string? text) => EscapeMarkdownLineStarts(EncodeLiteralMarkdownText(text));
+
     internal static string EscapeRenderedLineStarts(string? text) => string.IsNullOrEmpty(text) ? string.Empty : EscapeMarkdownLineStarts(text!);
     internal static string EscapeRenderedListItemLineStarts(string? text) => string.IsNullOrEmpty(text) ? string.Empty : EscapeMarkdownLineStarts(text!, preserveDefinitionText: true);
-    internal static string EscapeLiteralText(string? text) => EscapeMarkdownLineStarts(EncodeLiteralMarkdownText(text));
     internal static string EscapeLiteralTableCellText(string? text) => EncodeLiteralMarkdownText(text, encodeEntityLikeAmpersands: false);
     internal static string EscapeEmphasis(string? text) => Escape(text, GeneralReserved);
     internal static string EscapeHighlightText(string? text) => Escape(text, HighlightReserved);

--- a/OfficeIMO.Markdown/Utilities/MarkdownEscaper.cs
+++ b/OfficeIMO.Markdown/Utilities/MarkdownEscaper.cs
@@ -6,7 +6,7 @@ using System.Text;
 /// <summary>
 /// Shared helper for escaping Markdown-reserved characters across inline renderers.
 /// </summary>
-internal static class MarkdownEscaper {
+public static class MarkdownEscaper {
     // Inline HTML is allowed in rendered Markdown (e.g., <u> for underline), so we intentionally
     // do not escape angle brackets here to preserve legitimate HTML passthroughs.
     // Allows: "Use <u>underline</u> for emphasis" -> "Use <u>underline</u> for emphasis"
@@ -15,8 +15,14 @@ internal static class MarkdownEscaper {
     private static readonly char[] HighlightReserved = ['\\', '[', ']', '(', ')', '|', '*', '_', '='];
     private static readonly char[] UrlReserved = ['\\', '(', ')', '[', ']', '|'];
 
-    internal static string EscapeText(string? text) => Escape(text, GeneralReserved);
-    internal static string EscapeTextAndLineStarts(string? text) => EscapeMarkdownLineStarts(EscapeText(text));
+    /// <summary>Escapes Markdown-reserved punctuation in literal inline text.</summary>
+    public static string EscapeText(string? text) => Escape(text, GeneralReserved);
+
+    /// <summary>
+    /// Escapes literal inline text and any line-leading syntax that Markdown would otherwise parse
+    /// as a heading, quote, list, fence, thematic break, definition, or HTML block.
+    /// </summary>
+    public static string EscapeTextAndLineStarts(string? text) => EscapeMarkdownLineStarts(EscapeText(text));
     internal static string EscapeRenderedLineStarts(string? text) => string.IsNullOrEmpty(text) ? string.Empty : EscapeMarkdownLineStarts(text!);
     internal static string EscapeRenderedListItemLineStarts(string? text) => string.IsNullOrEmpty(text) ? string.Empty : EscapeMarkdownLineStarts(text!, preserveDefinitionText: true);
     internal static string EscapeLiteralText(string? text) => EscapeMarkdownLineStarts(EncodeLiteralMarkdownText(text));
@@ -31,7 +37,8 @@ internal static class MarkdownEscaper {
     internal static string EscapeImageAlt(string? text) => Escape(text, GeneralReserved);
     internal static string EscapeImageSrc(string? text) => Escape(text, UrlReserved);
 
-    internal static string FormatOptionalTitle(string? title) {
+    /// <summary>Formats an optional Markdown link or image title using a non-colliding delimiter.</summary>
+    public static string FormatOptionalTitle(string? title) {
         if (string.IsNullOrEmpty(title)) return string.Empty;
 
         // Titles cannot contain line breaks in Markdown link/image syntax; normalize them to spaces.

--- a/OfficeIMO.Markdown/Utilities/MarkdownFence.cs
+++ b/OfficeIMO.Markdown/Utilities/MarkdownFence.cs
@@ -100,6 +100,29 @@ public static class MarkdownFence {
     }
 
     /// <summary>
+    /// Normalizes an external language value to the first Markdown-safe fenced-code language token.
+    /// Whitespace, control characters, and backticks terminate the token.
+    /// </summary>
+    /// <param name="language">External language value.</param>
+    /// <returns>A single safe language token, or an empty string when none is present.</returns>
+    public static string NormalizeLanguageToken(string? language) {
+        if (string.IsNullOrWhiteSpace(language)) {
+            return string.Empty;
+        }
+
+        string value = language!.Trim();
+        int length = 0;
+        while (length < value.Length
+               && !char.IsWhiteSpace(value[length])
+               && !char.IsControl(value[length])
+               && value[length] != '`') {
+            length++;
+        }
+
+        return length == value.Length ? value : value.Substring(0, length);
+    }
+
+    /// <summary>
     /// Builds a complete inline-code span whose delimiter cannot collide with backtick runs in
     /// <paramref name="content"/>.
     /// </summary>

--- a/OfficeIMO.Markdown/Utilities/MarkdownFence.cs
+++ b/OfficeIMO.Markdown/Utilities/MarkdownFence.cs
@@ -101,7 +101,7 @@ public static class MarkdownFence {
 
     /// <summary>
     /// Normalizes an external language value to the first Markdown-safe fenced-code language token.
-    /// Whitespace, control characters, and backticks terminate the token.
+    /// Whitespace, control characters, and fence-marker characters terminate the token.
     /// </summary>
     /// <param name="language">External language value.</param>
     /// <returns>A single safe language token, or an empty string when none is present.</returns>
@@ -115,7 +115,8 @@ public static class MarkdownFence {
         while (length < value.Length
                && !char.IsWhiteSpace(value[length])
                && !char.IsControl(value[length])
-               && value[length] != '`') {
+               && value[length] != '`'
+               && value[length] != '~') {
             length++;
         }
 

--- a/OfficeIMO.Markdown/Utilities/MarkdownFence.cs
+++ b/OfficeIMO.Markdown/Utilities/MarkdownFence.cs
@@ -100,6 +100,27 @@ public static class MarkdownFence {
     }
 
     /// <summary>
+    /// Builds a complete inline-code span whose delimiter cannot collide with backtick runs in
+    /// <paramref name="content"/>.
+    /// </summary>
+    /// <param name="content">Literal inline-code content.</param>
+    /// <returns>A CommonMark-compatible inline-code span.</returns>
+    public static string BuildSafeCodeSpan(string? content) {
+        var value = content ?? string.Empty;
+        var fence = new string('`', LongestRun(value, '`') + 1);
+        bool padBothSides = value.StartsWith("`", StringComparison.Ordinal) || value.EndsWith("`", StringComparison.Ordinal);
+        if (!padBothSides && value.Length > 1 && value[0] == ' ' && value[value.Length - 1] == ' ') {
+            for (int i = 0; i < value.Length; i++) {
+                if (value[i] == ' ') continue;
+                padBothSides = true;
+                break;
+            }
+        }
+        string padding = padBothSides ? " " : string.Empty;
+        return fence + padding + value + padding + fence;
+    }
+
+    /// <summary>
     /// Applies a text transformation only to segments outside fenced code blocks while preserving
     /// container-aware fence boundaries such as blockquoted or indented fences.
     /// </summary>

--- a/OfficeIMO.Shared.Tests/ReleasePackagingGuardrails.cs
+++ b/OfficeIMO.Shared.Tests/ReleasePackagingGuardrails.cs
@@ -36,16 +36,16 @@ public sealed class ReleasePackagingGuardrails {
             Assert.True(
                 File.Exists(Path.Combine(repositoryRoot, match.Groups["path"].Value)),
                 "README project link is missing: " + match.Value));
-        Assert.Equal(24, CountProjectHeadings(readme, "Native formats and shared foundations"));
-        Assert.Equal(27, CountProjectHeadings(readme, "Conversion and cloud bridges"));
+        Assert.Equal(25, CountProjectHeadings(readme, "Native formats and shared foundations"));
+        Assert.Equal(28, CountProjectHeadings(readme, "Conversion and cloud bridges"));
         Assert.Equal(28, CountProjectHeadings(readme, "Unified Reader family"));
         Assert.Equal(11, CountProjectHeadings(readme, "Markdown rendering and OfficeIMO Markup"));
-        Assert.Equal(90, projectHeadings.Count);
+        Assert.Equal(92, projectHeadings.Count);
 
         Assert.Contains($"| Coordinated `3.0.x` release packages | {releasePackageCount} |", readme, StringComparison.Ordinal);
         Assert.Contains($"| Documented package, tool, and example projects below | {projectHeadings.Count} |", readme, StringComparison.Ordinal);
-        Assert.Contains("| Native format, foundation, and shared-service packages | 24 |", readme, StringComparison.Ordinal);
-        Assert.Contains("| Conversion and cloud bridge packages | 27 |", readme, StringComparison.Ordinal);
+        Assert.Contains("| Native format, foundation, and shared-service packages | 25 |", readme, StringComparison.Ordinal);
+        Assert.Contains("| Conversion and cloud bridge packages | 28 |", readme, StringComparison.Ordinal);
         Assert.Contains("| Unified Reader packages and tool | 28 |", readme, StringComparison.Ordinal);
         Assert.Contains("| Markdown renderer and OfficeIMO Markup surfaces | 11 |", readme, StringComparison.Ordinal);
         Assert.Contains("NuGet publication is a separate release step.", readme, StringComparison.Ordinal);
@@ -53,7 +53,7 @@ public sealed class ReleasePackagingGuardrails {
         AssertDotNetInstallCommands(
             readme,
             releasePackageIds,
-            expectedCount: 15,
+            expectedCount: 17,
             toolPackageId: "OfficeIMO.Reader.Tool");
     }
 

--- a/OfficeIMO.sln
+++ b/OfficeIMO.sln
@@ -370,6 +370,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.CompatibilityCata
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.OfficeInteroperabilityArtifacts.Tool", "Build\OfficeInteroperabilityArtifacts\OfficeIMO.OfficeInteroperabilityArtifacts.Tool.csproj", "{C9B2495D-98F0-4C68-AE86-CF93E627D6FB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Adf", "OfficeIMO.Adf\OfficeIMO.Adf.csproj", "{11A8D209-20AA-48EF-8759-185C2A6F0317}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Adf.Tests", "OfficeIMO.Adf.Tests\OfficeIMO.Adf.Tests.csproj", "{D04BEC82-AF41-4190-BD78-C38CF8A45F82}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Confluence", "OfficeIMO.Confluence\OfficeIMO.Confluence.csproj", "{6F44BD8F-890B-45CD-B039-02A69ABCB68E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfficeIMO.Confluence.Tests", "OfficeIMO.Confluence.Tests\OfficeIMO.Confluence.Tests.csproj", "{65706CEB-967D-44DF-84ED-FE0CA9C16274}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1904,6 +1912,54 @@ Global
 		{C9B2495D-98F0-4C68-AE86-CF93E627D6FB}.Release|x64.Build.0 = Release|Any CPU
 		{C9B2495D-98F0-4C68-AE86-CF93E627D6FB}.Release|x86.ActiveCfg = Release|Any CPU
 		{C9B2495D-98F0-4C68-AE86-CF93E627D6FB}.Release|x86.Build.0 = Release|Any CPU
+		{11A8D209-20AA-48EF-8759-185C2A6F0317}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11A8D209-20AA-48EF-8759-185C2A6F0317}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11A8D209-20AA-48EF-8759-185C2A6F0317}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{11A8D209-20AA-48EF-8759-185C2A6F0317}.Debug|x64.Build.0 = Debug|Any CPU
+		{11A8D209-20AA-48EF-8759-185C2A6F0317}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{11A8D209-20AA-48EF-8759-185C2A6F0317}.Debug|x86.Build.0 = Debug|Any CPU
+		{11A8D209-20AA-48EF-8759-185C2A6F0317}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11A8D209-20AA-48EF-8759-185C2A6F0317}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11A8D209-20AA-48EF-8759-185C2A6F0317}.Release|x64.ActiveCfg = Release|Any CPU
+		{11A8D209-20AA-48EF-8759-185C2A6F0317}.Release|x64.Build.0 = Release|Any CPU
+		{11A8D209-20AA-48EF-8759-185C2A6F0317}.Release|x86.ActiveCfg = Release|Any CPU
+		{11A8D209-20AA-48EF-8759-185C2A6F0317}.Release|x86.Build.0 = Release|Any CPU
+		{D04BEC82-AF41-4190-BD78-C38CF8A45F82}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D04BEC82-AF41-4190-BD78-C38CF8A45F82}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D04BEC82-AF41-4190-BD78-C38CF8A45F82}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D04BEC82-AF41-4190-BD78-C38CF8A45F82}.Debug|x64.Build.0 = Debug|Any CPU
+		{D04BEC82-AF41-4190-BD78-C38CF8A45F82}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D04BEC82-AF41-4190-BD78-C38CF8A45F82}.Debug|x86.Build.0 = Debug|Any CPU
+		{D04BEC82-AF41-4190-BD78-C38CF8A45F82}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D04BEC82-AF41-4190-BD78-C38CF8A45F82}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D04BEC82-AF41-4190-BD78-C38CF8A45F82}.Release|x64.ActiveCfg = Release|Any CPU
+		{D04BEC82-AF41-4190-BD78-C38CF8A45F82}.Release|x64.Build.0 = Release|Any CPU
+		{D04BEC82-AF41-4190-BD78-C38CF8A45F82}.Release|x86.ActiveCfg = Release|Any CPU
+		{D04BEC82-AF41-4190-BD78-C38CF8A45F82}.Release|x86.Build.0 = Release|Any CPU
+		{6F44BD8F-890B-45CD-B039-02A69ABCB68E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F44BD8F-890B-45CD-B039-02A69ABCB68E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F44BD8F-890B-45CD-B039-02A69ABCB68E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6F44BD8F-890B-45CD-B039-02A69ABCB68E}.Debug|x64.Build.0 = Debug|Any CPU
+		{6F44BD8F-890B-45CD-B039-02A69ABCB68E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6F44BD8F-890B-45CD-B039-02A69ABCB68E}.Debug|x86.Build.0 = Debug|Any CPU
+		{6F44BD8F-890B-45CD-B039-02A69ABCB68E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F44BD8F-890B-45CD-B039-02A69ABCB68E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F44BD8F-890B-45CD-B039-02A69ABCB68E}.Release|x64.ActiveCfg = Release|Any CPU
+		{6F44BD8F-890B-45CD-B039-02A69ABCB68E}.Release|x64.Build.0 = Release|Any CPU
+		{6F44BD8F-890B-45CD-B039-02A69ABCB68E}.Release|x86.ActiveCfg = Release|Any CPU
+		{6F44BD8F-890B-45CD-B039-02A69ABCB68E}.Release|x86.Build.0 = Release|Any CPU
+		{65706CEB-967D-44DF-84ED-FE0CA9C16274}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65706CEB-967D-44DF-84ED-FE0CA9C16274}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65706CEB-967D-44DF-84ED-FE0CA9C16274}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{65706CEB-967D-44DF-84ED-FE0CA9C16274}.Debug|x64.Build.0 = Debug|Any CPU
+		{65706CEB-967D-44DF-84ED-FE0CA9C16274}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{65706CEB-967D-44DF-84ED-FE0CA9C16274}.Debug|x86.Build.0 = Debug|Any CPU
+		{65706CEB-967D-44DF-84ED-FE0CA9C16274}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65706CEB-967D-44DF-84ED-FE0CA9C16274}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65706CEB-967D-44DF-84ED-FE0CA9C16274}.Release|x64.ActiveCfg = Release|Any CPU
+		{65706CEB-967D-44DF-84ED-FE0CA9C16274}.Release|x64.Build.0 = Release|Any CPU
+		{65706CEB-967D-44DF-84ED-FE0CA9C16274}.Release|x86.ActiveCfg = Release|Any CPU
+		{65706CEB-967D-44DF-84ED-FE0CA9C16274}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ OfficeIMO keeps document engines first-party and optional integrations isolated.
 
 | Surface | Current repository coverage |
 | --- | ---: |
-| Coordinated `3.0.x` release packages | 82 |
-| Documented package, tool, and example projects below | 90 |
-| Native format, foundation, and shared-service packages | 24 |
-| Conversion and cloud bridge packages | 27 |
+| Coordinated `3.0.x` release packages | 84 |
+| Documented package, tool, and example projects below | 92 |
+| Native format, foundation, and shared-service packages | 25 |
+| Conversion and cloud bridge packages | 28 |
 | Unified Reader packages and tool | 28 |
 | Markdown renderer and OfficeIMO Markup surfaces | 11 |
 | Runnable example projects | 1 |
@@ -239,6 +239,14 @@ _Dependency footprint:_ `System.Text.Encoding.CodePages` plus `OfficeIMO.Drawing
 
 _Dependency footprint:_ only `OfficeIMO.Drawing`; no Markdig or other Markdown parser dependency.
 
+#### [OfficeIMO.Adf](OfficeIMO.Adf/README.md)
+
+- [x] Lossless Atlas Document Format JSON model with unknown nodes, marks, attributes, and extension properties preserved
+- [x] Structural validation plus Markdown and HTML projections with explicit fidelity diagnostics
+- [x] Markdown and HTML import through OfficeIMO's existing document engines
+
+_Dependency footprint:_ OfficeIMO Markdown, Markdown.Html, and HTML plus `System.Text.Json` on compatibility targets; no Atlassian SDK.
+
 #### [OfficeIMO.Html](OfficeIMO.Html/README.md)
 
 - [x] Canonical `HtmlConversionDocument` with DOM, base-URI, media, resource, and URL-policy ownership
@@ -384,6 +392,14 @@ _Dependency footprint:_ Google authentication libraries plus OfficeIMO GoogleWor
 - [x] Dry-run, lossy approval, conflicts, cancellation, and item-level partial-failure outcomes
 
 _Dependency footprint:_ only OfficeIMO GoogleWorkspace and Drive.
+
+#### [OfficeIMO.Confluence](OfficeIMO.Confluence/README.md)
+
+- [x] Confluence Cloud v2 page read, cursor listing, create, update, dry-run request plans, and optimistic version contracts
+- [x] Attachment listing/download plus non-retried upload/versioning, cancellation, timeouts, and caller-owned credentials
+- [x] ADF, Markdown, HTML, and storage conversion with fidelity reports and marker-delimited managed-section replacement
+
+_Dependency footprint:_ only OfficeIMO ADF and Markdown plus platform HTTP and `System.Text.Json` on compatibility targets; no Atlassian SDK.
 
 ### Conversion and cloud bridges
 
@@ -982,6 +998,9 @@ dotnet add package OfficeIMO.Excel.Pdf --version 3.0.0
 
 dotnet add package OfficeIMO.Epub --version 3.0.0
 dotnet add package OfficeIMO.Epub.Image --version 3.0.0
+
+dotnet add package OfficeIMO.Adf --version 3.0.0
+dotnet add package OfficeIMO.Confluence --version 3.0.0
 
 dotnet add package OfficeIMO.Reader.Pdf --version 3.0.0
 

--- a/README.md
+++ b/README.md
@@ -393,6 +393,8 @@ _Dependency footprint:_ Google authentication libraries plus OfficeIMO GoogleWor
 
 _Dependency footprint:_ only OfficeIMO GoogleWorkspace and Drive.
 
+### Conversion and cloud bridges
+
 #### [OfficeIMO.Confluence](OfficeIMO.Confluence/README.md)
 
 - [x] Confluence Cloud v2 page read, cursor listing, create, update, dry-run request plans, and optimistic version contracts
@@ -400,8 +402,6 @@ _Dependency footprint:_ only OfficeIMO GoogleWorkspace and Drive.
 - [x] ADF, Markdown, HTML, and storage conversion with fidelity reports and marker-delimited managed-section replacement
 
 _Dependency footprint:_ only OfficeIMO ADF and Markdown plus platform HTTP and `System.Text.Json` on compatibility targets; no Atlassian SDK.
-
-### Conversion and cloud bridges
 
 #### [OfficeIMO.Word.Html](OfficeIMO.Word.Html/README.md)
 


### PR DESCRIPTION
## Summary

- add an OfficeIMO.Adf package for Markdown, HTML, storage, and ADF conversion with explicit fidelity diagnostics
- add an OfficeIMO.Confluence client for page create/read/update/delete, cursor pagination, managed sections, and streamed attachments
- support API-token sessions and Atlassian OAuth cloud-ID routing with guarded request origins
- retry safe reads across status, transport, and response-body failures while keeping writes non-retried

## Validation

- ADF contract tests pass on net472, net8.0, and net10.0
- Confluence contract tests pass on net472, net8.0, and net10.0
- OfficeIMO.Adf and OfficeIMO.Confluence pack successfully for netstandard2.0, net472, net8.0, and net10.0
- an independent review and one targeted confirmation were completed; all reported findings are addressed

## Release state

No NuGet packages were published from this work. Package publication remains a separate maintainer action after the other pending OfficeIMO work is ready.