### PR TITLE
Harden document processing against resource exhaustion

### DIFF
--- a/OfficeIMO.Drawing.Tests/Drawing.Tests.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.Tests.cs
@@ -3358,6 +3358,18 @@ public partial class DrawingTests {
     }
 
     [Fact]
+    public void ImageExportFontDiagnosticsBoundAttackerControlledFamilyListsBeforeAllocation() {
+        string familyNames = "Missing " + new string('x', 100_000) + ",Arial";
+        var fonts = new OfficeFontFaceCollection();
+
+        OfficeImageExportDiagnostic diagnostic = Assert.IsType<OfficeImageExportDiagnostic>(
+            fonts.CreateSubstitutionDiagnostic("bounded", familyNames));
+
+        Assert.True(diagnostic.Message.Length < 1024);
+        Assert.DoesNotContain(new string('x', 300), diagnostic.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void OfficeDrawingCarriesScopedFontsAcrossNestedDrawings() {
         byte[] fontData = CreateMinimalTrueTypeFont(CreateFormat12Cmap(0x1F600));
         var nested = new OfficeDrawing(20D, 20D).AddFont("Nested Demo", fontData, OfficeFontStyle.Bold);
@@ -3517,6 +3529,23 @@ public partial class DrawingTests {
             out string? unsupportedReason), unsupportedReason);
         Assert.NotNull(imageInfo);
         Assert.Equal(expectedFormat, imageInfo!.Format);
+    }
+
+    [Fact]
+    public void OfficeImagePdfCompatibilityRejectsRasterBeforeTranscodeBudgetIsExceeded() {
+        byte[] source = OfficeRasterImageEncoder.Encode(
+            new OfficeRasterImage(2, 2, OfficeColor.Red),
+            OfficeImageExportFormat.Tiff);
+
+        bool valid = OfficeImagePdfCompatibility.TryValidate(
+            source,
+            maximumTranscodePixels: 3,
+            out OfficeImageInfo? imageInfo,
+            out string? unsupportedReason);
+
+        Assert.False(valid);
+        Assert.Equal(OfficeImageFormat.Tiff, imageInfo!.Format);
+        Assert.Contains("exceeding the configured limit", unsupportedReason, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/OfficeIMO.Drawing/OfficeFontFaceCollection.cs
+++ b/OfficeIMO.Drawing/OfficeFontFaceCollection.cs
@@ -130,17 +130,12 @@ public sealed class OfficeFontFaceCollection {
 
     internal OfficeTrueTypeFont? Resolve(string? familyNames, OfficeFontStyle style, out OfficeFontStyle resolvedStyle) {
         resolvedStyle = OfficeFontStyle.Regular;
-        if (string.IsNullOrWhiteSpace(familyNames) || _faces.Count == 0) {
+        if (string.IsNullOrEmpty(familyNames) || _faces.Count == 0) {
             return null;
         }
 
         OfficeFontStyle normalizedStyle = OfficeFontFace.NormalizeStyle(style);
-        foreach (string rawFamily in familyNames!.Split(',')) {
-            string family = CleanFamilyName(rawFamily);
-            if (family.Length == 0) {
-                continue;
-            }
-
+        foreach (string family in OfficeFontFamilyParser.Parse(familyNames)) {
             OfficeFontFace? regular = null;
             OfficeFontFace? first = null;
             for (int index = _faces.Count - 1; index >= 0; index--) {
@@ -182,13 +177,10 @@ public sealed class OfficeFontFaceCollection {
 
     private OfficeTrueTypeFont? ResolveForText(string text, string? familyNames, OfficeFontStyle style, out OfficeFontFace? resolvedFace) {
         resolvedFace = null;
-        if (string.IsNullOrWhiteSpace(familyNames) || _faces.Count == 0) return null;
+        if (string.IsNullOrEmpty(familyNames) || _faces.Count == 0) return null;
 
         OfficeFontStyle normalizedStyle = OfficeFontFace.NormalizeStyle(style);
-        foreach (string rawFamily in familyNames!.Split(',')) {
-            string family = CleanFamilyName(rawFamily);
-            if (family.Length == 0) continue;
-
+        foreach (string family in OfficeFontFamilyParser.Parse(familyNames)) {
             OfficeFontFace? exact = null;
             OfficeFontFace? regular = null;
             OfficeFontFace? first = null;
@@ -219,14 +211,4 @@ public sealed class OfficeFontFaceCollection {
         return value.Length > 0;
     }
 
-    private static string CleanFamilyName(string familyName) {
-        string value = familyName.Trim();
-        while (value.Length >= 2
-               && ((value[0] == '"' && value[value.Length - 1] == '"')
-                   || (value[0] == '\'' && value[value.Length - 1] == '\''))) {
-            value = value.Substring(1, value.Length - 2).Trim();
-        }
-
-        return value;
-    }
 }

--- a/OfficeIMO.Drawing/OfficeFontFamilyParser.cs
+++ b/OfficeIMO.Drawing/OfficeFontFamilyParser.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+
+namespace OfficeIMO.Drawing;
+
+internal static class OfficeFontFamilyParser {
+    internal const int DefaultMaximumCandidates = 32;
+    internal const int DefaultMaximumFamilyNameLength = 256;
+
+    internal static List<string> Parse(
+        string? familyNames,
+        int maximumCandidates = DefaultMaximumCandidates,
+        int maximumFamilyNameLength = DefaultMaximumFamilyNameLength) {
+        var families = new List<string>();
+        if (string.IsNullOrEmpty(familyNames) || maximumCandidates < 1 || maximumFamilyNameLength < 1) {
+            return families;
+        }
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        int maximumSourceCharacters = checked(maximumCandidates * (maximumFamilyNameLength + 1));
+        int scanEnd = Math.Min(familyNames!.Length, maximumSourceCharacters);
+        int segmentStart = 0;
+        while (segmentStart < scanEnd && families.Count < maximumCandidates) {
+            int segmentEnd = segmentStart;
+            while (segmentEnd < scanEnd && familyNames[segmentEnd] != ',') segmentEnd++;
+            string family = CleanSegment(familyNames, segmentStart, segmentEnd, maximumFamilyNameLength);
+            if (family.Length > 0 && seen.Add(family)) families.Add(family);
+            segmentStart = segmentEnd + 1;
+        }
+
+        return families;
+    }
+
+    private static string CleanSegment(string value, int start, int end, int maximumLength) {
+        TrimBounds(value, ref start, ref end);
+        while (end - start >= 2 &&
+               ((value[start] == '"' && value[end - 1] == '"') ||
+                (value[start] == '\'' && value[end - 1] == '\''))) {
+            start++;
+            end--;
+            TrimBounds(value, ref start, ref end);
+        }
+
+        int length = Math.Min(end - start, maximumLength);
+        return length > 0 ? value.Substring(start, length) : string.Empty;
+    }
+
+    private static void TrimBounds(string value, ref int start, ref int end) {
+        while (start < end && char.IsWhiteSpace(value[start])) start++;
+        while (end > start && char.IsWhiteSpace(value[end - 1])) end--;
+    }
+}

--- a/OfficeIMO.Drawing/OfficeImageExportFontDiagnostics.cs
+++ b/OfficeIMO.Drawing/OfficeImageExportFontDiagnostics.cs
@@ -5,6 +5,9 @@ namespace OfficeIMO.Drawing;
 
 /// <summary>Shared font-resolution diagnostics for dependency-free image exporters.</summary>
 public static class OfficeImageExportFontDiagnostics {
+    private const int MaximumDiagnosticLookups = 256;
+    private const int MaximumDiagnosticElements = 4096;
+    private const int MaximumDiagnosticDepth = 64;
     /// <summary>
     /// Reports when the renderer cannot use the first requested font family/style and must select
     /// a later family or the managed stroke fallback.
@@ -16,7 +19,7 @@ public static class OfficeImageExportFontDiagnostics {
         OfficeFontStyle style = OfficeFontStyle.Regular,
         string? source = null) {
         if (fonts == null) throw new ArgumentNullException(nameof(fonts));
-        if (string.IsNullOrEmpty(text) || string.IsNullOrWhiteSpace(familyNames)) return null;
+        if (string.IsNullOrEmpty(text) || string.IsNullOrEmpty(familyNames)) return null;
 
         List<string> families = ParseFamilies(familyNames!);
         if (families.Count == 0 || IsGenericFamily(families[0])) return null;
@@ -67,17 +70,25 @@ public static class OfficeImageExportFontDiagnostics {
         if (diagnostics == null) throw new ArgumentNullException(nameof(diagnostics));
 
         var seen = new HashSet<string>(StringComparer.Ordinal);
-        AppendDrawing(drawing, diagnostics, seen, source);
+        int remainingLookups = MaximumDiagnosticLookups;
+        int remainingElements = MaximumDiagnosticElements;
+        AppendDrawing(drawing, diagnostics, seen, source, ref remainingLookups, ref remainingElements, depth: 0);
     }
 
     private static void AppendDrawing(
         OfficeDrawing drawing,
         ICollection<OfficeImageExportDiagnostic> diagnostics,
         HashSet<string> seen,
-        string? source) {
+        string? source,
+        ref int remainingLookups,
+        ref int remainingElements,
+        int depth) {
+        if (depth > MaximumDiagnosticDepth) return;
         foreach (OfficeDrawingElement element in drawing.Elements) {
+            if (remainingLookups == 0 || remainingElements-- == 0) return;
             switch (element) {
                 case OfficeDrawingText text:
+                    remainingLookups--;
                     Append(
                         drawing.Fonts.CreateSubstitutionDiagnostic(
                             text.Text,
@@ -89,6 +100,7 @@ public static class OfficeImageExportFontDiagnostics {
                     break;
                 case OfficeDrawingRichText richText:
                     foreach (OfficeRichTextRun run in richText.Runs) {
+                        if (remainingLookups-- == 0) return;
                         OfficeFontStyle style =
                             (run.Bold ? OfficeFontStyle.Bold : OfficeFontStyle.Regular) |
                             (run.Italic ? OfficeFontStyle.Italic : OfficeFontStyle.Regular);
@@ -103,16 +115,20 @@ public static class OfficeImageExportFontDiagnostics {
                     }
                     break;
                 case OfficeDrawingGroup group:
-                    AppendDrawing(group.InnerDrawing, diagnostics, seen, source);
+                    AppendDrawing(group.InnerDrawing, diagnostics, seen, source,
+                        ref remainingLookups, ref remainingElements, depth + 1);
                     break;
                 case OfficeDrawingEffectGroup effectGroup:
-                    AppendDrawing(effectGroup.InnerDrawing, diagnostics, seen, source);
+                    AppendDrawing(effectGroup.InnerDrawing, diagnostics, seen, source,
+                        ref remainingLookups, ref remainingElements, depth + 1);
                     if (effectGroup.SoftMask != null) {
-                        AppendDrawing(effectGroup.SoftMask.InnerDrawing, diagnostics, seen, source);
+                        AppendDrawing(effectGroup.SoftMask.InnerDrawing, diagnostics, seen, source,
+                            ref remainingLookups, ref remainingElements, depth + 1);
                     }
                     break;
                 case OfficeDrawingTilingPattern pattern:
-                    AppendDrawing(pattern.InnerTile, diagnostics, seen, source);
+                    AppendDrawing(pattern.InnerTile, diagnostics, seen, source,
+                        ref remainingLookups, ref remainingElements, depth + 1);
                     break;
             }
         }
@@ -148,23 +164,7 @@ public static class OfficeImageExportFontDiagnostics {
     }
 
     private static List<string> ParseFamilies(string familyNames) {
-        var families = new List<string>();
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (string rawFamily in familyNames.Split(',')) {
-            string family = CleanFamilyName(rawFamily);
-            if (family.Length > 0 && seen.Add(family)) families.Add(family);
-        }
-        return families;
-    }
-
-    private static string CleanFamilyName(string familyName) {
-        string value = familyName.Trim();
-        while (value.Length >= 2 &&
-               ((value[0] == '"' && value[value.Length - 1] == '"') ||
-                (value[0] == '\'' && value[value.Length - 1] == '\''))) {
-            value = value.Substring(1, value.Length - 2).Trim();
-        }
-        return value;
+        return OfficeFontFamilyParser.Parse(familyNames);
     }
 
     private static bool IsGenericFamily(string family) {

--- a/OfficeIMO.Drawing/OfficeImagePdfCompatibility.cs
+++ b/OfficeIMO.Drawing/OfficeImagePdfCompatibility.cs
@@ -3,14 +3,25 @@ namespace OfficeIMO.Drawing {
     /// Validates image bytes against the shared Drawing raster contract used by first-party PDF export preflight checks.
     /// </summary>
     public static class OfficeImagePdfCompatibility {
+        /// <summary>Default pixel ceiling for raster formats that must be decoded and re-encoded before PDF embedding.</summary>
+        public const long DefaultMaximumTranscodePixels = 8_000_000L;
+
         private static readonly byte[] PngSignature = { 137, 80, 78, 71, 13, 10, 26, 10 };
 
         /// <summary>
         /// Returns true when the image bytes can be embedded directly or normalized by the shared Drawing raster engine.
         /// </summary>
         public static bool TryValidate(byte[] bytes, out OfficeImageInfo? imageInfo, out string? unsupportedReason) {
+            return TryValidate(bytes, DefaultMaximumTranscodePixels, out imageInfo, out unsupportedReason);
+        }
+
+        /// <summary>
+        /// Returns true when the image bytes can be embedded directly or normalized without exceeding the supplied transcode pixel budget.
+        /// </summary>
+        public static bool TryValidate(byte[] bytes, long maximumTranscodePixels, out OfficeImageInfo? imageInfo, out string? unsupportedReason) {
             imageInfo = null;
             unsupportedReason = null;
+            if (maximumTranscodePixels < 1) throw new System.ArgumentOutOfRangeException(nameof(maximumTranscodePixels));
             if (bytes == null || bytes.Length == 0) {
                 unsupportedReason = "Image bytes are empty.";
                 return false;
@@ -33,6 +44,8 @@ namespace OfficeIMO.Drawing {
                         return false;
                     }
 
+                    if (!TryValidateTranscodeDimensions(detected, maximumTranscodePixels, out unsupportedReason)) return false;
+
                     if (!OfficeImagePngConverter.TryConvertToPng(bytes, out byte[] normalizedPng) ||
                         !TryValidatePngContainer(normalizedPng, out unsupportedReason)) {
                         unsupportedReason ??= $"Detected {detected.Format} ({detected.MimeType}), but the payload could not be normalized by OfficeIMO.Drawing.";
@@ -41,6 +54,26 @@ namespace OfficeIMO.Drawing {
 
                     return true;
             }
+        }
+
+        /// <summary>
+        /// Validates identified source dimensions before a PDF path decodes and re-encodes a raster payload.
+        /// </summary>
+        public static bool TryValidateTranscodeDimensions(
+            OfficeImageInfo imageInfo,
+            long maximumTranscodePixels,
+            out string? unsupportedReason) {
+            if (imageInfo == null) throw new System.ArgumentNullException(nameof(imageInfo));
+            if (maximumTranscodePixels < 1) throw new System.ArgumentOutOfRangeException(nameof(maximumTranscodePixels));
+
+            unsupportedReason = null;
+            long pixels = checked((long)imageInfo.Width * imageInfo.Height);
+            if (imageInfo.Width < 1 || imageInfo.Height < 1 || pixels > maximumTranscodePixels) {
+                unsupportedReason = $"Detected {imageInfo.Format} requires raster transcoding of {pixels} pixels, exceeding the configured limit of {maximumTranscodePixels} pixels.";
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/OfficeIMO.Drawing/OfficeTrueTypeFont.cs
+++ b/OfficeIMO.Drawing/OfficeTrueTypeFont.cs
@@ -18,6 +18,7 @@ public sealed partial class OfficeTrueTypeFont {
     private const int MaxFontTableRecords = 512;
     private const int MaxCmapSubtables = 64;
     private const uint MaxFormat12Groups = 4096;
+    private const int MaxFontCacheEntries = 1024;
     private static readonly object FontCacheLock = new();
     private static readonly Dictionary<string, OfficeTrueTypeFont?> FontCache = new(StringComparer.OrdinalIgnoreCase);
     private static readonly Dictionary<string, FontFamilyResolution> FontFamilyCache = new(StringComparer.OrdinalIgnoreCase);
@@ -102,6 +103,7 @@ public sealed partial class OfficeTrueTypeFont {
 
         FontFamilyResolution resolved = ResolveFontFamily(fontFamily);
         lock (FontCacheLock) {
+            if (FontFamilyCache.Count >= MaxFontCacheEntries) FontFamilyCache.Clear();
             FontFamilyCache[cacheKey] = resolved;
         }
 
@@ -123,7 +125,10 @@ public sealed partial class OfficeTrueTypeFont {
             }
 
             var font = File.Exists(fullPath) ? TryLoad(File.ReadAllBytes(fullPath), collectionIndex, faceName) : null;
-            lock (FontCacheLock) FontCache[cacheKey] = font;
+            lock (FontCacheLock) {
+                if (FontCache.Count >= MaxFontCacheEntries) FontCache.Clear();
+                FontCache[cacheKey] = font;
+            }
             return font;
         } catch (IOException) {
         } catch (UnauthorizedAccessException) {
@@ -763,7 +768,7 @@ public sealed partial class OfficeTrueTypeFont {
     private static GlyphPoint Mid(GlyphPoint left, GlyphPoint right) => new((left.X + right.X) / 2.0, (left.Y + right.Y) / 2.0, true);
 
     private static FontFamilyResolution ResolveFontFamily(string? fontFamily) {
-        if (string.IsNullOrWhiteSpace(fontFamily)) {
+        if (string.IsNullOrEmpty(fontFamily)) {
             OfficeTrueTypeFont? defaultFont = TryLoadDefault(out string? defaultPath);
             return new FontFamilyResolution(defaultFont, defaultPath);
         }
@@ -785,7 +790,7 @@ public sealed partial class OfficeTrueTypeFont {
     }
 
     private static string NormalizeFontFamilyCacheKey(string? fontFamily) {
-        if (string.IsNullOrWhiteSpace(fontFamily)) {
+        if (string.IsNullOrEmpty(fontFamily)) {
             return "__default";
         }
 
@@ -803,15 +808,13 @@ public sealed partial class OfficeTrueTypeFont {
 
     private static IEnumerable<string> ExpandFontFamilyFallbacks(string fontFamily) {
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (string rawFamily in fontFamily.Split(',')) {
-            string family = CleanFontFamilyName(rawFamily);
-            if (string.IsNullOrWhiteSpace(family)) {
-                continue;
-            }
-
+        int emitted = 0;
+        foreach (string family in OfficeFontFamilyParser.Parse(fontFamily)) {
             foreach (string expanded in ExpandGenericFontFamily(family)) {
                 if (seen.Add(expanded)) {
                     yield return expanded;
+                    emitted++;
+                    if (emitted >= OfficeFontFamilyParser.DefaultMaximumCandidates) yield break;
                 }
             }
         }
@@ -846,17 +849,6 @@ public sealed partial class OfficeTrueTypeFont {
         }
 
         yield return family;
-    }
-
-    private static string CleanFontFamilyName(string family) {
-        string value = family.Trim();
-        while (value.Length >= 2 &&
-               ((value[0] == '"' && value[value.Length - 1] == '"') ||
-                (value[0] == '\'' && value[value.Length - 1] == '\''))) {
-            value = value.Substring(1, value.Length - 2).Trim();
-        }
-
-        return value;
     }
 
     private static IEnumerable<string> CandidateFamilyPaths(string family) {

--- a/OfficeIMO.Email.Tests/Calendar/IcsDocumentTests.cs
+++ b/OfficeIMO.Email.Tests/Calendar/IcsDocumentTests.cs
@@ -4,6 +4,27 @@ namespace OfficeIMO.Email.Tests;
 
 public sealed class IcsDocumentTests {
     [Fact]
+    public void ValidationIndexesLargeRecurrenceSetsWithoutChangingResults() {
+        var document = new IcsDocument();
+        ContentLineComponent calendar = document.Calendars.Single();
+        ContentLineComponent master = calendar.AddComponent("VEVENT");
+        master.AddProperty("UID", "series@example.test");
+        master.AddProperty("DTSTAMP", "20260722T100000Z");
+        master.AddProperty("DTSTART", "20260722T110000Z");
+        for (int index = 0; index < 2000; index++) {
+            ContentLineComponent exception = calendar.AddComponent("VEVENT");
+            exception.AddProperty("UID", "series@example.test");
+            exception.AddProperty("DTSTAMP", "20260722T100000Z");
+            exception.AddProperty("DTSTART", "20260722T110000Z");
+            exception.AddProperty("RECURRENCE-ID", "20260722T110000Z");
+        }
+
+        IReadOnlyList<ContentLineValidationIssue> issues = document.Validate();
+
+        Assert.DoesNotContain(issues, issue => issue.Code.StartsWith("ICAL_RECURRENCE_ID_", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Parse_MultipleCalendarsPreservesUnknownRecurrenceAndNestedAlarm() {
         const string source = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//One//EN\r\n" +
             "X-WR-CALNAME:First\r\nBEGIN:VEVENT\r\nUID:event-1\r\nDTSTART;TZID=Europe/Warsaw:20260717T090000\r\n" +

--- a/OfficeIMO.Email/Calendar/IcsDocument.Validation.Temporal.cs
+++ b/OfficeIMO.Email/Calendar/IcsDocument.Validation.Temporal.cs
@@ -136,18 +136,17 @@ public sealed partial class IcsDocument {
             end.Kind == IcsTemporalValueKind.UtcDateTime && end.CompareClockTo(start) > 0;
     }
 
-    private static void ValidateRecurrenceIdentifier(ContentLineComponent component, ContentLineComponent parent,
+    private static void ValidateRecurrenceIdentifier(ContentLineComponent component,
+        IReadOnlyDictionary<(string Name, string Uid), ContentLineComponent> recurrenceMasters,
         ICollection<ContentLineValidationIssue> issues) {
         ContentLineProperty? recurrenceProperty = component.GetFirstProperty("RECURRENCE-ID");
         if (recurrenceProperty == null) return;
         ValidateRecurrenceIdentifierRange(component, recurrenceProperty, issues);
         ContentLineProperty? uidProperty = component.GetFirstProperty("UID");
         if (uidProperty == null || string.IsNullOrWhiteSpace(uidProperty.Value)) return;
-        ContentLineComponent? master = parent.Components.FirstOrDefault(candidate =>
-            !ReferenceEquals(candidate, component) &&
-            string.Equals(candidate.Name, component.Name, StringComparison.OrdinalIgnoreCase) &&
-            candidate.GetFirstProperty("RECURRENCE-ID") == null &&
-            string.Equals(candidate.GetFirstProperty("UID")?.Value, uidProperty.Value, StringComparison.Ordinal));
+        recurrenceMasters.TryGetValue(
+            (component.Name.ToUpperInvariant(), uidProperty.Value),
+            out ContentLineComponent? master);
         ContentLineProperty? masterStartProperty = master?.GetFirstProperty("DTSTART");
         if (!IcsTemporalValue.TryParse(masterStartProperty, out IcsTemporalValue start) ||
             !IcsTemporalValue.TryParse(recurrenceProperty, out IcsTemporalValue recurrence)) return;

--- a/OfficeIMO.Email/Calendar/IcsDocument.Validation.cs
+++ b/OfficeIMO.Email/Calendar/IcsDocument.Validation.cs
@@ -48,8 +48,10 @@ public sealed partial class IcsDocument {
                 }
             }
             var active = new HashSet<ContentLineComponent> { calendar };
+            Dictionary<(string Name, string Uid), ContentLineComponent> recurrenceMasters =
+                BuildRecurrenceMasterIndex(calendar);
             foreach (ContentLineComponent component in calendar.Components)
-                ValidateComponent(component, calendar, issues, active, depth: 2);
+                ValidateComponent(component, calendar, issues, active, recurrenceMasters, depth: 2);
             ValidateTimeZoneReferences(calendar, definedTimeZones, issues,
                 new HashSet<ContentLineComponent>(), depth: 1);
         }
@@ -57,7 +59,9 @@ public sealed partial class IcsDocument {
     }
 
     private static void ValidateComponent(ContentLineComponent component, ContentLineComponent parent,
-        ICollection<ContentLineValidationIssue> issues, ISet<ContentLineComponent> active, int depth) {
+        ICollection<ContentLineValidationIssue> issues, ISet<ContentLineComponent> active,
+        IReadOnlyDictionary<(string Name, string Uid), ContentLineComponent> recurrenceMasters,
+        int depth) {
         if (depth > ContentLineComponent.MaximumTraversalDepth) {
             issues.Add(Issue("ICAL_COMPONENT_DEPTH_EXCEEDED",
                 "The mutable iCalendar component graph exceeds the supported nesting depth.",
@@ -162,7 +166,7 @@ public sealed partial class IcsDocument {
                 ValidateFreeBusyWindow(component, issues);
             }
             if (name == "VEVENT" || name == "VTODO" || name == "VJOURNAL")
-                ValidateRecurrenceIdentifier(component, parent, issues);
+                ValidateRecurrenceIdentifier(component, recurrenceMasters, issues);
             if (name == "STANDARD" || name == "DAYLIGHT")
                 ValidateTimeZoneObservanceTimes(component, issues);
 
@@ -192,10 +196,26 @@ public sealed partial class IcsDocument {
             }
 
             foreach (ContentLineComponent child in component.Components)
-                ValidateComponent(child, component, issues, active, depth + 1);
+                ValidateComponent(child, component, issues, active, recurrenceMasters, depth + 1);
         } finally {
             active.Remove(component);
         }
+    }
+
+    private static Dictionary<(string Name, string Uid), ContentLineComponent> BuildRecurrenceMasterIndex(
+        ContentLineComponent calendar) {
+        var masters = new Dictionary<(string Name, string Uid), ContentLineComponent>();
+        foreach (ContentLineComponent component in calendar.Components) {
+            if (component.GetFirstProperty("RECURRENCE-ID") != null) continue;
+            string? uid = component.GetFirstProperty("UID")?.Value;
+            if (string.IsNullOrWhiteSpace(uid)) continue;
+            string name = component.Name.ToUpperInvariant();
+            if (name == "VEVENT" || name == "VTODO" || name == "VJOURNAL") {
+                var key = (name, uid!);
+                if (!masters.ContainsKey(key)) masters.Add(key, component);
+            }
+        }
+        return masters;
     }
 
     private static void ValidateUniquePrimaryComponentIdentifiers(ContentLineComponent calendar,

--- a/OfficeIMO.Excel.Tests/Excel.FormulaDepth.cs
+++ b/OfficeIMO.Excel.Tests/Excel.FormulaDepth.cs
@@ -87,6 +87,37 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_FormulaInspectionRejectsOversizedFormulaBeforeDependencyMasking() {
+            using ExcelDocument document = ExcelDocument.Create();
+            ExcelSheet sheet = document.AddWorksheet("Bounds");
+            sheet.CellValue(1, 1, 1D);
+            Cell cell = Assert.Single(sheet.WorksheetPart.Worksheet.Descendants<Cell>());
+            cell.CellFormula = new CellFormula("SUM(" + new string('A', 9000) + ")");
+
+            ExcelFormulaCellInfo formula = Assert.Single(document.InspectFormulas().Formulas);
+
+            Assert.Empty(formula.Dependencies);
+            Assert.Contains("longer than", formula.UnsupportedReason, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void Test_FormulaDependencyGraphCapsWholeColumnExpansionPerFormula() {
+            using ExcelDocument document = ExcelDocument.Create();
+            ExcelSheet sheet = document.AddWorksheet("Dense");
+            for (int row = 1; row <= 5000; row++) sheet.CellFormula(row, 1, "1");
+            sheet.CellFormula(1, 2, "SUM(A:A)");
+
+            ExcelFormulaInspection inspection = document.InspectFormulas();
+            ExcelFormulaDependencyNode node = Assert.IsType<ExcelFormulaDependencyNode>(
+                inspection.DependencyGraph.FindNode("Dense", "B1"));
+
+            Assert.Equal(4096, node.FormulaDependencies.Count);
+            Assert.True(inspection.DependencyGraph.AnalysisTruncated);
+            Assert.True(inspection.HasDependencyIssues);
+            Assert.Throws<InvalidOperationException>(() => inspection.EnsureNoDependencyIssues());
+        }
+
+        [Fact]
         public void Test_FormulaDependencyGraph_IgnoresReferenceShapeFunctionArguments() {
             using ExcelDocument document = ExcelDocument.Create();
             ExcelSheet sheet = document.AddWorksheet("Reference Shapes");

--- a/OfficeIMO.Excel/ExcelDocument.PivotInteractions.cs
+++ b/OfficeIMO.Excel/ExcelDocument.PivotInteractions.cs
@@ -5,6 +5,7 @@ using DocumentFormat.OpenXml.Spreadsheet;
 
 namespace OfficeIMO.Excel {
     public partial class ExcelDocument {
+        private const int MaximumPivotInteractionPartCharacters = 1_000_000;
         /// <summary>
         /// Adds slicer cache metadata bound to a validated pivot table field.
         /// </summary>
@@ -264,7 +265,17 @@ namespace OfficeIMO.Excel {
         private static string ReadPivotInteractionPartText(OpenXmlPart part) {
             using Stream stream = part.GetStream(FileMode.Open, FileAccess.Read);
             using var reader = new StreamReader(stream, Encoding.UTF8);
-            return reader.ReadToEnd();
+            var text = new StringBuilder();
+            var buffer = new char[4096];
+            while (true) {
+                int read = reader.ReadBlock(buffer, 0, buffer.Length);
+                if (read == 0) return text.ToString();
+                if (text.Length > MaximumPivotInteractionPartCharacters - read) {
+                    throw new InvalidDataException(
+                        "Pivot interaction metadata exceeds the supported character limit.");
+                }
+                text.Append(buffer, 0, read);
+            }
         }
 
         private static string EnsureUniquePivotInteractionCacheName(

--- a/OfficeIMO.Excel/ExcelFormulaInspection.cs
+++ b/OfficeIMO.Excel/ExcelFormulaInspection.cs
@@ -13,7 +13,9 @@ namespace OfficeIMO.Excel {
             MissingCachedResults = formulas.Count(formula => !formula.HasCachedValue);
             DirtyFormulas = formulas.Count(formula => formula.IsDirty);
             DependencyGraph = ExcelFormulaDependencyGraph.Create(formulas);
-            DependencyIssueCount = formulas.Sum(formula => formula.DependencyIssues.Count) + DependencyGraph.CircularReferenceCount;
+            DependencyIssueCount = formulas.Sum(formula => formula.DependencyIssues.Count) +
+                DependencyGraph.CircularReferenceCount +
+                (DependencyGraph.AnalysisTruncated ? 1 : 0);
         }
 
         /// <summary>Formula cells discovered in workbook order.</summary>
@@ -91,6 +93,9 @@ namespace OfficeIMO.Excel {
                     .Where(formula => formula.DependencyIssues.Count > 0)
                     .Select(formula => $"{formula.SheetName}!{formula.CellReference}: {string.Join("; ", formula.DependencyIssues)}")
                     .Concat(DependencyGraph.CircularReferences.Select(circular => $"Circular reference: {string.Join(" -> ", circular.References)}"))
+                    .Concat(DependencyGraph.AnalysisTruncated
+                        ? new[] { DependencyGraph.AnalysisTruncationReason! }
+                        : Array.Empty<string>())
                     .ToArray();
                 throw new InvalidOperationException("Formula dependency issues: " + string.Join(", ", issues));
             }
@@ -113,6 +118,7 @@ namespace OfficeIMO.Excel {
             builder.AppendLine($"Dependency issues: {DependencyIssueCount}");
             builder.AppendLine($"Maximum formula dependency depth: {DependencyGraph.MaximumDependencyDepth}");
             builder.AppendLine($"Circular reference groups: {DependencyGraph.CircularReferenceCount}");
+            builder.AppendLine($"Dependency graph analysis complete: {(DependencyGraph.AnalysisTruncated ? "no" : "yes")}");
             builder.AppendLine();
             builder.AppendLine("| Sheet | Cell | Formula | Supported | Cached | Dirty | Dependencies | Dependency issues | Reason |");
             builder.AppendLine("| --- | --- | --- | --- | --- | --- | --- | --- | --- |");
@@ -151,15 +157,19 @@ namespace OfficeIMO.Excel {
     /// Workbook-level dependency graph built from formula inspection metadata.
     /// </summary>
     public sealed class ExcelFormulaDependencyGraph {
+        private const int MaximumFormulaDependenciesPerCell = 4096;
+        private const int MaximumFormulaGraphEdges = 100_000;
         private readonly Dictionary<string, ExcelFormulaDependencyNode> _nodesByReference;
 
         private ExcelFormulaDependencyGraph(
             IReadOnlyList<ExcelFormulaDependencyNode> nodes,
             IReadOnlyList<ExcelFormulaCircularReference> circularReferences,
-            int maximumDependencyDepth) {
+            int maximumDependencyDepth,
+            string? analysisTruncationReason) {
             Nodes = nodes;
             CircularReferences = circularReferences;
             MaximumDependencyDepth = maximumDependencyDepth;
+            AnalysisTruncationReason = analysisTruncationReason;
             _nodesByReference = nodes.ToDictionary(node => node.Reference, StringComparer.OrdinalIgnoreCase);
         }
 
@@ -184,8 +194,14 @@ namespace OfficeIMO.Excel {
         /// <summary>True when one or more circular formula-reference groups were detected.</summary>
         public bool HasCircularReferences => CircularReferenceCount > 0;
 
+        /// <summary>True when resource limits stopped dependency-edge discovery before the graph was complete.</summary>
+        public bool AnalysisTruncated => AnalysisTruncationReason != null;
+
+        /// <summary>Reason dependency-edge discovery was truncated, or null when the graph is complete.</summary>
+        public string? AnalysisTruncationReason { get; }
+
         /// <summary>True when at least one formula node has dependency diagnostics.</summary>
-        public bool HasDependencyIssues => HasCircularReferences || Nodes.Any(node => node.HasDependencyIssues);
+        public bool HasDependencyIssues => AnalysisTruncated || HasCircularReferences || Nodes.Any(node => node.HasDependencyIssues);
 
         internal static ExcelFormulaDependencyGraph Create(IReadOnlyList<ExcelFormulaCellInfo> formulas) {
             var builders = new Dictionary<string, ExcelFormulaDependencyNodeBuilder>(StringComparer.OrdinalIgnoreCase);
@@ -224,17 +240,44 @@ namespace OfficeIMO.Excel {
                 });
             }
 
+            int remainingGraphEdges = MaximumFormulaGraphEdges;
+            string? analysisTruncationReason = null;
             foreach (ExcelFormulaCellInfo formula in formulas) {
                 string sourceReference = FormatReference(formula.SheetName, formula.CellReference);
+                int formulaDependencyCount = 0;
+                bool formulaTruncated = false;
+                bool graphTruncated = false;
                 foreach (string dependency in formula.Dependencies) {
-                    foreach (string targetReference in FindCoveredFormulaReferences(dependency, builders, formulaCellsBySheet)) {
+                    using IEnumerator<string> targets = FindCoveredFormulaReferences(
+                        dependency,
+                        builders,
+                        formulaCellsBySheet).GetEnumerator();
+                    while (targets.MoveNext()) {
+                        if (remainingGraphEdges == 0) {
+                            graphTruncated = true;
+                            analysisTruncationReason =
+                                $"Formula dependency graph exceeded the global limit of {MaximumFormulaGraphEdges} edges.";
+                            break;
+                        }
+                        if (formulaDependencyCount == MaximumFormulaDependenciesPerCell) {
+                            formulaTruncated = true;
+                            analysisTruncationReason ??=
+                                $"One or more formulas exceeded the limit of {MaximumFormulaDependenciesPerCell} formula dependencies.";
+                            break;
+                        }
+                        string targetReference = targets.Current;
                         if (builders.TryGetValue(sourceReference, out ExcelFormulaDependencyNodeBuilder? sourceNode)
                             && builders.TryGetValue(targetReference, out ExcelFormulaDependencyNodeBuilder? dependencyNode)) {
-                            sourceNode.FormulaDependencies.Add(targetReference);
-                            dependencyNode.Dependents.Add(sourceReference);
+                            if (sourceNode.FormulaDependencies.Add(targetReference)) {
+                                dependencyNode.Dependents.Add(sourceReference);
+                                formulaDependencyCount++;
+                                remainingGraphEdges--;
+                            }
                         }
                     }
+                    if (graphTruncated || formulaTruncated) break;
                 }
+                if (graphTruncated) break;
             }
 
             ExcelFormulaDependencyAnalysisResult analysis = ExcelFormulaDependencyAnalysis.Analyze(
@@ -250,7 +293,11 @@ namespace OfficeIMO.Excel {
             var circularReferences = analysis.CircularReferenceGroups
                 .Select(references => new ExcelFormulaCircularReference(references))
                 .ToList();
-            return new ExcelFormulaDependencyGraph(nodes, circularReferences, analysis.MaximumDepth);
+            return new ExcelFormulaDependencyGraph(
+                nodes,
+                circularReferences,
+                analysis.MaximumDepth,
+                analysisTruncationReason);
         }
 
         /// <summary>
@@ -272,6 +319,8 @@ namespace OfficeIMO.Excel {
             builder.AppendLine($"Formula dependency edges: {EdgeCount}");
             builder.AppendLine($"Maximum dependency depth: {MaximumDependencyDepth}");
             builder.AppendLine($"Circular reference groups: {CircularReferenceCount}");
+            builder.AppendLine($"Analysis complete: {(AnalysisTruncated ? "no" : "yes")}");
+            if (AnalysisTruncationReason != null) builder.AppendLine($"Analysis issue: {AnalysisTruncationReason}");
             builder.AppendLine();
             builder.AppendLine("| Formula | Dependencies | Formula dependencies | Dependents | Depth | Circular | Dependency issues |");
             builder.AppendLine("| --- | --- | --- | --- | --- | --- | --- |");

--- a/OfficeIMO.Excel/ExcelSheet.Formulas.Dependencies.Intersections.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Formulas.Dependencies.Intersections.cs
@@ -108,6 +108,9 @@ namespace OfficeIMO.Excel {
         }
 
         private static int[] BuildOpenGroupingParenthesisDepths(string formula) {
+            if (formula.Length > MaxSupportedFormulaLength) {
+                throw new InvalidOperationException("Formula exceeds the supported dependency-analysis length.");
+            }
             var depths = new int[formula.Length + 1];
             var parentheses = new Stack<bool>();
             int groupingDepth = 0;

--- a/OfficeIMO.Excel/ExcelSheet.Formulas.Dependencies.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Formulas.Dependencies.cs
@@ -154,7 +154,7 @@ namespace OfficeIMO.Excel {
             string formula,
             FormulaDependencyAliasCatalog aliases,
             FormulaDependencyTableCatalog tables) {
-            if (string.IsNullOrWhiteSpace(formula)) {
+            if (string.IsNullOrWhiteSpace(formula) || formula.Length > MaxSupportedFormulaLength) {
                 return Array.Empty<string>();
             }
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentImageValidationTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentImageValidationTests.cs
@@ -452,6 +452,23 @@ public class PdfDocumentImageValidationTests {
     }
 
     [Fact]
+    public void ImagePreparationRejectsOversizedRasterBeforeDecode() {
+        byte[] source = CreateMinimalBmp();
+        WriteInt32LittleEndian(source, 18, 3000);
+        WriteInt32LittleEndian(source, 22, 3000);
+
+        bool prepared = PdfDocument.TryPrepareImageBytes(
+            source,
+            out _,
+            out _,
+            out _,
+            out string? unsupportedReason);
+
+        Assert.False(prepared);
+        Assert.Contains("exceeding the configured limit", unsupportedReason, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RowColumnImage_WithNullBytes_ThrowsArgumentNullException() {
         var doc = PdfDocument.Create();
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
@@ -464,6 +464,20 @@ public class PdfReadLimitTests {
     }
 
     [Fact]
+    public void DeclaredStreamDictionaryIsBoundedBeforeSubstringParsing() {
+        byte[] pdf = BuildObjectPdf(
+            "<< /Length 0 /Padding (" + new string('x', 256) + ") >>\nstream\n\nendstream");
+        var options = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxObjectCharacters = 64 }
+        };
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(
+            () => PdfSyntax.ParseObjects(pdf, options));
+
+        Assert.Equal(PdfReadLimitKind.ObjectCharacters, exception.Kind);
+    }
+
+    [Fact]
     public void NestedObjectBudgetStopsRecursiveArrayParsing() {
         byte[] pdf = BuildObjectPdf("[[[[1]]]]");
         var options = new PdfReadOptions {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfTableStreamExportContracts.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfTableStreamExportContracts.cs
@@ -85,6 +85,41 @@ public class PdfTableStreamExportContracts {
     }
 
     [Fact]
+    public void TableScopeAnalysisReportsIncompleteClassificationWhenBudgetIsExhausted() {
+        byte[] source = PdfDocument.Create(new PdfOptions {
+                PageWidth = 420,
+                PageHeight = 360,
+                MarginLeft = 36,
+                MarginRight = 36,
+                MarginTop = 36,
+                MarginBottom = 36,
+                DefaultFontSize = 10
+            })
+            .KeyValueTable(new[] {
+                PdfKeyValueRow.Text("InvoiceId", "INV-001"),
+                PdfKeyValueRow.Text("Customer", "Evotec"),
+                PdfKeyValueRow.Text("Due", "2026-06-30")
+            }, style: new PdfTableStyle {
+                ColumnWidthPoints = new List<double?> { 120, 170 },
+                CellPaddingX = 6,
+                CellPaddingY = 4
+            })
+            .ToBytes();
+        PdfLogicalDocument logical = PdfLogicalDocument.Load(source, new PdfTextLayoutOptions {
+            ForceSingleColumn = true
+        });
+        Assert.NotEmpty(logical.Pages[0].Tables);
+
+        PdfTableExtractionScopeReport scope = PdfLogicalTableAnalysis.AnalyzeExtractionScope(
+            logical,
+            maximumComparisons: 0);
+
+        Assert.True(scope.AnalysisTruncated);
+        Assert.True(scope.HasOmittedPageContent);
+        Assert.Equal(0, scope.NonTableTextBlockCount);
+    }
+
+    [Fact]
     public void TableConversions_ReportOmittedVectorGraphics() {
         byte[] source = PdfDocument.Create()
             .Rectangle(

--- a/OfficeIMO.Pdf/Core/PdfDocument.Blocks.ImageValidation.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocument.Blocks.ImageValidation.cs
@@ -89,6 +89,13 @@ public sealed partial class PdfDocument {
             throw new NotSupportedException(SupportedImageMessage + suffix);
         }
 
+        if (!OfficeImagePdfCompatibility.TryValidateTranscodeDimensions(
+                sourceInfo,
+                OfficeImagePdfCompatibility.DefaultMaximumTranscodePixels,
+                out string? transcodeLimitReason)) {
+            throw new NotSupportedException(SupportedImageMessage + " " + transcodeLimitReason);
+        }
+
         if (!OfficeImagePngConverter.TryConvertToPng(data, out byte[] normalizedPng)) {
             throw new NotSupportedException(
                 $"{SupportedImageMessage} Detected {sourceInfo.Format} ({sourceInfo.MimeType}), but it could not be normalized.");

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Scanning.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Scanning.cs
@@ -4,7 +4,8 @@ internal static partial class PdfSyntax {
     private static int FindObjectEnd(
         string text,
         int start,
-        IReadOnlyDictionary<(int ObjectNumber, int Generation), int>? declaredLengthValues = null) {
+        IReadOnlyDictionary<(int ObjectNumber, int Generation), int>? declaredLengthValues = null,
+        PdfReadLimits? limits = null) {
         int searchFrom = start;
         while (searchFrom >= 0 && searchFrom < text.Length) {
             int streamIdx = IndexOfKeywordOutsideLiteralString(text, "stream", searchFrom, text.Length);
@@ -25,6 +26,7 @@ internal static partial class PdfSyntax {
                     streamIdx,
                     afterStream,
                     declaredLengthValues,
+                    limits,
                     out int declaredObjectEnd)) {
                 return declaredObjectEnd;
             }
@@ -92,6 +94,7 @@ internal static partial class PdfSyntax {
         int streamIndex,
         int dataStart,
         IReadOnlyDictionary<(int ObjectNumber, int Generation), int>? declaredLengthValues,
+        PdfReadLimits? limits,
         out int objectEnd) {
         objectEnd = -1;
         int dictionaryStart = text.IndexOf("<<", objectStart, streamIndex - objectStart, StringComparison.Ordinal);
@@ -104,9 +107,24 @@ internal static partial class PdfSyntax {
             return false;
         }
 
+        int dictionaryCharacters = dictionaryEnd - dictionaryStart - 2;
+        int maximumDictionaryCharacters = limits?.MaxObjectCharacters ?? 1_000_000;
+        if (dictionaryCharacters > maximumDictionaryCharacters) {
+            if (limits != null) {
+                throw PdfReadLimitException.Create(
+                    PdfReadLimitKind.ObjectCharacters,
+                    maximumDictionaryCharacters,
+                    dictionaryCharacters);
+            }
+            return false;
+        }
+
         PdfDictionary? dictionary;
         try {
-            dictionary = ParseDictionary(text.Substring(dictionaryStart + 2, dictionaryEnd - dictionaryStart - 2));
+            string dictionaryText = text.Substring(dictionaryStart + 2, dictionaryCharacters);
+            dictionary = limits == null
+                ? ParseDictionary(dictionaryText)
+                : ParseDictionary(dictionaryText, limits);
         } catch (Exception exception) when (exception is not OutOfMemoryException) {
             return false;
         }

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.cs
@@ -61,7 +61,7 @@ internal static partial class PdfSyntax {
             definitionCounts[definitionKey] = definitionCount + 1;
             int start = matches[i].Index;
             int bodyStart = matches[i].Index + matches[i].Length;
-            int end = FindObjectEnd(text, start, declaredLengthValues);
+            int end = FindObjectEnd(text, start, declaredLengthValues, limits);
             if (end < 0) {
                 HandleStructuralDefect(
                     parsingMode,

--- a/OfficeIMO.Pdf/Reading/Logical/PdfLogicalTableAnalysis.cs
+++ b/OfficeIMO.Pdf/Reading/Logical/PdfLogicalTableAnalysis.cs
@@ -6,6 +6,9 @@ namespace OfficeIMO.Pdf;
 /// Shared analysis helpers for logical PDF tables produced by <see cref="PdfLogicalDocument"/>.
 /// </summary>
 public static class PdfLogicalTableAnalysis {
+    private const int DefaultMaximumScopeAnalysisComparisons = 10_000;
+    private const int MaximumScopeComparisonTextCharacters = 512;
+    private const int MaximumScopeSourceCharactersPerValue = 2048;
     /// <summary>
     /// Infers structured extraction metadata for a logical PDF table.
     /// </summary>
@@ -114,7 +117,19 @@ public static class PdfLogicalTableAnalysis {
     /// Table counts plus visible and interactive page content that a table-only adapter will not import.
     /// </returns>
     public static PdfTableExtractionScopeReport AnalyzeExtractionScope(PdfLogicalDocument document) {
+        return AnalyzeExtractionScope(document, DefaultMaximumScopeAnalysisComparisons);
+    }
+
+    /// <summary>
+    /// Describes table extraction scope while bounding attacker-controlled text/table comparisons.
+    /// </summary>
+    public static PdfTableExtractionScopeReport AnalyzeExtractionScope(
+        PdfLogicalDocument document,
+        int maximumComparisons) {
         Guard.NotNull(document, nameof(document));
+#pragma warning disable CA1512 // ThrowIfNegative is unavailable on netstandard2.0 and net472.
+        if (maximumComparisons < 0) throw new ArgumentOutOfRangeException(nameof(maximumComparisons));
+#pragma warning restore CA1512
 
         int pagesWithTables = 0;
         int detectedTableCount = 0;
@@ -125,6 +140,9 @@ public static class PdfLogicalTableAnalysis {
         int formWidgetCount = 0;
         int annotationCount = 0;
         int pageActionCount = 0;
+        int remainingComparisons = Math.Min(maximumComparisons, DefaultMaximumScopeAnalysisComparisons);
+        bool analysisTruncated = false;
+        var normalizedRows = new Dictionary<PdfLogicalTable, Dictionary<int, ScopeComparisonText>>();
 
         for (int pageIndex = 0; pageIndex < document.Pages.Count; pageIndex++) {
             PdfLogicalPage page = document.Pages[pageIndex];
@@ -135,8 +153,15 @@ public static class PdfLogicalTableAnalysis {
 
             for (int blockIndex = 0; blockIndex < page.TextBlocks.Count; blockIndex++) {
                 PdfLogicalTextBlock block = page.TextBlocks[blockIndex];
-                if (!IsTextBlockRepresentedByAnyTable(block, page.Tables)) {
+                ScopeRepresentation representation = IsTextBlockRepresentedByAnyTable(
+                    block,
+                    page.Tables,
+                    normalizedRows,
+                    ref remainingComparisons);
+                if (representation == ScopeRepresentation.NotRepresented) {
                     nonTableTextBlockCount++;
+                } else if (representation == ScopeRepresentation.Incomplete) {
+                    analysisTruncated = true;
                 }
             }
 
@@ -158,7 +183,8 @@ public static class PdfLogicalTableAnalysis {
             linkCount,
             formWidgetCount,
             annotationCount,
-            pageActionCount);
+            pageActionCount,
+            analysisTruncated);
     }
 
     /// <summary>
@@ -206,10 +232,14 @@ public static class PdfLogicalTableAnalysis {
         return nonNumericCount == columnCount ? headers : null;
     }
 
-    private static bool IsTextBlockRepresentedByAnyTable(
+    private static ScopeRepresentation IsTextBlockRepresentedByAnyTable(
         PdfLogicalTextBlock block,
-        IReadOnlyList<PdfLogicalTable> tables) {
+        IReadOnlyList<PdfLogicalTable> tables,
+        IDictionary<PdfLogicalTable, Dictionary<int, ScopeComparisonText>> normalizedRows,
+        ref int remainingComparisons) {
+        ScopeComparisonText? normalizedBlock = null;
         for (int tableIndex = 0; tableIndex < tables.Count; tableIndex++) {
+            if (remainingComparisons-- <= 0) return ScopeRepresentation.Incomplete;
             PdfLogicalTable table = tables[tableIndex];
             double top = Math.Max(table.YTop, table.YBottom);
             double bottom = Math.Min(table.YTop, table.YBottom);
@@ -217,39 +247,102 @@ public static class PdfLogicalTableAnalysis {
                 continue;
             }
 
-            string blockText = NormalizeForScopeComparison(block.Text);
+            normalizedBlock ??= NormalizeForScopeComparison(block.Text);
+            if (normalizedBlock.Value.Truncated) return ScopeRepresentation.Incomplete;
+            string blockText = normalizedBlock.Value.Value;
             if (blockText.Length == 0) {
-                return true;
+                return ScopeRepresentation.Represented;
             }
 
             for (int rowIndex = 0; rowIndex < table.Rows.Count; rowIndex++) {
-                string rowText = NormalizeForScopeComparison(string.Join(" ", table.Rows[rowIndex]));
+                if (remainingComparisons-- <= 0) return ScopeRepresentation.Incomplete;
+                ScopeComparisonText normalizedRow = GetNormalizedScopeRow(table, rowIndex, normalizedRows);
+                if (normalizedRow.Truncated) return ScopeRepresentation.Incomplete;
+                string rowText = normalizedRow.Value;
                 if (rowText.Length > 0 &&
                     (ContainsOrdinal(rowText, blockText) ||
                      ContainsOrdinal(blockText, rowText))) {
-                    return true;
+                    return ScopeRepresentation.Represented;
                 }
             }
         }
 
-        return false;
+        return ScopeRepresentation.NotRepresented;
     }
 
-    private static string NormalizeForScopeComparison(string? value) {
-        if (string.IsNullOrWhiteSpace(value)) {
-            return string.Empty;
+    private static ScopeComparisonText GetNormalizedScopeRow(
+        PdfLogicalTable table,
+        int rowIndex,
+        IDictionary<PdfLogicalTable, Dictionary<int, ScopeComparisonText>> normalizedRows) {
+        if (!normalizedRows.TryGetValue(table, out Dictionary<int, ScopeComparisonText>? rows)) {
+            rows = new Dictionary<int, ScopeComparisonText>();
+            normalizedRows.Add(table, rows);
         }
+        if (rows.TryGetValue(rowIndex, out ScopeComparisonText cached)) return cached;
+
+        ScopeComparisonText normalized = NormalizeForScopeComparison(table.Rows[rowIndex]);
+        rows.Add(rowIndex, normalized);
+        return normalized;
+    }
+
+    private static ScopeComparisonText NormalizeForScopeComparison(string? value) {
+        if (string.IsNullOrEmpty(value)) return new ScopeComparisonText(string.Empty, truncated: false);
 
         string normalizedValue = value!;
-        var builder = new System.Text.StringBuilder(normalizedValue.Length);
+        var builder = new System.Text.StringBuilder(Math.Min(normalizedValue.Length, MaximumScopeComparisonTextCharacters));
+        int inspected = 0;
         for (int index = 0; index < normalizedValue.Length; index++) {
+            if (inspected++ == MaximumScopeSourceCharactersPerValue) {
+                return new ScopeComparisonText(builder.ToString(), truncated: true);
+            }
             char character = normalizedValue[index];
             if (!char.IsWhiteSpace(character)) {
+                if (builder.Length == MaximumScopeComparisonTextCharacters) {
+                    return new ScopeComparisonText(builder.ToString(), truncated: true);
+                }
                 builder.Append(char.ToUpperInvariant(character));
             }
         }
 
-        return builder.ToString();
+        return new ScopeComparisonText(builder.ToString(), truncated: false);
+    }
+
+    private static ScopeComparisonText NormalizeForScopeComparison(IReadOnlyList<string> row) {
+        var builder = new System.Text.StringBuilder(MaximumScopeComparisonTextCharacters);
+        int inspected = 0;
+        for (int cellIndex = 0; cellIndex < row.Count; cellIndex++) {
+            string value = row[cellIndex] ?? string.Empty;
+            for (int index = 0; index < value.Length; index++) {
+                if (inspected++ == MaximumScopeSourceCharactersPerValue) {
+                    return new ScopeComparisonText(builder.ToString(), truncated: true);
+                }
+                char character = value[index];
+                if (!char.IsWhiteSpace(character)) {
+                    if (builder.Length == MaximumScopeComparisonTextCharacters) {
+                        return new ScopeComparisonText(builder.ToString(), truncated: true);
+                    }
+                    builder.Append(char.ToUpperInvariant(character));
+                }
+            }
+        }
+
+        return new ScopeComparisonText(builder.ToString(), truncated: false);
+    }
+
+    private enum ScopeRepresentation {
+        NotRepresented,
+        Represented,
+        Incomplete
+    }
+
+    private readonly struct ScopeComparisonText {
+        internal ScopeComparisonText(string value, bool truncated) {
+            Value = value;
+            Truncated = truncated;
+        }
+
+        internal string Value { get; }
+        internal bool Truncated { get; }
     }
 
     private static bool ContainsOrdinal(string value, string candidate) {

--- a/OfficeIMO.Pdf/Reading/Logical/PdfTableExtractionScopeReport.cs
+++ b/OfficeIMO.Pdf/Reading/Logical/PdfTableExtractionScopeReport.cs
@@ -14,7 +14,8 @@ public sealed class PdfTableExtractionScopeReport {
         int linkCount,
         int formWidgetCount,
         int annotationCount,
-        int pageActionCount) {
+        int pageActionCount,
+        bool analysisTruncated) {
         SourcePageCount = sourcePageCount;
         PagesWithTables = pagesWithTables;
         DetectedTableCount = detectedTableCount;
@@ -25,6 +26,7 @@ public sealed class PdfTableExtractionScopeReport {
         FormWidgetCount = formWidgetCount;
         AnnotationCount = annotationCount;
         PageActionCount = pageActionCount;
+        AnalysisTruncated = analysisTruncated;
     }
 
     /// <summary>Number of logical source pages inspected.</summary>
@@ -67,10 +69,17 @@ public sealed class PdfTableExtractionScopeReport {
     public int PageActionCount { get; }
 
     /// <summary>
+    /// True when bounded text/table correlation stopped before every visible text block could be classified.
+    /// Exact omission counts describe only blocks classified before the limit was reached.
+    /// </summary>
+    public bool AnalysisTruncated { get; }
+
+    /// <summary>
     /// Gets whether visible or interactive page content existed outside the detected tables.
     /// This is expected for table-only extraction and is separate from truncation within a table.
     /// </summary>
     public bool HasOmittedPageContent =>
+        AnalysisTruncated ||
         NonTableTextBlockCount > 0 ||
         VectorPrimitiveCount > 0 ||
         ImageCount > 0 ||

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfAnnotationDictionaryBuilder.Annotations.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfAnnotationDictionaryBuilder.Annotations.cs
@@ -762,11 +762,14 @@ internal static partial class PdfAnnotationDictionaryBuilder {
         Math.Max(1D, Math.Min(2D, (topY - bottomY) * 0.18D));
 
     private static void AppendSquigglyLine(StringBuilder builder, double startX, double endX, double baseY, double amplitude) {
-        double step = amplitude * 2D;
+        const int maximumSegments = 512;
+        double width = Math.Max(0D, endX - startX);
+        double step = Math.Max(amplitude * 2D, width / maximumSegments);
         builder.Append(FormatCoordinate(startX)).Append(' ').Append(FormatCoordinate(baseY)).Append(" m ");
         double x = startX;
         bool up = true;
-        while (x + step < endX) {
+        int segmentCount = 0;
+        while (x + step < endX && segmentCount++ < maximumSegments) {
             x += step;
             double y = up ? baseY + amplitude : baseY - amplitude;
             builder.Append(FormatCoordinate(x)).Append(' ').Append(FormatCoordinate(y)).Append(" l ");

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.Extraction.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.Extraction.cs
@@ -212,6 +212,20 @@ namespace OfficeIMO.Tests {
                 markdown, StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void ExtractMarkdownChunks_ClampsMalformedListLevelsBeforeIndentAllocation() {
+            using PowerPointPresentation presentation = PowerPointPresentation.Create();
+            PowerPointTextBox text = presentation.AddSlide().AddTextBox(string.Empty);
+            PowerPointParagraph paragraph = text.AddParagraph("Bounded child");
+            paragraph.SetBullet();
+            paragraph.Paragraph.ParagraphProperties!.Level = 1_000_000;
+
+            string markdown = presentation.ExtractMarkdownChunks().Single().Markdown;
+
+            Assert.Contains(new string(' ', 32) + "-", markdown, StringComparison.Ordinal);
+            Assert.DoesNotContain(new string(' ', 36) + "-", markdown, StringComparison.Ordinal);
+        }
+
         private static void AppendNotesParagraph(string filePath, string text) {
             using PresentationDocument document = PresentationDocument.Open(filePath, true);
             NotesSlidePart notesPart = document.PresentationPart!.SlideParts.First().NotesSlidePart!;

--- a/OfficeIMO.PowerPoint/Extraction/PowerPointExtractionExtensions.cs
+++ b/OfficeIMO.PowerPoint/Extraction/PowerPointExtractionExtensions.cs
@@ -143,7 +143,9 @@ public static class PowerPointExtractionExtensions {
                 listContentIndents.Clear();
                 markdown.Append("### ").AppendLine(text);
             } else {
-                int level = Math.Max(0, paragraph.Level ?? 0);
+                // DrawingML list levels are defined only for levels 0-8. Clamp untrusted
+                // package values before they can drive indentation allocation.
+                int level = Math.Min(8, Math.Max(0, paragraph.Level ?? 0));
                 if (kind == ParagraphMarkdownKind.NumberedList) {
                     RemoveListState(numberingState, level,
                         includeLevel: false);

--- a/OfficeIMO.PowerPoint/LegacyPpt/Model/LegacyPptTable.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Model/LegacyPptTable.cs
@@ -5,6 +5,8 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Model {
     /// <summary>Represents a native binary PowerPoint table decoded from an OfficeArt shape group.</summary>
     public sealed class LegacyPptTable {
         private const ushort TablePropertiesId = 0x039F;
+        private const int MaximumTableDimension = 1024;
+        private const long MaximumTableGridCells = 100_000L;
 
         private LegacyPptTable(IReadOnlyList<int> columnBoundaries,
             IReadOnlyList<int> rowBoundaries,
@@ -81,6 +83,12 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Model {
                 })
                 .Distinct().OrderBy(value => value).ToArray();
             if (horizontal.Length < 2 || vertical.Length < 2) return null;
+            long columns = horizontal.Length - 1L;
+            long rows = vertical.Length - 1L;
+            if (columns > MaximumTableDimension || rows > MaximumTableDimension ||
+                columns * rows > MaximumTableGridCells) {
+                return null;
+            }
 
             IReadOnlyDictionary<(int Left, int Top, int Width, int Height),
                 LegacyPptShape> gridLines = children

--- a/OfficeIMO.Reader.Core/ReaderOptions.cs
+++ b/OfficeIMO.Reader.Core/ReaderOptions.cs
@@ -21,7 +21,7 @@ public sealed class ReaderOptions {
 
     /// <summary>
     /// Optional maximum input size in bytes enforced by <see cref="OfficeDocumentReader"/> when reading from a file or seekable stream.
-    /// When null, no size limit is enforced.
+    /// When null, a registered format handler may apply its documented default; otherwise no size limit is enforced.
     /// </summary>
     public long? MaxInputBytes { get; set; }
 

--- a/OfficeIMO.Reader.Excel/ExcelReaderAdapter.cs
+++ b/OfficeIMO.Reader.Excel/ExcelReaderAdapter.cs
@@ -78,7 +78,12 @@ internal static class ExcelReaderAdapter {
         if (string.Equals(extension, ".xls", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(options.OpenPassword)) {
             return ExcelDocument.LoadLegacyXls(path, new LegacyXlsImportOptions { Password = options.OpenPassword, ReportUnsupportedContent = true });
         }
-        var loadOptions = new ExcelLoadOptions { AccessMode = DocumentAccessMode.ReadOnly };
+        var loadOptions = new ExcelLoadOptions {
+            AccessMode = DocumentAccessMode.ReadOnly,
+            OpenSettings = options.OpenXmlMaxCharactersInPart.HasValue
+                ? new OpenSettings { MaxCharactersInPart = options.OpenXmlMaxCharactersInPart.Value }
+                : null
+        };
         try {
             return ExcelDocument.Load(path, loadOptions);
         } catch (Exception exception) when (!string.IsNullOrEmpty(options.OpenPassword) && exception is InvalidDataException or IOException) {
@@ -91,7 +96,12 @@ internal static class ExcelReaderAdapter {
         if (string.Equals(extension, ".xls", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(options.OpenPassword)) {
             return ExcelDocument.LoadLegacyXls(stream, new LegacyXlsImportOptions { Password = options.OpenPassword, ReportUnsupportedContent = true });
         }
-        var loadOptions = new ExcelLoadOptions { AccessMode = DocumentAccessMode.ReadOnly };
+        var loadOptions = new ExcelLoadOptions {
+            AccessMode = DocumentAccessMode.ReadOnly,
+            OpenSettings = options.OpenXmlMaxCharactersInPart.HasValue
+                ? new OpenSettings { MaxCharactersInPart = options.OpenXmlMaxCharactersInPart.Value }
+                : null
+        };
         if (stream.CanSeek) stream.Position = 0;
         try {
             return ExcelDocument.Load(stream, loadOptions);

--- a/OfficeIMO.Reader.Pdf/OfficeDocumentReadResultPdfExtensions.cs
+++ b/OfficeIMO.Reader.Pdf/OfficeDocumentReadResultPdfExtensions.cs
@@ -216,6 +216,12 @@ public static class OfficeDocumentReadResultPdfExtensions {
             return true;
         }
 
+        if (!identified ||
+            !OfficeImagePdfCompatibility.TryValidateTranscodeDimensions(
+                identifiedInfo,
+                OfficeImagePdfCompatibility.DefaultMaximumTranscodePixels,
+                out _)) return false;
+
         bool converted = OfficeImagePngConverter.TryConvertToPng(
             sourceBytes,
             rasterDecodeOptions,

--- a/OfficeIMO.Reader.PowerPoint/OfficeDocumentReaderBuilderPowerPointExtensions.cs
+++ b/OfficeIMO.Reader.PowerPoint/OfficeDocumentReaderBuilderPowerPointExtensions.cs
@@ -28,9 +28,10 @@ public static class OfficeDocumentReaderBuilderPowerPointExtensions {
                 .Where(format => format.Generation == OfficeFormatGeneration.Modern)
                 .Select(format => format.Extension)
                 .ToArray(),
+            DefaultMaxInputBytes = PowerPointReaderAdapter.DefaultModernMaxInputBytes,
             ReadDocumentPath = (path, readerOptions, token) => PowerPointReaderAdapter.ReadDocument(path, readerOptions, configured, token),
             ReadDocumentStream = (stream, sourceName, readerOptions, token) => PowerPointReaderAdapter.ReadDocument(stream, sourceName, readerOptions, configured, token),
-            ProbeStream = (stream, sourceName, readerOptions, token) => PowerPointReaderAdapter.ProbeEncryptedOpenXml(stream, readerOptions, token),
+            ProbeStream = (stream, sourceName, readerOptions, token) => PowerPointReaderAdapter.ProbeEncryptedOpenXml(stream, sourceName, readerOptions, token),
             WarningBehavior = ReaderWarningBehavior.Mixed,
             DeterministicOutput = true
         }, replaceExisting);

--- a/OfficeIMO.Reader.PowerPoint/PowerPointReaderAdapter.cs
+++ b/OfficeIMO.Reader.PowerPoint/PowerPointReaderAdapter.cs
@@ -8,6 +8,8 @@ using OfficeIMO.Reader.FormatInternals;
 namespace OfficeIMO.Reader.PowerPoint;
 
 internal static class PowerPointReaderAdapter {
+    internal const long DefaultModernMaxInputBytes = 512L * 1024L * 1024L;
+
     internal static ReaderPowerPointOptions Clone(ReaderPowerPointOptions? source) => new ReaderPowerPointOptions {
         IncludeNotes = source?.IncludeNotes ?? true,
         IncludeTables = source?.IncludeTables ?? true,
@@ -20,16 +22,16 @@ internal static class PowerPointReaderAdapter {
     }
 
     internal static OfficeDocumentReadResult ReadDocument(Stream stream, string? sourceName, ReaderOptions readerOptions, ReaderPowerPointOptions options, CancellationToken cancellationToken) {
-        using PowerPointPresentation presentation = Load(stream, readerOptions, cancellationToken);
+        using PowerPointPresentation presentation = Load(stream, sourceName, readerOptions, cancellationToken);
         return Project(presentation, string.IsNullOrWhiteSpace(sourceName) ? "presentation.pptx" : sourceName!, readerOptions, options, cancellationToken);
     }
 
-    internal static bool ProbeEncryptedOpenXml(Stream stream, ReaderOptions options, CancellationToken cancellationToken) {
+    internal static bool ProbeEncryptedOpenXml(Stream stream, string? sourceName, ReaderOptions options, CancellationToken cancellationToken) {
         if (string.IsNullOrEmpty(options.OpenPassword) || !stream.CanSeek) return false;
         long position = stream.Position;
         try {
             cancellationToken.ThrowIfCancellationRequested();
-            using PowerPointPresentation presentation = Load(stream, options, cancellationToken);
+            using PowerPointPresentation presentation = Load(stream, sourceName, options, cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
             return presentation.OpenXmlDocument.GetAllParts().Any(static part =>
                 string.Equals(part.Uri.OriginalString, "/ppt/presentation.xml",
@@ -44,7 +46,7 @@ internal static class PowerPointReaderAdapter {
     }
 
     private static PowerPointPresentation Load(string path, ReaderOptions options, CancellationToken cancellationToken) {
-        PowerPointLoadOptions loadOptions = CreateLoadOptions(options);
+        PowerPointLoadOptions loadOptions = CreateLoadOptions(options, path);
         try {
             return PowerPointPresentation.Load(path, loadOptions, cancellationToken);
         } catch (Exception exception) when (ShouldRetryEncrypted(exception, options)) {
@@ -56,9 +58,9 @@ internal static class PowerPointReaderAdapter {
         }
     }
 
-    private static PowerPointPresentation Load(Stream stream, ReaderOptions options, CancellationToken cancellationToken) {
+    private static PowerPointPresentation Load(Stream stream, string? sourceName, ReaderOptions options, CancellationToken cancellationToken) {
         if (stream.CanSeek) stream.Position = 0;
-        PowerPointLoadOptions loadOptions = CreateLoadOptions(options);
+        PowerPointLoadOptions loadOptions = CreateLoadOptions(options, sourceName);
         try {
             return PowerPointPresentation.Load(stream, loadOptions, cancellationToken);
         } catch (Exception exception) when (stream.CanSeek && ShouldRetryEncrypted(exception, options)) {
@@ -71,16 +73,31 @@ internal static class PowerPointReaderAdapter {
         }
     }
 
-    private static PowerPointLoadOptions CreateLoadOptions(ReaderOptions options) {
-        long maxInputBytes = options.MaxInputBytes ?? LegacyPptImportOptions.DefaultMaxInputBytes;
+    internal static PowerPointLoadOptions CreateLoadOptions(ReaderOptions options, string? sourceName) {
+        long defaultMaxInputBytes = IsLegacySourceName(sourceName)
+            ? LegacyPptImportOptions.DefaultMaxInputBytes
+            : DefaultModernMaxInputBytes;
+        long maxInputBytes = options.MaxInputBytes ?? defaultMaxInputBytes;
+        long legacyMaxInputBytes = options.MaxInputBytes ?? LegacyPptImportOptions.DefaultMaxInputBytes;
         return new PowerPointLoadOptions {
             AccessMode = DocumentAccessMode.ReadOnly,
+            OpenSettings = options.OpenXmlMaxCharactersInPart.HasValue
+                ? new OpenSettings { MaxCharactersInPart = options.OpenXmlMaxCharactersInPart.Value }
+                : null,
+            PackageSecurity = new OfficePackageSecurityOptions { MaxPackageBytes = maxInputBytes },
             LegacyPptImportOptions = new LegacyPptImportOptions {
-                MaxInputBytes = maxInputBytes > int.MaxValue ? int.MaxValue : checked((int)maxInputBytes),
+                MaxInputBytes = legacyMaxInputBytes > int.MaxValue ? int.MaxValue : checked((int)legacyMaxInputBytes),
                 Password = options.OpenPassword,
                 ReportUnsupportedContent = true
             }
         };
+    }
+
+    private static bool IsLegacySourceName(string? sourceName) {
+        string extension = Path.GetExtension(sourceName ?? string.Empty);
+        return PowerPointFormatCatalog.All.Any(format =>
+            format.Generation == OfficeFormatGeneration.Legacy &&
+            string.Equals(format.Extension, extension, StringComparison.OrdinalIgnoreCase));
     }
 
     private static bool ShouldRetryEncrypted(Exception exception, ReaderOptions options) =>

--- a/OfficeIMO.Reader.Tests/Reader.Registry.cs
+++ b/OfficeIMO.Reader.Tests/Reader.Registry.cs
@@ -4,6 +4,7 @@ using OfficeIMO.Drawing;
 using OfficeIMO.Excel;
 using OfficeIMO.PowerPoint;
 using OfficeIMO.PowerPoint.LegacyPpt;
+using OfficeIMO.Reader.PowerPoint;
 using OfficeIMO.Word;
 using System.Text;
 using Xunit;
@@ -48,7 +49,7 @@ public sealed partial class ReaderRegistryTests {
             openXml.Extensions);
         Assert.True(openXml.SupportsPath);
         Assert.True(openXml.SupportsStream);
-        Assert.Null(openXml.DefaultMaxInputBytes);
+        Assert.Equal(PowerPointReaderAdapter.DefaultModernMaxInputBytes, openXml.DefaultMaxInputBytes);
         Assert.Equal(ReaderInputKind.PowerPoint, binary.Kind);
         Assert.Equal(
             PowerPointFormatCatalog.All
@@ -61,11 +62,21 @@ public sealed partial class ReaderRegistryTests {
         Assert.True(binary.SupportsStream);
         Assert.Equal(LegacyPptImportOptions.DefaultMaxInputBytes,
             binary.DefaultMaxInputBytes);
-        Assert.Null(OfficeIMO.Reader.Tests.ReaderTestReaders.All
-            .GetHandlerDefaultMaxInputBytes("deck.pptx"));
+        Assert.Equal(PowerPointReaderAdapter.DefaultModernMaxInputBytes,
+            OfficeIMO.Reader.Tests.ReaderTestReaders.All.GetHandlerDefaultMaxInputBytes("deck.pptx"));
         Assert.Equal(LegacyPptImportOptions.DefaultMaxInputBytes,
             OfficeIMO.Reader.Tests.ReaderTestReaders.All.GetHandlerDefaultMaxInputBytes(
                 "deck.ppt"));
+    }
+
+    [Fact]
+    public void PowerPointReader_UnknownStreamNameKeepsLegacyParserAtLegacyLimit() {
+        PowerPointLoadOptions options = PowerPointReaderAdapter.CreateLoadOptions(
+            new ReaderOptions(),
+            sourceName: null);
+
+        Assert.Equal(PowerPointReaderAdapter.DefaultModernMaxInputBytes, options.PackageSecurity!.MaxPackageBytes);
+        Assert.Equal(LegacyPptImportOptions.DefaultMaxInputBytes, options.LegacyPptImportOptions!.MaxInputBytes);
     }
 
     [Fact]

--- a/OfficeIMO.Reader.Tests/Reader.RichMappings.Office.cs
+++ b/OfficeIMO.Reader.Tests/Reader.RichMappings.Office.cs
@@ -167,6 +167,27 @@ public sealed class ReaderOfficeRichMappingTests {
     }
 
     [Fact]
+    public void DocumentReader_WordChunksDoNotDuplicateOversizedHyperlinkDestinations() {
+        string destination = "https://example.test/" + new string('a', 3000);
+        using var stream = new MemoryStream();
+        using (WordDocument document = WordDocument.Create(stream)) {
+            document.AddParagraph().AddHyperLink(new string('x', 1000), new Uri(destination));
+            document.Save();
+        }
+        stream.Position = 0;
+
+        OfficeDocumentReadResult result = OfficeIMO.Reader.Tests.ReaderTestReaders.Word().ReadDocument(
+            stream,
+            "bounded-hyperlink.docx",
+            new ReaderOptions { MaxChars = 256 });
+
+        Assert.All(result.Chunks, chunk => Assert.True((chunk.Markdown?.Length ?? 0) <= 256));
+        Assert.DoesNotContain(result.Chunks, chunk => (chunk.Markdown ?? string.Empty).Contains(destination, StringComparison.Ordinal));
+        Assert.Contains(result.Chunks.SelectMany(chunk => chunk.Warnings ?? Array.Empty<string>()),
+            warning => warning.Contains("hyperlink destination", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void DocumentReader_ExcelRichMapping_UsesFormalTablesCellLinksAndProperties() {
         using var stream = new MemoryStream();
         using (ExcelDocument document = ExcelDocument.Create(stream)) {

--- a/OfficeIMO.Reader.Word/WordReaderAdapter.cs
+++ b/OfficeIMO.Reader.Word/WordReaderAdapter.cs
@@ -44,7 +44,12 @@ internal static class WordReaderAdapter {
     }
 
     private static WordDocument Load(string path, ReaderOptions options) {
-        var loadOptions = new WordLoadOptions { AccessMode = DocumentAccessMode.ReadOnly };
+        var loadOptions = new WordLoadOptions {
+            AccessMode = DocumentAccessMode.ReadOnly,
+            OpenSettings = options.OpenXmlMaxCharactersInPart.HasValue
+                ? new OpenSettings { MaxCharactersInPart = options.OpenXmlMaxCharactersInPart.Value }
+                : null
+        };
         try { return WordDocument.Load(path, loadOptions); }
         catch (Exception exception) when (!string.IsNullOrEmpty(options.OpenPassword) && exception is InvalidDataException or IOException) {
             return WordDocument.LoadEncrypted(path, options.OpenPassword!, loadOptions);
@@ -52,7 +57,12 @@ internal static class WordReaderAdapter {
     }
 
     private static WordDocument Load(Stream stream, ReaderOptions options) {
-        var loadOptions = new WordLoadOptions { AccessMode = DocumentAccessMode.ReadOnly };
+        var loadOptions = new WordLoadOptions {
+            AccessMode = DocumentAccessMode.ReadOnly,
+            OpenSettings = options.OpenXmlMaxCharactersInPart.HasValue
+                ? new OpenSettings { MaxCharactersInPart = options.OpenXmlMaxCharactersInPart.Value }
+                : null
+        };
         try { return WordDocument.Load(stream, loadOptions); }
         catch (Exception exception) when (!string.IsNullOrEmpty(options.OpenPassword) && exception is InvalidDataException or IOException) {
             if (stream.CanSeek) stream.Position = 0;
@@ -157,23 +167,30 @@ internal static class WordReaderAdapter {
         foreach (WordRunSnapshot run in paragraph.Runs) {
             int firstRunFragmentIndex = fragments.Count;
             string runText = run.Text ?? string.Empty;
+            int maximumLinkDestinationLength = Math.Min(2048, Math.Max(0, limit / 4));
+            bool renderHyperlink = run.IsHyperlink &&
+                !string.IsNullOrWhiteSpace(run.HyperlinkUri) &&
+                run.HyperlinkUri!.Length <= maximumLinkDestinationLength;
+            if (run.IsHyperlink && !string.IsNullOrWhiteSpace(run.HyperlinkUri) && !renderHyperlink) {
+                warningList.Add("Word hyperlink destination exceeded the bounded Markdown link budget; visible text was emitted without duplicating the destination.");
+            }
             if (runText.Length > 0) {
                 int offset = 0;
                 while (offset < runText.Length) {
-                    int sourceLength = FindRunSourceLength(run, runText, offset, prefix.Length, limit);
+                    int sourceLength = FindRunSourceLength(run, runText, offset, prefix.Length, limit, renderHyperlink);
                     if (sourceLength == 0) {
                         sourceLength = GetUnicodeSafeLength(runText, offset, Math.Min(limit, runText.Length - offset));
                         warningList.Add("Word paragraph contains an atomic formatted run whose Markdown exceeds MaxChars; the complete Markdown construct was preserved.");
                     }
 
                     string sourcePart = runText.Substring(offset, sourceLength);
-                    string markdownPart = prefix + RenderRunText(run, sourcePart);
+                    string markdownPart = prefix + RenderRunText(run, sourcePart, renderHyperlink);
                     fragments.Add(new ParagraphRepresentation(sourcePart, markdownPart));
                     prefix = string.Empty;
                     offset += sourceLength;
                 }
             } else {
-                string renderedEmptyRun = RenderRunText(run, string.Empty);
+                string renderedEmptyRun = RenderRunText(run, string.Empty, renderHyperlink);
                 if (renderedEmptyRun.Length > 0) {
                     AddAtomicMarkdownFragment(fragments, prefix + renderedEmptyRun, limit, warningList);
                     prefix = string.Empty;
@@ -222,15 +239,15 @@ internal static class WordReaderAdapter {
         return CombineParagraphFragments(fragments, limit);
     }
 
-    private static string RenderRunText(WordRunSnapshot run, string sourceText) {
+    private static string RenderRunText(WordRunSnapshot run, string sourceText, bool renderHyperlink) {
         string markdown = sourceText;
-        if (run.IsHyperlink && !string.IsNullOrWhiteSpace(run.HyperlinkUri)) markdown = $"[{markdown}]({run.HyperlinkUri})";
+        if (renderHyperlink) markdown = $"[{markdown}]({run.HyperlinkUri})";
         if (run.Bold && markdown.Length > 0) markdown = "**" + markdown + "**";
         if (run.Italic && markdown.Length > 0) markdown = "*" + markdown + "*";
         return markdown;
     }
 
-    private static int FindRunSourceLength(WordRunSnapshot run, string value, int offset, int markdownPrefixLength, int limit) {
+    private static int FindRunSourceLength(WordRunSnapshot run, string value, int offset, int markdownPrefixLength, int limit, bool renderHyperlink) {
         int maximum = Math.Min(limit, value.Length - offset);
         int low = 1;
         int high = maximum;
@@ -242,7 +259,7 @@ internal static class WordReaderAdapter {
                 low = midpoint + 1;
                 continue;
             }
-            int renderedLength = markdownPrefixLength + RenderRunText(run, value.Substring(offset, candidate)).Length;
+            int renderedLength = markdownPrefixLength + RenderRunText(run, value.Substring(offset, candidate), renderHyperlink).Length;
             if (renderedLength <= limit) {
                 best = candidate;
                 low = midpoint + 1;

--- a/OfficeIMO.Rtf.Pdf/RtfPdfConverter.Fonts.cs
+++ b/OfficeIMO.Rtf.Pdf/RtfPdfConverter.Fonts.cs
@@ -8,8 +8,11 @@ internal static partial class RtfPdfConverter {
         PdfCore.PdfOptions pdfOptions,
         RtfPdfSaveOptions options) {
         bool allowSystemFontEmbedding = options.ResourcePolicy.AllowSystemFontEmbedding;
+        bool systemFontBudgetReported = false;
         var fontSlots = new Dictionary<int, PdfCore.PdfStandardFont>();
         var familySlots = new Dictionary<string, PdfCore.PdfStandardFont>(StringComparer.OrdinalIgnoreCase);
+        var unresolvedFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var systemFontFamilies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         HashSet<int> referencedFontIds = CollectReferencedFontIds(document);
         HashSet<PdfCore.PdfStandardFont> registeredFontSlots = pdfOptions.CreateRegisteredFontFamilySlots(includeDocumentFontSlots: false);
         if (pdfOptions.HasExplicitDefaultFont) PdfCore.PdfOptions.AddRegisteredFontFamilySlot(registeredFontSlots, pdfOptions.DefaultFont);
@@ -32,12 +35,15 @@ internal static partial class RtfPdfConverter {
                 defaultFont.Name,
                 pdfOptions,
                 registeredFontSlots,
-                allowSystemFontEmbedding,
+                ResolveSystemFontPermission(defaultFont.Name, allowSystemFontEmbedding, options,
+                    systemFontFamilies, ref systemFontBudgetReported),
                 options,
                 out PdfCore.PdfStandardFont defaultSlot)) {
                 pdfOptions.ApplyInheritedFontFamily(defaultSlot);
                 familySlots[defaultFont.Name] = defaultSlot;
                 fontSlots[defaultFont.Id] = defaultSlot;
+            } else {
+                unresolvedFamilies.Add(defaultFont.Name);
             }
         }
 
@@ -50,20 +56,51 @@ internal static partial class RtfPdfConverter {
                 fontSlots[font.Id] = existingSlot;
                 continue;
             }
+            if (unresolvedFamilies.Contains(font.Name)) continue;
 
             if (TryRegisterDocumentFont(
                 font.Name,
                 pdfOptions,
                 registeredFontSlots,
-                allowSystemFontEmbedding,
+                ResolveSystemFontPermission(font.Name, allowSystemFontEmbedding, options,
+                    systemFontFamilies, ref systemFontBudgetReported),
                 options,
                 out PdfCore.PdfStandardFont fontSlot)) {
                 familySlots[font.Name] = fontSlot;
                 fontSlots[font.Id] = fontSlot;
+            } else {
+                unresolvedFamilies.Add(font.Name);
             }
         }
 
         return fontSlots;
+    }
+
+    private static bool ResolveSystemFontPermission(
+        string familyName,
+        bool allowSystemFontEmbedding,
+        RtfPdfSaveOptions options,
+        ISet<string> systemFontFamilies,
+        ref bool budgetReported) {
+        if (!allowSystemFontEmbedding) return false;
+        if (systemFontFamilies.Contains(familyName)) return true;
+        if (systemFontFamilies.Count < options.MaximumSystemFontFamilies) {
+            systemFontFamilies.Add(familyName);
+            return true;
+        }
+        if (!budgetReported) {
+            budgetReported = true;
+            AddConversionWarning(
+                options,
+                "SystemFontResolutionLimitExceeded",
+                "Font/" + familyName,
+                "The RTF font-family resolution budget was exhausted; remaining families use dependency-free PDF fallbacks.",
+                RtfConversionAction.Substituted,
+                new Dictionary<string, string> {
+                    ["maximumSystemFontFamilies"] = options.MaximumSystemFontFamilies.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                });
+        }
+        return false;
     }
 
     private static HashSet<int> CollectReferencedFontIds(RtfDocument document) {

--- a/OfficeIMO.Rtf.Pdf/RtfPdfSaveOptions.cs
+++ b/OfficeIMO.Rtf.Pdf/RtfPdfSaveOptions.cs
@@ -6,6 +6,9 @@ namespace OfficeIMO.Rtf.Pdf;
 /// Controls conversion from an RTF document model to a first-party PDF document.
 /// </summary>
 public sealed class RtfPdfSaveOptions {
+    /// <summary>Default number of distinct document font families allowed to probe installed system fonts.</summary>
+    public const int DefaultMaximumSystemFontFamilies = 32;
+
     private PdfCore.PdfResourcePolicy _resourcePolicy = PdfCore.PdfResourcePolicy.CreateDefault();
     /// <summary>Creates RTF to PDF save options.</summary>
     public RtfPdfSaveOptions() {
@@ -52,6 +55,12 @@ public sealed class RtfPdfSaveOptions {
     /// <summary>When true, footnote, endnote, and annotation bodies referenced by runs are appended to PDF output.</summary>
     public bool IncludeNotes { get; set; } = true;
 
+    /// <summary>
+    /// Maximum number of distinct RTF font families allowed to trigger installed-font resolution.
+    /// Additional families use dependency-free PDF fallbacks. Set to zero to disable system-font probes.
+    /// </summary>
+    public int MaximumSystemFontFamilies { get; set; } = DefaultMaximumSystemFontFamilies;
+
     /// <summary>Returns a normalized copy with valid dimensions and independent PDF options.</summary>
     internal RtfPdfSaveOptions CloneForConversion() {
         if (DefaultImageWidth <= 0) {
@@ -60,6 +69,9 @@ public sealed class RtfPdfSaveOptions {
 
         if (DefaultImageHeight <= 0) {
             throw new ArgumentOutOfRangeException(nameof(DefaultImageHeight), "Default image height must be greater than zero.");
+        }
+        if (MaximumSystemFontFamilies < 0) {
+            throw new ArgumentOutOfRangeException(nameof(MaximumSystemFontFamilies));
         }
 
         return new RtfPdfSaveOptions {
@@ -73,7 +85,8 @@ public sealed class RtfPdfSaveOptions {
             IncludeMetadata = IncludeMetadata,
             IncludeTables = IncludeTables,
             IncludeHeaderFooters = IncludeHeaderFooters,
-            IncludeNotes = IncludeNotes
+            IncludeNotes = IncludeNotes,
+            MaximumSystemFontFamilies = MaximumSystemFontFamilies
         };
     }
 

--- a/OfficeIMO.Rtf.Tests/Rtf/RtfPdfConverterTests.cs
+++ b/OfficeIMO.Rtf.Tests/Rtf/RtfPdfConverterTests.cs
@@ -9,6 +9,16 @@ namespace OfficeIMO.Tests.Rtf;
 
 public class RtfPdfConverterTests {
     [Fact]
+    public void RtfPdfSaveOptionsRejectNegativeSystemFontBudget() {
+        RtfDocument document = RtfDocument.Create();
+        document.AddParagraph("bounded font resolution");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => document.ToPdf(new RtfPdfSaveOptions {
+            MaximumSystemFontFamilies = -1
+        }));
+    }
+
+    [Fact]
     public void RtfDocument_ToPdfDocument_ResourcePolicyControlsSystemFontEmbedding() {
         string? installedFamily = new[] { "Arial", "Calibri", "Liberation Sans", "DejaVu Sans" }
             .FirstOrDefault(candidate => PdfCore.PdfEmbeddedFontFamily.TryFromSystem(candidate, out _));
@@ -29,6 +39,29 @@ public class RtfPdfConverterTests {
         Assert.NotEmpty(balanced.Options.EmbeddedFonts);
         Assert.Contains("RTF font policy marker", PdfCore.PdfReadDocument.Open(portable.ToBytes()).ExtractText(), StringComparison.Ordinal);
         Assert.Contains("RTF font policy marker", PdfCore.PdfReadDocument.Open(balanced.ToBytes()).ExtractText(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RtfDocument_ToPdfDocument_CountsDistinctSystemFontFamiliesOnce() {
+        string? installedFamily = new[] { "Arial", "Calibri", "Liberation Sans", "DejaVu Sans" }
+            .FirstOrDefault(candidate => PdfCore.PdfEmbeddedFontFamily.TryFromSystem(candidate, out _));
+        if (installedFamily == null) return;
+
+        RtfDocument document = RtfDocument.Create();
+        int missingFontId = document.AddFont("OfficeIMO Definitely Missing Font");
+        document.Settings.SetDefaultFont(missingFontId);
+        int installedFontId = document.AddFont(installedFamily);
+        document.AddParagraph().AddText("missing default").FontId = missingFontId;
+        document.AddParagraph().AddText("installed run").FontId = installedFontId;
+
+        PdfCore.PdfDocumentConversionResult result = document.ToPdfDocumentResult(new RtfPdfSaveOptions {
+            ResourcePolicy = PdfCore.PdfResourcePolicy.CreateTrustedHost(),
+            MaximumSystemFontFamilies = 2
+        });
+
+        Assert.DoesNotContain(result.Warnings, warning => warning.Code == "SystemFontResolutionLimitExceeded");
+        Assert.Contains(result.Value.Options.EmbeddedFonts.Keys, slot =>
+            result.Value.Options.EmbeddedFontFamilySlotMatches(slot, installedFamily));
     }
 
     [Fact]

--- a/OfficeIMO.Word.Tests/Word.ImageExport.Batch.cs
+++ b/OfficeIMO.Word.Tests/Word.ImageExport.Batch.cs
@@ -130,6 +130,18 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void WordDocument_VisualSnapshotBatchEnforcesMaximumOutputCount() {
+            using WordDocument document = CreateThreePageDocument();
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+                document.CreateVisualSnapshots(new WordImageExportOptions {
+                    MaximumOutputCount = 2
+                }));
+
+            Assert.Contains(nameof(OfficeImageExportOptions.MaximumOutputCount), exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public async Task WordDocument_VisualSnapshotBatchCancelsDuringASingleLargeRun() {
             using WordDocument document = WordDocument.Create();
             document.AddParagraph(new string('x', 2000000));

--- a/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.Batch.cs
+++ b/OfficeIMO.Word/Imaging/WordDocumentImageRenderer.Batch.cs
@@ -51,6 +51,11 @@ namespace OfficeIMO.Word {
                 cancellationToken,
                 options.CancellationCheckpoint);
             (int firstPage, int count) = ResolveBatchPageRange(options, sectionPageCounts);
+            if (count > options.MaximumOutputCount) {
+                throw new InvalidOperationException(
+                    "Word page snapshot count exceeds " + nameof(OfficeImageExportOptions.MaximumOutputCount) +
+                    ": " + count + " requested, " + options.MaximumOutputCount + " allowed.");
+            }
             var snapshots = new List<WordDocumentVisualSnapshot>(count);
             for (int index = 0; index < count; index++) {
                 cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
## Summary

This batch reviews the first 20 Codex Security findings and hardens the 18 issues that still applied:

- bound raster transcoding, font discovery, PDF stream/table/annotation analysis, and Word snapshot/link output
- restore Open XML part limits and add bounded modern/encrypted PowerPoint input handling
- cap Excel pivot metadata, formula preprocessing, dense dependency expansion, legacy PPT table projection, list indentation, RTF font probing, and iCalendar recurrence validation
- report bounded PDF and Excel analysis as incomplete instead of presenting partial results as authoritative

## Finding disposition

- 18 confirmed findings are fixed by this PR
- 1 PowerPoint temporary-stream finding was already fixed on current master and was closed as already fixed
- 1 web-reader SSRF report did not apply because the API explicitly treats URLs as trusted and the caller-owned HttpClient as the connection-time DNS/redirect policy boundary; it was closed as a false positive

## Compatibility

Modern PowerPoint Reader inputs now have a 512 MiB default package ceiling, while legacy PPT parsing retains its existing 64 MiB default even when a stream has no reliable filename. Explicit ReaderOptions.MaxInputBytes still overrides both.

## Validation

- Drawing: 932 passed
- PDF: 3,116 passed
- Excel: 2,493 passed, 5 gated integration tests skipped
- RTF: 699 passed
- Reader: 837 passed
- Word: 2,430 passed, 9 skipped
- PowerPoint: 1,334 passed, 2 skipped
- Email: 1,223 passed, 4 skipped; one pre-existing macOS /var versus /private/var symlink assertion remains unrelated
- affected netstandard2.0 builds pass without warnings
- independent local security review completed; all findings and its single targeted follow-up were resolved