### PR TITLE
Harden legacy PowerPoint import and conversion boundaries

### DIFF
--- a/OfficeIMO.Drawing/Binary/OfficeArtBlipStoreEntryWriter.cs
+++ b/OfficeIMO.Drawing/Binary/OfficeArtBlipStoreEntryWriter.cs
@@ -6,6 +6,7 @@ namespace OfficeIMO.Drawing.Binary;
 /// <summary>Writes bounded OfficeArt File BLIP Store Entry and image BLIP records.</summary>
 public static class OfficeArtBlipStoreEntryWriter {
     private const ushort OfficeArtFbse = 0xF007;
+    private const int MaximumImageBytes = 64 * 1024 * 1024;
 
     /// <summary>
     /// Creates one complete embedded FBSE record for a supported raster or
@@ -53,6 +54,11 @@ public static class OfficeArtBlipStoreEntryWriter {
         if (imageBytes == null) throw new ArgumentNullException(nameof(imageBytes));
         if (imageBytes.Length == 0) {
             throw new ArgumentException("Image data cannot be empty.",
+                nameof(imageBytes));
+        }
+        if (imageBytes.Length > MaximumImageBytes) {
+            throw new ArgumentException(
+                $"OfficeArt BLIP payloads cannot exceed {MaximumImageBytes} bytes.",
                 nameof(imageBytes));
         }
         if (string.IsNullOrWhiteSpace(contentType)) {

--- a/OfficeIMO.Email.Tests/AddressBook/OfflineAddressBookSessionTests.cs
+++ b/OfficeIMO.Email.Tests/AddressBook/OfflineAddressBookSessionTests.cs
@@ -124,7 +124,7 @@ public sealed class OfflineAddressBookSessionTests {
         }
     }
 
-    private sealed class ReportedLengthStream : Stream {
+    internal sealed class ReportedLengthStream : Stream {
         private readonly byte[] _data;
         private readonly long _length;
         private long _position;

--- a/OfficeIMO.Email.Tests/AddressBook/ReaderEmailAddressBookTests.cs
+++ b/OfficeIMO.Email.Tests/AddressBook/ReaderEmailAddressBookTests.cs
@@ -26,6 +26,25 @@ public sealed class ReaderEmailAddressBookTests {
     }
 
     [Fact]
+    public void SeekableItemReaderDoesNotSnapshotLogicallyHugeOabStreams() {
+        byte[] oab = new OabV4Fixture().Build();
+        const long reportedLength = 32L * 1024 * 1024 * 1024;
+        using var stream = new OfflineAddressBookSessionTests
+            .ReportedLengthStream(oab, reportedLength);
+
+        ReaderEmailAddressBookEntryResult result = Assert.Single(
+            EmailAddressBookEntryReader.Read(stream, "huge.oab",
+                addressBookOptions: new ReaderEmailAddressBookOptions {
+                    MaxEntries = 1
+                }));
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("Ada Lovelace", result.Summary!.DisplayName);
+        Assert.True(stream.BytesRead < oab.Length * 2L);
+        Assert.True(stream.MaximumReadRequest < 1024 * 1024);
+    }
+
+    [Fact]
     public void MembershipValuesAreExplicitlyOptIn() {
         byte[] oab = new OabV4Fixture().Build();
         var query = new OfflineAddressBookSearchQuery(

--- a/OfficeIMO.Email.Tests/AddressBook/ReaderEmailAddressBookTests.cs
+++ b/OfficeIMO.Email.Tests/AddressBook/ReaderEmailAddressBookTests.cs
@@ -45,6 +45,23 @@ public sealed class ReaderEmailAddressBookTests {
     }
 
     [Fact]
+    public void SeekableItemReaderParsesFromStartAndRestoresCallerPosition() {
+        byte[] oab = new OabV4Fixture().Build();
+        using var stream = new MemoryStream(oab, writable: false);
+        stream.Position = 17;
+
+        ReaderEmailAddressBookEntryResult result = Assert.Single(
+            EmailAddressBookEntryReader.Read(stream, "positioned.oab",
+                addressBookOptions: new ReaderEmailAddressBookOptions {
+                    MaxEntries = 1
+                }));
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("Ada Lovelace", result.Summary!.DisplayName);
+        Assert.Equal(17, stream.Position);
+    }
+
+    [Fact]
     public void MembershipValuesAreExplicitlyOptIn() {
         byte[] oab = new OabV4Fixture().Build();
         var query = new OfflineAddressBookSearchQuery(

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Comments.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Comments.cs
@@ -180,6 +180,39 @@ namespace OfficeIMO.Tests {
             Assert.Contains("color index", finding.Description, StringComparison.OrdinalIgnoreCase);
         }
 
+        [Fact]
+        public void LegacyEncryption_LoadEncryptedPropagatesAggregateImportLimits() {
+            const string password = "encrypted-limits";
+            byte[] encryptedBytes;
+            using (PowerPointPresentation source =
+                   PowerPointPresentation.Create()) {
+                PowerPointSlide first = source.AddSlide();
+                PowerPointSlide second = source.AddSlide();
+                AddAuthors(source, (0U, "Reviewer", "R", 2U));
+                AddComment(first, 0U, 1U, "First", DateTime.UtcNow,
+                    10, 20);
+                AddComment(second, 0U, 2U, "Second", DateTime.UtcNow,
+                    20, 30);
+                encryptedBytes = source.ToEncryptedBytes(password,
+                    PowerPointFileFormat.Ppt);
+            }
+            using var input = new MemoryStream(encryptedBytes,
+                writable: false);
+
+            InvalidDataException exception = Assert.Throws<
+                InvalidDataException>(() =>
+                PowerPointPresentation.LoadEncrypted(input, password,
+                    new PowerPointLoadOptions {
+                        LegacyPptImportOptions =
+                            new LegacyPptImportOptions {
+                                MaxCommentCount = 1
+                            }
+                    }));
+
+            Assert.Contains("comment count", exception.Message,
+                StringComparison.OrdinalIgnoreCase);
+        }
+
         private static void AddAuthors(PowerPointPresentation presentation,
             params (uint Id, string Name, string Initials, uint LastIndex)[] authors) {
             CommentAuthorsPart part = presentation.OpenXmlDocument.PresentationPart!

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Encryption.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Encryption.cs
@@ -394,7 +394,7 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void LegacyEncryption_EditedImportedDeckCanBeReEncryptedAndPreservesOpaqueStreams() {
+        public void LegacyEncryption_OpaqueStreamsRequireExplicitClearTextOptIn() {
             const string sourcePassword = "source-pass";
             const string targetPassword = "target-pass";
             byte[] plainBytes;
@@ -409,8 +409,14 @@ namespace OfficeIMO.Tests {
                 new Dictionary<string, byte[]> {
                     ["VendorData/opaque"] = opaqueBytes
                 });
+            NotSupportedException sourceFailure = Assert.Throws<
+                NotSupportedException>(() => LegacyPptRc4CryptoApi
+                .EncryptPackage(withOpaque, sourcePassword));
+            Assert.Contains("VendorData/opaque", sourceFailure.Message,
+                StringComparison.Ordinal);
             byte[] encryptedSource = LegacyPptRc4CryptoApi.EncryptPackage(
-                withOpaque, sourcePassword);
+                withOpaque, sourcePassword,
+                allowUnencryptedCompoundStreams: true);
 
             byte[] encryptedEdited;
             using (var input = new MemoryStream(encryptedSource))
@@ -420,8 +426,14 @@ namespace OfficeIMO.Tests {
                 Assert.Single(presentation.Slides[0].TextBoxes,
                     textBox => textBox.Text == "Original secret").Text =
                     "Edited secret";
+                Assert.Throws<NotSupportedException>(() => presentation
+                    .ToEncryptedBytes(targetPassword,
+                        PowerPointFileFormat.Ppt));
                 encryptedEdited = presentation.ToEncryptedBytes(
-                    targetPassword, PowerPointFileFormat.Ppt);
+                    targetPassword, PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LegacyPptAllowUnencryptedCompoundStreams = true
+                    });
             }
 
             Assert.Throws<CryptographicException>(() =>

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Interactions.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Interactions.cs
@@ -298,8 +298,13 @@ namespace OfficeIMO.Tests {
                 linked.Left += 250000;
 
                 LegacyPptWritePreflightReport report = imported.AnalyzeLegacyPptWrite();
-                Assert.True(report.CanWrite, string.Join(Environment.NewLine, report.Findings));
-                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt);
+                Assert.Contains(report.Findings, finding =>
+                    finding.Code == "PPT-WRITE-PRESERVED-EXTERNAL-LINK");
+                Assert.False(report.CanWrite);
+                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    });
             }
 
             LegacyPptPresentation saved = LegacyPptPresentation.Load(savedBytes);
@@ -352,9 +357,13 @@ namespace OfficeIMO.Tests {
                     .Descendants<A.HyperlinkOnClick>().Single();
                 link.Tooltip = "Updated tip";
                 LegacyPptWritePreflightReport report = imported.AnalyzeLegacyPptWrite();
-                Assert.True(report.CanWrite,
-                    string.Join(Environment.NewLine, report.Findings));
-                editedBytes = imported.ToBytes(PowerPointFileFormat.Ppt);
+                Assert.Contains(report.Findings, finding =>
+                    finding.Code == "PPT-WRITE-PRESERVED-EXTERNAL-LINK");
+                Assert.False(report.CanWrite);
+                editedBytes = imported.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    });
             }
             LegacyPptPresentation edited = LegacyPptPresentation.Load(editedBytes);
             Assert.Equal("Updated tip", Assert.Single(edited.Slides[0].Shapes
@@ -369,8 +378,11 @@ namespace OfficeIMO.Tests {
                 A.HyperlinkOnClick link = imported.Slides[0].SlidePart.Slide!
                     .Descendants<A.HyperlinkOnClick>().Single();
                 link.Tooltip = null;
-                Assert.True(imported.AnalyzeLegacyPptWrite().CanWrite);
-                removedBytes = imported.ToBytes(PowerPointFileFormat.Ppt);
+                Assert.False(imported.AnalyzeLegacyPptWrite().CanWrite);
+                removedBytes = imported.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    });
             }
             LegacyPptPresentation removed = LegacyPptPresentation.Load(removedBytes);
             Assert.Null(Assert.Single(removed.Slides[0].Shapes
@@ -417,8 +429,11 @@ namespace OfficeIMO.Tests {
                 P.NonVisualDrawingProperties properties = GetDrawingProperties(shape);
                 properties.RemoveAllChildren<A.HyperlinkOnClick>();
                 AddShapeHyperlink(slide, shape, secondTarget, mouseOver: false);
-                Assert.True(imported.AnalyzeLegacyPptWrite().CanWrite);
-                editedBytes = imported.ToBytes(PowerPointFileFormat.Ppt);
+                Assert.False(imported.AnalyzeLegacyPptWrite().CanWrite);
+                editedBytes = imported.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    });
             }
             LegacyPptPresentation edited = LegacyPptPresentation.Load(editedBytes);
             Assert.Equal(secondTarget, Assert.Single(edited.Slides[0].Shapes
@@ -480,8 +495,11 @@ namespace OfficeIMO.Tests {
                 string relationshipId = shape.TextBody!.Descendants<A.HyperlinkOnClick>()
                     .Single().Id!.Value!;
                 SetLinkedText(shape, relationshipId, linkFirstRun: true);
-                Assert.True(imported.AnalyzeLegacyPptWrite().CanWrite);
-                movedBytes = imported.ToBytes(PowerPointFileFormat.Ppt);
+                Assert.False(imported.AnalyzeLegacyPptWrite().CanWrite);
+                movedBytes = imported.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    });
             }
             LegacyPptPresentation moved = LegacyPptPresentation.Load(movedBytes);
             LegacyPptTextInteraction movedRange = Assert.Single(

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.OleObjects.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.OleObjects.cs
@@ -317,9 +317,13 @@ namespace OfficeIMO.Tests {
 
                 LegacyPptWritePreflightReport preflight = imported
                     .AnalyzeLegacyPptWrite();
-                Assert.True(preflight.CanWrite,
-                    string.Join(Environment.NewLine, preflight.Findings));
-                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt);
+                Assert.Contains(preflight.Findings, finding =>
+                    finding.Code == "PPT-WRITE-PRESERVED-OLE");
+                Assert.False(preflight.CanWrite);
+                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    });
             }
 
             LegacyPptPresentation saved = LegacyPptPresentation.Load(

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.PackageSecurity.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.PackageSecurity.cs
@@ -344,6 +344,18 @@ namespace OfficeIMO.Tests {
             Assert.True(neutral.HasRunProgramContent);
             Assert.Empty(neutral.Slides[0].Shapes.SelectMany(shape =>
                 shape.Interactions));
+            using (var preservationInput = new MemoryStream(malformed,
+                       writable: false))
+            using (PowerPointPresentation imported =
+                   PowerPointPresentation.Load(preservationInput,
+                       new PowerPointLoadOptions {
+                           LegacyPptImportOptions =
+                               new LegacyPptImportOptions {
+                                   ReportUnsupportedContent = false
+                               }
+                       })) {
+                Assert.True(imported.LegacyPptWillPreserveRunProgramContent);
+            }
             var security = OfficePackageSecurityOptions.SecureDefaults;
             security.ExternalRelationships =
                 OfficePackageContentPolicy.Reject;
@@ -398,22 +410,34 @@ namespace OfficeIMO.Tests {
             SlideLayoutPart layoutPart = imported.Slides[0].SlidePart
                 .SlideLayoutPart!;
             DocumentFormat.OpenXml.OpenXmlPartRootElement root;
+            OpenXmlPart targetPart;
             if (targetKind >= 2) {
                 imported.Slides[0].Notes.Text = "Speaker note";
                 NotesSlidePart notesPart = imported.Slides[0].SlidePart
                     .NotesSlidePart!;
-                root = targetKind == 2
-                    ? notesPart.NotesSlide!
-                    : notesPart.NotesMasterPart!.NotesMaster!;
+                if (targetKind == 2) {
+                    root = notesPart.NotesSlide!;
+                    targetPart = notesPart;
+                } else {
+                    root = notesPart.NotesMasterPart!.NotesMaster!;
+                    targetPart = notesPart.NotesMasterPart;
+                }
             } else {
-                root = targetKind == 0
-                    ? layoutPart.SlideMasterPart!.SlideMaster!
-                    : layoutPart.SlideLayout!;
+                if (targetKind == 0) {
+                    root = layoutPart.SlideMasterPart!.SlideMaster!;
+                    targetPart = layoutPart.SlideMasterPart;
+                } else {
+                    root = layoutPart.SlideLayout!;
+                    targetPart = layoutPart;
+                }
             }
+            HyperlinkRelationship preservedRelationship = targetPart
+                .AddHyperlinkRelationship(
+                    new Uri("https://example.test/still-present"), true);
             P.NonVisualDrawingProperties properties = root
                 .Descendants<P.NonVisualDrawingProperties>().First();
             properties.Append(new A.HyperlinkOnClick {
-                Id = "rPreservedActiveContent",
+                Id = preservedRelationship.Id,
                 Action = runProgram ? "ppaction://program" : null
             });
 
@@ -421,6 +445,45 @@ namespace OfficeIMO.Tests {
                 imported.LegacyPptWillPreserveRunProgramContent);
             Assert.Equal(!runProgram,
                 imported.LegacyPptWillPreserveExternalHyperlinkContent);
+        }
+
+        [Fact]
+        public void LegacyPreservationGateDoesNotTreatInternalSlideJumpAsExternal() {
+            byte[] binary;
+            using (PowerPointPresentation source =
+                   PowerPointPresentation.Create()) {
+                PowerPointSlide slide = source.AddSlide(
+                    P.SlideLayoutValues.Blank);
+                source.AddSlide(P.SlideLayoutValues.Blank);
+                PowerPointAutoShape shape = slide.AddRectangle(
+                    100000, 100000, 1000000, 500000);
+                HyperlinkRelationship external = slide.SlidePart
+                    .AddHyperlinkRelationship(
+                        new Uri("https://example.test/remove"), true);
+                ((P.Shape)shape.Element).NonVisualShapeProperties!
+                    .NonVisualDrawingProperties!
+                    .Append(new A.HyperlinkOnClick { Id = external.Id });
+                binary = source.ToBytes(PowerPointFileFormat.Ppt);
+            }
+
+            using var input = new MemoryStream(binary, writable: false);
+            using PowerPointPresentation imported =
+                PowerPointPresentation.Load(input);
+            SlidePart slidePart = imported.Slides[0].SlidePart;
+            slidePart.Slide!.Descendants<A.HyperlinkOnClick>()
+                .ToList().ForEach(item => item.Remove());
+            HyperlinkRelationship internalJump = slidePart
+                .AddHyperlinkRelationship(
+                    new Uri("../slides/slide2.xml", UriKind.Relative),
+                    false);
+            P.NonVisualDrawingProperties properties = slidePart.Slide
+                .Descendants<P.NonVisualDrawingProperties>().First();
+            properties.Append(new A.HyperlinkOnClick {
+                Id = internalJump.Id,
+                Action = "ppaction://hlinksldjump"
+            });
+
+            Assert.False(imported.LegacyPptWillPreserveExternalHyperlinkContent);
         }
 
         [Fact]

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.PackageSecurity.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.PackageSecurity.cs
@@ -358,6 +358,57 @@ namespace OfficeIMO.Tests {
                 exception.Rule);
         }
 
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void LegacyPreservationGateScansMasterAndLayoutHyperlinks(
+            bool useMaster, bool runProgram) {
+            byte[] binary;
+            using (PowerPointPresentation source =
+                   PowerPointPresentation.Create()) {
+                PowerPointSlide slide = source.AddSlide(
+                    P.SlideLayoutValues.Blank);
+                PowerPointAutoShape shape = slide.AddRectangle(
+                    100000, 100000, 1000000, 500000);
+                HyperlinkRelationship relationship = slide.SlidePart
+                    .AddHyperlinkRelationship(new Uri(
+                        "https://example.test/preserved"), true);
+                ((P.Shape)shape.Element).NonVisualShapeProperties!
+                    .NonVisualDrawingProperties!
+                    .Append(new A.HyperlinkOnClick {
+                        Id = relationship.Id,
+                        Action = runProgram ? "ppaction://program" : null
+                    });
+                binary = source.ToBytes(PowerPointFileFormat.Ppt);
+            }
+
+            using var input = new MemoryStream(binary, writable: false);
+            using PowerPointPresentation imported =
+                PowerPointPresentation.Load(input);
+            imported.Slides[0].SlidePart.Slide!
+                .Descendants<A.HyperlinkOnClick>()
+                .ToList()
+                .ForEach(item => item.Remove());
+            SlideLayoutPart layoutPart = imported.Slides[0].SlidePart
+                .SlideLayoutPart!;
+            P.NonVisualDrawingProperties properties = useMaster
+                ? layoutPart.SlideMasterPart!.SlideMaster!
+                    .Descendants<P.NonVisualDrawingProperties>().First()
+                : layoutPart.SlideLayout!
+                    .Descendants<P.NonVisualDrawingProperties>().First();
+            properties.Append(new A.HyperlinkOnClick {
+                Id = "rPreservedActiveContent",
+                Action = runProgram ? "ppaction://program" : null
+            });
+
+            Assert.Equal(runProgram,
+                imported.LegacyPptWillPreserveRunProgramContent);
+            Assert.Equal(!runProgram,
+                imported.LegacyPptWillPreserveExternalHyperlinkContent);
+        }
+
         [Fact]
         public void RawSecurityEvidenceScan_EnforcesRecordCountBudget() {
             var externalUri = new Uri("https://example.test/"

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.PackageSecurity.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.PackageSecurity.cs
@@ -359,12 +359,16 @@ namespace OfficeIMO.Tests {
         }
 
         [Theory]
-        [InlineData(false, false)]
-        [InlineData(false, true)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        public void LegacyPreservationGateScansMasterAndLayoutHyperlinks(
-            bool useMaster, bool runProgram) {
+        [InlineData(0, false)]
+        [InlineData(0, true)]
+        [InlineData(1, false)]
+        [InlineData(1, true)]
+        [InlineData(2, false)]
+        [InlineData(2, true)]
+        [InlineData(3, false)]
+        [InlineData(3, true)]
+        public void LegacyPreservationGateScansProjectedShapeRoots(
+            int targetKind, bool runProgram) {
             byte[] binary;
             using (PowerPointPresentation source =
                    PowerPointPresentation.Create()) {
@@ -393,11 +397,21 @@ namespace OfficeIMO.Tests {
                 .ForEach(item => item.Remove());
             SlideLayoutPart layoutPart = imported.Slides[0].SlidePart
                 .SlideLayoutPart!;
-            P.NonVisualDrawingProperties properties = useMaster
-                ? layoutPart.SlideMasterPart!.SlideMaster!
-                    .Descendants<P.NonVisualDrawingProperties>().First()
-                : layoutPart.SlideLayout!
-                    .Descendants<P.NonVisualDrawingProperties>().First();
+            DocumentFormat.OpenXml.OpenXmlPartRootElement root;
+            if (targetKind >= 2) {
+                imported.Slides[0].Notes.Text = "Speaker note";
+                NotesSlidePart notesPart = imported.Slides[0].SlidePart
+                    .NotesSlidePart!;
+                root = targetKind == 2
+                    ? notesPart.NotesSlide!
+                    : notesPart.NotesMasterPart!.NotesMaster!;
+            } else {
+                root = targetKind == 0
+                    ? layoutPart.SlideMasterPart!.SlideMaster!
+                    : layoutPart.SlideLayout!;
+            }
+            P.NonVisualDrawingProperties properties = root
+                .Descendants<P.NonVisualDrawingProperties>().First();
             properties.Append(new A.HyperlinkOnClick {
                 Id = "rPreservedActiveContent",
                 Action = runProgram ? "ppaction://program" : null

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.RichText.Readers.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.RichText.Readers.cs
@@ -230,6 +230,36 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void TextPropertyReader_RejectsOversizedTabStopCountBeforeAllocation() {
+            byte[] payload = { 0x01, 0x10 }; // 4,097 entries
+            var record = new LegacyPptRecord(payload, 0, 0, 0,
+                0x0FA6, 0, payload.Length);
+            var cursor = new LegacyPptTextPropertyCursor(record,
+                "oversized tab stops");
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(
+                () => LegacyPptTextPropertyReader.ReadTabStops(cursor));
+
+            Assert.Contains("4096", exception.Message,
+                StringComparison.Ordinal);
+            Assert.Equal(2, cursor.Offset);
+        }
+
+        [Fact]
+        public void TextStyle9Reader_StopsAtConfiguredEntryLimit() {
+            byte[] payload = new byte[24]; // two empty 12-byte StyleTextProp9 entries
+            var record = new LegacyPptRecord(payload, 0, 0, 0,
+                0x0FAC, 0, payload.Length);
+
+            LegacyPptTextBody result = LegacyPptTextStyle9Reader.Apply(
+                LegacyPptTextBody.Plain("A"), record,
+                maximumEntryCount: 1);
+
+            Assert.True(result.HasStyle9Record);
+            Assert.True(result.IsStyle9Truncated);
+        }
+
+        [Fact]
         public void TextMasterStyleReader_DecodesExplicitCenterStyleLevels() {
             byte[] payload;
             using (var stream = new MemoryStream()) {

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Safety.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Safety.cs
@@ -20,6 +20,25 @@ namespace OfficeIMO.Tests {
                 StringComparison.OrdinalIgnoreCase);
         }
 
+        [Theory]
+        [InlineData("masters")]
+        [InlineData("connectors")]
+        [InlineData("comments")]
+        [InlineData("ppt9")]
+        public void ImportOptions_RejectNonPositiveAggregateLimits(
+            string limit) {
+            var options = new LegacyPptImportOptions();
+            switch (limit) {
+                case "masters": options.MaxMasterCount = 0; break;
+                case "connectors": options.MaxConnectorRuleCount = 0; break;
+                case "comments": options.MaxCommentCount = 0; break;
+                case "ppt9": options.MaxTextStyle9EntryCount = 0; break;
+            }
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                options.Validate());
+        }
+
         [Fact]
         public void RecordReader_EnforcesNestingDepthBudget() {
             byte[] atom = CreateRecord(version: 0, payload: Array.Empty<byte>());

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.ShapeWrite.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.ShapeWrite.cs
@@ -4,6 +4,7 @@ using OfficeIMO.PowerPoint;
 using OfficeIMO.PowerPoint.LegacyPpt;
 using OfficeIMO.PowerPoint.LegacyPpt.Internal;
 using OfficeIMO.PowerPoint.LegacyPpt.Model;
+using OfficeIMO.PowerPoint.LegacyPpt.Write;
 using Xunit;
 using A = DocumentFormat.OpenXml.Drawing;
 using P = DocumentFormat.OpenXml.Presentation;
@@ -320,6 +321,35 @@ namespace OfficeIMO.Tests {
             Assert.Empty(projected.ValidateDocument());
             Assert.Equal(bytes,
                 projected.ToBytes(PowerPointFileFormat.Ppt));
+        }
+
+        [Fact]
+        public void NativeWriter_RejectsGroupNestingBeyondSafetyLimit() {
+            using PowerPointPresentation source = PowerPointPresentation
+                .Create();
+            PowerPointSlide slide = source.AddSlide(
+                P.SlideLayoutValues.Blank);
+            PowerPointGroupShape group = slide.GroupShapes(new PowerPointShape[] {
+                slide.AddRectangle(100000, 100000, 500000, 500000),
+                slide.AddRectangle(700000, 100000, 500000, 500000)
+            }, "Group 0");
+            for (int depth = 1;
+                 depth <= LegacyPptWriter.MaximumGroupNestingDepth;
+                 depth++) {
+                group = slide.GroupShapes(new PowerPointShape[] {
+                    group,
+                    slide.AddRectangle(100000, 700000 + depth * 10000L,
+                        200000, 200000)
+                }, $"Group {depth}");
+            }
+
+            LegacyPptWritePreflightReport preflight = source
+                .AnalyzeLegacyPptWrite();
+
+            Assert.False(preflight.CanWrite);
+            Assert.Contains(preflight.Findings, finding =>
+                finding.Description.Contains("64 nested group levels",
+                    StringComparison.Ordinal));
         }
 
         [Fact]

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Sounds.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Sounds.cs
@@ -322,9 +322,13 @@ namespace OfficeIMO.Tests {
                 imported.Slides[0].Shapes[0].Left += 1588;
                 LegacyPptWritePreflightReport preflight = imported
                     .AnalyzeLegacyPptWrite();
-                Assert.True(preflight.CanWrite,
-                    string.Join(Environment.NewLine, preflight.Findings));
-                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt);
+                Assert.Contains(preflight.Findings, finding =>
+                    finding.Code == "PPT-WRITE-PRESERVED-EXTERNAL-LINK");
+                Assert.False(preflight.CanWrite);
+                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    });
             }
 
             LegacyPptPresentation saved = LegacyPptPresentation.Load(savedBytes);
@@ -365,9 +369,13 @@ namespace OfficeIMO.Tests {
 
                 LegacyPptWritePreflightReport preflight = imported
                     .AnalyzeLegacyPptWrite();
-                Assert.True(preflight.CanWrite,
-                    string.Join(Environment.NewLine, preflight.Findings));
-                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt);
+                Assert.Contains(preflight.Findings, finding =>
+                    finding.Code == "PPT-WRITE-PRESERVED-EXTERNAL-LINK");
+                Assert.False(preflight.CanWrite);
+                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    });
             }
 
             LegacyPptPresentation saved = LegacyPptPresentation.Load(savedBytes);
@@ -407,9 +415,13 @@ namespace OfficeIMO.Tests {
 
                 LegacyPptWritePreflightReport preflight = imported
                     .AnalyzeLegacyPptWrite();
-                Assert.True(preflight.CanWrite,
-                    string.Join(Environment.NewLine, preflight.Findings));
-                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt);
+                Assert.Contains(preflight.Findings, finding =>
+                    finding.Code == "PPT-WRITE-PRESERVED-EXTERNAL-LINK");
+                Assert.False(preflight.CanWrite);
+                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    });
             }
 
             LegacyPptPresentation saved = LegacyPptPresentation.Load(savedBytes);

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Sounds.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Sounds.cs
@@ -225,6 +225,41 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void SoundCatalog_ReusesExistingSoundAtAggregateLimit() {
+            byte[] wave = CreateWavePayload();
+            var importedSound = new LegacyPptSound(7,
+                "OfficeIMO Chime", ".wav", builtInId: null, wave);
+            var catalog = new LegacyPptWriter.LegacyPptWriterSoundCatalog(
+                new[] { importedSound }, soundIdSeed: 7);
+            typeof(LegacyPptWriter.LegacyPptWriterSoundCatalog)
+                .GetField("_totalSoundBytes",
+                    System.Reflection.BindingFlags.Instance
+                    | System.Reflection.BindingFlags.NonPublic)!
+                .SetValue(catalog, LegacyPptWriter.MaximumTotalSoundBytes);
+            using PowerPointPresentation source =
+                PowerPointPresentation.Create();
+            PowerPointSlide slide = source.AddSlide(
+                P.SlideLayoutValues.Blank);
+            MediaDataPart media = source.OpenXmlDocument.CreateMediaDataPart(
+                "audio/wav", ".wav");
+            using (var input = new MemoryStream(wave, writable: false)) {
+                media.FeedData(input);
+            }
+            AudioReferenceRelationship relationship = slide.SlidePart
+                .AddAudioReferenceRelationship(media);
+            var soundElement = new P.Sound {
+                Embed = relationship.Id,
+                Name = "OfficeIMO Chime"
+            };
+
+            Assert.True(catalog.TryGetOrAdd(slide.SlidePart, soundElement,
+                out LegacyPptWriter.LegacyPptWriterSound? sound,
+                out string? reason), reason);
+            Assert.Same(importedSound.DataBytes, sound!.DataBytes);
+            Assert.Equal(7U, sound.Id);
+        }
+
+        [Fact]
         public void NativeWriter_RejectsInconsistentAlternateContentTransitionSounds() {
             using PowerPointPresentation source =
                 PowerPointPresentation.Create();

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.TablesWrite.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.TablesWrite.cs
@@ -187,6 +187,13 @@ namespace OfficeIMO.Tests {
             Assert.False(rendered);
             Assert.Contains("safe limit", reason,
                 StringComparison.OrdinalIgnoreCase);
+
+            PowerPointSlideVisualSnapshot snapshot = PowerPointSlideImageRenderer
+                .CreateSnapshot(table.OwnerSlide!,
+                    new PowerPointImageExportOptions());
+            Assert.Contains(snapshot.Diagnostics, diagnostic =>
+                diagnostic.Message.Contains("safe limit",
+                    StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.TablesWrite.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.TablesWrite.cs
@@ -175,5 +175,18 @@ namespace OfficeIMO.Tests {
                 .GetFirstChild<A.SolidFill>());
             Assert.Empty(projected.ValidateDocument());
         }
+
+        [Fact]
+        public void StaticTableRasterizationRejectsExcessiveRowCountBeforeMatrices() {
+            using PowerPointPresentation source = PowerPointPresentation.Create();
+            PowerPointTable table = source.AddSlide().AddTable(4097, 1);
+
+            bool rendered = PowerPointSlideImageRenderer.TryCreateTableDrawing(
+                table, out _, out string? reason);
+
+            Assert.False(rendered);
+            Assert.Contains("safe limit", reason,
+                StringComparison.OrdinalIgnoreCase);
+        }
     }
 }

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Vba.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Vba.cs
@@ -332,9 +332,13 @@ namespace OfficeIMO.Tests {
                 title.Left += 15875L;
                 LegacyPptWritePreflightReport preflight = imported
                     .AnalyzeLegacyPptWrite();
-                Assert.True(preflight.CanWrite,
-                    string.Join(Environment.NewLine, preflight.Findings));
-                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt);
+                Assert.Contains(preflight.Findings, finding =>
+                    finding.Code == "PPT-WRITE-PRESERVED-VBA");
+                Assert.False(preflight.CanWrite);
+                savedBytes = imported.ToBytes(PowerPointFileFormat.Ppt,
+                    new PowerPointSaveOptions {
+                        LossPolicy = PowerPointConversionLossPolicy.Allow
+                    });
             }
 
             LegacyPptPresentation saved = LegacyPptPresentation.Load(savedBytes);

--- a/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.Tables.cs
+++ b/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.Tables.cs
@@ -20,11 +20,7 @@ namespace OfficeIMO.PowerPoint {
                 reason = "The table has no positive renderable bounds.";
                 return false;
             }
-            long cellCount = checked((long)table.Rows * table.Columns);
-            if (table.Rows > MaximumTableRasterRows
-                || table.Columns > MaximumTableRasterColumns
-                || cellCount > MaximumTableRasterCells) {
-                reason = $"The table rasterization request ({table.Rows} rows, {table.Columns} columns, {cellCount} cells) exceeds the safe limit of {MaximumTableRasterRows} rows, {MaximumTableRasterColumns} columns, or {MaximumTableRasterCells} cells.";
+            if (!TryValidateTableRasterLimits(table, out reason)) {
                 return false;
             }
             try {
@@ -57,6 +53,11 @@ namespace OfficeIMO.PowerPoint {
         }
 
         private static void AddTable(OfficeDrawing drawing, PowerPointTable table, List<OfficeImageExportDiagnostic> diagnostics, PowerPointShapeBoundsMapping mapping, A.ColorScheme? colorScheme) {
+            if (!TryValidateTableRasterLimits(table, out string? limitReason)) {
+                AddUnsupportedShapeDiagnostic(diagnostics, table,
+                    limitReason!);
+                return;
+            }
             if (!TryGetBounds(table, drawing, diagnostics, mapping, out double left, out double top, out double width, out double height)) {
                 return;
             }
@@ -98,6 +99,19 @@ namespace OfficeIMO.PowerPoint {
                     AddTableCellText(drawing, table, cell, cellLeft, cellTop, cellWidth, cellHeight, left, top, width, height, diagnostics, mapping, colorScheme);
                 }
             }
+        }
+
+        private static bool TryValidateTableRasterLimits(
+            PowerPointTable table, out string? reason) {
+            long cellCount = checked((long)table.Rows * table.Columns);
+            if (table.Rows > MaximumTableRasterRows
+                || table.Columns > MaximumTableRasterColumns
+                || cellCount > MaximumTableRasterCells) {
+                reason = $"The table rasterization request ({table.Rows} rows, {table.Columns} columns, {cellCount} cells) exceeds the safe limit of {MaximumTableRasterRows} rows, {MaximumTableRasterColumns} columns, or {MaximumTableRasterCells} cells.";
+                return false;
+            }
+            reason = null;
+            return true;
         }
 
         private static void MarkCoveredTableCells(bool[,] coveredCells, int row, int column, int rowSpan, int columnSpan) {

--- a/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.Tables.cs
+++ b/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.Tables.cs
@@ -6,6 +6,10 @@ using A = DocumentFormat.OpenXml.Drawing;
 
 namespace OfficeIMO.PowerPoint {
     internal static partial class PowerPointSlideImageRenderer {
+        private const int MaximumTableRasterRows = 4096;
+        private const int MaximumTableRasterColumns = 4096;
+        private const long MaximumTableRasterCells = 100_000L;
+
         internal static bool TryCreateTableDrawing(PowerPointTable table,
             out OfficeDrawing drawing, out string? reason) {
             if (table == null) throw new ArgumentNullException(nameof(table));
@@ -14,6 +18,13 @@ namespace OfficeIMO.PowerPoint {
                     out double width, out double height)
                 || width <= 0D || height <= 0D) {
                 reason = "The table has no positive renderable bounds.";
+                return false;
+            }
+            long cellCount = checked((long)table.Rows * table.Columns);
+            if (table.Rows > MaximumTableRasterRows
+                || table.Columns > MaximumTableRasterColumns
+                || cellCount > MaximumTableRasterCells) {
+                reason = $"The table rasterization request ({table.Rows} rows, {table.Columns} columns, {cellCount} cells) exceeds the safe limit of {MaximumTableRasterRows} rows, {MaximumTableRasterColumns} columns, or {MaximumTableRasterCells} cells.";
                 return false;
             }
             try {

--- a/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptBackgroundProjectionFingerprint.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptBackgroundProjectionFingerprint.cs
@@ -1,5 +1,4 @@
 using System.Security.Cryptography;
-using System.Text;
 using DocumentFormat.OpenXml.Packaging;
 using A = DocumentFormat.OpenXml.Drawing;
 using P = DocumentFormat.OpenXml.Presentation;
@@ -15,35 +14,40 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
             if (ownerPart == null) throw new ArgumentNullException(
                 nameof(ownerPart));
             if (background == null) return string.Empty;
-            var fingerprint = new StringBuilder(background.OuterXml);
+            using IncrementalHash fingerprint = LegacyPptProjectionDigest
+                .CreateBuilder();
+            LegacyPptProjectionDigest.Append(fingerprint,
+                background.OuterXml);
             foreach (A.Blip blip in background.Descendants<A.Blip>()) {
                 string? relationshipId = blip.Embed?.Value;
-                fingerprint.Append("\nimage:").Append(relationshipId);
+                LegacyPptProjectionDigest.Append(fingerprint,
+                    "image:" + relationshipId);
                 if (string.IsNullOrWhiteSpace(relationshipId)) continue;
                 try {
                     if (ownerPart.GetPartById(relationshipId!)
                             is not ImagePart imagePart) {
-                        fingerprint.Append("|not-image");
+                        LegacyPptProjectionDigest.Append(fingerprint,
+                            "not-image");
                         continue;
                     }
-                    fingerprint.Append('|').Append(imagePart.ContentType)
-                        .Append('|');
+                    LegacyPptProjectionDigest.Append(fingerprint,
+                        imagePart.ContentType);
                     using Stream stream = imagePart.GetStream(FileMode.Open,
                         FileAccess.Read);
                     using SHA256 sha256 = SHA256.Create();
-                    fingerprint.Append(Convert.ToBase64String(
-                        sha256.ComputeHash(stream)));
+                    LegacyPptProjectionDigest.Append(fingerprint,
+                        Convert.ToBase64String(sha256.ComputeHash(stream)));
                 } catch (Exception exception) when (exception
                     is ArgumentOutOfRangeException
                     or InvalidDataException
                     or IOException
                     or NotSupportedException
                     or UnauthorizedAccessException) {
-                    fingerprint.Append("|unreadable:")
-                        .Append(exception.GetType().Name);
+                    LegacyPptProjectionDigest.Append(fingerprint,
+                        "unreadable:" + exception.GetType().Name);
                 }
             }
-            return fingerprint.ToString();
+            return LegacyPptProjectionDigest.Finish(fingerprint);
         }
     }
 }

--- a/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptMasterProjection.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptMasterProjection.cs
@@ -161,13 +161,14 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
                 ?? string.Empty;
             string colorMap = masterPart.SlideLayout?.ColorMapOverride?.OuterXml
                 ?? string.Empty;
-            return theme + "\n" + colorMap;
+            return LegacyPptProjectionDigest.Create(theme, colorMap);
         }
 
         private static string CreateThemeFingerprint(ThemePart? themePart,
             OpenXmlElement? colorMap) {
             string theme = themePart?.Theme?.OuterXml ?? string.Empty;
-            return theme + "\n" + (colorMap?.OuterXml ?? string.Empty);
+            return LegacyPptProjectionDigest.Create(theme,
+                colorMap?.OuterXml);
         }
 
         internal static IReadOnlyList<string> CreateClassicColorFingerprints(

--- a/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptNotesProjection.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptNotesProjection.cs
@@ -79,7 +79,7 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
                 ?? string.Empty;
             string colorMap = part.NotesSlide?.ColorMapOverride?.OuterXml
                 ?? string.Empty;
-            return theme + "\n" + colorMap;
+            return LegacyPptProjectionDigest.Create(theme, colorMap);
         }
 
         internal static IReadOnlyList<string>

--- a/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptProjectionDigest.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptProjectionDigest.cs
@@ -1,0 +1,37 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
+    /// <summary>
+    /// Produces compact, length-delimited SHA-256 guards for projected XML and
+    /// related payload descriptors without retaining their full concatenation.
+    /// </summary>
+    internal static class LegacyPptProjectionDigest {
+        internal static IncrementalHash CreateBuilder() =>
+            IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+
+        internal static void Append(IncrementalHash hash, string? value) {
+            if (hash == null) throw new ArgumentNullException(nameof(hash));
+            byte[] bytes = Encoding.UTF8.GetBytes(value ?? string.Empty);
+            var length = new byte[4];
+            uint count = checked((uint)bytes.Length);
+            length[0] = unchecked((byte)count);
+            length[1] = unchecked((byte)(count >> 8));
+            length[2] = unchecked((byte)(count >> 16));
+            length[3] = unchecked((byte)(count >> 24));
+            hash.AppendData(length);
+            hash.AppendData(bytes);
+        }
+
+        internal static string Finish(IncrementalHash hash) {
+            if (hash == null) throw new ArgumentNullException(nameof(hash));
+            return Convert.ToBase64String(hash.GetHashAndReset());
+        }
+
+        internal static string Create(params string?[] values) {
+            using IncrementalHash hash = CreateBuilder();
+            foreach (string? value in values) Append(hash, value);
+            return Finish(hash);
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptProjectionMap.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptProjectionMap.cs
@@ -213,6 +213,10 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
             }
 
             var slides = new List<LegacyPptSlideProjection>(legacy.Slides.Count);
+            var inheritedBackgrounds = new Dictionary<string, string>(
+                StringComparer.Ordinal);
+            var inheritedThemes = new Dictionary<string, string>(
+                StringComparer.Ordinal);
             var projectableSoundIds = new HashSet<uint>(legacy.Sounds.Where(sound =>
                 sound.HasData && sound.ContentType != null).Select(sound => sound.Id));
             for (int slideIndex = 0; slideIndex < legacy.Slides.Count; slideIndex++) {
@@ -232,6 +236,8 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
                 AddShapeProjectionTree(shapes, sourceShapes,
                     projectedShapes, projectableSoundIds,
                     $"slide {slideIndex + 1}", projectedSlide.SlidePart);
+                bool hasExplicitBackground = projectedSlide.SlidePart.Slide?
+                    .CommonSlideData?.Background != null;
                 slides.Add(new LegacyPptSlideProjection(projectedSlide.SlidePart.Uri.ToString(),
                     projectedSlide.SlidePart.SlideLayoutPart?.Uri.ToString(),
                     sourceSlide.PersistId, sourceSlide.SlideId, sourceSlide.MasterId,
@@ -240,13 +246,12 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
                         unchecked((byte)value)).ToArray(),
                     sourceSlide.Hidden, sourceSlide.FollowsMasterObjects,
                     sourceSlide.HeaderFooter,
-                    projectedSlide.SlidePart.Slide?.CommonSlideData?
-                        .Background != null,
-                    LegacyPptSlideProjection.CreateBackgroundFingerprint(
-                        projectedSlide),
+                    hasExplicitBackground,
+                    CreateSlideBackgroundFingerprint(projectedSlide,
+                        hasExplicitBackground, inheritedBackgrounds),
                     projectedSlide.SlidePart.ThemeOverridePart?.Uri.ToString(),
-                    LegacyPptSlideProjection.CreateThemeFingerprint(
-                        projectedSlide),
+                    CreateSlideThemeFingerprint(projectedSlide,
+                        inheritedThemes),
                     LegacyPptSlideProjection.CreateClassicColorFingerprints(
                         projectedSlide),
                     sourceSlide.Transition, sourceSlide.Comments, shapes,
@@ -270,6 +275,42 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
                 LegacyPptPropertySetCodec.CreateProjection(presentation,
                     legacy.Package),
                 LegacyPptVbaProjectProjection.Create(legacy.VbaProject));
+        }
+
+        private static string CreateSlideBackgroundFingerprint(
+            PowerPointSlide slide, bool hasExplicitBackground,
+            IDictionary<string, string> inheritedFingerprints) {
+            SlideLayoutPart? layoutPart = slide.SlidePart.SlideLayoutPart;
+            if (hasExplicitBackground || layoutPart == null) {
+                return LegacyPptSlideProjection.CreateBackgroundFingerprint(
+                    slide);
+            }
+            string key = layoutPart.Uri.ToString();
+            if (!inheritedFingerprints.TryGetValue(key,
+                    out string? fingerprint)) {
+                fingerprint = LegacyPptSlideProjection
+                    .CreateBackgroundFingerprint(slide);
+                inheritedFingerprints.Add(key, fingerprint);
+            }
+            return fingerprint;
+        }
+
+        private static string CreateSlideThemeFingerprint(
+            PowerPointSlide slide,
+            IDictionary<string, string> inheritedFingerprints) {
+            SlideLayoutPart? layoutPart = slide.SlidePart.SlideLayoutPart;
+            if (slide.SlidePart.ThemeOverridePart != null
+                || layoutPart == null) {
+                return LegacyPptSlideProjection.CreateThemeFingerprint(slide);
+            }
+            string key = layoutPart.Uri.ToString();
+            if (!inheritedFingerprints.TryGetValue(key,
+                    out string? fingerprint)) {
+                fingerprint = LegacyPptSlideProjection
+                    .CreateThemeFingerprint(slide);
+                inheritedFingerprints.Add(key, fingerprint);
+            }
+            return fingerprint;
         }
 
         private static void AddShapeProjectionTree(

--- a/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptRc4CryptoApi.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptRc4CryptoApi.cs
@@ -129,11 +129,14 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
 
         internal static byte[] EncryptPackage(byte[] plainBytes,
             string password, int keySizeBits = DefaultKeySizeBits,
-            bool encryptDocumentProperties = true) {
+            bool encryptDocumentProperties = true,
+            bool allowUnencryptedCompoundStreams = false) {
             if (plainBytes == null) throw new ArgumentNullException(nameof(plainBytes));
             if (password == null) throw new ArgumentNullException(nameof(password));
             LegacyPptPackage package = LegacyPptPackage.Read(plainBytes,
                 new LegacyPptImportOptions());
+            EnsureNoUnexpectedClearTextStreams(package.CompoundFile,
+                allowUnencryptedCompoundStreams);
             uint encryptionPersistId = package.PersistObjectOffsets.Count == 0
                 ? 1U
                 : checked(package.PersistObjectOffsets.Keys.Max() + 1U);
@@ -185,6 +188,34 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
             }
             return package.RewriteCompoundStreams(replacements,
                 new[] { "EncryptedSummary" });
+        }
+
+        private static void EnsureNoUnexpectedClearTextStreams(
+            OfficeCompoundFile compound,
+            bool allowUnencryptedCompoundStreams) {
+            if (allowUnencryptedCompoundStreams) return;
+            string[] clearTextStreams = compound.Streams.Keys.Where(path =>
+                    !string.Equals(path, "PowerPoint Document",
+                        StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(path, "Current User",
+                        StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(path, "Pictures",
+                        StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(path, "EncryptedSummary",
+                        StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(path,
+                        "\u0005SummaryInformation",
+                        StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(path,
+                        "\u0005DocumentSummaryInformation",
+                        StringComparison.OrdinalIgnoreCase))
+                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (clearTextStreams.Length == 0) return;
+            throw new NotSupportedException(
+                "Legacy RC4 CryptoAPI cannot encrypt these compound streams: "
+                + string.Join(", ", clearTextStreams)
+                + ". Remove them or explicitly set PowerPointSaveOptions.LegacyPptAllowUnencryptedCompoundStreams when clear-text retention is intentional.");
         }
 
         private static EncryptedPersistObject InspectEncryptedPersistObject(

--- a/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptSlideProjection.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptSlideProjection.cs
@@ -148,7 +148,7 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
                     ?? slide.SlidePart.SlideLayoutPart?.SlideLayout?
                         .ColorMapOverride)?.OuterXml
                 ?? string.Empty;
-            return theme + "\n" + colorMap;
+            return LegacyPptProjectionDigest.Create(theme, colorMap);
         }
 
         internal static IReadOnlyList<string>

--- a/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptTextProjection.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptTextProjection.cs
@@ -48,20 +48,22 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
             if (source == null) throw new ArgumentNullException(nameof(source));
             var textBody = new P.TextBody(new A.BodyProperties(), new A.ListStyle());
             ApplyTextFrame(textBody.BodyProperties, frame);
+            var projectionPlan = new LegacyPptTextProjectionPlan(source);
             string[] paragraphs = source.Text.Split(new[] { '\n' }, StringSplitOptions.None);
             int paragraphStart = 0;
             foreach (string paragraphText in paragraphs) {
                 int paragraphEnd = checked(paragraphStart + paragraphText.Length);
                 var paragraph = new A.Paragraph();
-                ApplyParagraphProperties(paragraph, source, paragraphStart,
-                    projectPictureBullet);
-                AppendParagraphRuns(paragraph, source, paragraphStart, paragraphEnd,
-                    projectInteraction);
+                ApplyParagraphProperties(paragraph, source, projectionPlan,
+                    paragraphStart, projectPictureBullet);
+                AppendParagraphRuns(paragraph, source, projectionPlan,
+                    paragraphStart, paragraphEnd, projectInteraction);
                 if (!paragraph.ChildElements.Any(child => child is A.Run
                         or A.Field or A.Break)) {
                     paragraph.Append(new A.Run(new A.Text(string.Empty)));
                 }
-                ApplyParagraphEndLanguage(paragraph, source, paragraphEnd);
+                ApplyParagraphEndLanguage(paragraph, projectionPlan,
+                    paragraphEnd);
                 textBody.Append(paragraph);
                 paragraphStart = checked(paragraphEnd + 1);
             }
@@ -116,11 +118,12 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
             }
         }
 
-        private static void ApplyParagraphProperties(A.Paragraph paragraph, LegacyPptTextBody source,
-            int paragraphStart,
+        private static void ApplyParagraphProperties(A.Paragraph paragraph,
+            LegacyPptTextBody source,
+            LegacyPptTextProjectionPlan projectionPlan, int paragraphStart,
             Func<LegacyPptPictureBullet, string?>? projectPictureBullet) {
-            LegacyPptParagraphRun? run = source.ParagraphRuns.FirstOrDefault(item =>
-                paragraphStart >= item.Start && paragraphStart < item.Start + item.Length);
+            LegacyPptParagraphRun? run = projectionPlan.FindParagraphRun(
+                paragraphStart);
             if ((run == null || !run.HasExplicitFormatting)
                 && source.Ruler?.HasFormatting != true) return;
             ushort level = run?.IndentLevel ?? 0;
@@ -388,60 +391,30 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
             P.TextBody? textBody) => textBody?.BodyProperties?.OuterXml
                 ?? string.Empty;
 
-        private static void AppendParagraphRuns(A.Paragraph paragraph, LegacyPptTextBody source,
+        private static void AppendParagraphRuns(A.Paragraph paragraph,
+            LegacyPptTextBody source,
+            LegacyPptTextProjectionPlan projectionPlan,
             int paragraphStart, int paragraphEnd,
             Func<LegacyPptInteraction, IReadOnlyList<OpenXmlElement>>? projectInteraction) {
-            var boundaries = new SortedSet<int> { paragraphStart, paragraphEnd };
-            foreach (LegacyPptCharacterRun run in source.CharacterRuns) {
-                AddClippedBoundaries(boundaries, run.Start,
-                    checked(run.Start + run.Length), paragraphStart, paragraphEnd);
-            }
-            foreach (LegacyPptTextLanguageRun run in source.LanguageRuns) {
-                AddClippedBoundaries(boundaries, run.Start,
-                    checked(run.Start + run.Length), paragraphStart,
-                    paragraphEnd);
-            }
-            foreach (LegacyPptTextInteraction interaction in source.Interactions) {
-                AddClippedBoundaries(boundaries, interaction.Start,
-                    checked(interaction.Start + interaction.Length), paragraphStart, paragraphEnd);
-            }
-            foreach (LegacyPptTextField field in source.Fields) {
-                AddClippedBoundaries(boundaries, field.Position,
-                    checked(field.Position + 1), paragraphStart,
-                    paragraphEnd);
-            }
-            int[] values = boundaries.ToArray();
-            for (int index = 0; index < values.Length - 1; index++) {
-                int start = values[index];
-                int end = values[index + 1];
+            IReadOnlyList<int> boundaries = projectionPlan
+                .GetParagraphBoundaries(paragraphStart, paragraphEnd);
+            for (int index = 0; index < boundaries.Count - 1; index++) {
+                int start = boundaries[index];
+                int end = boundaries[index + 1];
                 if (end <= start) continue;
-                LegacyPptCharacterRun? formatting = source.CharacterRuns.FirstOrDefault(run =>
-                    start >= run.Start && start < run.Start + run.Length);
-                LegacyPptTextLanguageRun? language = source.LanguageRuns
-                    .FirstOrDefault(run => start >= run.Start
-                        && start < run.Start + run.Length);
-                LegacyPptInteraction[] interactions = source.Interactions.Where(item =>
-                        start >= item.Start && end <= item.Start + item.Length)
-                    .Select(item => item.Interaction)
-                    .ToArray();
-                LegacyPptTextField? field = end == start + 1
-                    ? source.Fields.FirstOrDefault(item =>
-                        item.Position == start)
-                    : null;
+                LegacyPptCharacterRun? formatting = projectionPlan
+                    .FindCharacterRun(start);
+                LegacyPptTextLanguageRun? language = projectionPlan
+                    .FindLanguageRun(start);
+                IReadOnlyList<LegacyPptInteraction> interactions =
+                    projectionPlan.GetInteractions(start);
+                LegacyPptTextField? field = projectionPlan.FindField(start,
+                    end);
                 AppendRun(paragraph,
                     source.Text.Substring(start, end - start), formatting,
                     language,
                     field, interactions, projectInteraction);
             }
-        }
-
-        private static void AddClippedBoundaries(ISet<int> boundaries, int start, int end,
-            int paragraphStart, int paragraphEnd) {
-            int clippedStart = Math.Max(paragraphStart, start);
-            int clippedEnd = Math.Min(paragraphEnd, end);
-            if (clippedEnd <= clippedStart) return;
-            boundaries.Add(clippedStart);
-            boundaries.Add(clippedEnd);
         }
 
         private static void AppendRun(A.Paragraph paragraph, string text,
@@ -579,10 +552,10 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
         }
 
         private static void ApplyParagraphEndLanguage(A.Paragraph paragraph,
-            LegacyPptTextBody source, int paragraphEnd) {
-            LegacyPptTextLanguageRun? language = source.LanguageRuns
-                .FirstOrDefault(run => paragraphEnd >= run.Start
-                    && paragraphEnd < run.Start + run.Length);
+            LegacyPptTextProjectionPlan projectionPlan,
+            int paragraphEnd) {
+            LegacyPptTextLanguageRun? language = projectionPlan
+                .FindLanguageRun(paragraphEnd);
             if (!HasNativeLanguageInformation(language)) return;
             var properties = new A.EndParagraphRunProperties();
             ApplyLanguageInformation(properties, language);

--- a/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptTextProjectionPlan.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptTextProjectionPlan.cs
@@ -1,0 +1,201 @@
+using OfficeIMO.PowerPoint.LegacyPpt.Model;
+
+namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
+    /// <summary>
+    /// Indexes decoded text intervals once and advances interaction state in
+    /// document order, avoiding repeated full-list scans per paragraph and run.
+    /// </summary>
+    internal sealed class LegacyPptTextProjectionPlan {
+        private readonly LegacyPptParagraphRun[] _paragraphRuns;
+        private readonly LegacyPptCharacterRun[] _characterRuns;
+        private readonly LegacyPptTextLanguageRun[] _languageRuns;
+        private readonly IReadOnlyDictionary<int, LegacyPptTextField>
+            _fieldsByPosition;
+        private readonly IndexedInteraction[] _interactionsByStart;
+        private readonly IndexedInteraction[] _interactionsByEnd;
+        private readonly LegacyPptTextInteraction[] _interactionsByOriginalIndex;
+        private readonly SortedSet<int> _activeClickInteractions = new();
+        private readonly SortedSet<int> _activeHoverInteractions = new();
+        private readonly int[] _boundaries;
+        private int _interactionStartIndex;
+        private int _interactionEndIndex;
+        private int _lastInteractionPosition = -1;
+
+        internal LegacyPptTextProjectionPlan(LegacyPptTextBody source) {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            _paragraphRuns = source.ParagraphRuns.OrderBy(run => run.Start)
+                .ToArray();
+            _characterRuns = source.CharacterRuns.OrderBy(run => run.Start)
+                .ToArray();
+            _languageRuns = source.LanguageRuns.OrderBy(run => run.Start)
+                .ToArray();
+            _fieldsByPosition = source.Fields.GroupBy(field => field.Position)
+                .ToDictionary(group => group.Key, group => group.First());
+            _interactionsByOriginalIndex = source.Interactions.ToArray();
+            IndexedInteraction[] indexed = source.Interactions.Select(
+                    (interaction, index) => new IndexedInteraction(
+                        interaction, index))
+                .ToArray();
+            _interactionsByStart = indexed.OrderBy(item => item.Start)
+                .ThenBy(item => item.OriginalIndex).ToArray();
+            _interactionsByEnd = indexed.OrderBy(item => item.End)
+                .ThenBy(item => item.OriginalIndex).ToArray();
+
+            var boundaries = new SortedSet<int>();
+            foreach (LegacyPptCharacterRun run in _characterRuns) {
+                AddBoundaries(boundaries, run.Start, run.Length,
+                    source.Text.Length);
+            }
+            foreach (LegacyPptTextLanguageRun run in _languageRuns) {
+                AddBoundaries(boundaries, run.Start, run.Length,
+                    source.Text.Length);
+            }
+            foreach (LegacyPptTextInteraction interaction in
+                     source.Interactions) {
+                AddBoundaries(boundaries, interaction.Start,
+                    interaction.Length, source.Text.Length);
+            }
+            foreach (LegacyPptTextField field in source.Fields) {
+                AddBoundaries(boundaries, field.Position, length: 1,
+                    source.Text.Length);
+            }
+            _boundaries = boundaries.ToArray();
+        }
+
+        internal LegacyPptParagraphRun? FindParagraphRun(int position) =>
+            FindContaining(_paragraphRuns, position,
+                run => run.Start, run => run.Length);
+
+        internal LegacyPptCharacterRun? FindCharacterRun(int position) =>
+            FindContaining(_characterRuns, position,
+                run => run.Start, run => run.Length);
+
+        internal LegacyPptTextLanguageRun? FindLanguageRun(int position) =>
+            FindContaining(_languageRuns, position,
+                run => run.Start, run => run.Length);
+
+        internal LegacyPptTextField? FindField(int start, int end) =>
+            end == start + 1
+            && _fieldsByPosition.TryGetValue(start,
+                out LegacyPptTextField? field)
+                ? field
+                : null;
+
+        internal IReadOnlyList<int> GetParagraphBoundaries(int start,
+            int end) {
+            var result = new List<int> { start };
+            int index = LowerBound(_boundaries, start + 1);
+            while (index < _boundaries.Length
+                   && _boundaries[index] < end) {
+                result.Add(_boundaries[index++]);
+            }
+            if (end != start) result.Add(end);
+            return result;
+        }
+
+        internal IReadOnlyList<LegacyPptInteraction> GetInteractions(
+            int position) {
+            if (position < _lastInteractionPosition) {
+                throw new InvalidOperationException(
+                    "Text projection positions must advance monotonically.");
+            }
+            _lastInteractionPosition = position;
+            while (_interactionStartIndex < _interactionsByStart.Length
+                   && _interactionsByStart[_interactionStartIndex].Start
+                   <= position) {
+                IndexedInteraction item =
+                    _interactionsByStart[_interactionStartIndex++];
+                GetActiveSet(item.Interaction.Interaction.Trigger)
+                    .Add(item.OriginalIndex);
+            }
+            while (_interactionEndIndex < _interactionsByEnd.Length
+                   && _interactionsByEnd[_interactionEndIndex].End
+                   <= position) {
+                IndexedInteraction item =
+                    _interactionsByEnd[_interactionEndIndex++];
+                GetActiveSet(item.Interaction.Interaction.Trigger)
+                    .Remove(item.OriginalIndex);
+            }
+
+            var active = new List<(int Index,
+                LegacyPptInteraction Interaction)>(2);
+            AddFirstActive(_activeClickInteractions, active);
+            AddFirstActive(_activeHoverInteractions, active);
+            return active.OrderBy(item => item.Index)
+                .Select(item => item.Interaction).ToArray();
+        }
+
+        private void AddFirstActive(ISet<int> active,
+            ICollection<(int Index, LegacyPptInteraction Interaction)>
+                result) {
+            if (active.Count == 0) return;
+            int index = active.Min();
+            result.Add((index,
+                _interactionsByOriginalIndex[index].Interaction));
+        }
+
+        private ISet<int> GetActiveSet(
+            LegacyPptInteractionTrigger trigger) =>
+            trigger == LegacyPptInteractionTrigger.MouseOver
+                ? _activeHoverInteractions
+                : _activeClickInteractions;
+
+        private static T? FindContaining<T>(T[] runs, int position,
+            Func<T, int> getStart, Func<T, int> getLength)
+            where T : class {
+            int low = 0;
+            int high = runs.Length - 1;
+            int candidate = -1;
+            while (low <= high) {
+                int middle = low + ((high - low) / 2);
+                if (getStart(runs[middle]) <= position) {
+                    candidate = middle;
+                    low = middle + 1;
+                } else {
+                    high = middle - 1;
+                }
+            }
+            if (candidate < 0) return null;
+            T run = runs[candidate];
+            long end = (long)getStart(run) + getLength(run);
+            return position < end ? run : null;
+        }
+
+        private static int LowerBound(int[] values, int target) {
+            int low = 0;
+            int high = values.Length;
+            while (low < high) {
+                int middle = low + ((high - low) / 2);
+                if (values[middle] < target) low = middle + 1;
+                else high = middle;
+            }
+            return low;
+        }
+
+        private static void AddBoundaries(ISet<int> boundaries, int start,
+            int length, int textLength) {
+            long rawEnd = (long)start + length;
+            int clippedStart = Math.Max(0, Math.Min(textLength, start));
+            int clippedEnd = Math.Max(0, Math.Min(textLength,
+                rawEnd > int.MaxValue ? int.MaxValue : (int)rawEnd));
+            if (clippedEnd <= clippedStart) return;
+            boundaries.Add(clippedStart);
+            boundaries.Add(clippedEnd);
+        }
+
+        private readonly struct IndexedInteraction {
+            internal IndexedInteraction(LegacyPptTextInteraction interaction,
+                int originalIndex) {
+                Interaction = interaction;
+                OriginalIndex = originalIndex;
+                Start = interaction.Start;
+                End = checked(interaction.Start + interaction.Length);
+            }
+
+            internal LegacyPptTextInteraction Interaction { get; }
+            internal int OriginalIndex { get; }
+            internal int Start { get; }
+            internal int End { get; }
+        }
+    }
+}

--- a/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptTextPropertyReader.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptTextPropertyReader.cs
@@ -3,6 +3,7 @@ using OfficeIMO.PowerPoint.LegacyPpt.Model;
 namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
     /// <summary>Decodes reusable binary PowerPoint paragraph and character exceptions.</summary>
     internal static class LegacyPptTextPropertyReader {
+        private const int MaximumTabStopCount = 4096;
         private const uint CharacterStyleMask = 0x00003EB7U;
         private const uint CharacterTypefaceMask = 1U << 16;
         private const uint CharacterSizeMask = 1U << 17;
@@ -172,6 +173,10 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
         internal static IReadOnlyList<LegacyPptTabStop> ReadTabStops(
             LegacyPptTextPropertyCursor cursor) {
             ushort count = cursor.ReadUInt16();
+            if (count > MaximumTabStopCount) {
+                throw new InvalidDataException(
+                    $"A binary PowerPoint tab-stop list cannot contain more than {MaximumTabStopCount} entries.");
+            }
             var tabStops = new List<LegacyPptTabStop>(count);
             for (int index = 0; index < count; index++) {
                 short position = cursor.ReadInt16();

--- a/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptTextStyle9Reader.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Internal/LegacyPptTextStyle9Reader.cs
@@ -14,7 +14,8 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
             LegacyPptRecord? styleRecord,
             IReadOnlyDictionary<ushort, LegacyPptPictureBullet>?
                 pictureBullets = null,
-            bool malformedContainer = false) {
+            bool malformedContainer = false,
+            int maximumEntryCount = 100_000) {
             if (textBody == null) throw new ArgumentNullException(
                 nameof(textBody));
             if (styleRecord == null) {
@@ -33,7 +34,13 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Internal {
                 var cursor = new LegacyPptTextPropertyCursor(styleRecord,
                     "StyleTextProp9Atom");
                 var entries = new List<ParagraphProperties9>();
-                while (!cursor.IsAtEnd) entries.Add(ReadEntry(cursor));
+                while (!cursor.IsAtEnd) {
+                    if (entries.Count >= maximumEntryCount) {
+                        throw new InvalidDataException(
+                            $"The PPT9 extended-style entry count exceeds {maximumEntryCount}.");
+                    }
+                    entries.Add(ReadEntry(cursor));
+                }
                 return ApplyEntries(textBody, entries, pictureBullets,
                     malformedContainer);
             } catch (Exception exception) when (exception

--- a/OfficeIMO.PowerPoint/LegacyPpt/LegacyPptImportOptions.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/LegacyPptImportOptions.cs
@@ -16,6 +16,18 @@ namespace OfficeIMO.PowerPoint.LegacyPpt {
         /// <summary>Gets or sets the maximum nested record depth.</summary>
         public int MaxRecordDepth { get; set; } = 64;
 
+        /// <summary>Gets or sets the maximum number of decoded main and title masters.</summary>
+        public int MaxMasterCount { get; set; } = 4096;
+
+        /// <summary>Gets or sets the maximum aggregate number of decoded connector rules.</summary>
+        public int MaxConnectorRuleCount { get; set; } = 100_000;
+
+        /// <summary>Gets or sets the maximum aggregate number of decoded comments.</summary>
+        public int MaxCommentCount { get; set; } = 100_000;
+
+        /// <summary>Gets or sets the maximum number of PPT9 style entries decoded for one text body.</summary>
+        public int MaxTextStyle9EntryCount { get; set; } = 100_000;
+
         /// <summary>
         /// Gets or sets the maximum aggregate bytes retained from decoded pictures,
         /// embedded OLE, linked-object, ActiveX, and VBA storages during one import.
@@ -24,5 +36,16 @@ namespace OfficeIMO.PowerPoint.LegacyPpt {
 
         /// <summary>Gets or sets the password used to open an RC4 CryptoAPI encrypted binary presentation.</summary>
         public string? Password { get; set; }
+
+        internal void Validate() {
+            if (MaxInputBytes < 1) throw new ArgumentOutOfRangeException(nameof(MaxInputBytes));
+            if (MaxRecordCount < 1) throw new ArgumentOutOfRangeException(nameof(MaxRecordCount));
+            if (MaxRecordDepth < 1) throw new ArgumentOutOfRangeException(nameof(MaxRecordDepth));
+            if (MaxMasterCount < 1) throw new ArgumentOutOfRangeException(nameof(MaxMasterCount));
+            if (MaxConnectorRuleCount < 1) throw new ArgumentOutOfRangeException(nameof(MaxConnectorRuleCount));
+            if (MaxCommentCount < 1) throw new ArgumentOutOfRangeException(nameof(MaxCommentCount));
+            if (MaxTextStyle9EntryCount < 1) throw new ArgumentOutOfRangeException(nameof(MaxTextStyle9EntryCount));
+            if (MaxDecodedStorageBytes < 1) throw new ArgumentOutOfRangeException(nameof(MaxDecodedStorageBytes));
+        }
     }
 }

--- a/OfficeIMO.PowerPoint/LegacyPpt/LegacyPptPresentation.Comments.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/LegacyPptPresentation.Comments.cs
@@ -53,6 +53,11 @@ namespace OfficeIMO.PowerPoint.LegacyPpt {
 
             foreach (LegacyPptRecord record in records.Where(record =>
                          record.Type == RecordComment10)) {
+                if (_commentCount >= options.MaxCommentCount) {
+                    throw new InvalidDataException(
+                        $"The binary PowerPoint comment count exceeds {options.MaxCommentCount}.");
+                }
+                _commentCount++;
                 if (TryReadComment(record, slide.SlideId, out LegacyPptComment? comment)
                     && comment != null) {
                     slide.AddComment(comment);

--- a/OfficeIMO.PowerPoint/LegacyPpt/LegacyPptPresentation.CustomShows.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/LegacyPptPresentation.CustomShows.cs
@@ -9,6 +9,8 @@ namespace OfficeIMO.PowerPoint.LegacyPpt {
         private const ushort RecordNamedShowSlides = 0x0412;
 
         private readonly List<LegacyPptCustomShow> _customShows = new();
+        private readonly Dictionary<string, LegacyPptCustomShow>
+            _uniqueEditableCustomShowsByName = new(StringComparer.Ordinal);
         private bool _customShowsAreEditable = true;
 
         /// <summary>Gets named custom slide shows in document order.</summary>
@@ -69,6 +71,15 @@ namespace OfficeIMO.PowerPoint.LegacyPpt {
                     LegacyPptDiagnosticSeverity.Warning,
                     $"Named show '{duplicate.Key}' occurs more than once; its actions are ambiguous and remain preserve-only.",
                     duplicate.First().RecordOffset);
+            }
+            foreach (IGrouping<string, LegacyPptCustomShow> group in
+                     _customShows.GroupBy(show => show.Name,
+                         StringComparer.Ordinal)) {
+                LegacyPptCustomShow[] candidates = group.Take(2).ToArray();
+                if (candidates.Length == 1 && candidates[0].IsEditable) {
+                    _uniqueEditableCustomShowsByName[group.Key] =
+                        candidates[0];
+                }
             }
         }
 

--- a/OfficeIMO.PowerPoint/LegacyPpt/LegacyPptPresentation.Interactions.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/LegacyPptPresentation.Interactions.cs
@@ -294,11 +294,8 @@ namespace OfficeIMO.PowerPoint.LegacyPpt {
             }
             LegacyPptCustomShow? customShow = null;
             if (action == LegacyPptInteractionAction.CustomShow && name != null) {
-                LegacyPptCustomShow[] matches = _customShows.Where(show =>
-                    string.Equals(show.Name, name, StringComparison.Ordinal)).ToArray();
-                if (matches.Length == 1 && matches[0].IsEditable) {
-                    customShow = matches[0];
-                }
+                _uniqueEditableCustomShowsByName.TryGetValue(name,
+                    out customShow);
             }
             var interaction = new LegacyPptInteraction(
                 (LegacyPptInteractionTrigger)container.Instance, action,

--- a/OfficeIMO.PowerPoint/LegacyPpt/LegacyPptPresentation.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/LegacyPptPresentation.cs
@@ -62,6 +62,8 @@ namespace OfficeIMO.PowerPoint.LegacyPpt {
         private readonly List<LegacyPptImportDiagnostic> _diagnostics = new();
         private LegacyPptRecordTraversalBudget _recordBudget = null!;
         private LegacyPptDecodedStorageBudget _decodedStorageBudget = null!;
+        private int _connectorRuleCount;
+        private int _commentCount;
 
         private LegacyPptPresentation() { }
 
@@ -152,10 +154,7 @@ namespace OfficeIMO.PowerPoint.LegacyPpt {
             CancellationToken cancellationToken) {
             if (bytes == null) throw new ArgumentNullException(nameof(bytes));
             options ??= new LegacyPptImportOptions();
-            if (options.MaxInputBytes < 1) {
-                throw new ArgumentOutOfRangeException(
-                    nameof(options.MaxInputBytes));
-            }
+            options.Validate();
             if (bytes.Length > options.MaxInputBytes) {
                 throw new InvalidDataException(
                     $"The binary PowerPoint input exceeds {options.MaxInputBytes} bytes.");
@@ -303,8 +302,13 @@ namespace OfficeIMO.PowerPoint.LegacyPpt {
                 record.Type == RecordSlideListWithText && record.Instance == 1);
             if (masterList == null) return;
 
-            foreach (LegacyPptRecord masterPersist in masterList.Children.Where(record =>
-                         record.Type == RecordSlidePersistAtom)) {
+            LegacyPptRecord[] masterPersists = masterList.Children.Where(
+                record => record.Type == RecordSlidePersistAtom).ToArray();
+            if (masterPersists.Length > options.MaxMasterCount) {
+                throw new InvalidDataException(
+                    $"The binary PowerPoint master count {masterPersists.Length} exceeds {options.MaxMasterCount}.");
+            }
+            foreach (LegacyPptRecord masterPersist in masterPersists) {
                 cancellationToken.ThrowIfCancellationRequested();
                 if (masterPersist.PayloadLength < 20) {
                     AddDiagnostic("PPT-MASTER-PERSIST-TRUNCATED", LegacyPptDiagnosticSeverity.Warning,
@@ -430,6 +434,11 @@ namespace OfficeIMO.PowerPoint.LegacyPpt {
                          record.Type == OfficeArtSolverContainer)) {
                 foreach (LegacyPptRecord rule in solver.Children.Where(record =>
                              record.Type == OfficeArtFConnectorRule)) {
+                    if (_connectorRuleCount >= options.MaxConnectorRuleCount) {
+                        throw new InvalidDataException(
+                            $"The binary PowerPoint connector-rule count exceeds {options.MaxConnectorRuleCount}.");
+                    }
+                    _connectorRuleCount++;
                     if (rule.PayloadLength < 24) {
                         if (options.ReportUnsupportedContent) {
                             AddDiagnostic("PPT-CONNECTOR-RULE-TRUNCATED",
@@ -491,7 +500,8 @@ namespace OfficeIMO.PowerPoint.LegacyPpt {
             LegacyPptRecord? textStyle9 = ReadShapeStyle9(shapeContainer,
                 options, out bool isTextStyle9Malformed);
             textBody = LegacyPptTextStyle9Reader.Apply(textBody, textStyle9,
-                    _pictureBulletsByIndex, isTextStyle9Malformed);
+                    _pictureBulletsByIndex, isTextStyle9Malformed,
+                    options.MaxTextStyle9EntryCount);
             LegacyPptRecord? textSpecialInfo = textbox?.DescendantsAndSelf()
                 .FirstOrDefault(record =>
                     record.Type == RecordTextSpecialInfoAtom);

--- a/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptWritePreflight.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptWritePreflight.cs
@@ -10,9 +10,15 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
             if (presentation == null) throw new ArgumentNullException(nameof(presentation));
             var findings = new List<LegacyPptWriteFinding>();
             AddPackagePartFindings(presentation, findings);
-            if (findings.Count == 0
-                && (presentation.CanPreserveOriginalLegacyPackage
-                    || LegacyPptPreservingWriter.CanWritePresentation(presentation))) {
+            int packageFindingCount = findings.Count;
+            bool canPreserve = presentation.CanPreserveOriginalLegacyPackage
+                || LegacyPptPreservingWriter.CanWritePresentation(
+                    presentation);
+            if (canPreserve
+                && !presentation.CanPreserveOriginalLegacyPackage) {
+                AddPreservedActiveContentFindings(presentation, findings);
+            }
+            if (canPreserve && packageFindingCount == 0) {
                 return new LegacyPptWritePreflightReport(findings);
             }
             if (presentation.LegacyPptPackage != null) {
@@ -395,6 +401,53 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
                 }
             }
             return new LegacyPptWritePreflightReport(findings);
+        }
+
+        private static void AddPreservedActiveContentFindings(
+            PowerPointPresentation presentation,
+            ICollection<LegacyPptWriteFinding> findings) {
+            if (presentation.LegacyPptWillPreserveVbaContent) {
+                findings.Add(new LegacyPptWriteFinding(
+                    LegacyPptFeature.VbaProjects,
+                    "PPT-WRITE-PRESERVED-VBA",
+                    "The edited binary presentation will preserve an imported VBA project. Set LossPolicy to Allow only when retaining that active content is intentional."));
+            }
+            if (presentation.LegacyPptHasEmbeddedOleContent) {
+                findings.Add(new LegacyPptWriteFinding(
+                    LegacyPptFeature.EmbeddedOle,
+                    "PPT-WRITE-PRESERVED-OLE",
+                    "The edited binary presentation will preserve imported embedded OLE content. Set LossPolicy to Allow only when retaining that active content is intentional."));
+            }
+            if (presentation.LegacyPptHasLinkedOleContent) {
+                findings.Add(new LegacyPptWriteFinding(
+                    LegacyPptFeature.LinkedOle,
+                    "PPT-WRITE-PRESERVED-LINKED-OLE",
+                    "The edited binary presentation will preserve imported linked OLE content. Set LossPolicy to Allow only when retaining that external content is intentional."));
+            }
+            if (presentation.LegacyPptHasActiveXContent) {
+                findings.Add(new LegacyPptWriteFinding(
+                    LegacyPptFeature.ActiveX,
+                    "PPT-WRITE-PRESERVED-ACTIVEX",
+                    "The edited binary presentation will preserve imported ActiveX content. Set LossPolicy to Allow only when retaining that active content is intentional."));
+            }
+            if (presentation.LegacyPptWillPreserveRunProgramContent) {
+                findings.Add(new LegacyPptWriteFinding(
+                    LegacyPptFeature.Actions,
+                    "PPT-WRITE-PRESERVED-RUN-PROGRAM",
+                    "The edited binary presentation will preserve a run-program action. Set LossPolicy to Allow only when retaining that active action is intentional."));
+            }
+            if (presentation.LegacyPptWillPreserveExternalHyperlinkContent) {
+                findings.Add(new LegacyPptWriteFinding(
+                    LegacyPptFeature.Hyperlinks,
+                    "PPT-WRITE-PRESERVED-EXTERNAL-LINK",
+                    "The edited binary presentation will preserve an external hyperlink. Set LossPolicy to Allow only when retaining that external target is intentional."));
+            }
+            if (presentation.LegacyPptHasExternalMediaContent) {
+                findings.Add(new LegacyPptWriteFinding(
+                    LegacyPptFeature.LinkedMedia,
+                    "PPT-WRITE-PRESERVED-EXTERNAL-MEDIA",
+                    "The edited binary presentation will preserve externally linked media. Set LossPolicy to Allow only when retaining that external target is intentional."));
+            }
         }
 
         internal static bool CanWriteSlideLosslessly(PowerPointSlide slide) {

--- a/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptWriter.Groups.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptWriter.Groups.cs
@@ -68,17 +68,27 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
 
         internal static int CountDrawingShapes(
             IEnumerable<PowerPointShape> shapes,
-            LegacyPptWriterPictureCatalog? pictureCatalog = null) {
+            LegacyPptWriterPictureCatalog? pictureCatalog = null) =>
+            CountDrawingShapes(shapes, pictureCatalog, depth: 0);
+
+        private static int CountDrawingShapes(
+            IEnumerable<PowerPointShape> shapes,
+            LegacyPptWriterPictureCatalog? pictureCatalog, int depth) {
             int count = 0;
             foreach (PowerPointShape shape in shapes) {
                 if (shape is PowerPointGroupShape group) {
+                    if (depth >= MaximumGroupNestingDepth) {
+                        throw new NotSupportedException(
+                            $"Binary PowerPoint conversion supports at most {MaximumGroupNestingDepth} nested group levels.");
+                    }
                     if (!TryReadGroupForWrite(group,
                             out IReadOnlyList<PowerPointShape> children,
                             out string? reason)) {
                         throw new NotSupportedException(reason);
                     }
                     count = checked(count + 1
-                        + CountDrawingShapes(children, pictureCatalog));
+                        + CountDrawingShapes(children, pictureCatalog,
+                            checked(depth + 1)));
                 } else if (shape is PowerPointTable table) {
                     count = checked(count + (pictureCatalog?.Contains(table)
                         == true ? 1 : CountTableDrawingShapes(table)));
@@ -98,7 +108,12 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
             LegacyPptWriterOleObjectCatalog? oleCatalog,
             LegacyPptWriterPictureCatalog? pictureCatalog,
             LegacyPptWriterFontCatalog fonts,
-            LegacyPptWriterPictureBulletCatalog? pictureBullets) {
+            LegacyPptWriterPictureBulletCatalog? pictureBullets,
+            int depth = 1) {
+            if (depth > MaximumGroupNestingDepth) {
+                throw new NotSupportedException(
+                    $"Binary PowerPoint conversion supports at most {MaximumGroupNestingDepth} nested group levels.");
+            }
             if (!TryReadGroupForWrite(group,
                     out IReadOnlyList<PowerPointShape> groupChildren,
                     out string? reason)) {
@@ -126,7 +141,7 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
                     ? BuildGroupRecord(nested, ref nextShapeId,
                         interactionCatalog, animationCatalog, shapeContext,
                         mediaCatalog, oleCatalog, pictureCatalog, fonts,
-                        pictureBullets)
+                        pictureBullets, checked(depth + 1))
                     : child is PowerPointTable table
                         && pictureCatalog?.Contains(table) != true
                     ? BuildTableRecord(table, ref nextShapeId,

--- a/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptWriter.LayoutShapes.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptWriter.LayoutShapes.cs
@@ -40,13 +40,23 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
 
         internal static IReadOnlyList<PowerPointShape>
             FlattenShapeTreeForWrite(IEnumerable<PowerPointShape> shapes,
-                out string? unsupportedReason) {
+                out string? unsupportedReason) =>
+            FlattenShapeTreeForWrite(shapes, depth: 0,
+                out unsupportedReason);
+
+        private static IReadOnlyList<PowerPointShape>
+            FlattenShapeTreeForWrite(IEnumerable<PowerPointShape> shapes,
+                int depth, out string? unsupportedReason) {
             if (shapes == null) throw new ArgumentNullException(nameof(shapes));
             var result = new List<PowerPointShape>();
             unsupportedReason = null;
             foreach (PowerPointShape shape in shapes) {
                 result.Add(shape);
                 if (shape is not PowerPointGroupShape group) continue;
+                if (depth >= MaximumGroupNestingDepth) {
+                    unsupportedReason = $"Binary PowerPoint conversion supports at most {MaximumGroupNestingDepth} nested group levels.";
+                    return result;
+                }
                 IReadOnlyList<PowerPointShape> children =
                     ReadGroupChildrenForWrite(group,
                         out string? childReason);
@@ -55,7 +65,8 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
                     return result;
                 }
                 IReadOnlyList<PowerPointShape> descendants =
-                    FlattenShapeTreeForWrite(children, out childReason);
+                    FlattenShapeTreeForWrite(children, checked(depth + 1),
+                        out childReason);
                 if (childReason != null) {
                     unsupportedReason = childReason;
                     return result;

--- a/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptWriter.Pictures.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptWriter.Pictures.cs
@@ -286,21 +286,26 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
         private static bool TryRasterizeStaticVisual(OfficeDrawing drawing,
             string ownerName, out byte[] pngBytes, out string? reason) {
             pngBytes = Array.Empty<byte>();
-            double pixelAreaAtTwoX = checked(drawing.Width * drawing.Height
-                * 4D);
-            double scale = pixelAreaAtTwoX <= 16_000_000D
-                ? 2D
-                : Math.Sqrt(16_000_000D
-                    / (drawing.Width * drawing.Height));
-            if (double.IsNaN(scale) || double.IsInfinity(scale)
-                || scale <= 0D) {
+            try {
+                var options = new OfficeImageExportOptions {
+                    Scale = 2D,
+                    MaximumRasterPixels = MaximumStaticVisualRasterPixels,
+                    RasterOverflowBehavior = OfficeRasterOverflowBehavior.ReduceScale
+                };
+                OfficeRasterExportPlan plan = OfficeRasterExportPlanner.Resolve(
+                    drawing.Width, drawing.Height,
+                    OfficeImageExportFormat.Png, options,
+                    MaximumStaticVisualRasterPixels, ownerName);
+                pngBytes = OfficeDrawingRasterRenderer.ToPng(drawing,
+                    plan.Limit.Scale, OfficeColor.White);
+                reason = null;
+                return true;
+            } catch (Exception exception) when (exception
+                is ArgumentException or InvalidOperationException
+                    or OverflowException or OfficeImageExportLimitException) {
                 reason = $"The {ownerName} dimensions cannot be rasterized safely for binary PowerPoint conversion.";
                 return false;
             }
-            pngBytes = OfficeDrawingRasterRenderer.ToPng(drawing, scale,
-                OfficeColor.White);
-            reason = null;
-            return true;
         }
 
         internal static bool TryValidatePictureForWrite(
@@ -354,7 +359,7 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
                 return false;
             }
             try {
-                imageBytes = picture.GetImageBytes();
+                imageBytes = picture.GetImageBytes(MaximumPictureBytes);
                 _ = OfficeArtBlipStoreEntryWriter.CreateBlipRecord(imageBytes,
                     contentType);
             } catch (Exception exception) when (exception is InvalidOperationException
@@ -545,6 +550,7 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
             private readonly List<LegacyPptWriterPicture> _entries = new();
             private readonly int _baseStoreEntryCount;
             private readonly uint _baseDelayedStreamOffset;
+            private long _totalPictureBytes;
 
             internal LegacyPptWriterPictureCatalog(int baseStoreEntryCount = 0,
                 uint baseDelayedStreamOffset = 0) {
@@ -584,6 +590,10 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
                     reason = null;
                     return true;
                 }
+                if (imageBytes.Length > MaximumPictureBytes) {
+                    reason = $"A binary PowerPoint picture cannot exceed {MaximumPictureBytes} bytes.";
+                    return false;
+                }
                 string hash = ComputePictureHash(contentType, imageBytes);
                 if (!_entriesByHash.TryGetValue(hash,
                         out List<LegacyPptWriterPicture>? candidates)) {
@@ -599,12 +609,19 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
                         reason = "A binary PowerPoint drawing group cannot contain more than 4,095 distinct picture-store entries.";
                         return false;
                     }
+                    long nextTotal = checked(_totalPictureBytes
+                        + imageBytes.Length);
+                    if (nextTotal > MaximumTotalPictureBytes) {
+                        reason = $"Binary PowerPoint picture payloads cannot exceed {MaximumTotalPictureBytes} aggregate bytes.";
+                        return false;
+                    }
                     entry = new LegacyPptWriterPicture(
                         checked((uint)(_baseStoreEntryCount
                             + _entries.Count) + 1U), imageBytes,
                         contentType);
                     _entries.Add(entry);
                     candidates.Add(entry);
+                    _totalPictureBytes = nextTotal;
                 } else {
                     entry.AddReference();
                 }

--- a/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptWriter.ResourceLimits.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptWriter.ResourceLimits.cs
@@ -1,0 +1,14 @@
+namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
+    /// <summary>
+    /// Central resource ceilings for binary PowerPoint conversion paths that
+    /// materialize caller-controlled package content.
+    /// </summary>
+    internal static partial class LegacyPptWriter {
+        internal const int MaximumGroupNestingDepth = 64;
+        internal const long MaximumStaticVisualRasterPixels = 16_000_000L;
+        internal const int MaximumPictureBytes = 64 * 1024 * 1024;
+        internal const long MaximumTotalPictureBytes = 256L * 1024 * 1024;
+        internal const int MaximumSoundBytes = 64 * 1024 * 1024;
+        internal const long MaximumTotalSoundBytes = 256L * 1024 * 1024;
+    }
+}

--- a/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptWriter.Sounds.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptWriter.Sounds.cs
@@ -163,6 +163,7 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
                 }
                 string key = CreateSoundKey(name, extension, builtInId: null, bytes);
                 if (_soundsByKey.TryGetValue(key, out sound)) return true;
+                if (!CanAddSoundBytes(bytes.Length, out reason)) return false;
                 if (_nextId >= int.MaxValue) {
                     reason = "The binary sound identifier range is exhausted.";
                     return false;
@@ -219,6 +220,7 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
                 string key = CreateSoundKey(name, ".wav",
                     builtInId: null, bytes);
                 if (_soundsByKey.TryGetValue(key, out sound)) return true;
+                if (!CanAddSoundBytes(bytes.Length, out reason)) return false;
                 if (_nextId >= int.MaxValue) {
                     reason = "The binary sound identifier range is exhausted.";
                     return false;
@@ -241,12 +243,6 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
                         FileAccess.Read);
                     bytes = OfficeStreamReader.ReadAllBytes(input,
                         MaximumSoundBytes);
-                    long nextTotal = checked(_totalSoundBytes + bytes.Length);
-                    if (nextTotal > MaximumTotalSoundBytes) {
-                        bytes = Array.Empty<byte>();
-                        reason = $"Binary PowerPoint sound payloads cannot exceed {MaximumTotalSoundBytes} aggregate bytes.";
-                        return false;
-                    }
                     return true;
                 } catch (Exception exception) when (exception
                     is IOException or InvalidDataException
@@ -255,6 +251,16 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
                     reason = $"The embedded audio payload cannot be read within the {MaximumSoundBytes}-byte safety limit: {exception.Message}";
                     return false;
                 }
+            }
+
+            private bool CanAddSoundBytes(int byteCount, out string? reason) {
+                long nextTotal = checked(_totalSoundBytes + byteCount);
+                if (nextTotal <= MaximumTotalSoundBytes) {
+                    reason = null;
+                    return true;
+                }
+                reason = $"Binary PowerPoint sound payloads cannot exceed {MaximumTotalSoundBytes} aggregate bytes.";
+                return false;
             }
 
             private static string CreateSoundKey(string name, string extension,

--- a/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptWriter.Sounds.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/Write/LegacyPptWriter.Sounds.cs
@@ -56,6 +56,7 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
             private readonly List<LegacyPptWriterSound> _sounds = new();
             private readonly List<LegacyPptWriterSound> _newSounds = new();
             private uint _nextId;
+            private long _totalSoundBytes;
 
             internal LegacyPptWriterSoundCatalog() { }
 
@@ -73,6 +74,8 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
                         extension, source.BuiltInId, source.DataBytes,
                         isExisting: true);
                     _sounds.Add(sound);
+                    _totalSoundBytes = checked(_totalSoundBytes
+                        + source.DataBytes.Length);
                     string key = CreateSoundKey(sound.Name, sound.Extension,
                         sound.BuiltInId, sound.DataBytes);
                     if (!_soundsByKey.ContainsKey(key)) {
@@ -134,8 +137,8 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
                 }
                 if (name.Length == 0) name = "Sound";
                 byte[] bytes;
-                using (Stream input = mediaPart.GetStream(FileMode.Open, FileAccess.Read)) {
-                    bytes = OfficeStreamReader.ReadAllBytes(input);
+                if (!TryReadSoundBytes(mediaPart, out bytes, out reason)) {
+                    return false;
                 }
                 if (bytes.Length == 0) {
                     reason = "An embedded transition or action sound has an empty audio payload.";
@@ -170,6 +173,7 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
                 _sounds.Add(sound);
                 _newSounds.Add(sound);
                 _soundsByKey.Add(key, sound);
+                _totalSoundBytes = checked(_totalSoundBytes + bytes.Length);
                 return true;
             }
 
@@ -202,9 +206,8 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
                     return false;
                 }
                 byte[] bytes;
-                using (Stream input = mediaPart.GetStream(FileMode.Open,
-                           FileAccess.Read)) {
-                    bytes = OfficeStreamReader.ReadAllBytes(input);
+                if (!TryReadSoundBytes(mediaPart, out bytes, out reason)) {
+                    return false;
                 }
                 if (bytes.Length == 0) {
                     reason = "An embedded media shape has an empty audio payload.";
@@ -225,7 +228,33 @@ namespace OfficeIMO.PowerPoint.LegacyPpt.Write {
                 _sounds.Add(sound);
                 _newSounds.Add(sound);
                 _soundsByKey.Add(key, sound);
+                _totalSoundBytes = checked(_totalSoundBytes + bytes.Length);
                 return true;
+            }
+
+            private bool TryReadSoundBytes(MediaDataPart mediaPart,
+                out byte[] bytes, out string? reason) {
+                bytes = Array.Empty<byte>();
+                reason = null;
+                try {
+                    using Stream input = mediaPart.GetStream(FileMode.Open,
+                        FileAccess.Read);
+                    bytes = OfficeStreamReader.ReadAllBytes(input,
+                        MaximumSoundBytes);
+                    long nextTotal = checked(_totalSoundBytes + bytes.Length);
+                    if (nextTotal > MaximumTotalSoundBytes) {
+                        bytes = Array.Empty<byte>();
+                        reason = $"Binary PowerPoint sound payloads cannot exceed {MaximumTotalSoundBytes} aggregate bytes.";
+                        return false;
+                    }
+                    return true;
+                } catch (Exception exception) when (exception
+                    is IOException or InvalidDataException
+                        or NotSupportedException or OverflowException) {
+                    bytes = Array.Empty<byte>();
+                    reason = $"The embedded audio payload cannot be read within the {MaximumSoundBytes}-byte safety limit: {exception.Message}";
+                    return false;
+                }
             }
 
             private static string CreateSoundKey(string name, string extension,

--- a/OfficeIMO.PowerPoint/PowerPointPicture.ImageBytes.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPicture.ImageBytes.cs
@@ -8,11 +8,18 @@ namespace OfficeIMO.PowerPoint {
         ///     Returns a snapshot of the embedded image bytes for export adapters.
         /// </summary>
         public byte[] GetImageBytes() {
+            return GetImageBytes(maximumBytes: null);
+        }
+
+        /// <summary>Returns a bounded snapshot of the embedded image bytes.</summary>
+        internal byte[] GetImageBytes(int? maximumBytes) {
             ImagePart imagePart = GetImagePart() ?? throw new InvalidOperationException("Picture has no embedded image part.");
             using Stream source = imagePart.GetStream(FileMode.Open, FileAccess.Read);
-            using var buffer = new MemoryStream();
-            source.CopyTo(buffer);
-            return buffer.ToArray();
+            return maximumBytes.HasValue
+                ? OfficeIMO.Drawing.Internal.OfficeStreamReader.ReadAllBytes(
+                    source, maximumBytes.Value)
+                : OfficeIMO.Drawing.Internal.OfficeStreamReader.ReadAllBytes(
+                    source);
         }
     }
 }

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.Conversion.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.Conversion.cs
@@ -412,6 +412,10 @@ public sealed partial class PowerPointPresentation {
                     ReportUnsupportedContent = true,
                     MaxRecordCount = legacy.MaxRecordCount,
                     MaxRecordDepth = legacy.MaxRecordDepth,
+                    MaxMasterCount = legacy.MaxMasterCount,
+                    MaxConnectorRuleCount = legacy.MaxConnectorRuleCount,
+                    MaxCommentCount = legacy.MaxCommentCount,
+                    MaxTextStyle9EntryCount = legacy.MaxTextStyle9EntryCount,
                     MaxDecodedStorageBytes = legacy.MaxDecodedStorageBytes,
                     Password = legacy.Password
                 }
@@ -423,7 +427,9 @@ public sealed partial class PowerPointPresentation {
         bool allowsLoss) => new() {
         LossPolicy = allowsLoss ? PowerPointConversionLossPolicy.Allow : PowerPointConversionLossPolicy.Block,
         LegacyPptEncryptionKeySizeBits = source?.LegacyPptEncryptionKeySizeBits ?? 128,
-        LegacyPptEncryptDocumentProperties = source?.LegacyPptEncryptDocumentProperties ?? true
+        LegacyPptEncryptDocumentProperties = source?.LegacyPptEncryptDocumentProperties ?? true,
+        LegacyPptAllowUnencryptedCompoundStreams = source?
+            .LegacyPptAllowUnencryptedCompoundStreams ?? false
     };
 
     private static OfficeCompatibilityMode GetCompatibilityMode(PowerPointPresentationConversionOptions options) {

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.LegacyPpt.CustomShows.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.LegacyPpt.CustomShows.cs
@@ -29,6 +29,30 @@ namespace OfficeIMO.PowerPoint {
             }
             if (list.HasChildren) {
                 presentationPart.Presentation!.CustomShowList = list;
+                list.AddAnnotation(new LegacyPptCustomShowIdIndex(list));
+            }
+        }
+
+        private sealed class LegacyPptCustomShowIdIndex {
+            private readonly IReadOnlyDictionary<string, uint?> _idsByName;
+
+            internal LegacyPptCustomShowIdIndex(P.CustomShowList list) {
+                _idsByName = list.Elements<P.CustomShow>()
+                    .GroupBy(show => show.Name?.Value ?? string.Empty,
+                        StringComparer.Ordinal)
+                    .ToDictionary(group => group.Key,
+                        group => group.Count() == 1
+                            ? group.First().Id?.Value
+                            : null,
+                        StringComparer.Ordinal);
+            }
+
+            internal bool TryGetUniqueId(string name, out uint id) {
+                id = 0;
+                if (!_idsByName.TryGetValue(name, out uint? value)
+                    || !value.HasValue) return false;
+                id = value.Value;
+                return true;
             }
         }
     }

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.LegacyPpt.Interactions.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.LegacyPpt.Interactions.cs
@@ -203,16 +203,16 @@ namespace OfficeIMO.PowerPoint {
             customShowId = 0;
             PresentationPart? presentationPart = ownerPart.OpenXmlPackage.RootPart
                 as PresentationPart;
-            P.CustomShow[] matches = presentationPart?.Presentation?.CustomShowList?
-                .Elements<P.CustomShow>().Where(show => string.Equals(
-                    show.Name?.Value, name, StringComparison.Ordinal)).ToArray()
-                ?? Array.Empty<P.CustomShow>();
-            uint? id = matches.Length == 1 ? matches[0].Id?.Value : null;
-            if (!id.HasValue) {
-                return false;
+            P.CustomShowList? list = presentationPart?.Presentation?
+                .CustomShowList;
+            if (list == null) return false;
+            LegacyPptCustomShowIdIndex? index = list.Annotation<
+                LegacyPptCustomShowIdIndex>();
+            if (index == null) {
+                index = new LegacyPptCustomShowIdIndex(list);
+                list.AddAnnotation(index);
             }
-            customShowId = id.Value;
-            return true;
+            return index.TryGetUniqueId(name, out customShowId);
         }
 
         private static string? GetLegacyPowerPointAction(

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.LegacyPpt.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.LegacyPpt.cs
@@ -360,13 +360,22 @@ namespace OfficeIMO.PowerPoint {
         private static void ProjectLegacyConnectorRules(ShapeTree tree,
             IReadOnlyList<LegacyPptConnectorRule> rules,
             IReadOnlyDictionary<uint, uint> projectedShapeIds) {
+            var connectorsById = new Dictionary<uint,
+                DocumentFormat.OpenXml.Presentation.ConnectionShape>();
+            foreach (DocumentFormat.OpenXml.Presentation.ConnectionShape
+                     connector in tree.Descendants<
+                         DocumentFormat.OpenXml.Presentation.ConnectionShape>()) {
+                uint? id = connector.NonVisualConnectionShapeProperties?
+                    .NonVisualDrawingProperties?.Id?.Value;
+                if (id.HasValue && !connectorsById.ContainsKey(id.Value)) {
+                    connectorsById.Add(id.Value, connector);
+                }
+            }
             foreach (LegacyPptConnectorRule rule in rules) {
                 if (!projectedShapeIds.TryGetValue(rule.ConnectorShapeId, out uint connectorId)) continue;
-                DocumentFormat.OpenXml.Presentation.ConnectionShape? connector = tree
-                    .Descendants<DocumentFormat.OpenXml.Presentation.ConnectionShape>()
-                    .FirstOrDefault(item => item.NonVisualConnectionShapeProperties?
-                        .NonVisualDrawingProperties?.Id?.Value == connectorId);
-                if (connector == null) continue;
+                if (!connectorsById.TryGetValue(connectorId,
+                        out DocumentFormat.OpenXml.Presentation.ConnectionShape?
+                            connector)) continue;
                 NonVisualConnectorShapeDrawingProperties drawingProperties =
                     connector.NonVisualConnectionShapeProperties?.NonVisualConnectorShapeDrawingProperties
                     ?? new NonVisualConnectorShapeDrawingProperties();

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.LegacyPpt.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.LegacyPpt.cs
@@ -75,6 +75,11 @@ namespace OfficeIMO.PowerPoint {
                 ReportUnsupportedContent = sourceOptions.ReportUnsupportedContent,
                 MaxRecordCount = sourceOptions.MaxRecordCount,
                 MaxRecordDepth = sourceOptions.MaxRecordDepth,
+                MaxMasterCount = sourceOptions.MaxMasterCount,
+                MaxConnectorRuleCount = sourceOptions.MaxConnectorRuleCount,
+                MaxCommentCount = sourceOptions.MaxCommentCount,
+                MaxTextStyle9EntryCount =
+                    sourceOptions.MaxTextStyle9EntryCount,
                 MaxDecodedStorageBytes =
                     sourceOptions.MaxDecodedStorageBytes,
                 Password = password

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.LegacyPptState.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.LegacyPptState.cs
@@ -255,6 +255,12 @@ namespace OfficeIMO.PowerPoint {
                         yield return item;
                     }
                 }
+                if (slidePart.NotesSlidePart?.NotesSlide != null) {
+                    foreach (A.HyperlinkType item in EnumerateReferencedHyperlinks(
+                                 slidePart.NotesSlidePart.NotesSlide)) {
+                        yield return item;
+                    }
+                }
             }
             foreach (SlideMasterPart masterPart in _presentationPart.SlideMasterParts) {
                 if (masterPart.SlideMaster != null) {
@@ -269,6 +275,18 @@ namespace OfficeIMO.PowerPoint {
                                  layoutPart.SlideLayout)) {
                         yield return item;
                     }
+                }
+            }
+            if (_presentationPart.NotesMasterPart?.NotesMaster != null) {
+                foreach (A.HyperlinkType item in EnumerateReferencedHyperlinks(
+                             _presentationPart.NotesMasterPart.NotesMaster)) {
+                    yield return item;
+                }
+            }
+            if (_presentationPart.HandoutMasterPart?.HandoutMaster != null) {
+                foreach (A.HyperlinkType item in EnumerateReferencedHyperlinks(
+                             _presentationPart.HandoutMasterPart.HandoutMaster)) {
+                    yield return item;
                 }
             }
         }

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.LegacyPptState.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.LegacyPptState.cs
@@ -3,6 +3,8 @@ using OfficeIMO.PowerPoint.LegacyPpt.Diagnostics;
 using OfficeIMO.PowerPoint.LegacyPpt.Internal;
 using OfficeIMO.Drawing;
 using DocumentFormat.OpenXml.Packaging;
+using System.Security.Cryptography;
+using A = DocumentFormat.OpenXml.Drawing;
 
 namespace OfficeIMO.PowerPoint {
     public sealed partial class PowerPointPresentation {
@@ -15,6 +17,15 @@ namespace OfficeIMO.PowerPoint {
         private string[] _legacyPptLinkedOleDetails = Array.Empty<string>();
         private string[] _legacyPptActiveXDetails = Array.Empty<string>();
         private string[] _legacyPptMediaDetails = Array.Empty<string>();
+        private bool _legacyPptHasVbaContent;
+        private bool _legacyPptHadProjectedVbaContent;
+        private byte[]? _legacyPptProjectedVbaDigest;
+        private bool _legacyPptHasEmbeddedOleContent;
+        private bool _legacyPptHasLinkedOleContent;
+        private bool _legacyPptHasActiveXContent;
+        private bool _legacyPptHasExternalHyperlinkContent;
+        private bool _legacyPptHasExternalMediaContent;
+        private bool _legacyPptHasRunProgramContent;
         private byte[]? _openXmlOriginalPackageBytes;
 
         /// <summary>Gets the detected physical format of the presentation source.</summary>
@@ -95,6 +106,19 @@ namespace OfficeIMO.PowerPoint {
                         ? $"sound {media.SoundId.Value}"
                         : "native device reference")))
                 .ToArray();
+            _legacyPptHasVbaContent = legacy.HasVbaContent;
+            _legacyPptHadProjectedVbaContent = legacy.VbaProject != null;
+            _legacyPptProjectedVbaDigest = legacy.VbaProject == null
+                ? null
+                : ComputeSha256(legacy.VbaProject.GetBytes());
+            _legacyPptHasEmbeddedOleContent = legacy.HasEmbeddedOleContent;
+            _legacyPptHasLinkedOleContent = legacy.HasLinkedOleContent;
+            _legacyPptHasActiveXContent = legacy.HasActiveXContent;
+            _legacyPptHasExternalHyperlinkContent =
+                legacy.HasExternalHyperlinkContent;
+            _legacyPptHasExternalMediaContent =
+                legacy.HasExternalMediaContent;
+            _legacyPptHasRunProgramContent = legacy.HasRunProgramContent;
             SourceFormat = sourceFormat;
         }
 
@@ -110,6 +134,7 @@ namespace OfficeIMO.PowerPoint {
             _legacyPptLinkedOleDetails = Array.Empty<string>();
             _legacyPptActiveXDetails = Array.Empty<string>();
             _legacyPptMediaDetails = Array.Empty<string>();
+            ClearLegacyPptSecurityState();
             SourceFormat = PowerPointFileFormat.Pptx;
         }
 
@@ -130,6 +155,29 @@ namespace OfficeIMO.PowerPoint {
 
         internal IReadOnlyList<string> LegacyPptMediaDetails =>
             _legacyPptMediaDetails;
+
+        internal bool LegacyPptWillPreserveVbaContent =>
+            _legacyPptHasVbaContent
+            && (!_legacyPptHadProjectedVbaContent
+                || IsProjectedVbaContentUnchanged());
+        internal bool LegacyPptHasEmbeddedOleContent =>
+            _legacyPptHasEmbeddedOleContent;
+        internal bool LegacyPptHasLinkedOleContent =>
+            _legacyPptHasLinkedOleContent;
+        internal bool LegacyPptHasActiveXContent =>
+            _legacyPptHasActiveXContent;
+        internal bool LegacyPptWillPreserveExternalHyperlinkContent =>
+            _legacyPptHasExternalHyperlinkContent
+            && EnumerateReferencedHyperlinks().Any(item =>
+                !string.Equals(item.Action?.Value, "ppaction://program",
+                    StringComparison.OrdinalIgnoreCase));
+        internal bool LegacyPptHasExternalMediaContent =>
+            _legacyPptHasExternalMediaContent;
+        internal bool LegacyPptWillPreserveRunProgramContent =>
+            _legacyPptHasRunProgramContent
+            && EnumerateReferencedHyperlinks().Any(item =>
+                string.Equals(item.Action?.Value, "ppaction://program",
+                    StringComparison.OrdinalIgnoreCase));
 
         internal bool HasOnlyLegacyPptPreservableChanges => _legacyPptProjectionMap != null
             && _legacyPptPreservationFingerprint != null
@@ -164,6 +212,62 @@ namespace OfficeIMO.PowerPoint {
             _legacyPptLinkedOleDetails = Array.Empty<string>();
             _legacyPptActiveXDetails = Array.Empty<string>();
             _legacyPptMediaDetails = Array.Empty<string>();
+            ClearLegacyPptSecurityState();
+        }
+
+        private void ClearLegacyPptSecurityState() {
+            _legacyPptHasVbaContent = false;
+            _legacyPptHadProjectedVbaContent = false;
+            _legacyPptProjectedVbaDigest = null;
+            _legacyPptHasEmbeddedOleContent = false;
+            _legacyPptHasLinkedOleContent = false;
+            _legacyPptHasActiveXContent = false;
+            _legacyPptHasExternalHyperlinkContent = false;
+            _legacyPptHasExternalMediaContent = false;
+            _legacyPptHasRunProgramContent = false;
+        }
+
+        private bool IsProjectedVbaContentUnchanged() {
+            if (_legacyPptProjectedVbaDigest == null) return true;
+            VbaProjectPart? part = _presentationPart.VbaProjectPart;
+            if (part == null) return false;
+            try {
+                using Stream stream = part.GetStream(FileMode.Open,
+                    FileAccess.Read);
+                using SHA256 sha256 = SHA256.Create();
+                return sha256.ComputeHash(stream)
+                    .SequenceEqual(_legacyPptProjectedVbaDigest);
+            } catch (Exception exception) when (
+                exception is IOException
+                || exception is UnauthorizedAccessException
+                || exception is InvalidDataException) {
+                // A separate package-part finding will reject unreadable VBA.
+                // Remain conservative if that finding is bypassed.
+                return true;
+            }
+        }
+
+        private IEnumerable<A.HyperlinkType> EnumerateReferencedHyperlinks() {
+            foreach (SlidePart slidePart in _presentationPart.SlideParts) {
+                if (slidePart.Slide == null) continue;
+                foreach (A.HyperlinkOnClick item in slidePart.Slide
+                             .Descendants<A.HyperlinkOnClick>()) {
+                    if (!string.IsNullOrEmpty(item.Id?.Value)) yield return item;
+                }
+                foreach (A.HyperlinkOnHover item in slidePart.Slide
+                             .Descendants<A.HyperlinkOnHover>()) {
+                    if (!string.IsNullOrEmpty(item.Id?.Value)) yield return item;
+                }
+                foreach (A.HyperlinkOnMouseOver item in slidePart.Slide
+                             .Descendants<A.HyperlinkOnMouseOver>()) {
+                    if (!string.IsNullOrEmpty(item.Id?.Value)) yield return item;
+                }
+            }
+        }
+
+        private static byte[] ComputeSha256(byte[] bytes) {
+            using SHA256 sha256 = SHA256.Create();
+            return sha256.ComputeHash(bytes);
         }
 
         internal static bool IsLegacyBinaryFormat(PowerPointFileFormat format) =>

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.LegacyPptState.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.LegacyPptState.cs
@@ -249,19 +249,43 @@ namespace OfficeIMO.PowerPoint {
 
         private IEnumerable<A.HyperlinkType> EnumerateReferencedHyperlinks() {
             foreach (SlidePart slidePart in _presentationPart.SlideParts) {
-                if (slidePart.Slide == null) continue;
-                foreach (A.HyperlinkOnClick item in slidePart.Slide
-                             .Descendants<A.HyperlinkOnClick>()) {
-                    if (!string.IsNullOrEmpty(item.Id?.Value)) yield return item;
+                if (slidePart.Slide != null) {
+                    foreach (A.HyperlinkType item in EnumerateReferencedHyperlinks(
+                                 slidePart.Slide)) {
+                        yield return item;
+                    }
                 }
-                foreach (A.HyperlinkOnHover item in slidePart.Slide
-                             .Descendants<A.HyperlinkOnHover>()) {
-                    if (!string.IsNullOrEmpty(item.Id?.Value)) yield return item;
+            }
+            foreach (SlideMasterPart masterPart in _presentationPart.SlideMasterParts) {
+                if (masterPart.SlideMaster != null) {
+                    foreach (A.HyperlinkType item in EnumerateReferencedHyperlinks(
+                                 masterPart.SlideMaster)) {
+                        yield return item;
+                    }
                 }
-                foreach (A.HyperlinkOnMouseOver item in slidePart.Slide
-                             .Descendants<A.HyperlinkOnMouseOver>()) {
-                    if (!string.IsNullOrEmpty(item.Id?.Value)) yield return item;
+                foreach (SlideLayoutPart layoutPart in masterPart.SlideLayoutParts) {
+                    if (layoutPart.SlideLayout == null) continue;
+                    foreach (A.HyperlinkType item in EnumerateReferencedHyperlinks(
+                                 layoutPart.SlideLayout)) {
+                        yield return item;
+                    }
                 }
+            }
+        }
+
+        private static IEnumerable<A.HyperlinkType> EnumerateReferencedHyperlinks(
+            DocumentFormat.OpenXml.OpenXmlPartRootElement root) {
+            foreach (A.HyperlinkOnClick item in root
+                         .Descendants<A.HyperlinkOnClick>()) {
+                    if (!string.IsNullOrEmpty(item.Id?.Value)) yield return item;
+            }
+            foreach (A.HyperlinkOnHover item in root
+                         .Descendants<A.HyperlinkOnHover>()) {
+                    if (!string.IsNullOrEmpty(item.Id?.Value)) yield return item;
+            }
+            foreach (A.HyperlinkOnMouseOver item in root
+                         .Descendants<A.HyperlinkOnMouseOver>()) {
+                    if (!string.IsNullOrEmpty(item.Id?.Value)) yield return item;
             }
         }
 

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.LegacyPptState.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.LegacyPptState.cs
@@ -26,6 +26,7 @@ namespace OfficeIMO.PowerPoint {
         private bool _legacyPptHasExternalHyperlinkContent;
         private bool _legacyPptHasExternalMediaContent;
         private bool _legacyPptHasRunProgramContent;
+        private bool _legacyPptHadProjectedRunProgramContent;
         private byte[]? _openXmlOriginalPackageBytes;
 
         /// <summary>Gets the detected physical format of the presentation source.</summary>
@@ -119,6 +120,11 @@ namespace OfficeIMO.PowerPoint {
             _legacyPptHasExternalMediaContent =
                 legacy.HasExternalMediaContent;
             _legacyPptHasRunProgramContent = legacy.HasRunProgramContent;
+            _legacyPptHadProjectedRunProgramContent =
+                EnumerateReferencedHyperlinks().Any(item =>
+                    string.Equals(item.Hyperlink.Action?.Value,
+                        "ppaction://program",
+                        StringComparison.OrdinalIgnoreCase));
             SourceFormat = sourceFormat;
         }
 
@@ -169,15 +175,16 @@ namespace OfficeIMO.PowerPoint {
         internal bool LegacyPptWillPreserveExternalHyperlinkContent =>
             _legacyPptHasExternalHyperlinkContent
             && EnumerateReferencedHyperlinks().Any(item =>
-                !string.Equals(item.Action?.Value, "ppaction://program",
-                    StringComparison.OrdinalIgnoreCase));
+                IsExternalHyperlink(item.Part, item.Hyperlink));
         internal bool LegacyPptHasExternalMediaContent =>
             _legacyPptHasExternalMediaContent;
         internal bool LegacyPptWillPreserveRunProgramContent =>
             _legacyPptHasRunProgramContent
-            && EnumerateReferencedHyperlinks().Any(item =>
-                string.Equals(item.Action?.Value, "ppaction://program",
-                    StringComparison.OrdinalIgnoreCase));
+            && (!_legacyPptHadProjectedRunProgramContent
+                || EnumerateReferencedHyperlinks().Any(item =>
+                    string.Equals(item.Hyperlink.Action?.Value,
+                        "ppaction://program",
+                        StringComparison.OrdinalIgnoreCase)));
 
         internal bool HasOnlyLegacyPptPreservableChanges => _legacyPptProjectionMap != null
             && _legacyPptPreservationFingerprint != null
@@ -225,6 +232,7 @@ namespace OfficeIMO.PowerPoint {
             _legacyPptHasExternalHyperlinkContent = false;
             _legacyPptHasExternalMediaContent = false;
             _legacyPptHasRunProgramContent = false;
+            _legacyPptHadProjectedRunProgramContent = false;
         }
 
         private bool IsProjectedVbaContentUnchanged() {
@@ -247,16 +255,20 @@ namespace OfficeIMO.PowerPoint {
             }
         }
 
-        private IEnumerable<A.HyperlinkType> EnumerateReferencedHyperlinks() {
+        private IEnumerable<(OpenXmlPart Part, A.HyperlinkType Hyperlink)>
+            EnumerateReferencedHyperlinks() {
             foreach (SlidePart slidePart in _presentationPart.SlideParts) {
                 if (slidePart.Slide != null) {
-                    foreach (A.HyperlinkType item in EnumerateReferencedHyperlinks(
+                    foreach ((OpenXmlPart Part, A.HyperlinkType Hyperlink) item
+                             in EnumerateReferencedHyperlinks(slidePart,
                                  slidePart.Slide)) {
                         yield return item;
                     }
                 }
                 if (slidePart.NotesSlidePart?.NotesSlide != null) {
-                    foreach (A.HyperlinkType item in EnumerateReferencedHyperlinks(
+                    foreach ((OpenXmlPart Part, A.HyperlinkType Hyperlink) item
+                             in EnumerateReferencedHyperlinks(
+                                 slidePart.NotesSlidePart,
                                  slidePart.NotesSlidePart.NotesSlide)) {
                         yield return item;
                     }
@@ -264,47 +276,68 @@ namespace OfficeIMO.PowerPoint {
             }
             foreach (SlideMasterPart masterPart in _presentationPart.SlideMasterParts) {
                 if (masterPart.SlideMaster != null) {
-                    foreach (A.HyperlinkType item in EnumerateReferencedHyperlinks(
+                    foreach ((OpenXmlPart Part, A.HyperlinkType Hyperlink) item
+                             in EnumerateReferencedHyperlinks(masterPart,
                                  masterPart.SlideMaster)) {
                         yield return item;
                     }
                 }
                 foreach (SlideLayoutPart layoutPart in masterPart.SlideLayoutParts) {
                     if (layoutPart.SlideLayout == null) continue;
-                    foreach (A.HyperlinkType item in EnumerateReferencedHyperlinks(
+                    foreach ((OpenXmlPart Part, A.HyperlinkType Hyperlink) item
+                             in EnumerateReferencedHyperlinks(layoutPart,
                                  layoutPart.SlideLayout)) {
                         yield return item;
                     }
                 }
             }
             if (_presentationPart.NotesMasterPart?.NotesMaster != null) {
-                foreach (A.HyperlinkType item in EnumerateReferencedHyperlinks(
+                foreach ((OpenXmlPart Part, A.HyperlinkType Hyperlink) item
+                         in EnumerateReferencedHyperlinks(
+                             _presentationPart.NotesMasterPart,
                              _presentationPart.NotesMasterPart.NotesMaster)) {
                     yield return item;
                 }
             }
             if (_presentationPart.HandoutMasterPart?.HandoutMaster != null) {
-                foreach (A.HyperlinkType item in EnumerateReferencedHyperlinks(
+                foreach ((OpenXmlPart Part, A.HyperlinkType Hyperlink) item
+                         in EnumerateReferencedHyperlinks(
+                             _presentationPart.HandoutMasterPart,
                              _presentationPart.HandoutMasterPart.HandoutMaster)) {
                     yield return item;
                 }
             }
         }
 
-        private static IEnumerable<A.HyperlinkType> EnumerateReferencedHyperlinks(
+        private static IEnumerable<(OpenXmlPart Part,
+            A.HyperlinkType Hyperlink)> EnumerateReferencedHyperlinks(
+            OpenXmlPart part,
             DocumentFormat.OpenXml.OpenXmlPartRootElement root) {
             foreach (A.HyperlinkOnClick item in root
                          .Descendants<A.HyperlinkOnClick>()) {
-                    if (!string.IsNullOrEmpty(item.Id?.Value)) yield return item;
+                    if (!string.IsNullOrEmpty(item.Id?.Value))
+                        yield return (part, item);
             }
             foreach (A.HyperlinkOnHover item in root
                          .Descendants<A.HyperlinkOnHover>()) {
-                    if (!string.IsNullOrEmpty(item.Id?.Value)) yield return item;
+                    if (!string.IsNullOrEmpty(item.Id?.Value))
+                        yield return (part, item);
             }
             foreach (A.HyperlinkOnMouseOver item in root
                          .Descendants<A.HyperlinkOnMouseOver>()) {
-                    if (!string.IsNullOrEmpty(item.Id?.Value)) yield return item;
+                    if (!string.IsNullOrEmpty(item.Id?.Value))
+                        yield return (part, item);
             }
+        }
+
+        private static bool IsExternalHyperlink(OpenXmlPart part,
+            A.HyperlinkType hyperlink) {
+            string? relationshipId = hyperlink.Id?.Value;
+            return !string.IsNullOrEmpty(relationshipId)
+                && part.HyperlinkRelationships.Any(relationship =>
+                    relationship.IsExternal
+                    && string.Equals(relationship.Id, relationshipId,
+                        StringComparison.Ordinal));
         }
 
         private static byte[] ComputeSha256(byte[] bytes) {

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.ValidationAndSave.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.ValidationAndSave.cs
@@ -358,7 +358,8 @@ namespace OfficeIMO.PowerPoint {
                 ? _legacyPptPackage.EncryptedDocumentProperties ?? true
                 : options.LegacyPptEncryptDocumentProperties;
             return LegacyPptRc4CryptoApi.EncryptPackage(plainBytes,
-                password, keySizeBits, encryptDocumentProperties);
+                password, keySizeBits, encryptDocumentProperties,
+                options?.LegacyPptAllowUnencryptedCompoundStreams == true);
         }
 
         private byte[] CreatePlainLegacyPptBytesForSave(
@@ -510,7 +511,8 @@ namespace OfficeIMO.PowerPoint {
             byte[] plainBytes = CreatePlainLegacyPptBytesForSave(options);
             return LegacyPptRc4CryptoApi.EncryptPackage(plainBytes, password,
                 options?.LegacyPptEncryptionKeySizeBits ?? 128,
-                options?.LegacyPptEncryptDocumentProperties ?? true);
+                options?.LegacyPptEncryptDocumentProperties ?? true,
+                options?.LegacyPptAllowUnencryptedCompoundStreams == true);
         }
 
         private static void EnsureDestinationFileWritable(string filePath) {

--- a/OfficeIMO.PowerPoint/PowerPointSaveOptions.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSaveOptions.cs
@@ -24,5 +24,13 @@ namespace OfficeIMO.PowerPoint {
         /// document-property streams. The default is <see langword="true"/>.
         /// </summary>
         public bool LegacyPptEncryptDocumentProperties { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets whether legacy encrypted saves may retain compound
+        /// streams that the RC4 CryptoAPI format does not encrypt. The default
+        /// is <see langword="false"/> so password-protected output cannot
+        /// silently contain unknown clear-text payloads.
+        /// </summary>
+        public bool LegacyPptAllowUnencryptedCompoundStreams { get; set; }
     }
 }

--- a/OfficeIMO.Reader.Core/ReaderInputLimits.cs
+++ b/OfficeIMO.Reader.Core/ReaderInputLimits.cs
@@ -8,6 +8,8 @@ namespace OfficeIMO.Reader;
 /// Shared input-size guard helpers for reader adapters.
 /// </summary>
 public static class ReaderInputLimits {
+    private const long MaximumInMemorySnapshotBytes = 64L * 1024 * 1024;
+
     internal static MemoryStream CreateSnapshotStream(int initialCapacity = 0) {
         return new ReaderSnapshotStream(initialCapacity);
     }
@@ -97,7 +99,7 @@ public static class ReaderInputLimits {
             stream.Position = 0;
         }
 
-        var buffer = new ReaderSnapshotStream(0);
+        Stream buffer = CreateBoundedSnapshotBuffer(maxInputBytes);
         try {
             var chunk = new byte[64 * 1024];
             long totalBytes = 0;
@@ -152,7 +154,7 @@ public static class ReaderInputLimits {
             stream.Position = 0;
         }
 
-        var buffer = new ReaderSnapshotStream(0);
+        Stream buffer = CreateBoundedSnapshotBuffer(maxInputBytes);
         try {
             var chunk = new byte[64 * 1024];
             long totalBytes = 0;
@@ -177,6 +179,19 @@ public static class ReaderInputLimits {
 
         buffer.Position = 0;
         return buffer;
+    }
+
+    private static Stream CreateBoundedSnapshotBuffer(long? maxInputBytes) {
+        if (maxInputBytes.HasValue
+            && maxInputBytes.Value <= MaximumInMemorySnapshotBytes) {
+            return new ReaderSnapshotStream(0);
+        }
+
+        string path = Path.Combine(Path.GetTempPath(),
+            "officeimo-reader-" + Guid.NewGuid().ToString("N") + ".tmp");
+        return new FileStream(path, FileMode.CreateNew, FileAccess.ReadWrite,
+            FileShare.Read, 64 * 1024,
+            FileOptions.DeleteOnClose | FileOptions.SequentialScan);
     }
 
     private sealed class ReaderSnapshotStream : MemoryStream {

--- a/OfficeIMO.Reader.Core/ReaderInputLimits.cs
+++ b/OfficeIMO.Reader.Core/ReaderInputLimits.cs
@@ -15,7 +15,8 @@ public static class ReaderInputLimits {
     }
 
     internal static bool IsSnapshotStream(Stream stream) {
-        return stream is ReaderSnapshotStream;
+        return stream is ReaderSnapshotStream
+            || stream is ReaderSnapshotFileStream;
     }
 
     /// <summary>
@@ -84,7 +85,7 @@ public static class ReaderInputLimits {
         if (stream == null) throw new ArgumentNullException(nameof(stream));
         if (!stream.CanRead) throw new ArgumentException("Stream must be readable.", nameof(stream));
 
-        if (stream is ReaderSnapshotStream) {
+        if (IsSnapshotStream(stream)) {
             EnforceSeekableStreamSize(stream, maxInputBytes);
             stream.Position = 0;
             ownsStream = false;
@@ -140,7 +141,7 @@ public static class ReaderInputLimits {
         if (!stream.CanRead) throw new ArgumentException("Stream must be readable.", nameof(stream));
 
         cancellationToken.ThrowIfCancellationRequested();
-        if (stream is ReaderSnapshotStream) {
+        if (IsSnapshotStream(stream)) {
             EnforceSeekableStreamSize(stream, maxInputBytes);
             stream.Position = 0;
             return stream;
@@ -189,13 +190,19 @@ public static class ReaderInputLimits {
 
         string path = Path.Combine(Path.GetTempPath(),
             "officeimo-reader-" + Guid.NewGuid().ToString("N") + ".tmp");
-        return new FileStream(path, FileMode.CreateNew, FileAccess.ReadWrite,
-            FileShare.Read, 64 * 1024,
-            FileOptions.DeleteOnClose | FileOptions.SequentialScan);
+        return new ReaderSnapshotFileStream(path);
     }
 
     private sealed class ReaderSnapshotStream : MemoryStream {
         internal ReaderSnapshotStream(int initialCapacity) : base(initialCapacity) {
+        }
+    }
+
+    private sealed class ReaderSnapshotFileStream : FileStream {
+        internal ReaderSnapshotFileStream(string path) : base(path,
+            FileMode.CreateNew, FileAccess.ReadWrite, FileShare.Read,
+            64 * 1024,
+            FileOptions.DeleteOnClose | FileOptions.SequentialScan) {
         }
     }
 }

--- a/OfficeIMO.Reader.Email/EmailAddressBookEntryReader.cs
+++ b/OfficeIMO.Reader.Email/EmailAddressBookEntryReader.cs
@@ -63,9 +63,12 @@ public static class EmailAddressBookEntryReader {
             ReaderEmailAddressBookOptionsCloner.CreateEffective(adapterOptions, readerOptions);
         Stream parseStream;
         bool ownsParseStream;
+        long? originalPosition = null;
         if (stream.CanSeek) {
             ReaderInputLimits.EnforceSeekableStreamSize(stream,
                 effective.MaxInputBytes);
+            originalPosition = stream.Position;
+            stream.Position = 0;
             parseStream = stream;
             ownsParseStream = false;
         } else {
@@ -82,7 +85,11 @@ public static class EmailAddressBookEntryReader {
                 }
             }
         } finally {
-            if (ownsParseStream) parseStream.Dispose();
+            if (ownsParseStream) {
+                parseStream.Dispose();
+            } else if (originalPosition.HasValue && stream.CanSeek) {
+                stream.Position = originalPosition.Value;
+            }
         }
     }
 

--- a/OfficeIMO.Reader.Email/EmailAddressBookEntryReader.cs
+++ b/OfficeIMO.Reader.Email/EmailAddressBookEntryReader.cs
@@ -61,8 +61,18 @@ public static class EmailAddressBookEntryReader {
         ReaderEmailAddressBookOptions adapterOptions, CancellationToken cancellationToken) {
         OfflineAddressBookReaderOptions effective =
             ReaderEmailAddressBookOptionsCloner.CreateEffective(adapterOptions, readerOptions);
-        Stream parseStream = ReaderInputLimits.EnsureSeekableReadStream(
-            stream, effective.MaxInputBytes, cancellationToken, out bool ownsParseStream);
+        Stream parseStream;
+        bool ownsParseStream;
+        if (stream.CanSeek) {
+            ReaderInputLimits.EnforceSeekableStreamSize(stream,
+                effective.MaxInputBytes);
+            parseStream = stream;
+            ownsParseStream = false;
+        } else {
+            parseStream = ReaderInputLimits.EnsureSeekableReadStream(
+                stream, effective.MaxInputBytes, cancellationToken,
+                out ownsParseStream);
+        }
         try {
             using (OfflineAddressBookSession session = OfflineAddressBookSession.Open(
                 parseStream, sourceName, effective, cancellationToken)) {

--- a/OfficeIMO.Reader.Tests/Reader.InputLimits.cs
+++ b/OfficeIMO.Reader.Tests/Reader.InputLimits.cs
@@ -1,0 +1,27 @@
+using OfficeIMO.Reader;
+using System.Threading;
+using Xunit;
+
+namespace OfficeIMO.Reader.Tests;
+
+public sealed class ReaderInputLimitTests {
+    [Fact]
+    public void LargeSnapshotBudgetsUseDeleteOnCloseTemporaryStorage() {
+        byte[] payload = System.Text.Encoding.UTF8.GetBytes(
+            "bounded temporary snapshot");
+        using var source = new MemoryStream(payload, writable: false);
+        Stream prepared = ReaderInputLimits.EnsureSeekableReadStream(
+            source,
+            maxInputBytes: 64L * 1024 * 1024 + 1,
+            CancellationToken.None,
+            out bool ownsStream);
+        using (prepared) {
+            Assert.True(ownsStream);
+            Assert.IsType<FileStream>(prepared);
+            Assert.False(ReaderInputLimits.IsSnapshotStream(prepared));
+            using var copy = new MemoryStream();
+            prepared.CopyTo(copy);
+            Assert.Equal(payload, copy.ToArray());
+        }
+    }
+}

--- a/OfficeIMO.Reader.Tests/Reader.InputLimits.cs
+++ b/OfficeIMO.Reader.Tests/Reader.InputLimits.cs
@@ -17,11 +17,20 @@ public sealed class ReaderInputLimitTests {
             out bool ownsStream);
         using (prepared) {
             Assert.True(ownsStream);
-            Assert.IsType<FileStream>(prepared);
-            Assert.False(ReaderInputLimits.IsSnapshotStream(prepared));
+            Assert.IsAssignableFrom<FileStream>(prepared);
+            Assert.True(ReaderInputLimits.IsSnapshotStream(prepared));
             using var copy = new MemoryStream();
             prepared.CopyTo(copy);
             Assert.Equal(payload, copy.ToArray());
+
+            Stream reused = ReaderInputLimits.EnsureSeekableReadStream(
+                prepared,
+                maxInputBytes: 64L * 1024 * 1024 + 1,
+                CancellationToken.None,
+                out bool ownsReused);
+            Assert.Same(prepared, reused);
+            Assert.False(ownsReused);
+            Assert.Equal(0, reused.Position);
         }
     }
 }


### PR DESCRIPTION
This batch closes 18 validated security findings across legacy PowerPoint and address-book Reader paths.

Key changes:
- cap master, connector, comment, PPT9, tab-stop, group, picture, sound, table-raster, and static-visual work before allocation or traversal
- replace repeated custom-show, connector, rich-text, theme, and background projection scans with indexed or digest-based state
- reject clear-text opaque streams during legacy encryption unless explicitly allowed
- require explicit loss-policy opt-in when an edited legacy deck would retain imported VBA, OLE, ActiveX, run-program, external-link, or external-media content
- read seekable OAB streams lazily and reuse file-backed Reader snapshots so large inputs do not multiply memory or temporary-disk use

Compatibility:
- exact no-op legacy saves remain byte-preserving
- adding, replacing, or removing VBA remains an explicit supported operation
- removing active actions is not blocked by the preservation gate
- callers can intentionally retain preserved active content with LossPolicy = Allow and can opt into clear-text opaque compound streams with LegacyPptAllowUnencryptedCompoundStreams

Validation:
- all PowerPoint and Reader.Core target frameworks build cleanly
- full net10 PowerPoint suite: 1,341 passed, 2 environment-dependent tests skipped
- focused OAB/session suite: 11 passed
- focused Reader snapshot and bypass regressions: 2 passed
- independent read-only security review found two bypasses; both were fixed and the targeted confirmation found no remaining issues