### PR TITLE
Bound resource use across legacy and conversion parsers

### DIFF
--- a/OfficeIMO.Drawing.Tests/Drawing.OfficeArtBinary.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.OfficeArtBinary.cs
@@ -6,6 +6,26 @@ namespace OfficeIMO.Tests;
 
 public partial class DrawingTests {
     [Fact]
+    public void OfficeArtShapeStyle_RejectsOversizedGradientStopTables() {
+        const int stopCount = 257;
+        byte[] data = new byte[6 + stopCount * 8];
+        data[0] = (byte)(stopCount & 0xff);
+        data[1] = (byte)(stopCount >> 8);
+        data[2] = (byte)(stopCount & 0xff);
+        data[3] = (byte)(stopCount >> 8);
+        data[4] = 8;
+        var property = new OfficeArtProperty(
+            0, 0x8197, (uint)data.Length,
+            availableComplexDataLength: data.Length,
+            complexData: data);
+
+        OfficeArtShapeStyle style = OfficeArtShapeStyle.Decode(new[] { property });
+
+        Assert.Empty(style.FillGradientStops);
+        Assert.True(style.IsFillGradientStopTableTruncated);
+    }
+
+    [Fact]
     public void OfficeArtPropertyTableReader_DecodesFixedAndComplexEntries() {
         byte[] payload = {
             0x81, 0x01, 0x33, 0x22, 0x11, 0x00,

--- a/OfficeIMO.Drawing/Binary/OfficeArtShapeStyle.cs
+++ b/OfficeIMO.Drawing/Binary/OfficeArtShapeStyle.cs
@@ -9,6 +9,8 @@ namespace OfficeIMO.Drawing.Binary;
 /// Numeric enum values remain available so application-specific projectors can map them without loss.
 /// </summary>
 public sealed class OfficeArtShapeStyle {
+    private const int MaximumGradientStops = 256;
+
     private OfficeArtShapeStyle(IReadOnlyList<OfficeArtProperty> properties) {
         Properties = properties?.ToArray() ?? Array.Empty<OfficeArtProperty>();
         FillType = GetUInt32(0x0180);
@@ -267,7 +269,8 @@ public sealed class OfficeArtShapeStyle {
         int count = ReadUInt16(data, 0);
         int allocated = ReadUInt16(data, 2);
         int elementSize = ReadUInt16(data, 4);
-        if (count > allocated || elementSize != 8 || count > (data.Length - 6) / 8) {
+        if (count > allocated || elementSize != 8 || count > (data.Length - 6) / 8
+            || count > MaximumGradientStops) {
             truncated = true;
             return Array.Empty<OfficeArtGradientStop>();
         }

--- a/OfficeIMO.Drawing/Documents/OfficePackagePayload.cs
+++ b/OfficeIMO.Drawing/Documents/OfficePackagePayload.cs
@@ -68,6 +68,9 @@ public sealed class OfficeEmbeddedPayloadInfo {
 
 /// <summary>Describes a VBA project embedded in an Office document.</summary>
 public sealed class OfficeVbaProjectInfo {
+    /// <summary>Default maximum VBA project bytes materialized by metadata inspection.</summary>
+    public const long DefaultMaximumProjectBytes = 64L * 1024L * 1024L;
+
     internal OfficeVbaProjectInfo(
         string partUri,
         string contentType,

--- a/OfficeIMO.Email.Tests/Store/Olm/OlmStoreReaderTests.cs
+++ b/OfficeIMO.Email.Tests/Store/Olm/OlmStoreReaderTests.cs
@@ -196,6 +196,31 @@ public sealed class OlmStoreReaderTests {
         Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "EMAIL_STORE_OLM_XML_INVALID");
     }
 
+    [Fact]
+    public void DecodedEntryStream_EnforcesActualEntryAndAggregateBytes() {
+        using (var entry = new OlmDecodedEntryStream(
+            new MemoryStream(new byte[6], writable: false), 5,
+            nameof(EmailStoreReaderOptions.MaxArchiveEntryBytes),
+            new OlmDecodedArchiveBudget(100))) {
+            EmailStoreLimitExceededException entryLimit =
+                Assert.Throws<EmailStoreLimitExceededException>(() =>
+                    entry.CopyTo(Stream.Null));
+            Assert.Equal(nameof(EmailStoreReaderOptions.MaxArchiveEntryBytes),
+                entryLimit.LimitName);
+        }
+
+        using (var entry = new OlmDecodedEntryStream(
+            new MemoryStream(new byte[6], writable: false), 100,
+            nameof(EmailStoreReaderOptions.MaxArchiveEntryBytes),
+            new OlmDecodedArchiveBudget(5))) {
+            EmailStoreLimitExceededException aggregateLimit =
+                Assert.Throws<EmailStoreLimitExceededException>(() =>
+                    entry.CopyTo(Stream.Null));
+            Assert.Equal(nameof(EmailStoreReaderOptions.MaxArchiveDecodedBytes),
+                aggregateLimit.LimitName);
+        }
+    }
+
     private static EmailStoreReadResult Read(byte[] archive, EmailStoreReaderOptions? options = null) {
         using (var stream = new MemoryStream(archive, writable: false)) {
             return new EmailStoreReader(options).Read(stream, "archive.olm");

--- a/OfficeIMO.Email.Tests/Store/Pst/PstNdbRandomAccessTests.cs
+++ b/OfficeIMO.Email.Tests/Store/Pst/PstNdbRandomAccessTests.cs
@@ -40,6 +40,26 @@ public sealed class PstNdbRandomAccessTests {
         Assert.Equal(4, reads);
     }
 
+    [Fact]
+    public void LazyOperationsShareOneTraversalBudget() {
+        using var stream = new MemoryStream(PstTestFileBuilder.Create());
+        PstHeader header = PstHeader.Read(stream, EmailStoreFormat.Pst);
+        var options = new EmailStoreReaderOptions(maxNodeCount: 6);
+        var reader = new PstNdbReader(stream, header, options,
+            System.Threading.CancellationToken.None);
+
+        EmailStoreLimitExceededException exception =
+            Assert.Throws<EmailStoreLimitExceededException>(() =>
+            {
+                for (int index = 0; index < 10; index++) {
+                    Assert.True(reader.TryGetNode(0x8004, out _));
+                }
+            });
+
+        Assert.Equal(nameof(EmailStoreReaderOptions.MaxNodeCount),
+            exception.LimitName);
+    }
+
     private static byte[] CreatePage(ref int reads, byte value) {
         reads++;
         return new[] { value };

--- a/OfficeIMO.Email.Tests/Store/Pst/PstReaderTests.cs
+++ b/OfficeIMO.Email.Tests/Store/Pst/PstReaderTests.cs
@@ -117,6 +117,35 @@ public sealed class PstReaderTests {
     }
 
     [Fact]
+    public void EmbeddedPstObjectMetadataDoesNotReserveUndecodedPayloadBytes() {
+        using var stream = new MemoryStream(PstTestFileBuilder.Create(includeEmbeddedMessage: true));
+        var options = new EmailStoreReaderOptions(
+            maxAttachmentBytes: 16,
+            maxTotalAttachmentBytes: 16);
+        using EmailStoreSession session = EmailStoreSession.Open(stream, "mailbox.pst", options);
+        EmailStoreItemReference reference = Assert.Single(session.EnumerateItems());
+
+        EmailStoreItem item = session.ReadItem(reference,
+            new EmailStoreItemReadOptions(EmailStoreItemReadParts.AttachmentMetadata));
+
+        EmailAttachment attachment = Assert.Single(item.Document.Attachments);
+        Assert.Equal(5, attachment.MapiAttachMethod);
+        Assert.Null(attachment.EmbeddedDocument);
+    }
+
+    [Fact]
+    public void StoreProjectionOptionsPreserveSelectiveDecodedPropertyLimit() {
+        var storeOptions = new EmailStoreReaderOptions(maxDecodedPropertyBytesPerItem: 4_096);
+
+        EmailReaderOptions projectionOptions = EmailStoreMessageReader.CreateOptions(
+            storeOptions,
+            includeAttachmentContent: false,
+            maxDecodedPropertyBytes: 128);
+
+        Assert.Equal(128, projectionOptions.MaxDecodedPropertyBytes);
+    }
+
+    [Fact]
     public void PreservesEmbeddedAttachmentMetadataWhenDepthLimitIsZero() {
         using var stream = new MemoryStream(PstTestFileBuilder.Create(includeEmbeddedMessage: true));
         var reader = new EmailStoreReader(new EmailStoreReaderOptions(maxNestedMessageDepth: 0));

--- a/OfficeIMO.Email.Tests/Store/Pst/PstReaderTests.cs
+++ b/OfficeIMO.Email.Tests/Store/Pst/PstReaderTests.cs
@@ -117,6 +117,19 @@ public sealed class PstReaderTests {
     }
 
     [Fact]
+    public void ExhaustedEmbeddedPstObjectBudgetReportsTheAttachmentLimit() {
+        var budget = new PstDecodedObjectBudget(16);
+        budget.Add(16);
+
+        EmailStoreLimitExceededException exception = Assert.Throws<EmailStoreLimitExceededException>(() =>
+            PstStoreReader.GetEmbeddedMessageMaximumDecodedBytes(128, budget, 16));
+
+        Assert.Equal(nameof(EmailStoreReaderOptions.MaxAttachmentBytes), exception.LimitName);
+        Assert.Equal(17, exception.Actual);
+        Assert.Equal(16, exception.Maximum);
+    }
+
+    [Fact]
     public void EmbeddedPstObjectMetadataDoesNotReserveUndecodedPayloadBytes() {
         using var stream = new MemoryStream(PstTestFileBuilder.Create(includeEmbeddedMessage: true));
         var options = new EmailStoreReaderOptions(

--- a/OfficeIMO.Email.Tests/Store/Pst/PstReaderTests.cs
+++ b/OfficeIMO.Email.Tests/Store/Pst/PstReaderTests.cs
@@ -98,10 +98,22 @@ public sealed class PstReaderTests {
         Assert.Equal(5, attachment.MapiAttachMethod);
         Assert.Equal("forwarded.msg", attachment.FileName);
         Assert.Null(attachment.Content);
-        Assert.Equal(0, attachment.Length);
+        Assert.True(attachment.Length > 0);
         Assert.NotNull(attachment.EmbeddedDocument);
         Assert.Equal("Embedded PST message", attachment.EmbeddedDocument!.Subject);
         Assert.Equal("Body from the embedded PST item", attachment.EmbeddedDocument.Body.Text);
+    }
+
+    [Fact]
+    public void EmbeddedPstObjectAttachmentsHonorAttachmentByteLimit() {
+        using var stream = new MemoryStream(PstTestFileBuilder.Create(
+            includeEmbeddedMessage: true));
+        var reader = new EmailStoreReader(new EmailStoreReaderOptions(
+            maxAttachmentBytes: 16,
+            maxTotalAttachmentBytes: 1024));
+
+        Assert.Throws<EmailStoreLimitExceededException>(() =>
+            reader.Read(stream, "mailbox.pst"));
     }
 
     [Fact]

--- a/OfficeIMO.Email.Tests/Store/Pst/PstWriterTableTests.cs
+++ b/OfficeIMO.Email.Tests/Store/Pst/PstWriterTableTests.cs
@@ -6,6 +6,16 @@ namespace OfficeIMO.Email.Store.Tests;
 
 public sealed class PstWriterTableTests {
     [Fact]
+    public void Folder_table_row_matrix_uses_the_table_budget_by_default() {
+        var options = new EmailStoreReaderOptions(
+            maxDecodedPropertyBytesPerItem: 128,
+            maxDecodedTableBytes: 4096);
+
+        Assert.Equal(4096, PstTableContextReader.GetMaximumRowMatrixBytes(options, null));
+        Assert.Equal(64, PstTableContextReader.GetMaximumRowMatrixBytes(options, 64));
+    }
+
+    [Fact]
     public void Multi_block_heap_and_row_index_round_trip_more_than_one_thousand_rows() {
         string path = Path.Combine(Path.GetTempPath(),
             string.Concat("officeimo-pst-table-", Guid.NewGuid().ToString("N"), ".pst"));

--- a/OfficeIMO.Email/Store/Olm/OlmDecodedArchiveBudget.cs
+++ b/OfficeIMO.Email/Store/Olm/OlmDecodedArchiveBudget.cs
@@ -1,0 +1,90 @@
+namespace OfficeIMO.Email.Store;
+
+/// <summary>Counts bytes actually produced by OLM ZIP decompression.</summary>
+internal sealed class OlmDecodedArchiveBudget {
+    private readonly long _maximumBytes;
+    private readonly object _gate = new object();
+    private long _decodedBytes;
+
+    internal OlmDecodedArchiveBudget(long maximumBytes) {
+        if (maximumBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maximumBytes));
+        _maximumBytes = maximumBytes;
+    }
+
+    internal void Add(long bytes) {
+        if (bytes < 0) throw new ArgumentOutOfRangeException(nameof(bytes));
+        if (bytes == 0) return;
+        lock (_gate) {
+            if (bytes > _maximumBytes - _decodedBytes) {
+                long actual = bytes > long.MaxValue - _decodedBytes
+                    ? long.MaxValue
+                    : _decodedBytes + bytes;
+                throw new EmailStoreLimitExceededException(
+                    nameof(EmailStoreReaderOptions.MaxArchiveDecodedBytes),
+                    actual, _maximumBytes);
+            }
+            _decodedBytes += bytes;
+        }
+    }
+}
+
+/// <summary>Bounds one decoded ZIP entry while charging a read-wide aggregate budget.</summary>
+internal sealed class OlmDecodedEntryStream : Stream {
+    private readonly Stream _inner;
+    private readonly long _maximumBytes;
+    private readonly string _limitName;
+    private readonly OlmDecodedArchiveBudget _aggregateBudget;
+    private long _decodedBytes;
+
+    internal OlmDecodedEntryStream(Stream inner, long maximumBytes,
+        string limitName, OlmDecodedArchiveBudget aggregateBudget) {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        if (maximumBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maximumBytes));
+        _maximumBytes = maximumBytes;
+        _limitName = limitName ?? throw new ArgumentNullException(nameof(limitName));
+        _aggregateBudget = aggregateBudget ?? throw new ArgumentNullException(nameof(aggregateBudget));
+    }
+
+    public override bool CanRead => _inner.CanRead;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotSupportedException();
+    public override long Position {
+        get => _decodedBytes;
+        set => throw new NotSupportedException();
+    }
+
+    public override int Read(byte[] buffer, int offset, int count) =>
+        Count(_inner.Read(buffer, offset, count));
+
+    public override int ReadByte() {
+        int value = _inner.ReadByte();
+        if (value >= 0) Count(1);
+        return value;
+    }
+
+    protected override void Dispose(bool disposing) {
+        if (disposing) _inner.Dispose();
+        base.Dispose(disposing);
+    }
+
+    private int Count(int bytes) {
+        if (bytes <= 0) return bytes;
+        if (bytes > _maximumBytes - _decodedBytes) {
+            long actual = bytes > long.MaxValue - _decodedBytes
+                ? long.MaxValue
+                : _decodedBytes + bytes;
+            throw new EmailStoreLimitExceededException(
+                _limitName,
+                actual, _maximumBytes);
+        }
+        _decodedBytes += bytes;
+        _aggregateBudget.Add(bytes);
+        return bytes;
+    }
+
+    public override void Flush() => throw new NotSupportedException();
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+}

--- a/OfficeIMO.Email/Store/Olm/OlmStoreReader.Items.cs
+++ b/OfficeIMO.Email/Store/Olm/OlmStoreReader.Items.cs
@@ -269,28 +269,38 @@ internal sealed partial class OlmStoreReader {
         }
         _totalAttachmentBytes = AddBounded(_totalAttachmentBytes, attachment.Length,
             nameof(EmailStoreReaderOptions.MaxTotalAttachmentBytes), _options.MaxTotalAttachmentBytes);
-        if (_options.RetainAttachmentContent) attachment.Content = ReadEntryBytes(entry);
+        if (_options.RetainAttachmentContent) {
+            byte[] content = ReadEntryBytes(entry);
+            if (content.LongLength > attachment.Length) {
+                _totalAttachmentBytes = AddBounded(
+                    _totalAttachmentBytes, content.LongLength - attachment.Length,
+                    nameof(EmailStoreReaderOptions.MaxTotalAttachmentBytes),
+                    _options.MaxTotalAttachmentBytes);
+            }
+            attachment.Length = content.LongLength;
+            attachment.Content = content;
+        }
     }
 
     private byte[] ReadEntryBytes(ZipArchiveEntry entry) {
-        if (entry.Length > int.MaxValue) {
+        long maximumBytes = Math.Min(_options.MaxAttachmentBytes, int.MaxValue);
+        if (entry.Length > maximumBytes) {
             throw new EmailStoreLimitExceededException(nameof(EmailStoreReaderOptions.MaxAttachmentBytes),
-                entry.Length, Math.Min(_options.MaxAttachmentBytes, int.MaxValue));
+                entry.Length, maximumBytes);
         }
-        var data = new byte[(int)entry.Length];
-        int offset = 0;
-        using (Stream stream = entry.Open()) {
-            while (offset < data.Length) {
+        using (Stream stream = OpenDecodedEntry(entry, maximumBytes,
+            nameof(EmailStoreReaderOptions.MaxAttachmentBytes)))
+        using (var output = new MemoryStream(
+            entry.Length > 0 ? checked((int)entry.Length) : 0)) {
+            var buffer = new byte[81920];
+            while (true) {
                 _cancellationToken.ThrowIfCancellationRequested();
-                int read = stream.Read(data, offset, data.Length - offset);
-                if (read == 0) throw new InvalidDataException("An OLM archive entry ended before its declared length.");
-                offset += read;
+                int read = stream.Read(buffer, 0, buffer.Length);
+                if (read == 0) break;
+                output.Write(buffer, 0, read);
             }
-            if (stream.ReadByte() >= 0) {
-                throw new InvalidDataException("An OLM archive entry exceeds its declared length.");
-            }
+            return output.ToArray();
         }
-        return data;
     }
 
     private static void AddRecipients(EmailDocument document, XElement item,

--- a/OfficeIMO.Email/Store/Olm/OlmStoreReader.cs
+++ b/OfficeIMO.Email/Store/Olm/OlmStoreReader.cs
@@ -17,6 +17,7 @@ internal sealed partial class OlmStoreReader {
     private CancellationToken _cancellationToken;
     private int _itemCount;
     private long _totalAttachmentBytes;
+    private OlmDecodedArchiveBudget _decodedArchiveBudget = null!;
 
     internal OlmStoreReader(EmailStoreReaderOptions options) {
         _options = options ?? throw new ArgumentNullException(nameof(options));
@@ -24,6 +25,7 @@ internal sealed partial class OlmStoreReader {
 
     internal EmailStoreReadResult Read(Stream stream, string? sourceName, CancellationToken cancellationToken) {
         _cancellationToken = cancellationToken;
+        _decodedArchiveBudget = new OlmDecodedArchiveBudget(_options.MaxArchiveDecodedBytes);
         _store = new EmailStore {
             Format = EmailStoreFormat.Olm,
             DisplayName = GetDisplayName(sourceName)
@@ -158,11 +160,15 @@ internal sealed partial class OlmStoreReader {
             MaxCharactersFromEntities = 0,
             IgnoreComments = true
         };
-        using (Stream stream = entry.Open())
+        using (Stream stream = OpenDecodedEntry(entry, _options.MaxArchiveEntryBytes))
         using (XmlReader reader = XmlReader.Create(stream, settings)) {
             return XDocument.Load(reader, LoadOptions.None);
         }
     }
+
+    private Stream OpenDecodedEntry(ZipArchiveEntry entry, long maximumBytes,
+        string limitName = nameof(EmailStoreReaderOptions.MaxArchiveEntryBytes)) =>
+        new OlmDecodedEntryStream(entry.Open(), maximumBytes, limitName, _decodedArchiveBudget);
 
     private EmailStoreFolder GetOrCreateFolder(string path) {
         string normalized = NormalizeSlashes(path).Trim('/');

--- a/OfficeIMO.Email/Store/Pst/PstDecodedObjectBudget.cs
+++ b/OfficeIMO.Email/Store/Pst/PstDecodedObjectBudget.cs
@@ -1,0 +1,45 @@
+using OfficeIMO.Email;
+
+namespace OfficeIMO.Email.Store;
+
+/// <summary>Tracks all materialized data that belongs to one embedded PST message object.</summary>
+internal sealed class PstDecodedObjectBudget {
+    private readonly long _maximumBytes;
+
+    internal PstDecodedObjectBudget(long maximumBytes) {
+        if (maximumBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maximumBytes));
+        _maximumBytes = maximumBytes;
+    }
+
+    internal long ConsumedBytes { get; private set; }
+
+    internal long RemainingBytes => _maximumBytes - ConsumedBytes;
+
+    internal void Add(long bytes) {
+        if (bytes < 0) throw new ArgumentOutOfRangeException(nameof(bytes));
+        if (bytes > RemainingBytes) {
+            long actual = bytes > long.MaxValue - ConsumedBytes
+                ? long.MaxValue
+                : ConsumedBytes + bytes;
+            throw new EmailStoreLimitExceededException(
+                nameof(EmailStoreReaderOptions.MaxAttachmentBytes),
+                actual,
+                _maximumBytes);
+        }
+        ConsumedBytes += bytes;
+    }
+
+    internal void AddProperties(IEnumerable<MapiProperty> properties) {
+        foreach (MapiProperty property in properties) Add(property.RawData?.LongLength ?? 0);
+    }
+
+    internal void AddProjectedBodies(EmailDocument document) {
+        AddString(document.Body.Text);
+        AddString(document.Body.Html);
+        AddString(document.Body.Rtf);
+    }
+
+    private void AddString(string? value) {
+        if (!string.IsNullOrEmpty(value)) Add(checked((long)value!.Length * sizeof(char)));
+    }
+}

--- a/OfficeIMO.Email/Store/Pst/PstNdbReader.cs
+++ b/OfficeIMO.Email/Store/Pst/PstNdbReader.cs
@@ -8,6 +8,7 @@ internal sealed partial class PstNdbReader {
     private readonly Dictionary<ulong, PstBlockReference> _blocks = new Dictionary<ulong, PstBlockReference>();
     private readonly Dictionary<uint, PstNodeReference> _nodes = new Dictionary<uint, PstNodeReference>();
     private readonly PstPageCache _pageCache;
+    private readonly PstTraversalCounter _traversalCounter;
     private bool _indexesLoaded;
 
     internal PstNdbReader(Stream stream, PstHeader header, EmailStoreReaderOptions options,
@@ -17,6 +18,7 @@ internal sealed partial class PstNdbReader {
         _options = options;
         _cancellationToken = cancellationToken;
         _pageCache = new PstPageCache(options.MaxCachedBTreePages);
+        _traversalCounter = new PstTraversalCounter(options.MaxNodeCount);
     }
 
     internal IReadOnlyDictionary<uint, PstNodeReference> Nodes => _indexesLoaded
@@ -397,7 +399,8 @@ internal sealed partial class PstNdbReader {
 
     private PstTraversalBudget CreateBudget(CancellationToken cancellationToken = default) =>
         new PstTraversalBudget(_options,
-            cancellationToken.CanBeCanceled ? cancellationToken : _cancellationToken);
+            cancellationToken.CanBeCanceled ? cancellationToken : _cancellationToken,
+            _traversalCounter);
 
     private sealed class PstBTreePage {
         internal PstBTreePage(byte[] bytes, int count, int entrySize, int level) {
@@ -416,11 +419,14 @@ internal sealed partial class PstNdbReader {
     private sealed class PstTraversalBudget {
         private readonly EmailStoreReaderOptions _options;
         private readonly CancellationToken _cancellationToken;
-        private int _visitedStructures;
+        private readonly PstTraversalCounter _counter;
 
-        internal PstTraversalBudget(EmailStoreReaderOptions options, CancellationToken cancellationToken) {
+        internal PstTraversalBudget(EmailStoreReaderOptions options,
+            CancellationToken cancellationToken,
+            PstTraversalCounter counter) {
             _options = options;
             _cancellationToken = cancellationToken;
+            _counter = counter;
         }
 
         internal void CheckDepth(int depth) {
@@ -433,10 +439,24 @@ internal sealed partial class PstNdbReader {
 
         internal void CountStructure() {
             _cancellationToken.ThrowIfCancellationRequested();
-            _visitedStructures++;
-            if (_visitedStructures > _options.MaxNodeCount) {
-                throw new EmailStoreLimitExceededException(nameof(EmailStoreReaderOptions.MaxNodeCount),
-                    _visitedStructures, _options.MaxNodeCount);
+            _counter.Count();
+        }
+    }
+
+    private sealed class PstTraversalCounter {
+        private readonly int _maximumStructures;
+        private int _visitedStructures;
+
+        internal PstTraversalCounter(int maximumStructures) {
+            _maximumStructures = maximumStructures;
+        }
+
+        internal void Count() {
+            int observed = Interlocked.Increment(ref _visitedStructures);
+            if (observed > _maximumStructures) {
+                throw new EmailStoreLimitExceededException(
+                    nameof(EmailStoreReaderOptions.MaxNodeCount),
+                    observed, _maximumStructures);
             }
         }
     }

--- a/OfficeIMO.Email/Store/Pst/PstStoreReader.Messages.cs
+++ b/OfficeIMO.Email/Store/Pst/PstStoreReader.Messages.cs
@@ -136,12 +136,18 @@ internal sealed partial class PstStoreReader {
                 EmailStoreItemReadParts.ExtendedMapiProperties)
                 ? null
                 : AttachmentMetadataPropertyIds;
+            long? maximumAttachmentMetadataBytes = decodedObjectBudget == null
+                ? null
+                : GetEmbeddedMessageMaximumDecodedBytes(
+                    decodedObjectBudget.RemainingBytes,
+                    decodedObjectBudget,
+                    _options.MaxAttachmentBytes);
             PstHeap heap = CreateHeap(attachmentNode.DataBid, attachmentNode.SubnodeBid,
-                attachmentSubnodes, decodedObjectBudget?.RemainingBytes);
+                attachmentSubnodes, maximumAttachmentMetadataBytes);
             IReadOnlyList<MapiProperty> attachmentProperties = ReadProperties(
                 heap, attachmentLocation, sourceHnids, includedPropertyIds,
                 DeferredAttachmentPropertyIds,
-                maximumDecodedBytes: decodedObjectBudget?.RemainingBytes);
+                maximumDecodedBytes: maximumAttachmentMetadataBytes);
             decodedObjectBudget?.AddProperties(attachmentProperties);
             long declaredLength = Math.Max(0,
                 attachmentProperties.GetNullableMapiValue(MapiKnownProperties.PidTag.AttachSize) ?? 0);

--- a/OfficeIMO.Email/Store/Pst/PstStoreReader.Messages.cs
+++ b/OfficeIMO.Email/Store/Pst/PstStoreReader.Messages.cs
@@ -116,8 +116,19 @@ internal sealed partial class PstStoreReader {
                 DeferredAttachmentPropertyIds);
             long declaredLength = Math.Max(0,
                 attachmentProperties.GetNullableMapiValue(MapiKnownProperties.PidTag.AttachSize) ?? 0);
+            MapiProperty? attachData = attachmentProperties.GetMapiProperty(
+                MapiKnownProperties.PidTag.AttachData);
+            if (attachData?.PropertyType == MapiPropertyType.Object &&
+                attachData.RawData != null && attachData.RawData.Length >= 8) {
+                declaredLength = Math.Max(declaredLength,
+                    PstBinary.UInt32(attachData.RawData, 4));
+            }
             EmailAttachment attachment = PstAttachmentProjection.Create(
                 attachmentProperties, declaredLength);
+
+            if (attachment.MapiAttachMethod == 5) {
+                ReserveEmbeddedAttachment(declaredLength);
+            }
 
             if (readOptions.Includes(EmailStoreItemReadParts.AttachmentContent) &&
                 attachment.MapiAttachMethod != 5 &&
@@ -176,6 +187,15 @@ internal sealed partial class PstStoreReader {
         _attachmentBudget = new PstAttachmentAggregateBudget(_options.MaxTotalAttachmentBytes);
     }
 
+    private void ReserveEmbeddedAttachment(long declaredLength) {
+        if (declaredLength > _options.MaxAttachmentBytes) {
+            throw new EmailStoreLimitExceededException(
+                nameof(EmailStoreReaderOptions.MaxAttachmentBytes),
+                declaredLength, _options.MaxAttachmentBytes);
+        }
+        if (declaredLength > 0) CountAttachmentBytes(declaredLength);
+    }
+
     private void TryReadEmbeddedMessage(EmailAttachment attachment,
         IReadOnlyDictionary<uint, PstSubnodeReference> attachmentSubnodes,
         IReadOnlyDictionary<ushort, uint> sourceHnids, EmailStoreFormat format,
@@ -195,9 +215,39 @@ internal sealed partial class PstStoreReader {
         }
 
         string embeddedId = FormatId(embeddedNode.Nid);
-        attachment.EmbeddedDocument = ReadItemDocument(
+        long maximumDecodedBytes = Math.Min(
+            readOptions.MaxDecodedPropertyBytes ?? _options.MaxDecodedPropertyBytesPerItem,
+            _options.MaxAttachmentBytes);
+        var embeddedReadOptions = new EmailStoreItemReadOptions(
+            readOptions.Parts, maximumDecodedBytes,
+            readOptions.PreferStreamingAttachmentContent);
+        EmailDocument embeddedDocument = ReadItemDocument(
             embeddedNode.DataBid, embeddedNode.SubnodeBid, embeddedId, folderId: null,
-            format, string.Concat(location, "/embedded/", embeddedId), nestedDepth + 1, readOptions);
+            format, string.Concat(location, "/embedded/", embeddedId), nestedDepth + 1,
+            embeddedReadOptions);
+        long observedBytes = CountDecodedPropertyBytes(embeddedDocument.MapiProperties,
+            _options.MaxAttachmentBytes);
+        if (observedBytes > attachment.Length) {
+            CountAttachmentBytes(observedBytes - attachment.Length);
+            attachment.Length = observedBytes;
+        }
+        attachment.EmbeddedDocument = embeddedDocument;
+    }
+
+    private static long CountDecodedPropertyBytes(
+        IEnumerable<MapiProperty> properties,
+        long maximumBytes) {
+        long total = 0;
+        foreach (MapiProperty property in properties) {
+            long length = property.RawData?.LongLength ?? 0;
+            if (length > maximumBytes - total) {
+                long actual = length > long.MaxValue - total ? long.MaxValue : total + length;
+                throw new EmailStoreLimitExceededException(
+                    nameof(EmailStoreReaderOptions.MaxAttachmentBytes), actual, maximumBytes);
+            }
+            total += length;
+        }
+        return total;
     }
 
     private void ProjectItem(EmailDocument document, IReadOnlyList<MapiProperty> properties, string location) {
@@ -205,6 +255,7 @@ internal sealed partial class PstStoreReader {
             properties.GetNullableMapiValue(MapiKnownProperties.PidTag.InternetCodepage) ??
             properties.GetNullableMapiValue(MapiKnownProperties.PidTag.CodePageId);
         EmailReadResult projection = EmailMapiProjection.Project(document, codePage, location: location,
+            options: EmailStoreMessageReader.CreateOptions(_options, includeAttachmentContent: false),
             cancellationToken: _cancellationToken);
         foreach (EmailDiagnostic diagnostic in projection.Diagnostics) {
             _diagnostics.Add(new EmailStoreDiagnostic(

--- a/OfficeIMO.Email/Store/Pst/PstStoreReader.Messages.cs
+++ b/OfficeIMO.Email/Store/Pst/PstStoreReader.Messages.cs
@@ -250,9 +250,10 @@ internal sealed partial class PstStoreReader {
         var decodedObjectBudget = parentDecodedObjectBudget ??
             new PstDecodedObjectBudget(_options.MaxAttachmentBytes);
         long bytesBefore = decodedObjectBudget.ConsumedBytes;
-        long maximumDecodedBytes = Math.Min(
+        long maximumDecodedBytes = GetEmbeddedMessageMaximumDecodedBytes(
             readOptions.MaxDecodedPropertyBytes ?? _options.MaxDecodedPropertyBytesPerItem,
-            decodedObjectBudget.RemainingBytes);
+            decodedObjectBudget,
+            _options.MaxAttachmentBytes);
         var embeddedReadOptions = new EmailStoreItemReadOptions(
             readOptions.Parts, maximumDecodedBytes,
             readOptions.PreferStreamingAttachmentContent);
@@ -266,6 +267,22 @@ internal sealed partial class PstStoreReader {
             attachment.Length = observedBytes;
         }
         attachment.EmbeddedDocument = embeddedDocument;
+    }
+
+    internal static long GetEmbeddedMessageMaximumDecodedBytes(
+        long requestedMaximum,
+        PstDecodedObjectBudget decodedObjectBudget,
+        long maximumAttachmentBytes) {
+        if (decodedObjectBudget.RemainingBytes <= 0) {
+            long actual = decodedObjectBudget.ConsumedBytes == long.MaxValue
+                ? long.MaxValue
+                : decodedObjectBudget.ConsumedBytes + 1L;
+            throw new EmailStoreLimitExceededException(
+                nameof(EmailStoreReaderOptions.MaxAttachmentBytes),
+                actual,
+                maximumAttachmentBytes);
+        }
+        return Math.Min(requestedMaximum, decodedObjectBudget.RemainingBytes);
     }
 
     private void ProjectItem(EmailDocument document, IReadOnlyList<MapiProperty> properties,

--- a/OfficeIMO.Email/Store/Pst/PstStoreReader.Messages.cs
+++ b/OfficeIMO.Email/Store/Pst/PstStoreReader.Messages.cs
@@ -90,10 +90,16 @@ internal sealed partial class PstStoreReader {
             .Where(item => item.Type == 0x12).OrderBy(item => item.Nid)) {
             string recipientLocation = string.Concat(location, "/recipients/", FormatId(recipientTable.Nid));
             try {
+                long? maximumRecipientBytes = decodedObjectBudget == null
+                    ? null
+                    : GetEmbeddedMessageMaximumDecodedBytes(
+                        _options.MaxDecodedPropertyBytesPerItem,
+                        decodedObjectBudget,
+                        _options.MaxAttachmentBytes);
                 foreach (EmailRecipient recipient in ReadRecipients(
                     recipientTable,
                     recipientLocation,
-                    decodedObjectBudget?.RemainingBytes)) {
+                    maximumRecipientBytes)) {
                     decodedObjectBudget?.AddProperties(recipient.MapiProperties);
                     document.Recipients.Add(recipient);
                 }

--- a/OfficeIMO.Email/Store/Pst/PstStoreReader.Messages.cs
+++ b/OfficeIMO.Email/Store/Pst/PstStoreReader.Messages.cs
@@ -31,13 +31,16 @@ internal sealed partial class PstStoreReader {
     }
 
     private EmailDocument ReadItemDocument(ulong dataBid, ulong subnodeBid, string id, string? folderId,
-        EmailStoreFormat format, string location, int nestedDepth, EmailStoreItemReadOptions options) {
+        EmailStoreFormat format, string location, int nestedDepth, EmailStoreItemReadOptions options,
+        PstDecodedObjectBudget? decodedObjectBudget = null) {
         IReadOnlyDictionary<uint, PstSubnodeReference> subnodes =
             Ndb.ReadSubnodes(subnodeBid, _cancellationToken);
         ISet<ushort>? includedPropertyIds = GetIncludedItemPropertyIds(options);
+        long maximumDecodedBytes = ResolveMaximumDecodedBytes(options, decodedObjectBudget);
         IReadOnlyList<MapiProperty> properties = ReadProperties(
             dataBid, subnodeBid, location, subnodes, includedPropertyIds: includedPropertyIds,
-            maximumDecodedBytes: options.MaxDecodedPropertyBytes);
+            maximumDecodedBytes: maximumDecodedBytes);
+        decodedObjectBudget?.AddProperties(properties);
         var document = new EmailDocument { Format = EmailFileFormat.Unknown };
         document.Properties["EmailStore:Format"] = format.ToString();
         document.Properties["EmailStore:ItemId"] = id;
@@ -45,13 +48,25 @@ internal sealed partial class PstStoreReader {
         foreach (MapiProperty property in properties) document.MapiProperties.Add(property);
 
         if (options.Includes(EmailStoreItemReadParts.Recipients)) {
-            ReadItemRecipients(document, subnodes, location);
+            ReadItemRecipients(document, subnodes, location, decodedObjectBudget);
         }
         if (options.Includes(EmailStoreItemReadParts.AttachmentMetadata)) {
-            ReadItemAttachments(document, subnodes, format, location, nestedDepth, options);
+            ReadItemAttachments(document, subnodes, format, location, nestedDepth, options,
+                decodedObjectBudget);
         }
-        if (options.Parts != EmailStoreItemReadParts.None) ProjectItem(document, properties, location);
+        if (options.Parts != EmailStoreItemReadParts.None) {
+            ProjectItem(document, properties, location,
+                ResolveMaximumDecodedBytes(options, decodedObjectBudget));
+            decodedObjectBudget?.AddProjectedBodies(document);
+        }
         return document;
+    }
+
+    private long ResolveMaximumDecodedBytes(
+        EmailStoreItemReadOptions options,
+        PstDecodedObjectBudget? decodedObjectBudget) {
+        long maximum = options.MaxDecodedPropertyBytes ?? _options.MaxDecodedPropertyBytesPerItem;
+        return decodedObjectBudget == null ? maximum : Math.Min(maximum, decodedObjectBudget.RemainingBytes);
     }
 
     private ISet<ushort>? GetIncludedItemPropertyIds(EmailStoreItemReadOptions options) {
@@ -69,12 +84,17 @@ internal sealed partial class PstStoreReader {
     }
 
     private void ReadItemRecipients(EmailDocument document,
-        IReadOnlyDictionary<uint, PstSubnodeReference> subnodes, string location) {
+        IReadOnlyDictionary<uint, PstSubnodeReference> subnodes, string location,
+        PstDecodedObjectBudget? decodedObjectBudget) {
         foreach (PstSubnodeReference recipientTable in subnodes.Values
             .Where(item => item.Type == 0x12).OrderBy(item => item.Nid)) {
             string recipientLocation = string.Concat(location, "/recipients/", FormatId(recipientTable.Nid));
             try {
-                foreach (EmailRecipient recipient in ReadRecipients(recipientTable, recipientLocation)) {
+                foreach (EmailRecipient recipient in ReadRecipients(
+                    recipientTable,
+                    recipientLocation,
+                    decodedObjectBudget?.RemainingBytes)) {
+                    decodedObjectBudget?.AddProperties(recipient.MapiProperties);
                     document.Recipients.Add(recipient);
                 }
             } catch (EmailStoreLimitExceededException) {
@@ -91,7 +111,8 @@ internal sealed partial class PstStoreReader {
 
     private void ReadItemAttachments(EmailDocument document,
         IReadOnlyDictionary<uint, PstSubnodeReference> subnodes, EmailStoreFormat format,
-        string location, int nestedDepth, EmailStoreItemReadOptions readOptions) {
+        string location, int nestedDepth, EmailStoreItemReadOptions readOptions,
+        PstDecodedObjectBudget? decodedObjectBudget) {
         int attachmentCount = 0;
         foreach (PstSubnodeReference attachmentNode in subnodes.Values
             .Where(item => item.Type == 0x05).OrderBy(item => item.Nid)) {
@@ -110,10 +131,12 @@ internal sealed partial class PstStoreReader {
                 ? null
                 : AttachmentMetadataPropertyIds;
             PstHeap heap = CreateHeap(attachmentNode.DataBid, attachmentNode.SubnodeBid,
-                attachmentSubnodes);
+                attachmentSubnodes, decodedObjectBudget?.RemainingBytes);
             IReadOnlyList<MapiProperty> attachmentProperties = ReadProperties(
                 heap, attachmentLocation, sourceHnids, includedPropertyIds,
-                DeferredAttachmentPropertyIds);
+                DeferredAttachmentPropertyIds,
+                maximumDecodedBytes: decodedObjectBudget?.RemainingBytes);
+            decodedObjectBudget?.AddProperties(attachmentProperties);
             long declaredLength = Math.Max(0,
                 attachmentProperties.GetNullableMapiValue(MapiKnownProperties.PidTag.AttachSize) ?? 0);
             MapiProperty? attachData = attachmentProperties.GetMapiProperty(
@@ -126,7 +149,8 @@ internal sealed partial class PstStoreReader {
             EmailAttachment attachment = PstAttachmentProjection.Create(
                 attachmentProperties, declaredLength);
 
-            if (attachment.MapiAttachMethod == 5) {
+            if (attachment.MapiAttachMethod == 5 &&
+                readOptions.Includes(EmailStoreItemReadParts.EmbeddedItems)) {
                 ReserveEmbeddedAttachment(declaredLength);
             }
 
@@ -135,11 +159,13 @@ internal sealed partial class PstStoreReader {
                 sourceHnids.TryGetValue(MapiKnownProperties.PidTag.AttachData.PropertyId!.Value,
                     out uint contentHnid)) {
                 ReadAttachmentContent(attachment, attachmentProperties, heap, contentHnid,
-                    declaredLength, readOptions.PreferStreamingAttachmentContent);
+                    declaredLength, readOptions.PreferStreamingAttachmentContent,
+                    decodedObjectBudget);
             }
             if (readOptions.Includes(EmailStoreItemReadParts.EmbeddedItems)) {
                 TryReadEmbeddedMessage(attachment, attachmentSubnodes, sourceHnids,
-                    format, attachmentLocation, nestedDepth, readOptions);
+                    format, attachmentLocation, nestedDepth, readOptions,
+                    decodedObjectBudget);
             }
             document.Attachments.Add(attachment);
         }
@@ -147,7 +173,8 @@ internal sealed partial class PstStoreReader {
 
     private void ReadAttachmentContent(EmailAttachment attachment,
         IReadOnlyList<MapiProperty> properties, PstHeap heap, uint contentHnid,
-        long declaredLength, bool preferStreaming) {
+        long declaredLength, bool preferStreaming,
+        PstDecodedObjectBudget? decodedObjectBudget) {
         if (declaredLength > _options.MaxAttachmentBytes) {
             throw new EmailStoreLimitExceededException(nameof(EmailStoreReaderOptions.MaxAttachmentBytes),
                 declaredLength, _options.MaxAttachmentBytes);
@@ -155,7 +182,10 @@ internal sealed partial class PstStoreReader {
         if (declaredLength > 0) CountAttachmentBytes(declaredLength);
 
         if (_options.RetainAttachmentContent && !preferStreaming) {
-            byte[] content = heap.ResolveHnid(contentHnid, _options.MaxAttachmentBytes);
+            long maximumContentBytes = decodedObjectBudget == null
+                ? _options.MaxAttachmentBytes
+                : Math.Min(_options.MaxAttachmentBytes, decodedObjectBudget.RemainingBytes);
+            byte[] content = heap.ResolveHnid(contentHnid, maximumContentBytes);
             if (content.LongLength > _options.MaxAttachmentBytes) {
                 throw new EmailStoreLimitExceededException(
                     nameof(EmailStoreReaderOptions.MaxAttachmentBytes),
@@ -165,6 +195,7 @@ internal sealed partial class PstStoreReader {
                 CountAttachmentBytes(content.LongLength - declaredLength);
             }
             attachment.Content = content;
+            decodedObjectBudget?.Add(content.LongLength);
             attachment.Length = content.LongLength;
             MapiProperty? contentProperty = properties.GetMapiProperty(MapiKnownProperties.PidTag.AttachData);
             if (contentProperty != null) {
@@ -199,7 +230,8 @@ internal sealed partial class PstStoreReader {
     private void TryReadEmbeddedMessage(EmailAttachment attachment,
         IReadOnlyDictionary<uint, PstSubnodeReference> attachmentSubnodes,
         IReadOnlyDictionary<ushort, uint> sourceHnids, EmailStoreFormat format,
-        string location, int nestedDepth, EmailStoreItemReadOptions readOptions) {
+        string location, int nestedDepth, EmailStoreItemReadOptions readOptions,
+        PstDecodedObjectBudget? parentDecodedObjectBudget) {
         if (attachment.MapiAttachMethod != 5 ||
             !sourceHnids.TryGetValue(MapiKnownProperties.PidTag.AttachData.GetStandardPropertyId(), out uint embeddedNid) ||
             (embeddedNid & 0x1F) == 0 ||
@@ -215,18 +247,20 @@ internal sealed partial class PstStoreReader {
         }
 
         string embeddedId = FormatId(embeddedNode.Nid);
+        var decodedObjectBudget = parentDecodedObjectBudget ??
+            new PstDecodedObjectBudget(_options.MaxAttachmentBytes);
+        long bytesBefore = decodedObjectBudget.ConsumedBytes;
         long maximumDecodedBytes = Math.Min(
             readOptions.MaxDecodedPropertyBytes ?? _options.MaxDecodedPropertyBytesPerItem,
-            _options.MaxAttachmentBytes);
+            decodedObjectBudget.RemainingBytes);
         var embeddedReadOptions = new EmailStoreItemReadOptions(
             readOptions.Parts, maximumDecodedBytes,
             readOptions.PreferStreamingAttachmentContent);
         EmailDocument embeddedDocument = ReadItemDocument(
             embeddedNode.DataBid, embeddedNode.SubnodeBid, embeddedId, folderId: null,
             format, string.Concat(location, "/embedded/", embeddedId), nestedDepth + 1,
-            embeddedReadOptions);
-        long observedBytes = CountDecodedPropertyBytes(embeddedDocument.MapiProperties,
-            _options.MaxAttachmentBytes);
+            embeddedReadOptions, decodedObjectBudget);
+        long observedBytes = decodedObjectBudget.ConsumedBytes - bytesBefore;
         if (observedBytes > attachment.Length) {
             CountAttachmentBytes(observedBytes - attachment.Length);
             attachment.Length = observedBytes;
@@ -234,28 +268,16 @@ internal sealed partial class PstStoreReader {
         attachment.EmbeddedDocument = embeddedDocument;
     }
 
-    private static long CountDecodedPropertyBytes(
-        IEnumerable<MapiProperty> properties,
-        long maximumBytes) {
-        long total = 0;
-        foreach (MapiProperty property in properties) {
-            long length = property.RawData?.LongLength ?? 0;
-            if (length > maximumBytes - total) {
-                long actual = length > long.MaxValue - total ? long.MaxValue : total + length;
-                throw new EmailStoreLimitExceededException(
-                    nameof(EmailStoreReaderOptions.MaxAttachmentBytes), actual, maximumBytes);
-            }
-            total += length;
-        }
-        return total;
-    }
-
-    private void ProjectItem(EmailDocument document, IReadOnlyList<MapiProperty> properties, string location) {
+    private void ProjectItem(EmailDocument document, IReadOnlyList<MapiProperty> properties,
+        string location, long? maximumDecodedBytes = null) {
         int? codePage = properties.GetNullableMapiValue(MapiKnownProperties.PidTag.MessageCodepage) ??
             properties.GetNullableMapiValue(MapiKnownProperties.PidTag.InternetCodepage) ??
             properties.GetNullableMapiValue(MapiKnownProperties.PidTag.CodePageId);
         EmailReadResult projection = EmailMapiProjection.Project(document, codePage, location: location,
-            options: EmailStoreMessageReader.CreateOptions(_options, includeAttachmentContent: false),
+            options: EmailStoreMessageReader.CreateOptions(
+                _options,
+                includeAttachmentContent: false,
+                maxDecodedPropertyBytes: maximumDecodedBytes),
             cancellationToken: _cancellationToken);
         foreach (EmailDiagnostic diagnostic in projection.Diagnostics) {
             _diagnostics.Add(new EmailStoreDiagnostic(
@@ -270,15 +292,18 @@ internal sealed partial class PstStoreReader {
         }
     }
 
-    private IReadOnlyList<EmailRecipient> ReadRecipients(PstSubnodeReference table, string location) {
+    private IReadOnlyList<EmailRecipient> ReadRecipients(PstSubnodeReference table, string location,
+        long? maximumDecodedBytes = null) {
+        long effectiveMaximum = maximumDecodedBytes ?? _options.MaxDecodedPropertyBytesPerItem;
         PstDataTree data = Ndb.ReadDataTree(
-            table.DataBid, _options.MaxDecodedPropertyBytesPerItem, _cancellationToken);
+            table.DataBid, effectiveMaximum, _cancellationToken);
         IReadOnlyDictionary<uint, PstSubnodeReference> subnodes =
             Ndb.ReadSubnodes(table.SubnodeBid, _cancellationToken);
         var heap = new PstHeap(data, subnodes, Ndb, _options, _cancellationToken);
         IReadOnlyList<IReadOnlyList<MapiProperty>> rows = new PstTableContextReader(
             heap, Ndb.IsUnicode, _options, _cancellationToken,
-            message => AddTableCellDiagnostic(message, location)).ReadRows();
+            message => AddTableCellDiagnostic(message, location),
+            effectiveMaximum).ReadRows();
         var recipients = new List<EmailRecipient>(rows.Count);
         foreach (IReadOnlyList<MapiProperty> row in rows) {
             _namedProperties.Apply(row);
@@ -315,7 +340,7 @@ internal sealed partial class PstStoreReader {
         try {
             IReadOnlyDictionary<uint, PstSubnodeReference> subnodes = knownSubnodes ??
                 Ndb.ReadSubnodes(subnodeBid, _cancellationToken);
-            PstHeap heap = CreateHeap(dataBid, subnodeBid, subnodes);
+            PstHeap heap = CreateHeap(dataBid, subnodeBid, subnodes, maximumDecodedBytes);
             return ReadProperties(heap, location, sourceHnids, includedPropertyIds,
                 deferredPropertyIds: null, applyNamedProperties: applyNamedProperties,
                 maximumDecodedBytes: maximumDecodedBytes);
@@ -332,9 +357,12 @@ internal sealed partial class PstStoreReader {
     }
 
     private PstHeap CreateHeap(ulong dataBid, ulong subnodeBid,
-        IReadOnlyDictionary<uint, PstSubnodeReference> subnodes) {
+        IReadOnlyDictionary<uint, PstSubnodeReference> subnodes,
+        long? maximumDecodedBytes = null) {
         PstDataTree data = Ndb.OpenDataTree(
-            dataBid, _options.MaxDecodedPropertyBytesPerItem, _cancellationToken);
+            dataBid,
+            maximumDecodedBytes ?? _options.MaxDecodedPropertyBytesPerItem,
+            _cancellationToken);
         return new PstHeap(data, subnodes, Ndb, _options, _cancellationToken);
     }
 

--- a/OfficeIMO.Email/Store/Pst/PstStoreReader.cs
+++ b/OfficeIMO.Email/Store/Pst/PstStoreReader.cs
@@ -37,6 +37,16 @@ internal sealed partial class PstStoreReader {
         MapiKnownProperties.PidTag.MessageCodepage);
     private static readonly ISet<ushort> DeferredAttachmentPropertyIds =
         PropertyIds(MapiKnownProperties.PidTag.AttachData);
+    private static readonly ISet<ushort> FolderPropertyIds = PropertyIds(
+        MapiKnownProperties.PidTag.DisplayName, MapiKnownProperties.PidTag.ContentCount,
+        MapiKnownProperties.PidTag.AssociatedContentCount, MapiKnownProperties.PidTag.ContainerClass,
+        MapiKnownProperties.PidTag.RecordKey,
+        MapiKnownProperties.PidTag.IpmAppointmentEntryId,
+        MapiKnownProperties.PidTag.IpmContactEntryId,
+        MapiKnownProperties.PidTag.IpmJournalEntryId,
+        MapiKnownProperties.PidTag.IpmNoteEntryId,
+        MapiKnownProperties.PidTag.IpmTaskEntryId,
+        MapiKnownProperties.PidTag.IpmDraftsEntryId);
     private readonly EmailStoreReaderOptions _options;
     private readonly EmailStoreSessionLifetime _lifetime;
     private readonly List<EmailStoreDiagnostic> _diagnostics = new List<EmailStoreDiagnostic>();
@@ -186,7 +196,8 @@ internal sealed partial class PstStoreReader {
             _cancellationToken.ThrowIfCancellationRequested();
             string location = string.Concat("folder/0x", node.Nid.ToString("X", CultureInfo.InvariantCulture));
             IReadOnlyList<MapiProperty> properties = ReadProperties(
-                node.DataBid, node.SubnodeBid, location);
+                node.DataBid, node.SubnodeBid, location,
+                includedPropertyIds: FolderPropertyIds);
             string name = properties.GetMapiValueOrDefault(MapiKnownProperties.PidTag.DisplayName) ??
                 string.Concat("Folder 0x", node.Nid.ToString("X", CultureInfo.InvariantCulture));
             string? parentId = node.ParentNid != node.Nid && folderIds.Contains(node.ParentNid)

--- a/OfficeIMO.Email/Store/Pst/PstTableContextReader.cs
+++ b/OfficeIMO.Email/Store/Pst/PstTableContextReader.cs
@@ -8,14 +8,17 @@ internal sealed class PstTableContextReader {
     private readonly EmailStoreReaderOptions _options;
     private readonly CancellationToken _cancellationToken;
     private readonly Action<string>? _reportCellWarning;
+    private readonly long _maximumDecodedPropertyBytes;
 
     internal PstTableContextReader(PstHeap heap, bool isUnicode, EmailStoreReaderOptions options,
-        CancellationToken cancellationToken, Action<string>? reportCellWarning = null) {
+        CancellationToken cancellationToken, Action<string>? reportCellWarning = null,
+        long? maximumDecodedPropertyBytes = null) {
         _heap = heap;
         _isUnicode = isUnicode;
         _options = options;
         _cancellationToken = cancellationToken;
         _reportCellWarning = reportCellWarning;
+        _maximumDecodedPropertyBytes = maximumDecodedPropertyBytes ?? options.MaxDecodedPropertyBytesPerItem;
     }
 
     internal IReadOnlyList<IReadOnlyList<MapiProperty>> ReadRows() => EnumerateRows().ToArray();
@@ -59,7 +62,8 @@ internal sealed class PstTableContextReader {
                 rowIndexHid, rowsHnid, "row-index", exception);
         }
         IEnumerable<byte[]> rowBlocks = _heap.EnumerateHnidBlocks(
-            rowsHnid, _options.MaxDecodedTableBytes);
+            rowsHnid, Math.Min(_options.MaxDecodedTableBytes, _maximumDecodedPropertyBytes));
+        long decodedBytes = 0;
         using (var cursor = new PstTableRowCursor(rowBlocks, rowSize)) {
             foreach (int rowIndex in rowIndexes.OrderBy(index => index)) {
                 _cancellationToken.ThrowIfCancellationRequested();
@@ -71,7 +75,6 @@ internal sealed class PstTableContextReader {
                         rowIndexHid, rowsHnid, "row-matrix", exception);
                 }
                 var properties = new List<MapiProperty>(columns.Count);
-                long decodedBytes = 0;
                 foreach (PstTableColumn column in columns) {
                     int existenceByte = row.Offset + existenceOffset + column.BitIndex / 8;
                     if (existenceByte >= row.Offset + row.Length ||
@@ -156,7 +159,7 @@ internal sealed class PstTableContextReader {
             default:
                 uint hnid = PstBinary.UInt32(row.Bytes, offset);
                 try {
-                    rawData = _heap.ResolveHnid(hnid, _options.MaxDecodedPropertyBytesPerItem);
+                    rawData = _heap.ResolveHnid(hnid, _maximumDecodedPropertyBytes);
                 } catch (InvalidDataException exception) {
                     _reportCellWarning?.Invoke(string.Concat(
                         "Table row ", rowIndex.ToString(CultureInfo.InvariantCulture),
@@ -168,10 +171,10 @@ internal sealed class PstTableContextReader {
                     return null;
                 }
                 decodedBytes = checked(decodedBytes + rawData.Length);
-                if (decodedBytes > _options.MaxDecodedPropertyBytesPerItem) {
+                if (decodedBytes > _maximumDecodedPropertyBytes) {
                     throw new EmailStoreLimitExceededException(
                         nameof(EmailStoreReaderOptions.MaxDecodedPropertyBytesPerItem), decodedBytes,
-                        _options.MaxDecodedPropertyBytesPerItem);
+                        _maximumDecodedPropertyBytes);
                 }
                 value = PstPropertyContextReader.DecodeVariable(type, rawData);
                 break;

--- a/OfficeIMO.Email/Store/Pst/PstTableContextReader.cs
+++ b/OfficeIMO.Email/Store/Pst/PstTableContextReader.cs
@@ -9,6 +9,7 @@ internal sealed class PstTableContextReader {
     private readonly CancellationToken _cancellationToken;
     private readonly Action<string>? _reportCellWarning;
     private readonly long _maximumDecodedPropertyBytes;
+    private readonly bool _hasMaximumDecodedPropertyBytesOverride;
 
     internal PstTableContextReader(PstHeap heap, bool isUnicode, EmailStoreReaderOptions options,
         CancellationToken cancellationToken, Action<string>? reportCellWarning = null,
@@ -18,6 +19,7 @@ internal sealed class PstTableContextReader {
         _options = options;
         _cancellationToken = cancellationToken;
         _reportCellWarning = reportCellWarning;
+        _hasMaximumDecodedPropertyBytesOverride = maximumDecodedPropertyBytes.HasValue;
         _maximumDecodedPropertyBytes = maximumDecodedPropertyBytes ?? options.MaxDecodedPropertyBytesPerItem;
     }
 
@@ -61,8 +63,10 @@ internal sealed class PstTableContextReader {
             throw CreateTableInfoException(info, columnCount, rowSize, existenceOffset,
                 rowIndexHid, rowsHnid, "row-index", exception);
         }
-        IEnumerable<byte[]> rowBlocks = _heap.EnumerateHnidBlocks(
-            rowsHnid, Math.Min(_options.MaxDecodedTableBytes, _maximumDecodedPropertyBytes));
+        long maximumRowMatrixBytes = GetMaximumRowMatrixBytes(
+            _options,
+            _hasMaximumDecodedPropertyBytesOverride ? _maximumDecodedPropertyBytes : null);
+        IEnumerable<byte[]> rowBlocks = _heap.EnumerateHnidBlocks(rowsHnid, maximumRowMatrixBytes);
         long decodedBytes = 0;
         using (var cursor = new PstTableRowCursor(rowBlocks, rowSize)) {
             foreach (int rowIndex in rowIndexes.OrderBy(index => index)) {
@@ -86,6 +90,13 @@ internal sealed class PstTableContextReader {
             }
         }
     }
+
+    internal static long GetMaximumRowMatrixBytes(
+        EmailStoreReaderOptions options,
+        long? maximumDecodedPropertyBytes) =>
+        maximumDecodedPropertyBytes.HasValue
+            ? Math.Min(options.MaxDecodedTableBytes, maximumDecodedPropertyBytes.Value)
+            : options.MaxDecodedTableBytes;
 
     private static InvalidDataException CreateTableInfoException(
         byte[] info, int columnCount, int rowSize, int existenceOffset,

--- a/OfficeIMO.Email/Store/Reading/EmailStoreMessageReader.cs
+++ b/OfficeIMO.Email/Store/Reading/EmailStoreMessageReader.cs
@@ -24,7 +24,8 @@ internal static class EmailStoreMessageReader {
     }
 
     internal static EmailReaderOptions CreateOptions(EmailStoreReaderOptions options,
-        bool? includeAttachmentContent = null) =>
+        bool? includeAttachmentContent = null,
+        long? maxDecodedPropertyBytes = null) =>
         new EmailReaderOptions(
             maxInputBytes: options.MaxMessageBytes,
             maxAttachmentBytes: options.MaxAttachmentBytes,
@@ -32,7 +33,7 @@ internal static class EmailStoreMessageReader {
             maxNestedMessageDepth: options.MaxNestedMessageDepth,
             includeAttachmentContent: includeAttachmentContent ?? options.RetainAttachmentContent,
             maxMapiPropertyCount: options.MaxPropertiesPerItem,
-            maxDecodedPropertyBytes: options.MaxDecodedPropertyBytesPerItem);
+            maxDecodedPropertyBytes: maxDecodedPropertyBytes ?? options.MaxDecodedPropertyBytesPerItem);
 
     private static EmailStoreLimitExceededException ConvertLimit(EmailLimitExceededException exception) {
         string name = exception.LimitName == nameof(EmailReaderOptions.MaxInputBytes)

--- a/OfficeIMO.Excel.Tests/Excel.LegacyXls.cs
+++ b/OfficeIMO.Excel.Tests/Excel.LegacyXls.cs
@@ -13,6 +13,16 @@ using Xunit;
 namespace OfficeIMO.Tests {
     public partial class Excel {
         [Fact]
+        public void LegacyXls_Load_RejectsNonPositiveDecodedImageBudget() {
+            byte[] workbookStream = LegacyXlsTestWorkbookBuilder.CreateMinimalWorkbookStream();
+            byte[] compound = LegacyXlsCompoundTestBuilder.CreateWorkbookCompoundFile(workbookStream);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                LegacyXlsWorkbook.Load(compound,
+                    new LegacyXlsImportOptions { MaxDecodedImageBytes = 0 }));
+        }
+
+        [Fact]
         public void LegacyXls_BiffRecordReader_ReadsRecordsAndReportsTruncation() {
             var diagnostics = new List<LegacyXlsImportDiagnostic>();
             byte[] bytes = {

--- a/OfficeIMO.Excel.Tests/Excel.PackagePayloads.cs
+++ b/OfficeIMO.Excel.Tests/Excel.PackagePayloads.cs
@@ -26,6 +26,9 @@ namespace OfficeIMO.Tests {
                     Assert.Equal(vbaProject.Length, info.Length);
                     Assert.Equal(64, info.Sha256!.Length);
                     Assert.Equal(new[] { "Module1", "ThisWorkbook" }, info.ModuleNames);
+                    Assert.Throws<InvalidDataException>(() =>
+                        document.InspectVbaProject(includeSha256: false,
+                            maxBytes: info.Length - 1));
                     Assert.Equal(vbaProject, document.ExtractMacros());
                     document.Save();
                 }

--- a/OfficeIMO.Excel.Tests/Excel.Xlsb.Foundation.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Xlsb.Foundation.cs
@@ -11,6 +11,13 @@ using Xunit;
 namespace OfficeIMO.Tests {
     public partial class Excel {
         [Fact]
+        public void Xlsb_DefaultRecordBudgetCanRepresentTheDefaultCellBudget() {
+            var options = new XlsbImportOptions();
+
+            Assert.True(options.MaxRecordCount > options.MaxCells);
+        }
+
+        [Fact]
         public void Xlsb_RecordReader_FramesCanonicalWorkbookBoundaryRecords() {
             byte[] bytes = {
                 0x83, 0x01, 0x00, // BrtBeginBook (131), empty payload

--- a/OfficeIMO.Excel.Tests/Excel.Xlsb.Foundation.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Xlsb.Foundation.cs
@@ -2,6 +2,7 @@ using OfficeIMO.Excel;
 using OfficeIMO.Excel.Xlsb.Biff12;
 using OfficeIMO.Excel.Xlsb.Package;
 using OfficeIMO.Excel.Xlsb;
+using OfficeIMO.Excel.Xlsb.Write;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System.IO.Compression;
 using System.Threading.Tasks;
@@ -114,6 +115,51 @@ namespace OfficeIMO.Tests {
                 XlsbRecordReader.ReadAll(stream, maxRecordBytes: 1));
 
             Assert.Contains("configured limit of 1 byte", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Xlsb_RecordReader_EnforcesWorkbookWideRecordBudget() {
+            byte[] bytes = {
+                0x83, 0x01, 0x00,
+                0x84, 0x01, 0x00
+            };
+            using var stream = new MemoryStream(bytes, writable: false);
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                XlsbRecordReader.ReadAll(stream, budget: new XlsbRecordReadBudget(1)));
+
+            Assert.Contains("BIFF12 records", exception.Message,
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Xlsb_FormulaEncoder_RejectsDeepControlFunctionNesting() {
+            string formula = "1";
+            for (int index = 0; index < 66; index++) {
+                formula = $"IF(TRUE,{formula},0)";
+            }
+
+            Assert.False(XlsbFormulaEncoder.TryEncode(
+                formula, out _, out string? reason));
+            Assert.Contains("nesting", reason, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Xlsb_WorkbookReader_EnforcesRowMetadataBudget() {
+            byte[] package;
+            using (ExcelDocument document = ExcelDocument.Create()) {
+                ExcelSheet sheet = document.AddWorksheet("Rows");
+                sheet.CellValue(1, 1, "one");
+                sheet.CellValue(2, 1, "two");
+                package = document.ToBytes(ExcelFileFormat.Xlsb);
+            }
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                XlsbWorkbookReader.Load(package,
+                    new XlsbImportOptions { MaxRowDefinitions = 1 }));
+
+            Assert.Contains("row definitions", exception.Message,
+                StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]

--- a/OfficeIMO.Excel.Tests/Excel.Xlsb.Foundation.cs
+++ b/OfficeIMO.Excel.Tests/Excel.Xlsb.Foundation.cs
@@ -145,6 +145,26 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Xlsb_FormulaEncoder_RejectsDeepLegacyParserNesting() {
+            string formula = new string('(', 65) + "1" + new string(')', 65);
+
+            Assert.False(XlsbFormulaEncoder.TryEncode(
+                formula, out _, out string? reason));
+            Assert.Contains("nesting", reason, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Xlsb_FormulaEncoder_RejectsExcessiveLegacyOperatorChains() {
+            string postfix = "1" + new string('%', 300);
+            string binary = string.Join("+", Enumerable.Repeat("1", 300));
+
+            Assert.False(XlsbFormulaEncoder.TryEncode(postfix, out _, out string? postfixReason));
+            Assert.False(XlsbFormulaEncoder.TryEncode(binary, out _, out string? binaryReason));
+            Assert.Contains("nesting", postfixReason, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("nesting", binaryReason, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
         public void Xlsb_WorkbookReader_EnforcesRowMetadataBudget() {
             byte[] package;
             using (ExcelDocument document = ExcelDocument.Create()) {

--- a/OfficeIMO.Excel/ExcelDocument.PackagePayloads.cs
+++ b/OfficeIMO.Excel/ExcelDocument.PackagePayloads.cs
@@ -11,9 +11,16 @@ namespace OfficeIMO.Excel {
 
         /// <summary>Inspects the attached VBA project without executing macro code.</summary>
         public OfficeVbaProjectInfo? InspectVbaProject(bool includeSha256 = false) {
+            return InspectVbaProject(includeSha256, OfficeVbaProjectInfo.DefaultMaximumProjectBytes);
+        }
+
+        /// <summary>Inspects the attached VBA project while enforcing a decoded byte limit.</summary>
+        public OfficeVbaProjectInfo? InspectVbaProject(bool includeSha256, long maxBytes) {
+            if (maxBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maxBytes));
             return Locking.ExecuteRead(EnsureLock(), () => {
                 VbaProjectPart? part = WorkbookPartRoot?.VbaProjectPart;
-                return part == null ? null : OfficeOpenXmlPackagePayload.CreateVbaProjectInfo(part, includeSha256);
+                return part == null ? null : OfficeOpenXmlPackagePayload.CreateVbaProjectInfo(
+                    part, includeSha256, maxBytes);
             });
         }
 

--- a/OfficeIMO.Excel/LegacyXls/Biff/BiffChartMetadataReader.cs
+++ b/OfficeIMO.Excel/LegacyXls/Biff/BiffChartMetadataReader.cs
@@ -10,7 +10,8 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             IReadOnlyList<BiffExternSheetReference>? externSheets = null,
             IReadOnlyList<LegacyXlsExternalReference>? externalReferences = null,
             IReadOnlyList<string>? sheetNames = null,
-            IReadOnlyList<string?>? definedNames = null) {
+            IReadOnlyList<string?>? definedNames = null,
+            LegacyXlsDecodedImageBudget? decodedImageBudget = null) {
             if (!BiffUnsupportedRecordDiagnostics.IsChartRecord(record.Type)) {
                 return false;
             }
@@ -67,7 +68,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             TryReadFutureBlock(record, out LegacyXlsChartFutureBlock? futureBlock);
             TryReadUnits(record, out LegacyXlsChartUnits? units);
             TryReadAxisExtension(record, out LegacyXlsChartAxisExtension? axisExtension);
-            TryReadGelFrame(record, out LegacyXlsChartGelFrame? gelFrame);
+            TryReadGelFrame(record, out LegacyXlsChartGelFrame? gelFrame, decodedImageBudget);
             records.Add(new LegacyXlsChartRecord(
                 GetKind(record.Type),
                 BiffUnsupportedRecordDiagnostics.GetBiffRecordName(record.Type),
@@ -694,7 +695,10 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             return true;
         }
 
-        private static bool TryReadGelFrame(BiffRecord record, out LegacyXlsChartGelFrame? gelFrame) {
+        private static bool TryReadGelFrame(
+            BiffRecord record,
+            out LegacyXlsChartGelFrame? gelFrame,
+            LegacyXlsDecodedImageBudget? decodedImageBudget) {
             gelFrame = null;
             if (record.Type != 0x1066 || record.Payload.Length < 8) {
                 return false;
@@ -710,7 +714,8 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                 out _,
                 out _,
                 out IReadOnlyList<LegacyXlsDrawingShapeProperty> shapeProperties,
-                out _);
+                out _,
+                decodedImageBudget);
             gelFrame = new LegacyXlsChartGelFrame(officeArtRecords, shapeProperties);
             return true;
         }

--- a/OfficeIMO.Excel/LegacyXls/Biff/BiffCommentImportState.cs
+++ b/OfficeIMO.Excel/LegacyXls/Biff/BiffCommentImportState.cs
@@ -7,6 +7,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
     /// </summary>
     internal sealed class BiffCommentImportState {
         private readonly LegacyXlsWorksheet _sheet;
+        private readonly LegacyXlsDecodedImageBudget? _decodedImageBudget;
         private readonly Dictionary<ushort, PendingNote> _notes = new();
         private readonly Dictionary<ushort, string> _texts = new();
         private readonly Dictionary<ushort, IReadOnlyList<LegacyXlsCommentFormattingRun>> _formattingRuns = new();
@@ -18,8 +19,11 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
         private PendingTextObject? _pendingTextObject;
         private ushort? _pendingCommentObjectId;
 
-        internal BiffCommentImportState(LegacyXlsWorksheet sheet) {
+        internal BiffCommentImportState(
+            LegacyXlsWorksheet sheet,
+            LegacyXlsDecodedImageBudget? decodedImageBudget = null) {
             _sheet = sheet;
+            _decodedImageBudget = decodedImageBudget;
         }
 
         internal bool TryReadObject(byte[] payload) {
@@ -52,7 +56,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
 
         internal bool TryReadDrawingAnchors(BiffRecord record, out LegacyXlsDrawingRecord? drawingRecord) {
             drawingRecord = null;
-            if (BiffDrawingMetadataReader.TryRead(record, _sheet.Name, out LegacyXlsDrawingRecord? parsedRecord) && parsedRecord!.AnchorEntries.Count > 0) {
+            if (BiffDrawingMetadataReader.TryRead(record, _sheet.Name, out LegacyXlsDrawingRecord? parsedRecord, _decodedImageBudget) && parsedRecord!.AnchorEntries.Count > 0) {
                 if (!_drawingAnchorRecordOffsets.Add(record.Offset)) {
                     drawingRecord = parsedRecord;
                     return false;

--- a/OfficeIMO.Excel/LegacyXls/Biff/BiffDrawingContinuationImportState.cs
+++ b/OfficeIMO.Excel/LegacyXls/Biff/BiffDrawingContinuationImportState.cs
@@ -30,13 +30,15 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                 return false;
             }
 
-            if (!BiffDrawingMetadataReader.TryRead(record, _sheetName, out LegacyXlsDrawingRecord? drawingRecord, _decodedImageBudget)) {
+            bool requiresContinuation = TryGetRequiredPayloadLength(record.Payload, out int requiredPayloadLength)
+                && requiredPayloadLength > record.Payload.Length;
+            LegacyXlsDecodedImageBudget? preliminaryBudget = requiresContinuation ? null : _decodedImageBudget;
+            if (!BiffDrawingMetadataReader.TryRead(record, _sheetName, out LegacyXlsDrawingRecord? drawingRecord, preliminaryBudget)) {
                 return false;
             }
 
             _drawingRecords.Add(drawingRecord!);
-            if (!TryGetRequiredPayloadLength(record.Payload, out int requiredPayloadLength)
-                || requiredPayloadLength <= record.Payload.Length) {
+            if (!requiresContinuation) {
                 if (!drawingRecord!.HasSupportedDrawingMetadata) {
                     AddUnsupportedFeature(
                         unsupportedFeatures,

--- a/OfficeIMO.Excel/LegacyXls/Biff/BiffDrawingContinuationImportState.cs
+++ b/OfficeIMO.Excel/LegacyXls/Biff/BiffDrawingContinuationImportState.cs
@@ -8,11 +8,16 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
     internal sealed class BiffDrawingContinuationImportState {
         private readonly string _sheetName;
         private readonly List<LegacyXlsDrawingRecord> _drawingRecords;
+        private readonly LegacyXlsDecodedImageBudget? _decodedImageBudget;
         private PendingDrawing? _pendingDrawing;
 
-        internal BiffDrawingContinuationImportState(string sheetName, List<LegacyXlsDrawingRecord> drawingRecords) {
+        internal BiffDrawingContinuationImportState(
+            string sheetName,
+            List<LegacyXlsDrawingRecord> drawingRecords,
+            LegacyXlsDecodedImageBudget? decodedImageBudget = null) {
             _sheetName = sheetName ?? throw new ArgumentNullException(nameof(sheetName));
             _drawingRecords = drawingRecords ?? throw new ArgumentNullException(nameof(drawingRecords));
+            _decodedImageBudget = decodedImageBudget;
         }
 
         internal bool TryReadDrawing(
@@ -25,7 +30,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                 return false;
             }
 
-            if (!BiffDrawingMetadataReader.TryRead(record, _sheetName, out LegacyXlsDrawingRecord? drawingRecord)) {
+            if (!BiffDrawingMetadataReader.TryRead(record, _sheetName, out LegacyXlsDrawingRecord? drawingRecord, _decodedImageBudget)) {
                 return false;
             }
 
@@ -74,7 +79,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
 
             byte[] assembledPayload = _pendingDrawing.GetAssembledPayload();
             var completedRecord = new BiffRecord(_pendingDrawing.RecordType, _pendingDrawing.RecordOffset, assembledPayload);
-            if (BiffDrawingMetadataReader.TryRead(completedRecord, _sheetName, out LegacyXlsDrawingRecord? drawingRecord)) {
+            if (BiffDrawingMetadataReader.TryRead(completedRecord, _sheetName, out LegacyXlsDrawingRecord? drawingRecord, _decodedImageBudget)) {
                 _drawingRecords[_pendingDrawing.DrawingRecordIndex] = drawingRecord!;
                 if (!drawingRecord!.HasSupportedDrawingMetadata) {
                     AddUnsupportedFeature(

--- a/OfficeIMO.Excel/LegacyXls/Biff/BiffDrawingMetadataReader.cs
+++ b/OfficeIMO.Excel/LegacyXls/Biff/BiffDrawingMetadataReader.cs
@@ -6,8 +6,9 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
         internal static bool TryRead(
             BiffRecord record,
             string? sheetName,
-            List<LegacyXlsDrawingRecord> records) {
-            if (TryRead(record, sheetName, out LegacyXlsDrawingRecord? drawingRecord)) {
+            List<LegacyXlsDrawingRecord> records,
+            LegacyXlsDecodedImageBudget? decodedImageBudget = null) {
+            if (TryRead(record, sheetName, out LegacyXlsDrawingRecord? drawingRecord, decodedImageBudget)) {
                 records.Add(drawingRecord!);
                 return true;
             }
@@ -18,7 +19,8 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
         internal static bool TryRead(
             BiffRecord record,
             string? sheetName,
-            out LegacyXlsDrawingRecord? drawingRecord) {
+            out LegacyXlsDrawingRecord? drawingRecord,
+            LegacyXlsDecodedImageBudget? decodedImageBudget = null) {
             drawingRecord = null;
             if (!BiffUnsupportedRecordDiagnostics.IsDrawingRecord(record.Type)) {
                 return false;
@@ -40,7 +42,8 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                 out IReadOnlyList<LegacyXlsDrawingGroupBlock> drawingGroupBlocks,
                 out IReadOnlyList<LegacyXlsDrawingGroupInfo> drawingGroupInfos,
                 out IReadOnlyList<LegacyXlsDrawingShapeProperty> shapeProperties,
-                out bool officeArtPayloadFullyTraversed);
+                out bool officeArtPayloadFullyTraversed,
+                decodedImageBudget);
             drawingRecord = new LegacyXlsDrawingRecord(
                 GetKind(record.Type),
                 BiffUnsupportedRecordDiagnostics.GetBiffRecordName(record.Type),
@@ -103,7 +106,8 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             out IReadOnlyList<LegacyXlsDrawingGroupBlock> drawingGroupBlocks,
             out IReadOnlyList<LegacyXlsDrawingGroupInfo> drawingGroupInfos,
             out IReadOnlyList<LegacyXlsDrawingShapeProperty> shapeProperties,
-            out bool officeArtPayloadFullyTraversed) {
+            out bool officeArtPayloadFullyTraversed,
+            LegacyXlsDecodedImageBudget? decodedImageBudget = null) {
             if (!TryGetOfficeArtPayloadRange(record, out int officeArtOffset, out int officeArtLength)) {
                 blipStoreEntries = Array.Empty<LegacyXlsDrawingBlipStoreEntry>();
                 shapeEntries = Array.Empty<LegacyXlsDrawingShape>();
@@ -129,7 +133,8 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                 out drawingGroupBlocks,
                 out drawingGroupInfos,
                 out shapeProperties,
-                out officeArtPayloadFullyTraversed);
+                out officeArtPayloadFullyTraversed,
+                decodedImageBudget);
         }
 
         internal static void ReadOfficeArtPayload(
@@ -142,7 +147,8 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             out IReadOnlyList<LegacyXlsDrawingGroupBlock> drawingGroupBlocks,
             out IReadOnlyList<LegacyXlsDrawingGroupInfo> drawingGroupInfos,
             out IReadOnlyList<LegacyXlsDrawingShapeProperty> shapeProperties,
-            out bool fullyTraversed) {
+            out bool fullyTraversed,
+            LegacyXlsDecodedImageBudget? decodedImageBudget = null) {
             if (payload == null) {
                 throw new ArgumentNullException(nameof(payload));
             }
@@ -155,7 +161,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             var groupBlocks = new List<LegacyXlsDrawingGroupBlock>();
             var groupInfos = new List<LegacyXlsDrawingGroupInfo>();
             var properties = new List<LegacyXlsDrawingShapeProperty>();
-            fullyTraversed = TryReadOfficeArtRecords(payload, 0, payload.Length, records, blips, shapes, anchors, childAnchors, groupBlocks, groupInfos, properties, depth: 0);
+            fullyTraversed = TryReadOfficeArtRecords(payload, 0, payload.Length, records, blips, shapes, anchors, childAnchors, groupBlocks, groupInfos, properties, depth: 0, decodedImageBudget);
             blipStoreEntries = blips;
             shapeEntries = shapes;
             anchorEntries = anchors;
@@ -178,7 +184,8 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             out IReadOnlyList<LegacyXlsDrawingGroupBlock> drawingGroupBlocks,
             out IReadOnlyList<LegacyXlsDrawingGroupInfo> drawingGroupInfos,
             out IReadOnlyList<LegacyXlsDrawingShapeProperty> shapeProperties,
-            out bool fullyTraversed) {
+            out bool fullyTraversed,
+            LegacyXlsDecodedImageBudget? decodedImageBudget = null) {
             if (payload == null) {
                 throw new ArgumentNullException(nameof(payload));
             }
@@ -195,7 +202,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             fullyTraversed = offset >= 0
                 && length >= 0
                 && endOffset <= payload.Length
-                && TryReadOfficeArtRecords(payload, offset, endOffset, records, blips, shapes, anchors, childAnchors, groupBlocks, groupInfos, properties, depth: 0);
+                && TryReadOfficeArtRecords(payload, offset, endOffset, records, blips, shapes, anchors, childAnchors, groupBlocks, groupInfos, properties, depth: 0, decodedImageBudget);
             blipStoreEntries = blips;
             shapeEntries = shapes;
             anchorEntries = anchors;
@@ -218,7 +225,8 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             List<LegacyXlsDrawingGroupBlock> drawingGroupBlocks,
             List<LegacyXlsDrawingGroupInfo> drawingGroupInfos,
             List<LegacyXlsDrawingShapeProperty> shapeProperties,
-            int depth) {
+            int depth,
+            LegacyXlsDecodedImageBudget? decodedImageBudget) {
             if (depth > 8) {
                 return false;
             }
@@ -239,7 +247,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                 if (contentStart + (int)recordLength > endOffset) {
                     if (version == 0x0f) {
                         officeArtRecords.Add(new LegacyXlsDrawingOfficeArtRecord(recordType, instance, version, recordLength, depth));
-                        TryReadOfficeArtRecords(payload, contentStart, endOffset, officeArtRecords, blipStoreEntries, shapeEntries, anchorEntries, childAnchorEntries, drawingGroupBlocks, drawingGroupInfos, shapeProperties, depth + 1);
+                        TryReadOfficeArtRecords(payload, contentStart, endOffset, officeArtRecords, blipStoreEntries, shapeEntries, anchorEntries, childAnchorEntries, drawingGroupBlocks, drawingGroupInfos, shapeProperties, depth + 1, decodedImageBudget);
                     }
 
                     return false;
@@ -248,7 +256,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                 int contentEnd = contentStart + (int)recordLength;
                 officeArtRecords.Add(new LegacyXlsDrawingOfficeArtRecord(recordType, instance, version, recordLength, depth));
 
-                if (recordType == 0xF007 && TryReadBlipStoreEntry(payload, contentStart, contentEnd, instance, out LegacyXlsDrawingBlipStoreEntry? blipEntry)) {
+                if (recordType == 0xF007 && TryReadBlipStoreEntry(payload, contentStart, contentEnd, instance, out LegacyXlsDrawingBlipStoreEntry? blipEntry, decodedImageBudget)) {
                     blipStoreEntries.Add(blipEntry!);
                 } else if (recordType == 0xF006 && TryReadDrawingGroupBlock(payload, contentStart, contentEnd, out LegacyXlsDrawingGroupBlock? drawingGroupBlock)) {
                     drawingGroupBlocks.Add(drawingGroupBlock!);
@@ -265,7 +273,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                 }
 
                 if (version == 0x0f) {
-                    fullyTraversed &= TryReadOfficeArtRecords(payload, contentStart, contentEnd, officeArtRecords, blipStoreEntries, shapeEntries, anchorEntries, childAnchorEntries, drawingGroupBlocks, drawingGroupInfos, shapeProperties, depth + 1);
+                    fullyTraversed &= TryReadOfficeArtRecords(payload, contentStart, contentEnd, officeArtRecords, blipStoreEntries, shapeEntries, anchorEntries, childAnchorEntries, drawingGroupBlocks, drawingGroupInfos, shapeProperties, depth + 1, decodedImageBudget);
                 }
 
                 offset = contentEnd;
@@ -331,14 +339,17 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             int contentStart,
             int contentEnd,
             ushort recordInstance,
-            out LegacyXlsDrawingBlipStoreEntry? entry) {
+            out LegacyXlsDrawingBlipStoreEntry? entry,
+            LegacyXlsDecodedImageBudget? decodedImageBudget) {
             entry = null;
             if (contentStart < 0 || contentEnd < contentStart || contentEnd > payload.Length
                 || !OfficeArtBlipStoreEntryReader.TryRead(payload, contentStart,
                     contentEnd - contentStart, recordInstance, delayStream: null,
-                    out OfficeArtBlipStoreEntry? sharedEntry) || sharedEntry == null) {
+                    out OfficeArtBlipStoreEntry? sharedEntry,
+                    decodedImageBudget?.RemainingBytes ?? 64 * 1024 * 1024) || sharedEntry == null) {
                 return false;
             }
+            decodedImageBudget?.Consume(sharedEntry.ImageByteCount);
             entry = new LegacyXlsDrawingBlipStoreEntry(sharedEntry);
             return true;
         }

--- a/OfficeIMO.Excel/LegacyXls/Biff/BiffDrawingTextObjectImportState.cs
+++ b/OfficeIMO.Excel/LegacyXls/Biff/BiffDrawingTextObjectImportState.cs
@@ -8,11 +8,16 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
     internal sealed class BiffDrawingTextObjectImportState {
         private readonly string _sheetName;
         private readonly List<LegacyXlsDrawingRecord> _drawingRecords;
+        private readonly LegacyXlsDecodedImageBudget? _decodedImageBudget;
         private PendingTextObject? _pendingTextObject;
 
-        internal BiffDrawingTextObjectImportState(string sheetName, List<LegacyXlsDrawingRecord> drawingRecords) {
+        internal BiffDrawingTextObjectImportState(
+            string sheetName,
+            List<LegacyXlsDrawingRecord> drawingRecords,
+            LegacyXlsDecodedImageBudget? decodedImageBudget = null) {
             _sheetName = sheetName ?? throw new ArgumentNullException(nameof(sheetName));
             _drawingRecords = drawingRecords ?? throw new ArgumentNullException(nameof(drawingRecords));
+            _decodedImageBudget = decodedImageBudget;
         }
 
         internal bool TryReadTextObject(BiffRecord record) {
@@ -20,7 +25,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                 return false;
             }
 
-            if (!BiffDrawingMetadataReader.TryRead(record, _sheetName, out LegacyXlsDrawingRecord? drawingRecord)
+            if (!BiffDrawingMetadataReader.TryRead(record, _sheetName, out LegacyXlsDrawingRecord? drawingRecord, _decodedImageBudget)
                 || drawingRecord?.TextObject == null) {
                 return false;
             }

--- a/OfficeIMO.Excel/LegacyXls/Biff/LegacyBiffChartSheetScanner.cs
+++ b/OfficeIMO.Excel/LegacyXls/Biff/LegacyBiffChartSheetScanner.cs
@@ -21,13 +21,14 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             IReadOnlyList<string> sheetNames,
             IReadOnlyList<string?> definedNames,
             List<LegacyXlsImportDiagnostic> diagnostics,
-            LegacyXlsImportOptions options) {
+            LegacyXlsImportOptions options,
+            LegacyXlsDecodedImageBudget? decodedImageBudget = null) {
             foreach (LegacyXlsChartSheet sheet in chartSheets) {
                 if (sheet.StreamOffset <= 0) {
                     continue;
                 }
 
-                ScanSheet(workbookStream, sheet, unsupportedFeatures, preservedFeatureRecords, pivotTableRecords, chartRecords, drawingRecords, externalQueryConnections, formulaTokenRecords, externSheets, externalReferences, sheetNames, definedNames, diagnostics, options);
+                ScanSheet(workbookStream, sheet, unsupportedFeatures, preservedFeatureRecords, pivotTableRecords, chartRecords, drawingRecords, externalQueryConnections, formulaTokenRecords, externSheets, externalReferences, sheetNames, definedNames, diagnostics, options, decodedImageBudget);
             }
         }
 
@@ -46,7 +47,8 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             IReadOnlyList<string> sheetNames,
             IReadOnlyList<string?> definedNames,
             List<LegacyXlsImportDiagnostic> diagnostics,
-            LegacyXlsImportOptions options) {
+            LegacyXlsImportOptions options,
+            LegacyXlsDecodedImageBudget? decodedImageBudget) {
             if (sheet.StreamOffset >= workbookStream.Length) {
                 diagnostics.Add(new LegacyXlsImportDiagnostic(
                     LegacyXlsDiagnosticSeverity.Warning,
@@ -92,7 +94,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                     return;
                 }
 
-                if (TryReadChartSheetMetadata(workbookStream, sheet, diagnostics, type, offset, payloadOffset, length, drawingRecords)) {
+                if (TryReadChartSheetMetadata(workbookStream, sheet, diagnostics, type, offset, payloadOffset, length, drawingRecords, decodedImageBudget)) {
                     offset = payloadOffset + length;
                     continue;
                 }
@@ -112,13 +114,13 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                     bool isSupportedPivotTableMetadata = false;
 
                     var record = new BiffRecord(type, offset, payload);
-                    if (BiffDrawingMetadataReader.TryRead(record, sheet.Name, out LegacyXlsDrawingRecord? drawingRecord)) {
+                    if (BiffDrawingMetadataReader.TryRead(record, sheet.Name, out LegacyXlsDrawingRecord? drawingRecord, decodedImageBudget)) {
                         drawingRecords.Add(drawingRecord!);
                         isSupportedDrawingMetadata = drawingRecord!.HasSupportedDrawingMetadata;
                     }
 
                     int chartRecordCountBefore = chartRecords.Count;
-                    if (BiffChartMetadataReader.TryRead(record, sheet.Name, chartRecords, chartMetadataState, externSheets, externalReferences, sheetNames, definedNames)
+                    if (BiffChartMetadataReader.TryRead(record, sheet.Name, chartRecords, chartMetadataState, externSheets, externalReferences, sheetNames, definedNames, decodedImageBudget)
                         && chartRecords.Count > chartRecordCountBefore) {
                         BiffChartMetadataReader.ScanFormulaTokens(record, sheet.Name, formulaTokenRecords);
                         sheet.AddChartRecord(chartRecords[chartRecords.Count - 1]);
@@ -177,11 +179,12 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             int recordOffset,
             int payloadOffset,
             ushort payloadLength,
-            List<LegacyXlsDrawingRecord> drawingRecords) {
+            List<LegacyXlsDrawingRecord> drawingRecords,
+            LegacyXlsDecodedImageBudget? decodedImageBudget) {
             if (type == (ushort)BiffRecordType.Txo) {
                 byte[] payload = new byte[payloadLength];
                 Buffer.BlockCopy(workbookStream, payloadOffset, payload, 0, payloadLength);
-                BiffDrawingMetadataReader.TryRead(new BiffRecord(type, recordOffset, payload), sheet.Name, drawingRecords);
+                BiffDrawingMetadataReader.TryRead(new BiffRecord(type, recordOffset, payload), sheet.Name, drawingRecords, decodedImageBudget);
                 sheet.IncrementChartTextObjectCount();
                 sheet.AddMetadataRecord(LegacyXlsChartSheetMetadataKind.ChartTextObject, recordOffset, type);
                 return true;

--- a/OfficeIMO.Excel/LegacyXls/Biff/LegacyBiffUnsupportedSheetScanner.cs
+++ b/OfficeIMO.Excel/LegacyXls/Biff/LegacyBiffUnsupportedSheetScanner.cs
@@ -21,13 +21,14 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             IReadOnlyList<string> sheetNames,
             IReadOnlyList<string?> definedNames,
             List<LegacyXlsImportDiagnostic> diagnostics,
-            LegacyXlsImportOptions options) {
+            LegacyXlsImportOptions options,
+            LegacyXlsDecodedImageBudget? decodedImageBudget = null) {
             foreach (LegacyXlsUnsupportedSheet sheet in unsupportedSheets) {
                 if (!ShouldScan(sheet)) {
                     continue;
                 }
 
-                ScanSheet(workbookStream, sheet, unsupportedFeatures, preservedFeatureRecords, pivotTableRecords, chartRecords, drawingRecords, externalQueryConnections, formulaTokenRecords, externSheets, externalReferences, sheetNames, definedNames, diagnostics, options);
+                ScanSheet(workbookStream, sheet, unsupportedFeatures, preservedFeatureRecords, pivotTableRecords, chartRecords, drawingRecords, externalQueryConnections, formulaTokenRecords, externSheets, externalReferences, sheetNames, definedNames, diagnostics, options, decodedImageBudget);
             }
         }
 
@@ -51,7 +52,8 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             IReadOnlyList<string> sheetNames,
             IReadOnlyList<string?> definedNames,
             List<LegacyXlsImportDiagnostic> diagnostics,
-            LegacyXlsImportOptions options) {
+            LegacyXlsImportOptions options,
+            LegacyXlsDecodedImageBudget? decodedImageBudget) {
             if (sheet.StreamOffset >= workbookStream.Length) {
                 diagnostics.Add(new LegacyXlsImportDiagnostic(
                     LegacyXlsDiagnosticSeverity.Warning,
@@ -97,7 +99,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                     return;
                 }
 
-                if (TryReadUnsupportedSheetMetadata(workbookStream, sheet, diagnostics, type, offset, payloadOffset, length, drawingRecords)) {
+                if (TryReadUnsupportedSheetMetadata(workbookStream, sheet, diagnostics, type, offset, payloadOffset, length, drawingRecords, decodedImageBudget)) {
                     offset = payloadOffset + length;
                     continue;
                 }
@@ -115,14 +117,14 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                     bool isSupportedDrawingMetadata = false;
                     bool isSupportedChartMetadata = false;
                     bool isSupportedPivotTableMetadata = false;
-                    if (BiffDrawingMetadataReader.TryRead(new BiffRecord(type, offset, payload), sheet.Name, out LegacyXlsDrawingRecord? drawingRecord)) {
+                    if (BiffDrawingMetadataReader.TryRead(new BiffRecord(type, offset, payload), sheet.Name, out LegacyXlsDrawingRecord? drawingRecord, decodedImageBudget)) {
                         drawingRecords.Add(drawingRecord!);
                         isSupportedDrawingMetadata = drawingRecord!.HasSupportedDrawingMetadata;
                     }
 
                     int chartRecordCountBefore = chartRecords.Count;
                     var chartRecord = new BiffRecord(type, offset, payload);
-                    if (BiffChartMetadataReader.TryRead(chartRecord, sheet.Name, chartRecords, chartMetadataState, externSheets, externalReferences, sheetNames, definedNames)
+                    if (BiffChartMetadataReader.TryRead(chartRecord, sheet.Name, chartRecords, chartMetadataState, externSheets, externalReferences, sheetNames, definedNames, decodedImageBudget)
                         && sheet.Kind == LegacyXlsUnsupportedSheetKind.ChartSheet
                         && chartRecords.Count > chartRecordCountBefore) {
                         BiffChartMetadataReader.ScanFormulaTokens(chartRecord, sheet.Name, formulaTokenRecords);
@@ -182,7 +184,8 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             int recordOffset,
             int payloadOffset,
             ushort payloadLength,
-            List<LegacyXlsDrawingRecord> drawingRecords) {
+            List<LegacyXlsDrawingRecord> drawingRecords,
+            LegacyXlsDecodedImageBudget? decodedImageBudget) {
             if (sheet.Kind != LegacyXlsUnsupportedSheetKind.ChartSheet) {
                 return false;
             }
@@ -190,7 +193,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             if (type == (ushort)BiffRecordType.Txo) {
                 byte[] payload = new byte[payloadLength];
                 Buffer.BlockCopy(workbookStream, payloadOffset, payload, 0, payloadLength);
-                BiffDrawingMetadataReader.TryRead(new BiffRecord(type, recordOffset, payload), sheet.Name, drawingRecords);
+                BiffDrawingMetadataReader.TryRead(new BiffRecord(type, recordOffset, payload), sheet.Name, drawingRecords, decodedImageBudget);
                 sheet.IncrementChartTextObjectCount();
                 sheet.AddMetadataRecord(LegacyXlsUnsupportedSheetMetadataKind.ChartTextObject, recordOffset, type);
                 return true;

--- a/OfficeIMO.Excel/LegacyXls/Biff/LegacyBiffWorkbookParser.cs
+++ b/OfficeIMO.Excel/LegacyXls/Biff/LegacyBiffWorkbookParser.cs
@@ -5,6 +5,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
     internal static class LegacyBiffWorkbookParser {
         internal static LegacyXlsWorkbook Parse(byte[] workbookStream, LegacyXlsImportOptions options) {
             var workbook = new LegacyXlsWorkbook();
+            var decodedImageBudget = new LegacyXlsDecodedImageBudget(options.MaxDecodedImageBytes);
             IReadOnlyList<BiffRecord> records = ReadWorkbookGlobalRecords(workbookStream, workbook.MutableDiagnostics);
             var sharedStrings = new List<BiffStringReader.BiffStringValue>();
             var numberFormatsById = new Dictionary<ushort, string>();
@@ -143,7 +144,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                     }
 
                     continue;
-                } else if (BiffDrawingMetadataReader.TryRead(record, sheetName: null, out LegacyXlsDrawingRecord? drawingRecord)) {
+                } else if (BiffDrawingMetadataReader.TryRead(record, sheetName: null, out LegacyXlsDrawingRecord? drawingRecord, decodedImageBudget)) {
                     workbook.MutableDrawingRecords.Add(drawingRecord!);
                     if (record.Type == (ushort)BiffRecordType.DrawingGroup || drawingRecord!.HasSupportedDrawingMetadata) {
                         continue;
@@ -173,7 +174,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                     }
                 } else if (BiffExternalQueryConnectionReader.TryRead(record, sheetName: null, workbook.MutableDiagnostics, out LegacyXlsExternalQueryConnection? externalQueryConnection)) {
                     workbook.MutableExternalQueryConnections.Add(externalQueryConnection!);
-                } else if (BiffChartMetadataReader.TryRead(record, sheetName: null, workbook.MutableChartRecords, chartMetadataState, externSheets, workbook.ExternalReferences, boundSheetNames, definedNameTable)) {
+                } else if (BiffChartMetadataReader.TryRead(record, sheetName: null, workbook.MutableChartRecords, chartMetadataState, externSheets, workbook.ExternalReferences, boundSheetNames, definedNameTable, decodedImageBudget)) {
                     BiffChartMetadataReader.ScanFormulaTokens(record, sheetName: null, workbook.MutableFormulaTokenRecords);
                     LegacyXlsChartRecord chartRecord = workbook.MutableChartRecords[workbook.MutableChartRecords.Count - 1];
                     if (!chartRecord.HasSupportedChartMetadata) {
@@ -227,7 +228,8 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                 sheetNames,
                 definedNameTable,
                 workbook.MutableDiagnostics,
-                options);
+                options,
+                decodedImageBudget);
             LegacyBiffUnsupportedSheetScanner.Scan(
                 workbookStream,
                 workbook.UnsupportedSheets,
@@ -243,10 +245,11 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                 sheetNames,
                 definedNameTable,
                 workbook.MutableDiagnostics,
-                options);
+                options,
+                decodedImageBudget);
 
             foreach (LegacyXlsWorksheet sheet in workbook.Worksheets) {
-                LegacyBiffWorksheetParser.Parse(workbookStream, workbookGlobalsBiffVersion, workbook, sheet, sharedStrings, externSheets, workbook.ExternalReferences, sheetNames, definedNameTable, workbook.MutableUnsupportedFeatures, workbook.MutablePreservedFeatureRecords, workbook.MutablePivotTableRecords, workbook.MutableChartRecords, workbook.MutableDrawingRecords, workbook.MutableExternalQueryConnections, workbook.DifferentialFormats, workbook.MutableCalculationSettings, workbook.MutableFormulaTokenRecords, workbook.MutableDiagnostics, options);
+                LegacyBiffWorksheetParser.Parse(workbookStream, workbookGlobalsBiffVersion, workbook, sheet, sharedStrings, externSheets, workbook.ExternalReferences, sheetNames, definedNameTable, workbook.MutableUnsupportedFeatures, workbook.MutablePreservedFeatureRecords, workbook.MutablePivotTableRecords, workbook.MutableChartRecords, workbook.MutableDrawingRecords, workbook.MutableExternalQueryConnections, workbook.DifferentialFormats, workbook.MutableCalculationSettings, workbook.MutableFormulaTokenRecords, workbook.MutableDiagnostics, options, decodedImageBudget);
             }
 
             return workbook;

--- a/OfficeIMO.Excel/LegacyXls/Biff/LegacyBiffWorksheetParser.cs
+++ b/OfficeIMO.Excel/LegacyXls/Biff/LegacyBiffWorksheetParser.cs
@@ -23,7 +23,8 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             LegacyXlsCalculationSettings calculationSettings,
             List<LegacyXlsFormulaTokenRecord> formulaTokenRecords,
             List<LegacyXlsImportDiagnostic> diagnostics,
-            LegacyXlsImportOptions options) {
+            LegacyXlsImportOptions options,
+            LegacyXlsDecodedImageBudget? decodedImageBudget = null) {
             if (sheet.StreamOffset < 0 || sheet.StreamOffset >= workbookStream.Length) {
                 diagnostics.Add(new LegacyXlsImportDiagnostic(
                     LegacyXlsDiagnosticSeverity.Warning,
@@ -38,9 +39,9 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             bool frozenWindow = false;
             int nestedSubstreamDepth = 0;
             PendingFormulaString? pendingFormulaString = null;
-            var commentState = new BiffCommentImportState(sheet);
-            var drawingContinuationState = new BiffDrawingContinuationImportState(sheet.Name, drawingRecords);
-            var drawingTextObjectState = new BiffDrawingTextObjectImportState(sheet.Name, drawingRecords);
+            var commentState = new BiffCommentImportState(sheet, decodedImageBudget);
+            var drawingContinuationState = new BiffDrawingContinuationImportState(sheet.Name, drawingRecords, decodedImageBudget);
+            var drawingTextObjectState = new BiffDrawingTextObjectImportState(sheet.Name, drawingRecords, decodedImageBudget);
             var conditionalFormattingState = new BiffConditionalFormattingImportState(workbook, sheet, externSheets, externalReferences, sheetNames, definedNames, differentialFormats);
             var sharedFormulaState = new BiffSharedFormulaImportState(sheet, externSheets, externalReferences, sheetNames, definedNames, formulaTokenRecords, diagnostics, options);
             var chartMetadataState = new BiffChartMetadataReaderState();
@@ -108,7 +109,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                     return;
                 }
 
-                ParseWorksheetRecord(sheet, workbookGlobalsBiffVersion, sharedStrings, externSheets, externalReferences, sheetNames, definedNames, unsupportedFeatures, preservedFeatureRecords, pivotTableRecords, chartRecords, drawingRecords, externalQueryConnections, calculationSettings, formulaTokenRecords, diagnostics, options, commentState, drawingTextObjectState, drawingContinuationState, conditionalFormattingState, sharedFormulaState, chartMetadataState, pivotTableMetadataState, type, offset, payload, ref frozenWindow, ref pendingFormulaString);
+                ParseWorksheetRecord(sheet, workbookGlobalsBiffVersion, sharedStrings, externSheets, externalReferences, sheetNames, definedNames, unsupportedFeatures, preservedFeatureRecords, pivotTableRecords, chartRecords, drawingRecords, externalQueryConnections, calculationSettings, formulaTokenRecords, diagnostics, options, decodedImageBudget, commentState, drawingTextObjectState, drawingContinuationState, conditionalFormattingState, sharedFormulaState, chartMetadataState, pivotTableMetadataState, type, offset, payload, ref frozenWindow, ref pendingFormulaString);
                 offset = payloadOffset + length;
             }
 
@@ -139,6 +140,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
             List<LegacyXlsFormulaTokenRecord> formulaTokenRecords,
             List<LegacyXlsImportDiagnostic> diagnostics,
             LegacyXlsImportOptions options,
+            LegacyXlsDecodedImageBudget? decodedImageBudget,
             BiffCommentImportState commentState,
             BiffDrawingTextObjectImportState drawingTextObjectState,
             BiffDrawingContinuationImportState drawingContinuationState,
@@ -487,7 +489,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                     case BiffRecordType.Obj:
                         if (!commentState.TryReadObject(payload)) {
                             commentState.AddPendingDrawingFeatures(unsupportedFeatures, preservedFeatureRecords, diagnostics, options.ReportUnsupportedContent);
-                            if (BiffDrawingMetadataReader.TryRead(new BiffRecord(type, offset, payload), sheet.Name, out LegacyXlsDrawingRecord? drawingRecord)) {
+                            if (BiffDrawingMetadataReader.TryRead(new BiffRecord(type, offset, payload), sheet.Name, out LegacyXlsDrawingRecord? drawingRecord, decodedImageBudget)) {
                                 drawingRecords.Add(drawingRecord!);
                                 if (!drawingRecord!.HasSupportedDrawingMetadata) {
                                     AddUnsupportedFeature(unsupportedFeatures, preservedFeatureRecords, diagnostics, options, type, offset, sheet.Name, payload.Length);
@@ -623,7 +625,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                     case BiffRecordType.Txo:
                         if (!commentState.TryReadTextObject(payload)) {
                             if (!drawingTextObjectState.TryReadTextObject(new BiffRecord(type, offset, payload))) {
-                                BiffDrawingMetadataReader.TryRead(new BiffRecord(type, offset, payload), sheet.Name, drawingRecords);
+                                BiffDrawingMetadataReader.TryRead(new BiffRecord(type, offset, payload), sheet.Name, drawingRecords, decodedImageBudget);
                                 AddUnsupportedFeature(unsupportedFeatures, preservedFeatureRecords, diagnostics, options, type, offset, sheet.Name, payload.Length);
                             }
                         }
@@ -688,7 +690,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                                 break;
                             }
 
-                            if (BiffDrawingMetadataReader.TryRead(new BiffRecord(type, offset, payload), sheet.Name, drawingRecords)) {
+                            if (BiffDrawingMetadataReader.TryRead(new BiffRecord(type, offset, payload), sheet.Name, drawingRecords, decodedImageBudget)) {
                                 LegacyXlsDrawingRecord drawingRecord = drawingRecords[drawingRecords.Count - 1];
                                 if (!drawingRecord.HasSupportedDrawingMetadata) {
                                     AddUnsupportedFeature(unsupportedFeatures, preservedFeatureRecords, diagnostics, options, type, offset, sheet.Name, payload.Length);
@@ -698,7 +700,7 @@ namespace OfficeIMO.Excel.LegacyXls.Biff {
                             }
 
                             var chartRecord = new BiffRecord(type, offset, payload);
-                            if (BiffChartMetadataReader.TryRead(chartRecord, sheet.Name, chartRecords, chartMetadataState, externSheets, externalReferences, sheetNames, definedNames)) {
+                            if (BiffChartMetadataReader.TryRead(chartRecord, sheet.Name, chartRecords, chartMetadataState, externSheets, externalReferences, sheetNames, definedNames, decodedImageBudget)) {
                                 BiffChartMetadataReader.ScanFormulaTokens(chartRecord, sheet.Name, formulaTokenRecords);
                                 LegacyXlsChartRecord parsedChartRecord = chartRecords[chartRecords.Count - 1];
                                 if (!parsedChartRecord.HasSupportedChartMetadata) {

--- a/OfficeIMO.Excel/LegacyXls/Biff/LegacyXlsDecodedImageBudget.cs
+++ b/OfficeIMO.Excel/LegacyXls/Biff/LegacyXlsDecodedImageBudget.cs
@@ -1,0 +1,23 @@
+namespace OfficeIMO.Excel.LegacyXls.Biff {
+    /// <summary>Tracks aggregate decoded OfficeArt image bytes for one XLS import.</summary>
+    internal sealed class LegacyXlsDecodedImageBudget {
+        private readonly int _maximumBytes;
+        private int _decodedBytes;
+
+        internal LegacyXlsDecodedImageBudget(int maximumBytes) {
+            if (maximumBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maximumBytes));
+            _maximumBytes = maximumBytes;
+        }
+
+        internal int RemainingBytes => _maximumBytes - _decodedBytes;
+
+        internal void Consume(int bytes) {
+            if (bytes < 0) throw new ArgumentOutOfRangeException(nameof(bytes));
+            _decodedBytes = checked(_decodedBytes + bytes);
+            if (_decodedBytes > _maximumBytes) {
+                throw new InvalidDataException(
+                    $"The legacy XLS decoded-image payload exceeds the configured limit of {_maximumBytes} bytes.");
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/LegacyXls/LegacyXlsImportOptions.cs
+++ b/OfficeIMO.Excel/LegacyXls/LegacyXlsImportOptions.cs
@@ -8,6 +8,9 @@ namespace OfficeIMO.Excel.LegacyXls {
         /// </summary>
         public int MaxInputBytes { get; set; } = 64 * 1024 * 1024;
 
+        /// <summary>Maximum aggregate decoded OfficeArt image bytes retained during import.</summary>
+        public int MaxDecodedImageBytes { get; set; } = 64 * 1024 * 1024;
+
         /// <summary>
         /// When true, unsupported legacy content is reported as warnings.
         /// </summary>
@@ -17,6 +20,11 @@ namespace OfficeIMO.Excel.LegacyXls {
         /// Optional password used to decrypt password-to-open encrypted legacy XLS workbooks.
         /// </summary>
         public string? Password { get; set; }
+
+        internal void Validate() {
+            if (MaxInputBytes <= 0) throw new ArgumentOutOfRangeException(nameof(MaxInputBytes));
+            if (MaxDecodedImageBytes <= 0) throw new ArgumentOutOfRangeException(nameof(MaxDecodedImageBytes));
+        }
 
     }
 }

--- a/OfficeIMO.Excel/LegacyXls/Model/LegacyXlsWorkbook.cs
+++ b/OfficeIMO.Excel/LegacyXls/Model/LegacyXlsWorkbook.cs
@@ -642,6 +642,7 @@ namespace OfficeIMO.Excel.LegacyXls.Model {
             if (bytes == null) throw new ArgumentNullException(nameof(bytes));
 
             options ??= new LegacyXlsImportOptions();
+            options.Validate();
             if (!OfficeCompoundFileReader.TryRead(bytes, out OfficeCompoundFile? compoundFile, out string? compoundError)) {
                 var workbook = new LegacyXlsWorkbook();
                 if (!string.IsNullOrWhiteSpace(compoundError)) {

--- a/OfficeIMO.Excel/Xlsb/Biff12/XlsbRecordReadBudget.cs
+++ b/OfficeIMO.Excel/Xlsb/Biff12/XlsbRecordReadBudget.cs
@@ -1,0 +1,20 @@
+namespace OfficeIMO.Excel.Xlsb.Biff12 {
+    /// <summary>Tracks the aggregate BIFF12 record count across one workbook import.</summary>
+    internal sealed class XlsbRecordReadBudget {
+        private readonly int _maximum;
+        private int _count;
+
+        internal XlsbRecordReadBudget(int maximum) {
+            if (maximum <= 0) throw new ArgumentOutOfRangeException(nameof(maximum));
+            _maximum = maximum;
+        }
+
+        internal void Consume() {
+            _count = checked(_count + 1);
+            if (_count > _maximum) {
+                throw new InvalidDataException(
+                    $"The XLSB workbook exceeds the configured limit of {_maximum} BIFF12 records.");
+            }
+        }
+    }
+}

--- a/OfficeIMO.Excel/Xlsb/Biff12/XlsbRecordReader.cs
+++ b/OfficeIMO.Excel/Xlsb/Biff12/XlsbRecordReader.cs
@@ -8,13 +8,15 @@ namespace OfficeIMO.Excel.Xlsb.Biff12 {
         /// <summary>Reads all records from a BIFF12 part while enforcing a per-record allocation limit.</summary>
         internal static IReadOnlyList<XlsbRecord> ReadAll(
             Stream stream,
-            int maxRecordBytes = DefaultMaxRecordBytes) {
+            int maxRecordBytes = DefaultMaxRecordBytes,
+            XlsbRecordReadBudget? budget = null) {
             if (stream == null) throw new ArgumentNullException(nameof(stream));
             if (!stream.CanRead) throw new ArgumentException("The BIFF12 stream must be readable.", nameof(stream));
             if (maxRecordBytes < 0) throw new ArgumentOutOfRangeException(nameof(maxRecordBytes));
 
             var records = new List<XlsbRecord>();
             while (TryRead(stream, maxRecordBytes, out XlsbRecord record)) {
+                budget?.Consume();
                 records.Add(record);
             }
 

--- a/OfficeIMO.Excel/Xlsb/Styles/XlsbStylesheetReader.cs
+++ b/OfficeIMO.Excel/Xlsb/Styles/XlsbStylesheetReader.cs
@@ -29,7 +29,8 @@ namespace OfficeIMO.Excel.Xlsb.Styles {
             byte[] bytes,
             string partName,
             XlsbImportOptions options,
-            XlsbWorkbook workbook) {
+            XlsbWorkbook workbook,
+            XlsbRecordReadBudget budget) {
             if (bytes == null) throw new ArgumentNullException(nameof(bytes));
             if (string.IsNullOrWhiteSpace(partName)) throw new ArgumentNullException(nameof(partName));
             if (options == null) throw new ArgumentNullException(nameof(options));
@@ -37,7 +38,7 @@ namespace OfficeIMO.Excel.Xlsb.Styles {
 
             IReadOnlyList<XlsbRecord> records;
             using (var stream = new MemoryStream(bytes, writable: false)) {
-                records = XlsbRecordReader.ReadAll(stream, options.MaxRecordBytes);
+                records = XlsbRecordReader.ReadAll(stream, options.MaxRecordBytes, budget);
             }
 
             if (records.Count < 2

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbFormulaEncoder.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbFormulaEncoder.cs
@@ -5,9 +5,17 @@ namespace OfficeIMO.Excel.Xlsb.Write {
     /// Reuses the established formula parser and converts its common BIFF8 token subset to BIFF12.
     /// </summary>
     internal static class XlsbFormulaEncoder {
+        private const int MaximumFormulaCharacters = 8_192;
+        private const int MaximumControlFunctionDepth = 64;
+
         internal static bool TryEncode(string formulaText, out byte[] formulaPayload, out string? reason) {
             formulaPayload = Array.Empty<byte>();
-            if (!TryEncodeTokens(formulaText, out byte[] biff12Tokens, out reason)) return false;
+            if (formulaText == null) throw new ArgumentNullException(nameof(formulaText));
+            if (formulaText.Length > MaximumFormulaCharacters) {
+                reason = $"Formula text exceeds the supported limit of {MaximumFormulaCharacters} characters.";
+                return false;
+            }
+            if (!TryEncodeTokens(formulaText, depth: 0, out byte[] biff12Tokens, out reason)) return false;
 
             using var payload = new MemoryStream(checked(biff12Tokens.Length + 10));
             WriteUInt16(payload, 0); // grbit
@@ -18,8 +26,14 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             return true;
         }
 
-        private static bool TryEncodeTokens(string formulaText, out byte[] tokens, out string? reason) {
-            if (TryEncodeControlFunction(formulaText, out tokens, out reason)) return true;
+        private static bool TryEncodeTokens(string formulaText, int depth,
+            out byte[] tokens, out string? reason) {
+            if (depth > MaximumControlFunctionDepth) {
+                tokens = Array.Empty<byte>();
+                reason = $"Formula control-function nesting exceeds the supported depth of {MaximumControlFunctionDepth}.";
+                return false;
+            }
+            if (TryEncodeControlFunction(formulaText, depth, out tokens, out reason)) return true;
             if (reason != null) return false;
 
             if (!LegacyXlsFormulaEncoder.TryEncode(formulaText, out byte[] biff8Tokens, out reason)) {
@@ -30,7 +44,8 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             return TryConvertTokens(biff8Tokens, out tokens, out reason);
         }
 
-        private static bool TryEncodeControlFunction(string formulaText, out byte[] tokens, out string? reason) {
+        private static bool TryEncodeControlFunction(string formulaText, int depth,
+            out byte[] tokens, out string? reason) {
             tokens = Array.Empty<byte>();
             reason = null;
             string normalized = formulaText.Trim();
@@ -73,7 +88,8 @@ namespace OfficeIMO.Excel.Xlsb.Write {
                     continue;
                 }
 
-                if (!TryEncodeTokens(argument, out byte[] argumentTokens, out reason)) return false;
+                if (!TryEncodeTokens(argument, checked(depth + 1),
+                        out byte[] argumentTokens, out reason)) return false;
                 output.Write(argumentTokens, 0, argumentTokens.Length);
             }
 

--- a/OfficeIMO.Excel/Xlsb/Write/XlsbFormulaEncoder.cs
+++ b/OfficeIMO.Excel/Xlsb/Write/XlsbFormulaEncoder.cs
@@ -7,15 +7,20 @@ namespace OfficeIMO.Excel.Xlsb.Write {
     internal static class XlsbFormulaEncoder {
         private const int MaximumFormulaCharacters = 8_192;
         private const int MaximumControlFunctionDepth = 64;
+        private const int MaximumFormulaOperators = 256;
 
         internal static bool TryEncode(string formulaText, out byte[] formulaPayload, out string? reason) {
             formulaPayload = Array.Empty<byte>();
             if (formulaText == null) throw new ArgumentNullException(nameof(formulaText));
-            if (formulaText.Length > MaximumFormulaCharacters) {
+        if (formulaText.Length > MaximumFormulaCharacters) {
                 reason = $"Formula text exceeds the supported limit of {MaximumFormulaCharacters} characters.";
-                return false;
-            }
-            if (!TryEncodeTokens(formulaText, depth: 0, out byte[] biff12Tokens, out reason)) return false;
+            return false;
+        }
+        if (ExceedsSyntacticNestingLimit(formulaText)) {
+            reason = $"Formula syntactic nesting exceeds the supported depth of {MaximumControlFunctionDepth}.";
+            return false;
+        }
+        if (!TryEncodeTokens(formulaText, depth: 0, out byte[] biff12Tokens, out reason)) return false;
 
             using var payload = new MemoryStream(checked(biff12Tokens.Length + 10));
             WriteUInt16(payload, 0); // grbit
@@ -24,6 +29,46 @@ namespace OfficeIMO.Excel.Xlsb.Write {
             WriteUInt32(payload, 0); // cbExtra
             formulaPayload = payload.ToArray();
             return true;
+        }
+
+        private static bool ExceedsSyntacticNestingLimit(string formulaText) {
+            int parenthesisDepth = 0;
+            int unaryRun = 0;
+            int operators = 0;
+            bool quoted = false;
+            for (int index = 0; index < formulaText.Length; index++) {
+                char current = formulaText[index];
+                if (current == '"') {
+                    if (quoted && index + 1 < formulaText.Length && formulaText[index + 1] == '"') {
+                        index++;
+                        continue;
+                    }
+                    quoted = !quoted;
+                    unaryRun = 0;
+                    continue;
+                }
+                if (quoted) continue;
+                if (current == '(') {
+                    parenthesisDepth++;
+                    if (parenthesisDepth > MaximumControlFunctionDepth) return true;
+                    unaryRun = 0;
+                } else if (current == ')') {
+                    if (parenthesisDepth > 0) parenthesisDepth--;
+                    unaryRun = 0;
+                } else if (current == '+' || current == '-') {
+                    unaryRun++;
+                    if (unaryRun > MaximumControlFunctionDepth) return true;
+                    if (++operators > MaximumFormulaOperators) return true;
+                } else if (current == '*' || current == '/' || current == '^' ||
+                           current == '&' || current == '=' || current == '<' ||
+                           current == '>' || current == '%') {
+                    unaryRun = 0;
+                    if (++operators > MaximumFormulaOperators) return true;
+                } else if (!char.IsWhiteSpace(current)) {
+                    unaryRun = 0;
+                }
+            }
+            return false;
         }
 
         private static bool TryEncodeTokens(string formulaText, int depth,

--- a/OfficeIMO.Excel/Xlsb/XlsbImportOptions.cs
+++ b/OfficeIMO.Excel/Xlsb/XlsbImportOptions.cs
@@ -12,11 +12,17 @@ namespace OfficeIMO.Excel.Xlsb {
         /// <summary>Gets or sets the largest accepted BIFF12 record payload. The default is 64 MiB.</summary>
         public int MaxRecordBytes { get; set; } = 64 * 1024 * 1024;
 
+        /// <summary>Gets or sets the aggregate BIFF12 record limit across one workbook import.</summary>
+        public int MaxRecordCount { get; set; } = 1_000_000;
+
         /// <summary>Gets or sets the maximum number of worksheets accepted from one workbook.</summary>
         public int MaxWorksheets { get; set; } = 16_384;
 
         /// <summary>Gets or sets the maximum number of populated cells projected from one workbook.</summary>
         public int MaxCells { get; set; } = 4_000_000;
+
+        /// <summary>Gets or sets the maximum number of row metadata definitions projected from one workbook.</summary>
+        public int MaxRowDefinitions { get; set; } = 100_000;
 
         /// <summary>Gets or sets the maximum number of shared-string items accepted.</summary>
         public int MaxSharedStrings { get; set; } = 1_000_000;
@@ -37,8 +43,10 @@ namespace OfficeIMO.Excel.Xlsb {
             if (MaxPartBytes <= 0) throw new ArgumentOutOfRangeException(nameof(MaxPartBytes));
             if (MaxPackageBytes <= 0) throw new ArgumentOutOfRangeException(nameof(MaxPackageBytes));
             if (MaxRecordBytes <= 0) throw new ArgumentOutOfRangeException(nameof(MaxRecordBytes));
+            if (MaxRecordCount <= 0) throw new ArgumentOutOfRangeException(nameof(MaxRecordCount));
             if (MaxWorksheets <= 0) throw new ArgumentOutOfRangeException(nameof(MaxWorksheets));
             if (MaxCells <= 0) throw new ArgumentOutOfRangeException(nameof(MaxCells));
+            if (MaxRowDefinitions <= 0) throw new ArgumentOutOfRangeException(nameof(MaxRowDefinitions));
             if (MaxSharedStrings <= 0) throw new ArgumentOutOfRangeException(nameof(MaxSharedStrings));
             if (MaxMergedRanges <= 0) throw new ArgumentOutOfRangeException(nameof(MaxMergedRanges));
             if (MaxHyperlinks <= 0) throw new ArgumentOutOfRangeException(nameof(MaxHyperlinks));

--- a/OfficeIMO.Excel/Xlsb/XlsbImportOptions.cs
+++ b/OfficeIMO.Excel/Xlsb/XlsbImportOptions.cs
@@ -12,8 +12,8 @@ namespace OfficeIMO.Excel.Xlsb {
         /// <summary>Gets or sets the largest accepted BIFF12 record payload. The default is 64 MiB.</summary>
         public int MaxRecordBytes { get; set; } = 64 * 1024 * 1024;
 
-        /// <summary>Gets or sets the aggregate BIFF12 record limit across one workbook import.</summary>
-        public int MaxRecordCount { get; set; } = 1_000_000;
+        /// <summary>Gets or sets the aggregate BIFF12 record limit across one workbook import. The default is 8,000,000.</summary>
+        public int MaxRecordCount { get; set; } = 8_000_000;
 
         /// <summary>Gets or sets the maximum number of worksheets accepted from one workbook.</summary>
         public int MaxWorksheets { get; set; } = 16_384;

--- a/OfficeIMO.Excel/Xlsb/XlsbWorkbookReader.cs
+++ b/OfficeIMO.Excel/Xlsb/XlsbWorkbookReader.cs
@@ -89,10 +89,14 @@ namespace OfficeIMO.Excel.Xlsb {
             using var packageStream = new MemoryStream(packageBytes, writable: false);
             using var archive = new ZipArchive(packageStream, ZipArchiveMode.Read, leaveOpen: false);
             var parts = new XlsbPackagePartReader(archive, resolved);
+            var recordBudget = new XlsbRecordReadBudget(resolved.MaxRecordCount);
             IReadOnlyDictionary<string, XlsbPackageRelationship> relationships = parts.ReadRelationships(workbookPartName!);
-            IReadOnlyList<string> sharedStrings = ReadSharedStrings(parts, workbookPartName!, relationships, resolved, workbook);
-            workbook.Stylesheet = ReadStyles(parts, workbookPartName!, relationships, resolved, workbook);
-            ParseWorkbookPart(parts.ReadPart(workbookPartName!), workbookPartName!, resolved, workbook);
+            IReadOnlyList<string> sharedStrings = ReadSharedStrings(parts, workbookPartName!, relationships,
+                resolved, workbook, recordBudget);
+            workbook.Stylesheet = ReadStyles(parts, workbookPartName!, relationships, resolved,
+                workbook, recordBudget);
+            ParseWorkbookPart(parts.ReadPart(workbookPartName!), workbookPartName!, resolved, workbook,
+                recordBudget);
 
             if (workbook.Worksheets.Count == 0) {
                 throw new InvalidDataException("The XLSB workbook contains no worksheet bundle records.");
@@ -103,6 +107,7 @@ namespace OfficeIMO.Excel.Xlsb {
             }
 
             int totalCells = 0;
+            int totalRowDefinitions = 0;
             int totalMergedRanges = 0;
             int totalHyperlinks = 0;
             foreach (XlsbWorksheet worksheet in workbook.Worksheets) {
@@ -123,7 +128,9 @@ namespace OfficeIMO.Excel.Xlsb {
                     sharedStrings,
                     resolved,
                     workbook,
+                    recordBudget,
                     ref totalCells,
+                    ref totalRowDefinitions,
                     ref totalMergedRanges,
                     ref totalHyperlinks);
             }
@@ -143,8 +150,9 @@ namespace OfficeIMO.Excel.Xlsb {
             byte[] bytes,
             string partName,
             XlsbImportOptions options,
-            XlsbWorkbook workbook) {
-            IReadOnlyList<XlsbRecord> records = ReadRecords(bytes, options);
+            XlsbWorkbook workbook,
+            XlsbRecordReadBudget recordBudget) {
+            IReadOnlyList<XlsbRecord> records = ReadRecords(bytes, options, recordBudget);
             if (records.Count < 2 || records[0].Type != BrtBeginBook || records[records.Count - 1].Type != BrtEndBook) {
                 throw new InvalidDataException($"The XLSB workbook part '{partName}' is missing its BrtBeginBook/BrtEndBook boundaries.");
             }
@@ -366,13 +374,15 @@ namespace OfficeIMO.Excel.Xlsb {
             string workbookPartName,
             IReadOnlyDictionary<string, XlsbPackageRelationship> relationships,
             XlsbImportOptions options,
-            XlsbWorkbook workbook) {
+            XlsbWorkbook workbook,
+            XlsbRecordReadBudget recordBudget) {
             XlsbPackageRelationship? relationship = relationships.Values.FirstOrDefault(item =>
                 !item.IsExternal && item.Type.EndsWith(StylesRelationshipSuffix, StringComparison.Ordinal));
             if (relationship == null) return null;
 
             string partName = XlsbPackagePartReader.ResolveTarget(workbookPartName, relationship.Target);
-            return XlsbStylesheetReader.Read(parts.ReadPart(partName), partName, options, workbook);
+            return XlsbStylesheetReader.Read(parts.ReadPart(partName), partName, options, workbook,
+                recordBudget);
         }
 
         private static IReadOnlyList<string> ReadSharedStrings(
@@ -380,13 +390,15 @@ namespace OfficeIMO.Excel.Xlsb {
             string workbookPartName,
             IReadOnlyDictionary<string, XlsbPackageRelationship> relationships,
             XlsbImportOptions options,
-            XlsbWorkbook workbook) {
+            XlsbWorkbook workbook,
+            XlsbRecordReadBudget recordBudget) {
             XlsbPackageRelationship? relationship = relationships.Values.FirstOrDefault(item =>
                 !item.IsExternal && item.Type.EndsWith(SharedStringsRelationshipSuffix, StringComparison.Ordinal));
             if (relationship == null) return Array.Empty<string>();
 
             string partName = XlsbPackagePartReader.ResolveTarget(workbookPartName, relationship.Target);
-            IReadOnlyList<XlsbRecord> records = ReadRecords(parts.ReadPart(partName), options);
+            IReadOnlyList<XlsbRecord> records = ReadRecords(parts.ReadPart(partName), options,
+                recordBudget);
             var values = new List<string>();
             bool hasBegin = false;
             bool hasEnd = false;
@@ -434,10 +446,12 @@ namespace OfficeIMO.Excel.Xlsb {
             IReadOnlyList<string> sharedStrings,
             XlsbImportOptions options,
             XlsbWorkbook workbook,
+            XlsbRecordReadBudget recordBudget,
             ref int totalCells,
+            ref int totalRowDefinitions,
             ref int totalMergedRanges,
             ref int totalHyperlinks) {
-            IReadOnlyList<XlsbRecord> records = ReadRecords(bytes, options);
+            IReadOnlyList<XlsbRecord> records = ReadRecords(bytes, options, recordBudget);
             if (records.Count < 2 || records[0].Type != BrtBeginSheet || records[records.Count - 1].Type != BrtEndSheet) {
                 throw new InvalidDataException($"The XLSB worksheet part '{partName}' is missing its BrtBeginSheet/BrtEndSheet boundaries.");
             }
@@ -535,6 +549,11 @@ namespace OfficeIMO.Excel.Xlsb {
                             throw new InvalidDataException($"The XLSB row record at offset {record.Offset} is duplicated or out of order.");
                         }
                         previousRow = currentRow.Row - 1;
+                        totalRowDefinitions = checked(totalRowDefinitions + 1);
+                        if (totalRowDefinitions > options.MaxRowDefinitions) {
+                            throw new InvalidDataException(
+                                $"The XLSB workbook exceeds the configured limit of {options.MaxRowDefinitions} row definitions.");
+                        }
                         worksheet.AddRow(currentRow);
                         break;
                     case BrtBeginMergeCells:
@@ -932,9 +951,10 @@ namespace OfficeIMO.Excel.Xlsb {
             }
         }
 
-        private static IReadOnlyList<XlsbRecord> ReadRecords(byte[] bytes, XlsbImportOptions options) {
+        private static IReadOnlyList<XlsbRecord> ReadRecords(byte[] bytes, XlsbImportOptions options,
+            XlsbRecordReadBudget budget) {
             using var stream = new MemoryStream(bytes, writable: false);
-            return XlsbRecordReader.ReadAll(stream, options.MaxRecordBytes);
+            return XlsbRecordReader.ReadAll(stream, options.MaxRecordBytes, budget);
         }
 
         private static void PreserveRecord(

--- a/OfficeIMO.Html.Tests/Html.AccessibleNames.cs
+++ b/OfficeIMO.Html.Tests/Html.AccessibleNames.cs
@@ -99,6 +99,50 @@ public sealed class HtmlAccessibleNameTests {
         Assert.Equal("Download annual report", Find(aria.Root, HtmlLogicalNodeKind.Link).AccessibleName);
     }
 
+    [Fact]
+    public void AccessibilitySemantics_BoundsAriaLabelRecursion() {
+        var html = new System.Text.StringBuilder();
+        for (int index = 0; index < 80; index++) {
+            html.Append("<span id=\"label-").Append(index)
+                .Append("\" aria-labelledby=\"label-").Append(index + 1)
+                .Append("\"></span>");
+        }
+        html.Append("<span id=\"label-80\" aria-label=\"terminal\"></span>");
+        var document = HtmlDocumentParser.ParseDocument(html.ToString());
+
+        string name = HtmlAccessibilitySemantics.GetAccessibleName(
+            document.GetElementById("label-0")!, includeTextFallback: true);
+
+        Assert.Equal(string.Empty, name);
+    }
+
+    [Fact]
+    public void LogicalDocument_BoundsNestedLinkTextFallbacks() {
+        var html = new System.Text.StringBuilder();
+        for (int index = 0; index < 128; index++) {
+            html.Append("<span role=\"link\">");
+        }
+        html.Append(new string('x', 20_000));
+        for (int index = 0; index < 128; index++) html.Append("</span>");
+
+        HtmlLogicalDocument logical = HtmlLogicalDocumentBuilder.FromHtml(html.ToString());
+        string[] names = Descendants(logical.Root)
+            .Where(node => node.Kind == HtmlLogicalNodeKind.Link)
+            .Select(node => node.AccessibleName ?? string.Empty)
+            .ToArray();
+
+        Assert.Equal(128, names.Length);
+        Assert.All(names, name => Assert.InRange(name.Length, 0, 4096));
+        Assert.True(names.Sum(name => (long)name.Length) <= 4L * 1024 * 1024);
+    }
+
+    private static IEnumerable<HtmlLogicalNode> Descendants(HtmlLogicalNode node) {
+        yield return node;
+        foreach (HtmlLogicalNode child in node.Children) {
+            foreach (HtmlLogicalNode descendant in Descendants(child)) yield return descendant;
+        }
+    }
+
     private static HtmlLogicalNode Find(HtmlLogicalNode node, HtmlLogicalNodeKind kind) {
         if (node.Kind == kind) return node;
         foreach (HtmlLogicalNode child in node.Children) {

--- a/OfficeIMO.Html.Tests/Html.AccessibleNames.cs
+++ b/OfficeIMO.Html.Tests/Html.AccessibleNames.cs
@@ -117,6 +117,24 @@ public sealed class HtmlAccessibleNameTests {
     }
 
     [Fact]
+    public void AccessibilitySemantics_BoundsBranchingAriaLabelWork() {
+        var html = new System.Text.StringBuilder("<span id=\"root\" aria-labelledby=\"a-0 b-0\"></span>");
+        for (int index = 0; index < 32; index++) {
+            html.Append("<span id=\"a-").Append(index).Append("\" aria-labelledby=\"a-")
+                .Append(index + 1).Append(" b-").Append(index + 1).Append("\"></span>");
+            html.Append("<span id=\"b-").Append(index).Append("\" aria-labelledby=\"a-")
+                .Append(index + 1).Append(" b-").Append(index + 1).Append("\"></span>");
+        }
+        html.Append("<span id=\"a-32\"></span><span id=\"b-32\"></span>");
+        var document = HtmlDocumentParser.ParseDocument(html.ToString());
+
+        string name = HtmlAccessibilitySemantics.GetAccessibleName(
+            document.GetElementById("root")!, includeTextFallback: true);
+
+        Assert.Equal(string.Empty, name);
+    }
+
+    [Fact]
     public void LogicalDocument_BoundsNestedLinkTextFallbacks() {
         var html = new System.Text.StringBuilder();
         for (int index = 0; index < 128; index++) {
@@ -134,6 +152,27 @@ public sealed class HtmlAccessibleNameTests {
         Assert.Equal(128, names.Length);
         Assert.All(names, name => Assert.InRange(name.Length, 0, 4096));
         Assert.True(names.Sum(name => (long)name.Length) <= 4L * 1024 * 1024);
+    }
+
+    [Fact]
+    public void LogicalDocument_BoundsEmptyNestedLinkTraversalWork() {
+        var html = new System.Text.StringBuilder();
+        for (int index = 0; index < 250; index++) html.Append("<span role=\"link\">");
+        for (int index = 0; index < 250; index++) html.Append("</span>");
+
+        HtmlLogicalDocument logical = HtmlLogicalDocumentBuilder.FromHtml(html.ToString());
+
+        Assert.Equal(250, Descendants(logical.Root).Count(node => node.Kind == HtmlLogicalNodeKind.Link));
+    }
+
+    [Fact]
+    public void LogicalDocument_ChargesLargeSharedTextSourcesAgainstTraversalBudget() {
+        string largeWhitespacePrefix = new string(' ', 4 * 1024 * 1024 + 1) + "visible";
+        string html = "<span role=\"link\">" + largeWhitespacePrefix + "</span>";
+
+        HtmlLogicalDocument logical = HtmlLogicalDocumentBuilder.FromHtml(html);
+
+        Assert.Null(Find(logical.Root, HtmlLogicalNodeKind.Link).AccessibleName);
     }
 
     private static IEnumerable<HtmlLogicalNode> Descendants(HtmlLogicalNode node) {

--- a/OfficeIMO.Html/Accessibility/HtmlAccessibilitySemantics.cs
+++ b/OfficeIMO.Html/Accessibility/HtmlAccessibilitySemantics.cs
@@ -96,13 +96,14 @@ public static class HtmlAccessibilitySemantics {
         int depth) {
         if (element == null) return string.Empty;
         if (depth > MaximumAriaResolutionDepth) return string.Empty;
+        if (!context.TryConsumeTraversalWork()) return string.Empty;
         if (!resolutionPath.Add(element)) return string.Empty;
 
         try {
             string labelledBy = ResolveLabelledBy(element, resolutionPath, context, depth);
             if (labelledBy.Length > 0) return labelledBy;
 
-            string ariaLabel = NormalizeText(element.GetAttribute("aria-label"));
+            string ariaLabel = context.NormalizeText(element.GetAttribute("aria-label"));
             if (ariaLabel.Length > 0) return ariaLabel;
 
             string tagName = element.TagName;
@@ -110,12 +111,12 @@ public static class HtmlAccessibilitySemantics {
                  || tagName.Equals("IMG", StringComparison.OrdinalIgnoreCase)
                  || tagName.Equals("AREA", StringComparison.OrdinalIgnoreCase))
                 && element.HasAttribute("alt")) {
-                return NormalizeText(element.GetAttribute("alt"));
+                return context.NormalizeText(element.GetAttribute("alt"));
             }
             if (tagName.Equals("INPUT", StringComparison.OrdinalIgnoreCase)
                 && string.Equals(element.GetAttribute("type"), "image", StringComparison.OrdinalIgnoreCase)
                 && element.HasAttribute("alt")) {
-                return NormalizeText(element.GetAttribute("alt"));
+                return context.NormalizeText(element.GetAttribute("alt"));
             }
             if (tagName.Equals("SVG", StringComparison.OrdinalIgnoreCase)) {
                 IElement? titleElement = element.Children.FirstOrDefault(static child =>
@@ -129,7 +130,7 @@ public static class HtmlAccessibilitySemantics {
                 if (text.Length > 0) return text;
             }
 
-            return NormalizeText(element.GetAttribute("title"));
+            return context.NormalizeText(element.GetAttribute("title"));
         } finally {
             resolutionPath.Remove(element);
         }
@@ -214,7 +215,26 @@ public static class HtmlAccessibilitySemantics {
 
     internal sealed class HtmlAccessibleNameContext {
         private const int MaximumAggregateNameCharacters = 4 * 1024 * 1024;
+        private const int MaximumTraversalWork = 4 * 1024 * 1024;
         private int _remainingCharacters = MaximumAggregateNameCharacters;
+        private int _remainingTraversalWork = MaximumTraversalWork;
+
+        internal bool TryConsumeTraversalWork(int units = 1) {
+            if (units <= 0) units = 1;
+            if (_remainingTraversalWork < units) {
+                _remainingTraversalWork = 0;
+                return false;
+            }
+            _remainingTraversalWork -= units;
+            return true;
+        }
+
+        internal string NormalizeText(string? value) {
+            if (string.IsNullOrEmpty(value) || !TryConsumeTraversalWork(value!.Length)) {
+                return string.Empty;
+            }
+            return HtmlAccessibilitySemantics.NormalizeText(value);
+        }
 
         internal string Limit(string value) {
             if (_remainingCharacters <= 0 || value.Length == 0) return string.Empty;
@@ -225,7 +245,7 @@ public static class HtmlAccessibilitySemantics {
         }
 
         internal string GetBoundedText(IElement? element) {
-            if (element == null || _remainingCharacters <= 0) return string.Empty;
+            if (element == null || _remainingCharacters <= 0 || !TryConsumeTraversalWork()) return string.Empty;
             var builder = new System.Text.StringBuilder(MaximumAccessibleNameCharacters);
             var stack = new Stack<INode>();
             for (int index = element.ChildNodes.Length - 1; index >= 0; index--) {
@@ -233,9 +253,14 @@ public static class HtmlAccessibilitySemantics {
             }
             bool pendingSpace = false;
             while (stack.Count > 0 && builder.Length < MaximumAccessibleNameCharacters) {
+                if (!TryConsumeTraversalWork()) break;
                 INode node = stack.Pop();
                 if (node.NodeType == NodeType.Text) {
-                    string text = NormalizeText(node.TextContent);
+                    string? sourceText = node.TextContent;
+                    if (string.IsNullOrEmpty(sourceText) || !TryConsumeTraversalWork(sourceText!.Length)) {
+                        continue;
+                    }
+                    string text = HtmlAccessibilitySemantics.NormalizeText(sourceText);
                     if (text.Length == 0) continue;
                     if (pendingSpace && builder.Length < MaximumAccessibleNameCharacters) builder.Append(' ');
                     int available = MaximumAccessibleNameCharacters - builder.Length;

--- a/OfficeIMO.Html/Accessibility/HtmlAccessibilitySemantics.cs
+++ b/OfficeIMO.Html/Accessibility/HtmlAccessibilitySemantics.cs
@@ -7,7 +7,10 @@ namespace OfficeIMO.Html;
 /// used by OfficeIMO document conversion pipelines.
 /// </summary>
 public static class HtmlAccessibilitySemantics {
-    private static readonly char[] TokenSeparators = { ' ', '\t', '\r', '\n', '\f' };
+    private const int MaximumAccessibleNameCharacters = 4096;
+    private const int MaximumAriaResolutionDepth = 64;
+    private const int MaximumTokenSourceCharacters = 8192;
+    private const int MaximumTokens = 256;
 
     /// <summary>Returns whether an element declares the requested ARIA role.</summary>
     public static bool HasRole(IElement element, string role) =>
@@ -66,25 +69,37 @@ public static class HtmlAccessibilitySemantics {
     /// <param name="element">Element to name.</param>
     /// <param name="includeTextFallback">Whether normalized descendant text may supply the name.</param>
     public static string GetAccessibleName(IElement element, bool includeTextFallback = false) =>
-        GetAccessibleName(element, includeTextFallback, treatAsImage: false, new HashSet<IElement>());
+        GetAccessibleName(element, includeTextFallback, new HtmlAccessibleNameContext());
+
+    internal static string GetAccessibleName(IElement element, bool includeTextFallback,
+        HtmlAccessibleNameContext context) =>
+        context.Limit(GetAccessibleName(element, includeTextFallback, treatAsImage: false,
+            new HashSet<IElement>(), context, depth: 0));
 
     /// <summary>
     /// Resolves an accessible image name, including image <c>alt</c> semantics for custom
     /// elements that a converter explicitly aliases to an image.
     /// </summary>
-    public static string GetImageAccessibleName(IElement element) =>
-        GetAccessibleName(element, includeTextFallback: false, treatAsImage: true, new HashSet<IElement>());
+    public static string GetImageAccessibleName(IElement element) {
+        var context = new HtmlAccessibleNameContext();
+        return context.Limit(GetAccessibleName(element,
+            includeTextFallback: false, treatAsImage: true, new HashSet<IElement>(),
+            context, depth: 0));
+    }
 
     private static string GetAccessibleName(
         IElement element,
         bool includeTextFallback,
         bool treatAsImage,
-        ISet<IElement> resolutionPath) {
+        ISet<IElement> resolutionPath,
+        HtmlAccessibleNameContext context,
+        int depth) {
         if (element == null) return string.Empty;
+        if (depth > MaximumAriaResolutionDepth) return string.Empty;
         if (!resolutionPath.Add(element)) return string.Empty;
 
         try {
-            string labelledBy = ResolveLabelledBy(element, resolutionPath);
+            string labelledBy = ResolveLabelledBy(element, resolutionPath, context, depth);
             if (labelledBy.Length > 0) return labelledBy;
 
             string ariaLabel = NormalizeText(element.GetAttribute("aria-label"));
@@ -105,12 +120,12 @@ public static class HtmlAccessibilitySemantics {
             if (tagName.Equals("SVG", StringComparison.OrdinalIgnoreCase)) {
                 IElement? titleElement = element.Children.FirstOrDefault(static child =>
                     child.TagName.Equals("TITLE", StringComparison.OrdinalIgnoreCase));
-                string svgTitle = NormalizeText(titleElement?.TextContent);
+                string svgTitle = context.GetBoundedText(titleElement);
                 if (svgTitle.Length > 0) return svgTitle;
             }
 
             if (includeTextFallback) {
-                string text = NormalizeText(element.TextContent);
+                string text = context.GetBoundedText(element);
                 if (text.Length > 0) return text;
             }
 
@@ -127,30 +142,112 @@ public static class HtmlAccessibilitySemantics {
 
     internal static bool ContainsToken(string? value, string token) {
         if (string.IsNullOrWhiteSpace(value) || string.IsNullOrWhiteSpace(token)) return false;
-        foreach (string candidate in value!.Split(TokenSeparators, StringSplitOptions.RemoveEmptyEntries)) {
+        foreach (string candidate in EnumerateTokens(value!)) {
             if (candidate.Equals(token, StringComparison.OrdinalIgnoreCase)) return true;
         }
         return false;
     }
 
-    private static string ResolveLabelledBy(IElement element, ISet<IElement> resolutionPath) {
+    private static string ResolveLabelledBy(IElement element, ISet<IElement> resolutionPath,
+        HtmlAccessibleNameContext context, int depth) {
         string? value = element.GetAttribute("aria-labelledby");
         if (string.IsNullOrWhiteSpace(value) || element.Owner == null) return string.Empty;
 
         var labels = new List<string>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
-        foreach (string id in value!.Split(TokenSeparators, StringSplitOptions.RemoveEmptyEntries)) {
+        int outputLength = 0;
+        foreach (string id in EnumerateTokens(value!)) {
             if (!seen.Add(id)) continue;
             IElement? label = element.Owner.GetElementById(id);
             if (label == null || ReferenceEquals(label, element)) continue;
-            string text = GetAccessibleName(label, includeTextFallback: true, treatAsImage: false, resolutionPath);
-            if (text.Length > 0) labels.Add(text);
+            string text = GetAccessibleName(label, includeTextFallback: true,
+                treatAsImage: false, resolutionPath, context, depth + 1);
+            if (text.Length == 0) continue;
+            int available = MaximumAccessibleNameCharacters - outputLength - (labels.Count > 0 ? 1 : 0);
+            if (available <= 0) break;
+            if (text.Length > available) text = text.Substring(0, available).TrimEnd();
+            if (text.Length > 0) {
+                labels.Add(text);
+                outputLength += text.Length + (labels.Count > 1 ? 1 : 0);
+            }
         }
         return string.Join(" ", labels);
     }
 
     private static string NormalizeText(string? value) {
         if (string.IsNullOrWhiteSpace(value)) return string.Empty;
-        return string.Join(" ", value!.Split(TokenSeparators, StringSplitOptions.RemoveEmptyEntries));
+        var builder = new System.Text.StringBuilder(
+            Math.Min(value!.Length, MaximumAccessibleNameCharacters));
+        bool pendingSpace = false;
+        foreach (char character in value) {
+            if (IsTokenSeparator(character)) {
+                if (builder.Length > 0) pendingSpace = true;
+                continue;
+            }
+            if (pendingSpace && builder.Length < MaximumAccessibleNameCharacters) {
+                builder.Append(' ');
+            }
+            pendingSpace = false;
+            if (builder.Length >= MaximumAccessibleNameCharacters) break;
+            builder.Append(character);
+        }
+        return builder.ToString();
+    }
+
+    private static IEnumerable<string> EnumerateTokens(string value) {
+        int maximum = Math.Min(value.Length, MaximumTokenSourceCharacters);
+        int count = 0;
+        int offset = 0;
+        while (offset < maximum && count < MaximumTokens) {
+            while (offset < maximum && IsTokenSeparator(value[offset])) offset++;
+            int start = offset;
+            while (offset < maximum && !IsTokenSeparator(value[offset])) offset++;
+            if (offset > start) {
+                count++;
+                yield return value.Substring(start, offset - start);
+            }
+        }
+    }
+
+    private static bool IsTokenSeparator(char value) =>
+        value == ' ' || value == '\t' || value == '\r' || value == '\n' || value == '\f';
+
+    internal sealed class HtmlAccessibleNameContext {
+        private const int MaximumAggregateNameCharacters = 4 * 1024 * 1024;
+        private int _remainingCharacters = MaximumAggregateNameCharacters;
+
+        internal string Limit(string value) {
+            if (_remainingCharacters <= 0 || value.Length == 0) return string.Empty;
+            int length = Math.Min(value.Length,
+                Math.Min(MaximumAccessibleNameCharacters, _remainingCharacters));
+            _remainingCharacters -= length;
+            return length == value.Length ? value : value.Substring(0, length).TrimEnd();
+        }
+
+        internal string GetBoundedText(IElement? element) {
+            if (element == null || _remainingCharacters <= 0) return string.Empty;
+            var builder = new System.Text.StringBuilder(MaximumAccessibleNameCharacters);
+            var stack = new Stack<INode>();
+            for (int index = element.ChildNodes.Length - 1; index >= 0; index--) {
+                stack.Push(element.ChildNodes[index]);
+            }
+            bool pendingSpace = false;
+            while (stack.Count > 0 && builder.Length < MaximumAccessibleNameCharacters) {
+                INode node = stack.Pop();
+                if (node.NodeType == NodeType.Text) {
+                    string text = NormalizeText(node.TextContent);
+                    if (text.Length == 0) continue;
+                    if (pendingSpace && builder.Length < MaximumAccessibleNameCharacters) builder.Append(' ');
+                    int available = MaximumAccessibleNameCharacters - builder.Length;
+                    builder.Append(text, 0, Math.Min(text.Length, available));
+                    pendingSpace = true;
+                    continue;
+                }
+                for (int index = node.ChildNodes.Length - 1; index >= 0; index--) {
+                    stack.Push(node.ChildNodes[index]);
+                }
+            }
+            return builder.ToString().TrimEnd();
+        }
     }
 }

--- a/OfficeIMO.Html/Model/HtmlLogicalDocumentBuilder.cs
+++ b/OfficeIMO.Html/Model/HtmlLogicalDocumentBuilder.cs
@@ -28,11 +28,17 @@ internal static class HtmlLogicalDocumentBuilder {
         INode rootNode = HtmlDocumentParser.GetConversionRoot(document, useBodyContentsOnly);
         var counts = new Dictionary<HtmlLogicalNodeKind, int>();
         var capabilities = new List<string>();
-        HtmlLogicalNode root = Build(rootNode, counts, capabilities, forceRetain: true)!;
+        var accessibleNames = new HtmlAccessibilitySemantics.HtmlAccessibleNameContext();
+        HtmlLogicalNode root = Build(rootNode, counts, capabilities, accessibleNames,
+            forceRetain: true)!;
         return new HtmlLogicalDocument(root, counts, capabilities);
     }
 
-    private static HtmlLogicalNode? Build(INode source, IDictionary<HtmlLogicalNodeKind, int> counts, ICollection<string> capabilities, bool forceRetain = false) {
+    private static HtmlLogicalNode? Build(INode source,
+        IDictionary<HtmlLogicalNodeKind, int> counts,
+        ICollection<string> capabilities,
+        HtmlAccessibilitySemantics.HtmlAccessibleNameContext accessibleNames,
+        bool forceRetain = false) {
         if (!forceRetain && source is IElement sourceElement && IsNonDocumentLogicalElement(sourceElement.TagName)) {
             return null;
         }
@@ -42,7 +48,8 @@ internal static class HtmlLogicalDocumentBuilder {
         if (source is IElement element) {
             string accessibleName = HtmlAccessibilitySemantics.GetAccessibleName(
                 element,
-                includeTextFallback: node.Kind == HtmlLogicalNodeKind.Link);
+                includeTextFallback: node.Kind == HtmlLogicalNodeKind.Link,
+                accessibleNames);
             node.AccessibleName = accessibleName.Length == 0 ? null : accessibleName;
             foreach (IAttr attribute in element.Attributes) {
                 node.AddAttribute(attribute.Name, attribute.Value);
@@ -59,7 +66,7 @@ internal static class HtmlLogicalDocumentBuilder {
                 continue;
             }
 
-            HtmlLogicalNode? childNode = Build(child, counts, capabilities);
+            HtmlLogicalNode? childNode = Build(child, counts, capabilities, accessibleNames);
             if (childNode != null) {
                 node.AddChild(childNode);
             }

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Safety.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.LegacyPpt.Safety.cs
@@ -131,6 +131,18 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void PresentationReader_EnforcesSlideCountBeforeProjection() {
+            byte[] bytes = CreatePresentationBytes();
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                LegacyPptPresentation.Load(bytes,
+                    new LegacyPptImportOptions { MaxSlideCount = 1 }));
+
+            Assert.Contains("slide count", exception.Message,
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
         public void PackageReader_EnforcesInputBudgetBeforeBufferingPathOrStream() {
             byte[] bytes = CreatePresentationBytes();
             int limit = bytes.Length - 1;

--- a/OfficeIMO.PowerPoint/LegacyPpt/LegacyPptImportOptions.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/LegacyPptImportOptions.cs
@@ -13,6 +13,9 @@ namespace OfficeIMO.PowerPoint.LegacyPpt {
         /// <summary>Gets or sets the maximum number of binary records traversed.</summary>
         public int MaxRecordCount { get; set; } = 1_000_000;
 
+        /// <summary>Gets or sets the maximum number of decoded slides.</summary>
+        public int MaxSlideCount { get; set; } = 10_000;
+
         /// <summary>Gets or sets the maximum nested record depth.</summary>
         public int MaxRecordDepth { get; set; } = 64;
 
@@ -40,6 +43,7 @@ namespace OfficeIMO.PowerPoint.LegacyPpt {
         internal void Validate() {
             if (MaxInputBytes < 1) throw new ArgumentOutOfRangeException(nameof(MaxInputBytes));
             if (MaxRecordCount < 1) throw new ArgumentOutOfRangeException(nameof(MaxRecordCount));
+            if (MaxSlideCount < 1) throw new ArgumentOutOfRangeException(nameof(MaxSlideCount));
             if (MaxRecordDepth < 1) throw new ArgumentOutOfRangeException(nameof(MaxRecordDepth));
             if (MaxMasterCount < 1) throw new ArgumentOutOfRangeException(nameof(MaxMasterCount));
             if (MaxConnectorRuleCount < 1) throw new ArgumentOutOfRangeException(nameof(MaxConnectorRuleCount));

--- a/OfficeIMO.PowerPoint/LegacyPpt/LegacyPptPresentation.cs
+++ b/OfficeIMO.PowerPoint/LegacyPpt/LegacyPptPresentation.cs
@@ -240,8 +240,15 @@ namespace OfficeIMO.PowerPoint.LegacyPpt {
             IReadOnlyDictionary<uint, LegacyPptNotesDirectoryEntry> notesDirectory =
                 ReadNotesDirectory(document, options);
 
+            LegacyPptRecord[] slidePersists = slideList.Children.Where(
+                record => record.Type == RecordSlidePersistAtom).ToArray();
+            if (slidePersists.Length > options.MaxSlideCount) {
+                throw new InvalidDataException(
+                    $"The binary PowerPoint slide count {slidePersists.Length} exceeds {options.MaxSlideCount}.");
+            }
+
             int slideIndex = 0;
-            foreach (LegacyPptRecord slidePersist in slideList.Children.Where(record => record.Type == RecordSlidePersistAtom)) {
+            foreach (LegacyPptRecord slidePersist in slidePersists) {
                 cancellationToken.ThrowIfCancellationRequested();
                 if (slidePersist.PayloadLength < 16) {
                     AddDiagnostic("PPT-SLIDE-PERSIST-TRUNCATED", LegacyPptDiagnosticSeverity.Warning,

--- a/OfficeIMO.SharedSource/OpenXml/OfficeOpenXmlPackagePayload.cs
+++ b/OfficeIMO.SharedSource/OpenXml/OfficeOpenXmlPackagePayload.cs
@@ -157,9 +157,11 @@ namespace OfficeIMO.OpenXml.Internal {
                     || string.Equals(element.LocalName, "controls", StringComparison.OrdinalIgnoreCase));
         }
 
-        internal static OfficeVbaProjectInfo CreateVbaProjectInfo(VbaProjectPart part, bool includeSha256) {
+        internal static OfficeVbaProjectInfo CreateVbaProjectInfo(VbaProjectPart part, bool includeSha256,
+            long maxBytes = OfficeVbaProjectInfo.DefaultMaximumProjectBytes) {
             if (part == null) throw new ArgumentNullException(nameof(part));
-            byte[] projectBytes = ReadBytes(part);
+            if (maxBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maxBytes));
+            byte[] projectBytes = ReadBytes(part, maxBytes);
             string? sha256 = includeSha256 ? ComputeSha256(projectBytes) : null;
             bool hasSignature = part.Parts.Any(pair =>
                 pair.OpenXmlPart.RelationshipType.IndexOf("vbaProjectSignature", StringComparison.OrdinalIgnoreCase) >= 0

--- a/OfficeIMO.Word.GoogleDocs/GoogleDocsBatchCompiler.cs
+++ b/OfficeIMO.Word.GoogleDocs/GoogleDocsBatchCompiler.cs
@@ -5,7 +5,9 @@ using System.IO;
 
 namespace OfficeIMO.Word.GoogleDocs {
     internal static class GoogleDocsBatchCompiler {
-        internal static GoogleDocsBatch Build(WordDocument document, GoogleDocsSaveOptions options) {
+        internal static GoogleDocsBatch Build(WordDocument document, GoogleDocsSaveOptions options,
+            CancellationToken cancellationToken = default) {
+            cancellationToken.ThrowIfCancellationRequested();
             var plan = GoogleDocsPlanBuilder.Build(document, options);
             var report = plan.Report;
             var snapshot = document.CreateInspectionSnapshot();
@@ -210,12 +212,15 @@ namespace OfficeIMO.Word.GoogleDocs {
                 }
             }
 
-            AppendExecutedFallbacks(document, options, batch);
+            AppendExecutedFallbacks(document, options, batch, cancellationToken);
 
             return batch;
         }
 
-        private static void AppendExecutedFallbacks(WordDocument document, GoogleDocsSaveOptions options, GoogleDocsBatch batch) {
+        private static void AppendExecutedFallbacks(WordDocument document,
+            GoogleDocsSaveOptions options,
+            GoogleDocsBatch batch,
+            CancellationToken cancellationToken) {
             int targetSectionIndex = Math.Max(0, batch.Plan.SectionCount - 1);
             int fallbackElementIndex = batch.Requests
                 .Where(request => request.SectionIndex == targetSectionIndex)
@@ -241,25 +246,42 @@ namespace OfficeIMO.Word.GoogleDocs {
 
             bool rasterize = HasRasterizedFallback(options.UnsupportedFeatures, batch.Plan);
             if (!rasterize || options.InlineImageMode != GoogleDocsInlineImageMode.TemporaryPublicDriveLease) return;
-            int pageCount = document.GetEstimatedImagePageCount();
-            for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
-                OfficeImageExportResult rendered = document.ExportImage(
-                    OfficeImageExportFormat.Png,
-                    new WordImageExportOptions { IncludeDocumentContent = true, PageIndex = pageIndex });
-                var imageParagraph = new GoogleDocsParagraph { Text = $"[Rendered Word fallback page {pageIndex + 1} of {pageCount}]" };
+            if (options.RasterFallbackImageOptions == null) {
+                throw new InvalidOperationException(
+                    "Raster fallback image options cannot be null.");
+            }
+            WordImageExportOptions imageOptions = options.RasterFallbackImageOptions.Clone();
+            imageOptions.IncludeDocumentContent = true;
+            imageOptions.PageIndex = 0;
+            imageOptions.PageCount = null;
+            var renderedPages = new List<(GoogleDocsParagraph Paragraph, GoogleDocsInlineImage Image)>();
+            document.ExportImages(
+                OfficeImageExportFormat.Png,
+                rendered => {
+                cancellationToken.ThrowIfCancellationRequested();
+                int pageNumber = renderedPages.Count + 1;
+                var imageParagraph = new GoogleDocsParagraph();
+                var inlineImage = new GoogleDocsInlineImage {
+                    Bytes = rendered.Bytes,
+                    FileName = $"officeimo-word-fallback-page-{pageNumber}.png",
+                    ContentType = "image/png",
+                    Width = rendered.Width,
+                    Height = rendered.Height,
+                    IsInline = true,
+                };
                 imageParagraph.AddRun(new GoogleDocsParagraphRun {
                     Text = string.Empty,
-                    InlineImage = new GoogleDocsInlineImage {
-                        Bytes = rendered.Bytes,
-                        FileName = $"officeimo-word-fallback-page-{pageIndex + 1}.png",
-                        ContentType = "image/png",
-                        Description = $"Rendered page {pageIndex + 1} of {pageCount} for Word content without a native Google Docs representation.",
-                        Width = rendered.Width,
-                        Height = rendered.Height,
-                        IsInline = true,
-                    },
+                    InlineImage = inlineImage,
                 });
                 batch.Add(new GoogleDocsInsertParagraphRequest { SectionIndex = targetSectionIndex, ElementIndex = fallbackElementIndex++, Paragraph = imageParagraph });
+                renderedPages.Add((imageParagraph, inlineImage));
+            }, imageOptions, cancellationToken);
+            int pageCount = renderedPages.Count;
+            for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+                renderedPages[pageIndex].Paragraph.Text =
+                    $"[Rendered Word fallback page {pageIndex + 1} of {pageCount}]";
+                renderedPages[pageIndex].Image.Description =
+                    $"Rendered page {pageIndex + 1} of {pageCount} for Word content without a native Google Docs representation.";
             }
             batch.Report.Add(TranslationSeverity.Warning, "RasterFallback", $"Inserted {pageCount} renderer-owned PNG fallback page(s) for unsupported Word content.",
                 code: "DOCS.FALLBACK.RENDERED_PAGES", action: TranslationAction.Rasterize, count: pageCount);

--- a/OfficeIMO.Word.GoogleDocs/GoogleDocsExporter.cs
+++ b/OfficeIMO.Word.GoogleDocs/GoogleDocsExporter.cs
@@ -32,7 +32,8 @@ namespace OfficeIMO.Word.GoogleDocs {
             if (session == null) throw new ArgumentNullException(nameof(session));
 
             var effectiveOptions = options ?? new GoogleDocsSaveOptions();
-            var batch = BuildBatch(document, effectiveOptions);
+            var batch = GoogleDocsBatchCompiler.Build(
+                document, effectiveOptions, cancellationToken);
             GoogleWorkspacePreflight.Validate(batch.Report, effectiveOptions.FidelityPolicy);
             var effectiveLocation = session.ResolveLocationDefaults(effectiveOptions.Location);
             if (string.IsNullOrWhiteSpace(effectiveLocation.FolderId) && !string.IsNullOrWhiteSpace(effectiveLocation.DriveId)) {

--- a/OfficeIMO.Word.GoogleDocs/GoogleDocsExporter.cs
+++ b/OfficeIMO.Word.GoogleDocs/GoogleDocsExporter.cs
@@ -32,8 +32,17 @@ namespace OfficeIMO.Word.GoogleDocs {
             if (session == null) throw new ArgumentNullException(nameof(session));
 
             var effectiveOptions = options ?? new GoogleDocsSaveOptions();
-            var batch = GoogleDocsBatchCompiler.Build(
-                document, effectiveOptions, cancellationToken);
+            GoogleDocsBatch batch;
+            try {
+                batch = GoogleDocsBatchCompiler.Build(
+                    document, effectiveOptions, cancellationToken);
+            } catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested) {
+                throw GoogleWorkspaceFailureDiagnostics.CreateCanceledFailure(
+                    "Google Docs export",
+                    session.Options,
+                    new TranslationReport(),
+                    ex);
+            }
             GoogleWorkspacePreflight.Validate(batch.Report, effectiveOptions.FidelityPolicy);
             var effectiveLocation = session.ResolveLocationDefaults(effectiveOptions.Location);
             if (string.IsNullOrWhiteSpace(effectiveLocation.FolderId) && !string.IsNullOrWhiteSpace(effectiveLocation.DriveId)) {

--- a/OfficeIMO.Word.GoogleDocs/GoogleDocsSaveOptions.cs
+++ b/OfficeIMO.Word.GoogleDocs/GoogleDocsSaveOptions.cs
@@ -1,4 +1,5 @@
 using OfficeIMO.GoogleWorkspace;
+using OfficeIMO.Word;
 
 namespace OfficeIMO.Word.GoogleDocs {
     /// <summary>
@@ -13,6 +14,22 @@ namespace OfficeIMO.Word.GoogleDocs {
         public GoogleDocsTabOptions Tabs { get; set; } = new GoogleDocsTabOptions();
         public GoogleDocsReplaceOptions Replace { get; set; } = new GoogleDocsReplaceOptions();
         public GoogleDocsCommentMode Comments { get; set; } = GoogleDocsCommentMode.UnanchoredDriveComments;
+        /// <summary>
+        /// Bounded renderer settings used when unsupported Word content is rasterized into fallback pages.
+        /// The page range is always the complete document; output-count, pixel, byte, codec, and policy
+        /// settings are honored.
+        /// </summary>
+        public WordImageExportOptions RasterFallbackImageOptions { get; set; } =
+            CreateRasterFallbackImageOptions();
+
+        private static WordImageExportOptions CreateRasterFallbackImageOptions() =>
+            new WordImageExportOptions {
+                MaximumOutputCount = 100,
+                MaximumRasterPixels = 25_000_000,
+                MaximumTotalRasterPixels = 250_000_000,
+                MaximumTotalEncodedBytes = 128L * 1024 * 1024,
+                MaximumDegreeOfParallelism = 1,
+            };
     }
 
     public sealed class GoogleDocsUnsupportedFeatureOptions {

--- a/OfficeIMO.Word.Tests/Word.GoogleDocs.cs
+++ b/OfficeIMO.Word.Tests/Word.GoogleDocs.cs
@@ -1,5 +1,6 @@
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Wordprocessing;
+using OfficeIMO.Drawing;
 using OfficeIMO.GoogleWorkspace;
 using OfficeIMO.Word;
 using OfficeIMO.Word.GoogleDocs;
@@ -143,6 +144,36 @@ namespace OfficeIMO.Tests {
                 Assert.Contains("page 2 of 2", fallbacks[1].Description, StringComparison.OrdinalIgnoreCase);
                 Assert.All(fallbacks, image => Assert.True(image.Bytes.Length > 0));
                 Assert.Contains(batch.Report.Notices, notice => notice.Code == "DOCS.FALLBACK.RENDERED_PAGES" && notice.Count == 2);
+            } finally {
+                if (File.Exists(filePath)) File.Delete(filePath);
+            }
+        }
+
+        [Fact]
+        public void Test_GoogleDocsBatchCompiler_EnforcesRasterFallbackPageBudget() {
+            string filePath = Path.Combine(_directoryWithFiles,
+                "GoogleDocsFallbackLimit.docx");
+            try {
+                using var document = WordDocument.Create(filePath);
+                document.AddParagraph("Page one");
+                document.AddPageBreak();
+                document.AddParagraph("Page two");
+                document.AddStructuredDocumentTag("Unsupported control");
+                var options = new GoogleDocsSaveOptions {
+                    InlineImageMode = GoogleDocsInlineImageMode.TemporaryPublicDriveLease,
+                    RasterFallbackImageOptions = new WordImageExportOptions {
+                        MaximumOutputCount = 1,
+                    },
+                };
+                options.UnsupportedFeatures.ContentControls =
+                    UnsupportedFeatureMode.Rasterize;
+
+                OfficeImageExportBatchLimitException exception =
+                    Assert.Throws<OfficeImageExportBatchLimitException>(() =>
+                        document.BuildGoogleDocsBatch(options));
+
+                Assert.Equal(nameof(OfficeImageExportOptions.MaximumOutputCount),
+                    exception.LimitName);
             } finally {
                 if (File.Exists(filePath)) File.Delete(filePath);
             }

--- a/OfficeIMO.Word.Tests/Word.LegacyDoc.Safety.cs
+++ b/OfficeIMO.Word.Tests/Word.LegacyDoc.Safety.cs
@@ -121,7 +121,17 @@ namespace OfficeIMO.Tests {
             Assert.Null(importOptionsType.GetProperty("MaxWordDocumentStreamBytes"));
             Assert.Null(importOptionsType.GetProperty("ReportUnsupportedFeatures"));
             Assert.NotNull(importOptionsType.GetProperty(nameof(LegacyDocImportOptions.MaxInputBytes)));
+            Assert.NotNull(importOptionsType.GetProperty(nameof(LegacyDocImportOptions.MaxDecodedImageBytes)));
             Assert.NotNull(importOptionsType.GetProperty(nameof(LegacyDocImportOptions.ReportUnsupportedContent)));
+        }
+
+        [Fact]
+        public void LegacyDoc_RejectsNonPositiveDecodedImageBudget() {
+            byte[] bytes = LegacyDocTestBuilder.CreateSimpleDoc("Image budget");
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                OfficeIMO.Word.LegacyDoc.Model.LegacyDocDocument.Load(bytes,
+                    new LegacyDocImportOptions { MaxDecodedImageBytes = 0 }));
         }
 
         private static void AssertOleCompoundBytes(byte[] bytes) {

--- a/OfficeIMO.Word.Tests/Word.Macros.cs
+++ b/OfficeIMO.Word.Tests/Word.Macros.cs
@@ -346,6 +346,9 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(new[] { "Module1", "Module2" }, info.ModuleNames);
                 Assert.Equal(new FileInfo(vbaPath).Length, info.Length);
                 Assert.Equal(64, info.Sha256!.Length);
+                Assert.Throws<InvalidDataException>(() =>
+                    document.InspectVbaProject(includeSha256: false,
+                        maxBytes: info.Length - 1));
                 Assert.Throws<InvalidDataException>(() => document.ExtractMacros(info.Length - 1));
                 Assert.Equal(File.ReadAllBytes(vbaPath), document.ExtractMacros(info.Length));
                 document.Save();

--- a/OfficeIMO.Word/LegacyDoc/LegacyDocImportOptions.cs
+++ b/OfficeIMO.Word/LegacyDoc/LegacyDocImportOptions.cs
@@ -8,10 +8,18 @@ namespace OfficeIMO.Word.LegacyDoc {
         /// </summary>
         public int MaxInputBytes { get; set; } = 64 * 1024 * 1024;
 
+        /// <summary>Maximum aggregate decoded OfficeArt image bytes retained during import.</summary>
+        public int MaxDecodedImageBytes { get; set; } = 64 * 1024 * 1024;
+
         /// <summary>
         /// When true, known unsupported legacy content is reported as diagnostics.
         /// </summary>
         public bool ReportUnsupportedContent { get; set; } = true;
+
+        internal void Validate() {
+            if (MaxInputBytes <= 0) throw new ArgumentOutOfRangeException(nameof(MaxInputBytes));
+            if (MaxDecodedImageBytes <= 0) throw new ArgumentOutOfRangeException(nameof(MaxDecodedImageBytes));
+        }
 
     }
 }

--- a/OfficeIMO.Word/LegacyDoc/Model/LegacyDocDocument.cs
+++ b/OfficeIMO.Word/LegacyDoc/Model/LegacyDocDocument.cs
@@ -99,6 +99,7 @@ namespace OfficeIMO.Word.LegacyDoc.Model {
         public static LegacyDocDocument Load(byte[] bytes, LegacyDocImportOptions? options = null) {
             if (bytes == null) throw new ArgumentNullException(nameof(bytes));
             options ??= new LegacyDocImportOptions();
+            options.Validate();
 
             var document = new LegacyDocDocument();
             if (!OfficeCompoundFileReader.TryRead(bytes, out OfficeCompoundFile? compoundFile, out string? compoundError)) {
@@ -218,7 +219,8 @@ namespace OfficeIMO.Word.LegacyDoc.Model {
                 dataStream,
                 textContent.AllCharacters,
                 formattingRanges,
-                fib.CcpText + fib.CcpFtn + fib.CcpHdd + fib.CcpAtn + fib.CcpEdn);
+                fib.CcpText + fib.CcpFtn + fib.CcpHdd + fib.CcpAtn + fib.CcpEdn,
+                options.MaxDecodedImageBytes);
             if (pictures.Warning != null) {
                 AddWarning("DOC-PICTURE-DATA-INVALID", pictures.Warning);
             }

--- a/OfficeIMO.Word/LegacyDoc/Model/LegacyDocPicture.cs
+++ b/OfficeIMO.Word/LegacyDoc/Model/LegacyDocPicture.cs
@@ -11,6 +11,8 @@ namespace OfficeIMO.Word.LegacyDoc.Model {
 
         internal byte[] ImageBytes => (byte[])_imageBytes.Clone();
 
+        internal int ImageByteCount => _imageBytes.Length;
+
         internal string ContentType { get; }
 
         internal double WidthPixels { get; }

--- a/OfficeIMO.Word/LegacyDoc/Model/LegacyDocPictureReader.cs
+++ b/OfficeIMO.Word/LegacyDoc/Model/LegacyDocPictureReader.cs
@@ -12,13 +12,19 @@ namespace OfficeIMO.Word.LegacyDoc.Model {
             byte[] dataStream,
             IReadOnlyList<LegacyDocTextCharacter> characters,
             IReadOnlyList<LegacyDocCharacterFormatRange> formattingRanges,
-            int supportedStoryCharacterCount) {
+            int supportedStoryCharacterCount,
+            int maximumDecodedImageBytes) {
+            if (maximumDecodedImageBytes <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(maximumDecodedImageBytes));
+            }
             if (dataStream.Length == 0 || supportedStoryCharacterCount <= 0) {
                 return LegacyDocPictureReadResult.Empty;
             }
 
             var pictures = new Dictionary<int, LegacyDocPicture>();
+            var picturesByDataOffset = new Dictionary<int, LegacyDocPicture>();
             var ranges = new Dictionary<int, int>();
+            int decodedImageBytes = 0;
             string? warning = null;
             foreach (LegacyDocTextCharacter character in characters) {
                 if (character.CharacterPosition < 0 || character.CharacterPosition >= supportedStoryCharacterCount
@@ -32,11 +38,20 @@ namespace OfficeIMO.Word.LegacyDoc.Model {
                 }
 
                 int offset = format.PictureDataOffset.Value;
-                if (!TryReadPicture(dataStream, offset, out LegacyDocPicture? picture, out int consumedLength, out string? pictureWarning)) {
+                if (picturesByDataOffset.TryGetValue(offset, out LegacyDocPicture? cachedPicture)) {
+                    pictures[character.CharacterPosition] = cachedPicture;
+                    continue;
+                }
+                int remainingImageBytes = maximumDecodedImageBytes - decodedImageBytes;
+                if (!TryReadPicture(dataStream, offset, remainingImageBytes,
+                        out LegacyDocPicture? picture, out int consumedLength,
+                        out string? pictureWarning)) {
                     warning ??= pictureWarning;
                     continue;
                 }
 
+                decodedImageBytes = checked(decodedImageBytes + picture!.ImageByteCount);
+                picturesByDataOffset.Add(offset, picture);
                 pictures[character.CharacterPosition] = picture!;
                 ranges[offset] = Math.Max(ranges.TryGetValue(offset, out int previousLength) ? previousLength : 0, consumedLength);
             }
@@ -84,6 +99,7 @@ namespace OfficeIMO.Word.LegacyDoc.Model {
         private static bool TryReadPicture(
             byte[] data,
             int offset,
+            int maximumDecodedImageBytes,
             out LegacyDocPicture? picture,
             out int consumedLength,
             out string? warning) {
@@ -139,7 +155,8 @@ namespace OfficeIMO.Word.LegacyDoc.Model {
                     payloadLength,
                     recordInstance,
                     delayStream: null,
-                    out OfficeArtBlipStoreEntry? entry)
+                    out OfficeArtBlipStoreEntry? entry,
+                    maximumDecodedImageBytes)
                 || entry?.HasImportableImage != true) {
                 warning = $"The picture data at DOC Data stream offset {offset} has no importable embedded OfficeArt BLIP.";
                 return false;

--- a/OfficeIMO.Word/LegacyDoc/Write/LegacyDocWriter.Comments.cs
+++ b/OfficeIMO.Word/LegacyDoc/Write/LegacyDocWriter.Comments.cs
@@ -252,16 +252,28 @@ namespace OfficeIMO.Word.LegacyDoc.Write {
             }
 
             internal void BindBodyReferences(Body body, string bodyText) {
+                const int maximumCommentReferences = 100_000;
                 CommentReference[] references = body.Descendants<CommentReference>().ToArray();
-                int[] markerPositions = bodyText
-                    .Select((character, index) => new { character, index })
-                    .Where(item => item.character == LegacyDocCommentReader.CommentReferenceCharacter)
-                    .Select(item => item.index)
-                    .ToArray();
-                if (references.Length != markerPositions.Length) {
+                if (references.Length > maximumCommentReferences) {
+                    throw new NotSupportedException(
+                        $"Native DOC saving supports at most {maximumCommentReferences} comment references.");
+                }
+
+                var markerPositions = new List<int>(references.Length);
+                for (int index = 0; index < bodyText.Length; index++) {
+                    if (bodyText[index] == LegacyDocCommentReader.CommentReferenceCharacter) {
+                        markerPositions.Add(index);
+                    }
+                }
+                if (references.Length != markerPositions.Count) {
                     throw new NotSupportedException(
                         "Native DOC saving could not match body comment-reference elements to encoded comment markers.");
                 }
+
+                IReadOnlyDictionary<string, int> rangeStartCounts = CountCommentMarkers(
+                    body.Descendants<CommentRangeStart>().Select(marker => marker.Id?.Value));
+                IReadOnlyDictionary<string, int> rangeEndCounts = CountCommentMarkers(
+                    body.Descendants<CommentRangeEnd>().Select(marker => marker.Id?.Value));
 
                 var referencedIds = new HashSet<string>(StringComparer.Ordinal);
                 for (int index = 0; index < references.Length; index++) {
@@ -276,10 +288,8 @@ namespace OfficeIMO.Word.LegacyDoc.Write {
                             $"Native DOC saving currently supports one body reference per comment id. Duplicate reference id '{id}' was found.");
                     }
 
-                    int rangeStartCount = body.Descendants<CommentRangeStart>()
-                        .Count(marker => string.Equals(marker.Id?.Value, id, StringComparison.Ordinal));
-                    int rangeEndCount = body.Descendants<CommentRangeEnd>()
-                        .Count(marker => string.Equals(marker.Id?.Value, id, StringComparison.Ordinal));
+                    int rangeStartCount = rangeStartCounts.TryGetValue(id!, out int starts) ? starts : 0;
+                    int rangeEndCount = rangeEndCounts.TryGetValue(id!, out int ends) ? ends : 0;
                     if (rangeStartCount != 1 || rangeEndCount != 1) {
                         throw new NotSupportedException(
                             $"Native DOC saving supports comment id '{id}' only with one matching range start and range end in the body.");
@@ -293,6 +303,18 @@ namespace OfficeIMO.Word.LegacyDoc.Write {
                         throw new NotSupportedException($"Native DOC saving cannot write unreferenced comment id '{id}'.");
                     }
                 }
+            }
+
+            private static IReadOnlyDictionary<string, int> CountCommentMarkers(
+                IEnumerable<string?> markerIds) {
+                var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+                foreach (string? markerId in markerIds) {
+                    if (string.IsNullOrWhiteSpace(markerId)) continue;
+                    counts[markerId!] = counts.TryGetValue(markerId!, out int count)
+                        ? checked(count + 1)
+                        : 1;
+                }
+                return counts;
             }
 
             internal LegacyDocWritableCommentStories CreateStories() {

--- a/OfficeIMO.Word/WordDocument.Conversion.cs
+++ b/OfficeIMO.Word/WordDocument.Conversion.cs
@@ -230,6 +230,7 @@ namespace OfficeIMO.Word {
         private static LegacyDocImportOptions CreateConversionImportOptions(LegacyDocImportOptions options) {
             return new LegacyDocImportOptions {
                 MaxInputBytes = options.MaxInputBytes,
+                MaxDecodedImageBytes = options.MaxDecodedImageBytes,
                 // Conversion loss policy depends on complete unsupported-content discovery.
                 ReportUnsupportedContent = true
             };

--- a/OfficeIMO.Word/WordDocument.PackagePayloads.cs
+++ b/OfficeIMO.Word/WordDocument.PackagePayloads.cs
@@ -9,8 +9,18 @@ namespace OfficeIMO.Word {
         /// <param name="includeSha256">Whether to calculate the project SHA-256 digest.</param>
         /// <returns>Project metadata, or null when the document has no VBA project.</returns>
         public OfficeVbaProjectInfo? InspectVbaProject(bool includeSha256 = false) {
+            return InspectVbaProject(includeSha256, OfficeVbaProjectInfo.DefaultMaximumProjectBytes);
+        }
+
+        /// <summary>Inspects the attached VBA project while enforcing a decoded byte limit.</summary>
+        /// <param name="includeSha256">Whether to calculate the project SHA-256 digest.</param>
+        /// <param name="maxBytes">Maximum decoded VBA project bytes accepted.</param>
+        /// <returns>Project metadata, or null when the document has no VBA project.</returns>
+        public OfficeVbaProjectInfo? InspectVbaProject(bool includeSha256, long maxBytes) {
+            if (maxBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maxBytes));
             VbaProjectPart? part = _wordprocessingDocument.MainDocumentPart?.VbaProjectPart;
-            return part == null ? null : OfficeOpenXmlPackagePayload.CreateVbaProjectInfo(part, includeSha256);
+            return part == null ? null : OfficeOpenXmlPackagePayload.CreateVbaProjectInfo(
+                part, includeSha256, maxBytes);
         }
 
         /// <summary>Extracts a VBA project while enforcing a maximum byte count.</summary>


### PR DESCRIPTION
## Summary

- bound recursive and aggregate work in HTML accessible-name extraction and Google Docs conversion
- enforce decoded object, archive, stream, image, record, and payload budgets across PST, OLM, XLS, XLSB, DOC, PPT, and Open XML readers
- reject adversarial formula nesting and operator chains before recursive parsing
- cover the affected limits with focused regression tests

This is the third security-finding batch and is intentionally stacked on #2133. It contains 17 validated findings.

## Compatibility

Normal documents continue to use the existing APIs. New limits have conservative defaults and remain configurable through the relevant load, import, or save options.

## Validation

- HTML accessible-name focused suite: 13 passed
- XLSB formula-limit focused suite: 3 passed
- PST focused suite: 19 passed
- Full affected suites before review: approximately 8,300 passing tests, with one pre-existing macOS path-alias failure documented separately
- Independent security review completed; all six findings and three targeted confirmation gaps were addressed
