### PR TITLE
Bound resource use across document pipelines

### DIFF
--- a/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvStreamingTests.cs
@@ -104,6 +104,23 @@ public class CsvStreamingTests
     }
 
     [Fact]
+    public async Task StreamLoads_EnforceCompleteInputLimitAndRestorePosition()
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes("Id,Name\n1,Alice\n");
+        using var syncStream = new MemoryStream(bytes);
+        syncStream.Position = 3;
+        Assert.Throws<InvalidDataException>(() =>
+            CsvDocument.Load(syncStream, new CsvLoadOptions { MaxInputBytes = 8 }));
+        Assert.Equal(3, syncStream.Position);
+
+        using var asyncStream = new MemoryStream(bytes);
+        asyncStream.Position = 4;
+        await Assert.ThrowsAsync<InvalidDataException>(() =>
+            CsvDocument.LoadAsync(asyncStream, new CsvLoadOptions { MaxInputBytes = 8 }));
+        Assert.Equal(4, asyncStream.Position);
+    }
+
+    [Fact]
     public void LoadOptionsClone_PreservesCallerErrorSinkWithoutMutatingMissingSink()
     {
         var originalError = new CsvParseError(1, "original", new FormatException("original"));

--- a/OfficeIMO.CSV/CsvDocument.Loading.cs
+++ b/OfficeIMO.CSV/CsvDocument.Loading.cs
@@ -281,7 +281,7 @@ public sealed partial class CsvDocument
 
         options = options?.Clone() ?? new CsvLoadOptions();
         var encoding = options.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-        byte[] snapshot = OfficeStreamReader.ReadAllBytes(stream);
+        byte[] snapshot = OfficeStreamReader.ReadAllBytes(stream, options.MaxInputBytes);
         return LoadInternal(
             () => CsvFile.OpenTextReader(
                 new MemoryStream(snapshot, writable: false),
@@ -310,7 +310,10 @@ public sealed partial class CsvDocument
         if (!stream.CanRead) throw new ArgumentException("Stream must be readable.", nameof(stream));
         CsvLoadOptions resolved = options?.Clone() ?? new CsvLoadOptions();
         Encoding encoding = resolved.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-        byte[] snapshot = await OfficeStreamReader.ReadAllBytesAsync(stream, cancellationToken).ConfigureAwait(false);
+        byte[] snapshot = await OfficeStreamReader.ReadAllBytesAsync(
+            stream,
+            cancellationToken,
+            resolved.MaxInputBytes).ConfigureAwait(false);
         return LoadInternal(
             () => CsvFile.OpenTextReader(
                 new MemoryStream(snapshot, writable: false),

--- a/OfficeIMO.CSV/CsvLoadOptions.cs
+++ b/OfficeIMO.CSV/CsvLoadOptions.cs
@@ -13,6 +13,9 @@ public sealed class CsvLoadOptions
 {
     private const char DefaultDelimiter = ',';
 
+    /// <summary>Default maximum complete stream input size (256 MiB).</summary>
+    public const long DefaultMaxInputBytes = 256L * 1024L * 1024L;
+
     /// <summary>
     /// Gets or sets whether the first record in the file represents the header row. Default is <c>true</c>.
     /// Ignored when <see cref="Header"/> is provided; in that case the first record is treated as data.
@@ -147,6 +150,12 @@ public sealed class CsvLoadOptions
     /// Gets or sets an optional limit for decompressed bytes read from compressed CSV files.
     /// </summary>
     public long? MaxDecompressedBytes { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of bytes accepted by stream-based load APIs.
+    /// Defaults to 256 MiB so non-seekable and never-ending inputs cannot be buffered without bound.
+    /// </summary>
+    public long MaxInputBytes { get; set; } = DefaultMaxInputBytes;
 
     /// <summary>
     /// Gets or sets an optional cancellation token checked while reading records.

--- a/OfficeIMO.Drawing.Tests/Drawing.ImageOptimization.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.ImageOptimization.cs
@@ -169,6 +169,19 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void OfficeJpegCodec_RejectsOrientedDecodeBeforeAllocatingSecondRgbaBuffer() {
+            var source = new OfficeRasterImage(8, 8, OfficeColor.Red);
+            byte[] jpeg = OfficeJpegCodec.Encode(source, new OfficeJpegEncodeOptions {
+                Metadata = new OfficeJpegMetadata(exif: CreateExifOrientation(6))
+            });
+            SetJpegFrameDimensions(jpeg, 5000, 5000);
+
+            FormatException exception = Assert.Throws<FormatException>(() => OfficeJpegCodec.Decode(jpeg));
+
+            Assert.Contains("dimensions exceed", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
         public void OfficeJpegCodec_DecodesIndependentJpegFixture() {
             byte[] jpeg = File.ReadAllBytes(Path.Combine(AppContext.BaseDirectory, "TestAssets", "Kulek.jpg"));
             OfficeImageInfo identified = OfficeImageReader.Identify(jpeg);
@@ -263,6 +276,24 @@ namespace OfficeIMO.Tests {
                 }
             }
             return image;
+        }
+
+        private static byte[] CreateExifOrientation(ushort orientation) => new byte[] {
+            (byte)'I', (byte)'I', 0x2A, 0x00, 0x08, 0x00, 0x00, 0x00,
+            0x01, 0x00,
+            0x12, 0x01, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00,
+            (byte)orientation, (byte)(orientation >> 8), 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00
+        };
+
+        private static void SetJpegFrameDimensions(byte[] jpeg, ushort width, ushort height) {
+            int frame = FindMarker(jpeg, 0xC0);
+            if (frame < 0) frame = FindMarker(jpeg, 0xC2);
+            Assert.True(frame >= 0);
+            jpeg[frame + 5] = (byte)(height >> 8);
+            jpeg[frame + 6] = (byte)height;
+            jpeg[frame + 7] = (byte)(width >> 8);
+            jpeg[frame + 8] = (byte)width;
         }
 
         private static byte[] BuildSeparateComponentBaselineJpeg() {

--- a/OfficeIMO.Drawing.Tests/Drawing.ImageOptimization.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.ImageOptimization.cs
@@ -129,6 +129,20 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void OfficeJpegCodec_RejectsDuplicateScanComponentsBeforeDecoding() {
+            byte[] jpeg = OfficeJpegCodec.Encode(
+                new OfficeRasterImage(1, 1, OfficeColor.Red),
+                new OfficeJpegEncodeOptions { Subsampling = OfficeJpegSubsampling.Y444 });
+            int startOfScan = FindMarker(jpeg, 0xDA);
+            Assert.True(startOfScan > 0);
+            jpeg[startOfScan + 7] = jpeg[startOfScan + 5];
+
+            FormatException exception = Assert.Throws<FormatException>(() => OfficeJpegCodec.Decode(jpeg));
+
+            Assert.Contains("Duplicate", exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void OfficeJpegCodec_DecodesBaselineComponentsStoredInSeparateScans() {
             byte[] jpeg = BuildSeparateComponentBaselineJpeg();
 

--- a/OfficeIMO.Drawing.Tests/Drawing.ImageOptimization.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.ImageOptimization.cs
@@ -115,6 +115,20 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void OfficeJpegCodec_RejectsExcessiveSamplingBeforeDecoderStateAllocation() {
+            byte[] jpeg = OfficeJpegCodec.Encode(
+                new OfficeRasterImage(1, 1, OfficeColor.Red),
+                new OfficeJpegEncodeOptions { Subsampling = OfficeJpegSubsampling.Y444 });
+            int startOfFrame = FindMarker(jpeg, 0xC0);
+            Assert.True(startOfFrame > 0);
+            jpeg[startOfFrame + 11] = 0x44;
+
+            FormatException exception = Assert.Throws<FormatException>(() => OfficeJpegCodec.Decode(jpeg));
+
+            Assert.Contains("sampling", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
         public void OfficeJpegCodec_DecodesBaselineComponentsStoredInSeparateScans() {
             byte[] jpeg = BuildSeparateComponentBaselineJpeg();
 

--- a/OfficeIMO.Drawing/Internal/OfficeStreamReader.cs
+++ b/OfficeIMO.Drawing/Internal/OfficeStreamReader.cs
@@ -22,8 +22,19 @@ namespace OfficeIMO.Drawing.Internal {
         /// Reads from the caller's current position through the end of the stream without rewinding.
         /// </summary>
         public static byte[] ReadRemainingBytes(Stream source, long? maxBytes = null) {
+            return ReadRemainingBytes(source, CancellationToken.None, maxBytes);
+        }
+
+        /// <summary>
+        /// Reads from the caller's current position through the end of the stream without rewinding,
+        /// with cooperative cancellation.
+        /// </summary>
+        public static byte[] ReadRemainingBytes(
+            Stream source,
+            CancellationToken cancellationToken,
+            long? maxBytes = null) {
             ValidateRemainingSource(source, maxBytes);
-            return ReadToEnd(source, CancellationToken.None, maxBytes);
+            return ReadToEnd(source, cancellationToken, maxBytes);
         }
 
         /// <summary>Reads a complete artifact with cooperative cancellation.</summary>

--- a/OfficeIMO.Drawing/Internal/OfficeStreamReader.cs
+++ b/OfficeIMO.Drawing/Internal/OfficeStreamReader.cs
@@ -18,6 +18,14 @@ namespace OfficeIMO.Drawing.Internal {
         public static byte[] ReadAllBytes(Stream source, long? maxBytes = null) =>
             ReadAllBytes(source, CancellationToken.None, maxBytes);
 
+        /// <summary>
+        /// Reads from the caller's current position through the end of the stream without rewinding.
+        /// </summary>
+        public static byte[] ReadRemainingBytes(Stream source, long? maxBytes = null) {
+            ValidateRemainingSource(source, maxBytes);
+            return ReadToEnd(source, CancellationToken.None, maxBytes);
+        }
+
         /// <summary>Reads a complete artifact with cooperative cancellation.</summary>
         public static byte[] ReadAllBytes(
             Stream source,
@@ -81,6 +89,15 @@ namespace OfficeIMO.Drawing.Internal {
             if (maxBytes.HasValue && maxBytes.Value < 1) throw new ArgumentOutOfRangeException(nameof(maxBytes));
             if (source.CanSeek && maxBytes.HasValue && source.Length > maxBytes.Value) {
                 throw new InvalidDataException($"Stream exceeds the configured maximum size ({maxBytes.Value} bytes).");
+            }
+        }
+
+        private static void ValidateRemainingSource(Stream source, long? maxBytes) {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (!source.CanRead) throw new ArgumentException("Stream must be readable.", nameof(source));
+            if (maxBytes.HasValue && maxBytes.Value < 1) throw new ArgumentOutOfRangeException(nameof(maxBytes));
+            if (source.CanSeek && maxBytes.HasValue && source.Length - source.Position > maxBytes.Value) {
+                throw new InvalidDataException($"Remaining stream content exceeds the configured maximum size ({maxBytes.Value} bytes).");
             }
         }
 

--- a/OfficeIMO.Drawing/Jpeg/OfficeJpegReader.Decode.Helpers.cs
+++ b/OfficeIMO.Drawing/Jpeg/OfficeJpegReader.Decode.Helpers.cs
@@ -573,10 +573,11 @@ internal static partial class OfficeJpegReader {
 
     private static ScanHeader ParseScanHeader(OfficeByteView data, ref JpegFrame frame) {
         var components = data[0];
-        if (components == 0) throw new FormatException("Invalid JPEG scan component count.");
+        if (components == 0 || components > frame.ComponentCount) throw new FormatException("Invalid JPEG scan component count.");
         if (data.Length < 1 + components * 2 + 3) throw new FormatException("Invalid JPEG scan header.");
 
         var indices = new int[components];
+        var seenComponents = new bool[frame.ComponentCount];
         var offset = 1;
         for (var i = 0; i < components; i++) {
             var id = data[offset++];
@@ -585,6 +586,8 @@ internal static partial class OfficeJpegReader {
             var ac = table & 0x0F;
             var index = FindComponentIndex(frame.Components, id);
             if (index < 0) throw new FormatException("Unknown JPEG component in scan.");
+            if (seenComponents[index]) throw new FormatException("Duplicate JPEG component in scan.");
+            seenComponents[index] = true;
             frame.Components[index].DcTable = (byte)dc;
             frame.Components[index].AcTable = (byte)ac;
             indices[i] = index;

--- a/OfficeIMO.Drawing/Jpeg/OfficeJpegReader.Decode.Helpers.cs
+++ b/OfficeIMO.Drawing/Jpeg/OfficeJpegReader.Decode.Helpers.cs
@@ -808,13 +808,14 @@ internal static partial class OfficeJpegReader {
         public int McuCols;
         public int McuRows;
 
-        public static BaselineState Create(JpegFrame frame) {
+        public static BaselineState Create(JpegFrame frame, int orientation) {
             var mcuWidth = frame.MaxH * 8;
             var mcuHeight = frame.MaxV * 8;
             var mcuCols = (frame.Width + mcuWidth - 1) / mcuWidth;
             var mcuRows = (frame.Height + mcuHeight - 1) / mcuHeight;
             var components = new BaselineComponentState[frame.ComponentCount];
-            long aggregateBytes = checked((long)frame.Width * frame.Height * 4L);
+            long rgbaBytes = checked((long)frame.Width * frame.Height * 4L);
+            long aggregateBytes = checked(rgbaBytes * (orientation > 1 ? 2L : 1L));
             if (aggregateBytes > OfficeRasterGuards.MaximumDecodedBytes) {
                 throw new FormatException(JpegDimensionsLimitMessage);
             }
@@ -893,7 +894,7 @@ internal static partial class OfficeJpegReader {
         public int McuCols;
         public int McuRows;
 
-        public static ProgressiveState Create(JpegFrame frame, int[][] quantTables) {
+        public static ProgressiveState Create(JpegFrame frame, int[][] quantTables, int orientation) {
             var maxH = frame.MaxH;
             var maxV = frame.MaxV;
             var mcuWidth = maxH * 8;
@@ -902,7 +903,8 @@ internal static partial class OfficeJpegReader {
             var mcuRows = (frame.Height + mcuHeight - 1) / mcuHeight;
 
             var components = new ProgressiveComponentState[frame.ComponentCount];
-            long aggregateBytes = checked((long)frame.Width * frame.Height * 4L);
+            long rgbaBytes = checked((long)frame.Width * frame.Height * 4L);
+            long aggregateBytes = checked(rgbaBytes * (orientation > 1 ? 2L : 1L));
             if (aggregateBytes > OfficeRasterGuards.MaximumDecodedBytes) {
                 throw new FormatException(JpegDimensionsLimitMessage);
             }

--- a/OfficeIMO.Drawing/Jpeg/OfficeJpegReader.Decode.Helpers.cs
+++ b/OfficeIMO.Drawing/Jpeg/OfficeJpegReader.Decode.Helpers.cs
@@ -531,7 +531,9 @@ internal static partial class OfficeJpegReader {
         if (!OfficeRasterGuards.TryEnsurePixelCount(width, height, out _)) {
             throw new FormatException(JpegDimensionsLimitMessage);
         }
-        if (components == 0) throw new FormatException("Invalid JPEG component count.");
+        if (components != 1 && components != 3 && components != 4) {
+            throw new FormatException("Unsupported JPEG component count.");
+        }
         if (data.Length < 6 + components * 3) throw new FormatException("Invalid JPEG SOF segment.");
 
         var frame = new JpegFrame {
@@ -544,13 +546,16 @@ internal static partial class OfficeJpegReader {
         var offset = 6;
         var maxH = 0;
         var maxV = 0;
+        var samplingUnits = 0;
         for (var i = 0; i < components; i++) {
             var id = data[offset++];
             var sampling = data[offset++];
             var h = sampling >> 4;
             var v = sampling & 0x0F;
             var qt = data[offset++];
-            if (h == 0 || v == 0) throw new FormatException("Invalid JPEG sampling factors.");
+            if (h == 0 || v == 0 || h > 4 || v > 4) throw new FormatException("Invalid JPEG sampling factors.");
+            samplingUnits = checked(samplingUnits + h * v);
+            if (samplingUnits > 10) throw new FormatException("JPEG sampling factors exceed supported limits.");
             if (qt >= 4) throw new FormatException("Unsupported JPEG quantization table.");
             frame.Components[i] = new Component {
                 Id = id,
@@ -806,11 +811,15 @@ internal static partial class OfficeJpegReader {
             var mcuCols = (frame.Width + mcuWidth - 1) / mcuWidth;
             var mcuRows = (frame.Height + mcuHeight - 1) / mcuHeight;
             var components = new BaselineComponentState[frame.ComponentCount];
+            long aggregateBytes = checked((long)frame.Width * frame.Height * 4L);
+            if (aggregateBytes > OfficeRasterGuards.MaximumDecodedBytes) {
+                throw new FormatException(JpegDimensionsLimitMessage);
+            }
             for (var i = 0; i < frame.ComponentCount; i++) {
                 var component = frame.Components[i];
                 var blocksPerRow = OfficeRasterGuards.EnsureByteCount((long)mcuCols * component.H, JpegDimensionsLimitMessage);
                 var blocksPerCol = OfficeRasterGuards.EnsureByteCount((long)mcuRows * component.V, JpegDimensionsLimitMessage);
-                components[i] = new BaselineComponentState(component, blocksPerRow, blocksPerCol);
+                components[i] = new BaselineComponentState(component, blocksPerRow, blocksPerCol, ref aggregateBytes);
             }
 
             return new BaselineState {
@@ -840,16 +849,39 @@ internal static partial class OfficeJpegReader {
         public int BlocksPerCol;
         public int PrevDc;
 
-        public BaselineComponentState(Component component, int blocksPerRow, int blocksPerCol) {
+        public BaselineComponentState(Component component, int blocksPerRow, int blocksPerCol, ref long aggregateBytes) {
             Component = component;
             BlocksPerRow = blocksPerRow;
             BlocksPerCol = blocksPerCol;
             Stride = OfficeRasterGuards.EnsureByteCount((long)blocksPerRow * 8, JpegDimensionsLimitMessage);
-            var bufferLength = OfficeRasterGuards.EnsureByteCount((long)Stride * blocksPerCol * 8, JpegDimensionsLimitMessage);
+            var bufferLength = OfficeRasterGuards.EnsureInt32ArrayLength((long)Stride * blocksPerCol * 8, ref aggregateBytes, JpegDimensionsLimitMessage);
             Buffer = new int[bufferLength];
-            BlockCoeffs = new int[64];
-            BlockPixels = new int[64];
+            BlockCoeffs = new int[OfficeRasterGuards.EnsureInt32ArrayLength(64, ref aggregateBytes, JpegDimensionsLimitMessage)];
+            BlockPixels = new int[OfficeRasterGuards.EnsureInt32ArrayLength(64, ref aggregateBytes, JpegDimensionsLimitMessage)];
             PrevDc = 0;
+        }
+
+        public static BaselineComponentState FromDecodedBuffer(
+            Component component,
+            int blocksPerRow,
+            int blocksPerCol,
+            int stride,
+            int[] buffer) {
+            return new BaselineComponentState {
+                Component = component,
+                BlocksPerRow = blocksPerRow,
+                BlocksPerCol = blocksPerCol,
+                Stride = stride,
+                Buffer = buffer,
+                BlockCoeffs = Array.Empty<int>(),
+                BlockPixels = Array.Empty<int>()
+            };
+        }
+
+        private BaselineComponentState() {
+            Buffer = Array.Empty<int>();
+            BlockCoeffs = Array.Empty<int>();
+            BlockPixels = Array.Empty<int>();
         }
     }
 
@@ -867,6 +899,10 @@ internal static partial class OfficeJpegReader {
             var mcuRows = (frame.Height + mcuHeight - 1) / mcuHeight;
 
             var components = new ProgressiveComponentState[frame.ComponentCount];
+            long aggregateBytes = checked((long)frame.Width * frame.Height * 4L);
+            if (aggregateBytes > OfficeRasterGuards.MaximumDecodedBytes) {
+                throw new FormatException(JpegDimensionsLimitMessage);
+            }
             for (var i = 0; i < frame.ComponentCount; i++) {
                 var comp = frame.Components[i];
                 if (comp.QuantId >= quantTables.Length || quantTables[comp.QuantId] is null) {
@@ -874,7 +910,7 @@ internal static partial class OfficeJpegReader {
                 }
                 var blocksPerRow = OfficeRasterGuards.EnsureByteCount((long)mcuCols * comp.H, JpegDimensionsLimitMessage);
                 var blocksPerCol = OfficeRasterGuards.EnsureByteCount((long)mcuRows * comp.V, JpegDimensionsLimitMessage);
-                components[i] = new ProgressiveComponentState(comp, blocksPerRow, blocksPerCol);
+                components[i] = new ProgressiveComponentState(comp, blocksPerRow, blocksPerCol, ref aggregateBytes);
             }
 
             return new ProgressiveState {
@@ -900,11 +936,12 @@ internal static partial class OfficeJpegReader {
             var baselineStates = new BaselineComponentState[Components.Length];
             for (var i = 0; i < Components.Length; i++) {
                 var compState = Components[i];
-                var baseline = new BaselineComponentState(compState.Component, compState.BlocksPerRow, compState.BlocksPerCol) {
-                    Buffer = compState.Buffer,
-                    Stride = compState.Stride
-                };
-                baselineStates[i] = baseline;
+                baselineStates[i] = BaselineComponentState.FromDecodedBuffer(
+                    compState.Component,
+                    compState.BlocksPerRow,
+                    compState.BlocksPerCol,
+                    compState.Stride,
+                    compState.Buffer);
             }
 
             return ComposeRgba(frame, baselineStates, adobeTransform, highQualityChroma);
@@ -928,17 +965,17 @@ internal static partial class OfficeJpegReader {
         public int Stride;
         public int PrevDc;
 
-        public ProgressiveComponentState(Component component, int blocksPerRow, int blocksPerCol) {
+        public ProgressiveComponentState(Component component, int blocksPerRow, int blocksPerCol, ref long aggregateBytes) {
             Component = component;
             BlocksPerRow = blocksPerRow;
             BlocksPerCol = blocksPerCol;
             Stride = OfficeRasterGuards.EnsureByteCount((long)blocksPerRow * 8, JpegDimensionsLimitMessage);
-            var coeffLength = OfficeRasterGuards.EnsureByteCount((long)BlocksPerRow * BlocksPerCol * 64, JpegDimensionsLimitMessage);
-            var bufferLength = OfficeRasterGuards.EnsureByteCount((long)Stride * blocksPerCol * 8, JpegDimensionsLimitMessage);
+            var coeffLength = OfficeRasterGuards.EnsureInt32ArrayLength((long)BlocksPerRow * BlocksPerCol * 64, ref aggregateBytes, JpegDimensionsLimitMessage);
+            var bufferLength = OfficeRasterGuards.EnsureInt32ArrayLength((long)Stride * blocksPerCol * 8, ref aggregateBytes, JpegDimensionsLimitMessage);
             Coeffs = new int[coeffLength];
             Buffer = new int[bufferLength];
-            BlockCoeffs = new int[64];
-            BlockPixels = new int[64];
+            BlockCoeffs = new int[OfficeRasterGuards.EnsureInt32ArrayLength(64, ref aggregateBytes, JpegDimensionsLimitMessage)];
+            BlockPixels = new int[OfficeRasterGuards.EnsureInt32ArrayLength(64, ref aggregateBytes, JpegDimensionsLimitMessage)];
             PrevDc = 0;
         }
     }

--- a/OfficeIMO.Drawing/Jpeg/OfficeJpegReader.Decode.Scan.cs
+++ b/OfficeIMO.Drawing/Jpeg/OfficeJpegReader.Decode.Scan.cs
@@ -13,29 +13,12 @@ internal static partial class OfficeJpegReader {
         HuffmanTable[] acTables,
         int restartInterval,
         bool allowTruncated) {
-        if (frame.ComponentCount == 0) throw new FormatException("Invalid JPEG frame.");
-        if (frame.ComponentCount != 1 && frame.ComponentCount != 3 && frame.ComponentCount != 4) {
-            throw new FormatException("Unsupported JPEG component count.");
-        }
-        if (scan.Ss != 0 || scan.Se != 63 || scan.Ah != 0 || scan.Al != 0) {
-            throw new FormatException("Invalid baseline JPEG scan parameters.");
-        }
-
-        EnsureStandardHuffmanTables(dcTables, acTables);
+        ValidateBaselineScan(scan, frame, quantTables, dcTables, acTables);
 
         var states = state.Components;
         for (var i = 0; i < scan.ComponentIndices.Length; i++) {
             var componentIndex = scan.ComponentIndices[i];
             var comp = frame.Components[componentIndex];
-            if (comp.QuantId >= quantTables.Length || quantTables[comp.QuantId] is null) {
-                throw new FormatException("Missing JPEG quantization table.");
-            }
-            if (comp.DcTable >= dcTables.Length || !dcTables[comp.DcTable].IsValid) {
-                throw new FormatException("Missing JPEG DC Huffman table.");
-            }
-            if (comp.AcTable >= acTables.Length || !acTables[comp.AcTable].IsValid) {
-                throw new FormatException("Missing JPEG AC Huffman table.");
-            }
             states[componentIndex].Component = comp;
             states[componentIndex].PrevDc = 0;
         }
@@ -106,6 +89,37 @@ internal static partial class OfficeJpegReader {
         }
     }
 
+    private static void ValidateBaselineScan(
+        ScanHeader scan,
+        JpegFrame frame,
+        int[][] quantTables,
+        HuffmanTable[] dcTables,
+        HuffmanTable[] acTables) {
+        if (frame.ComponentCount == 0) throw new FormatException("Invalid JPEG frame.");
+        if (frame.ComponentCount != 1 && frame.ComponentCount != 3 && frame.ComponentCount != 4) {
+            throw new FormatException("Unsupported JPEG component count.");
+        }
+        if (scan.Ss != 0 || scan.Se != 63 || scan.Ah != 0 || scan.Al != 0) {
+            throw new FormatException("Invalid baseline JPEG scan parameters.");
+        }
+
+        EnsureStandardHuffmanTables(dcTables, acTables);
+
+        for (var i = 0; i < scan.ComponentIndices.Length; i++) {
+            var componentIndex = scan.ComponentIndices[i];
+            var comp = frame.Components[componentIndex];
+            if (comp.QuantId >= quantTables.Length || quantTables[comp.QuantId] is null) {
+                throw new FormatException("Missing JPEG quantization table.");
+            }
+            if (comp.DcTable >= dcTables.Length || !dcTables[comp.DcTable].IsValid) {
+                throw new FormatException("Missing JPEG DC Huffman table.");
+            }
+            if (comp.AcTable >= acTables.Length || !acTables[comp.AcTable].IsValid) {
+                throw new FormatException("Missing JPEG AC Huffman table.");
+            }
+        }
+    }
+
     private static void DecodeProgressiveScan(
         OfficeByteView scanData,
         ScanHeader scan,
@@ -116,10 +130,7 @@ internal static partial class OfficeJpegReader {
         HuffmanTable[] acTables,
         int restartInterval,
         bool allowTruncated) {
-        EnsureStandardHuffmanTables(dcTables, acTables);
-        if (scan.Ss > 0 && scan.ComponentIndices.Length != 1) {
-            throw new FormatException("Progressive JPEG AC scans must contain exactly one component.");
-        }
+        ValidateProgressiveScan(scan, frame, quantTables, dcTables, acTables);
         // Progressive scans are lenient to match historical behavior.
         var reader = new JpegBitReader(scanData, allowTruncated);
         var mcuIndex = 0;
@@ -186,6 +197,30 @@ internal static partial class OfficeJpegReader {
                 }
 
                 mcuIndex++;
+            }
+        }
+    }
+
+    private static void ValidateProgressiveScan(
+        ScanHeader scan,
+        JpegFrame frame,
+        int[][] quantTables,
+        HuffmanTable[] dcTables,
+        HuffmanTable[] acTables) {
+        EnsureStandardHuffmanTables(dcTables, acTables);
+        if (scan.Ss > 0 && scan.ComponentIndices.Length != 1) {
+            throw new FormatException("Progressive JPEG AC scans must contain exactly one component.");
+        }
+        foreach (int componentIndex in scan.ComponentIndices) {
+            Component component = frame.Components[componentIndex];
+            if (component.QuantId >= quantTables.Length || quantTables[component.QuantId] is null) {
+                throw new FormatException("Missing JPEG quantization table.");
+            }
+            if (scan.Ss == 0 && (component.DcTable >= dcTables.Length || !dcTables[component.DcTable].IsValid)) {
+                throw new FormatException("Missing JPEG DC Huffman table.");
+            }
+            if (scan.Se > 0 && (component.AcTable >= acTables.Length || !acTables[component.AcTable].IsValid)) {
+                throw new FormatException("Missing JPEG AC Huffman table.");
             }
         }
     }

--- a/OfficeIMO.Drawing/Jpeg/OfficeJpegReader.cs
+++ b/OfficeIMO.Drawing/Jpeg/OfficeJpegReader.cs
@@ -128,7 +128,7 @@ internal static partial class OfficeJpegReader {
 
                 if (!progressive) {
                     ValidateBaselineScan(scan, frame, quantTables, dcTables, acTables);
-                    baselineState ??= BaselineState.Create(frame);
+                    baselineState ??= BaselineState.Create(frame, orientation);
                     DecodeBaselineScan(
                         scanData,
                         scan,
@@ -144,7 +144,7 @@ internal static partial class OfficeJpegReader {
                 }
 
                 ValidateProgressiveScan(scan, frame, quantTables, dcTables, acTables);
-                progressiveState ??= ProgressiveState.Create(frame, quantTables);
+                progressiveState ??= ProgressiveState.Create(frame, quantTables, orientation);
                 DecodeProgressiveScan(
                     scanData,
                     scan,

--- a/OfficeIMO.Drawing/Jpeg/OfficeJpegReader.cs
+++ b/OfficeIMO.Drawing/Jpeg/OfficeJpegReader.cs
@@ -127,6 +127,7 @@ internal static partial class OfficeJpegReader {
                 var scanData = data.Slice(offset, scanEnd - offset);
 
                 if (!progressive) {
+                    ValidateBaselineScan(scan, frame, quantTables, dcTables, acTables);
                     baselineState ??= BaselineState.Create(frame);
                     DecodeBaselineScan(
                         scanData,
@@ -142,6 +143,7 @@ internal static partial class OfficeJpegReader {
                     continue;
                 }
 
+                ValidateProgressiveScan(scan, frame, quantTables, dcTables, acTables);
                 progressiveState ??= ProgressiveState.Create(frame, quantTables);
                 DecodeProgressiveScan(
                     scanData,

--- a/OfficeIMO.Drawing/Raster/OfficeRasterGuards.cs
+++ b/OfficeIMO.Drawing/Raster/OfficeRasterGuards.cs
@@ -5,6 +5,7 @@ namespace OfficeIMO.Drawing;
 internal static class OfficeRasterGuards {
     internal const long MaximumPixels = 50_000_000L;
     internal const int MaximumEncodedBytes = 128 * 1024 * 1024;
+    internal const long MaximumDecodedBytes = 256L * 1024L * 1024L;
 
     public static void EnsurePayloadWithinLimits(int length, string message) {
         if (length < 0 || length > MaximumEncodedBytes) throw new FormatException(message);
@@ -30,6 +31,19 @@ internal static class OfficeRasterGuards {
     public static int EnsureByteCount(long bytes, string message) {
         if (bytes <= 0 || bytes > int.MaxValue || bytes > MaximumEncodedBytes) throw new FormatException(message);
         return (int)bytes;
+    }
+
+    public static int EnsureInt32ArrayLength(long elements, ref long aggregateBytes, string message) {
+        if (elements <= 0 || elements > int.MaxValue) throw new FormatException(message);
+        long bytes;
+        try {
+            bytes = checked(elements * sizeof(int));
+            aggregateBytes = checked(aggregateBytes + bytes);
+        } catch (OverflowException) {
+            throw new FormatException(message);
+        }
+        if (aggregateBytes > MaximumDecodedBytes) throw new FormatException(message);
+        return (int)elements;
     }
 
     public static byte[] AllocatePixelBuffer(int width, int height, string message) =>

--- a/OfficeIMO.Email/Msg/MsgParserState.cs
+++ b/OfficeIMO.Email/Msg/MsgParserState.cs
@@ -17,6 +17,8 @@ internal sealed class MsgParserState {
 
     internal long DecodedPropertyBytes { get; private set; }
 
+    internal long RemainingDecodedPropertyBytes => Options.MaxDecodedPropertyBytes - DecodedPropertyBytes;
+
     internal int AttachmentCount { get; private set; }
 
     internal long TotalAttachmentBytes { get; private set; }

--- a/OfficeIMO.Email/Msg/MsgProjection.cs
+++ b/OfficeIMO.Email/Msg/MsgProjection.cs
@@ -516,7 +516,7 @@ internal static class MsgProjection {
     private static string? GetRtf(MapiPropertyBag properties, MsgParserState state, string location) {
         MapiProperty? property = properties.Find(MapiKnownProperties.PidTag.RtfCompressed);
         if (!(property?.Value is byte[] compressed)) return null;
-        if (!MapiCompressedRtfCodec.TryDecompress(compressed, state.Options.MaxDecodedPropertyBytes,
+        if (!MapiCompressedRtfCodec.TryDecompress(compressed, state.RemainingDecodedPropertyBytes,
             state.Diagnostics, string.Concat(location, "/rtf"), state.CancellationToken, out byte[] rtfBytes)) return null;
         state.CountDecodedBytes(rtfBytes.Length);
         char[] characters = new char[rtfBytes.Length];

--- a/OfficeIMO.Excel.Tests/Excel.WorksheetPackageCopyPerformanceContracts.cs
+++ b/OfficeIMO.Excel.Tests/Excel.WorksheetPackageCopyPerformanceContracts.cs
@@ -8,7 +8,7 @@ using Xunit;
 namespace OfficeIMO.Tests {
     public partial class Excel {
         [Fact]
-        public void Test_CopyWorksheetFrom_PackageModeEmptyTargetAdoptsSourceIndexes() {
+        public void Test_CopyWorksheetFrom_PackageModeRewritesSharedStringsWithoutAdoptingSourceTable() {
             string sourcePath = Path.Combine(_directoryWithFiles, "WorksheetCopyIndexedSource.xlsx");
             string targetPath = Path.Combine(_directoryWithFiles, "WorksheetCopyIndexedTarget.xlsx");
 
@@ -32,9 +32,7 @@ namespace OfficeIMO.Tests {
                     "Imported",
                     SheetNameValidationMode.Sanitize,
                     new ExcelWorksheetCopyOptions { CopyMode = ExcelWorksheetCopyMode.Package });
-                Assert.False(copied.WorksheetPart.IsRootElementLoaded);
                 targetDocument.Save();
-                Assert.False(copied.WorksheetPart.IsRootElementLoaded);
                 targetDocument.AddWorksheet("AfterCopy").CellValue(1, 1, "New shared string");
                 targetDocument.Save();
             }
@@ -42,11 +40,16 @@ namespace OfficeIMO.Tests {
             using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(targetPath, false)) {
                 WorkbookPart workbookPart = spreadsheet.WorkbookPart!;
                 Assert.NotNull(workbookPart.SharedStringTablePart);
+                Assert.Equal(
+                    new[] { "New shared string" },
+                    workbookPart.SharedStringTablePart!.SharedStringTable!.Elements<SharedStringItem>()
+                        .Select(static item => item.InnerText));
                 WorksheetPart importedPart = workbookPart.WorksheetParts.Single(part =>
                     part.TableDefinitionParts.Any(tablePart => tablePart.Table?.Name?.Value == "SourceSales"));
                 Cell header = importedPart.Worksheet.Descendants<Cell>()
                     .Single(cell => cell.CellReference?.Value == "A1");
-                Assert.Equal(CellValues.SharedString, header.DataType?.Value);
+                Assert.Equal(CellValues.InlineString, header.DataType?.Value);
+                Assert.Equal("Region", header.InnerText);
                 Assert.NotNull(header.StyleIndex);
                 Assert.NotEqual(0U, header.StyleIndex!.Value);
             }

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.FastPath.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.FastPath.cs
@@ -55,6 +55,7 @@ namespace OfficeIMO.Excel {
         private static bool CanCopyWorksheetPartGraphDirectly(ExcelDocument sourceDocument, WorksheetPart sourcePart) {
             WorkbookPart sourceWorkbookPart = sourceDocument.WorkbookPartRoot;
             if (sourcePart.IsRootElementLoaded
+                || sourceWorkbookPart.SharedStringTablePart != null
                 || sourceWorkbookPart.CellMetadataPart != null
                 || sourceDocument.WorkbookRoot.ExternalReferences != null
                 || sourceDocument.WorkbookRoot.DefinedNames?.Elements<DefinedName>().Any() == true
@@ -76,13 +77,6 @@ namespace OfficeIMO.Excel {
             WorkbookPart sourceWorkbookPart = sourceDocument.WorkbookPartRoot;
             if (sourceWorkbookPart.WorkbookStylesPart is WorkbookStylesPart sourceStylesPart) {
                 WorkbookPartRoot.AddPart(sourceStylesPart);
-            }
-
-            if (sourceWorkbookPart.SharedStringTablePart is SharedStringTablePart sourceSharedStringsPart) {
-                _sharedStringTablePart = WorkbookPartRoot.AddPart(sourceSharedStringsPart);
-                _sharedStringTableCount = -1;
-                _sharedStringCache.Clear();
-                _sharedStringLineBreakCache?.Clear();
             }
 
             ThemePart? sourceThemePart = sourceWorkbookPart.GetPartsOfType<ThemePart>().FirstOrDefault();

--- a/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
+++ b/OfficeIMO.Excel/ExcelDocument.WorksheetPackageCopy.cs
@@ -60,8 +60,8 @@ namespace OfficeIMO.Excel {
 
                 WorksheetPart copiedPart = WorkbookPartRoot.AddNewPart<WorksheetPart>();
                 copiedPart.Worksheet = (Worksheet)sourcePart.Worksheet!.CloneNode(true);
+                RewriteSharedStringCellsToInlineStrings(copiedPart.Worksheet, sourceDocument.WorkbookPartRoot.SharedStringTablePart);
                 if (!adoptedSourceIndexes) {
-                    RewriteSharedStringCellsToInlineStrings(copiedPart.Worksheet, sourceDocument.WorkbookPartRoot.SharedStringTablePart);
                     WorksheetStyleCopyMap styleMap = RemapCopiedWorksheetStyles(sourceDocument.WorkbookPartRoot, WorkbookPartRoot, copiedPart.Worksheet);
                     RemapCopiedWorksheetConditionalFormats(copiedPart.Worksheet, styleMap.DifferentialFormats);
                     ConvertCopiedWorksheetDateSerials(copiedPart.Worksheet, sourceDocument.DateSystem, DateSystem);

--- a/OfficeIMO.Html.Pdf/HtmlPdfRenderedConverter.cs
+++ b/OfficeIMO.Html.Pdf/HtmlPdfRenderedConverter.cs
@@ -9,7 +9,8 @@ namespace OfficeIMO.Html.Pdf;
 
 internal static class HtmlPdfRenderedConverter {
     private const double PointsPerCssPixel = 72D / HtmlRenderOptions.CssPixelsPerInch;
-    private const int MaximumSystemFontFamilyCandidates = 32;
+    private const int MaximumSystemFontFamilyCandidates = 512;
+    private const int MaximumLoadedSystemFontFamilies = 32;
 
     internal static HtmlPdfRenderResult Convert(HtmlConversionDocument document, HtmlPdfSaveOptions options) {
         HtmlRenderOptions renderOptions = ResolveRenderOptions(options);
@@ -580,6 +581,7 @@ internal static class HtmlPdfRenderedConverter {
             .OfType<HtmlRenderText>()
             .Where(text => !EnumerateFamilies(text.Font.FamilyName).Any(activeWebFontFamilies.Contains))
             .ToList();
+        int loadedFamilyCount = 0;
 
         foreach (string familyName in textRuns
                      .SelectMany(text => EnumerateFamilies(text.Font.FamilyName))
@@ -593,12 +595,15 @@ internal static class HtmlPdfRenderedConverter {
                 continue;
             }
 
-                if (!PdfCore.PdfEmbeddedFontFamily.TryFromSystem(familyName, out PdfCore.PdfEmbeddedFontFamily? family) || family == null) {
-                    continue;
-                }
+            if (loadedFamilyCount >= MaximumLoadedSystemFontFamilies) break;
+
+            if (!PdfCore.PdfEmbeddedFontFamily.TryFromSystem(familyName, out PdfCore.PdfEmbeddedFontFamily? family) || family == null) {
+                continue;
+            }
 
             pdf.Options.RegisterNamedFontFamily(CreateCoverageSafeFontFamily(family, familyRuns));
             reservedFontSlots.Add(PdfCore.PdfStandardFontMapper.GetFontFamily(MapStandardFont(familyName)));
+            loadedFamilyCount++;
         }
     }
 

--- a/OfficeIMO.Html.Pdf/HtmlPdfRenderedConverter.cs
+++ b/OfficeIMO.Html.Pdf/HtmlPdfRenderedConverter.cs
@@ -9,6 +9,7 @@ namespace OfficeIMO.Html.Pdf;
 
 internal static class HtmlPdfRenderedConverter {
     private const double PointsPerCssPixel = 72D / HtmlRenderOptions.CssPixelsPerInch;
+    private const int MaximumSystemFontFamilyCandidates = 32;
 
     internal static HtmlPdfRenderResult Convert(HtmlConversionDocument document, HtmlPdfSaveOptions options) {
         HtmlRenderOptions renderOptions = ResolveRenderOptions(options);
@@ -102,7 +103,7 @@ internal static class HtmlPdfRenderedConverter {
             StringComparer.OrdinalIgnoreCase);
         PdfCore.PdfTextFallbackFeatures activeTextFallbacks = ResolveTextFallbackFeatures(rendered, options.TextFallbacks);
         if (activeTextFallbacks != PdfCore.PdfTextFallbackFeatures.None && options.ResourcePolicy.AllowSystemFontEmbedding) {
-            RegisterUsedSystemFontFamilies(pdf, rendered, activeWebFontFamilies, reservedFontSlots);
+            RegisterUsedSystemFontFamilies(pdf, rendered, activeWebFontFamilies, reservedFontSlots, cancellationToken);
         }
         ReserveUsedStandardFontSlots(rendered, activeWebFontFamilies, reservedFontSlots);
         IReadOnlyDictionary<string, PdfCore.PdfStandardFont> webFonts = RegisterWebFonts(
@@ -573,7 +574,8 @@ internal static class HtmlPdfRenderedConverter {
         PdfCore.PdfDocument pdf,
         HtmlRenderDocument rendered,
         ISet<string> activeWebFontFamilies,
-        ISet<PdfCore.PdfStandardFont> reservedFontSlots) {
+        ISet<PdfCore.PdfStandardFont> reservedFontSlots,
+        CancellationToken cancellationToken) {
         List<HtmlRenderText> textRuns = EnumerateVisuals(rendered.Pages.SelectMany(page => page.Visuals))
             .OfType<HtmlRenderText>()
             .Where(text => !EnumerateFamilies(text.Font.FamilyName).Any(activeWebFontFamilies.Contains))
@@ -581,7 +583,9 @@ internal static class HtmlPdfRenderedConverter {
 
         foreach (string familyName in textRuns
                      .SelectMany(text => EnumerateFamilies(text.Font.FamilyName))
-                     .Distinct(StringComparer.OrdinalIgnoreCase)) {
+                     .Distinct(StringComparer.OrdinalIgnoreCase)
+                     .Take(MaximumSystemFontFamilyCandidates)) {
+            cancellationToken.ThrowIfCancellationRequested();
             List<HtmlRenderText> familyRuns = textRuns
                 .Where(text => EnumerateFamilies(text.Font.FamilyName).Contains(familyName, StringComparer.OrdinalIgnoreCase))
                 .ToList();

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfAnnotationCreationTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfAnnotationCreationTests.cs
@@ -116,9 +116,15 @@ public class PdfAnnotationCreationTests {
         PdfAnnotation annotation = Assert.Single(PdfInspector.Inspect(added.Bytes, readOptions).GetAnnotationsBySubtype("Text"));
         PdfAnnotationEditResult updated = added.ToDocument().Annotations.Update(
             annotation.ObjectNumber!.Value,
-            new PdfAnnotationUpdateOptions { Contents = "Updated encrypted note" });
+            new PdfAnnotationUpdateOptions {
+                Contents = "Updated encrypted note",
+                AllowResidualDataInAppendOnly = true
+            });
         PdfAnnotationEditResult removed = updated.ToDocument().Annotations.Remove(
-            new PdfAnnotationRemovalOptions { ObjectNumber = annotation.ObjectNumber });
+            new PdfAnnotationRemovalOptions {
+                ObjectNumber = annotation.ObjectNumber,
+                AllowResidualDataInAppendOnly = true
+            });
 
         Assert.Equal(PdfMutationExecutionMode.AppendOnly, added.MutationPlan.ExecutionMode);
         Assert.Equal("Updated encrypted note", Assert.Single(PdfInspector.Inspect(updated.Bytes, readOptions).GetAnnotationsBySubtype("Text")).Contents);

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfAssociatedFileTestSupport.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfAssociatedFileTestSupport.cs
@@ -27,6 +27,26 @@ internal static class PdfAssociatedFileTestSupport {
         return BuildFileAttachmentAnnotationPdf(includePageAssociatedFile: false);
     }
 
+    internal static byte[] BuildDuplicateNamedFileAttachmentAnnotationsPdf() {
+        const string firstPayload = "FIRST-DUPLICATE-PAYLOAD";
+        const string secondPayload = "SECOND-DUPLICATE-PAYLOAD";
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /Annots [7 0 R 10 0 R] >>", "endobj",
+            "4 0 obj", "<< /Length 0 >>", "stream", string.Empty, "endstream", "endobj",
+            "5 0 obj", "<< /Type /Filespec /F (duplicate.txt) /UF (duplicate.txt) /EF << /F 6 0 R /UF 6 0 R >> >>", "endobj",
+            "6 0 obj", "<< /Type /EmbeddedFile /Subtype /text#2Fplain /Length " + firstPayload.Length.ToString(System.Globalization.CultureInfo.InvariantCulture) + " >>", "stream", firstPayload, "endstream", "endobj",
+            "7 0 obj", "<< /Type /Annot /Subtype /FileAttachment /Rect [10 10 30 30] /FS 5 0 R >>", "endobj",
+            "8 0 obj", "<< /Type /Filespec /F (duplicate.txt) /UF (duplicate.txt) /EF << /F 9 0 R /UF 9 0 R >> >>", "endobj",
+            "9 0 obj", "<< /Type /EmbeddedFile /Subtype /text#2Fplain /Length " + secondPayload.Length.ToString(System.Globalization.CultureInfo.InvariantCulture) + " >>", "stream", secondPayload, "endstream", "endobj",
+            "10 0 obj", "<< /Type /Annot /Subtype /FileAttachment /Rect [40 10 60 30] /FS 8 0 R >>", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 11 >>", "%%EOF"
+        }) + "\n";
+        return Encoding.ASCII.GetBytes(pdf);
+    }
+
     private static byte[] BuildFileAttachmentAnnotationPdf(bool includePageAssociatedFile) {
         string associatedFiles = includePageAssociatedFile ? " /AF [5 0 R]" : string.Empty;
         string pdf = string.Join("\n", new[] {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfAssociatedFileTestSupport.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfAssociatedFileTestSupport.cs
@@ -18,4 +18,19 @@ internal static class PdfAssociatedFileTestSupport {
         }) + "\n";
         return Encoding.ASCII.GetBytes(pdf);
     }
+
+    internal static byte[] BuildFileAttachmentAnnotationPdf() {
+        string pdf = string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /AF [5 0 R] /Annots [7 0 R] >>", "endobj",
+            "4 0 obj", "<< /Length 0 >>", "stream", string.Empty, "endstream", "endobj",
+            "5 0 obj", "<< /Type /Filespec /F (page.txt) /UF (page.txt) /AFRelationship /Data /EF << /F 6 0 R /UF 6 0 R >> >>", "endobj",
+            "6 0 obj", "<< /Type /EmbeddedFile /Subtype /text#2Fplain /Length " + Payload.Length.ToString(System.Globalization.CultureInfo.InvariantCulture) + " >>", "stream", Payload, "endstream", "endobj",
+            "7 0 obj", "<< /Type /Annot /Subtype /FileAttachment /Rect [10 10 30 30] /FS 5 0 R >>", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 8 >>", "%%EOF"
+        }) + "\n";
+        return Encoding.ASCII.GetBytes(pdf);
+    }
 }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfAssociatedFileTestSupport.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfAssociatedFileTestSupport.cs
@@ -20,11 +20,20 @@ internal static class PdfAssociatedFileTestSupport {
     }
 
     internal static byte[] BuildFileAttachmentAnnotationPdf() {
+        return BuildFileAttachmentAnnotationPdf(includePageAssociatedFile: true);
+    }
+
+    internal static byte[] BuildStandaloneFileAttachmentAnnotationPdf() {
+        return BuildFileAttachmentAnnotationPdf(includePageAssociatedFile: false);
+    }
+
+    private static byte[] BuildFileAttachmentAnnotationPdf(bool includePageAssociatedFile) {
+        string associatedFiles = includePageAssociatedFile ? " /AF [5 0 R]" : string.Empty;
         string pdf = string.Join("\n", new[] {
             "%PDF-1.7",
             "1 0 obj", "<< /Type /Catalog /Pages 2 0 R >>", "endobj",
             "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
-            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /AF [5 0 R] /Annots [7 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R" + associatedFiles + " /Annots [7 0 R] >>", "endobj",
             "4 0 obj", "<< /Length 0 >>", "stream", string.Empty, "endstream", "endobj",
             "5 0 obj", "<< /Type /Filespec /F (page.txt) /UF (page.txt) /AFRelationship /Data /EF << /F 6 0 R /UF 6 0 R >> >>", "endobj",
             "6 0 obj", "<< /Type /EmbeddedFile /Subtype /text#2Fplain /Length " + Payload.Length.ToString(System.Globalization.CultureInfo.InvariantCulture) + " >>", "stream", Payload, "endstream", "endobj",

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfAttachmentEditorTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfAttachmentEditorTests.cs
@@ -99,6 +99,32 @@ public class PdfAttachmentEditorTests {
     }
 
     [Fact]
+    public void Edit_RetainsStandaloneFileAttachmentAnnotationWhenAddingAnotherAttachment() {
+        byte[] source = PdfAssociatedFileTestSupport.BuildStandaloneFileAttachmentAnnotationPdf();
+        Assert.Single(PdfAttachmentExtractor.ExtractAttachmentsByFileName(source, "page.txt"));
+
+        byte[] output = PdfAttachmentEditor.Add(
+            source,
+            new PdfEmbeddedFile("new.txt", Encoding.UTF8.GetBytes("new payload"), "text/plain")).ToBytes();
+        var (objects, _) = PdfSyntax.ParseObjects(output);
+
+        Assert.Single(objects.Values, static item =>
+            (item.Value as PdfDictionary)?.Get<PdfName>("Subtype")?.Name == "FileAttachment");
+        Assert.Single(PdfAttachmentExtractor.ExtractAttachmentsByFileName(output, "page.txt"));
+        Assert.Single(PdfAttachmentExtractor.ExtractAttachmentsByFileName(output, "new.txt"));
+    }
+
+    [Fact]
+    public void EditSession_AllowsDuplicateNamesAlreadyPresentInTheSource() {
+        var session = new PdfAttachmentEditSession(new[] {
+            new PdfEmbeddedFile("duplicate.txt", new byte[] { 1 }),
+            new PdfEmbeddedFile("duplicate.txt", new byte[] { 2 })
+        });
+
+        Assert.Equal(2, session.Attachments.Count);
+    }
+
+    [Fact]
     public void Edit_RemovesFileAttachmentAnnotationWhenItsPayloadIsRemoved() {
         byte[] source = PdfAssociatedFileTestSupport.BuildFileAttachmentAnnotationPdf();
 

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfAttachmentEditorTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfAttachmentEditorTests.cs
@@ -125,6 +125,31 @@ public class PdfAttachmentEditorTests {
     }
 
     [Fact]
+    public void Edit_PreservesDuplicateNamedAnnotationPayloadIdentity() {
+        byte[] source = PdfAssociatedFileTestSupport.BuildDuplicateNamedFileAttachmentAnnotationsPdf();
+
+        byte[] output = PdfAttachmentEditor.Add(
+            source,
+            new PdfEmbeddedFile("new.txt", Encoding.UTF8.GetBytes("new payload"), "text/plain"))
+            .ToBytes();
+        var (objects, _) = PdfSyntax.ParseObjects(output);
+        PdfDictionary[] annotations = objects.Values
+            .Select(static item => item.Value as PdfDictionary)
+            .Where(static dictionary =>
+                string.Equals(dictionary?.Get<PdfName>("Subtype")?.Name,
+                    "FileAttachment", StringComparison.Ordinal))
+            .Select(static dictionary => dictionary!)
+            .OrderBy(static dictionary => Assert.IsType<PdfNumber>(
+                Assert.IsType<PdfArray>(dictionary.Items["Rect"]).Items[0]).Value)
+            .ToArray();
+
+        Assert.Equal(2, annotations.Length);
+        Assert.Equal("FIRST-DUPLICATE-PAYLOAD", ReadAnnotationPayload(objects, annotations[0]));
+        Assert.Equal("SECOND-DUPLICATE-PAYLOAD", ReadAnnotationPayload(objects, annotations[1]));
+        Assert.Equal(2, PdfAttachmentExtractor.ExtractAttachmentsByFileName(output, "duplicate.txt").Count);
+    }
+
+    [Fact]
     public void Edit_RemovesFileAttachmentAnnotationWhenItsPayloadIsRemoved() {
         byte[] source = PdfAssociatedFileTestSupport.BuildFileAttachmentAnnotationPdf();
 
@@ -144,5 +169,16 @@ public class PdfAttachmentEditorTests {
 
         Assert.Equal(PdfReadLimitKind.DecodedStreamBytes, exception.Kind);
         Assert.Equal(8, exception.Limit);
+    }
+
+    private static string ReadAnnotationPayload(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfDictionary annotation) {
+        PdfReference fileSpecReference = Assert.IsType<PdfReference>(annotation.Items["FS"]);
+        PdfDictionary fileSpec = Assert.IsType<PdfDictionary>(objects[fileSpecReference.ObjectNumber].Value);
+        PdfDictionary embeddedFiles = Assert.IsType<PdfDictionary>(fileSpec.Items["EF"]);
+        PdfReference embeddedFileReference = Assert.IsType<PdfReference>(embeddedFiles.Items["UF"]);
+        PdfStream embeddedFile = Assert.IsType<PdfStream>(objects[embeddedFileReference.ObjectNumber].Value);
+        return Encoding.ASCII.GetString(embeddedFile.Data);
     }
 }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfAttachmentEditorTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfAttachmentEditorTests.cs
@@ -83,6 +83,33 @@ public class PdfAttachmentEditorTests {
     }
 
     [Fact]
+    public void Edit_RetainsAndReconnectsFileAttachmentAnnotations() {
+        byte[] source = PdfAssociatedFileTestSupport.BuildFileAttachmentAnnotationPdf();
+
+        byte[] output = PdfAttachmentEditor.Rename(source, "page.txt", "renamed.txt").ToBytes();
+        var (objects, _) = PdfSyntax.ParseObjects(output);
+        PdfDictionary annotation = Assert.Single(
+            objects.Values.Select(static item => item.Value as PdfDictionary),
+            static dictionary => string.Equals(dictionary?.Get<PdfName>("Subtype")?.Name, "FileAttachment", StringComparison.Ordinal))!;
+        PdfReference fileSpecificationReference = Assert.IsType<PdfReference>(annotation.Items["FS"]);
+        PdfDictionary fileSpecification = Assert.IsType<PdfDictionary>(objects[fileSpecificationReference.ObjectNumber].Value);
+
+        Assert.Equal("renamed.txt", fileSpecification.Get<PdfStringObj>("UF")?.Value);
+        Assert.Single(PdfAttachmentExtractor.ExtractAttachmentsByFileName(output, "renamed.txt"));
+    }
+
+    [Fact]
+    public void Edit_RemovesFileAttachmentAnnotationWhenItsPayloadIsRemoved() {
+        byte[] source = PdfAssociatedFileTestSupport.BuildFileAttachmentAnnotationPdf();
+
+        byte[] output = PdfAttachmentEditor.Remove(source, "page.txt").ToBytes();
+        var (objects, _) = PdfSyntax.ParseObjects(output);
+
+        Assert.DoesNotContain(objects.Values, static item =>
+            (item.Value as PdfDictionary)?.Get<PdfName>("Subtype")?.Name == "FileAttachment");
+    }
+
+    [Fact]
     public void ReadDocument_AppliesDecodedStreamLimitToPageAssociatedFiles() {
         byte[] source = PdfAssociatedFileTestSupport.BuildPageAssociatedFilePdf();
         var options = new PdfReadOptions { Limits = new PdfReadLimits { MaxDecodedStreamBytes = 8 } };

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfAttachmentEditorTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfAttachmentEditorTests.cs
@@ -64,6 +64,25 @@ public class PdfAttachmentEditorTests {
     }
 
     [Fact]
+    public void Edit_RemoveDeletesUnreferencedEmbeddedFileObjectsFromTheRewrittenGraph() {
+        byte[] source = PdfDocument.Create()
+            .Paragraph(p => p.Text("Attachment graph cleanup"))
+            .AttachFile("hidden-marker.txt", Encoding.ASCII.GetBytes("hidden-attachment-marker"), "text/plain")
+            .ToBytes();
+
+        byte[] output = PdfAttachmentEditor.Remove(source, "hidden-marker.txt").ToBytes();
+        var (objects, _) = PdfSyntax.ParseObjects(output);
+
+        Assert.Empty(PdfAttachmentExtractor.ExtractAttachments(output));
+        Assert.DoesNotContain(objects.Values, static item =>
+            item.Value is PdfStream stream &&
+            string.Equals(stream.Dictionary.Get<PdfName>("Type")?.Name, "EmbeddedFile", StringComparison.Ordinal));
+        Assert.DoesNotContain(objects.Values, static item =>
+            (item.Value as PdfDictionary)?.Items.ContainsKey("EF") == true);
+        Assert.DoesNotContain("hidden-attachment-marker", PdfEncoding.Latin1GetString(output), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ReadDocument_AppliesDecodedStreamLimitToPageAssociatedFiles() {
         byte[] source = PdfAssociatedFileTestSupport.BuildPageAssociatedFilePdf();
         var options = new PdfReadOptions { Limits = new PdfReadLimits { MaxDecodedStreamBytes = 8 } };

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfDebuggerTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfDebuggerTests.cs
@@ -53,4 +53,27 @@ public class PdfDebuggerTests {
         Assert.Throws<PdfPasswordRequiredException>(() => PdfDebugger.Dump(encrypted));
         Assert.Throws<ArgumentOutOfRangeException>(() => PdfDebugger.Dump(encrypted, new PdfDebuggerOptions { MaxContentOperatorsPerPage = 0 }, new PdfReadOptions { Password = "open" }));
     }
+
+    [Fact]
+    public void Dump_PathAndStreamEnforceParserInputBudgetBeforeBuffering() {
+        byte[] source = PdfDocument.Create().Paragraph(paragraph => paragraph.Text("Bounded debugger")).ToBytes();
+        var readOptions = new PdfReadOptions {
+            Limits = new PdfReadLimits { MaxInputBytes = source.Length - 1L }
+        };
+
+        using var stream = new MemoryStream(source);
+        PdfReadLimitException streamException = Assert.Throws<PdfReadLimitException>(() =>
+            PdfDebugger.Dump(stream, readOptions: readOptions));
+        Assert.Equal(PdfReadLimitKind.InputBytes, streamException.Kind);
+
+        string path = Path.Combine(Path.GetTempPath(), "OfficeIMO.Pdf.Debugger." + Guid.NewGuid().ToString("N") + ".pdf");
+        try {
+            File.WriteAllBytes(path, source);
+            PdfReadLimitException pathException = Assert.Throws<PdfReadLimitException>(() =>
+                PdfDebugger.Dump(path, readOptions: readOptions));
+            Assert.Equal(PdfReadLimitKind.InputBytes, pathException.Kind);
+        } finally {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
 }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfDebuggerTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfDebuggerTests.cs
@@ -76,4 +76,26 @@ public class PdfDebuggerTests {
             if (File.Exists(path)) File.Delete(path);
         }
     }
+
+    [Fact]
+    public void Dump_StreamReadsFromCurrentPosition() {
+        byte[] source = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("Current-position debugger"))
+            .ToBytes();
+        byte[] prefixed = new byte[source.Length + 5];
+        Array.Fill(prefixed, (byte)0xFF, 0, 5);
+        Buffer.BlockCopy(source, 0, prefixed, 5, source.Length);
+
+        using var stream = new MemoryStream(prefixed);
+        stream.Position = 5;
+
+        PdfDebuggerReport report = PdfDebugger.Dump(
+            stream,
+            readOptions: new PdfReadOptions {
+                Limits = new PdfReadLimits { MaxInputBytes = source.Length }
+            });
+
+        Assert.Single(report.Pages);
+        Assert.Equal(stream.Length, stream.Position);
+    }
 }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfDebuggerTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfDebuggerTests.cs
@@ -83,7 +83,9 @@ public class PdfDebuggerTests {
             .Paragraph(paragraph => paragraph.Text("Current-position debugger"))
             .ToBytes();
         byte[] prefixed = new byte[source.Length + 5];
-        Array.Fill(prefixed, (byte)0xFF, 0, 5);
+        for (int index = 0; index < 5; index++) {
+            prefixed[index] = 0xFF;
+        }
         Buffer.BlockCopy(source, 0, prefixed, 5, source.Length);
 
         using var stream = new MemoryStream(prefixed);

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfIncrementalAnnotationEditorTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfIncrementalAnnotationEditorTests.cs
@@ -12,7 +12,10 @@ public class PdfIncrementalAnnotationEditorTests {
         PdfAnnotationEditResult result = PdfAnnotationEditor.UpdateAnnotation(
             signedPdf,
             annotationObjectNumber,
-            new PdfAnnotationUpdateOptions { Contents = "Updated after certification" });
+            new PdfAnnotationUpdateOptions {
+                Contents = "Updated after certification",
+                AllowResidualDataInAppendOnly = true
+            });
 
         Assert.Equal(PdfMutationExecutionMode.AppendOnly, result.MutationPlan.ExecutionMode);
         Assert.NotNull(result.SignatureMutationReport);
@@ -29,12 +32,28 @@ public class PdfIncrementalAnnotationEditorTests {
 
         PdfAnnotationEditResult result = PdfAnnotationEditor.RemoveAnnotations(
             signedPdf,
-            new PdfAnnotationRemovalOptions { Subtype = "Text" });
+            new PdfAnnotationRemovalOptions {
+                Subtype = "Text",
+                AllowResidualDataInAppendOnly = true
+            });
 
         Assert.True(result.Applied);
         Assert.Equal(PdfMutationExecutionMode.AppendOnly, result.MutationPlan.ExecutionMode);
         Assert.True(result.SignatureMutationReport!.IsPreservedAppendOnlyMutation);
         Assert.Empty(PdfInspector.Inspect(result.Bytes).GetAnnotationsBySubtype("Text"));
+    }
+
+    [Fact]
+    public void CertifiedP3AnnotationRemovalRejectsResidualDataByDefault() {
+        (byte[] signedPdf, _) = BuildCertifiedAnnotatedPdf(
+            PdfCertificationPermissionLevel.FormFillingAnnotationsAndSignatures);
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(() =>
+            PdfAnnotationEditor.RemoveAnnotations(
+                signedPdf,
+                new PdfAnnotationRemovalOptions { Subtype = "Text" }));
+
+        Assert.Contains("prior revisions", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -96,7 +115,8 @@ public class PdfIncrementalAnnotationEditorTests {
         PdfAnnotationEditResult result = PdfAnnotationEditor.UpdateAnnotation(signedPdf, annotationObjectNumber, new PdfAnnotationUpdateOptions {
             Rectangle = new[] { 24D, 40D, 144D, 56D },
             QuadPoints = new[] { 24D, 56D, 144D, 56D, 24D, 40D, 144D, 40D },
-            RegenerateAppearance = true
+            RegenerateAppearance = true,
+            AllowResidualDataInAppendOnly = true
         });
 
         Assert.Equal(PdfMutationExecutionMode.AppendOnly, result.MutationPlan.ExecutionMode);

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfOcrTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfOcrTests.cs
@@ -73,6 +73,30 @@ public class PdfOcrTests {
         Assert.Equal(1, exception.Limit);
     }
 
+    [Fact]
+    public async Task RecognizeAndMergeAsync_BoundsNativeOverlapWork() {
+        byte[] pdf = PdfDocument.Create()
+            .Paragraph(paragraph => paragraph.Text("First native block"))
+            .Paragraph(paragraph => paragraph.Text("Second native block"))
+            .ToBytes();
+        var provider = new StubOcrProvider(_ => new PdfOcrResponse(new[] {
+            new PdfOcrWord("scanned", 10, 10, 10, 10, 0.9)
+        }));
+
+        PdfReadLimitException exception = await Assert.ThrowsAsync<PdfReadLimitException>(() =>
+            PdfOcr.RecognizeAndMergeAsync(pdf, provider, new PdfOcrMergeOptions {
+                MaxNativeTextOverlapComparisonsPerPage = 1
+            }));
+
+        Assert.Equal(PdfReadLimitKind.OcrArtifacts, exception.Kind);
+        Assert.Equal(1, exception.Limit);
+    }
+
+    [Fact]
+    public void PdfReadLimitKind_PreservesExistingInteractionRegionsValue() {
+        Assert.Equal(20, (int)PdfReadLimitKind.InteractionRegions);
+    }
+
     private sealed class StubOcrProvider : IPdfOcrProvider {
         private readonly Func<PdfOcrRequest, PdfOcrResponse> _response;
         public StubOcrProvider(Func<PdfOcrRequest, PdfOcrResponse> response) { _response = response; }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfOcrTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfOcrTests.cs
@@ -56,6 +56,23 @@ public class PdfOcrTests {
             PdfOcr.RecognizeAndMergeAsync(pdf, provider, cancellationToken: cancellation.Token));
     }
 
+    [Fact]
+    public async Task RecognizeAndMergeAsync_RejectsOversizedProviderArtifactsBeforeMerge() {
+        byte[] pdf = PdfDocument.Create().Paragraph(paragraph => paragraph.Text("Native")).ToBytes();
+        var provider = new StubOcrProvider(_ => new PdfOcrResponse(new[] {
+            new PdfOcrWord("one", 10, 10, 10, 10, 0.9),
+            new PdfOcrWord("two", 30, 10, 10, 10, 0.9)
+        }));
+
+        PdfReadLimitException exception = await Assert.ThrowsAsync<PdfReadLimitException>(() =>
+            PdfOcr.RecognizeAndMergeAsync(pdf, provider, new PdfOcrMergeOptions {
+                MaxOcrWordsPerPage = 1
+            }));
+
+        Assert.Equal(PdfReadLimitKind.OcrArtifacts, exception.Kind);
+        Assert.Equal(1, exception.Limit);
+    }
+
     private sealed class StubOcrProvider : IPdfOcrProvider {
         private readonly Func<PdfOcrRequest, PdfOcrResponse> _response;
         public StubOcrProvider(Func<PdfOcrRequest, PdfOcrResponse> response) { _response = response; }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfOcrTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfOcrTests.cs
@@ -49,6 +49,9 @@ public class PdfOcrTests {
             Selection = PdfPageSelection.From(2)
         });
         Assert.Equal(2, Assert.Single(selected.Pages).PageNumber);
+        Assert.Equal(new[] { 1, 2 }, selected.NativeDocument.Pages.Select(page => page.PageNumber).ToArray());
+        Assert.Contains(selected.NativeDocument.Pages[0].TextBlocks, block => block.Text.Contains("One", StringComparison.Ordinal));
+        Assert.Contains(selected.NativeDocument.Pages[1].TextBlocks, block => block.Text.Contains("Two", StringComparison.Ordinal));
 
         using var cancellation = new CancellationTokenSource();
         cancellation.Cancel();

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfOptimizerAdvancedTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfOptimizerAdvancedTests.cs
@@ -136,5 +136,14 @@ public class PdfOptimizerAdvancedTests {
         Assert.Contains(result.Actions, static action => action.Kind == "DeduplicateImage");
         Assert.Single(PdfReadDocument.Open(result.Bytes).Pages[0].GetImagePlacements().Select(static placement => placement.ObjectNumber).Distinct());
         Assert.True(result.PreservationReport.IsPreserved);
+
+        options.MaximumTotalDecodedImageBytes = 4;
+        PdfOptimizationActionResult limited = PdfOptimizer.Optimize(source, options);
+        Assert.DoesNotContain(limited.Actions, static action => action.Kind == "DeduplicateImage");
+        Assert.Contains(limited.SkippedActions, static action =>
+            action.Kind == "DeduplicateImage" && action.Reason == "AggregateDecodeLimit");
+
+        options.MaximumTotalDecodedImageBytes = 0;
+        Assert.Throws<ArgumentOutOfRangeException>(() => PdfOptimizer.Optimize(source, options));
     }
 }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPageImageRendererBatchTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPageImageRendererBatchTests.cs
@@ -82,6 +82,31 @@ public class PdfPageImageRendererBatchTests {
             PdfPageImageRenderer.RenderPages(pdf, cancellationToken: cancellation.Token));
     }
 
+    [Fact]
+    public void RenderPages_EnforcesPerPageAndAggregateEncodedOutputBudgets() {
+        byte[] pdf = BuildTwoPagePdf();
+
+        PdfReadLimitException perPage = Assert.Throws<PdfReadLimitException>(() =>
+            PdfPageImageRenderer.RenderPages(
+                pdf,
+                PdfPageSelection.From(1),
+                new PdfPageRenderOptions {
+                    Format = PdfPageRenderFormat.Svg,
+                    MaxOutputBytesPerPage = 1,
+                    ContinueOnError = false
+                }));
+        Assert.Equal(PdfReadLimitKind.RenderBytes, perPage.Kind);
+
+        PdfReadLimitException aggregate = Assert.Throws<PdfReadLimitException>(() =>
+            PdfPageImageRenderer.RenderPages(
+                pdf,
+                options: new PdfPageRenderOptions {
+                    Format = PdfPageRenderFormat.Svg,
+                    MaxTotalOutputBytes = 1
+                }));
+        Assert.Equal(PdfReadLimitKind.RenderBytes, aggregate.Kind);
+    }
+
     private static byte[] BuildTwoPagePdf() => PdfDocument.Create()
         .Paragraph(paragraph => paragraph.Text("Batch page one"))
         .PageBreak()

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPageInteractionMapTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPageInteractionMapTests.cs
@@ -1,4 +1,6 @@
 using OfficeIMO.Pdf;
+using System.Globalization;
+using System.Text;
 using Xunit;
 
 namespace OfficeIMO.Tests.Pdf;
@@ -66,5 +68,26 @@ public class PdfPageInteractionMapTests {
 
         Assert.Equal(PdfReadLimitKind.InteractionRegions, exception.Kind);
         Assert.Equal(1, exception.Limit);
+    }
+
+    [Fact]
+    public void InteractionMap_CountsOnlyTextRegionsThatIntersectThePage() {
+        const string content = "BT /F1 12 Tf 10000 10000 Td (off-page text) Tj ET";
+        byte[] source = Encoding.ASCII.GetBytes(string.Join("\n", new[] {
+            "%PDF-1.7",
+            "1 0 obj", "<< /Type /Catalog /Pages 2 0 R >>", "endobj",
+            "2 0 obj", "<< /Type /Pages /Count 1 /Kids [3 0 R] >>", "endobj",
+            "3 0 obj", "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>", "endobj",
+            "4 0 obj", "<< /Length " + content.Length.ToString(CultureInfo.InvariantCulture) + " >>", "stream", content, "endstream", "endobj",
+            "5 0 obj", "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>", "endobj",
+            "trailer", "<< /Root 1 0 R /Size 6 >>", "%%EOF"
+        }));
+
+        PdfPageInteractionMap map = PdfPageInteractionMap.Create(
+            source,
+            1,
+            new PdfPageInteractionOptions { MaxTextRegions = 1 });
+
+        Assert.Empty(map.TextRegions);
     }
 }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPublicApiContractTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPublicApiContractTests.cs
@@ -129,7 +129,7 @@ public sealed class PdfPublicApiContractTests {
                 BindingFlags.DeclaredOnly).Length);
 
         Assert.InRange(exportedTypes.Length, 1, 500);
-        Assert.InRange(publicMemberCount, 1, 9750);
+        Assert.InRange(publicMemberCount, 1, 9800);
 
         string[] officeReferences = assembly.GetReferencedAssemblies()
             .Select(reference => reference.Name)

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfPublicApiContractTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfPublicApiContractTests.cs
@@ -129,7 +129,7 @@ public sealed class PdfPublicApiContractTests {
                 BindingFlags.DeclaredOnly).Length);
 
         Assert.InRange(exportedTypes.Length, 1, 500);
-        Assert.InRange(publicMemberCount, 1, 9800);
+        Assert.InRange(publicMemberCount, 1, 9850);
 
         string[] officeReferences = assembly.GetReferencedAssemblies()
             .Select(reference => reference.Name)

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
@@ -120,6 +120,59 @@ public class PdfReadLimitTests {
     }
 
     [Fact]
+    public void ExternalSignaturePreparationBoundsByteStreamAndPathInputs() {
+        byte[] pdf = BuildPdf();
+
+        PdfReadLimitException bytesLimit = Assert.Throws<PdfReadLimitException>(() =>
+            PdfIncrementalUpdater.PrepareExternalSignature(
+                pdf,
+                new PdfExternalSignatureOptions { MaxInputBytes = pdf.Length - 1L }));
+        Assert.Equal(PdfReadLimitKind.InputBytes, bytesLimit.Kind);
+
+        byte[] prefixed = new byte[pdf.Length + 5];
+        Buffer.BlockCopy(pdf, 0, prefixed, 5, pdf.Length);
+        using var stream = new MemoryStream(prefixed);
+        stream.Position = 5;
+        PdfReadLimitException streamLimit = Assert.Throws<PdfReadLimitException>(() =>
+            PdfIncrementalUpdater.PrepareExternalSignature(
+                stream,
+                new PdfExternalSignatureOptions { MaxInputBytes = pdf.Length - 1L }));
+        Assert.Equal(PdfReadLimitKind.InputBytes, streamLimit.Kind);
+        Assert.Equal(5, stream.Position);
+
+        using var successfulStream = new MemoryStream(prefixed);
+        successfulStream.Position = 5;
+        PdfExternalSignaturePreparation preparation = PdfIncrementalUpdater.PrepareExternalSignature(
+            successfulStream,
+            new PdfExternalSignatureOptions { MaxInputBytes = pdf.Length });
+        Assert.True(preparation.PreparedPdf.Length > pdf.Length);
+        Assert.Equal(successfulStream.Length, successfulStream.Position);
+
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        Assert.Throws<OperationCanceledException>(() =>
+            PdfIncrementalUpdater.PrepareExternalSignature(
+                pdf,
+                new PdfExternalSignatureOptions { CancellationToken = cancellation.Token }));
+
+        string inputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".pdf");
+        string outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".pdf");
+        try {
+            File.WriteAllBytes(inputPath, pdf);
+            PdfReadLimitException pathLimit = Assert.Throws<PdfReadLimitException>(() =>
+                PdfIncrementalUpdater.PrepareExternalSignature(
+                    inputPath,
+                    outputPath,
+                    new PdfExternalSignatureOptions { MaxInputBytes = pdf.Length - 1L }));
+            Assert.Equal(PdfReadLimitKind.InputBytes, pathLimit.Kind);
+            Assert.False(File.Exists(outputPath));
+        } finally {
+            File.Delete(inputPath);
+            File.Delete(outputPath);
+        }
+    }
+
+    [Fact]
     public void PageCompositionRejectsOversizedRemainingStreamBeforeReading() {
         using var stream = new LengthOnlyReadStream(
             PdfReadOptions.Default.Limits.MaxInputBytes + 1L);

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
@@ -81,8 +81,10 @@ public class PdfReadLimitTests {
     [Fact]
     public void OneShotExternalSignatureBoundsAndCancelsStreamInputBeforeCallingSigner() {
         byte[] pdf = BuildPdf();
+        byte[] prefixed = new byte[pdf.Length + 5];
+        Buffer.BlockCopy(pdf, 0, prefixed, 5, pdf.Length);
         var signer = new RecordingExternalSigner();
-        using var stream = new MemoryStream(pdf);
+        using var stream = new MemoryStream(prefixed);
         stream.Position = 5;
 
         PdfReadLimitException limit = Assert.Throws<PdfReadLimitException>(() =>
@@ -102,6 +104,19 @@ public class PdfReadLimitTests {
                 signer,
                 new PdfExternalSignatureOptions { CancellationToken = cancellation.Token }));
         Assert.False(signer.WasCalled);
+
+        using var currentPositionStream = new MemoryStream(prefixed);
+        currentPositionStream.Position = 5;
+        var currentPositionSigner = new RecordingExternalSigner();
+
+        PdfExternalSignatureCompletion completion = PdfIncrementalUpdater.SignExternal(
+            currentPositionStream,
+            currentPositionSigner,
+            new PdfExternalSignatureOptions { MaxInputBytes = pdf.Length });
+
+        Assert.True(currentPositionSigner.WasCalled);
+        Assert.Equal(currentPositionStream.Length, currentPositionStream.Position);
+        Assert.True(completion.Pdf.Length > pdf.Length);
     }
 
     [Fact]

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.IO.Compression;
+using System.Threading;
 using System.Threading.Tasks;
 using OfficeIMO.Pdf;
 using OfficeIMO.Pdf.Filters;
@@ -75,6 +76,44 @@ public class PdfReadLimitTests {
 
         Assert.True(completion.Pdf.LongLength > readOptions.Limits.MaxInputBytes);
         Assert.Single(completion.ToDocument().Inspect().FormFields);
+    }
+
+    [Fact]
+    public void OneShotExternalSignatureBoundsAndCancelsStreamInputBeforeCallingSigner() {
+        byte[] pdf = BuildPdf();
+        var signer = new RecordingExternalSigner();
+        using var stream = new MemoryStream(pdf);
+        stream.Position = 5;
+
+        PdfReadLimitException limit = Assert.Throws<PdfReadLimitException>(() =>
+            PdfIncrementalUpdater.SignExternal(
+                stream,
+                signer,
+                new PdfExternalSignatureOptions { MaxInputBytes = pdf.Length - 1L }));
+        Assert.Equal(PdfReadLimitKind.InputBytes, limit.Kind);
+        Assert.Equal(5, stream.Position);
+        Assert.False(signer.WasCalled);
+
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        Assert.Throws<OperationCanceledException>(() =>
+            PdfIncrementalUpdater.SignExternal(
+                stream,
+                signer,
+                new PdfExternalSignatureOptions { CancellationToken = cancellation.Token }));
+        Assert.False(signer.WasCalled);
+    }
+
+    [Fact]
+    public void PageCompositionRejectsOversizedRemainingStreamBeforeReading() {
+        using var stream = new LengthOnlyReadStream(
+            PdfReadOptions.Default.Limits.MaxInputBytes + 1L);
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            PdfPageEditor.DeletePages(stream, 1));
+
+        Assert.Equal(PdfReadLimitKind.InputBytes, exception.Kind);
+        Assert.False(stream.WasRead);
     }
 
     [Fact]
@@ -850,6 +889,42 @@ public class PdfReadLimitTests {
 
         public override void Flush() { }
         public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    private sealed class LengthOnlyReadStream : Stream {
+        private long _position;
+
+        internal LengthOnlyReadStream(long length) {
+            Length = length;
+        }
+
+        internal bool WasRead { get; private set; }
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length { get; }
+        public override long Position {
+            get => _position;
+            set => _position = value;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) {
+            WasRead = true;
+            return 0;
+        }
+
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) {
+            _position = origin switch {
+                SeekOrigin.Begin => offset,
+                SeekOrigin.Current => _position + offset,
+                SeekOrigin.End => Length + offset,
+                _ => throw new ArgumentOutOfRangeException(nameof(origin))
+            };
+            return _position;
+        }
         public override void SetLength(long value) => throw new NotSupportedException();
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfUnderstandingPipelineTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfUnderstandingPipelineTests.cs
@@ -51,6 +51,24 @@ public class PdfUnderstandingPipelineTests {
     }
 
     [Fact]
+    public void Pipeline_RejectsOversizedCustomStageArtifacts() {
+        byte[] pdf = PdfDocument.Create().Paragraph(p => p.Text("placeholder")).ToBytes();
+        var options = new PdfUnderstandingPipelineOptions {
+            GlyphDecoding = new FixedGlyphStage(new[] {
+                new PdfTextSpan("one", "F1", 12, 10, 10, 20),
+                new PdfTextSpan("two", "F1", 12, 40, 10, 20)
+            }),
+            MaxRunsPerPage = 1
+        };
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() =>
+            new PdfUnderstandingPipeline(options).Run(PdfReadDocument.Open(pdf)));
+
+        Assert.Equal(PdfReadLimitKind.UnderstandingArtifacts, exception.Kind);
+        Assert.Equal(1, exception.Limit);
+    }
+
+    [Fact]
     public void AdvancedPipeline_GroupsRotatedBaselinesAndOrdersMultipleColumns() {
         byte[] pdf = PdfDocument.Create().Paragraph(p => p.Text("placeholder")).ToBytes();
         var glyphs = new FixedGlyphStage(new[] {

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfVisualComparerTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfVisualComparerTests.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using OfficeIMO.Pdf;
 using Xunit;
 
@@ -53,6 +54,28 @@ public class PdfVisualComparerTests {
         PdfVisualPageComparison page = Assert.Single(report.Pages);
         Assert.Equal(320, page.Width);
         Assert.Equal(420, page.Height);
+    }
+
+    [Fact]
+    public void Compare_EnforcesPagePixelOutputAndCancellationBudgets() {
+        byte[] pdf = BuildPdf("Bounded visual comparison");
+
+        PdfReadLimitException pixels = Assert.Throws<PdfReadLimitException>(() =>
+            PdfVisualComparer.Compare(pdf, pdf, options: new PdfVisualComparisonOptions {
+                MaxPixelsPerImage = 1
+            }));
+        Assert.Equal(PdfReadLimitKind.RenderPixels, pixels.Kind);
+
+        PdfReadLimitException output = Assert.Throws<PdfReadLimitException>(() =>
+            PdfVisualComparer.Compare(pdf, pdf, options: new PdfVisualComparisonOptions {
+                MaxTotalOutputBytes = 1
+            }));
+        Assert.Equal(PdfReadLimitKind.RenderBytes, output.Kind);
+
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        Assert.Throws<OperationCanceledException>(() =>
+            PdfVisualComparer.Compare(pdf, pdf, cancellationToken: cancellation.Token));
     }
 
     private static byte[] BuildPdf(string text) => PdfDocument.Create(new PdfOptions { PageSize = new PageSize(240, 180) })

--- a/OfficeIMO.Pdf/Core/PdfDocumentSource.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocumentSource.cs
@@ -69,6 +69,21 @@ internal sealed class PdfDocumentSource {
         return FromBoundedStream(stream, effectiveOptions);
     }
 
+    /// <summary>
+    /// Reads and owns one bounded stream snapshot from the caller's current position.
+    /// </summary>
+    internal static PdfDocumentSource FromRemainingStream(Stream stream, PdfReadOptions? options) {
+        Guard.NotNull(stream, nameof(stream));
+        PdfReadOptions effectiveOptions = PdfReadOptions.Resolve(options);
+        long limit = effectiveOptions.Limits.MaxInputBytes;
+        try {
+            byte[] bytes = OfficeStreamReader.ReadRemainingBytes(stream, limit);
+            return FromOwnedBytes(bytes, effectiveOptions);
+        } catch (InvalidDataException) {
+            throw CreateInputLimitException(stream, limit, remainingOnly: true);
+        }
+    }
+
     /// <summary>Asynchronously reads and owns one bounded file snapshot.</summary>
     internal static async Task<PdfDocumentSource> FromPathAsync(
         string path,
@@ -162,11 +177,11 @@ internal sealed class PdfDocumentSource {
         }
     }
 
-    private static PdfReadLimitException CreateInputLimitException(Stream stream, long limit) {
+    private static PdfReadLimitException CreateInputLimitException(Stream stream, long limit, bool remainingOnly = false) {
         long actual = limit + 1;
         if (stream.CanSeek) {
             try {
-                actual = stream.Length;
+                actual = remainingOnly ? stream.Length - stream.Position : stream.Length;
             } catch (NotSupportedException) {
                 // The bounded reader already proved the limit was exceeded.
             }

--- a/OfficeIMO.Pdf/Diagnostics/PdfDebugger.cs
+++ b/OfficeIMO.Pdf/Diagnostics/PdfDebugger.cs
@@ -46,7 +46,7 @@ internal static class PdfDebugger {
             throw new ArgumentException("Stream must be readable.", nameof(stream));
         }
 
-        PdfDocumentSource source = PdfDocumentSource.FromStream(stream, readOptions);
+        PdfDocumentSource source = PdfDocumentSource.FromRemainingStream(stream, readOptions);
         return Dump(source.Bytes, options, source.Options);
     }
 

--- a/OfficeIMO.Pdf/Diagnostics/PdfDebugger.cs
+++ b/OfficeIMO.Pdf/Diagnostics/PdfDebugger.cs
@@ -35,7 +35,8 @@ internal static class PdfDebugger {
     /// <summary>Dumps a PDF file into typed debugger records.</summary>
     public static PdfDebuggerReport Dump(string path, PdfDebuggerOptions? options = null, PdfReadOptions? readOptions = null) {
         Guard.NotNullOrWhiteSpace(path, nameof(path));
-        return Dump(File.ReadAllBytes(path), options, readOptions);
+        PdfDocumentSource source = PdfDocumentSource.FromPath(path, readOptions);
+        return Dump(source.Bytes, options, source.Options);
     }
 
     /// <summary>Dumps a readable PDF stream from its current position.</summary>
@@ -45,9 +46,8 @@ internal static class PdfDebugger {
             throw new ArgumentException("Stream must be readable.", nameof(stream));
         }
 
-        using var buffer = new MemoryStream();
-        stream.CopyTo(buffer);
-        return Dump(buffer.ToArray(), options, readOptions);
+        PdfDocumentSource source = PdfDocumentSource.FromStream(stream, readOptions);
+        return Dump(source.Bytes, options, source.Options);
     }
 
     private static PdfDebugObject BuildObject(PdfIndirectObject indirect, Dictionary<int, PdfIndirectObject> objects, HashSet<int> reachable, PdfDebuggerOptions options) {

--- a/OfficeIMO.Pdf/Manipulation/PdfAnnotationEditor.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfAnnotationEditor.cs
@@ -47,6 +47,9 @@ internal static partial class PdfAnnotationEditor {
             readOptions,
             executionPreference: effectiveOptions.ExecutionPreference);
         if (mutationPlan.ExecutionMode == PdfMutationExecutionMode.AppendOnly) {
+            if (!effectiveOptions.AllowResidualDataInAppendOnly) {
+                throw new NotSupportedException("Append-only annotation removal retains the original annotation bytes in prior revisions. Use a permitted full rewrite for sanitization or explicitly allow residual data.");
+            }
             return RemoveAnnotationsIncrementally(pdf, effectiveOptions, mutationPlan, readOptions);
         }
 
@@ -142,6 +145,9 @@ internal static partial class PdfAnnotationEditor {
             readOptions,
             executionPreference: options.ExecutionPreference);
         if (mutationPlan.ExecutionMode == PdfMutationExecutionMode.AppendOnly) {
+            if (!options.AllowResidualDataInAppendOnly) {
+                throw new NotSupportedException("Append-only annotation updates retain replaced annotation data in prior revisions. Use a permitted full rewrite for sanitization or explicitly allow residual data.");
+            }
             return UpdateAnnotationIncrementally(pdf, objectNumber, options, mutationPlan, readOptions);
         }
 

--- a/OfficeIMO.Pdf/Manipulation/PdfAnnotationRemovalOptions.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfAnnotationRemovalOptions.cs
@@ -16,4 +16,10 @@ public sealed class PdfAnnotationRemovalOptions {
 
     /// <summary>Remove popup annotations linked from matching annotations through /Popup.</summary>
     public bool RemoveMatchingPopups { get; set; } = true;
+
+    /// <summary>
+    /// Allows append-only removal even though prior revisions retain the removed annotation bytes.
+    /// Disabled by default because append-only output is not a sanitization boundary.
+    /// </summary>
+    public bool AllowResidualDataInAppendOnly { get; set; }
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfAnnotationUpdateOptions.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfAnnotationUpdateOptions.cs
@@ -58,4 +58,10 @@ public sealed class PdfAnnotationUpdateOptions {
 
     /// <summary>Regenerates a supported normal appearance stream after applying the update.</summary>
     public bool RegenerateAppearance { get; set; }
+
+    /// <summary>
+    /// Allows append-only updates even though prior revisions retain replaced annotation data.
+    /// Disabled by default because append-only output is not a sanitization boundary.
+    /// </summary>
+    public bool AllowResidualDataInAppendOnly { get; set; }
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfAttachmentEditSession.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfAttachmentEditSession.cs
@@ -27,7 +27,9 @@ public sealed class PdfAttachmentEditSession {
         IEnumerable<PdfEmbeddedFile> attachments) {
         var retainedOriginalNames = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach (PdfEmbeddedFile attachment in attachments) {
-            retainedOriginalNames.TryAdd(attachment.FileName, attachment.FileName);
+            if (!retainedOriginalNames.ContainsKey(attachment.FileName)) {
+                retainedOriginalNames.Add(attachment.FileName, attachment.FileName);
+            }
         }
         return retainedOriginalNames;
     }

--- a/OfficeIMO.Pdf/Manipulation/PdfAttachmentEditSession.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfAttachmentEditSession.cs
@@ -3,14 +3,33 @@ namespace OfficeIMO.Pdf;
 /// <summary>Mutable attachment collection used by one existing-document attachment edit.</summary>
 public sealed class PdfAttachmentEditSession {
     private readonly List<PdfEmbeddedFile> _attachments;
+    private readonly List<PdfAttachmentSourceIdentity> _sourceIdentities;
     private readonly Dictionary<string, string> _retainedOriginalNames;
 
     internal PdfAttachmentEditSession(IEnumerable<PdfEmbeddedFile> attachments) {
         _attachments = attachments.Select(static file => file.Clone()).ToList();
-        _retainedOriginalNames = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (PdfEmbeddedFile attachment in _attachments) {
-            _retainedOriginalNames.TryAdd(attachment.FileName, attachment.FileName);
+        _sourceIdentities = _attachments
+            .Select(static _ => new PdfAttachmentSourceIdentity(0, 0))
+            .ToList();
+        _retainedOriginalNames = CreateRetainedOriginalNames(_attachments);
+    }
+
+    internal PdfAttachmentEditSession(IEnumerable<PdfAttachmentEditSource> attachments) {
+        IReadOnlyList<PdfAttachmentEditSource> sources = attachments.ToArray();
+        _attachments = sources.Select(static source => source.Attachment.Clone()).ToList();
+        _sourceIdentities = sources.Select(static source => new PdfAttachmentSourceIdentity(
+            source.FileSpecObjectNumber,
+            source.EmbeddedFileObjectNumber)).ToList();
+        _retainedOriginalNames = CreateRetainedOriginalNames(_attachments);
+    }
+
+    private static Dictionary<string, string> CreateRetainedOriginalNames(
+        IEnumerable<PdfEmbeddedFile> attachments) {
+        var retainedOriginalNames = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (PdfEmbeddedFile attachment in attachments) {
+            retainedOriginalNames.TryAdd(attachment.FileName, attachment.FileName);
         }
+        return retainedOriginalNames;
     }
 
     /// <summary>Current attachment snapshots in edit order.</summary>
@@ -21,6 +40,7 @@ public sealed class PdfAttachmentEditSession {
         Guard.NotNull(attachment, nameof(attachment));
         EnsureMissing(attachment.FileName);
         _attachments.Add(attachment.Clone());
+        _sourceIdentities.Add(new PdfAttachmentSourceIdentity(0, 0));
         return this;
     }
 
@@ -47,13 +67,18 @@ public sealed class PdfAttachmentEditSession {
 
     /// <summary>Removes an attachment by file name.</summary>
     public PdfAttachmentEditSession Remove(string fileName) {
-        _attachments.RemoveAt(RequireIndex(fileName));
+        int index = RequireIndex(fileName);
+        _attachments.RemoveAt(index);
+        _sourceIdentities.RemoveAt(index);
         string? originalName = _retainedOriginalNames.FirstOrDefault(pair => string.Equals(pair.Value, fileName, StringComparison.Ordinal)).Key;
         if (originalName != null) _retainedOriginalNames.Remove(originalName);
         return this;
     }
 
     internal IReadOnlyList<PdfEmbeddedFile> Snapshot() => _attachments.Select(static file => file.Clone()).ToArray();
+    internal IReadOnlyList<PdfAttachmentEditEntry> SnapshotEntries() => _attachments
+        .Select((file, index) => new PdfAttachmentEditEntry(file.Clone(), _sourceIdentities[index]))
+        .ToArray();
     internal IReadOnlyDictionary<string, string> RetainedOriginalNames => _retainedOriginalNames;
 
     private void UpdateRetainedName(string currentName, string newName) {
@@ -64,4 +89,43 @@ public sealed class PdfAttachmentEditSession {
     private int RequireIndex(string fileName) { Guard.NotNullOrWhiteSpace(fileName, nameof(fileName)); int index = FindIndex(fileName); return index >= 0 ? index : throw new KeyNotFoundException("PDF attachment was not found: " + fileName); }
     private void EnsureMissing(string fileName) { if (FindIndex(fileName) >= 0) throw new ArgumentException("A PDF attachment with this file name already exists: " + fileName, nameof(fileName)); }
     private int FindIndex(string fileName) => _attachments.FindIndex(file => string.Equals(file.FileName, fileName, StringComparison.Ordinal));
+}
+
+internal sealed class PdfAttachmentEditSource {
+    internal PdfAttachmentEditSource(
+        PdfEmbeddedFile attachment,
+        int fileSpecObjectNumber,
+        int embeddedFileObjectNumber) {
+        Attachment = attachment;
+        FileSpecObjectNumber = fileSpecObjectNumber;
+        EmbeddedFileObjectNumber = embeddedFileObjectNumber;
+    }
+
+    internal PdfEmbeddedFile Attachment { get; }
+    internal int FileSpecObjectNumber { get; }
+    internal int EmbeddedFileObjectNumber { get; }
+}
+
+internal sealed class PdfAttachmentEditEntry {
+    internal PdfAttachmentEditEntry(
+        PdfEmbeddedFile attachment,
+        PdfAttachmentSourceIdentity sourceIdentity) {
+        Attachment = attachment;
+        SourceIdentity = sourceIdentity;
+    }
+
+    internal PdfEmbeddedFile Attachment { get; }
+    internal PdfAttachmentSourceIdentity SourceIdentity { get; }
+}
+
+internal readonly struct PdfAttachmentSourceIdentity {
+    internal PdfAttachmentSourceIdentity(
+        int fileSpecObjectNumber,
+        int embeddedFileObjectNumber) {
+        FileSpecObjectNumber = fileSpecObjectNumber;
+        EmbeddedFileObjectNumber = embeddedFileObjectNumber;
+    }
+
+    internal int FileSpecObjectNumber { get; }
+    internal int EmbeddedFileObjectNumber { get; }
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfAttachmentEditSession.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfAttachmentEditSession.cs
@@ -7,10 +7,10 @@ public sealed class PdfAttachmentEditSession {
 
     internal PdfAttachmentEditSession(IEnumerable<PdfEmbeddedFile> attachments) {
         _attachments = attachments.Select(static file => file.Clone()).ToList();
-        _retainedOriginalNames = _attachments.ToDictionary(
-            static file => file.FileName,
-            static file => file.FileName,
-            StringComparer.Ordinal);
+        _retainedOriginalNames = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (PdfEmbeddedFile attachment in _attachments) {
+            _retainedOriginalNames.TryAdd(attachment.FileName, attachment.FileName);
+        }
     }
 
     /// <summary>Current attachment snapshots in edit order.</summary>

--- a/OfficeIMO.Pdf/Manipulation/PdfAttachmentEditSession.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfAttachmentEditSession.cs
@@ -3,8 +3,15 @@ namespace OfficeIMO.Pdf;
 /// <summary>Mutable attachment collection used by one existing-document attachment edit.</summary>
 public sealed class PdfAttachmentEditSession {
     private readonly List<PdfEmbeddedFile> _attachments;
+    private readonly Dictionary<string, string> _retainedOriginalNames;
 
-    internal PdfAttachmentEditSession(IEnumerable<PdfEmbeddedFile> attachments) { _attachments = attachments.Select(static file => file.Clone()).ToList(); }
+    internal PdfAttachmentEditSession(IEnumerable<PdfEmbeddedFile> attachments) {
+        _attachments = attachments.Select(static file => file.Clone()).ToList();
+        _retainedOriginalNames = _attachments.ToDictionary(
+            static file => file.FileName,
+            static file => file.FileName,
+            StringComparer.Ordinal);
+    }
 
     /// <summary>Current attachment snapshots in edit order.</summary>
     public IReadOnlyList<PdfEmbeddedFile> Attachments => _attachments.Select(static file => file.Clone()).ToArray();
@@ -23,6 +30,7 @@ public sealed class PdfAttachmentEditSession {
         int index = RequireIndex(fileName);
         int conflict = FindIndex(replacement.FileName);
         if (conflict >= 0 && conflict != index) throw new ArgumentException("An attachment with the replacement file name already exists.", nameof(replacement));
+        UpdateRetainedName(_attachments[index].FileName, replacement.FileName);
         _attachments[index] = replacement.Clone();
         return this;
     }
@@ -32,14 +40,26 @@ public sealed class PdfAttachmentEditSession {
         int index = RequireIndex(fileName);
         if (!string.Equals(fileName, newFileName, StringComparison.Ordinal)) EnsureMissing(newFileName);
         PdfEmbeddedFile current = _attachments[index];
+        UpdateRetainedName(current.FileName, newFileName);
         _attachments[index] = new PdfEmbeddedFile(newFileName, current.DataSnapshot, current.MimeType, current.Relationship, current.Description, current.CreationDate, current.ModificationDate);
         return this;
     }
 
     /// <summary>Removes an attachment by file name.</summary>
-    public PdfAttachmentEditSession Remove(string fileName) { _attachments.RemoveAt(RequireIndex(fileName)); return this; }
+    public PdfAttachmentEditSession Remove(string fileName) {
+        _attachments.RemoveAt(RequireIndex(fileName));
+        string? originalName = _retainedOriginalNames.FirstOrDefault(pair => string.Equals(pair.Value, fileName, StringComparison.Ordinal)).Key;
+        if (originalName != null) _retainedOriginalNames.Remove(originalName);
+        return this;
+    }
 
     internal IReadOnlyList<PdfEmbeddedFile> Snapshot() => _attachments.Select(static file => file.Clone()).ToArray();
+    internal IReadOnlyDictionary<string, string> RetainedOriginalNames => _retainedOriginalNames;
+
+    private void UpdateRetainedName(string currentName, string newName) {
+        string? originalName = _retainedOriginalNames.FirstOrDefault(pair => string.Equals(pair.Value, currentName, StringComparison.Ordinal)).Key;
+        if (originalName != null) _retainedOriginalNames[originalName] = newName;
+    }
 
     private int RequireIndex(string fileName) { Guard.NotNullOrWhiteSpace(fileName, nameof(fileName)); int index = FindIndex(fileName); return index >= 0 ? index : throw new KeyNotFoundException("PDF attachment was not found: " + fileName); }
     private void EnsureMissing(string fileName) { if (FindIndex(fileName) >= 0) throw new ArgumentException("A PDF attachment with this file name already exists: " + fileName, nameof(fileName)); }

--- a/OfficeIMO.Pdf/Manipulation/PdfAttachmentEditor.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfAttachmentEditor.cs
@@ -9,17 +9,27 @@ internal static class PdfAttachmentEditor {
         Guard.NotNull(pdf, nameof(pdf)); Guard.NotNull(edit, nameof(edit));
         PdfMutationPlan plan = PdfMutationPlanner.RequireFullRewrite(pdf, PdfMutationOperation.ModifyAttachments, readOptions);
         IReadOnlyList<PdfExtractedAttachment> existing = PdfAttachmentExtractor.ExtractAttachments(PdfReadDocument.Open(pdf, readOptions));
-        var session = new PdfAttachmentEditSession(existing.Select(static attachment => new PdfEmbeddedFile(attachment.FileName, attachment.Bytes, attachment.MimeType, attachment.Relationship, attachment.Description, attachment.CreationDate, attachment.ModificationDate)));
+        var session = new PdfAttachmentEditSession(existing.Select(static attachment =>
+            new PdfAttachmentEditSource(
+                new PdfEmbeddedFile(attachment.FileName, attachment.Bytes, attachment.MimeType,
+                    attachment.Relationship, attachment.Description, attachment.CreationDate,
+                    attachment.ModificationDate),
+                attachment.FileSpecObjectNumber,
+                attachment.EmbeddedFileObjectNumber)));
         edit(session);
-        IReadOnlyList<PdfEmbeddedFile> target = session.Snapshot();
+        IReadOnlyList<PdfAttachmentEditEntry> targetEntries = session.SnapshotEntries();
+        PdfEmbeddedFile[] target = targetEntries
+            .Select(static entry => entry.Attachment)
+            .ToArray();
         IReadOnlyDictionary<string, string> retainedOriginalNames = session.RetainedOriginalNames;
         bool removedFileAttachmentAnnotations = false;
         byte[] output = PdfDocumentObjectGraphRewriter.Rewrite(pdf, readOptions, null, (objects, security) => {
-            removedFileAttachmentAnnotations = RewriteAttachmentGraph(objects, security, target, retainedOriginalNames);
+            removedFileAttachmentAnnotations = RewriteAttachmentGraph(
+                objects, security, targetEntries, retainedOriginalNames);
             return security.InfoObjectNumber.HasValue && objects.ContainsKey(security.InfoObjectNumber.Value) ? security.InfoObjectNumber : null;
         });
         IReadOnlyList<PdfAttachmentValidation> validations = Validate(output, target);
-        ValidateAttachmentGraph(output, target.Count, readOptions);
+        ValidateAttachmentGraph(output, target.Length, readOptions);
         if (validations.Any(static validation => !validation.IsValid)) throw new InvalidOperationException("PDF attachment post-save validation failed; the artifact was not returned.");
         var preservationOptions = new PdfRewritePreservationOptions {
             OriginalReadOptions = readOptions,
@@ -43,7 +53,7 @@ internal static class PdfAttachmentEditor {
     private static bool RewriteAttachmentGraph(
         Dictionary<int, PdfIndirectObject> objects,
         PdfDocumentSecurityInfo security,
-        IReadOnlyList<PdfEmbeddedFile> attachments,
+        IReadOnlyList<PdfAttachmentEditEntry> attachments,
         IReadOnlyDictionary<string, string> retainedOriginalNames) {
         if (!security.RootObjectNumber.HasValue || !objects.TryGetValue(security.RootObjectNumber.Value, out PdfIndirectObject? root) || root.Value is not PdfDictionary catalog) throw new InvalidOperationException("PDF catalog is not readable.");
         List<FileAttachmentAnnotation> fileAttachmentAnnotations = CaptureFileAttachmentAnnotations(objects);
@@ -56,15 +66,21 @@ internal static class PdfAttachmentEditor {
                 objects,
                 fileAttachmentAnnotations,
                 retainedOriginalNames,
-                new Dictionary<string, PdfReference>(StringComparer.Ordinal));
+                new Dictionary<string, PdfReference>(StringComparer.Ordinal),
+                new Dictionary<int, PdfReference>(),
+                new Dictionary<int, PdfReference>());
         }
 
         if (names == null) { names = new PdfDictionary(); catalog.Items["Names"] = names; }
         int nextObjectNumber = objects.Count == 0 ? 1 : objects.Keys.Max() + 1;
         var nameEntries = new List<(string Name, PdfReference FileSpec)>(attachments.Count);
         var fileSpecificationsByName = new Dictionary<string, PdfReference>(StringComparer.Ordinal);
+        var fileSpecificationsByOriginalObject = new Dictionary<int, PdfReference>();
+        var fileSpecificationsByOriginalEmbeddedFile = new Dictionary<int, PdfReference>();
         var associated = new PdfArray();
-        foreach (PdfEmbeddedFile attachment in attachments.OrderBy(static file => file.FileName, StringComparer.Ordinal)) {
+        foreach (PdfAttachmentEditEntry entry in attachments
+            .OrderBy(static item => item.Attachment.FileName, StringComparer.Ordinal)) {
+            PdfEmbeddedFile attachment = entry.Attachment;
             byte[] data = attachment.DataSnapshot;
             int streamNumber = nextObjectNumber++;
             int fileSpecNumber = nextObjectNumber++;
@@ -75,13 +91,25 @@ internal static class PdfAttachmentEditor {
             var reference = new PdfReference(fileSpecNumber, 0);
             nameEntries.Add((attachment.FileName, reference));
             fileSpecificationsByName[attachment.FileName] = reference;
+            if (entry.SourceIdentity.FileSpecObjectNumber > 0) {
+                fileSpecificationsByOriginalObject[entry.SourceIdentity.FileSpecObjectNumber] = reference;
+            }
+            if (entry.SourceIdentity.EmbeddedFileObjectNumber > 0) {
+                fileSpecificationsByOriginalEmbeddedFile[entry.SourceIdentity.EmbeddedFileObjectNumber] = reference;
+            }
             if (attachment.Relationship != PdfAssociatedFileRelationship.Unspecified) associated.Items.Add(reference);
         }
         var nameArray = new PdfArray();
         foreach ((string name, PdfReference reference) in nameEntries) { nameArray.Items.Add(new PdfStringObj(name, true)); nameArray.Items.Add(reference); }
         var embeddedFiles = new PdfDictionary(); embeddedFiles.Items["Names"] = nameArray; names.Items["EmbeddedFiles"] = embeddedFiles;
         if (associated.Items.Count > 0) catalog.Items["AF"] = associated;
-        return ReconnectFileAttachmentAnnotations(objects, fileAttachmentAnnotations, retainedOriginalNames, fileSpecificationsByName);
+        return ReconnectFileAttachmentAnnotations(
+            objects,
+            fileAttachmentAnnotations,
+            retainedOriginalNames,
+            fileSpecificationsByName,
+            fileSpecificationsByOriginalObject,
+            fileSpecificationsByOriginalEmbeddedFile);
     }
 
     private static void RemoveExistingEmbeddedFileGraph(Dictionary<int, PdfIndirectObject> objects) {
@@ -127,12 +155,36 @@ internal static class PdfAttachmentEditor {
         if (value is PdfDictionary dictionary) {
             if (string.Equals(dictionary.Get<PdfName>("Subtype")?.Name, "FileAttachment", StringComparison.Ordinal)) {
                 string? fileName = null;
+                int fileSpecObjectNumber = 0;
+                int embeddedFileObjectNumber = 0;
                 if (dictionary.Items.TryGetValue("FS", out PdfObject? fileSpecification) &&
                     ResolveDictionary(objects, fileSpecification) is PdfDictionary fileSpecificationDictionary) {
+                    fileSpecObjectNumber = fileSpecification is PdfReference fileSpecReference
+                        ? fileSpecReference.ObjectNumber
+                        : 0;
                     fileName = fileSpecificationDictionary.Get<PdfStringObj>("UF")?.Value
                         ?? fileSpecificationDictionary.Get<PdfStringObj>("F")?.Value;
+                    PdfDictionary? embeddedFiles = ResolveDictionary(
+                        objects,
+                        fileSpecificationDictionary.Items.TryGetValue("EF", out PdfObject? efObject)
+                            ? efObject
+                            : null);
+                    PdfObject? embeddedFile = embeddedFiles?.Items.TryGetValue("UF", out PdfObject? unicodeFile)
+                        == true
+                        ? unicodeFile
+                        : embeddedFiles?.Items.TryGetValue("F", out PdfObject? regularFile) == true
+                            ? regularFile
+                            : null;
+                    embeddedFileObjectNumber = embeddedFile is PdfReference embeddedFileReference
+                        ? embeddedFileReference.ObjectNumber
+                        : 0;
                 }
-                result.Add(new FileAttachmentAnnotation(dictionary, indirectObjectNumber, fileName));
+                result.Add(new FileAttachmentAnnotation(
+                    dictionary,
+                    indirectObjectNumber,
+                    fileName,
+                    fileSpecObjectNumber,
+                    embeddedFileObjectNumber));
             }
             foreach (PdfObject child in dictionary.Items.Values) {
                 if (child is not PdfReference) CaptureFileAttachmentAnnotations(child, null, objects, result, visited);
@@ -150,13 +202,25 @@ internal static class PdfAttachmentEditor {
         Dictionary<int, PdfIndirectObject> objects,
         IReadOnlyList<FileAttachmentAnnotation> annotations,
         IReadOnlyDictionary<string, string> retainedOriginalNames,
-        Dictionary<string, PdfReference> fileSpecificationsByName) {
+        Dictionary<string, PdfReference> fileSpecificationsByName,
+        Dictionary<int, PdfReference> fileSpecificationsByOriginalObject,
+        Dictionary<int, PdfReference> fileSpecificationsByOriginalEmbeddedFile) {
         var removedObjectNumbers = new HashSet<int>();
         var removedDirectAnnotations = new HashSet<PdfDictionary>();
         foreach (FileAttachmentAnnotation annotation in annotations) {
-            if (annotation.FileName != null &&
+            PdfReference? replacement = null;
+            if (annotation.FileSpecObjectNumber > 0) {
+                fileSpecificationsByOriginalObject.TryGetValue(
+                    annotation.FileSpecObjectNumber, out replacement);
+            } else if (annotation.EmbeddedFileObjectNumber > 0) {
+                fileSpecificationsByOriginalEmbeddedFile.TryGetValue(
+                    annotation.EmbeddedFileObjectNumber, out replacement);
+            } else if (annotation.FileName != null &&
                 retainedOriginalNames.TryGetValue(annotation.FileName, out string? retainedName) &&
-                fileSpecificationsByName.TryGetValue(retainedName, out PdfReference? replacement)) {
+                fileSpecificationsByName.TryGetValue(retainedName, out PdfReference? nameReplacement)) {
+                replacement = nameReplacement;
+            }
+            if (replacement != null) {
                 annotation.Dictionary.Items["FS"] = replacement;
                 continue;
             }
@@ -209,15 +273,24 @@ internal static class PdfAttachmentEditor {
     }
 
     private sealed class FileAttachmentAnnotation {
-        internal FileAttachmentAnnotation(PdfDictionary dictionary, int? objectNumber, string? fileName) {
+        internal FileAttachmentAnnotation(
+            PdfDictionary dictionary,
+            int? objectNumber,
+            string? fileName,
+            int fileSpecObjectNumber,
+            int embeddedFileObjectNumber) {
             Dictionary = dictionary;
             ObjectNumber = objectNumber;
             FileName = fileName;
+            FileSpecObjectNumber = fileSpecObjectNumber;
+            EmbeddedFileObjectNumber = embeddedFileObjectNumber;
         }
 
         internal PdfDictionary Dictionary { get; }
         internal int? ObjectNumber { get; }
         internal string? FileName { get; }
+        internal int FileSpecObjectNumber { get; }
+        internal int EmbeddedFileObjectNumber { get; }
     }
 
     private static void ScrubEmbeddedFileReferences(
@@ -301,17 +374,22 @@ internal static class PdfAttachmentEditor {
         return dictionary;
     }
 
-    private static System.Collections.ObjectModel.ReadOnlyCollection<PdfAttachmentValidation> Validate(byte[] pdf, IReadOnlyList<PdfEmbeddedFile> target) {
+    private static System.Collections.ObjectModel.ReadOnlyCollection<PdfAttachmentValidation> Validate(byte[] pdf, PdfEmbeddedFile[] target) {
         IReadOnlyList<PdfExtractedAttachment> actual = PdfAttachmentExtractor.ExtractAttachments(pdf);
-        var result = new List<PdfAttachmentValidation>(target.Count);
+        var unmatched = actual.ToList();
+        var result = new List<PdfAttachmentValidation>(target.Length);
         foreach (PdfEmbeddedFile expected in target) {
-            PdfExtractedAttachment? found = actual.FirstOrDefault(item => string.Equals(item.FileName, expected.FileName, StringComparison.Ordinal));
             byte[] data = expected.DataSnapshot;
+            int foundIndex = unmatched.FindIndex(item =>
+                string.Equals(item.FileName, expected.FileName, StringComparison.Ordinal) &&
+                item.Bytes.SequenceEqual(data));
+            PdfExtractedAttachment? found = foundIndex >= 0 ? unmatched[foundIndex] : null;
+            if (foundIndex >= 0) unmatched.RemoveAt(foundIndex);
             bool payload = found != null && found.Bytes.SequenceEqual(data);
             bool metadata = found != null && string.Equals(found.MimeType, expected.MimeType, StringComparison.Ordinal) && string.Equals(found.Description, expected.Description, StringComparison.Ordinal) && found.Relationship == expected.Relationship && DatesMatch(found.CreationDate, expected.CreationDate) && DatesMatch(found.ModificationDate, expected.ModificationDate);
             result.Add(new PdfAttachmentValidation(expected.FileName, ToHex(ComputeChecksum(data)), payload, metadata));
         }
-        if (actual.Count != target.Count) throw new InvalidOperationException("PDF attachment post-save validation found an unexpected attachment count.");
+        if (actual.Count != target.Length) throw new InvalidOperationException("PDF attachment post-save validation found an unexpected attachment count.");
         return result.AsReadOnly();
     }
 

--- a/OfficeIMO.Pdf/Manipulation/PdfAttachmentEditor.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfAttachmentEditor.cs
@@ -17,6 +17,7 @@ internal static class PdfAttachmentEditor {
             return security.InfoObjectNumber.HasValue && objects.ContainsKey(security.InfoObjectNumber.Value) ? security.InfoObjectNumber : null;
         });
         IReadOnlyList<PdfAttachmentValidation> validations = Validate(output, target);
+        ValidateAttachmentGraph(output, target.Count, readOptions);
         if (validations.Any(static validation => !validation.IsValid)) throw new InvalidOperationException("PDF attachment post-save validation failed; the artifact was not returned.");
         var preservationOptions = new PdfRewritePreservationOptions { OriginalReadOptions = readOptions, PreserveEmbeddedFiles = false, PreserveRevisionStructure = false };
         PdfRewritePreservationReport preservation = PdfRewritePreservation.AssertPreserved(pdf, output, preservationOptions);
@@ -36,6 +37,7 @@ internal static class PdfAttachmentEditor {
         if (!security.RootObjectNumber.HasValue || !objects.TryGetValue(security.RootObjectNumber.Value, out PdfIndirectObject? root) || root.Value is not PdfDictionary catalog) throw new InvalidOperationException("PDF catalog is not readable.");
         PdfDictionary? names = ResolveDictionary(objects, catalog.Items.TryGetValue("Names", out PdfObject? namesObject) ? namesObject : null);
         names?.Items.Remove("EmbeddedFiles");
+        RemoveExistingEmbeddedFileGraph(objects);
         PdfAssociatedFileGraph.RemoveAssociatedFileReferences(objects);
         if (attachments.Count == 0) return;
 
@@ -59,6 +61,89 @@ internal static class PdfAttachmentEditor {
         foreach ((string name, PdfReference reference) in nameEntries) { nameArray.Items.Add(new PdfStringObj(name, true)); nameArray.Items.Add(reference); }
         var embeddedFiles = new PdfDictionary(); embeddedFiles.Items["Names"] = nameArray; names.Items["EmbeddedFiles"] = embeddedFiles;
         if (associated.Items.Count > 0) catalog.Items["AF"] = associated;
+    }
+
+    private static void RemoveExistingEmbeddedFileGraph(Dictionary<int, PdfIndirectObject> objects) {
+        var removedObjectNumbers = new HashSet<int>();
+        foreach (PdfIndirectObject indirect in objects.Values) {
+            PdfDictionary? dictionary = indirect.Value is PdfStream stream
+                ? stream.Dictionary
+                : indirect.Value as PdfDictionary;
+            if (dictionary == null) continue;
+            if (indirect.Value is PdfStream &&
+                string.Equals(dictionary.Get<PdfName>("Type")?.Name, "EmbeddedFile", StringComparison.Ordinal)) {
+                removedObjectNumbers.Add(indirect.ObjectNumber);
+            }
+            if (dictionary.Items.ContainsKey("EF")) removedObjectNumbers.Add(indirect.ObjectNumber);
+        }
+
+        foreach (PdfIndirectObject indirect in objects.Values) {
+            ScrubEmbeddedFileReferences(indirect.Value, removedObjectNumbers, new HashSet<PdfObject>());
+        }
+        foreach (int objectNumber in removedObjectNumbers) objects.Remove(objectNumber);
+    }
+
+    private static void ScrubEmbeddedFileReferences(
+        PdfObject value,
+        ISet<int> removedObjectNumbers,
+        ISet<PdfObject> visited) {
+        if (!visited.Add(value)) return;
+        if (value is PdfStream stream) {
+            ScrubEmbeddedFileReferences(stream.Dictionary, removedObjectNumbers, visited);
+            return;
+        }
+        if (value is PdfDictionary dictionary) {
+            dictionary.Items.Remove("EF");
+            foreach (string key in dictionary.Items.Keys.ToArray()) {
+                PdfObject child = dictionary.Items[key];
+                if (child is PdfReference reference && removedObjectNumbers.Contains(reference.ObjectNumber)) {
+                    dictionary.Items.Remove(key);
+                    continue;
+                }
+                if (child is PdfArray array) {
+                    RemoveEmbeddedFileReferences(array, removedObjectNumbers, visited);
+                    if (array.Items.Count == 0 && (key == "AF" || key == "Names")) dictionary.Items.Remove(key);
+                } else if (child is not PdfReference) {
+                    ScrubEmbeddedFileReferences(child, removedObjectNumbers, visited);
+                }
+            }
+            return;
+        }
+        if (value is PdfArray values) RemoveEmbeddedFileReferences(values, removedObjectNumbers, visited);
+    }
+
+    private static void RemoveEmbeddedFileReferences(
+        PdfArray array,
+        ISet<int> removedObjectNumbers,
+        ISet<PdfObject> visited) {
+        for (int index = array.Items.Count - 1; index >= 0; index--) {
+            PdfObject child = array.Items[index];
+            if (child is PdfReference reference && removedObjectNumbers.Contains(reference.ObjectNumber)) {
+                array.Items.RemoveAt(index);
+            } else if (child is not PdfReference) {
+                ScrubEmbeddedFileReferences(child, removedObjectNumbers, visited);
+            }
+        }
+    }
+
+    private static void ValidateAttachmentGraph(byte[] pdf, int expectedCount, PdfReadOptions? readOptions) {
+        var (objects, _) = PdfSyntax.ParseObjects(pdf, readOptions);
+        int embeddedStreams = 0;
+        int fileSpecifications = 0;
+        foreach (PdfIndirectObject indirect in objects.Values) {
+            PdfDictionary? dictionary = indirect.Value is PdfStream stream
+                ? stream.Dictionary
+                : indirect.Value as PdfDictionary;
+            if (dictionary == null) continue;
+            if (indirect.Value is PdfStream &&
+                string.Equals(dictionary.Get<PdfName>("Type")?.Name, "EmbeddedFile", StringComparison.Ordinal)) {
+                embeddedStreams++;
+            }
+            if (dictionary.Items.ContainsKey("EF")) fileSpecifications++;
+        }
+        if (embeddedStreams != expectedCount || fileSpecifications != expectedCount) {
+            throw new InvalidOperationException("PDF attachment post-save validation found hidden or missing embedded-file objects.");
+        }
     }
 
     private static PdfDictionary BuildEmbeddedFileDictionary(PdfEmbeddedFile attachment, byte[] data) {

--- a/OfficeIMO.Pdf/Manipulation/PdfAttachmentEditor.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfAttachmentEditor.cs
@@ -12,14 +12,21 @@ internal static class PdfAttachmentEditor {
         var session = new PdfAttachmentEditSession(existing.Select(static attachment => new PdfEmbeddedFile(attachment.FileName, attachment.Bytes, attachment.MimeType, attachment.Relationship, attachment.Description, attachment.CreationDate, attachment.ModificationDate)));
         edit(session);
         IReadOnlyList<PdfEmbeddedFile> target = session.Snapshot();
+        IReadOnlyDictionary<string, string> retainedOriginalNames = session.RetainedOriginalNames;
+        bool removedFileAttachmentAnnotations = false;
         byte[] output = PdfDocumentObjectGraphRewriter.Rewrite(pdf, readOptions, null, (objects, security) => {
-            RewriteAttachmentGraph(objects, security, target);
+            removedFileAttachmentAnnotations = RewriteAttachmentGraph(objects, security, target, retainedOriginalNames);
             return security.InfoObjectNumber.HasValue && objects.ContainsKey(security.InfoObjectNumber.Value) ? security.InfoObjectNumber : null;
         });
         IReadOnlyList<PdfAttachmentValidation> validations = Validate(output, target);
         ValidateAttachmentGraph(output, target.Count, readOptions);
         if (validations.Any(static validation => !validation.IsValid)) throw new InvalidOperationException("PDF attachment post-save validation failed; the artifact was not returned.");
-        var preservationOptions = new PdfRewritePreservationOptions { OriginalReadOptions = readOptions, PreserveEmbeddedFiles = false, PreserveRevisionStructure = false };
+        var preservationOptions = new PdfRewritePreservationOptions {
+            OriginalReadOptions = readOptions,
+            PreserveAnnotations = !removedFileAttachmentAnnotations,
+            PreserveEmbeddedFiles = false,
+            PreserveRevisionStructure = false
+        };
         PdfRewritePreservationReport preservation = PdfRewritePreservation.AssertPreserved(pdf, output, preservationOptions);
         return new PdfAttachmentEditResult(output, plan, preservation, validations);
     }
@@ -33,17 +40,29 @@ internal static class PdfAttachmentEditor {
     /// <summary>Removes one attachment.</summary>
     public static PdfAttachmentEditResult Remove(byte[] pdf, string fileName, PdfReadOptions? readOptions = null) => Edit(pdf, session => session.Remove(fileName), readOptions);
 
-    private static void RewriteAttachmentGraph(Dictionary<int, PdfIndirectObject> objects, PdfDocumentSecurityInfo security, IReadOnlyList<PdfEmbeddedFile> attachments) {
+    private static bool RewriteAttachmentGraph(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfDocumentSecurityInfo security,
+        IReadOnlyList<PdfEmbeddedFile> attachments,
+        IReadOnlyDictionary<string, string> retainedOriginalNames) {
         if (!security.RootObjectNumber.HasValue || !objects.TryGetValue(security.RootObjectNumber.Value, out PdfIndirectObject? root) || root.Value is not PdfDictionary catalog) throw new InvalidOperationException("PDF catalog is not readable.");
+        List<FileAttachmentAnnotation> fileAttachmentAnnotations = CaptureFileAttachmentAnnotations(objects);
         PdfDictionary? names = ResolveDictionary(objects, catalog.Items.TryGetValue("Names", out PdfObject? namesObject) ? namesObject : null);
         names?.Items.Remove("EmbeddedFiles");
         RemoveExistingEmbeddedFileGraph(objects);
         PdfAssociatedFileGraph.RemoveAssociatedFileReferences(objects);
-        if (attachments.Count == 0) return;
+        if (attachments.Count == 0) {
+            return ReconnectFileAttachmentAnnotations(
+                objects,
+                fileAttachmentAnnotations,
+                retainedOriginalNames,
+                new Dictionary<string, PdfReference>(StringComparer.Ordinal));
+        }
 
         if (names == null) { names = new PdfDictionary(); catalog.Items["Names"] = names; }
         int nextObjectNumber = objects.Count == 0 ? 1 : objects.Keys.Max() + 1;
         var nameEntries = new List<(string Name, PdfReference FileSpec)>(attachments.Count);
+        var fileSpecificationsByName = new Dictionary<string, PdfReference>(StringComparer.Ordinal);
         var associated = new PdfArray();
         foreach (PdfEmbeddedFile attachment in attachments.OrderBy(static file => file.FileName, StringComparer.Ordinal)) {
             byte[] data = attachment.DataSnapshot;
@@ -55,12 +74,14 @@ internal static class PdfAttachmentEditor {
             objects[fileSpecNumber] = new PdfIndirectObject(fileSpecNumber, 0, fileSpec);
             var reference = new PdfReference(fileSpecNumber, 0);
             nameEntries.Add((attachment.FileName, reference));
+            fileSpecificationsByName[attachment.FileName] = reference;
             if (attachment.Relationship != PdfAssociatedFileRelationship.Unspecified) associated.Items.Add(reference);
         }
         var nameArray = new PdfArray();
         foreach ((string name, PdfReference reference) in nameEntries) { nameArray.Items.Add(new PdfStringObj(name, true)); nameArray.Items.Add(reference); }
         var embeddedFiles = new PdfDictionary(); embeddedFiles.Items["Names"] = nameArray; names.Items["EmbeddedFiles"] = embeddedFiles;
         if (associated.Items.Count > 0) catalog.Items["AF"] = associated;
+        return ReconnectFileAttachmentAnnotations(objects, fileAttachmentAnnotations, retainedOriginalNames, fileSpecificationsByName);
     }
 
     private static void RemoveExistingEmbeddedFileGraph(Dictionary<int, PdfIndirectObject> objects) {
@@ -81,6 +102,122 @@ internal static class PdfAttachmentEditor {
             ScrubEmbeddedFileReferences(indirect.Value, removedObjectNumbers, new HashSet<PdfObject>());
         }
         foreach (int objectNumber in removedObjectNumbers) objects.Remove(objectNumber);
+    }
+
+    private static List<FileAttachmentAnnotation> CaptureFileAttachmentAnnotations(Dictionary<int, PdfIndirectObject> objects) {
+        var result = new List<FileAttachmentAnnotation>();
+        var visited = new HashSet<PdfObject>();
+        foreach (PdfIndirectObject indirect in objects.Values) {
+            CaptureFileAttachmentAnnotations(indirect.Value, indirect.ObjectNumber, objects, result, visited);
+        }
+        return result;
+    }
+
+    private static void CaptureFileAttachmentAnnotations(
+        PdfObject value,
+        int? indirectObjectNumber,
+        Dictionary<int, PdfIndirectObject> objects,
+        List<FileAttachmentAnnotation> result,
+        ISet<PdfObject> visited) {
+        if (!visited.Add(value)) return;
+        if (value is PdfStream stream) {
+            CaptureFileAttachmentAnnotations(stream.Dictionary, indirectObjectNumber, objects, result, visited);
+            return;
+        }
+        if (value is PdfDictionary dictionary) {
+            if (string.Equals(dictionary.Get<PdfName>("Subtype")?.Name, "FileAttachment", StringComparison.Ordinal)) {
+                string? fileName = null;
+                if (dictionary.Items.TryGetValue("FS", out PdfObject? fileSpecification) &&
+                    ResolveDictionary(objects, fileSpecification) is PdfDictionary fileSpecificationDictionary) {
+                    fileName = fileSpecificationDictionary.Get<PdfStringObj>("UF")?.Value
+                        ?? fileSpecificationDictionary.Get<PdfStringObj>("F")?.Value;
+                }
+                result.Add(new FileAttachmentAnnotation(dictionary, indirectObjectNumber, fileName));
+            }
+            foreach (PdfObject child in dictionary.Items.Values) {
+                if (child is not PdfReference) CaptureFileAttachmentAnnotations(child, null, objects, result, visited);
+            }
+            return;
+        }
+        if (value is PdfArray array) {
+            foreach (PdfObject child in array.Items) {
+                if (child is not PdfReference) CaptureFileAttachmentAnnotations(child, null, objects, result, visited);
+            }
+        }
+    }
+
+    private static bool ReconnectFileAttachmentAnnotations(
+        Dictionary<int, PdfIndirectObject> objects,
+        IReadOnlyList<FileAttachmentAnnotation> annotations,
+        IReadOnlyDictionary<string, string> retainedOriginalNames,
+        Dictionary<string, PdfReference> fileSpecificationsByName) {
+        var removedObjectNumbers = new HashSet<int>();
+        var removedDirectAnnotations = new HashSet<PdfDictionary>();
+        foreach (FileAttachmentAnnotation annotation in annotations) {
+            if (annotation.FileName != null &&
+                retainedOriginalNames.TryGetValue(annotation.FileName, out string? retainedName) &&
+                fileSpecificationsByName.TryGetValue(retainedName, out PdfReference? replacement)) {
+                annotation.Dictionary.Items["FS"] = replacement;
+                continue;
+            }
+
+            if (annotation.ObjectNumber.HasValue) removedObjectNumbers.Add(annotation.ObjectNumber.Value);
+            else removedDirectAnnotations.Add(annotation.Dictionary);
+        }
+
+        if (removedObjectNumbers.Count == 0 && removedDirectAnnotations.Count == 0) return false;
+        var visited = new HashSet<PdfObject>();
+        foreach (PdfIndirectObject indirect in objects.Values) {
+            RemoveFileAttachmentAnnotationReferences(indirect.Value, removedObjectNumbers, removedDirectAnnotations, visited);
+        }
+        foreach (int objectNumber in removedObjectNumbers) objects.Remove(objectNumber);
+        return true;
+    }
+
+    private static void RemoveFileAttachmentAnnotationReferences(
+        PdfObject value,
+        ISet<int> removedObjectNumbers,
+        ISet<PdfDictionary> removedDirectAnnotations,
+        ISet<PdfObject> visited) {
+        if (!visited.Add(value)) return;
+        if (value is PdfStream stream) {
+            RemoveFileAttachmentAnnotationReferences(stream.Dictionary, removedObjectNumbers, removedDirectAnnotations, visited);
+            return;
+        }
+        if (value is PdfDictionary dictionary) {
+            foreach (string key in dictionary.Items.Keys.ToArray()) {
+                PdfObject child = dictionary.Items[key];
+                if (child is PdfReference reference && removedObjectNumbers.Contains(reference.ObjectNumber) ||
+                    child is PdfDictionary childDictionary && removedDirectAnnotations.Contains(childDictionary)) {
+                    dictionary.Items.Remove(key);
+                } else if (child is not PdfReference) {
+                    RemoveFileAttachmentAnnotationReferences(child, removedObjectNumbers, removedDirectAnnotations, visited);
+                }
+            }
+            return;
+        }
+        if (value is not PdfArray array) return;
+        for (int index = array.Items.Count - 1; index >= 0; index--) {
+            PdfObject child = array.Items[index];
+            if (child is PdfReference reference && removedObjectNumbers.Contains(reference.ObjectNumber) ||
+                child is PdfDictionary childDictionary && removedDirectAnnotations.Contains(childDictionary)) {
+                array.Items.RemoveAt(index);
+            } else if (child is not PdfReference) {
+                RemoveFileAttachmentAnnotationReferences(child, removedObjectNumbers, removedDirectAnnotations, visited);
+            }
+        }
+    }
+
+    private sealed class FileAttachmentAnnotation {
+        internal FileAttachmentAnnotation(PdfDictionary dictionary, int? objectNumber, string? fileName) {
+            Dictionary = dictionary;
+            ObjectNumber = objectNumber;
+            FileName = fileName;
+        }
+
+        internal PdfDictionary Dictionary { get; }
+        internal int? ObjectNumber { get; }
+        internal string? FileName { get; }
     }
 
     private static void ScrubEmbeddedFileReferences(

--- a/OfficeIMO.Pdf/Manipulation/PdfIncrementalUpdater.ExternalSigner.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfIncrementalUpdater.ExternalSigner.cs
@@ -50,13 +50,13 @@ internal static partial class PdfIncrementalUpdater {
         ValidateSigningInput(0, effectiveOptions);
         byte[] pdf;
         try {
-            pdf = OfficeStreamReader.ReadAllBytes(
+            pdf = OfficeStreamReader.ReadRemainingBytes(
                 input,
                 effectiveOptions.CancellationToken,
                 effectiveOptions.MaxInputBytes);
         } catch (InvalidDataException) {
             long observedBytes = input.CanSeek
-                ? input.Length
+                ? Math.Max(0L, input.Length - input.Position)
                 : checked(effectiveOptions.MaxInputBytes + 1L);
             throw PdfReadLimitException.Create(PdfReadLimitKind.InputBytes,
                 effectiveOptions.MaxInputBytes, observedBytes);

--- a/OfficeIMO.Pdf/Manipulation/PdfIncrementalUpdater.ExternalSigner.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfIncrementalUpdater.ExternalSigner.cs
@@ -47,10 +47,14 @@ internal static partial class PdfIncrementalUpdater {
         Guard.NotNull(input, nameof(input));
         if (!input.CanRead) throw new ArgumentException("Stream must be readable.", nameof(input));
         PdfExternalSignatureOptions effectiveOptions = options ?? new PdfExternalSignatureOptions();
+        byte[] pdf = ReadSigningInput(input, effectiveOptions);
+        return SignExternal(pdf, signer, effectiveOptions);
+    }
+
+    private static byte[] ReadSigningInput(Stream input, PdfExternalSignatureOptions effectiveOptions) {
         ValidateSigningInput(0, effectiveOptions);
-        byte[] pdf;
         try {
-            pdf = OfficeStreamReader.ReadRemainingBytes(
+            return OfficeStreamReader.ReadRemainingBytes(
                 input,
                 effectiveOptions.CancellationToken,
                 effectiveOptions.MaxInputBytes);
@@ -61,7 +65,6 @@ internal static partial class PdfIncrementalUpdater {
             throw PdfReadLimitException.Create(PdfReadLimitKind.InputBytes,
                 effectiveOptions.MaxInputBytes, observedBytes);
         }
-        return SignExternal(pdf, signer, effectiveOptions);
     }
 
     /// <summary>Signs a PDF file through caller-owned key infrastructure and writes the completed output.</summary>

--- a/OfficeIMO.Pdf/Manipulation/PdfIncrementalUpdater.ExternalSigner.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfIncrementalUpdater.ExternalSigner.cs
@@ -16,11 +16,15 @@ internal static partial class PdfIncrementalUpdater {
         PdfReadOptions? readOptions) {
         Guard.NotNull(pdf, nameof(pdf));
         Guard.NotNull(signer, nameof(signer));
+        PdfExternalSignatureOptions effectiveOptions = options ?? new PdfExternalSignatureOptions();
+        ValidateSigningInput(pdf.LongLength, effectiveOptions);
+        effectiveOptions.CancellationToken.ThrowIfCancellationRequested();
         if (string.IsNullOrWhiteSpace(signer.Name)) {
             throw new ArgumentException("External signer name cannot be empty.", nameof(signer));
         }
 
-        PdfExternalSignaturePreparation preparation = PrepareExternalSignature(pdf, options, readOptions);
+        PdfExternalSignaturePreparation preparation = PrepareExternalSignature(pdf, effectiveOptions, readOptions);
+        effectiveOptions.CancellationToken.ThrowIfCancellationRequested();
         byte[] signatureContents = signer.Sign(new PdfExternalSignatureRequest(preparation));
         if (signatureContents is null || signatureContents.Length == 0) {
             throw new InvalidOperationException(signer.Name + " returned empty signature contents.");
@@ -42,9 +46,22 @@ internal static partial class PdfIncrementalUpdater {
         PdfExternalSignatureOptions? options = null) {
         Guard.NotNull(input, nameof(input));
         if (!input.CanRead) throw new ArgumentException("Stream must be readable.", nameof(input));
-        using var buffer = new MemoryStream();
-        input.CopyTo(buffer);
-        return SignExternal(buffer.ToArray(), signer, options);
+        PdfExternalSignatureOptions effectiveOptions = options ?? new PdfExternalSignatureOptions();
+        ValidateSigningInput(0, effectiveOptions);
+        byte[] pdf;
+        try {
+            pdf = OfficeStreamReader.ReadAllBytes(
+                input,
+                effectiveOptions.CancellationToken,
+                effectiveOptions.MaxInputBytes);
+        } catch (InvalidDataException) {
+            long observedBytes = input.CanSeek
+                ? input.Length
+                : checked(effectiveOptions.MaxInputBytes + 1L);
+            throw PdfReadLimitException.Create(PdfReadLimitKind.InputBytes,
+                effectiveOptions.MaxInputBytes, observedBytes);
+        }
+        return SignExternal(pdf, signer, effectiveOptions);
     }
 
     /// <summary>Signs a PDF file through caller-owned key infrastructure and writes the completed output.</summary>
@@ -55,8 +72,22 @@ internal static partial class PdfIncrementalUpdater {
         PdfExternalSignatureOptions? options = null) {
         Guard.NotNullOrWhiteSpace(inputPath, nameof(inputPath));
         Guard.NotNullOrWhiteSpace(outputPath, nameof(outputPath));
-        PdfExternalSignatureCompletion completion = SignExternal(File.ReadAllBytes(inputPath), signer, options);
+        PdfExternalSignatureOptions effectiveOptions = options ?? new PdfExternalSignatureOptions();
+        PdfExternalSignatureCompletion completion;
+        using (var input = new FileStream(inputPath, FileMode.Open, FileAccess.Read, FileShare.Read)) {
+            completion = SignExternal(input, signer, effectiveOptions);
+        }
         OfficeFileCommit.WriteAllBytes(outputPath, completion.Pdf);
         return completion;
+    }
+
+    private static void ValidateSigningInput(long observedBytes, PdfExternalSignatureOptions options) {
+        if (options.MaxInputBytes <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(options), options.MaxInputBytes,
+                "Maximum signing input bytes must be positive.");
+        }
+        if (observedBytes > options.MaxInputBytes) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.InputBytes, options.MaxInputBytes, observedBytes);
+        }
     }
 }

--- a/OfficeIMO.Pdf/Manipulation/PdfIncrementalUpdater.Signatures.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfIncrementalUpdater.Signatures.cs
@@ -20,6 +20,8 @@ internal static partial class PdfIncrementalUpdater {
         PdfReadOptions? readOptions) {
         Guard.NotNull(pdf, nameof(pdf));
         PdfExternalSignatureOptions effectiveOptions = options ?? new PdfExternalSignatureOptions();
+        ValidateSigningInput(pdf.LongLength, effectiveOptions);
+        effectiveOptions.CancellationToken.ThrowIfCancellationRequested();
         ValidateExternalSignatureOptions(effectiveOptions);
         PdfSignatureProfile signatureProfile = ResolveSignatureProfile(effectiveOptions);
         _ = PdfMutationPlanner.RequireAppendOnly(pdf, PdfMutationOperation.PrepareExternalSignature, readOptions);
@@ -101,16 +103,19 @@ internal static partial class PdfIncrementalUpdater {
             throw new ArgumentException("Stream must be readable.", nameof(input));
         }
 
-        using var buffer = new MemoryStream();
-        input.CopyTo(buffer);
-        return PrepareExternalSignature(buffer.ToArray(), options);
+        PdfExternalSignatureOptions effectiveOptions = options ?? new PdfExternalSignatureOptions();
+        return PrepareExternalSignature(ReadSigningInput(input, effectiveOptions), effectiveOptions);
     }
 
     /// <summary>Appends an external signature placeholder to a PDF file and writes the prepared PDF to <paramref name="outputPath"/>.</summary>
     public static PdfExternalSignaturePreparation PrepareExternalSignature(string inputPath, string outputPath, PdfExternalSignatureOptions? options = null) {
         Guard.NotNullOrWhiteSpace(inputPath, nameof(inputPath));
         Guard.NotNullOrWhiteSpace(outputPath, nameof(outputPath));
-        PdfExternalSignaturePreparation preparation = PrepareExternalSignature(File.ReadAllBytes(inputPath), options);
+        PdfExternalSignatureOptions effectiveOptions = options ?? new PdfExternalSignatureOptions();
+        PdfExternalSignaturePreparation preparation;
+        using (var input = new FileStream(inputPath, FileMode.Open, FileAccess.Read, FileShare.Read)) {
+            preparation = PrepareExternalSignature(ReadSigningInput(input, effectiveOptions), effectiveOptions);
+        }
         OfficeFileCommit.WriteAllBytes(outputPath, preparation.PreparedPdf);
         return preparation;
     }

--- a/OfficeIMO.Pdf/Manipulation/PdfOptimizationOptions.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfOptimizationOptions.cs
@@ -54,7 +54,10 @@ public sealed class PdfOptimizationOptions {
     public bool Linearize { get; set; }
 
     /// <summary>Maximum decoded image bytes considered for semantic image deduplication.</summary>
-    public int MaximumDecodedImageBytes { get; set; } = 256 * 1024 * 1024;
+    public int MaximumDecodedImageBytes { get; set; } = 64 * 1024 * 1024;
+
+    /// <summary>Maximum aggregate decoded image bytes inspected for semantic deduplication.</summary>
+    public long MaximumTotalDecodedImageBytes { get; set; } = 256L * 1024L * 1024L;
 
     /// <summary>Return the original PDF bytes when the optimized output would not be smaller.</summary>
     public bool KeepOriginalWhenNotSmaller { get; set; } = true;
@@ -92,6 +95,7 @@ public sealed class PdfOptimizationOptions {
             XrefFormat = XrefFormat,
             Linearize = Linearize,
             MaximumDecodedImageBytes = MaximumDecodedImageBytes,
+            MaximumTotalDecodedImageBytes = MaximumTotalDecodedImageBytes,
             Profile = Profile,
             KeepOriginalWhenNotSmaller = KeepOriginalWhenNotSmaller,
             MinimumStreamCompressionBytes = MinimumStreamCompressionBytes

--- a/OfficeIMO.Pdf/Manipulation/PdfOptimizer.SemanticDeduplication.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfOptimizer.SemanticDeduplication.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Security.Cryptography;
 using System.Text;
 using OfficeIMO.Pdf.Filters;
 
@@ -7,16 +8,33 @@ namespace OfficeIMO.Pdf;
 internal static partial class PdfOptimizer {
     private static void DeduplicateImages(Dictionary<int, PdfIndirectObject> objects, PdfOptimizationOptions options, List<PdfOptimizationAction> actions, List<PdfOptimizationSkippedAction> skippedActions) {
         var groups = new Dictionary<string, List<int>>(StringComparer.Ordinal);
+        long totalDecodedBytes = 0;
         foreach (KeyValuePair<int, PdfIndirectObject> entry in objects.OrderBy(static item => item.Key)) {
             if (entry.Value.Value is not PdfStream stream || !string.Equals(ReadName(stream.Dictionary, "Subtype"), "Image", StringComparison.Ordinal)) continue;
             if (!StreamDecoder.TryDecode(stream.Dictionary, stream.Data, options.MaximumDecodedImageBytes, out byte[] decoded, objects)) {
                 skippedActions.Add(new PdfOptimizationSkippedAction("DeduplicateImage", entry.Key, stream.Data.LongLength, "UnsupportedImageFilter", "Skipped semantic image deduplication because the image samples could not be decoded within the configured limit."));
                 continue;
             }
-            string fingerprint = BuildCanonicalDictionary(stream.Dictionary, "Length", "Filter", "DecodeParms") + "|" + Convert.ToBase64String(decoded);
+            if (decoded.LongLength > options.MaximumTotalDecodedImageBytes - totalDecodedBytes) {
+                skippedActions.Add(new PdfOptimizationSkippedAction("DeduplicateImage", entry.Key, stream.Data.LongLength, "AggregateDecodeLimit", "Stopped semantic image deduplication after the aggregate decoded-image budget was exhausted."));
+                break;
+            }
+            totalDecodedBytes += decoded.LongLength;
+            byte[] digest = ComputeSha256(decoded);
+            string fingerprint = BuildCanonicalDictionary(stream.Dictionary, "Length", "Filter", "DecodeParms") + "|sha256:" + Convert.ToBase64String(digest);
             AddGroup(groups, fingerprint, entry.Key);
         }
         ApplyDuplicateGroups(objects, groups, "DeduplicateImage", "Reused a losslessly equivalent decoded image XObject.", actions);
+    }
+
+    private static byte[] ComputeSha256(byte[] value) {
+#if NET6_0_OR_GREATER
+        return SHA256.HashData(value);
+#else
+        using (SHA256 sha256 = SHA256.Create()) {
+            return sha256.ComputeHash(value);
+        }
+#endif
     }
 
     private static void DeduplicateTypedDictionaries(Dictionary<int, PdfIndirectObject> objects, string typeName, string actionKind, List<PdfOptimizationAction> actions) {

--- a/OfficeIMO.Pdf/Manipulation/PdfOptimizer.SemanticDeduplication.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfOptimizer.SemanticDeduplication.cs
@@ -11,11 +11,25 @@ internal static partial class PdfOptimizer {
         long totalDecodedBytes = 0;
         foreach (KeyValuePair<int, PdfIndirectObject> entry in objects.OrderBy(static item => item.Key)) {
             if (entry.Value.Value is not PdfStream stream || !string.Equals(ReadName(stream.Dictionary, "Subtype"), "Image", StringComparison.Ordinal)) continue;
-            if (!StreamDecoder.TryDecode(stream.Dictionary, stream.Data, options.MaximumDecodedImageBytes, out byte[] decoded, objects)) {
-                skippedActions.Add(new PdfOptimizationSkippedAction("DeduplicateImage", entry.Key, stream.Data.LongLength, "UnsupportedImageFilter", "Skipped semantic image deduplication because the image samples could not be decoded within the configured limit."));
+            long remainingDecodedBytes = options.MaximumTotalDecodedImageBytes - totalDecodedBytes;
+            if (remainingDecodedBytes <= 0) {
+                skippedActions.Add(new PdfOptimizationSkippedAction("DeduplicateImage", entry.Key, stream.Data.LongLength, "AggregateDecodeLimit", "Stopped semantic image deduplication after the aggregate decoded-image budget was exhausted."));
+                break;
+            }
+            int maximumDecodedBytes = (int)Math.Min(options.MaximumDecodedImageBytes, Math.Min(int.MaxValue, remainingDecodedBytes));
+            if (!StreamDecoder.TryDecode(stream.Dictionary, stream.Data, maximumDecodedBytes, out byte[] decoded, objects)) {
+                string reason = maximumDecodedBytes < options.MaximumDecodedImageBytes
+                    ? "AggregateDecodeLimit"
+                    : "UnsupportedImageFilter";
+                string description = reason == "AggregateDecodeLimit"
+                    ? "Stopped semantic image deduplication before decoding an image beyond the remaining aggregate budget."
+                    : "Skipped semantic image deduplication because the image samples could not be decoded within the configured limit.";
+                skippedActions.Add(new PdfOptimizationSkippedAction("DeduplicateImage", entry.Key, stream.Data.LongLength, reason, description));
+                if (reason == "AggregateDecodeLimit") break;
                 continue;
             }
-            if (decoded.LongLength > options.MaximumTotalDecodedImageBytes - totalDecodedBytes) {
+            if (decoded.LongLength > remainingDecodedBytes) {
+                // Defensive fallback for decoders that cannot enforce their output limit incrementally.
                 skippedActions.Add(new PdfOptimizationSkippedAction("DeduplicateImage", entry.Key, stream.Data.LongLength, "AggregateDecodeLimit", "Stopped semantic image deduplication after the aggregate decoded-image budget was exhausted."));
                 break;
             }

--- a/OfficeIMO.Pdf/Manipulation/PdfOptimizer.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfOptimizer.cs
@@ -19,6 +19,7 @@ internal static partial class PdfOptimizer {
             throw new ArgumentOutOfRangeException(nameof(options), "Minimum stream compression size cannot be negative.");
         }
         if (effectiveOptions.MaximumDecodedImageBytes <= 0) throw new ArgumentOutOfRangeException(nameof(options), "Maximum decoded image bytes must be positive.");
+        if (effectiveOptions.MaximumTotalDecodedImageBytes <= 0) throw new ArgumentOutOfRangeException(nameof(options), "Maximum total decoded image bytes must be positive.");
         if (effectiveOptions.XrefFormat != PdfOptimizationXrefFormat.ClassicTable && effectiveOptions.XrefFormat != PdfOptimizationXrefFormat.XrefStream) throw new ArgumentOutOfRangeException(nameof(options), "Unsupported optimization xref format.");
         if (effectiveOptions.UseObjectStreams) effectiveOptions.XrefFormat = PdfOptimizationXrefFormat.XrefStream;
         if (effectiveOptions.Linearize && (effectiveOptions.UseObjectStreams || effectiveOptions.XrefFormat != PdfOptimizationXrefFormat.ClassicTable)) {

--- a/OfficeIMO.Pdf/Manipulation/PdfPageEditor.IO.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfPageEditor.IO.cs
@@ -8,9 +8,20 @@ internal static partial class PdfPageEditor {
             throw new ArgumentException("Stream must be readable.", paramName);
         }
 
-        using var buffer = new MemoryStream();
-        stream.CopyTo(buffer);
-        return buffer.ToArray();
+        long limit = PdfReadOptions.Default.Limits.MaxInputBytes;
+        long observedBytes = limit + 1L;
+        if (stream.CanSeek) {
+            try {
+                observedBytes = Math.Max(0L, stream.Length - stream.Position);
+            } catch (NotSupportedException) {
+                // The bounded reader will still enforce the limit while consuming the stream.
+            }
+        }
+        try {
+            return OfficeStreamReader.ReadRemainingBytes(stream, limit);
+        } catch (InvalidDataException) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.InputBytes, limit, observedBytes);
+        }
     }
 
     private static void WriteOutput(Stream outputStream, byte[] bytes) {

--- a/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.Paths.cs
+++ b/OfficeIMO.Pdf/Manipulation/PdfRedactionApplier.Paths.cs
@@ -34,6 +34,7 @@ internal static partial class PdfRedactionApplier {
             else if (op == "c") { StartPath(args, ref pathStart); for (int i = Math.Max(0, args.Count - 6); i + 1 < args.Count; i += 2) AddPoint(ctm, args[i].Number, args[i + 1].Number, ref minX, ref minY, ref maxX, ref maxY); }
             else if (op == "v" || op == "y") { StartPath(args, ref pathStart); for (int i = Math.Max(0, args.Count - 4); i + 1 < args.Count; i += 2) AddPoint(ctm, args[i].Number, args[i + 1].Number, ref minX, ref minY, ref maxX, ref maxY); }
             else if (op == "re" && args.Count >= 4) { StartPath(args, ref pathStart); int start = args.Count - 4; double x = args[start].Number, y = args[start + 1].Number, width = args[start + 2].Number, height = args[start + 3].Number; AddPoint(ctm, x, y, ref minX, ref minY, ref maxX, ref maxY); AddPoint(ctm, x + width, y, ref minX, ref minY, ref maxX, ref maxY); AddPoint(ctm, x, y + height, ref minX, ref minY, ref maxX, ref maxY); AddPoint(ctm, x + width, y + height, ref minX, ref minY, ref maxX, ref maxY); }
+            else if (op == "n") { pathStart = -1; minX = minY = double.MaxValue; maxX = maxY = double.MinValue; }
             else if (IsPathPaintOperator(op)) { if (pathStart >= 0 && maxX > minX && maxY > minY && areas.Any(area => Intersects(area.X, area.Y, area.Width, area.Height, minX, minY, maxX - minX, maxY - minY))) ranges.Add(new RemovalRange(pathStart, opEnd)); pathStart = -1; minX = minY = double.MaxValue; maxX = maxY = double.MinValue; }
             args.Clear();
         }
@@ -42,5 +43,5 @@ internal static partial class PdfRedactionApplier {
 
     private static void StartPath(List<ImageContentOperand> args, ref int pathStart) { if (pathStart < 0 && args.Count > 0) pathStart = args[0].Start; }
     private static void AddPoint(Matrix2D transform, double x, double y, ref double minX, ref double minY, ref double maxX, ref double maxY) { var point = transform.Transform(x, y); minX = Math.Min(minX, point.X); minY = Math.Min(minY, point.Y); maxX = Math.Max(maxX, point.X); maxY = Math.Max(maxY, point.Y); }
-    private static bool IsPathPaintOperator(string value) => value == "S" || value == "s" || value == "f" || value == "F" || value == "f*" || value == "B" || value == "B*" || value == "b" || value == "b*" || value == "n";
+    private static bool IsPathPaintOperator(string value) => value == "S" || value == "s" || value == "f" || value == "F" || value == "f*" || value == "B" || value == "B*" || value == "b" || value == "b*";
 }

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Scanning.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Scanning.cs
@@ -5,11 +5,13 @@ internal static partial class PdfSyntax {
         string text,
         int start,
         IReadOnlyDictionary<(int ObjectNumber, int Generation), int>? declaredLengthValues = null,
-        PdfReadLimits? limits = null) {
+        PdfReadLimits? limits = null,
+        int? maximumIndex = null) {
+        int limit = Math.Min(text.Length, maximumIndex ?? text.Length);
         int searchFrom = start;
-        while (searchFrom >= 0 && searchFrom < text.Length) {
-            int streamIdx = IndexOfKeywordOutsideLiteralString(text, "stream", searchFrom, text.Length);
-            int endObjIdx = IndexOfKeywordOutsideLiteralString(text, "endobj", searchFrom, text.Length);
+        while (searchFrom >= 0 && searchFrom < limit) {
+            int streamIdx = IndexOfKeywordOutsideLiteralString(text, "stream", searchFrom, limit);
+            int endObjIdx = IndexOfKeywordOutsideLiteralString(text, "endobj", searchFrom, limit);
 
             if (streamIdx < 0) {
                 return endObjIdx < 0 ? -1 : endObjIdx + 6;
@@ -19,7 +21,7 @@ internal static partial class PdfSyntax {
                 return endObjIdx + 6;
             }
 
-            int afterStream = SkipEOL(text, streamIdx + 6, text.Length);
+            int afterStream = SkipEOL(text, streamIdx + 6, limit);
             if (TryFindDeclaredStreamObjectEnd(
                     text,
                     start,
@@ -27,13 +29,14 @@ internal static partial class PdfSyntax {
                     afterStream,
                     declaredLengthValues,
                     limits,
+                    limit,
                     out int declaredObjectEnd)) {
                 return declaredObjectEnd;
             }
 
             int endStreamSearchFrom = afterStream;
-            while (endStreamSearchFrom < text.Length) {
-                int endStreamIdx = IndexOfKeyword(text, "endstream", endStreamSearchFrom, text.Length);
+            while (endStreamSearchFrom < limit) {
+                int endStreamIdx = IndexOfKeyword(text, "endstream", endStreamSearchFrom, limit);
                 if (endStreamIdx < 0) {
                     return -1;
                 }
@@ -45,8 +48,8 @@ internal static partial class PdfSyntax {
                     return -1;
                 }
 
-                int nextToken = SkipWhitespaceAndComments(text, endStreamIdx + 9, text.Length);
-                if (IsKeywordAt(text, "endobj", nextToken, text.Length)) {
+                int nextToken = SkipWhitespaceAndComments(text, endStreamIdx + 9, limit);
+                if (IsKeywordAt(text, "endobj", nextToken, limit)) {
                     return nextToken + 6;
                 }
 
@@ -95,6 +98,7 @@ internal static partial class PdfSyntax {
         int dataStart,
         IReadOnlyDictionary<(int ObjectNumber, int Generation), int>? declaredLengthValues,
         PdfReadLimits? limits,
+        int limit,
         out int objectEnd) {
         objectEnd = -1;
         int dictionaryStart = text.IndexOf("<<", objectStart, streamIndex - objectStart, StringComparison.Ordinal);
@@ -133,12 +137,12 @@ internal static partial class PdfSyntax {
             return false;
         }
 
-        if (!TryGetDeclaredEndStreamIndex(text, dataStart, byteLength, text.Length, out int endStream)) {
+        if (!TryGetDeclaredEndStreamIndex(text, dataStart, byteLength, limit, out int endStream)) {
             return false;
         }
 
-        int endObject = SkipWhitespaceAndComments(text, endStream + 9, text.Length);
-        if (!IsKeywordAt(text, "endobj", endObject, text.Length)) {
+        int endObject = SkipWhitespaceAndComments(text, endStream + 9, limit);
+        if (!IsKeywordAt(text, "endobj", endObject, limit)) {
             return false;
         }
 

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Xref.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Xref.cs
@@ -2,7 +2,6 @@ namespace OfficeIMO.Pdf;
 
 internal static partial class PdfSyntax {
     private const int MaximumXrefObjectCharacters = 1_000_000;
-    private const int MaximumXrefObjectScanMultiplier = 16;
 
     private sealed class XrefObjectScanBudget {
         private readonly long _maximum;
@@ -10,9 +9,7 @@ internal static partial class PdfSyntax {
 
         internal XrefObjectScanBudget(PdfReadLimits limits) {
             MaximumPerObject = Math.Min(MaximumXrefObjectCharacters, limits.MaxObjectCharacters);
-            _maximum = Math.Min(
-                limits.MaxInputBytes,
-                checked((long)MaximumPerObject * MaximumXrefObjectScanMultiplier));
+            _maximum = limits.MaxInputBytes;
         }
 
         internal int MaximumPerObject { get; }

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Xref.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Xref.cs
@@ -176,7 +176,8 @@ internal static partial class PdfSyntax {
 
         int dictStart = text.IndexOf("<<", trailerIndex, StringComparison.Ordinal);
         if (dictStart >= 0) {
-            int dictEnd = FindDictEnd(text, dictStart, text.Length);
+            int dictionaryLimit = (int)Math.Min((long)text.Length, (long)dictStart + 1_000_002L);
+            int dictEnd = FindDictEnd(text, dictStart, dictionaryLimit);
             if (dictEnd > dictStart) {
                 trailerRaw = SafeSlice(text, trailerIndex, dictEnd - trailerIndex, 1_000_000);
                 string dictText = SafeSlice(text, dictStart + 2, dictEnd - (dictStart + 2), 1_000_000);

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Xref.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.Xref.cs
@@ -1,6 +1,31 @@
 namespace OfficeIMO.Pdf;
 
 internal static partial class PdfSyntax {
+    private const int MaximumXrefObjectCharacters = 1_000_000;
+    private const int MaximumXrefObjectScanMultiplier = 16;
+
+    private sealed class XrefObjectScanBudget {
+        private readonly long _maximum;
+        private long _used;
+
+        internal XrefObjectScanBudget(PdfReadLimits limits) {
+            MaximumPerObject = Math.Min(MaximumXrefObjectCharacters, limits.MaxObjectCharacters);
+            _maximum = Math.Min(
+                limits.MaxInputBytes,
+                checked((long)MaximumPerObject * MaximumXrefObjectScanMultiplier));
+        }
+
+        internal int MaximumPerObject { get; }
+
+        internal void Charge(long characters) {
+            if (characters <= 0) return;
+            _used = checked(_used + characters);
+            if (_used > _maximum) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.ObjectCharacters, _maximum, _used);
+            }
+        }
+    }
+
     private static void ResolveIndirectStreamLengths(
         Dictionary<int, PdfIndirectObject> map,
         byte[] pdf,
@@ -40,6 +65,7 @@ internal static partial class PdfSyntax {
         Dictionary<int, int> parsedOffsets,
         HashSet<int> activeObjectNumbers,
         PdfReadLimits limits,
+        XrefObjectScanBudget scanBudget,
         out bool appliedClassicEntries) {
         appliedClassicEntries = false;
         string text = PdfEncoding.Latin1GetString(pdf);
@@ -54,10 +80,11 @@ internal static partial class PdfSyntax {
 
         appliedClassicEntries = true;
         bool appliedXrefStream = false;
+        var parsedObjectsByOffset = new Dictionary<int, PdfIndirectObject?>();
         foreach (var table in tables) {
-            ApplyClassicXrefTableEntries(map, pdf, parsedOffsets, text, table.Entries, activeObjectNumbers);
+            ApplyClassicXrefTableEntries(map, pdf, parsedOffsets, text, table.Entries, scanBudget, activeObjectNumbers, parsedObjectsByOffset);
             if (table.XrefStreamOffset.HasValue) {
-                appliedXrefStream = ApplyXrefStreamAtOffset(map, pdf, parsedOffsets, text, table.XrefStreamOffset.Value, limits) || appliedXrefStream;
+                appliedXrefStream = ApplyXrefStreamAtOffset(map, pdf, parsedOffsets, text, table.XrefStreamOffset.Value, limits, scanBudget) || appliedXrefStream;
             }
         }
 
@@ -70,7 +97,10 @@ internal static partial class PdfSyntax {
         Dictionary<int, int> parsedOffsets,
         string text,
         List<(int ObjectNumber, int Offset, int Generation, bool InUse)> entries,
-        HashSet<int>? activeObjectNumbers = null) {
+        XrefObjectScanBudget scanBudget,
+        HashSet<int>? activeObjectNumbers = null,
+        Dictionary<int, PdfIndirectObject?>? parsedObjectsByOffset = null) {
+        parsedObjectsByOffset ??= new Dictionary<int, PdfIndirectObject?>();
         foreach (var entry in entries) {
             if (!entry.InUse) {
                 if (entry.ObjectNumber != 0) {
@@ -87,7 +117,14 @@ internal static partial class PdfSyntax {
                 continue;
             }
 
-            if (TryParseIndirectObjectAt(pdf, text, entry.Offset, map, out var parsed) &&
+            if (!parsedObjectsByOffset.TryGetValue(entry.Offset, out PdfIndirectObject? parsed)) {
+                parsed = TryParseIndirectObjectAt(pdf, text, entry.Offset, map, scanBudget, out PdfIndirectObject candidate)
+                    ? candidate
+                    : null;
+                parsedObjectsByOffset[entry.Offset] = parsed;
+            }
+
+            if (parsed is not null &&
                 parsed.ObjectNumber == entry.ObjectNumber &&
                 parsed.Generation == entry.Generation) {
                 map[entry.ObjectNumber] = parsed;
@@ -208,7 +245,7 @@ internal static partial class PdfSyntax {
         return value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
     }
 
-    private static bool ApplyXrefStreamEntries(Dictionary<int, PdfIndirectObject> map, byte[] pdf, Dictionary<int, int> parsedOffsets, PdfReadLimits limits) {
+    private static bool ApplyXrefStreamEntries(Dictionary<int, PdfIndirectObject> map, byte[] pdf, Dictionary<int, int> parsedOffsets, PdfReadLimits limits, XrefObjectScanBudget scanBudget) {
         var xrefStreams = new List<(int ObjectNumber, int Offset, PdfStream Stream)>();
         foreach (var entry in map.Values) {
             if (entry.Value is PdfStream stream &&
@@ -234,16 +271,17 @@ internal static partial class PdfSyntax {
         }
 
         var classicPredecessors = GetClassicPredecessorTablesForXrefStreamChain(text, xrefStreams, activeXrefOffset);
+        var parsedObjectsByOffset = new Dictionary<int, PdfIndirectObject?>();
         foreach (var table in classicPredecessors) {
-            ApplyClassicXrefTableEntries(map, pdf, parsedOffsets, text, table.Entries);
+            ApplyClassicXrefTableEntries(map, pdf, parsedOffsets, text, table.Entries, scanBudget, parsedObjectsByOffset: parsedObjectsByOffset);
             if (table.XrefStreamOffset.HasValue) {
-                ApplyXrefStreamAtOffset(map, pdf, parsedOffsets, text, table.XrefStreamOffset.Value, limits);
+                ApplyXrefStreamAtOffset(map, pdf, parsedOffsets, text, table.XrefStreamOffset.Value, limits, scanBudget);
             }
         }
 
         foreach (int chainOffset in activeChainOffsets) {
             var xrefStream = xrefStreams.First(item => item.Offset == chainOffset);
-            ApplyXrefStreamObjectEntries(map, pdf, parsedOffsets, text, xrefStream.Stream, limits);
+            ApplyXrefStreamObjectEntries(map, pdf, parsedOffsets, text, xrefStream.Stream, limits, scanBudget);
         }
 
         return true;
@@ -338,7 +376,8 @@ internal static partial class PdfSyntax {
         Dictionary<int, int> parsedOffsets,
         string text,
         int xrefStreamOffset,
-        PdfReadLimits limits) {
+        PdfReadLimits limits,
+        XrefObjectScanBudget scanBudget) {
         PdfStream? targetStream = null;
         foreach (var entry in map.Values) {
             if (!parsedOffsets.TryGetValue(entry.ObjectNumber, out int offset) ||
@@ -356,7 +395,7 @@ internal static partial class PdfSyntax {
             return false;
         }
 
-        ApplyXrefStreamObjectEntries(map, pdf, parsedOffsets, text, targetStream, limits);
+        ApplyXrefStreamObjectEntries(map, pdf, parsedOffsets, text, targetStream, limits, scanBudget);
         return true;
     }
 
@@ -366,9 +405,11 @@ internal static partial class PdfSyntax {
         Dictionary<int, int> parsedOffsets,
         string text,
         PdfStream xrefStream,
-        PdfReadLimits limits) {
+        PdfReadLimits limits,
+        XrefObjectScanBudget scanBudget) {
         byte[] data = Filters.StreamDecoder.Decode(xrefStream.Dictionary, xrefStream.Data, map, limits.MaxDecodedStreamBytes);
         var entries = ReadXrefStreamEntries(xrefStream.Dictionary, data).ToList();
+        var parsedObjectsByOffset = new Dictionary<int, PdfIndirectObject?>();
         foreach (var entry in entries) {
             if (entry.Type == 0 &&
                 entry.ObjectNumber != 0) {
@@ -388,7 +429,14 @@ internal static partial class PdfSyntax {
 
             int offset = (int)entry.Field1;
             int generation = (int)entry.Field2;
-            if (TryParseIndirectObjectAt(pdf, text, offset, map, out var parsed) &&
+            if (!parsedObjectsByOffset.TryGetValue(offset, out PdfIndirectObject? parsed)) {
+                parsed = TryParseIndirectObjectAt(pdf, text, offset, map, scanBudget, out PdfIndirectObject candidate)
+                    ? candidate
+                    : null;
+                parsedObjectsByOffset[offset] = parsed;
+            }
+
+            if (parsed is not null &&
                 parsed.ObjectNumber == entry.ObjectNumber &&
                 parsed.Generation == generation) {
                 map[entry.ObjectNumber] = parsed;
@@ -571,13 +619,23 @@ internal static partial class PdfSyntax {
         return value;
     }
 
-    private static bool TryParseIndirectObjectAt(byte[] pdf, string text, int offset, Dictionary<int, PdfIndirectObject> map, out PdfIndirectObject parsed) {
+    private static bool TryParseIndirectObjectAt(byte[] pdf, string text, int offset, Dictionary<int, PdfIndirectObject> map, XrefObjectScanBudget scanBudget, out PdfIndirectObject parsed) {
         parsed = null!;
         if (offset < 0 || offset >= text.Length) {
             return false;
         }
 
-        if (!TryReadIndirectObjectHeaderAt(text, offset, text.Length, out IndirectObjectHeader header)) {
+        int scanLimit = (int)Math.Min(
+            (long)text.Length,
+            (long)offset + scanBudget.MaximumPerObject);
+        int chargedThrough = offset;
+        void ChargeThrough(int scannedThrough) {
+            int bounded = Math.Max(offset, Math.Min(scanLimit, scannedThrough));
+            scanBudget.Charge(bounded - chargedThrough);
+            chargedThrough = Math.Max(chargedThrough, bounded);
+        }
+        if (!TryReadIndirectObjectHeaderAt(text, offset, scanLimit, out IndirectObjectHeader header)) {
+            ChargeThrough(Math.Min(scanLimit, offset + 128));
             return false;
         }
 
@@ -586,13 +644,14 @@ internal static partial class PdfSyntax {
         int start = header.Index;
         int bodyStart = header.Index + header.Length;
         int valueStart = bodyStart;
-        while (valueStart < text.Length && char.IsWhiteSpace(text[valueStart])) {
+        while (valueStart < scanLimit && char.IsWhiteSpace(text[valueStart])) {
             valueStart++;
         }
 
-        if (valueStart + 1 < text.Length && text[valueStart] == '<' && text[valueStart + 1] == '<') {
+        if (valueStart + 1 < scanLimit && text[valueStart] == '<' && text[valueStart + 1] == '<') {
             int dictStart = valueStart;
-            int dictEnd = FindDictEnd(text, dictStart, text.Length);
+            int dictEnd = FindDictEnd(text, dictStart, scanLimit);
+            ChargeThrough(dictEnd > dictStart ? dictEnd + 2 : scanLimit);
             if (dictEnd > dictStart) {
                 string dictText = SafeSlice(text, dictStart + 2, dictEnd - (dictStart + 2), 1_000_000);
                 PdfDictionary? dict;
@@ -603,19 +662,20 @@ internal static partial class PdfSyntax {
                 }
 
                 int streamKw = dictEnd;
-                while (streamKw < text.Length && char.IsWhiteSpace(text[streamKw])) {
+                while (streamKw < scanLimit && char.IsWhiteSpace(text[streamKw])) {
                     streamKw++;
                 }
 
-                bool hasStream = streamKw + 6 <= text.Length &&
+                bool hasStream = streamKw + 6 <= scanLimit &&
                     string.CompareOrdinal(text, streamKw, "stream", 0, 6) == 0 &&
-                    HasKeywordBoundary(text, streamKw + 6, bodyStart, text.Length);
+                    HasKeywordBoundary(text, streamKw + 6, bodyStart, scanLimit);
                 if (hasStream) {
-                    int dataStart = SkipEOL(text, streamKw + 6, text.Length);
+                    int dataStart = SkipEOL(text, streamKw + 6, scanLimit);
                     int byteLen = -1;
                     TryGetResolvedLength(dict, map, out byteLen);
                     if (byteLen < 0) {
-                        int fallbackEnd = FindObjectEnd(text, start);
+                        int fallbackEnd = FindObjectEnd(text, start, maximumIndex: scanLimit);
+                        ChargeThrough(fallbackEnd > start ? fallbackEnd : scanLimit);
                         if (fallbackEnd < 0) {
                             return false;
                         }
@@ -637,7 +697,8 @@ internal static partial class PdfSyntax {
             }
         }
 
-        int end = FindObjectEnd(text, start);
+        int end = FindObjectEnd(text, start, maximumIndex: scanLimit);
+        ChargeThrough(end > start ? end : scanLimit);
         if (end < 0) {
             return false;
         }

--- a/OfficeIMO.Pdf/Reading/Core/PdfSyntax.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfSyntax.cs
@@ -194,8 +194,9 @@ internal static partial class PdfSyntax {
         ValidateActiveCrossReference(text, map, parsedOffsets, parsingMode, repairDiagnostics);
         ResolveIndirectStreamLengths(map, pdf, streamLocations, limits);
         var activeClassicObjectNumbers = new HashSet<int>();
-        bool appliedXrefStreamEntries = ApplyClassicXrefEntries(map, pdf, parsedOffsets, activeClassicObjectNumbers, limits, out bool appliedClassicEntries);
-        appliedXrefStreamEntries = ApplyXrefStreamEntries(map, pdf, parsedOffsets, limits) || appliedXrefStreamEntries;
+        var xrefScanBudget = new XrefObjectScanBudget(limits);
+        bool appliedXrefStreamEntries = ApplyClassicXrefEntries(map, pdf, parsedOffsets, activeClassicObjectNumbers, limits, xrefScanBudget, out bool appliedClassicEntries);
+        appliedXrefStreamEntries = ApplyXrefStreamEntries(map, pdf, parsedOffsets, limits, xrefScanBudget) || appliedXrefStreamEntries;
         string trailerRaw = GetActiveTrailerRaw(text, map, parsedOffsets);
         if (trailerRaw.IndexOf("/Prev", StringComparison.Ordinal) < 0) {
             foreach (KeyValuePair<(int Id, int Generation), int> definition in definitionCounts) {

--- a/OfficeIMO.Pdf/Reading/Interaction/PdfPageInteractionMap.cs
+++ b/OfficeIMO.Pdf/Reading/Interaction/PdfPageInteractionMap.cs
@@ -122,7 +122,6 @@ public sealed class PdfPageInteractionMap {
         List<PdfPageInteractionRegion> regions) {
         IReadOnlyList<PdfTextSpan> spans = page.GetInteractionTextSpans();
         int textIndex = 0;
-        int processedTextElements = 0;
         for (int spanIndex = 0; spanIndex < spans.Count; spanIndex++) {
             PdfTextSpan span = spans[spanIndex];
             if (string.IsNullOrEmpty(span.Text) || (!span.IsVisible && !options.IncludeInvisibleText)) {
@@ -133,10 +132,6 @@ public sealed class PdfPageInteractionMap {
             int elementCount = 0;
             while (enumerator.MoveNext()) {
                 elementCount++;
-                processedTextElements++;
-                if (processedTextElements > options.MaxTextRegions) {
-                    throw PdfReadLimitException.Create(PdfReadLimitKind.InteractionRegions, options.MaxTextRegions, processedTextElements);
-                }
             }
 
             if (elementCount == 0) {
@@ -168,6 +163,9 @@ public sealed class PdfPageInteractionMap {
                     normalX, normalY, ascent, descent, pageHeight);
                 if (!quad.Intersects(0D, 0D, pageWidth, pageHeight)) {
                     continue;
+                }
+                if (textIndex >= options.MaxTextRegions) {
+                    throw PdfReadLimitException.Create(PdfReadLimitKind.InteractionRegions, options.MaxTextRegions, textIndex + 1L);
                 }
                 regions.Add(new PdfPageInteractionRegion(
                     PdfInteractionKind.Text,

--- a/OfficeIMO.Pdf/Reading/Interaction/PdfPageInteractionMap.cs
+++ b/OfficeIMO.Pdf/Reading/Interaction/PdfPageInteractionMap.cs
@@ -122,24 +122,29 @@ public sealed class PdfPageInteractionMap {
         List<PdfPageInteractionRegion> regions) {
         IReadOnlyList<PdfTextSpan> spans = page.GetInteractionTextSpans();
         int textIndex = 0;
+        int processedTextElements = 0;
         for (int spanIndex = 0; spanIndex < spans.Count; spanIndex++) {
             PdfTextSpan span = spans[spanIndex];
             if (string.IsNullOrEmpty(span.Text) || (!span.IsVisible && !options.IncludeInvisibleText)) {
                 continue;
             }
 
-            var elements = new List<string>();
             TextElementEnumerator enumerator = StringInfo.GetTextElementEnumerator(span.Text);
+            int elementCount = 0;
             while (enumerator.MoveNext()) {
-                elements.Add((string)enumerator.Current!);
+                elementCount++;
+                processedTextElements++;
+                if (processedTextElements > options.MaxTextRegions) {
+                    throw PdfReadLimitException.Create(PdfReadLimitKind.InteractionRegions, options.MaxTextRegions, processedTextElements);
+                }
             }
 
-            if (elements.Count == 0) {
+            if (elementCount == 0) {
                 continue;
             }
 
-            double totalAdvance = Math.Max(Math.Abs(span.Advance), elements.Count * Math.Max(1D, span.FontSize * 0.5D));
-            double elementAdvance = totalAdvance / elements.Count;
+            double totalAdvance = Math.Max(Math.Abs(span.Advance), elementCount * Math.Max(1D, span.FontSize * 0.5D));
+            double elementAdvance = totalAdvance / elementCount;
             double radians = span.RotationDegrees * Math.PI / 180D;
             double directionX = Math.Cos(radians);
             double directionY = Math.Sin(radians);
@@ -147,13 +152,13 @@ public sealed class PdfPageInteractionMap {
             double normalY = directionX;
             double ascent = Math.Max(1D, span.FontSize);
             double descent = Math.Max(0.5D, span.FontSize * 0.2D);
-            for (int elementIndex = 0; elementIndex < elements.Count; elementIndex++) {
-                if (textIndex >= options.MaxTextRegions) {
-                    throw PdfReadLimitException.Create(PdfReadLimitKind.InteractionRegions, options.MaxTextRegions, textIndex + 1L);
-                }
-
-                double startAdvance = elementIndex * elementAdvance;
-                double endAdvance = (elementIndex + 1) * elementAdvance;
+            enumerator = StringInfo.GetTextElementEnumerator(span.Text);
+            int elementIndex = 0;
+            while (enumerator.MoveNext()) {
+                string element = (string)enumerator.Current!;
+                int currentElementIndex = elementIndex++;
+                double startAdvance = currentElementIndex * elementAdvance;
+                double endAdvance = (currentElementIndex + 1) * elementAdvance;
                 double startX = span.X + directionX * startAdvance;
                 double startY = span.Y + directionY * startAdvance;
                 double endX = span.X + directionX * endAdvance;
@@ -167,7 +172,7 @@ public sealed class PdfPageInteractionMap {
                 regions.Add(new PdfPageInteractionRegion(
                     PdfInteractionKind.Text,
                     quad,
-                    text: elements[elementIndex],
+                    text: element,
                     textIndex: textIndex));
                 textIndex++;
             }

--- a/OfficeIMO.Pdf/Reading/Logical/PdfLogicalDocument.cs
+++ b/OfficeIMO.Pdf/Reading/Logical/PdfLogicalDocument.cs
@@ -942,7 +942,7 @@ public sealed partial class PdfLogicalDocument {
         return FromPageNumbers(document, options, pageNumbers);
     }
 
-    private static PdfLogicalDocument FromPageNumbers(PdfReadDocument document, PdfTextLayoutOptions? options, int[] pageNumbers) {
+    internal static PdfLogicalDocument FromPageNumbers(PdfReadDocument document, PdfTextLayoutOptions? options, int[] pageNumbers) {
         document.DemandContentExtraction("logical object");
         bool useDocumentWideObjects = PdfPageRangeObjectFilter.ShouldUseDocumentWideObjects(document.Pages.Count, pageNumbers);
         IReadOnlyList<PdfFormField> formFields = useDocumentWideObjects

--- a/OfficeIMO.Pdf/Reading/Ocr/PdfOcr.cs
+++ b/OfficeIMO.Pdf/Reading/Ocr/PdfOcr.cs
@@ -23,7 +23,7 @@ internal static class PdfOcr {
         if (selectedPages.Length > effectiveOptions.MaxPages) {
             throw PdfReadLimitException.Create(PdfReadLimitKind.Pages, effectiveOptions.MaxPages, selectedPages.Length);
         }
-        PdfLogicalDocument logical = PdfLogicalDocument.FromPageNumbers(readDocument, null, selectedPages);
+        PdfLogicalDocument logical = PdfLogicalDocument.From(readDocument);
         var renderOptions = new PdfPageRenderOptions {
             Format = PdfPageRenderFormat.Png,
             Dpi = effectiveOptions.Dpi,

--- a/OfficeIMO.Pdf/Reading/Ocr/PdfOcr.cs
+++ b/OfficeIMO.Pdf/Reading/Ocr/PdfOcr.cs
@@ -41,19 +41,21 @@ internal static class PdfOcr {
             var request = new PdfOcrRequest(render.PageNumber, render.Bytes!, render.Width, render.Height, nativePage.Width, nativePage.Height, scale);
             PdfOcrResponse response = await provider.RecognizeAsync(request, cancellationToken).ConfigureAwait(false)
                 ?? throw new InvalidOperationException("OCR provider returned a null response.");
-            pages.Add(MergePage(nativePage, response, request, effectiveOptions));
+            pages.Add(MergePage(nativePage, response, request, effectiveOptions, cancellationToken));
         }
 
         return new PdfOcrMergeResult(logical, pages.AsReadOnly());
     }
 
-    private static PdfOcrPageMergeResult MergePage(PdfLogicalPage nativePage, PdfOcrResponse response, PdfOcrRequest request, PdfOcrMergeOptions options) {
+    private static PdfOcrPageMergeResult MergePage(PdfLogicalPage nativePage, PdfOcrResponse response, PdfOcrRequest request, PdfOcrMergeOptions options, CancellationToken cancellationToken) {
         ValidateProviderResponse(nativePage, response, options);
         var diagnostics = new List<string>(response.Diagnostics);
         var accepted = new List<PdfRecognizedWord>();
         int lowConfidence = 0;
         int nativeOverlap = 0;
+        long overlapComparisons = 0;
         for (int i = 0; i < response.Words.Count; i++) {
+            cancellationToken.ThrowIfCancellationRequested();
             PdfOcrWord word = response.Words[i];
             if (!IsValid(word, request)) {
                 diagnostics.Add("InvalidWordGeometry: provider word " + i + " was outside the rendered page or contained non-finite values.");
@@ -66,7 +68,14 @@ internal static class PdfOcr {
             }
 
             var normalized = new PdfRecognizedWord(word.Text, word.X / request.Scale, word.Y / request.Scale, word.Width / request.Scale, word.Height / request.Scale, word.Confidence);
-            if (OverlapsNativeText(normalized, nativePage.TextBlocks, nativePage.Height, options.NativeTextOverlapThreshold)) {
+            if (OverlapsNativeText(
+                    normalized,
+                    nativePage.TextBlocks,
+                    nativePage.Height,
+                    options.NativeTextOverlapThreshold,
+                    options.MaxNativeTextOverlapComparisonsPerPage,
+                    ref overlapComparisons,
+                    cancellationToken)) {
                 nativeOverlap++;
                 continue;
             }
@@ -87,9 +96,21 @@ internal static class PdfOcr {
         word.X >= 0D && word.Y >= 0D && word.Width > 0D && word.Height > 0D && word.Confidence >= 0D && word.Confidence <= 1D &&
         word.X + word.Width <= request.PixelWidth + 0.01D && word.Y + word.Height <= request.PixelHeight + 0.01D;
 
-    private static bool OverlapsNativeText(PdfRecognizedWord word, IReadOnlyList<PdfLogicalTextBlock> blocks, double pageHeight, double threshold) {
+    private static bool OverlapsNativeText(
+        PdfRecognizedWord word,
+        IReadOnlyList<PdfLogicalTextBlock> blocks,
+        double pageHeight,
+        double threshold,
+        long maximumComparisons,
+        ref long comparisons,
+        CancellationToken cancellationToken) {
         double wordArea = word.Width * word.Height;
         for (int i = 0; i < blocks.Count; i++) {
+            comparisons = checked(comparisons + 1L);
+            if (comparisons > maximumComparisons) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.OcrArtifacts, maximumComparisons, comparisons);
+            }
+            if ((i & 255) == 0) cancellationToken.ThrowIfCancellationRequested();
             PdfLogicalTextBlock block = blocks[i];
             double blockHeight = Math.Max(block.FontSize * 1.2D, 1D);
             double blockTop = pageHeight - block.BaselineY - blockHeight;

--- a/OfficeIMO.Pdf/Reading/Ocr/PdfOcr.cs
+++ b/OfficeIMO.Pdf/Reading/Ocr/PdfOcr.cs
@@ -17,7 +17,13 @@ internal static class PdfOcr {
         PdfOcrMergeOptions effectiveOptions = options ?? new PdfOcrMergeOptions();
         effectiveOptions.Validate();
         PdfReadDocument readDocument = PdfReadDocument.Open(pdf, readOptions);
-        PdfLogicalDocument logical = PdfLogicalDocument.From(readDocument);
+        int[] selectedPages = effectiveOptions.Selection?.ToPageNumbers(
+            readDocument.Pages.Count,
+            nameof(effectiveOptions.Selection)) ?? Enumerable.Range(1, readDocument.Pages.Count).ToArray();
+        if (selectedPages.Length > effectiveOptions.MaxPages) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.Pages, effectiveOptions.MaxPages, selectedPages.Length);
+        }
+        PdfLogicalDocument logical = PdfLogicalDocument.FromPageNumbers(readDocument, null, selectedPages);
         var renderOptions = new PdfPageRenderOptions {
             Format = PdfPageRenderFormat.Png,
             Dpi = effectiveOptions.Dpi,
@@ -42,6 +48,7 @@ internal static class PdfOcr {
     }
 
     private static PdfOcrPageMergeResult MergePage(PdfLogicalPage nativePage, PdfOcrResponse response, PdfOcrRequest request, PdfOcrMergeOptions options) {
+        ValidateProviderResponse(nativePage, response, options);
         var diagnostics = new List<string>(response.Diagnostics);
         var accepted = new List<PdfRecognizedWord>();
         int lowConfidence = 0;
@@ -71,7 +78,7 @@ internal static class PdfOcr {
             int y = left.Y.CompareTo(right.Y);
             return y != 0 ? y : left.X.CompareTo(right.X);
         });
-        string text = BuildMergedText(nativePage, accepted);
+        string text = BuildMergedText(nativePage, accepted, options.MaxMergedTextCharactersPerPage);
         return new PdfOcrPageMergeResult(nativePage.PageNumber, accepted.AsReadOnly(), lowConfidence, nativeOverlap, diagnostics.AsReadOnly(), text);
     }
 
@@ -94,7 +101,7 @@ internal static class PdfOcr {
         return false;
     }
 
-    private static string BuildMergedText(PdfLogicalPage page, List<PdfRecognizedWord> words) {
+    private static string BuildMergedText(PdfLogicalPage page, List<PdfRecognizedWord> words, int maximumCharacters) {
         var items = new List<(double Y, double X, string Text)>(page.TextBlocks.Count + words.Count);
         for (int i = 0; i < page.TextBlocks.Count; i++) {
             PdfLogicalTextBlock block = page.TextBlocks[i];
@@ -102,7 +109,39 @@ internal static class PdfOcr {
         }
 
         for (int i = 0; i < words.Count; i++) items.Add((words[i].Y, words[i].X, words[i].Text));
-        return string.Join(Environment.NewLine, items.OrderBy(static item => item.Y).ThenBy(static item => item.X).Select(static item => item.Text));
+        var builder = new System.Text.StringBuilder(Math.Min(maximumCharacters, 4096));
+        foreach ((double _, double _, string text) in items.OrderBy(static item => item.Y).ThenBy(static item => item.X)) {
+            int separatorLength = builder.Length == 0 ? 0 : Environment.NewLine.Length;
+            long projected = (long)builder.Length + separatorLength + text.Length;
+            if (projected > maximumCharacters) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.OcrArtifacts, maximumCharacters, projected);
+            }
+            if (separatorLength > 0) builder.AppendLine();
+            builder.Append(text);
+        }
+        return builder.ToString();
+    }
+
+    private static void ValidateProviderResponse(PdfLogicalPage nativePage, PdfOcrResponse response, PdfOcrMergeOptions options) {
+        if (response.Words.Count > options.MaxOcrWordsPerPage) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.OcrArtifacts, options.MaxOcrWordsPerPage, response.Words.Count);
+        }
+        if (response.Diagnostics.Count > options.MaxDiagnosticsPerPage) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.OcrArtifacts, options.MaxDiagnosticsPerPage, response.Diagnostics.Count);
+        }
+        if (nativePage.TextBlocks.Count > options.MaxNativeTextBlocksPerPage) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.OcrArtifacts, options.MaxNativeTextBlocksPerPage, nativePage.TextBlocks.Count);
+        }
+        EnsureCharacters(response.Words.Select(static word => word.Text), options.MaxOcrTextCharactersPerPage);
+        EnsureCharacters(response.Diagnostics, options.MaxDiagnosticCharactersPerPage);
+    }
+
+    private static void EnsureCharacters(IEnumerable<string> values, int maximum) {
+        long total = 0;
+        foreach (string value in values) {
+            total = checked(total + value.Length);
+            if (total > maximum) throw PdfReadLimitException.Create(PdfReadLimitKind.OcrArtifacts, maximum, total);
+        }
     }
 
     private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);

--- a/OfficeIMO.Pdf/Reading/Ocr/PdfOcrContracts.cs
+++ b/OfficeIMO.Pdf/Reading/Ocr/PdfOcrContracts.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -34,16 +35,53 @@ public sealed class PdfOcrRequest {
 
 /// <summary>OCR provider response for one page.</summary>
 public sealed class PdfOcrResponse {
+    private const int AbsoluteMaximumWords = 1_000_000;
+    private const int AbsoluteMaximumDiagnostics = 100_000;
+    private const int AbsoluteMaximumTextCharacters = 16 * 1024 * 1024;
     /// <summary>Creates a provider response.</summary>
     public PdfOcrResponse(IEnumerable<PdfOcrWord> words, IEnumerable<string>? diagnostics = null) {
         Guard.NotNull(words as object, nameof(words));
-        Words = words.ToArray();
-        Diagnostics = diagnostics?.ToArray() ?? Array.Empty<string>();
+        Words = MaterializeWords(words);
+        Diagnostics = MaterializeDiagnostics(diagnostics);
     }
     /// <summary>Recognized words in pixel coordinates from the top-left.</summary>
     public IReadOnlyList<PdfOcrWord> Words { get; }
     /// <summary>Provider diagnostics retained in the merge report.</summary>
     public IReadOnlyList<string> Diagnostics { get; }
+
+    private static ReadOnlyCollection<PdfOcrWord> MaterializeWords(IEnumerable<PdfOcrWord> words) {
+        var result = new List<PdfOcrWord>();
+        long characters = 0;
+        foreach (PdfOcrWord word in words) {
+            if (word == null) throw new ArgumentException("OCR words cannot contain null entries.", nameof(words));
+            if (result.Count >= AbsoluteMaximumWords) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.OcrArtifacts, AbsoluteMaximumWords, result.Count + 1L);
+            }
+            characters = checked(characters + word.Text.Length);
+            if (characters > AbsoluteMaximumTextCharacters) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.OcrArtifacts, AbsoluteMaximumTextCharacters, characters);
+            }
+            result.Add(word);
+        }
+        return result.AsReadOnly();
+    }
+
+    private static IReadOnlyList<string> MaterializeDiagnostics(IEnumerable<string>? diagnostics) {
+        if (diagnostics == null) return Array.Empty<string>();
+        var result = new List<string>();
+        long characters = 0;
+        foreach (string diagnostic in diagnostics) {
+            if (result.Count >= AbsoluteMaximumDiagnostics) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.OcrArtifacts, AbsoluteMaximumDiagnostics, result.Count + 1L);
+            }
+            characters = checked(characters + (diagnostic?.Length ?? 0));
+            if (characters > AbsoluteMaximumTextCharacters) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.OcrArtifacts, AbsoluteMaximumTextCharacters, characters);
+            }
+            result.Add(diagnostic ?? string.Empty);
+        }
+        return result.AsReadOnly();
+    }
 }
 
 /// <summary>One OCR word in rendered pixel coordinates.</summary>

--- a/OfficeIMO.Pdf/Reading/Ocr/PdfOcrMergeOptions.cs
+++ b/OfficeIMO.Pdf/Reading/Ocr/PdfOcrMergeOptions.cs
@@ -14,6 +14,18 @@ public sealed class PdfOcrMergeOptions {
     public int MaxPages { get; set; } = 100;
     /// <summary>Maximum pixels rendered per page.</summary>
     public long MaxPixelsPerPage { get; set; } = 100_000_000L;
+    /// <summary>Maximum OCR words accepted from the provider for one page.</summary>
+    public int MaxOcrWordsPerPage { get; set; } = 50_000;
+    /// <summary>Maximum aggregate OCR word characters accepted for one page.</summary>
+    public int MaxOcrTextCharactersPerPage { get; set; } = 4 * 1024 * 1024;
+    /// <summary>Maximum provider diagnostics accepted for one page.</summary>
+    public int MaxDiagnosticsPerPage { get; set; } = 1_000;
+    /// <summary>Maximum aggregate provider diagnostic characters accepted for one page.</summary>
+    public int MaxDiagnosticCharactersPerPage { get; set; } = 1 * 1024 * 1024;
+    /// <summary>Maximum native text blocks merged with OCR output for one page.</summary>
+    public int MaxNativeTextBlocksPerPage { get; set; } = 100_000;
+    /// <summary>Maximum characters retained in one merged native/OCR text result.</summary>
+    public int MaxMergedTextCharactersPerPage { get; set; } = 8 * 1024 * 1024;
 
     internal void Validate() {
         Guard.Positive(Dpi, nameof(Dpi));
@@ -21,6 +33,12 @@ public sealed class PdfOcrMergeOptions {
         ValidateRatio(NativeTextOverlapThreshold, nameof(NativeTextOverlapThreshold));
         Guard.PositiveInteger(MaxPages, nameof(MaxPages));
         if (MaxPixelsPerPage <= 0) throw new ArgumentOutOfRangeException(nameof(MaxPixelsPerPage));
+        Guard.PositiveInteger(MaxOcrWordsPerPage, nameof(MaxOcrWordsPerPage));
+        Guard.PositiveInteger(MaxOcrTextCharactersPerPage, nameof(MaxOcrTextCharactersPerPage));
+        Guard.PositiveInteger(MaxDiagnosticsPerPage, nameof(MaxDiagnosticsPerPage));
+        Guard.PositiveInteger(MaxDiagnosticCharactersPerPage, nameof(MaxDiagnosticCharactersPerPage));
+        Guard.PositiveInteger(MaxNativeTextBlocksPerPage, nameof(MaxNativeTextBlocksPerPage));
+        Guard.PositiveInteger(MaxMergedTextCharactersPerPage, nameof(MaxMergedTextCharactersPerPage));
     }
 
     private static void ValidateRatio(double value, string name) {

--- a/OfficeIMO.Pdf/Reading/Ocr/PdfOcrMergeOptions.cs
+++ b/OfficeIMO.Pdf/Reading/Ocr/PdfOcrMergeOptions.cs
@@ -24,6 +24,8 @@ public sealed class PdfOcrMergeOptions {
     public int MaxDiagnosticCharactersPerPage { get; set; } = 1 * 1024 * 1024;
     /// <summary>Maximum native text blocks merged with OCR output for one page.</summary>
     public int MaxNativeTextBlocksPerPage { get; set; } = 100_000;
+    /// <summary>Maximum native-text overlap comparisons performed for one page.</summary>
+    public long MaxNativeTextOverlapComparisonsPerPage { get; set; } = 5_000_000L;
     /// <summary>Maximum characters retained in one merged native/OCR text result.</summary>
     public int MaxMergedTextCharactersPerPage { get; set; } = 8 * 1024 * 1024;
 
@@ -38,6 +40,7 @@ public sealed class PdfOcrMergeOptions {
         Guard.PositiveInteger(MaxDiagnosticsPerPage, nameof(MaxDiagnosticsPerPage));
         Guard.PositiveInteger(MaxDiagnosticCharactersPerPage, nameof(MaxDiagnosticCharactersPerPage));
         Guard.PositiveInteger(MaxNativeTextBlocksPerPage, nameof(MaxNativeTextBlocksPerPage));
+        if (MaxNativeTextOverlapComparisonsPerPage <= 0) throw new ArgumentOutOfRangeException(nameof(MaxNativeTextOverlapComparisonsPerPage));
         Guard.PositiveInteger(MaxMergedTextCharactersPerPage, nameof(MaxMergedTextCharactersPerPage));
     }
 

--- a/OfficeIMO.Pdf/Reading/Options/PdfReadLimitKind.cs
+++ b/OfficeIMO.Pdf/Reading/Options/PdfReadLimitKind.cs
@@ -62,6 +62,15 @@ public enum PdfReadLimitKind {
     /// <summary>Output pixels requested for one managed rendered page.</summary>
     RenderPixels,
 
+    /// <summary>Rendered bytes retained by one managed render operation.</summary>
+    RenderBytes,
+
     /// <summary>Selectable text regions requested for one page interaction map.</summary>
-    InteractionRegions
+    InteractionRegions,
+
+    /// <summary>Intermediate artifacts produced by the PDF understanding pipeline.</summary>
+    UnderstandingArtifacts,
+
+    /// <summary>Words, text, or diagnostics returned by an OCR provider.</summary>
+    OcrArtifacts
 }

--- a/OfficeIMO.Pdf/Reading/Options/PdfReadLimitKind.cs
+++ b/OfficeIMO.Pdf/Reading/Options/PdfReadLimitKind.cs
@@ -3,74 +3,74 @@ namespace OfficeIMO.Pdf;
 /// <summary>Bounded PDF read resource whose configured limit was exceeded.</summary>
 public enum PdfReadLimitKind {
     /// <summary>Total PDF input byte count.</summary>
-    InputBytes,
+    InputBytes = 0,
 
     /// <summary>Indirect object declaration or resolved-object count.</summary>
-    IndirectObjects,
+    IndirectObjects = 1,
 
     /// <summary>Raw bytes in one PDF stream before decoding.</summary>
-    RawStreamBytes,
+    RawStreamBytes = 2,
 
     /// <summary>Bytes produced while decoding one filtered PDF stream.</summary>
-    DecodedStreamBytes,
+    DecodedStreamBytes = 3,
 
     /// <summary>Characters scanned for one object or dictionary.</summary>
-    ObjectCharacters,
+    ObjectCharacters = 4,
 
     /// <summary>Tokens produced for one object or dictionary.</summary>
-    ObjectTokens,
+    ObjectTokens = 5,
 
     /// <summary>Nested array/dictionary parsing depth.</summary>
-    ObjectNestingDepth,
+    ObjectNestingDepth = 6,
 
     /// <summary>Wall-clock time spent in the core object parsing pass.</summary>
-    ObjectParsingTime,
+    ObjectParsingTime = 7,
 
     /// <summary>Cross-reference revisions discovered in the input.</summary>
-    Revisions,
+    Revisions = 8,
 
     /// <summary>Page-tree dictionaries traversed while discovering pages.</summary>
-    PageTreeNodes,
+    PageTreeNodes = 9,
 
     /// <summary>Nested page-tree depth.</summary>
-    PageTreeDepth,
+    PageTreeDepth = 10,
 
     /// <summary>Pages discovered in the document.</summary>
-    Pages,
+    Pages = 11,
 
     /// <summary>AcroForm field-tree nodes or terminal fields.</summary>
-    FormFields,
+    FormFields = 12,
 
     /// <summary>Nested AcroForm field-tree depth.</summary>
-    FormFieldDepth,
+    FormFieldDepth = 13,
 
     /// <summary>Annotations declared on one page.</summary>
-    AnnotationsPerPage,
+    AnnotationsPerPage = 14,
 
     /// <summary>Operators parsed from one page or form content stream.</summary>
-    ContentOperations,
+    ContentOperations = 15,
 
     /// <summary>Operand values and dictionary keys parsed from one page or form content stream.</summary>
-    ContentOperands,
+    ContentOperands = 16,
 
     /// <summary>Nested lexical arrays/dictionaries or form XObjects traversed while parsing page content.</summary>
-    ContentNestingDepth,
+    ContentNestingDepth = 17,
 
     /// <summary>Pages requested in one managed render batch.</summary>
-    RenderPages,
+    RenderPages = 18,
 
     /// <summary>Output pixels requested for one managed rendered page.</summary>
-    RenderPixels,
-
-    /// <summary>Rendered bytes retained by one managed render operation.</summary>
-    RenderBytes,
+    RenderPixels = 19,
 
     /// <summary>Selectable text regions requested for one page interaction map.</summary>
-    InteractionRegions,
+    InteractionRegions = 20,
 
     /// <summary>Intermediate artifacts produced by the PDF understanding pipeline.</summary>
-    UnderstandingArtifacts,
+    UnderstandingArtifacts = 21,
 
     /// <summary>Words, text, or diagnostics returned by an OCR provider.</summary>
-    OcrArtifacts
+    OcrArtifacts = 22,
+
+    /// <summary>Rendered bytes retained by one managed render operation.</summary>
+    RenderBytes = 23
 }

--- a/OfficeIMO.Pdf/Reading/PdfAttachmentExtractor.cs
+++ b/OfficeIMO.Pdf/Reading/PdfAttachmentExtractor.cs
@@ -98,8 +98,69 @@ internal static class PdfAttachmentExtractor {
             ReadAssociatedFiles(objects, associatedFiles, attachments, effectiveLimits.MaxDecodedStreamBytes);
         }
 
+        ReadFileAttachmentAnnotations(objects, attachments, effectiveLimits.MaxDecodedStreamBytes);
+
         return attachments.Count == 0 ? Array.Empty<PdfExtractedAttachment>() : attachments.AsReadOnly();
     }
+
+    private static void ReadFileAttachmentAnnotations(
+        Dictionary<int, PdfIndirectObject> objects,
+        List<PdfExtractedAttachment> attachments,
+        int maximumDecodedStreamBytes) {
+        var visited = new HashSet<PdfObject>();
+        foreach (PdfIndirectObject indirect in objects.Values) {
+            ReadFileAttachmentAnnotations(objects, indirect.Value, attachments, visited, maximumDecodedStreamBytes);
+        }
+    }
+
+    private static void ReadFileAttachmentAnnotations(
+        Dictionary<int, PdfIndirectObject> objects,
+        PdfObject value,
+        List<PdfExtractedAttachment> attachments,
+        ISet<PdfObject> visited,
+        int maximumDecodedStreamBytes) {
+        if (!visited.Add(value)) return;
+        if (value is PdfStream stream) {
+            ReadFileAttachmentAnnotations(objects, stream.Dictionary, attachments, visited, maximumDecodedStreamBytes);
+            return;
+        }
+        if (value is PdfDictionary dictionary) {
+            if (string.Equals(dictionary.Get<PdfName>("Subtype")?.Name, "FileAttachment", StringComparison.Ordinal) &&
+                dictionary.Items.TryGetValue("FS", out PdfObject? fileSpecObject)) {
+                string name = TryReadFileSpecName(objects, fileSpecObject) ?? "FileAttachment";
+                PdfExtractedAttachment? attachment = TryBuildAttachment(
+                    objects,
+                    name,
+                    fileSpecObject,
+                    "FileAttachment",
+                    maximumDecodedStreamBytes);
+                if (attachment != null && !ContainsAttachment(attachments, attachment)) {
+                    attachments.Add(attachment);
+                }
+            }
+
+            foreach (PdfObject child in dictionary.Items.Values) {
+                if (child is not PdfReference) {
+                    ReadFileAttachmentAnnotations(objects, child, attachments, visited, maximumDecodedStreamBytes);
+                }
+            }
+            return;
+        }
+        if (value is PdfArray array) {
+            foreach (PdfObject child in array.Items) {
+                if (child is not PdfReference) {
+                    ReadFileAttachmentAnnotations(objects, child, attachments, visited, maximumDecodedStreamBytes);
+                }
+            }
+        }
+    }
+
+    private static bool ContainsAttachment(
+        IEnumerable<PdfExtractedAttachment> attachments,
+        PdfExtractedAttachment candidate) =>
+        attachments.Any(attachment =>
+            candidate.FileSpecObjectNumber > 0 && attachment.FileSpecObjectNumber == candidate.FileSpecObjectNumber ||
+            candidate.EmbeddedFileObjectNumber > 0 && attachment.EmbeddedFileObjectNumber == candidate.EmbeddedFileObjectNumber);
 
     private static void ReadEmbeddedFilesNameTree(
         Dictionary<int, PdfIndirectObject> objects,

--- a/OfficeIMO.Pdf/Reading/Understanding/PdfUnderstandingContracts.cs
+++ b/OfficeIMO.Pdf/Reading/Understanding/PdfUnderstandingContracts.cs
@@ -24,13 +24,16 @@ public enum PdfUnderstandingSemanticKind {
 
 /// <summary>Page and option context shared by understanding stages.</summary>
 public sealed class PdfUnderstandingPageContext {
-    internal PdfUnderstandingPageContext(PdfReadPage page, int pageNumber, PdfTextLayoutOptions options) {
+    internal PdfUnderstandingPageContext(PdfReadPage page, int pageNumber, PdfTextLayoutOptions options,
+        int maxTextCharactersPerPage, int maxWordsPerPage) {
         Page = page;
         PageNumber = pageNumber;
         LayoutOptions = options;
         (double width, double height) = page.GetPageSize();
         Width = width;
         Height = height;
+        MaxTextCharactersPerPage = maxTextCharactersPerPage;
+        MaxWordsPerPage = maxWordsPerPage;
     }
 
     /// <summary>Parsed source page.</summary>
@@ -43,6 +46,10 @@ public sealed class PdfUnderstandingPageContext {
     public double Height { get; }
     /// <summary>Layout options supplied to the pipeline.</summary>
     public PdfTextLayoutOptions LayoutOptions { get; }
+    /// <summary>Maximum decoded text characters accepted for this page.</summary>
+    public int MaxTextCharactersPerPage { get; }
+    /// <summary>Maximum word artifacts accepted for this page.</summary>
+    public int MaxWordsPerPage { get; }
 }
 
 /// <summary>One decoded word candidate with source-run traceability.</summary>

--- a/OfficeIMO.Pdf/Reading/Understanding/PdfUnderstandingPipeline.cs
+++ b/OfficeIMO.Pdf/Reading/Understanding/PdfUnderstandingPipeline.cs
@@ -30,6 +30,16 @@ public sealed class PdfUnderstandingPipelineOptions {
     public PdfTextLayoutOptions Layout { get; set; } = new PdfTextLayoutOptions();
     /// <summary>Maximum selected pages processed by one run.</summary>
     public int MaxPages { get; set; } = 1000;
+    /// <summary>Maximum decoded text runs retained for one page.</summary>
+    public int MaxRunsPerPage { get; set; } = 100_000;
+    /// <summary>Maximum decoded text characters retained for one page.</summary>
+    public int MaxTextCharactersPerPage { get; set; } = 4 * 1024 * 1024;
+    /// <summary>Maximum grouped words retained for one page.</summary>
+    public int MaxWordsPerPage { get; set; } = 100_000;
+    /// <summary>Maximum grouped lines retained for one page.</summary>
+    public int MaxLinesPerPage { get; set; } = 50_000;
+    /// <summary>Maximum regions and semantic elements retained for one page.</summary>
+    public int MaxRegionsPerPage { get; set; } = 10_000;
 }
 
 /// <summary>Runs a bounded, typed, pluggable PDF text-understanding pipeline.</summary>
@@ -42,6 +52,7 @@ public sealed class PdfUnderstandingPipeline {
     private readonly IPdfSemanticClassificationStage _semanticClassification;
     private readonly PdfTextLayoutOptions _layout;
     private readonly int _maxPages;
+    private readonly PdfUnderstandingPipelineOptions _limits;
 
     /// <summary>Creates a pipeline, using the lightweight built-in stage for each unspecified slot.</summary>
     public PdfUnderstandingPipeline(PdfUnderstandingPipelineOptions? options = null) {
@@ -54,7 +65,13 @@ public sealed class PdfUnderstandingPipeline {
         _semanticClassification = effective.SemanticClassification ?? PdfFastUnderstandingStages.SemanticClassification;
         _layout = effective.Layout ?? throw new ArgumentNullException(nameof(options), "Layout options cannot be null.");
         _maxPages = effective.MaxPages;
+        _limits = effective;
         if (_maxPages <= 0) throw new ArgumentOutOfRangeException(nameof(options), effective.MaxPages, "Maximum pages must be positive.");
+        ValidateLimit(effective.MaxRunsPerPage, nameof(effective.MaxRunsPerPage));
+        ValidateLimit(effective.MaxTextCharactersPerPage, nameof(effective.MaxTextCharactersPerPage));
+        ValidateLimit(effective.MaxWordsPerPage, nameof(effective.MaxWordsPerPage));
+        ValidateLimit(effective.MaxLinesPerPage, nameof(effective.MaxLinesPerPage));
+        ValidateLimit(effective.MaxRegionsPerPage, nameof(effective.MaxRegionsPerPage));
     }
 
     /// <summary>Runs all stages for all pages or a caller-ordered page selection.</summary>
@@ -66,7 +83,7 @@ public sealed class PdfUnderstandingPipeline {
         for (int i = 0; i < pageNumbers.Length; i++) {
             cancellationToken.ThrowIfCancellationRequested();
             int pageNumber = pageNumbers[i];
-            pages.Add(RunPage(document.Pages[pageNumber - 1], pageNumber));
+            pages.Add(RunPage(document.Pages[pageNumber - 1], pageNumber, cancellationToken));
         }
         return new PdfUnderstandingResult(pages.AsReadOnly());
     }
@@ -78,21 +95,38 @@ public sealed class PdfUnderstandingPipeline {
         return Run(document, selector.ResolveSelection(document.Pages.Count), cancellationToken);
     }
 
-    private PdfUnderstandingPageResult RunPage(PdfReadPage page, int pageNumber) {
-        var context = new PdfUnderstandingPageContext(page, pageNumber, _layout);
+    private PdfUnderstandingPageResult RunPage(PdfReadPage page, int pageNumber, CancellationToken cancellationToken) {
+        var context = new PdfUnderstandingPageContext(
+            page,
+            pageNumber,
+            _layout,
+            _limits.MaxTextCharactersPerPage,
+            _limits.MaxWordsPerPage);
         var trace = new List<PdfUnderstandingStageTrace>(6);
         IReadOnlyList<PdfTextSpan> runs = NotNull(_glyphDecoding.Decode(context), nameof(IPdfGlyphDecodingStage));
+        EnsureCount(runs.Count, _limits.MaxRunsPerPage);
+        EnsureTextCharacters(runs.Select(static run => run.Text), _limits.MaxTextCharactersPerPage);
+        cancellationToken.ThrowIfCancellationRequested();
         trace.Add(new PdfUnderstandingStageTrace("glyph-decoding", _glyphDecoding.GetType(), 0, runs.Count));
         IReadOnlyList<PdfUnderstandingWord> words = NotNull(_wordGrouping.GroupWords(context, runs), nameof(IPdfWordGroupingStage));
+        EnsureCount(words.Count, _limits.MaxWordsPerPage);
+        EnsureTextCharacters(words.Select(static word => word.Text), _limits.MaxTextCharactersPerPage);
+        cancellationToken.ThrowIfCancellationRequested();
         trace.Add(new PdfUnderstandingStageTrace("word-grouping", _wordGrouping.GetType(), runs.Count, words.Count));
         IReadOnlyList<PdfUnderstandingLine> lines = NotNull(_lineGrouping.GroupLines(context, words), nameof(IPdfLineGroupingStage));
+        EnsureCount(lines.Count, _limits.MaxLinesPerPage);
+        cancellationToken.ThrowIfCancellationRequested();
         trace.Add(new PdfUnderstandingStageTrace("line-grouping", _lineGrouping.GetType(), words.Count, lines.Count));
         IReadOnlyList<PdfUnderstandingRegion> regions = NotNull(_pageSegmentation.Segment(context, lines), nameof(IPdfPageSegmentationStage));
+        EnsureCount(regions.Count, _limits.MaxRegionsPerPage);
+        cancellationToken.ThrowIfCancellationRequested();
         trace.Add(new PdfUnderstandingStageTrace("page-segmentation", _pageSegmentation.GetType(), lines.Count, regions.Count));
         IReadOnlyList<PdfUnderstandingRegion> ordered = NotNull(_readingOrder.Order(context, regions), nameof(IPdfReadingOrderStage));
+        EnsureCount(ordered.Count, _limits.MaxRegionsPerPage);
         trace.Add(new PdfUnderstandingStageTrace("reading-order", _readingOrder.GetType(), regions.Count, ordered.Count));
         IReadOnlyList<PdfReadingOrderEvidence> readingOrderEvidence = BuildReadingOrderEvidence(ordered, _readingOrder.GetType());
         IReadOnlyList<PdfUnderstandingSemanticElement> elements = NotNull(_semanticClassification.Classify(context, ordered), nameof(IPdfSemanticClassificationStage));
+        EnsureCount(elements.Count, _limits.MaxRegionsPerPage);
         trace.Add(new PdfUnderstandingStageTrace("semantic-classification", _semanticClassification.GetType(), ordered.Count, elements.Count));
         return new PdfUnderstandingPageResult(pageNumber, runs, words, lines, regions, ordered, readingOrderEvidence, elements, trace.AsReadOnly());
     }
@@ -112,6 +146,22 @@ public sealed class PdfUnderstandingPipeline {
     }
 
     private static IReadOnlyList<T> NotNull<T>(IReadOnlyList<T>? value, string stage) => value ?? throw new InvalidOperationException(stage + " returned null.");
+
+    private static void ValidateLimit(int value, string name) {
+        if (value <= 0) throw new ArgumentOutOfRangeException(name);
+    }
+
+    private static void EnsureCount(int actual, int maximum) {
+        if (actual > maximum) throw PdfReadLimitException.Create(PdfReadLimitKind.UnderstandingArtifacts, maximum, actual);
+    }
+
+    private static void EnsureTextCharacters(IEnumerable<string?> values, int maximum) {
+        long total = 0;
+        foreach (string? value in values) {
+            total = checked(total + (value?.Length ?? 0));
+            if (total > maximum) throw PdfReadLimitException.Create(PdfReadLimitKind.UnderstandingArtifacts, maximum, total);
+        }
+    }
 }
 
 internal static class PdfFastUnderstandingStages {
@@ -138,6 +188,9 @@ internal static class PdfFastUnderstandingStages {
                     int start = cursor;
                     while (cursor < text.Length && !char.IsWhiteSpace(text[cursor])) cursor++;
                     if (cursor <= start) continue;
+                    if (words.Count >= context.MaxWordsPerPage) {
+                        throw PdfReadLimitException.Create(PdfReadLimitKind.UnderstandingArtifacts, context.MaxWordsPerPage, words.Count + 1L);
+                    }
                     double perCharacter = run.Advance > 0D && text.Length > 0 ? run.Advance / text.Length : run.FontSize * 0.55D;
                     double xStart = run.X + (start * perCharacter);
                     double xEnd = xStart + ((cursor - start) * perCharacter);

--- a/OfficeIMO.Pdf/Rendering/PdfPageImageRenderer.Batch.cs
+++ b/OfficeIMO.Pdf/Rendering/PdfPageImageRenderer.Batch.cs
@@ -22,9 +22,15 @@ internal static partial class PdfPageImageRenderer {
         }
 
         var results = new List<PdfPageRenderResult>(pages.Length);
+        long totalOutputBytes = 0;
         for (int i = 0; i < pages.Length; i++) {
             cancellationToken.ThrowIfCancellationRequested();
-            results.Add(RenderPage(document, pages[i], effectiveOptions, cancellationToken));
+            PdfPageRenderResult result = RenderPage(document, pages[i], effectiveOptions, cancellationToken);
+            totalOutputBytes = checked(totalOutputBytes + result.OutputByteLength);
+            if (totalOutputBytes > effectiveOptions.MaxTotalOutputBytes) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.RenderBytes, effectiveOptions.MaxTotalOutputBytes, totalOutputBytes);
+            }
+            results.Add(result);
         }
 
         return results.AsReadOnly();
@@ -75,6 +81,9 @@ internal static partial class PdfPageImageRenderer {
             byte[] bytes = options.Format == PdfPageRenderFormat.Png
                 ? RenderDrawingAsPng(drawing, scale, options.Background, options.ImageCodec)
                 : OfficeDrawingSvgExporter.ToSvgBytes(drawing, scale);
+            if (bytes.LongLength > options.MaxOutputBytesPerPage) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.RenderBytes, options.MaxOutputBytesPerPage, bytes.LongLength);
+            }
             timer.Stop();
             return new PdfPageRenderResult(pageNumber, options.Format, bytes, width, height, timer.Elapsed, capabilityDiagnostics);
         } catch (OperationCanceledException) {

--- a/OfficeIMO.Pdf/Rendering/PdfPageRenderOptions.cs
+++ b/OfficeIMO.Pdf/Rendering/PdfPageRenderOptions.cs
@@ -35,6 +35,10 @@ public sealed class PdfPageRenderOptions : OfficeImageExportOptions {
         get => MaximumRasterPixels;
         set => MaximumRasterPixels = value;
     }
+    /// <summary>Maximum encoded output bytes retained for one page.</summary>
+    public long MaxOutputBytesPerPage { get; set; } = 64L * 1024L * 1024L;
+    /// <summary>Maximum aggregate encoded output bytes retained for one batch.</summary>
+    public long MaxTotalOutputBytes { get; set; } = 256L * 1024L * 1024L;
     /// <summary>Continues a batch and returns a failed per-page report when rendering fails.</summary>
     public bool ContinueOnError { get; set; } = true;
     internal double GetScale(OfficeDrawing drawing) {
@@ -53,6 +57,8 @@ public sealed class PdfPageRenderOptions : OfficeImageExportOptions {
         if (Dpi.HasValue && !IsPositiveFinite(Dpi.Value)) throw new ArgumentOutOfRangeException(nameof(Dpi), Dpi, "DPI must be positive and finite.");
         if (ThumbnailMaxDimension.HasValue && ThumbnailMaxDimension.Value <= 0) throw new ArgumentOutOfRangeException(nameof(ThumbnailMaxDimension));
         if (MaxPages <= 0) throw new ArgumentOutOfRangeException(nameof(MaxPages));
+        if (MaxOutputBytesPerPage <= 0) throw new ArgumentOutOfRangeException(nameof(MaxOutputBytesPerPage));
+        if (MaxTotalOutputBytes <= 0) throw new ArgumentOutOfRangeException(nameof(MaxTotalOutputBytes));
     }
 
     private static bool IsPositiveFinite(double value) => value > 0D && !double.IsNaN(value) && !double.IsInfinity(value);
@@ -102,4 +108,5 @@ public sealed class PdfPageRenderResult {
     public IReadOnlyList<PdfRenderCapabilityDiagnostic> CapabilityDiagnostics { get; }
     /// <summary>True when output bytes were produced.</summary>
     public bool Succeeded => _bytes is not null;
+    internal long OutputByteLength => _bytes?.LongLength ?? 0L;
 }

--- a/OfficeIMO.Pdf/Rendering/PdfVisualComparer.cs
+++ b/OfficeIMO.Pdf/Rendering/PdfVisualComparer.cs
@@ -1,4 +1,5 @@
 using OfficeIMO.Drawing;
+using System.Threading;
 
 namespace OfficeIMO.Pdf;
 
@@ -11,7 +12,8 @@ public static class PdfVisualComparer {
         PdfPageSelection? selection = null,
         PdfVisualComparisonOptions? options = null,
         PdfReadOptions? expectedReadOptions = null,
-        PdfReadOptions? actualReadOptions = null) {
+        PdfReadOptions? actualReadOptions = null,
+        CancellationToken cancellationToken = default) {
         Guard.NotNull(expectedPdf, nameof(expectedPdf));
         Guard.NotNull(actualPdf, nameof(actualPdf));
         PdfVisualComparisonOptions effectiveOptions = options ?? new PdfVisualComparisonOptions();
@@ -25,23 +27,44 @@ public static class PdfVisualComparer {
 
         int commonPageCount = Math.Min(expected.Pages.Count, actual.Pages.Count);
         int[] pageNumbers = selection?.ToPageNumbers(expected.Pages.Count, nameof(selection)) ?? Enumerable.Range(1, commonPageCount).ToArray();
+        if (pageNumbers.Length > effectiveOptions.MaxPages) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.RenderPages, effectiveOptions.MaxPages, pageNumbers.Length);
+        }
         var pages = new List<PdfVisualPageComparison>(pageNumbers.Length);
+        long totalPixels = 0;
+        long totalOutputBytes = 0;
         for (int i = 0; i < pageNumbers.Length; i++) {
+            cancellationToken.ThrowIfCancellationRequested();
             int pageNumber = pageNumbers[i];
             if (pageNumber > actual.Pages.Count) {
                 structural.Add("Page " + pageNumber + " is missing from the actual document.");
                 continue;
             }
 
-            pages.Add(ComparePage(expected, actual, pageNumber, effectiveOptions, structural));
+            PdfVisualPageComparison page = ComparePage(
+                expected,
+                actual,
+                pageNumber,
+                effectiveOptions,
+                structural,
+                ref totalPixels,
+                cancellationToken);
+            totalOutputBytes = checked(totalOutputBytes + page.OutputByteLength);
+            if (totalOutputBytes > effectiveOptions.MaxTotalOutputBytes) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.RenderBytes, effectiveOptions.MaxTotalOutputBytes, totalOutputBytes);
+            }
+            pages.Add(page);
         }
 
         return new PdfVisualComparisonReport(pages.AsReadOnly(), structural.AsReadOnly());
     }
 
-    private static PdfVisualPageComparison ComparePage(PdfReadDocument expectedDocument, PdfReadDocument actualDocument, int pageNumber, PdfVisualComparisonOptions options, List<string> structural) {
+    private static PdfVisualPageComparison ComparePage(PdfReadDocument expectedDocument, PdfReadDocument actualDocument, int pageNumber, PdfVisualComparisonOptions options, List<string> structural, ref long totalPixels, CancellationToken cancellationToken) {
         OfficeDrawing expectedDrawing = PdfPageImageRenderer.RenderPage(expectedDocument, pageNumber);
         OfficeDrawing actualDrawing = PdfPageImageRenderer.RenderPage(actualDocument, pageNumber);
+        AddPixelBudget(expectedDrawing.Width, expectedDrawing.Height, options.Scale, options, ref totalPixels);
+        AddPixelBudget(actualDrawing.Width, actualDrawing.Height, options.Scale, options, ref totalPixels);
+        cancellationToken.ThrowIfCancellationRequested();
         byte[] expectedPng = OfficeDrawingRasterRenderer.ToPng(expectedDrawing, options.Scale, options.Background);
         byte[] actualPng = OfficeDrawingRasterRenderer.ToPng(actualDrawing, options.Scale, options.Background);
         if (!OfficeRasterImageDecoder.TryDecode(expectedPng, out OfficeRasterImage? expectedImage) || expectedImage is null ||
@@ -55,6 +78,7 @@ public static class PdfVisualComparer {
 
         int width = Math.Max(expectedImage.Width, actualImage.Width);
         int height = Math.Max(expectedImage.Height, actualImage.Height);
+        AddPixelBudget(width, height, 1D, options, ref totalPixels);
         (int ExpectedX, int ExpectedY) = GetOffset(width, height, expectedImage.Width, expectedImage.Height, options.Alignment);
         (int ActualX, int ActualY) = GetOffset(width, height, actualImage.Width, actualImage.Height, options.Alignment);
         var diff = new OfficeRasterImage(width, height, OfficeColor.White);
@@ -63,6 +87,7 @@ public static class PdfVisualComparer {
         long channelDifferenceTotal = 0;
         int maximumDifference = 0;
         for (int y = 0; y < height; y++) {
+            cancellationToken.ThrowIfCancellationRequested();
             for (int x = 0; x < width; x++) {
                 if (options.IgnoredRegions.Any(region => region.Contains(x, y))) {
                     diff.SetPixel(x, y, OfficeColor.FromRgb(224, 224, 224));
@@ -92,6 +117,7 @@ public static class PdfVisualComparer {
 
         double ratio = compared == 0 ? 0D : different / (double)compared;
         double mean = compared == 0 ? 0D : channelDifferenceTotal / (double)(compared * 4L);
+        byte[] diffPng = OfficePngWriter.Encode(diff);
         return new PdfVisualPageComparison(
             pageNumber,
             ratio <= options.AllowedDifferenceRatio,
@@ -103,7 +129,20 @@ public static class PdfVisualComparer {
             mean,
             expectedPng,
             actualPng,
-            OfficePngWriter.Encode(diff));
+            diffPng);
+    }
+
+    private static void AddPixelBudget(double width, double height, double scale, PdfVisualComparisonOptions options, ref long totalPixels) {
+        int pixelWidth = checked((int)Math.Ceiling(width * scale));
+        int pixelHeight = checked((int)Math.Ceiling(height * scale));
+        long pixels = checked((long)pixelWidth * pixelHeight);
+        if (pixels > options.MaxPixelsPerImage) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.RenderPixels, options.MaxPixelsPerImage, pixels);
+        }
+        totalPixels = checked(totalPixels + pixels);
+        if (totalPixels > options.MaxTotalPixels) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.RenderPixels, options.MaxTotalPixels, totalPixels);
+        }
     }
 
     private static (int X, int Y) GetOffset(int canvasWidth, int canvasHeight, int imageWidth, int imageHeight, PdfVisualPageAlignment alignment) =>

--- a/OfficeIMO.Pdf/Rendering/PdfVisualComparer.cs
+++ b/OfficeIMO.Pdf/Rendering/PdfVisualComparer.cs
@@ -12,8 +12,18 @@ public static class PdfVisualComparer {
         PdfPageSelection? selection = null,
         PdfVisualComparisonOptions? options = null,
         PdfReadOptions? expectedReadOptions = null,
-        PdfReadOptions? actualReadOptions = null,
-        CancellationToken cancellationToken = default) {
+        PdfReadOptions? actualReadOptions = null) =>
+        Compare(expectedPdf, actualPdf, CancellationToken.None, selection, options, expectedReadOptions, actualReadOptions);
+
+    /// <summary>Compares all common pages or a selected page set with cooperative cancellation.</summary>
+    public static PdfVisualComparisonReport Compare(
+        byte[] expectedPdf,
+        byte[] actualPdf,
+        CancellationToken cancellationToken,
+        PdfPageSelection? selection = null,
+        PdfVisualComparisonOptions? options = null,
+        PdfReadOptions? expectedReadOptions = null,
+        PdfReadOptions? actualReadOptions = null) {
         Guard.NotNull(expectedPdf, nameof(expectedPdf));
         Guard.NotNull(actualPdf, nameof(actualPdf));
         PdfVisualComparisonOptions effectiveOptions = options ?? new PdfVisualComparisonOptions();

--- a/OfficeIMO.Pdf/Rendering/PdfVisualComparisonOptions.cs
+++ b/OfficeIMO.Pdf/Rendering/PdfVisualComparisonOptions.cs
@@ -47,10 +47,22 @@ public sealed class PdfVisualComparisonOptions {
     public OfficeColor Background { get; set; } = OfficeColor.White;
     /// <summary>Ignored comparison regions in output pixel coordinates.</summary>
     public IList<PdfPixelRegion> IgnoredRegions => _ignoredRegions;
+    /// <summary>Maximum pages compared by one call.</summary>
+    public int MaxPages { get; set; } = 100;
+    /// <summary>Maximum raster pixels allocated for one expected, actual, or diff page image.</summary>
+    public long MaxPixelsPerImage { get; set; } = 20_000_000L;
+    /// <summary>Maximum aggregate raster pixels allocated across the comparison.</summary>
+    public long MaxTotalPixels { get; set; } = 100_000_000L;
+    /// <summary>Maximum aggregate PNG bytes retained in the comparison report.</summary>
+    public long MaxTotalOutputBytes { get; set; } = 256L * 1024L * 1024L;
 
     internal void Validate() {
         if (Scale <= 0D || double.IsNaN(Scale) || double.IsInfinity(Scale)) throw new ArgumentOutOfRangeException(nameof(Scale));
         if (AllowedDifferenceRatio < 0D || AllowedDifferenceRatio > 1D || double.IsNaN(AllowedDifferenceRatio)) throw new ArgumentOutOfRangeException(nameof(AllowedDifferenceRatio));
         if (Alignment < PdfVisualPageAlignment.TopLeft || Alignment > PdfVisualPageAlignment.Center) throw new ArgumentOutOfRangeException(nameof(Alignment));
+        if (MaxPages <= 0) throw new ArgumentOutOfRangeException(nameof(MaxPages));
+        if (MaxPixelsPerImage <= 0) throw new ArgumentOutOfRangeException(nameof(MaxPixelsPerImage));
+        if (MaxTotalPixels <= 0) throw new ArgumentOutOfRangeException(nameof(MaxTotalPixels));
+        if (MaxTotalOutputBytes <= 0) throw new ArgumentOutOfRangeException(nameof(MaxTotalOutputBytes));
     }
 }

--- a/OfficeIMO.Pdf/Rendering/PdfVisualComparisonReport.cs
+++ b/OfficeIMO.Pdf/Rendering/PdfVisualComparisonReport.cs
@@ -75,4 +75,5 @@ public sealed class PdfVisualPageComparison {
     public byte[] ActualPng => (byte[])_actualPng.Clone();
     /// <summary>Highlighted diff PNG.</summary>
     public byte[] DiffPng => (byte[])_diffPng.Clone();
+    internal long OutputByteLength => checked(_expectedPng.LongLength + _actualPng.LongLength + _diffPng.LongLength);
 }

--- a/OfficeIMO.Pdf/Signatures/PdfExternalSignatureOptions.cs
+++ b/OfficeIMO.Pdf/Signatures/PdfExternalSignatureOptions.cs
@@ -1,9 +1,20 @@
+using System.Threading;
+
 namespace OfficeIMO.Pdf;
 
 /// <summary>Options for preparing a dependency-free external PDF signature placeholder.</summary>
 public sealed class PdfExternalSignatureOptions {
+    /// <summary>Default maximum PDF source size accepted by one-shot signing APIs (512 MiB).</summary>
+    public const long DefaultMaxInputBytes = 512L * 1024L * 1024L;
+
     private string _fieldName = "Signature1";
     private int _reservedSignatureContentsBytes = 32768;
+
+    /// <summary>Maximum PDF source bytes accepted before signature preparation begins.</summary>
+    public long MaxInputBytes { get; set; } = DefaultMaxInputBytes;
+
+    /// <summary>Cancellation observed while reading and preparing a one-shot external signature.</summary>
+    public CancellationToken CancellationToken { get; set; }
 
     /// <summary>High-level signature intent. Approval is the default.</summary>
     public PdfSignatureProfile Profile { get; set; } = PdfSignatureProfile.Approval;

--- a/OfficeIMO.Pdf/Signatures/PdfExternalSignaturePreparation.cs
+++ b/OfficeIMO.Pdf/Signatures/PdfExternalSignaturePreparation.cs
@@ -60,20 +60,22 @@ public sealed class PdfExternalSignaturePreparation {
     /// <summary>Bytes covered by the /ByteRange and intended for external digest/signing.</summary>
     public byte[] SignedContent {
         get {
-            using var stream = new MemoryStream();
-            stream.Write(_preparedPdf, (int)ByteRangeValues[0], (int)ByteRangeValues[1]);
-            stream.Write(_preparedPdf, (int)ByteRangeValues[2], (int)ByteRangeValues[3]);
-            return stream.ToArray();
+            int firstLength = checked((int)ByteRangeValues[1]);
+            int secondLength = checked((int)ByteRangeValues[3]);
+            var result = new byte[checked(firstLength + secondLength)];
+            Buffer.BlockCopy(_preparedPdf, checked((int)ByteRangeValues[0]), result, 0, firstLength);
+            Buffer.BlockCopy(_preparedPdf, checked((int)ByteRangeValues[2]), result, firstLength, secondLength);
+            return result;
         }
     }
 
     /// <summary>Computes the SHA-256 digest of <see cref="SignedContent"/> for external signing services.</summary>
-#pragma warning disable CA1850
     public byte[] ComputeSha256Digest() {
-        using SHA256 sha256 = SHA256.Create();
-        return sha256.ComputeHash(SignedContent);
+        using IncrementalHash sha256 = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        sha256.AppendData(_preparedPdf, checked((int)ByteRangeValues[0]), checked((int)ByteRangeValues[1]));
+        sha256.AppendData(_preparedPdf, checked((int)ByteRangeValues[2]), checked((int)ByteRangeValues[3]));
+        return sha256.GetHashAndReset();
     }
-#pragma warning restore CA1850
 
     /// <summary>
     /// Completes this in-memory preparation with detached CMS or timestamp bytes.

--- a/OfficeIMO.Word.Tests/Word.EmbeddedRtfLists.cs
+++ b/OfficeIMO.Word.Tests/Word.EmbeddedRtfLists.cs
@@ -104,6 +104,18 @@ public partial class Word {
         Assert.NotEqual(100, int.Parse(listTableId.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture));
     }
 
+    [Fact]
+    public void AddEmbeddedFragment_RejectsOversizedExistingRtfPartBeforeReadingItUnbounded() {
+        using WordDocument document = WordDocument.Create();
+        string oversized = "{\\rtf1 " + new string('A', 16 * 1024 * 1024) + "}";
+        document.AddEmbeddedFragment(oversized, WordAlternativeFormatImportPartType.Rtf);
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+            document.AddEmbeddedFragment(BulletListRtf, WordAlternativeFormatImportPartType.Rtf));
+
+        Assert.Contains("maximum size", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static string ReadRtf(WordEmbeddedDocument embedded) =>
         Encoding.UTF8.GetString(embedded.ToBytes());
 

--- a/OfficeIMO.Word.Tests/Word.LegacyDoc.Conversion.cs
+++ b/OfficeIMO.Word.Tests/Word.LegacyDoc.Conversion.cs
@@ -84,7 +84,8 @@ namespace OfficeIMO.Tests {
                     LegacyDocImportOptions = new LegacyDocImportOptions { MaxInputBytes = 1 }
                 }));
 
-            Assert.Contains("configured limit of 1 byte", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("configured maximum size", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("1", exception.Message, StringComparison.Ordinal);
             Assert.False(File.Exists(destinationPath));
         }
 

--- a/OfficeIMO.Word.Tests/Word.LegacyDoc.Conversion.cs
+++ b/OfficeIMO.Word.Tests/Word.LegacyDoc.Conversion.cs
@@ -90,6 +90,28 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void LegacyDoc_Convert_DoesNotApplyLegacyInputLimitToOpenXml() {
+            string sourcePath = Path.Combine(_directoryWithFiles, Guid.NewGuid().ToString("N") + ".docx");
+            string destinationPath = Path.Combine(_directoryWithFiles, Guid.NewGuid().ToString("N") + ".doc");
+            using (WordDocument document = WordDocument.Create(sourcePath)) {
+                document.AddParagraph("Open XML source");
+                document.Save();
+            }
+
+            WordDocumentConversionResult result = WordDocument.Convert(
+                sourcePath,
+                destinationPath,
+                new WordDocumentConversionOptions {
+                    LegacyDocImportOptions = new LegacyDocImportOptions { MaxInputBytes = 1 }
+                });
+
+            Assert.Equal(destinationPath, result.RequireNoLoss());
+            using WordDocument converted = WordDocument.Load(destinationPath);
+            Assert.Equal(WordFileFormat.Doc, converted.SourceFormat);
+            Assert.Contains(converted.Paragraphs, paragraph => paragraph.Text == "Open XML source");
+        }
+
+        [Fact]
         public void LegacyDoc_Convert_CannotSuppressDiscoveryToBypassLossPolicy() {
             string sourcePath = Path.Combine(_directoryWithFiles, Guid.NewGuid().ToString("N") + ".doc");
             string destinationPath = Path.Combine(_directoryWithFiles, Guid.NewGuid().ToString("N") + ".docx");

--- a/OfficeIMO.Word.Tests/Word.LegacyDoc.Safety.cs
+++ b/OfficeIMO.Word.Tests/Word.LegacyDoc.Safety.cs
@@ -34,6 +34,23 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public async Task Load_StreamAndAsyncStreamEnforceCompleteInputLimit() {
+            using WordDocument document = WordDocument.Create();
+            document.AddParagraph("Bounded DOCX stream");
+            byte[] bytes = document.ToBytes();
+
+            using var syncStream = new MemoryStream(bytes);
+            Assert.Throws<InvalidDataException>(() => WordDocument.Load(
+                syncStream,
+                new WordLoadOptions { MaxInputBytes = bytes.Length - 1L }));
+
+            using var asyncStream = new MemoryStream(bytes);
+            await Assert.ThrowsAsync<InvalidDataException>(() => WordDocument.LoadAsync(
+                asyncStream,
+                new WordLoadOptions { MaxInputBytes = bytes.Length - 1L }));
+        }
+
+        [Fact]
         public void LegacyDoc_LoadResult_CachesCompactAndAdvancedReports() {
             using LegacyDocLoadResult result = WordDocument.LoadLegacyDocWithReport(
                 new MemoryStream(LegacyDocTestBuilder.CreateSimpleDoc("Summary paragraph")));

--- a/OfficeIMO.Word.Tests/Word.LegacyDoc.Safety.cs
+++ b/OfficeIMO.Word.Tests/Word.LegacyDoc.Safety.cs
@@ -151,6 +151,21 @@ namespace OfficeIMO.Tests {
                     new LegacyDocImportOptions { MaxDecodedImageBytes = 0 }));
         }
 
+        [Fact]
+        public void LegacyDoc_AllPublicLoadShapesEnforceTheCompleteInputBudget() {
+            byte[] bytes = LegacyDocTestBuilder.CreateSimpleDoc("Bounded legacy input");
+            var options = new LegacyDocImportOptions { MaxInputBytes = bytes.Length - 1 };
+            string path = Path.Combine(_directoryWithFiles, Guid.NewGuid().ToString("N") + ".doc");
+            File.WriteAllBytes(path, bytes);
+
+            Assert.Throws<InvalidDataException>(() =>
+                OfficeIMO.Word.LegacyDoc.Model.LegacyDocDocument.Load(bytes, options));
+            Assert.Throws<InvalidDataException>(() =>
+                OfficeIMO.Word.LegacyDoc.Model.LegacyDocDocument.Load(new MemoryStream(bytes), options));
+            Assert.Throws<InvalidDataException>(() =>
+                OfficeIMO.Word.LegacyDoc.Model.LegacyDocDocument.Load(path, options));
+        }
+
         private static void AssertOleCompoundBytes(byte[] bytes) {
             Assert.True(bytes.Length > 8);
             Assert.Equal(0xd0, bytes[0]);

--- a/OfficeIMO.Word/Helpers/RtfListSemanticsNormalizer.cs
+++ b/OfficeIMO.Word/Helpers/RtfListSemanticsNormalizer.cs
@@ -1,4 +1,5 @@
 using DocumentFormat.OpenXml.Packaging;
+using OfficeIMO.Drawing.Internal;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 
@@ -16,6 +17,9 @@ namespace OfficeIMO.Word;
 /// </remarks>
 internal static class RtfListSemanticsNormalizer {
     private const string RtfContentType = "application/rtf";
+    private const int MaximumExistingRtfPartCount = 1_024;
+    private const long MaximumExistingRtfPartBytes = 16L * 1024L * 1024L;
+    private const long MaximumExistingRtfTotalBytes = 64L * 1024L * 1024L;
     private static readonly ConditionalWeakTable<MainDocumentPart, OccupiedIdentifierState> IdentifierStates =
         new ConditionalWeakTable<MainDocumentPart, OccupiedIdentifierState>();
 
@@ -53,13 +57,29 @@ internal static class RtfListSemanticsNormalizer {
     private static void CollectExistingIdentifiers(
         MainDocumentPart mainDocumentPart,
         IdentifierSets identifiers) {
+        int partCount = 0;
+        long totalBytes = 0;
         foreach (AlternativeFormatImportPart part in mainDocumentPart.AlternativeFormatImportParts) {
             if (!string.Equals(part.ContentType, RtfContentType, StringComparison.OrdinalIgnoreCase)) {
                 continue;
             }
 
+            partCount++;
+            if (partCount > MaximumExistingRtfPartCount) {
+                throw new InvalidDataException($"RTF altChunk count exceeds the configured limit of {MaximumExistingRtfPartCount}.");
+            }
+
             using Stream stream = part.GetStream(FileMode.Open, FileAccess.Read);
-            using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+            long remaining = MaximumExistingRtfTotalBytes - totalBytes;
+            if (remaining <= 0) {
+                throw new InvalidDataException($"RTF altChunk bytes exceed the configured aggregate limit of {MaximumExistingRtfTotalBytes}.");
+            }
+            byte[] bytes = OfficeStreamReader.ReadAllBytes(stream, Math.Min(MaximumExistingRtfPartBytes, remaining));
+            totalBytes = checked(totalBytes + bytes.LongLength);
+            using var reader = new StreamReader(
+                new MemoryStream(bytes, writable: false),
+                Encoding.UTF8,
+                detectEncodingFromByteOrderMarks: true);
             CollectIdentifiers(reader.ReadToEnd(), identifiers);
         }
     }

--- a/OfficeIMO.Word/LegacyDoc/Model/LegacyDocDocument.cs
+++ b/OfficeIMO.Word/LegacyDoc/Model/LegacyDocDocument.cs
@@ -77,7 +77,10 @@ namespace OfficeIMO.Word.LegacyDoc.Model {
         /// </summary>
         public static LegacyDocDocument Load(string path, LegacyDocImportOptions? options = null) {
             if (path == null) throw new ArgumentNullException(nameof(path));
-            return Load(File.ReadAllBytes(path), options);
+            options ??= new LegacyDocImportOptions();
+            options.Validate();
+            using FileStream stream = File.OpenRead(path);
+            return Load(OfficeStreamReader.ReadAllBytes(stream, options.MaxInputBytes), options);
         }
 
         /// <summary>
@@ -85,12 +88,9 @@ namespace OfficeIMO.Word.LegacyDoc.Model {
         /// </summary>
         public static LegacyDocDocument Load(Stream stream, LegacyDocImportOptions? options = null) {
             if (stream == null) throw new ArgumentNullException(nameof(stream));
-            using var buffer = new MemoryStream();
-            if (stream.CanSeek) {
-                stream.Seek(0, SeekOrigin.Begin);
-            }
-            stream.CopyTo(buffer);
-            return Load(buffer.ToArray(), options);
+            options ??= new LegacyDocImportOptions();
+            options.Validate();
+            return Load(OfficeStreamReader.ReadAllBytes(stream, options.MaxInputBytes), options);
         }
 
         /// <summary>
@@ -100,6 +100,9 @@ namespace OfficeIMO.Word.LegacyDoc.Model {
             if (bytes == null) throw new ArgumentNullException(nameof(bytes));
             options ??= new LegacyDocImportOptions();
             options.Validate();
+            if (bytes.Length > options.MaxInputBytes) {
+                throw new InvalidDataException($"Legacy DOC input exceeds the configured maximum size ({options.MaxInputBytes} bytes).");
+            }
 
             var document = new LegacyDocDocument();
             if (!OfficeCompoundFileReader.TryRead(bytes, out OfficeCompoundFile? compoundFile, out string? compoundError)) {

--- a/OfficeIMO.Word/WordDocument.Conversion.cs
+++ b/OfficeIMO.Word/WordDocument.Conversion.cs
@@ -193,9 +193,16 @@ namespace OfficeIMO.Word {
             WordDocumentConversionOptions options,
             CancellationToken cancellationToken) {
             if (options.LegacyDocImportOptions != null) {
-                byte[] sourceBytes = await OfficeFileConversion.ReadAllBytesAsync(sourcePath, cancellationToken).ConfigureAwait(false);
+                LegacyDocImportOptions importOptions = CreateConversionImportOptions(options.LegacyDocImportOptions);
+                importOptions.Validate();
+                byte[] sourceBytes;
+                using (FileStream source = File.OpenRead(sourcePath)) {
+                    sourceBytes = await OfficeStreamReader.ReadAllBytesAsync(
+                        source,
+                        cancellationToken,
+                        importOptions.MaxInputBytes).ConfigureAwait(false);
+                }
                 if (WordDocumentLoadRouting.IsLegacyDoc(sourceBytes, sourcePath)) {
-                    LegacyDocImportOptions importOptions = CreateConversionImportOptions(options.LegacyDocImportOptions);
                     return LoadLegacyDocFromNormalFlow(
                         sourceBytes,
                         sourcePath,

--- a/OfficeIMO.Word/WordDocument.Conversion.cs
+++ b/OfficeIMO.Word/WordDocument.Conversion.cs
@@ -195,20 +195,42 @@ namespace OfficeIMO.Word {
             if (options.LegacyDocImportOptions != null) {
                 LegacyDocImportOptions importOptions = CreateConversionImportOptions(options.LegacyDocImportOptions);
                 importOptions.Validate();
-                byte[] sourceBytes;
+                byte[] signature = new byte[WordDocumentLoadRouting.SignatureLength];
+                int signatureLength = 0;
                 using (FileStream source = File.OpenRead(sourcePath)) {
-                    sourceBytes = await OfficeStreamReader.ReadAllBytesAsync(
-                        source,
-                        cancellationToken,
-                        importOptions.MaxInputBytes).ConfigureAwait(false);
+                    while (signatureLength < signature.Length) {
+                        int read = await source.ReadAsync(
+                            signature,
+                            signatureLength,
+                            signature.Length - signatureLength,
+                            cancellationToken).ConfigureAwait(false);
+                        if (read == 0) break;
+                        signatureLength += read;
+                    }
                 }
-                if (WordDocumentLoadRouting.IsLegacyDoc(sourceBytes, sourcePath)) {
-                    return LoadLegacyDocFromNormalFlow(
-                        sourceBytes,
-                        sourcePath,
-                        saveOnDispose: false,
-                        readOnly: false,
-                        importOptions: importOptions);
+                if (signatureLength != signature.Length) {
+                    Array.Resize(ref signature, signatureLength);
+                }
+
+                bool mayBeLegacyDoc = !WordDocumentLoadRouting.HasZipSignature(signature)
+                    && (WordDocumentLoadRouting.HasOleCompoundSignature(signature)
+                        || WordDocumentLoadRouting.HasLegacyDocExtension(sourcePath));
+                if (mayBeLegacyDoc) {
+                    byte[] sourceBytes;
+                    using (FileStream source = File.OpenRead(sourcePath)) {
+                        sourceBytes = await OfficeStreamReader.ReadAllBytesAsync(
+                            source,
+                            cancellationToken,
+                            importOptions.MaxInputBytes).ConfigureAwait(false);
+                    }
+                    if (WordDocumentLoadRouting.IsLegacyDoc(sourceBytes, sourcePath)) {
+                        return LoadLegacyDocFromNormalFlow(
+                            sourceBytes,
+                            sourcePath,
+                            saveOnDispose: false,
+                            readOnly: false,
+                            importOptions: importOptions);
+                    }
                 }
             }
 

--- a/OfficeIMO.Word/WordDocument.CreateLoad.cs
+++ b/OfficeIMO.Word/WordDocument.CreateLoad.cs
@@ -52,17 +52,36 @@ namespace OfficeIMO.Word {
             };
         }
 
-        private static byte[] ReadSourceBytes(Stream stream, OfficePackageSecurityOptions? securityOptions) =>
-            securityOptions == null
-                ? OfficeStreamReader.ReadAllBytes(stream)
-                : OfficePackageSecurityInspector.ReadBounded(stream, securityOptions);
+        private static byte[] ReadSourceBytes(Stream stream, WordLoadOptions options) {
+            ValidateMaxInputBytes(options);
+            if (options.PackageSecurity != null &&
+                options.PackageSecurity.MaxPackageBytes <= options.MaxInputBytes) {
+                return OfficePackageSecurityInspector.ReadBounded(stream, options.PackageSecurity);
+            }
+
+            return OfficeStreamReader.ReadAllBytes(stream, options.MaxInputBytes);
+        }
 
         private static async Task<byte[]> ReadSourceBytesAsync(Stream stream,
-            OfficePackageSecurityOptions? securityOptions, CancellationToken cancellationToken) =>
-            securityOptions == null
-                ? await OfficeStreamReader.ReadAllBytesAsync(stream, cancellationToken).ConfigureAwait(false)
-                : await OfficePackageSecurityInspector.ReadBoundedAsync(stream, securityOptions, cancellationToken)
-                    .ConfigureAwait(false);
+            WordLoadOptions options, CancellationToken cancellationToken) {
+            ValidateMaxInputBytes(options);
+            if (options.PackageSecurity != null &&
+                options.PackageSecurity.MaxPackageBytes <= options.MaxInputBytes) {
+                return await OfficePackageSecurityInspector.ReadBoundedAsync(
+                    stream,
+                    options.PackageSecurity,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            return await OfficeStreamReader.ReadAllBytesAsync(
+                stream,
+                cancellationToken,
+                options.MaxInputBytes).ConfigureAwait(false);
+        }
+
+        private static void ValidateMaxInputBytes(WordLoadOptions options) {
+            if (options.MaxInputBytes <= 0) throw new ArgumentOutOfRangeException(nameof(options.MaxInputBytes));
+        }
 
         private static void ValidateSourcePackage(byte[] sourceBytes,
             OfficePackageSecurityOptions? securityOptions) {
@@ -339,7 +358,7 @@ namespace OfficeIMO.Word {
 
             // Read the source file into memory with a shared read handle to avoid test collisions.
             using (var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete)) {
-                byte[] sourceBytes = ReadSourceBytes(fileStream, resolved.PackageSecurity);
+                byte[] sourceBytes = ReadSourceBytes(fileStream, resolved);
                 ValidateSourcePackage(sourceBytes, resolved.PackageSecurity);
 
                 if (WordDocumentLoadRouting.IsLegacyDoc(sourceBytes, filePath)) {
@@ -395,7 +414,7 @@ namespace OfficeIMO.Word {
 
             byte[] encryptedBytes;
             using (var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete)) {
-                encryptedBytes = ReadSourceBytes(fileStream, resolved.PackageSecurity);
+                encryptedBytes = ReadSourceBytes(fileStream, resolved);
             }
             ValidateSourcePackage(encryptedBytes, resolved.PackageSecurity);
             byte[] packageBytes = OfficeEncryption.DecryptPackage(encryptedBytes, password);
@@ -417,7 +436,7 @@ namespace OfficeIMO.Word {
             WordLoadOptions resolved = options ?? new WordLoadOptions();
             EnsureEncryptedLoadUsesExplicitPersistence(resolved);
 
-            byte[] encryptedBytes = ReadSourceBytes(stream, resolved.PackageSecurity);
+            byte[] encryptedBytes = ReadSourceBytes(stream, resolved);
             ValidateSourcePackage(encryptedBytes, resolved.PackageSecurity);
             byte[] packageBytes = OfficeEncryption.DecryptPackage(encryptedBytes, password);
             using var decryptedSource = new MemoryStream(packageBytes, writable: false);
@@ -450,7 +469,7 @@ namespace OfficeIMO.Word {
             OfficeDocumentLifecycle.Validate(resolved.AccessMode, resolved.PersistenceMode, "document");
             using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read,
                 FileShare.ReadWrite | FileShare.Delete, 4096, FileOptions.Asynchronous);
-            byte[] sourceBytes = await ReadSourceBytesAsync(fileStream, resolved.PackageSecurity,
+            byte[] sourceBytes = await ReadSourceBytesAsync(fileStream, resolved,
                 cancellationToken).ConfigureAwait(false);
             ValidateSourcePackage(sourceBytes, resolved.PackageSecurity);
             bool readOnly = resolved.AccessMode == DocumentAccessMode.ReadOnly;
@@ -509,7 +528,7 @@ namespace OfficeIMO.Word {
             bool copyBackToSource = resolved.PersistenceMode == DocumentPersistenceMode.SaveOnDispose && !readOnly;
             OfficeDocumentLifecycle.EnsureSaveOnDisposeDestination(stream, resolved.PersistenceMode, nameof(stream));
 
-            byte[] sourceBytes = await ReadSourceBytesAsync(stream, resolved.PackageSecurity,
+            byte[] sourceBytes = await ReadSourceBytesAsync(stream, resolved,
                 cancellationToken).ConfigureAwait(false);
             using var bufferedStream = new MemoryStream(sourceBytes.Length);
             bufferedStream.Write(sourceBytes, 0, sourceBytes.Length);
@@ -542,7 +561,7 @@ namespace OfficeIMO.Word {
             bool saveOnDispose = resolved.PersistenceMode == DocumentPersistenceMode.SaveOnDispose;
             OfficeDocumentLifecycle.EnsureSaveOnDisposeDestination(stream, resolved.PersistenceMode, nameof(stream));
             var effectiveOpenSettings = CreateOpenSettings(resolved.OpenSettings);
-            byte[] sourceBytes = ReadSourceBytes(stream, resolved.PackageSecurity);
+            byte[] sourceBytes = ReadSourceBytes(stream, resolved);
             ValidateSourcePackage(sourceBytes, resolved.PackageSecurity);
 
             if (WordDocumentLoadRouting.IsLegacyDoc(sourceBytes, filePath: null)) {

--- a/OfficeIMO.Word/WordDocument.LoadRouting.cs
+++ b/OfficeIMO.Word/WordDocument.LoadRouting.cs
@@ -24,7 +24,7 @@ namespace OfficeIMO.Word {
                 || string.Equals(extension, ".dot", StringComparison.OrdinalIgnoreCase);
         }
 
-        private static bool HasZipSignature(byte[] bytes) {
+        internal static bool HasZipSignature(byte[] bytes) {
             return bytes.Length >= ZipSignature.Length
                 && bytes[0] == ZipSignature[0]
                 && bytes[1] == ZipSignature[1];

--- a/OfficeIMO.Word/WordLifecycleOptions.cs
+++ b/OfficeIMO.Word/WordLifecycleOptions.cs
@@ -10,6 +10,14 @@ namespace OfficeIMO.Word {
 
     /// <summary>Controls access, persistence, and package behavior when loading a Word document.</summary>
     public sealed class WordLoadOptions : DocumentLoadOptions {
+        /// <summary>Default maximum complete source size (512 MiB).</summary>
+        public const long DefaultMaxInputBytes = 512L * 1024L * 1024L;
+
+        /// <summary>
+        /// Maximum number of source bytes accepted before Word package parsing begins.
+        /// </summary>
+        public long MaxInputBytes { get; set; } = DefaultMaxInputBytes;
+
         /// <summary>Replaces existing styles with OfficeIMO defaults when the document is editable.</summary>
         public bool OverrideStyles { get; set; }
 


### PR DESCRIPTION
## Summary

- Bound attacker-controlled memory and CPU work across JPEG, RTF, Word, Excel, CSV, HTML/PDF, OCR, signing, rendering, and PDF object parsing paths.
- Add aggregate budgets, recursion and artifact limits, deduplication, cancellation checks, and bounded stream handling while preserving existing public behavior.
- Make destructive annotation cleanup explicit, retain compatible binary API and enum values, and keep file-attachment annotations connected to retained or renamed payloads.

## Compatibility

Defaults are intentionally generous for normal documents. Callers can opt into append-only annotation residual data explicitly; secure full rewrites remain the default for cleanup.

## Validation

- Full Drawing, Excel, HTML, PDF, and Word suites passed on the supported local targets.
- Focused security contracts passed on .NET 8 and .NET 10.
- Independent review findings were fixed and narrowly reconfirmed.