### PR TITLE
Harden document rendering and inspection limits

### DIFF
--- a/OfficeIMO.Drawing.CodeGlyphX.Tests/CodeGlyphDrawingIntegrationTests.cs
+++ b/OfficeIMO.Drawing.CodeGlyphX.Tests/CodeGlyphDrawingIntegrationTests.cs
@@ -142,4 +142,16 @@ public sealed class CodeGlyphDrawingIntegrationTests {
         Assert.Equal(0, unsupported);
         Assert.True(drawing.Shapes.Count > OfficeSvgDrawingReaderOptions.DefaultMaximumElements);
     }
+
+    [Fact]
+    public void AdapterImportsTrustedBarcodeViewportBeyondDefaultAreaLimit() {
+        Barcode1D barcode = new Barcode1D(Enumerable.Range(0, 5_000).Select(index => new BarSegment(index % 2 == 0, 1)));
+        var options = new BarcodeSvgRenderOptions { HeightModules = 5_000 };
+
+        OfficeDrawing drawing = barcode.ToOfficeDrawing(out int unsupported, options);
+
+        Assert.Equal(0, unsupported);
+        Assert.True(drawing.Width * drawing.Height > OfficeSvgDrawingReaderOptions.DefaultMaximumViewportPixels);
+        Assert.True(drawing.Width * drawing.Height <= OfficeSvgDrawingReaderOptions.MaximumAllowedViewportPixels);
+    }
 }

--- a/OfficeIMO.Drawing.CodeGlyphX/CodeGlyphDrawingExtensions.cs
+++ b/OfficeIMO.Drawing.CodeGlyphX/CodeGlyphDrawingExtensions.cs
@@ -72,7 +72,10 @@ public static class CodeGlyphDrawingExtensions {
 
     private static OfficeDrawing ReadSvg(string svg, int maximumElements, out int unsupportedFeatureCount) {
         byte[] bytes = Encoding.UTF8.GetBytes(svg);
-        var readerOptions = new OfficeSvgDrawingReaderOptions { MaximumElements = maximumElements };
+        var readerOptions = new OfficeSvgDrawingReaderOptions {
+            MaximumElements = maximumElements,
+            MaximumViewportDimension = OfficeSvgDrawingReaderOptions.MaximumAllowedViewportDimension
+        };
         if (!OfficeSvgDrawingReader.TryRead(bytes, readerOptions, out OfficeDrawing? drawing, out unsupportedFeatureCount) || drawing is null) {
             throw new InvalidOperationException("CodeGlyphX produced SVG that OfficeIMO.Drawing could not read.");
         }

--- a/OfficeIMO.Drawing.CodeGlyphX/CodeGlyphDrawingExtensions.cs
+++ b/OfficeIMO.Drawing.CodeGlyphX/CodeGlyphDrawingExtensions.cs
@@ -74,7 +74,8 @@ public static class CodeGlyphDrawingExtensions {
         byte[] bytes = Encoding.UTF8.GetBytes(svg);
         var readerOptions = new OfficeSvgDrawingReaderOptions {
             MaximumElements = maximumElements,
-            MaximumViewportDimension = OfficeSvgDrawingReaderOptions.MaximumAllowedViewportDimension
+            MaximumViewportDimension = OfficeSvgDrawingReaderOptions.MaximumAllowedViewportDimension,
+            MaximumViewportPixels = OfficeSvgDrawingReaderOptions.MaximumAllowedViewportPixels
         };
         if (!OfficeSvgDrawingReader.TryRead(bytes, readerOptions, out OfficeDrawing? drawing, out unsupportedFeatureCount) || drawing is null) {
             throw new InvalidOperationException("CodeGlyphX produced SVG that OfficeIMO.Drawing could not read.");

--- a/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
@@ -380,6 +380,41 @@ public class DrawingSvgReaderTests {
     }
 
     [Fact]
+    public void SvgReaderChargesRepeatedUsePolylinesToOneCommandBudget() {
+        var points = new StringBuilder("0,0");
+        for (int index = 1; index < 1000; index++) points.Append(' ').Append(index % 10).Append(',').Append(index % 10);
+        var svg = new StringBuilder("<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'><defs><polyline id='p' points='")
+            .Append(points).Append("' stroke='black'/></defs>");
+        for (int index = 0; index < 25; index++) svg.Append("<use href='#p'/>");
+        svg.Append("</svg>");
+
+        Assert.True(OfficeSvgDrawingReader.TryRead(Encoding.UTF8.GetBytes(svg.ToString()),
+            out OfficeDrawing? drawing, out int unsupported));
+        Assert.NotNull(drawing);
+        Assert.InRange(drawing!.Shapes.Count, 1, 20);
+        Assert.True(unsupported > 0);
+        Assert.True(drawing.Shapes.Sum(shape => shape.Shape.PathCommands.Count) <= 20000);
+    }
+
+    [Fact]
+    public void SvgReaderRejectsTransformArgumentsBeyondSupportedArity() {
+        var arguments = new StringBuilder("0");
+        for (int index = 1; index < 1000; index++) arguments.Append(" 0");
+        string svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 10'>"
+            + "<rect width='10' height='10' fill='red' transform='matrix(" + arguments + ")'/>"
+            + "<rect x='10' width='10' height='10' fill='lime'/></svg>";
+
+        Assert.True(OfficeSvgDrawingReader.TryRead(Encoding.UTF8.GetBytes(svg),
+            out OfficeDrawing? drawing, out int unsupported));
+        Assert.NotNull(drawing);
+        Assert.Equal(1, unsupported);
+        Assert.Equal(2, drawing!.Shapes.Count);
+        Assert.Equal(OfficeColor.Red, drawing.Shapes[0].Shape.FillColor);
+        Assert.False(drawing.Shapes[0].Shape.Transform.HasValue);
+        Assert.Equal(OfficeColor.Lime, drawing.Shapes[1].Shape.FillColor);
+    }
+
+    [Fact]
     public void SvgReaderResolvesInheritedLinearPaintServersWithoutRasterFallback() {
         const string svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 20'>"
             + "<defs><linearGradient id='base'><stop offset='20%' stop-color='red'/><stop offset='50%' stop-color='red'/><stop offset='50%' stop-color='blue'/><stop offset='80%' stop-color='blue'/></linearGradient>"

--- a/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
@@ -108,6 +108,22 @@ public class DrawingSvgReaderTests {
     }
 
     [Fact]
+    public void SvgReaderPreservesThePathBudgetAfterMalformedPathData() {
+        const string svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'>"
+            + "<path d='M0 0 L nope' stroke='red'/>"
+            + "<path d='M1 1 L10 10' stroke='blue'/>"
+            + "<polyline points='1,10 5,15 10,10' stroke='green'/></svg>";
+
+        Assert.True(OfficeSvgDrawingReader.TryRead(Encoding.UTF8.GetBytes(svg), out OfficeDrawing? drawing, out int unsupported));
+
+        Assert.NotNull(drawing);
+        Assert.Equal(1, unsupported);
+        Assert.Equal(2, drawing!.Shapes.Count);
+        Assert.Contains(drawing.Shapes, item => item.Shape.StrokeColor == OfficeColor.Blue);
+        Assert.Contains(drawing.Shapes, item => item.Shape.StrokeColor == OfficeColor.Green);
+    }
+
+    [Fact]
     public void SvgReaderConvertsRotatedEllipticalArcsToBoundedCubicPaths() {
         const string svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'>"
             + "<path fill='none' stroke='blue' d='M2 10 A8 6 30 0 1 18 10 A8 6 30 1 1 2 10 Z'/></svg>";

--- a/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
@@ -92,6 +92,21 @@ public class DrawingSvgReaderTests {
     }
 
     [Fact]
+    public void SvgReaderAllowsAnExplicitTrustedViewportLimit() {
+        const string svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 22000 100'>"
+            + "<rect width='22000' height='100' fill='black'/></svg>";
+        byte[] bytes = Encoding.UTF8.GetBytes(svg);
+
+        Assert.False(OfficeSvgDrawingReader.TryRead(bytes, out _));
+
+        var options = new OfficeSvgDrawingReaderOptions { MaximumViewportDimension = 22000D };
+        Assert.True(OfficeSvgDrawingReader.TryRead(bytes, options, out OfficeDrawing? drawing, out int unsupported));
+        Assert.NotNull(drawing);
+        Assert.Equal(0, unsupported);
+        Assert.Equal(22000D, drawing!.Width);
+    }
+
+    [Fact]
     public void SvgReaderParsesAbsoluteRelativeAndSmoothPathCommands() {
         const string svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='10 20 40 20'>"
             + "<path fill='red' d='M10 20 h20 v20 h-20 z'/>"

--- a/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
@@ -339,6 +339,47 @@ public class DrawingSvgReaderTests {
     }
 
     [Fact]
+    public void SvgReaderBoundsNestedTextTransformsAndSymbolSurfaces() {
+        var nested = new StringBuilder("<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'><text>");
+        for (int index = 0; index < 160; index++) nested.Append("<tspan>");
+        nested.Append("Text");
+        for (int index = 0; index < 160; index++) nested.Append("</tspan>");
+        nested.Append("</text><line x2='10' y2='10' stroke='black' stroke-dasharray='1 1' transform='scale(1000000000)'/></svg>");
+
+        Assert.True(OfficeSvgDrawingReader.TryRead(Encoding.UTF8.GetBytes(nested.ToString()),
+            out OfficeDrawing? bounded, out int unsupported));
+        Assert.NotNull(bounded);
+        Assert.True(unsupported >= 2);
+        OfficeDrawingRasterRenderer.Render(bounded!);
+
+        const string oversized = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'>"
+            + "<defs><symbol id='large' viewBox='0 0 100000 100000'><rect width='1' height='1'/></symbol></defs>"
+            + "<use href='#large' width='100000' height='100000'/></svg>";
+        Assert.True(OfficeSvgDrawingReader.TryRead(Encoding.UTF8.GetBytes(oversized),
+            out OfficeDrawing? safe, out int surfaceUnsupported));
+        Assert.NotNull(safe);
+        Assert.Empty(safe!.Elements);
+        Assert.Equal(1, surfaceUnsupported);
+    }
+
+    [Fact]
+    public void SvgReaderChargesRepeatedUsePathsToOneCommandBudget() {
+        var path = new StringBuilder("M0 0");
+        for (int index = 0; index < 1000; index++) path.Append(" L1 1");
+        var svg = new StringBuilder("<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'><defs><path id='p' d='")
+            .Append(path).Append("' stroke='black'/></defs>");
+        for (int index = 0; index < 25; index++) svg.Append("<use href='#p'/>");
+        svg.Append("</svg>");
+
+        Assert.True(OfficeSvgDrawingReader.TryRead(Encoding.UTF8.GetBytes(svg.ToString()),
+            out OfficeDrawing? drawing, out int unsupported));
+        Assert.NotNull(drawing);
+        Assert.InRange(drawing!.Shapes.Count, 1, 19);
+        Assert.True(unsupported > 0);
+        Assert.True(drawing.Shapes.Sum(shape => shape.Shape.PathCommands.Count) <= 20000);
+    }
+
+    [Fact]
     public void SvgReaderResolvesInheritedLinearPaintServersWithoutRasterFallback() {
         const string svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 20'>"
             + "<defs><linearGradient id='base'><stop offset='20%' stop-color='red'/><stop offset='50%' stop-color='red'/><stop offset='50%' stop-color='blue'/><stop offset='80%' stop-color='blue'/></linearGradient>"

--- a/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
@@ -413,6 +413,20 @@ public class DrawingSvgReaderTests {
     }
 
     [Fact]
+    public void SvgReaderDoesNotExhaustPathBudgetForMalformedPointLists() {
+        const string svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 10'>"
+            + "<polygon points='0,0 nope'/><polyline points='0,0 1'/><path d='M10 0 L20 10' stroke='lime'/></svg>";
+
+        Assert.True(OfficeSvgDrawingReader.TryRead(Encoding.UTF8.GetBytes(svg),
+            out OfficeDrawing? drawing, out int unsupported));
+        Assert.NotNull(drawing);
+        Assert.Equal(2, unsupported);
+        OfficeDrawingShape shape = Assert.Single(drawing!.Shapes);
+        Assert.Equal(OfficeColor.Lime, shape.Shape.StrokeColor);
+        Assert.Equal(2, shape.Shape.PathCommands.Count);
+    }
+
+    [Fact]
     public void SvgReaderRejectsTransformArgumentsBeyondSupportedArity() {
         var arguments = new StringBuilder("0");
         for (int index = 1; index < 1000; index++) arguments.Append(" 0");

--- a/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
@@ -442,6 +442,24 @@ public class DrawingSvgReaderTests {
     }
 
     [Fact]
+    public void SvgReaderDoesNotChargeRejectedTwoPointPolygonsToPathBudget() {
+        var svg = new StringBuilder("<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 10'>");
+        for (int index = 0; index < 6_667; index++) {
+            svg.Append("<polygon points='0,0 1,1'/>");
+        }
+        svg.Append("<path d='M10 0 L20 10' stroke='lime'/></svg>");
+
+        Assert.True(OfficeSvgDrawingReader.TryRead(Encoding.UTF8.GetBytes(svg.ToString()),
+            out OfficeDrawing? drawing, out int unsupported));
+
+        Assert.NotNull(drawing);
+        Assert.Equal(6_667, unsupported);
+        OfficeDrawingShape shape = Assert.Single(drawing!.Shapes);
+        Assert.Equal(OfficeColor.Lime, shape.Shape.StrokeColor);
+        Assert.Equal(2, shape.Shape.PathCommands.Count);
+    }
+
+    [Fact]
     public void SvgReaderRejectsTransformArgumentsBeyondSupportedArity() {
         var arguments = new StringBuilder("0");
         for (int index = 1; index < 1000; index++) arguments.Append(" 0");

--- a/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.SvgReader.cs
@@ -601,8 +601,9 @@ public class DrawingSvgReaderTests {
     [Fact]
     public void SvgReaderResolvesRgbaCurrentColorInGradientStops() {
         const string svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'>"
-            + "<defs><linearGradient id='paint' style='color:rgba(36,87,166,0.502)'>"
-            + "<stop stop-color='currentColor'/><stop offset='1' stop-color='white'/></linearGradient></defs>"
+            + "<defs><linearGradient id='paint'>"
+            + "<stop style='color:rgba(36,87,166,0.502);stop-color:currentColor'/>"
+            + "<stop offset='1' color='rgb(10%,20%,30%)' stop-color='currentColor'/></linearGradient></defs>"
             + "<rect width='10' height='10' fill='url(#paint)'/></svg>";
 
         Assert.True(OfficeSvgDrawingReader.TryRead(Encoding.UTF8.GetBytes(svg), out OfficeDrawing? drawing, out int unsupported));
@@ -610,6 +611,7 @@ public class DrawingSvgReaderTests {
         Assert.Equal(0, unsupported);
         OfficeLinearGradient gradient = Assert.IsType<OfficeLinearGradient>(Assert.Single(drawing!.Shapes).Shape.FillGradient);
         Assert.Equal(OfficeColor.FromRgba(36, 87, 166, 128), gradient.Stops[0].Color);
+        Assert.Equal(OfficeColor.FromRgb(26, 51, 76), gradient.Stops[gradient.Stops.Count - 1].Color);
     }
 
     [Fact]

--- a/OfficeIMO.Drawing.Tests/Drawing.TilingPatterns.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.TilingPatterns.cs
@@ -29,6 +29,33 @@ public partial class DrawingTests {
         Assert.Equal(expectedCount, pattern.GetTileTransforms().Count);
     }
 
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void OfficeDrawingTilingPattern_PreservesRepeatAxesWhenTinted(bool repeatX, bool repeatY) {
+        var tile = new OfficeDrawing(2D, 2D);
+        OfficeShape square = OfficeShape.Rectangle(2D, 2D);
+        square.FillColor = OfficeColor.Red;
+        square.StrokeWidth = 0D;
+        tile.AddShape(square, 0D, 0D);
+        var drawing = new OfficeDrawing(6D, 4D);
+        drawing.AddTilingPattern(
+            tile,
+            new OfficeImagePlacement(0D, 0D, 6D, 4D),
+            2D,
+            2D,
+            repeatX,
+            repeatY);
+
+        drawing.ApplyColorTint(OfficeColor.Blue);
+
+        OfficeDrawingTilingPattern pattern = Assert.Single(drawing.Elements.OfType<OfficeDrawingTilingPattern>());
+        Assert.Equal(repeatX, pattern.RepeatX);
+        Assert.Equal(repeatY, pattern.RepeatY);
+        OfficeDrawingShape shape = Assert.Single(pattern.Tile.Elements.OfType<OfficeDrawingShape>());
+        Assert.Equal(OfficeColor.Blue, shape.Shape.FillColor);
+    }
+
     [Fact]
     public void OfficeDrawingTilingPattern_RepeatsVectorContentWithGaps() {
         var tile = new OfficeDrawing(2D, 2D);

--- a/OfficeIMO.Drawing.Tests/Drawing.TilingPatterns.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.TilingPatterns.cs
@@ -4,6 +4,31 @@ using Xunit;
 namespace OfficeIMO.Tests;
 
 public partial class DrawingTests {
+    [Theory]
+    [InlineData(true, false, 3)]
+    [InlineData(false, true, 2)]
+    public void OfficeDrawingTilingPattern_PreservesSingleAxisRepetition(bool repeatX, bool repeatY, int expectedCount) {
+        var tile = new OfficeDrawing(2D, 2D);
+        OfficeShape square = OfficeShape.Rectangle(2D, 2D);
+        square.FillColor = OfficeColor.Red;
+        square.StrokeWidth = 0D;
+        tile.AddShape(square, 0D, 0D);
+        var drawing = new OfficeDrawing(6D, 4D);
+
+        drawing.AddTilingPattern(
+            tile,
+            new OfficeImagePlacement(0D, 0D, 6D, 4D),
+            2D,
+            2D,
+            repeatX: repeatX,
+            repeatY: repeatY);
+
+        OfficeDrawingTilingPattern pattern = Assert.Single(drawing.Elements.OfType<OfficeDrawingTilingPattern>());
+        Assert.Equal(repeatX, pattern.RepeatX);
+        Assert.Equal(repeatY, pattern.RepeatY);
+        Assert.Equal(expectedCount, pattern.GetTileTransforms().Count);
+    }
+
     [Fact]
     public void OfficeDrawingTilingPattern_RepeatsVectorContentWithGaps() {
         var tile = new OfficeDrawing(2D, 2D);

--- a/OfficeIMO.Drawing/OfficeDrawing.ColorTint.cs
+++ b/OfficeIMO.Drawing/OfficeDrawing.ColorTint.cs
@@ -48,7 +48,8 @@ public sealed partial class OfficeDrawing {
                 OfficeDrawing tile = pattern.InnerTile.Clone();
                 tile.ApplyColorTint(tint);
                 replacement = new OfficeDrawingTilingPattern(
-                    tile, pattern.Area, pattern.HorizontalStep, pattern.VerticalStep, pattern.Transform,
+                    tile, pattern.Area, pattern.HorizontalStep, pattern.VerticalStep,
+                    pattern.RepeatX, pattern.RepeatY, pattern.Transform,
                     pattern.OriginX, pattern.OriginY, pattern.MaximumTileCount, pattern.Opacity);
             }
 

--- a/OfficeIMO.Drawing/OfficeDrawing.ImagePatterns.cs
+++ b/OfficeIMO.Drawing/OfficeDrawing.ImagePatterns.cs
@@ -21,6 +21,24 @@ public sealed partial class OfficeDrawing {
         return this;
     }
 
+    internal OfficeDrawing AddImagePatternShared(
+        byte[] bytes,
+        string contentType,
+        OfficeImagePatternLayout layout,
+        int maximumTileCount = 16384,
+        double opacity = 1D) {
+        OfficeImagePlacement area = layout.Area;
+        if (area.X < 0D || area.Y < 0D || area.X + area.Width > Width || area.Y + area.Height > Height) {
+            throw new ArgumentOutOfRangeException(nameof(layout), "Image-pattern area must fit inside the drawing bounds.");
+        }
+
+        var pattern = new OfficeDrawingImagePattern(bytes, contentType, layout, maximumTileCount, opacity,
+            useSnapshot: true);
+        _imagePatterns.Add(pattern);
+        _elements.Add(pattern);
+        return this;
+    }
+
     private void AddNestedImagePattern(OfficeDrawingImagePattern pattern, double offsetX, double offsetY, OfficeImageFrameTransform? frameTransform, bool allowOverflow) {
         OfficeImagePatternLayout translated = pattern.Layout.Translate(offsetX, offsetY);
         OfficeImagePlacement area = translated.Area;

--- a/OfficeIMO.Drawing/OfficeDrawing.TilingPatterns.cs
+++ b/OfficeIMO.Drawing/OfficeDrawing.TilingPatterns.cs
@@ -13,13 +13,28 @@ public sealed partial class OfficeDrawing {
         double originX = 0D,
         double originY = 0D,
         int maximumTileCount = 16384,
+        double opacity = 1D) =>
+        AddTilingPattern(tile, area, horizontalStep, verticalStep, true, true, transform, originX, originY, maximumTileCount, opacity);
+
+    /// <summary>Adds a clipped, transform-aware vector tiling pattern with independent axis repetition.</summary>
+    public OfficeDrawing AddTilingPattern(
+        OfficeDrawing tile,
+        OfficeImagePlacement area,
+        double horizontalStep,
+        double verticalStep,
+        bool repeatX,
+        bool repeatY,
+        OfficeTransform? transform = null,
+        double originX = 0D,
+        double originY = 0D,
+        int maximumTileCount = 16384,
         double opacity = 1D) {
         if (area.X < 0D || area.Y < 0D || area.X + area.Width > Width || area.Y + area.Height > Height) {
             throw new ArgumentOutOfRangeException(nameof(area), "Pattern area must fit inside the drawing bounds.");
         }
         if (tile == null) throw new ArgumentNullException(nameof(tile));
         Fonts.AddRange(tile.Fonts);
-        _elements.Add(new OfficeDrawingTilingPattern(tile, area, horizontalStep, verticalStep, transform, originX, originY, maximumTileCount, opacity));
+        _elements.Add(new OfficeDrawingTilingPattern(tile, area, horizontalStep, verticalStep, repeatX, repeatY, transform, originX, originY, maximumTileCount, opacity));
         return this;
     }
 
@@ -37,6 +52,8 @@ public sealed partial class OfficeDrawing {
             translatedArea,
             pattern.HorizontalStep,
             pattern.VerticalStep,
+            pattern.RepeatX,
+            pattern.RepeatY,
             transform,
             pattern.OriginX,
             pattern.OriginY,

--- a/OfficeIMO.Drawing/OfficeDrawing.cs
+++ b/OfficeIMO.Drawing/OfficeDrawing.cs
@@ -152,6 +152,12 @@ public sealed partial class OfficeDrawing {
         return AddImageCore(bytes, contentType, projection, alternativeText, opacity, allowOverflow: false);
     }
 
+    internal OfficeDrawing AddImageShared(byte[] bytes, string? contentType, OfficeImageProjection projection,
+        string? alternativeText = null, double opacity = 1D) {
+        return AddImageCore(bytes, contentType, projection, alternativeText, opacity,
+            allowOverflow: false, useDataSnapshot: true);
+    }
+
     /// <summary>Adds an image clipped by a drawing-local clipping path.</summary>
     public OfficeDrawing AddClippedImage(byte[] bytes, string? contentType, OfficeImageProjection projection, double clipX, double clipY, OfficeClipPath clipPath, string? alternativeText = null, double opacity = 1D) {
         if (clipPath == null) {
@@ -209,8 +215,10 @@ public sealed partial class OfficeDrawing {
         return AddClippedDrawing(clipped, clipX, clipY, clipPath);
     }
 
-    private OfficeDrawing AddImageCore(byte[] bytes, string? contentType, OfficeImageProjection projection, string? alternativeText, double opacity, bool allowOverflow) {
-        var item = new OfficeDrawingImage(bytes, contentType, projection, alternativeText, opacity);
+    private OfficeDrawing AddImageCore(byte[] bytes, string? contentType, OfficeImageProjection projection,
+        string? alternativeText, double opacity, bool allowOverflow, bool useDataSnapshot = false) {
+        var item = new OfficeDrawingImage(bytes, contentType, projection, alternativeText, opacity,
+            useDataSnapshot);
         (double left, double top, double right, double bottom) = item.Projection.GetDestinationBounds();
         if (!allowOverflow && (left < 0D || top < 0D || right > Width || bottom > Height)) {
             throw new ArgumentOutOfRangeException(nameof(projection), "Drawing images must fit inside the drawing bounds.");

--- a/OfficeIMO.Drawing/OfficeDrawingTilingPattern.cs
+++ b/OfficeIMO.Drawing/OfficeDrawingTilingPattern.cs
@@ -71,6 +71,9 @@ public sealed class OfficeDrawingTilingPattern : OfficeDrawingElement {
 
     internal OfficeDrawing InnerTile => _tile;
 
+    /// <summary>Returns the bounded transforms needed to paint this pattern.</summary>
+    public IReadOnlyList<OfficeTransform> GetTileTransforms() => GetTileTransforms(MaximumTileCount);
+
     internal IReadOnlyList<OfficeTransform> GetTileTransforms(int maximumTileCount) {
         if (maximumTileCount <= 0) throw new ArgumentOutOfRangeException(nameof(maximumTileCount));
         Transform.TryInvert(out OfficeTransform inverse);

--- a/OfficeIMO.Drawing/OfficeDrawingTilingPattern.cs
+++ b/OfficeIMO.Drawing/OfficeDrawingTilingPattern.cs
@@ -20,6 +20,22 @@ public sealed class OfficeDrawingTilingPattern : OfficeDrawingElement {
         double originX = 0D,
         double originY = 0D,
         int maximumTileCount = 16384,
+        double opacity = 1D)
+        : this(tile, area, horizontalStep, verticalStep, true, true, transform, originX, originY, maximumTileCount, opacity) {
+    }
+
+    /// <summary>Creates a bounded vector tiling pattern with independent axis repetition.</summary>
+    public OfficeDrawingTilingPattern(
+        OfficeDrawing tile,
+        OfficeImagePlacement area,
+        double horizontalStep,
+        double verticalStep,
+        bool repeatX,
+        bool repeatY,
+        OfficeTransform? transform = null,
+        double originX = 0D,
+        double originY = 0D,
+        int maximumTileCount = 16384,
         double opacity = 1D) {
         if (tile == null) throw new ArgumentNullException(nameof(tile));
         if (tile.Width <= 0D || tile.Height <= 0D) throw new ArgumentException("Pattern tile dimensions must be positive.", nameof(tile));
@@ -39,6 +55,8 @@ public sealed class OfficeDrawingTilingPattern : OfficeDrawingElement {
         OriginY = originY;
         MaximumTileCount = maximumTileCount;
         Opacity = opacity;
+        RepeatX = repeatX;
+        RepeatY = repeatY;
         _ = GetTileTransforms(maximumTileCount);
     }
 
@@ -69,6 +87,12 @@ public sealed class OfficeDrawingTilingPattern : OfficeDrawingElement {
     /// <summary>Pattern opacity from zero through one.</summary>
     public double Opacity { get; }
 
+    /// <summary>Whether the origin tile repeats horizontally.</summary>
+    public bool RepeatX { get; }
+
+    /// <summary>Whether the origin tile repeats vertically.</summary>
+    public bool RepeatY { get; }
+
     internal OfficeDrawing InnerTile => _tile;
 
     /// <summary>Returns the bounded transforms needed to paint this pattern.</summary>
@@ -85,10 +109,18 @@ public sealed class OfficeDrawingTilingPattern : OfficeDrawingElement {
         double maxX = Math.Max(Math.Max(topLeft.X, topRight.X), Math.Max(bottomRight.X, bottomLeft.X));
         double minY = Math.Min(Math.Min(topLeft.Y, topRight.Y), Math.Min(bottomRight.Y, bottomLeft.Y));
         double maxY = Math.Max(Math.Max(topLeft.Y, topRight.Y), Math.Max(bottomRight.Y, bottomLeft.Y));
-        long firstColumn = (long)Math.Floor((minX - OriginX - _tile.Width) / HorizontalStep) + 1L;
-        long lastColumn = (long)Math.Ceiling((maxX - OriginX) / HorizontalStep) - 1L;
-        long firstRow = (long)Math.Floor((minY - OriginY - _tile.Height) / VerticalStep) + 1L;
-        long lastRow = (long)Math.Ceiling((maxY - OriginY) / VerticalStep) - 1L;
+        long firstColumn = RepeatX
+            ? (long)Math.Floor((minX - OriginX - _tile.Width) / HorizontalStep) + 1L
+            : 0L;
+        long lastColumn = RepeatX
+            ? (long)Math.Ceiling((maxX - OriginX) / HorizontalStep) - 1L
+            : OriginX < maxX && OriginX + _tile.Width > minX ? 0L : -1L;
+        long firstRow = RepeatY
+            ? (long)Math.Floor((minY - OriginY - _tile.Height) / VerticalStep) + 1L
+            : 0L;
+        long lastRow = RepeatY
+            ? (long)Math.Ceiling((maxY - OriginY) / VerticalStep) - 1L
+            : OriginY < maxY && OriginY + _tile.Height > minY ? 0L : -1L;
         long columns = Math.Max(0L, lastColumn - firstColumn + 1L);
         long rows = Math.Max(0L, lastRow - firstRow + 1L);
         long count = columns == 0L || rows == 0L || columns > long.MaxValue / rows ? (columns == 0L || rows == 0L ? 0L : long.MaxValue) : columns * rows;
@@ -106,7 +138,7 @@ public sealed class OfficeDrawingTilingPattern : OfficeDrawingElement {
     }
 
     internal override OfficeDrawingElement CloneElement() => new OfficeDrawingTilingPattern(
-        _tile, Area, HorizontalStep, VerticalStep, Transform, OriginX, OriginY, MaximumTileCount, Opacity);
+        _tile, Area, HorizontalStep, VerticalStep, RepeatX, RepeatY, Transform, OriginX, OriginY, MaximumTileCount, Opacity);
 
     private static double ValidateStep(double value, string parameterName) {
         EnsureFinite(value, parameterName);

--- a/OfficeIMO.Drawing/OfficeFontFaceCollection.cs
+++ b/OfficeIMO.Drawing/OfficeFontFaceCollection.cs
@@ -94,6 +94,25 @@ public sealed class OfficeFontFaceCollection {
         return true;
     }
 
+    internal bool TryMeasureTextElements(
+        string text,
+        IReadOnlyList<string> elements,
+        double fontSize,
+        string? familyNames,
+        OfficeFontStyle style,
+        out IReadOnlyList<double> widths) {
+        widths = Array.Empty<double>();
+        if (string.IsNullOrEmpty(text) || elements.Count == 0 || fontSize <= 0D || double.IsNaN(fontSize) || double.IsInfinity(fontSize)) {
+            return false;
+        }
+
+        OfficeTrueTypeFont? font = ResolveForText(text, familyNames, style, out OfficeFontStyle _);
+        if (font == null) return false;
+
+        widths = font.MeasureTextElements(elements, fontSize);
+        return true;
+    }
+
     /// <summary>
     /// Splits text into grapheme-safe runs using the first scoped family whose selected face covers each text element.
     /// Unresolved elements retain the original family list for platform or adapter fallback.

--- a/OfficeIMO.Drawing/OfficeFontFaceCollection.cs
+++ b/OfficeIMO.Drawing/OfficeFontFaceCollection.cs
@@ -102,15 +102,28 @@ public sealed class OfficeFontFaceCollection {
         if (string.IsNullOrEmpty(text)) return Array.Empty<OfficeFontFallbackRun>();
 
         string requestedFamilies = familyNames?.Trim() ?? string.Empty;
+        IReadOnlyList<OfficeFontFace> candidates = ResolveFallbackCandidates(requestedFamilies, style);
+        var resolvedFamilies = new Dictionary<string, string>(StringComparer.Ordinal);
         var runs = new List<OfficeFontFallbackRun>();
         var currentText = new StringBuilder();
         string? currentFamily = null;
         foreach (string element in OfficeTextElements.Enumerate(text)) {
-            string family = IsWhitespace(element) && currentFamily != null
-                ? currentFamily
-                : ResolveForText(element, requestedFamilies, style, out OfficeFontFace? face) != null
-                    ? face!.FamilyName
-                    : requestedFamilies;
+            string family;
+            if (IsWhitespace(element) && currentFamily != null) {
+                family = currentFamily;
+            } else {
+                if (!resolvedFamilies.TryGetValue(element, out string? resolvedFamily)) {
+                    OfficeFontFace? face = null;
+                    for (int candidateIndex = 0; candidateIndex < candidates.Count; candidateIndex++) {
+                        if (!candidates[candidateIndex].ParsedFont.HasGlyphs(element)) continue;
+                        face = candidates[candidateIndex];
+                        break;
+                    }
+                    resolvedFamily = face?.FamilyName ?? requestedFamilies;
+                    resolvedFamilies.Add(element, resolvedFamily);
+                }
+                family = resolvedFamily;
+            }
             if (currentFamily != null && !string.Equals(currentFamily, family, StringComparison.OrdinalIgnoreCase)) {
                 runs.Add(new OfficeFontFallbackRun(currentText.ToString(), currentFamily));
                 currentText.Clear();
@@ -122,6 +135,31 @@ public sealed class OfficeFontFaceCollection {
 
         if (currentText.Length > 0) runs.Add(new OfficeFontFallbackRun(currentText.ToString(), currentFamily ?? requestedFamilies));
         return runs.AsReadOnly();
+    }
+
+    private IReadOnlyList<OfficeFontFace> ResolveFallbackCandidates(string familyNames, OfficeFontStyle style) {
+        if (string.IsNullOrWhiteSpace(familyNames) || _faces.Count == 0) return Array.Empty<OfficeFontFace>();
+
+        OfficeFontStyle normalizedStyle = OfficeFontFace.NormalizeStyle(style);
+        var result = new List<OfficeFontFace>();
+        var added = new HashSet<OfficeFontFace>();
+        foreach (string rawFamily in familyNames.Split(',')) {
+            string family = CleanFamilyName(rawFamily);
+            if (family.Length == 0) continue;
+            OfficeFontFace? exact = null;
+            OfficeFontFace? regular = null;
+            OfficeFontFace? first = null;
+            for (int index = _faces.Count - 1; index >= 0; index--) {
+                OfficeFontFace face = _faces[index];
+                if (!string.Equals(face.FamilyName, family, StringComparison.OrdinalIgnoreCase)) continue;
+                first ??= face;
+                if (face.Style == normalizedStyle) exact ??= face;
+                if (face.Style == OfficeFontStyle.Regular) regular ??= face;
+            }
+            OfficeFontFace? preferred = exact ?? regular ?? first;
+            if (preferred != null && added.Add(preferred)) result.Add(preferred);
+        }
+        return result;
     }
 
     internal OfficeTrueTypeFont? Resolve(string? familyNames, OfficeFontStyle style) {

--- a/OfficeIMO.Drawing/OfficeFontFaceCollection.cs
+++ b/OfficeIMO.Drawing/OfficeFontFaceCollection.cs
@@ -162,9 +162,7 @@ public sealed class OfficeFontFaceCollection {
         OfficeFontStyle normalizedStyle = OfficeFontFace.NormalizeStyle(style);
         var result = new List<OfficeFontFace>();
         var added = new HashSet<OfficeFontFace>();
-        foreach (string rawFamily in familyNames.Split(',')) {
-            string family = CleanFamilyName(rawFamily);
-            if (family.Length == 0) continue;
+        foreach (string family in OfficeFontFamilyParser.Parse(familyNames)) {
             OfficeFontFace? exact = null;
             OfficeFontFace? regular = null;
             OfficeFontFace? first = null;

--- a/OfficeIMO.Drawing/OfficeIMO.Drawing.csproj
+++ b/OfficeIMO.Drawing/OfficeIMO.Drawing.csproj
@@ -29,6 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="OfficeIMO.Html" />
     <Compile Include="..\OfficeIMO.SharedSource\Compound\*.cs" Link="Internal\Compound\%(Filename)%(Extension)" />
     <None Include="..\Assets\OfficeIMO.png">
       <Pack>True</Pack>

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.PaintServers.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.PaintServers.cs
@@ -346,7 +346,7 @@ public static partial class OfficeSvgDrawingReader {
 
             if (!string.IsNullOrWhiteSpace(currentColorText) &&
                 !currentColorText!.Trim().Equals("currentcolor", StringComparison.OrdinalIgnoreCase) &&
-                !OfficeColor.TryParse(currentColorText.Trim(), out currentColor)) return false;
+                !TrySvgColor(currentColorText.Trim(), out currentColor)) return false;
 
             if (string.IsNullOrWhiteSpace(colorText)) color = OfficeColor.Black;
             else if (colorText!.Trim().Equals("currentcolor", StringComparison.OrdinalIgnoreCase)) color = currentColor;

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.PaintServers.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.PaintServers.cs
@@ -293,13 +293,14 @@ public static partial class OfficeSvgDrawingReader {
                 .Where(element => element.Name.LocalName.Equals("stop", StringComparison.OrdinalIgnoreCase))
                 .ToArray();
             if (elements.Length == 0 || elements.Length > MaximumGradientStops) return false;
+            if (!TryResolveCurrentColor(gradient, out OfficeColor inheritedCurrentColor)) return false;
 
             var parsed = new List<OfficeGradientStop>(elements.Length + 2);
             double previous = -1D;
             foreach (XElement element in elements) {
                 if (!TryStopOffset(element.Attribute("offset")?.Value, out double offset)) return false;
                 offset = Math.Max(previous, offset);
-                if (!TryStopColor(element, out OfficeColor color)) return false;
+                if (!TryStopColor(element, inheritedCurrentColor, out OfficeColor color)) return false;
                 parsed.Add(new OfficeGradientStop(offset, color));
                 previous = offset;
             }
@@ -323,9 +324,11 @@ public static partial class OfficeSvgDrawingReader {
             return TryUnitOrPercentage(value!, clamp: true, out offset);
         }
 
-        private static bool TryStopColor(XElement element, out OfficeColor color) {
+        private static bool TryStopColor(XElement element, OfficeColor inheritedCurrentColor,
+            out OfficeColor color) {
             color = OfficeColor.Black;
-            if (!TryResolveCurrentColor(element, out OfficeColor currentColor)) return false;
+            OfficeColor currentColor = inheritedCurrentColor;
+            string? currentColorText = element.Attribute("color")?.Value;
             string? colorText = element.Attribute("stop-color")?.Value;
             string? opacityText = element.Attribute("stop-opacity")?.Value;
             string? declarations = element.Attribute("style")?.Value;
@@ -337,8 +340,13 @@ public static partial class OfficeSvgDrawingReader {
                     string value = declaration.Substring(colon + 1).Trim();
                     if (name.Equals("stop-color", StringComparison.OrdinalIgnoreCase)) colorText = value;
                     else if (name.Equals("stop-opacity", StringComparison.OrdinalIgnoreCase)) opacityText = value;
+                    else if (name.Equals("color", StringComparison.OrdinalIgnoreCase)) currentColorText = value;
                 }
             }
+
+            if (!string.IsNullOrWhiteSpace(currentColorText) &&
+                !currentColorText!.Trim().Equals("currentcolor", StringComparison.OrdinalIgnoreCase) &&
+                !OfficeColor.TryParse(currentColorText.Trim(), out currentColor)) return false;
 
             if (string.IsNullOrWhiteSpace(colorText)) color = OfficeColor.Black;
             else if (colorText!.Trim().Equals("currentcolor", StringComparison.OrdinalIgnoreCase)) color = currentColor;

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.References.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.References.cs
@@ -18,7 +18,9 @@ public static partial class OfficeSvgDrawingReader {
         double viewX,
         double viewY,
         int maximumElements,
+        int depth,
         ref int visited,
+        ref int pathCommands,
         ref int unsupported) {
         if (!references.TryEnter(use, out string referenceId, out XElement? target)) {
             unsupported++;
@@ -32,7 +34,8 @@ public static partial class OfficeSvgDrawingReader {
                 return;
             }
             if (targetName == "symbol") {
-                AddReferencedSymbol(use, target, drawing, style, paintServers, references, transform, maximumElements, ref visited, ref unsupported);
+                AddReferencedSymbol(use, target, drawing, style, paintServers, references, transform,
+                    maximumElements, depth, ref visited, ref pathCommands, ref unsupported);
                 return;
             }
             if (!TryOptionalUseLength(use, "x", out double x) || !TryOptionalUseLength(use, "y", out double y)) {
@@ -41,7 +44,8 @@ public static partial class OfficeSvgDrawingReader {
             }
 
             OfficeTransform placement = OfficeTransform.Translate(x, y).Then(transform);
-            AddElement(target, drawing, style, paintServers, references, placement, viewX, viewY, maximumElements, ref visited, ref unsupported);
+            AddElement(target, drawing, style, paintServers, references, placement, viewX, viewY,
+                maximumElements, depth, ref visited, ref pathCommands, ref unsupported);
         } finally {
             references.Exit(referenceId);
         }

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.References.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.References.cs
@@ -18,6 +18,8 @@ public static partial class OfficeSvgDrawingReader {
         double viewX,
         double viewY,
         int maximumElements,
+        double maximumViewportDimension,
+        double maximumViewportPixels,
         int depth,
         ref int visited,
         ref int pathCommands,
@@ -35,7 +37,8 @@ public static partial class OfficeSvgDrawingReader {
             }
             if (targetName == "symbol") {
                 AddReferencedSymbol(use, target, drawing, style, paintServers, references, transform,
-                    maximumElements, depth, ref visited, ref pathCommands, ref unsupported);
+                    maximumElements, maximumViewportDimension, maximumViewportPixels, depth,
+                    ref visited, ref pathCommands, ref unsupported);
                 return;
             }
             if (!TryOptionalUseLength(use, "x", out double x) || !TryOptionalUseLength(use, "y", out double y)) {
@@ -45,7 +48,8 @@ public static partial class OfficeSvgDrawingReader {
 
             OfficeTransform placement = OfficeTransform.Translate(x, y).Then(transform);
             AddElement(target, drawing, style, paintServers, references, placement, viewX, viewY,
-                maximumElements, depth, ref visited, ref pathCommands, ref unsupported);
+                maximumElements, maximumViewportDimension, maximumViewportPixels, depth,
+                ref visited, ref pathCommands, ref unsupported);
         } finally {
             references.Exit(referenceId);
         }

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.Symbols.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.Symbols.cs
@@ -14,6 +14,8 @@ public static partial class OfficeSvgDrawingReader {
         SvgElementReferenceRegistry references,
         OfficeTransform inheritedTransform,
         int maximumElements,
+        double maximumViewportDimension,
+        double maximumViewportPixels,
         int depth,
         ref int visited,
         ref int pathCommands,
@@ -22,14 +24,14 @@ public static partial class OfficeSvgDrawingReader {
             || viewBox.Count != 4
             || viewBox[2] <= 0D
             || viewBox[3] <= 0D
-            || !IsSupportedSvgViewport(viewBox[2], viewBox[3])
+            || !IsSupportedSvgViewport(viewBox[2], viewBox[3], maximumViewportDimension, maximumViewportPixels)
             || !TrySymbolLength(use, symbol, "width", viewBox[2], out double width)
             || !TrySymbolLength(use, symbol, "height", viewBox[3], out double height)
             || !TryOptionalUseLength(use, "x", out double x)
             || !TryOptionalUseLength(use, "y", out double y)
             || width <= 0D
             || height <= 0D
-            || !IsSupportedSvgViewport(width, height)) {
+            || !IsSupportedSvgViewport(width, height, maximumViewportDimension, maximumViewportPixels)) {
             unsupported++;
             return;
         }
@@ -46,7 +48,8 @@ public static partial class OfficeSvgDrawingReader {
         SvgPaintContext style = ResolvePaintContext(symbol, inheritedStyle, paintServers, ref unsupported);
         OfficeTransform symbolTransform = ResolveTransform(symbol, OfficeTransform.Identity, viewBox[0], viewBox[1], ref unsupported);
         AddChildren(symbol, scene, style, paintServers, references, symbolTransform, viewBox[0], viewBox[1],
-            maximumElements, depth, ref visited, ref pathCommands, ref unsupported);
+            maximumElements, maximumViewportDimension, maximumViewportPixels, depth,
+            ref visited, ref pathCommands, ref unsupported);
 
         OfficeTransform viewportTransform;
         if (alignment == SvgAspectAlignment.None) {

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.Symbols.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.Symbols.cs
@@ -14,18 +14,22 @@ public static partial class OfficeSvgDrawingReader {
         SvgElementReferenceRegistry references,
         OfficeTransform inheritedTransform,
         int maximumElements,
+        int depth,
         ref int visited,
+        ref int pathCommands,
         ref int unsupported) {
         if (!TryParseNumberList(symbol.Attribute("viewBox")?.Value, out IReadOnlyList<double> viewBox)
             || viewBox.Count != 4
             || viewBox[2] <= 0D
             || viewBox[3] <= 0D
+            || !IsSupportedSvgViewport(viewBox[2], viewBox[3])
             || !TrySymbolLength(use, symbol, "width", viewBox[2], out double width)
             || !TrySymbolLength(use, symbol, "height", viewBox[3], out double height)
             || !TryOptionalUseLength(use, "x", out double x)
             || !TryOptionalUseLength(use, "y", out double y)
             || width <= 0D
-            || height <= 0D) {
+            || height <= 0D
+            || !IsSupportedSvgViewport(width, height)) {
             unsupported++;
             return;
         }
@@ -41,7 +45,8 @@ public static partial class OfficeSvgDrawingReader {
         var scene = new OfficeDrawing(viewBox[2], viewBox[3]);
         SvgPaintContext style = ResolvePaintContext(symbol, inheritedStyle, paintServers, ref unsupported);
         OfficeTransform symbolTransform = ResolveTransform(symbol, OfficeTransform.Identity, viewBox[0], viewBox[1], ref unsupported);
-        AddChildren(symbol, scene, style, paintServers, references, symbolTransform, viewBox[0], viewBox[1], maximumElements, ref visited, ref unsupported);
+        AddChildren(symbol, scene, style, paintServers, references, symbolTransform, viewBox[0], viewBox[1],
+            maximumElements, depth, ref visited, ref pathCommands, ref unsupported);
 
         OfficeTransform viewportTransform;
         if (alignment == SvgAspectAlignment.None) {

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.Text.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.Text.cs
@@ -21,7 +21,8 @@ public static partial class OfficeSvgDrawingReader {
         var runs = new List<SvgTextRun>();
         var cursor = new SvgTextCursor { Chunk = -1 };
         bool preserve = string.Equals(element.Attribute(XNamespace.Xml + "space")?.Value, "preserve", StringComparison.OrdinalIgnoreCase);
-        AddTextElementRuns(element, style, paintServers, transform, preserve, false, viewX, viewY, drawing.Width, drawing.Height, runs, ref cursor, ref unsupported);
+        AddTextElementRuns(element, style, paintServers, transform, preserve, false, viewX, viewY,
+            drawing.Width, drawing.Height, runs, 0, ref cursor, ref unsupported);
         if (runs.Count == 0) return;
         ApplyTextAnchors(runs);
         foreach (SvgTextRun run in runs) AddTextRun(drawing, run, ref unsupported);
@@ -39,8 +40,13 @@ public static partial class OfficeSvgDrawingReader {
         double viewportWidth,
         double viewportHeight,
         ICollection<SvgTextRun> runs,
+        int depth,
         ref SvgTextCursor cursor,
         ref int unsupported) {
+        if (depth > MaximumSvgNestingDepth) {
+            unsupported++;
+            return;
+        }
         if (runs.Count >= MaximumTextRuns) {
             ReportTextRunLimit(ref cursor, ref unsupported);
             return;
@@ -82,7 +88,8 @@ public static partial class OfficeSvgDrawingReader {
                 continue;
             }
             if (node is XElement child && child.Name.LocalName.Equals("tspan", StringComparison.OrdinalIgnoreCase)) {
-                AddTextElementRuns(child, style, paintServers, transform, preserve, true, viewX, viewY, viewportWidth, viewportHeight, runs, ref cursor, ref unsupported);
+                AddTextElementRuns(child, style, paintServers, transform, preserve, true, viewX, viewY,
+                    viewportWidth, viewportHeight, runs, depth + 1, ref cursor, ref unsupported);
             } else if (node is XElement) {
                 unsupported++;
             }

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
@@ -182,8 +182,8 @@ public static partial class OfficeSvgDrawingReader {
             "circle" => CreateCircle(element, style, viewX, viewY, drawing.Width, drawing.Height),
             "ellipse" => CreateEllipse(element, style, viewX, viewY, drawing.Width, drawing.Height),
             "line" => CreateLine(element, style, viewX, viewY, drawing.Width, drawing.Height),
-            "polygon" => CreatePolygon(element, style, viewX, viewY, close: true),
-            "polyline" => CreatePolygon(element, style, viewX, viewY, close: false),
+            "polygon" => CreatePolygon(element, style, viewX, viewY, close: true, ref pathCommands),
+            "polyline" => CreatePolygon(element, style, viewX, viewY, close: false, ref pathCommands),
             "path" => CreatePath(element, style, viewX, viewY, ref pathCommands),
             _ => null
         };
@@ -333,8 +333,24 @@ public static partial class OfficeSvgDrawingReader {
         return new OfficeDrawingShape(shape, x, y);
     }
 
-    private static OfficeDrawingShape? CreatePolygon(XElement element, SvgPaintContext style, double viewX, double viewY, bool close) {
-        if (!TryParseNumberList(element.Attribute("points")?.Value, out IReadOnlyList<double> values) || values.Count < 4 || values.Count % 2 != 0) return null;
+    private static OfficeDrawingShape? CreatePolygon(XElement element, SvgPaintContext style, double viewX,
+        double viewY, bool close, ref int pathCommands) {
+        int remainingCommands = MaximumSvgPathCommands - pathCommands;
+        if (remainingCommands <= 0
+            || !TryParseNumberList(element.Attribute("points")?.Value, remainingCommands * 2,
+                out IReadOnlyList<double> values)
+            || values.Count < 4
+            || values.Count % 2 != 0) {
+            pathCommands = MaximumSvgPathCommands;
+            return null;
+        }
+        int commandCount = values.Count / 2;
+        if (close) commandCount++;
+        if (commandCount > remainingCommands) {
+            pathCommands = MaximumSvgPathCommands;
+            return null;
+        }
+        pathCommands += commandCount;
         var points = new List<OfficePoint>(values.Count / 2);
         for (int index = 0; index < values.Count; index += 2) points.Add(new OfficePoint(values[index] - viewX, values[index + 1] - viewY));
         double minX = points.Min(point => point.X);
@@ -676,13 +692,25 @@ public static partial class OfficeSvgDrawingReader {
         && result >= 0D
         && result <= 1D;
 
-    private static bool TryParseNumberList(string? value, out IReadOnlyList<double> values) {
-        var result = new List<double>();
+    private static bool TryParseNumberList(string? value, out IReadOnlyList<double> values) =>
+        TryParseNumberList(value, int.MaxValue, out values);
+
+    private static bool TryParseNumberList(string? value, int maximumValues,
+        out IReadOnlyList<double> values) {
+        var result = new List<double>(Math.Min(maximumValues, 16));
         values = result;
-        if (string.IsNullOrWhiteSpace(value)) return false;
-        string normalized = value!.Replace(',', ' ');
-        foreach (string part in normalized.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)) {
-            if (!double.TryParse(part, NumberStyles.Float, CultureInfo.InvariantCulture, out double number)
+        if (maximumValues <= 0 || string.IsNullOrWhiteSpace(value)) return false;
+        int index = 0;
+        while (index < value!.Length) {
+            while (index < value.Length && (char.IsWhiteSpace(value[index]) || value[index] == ',')) index++;
+            if (index >= value.Length) break;
+            if (result.Count >= maximumValues) return false;
+            int start = index;
+            while (index < value.Length && !char.IsWhiteSpace(value[index]) && value[index] != ',') index++;
+            int length = index - start;
+            if (length <= 0 || length > 128
+                || !double.TryParse(value.Substring(start, length), NumberStyles.Float,
+                    CultureInfo.InvariantCulture, out double number)
                 || double.IsNaN(number)
                 || double.IsInfinity(number)) return false;
             result.Add(number);

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
@@ -336,12 +336,14 @@ public static partial class OfficeSvgDrawingReader {
     private static OfficeDrawingShape? CreatePolygon(XElement element, SvgPaintContext style, double viewX,
         double viewY, bool close, ref int pathCommands) {
         int remainingCommands = MaximumSvgPathCommands - pathCommands;
-        if (remainingCommands <= 0
-            || !TryParseNumberList(element.Attribute("points")?.Value, remainingCommands * 2,
-                out IReadOnlyList<double> values)
-            || values.Count < 4
-            || values.Count % 2 != 0) {
+        if (remainingCommands <= 0) {
             pathCommands = MaximumSvgPathCommands;
+            return null;
+        }
+        bool parsed = TryParseNumberList(element.Attribute("points")?.Value, remainingCommands * 2,
+            out IReadOnlyList<double> values, out bool limitExceeded);
+        if (!parsed || values.Count < 4 || values.Count % 2 != 0) {
+            if (limitExceeded) pathCommands = MaximumSvgPathCommands;
             return null;
         }
         int commandCount = values.Count / 2;
@@ -696,15 +698,23 @@ public static partial class OfficeSvgDrawingReader {
         TryParseNumberList(value, int.MaxValue, out values);
 
     private static bool TryParseNumberList(string? value, int maximumValues,
-        out IReadOnlyList<double> values) {
+        out IReadOnlyList<double> values) =>
+        TryParseNumberList(value, maximumValues, out values, out _);
+
+    private static bool TryParseNumberList(string? value, int maximumValues,
+        out IReadOnlyList<double> values, out bool limitExceeded) {
         var result = new List<double>(Math.Min(maximumValues, 16));
         values = result;
+        limitExceeded = false;
         if (maximumValues <= 0 || string.IsNullOrWhiteSpace(value)) return false;
         int index = 0;
         while (index < value!.Length) {
             while (index < value.Length && (char.IsWhiteSpace(value[index]) || value[index] == ',')) index++;
             if (index >= value.Length) break;
-            if (result.Count >= maximumValues) return false;
+            if (result.Count >= maximumValues) {
+                limitExceeded = true;
+                return false;
+            }
             int start = index;
             while (index < value.Length && !char.IsWhiteSpace(value[index]) && value[index] != ',') index++;
             int length = index - start;

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
@@ -13,6 +13,12 @@ namespace OfficeIMO.Drawing;
 /// </summary>
 public static partial class OfficeSvgDrawingReader {
     private const int MaximumInputBytes = 8 * 1024 * 1024;
+    private const int MaximumSvgNestingDepth = 128;
+    private const int MaximumSvgPathCommands = 20000;
+    private const double MaximumSvgViewportDimension = 8192D;
+    private const double MaximumSvgViewportPixels = 16D * 1024D * 1024D;
+    private const double MaximumSvgTransformCoefficient = 1024D;
+    private const double MaximumSvgTransformOffset = 1000000D;
 
     /// <summary>Attempts to interpret supported SVG vector primitives as a shared drawing.</summary>
     public static bool TryRead(byte[]? bytes, out OfficeDrawing? drawing) =>
@@ -63,15 +69,17 @@ public static partial class OfficeSvgDrawingReader {
 
             var result = new OfficeDrawing(width, height);
             int visited = 0;
+            int pathCommands = 0;
             SvgDefinitionRegistry definitions = SvgDefinitionRegistry.Create(root);
             var paintServers = new SvgPaintServerRegistry(definitions);
             var references = new SvgElementReferenceRegistry(definitions);
             var context = ResolvePaintContext(root, SvgPaintContext.Default, paintServers, ref unsupportedFeatureCount);
             OfficeTransform rootTransform = ResolveTransform(root, OfficeTransform.Identity, viewX, viewY, ref unsupportedFeatureCount);
-            AddChildren(root, result, context, paintServers, references, rootTransform, viewX, viewY, maximumElements, ref visited, ref unsupportedFeatureCount);
+            AddChildren(root, result, context, paintServers, references, rootTransform, viewX, viewY,
+                maximumElements, 0, ref visited, ref pathCommands, ref unsupportedFeatureCount);
             if (visited > maximumElements) return false;
             drawing = result;
-            return true;
+            return IsSupportedSvgViewport(width, height);
         } catch (XmlException) {
             return false;
         } catch (InvalidOperationException) {
@@ -98,8 +106,13 @@ public static partial class OfficeSvgDrawingReader {
         if (!OfficeImageReader.TryIdentify(bytes, ".svg", out OfficeImageInfo info) || info.Width <= 0 || info.Height <= 0) return false;
         width = info.Width * 96D / Math.Max(1D, info.DpiX);
         height = info.Height * 96D / Math.Max(1D, info.DpiY);
-        return width > 0D && height > 0D;
+        return IsSupportedSvgViewport(width, height);
     }
+
+    private static bool IsSupportedSvgViewport(double width, double height) =>
+        width > 0D && height > 0D &&
+        width <= MaximumSvgViewportDimension && height <= MaximumSvgViewportDimension &&
+        width * height <= MaximumSvgViewportPixels;
 
     private static void AddChildren(
         XElement parent,
@@ -111,10 +124,17 @@ public static partial class OfficeSvgDrawingReader {
         double viewX,
         double viewY,
         int maximumElements,
+        int depth,
         ref int visited,
+        ref int pathCommands,
         ref int unsupported) {
+        if (depth > MaximumSvgNestingDepth) {
+            unsupported++;
+            return;
+        }
         foreach (XElement element in parent.Elements()) {
-            AddElement(element, drawing, inherited, paintServers, references, inheritedTransform, viewX, viewY, maximumElements, ref visited, ref unsupported);
+            AddElement(element, drawing, inherited, paintServers, references, inheritedTransform, viewX, viewY,
+                maximumElements, depth, ref visited, ref pathCommands, ref unsupported);
             if (visited > maximumElements) return;
         }
     }
@@ -129,7 +149,9 @@ public static partial class OfficeSvgDrawingReader {
         double viewX,
         double viewY,
         int maximumElements,
+        int depth,
         ref int visited,
+        ref int pathCommands,
         ref int unsupported) {
         visited++;
         if (visited > maximumElements) return;
@@ -141,11 +163,13 @@ public static partial class OfficeSvgDrawingReader {
         if (!style.Visible) return;
         OfficeTransform transform = ResolveTransform(element, inheritedTransform, viewX, viewY, ref unsupported);
         if (name is "g" or "svg" or "a" or "switch") {
-            AddChildren(element, drawing, style, paintServers, references, transform, viewX, viewY, maximumElements, ref visited, ref unsupported);
+            AddChildren(element, drawing, style, paintServers, references, transform, viewX, viewY,
+                maximumElements, depth + 1, ref visited, ref pathCommands, ref unsupported);
             return;
         }
         if (name == "use") {
-            AddReferencedElement(element, drawing, style, paintServers, references, transform, viewX, viewY, maximumElements, ref visited, ref unsupported);
+            AddReferencedElement(element, drawing, style, paintServers, references, transform, viewX, viewY,
+                maximumElements, depth + 1, ref visited, ref pathCommands, ref unsupported);
             return;
         }
         if (name == "text") {
@@ -160,7 +184,7 @@ public static partial class OfficeSvgDrawingReader {
             "line" => CreateLine(element, style, viewX, viewY, drawing.Width, drawing.Height),
             "polygon" => CreatePolygon(element, style, viewX, viewY, close: true),
             "polyline" => CreatePolygon(element, style, viewX, viewY, close: false),
-            "path" => CreatePath(element, style, viewX, viewY),
+            "path" => CreatePath(element, style, viewX, viewY, ref pathCommands),
             _ => null
         };
         if (shape == null) {
@@ -194,8 +218,21 @@ public static partial class OfficeSvgDrawingReader {
         OfficeTransform normalized = OfficeTransform.Translate(viewX, viewY)
             .Then(parsed)
             .Then(OfficeTransform.Translate(-viewX, -viewY));
-        return normalized.Then(inherited);
+        OfficeTransform combined = normalized.Then(inherited);
+        if (!IsSupportedSvgTransform(combined)) {
+            unsupported++;
+            return inherited;
+        }
+        return combined;
     }
+
+    private static bool IsSupportedSvgTransform(OfficeTransform transform) =>
+        Math.Abs(transform.M11) <= MaximumSvgTransformCoefficient &&
+        Math.Abs(transform.M12) <= MaximumSvgTransformCoefficient &&
+        Math.Abs(transform.M21) <= MaximumSvgTransformCoefficient &&
+        Math.Abs(transform.M22) <= MaximumSvgTransformCoefficient &&
+        Math.Abs(transform.OffsetX) <= MaximumSvgTransformOffset &&
+        Math.Abs(transform.OffsetY) <= MaximumSvgTransformOffset;
 
     private static void ApplyTransform(OfficeDrawingShape drawingShape, OfficeTransform transform) {
         if (transform == OfficeTransform.Identity) return;
@@ -320,8 +357,16 @@ public static partial class OfficeSvgDrawingReader {
         return new OfficeDrawingShape(shape, minX, minY);
     }
 
-    private static OfficeDrawingShape? CreatePath(XElement element, SvgPaintContext style, double viewX, double viewY) {
-        if (!OfficeSvgPathDataParser.TryParse(element.Attribute("d")?.Value, out IReadOnlyList<OfficePathCommand> parsed)) return null;
+    private static OfficeDrawingShape? CreatePath(XElement element, SvgPaintContext style, double viewX,
+        double viewY, ref int pathCommands) {
+        int remaining = MaximumSvgPathCommands - pathCommands;
+        if (remaining <= 0) return null;
+        if (!OfficeSvgPathDataParser.TryParse(element.Attribute("d")?.Value, remaining,
+                out IReadOnlyList<OfficePathCommand> parsed)) {
+            pathCommands = MaximumSvgPathCommands;
+            return null;
+        }
+        pathCommands += parsed.Count;
         var commands = new List<OfficePathCommand>(parsed.Count + 1);
         double minX = double.PositiveInfinity;
         double minY = double.PositiveInfinity;

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
@@ -371,18 +371,19 @@ public static partial class OfficeSvgDrawingReader {
         }
         int commandCount = values.Count / 2;
         if (close) commandCount++;
+        if (close && values.Count < 6) {
+            return null;
+        }
         if (commandCount > remainingCommands) {
             pathCommands = MaximumSvgPathCommands;
             return null;
         }
-        pathCommands += commandCount;
         var points = new List<OfficePoint>(values.Count / 2);
         for (int index = 0; index < values.Count; index += 2) points.Add(new OfficePoint(values[index] - viewX, values[index + 1] - viewY));
         double minX = points.Min(point => point.X);
         double minY = points.Min(point => point.Y);
         OfficeShape shape;
         if (close) {
-            if (points.Count < 3) return null;
             shape = OfficeShape.Polygon(points);
         } else {
             var commands = new List<OfficePathCommand> { OfficePathCommand.MoveTo(points[0]) };
@@ -394,6 +395,7 @@ public static partial class OfficeSvgDrawingReader {
             }
             shape.FillColor = null;
         }
+        pathCommands += commandCount;
         ApplyPaint(shape, style);
         return new OfficeDrawingShape(shape, minX, minY);
     }

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
@@ -15,8 +15,6 @@ public static partial class OfficeSvgDrawingReader {
     private const int MaximumInputBytes = 8 * 1024 * 1024;
     private const int MaximumSvgNestingDepth = 128;
     private const int MaximumSvgPathCommands = 20000;
-    private const double MaximumSvgViewportDimension = 8192D;
-    private const double MaximumSvgViewportPixels = 16D * 1024D * 1024D;
     private const double MaximumSvgTransformCoefficient = 1024D;
     private const double MaximumSvgTransformOffset = 1000000D;
 
@@ -48,7 +46,11 @@ public static partial class OfficeSvgDrawingReader {
         unsupportedFeatureCount = 0;
         if (bytes == null || bytes.Length == 0 || bytes.Length > MaximumInputBytes) return false;
         int maximumElements = options?.MaximumElements ?? OfficeSvgDrawingReaderOptions.DefaultMaximumElements;
+        double maximumViewportDimension = options?.MaximumViewportDimension ?? OfficeSvgDrawingReaderOptions.DefaultMaximumViewportDimension;
+        double maximumViewportPixels = options?.MaximumViewportPixels ?? OfficeSvgDrawingReaderOptions.DefaultMaximumViewportPixels;
         if (maximumElements <= 0 || maximumElements > OfficeSvgDrawingReaderOptions.MaximumAllowedElements) return false;
+        if (maximumViewportDimension <= 0D || maximumViewportDimension > OfficeSvgDrawingReaderOptions.MaximumAllowedViewportDimension ||
+            maximumViewportPixels <= 0D || maximumViewportPixels > OfficeSvgDrawingReaderOptions.MaximumAllowedViewportPixels) return false;
 
         try {
             var settings = new XmlReaderSettings {
@@ -65,7 +67,8 @@ public static partial class OfficeSvgDrawingReader {
             XElement? root = document.Root;
             if (root == null || !string.Equals(root.Name.LocalName, "svg", StringComparison.OrdinalIgnoreCase)) return false;
             if (root.Descendants().Take(maximumElements + 1).Count() > maximumElements) return false;
-            if (!TryResolveViewport(bytes, root, out double viewX, out double viewY, out double width, out double height)) return false;
+            if (!TryResolveViewport(bytes, root, maximumViewportDimension, maximumViewportPixels,
+                    out double viewX, out double viewY, out double width, out double height)) return false;
 
             var result = new OfficeDrawing(width, height);
             int visited = 0;
@@ -76,10 +79,11 @@ public static partial class OfficeSvgDrawingReader {
             var context = ResolvePaintContext(root, SvgPaintContext.Default, paintServers, ref unsupportedFeatureCount);
             OfficeTransform rootTransform = ResolveTransform(root, OfficeTransform.Identity, viewX, viewY, ref unsupportedFeatureCount);
             AddChildren(root, result, context, paintServers, references, rootTransform, viewX, viewY,
-                maximumElements, 0, ref visited, ref pathCommands, ref unsupportedFeatureCount);
+                maximumElements, maximumViewportDimension, maximumViewportPixels, 0,
+                ref visited, ref pathCommands, ref unsupportedFeatureCount);
             if (visited > maximumElements) return false;
             drawing = result;
-            return IsSupportedSvgViewport(width, height);
+            return IsSupportedSvgViewport(width, height, maximumViewportDimension, maximumViewportPixels);
         } catch (XmlException) {
             return false;
         } catch (InvalidOperationException) {
@@ -89,7 +93,15 @@ public static partial class OfficeSvgDrawingReader {
         }
     }
 
-    private static bool TryResolveViewport(byte[] bytes, XElement root, out double viewX, out double viewY, out double width, out double height) {
+    private static bool TryResolveViewport(
+        byte[] bytes,
+        XElement root,
+        double maximumViewportDimension,
+        double maximumViewportPixels,
+        out double viewX,
+        out double viewY,
+        out double width,
+        out double height) {
         viewX = viewY = 0D;
         width = height = 0D;
         if (TryParseNumberList(root.Attribute("viewBox")?.Value, out IReadOnlyList<double> viewBox)
@@ -100,19 +112,23 @@ public static partial class OfficeSvgDrawingReader {
             viewY = viewBox[1];
             width = viewBox[2];
             height = viewBox[3];
-            return true;
+            return IsSupportedSvgViewport(width, height, maximumViewportDimension, maximumViewportPixels);
         }
 
         if (!OfficeImageReader.TryIdentify(bytes, ".svg", out OfficeImageInfo info) || info.Width <= 0 || info.Height <= 0) return false;
         width = info.Width * 96D / Math.Max(1D, info.DpiX);
         height = info.Height * 96D / Math.Max(1D, info.DpiY);
-        return IsSupportedSvgViewport(width, height);
+        return IsSupportedSvgViewport(width, height, maximumViewportDimension, maximumViewportPixels);
     }
 
-    private static bool IsSupportedSvgViewport(double width, double height) =>
+    private static bool IsSupportedSvgViewport(
+        double width,
+        double height,
+        double maximumViewportDimension,
+        double maximumViewportPixels) =>
         width > 0D && height > 0D &&
-        width <= MaximumSvgViewportDimension && height <= MaximumSvgViewportDimension &&
-        width * height <= MaximumSvgViewportPixels;
+        width <= maximumViewportDimension && height <= maximumViewportDimension &&
+        width * height <= maximumViewportPixels;
 
     private static void AddChildren(
         XElement parent,
@@ -124,6 +140,8 @@ public static partial class OfficeSvgDrawingReader {
         double viewX,
         double viewY,
         int maximumElements,
+        double maximumViewportDimension,
+        double maximumViewportPixels,
         int depth,
         ref int visited,
         ref int pathCommands,
@@ -134,7 +152,8 @@ public static partial class OfficeSvgDrawingReader {
         }
         foreach (XElement element in parent.Elements()) {
             AddElement(element, drawing, inherited, paintServers, references, inheritedTransform, viewX, viewY,
-                maximumElements, depth, ref visited, ref pathCommands, ref unsupported);
+                maximumElements, maximumViewportDimension, maximumViewportPixels, depth,
+                ref visited, ref pathCommands, ref unsupported);
             if (visited > maximumElements) return;
         }
     }
@@ -149,6 +168,8 @@ public static partial class OfficeSvgDrawingReader {
         double viewX,
         double viewY,
         int maximumElements,
+        double maximumViewportDimension,
+        double maximumViewportPixels,
         int depth,
         ref int visited,
         ref int pathCommands,
@@ -164,12 +185,14 @@ public static partial class OfficeSvgDrawingReader {
         OfficeTransform transform = ResolveTransform(element, inheritedTransform, viewX, viewY, ref unsupported);
         if (name is "g" or "svg" or "a" or "switch") {
             AddChildren(element, drawing, style, paintServers, references, transform, viewX, viewY,
-                maximumElements, depth + 1, ref visited, ref pathCommands, ref unsupported);
+                maximumElements, maximumViewportDimension, maximumViewportPixels, depth + 1,
+                ref visited, ref pathCommands, ref unsupported);
             return;
         }
         if (name == "use") {
             AddReferencedElement(element, drawing, style, paintServers, references, transform, viewX, viewY,
-                maximumElements, depth + 1, ref visited, ref pathCommands, ref unsupported);
+                maximumElements, maximumViewportDimension, maximumViewportPixels, depth + 1,
+                ref visited, ref pathCommands, ref unsupported);
             return;
         }
         if (name == "text") {

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReader.cs
@@ -378,8 +378,8 @@ public static partial class OfficeSvgDrawingReader {
         int remaining = MaximumSvgPathCommands - pathCommands;
         if (remaining <= 0) return null;
         if (!OfficeSvgPathDataParser.TryParse(element.Attribute("d")?.Value, remaining,
-                out IReadOnlyList<OfficePathCommand> parsed)) {
-            pathCommands = MaximumSvgPathCommands;
+                out IReadOnlyList<OfficePathCommand> parsed, out bool commandLimitExceeded)) {
+            if (commandLimitExceeded) pathCommands = MaximumSvgPathCommands;
             return null;
         }
         pathCommands += parsed.Count;

--- a/OfficeIMO.Drawing/OfficeSvgDrawingReaderOptions.cs
+++ b/OfficeIMO.Drawing/OfficeSvgDrawingReaderOptions.cs
@@ -10,8 +10,26 @@ public sealed class OfficeSvgDrawingReaderOptions {
     /// <summary>Hard maximum accepted by the reader, even when explicitly requested.</summary>
     public const int MaximumAllowedElements = 100000;
 
+    /// <summary>Default maximum width or height of an imported SVG viewport.</summary>
+    public const double DefaultMaximumViewportDimension = 8192D;
+
+    /// <summary>Hard maximum viewport dimension accepted for explicitly trusted SVG input.</summary>
+    public const double MaximumAllowedViewportDimension = 1000000D;
+
+    /// <summary>Default maximum viewport area accepted by the reader.</summary>
+    public const double DefaultMaximumViewportPixels = 16D * 1024D * 1024D;
+
+    /// <summary>Hard maximum viewport area accepted for explicitly trusted SVG input.</summary>
+    public const double MaximumAllowedViewportPixels = 256D * 1024D * 1024D;
+
     /// <summary>
     /// Maximum number of descendant and expanded reference elements. Increase this only for trusted SVG input.
     /// </summary>
     public int MaximumElements { get; set; } = DefaultMaximumElements;
+
+    /// <summary>Maximum SVG viewport width or height. Increase this only for trusted SVG input.</summary>
+    public double MaximumViewportDimension { get; set; } = DefaultMaximumViewportDimension;
+
+    /// <summary>Maximum SVG viewport width-times-height area. Increase this only for trusted SVG input.</summary>
+    public double MaximumViewportPixels { get; set; } = DefaultMaximumViewportPixels;
 }

--- a/OfficeIMO.Drawing/OfficeSvgPathDataParser.cs
+++ b/OfficeIMO.Drawing/OfficeSvgPathDataParser.cs
@@ -5,9 +5,8 @@ using System.Globalization;
 namespace OfficeIMO.Drawing;
 
 internal static class OfficeSvgPathDataParser {
-    private const int MaximumCommands = 100000;
-
-    internal static bool TryParse(string? data, out IReadOnlyList<OfficePathCommand> commands) {
+    internal static bool TryParse(string? data, int maximumCommands,
+        out IReadOnlyList<OfficePathCommand> commands) {
         var result = new List<OfficePathCommand>();
         commands = result;
         if (string.IsNullOrWhiteSpace(data)) return false;
@@ -23,7 +22,7 @@ internal static class OfficeSvgPathDataParser {
         bool hasDraw = false;
 
         while (reader.SkipSeparators()) {
-            if (result.Count >= MaximumCommands) return false;
+            if (result.Count >= maximumCommands) return false;
             if (reader.TryReadCommand(out char explicitCommand)) command = explicitCommand;
             else if (command == '\0' || command is 'Z' or 'z') return false;
             bool relative = char.IsLower(command);
@@ -40,7 +39,7 @@ internal static class OfficeSvgPathDataParser {
 
             int groups = 0;
             while (reader.HasNumberAhead()) {
-                if (result.Count >= MaximumCommands) return false;
+                if (result.Count >= maximumCommands) return false;
                 switch (upper) {
                     case 'M':
                     case 'L':

--- a/OfficeIMO.Drawing/OfficeSvgPathDataParser.cs
+++ b/OfficeIMO.Drawing/OfficeSvgPathDataParser.cs
@@ -6,9 +6,11 @@ namespace OfficeIMO.Drawing;
 
 internal static class OfficeSvgPathDataParser {
     internal static bool TryParse(string? data, int maximumCommands,
-        out IReadOnlyList<OfficePathCommand> commands) {
+        out IReadOnlyList<OfficePathCommand> commands,
+        out bool commandLimitExceeded) {
         var result = new List<OfficePathCommand>();
         commands = result;
+        commandLimitExceeded = false;
         if (string.IsNullOrWhiteSpace(data)) return false;
 
         var reader = new PathReader(data!);
@@ -22,7 +24,10 @@ internal static class OfficeSvgPathDataParser {
         bool hasDraw = false;
 
         while (reader.SkipSeparators()) {
-            if (result.Count >= maximumCommands) return false;
+            if (result.Count >= maximumCommands) {
+                commandLimitExceeded = true;
+                return false;
+            }
             if (reader.TryReadCommand(out char explicitCommand)) command = explicitCommand;
             else if (command == '\0' || command is 'Z' or 'z') return false;
             bool relative = char.IsLower(command);
@@ -39,7 +44,10 @@ internal static class OfficeSvgPathDataParser {
 
             int groups = 0;
             while (reader.HasNumberAhead()) {
-                if (result.Count >= maximumCommands) return false;
+                if (result.Count >= maximumCommands) {
+                    commandLimitExceeded = true;
+                    return false;
+                }
                 switch (upper) {
                     case 'M':
                     case 'L':
@@ -125,6 +133,10 @@ internal static class OfficeSvgPathDataParser {
                             || !reader.TryReadPoint(out OfficePoint arcEnd)) return false;
                         arcEnd = Resolve(arcEnd, current, relative);
                         if (!AppendArc(result, current, arcEnd, radiusX, radiusY, rotationDegrees, largeArc, sweep)) return false;
+                        if (result.Count > maximumCommands) {
+                            commandLimitExceeded = true;
+                            return false;
+                        }
                         current = arcEnd;
                         hasDraw = true;
                         break;

--- a/OfficeIMO.Drawing/OfficeSvgTransformParser.cs
+++ b/OfficeIMO.Drawing/OfficeSvgTransformParser.cs
@@ -23,7 +23,7 @@ internal static class OfficeSvgTransformParser {
             int argumentsStart = index;
             int close = value.IndexOf(')', index);
             if (close < 0) return false;
-            if (!TryParseNumbers(value.Substring(argumentsStart, close - argumentsStart), out IReadOnlyList<double> arguments)
+            if (!TryParseNumbers(value, argumentsStart, close, 6, out IReadOnlyList<double> arguments)
                 || !TryCreateTransform(name, arguments, out OfficeTransform current)) return false;
             transform = current.Then(transform);
             index = close + 1;
@@ -69,38 +69,47 @@ internal static class OfficeSvgTransformParser {
         }
     }
 
-    private static bool TryParseNumbers(string value, out IReadOnlyList<double> numbers) {
-        var result = new List<double>();
+    private static bool TryParseNumbers(string value, int startIndex, int endIndex, int maximumNumbers,
+        out IReadOnlyList<double> numbers) {
+        var result = new List<double>(maximumNumbers);
         numbers = result;
-        int index = 0;
-        while (SkipSeparators(value, ref index)) {
+        int index = startIndex;
+        while (SkipSeparators(value, ref index, endIndex)) {
+            if (result.Count >= maximumNumbers) return false;
             int start = index;
             if (value[index] is '+' or '-') index++;
             bool digits = false;
-            while (index < value.Length && char.IsDigit(value[index])) {
+            while (index < endIndex && char.IsDigit(value[index])) {
                 digits = true;
                 index++;
             }
-            if (index < value.Length && value[index] == '.') {
+            if (index < endIndex && value[index] == '.') {
                 index++;
-                while (index < value.Length && char.IsDigit(value[index])) {
+                while (index < endIndex && char.IsDigit(value[index])) {
                     digits = true;
                     index++;
                 }
             }
             if (!digits) return false;
-            if (index < value.Length && (value[index] is 'e' or 'E')) {
+            if (index < endIndex && (value[index] is 'e' or 'E')) {
                 int exponent = index++;
-                if (index < value.Length && (value[index] is '+' or '-')) index++;
+                if (index < endIndex && (value[index] is '+' or '-')) index++;
                 int exponentDigits = index;
-                while (index < value.Length && char.IsDigit(value[index])) index++;
+                while (index < endIndex && char.IsDigit(value[index])) index++;
                 if (index == exponentDigits) index = exponent;
             }
-            if (!double.TryParse(value.Substring(start, index - start), NumberStyles.Float, CultureInfo.InvariantCulture, out double number)
+            int length = index - start;
+            if (length > 128
+                || !double.TryParse(value.Substring(start, length), NumberStyles.Float, CultureInfo.InvariantCulture, out double number)
                 || !IsFinite(number)) return false;
             result.Add(number);
         }
         return result.Count > 0;
+    }
+
+    private static bool SkipSeparators(string value, ref int index, int endIndex) {
+        while (index < endIndex && (char.IsWhiteSpace(value[index]) || value[index] == ',')) index++;
+        return index < endIndex;
     }
 
     private static bool SkipSeparators(string value, ref int index) {

--- a/OfficeIMO.Drawing/OfficeSvgTransformParser.cs
+++ b/OfficeIMO.Drawing/OfficeSvgTransformParser.cs
@@ -5,11 +5,15 @@ using System.Globalization;
 namespace OfficeIMO.Drawing;
 
 internal static class OfficeSvgTransformParser {
+    private const int MaximumTransformOperations = 256;
+
     internal static bool TryParse(string? value, out OfficeTransform transform) {
         transform = OfficeTransform.Identity;
         if (string.IsNullOrWhiteSpace(value)) return true;
         int index = 0;
+        int operationCount = 0;
         while (SkipSeparators(value!, ref index)) {
+            if (++operationCount > MaximumTransformOperations) return false;
             int nameStart = index;
             while (index < value!.Length && char.IsLetter(value[index])) index++;
             if (index == nameStart) return false;

--- a/OfficeIMO.Drawing/OfficeTrueTypeFont.cs
+++ b/OfficeIMO.Drawing/OfficeTrueTypeFont.cs
@@ -211,6 +211,25 @@ public sealed partial class OfficeTrueTypeFont {
         return width;
     }
 
+    internal IReadOnlyList<double> MeasureTextElements(IReadOnlyList<string> elements, double fontSize) {
+        var widths = new double[elements.Count];
+        double scale = ScaleFor(fontSize);
+        ushort? previous = null;
+        for (int elementIndex = 0; elementIndex < elements.Count; elementIndex++) {
+            string text = elements[elementIndex];
+            double width = 0D;
+            for (int textIndex = 0; textIndex < text.Length;) {
+                int scalar = ReadScalar(text, ref textIndex);
+                ushort glyph = MapGlyph(scalar);
+                if (previous.HasValue) width += Kerning(previous.Value, glyph) * scale;
+                width += AdvanceWidth(glyph) * scale;
+                previous = glyph;
+            }
+            widths[elementIndex] = width;
+        }
+        return widths;
+    }
+
     public double LineHeight(double fontSize) {
         return Math.Max(1, _ascender - _descender) * ScaleFor(fontSize);
     }

--- a/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.MergedCells.cs
+++ b/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.MergedCells.cs
@@ -34,14 +34,8 @@ public static partial class ExcelHtmlConverterExtensions {
             lastColumn = Math.Max(lastColumn, merge.EndColumn);
         }
 
-        lastRow = Math.Min(lastRow, AddBounded(firstRow, maximumRows - 1));
-        lastColumn = Math.Min(lastColumn, AddBounded(firstColumn, maximumColumns - 1));
-
         return A1.CellReference(firstRow, firstColumn) + ":" + A1.CellReference(lastRow, lastColumn);
     }
-
-    private static int AddBounded(int value, int offset) =>
-        value > int.MaxValue - offset ? int.MaxValue : value + offset;
 
     private static ExcelMergeExportMap BuildMergeExportMap(
         IReadOnlyList<ExcelMergedRangeSnapshot> mergedRanges,

--- a/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.MergedCells.cs
+++ b/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.MergedCells.cs
@@ -3,12 +3,23 @@ using OfficeIMO.Html;
 namespace OfficeIMO.Excel.Html;
 
 public static partial class ExcelHtmlConverterExtensions {
-    private static string ExpandUsedRangeForMerges(ExcelSheet sheet, string usedRange, IReadOnlyList<ExcelMergedRangeSnapshot> mergedRanges) {
+    private static string ExpandUsedRangeForMerges(
+        ExcelSheet sheet,
+        string usedRange,
+        IReadOnlyList<ExcelMergedRangeSnapshot> mergedRanges,
+        int maximumRows,
+        int maximumColumns,
+        int maximumCells) {
         ParseUsedRange(usedRange, out int firstRow, out int firstColumn, out int rowCount, out int columnCount);
         int lastRow = firstRow + Math.Max(1, rowCount) - 1;
         int lastColumn = firstColumn + Math.Max(1, columnCount) - 1;
 
-        if (mergedRanges.Count > 0 && !SheetHasUsedCells(sheet, firstRow, firstColumn, rowCount, columnCount)) {
+        int scanColumns = Math.Min(Math.Min(columnCount, maximumColumns), maximumCells);
+        int scanRows = scanColumns == 0
+            ? 0
+            : Math.Min(Math.Min(rowCount, maximumRows), Math.Max(1, maximumCells / scanColumns));
+        if (mergedRanges.Count > 0 &&
+            !SheetHasUsedCells(sheet, firstRow, firstColumn, scanRows, scanColumns)) {
             ExcelMergedRangeSnapshot firstMerge = mergedRanges[0];
             firstRow = firstMerge.StartRow;
             firstColumn = firstMerge.StartColumn;
@@ -23,8 +34,14 @@ public static partial class ExcelHtmlConverterExtensions {
             lastColumn = Math.Max(lastColumn, merge.EndColumn);
         }
 
+        lastRow = Math.Min(lastRow, AddBounded(firstRow, maximumRows - 1));
+        lastColumn = Math.Min(lastColumn, AddBounded(firstColumn, maximumColumns - 1));
+
         return A1.CellReference(firstRow, firstColumn) + ":" + A1.CellReference(lastRow, lastColumn);
     }
+
+    private static int AddBounded(int value, int offset) =>
+        value > int.MaxValue - offset ? int.MaxValue : value + offset;
 
     private static ExcelMergeExportMap BuildMergeExportMap(
         IReadOnlyList<ExcelMergedRangeSnapshot> mergedRanges,
@@ -34,7 +51,7 @@ public static partial class ExcelHtmlConverterExtensions {
         int columnCount) {
         int lastRow = firstRow + rowCount - 1;
         int lastColumn = firstColumn + columnCount - 1;
-        var map = new ExcelMergeExportMap();
+        var candidates = new List<ExcelMergeExportRange>();
 
         foreach (ExcelMergedRangeSnapshot merge in mergedRanges) {
             int startRow = Math.Max(firstRow, merge.StartRow);
@@ -45,10 +62,22 @@ public static partial class ExcelHtmlConverterExtensions {
                 continue;
             }
 
-            map.TryAdd(new ExcelMergeExportRange(startRow, startColumn, endRow, endColumn));
+            candidates.Add(new ExcelMergeExportRange(startRow, startColumn, endRow, endColumn));
         }
 
-        return map;
+        candidates.Sort(static (left, right) => {
+            int row = left.StartRow.CompareTo(right.StartRow);
+            return row != 0 ? row : left.StartColumn.CompareTo(right.StartColumn);
+        });
+        var accepted = new List<ExcelMergeExportRange>(candidates.Count);
+        var active = new List<ExcelMergeExportRange>();
+        foreach (ExcelMergeExportRange candidate in candidates) {
+            active.RemoveAll(range => range.EndRow < candidate.StartRow);
+            if (active.Any(range => range.Intersects(candidate))) continue;
+            accepted.Add(candidate);
+            active.Add(candidate);
+        }
+        return new ExcelMergeExportMap(accepted);
     }
 
     private static void AppendMergeAttributes(StringBuilder body, ExcelMergeExportRange merge) {
@@ -70,27 +99,65 @@ public static partial class ExcelHtmlConverterExtensions {
     }
 
     private sealed class ExcelMergeExportMap {
-        private readonly Dictionary<long, ExcelMergeExportRange> _origins = new();
-        private readonly List<ExcelMergeExportRange> _ranges = new();
+        private readonly IReadOnlyList<ExcelMergeExportRange> _ranges;
 
-        internal int Count => _origins.Count;
-
-        internal bool TryAdd(ExcelMergeExportRange merge) {
-            if (_ranges.Any(existing => existing.Intersects(merge))) {
-                return false;
-            }
-
-            _origins.Add(GetCellKey(merge.StartRow, merge.StartColumn), merge);
-            _ranges.Add(merge);
-
-            return true;
+        internal ExcelMergeExportMap(IReadOnlyList<ExcelMergeExportRange> ranges) {
+            _ranges = ranges;
         }
 
-        internal bool IsCoveredCell(int row, int column) =>
-            _ranges.Any(range => range.Contains(row, column) && (row != range.StartRow || column != range.StartColumn));
+        internal int Count => _ranges.Count;
 
-        internal bool TryGetOrigin(int row, int column, out ExcelMergeExportRange merge) =>
-            _origins.TryGetValue(GetCellKey(row, column), out merge);
+        internal ExcelMergeExportRowCursor CreateRowCursor() => new(_ranges);
+    }
+
+    private sealed class ExcelMergeExportRowCursor {
+        private readonly IReadOnlyList<ExcelMergeExportRange> _ranges;
+        private readonly List<ExcelMergeExportRange> _active = new();
+        private int _nextRange;
+        private int _row;
+
+        internal ExcelMergeExportRowCursor(IReadOnlyList<ExcelMergeExportRange> ranges) {
+            _ranges = ranges;
+        }
+
+        internal void MoveToRow(int row) {
+            if (_row != 0 && row < _row) throw new InvalidOperationException("Merge row cursors must move forward.");
+            _row = row;
+            _active.RemoveAll(range => range.EndRow < row);
+            while (_nextRange < _ranges.Count && _ranges[_nextRange].StartRow <= row) {
+                ExcelMergeExportRange range = _ranges[_nextRange++];
+                if (range.EndRow >= row) _active.Add(range);
+            }
+            _active.Sort(static (left, right) => left.StartColumn.CompareTo(right.StartColumn));
+        }
+
+        internal bool IsCoveredCell(int column) {
+            if (!TryFind(column, out ExcelMergeExportRange range)) return false;
+            return _row != range.StartRow || column != range.StartColumn;
+        }
+
+        internal bool TryGetOrigin(int column, out ExcelMergeExportRange merge) {
+            if (TryFind(column, out merge) && _row == merge.StartRow && column == merge.StartColumn) return true;
+            merge = default;
+            return false;
+        }
+
+        private bool TryFind(int column, out ExcelMergeExportRange range) {
+            int low = 0;
+            int high = _active.Count - 1;
+            while (low <= high) {
+                int middle = low + ((high - low) / 2);
+                ExcelMergeExportRange candidate = _active[middle];
+                if (column < candidate.StartColumn) high = middle - 1;
+                else if (column > candidate.EndColumn) low = middle + 1;
+                else {
+                    range = candidate;
+                    return true;
+                }
+            }
+            range = default;
+            return false;
+        }
     }
 
     private readonly struct ExcelMergeExportRange {
@@ -115,13 +182,9 @@ public static partial class ExcelHtmlConverterExtensions {
 
         internal string A1Range => A1.CellReference(StartRow, StartColumn) + ":" + A1.CellReference(EndRow, EndColumn);
 
-        internal bool Contains(int row, int column) =>
-            row >= StartRow && row <= EndRow && column >= StartColumn && column <= EndColumn;
-
         internal bool Intersects(ExcelMergeExportRange other) =>
             StartRow <= other.EndRow && EndRow >= other.StartRow
             && StartColumn <= other.EndColumn && EndColumn >= other.StartColumn;
     }
 
-    private static long GetCellKey(int row, int column) => ((long)row << 32) | (uint)column;
 }

--- a/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.cs
+++ b/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.cs
@@ -117,9 +117,9 @@ public static partial class ExcelHtmlConverterExtensions {
     }
 
     private static void AppendSheetTable(StringBuilder body, ExcelSheet sheet, ExcelHtmlSaveOptions options) {
-        IReadOnlyList<ExcelMergedRangeSnapshot> mergedRanges = sheet.GetMergedRanges();
         int rowLimit = options.MaxRowsPerSheet ?? ExcelHtmlSaveOptions.DefaultMaxRowsPerSheet;
         int columnLimit = options.MaxColumnsPerSheet ?? ExcelHtmlSaveOptions.DefaultMaxColumnsPerSheet;
+        IReadOnlyList<ExcelMergedRangeSnapshot> mergedRanges = sheet.GetMergedRanges(options.MaxMergedRangesPerSheet);
         string usedRange = ExpandUsedRangeForMerges(
             sheet,
             sheet.GetUsedRangeA1(),

--- a/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.cs
+++ b/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.cs
@@ -208,6 +208,13 @@ public static partial class ExcelHtmlConverterExtensions {
         }
 
         body.Append(firstRowIsHeader && maxRows == 1 ? "</thead></table>" : "</tbody></table>");
+        if (maxColumns < columnCount) {
+            body.Append("<p class=\"officeimo-diagnostic\">Columns truncated: ")
+                .Append(maxColumns.ToString(CultureInfo.InvariantCulture))
+                .Append(" of ")
+                .Append(columnCount.ToString(CultureInfo.InvariantCulture))
+                .Append(" exported.</p>");
+        }
         if (maxRows < rowCount) {
             body.Append("<p class=\"officeimo-diagnostic\">Rows truncated: ")
                 .Append(maxRows.ToString(CultureInfo.InvariantCulture))

--- a/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.cs
+++ b/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.cs
@@ -120,9 +120,14 @@ public static partial class ExcelHtmlConverterExtensions {
         int rowLimit = options.MaxRowsPerSheet ?? ExcelHtmlSaveOptions.DefaultMaxRowsPerSheet;
         int columnLimit = options.MaxColumnsPerSheet ?? ExcelHtmlSaveOptions.DefaultMaxColumnsPerSheet;
         IReadOnlyList<ExcelMergedRangeSnapshot> mergedRanges = sheet.GetMergedRanges(options.MaxMergedRangesPerSheet);
+        string reportedUsedRange = sheet.GetUsedRangeA1();
+        bool isEmptyDefaultRange = mergedRanges.Count == 0
+            && (string.Equals(reportedUsedRange, "A1", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(reportedUsedRange, "A1:A1", StringComparison.OrdinalIgnoreCase))
+            && !sheet.TryGetCellText(1, 1, out _);
         string usedRange = ExpandUsedRangeForMerges(
             sheet,
-            sheet.GetUsedRangeA1(),
+            reportedUsedRange,
             mergedRanges,
             rowLimit,
             columnLimit,
@@ -144,9 +149,9 @@ public static partial class ExcelHtmlConverterExtensions {
         }
         ExcelMergeExportMap mergeMap = BuildMergeExportMap(mergedRanges, firstRow, firstColumn, maxRows, maxColumns);
         if (rowCount == 0 || columnCount == 0 || maxRows == 0 || maxColumns == 0 || (!SheetHasUsedCells(sheet, firstRow, firstColumn, maxRows, maxColumns) && mergeMap.Count == 0)) {
-            body.Append(rowCount > 0 && columnCount > 0
-                ? "<p class=\"officeimo-muted\">No cells within export limits.</p>"
-                : "<p class=\"officeimo-muted\">No used cells.</p>");
+            body.Append(isEmptyDefaultRange
+                ? "<p class=\"officeimo-muted\">No used cells.</p>"
+                : "<p class=\"officeimo-muted\">No cells within export limits.</p>");
             AppendSheetTruncationDiagnostics(body, maxRows, rowCount, maxColumns, columnCount);
             AppendSheetFeatureInventory(body, sheet, GetFeatureInventoryWindow(firstRow, maxRows, rowCount));
             body.Append("</section>");

--- a/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.cs
+++ b/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.cs
@@ -118,7 +118,15 @@ public static partial class ExcelHtmlConverterExtensions {
 
     private static void AppendSheetTable(StringBuilder body, ExcelSheet sheet, ExcelHtmlSaveOptions options) {
         IReadOnlyList<ExcelMergedRangeSnapshot> mergedRanges = sheet.GetMergedRanges();
-        string usedRange = ExpandUsedRangeForMerges(sheet, sheet.GetUsedRangeA1(), mergedRanges);
+        int rowLimit = options.MaxRowsPerSheet ?? ExcelHtmlSaveOptions.DefaultMaxRowsPerSheet;
+        int columnLimit = options.MaxColumnsPerSheet ?? ExcelHtmlSaveOptions.DefaultMaxColumnsPerSheet;
+        string usedRange = ExpandUsedRangeForMerges(
+            sheet,
+            sheet.GetUsedRangeA1(),
+            mergedRanges,
+            rowLimit,
+            columnLimit,
+            options.MaxCellsPerSheet);
         body.Append("<section class=\"officeimo-sheet\" data-officeimo-sheet=\"")
             .Append(OfficeHtmlText.EscapeAttribute(sheet.Name))
             .Append("\" data-officeimo-range=\"")
@@ -129,11 +137,13 @@ public static partial class ExcelHtmlConverterExtensions {
         body.Append("<h2>").Append(OfficeHtmlText.Escape(sheet.Name)).Append("</h2>");
 
         ParseUsedRange(usedRange, out int firstRow, out int firstColumn, out int rowCount, out int columnCount);
-        int maxRows = options.MaxRowsPerSheet.HasValue
-            ? Math.Min(rowCount, options.MaxRowsPerSheet.Value)
-            : rowCount;
-        ExcelMergeExportMap mergeMap = BuildMergeExportMap(mergedRanges, firstRow, firstColumn, maxRows, columnCount);
-        if (rowCount == 0 || columnCount == 0 || maxRows == 0 || (!SheetHasUsedCells(sheet, firstRow, firstColumn, rowCount, columnCount) && mergeMap.Count == 0)) {
+        int maxColumns = Math.Min(Math.Min(columnCount, columnLimit), options.MaxCellsPerSheet);
+        int maxRows = Math.Min(rowCount, rowLimit);
+        if (maxColumns > 0 && (long)maxRows * maxColumns > options.MaxCellsPerSheet) {
+            maxRows = Math.Min(maxRows, Math.Max(1, options.MaxCellsPerSheet / maxColumns));
+        }
+        ExcelMergeExportMap mergeMap = BuildMergeExportMap(mergedRanges, firstRow, firstColumn, maxRows, maxColumns);
+        if (rowCount == 0 || columnCount == 0 || maxRows == 0 || maxColumns == 0 || (!SheetHasUsedCells(sheet, firstRow, firstColumn, maxRows, maxColumns) && mergeMap.Count == 0)) {
             body.Append("<p class=\"officeimo-muted\">No used cells.</p>");
             AppendSheetFeatureInventory(body, sheet, GetFeatureInventoryWindow(firstRow, maxRows, rowCount));
             body.Append("</section>");
@@ -148,17 +158,19 @@ public static partial class ExcelHtmlConverterExtensions {
             body.Append("<tbody>");
         }
 
+        ExcelMergeExportRowCursor mergeCursor = mergeMap.CreateRowCursor();
         for (int row = 0; row < maxRows; row++) {
             if (row == 1 && firstRowIsHeader) {
                 body.Append("</thead><tbody>");
             }
 
             body.Append("<tr>");
-            for (int column = 0; column < columnCount; column++) {
+            mergeCursor.MoveToRow(firstRow + row);
+            for (int column = 0; column < maxColumns; column++) {
                 string tag = firstRowIsHeader && row == 0 ? "th" : "td";
                 int cellRow = firstRow + row;
                 int cellColumn = firstColumn + column;
-                if (mergeMap.IsCoveredCell(cellRow, cellColumn)) {
+                if (mergeCursor.IsCoveredCell(cellColumn)) {
                     continue;
                 }
 
@@ -168,7 +180,7 @@ public static partial class ExcelHtmlConverterExtensions {
                     .Append(" data-officeimo-cell=\"")
                     .Append(OfficeHtmlText.EscapeAttribute(A1.CellReference(cellRow, cellColumn)))
                     .Append('"');
-                if (mergeMap.TryGetOrigin(cellRow, cellColumn, out ExcelMergeExportRange merge)) {
+                if (mergeCursor.TryGetOrigin(cellColumn, out ExcelMergeExportRange merge)) {
                     AppendMergeAttributes(body, merge);
                 }
 

--- a/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.cs
+++ b/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.cs
@@ -144,7 +144,10 @@ public static partial class ExcelHtmlConverterExtensions {
         }
         ExcelMergeExportMap mergeMap = BuildMergeExportMap(mergedRanges, firstRow, firstColumn, maxRows, maxColumns);
         if (rowCount == 0 || columnCount == 0 || maxRows == 0 || maxColumns == 0 || (!SheetHasUsedCells(sheet, firstRow, firstColumn, maxRows, maxColumns) && mergeMap.Count == 0)) {
-            body.Append("<p class=\"officeimo-muted\">No used cells.</p>");
+            body.Append(rowCount > 0 && columnCount > 0
+                ? "<p class=\"officeimo-muted\">No cells within export limits.</p>"
+                : "<p class=\"officeimo-muted\">No used cells.</p>");
+            AppendSheetTruncationDiagnostics(body, maxRows, rowCount, maxColumns, columnCount);
             AppendSheetFeatureInventory(body, sheet, GetFeatureInventoryWindow(firstRow, maxRows, rowCount));
             body.Append("</section>");
             return;
@@ -208,23 +211,32 @@ public static partial class ExcelHtmlConverterExtensions {
         }
 
         body.Append(firstRowIsHeader && maxRows == 1 ? "</thead></table>" : "</tbody></table>");
-        if (maxColumns < columnCount) {
-            body.Append("<p class=\"officeimo-diagnostic\">Columns truncated: ")
-                .Append(maxColumns.ToString(CultureInfo.InvariantCulture))
-                .Append(" of ")
-                .Append(columnCount.ToString(CultureInfo.InvariantCulture))
-                .Append(" exported.</p>");
-        }
-        if (maxRows < rowCount) {
-            body.Append("<p class=\"officeimo-diagnostic\">Rows truncated: ")
-                .Append(maxRows.ToString(CultureInfo.InvariantCulture))
-                .Append(" of ")
-                .Append(rowCount.ToString(CultureInfo.InvariantCulture))
-                .Append(" exported.</p>");
-        }
+        AppendSheetTruncationDiagnostics(body, maxRows, rowCount, maxColumns, columnCount);
 
         AppendSheetFeatureInventory(body, sheet, GetFeatureInventoryWindow(firstRow, maxRows, rowCount));
         body.Append("</section>");
+    }
+
+    private static void AppendSheetTruncationDiagnostics(
+        StringBuilder body,
+        int exportedRows,
+        int totalRows,
+        int exportedColumns,
+        int totalColumns) {
+        if (exportedColumns < totalColumns) {
+            body.Append("<p class=\"officeimo-diagnostic\">Columns truncated: ")
+                .Append(exportedColumns.ToString(CultureInfo.InvariantCulture))
+                .Append(" of ")
+                .Append(totalColumns.ToString(CultureInfo.InvariantCulture))
+                .Append(" exported.</p>");
+        }
+        if (exportedRows < totalRows) {
+            body.Append("<p class=\"officeimo-diagnostic\">Rows truncated: ")
+                .Append(exportedRows.ToString(CultureInfo.InvariantCulture))
+                .Append(" of ")
+                .Append(totalRows.ToString(CultureInfo.InvariantCulture))
+                .Append(" exported.</p>");
+        }
     }
 
     private static bool SheetHasUsedCells(ExcelSheet sheet, int firstRow, int firstColumn, int rowCount, int columnCount) {

--- a/OfficeIMO.Excel.Html/ExcelHtmlSaveOptions.cs
+++ b/OfficeIMO.Excel.Html/ExcelHtmlSaveOptions.cs
@@ -6,6 +6,15 @@ namespace OfficeIMO.Excel.Html;
 /// Options for exporting Excel workbooks and worksheets to HTML.
 /// </summary>
 public sealed class ExcelHtmlSaveOptions {
+    /// <summary>Default maximum worksheet rows projected to semantic HTML.</summary>
+    public const int DefaultMaxRowsPerSheet = 10000;
+
+    /// <summary>Default maximum worksheet columns projected to semantic HTML.</summary>
+    public const int DefaultMaxColumnsPerSheet = 1024;
+
+    /// <summary>Default maximum worksheet cells visited while projecting semantic HTML.</summary>
+    public const int DefaultMaxCellsPerSheet = 1000000;
+
     /// <summary>Excel-to-HTML lane to export. Defaults to semantic worksheet tables.</summary>
     public OfficeHtmlConversionProfile Profile { get; set; } = OfficeHtmlConversionProfile.ExcelSemanticTables;
 
@@ -18,8 +27,14 @@ public sealed class ExcelHtmlSaveOptions {
     /// <summary>Optional document title.</summary>
     public string? Title { get; set; }
 
-    /// <summary>Optional maximum number of used-range rows exported per worksheet.</summary>
-    public int? MaxRowsPerSheet { get; set; }
+    /// <summary>Maximum number of used-range rows exported per worksheet. Null uses the bounded default.</summary>
+    public int? MaxRowsPerSheet { get; set; } = DefaultMaxRowsPerSheet;
+
+    /// <summary>Maximum number of used-range columns exported per worksheet. Null uses the bounded default.</summary>
+    public int? MaxColumnsPerSheet { get; set; } = DefaultMaxColumnsPerSheet;
+
+    /// <summary>Maximum number of worksheet cells visited per semantic HTML table.</summary>
+    public int MaxCellsPerSheet { get; set; } = DefaultMaxCellsPerSheet;
 
     /// <summary>Text used for empty cells.</summary>
     public string EmptyCellText { get; set; } = string.Empty;
@@ -36,6 +51,12 @@ public sealed class ExcelHtmlSaveOptions {
     internal void Validate() {
         if (MaxRowsPerSheet.HasValue && MaxRowsPerSheet.Value <= 0) {
             throw new ArgumentOutOfRangeException(nameof(MaxRowsPerSheet), "Maximum rows per worksheet must be positive when configured.");
+        }
+        if (MaxColumnsPerSheet.HasValue && MaxColumnsPerSheet.Value <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(MaxColumnsPerSheet), "Maximum columns per worksheet must be positive when configured.");
+        }
+        if (MaxCellsPerSheet <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(MaxCellsPerSheet), "Maximum cells per worksheet must be positive.");
         }
     }
 }

--- a/OfficeIMO.Excel.Html/ExcelHtmlSaveOptions.cs
+++ b/OfficeIMO.Excel.Html/ExcelHtmlSaveOptions.cs
@@ -15,6 +15,9 @@ public sealed class ExcelHtmlSaveOptions {
     /// <summary>Default maximum worksheet cells visited while projecting semantic HTML.</summary>
     public const int DefaultMaxCellsPerSheet = 1000000;
 
+    /// <summary>Default maximum merged-range records inspected per worksheet.</summary>
+    public const int DefaultMaxMergedRangesPerSheet = 10000;
+
     /// <summary>Excel-to-HTML lane to export. Defaults to semantic worksheet tables.</summary>
     public OfficeHtmlConversionProfile Profile { get; set; } = OfficeHtmlConversionProfile.ExcelSemanticTables;
 
@@ -35,6 +38,9 @@ public sealed class ExcelHtmlSaveOptions {
 
     /// <summary>Maximum number of worksheet cells visited per semantic HTML table.</summary>
     public int MaxCellsPerSheet { get; set; } = DefaultMaxCellsPerSheet;
+
+    /// <summary>Maximum number of merged-range records inspected per semantic HTML table.</summary>
+    public int MaxMergedRangesPerSheet { get; set; } = DefaultMaxMergedRangesPerSheet;
 
     /// <summary>Text used for empty cells.</summary>
     public string EmptyCellText { get; set; } = string.Empty;
@@ -57,6 +63,9 @@ public sealed class ExcelHtmlSaveOptions {
         }
         if (MaxCellsPerSheet <= 0) {
             throw new ArgumentOutOfRangeException(nameof(MaxCellsPerSheet), "Maximum cells per worksheet must be positive.");
+        }
+        if (MaxMergedRangesPerSheet <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(MaxMergedRangesPerSheet), "Maximum merged ranges per worksheet must be positive.");
         }
     }
 }

--- a/OfficeIMO.Excel/ExcelSheet.MergedRanges.cs
+++ b/OfficeIMO.Excel/ExcelSheet.MergedRanges.cs
@@ -5,14 +5,25 @@ namespace OfficeIMO.Excel {
         /// <summary>
         /// Gets worksheet merged ranges as reusable one-based A1 metadata.
         /// </summary>
-        public IReadOnlyList<ExcelMergedRangeSnapshot> GetMergedRanges() {
+        public IReadOnlyList<ExcelMergedRangeSnapshot> GetMergedRanges() => GetMergedRanges(int.MaxValue);
+
+        /// <summary>
+        /// Gets worksheet merged ranges while rejecting collections beyond the configured inspection limit.
+        /// </summary>
+        /// <param name="maximumRanges">Maximum merge records inspected.</param>
+        public IReadOnlyList<ExcelMergedRangeSnapshot> GetMergedRanges(int maximumRanges) {
+            if (maximumRanges <= 0) throw new ArgumentOutOfRangeException(nameof(maximumRanges));
             MergeCells? merges = WorksheetRoot.GetFirstChild<MergeCells>();
             if (merges == null) {
                 return Array.Empty<ExcelMergedRangeSnapshot>();
             }
 
             var ranges = new List<ExcelMergedRangeSnapshot>();
+            int inspected = 0;
             foreach (MergeCell merge in merges.Elements<MergeCell>()) {
+                if (++inspected > maximumRanges) {
+                    throw new InvalidOperationException("The merged-range count exceeds the configured inspection limit.");
+                }
                 string? reference = merge.Reference?.Value;
                 if (string.IsNullOrWhiteSpace(reference)) {
                     continue;

--- a/OfficeIMO.Html.Pdf/HtmlPdfRenderedConverter.cs
+++ b/OfficeIMO.Html.Pdf/HtmlPdfRenderedConverter.cs
@@ -461,6 +461,26 @@ internal static class HtmlPdfRenderedConverter {
                     target.Effect(pageTransform, effectGroup.Opacity, nested => AddElements(nested, nestedDrawing.Elements));
                     continue;
                 }
+                if (element is OfficeDrawingTilingPattern tilingPattern) {
+                    FlushShapes();
+                    OfficeDrawing tileDrawing = tilingPattern.Tile;
+                    OfficeImagePlacement area = tilingPattern.Area;
+                    double clipX = (visual.X + (area.X * scaleX)) * PointsPerCssPixel;
+                    double clipY = (visual.Y + (area.Y * scaleY)) * PointsPerCssPixel;
+                    double clipWidth = area.Width * scaleX * PointsPerCssPixel;
+                    double clipHeight = area.Height * scaleY * PointsPerCssPixel;
+                    target.Clip(clipX, clipY, clipWidth, clipHeight, clipped => {
+                        foreach (OfficeTransform tileTransform in tilingPattern.GetTileTransforms()) {
+                            cancellationToken.ThrowIfCancellationRequested();
+                            OfficeTransform pageTransform = pageToDrawing
+                                .Then(tileTransform)
+                                .Then(drawingToPage);
+                            clipped.Effect(pageTransform, tilingPattern.Opacity,
+                                nested => AddElements(nested, tileDrawing.Elements));
+                        }
+                    });
+                    continue;
+                }
                 if (element is not OfficeDrawingText text || text.Text.Length == 0) continue;
                 FlushShapes();
                 double fontSize = text.Font.Size * scaleY * PointsPerCssPixel;

--- a/OfficeIMO.Html.Pdf/HtmlPdfRenderedConverter.cs
+++ b/OfficeIMO.Html.Pdf/HtmlPdfRenderedConverter.cs
@@ -756,6 +756,7 @@ internal static class HtmlPdfRenderedConverter {
         foreach (OfficeDrawingElement element in elements) {
             if (element is OfficeDrawingText text && RequiresUnicodeFont(text.Text)) return true;
             if (element is OfficeDrawingEffectGroup effectGroup && DrawingRequiresUnicodeFont(effectGroup.Drawing.Elements)) return true;
+            if (element is OfficeDrawingTilingPattern tilingPattern && DrawingRequiresUnicodeFont(tilingPattern.Tile.Elements)) return true;
         }
 
         return false;

--- a/OfficeIMO.Html.Pdf/HtmlPdfRenderedConverter.cs
+++ b/OfficeIMO.Html.Pdf/HtmlPdfRenderedConverter.cs
@@ -1,6 +1,7 @@
 using OfficeIMO.Drawing;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using PdfCore = OfficeIMO.Pdf;
@@ -11,6 +12,7 @@ internal static class HtmlPdfRenderedConverter {
     private const double PointsPerCssPixel = 72D / HtmlRenderOptions.CssPixelsPerInch;
     private const int MaximumSystemFontFamilyCandidates = 512;
     private const int MaximumLoadedSystemFontFamilies = 32;
+    private static readonly ConditionalWeakTable<byte[], CachedPdfImageResources> PdfImageResources = new();
 
     internal static HtmlPdfRenderResult Convert(HtmlConversionDocument document, HtmlPdfSaveOptions options) {
         HtmlRenderOptions renderOptions = ResolveRenderOptions(options);
@@ -390,7 +392,9 @@ internal static class HtmlPdfRenderedConverter {
     }
 
     private static void AddImage(PdfCore.PdfPageCanvas canvas, HtmlRenderImage visual) {
-        if (!TryPreparePdfImageBytes(visual.Bytes, visual.ContentType, out byte[] imageBytes)) return;
+        PdfCore.PdfCanvasImageResource? imageResource = GetSharedPdfImageResource(
+            visual.EncodedBytes, visual.ContentType);
+        if (imageResource == null) return;
         PdfCore.PdfImageStyle? style = visual.SourceCrop.HasCrop
             ? new PdfCore.PdfImageStyle {
                 SourceCrop = new PdfCore.PdfImageSourceCrop(
@@ -400,8 +404,8 @@ internal static class HtmlPdfRenderedConverter {
                     visual.SourceCrop.Bottom)
             }
             : null;
-        canvas.Image(
-            imageBytes,
+        canvas.ImageShared(
+            imageResource,
             visual.X * PointsPerCssPixel,
             visual.Y * PointsPerCssPixel,
             visual.Width * PointsPerCssPixel,
@@ -496,16 +500,41 @@ internal static class HtmlPdfRenderedConverter {
     }
 
     private static void AddImagePattern(PdfCore.PdfPageCanvas canvas, HtmlRenderImagePattern visual, CancellationToken cancellationToken) {
-        if (!TryPreparePdfImageBytes(visual.Bytes, visual.ContentType, out byte[] imageBytes)) return;
+        PdfCore.PdfCanvasImageResource? imageResource = GetSharedPdfImageResource(
+            visual.EncodedBytes, visual.ContentType);
+        if (imageResource == null) return;
         OfficeImagePatternLayout pattern = visual.Pattern.Scale(PointsPerCssPixel);
         OfficeImagePlacement area = pattern.Area;
-        PdfCore.PdfCanvasImageResource imageResource = PdfCore.PdfCanvasImageResource.Create(imageBytes);
         canvas.Clip(area.X, area.Y, area.Width, area.Height, clipped => {
             foreach (OfficeImagePlacement tile in pattern.GetTilePlacements(visual.MaximumTileCount)) {
                 cancellationToken.ThrowIfCancellationRequested();
                 clipped.ImageShared(imageResource, tile.X, tile.Y, tile.Width, tile.Height);
             }
         });
+    }
+
+    private static PdfCore.PdfCanvasImageResource? GetSharedPdfImageResource(byte[] encodedBytes,
+        string contentType) {
+        return PdfImageResources.GetValue(encodedBytes, static _ => new CachedPdfImageResources())
+            .GetOrCreate(encodedBytes, contentType);
+    }
+
+    private sealed class CachedPdfImageResources {
+        private readonly Dictionary<string, PdfCore.PdfCanvasImageResource?> _resources =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        internal PdfCore.PdfCanvasImageResource? GetOrCreate(byte[] encodedBytes, string contentType) {
+            lock (_resources) {
+                if (_resources.TryGetValue(contentType, out PdfCore.PdfCanvasImageResource? resource)) {
+                    return resource;
+                }
+                if (TryPreparePdfImageBytes(encodedBytes, contentType, out byte[] prepared)) {
+                    resource = PdfCore.PdfCanvasImageResource.Create(prepared);
+                }
+                _resources.Add(contentType, resource);
+                return resource;
+            }
+        }
     }
 
     private static PdfCore.PdfStandardFont MapFont(string familyName, IReadOnlyDictionary<string, PdfCore.PdfStandardFont> webFonts) {

--- a/OfficeIMO.Html.Pdf/HtmlPdfRenderedConverter.cs
+++ b/OfficeIMO.Html.Pdf/HtmlPdfRenderedConverter.cs
@@ -713,6 +713,8 @@ internal static class HtmlPdfRenderedConverter {
                 yield return text.Font.FamilyName;
             } else if (element is OfficeDrawingEffectGroup effectGroup) {
                 foreach (string familyNames in EnumerateDrawingFontFamilyLists(effectGroup.Drawing.Elements)) yield return familyNames;
+            } else if (element is OfficeDrawingTilingPattern tilingPattern) {
+                foreach (string familyNames in EnumerateDrawingFontFamilyLists(tilingPattern.Tile.Elements)) yield return familyNames;
             }
         }
     }

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapterLimits.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapterLimits.cs
@@ -16,6 +16,7 @@ public sealed class HtmlOfficeAdapterLimitTests {
 
         Assert.Throws<ArgumentOutOfRangeException>(() => workbook.ToHtml(new ExcelHtmlSaveOptions { MaxRowsPerSheet = -1 }));
         Assert.Throws<ArgumentOutOfRangeException>(() => workbook.ToHtml(new ExcelHtmlSaveOptions { MaxRowsPerSheet = 0 }));
+        Assert.Throws<ArgumentOutOfRangeException>(() => workbook.ToHtml(new ExcelHtmlSaveOptions { MaxMergedRangesPerSheet = 0 }));
     }
 
     [Fact]

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.ExcelMergedCells.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.ExcelMergedCells.cs
@@ -7,6 +7,15 @@ namespace OfficeIMO.Tests;
 
 public class HtmlOfficeAdaptersExcelMergedCells {
     [Fact]
+    public void ExcelHtml_DefaultSemanticExportLimitsAreBounded() {
+        var options = new ExcelHtmlSaveOptions();
+
+        Assert.Equal(ExcelHtmlSaveOptions.DefaultMaxRowsPerSheet, options.MaxRowsPerSheet);
+        Assert.Equal(ExcelHtmlSaveOptions.DefaultMaxColumnsPerSheet, options.MaxColumnsPerSheet);
+        Assert.Equal(ExcelHtmlSaveOptions.DefaultMaxCellsPerSheet, options.MaxCellsPerSheet);
+    }
+
+    [Fact]
     public void ExcelHtml_RoundTripsMergedCellsWithoutDuplicatingCoveredCells() {
         using ExcelDocument workbook = ExcelDocument.Create(new MemoryStream());
         ExcelSheet sheet = workbook.AddWorksheet("Merged");
@@ -80,5 +89,39 @@ public class HtmlOfficeAdaptersExcelMergedCells {
 
         Assert.Contains("data-officeimo-merge=\"A1:B2\"", html, StringComparison.Ordinal);
         Assert.Equal("A1:B2", Assert.Single(Assert.Single(imported.Sheets).GetMergedRanges()).A1Range);
+    }
+
+    [Fact]
+    public void ExcelHtml_HugeMergeIsClippedBeforeCellMaterialization() {
+        using ExcelDocument workbook = ExcelDocument.Create(new MemoryStream());
+        ExcelSheet sheet = workbook.AddWorksheet("Bounded");
+        sheet.CellValue(1, 1, "Visible");
+        sheet.MergeRange("A1:XFD1048576");
+
+        string html = workbook.ToHtml(new ExcelHtmlSaveOptions {
+            MaxRowsPerSheet = 2,
+            MaxColumnsPerSheet = 3,
+            MaxCellsPerSheet = 6
+        });
+
+        Assert.Contains("data-officeimo-merge=\"A1:C2\"", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("data-officeimo-cell=\"D1\"", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("data-officeimo-cell=\"A3\"", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExcelHtml_EmptyHugeMergeUsesTheBoundedProbeWindow() {
+        using ExcelDocument workbook = ExcelDocument.Create(new MemoryStream());
+        ExcelSheet sheet = workbook.AddWorksheet("EmptyBounded");
+        sheet.MergeRange("A1:XFD1048576");
+
+        string html = workbook.ToHtml(new ExcelHtmlSaveOptions {
+            MaxRowsPerSheet = 2,
+            MaxColumnsPerSheet = 3,
+            MaxCellsPerSheet = 4
+        });
+
+        Assert.Contains("data-officeimo-merge=\"A1:C1\"", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("data-officeimo-cell=\"A2\"", html, StringComparison.Ordinal);
     }
 }

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.ExcelMergedCells.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.ExcelMergedCells.cs
@@ -13,6 +13,7 @@ public class HtmlOfficeAdaptersExcelMergedCells {
         Assert.Equal(ExcelHtmlSaveOptions.DefaultMaxRowsPerSheet, options.MaxRowsPerSheet);
         Assert.Equal(ExcelHtmlSaveOptions.DefaultMaxColumnsPerSheet, options.MaxColumnsPerSheet);
         Assert.Equal(ExcelHtmlSaveOptions.DefaultMaxCellsPerSheet, options.MaxCellsPerSheet);
+        Assert.Equal(ExcelHtmlSaveOptions.DefaultMaxMergedRangesPerSheet, options.MaxMergedRangesPerSheet);
     }
 
     [Fact]
@@ -123,5 +124,17 @@ public class HtmlOfficeAdaptersExcelMergedCells {
 
         Assert.Contains("data-officeimo-merge=\"A1:C1\"", html, StringComparison.Ordinal);
         Assert.DoesNotContain("data-officeimo-cell=\"A2\"", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExcelHtml_RejectsMergeMetadataBeyondTheConfiguredLimit() {
+        using ExcelDocument workbook = ExcelDocument.Create(new MemoryStream());
+        ExcelSheet sheet = workbook.AddWorksheet("MergeBounded");
+        sheet.MergeRange("A1:B1");
+        sheet.MergeRange("A2:B2");
+
+        Assert.Throws<InvalidOperationException>(() => workbook.ToHtml(new ExcelHtmlSaveOptions {
+            MaxMergedRangesPerSheet = 1
+        }));
     }
 }

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.ExcelMergedCells.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.ExcelMergedCells.cs
@@ -111,6 +111,22 @@ public class HtmlOfficeAdaptersExcelMergedCells {
     }
 
     [Fact]
+    public void ExcelHtml_Reports_Column_Truncation_In_Semantic_Exports() {
+        using ExcelDocument workbook = ExcelDocument.Create(new MemoryStream());
+        ExcelSheet sheet = workbook.AddWorksheet("Columns");
+        sheet.CellValue(1, 1, "Visible");
+        sheet.CellValue(1, 4, "Truncated");
+
+        string html = workbook.ToHtml(new ExcelHtmlSaveOptions {
+            Profile = OfficeHtmlConversionProfile.ExcelSemanticTables,
+            MaxColumnsPerSheet = 2
+        });
+
+        Assert.Contains("Columns truncated: 2 of 4 exported.", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("Truncated</td>", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ExcelHtml_EmptyHugeMergeUsesTheBoundedProbeWindow() {
         using ExcelDocument workbook = ExcelDocument.Create(new MemoryStream());
         ExcelSheet sheet = workbook.AddWorksheet("EmptyBounded");

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.cs
@@ -409,6 +409,25 @@ public class HtmlOfficeAdapters {
     }
 
     [Fact]
+    public void ExcelHtml_ReportsTruncationWhenRetainedWindowContainsNoUsedCells() {
+        using ExcelDocument workbook = ExcelDocument.Create(new MemoryStream());
+        ExcelSheet sheet = workbook.AddWorksheet("Sparse");
+        sheet.CellValue(1, A1.MaxColumns, "Far column");
+        sheet.CellValue(A1.MaxRows, 1, "Far row");
+
+        string html = workbook.ToHtml(new ExcelHtmlSaveOptions {
+            Profile = OfficeHtmlConversionProfile.ExcelSemanticTables,
+            MaxRowsPerSheet = 2,
+            MaxColumnsPerSheet = 2
+        });
+
+        Assert.Contains("No cells within export limits.", html, StringComparison.Ordinal);
+        Assert.Contains("Columns truncated: 2 of 16384 exported.", html, StringComparison.Ordinal);
+        Assert.Contains("Rows truncated: 2 of 1048576 exported.", html, StringComparison.Ordinal);
+        Assert.DoesNotContain("No used cells.", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ExcelHtml_RoundTripsHiddenWorksheetVisibility() {
         using ExcelDocument workbook = ExcelDocument.Create(new MemoryStream());
         ExcelSheet visible = workbook.AddWorksheet("Visible");

--- a/OfficeIMO.Html.Tests/Html.Rendering.Backgrounds.cs
+++ b/OfficeIMO.Html.Tests/Html.Rendering.Backgrounds.cs
@@ -182,6 +182,30 @@ public sealed partial class HtmlRenderingTests {
         Assert.DoesNotContain(OfficeIMO.Html.HtmlConversionDocument.Parse(html).ToPdfDocumentResult(pdfOptions).Report.Warnings, warning => warning.Severity == PdfCore.PdfConversionWarningSeverity.Error);
     }
 
+    [Theory]
+    [InlineData("repeat-x", true, false, 4)]
+    [InlineData("repeat-y", false, true, 2)]
+    public void HtmlSvgBackgroundRepeat_PreservesSingleAxisPatterns(string repeat, bool repeatX, bool repeatY, int expectedTiles) {
+        const string svgSource = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'>"
+            + "<rect width='10' height='10' fill='red'/></svg>";
+        string data = Convert.ToBase64String(Encoding.UTF8.GetBytes(svgSource));
+        string html = "<div style=\"width:40px;height:20px;background-image:url('data:image/svg+xml;base64,"
+            + data
+            + "');background-size:10px 10px;background-repeat:"
+            + repeat
+            + "\"></div>";
+
+        HtmlRenderDocument rendered = HtmlRenderTestDriver.Render(HtmlConversionDocument.Parse(html));
+        HtmlRenderDrawing visual = Assert.Single(
+            rendered.Pages[0].Visuals.OfType<HtmlRenderDrawing>(),
+            item => item.Source != null && item.Source.Contains(":background-image", StringComparison.Ordinal));
+        OfficeDrawingTilingPattern pattern = Assert.Single(visual.InnerDrawing.Elements.OfType<OfficeDrawingTilingPattern>());
+
+        Assert.Equal(repeatX, pattern.RepeatX);
+        Assert.Equal(repeatY, pattern.RepeatY);
+        Assert.Equal(expectedTiles, pattern.GetTileTransforms().Count);
+    }
+
     [Fact]
     public void HtmlRender_DiagnosesDeterministicBackgroundFallbacks() {
         string imageData = Convert.ToBase64String(PdfPngTestImages.CreateRgbPng(2, 1));

--- a/OfficeIMO.Html.Tests/Html.Rendering.Backgrounds.cs
+++ b/OfficeIMO.Html.Tests/Html.Rendering.Backgrounds.cs
@@ -157,9 +157,9 @@ public sealed partial class HtmlRenderingTests {
         };
 
         HtmlRenderDocument rendered = HtmlRenderTestDriver.Render(HtmlConversionDocument.Parse(html), options);
-        HtmlRenderClipGroup pattern = Assert.Single(
-            rendered.Pages[0].Visuals.OfType<HtmlRenderClipGroup>(),
-            visual => visual.Source != null && visual.Source.Contains(":background-image:pattern-clip", StringComparison.Ordinal));
+        HtmlRenderDrawing pattern = Assert.Single(
+            rendered.Pages[0].Visuals.OfType<HtmlRenderDrawing>(),
+            visual => visual.Source != null && visual.Source.Contains(":background-image", StringComparison.Ordinal));
         OfficeRasterImage raster = OfficeDrawingRasterRenderer.Render(rendered.Pages[0].CreateDrawing());
         string svg = HtmlConversionDocument.Parse(html).ToSvg(options);
         HtmlPdfSaveOptions pdfOptions = new HtmlPdfSaveOptions();
@@ -167,7 +167,7 @@ public sealed partial class HtmlRenderingTests {
         byte[] pdf = OfficeIMO.Html.HtmlConversionDocument.Parse(html).ToPdf(pdfOptions);
         string pdfText = string.Concat(PdfCore.PdfReadDocument.Open(pdf).ExtractText().Where(character => !char.IsWhiteSpace(character)));
 
-        Assert.Equal(8, pattern.Visuals.OfType<HtmlRenderDrawing>().Count());
+        Assert.Single(pattern.InnerDrawing.Elements.OfType<OfficeDrawingTilingPattern>());
         Assert.Equal(OfficeColor.Red, raster.GetPixel(9, 9));
         Assert.Equal(OfficeColor.Blue, raster.GetPixel(14, 9));
         Assert.Equal(OfficeColor.Red, raster.GetPixel(19, 9));

--- a/OfficeIMO.Html.Tests/Html.Rendering.Backgrounds.cs
+++ b/OfficeIMO.Html.Tests/Html.Rendering.Backgrounds.cs
@@ -166,6 +166,7 @@ public sealed partial class HtmlRenderingTests {
         pdfOptions = new HtmlPdfSaveOptions(options);
         byte[] pdf = OfficeIMO.Html.HtmlConversionDocument.Parse(html).ToPdf(pdfOptions);
         string pdfText = string.Concat(PdfCore.PdfReadDocument.Open(pdf).ExtractText().Where(character => !char.IsWhiteSpace(character)));
+        OfficeDrawing pdfDrawing = PdfCore.PdfPageImageRenderer.RenderPage(pdf);
 
         Assert.Single(pattern.InnerDrawing.Elements.OfType<OfficeDrawingTilingPattern>());
         Assert.Equal(OfficeColor.Red, raster.GetPixel(9, 9));
@@ -175,6 +176,7 @@ public sealed partial class HtmlRenderingTests {
         Assert.DoesNotContain("data:image/svg+xml", svg, StringComparison.Ordinal);
         Assert.True(CountBackgroundOccurrences(svg, "<rect") >= 16);
         Assert.Contains("SvgBgPdf", pdfText, StringComparison.Ordinal);
+        Assert.Contains(pdfDrawing.Shapes, shape => shape.Shape.FillColor == OfficeColor.Red);
         Assert.Empty(PdfCore.PdfImageExtractor.ExtractImages(pdf));
         Assert.DoesNotContain(rendered.Diagnostics, diagnostic => diagnostic.Code == HtmlRenderDiagnosticCodes.SvgContentUnsupported);
         Assert.DoesNotContain(OfficeIMO.Html.HtmlConversionDocument.Parse(html).ToPdfDocumentResult(pdfOptions).Report.Warnings, warning => warning.Severity == PdfCore.PdfConversionWarningSeverity.Error);

--- a/OfficeIMO.Html.Tests/Html.Rendering.Fonts.cs
+++ b/OfficeIMO.Html.Tests/Html.Rendering.Fonts.cs
@@ -9,6 +9,25 @@ namespace OfficeIMO.Tests;
 
 public sealed partial class HtmlRenderingTests {
     [Fact]
+    public void HtmlRender_KeepsRtlGlyphPositionsAlignedWithScopedFontKerning() {
+        byte[] fontData = CreateHtmlRenderTestFont(0x05D0, kerningAdjustment: -100);
+        string encoded = Convert.ToBase64String(fontData);
+        string html = "<style>@font-face{font-family:'Kerned Hebrew';src:url('data:font/ttf;base64,"
+            + encoded
+            + "')}</style><p dir='rtl' style=\"margin:0;font-family:'Kerned Hebrew';font-size:20px\">\u05D0\u05D0\u05D0</p>";
+
+        HtmlRenderDocument rendered = HtmlRenderTestDriver.Render(HtmlConversionDocument.Parse(html));
+        HtmlRenderLogicalTextGroup group = Assert.Single(
+            EnumerateRenderVisuals(rendered.Pages[0].Scene).OfType<HtmlRenderLogicalTextGroup>(),
+            item => item.Text == "\u05D0\u05D0\u05D0");
+        IReadOnlyList<HtmlRenderText> glyphs = group.Visuals.OfType<HtmlRenderText>().ToList();
+
+        Assert.Equal(3, glyphs.Count);
+        Assert.Equal(group.X, glyphs.Min(glyph => glyph.X), 6);
+        Assert.Equal(group.X + group.Width, glyphs.Max(glyph => glyph.X + glyph.Width), 6);
+    }
+
+    [Fact]
     public void HtmlRender_UsesSharedGlyphCoveragePlanAcrossFontFamilyFallbacks() {
         string emoji = char.ConvertFromUtf32(0x1F600);
         byte[] emojiFont = CreateHtmlRenderTestFont(0x1F600);
@@ -278,7 +297,7 @@ public sealed partial class HtmlRenderingTests {
         Assert.DoesNotContain(result.Report.Warnings, diagnostic => diagnostic.Code == HtmlPdfDiagnosticCodes.RenderedFontFamilyLimitExceeded);
     }
 
-    private static byte[] CreateHtmlRenderTestFont(int scalar = 0x1F600) {
+    private static byte[] CreateHtmlRenderTestFont(int scalar = 0x1F600, short kerningAdjustment = 0) {
         byte[] cmap = CreateHtmlRenderFormat12Cmap(scalar);
         var tables = new List<(string Tag, byte[] Data)> {
             ("cmap", cmap),
@@ -289,6 +308,7 @@ public sealed partial class HtmlRenderingTests {
             ("loca", new byte[4]),
             ("maxp", new byte[] { 0x00, 0x01, 0x00, 0x00, 0x00, 0x02 })
         };
+        if (kerningAdjustment != 0) tables.Add(("kern", CreateHtmlRenderKerningTable(kerningAdjustment)));
         int directoryLength = 12 + tables.Count * 16;
         var offsets = new int[tables.Count];
         int length = directoryLength;
@@ -309,6 +329,19 @@ public sealed partial class HtmlRenderingTests {
         }
 
         return font;
+    }
+
+    private static byte[] CreateHtmlRenderKerningTable(short adjustment) {
+        var table = new byte[24];
+        WriteHtmlRenderUInt16(table, 2, 1);
+        WriteHtmlRenderUInt16(table, 6, 20);
+        WriteHtmlRenderUInt16(table, 8, 1);
+        WriteHtmlRenderUInt16(table, 10, 1);
+        WriteHtmlRenderUInt16(table, 12, 6);
+        WriteHtmlRenderUInt16(table, 18, 1);
+        WriteHtmlRenderUInt16(table, 20, 1);
+        WriteHtmlRenderUInt16(table, 22, unchecked((ushort)adjustment));
+        return table;
     }
 
     private static byte[] CreateHtmlRenderFormat12Cmap(int scalar) {

--- a/OfficeIMO.Html.Tests/Html.Rendering.Fonts.cs
+++ b/OfficeIMO.Html.Tests/Html.Rendering.Fonts.cs
@@ -226,6 +226,41 @@ public sealed partial class HtmlRenderingTests {
     }
 
     [Fact]
+    public void HtmlPdf_DirectRenderer_EmbedsWebFontUsedByRepeatedSvgBackgroundText() {
+        OfficeTrueTypeFont? font = OfficeTrueTypeFont.TryLoadDefault(out string? fontPath);
+        if (font == null
+            || string.IsNullOrWhiteSpace(fontPath)
+            || !string.Equals(Path.GetExtension(fontPath), ".ttf", StringComparison.OrdinalIgnoreCase)) {
+            return;
+        }
+
+        byte[] fontData = File.ReadAllBytes(fontPath!);
+        if (fontData.LongLength > 10L * 1024L * 1024L) {
+            return;
+        }
+
+        const string svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 24'>"
+            + "<text x='2' y='17' font-family='Pdf Tile Demo' font-size='12'>TiledFontMarker</text></svg>";
+        string html = "<style>@font-face{font-family:'Pdf Tile Demo';src:url(\"data:font/ttf;base64,"
+            + Convert.ToBase64String(fontData)
+            + "\") format('truetype')}</style><div style=\"width:240px;height:48px;background-image:url('data:image/svg+xml;base64,"
+            + Convert.ToBase64String(Encoding.UTF8.GetBytes(svg))
+            + "');background-size:120px 24px;background-repeat:repeat\"></div>";
+
+        HtmlRenderDocument rendered = HtmlRenderTestDriver.Render(HtmlConversionDocument.Parse(html));
+        PdfCore.PdfDocumentConversionResult result = HtmlConversionDocument.Parse(html).ToPdfDocumentResult(new HtmlPdfSaveOptions());
+        byte[] pdf = result.ToBytes();
+
+        HtmlRenderDrawing background = Assert.Single(
+            rendered.Pages[0].Visuals.OfType<HtmlRenderDrawing>(),
+            visual => visual.Source != null && visual.Source.Contains(":background-image", StringComparison.Ordinal));
+        Assert.Single(background.InnerDrawing.Elements.OfType<OfficeDrawingTilingPattern>());
+        Assert.Contains("TiledFontMarker", PdfCore.PdfReadDocument.Open(pdf).ExtractText(), StringComparison.Ordinal);
+        Assert.True(PdfCore.PdfDiagnostics.Analyze(pdf).EmbeddedFontCount > 0);
+        Assert.DoesNotContain(result.Report.Warnings, diagnostic => diagnostic.Code == HtmlRenderDiagnosticCodes.FontFaceUnavailable);
+    }
+
+    [Fact]
     public void HtmlPdf_DirectRenderer_EmbedsWebFontsWithoutConsumingStandardFontSlots() {
         OfficeTrueTypeFont? font = OfficeTrueTypeFont.TryLoadDefault(out string? fontPath);
         if (font == null

--- a/OfficeIMO.Html.Tests/Html.Rendering.Fonts.cs
+++ b/OfficeIMO.Html.Tests/Html.Rendering.Fonts.cs
@@ -261,6 +261,26 @@ public sealed partial class HtmlRenderingTests {
     }
 
     [Fact]
+    public void HtmlPdf_DirectRenderer_ActivatesManagedFallbackForUnicodeRepeatedSvgBackgroundText() {
+        const string marker = "שלום";
+        const string svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 24'>"
+            + "<text x='2' y='17' font-size='12'>" + marker + "</text></svg>";
+        string html = "<div style=\"width:240px;height:48px;background-image:url('data:image/svg+xml;base64,"
+            + Convert.ToBase64String(Encoding.UTF8.GetBytes(svg))
+            + "');background-size:120px 24px;background-repeat:repeat\"></div>";
+
+        HtmlRenderDocument rendered = HtmlRenderTestDriver.Render(HtmlConversionDocument.Parse(html));
+
+        HtmlRenderDrawing background = Assert.Single(
+            rendered.Pages[0].Visuals.OfType<HtmlRenderDrawing>(),
+            visual => visual.Source != null && visual.Source.Contains(":background-image", StringComparison.Ordinal));
+        Assert.Single(background.InnerDrawing.Elements.OfType<OfficeDrawingTilingPattern>());
+        Assert.Equal(
+            PdfCore.PdfTextFallbackFeatures.Default,
+            HtmlPdfRenderedConverter.ResolveTextFallbackFeatures(rendered, PdfCore.PdfTextFallbackFeatures.Default));
+    }
+
+    [Fact]
     public void HtmlPdf_DirectRenderer_EmbedsWebFontsWithoutConsumingStandardFontSlots() {
         OfficeTrueTypeFont? font = OfficeTrueTypeFont.TryLoadDefault(out string? fontPath);
         if (font == null

--- a/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.BackgroundDrawings.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.BackgroundDrawings.cs
@@ -25,7 +25,9 @@ internal sealed partial class HtmlRenderLayoutEngine {
             pattern.VerticalStep,
             originX: tile.X - area.X,
             originY: tile.Y - area.Y,
-            maximumTileCount: maximumTileCount);
+            maximumTileCount: maximumTileCount,
+            repeatX: pattern.RepeatX,
+            repeatY: pattern.RepeatY);
         visuals.Add(HtmlRenderDrawing.CreateShared(
             patternDrawing,
             area.X,

--- a/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.BackgroundDrawings.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.BackgroundDrawings.cs
@@ -9,30 +9,33 @@ internal sealed partial class HtmlRenderLayoutEngine {
         OfficeImagePatternLayout pattern,
         int maximumTileCount,
         string visualSourceDescription) {
-        var tiles = new List<HtmlRenderVisual>();
-        foreach (OfficeImagePlacement tile in pattern.GetTilePlacements(maximumTileCount)) {
-            tiles.Add(HtmlRenderDrawing.CreateShared(
-                drawing,
-                tile.X,
-                tile.Y,
-                tile.Width,
-                tile.Height,
-                tiles.Count,
-                alternativeText: null,
-                linkUri: null,
-                source: visualSourceDescription));
-        }
-        if (tiles.Count == 0) return;
-        visuals.Add(new HtmlRenderClipGroup(
-            pattern.Area.X,
-            pattern.Area.Y,
-            pattern.Area.Width,
-            pattern.Area.Height,
-            clipHorizontal: true,
-            clipVertical: true,
-            tiles,
+        if (pattern.EstimatedTileCount <= 0L || pattern.EstimatedTileCount > maximumTileCount) return;
+        OfficeImagePlacement tile = pattern.Tile;
+        var tileDrawing = new OfficeDrawing(tile.Width, tile.Height);
+        tileDrawing.AddEffectDrawing(drawing, OfficeTransform.Scale(
+            tile.Width / drawing.Width,
+            tile.Height / drawing.Height));
+
+        OfficeImagePlacement area = pattern.Area;
+        var patternDrawing = new OfficeDrawing(area.Width, area.Height);
+        patternDrawing.AddTilingPattern(
+            tileDrawing,
+            new OfficeImagePlacement(0D, 0D, area.Width, area.Height),
+            pattern.HorizontalStep,
+            pattern.VerticalStep,
+            originX: tile.X - area.X,
+            originY: tile.Y - area.Y,
+            maximumTileCount: maximumTileCount);
+        visuals.Add(HtmlRenderDrawing.CreateShared(
+            patternDrawing,
+            area.X,
+            area.Y,
+            area.Width,
+            area.Height,
             visuals.Count,
-            visualSourceDescription + ":pattern-clip"));
+            alternativeText: null,
+            linkUri: null,
+            source: visualSourceDescription));
     }
 
     private static void AddVisibleBackgroundDrawing(

--- a/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Bidi.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Bidi.cs
@@ -62,12 +62,12 @@ internal sealed partial class HtmlRenderLayoutEngine {
     }
 
     private void AppendRightToLeftPaintSegments(List<InlinePaintSegment> result, InlineDirectionalGroup group, double x, OfficeFontInfo font) {
-        var prefix = new StringBuilder();
         double right = x + group.Width;
         foreach (string element in OfficeTextElements.Enumerate(group.Text)) {
-            prefix.Append(element);
-            double elementX = right - MeasureText(prefix.ToString(), font);
-            result.Add(new InlinePaintSegment(element, elementX, Math.Max(0.01D, MeasureText(element, font))));
+            CheckCancellation();
+            double width = Math.Max(0.01D, MeasureText(element, font));
+            right -= width;
+            result.Add(new InlinePaintSegment(element, right, width));
         }
     }
 

--- a/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Bidi.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Bidi.cs
@@ -62,12 +62,21 @@ internal sealed partial class HtmlRenderLayoutEngine {
     }
 
     private void AppendRightToLeftPaintSegments(List<InlinePaintSegment> result, InlineDirectionalGroup group, double x, OfficeFontInfo font) {
+        IReadOnlyList<string> elements = OfficeTextElements.Enumerate(group.Text).ToList();
+        bool hasContextualWidths = _fonts.TryMeasureTextElements(
+            group.Text,
+            elements,
+            font.Size,
+            font.FamilyName,
+            font.Style,
+            out IReadOnlyList<double> contextualWidths);
         double right = x + group.Width;
-        foreach (string element in OfficeTextElements.Enumerate(group.Text)) {
+        for (int index = 0; index < elements.Count; index++) {
             CheckCancellation();
-            double width = Math.Max(0.01D, MeasureText(element, font));
-            right -= width;
-            result.Add(new InlinePaintSegment(element, right, width));
+            string element = elements[index];
+            double advance = hasContextualWidths ? contextualWidths[index] : MeasureText(element, font);
+            right -= advance;
+            result.Add(new InlinePaintSegment(element, right, Math.Max(0.01D, advance)));
         }
     }
 

--- a/OfficeIMO.Html/Rendering/HtmlRenderPage.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderPage.cs
@@ -111,7 +111,8 @@ public sealed class HtmlRenderPage {
             }
         } else if (visual is HtmlRenderImage image) {
             var placement = new OfficeImagePlacement(image.X, image.Y, image.Width, image.Height);
-            drawing.AddImage(image.EncodedBytes, image.ContentType, new OfficeImageProjection(placement, image.SourceCrop), image.AlternativeText);
+            drawing.AddImageShared(image.EncodedBytes, image.ContentType,
+                new OfficeImageProjection(placement, image.SourceCrop), image.AlternativeText);
         } else if (visual is HtmlRenderDrawing vector) {
             OfficeTransform transform = OfficeTransform.Scale(
                     vector.Width / vector.InnerDrawing.Width,
@@ -119,7 +120,7 @@ public sealed class HtmlRenderPage {
                 .Then(OfficeTransform.Translate(vector.X, vector.Y));
             drawing.AddEffectDrawing(vector.InnerDrawing, transform);
         } else if (visual is HtmlRenderImagePattern imagePattern) {
-            drawing.AddImagePattern(
+            drawing.AddImagePatternShared(
                 imagePattern.EncodedBytes,
                 imagePattern.ContentType,
                 imagePattern.Pattern,

--- a/OfficeIMO.OpenDocument.Tests/OpenDocument.RepeatedTableRows.cs
+++ b/OfficeIMO.OpenDocument.Tests/OpenDocument.RepeatedTableRows.cs
@@ -7,6 +7,23 @@ namespace OfficeIMO.OpenDocument.Tests;
 
 public sealed class OpenDocumentRepeatedTableRowTests {
     [Fact]
+    public void TextAndPresentationTablesRejectExcessiveLogicalRepeats() {
+        OdtDocument text = OdtDocument.Create();
+        OdtTable textTable = text.AddTable(1, 1, "BoundedText");
+        textTable.Element.Elements(OdfNamespaces.Table + "table-row").Single()
+            .SetAttributeValue(OdfNamespaces.Table + "number-rows-repeated", 1000001);
+
+        OdpPresentation presentation = OdpPresentation.Create();
+        OdpTable presentationTable = presentation.AddSlide("Bounded").AddTable(
+            OdfRect.FromCentimeters(1, 1, 8, 4), 1, 1, "BoundedPresentation");
+        presentationTable.Element.Descendants(OdfNamespaces.Table + "table-row").Single()
+            .SetAttributeValue(OdfNamespaces.Table + "number-rows-repeated", 1000001);
+
+        Assert.Throws<InvalidDataException>(() => _ = textTable.Rows);
+        Assert.Throws<InvalidDataException>(() => _ = presentationTable.Rows);
+    }
+
+    [Fact]
     public void TextAndPresentationTablesExposeRepeatedRowsLogically() {
         OdtDocument text = OdtDocument.Create();
         OdtTable textTable = text.AddTable(1, 1, "RepeatedText");

--- a/OfficeIMO.OpenDocument/Xml/OdfRepeatedElementCollection.cs
+++ b/OfficeIMO.OpenDocument/Xml/OdfRepeatedElementCollection.cs
@@ -2,6 +2,7 @@ namespace OfficeIMO.OpenDocument;
 
 /// <summary>Projects repeated ODF XML elements as a lazy logical read-only list.</summary>
 internal sealed class OdfRepeatedElementCollection<T> : IReadOnlyList<T> {
+    private const int MaximumLogicalItems = 1000000;
     private readonly IReadOnlyList<XElement> _elements;
     private readonly XName _repeatAttribute;
     private readonly Func<XElement, long, T> _factory;
@@ -15,7 +16,9 @@ internal sealed class OdfRepeatedElementCollection<T> : IReadOnlyList<T> {
         long count = 0;
         foreach (XElement element in elements) {
             count = checked(count + OdsRepeatModel.Read(element, repeatAttribute));
-            if (count > int.MaxValue) throw new InvalidDataException("ODF collection exceeds the supported logical item count.");
+            if (count > MaximumLogicalItems) {
+                throw new InvalidDataException($"ODF collection exceeds the supported logical item limit of {MaximumLogicalItems}.");
+            }
         }
         _count = (int)count;
     }

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.Accessibility.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.Accessibility.cs
@@ -201,6 +201,20 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void AccessibilityRejectsShapeTreesBeyondTheConfiguredLimit() {
+            using var stream = new MemoryStream();
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(stream, new PowerPointCreateOptions());
+            PowerPointSlide slide = presentation.AddSlide();
+            slide.AddRectanglePoints(10, 10, 20, 20, "One");
+            slide.AddRectanglePoints(40, 10, 20, 20, "Two");
+
+            Assert.Throws<InvalidOperationException>(() => presentation.InspectAccessibility(
+                new PowerPointAccessibilityOptions { MaximumShapeCount = 1 }));
+            Assert.Throws<InvalidOperationException>(() => presentation.InspectPreflight(
+                new PowerPointDeckPreflightOptions { MaximumShapeCount = 1 }));
+        }
+
+        [Fact]
         public void AccessibilityReportIsStableForGeneratedAndReloadedDecks() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
             string reportPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".json");

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.Accessibility.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.Accessibility.cs
@@ -215,6 +215,35 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void AccessibilityBoundsGroupChildrenWhileMaterializingTheTree() {
+            using var stream = new MemoryStream();
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(stream, new PowerPointCreateOptions());
+            PowerPointSlide slide = presentation.AddSlide();
+            PowerPointAutoShape first = slide.AddRectanglePoints(10, 10, 20, 20, "One");
+            PowerPointAutoShape second = slide.AddRectanglePoints(40, 10, 20, 20, "Two");
+            PowerPointGroupShape group = slide.GroupShapes(new PowerPointShape[] { first, second }, "Bounded group");
+
+            Assert.Throws<InvalidOperationException>(() => slide.GetGroupChildren(group, maximumChildren: 1));
+            Assert.Throws<InvalidOperationException>(() => presentation.InspectAccessibility(
+                new PowerPointAccessibilityOptions { MaximumShapeCount = 2 }));
+            Assert.Throws<InvalidOperationException>(() => presentation.InspectPreflight(
+                new PowerPointDeckPreflightOptions { MaximumShapeCount = 2 }));
+        }
+
+        [Fact]
+        public void PackageFingerprintBoundsRelationshipFanOutWhileCollectingParts() {
+            using var stream = new MemoryStream();
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(stream, new PowerPointCreateOptions());
+            presentation.AddSlide();
+
+            Assert.ThrowsAny<IOException>(() => PowerPointPackageFingerprint.CollectParts(
+                presentation.OpenXmlDocument,
+                maximumPartCount: 100,
+                maximumPartDepth: 100,
+                maximumRelationshipCount: 1));
+        }
+
+        [Fact]
         public void AccessibilityReportIsStableForGeneratedAndReloadedDecks() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
             string reportPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".json");

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.Accessibility.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.Accessibility.cs
@@ -244,6 +244,19 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void PackageFingerprintPreservesUnsavedSlideRoots() {
+            using var stream = new MemoryStream();
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(stream, new PowerPointCreateOptions());
+            PowerPointSlide slide = presentation.AddSlide();
+            slide.AddRectanglePoints(10, 10, 20, 20, "Unsaved shape");
+
+            _ = PowerPointPackageFingerprint.Create(presentation.OpenXmlDocument);
+
+            Assert.Single(slide.Shapes);
+            Assert.Empty(slide.ClassicAnimations);
+        }
+
+        [Fact]
         public void AccessibilityReportIsStableForGeneratedAndReloadedDecks() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
             string reportPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".json");

--- a/OfficeIMO.PowerPoint/Internal/PowerPointPackageFingerprint.cs
+++ b/OfficeIMO.PowerPoint/Internal/PowerPointPackageFingerprint.cs
@@ -7,6 +7,13 @@ using DocumentFormat.OpenXml.Packaging;
 namespace OfficeIMO.PowerPoint {
     /// <summary>Creates deterministic fingerprints over a presentation package and its relationships.</summary>
     internal static class PowerPointPackageFingerprint {
+        private const int MaximumPartCount = 100000;
+        private const int MaximumPartDepth = 256;
+        private const int MaximumRelationshipCount = 1000000;
+        private const int MaximumNormalizedXmlCharacters = 64 * 1024 * 1024;
+        private const long MaximumNormalizedXmlBytes = 64L * 1024 * 1024;
+        private const long MaximumContentBytes = 512L * 1024 * 1024;
+
         internal static string Create(PresentationDocument document,
             Action<OpenXmlPart, OpenXmlElement>? normalizeRoot = null,
             Func<OpenXmlPart, bool>? includePart = null,
@@ -16,59 +23,74 @@ namespace OfficeIMO.PowerPoint {
                 includeDataPartReferenceRelationship = null,
             bool includePackageProperties = true) {
             if (document == null) throw new ArgumentNullException(nameof(document));
-            var parts = new HashSet<OpenXmlPart>();
-            foreach (IdPartPair pair in document.Parts) CollectParts(pair.OpenXmlPart, parts);
+            HashSet<OpenXmlPart> parts = CollectParts(document);
+            using var content = new FingerprintWriter(MaximumContentBytes, MaximumRelationshipCount);
 
-            var content = new StringBuilder();
             foreach (OpenXmlPart part in parts.OrderBy(item => item.Uri.ToString(), StringComparer.Ordinal)) {
                 if (includePart != null && !includePart(part)) continue;
-                content.Append(part.Uri).Append('|').Append(part.ContentType).Append('|');
+                content.Append(part.Uri.ToString());
+                content.Append(part.ContentType);
                 try {
+                    if (IsXmlContentType(part.ContentType)) {
+                        using (Stream source = part.GetStream(FileMode.Open, FileAccess.Read)) {
+                            if (source.CanSeek && source.Length - source.Position > MaximumNormalizedXmlBytes) {
+                                throw new FingerprintLimitExceededException(
+                                    "A presentation XML part exceeds the fingerprint normalization limit.");
+                            }
+                        }
+                    }
                     OpenXmlPartRootElement? root = part.RootElement;
                     if (root != null) {
-                        if (normalizeRoot == null) {
-                            content.Append(root.OuterXml);
-                        } else {
+                        if (normalizeRoot != null) {
                             OpenXmlElement normalized = root.CloneNode(true);
                             normalizeRoot(part, normalized);
-                            content.Append(normalized.OuterXml);
+                            string xml = normalized.OuterXml;
+                            if (xml.Length > MaximumNormalizedXmlCharacters) {
+                                throw new FingerprintLimitExceededException(
+                                    "A normalized presentation XML part exceeds the fingerprint limit.");
+                            }
+                            content.Append(xml);
+                        } else {
+                            string xml = root.OuterXml;
+                            if (xml.Length > MaximumNormalizedXmlCharacters) {
+                                throw new FingerprintLimitExceededException(
+                                    "A presentation XML part exceeds the fingerprint limit.");
+                            }
+                            content.Append(xml);
                         }
                     } else {
                         using Stream stream = part.GetStream(FileMode.Open, FileAccess.Read);
-                        using var memory = new MemoryStream();
-                        stream.CopyTo(memory);
-                        content.Append(Convert.ToBase64String(memory.ToArray()));
+                        content.Append(stream);
                     }
-                } catch (InvalidDataException) {
+                } catch (FingerprintLimitExceededException) {
+                    throw;
+                } catch (Exception exception) when (exception is InvalidDataException || exception is IOException) {
                     content.Append("unreadable");
                 }
+
                 foreach (IdPartPair relationship in part.Parts.OrderBy(item => item.RelationshipId,
                              StringComparer.Ordinal)) {
                     if (includeRelationship != null && !includeRelationship(part, relationship)) continue;
-                    content.Append('|').Append(relationship.RelationshipId).Append('=')
-                        .Append(relationship.OpenXmlPart.Uri);
+                    content.CountRelationship();
+                    content.Append(relationship.RelationshipId);
+                    content.Append(relationship.OpenXmlPart.Uri.ToString());
                 }
-                foreach (DataPartReferenceRelationship relationship in part
-                             .DataPartReferenceRelationships
-                             .OrderBy(item => item.Id,
-                                 StringComparer.Ordinal)) {
-                    if (includeDataPartReferenceRelationship != null
-                        && !includeDataPartReferenceRelationship(part,
-                            relationship)) continue;
+                foreach (DataPartReferenceRelationship relationship in part.DataPartReferenceRelationships
+                             .OrderBy(item => item.Id, StringComparer.Ordinal)) {
+                    if (includeDataPartReferenceRelationship != null &&
+                        !includeDataPartReferenceRelationship(part, relationship)) continue;
+                    content.CountRelationship();
                     DataPart dataPart = relationship.DataPart;
-                    content.Append("|data:").Append(relationship.Id)
-                        .Append('=').Append(relationship.RelationshipType)
-                        .Append('>').Append(dataPart.Uri).Append('|')
-                        .Append(dataPart.ContentType).Append('|');
+                    content.Append(relationship.Id);
+                    content.Append(relationship.RelationshipType);
+                    content.Append(dataPart.Uri.ToString());
+                    content.Append(dataPart.ContentType);
                     try {
-                        using Stream stream = dataPart.GetStream(
-                            FileMode.Open, FileAccess.Read);
-                        using SHA256 dataHash = SHA256.Create();
-                        content.Append(Convert.ToBase64String(
-                            dataHash.ComputeHash(stream)));
-                    } catch (Exception exception) when (
-                        exception is InvalidDataException
-                        || exception is IOException) {
+                        using Stream stream = dataPart.GetStream(FileMode.Open, FileAccess.Read);
+                        content.Append(stream);
+                    } catch (FingerprintLimitExceededException) {
+                        throw;
+                    } catch (Exception exception) when (exception is InvalidDataException || exception is IOException) {
                         content.Append("unreadable");
                     }
                 }
@@ -77,17 +99,18 @@ namespace OfficeIMO.PowerPoint {
                     .Concat(part.HyperlinkRelationships)
                     .OrderBy(item => item.Id, StringComparer.Ordinal);
                 foreach (ReferenceRelationship relationship in references) {
-                    if (includeReferenceRelationship != null
-                        && !includeReferenceRelationship(part, relationship)) continue;
-                    content.Append("|ref:").Append(relationship.Id).Append('=')
-                        .Append(relationship.RelationshipType).Append('>')
-                        .Append(relationship.Uri.OriginalString);
+                    if (includeReferenceRelationship != null &&
+                        !includeReferenceRelationship(part, relationship)) continue;
+                    content.CountRelationship();
+                    content.Append(relationship.Id);
+                    content.Append(relationship.RelationshipType);
+                    content.Append(relationship.Uri.OriginalString);
                 }
             }
 
             if (includePackageProperties) {
                 var properties = document.PackageProperties;
-                content.Append("|core|");
+                content.Append("core");
                 AppendPackageProperty(content, "Creator", properties.Creator);
                 AppendPackageProperty(content, "Title", properties.Title);
                 AppendPackageProperty(content, "Description", properties.Description);
@@ -109,21 +132,116 @@ namespace OfficeIMO.PowerPoint {
                     .ToUniversalTime().Ticks.ToString(CultureInfo.InvariantCulture));
             }
 
-            using SHA256 sha = SHA256.Create();
-            return Convert.ToBase64String(sha.ComputeHash(Encoding.UTF8.GetBytes(content.ToString())));
+            return content.Complete();
         }
 
-        private static void CollectParts(OpenXmlPart part, ISet<OpenXmlPart> parts) {
-            if (!parts.Add(part)) return;
-            foreach (IdPartPair child in part.Parts) CollectParts(child.OpenXmlPart, parts);
+        private static HashSet<OpenXmlPart> CollectParts(PresentationDocument document) {
+            var parts = new HashSet<OpenXmlPart>();
+            var pending = new Stack<(OpenXmlPart Part, int Depth)>();
+            foreach (IdPartPair pair in document.Parts) pending.Push((pair.OpenXmlPart, 0));
+            while (pending.Count > 0) {
+                (OpenXmlPart part, int depth) = pending.Pop();
+                if (!parts.Add(part)) continue;
+                if (parts.Count > MaximumPartCount) {
+                    throw new FingerprintLimitExceededException(
+                        "The presentation part count exceeds the fingerprint limit.");
+                }
+                if (depth > MaximumPartDepth) {
+                    throw new FingerprintLimitExceededException(
+                        "The presentation part graph depth exceeds the fingerprint limit.");
+                }
+                foreach (IdPartPair child in part.Parts) pending.Push((child.OpenXmlPart, depth + 1));
+            }
+            return parts;
         }
 
-        private static void AppendPackageProperty(StringBuilder content,
-            string name, string? value) {
-            string resolved = value ?? string.Empty;
-            content.Append(name.Length).Append(':').Append(name)
-                .Append('=').Append(resolved.Length).Append(':')
-                .Append(resolved).Append(';');
+        private static void AppendPackageProperty(FingerprintWriter content, string name, string? value) {
+            content.Append(name);
+            content.Append(value ?? string.Empty);
+        }
+
+        private static bool IsXmlContentType(string? contentType) =>
+            !string.IsNullOrWhiteSpace(contentType) &&
+            (contentType!.EndsWith("+xml", StringComparison.OrdinalIgnoreCase) ||
+             contentType.IndexOf("/xml", StringComparison.OrdinalIgnoreCase) >= 0);
+
+        private sealed class FingerprintWriter : IDisposable {
+            private readonly IncrementalHash _hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            private readonly byte[] _buffer = new byte[81920];
+            private readonly char[] _charBuffer = new char[16384];
+            private readonly long _maximumBytes;
+            private readonly int _maximumRelationships;
+            private long _bytes;
+            private int _relationships;
+
+            internal FingerprintWriter(long maximumBytes, int maximumRelationships) {
+                _maximumBytes = maximumBytes;
+                _maximumRelationships = maximumRelationships;
+            }
+
+            internal void Append(string value) {
+                value ??= string.Empty;
+                int byteCount = Encoding.UTF8.GetByteCount(value);
+                AppendLength(byteCount);
+                Consume(byteCount);
+                Encoder encoder = Encoding.UTF8.GetEncoder();
+                int characterIndex = 0;
+                while (characterIndex < value.Length) {
+                    int characterCount = Math.Min(_charBuffer.Length, value.Length - characterIndex);
+                    value.CopyTo(characterIndex, _charBuffer, 0, characterCount);
+                    characterIndex += characterCount;
+                    encoder.Convert(
+                        _charBuffer, 0, characterCount,
+                        _buffer, 0, _buffer.Length,
+                        characterIndex == value.Length,
+                        out _, out int bytesUsed, out _);
+                    if (bytesUsed > 0) _hash.AppendData(_buffer, 0, bytesUsed);
+                }
+            }
+
+            internal void Append(Stream stream) {
+                long declaredLength = stream.CanSeek ? stream.Length - stream.Position : -1L;
+                AppendLength(declaredLength);
+                bool precharged = declaredLength >= 0L;
+                if (precharged) Consume(declaredLength);
+                int read;
+                while ((read = stream.Read(_buffer, 0, _buffer.Length)) > 0) {
+                    if (!precharged) Consume(read);
+                    _hash.AppendData(_buffer, 0, read);
+                }
+            }
+
+            internal void CountRelationship() {
+                if (++_relationships > _maximumRelationships) {
+                    throw new FingerprintLimitExceededException(
+                        "The presentation relationship count exceeds the fingerprint limit.");
+                }
+            }
+
+            internal string Complete() {
+                return Convert.ToBase64String(_hash.GetHashAndReset());
+            }
+
+            public void Dispose() {
+                _hash.Dispose();
+            }
+
+            private void AppendLength(long length) {
+                byte[] lengthBytes = BitConverter.GetBytes(length);
+                _hash.AppendData(lengthBytes);
+            }
+
+            private void Consume(long count) {
+                _bytes += count;
+                if (_bytes > _maximumBytes) {
+                    throw new FingerprintLimitExceededException(
+                        "The presentation content exceeds the fingerprint byte limit.");
+                }
+            }
+        }
+
+        private sealed class FingerprintLimitExceededException : IOException {
+            internal FingerprintLimitExceededException(string message) : base(message) { }
         }
     }
 }

--- a/OfficeIMO.PowerPoint/Internal/PowerPointPackageFingerprint.cs
+++ b/OfficeIMO.PowerPoint/Internal/PowerPointPackageFingerprint.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
+using System.Xml;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 
@@ -10,7 +11,6 @@ namespace OfficeIMO.PowerPoint {
         private const int MaximumPartCount = 100000;
         private const int MaximumPartDepth = 256;
         private const int MaximumRelationshipCount = 1000000;
-        private const int MaximumNormalizedXmlCharacters = 64 * 1024 * 1024;
         private const long MaximumNormalizedXmlBytes = 64L * 1024 * 1024;
         private const long MaximumContentBytes = 512L * 1024 * 1024;
 
@@ -32,32 +32,14 @@ namespace OfficeIMO.PowerPoint {
                 content.Append(part.Uri.ToString());
                 content.Append(part.ContentType);
                 try {
-                    if (IsXmlContentType(part.ContentType)) {
-                        using (Stream source = part.GetStream(FileMode.Open, FileAccess.Read)) {
-                            if (source.CanSeek && source.Length - source.Position > MaximumNormalizedXmlBytes) {
-                                throw new FingerprintLimitExceededException(
-                                    "A presentation XML part exceeds the fingerprint normalization limit.");
-                            }
-                        }
-                    }
                     OpenXmlPartRootElement? root = part.RootElement;
                     if (root != null) {
                         if (normalizeRoot != null) {
                             OpenXmlElement normalized = root.CloneNode(true);
                             normalizeRoot(part, normalized);
-                            string xml = normalized.OuterXml;
-                            if (xml.Length > MaximumNormalizedXmlCharacters) {
-                                throw new FingerprintLimitExceededException(
-                                    "A normalized presentation XML part exceeds the fingerprint limit.");
-                            }
-                            content.Append(xml);
+                            content.AppendXml(normalized, MaximumNormalizedXmlBytes);
                         } else {
-                            string xml = root.OuterXml;
-                            if (xml.Length > MaximumNormalizedXmlCharacters) {
-                                throw new FingerprintLimitExceededException(
-                                    "A presentation XML part exceeds the fingerprint limit.");
-                            }
-                            content.Append(xml);
+                            content.AppendXml(root, MaximumNormalizedXmlBytes);
                         }
                     } else {
                         using Stream stream = part.GetStream(FileMode.Open, FileAccess.Read);
@@ -178,11 +160,6 @@ namespace OfficeIMO.PowerPoint {
             content.Append(value ?? string.Empty);
         }
 
-        private static bool IsXmlContentType(string? contentType) =>
-            !string.IsNullOrWhiteSpace(contentType) &&
-            (contentType!.EndsWith("+xml", StringComparison.OrdinalIgnoreCase) ||
-             contentType.IndexOf("/xml", StringComparison.OrdinalIgnoreCase) >= 0);
-
         private sealed class FingerprintWriter : IDisposable {
             private readonly IncrementalHash _hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
             private readonly byte[] _buffer = new byte[81920];
@@ -229,6 +206,27 @@ namespace OfficeIMO.PowerPoint {
                 }
             }
 
+            internal void AppendXml(OpenXmlElement element, long maximumXmlBytes) {
+                if (element == null) throw new ArgumentNullException(nameof(element));
+                if (maximumXmlBytes <= 0L) throw new ArgumentOutOfRangeException(nameof(maximumXmlBytes));
+                using var xmlHash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+                var xmlStream = new BoundedHashStream(xmlHash, maximumXmlBytes);
+                var settings = new XmlWriterSettings {
+                    CloseOutput = false,
+                    ConformanceLevel = ConformanceLevel.Fragment,
+                    Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                    OmitXmlDeclaration = true
+                };
+                using (XmlWriter writer = XmlWriter.Create(xmlStream, settings)) {
+                    element.WriteTo(writer);
+                }
+
+                Consume(xmlStream.BytesWritten);
+                Append("xml");
+                AppendLength(xmlStream.BytesWritten);
+                _hash.AppendData(xmlHash.GetHashAndReset());
+            }
+
             internal void CountRelationship() {
                 if (++_relationships > _maximumRelationships) {
                     throw new FingerprintLimitExceededException(
@@ -250,12 +248,53 @@ namespace OfficeIMO.PowerPoint {
             }
 
             private void Consume(long count) {
-                _bytes += count;
-                if (_bytes > _maximumBytes) {
+                if (count < 0L || count > _maximumBytes - _bytes) {
                     throw new FingerprintLimitExceededException(
                         "The presentation content exceeds the fingerprint byte limit.");
                 }
+                _bytes += count;
             }
+        }
+
+        private sealed class BoundedHashStream : Stream {
+            private readonly IncrementalHash _hash;
+            private readonly long _maximumBytes;
+
+            internal BoundedHashStream(IncrementalHash hash, long maximumBytes) {
+                _hash = hash ?? throw new ArgumentNullException(nameof(hash));
+                _maximumBytes = maximumBytes;
+            }
+
+            internal long BytesWritten { get; private set; }
+
+            public override bool CanRead => false;
+            public override bool CanSeek => false;
+            public override bool CanWrite => true;
+            public override long Length => BytesWritten;
+            public override long Position {
+                get => BytesWritten;
+                set => throw new NotSupportedException();
+            }
+
+            public override void Flush() { }
+
+            public override void Write(byte[] buffer, int offset, int count) {
+                if (buffer == null) throw new ArgumentNullException(nameof(buffer));
+                if (offset < 0 || count < 0 || offset > buffer.Length - count) {
+                    throw new ArgumentOutOfRangeException();
+                }
+                if (count > _maximumBytes - BytesWritten) {
+                    throw new FingerprintLimitExceededException(
+                        "A presentation XML part exceeds the fingerprint normalization limit.");
+                }
+                if (count == 0) return;
+                _hash.AppendData(buffer, offset, count);
+                BytesWritten += count;
+            }
+
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
         }
 
         private sealed class FingerprintLimitExceededException : IOException {

--- a/OfficeIMO.PowerPoint/Internal/PowerPointPackageFingerprint.cs
+++ b/OfficeIMO.PowerPoint/Internal/PowerPointPackageFingerprint.cs
@@ -23,7 +23,8 @@ namespace OfficeIMO.PowerPoint {
                 includeDataPartReferenceRelationship = null,
             bool includePackageProperties = true) {
             if (document == null) throw new ArgumentNullException(nameof(document));
-            HashSet<OpenXmlPart> parts = CollectParts(document);
+            HashSet<OpenXmlPart> parts = CollectParts(
+                document, MaximumPartCount, MaximumPartDepth, MaximumRelationshipCount);
             using var content = new FingerprintWriter(MaximumContentBytes, MaximumRelationshipCount);
 
             foreach (OpenXmlPart part in parts.OrderBy(item => item.Uri.ToString(), StringComparer.Ordinal)) {
@@ -135,22 +136,39 @@ namespace OfficeIMO.PowerPoint {
             return content.Complete();
         }
 
-        private static HashSet<OpenXmlPart> CollectParts(PresentationDocument document) {
+        internal static HashSet<OpenXmlPart> CollectParts(PresentationDocument document,
+            int maximumPartCount, int maximumPartDepth, int maximumRelationshipCount) {
+            if (document == null) throw new ArgumentNullException(nameof(document));
+            if (maximumPartCount <= 0) throw new ArgumentOutOfRangeException(nameof(maximumPartCount));
+            if (maximumPartDepth < 0) throw new ArgumentOutOfRangeException(nameof(maximumPartDepth));
+            if (maximumRelationshipCount <= 0) throw new ArgumentOutOfRangeException(nameof(maximumRelationshipCount));
             var parts = new HashSet<OpenXmlPart>();
+            var scheduled = new HashSet<OpenXmlPart>();
             var pending = new Stack<(OpenXmlPart Part, int Depth)>();
-            foreach (IdPartPair pair in document.Parts) pending.Push((pair.OpenXmlPart, 0));
-            while (pending.Count > 0) {
-                (OpenXmlPart part, int depth) = pending.Pop();
-                if (!parts.Add(part)) continue;
-                if (parts.Count > MaximumPartCount) {
+            int relationshipCount = 0;
+
+            void Schedule(OpenXmlPart part, int depth) {
+                if (++relationshipCount > maximumRelationshipCount) {
+                    throw new FingerprintLimitExceededException(
+                        "The presentation relationship count exceeds the fingerprint limit.");
+                }
+                if (!scheduled.Add(part)) return;
+                if (scheduled.Count > maximumPartCount) {
                     throw new FingerprintLimitExceededException(
                         "The presentation part count exceeds the fingerprint limit.");
                 }
-                if (depth > MaximumPartDepth) {
+                if (depth > maximumPartDepth) {
                     throw new FingerprintLimitExceededException(
                         "The presentation part graph depth exceeds the fingerprint limit.");
                 }
-                foreach (IdPartPair child in part.Parts) pending.Push((child.OpenXmlPart, depth + 1));
+                pending.Push((part, depth));
+            }
+
+            foreach (IdPartPair pair in document.Parts) Schedule(pair.OpenXmlPart, 0);
+            while (pending.Count > 0) {
+                (OpenXmlPart part, int depth) = pending.Pop();
+                parts.Add(part);
+                foreach (IdPartPair child in part.Parts) Schedule(child.OpenXmlPart, depth + 1);
             }
             return parts;
         }

--- a/OfficeIMO.PowerPoint/PowerPointAccessibilityPolicy.cs
+++ b/OfficeIMO.PowerPoint/PowerPointAccessibilityPolicy.cs
@@ -13,6 +13,20 @@ namespace OfficeIMO.PowerPoint {
     public sealed class PowerPointAccessibilityOptions {
         private double _minimumTextContrastRatio = 4.5D;
         private double _minimumLargeTextContrastRatio = 3D;
+        private int _maximumShapeCount = 10000;
+        private int _maximumGroupDepth = 128;
+
+        /// <summary>Maximum number of shapes inspected on one slide.</summary>
+        public int MaximumShapeCount {
+            get => _maximumShapeCount;
+            set => _maximumShapeCount = ValidatePositive(value, nameof(MaximumShapeCount));
+        }
+
+        /// <summary>Maximum supported nesting depth for grouped shapes.</summary>
+        public int MaximumGroupDepth {
+            get => _maximumGroupDepth;
+            set => _maximumGroupDepth = ValidatePositive(value, nameof(MaximumGroupDepth));
+        }
 
         /// <summary>Selected built-in profile. Use <see cref="ForProfile"/> to apply its defaults.</summary>
         public PowerPointAccessibilityPolicyProfile Profile { get; set; } = PowerPointAccessibilityPolicyProfile.Default;
@@ -103,8 +117,15 @@ namespace OfficeIMO.PowerPoint {
                 MinimumTextContrastRatio = MinimumTextContrastRatio,
                 MinimumLargeTextContrastRatio = MinimumLargeTextContrastRatio,
                 LargeTextThresholdPoints = LargeTextThresholdPoints,
-                LargeBoldTextThresholdPoints = LargeBoldTextThresholdPoints
+                LargeBoldTextThresholdPoints = LargeBoldTextThresholdPoints,
+                MaximumShapeCount = MaximumShapeCount,
+                MaximumGroupDepth = MaximumGroupDepth
             };
+        }
+
+        private static int ValidatePositive(int value, string name) {
+            if (value <= 0) throw new ArgumentOutOfRangeException(name, "Value must be positive.");
+            return value;
         }
 
         private static double ValidateContrast(double value, string name) {

--- a/OfficeIMO.PowerPoint/PowerPointDeckPreflightOptions.cs
+++ b/OfficeIMO.PowerPoint/PowerPointDeckPreflightOptions.cs
@@ -10,6 +10,20 @@ namespace OfficeIMO.PowerPoint {
         private double _collisionTolerancePoints = 1D;
         private double _defaultFontSizePoints = 18D;
         private double _maximumDecorativeBleedPoints = 36D;
+        private int _maximumShapeCount = 10000;
+        private int _maximumGroupDepth = 128;
+
+        /// <summary>Maximum number of shapes inspected across the presentation.</summary>
+        public int MaximumShapeCount {
+            get => _maximumShapeCount;
+            set => _maximumShapeCount = RequirePositive(value, nameof(MaximumShapeCount));
+        }
+
+        /// <summary>Maximum supported nesting depth for grouped shapes.</summary>
+        public int MaximumGroupDepth {
+            get => _maximumGroupDepth;
+            set => _maximumGroupDepth = RequirePositive(value, nameof(MaximumGroupDepth));
+        }
 
         /// <summary>Checks whether explicit slide shapes extend beyond the slide canvas.</summary>
         public bool DetectOffSlideShapes { get; set; } = true;
@@ -110,8 +124,18 @@ namespace OfficeIMO.PowerPoint {
             DefaultFontSizePoints = DefaultFontSizePoints,
             MinimumCollisionOverlapRatio = MinimumCollisionOverlapRatio,
             CollisionTolerancePoints = CollisionTolerancePoints,
+            MaximumShapeCount = MaximumShapeCount,
+            MaximumGroupDepth = MaximumGroupDepth,
             FailureSeverity = FailureSeverity
         };
+
+        private static int RequirePositive(int value, string propertyName) {
+            if (value <= 0) {
+                throw new ArgumentOutOfRangeException(propertyName, "Value must be positive.");
+            }
+
+            return value;
+        }
 
         private static double RequirePositive(double value, string propertyName) {
             if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0D) {

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.Accessibility.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.Accessibility.cs
@@ -25,9 +25,8 @@ namespace OfficeIMO.PowerPoint {
             for (int slideIndex = 0; slideIndex < _slides.Count; slideIndex++) {
                 PowerPointSlide slide = _slides[slideIndex];
                 if (slide.Hidden && !resolved.IncludeHiddenSlides) continue;
-                List<PowerPointShape> shapes = EnumerateAccessibilityShapes(slide).ToList();
-                string? slideTitle = FindSlideTitle(slide.EnumerateShapesDeep(slide.Shapes),
-                    SlideSize.HeightPoints);
+                List<PowerPointShape> shapes = EnumerateAccessibilityShapes(slide, resolved).ToList();
+                string? slideTitle = FindSlideTitle(shapes, SlideSize.HeightPoints);
                 if (resolved.RequireSlideTitles && string.IsNullOrWhiteSpace(slideTitle)) {
                     findings.Add(new PowerPointAccessibilityFinding(PowerPointAccessibilitySeverity.Error,
                         "Accessibility.MissingSlideTitle", "The slide does not expose a recognizable title.", slideIndex));
@@ -47,8 +46,10 @@ namespace OfficeIMO.PowerPoint {
             return new PowerPointAccessibilityReport(resolved.Profile, slideInfos, findings);
         }
 
-        private static IEnumerable<PowerPointShape> EnumerateAccessibilityShapes(PowerPointSlide slide) {
-            return slide.EnumerateShapesDeep(slide.GetInheritedShapesForExport().Concat(slide.Shapes));
+        private static IEnumerable<PowerPointShape> EnumerateAccessibilityShapes(PowerPointSlide slide,
+            PowerPointAccessibilityOptions options) {
+            return slide.EnumerateShapesDeep(slide.GetInheritedShapesForExport().Concat(slide.Shapes),
+                includeHidden: false, options.MaximumShapeCount, options.MaximumGroupDepth);
         }
 
         private static string? FindSlideTitle(IEnumerable<PowerPointShape> shapes, double slideHeightPoints) {

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.Accessibility.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.Accessibility.cs
@@ -26,7 +26,10 @@ namespace OfficeIMO.PowerPoint {
                 PowerPointSlide slide = _slides[slideIndex];
                 if (slide.Hidden && !resolved.IncludeHiddenSlides) continue;
                 List<PowerPointShape> shapes = EnumerateAccessibilityShapes(slide, resolved).ToList();
-                string? slideTitle = FindSlideTitle(shapes, SlideSize.HeightPoints);
+                string? slideTitle = FindSlideTitle(
+                    slide.EnumerateShapesDeep(slide.Shapes, includeHidden: false,
+                        resolved.MaximumShapeCount, resolved.MaximumGroupDepth),
+                    SlideSize.HeightPoints);
                 if (resolved.RequireSlideTitles && string.IsNullOrWhiteSpace(slideTitle)) {
                     findings.Add(new PowerPointAccessibilityFinding(PowerPointAccessibilitySeverity.Error,
                         "Accessibility.MissingSlideTitle", "The slide does not expose a recognizable title.", slideIndex));

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.Preflight.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.Preflight.cs
@@ -83,8 +83,10 @@ namespace OfficeIMO.PowerPoint {
                     InspectPicture(picture, reportShapeIndex, slideIndex, findings);
                 }
                 if (shape is PowerPointGroupShape groupShape) {
-                    IReadOnlyList<PowerPointShape> children = slide.GetGroupChildren(groupShape);
-                    InspectShapeTree(slide, children, slideIndex, slide.GetGroupChildBounds(groupShape),
+                    int remainingShapeCount = options.MaximumShapeCount - inspectedShapeCount;
+                    IReadOnlyList<PowerPointShape> children = slide.GetGroupChildren(groupShape, remainingShapeCount);
+                    InspectShapeTree(slide, children, slideIndex,
+                        PowerPointSlide.GetGroupChildBounds(groupShape, children),
                         options, findings, reportShapeIndex, groupDepth + 1, ref inspectedShapeCount);
                 }
             }

--- a/OfficeIMO.PowerPoint/PowerPointPresentation.Preflight.cs
+++ b/OfficeIMO.PowerPoint/PowerPointPresentation.Preflight.cs
@@ -15,10 +15,12 @@ namespace OfficeIMO.PowerPoint {
             var findings = new List<PowerPointDeckPreflightFinding>();
             long slideWidth = SlideSize.WidthEmus;
             long slideHeight = SlideSize.HeightEmus;
+            int inspectedShapeCount = 0;
 
             for (int slideIndex = 0; slideIndex < Slides.Count; slideIndex++) {
                 PowerPointSlide slide = Slides[slideIndex];
-                InspectSlide(slide, slideIndex, slideWidth, slideHeight, resolved, findings);
+                InspectSlide(slide, slideIndex, slideWidth, slideHeight, resolved, findings,
+                    ref inspectedShapeCount);
             }
 
             return new PowerPointDeckPreflightReport(Slides.Count, findings);
@@ -42,9 +44,11 @@ namespace OfficeIMO.PowerPoint {
             InspectPreflight(options);
 
         private static void InspectSlide(PowerPointSlide slide, int slideIndex, long slideWidth, long slideHeight,
-            PowerPointDeckPreflightOptions options, IList<PowerPointDeckPreflightFinding> findings) {
+            PowerPointDeckPreflightOptions options, IList<PowerPointDeckPreflightFinding> findings,
+            ref int inspectedShapeCount) {
             InspectShapeTree(slide, slide.Shapes, slideIndex,
-                new PowerPointLayoutBox(0L, 0L, slideWidth, slideHeight), options, findings, null);
+                new PowerPointLayoutBox(0L, 0L, slideWidth, slideHeight), options, findings, null,
+                0, ref inspectedShapeCount);
 
             if (options.IncludeVisualSnapshotDiagnostics) {
                 InspectVisualSnapshot(slide, slideIndex, findings);
@@ -53,9 +57,16 @@ namespace OfficeIMO.PowerPoint {
 
         private static void InspectShapeTree(PowerPointSlide slide, IReadOnlyList<PowerPointShape> shapes,
             int slideIndex, PowerPointLayoutBox canvas, PowerPointDeckPreflightOptions options,
-            IList<PowerPointDeckPreflightFinding> findings, int? containingShapeIndex) {
+            IList<PowerPointDeckPreflightFinding> findings, int? containingShapeIndex, int groupDepth,
+            ref int inspectedShapeCount) {
+            if (groupDepth > options.MaximumGroupDepth) {
+                throw new InvalidOperationException("The grouped-shape nesting depth exceeds the configured limit.");
+            }
             for (int shapeIndex = 0; shapeIndex < shapes.Count; shapeIndex++) {
                 PowerPointShape shape = shapes[shapeIndex];
+                if (++inspectedShapeCount > options.MaximumShapeCount) {
+                    throw new InvalidOperationException("The shape count exceeds the configured inspection limit.");
+                }
                 int reportShapeIndex = containingShapeIndex ?? shapeIndex;
                 if (shape.Hidden) {
                     continue;
@@ -74,7 +85,7 @@ namespace OfficeIMO.PowerPoint {
                 if (shape is PowerPointGroupShape groupShape) {
                     IReadOnlyList<PowerPointShape> children = slide.GetGroupChildren(groupShape);
                     InspectShapeTree(slide, children, slideIndex, slide.GetGroupChildBounds(groupShape),
-                        options, findings, reportShapeIndex);
+                        options, findings, reportShapeIndex, groupDepth + 1, ref inspectedShapeCount);
                 }
             }
 

--- a/OfficeIMO.PowerPoint/PowerPointSlide.GroupLayout.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.GroupLayout.cs
@@ -9,10 +9,15 @@ namespace OfficeIMO.PowerPoint {
         /// <summary>
         ///     Returns the child shapes of a group shape.
         /// </summary>
-        public IReadOnlyList<PowerPointShape> GetGroupChildren(PowerPointGroupShape groupShape) {
+        public IReadOnlyList<PowerPointShape> GetGroupChildren(PowerPointGroupShape groupShape) =>
+            GetGroupChildren(groupShape, int.MaxValue);
+
+        internal IReadOnlyList<PowerPointShape> GetGroupChildren(PowerPointGroupShape groupShape,
+            int maximumChildren) {
             if (groupShape == null) {
                 throw new ArgumentNullException(nameof(groupShape));
             }
+            if (maximumChildren < 0) throw new ArgumentOutOfRangeException(nameof(maximumChildren));
 
             GroupShape group = groupShape.GroupShape;
             var children = new List<PowerPointShape>();
@@ -23,6 +28,9 @@ namespace OfficeIMO.PowerPoint {
 
                 PowerPointShape? shape = CreateShapeFromElement(child, groupShape.OwnerPart ?? _slidePart);
                 if (shape != null) {
+                    if (children.Count >= maximumChildren) {
+                        throw new InvalidOperationException("The shape count exceeds the configured inspection limit.");
+                    }
                     children.Add(shape.AttachTo(this));
                 }
             }
@@ -45,34 +53,37 @@ namespace OfficeIMO.PowerPoint {
                 throw new ArgumentNullException(nameof(shapes));
             }
 
-            var stack = new Stack<(PowerPointShape Shape, int Depth)>();
-            var roots = new List<PowerPointShape>();
-            foreach (PowerPointShape root in shapes) {
-                if (roots.Count >= maximumShapeCount) {
-                    throw new InvalidOperationException("The shape count exceeds the configured inspection limit.");
-                }
-                roots.Add(root);
-            }
-            for (int index = roots.Count - 1; index >= 0; index--) {
-                stack.Push((roots[index], 0));
-            }
-
+            var stack = new Stack<(IEnumerator<PowerPointShape> Enumerator, int Depth, bool CountOnMove)>();
+            stack.Push((shapes.GetEnumerator(), 0, true));
+            int scheduledShapeCount = 0;
             int shapeCount = 0;
-            while (stack.Count > 0) {
-                (PowerPointShape shape, int depth) = stack.Pop();
-                if (!includeHidden && shape.Hidden) continue;
-                if (depth > maximumGroupDepth) {
-                    throw new InvalidOperationException("The grouped-shape nesting depth exceeds the configured limit.");
+            try {
+                while (stack.Count > 0) {
+                    (IEnumerator<PowerPointShape> enumerator, int depth, bool countOnMove) = stack.Peek();
+                    if (!enumerator.MoveNext()) {
+                        stack.Pop().Enumerator.Dispose();
+                        continue;
+                    }
+                    if (countOnMove && ++scheduledShapeCount > maximumShapeCount) {
+                        throw new InvalidOperationException("The shape count exceeds the configured inspection limit.");
+                    }
+                    PowerPointShape shape = enumerator.Current;
+                    if (!includeHidden && shape.Hidden) continue;
+                    if (depth > maximumGroupDepth) {
+                        throw new InvalidOperationException("The grouped-shape nesting depth exceeds the configured limit.");
+                    }
+                    if (++shapeCount > maximumShapeCount) {
+                        throw new InvalidOperationException("The shape count exceeds the configured inspection limit.");
+                    }
+                    yield return shape;
+                    if (shape is not PowerPointGroupShape groupShape) continue;
+                    int remainingShapeCount = maximumShapeCount - scheduledShapeCount;
+                    IReadOnlyList<PowerPointShape> children = GetGroupChildren(groupShape, remainingShapeCount);
+                    scheduledShapeCount += children.Count;
+                    stack.Push((children.GetEnumerator(), depth + 1, false));
                 }
-                if (++shapeCount > maximumShapeCount) {
-                    throw new InvalidOperationException("The shape count exceeds the configured inspection limit.");
-                }
-                yield return shape;
-                if (shape is not PowerPointGroupShape groupShape) continue;
-                IReadOnlyList<PowerPointShape> children = GetGroupChildren(groupShape);
-                for (int index = children.Count - 1; index >= 0; index--) {
-                    stack.Push((children[index], depth + 1));
-                }
+            } finally {
+                while (stack.Count > 0) stack.Pop().Enumerator.Dispose();
             }
         }
 
@@ -310,7 +321,7 @@ namespace OfficeIMO.PowerPoint {
             ArrangeShapesInGridAuto(children, GetGroupChildBounds(groupShape, children), options);
         }
 
-        private static PowerPointLayoutBox GetGroupChildBounds(PowerPointGroupShape groupShape,
+        internal static PowerPointLayoutBox GetGroupChildBounds(PowerPointGroupShape groupShape,
             IReadOnlyList<PowerPointShape> children) {
             A.TransformGroup? transform = groupShape.GroupShape.GroupShapeProperties?.TransformGroup;
             long? x = transform?.ChildOffset?.X?.Value;

--- a/OfficeIMO.PowerPoint/PowerPointSlide.GroupLayout.cs
+++ b/OfficeIMO.PowerPoint/PowerPointSlide.GroupLayout.cs
@@ -36,15 +36,42 @@ namespace OfficeIMO.PowerPoint {
         /// </summary>
         public IEnumerable<PowerPointShape> EnumerateShapesDeep(IEnumerable<PowerPointShape> shapes,
             bool includeHidden = false) {
+            return EnumerateShapesDeep(shapes, includeHidden, 10000, 128);
+        }
+
+        internal IEnumerable<PowerPointShape> EnumerateShapesDeep(IEnumerable<PowerPointShape> shapes,
+            bool includeHidden, int maximumShapeCount, int maximumGroupDepth) {
             if (shapes == null) {
                 throw new ArgumentNullException(nameof(shapes));
             }
-            foreach (PowerPointShape shape in shapes) {
+
+            var stack = new Stack<(PowerPointShape Shape, int Depth)>();
+            var roots = new List<PowerPointShape>();
+            foreach (PowerPointShape root in shapes) {
+                if (roots.Count >= maximumShapeCount) {
+                    throw new InvalidOperationException("The shape count exceeds the configured inspection limit.");
+                }
+                roots.Add(root);
+            }
+            for (int index = roots.Count - 1; index >= 0; index--) {
+                stack.Push((roots[index], 0));
+            }
+
+            int shapeCount = 0;
+            while (stack.Count > 0) {
+                (PowerPointShape shape, int depth) = stack.Pop();
                 if (!includeHidden && shape.Hidden) continue;
+                if (depth > maximumGroupDepth) {
+                    throw new InvalidOperationException("The grouped-shape nesting depth exceeds the configured limit.");
+                }
+                if (++shapeCount > maximumShapeCount) {
+                    throw new InvalidOperationException("The shape count exceeds the configured inspection limit.");
+                }
                 yield return shape;
                 if (shape is not PowerPointGroupShape groupShape) continue;
-                foreach (PowerPointShape child in EnumerateShapesDeep(GetGroupChildren(groupShape), includeHidden)) {
-                    yield return child;
+                IReadOnlyList<PowerPointShape> children = GetGroupChildren(groupShape);
+                for (int index = children.Count - 1; index >= 0; index--) {
+                    stack.Push((children[index], depth + 1));
                 }
             }
         }

--- a/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
@@ -184,20 +184,27 @@ public static partial class ReaderHierarchicalChunker {
         var seenIds = new HashSet<string>(StringComparer.Ordinal);
         IReadOnlyList<OfficeDocumentPage> pages = document.Pages ?? Array.Empty<OfficeDocumentPage>();
         PageBlockIndex pageIndex = IndexPageBlocks(pages, maximumInputChunks, cancellationToken);
-        int inspectedBlocks = 0;
+        int maximumInspections = (int)Math.Min(int.MaxValue, (long)maximumInputChunks * 4L);
+        int emittedBlocks = 0;
+        int inspectedDocumentBlocks = 0;
         IReadOnlyList<OfficeDocumentBlock> documentBlocks = document.Blocks ?? Array.Empty<OfficeDocumentBlock>();
         for (int blockIndex = 0; blockIndex < documentBlocks.Count; blockIndex++) {
-            if (inspectedBlocks >= maximumInputChunks) {
+            if (inspectedDocumentBlocks >= maximumInspections) {
                 yield return FallbackBlock.LimitMarker;
                 yield break;
             }
             cancellationToken.ThrowIfCancellationRequested();
-            inspectedBlocks++;
+            inspectedDocumentBlocks++;
             OfficeDocumentBlock block = documentBlocks[blockIndex];
             if (!TryRegisterFallbackBlock(block, seen, seenIds)) continue;
+            if (emittedBlocks >= maximumInputChunks) {
+                yield return FallbackBlock.LimitMarker;
+                yield break;
+            }
             if (!pageIndex.ByReference.TryGetValue(block, out OfficeDocumentPage? page) && !string.IsNullOrWhiteSpace(block.Id)) {
                 pageIndex.ById.TryGetValue(block.Id!, out page);
             }
+            emittedBlocks++;
             yield return new FallbackBlock(block, page);
         }
         int inspectedPageBlocks = 0;
@@ -207,7 +214,7 @@ public static partial class ReaderHierarchicalChunker {
             if (page?.Blocks == null) continue;
             IReadOnlyList<OfficeDocumentBlock> pageBlocks = page.Blocks;
             for (int blockIndex = 0; blockIndex < pageBlocks.Count; blockIndex++) {
-                if (inspectedPageBlocks >= maximumInputChunks) {
+                if (inspectedPageBlocks >= maximumInspections) {
                     yield return FallbackBlock.LimitMarker;
                     yield break;
                 }
@@ -215,11 +222,11 @@ public static partial class ReaderHierarchicalChunker {
                 inspectedPageBlocks++;
                 OfficeDocumentBlock block = pageBlocks[blockIndex];
                 if (!TryRegisterFallbackBlock(block, seen, seenIds)) continue;
-                if (inspectedBlocks >= maximumInputChunks) {
+                if (emittedBlocks >= maximumInputChunks) {
                     yield return FallbackBlock.LimitMarker;
                     yield break;
                 }
-                inspectedBlocks++;
+                emittedBlocks++;
                 yield return new FallbackBlock(block, page);
             }
         }

--- a/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
@@ -200,8 +200,9 @@ public static partial class ReaderHierarchicalChunker {
             }
             yield return new FallbackBlock(block, page);
         }
+        int inspectedPageBlocks = 0;
         for (int pageIndexValue = 0; pageIndexValue < pages.Count; pageIndexValue++) {
-            if (pageIndexValue >= maximumInputChunks || inspectedBlocks >= maximumInputChunks) {
+            if (pageIndexValue >= maximumInputChunks) {
                 yield return FallbackBlock.LimitMarker;
                 yield break;
             }
@@ -210,14 +211,20 @@ public static partial class ReaderHierarchicalChunker {
             if (page?.Blocks == null) continue;
             IReadOnlyList<OfficeDocumentBlock> pageBlocks = page.Blocks;
             for (int blockIndex = 0; blockIndex < pageBlocks.Count; blockIndex++) {
-                if (inspectedBlocks >= maximumInputChunks) {
+                if (inspectedPageBlocks >= maximumInputChunks) {
                     yield return FallbackBlock.LimitMarker;
                     yield break;
                 }
                 cancellationToken.ThrowIfCancellationRequested();
-                inspectedBlocks++;
+                inspectedPageBlocks++;
                 OfficeDocumentBlock block = pageBlocks[blockIndex];
-                if (TryRegisterFallbackBlock(block, seen, seenIds)) yield return new FallbackBlock(block, page);
+                if (!TryRegisterFallbackBlock(block, seen, seenIds)) continue;
+                if (inspectedBlocks >= maximumInputChunks) {
+                    yield return FallbackBlock.LimitMarker;
+                    yield break;
+                }
+                inspectedBlocks++;
+                yield return new FallbackBlock(block, page);
             }
         }
     }

--- a/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
@@ -175,19 +175,31 @@ public static partial class ReaderHierarchicalChunker {
         var seenIds = new HashSet<string>(StringComparer.Ordinal);
         IReadOnlyList<OfficeDocumentPage> pages = document.Pages ?? Array.Empty<OfficeDocumentPage>();
         PageBlockIndex pageIndex = IndexPageBlocks(pages, maximumInputChunks, cancellationToken);
-        foreach (OfficeDocumentBlock block in document.Blocks ?? Array.Empty<OfficeDocumentBlock>()) {
+        int inspectedBlocks = 0;
+        IReadOnlyList<OfficeDocumentBlock> documentBlocks = document.Blocks ?? Array.Empty<OfficeDocumentBlock>();
+        for (int blockIndex = 0;
+             blockIndex < documentBlocks.Count && inspectedBlocks < maximumInputChunks;
+             blockIndex++, inspectedBlocks++) {
             cancellationToken.ThrowIfCancellationRequested();
+            OfficeDocumentBlock block = documentBlocks[blockIndex];
             if (!TryRegisterFallbackBlock(block, seen, seenIds)) continue;
             if (!pageIndex.ByReference.TryGetValue(block, out OfficeDocumentPage? page) && !string.IsNullOrWhiteSpace(block.Id)) {
                 pageIndex.ById.TryGetValue(block.Id!, out page);
             }
             yield return new FallbackBlock(block, page);
         }
-        foreach (OfficeDocumentPage page in pages) {
+        for (int pageIndexValue = 0;
+             pageIndexValue < pages.Count && pageIndexValue < maximumInputChunks && inspectedBlocks < maximumInputChunks;
+             pageIndexValue++) {
             cancellationToken.ThrowIfCancellationRequested();
+            OfficeDocumentPage page = pages[pageIndexValue];
             if (page?.Blocks == null) continue;
-            foreach (OfficeDocumentBlock block in page.Blocks) {
+            IReadOnlyList<OfficeDocumentBlock> pageBlocks = page.Blocks;
+            for (int blockIndex = 0;
+                 blockIndex < pageBlocks.Count && inspectedBlocks < maximumInputChunks;
+                 blockIndex++, inspectedBlocks++) {
                 cancellationToken.ThrowIfCancellationRequested();
+                OfficeDocumentBlock block = pageBlocks[blockIndex];
                 if (TryRegisterFallbackBlock(block, seen, seenIds)) yield return new FallbackBlock(block, page);
             }
         }
@@ -209,8 +221,9 @@ public static partial class ReaderHierarchicalChunker {
             ReferenceIdentityComparer<OfficeDocumentBlock>.Instance);
         var byId = new Dictionary<string, OfficeDocumentPage>(StringComparer.Ordinal);
         int visited = 0;
-        foreach (OfficeDocumentPage page in pages) {
+        for (int pageIndex = 0; pageIndex < pages.Count && pageIndex < maximumBlocks; pageIndex++) {
             cancellationToken.ThrowIfCancellationRequested();
+            OfficeDocumentPage page = pages[pageIndex];
             if (page?.Blocks == null) continue;
             foreach (OfficeDocumentBlock block in page.Blocks) {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
@@ -183,8 +183,8 @@ public static partial class ReaderHierarchicalChunker {
         var seen = new HashSet<OfficeDocumentBlock>(ReferenceIdentityComparer<OfficeDocumentBlock>.Instance);
         var seenIds = new HashSet<string>(StringComparer.Ordinal);
         IReadOnlyList<OfficeDocumentPage> pages = document.Pages ?? Array.Empty<OfficeDocumentPage>();
-        PageBlockIndex pageIndex = IndexPageBlocks(pages, maximumInputChunks, cancellationToken);
         int maximumInspections = (int)Math.Min(int.MaxValue, (long)maximumInputChunks * 4L);
+        PageBlockIndex pageIndex = IndexPageBlocks(pages, maximumInspections, cancellationToken);
         int emittedBlocks = 0;
         int inspectedDocumentBlocks = 0;
         IReadOnlyList<OfficeDocumentBlock> documentBlocks = document.Blocks ?? Array.Empty<OfficeDocumentBlock>();

--- a/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
@@ -202,10 +202,6 @@ public static partial class ReaderHierarchicalChunker {
         }
         int inspectedPageBlocks = 0;
         for (int pageIndexValue = 0; pageIndexValue < pages.Count; pageIndexValue++) {
-            if (pageIndexValue >= maximumInputChunks) {
-                yield return FallbackBlock.LimitMarker;
-                yield break;
-            }
             cancellationToken.ThrowIfCancellationRequested();
             OfficeDocumentPage page = pages[pageIndexValue];
             if (page?.Blocks == null) continue;
@@ -245,7 +241,7 @@ public static partial class ReaderHierarchicalChunker {
             ReferenceIdentityComparer<OfficeDocumentBlock>.Instance);
         var byId = new Dictionary<string, OfficeDocumentPage>(StringComparer.Ordinal);
         int visited = 0;
-        for (int pageIndex = 0; pageIndex < pages.Count && pageIndex < maximumBlocks; pageIndex++) {
+        for (int pageIndex = 0; pageIndex < pages.Count; pageIndex++) {
             cancellationToken.ThrowIfCancellationRequested();
             OfficeDocumentPage page = pages[pageIndex];
             if (page?.Blocks == null) continue;

--- a/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
@@ -184,29 +184,36 @@ public static partial class ReaderHierarchicalChunker {
         var seenIds = new HashSet<string>(StringComparer.Ordinal);
         IReadOnlyList<OfficeDocumentPage> pages = document.Pages ?? Array.Empty<OfficeDocumentPage>();
         int maximumInspections = (int)Math.Min(int.MaxValue, (long)maximumInputChunks * 4L);
-        PageBlockIndex pageIndex = IndexPageBlocks(pages, maximumInspections, cancellationToken);
         int emittedBlocks = 0;
-        int inspectedDocumentBlocks = 0;
         IReadOnlyList<OfficeDocumentBlock> documentBlocks = document.Blocks ?? Array.Empty<OfficeDocumentBlock>();
-        for (int blockIndex = 0; blockIndex < documentBlocks.Count; blockIndex++) {
-            if (inspectedDocumentBlocks >= maximumInspections) {
-                yield return FallbackBlock.LimitMarker;
-                yield break;
-            }
+        int documentInspectionCount = Math.Min(documentBlocks.Count, maximumInspections);
+        var retainedDocumentBlocks = new List<OfficeDocumentBlock>(Math.Min(documentInspectionCount, maximumInputChunks));
+        bool documentLimitReached = documentBlocks.Count > documentInspectionCount;
+        for (int blockIndex = 0; blockIndex < documentInspectionCount; blockIndex++) {
             cancellationToken.ThrowIfCancellationRequested();
-            inspectedDocumentBlocks++;
             OfficeDocumentBlock block = documentBlocks[blockIndex];
             if (!TryRegisterFallbackBlock(block, seen, seenIds)) continue;
             if (emittedBlocks >= maximumInputChunks) {
-                yield return FallbackBlock.LimitMarker;
-                yield break;
+                documentLimitReached = true;
+                break;
             }
+            retainedDocumentBlocks.Add(block);
+            emittedBlocks++;
+        }
+
+        PageBlockIndex pageIndex = IndexPageBlocks(pages, retainedDocumentBlocks, cancellationToken);
+        for (int blockIndex = 0; blockIndex < retainedDocumentBlocks.Count; blockIndex++) {
+            OfficeDocumentBlock block = retainedDocumentBlocks[blockIndex];
             if (!pageIndex.ByReference.TryGetValue(block, out OfficeDocumentPage? page) && !string.IsNullOrWhiteSpace(block.Id)) {
                 pageIndex.ById.TryGetValue(block.Id!, out page);
             }
-            emittedBlocks++;
             yield return new FallbackBlock(block, page);
         }
+        if (documentLimitReached) {
+            yield return FallbackBlock.LimitMarker;
+            yield break;
+        }
+
         int inspectedPageBlocks = 0;
         for (int pageIndexValue = 0; pageIndexValue < pages.Count; pageIndexValue++) {
             cancellationToken.ThrowIfCancellationRequested();
@@ -242,22 +249,39 @@ public static partial class ReaderHierarchicalChunker {
 
     private static PageBlockIndex IndexPageBlocks(
         IReadOnlyList<OfficeDocumentPage> pages,
-        int maximumBlocks,
+        IReadOnlyList<OfficeDocumentBlock> targetBlocks,
         CancellationToken cancellationToken) {
         var byReference = new Dictionary<OfficeDocumentBlock, OfficeDocumentPage>(
             ReferenceIdentityComparer<OfficeDocumentBlock>.Instance);
         var byId = new Dictionary<string, OfficeDocumentPage>(StringComparer.Ordinal);
-        int visited = 0;
+        var remaining = new HashSet<OfficeDocumentBlock>(
+            targetBlocks,
+            ReferenceIdentityComparer<OfficeDocumentBlock>.Instance);
+        var targetsById = new Dictionary<string, OfficeDocumentBlock>(StringComparer.Ordinal);
+        for (int targetIndex = 0; targetIndex < targetBlocks.Count; targetIndex++) {
+            OfficeDocumentBlock target = targetBlocks[targetIndex];
+            if (!string.IsNullOrWhiteSpace(target.Id)) {
+                targetsById[target.Id!] = target;
+            }
+        }
+
         for (int pageIndex = 0; pageIndex < pages.Count; pageIndex++) {
             cancellationToken.ThrowIfCancellationRequested();
             OfficeDocumentPage page = pages[pageIndex];
             if (page?.Blocks == null) continue;
             foreach (OfficeDocumentBlock block in page.Blocks) {
                 cancellationToken.ThrowIfCancellationRequested();
-                if (visited++ >= maximumBlocks) return new PageBlockIndex(byReference, byId);
                 if (block == null) continue;
-                if (!byReference.ContainsKey(block)) byReference.Add(block, page);
-                if (!string.IsNullOrWhiteSpace(block.Id) && !byId.ContainsKey(block.Id!)) byId.Add(block.Id!, page);
+                if (remaining.Contains(block)) {
+                    byReference[block] = page;
+                    remaining.Remove(block);
+                }
+                if (!string.IsNullOrWhiteSpace(block.Id) &&
+                    targetsById.TryGetValue(block.Id!, out OfficeDocumentBlock? target)) {
+                    byId[block.Id!] = page;
+                    remaining.Remove(target);
+                }
+                if (remaining.Count == 0) return new PageBlockIndex(byReference, byId);
             }
         }
         return new PageBlockIndex(byReference, byId);

--- a/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
@@ -18,10 +18,11 @@ public static partial class ReaderHierarchicalChunker {
         ReaderHierarchicalChunkingOptions? options = null,
         CancellationToken cancellationToken = default) {
         if (document == null) throw new ArgumentNullException(nameof(document));
+        ReaderHierarchicalChunkingOptions normalized = Normalize(options);
         return ChunkCore(
-            GetSourceChunks(document),
+            GetSourceChunks(document, normalized.MaxInputChunks, cancellationToken),
             document.Source ?? new OfficeDocumentSource(),
-            Normalize(options),
+            normalized,
             cancellationToken,
             enforceSingleSourceIdentity: false);
     }
@@ -101,7 +102,10 @@ public static partial class ReaderHierarchicalChunker {
         return effective;
     }
 
-    private static IEnumerable<ReaderChunk> GetSourceChunks(OfficeDocumentReadResult document) {
+    private static IEnumerable<ReaderChunk> GetSourceChunks(
+        OfficeDocumentReadResult document,
+        int maximumInputChunks,
+        CancellationToken cancellationToken) {
         IReadOnlyList<ReaderChunk> chunks = document.Chunks ?? Array.Empty<ReaderChunk>();
         if (chunks.Count > 0) {
             for (int chunkIndex = 0; chunkIndex < chunks.Count; chunkIndex++) {
@@ -113,7 +117,7 @@ public static partial class ReaderHierarchicalChunker {
 
         var headings = new List<FallbackHeading>();
         int index = 0;
-        foreach (FallbackBlock fallback in EnumerateFallbackBlocks(document)) {
+        foreach (FallbackBlock fallback in EnumerateFallbackBlocks(document, maximumInputChunks, cancellationToken)) {
             OfficeDocumentBlock block = fallback.Block;
             string text = block.Text ?? string.Empty;
             bool isHeading = string.Equals(block.Kind?.Trim(), "heading", StringComparison.OrdinalIgnoreCase);
@@ -163,22 +167,27 @@ public static partial class ReaderHierarchicalChunker {
         }
     }
 
-    private static IEnumerable<FallbackBlock> EnumerateFallbackBlocks(OfficeDocumentReadResult document) {
+    private static IEnumerable<FallbackBlock> EnumerateFallbackBlocks(
+        OfficeDocumentReadResult document,
+        int maximumInputChunks,
+        CancellationToken cancellationToken) {
         var seen = new HashSet<OfficeDocumentBlock>(ReferenceIdentityComparer<OfficeDocumentBlock>.Instance);
         var seenIds = new HashSet<string>(StringComparer.Ordinal);
         IReadOnlyList<OfficeDocumentPage> pages = document.Pages ?? Array.Empty<OfficeDocumentPage>();
-        IReadOnlyDictionary<OfficeDocumentBlock, OfficeDocumentPage> pageByBlock = IndexPageBlocks(pages);
-        IReadOnlyDictionary<string, OfficeDocumentPage> pageByBlockId = IndexPageBlockIds(pages);
+        PageBlockIndex pageIndex = IndexPageBlocks(pages, maximumInputChunks, cancellationToken);
         foreach (OfficeDocumentBlock block in document.Blocks ?? Array.Empty<OfficeDocumentBlock>()) {
+            cancellationToken.ThrowIfCancellationRequested();
             if (!TryRegisterFallbackBlock(block, seen, seenIds)) continue;
-            if (!pageByBlock.TryGetValue(block, out OfficeDocumentPage? page) && !string.IsNullOrWhiteSpace(block.Id)) {
-                pageByBlockId.TryGetValue(block.Id!, out page);
+            if (!pageIndex.ByReference.TryGetValue(block, out OfficeDocumentPage? page) && !string.IsNullOrWhiteSpace(block.Id)) {
+                pageIndex.ById.TryGetValue(block.Id!, out page);
             }
             yield return new FallbackBlock(block, page);
         }
         foreach (OfficeDocumentPage page in pages) {
+            cancellationToken.ThrowIfCancellationRequested();
             if (page?.Blocks == null) continue;
             foreach (OfficeDocumentBlock block in page.Blocks) {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (TryRegisterFallbackBlock(block, seen, seenIds)) yield return new FallbackBlock(block, page);
             }
         }
@@ -192,31 +201,38 @@ public static partial class ReaderHierarchicalChunker {
         return string.IsNullOrWhiteSpace(block.Id) || seenIds.Add(block.Id!);
     }
 
-    private static IReadOnlyDictionary<OfficeDocumentBlock, OfficeDocumentPage> IndexPageBlocks(
-        IReadOnlyList<OfficeDocumentPage> pages) {
-        var pageByBlock = new Dictionary<OfficeDocumentBlock, OfficeDocumentPage>(
+    private static PageBlockIndex IndexPageBlocks(
+        IReadOnlyList<OfficeDocumentPage> pages,
+        int maximumBlocks,
+        CancellationToken cancellationToken) {
+        var byReference = new Dictionary<OfficeDocumentBlock, OfficeDocumentPage>(
             ReferenceIdentityComparer<OfficeDocumentBlock>.Instance);
+        var byId = new Dictionary<string, OfficeDocumentPage>(StringComparer.Ordinal);
+        int visited = 0;
         foreach (OfficeDocumentPage page in pages) {
+            cancellationToken.ThrowIfCancellationRequested();
             if (page?.Blocks == null) continue;
             foreach (OfficeDocumentBlock block in page.Blocks) {
-                if (block != null && !pageByBlock.ContainsKey(block)) pageByBlock.Add(block, page);
+                cancellationToken.ThrowIfCancellationRequested();
+                if (visited++ >= maximumBlocks) return new PageBlockIndex(byReference, byId);
+                if (block == null) continue;
+                if (!byReference.ContainsKey(block)) byReference.Add(block, page);
+                if (!string.IsNullOrWhiteSpace(block.Id) && !byId.ContainsKey(block.Id!)) byId.Add(block.Id!, page);
             }
         }
-        return pageByBlock;
+        return new PageBlockIndex(byReference, byId);
     }
 
-    private static IReadOnlyDictionary<string, OfficeDocumentPage> IndexPageBlockIds(
-        IReadOnlyList<OfficeDocumentPage> pages) {
-        var pageByBlockId = new Dictionary<string, OfficeDocumentPage>(StringComparer.Ordinal);
-        foreach (OfficeDocumentPage page in pages) {
-            if (page?.Blocks == null) continue;
-            foreach (OfficeDocumentBlock block in page.Blocks) {
-                if (block != null && !string.IsNullOrWhiteSpace(block.Id) && !pageByBlockId.ContainsKey(block.Id!)) {
-                    pageByBlockId.Add(block.Id!, page);
-                }
-            }
+    private sealed class PageBlockIndex {
+        internal PageBlockIndex(
+            IReadOnlyDictionary<OfficeDocumentBlock, OfficeDocumentPage> byReference,
+            IReadOnlyDictionary<string, OfficeDocumentPage> byId) {
+            ByReference = byReference;
+            ById = byId;
         }
-        return pageByBlockId;
+
+        internal IReadOnlyDictionary<OfficeDocumentBlock, OfficeDocumentPage> ByReference { get; }
+        internal IReadOnlyDictionary<string, OfficeDocumentPage> ById { get; }
     }
 
     private static ReaderChunk InheritDocumentSource(ReaderChunk chunk, OfficeDocumentSource? source) {

--- a/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
+++ b/OfficeIMO.Reader.Core/ReaderHierarchicalChunker.cs
@@ -11,6 +11,7 @@ namespace OfficeIMO.Reader;
 public static partial class ReaderHierarchicalChunker {
     private static readonly ConditionalWeakTable<ReaderChunk, FallbackHeadingIdentityPath> FallbackHeadingIdentities =
         new ConditionalWeakTable<ReaderChunk, FallbackHeadingIdentityPath>();
+    private static readonly ReaderChunk FallbackInputLimitMarker = new ReaderChunk();
 
     /// <summary>Chunks an already-read rich document.</summary>
     public static ReaderChunkHierarchyResult Chunk(
@@ -53,11 +54,15 @@ public static partial class ReaderHierarchicalChunker {
         while (!state.OutputLimitReached) {
             cancellationToken.ThrowIfCancellationRequested();
             if (!enumerator.MoveNext()) break;
+            ReaderChunk? chunk = enumerator.Current;
+            if (ReferenceEquals(chunk, FallbackInputLimitMarker)) {
+                state.AddLimitDiagnostic("hierarchical-input-chunk-limit", options.MaxInputChunks, "input chunks");
+                break;
+            }
             if (inputIndex >= options.MaxInputChunks) {
                 state.AddLimitDiagnostic("hierarchical-input-chunk-limit", options.MaxInputChunks, "input chunks");
                 break;
             }
-            ReaderChunk? chunk = enumerator.Current;
             if (chunk == null) {
                 state.AddDiagnostic("hierarchical-null-input-chunk", "A null input chunk was skipped.");
                 inputIndex++;
@@ -118,6 +123,10 @@ public static partial class ReaderHierarchicalChunker {
         var headings = new List<FallbackHeading>();
         int index = 0;
         foreach (FallbackBlock fallback in EnumerateFallbackBlocks(document, maximumInputChunks, cancellationToken)) {
+            if (fallback.IsLimitMarker) {
+                yield return FallbackInputLimitMarker;
+                yield break;
+            }
             OfficeDocumentBlock block = fallback.Block;
             string text = block.Text ?? string.Empty;
             bool isHeading = string.Equals(block.Kind?.Trim(), "heading", StringComparison.OrdinalIgnoreCase);
@@ -177,10 +186,13 @@ public static partial class ReaderHierarchicalChunker {
         PageBlockIndex pageIndex = IndexPageBlocks(pages, maximumInputChunks, cancellationToken);
         int inspectedBlocks = 0;
         IReadOnlyList<OfficeDocumentBlock> documentBlocks = document.Blocks ?? Array.Empty<OfficeDocumentBlock>();
-        for (int blockIndex = 0;
-             blockIndex < documentBlocks.Count && inspectedBlocks < maximumInputChunks;
-             blockIndex++, inspectedBlocks++) {
+        for (int blockIndex = 0; blockIndex < documentBlocks.Count; blockIndex++) {
+            if (inspectedBlocks >= maximumInputChunks) {
+                yield return FallbackBlock.LimitMarker;
+                yield break;
+            }
             cancellationToken.ThrowIfCancellationRequested();
+            inspectedBlocks++;
             OfficeDocumentBlock block = documentBlocks[blockIndex];
             if (!TryRegisterFallbackBlock(block, seen, seenIds)) continue;
             if (!pageIndex.ByReference.TryGetValue(block, out OfficeDocumentPage? page) && !string.IsNullOrWhiteSpace(block.Id)) {
@@ -188,17 +200,22 @@ public static partial class ReaderHierarchicalChunker {
             }
             yield return new FallbackBlock(block, page);
         }
-        for (int pageIndexValue = 0;
-             pageIndexValue < pages.Count && pageIndexValue < maximumInputChunks && inspectedBlocks < maximumInputChunks;
-             pageIndexValue++) {
+        for (int pageIndexValue = 0; pageIndexValue < pages.Count; pageIndexValue++) {
+            if (pageIndexValue >= maximumInputChunks || inspectedBlocks >= maximumInputChunks) {
+                yield return FallbackBlock.LimitMarker;
+                yield break;
+            }
             cancellationToken.ThrowIfCancellationRequested();
             OfficeDocumentPage page = pages[pageIndexValue];
             if (page?.Blocks == null) continue;
             IReadOnlyList<OfficeDocumentBlock> pageBlocks = page.Blocks;
-            for (int blockIndex = 0;
-                 blockIndex < pageBlocks.Count && inspectedBlocks < maximumInputChunks;
-                 blockIndex++, inspectedBlocks++) {
+            for (int blockIndex = 0; blockIndex < pageBlocks.Count; blockIndex++) {
+                if (inspectedBlocks >= maximumInputChunks) {
+                    yield return FallbackBlock.LimitMarker;
+                    yield break;
+                }
                 cancellationToken.ThrowIfCancellationRequested();
+                inspectedBlocks++;
                 OfficeDocumentBlock block = pageBlocks[blockIndex];
                 if (TryRegisterFallbackBlock(block, seen, seenIds)) yield return new FallbackBlock(block, page);
             }
@@ -486,10 +503,20 @@ public static partial class ReaderHierarchicalChunker {
         internal FallbackBlock(OfficeDocumentBlock block, OfficeDocumentPage? page) {
             Block = block;
             Page = page;
+            IsLimitMarker = false;
         }
+
+        private FallbackBlock(bool isLimitMarker) {
+            Block = null!;
+            Page = null;
+            IsLimitMarker = isLimitMarker;
+        }
+
+        internal static FallbackBlock LimitMarker { get; } = new FallbackBlock(true);
 
         internal OfficeDocumentBlock Block { get; }
         internal OfficeDocumentPage? Page { get; }
+        internal bool IsLimitMarker { get; }
     }
 
     private readonly struct FallbackHeading {

--- a/OfficeIMO.Reader.Epub/EpubReaderAdapter.Document.cs
+++ b/OfficeIMO.Reader.Epub/EpubReaderAdapter.Document.cs
@@ -48,6 +48,7 @@ internal static partial class EpubReaderAdapter {
     private static OfficeDocumentReadResult BuildEpubDocumentResult(EpubDocument document, SourceMetadata source, ReaderOptions readerOptions, CancellationToken cancellationToken) {
         ReaderChunk[] chunks = ReadDocument(document, source, readerOptions, cancellationToken).ToArray();
         List<OfficeDocumentAsset> assets = BuildEpubAssets(document, source.Path).ToList();
+        Dictionary<string, OfficeDocumentAsset> assetsByLocation = BuildEpubAssetIndex(assets);
         var blocks = new List<OfficeDocumentBlock>();
         var tables = new List<ReaderTable>();
         var links = new List<OfficeDocumentLink>();
@@ -94,12 +95,12 @@ internal static partial class EpubReaderAdapter {
                 chapterTables.AddRange(htmlResult.Tables);
                 chapterLinks.AddRange(resolvedLinks);
                 chapterForms.AddRange(htmlResult.Forms);
-                AddEpubChapterAssets(source.Path, chapter, htmlResult.Assets, assets, chapterAssets, diagnostics);
+                AddEpubChapterAssets(source.Path, chapter, htmlResult.Assets, assets, assetsByLocation, chapterAssets, diagnostics);
                 IReadOnlyList<ReaderVisual> resolvedVisuals = ResolveEpubChapterVisuals(
                     source.Path,
                     chapter,
                     htmlResult.Visuals,
-                    assets,
+                    assetsByLocation,
                     chapterAssets,
                     diagnostics);
                 visuals.AddRange(resolvedVisuals);

--- a/OfficeIMO.Reader.Epub/EpubReaderAdapter.References.cs
+++ b/OfficeIMO.Reader.Epub/EpubReaderAdapter.References.cs
@@ -55,7 +55,7 @@ internal static partial class EpubReaderAdapter {
         string sourcePath,
         EpubChapter chapter,
         IReadOnlyList<ReaderVisual> visuals,
-        List<OfficeDocumentAsset> documentAssets,
+        IReadOnlyDictionary<string, OfficeDocumentAsset> assetsByLocation,
         List<OfficeDocumentAsset> chapterAssets,
         List<OfficeDocumentDiagnostic> diagnostics) {
         var resolvedVisuals = new List<ReaderVisual>(visuals.Count);
@@ -78,7 +78,7 @@ internal static partial class EpubReaderAdapter {
 
             string? location = BuildEpubResolvedLocation(sourcePath, reference, includeFragment: true);
             if (!string.IsNullOrWhiteSpace(location)) visual.SourceName = location;
-            OfficeDocumentAsset? asset = FindEpubAsset(sourcePath, reference, documentAssets);
+            OfficeDocumentAsset? asset = FindEpubAsset(sourcePath, reference, assetsByLocation);
             if (asset != null && !chapterAssets.Contains(asset)) chapterAssets.Add(asset);
             resolvedVisuals.Add(visual);
         }
@@ -88,18 +88,18 @@ internal static partial class EpubReaderAdapter {
     private static OfficeDocumentAsset? FindEpubAsset(
         string sourcePath,
         EpubReference reference,
-        IReadOnlyList<OfficeDocumentAsset> assets) {
+        IReadOnlyDictionary<string, OfficeDocumentAsset> assetsByLocation) {
         string? targetLocation = BuildEpubResolvedLocation(sourcePath, reference, includeFragment: false);
         if (string.IsNullOrWhiteSpace(targetLocation)) return null;
 
-        OfficeDocumentAsset? exact = assets.FirstOrDefault(asset =>
-            string.Equals(asset.Location.Path, targetLocation, StringComparison.Ordinal));
+        assetsByLocation.TryGetValue(targetLocation!, out OfficeDocumentAsset? exact);
         if (exact != null || reference.Kind != EpubReferenceKind.Container || string.IsNullOrWhiteSpace(reference.ContainerPath)) {
             return exact;
         }
 
         string packageLocation = BuildVirtualPath(sourcePath, reference.ContainerPath!);
-        return assets.FirstOrDefault(asset => string.Equals(asset.Location.Path, packageLocation, StringComparison.Ordinal));
+        assetsByLocation.TryGetValue(packageLocation, out OfficeDocumentAsset? packageAsset);
+        return packageAsset;
     }
 
     private static string? BuildEpubResolvedLocation(

--- a/OfficeIMO.Reader.Epub/EpubReaderAdapter.Resources.cs
+++ b/OfficeIMO.Reader.Epub/EpubReaderAdapter.Resources.cs
@@ -42,6 +42,7 @@ internal static partial class EpubReaderAdapter {
         EpubChapter chapter,
         IReadOnlyList<OfficeDocumentAsset> htmlAssets,
         List<OfficeDocumentAsset> documentAssets,
+        Dictionary<string, OfficeDocumentAsset> assetsByLocation,
         List<OfficeDocumentAsset> chapterAssets,
         List<OfficeDocumentDiagnostic> diagnostics) {
         foreach (OfficeDocumentAsset htmlAsset in htmlAssets) {
@@ -57,7 +58,7 @@ internal static partial class EpubReaderAdapter {
                 AddEpubReferenceDiagnostic(sourcePath, chapter, reference, diagnostics);
                 string? resourceLocation = BuildEpubResolvedLocation(sourcePath, reference, includeFragment: true);
                 if (!string.IsNullOrWhiteSpace(resourceLocation)) {
-                    mappedAsset = FindEpubAsset(sourcePath, reference, documentAssets);
+                    mappedAsset = FindEpubAsset(sourcePath, reference, assetsByLocation);
                     if (mappedAsset == null) {
                         htmlAsset.Location.Path = resourceLocation;
                     } else {
@@ -69,9 +70,25 @@ internal static partial class EpubReaderAdapter {
             if (mappedAsset == null) {
                 mappedAsset = htmlAsset;
                 documentAssets.Add(mappedAsset);
+                if (!string.IsNullOrWhiteSpace(mappedAsset.Location.Path)
+                    && !assetsByLocation.ContainsKey(mappedAsset.Location.Path!)) {
+                    assetsByLocation.Add(mappedAsset.Location.Path!, mappedAsset);
+                }
             }
             if (!chapterAssets.Contains(mappedAsset)) chapterAssets.Add(mappedAsset);
         }
+    }
+
+    private static Dictionary<string, OfficeDocumentAsset> BuildEpubAssetIndex(
+        IEnumerable<OfficeDocumentAsset> assets) {
+        var result = new Dictionary<string, OfficeDocumentAsset>(StringComparer.Ordinal);
+        foreach (OfficeDocumentAsset asset in assets) {
+            if (!string.IsNullOrWhiteSpace(asset.Location.Path)
+                && !result.ContainsKey(asset.Location.Path!)) {
+                result.Add(asset.Location.Path!, asset);
+            }
+        }
+        return result;
     }
 
     private static void ApplyEpubOccurrenceMetadata(OfficeDocumentAsset packageAsset, OfficeDocumentAsset occurrenceAsset) {

--- a/OfficeIMO.Reader.OpenDocument/OpenDocumentReaderAdapter.Odp.cs
+++ b/OfficeIMO.Reader.OpenDocument/OpenDocumentReaderAdapter.Odp.cs
@@ -10,7 +10,7 @@ internal static partial class OpenDocumentReaderAdapter {
             OdpSlide slide = document.Slides[slideIndex];
             var paragraphs = new List<string>();
             var tables = new List<ReaderTable>();
-            CollectSlideContent(slide.Shapes, sourceName, slideIndex, options, paragraphs, tables);
+            CollectSlideContent(slide.Shapes, sourceName, slideIndex, options, paragraphs, tables, cancellationToken);
             var notes = formatOptions.IncludeSpeakerNotes
                 ? slide.SpeakerNotes?.Paragraphs.Select(paragraph => paragraph.Text.Trim()).Where(text => text.Length > 0).ToArray()
                 : null;
@@ -38,27 +38,38 @@ internal static partial class OpenDocumentReaderAdapter {
     }
 
     private static void CollectSlideContent(IEnumerable<OdpShape> shapes, string sourceName, int slideIndex, ReaderOptions options,
-        List<string> paragraphs, List<ReaderTable> tables) {
+        List<string> paragraphs, List<ReaderTable> tables, CancellationToken cancellationToken) {
         foreach (OdpShape shape in shapes) {
+            cancellationToken.ThrowIfCancellationRequested();
             if (shape is OdpTextBox textBox) {
                 paragraphs.AddRange(textBox.Paragraphs.Select(paragraph => paragraph.Text.Trim()).Where(text => text.Length > 0));
             } else if (shape is OdpTable table) {
-                tables.Add(BuildPresentationTable(table, sourceName, slideIndex, tables.Count, options));
+                tables.Add(BuildPresentationTable(table, sourceName, slideIndex, tables.Count, options, cancellationToken));
             } else if (shape is OdpGroup group) {
-                CollectSlideContent(group.Shapes, sourceName, slideIndex, options, paragraphs, tables);
+                CollectSlideContent(group.Shapes, sourceName, slideIndex, options, paragraphs, tables, cancellationToken);
             }
         }
     }
 
-    private static ReaderTable BuildPresentationTable(OdpTable table, string sourceName, int slideIndex, int tableIndex, ReaderOptions options) {
-        int columnCount = table.Rows.Count == 0 ? 0 : table.Rows.Max(row => row.Cells.Count);
-        string[] columns = Enumerable.Range(1, columnCount).Select(index => "Column " + index.ToString(CultureInfo.InvariantCulture)).ToArray();
+    private static ReaderTable BuildPresentationTable(OdpTable table, string sourceName, int slideIndex, int tableIndex, ReaderOptions options,
+        CancellationToken cancellationToken) {
         int maxRows = options.MaxTableRows > 0 ? options.MaxTableRows : 200;
-        var rows = table.Rows.Take(maxRows).Select(row => (IReadOnlyList<string>)Enumerable.Range(0, columnCount)
-            .Select(index => index < row.Cells.Count ? row.Cells[index].Text : string.Empty).ToArray()).ToArray();
+        IReadOnlyList<OdpTableRow> sourceRows = table.Rows;
+        OdpTableRow[] selectedRows = sourceRows.Take(maxRows).ToArray();
+        int columnCount = selectedRows.Length == 0
+            ? 0
+            : Math.Min(MaximumTableColumns, selectedRows.Max(row => row.Cells.Count));
+        string[] columns = Enumerable.Range(1, columnCount).Select(index => "Column " + index.ToString(CultureInfo.InvariantCulture)).ToArray();
+        var rows = new List<IReadOnlyList<string>>(selectedRows.Length);
+        foreach (OdpTableRow row in selectedRows) {
+            cancellationToken.ThrowIfCancellationRequested();
+            rows.Add(Enumerable.Range(0, columnCount)
+                .Select(index => index < row.Cells.Count ? row.Cells[index].Text : string.Empty).ToArray());
+        }
         return new ReaderTable {
             Title = table.Name, Kind = "odp-table", Columns = columns, Rows = rows,
-            TotalRowCount = table.Rows.Count, Truncated = table.Rows.Count > maxRows,
+            TotalRowCount = sourceRows.Count,
+            Truncated = sourceRows.Count > maxRows || selectedRows.Any(row => row.Cells.Count > MaximumTableColumns),
             Location = new ReaderLocation { Path = sourceName, Slide = slideIndex + 1, TableIndex = tableIndex, SourceBlockKind = "table" }
         };
     }

--- a/OfficeIMO.Reader.OpenDocument/OpenDocumentReaderAdapter.Odp.cs
+++ b/OfficeIMO.Reader.OpenDocument/OpenDocumentReaderAdapter.Odp.cs
@@ -10,7 +10,8 @@ internal static partial class OpenDocumentReaderAdapter {
             OdpSlide slide = document.Slides[slideIndex];
             var paragraphs = new List<string>();
             var tables = new List<ReaderTable>();
-            CollectSlideContent(slide.Shapes, sourceName, slideIndex, options, paragraphs, tables, cancellationToken);
+            var warnings = new List<string>();
+            CollectSlideContent(slide.Shapes, sourceName, slideIndex, options, paragraphs, tables, warnings, cancellationToken);
             var notes = formatOptions.IncludeSpeakerNotes
                 ? slide.SpeakerNotes?.Paragraphs.Select(paragraph => paragraph.Text.Trim()).Where(text => text.Length > 0).ToArray()
                 : null;
@@ -22,7 +23,6 @@ internal static partial class OpenDocumentReaderAdapter {
             foreach (ReaderTable table in tables) {
                 markdown.AppendLine().AppendLine(BuildTableMarkdown(table.Columns, table.Rows));
             }
-            var warnings = new List<string>();
             if (slide.Hidden) warnings.Add("Slide is hidden in the source presentation.");
             if (!formatOptions.IncludeSpeakerNotes && slide.SpeakerNotes != null) warnings.Add("Speaker notes were omitted by ReaderOpenDocumentOptions.");
             yield return new ReaderChunk {
@@ -38,24 +38,33 @@ internal static partial class OpenDocumentReaderAdapter {
     }
 
     private static void CollectSlideContent(IEnumerable<OdpShape> shapes, string sourceName, int slideIndex, ReaderOptions options,
-        List<string> paragraphs, List<ReaderTable> tables, CancellationToken cancellationToken) {
+        List<string> paragraphs, List<ReaderTable> tables, List<string> warnings, CancellationToken cancellationToken) {
         foreach (OdpShape shape in shapes) {
             cancellationToken.ThrowIfCancellationRequested();
             if (shape is OdpTextBox textBox) {
                 paragraphs.AddRange(textBox.Paragraphs.Select(paragraph => paragraph.Text.Trim()).Where(text => text.Length > 0));
             } else if (shape is OdpTable table) {
-                tables.Add(BuildPresentationTable(table, sourceName, slideIndex, tables.Count, options, cancellationToken));
+                tables.Add(BuildPresentationTable(table, sourceName, slideIndex, tables.Count, options, cancellationToken,
+                    out bool rowsTruncated, out bool columnsTruncated));
+                if (rowsTruncated && !warnings.Contains("Table rows were truncated due to MaxTableRows.")) {
+                    warnings.Add("Table rows were truncated due to MaxTableRows.");
+                }
+                if (columnsTruncated && !warnings.Contains("Table columns were truncated to 256 columns for bounded extraction.")) {
+                    warnings.Add("Table columns were truncated to 256 columns for bounded extraction.");
+                }
             } else if (shape is OdpGroup group) {
-                CollectSlideContent(group.Shapes, sourceName, slideIndex, options, paragraphs, tables, cancellationToken);
+                CollectSlideContent(group.Shapes, sourceName, slideIndex, options, paragraphs, tables, warnings, cancellationToken);
             }
         }
     }
 
     private static ReaderTable BuildPresentationTable(OdpTable table, string sourceName, int slideIndex, int tableIndex, ReaderOptions options,
-        CancellationToken cancellationToken) {
+        CancellationToken cancellationToken, out bool rowsTruncated, out bool columnsTruncated) {
         int maxRows = options.MaxTableRows > 0 ? options.MaxTableRows : 200;
         IReadOnlyList<OdpTableRow> sourceRows = table.Rows;
         OdpTableRow[] selectedRows = sourceRows.Take(maxRows).ToArray();
+        rowsTruncated = sourceRows.Count > maxRows;
+        columnsTruncated = selectedRows.Any(row => row.Cells.Count > MaximumTableColumns);
         int columnCount = selectedRows.Length == 0
             ? 0
             : Math.Min(MaximumTableColumns, selectedRows.Max(row => row.Cells.Count));
@@ -69,7 +78,7 @@ internal static partial class OpenDocumentReaderAdapter {
         return new ReaderTable {
             Title = table.Name, Kind = "odp-table", Columns = columns, Rows = rows,
             TotalRowCount = sourceRows.Count,
-            Truncated = sourceRows.Count > maxRows || selectedRows.Any(row => row.Cells.Count > MaximumTableColumns),
+            Truncated = rowsTruncated || columnsTruncated,
             Location = new ReaderLocation { Path = sourceName, Slide = slideIndex + 1, TableIndex = tableIndex, SourceBlockKind = "table" }
         };
     }

--- a/OfficeIMO.Reader.OpenDocument/OpenDocumentReaderAdapter.Ods.cs
+++ b/OfficeIMO.Reader.OpenDocument/OpenDocumentReaderAdapter.Ods.cs
@@ -20,9 +20,8 @@ internal static partial class OpenDocumentReaderAdapter {
                 range = new OdsUsedRange(firstRow - 1L, firstColumn - 1L, lastRow - 1L, lastColumn - 1L);
             }
             int maxRows = options.MaxTableRows > 0 ? options.MaxTableRows : 200;
-            const int maxColumns = 256;
             long sourceColumns = range.ColumnCount;
-            int columnCount = (int)Math.Min(sourceColumns, maxColumns);
+            int columnCount = (int)Math.Min(sourceColumns, MaximumTableColumns);
             long headerRow = range.FirstRow;
             string[] columns = Enumerable.Range(0, columnCount).Select(index => {
                 string value = formatOptions.HeadersInFirstRow ? sheet.GetValue(headerRow, range.FirstColumn + index).ToString() : string.Empty;
@@ -46,12 +45,12 @@ internal static partial class OpenDocumentReaderAdapter {
             var table = new ReaderTable {
                 Title = sheet.Name, Kind = "ods-sheet", Columns = columns, Rows = rows,
                 TotalRowCount = checked((int)Math.Min(availableDataRows, int.MaxValue)),
-                Truncated = availableDataRows > emittedRows || sourceColumns > maxColumns,
+                Truncated = availableDataRows > emittedRows || sourceColumns > MaximumTableColumns,
                 Location = location
             };
             var warnings = new List<string>();
             if (availableDataRows > emittedRows) warnings.Add("Sheet rows were truncated due to MaxTableRows.");
-            if (sourceColumns > maxColumns) warnings.Add("Sheet columns were truncated to 256 columns for bounded extraction.");
+            if (sourceColumns > MaximumTableColumns) warnings.Add("Sheet columns were truncated to 256 columns for bounded extraction.");
             yield return new ReaderChunk {
                 Id = BuildId(sourceName, "sheet", blockIndex), Kind = ReaderInputKind.OpenDocument,
                 Location = location,

--- a/OfficeIMO.Reader.OpenDocument/OpenDocumentReaderAdapter.Odt.cs
+++ b/OfficeIMO.Reader.OpenDocument/OpenDocumentReaderAdapter.Odt.cs
@@ -10,7 +10,7 @@ internal static partial class OpenDocumentReaderAdapter {
         foreach (OdtContentBlock block in document.ContentBlocks) {
             cancellationToken.ThrowIfCancellationRequested();
             if (block.Table != null) {
-                yield return BuildTableChunk(block.Table, sourceName, blockIndex, options);
+                yield return BuildTableChunk(block.Table, sourceName, blockIndex, options, cancellationToken);
                 blockIndex++;
                 continue;
             }
@@ -46,20 +46,28 @@ internal static partial class OpenDocumentReaderAdapter {
         }
     }
 
-    private static ReaderChunk BuildTableChunk(OdtTable table, string sourceName, int blockIndex, ReaderOptions options) {
+    private static ReaderChunk BuildTableChunk(OdtTable table, string sourceName, int blockIndex, ReaderOptions options,
+        CancellationToken cancellationToken) {
         IReadOnlyList<OdtTableRow> rows = table.Rows;
-        int columnCount = rows.Count == 0 ? 0 : rows.Max(row => row.Cells.Count);
-        string[] columns = Enumerable.Range(1, columnCount).Select(index => "Column " + index.ToString(CultureInfo.InvariantCulture)).ToArray();
         int maximumRows = options.MaxTableRows > 0 ? options.MaxTableRows : 200;
-        var values = rows.Take(maximumRows).Select(row => (IReadOnlyList<string>)Enumerable.Range(0, columnCount)
-            .Select(index => index < row.Cells.Count ? row.Cells[index].Text : string.Empty).ToArray()).ToArray();
+        OdtTableRow[] selectedRows = rows.Take(maximumRows).ToArray();
+        int columnCount = selectedRows.Length == 0
+            ? 0
+            : Math.Min(MaximumTableColumns, selectedRows.Max(row => row.Cells.Count));
+        string[] columns = Enumerable.Range(1, columnCount).Select(index => "Column " + index.ToString(CultureInfo.InvariantCulture)).ToArray();
+        var values = new List<IReadOnlyList<string>>(selectedRows.Length);
+        foreach (OdtTableRow row in selectedRows) {
+            cancellationToken.ThrowIfCancellationRequested();
+            values.Add(Enumerable.Range(0, columnCount)
+                .Select(index => index < row.Cells.Count ? row.Cells[index].Text : string.Empty).ToArray());
+        }
         var readerTable = new ReaderTable {
             Title = table.Name,
             Kind = "odt-table",
             Columns = columns,
             Rows = values,
             TotalRowCount = rows.Count,
-            Truncated = rows.Count > maximumRows,
+            Truncated = rows.Count > maximumRows || selectedRows.Any(row => row.Cells.Count > MaximumTableColumns),
             Location = new ReaderLocation { Path = sourceName, BlockIndex = blockIndex, SourceBlockIndex = blockIndex, SourceBlockKind = "table" }
         };
         string text = string.Join(Environment.NewLine, values.Select(row => string.Join("\t", row)));

--- a/OfficeIMO.Reader.OpenDocument/OpenDocumentReaderAdapter.Odt.cs
+++ b/OfficeIMO.Reader.OpenDocument/OpenDocumentReaderAdapter.Odt.cs
@@ -54,6 +54,8 @@ internal static partial class OpenDocumentReaderAdapter {
         int columnCount = selectedRows.Length == 0
             ? 0
             : Math.Min(MaximumTableColumns, selectedRows.Max(row => row.Cells.Count));
+        bool rowsTruncated = rows.Count > maximumRows;
+        bool columnsTruncated = selectedRows.Any(row => row.Cells.Count > MaximumTableColumns);
         string[] columns = Enumerable.Range(1, columnCount).Select(index => "Column " + index.ToString(CultureInfo.InvariantCulture)).ToArray();
         var values = new List<IReadOnlyList<string>>(selectedRows.Length);
         foreach (OdtTableRow row in selectedRows) {
@@ -67,7 +69,7 @@ internal static partial class OpenDocumentReaderAdapter {
             Columns = columns,
             Rows = values,
             TotalRowCount = rows.Count,
-            Truncated = rows.Count > maximumRows || selectedRows.Any(row => row.Cells.Count > MaximumTableColumns),
+            Truncated = rowsTruncated || columnsTruncated,
             Location = new ReaderLocation { Path = sourceName, BlockIndex = blockIndex, SourceBlockIndex = blockIndex, SourceBlockKind = "table" }
         };
         string text = string.Join(Environment.NewLine, values.Select(row => string.Join("\t", row)));
@@ -79,8 +81,16 @@ internal static partial class OpenDocumentReaderAdapter {
             Text = text,
             Markdown = markdown,
             Tables = new[] { readerTable },
-            Warnings = readerTable.Truncated ? new[] { "Table rows were truncated due to MaxTableRows." } : null
+            Warnings = BuildTableWarnings(rowsTruncated, columnsTruncated)
         };
+    }
+
+    private static IReadOnlyList<string>? BuildTableWarnings(bool rowsTruncated, bool columnsTruncated) {
+        if (!rowsTruncated && !columnsTruncated) return null;
+        var warnings = new List<string>(2);
+        if (rowsTruncated) warnings.Add("Table rows were truncated due to MaxTableRows.");
+        if (columnsTruncated) warnings.Add("Table columns were truncated to 256 columns for bounded extraction.");
+        return warnings;
     }
 
     private static string BuildTableMarkdown(IReadOnlyList<string> columns, IReadOnlyList<IReadOnlyList<string>> rows) {

--- a/OfficeIMO.Reader.OpenDocument/OpenDocumentReaderAdapter.cs
+++ b/OfficeIMO.Reader.OpenDocument/OpenDocumentReaderAdapter.cs
@@ -4,6 +4,8 @@ namespace OfficeIMO.Reader.OpenDocument;
 
 /// <summary>Native OpenDocument ingestion adapter for <see cref="OfficeDocumentReader"/>.</summary>
 internal static partial class OpenDocumentReaderAdapter {
+    private const int MaximumTableColumns = 256;
+
     /// <summary>Reads an ODT, ODS, or ODP file and emits format-aligned chunks.</summary>
     public static IEnumerable<ReaderChunk> Read(string path, ReaderOptions? options = null, ReaderOpenDocumentOptions? openDocumentOptions = null,
         CancellationToken cancellationToken = default) {

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -355,6 +355,28 @@ public sealed class ReaderHierarchicalChunkingTests {
     }
 
     [Fact]
+    public void Chunk_Does_Not_Report_Input_Truncation_For_Duplicate_Page_Blocks() {
+        var block = new OfficeDocumentBlock { Id = "same", Text = "body" };
+        var document = new OfficeDocumentReadResult {
+            Kind = ReaderInputKind.Text,
+            Blocks = new[] { block },
+            Pages = new[] { new OfficeDocumentPage { Number = 1, Blocks = new[] { block } } }
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(document,
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 10,
+                OverlapTokens = 0,
+                MaxInputChunks = 1,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+
+        Assert.Single(result.Chunks);
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-input-chunk-limit");
+    }
+
+    [Fact]
     public void Chunk_BoundsLeafTitlesAndPathsWithoutChangingLeafIdentity() {
         ReaderChunk source = CreateChunk("stable-id", "body");
         source.Location.Page = null;

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -427,6 +427,32 @@ public sealed class ReaderHierarchicalChunkingTests {
     }
 
     [Fact]
+    public void Chunk_InheritsPageLocationPastUnrelatedPageBlocks() {
+        var retained = new OfficeDocumentBlock { Id = "retained", Text = "body" };
+        var unrelated = new OfficeDocumentBlock { Id = "unrelated", Text = "other" };
+        var document = new OfficeDocumentReadResult {
+            Kind = ReaderInputKind.Text,
+            Blocks = new[] { retained },
+            Pages = new[] {
+                new OfficeDocumentPage { Number = 1, Blocks = new[] { unrelated } },
+                new OfficeDocumentPage { Number = 2, Blocks = new[] { retained } }
+            }
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(document,
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 10,
+                OverlapTokens = 0,
+                MaxInputChunks = 1,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+
+        ReaderChunk chunk = Assert.Single(result.Chunks);
+        Assert.Equal(2, chunk.Location.Page);
+    }
+
+    [Fact]
     public void Chunk_BoundsLeafTitlesAndPathsWithoutChangingLeafIdentity() {
         ReaderChunk source = CreateChunk("stable-id", "body");
         source.Location.Page = null;

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -328,6 +328,30 @@ public sealed class ReaderHierarchicalChunkingTests {
 
         Assert.Single(result.Chunks);
         Assert.Equal(2, blocks.ReadCount);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-input-chunk-limit");
+    }
+
+    [Fact]
+    public void Chunk_ReportsInputLimitWhenFallbackBlocksAreTruncated() {
+        var document = new OfficeDocumentReadResult {
+            Kind = ReaderInputKind.Text,
+            Blocks = new[] {
+                new OfficeDocumentBlock { Id = "first", Text = "first" },
+                new OfficeDocumentBlock { Id = "second", Text = "second" }
+            }
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(document,
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 10,
+                OverlapTokens = 0,
+                MaxInputChunks = 1,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+
+        Assert.Single(result.Chunks);
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-input-chunk-limit");
     }
 
     [Fact]

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -309,6 +309,28 @@ public sealed class ReaderHierarchicalChunkingTests {
     }
 
     [Fact]
+    public void Chunk_BoundsFallbackInspectionWhenSourceBlocksAreDuplicates() {
+        var duplicate = new OfficeDocumentBlock { Id = "duplicate", Text = "body" };
+        var blocks = new CountingBlockList(duplicate, 1000);
+        var document = new OfficeDocumentReadResult {
+            Kind = ReaderInputKind.Text,
+            Blocks = blocks
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(document,
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 10,
+                OverlapTokens = 0,
+                MaxInputChunks = 2,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+
+        Assert.Single(result.Chunks);
+        Assert.Equal(2, blocks.ReadCount);
+    }
+
+    [Fact]
     public void Chunk_BoundsLeafTitlesAndPathsWithoutChangingLeafIdentity() {
         ReaderChunk source = CreateChunk("stable-id", "body");
         source.Location.Page = null;
@@ -985,6 +1007,32 @@ public sealed class ReaderHierarchicalChunkingTests {
             if (text.EndsWith("\n\n", StringComparison.Ordinal)) return 1;
             return text.Contains("\n\n", StringComparison.Ordinal) ? 3 : 1;
         }
+    }
+
+    private sealed class CountingBlockList : IReadOnlyList<OfficeDocumentBlock> {
+        private readonly OfficeDocumentBlock _block;
+
+        internal CountingBlockList(OfficeDocumentBlock block, int count) {
+            _block = block;
+            Count = count;
+        }
+
+        public int Count { get; }
+        internal int ReadCount { get; private set; }
+
+        public OfficeDocumentBlock this[int index] {
+            get {
+                if (index < 0 || index >= Count) throw new ArgumentOutOfRangeException(nameof(index));
+                ReadCount++;
+                return _block;
+            }
+        }
+
+        public IEnumerator<OfficeDocumentBlock> GetEnumerator() {
+            for (int index = 0; index < Count; index++) yield return this[index];
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
 }

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -327,8 +327,32 @@ public sealed class ReaderHierarchicalChunkingTests {
             });
 
         Assert.Single(result.Chunks);
-        Assert.Equal(2, blocks.ReadCount);
+        Assert.Equal(8, blocks.ReadCount);
         Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-input-chunk-limit");
+    }
+
+    [Fact]
+    public void Chunk_DoesNotChargeDuplicateFallbackBlocksToInputQuota() {
+        var document = new OfficeDocumentReadResult {
+            Kind = ReaderInputKind.Text,
+            Blocks = new[] {
+                new OfficeDocumentBlock { Id = "first", Text = "first" },
+                new OfficeDocumentBlock { Id = "first", Text = "duplicate" },
+                new OfficeDocumentBlock { Id = "second", Text = "second" }
+            }
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(document,
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 10,
+                OverlapTokens = 0,
+                MaxInputChunks = 2,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+
+        Assert.Equal(new[] { "first", "second" }, result.Chunks.Select(chunk => chunk.Text));
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-input-chunk-limit");
     }
 
     [Fact]

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -377,6 +377,32 @@ public sealed class ReaderHierarchicalChunkingTests {
     }
 
     [Fact]
+    public void Chunk_InheritsPageLocationBeyondInputChunkOrdinal() {
+        var block = new OfficeDocumentBlock { Id = "retained", Text = "body" };
+        var document = new OfficeDocumentReadResult {
+            Kind = ReaderInputKind.Text,
+            Blocks = new[] { block },
+            Pages = new[] {
+                new OfficeDocumentPage { Number = 1, Blocks = Array.Empty<OfficeDocumentBlock>() },
+                new OfficeDocumentPage { Number = 2, Blocks = new[] { block } }
+            }
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(document,
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 10,
+                OverlapTokens = 0,
+                MaxInputChunks = 1,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+
+        ReaderChunk chunk = Assert.Single(result.Chunks);
+        Assert.Equal(2, chunk.Location.Page);
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Code == "hierarchical-input-chunk-limit");
+    }
+
+    [Fact]
     public void Chunk_BoundsLeafTitlesAndPathsWithoutChangingLeafIdentity() {
         ReaderChunk source = CreateChunk("stable-id", "body");
         source.Location.Page = null;

--- a/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
+++ b/OfficeIMO.Reader.Tests/Reader.HierarchicalChunking.cs
@@ -453,6 +453,32 @@ public sealed class ReaderHierarchicalChunkingTests {
     }
 
     [Fact]
+    public void Chunk_InheritsPageLocationBeyondUnrelatedInspectionAllowance() {
+        var retained = new OfficeDocumentBlock { Id = "retained", Text = "body" };
+        var unrelated = Enumerable.Range(0, 5)
+            .Select(index => new OfficeDocumentBlock { Id = "unrelated-" + index, Text = "other" })
+            .ToArray();
+        var pageBlocks = unrelated.Concat(new[] { retained }).ToArray();
+        var document = new OfficeDocumentReadResult {
+            Kind = ReaderInputKind.Text,
+            Blocks = new[] { retained },
+            Pages = new[] { new OfficeDocumentPage { Number = 7, Blocks = pageBlocks } }
+        };
+
+        ReaderChunkHierarchyResult result = ReaderHierarchicalChunker.Chunk(document,
+            new ReaderHierarchicalChunkingOptions {
+                MaxTokens = 10,
+                OverlapTokens = 0,
+                MaxInputChunks = 1,
+                IncludeContextInText = false,
+                TokenCounter = WordCounter
+            });
+
+        ReaderChunk chunk = Assert.Single(result.Chunks);
+        Assert.Equal(7, chunk.Location.Page);
+    }
+
+    [Fact]
     public void Chunk_BoundsLeafTitlesAndPathsWithoutChangingLeafIdentity() {
         ReaderChunk source = CreateChunk("stable-id", "body");
         source.Location.Page = null;

--- a/OfficeIMO.Reader.Tests/Reader.OpenDocument.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.OpenDocument.Modular.cs
@@ -115,6 +115,21 @@ public class ReaderOpenDocumentModularTests {
 
     }
 
+    [Fact]
+    public void RegisteredAdapterReportsOdtColumnTruncationSeparately() {
+        OdtDocument document = OdtDocument.Create();
+        OdtTable table = document.AddTable(1, 257, "Wide");
+        table.Cell(0, 256).Text = "Truncated column";
+
+        ReaderChunk chunk = Assert.Single(CreateReader().Read(document.ToBytes(), "wide.odt"));
+
+        ReaderTable extracted = Assert.Single(chunk.Tables!);
+        Assert.True(extracted.Truncated);
+        Assert.Equal(256, extracted.Columns.Count);
+        Assert.Contains(chunk.Warnings!, warning => warning.Contains("columns were truncated", StringComparison.Ordinal));
+        Assert.DoesNotContain(chunk.Warnings!, warning => warning.Contains("rows were truncated", StringComparison.Ordinal));
+    }
+
     private static OfficeDocumentReader CreateReader() {
         return new OfficeDocumentReaderBuilder().AddOpenDocumentHandler().Build();
     }

--- a/OfficeIMO.Reader.Tests/Reader.OpenDocument.Modular.cs
+++ b/OfficeIMO.Reader.Tests/Reader.OpenDocument.Modular.cs
@@ -70,6 +70,22 @@ public class ReaderOpenDocumentModularTests {
     }
 
     [Fact]
+    public void RegisteredAdapterReportsOdpColumnTruncationSeparately() {
+        OdpPresentation document = OdpPresentation.Create();
+        OdpSlide slide = document.AddSlide("Wide");
+        OdpTable table = slide.AddTable(OdfRect.FromCentimeters(1, 1, 20, 4), 1, 257, "Wide table");
+        table.Cell(0, 256).Text = "Truncated column";
+
+        ReaderChunk chunk = Assert.Single(CreateReader().Read(document.ToBytes(), "wide.odp"));
+
+        ReaderTable extracted = Assert.Single(chunk.Tables!);
+        Assert.True(extracted.Truncated);
+        Assert.Equal(256, extracted.Columns.Count);
+        Assert.Contains(chunk.Warnings!, warning => warning.Contains("columns were truncated", StringComparison.Ordinal));
+        Assert.DoesNotContain(chunk.Warnings!, warning => warning.Contains("rows were truncated", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void RegisteredAdapterEmitsBoundedOdsSheetTableChunk() {
         OdsDocument document = OdsDocument.Create();
         OdsSheet sheet = document.AddSheet("Metrics");

--- a/OfficeIMO.Security.Tests/CmsSecurityTests.cs
+++ b/OfficeIMO.Security.Tests/CmsSecurityTests.cs
@@ -44,6 +44,21 @@ public sealed class CmsSecurityTests {
     }
 
     [Fact]
+    public void Verification_RejectsTlsOnlySignerCertificates() {
+        byte[] content = Encoding.UTF8.GetBytes("TLS certificates are not document signers");
+        using X509Certificate2 certificate = CreateRsaCertificate(
+            "OfficeIMO TLS Only",
+            new Oid("1.3.6.1.5.5.7.3.1"));
+        byte[] encoded = CmsSignedDataSigner.SignEncapsulated(content, certificate);
+
+        CmsVerificationResult result = CmsSignedDataVerifier.Verify(encoded, TrustSelfSigned());
+
+        CmsSignerVerificationResult signer = Assert.Single(result.Signers);
+        Assert.Equal(SecurityValidationStatus.Invalid, signer.CertificateValidation.ChainStatus);
+        Assert.Contains(signer.Findings, finding => finding.Code == "CertificateEnhancedKeyUsageInvalid");
+    }
+
+    [Fact]
     public void EncapsulatedSignature_StopsAtTheConfiguredContentLimit() {
         byte[] content = Enumerable.Repeat((byte)0x5a, 4096).ToArray();
         using X509Certificate2 certificate = CreateRsaCertificate("OfficeIMO CMS Bounded Encapsulated");
@@ -227,7 +242,7 @@ public sealed class CmsSecurityTests {
         return options;
     }
 
-    private static X509Certificate2 CreateRsaCertificate(string commonName) {
+    private static X509Certificate2 CreateRsaCertificate(string commonName, Oid? enhancedKeyUsage = null) {
         using RSA rsa = RSA.Create(2048);
         var request = new CertificateRequest(
             "CN=" + commonName,
@@ -237,6 +252,11 @@ public sealed class CmsSecurityTests {
         request.CertificateExtensions.Add(new X509KeyUsageExtension(
             X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment,
             critical: true));
+        if (enhancedKeyUsage != null) {
+            request.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(
+                new OidCollection { enhancedKeyUsage },
+                critical: true));
+        }
         request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, critical: false));
         return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddDays(1));
     }

--- a/OfficeIMO.Security.Tests/CmsSecurityTests.cs
+++ b/OfficeIMO.Security.Tests/CmsSecurityTests.cs
@@ -214,6 +214,10 @@ public sealed class CmsSecurityTests {
             encoded,
             Encoding.UTF8.GetBytes("different signature bytes"),
             trust);
+        Rfc3161TimestampVerificationResult untrusted = Rfc3161TimestampVerifier.Verify(
+            encoded,
+            timestampedData,
+            new CertificateValidationOptions { ChainEvaluator = static (_, _) => false });
         DateTime explicitVerificationTime = generationTime.AddSeconds(30);
         DateTime? observedExplicitVerificationTime = null;
         var explicitTrust = new CertificateValidationOptions {
@@ -234,6 +238,8 @@ public sealed class CmsSecurityTests {
         Assert.Equal("2.16.840.1.101.3.4.2.1", valid.MessageImprintAlgorithmOid);
         Assert.Equal(SecurityValidationStatus.Invalid, tampered.Status);
         Assert.Contains(tampered.Findings, finding => finding.Code == "TimestampImprintMismatch");
+        Assert.Equal(SecurityValidationStatus.Invalid, untrusted.Status);
+        Assert.Equal(SecurityValidationStatus.Invalid, untrusted.CertificateValidation.ChainStatus);
     }
 
     private static CmsVerificationOptions TrustSelfSigned() {

--- a/OfficeIMO.Security/CertificateChainValidator.cs
+++ b/OfficeIMO.Security/CertificateChainValidator.cs
@@ -3,6 +3,11 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace OfficeIMO.Security;
 
+internal enum CertificateUsagePurpose {
+    CmsSigner,
+    TimestampAuthority
+}
+
 internal static class CertificateChainValidator {
     internal static CertificateValidationResult Validate(
         X509Certificate2? certificate,
@@ -10,6 +15,7 @@ internal static class CertificateChainValidator {
         CertificateValidationOptions options,
         IList<SecurityFinding> findings,
         string role,
+        CertificateUsagePurpose purpose,
         int? signerIndex = null) {
         if (certificate == null) {
             return Empty(SecurityValidationStatus.Indeterminate);
@@ -46,7 +52,9 @@ internal static class CertificateChainValidator {
             return Empty(SecurityValidationStatus.Indeterminate);
         }
 
-        bool accepted = options.ChainEvaluator?.Invoke(certificate, chain) ?? platformResult;
+        bool chainAccepted = options.ChainEvaluator?.Invoke(certificate, chain) ?? platformResult;
+        bool usageAccepted = ValidateCertificateUsage(certificate, purpose, findings, role, signerIndex);
+        bool accepted = chainAccepted && usageAccepted;
         string[] statuses = chain.ChainStatus
             .Select(static status => string.IsNullOrWhiteSpace(status.StatusInformation)
                 ? status.Status.ToString()
@@ -65,6 +73,76 @@ internal static class CertificateChainValidator {
             accepted ? SecurityValidationStatus.Valid : SecurityValidationStatus.Invalid,
             ClassifyRevocation(chain, options.RevocationMode),
             statuses);
+    }
+
+    private static bool ValidateCertificateUsage(
+        X509Certificate2 certificate,
+        CertificateUsagePurpose purpose,
+        IList<SecurityFinding> findings,
+        string role,
+        int? signerIndex) {
+        X509KeyUsageExtension? keyUsage = certificate.Extensions
+            .OfType<X509KeyUsageExtension>()
+            .FirstOrDefault();
+        if (keyUsage != null &&
+            (keyUsage.KeyUsages & (X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.NonRepudiation)) == 0) {
+            findings.Add(new SecurityFinding(
+                SecurityFindingSeverity.Error,
+                "CertificateKeyUsageInvalid",
+                role + " certificate key usage does not permit digital signatures.",
+                signerIndex));
+            return false;
+        }
+
+        X509EnhancedKeyUsageExtension? enhancedKeyUsage = certificate.Extensions
+            .OfType<X509EnhancedKeyUsageExtension>()
+            .FirstOrDefault();
+        if (enhancedKeyUsage == null) {
+            if (purpose == CertificateUsagePurpose.TimestampAuthority) {
+                findings.Add(new SecurityFinding(
+                    SecurityFindingSeverity.Error,
+                    "CertificateEnhancedKeyUsageInvalid",
+                    role + " certificate does not declare the timestamping enhanced key usage.",
+                    signerIndex));
+                return false;
+            }
+            return true;
+        }
+
+        if (purpose == CertificateUsagePurpose.TimestampAuthority &&
+            (!enhancedKeyUsage.Critical || enhancedKeyUsage.EnhancedKeyUsages.Count != 1)) {
+            findings.Add(new SecurityFinding(
+                SecurityFindingSeverity.Error,
+                "CertificateEnhancedKeyUsageInvalid",
+                role + " certificate must declare only the critical timestamping enhanced key usage.",
+                signerIndex));
+            return false;
+        }
+
+        bool permitted = enhancedKeyUsage.EnhancedKeyUsages
+            .Cast<Oid>()
+            .Any(oid => IsPermittedEnhancedKeyUsage(oid.Value, purpose));
+        if (!permitted) {
+            findings.Add(new SecurityFinding(
+                SecurityFindingSeverity.Error,
+                "CertificateEnhancedKeyUsageInvalid",
+                role + " certificate enhanced key usage is not valid for " +
+                    (purpose == CertificateUsagePurpose.TimestampAuthority ? "timestamping." : "document or CMS signing."),
+                signerIndex));
+        }
+        return permitted;
+    }
+
+    private static bool IsPermittedEnhancedKeyUsage(string? oid, CertificateUsagePurpose purpose) {
+        if (purpose == CertificateUsagePurpose.TimestampAuthority) {
+            return string.Equals(oid, "1.3.6.1.5.5.7.3.8", StringComparison.Ordinal);
+        }
+
+        return oid is "2.5.29.37.0" or
+            "1.3.6.1.5.5.7.3.3" or
+            "1.3.6.1.5.5.7.3.4" or
+            "1.3.6.1.5.5.7.3.36" or
+            "1.3.6.1.4.1.311.10.3.12";
     }
 
     private static CertificateValidationResult Empty(SecurityValidationStatus chainStatus) =>

--- a/OfficeIMO.Security/CmsSignedDataVerifier.cs
+++ b/OfficeIMO.Security/CmsSignedDataVerifier.cs
@@ -193,6 +193,7 @@ public static class CmsSignedDataVerifier {
             options.CertificateValidation,
             findings,
             "CMS signer",
+            CertificateUsagePurpose.CmsSigner,
             signerIndex);
         DateTimeOffset? signingTime = ReadSigningTime(signer.SignedAttributes, signerIndex, findings);
         IReadOnlyList<Rfc3161TimestampVerificationResult> timestamps = options.ValidateTimestamps

--- a/OfficeIMO.Security/Rfc3161TimestampVerifier.cs
+++ b/OfficeIMO.Security/Rfc3161TimestampVerifier.cs
@@ -84,9 +84,10 @@ public static class Rfc3161TimestampVerifier {
                     findings,
                     "TSA",
                     CertificateUsagePurpose.TimestampAuthority);
-                SecurityValidationStatus status = signatureValid && imprintValid
-                    ? SecurityValidationStatus.Valid
-                    : SecurityValidationStatus.Invalid;
+                SecurityValidationStatus status = ResolveTimestampStatus(
+                    signatureValid,
+                    imprintValid,
+                    chain.ChainStatus);
                 return CreateResult(status, info, tsaCertificate.GetEncoded(), chain, findings);
             } finally {
                 foreach (X509Certificate2 certificate in platformEmbedded) certificate.Dispose();
@@ -131,6 +132,18 @@ public static class Rfc3161TimestampVerifier {
             SecurityValidationStatus.Indeterminate,
             SecurityValidationStatus.NotPerformed,
             Array.Empty<string>());
+
+    private static SecurityValidationStatus ResolveTimestampStatus(
+        bool signatureValid,
+        bool imprintValid,
+        SecurityValidationStatus certificateStatus) {
+        if (!signatureValid || !imprintValid || certificateStatus == SecurityValidationStatus.Invalid) {
+            return SecurityValidationStatus.Invalid;
+        }
+        return certificateStatus == SecurityValidationStatus.Valid
+            ? SecurityValidationStatus.Valid
+            : SecurityValidationStatus.Indeterminate;
+    }
 
     private static CertificateValidationOptions ResolveCertificateValidation(
         CertificateValidationOptions? source,

--- a/OfficeIMO.Security/Rfc3161TimestampVerifier.cs
+++ b/OfficeIMO.Security/Rfc3161TimestampVerifier.cs
@@ -82,7 +82,8 @@ public static class Rfc3161TimestampVerifier {
                     platformEmbedded,
                     effectiveCertificateValidation,
                     findings,
-                    "TSA");
+                    "TSA",
+                    CertificateUsagePurpose.TimestampAuthority);
                 SecurityValidationStatus status = signatureValid && imprintValid
                     ? SecurityValidationStatus.Valid
                     : SecurityValidationStatus.Invalid;

--- a/OfficeIMO.Security/SecurityValidationModels.cs
+++ b/OfficeIMO.Security/SecurityValidationModels.cs
@@ -240,7 +240,7 @@ public sealed class Rfc3161TimestampVerificationResult {
         Findings = findings;
     }
 
-    /// <summary>Combined token signature and message-imprint outcome.</summary>
+    /// <summary>Combined token signature, message-imprint, and TSA certificate-validation outcome.</summary>
     public SecurityValidationStatus Status { get; }
     /// <summary>Timestamp generation time.</summary>
     public DateTimeOffset? Timestamp { get; }


### PR DESCRIPTION
## Summary

This batch bounds expensive work across document rendering, structured extraction, and package inspection so adversarial inputs fail with configured limits instead of consuming unbounded CPU, memory, or stack depth.

- caps Excel merged-range expansion, OpenDocument repeated items, Reader page/chunk traversal, and PowerPoint group/package traversal
- makes EPUB asset lookup, RTL processing, and font fallback linear or bounded
- limits SVG nesting, path commands, transforms, viewport expansion, symbols, references, and repeated backgrounds while preserving vector PDF output
- shares paged image resources and streams signed PowerPoint package fingerprints instead of buffering duplicate content
- enforces signing-certificate key-usage and extended-key-usage policy

The limits are exposed through the existing owning options or internal package safety policies, with compatibility-preserving defaults for normal documents.

## Validation

- full solution build on .NET 10
- focused .NET 8 and .NET 10 regression suites for Drawing, HTML/PDF, Excel, Reader, PowerPoint, EPUB, OpenDocument, RTF, and signing behavior
