### PR TITLE
Harden bounded document processing paths

### DIFF
--- a/OfficeIMO.AsciiDoc.Tests/Parsing/AsciiDocInlineParsingTests.cs
+++ b/OfficeIMO.AsciiDoc.Tests/Parsing/AsciiDocInlineParsingTests.cs
@@ -70,4 +70,13 @@ public sealed class AsciiDocInlineParsingTests {
 
         Assert.Throws<InvalidDataException>(() => AsciiDocDocument.Parse("*one* {two} three", options));
     }
+
+    [Fact]
+    public void LongEscapeRuns_AreParsedLosslesslyWithoutBackwardRescanning() {
+        string source = new string('\\', 100_000) + "*literal*\n";
+
+        AsciiDocDocument document = AsciiDocDocument.Parse(source).Document;
+
+        Assert.Equal(source, document.ToAsciiDoc());
+    }
 }

--- a/OfficeIMO.AsciiDoc/Parsing/AsciiDocInlineParser.cs
+++ b/OfficeIMO.AsciiDoc/Parsing/AsciiDocInlineParser.cs
@@ -19,7 +19,10 @@ internal sealed class AsciiDocInlineParser {
         int textStart = start;
         int index = start;
         while (index < end) {
-            if (IsEscaped(index, start)) { index += Math.Min(2, end - index); continue; }
+            // An escape consumes itself and the following character. Because the parser
+            // advances past both characters, it never lands on an escaped backslash and
+            // does not need to rescan the preceding run for every slash.
+            if (_factory.Source.Text[index] == '\\') { index += Math.Min(2, end - index); continue; }
             AsciiDocInline? item = TryParseExplicit(index, end, depth, out int next);
             if (item == null) { index++; continue; }
             AddText(textStart, index, items, syntax);
@@ -141,13 +144,6 @@ internal sealed class AsciiDocInlineParser {
         if (_nodeCount > _options.MaximumInlineNodeCount) throw new InvalidDataException("AsciiDoc source exceeds MaximumInlineNodeCount.");
         items.Add(item);
         syntaxNodes.Add(item.Syntax);
-    }
-
-    private bool IsEscaped(int index, int rangeStart) {
-        if (_factory.Source.Text[index] != '\\') return false;
-        int slashes = 0;
-        for (int current = index - 1; current >= rangeStart && _factory.Source.Text[current] == '\\'; current--) slashes++;
-        return slashes % 2 == 0;
     }
 
     private static bool TryGetStyle(char marker, out AsciiDocInlineStyle style) {

--- a/OfficeIMO.CSV.Tests/CsvDocumentFromObjectsTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvDocumentFromObjectsTests.cs
@@ -645,6 +645,14 @@ public class CsvDocumentFromObjectsTests
     }
 
     [Fact]
+    public void LoadOptions_BoundsCompressedInputByDefault()
+    {
+        var options = new CsvLoadOptions();
+
+        Assert.Equal(CsvLoadOptions.DefaultMaxInputBytes, options.MaxDecompressedBytes);
+    }
+
+    [Fact]
     public void Save_InvalidCompressionLevelDoesNotTruncateExistingFile()
     {
         var path = Path.Combine(Path.GetTempPath(), "OfficeIMO.CSV.InvalidCompressionLevel." + Guid.NewGuid().ToString("N") + ".csv.gz");

--- a/OfficeIMO.CSV.Tests/CsvDocumentFromObjectsTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvDocumentFromObjectsTests.cs
@@ -653,6 +653,27 @@ public class CsvDocumentFromObjectsTests
     }
 
     [Fact]
+    public void Load_DoesNotApplyDecompressionLimitToPlainCsvFiles()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "OfficeIMO.CSV.Plain." + Guid.NewGuid().ToString("N") + ".csv");
+        try
+        {
+            File.WriteAllText(path, "Name,Value\nAlpha,1\n");
+
+            CsvDocument document = CsvDocument.Load(path, new CsvLoadOptions { MaxDecompressedBytes = 1 });
+
+            Assert.Equal("Alpha", Assert.Single(document.AsEnumerable()).AsString("Name"));
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
     public void Save_InvalidCompressionLevelDoesNotTruncateExistingFile()
     {
         var path = Path.Combine(Path.GetTempPath(), "OfficeIMO.CSV.InvalidCompressionLevel." + Guid.NewGuid().ToString("N") + ".csv.gz");

--- a/OfficeIMO.CSV/CsvFile.cs
+++ b/OfficeIMO.CSV/CsvFile.cs
@@ -47,7 +47,7 @@ public static class CsvFile
         ValidateMaxDecompressedBytes(options);
 
         Stream input = WrapReadStream(source, compressionType, leaveOpen);
-        if (options.MaxDecompressedBytes is { } maxBytesLimit)
+        if (compressionType != CsvCompressionType.None && options.MaxDecompressedBytes is { } maxBytesLimit)
         {
             bool leaveBoundedInputOpen = compressionType == CsvCompressionType.None && leaveOpen;
             input = new CsvBoundedReadStream(input, maxBytesLimit, leaveBoundedInputOpen);
@@ -59,7 +59,7 @@ public static class CsvFile
             encoding,
             detectEncodingFromByteOrderMarks: true,
             bufferSize,
-            leaveOpen: compressionType == CsvCompressionType.None && leaveOpen && options.MaxDecompressedBytes is null);
+            leaveOpen: compressionType == CsvCompressionType.None && leaveOpen);
     }
 
     /// <summary>
@@ -157,7 +157,7 @@ public static class CsvFile
 
         var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize, fileOptions);
         Stream stream = WrapReadStream(fileStream, compressionType, leaveOpen: false);
-        if (options.MaxDecompressedBytes is { } maxBytesLimit)
+        if (compressionType != CsvCompressionType.None && options.MaxDecompressedBytes is { } maxBytesLimit)
         {
             stream = new CsvBoundedReadStream(stream, maxBytesLimit, leaveOpen: false);
         }

--- a/OfficeIMO.CSV/CsvLoadOptions.cs
+++ b/OfficeIMO.CSV/CsvLoadOptions.cs
@@ -148,8 +148,9 @@ public sealed class CsvLoadOptions
 
     /// <summary>
     /// Gets or sets an optional limit for decompressed bytes read from compressed CSV files.
+    /// Defaults to 256 MiB. Set to <c>null</c> only for trusted inputs that intentionally exceed the limit.
     /// </summary>
-    public long? MaxDecompressedBytes { get; set; }
+    public long? MaxDecompressedBytes { get; set; } = DefaultMaxInputBytes;
 
     /// <summary>
     /// Gets or sets the maximum number of bytes accepted by stream-based load APIs.

--- a/OfficeIMO.Drawing.Tests/Drawing.Tests.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.Tests.cs
@@ -3600,16 +3600,6 @@ public partial class DrawingTests {
     }
 
     [Fact]
-    public void OfficeImageReaderRejectsPngWithoutACompleteContainer() {
-        byte[] truncated = OnePixelPng.Take(33).ToArray();
-
-        bool identified = OfficeImageReader.TryIdentify(truncated, fileName: null, out OfficeImageInfo image);
-
-        Assert.False(identified);
-        Assert.Equal(OfficeImageFormat.Unknown, image.Format);
-    }
-
-    [Fact]
     public void OfficeImageReaderRejectsPngDimensionsBeyondRasterLimits() {
         byte[] oversized = OnePixelPng.ToArray();
         oversized[16] = 0x7F;

--- a/OfficeIMO.Drawing.Tests/Drawing.Tests.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.Tests.cs
@@ -3599,6 +3599,28 @@ public partial class DrawingTests {
         Assert.Equal(OfficeImageFormat.Unknown, image.Format);
     }
 
+    [Fact]
+    public void OfficeImageReaderRejectsPngWithoutACompleteContainer() {
+        byte[] truncated = OnePixelPng.Take(33).ToArray();
+
+        bool identified = OfficeImageReader.TryIdentify(truncated, fileName: null, out OfficeImageInfo image);
+
+        Assert.False(identified);
+        Assert.Equal(OfficeImageFormat.Unknown, image.Format);
+    }
+
+    [Fact]
+    public void OfficeImageReaderRejectsPngDimensionsBeyondRasterLimits() {
+        byte[] oversized = OnePixelPng.ToArray();
+        oversized[16] = 0x7F;
+        oversized[20] = 0x7F;
+
+        bool identified = OfficeImageReader.TryIdentify(oversized, fileName: null, out OfficeImageInfo image);
+
+        Assert.False(identified);
+        Assert.Equal(OfficeImageFormat.Unknown, image.Format);
+    }
+
     [Theory]
     [InlineData(0x00, 0x00)]
     [InlineData(0xFF, 0xD9)]

--- a/OfficeIMO.Drawing.Tests/Drawing.Tests.cs
+++ b/OfficeIMO.Drawing.Tests/Drawing.Tests.cs
@@ -3576,6 +3576,21 @@ public partial class DrawingTests {
     }
 
     [Fact]
+    public void OfficeImagePdfCompatibilityPreservesMalformedPngDiagnostics() {
+        byte[] invalidCrc = OnePixelPng.ToArray();
+        invalidCrc[^1] ^= 0x01;
+
+        bool valid = OfficeImagePdfCompatibility.TryValidate(
+            invalidCrc,
+            out OfficeImageInfo? imageInfo,
+            out string? unsupportedReason);
+
+        Assert.False(valid);
+        Assert.Null(imageInfo);
+        Assert.Contains("invalid CRC", unsupportedReason, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void OfficeImageReaderIdentifiesPngWithoutDecodingPixels() {
         var image = OfficeImageReader.Identify(OnePixelPng);
 
@@ -3594,6 +3609,16 @@ public partial class DrawingTests {
         malformed[23] = 2;
 
         bool identified = OfficeImageReader.TryIdentify(malformed, fileName: null, out OfficeImageInfo image);
+
+        Assert.False(identified);
+        Assert.Equal(OfficeImageFormat.Unknown, image.Format);
+    }
+
+    [Fact]
+    public void OfficeImageReaderRejectsPngWithoutACompleteContainer() {
+        byte[] truncated = OnePixelPng.Take(33).ToArray();
+
+        bool identified = OfficeImageReader.TryIdentify(truncated, fileName: null, out OfficeImageInfo image);
 
         Assert.False(identified);
         Assert.Equal(OfficeImageFormat.Unknown, image.Format);

--- a/OfficeIMO.Drawing/OfficeImagePdfCompatibility.cs
+++ b/OfficeIMO.Drawing/OfficeImagePdfCompatibility.cs
@@ -27,6 +27,12 @@ namespace OfficeIMO.Drawing {
                 return false;
             }
 
+            // Preserve actionable PNG diagnostics even when the general image reader
+            // correctly rejects a malformed container during format identification.
+            if (StartsWith(bytes, PngSignature) && !TryValidatePngContainer(bytes, out unsupportedReason)) {
+                return false;
+            }
+
             if (!OfficeImageReader.TryIdentify(bytes, null, out OfficeImageInfo detected)) {
                 unsupportedReason = "Image bytes do not contain a supported image header.";
                 return false;

--- a/OfficeIMO.Drawing/OfficeImageReader.cs
+++ b/OfficeIMO.Drawing/OfficeImageReader.cs
@@ -176,8 +176,7 @@ public static partial class OfficeImageReader {
 
         int width = ReadInt32BigEndian(data, 16);
         int height = ReadInt32BigEndian(data, 20);
-        if (!OfficeRasterGuards.TryEnsurePixelCount(width, height, out _) ||
-            !OfficePngReader.TryGetFrameCount(data, out _)) {
+        if (!OfficeRasterGuards.TryEnsurePixelCount(width, height, out _)) {
             return false;
         }
         double dpiX = 96.0;

--- a/OfficeIMO.Drawing/OfficeImageReader.cs
+++ b/OfficeIMO.Drawing/OfficeImageReader.cs
@@ -176,6 +176,10 @@ public static partial class OfficeImageReader {
 
         int width = ReadInt32BigEndian(data, 16);
         int height = ReadInt32BigEndian(data, 20);
+        if (!OfficeRasterGuards.TryEnsurePixelCount(width, height, out _) ||
+            !OfficePngReader.TryGetFrameCount(data, out _)) {
+            return false;
+        }
         double dpiX = 96.0;
         double dpiY = 96.0;
 

--- a/OfficeIMO.Drawing/OfficeImageReader.cs
+++ b/OfficeIMO.Drawing/OfficeImageReader.cs
@@ -176,7 +176,8 @@ public static partial class OfficeImageReader {
 
         int width = ReadInt32BigEndian(data, 16);
         int height = ReadInt32BigEndian(data, 20);
-        if (!OfficeRasterGuards.TryEnsurePixelCount(width, height, out _)) {
+        if (!OfficeRasterGuards.TryEnsurePixelCount(width, height, out _) ||
+            !OfficePngReader.TryGetFrameCount(data, out _)) {
             return false;
         }
         double dpiX = 96.0;

--- a/OfficeIMO.Drawing/Png/OfficePngReader.cs
+++ b/OfficeIMO.Drawing/Png/OfficePngReader.cs
@@ -22,6 +22,7 @@ public static class OfficePngReader {
             OfficeRasterGuards.EnsurePayloadWithinLimits(bytes.Length, "PNG payload exceeds size limits.");
 
             bool hasHeader = false;
+            bool hasImageData = false;
             bool hasEnd = false;
             int declaredFrameCount = 1;
             int offset = Signature.Length;
@@ -40,6 +41,9 @@ public static class OfficePngReader {
                     int candidate = ReadBigEndianInt32(bytes, dataOffset);
                     if (candidate <= 0) return false;
                     declaredFrameCount = candidate;
+                } else if (type == "IDAT") {
+                    if (!hasHeader) return false;
+                    hasImageData = true;
                 } else if (type == "IEND") {
                     if (length != 0) return false;
                     hasEnd = true;
@@ -50,7 +54,7 @@ public static class OfficePngReader {
                 offset = (int)chunkEnd;
             }
 
-            if (!hasHeader || !hasEnd || offset != bytes.Length) return false;
+            if (!hasHeader || !hasImageData || !hasEnd || offset != bytes.Length) return false;
             frameCount = declaredFrameCount;
             return true;
         } catch {

--- a/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.cs
+++ b/OfficeIMO.Excel.Html/ExcelHtmlConverterExtensions.cs
@@ -641,7 +641,7 @@ public static partial class ExcelHtmlConverterExtensions {
             return svg;
         }
 
-        var ids = new SortedSet<string>(StringComparer.Ordinal);
+        var ids = new HashSet<string>(StringComparer.Ordinal);
         foreach (System.Text.RegularExpressions.Match match in System.Text.RegularExpressions.Regex.Matches(svg, "\\bid=(['\\\"])(?<id>[^'\\\"]+)\\1")) {
             string id = match.Groups["id"].Value;
             if (id.Length > 0 && !id.StartsWith(prefix, StringComparison.Ordinal)) {
@@ -649,20 +649,22 @@ public static partial class ExcelHtmlConverterExtensions {
             }
         }
 
-        string namespaced = svg;
-        foreach (string id in ids.OrderByDescending(item => item.Length)) {
-            string replacement = prefix + id;
-            namespaced = namespaced
-                .Replace("id=\"" + id + "\"", "id=\"" + replacement + "\"")
-                .Replace("id='" + id + "'", "id='" + replacement + "'")
-                .Replace("url(#" + id + ")", "url(#" + replacement + ")")
-                .Replace("href=\"#" + id + "\"", "href=\"#" + replacement + "\"")
-                .Replace("href='#" + id + "'", "href='#" + replacement + "'")
-                .Replace("xlink:href=\"#" + id + "\"", "xlink:href=\"#" + replacement + "\"")
-                .Replace("xlink:href='#" + id + "'", "xlink:href='#" + replacement + "'");
-        }
-
-        return namespaced;
+        if (ids.Count == 0) return svg;
+        const string references = "\\bid=(?<idq>['\"])(?<id>[^'\"]+)\\k<idq>|url\\(#(?<url>[^)]+)\\)|(?<hrefName>(?:xlink:)?href)=(?<hrefq>['\"])#(?<href>[^'\"]+)\\k<hrefq>";
+        return System.Text.RegularExpressions.Regex.Replace(svg, references, match => {
+            if (match.Groups["id"].Success) {
+                string id = match.Groups["id"].Value;
+                return ids.Contains(id) ? "id=" + match.Groups["idq"].Value + prefix + id + match.Groups["idq"].Value : match.Value;
+            }
+            if (match.Groups["url"].Success) {
+                string id = match.Groups["url"].Value;
+                return ids.Contains(id) ? "url(#" + prefix + id + ")" : match.Value;
+            }
+            string href = match.Groups["href"].Value;
+            return ids.Contains(href)
+                ? match.Groups["hrefName"].Value + "=" + match.Groups["hrefq"].Value + "#" + prefix + href + match.Groups["hrefq"].Value
+                : match.Value;
+        });
     }
 
     private static string CreateDiagnosticGroupKey(OfficeImageExportDiagnostic diagnostic) {

--- a/OfficeIMO.Excel.Html/HtmlExcelConverterExtensions.cs
+++ b/OfficeIMO.Excel.Html/HtmlExcelConverterExtensions.cs
@@ -470,6 +470,15 @@ public static partial class HtmlExcelConverterExtensions {
             toColumn = NormalizeImportInt(toColumn, Math.Min(A1.MaxColumns, column + 1), 1, A1.MaxColumns, budget, result, "image ending column");
             int endRow = Math.Max(row, toRow - 1);
             int endColumn = Math.Max(column, toColumn - 1);
+            long anchoredCells = (long)(endRow - row + 1) * (endColumn - column + 1);
+            if (anchoredCells > budget.Limits.MaxTableCells) {
+                AddImportDiagnostic(result, HtmlConversionDiagnosticCodes.ContentApproximated,
+                    "Image inventory item '" + (name.Length == 0 ? "Image" : name) + "' exceeded MaxTableCells for its two-cell anchor and was restored to its fallback cell anchor.",
+                    lossKind: HtmlConversionLossKind.Approximation);
+                return sheet.AddImage(row, column, bytes, contentType, width, height, offsetX, offsetY,
+                    name: name.Length == 0 ? null : name,
+                    altText: description.Length == 0 ? null : description);
+            }
             int maxGeometry = (int)Math.Min(int.MaxValue, budget.Limits.MaxAbsoluteGeometry);
             int endOffsetX = NormalizeImportInt(ReadOptionalIntAttribute(item, "data-officeimo-to-offset-x") ?? 0, 0, 0, maxGeometry, budget, result, "image ending x offset");
             int endOffsetY = NormalizeImportInt(ReadOptionalIntAttribute(item, "data-officeimo-to-offset-y") ?? 0, 0, 0, maxGeometry, budget, result, "image ending y offset");

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
@@ -329,6 +329,36 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ExcelRange_ImageExportDoesNotChargeInvalidChartSourcesBeforeCacheFallback() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("Data");
+            sheet.CellValue(1, 1, "not-a-number");
+            sheet.CellValue(2, 1, 20D);
+            Type utilities = typeof(ExcelDocument).Assembly.GetType("OfficeIMO.Excel.ExcelChartUtils")!;
+            System.Reflection.MethodInfo readReference = utilities.GetMethod("TryReadReferencedNumberValues", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+            System.Reflection.MethodInfo readCache = utilities.GetMethod("TryReadNumberPoints", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+            Type budgetType = utilities.GetNestedType("ChartDataPointBudget", System.Reflection.BindingFlags.NonPublic)!;
+            object budget = Activator.CreateInstance(
+                budgetType,
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+                binder: null,
+                args: new object[] { 2L },
+                culture: null)!;
+            object?[] invalidReference = { sheet, "Data!$A$1:$A$2", budget, null };
+            var cache = new NumberingCache(
+                new PointCount { Val = 2U },
+                new NumericPoint(new NumericValue("10")) { Index = 0U },
+                new NumericPoint(new NumericValue("20")) { Index = 1U });
+            object?[] cachedValues = { cache, budget, null };
+
+            Assert.False((bool)readReference.Invoke(null, invalidReference)!);
+            Assert.True((bool)readCache.Invoke(null, cachedValues)!);
+            Assert.Equal(new[] { 10D, 20D }, (IReadOnlyList<double>)cachedValues[2]!);
+            System.Reflection.FieldInfo remainingSourceReads = budgetType.GetField("_remainingSourceReads", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            Assert.Equal(0L, (long)remainingSourceReads.GetValue(budget)!);
+        }
+
+        [Fact]
         public void ExcelRange_ImageExportReusesFirstScatterXValuesWithinAggregateBudget() {
             using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
             ExcelSheet sheet = document.AddWorksheet("ScatterBudget");

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
@@ -235,6 +235,34 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ExcelRange_ImageExportRejectsUnboundedChartFormulaRangesBeforeEnumeration() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("Data");
+            Type utilities = typeof(ExcelDocument).Assembly.GetType("OfficeIMO.Excel.ExcelChartUtils")!;
+            System.Reflection.MethodInfo method = utilities.GetMethod("TryReadReferencedNumberValues", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+            object?[] args = { sheet, "Data!$A$1:$XFD$1048576", null };
+
+            bool read = (bool)method.Invoke(null, args)!;
+
+            Assert.False(read);
+            Assert.Null(args[2]);
+        }
+
+        [Fact]
+        public void ExcelRange_ImageExportRejectsOversizedChartCachePointCountsBeforeAllocation() {
+            Type utilities = typeof(ExcelDocument).Assembly.GetType("OfficeIMO.Excel.ExcelChartUtils")!;
+            System.Reflection.MethodInfo method = utilities.GetMethod("TryReadNumberPoints", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+            var cache = new DocumentFormat.OpenXml.Drawing.Charts.NumberingCache(
+                new DocumentFormat.OpenXml.Drawing.Charts.PointCount { Val = 1_000_001U });
+            object?[] args = { cache, null };
+
+            bool read = (bool)method.Invoke(null, args)!;
+
+            Assert.False(read);
+            Assert.Null(args[1]);
+        }
+
+        [Fact]
         public void ExcelRange_ImageExportUsesReferencedValuesWhenVerticalSeriesIsNonAdjacent() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             using ExcelDocument document = ExcelDocument.Create(filePath);

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
@@ -329,11 +329,15 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void ExcelRange_ImageExportDoesNotChargeInvalidChartSourcesBeforeCacheFallback() {
+        public void ExcelRange_ImageExportRestoresUnusedReadsAfterInvalidChartSourceFallback() {
             using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
             ExcelSheet sheet = document.AddWorksheet("Data");
             sheet.CellValue(1, 1, "not-a-number");
             sheet.CellValue(2, 1, 20D);
+            sheet.CellValue(3, 1, 30D);
+            sheet.CellValue(4, 1, 40D);
+            sheet.CellValue(1, 2, 50D);
+            sheet.CellValue(2, 2, 60D);
             Type utilities = typeof(ExcelDocument).Assembly.GetType("OfficeIMO.Excel.ExcelChartUtils")!;
             System.Reflection.MethodInfo readReference = utilities.GetMethod("TryReadReferencedNumberValues", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
             System.Reflection.MethodInfo readCache = utilities.GetMethod("TryReadNumberPoints", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
@@ -342,20 +346,22 @@ namespace OfficeIMO.Tests {
                 budgetType,
                 System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
                 binder: null,
-                args: new object[] { 2L },
+                args: new object[] { 4L },
                 culture: null)!;
-            object?[] invalidReference = { sheet, "Data!$A$1:$A$2", budget, null };
+            object?[] invalidReference = { sheet, "Data!$A$1:$A$4", budget, null };
             var cache = new NumberingCache(
-                new PointCount { Val = 2U },
-                new NumericPoint(new NumericValue("10")) { Index = 0U },
-                new NumericPoint(new NumericValue("20")) { Index = 1U });
+                new PointCount { Val = 1U },
+                new NumericPoint(new NumericValue("10")) { Index = 0U });
             object?[] cachedValues = { cache, budget, null };
+            object?[] validReference = { sheet, "Data!$B$1:$B$2", budget, null };
 
             Assert.False((bool)readReference.Invoke(null, invalidReference)!);
             Assert.True((bool)readCache.Invoke(null, cachedValues)!);
-            Assert.Equal(new[] { 10D, 20D }, (IReadOnlyList<double>)cachedValues[2]!);
+            Assert.True((bool)readReference.Invoke(null, validReference)!);
+            Assert.Equal(new[] { 10D }, (IReadOnlyList<double>)cachedValues[2]!);
+            Assert.Equal(new[] { 50D, 60D }, (IReadOnlyList<double>)validReference[3]!);
             System.Reflection.FieldInfo remainingSourceReads = budgetType.GetField("_remainingSourceReads", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
-            Assert.Equal(0L, (long)remainingSourceReads.GetValue(budget)!);
+            Assert.Equal(1L, (long)remainingSourceReads.GetValue(budget)!);
         }
 
         [Fact]

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
@@ -364,6 +364,50 @@ namespace OfficeIMO.Tests {
             Assert.Equal(new[] { 10D, 20D }, series.Values);
         }
 
+        [Fact]
+        public void ExcelRange_ImageExportDoesNotChargeReferencedSeriesNamesToDataPointBudget() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("CaptionBudget");
+            sheet.CellValue(1, 1, 1D);
+            sheet.CellValue(2, 1, 2D);
+            sheet.CellValue(1, 2, "Referenced caption");
+            sheet.CellValue(1, 3, 10D);
+            sheet.CellValue(2, 3, 20D);
+            sheet.AddScatterChartFromRanges(
+                new[] { new ExcelChartSeriesRange("Placeholder", "A1:A2", "C1:C2") },
+                row: 1,
+                column: 5,
+                widthPixels: 260,
+                heightPixels: 170,
+                title: "Budget");
+            ChartPart chartPart = GetFirstChartPart(document);
+            ScatterChartSeries chartSeries = chartPart.ChartSpace!.Descendants<ScatterChartSeries>().First();
+            SeriesText seriesText = chartSeries.GetFirstChild<SeriesText>()!;
+            seriesText.RemoveAllChildren();
+            seriesText.Append(new StringReference(new Formula("CaptionBudget!$B$1")));
+            chartPart.ChartSpace.Save();
+
+            Type utilities = typeof(ExcelDocument).Assembly.GetType("OfficeIMO.Excel.ExcelChartUtils")!;
+            Type budgetType = utilities.GetNestedType("ChartDataPointBudget", System.Reflection.BindingFlags.NonPublic)!;
+            object budget = Activator.CreateInstance(
+                budgetType,
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+                binder: null,
+                args: new object[] { 4L },
+                culture: null)!;
+            System.Reflection.MethodInfo method = utilities.GetMethod(
+                "TryReadChartDataCore",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+
+            ExcelChartData? data = (ExcelChartData?)method.Invoke(null, new[] { chartPart, sheet, budget });
+
+            Assert.NotNull(data);
+            ExcelChartSeries series = Assert.Single(data!.Series);
+            Assert.Equal("Referenced caption", series.Name);
+            Assert.Equal(new[] { 1D, 2D }, series.XValues);
+            Assert.Equal(new[] { 10D, 20D }, series.Values);
+        }
+
         private static object CreateChartDataPointBudget(Type utilities) {
             Type budgetType = utilities.GetNestedType("ChartDataPointBudget", System.Reflection.BindingFlags.NonPublic)!;
             return Activator.CreateInstance(budgetType, nonPublic: true)!;

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
@@ -302,6 +302,42 @@ namespace OfficeIMO.Tests {
             Assert.Equal(999_997L, (long)remaining.GetValue(budget)!);
         }
 
+        [Fact]
+        public void ExcelRange_ImageExportReusesFirstScatterXValuesWithinAggregateBudget() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("ScatterBudget");
+            sheet.CellValue(1, 1, 1D);
+            sheet.CellValue(2, 1, 2D);
+            sheet.CellValue(1, 3, 10D);
+            sheet.CellValue(2, 3, 20D);
+            sheet.AddScatterChartFromRanges(
+                new[] { new ExcelChartSeriesRange("Points", "A1:A2", "C1:C2") },
+                row: 1,
+                column: 5,
+                widthPixels: 260,
+                heightPixels: 170,
+                title: "Budget");
+            ChartPart chartPart = GetFirstChartPart(document);
+            Type utilities = typeof(ExcelDocument).Assembly.GetType("OfficeIMO.Excel.ExcelChartUtils")!;
+            Type budgetType = utilities.GetNestedType("ChartDataPointBudget", System.Reflection.BindingFlags.NonPublic)!;
+            object budget = Activator.CreateInstance(
+                budgetType,
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+                binder: null,
+                args: new object[] { 4L },
+                culture: null)!;
+            System.Reflection.MethodInfo method = utilities.GetMethod(
+                "TryReadChartDataCore",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+
+            ExcelChartData? data = (ExcelChartData?)method.Invoke(null, new[] { chartPart, sheet, budget });
+
+            Assert.NotNull(data);
+            ExcelChartSeries series = Assert.Single(data!.Series);
+            Assert.Equal(new[] { 1D, 2D }, series.XValues);
+            Assert.Equal(new[] { 10D, 20D }, series.Values);
+        }
+
         private static object CreateChartDataPointBudget(Type utilities) {
             Type budgetType = utilities.GetNestedType("ChartDataPointBudget", System.Reflection.BindingFlags.NonPublic)!;
             return Activator.CreateInstance(budgetType, nonPublic: true)!;

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
@@ -226,12 +226,13 @@ namespace OfficeIMO.Tests {
             sheet.CellValue(4, 2, 30);
             Type utilities = typeof(ExcelDocument).Assembly.GetType("OfficeIMO.Excel.ExcelChartUtils")!;
             System.Reflection.MethodInfo method = utilities.GetMethod("TryReadReferencedNumberValues", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
-            object?[] args = { sheet, "BlankPoints!$B$2:$B$4", null };
+            object budget = CreateChartDataPointBudget(utilities);
+            object?[] args = { sheet, "BlankPoints!$B$2:$B$4", budget, null };
 
             bool read = (bool)method.Invoke(null, args)!;
 
             Assert.True(read);
-            Assert.Equal(new[] { 10D, 0D, 30D }, (IReadOnlyList<double>)args[2]!);
+            Assert.Equal(new[] { 10D, 0D, 30D }, (IReadOnlyList<double>)args[3]!);
         }
 
         [Fact]
@@ -240,12 +241,13 @@ namespace OfficeIMO.Tests {
             ExcelSheet sheet = document.AddWorksheet("Data");
             Type utilities = typeof(ExcelDocument).Assembly.GetType("OfficeIMO.Excel.ExcelChartUtils")!;
             System.Reflection.MethodInfo method = utilities.GetMethod("TryReadReferencedNumberValues", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
-            object?[] args = { sheet, "Data!$A$1:$XFD$1048576", null };
+            object budget = CreateChartDataPointBudget(utilities);
+            object?[] args = { sheet, "Data!$A$1:$XFD$1048576", budget, null };
 
             bool read = (bool)method.Invoke(null, args)!;
 
             Assert.False(read);
-            Assert.Null(args[2]);
+            Assert.Null(args[3]);
         }
 
         [Fact]
@@ -254,12 +256,55 @@ namespace OfficeIMO.Tests {
             System.Reflection.MethodInfo method = utilities.GetMethod("TryReadNumberPoints", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
             var cache = new DocumentFormat.OpenXml.Drawing.Charts.NumberingCache(
                 new DocumentFormat.OpenXml.Drawing.Charts.PointCount { Val = 1_000_001U });
-            object?[] args = { cache, null };
+            object budget = CreateChartDataPointBudget(utilities);
+            object?[] args = { cache, budget, null };
 
             bool read = (bool)method.Invoke(null, args)!;
 
             Assert.False(read);
-            Assert.Null(args[1]);
+            Assert.Null(args[2]);
+        }
+
+        [Fact]
+        public void ExcelRange_ImageExportChargesActualCachePointsWhenPointCountIsUnderstated() {
+            Type utilities = typeof(ExcelDocument).Assembly.GetType("OfficeIMO.Excel.ExcelChartUtils")!;
+            System.Reflection.MethodInfo method = utilities.GetMethod("TryReadNumberPoints", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+            var cache = new DocumentFormat.OpenXml.Drawing.Charts.NumberingCache(
+                new DocumentFormat.OpenXml.Drawing.Charts.PointCount { Val = 1U },
+                new NumericPoint(new NumericValue("1")) { Index = 0U },
+                new NumericPoint(new NumericValue("2")) { Index = 1U });
+            object budget = CreateChartDataPointBudget(utilities);
+            object?[] args = { cache, budget, null };
+
+            Assert.True((bool)method.Invoke(null, args)!);
+
+            System.Reflection.FieldInfo remaining = budget.GetType().GetField("_remaining", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            Assert.Equal(999_998L, (long)remaining.GetValue(budget)!);
+        }
+
+        [Fact]
+        public void ExcelRange_ImageExportSharesOneAggregateBudgetAcrossChartReferences() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("AggregateBudget");
+            sheet.CellValue(1, 1, 1);
+            sheet.CellValue(2, 1, 2);
+            sheet.CellValue(1, 2, 3);
+            Type utilities = typeof(ExcelDocument).Assembly.GetType("OfficeIMO.Excel.ExcelChartUtils")!;
+            System.Reflection.MethodInfo method = utilities.GetMethod("TryReadReferencedNumberValues", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+            object budget = CreateChartDataPointBudget(utilities);
+            object?[] first = { sheet, "AggregateBudget!$A$1:$A$2", budget, null };
+            object?[] second = { sheet, "AggregateBudget!$B$1", budget, null };
+
+            Assert.True((bool)method.Invoke(null, first)!);
+            Assert.True((bool)method.Invoke(null, second)!);
+
+            System.Reflection.FieldInfo remaining = budget.GetType().GetField("_remaining", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            Assert.Equal(999_997L, (long)remaining.GetValue(budget)!);
+        }
+
+        private static object CreateChartDataPointBudget(Type utilities) {
+            Type budgetType = utilities.GetNestedType("ChartDataPointBudget", System.Reflection.BindingFlags.NonPublic)!;
+            return Activator.CreateInstance(budgetType, nonPublic: true)!;
         }
 
         [Fact]

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
@@ -303,6 +303,32 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ExcelRange_ImageExportDoesNotChargeMissingChartSourcesBeforeCacheFallback() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("Data");
+            Type utilities = typeof(ExcelDocument).Assembly.GetType("OfficeIMO.Excel.ExcelChartUtils")!;
+            System.Reflection.MethodInfo readReference = utilities.GetMethod("TryReadReferencedNumberValues", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+            System.Reflection.MethodInfo readCache = utilities.GetMethod("TryReadNumberPoints", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+            Type budgetType = utilities.GetNestedType("ChartDataPointBudget", System.Reflection.BindingFlags.NonPublic)!;
+            object budget = Activator.CreateInstance(
+                budgetType,
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+                binder: null,
+                args: new object[] { 2L },
+                culture: null)!;
+            object?[] missingReference = { sheet, "Missing!$A$1:$A$1000000", budget, null };
+            var cache = new NumberingCache(
+                new PointCount { Val = 2U },
+                new NumericPoint(new NumericValue("10")) { Index = 0U },
+                new NumericPoint(new NumericValue("20")) { Index = 1U });
+            object?[] cachedValues = { cache, budget, null };
+
+            Assert.False((bool)readReference.Invoke(null, missingReference)!);
+            Assert.True((bool)readCache.Invoke(null, cachedValues)!);
+            Assert.Equal(new[] { 10D, 20D }, (IReadOnlyList<double>)cachedValues[2]!);
+        }
+
+        [Fact]
         public void ExcelRange_ImageExportReusesFirstScatterXValuesWithinAggregateBudget() {
             using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
             ExcelSheet sheet = document.AddWorksheet("ScatterBudget");

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
@@ -395,6 +395,48 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ExcelRange_ImageExportDoesNotRechargeMaterializedScatterYValues() {
+            const uint pointsPerSeries = 200_000U;
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("ScatterXYBudget");
+            for (int column = 1; column <= 8; column++) {
+                sheet.CellValue(1, column, column);
+            }
+            sheet.AddScatterChartFromRanges(
+                new[] {
+                    new ExcelChartSeriesRange("One", "A1:A1", "B1:B1"),
+                    new ExcelChartSeriesRange("Two", "C1:C1", "D1:D1"),
+                    new ExcelChartSeriesRange("Three", "E1:E1", "F1:F1"),
+                    new ExcelChartSeriesRange("Four", "G1:G1", "H1:H1")
+                },
+                row: 1,
+                column: 10,
+                widthPixels: 260,
+                heightPixels: 170,
+                title: "XY budget");
+
+            ChartPart chartPart = GetFirstChartPart(document);
+            foreach (ScatterChartSeries chartSeries in chartPart.ChartSpace!.Descendants<ScatterChartSeries>()) {
+                ReplaceWithLargeNumberCache(chartSeries.GetFirstChild<XValues>()!.GetFirstChild<NumberReference>()!, pointsPerSeries);
+                ReplaceWithLargeNumberCache(chartSeries.GetFirstChild<YValues>()!.GetFirstChild<NumberReference>()!, pointsPerSeries);
+            }
+            chartPart.ChartSpace.Save();
+
+            string[] categories = new string[(int)pointsPerSeries];
+            double[] values = new double[(int)pointsPerSeries];
+            var input = new ExcelChartData(
+                categories,
+                Enumerable.Range(1, 4).Select(index => new ExcelChartSeries("Series " + index, values, ExcelChartType.Scatter)));
+
+            ExcelChartData result = ExcelChartUtils.ApplyScatterSeriesXValues(chartPart, input, sheet);
+
+            Assert.All(result.Series, series => {
+                Assert.NotNull(series.XValues);
+                Assert.Equal((int)pointsPerSeries, series.XValues!.Count);
+            });
+        }
+
+        [Fact]
         public void ExcelRange_ImageExportDoesNotChargeReferencedSeriesNamesToDataPointBudget() {
             using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
             ExcelSheet sheet = document.AddWorksheet("CaptionBudget");
@@ -441,6 +483,13 @@ namespace OfficeIMO.Tests {
         private static object CreateChartDataPointBudget(Type utilities) {
             Type budgetType = utilities.GetNestedType("ChartDataPointBudget", System.Reflection.BindingFlags.NonPublic)!;
             return Activator.CreateInstance(budgetType, nonPublic: true)!;
+        }
+
+        private static void ReplaceWithLargeNumberCache(NumberReference reference, uint pointCount) {
+            reference.RemoveAllChildren();
+            reference.Append(new NumberingCache(
+                new PointCount { Val = pointCount },
+                new NumericPoint(new NumericValue("1")) { Index = 0U }));
         }
 
         [Fact]

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
@@ -303,6 +303,50 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ExcelRange_ImageExportDoesNotChargeUnusedSeriesCaches() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("SourceBudget");
+            sheet.CellValue(1, 1, "Category");
+            sheet.CellValue(1, 2, "First");
+            sheet.CellValue(1, 3, "Second");
+            sheet.CellValue(2, 1, "Jan");
+            sheet.CellValue(3, 1, "Feb");
+            sheet.CellValue(2, 2, 10D);
+            sheet.CellValue(3, 2, 20D);
+            sheet.CellValue(2, 3, 30D);
+            sheet.CellValue(3, 3, 40D);
+            sheet.AddChartFromRange(
+                "A1:C3",
+                row: 1,
+                column: 5,
+                widthPixels: 260,
+                heightPixels: 170,
+                type: ExcelChartType.ColumnClustered,
+                title: "Source budget");
+
+            ChartPart chartPart = GetFirstChartPart(document);
+            Type utilities = typeof(ExcelDocument).Assembly.GetType("OfficeIMO.Excel.ExcelChartUtils")!;
+            Type budgetType = utilities.GetNestedType("ChartDataPointBudget", System.Reflection.BindingFlags.NonPublic)!;
+            object budget = Activator.CreateInstance(
+                budgetType,
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+                binder: null,
+                args: new object[] { 6L },
+                culture: null)!;
+            System.Reflection.MethodInfo method = utilities.GetMethod(
+                "TryReadChartDataCore",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+
+            ExcelChartData? data = (ExcelChartData?)method.Invoke(null, new[] { chartPart, sheet, budget });
+
+            Assert.NotNull(data);
+            Assert.Equal(new[] { "Jan", "Feb" }, data!.Categories);
+            Assert.Equal(2, data.Series.Count);
+            Assert.Equal(new[] { 10D, 20D }, data.Series[0].Values);
+            Assert.Equal(new[] { 30D, 40D }, data.Series[1].Values);
+        }
+
+        [Fact]
         public void ExcelRange_ImageExportDoesNotChargeMissingChartSourcesBeforeCacheFallback() {
             using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
             ExcelSheet sheet = document.AddWorksheet("Data");

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
@@ -761,6 +761,25 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ExcelRange_ImageExportOmitsConditionalRulesBeyondReferenceLimit() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("OversizedConditional");
+            sheet.CellValue(1, 1, 0D);
+            sheet.CellValue(100_001, 1, 1000D);
+            sheet.AddConditionalColorScale("A1:A100001", OfficeColor.Red, OfficeColor.Lime);
+
+            ExcelRangeVisualSnapshot snapshot = sheet.Range("A1:A1").CreateVisualSnapshot();
+
+            Assert.Null(Assert.Single(snapshot.Cells).Style.FillColorArgb);
+            OfficeImageExportDiagnostic diagnostic = Assert.Single(
+                snapshot.Diagnostics,
+                item => item.Code == ExcelImageExportDiagnosticCodes.ConditionalReferenceLimitExceeded);
+            Assert.Equal(OfficeImageExportDiagnosticSeverity.Warning, diagnostic.Severity);
+            Assert.Equal(OfficeImageExportLossKind.Omission, diagnostic.LossKind);
+            Assert.Equal("OversizedConditional!A1:A100001", diagnostic.Source);
+        }
+
+        [Fact]
         public void ExcelRange_ImageExportKeepsStoppedCellsInColorScaleThresholds() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             using ExcelDocument document = ExcelDocument.Create(filePath);

--- a/OfficeIMO.Excel.Tests/Excel.ReaderDataReader.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ReaderDataReader.cs
@@ -84,6 +84,22 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Reader_ReadRangeAsDataReader_RejectsRangesBeyondBufferedCellBudget() {
+            using var memory = new MemoryStream();
+            using (var document = ExcelDocument.Create(memory, new ExcelCreateOptions { PersistenceMode = OfficeIMO.Drawing.DocumentPersistenceMode.SaveOnDispose })) {
+                document.AddWorksheet("Data").CellValue(1, 1, "Header");
+            }
+            using var reader = ExcelDocumentReader.Open(memory.ToArray(), new ExcelReadOptions {
+                MaxDataReaderBufferedCells = 2
+            });
+
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+                reader.GetSheet("Data").ReadRangeAsDataReader("A1:C2"));
+
+            Assert.Contains(nameof(ExcelReadOptions.MaxDataReaderBufferedCells), exception.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void Reader_ReadRangeAsDataReader_WithoutHeadersPreservesBlankRowsInsideRange() {
             using var memory = new MemoryStream();
 

--- a/OfficeIMO.Excel.Tests/Excel.ReaderDataReader.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ReaderDataReader.cs
@@ -219,6 +219,24 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Reader_ReadRangeAsDataReader_XmlFastPathDoesNotChargeUnusedChunkBuffer() {
+            using var memory = new MemoryStream();
+
+            using (var document = ExcelDocument.Create(memory, new ExcelCreateOptions { PersistenceMode = OfficeIMO.Drawing.DocumentPersistenceMode.SaveOnDispose })) {
+                var sheet = document.AddWorksheet("Data");
+                sheet.CellValue(1, 1, "First");
+                sheet.CellValue(5000, 1000, "Last");
+            }
+
+            using var reader = ExcelDocumentReader.Open(memory.ToArray());
+            using var dataReader = reader.GetSheet("Data").ReadRangeAsDataReader("A1:ALL5000", schemaSampleRows: 0);
+
+            Assert.Equal(1000, dataReader.FieldCount);
+            Assert.True(dataReader.Read());
+            Assert.True(dataReader.IsDBNull(0));
+        }
+
+        [Fact]
         public void Reader_ReadRangeAsDataReader_WithoutSchemaSamples_PreservesValuesAfterTypedAccess() {
             var expectedDate = new DateTime(2026, 7, 9);
             using var memory = new MemoryStream();

--- a/OfficeIMO.Excel/ExcelChartSeries.cs
+++ b/OfficeIMO.Excel/ExcelChartSeries.cs
@@ -46,9 +46,6 @@ namespace OfficeIMO.Excel {
         internal ExcelChartSeries WithXValues(IReadOnlyList<double>? xValues) =>
             new(Name, Values, xValues, ChartType, AxisGroup, SeriesColorArgb, SeriesLineWidth, SeriesLineDashStyle, PointColorArgb, ShowMarkers, ConnectLine, MarkerSize, MarkerShape, MarkerOutlineColorArgb, MarkerOutlineWidth, ownsValues: false);
 
-        internal ExcelChartSeries WithValuesAndXValues(IReadOnlyList<double> values, IReadOnlyList<double>? xValues) =>
-            new(Name, values, xValues, ChartType, AxisGroup, SeriesColorArgb, SeriesLineWidth, SeriesLineDashStyle, PointColorArgb, ShowMarkers, ConnectLine, MarkerSize, MarkerShape, MarkerOutlineColorArgb, MarkerOutlineWidth, ownsValues: false);
-
         internal ExcelChartSeries WithImageExportStyle(string? seriesColorArgb, double? seriesLineWidth, OfficeStrokeDashStyle? seriesLineDashStyle, IReadOnlyList<string?>? pointColorArgb, bool showMarkers, bool? connectLine, int? markerSize, OfficeChartMarkerShape? markerShape, string? markerOutlineColorArgb, double? markerOutlineWidth) =>
             new(Name, Values, XValues, ChartType, AxisGroup, seriesColorArgb ?? SeriesColorArgb, seriesLineWidth ?? SeriesLineWidth, seriesLineDashStyle ?? SeriesLineDashStyle, pointColorArgb ?? PointColorArgb, showMarkers, connectLine ?? ConnectLine, markerSize ?? MarkerSize, markerShape ?? MarkerShape, markerOutlineColorArgb ?? MarkerOutlineColorArgb, markerOutlineWidth ?? MarkerOutlineWidth, ownsValues: false);
 

--- a/OfficeIMO.Excel/ExcelChartUtils.Update.Range.cs
+++ b/OfficeIMO.Excel/ExcelChartUtils.Update.Range.cs
@@ -552,16 +552,6 @@ namespace OfficeIMO.Excel {
             }
 
             var pointBudget = new ChartDataPointBudget();
-            if (!pointBudget.TryCharge(data.Categories.Count)) {
-                return data;
-            }
-            foreach (ExcelChartSeries existingSeries in data.Series) {
-                if (!pointBudget.TryCharge(existingSeries.Values.Count) ||
-                    (existingSeries.XValues != null && !pointBudget.TryCharge(existingSeries.XValues.Count))) {
-                    return data;
-                }
-            }
-
             var scatterValuesByIndex = new Dictionary<int, (IReadOnlyList<double>? XValues, IReadOnlyList<double>? YValues)>();
             int seriesOrder = 0;
             foreach (OpenXmlElement seriesElement in GetChartSeries(plotArea)) {

--- a/OfficeIMO.Excel/ExcelChartUtils.Update.Range.cs
+++ b/OfficeIMO.Excel/ExcelChartUtils.Update.Range.cs
@@ -580,7 +580,7 @@ namespace OfficeIMO.Excel {
             }
 
             var pointBudget = new ChartDataPointBudget();
-            var scatterValuesByIndex = new Dictionary<int, (IReadOnlyList<double>? XValues, IReadOnlyList<double>? YValues)>();
+            var scatterXValuesByIndex = new Dictionary<int, IReadOnlyList<double>>();
             int seriesOrder = 0;
             foreach (OpenXmlElement seriesElement in GetChartSeries(plotArea)) {
                 int index = seriesOrder++;
@@ -593,44 +593,30 @@ namespace OfficeIMO.Excel {
                 }
 
                 NumberReference? xReference = scatterSeries.GetFirstChild<XValues>()?.GetFirstChild<NumberReference>();
-                NumberReference? yReference = scatterSeries.GetFirstChild<YValues>()?.GetFirstChild<NumberReference>();
                 NumberLiteral? xLiteral = scatterSeries.GetFirstChild<XValues>()?.GetFirstChild<NumberLiteral>();
                 if (!TryReadNumberLiteralValues(xLiteral, pointBudget, out IReadOnlyList<double>? xValues) &&
                     !TryReadReferencedNumberValues(contextSheet, xReference?.Formula?.Text, pointBudget, out xValues)) {
                     TryReadCachedNumberValues(xReference, pointBudget, out xValues);
                 }
 
-                TryReadReferencedNumberValues(contextSheet, yReference?.Formula?.Text, pointBudget, out IReadOnlyList<double>? referencedYValues);
-                TryReadCachedNumberValues(yReference, pointBudget, out IReadOnlyList<double>? cachedYValues);
-                IReadOnlyList<double>? yValues = referencedYValues;
-                if (xValues != null &&
-                    referencedYValues != null &&
-                    referencedYValues.Count != xValues.Count &&
-                    cachedYValues != null &&
-                    cachedYValues.Count == xValues.Count) {
-                    yValues = cachedYValues;
-                }
-
-                yValues ??= cachedYValues;
-                if (xValues != null || yValues != null) {
-                    scatterValuesByIndex[index] = (xValues, yValues);
+                if (xValues != null) {
+                    scatterXValuesByIndex[index] = xValues;
                 }
             }
 
-            if (scatterValuesByIndex.Count == 0) {
+            if (scatterXValuesByIndex.Count == 0) {
                 return data;
             }
 
             var series = new List<ExcelChartSeries>(data.Series.Count);
             for (int i = 0; i < data.Series.Count; i++) {
                 ExcelChartSeries current = data.Series[i];
-                if (!scatterValuesByIndex.TryGetValue(i, out var cachedValues)) {
+                if (!scatterXValuesByIndex.TryGetValue(i, out IReadOnlyList<double>? xValues)) {
                     series.Add(current);
                     continue;
                 }
 
-                IReadOnlyList<double> values = cachedValues.YValues ?? current.Values;
-                series.Add(current.WithValuesAndXValues(values, cachedValues.XValues ?? current.XValues));
+                series.Add(current.WithXValues(xValues));
             }
 
             return new ExcelChartData(data.Categories, series);

--- a/OfficeIMO.Excel/ExcelChartUtils.Update.Range.cs
+++ b/OfficeIMO.Excel/ExcelChartUtils.Update.Range.cs
@@ -709,8 +709,7 @@ namespace OfficeIMO.Excel {
         private static bool TryReadReferencedTextValues(ExcelSheet contextSheet, string? formula, ChartDataPointBudget pointBudget, out IReadOnlyList<string>? values) {
             values = null;
             if (!TryParseSheetQualifiedRange(formula, out string sheetName, out string range) ||
-                !TryParseRange(range, out int r1, out int c1, out int r2, out int c2) ||
-                !pointBudget.TryCharge((long)(r2 - r1 + 1) * (c2 - c1 + 1))) {
+                !TryParseRange(range, out int r1, out int c1, out int r2, out int c2)) {
                 return false;
             }
 
@@ -718,6 +717,10 @@ namespace OfficeIMO.Excel {
             try {
                 sheet = contextSheet.Document[sheetName];
             } catch {
+                return false;
+            }
+
+            if (!pointBudget.TryCharge((long)(r2 - r1 + 1) * (c2 - c1 + 1))) {
                 return false;
             }
 
@@ -735,8 +738,7 @@ namespace OfficeIMO.Excel {
         private static bool TryReadReferencedNumberValues(ExcelSheet contextSheet, string? formula, ChartDataPointBudget pointBudget, out IReadOnlyList<double>? values) {
             values = null;
             if (!TryParseSheetQualifiedRange(formula, out string sheetName, out string range) ||
-                !TryParseRange(range, out int r1, out int c1, out int r2, out int c2) ||
-                !pointBudget.TryCharge((long)(r2 - r1 + 1) * (c2 - c1 + 1))) {
+                !TryParseRange(range, out int r1, out int c1, out int r2, out int c2)) {
                 return false;
             }
 
@@ -744,6 +746,10 @@ namespace OfficeIMO.Excel {
             try {
                 sheet = contextSheet.Document[sheetName];
             } catch {
+                return false;
+            }
+
+            if (!pointBudget.TryCharge((long)(r2 - r1 + 1) * (c2 - c1 + 1))) {
                 return false;
             }
 

--- a/OfficeIMO.Excel/ExcelChartUtils.Update.Range.cs
+++ b/OfficeIMO.Excel/ExcelChartUtils.Update.Range.cs
@@ -37,6 +37,13 @@ namespace OfficeIMO.Excel {
                 _remainingSourceReads -= count;
                 return true;
             }
+
+            internal void RestoreUnusedSourceReads(long reserved, long consumed) {
+                long unused = reserved - consumed;
+                if (unused > 0) {
+                    _remainingSourceReads += unused;
+                }
+            }
         }
 
         internal static ExcelChartDataRange? TryExtractDataRange(ChartPart chartPart) {
@@ -758,8 +765,10 @@ namespace OfficeIMO.Excel {
             }
 
             var numericValues = new List<double>();
+            long consumedSourceReads = 0;
             for (int row = r1; row <= r2; row++) {
                 for (int column = c1; column <= c2; column++) {
+                    consumedSourceReads++;
                     if (!sheet.TryGetCellText(row, column, out string? raw) ||
                         string.IsNullOrWhiteSpace(raw)) {
                         numericValues.Add(0D);
@@ -767,6 +776,7 @@ namespace OfficeIMO.Excel {
                     }
 
                     if (!double.TryParse(raw, NumberStyles.Any, CultureInfo.InvariantCulture, out double value)) {
+                        pointBudget.RestoreUnusedSourceReads(requestedPointCount, consumedSourceReads);
                         return false;
                     }
 

--- a/OfficeIMO.Excel/ExcelChartUtils.Update.Range.cs
+++ b/OfficeIMO.Excel/ExcelChartUtils.Update.Range.cs
@@ -13,18 +13,28 @@ namespace OfficeIMO.Excel {
 
         private sealed class ChartDataPointBudget {
             private long _remaining;
+            private long _remainingSourceReads;
 
             internal ChartDataPointBudget() : this(MaxChartDataPoints) { }
 
             internal ChartDataPointBudget(long maximum) {
                 _remaining = maximum;
+                _remainingSourceReads = maximum;
             }
 
+            internal bool CanCharge(long count) => count >= 0 && count <= _remaining;
+
             internal bool TryCharge(long count) {
-                if (count < 0 || count > _remaining) {
+                if (!CanCharge(count)) {
                     return false;
                 }
                 _remaining -= count;
+                return true;
+            }
+
+            internal bool TryChargeSourceRead(long count) {
+                if (count < 0 || count > _remainingSourceReads) return false;
+                _remainingSourceReads -= count;
                 return true;
             }
         }
@@ -723,7 +733,9 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            if (!pointBudget.TryCharge((long)(r2 - r1 + 1) * (c2 - c1 + 1))) {
+            long requestedPointCount = (long)(r2 - r1 + 1) * (c2 - c1 + 1);
+            if (!pointBudget.CanCharge(requestedPointCount) ||
+                !pointBudget.TryChargeSourceRead(requestedPointCount)) {
                 return false;
             }
 
@@ -734,8 +746,9 @@ namespace OfficeIMO.Excel {
                 }
             }
 
+            if (textValues.Count == 0 || !pointBudget.TryCharge(requestedPointCount)) return false;
             values = textValues;
-            return textValues.Count > 0;
+            return true;
         }
 
         private static bool TryReadReferencedNumberValues(ExcelSheet contextSheet, string? formula, ChartDataPointBudget pointBudget, out IReadOnlyList<double>? values) {
@@ -752,7 +765,9 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            if (!pointBudget.TryCharge((long)(r2 - r1 + 1) * (c2 - c1 + 1))) {
+            long requestedPointCount = (long)(r2 - r1 + 1) * (c2 - c1 + 1);
+            if (!pointBudget.CanCharge(requestedPointCount) ||
+                !pointBudget.TryChargeSourceRead(requestedPointCount)) {
                 return false;
             }
 
@@ -773,8 +788,11 @@ namespace OfficeIMO.Excel {
                 }
             }
 
+            if (numericValues.Count == 0 || !pointBudget.TryCharge(requestedPointCount)) {
+                return false;
+            }
             values = numericValues;
-            return numericValues.Count > 0;
+            return true;
         }
 
         private static bool TryGetChartElementType(OpenXmlElement element, out ExcelChartType chartType) {

--- a/OfficeIMO.Excel/ExcelChartUtils.Update.Range.cs
+++ b/OfficeIMO.Excel/ExcelChartUtils.Update.Range.cs
@@ -9,6 +9,8 @@ using ChartIndex = DocumentFormat.OpenXml.Drawing.Charts.Index;
 
 namespace OfficeIMO.Excel {
     internal static partial class ExcelChartUtils {
+        private const int MaxChartDataPoints = 1_000_000;
+
         internal static ExcelChartDataRange? TryExtractDataRange(ChartPart chartPart) {
             var chart = chartPart.ChartSpace?.GetFirstChild<Chart>();
             var plotArea = chart?.GetFirstChild<PlotArea>();
@@ -54,7 +56,7 @@ namespace OfficeIMO.Excel {
             int valueColumns = valC2 - valC1 + 1;
             bool horizontal = categoryRows == 1 && categoryColumns > 1 && valueRows == 1 && valueColumns == categoryColumns && valC1 == c1 && valC2 == c2;
             int categoryCount = horizontal ? categoryColumns : categoryRows;
-            if (categoryCount <= 0) return null;
+            if (categoryCount <= 0 || (long)categoryCount * seriesList.Count > MaxChartDataPoints) return null;
 
             if (horizontal) {
                 if (valR1 != r1 + 1 || !HorizontalSeriesRangesAreContiguous(seriesList, sheetName, valR1, c1, c2)) {
@@ -259,6 +261,8 @@ namespace OfficeIMO.Excel {
 
         internal static ExcelChartData? TryReadChartData(ExcelSheet sheet, ExcelChartDataRange range) {
             try {
+                if (range.CategoryCount <= 0 || range.SeriesCount <= 0 ||
+                    (long)range.CategoryCount * range.SeriesCount > MaxChartDataPoints) return null;
                 var categories = new List<string>(range.CategoryCount);
                 for (int i = 0; i < range.CategoryCount; i++) {
                     int row = range.Orientation == ExcelChartDataOrientation.Vertical ? range.CategoryStartRow + i : range.CategoryStartRow;
@@ -583,7 +587,7 @@ namespace OfficeIMO.Excel {
 
             uint? pointCount = container.GetFirstChild<PointCount>()?.Val?.Value;
             if (pointCount.HasValue) {
-                if (pointCount.Value > int.MaxValue) {
+                if (pointCount.Value > MaxChartDataPoints) {
                     return false;
                 }
 
@@ -611,6 +615,7 @@ namespace OfficeIMO.Excel {
 
             var numericValues = new List<double>();
             foreach (NumericPoint point in container.Elements<NumericPoint>().OrderBy(point => point.Index?.Value ?? uint.MaxValue)) {
+                if (numericValues.Count >= MaxChartDataPoints) return false;
                 string? text = point.NumericValue?.Text;
                 if (!double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out double value)) {
                     return false;
@@ -630,17 +635,21 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            values = cache.Elements<StringPoint>()
+            string[] cachedValues = cache.Elements<StringPoint>()
                 .OrderBy(point => point.Index?.Value ?? uint.MaxValue)
                 .Select(point => point.NumericValue?.Text ?? string.Empty)
+                .Take(MaxChartDataPoints + 1)
                 .ToArray();
+            if (cachedValues.Length > MaxChartDataPoints) return false;
+            values = cachedValues;
             return values.Count > 0;
         }
 
         private static bool TryReadReferencedTextValues(ExcelSheet contextSheet, string? formula, out IReadOnlyList<string>? values) {
             values = null;
             if (!TryParseSheetQualifiedRange(formula, out string sheetName, out string range) ||
-                !TryParseRange(range, out int r1, out int c1, out int r2, out int c2)) {
+                !TryParseRange(range, out int r1, out int c1, out int r2, out int c2) ||
+                (long)(r2 - r1 + 1) * (c2 - c1 + 1) > MaxChartDataPoints) {
                 return false;
             }
 
@@ -665,7 +674,8 @@ namespace OfficeIMO.Excel {
         private static bool TryReadReferencedNumberValues(ExcelSheet contextSheet, string? formula, out IReadOnlyList<double>? values) {
             values = null;
             if (!TryParseSheetQualifiedRange(formula, out string sheetName, out string range) ||
-                !TryParseRange(range, out int r1, out int c1, out int r2, out int c2)) {
+                !TryParseRange(range, out int r1, out int c1, out int r2, out int c2) ||
+                (long)(r2 - r1 + 1) * (c2 - c1 + 1) > MaxChartDataPoints) {
                 return false;
             }
 

--- a/OfficeIMO.Excel/ExcelChartUtils.Update.Range.cs
+++ b/OfficeIMO.Excel/ExcelChartUtils.Update.Range.cs
@@ -386,7 +386,12 @@ namespace OfficeIMO.Excel {
                     }
 
                     TryReadReferencedNumberValues(contextSheet, valuesReference?.Formula?.Text, pointBudget, out IReadOnlyList<double>? referencedValues);
-                    TryReadCachedNumberValues(valuesReference, pointBudget, out IReadOnlyList<double>? cachedValues);
+                    IReadOnlyList<double>? cachedValues = null;
+                    if (referencedValues == null ||
+                        xValues != null && referencedValues.Count != xValues.Count) {
+                        TryReadCachedNumberValues(valuesReference, pointBudget, out cachedValues);
+                    }
+
                     IReadOnlyList<double>? values = referencedValues;
                     if (xValues != null &&
                         referencedValues != null &&

--- a/OfficeIMO.Excel/ExcelChartUtils.Update.Range.cs
+++ b/OfficeIMO.Excel/ExcelChartUtils.Update.Range.cs
@@ -12,7 +12,13 @@ namespace OfficeIMO.Excel {
         private const int MaxChartDataPoints = 1_000_000;
 
         private sealed class ChartDataPointBudget {
-            private long _remaining = MaxChartDataPoints;
+            private long _remaining;
+
+            internal ChartDataPointBudget() : this(MaxChartDataPoints) { }
+
+            internal ChartDataPointBudget(long maximum) {
+                _remaining = maximum;
+            }
 
             internal bool TryCharge(long count) {
                 if (count < 0 || count > _remaining) {
@@ -318,7 +324,13 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        internal static ExcelChartData? TryReadChartData(ChartPart chartPart, ExcelSheet contextSheet) {
+        internal static ExcelChartData? TryReadChartData(ChartPart chartPart, ExcelSheet contextSheet) =>
+            TryReadChartDataCore(chartPart, contextSheet, new ChartDataPointBudget());
+
+        private static ExcelChartData? TryReadChartDataCore(
+            ChartPart chartPart,
+            ExcelSheet contextSheet,
+            ChartDataPointBudget pointBudget) {
             try {
                 var chart = chartPart.ChartSpace?.GetFirstChild<Chart>();
                 var plotArea = chart?.GetFirstChild<PlotArea>();
@@ -331,7 +343,6 @@ namespace OfficeIMO.Excel {
                     return null;
                 }
 
-                var pointBudget = new ChartDataPointBudget();
                 if (!TryReadCategoryValues(seriesList[0], contextSheet, pointBudget, out IReadOnlyList<string>? categories) || categories == null || categories.Count == 0) {
                     return null;
                 }
@@ -345,11 +356,15 @@ namespace OfficeIMO.Excel {
                         : $"Series {i + 1}";
                     IReadOnlyList<double>? xValues = null;
                     if (seriesElement is ScatterChartSeries scatterSeries) {
-                        NumberReference? xReference = scatterSeries.GetFirstChild<XValues>()?.GetFirstChild<NumberReference>();
-                        NumberLiteral? xLiteral = scatterSeries.GetFirstChild<XValues>()?.GetFirstChild<NumberLiteral>();
-                        if (!TryReadNumberLiteralValues(xLiteral, pointBudget, out xValues) &&
-                            !TryReadReferencedNumberValues(contextSheet, xReference?.Formula?.Text, pointBudget, out xValues)) {
-                            TryReadCachedNumberValues(xReference, pointBudget, out xValues);
+                        if (i == 0) {
+                            xValues = ParseNumericCategories(categories);
+                        } else {
+                            NumberReference? xReference = scatterSeries.GetFirstChild<XValues>()?.GetFirstChild<NumberReference>();
+                            NumberLiteral? xLiteral = scatterSeries.GetFirstChild<XValues>()?.GetFirstChild<NumberLiteral>();
+                            if (!TryReadNumberLiteralValues(xLiteral, pointBudget, out xValues) &&
+                                !TryReadReferencedNumberValues(contextSheet, xReference?.Formula?.Text, pointBudget, out xValues)) {
+                                TryReadCachedNumberValues(xReference, pointBudget, out xValues);
+                            }
                         }
                     }
 

--- a/OfficeIMO.Excel/ExcelChartUtils.Update.Range.cs
+++ b/OfficeIMO.Excel/ExcelChartUtils.Update.Range.cs
@@ -351,7 +351,7 @@ namespace OfficeIMO.Excel {
                 for (int i = 0; i < seriesList.Count; i++) {
                     OpenXmlCompositeElement seriesElement = seriesList[i];
                     NumberReference? valuesReference = GetSeriesValuesReference(seriesElement);
-                    string name = TryReadSeriesName(seriesElement, contextSheet, pointBudget, out string? resolvedName) && !string.IsNullOrWhiteSpace(resolvedName)
+                    string name = TryReadSeriesName(seriesElement, contextSheet, out string? resolvedName) && !string.IsNullOrWhiteSpace(resolvedName)
                         ? resolvedName!
                         : $"Series {i + 1}";
                     IReadOnlyList<double>? xValues = null;
@@ -443,22 +443,25 @@ namespace OfficeIMO.Excel {
             return categories.Count > 0;
         }
 
-        private static bool TryReadSeriesName(OpenXmlCompositeElement seriesElement, ExcelSheet contextSheet, ChartDataPointBudget pointBudget, out string? name) {
+        private static bool TryReadSeriesName(OpenXmlCompositeElement seriesElement, ExcelSheet contextSheet, out string? name) {
             name = null;
+            var nameBudget = new ChartDataPointBudget(1L);
             SeriesText? seriesText = seriesElement.GetFirstChild<SeriesText>();
             StringReference? reference = seriesText?.GetFirstChild<StringReference>();
-            if (TryReadReferencedTextValues(contextSheet, reference?.Formula?.Text, pointBudget, out IReadOnlyList<string>? referencedValues) && referencedValues != null && referencedValues.Count > 0) {
+            if (TryReadReferencedTextValues(contextSheet, reference?.Formula?.Text, nameBudget, out IReadOnlyList<string>? referencedValues) && referencedValues != null && referencedValues.Count > 0) {
                 name = referencedValues[0];
                 return true;
             }
 
-            if (TryReadCachedStringValues(reference, pointBudget, out IReadOnlyList<string>? cachedValues) && cachedValues != null && cachedValues.Count > 0) {
+            nameBudget = new ChartDataPointBudget(1L);
+            if (TryReadCachedStringValues(reference, nameBudget, out IReadOnlyList<string>? cachedValues) && cachedValues != null && cachedValues.Count > 0) {
                 name = cachedValues[0];
                 return true;
             }
 
             StringLiteral? literal = seriesText?.GetFirstChild<StringLiteral>();
-            if (TryReadFirstStringLiteralValue(literal, pointBudget, out string? literalText) &&
+            nameBudget = new ChartDataPointBudget(1L);
+            if (TryReadFirstStringLiteralValue(literal, nameBudget, out string? literalText) &&
                 !string.IsNullOrWhiteSpace(literalText)) {
                 name = literalText;
                 return true;

--- a/OfficeIMO.Excel/ExcelChartUtils.Update.Range.cs
+++ b/OfficeIMO.Excel/ExcelChartUtils.Update.Range.cs
@@ -11,6 +11,18 @@ namespace OfficeIMO.Excel {
     internal static partial class ExcelChartUtils {
         private const int MaxChartDataPoints = 1_000_000;
 
+        private sealed class ChartDataPointBudget {
+            private long _remaining = MaxChartDataPoints;
+
+            internal bool TryCharge(long count) {
+                if (count < 0 || count > _remaining) {
+                    return false;
+                }
+                _remaining -= count;
+                return true;
+            }
+        }
+
         internal static ExcelChartDataRange? TryExtractDataRange(ChartPart chartPart) {
             var chart = chartPart.ChartSpace?.GetFirstChild<Chart>();
             var plotArea = chart?.GetFirstChild<PlotArea>();
@@ -56,7 +68,8 @@ namespace OfficeIMO.Excel {
             int valueColumns = valC2 - valC1 + 1;
             bool horizontal = categoryRows == 1 && categoryColumns > 1 && valueRows == 1 && valueColumns == categoryColumns && valC1 == c1 && valC2 == c2;
             int categoryCount = horizontal ? categoryColumns : categoryRows;
-            if (categoryCount <= 0 || (long)categoryCount * seriesList.Count > MaxChartDataPoints) return null;
+            if (categoryCount <= 0 ||
+                (long)categoryCount + ((long)categoryCount * seriesList.Count) > MaxChartDataPoints) return null;
 
             if (horizontal) {
                 if (valR1 != r1 + 1 || !HorizontalSeriesRangesAreContiguous(seriesList, sheetName, valR1, c1, c2)) {
@@ -262,7 +275,7 @@ namespace OfficeIMO.Excel {
         internal static ExcelChartData? TryReadChartData(ExcelSheet sheet, ExcelChartDataRange range) {
             try {
                 if (range.CategoryCount <= 0 || range.SeriesCount <= 0 ||
-                    (long)range.CategoryCount * range.SeriesCount > MaxChartDataPoints) return null;
+                    (long)range.CategoryCount + ((long)range.CategoryCount * range.SeriesCount) > MaxChartDataPoints) return null;
                 var categories = new List<string>(range.CategoryCount);
                 for (int i = 0; i < range.CategoryCount; i++) {
                     int row = range.Orientation == ExcelChartDataOrientation.Vertical ? range.CategoryStartRow + i : range.CategoryStartRow;
@@ -318,7 +331,8 @@ namespace OfficeIMO.Excel {
                     return null;
                 }
 
-                if (!TryReadCategoryValues(seriesList[0], contextSheet, out IReadOnlyList<string>? categories) || categories == null || categories.Count == 0) {
+                var pointBudget = new ChartDataPointBudget();
+                if (!TryReadCategoryValues(seriesList[0], contextSheet, pointBudget, out IReadOnlyList<string>? categories) || categories == null || categories.Count == 0) {
                     return null;
                 }
 
@@ -326,21 +340,21 @@ namespace OfficeIMO.Excel {
                 for (int i = 0; i < seriesList.Count; i++) {
                     OpenXmlCompositeElement seriesElement = seriesList[i];
                     NumberReference? valuesReference = GetSeriesValuesReference(seriesElement);
-                    string name = TryReadSeriesName(seriesElement, contextSheet, out string? resolvedName) && !string.IsNullOrWhiteSpace(resolvedName)
+                    string name = TryReadSeriesName(seriesElement, contextSheet, pointBudget, out string? resolvedName) && !string.IsNullOrWhiteSpace(resolvedName)
                         ? resolvedName!
                         : $"Series {i + 1}";
                     IReadOnlyList<double>? xValues = null;
                     if (seriesElement is ScatterChartSeries scatterSeries) {
                         NumberReference? xReference = scatterSeries.GetFirstChild<XValues>()?.GetFirstChild<NumberReference>();
                         NumberLiteral? xLiteral = scatterSeries.GetFirstChild<XValues>()?.GetFirstChild<NumberLiteral>();
-                        if (!TryReadNumberLiteralValues(xLiteral, out xValues) &&
-                            !TryReadReferencedNumberValues(contextSheet, xReference?.Formula?.Text, out xValues)) {
-                            TryReadCachedNumberValues(xReference, out xValues);
+                        if (!TryReadNumberLiteralValues(xLiteral, pointBudget, out xValues) &&
+                            !TryReadReferencedNumberValues(contextSheet, xReference?.Formula?.Text, pointBudget, out xValues)) {
+                            TryReadCachedNumberValues(xReference, pointBudget, out xValues);
                         }
                     }
 
-                    TryReadReferencedNumberValues(contextSheet, valuesReference?.Formula?.Text, out IReadOnlyList<double>? referencedValues);
-                    TryReadCachedNumberValues(valuesReference, out IReadOnlyList<double>? cachedValues);
+                    TryReadReferencedNumberValues(contextSheet, valuesReference?.Formula?.Text, pointBudget, out IReadOnlyList<double>? referencedValues);
+                    TryReadCachedNumberValues(valuesReference, pointBudget, out IReadOnlyList<double>? cachedValues);
                     IReadOnlyList<double>? values = referencedValues;
                     if (xValues != null &&
                         referencedValues != null &&
@@ -373,14 +387,14 @@ namespace OfficeIMO.Excel {
             }
         }
 
-        private static bool TryReadCategoryValues(OpenXmlCompositeElement seriesElement, ExcelSheet contextSheet, out IReadOnlyList<string>? categories) {
+        private static bool TryReadCategoryValues(OpenXmlCompositeElement seriesElement, ExcelSheet contextSheet, ChartDataPointBudget pointBudget, out IReadOnlyList<string>? categories) {
             categories = null;
             if (seriesElement is ScatterChartSeries scatterSeries) {
                 NumberReference? xReference = scatterSeries.GetFirstChild<XValues>()?.GetFirstChild<NumberReference>();
                 NumberLiteral? xLiteral = scatterSeries.GetFirstChild<XValues>()?.GetFirstChild<NumberLiteral>();
-                if (!TryReadNumberLiteralValues(xLiteral, out IReadOnlyList<double>? numericValues) &&
-                    !TryReadReferencedNumberValues(contextSheet, xReference?.Formula?.Text, out numericValues)) {
-                    TryReadCachedNumberValues(xReference, out numericValues);
+                if (!TryReadNumberLiteralValues(xLiteral, pointBudget, out IReadOnlyList<double>? numericValues) &&
+                    !TryReadReferencedNumberValues(contextSheet, xReference?.Formula?.Text, pointBudget, out numericValues)) {
+                    TryReadCachedNumberValues(xReference, pointBudget, out numericValues);
                 }
 
                 if (numericValues == null) {
@@ -393,17 +407,17 @@ namespace OfficeIMO.Excel {
 
             CategoryAxisData? categoryAxisData = seriesElement.GetFirstChild<CategoryAxisData>();
             StringReference? stringReference = categoryAxisData?.GetFirstChild<StringReference>();
-            if (TryReadReferencedTextValues(contextSheet, stringReference?.Formula?.Text, out categories)) {
+            if (TryReadReferencedTextValues(contextSheet, stringReference?.Formula?.Text, pointBudget, out categories)) {
                 return true;
             }
 
-            if (TryReadCachedStringValues(stringReference, out categories)) {
+            if (TryReadCachedStringValues(stringReference, pointBudget, out categories)) {
                 return true;
             }
 
             NumberReference? numberReference = categoryAxisData?.GetFirstChild<NumberReference>();
-            if (!TryReadReferencedNumberValues(contextSheet, numberReference?.Formula?.Text, out IReadOnlyList<double>? numberValues)) {
-                TryReadCachedNumberValues(numberReference, out numberValues);
+            if (!TryReadReferencedNumberValues(contextSheet, numberReference?.Formula?.Text, pointBudget, out IReadOnlyList<double>? numberValues)) {
+                TryReadCachedNumberValues(numberReference, pointBudget, out numberValues);
             }
 
             if (numberValues == null) {
@@ -414,27 +428,23 @@ namespace OfficeIMO.Excel {
             return categories.Count > 0;
         }
 
-        private static bool TryReadSeriesName(OpenXmlCompositeElement seriesElement, ExcelSheet contextSheet, out string? name) {
+        private static bool TryReadSeriesName(OpenXmlCompositeElement seriesElement, ExcelSheet contextSheet, ChartDataPointBudget pointBudget, out string? name) {
             name = null;
             SeriesText? seriesText = seriesElement.GetFirstChild<SeriesText>();
             StringReference? reference = seriesText?.GetFirstChild<StringReference>();
-            if (TryReadReferencedTextValues(contextSheet, reference?.Formula?.Text, out IReadOnlyList<string>? referencedValues) && referencedValues != null && referencedValues.Count > 0) {
+            if (TryReadReferencedTextValues(contextSheet, reference?.Formula?.Text, pointBudget, out IReadOnlyList<string>? referencedValues) && referencedValues != null && referencedValues.Count > 0) {
                 name = referencedValues[0];
                 return true;
             }
 
-            if (TryReadCachedStringValues(reference, out IReadOnlyList<string>? cachedValues) && cachedValues != null && cachedValues.Count > 0) {
+            if (TryReadCachedStringValues(reference, pointBudget, out IReadOnlyList<string>? cachedValues) && cachedValues != null && cachedValues.Count > 0) {
                 name = cachedValues[0];
                 return true;
             }
 
             StringLiteral? literal = seriesText?.GetFirstChild<StringLiteral>();
-            string? literalText = literal?.Elements<StringPoint>()
-                .OrderBy(point => point.Index?.Value ?? uint.MaxValue)
-                .FirstOrDefault()?
-                .NumericValue?
-                .Text;
-            if (!string.IsNullOrWhiteSpace(literalText)) {
+            if (TryReadFirstStringLiteralValue(literal, pointBudget, out string? literalText) &&
+                !string.IsNullOrWhiteSpace(literalText)) {
                 name = literalText;
                 return true;
             }
@@ -446,6 +456,34 @@ namespace OfficeIMO.Excel {
             }
 
             return false;
+        }
+
+        private static bool TryReadFirstStringLiteralValue(
+            StringLiteral? literal,
+            ChartDataPointBudget pointBudget,
+            out string? value) {
+            value = null;
+            uint selectedIndex = uint.MaxValue;
+            bool selected = false;
+            if (literal == null) {
+                return false;
+            }
+
+            foreach (StringPoint point in literal.Elements<StringPoint>()) {
+                if (!pointBudget.TryCharge(1)) {
+                    value = null;
+                    return false;
+                }
+
+                uint index = point.Index?.Value ?? uint.MaxValue;
+                if (!selected || index < selectedIndex) {
+                    selected = true;
+                    selectedIndex = index;
+                    value = point.NumericValue?.Text;
+                }
+            }
+
+            return selected;
         }
 
         internal static ExcelChartData ApplyChartSeriesTypes(ChartPart chartPart, ExcelChartData data, ExcelChartType defaultType) {
@@ -513,6 +551,17 @@ namespace OfficeIMO.Excel {
                 return data;
             }
 
+            var pointBudget = new ChartDataPointBudget();
+            if (!pointBudget.TryCharge(data.Categories.Count)) {
+                return data;
+            }
+            foreach (ExcelChartSeries existingSeries in data.Series) {
+                if (!pointBudget.TryCharge(existingSeries.Values.Count) ||
+                    (existingSeries.XValues != null && !pointBudget.TryCharge(existingSeries.XValues.Count))) {
+                    return data;
+                }
+            }
+
             var scatterValuesByIndex = new Dictionary<int, (IReadOnlyList<double>? XValues, IReadOnlyList<double>? YValues)>();
             int seriesOrder = 0;
             foreach (OpenXmlElement seriesElement in GetChartSeries(plotArea)) {
@@ -528,13 +577,13 @@ namespace OfficeIMO.Excel {
                 NumberReference? xReference = scatterSeries.GetFirstChild<XValues>()?.GetFirstChild<NumberReference>();
                 NumberReference? yReference = scatterSeries.GetFirstChild<YValues>()?.GetFirstChild<NumberReference>();
                 NumberLiteral? xLiteral = scatterSeries.GetFirstChild<XValues>()?.GetFirstChild<NumberLiteral>();
-                if (!TryReadNumberLiteralValues(xLiteral, out IReadOnlyList<double>? xValues) &&
-                    !TryReadReferencedNumberValues(contextSheet, xReference?.Formula?.Text, out xValues)) {
-                    TryReadCachedNumberValues(xReference, out xValues);
+                if (!TryReadNumberLiteralValues(xLiteral, pointBudget, out IReadOnlyList<double>? xValues) &&
+                    !TryReadReferencedNumberValues(contextSheet, xReference?.Formula?.Text, pointBudget, out xValues)) {
+                    TryReadCachedNumberValues(xReference, pointBudget, out xValues);
                 }
 
-                TryReadReferencedNumberValues(contextSheet, yReference?.Formula?.Text, out IReadOnlyList<double>? referencedYValues);
-                TryReadCachedNumberValues(yReference, out IReadOnlyList<double>? cachedYValues);
+                TryReadReferencedNumberValues(contextSheet, yReference?.Formula?.Text, pointBudget, out IReadOnlyList<double>? referencedYValues);
+                TryReadCachedNumberValues(yReference, pointBudget, out IReadOnlyList<double>? cachedYValues);
                 IReadOnlyList<double>? yValues = referencedYValues;
                 if (xValues != null &&
                     referencedYValues != null &&
@@ -569,25 +618,30 @@ namespace OfficeIMO.Excel {
             return new ExcelChartData(data.Categories, series);
         }
 
-        private static bool TryReadCachedNumberValues(NumberReference? reference, out IReadOnlyList<double>? values) {
+        private static bool TryReadCachedNumberValues(NumberReference? reference, ChartDataPointBudget pointBudget, out IReadOnlyList<double>? values) {
             values = null;
             NumberingCache? cache = reference?.GetFirstChild<NumberingCache>();
-            return TryReadNumberPoints(cache, out values);
+            return TryReadNumberPoints(cache, pointBudget, out values);
         }
 
-        private static bool TryReadNumberLiteralValues(NumberLiteral? literal, out IReadOnlyList<double>? values) {
-            return TryReadNumberPoints(literal, out values);
+        private static bool TryReadNumberLiteralValues(NumberLiteral? literal, ChartDataPointBudget pointBudget, out IReadOnlyList<double>? values) {
+            return TryReadNumberPoints(literal, pointBudget, out values);
         }
 
-        private static bool TryReadNumberPoints(OpenXmlCompositeElement? container, out IReadOnlyList<double>? values) {
+        private static bool TryReadNumberPoints(OpenXmlCompositeElement? container, ChartDataPointBudget pointBudget, out IReadOnlyList<double>? values) {
             values = null;
             if (container == null) {
                 return false;
             }
 
             uint? pointCount = container.GetFirstChild<PointCount>()?.Val?.Value;
+            int actualPointCount = container.Elements<NumericPoint>().Take(MaxChartDataPoints + 1).Count();
+            if (actualPointCount > MaxChartDataPoints) {
+                return false;
+            }
             if (pointCount.HasValue) {
-                if (pointCount.Value > MaxChartDataPoints) {
+                long chargedPoints = Math.Max((long)pointCount.Value, actualPointCount);
+                if (pointCount.Value > MaxChartDataPoints || !pointBudget.TryCharge(chargedPoints)) {
                     return false;
                 }
 
@@ -613,9 +667,11 @@ namespace OfficeIMO.Excel {
                 return hasValues;
             }
 
-            var numericValues = new List<double>();
+            if (!pointBudget.TryCharge(actualPointCount)) {
+                return false;
+            }
+            var numericValues = new List<double>(actualPointCount);
             foreach (NumericPoint point in container.Elements<NumericPoint>().OrderBy(point => point.Index?.Value ?? uint.MaxValue)) {
-                if (numericValues.Count >= MaxChartDataPoints) return false;
                 string? text = point.NumericValue?.Text;
                 if (!double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out double value)) {
                     return false;
@@ -628,28 +684,28 @@ namespace OfficeIMO.Excel {
             return numericValues.Count > 0;
         }
 
-        private static bool TryReadCachedStringValues(StringReference? reference, out IReadOnlyList<string>? values) {
+        private static bool TryReadCachedStringValues(StringReference? reference, ChartDataPointBudget pointBudget, out IReadOnlyList<string>? values) {
             values = null;
             StringCache? cache = reference?.GetFirstChild<StringCache>();
             if (cache == null) {
                 return false;
             }
 
+            int actualPointCount = cache.Elements<StringPoint>().Take(MaxChartDataPoints + 1).Count();
+            if (actualPointCount > MaxChartDataPoints || !pointBudget.TryCharge(actualPointCount)) return false;
             string[] cachedValues = cache.Elements<StringPoint>()
                 .OrderBy(point => point.Index?.Value ?? uint.MaxValue)
                 .Select(point => point.NumericValue?.Text ?? string.Empty)
-                .Take(MaxChartDataPoints + 1)
                 .ToArray();
-            if (cachedValues.Length > MaxChartDataPoints) return false;
             values = cachedValues;
             return values.Count > 0;
         }
 
-        private static bool TryReadReferencedTextValues(ExcelSheet contextSheet, string? formula, out IReadOnlyList<string>? values) {
+        private static bool TryReadReferencedTextValues(ExcelSheet contextSheet, string? formula, ChartDataPointBudget pointBudget, out IReadOnlyList<string>? values) {
             values = null;
             if (!TryParseSheetQualifiedRange(formula, out string sheetName, out string range) ||
                 !TryParseRange(range, out int r1, out int c1, out int r2, out int c2) ||
-                (long)(r2 - r1 + 1) * (c2 - c1 + 1) > MaxChartDataPoints) {
+                !pointBudget.TryCharge((long)(r2 - r1 + 1) * (c2 - c1 + 1))) {
                 return false;
             }
 
@@ -671,11 +727,11 @@ namespace OfficeIMO.Excel {
             return textValues.Count > 0;
         }
 
-        private static bool TryReadReferencedNumberValues(ExcelSheet contextSheet, string? formula, out IReadOnlyList<double>? values) {
+        private static bool TryReadReferencedNumberValues(ExcelSheet contextSheet, string? formula, ChartDataPointBudget pointBudget, out IReadOnlyList<double>? values) {
             values = null;
             if (!TryParseSheetQualifiedRange(formula, out string sheetName, out string range) ||
                 !TryParseRange(range, out int r1, out int c1, out int r2, out int c2) ||
-                (long)(r2 - r1 + 1) * (c2 - c1 + 1) > MaxChartDataPoints) {
+                !pointBudget.TryCharge((long)(r2 - r1 + 1) * (c2 - c1 + 1))) {
                 return false;
             }
 

--- a/OfficeIMO.Excel/ExcelFeatureReport.PdfPreflight.cs
+++ b/OfficeIMO.Excel/ExcelFeatureReport.PdfPreflight.cs
@@ -335,11 +335,6 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            if (image.WidthPixels <= 0 || image.HeightPixels <= 0) {
-                reason = "image has non-positive dimensions.";
-                return false;
-            }
-
             byte[] bytes = image.ToBytes();
             if (bytes.Length == 0) {
                 reason = "image has empty bytes.";
@@ -348,6 +343,11 @@ namespace OfficeIMO.Excel {
 
             if (!OfficeImagePdfCompatibility.TryValidate(bytes, out OfficeImageInfo? imageInfo, out string? unsupportedReason)) {
                 reason = unsupportedReason ?? "image bytes are not supported by the first-party PDF image writer.";
+                return false;
+            }
+
+            if (image.WidthPixels <= 0 || image.HeightPixels <= 0) {
+                reason = "image has non-positive dimensions.";
                 return false;
             }
 

--- a/OfficeIMO.Excel/ExcelImageExportDiagnosticCodes.cs
+++ b/OfficeIMO.Excel/ExcelImageExportDiagnosticCodes.cs
@@ -36,6 +36,9 @@ public static class ExcelImageExportDiagnosticCodes {
     /// <summary>Unsupported conditional formatting rule type.</summary>
     public const string ConditionalRuleUnsupported = "ExcelConditionalRuleUnsupported";
 
+    /// <summary>A conditional formatting rule was omitted because its reference exceeds the bounded evaluation limit.</summary>
+    public const string ConditionalReferenceLimitExceeded = "ExcelConditionalReferenceLimitExceeded";
+
     /// <summary>Unsupported conditional formatting icon set.</summary>
     public const string ConditionalIconSetUnsupported = "ExcelConditionalIconSetUnsupported";
 

--- a/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.IconSets.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.IconSets.cs
@@ -7,7 +7,7 @@ namespace OfficeIMO.Excel {
             ExcelSheet sheet,
             IReadOnlyList<ExcelVisualCell> cells,
             IReadOnlyList<ExcelConditionalFormattingInfo> rules,
-            DateTime conditionalFormattingDate,
+            IReadOnlyDictionary<int, HashSet<string>> stoppedCellsByPriority,
             List<OfficeImageExportDiagnostic> diagnostics) {
             var icons = new List<ExcelVisualConditionalIcon>();
             foreach (ExcelConditionalFormattingInfo rule in rules
@@ -17,7 +17,9 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                HashSet<string> stoppedCells = BuildStoppedCellsBeforePriority(sheet, cells, rules, rule, conditionalFormattingDate);
+                HashSet<string> stoppedCells = stoppedCellsByPriority.TryGetValue(NormalizePriority(rule.Priority), out HashSet<string>? stopped)
+                    ? stopped
+                    : EmptyStoppedCells;
                 List<ConditionalNumericCell> candidates = GetNumericCandidates(sheet, cells, rule.Range)
                     .Where(candidate => !stoppedCells.Contains(Key(candidate.Cell.Row, candidate.Cell.Column)))
                     .ToList();

--- a/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.IconSets.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.IconSets.cs
@@ -7,7 +7,7 @@ namespace OfficeIMO.Excel {
             ExcelSheet sheet,
             IReadOnlyList<ExcelVisualCell> cells,
             IReadOnlyList<ExcelConditionalFormattingInfo> rules,
-            IReadOnlyDictionary<int, HashSet<string>> stoppedCellsByPriority,
+            IReadOnlyDictionary<string, int> firstStoppingPriorityByCell,
             List<OfficeImageExportDiagnostic> diagnostics) {
             var icons = new List<ExcelVisualConditionalIcon>();
             foreach (ExcelConditionalFormattingInfo rule in rules
@@ -17,11 +17,10 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                HashSet<string> stoppedCells = stoppedCellsByPriority.TryGetValue(NormalizePriority(rule.Priority), out HashSet<string>? stopped)
-                    ? stopped
-                    : EmptyStoppedCells;
+                int priority = NormalizePriority(rule.Priority);
                 List<ConditionalNumericCell> candidates = GetNumericCandidates(sheet, cells, rule.Range)
-                    .Where(candidate => !stoppedCells.Contains(Key(candidate.Cell.Row, candidate.Cell.Column)))
+                    .Where(candidate => !WasStoppedBeforePriority(firstStoppingPriorityByCell,
+                        Key(candidate.Cell.Row, candidate.Cell.Column), priority))
                     .ToList();
                 if (candidates.Count == 0) {
                     diagnostics.Add(ExcelImageExportDiagnosticClassifier.Create(

--- a/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.cs
@@ -16,6 +16,11 @@ namespace OfficeIMO.Excel {
                 return ExcelConditionalVisualState.Empty;
             }
 
+            rules = ExcludeOversizedConditionalRules(sheet, rules, diagnostics);
+            if (rules.Count == 0) {
+                return ExcelConditionalVisualState.Empty;
+            }
+
             ReportUnsupportedConditionalRules(sheet, cells, rules, conditionalFormattingDate, diagnostics);
 
             IReadOnlyDictionary<string, int> firstStoppingPriorityByCell =
@@ -27,6 +32,29 @@ namespace OfficeIMO.Excel {
             return cellFormats.Count == 0 && dataBars.Count == 0 && icons.Count == 0
                 ? ExcelConditionalVisualState.Empty
                 : new ExcelConditionalVisualState(cellFormats, dataBars, icons);
+        }
+
+        private static IReadOnlyList<ExcelConditionalFormattingInfo> ExcludeOversizedConditionalRules(
+            ExcelSheet sheet,
+            IReadOnlyList<ExcelConditionalFormattingInfo> rules,
+            List<OfficeImageExportDiagnostic> diagnostics) {
+            var retained = new List<ExcelConditionalFormattingInfo>(rules.Count);
+            foreach (ExcelConditionalFormattingInfo rule in rules) {
+                if (!EnumerateReferenceCells(rule.Range, MaxConditionalReferenceCells + 1)
+                    .Skip(MaxConditionalReferenceCells)
+                    .Any()) {
+                    retained.Add(rule);
+                    continue;
+                }
+
+                diagnostics.Add(ExcelImageExportDiagnosticClassifier.Create(
+                    OfficeImageExportDiagnosticSeverity.Warning,
+                    ExcelImageExportDiagnosticCodes.ConditionalReferenceLimitExceeded,
+                    $"Conditional formatting rule was omitted because its reference exceeds the {MaxConditionalReferenceCells.ToString(CultureInfo.InvariantCulture)}-cell image-export limit.",
+                    sheet.Name + "!" + rule.Range));
+            }
+
+            return retained;
         }
 
         private static List<ExcelVisualConditionalDataBar> BuildConditionalDataBars(
@@ -887,7 +915,9 @@ namespace OfficeIMO.Excel {
             return false;
         }
 
-        private static IEnumerable<(int Row, int Column)> EnumerateReferenceCells(string referenceList) {
+        private static IEnumerable<(int Row, int Column)> EnumerateReferenceCells(
+            string referenceList,
+            int maximumCells = MaxConditionalReferenceCells) {
             if (string.IsNullOrWhiteSpace(referenceList)) {
                 yield break;
             }
@@ -895,12 +925,12 @@ namespace OfficeIMO.Excel {
             var seen = new HashSet<string>(StringComparer.Ordinal);
             int emitted = 0;
             foreach (string rawToken in referenceList.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)) {
-                if (emitted >= MaxConditionalReferenceCells) yield break;
+                if (emitted >= maximumCells) yield break;
                 string token = StripSheetPrefix(rawToken).Replace("$", string.Empty);
                 if (A1.TryParseRange(token, out int firstRow, out int firstColumn, out int lastRow, out int lastColumn)) {
                     for (int row = firstRow; row <= lastRow; row++) {
                         for (int column = firstColumn; column <= lastColumn; column++) {
-                            if (emitted >= MaxConditionalReferenceCells) yield break;
+                            if (emitted >= maximumCells) yield break;
                             if (seen.Add(Key(row, column))) {
                                 emitted++;
                                 yield return (row, column);

--- a/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.cs
@@ -3,6 +3,8 @@ using OfficeIMO.Drawing;
 
 namespace OfficeIMO.Excel {
     internal static partial class ExcelConditionalVisualEvaluator {
+        private const int MaxConditionalReferenceCells = 100_000;
+
         internal static ExcelConditionalVisualState Evaluate(
             ExcelSheet sheet,
             IReadOnlyList<ExcelVisualCell> cells,
@@ -16,10 +18,12 @@ namespace OfficeIMO.Excel {
 
             ReportUnsupportedConditionalRules(sheet, cells, rules, conditionalFormattingDate, diagnostics);
 
+            IReadOnlyDictionary<int, HashSet<string>> stoppedCellsByPriority =
+                BuildStoppedCellsByPriority(sheet, cells, rules, conditionalFormattingDate);
             var stoppedCells = new HashSet<string>(StringComparer.Ordinal);
             var cellFormats = BuildConditionalCellFormats(sheet, cells, rules, conditionalFormattingDate, stoppedCells);
-            var dataBars = BuildConditionalDataBars(sheet, cells, rules, conditionalFormattingDate);
-            var icons = BuildConditionalIcons(sheet, cells, rules, conditionalFormattingDate, diagnostics);
+            var dataBars = BuildConditionalDataBars(sheet, cells, rules, stoppedCellsByPriority);
+            var icons = BuildConditionalIcons(sheet, cells, rules, stoppedCellsByPriority, diagnostics);
             return cellFormats.Count == 0 && dataBars.Count == 0 && icons.Count == 0
                 ? ExcelConditionalVisualState.Empty
                 : new ExcelConditionalVisualState(cellFormats, dataBars, icons);
@@ -29,7 +33,7 @@ namespace OfficeIMO.Excel {
             ExcelSheet sheet,
             IReadOnlyList<ExcelVisualCell> cells,
             IReadOnlyList<ExcelConditionalFormattingInfo> rules,
-            DateTime conditionalFormattingDate) {
+            IReadOnlyDictionary<int, HashSet<string>> stoppedCellsByPriority) {
             var dataBars = new List<ExcelVisualConditionalDataBar>();
             foreach (ExcelConditionalFormattingInfo rule in rules
                 .Where(rule => string.Equals(rule.Type, "DataBar", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrWhiteSpace(rule.DataBarColor))
@@ -38,7 +42,9 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                HashSet<string> stoppedCells = BuildStoppedCellsBeforePriority(sheet, cells, rules, rule, conditionalFormattingDate);
+                HashSet<string> stoppedCells = stoppedCellsByPriority.TryGetValue(NormalizePriority(rule.Priority), out HashSet<string>? stopped)
+                    ? stopped
+                    : EmptyStoppedCells;
                 List<ConditionalNumericCell> candidates = GetNumericCandidates(sheet, cells, rule.Range)
                     .Where(candidate => !stoppedCells.Contains(Key(candidate.Cell.Row, candidate.Cell.Column)))
                     .ToList();
@@ -71,23 +77,25 @@ namespace OfficeIMO.Excel {
             return dataBars;
         }
 
-        private static HashSet<string> BuildStoppedCellsBeforePriority(
+        private static readonly HashSet<string> EmptyStoppedCells = new HashSet<string>(StringComparer.Ordinal);
+
+        private static IReadOnlyDictionary<int, HashSet<string>> BuildStoppedCellsByPriority(
             ExcelSheet sheet,
             IReadOnlyList<ExcelVisualCell> cells,
             IReadOnlyList<ExcelConditionalFormattingInfo> rules,
-            ExcelConditionalFormattingInfo currentRule,
             DateTime conditionalFormattingDate) {
-            int currentPriority = NormalizePriority(currentRule.Priority);
-            ExcelConditionalFormattingInfo[] higherPriorityStopRules = rules
-                .Where(rule => rule.StopIfTrue && NormalizePriority(rule.Priority) < currentPriority)
-                .OrderBy(rule => NormalizePriority(rule.Priority))
-                .ToArray();
             var stoppedCells = new HashSet<string>(StringComparer.Ordinal);
-            if (higherPriorityStopRules.Length > 0) {
-                _ = BuildConditionalCellFormats(sheet, cells, higherPriorityStopRules, conditionalFormattingDate, stoppedCells);
+            var result = new Dictionary<int, HashSet<string>>();
+            foreach (IGrouping<int, ExcelConditionalFormattingInfo> priorityGroup in rules
+                .OrderBy(rule => NormalizePriority(rule.Priority))
+                .GroupBy(rule => NormalizePriority(rule.Priority))) {
+                result[priorityGroup.Key] = new HashSet<string>(stoppedCells, StringComparer.Ordinal);
+                ExcelConditionalFormattingInfo[] stopRules = priorityGroup.Where(rule => rule.StopIfTrue).ToArray();
+                if (stopRules.Length > 0) {
+                    _ = BuildConditionalCellFormats(sheet, cells, stopRules, conditionalFormattingDate, stoppedCells);
+                }
             }
-
-            return stoppedCells;
+            return result;
         }
 
         private static void ReportUnsupportedConditionalRules(
@@ -874,12 +882,15 @@ namespace OfficeIMO.Excel {
             }
 
             var seen = new HashSet<string>(StringComparer.Ordinal);
+            int emitted = 0;
             foreach (string rawToken in referenceList.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)) {
                 string token = StripSheetPrefix(rawToken).Replace("$", string.Empty);
                 if (A1.TryParseRange(token, out int firstRow, out int firstColumn, out int lastRow, out int lastColumn)) {
                     for (int row = firstRow; row <= lastRow; row++) {
                         for (int column = firstColumn; column <= lastColumn; column++) {
                             if (seen.Add(Key(row, column))) {
+                                if (emitted >= MaxConditionalReferenceCells) yield break;
+                                emitted++;
                                 yield return (row, column);
                             }
                         }
@@ -890,6 +901,8 @@ namespace OfficeIMO.Excel {
 
                 if (A1.TryParseCellReferenceFast(token, out int singleRow, out int singleColumn) &&
                     seen.Add(Key(singleRow, singleColumn))) {
+                    if (emitted >= MaxConditionalReferenceCells) yield break;
+                    emitted++;
                     yield return (singleRow, singleColumn);
                 }
             }

--- a/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.cs
@@ -18,12 +18,12 @@ namespace OfficeIMO.Excel {
 
             ReportUnsupportedConditionalRules(sheet, cells, rules, conditionalFormattingDate, diagnostics);
 
-            IReadOnlyDictionary<int, HashSet<string>> stoppedCellsByPriority =
-                BuildStoppedCellsByPriority(sheet, cells, rules, conditionalFormattingDate);
+            IReadOnlyDictionary<string, int> firstStoppingPriorityByCell =
+                BuildFirstStoppingPriorityByCell(sheet, cells, rules, conditionalFormattingDate);
             var stoppedCells = new HashSet<string>(StringComparer.Ordinal);
             var cellFormats = BuildConditionalCellFormats(sheet, cells, rules, conditionalFormattingDate, stoppedCells);
-            var dataBars = BuildConditionalDataBars(sheet, cells, rules, stoppedCellsByPriority);
-            var icons = BuildConditionalIcons(sheet, cells, rules, stoppedCellsByPriority, diagnostics);
+            var dataBars = BuildConditionalDataBars(sheet, cells, rules, firstStoppingPriorityByCell);
+            var icons = BuildConditionalIcons(sheet, cells, rules, firstStoppingPriorityByCell, diagnostics);
             return cellFormats.Count == 0 && dataBars.Count == 0 && icons.Count == 0
                 ? ExcelConditionalVisualState.Empty
                 : new ExcelConditionalVisualState(cellFormats, dataBars, icons);
@@ -33,7 +33,7 @@ namespace OfficeIMO.Excel {
             ExcelSheet sheet,
             IReadOnlyList<ExcelVisualCell> cells,
             IReadOnlyList<ExcelConditionalFormattingInfo> rules,
-            IReadOnlyDictionary<int, HashSet<string>> stoppedCellsByPriority) {
+            IReadOnlyDictionary<string, int> firstStoppingPriorityByCell) {
             var dataBars = new List<ExcelVisualConditionalDataBar>();
             foreach (ExcelConditionalFormattingInfo rule in rules
                 .Where(rule => string.Equals(rule.Type, "DataBar", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrWhiteSpace(rule.DataBarColor))
@@ -42,11 +42,10 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                HashSet<string> stoppedCells = stoppedCellsByPriority.TryGetValue(NormalizePriority(rule.Priority), out HashSet<string>? stopped)
-                    ? stopped
-                    : EmptyStoppedCells;
+                int priority = NormalizePriority(rule.Priority);
                 List<ConditionalNumericCell> candidates = GetNumericCandidates(sheet, cells, rule.Range)
-                    .Where(candidate => !stoppedCells.Contains(Key(candidate.Cell.Row, candidate.Cell.Column)))
+                    .Where(candidate => !WasStoppedBeforePriority(firstStoppingPriorityByCell,
+                        Key(candidate.Cell.Row, candidate.Cell.Column), priority))
                     .ToList();
                 if (candidates.Count == 0) {
                     continue;
@@ -77,26 +76,38 @@ namespace OfficeIMO.Excel {
             return dataBars;
         }
 
-        private static readonly HashSet<string> EmptyStoppedCells = new HashSet<string>(StringComparer.Ordinal);
-
-        private static IReadOnlyDictionary<int, HashSet<string>> BuildStoppedCellsByPriority(
+        private static IReadOnlyDictionary<string, int> BuildFirstStoppingPriorityByCell(
             ExcelSheet sheet,
             IReadOnlyList<ExcelVisualCell> cells,
             IReadOnlyList<ExcelConditionalFormattingInfo> rules,
             DateTime conditionalFormattingDate) {
             var stoppedCells = new HashSet<string>(StringComparer.Ordinal);
-            var result = new Dictionary<int, HashSet<string>>();
+            var result = new Dictionary<string, int>(StringComparer.Ordinal);
             foreach (IGrouping<int, ExcelConditionalFormattingInfo> priorityGroup in rules
                 .OrderBy(rule => NormalizePriority(rule.Priority))
                 .GroupBy(rule => NormalizePriority(rule.Priority))) {
-                result[priorityGroup.Key] = new HashSet<string>(stoppedCells, StringComparer.Ordinal);
-                ExcelConditionalFormattingInfo[] stopRules = priorityGroup.Where(rule => rule.StopIfTrue).ToArray();
-                if (stopRules.Length > 0) {
-                    _ = BuildConditionalCellFormats(sheet, cells, stopRules, conditionalFormattingDate, stoppedCells);
+                foreach (ExcelConditionalFormattingInfo stopRule in priorityGroup.Where(rule => rule.StopIfTrue)) {
+                    Dictionary<string, ExcelConditionalCellFormat> newlyStopped = BuildConditionalCellFormats(
+                        sheet,
+                        cells,
+                        new[] { stopRule },
+                        conditionalFormattingDate,
+                        stoppedCells);
+                    foreach (string key in newlyStopped.Keys) {
+                        if (!result.ContainsKey(key)) {
+                            result.Add(key, priorityGroup.Key);
+                        }
+                    }
                 }
             }
             return result;
         }
+
+        private static bool WasStoppedBeforePriority(
+            IReadOnlyDictionary<string, int> firstStoppingPriorityByCell,
+            string key,
+            int priority) =>
+            firstStoppingPriorityByCell.TryGetValue(key, out int stoppingPriority) && stoppingPriority < priority;
 
         private static void ReportUnsupportedConditionalRules(
             ExcelSheet sheet,
@@ -884,12 +895,13 @@ namespace OfficeIMO.Excel {
             var seen = new HashSet<string>(StringComparer.Ordinal);
             int emitted = 0;
             foreach (string rawToken in referenceList.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)) {
+                if (emitted >= MaxConditionalReferenceCells) yield break;
                 string token = StripSheetPrefix(rawToken).Replace("$", string.Empty);
                 if (A1.TryParseRange(token, out int firstRow, out int firstColumn, out int lastRow, out int lastColumn)) {
                     for (int row = firstRow; row <= lastRow; row++) {
                         for (int column = firstColumn; column <= lastColumn; column++) {
+                            if (emitted >= MaxConditionalReferenceCells) yield break;
                             if (seen.Add(Key(row, column))) {
-                                if (emitted >= MaxConditionalReferenceCells) yield break;
                                 emitted++;
                                 yield return (row, column);
                             }
@@ -901,7 +913,6 @@ namespace OfficeIMO.Excel {
 
                 if (A1.TryParseCellReferenceFast(token, out int singleRow, out int singleColumn) &&
                     seen.Add(Key(singleRow, singleColumn))) {
-                    if (emitted >= MaxConditionalReferenceCells) yield break;
                     emitted++;
                     yield return (singleRow, singleColumn);
                 }

--- a/OfficeIMO.Excel/Imaging/ExcelImageExportDiagnosticClassifier.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelImageExportDiagnosticClassifier.cs
@@ -70,6 +70,7 @@ namespace OfficeIMO.Excel {
                 case ExcelImageExportDiagnosticCodes.CellTextOccludedByDrawing:
                 case ExcelImageExportDiagnosticCodes.FillGradientUnsupported:
                 case ExcelImageExportDiagnosticCodes.ConditionalRuleUnsupported:
+                case ExcelImageExportDiagnosticCodes.ConditionalReferenceLimitExceeded:
                 case ExcelImageExportDiagnosticCodes.ConditionalIconSetUnsupported:
                 case ExcelImageExportDiagnosticCodes.ConditionalColorScaleUnsupported:
                 case ExcelImageExportDiagnosticCodes.ConditionalDataBarUnsupported:

--- a/OfficeIMO.Excel/Read/ExcelReadOptions.cs
+++ b/OfficeIMO.Excel/Read/ExcelReadOptions.cs
@@ -9,6 +9,18 @@ namespace OfficeIMO.Excel {
         private int _maxSharedStringItemCharacters = 32_767;
         private long _maxSharedStringCharacters = 64L * 1024L * 1024L;
 
+        /// <summary>Maximum columns exposed by one range data reader.</summary>
+        public int MaxDataReaderColumns { get; set; } = 16_384;
+
+        /// <summary>Maximum worksheet rows materialized in one data-reader chunk.</summary>
+        public int MaxDataReaderChunkRows { get; set; } = 8_192;
+
+        /// <summary>Maximum rows retained for data-reader schema inference.</summary>
+        public int MaxDataReaderSchemaSampleRows { get; set; } = 4_096;
+
+        /// <summary>Maximum cells materialized by a data-reader chunk or schema sample.</summary>
+        public long MaxDataReaderBufferedCells { get; set; } = 1_000_000L;
+
         /// <summary>
         /// Execution policy used to decide Sequential vs Parallel conversion.
         /// Reuses the writer-side policy for symmetry.

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.cs
@@ -32,8 +32,20 @@ namespace OfficeIMO.Excel {
             int schemaSampleRows = 1024,
             OfficeIMO.Excel.ExecutionMode? mode = null,
             CancellationToken ct = default) {
+            if (chunkRows <= 0 || chunkRows > _opt.MaxDataReaderChunkRows) {
+                throw new ArgumentOutOfRangeException(nameof(chunkRows),
+                    $"Chunk row count must be between 1 and {_opt.MaxDataReaderChunkRows}.");
+            }
             if (schemaSampleRows < 0) {
                 throw new ArgumentOutOfRangeException(nameof(schemaSampleRows), "Schema sample row count cannot be negative.");
+            }
+            if (schemaSampleRows > _opt.MaxDataReaderSchemaSampleRows) {
+                throw new ArgumentOutOfRangeException(nameof(schemaSampleRows),
+                    $"Schema sample row count exceeds {_opt.MaxDataReaderSchemaSampleRows}.");
+            }
+            if (_opt.MaxDataReaderColumns <= 0 || _opt.MaxDataReaderChunkRows <= 0 ||
+                _opt.MaxDataReaderSchemaSampleRows < 0 || _opt.MaxDataReaderBufferedCells <= 0L) {
+                throw new InvalidOperationException("Excel data-reader safety limits must be positive.");
             }
 
             var (r1, c1, r2, c2) = A1.ParseRange(a1Range);
@@ -43,6 +55,14 @@ namespace OfficeIMO.Excel {
 
             int cols = c2 - c1 + 1;
             int rows = r2 - r1 + 1;
+            if (cols > _opt.MaxDataReaderColumns) {
+                throw new InvalidDataException($"Range data-reader column count exceeds {nameof(ExcelReadOptions.MaxDataReaderColumns)}.");
+            }
+            long chunkCells = (long)Math.Min(rows, chunkRows) * cols;
+            long sampleCells = (long)Math.Min(Math.Max(0, rows - (headersInFirstRow ? 1 : 0)), schemaSampleRows) * cols;
+            if (chunkCells > _opt.MaxDataReaderBufferedCells || sampleCells > _opt.MaxDataReaderBufferedCells) {
+                throw new InvalidDataException($"Range data-reader buffering exceeds {nameof(ExcelReadOptions.MaxDataReaderBufferedCells)}.");
+            }
             if (schemaSampleRows == 0
                 && rows > BufferedRangeStreamRowLimit
                 && mode != OfficeIMO.Excel.ExecutionMode.Parallel

--- a/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.cs
+++ b/OfficeIMO.Excel/Read/ExcelSheetReader.Range.DataReader.cs
@@ -58,16 +58,24 @@ namespace OfficeIMO.Excel {
             if (cols > _opt.MaxDataReaderColumns) {
                 throw new InvalidDataException($"Range data-reader column count exceeds {nameof(ExcelReadOptions.MaxDataReaderColumns)}.");
             }
-            long chunkCells = (long)Math.Min(rows, chunkRows) * cols;
             long sampleCells = (long)Math.Min(Math.Max(0, rows - (headersInFirstRow ? 1 : 0)), schemaSampleRows) * cols;
-            if (chunkCells > _opt.MaxDataReaderBufferedCells || sampleCells > _opt.MaxDataReaderBufferedCells) {
+            if (sampleCells > _opt.MaxDataReaderBufferedCells) {
                 throw new InvalidDataException($"Range data-reader buffering exceeds {nameof(ExcelReadOptions.MaxDataReaderBufferedCells)}.");
             }
             if (schemaSampleRows == 0
                 && rows > BufferedRangeStreamRowLimit
                 && mode != OfficeIMO.Excel.ExecutionMode.Parallel
                 && CanUseRangeStreamXmlReader()) {
+                if (cols > _opt.MaxDataReaderBufferedCells) {
+                    throw new InvalidDataException($"Range data-reader buffering exceeds {nameof(ExcelReadOptions.MaxDataReaderBufferedCells)}.");
+                }
+
                 return new ExcelXmlRangeDataReader(this, r1, c1, r2, c2, cols, headersInFirstRow, _opt, ct);
+            }
+
+            long chunkCells = (long)Math.Min(rows, chunkRows) * cols;
+            if (chunkCells > _opt.MaxDataReaderBufferedCells) {
+                throw new InvalidDataException($"Range data-reader buffering exceeds {nameof(ExcelReadOptions.MaxDataReaderBufferedCells)}.");
             }
 
             IEnumerable<RangeChunk> chunks = ReadRangeStreamForDataReader(a1Range, chunkRows, mode, ct);

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.ExcelSemantics.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.ExcelSemantics.cs
@@ -58,4 +58,38 @@ public class HtmlOfficeAdaptersExcelSemantics {
         Assert.Contains(result.Report.Diagnostics, diagnostic => diagnostic.Code == HtmlConversionDiagnosticCodes.TargetLimitExceeded);
         Assert.Empty(Assert.Single(workbook.Sheets).GetMergedRanges());
     }
+
+    [Fact]
+    public void ExcelHtml_TwoCellImageFallsBackBeforeEnumeratingAnOversizedAnchor() {
+        const string png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAEAQH/69DjmQAAAABJRU5ErkJggg==";
+        string html = "<section class='officeimo-sheet' data-officeimo-sheet='Images'><table><tr><td>A</td></tr></table>"
+            + "<section class='officeimo-images'><ul><li data-officeimo-anchor='twoCell' data-officeimo-row='1' data-officeimo-column='1' "
+            + "data-officeimo-to-row='1048576' data-officeimo-to-column='16384'><span class='officeimo-feature-label'>Huge</span>"
+            + "<img src='data:image/png;base64," + png + "'></li></ul></section></section>";
+
+        HtmlToExcelResult result = HtmlConversionDocument.Parse(html).ToExcelDocumentResult(
+            new HtmlToExcelOptions { MaxTableCells = 4 });
+        using ExcelDocument workbook = result.Value;
+        ExcelImage image = Assert.Single(Assert.Single(workbook.Sheets).Images);
+
+        Assert.False(image.HasTwoCellAnchor);
+        Assert.Contains(result.Report.Diagnostics, diagnostic =>
+            diagnostic.Message.Contains("two-cell anchor", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void ExcelHtml_SvgIdNamespacingRewritesIdsAndReferencesInOnePass() {
+        System.Reflection.MethodInfo method = typeof(ExcelHtmlConverterExtensions).GetMethod(
+            "NamespaceSvgIds", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+        const string svg = "<svg><defs><linearGradient id=\"g\"/><clipPath id='c'/></defs><rect fill=\"url(#g)\" clip-path=\"url(#c)\"/><use href=\"#g\" xlink:href='#c'/></svg>";
+
+        string namespaced = (string)method.Invoke(null, new object[] { svg, "sheet-" })!;
+
+        Assert.Contains("id=\"sheet-g\"", namespaced, StringComparison.Ordinal);
+        Assert.Contains("id='sheet-c'", namespaced, StringComparison.Ordinal);
+        Assert.Contains("url(#sheet-g)", namespaced, StringComparison.Ordinal);
+        Assert.Contains("url(#sheet-c)", namespaced, StringComparison.Ordinal);
+        Assert.Contains("href=\"#sheet-g\"", namespaced, StringComparison.Ordinal);
+        Assert.Contains("xlink:href='#sheet-c'", namespaced, StringComparison.Ordinal);
+    }
 }

--- a/OfficeIMO.Html.Tests/Html.OfficeAdapters.PowerPointOrder.cs
+++ b/OfficeIMO.Html.Tests/Html.OfficeAdapters.PowerPointOrder.cs
@@ -68,4 +68,16 @@ public class HtmlOfficeAdaptersPowerPointOrder {
         Assert.Equal(230D, importedLastText.TopPoints, 3);
         Assert.Empty(result.Report.Diagnostics);
     }
+
+    [Fact]
+    public void PowerPointHtml_UsesTheLastStandaloneNotesMarkerAfterManyFalseCandidates() {
+        string falseCandidates = string.Join("\n", Enumerable.Repeat("prefix ### Notes suffix", 10_000));
+        string html = "<section class='officeimo-slide'><pre class='officeimo-source-markdown'>"
+            + falseCandidates + "\n### Notes\nBounded presenter notes</pre></section>";
+
+        HtmlToPowerPointResult result = HtmlConversionDocument.Parse(html).ToPowerPointPresentationResult();
+        using PowerPointPresentation presentation = result.Value;
+
+        Assert.Equal("Bounded presenter notes", Assert.Single(presentation.Slides).Notes.Text);
+    }
 }

--- a/OfficeIMO.Html.Tests/Html.Rendering.cs
+++ b/OfficeIMO.Html.Tests/Html.Rendering.cs
@@ -1107,6 +1107,21 @@ public sealed partial class HtmlRenderingTests {
     }
 
     [Fact]
+    public void HtmlRender_Paged_ChargesRepeatedMarginTextToTheLayoutBudgetBeforeAllocation() {
+        string html = "<style>@page { @top-left { content:\"" + new string('A', 500) + "\"; } }</style><p>Body</p>";
+        var options = new HtmlRenderOptions {
+            Mode = HtmlRenderMode.Paged,
+            MaxLayoutOperations = 100
+        };
+
+        HtmlDomLimitException exception = Assert.Throws<HtmlDomLimitException>(() =>
+            HtmlRenderTestDriver.Render(HtmlConversionDocument.Parse(html), options));
+
+        Assert.Equal(HtmlRenderDiagnosticCodes.LayoutOperationLimitExceeded, exception.Code);
+        Assert.Equal(nameof(HtmlRenderOptions.MaxLayoutOperations), exception.LimitSource);
+    }
+
+    [Fact]
     public void HtmlRender_Paged_AppliesNamedPageMastersAndNamedPseudoPages() {
         string words = string.Join(" ", Enumerable.Range(0, 150).Select(index => "word" + index.ToString("D3")));
         string html = """

--- a/OfficeIMO.Html/Rendering/HtmlCssGeneratedContentTemplate.cs
+++ b/OfficeIMO.Html/Rendering/HtmlCssGeneratedContentTemplate.cs
@@ -12,8 +12,21 @@ internal sealed class HtmlCssGeneratedContentTemplate {
 
     internal bool IsEmpty => _segments.Count == 0;
 
+    internal int GetRenderedLength(int pageNumber, int pageCount) {
+        int length = 0;
+        foreach (Segment segment in _segments) {
+            int segmentLength = segment.Counter == CounterKind.Page
+                ? pageNumber.ToString(CultureInfo.InvariantCulture).Length
+                : segment.Counter == CounterKind.Pages
+                    ? pageCount.ToString(CultureInfo.InvariantCulture).Length
+                    : segment.Text.Length;
+            length = checked(length + segmentLength);
+        }
+        return length;
+    }
+
     internal string Render(int pageNumber, int pageCount) {
-        var text = new StringBuilder();
+        var text = new StringBuilder(GetRenderedLength(pageNumber, pageCount));
         foreach (Segment segment in _segments) {
             if (segment.Counter == CounterKind.Page) text.Append(pageNumber.ToString(CultureInfo.InvariantCulture));
             else if (segment.Counter == CounterKind.Pages) text.Append(pageCount.ToString(CultureInfo.InvariantCulture));

--- a/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Blocks.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.Blocks.cs
@@ -156,7 +156,15 @@ internal sealed partial class HtmlRenderLayoutEngine {
     }
 
     private void ChargeLayoutOperation(string source) {
-        _layoutOperationCount++;
+        ChargeLayoutOperations(1L, source);
+    }
+
+    private void ChargeLayoutOperations(long count, string source) {
+        if (count < 0L || _layoutOperationCount > _options.MaxLayoutOperations - count) {
+            _layoutOperationCount = (long)_options.MaxLayoutOperations + 1L;
+        } else {
+            _layoutOperationCount += count;
+        }
         if (_layoutOperationCount > _options.MaxLayoutOperations) {
             throw new HtmlDomLimitException(
                 HtmlRenderDiagnosticCodes.LayoutOperationLimitExceeded,

--- a/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.PageMargins.cs
+++ b/OfficeIMO.Html/Rendering/HtmlRenderLayoutEngine.PageMargins.cs
@@ -14,6 +14,8 @@ internal sealed partial class HtmlRenderLayoutEngine {
 
             var visuals = new List<HtmlRenderVisual>(page.Scene);
             foreach (HtmlCssPageMarginTemplate box in boxes.Values.OrderBy(item => item.Position)) {
+                ChargeLayoutOperations(box.Content.GetRenderedLength(page.PageNumber, pages.Count),
+                    "@page @" + GetMarginBoxName(box.Position) + " generated content");
                 string text = box.Content.Render(page.PageNumber, pages.Count);
                 if (text.Length == 0 || !TryGetMarginBoxBounds(page, box.Position, box.Font.Size, out double x, out double y, out double width, out double height)) continue;
                 visuals.Add(new HtmlRenderText(

--- a/OfficeIMO.OpenDocument.Tests/OpenDocument.Hardening.cs
+++ b/OfficeIMO.OpenDocument.Tests/OpenDocument.Hardening.cs
@@ -118,6 +118,20 @@ public sealed class OpenDocumentHardeningTests {
         Assert.Contains("character limit", oversized.Error, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Theory]
+    [InlineData("of:=----------------1")]
+    [InlineData("of:=1^1^1^1^1^1^1^1^1")]
+    public void FormulaSyntaxDepthBoundsRecursiveUnaryAndPowerOperators(string formula) {
+        OdsDocument document = OdsDocument.Create();
+        document.AddSheet("Data");
+
+        OdsFormulaEvaluationResult result = OdsFormulaEvaluator.EvaluateExpression(document, "Data", formula,
+            new OdsFormulaEvaluationOptions { MaximumDependencyDepth = 4 });
+
+        Assert.False(result.Success);
+        Assert.Contains("syntax depth", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Fact]
     public void DetectsInvalidRepeatsAndStyleCyclesWithoutUnboundedTraversal() {
         OdsDocument created = OdsDocument.Create();

--- a/OfficeIMO.OpenDocument/Spreadsheet/Formulas/OdsFormulaParser.cs
+++ b/OfficeIMO.OpenDocument/Spreadsheet/Formulas/OdsFormulaParser.cs
@@ -72,18 +72,25 @@ internal sealed class OdsFormulaParser {
         OdsFormulaOperand left = ParsePostfix();
         if (_current.Kind == OdsFormulaTokenKind.Caret) {
             Take();
-            OdsFormulaValue right = ParseUnary().RequireScalar();
-            left = Scalar(NumericBinary(OdsFormulaTokenKind.Caret, left.RequireScalar(), right));
+            EnterSyntax();
+            try {
+                OdsFormulaValue right = ParseUnary().RequireScalar();
+                left = Scalar(NumericBinary(OdsFormulaTokenKind.Caret, left.RequireScalar(), right));
+            } finally { _syntaxDepth--; }
         }
         return left;
     }
 
     private OdsFormulaOperand ParseUnary() {
-        if (_current.Kind == OdsFormulaTokenKind.Plus) { Take(); return ParseUnary(); }
-        if (_current.Kind == OdsFormulaTokenKind.Minus) {
-            Take();
-            OdsFormulaValue value = ParseUnary().RequireScalar();
-            return value.Kind == OdsFormulaValueKind.Error ? Scalar(value) : Scalar(Number(-RequireNumber(value)));
+        if (_current.Kind == OdsFormulaTokenKind.Plus || _current.Kind == OdsFormulaTokenKind.Minus) {
+            bool negate = Take().Kind == OdsFormulaTokenKind.Minus;
+            EnterSyntax();
+            try {
+                OdsFormulaOperand operand = ParseUnary();
+                if (!negate) return operand;
+                OdsFormulaValue value = operand.RequireScalar();
+                return value.Kind == OdsFormulaValueKind.Error ? Scalar(value) : Scalar(Number(-RequireNumber(value)));
+            } finally { _syntaxDepth--; }
         }
         return ParsePower();
     }

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfImageExtractorTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfImageExtractorTests.cs
@@ -384,6 +384,22 @@ public class PdfImageExtractorTests {
     }
 
     [Fact]
+    public void ExtractImages_RejectsImageMaskDimensionsThatOverflowDecodedBuffers() {
+        byte[] source = BuildImagePdfWithColorSpace(
+            "/DeviceGray",
+            int.MaxValue,
+            int.MaxValue,
+            1,
+            "@",
+            " /ImageMask true");
+
+        PdfExtractedImage image = Assert.Single(PdfImageExtractor.ExtractImages(source));
+
+        Assert.False(image.IsImageFile);
+        Assert.NotEqual("png", image.FileExtension);
+    }
+
+    [Fact]
     public void ExtractImages_AppliesImageDecodeArrayWhenNormalizingIndexedStreamsToRgbPngFiles() {
         byte[] source = BuildUnfilteredIndexedRgbInvertedDecodeImagePdf();
 

--- a/OfficeIMO.Pdf/Core/PdfDocument.Blocks.ImageValidation.cs
+++ b/OfficeIMO.Pdf/Core/PdfDocument.Blocks.ImageValidation.cs
@@ -73,6 +73,22 @@ public sealed partial class PdfDocument {
                     wasTranscoded: false);
             }
 
+            // Metadata identification deliberately rejects PNG dimensions that exceed the
+            // shared raster budget. Preserve the PDF writer's more specific validation
+            // diagnostic instead of collapsing those payloads into an unknown header.
+            if (LooksLikePng(data)) {
+                if (PdfWriter.TryGetPngImageData(data, out PdfWriter.PdfImageStream pngImage, out string? pngReason)) {
+                    return new PreparedImage(
+                        (byte[])data.Clone(),
+                        new OfficeImageInfo(OfficeImageFormat.Png, pngImage.PixelWidth, pngImage.PixelHeight),
+                        OfficeImageFormat.Png,
+                        wasTranscoded: false);
+                }
+
+                string suffix = string.IsNullOrWhiteSpace(pngReason) ? string.Empty : " " + pngReason;
+                throw new NotSupportedException(SupportedImageMessage + suffix);
+            }
+
             throw new NotSupportedException(SupportedImageMessage + " The source image header is not recognized.");
         }
 
@@ -127,4 +143,9 @@ public sealed partial class PdfDocument {
         data[1] == 0xD8 &&
         data[data.Length - 2] == 0xFF &&
         data[data.Length - 1] == 0xD9;
+
+    private static bool LooksLikePng(byte[] data) =>
+        data.Length >= 8 &&
+        data[0] == 137 && data[1] == 80 && data[2] == 78 && data[3] == 71 &&
+        data[4] == 13 && data[5] == 10 && data[6] == 26 && data[7] == 10;
 }

--- a/OfficeIMO.Pdf/Reading/Core/PdfImageBufferLimits.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfImageBufferLimits.cs
@@ -1,0 +1,24 @@
+namespace OfficeIMO.Pdf;
+
+internal static class PdfImageBufferLimits {
+    internal static bool TryGetScanlineBufferSize(
+        int width,
+        int height,
+        int channels,
+        out int pixelCount,
+        out int bufferSize) {
+        pixelCount = 0;
+        bufferSize = 0;
+        if (width <= 0 || height <= 0 || channels <= 0) return false;
+
+        long pixels = (long)width * height;
+        long rowBytes = 1L + (long)width * channels;
+        long totalBytes = rowBytes * height;
+        if (pixels > int.MaxValue || rowBytes > int.MaxValue || totalBytes > int.MaxValue ||
+            totalBytes > PdfReadLimits.DefaultMaxDecodedStreamBytes) return false;
+
+        pixelCount = (int)pixels;
+        bufferSize = (int)totalBytes;
+        return true;
+    }
+}

--- a/OfficeIMO.Pdf/Reading/Core/PdfImageMaskNormalizer.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfImageMaskNormalizer.cs
@@ -13,6 +13,7 @@ internal static class PdfImageMaskNormalizer {
         if (width <= 0 ||
             height <= 0 ||
             !IsImageMask(stream, objects) ||
+            !PdfImageBufferLimits.TryGetScanlineBufferSize(width, height, 2, out _, out int scanlineBytes) ||
             !TryReadDecodedStreamBytes(stream, objects, out var maskPixels)) {
             return false;
         }
@@ -34,7 +35,7 @@ internal static class PdfImageMaskNormalizer {
         }
 
         var decodeTransform = PdfImageDecodeTransform.CreateIndexed(stream.Dictionary, 1, objects);
-        byte[] scanlines = new byte[(1 + outputRowLength) * height];
+        byte[] scanlines = new byte[scanlineBytes];
         for (int row = 0; row < height; row++) {
             int outputRow = row * (1 + outputRowLength);
             int sourceRow = row * sourceRowLength;

--- a/OfficeIMO.Pdf/Reading/Core/ResourceResolver.Images.cs
+++ b/OfficeIMO.Pdf/Reading/Core/ResourceResolver.Images.cs
@@ -57,10 +57,12 @@ internal static partial class ResourceResolver {
         if (bitsPerComponent is not (0 or 1)) {
             return false;
         }
+        if (!PdfImageBufferLimits.TryGetScanlineBufferSize(width, height, 4, out int pixelCount, out int scanlineBytes)) {
+            return false;
+        }
 
         byte[] maskPixels = Filters.StreamDecoder.Decode(stream.Dictionary, stream.Data, objects);
-        int pixelCount = width * height;
-        byte[] scanlines = new byte[(1 + width * 4) * height];
+        byte[] scanlines = new byte[scanlineBytes];
         for (int sampleIndex = 0; sampleIndex < pixelCount; sampleIndex++) {
             if (!TryReadIndexedSample(maskPixels, width, sampleIndex, 1, out int sample)) {
                 return false;

--- a/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Html/HtmlPowerPointConverterExtensions.cs
@@ -510,32 +510,24 @@ public static partial class HtmlPowerPointConverterExtensions {
     }
 
     private static int FindPresenterNotesMarker(string normalizedMarkdown) {
-        int searchStart = normalizedMarkdown.Length - 1;
-        while (searchStart >= 0) {
-            int marker = normalizedMarkdown.LastIndexOf("### Notes", searchStart, StringComparison.OrdinalIgnoreCase);
-            if (marker < 0) {
-                return -1;
+        int lastMarker = -1;
+        int lineStart = 0;
+        while (lineStart <= normalizedMarkdown.Length) {
+            int lineEnd = normalizedMarkdown.IndexOf('\n', lineStart);
+            if (lineEnd < 0) lineEnd = normalizedMarkdown.Length;
+            int contentStart = lineStart;
+            int contentEnd = lineEnd;
+            while (contentStart < contentEnd && char.IsWhiteSpace(normalizedMarkdown[contentStart])) contentStart++;
+            while (contentEnd > contentStart && char.IsWhiteSpace(normalizedMarkdown[contentEnd - 1])) contentEnd--;
+            const string markerText = "### Notes";
+            if (contentEnd - contentStart == markerText.Length &&
+                string.Compare(normalizedMarkdown, contentStart, markerText, 0, markerText.Length, StringComparison.OrdinalIgnoreCase) == 0) {
+                lastMarker = contentStart;
             }
-
-            int lineStart = marker;
-            while (lineStart > 0 && normalizedMarkdown[lineStart - 1] != '\n') {
-                lineStart--;
-            }
-
-            int lineEnd = normalizedMarkdown.IndexOf('\n', marker);
-            if (lineEnd < 0) {
-                lineEnd = normalizedMarkdown.Length;
-            }
-
-            string line = normalizedMarkdown.Substring(lineStart, lineEnd - lineStart).Trim();
-            if (line.Equals("### Notes", StringComparison.OrdinalIgnoreCase)) {
-                return marker;
-            }
-
-            searchStart = marker - 1;
+            if (lineEnd == normalizedMarkdown.Length) break;
+            lineStart = lineEnd + 1;
         }
-
-        return -1;
+        return lastMarker;
     }
 
     private static bool TryAddChartByKind(PptCore.PowerPointSlide slide, string chartKind, PptCore.PowerPointChartData data, double left, double top, double width, double height, out PptCore.PowerPointChart? chart, out string? fallbackMessage) {

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.cs
@@ -297,7 +297,7 @@ public static partial class PowerPointPdfConverterExtensions {
                 IncludeTextBoxes = options.IncludeTextBoxes,
                 IncludeTables = options.IncludeTables,
                 IncludeCharts = options.IncludeCharts,
-                MaxGroupShapeDepth = options.MaxGroupShapeDepth > 0 ? options.MaxGroupShapeDepth : 32
+                MaxGroupShapeDepth = options.MaxGroupShapeDepth
             });
         canvas.Drawing(snapshot.Drawing, x, y, width, height);
         foreach (OfficeImageExportDiagnostic diagnostic in snapshot.Diagnostics) {

--- a/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.cs
+++ b/OfficeIMO.PowerPoint.Pdf/PowerPointPdfConverterExtensions.cs
@@ -296,7 +296,8 @@ public static partial class PowerPointPdfConverterExtensions {
                 IncludeAutoShapes = options.IncludeAutoShapes,
                 IncludeTextBoxes = options.IncludeTextBoxes,
                 IncludeTables = options.IncludeTables,
-                IncludeCharts = options.IncludeCharts
+                IncludeCharts = options.IncludeCharts,
+                MaxGroupShapeDepth = options.MaxGroupShapeDepth > 0 ? options.MaxGroupShapeDepth : 32
             });
         canvas.Drawing(snapshot.Drawing, x, y, width, height);
         foreach (OfficeImageExportDiagnostic diagnostic in snapshot.Diagnostics) {

--- a/OfficeIMO.PowerPoint.Tests/Pdf/PowerPoint.SaveAsPdf.SecurityTests.cs
+++ b/OfficeIMO.PowerPoint.Tests/Pdf/PowerPoint.SaveAsPdf.SecurityTests.cs
@@ -33,4 +33,29 @@ public class PowerPointSaveAsPdfSecurityTests {
             }
         }
     }
+
+    [Fact]
+    public void SaveAsPdf_PowerPointHandouts_HonorZeroGroupDepth() {
+        string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".pptx");
+        try {
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(path);
+            PowerPointSlide slide = presentation.AddSlide();
+            PowerPointTextBox textBox = slide.AddTextBoxPoints("Nested text", 72, 72, 144, 36);
+            PowerPointTextBox secondTextBox = slide.AddTextBoxPoints("Nested sibling", 72, 120, 144, 36);
+            slide.GroupShapes(new PowerPointShape[] { textBox, secondTextBox }, "Outer");
+
+            PdfCore.PdfDocumentConversionResult result = presentation.ToPdfDocumentResult(new PowerPointPdfSaveOptions {
+                PageLayout = PowerPointPdfPageLayout.Handouts,
+                HandoutSlidesPerPage = 1,
+                MaxGroupShapeDepth = 0
+            });
+
+            Assert.Contains(result.Warnings, warning =>
+                warning.Message.Contains(nameof(PowerPointPdfSaveOptions.MaxGroupShapeDepth), StringComparison.Ordinal));
+        } finally {
+            if (File.Exists(path)) {
+                File.Delete(path);
+            }
+        }
+    }
 }

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.AdvancedWorkflows.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.AdvancedWorkflows.cs
@@ -125,6 +125,38 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void AnimationInspectionSkipsShapeTraversalForUntargetedTimingNodes() {
+            string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
+            try {
+                using (PowerPointPresentation presentation = PowerPointPresentation.Create(path)) {
+                    PowerPointSlide slide = presentation.AddSlide();
+                    ShapeTree shapeTree = slide.SlidePart.Slide!.CommonSlideData!.ShapeTree!;
+                    for (uint shapeId = 100U; shapeId < 10_101U; shapeId++) {
+                        shapeTree.Append(new Shape(
+                            new NonVisualShapeProperties(
+                                new NonVisualDrawingProperties { Id = shapeId, Name = "Shape " + shapeId },
+                                new NonVisualShapeDrawingProperties(),
+                                new ApplicationNonVisualDrawingProperties()),
+                            new ShapeProperties()));
+                    }
+                    slide.SlidePart.Slide.Timing = new Timing(
+                        new TimeNodeList(new ParallelTimeNode(new CommonTimeNode { Id = 1U })));
+                    presentation.Save();
+                }
+
+                using PowerPointPresentation reopened = PowerPointPresentation.Load(path);
+                Assert.True(reopened.Slides[0].Shapes.Count > 10_000);
+                PowerPointAnimationNode node = Assert.Single(reopened.InspectAnimations().Nodes);
+
+                Assert.Equal(PowerPointAnimationKind.Parallel, node.Kind);
+                Assert.Null(node.ShapeId);
+                Assert.Null(node.ShapeName);
+            } finally {
+                if (File.Exists(path)) File.Delete(path);
+            }
+        }
+
+        [Fact]
         public void SemanticSmartArtWorkflowsRoundTripEditableNodeText() {
             string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
             try {

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.AdvancedWorkflows.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.AdvancedWorkflows.cs
@@ -106,6 +106,25 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void AnimationInspectionBoundsTraversalAndProjectedNodes() {
+            using var stream = new MemoryStream();
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
+            PowerPointSlide slide = presentation.AddSlide();
+            slide.SlidePart.Slide!.Timing = new Timing(
+                new TimeNodeList(
+                    new ParallelTimeNode(new CommonTimeNode { Id = 1U }),
+                    new ParallelTimeNode(new CommonTimeNode { Id = 2U })));
+
+            InvalidDataException nodeException = Assert.Throws<InvalidDataException>(() =>
+                presentation.InspectAnimations(new PowerPointAnimationInspectionOptions { MaxAnimationNodes = 1 }));
+            InvalidDataException elementException = Assert.Throws<InvalidDataException>(() =>
+                presentation.InspectAnimations(new PowerPointAnimationInspectionOptions { MaxXmlElements = 1 }));
+
+            Assert.Contains(nameof(PowerPointAnimationInspectionOptions.MaxAnimationNodes), nodeException.Message, StringComparison.Ordinal);
+            Assert.Contains(nameof(PowerPointAnimationInspectionOptions.MaxXmlElements), elementException.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void SemanticSmartArtWorkflowsRoundTripEditableNodeText() {
             string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".pptx");
             try {

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.ImageExport.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.ImageExport.cs
@@ -503,6 +503,24 @@ namespace OfficeIMO.Tests {
                     StringComparison.OrdinalIgnoreCase));
         }
 
+        [Fact]
+        public void PowerPointSlide_SharedSnapshotStopsAtConfiguredGroupDepth() {
+            using var stream = new MemoryStream();
+            using PowerPointPresentation presentation = PowerPointPresentation.Create(stream);
+            PowerPointSlide slide = presentation.AddSlide();
+            PowerPointAutoShape first = slide.AddShapePoints(A.ShapeTypeValues.Rectangle, 10, 10, 20, 20);
+            PowerPointAutoShape second = slide.AddShapePoints(A.ShapeTypeValues.Rectangle, 40, 10, 20, 20);
+            PowerPointAutoShape third = slide.AddShapePoints(A.ShapeTypeValues.Rectangle, 70, 10, 20, 20);
+            PowerPointGroupShape inner = slide.GroupShapes(new PowerPointShape[] { first, second }, "Inner");
+            slide.GroupShapes(new PowerPointShape[] { inner, third }, "Outer");
+
+            PowerPointSlideVisualSnapshot snapshot = slide.CreateVisualSnapshot(
+                new PowerPointImageExportOptions { MaxGroupShapeDepth = 1 });
+
+            Assert.Contains(snapshot.Diagnostics, diagnostic =>
+                diagnostic.Message.Contains(nameof(PowerPointImageExportOptions.MaxGroupShapeDepth), StringComparison.Ordinal));
+        }
+
         private static void AddShapeLinearGradient(Shape shape, bool rotateWithShape,
             double angleDegrees = 0D) {
             shape.ShapeProperties!.Append(new A.GradientFill(

--- a/OfficeIMO.PowerPoint/Imaging/PowerPointImageExportOptions.cs
+++ b/OfficeIMO.PowerPoint/Imaging/PowerPointImageExportOptions.cs
@@ -40,6 +40,9 @@ namespace OfficeIMO.PowerPoint {
         /// </summary>
         public bool IncludeHiddenShapes { get; set; }
 
+        /// <summary>Maximum nested group-shape depth rendered into a shared visual snapshot.</summary>
+        public int MaxGroupShapeDepth { get; set; } = 32;
+
         /// <summary>Creates an independent options snapshot.</summary>
         public PowerPointImageExportOptions Clone() =>
             CopyPowerPointOptionsTo(new PowerPointImageExportOptions());
@@ -54,10 +57,14 @@ namespace OfficeIMO.PowerPoint {
             target.IncludeTables = IncludeTables;
             target.IncludeCharts = IncludeCharts;
             target.IncludeHiddenShapes = IncludeHiddenShapes;
+            target.MaxGroupShapeDepth = MaxGroupShapeDepth;
             return target;
         }
 
-        internal void Validate() => ValidateImageExportOptions();
+        internal void Validate() {
+            ValidateImageExportOptions();
+            if (MaxGroupShapeDepth <= 0) throw new ArgumentOutOfRangeException(nameof(MaxGroupShapeDepth));
+        }
     }
 
     /// <summary>

--- a/OfficeIMO.PowerPoint/Imaging/PowerPointImageExportOptions.cs
+++ b/OfficeIMO.PowerPoint/Imaging/PowerPointImageExportOptions.cs
@@ -40,7 +40,7 @@ namespace OfficeIMO.PowerPoint {
         /// </summary>
         public bool IncludeHiddenShapes { get; set; }
 
-        /// <summary>Maximum nested group-shape depth rendered into a shared visual snapshot.</summary>
+        /// <summary>Maximum nested group-shape depth rendered into a shared visual snapshot. Zero skips group content; negative values disable the depth limit.</summary>
         public int MaxGroupShapeDepth { get; set; } = 32;
 
         /// <summary>Creates an independent options snapshot.</summary>
@@ -63,7 +63,6 @@ namespace OfficeIMO.PowerPoint {
 
         internal void Validate() {
             ValidateImageExportOptions();
-            if (MaxGroupShapeDepth <= 0) throw new ArgumentOutOfRangeException(nameof(MaxGroupShapeDepth));
         }
     }
 

--- a/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.cs
+++ b/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.cs
@@ -143,7 +143,7 @@ namespace OfficeIMO.PowerPoint {
         private static void AddGroupShape(OfficeDrawing drawing, PowerPointGroupShape groupShape,
             List<OfficeImageExportDiagnostic> diagnostics, PowerPointShapeBoundsMapping mapping,
             A.ColorScheme? colorScheme, PowerPointImageExportOptions options, int groupDepth) {
-            if (groupDepth >= options.MaxGroupShapeDepth) {
+            if (options.MaxGroupShapeDepth >= 0 && groupDepth >= options.MaxGroupShapeDepth) {
                 AddUnsupportedShapeDiagnostic(diagnostics, groupShape,
                     "Skipped nested PowerPoint group content because MaxGroupShapeDepth was reached.");
                 return;

--- a/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.cs
+++ b/OfficeIMO.PowerPoint/Imaging/PowerPointSlideImageRenderer.cs
@@ -84,9 +84,9 @@ namespace OfficeIMO.PowerPoint {
             if (options.IncludeSlideContent) {
                 A.ColorScheme? colorScheme = GetSlideColorScheme(slide);
                 AddSlideContent(slide.GetInheritedShapesForExport(), drawing, diagnostics,
-                    PowerPointShapeBoundsMapping.Identity, colorScheme, options);
+                    PowerPointShapeBoundsMapping.Identity, colorScheme, options, 0);
                 AddSlideContent(slide.Shapes, drawing, diagnostics,
-                    PowerPointShapeBoundsMapping.Identity, colorScheme, options);
+                    PowerPointShapeBoundsMapping.Identity, colorScheme, options, 0);
             }
 
             return drawing;
@@ -94,7 +94,7 @@ namespace OfficeIMO.PowerPoint {
 
         private static void AddSlideContent(IEnumerable<PowerPointShape> shapes, OfficeDrawing drawing,
             List<OfficeImageExportDiagnostic> diagnostics, PowerPointShapeBoundsMapping mapping,
-            A.ColorScheme? colorScheme, PowerPointImageExportOptions options) {
+            A.ColorScheme? colorScheme, PowerPointImageExportOptions options, int groupDepth) {
             foreach (PowerPointShape shape in shapes) {
                 if (shape.Hidden && !options.IncludeHiddenShapes) {
                     continue;
@@ -104,7 +104,7 @@ namespace OfficeIMO.PowerPoint {
                 }
 
                 if (shape is PowerPointGroupShape groupShape) {
-                    AddGroupShape(drawing, groupShape, diagnostics, mapping, colorScheme, options);
+                    AddGroupShape(drawing, groupShape, diagnostics, mapping, colorScheme, options, groupDepth);
                 } else if (shape is PowerPointPicture picture) {
                     AddPicture(drawing, picture, diagnostics, mapping);
                 } else if (shape is PowerPointTable table) {
@@ -142,7 +142,12 @@ namespace OfficeIMO.PowerPoint {
 
         private static void AddGroupShape(OfficeDrawing drawing, PowerPointGroupShape groupShape,
             List<OfficeImageExportDiagnostic> diagnostics, PowerPointShapeBoundsMapping mapping,
-            A.ColorScheme? colorScheme, PowerPointImageExportOptions options) {
+            A.ColorScheme? colorScheme, PowerPointImageExportOptions options, int groupDepth) {
+            if (groupDepth >= options.MaxGroupShapeDepth) {
+                AddUnsupportedShapeDiagnostic(diagnostics, groupShape,
+                    "Skipped nested PowerPoint group content because MaxGroupShapeDepth was reached.");
+                return;
+            }
             if (groupShape.OwnerSlide == null) {
                 AddUnsupportedShapeDiagnostic(diagnostics, groupShape, "Skipped a PowerPoint group shape because its owning slide context could not be resolved.");
                 return;
@@ -158,7 +163,7 @@ namespace OfficeIMO.PowerPoint {
                 groupDrawing.Fonts.AddRange(drawing.Fonts);
                 PowerPointShapeBoundsMapping localChildMapping = CreateGroupLocalChildMapping(groupShape, mapping);
                 AddSlideContent(groupShape.OwnerSlide.GetGroupChildren(groupShape), groupDrawing, diagnostics,
-                    localChildMapping, colorScheme, options);
+                    localChildMapping, colorScheme, options, groupDepth + 1);
 
                 try {
                     OfficeImageFrameTransform groupFrameTransform = CreateGroupFrameTransform(groupShape, left, top, width, height);
@@ -180,7 +185,7 @@ namespace OfficeIMO.PowerPoint {
                 groupDrawing.Fonts.AddRange(drawing.Fonts);
                 PowerPointShapeBoundsMapping localChildMapping = CreateGroupLocalChildMapping(groupShape, mapping);
                 AddSlideContent(groupShape.OwnerSlide.GetGroupChildren(groupShape), groupDrawing, diagnostics,
-                    localChildMapping, colorScheme, options);
+                    localChildMapping, colorScheme, options, groupDepth + 1);
                 if (RequiresGroupClip(groupDrawing, clipWidth, clipHeight)) {
                     drawing.AddClippedDrawing(groupDrawing, clipLeft, clipTop, OfficeClipPath.Rectangle(clipWidth, clipHeight));
                     return;
@@ -188,7 +193,7 @@ namespace OfficeIMO.PowerPoint {
             }
 
             AddSlideContent(groupShape.OwnerSlide.GetGroupChildren(groupShape), drawing, diagnostics,
-                childMapping, colorScheme, options);
+                childMapping, colorScheme, options, groupDepth + 1);
         }
 
         private static bool RequiresGroupClip(OfficeDrawing groupDrawing, double width, double height) {

--- a/OfficeIMO.PowerPoint/PowerPointReviewAndAnimationReports.cs
+++ b/OfficeIMO.PowerPoint/PowerPointReviewAndAnimationReports.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Presentation;
@@ -196,6 +197,24 @@ namespace OfficeIMO.PowerPoint {
         public bool HasAnimations => Nodes.Count > 0;
     }
 
+    /// <summary>Safety limits for inspecting untrusted presentation timing trees.</summary>
+    public sealed class PowerPointAnimationInspectionOptions {
+        /// <summary>Maximum XML elements visited across all slide timing trees.</summary>
+        public int MaxXmlElements { get; set; } = 100_000;
+        /// <summary>Maximum timing-tree nesting depth visited.</summary>
+        public int MaxXmlDepth { get; set; } = 128;
+        /// <summary>Maximum animation nodes projected into the report.</summary>
+        public int MaxAnimationNodes { get; set; } = 10_000;
+        /// <summary>Optional cancellation token checked during inspection.</summary>
+        public CancellationToken CancellationToken { get; set; }
+
+        internal void Validate() {
+            if (MaxXmlElements <= 0) throw new ArgumentOutOfRangeException(nameof(MaxXmlElements));
+            if (MaxXmlDepth <= 0) throw new ArgumentOutOfRangeException(nameof(MaxXmlDepth));
+            if (MaxAnimationNodes <= 0) throw new ArgumentOutOfRangeException(nameof(MaxAnimationNodes));
+        }
+    }
+
     public sealed partial class PowerPointPresentation {
         /// <summary>Inspects classic and modern comments without mutating review markup.</summary>
         public PowerPointReviewReport InspectReviewComments() {
@@ -211,36 +230,80 @@ namespace OfficeIMO.PowerPoint {
         }
 
         /// <summary>Inspects slide timing trees before any animation authoring is attempted.</summary>
-        public PowerPointAnimationReport InspectAnimations() {
+        public PowerPointAnimationReport InspectAnimations() => InspectAnimations(new PowerPointAnimationInspectionOptions());
+
+        /// <summary>Inspects slide timing trees with explicit traversal and result limits.</summary>
+        public PowerPointAnimationReport InspectAnimations(PowerPointAnimationInspectionOptions options) {
             ThrowIfDisposed();
+            if (options == null) throw new ArgumentNullException(nameof(options));
+            options.Validate();
             var nodes = new List<PowerPointAnimationNode>();
+            int visitedElements = 0;
             for (int index = 0; index < _slides.Count; index++) {
+                options.CancellationToken.ThrowIfCancellationRequested();
                 PowerPointSlide slide = _slides[index];
                 Timing? timing = slide.SlidePart.Slide?.Timing;
                 if (timing == null) continue;
-                foreach (OpenXmlElement element in timing.Descendants().Where(IsAnimationElement)) {
-                    OpenXmlElement? common = FindOwnedAnimationDescendant(element, "cTn");
-                    OpenXmlElement? target = FindOwnedAnimationDescendant(element, "spTgt");
-                    uint? shapeId = ParseUInt(GetAttribute(target, "spid"));
-                    string? shapeName = shapeId.HasValue
-                        ? slide.EnumerateShapesDeep(slide.Shapes.Concat(slide.GetInheritedShapesForExport()))
-                            .FirstOrDefault(shape => shape.Id == shapeId)?.Name
+                var slideItems = new List<AnimationInspectionItem>();
+                InspectAnimationTree(timing, options, ref visitedElements, nodes.Count, slideItems);
+                Dictionary<uint, string?> shapeNames = slide
+                    .EnumerateShapesDeep(slide.Shapes.Concat(slide.GetInheritedShapesForExport()))
+                    .Where(shape => shape.Id.HasValue)
+                    .GroupBy(shape => shape.Id!.Value)
+                    .ToDictionary(group => group.Key, group => group.First().Name);
+                foreach (AnimationInspectionItem item in slideItems) {
+                    uint? shapeId = ParseUInt(GetAttribute(item.Target, "spid"));
+                    string? shapeName = shapeId.HasValue && shapeNames.TryGetValue(shapeId.Value, out string? resolvedName)
+                        ? resolvedName
                         : null;
-                    OpenXmlElement? condition = FindOwnedAnimationDescendant(element, "cond");
-                    nodes.Add(new PowerPointAnimationNode(index + 1, MapAnimationKind(element.LocalName),
-                        element.LocalName, GetAttribute(common, "id"), shapeId, shapeName,
-                        GetAttribute(condition, "evt"), GetAttribute(condition, "delay"),
-                        GetAttribute(common, "dur"), GetAttribute(common, "presetClass"),
-                        GetAttribute(common, "presetID"), GetAttribute(common, "presetSubtype")));
+                    nodes.Add(new PowerPointAnimationNode(index + 1, MapAnimationKind(item.Element.LocalName),
+                        item.Element.LocalName, GetAttribute(item.Common, "id"), shapeId, shapeName,
+                        GetAttribute(item.Condition, "evt"), GetAttribute(item.Condition, "delay"),
+                        GetAttribute(item.Common, "dur"), GetAttribute(item.Common, "presetClass"),
+                        GetAttribute(item.Common, "presetID"), GetAttribute(item.Common, "presetSubtype")));
                 }
             }
             return new PowerPointAnimationReport(nodes);
         }
 
-        private static OpenXmlElement? FindOwnedAnimationDescendant(OpenXmlElement animation, string localName) =>
-            animation.Descendants().FirstOrDefault(candidate =>
-                candidate.LocalName == localName &&
-                ReferenceEquals(candidate.Ancestors().FirstOrDefault(IsAnimationElement), animation));
+        private static void InspectAnimationTree(Timing timing, PowerPointAnimationInspectionOptions options,
+            ref int visitedElements, int existingAnimationCount, IList<AnimationInspectionItem> destination) {
+            var stack = new Stack<(OpenXmlElement Element, int Depth, AnimationInspectionItem? Owner)>();
+            for (int childIndex = timing.ChildElements.Count - 1; childIndex >= 0; childIndex--) {
+                stack.Push((timing.ChildElements[childIndex], 1, null));
+            }
+            while (stack.Count > 0) {
+                (OpenXmlElement element, int depth, AnimationInspectionItem? owner) = stack.Pop();
+                if ((visitedElements++ & 0xFF) == 0) options.CancellationToken.ThrowIfCancellationRequested();
+                if (visitedElements > options.MaxXmlElements) throw new InvalidDataException("Animation inspection exceeded MaxXmlElements.");
+                if (depth > options.MaxXmlDepth) throw new InvalidDataException("Animation inspection exceeded MaxXmlDepth.");
+
+                AnimationInspectionItem? childOwner = owner;
+                if (IsAnimationElement(element)) {
+                    if (existingAnimationCount + destination.Count >= options.MaxAnimationNodes) {
+                        throw new InvalidDataException("Animation inspection exceeded MaxAnimationNodes.");
+                    }
+                    childOwner = new AnimationInspectionItem(element);
+                    destination.Add(childOwner);
+                } else if (owner != null) {
+                    if (element.LocalName == "cTn" && owner.Common == null) owner.Common = element;
+                    else if (element.LocalName == "spTgt" && owner.Target == null) owner.Target = element;
+                    else if (element.LocalName == "cond" && owner.Condition == null) owner.Condition = element;
+                }
+
+                for (int childIndex = element.ChildElements.Count - 1; childIndex >= 0; childIndex--) {
+                    stack.Push((element.ChildElements[childIndex], depth + 1, childOwner));
+                }
+            }
+        }
+
+        private sealed class AnimationInspectionItem {
+            internal AnimationInspectionItem(OpenXmlElement element) { Element = element; }
+            internal OpenXmlElement Element { get; }
+            internal OpenXmlElement? Common { get; set; }
+            internal OpenXmlElement? Target { get; set; }
+            internal OpenXmlElement? Condition { get; set; }
+        }
 
         private Dictionary<uint, string> GetClassicAuthors() {
             var result = new Dictionary<uint, string>();

--- a/OfficeIMO.PowerPoint/PowerPointReviewAndAnimationReports.cs
+++ b/OfficeIMO.PowerPoint/PowerPointReviewAndAnimationReports.cs
@@ -269,8 +269,13 @@ namespace OfficeIMO.PowerPoint {
         private static void InspectAnimationTree(Timing timing, PowerPointAnimationInspectionOptions options,
             ref int visitedElements, int existingAnimationCount, IList<AnimationInspectionItem> destination) {
             var stack = new Stack<(OpenXmlElement Element, int Depth, AnimationInspectionItem? Owner)>();
+            int scheduledElements = visitedElements;
             for (int childIndex = timing.ChildElements.Count - 1; childIndex >= 0; childIndex--) {
+                if (scheduledElements >= options.MaxXmlElements) {
+                    throw new InvalidDataException("Animation inspection exceeded MaxXmlElements.");
+                }
                 stack.Push((timing.ChildElements[childIndex], 1, null));
+                scheduledElements++;
             }
             while (stack.Count > 0) {
                 (OpenXmlElement element, int depth, AnimationInspectionItem? owner) = stack.Pop();
@@ -292,7 +297,12 @@ namespace OfficeIMO.PowerPoint {
                 }
 
                 for (int childIndex = element.ChildElements.Count - 1; childIndex >= 0; childIndex--) {
+                    if (scheduledElements >= options.MaxXmlElements) {
+                        throw new InvalidDataException("Animation inspection exceeded MaxXmlElements.");
+                    }
+                    if ((scheduledElements & 0xFF) == 0) options.CancellationToken.ThrowIfCancellationRequested();
                     stack.Push((element.ChildElements[childIndex], depth + 1, childOwner));
+                    scheduledElements++;
                 }
             }
         }

--- a/OfficeIMO.PowerPoint/PowerPointReviewAndAnimationReports.cs
+++ b/OfficeIMO.PowerPoint/PowerPointReviewAndAnimationReports.cs
@@ -246,13 +246,13 @@ namespace OfficeIMO.PowerPoint {
                 if (timing == null) continue;
                 var slideItems = new List<AnimationInspectionItem>();
                 InspectAnimationTree(timing, options, ref visitedElements, nodes.Count, slideItems);
-                Dictionary<uint, string?> shapeNames = slide
-                    .EnumerateShapesDeep(slide.Shapes.Concat(slide.GetInheritedShapesForExport()))
-                    .Where(shape => shape.Id.HasValue)
-                    .GroupBy(shape => shape.Id!.Value)
-                    .ToDictionary(group => group.Key, group => group.First().Name);
-                foreach (AnimationInspectionItem item in slideItems) {
-                    uint? shapeId = ParseUInt(GetAttribute(item.Target, "spid"));
+                uint?[] shapeIds = slideItems
+                    .Select(item => ParseUInt(GetAttribute(item.Target, "spid")))
+                    .ToArray();
+                Dictionary<uint, string?> shapeNames = ResolveAnimationShapeNames(slide, shapeIds);
+                for (int itemIndex = 0; itemIndex < slideItems.Count; itemIndex++) {
+                    AnimationInspectionItem item = slideItems[itemIndex];
+                    uint? shapeId = shapeIds[itemIndex];
                     string? shapeName = shapeId.HasValue && shapeNames.TryGetValue(shapeId.Value, out string? resolvedName)
                         ? resolvedName
                         : null;
@@ -264,6 +264,23 @@ namespace OfficeIMO.PowerPoint {
                 }
             }
             return new PowerPointAnimationReport(nodes);
+        }
+
+        private static Dictionary<uint, string?> ResolveAnimationShapeNames(
+            PowerPointSlide slide,
+            IEnumerable<uint?> shapeIds) {
+            var unresolvedShapeIds = new HashSet<uint>(shapeIds.Where(shapeId => shapeId.HasValue)
+                .Select(shapeId => shapeId!.Value));
+            var shapeNames = new Dictionary<uint, string?>();
+            if (unresolvedShapeIds.Count == 0) return shapeNames;
+
+            foreach (PowerPointShape shape in slide
+                         .EnumerateShapesDeep(slide.Shapes.Concat(slide.GetInheritedShapesForExport()))) {
+                if (!shape.Id.HasValue || !unresolvedShapeIds.Remove(shape.Id.Value)) continue;
+                shapeNames.Add(shape.Id.Value, shape.Name);
+                if (unresolvedShapeIds.Count == 0) break;
+            }
+            return shapeNames;
         }
 
         private static void InspectAnimationTree(Timing timing, PowerPointAnimationInspectionOptions options,

--- a/OfficeIMO.Word.Tests/Word.FieldUpdateReport.cs
+++ b/OfficeIMO.Word.Tests/Word.FieldUpdateReport.cs
@@ -2025,6 +2025,22 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_UpdateFieldsAndGetReport_EvaluatesLongExponentChainsWithoutParserRecursion() {
+            string filePath = Path.Combine(_directoryWithFiles, "FieldUpdate.FormulaExponentChain.docx");
+            string expression = string.Join(" ^ ", Enumerable.Repeat("1", 4096));
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Formula: ")._paragraph.Append(BuildSimpleField(" = " + expression + " ", "stale"));
+                document.Save();
+            }
+
+            using WordDocument loaded = WordDocument.Load(filePath);
+            WordFieldUpdateResult result = Assert.Single(loaded.UpdateFieldsAndGetReport().Results);
+
+            Assert.Equal(WordFieldUpdateStatus.Updated, result.Status);
+            Assert.Equal("1", result.ResultText);
+        }
+
+        [Fact]
         public void Test_UpdateFieldsAndGetReport_AppliesFormulaNumericPictureSwitches() {
             string filePath = Path.Combine(_directoryWithFiles, "FieldUpdate.FormulaNumericPictures.docx");
 

--- a/OfficeIMO.Word.Tests/Word.FieldUpdateReport.cs
+++ b/OfficeIMO.Word.Tests/Word.FieldUpdateReport.cs
@@ -2041,6 +2041,23 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_UpdateFieldsAndGetReport_AppliesUnarySignsAfterExponentiation() {
+            string filePath = Path.Combine(_directoryWithFiles, "FieldUpdate.FormulaUnaryExponent.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Signed base: ")._paragraph.Append(BuildSimpleField(" = -2 ^ 2 ", "stale"));
+                document.AddParagraph("Grouped base: ")._paragraph.Append(BuildSimpleField(" = (-2) ^ 2 ", "stale"));
+                document.AddParagraph("Signed exponent: ")._paragraph.Append(BuildSimpleField(" = 2 ^ -2 ^ 2 ", "stale"));
+                document.Save();
+            }
+
+            using WordDocument loaded = WordDocument.Load(filePath);
+            WordFieldUpdateReport report = loaded.UpdateFieldsAndGetReport();
+
+            Assert.Equal(new[] { "-4", "4", "0.0625" }, report.Results.Select(result => result.ResultText).ToArray());
+            Assert.All(report.Results, result => Assert.Equal(WordFieldUpdateStatus.Updated, result.Status));
+        }
+
+        [Fact]
         public void Test_UpdateFieldsAndGetReport_AppliesFormulaNumericPictureSwitches() {
             string filePath = Path.Combine(_directoryWithFiles, "FieldUpdate.FormulaNumericPictures.docx");
 

--- a/OfficeIMO.Word.Tests/Word.FieldUpdateReport.cs
+++ b/OfficeIMO.Word.Tests/Word.FieldUpdateReport.cs
@@ -2010,6 +2010,21 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void Test_UpdateFieldsAndGetReport_EvaluatesHugeIntegralExponentInLogarithmicSteps() {
+            string filePath = Path.Combine(_directoryWithFiles, "FieldUpdate.FormulaExponent.docx");
+            using (WordDocument document = WordDocument.Create(filePath)) {
+                document.AddParagraph("Formula: ")._paragraph.Append(BuildSimpleField(" = 1 ^ 2147483647 ", "stale"));
+                document.Save();
+            }
+
+            using WordDocument loaded = WordDocument.Load(filePath);
+            WordFieldUpdateResult result = Assert.Single(loaded.UpdateFieldsAndGetReport().Results);
+
+            Assert.Equal(WordFieldUpdateStatus.Updated, result.Status);
+            Assert.Equal("1", result.ResultText);
+        }
+
+        [Fact]
         public void Test_UpdateFieldsAndGetReport_AppliesFormulaNumericPictureSwitches() {
             string filePath = Path.Combine(_directoryWithFiles, "FieldUpdate.FormulaNumericPictures.docx");
 

--- a/OfficeIMO.Word.Tests/Word.LegacyDoc.Safety.cs
+++ b/OfficeIMO.Word.Tests/Word.LegacyDoc.Safety.cs
@@ -139,6 +139,7 @@ namespace OfficeIMO.Tests {
             Assert.Null(importOptionsType.GetProperty("ReportUnsupportedFeatures"));
             Assert.NotNull(importOptionsType.GetProperty(nameof(LegacyDocImportOptions.MaxInputBytes)));
             Assert.NotNull(importOptionsType.GetProperty(nameof(LegacyDocImportOptions.MaxDecodedImageBytes)));
+            Assert.NotNull(importOptionsType.GetProperty(nameof(LegacyDocImportOptions.MaxDecodedCharacters)));
             Assert.NotNull(importOptionsType.GetProperty(nameof(LegacyDocImportOptions.ReportUnsupportedContent)));
         }
 
@@ -149,6 +150,19 @@ namespace OfficeIMO.Tests {
             Assert.Throws<ArgumentOutOfRangeException>(() =>
                 OfficeIMO.Word.LegacyDoc.Model.LegacyDocDocument.Load(bytes,
                     new LegacyDocImportOptions { MaxDecodedImageBytes = 0 }));
+        }
+
+        [Fact]
+        public void LegacyDoc_RejectsPieceTablesBeyondDecodedCharacterBudgetBeforeAllocation() {
+            byte[] bytes = LegacyDocTestBuilder.CreateSimpleDoc("Decoded character budget");
+
+            OfficeIMO.Word.LegacyDoc.Model.LegacyDocDocument result =
+                OfficeIMO.Word.LegacyDoc.Model.LegacyDocDocument.Load(bytes,
+                    new LegacyDocImportOptions { MaxDecodedCharacters = 4 });
+
+            Assert.Contains(result.Diagnostics, diagnostic =>
+                diagnostic.Code == "DOC-PIECE-TABLE-INVALID" &&
+                diagnostic.Message.Contains(nameof(LegacyDocImportOptions.MaxDecodedCharacters), StringComparison.Ordinal));
         }
 
         [Fact]

--- a/OfficeIMO.Word.Tests/Word.LegacyDoc.Safety.cs
+++ b/OfficeIMO.Word.Tests/Word.LegacyDoc.Safety.cs
@@ -166,6 +166,46 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void LegacyDoc_RejectsNonMonotonicPieceTableCharacterPositions() {
+            byte[] wordDocumentStream = new byte[0x900];
+            WriteUInt16LittleEndian(wordDocumentStream, 0, 0xA5EC);
+            WriteUInt16LittleEndian(wordDocumentStream, 0x02, 0x00C1);
+            WriteInt32LittleEndian(wordDocumentStream, 0x4C, 4);
+            WriteInt32LittleEndian(wordDocumentStream, 0x1A2, 0);
+            WriteInt32LittleEndian(wordDocumentStream, 0x1A6, 45);
+            wordDocumentStream[0x800] = (byte)'A';
+            wordDocumentStream[0x801] = (byte)'B';
+            wordDocumentStream[0x802] = (byte)'C';
+            wordDocumentStream[0x803] = (byte)'D';
+
+            byte[] tableStream = new byte[45];
+            tableStream[0] = 0x02;
+            WriteInt32LittleEndian(tableStream, 1, 40);
+            WriteInt32LittleEndian(tableStream, 5, 0);
+            WriteInt32LittleEndian(tableStream, 9, 4);
+            WriteInt32LittleEndian(tableStream, 13, 0);
+            WriteInt32LittleEndian(tableStream, 17, 4);
+            int compressedOffset = unchecked((int)(0x40000000U | 0x1000U));
+            WriteInt32LittleEndian(tableStream, 23, compressedOffset);
+            WriteInt32LittleEndian(tableStream, 31, compressedOffset);
+            WriteInt32LittleEndian(tableStream, 39, compressedOffset);
+
+            Assert.True(OfficeIMO.Word.LegacyDoc.Model.LegacyDocFib.TryRead(
+                wordDocumentStream,
+                out OfficeIMO.Word.LegacyDoc.Model.LegacyDocFib fib,
+                out string? fibError), fibError);
+
+            Assert.False(OfficeIMO.Word.LegacyDoc.Model.LegacyDocPieceTable.TryRead(
+                wordDocumentStream,
+                tableStream,
+                fib,
+                maxDecodedCharacters: 4,
+                out _,
+                out string? error));
+            Assert.Contains("not monotonic", error, StringComparison.Ordinal);
+        }
+
+        [Fact]
         public void LegacyDoc_AllPublicLoadShapesEnforceTheCompleteInputBudget() {
             byte[] bytes = LegacyDocTestBuilder.CreateSimpleDoc("Bounded legacy input");
             var options = new LegacyDocImportOptions { MaxInputBytes = bytes.Length - 1 };

--- a/OfficeIMO.Word/LegacyDoc/LegacyDocImportOptions.cs
+++ b/OfficeIMO.Word/LegacyDoc/LegacyDocImportOptions.cs
@@ -11,6 +11,9 @@ namespace OfficeIMO.Word.LegacyDoc {
         /// <summary>Maximum aggregate decoded OfficeArt image bytes retained during import.</summary>
         public int MaxDecodedImageBytes { get; set; } = 64 * 1024 * 1024;
 
+        /// <summary>Maximum number of text characters decoded from the legacy piece table.</summary>
+        public int MaxDecodedCharacters { get; set; } = 16 * 1024 * 1024;
+
         /// <summary>
         /// When true, known unsupported legacy content is reported as diagnostics.
         /// </summary>
@@ -19,6 +22,7 @@ namespace OfficeIMO.Word.LegacyDoc {
         internal void Validate() {
             if (MaxInputBytes <= 0) throw new ArgumentOutOfRangeException(nameof(MaxInputBytes));
             if (MaxDecodedImageBytes <= 0) throw new ArgumentOutOfRangeException(nameof(MaxDecodedImageBytes));
+            if (MaxDecodedCharacters <= 0) throw new ArgumentOutOfRangeException(nameof(MaxDecodedCharacters));
         }
 
     }

--- a/OfficeIMO.Word/LegacyDoc/Model/LegacyDocDocument.cs
+++ b/OfficeIMO.Word/LegacyDoc/Model/LegacyDocDocument.cs
@@ -162,7 +162,7 @@ namespace OfficeIMO.Word.LegacyDoc.Model {
             DifferentOddAndEvenPages = ReadDopFacingPagesFlag(tableStream, fib);
             EndnotePositionValues? dopEndnotePosition = ReadDopEndnotePlacement(tableStream, fib);
 
-            if (!LegacyDocPieceTable.TryRead(wordDocumentStream, tableStream, fib, out LegacyDocTextContent textContent, out string? textError)) {
+            if (!LegacyDocPieceTable.TryRead(wordDocumentStream, tableStream, fib, options.MaxDecodedCharacters, out LegacyDocTextContent textContent, out string? textError)) {
                 AddError("DOC-PIECE-TABLE-INVALID", textError ?? "The legacy DOC piece table could not be decoded.");
                 return;
             }

--- a/OfficeIMO.Word/LegacyDoc/Model/LegacyDocPieceTable.cs
+++ b/OfficeIMO.Word/LegacyDoc/Model/LegacyDocPieceTable.cs
@@ -5,20 +5,25 @@ namespace OfficeIMO.Word.LegacyDoc.Model {
         private const uint CompressedTextFlag = 0x40000000;
         private const uint FcMask = 0x3FFFFFFF;
 
-        internal static bool TryRead(byte[] wordDocumentStream, byte[] tableStream, LegacyDocFib fib, out LegacyDocTextContent content, out string? error) {
+        internal static bool TryRead(byte[] wordDocumentStream, byte[] tableStream, LegacyDocFib fib, int maxDecodedCharacters, out LegacyDocTextContent content, out string? error) {
             content = new LegacyDocTextContent(string.Empty, Array.Empty<LegacyDocTextCharacter>());
             error = null;
-            int totalCharacterCount = checked(fib.CcpText
+            long totalCharacterCountLong = (long)fib.CcpText
                 + fib.CcpFtn
                 + fib.CcpHdd
                 + fib.CcpAtn
                 + fib.CcpEdn
                 + fib.CcpTxbx
-                + fib.CcpHdrTxbx);
+                + fib.CcpHdrTxbx;
 
-            if (totalCharacterCount == 0) {
+            if (totalCharacterCountLong == 0) {
                 return true;
             }
+            if (totalCharacterCountLong < 0 || totalCharacterCountLong > maxDecodedCharacters || totalCharacterCountLong > int.MaxValue) {
+                error = "The FIB decoded character count exceeds MaxDecodedCharacters.";
+                return false;
+            }
+            int totalCharacterCount = (int)totalCharacterCountLong;
 
             if (fib.FcClx < 0 || fib.LcbClx <= 0 || fib.FcClx + fib.LcbClx > tableStream.Length) {
                 error = "The FIB points outside the selected table stream for the CLX piece table.";

--- a/OfficeIMO.Word/LegacyDoc/Model/LegacyDocPieceTable.cs
+++ b/OfficeIMO.Word/LegacyDoc/Model/LegacyDocPieceTable.cs
@@ -64,16 +64,23 @@ namespace OfficeIMO.Word.LegacyDoc.Model {
             int cpArrayOffset = pcdOffset;
             int pcdArrayOffset = cpArrayOffset + ((pieceCount + 1) * 4);
 
+            long appendedCharacterCount = 0;
             for (int i = 0; i < pieceCount; i++) {
                 int cpStart = LegacyDocFib.ReadInt32(tableStream, cpArrayOffset + (i * 4));
                 int cpEnd = LegacyDocFib.ReadInt32(tableStream, cpArrayOffset + ((i + 1) * 4));
-                if (cpEnd <= cpStart) {
+                if (cpStart < 0 || cpEnd < cpStart || cpEnd > totalCharacterCount) {
+                    error = "The PLCFPCD character positions are not monotonic or exceed the FIB character count.";
+                    return false;
+                }
+                if (cpEnd == cpStart) {
                     continue;
                 }
 
-                int decodedCharacterCount = Math.Min(cpEnd, totalCharacterCount) - cpStart;
-                if (decodedCharacterCount <= 0) {
-                    break;
+                int decodedCharacterCount = cpEnd - cpStart;
+                appendedCharacterCount += decodedCharacterCount;
+                if (appendedCharacterCount > maxDecodedCharacters || appendedCharacterCount > totalCharacterCount) {
+                    error = "The PLCFPCD decoded character count exceeds MaxDecodedCharacters.";
+                    return false;
                 }
 
                 uint fcCompressed = unchecked((uint)LegacyDocFib.ReadInt32(tableStream, pcdArrayOffset + (i * 8) + 2));

--- a/OfficeIMO.Word/LegacyDoc/Model/LegacyDocPieceTable.cs
+++ b/OfficeIMO.Word/LegacyDoc/Model/LegacyDocPieceTable.cs
@@ -68,15 +68,18 @@ namespace OfficeIMO.Word.LegacyDoc.Model {
             for (int i = 0; i < pieceCount; i++) {
                 int cpStart = LegacyDocFib.ReadInt32(tableStream, cpArrayOffset + (i * 4));
                 int cpEnd = LegacyDocFib.ReadInt32(tableStream, cpArrayOffset + ((i + 1) * 4));
-                if (cpStart < 0 || cpEnd < cpStart || cpEnd > totalCharacterCount) {
-                    error = "The PLCFPCD character positions are not monotonic or exceed the FIB character count.";
+                if (cpStart < 0 || cpEnd < cpStart) {
+                    error = "The PLCFPCD character positions are not monotonic.";
                     return false;
                 }
                 if (cpEnd == cpStart) {
                     continue;
                 }
 
-                int decodedCharacterCount = cpEnd - cpStart;
+                int decodedCharacterCount = Math.Min(cpEnd, totalCharacterCount) - cpStart;
+                if (decodedCharacterCount <= 0) {
+                    break;
+                }
                 appendedCharacterCount += decodedCharacterCount;
                 if (appendedCharacterCount > maxDecodedCharacters || appendedCharacterCount > totalCharacterCount) {
                     error = "The PLCFPCD decoded character count exceeds MaxDecodedCharacters.";

--- a/OfficeIMO.Word/WordDocument.Conversion.cs
+++ b/OfficeIMO.Word/WordDocument.Conversion.cs
@@ -260,6 +260,7 @@ namespace OfficeIMO.Word {
             return new LegacyDocImportOptions {
                 MaxInputBytes = options.MaxInputBytes,
                 MaxDecodedImageBytes = options.MaxDecodedImageBytes,
+                MaxDecodedCharacters = options.MaxDecodedCharacters,
                 // Conversion loss policy depends on complete unsupported-content discovery.
                 ReportUnsupportedContent = true
             };

--- a/OfficeIMO.Word/WordFieldUpdater.Formulas.cs
+++ b/OfficeIMO.Word/WordFieldUpdater.Formulas.cs
@@ -1506,11 +1506,13 @@ namespace OfficeIMO.Word {
                 }
 
                 bool negativeExponent = power < 0;
-                power = Math.Abs(power);
-
+                long remaining = Math.Abs((long)power);
                 decimal result = 1m;
-                for (int i = 0; i < power; i++) {
-                    result *= value;
+                decimal factor = value;
+                while (remaining > 0) {
+                    if ((remaining & 1L) != 0) result *= factor;
+                    remaining >>= 1;
+                    if (remaining > 0) factor *= factor;
                 }
 
                 return negativeExponent ? 1m / result : result;

--- a/OfficeIMO.Word/WordFieldUpdater.Formulas.cs
+++ b/OfficeIMO.Word/WordFieldUpdater.Formulas.cs
@@ -1030,15 +1030,15 @@ namespace OfficeIMO.Word {
             }
 
             private decimal ParseTerm() {
-                decimal value = ParsePower();
+                decimal value = ParseUnary();
 
                 while (true) {
                     SkipWhitespace();
 
                     if (TryConsume('*')) {
-                        value *= ParsePower();
+                        value *= ParseUnary();
                     } else if (TryConsume('/')) {
-                        decimal divisor = ParsePower();
+                        decimal divisor = ParseUnary();
                         if (divisor == 0m) {
                             throw new DivideByZeroException();
                         }
@@ -1051,21 +1051,24 @@ namespace OfficeIMO.Word {
             }
 
             private decimal ParsePower() {
-                var operands = new List<decimal> { ParseUnary() };
+                var operands = new List<decimal> { ParsePostfix() };
+                var signs = new List<int> { 1 };
                 while (true) {
                     SkipWhitespace();
                     if (!TryConsume('^')) {
                         break;
                     }
-                    operands.Add(ParseUnary());
+                    signs.Add(ParseUnarySign());
+                    operands.Add(ParsePostfix());
                 }
 
-                decimal value = operands[operands.Count - 1];
+                decimal value = signs[signs.Count - 1] * operands[operands.Count - 1];
                 for (int i = operands.Count - 2; i >= 0; i--) {
                     if (decimal.Truncate(value) != value) {
                         throw new InvalidOperationException("Formula exponent must be an integer.");
                     }
                     value = DecimalPower(operands[i], value);
+                    value *= signs[i];
                 }
                 return value;
             }
@@ -1073,19 +1076,29 @@ namespace OfficeIMO.Word {
             private decimal ParseUnary() {
                 EnterSyntax();
                 try {
-                    SkipWhitespace();
-
-                    if (TryConsume('+')) {
-                        return ParseUnary();
-                    }
-
-                    if (TryConsume('-')) {
-                        return -ParseUnary();
-                    }
-
-                    return ParsePostfix();
+                    return ParseUnarySign() * ParsePower();
                 } finally {
                     _syntaxDepth--;
+                }
+            }
+
+            private int ParseUnarySign() {
+                int sign = 1;
+                int operators = 0;
+                while (true) {
+                    SkipWhitespace();
+                    if (TryConsume('+')) {
+                        operators++;
+                    } else if (TryConsume('-')) {
+                        sign = -sign;
+                        operators++;
+                    } else {
+                        return sign;
+                    }
+
+                    if (operators > MaxSyntaxDepth) {
+                        throw new InvalidOperationException($"Formula expression exceeds the supported syntax depth of {MaxSyntaxDepth}.");
+                    }
                 }
             }
 

--- a/OfficeIMO.Word/WordFieldUpdater.Formulas.cs
+++ b/OfficeIMO.Word/WordFieldUpdater.Formulas.cs
@@ -938,8 +938,11 @@ namespace OfficeIMO.Word {
         }
 
         private sealed class FormulaExpressionParser {
+            private const int MaxExpressionLength = 16_384;
+            private const int MaxSyntaxDepth = 128;
             private readonly string _expression;
             private int _position;
+            private int _syntaxDepth;
 
             private FormulaExpressionParser(string expression) {
                 _expression = expression;
@@ -948,6 +951,11 @@ namespace OfficeIMO.Word {
             internal static bool TryEvaluate(string expression, out decimal result, out string? diagnostic) {
                 result = 0m;
                 diagnostic = null;
+
+                if (expression.Length > MaxExpressionLength) {
+                    diagnostic = $"Formula expression exceeds the supported length of {MaxExpressionLength} characters.";
+                    return false;
+                }
 
                 try {
                     var parser = new FormulaExpressionParser(expression);
@@ -977,26 +985,31 @@ namespace OfficeIMO.Word {
             private char CurrentChar => IsAtEnd ? '\0' : _expression[_position];
 
             private decimal ParseComparison() {
-                decimal value = ParseExpression();
+                EnterSyntax();
+                try {
+                    decimal value = ParseExpression();
 
-                while (true) {
-                    SkipWhitespace();
+                    while (true) {
+                        SkipWhitespace();
 
-                    if (TryConsume("<>")) {
-                        value = value != ParseExpression() ? 1m : 0m;
-                    } else if (TryConsume("<=")) {
-                        value = value <= ParseExpression() ? 1m : 0m;
-                    } else if (TryConsume(">=")) {
-                        value = value >= ParseExpression() ? 1m : 0m;
-                    } else if (TryConsume("=")) {
-                        value = value == ParseExpression() ? 1m : 0m;
-                    } else if (TryConsume("<")) {
-                        value = value < ParseExpression() ? 1m : 0m;
-                    } else if (TryConsume(">")) {
-                        value = value > ParseExpression() ? 1m : 0m;
-                    } else {
-                        return value;
+                        if (TryConsume("<>")) {
+                            value = value != ParseExpression() ? 1m : 0m;
+                        } else if (TryConsume("<=")) {
+                            value = value <= ParseExpression() ? 1m : 0m;
+                        } else if (TryConsume(">=")) {
+                            value = value >= ParseExpression() ? 1m : 0m;
+                        } else if (TryConsume("=")) {
+                            value = value == ParseExpression() ? 1m : 0m;
+                        } else if (TryConsume("<")) {
+                            value = value < ParseExpression() ? 1m : 0m;
+                        } else if (TryConsume(">")) {
+                            value = value > ParseExpression() ? 1m : 0m;
+                        } else {
+                            return value;
+                        }
                     }
+                } finally {
+                    _syntaxDepth--;
                 }
             }
 
@@ -1038,33 +1051,50 @@ namespace OfficeIMO.Word {
             }
 
             private decimal ParsePower() {
-                decimal value = ParseUnary();
-                SkipWhitespace();
-
-                if (!TryConsume('^')) {
-                    return value;
+                var operands = new List<decimal> { ParseUnary() };
+                while (true) {
+                    SkipWhitespace();
+                    if (!TryConsume('^')) {
+                        break;
+                    }
+                    operands.Add(ParseUnary());
                 }
 
-                decimal exponent = ParsePower();
-                if (decimal.Truncate(exponent) != exponent) {
-                    throw new InvalidOperationException("Formula exponent must be an integer.");
+                decimal value = operands[operands.Count - 1];
+                for (int i = operands.Count - 2; i >= 0; i--) {
+                    if (decimal.Truncate(value) != value) {
+                        throw new InvalidOperationException("Formula exponent must be an integer.");
+                    }
+                    value = DecimalPower(operands[i], value);
                 }
-
-                return DecimalPower(value, exponent);
+                return value;
             }
 
             private decimal ParseUnary() {
-                SkipWhitespace();
+                EnterSyntax();
+                try {
+                    SkipWhitespace();
 
-                if (TryConsume('+')) {
-                    return ParseUnary();
+                    if (TryConsume('+')) {
+                        return ParseUnary();
+                    }
+
+                    if (TryConsume('-')) {
+                        return -ParseUnary();
+                    }
+
+                    return ParsePostfix();
+                } finally {
+                    _syntaxDepth--;
                 }
+            }
 
-                if (TryConsume('-')) {
-                    return -ParseUnary();
+            private void EnterSyntax() {
+                _syntaxDepth++;
+                if (_syntaxDepth > MaxSyntaxDepth) {
+                    _syntaxDepth--;
+                    throw new InvalidOperationException($"Formula expression exceeds the supported syntax depth of {MaxSyntaxDepth}.");
                 }
-
-                return ParsePostfix();
             }
 
             private decimal ParsePostfix() {


### PR DESCRIPTION
## Summary

- Bounds document-driven work across Excel, PowerPoint, Word, PDF, CSV, AsciiDoc, HTML, and OpenDocument processing paths.
- Replaces repeated scans or recursive processing with forward-only, iterative, or aggregate-budgeted implementations.
- Preserves actionable malformed-image diagnostics while requiring complete PNG containers.
- Adds focused regression coverage for every changed security boundary.

## Findings

This batch covers findings 121–140: 18 confirmed findings are fixed here, while 2 were already covered by the preceding stacked batches.

Fixed:

- `403f4caca5d481918f16f77e50fac607` — page-margin content amplification
- `f44ddba21704819194a8cf9a9e144789` — quadratic AsciiDoc escape handling
- `25b01eb3c5f88191bdc35c2cd4d618bf` — PowerPoint animation inspection exhaustion
- `9d8974645c648191b5b4943dbec4da60` — ODS formula recursion
- `ba0ef655f8248191aff2cc619cfe83df` — shared PowerPoint snapshot group depth
- `b191e8091ac88191bec0635d386de5f6` — Excel DataReader range buffering
- `6f67d4486dec819191c812e3e3bdb33d` — PDF image-mask dimensions
- `f344872d5fe08191ae679cdf85409090` — compressed CSV expansion
- `f6ae9100102481919b6644b28f7d8254` — flag icon range enumeration
- `4eab45c881788191a4fe155023bba529` — Word exponent evaluation
- `7a90b3247ae48191b4bb2853335bea97` — legacy DOC FIB and piece-table counts
- `fd05ab73546c8191affcc232c547c309` — malformed PNG worksheet images
- `3dbeb9f19ec48191a61e35dda53fedf0` — chart cache point counts
- `bc008fc4bb0c8191a2bd6882f2521739` — HTML two-cell anchors
- `0970cb836ee881918ea2abd38fe93f68` — presenter-notes scanning
- `ea0d0c025ed081918edf68f198f5df4e` — SVG ID namespacing
- `f36c255d7b1c8191a4ede742ebb1be8c` — chart formula ranges
- `3bd5524b4d1c8191a7a6343f7c6ef340` — conditional-format evaluation

Already covered by earlier stacked changes:

- `964db83aee74819189ae9471cf2a49ef` — repeated HTML backgrounds during PDF export
- `242301170d4c81919760e464f98b6bad` — table-span grid expansion

## Validation

- Current-head full suites: Drawing 945/945, PDF 3131/3131, Excel 2503 passed with 5 opt-in skips, Word 2437 passed with 9 opt-in skips.
- Additional full suites: HTML 1166/1166, CSV 296/296, OpenDocument 101/101, AsciiDoc 87/87.
- PowerPoint: 1350 passed, 2 skipped, with 8 existing fixture/baseline failures reproduced outside these paths.
- Multi-target builds succeeded for the affected Word, Excel, PowerPoint, HTML, Excel.Html, PowerPoint.Html, and current PDF targets. The repository's existing netstandard2.0 `Dictionary.TryAdd` failure remains outside this change.
- One existing Word content-detection assertion remains and was reproduced on the parent branch.
- An independent read-only review identified seven budget bypasses; all were fixed and the targeted confirmation found them resolved. No hosted review was requested.
