### PR TITLE
Bound adversarial Excel and CSV processing

### DIFF
--- a/OfficeIMO.CSV.Tests/CsvDocumentBasicsTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvDocumentBasicsTests.cs
@@ -46,6 +46,30 @@ public class CsvDocumentBasicsTests
     }
 
     [Fact]
+    public void Lenient_Multiline_Record_Uses_Flexible_Parser_State()
+    {
+        CsvDocument parsed = CsvDocument.Parse(
+            "A,\"a\" \"b\"\nc\"\n",
+            new CsvLoadOptions { HasHeaderRow = false, TrimWhitespace = true });
+
+        CsvRow row = parsed.AsEnumerable().Single();
+        Assert.Equal("A", row.AsString("Column1"));
+        Assert.Equal("a\"b\nc", row.AsString("Column2"));
+    }
+
+    [Fact]
+    public void Lenient_Multiline_TextDelimiter_Record_Uses_Flexible_Parser_State()
+    {
+        CsvDocument parsed = CsvDocument.Parse(
+            "A||\"a\" \"b\"\nc\"\n",
+            new CsvLoadOptions { HasHeaderRow = false, TrimWhitespace = true, DelimiterText = "||" });
+
+        CsvRow row = parsed.AsEnumerable().Single();
+        Assert.Equal("A", row.AsString("Column1"));
+        Assert.Equal("a\"b\nc", row.AsString("Column2"));
+    }
+
+    [Fact]
     public void RoundTrip_ToString_ParsesBack()
     {
         var doc = new CsvDocument()

--- a/OfficeIMO.CSV.Tests/CsvDocumentBasicsTests.cs
+++ b/OfficeIMO.CSV.Tests/CsvDocumentBasicsTests.cs
@@ -10,6 +10,42 @@ namespace OfficeIMO.CSV.Tests;
 public class CsvDocumentBasicsTests
 {
     [Fact]
+    public void Quoted_Field_Delimiters_Do_Not_Inflate_Field_Allocation()
+    {
+        string value = new string(',', 100_000);
+
+        CsvDocument parsed = CsvDocument.Parse(
+            "\"" + value + "\"\n",
+            new CsvLoadOptions { HasHeaderRow = false });
+
+        Assert.Equal(value, parsed.AsEnumerable().Single().AsString("Column1"));
+    }
+
+    [Fact]
+    public void Multiline_Quoted_Record_Is_Parsed_Without_Reparsing_Each_Prefix()
+    {
+        string value = string.Join("\n", Enumerable.Repeat("payload", 5_000));
+
+        CsvDocument parsed = CsvDocument.Parse(
+            "\"" + value + "\",done\n",
+            new CsvLoadOptions { HasHeaderRow = false });
+
+        CsvRow row = parsed.AsEnumerable().Single();
+        Assert.Equal(value, row.AsString("Column1"));
+        Assert.Equal("done", row.AsString("Column2"));
+    }
+
+    [Fact]
+    public void Unterminated_Multiline_Quote_Fails_After_A_Single_Forward_Scan()
+    {
+        string value = "\"" + string.Join("\n", Enumerable.Repeat("payload", 5_000));
+
+        Assert.Throws<CsvParseException>(() => CsvDocument.Parse(
+            value,
+            new CsvLoadOptions { HasHeaderRow = false }));
+    }
+
+    [Fact]
     public void RoundTrip_ToString_ParsesBack()
     {
         var doc = new CsvDocument()

--- a/OfficeIMO.CSV/CsvDocument.DelimiterDetection.cs
+++ b/OfficeIMO.CSV/CsvDocument.DelimiterDetection.cs
@@ -128,13 +128,15 @@ public sealed partial class CsvDocument
         var pendingLines = new Queue<string>();
         while (TryReadDelimiterDetectionLine(reader, pendingLines, out var line))
         {
-            if (shouldSkipRawCommentRecord(line) && !IsLogicalDelimiterDetectionRecordComplete(line))
+            var inQuotes = false;
+            UpdateLogicalDelimiterDetectionQuoteState(line, ref inQuotes);
+            if (shouldSkipRawCommentRecord(line) && inQuotes)
             {
                 SkipRawDelimiterDetectionCommentRecord(reader, pendingLines, line, isHeaderCandidate);
                 continue;
             }
 
-            if (IsLogicalDelimiterDetectionRecordComplete(line))
+            if (!inQuotes)
             {
                 yield return line;
                 continue;
@@ -145,7 +147,8 @@ public sealed partial class CsvDocument
             {
                 record.Append('\n');
                 record.Append(line);
-                if (IsLogicalDelimiterDetectionRecordComplete(record.ToString()))
+                UpdateLogicalDelimiterDetectionQuoteState(line, ref inQuotes);
+                if (!inQuotes)
                 {
                     break;
                 }
@@ -181,11 +184,13 @@ public sealed partial class CsvDocument
         Func<string, bool> isHeaderCandidate)
     {
         var continuations = new List<string>();
+        var inQuotes = false;
+        UpdateLogicalDelimiterDetectionQuoteState(firstLine, ref inQuotes);
         while (reader.ReadLine() is { } next)
         {
             continuations.Add(next);
-            var candidate = string.Concat(firstLine, "\n", next);
-            if (IsLogicalDelimiterDetectionRecordComplete(candidate))
+            UpdateLogicalDelimiterDetectionQuoteState(next, ref inQuotes);
+            if (!inQuotes)
             {
                 return;
             }
@@ -195,8 +200,6 @@ public sealed partial class CsvDocument
                 EnqueueDelimiterDetectionContinuations(pendingLines, continuations);
                 return;
             }
-
-            firstLine = candidate;
         }
 
         EnqueueDelimiterDetectionContinuations(pendingLines, continuations);
@@ -213,14 +216,20 @@ public sealed partial class CsvDocument
     private static bool IsLogicalDelimiterDetectionRecordComplete(string record)
     {
         var inQuotes = false;
-        for (var i = 0; i < record.Length; i++)
+        UpdateLogicalDelimiterDetectionQuoteState(record, ref inQuotes);
+        return !inQuotes;
+    }
+
+    private static void UpdateLogicalDelimiterDetectionQuoteState(string text, ref bool inQuotes)
+    {
+        for (var i = 0; i < text.Length; i++)
         {
-            if (record[i] != '"')
+            if (text[i] != '"')
             {
                 continue;
             }
 
-            if (inQuotes && i + 1 < record.Length && record[i + 1] == '"')
+            if (inQuotes && i + 1 < text.Length && text[i + 1] == '"')
             {
                 i++;
                 continue;
@@ -228,8 +237,6 @@ public sealed partial class CsvDocument
 
             inQuotes = !inQuotes;
         }
-
-        return !inQuotes;
     }
 
     private static bool ShouldSkipCommentDuringDelimiterDetection(string line, CsvLoadOptions options, bool useHeaderDiscovery, bool allowPreHeaderCommentSkip)

--- a/OfficeIMO.CSV/CsvParser.Quoted.cs
+++ b/OfficeIMO.CSV/CsvParser.Quoted.cs
@@ -42,6 +42,7 @@ internal static partial class CsvParser
         var inQuotes = false;
         var fieldWasQuoted = false;
         var afterClosingQuote = false;
+        var bufferIsWhitespaceOnly = true;
 
         for (var i = 0; i < text.Length; i++)
         {
@@ -55,6 +56,7 @@ internal static partial class CsvParser
                     {
                         i++;
                         buffer.Append('"');
+                        bufferIsWhitespaceOnly = false;
                     }
                     else
                     {
@@ -65,6 +67,10 @@ internal static partial class CsvParser
                 else
                 {
                     buffer.Append(c);
+                    if (!char.IsWhiteSpace(c))
+                    {
+                        bufferIsWhitespaceOnly = false;
+                    }
                 }
 
                 continue;
@@ -75,11 +81,12 @@ internal static partial class CsvParser
                 if (afterClosingQuote)
                 {
                     buffer.Append(c);
+                    bufferIsWhitespaceOnly = false;
                     afterClosingQuote = false;
                     continue;
                 }
 
-                if (trim && IsWhitespaceOnly(buffer))
+                if (trim && bufferIsWhitespaceOnly)
                 {
                     buffer.Clear();
                 }
@@ -92,6 +99,7 @@ internal static partial class CsvParser
             if (c == delimiter)
             {
                 AddQuotedField(parsedFields, buffer, trim, ref fieldWasQuoted);
+                bufferIsWhitespaceOnly = true;
                 afterClosingQuote = false;
                 continue;
             }
@@ -103,6 +111,10 @@ internal static partial class CsvParser
 
             afterClosingQuote = false;
             buffer.Append(c);
+            if (!char.IsWhiteSpace(c))
+            {
+                bufferIsWhitespaceOnly = false;
+            }
         }
 
         if (inQuotes)
@@ -144,12 +156,114 @@ internal static partial class CsvParser
     private static bool TryParseQuotedRecordLenient(string text, char delimiter, bool trim, List<string> fields) =>
         TryParseQuotedRecord(text, delimiter, trim, strictQuotes: false, lineNumber: 0, fields);
 
+    private static bool TryParseQuotedRecordWithContinuations(
+        CsvLineReader reader,
+        Queue<CsvLine> pendingLines,
+        string firstLine,
+        string firstLineSeparator,
+        char delimiter,
+        bool trim,
+        bool strictQuotes,
+        CsvLoadOptions options,
+        ref int lineNumber,
+        out string[] fields)
+    {
+        if (TryParseQuotedRecord(firstLine, delimiter, trim, strictQuotes, lineNumber, out fields))
+        {
+            return true;
+        }
+
+        var logicalRecord = new StringBuilder(firstLine);
+        var pendingSeparator = firstLineSeparator;
+        var inQuotes = false;
+        UpdateQuotedRecordState(firstLine, ref inQuotes);
+        while (inQuotes)
+        {
+            ThrowIfCancellationRequested(options);
+            var next = ReadLineWithSeparator(reader, pendingLines, out var nextSeparator);
+            if (next == null)
+            {
+                fields = Array.Empty<string>();
+                return false;
+            }
+
+            logicalRecord.Append(pendingSeparator);
+            logicalRecord.Append(next);
+            lineNumber++;
+            UpdateQuotedRecordState(next, ref inQuotes);
+            pendingSeparator = nextSeparator;
+        }
+
+        return TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, strictQuotes, lineNumber, out fields);
+    }
+
+    private static bool TryParseQuotedRecordWithContinuations(
+        CsvLineReader reader,
+        Queue<CsvLine> pendingLines,
+        string firstLine,
+        string firstLineSeparator,
+        char delimiter,
+        bool trim,
+        bool strictQuotes,
+        CsvLoadOptions options,
+        ref int lineNumber,
+        List<string> fields)
+    {
+        if (TryParseQuotedRecord(firstLine, delimiter, trim, strictQuotes, lineNumber, fields))
+        {
+            return true;
+        }
+
+        var logicalRecord = new StringBuilder(firstLine);
+        var pendingSeparator = firstLineSeparator;
+        var inQuotes = false;
+        UpdateQuotedRecordState(firstLine, ref inQuotes);
+        while (inQuotes)
+        {
+            ThrowIfCancellationRequested(options);
+            var next = ReadLineWithSeparator(reader, pendingLines, out var nextSeparator);
+            if (next == null)
+            {
+                fields.Clear();
+                return false;
+            }
+
+            logicalRecord.Append(pendingSeparator);
+            logicalRecord.Append(next);
+            lineNumber++;
+            UpdateQuotedRecordState(next, ref inQuotes);
+            pendingSeparator = nextSeparator;
+        }
+
+        return TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, strictQuotes, lineNumber, fields);
+    }
+
+    private static void UpdateQuotedRecordState(string text, ref bool inQuotes)
+    {
+        for (var index = 0; index < text.Length; index++)
+        {
+            if (text[index] != '"')
+            {
+                continue;
+            }
+
+            if (inQuotes && index + 1 < text.Length && text[index + 1] == '"')
+            {
+                index++;
+                continue;
+            }
+
+            inQuotes = !inQuotes;
+        }
+    }
+
     private static bool TryParseFlexibleQuotedRecord(string text, char delimiter, bool trim, List<string> parsedFields)
     {
         var buffer = new StringBuilder();
         var inQuotes = false;
         var fieldWasQuoted = false;
         var afterClosingQuote = false;
+        var bufferIsWhitespaceOnly = true;
 
         for (var i = 0; i < text.Length; i++)
         {
@@ -163,6 +277,7 @@ internal static partial class CsvParser
                     {
                         i++;
                         buffer.Append('"');
+                        bufferIsWhitespaceOnly = false;
                     }
                     else
                     {
@@ -173,6 +288,10 @@ internal static partial class CsvParser
                 else
                 {
                     buffer.Append(c);
+                    if (!char.IsWhiteSpace(c))
+                    {
+                        bufferIsWhitespaceOnly = false;
+                    }
                 }
 
                 continue;
@@ -183,11 +302,12 @@ internal static partial class CsvParser
                 if (afterClosingQuote)
                 {
                     buffer.Append(c);
+                    bufferIsWhitespaceOnly = false;
                     afterClosingQuote = false;
                     continue;
                 }
 
-                if (trim && IsWhitespaceOnly(buffer))
+                if (trim && bufferIsWhitespaceOnly)
                 {
                     buffer.Clear();
                 }
@@ -200,6 +320,7 @@ internal static partial class CsvParser
             if (c == delimiter)
             {
                 AddQuotedField(parsedFields, buffer, trim, ref fieldWasQuoted);
+                bufferIsWhitespaceOnly = true;
                 afterClosingQuote = false;
                 continue;
             }
@@ -211,6 +332,10 @@ internal static partial class CsvParser
 
             afterClosingQuote = false;
             buffer.Append(c);
+            if (!char.IsWhiteSpace(c))
+            {
+                bufferIsWhitespaceOnly = false;
+            }
         }
 
         if (inQuotes)
@@ -492,12 +617,13 @@ internal static partial class CsvParser
         var inQuotes = false;
         var fieldWasQuoted = false;
         var afterClosingQuote = false;
+        var bufferIsWhitespaceOnly = true;
         var line = firstLine;
         var lineSeparator = firstLineSeparator;
 
         while (true)
         {
-            ParseQuotedLineSegment(line, delimiter, trim, parsedFields, buffer, ref inQuotes, ref fieldWasQuoted, ref afterClosingQuote);
+            ParseQuotedLineSegment(line, delimiter, trim, parsedFields, buffer, ref inQuotes, ref fieldWasQuoted, ref afterClosingQuote, ref bufferIsWhitespaceOnly);
             if (!inQuotes)
             {
                 AddQuotedField(parsedFields, buffer, trim, ref fieldWasQuoted);
@@ -525,7 +651,8 @@ internal static partial class CsvParser
         StringBuilder buffer,
         ref bool inQuotes,
         ref bool fieldWasQuoted,
-        ref bool afterClosingQuote)
+        ref bool afterClosingQuote,
+        ref bool bufferIsWhitespaceOnly)
     {
         for (var i = 0; i < text.Length; i++)
         {
@@ -539,6 +666,7 @@ internal static partial class CsvParser
                     {
                         i++;
                         buffer.Append('"');
+                        bufferIsWhitespaceOnly = false;
                     }
                     else
                     {
@@ -549,6 +677,10 @@ internal static partial class CsvParser
                 else
                 {
                     buffer.Append(c);
+                    if (!char.IsWhiteSpace(c))
+                    {
+                        bufferIsWhitespaceOnly = false;
+                    }
                 }
 
                 continue;
@@ -559,11 +691,12 @@ internal static partial class CsvParser
                 if (afterClosingQuote)
                 {
                     buffer.Append(c);
+                    bufferIsWhitespaceOnly = false;
                     afterClosingQuote = false;
                     continue;
                 }
 
-                if (trim && IsWhitespaceOnly(buffer))
+                if (trim && bufferIsWhitespaceOnly)
                 {
                     buffer.Clear();
                 }
@@ -576,6 +709,7 @@ internal static partial class CsvParser
             if (c == delimiter)
             {
                 AddQuotedField(parsedFields, buffer, trim, ref fieldWasQuoted);
+                bufferIsWhitespaceOnly = true;
                 afterClosingQuote = false;
                 continue;
             }
@@ -587,6 +721,10 @@ internal static partial class CsvParser
 
             afterClosingQuote = false;
             buffer.Append(c);
+            if (!char.IsWhiteSpace(c))
+            {
+                bufferIsWhitespaceOnly = false;
+            }
         }
     }
 #endif
@@ -861,19 +999,6 @@ internal static partial class CsvParser
     }
 #endif
 
-    private static bool IsWhitespaceOnly(StringBuilder buffer)
-    {
-        for (var i = 0; i < buffer.Length; i++)
-        {
-            if (!char.IsWhiteSpace(buffer[i]))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
     private static bool TryParseStrictQuotedRecord(string text, char delimiter, bool trim, out string[] fields)
     {
         if (text.Length == 0)
@@ -883,9 +1008,14 @@ internal static partial class CsvParser
         }
 
         var fieldCount = 1;
+        var inQuotes = false;
         for (var i = 0; i < text.Length; i++)
         {
-            if (text[i] == delimiter)
+            if (text[i] == '"')
+            {
+                inQuotes = !inQuotes;
+            }
+            else if (text[i] == delimiter && !inQuotes)
             {
                 fieldCount++;
             }

--- a/OfficeIMO.CSV/CsvParser.Quoted.cs
+++ b/OfficeIMO.CSV/CsvParser.Quoted.cs
@@ -175,9 +175,9 @@ internal static partial class CsvParser
 
         var logicalRecord = new StringBuilder(firstLine);
         var pendingSeparator = firstLineSeparator;
-        var inQuotes = false;
-        UpdateQuotedRecordState(firstLine, ref inQuotes);
-        while (inQuotes)
+        var state = new QuotedRecordState();
+        UpdateQuotedRecordState(firstLine, delimiter, trim, ref state);
+        while (state.InQuotes)
         {
             ThrowIfCancellationRequested(options);
             var next = ReadLineWithSeparator(reader, pendingLines, out var nextSeparator);
@@ -190,7 +190,7 @@ internal static partial class CsvParser
             logicalRecord.Append(pendingSeparator);
             logicalRecord.Append(next);
             lineNumber++;
-            UpdateQuotedRecordState(next, ref inQuotes);
+            UpdateQuotedRecordState(next, delimiter, trim, ref state);
             pendingSeparator = nextSeparator;
         }
 
@@ -216,9 +216,9 @@ internal static partial class CsvParser
 
         var logicalRecord = new StringBuilder(firstLine);
         var pendingSeparator = firstLineSeparator;
-        var inQuotes = false;
-        UpdateQuotedRecordState(firstLine, ref inQuotes);
-        while (inQuotes)
+        var state = new QuotedRecordState();
+        UpdateQuotedRecordState(firstLine, delimiter, trim, ref state);
+        while (state.InQuotes)
         {
             ThrowIfCancellationRequested(options);
             var next = ReadLineWithSeparator(reader, pendingLines, out var nextSeparator);
@@ -231,29 +231,82 @@ internal static partial class CsvParser
             logicalRecord.Append(pendingSeparator);
             logicalRecord.Append(next);
             lineNumber++;
-            UpdateQuotedRecordState(next, ref inQuotes);
+            UpdateQuotedRecordState(next, delimiter, trim, ref state);
             pendingSeparator = nextSeparator;
         }
 
         return TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, strictQuotes, lineNumber, fields);
     }
 
-    private static void UpdateQuotedRecordState(string text, ref bool inQuotes)
+    private struct QuotedRecordState
+    {
+        internal bool InQuotes;
+        internal bool AfterClosingQuote;
+    }
+
+    private static void UpdateQuotedRecordState(string text, char delimiter, bool trim, ref QuotedRecordState state) =>
+        UpdateQuotedRecordState(text, delimiter, null, trim, ref state);
+
+    private static void UpdateQuotedRecordState(string text, string delimiter, bool trim, ref QuotedRecordState state) =>
+        UpdateQuotedRecordState(text, default, delimiter, trim, ref state);
+
+    private static void UpdateQuotedRecordState(
+        string text,
+        char delimiter,
+        string? delimiterText,
+        bool trim,
+        ref QuotedRecordState state)
     {
         for (var index = 0; index < text.Length; index++)
         {
-            if (text[index] != '"')
+            var current = text[index];
+            if (state.InQuotes)
+            {
+                if (current != '"')
+                {
+                    continue;
+                }
+
+                if (index + 1 < text.Length && text[index + 1] == '"')
+                {
+                    index++;
+                    continue;
+                }
+
+                state.InQuotes = false;
+                state.AfterClosingQuote = true;
+                continue;
+            }
+
+            var delimiterLength = delimiterText == null ? 1 : delimiterText.Length;
+            var isDelimiter = delimiterText == null
+                ? current == delimiter
+                : StartsWithDelimiter(text, delimiterText, index);
+            if (isDelimiter)
+            {
+                state.AfterClosingQuote = false;
+                index += delimiterLength - 1;
+                continue;
+            }
+
+            if (current == '"')
+            {
+                if (state.AfterClosingQuote)
+                {
+                    state.AfterClosingQuote = false;
+                    continue;
+                }
+
+                state.InQuotes = true;
+                continue;
+            }
+
+            if (state.AfterClosingQuote && trim && char.IsWhiteSpace(current))
             {
                 continue;
             }
 
-            if (inQuotes && index + 1 < text.Length && text[index + 1] == '"')
-            {
-                index++;
-                continue;
-            }
-
-            inQuotes = !inQuotes;
+            state.AfterClosingQuote = false;
         }
     }
 

--- a/OfficeIMO.CSV/CsvParser.ReusableEnumerable.cs
+++ b/OfficeIMO.CSV/CsvParser.ReusableEnumerable.cs
@@ -115,30 +115,9 @@ internal static partial class CsvParser
 
             try
             {
-                if (!TryParseQuotedRecord(line, delimiter, trim, strictQuotes, lineNumber, reusableQuotedRecord))
+                if (!TryParseQuotedRecordWithContinuations(lineReader, pendingLines, line, lineSeparator, delimiter, trim, strictQuotes, options, ref lineNumber, reusableQuotedRecord))
                 {
-                    var logicalRecord = new StringBuilder(line);
-                    var pendingSeparator = lineSeparator;
-                    while (true)
-                    {
-                        ThrowIfCancellationRequested(options);
-                        var next = ReadLineWithSeparator(lineReader, pendingLines, out var nextSeparator);
-                        if (next == null)
-                        {
-                            throw new CsvParseException("Unterminated quoted field.", lineNumber);
-                        }
-
-                        logicalRecord.Append(pendingSeparator);
-                        logicalRecord.Append(next);
-                        lineNumber++;
-
-                        if (TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, strictQuotes, lineNumber, reusableQuotedRecord))
-                        {
-                            break;
-                        }
-
-                        pendingSeparator = nextSeparator;
-                    }
+                    throw new CsvParseException("Unterminated quoted field.", lineNumber);
                 }
             }
             catch (CsvParseException ex) when (HandleParseError(options, ex, lineNumber))

--- a/OfficeIMO.CSV/CsvParser.ReusableHeader.cs
+++ b/OfficeIMO.CSV/CsvParser.ReusableHeader.cs
@@ -131,30 +131,9 @@ internal static partial class CsvParser
 
             try
             {
-                if (!TryParseQuotedRecord(line, delimiter, trim, strictQuotes, lineNumber, reusableQuotedRecord))
+                if (!TryParseQuotedRecordWithContinuations(lineReader, pendingLines, line, lineSeparator, delimiter, trim, strictQuotes, options, ref lineNumber, reusableQuotedRecord))
                 {
-                    var logicalRecord = new System.Text.StringBuilder(line);
-                    var pendingSeparator = lineSeparator;
-                    while (true)
-                    {
-                        ThrowIfCancellationRequested(options);
-                        var next = ReadLineWithSeparator(lineReader, pendingLines, out var nextSeparator);
-                        if (next == null)
-                        {
-                            throw new CsvParseException("Unterminated quoted field.", lineNumber);
-                        }
-
-                        logicalRecord.Append(pendingSeparator);
-                        logicalRecord.Append(next);
-                        lineNumber++;
-
-                        if (TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, strictQuotes, lineNumber, reusableQuotedRecord))
-                        {
-                            break;
-                        }
-
-                        pendingSeparator = nextSeparator;
-                    }
+                    throw new CsvParseException("Unterminated quoted field.", lineNumber);
                 }
             }
             catch (CsvParseException ex) when (HandleParseError(options, ex, lineNumber))

--- a/OfficeIMO.CSV/CsvParser.TextDelimiter.cs
+++ b/OfficeIMO.CSV/CsvParser.TextDelimiter.cs
@@ -115,9 +115,9 @@ internal static partial class CsvParser
                 {
                     var logicalRecord = new StringBuilder(line);
                     var pendingSeparator = lineSeparator;
-                    var inQuotes = false;
-                    UpdateQuotedRecordState(line, ref inQuotes);
-                    while (inQuotes)
+                    var state = new QuotedRecordState();
+                    UpdateQuotedRecordState(line, delimiter, trim, ref state);
+                    while (state.InQuotes)
                     {
                         ThrowIfCancellationRequested(options);
                         var next = lineReader.ReadLine(out var nextSeparator);
@@ -129,7 +129,7 @@ internal static partial class CsvParser
                         logicalRecord.Append(pendingSeparator);
                         logicalRecord.Append(next);
                         lineNumber++;
-                        UpdateQuotedRecordState(next, ref inQuotes);
+                        UpdateQuotedRecordState(next, delimiter, trim, ref state);
                         pendingSeparator = nextSeparator;
                     }
 
@@ -320,8 +320,8 @@ internal static partial class CsvParser
         }
 
         var continuationCount = 0;
-        var inQuotes = false;
-        UpdateQuotedRecordState(firstLine, ref inQuotes);
+        var state = new QuotedRecordState();
+        UpdateQuotedRecordState(firstLine, delimiter, trim, ref state);
         while (true)
         {
             ThrowIfCancellationRequested(options);
@@ -332,8 +332,8 @@ internal static partial class CsvParser
             }
 
             continuationCount++;
-            UpdateQuotedRecordState(next, ref inQuotes);
-            if (!inQuotes)
+            UpdateQuotedRecordState(next, delimiter, trim, ref state);
+            if (!state.InQuotes)
             {
                 lineNumber += continuationCount;
                 return true;

--- a/OfficeIMO.CSV/CsvParser.TextDelimiter.cs
+++ b/OfficeIMO.CSV/CsvParser.TextDelimiter.cs
@@ -115,7 +115,9 @@ internal static partial class CsvParser
                 {
                     var logicalRecord = new StringBuilder(line);
                     var pendingSeparator = lineSeparator;
-                    while (true)
+                    var inQuotes = false;
+                    UpdateQuotedRecordState(line, ref inQuotes);
+                    while (inQuotes)
                     {
                         ThrowIfCancellationRequested(options);
                         var next = lineReader.ReadLine(out var nextSeparator);
@@ -127,13 +129,13 @@ internal static partial class CsvParser
                         logicalRecord.Append(pendingSeparator);
                         logicalRecord.Append(next);
                         lineNumber++;
-
-                        if (TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, strictQuotes, lineNumber, out fields))
-                        {
-                            break;
-                        }
-
+                        UpdateQuotedRecordState(next, ref inQuotes);
                         pendingSeparator = nextSeparator;
+                    }
+
+                    if (!TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, strictQuotes, lineNumber, out fields))
+                    {
+                        throw new CsvParseException("Unterminated quoted field.", lineNumber);
                     }
                 }
             }
@@ -193,6 +195,7 @@ internal static partial class CsvParser
         var inQuotes = false;
         var fieldWasQuoted = false;
         var afterClosingQuote = false;
+        var bufferIsWhitespaceOnly = true;
 
         for (var i = 0; i < text.Length; i++)
         {
@@ -206,6 +209,7 @@ internal static partial class CsvParser
                     {
                         i++;
                         buffer.Append('"');
+                        bufferIsWhitespaceOnly = false;
                     }
                     else
                     {
@@ -216,6 +220,10 @@ internal static partial class CsvParser
                 else
                 {
                     buffer.Append(c);
+                    if (!char.IsWhiteSpace(c))
+                    {
+                        bufferIsWhitespaceOnly = false;
+                    }
                 }
 
                 continue;
@@ -224,6 +232,7 @@ internal static partial class CsvParser
             if (StartsWithDelimiter(text, delimiter, i))
             {
                 AddQuotedField(parsedFields, buffer, trim, ref fieldWasQuoted);
+                bufferIsWhitespaceOnly = true;
                 afterClosingQuote = false;
                 i += delimiter.Length - 1;
                 continue;
@@ -239,11 +248,12 @@ internal static partial class CsvParser
                     }
 
                     buffer.Append(c);
+                    bufferIsWhitespaceOnly = false;
                     afterClosingQuote = false;
                     continue;
                 }
 
-                if (trim && IsWhitespaceOnly(buffer))
+                if (trim && bufferIsWhitespaceOnly)
                 {
                     buffer.Clear();
                 }
@@ -265,6 +275,10 @@ internal static partial class CsvParser
 
             afterClosingQuote = false;
             buffer.Append(c);
+            if (!char.IsWhiteSpace(c))
+            {
+                bufferIsWhitespaceOnly = false;
+            }
         }
 
         if (inQuotes)
@@ -305,28 +319,25 @@ internal static partial class CsvParser
             return true;
         }
 
-        var logicalRecord = new StringBuilder(firstLine);
-        var pendingSeparator = firstLineSeparator;
         var continuationCount = 0;
+        var inQuotes = false;
+        UpdateQuotedRecordState(firstLine, ref inQuotes);
         while (true)
         {
             ThrowIfCancellationRequested(options);
-            var next = reader.ReadLine(out var nextSeparator);
+            var next = reader.ReadLine(out _);
             if (next == null)
             {
                 return true;
             }
 
             continuationCount++;
-            logicalRecord.Append(pendingSeparator);
-            logicalRecord.Append(next);
-            if (TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, strictQuotes: false, lineNumber, out _))
+            UpdateQuotedRecordState(next, ref inQuotes);
+            if (!inQuotes)
             {
                 lineNumber += continuationCount;
                 return true;
             }
-
-            pendingSeparator = nextSeparator;
         }
     }
 

--- a/OfficeIMO.CSV/CsvParser.cs
+++ b/OfficeIMO.CSV/CsvParser.cs
@@ -225,30 +225,9 @@ internal static partial class CsvParser
             string[] fields;
             try
             {
-                if (!TryParseQuotedRecord(line, delimiter, trim, strictQuotes, lineNumber, out fields))
+                if (!TryParseQuotedRecordWithContinuations(lineReader, pendingLines, line, lineSeparator, delimiter, trim, strictQuotes, options, ref lineNumber, out fields))
                 {
-                    var logicalRecord = new StringBuilder(line);
-                    var pendingSeparator = lineSeparator;
-                    while (true)
-                    {
-                        ThrowIfCancellationRequested(options);
-                        var next = ReadLineWithSeparator(lineReader, pendingLines, out var nextSeparator);
-                        if (next == null)
-                        {
-                            throw new CsvParseException("Unterminated quoted field.", lineNumber);
-                        }
-
-                        logicalRecord.Append(pendingSeparator);
-                        logicalRecord.Append(next);
-                        lineNumber++;
-
-                        if (TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, strictQuotes, lineNumber, out fields))
-                        {
-                            break;
-                        }
-
-                        pendingSeparator = nextSeparator;
-                    }
+                    throw new CsvParseException("Unterminated quoted field.", lineNumber);
                 }
             }
             catch (CsvParseException ex) when (HandleParseError(options, ex, lineNumber))
@@ -333,30 +312,9 @@ internal static partial class CsvParser
             string[] fields;
             try
             {
-                if (!TryParseQuotedRecord(line, delimiter, trim, strictQuotes, lineNumber, out fields))
+                if (!TryParseQuotedRecordWithContinuations(lineReader, pendingLines, line, lineSeparator, delimiter, trim, strictQuotes, options, ref lineNumber, out fields))
                 {
-                    var logicalRecord = new StringBuilder(line);
-                    var pendingSeparator = lineSeparator;
-                    while (true)
-                    {
-                        ThrowIfCancellationRequested(options);
-                        var next = ReadLineWithSeparator(lineReader, pendingLines, out var nextSeparator);
-                        if (next == null)
-                        {
-                            throw new CsvParseException("Unterminated quoted field.", lineNumber);
-                        }
-
-                        logicalRecord.Append(pendingSeparator);
-                        logicalRecord.Append(next);
-                        lineNumber++;
-
-                        if (TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, strictQuotes, lineNumber, out fields))
-                        {
-                            break;
-                        }
-
-                        pendingSeparator = nextSeparator;
-                    }
+                    throw new CsvParseException("Unterminated quoted field.", lineNumber);
                 }
             }
             catch (CsvParseException ex) when (HandleParseError(options, ex, lineNumber))
@@ -476,30 +434,9 @@ internal static partial class CsvParser
 
             try
             {
-                if (!TryParseQuotedRecord(line, delimiter, trim, strictQuotes, lineNumber, reusableQuotedRecord))
+                if (!TryParseQuotedRecordWithContinuations(lineReader, pendingLines, line, lineSeparator, delimiter, trim, strictQuotes, options, ref lineNumber, reusableQuotedRecord))
                 {
-                    var logicalRecord = new StringBuilder(line);
-                    var pendingSeparator = lineSeparator;
-                    while (true)
-                    {
-                        ThrowIfCancellationRequested(options);
-                        var next = ReadLineWithSeparator(lineReader, pendingLines, out var nextSeparator);
-                        if (next == null)
-                        {
-                            throw new CsvParseException("Unterminated quoted field.", lineNumber);
-                        }
-
-                        logicalRecord.Append(pendingSeparator);
-                        logicalRecord.Append(next);
-                        lineNumber++;
-
-                        if (TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, strictQuotes, lineNumber, reusableQuotedRecord))
-                        {
-                            break;
-                        }
-
-                        pendingSeparator = nextSeparator;
-                    }
+                    throw new CsvParseException("Unterminated quoted field.", lineNumber);
                 }
             }
             catch (CsvParseException ex) when (HandleParseError(options, ex, lineNumber))
@@ -619,30 +556,9 @@ internal static partial class CsvParser
 
             try
             {
-                if (!TryParseQuotedRecord(line, delimiter, trim, strictQuotes, lineNumber, reusableQuotedRecord))
+                if (!TryParseQuotedRecordWithContinuations(lineReader, pendingLines, line, lineSeparator, delimiter, trim, strictQuotes, options, ref lineNumber, reusableQuotedRecord))
                 {
-                    var logicalRecord = new StringBuilder(line);
-                    var pendingSeparator = lineSeparator;
-                    while (true)
-                    {
-                        ThrowIfCancellationRequested(options);
-                        var next = ReadLineWithSeparator(lineReader, pendingLines, out var nextSeparator);
-                        if (next == null)
-                        {
-                            throw new CsvParseException("Unterminated quoted field.", lineNumber);
-                        }
-
-                        logicalRecord.Append(pendingSeparator);
-                        logicalRecord.Append(next);
-                        lineNumber++;
-
-                        if (TryParseQuotedRecord(logicalRecord.ToString(), delimiter, trim, strictQuotes, lineNumber, reusableQuotedRecord))
-                        {
-                            break;
-                        }
-
-                        pendingSeparator = nextSeparator;
-                    }
+                    throw new CsvParseException("Unterminated quoted field.", lineNumber);
                 }
             }
             catch (CsvParseException ex) when (HandleParseError(options, ex, lineNumber))
@@ -959,9 +875,9 @@ internal static partial class CsvParser
             return true;
         }
 
-        var logicalRecord = new StringBuilder(firstLine);
-        var pendingSeparator = firstLineSeparator;
         var continuations = new List<CsvLine>();
+        var inQuotes = false;
+        UpdateQuotedRecordState(firstLine, ref inQuotes);
         while (true)
         {
             var next = ReadLineWithSeparator(reader, pendingLines, out var nextSeparator);
@@ -972,8 +888,8 @@ internal static partial class CsvParser
             }
 
             continuations.Add(new CsvLine(next, nextSeparator));
-            var candidate = string.Concat(logicalRecord.ToString(), pendingSeparator, next);
-            if (TryParseQuotedRecordLenient(candidate, delimiter, options.TrimWhitespace, out _))
+            UpdateQuotedRecordState(next, ref inQuotes);
+            if (!inQuotes)
             {
                 lineNumber += continuations.Count;
                 return true;
@@ -984,10 +900,6 @@ internal static partial class CsvParser
                 EnqueueContinuations(pendingLines, continuations);
                 return true;
             }
-
-            logicalRecord.Append(pendingSeparator);
-            logicalRecord.Append(next);
-            pendingSeparator = nextSeparator;
         }
     }
 

--- a/OfficeIMO.CSV/CsvParser.cs
+++ b/OfficeIMO.CSV/CsvParser.cs
@@ -876,8 +876,8 @@ internal static partial class CsvParser
         }
 
         var continuations = new List<CsvLine>();
-        var inQuotes = false;
-        UpdateQuotedRecordState(firstLine, ref inQuotes);
+        var state = new QuotedRecordState();
+        UpdateQuotedRecordState(firstLine, delimiter, options.TrimWhitespace, ref state);
         while (true)
         {
             var next = ReadLineWithSeparator(reader, pendingLines, out var nextSeparator);
@@ -888,8 +888,8 @@ internal static partial class CsvParser
             }
 
             continuations.Add(new CsvLine(next, nextSeparator));
-            UpdateQuotedRecordState(next, ref inQuotes);
-            if (!inQuotes)
+            UpdateQuotedRecordState(next, delimiter, options.TrimWhitespace, ref state);
+            if (!state.InQuotes)
             {
                 lineNumber += continuations.Count;
                 return true;

--- a/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.SheetData.ConditionalFormatting.cs
+++ b/OfficeIMO.Excel.Pdf/ExcelPdfConverterExtensions.SheetData.ConditionalFormatting.cs
@@ -41,10 +41,16 @@ namespace OfficeIMO.Excel.Pdf {
                 }
 
                 IReadOnlyList<double> candidateValues = candidates.Select(candidate => candidate.Value).ToArray();
+                if (!ExcelConditionalFormatThresholds.TryCreateColorScaleEvaluator(
+                        candidateValues,
+                        rule.ColorScaleColors,
+                        rule.ColorScaleThresholds,
+                        out ExcelConditionalFormatThresholds.ColorScaleEvaluator? colorScale) ||
+                    colorScale == null) {
+                    continue;
+                }
                 foreach (var candidate in candidates) {
-                    if (ExcelConditionalFormatThresholds.TryGetColorScaleRgb(candidateValues, rule.ColorScaleColors, rule.ColorScaleThresholds, candidate.Value, out string rgbHex)) {
-                        fills[(candidate.Row, candidate.Column)] = rgbHex;
-                    }
+                    fills[(candidate.Row, candidate.Column)] = colorScale.GetRgbHex(candidate.Value);
                 }
             }
 

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
@@ -39,6 +39,48 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ExcelChart_ImageExportPreservesOnePixelTwoCellAnchors() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("TinyAnchor");
+            sheet.CellValue(1, 1, "Category");
+            sheet.CellValue(1, 2, "Value");
+            sheet.CellValue(2, 1, "Only");
+            sheet.CellValue(2, 2, 1);
+            ExcelChart chart = sheet.AddChartFromRange("A1:B2", row: 1, column: 3);
+            ReplaceChartAnchorWithTwoCell(
+                document,
+                new Xdr.FromMarker(new Xdr.ColumnId("0"), new Xdr.ColumnOffset("0"), new Xdr.RowId("0"), new Xdr.RowOffset("0")),
+                new Xdr.ToMarker(new Xdr.ColumnId("0"), new Xdr.ColumnOffset("9525"), new Xdr.RowId("0"), new Xdr.RowOffset("9525")));
+
+            Assert.True(chart.TryGetSnapshot(out ExcelChartSnapshot snapshot));
+            Assert.Equal(1, snapshot.WidthPixels);
+            Assert.Equal(1, snapshot.HeightPixels);
+        }
+
+        [Fact]
+        public void ExcelChart_ImageExportRefreshesTwoCellGeometryAfterWorksheetMutation() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("MutableGeometry");
+            sheet.CellValue(1, 1, "Category");
+            sheet.CellValue(1, 2, "Value");
+            sheet.CellValue(2, 1, "Only");
+            sheet.CellValue(2, 2, 1);
+            ExcelChart chart = sheet.AddChartFromRange("A1:B2", row: 1, column: 3);
+            ReplaceChartAnchorWithTwoCell(
+                document,
+                new Xdr.FromMarker(new Xdr.ColumnId("0"), new Xdr.ColumnOffset("0"), new Xdr.RowId("0"), new Xdr.RowOffset("0")),
+                new Xdr.ToMarker(new Xdr.ColumnId("1"), new Xdr.ColumnOffset("0"), new Xdr.RowId("1"), new Xdr.RowOffset("0")));
+
+            Assert.True(chart.TryGetSnapshot(out ExcelChartSnapshot before));
+            sheet.SetColumnWidth(1, 30D);
+            sheet.SetRowHeight(1, 45D);
+            Assert.True(chart.TryGetSnapshot(out ExcelChartSnapshot after));
+
+            Assert.True(after.WidthPixels > before.WidthPixels);
+            Assert.True(after.HeightPixels > before.HeightPixels);
+        }
+
+        [Fact]
         public void ExcelRange_ImageExportPreservesScatterSeriesCachedXYValues() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             using ExcelDocument document = ExcelDocument.Create(filePath);
@@ -569,6 +611,23 @@ namespace OfficeIMO.Tests {
             reference.Append(new NumberingCache(
                 new PointCount { Val = pointCount },
                 new NumericPoint(new NumericValue("1")) { Index = 0U }));
+        }
+
+        private static void ReplaceChartAnchorWithTwoCell(
+            ExcelDocument document,
+            Xdr.FromMarker fromMarker,
+            Xdr.ToMarker toMarker) {
+            ChartPart chartPart = GetFirstChartPart(document);
+            DrawingsPart drawingsPart = chartPart.GetParentParts().OfType<DrawingsPart>().Single();
+            Xdr.OneCellAnchor oneCellAnchor = Assert.Single(drawingsPart.WorksheetDrawing!.Elements<Xdr.OneCellAnchor>());
+            Xdr.GraphicFrame frame = oneCellAnchor.GetFirstChild<Xdr.GraphicFrame>()!;
+            frame.Remove();
+            oneCellAnchor.Remove();
+            drawingsPart.WorksheetDrawing.Append(new Xdr.TwoCellAnchor(
+                fromMarker,
+                toMarker,
+                frame,
+                new Xdr.ClientData()));
         }
 
         [Fact]

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
@@ -4,6 +4,7 @@ using DocumentFormat.OpenXml.Packaging;
 using OfficeIMO.Drawing;
 using OfficeIMO.Excel;
 using A = DocumentFormat.OpenXml.Drawing;
+using X = DocumentFormat.OpenXml.Spreadsheet;
 using Xdr = DocumentFormat.OpenXml.Drawing.Spreadsheet;
 using Xunit;
 
@@ -78,6 +79,31 @@ namespace OfficeIMO.Tests {
 
             Assert.True(after.WidthPixels > before.WidthPixels);
             Assert.True(after.HeightPixels > before.HeightPixels);
+        }
+
+        [Fact]
+        public void ExcelChart_ImageExportUsesCustomRowGeometryAfterInitialIndexBudget() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("LateGeometry");
+            sheet.CellValue(1, 1, "Category");
+            sheet.CellValue(1, 2, "Value");
+            sheet.CellValue(2, 1, "Only");
+            sheet.CellValue(2, 2, 1);
+            ExcelChart chart = sheet.AddChartFromRange("A1:B2", row: 1, column: 3);
+            ReplaceChartAnchorWithTwoCell(
+                document,
+                new Xdr.FromMarker(new Xdr.ColumnId("0"), new Xdr.ColumnOffset("0"), new Xdr.RowId("100000"), new Xdr.RowOffset("0")),
+                new Xdr.ToMarker(new Xdr.ColumnId("1"), new Xdr.ColumnOffset("0"), new Xdr.RowId("100001"), new Xdr.RowOffset("0")));
+
+            X.SheetData sheetData = sheet.WorksheetPart.Worksheet!.GetFirstChild<X.SheetData>()!;
+            sheetData.RemoveAllChildren<X.Row>();
+            for (uint index = 1; index <= 100000U; index++) {
+                sheetData.Append(new X.Row { RowIndex = index });
+            }
+            sheetData.Append(new X.Row { RowIndex = 100001U, Height = 60D, CustomHeight = true });
+
+            Assert.True(chart.TryGetSnapshot(out ExcelChartSnapshot snapshot));
+            Assert.Equal(80, snapshot.HeightPixels);
         }
 
         [Fact]

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
@@ -10,6 +10,21 @@ using Xunit;
 namespace OfficeIMO.Tests {
     public partial class ExcelImageExportTests {
         [Fact]
+        public void ExcelChart_ImageExportClampsUntrustedLineWidths() {
+            var properties = new ChartShapeProperties(
+                new A.Outline { Width = int.MaxValue });
+            System.Reflection.MethodInfo method = typeof(ExcelChart).GetMethod(
+                "TryGetLineWidth",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+            object?[] arguments = { properties, 0D };
+
+            bool resolved = (bool)method.Invoke(null, arguments)!;
+
+            Assert.True(resolved);
+            Assert.Equal(64D, Assert.IsType<double>(arguments[1]));
+        }
+
+        [Fact]
         public void ExcelRange_ImageExportPreservesScatterSeriesCachedXYValues() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             using ExcelDocument document = ExcelDocument.Create(filePath);

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
@@ -101,6 +101,7 @@ namespace OfficeIMO.Tests {
                 sheetData.Append(new X.Row { RowIndex = index });
             }
             sheetData.Append(new X.Row { RowIndex = 100001U, Height = 60D, CustomHeight = true });
+            sheetData.Append(new X.Row { RowIndex = 100001U, Height = 30D, CustomHeight = true });
 
             Assert.True(chart.TryGetSnapshot(out ExcelChartSnapshot snapshot));
             Assert.Equal(80, snapshot.HeightPixels);

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.Charts.cs
@@ -25,6 +25,20 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ExcelChart_ImageExportClampsUntrustedMarkerOutlineWidths() {
+            var marker = new Marker(
+                new ChartShapeProperties(
+                    new A.Outline { Width = int.MaxValue }));
+            System.Reflection.MethodInfo method = typeof(ExcelChart).GetMethod(
+                "GetImageExportMarkerOutlineWidth",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+
+            double? width = (double?)method.Invoke(null, new object?[] { marker });
+
+            Assert.Equal(64D, width);
+        }
+
+        [Fact]
         public void ExcelRange_ImageExportPreservesScatterSeriesCachedXYValues() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             using ExcelDocument document = ExcelDocument.Create(filePath);

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.Objects.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.Objects.cs
@@ -573,6 +573,27 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ExcelRange_ImageExportClampsUntrustedDrawingShapeOutlineWidths() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorksheet("BoundedOutline");
+                sheet.CellValue(1, 1, "Shape");
+                document.Save();
+            }
+
+            AppendSupportedDrawingShape(
+                filePath,
+                "Bounded outline",
+                string.Empty,
+                strokeWidthEmu: int.MaxValue);
+
+            using ExcelDocument loaded = ExcelDocument.Load(filePath);
+            ExcelRangeVisualSnapshot snapshot = loaded.Sheets.Single().Range("A1:D4").CreateVisualSnapshot();
+
+            Assert.Equal(64D, Assert.Single(snapshot.DrawingObjects).StrokeWidth);
+        }
+
+        [Fact]
         public void ExcelRange_ImageExportRendersDrawingShapeEffectsThroughSharedDrawing() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             using (ExcelDocument document = ExcelDocument.Create(filePath)) {
@@ -1353,7 +1374,8 @@ namespace OfficeIMO.Tests {
             int? shadowAlpha = null,
             int shadowDistancePixels = 0,
             int shadowBlurPixels = 0,
-            int shadowDirectionDegrees = 0) {
+            int shadowDirectionDegrees = 0,
+            int? strokeWidthEmu = null) {
             using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true);
             WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
             DrawingsPart drawingsPart = worksheetPart.DrawingsPart ?? worksheetPart.AddNewPart<DrawingsPart>();
@@ -1363,7 +1385,7 @@ namespace OfficeIMO.Tests {
 
             drawingsPart.WorksheetDrawing ??= new Xdr.WorksheetDrawing();
             drawingsPart.WorksheetDrawing.Append(
-                CreateSupportedShapeAnchor(1, 1, toColumn, toRow, 2U, name, text, preset, horizontalFlip, verticalFlip, rotationDegrees, fillHex, strokeHex, paragraphAlignment, verticalAlignment, textColorHex, fillSchemeColor, fillLuminanceModulation, fillLuminanceOffset, strokeSchemeColor, textSchemeColor, textFontFamily, textFontSize, textBold, textItalic, textUnderline, textWrap, textShrinkToFit, textResizeShapeToFit, textOrientation, textInsetLeftEmu, textInsetTopEmu, textInsetRightEmu, textInsetBottomEmu, textHardBreak, offsetXPixels, offsetYPixels, strokeDash, strokeLineCap, strokeLineJoin, glowHex, glowAlpha, glowRadiusPixels, shadowHex, shadowAlpha, shadowDistancePixels, shadowBlurPixels, shadowDirectionDegrees));
+                CreateSupportedShapeAnchor(1, 1, toColumn, toRow, 2U, name, text, preset, horizontalFlip, verticalFlip, rotationDegrees, fillHex, strokeHex, paragraphAlignment, verticalAlignment, textColorHex, fillSchemeColor, fillLuminanceModulation, fillLuminanceOffset, strokeSchemeColor, textSchemeColor, textFontFamily, textFontSize, textBold, textItalic, textUnderline, textWrap, textShrinkToFit, textResizeShapeToFit, textOrientation, textInsetLeftEmu, textInsetTopEmu, textInsetRightEmu, textInsetBottomEmu, textHardBreak, offsetXPixels, offsetYPixels, strokeDash, strokeLineCap, strokeLineJoin, glowHex, glowAlpha, glowRadiusPixels, shadowHex, shadowAlpha, shadowDistancePixels, shadowBlurPixels, shadowDirectionDegrees, strokeWidthEmu));
             drawingsPart.WorksheetDrawing.Save();
             worksheetPart.Worksheet.Save();
         }
@@ -1514,7 +1536,8 @@ namespace OfficeIMO.Tests {
             int? shadowAlpha = null,
             int shadowDistancePixels = 0,
             int shadowBlurPixels = 0,
-            int shadowDirectionDegrees = 0) {
+            int shadowDirectionDegrees = 0,
+            int? strokeWidthEmu = null) {
             var transform = new A.Transform2D {
                 HorizontalFlip = horizontalFlip,
                 VerticalFlip = verticalFlip
@@ -1599,7 +1622,7 @@ namespace OfficeIMO.Tests {
 
             var outline = new A.Outline(
                 CreateSolidFill(strokeHex, strokeSchemeColor)) {
-                Width = 12700
+                Width = strokeWidthEmu ?? 12700
             };
             if (strokeDash.HasValue) {
                 outline.Append(new A.PresetDash { Val = strokeDash.Value });

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.SecurityBounds.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.SecurityBounds.cs
@@ -1,6 +1,7 @@
 using DocumentFormat.OpenXml;
 using OfficeIMO.Drawing;
 using OfficeIMO.Excel;
+using OfficeIMO.Excel.Utilities;
 using X = DocumentFormat.OpenXml.Spreadsheet;
 using Xdr = DocumentFormat.OpenXml.Drawing.Spreadsheet;
 using Xunit;
@@ -72,6 +73,44 @@ namespace OfficeIMO.Tests {
             Assert.True(chart.TryGetSnapshot(out ExcelChartSnapshot snapshot));
             Assert.True(snapshot.WidthPixels > 0);
             Assert.True(snapshot.HeightPixels > 0);
+        }
+
+        [Fact]
+        public void ExcelChart_ImageExportCountsInvalidColumnDefinitionsAgainstWorkBudget() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("InvalidColumns");
+            X.Worksheet worksheet = sheet.WorksheetPart.Worksheet!;
+            var columns = new X.Columns();
+            var invalid = new X.Column();
+            for (int index = 0; index < 100_000; index++) {
+                columns.Append((X.Column)invalid.CloneNode(true));
+            }
+            columns.Append(new X.Column { Min = 1U, Max = 1U, Width = 50D, CustomWidth = true });
+            worksheet.InsertBefore(columns, worksheet.GetFirstChild<X.SheetData>());
+
+            ExcelWorksheetGeometryIndex geometry = ExcelWorksheetGeometryIndex.Create(sheet.WorksheetPart);
+
+            Assert.Equal(64, geometry.GetSimpleColumnWidthPixels(1));
+        }
+
+        [Fact]
+        public void ExcelRange_ImageExportKeepsNearbyAnchorsThatOverlapThroughNegativeOffsets() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("NegativeOffset");
+            sheet.AddImage(
+                1,
+                2,
+                CreateSolidPng(8, 8, OfficeColor.FromRgb(37, 99, 235)),
+                widthPixels: 64,
+                heightPixels: 8,
+                offsetXPixels: -50,
+                name: "Overlap");
+
+            ExcelRangeVisualSnapshot snapshot = sheet.Range("A1:A1").CreateVisualSnapshot(
+                new ExcelImageExportOptions { ShowGridlines = false });
+
+            ExcelVisualImage image = Assert.Single(snapshot.Images);
+            Assert.InRange(image.X, 13D, 15D);
         }
     }
 }

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.SecurityBounds.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.SecurityBounds.cs
@@ -1,0 +1,77 @@
+using DocumentFormat.OpenXml;
+using OfficeIMO.Drawing;
+using OfficeIMO.Excel;
+using X = DocumentFormat.OpenXml.Spreadsheet;
+using Xdr = DocumentFormat.OpenXml.Drawing.Spreadsheet;
+using Xunit;
+
+namespace OfficeIMO.Tests {
+    public partial class ExcelImageExportTests {
+        [Fact]
+        public void ExcelRange_ImageExportKeepsAnchorsInsideTallRequestedRanges() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("TallRange");
+            sheet.AddImage(
+                15000,
+                1,
+                CreateSolidPng(8, 8, OfficeColor.FromRgb(37, 99, 235)),
+                "image/png",
+                widthPixels: 8,
+                heightPixels: 8,
+                name: "DeepAnchor");
+
+            ExcelRangeVisualSnapshot snapshot = sheet.Range("A1:A20000").CreateVisualSnapshot(
+                new ExcelImageExportOptions { ShowGridlines = false });
+
+            ExcelVisualImage image = Assert.Single(snapshot.Images);
+            Assert.Equal("TallRange!DeepAnchor", image.Source);
+        }
+
+        [Fact]
+        public void ExcelChart_ImageExportSkipsWorksheetGeometryForOneCellAnchors() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("OneCell");
+            sheet.CellValue(1, 1, "Category");
+            sheet.CellValue(1, 2, "Value");
+            sheet.CellValue(2, 1, "Only");
+            sheet.CellValue(2, 2, 1);
+            ExcelChart chart = sheet.AddChartFromRange("A1:B2", row: 1, column: 3);
+            X.Row invalidRow = new X.Row();
+            invalidRow.SetAttribute(new OpenXmlAttribute("r", string.Empty, "invalid"));
+            sheet.WorksheetPart.Worksheet!.GetFirstChild<X.SheetData>()!.Append(invalidRow);
+
+            Assert.True(chart.TryGetSnapshot(out ExcelChartSnapshot snapshot));
+            Assert.True(snapshot.WidthPixels > 0);
+            Assert.True(snapshot.HeightPixels > 0);
+        }
+
+        [Fact]
+        public void ExcelChart_ImageExportBoundsDuplicateRowDefinitionWork() {
+            using ExcelDocument document = ExcelDocument.Create(new MemoryStream());
+            ExcelSheet sheet = document.AddWorksheet("DuplicateRows");
+            sheet.CellValue(1, 1, "Category");
+            sheet.CellValue(1, 2, "Value");
+            sheet.CellValue(2, 1, "Only");
+            sheet.CellValue(2, 2, 1);
+            ExcelChart chart = sheet.AddChartFromRange("A1:B2", row: 1, column: 3);
+            ReplaceChartAnchorWithTwoCell(
+                document,
+                new Xdr.FromMarker(new Xdr.ColumnId("0"), new Xdr.ColumnOffset("0"), new Xdr.RowId("0"), new Xdr.RowOffset("0")),
+                new Xdr.ToMarker(new Xdr.ColumnId("1"), new Xdr.ColumnOffset("0"), new Xdr.RowId("1"), new Xdr.RowOffset("0")));
+
+            X.SheetData sheetData = sheet.WorksheetPart.Worksheet!.GetFirstChild<X.SheetData>()!;
+            X.Row duplicate = new X.Row { RowIndex = 1U };
+            sheetData.RemoveAllChildren<X.Row>();
+            for (int index = 0; index < 100_000; index++) {
+                sheetData.Append((X.Row)duplicate.CloneNode(true));
+            }
+            X.Row invalidRow = new X.Row();
+            invalidRow.SetAttribute(new OpenXmlAttribute("r", string.Empty, "invalid"));
+            sheetData.Append(invalidRow);
+
+            Assert.True(chart.TryGetSnapshot(out ExcelChartSnapshot snapshot));
+            Assert.True(snapshot.WidthPixels > 0);
+            Assert.True(snapshot.HeightPixels > 0);
+        }
+    }
+}

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.Sparklines.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.Sparklines.cs
@@ -118,6 +118,37 @@ namespace OfficeIMO.Tests {
             Assert.Contains(png.Diagnostics, item => item.Code == ExcelImageExportDiagnosticCodes.SparklineExternalRangeUnsupported && item.Source == "Summary!A1");
         }
 
+        [Fact]
+        public void ExcelRange_ImageExportSkipsOffscreenSparklineDataPrefetch() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            using ExcelDocument document = ExcelDocument.Create(filePath);
+            ExcelSheet sheet = document.AddWorksheet("Sparklines");
+            sheet.CellValue(1, 1, 1);
+            sheet.AddSparklines("A1:A100001", "Z1000");
+
+            ExcelRangeVisualSnapshot snapshot = sheet.Range("A1:A1").CreateVisualSnapshot();
+
+            Assert.Empty(snapshot.Sparklines);
+            Assert.DoesNotContain(snapshot.Diagnostics, diagnostic => diagnostic.Source == "Sparklines!Z1000");
+        }
+
+        [Fact]
+        public void ExcelRange_ImageExportRejectsOversizedVisibleSparklineDataRange() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            using ExcelDocument document = ExcelDocument.Create(filePath);
+            ExcelSheet sheet = document.AddWorksheet("Sparklines");
+            sheet.CellValue(1, 1, 1);
+            sheet.AddSparklines("A1:A100001", "B1");
+
+            ExcelRangeVisualSnapshot snapshot = sheet.Range("A1:B1").CreateVisualSnapshot();
+
+            Assert.Empty(snapshot.Sparklines);
+            Assert.Contains(
+                snapshot.Diagnostics,
+                diagnostic => diagnostic.Code == ExcelImageExportDiagnosticCodes.SparklineRangeUnsupported &&
+                    diagnostic.Source == "Sparklines!B1");
+        }
+
         private static int CountBluePixels(OfficeRasterImage image) {
             int count = 0;
             for (int y = 0; y < image.Height; y++) {

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.Sparklines.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.Sparklines.cs
@@ -97,6 +97,26 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ExcelRange_ImageExportIncludesOffRangeGroupMembersInSparklineScale() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            using ExcelDocument document = ExcelDocument.Create(filePath);
+            ExcelSheet sheet = document.AddWorksheet("PartialGroupScale");
+            sheet.CellValue(1, 1, 1);
+            sheet.CellValue(1, 2, 2);
+            sheet.CellValue(1, 3, 3);
+            sheet.CellValue(2, 1, 0);
+            sheet.CellValue(2, 2, 50);
+            sheet.CellValue(2, 3, 100);
+            sheet.AddSparklines("A1:C2", "D1:D2", SparklineTypeValues.Column, seriesColor: "#2563EB");
+
+            ExcelVisualSparkline visible = Assert.Single(sheet.Range("D1:D1").CreateVisualSnapshot().Sparklines);
+
+            Assert.Equal("PartialGroupScale!D1", visible.Source);
+            Assert.Equal(0D, visible.ScaleMinimum);
+            Assert.Equal(100D, visible.ScaleMaximum);
+        }
+
+        [Fact]
         public void ExcelRange_ImageExportReportsExternalSparklineRanges() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             using ExcelDocument document = ExcelDocument.Create(filePath);

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
@@ -269,6 +269,7 @@ namespace OfficeIMO.Tests {
             Assert.Equal("1/10", ExcelNumberFormatDisplay.FormatNumericText(0.1D, 13U, null, "0.1"));
             Assert.Equal("1/2", ExcelNumberFormatDisplay.FormatNumericText(0.5D, 1U, "# ?/2", "0.5"));
             Assert.Equal("1073741824/2147483647", ExcelNumberFormatDisplay.FormatNumericText(0.5D, 1U, "# ?/2147483647", "0.5"));
+            Assert.Equal("3221225471/2147483647", ExcelNumberFormatDisplay.FormatNumericText(1.5D, 1U, "?/2147483647", "1.5"));
             Assert.Equal("(1/2)", ExcelNumberFormatDisplay.FormatNumericText(-0.5D, 1U, "# ?/?;(# ?/?)", "-0.5"));
             Assert.Equal("1,235", ExcelNumberFormatDisplay.FormatNumericText(1234567D, 1U, "#,##0,", "1234567"));
             Assert.Equal("1 K", ExcelNumberFormatDisplay.FormatNumericText(1234D, 1U, "#,##0, \"K\"", "1234"));
@@ -869,6 +870,41 @@ namespace OfficeIMO.Tests {
 
                 Assert.Equal("FFFFFF00", snapshot.Cells.Single(cell => cell.Row == 3).Style.FillColorArgb);
             }
+        }
+
+        [Fact]
+        public void ExcelRange_ImageExportRejectsMalformedColorScaleStopCounts() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorksheet("MalformedColor");
+                for (int row = 1; row <= 4; row++) {
+                    sheet.CellValue(row, 1, row);
+                }
+
+                sheet.AddConditionalColorScale("A1:A4", OfficeColor.Red, OfficeColor.Green);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                Worksheet worksheet = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet;
+                ColorScale colorScale = worksheet.Descendants<ColorScale>().Single();
+                colorScale.RemoveAllChildren<ConditionalFormatValueObject>();
+                colorScale.RemoveAllChildren<X.Color>();
+                for (int index = 0; index < 4; index++) {
+                    colorScale.Append(new ConditionalFormatValueObject {
+                        Type = ConditionalFormatValueObjectValues.Number,
+                        Val = index.ToString(CultureInfo.InvariantCulture)
+                    });
+                    colorScale.Append(new X.Color { Rgb = "FF" + index.ToString("X6", CultureInfo.InvariantCulture) });
+                }
+
+                worksheet.Save();
+            }
+
+            using ExcelDocument loaded = ExcelDocument.Load(filePath);
+            ExcelRangeVisualSnapshot snapshot = loaded.Sheets.Single().Range("A1:A4").CreateVisualSnapshot();
+
+            Assert.All(snapshot.Cells, cell => Assert.Null(cell.Style.FillColorArgb));
         }
 
         [Fact]
@@ -1876,6 +1912,22 @@ namespace OfficeIMO.Tests {
             Assert.Equal("Merged title", mergedOrigin.Text);
             Assert.True(mergedOrigin.X < 0D, "The merged origin should keep its true negative X position relative to the selected range.");
             Assert.True(mergedOrigin.Width > snapshot.Width, "The merged origin should retain the full merged-cell width for clipping.");
+        }
+
+        [Fact]
+        public void ExcelRange_ImageExportBoundsMergedRangesBeforeExpansion() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            using ExcelDocument document = ExcelDocument.Create(filePath);
+            ExcelSheet sheet = document.AddWorksheet("MergedLimit");
+            sheet.CellValue(1, 1, "Bounded");
+            sheet.Range("A1:XFD1048576").Merge();
+
+            ExcelRangeVisualSnapshot snapshot = sheet.Range("A1:A1").CreateVisualSnapshot();
+
+            ExcelVisualCell cell = Assert.Single(snapshot.Cells);
+            Assert.Equal("Bounded", cell.Text);
+            Assert.True(cell.Width <= snapshot.Width);
+            Assert.True(cell.Height <= snapshot.Height);
         }
 
         [Fact]

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
@@ -1931,6 +1931,25 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void ExcelRange_ImageExportRetainsVisibleMergesAfterLargeOffRangeOrigin() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            using ExcelDocument document = ExcelDocument.Create(filePath);
+            ExcelSheet sheet = document.AddWorksheet("MergeBudget");
+            sheet.CellValue(1, 1, "Outside origin");
+            sheet.CellValue(1, 3, "Visible origin");
+            sheet.Range("A1:B50").Merge();
+            sheet.Range("C1:C2").Merge();
+
+            ExcelRangeVisualSnapshot snapshot = sheet.Range("B1:C2").CreateVisualSnapshot(
+                new ExcelImageExportOptions { MaximumRenderedCells = 100 });
+
+            Assert.Contains(snapshot.Cells, cell => cell.Row == 1 && cell.Column == 1 && !cell.CoveredByMerge);
+            ExcelVisualCell covered = snapshot.Cells.Single(cell => cell.Row == 2 && cell.Column == 3);
+            Assert.True(covered.CoveredByMerge);
+            Assert.True(snapshot.Cells.Single(cell => cell.Row == 1 && cell.Column == 3).Height > covered.Height);
+        }
+
+        [Fact]
         public void ExcelRange_ImageExportUsesTwoCellImageAnchorDimensions() {
             string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
             byte[] banner = CreateSolidPng(32, 32, OfficeColor.FromRgb(37, 99, 235));
@@ -1966,6 +1985,29 @@ namespace OfficeIMO.Tests {
             Assert.True(OfficePngReader.TryDecode(png.Bytes, out OfficeRasterImage? rendered));
             Assert.NotNull(rendered);
             AssertPixelNear(rendered!, Math.Min(rendered!.Width - 1, 120), Math.Min(rendered.Height - 1, 40), OfficeColor.FromRgb(37, 99, 235), tolerance: 3);
+        }
+
+        [Fact]
+        public void ExcelRange_ImageExportSaturatesOverflowingTwoCellAnchorOffsets() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            byte[] banner = CreateSolidPng(8, 8, OfficeColor.FromRgb(37, 99, 235));
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorksheet("AnchorOverflow");
+                sheet.CellValue(1, 1, "Anchor");
+                document.Save();
+            }
+
+            AddTwoCellAnchoredImage(
+                filePath,
+                banner,
+                fromColumnOffset: long.MinValue.ToString(CultureInfo.InvariantCulture),
+                toColumnOffset: long.MaxValue.ToString(CultureInfo.InvariantCulture),
+                toColumnId: "0");
+
+            using ExcelDocument loaded = ExcelDocument.Load(filePath);
+            ExcelImage image = Assert.Single(loaded.Sheets.Single().Images);
+
+            Assert.Equal(16384, image.WidthPixels);
         }
 
         [Fact]
@@ -4478,7 +4520,12 @@ namespace OfficeIMO.Tests {
             sheet.WorksheetPart.Worksheet.Save();
         }
 
-        private static void AddTwoCellAnchoredImage(string filePath, byte[] imageBytes) {
+        private static void AddTwoCellAnchoredImage(
+            string filePath,
+            byte[] imageBytes,
+            string fromColumnOffset = "0",
+            string toColumnOffset = "0",
+            string toColumnId = "3") {
             using SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true);
             WorksheetPart worksheetPart = spreadsheet.WorkbookPart!.WorksheetParts.First();
             DrawingsPart drawingsPart = worksheetPart.DrawingsPart ?? worksheetPart.AddNewPart<DrawingsPart>();
@@ -4497,12 +4544,12 @@ namespace OfficeIMO.Tests {
             drawingsPart.WorksheetDrawing.Append(new Xdr.TwoCellAnchor(
                 new Xdr.FromMarker(
                     new Xdr.ColumnId("0"),
-                    new Xdr.ColumnOffset("0"),
+                    new Xdr.ColumnOffset(fromColumnOffset),
                     new Xdr.RowId("0"),
                     new Xdr.RowOffset("0")),
                 new Xdr.ToMarker(
-                    new Xdr.ColumnId("3"),
-                    new Xdr.ColumnOffset("0"),
+                    new Xdr.ColumnId(toColumnId),
+                    new Xdr.ColumnOffset(toColumnOffset),
                     new Xdr.RowId("2"),
                     new Xdr.RowOffset("0")),
                 new Xdr.Picture(

--- a/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
+++ b/OfficeIMO.Excel.Tests/Excel.ImageExport.cs
@@ -267,6 +267,8 @@ namespace OfficeIMO.Tests {
             Assert.Equal("1 1/4", ExcelNumberFormatDisplay.FormatNumericText(1.25D, 12U, null, "1.25"));
             Assert.Equal("-1/2", ExcelNumberFormatDisplay.FormatNumericText(-0.5D, 12U, null, "-0.5"));
             Assert.Equal("1/10", ExcelNumberFormatDisplay.FormatNumericText(0.1D, 13U, null, "0.1"));
+            Assert.Equal("1/2", ExcelNumberFormatDisplay.FormatNumericText(0.5D, 1U, "# ?/2", "0.5"));
+            Assert.Equal("1073741824/2147483647", ExcelNumberFormatDisplay.FormatNumericText(0.5D, 1U, "# ?/2147483647", "0.5"));
             Assert.Equal("(1/2)", ExcelNumberFormatDisplay.FormatNumericText(-0.5D, 1U, "# ?/?;(# ?/?)", "-0.5"));
             Assert.Equal("1,235", ExcelNumberFormatDisplay.FormatNumericText(1234567D, 1U, "#,##0,", "1234567"));
             Assert.Equal("1 K", ExcelNumberFormatDisplay.FormatNumericText(1234D, 1U, "#,##0, \"K\"", "1234"));
@@ -831,6 +833,41 @@ namespace OfficeIMO.Tests {
                 Assert.Equal("FFFF0000", snapshot.Cells.Single(cell => cell.Row == 1 && cell.Column == 1).Style.FillColorArgb);
                 Assert.Equal("FFFFFF00", snapshot.Cells.Single(cell => cell.Row == 2 && cell.Column == 1).Style.FillColorArgb);
                 Assert.Equal("FF00FF00", snapshot.Cells.Single(cell => cell.Row == 3 && cell.Column == 1).Style.FillColorArgb);
+            }
+        }
+
+        [Fact]
+        public void ExcelRange_ImageExportHonorsPercentileColorScaleMiddleStop() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorksheet("PercentileColor");
+                int[] values = { 0, 10, 15, 20, 100 };
+                for (int row = 1; row <= values.Length; row++) {
+                    sheet.CellValue(row, 1, values[row - 1]);
+                }
+
+                sheet.AddConditionalColorScale("A1:A5", OfficeColor.Red, OfficeColor.Green);
+                document.Save();
+            }
+
+            using (SpreadsheetDocument spreadsheet = SpreadsheetDocument.Open(filePath, true)) {
+                Worksheet worksheet = spreadsheet.WorkbookPart!.WorksheetParts.First().Worksheet;
+                ColorScale colorScale = worksheet.Elements<ConditionalFormatting>().First().Elements<ConditionalFormattingRule>().First().GetFirstChild<ColorScale>()!;
+                colorScale.RemoveAllChildren<ConditionalFormatValueObject>();
+                colorScale.RemoveAllChildren<X.Color>();
+                colorScale.Append(new ConditionalFormatValueObject { Type = ConditionalFormatValueObjectValues.Min });
+                colorScale.Append(new ConditionalFormatValueObject { Type = ConditionalFormatValueObjectValues.Percentile, Val = "50" });
+                colorScale.Append(new ConditionalFormatValueObject { Type = ConditionalFormatValueObjectValues.Max });
+                colorScale.Append(new X.Color { Rgb = "FFFF0000" });
+                colorScale.Append(new X.Color { Rgb = "FFFFFF00" });
+                colorScale.Append(new X.Color { Rgb = "FF00FF00" });
+                worksheet.Save();
+            }
+
+            using (ExcelDocument document = ExcelDocument.Load(filePath)) {
+                ExcelRangeVisualSnapshot snapshot = document.Sheets.Single().Range("A1:A5").CreateVisualSnapshot();
+
+                Assert.Equal("FFFFFF00", snapshot.Cells.Single(cell => cell.Row == 3).Style.FillColorArgb);
             }
         }
 
@@ -2821,6 +2858,30 @@ namespace OfficeIMO.Tests {
                 Assert.Equal(220D, visualChart.Width);
                 Assert.Equal(120D, visualChart.Height);
             }
+        }
+
+        [Fact]
+        public void ExcelWorksheet_ImageExportRejectsDrawingExpandedRangesBeforeMaterialization() {
+            string filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xlsx");
+            using (ExcelDocument document = ExcelDocument.Create(filePath)) {
+                ExcelSheet sheet = document.AddWorksheet("BoundedDrawingRange");
+                sheet.CellValue(1, 1, "Category");
+                sheet.CellValue(1, 2, "Value");
+                sheet.CellValue(2, 1, "Item");
+                sheet.CellValue(2, 2, 1);
+                sheet.AddChartFromRange("A1:B2", row: 1, column: 3, widthPixels: 240, heightPixels: 140, type: ExcelChartType.ColumnClustered);
+                document.Save();
+            }
+
+            MoveFirstChartToAbsoluteAnchor(filePath, xPixels: 1_000_000, yPixels: 1_000_000, widthPixels: 1_000_000, heightPixels: 1_000_000);
+
+            using ExcelDocument loaded = ExcelDocument.Load(filePath);
+            InvalidOperationException error = Assert.Throws<InvalidOperationException>(() =>
+                loaded.Sheets.Single().ExportImage(
+                    OfficeImageExportFormat.Png,
+                    new ExcelWorksheetImageExportOptions { ShowGridlines = false }));
+
+            Assert.Contains("100000 rendered cells", error.Message, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/OfficeIMO.Excel/ExcelChart.ImageExport.cs
+++ b/OfficeIMO.Excel/ExcelChart.ImageExport.cs
@@ -10,8 +10,6 @@ using OfficeIMO.Excel.Utilities;
 
 namespace OfficeIMO.Excel {
     public sealed partial class ExcelChart {
-        private const double MaximumImageExportLineWidthPoints = 64D;
-
         private OfficeChartStyle? CreateImageExportStyle() {
             C.ChartSpace? chartSpace = GetChartPart().ChartSpace;
             if (chartSpace == null) {
@@ -680,7 +678,9 @@ namespace OfficeIMO.Excel {
                 .GetFirstChild<C.ChartShapeProperties>()?
                 .GetFirstChild<A.Outline>();
             long? emu = outline?.Width?.Value;
-            return emu.HasValue && emu.Value > 0 ? emu.Value / 12700D : null;
+            return emu.HasValue && emu.Value > 0
+                ? ExcelImageExportLimits.ClampStrokeWidth(emu.Value / 12700D)
+                : null;
         }
 
         private IReadOnlyList<OfficeImageExportDiagnostic> CreateImageExportDiagnostics() {
@@ -869,7 +869,7 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            width = Math.Min(MaximumImageExportLineWidthPoints, emu.Value / 12700D);
+            width = ExcelImageExportLimits.ClampStrokeWidth(emu.Value / 12700D);
             return true;
         }
 

--- a/OfficeIMO.Excel/ExcelChart.ImageExport.cs
+++ b/OfficeIMO.Excel/ExcelChart.ImageExport.cs
@@ -10,6 +10,8 @@ using OfficeIMO.Excel.Utilities;
 
 namespace OfficeIMO.Excel {
     public sealed partial class ExcelChart {
+        private const double MaximumImageExportLineWidthPoints = 64D;
+
         private OfficeChartStyle? CreateImageExportStyle() {
             C.ChartSpace? chartSpace = GetChartPart().ChartSpace;
             if (chartSpace == null) {
@@ -867,7 +869,7 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            width = emu.Value / 12700D;
+            width = Math.Min(MaximumImageExportLineWidthPoints, emu.Value / 12700D);
             return true;
         }
 

--- a/OfficeIMO.Excel/ExcelChart.cs
+++ b/OfficeIMO.Excel/ExcelChart.cs
@@ -20,16 +20,14 @@ namespace OfficeIMO.Excel {
         private readonly ExcelDocument _document;
         private readonly string _sheetName;
         private ExcelChartDataRange? _dataRange;
-        private ExcelWorksheetGeometryIndex? _worksheetGeometry;
 
-        internal ExcelChart(Xdr.GraphicFrame frame, DrawingsPart drawingsPart, ExcelSheet sheet, ExcelChartDataRange? dataRange = null, ExcelWorksheetGeometryIndex? worksheetGeometry = null) {
+        internal ExcelChart(Xdr.GraphicFrame frame, DrawingsPart drawingsPart, ExcelSheet sheet, ExcelChartDataRange? dataRange = null) {
             _frame = frame ?? throw new ArgumentNullException(nameof(frame));
             _drawingsPart = drawingsPart ?? throw new ArgumentNullException(nameof(drawingsPart));
             if (sheet == null) throw new ArgumentNullException(nameof(sheet));
             _document = sheet.Document;
             _sheetName = sheet.Name;
             _dataRange = dataRange;
-            _worksheetGeometry = worksheetGeometry;
         }
 
         /// <summary>
@@ -462,8 +460,8 @@ namespace OfficeIMO.Excel {
             return 0;
         }
 
-        private ExcelWorksheetGeometryIndex GetWorksheetGeometry(WorksheetPart? worksheetPart) =>
-            _worksheetGeometry ??= ExcelWorksheetGeometryIndex.Create(worksheetPart);
+        private static ExcelWorksheetGeometryIndex GetWorksheetGeometry(WorksheetPart? worksheetPart) =>
+            ExcelWorksheetGeometryIndex.Create(worksheetPart);
 
         private static bool TryGetTwoCellAnchorSizePixels(Xdr.TwoCellAnchor? anchor, WorksheetPart? worksheetPart, ExcelWorksheetGeometryIndex geometry, bool horizontal, out int pixels) {
             pixels = 0;
@@ -491,7 +489,7 @@ namespace OfficeIMO.Excel {
             int offsetPixels = EmuOffsetToPixels(toOffset - fromOffset);
             long totalPixels = Math.Max(1L, basePixels + offsetPixels);
             pixels = ExcelImageExportLimits.ClampExtentPixels((int)Math.Min(int.MaxValue, totalPixels));
-            return pixels > 1;
+            return pixels > 0;
         }
 
         private static double GetDefaultMaximumDigitWidth(WorksheetPart? worksheetPart) {

--- a/OfficeIMO.Excel/ExcelChart.cs
+++ b/OfficeIMO.Excel/ExcelChart.cs
@@ -65,8 +65,9 @@ namespace OfficeIMO.Excel {
 
             xPixels = ExcelImageExportLimits.ClampAbsoluteOffsetPixels(EmuOffsetToPixels(absoluteAnchor.Position?.X?.Value ?? 0L));
             yPixels = ExcelImageExportLimits.ClampAbsoluteOffsetPixels(EmuOffsetToPixels(absoluteAnchor.Position?.Y?.Value ?? 0L));
-            widthPixels = ExcelImageExportLimits.ClampExtentPixels(EmuToPixels(absoluteAnchor.Extent?.Cx?.Value, GetAnchorWidthPixels()));
-            heightPixels = ExcelImageExportLimits.ClampExtentPixels(EmuToPixels(absoluteAnchor.Extent?.Cy?.Value, GetAnchorHeightPixels()));
+            (int fallbackWidthPixels, int fallbackHeightPixels) = GetAnchorSizePixels();
+            widthPixels = ExcelImageExportLimits.ClampExtentPixels(EmuToPixels(absoluteAnchor.Extent?.Cx?.Value, fallbackWidthPixels));
+            heightPixels = ExcelImageExportLimits.ClampExtentPixels(EmuToPixels(absoluteAnchor.Extent?.Cy?.Value, fallbackHeightPixels));
             return widthPixels > 0 && heightPixels > 0;
         }
 
@@ -124,6 +125,7 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
+            (int anchorWidthPixels, int anchorHeightPixels) = GetAnchorSizePixels();
             snapshot = new ExcelChartSnapshot(
                 Name,
                 Title,
@@ -133,8 +135,8 @@ namespace OfficeIMO.Excel {
                 GetAnchorColumn(),
                 GetAnchorOffsetXPixels(),
                 GetAnchorOffsetYPixels(),
-                GetAnchorWidthPixels(),
-                GetAnchorHeightPixels(),
+                anchorWidthPixels,
+                anchorHeightPixels,
                 CreateImageExportStyle(),
                 CreateImageExportLayout(),
                 CreateImageExportDiagnostics());
@@ -419,26 +421,18 @@ namespace OfficeIMO.Excel {
             return EmuOffsetToPixels(ParseEmuOffset(marker?.RowOffset?.Text));
         }
 
-        private int GetAnchorWidthPixels() {
+        private (int WidthPixels, int HeightPixels) GetAnchorSizePixels() {
             Xdr.TwoCellAnchor? twoCellAnchor = _frame.Ancestors<Xdr.TwoCellAnchor>().FirstOrDefault();
-            WorksheetPart? worksheetPart = _drawingsPart.GetParentParts().OfType<WorksheetPart>().FirstOrDefault();
-            if (TryGetTwoCellAnchorSizePixels(twoCellAnchor, worksheetPart, GetWorksheetGeometry(worksheetPart), horizontal: true, out int widthPixels)) {
-                return widthPixels;
+            if (twoCellAnchor?.FromMarker != null && twoCellAnchor.ToMarker != null) {
+                WorksheetPart? worksheetPart = _drawingsPart.GetParentParts().OfType<WorksheetPart>().FirstOrDefault();
+                ExcelWorksheetGeometryIndex geometry = ExcelWorksheetGeometryIndex.Create(worksheetPart);
+                bool hasWidth = TryGetTwoCellAnchorSizePixels(twoCellAnchor, worksheetPart, geometry, horizontal: true, out int widthPixels);
+                bool hasHeight = TryGetTwoCellAnchorSizePixels(twoCellAnchor, worksheetPart, geometry, horizontal: false, out int heightPixels);
+                return (hasWidth ? widthPixels : 480, hasHeight ? heightPixels : 320);
             }
 
-            long? emu = _frame.Ancestors<Xdr.OneCellAnchor>().FirstOrDefault()?.Extent?.Cx?.Value;
-            return EmuToPixels(emu, 480);
-        }
-
-        private int GetAnchorHeightPixels() {
-            Xdr.TwoCellAnchor? twoCellAnchor = _frame.Ancestors<Xdr.TwoCellAnchor>().FirstOrDefault();
-            WorksheetPart? worksheetPart = _drawingsPart.GetParentParts().OfType<WorksheetPart>().FirstOrDefault();
-            if (TryGetTwoCellAnchorSizePixels(twoCellAnchor, worksheetPart, GetWorksheetGeometry(worksheetPart), horizontal: false, out int heightPixels)) {
-                return heightPixels;
-            }
-
-            long? emu = _frame.Ancestors<Xdr.OneCellAnchor>().FirstOrDefault()?.Extent?.Cy?.Value;
-            return EmuToPixels(emu, 320);
+            Xdr.Extent? extent = _frame.Ancestors<Xdr.OneCellAnchor>().FirstOrDefault()?.Extent;
+            return (EmuToPixels(extent?.Cx?.Value, 480), EmuToPixels(extent?.Cy?.Value, 320));
         }
 
         private int GetDrawingOrder() {
@@ -459,9 +453,6 @@ namespace OfficeIMO.Excel {
 
             return 0;
         }
-
-        private static ExcelWorksheetGeometryIndex GetWorksheetGeometry(WorksheetPart? worksheetPart) =>
-            ExcelWorksheetGeometryIndex.Create(worksheetPart);
 
         private static bool TryGetTwoCellAnchorSizePixels(Xdr.TwoCellAnchor? anchor, WorksheetPart? worksheetPart, ExcelWorksheetGeometryIndex geometry, bool horizontal, out int pixels) {
             pixels = 0;

--- a/OfficeIMO.Excel/ExcelChart.cs
+++ b/OfficeIMO.Excel/ExcelChart.cs
@@ -62,10 +62,10 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            xPixels = EmuOffsetToPixels(absoluteAnchor.Position?.X?.Value ?? 0L);
-            yPixels = EmuOffsetToPixels(absoluteAnchor.Position?.Y?.Value ?? 0L);
-            widthPixels = EmuToPixels(absoluteAnchor.Extent?.Cx?.Value, GetAnchorWidthPixels());
-            heightPixels = EmuToPixels(absoluteAnchor.Extent?.Cy?.Value, GetAnchorHeightPixels());
+            xPixels = ExcelImageExportLimits.ClampAbsoluteOffsetPixels(EmuOffsetToPixels(absoluteAnchor.Position?.X?.Value ?? 0L));
+            yPixels = ExcelImageExportLimits.ClampAbsoluteOffsetPixels(EmuOffsetToPixels(absoluteAnchor.Position?.Y?.Value ?? 0L));
+            widthPixels = ExcelImageExportLimits.ClampExtentPixels(EmuToPixels(absoluteAnchor.Extent?.Cx?.Value, GetAnchorWidthPixels()));
+            heightPixels = ExcelImageExportLimits.ClampExtentPixels(EmuToPixels(absoluteAnchor.Extent?.Cy?.Value, GetAnchorHeightPixels()));
             return widthPixels > 0 && heightPixels > 0;
         }
 
@@ -397,13 +397,13 @@ namespace OfficeIMO.Excel {
         private int GetAnchorRow() {
             Xdr.FromMarker? marker = _frame.Ancestors<Xdr.OneCellAnchor>().FirstOrDefault()?.FromMarker
                 ?? _frame.Ancestors<Xdr.TwoCellAnchor>().FirstOrDefault()?.FromMarker;
-            return ParseOneBasedMarker(marker?.RowId?.Text);
+            return ParseOneBasedMarker(marker?.RowId?.Text, 1048576);
         }
 
         private int GetAnchorColumn() {
             Xdr.FromMarker? marker = _frame.Ancestors<Xdr.OneCellAnchor>().FirstOrDefault()?.FromMarker
                 ?? _frame.Ancestors<Xdr.TwoCellAnchor>().FirstOrDefault()?.FromMarker;
-            return ParseOneBasedMarker(marker?.ColumnId?.Text);
+            return ParseOneBasedMarker(marker?.ColumnId?.Text, 16384);
         }
 
         private int GetAnchorOffsetXPixels() {
@@ -467,10 +467,15 @@ namespace OfficeIMO.Excel {
 
             int from = horizontal ? ParseZeroBasedMarker(anchor.FromMarker.ColumnId?.Text) : ParseZeroBasedMarker(anchor.FromMarker.RowId?.Text);
             int to = horizontal ? ParseZeroBasedMarker(anchor.ToMarker.ColumnId?.Text) : ParseZeroBasedMarker(anchor.ToMarker.RowId?.Text);
+            int maximumMarker = horizontal ? 16384 : 1048576;
+            if (!ExcelImageExportLimits.IsValidMarkerSpan(from, to, maximumMarker)) {
+                return false;
+            }
+
             long fromOffset = ParseEmuOffset(horizontal ? anchor.FromMarker.ColumnOffset?.Text : anchor.FromMarker.RowOffset?.Text);
             long toOffset = ParseEmuOffset(horizontal ? anchor.ToMarker.ColumnOffset?.Text : anchor.ToMarker.RowOffset?.Text);
             double maximumDigitWidth = GetDefaultMaximumDigitWidth(worksheetPart);
-            int basePixels = 0;
+            long basePixels = 0L;
             for (int index = from; index < to; index++) {
                 basePixels += horizontal
                     ? GetColumnWidthPixels(worksheetPart, index + 1, maximumDigitWidth)
@@ -478,7 +483,8 @@ namespace OfficeIMO.Excel {
             }
 
             int offsetPixels = EmuOffsetToPixels(toOffset - fromOffset);
-            pixels = Math.Max(1, basePixels + offsetPixels);
+            long totalPixels = Math.Max(1L, basePixels + offsetPixels);
+            pixels = ExcelImageExportLimits.ClampExtentPixels((int)Math.Min(int.MaxValue, totalPixels));
             return pixels > 1;
         }
 
@@ -552,8 +558,8 @@ namespace OfficeIMO.Excel {
             return Math.Max(1, (int)Math.Round(heightPoints * 96D / 72D));
         }
 
-        private static int ParseOneBasedMarker(string? value) {
-            return int.TryParse(value, out int zeroBased) && zeroBased >= 0 ? zeroBased + 1 : 1;
+        private static int ParseOneBasedMarker(string? value, int maximum) {
+            return int.TryParse(value, out int zeroBased) && zeroBased >= 0 && zeroBased < maximum ? zeroBased + 1 : 1;
         }
 
         private static int ParseZeroBasedMarker(string? value) {
@@ -565,7 +571,10 @@ namespace OfficeIMO.Excel {
         }
 
         private static int EmuOffsetToPixels(long emu) {
-            return (int)Math.Round(emu / 9525D);
+            double pixels = Math.Round(emu / 9525D);
+            if (pixels <= -int.MaxValue) return -int.MaxValue;
+            if (pixels >= int.MaxValue) return int.MaxValue;
+            return ExcelImageExportLimits.ClampOffsetPixels((int)pixels);
         }
 
         private static int EmuToPixels(long? emu, int fallback) {
@@ -573,7 +582,8 @@ namespace OfficeIMO.Excel {
                 return fallback;
             }
 
-            return Math.Max(1, (int)Math.Round(emu.Value / 9525D));
+            double pixels = Math.Round(emu.Value / 9525D);
+            return ExcelImageExportLimits.ClampExtentPixels(pixels >= int.MaxValue ? int.MaxValue : Math.Max(1, (int)pixels));
         }
 
         private ChartPart GetChartPart() {

--- a/OfficeIMO.Excel/ExcelChart.cs
+++ b/OfficeIMO.Excel/ExcelChart.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using OfficeIMO.Drawing;
+using OfficeIMO.Excel.Utilities;
 using A = DocumentFormat.OpenXml.Drawing;
 using C = DocumentFormat.OpenXml.Drawing.Charts;
 using Xdr = DocumentFormat.OpenXml.Drawing.Spreadsheet;
@@ -19,14 +20,16 @@ namespace OfficeIMO.Excel {
         private readonly ExcelDocument _document;
         private readonly string _sheetName;
         private ExcelChartDataRange? _dataRange;
+        private ExcelWorksheetGeometryIndex? _worksheetGeometry;
 
-        internal ExcelChart(Xdr.GraphicFrame frame, DrawingsPart drawingsPart, ExcelSheet sheet, ExcelChartDataRange? dataRange = null) {
+        internal ExcelChart(Xdr.GraphicFrame frame, DrawingsPart drawingsPart, ExcelSheet sheet, ExcelChartDataRange? dataRange = null, ExcelWorksheetGeometryIndex? worksheetGeometry = null) {
             _frame = frame ?? throw new ArgumentNullException(nameof(frame));
             _drawingsPart = drawingsPart ?? throw new ArgumentNullException(nameof(drawingsPart));
             if (sheet == null) throw new ArgumentNullException(nameof(sheet));
             _document = sheet.Document;
             _sheetName = sheet.Name;
             _dataRange = dataRange;
+            _worksheetGeometry = worksheetGeometry;
         }
 
         /// <summary>
@@ -421,7 +424,7 @@ namespace OfficeIMO.Excel {
         private int GetAnchorWidthPixels() {
             Xdr.TwoCellAnchor? twoCellAnchor = _frame.Ancestors<Xdr.TwoCellAnchor>().FirstOrDefault();
             WorksheetPart? worksheetPart = _drawingsPart.GetParentParts().OfType<WorksheetPart>().FirstOrDefault();
-            if (TryGetTwoCellAnchorSizePixels(twoCellAnchor, worksheetPart, horizontal: true, out int widthPixels)) {
+            if (TryGetTwoCellAnchorSizePixels(twoCellAnchor, worksheetPart, GetWorksheetGeometry(worksheetPart), horizontal: true, out int widthPixels)) {
                 return widthPixels;
             }
 
@@ -432,7 +435,7 @@ namespace OfficeIMO.Excel {
         private int GetAnchorHeightPixels() {
             Xdr.TwoCellAnchor? twoCellAnchor = _frame.Ancestors<Xdr.TwoCellAnchor>().FirstOrDefault();
             WorksheetPart? worksheetPart = _drawingsPart.GetParentParts().OfType<WorksheetPart>().FirstOrDefault();
-            if (TryGetTwoCellAnchorSizePixels(twoCellAnchor, worksheetPart, horizontal: false, out int heightPixels)) {
+            if (TryGetTwoCellAnchorSizePixels(twoCellAnchor, worksheetPart, GetWorksheetGeometry(worksheetPart), horizontal: false, out int heightPixels)) {
                 return heightPixels;
             }
 
@@ -459,7 +462,10 @@ namespace OfficeIMO.Excel {
             return 0;
         }
 
-        private static bool TryGetTwoCellAnchorSizePixels(Xdr.TwoCellAnchor? anchor, WorksheetPart? worksheetPart, bool horizontal, out int pixels) {
+        private ExcelWorksheetGeometryIndex GetWorksheetGeometry(WorksheetPart? worksheetPart) =>
+            _worksheetGeometry ??= ExcelWorksheetGeometryIndex.Create(worksheetPart);
+
+        private static bool TryGetTwoCellAnchorSizePixels(Xdr.TwoCellAnchor? anchor, WorksheetPart? worksheetPart, ExcelWorksheetGeometryIndex geometry, bool horizontal, out int pixels) {
             pixels = 0;
             if (anchor?.FromMarker == null || anchor.ToMarker == null) {
                 return false;
@@ -478,33 +484,14 @@ namespace OfficeIMO.Excel {
             long basePixels = 0L;
             for (int index = from; index < to; index++) {
                 basePixels += horizontal
-                    ? GetColumnWidthPixels(worksheetPart, index + 1, maximumDigitWidth)
-                    : GetRowHeightPixels(worksheetPart, index + 1);
+                    ? geometry.GetColumnWidthPixels(index + 1, maximumDigitWidth)
+                    : geometry.GetRowHeightPixels(index + 1);
             }
 
             int offsetPixels = EmuOffsetToPixels(toOffset - fromOffset);
             long totalPixels = Math.Max(1L, basePixels + offsetPixels);
             pixels = ExcelImageExportLimits.ClampExtentPixels((int)Math.Min(int.MaxValue, totalPixels));
             return pixels > 1;
-        }
-
-        private static int GetColumnWidthPixels(WorksheetPart? worksheetPart, int columnIndex, double maximumDigitWidth) {
-            DocumentFormat.OpenXml.Spreadsheet.Worksheet? worksheet = worksheetPart?.Worksheet;
-            DocumentFormat.OpenXml.Spreadsheet.Column? column = worksheet?
-                .GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.Columns>()?
-                .Elements<DocumentFormat.OpenXml.Spreadsheet.Column>()
-                .FirstOrDefault(item => item.Min != null && item.Max != null && item.Min.Value <= (uint)columnIndex && item.Max.Value >= (uint)columnIndex);
-            if (column?.Hidden?.Value == true) {
-                return 0;
-            }
-
-            double width = column?.Width?.Value > 0 && column.CustomWidth?.Value == true
-                ? column.Width.Value
-                : worksheet?.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.SheetFormatProperties>()?.DefaultColumnWidth?.Value > 0
-                    ? worksheet.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.SheetFormatProperties>()!.DefaultColumnWidth!.Value
-                    : 8.43D;
-            double pixels = Math.Truncate((256D * width + Math.Truncate(128D / maximumDigitWidth)) / 256D * maximumDigitWidth);
-            return Math.Max(1, (int)Math.Round(pixels));
         }
 
         private static double GetDefaultMaximumDigitWidth(WorksheetPart? worksheetPart) {
@@ -538,24 +525,6 @@ namespace OfficeIMO.Excel {
             } catch {
                 return fallbackMaximumDigitWidth;
             }
-        }
-
-        private static int GetRowHeightPixels(WorksheetPart? worksheetPart, int rowIndex) {
-            DocumentFormat.OpenXml.Spreadsheet.Worksheet? worksheet = worksheetPart?.Worksheet;
-            DocumentFormat.OpenXml.Spreadsheet.Row? row = worksheet?
-                .GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.SheetData>()?
-                .Elements<DocumentFormat.OpenXml.Spreadsheet.Row>()
-                .FirstOrDefault(item => item.RowIndex != null && item.RowIndex.Value == (uint)rowIndex);
-            if (row?.Hidden?.Value == true) {
-                return 0;
-            }
-
-            double heightPoints = row?.Height?.Value > 0 && row.CustomHeight?.Value == true
-                ? row.Height.Value
-                : worksheet?.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.SheetFormatProperties>()?.DefaultRowHeight?.Value > 0
-                    ? worksheet.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.SheetFormatProperties>()!.DefaultRowHeight!.Value
-                    : 15D;
-            return Math.Max(1, (int)Math.Round(heightPoints * 96D / 72D));
         }
 
         private static int ParseOneBasedMarker(string? value, int maximum) {

--- a/OfficeIMO.Excel/ExcelChart.cs
+++ b/OfficeIMO.Excel/ExcelChart.cs
@@ -486,7 +486,7 @@ namespace OfficeIMO.Excel {
                     : geometry.GetRowHeightPixels(index + 1);
             }
 
-            int offsetPixels = EmuOffsetToPixels(toOffset - fromOffset);
+            int offsetPixels = ExcelImageExportLimits.EmuOffsetDifferencePixels(fromOffset, toOffset);
             long totalPixels = Math.Max(1L, basePixels + offsetPixels);
             pixels = ExcelImageExportLimits.ClampExtentPixels((int)Math.Min(int.MaxValue, totalPixels));
             return pixels > 0;

--- a/OfficeIMO.Excel/ExcelConditionalFormatThresholds.cs
+++ b/OfficeIMO.Excel/ExcelConditionalFormatThresholds.cs
@@ -74,7 +74,7 @@ namespace OfficeIMO.Excel {
             IReadOnlyList<ExcelConditionalFormatThreshold> thresholds,
             out ColorScaleEvaluator? evaluator) {
             evaluator = null;
-            if (values.Count == 0 || colors.Count < 2) {
+            if (values.Count == 0 || (colors.Count != 2 && colors.Count != 3)) {
                 return false;
             }
 

--- a/OfficeIMO.Excel/ExcelConditionalFormatThresholds.cs
+++ b/OfficeIMO.Excel/ExcelConditionalFormatThresholds.cs
@@ -68,13 +68,12 @@ namespace OfficeIMO.Excel {
             return false;
         }
 
-        internal static bool TryGetColorScaleRgb(
+        internal static bool TryCreateColorScaleEvaluator(
             IReadOnlyList<double> values,
             IReadOnlyList<string> colors,
             IReadOnlyList<ExcelConditionalFormatThreshold> thresholds,
-            double value,
-            out string rgbHex) {
-            rgbHex = string.Empty;
+            out ColorScaleEvaluator? evaluator) {
+            evaluator = null;
             if (values.Count == 0 || colors.Count < 2) {
                 return false;
             }
@@ -82,6 +81,10 @@ namespace OfficeIMO.Excel {
             double min = values.Min();
             double max = values.Max();
             int stopCount = colors.Count;
+            IReadOnlyList<double>? sortedValues = thresholds.Any(threshold =>
+                string.Equals(threshold.Type, "percentile", StringComparison.OrdinalIgnoreCase))
+                ? values.OrderBy(item => item).ToArray()
+                : null;
             var stops = new List<ColorStop>(stopCount);
             for (int i = 0; i < stopCount; i++) {
                 if (!TryGetRgb(colors[i], out byte red, out byte green, out byte blue)) {
@@ -92,30 +95,12 @@ namespace OfficeIMO.Excel {
                     ? min
                     : min + ((max - min) * i / (stopCount - 1));
                 double thresholdValue = i < thresholds.Count
-                    ? ResolveThresholdValue(thresholds[i], values, min, max, fallback)
+                    ? ResolveThresholdValue(thresholds[i], values, min, max, fallback, sortedValues)
                     : fallback;
                 stops.Add(new ColorStop(thresholdValue, red, green, blue));
             }
 
-            if (value <= stops[0].Value) {
-                rgbHex = ToRgbHex(stops[0].Red, stops[0].Green, stops[0].Blue);
-                return true;
-            }
-
-            for (int i = 0; i < stops.Count - 1; i++) {
-                ColorStop start = stops[i];
-                ColorStop end = stops[i + 1];
-                if (value > end.Value) {
-                    continue;
-                }
-
-                double ratio = end.Value <= start.Value ? 1D : Math.Max(0D, Math.Min(1D, (value - start.Value) / (end.Value - start.Value)));
-                rgbHex = InterpolateRgbHex(start.Red, start.Green, start.Blue, end.Red, end.Green, end.Blue, ratio);
-                return true;
-            }
-
-            ColorStop last = stops[stops.Count - 1];
-            rgbHex = ToRgbHex(last.Red, last.Green, last.Blue);
+            evaluator = new ColorScaleEvaluator(stops);
             return true;
         }
 
@@ -145,7 +130,13 @@ namespace OfficeIMO.Excel {
             return (0D, positiveRatio);
         }
 
-        private static double ResolveThresholdValue(ExcelConditionalFormatThreshold threshold, IReadOnlyList<double> values, double min, double max, double fallback) {
+        private static double ResolveThresholdValue(
+            ExcelConditionalFormatThreshold threshold,
+            IReadOnlyList<double> values,
+            double min,
+            double max,
+            double fallback,
+            IReadOnlyList<double>? sortedValues = null) {
             string type = threshold.Type ?? string.Empty;
             if (string.Equals(type, "min", StringComparison.OrdinalIgnoreCase) ||
                 string.Equals(type, "minimum", StringComparison.OrdinalIgnoreCase)) {
@@ -170,7 +161,9 @@ namespace OfficeIMO.Excel {
 
             if (string.Equals(type, "percentile", StringComparison.OrdinalIgnoreCase)) {
                 double percentile = TryParseThresholdNumber(threshold.Value, out double number) ? Math.Max(0D, Math.Min(100D, number)) : 0D;
-                return CalculatePercentile(values, percentile);
+                return sortedValues == null
+                    ? CalculatePercentile(values, percentile)
+                    : CalculatePercentileSorted(sortedValues, percentile);
             }
 
             return fallback;
@@ -182,6 +175,10 @@ namespace OfficeIMO.Excel {
             }
 
             List<double> sorted = values.OrderBy(value => value).ToList();
+            return CalculatePercentileSorted(sorted, percentile);
+        }
+
+        private static double CalculatePercentileSorted(IReadOnlyList<double> sorted, double percentile) {
             if (sorted.Count == 1) {
                 return sorted[0];
             }
@@ -214,7 +211,35 @@ namespace OfficeIMO.Excel {
             return (byte)Math.Max(0, Math.Min(255, (int)Math.Round(start + ((end - start) * ratio), MidpointRounding.AwayFromZero)));
         }
 
-        private readonly struct ColorStop {
+        internal sealed class ColorScaleEvaluator {
+            private readonly IReadOnlyList<ColorStop> _stops;
+
+            internal ColorScaleEvaluator(IReadOnlyList<ColorStop> stops) {
+                _stops = stops;
+            }
+
+            internal string GetRgbHex(double value) {
+                if (value <= _stops[0].Value) {
+                    return ToRgbHex(_stops[0].Red, _stops[0].Green, _stops[0].Blue);
+                }
+
+                for (int i = 0; i < _stops.Count - 1; i++) {
+                    ColorStop start = _stops[i];
+                    ColorStop end = _stops[i + 1];
+                    if (value > end.Value) {
+                        continue;
+                    }
+
+                    double ratio = end.Value <= start.Value ? 1D : Math.Max(0D, Math.Min(1D, (value - start.Value) / (end.Value - start.Value)));
+                    return InterpolateRgbHex(start.Red, start.Green, start.Blue, end.Red, end.Green, end.Blue, ratio);
+                }
+
+                ColorStop last = _stops[_stops.Count - 1];
+                return ToRgbHex(last.Red, last.Green, last.Blue);
+            }
+        }
+
+        internal readonly struct ColorStop {
             internal ColorStop(double value, byte red, byte green, byte blue) {
                 Value = value;
                 Red = red;

--- a/OfficeIMO.Excel/ExcelImage.cs
+++ b/OfficeIMO.Excel/ExcelImage.cs
@@ -821,7 +821,7 @@ namespace OfficeIMO.Excel {
                     : GetRowHeightPixels(worksheetPart, index + 1);
             }
 
-            int offsetPixels = EmuOffsetToPx(toOffset - fromOffset);
+            int offsetPixels = ExcelImageExportLimits.EmuOffsetDifferencePixels(fromOffset, toOffset);
             int pixels = ExcelImageExportLimits.ClampExtentPixels((int)Math.Min(int.MaxValue, Math.Max(1L, basePixels + offsetPixels)));
             emu = PxToEmu(pixels);
             return true;

--- a/OfficeIMO.Excel/ExcelImage.cs
+++ b/OfficeIMO.Excel/ExcelImage.cs
@@ -143,10 +143,10 @@ namespace OfficeIMO.Excel {
                 return false;
             }
 
-            xPixels = EmuOffsetToPx(absoluteAnchor.Position?.X?.Value ?? 0L);
-            yPixels = EmuOffsetToPx(absoluteAnchor.Position?.Y?.Value ?? 0L);
-            widthPixels = EmuToPx(absoluteAnchor.Extent?.Cx?.Value ?? 0L);
-            heightPixels = EmuToPx(absoluteAnchor.Extent?.Cy?.Value ?? 0L);
+            xPixels = ExcelImageExportLimits.ClampAbsoluteOffsetPixels(EmuOffsetToPx(absoluteAnchor.Position?.X?.Value ?? 0L));
+            yPixels = ExcelImageExportLimits.ClampAbsoluteOffsetPixels(EmuOffsetToPx(absoluteAnchor.Position?.Y?.Value ?? 0L));
+            widthPixels = ExcelImageExportLimits.ClampExtentPixels(EmuToPx(absoluteAnchor.Extent?.Cx?.Value ?? 0L));
+            heightPixels = ExcelImageExportLimits.ClampExtentPixels(EmuToPx(absoluteAnchor.Extent?.Cy?.Value ?? 0L));
             if (widthPixels <= 0 || heightPixels <= 0) {
                 widthPixels = WidthPixels;
                 heightPixels = HeightPixels;
@@ -568,10 +568,16 @@ namespace OfficeIMO.Excel {
                 return 0;
             }
 
-            return (int)Math.Max(1, Math.Round(emu / 9525.0));
+            double pixels = Math.Max(1D, Math.Round(emu / 9525.0));
+            return ExcelImageExportLimits.ClampExtentPixels(pixels >= int.MaxValue ? int.MaxValue : (int)pixels);
         }
 
-        private static int EmuOffsetToPx(long emu) => (int)Math.Round(emu / 9525.0);
+        private static int EmuOffsetToPx(long emu) {
+            double pixels = Math.Round(emu / 9525.0);
+            if (pixels <= -int.MaxValue) return -int.MaxValue;
+            if (pixels >= int.MaxValue) return int.MaxValue;
+            return ExcelImageExportLimits.ClampOffsetPixels((int)pixels);
+        }
 
         private static double GetCropRatio(int? percentage) {
             if (!percentage.HasValue || percentage.Value <= 0) {
@@ -610,8 +616,9 @@ namespace OfficeIMO.Excel {
             int limit,
             Func<int, int> segmentSizePixels) {
             int index = Math.Max(0, startIndex);
-            int remainingPixels = Math.Max(1, sizePixels) + EmuToPx(startOffsetEmu);
-            while (index < limit - 1) {
+            int remainingPixels = ExcelImageExportLimits.SaturatingAddExtent(sizePixels, EmuToPx(startOffsetEmu));
+            int maximumIndex = Math.Min(limit - 1, index + ExcelImageExportLimits.MaximumAnchorSpanCells);
+            while (index < maximumIndex) {
                 int segmentPixels = Math.Max(1, segmentSizePixels(index));
                 if (remainingPixels < segmentPixels) {
                     break;
@@ -789,6 +796,11 @@ namespace OfficeIMO.Excel {
             int to = horizontal
                 ? ParseMarkerIndex(twoCellAnchor.ToMarker.ColumnId?.Text)
                 : ParseMarkerIndex(twoCellAnchor.ToMarker.RowId?.Text);
+            int maximumMarker = horizontal ? 16384 : 1048576;
+            if (!ExcelImageExportLimits.IsValidMarkerSpan(from, to, maximumMarker)) {
+                return false;
+            }
+
             long fromOffset = ParseMarkerOffset(horizontal
                 ? twoCellAnchor.FromMarker.ColumnOffset?.Text
                 : twoCellAnchor.FromMarker.RowOffset?.Text);
@@ -802,15 +814,15 @@ namespace OfficeIMO.Excel {
 
             WorksheetPart? worksheetPart = _drawingsPart.GetParentParts().OfType<WorksheetPart>().FirstOrDefault();
             double maximumDigitWidth = GetDefaultMaximumDigitWidth(worksheetPart);
-            int basePixels = 0;
+            long basePixels = 0L;
             for (int index = from; index < to; index++) {
                 basePixels += horizontal
                     ? GetColumnWidthPixels(worksheetPart, index + 1, maximumDigitWidth)
                     : GetRowHeightPixels(worksheetPart, index + 1);
             }
 
-            int offsetPixels = (int)Math.Round((toOffset - fromOffset) / 9525D);
-            int pixels = Math.Max(1, basePixels + offsetPixels);
+            int offsetPixels = EmuOffsetToPx(toOffset - fromOffset);
+            int pixels = ExcelImageExportLimits.ClampExtentPixels((int)Math.Min(int.MaxValue, Math.Max(1L, basePixels + offsetPixels)));
             emu = PxToEmu(pixels);
             return true;
         }

--- a/OfficeIMO.Excel/ExcelSheet.Charts.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Charts.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
+using OfficeIMO.Excel.Utilities;
 using A = DocumentFormat.OpenXml.Drawing;
 using C = DocumentFormat.OpenXml.Drawing.Charts;
 using Xdr = DocumentFormat.OpenXml.Drawing.Spreadsheet;
@@ -19,10 +20,11 @@ namespace OfficeIMO.Excel {
             get {
                 var drawingPart = _worksheetPart.DrawingsPart;
                 if (drawingPart?.WorksheetDrawing == null) return Enumerable.Empty<ExcelChart>();
+                ExcelWorksheetGeometryIndex geometry = ExcelWorksheetGeometryIndex.Create(_worksheetPart);
                 return drawingPart.WorksheetDrawing
                     .Descendants<Xdr.GraphicFrame>()
                     .Where(frame => frame.Graphic?.GraphicData?.GetFirstChild<C.ChartReference>() != null)
-                    .Select(frame => new ExcelChart(frame, drawingPart, this))
+                    .Select(frame => new ExcelChart(frame, drawingPart, this, worksheetGeometry: geometry))
                     .ToList();
             }
         }

--- a/OfficeIMO.Excel/ExcelSheet.Charts.cs
+++ b/OfficeIMO.Excel/ExcelSheet.Charts.cs
@@ -20,11 +20,10 @@ namespace OfficeIMO.Excel {
             get {
                 var drawingPart = _worksheetPart.DrawingsPart;
                 if (drawingPart?.WorksheetDrawing == null) return Enumerable.Empty<ExcelChart>();
-                ExcelWorksheetGeometryIndex geometry = ExcelWorksheetGeometryIndex.Create(_worksheetPart);
                 return drawingPart.WorksheetDrawing
                     .Descendants<Xdr.GraphicFrame>()
                     .Where(frame => frame.Graphic?.GraphicData?.GetFirstChild<C.ChartReference>() != null)
-                    .Select(frame => new ExcelChart(frame, drawingPart, this, worksheetGeometry: geometry))
+                    .Select(frame => new ExcelChart(frame, drawingPart, this))
                     .ToList();
             }
         }

--- a/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelConditionalVisualEvaluator.cs
@@ -436,6 +436,14 @@ namespace OfficeIMO.Excel {
             if (values.Count == 0) {
                 values = candidates.Select(candidate => candidate.Value).ToArray();
             }
+            if (!ExcelConditionalFormatThresholds.TryCreateColorScaleEvaluator(
+                    values,
+                    rule.ColorScaleColors,
+                    rule.ColorScaleThresholds,
+                    out ExcelConditionalFormatThresholds.ColorScaleEvaluator? colorScale) ||
+                colorScale == null) {
+                return;
+            }
 
             foreach (ConditionalNumericCell candidate in candidates) {
                 string key = Key(candidate.Cell.Row, candidate.Cell.Column);
@@ -444,9 +452,7 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                if (ExcelConditionalFormatThresholds.TryGetColorScaleRgb(values, rule.ColorScaleColors, rule.ColorScaleThresholds, candidate.Value, out string rgbHex)) {
-                    ApplyFillFormat(key, "FF" + rgbHex, formats);
-                }
+                ApplyFillFormat(key, "FF" + colorScale.GetRgbHex(candidate.Value), formats);
             }
         }
 

--- a/OfficeIMO.Excel/Imaging/ExcelImageExportLimits.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelImageExportLimits.cs
@@ -3,6 +3,7 @@ namespace OfficeIMO.Excel {
         internal const int MaximumAnchorSpanCells = 10_000;
         internal const int MaximumAnchorOffsetPixels = 100_000;
         internal const int MaximumAnchorExtentPixels = 16_384;
+        internal const double MaximumStrokeWidth = 64D;
 
         internal static int ClampOffsetPixels(int value) =>
             Math.Max(-MaximumAnchorOffsetPixels, Math.Min(MaximumAnchorOffsetPixels, value));
@@ -12,6 +13,9 @@ namespace OfficeIMO.Excel {
 
         internal static int ClampExtentPixels(int value) =>
             Math.Max(0, Math.Min(MaximumAnchorExtentPixels, value));
+
+        internal static double ClampStrokeWidth(double value) =>
+            Math.Max(0D, Math.Min(MaximumStrokeWidth, value));
 
         internal static int SaturatingAddExtent(int sizePixels, int offsetPixels) {
             long total = Math.Max(1, sizePixels) + Math.Max(0, (long)offsetPixels);

--- a/OfficeIMO.Excel/Imaging/ExcelImageExportLimits.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelImageExportLimits.cs
@@ -14,6 +14,13 @@ namespace OfficeIMO.Excel {
         internal static int ClampExtentPixels(int value) =>
             Math.Max(0, Math.Min(MaximumAnchorExtentPixels, value));
 
+        internal static int EmuOffsetDifferencePixels(long fromOffset, long toOffset) {
+            double pixels = Math.Round(((double)toOffset - fromOffset) / 9525D);
+            if (pixels <= -MaximumAnchorOffsetPixels) return -MaximumAnchorOffsetPixels;
+            if (pixels >= MaximumAnchorOffsetPixels) return MaximumAnchorOffsetPixels;
+            return (int)pixels;
+        }
+
         internal static double ClampStrokeWidth(double value) =>
             Math.Max(0D, Math.Min(MaximumStrokeWidth, value));
 

--- a/OfficeIMO.Excel/Imaging/ExcelImageExportLimits.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelImageExportLimits.cs
@@ -1,0 +1,33 @@
+namespace OfficeIMO.Excel {
+    internal static class ExcelImageExportLimits {
+        internal const int MaximumAnchorSpanCells = 10_000;
+        internal const int MaximumAnchorOffsetPixels = 100_000;
+        internal const int MaximumAnchorExtentPixels = 16_384;
+
+        internal static int ClampOffsetPixels(int value) =>
+            Math.Max(-MaximumAnchorOffsetPixels, Math.Min(MaximumAnchorOffsetPixels, value));
+
+        internal static int ClampAbsoluteOffsetPixels(int value) =>
+            Math.Max(0, Math.Min(MaximumAnchorOffsetPixels, value));
+
+        internal static int ClampExtentPixels(int value) =>
+            Math.Max(0, Math.Min(MaximumAnchorExtentPixels, value));
+
+        internal static int SaturatingAddExtent(int sizePixels, int offsetPixels) {
+            long total = Math.Max(1, sizePixels) + Math.Max(0, (long)offsetPixels);
+            return (int)Math.Min(MaximumAnchorExtentPixels, total);
+        }
+
+        internal static int SaturatingAddAbsoluteOffset(int offsetPixels, int extentPixels) {
+            long total = Math.Max(0, (long)offsetPixels) + Math.Max(1, (long)extentPixels);
+            return (int)Math.Min(MaximumAnchorOffsetPixels, total);
+        }
+
+        internal static bool IsValidMarkerSpan(int from, int to, int maximumMarker) =>
+            from >= 0 &&
+            to >= from &&
+            from < maximumMarker &&
+            to < maximumMarker &&
+            to - from <= MaximumAnchorSpanCells;
+    }
+}

--- a/OfficeIMO.Excel/Imaging/ExcelImageExportOptions.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelImageExportOptions.cs
@@ -5,6 +5,9 @@ namespace OfficeIMO.Excel {
     /// Options for dependency-free Excel range, worksheet, and workbook image export.
     /// </summary>
     public class ExcelImageExportOptions : OfficeImageExportOptions {
+        /// <summary>Default maximum number of worksheet cells materialized for one visual snapshot.</summary>
+        public const int DefaultMaximumRenderedCells = 100_000;
+
         /// <summary>
         /// Gridline color used when <see cref="ShowGridlines"/> is enabled.
         /// </summary>
@@ -66,6 +69,12 @@ namespace OfficeIMO.Excel {
         /// </summary>
         public double DefaultRowHeightPixels { get; set; } = 20D;
 
+        /// <summary>
+        /// Maximum number of worksheet cells materialized for one visual snapshot.
+        /// This limit is applied before rows, columns, and cells are expanded from drawing-driven ranges.
+        /// </summary>
+        public int MaximumRenderedCells { get; set; } = DefaultMaximumRenderedCells;
+
         /// <summary>Creates an independent options snapshot.</summary>
         public ExcelImageExportOptions Clone() => CopyExcelOptionsTo(new ExcelImageExportOptions());
 
@@ -83,10 +92,16 @@ namespace OfficeIMO.Excel {
             target.ShowCommentBodies = ShowCommentBodies;
             target.DefaultColumnWidthPixels = DefaultColumnWidthPixels;
             target.DefaultRowHeightPixels = DefaultRowHeightPixels;
+            target.MaximumRenderedCells = MaximumRenderedCells;
             return target;
         }
 
-        internal void Validate() => ValidateImageExportOptions();
+        internal void Validate() {
+            ValidateImageExportOptions();
+            if (MaximumRenderedCells <= 0) {
+                throw new ArgumentOutOfRangeException(nameof(MaximumRenderedCells), "Maximum rendered cells must be positive.");
+            }
+        }
     }
 
     /// <summary>

--- a/OfficeIMO.Excel/Imaging/ExcelRangeImageRenderer.Text.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelRangeImageRenderer.Text.cs
@@ -18,17 +18,19 @@ namespace OfficeIMO.Excel {
             ExcelImageExportOptions options,
             double scale,
             IReadOnlyDictionary<string, ExcelVisualCell> cellsByAddress,
+            IReadOnlyDictionary<string, ExcelVisualConditionalDataBar> dataBars,
+            IReadOnlyDictionary<string, ExcelVisualConditionalIcon> conditionalIcons,
             List<OfficeImageExportDiagnostic>? diagnostics) {
             if (string.IsNullOrEmpty(cell.Text)) {
                 return;
             }
 
-            if (TryGetConditionalDataBarForCell(snapshot, cell, out ExcelVisualConditionalDataBar dataBar) && !dataBar.ShowValue) {
+            if (dataBars.TryGetValue(Key(cell.Row, cell.Column), out ExcelVisualConditionalDataBar? dataBar) && !dataBar.ShowValue) {
                 return;
             }
 
             CellTextViewport viewport = ResolveCellTextViewport(cell, snapshot, scale, cellsByAddress);
-            if (TryGetConditionalIconForCell(snapshot, cell, out ExcelVisualConditionalIcon conditionalIcon)) {
+            if (conditionalIcons.TryGetValue(Key(cell.Row, cell.Column), out ExcelVisualConditionalIcon? conditionalIcon)) {
                 if (!conditionalIcon.ShowValue) {
                     return;
                 }
@@ -156,18 +158,20 @@ namespace OfficeIMO.Excel {
             ExcelImageExportOptions options,
             OfficeTextMeasurer textMeasurer,
             IReadOnlyDictionary<string, ExcelVisualCell> cellsByAddress,
+            IReadOnlyDictionary<string, ExcelVisualConditionalDataBar> dataBars,
+            IReadOnlyDictionary<string, ExcelVisualConditionalIcon> conditionalIcons,
             List<OfficeImageExportDiagnostic>? diagnostics) {
             if (string.IsNullOrEmpty(cell.Text)) {
                 return;
             }
 
             double scale = options.Scale;
-            if (TryGetConditionalDataBarForCell(snapshot, cell, out ExcelVisualConditionalDataBar dataBar) && !dataBar.ShowValue) {
+            if (dataBars.TryGetValue(Key(cell.Row, cell.Column), out ExcelVisualConditionalDataBar? dataBar) && !dataBar.ShowValue) {
                 return;
             }
 
             CellTextViewport viewport = ResolveCellTextViewport(cell, snapshot, scale, cellsByAddress);
-            if (TryGetConditionalIconForCell(snapshot, cell, out ExcelVisualConditionalIcon conditionalIcon)) {
+            if (conditionalIcons.TryGetValue(Key(cell.Row, cell.Column), out ExcelVisualConditionalIcon? conditionalIcon)) {
                 if (!conditionalIcon.ShowValue) {
                     return;
                 }
@@ -547,32 +551,6 @@ namespace OfficeIMO.Excel {
 
         private static bool IsRichTextRenderingSupported(ExcelVisualCell cell, bool rotated) {
             return true;
-        }
-
-        private static bool TryGetConditionalIconForCell(ExcelRangeVisualSnapshot snapshot, ExcelVisualCell cell, out ExcelVisualConditionalIcon icon) {
-            for (int index = 0; index < snapshot.ConditionalIcons.Count; index++) {
-                ExcelVisualConditionalIcon candidate = snapshot.ConditionalIcons[index];
-                if (candidate.Row == cell.Row && candidate.Column == cell.Column) {
-                    icon = candidate;
-                    return true;
-                }
-            }
-
-            icon = null!;
-            return false;
-        }
-
-        private static bool TryGetConditionalDataBarForCell(ExcelRangeVisualSnapshot snapshot, ExcelVisualCell cell, out ExcelVisualConditionalDataBar dataBar) {
-            for (int index = 0; index < snapshot.ConditionalDataBars.Count; index++) {
-                ExcelVisualConditionalDataBar candidate = snapshot.ConditionalDataBars[index];
-                if (candidate.Row == cell.Row && candidate.Column == cell.Column) {
-                    dataBar = candidate;
-                    return true;
-                }
-            }
-
-            dataBar = null!;
-            return false;
         }
 
         private static CellTextViewport ReserveConditionalIconTextSpace(CellTextViewport viewport, ExcelVisualConditionalIcon icon, double scale) {

--- a/OfficeIMO.Excel/Imaging/ExcelRangeImageRenderer.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelRangeImageRenderer.cs
@@ -93,6 +93,7 @@ namespace OfficeIMO.Excel {
                 cancellationToken: cancellationToken);
             double scale = options.Scale;
             Dictionary<string, ExcelVisualConditionalDataBar> dataBars = BuildDataBarMap(snapshot.ConditionalDataBars);
+            Dictionary<string, ExcelVisualConditionalIcon> conditionalIcons = BuildConditionalIconMap(snapshot.ConditionalIcons);
             Dictionary<string, ExcelVisualCell> cellsByAddress = BuildCellMap(snapshot.Cells);
 
             foreach (ExcelVisualCell cell in snapshot.Cells) {
@@ -123,7 +124,7 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                DrawRasterCellText(canvas, cell, snapshot, options, scale, cellsByAddress, diagnostics);
+                DrawRasterCellText(canvas, cell, snapshot, options, scale, cellsByAddress, dataBars, conditionalIcons, diagnostics);
             }
 
             RenderRasterConditionalIcons(canvas, snapshot, options);
@@ -149,6 +150,7 @@ namespace OfficeIMO.Excel {
             builder.AppendRectElement(0D, 0D, width, height, backgroundAttributes.ToString());
             OfficeTextMeasurer textMeasurer = OfficeTextMeasurer.Create();
             Dictionary<string, ExcelVisualConditionalDataBar> dataBars = BuildDataBarMap(snapshot.ConditionalDataBars);
+            Dictionary<string, ExcelVisualConditionalIcon> conditionalIcons = BuildConditionalIconMap(snapshot.ConditionalIcons);
             Dictionary<string, ExcelVisualCell> cellsByAddress = BuildCellMap(snapshot.Cells);
 
             foreach (ExcelVisualCell cell in snapshot.Cells) {
@@ -182,7 +184,7 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                AppendSvgCellText(builder, cell, snapshot, options, textMeasurer, cellsByAddress, diagnostics);
+                AppendSvgCellText(builder, cell, snapshot, options, textMeasurer, cellsByAddress, dataBars, conditionalIcons, diagnostics);
             }
 
             AppendSvgConditionalIcons(builder, snapshot, options);
@@ -228,6 +230,18 @@ namespace OfficeIMO.Excel {
                 string key = Key(dataBar.Row, dataBar.Column);
                 if (!resolved.ContainsKey(key)) {
                     resolved[key] = dataBar;
+                }
+            }
+
+            return resolved;
+        }
+
+        private static Dictionary<string, ExcelVisualConditionalIcon> BuildConditionalIconMap(IReadOnlyList<ExcelVisualConditionalIcon> icons) {
+            var resolved = new Dictionary<string, ExcelVisualConditionalIcon>(StringComparer.Ordinal);
+            foreach (ExcelVisualConditionalIcon icon in icons) {
+                string key = Key(icon.Row, icon.Column);
+                if (!resolved.ContainsKey(key)) {
+                    resolved[key] = icon;
                 }
             }
 

--- a/OfficeIMO.Excel/Imaging/ExcelRangeVisualSnapshotBuilder.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelRangeVisualSnapshotBuilder.cs
@@ -91,7 +91,8 @@ namespace OfficeIMO.Excel {
             var mergeOrigins = new Dictionary<string, (double Width, double Height)>(StringComparer.Ordinal);
             var fullMergeGeometry = new HashSet<string>(StringComparer.Ordinal);
             var boundedMergeGeometry = new HashSet<string>(StringComparer.Ordinal);
-            long remainingMergeCellWork = options.MaximumRenderedCells;
+            long remainingVisibleMergeCellWork = options.MaximumRenderedCells;
+            long remainingFullMergeCellWork = options.MaximumRenderedCells;
             foreach (ExcelMergedRangeSnapshot merge in merges) {
                 int visibleStartRow = Math.Max(firstRow, merge.StartRow);
                 int visibleStartColumn = Math.Max(firstColumn, merge.StartColumn);
@@ -105,15 +106,21 @@ namespace OfficeIMO.Excel {
                     ((long)visibleEndColumn - visibleStartColumn + 1L);
                 long fullCellCount = ((long)merge.EndRow - merge.StartRow + 1L) *
                     ((long)merge.EndColumn - merge.StartColumn + 1L);
-                bool preserveFullGeometry = fullCellCount > 0L && fullCellCount <= remainingMergeCellWork;
-                long chargedWork = preserveFullGeometry ? fullCellCount : visibleCellCount;
-                if (chargedWork <= 0L || chargedWork > remainingMergeCellWork) {
+                if (visibleCellCount <= 0L || visibleCellCount > remainingVisibleMergeCellWork) {
                     continue;
                 }
 
-                remainingMergeCellWork -= chargedWork;
+                remainingVisibleMergeCellWork -= visibleCellCount;
                 boundedMergeGeometry.Add(MergeGeometryKey(merge));
+                bool originIsVisible = merge.StartRow >= firstRow && merge.StartRow <= lastRow
+                    && merge.StartColumn >= firstColumn && merge.StartColumn <= lastColumn
+                    && rowsByIndex.ContainsKey(merge.StartRow)
+                    && columnsByIndex.ContainsKey(merge.StartColumn);
+                bool preserveFullGeometry = !originIsVisible
+                    && fullCellCount > 0L
+                    && fullCellCount <= remainingFullMergeCellWork;
                 if (preserveFullGeometry) {
+                    remainingFullMergeCellWork -= fullCellCount;
                     fullMergeGeometry.Add(MergeGeometryKey(merge));
                 }
 
@@ -1175,10 +1182,9 @@ namespace OfficeIMO.Excel {
             IReadOnlyDictionary<int, ExcelVisualColumn> columnsByIndex,
             IReadOnlyDictionary<int, ExcelVisualRow> rowsByIndex) {
             IReadOnlyList<ExcelWorksheetSparklineInfo> sparklines = ExcelWorksheetSparklineResolver.FindSparklines(sheet.WorksheetPart);
-            var resolved = new List<ResolvedSparkline>(sparklines.Count);
-            foreach (ExcelWorksheetSparklineInfo sparkline in sparklines) {
-                if (!IsSupportedSparklineKind(sparkline.Kind) ||
-                    !TryResolveVisibleExportCell(
+            var visibleGroups = new HashSet<int>(sparklines
+                .Where(sparkline => IsSupportedSparklineKind(sparkline.Kind)
+                    && TryResolveVisibleExportCell(
                         sparkline.CellReference,
                         firstRow,
                         firstColumn,
@@ -1186,7 +1192,12 @@ namespace OfficeIMO.Excel {
                         lastColumn,
                         columnsByIndex,
                         rowsByIndex,
-                        out _)) {
+                        out _))
+                .Select(sparkline => sparkline.GroupIndex));
+            var resolved = new List<ResolvedSparkline>(sparklines.Count);
+            foreach (ExcelWorksheetSparklineInfo sparkline in sparklines) {
+                if (!IsSupportedSparklineKind(sparkline.Kind) ||
+                    !visibleGroups.Contains(sparkline.GroupIndex)) {
                     resolved.Add(new ResolvedSparkline(sparkline, Array.Empty<double>(), hasResolvedRange: false, externalRange: false));
                     continue;
                 }
@@ -1524,7 +1535,7 @@ namespace OfficeIMO.Excel {
                 double from = ResolveRelativeColumnOffset(firstColumn, anchorColumn, offsetPixels, columnDefinitions, options);
                 double to = ResolveRelativeColumnOffset(firstColumn, toColumnIndex.Value, toOffsetPixels, columnDefinitions, options);
                 if (to > from) {
-                    return Math.Max(1D, to - from);
+                    return Math.Min(ExcelImageExportLimits.MaximumAnchorExtentPixels, Math.Max(1D, to - from));
                 }
             }
 
@@ -1566,7 +1577,7 @@ namespace OfficeIMO.Excel {
                 double from = ResolveRelativeRowOffset(firstRow, anchorRow, offsetPixels, rowDefinitions, defaultRowsHidden, options);
                 double to = ResolveRelativeRowOffset(firstRow, toRowIndex.Value, toOffsetPixels, rowDefinitions, defaultRowsHidden, options);
                 if (to > from) {
-                    return Math.Max(1D, to - from);
+                    return Math.Min(ExcelImageExportLimits.MaximumAnchorExtentPixels, Math.Max(1D, to - from));
                 }
             }
 

--- a/OfficeIMO.Excel/Imaging/ExcelRangeVisualSnapshotBuilder.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelRangeVisualSnapshotBuilder.cs
@@ -1446,15 +1446,14 @@ namespace OfficeIMO.Excel {
 
             int lastVisibleColumn = columnsByIndex.Keys.Max();
             int lastVisibleRow = rowsByIndex.Keys.Max();
-            if (columnIndex > lastVisibleColumn || rowIndex > lastVisibleRow ||
-                (toColumnIndex.HasValue && toColumnIndex.Value < firstColumn) ||
-                (toRowIndex.HasValue && toRowIndex.Value < firstRow) ||
-                (columnIndex < firstColumn && (long)firstColumn - columnIndex > ExcelImageExportLimits.MaximumAnchorSpanCells) ||
-                (rowIndex < firstRow && (long)firstRow - rowIndex > ExcelImageExportLimits.MaximumAnchorSpanCells) ||
-                (toColumnIndex.HasValue && toColumnIndex.Value > lastVisibleColumn &&
-                    Math.Abs((long)toColumnIndex.Value - columnIndex) > ExcelImageExportLimits.MaximumAnchorSpanCells) ||
-                (toRowIndex.HasValue && toRowIndex.Value > lastVisibleRow &&
-                    Math.Abs((long)toRowIndex.Value - rowIndex) > ExcelImageExportLimits.MaximumAnchorSpanCells)) {
+            if (DistanceOutsideRange(columnIndex, firstColumn, lastVisibleColumn) > ExcelImageExportLimits.MaximumAnchorSpanCells ||
+                DistanceOutsideRange(rowIndex, firstRow, lastVisibleRow) > ExcelImageExportLimits.MaximumAnchorSpanCells ||
+                (toColumnIndex.HasValue &&
+                    (DistanceOutsideRange(toColumnIndex.Value, firstColumn, lastVisibleColumn) > ExcelImageExportLimits.MaximumAnchorSpanCells ||
+                     Math.Abs((long)toColumnIndex.Value - columnIndex) > ExcelImageExportLimits.MaximumAnchorSpanCells)) ||
+                (toRowIndex.HasValue &&
+                    (DistanceOutsideRange(toRowIndex.Value, firstRow, lastVisibleRow) > ExcelImageExportLimits.MaximumAnchorSpanCells ||
+                     Math.Abs((long)toRowIndex.Value - rowIndex) > ExcelImageExportLimits.MaximumAnchorSpanCells))) {
                 return false;
             }
 
@@ -1475,6 +1474,14 @@ namespace OfficeIMO.Excel {
                 x + width > 0D &&
                 y < rangeHeight &&
                 y + height > 0D;
+        }
+
+        private static long DistanceOutsideRange(int value, int first, int last) {
+            if (value < first) {
+                return (long)first - value;
+            }
+
+            return value > last ? (long)value - last : 0L;
         }
 
         private static bool TryGetAnchor(

--- a/OfficeIMO.Excel/Imaging/ExcelRangeVisualSnapshotBuilder.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelRangeVisualSnapshotBuilder.cs
@@ -89,24 +89,43 @@ namespace OfficeIMO.Excel {
             Dictionary<int, ExcelVisualRow> rowsByIndex = rows.ToDictionary(row => row.Index);
             var coveredByMerge = new HashSet<string>(StringComparer.Ordinal);
             var mergeOrigins = new Dictionary<string, (double Width, double Height)>(StringComparer.Ordinal);
+            var fullMergeGeometry = new HashSet<string>(StringComparer.Ordinal);
+            var boundedMergeGeometry = new HashSet<string>(StringComparer.Ordinal);
+            long remainingMergeCellWork = options.MaximumRenderedCells;
             foreach (ExcelMergedRangeSnapshot merge in merges) {
-                double mergeWidth = 0D;
-                double mergeHeight = 0D;
-                for (int column = merge.StartColumn; column <= merge.EndColumn; column++) {
-                    if (columnsByIndex.TryGetValue(column, out ExcelVisualColumn? visualColumn)) {
-                        mergeWidth += visualColumn.Width;
-                    }
+                int visibleStartRow = Math.Max(firstRow, merge.StartRow);
+                int visibleStartColumn = Math.Max(firstColumn, merge.StartColumn);
+                int visibleEndRow = Math.Min(lastRow, merge.EndRow);
+                int visibleEndColumn = Math.Min(lastColumn, merge.EndColumn);
+                if (visibleStartRow > visibleEndRow || visibleStartColumn > visibleEndColumn) {
+                    continue;
                 }
 
-                for (int row = merge.StartRow; row <= merge.EndRow; row++) {
-                    if (rowsByIndex.TryGetValue(row, out ExcelVisualRow? visualRow)) {
-                        mergeHeight += visualRow.Height;
-                    }
+                long visibleCellCount = ((long)visibleEndRow - visibleStartRow + 1L) *
+                    ((long)visibleEndColumn - visibleStartColumn + 1L);
+                long fullCellCount = ((long)merge.EndRow - merge.StartRow + 1L) *
+                    ((long)merge.EndColumn - merge.StartColumn + 1L);
+                bool preserveFullGeometry = fullCellCount > 0L && fullCellCount <= remainingMergeCellWork;
+                long chargedWork = preserveFullGeometry ? fullCellCount : visibleCellCount;
+                if (chargedWork <= 0L || chargedWork > remainingMergeCellWork) {
+                    continue;
                 }
 
+                remainingMergeCellWork -= chargedWork;
+                boundedMergeGeometry.Add(MergeGeometryKey(merge));
+                if (preserveFullGeometry) {
+                    fullMergeGeometry.Add(MergeGeometryKey(merge));
+                }
+
+                double mergeWidth = columns
+                    .Where(column => column.Index >= visibleStartColumn && column.Index <= visibleEndColumn)
+                    .Sum(column => column.Width);
+                double mergeHeight = rows
+                    .Where(row => row.Index >= visibleStartRow && row.Index <= visibleEndRow)
+                    .Sum(row => row.Height);
                 mergeOrigins[Key(merge.StartRow, merge.StartColumn)] = (mergeWidth, mergeHeight);
-                for (int row = merge.StartRow; row <= merge.EndRow; row++) {
-                    for (int column = merge.StartColumn; column <= merge.EndColumn; column++) {
+                for (int row = visibleStartRow; row <= visibleEndRow; row++) {
+                    for (int column = visibleStartColumn; column <= visibleEndColumn; column++) {
                         if (row != merge.StartRow || column != merge.StartColumn) {
                             coveredByMerge.Add(Key(row, column));
                         }
@@ -169,7 +188,7 @@ namespace OfficeIMO.Excel {
                 }
             }
 
-            AddIntersectingMergeOriginCells(sheet, options, firstRow, firstColumn, lastRow, lastColumn, merges, rowDefinitions, defaultRowsHidden, columnDefinitions, columnsByIndex, rowsByIndex, hyperlinkMap, cells);
+            AddIntersectingMergeOriginCells(sheet, options, firstRow, firstColumn, lastRow, lastColumn, merges, boundedMergeGeometry, fullMergeGeometry, rowDefinitions, defaultRowsHidden, columnDefinitions, columnsByIndex, rowsByIndex, hyperlinkMap, cells);
 
             ExcelConditionalVisualState conditionalVisuals = options.IncludeConditionalFormatting
                 ? ExcelConditionalVisualEvaluator.Evaluate(sheet, cells, range, options.ConditionalFormattingDate ?? DateTime.Today, diagnostics)
@@ -280,6 +299,8 @@ namespace OfficeIMO.Excel {
             int lastRow,
             int lastColumn,
             IReadOnlyList<ExcelMergedRangeSnapshot> merges,
+            ISet<string> boundedMergeGeometry,
+            ISet<string> fullMergeGeometry,
             IReadOnlyDictionary<int, ExcelRowSnapshot> rowDefinitions,
             bool defaultRowsHidden,
             IReadOnlyList<ExcelColumnSnapshot> columnDefinitions,
@@ -288,6 +309,10 @@ namespace OfficeIMO.Excel {
             IReadOnlyDictionary<string, ExcelHyperlinkSnapshot> hyperlinkMap,
             List<ExcelVisualCell> cells) {
             foreach (ExcelMergedRangeSnapshot merge in merges) {
+                if (!boundedMergeGeometry.Contains(MergeGeometryKey(merge))) {
+                    continue;
+                }
+
                 if (merge.StartRow >= firstRow &&
                     merge.StartRow <= lastRow &&
                     merge.StartColumn >= firstColumn &&
@@ -297,22 +322,47 @@ namespace OfficeIMO.Excel {
                     continue;
                 }
 
-                double width = 0D;
-                for (int column = merge.StartColumn; column <= merge.EndColumn; column++) {
-                    width += ResolveVisibleColumnWidth(column, columnDefinitions, options);
-                }
+                bool preserveFullGeometry = fullMergeGeometry.Contains(MergeGeometryKey(merge));
+                double width;
+                double height;
+                double x;
+                double y;
+                if (preserveFullGeometry) {
+                    width = 0D;
+                    for (int column = merge.StartColumn; column <= merge.EndColumn; column++) {
+                        width += ResolveVisibleColumnWidth(column, columnDefinitions, options);
+                    }
 
-                double height = 0D;
-                for (int row = merge.StartRow; row <= merge.EndRow; row++) {
-                    height += ResolveVisibleRowHeight(row, rowDefinitions, defaultRowsHidden, options);
+                    height = 0D;
+                    for (int row = merge.StartRow; row <= merge.EndRow; row++) {
+                        height += ResolveVisibleRowHeight(row, rowDefinitions, defaultRowsHidden, options);
+                    }
+
+                    x = ResolveRelativeColumnOffset(firstColumn, merge.StartColumn, 0, columnDefinitions, options);
+                    y = ResolveRelativeRowOffset(firstRow, merge.StartRow, 0, rowDefinitions, defaultRowsHidden, options);
+                } else {
+                    ExcelVisualColumn[] visibleColumns = columnsByIndex.Values
+                        .Where(column => column.Index >= Math.Max(firstColumn, merge.StartColumn) && column.Index <= Math.Min(lastColumn, merge.EndColumn))
+                        .OrderBy(column => column.Index)
+                        .ToArray();
+                    ExcelVisualRow[] visibleRows = rowsByIndex.Values
+                        .Where(row => row.Index >= Math.Max(firstRow, merge.StartRow) && row.Index <= Math.Min(lastRow, merge.EndRow))
+                        .OrderBy(row => row.Index)
+                        .ToArray();
+                    if (visibleColumns.Length == 0 || visibleRows.Length == 0) {
+                        continue;
+                    }
+
+                    width = visibleColumns.Sum(column => column.Width);
+                    height = visibleRows.Sum(row => row.Height);
+                    x = visibleColumns[0].X;
+                    y = visibleRows[0].Y;
                 }
 
                 if (width <= 0D || height <= 0D) {
                     continue;
                 }
 
-                double x = ResolveRelativeColumnOffset(firstColumn, merge.StartColumn, 0, columnDefinitions, options);
-                double y = ResolveRelativeRowOffset(firstRow, merge.StartRow, 0, rowDefinitions, defaultRowsHidden, options);
                 ExcelCellStyleSnapshot style = sheet.GetCellStyle(merge.StartRow, merge.StartColumn);
                 ExcelCellData valueData = sheet.GetCellValueSnapshot(merge.StartRow, merge.StartColumn);
                 string rawText = sheet.TryGetCellText(merge.StartRow, merge.StartColumn, out string cellText)
@@ -1712,5 +1762,8 @@ namespace OfficeIMO.Excel {
         }
 
         private static string Key(int row, int column) => row.ToString(System.Globalization.CultureInfo.InvariantCulture) + ":" + column.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        private static string MergeGeometryKey(ExcelMergedRangeSnapshot merge) =>
+            Key(merge.StartRow, merge.StartColumn) + ":" + Key(merge.EndRow, merge.EndColumn);
     }
 }

--- a/OfficeIMO.Excel/Imaging/ExcelRangeVisualSnapshotBuilder.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelRangeVisualSnapshotBuilder.cs
@@ -1449,10 +1449,12 @@ namespace OfficeIMO.Excel {
             if (columnIndex > lastVisibleColumn || rowIndex > lastVisibleRow ||
                 (toColumnIndex.HasValue && toColumnIndex.Value < firstColumn) ||
                 (toRowIndex.HasValue && toRowIndex.Value < firstRow) ||
-                Math.Abs((long)columnIndex - firstColumn) > ExcelImageExportLimits.MaximumAnchorSpanCells ||
-                Math.Abs((long)rowIndex - firstRow) > ExcelImageExportLimits.MaximumAnchorSpanCells ||
-                (toColumnIndex.HasValue && Math.Abs((long)toColumnIndex.Value - columnIndex) > ExcelImageExportLimits.MaximumAnchorSpanCells) ||
-                (toRowIndex.HasValue && Math.Abs((long)toRowIndex.Value - rowIndex) > ExcelImageExportLimits.MaximumAnchorSpanCells)) {
+                (columnIndex < firstColumn && (long)firstColumn - columnIndex > ExcelImageExportLimits.MaximumAnchorSpanCells) ||
+                (rowIndex < firstRow && (long)firstRow - rowIndex > ExcelImageExportLimits.MaximumAnchorSpanCells) ||
+                (toColumnIndex.HasValue && toColumnIndex.Value > lastVisibleColumn &&
+                    Math.Abs((long)toColumnIndex.Value - columnIndex) > ExcelImageExportLimits.MaximumAnchorSpanCells) ||
+                (toRowIndex.HasValue && toRowIndex.Value > lastVisibleRow &&
+                    Math.Abs((long)toRowIndex.Value - rowIndex) > ExcelImageExportLimits.MaximumAnchorSpanCells)) {
                 return false;
             }
 

--- a/OfficeIMO.Excel/Imaging/ExcelRangeVisualSnapshotBuilder.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelRangeVisualSnapshotBuilder.cs
@@ -5,6 +5,7 @@ using OfficeIMO.Excel.Utilities;
 
 namespace OfficeIMO.Excel {
     internal static class ExcelRangeVisualSnapshotBuilder {
+        private const int MaxSparklineDataCells = 100_000;
         internal static ExcelRangeVisualSnapshot Build(ExcelSheet sheet, string range, ExcelImageExportOptions options, IReadOnlyList<OfficeImageExportDiagnostic>? initialDiagnostics = null) {
             if (sheet == null) {
                 throw new ArgumentNullException(nameof(sheet));
@@ -16,6 +17,22 @@ namespace OfficeIMO.Excel {
 
             if (!A1.TryParseRange(range, out int firstRow, out int firstColumn, out int lastRow, out int lastColumn)) {
                 throw new ArgumentException("Range must be a valid A1 range.", nameof(range));
+            }
+
+            if (options.MaximumRenderedCells <= 0) {
+                throw new ArgumentOutOfRangeException(
+                    nameof(options),
+                    options.MaximumRenderedCells,
+                    "MaximumRenderedCells must be greater than zero.");
+            }
+
+            long rowCount = (long)lastRow - firstRow + 1L;
+            long columnCount = (long)lastColumn - firstColumn + 1L;
+            if (rowCount <= 0L || columnCount <= 0L || rowCount > options.MaximumRenderedCells / columnCount) {
+                throw new InvalidOperationException(
+                    "The requested Excel visual range exceeds the configured limit of " +
+                    options.MaximumRenderedCells.ToString(CultureInfo.InvariantCulture) +
+                    " rendered cells.");
             }
 
             var diagnostics = initialDiagnostics == null
@@ -1012,7 +1029,14 @@ namespace OfficeIMO.Excel {
             IReadOnlyDictionary<int, ExcelVisualRow> rowsByIndex,
             List<OfficeImageExportDiagnostic> diagnostics) {
             var visuals = new List<ExcelVisualSparkline>();
-            IReadOnlyList<ResolvedSparkline> resolvedSparklines = ResolveSparklines(sheet);
+            IReadOnlyList<ResolvedSparkline> resolvedSparklines = ResolveSparklines(
+                sheet,
+                firstRow,
+                firstColumn,
+                lastRow,
+                lastColumn,
+                columnsByIndex,
+                rowsByIndex);
             IReadOnlyDictionary<int, SparklineScaleRange> scaleRanges = ResolveSparklineScaleRanges(resolvedSparklines);
             foreach (ResolvedSparkline resolvedSparkline in resolvedSparklines) {
                 ExcelWorksheetSparklineInfo sparkline = resolvedSparkline.Info;
@@ -1092,16 +1116,42 @@ namespace OfficeIMO.Excel {
             return visuals;
         }
 
-        private static IReadOnlyList<ResolvedSparkline> ResolveSparklines(ExcelSheet sheet) {
+        private static IReadOnlyList<ResolvedSparkline> ResolveSparklines(
+            ExcelSheet sheet,
+            int firstRow,
+            int firstColumn,
+            int lastRow,
+            int lastColumn,
+            IReadOnlyDictionary<int, ExcelVisualColumn> columnsByIndex,
+            IReadOnlyDictionary<int, ExcelVisualRow> rowsByIndex) {
             IReadOnlyList<ExcelWorksheetSparklineInfo> sparklines = ExcelWorksheetSparklineResolver.FindSparklines(sheet.WorksheetPart);
             var resolved = new List<ResolvedSparkline>(sparklines.Count);
             foreach (ExcelWorksheetSparklineInfo sparkline in sparklines) {
+                if (!IsSupportedSparklineKind(sparkline.Kind) ||
+                    !TryResolveVisibleExportCell(
+                        sparkline.CellReference,
+                        firstRow,
+                        firstColumn,
+                        lastRow,
+                        lastColumn,
+                        columnsByIndex,
+                        rowsByIndex,
+                        out _)) {
+                    resolved.Add(new ResolvedSparkline(sparkline, Array.Empty<double>(), hasResolvedRange: false, externalRange: false));
+                    continue;
+                }
+
                 if (!TryResolveSparklineDataRange(sheet.Name, sparkline.Formula, out string? dataRange, out bool externalRange) || dataRange == null) {
                     resolved.Add(new ResolvedSparkline(sparkline, Array.Empty<double>(), hasResolvedRange: false, externalRange));
                     continue;
                 }
 
-                resolved.Add(new ResolvedSparkline(sparkline, ReadSparklineValues(sheet, dataRange), hasResolvedRange: true, externalRange: false));
+                if (!TryReadSparklineValues(sheet, dataRange, out IReadOnlyList<double> values)) {
+                    resolved.Add(new ResolvedSparkline(sparkline, Array.Empty<double>(), hasResolvedRange: false, externalRange: false));
+                    continue;
+                }
+
+                resolved.Add(new ResolvedSparkline(sparkline, values, hasResolvedRange: true, externalRange: false));
             }
 
             return resolved.AsReadOnly();
@@ -1197,32 +1247,41 @@ namespace OfficeIMO.Excel {
             return normalized;
         }
 
-        private static IReadOnlyList<double> ReadSparklineValues(ExcelSheet sheet, string dataRange) {
+        private static bool TryReadSparklineValues(ExcelSheet sheet, string dataRange, out IReadOnlyList<double> values) {
             int firstRow;
             int firstColumn;
             int lastRow;
             int lastColumn;
             if (!A1.TryParseRange(dataRange, out firstRow, out firstColumn, out lastRow, out lastColumn)) {
                 if (!A1.TryParseCellReferenceFast(dataRange, out firstRow, out firstColumn)) {
-                    return Array.Empty<double>();
+                    values = Array.Empty<double>();
+                    return false;
                 }
 
                 lastRow = firstRow;
                 lastColumn = firstColumn;
             }
 
-            var values = new List<double>();
+            long rowCount = (long)lastRow - firstRow + 1L;
+            long columnCount = (long)lastColumn - firstColumn + 1L;
+            if (rowCount <= 0L || columnCount <= 0L || rowCount > MaxSparklineDataCells / columnCount) {
+                values = Array.Empty<double>();
+                return false;
+            }
+
+            var resolvedValues = new List<double>();
             for (int row = firstRow; row <= lastRow; row++) {
                 for (int column = firstColumn; column <= lastColumn; column++) {
                     ExcelCellData data = sheet.GetCellValueSnapshot(row, column);
                     if (TryConvertSparklineNumber(data.Value, out double value) ||
                         TryConvertSparklineNumber(data.CachedText, out value)) {
-                        values.Add(value);
+                        resolvedValues.Add(value);
                     }
                 }
             }
 
-            return values.AsReadOnly();
+            values = resolvedValues.AsReadOnly();
+            return true;
         }
 
         private static bool TryConvertSparklineNumber(object? value, out double number) {
@@ -1320,10 +1379,28 @@ namespace OfficeIMO.Excel {
             y = 0D;
             width = 0D;
             height = 0D;
-            if (rowIndex <= 0 || columnIndex <= 0) {
+            if (rowIndex <= 0 || columnIndex <= 0 || columnsByIndex.Count == 0 || rowsByIndex.Count == 0) {
                 return false;
             }
 
+            int lastVisibleColumn = columnsByIndex.Keys.Max();
+            int lastVisibleRow = rowsByIndex.Keys.Max();
+            if (columnIndex > lastVisibleColumn || rowIndex > lastVisibleRow ||
+                (toColumnIndex.HasValue && toColumnIndex.Value < firstColumn) ||
+                (toRowIndex.HasValue && toRowIndex.Value < firstRow) ||
+                Math.Abs((long)columnIndex - firstColumn) > ExcelImageExportLimits.MaximumAnchorSpanCells ||
+                Math.Abs((long)rowIndex - firstRow) > ExcelImageExportLimits.MaximumAnchorSpanCells ||
+                (toColumnIndex.HasValue && Math.Abs((long)toColumnIndex.Value - columnIndex) > ExcelImageExportLimits.MaximumAnchorSpanCells) ||
+                (toRowIndex.HasValue && Math.Abs((long)toRowIndex.Value - rowIndex) > ExcelImageExportLimits.MaximumAnchorSpanCells)) {
+                return false;
+            }
+
+            offsetXPixels = ExcelImageExportLimits.ClampOffsetPixels(offsetXPixels);
+            offsetYPixels = ExcelImageExportLimits.ClampOffsetPixels(offsetYPixels);
+            toOffsetXPixels = ExcelImageExportLimits.ClampOffsetPixels(toOffsetXPixels);
+            toOffsetYPixels = ExcelImageExportLimits.ClampOffsetPixels(toOffsetYPixels);
+            widthPixels = ExcelImageExportLimits.ClampExtentPixels(widthPixels);
+            heightPixels = ExcelImageExportLimits.ClampExtentPixels(heightPixels);
             x = ResolveRelativeColumnOffset(firstColumn, columnIndex, offsetXPixels, columnDefinitions, options);
             y = ResolveRelativeRowOffset(firstRow, rowIndex, offsetYPixels, rowDefinitions, defaultRowsHidden, options);
             width = ResolveImageWidth(options, firstColumn, columnDefinitions, columnIndex, offsetXPixels, widthPixels, toColumnIndex, toOffsetXPixels);

--- a/OfficeIMO.Excel/Imaging/ExcelSheet.Imaging.cs
+++ b/OfficeIMO.Excel/Imaging/ExcelSheet.Imaging.cs
@@ -370,8 +370,8 @@ namespace OfficeIMO.Excel {
                         ExpandVisualAnchor(
                             image.RowIndex,
                             image.ColumnIndex,
-                            Math.Max(1, image.WidthPixels + Math.Max(0, image.OffsetXPixels)),
-                            Math.Max(1, image.HeightPixels + Math.Max(0, image.OffsetYPixels)),
+                            ExcelImageExportLimits.SaturatingAddExtent(image.WidthPixels, image.OffsetXPixels),
+                            ExcelImageExportLimits.SaturatingAddExtent(image.HeightPixels, image.OffsetYPixels),
                             columns,
                             rows,
                             defaultRowsHidden,
@@ -393,8 +393,8 @@ namespace OfficeIMO.Excel {
                             ExpandVisualAnchor(
                                 snapshot.RowIndex,
                                 snapshot.ColumnIndex,
-                                Math.Max(1, snapshot.WidthPixels + Math.Max(0, snapshot.OffsetXPixels)),
-                                Math.Max(1, snapshot.HeightPixels + Math.Max(0, snapshot.OffsetYPixels)),
+                                ExcelImageExportLimits.SaturatingAddExtent(snapshot.WidthPixels, snapshot.OffsetXPixels),
+                                ExcelImageExportLimits.SaturatingAddExtent(snapshot.HeightPixels, snapshot.OffsetYPixels),
                                 columns,
                                 rows,
                                 defaultRowsHidden,
@@ -414,8 +414,8 @@ namespace OfficeIMO.Excel {
                         ExpandVisualAnchor(
                             drawing.Row,
                             drawing.Column,
-                            Math.Max(1, drawing.WidthPixels + Math.Max(0, drawing.OffsetXPixels)),
-                            Math.Max(1, drawing.HeightPixels + Math.Max(0, drawing.OffsetYPixels)),
+                            ExcelImageExportLimits.SaturatingAddExtent(drawing.WidthPixels, drawing.OffsetXPixels),
+                            ExcelImageExportLimits.SaturatingAddExtent(drawing.HeightPixels, drawing.OffsetYPixels),
                             columns,
                             rows,
                             defaultRowsHidden,
@@ -484,10 +484,10 @@ namespace OfficeIMO.Excel {
             ref int firstColumn,
             ref int lastRow,
             ref int lastColumn) {
-            int startColumn = ResolveColumnAtAbsoluteOffset(xPixels, columns, options);
-            int endColumn = ResolveColumnAtAbsoluteOffset(xPixels + Math.Max(1, widthPixels), columns, options);
-            int startRow = ResolveRowAtAbsoluteOffset(yPixels, rows, options);
-            int endRow = ResolveRowAtAbsoluteOffset(yPixels + Math.Max(1, heightPixels), rows, options);
+            int startColumn = ResolveColumnAtAbsoluteOffset(ExcelImageExportLimits.ClampAbsoluteOffsetPixels(xPixels), columns, options);
+            int endColumn = ResolveColumnAtAbsoluteOffset(ExcelImageExportLimits.SaturatingAddAbsoluteOffset(xPixels, widthPixels), columns, options);
+            int startRow = ResolveRowAtAbsoluteOffset(ExcelImageExportLimits.ClampAbsoluteOffsetPixels(yPixels), rows, options);
+            int endRow = ResolveRowAtAbsoluteOffset(ExcelImageExportLimits.SaturatingAddAbsoluteOffset(yPixels, heightPixels), rows, options);
             firstColumn = Math.Min(firstColumn, startColumn);
             lastColumn = Math.Max(lastColumn, endColumn);
             firstRow = Math.Min(firstRow, startRow);
@@ -495,8 +495,10 @@ namespace OfficeIMO.Excel {
         }
 
         private static int ResolveColumnAtAbsoluteOffset(int offsetPixels, IReadOnlyList<ExcelColumnSnapshot> columns, ExcelImageExportOptions options) {
+            offsetPixels = ExcelImageExportLimits.ClampAbsoluteOffsetPixels(offsetPixels);
             double cursor = 0D;
-            for (int column = 1; column < 16384; column++) {
+            int maximumColumn = Math.Min(16384, ExcelImageExportLimits.MaximumAnchorSpanCells);
+            for (int column = 1; column <= maximumColumn; column++) {
                 ExcelColumnSnapshot? definition = columns.FirstOrDefault(item => column >= item.StartIndex && column <= item.EndIndex);
                 double width = ResolveColumnWidth(definition, options);
                 if (definition?.Hidden == true && !options.IncludeHidden) {
@@ -510,12 +512,14 @@ namespace OfficeIMO.Excel {
                 cursor += width;
             }
 
-            return 16384;
+            return maximumColumn;
         }
 
         private static int ResolveRowAtAbsoluteOffset(int offsetPixels, IReadOnlyDictionary<int, ExcelRowSnapshot> rows, ExcelImageExportOptions options) {
+            offsetPixels = ExcelImageExportLimits.ClampAbsoluteOffsetPixels(offsetPixels);
             double cursor = 0D;
-            for (int row = 1; row < 1048576; row++) {
+            int maximumRow = Math.Min(1048576, ExcelImageExportLimits.MaximumAnchorSpanCells);
+            for (int row = 1; row <= maximumRow; row++) {
                 rows.TryGetValue(row, out ExcelRowSnapshot? definition);
                 double height = ResolveRowHeight(definition, options);
                 if (definition?.Hidden == true && !options.IncludeHidden) {
@@ -529,13 +533,14 @@ namespace OfficeIMO.Excel {
                 cursor += height;
             }
 
-            return 1048576;
+            return maximumRow;
         }
 
         private static int ResolveLastVisualColumn(int startColumn, int widthPixels, IReadOnlyList<ExcelColumnSnapshot> columns, ExcelImageExportOptions options) {
-            double remaining = Math.Max(1D, widthPixels);
+            double remaining = Math.Max(1D, ExcelImageExportLimits.ClampExtentPixels(widthPixels));
             int column = startColumn;
-            while (column < 16384) {
+            int stopColumn = Math.Min(16384, startColumn + ExcelImageExportLimits.MaximumAnchorSpanCells);
+            while (column < stopColumn) {
                 remaining -= ResolveVisibleColumnWidth(column, columns, options);
                 if (remaining <= 0D) {
                     return column;
@@ -548,9 +553,10 @@ namespace OfficeIMO.Excel {
         }
 
         private static int ResolveLastVisualRow(int startRow, int heightPixels, IReadOnlyDictionary<int, ExcelRowSnapshot> rows, bool defaultRowsHidden, ExcelImageExportOptions options) {
-            double remaining = Math.Max(1D, heightPixels);
+            double remaining = Math.Max(1D, ExcelImageExportLimits.ClampExtentPixels(heightPixels));
             int row = startRow;
-            while (row < 1048576) {
+            int stopRow = Math.Min(1048576, startRow + ExcelImageExportLimits.MaximumAnchorSpanCells);
+            while (row < stopRow) {
                 rows.TryGetValue(row, out ExcelRowSnapshot? definition);
                 remaining -= ResolveVisibleRowHeight(row, definition, rows, defaultRowsHidden, options);
                 if (remaining <= 0D) {

--- a/OfficeIMO.Excel/Utilities/ExcelNumberFormatDisplay.cs
+++ b/OfficeIMO.Excel/Utilities/ExcelNumberFormatDisplay.cs
@@ -372,10 +372,14 @@ namespace OfficeIMO.Excel {
             double displayValue = selectedSection == 1 ? Math.Abs(value) : value;
             bool negative = displayValue < 0D;
             double absoluteValue = Math.Abs(displayValue);
-            int whole = (int)Math.Floor(absoluteValue);
+            if (absoluteValue >= long.MaxValue) {
+                return false;
+            }
+
+            long whole = (long)Math.Floor(absoluteValue);
             double fractional = absoluteValue - whole;
-            int numerator = 0;
-            int denominator = 1;
+            long numerator = 0L;
+            long denominator = 1L;
 
             if (fractional > 0.0000000001D) {
                 if (fixedDenominator) {
@@ -384,7 +388,7 @@ namespace OfficeIMO.Excel {
                 } else {
                     double bestError = double.MaxValue;
                     for (int currentDenominator = 1; currentDenominator <= maxDenominator; currentDenominator++) {
-                        int currentNumerator = (int)Math.Round(fractional * currentDenominator, MidpointRounding.AwayFromZero);
+                        long currentNumerator = (long)Math.Round(fractional * currentDenominator, MidpointRounding.AwayFromZero);
                         double candidate = currentNumerator / (double)currentDenominator;
                         double error = Math.Abs(candidate - fractional);
                         if (error + 0.0000000001D < bestError) {
@@ -396,6 +400,10 @@ namespace OfficeIMO.Excel {
                 }
 
                 if (numerator >= denominator) {
+                    if (whole > long.MaxValue - (numerator / denominator)) {
+                        return false;
+                    }
+
                     whole += numerator / denominator;
                     numerator %= denominator;
                 }
@@ -403,6 +411,10 @@ namespace OfficeIMO.Excel {
 
             bool mixedFraction = HasMixedFractionWholePart(formatCode, slash);
             if (!mixedFraction && numerator > 0) {
+                if (whole > (long.MaxValue - numerator) / denominator) {
+                    return false;
+                }
+
                 numerator += whole * denominator;
                 whole = 0;
             }

--- a/OfficeIMO.Excel/Utilities/ExcelNumberFormatDisplay.cs
+++ b/OfficeIMO.Excel/Utilities/ExcelNumberFormatDisplay.cs
@@ -257,7 +257,7 @@ namespace OfficeIMO.Excel {
             }
 
             if (TryFormatFraction(value, normalized, selectedSection, out string fractionText)) {
-                return ApplyNumericAffixes(normalized, fractionText);
+                return ApplyFractionAffixes(normalized, fractionText);
             }
 
             if (lower.Contains("e+") || lower.Contains("e-")) {
@@ -378,17 +378,20 @@ namespace OfficeIMO.Excel {
             int denominator = 1;
 
             if (fractional > 0.0000000001D) {
-                double bestError = double.MaxValue;
-                int startDenominator = fixedDenominator ? fixedValue : 1;
-                int endDenominator = fixedDenominator ? fixedValue : maxDenominator;
-                for (int currentDenominator = startDenominator; currentDenominator <= endDenominator; currentDenominator++) {
-                    int currentNumerator = (int)Math.Round(fractional * currentDenominator, MidpointRounding.AwayFromZero);
-                    double candidate = currentNumerator / (double)currentDenominator;
-                    double error = Math.Abs(candidate - fractional);
-                    if (error + 0.0000000001D < bestError) {
-                        bestError = error;
-                        numerator = currentNumerator;
-                        denominator = currentDenominator;
+                if (fixedDenominator) {
+                    denominator = fixedValue;
+                    numerator = (int)Math.Round(fractional * denominator, MidpointRounding.AwayFromZero);
+                } else {
+                    double bestError = double.MaxValue;
+                    for (int currentDenominator = 1; currentDenominator <= maxDenominator; currentDenominator++) {
+                        int currentNumerator = (int)Math.Round(fractional * currentDenominator, MidpointRounding.AwayFromZero);
+                        double candidate = currentNumerator / (double)currentDenominator;
+                        double error = Math.Abs(candidate - fractional);
+                        if (error + 0.0000000001D < bestError) {
+                            bestError = error;
+                            numerator = currentNumerator;
+                            denominator = currentDenominator;
+                        }
                     }
                 }
 
@@ -804,6 +807,42 @@ namespace OfficeIMO.Excel {
         private static string ApplyNumericAffixes(string formatCode, string numericText) {
             int first = FindFirstNumericPlaceholder(formatCode);
             int last = FindLastNumericPlaceholder(formatCode);
+            if (first < 0 || last < first) {
+                return CleanLiteralAffix(formatCode);
+            }
+
+            string prefix = CleanLiteralAffix(formatCode.Substring(0, first));
+            string suffix = CleanLiteralAffix(formatCode.Substring(last + 1));
+            return prefix + numericText + suffix;
+        }
+
+        private static string ApplyFractionAffixes(string formatCode, string numericText) {
+            int first = FindFirstNumericPlaceholder(formatCode);
+            int last = FindLastNumericPlaceholder(formatCode);
+            int slash = formatCode.IndexOf('/');
+            if (slash >= 0) {
+                int denominatorEnd = slash;
+                for (int i = slash + 1; i < formatCode.Length; i++) {
+                    char ch = formatCode[i];
+                    if (char.IsWhiteSpace(ch)) {
+                        if (denominatorEnd > slash) {
+                            break;
+                        }
+
+                        continue;
+                    }
+
+                    if (char.IsDigit(ch) || IsNumericPlaceholder(ch)) {
+                        denominatorEnd = i;
+                        continue;
+                    }
+
+                    break;
+                }
+
+                last = Math.Max(last, denominatorEnd);
+            }
+
             if (first < 0 || last < first) {
                 return CleanLiteralAffix(formatCode);
             }

--- a/OfficeIMO.Excel/Utilities/ExcelWorksheetDrawingObjectResolver.cs
+++ b/OfficeIMO.Excel/Utilities/ExcelWorksheetDrawingObjectResolver.cs
@@ -22,10 +22,11 @@ namespace OfficeIMO.Excel.Utilities {
             }
 
             WorkbookPart? workbookPart = worksheetPart.GetParentParts().OfType<WorkbookPart>().FirstOrDefault();
+            ExcelWorksheetGeometryIndex geometry = ExcelWorksheetGeometryIndex.Create(worksheetPart);
             var objects = new List<ExcelWorksheetDrawingObjectInfo>();
             for (int order = 0; order < worksheetDrawing.ChildElements.Count; order++) {
                 OpenXmlElement anchor = worksheetDrawing.ChildElements[order];
-                AnchorPosition position = GetAnchorPosition(anchor, worksheetPart);
+                AnchorPosition position = GetAnchorPosition(anchor, geometry);
                 foreach (OpenXmlElement element in anchor.ChildElements) {
                     if (element is Xdr.Shape shape) {
                         objects.Add(CreateShapeInfo(shape, position, order, workbookPart));
@@ -300,12 +301,12 @@ namespace OfficeIMO.Excel.Utilities {
             return new DrawingTextStyle(colorArgb, fontFamily, fontSize, fontStyle);
         }
 
-        private static AnchorPosition GetAnchorPosition(OpenXmlElement anchor, WorksheetPart worksheetPart) {
+        private static AnchorPosition GetAnchorPosition(OpenXmlElement anchor, ExcelWorksheetGeometryIndex geometry) {
             if (anchor is Xdr.AbsoluteAnchor absoluteAnchor) {
                 int absoluteX = ExcelImageExportLimits.ClampAbsoluteOffsetPixels(ParseEmuPixels(absoluteAnchor.Position?.X?.Value));
                 int absoluteY = ExcelImageExportLimits.ClampAbsoluteOffsetPixels(ParseEmuPixels(absoluteAnchor.Position?.Y?.Value));
-                ResolveAbsoluteColumn(worksheetPart, absoluteX, out int absoluteColumn, out int columnOffset);
-                ResolveAbsoluteRow(worksheetPart, absoluteY, out int absoluteRow, out int rowOffset);
+                ResolveAbsoluteColumn(geometry, absoluteX, out int absoluteColumn, out int columnOffset);
+                ResolveAbsoluteRow(geometry, absoluteY, out int absoluteRow, out int rowOffset);
                 return new AnchorPosition(
                     absoluteRow,
                     absoluteColumn,
@@ -338,19 +339,19 @@ namespace OfficeIMO.Excel.Utilities {
             int width = ExcelImageExportLimits.ClampExtentPixels(ParseEmuPixels(extent?.Cx?.Value));
             int height = ExcelImageExportLimits.ClampExtentPixels(ParseEmuPixels(extent?.Cy?.Value));
             if (anchor is Xdr.TwoCellAnchor && toColumn.HasValue && toRow.HasValue) {
-                width = ResolveTwoCellWidthPixels(worksheetPart, column, offsetX, toColumn.Value, toOffsetX);
-                height = ResolveTwoCellHeightPixels(worksheetPart, row, offsetY, toRow.Value, toOffsetY);
+                width = ResolveTwoCellWidthPixels(geometry, column, offsetX, toColumn.Value, toOffsetX);
+                height = ResolveTwoCellHeightPixels(geometry, row, offsetY, toRow.Value, toOffsetY);
             }
 
             return new AnchorPosition(row, column, offsetX, offsetY, width, height, toColumn, toRow, toOffsetX, toOffsetY);
         }
 
-        private static void ResolveAbsoluteColumn(WorksheetPart worksheetPart, int absolutePixels, out int column, out int offsetPixels) {
+        private static void ResolveAbsoluteColumn(ExcelWorksheetGeometryIndex geometry, int absolutePixels, out int column, out int offsetPixels) {
             absolutePixels = ExcelImageExportLimits.ClampAbsoluteOffsetPixels(absolutePixels);
             int cursor = 0;
             int maximumColumn = Math.Min(16384, ExcelImageExportLimits.MaximumAnchorSpanCells);
             for (column = 1; column <= maximumColumn; column++) {
-                int width = GetColumnWidthPixels(worksheetPart, column);
+                int width = geometry.GetSimpleColumnWidthPixels(column);
                 if (cursor + width >= absolutePixels) {
                     offsetPixels = Math.Max(0, absolutePixels - cursor);
                     return;
@@ -363,12 +364,12 @@ namespace OfficeIMO.Excel.Utilities {
             offsetPixels = 0;
         }
 
-        private static void ResolveAbsoluteRow(WorksheetPart worksheetPart, int absolutePixels, out int row, out int offsetPixels) {
+        private static void ResolveAbsoluteRow(ExcelWorksheetGeometryIndex geometry, int absolutePixels, out int row, out int offsetPixels) {
             absolutePixels = ExcelImageExportLimits.ClampAbsoluteOffsetPixels(absolutePixels);
             int cursor = 0;
             int maximumRow = Math.Min(1048576, ExcelImageExportLimits.MaximumAnchorSpanCells);
             for (row = 1; row <= maximumRow; row++) {
-                int height = GetRowHeightPixels(worksheetPart, row);
+                int height = geometry.GetRowHeightPixels(row);
                 if (cursor + height >= absolutePixels) {
                     offsetPixels = Math.Max(0, absolutePixels - cursor);
                     return;
@@ -381,67 +382,30 @@ namespace OfficeIMO.Excel.Utilities {
             offsetPixels = 0;
         }
 
-        private static int ResolveTwoCellWidthPixels(WorksheetPart worksheetPart, int fromColumn, int fromOffsetPixels, int toColumn, int toOffsetPixels) {
+        private static int ResolveTwoCellWidthPixels(ExcelWorksheetGeometryIndex geometry, int fromColumn, int fromOffsetPixels, int toColumn, int toOffsetPixels) {
             if (!ExcelImageExportLimits.IsValidMarkerSpan(fromColumn - 1, toColumn - 1, 16384)) {
                 return 0;
             }
 
             long pixels = -(long)fromOffsetPixels + toOffsetPixels;
             for (int column = fromColumn; column < toColumn; column++) {
-                pixels += GetColumnWidthPixels(worksheetPart, column);
+                pixels += geometry.GetSimpleColumnWidthPixels(column);
             }
 
             return ExcelImageExportLimits.ClampExtentPixels((int)Math.Max(0L, Math.Min(int.MaxValue, pixels)));
         }
 
-        private static int ResolveTwoCellHeightPixels(WorksheetPart worksheetPart, int fromRow, int fromOffsetPixels, int toRow, int toOffsetPixels) {
+        private static int ResolveTwoCellHeightPixels(ExcelWorksheetGeometryIndex geometry, int fromRow, int fromOffsetPixels, int toRow, int toOffsetPixels) {
             if (!ExcelImageExportLimits.IsValidMarkerSpan(fromRow - 1, toRow - 1, 1048576)) {
                 return 0;
             }
 
             long pixels = -(long)fromOffsetPixels + toOffsetPixels;
             for (int row = fromRow; row < toRow; row++) {
-                pixels += GetRowHeightPixels(worksheetPart, row);
+                pixels += geometry.GetRowHeightPixels(row);
             }
 
             return ExcelImageExportLimits.ClampExtentPixels((int)Math.Max(0L, Math.Min(int.MaxValue, pixels)));
-        }
-
-        private static int GetColumnWidthPixels(WorksheetPart worksheetPart, int columnIndex) {
-            DocumentFormat.OpenXml.Spreadsheet.Worksheet? worksheet = worksheetPart.Worksheet;
-            DocumentFormat.OpenXml.Spreadsheet.Column? column = worksheet?
-                .GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.Columns>()?
-                .Elements<DocumentFormat.OpenXml.Spreadsheet.Column>()
-                .FirstOrDefault(item => item.Min != null && item.Max != null && item.Min.Value <= (uint)columnIndex && item.Max.Value >= (uint)columnIndex);
-            if (column?.Hidden?.Value == true) {
-                return 0;
-            }
-
-            double width = column?.Width?.Value > 0 && column.CustomWidth?.Value == true
-                ? column.Width.Value
-                : worksheet?.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.SheetFormatProperties>()?.DefaultColumnWidth?.Value > 0
-                    ? worksheet.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.SheetFormatProperties>()!.DefaultColumnWidth!.Value
-                    : 8.43D;
-            double pixels = Math.Round((width * 7D) + 5D, 2);
-            return Math.Max(1, (int)Math.Round(pixels));
-        }
-
-        private static int GetRowHeightPixels(WorksheetPart worksheetPart, int rowIndex) {
-            DocumentFormat.OpenXml.Spreadsheet.Worksheet? worksheet = worksheetPart.Worksheet;
-            DocumentFormat.OpenXml.Spreadsheet.Row? row = worksheet?
-                .GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.SheetData>()?
-                .Elements<DocumentFormat.OpenXml.Spreadsheet.Row>()
-                .FirstOrDefault(item => item.RowIndex != null && item.RowIndex.Value == (uint)rowIndex);
-            if (row?.Hidden?.Value == true) {
-                return 0;
-            }
-
-            double heightPoints = row?.Height?.Value > 0 && row.CustomHeight?.Value == true
-                ? row.Height.Value
-                : worksheet?.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.SheetFormatProperties>()?.DefaultRowHeight?.Value > 0
-                    ? worksheet.GetFirstChild<DocumentFormat.OpenXml.Spreadsheet.SheetFormatProperties>()!.DefaultRowHeight!.Value
-                    : 15D;
-            return Math.Max(1, (int)Math.Round(heightPoints * 96D / 72D));
         }
 
         private static bool TryGetShapePreset(Xdr.Shape shape, out string shapePresetName, out OfficeShapeKind shapeKind, out string? unsupportedReason) {
@@ -532,7 +496,7 @@ namespace OfficeIMO.Excel.Utilities {
             }
 
             if (outline.Width != null && outline.Width.Value > 0) {
-                strokeWidth = Math.Max(1D, outline.Width.Value / EmusPerPixel);
+                strokeWidth = ExcelImageExportLimits.ClampStrokeWidth(Math.Max(1D, outline.Width.Value / EmusPerPixel));
             }
 
             strokeDashStyle = ResolveStrokeDashStyle(outline);

--- a/OfficeIMO.Excel/Utilities/ExcelWorksheetDrawingObjectResolver.cs
+++ b/OfficeIMO.Excel/Utilities/ExcelWorksheetDrawingObjectResolver.cs
@@ -302,8 +302,8 @@ namespace OfficeIMO.Excel.Utilities {
 
         private static AnchorPosition GetAnchorPosition(OpenXmlElement anchor, WorksheetPart worksheetPart) {
             if (anchor is Xdr.AbsoluteAnchor absoluteAnchor) {
-                int absoluteX = ParseEmuPixels(absoluteAnchor.Position?.X?.Value);
-                int absoluteY = ParseEmuPixels(absoluteAnchor.Position?.Y?.Value);
+                int absoluteX = ExcelImageExportLimits.ClampAbsoluteOffsetPixels(ParseEmuPixels(absoluteAnchor.Position?.X?.Value));
+                int absoluteY = ExcelImageExportLimits.ClampAbsoluteOffsetPixels(ParseEmuPixels(absoluteAnchor.Position?.Y?.Value));
                 ResolveAbsoluteColumn(worksheetPart, absoluteX, out int absoluteColumn, out int columnOffset);
                 ResolveAbsoluteRow(worksheetPart, absoluteY, out int absoluteRow, out int rowOffset);
                 return new AnchorPosition(
@@ -311,8 +311,8 @@ namespace OfficeIMO.Excel.Utilities {
                     absoluteColumn,
                     columnOffset,
                     rowOffset,
-                    ParseEmuPixels(absoluteAnchor.Extent?.Cx?.Value),
-                    ParseEmuPixels(absoluteAnchor.Extent?.Cy?.Value),
+                    ExcelImageExportLimits.ClampExtentPixels(ParseEmuPixels(absoluteAnchor.Extent?.Cx?.Value)),
+                    ExcelImageExportLimits.ClampExtentPixels(ParseEmuPixels(absoluteAnchor.Extent?.Cy?.Value)),
                     toColumn: null,
                     toRow: null,
                     toOffsetXPixels: 0,
@@ -327,16 +327,16 @@ namespace OfficeIMO.Excel.Utilities {
             Xdr.MarkerType? toMarker = anchor is Xdr.TwoCellAnchor twoCell ? twoCell.ToMarker : null;
             Xdr.Extent? extent = anchor is Xdr.OneCellAnchor oneCell ? oneCell.Extent : null;
 
-            int row = ParseOneBasedMarker(fromMarker?.RowId?.Text);
-            int column = ParseOneBasedMarker(fromMarker?.ColumnId?.Text);
-            int offsetX = ParseEmuPixels(fromMarker?.ColumnOffset?.Text);
-            int offsetY = ParseEmuPixels(fromMarker?.RowOffset?.Text);
-            int? toRow = ParseOneBasedMarkerOrNull(toMarker?.RowId?.Text);
-            int? toColumn = ParseOneBasedMarkerOrNull(toMarker?.ColumnId?.Text);
-            int toOffsetX = ParseEmuPixels(toMarker?.ColumnOffset?.Text);
-            int toOffsetY = ParseEmuPixels(toMarker?.RowOffset?.Text);
-            int width = ParseEmuPixels(extent?.Cx?.Value);
-            int height = ParseEmuPixels(extent?.Cy?.Value);
+            int row = ParseOneBasedMarker(fromMarker?.RowId?.Text, 1048576);
+            int column = ParseOneBasedMarker(fromMarker?.ColumnId?.Text, 16384);
+            int offsetX = ExcelImageExportLimits.ClampOffsetPixels(ParseEmuPixels(fromMarker?.ColumnOffset?.Text));
+            int offsetY = ExcelImageExportLimits.ClampOffsetPixels(ParseEmuPixels(fromMarker?.RowOffset?.Text));
+            int? toRow = ParseOneBasedMarkerOrNull(toMarker?.RowId?.Text, 1048576);
+            int? toColumn = ParseOneBasedMarkerOrNull(toMarker?.ColumnId?.Text, 16384);
+            int toOffsetX = ExcelImageExportLimits.ClampOffsetPixels(ParseEmuPixels(toMarker?.ColumnOffset?.Text));
+            int toOffsetY = ExcelImageExportLimits.ClampOffsetPixels(ParseEmuPixels(toMarker?.RowOffset?.Text));
+            int width = ExcelImageExportLimits.ClampExtentPixels(ParseEmuPixels(extent?.Cx?.Value));
+            int height = ExcelImageExportLimits.ClampExtentPixels(ParseEmuPixels(extent?.Cy?.Value));
             if (anchor is Xdr.TwoCellAnchor && toColumn.HasValue && toRow.HasValue) {
                 width = ResolveTwoCellWidthPixels(worksheetPart, column, offsetX, toColumn.Value, toOffsetX);
                 height = ResolveTwoCellHeightPixels(worksheetPart, row, offsetY, toRow.Value, toOffsetY);
@@ -346,8 +346,10 @@ namespace OfficeIMO.Excel.Utilities {
         }
 
         private static void ResolveAbsoluteColumn(WorksheetPart worksheetPart, int absolutePixels, out int column, out int offsetPixels) {
+            absolutePixels = ExcelImageExportLimits.ClampAbsoluteOffsetPixels(absolutePixels);
             int cursor = 0;
-            for (column = 1; column < 16384; column++) {
+            int maximumColumn = Math.Min(16384, ExcelImageExportLimits.MaximumAnchorSpanCells);
+            for (column = 1; column <= maximumColumn; column++) {
                 int width = GetColumnWidthPixels(worksheetPart, column);
                 if (cursor + width >= absolutePixels) {
                     offsetPixels = Math.Max(0, absolutePixels - cursor);
@@ -357,12 +359,15 @@ namespace OfficeIMO.Excel.Utilities {
                 cursor += width;
             }
 
+            column = maximumColumn;
             offsetPixels = 0;
         }
 
         private static void ResolveAbsoluteRow(WorksheetPart worksheetPart, int absolutePixels, out int row, out int offsetPixels) {
+            absolutePixels = ExcelImageExportLimits.ClampAbsoluteOffsetPixels(absolutePixels);
             int cursor = 0;
-            for (row = 1; row < 1048576; row++) {
+            int maximumRow = Math.Min(1048576, ExcelImageExportLimits.MaximumAnchorSpanCells);
+            for (row = 1; row <= maximumRow; row++) {
                 int height = GetRowHeightPixels(worksheetPart, row);
                 if (cursor + height >= absolutePixels) {
                     offsetPixels = Math.Max(0, absolutePixels - cursor);
@@ -372,33 +377,34 @@ namespace OfficeIMO.Excel.Utilities {
                 cursor += height;
             }
 
+            row = maximumRow;
             offsetPixels = 0;
         }
 
         private static int ResolveTwoCellWidthPixels(WorksheetPart worksheetPart, int fromColumn, int fromOffsetPixels, int toColumn, int toOffsetPixels) {
-            if (fromColumn <= 0 || toColumn <= 0 || toColumn < fromColumn) {
+            if (!ExcelImageExportLimits.IsValidMarkerSpan(fromColumn - 1, toColumn - 1, 16384)) {
                 return 0;
             }
 
-            int pixels = -fromOffsetPixels + toOffsetPixels;
+            long pixels = -(long)fromOffsetPixels + toOffsetPixels;
             for (int column = fromColumn; column < toColumn; column++) {
                 pixels += GetColumnWidthPixels(worksheetPart, column);
             }
 
-            return Math.Max(0, pixels);
+            return ExcelImageExportLimits.ClampExtentPixels((int)Math.Max(0L, Math.Min(int.MaxValue, pixels)));
         }
 
         private static int ResolveTwoCellHeightPixels(WorksheetPart worksheetPart, int fromRow, int fromOffsetPixels, int toRow, int toOffsetPixels) {
-            if (fromRow <= 0 || toRow <= 0 || toRow < fromRow) {
+            if (!ExcelImageExportLimits.IsValidMarkerSpan(fromRow - 1, toRow - 1, 1048576)) {
                 return 0;
             }
 
-            int pixels = -fromOffsetPixels + toOffsetPixels;
+            long pixels = -(long)fromOffsetPixels + toOffsetPixels;
             for (int row = fromRow; row < toRow; row++) {
                 pixels += GetRowHeightPixels(worksheetPart, row);
             }
 
-            return Math.Max(0, pixels);
+            return ExcelImageExportLimits.ClampExtentPixels((int)Math.Max(0L, Math.Min(int.MaxValue, pixels)));
         }
 
         private static int GetColumnWidthPixels(WorksheetPart worksheetPart, int columnIndex) {
@@ -778,19 +784,28 @@ namespace OfficeIMO.Excel.Utilities {
         private static string? NormalizeFontFamily(string? value) =>
             string.IsNullOrWhiteSpace(value) ? null : value!.Trim();
 
-        private static int ParseOneBasedMarker(string? value) =>
-            int.TryParse(value, out int zeroBased) && zeroBased >= 0 ? zeroBased + 1 : 0;
+        private static int ParseOneBasedMarker(string? value, int maximum) =>
+            int.TryParse(value, out int zeroBased) && zeroBased >= 0 && zeroBased < maximum ? zeroBased + 1 : 0;
 
-        private static int? ParseOneBasedMarkerOrNull(string? value) {
-            int parsed = ParseOneBasedMarker(value);
+        private static int? ParseOneBasedMarkerOrNull(string? value, int maximum) {
+            int parsed = ParseOneBasedMarker(value, maximum);
             return parsed > 0 ? parsed : null;
         }
 
         private static int ParseEmuPixels(string? value) =>
-            long.TryParse(value, out long emus) ? Math.Max(0, (int)Math.Round(emus / EmusPerPixel)) : 0;
+            long.TryParse(value, out long emus) ? ConvertEmuToPixels(emus) : 0;
 
         private static int ParseEmuPixels(long? value) =>
-            value.HasValue ? Math.Max(0, (int)Math.Round(value.Value / EmusPerPixel)) : 0;
+            value.HasValue ? ConvertEmuToPixels(value.Value) : 0;
+
+        private static int ConvertEmuToPixels(long emus) {
+            double pixels = Math.Round(emus / EmusPerPixel);
+            if (pixels <= 0D) {
+                return 0;
+            }
+
+            return pixels >= int.MaxValue ? int.MaxValue : (int)pixels;
+        }
 
         private readonly struct AnchorPosition {
             internal AnchorPosition(

--- a/OfficeIMO.Excel/Utilities/ExcelWorksheetGeometryIndex.cs
+++ b/OfficeIMO.Excel/Utilities/ExcelWorksheetGeometryIndex.cs
@@ -1,0 +1,115 @@
+using DocumentFormat.OpenXml.Packaging;
+using X = DocumentFormat.OpenXml.Spreadsheet;
+
+namespace OfficeIMO.Excel.Utilities {
+    internal sealed class ExcelWorksheetGeometryIndex {
+        private const int MaximumColumnDefinitionWork = 100_000;
+        private const int MaximumIndexedRows = 100_000;
+        private readonly X.Column?[] _columns;
+        private readonly IReadOnlyDictionary<int, X.Row> _rows;
+        private readonly double _defaultColumnWidth;
+        private readonly double _defaultRowHeightPoints;
+
+        private ExcelWorksheetGeometryIndex(
+            X.Column?[] columns,
+            IReadOnlyDictionary<int, X.Row> rows,
+            double defaultColumnWidth,
+            double defaultRowHeightPoints) {
+            _columns = columns;
+            _rows = rows;
+            _defaultColumnWidth = defaultColumnWidth;
+            _defaultRowHeightPoints = defaultRowHeightPoints;
+        }
+
+        internal static ExcelWorksheetGeometryIndex Create(WorksheetPart? worksheetPart) {
+            X.Worksheet? worksheet = worksheetPart?.Worksheet;
+            X.SheetFormatProperties? format = worksheet?.GetFirstChild<X.SheetFormatProperties>();
+            double defaultColumnWidth = format?.DefaultColumnWidth?.Value > 0
+                ? format.DefaultColumnWidth.Value
+                : 8.43D;
+            double defaultRowHeight = format?.DefaultRowHeight?.Value > 0
+                ? format.DefaultRowHeight.Value
+                : 15D;
+
+            var columns = new X.Column?[16385];
+            int remainingColumnWork = MaximumColumnDefinitionWork;
+            foreach (X.Column definition in worksheet?
+                .GetFirstChild<X.Columns>()?
+                .Elements<X.Column>() ?? Enumerable.Empty<X.Column>()) {
+                if (remainingColumnWork <= 0) {
+                    break;
+                }
+
+                if (definition.Min?.Value is not uint minimum ||
+                    definition.Max?.Value is not uint maximum ||
+                    minimum == 0U ||
+                    minimum > 16384U ||
+                    maximum < minimum) {
+                    continue;
+                }
+
+                int start = (int)minimum;
+                int end = (int)Math.Min(16384U, maximum);
+
+                for (int column = start; column <= end && remainingColumnWork > 0; column++, remainingColumnWork--) {
+                    columns[column] ??= definition;
+                }
+            }
+
+            var rows = new Dictionary<int, X.Row>();
+            foreach (X.Row row in worksheet?
+                .GetFirstChild<X.SheetData>()?
+                .Elements<X.Row>() ?? Enumerable.Empty<X.Row>()) {
+                if (rows.Count >= MaximumIndexedRows) {
+                    break;
+                }
+
+                if (row.RowIndex?.Value is uint rowIndex && rowIndex > 0U && rowIndex <= 1048576U) {
+                    int index = (int)rowIndex;
+                    if (!rows.ContainsKey(index)) {
+                        rows[index] = row;
+                    }
+                }
+            }
+
+            return new ExcelWorksheetGeometryIndex(columns, rows, defaultColumnWidth, defaultRowHeight);
+        }
+
+        internal int GetSimpleColumnWidthPixels(int columnIndex) {
+            X.Column? column = columnIndex > 0 && columnIndex < _columns.Length ? _columns[columnIndex] : null;
+            if (column?.Hidden?.Value == true) {
+                return 0;
+            }
+
+            double width = column?.Width?.Value > 0 && column.CustomWidth?.Value == true
+                ? column.Width.Value
+                : _defaultColumnWidth;
+            return Math.Max(1, (int)Math.Round(Math.Round((width * 7D) + 5D, 2)));
+        }
+
+        internal int GetColumnWidthPixels(int columnIndex, double maximumDigitWidth) {
+            X.Column? column = columnIndex > 0 && columnIndex < _columns.Length ? _columns[columnIndex] : null;
+            if (column?.Hidden?.Value == true) {
+                return 0;
+            }
+
+            double width = column?.Width?.Value > 0 && column.CustomWidth?.Value == true
+                ? column.Width.Value
+                : _defaultColumnWidth;
+            double pixels = Math.Truncate((256D * width + Math.Truncate(128D / maximumDigitWidth)) / 256D * maximumDigitWidth);
+            return Math.Max(1, (int)Math.Round(pixels));
+        }
+
+        internal int GetRowHeightPixels(int rowIndex) {
+            _rows.TryGetValue(rowIndex, out X.Row? row);
+            if (row?.Hidden?.Value == true) {
+                return 0;
+            }
+
+            double heightPoints = row?.Height?.Value > 0 && row.CustomHeight?.Value == true
+                ? row.Height.Value
+                : _defaultRowHeightPoints;
+            return Math.Max(1, (int)Math.Round(heightPoints * 96D / 72D));
+        }
+    }
+}

--- a/OfficeIMO.Excel/Utilities/ExcelWorksheetGeometryIndex.cs
+++ b/OfficeIMO.Excel/Utilities/ExcelWorksheetGeometryIndex.cs
@@ -5,6 +5,7 @@ namespace OfficeIMO.Excel.Utilities {
     internal sealed class ExcelWorksheetGeometryIndex {
         private const int MaximumColumnDefinitionWork = 100_000;
         private const int MaximumIndexedRows = 100_000;
+        private const int MaximumOverflowRowDefinitionWork = 1_048_576;
         private readonly X.Column?[] _columns;
         private readonly IReadOnlyDictionary<int, X.Row> _rows;
         private readonly X.SheetData? _sheetData;
@@ -65,10 +66,14 @@ namespace OfficeIMO.Excel.Utilities {
 
             X.SheetData? sheetData = worksheet?.GetFirstChild<X.SheetData>();
             var rows = new Dictionary<int, X.Row>();
+            int processedRowDefinitions = 0;
+            bool rowIndexMayBeTruncated = false;
             foreach (X.Row row in sheetData?.Elements<X.Row>() ?? Enumerable.Empty<X.Row>()) {
-                if (rows.Count >= MaximumIndexedRows) {
+                if (processedRowDefinitions >= MaximumIndexedRows) {
+                    rowIndexMayBeTruncated = true;
                     break;
                 }
+                processedRowDefinitions++;
 
                 if (row.RowIndex?.Value is uint rowIndex && rowIndex > 0U && rowIndex <= 1048576U) {
                     int index = (int)rowIndex;
@@ -82,7 +87,7 @@ namespace OfficeIMO.Excel.Utilities {
                 columns,
                 rows,
                 sheetData,
-                rows.Count >= MaximumIndexedRows,
+                rowIndexMayBeTruncated,
                 defaultColumnWidth,
                 defaultRowHeight);
         }
@@ -152,7 +157,13 @@ namespace OfficeIMO.Excel.Utilities {
             }
 
             var heights = new double[1048577];
+            int processedRowDefinitions = 0;
             foreach (X.Row row in _sheetData?.Elements<X.Row>() ?? Enumerable.Empty<X.Row>()) {
+                if (processedRowDefinitions >= MaximumOverflowRowDefinitionWork) {
+                    break;
+                }
+                processedRowDefinitions++;
+
                 if (row.RowIndex?.Value is not uint rowIndex || rowIndex == 0U || rowIndex > 1048576U || _rows.ContainsKey((int)rowIndex)) {
                     continue;
                 }

--- a/OfficeIMO.Excel/Utilities/ExcelWorksheetGeometryIndex.cs
+++ b/OfficeIMO.Excel/Utilities/ExcelWorksheetGeometryIndex.cs
@@ -47,6 +47,7 @@ namespace OfficeIMO.Excel.Utilities {
                 if (remainingColumnWork <= 0) {
                     break;
                 }
+                remainingColumnWork--;
 
                 if (definition.Min?.Value is not uint minimum ||
                     definition.Max?.Value is not uint maximum ||
@@ -157,6 +158,7 @@ namespace OfficeIMO.Excel.Utilities {
             }
 
             var heights = new double[1048577];
+            var assigned = new bool[1048577];
             int processedRowDefinitions = 0;
             foreach (X.Row row in _sheetData?.Elements<X.Row>() ?? Enumerable.Empty<X.Row>()) {
                 if (processedRowDefinitions >= MaximumOverflowRowDefinitionWork) {
@@ -164,10 +166,12 @@ namespace OfficeIMO.Excel.Utilities {
                 }
                 processedRowDefinitions++;
 
-                if (row.RowIndex?.Value is not uint rowIndex || rowIndex == 0U || rowIndex > 1048576U || _rows.ContainsKey((int)rowIndex)) {
+                if (row.RowIndex?.Value is not uint rowIndex || rowIndex == 0U || rowIndex > 1048576U ||
+                    _rows.ContainsKey((int)rowIndex) || assigned[rowIndex]) {
                     continue;
                 }
 
+                assigned[rowIndex] = true;
                 heights[rowIndex] = row.Hidden?.Value == true
                     ? -1D
                     : row.Height?.Value > 0D && row.CustomHeight?.Value == true

--- a/OfficeIMO.Excel/Utilities/ExcelWorksheetGeometryIndex.cs
+++ b/OfficeIMO.Excel/Utilities/ExcelWorksheetGeometryIndex.cs
@@ -7,16 +7,23 @@ namespace OfficeIMO.Excel.Utilities {
         private const int MaximumIndexedRows = 100_000;
         private readonly X.Column?[] _columns;
         private readonly IReadOnlyDictionary<int, X.Row> _rows;
+        private readonly X.SheetData? _sheetData;
+        private readonly bool _rowIndexMayBeTruncated;
         private readonly double _defaultColumnWidth;
         private readonly double _defaultRowHeightPoints;
+        private double[]? _overflowRowHeights;
 
         private ExcelWorksheetGeometryIndex(
             X.Column?[] columns,
             IReadOnlyDictionary<int, X.Row> rows,
+            X.SheetData? sheetData,
+            bool rowIndexMayBeTruncated,
             double defaultColumnWidth,
             double defaultRowHeightPoints) {
             _columns = columns;
             _rows = rows;
+            _sheetData = sheetData;
+            _rowIndexMayBeTruncated = rowIndexMayBeTruncated;
             _defaultColumnWidth = defaultColumnWidth;
             _defaultRowHeightPoints = defaultRowHeightPoints;
         }
@@ -56,10 +63,9 @@ namespace OfficeIMO.Excel.Utilities {
                 }
             }
 
+            X.SheetData? sheetData = worksheet?.GetFirstChild<X.SheetData>();
             var rows = new Dictionary<int, X.Row>();
-            foreach (X.Row row in worksheet?
-                .GetFirstChild<X.SheetData>()?
-                .Elements<X.Row>() ?? Enumerable.Empty<X.Row>()) {
+            foreach (X.Row row in sheetData?.Elements<X.Row>() ?? Enumerable.Empty<X.Row>()) {
                 if (rows.Count >= MaximumIndexedRows) {
                     break;
                 }
@@ -72,7 +78,13 @@ namespace OfficeIMO.Excel.Utilities {
                 }
             }
 
-            return new ExcelWorksheetGeometryIndex(columns, rows, defaultColumnWidth, defaultRowHeight);
+            return new ExcelWorksheetGeometryIndex(
+                columns,
+                rows,
+                sheetData,
+                rows.Count >= MaximumIndexedRows,
+                defaultColumnWidth,
+                defaultRowHeight);
         }
 
         internal int GetSimpleColumnWidthPixels(int columnIndex) {
@@ -106,10 +118,53 @@ namespace OfficeIMO.Excel.Utilities {
                 return 0;
             }
 
-            double heightPoints = row?.Height?.Value > 0 && row.CustomHeight?.Value == true
-                ? row.Height.Value
-                : _defaultRowHeightPoints;
+            double heightPoints = _defaultRowHeightPoints;
+            if (row != null) {
+                if (row.Height?.Value > 0 && row.CustomHeight?.Value == true) {
+                    heightPoints = row.Height.Value;
+                }
+            } else {
+                double overflowHeight = GetOverflowRowHeight(rowIndex);
+                if (overflowHeight < 0D) {
+                    return 0;
+                }
+
+                if (overflowHeight > 0D) {
+                    heightPoints = overflowHeight;
+                }
+            }
+
             return Math.Max(1, (int)Math.Round(heightPoints * 96D / 72D));
+        }
+
+        private double GetOverflowRowHeight(int rowIndex) {
+            if (!_rowIndexMayBeTruncated || rowIndex <= 0 || rowIndex > 1048576) {
+                return 0D;
+            }
+
+            EnsureOverflowRowsIndexed();
+            return _overflowRowHeights![rowIndex];
+        }
+
+        private void EnsureOverflowRowsIndexed() {
+            if (_overflowRowHeights != null) {
+                return;
+            }
+
+            var heights = new double[1048577];
+            foreach (X.Row row in _sheetData?.Elements<X.Row>() ?? Enumerable.Empty<X.Row>()) {
+                if (row.RowIndex?.Value is not uint rowIndex || rowIndex == 0U || rowIndex > 1048576U || _rows.ContainsKey((int)rowIndex)) {
+                    continue;
+                }
+
+                heights[rowIndex] = row.Hidden?.Value == true
+                    ? -1D
+                    : row.Height?.Value > 0D && row.CustomHeight?.Value == true
+                        ? row.Height.Value
+                        : 0D;
+            }
+
+            _overflowRowHeights = heights;
         }
     }
 }


### PR DESCRIPTION
## Summary

- Bounds attacker-controlled Excel drawing anchors, worksheet image materialization, sparkline data ranges, and chart stroke widths before expensive rendering work begins.
- Precomputes conditional color-scale evaluators and cell visual lookup maps so work scales with the rule and cell counts instead of multiplying repeated scans.
- Reworks CSV delimiter detection and multiline quoted-record handling into forward-only scans with quote-aware allocation sizing.
- Adds focused regressions for oversized anchors, sparkline ranges, extreme fixed denominators, percentile color scales, and adversarial quoted CSV input.

## Findings

This batch covers findings 141–160: 16 confirmed findings are fixed here, while 4 were already covered by preceding stacked changes.

Fixed:

- `ac25e3a35d0c81919d299e9224f6b147` — unbounded XLSX drawing offsets
- `b459a3db84488191817e73be8ad8299f` — unbounded drawing-offset traversal
- `195cf28349a0819187ef7e1c41055c80` — unbounded fixed fraction denominator loop
- `2dd29a87d8348191bcc0f0560025b3de` — unbounded absolute chart anchors
- `b60e6b5d397c81919f8bc1960bb54406` — repeated color-scale threshold sorting
- `d1f63dd8787881919b3aec0ec2a15ea2` — quadratic CSV delimiter detection
- `7f70ff5a2f088191b462346d80b990fd` — absolute-anchor resolution exhaustion
- `fe2f017c36e08191aa783da534328a71` — image-export range expansion from drawing anchors
- `7e0eb7d4694c8191bdad8b863be00350` — quadratic flexible CSV parsing
- `a7ea6c9a7fb481918c766c181cd82110` — off-screen sparkline data prefetch
- `394476970534819196ca7c2292b218c5` — quadratic delimited Excel import parsing
- `dd4558ecefc4819182e657f724f23858` — chart data-label border width exhaustion
- `67e7bfe3b4a88191a04ddd92907467cf` — repeated conditional-icon lookup
- `d2ed1daad0588191ae04c59bd36ca6bd` — quoted CSV delimiter memory amplification
- `1a41fd7d62388191b5d308f0ea185b73` — unterminated quoted-record reparsing
- `0ff59b6f13d48191ba4dab16f5644f4e` — bounded chart anchor traversal

Already covered by earlier stacked changes:

- `29b65beff53c8191a48a969e7f8a5b80` — sparse Excel ranges during HTML export
- `306dfd3f210081919054ff43ef969e40` — conditional-format range expansion
- `cb46e6bb50f88191abc770358998d0a9` — Excel conditional-format range expansion
- `4793e5bc76888191bcc0f0560025b3de` — SVG ID namespacing

## Validation

- CSV: 300/300 in Debug and Release on .NET 10.
- Excel: 2512 passed with 5 opt-in platform/live skips on .NET 10.
- Focused security regressions: 14/14.
- Multi-target Release builds succeeded for CSV and Excel across their supported targets.
- Excel.Pdf succeeded on .NET 8 and .NET 10. Its aggregate multi-target build still encounters the repository's existing netstandard2.0 `Dictionary.TryAdd` failure in `OfficeIMO.Pdf`, outside this change.
- An independent read-only security review found five budget-bypass edge cases in the frozen candidate. All five were fixed before publication and covered by focused regressions; a targeted confirmation was then run against those fixes. No hosted review was requested.
