### PR TITLE
Bound document conversion and inspection workloads

### DIFF
--- a/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Helpers.cs
+++ b/OfficeIMO.Drawing/OfficeChartDrawingRenderer.Helpers.cs
@@ -114,42 +114,54 @@ public static partial class OfficeChartDrawingRenderer {
         return total;
     }
 
-    private static double GetPercentStackedCategoryTotal(IReadOnlyList<OfficeChartSeries> series, int categoryIndex, bool positive) {
-        double total = 0D;
-        for (int s = 0; s < series.Count; s++) {
-            if (!TryGetSeriesValue(series[s], categoryIndex, out double value)) {
-                continue;
-            }
+    private readonly struct PercentStackedTotals {
+        internal PercentStackedTotals(double[] positive, double[] negative) {
+            Positive = positive;
+            Negative = negative;
+        }
 
-            if (positive && value > 0D) {
-                total += value;
-            } else if (!positive && value < 0D) {
-                total += Math.Abs(value);
+        internal double[] Positive { get; }
+        internal double[] Negative { get; }
+    }
+
+    private static PercentStackedTotals BuildPercentStackedTotals(IReadOnlyList<OfficeChartSeries> series, int categoryCount) {
+        var positive = new double[categoryCount];
+        var negative = new double[categoryCount];
+        for (int s = 0; s < series.Count; s++) {
+            for (int categoryIndex = 0; categoryIndex < categoryCount; categoryIndex++) {
+                if (!TryGetSeriesValue(series[s], categoryIndex, out double value)) {
+                    continue;
+                }
+
+                if (value > 0D) {
+                    positive[categoryIndex] += value;
+                } else if (value < 0D) {
+                    negative[categoryIndex] += Math.Abs(value);
+                }
             }
         }
 
-        return total;
+        return new PercentStackedTotals(positive, negative);
     }
 
-    private static double NormalizePercentStackedValue(IReadOnlyList<OfficeChartSeries> series, int categoryIndex, double value) {
+    private static double NormalizePercentStackedValue(PercentStackedTotals totals, int categoryIndex, double value) {
         if (value == 0D) {
             return 0D;
         }
 
-        double total = GetPercentStackedCategoryTotal(series, categoryIndex, value > 0D);
+        double total = value > 0D ? totals.Positive[categoryIndex] : totals.Negative[categoryIndex];
         return total <= 0D ? 0D : value / total;
     }
 
     private static ValueRange GetPercentStackedSeriesRange(IReadOnlyList<OfficeChartSeries> series, int categoryCount) {
-        bool hasNegative = false;
+        PercentStackedTotals totals = BuildPercentStackedTotals(series, categoryCount);
         for (int category = 0; category < categoryCount; category++) {
-            if (GetPercentStackedCategoryTotal(series, category, positive: false) > 0D) {
-                hasNegative = true;
-                break;
+            if (totals.Negative[category] > 0D) {
+                return new ValueRange(-1D, 1D);
             }
         }
 
-        return hasNegative ? new ValueRange(-1D, 1D) : new ValueRange(0D, 1D);
+        return new ValueRange(0D, 1D);
     }
 
     private static ValueRange GetStackedSeriesRange(IReadOnlyList<OfficeChartSeries> series, int categoryCount) {

--- a/OfficeIMO.Drawing/OfficeChartDrawingRenderer.cs
+++ b/OfficeIMO.Drawing/OfficeChartDrawingRenderer.cs
@@ -977,15 +977,29 @@ public static partial class OfficeChartDrawingRenderer {
         IReadOnlyList<OfficeChartSeries> barSeriesValues = barSeries.Select(item => item.Series).ToArray();
         var stackedSlots = new Dictionary<OfficeChartKind, int>();
         var clusteredSlots = new Dictionary<int, int>();
+        var stackedSeriesByKind = new Dictionary<OfficeChartKind, List<OfficeChartSeries>>();
         int slotCount = 0;
         for (int i = 0; i < barSeries.Count; i++) {
             OfficeChartKind kind = GetEffectiveSeriesKind(snapshot, barSeries[i].Series);
             if (IsStackedBarOrColumnChart(kind) || IsPercentStackedBarOrColumnChart(kind)) {
+                if (!stackedSeriesByKind.TryGetValue(kind, out List<OfficeChartSeries>? stackGroup)) {
+                    stackGroup = new List<OfficeChartSeries>();
+                    stackedSeriesByKind.Add(kind, stackGroup);
+                }
+
+                stackGroup.Add(barSeries[i].Series);
                 if (!stackedSlots.ContainsKey(kind)) {
                     stackedSlots[kind] = slotCount++;
                 }
             } else {
                 clusteredSlots[barSeries[i].SourceIndex] = slotCount++;
+            }
+        }
+
+        var percentStackedTotalsByKind = new Dictionary<OfficeChartKind, PercentStackedTotals>();
+        foreach (KeyValuePair<OfficeChartKind, List<OfficeChartSeries>> stackGroup in stackedSeriesByKind) {
+            if (IsPercentStackedBarOrColumnChart(stackGroup.Key)) {
+                percentStackedTotalsByKind.Add(stackGroup.Key, BuildPercentStackedTotals(stackGroup.Value, categories.Count));
             }
         }
 
@@ -1025,12 +1039,8 @@ public static partial class OfficeChartDrawingRenderer {
                 double baseline = 0D;
                 double plottedValue = value;
                 if (seriesStacked) {
-                    IReadOnlyList<OfficeChartSeries> stackGroup = barSeries
-                        .Where(item => GetEffectiveSeriesKind(snapshot, item.Series) == seriesKind)
-                        .Select(item => item.Series)
-                        .ToArray();
                     if (seriesPercentStacked) {
-                        plottedValue = NormalizePercentStackedValue(stackGroup, category, value);
+                        plottedValue = NormalizePercentStackedValue(percentStackedTotalsByKind[seriesKind], category, value);
                     }
 
                     positiveBases.TryGetValue(seriesKind, out double positiveBase);
@@ -1191,13 +1201,17 @@ public static partial class OfficeChartDrawingRenderer {
         double step = plotWidth / (categories.Count - 1);
         var positiveCumulativeByKind = new Dictionary<OfficeChartKind, double[]>();
         var negativeCumulativeByKind = new Dictionary<OfficeChartKind, double[]>();
+        var stackedSeriesByKind = areaSeries
+            .Where(item => IsStackedAreaChart(item.Kind) || IsPercentStackedAreaChart(item.Kind))
+            .GroupBy(item => item.Kind)
+            .ToDictionary(group => group.Key, group => group.Select(item => item.Series).ToList());
+        var percentStackedTotalsByKind = stackedSeriesByKind
+            .Where(group => IsPercentStackedAreaChart(group.Key))
+            .ToDictionary(group => group.Key, group => BuildPercentStackedTotals(group.Value, categories.Count));
 
         foreach ((OfficeChartSeries currentSeries, int sourceSeriesIndex, OfficeChartKind kind) in areaSeries) {
             bool currentStacked = IsStackedAreaChart(kind) || IsPercentStackedAreaChart(kind);
             bool currentPercentStacked = IsPercentStackedAreaChart(kind);
-            List<OfficeChartSeries> stackSeries = currentStacked
-                ? areaSeries.Where(item => item.Kind == kind).Select(item => item.Series).ToList()
-                : new List<OfficeChartSeries>();
             double[] positiveCumulative = currentStacked ? GetCumulative(positiveCumulativeByKind, kind, categories.Count) : Array.Empty<double>();
             double[] negativeCumulative = currentStacked ? GetCumulative(negativeCumulativeByKind, kind, categories.Count) : Array.Empty<double>();
             OfficeColor color = GetSeriesColor(style, series, sourceSeriesIndex);
@@ -1217,7 +1231,7 @@ public static partial class OfficeChartDrawingRenderer {
                     continue;
                 }
 
-                double rawValue = currentPercentStacked ? NormalizePercentStackedValue(stackSeries, i, value) : value;
+                double rawValue = currentPercentStacked ? NormalizePercentStackedValue(percentStackedTotalsByKind[kind], i, value) : value;
                 double baseline = currentStacked
                     ? (rawValue >= 0D ? positiveCumulative[i] : negativeCumulative[i])
                     : 0D;
@@ -1229,11 +1243,10 @@ public static partial class OfficeChartDrawingRenderer {
                 runCategoryIndices.Add(i);
 
                 if (currentStacked) {
-                    double stackedValue = currentPercentStacked ? NormalizePercentStackedValue(stackSeries, i, value) : value;
-                    if (stackedValue >= 0D) {
-                        positiveCumulative[i] += stackedValue;
+                    if (rawValue >= 0D) {
+                        positiveCumulative[i] += rawValue;
                     } else {
-                        negativeCumulative[i] += stackedValue;
+                        negativeCumulative[i] += rawValue;
                     }
                 }
             }
@@ -1305,12 +1318,16 @@ public static partial class OfficeChartDrawingRenderer {
         double step = categories.Count > 1 ? plotWidth / (categories.Count - 1) : 0D;
         var positiveCumulativeByKind = new Dictionary<OfficeChartKind, double[]>();
         var negativeCumulativeByKind = new Dictionary<OfficeChartKind, double[]>();
+        var stackedSeriesByKind = lineSeries
+            .Where(item => IsStackedLineChart(item.Kind) || IsPercentStackedLineChart(item.Kind))
+            .GroupBy(item => item.Kind)
+            .ToDictionary(group => group.Key, group => group.Select(item => item.Series).ToList());
+        var percentStackedTotalsByKind = stackedSeriesByKind
+            .Where(group => IsPercentStackedLineChart(group.Key))
+            .ToDictionary(group => group.Key, group => BuildPercentStackedTotals(group.Value, categories.Count));
         foreach ((OfficeChartSeries currentSeries, int sourceSeriesIndex, OfficeChartKind kind) in lineSeries) {
             bool currentStacked = IsStackedLineChart(kind) || IsPercentStackedLineChart(kind);
             bool currentPercentStacked = IsPercentStackedLineChart(kind);
-            List<OfficeChartSeries> stackSeries = currentStacked
-                ? lineSeries.Where(item => item.Kind == kind).Select(item => item.Series).ToList()
-                : new List<OfficeChartSeries>();
             double[] positiveCumulative = currentStacked ? GetCumulative(positiveCumulativeByKind, kind, categories.Count) : Array.Empty<double>();
             double[] negativeCumulative = currentStacked ? GetCumulative(negativeCumulativeByKind, kind, categories.Count) : Array.Empty<double>();
             OfficeColor color = GetSeriesColor(style, series, sourceSeriesIndex);
@@ -1323,7 +1340,7 @@ public static partial class OfficeChartDrawingRenderer {
                     continue;
                 }
 
-                double rawValue = currentPercentStacked ? NormalizePercentStackedValue(stackSeries, i, value) : value;
+                double rawValue = currentPercentStacked ? NormalizePercentStackedValue(percentStackedTotalsByKind[kind], i, value) : value;
                 double baseline = currentStacked
                     ? (rawValue >= 0D ? positiveCumulative[i] : negativeCumulative[i])
                     : 0D;
@@ -1380,7 +1397,7 @@ public static partial class OfficeChartDrawingRenderer {
                         continue;
                     }
 
-                    double value = currentPercentStacked ? NormalizePercentStackedValue(stackSeries, i, seriesValue) : seriesValue;
+                    double value = currentPercentStacked ? NormalizePercentStackedValue(percentStackedTotalsByKind[kind], i, seriesValue) : seriesValue;
                     if (value >= 0D) {
                         positiveCumulative[i] += value;
                     } else {

--- a/OfficeIMO.Markdown/Blocks/OrderedListBlock.cs
+++ b/OfficeIMO.Markdown/Blocks/OrderedListBlock.cs
@@ -88,7 +88,7 @@ public sealed class OrderedListBlock : MarkdownBlock, IMarkdownListBlock, ISynta
         return attributes.ToString();
     }
 
-    private static string FormatMarker(int value, MarkdownOrderedListMarkerStyle style, char delimiter) {
+    internal static string FormatMarker(int value, MarkdownOrderedListMarkerStyle style, char delimiter) {
         var text = style switch {
             MarkdownOrderedListMarkerStyle.LowerAlpha => FormatAlpha(value, uppercase: false),
             MarkdownOrderedListMarkerStyle.UpperAlpha => FormatAlpha(value, uppercase: true),

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentVisualQualityFlowKeepTopLevelTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfDocumentVisualQualityFlowKeepTopLevelTests.cs
@@ -503,12 +503,16 @@ public partial class PdfDocumentVisualQualityTests {
             DefaultFontSize = 10
         };
 
-        byte[] bytes = PdfDocument.Create(options)
+        PdfDocument document = PdfDocument.Create(options)
             .Paragraph(p => p.Text("IntroMarker"), style: new PdfParagraphStyle {
                 SpacingAfter = 45
             })
-            .H2("BookmarkChainTopHeading")
-            .Bookmark("bookmark-chain-subheading")
+            .H2("BookmarkChainTopHeading");
+        for (int index = 0; index < 300; index++) {
+            document.Bookmark("bookmark-chain-marker-" + index.ToString(CultureInfo.InvariantCulture));
+        }
+
+        byte[] bytes = document
             .H3("BookmarkChainSubHeading")
             .Paragraph(p => p.Text("BookmarkChainBody"))
             .ToBytes();

--- a/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/PdfReadLimitTests.cs
@@ -675,6 +675,30 @@ public class PdfReadLimitTests {
     }
 
     [Fact]
+    public void WidgetAppearanceStateBudgetStopsDictionaryExpansion() {
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() => PdfReadDocument.Open(
+            BuildWidgetAppearanceStatesPdf(),
+            new PdfReadOptions { Limits = new PdfReadLimits { MaxFormFieldAppearanceStates = 1 } }));
+
+        Assert.Equal(PdfReadLimitKind.FormAppearanceStates, exception.Kind);
+        Assert.Equal(1, exception.Limit);
+        Assert.Equal(2, exception.Actual);
+    }
+
+    [Fact]
+    public void WidgetAppearanceStateBudgetAlsoAppliesToOrphanAnnotationRendering() {
+        PdfReadDocument document = PdfReadDocument.Open(
+            BuildOrphanWidgetAppearanceStatesPdf(),
+            new PdfReadOptions { Limits = new PdfReadLimits { MaxFormFieldAppearanceStates = 1 } });
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() => document.Pages[0].ToDrawing());
+
+        Assert.Equal(PdfReadLimitKind.FormAppearanceStates, exception.Kind);
+        Assert.Equal(1, exception.Limit);
+        Assert.Equal(2, exception.Actual);
+    }
+
+    [Fact]
     public void AnnotationAndContentOperationBudgetsStopPageParsing() {
         byte[] annotations = BuildAnnotatedPagePdf();
         byte[] content = BuildPdf();
@@ -710,6 +734,19 @@ public class PdfReadLimitTests {
             new PdfReadOptions { Limits = new PdfReadLimits { MaxContentNestingDepth = 1 } });
 
         PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() => document.Pages[0].ExtractText());
+
+        Assert.Equal(PdfReadLimitKind.ContentNestingDepth, exception.Kind);
+        Assert.Equal(1, exception.Limit);
+        Assert.Equal(2, exception.Actual);
+    }
+
+    [Fact]
+    public void ImageResourceTraversalUsesTheContentNestingBudget() {
+        PdfReadDocument document = PdfReadDocument.Open(
+            BuildNestedFormXObjectPdf(),
+            new PdfReadOptions { Limits = new PdfReadLimits { MaxContentNestingDepth = 1 } });
+
+        PdfReadLimitException exception = Assert.Throws<PdfReadLimitException>(() => document.Pages[0].GetImages());
 
         Assert.Equal(PdfReadLimitKind.ContentNestingDepth, exception.Kind);
         Assert.Equal(1, exception.Limit);
@@ -875,6 +912,23 @@ public class PdfReadLimitTests {
         "<< /Fields [7 0 R] >>",
         "<< /T (Parent) /Kids [8 0 R] >>",
         "<< /Type /Annot /Subtype /Widget /Parent 7 0 R /T (Child) /FT /Tx /Rect [10 10 100 30] >>");
+
+    private static byte[] BuildWidgetAppearanceStatesPdf() => BuildPdfObjects(
+        "<< /Type /Catalog /Pages 2 0 R /AcroForm 5 0 R >>",
+        "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /Annots [6 0 R] >>",
+        "<< /Length 0 >>\nstream\n\nendstream",
+        "<< /Fields [6 0 R] >>",
+        "<< /Type /Annot /Subtype /Widget /T (Choice) /FT /Btn /Rect [10 10 100 30] /AP << /N << /Off 7 0 R /On 7 0 R >> >> >>",
+        "<< /Type /XObject /Subtype /Form /BBox [0 0 10 10] /Length 0 >>\nstream\n\nendstream");
+
+    private static byte[] BuildOrphanWidgetAppearanceStatesPdf() => BuildPdfObjects(
+        "<< /Type /Catalog /Pages 2 0 R >>",
+        "<< /Type /Pages /Count 1 /Kids [3 0 R] >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /Annots [5 0 R] >>",
+        "<< /Length 0 >>\nstream\n\nendstream",
+        "<< /Type /Annot /Subtype /Widget /Rect [10 10 100 30] /AP << /N << /Off 6 0 R /On 6 0 R >> >> >>",
+        "<< /Type /XObject /Subtype /Form /BBox [0 0 10 10] /Length 0 >>\nstream\n\nendstream");
 
     private static byte[] BuildAnnotatedPagePdf() => BuildPdfObjects(
         "<< /Type /Catalog /Pages 2 0 R >>",

--- a/OfficeIMO.Pdf.Tests/Pdf/TableLayoutCacheTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/TableLayoutCacheTests.cs
@@ -1,6 +1,8 @@
 using OfficeIMO.Word.Pdf;
 using OfficeIMO.Word;
 using W = DocumentFormat.OpenXml.Wordprocessing;
+using System.IO;
+using System.Reflection;
 using Xunit;
 
 namespace OfficeIMO.Tests.Pdf {
@@ -69,6 +71,23 @@ namespace OfficeIMO.Tests.Pdf {
             Assert.Equal(144f, layout.ColumnWidths[1]);
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void OversizedRowGridOffsetsAreRejectedBeforeColumnArraysAreAllocated(bool before) {
+            using WordDocument document = WordDocument.Create();
+            WordTable table = document.AddTable(1, 1);
+            table.GridColumnWidth = new List<int>();
+            table.Rows[0]._tableRow.TableRowProperties ??= new W.TableRowProperties();
+            if (before) {
+                table.Rows[0]._tableRow.TableRowProperties.Append(new W.GridBefore { Val = 16_385 });
+            } else {
+                table.Rows[0]._tableRow.TableRowProperties.Append(new W.GridAfter { Val = 16_385 });
+            }
+
+            Assert.Throws<InvalidDataException>(() => TableLayoutCache.GetLayout(table));
+        }
+
         [Fact]
         public void NestedTableWidthsPropagateToParent() {
             using WordDocument document = WordDocument.Create();
@@ -106,6 +125,46 @@ namespace OfficeIMO.Tests.Pdf {
             TableLayout innerLayout = TableLayoutCache.GetLayout(inner);
             Assert.Equal(144f, innerLayout.ColumnWidths[0]);
         }
+
+        [Fact]
+        public void ExcessiveNestedTableDepthIsRejectedBeforeRecursiveLayoutCanOverflow() {
+            using WordDocument document = WordDocument.Create();
+            WordTable root = document.AddTable(1, 1);
+            WordTable current = root;
+            for (int depth = 0; depth < 128; depth++) {
+                current = current.Rows[0].Cells[0].AddTable(1, 1);
+            }
+
+            Assert.Throws<InvalidDataException>(() => TableLayoutCache.GetLayout(root));
+        }
+
+        [Fact]
+        public void StyleTabStopInspectionIsBoundedEvenWhenEntriesAreInvalid() {
+            using WordDocument document = WordDocument.Create();
+            WordParagraph paragraph = document.AddParagraph("Bounded tabs");
+            const string styleId = "HostileTabStops";
+            var tabs = new W.Tabs();
+            for (int index = 0; index < 1_024; index++) {
+                tabs.Append(new W.TabStop { Position = 0, Val = W.TabStopValues.Left });
+            }
+
+            tabs.Append(new W.TabStop { Position = 1_440, Val = W.TabStopValues.Left });
+            W.Styles styles = document._wordprocessingDocument.MainDocumentPart!.StyleDefinitionsPart!.Styles!;
+            styles.Append(new W.Style(
+                new W.StyleName { Val = styleId },
+                new W.StyleParagraphProperties(tabs)) {
+                Type = W.StyleValues.Paragraph,
+                StyleId = styleId
+            });
+            paragraph._paragraph.ParagraphProperties ??= new W.ParagraphProperties();
+            paragraph._paragraph.ParagraphProperties.ParagraphStyleId = new W.ParagraphStyleId { Val = styleId };
+
+            MethodInfo method = typeof(WordPdfConverterExtensions).GetMethod(
+                "GetNativeParagraphEffectiveTabStops",
+                BindingFlags.NonPublic | BindingFlags.Static)!;
+            var effectiveTabStops = Assert.IsAssignableFrom<IReadOnlyList<WordTabStop>>(method.Invoke(null, new object[] { paragraph }));
+
+            Assert.Empty(effectiveTabStops);
+        }
     }
 }
-

--- a/OfficeIMO.Pdf.Tests/Pdf/TableLayoutCacheTests.cs
+++ b/OfficeIMO.Pdf.Tests/Pdf/TableLayoutCacheTests.cs
@@ -89,6 +89,19 @@ namespace OfficeIMO.Tests.Pdf {
         }
 
         [Fact]
+        public void CombinedRowGridOffsetsAreRejectedBeforeColumnArraysAreAllocated() {
+            using WordDocument document = WordDocument.Create();
+            WordTable table = document.AddTable(1, 1);
+            table.GridColumnWidth = new List<int>();
+            table.Rows[0]._tableRow.TableRowProperties ??= new W.TableRowProperties();
+            table.Rows[0]._tableRow.TableRowProperties.Append(new W.GridBefore { Val = 16_384 });
+            table.Rows[0]._tableRow.TableRowProperties.Append(new W.GridAfter { Val = 16_384 });
+            table.Rows[0].Cells[0].HorizontalMerge = W.MergedCellValues.Continue;
+
+            Assert.Throws<InvalidDataException>(() => TableLayoutCache.GetLayout(table));
+        }
+
+        [Fact]
         public void NestedTableWidthsPropagateToParent() {
             using WordDocument document = WordDocument.Create();
             WordTable outer = document.AddTable(1, 2);

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Forms.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadDocument.Forms.cs
@@ -381,6 +381,13 @@ public sealed partial class PdfReadDocument {
             return Array.Empty<string>();
         }
 
+        if (normalAppearances.Items.Count > _options.Limits.MaxFormFieldAppearanceStates) {
+            throw PdfReadLimitException.Create(
+                PdfReadLimitKind.FormAppearanceStates,
+                _options.Limits.MaxFormFieldAppearanceStates,
+                normalAppearances.Items.Count);
+        }
+
         var states = new List<string>();
         foreach (string state in normalAppearances.Items.Keys) {
             if (!string.IsNullOrEmpty(state)) {

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.Visual.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.Visual.cs
@@ -1118,6 +1118,13 @@ public sealed partial class PdfReadPage {
             return false;
         }
 
+        if (stateDictionary.Items.Count > _limits.MaxFormFieldAppearanceStates) {
+            throw PdfReadLimitException.Create(
+                PdfReadLimitKind.FormAppearanceStates,
+                _limits.MaxFormFieldAppearanceStates,
+                stateDictionary.Items.Count);
+        }
+
         if (annotation.Items.TryGetValue("AS", out PdfObject? appearanceStateObject) &&
             ResolveObject(appearanceStateObject) is PdfName appearanceState) {
             if (stateDictionary.Items.TryGetValue(appearanceState.Name, out PdfObject? stateObject) &&

--- a/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
+++ b/OfficeIMO.Pdf/Reading/Core/PdfReadPage.cs
@@ -339,7 +339,7 @@ public sealed partial class PdfReadPage {
     private IReadOnlyList<PdfExtractedImage> GetImagesForResources(PdfDictionary? resources, int pageNumber, IReadOnlyList<PdfImagePlacement>? imagePlacements, bool colorizeImageMasks = false) {
         var images = resources == null
             ? new List<PdfExtractedImage>()
-            : new List<PdfExtractedImage>(ResourceResolver.GetImageXObjectsForResources(resources, _objects, pageNumber, imagePlacements, colorizeImageMasks));
+            : new List<PdfExtractedImage>(ResourceResolver.GetImageXObjectsForResources(resources, _objects, pageNumber, imagePlacements, colorizeImageMasks, _limits));
         if (imagePlacements is not null) {
             for (int i = 0; i < imagePlacements.Count; i++) {
                 PdfImagePlacement placement = imagePlacements[i];

--- a/OfficeIMO.Pdf/Reading/Core/ResourceResolver.cs
+++ b/OfficeIMO.Pdf/Reading/Core/ResourceResolver.cs
@@ -187,7 +187,7 @@ internal static partial class ResourceResolver {
         return result;
     }
 
-    internal static IReadOnlyList<PdfExtractedImage> GetImageXObjectsForResources(PdfDictionary resources, Dictionary<int, PdfIndirectObject> objects, int pageNumber, IReadOnlyList<PdfImagePlacement>? imagePlacements = null, bool colorizeImageMasks = false) {
+    internal static IReadOnlyList<PdfExtractedImage> GetImageXObjectsForResources(PdfDictionary resources, Dictionary<int, PdfIndirectObject> objects, int pageNumber, IReadOnlyList<PdfImagePlacement>? imagePlacements = null, bool colorizeImageMasks = false, PdfReadLimits? limits = null) {
         var result = new List<PdfExtractedImage>();
         Dictionary<string, List<PdfImagePlacement>>? placedImagesByKey = null;
         Dictionary<string, List<PdfImagePlacement>>? placedImagesByResourceNameWithoutIdentity = null;
@@ -206,16 +206,27 @@ internal static partial class ResourceResolver {
             }
         }
 
-        CollectImageXObjectsFromResources(resources, objects, pageNumber, result, new HashSet<PdfStream>(), new HashSet<string>(System.StringComparer.Ordinal), placedImagesByKey, placedImagesByResourceNameWithoutIdentity, colorizeImageMasks);
+        PdfReadLimits effectiveLimits = limits ?? PdfReadLimits.Default;
+        int traversedObjects = 0;
+        CollectImageXObjectsFromResources(resources, objects, pageNumber, result, new HashSet<PdfStream>(), new HashSet<string>(System.StringComparer.Ordinal), placedImagesByKey, placedImagesByResourceNameWithoutIdentity, colorizeImageMasks, effectiveLimits, depth: 0, ref traversedObjects);
         return result;
     }
 
-    private static void CollectImageXObjectsFromResources(PdfDictionary resources, Dictionary<int, PdfIndirectObject> objects, int pageNumber, List<PdfExtractedImage> result, HashSet<PdfStream> activeForms, HashSet<string> addedImageKeys, Dictionary<string, List<PdfImagePlacement>>? placedImagesByKey, Dictionary<string, List<PdfImagePlacement>>? placedImagesByResourceNameWithoutIdentity, bool colorizeImageMasks) {
+    private static void CollectImageXObjectsFromResources(PdfDictionary resources, Dictionary<int, PdfIndirectObject> objects, int pageNumber, List<PdfExtractedImage> result, HashSet<PdfStream> visitedForms, HashSet<string> addedImageKeys, Dictionary<string, List<PdfImagePlacement>>? placedImagesByKey, Dictionary<string, List<PdfImagePlacement>>? placedImagesByResourceNameWithoutIdentity, bool colorizeImageMasks, PdfReadLimits limits, int depth, ref int traversedObjects) {
+        if (depth > limits.MaxContentNestingDepth) {
+            throw PdfReadLimitException.Create(PdfReadLimitKind.ContentNestingDepth, limits.MaxContentNestingDepth, depth);
+        }
+
         if (!resources.Items.TryGetValue("XObject", out var xoObj)) return;
         var xo = ResolveDict(xoObj, objects);
         if (xo is null) return;
 
         foreach (var kv in xo.Items) {
+            traversedObjects++;
+            if (traversedObjects > limits.MaxContentOperands) {
+                throw PdfReadLimitException.Create(PdfReadLimitKind.ContentOperands, limits.MaxContentOperands, traversedObjects);
+            }
+
             int objectNumber = 0;
             PdfStream? stream = null;
             if (kv.Value is PdfReference reference &&
@@ -266,21 +277,17 @@ internal static partial class ResourceResolver {
                 continue;
             }
 
-            if (!activeForms.Add(stream)) {
+            if (!visitedForms.Add(stream)) {
                 continue;
             }
 
-            try {
-                PdfDictionary? formResources = null;
-                if (stream.Dictionary.Items.TryGetValue("Resources", out var formResourcesObj)) {
-                    formResources = ResolveDict(formResourcesObj, objects);
-                }
-
-                formResources ??= resources;
-                CollectImageXObjectsFromResources(formResources, objects, pageNumber, result, activeForms, addedImageKeys, placedImagesByKey, placedImagesByResourceNameWithoutIdentity, colorizeImageMasks);
-            } finally {
-                activeForms.Remove(stream);
+            PdfDictionary? formResources = null;
+            if (stream.Dictionary.Items.TryGetValue("Resources", out var formResourcesObj)) {
+                formResources = ResolveDict(formResourcesObj, objects);
             }
+
+            formResources ??= resources;
+            CollectImageXObjectsFromResources(formResources, objects, pageNumber, result, visitedForms, addedImageKeys, placedImagesByKey, placedImagesByResourceNameWithoutIdentity, colorizeImageMasks, limits, depth + 1, ref traversedObjects);
         }
     }
 

--- a/OfficeIMO.Pdf/Reading/Core/ResourceResolver.cs
+++ b/OfficeIMO.Pdf/Reading/Core/ResourceResolver.cs
@@ -208,11 +208,11 @@ internal static partial class ResourceResolver {
 
         PdfReadLimits effectiveLimits = limits ?? PdfReadLimits.Default;
         int traversedObjects = 0;
-        CollectImageXObjectsFromResources(resources, objects, pageNumber, result, new HashSet<PdfStream>(), new HashSet<string>(System.StringComparer.Ordinal), placedImagesByKey, placedImagesByResourceNameWithoutIdentity, colorizeImageMasks, effectiveLimits, depth: 0, ref traversedObjects);
+        CollectImageXObjectsFromResources(resources, objects, pageNumber, result, new HashSet<(PdfStream Stream, PdfDictionary Resources)>(), new HashSet<string>(System.StringComparer.Ordinal), placedImagesByKey, placedImagesByResourceNameWithoutIdentity, colorizeImageMasks, effectiveLimits, depth: 0, ref traversedObjects);
         return result;
     }
 
-    private static void CollectImageXObjectsFromResources(PdfDictionary resources, Dictionary<int, PdfIndirectObject> objects, int pageNumber, List<PdfExtractedImage> result, HashSet<PdfStream> visitedForms, HashSet<string> addedImageKeys, Dictionary<string, List<PdfImagePlacement>>? placedImagesByKey, Dictionary<string, List<PdfImagePlacement>>? placedImagesByResourceNameWithoutIdentity, bool colorizeImageMasks, PdfReadLimits limits, int depth, ref int traversedObjects) {
+    private static void CollectImageXObjectsFromResources(PdfDictionary resources, Dictionary<int, PdfIndirectObject> objects, int pageNumber, List<PdfExtractedImage> result, HashSet<(PdfStream Stream, PdfDictionary Resources)> visitedFormContexts, HashSet<string> addedImageKeys, Dictionary<string, List<PdfImagePlacement>>? placedImagesByKey, Dictionary<string, List<PdfImagePlacement>>? placedImagesByResourceNameWithoutIdentity, bool colorizeImageMasks, PdfReadLimits limits, int depth, ref int traversedObjects) {
         if (depth > limits.MaxContentNestingDepth) {
             throw PdfReadLimitException.Create(PdfReadLimitKind.ContentNestingDepth, limits.MaxContentNestingDepth, depth);
         }
@@ -277,17 +277,17 @@ internal static partial class ResourceResolver {
                 continue;
             }
 
-            if (!visitedForms.Add(stream)) {
-                continue;
-            }
-
             PdfDictionary? formResources = null;
             if (stream.Dictionary.Items.TryGetValue("Resources", out var formResourcesObj)) {
                 formResources = ResolveDict(formResourcesObj, objects);
             }
 
             formResources ??= resources;
-            CollectImageXObjectsFromResources(formResources, objects, pageNumber, result, visitedForms, addedImageKeys, placedImagesByKey, placedImagesByResourceNameWithoutIdentity, colorizeImageMasks, limits, depth + 1, ref traversedObjects);
+            if (!visitedFormContexts.Add((stream, formResources))) {
+                continue;
+            }
+
+            CollectImageXObjectsFromResources(formResources, objects, pageNumber, result, visitedFormContexts, addedImageKeys, placedImagesByKey, placedImagesByResourceNameWithoutIdentity, colorizeImageMasks, limits, depth + 1, ref traversedObjects);
         }
     }
 

--- a/OfficeIMO.Pdf/Reading/Logical/PdfLogicalPage.cs
+++ b/OfficeIMO.Pdf/Reading/Logical/PdfLogicalPage.cs
@@ -299,9 +299,25 @@ public sealed class PdfLogicalPage {
         return link.WithDestinationPageNumber(document.GetPageNumberForObject(link.DestinationPageObjectNumber.Value));
     }
 
-    private static IReadOnlyList<PdfLogicalParagraph> BuildParagraphs(int pageNumber, List<StructuredParagraph> paragraphs, IReadOnlyList<PdfLogicalTextBlock> textBlocks) {
+    private static IReadOnlyList<PdfLogicalParagraph> BuildParagraphs(int pageNumber, List<StructuredParagraph> paragraphs, List<PdfLogicalTextBlock> textBlocks) {
         if (paragraphs.Count == 0) {
             return Array.Empty<PdfLogicalParagraph>();
+        }
+
+        var textBlockLookup = new Dictionary<(long BaselineY, long XStart, string Text), Queue<PdfLogicalTextBlock>>();
+        for (int i = 0; i < textBlocks.Count; i++) {
+            PdfLogicalTextBlock block = textBlocks[i];
+            if (block.Kind != PdfLogicalElementKind.TextBlock) {
+                continue;
+            }
+
+            var key = CreateTextBlockLookupKey(block.BaselineY, block.XStart, block.Text);
+            if (!textBlockLookup.TryGetValue(key, out Queue<PdfLogicalTextBlock>? blocks)) {
+                blocks = new Queue<PdfLogicalTextBlock>();
+                textBlockLookup.Add(key, blocks);
+            }
+
+            blocks.Enqueue(block);
         }
 
         var result = new List<PdfLogicalParagraph>(paragraphs.Count);
@@ -310,9 +326,9 @@ public sealed class PdfLogicalPage {
             var lines = new List<PdfLogicalTextBlock>(paragraph.Lines.Count);
             for (int lineIndex = 0; lineIndex < paragraph.Lines.Count; lineIndex++) {
                 var line = paragraph.Lines[lineIndex];
-                PdfLogicalTextBlock? block = FindTextBlock(line, textBlocks, PdfLogicalElementKind.TextBlock);
-                if (block is not null) {
-                    lines.Add(block);
+                var key = CreateTextBlockLookupKey(line.Y, line.XStart, line.Text.Trim());
+                if (textBlockLookup.TryGetValue(key, out Queue<PdfLogicalTextBlock>? blocks) && blocks.Count > 0) {
+                    lines.Add(blocks.Dequeue());
                 }
             }
 
@@ -323,6 +339,9 @@ public sealed class PdfLogicalPage {
 
         return result.AsReadOnly();
     }
+
+    private static (long BaselineY, long XStart, string Text) CreateTextBlockLookupKey(double baselineY, double xStart, string text) =>
+        (BitConverter.DoubleToInt64Bits(baselineY), BitConverter.DoubleToInt64Bits(xStart), text);
 
     private static IReadOnlyList<PdfLogicalListItem> BuildListItems(int pageNumber, List<StructuredListItem> listItems, IReadOnlyList<PdfLogicalTextBlock> textBlocks) {
         if (listItems.Count == 0) {

--- a/OfficeIMO.Pdf/Reading/Options/PdfReadLimitKind.cs
+++ b/OfficeIMO.Pdf/Reading/Options/PdfReadLimitKind.cs
@@ -72,5 +72,8 @@ public enum PdfReadLimitKind {
     OcrArtifacts = 22,
 
     /// <summary>Rendered bytes retained by one managed render operation.</summary>
-    RenderBytes = 23
+    RenderBytes = 23,
+
+    /// <summary>Named appearance states declared for one AcroForm widget.</summary>
+    FormAppearanceStates = 24
 }

--- a/OfficeIMO.Pdf/Reading/Options/PdfReadLimits.cs
+++ b/OfficeIMO.Pdf/Reading/Options/PdfReadLimits.cs
@@ -52,6 +52,9 @@ public sealed class PdfReadLimits {
     /// <summary>Maximum nested AcroForm field-tree depth. Default: 256.</summary>
     public int MaxFormFieldDepth { get; init; } = 256;
 
+    /// <summary>Maximum named appearance states declared for one AcroForm widget. Default: 4,096.</summary>
+    public int MaxFormFieldAppearanceStates { get; init; } = 4_096;
+
     /// <summary>Maximum annotations declared on one page. Default: 100,000.</summary>
     public int MaxAnnotationsPerPage { get; init; } = 100_000;
 
@@ -80,6 +83,7 @@ public sealed class PdfReadLimits {
             MaxPages = MaxPages,
             MaxFormFields = MaxFormFields,
             MaxFormFieldDepth = MaxFormFieldDepth,
+            MaxFormFieldAppearanceStates = MaxFormFieldAppearanceStates,
             MaxAnnotationsPerPage = MaxAnnotationsPerPage,
             MaxContentOperations = MaxContentOperations,
             MaxContentOperands = MaxContentOperands,
@@ -126,6 +130,7 @@ public sealed class PdfReadLimits {
         ValidatePositive(MaxPages, nameof(MaxPages), "Maximum pages must be positive.");
         ValidatePositive(MaxFormFields, nameof(MaxFormFields), "Maximum form fields must be positive.");
         ValidatePositive(MaxFormFieldDepth, nameof(MaxFormFieldDepth), "Maximum form-field depth must be positive.");
+        ValidatePositive(MaxFormFieldAppearanceStates, nameof(MaxFormFieldAppearanceStates), "Maximum form-field appearance states must be positive.");
         ValidatePositive(MaxAnnotationsPerPage, nameof(MaxAnnotationsPerPage), "Maximum annotations per page must be positive.");
         ValidatePositive(MaxContentOperations, nameof(MaxContentOperations), "Maximum content operations must be positive.");
         ValidatePositive(MaxContentOperands, nameof(MaxContentOperands), "Maximum content operands must be positive.");

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.FlowMetrics.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.FlowMetrics.cs
@@ -246,11 +246,15 @@ internal static partial class PdfWriter {
         private double MeasureKeepWithNextChainHeight(System.Collections.Generic.IList<IPdfBlock> blocks, int startIndex, double frameX, double frameWidth, double fontSize) {
             double height = 0D;
             int inspectedBlocks = 0;
-            for (int blockIndex = startIndex; blockIndex < blocks.Count && inspectedBlocks < MaxKeepWithNextChainBlocks; blockIndex++, inspectedBlocks++) {
+            for (int blockIndex = startIndex; blockIndex < blocks.Count; blockIndex++) {
                 IPdfBlock block = blocks[blockIndex];
                 if (IsNonVisualFlowMarker(block)) {
                     continue;
                 }
+                if (inspectedBlocks >= MaxKeepWithNextChainBlocks) {
+                    break;
+                }
+                inspectedBlocks++;
 
                 bool keepWithNext = KeepsWithNext(block);
                 height += keepWithNext

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.FlowMetrics.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Layout.Context.FlowMetrics.cs
@@ -241,9 +241,12 @@ internal static partial class PdfWriter {
             return height;
         }
 
+        private const int MaxKeepWithNextChainBlocks = 256;
+
         private double MeasureKeepWithNextChainHeight(System.Collections.Generic.IList<IPdfBlock> blocks, int startIndex, double frameX, double frameWidth, double fontSize) {
             double height = 0D;
-            for (int blockIndex = startIndex; blockIndex < blocks.Count; blockIndex++) {
+            int inspectedBlocks = 0;
+            for (int blockIndex = startIndex; blockIndex < blocks.Count && inspectedBlocks < MaxKeepWithNextChainBlocks; blockIndex++, inspectedBlocks++) {
                 IPdfBlock block = blocks[blockIndex];
                 if (IsNonVisualFlowMarker(block)) {
                     continue;

--- a/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.Tabs.cs
+++ b/OfficeIMO.Pdf/Rendering/Writer/PdfWriter.Text.Tabs.cs
@@ -126,6 +126,8 @@ internal static partial class PdfWriter {
         return Math.Max(spaceWidth, advance);
     }
 
+    private const int MaxTabLeaderGlyphCount = 4_096;
+
     private static string BuildTabLeaderText(double gap, PdfStandardFont font, double fontSize, PdfTextBaseline baseline, PdfTabLeaderStyle leaderStyle, PdfOptions? options) {
         string leaderGlyph = leaderStyle switch {
             PdfTabLeaderStyle.Dots => ".",
@@ -143,7 +145,10 @@ internal static partial class PdfWriter {
             return string.Empty;
         }
 
-        int count = Math.Max(3, (int)Math.Floor(gap / glyphWidth));
+        double requestedCount = Math.Floor(gap / glyphWidth);
+        int count = requestedCount >= MaxTabLeaderGlyphCount
+            ? MaxTabLeaderGlyphCount
+            : Math.Max(3, (int)requestedCount);
         return new string(leaderGlyph[0], count);
     }
 }

--- a/OfficeIMO.PowerPoint.Tests/PowerPoint.ChartCacheLimits.cs
+++ b/OfficeIMO.PowerPoint.Tests/PowerPoint.ChartCacheLimits.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using DocumentFormat.OpenXml;
+using OfficeIMO.PowerPoint;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+using Xunit;
+
+namespace OfficeIMO.Tests;
+
+public partial class PowerPoint {
+    [Fact]
+    public void ChartSnapshotRejectsOversizedDeclaredCacheBeforeAllocation() {
+        var cache = new C.NumberingCache(new C.PointCount { Val = 100_001U });
+        var points = new List<C.NumericPoint>();
+        Func<C.NumericPoint, uint?> getIndex = point => point.Index?.Value;
+        MethodInfo method = typeof(PowerPointChart)
+            .GetMethod("GetCachedPointLength", BindingFlags.NonPublic | BindingFlags.Static)!
+            .MakeGenericMethod(typeof(C.NumericPoint));
+
+        TargetInvocationException invocation = Assert.Throws<TargetInvocationException>(() =>
+            method.Invoke(null, new object[] { cache, points, getIndex }));
+
+        Assert.IsType<InvalidDataException>(invocation.InnerException);
+    }
+
+    [Fact]
+    public void ChartSnapshotRejectsSparseOversizedCacheIndexBeforeAllocation() {
+        var cache = new C.NumberingCache();
+        var points = new List<C.NumericPoint> {
+            new C.NumericPoint { Index = 100_000U }
+        };
+        Func<C.NumericPoint, uint?> getIndex = point => point.Index?.Value;
+        MethodInfo method = typeof(PowerPointChart)
+            .GetMethod("GetCachedPointLength", BindingFlags.NonPublic | BindingFlags.Static)!
+            .MakeGenericMethod(typeof(C.NumericPoint));
+
+        TargetInvocationException invocation = Assert.Throws<TargetInvocationException>(() =>
+            method.Invoke(null, new object[] { cache, points, getIndex }));
+
+        Assert.IsType<InvalidDataException>(invocation.InnerException);
+    }
+}

--- a/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
+++ b/OfficeIMO.PowerPoint/PowerPointChart.Snapshot.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
@@ -10,6 +11,8 @@ using C = DocumentFormat.OpenXml.Drawing.Charts;
 
 namespace OfficeIMO.PowerPoint {
     public partial class PowerPointChart {
+        private const int MaxChartCachePoints = 100_000;
+
         /// <summary>
         /// Tries to create a dependency-free snapshot for rendering/export consumers.
         /// </summary>
@@ -451,7 +454,8 @@ namespace OfficeIMO.PowerPoint {
                 return Array.Empty<string>();
             }
 
-            List<C.StringPoint> stringPoints = container.Descendants<C.StringPoint>().OrderBy(point => point.Index?.Value ?? 0U).ToList();
+            List<C.StringPoint> stringPoints = GetBoundedCachedPoints(container.Descendants<C.StringPoint>());
+            stringPoints.Sort((left, right) => (left.Index?.Value ?? 0U).CompareTo(right.Index?.Value ?? 0U));
             if (stringPoints.Count > 0) {
                 return CreateIndexedCache(
                     container,
@@ -461,7 +465,8 @@ namespace OfficeIMO.PowerPoint {
                     string.Empty);
             }
 
-            List<C.NumericPoint> numericPoints = container.Descendants<C.NumericPoint>().OrderBy(point => point.Index?.Value ?? 0U).ToList();
+            List<C.NumericPoint> numericPoints = GetBoundedCachedPoints(container.Descendants<C.NumericPoint>());
+            numericPoints.Sort((left, right) => (left.Index?.Value ?? 0U).CompareTo(right.Index?.Value ?? 0U));
             if (numericPoints.Count > 0) {
                 return CreateIndexedCache(
                     container,
@@ -479,7 +484,8 @@ namespace OfficeIMO.PowerPoint {
                 return Array.Empty<double>();
             }
 
-            List<C.NumericPoint> points = container.Descendants<C.NumericPoint>().OrderBy(point => point.Index?.Value ?? 0U).ToList();
+            List<C.NumericPoint> points = GetBoundedCachedPoints(container.Descendants<C.NumericPoint>());
+            points.Sort((left, right) => (left.Index?.Value ?? 0U).CompareTo(right.Index?.Value ?? 0U));
             if (points.Count == 0) {
                 return Array.Empty<double>();
             }
@@ -523,14 +529,35 @@ namespace OfficeIMO.PowerPoint {
             return values;
         }
 
+        private static List<TPoint> GetBoundedCachedPoints<TPoint>(IEnumerable<TPoint> points) {
+            List<TPoint> boundedPoints = points.Take(MaxChartCachePoints + 1).ToList();
+            if (boundedPoints.Count > MaxChartCachePoints) {
+                throw new InvalidDataException($"The chart cache exceeds the supported limit of {MaxChartCachePoints} points.");
+            }
+
+            return boundedPoints;
+        }
+
         private static int GetCachedPointLength<TPoint>(OpenXmlElement container, IReadOnlyList<TPoint> points, Func<TPoint, uint?> getIndex) {
+            if (points.Count > MaxChartCachePoints) {
+                throw new InvalidDataException($"The chart cache exceeds the supported limit of {MaxChartCachePoints} points.");
+            }
+
             uint? pointCount = container.Descendants<C.PointCount>().FirstOrDefault()?.Val?.Value;
+            if (pointCount > MaxChartCachePoints) {
+                throw new InvalidDataException($"The chart cache declares more than the supported limit of {MaxChartCachePoints} points.");
+            }
+
             uint maxIndex = 0U;
             bool hasIndexedPoint = false;
             for (int i = 0; i < points.Count; i++) {
                 uint? index = getIndex(points[i]);
                 if (!index.HasValue) {
                     continue;
+                }
+
+                if (index.Value >= MaxChartCachePoints) {
+                    throw new InvalidDataException($"The chart cache point index exceeds the supported limit of {MaxChartCachePoints} points.");
                 }
 
                 hasIndexedPoint = true;
@@ -541,10 +568,6 @@ namespace OfficeIMO.PowerPoint {
 
             uint indexedLength = hasIndexedPoint ? maxIndex + 1U : (uint)points.Count;
             uint length = Math.Max(pointCount ?? 0U, indexedLength);
-            if (length > int.MaxValue) {
-                return points.Count;
-            }
-
             return (int)length;
         }
 

--- a/OfficeIMO.PowerPoint/PowerPointFeatureReport.cs
+++ b/OfficeIMO.PowerPoint/PowerPointFeatureReport.cs
@@ -300,6 +300,10 @@ namespace OfficeIMO.PowerPoint {
     }
 
     public sealed partial class PowerPointPresentation {
+        private const int MaxFeatureInspectionParts = 100_000;
+        private const int MaxFeatureInspectionRelationships = 500_000;
+        private const int MaxFeatureInspectionDepth = 128;
+
         /// <summary>
         /// Inspects presentation features and reports which ones OfficeIMO can edit, partially edit, preserve, or does not support yet.
         /// </summary>
@@ -455,41 +459,57 @@ namespace OfficeIMO.PowerPoint {
 
         private static IEnumerable<OpenXmlPart> EnumeratePowerPointPartsAndPackage(PresentationDocument document, OpenXmlPart root) {
             var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var pending = new Stack<(OpenXmlPart Part, int Depth)>();
+            int relationshipCount = 0;
             foreach (var pair in document.Parts) {
-                foreach (var part in EnumeratePowerPointParts(pair.OpenXmlPart, visited)) {
-                    yield return part;
+                relationshipCount++;
+                if (relationshipCount > MaxFeatureInspectionRelationships) {
+                    throw new InvalidDataException($"PowerPoint feature inspection exceeded the supported relationship limit of {MaxFeatureInspectionRelationships}.");
                 }
+
+                pending.Push((pair.OpenXmlPart, 0));
             }
 
-            foreach (var part in EnumeratePowerPointParts(root, visited)) {
-                yield return part;
+            relationshipCount++;
+            if (relationshipCount > MaxFeatureInspectionRelationships) {
+                throw new InvalidDataException($"PowerPoint feature inspection exceeded the supported relationship limit of {MaxFeatureInspectionRelationships}.");
             }
+
+            pending.Push((root, 0));
 
             if (document.DigitalSignatureOriginPart != null) {
-                foreach (var part in EnumeratePowerPointParts(document.DigitalSignatureOriginPart, visited)) {
-                    yield return part;
+                relationshipCount++;
+                if (relationshipCount > MaxFeatureInspectionRelationships) {
+                    throw new InvalidDataException($"PowerPoint feature inspection exceeded the supported relationship limit of {MaxFeatureInspectionRelationships}.");
                 }
-            }
-        }
 
-        private static IEnumerable<OpenXmlPart> EnumeratePowerPointParts(OpenXmlPart part, HashSet<string> visited) {
-            string key = part.Uri.OriginalString + "|" + part.ContentType;
-            if (!visited.Add(key)) {
-                yield break;
+                pending.Push((document.DigitalSignatureOriginPart, 0));
             }
 
-            yield return part;
+            while (pending.Count > 0) {
+                (OpenXmlPart part, int depth) = pending.Pop();
+                if (depth > MaxFeatureInspectionDepth) {
+                    throw new InvalidDataException($"PowerPoint feature inspection exceeded the supported relationship depth of {MaxFeatureInspectionDepth}.");
+                }
 
-            foreach (var child in EnumeratePowerPointParts((OpenXmlPartContainer)part, visited)) {
-                yield return child;
-            }
-        }
+                string key = part.Uri.OriginalString + "|" + part.ContentType;
+                if (!visited.Add(key)) {
+                    continue;
+                }
 
-        private static IEnumerable<OpenXmlPart> EnumeratePowerPointParts(OpenXmlPartContainer container, HashSet<string> visited) {
-            foreach (var pair in container.Parts) {
-                var part = pair.OpenXmlPart;
-                foreach (var child in EnumeratePowerPointParts(part, visited)) {
-                    yield return child;
+                if (visited.Count > MaxFeatureInspectionParts) {
+                    throw new InvalidDataException($"PowerPoint feature inspection exceeded the supported part limit of {MaxFeatureInspectionParts}.");
+                }
+
+                yield return part;
+
+                foreach (IdPartPair pair in part.Parts) {
+                    relationshipCount++;
+                    if (relationshipCount > MaxFeatureInspectionRelationships) {
+                        throw new InvalidDataException($"PowerPoint feature inspection exceeded the supported relationship limit of {MaxFeatureInspectionRelationships}.");
+                    }
+
+                    pending.Push((pair.OpenXmlPart, depth + 1));
                 }
             }
         }

--- a/OfficeIMO.Rtf.Markdown/MarkdownToRtfConverter.cs
+++ b/OfficeIMO.Rtf.Markdown/MarkdownToRtfConverter.cs
@@ -251,32 +251,42 @@ internal static class MarkdownToRtfConverter {
         int parentLevel,
         MarkdownToRtfConversionContext context,
         IReadOnlyDictionary<string, FootnoteDefinitionBlock> footnoteDefinitions) {
-        var pending = new Queue<ListItem>();
-        EnqueueListItems(listBlock, pending);
+        var pending = new Stack<object>();
+        PushListItems(listBlock, pending);
         while (pending.Count > 0) {
-            ListItem item = pending.Dequeue();
+            object next = pending.Pop();
+            if (next is IMarkdownBlock continuationBlock) {
+                ConvertNestedContinuationBlock(document, continuationBlock, parentLevel, context, footnoteDefinitions);
+                continue;
+            }
+
+            ListItem item = (ListItem)next;
             AppendInlineSequence(AddListContinuationParagraph(document, parentLevel), item.Content, document, context, InlineStyle.Normal, footnoteDefinitions);
             for (int paragraphIndex = 0; paragraphIndex < item.AdditionalParagraphs.Count; paragraphIndex++) {
                 AppendInlineSequence(AddListContinuationParagraph(document, parentLevel), item.AdditionalParagraphs[paragraphIndex], document, context, InlineStyle.Normal, footnoteDefinitions);
             }
 
-            for (int childIndex = 0; childIndex < item.ChildBlocks.Count; childIndex++) {
+            for (int childIndex = item.ChildBlocks.Count - 1; childIndex >= 0; childIndex--) {
                 IMarkdownBlock child = item.ChildBlocks[childIndex];
+                if (IsRenderedListItemParagraphBlock(item, child)) {
+                    continue;
+                }
+
                 if (child is UnorderedListBlock || child is OrderedListBlock) {
-                    EnqueueListItems(child, pending);
-                } else if (!IsRenderedListItemParagraphBlock(item, child)) {
-                    ConvertNestedContinuationBlock(document, child, parentLevel, context, footnoteDefinitions);
+                    PushListItems(child, pending);
+                } else {
+                    pending.Push(child);
                 }
             }
         }
     }
 
-    private static void EnqueueListItems(IMarkdownBlock listBlock, Queue<ListItem> pending) {
+    private static void PushListItems(IMarkdownBlock listBlock, Stack<object> pending) {
         IReadOnlyList<ListItem> items = listBlock is UnorderedListBlock unorderedList
             ? unorderedList.Items
             : ((OrderedListBlock)listBlock).Items;
-        for (int index = 0; index < items.Count; index++) {
-            pending.Enqueue(items[index]);
+        for (int index = items.Count - 1; index >= 0; index--) {
+            pending.Push(items[index]);
         }
     }
 

--- a/OfficeIMO.Rtf.Markdown/MarkdownToRtfConverter.cs
+++ b/OfficeIMO.Rtf.Markdown/MarkdownToRtfConverter.cs
@@ -298,6 +298,8 @@ internal static class MarkdownToRtfConverter {
             if (listBlock is OrderedListBlock orderedList) {
                 int markerValue = orderedList.Reversed ? orderedList.Start - index : orderedList.Start + index;
                 markerText = items[index].MarkerText ?? OrderedListBlock.FormatMarker(markerValue, orderedList.MarkerStyle, orderedList.MarkerDelimiter);
+            } else if (listBlock is UnorderedListBlock) {
+                markerText = items[index].MarkerText ?? "-";
             }
 
             pending.Push(new FlattenedListItem(items[index], markerText));

--- a/OfficeIMO.Rtf.Markdown/MarkdownToRtfConverter.cs
+++ b/OfficeIMO.Rtf.Markdown/MarkdownToRtfConverter.cs
@@ -260,8 +260,12 @@ internal static class MarkdownToRtfConverter {
                 continue;
             }
 
-            ListItem item = (ListItem)next;
+            FlattenedListItem flattenedItem = (FlattenedListItem)next;
+            ListItem item = flattenedItem.Item;
             RtfParagraph paragraph = AddListContinuationParagraph(document, parentLevel);
+            if (flattenedItem.MarkerText != null) {
+                paragraph.AddText(flattenedItem.MarkerText + " ");
+            }
             if (item.IsTask) {
                 paragraph.AddText(item.Checked ? "[x] " : "[ ] ");
             }
@@ -290,8 +294,24 @@ internal static class MarkdownToRtfConverter {
             ? unorderedList.Items
             : ((OrderedListBlock)listBlock).Items;
         for (int index = items.Count - 1; index >= 0; index--) {
-            pending.Push(items[index]);
+            string? markerText = null;
+            if (listBlock is OrderedListBlock orderedList) {
+                int markerValue = orderedList.Reversed ? orderedList.Start - index : orderedList.Start + index;
+                markerText = items[index].MarkerText ?? OrderedListBlock.FormatMarker(markerValue, orderedList.MarkerStyle, orderedList.MarkerDelimiter);
+            }
+
+            pending.Push(new FlattenedListItem(items[index], markerText));
         }
+    }
+
+    private sealed class FlattenedListItem {
+        internal FlattenedListItem(ListItem item, string? markerText) {
+            Item = item;
+            MarkerText = markerText;
+        }
+
+        internal ListItem Item { get; }
+        internal string? MarkerText { get; }
     }
 
     private static void ConvertNestedContinuationBlock(RtfDocument document, IMarkdownBlock block, int parentLevel, MarkdownToRtfConversionContext context, IReadOnlyDictionary<string, FootnoteDefinitionBlock> footnoteDefinitions) {

--- a/OfficeIMO.Rtf.Markdown/MarkdownToRtfConverter.cs
+++ b/OfficeIMO.Rtf.Markdown/MarkdownToRtfConverter.cs
@@ -124,7 +124,15 @@ internal static class MarkdownToRtfConverter {
         for (int i = 0; i < items.Count; i++) {
             ListItem item = items[i];
             RtfParagraph paragraph = document.AddParagraph();
-            int level = Math.Max(0, levelOffset + item.Level);
+            long requestedLevel = (long)levelOffset + item.Level;
+            int level = (int)Math.Min(context.MaxListNestingDepth - 1L, Math.Max(0L, requestedLevel));
+            if (requestedLevel >= context.MaxListNestingDepth) {
+                context.Report(
+                    "MDRTF018",
+                    RtfMarkdownDiagnosticSeverity.Warning,
+                    $"Markdown list nesting was limited to {context.MaxListNestingDepth} levels.",
+                    action: RtfConversionAction.Flattened);
+            }
             EnsureListLevel(document, listId, level, kind, start);
             paragraph.SetList(listId, level, kind);
             paragraph.ListDefinitionId = listId;
@@ -212,6 +220,17 @@ internal static class MarkdownToRtfConverter {
     }
 
     private static void ConvertNestedListOrBlock(RtfDocument document, IMarkdownBlock block, int listId, int parentLevel, MarkdownToRtfConversionContext context, IReadOnlyDictionary<string, FootnoteDefinitionBlock> footnoteDefinitions) {
+        if (parentLevel >= context.MaxListNestingDepth - 1 &&
+            (block is UnorderedListBlock || block is OrderedListBlock)) {
+            ConvertFlattenedListAsContinuations(document, block, parentLevel, context, footnoteDefinitions);
+            context.Report(
+                "MDRTF018",
+                RtfMarkdownDiagnosticSeverity.Warning,
+                $"Markdown list nesting was limited to {context.MaxListNestingDepth} levels.",
+                action: RtfConversionAction.Flattened);
+            return;
+        }
+
         switch (block) {
             case UnorderedListBlock unorderedList:
                 ConvertListItems(document, unorderedList.Items, listId, RtfListKind.Bullet, 1, parentLevel + 1, context, footnoteDefinitions);
@@ -223,6 +242,41 @@ internal static class MarkdownToRtfConverter {
             default:
                 ConvertNestedContinuationBlock(document, block, parentLevel, context, footnoteDefinitions);
                 break;
+        }
+    }
+
+    private static void ConvertFlattenedListAsContinuations(
+        RtfDocument document,
+        IMarkdownBlock listBlock,
+        int parentLevel,
+        MarkdownToRtfConversionContext context,
+        IReadOnlyDictionary<string, FootnoteDefinitionBlock> footnoteDefinitions) {
+        var pending = new Queue<ListItem>();
+        EnqueueListItems(listBlock, pending);
+        while (pending.Count > 0) {
+            ListItem item = pending.Dequeue();
+            AppendInlineSequence(AddListContinuationParagraph(document, parentLevel), item.Content, document, context, InlineStyle.Normal, footnoteDefinitions);
+            for (int paragraphIndex = 0; paragraphIndex < item.AdditionalParagraphs.Count; paragraphIndex++) {
+                AppendInlineSequence(AddListContinuationParagraph(document, parentLevel), item.AdditionalParagraphs[paragraphIndex], document, context, InlineStyle.Normal, footnoteDefinitions);
+            }
+
+            for (int childIndex = 0; childIndex < item.ChildBlocks.Count; childIndex++) {
+                IMarkdownBlock child = item.ChildBlocks[childIndex];
+                if (child is UnorderedListBlock || child is OrderedListBlock) {
+                    EnqueueListItems(child, pending);
+                } else if (!IsRenderedListItemParagraphBlock(item, child)) {
+                    ConvertNestedContinuationBlock(document, child, parentLevel, context, footnoteDefinitions);
+                }
+            }
+        }
+    }
+
+    private static void EnqueueListItems(IMarkdownBlock listBlock, Queue<ListItem> pending) {
+        IReadOnlyList<ListItem> items = listBlock is UnorderedListBlock unorderedList
+            ? unorderedList.Items
+            : ((OrderedListBlock)listBlock).Items;
+        for (int index = 0; index < items.Count; index++) {
+            pending.Enqueue(items[index]);
         }
     }
 
@@ -242,6 +296,7 @@ internal static class MarkdownToRtfConverter {
                 ConvertNestedCodeBlock(document, code, parentLevel);
                 break;
             case TableBlock table:
+                EnsureTableWithinLimit(table, context);
                 context.Report("MDRTF013", RtfMarkdownDiagnosticSeverity.Info, "Markdown table inside list item preserved as continuation text.");
                 ConvertRenderedBlockAsContinuation(document, table, parentLevel);
                 break;
@@ -307,6 +362,8 @@ internal static class MarkdownToRtfConverter {
             return;
         }
 
+        EnsureTableWithinLimit(rowCount, columnCount, context);
+
         RtfTable rtfTable = document.AddTable(rowCount, columnCount);
         int rtfRowIndex = 0;
         if (table.Headers.Count > 0) {
@@ -321,6 +378,19 @@ internal static class MarkdownToRtfConverter {
                 ? rowInlines[rowIndex]
                 : Array.Empty<InlineSequence>();
             FillTableRow(rtfTable.Rows[rtfRowIndex++], cells, table.Alignments, document, context, footnoteDefinitions);
+        }
+    }
+
+    private static void EnsureTableWithinLimit(TableBlock table, MarkdownToRtfConversionContext context) {
+        int rowCount = table.Rows.Count + (table.Headers.Count > 0 ? 1 : 0);
+        int columnCount = Math.Max(table.Headers.Count, table.Rows.Count == 0 ? 0 : table.Rows.Max(row => row.Count));
+        EnsureTableWithinLimit(rowCount, columnCount, context);
+    }
+
+    private static void EnsureTableWithinLimit(int rowCount, int columnCount, MarkdownToRtfConversionContext context) {
+        long tableCells = (long)rowCount * columnCount;
+        if (tableCells > context.MaxTableCells) {
+            throw new InvalidOperationException($"The Markdown table contains {tableCells} cells, exceeding the configured limit of {context.MaxTableCells}.");
         }
     }
 

--- a/OfficeIMO.Rtf.Markdown/MarkdownToRtfConverter.cs
+++ b/OfficeIMO.Rtf.Markdown/MarkdownToRtfConverter.cs
@@ -261,7 +261,11 @@ internal static class MarkdownToRtfConverter {
             }
 
             ListItem item = (ListItem)next;
-            AppendInlineSequence(AddListContinuationParagraph(document, parentLevel), item.Content, document, context, InlineStyle.Normal, footnoteDefinitions);
+            RtfParagraph paragraph = AddListContinuationParagraph(document, parentLevel);
+            if (item.IsTask) {
+                paragraph.AddText(item.Checked ? "[x] " : "[ ] ");
+            }
+            AppendInlineSequence(paragraph, item.Content, document, context, InlineStyle.Normal, footnoteDefinitions);
             for (int paragraphIndex = 0; paragraphIndex < item.AdditionalParagraphs.Count; paragraphIndex++) {
                 AppendInlineSequence(AddListContinuationParagraph(document, parentLevel), item.AdditionalParagraphs[paragraphIndex], document, context, InlineStyle.Normal, footnoteDefinitions);
             }

--- a/OfficeIMO.Rtf.Markdown/MarkdownToRtfOptions.cs
+++ b/OfficeIMO.Rtf.Markdown/MarkdownToRtfOptions.cs
@@ -9,4 +9,10 @@ public sealed class MarkdownToRtfOptions {
 
     /// <summary>Preserves raw HTML as visible text. Otherwise raw HTML is omitted with a diagnostic.</summary>
     public bool PreserveRawHtmlAsText { get; set; }
+
+    /// <summary>Maximum nested Markdown list depth converted into RTF list levels. Default: 32.</summary>
+    public int MaxListNestingDepth { get; set; } = 32;
+
+    /// <summary>Maximum number of cells allocated for one converted Markdown table. Default: 100,000.</summary>
+    public int MaxTableCells { get; set; } = 100_000;
 }

--- a/OfficeIMO.Rtf.Markdown/RtfMarkdownBridgeMarkers.cs
+++ b/OfficeIMO.Rtf.Markdown/RtfMarkdownBridgeMarkers.cs
@@ -7,6 +7,7 @@ namespace OfficeIMO.Rtf.Markdown;
 internal static class RtfMarkdownBridgeMarkers {
     private const string ListContinuationBookmarkPrefix = "_OfficeIMO_MLC_";
     private const string CodeBlockBookmarkPrefix = "_OfficeIMO_MCB_";
+    private const int MaxCodeBlockInfoStringCharacters = 1_024;
 
     internal static string CreateListContinuationBookmarkName(int ordinal) =>
         ListContinuationBookmarkPrefix + Math.Max(0, ordinal).ToString(CultureInfo.InvariantCulture);
@@ -44,7 +45,10 @@ internal static class RtfMarkdownBridgeMarkers {
             return string.Empty;
         }
 
-        byte[] bytes = Encoding.UTF8.GetBytes(value!);
+        string boundedValue = value!.Length <= MaxCodeBlockInfoStringCharacters
+            ? value
+            : value.Substring(0, MaxCodeBlockInfoStringCharacters);
+        byte[] bytes = Encoding.UTF8.GetBytes(boundedValue);
         var builder = new StringBuilder(bytes.Length * 2);
         for (int i = 0; i < bytes.Length; i++) {
             builder.Append(bytes[i].ToString("X2", CultureInfo.InvariantCulture));

--- a/OfficeIMO.Rtf.Markdown/RtfMarkdownConversionContexts.cs
+++ b/OfficeIMO.Rtf.Markdown/RtfMarkdownConversionContexts.cs
@@ -60,10 +60,19 @@ internal sealed class MarkdownToRtfConversionContext : RtfMarkdownConversionCont
 
     internal MarkdownToRtfConversionContext(MarkdownToRtfOptions options) {
         _options = options ?? throw new ArgumentNullException(nameof(options));
+        if (_options.MaxListNestingDepth <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(options.MaxListNestingDepth), _options.MaxListNestingDepth, "Maximum list nesting depth must be positive.");
+        }
+
+        if (_options.MaxTableCells <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(options.MaxTableCells), _options.MaxTableCells, "Maximum table cells must be positive.");
+        }
     }
 
     internal MarkdownReaderOptions? ReaderOptions => _options.ReaderOptions;
     internal bool PreserveRawHtmlAsText => _options.PreserveRawHtmlAsText;
+    internal int MaxListNestingDepth => _options.MaxListNestingDepth;
+    internal int MaxTableCells => _options.MaxTableCells;
 
     internal void Report(
         string code,

--- a/OfficeIMO.Rtf.Tests/Rtf/RtfMarkdownSecurityLimitTests.cs
+++ b/OfficeIMO.Rtf.Tests/Rtf/RtfMarkdownSecurityLimitTests.cs
@@ -84,6 +84,25 @@ public class RtfMarkdownSecurityLimitTests {
     }
 
     [Fact]
+    public void MarkdownListConversionPreservesOrderedMarkersWhenFlatteningCappedLists() {
+        ListItem root = ListItem.Text("Root");
+        root.NestedBlocks.Add(new OrderedListBlock {
+            Start = 3,
+            Items = {
+                ListItem.Text("Third"),
+                ListItem.Text("Fourth")
+            }
+        });
+        MarkdownDoc markdown = MarkdownDoc.Create().Add(new UnorderedListBlock { Items = { root } });
+
+        RtfDocument rtf = markdown.ToRtfDocument(new MarkdownToRtfOptions { MaxListNestingDepth = 1 });
+        string plainText = string.Join("\n", rtf.Paragraphs.Select(paragraph => paragraph.ToPlainText()));
+
+        Assert.Contains("3. Third", plainText, StringComparison.Ordinal);
+        Assert.Contains("4. Fourth", plainText, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CodeBlockInfoBookmarkPayloadIsBounded() {
         string infoString = new string('x', 2_000);
         MarkdownDoc markdown = MarkdownDoc.Create().Add(new CodeBlock(infoString, "value"));

--- a/OfficeIMO.Rtf.Tests/Rtf/RtfMarkdownSecurityLimitTests.cs
+++ b/OfficeIMO.Rtf.Tests/Rtf/RtfMarkdownSecurityLimitTests.cs
@@ -63,6 +63,27 @@ public class RtfMarkdownSecurityLimitTests {
     }
 
     [Fact]
+    public void MarkdownListConversionPreservesTaskMarkersWhenFlatteningCappedLists() {
+        ListItem root = ListItem.Text("Root");
+        root.NestedBlocks.Add(new UnorderedListBlock {
+            Items = {
+                ListItem.Task("Finished", done: true),
+                ListItem.Task("Pending")
+            }
+        });
+        MarkdownDoc markdown = MarkdownDoc.Create().Add(new UnorderedListBlock { Items = { root } });
+
+        RtfDocument rtf = markdown.ToRtfDocument(new MarkdownToRtfOptions { MaxListNestingDepth = 1 });
+        string plainText = string.Join("\n", rtf.Paragraphs.Select(paragraph => paragraph.ToPlainText()));
+        string roundTrip = rtf.ToMarkdown();
+
+        Assert.Contains("[x] Finished", plainText, StringComparison.Ordinal);
+        Assert.Contains("[ ] Pending", plainText, StringComparison.Ordinal);
+        Assert.Contains("\\[x\\] Finished", roundTrip, StringComparison.Ordinal);
+        Assert.Contains("\\[ \\] Pending", roundTrip, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CodeBlockInfoBookmarkPayloadIsBounded() {
         string infoString = new string('x', 2_000);
         MarkdownDoc markdown = MarkdownDoc.Create().Add(new CodeBlock(infoString, "value"));

--- a/OfficeIMO.Rtf.Tests/Rtf/RtfMarkdownSecurityLimitTests.cs
+++ b/OfficeIMO.Rtf.Tests/Rtf/RtfMarkdownSecurityLimitTests.cs
@@ -1,0 +1,69 @@
+using OfficeIMO.Markdown;
+using OfficeIMO.Rtf;
+using OfficeIMO.Rtf.Markdown;
+using Xunit;
+
+namespace OfficeIMO.Tests.Rtf;
+
+public class RtfMarkdownSecurityLimitTests {
+    [Fact]
+    public void MarkdownTableConversionRejectsConfiguredCellBudgetBeforeAllocation() {
+        var table = new TableBlock();
+        table.Headers.AddRange(new[] { "A", "B" });
+        table.Rows.Add(new[] { "1", "2" });
+        MarkdownDoc markdown = MarkdownDoc.Create().Add(table);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+            markdown.ToRtfDocument(new MarkdownToRtfOptions { MaxTableCells = 3 }));
+
+        Assert.Contains("exceeding the configured limit of 3", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MarkdownTableInsideListUsesTheSameCellBudget() {
+        var table = new TableBlock();
+        table.Headers.AddRange(new[] { "A", "B" });
+        table.Rows.Add(new[] { "1", "2" });
+        ListItem item = ListItem.Text("Item");
+        item.NestedBlocks.Add(table);
+        MarkdownDoc markdown = MarkdownDoc.Create().Add(new UnorderedListBlock { Items = { item } });
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+            markdown.ToRtfDocument(new MarkdownToRtfOptions { MaxTableCells = 3 }));
+
+        Assert.Contains("exceeding the configured limit of 3", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MarkdownListConversionCapsAuthoredRtfLevels() {
+        string markdownText = "- zero\n  - one\n    - two\n      - three\n        - four\n";
+        RtfConversionResult<OfficeIMO.Rtf.RtfDocument> result = MarkdownReader.Parse(markdownText).ToRtfDocumentResult(
+            new MarkdownToRtfOptions { MaxListNestingDepth = 3 });
+
+        Assert.All(result.Value.ListDefinitions, definition => Assert.InRange(definition.Levels.Count, 1, 3));
+        Assert.Contains(result.Report.Diagnostics, diagnostic => diagnostic.Code == "MDRTF018");
+    }
+
+    [Fact]
+    public void CodeBlockInfoBookmarkPayloadIsBounded() {
+        string infoString = new string('x', 2_000);
+        MarkdownDoc markdown = MarkdownDoc.Create().Add(new CodeBlock(infoString, "value"));
+
+        string roundTrip = markdown.ToRtfDocument().ToMarkdown();
+
+        Assert.Contains(new string('x', 1_024), roundTrip, StringComparison.Ordinal);
+        Assert.DoesNotContain(new string('x', 1_025), roundTrip, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(1, 0)]
+    public void MarkdownConversionRejectsNonPositiveResourceLimits(int maxDepth, int maxCells) {
+        var options = new MarkdownToRtfOptions {
+            MaxListNestingDepth = maxDepth,
+            MaxTableCells = maxCells
+        };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => MarkdownDoc.Create().ToRtfDocument(options));
+    }
+}

--- a/OfficeIMO.Rtf.Tests/Rtf/RtfMarkdownSecurityLimitTests.cs
+++ b/OfficeIMO.Rtf.Tests/Rtf/RtfMarkdownSecurityLimitTests.cs
@@ -45,6 +45,24 @@ public class RtfMarkdownSecurityLimitTests {
     }
 
     [Fact]
+    public void MarkdownListConversionPreservesDepthFirstOrderWhenFlatteningCappedLists() {
+        ListItem nested = ListItem.Text("AlphaChild");
+        ListItem first = ListItem.Text("AlphaParent");
+        first.NestedBlocks.Add(new UnorderedListBlock { Items = { nested } });
+        ListItem second = ListItem.Text("BetaSibling");
+        ListItem root = ListItem.Text("Root");
+        root.NestedBlocks.Add(new UnorderedListBlock { Items = { first, second } });
+        MarkdownDoc markdown = MarkdownDoc.Create().Add(new UnorderedListBlock { Items = { root } });
+
+        string roundTrip = markdown.ToRtfDocument(new MarkdownToRtfOptions { MaxListNestingDepth = 1 }).ToMarkdown();
+
+        int firstIndex = roundTrip.IndexOf("AlphaParent", StringComparison.Ordinal);
+        int childIndex = roundTrip.IndexOf("AlphaChild", StringComparison.Ordinal);
+        int secondIndex = roundTrip.IndexOf("BetaSibling", StringComparison.Ordinal);
+        Assert.True(firstIndex >= 0 && childIndex > firstIndex && secondIndex > childIndex, roundTrip);
+    }
+
+    [Fact]
     public void CodeBlockInfoBookmarkPayloadIsBounded() {
         string infoString = new string('x', 2_000);
         MarkdownDoc markdown = MarkdownDoc.Create().Add(new CodeBlock(infoString, "value"));

--- a/OfficeIMO.Rtf.Tests/Rtf/RtfMarkdownSecurityLimitTests.cs
+++ b/OfficeIMO.Rtf.Tests/Rtf/RtfMarkdownSecurityLimitTests.cs
@@ -103,6 +103,24 @@ public class RtfMarkdownSecurityLimitTests {
     }
 
     [Fact]
+    public void MarkdownListConversionPreservesUnorderedMarkersWhenFlatteningCappedLists() {
+        ListItem root = ListItem.Text("Root");
+        root.NestedBlocks.Add(new UnorderedListBlock {
+            Items = {
+                ListItem.Text("First child"),
+                ListItem.Text("Second child")
+            }
+        });
+        MarkdownDoc markdown = MarkdownDoc.Create().Add(new UnorderedListBlock { Items = { root } });
+
+        RtfDocument rtf = markdown.ToRtfDocument(new MarkdownToRtfOptions { MaxListNestingDepth = 1 });
+        string plainText = string.Join("\n", rtf.Paragraphs.Select(paragraph => paragraph.ToPlainText()));
+
+        Assert.Contains("- First child", plainText, StringComparison.Ordinal);
+        Assert.Contains("- Second child", plainText, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CodeBlockInfoBookmarkPayloadIsBounded() {
         string infoString = new string('x', 2_000);
         MarkdownDoc markdown = MarkdownDoc.Create().Add(new CodeBlock(infoString, "value"));

--- a/OfficeIMO.Word.Pdf/TableLayoutCache.cs
+++ b/OfficeIMO.Word.Pdf/TableLayoutCache.cs
@@ -1,12 +1,21 @@
 using DocumentFormat.OpenXml.Wordprocessing;
 using System.Collections.Generic;
+using System.IO;
 using System.Runtime.CompilerServices;
 
 namespace OfficeIMO.Word.Pdf {
     internal static class TableLayoutCache {
+        private const int MaxTableGridColumns = 16_384;
+        private const int MaxTableNestingDepth = 128;
         private static readonly ConditionalWeakTable<WordTable, TableLayout> _cache = new();
 
-        internal static TableLayout GetLayout(WordTable table) {
+        internal static TableLayout GetLayout(WordTable table) => GetLayout(table, depth: 0);
+
+        private static TableLayout GetLayout(WordTable table, int depth) {
+            if (depth >= MaxTableNestingDepth) {
+                throw new InvalidDataException($"Table nesting exceeds the supported limit of {MaxTableNestingDepth} levels.");
+            }
+
             if (_cache.TryGetValue(table, out TableLayout? existingLayout) && existingLayout != null) {
                 return existingLayout;
             }
@@ -15,6 +24,7 @@ namespace OfficeIMO.Word.Pdf {
             int[] rowStartColumns = ResolveRowGridOffsets(table, rows.Count, before: true);
             int[] rowTrailingColumns = ResolveRowGridOffsets(table, rows.Count, before: false);
             int columnCount = ResolveColumnCount(table, rows, rowStartColumns, rowTrailingColumns);
+            EnsureSupportedColumnCount(columnCount);
             float[] widths = new float[columnCount];
             float[] gridWidths = new float[columnCount];
             bool[] explicitCellWidthColumns = new bool[columnCount];
@@ -46,13 +56,11 @@ namespace OfficeIMO.Word.Pdf {
                         hasExplicitCellWidth = true;
                     }
 
-                    if (cell.HasNestedTables) {
-                        foreach (WordTable nested in cell.NestedTables) {
-                            TableLayout nestedLayout = GetLayout(nested);
-                            float nestedWidth = nestedLayout.ColumnWidths.Sum();
-                            if (nestedWidth > width) {
-                                width = nestedWidth;
-                            }
+                    foreach (WordTable nested in cell.DirectNestedTables) {
+                        TableLayout nestedLayout = GetLayout(nested, depth + 1);
+                        float nestedWidth = nestedLayout.ColumnWidths.Sum();
+                        if (nestedWidth > width) {
+                            width = nestedWidth;
                         }
                     }
 
@@ -89,23 +97,27 @@ namespace OfficeIMO.Word.Pdf {
         private static int ResolveColumnCount(WordTable table, List<IReadOnlyList<WordTableCell>> rows, int[] rowStartColumns, int[] rowTrailingColumns) {
             List<int> gridColumnWidths = table.GridColumnWidth;
             if (gridColumnWidths.Count > 0) {
+                EnsureSupportedColumnCount(gridColumnWidths.Count);
                 return gridColumnWidths.Count;
             }
 
             int columnCount = 0;
             for (int rowIndex = 0; rowIndex < rows.Count; rowIndex++) {
                 IReadOnlyList<WordTableCell> row = rows[rowIndex];
-                int rowColumns = rowStartColumns[rowIndex] + rowTrailingColumns[rowIndex];
+                long rowColumns = (long)rowStartColumns[rowIndex] + rowTrailingColumns[rowIndex];
                 foreach (WordTableCell cell in row) {
                     if (cell.HorizontalMerge == MergedCellValues.Continue) {
                         continue;
                     }
 
                     rowColumns += System.Math.Max(1, cell.ColumnSpan);
+                    if (rowColumns > MaxTableGridColumns) {
+                        throw new InvalidDataException($"The table grid exceeds the supported limit of {MaxTableGridColumns} columns.");
+                    }
                 }
 
                 if (rowColumns > columnCount) {
-                    columnCount = rowColumns;
+                    columnCount = (int)rowColumns;
                 }
             }
 
@@ -124,10 +136,20 @@ namespace OfficeIMO.Word.Pdf {
             return offsets;
         }
 
-        private static int ToNonNegativeInt(int? value) =>
-            value.HasValue && value.Value > 0
-                ? value.Value
-                : 0;
+        private static int ToNonNegativeInt(int? value) {
+            if (!value.HasValue || value.Value <= 0) {
+                return 0;
+            }
+
+            EnsureSupportedColumnCount(value.Value);
+            return value.Value;
+        }
+
+        private static void EnsureSupportedColumnCount(int columnCount) {
+            if (columnCount > MaxTableGridColumns) {
+                throw new InvalidDataException($"The table grid exceeds the supported limit of {MaxTableGridColumns} columns.");
+            }
+        }
 
         private static bool IsExplicitDxaCellWidth(WordTableCell cell) =>
             cell.Width.HasValue &&

--- a/OfficeIMO.Word.Pdf/TableLayoutCache.cs
+++ b/OfficeIMO.Word.Pdf/TableLayoutCache.cs
@@ -105,6 +105,7 @@ namespace OfficeIMO.Word.Pdf {
             for (int rowIndex = 0; rowIndex < rows.Count; rowIndex++) {
                 IReadOnlyList<WordTableCell> row = rows[rowIndex];
                 long rowColumns = (long)rowStartColumns[rowIndex] + rowTrailingColumns[rowIndex];
+                EnsureSupportedColumnCount(rowColumns);
                 foreach (WordTableCell cell in row) {
                     if (cell.HorizontalMerge == MergedCellValues.Continue) {
                         continue;
@@ -145,7 +146,7 @@ namespace OfficeIMO.Word.Pdf {
             return value.Value;
         }
 
-        private static void EnsureSupportedColumnCount(int columnCount) {
+        private static void EnsureSupportedColumnCount(long columnCount) {
             if (columnCount > MaxTableGridColumns) {
                 throw new InvalidDataException($"The table grid exceeds the supported limit of {MaxTableGridColumns} columns.");
             }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.FootnotesImages.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.FootnotesImages.cs
@@ -14,7 +14,7 @@ namespace OfficeIMO.Word.Pdf {
         private static List<PdfFootnote> CollectNativeFootnotes(IReadOnlyList<WordElement> elements, Dictionary<long, int> footnoteNumbersById) {
             var footnotes = new List<PdfFootnote>();
             foreach (WordElement element in elements) {
-                CollectNativeFootnotes(element, footnotes, footnoteNumbersById, structuredDocumentTagDepth: 0);
+                CollectNativeFootnotes(element, footnotes, footnoteNumbersById, structuredDocumentTagDepth: 0, tableDepth: 0);
             }
 
             return footnotes;
@@ -24,7 +24,8 @@ namespace OfficeIMO.Word.Pdf {
             WordElement element,
             List<PdfFootnote> footnotes,
             Dictionary<long, int> footnoteNumbersById,
-            int structuredDocumentTagDepth) {
+            int structuredDocumentTagDepth,
+            int tableDepth) {
             switch (element) {
                 case WordFootNote footNote:
                     AddNativeFootnote(footNote, footnotes, footnoteNumbersById);
@@ -57,12 +58,16 @@ namespace OfficeIMO.Word.Pdf {
 
                     break;
                 case WordTable table:
-                    foreach (WordTable currentTable in EnumerateNativeTableTree(table)) {
-                        foreach (WordTableRow row in currentTable.Rows) {
-                            foreach (WordTableCell cell in row.Cells) {
-                                foreach (WordParagraph paragraph in cell.Paragraphs) {
-                                    CollectNativeFootnotes(paragraph, footnotes, footnoteNumbersById, structuredDocumentTagDepth);
-                                }
+                    EnsureNativeTableDepth(tableDepth);
+                    foreach (WordTableRow row in table.Rows) {
+                        foreach (WordTableCell cell in row.Cells) {
+                            foreach (WordElement cellElement in cell.Elements) {
+                                CollectNativeFootnotes(
+                                    cellElement,
+                                    footnotes,
+                                    footnoteNumbersById,
+                                    structuredDocumentTagDepth,
+                                    tableDepth + 1);
                             }
                         }
                     }
@@ -71,14 +76,14 @@ namespace OfficeIMO.Word.Pdf {
                 case WordCoverPage coverPage:
                     EnsureNativeStructuredDocumentTagDepth(structuredDocumentTagDepth);
                     foreach (WordElement coverElement in GetNativeStructuredBlockElements(coverPage.Document, coverPage.SdtBlock)) {
-                        CollectNativeFootnotes(coverElement, footnotes, footnoteNumbersById, structuredDocumentTagDepth + 1);
+                        CollectNativeFootnotes(coverElement, footnotes, footnoteNumbersById, structuredDocumentTagDepth + 1, tableDepth);
                     }
 
                     break;
                 case WordStructuredDocumentTag structuredDocumentTag:
                     EnsureNativeStructuredDocumentTagDepth(structuredDocumentTagDepth);
                     foreach (WordElement structuredElement in GetNativeStructuredBlockElements(structuredDocumentTag.Document, structuredDocumentTag.SdtBlock)) {
-                        CollectNativeFootnotes(structuredElement, footnotes, footnoteNumbersById, structuredDocumentTagDepth + 1);
+                        CollectNativeFootnotes(structuredElement, footnotes, footnoteNumbersById, structuredDocumentTagDepth + 1, tableDepth);
                     }
 
                     break;

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.FootnotesImages.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.FootnotesImages.cs
@@ -57,14 +57,12 @@ namespace OfficeIMO.Word.Pdf {
 
                     break;
                 case WordTable table:
-                    foreach (WordTableRow row in table.Rows) {
-                        foreach (WordTableCell cell in row.Cells) {
-                            foreach (WordParagraph paragraph in cell.Paragraphs) {
-                                CollectNativeFootnotes(paragraph, footnotes, footnoteNumbersById, structuredDocumentTagDepth);
-                            }
-
-                            foreach (WordTable nested in cell.NestedTables) {
-                                CollectNativeFootnotes(nested, footnotes, footnoteNumbersById, structuredDocumentTagDepth);
+                    foreach (WordTable currentTable in EnumerateNativeTableTree(table)) {
+                        foreach (WordTableRow row in currentTable.Rows) {
+                            foreach (WordTableCell cell in row.Cells) {
+                                foreach (WordParagraph paragraph in cell.Paragraphs) {
+                                    CollectNativeFootnotes(paragraph, footnotes, footnoteNumbersById, structuredDocumentTagDepth);
+                                }
                             }
                         }
                     }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.HeaderFooter.Content.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.HeaderFooter.Content.cs
@@ -264,17 +264,13 @@ namespace OfficeIMO.Word.Pdf {
                 yield break;
             }
 
-            foreach (WordTableRow row in table.Rows) {
-                foreach (WordTableCell cell in row.Cells) {
-                    foreach (WordParagraph cellParagraph in cell.Paragraphs) {
-                        foreach (string familyName in EnumerateNativeParagraphFontFamilies(cellParagraph)) {
-                            yield return familyName;
-                        }
-                    }
-
-                    foreach (WordTable nestedTable in cell.NestedTables) {
-                        foreach (string familyName in EnumerateNativeHeaderFooterElementFontFamilies(nestedTable)) {
-                            yield return familyName;
+            foreach (WordTable currentTable in EnumerateNativeTableTree(table)) {
+                foreach (WordTableRow row in currentTable.Rows) {
+                    foreach (WordTableCell cell in row.Cells) {
+                        foreach (WordParagraph cellParagraph in cell.Paragraphs) {
+                            foreach (string familyName in EnumerateNativeParagraphFontFamilies(cellParagraph)) {
+                                yield return familyName;
+                            }
                         }
                     }
                 }
@@ -294,17 +290,13 @@ namespace OfficeIMO.Word.Pdf {
                 yield break;
             }
 
-            foreach (WordTableRow row in table.Rows) {
-                foreach (WordTableCell cell in row.Cells) {
-                    foreach (WordParagraph cellParagraph in cell.Paragraphs) {
-                        foreach (NativeResolvedTextStyle style in EnumerateNativeParagraphTextStyles(cellParagraph)) {
-                            yield return style;
-                        }
-                    }
-
-                    foreach (WordTable nestedTable in cell.NestedTables) {
-                        foreach (NativeResolvedTextStyle style in EnumerateNativeHeaderFooterElementTextStyles(nestedTable)) {
-                            yield return style;
+            foreach (WordTable currentTable in EnumerateNativeTableTree(table)) {
+                foreach (WordTableRow row in currentTable.Rows) {
+                    foreach (WordTableCell cell in row.Cells) {
+                        foreach (WordParagraph cellParagraph in cell.Paragraphs) {
+                            foreach (NativeResolvedTextStyle style in EnumerateNativeParagraphTextStyles(cellParagraph)) {
+                                yield return style;
+                            }
                         }
                     }
                 }
@@ -326,19 +318,15 @@ namespace OfficeIMO.Word.Pdf {
                 yield break;
             }
 
-            foreach (WordTableRow row in table.Rows) {
-                foreach (WordTableCell cell in row.Cells) {
-                    foreach (WordParagraph cellParagraph in cell.Paragraphs) {
-                        foreach (NativeResolvedTextStyle style in EnumerateNativeParagraphTextStyles(cellParagraph)) {
-                            if (style.FontSize.HasValue && style.FontSize.Value > 0D) {
-                                yield return style.FontSize.Value;
+            foreach (WordTable currentTable in EnumerateNativeTableTree(table)) {
+                foreach (WordTableRow row in currentTable.Rows) {
+                    foreach (WordTableCell cell in row.Cells) {
+                        foreach (WordParagraph cellParagraph in cell.Paragraphs) {
+                            foreach (NativeResolvedTextStyle style in EnumerateNativeParagraphTextStyles(cellParagraph)) {
+                                if (style.FontSize.HasValue && style.FontSize.Value > 0D) {
+                                    yield return style.FontSize.Value;
+                                }
                             }
-                        }
-                    }
-
-                    foreach (WordTable nestedTable in cell.NestedTables) {
-                        foreach (double fontSize in EnumerateNativeHeaderFooterElementFontSizes(nestedTable)) {
-                            yield return fontSize;
                         }
                     }
                 }
@@ -358,17 +346,13 @@ namespace OfficeIMO.Word.Pdf {
                 yield break;
             }
 
-            foreach (WordTableRow row in table.Rows) {
-                foreach (WordTableCell cell in row.Cells) {
-                    foreach (WordParagraph cellParagraph in cell.Paragraphs) {
-                        foreach (PdfCore.PdfColor color in EnumerateNativeParagraphColors(cellParagraph)) {
-                            yield return color;
-                        }
-                    }
-
-                    foreach (WordTable nestedTable in cell.NestedTables) {
-                        foreach (PdfCore.PdfColor color in EnumerateNativeHeaderFooterElementColors(nestedTable)) {
-                            yield return color;
+            foreach (WordTable currentTable in EnumerateNativeTableTree(table)) {
+                foreach (WordTableRow row in currentTable.Rows) {
+                    foreach (WordTableCell cell in row.Cells) {
+                        foreach (WordParagraph cellParagraph in cell.Paragraphs) {
+                            foreach (PdfCore.PdfColor color in EnumerateNativeParagraphColors(cellParagraph)) {
+                                yield return color;
+                            }
                         }
                     }
                 }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.OptionsAndToc.cs
@@ -205,26 +205,24 @@ namespace OfficeIMO.Word.Pdf {
         }
 
         private static void RegisterNativeTableFonts(WordTable table, PdfCore.PdfOptions pdfOptions, HashSet<string> registeredFamilies, HashSet<PdfCore.PdfStandardFont> registeredFontSlots, bool allowSystemFontEmbedding, NativeFontMap nativeFontMap) {
-            NativeTableStyleDefaults tableStyleDefaults = GetNativeTableStyleDefaults(
-                table,
-                GetNativeDocumentDefaults(table.Document),
-                ignoreFallbackTableStyle: pdfOptions.HasExplicitDefaultTableStyle);
+            foreach (WordTable currentTable in EnumerateNativeTableTree(table)) {
+                NativeTableStyleDefaults tableStyleDefaults = GetNativeTableStyleDefaults(
+                    currentTable,
+                    GetNativeDocumentDefaults(currentTable.Document),
+                    ignoreFallbackTableStyle: pdfOptions.HasExplicitDefaultTableStyle);
 
-            foreach (WordTableRow row in table.Rows) {
-                foreach (WordTableCell cell in row.Cells) {
-                    foreach (WordParagraph paragraph in cell.Paragraphs) {
-                        RegisterNativeParagraphContentFonts(
-                            paragraph,
-                            tableStyleDefaults.RunStyle,
-                            pdfOptions,
-                            registeredFamilies,
-                            registeredFontSlots,
-                            allowSystemFontEmbedding,
-                            nativeFontMap);
-                    }
-
-                    foreach (WordTable nestedTable in cell.NestedTables) {
-                        RegisterNativeTableFonts(nestedTable, pdfOptions, registeredFamilies, registeredFontSlots, allowSystemFontEmbedding, nativeFontMap);
+                foreach (WordTableRow row in currentTable.Rows) {
+                    foreach (WordTableCell cell in row.Cells) {
+                        foreach (WordParagraph paragraph in cell.Paragraphs) {
+                            RegisterNativeParagraphContentFonts(
+                                paragraph,
+                                tableStyleDefaults.RunStyle,
+                                pdfOptions,
+                                registeredFamilies,
+                                registeredFontSlots,
+                                allowSystemFontEmbedding,
+                                nativeFontMap);
+                        }
                     }
                 }
             }

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.ParagraphStyleDefaults.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.ParagraphStyleDefaults.cs
@@ -4,6 +4,7 @@ using W = DocumentFormat.OpenXml.Wordprocessing;
 
 namespace OfficeIMO.Word.Pdf {
     public static partial class WordPdfConverterExtensions {
+        private const int MaxNativeParagraphTabStops = 1_024;
         private readonly record struct NativeParagraphStyleDefaults(
             double? FontSize,
             string? FontFamily,
@@ -288,36 +289,54 @@ namespace OfficeIMO.Word.Pdf {
         }
 
         private static IReadOnlyList<WordTabStop> GetNativeParagraphEffectiveTabStops(WordParagraph paragraph) {
-            IReadOnlyList<WordTabStop> directTabStops = paragraph.TabStops;
-            if (directTabStops.Count > 0) {
-                return directTabStops;
+            W.Tabs? directTabs = paragraph._paragraphProperties?.Tabs;
+            if (directTabs != null) {
+                WordTabStop[] directTabStops = directTabs.Elements<W.TabStop>()
+                    .Take(MaxNativeParagraphTabStops)
+                    .Select(tabStop => new WordTabStop(paragraph, tabStop))
+                    .ToArray();
+                if (directTabStops.Length > 0) {
+                    return directTabStops;
+                }
             }
 
-            List<WordTabStop>? styleTabStops = null;
-            foreach (W.Style style in GetNativeParagraphStyleChain(paragraph._document, paragraph.StyleId)) {
+            var styleTabStops = new Dictionary<int, WordTabStop>();
+            int inspectedStyleTabStops = 0;
+            foreach (W.Style style in GetNativeParagraphStyleChain(paragraph._document, paragraph.StyleId).Reverse()) {
                 W.Tabs? tabs = style.GetFirstChild<W.StyleParagraphProperties>()?.GetFirstChild<W.Tabs>();
                 if (tabs == null) {
                     continue;
                 }
 
                 foreach (W.TabStop tabStop in tabs.Elements<W.TabStop>()) {
+                    if (inspectedStyleTabStops >= MaxNativeParagraphTabStops) {
+                        break;
+                    }
+
+                    inspectedStyleTabStops++;
                     WordTabStop wordTabStop = new WordTabStop(paragraph, (W.TabStop)tabStop.CloneNode(true));
                     if (wordTabStop.Position <= 0 || !IsNativeRenderableTextTabStop(wordTabStop.Alignment)) {
                         continue;
                     }
 
-                    styleTabStops ??= new List<WordTabStop>();
-                    styleTabStops.RemoveAll(existing => existing.Position == wordTabStop.Position);
-                    styleTabStops.Add(wordTabStop);
+                    if (!styleTabStops.ContainsKey(wordTabStop.Position)) {
+                        styleTabStops.Add(wordTabStop.Position, wordTabStop);
+                    }
+                    if (styleTabStops.Count >= MaxNativeParagraphTabStops) {
+                        break;
+                    }
+                }
+
+                if (inspectedStyleTabStops >= MaxNativeParagraphTabStops) {
+                    break;
                 }
             }
 
-            if (styleTabStops == null || styleTabStops.Count == 0) {
+            if (styleTabStops.Count == 0) {
                 return Array.Empty<WordTabStop>();
             }
 
-            styleTabStops.Sort((left, right) => left.Position.CompareTo(right.Position));
-            return styleTabStops;
+            return styleTabStops.Values.OrderBy(tabStop => tabStop.Position).ToArray();
         }
 
         private static bool IsNativeParagraphStyle(W.Style style) {

--- a/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.StructuredBlocks.cs
+++ b/OfficeIMO.Word.Pdf/WordPdfConverterExtensions.Native.StructuredBlocks.cs
@@ -7,6 +7,7 @@ using PdfCore = OfficeIMO.Pdf;
 namespace OfficeIMO.Word.Pdf {
     public static partial class WordPdfConverterExtensions {
         private const int MaximumNativeStructuredDocumentTagDepth = 128;
+        private const int MaximumNativeTableNestingDepth = 128;
 
         [ThreadStatic]
         private static int _nativeStructuredDocumentTagDepth;
@@ -86,6 +87,34 @@ namespace OfficeIMO.Word.Pdf {
             }
 
             return elements;
+        }
+
+        private static IEnumerable<WordTable> EnumerateNativeTableTree(WordTable root) {
+            var pending = new Stack<(WordTable Table, int Depth)>();
+            pending.Push((root, 0));
+            while (pending.Count > 0) {
+                (WordTable table, int depth) = pending.Pop();
+                EnsureNativeTableDepth(depth);
+                yield return table;
+
+                List<WordTableRow> rows = table.Rows;
+                for (int rowIndex = rows.Count - 1; rowIndex >= 0; rowIndex--) {
+                    List<WordTableCell> cells = rows[rowIndex].Cells;
+                    for (int cellIndex = cells.Count - 1; cellIndex >= 0; cellIndex--) {
+                        List<WordTable> nestedTables = cells[cellIndex].DirectNestedTables;
+                        for (int nestedIndex = nestedTables.Count - 1; nestedIndex >= 0; nestedIndex--) {
+                            pending.Push((nestedTables[nestedIndex], depth + 1));
+                        }
+                    }
+                }
+            }
+        }
+
+        private static void EnsureNativeTableDepth(int depth) {
+            if (depth >= MaximumNativeTableNestingDepth) {
+                throw new InvalidDataException(
+                    $"Table nesting exceeds the supported limit of {MaximumNativeTableNestingDepth} levels.");
+            }
         }
 
         private static IReadOnlyList<int> GetNativeStructuredBlockFootnoteNumbersForElement(IReadOnlyList<WordElement> elements, int index, Dictionary<long, int> footnoteNumbersById) {

--- a/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.Footnotes.cs
+++ b/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.Footnotes.cs
@@ -107,5 +107,33 @@ namespace OfficeIMO.Tests {
                 Assert.DoesNotContain("Second section note1", allText);
             }
         }
+
+        [Fact]
+        public void SaveAsPdf_OfficeIMOEngine_Numbers_Nested_Table_Footnotes_In_Document_Order() {
+            string docPath = Path.Combine(_directoryWithFiles, "PdfNativeNestedTableFootnotes.docx");
+            string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeNestedTableFootnotes.pdf");
+
+            using (WordDocument document = WordDocument.Create(docPath)) {
+                WordTable outer = document.AddTable(1, 2);
+                WordTable nested = outer.Rows[0].Cells[0].AddTable(1, 1);
+                nested.Rows[0].Cells[0].Paragraphs[0]
+                    .SetText("Nested table note")
+                    .AddFootNote("Nested table footnote");
+                outer.Rows[0].Cells[1].Paragraphs[0]
+                    .SetText("Later outer note")
+                    .AddFootNote("Later outer footnote");
+                document.Save();
+                document.SaveAsPdf(pdfPath, new PdfSaveOptions { IncludePageNumbers = false });
+            }
+
+            using (var pdf = PdfPigDocument.Open(pdfPath)) {
+                string allText = string.Concat(pdf.GetPages().Select(page => page.Text));
+                string normalizedText = Regex.Replace(allText, @"\s+", " ");
+                Assert.Contains("Later outer note2", allText);
+                Assert.Contains("1 Nested table footnote", normalizedText);
+                Assert.Contains("2 Later outer footnote", normalizedText);
+                Assert.DoesNotContain("Later outer note1", allText);
+            }
+        }
     }
 }

--- a/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.TablePlacementWidth.cs
+++ b/OfficeIMO.Word.Tests/Pdf/Word.SaveAsPdf.TablePlacementWidth.cs
@@ -14,6 +14,29 @@ namespace OfficeIMO.Tests;
 
 public partial class Word {
     [Fact]
+    public void TableLayoutCache_AccountsForNestedTablesInsideCellContentControls() {
+        string docPath = Path.Combine(_directoryWithFiles, "PdfNativeNestedTableContentControlWidth.docx");
+        using WordDocument document = WordDocument.Create(docPath);
+        WordTable outer = document.AddTable(1, 1);
+        WordTableCell cell = outer.Rows[0].Cells[0];
+        WordTable nested = cell.AddTable(1, 2);
+        foreach (WordTableCell nestedCell in nested.Rows[0].Cells) {
+            nestedCell.Width = 2880;
+            nestedCell.WidthType = TableWidthUnitValues.Dxa;
+        }
+
+        nested._table.Remove();
+        cell._tableCell.Append(new SdtBlock(
+            new SdtProperties(new SdtAlias { Val = "Nested table host" }),
+            new SdtContentBlock(nested._table)));
+
+        OfficeIMO.Word.Pdf.TableLayout layout = TableLayoutCache.GetLayout(outer);
+
+        Assert.Single(cell.DirectNestedTables);
+        Assert.True(Assert.Single(layout.ColumnWidths) >= 288F);
+    }
+
+    [Fact]
     public void SaveAsPdf_OfficeIMOEngine_Renders_Table_Placement() {
         string docPath = Path.Combine(_directoryWithFiles, "PdfNativeTablePlacement.docx");
         string pdfPath = Path.Combine(_directoryWithFiles, "PdfNativeTablePlacement.pdf");

--- a/OfficeIMO.Word.Tests/Word.CompareDocuments.StructuredRegression.cs
+++ b/OfficeIMO.Word.Tests/Word.CompareDocuments.StructuredRegression.cs
@@ -366,6 +366,45 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void CompareStructureAlignsModifiedTableRowInMiddleOfLargeInsertionRange() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "compare_structure_source_large_inserted_row_range.docx");
+            using (WordDocument doc = WordDocument.Create(sourcePath)) {
+                WordTable table = doc.AddTable(2, 1);
+                table.Rows[0].Cells[0].Paragraphs[0].SetText("Status: Pending");
+                table.Rows[1].Cells[0].Paragraphs[0].SetText("Closing");
+                doc.Save();
+            }
+
+            string targetPath = Path.Combine(_directoryWithFiles, "compare_structure_target_large_inserted_row_range.docx");
+            using (WordDocument doc = WordDocument.Create(targetPath)) {
+                WordTable table = doc.AddTable(602, 1);
+                for (int index = 0; index < 300; index++) {
+                    table.Rows[index].Cells[0].Paragraphs[0].SetText("Evidence before " + index);
+                }
+
+                table.Rows[300].Cells[0].Paragraphs[0].SetText("Status: Approved");
+                for (int index = 0; index < 300; index++) {
+                    table.Rows[index + 301].Cells[0].Paragraphs[0].SetText("Evidence after " + index);
+                }
+
+                table.Rows[601].Cells[0].Paragraphs[0].SetText("Closing");
+                doc.Save();
+            }
+
+            WordComparisonResult result = WordDocumentComparer.CompareStructure(sourcePath, targetPath);
+
+            Assert.Equal(600, result.Findings.Count(finding =>
+                finding.Scope == WordComparisonScope.TableRow &&
+                finding.ChangeKind == WordComparisonChangeKind.Inserted &&
+                finding.TargetText?.StartsWith("Evidence ", StringComparison.Ordinal) == true));
+            Assert.Contains(result.Findings, finding =>
+                finding.Scope == WordComparisonScope.TableCell &&
+                finding.ChangeKind == WordComparisonChangeKind.Modified &&
+                finding.SourceText == "Status: Pending" &&
+                finding.TargetText == "Status: Approved");
+        }
+
+        [Fact]
         public void CompareStructureReportsFootnoteAndEndnoteBodyChanges() {
             string sourcePath = Path.Combine(_directoryWithFiles, "compare_structure_source_notes.docx");
             using (WordDocument doc = WordDocument.Create(sourcePath)) {

--- a/OfficeIMO.Word.Tests/Word.CompareDocuments.StructuredReviewRegression.cs
+++ b/OfficeIMO.Word.Tests/Word.CompareDocuments.StructuredReviewRegression.cs
@@ -323,6 +323,44 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void CompareStructureAlignsModifiedParagraphBeyondBoundedInsertionWindow() {
+            string sourcePath = Path.Combine(_directoryWithFiles, "compare_structure_source_large_inserted_paragraph_range.docx");
+            using (WordDocument doc = WordDocument.Create(sourcePath)) {
+                doc.AddParagraph("Status: Pending");
+                doc.AddParagraph("Closing");
+                doc.Save();
+            }
+
+            string targetPath = Path.Combine(_directoryWithFiles, "compare_structure_target_large_inserted_paragraph_range.docx");
+            using (WordDocument doc = WordDocument.Create(targetPath)) {
+                for (int index = 0; index < 300; index++) {
+                    doc.AddParagraph("Evidence row " + index);
+                }
+
+                doc.AddParagraph("Status: Approved");
+                doc.AddParagraph("Closing");
+                doc.Save();
+            }
+
+            WordComparisonResult result = WordDocumentComparer.CompareStructure(sourcePath, targetPath);
+
+            Assert.Equal(300, result.Findings.Count(finding =>
+                finding.Scope == WordComparisonScope.Paragraph &&
+                finding.ChangeKind == WordComparisonChangeKind.Inserted &&
+                finding.TargetText?.StartsWith("Evidence row ", StringComparison.Ordinal) == true));
+            Assert.Contains(result.Findings, finding =>
+                finding.Scope == WordComparisonScope.Paragraph &&
+                finding.ChangeKind == WordComparisonChangeKind.Modified &&
+                finding.SourceText == "Status: Pending" &&
+                finding.TargetText == "Status: Approved");
+            Assert.DoesNotContain(result.Findings, finding =>
+                finding.Scope == WordComparisonScope.Paragraph &&
+                finding.ChangeKind == WordComparisonChangeKind.Modified &&
+                finding.SourceText == "Status: Pending" &&
+                finding.TargetText?.StartsWith("Evidence row ", StringComparison.Ordinal) == true);
+        }
+
+        [Fact]
         public void CompareStructureReadsExplicitNormalFootnotes() {
             string sourcePath = Path.Combine(_directoryWithFiles, "compare_structure_source_explicit_normal_footnote.docx");
             using (WordDocument doc = WordDocument.Create(sourcePath)) {

--- a/OfficeIMO.Word.Tests/Word.CompareDocuments.StructuredReviewRegression.cs
+++ b/OfficeIMO.Word.Tests/Word.CompareDocuments.StructuredReviewRegression.cs
@@ -323,7 +323,7 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
-        public void CompareStructureAlignsModifiedParagraphBeyondBoundedInsertionWindow() {
+        public void CompareStructureAlignsModifiedParagraphInMiddleOfLargeInsertionRange() {
             string sourcePath = Path.Combine(_directoryWithFiles, "compare_structure_source_large_inserted_paragraph_range.docx");
             using (WordDocument doc = WordDocument.Create(sourcePath)) {
                 doc.AddParagraph("Status: Pending");
@@ -334,20 +334,24 @@ namespace OfficeIMO.Tests {
             string targetPath = Path.Combine(_directoryWithFiles, "compare_structure_target_large_inserted_paragraph_range.docx");
             using (WordDocument doc = WordDocument.Create(targetPath)) {
                 for (int index = 0; index < 300; index++) {
-                    doc.AddParagraph("Evidence row " + index);
+                    doc.AddParagraph("Evidence before " + index);
                 }
 
                 doc.AddParagraph("Status: Approved");
+                for (int index = 0; index < 300; index++) {
+                    doc.AddParagraph("Evidence after " + index);
+                }
+
                 doc.AddParagraph("Closing");
                 doc.Save();
             }
 
             WordComparisonResult result = WordDocumentComparer.CompareStructure(sourcePath, targetPath);
 
-            Assert.Equal(300, result.Findings.Count(finding =>
+            Assert.Equal(600, result.Findings.Count(finding =>
                 finding.Scope == WordComparisonScope.Paragraph &&
                 finding.ChangeKind == WordComparisonChangeKind.Inserted &&
-                finding.TargetText?.StartsWith("Evidence row ", StringComparison.Ordinal) == true));
+                finding.TargetText?.StartsWith("Evidence ", StringComparison.Ordinal) == true));
             Assert.Contains(result.Findings, finding =>
                 finding.Scope == WordComparisonScope.Paragraph &&
                 finding.ChangeKind == WordComparisonChangeKind.Modified &&
@@ -357,7 +361,7 @@ namespace OfficeIMO.Tests {
                 finding.Scope == WordComparisonScope.Paragraph &&
                 finding.ChangeKind == WordComparisonChangeKind.Modified &&
                 finding.SourceText == "Status: Pending" &&
-                finding.TargetText?.StartsWith("Evidence row ", StringComparison.Ordinal) == true);
+                finding.TargetText?.StartsWith("Evidence ", StringComparison.Ordinal) == true);
         }
 
         [Fact]

--- a/OfficeIMO.Word.Tests/Word.CompareDocuments.StructuredReviewRegression.cs
+++ b/OfficeIMO.Word.Tests/Word.CompareDocuments.StructuredReviewRegression.cs
@@ -402,6 +402,43 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void CompareStructureRetainsModifiedParagraphWithShiftedInternalMatch() {
+            string sharedMiddle = string.Concat(Enumerable.Range(0, 512).Select(index => index % 2 == 0 ? 'x' : 'y'));
+            string sourceText = "A" + sharedMiddle + "ZXCVBNMASD";
+            string targetText = "B12345" + sharedMiddle + "QWERT";
+            string sourcePath = Path.Combine(_directoryWithFiles, "compare_structure_source_shifted_internal_alignment.docx");
+            using (WordDocument doc = WordDocument.Create(sourcePath)) {
+                doc.AddParagraph(sourceText);
+                doc.AddParagraph("Closing");
+                doc.Save();
+            }
+
+            string targetPath = Path.Combine(_directoryWithFiles, "compare_structure_target_shifted_internal_alignment.docx");
+            using (WordDocument doc = WordDocument.Create(targetPath)) {
+                for (int index = 0; index < 260; index++) {
+                    doc.AddParagraph("A inserted candidate " + index);
+                }
+
+                doc.AddParagraph(targetText);
+                doc.AddParagraph("Closing");
+                doc.Save();
+            }
+
+            WordComparisonResult result = WordDocumentComparer.CompareStructure(sourcePath, targetPath);
+
+            Assert.Contains(result.Findings, finding =>
+                finding.Scope == WordComparisonScope.Paragraph &&
+                finding.ChangeKind == WordComparisonChangeKind.Modified &&
+                finding.SourceText == sourceText &&
+                finding.TargetText == targetText);
+            Assert.DoesNotContain(result.Findings, finding =>
+                finding.Scope == WordComparisonScope.Paragraph &&
+                finding.ChangeKind == WordComparisonChangeKind.Modified &&
+                finding.SourceText == sourceText &&
+                finding.TargetText?.StartsWith("A inserted candidate ", StringComparison.Ordinal) == true);
+        }
+
+        [Fact]
         public void CompareStructureReadsExplicitNormalFootnotes() {
             string sourcePath = Path.Combine(_directoryWithFiles, "compare_structure_source_explicit_normal_footnote.docx");
             using (WordDocument doc = WordDocument.Create(sourcePath)) {

--- a/OfficeIMO.Word.Tests/Word.CompareDocuments.StructuredReviewRegression.cs
+++ b/OfficeIMO.Word.Tests/Word.CompareDocuments.StructuredReviewRegression.cs
@@ -365,6 +365,43 @@ namespace OfficeIMO.Tests {
         }
 
         [Fact]
+        public void CompareStructureRetainsModifiedParagraphWithStrongInternalMatch() {
+            string sharedMiddle = string.Concat(Enumerable.Repeat("shared middle content ", 12));
+            string sourceText = "A source start " + sharedMiddle + " source end";
+            string targetText = "B target start " + sharedMiddle + " target end";
+            string sourcePath = Path.Combine(_directoryWithFiles, "compare_structure_source_internal_alignment.docx");
+            using (WordDocument doc = WordDocument.Create(sourcePath)) {
+                doc.AddParagraph(sourceText);
+                doc.AddParagraph("Closing");
+                doc.Save();
+            }
+
+            string targetPath = Path.Combine(_directoryWithFiles, "compare_structure_target_internal_alignment.docx");
+            using (WordDocument doc = WordDocument.Create(targetPath)) {
+                for (int index = 0; index < 260; index++) {
+                    doc.AddParagraph("A inserted candidate " + index);
+                }
+
+                doc.AddParagraph(targetText);
+                doc.AddParagraph("Closing");
+                doc.Save();
+            }
+
+            WordComparisonResult result = WordDocumentComparer.CompareStructure(sourcePath, targetPath);
+
+            Assert.Contains(result.Findings, finding =>
+                finding.Scope == WordComparisonScope.Paragraph &&
+                finding.ChangeKind == WordComparisonChangeKind.Modified &&
+                finding.SourceText == sourceText &&
+                finding.TargetText == targetText);
+            Assert.DoesNotContain(result.Findings, finding =>
+                finding.Scope == WordComparisonScope.Paragraph &&
+                finding.ChangeKind == WordComparisonChangeKind.Modified &&
+                finding.SourceText == sourceText &&
+                finding.TargetText?.StartsWith("A inserted candidate ", StringComparison.Ordinal) == true);
+        }
+
+        [Fact]
         public void CompareStructureReadsExplicitNormalFootnotes() {
             string sourcePath = Path.Combine(_directoryWithFiles, "compare_structure_source_explicit_normal_footnote.docx");
             using (WordDocument doc = WordDocument.Create(sourcePath)) {

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.Paragraphs.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.Paragraphs.cs
@@ -796,7 +796,24 @@ namespace OfficeIMO.Word {
                 targetSuffixIndex--;
             }
 
-            return (double)(prefixLength + suffixLength) / Math.Max(source.Length, target.Length);
+            double edgeSimilarity = (double)(prefixLength + suffixLength) / Math.Max(source.Length, target.Length);
+            int sampleCount = Math.Min(MaxBoundedTextSimilaritySamples, Math.Min(source.Length, target.Length));
+            if (sampleCount <= 1) {
+                return edgeSimilarity;
+            }
+
+            int matchingSamples = 0;
+            for (int sample = 0; sample < sampleCount; sample++) {
+                int sourceIndex = (int)((long)sample * (source.Length - 1) / (sampleCount - 1));
+                int targetIndex = (int)((long)sample * (target.Length - 1) / (sampleCount - 1));
+                if (source[sourceIndex] == target[targetIndex]) {
+                    matchingSamples++;
+                }
+            }
+
+            double lengthRatio = (double)Math.Min(source.Length, target.Length) / Math.Max(source.Length, target.Length);
+            double sampledSimilarity = (double)matchingSamples / sampleCount * lengthRatio;
+            return Math.Max(edgeSimilarity, sampledSimilarity);
         }
 
         private static int GetCommonSubsequenceLength(string source, string target) {

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.Paragraphs.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.Paragraphs.cs
@@ -217,7 +217,8 @@ namespace OfficeIMO.Word {
             double bestVisibleSimilarity = currentVisibleSimilarity;
             double bestSimilarity = GetParagraphSimilarity(sourceParagraph, targetParagraphs[targetStart]);
 
-            for (int index = targetStart + 1; index < targetEnd; index++) {
+            int boundedTargetEnd = Math.Min(targetEnd, targetStart + MaxComparisonAlignmentWindow);
+            for (int index = targetStart + 1; index < boundedTargetEnd; index++) {
                 double visibleSimilarity = GetParagraphVisibleTextSimilarity(sourceParagraph, targetParagraphs[index]);
                 double similarity = GetParagraphSimilarity(sourceParagraph, targetParagraphs[index]);
                 if (visibleSimilarity < bestVisibleSimilarity ||
@@ -244,7 +245,8 @@ namespace OfficeIMO.Word {
             double bestVisibleSimilarity = currentVisibleSimilarity;
             double bestSimilarity = GetParagraphSimilarity(sourceParagraphs[sourceStart], targetParagraph);
 
-            for (int index = sourceStart + 1; index < sourceEnd; index++) {
+            int boundedSourceEnd = Math.Min(sourceEnd, sourceStart + MaxComparisonAlignmentWindow);
+            for (int index = sourceStart + 1; index < boundedSourceEnd; index++) {
                 double visibleSimilarity = GetParagraphVisibleTextSimilarity(sourceParagraphs[index], targetParagraph);
                 double similarity = GetParagraphSimilarity(sourceParagraphs[index], targetParagraph);
                 if (visibleSimilarity < bestVisibleSimilarity ||

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.Paragraphs.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.Paragraphs.cs
@@ -217,8 +217,10 @@ namespace OfficeIMO.Word {
             double bestVisibleSimilarity = currentVisibleSimilarity;
             double bestSimilarity = GetParagraphSimilarity(sourceParagraph, targetParagraphs[targetStart]);
 
-            int boundedTargetEnd = Math.Min(targetEnd, targetStart + MaxComparisonAlignmentWindow);
-            for (int index = targetStart + 1; index < boundedTargetEnd; index++) {
+            foreach (int index in SelectBoundedAlignmentCandidates(
+                targetStart + 1,
+                targetEnd,
+                index => GetParagraphAlignmentPrefilterSimilarity(sourceParagraph, targetParagraphs[index]))) {
                 double visibleSimilarity = GetParagraphVisibleTextSimilarity(sourceParagraph, targetParagraphs[index]);
                 double similarity = GetParagraphSimilarity(sourceParagraph, targetParagraphs[index]);
                 if (visibleSimilarity < bestVisibleSimilarity ||
@@ -232,20 +234,6 @@ namespace OfficeIMO.Word {
                 if (similarity >= 1) {
                     break;
                 }
-            }
-
-            int trailingTargetStart = Math.Max(boundedTargetEnd, targetEnd - MaxComparisonAlignmentWindow);
-            for (int index = trailingTargetStart; index < targetEnd && bestSimilarity < 1; index++) {
-                double visibleSimilarity = GetParagraphVisibleTextSimilarity(sourceParagraph, targetParagraphs[index]);
-                double similarity = GetParagraphSimilarity(sourceParagraph, targetParagraphs[index]);
-                if (visibleSimilarity < bestVisibleSimilarity ||
-                    (visibleSimilarity == bestVisibleSimilarity && similarity <= bestSimilarity)) {
-                    continue;
-                }
-
-                bestVisibleSimilarity = visibleSimilarity;
-                bestSimilarity = similarity;
-                bestIndex = index;
             }
 
             return bestVisibleSimilarity > currentVisibleSimilarity || bestSimilarity > GetParagraphSimilarity(sourceParagraph, targetParagraphs[targetStart])
@@ -259,8 +247,10 @@ namespace OfficeIMO.Word {
             double bestVisibleSimilarity = currentVisibleSimilarity;
             double bestSimilarity = GetParagraphSimilarity(sourceParagraphs[sourceStart], targetParagraph);
 
-            int boundedSourceEnd = Math.Min(sourceEnd, sourceStart + MaxComparisonAlignmentWindow);
-            for (int index = sourceStart + 1; index < boundedSourceEnd; index++) {
+            foreach (int index in SelectBoundedAlignmentCandidates(
+                sourceStart + 1,
+                sourceEnd,
+                index => GetParagraphAlignmentPrefilterSimilarity(sourceParagraphs[index], targetParagraph))) {
                 double visibleSimilarity = GetParagraphVisibleTextSimilarity(sourceParagraphs[index], targetParagraph);
                 double similarity = GetParagraphSimilarity(sourceParagraphs[index], targetParagraph);
                 if (visibleSimilarity < bestVisibleSimilarity ||
@@ -274,20 +264,6 @@ namespace OfficeIMO.Word {
                 if (similarity >= 1) {
                     break;
                 }
-            }
-
-            int trailingSourceStart = Math.Max(boundedSourceEnd, sourceEnd - MaxComparisonAlignmentWindow);
-            for (int index = trailingSourceStart; index < sourceEnd && bestSimilarity < 1; index++) {
-                double visibleSimilarity = GetParagraphVisibleTextSimilarity(sourceParagraphs[index], targetParagraph);
-                double similarity = GetParagraphSimilarity(sourceParagraphs[index], targetParagraph);
-                if (visibleSimilarity < bestVisibleSimilarity ||
-                    (visibleSimilarity == bestVisibleSimilarity && similarity <= bestSimilarity)) {
-                    continue;
-                }
-
-                bestVisibleSimilarity = visibleSimilarity;
-                bestSimilarity = similarity;
-                bestIndex = index;
             }
 
             return bestVisibleSimilarity > currentVisibleSimilarity || bestSimilarity > GetParagraphSimilarity(sourceParagraphs[sourceStart], targetParagraph)
@@ -303,6 +279,52 @@ namespace OfficeIMO.Word {
             return Math.Max(
                 GetTextSimilarity(sourceParagraph.MatchText, targetParagraph.MatchText),
                 GetTextSimilarity(sourceParagraph.ComparisonText, targetParagraph.ComparisonText));
+        }
+
+        private static double GetParagraphAlignmentPrefilterSimilarity(ParagraphSnapshot sourceParagraph, ParagraphSnapshot targetParagraph) {
+            if (!string.Equals(sourceParagraph.PartKind, targetParagraph.PartKind, StringComparison.Ordinal)) {
+                return 0;
+            }
+
+            return Math.Max(
+                GetBoundedTextSimilarity(sourceParagraph.MatchText, targetParagraph.MatchText),
+                GetBoundedTextSimilarity(sourceParagraph.ComparisonText, targetParagraph.ComparisonText));
+        }
+
+        private static IReadOnlyList<int> SelectBoundedAlignmentCandidates(int start, int end, Func<int, double> getPrefilterSimilarity) {
+            var candidates = new SortedSet<AlignmentCandidate>(AlignmentCandidateComparer.Instance);
+            for (int index = start; index < end; index++) {
+                var candidate = new AlignmentCandidate(index, getPrefilterSimilarity(index));
+                candidates.Add(candidate);
+                if (candidates.Count > MaxComparisonAlignmentWindow) {
+                    candidates.Remove(candidates.Min);
+                }
+            }
+
+            return candidates
+                .OrderByDescending(candidate => candidate.Similarity)
+                .ThenBy(candidate => candidate.Index)
+                .Select(candidate => candidate.Index)
+                .ToArray();
+        }
+
+        private readonly struct AlignmentCandidate {
+            internal AlignmentCandidate(int index, double similarity) {
+                Index = index;
+                Similarity = similarity;
+            }
+
+            internal int Index { get; }
+            internal double Similarity { get; }
+        }
+
+        private sealed class AlignmentCandidateComparer : IComparer<AlignmentCandidate> {
+            internal static readonly AlignmentCandidateComparer Instance = new AlignmentCandidateComparer();
+
+            public int Compare(AlignmentCandidate x, AlignmentCandidate y) {
+                int similarity = x.Similarity.CompareTo(y.Similarity);
+                return similarity != 0 ? similarity : y.Index.CompareTo(x.Index);
+            }
         }
 
         private static double GetParagraphVisibleTextSimilarity(ParagraphSnapshot sourceParagraph, ParagraphSnapshot targetParagraph) {

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.Paragraphs.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.Paragraphs.cs
@@ -234,6 +234,20 @@ namespace OfficeIMO.Word {
                 }
             }
 
+            int trailingTargetStart = Math.Max(boundedTargetEnd, targetEnd - MaxComparisonAlignmentWindow);
+            for (int index = trailingTargetStart; index < targetEnd && bestSimilarity < 1; index++) {
+                double visibleSimilarity = GetParagraphVisibleTextSimilarity(sourceParagraph, targetParagraphs[index]);
+                double similarity = GetParagraphSimilarity(sourceParagraph, targetParagraphs[index]);
+                if (visibleSimilarity < bestVisibleSimilarity ||
+                    (visibleSimilarity == bestVisibleSimilarity && similarity <= bestSimilarity)) {
+                    continue;
+                }
+
+                bestVisibleSimilarity = visibleSimilarity;
+                bestSimilarity = similarity;
+                bestIndex = index;
+            }
+
             return bestVisibleSimilarity > currentVisibleSimilarity || bestSimilarity > GetParagraphSimilarity(sourceParagraph, targetParagraphs[targetStart])
                 ? bestIndex
                 : targetStart;
@@ -260,6 +274,20 @@ namespace OfficeIMO.Word {
                 if (similarity >= 1) {
                     break;
                 }
+            }
+
+            int trailingSourceStart = Math.Max(boundedSourceEnd, sourceEnd - MaxComparisonAlignmentWindow);
+            for (int index = trailingSourceStart; index < sourceEnd && bestSimilarity < 1; index++) {
+                double visibleSimilarity = GetParagraphVisibleTextSimilarity(sourceParagraphs[index], targetParagraph);
+                double similarity = GetParagraphSimilarity(sourceParagraphs[index], targetParagraph);
+                if (visibleSimilarity < bestVisibleSimilarity ||
+                    (visibleSimilarity == bestVisibleSimilarity && similarity <= bestSimilarity)) {
+                    continue;
+                }
+
+                bestVisibleSimilarity = visibleSimilarity;
+                bestSimilarity = similarity;
+                bestIndex = index;
             }
 
             return bestVisibleSimilarity > currentVisibleSimilarity || bestSimilarity > GetParagraphSimilarity(sourceParagraphs[sourceStart], targetParagraph)

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.Paragraphs.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.Paragraphs.cs
@@ -813,7 +813,30 @@ namespace OfficeIMO.Word {
 
             double lengthRatio = (double)Math.Min(source.Length, target.Length) / Math.Max(source.Length, target.Length);
             double sampledSimilarity = (double)matchingSamples / sampleCount * lengthRatio;
-            return Math.Max(edgeSimilarity, sampledSimilarity);
+            double anchorSimilarity = GetBoundedAnchorTextSimilarity(source, target, lengthRatio);
+            return Math.Max(edgeSimilarity, Math.Max(sampledSimilarity, anchorSimilarity));
+        }
+
+        private static double GetBoundedAnchorTextSimilarity(string source, string target, double lengthRatio) {
+            string anchors = source.Length <= target.Length ? source : target;
+            string searchable = source.Length <= target.Length ? target : source;
+            if (anchors.Length == 0) return 0D;
+
+            int anchorLength = Math.Min(BoundedTextSimilarityAnchorLength, anchors.Length);
+            int maximumStart = anchors.Length - anchorLength;
+            int sampleCount = Math.Min(MaxBoundedTextSimilarityAnchors, maximumStart + 1);
+            int matchingAnchors = 0;
+            for (int sample = 0; sample < sampleCount; sample++) {
+                int start = sampleCount == 1
+                    ? 0
+                    : (int)((long)sample * maximumStart / (sampleCount - 1));
+                string anchor = anchors.Substring(start, anchorLength);
+                if (searchable.IndexOf(anchor, StringComparison.Ordinal) >= 0) {
+                    matchingAnchors++;
+                }
+            }
+
+            return (double)matchingAnchors / sampleCount * lengthRatio;
         }
 
         private static int GetCommonSubsequenceLength(string source, string target) {

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.cs
@@ -9,6 +9,7 @@ using V = DocumentFormat.OpenXml.Vml;
 namespace OfficeIMO.Word {
     public static partial class WordDocumentComparer {
         private const int LcsCellLimit = 1_000_000;
+        private const int MaxComparisonAlignmentWindow = 256;
         private const int BodyPartOrderBase = 0;
         private const int HeaderPartOrderBase = 1_000_000;
         private const int FooterPartOrderBase = 2_000_000;
@@ -297,7 +298,8 @@ namespace OfficeIMO.Word {
             int bestIndex = targetStart;
             double bestSimilarity = currentSimilarity;
 
-            for (int index = targetStart + 1; index < targetEnd; index++) {
+            int boundedTargetEnd = Math.Min(targetEnd, targetStart + MaxComparisonAlignmentWindow);
+            for (int index = targetStart + 1; index < boundedTargetEnd; index++) {
                 double similarity = GetRowSimilarity(sourceRow, targetRows[index], options);
                 if (similarity > bestSimilarity) {
                     bestSimilarity = similarity;
@@ -318,7 +320,8 @@ namespace OfficeIMO.Word {
             int bestIndex = sourceStart;
             double bestSimilarity = currentSimilarity;
 
-            for (int index = sourceStart + 1; index < sourceEnd; index++) {
+            int boundedSourceEnd = Math.Min(sourceEnd, sourceStart + MaxComparisonAlignmentWindow);
+            for (int index = sourceStart + 1; index < boundedSourceEnd; index++) {
                 double similarity = GetRowSimilarity(sourceRows[index], targetRow, options);
                 if (similarity > bestSimilarity) {
                     bestSimilarity = similarity;
@@ -474,7 +477,7 @@ namespace OfficeIMO.Word {
                 GetTableChildDocumentOrder(tableDocumentOrder, sourceCells[cellIndex]._tableCell));
         }
 
-        private static IReadOnlyList<MatchedIndexPair> FindMatchingIndexes<T>(IReadOnlyList<T> source, IReadOnlyList<T> target, IEqualityComparer<T> comparer) {
+        private static IReadOnlyList<MatchedIndexPair> FindMatchingIndexes<T>(IReadOnlyList<T> source, IReadOnlyList<T> target, IEqualityComparer<T> comparer) where T : notnull {
             if ((long)(source.Count + 1) * (target.Count + 1) > LcsCellLimit) {
                 return FindGreedyMatchingIndexes(source, target, comparer);
             }
@@ -508,19 +511,33 @@ namespace OfficeIMO.Word {
             return matches;
         }
 
-        private static IReadOnlyList<MatchedIndexPair> FindGreedyMatchingIndexes<T>(IReadOnlyList<T> source, IReadOnlyList<T> target, IEqualityComparer<T> comparer) {
+        private static IReadOnlyList<MatchedIndexPair> FindGreedyMatchingIndexes<T>(IReadOnlyList<T> source, IReadOnlyList<T> target, IEqualityComparer<T> comparer) where T : notnull {
             var matches = new List<MatchedIndexPair>();
+            var targetIndexes = new Dictionary<T, Queue<int>>(comparer);
+            for (int targetIndex = 0; targetIndex < target.Count; targetIndex++) {
+                if (!targetIndexes.TryGetValue(target[targetIndex], out Queue<int>? indexes)) {
+                    indexes = new Queue<int>();
+                    targetIndexes.Add(target[targetIndex], indexes);
+                }
+
+                indexes.Enqueue(targetIndex);
+            }
+
             int targetCursor = 0;
 
             for (int sourceIndex = 0; sourceIndex < source.Count && targetCursor < target.Count; sourceIndex++) {
-                for (int targetIndex = targetCursor; targetIndex < target.Count; targetIndex++) {
-                    if (!comparer.Equals(source[sourceIndex], target[targetIndex])) {
-                        continue;
-                    }
+                if (!targetIndexes.TryGetValue(source[sourceIndex], out Queue<int>? indexes)) {
+                    continue;
+                }
 
+                while (indexes.Count > 0 && indexes.Peek() < targetCursor) {
+                    indexes.Dequeue();
+                }
+
+                if (indexes.Count > 0) {
+                    int targetIndex = indexes.Dequeue();
                     matches.Add(new MatchedIndexPair(sourceIndex, targetIndex));
                     targetCursor = targetIndex + 1;
-                    break;
                 }
             }
 

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.cs
@@ -298,8 +298,10 @@ namespace OfficeIMO.Word {
             int bestIndex = targetStart;
             double bestSimilarity = currentSimilarity;
 
-            int boundedTargetEnd = Math.Min(targetEnd, targetStart + MaxComparisonAlignmentWindow);
-            for (int index = targetStart + 1; index < boundedTargetEnd; index++) {
+            foreach (int index in SelectBoundedAlignmentCandidates(
+                targetStart + 1,
+                targetEnd,
+                index => GetRowAlignmentPrefilterSimilarity(sourceRow, targetRows[index], options))) {
                 double similarity = GetRowSimilarity(sourceRow, targetRows[index], options);
                 if (similarity > bestSimilarity) {
                     bestSimilarity = similarity;
@@ -320,8 +322,10 @@ namespace OfficeIMO.Word {
             int bestIndex = sourceStart;
             double bestSimilarity = currentSimilarity;
 
-            int boundedSourceEnd = Math.Min(sourceEnd, sourceStart + MaxComparisonAlignmentWindow);
-            for (int index = sourceStart + 1; index < boundedSourceEnd; index++) {
+            foreach (int index in SelectBoundedAlignmentCandidates(
+                sourceStart + 1,
+                sourceEnd,
+                index => GetRowAlignmentPrefilterSimilarity(sourceRows[index], targetRow, options))) {
                 double similarity = GetRowSimilarity(sourceRows[index], targetRow, options);
                 if (similarity > bestSimilarity) {
                     bestSimilarity = similarity;
@@ -701,6 +705,16 @@ namespace OfficeIMO.Word {
             }
 
             return GetContainmentAwareTextSimilarity(NormalizeComparisonText(GetRowText(source), options), NormalizeComparisonText(GetRowText(target), options));
+        }
+
+        private static double GetRowAlignmentPrefilterSimilarity(WordTableRow source, WordTableRow target, WordComparisonOptions options) {
+            if (source.Cells.Count != target.Cells.Count) {
+                return 0;
+            }
+
+            return GetBoundedTextSimilarity(
+                NormalizeComparisonText(GetRowText(source), options),
+                NormalizeComparisonText(GetRowText(target), options));
         }
 
         private static double GetTableSimilarity(TableSnapshot source, TableSnapshot target, WordComparisonOptions options) {

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.cs
@@ -11,6 +11,8 @@ namespace OfficeIMO.Word {
         private const int LcsCellLimit = 1_000_000;
         private const int MaxComparisonAlignmentWindow = 256;
         private const int MaxBoundedTextSimilaritySamples = 64;
+        private const int MaxBoundedTextSimilarityAnchors = 8;
+        private const int BoundedTextSimilarityAnchorLength = 8;
         private const int BodyPartOrderBase = 0;
         private const int HeaderPartOrderBase = 1_000_000;
         private const int FooterPartOrderBase = 2_000_000;

--- a/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.cs
+++ b/OfficeIMO.Word/WordDocumentComparer/WordDocumentComparer.Structured.cs
@@ -10,6 +10,7 @@ namespace OfficeIMO.Word {
     public static partial class WordDocumentComparer {
         private const int LcsCellLimit = 1_000_000;
         private const int MaxComparisonAlignmentWindow = 256;
+        private const int MaxBoundedTextSimilaritySamples = 64;
         private const int BodyPartOrderBase = 0;
         private const int HeaderPartOrderBase = 1_000_000;
         private const int FooterPartOrderBase = 2_000_000;

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -944,7 +944,11 @@ namespace OfficeIMO.Word {
         internal List<WordTable> DirectNestedTables {
             get {
                 var tables = new List<WordTable>();
-                foreach (Table table in _tableCell.Elements<Table>()) {
+                foreach (Table table in _tableCell.Descendants<Table>()) {
+                    if (!ReferenceEquals(table.Ancestors<TableCell>().FirstOrDefault(), _tableCell)) {
+                        continue;
+                    }
+
                     tables.Add(new WordTable(_document, table));
                 }
 

--- a/OfficeIMO.Word/WordTableCell.cs
+++ b/OfficeIMO.Word/WordTableCell.cs
@@ -941,6 +941,17 @@ namespace OfficeIMO.Word {
             }
         }
 
+        internal List<WordTable> DirectNestedTables {
+            get {
+                var tables = new List<WordTable>();
+                foreach (Table table in _tableCell.Elements<Table>()) {
+                    tables.Add(new WordTable(_document, table));
+                }
+
+                return tables;
+            }
+        }
+
         /// <summary>
         /// Determines whether this instance and another cell reference the same underlying OpenXML cell.
         /// </summary>


### PR DESCRIPTION
## Summary

- bound Word comparison, table layout, nested-table, tab-stop, and PDF rendering work on adversarial documents
- bound PDF resource, form appearance, logical matching, image, and keep-chain processing
- bound PowerPoint feature/chart inspection and RTF Markdown list, table, and bookmark conversion
- reject row grid offsets whose combined column count exceeds the allocation limit before creating layout arrays

## Validation

- focused regression suites pass on .NET 8 and .NET 10
- the combined grid-offset regression passes in TableLayoutCacheTests on both target frameworks
- affected netstandard2.0 projects build without warnings

This is security findings batch 10 and is based on master.